### PR TITLE
Lurker API tokens + MCP server (issue #1)

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -1,0 +1,187 @@
+# Lurker MCP & HTTP API
+
+Lurker exposes its data and IRC actions through an authenticated
+[Model Context Protocol](https://modelcontextprotocol.io/) endpoint so
+external programs — LLM-driven agents, scripts, or anything else — can drive
+your bouncer without a browser open.
+
+This document covers the operator side: how to mint a token, point an
+MCP-aware client at your Lurker, and what tools are available.
+
+## Quick start
+
+1. **Mint a token** in your settings (`/settings/api-tokens`). Choose
+   read-only or read-write at creation time. The raw token is shown
+   exactly once; copy it now.
+2. **Configure your MCP client** with the token and the endpoint
+   (`https://<your-lurker>/mcp`). See [Claude Desktop](#claude-desktop)
+   below for a worked example.
+3. **Verify** with `curl`:
+   ```sh
+   curl -X POST https://<your-lurker>/mcp \
+     -H "Authorization: Bearer <your-token>" \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+   ```
+
+## Scopes
+
+| scope | what it grants |
+|---|---|
+| `read` | All read verbs. The token can list networks, browse buffers, fetch backlog, search history, and read your nick notes. |
+| `read-write` | Everything `read` does, plus sending messages, sending CTCP actions, and writing nick notes. |
+
+Scopes are coarse on purpose. Per-verb scopes are not implemented because
+the threat model assumes the operator is the only person holding tokens for
+their own account.
+
+## Tokens are HTTP-only
+
+API tokens authenticate the HTTP endpoint (`/mcp` and `/api/api-tokens`). The
+WebSocket endpoint used by the browser is cookie-only and does not accept
+bearer tokens. There is no way to drive the browser-style stateful protocol
+(presence, drafts, snapshot resume) from an MCP client — that surface is
+deliberately out of scope.
+
+## Tools (MCP verbs)
+
+All eight tools come back through `tools/list` with full JSON Schemas for
+their inputs. A read-only token only sees the five read tools.
+
+### `list_networks`  *(read)*
+Networks configured for your account, with live connection state and the
+current nick.
+
+### `list_buffers`  *(read)*
+Channels and DMs you have history for, with the most recent message
+timestamp. Optionally filter by `networkId`. Server pseudo-buffers
+(`:server:*`) are deliberately excluded — they're a UI plumbing concept,
+not data agents should reason about.
+
+### `recent_messages`  *(read)*
+Window of recent messages for one buffer, oldest-first. Paginate backwards
+by passing the lowest id from a previous result as `before`. Limit defaults
+to 100, capped at 500.
+
+### `search_messages`  *(read)*
+Full-text search across your message history. Free-text `query` runs through
+SQLite FTS5 (multiple terms are ANDed). Optional structured filters:
+`networkId`, `target`, `nick`. Limit defaults to 50, capped at 100.
+
+### `get_nick_note`  *(read)*
+Read your free-form note about a nick on a network. Empty string when no
+note exists.
+
+### `set_nick_note`  *(read-write)*
+Write a free-form note. Pass an empty string to delete. Notes are capped at
+4096 chars. Writes fan out to any open browser tabs so the UI reflects the
+change immediately.
+
+### `send_message`  *(read-write)*
+Send a PRIVMSG to a channel or peer. Returns
+`{ ok: false, error: "not-connected" }` when the network is offline; this
+comes back as a normal tool result (not a JSON-RPC error) so agents can
+branch on the value instead of catching.
+
+### `send_action`  *(read-write)*
+Send a CTCP ACTION (`/me ...`). Same shape and error semantics as
+`send_message`.
+
+## Wire format
+
+Transport is MCP's Streamable HTTP profile: a single `POST /mcp` with a
+JSON-RPC 2.0 envelope. Each request reauthenticates via the `Authorization`
+header — there is no Mcp-Session-Id state on the server side.
+
+We implement four methods:
+
+- `initialize` — capability handshake. Returns `protocolVersion`,
+  `capabilities: { tools: {} }`, and `serverInfo`.
+- `notifications/initialized` — client ack. No response.
+- `tools/list` — enumerates verbs the token can invoke.
+- `tools/call` — invokes a verb by name with arguments.
+
+Verb-level failures (insufficient scope, unknown network, IRC offline) are
+returned as a tool result with `isError: true` and a structured payload, not
+as JSON-RPC errors. JSON-RPC errors are reserved for protocol problems:
+malformed envelope, unknown method, missing tool name.
+
+## Examples
+
+### Claude Desktop
+
+Add an entry under `mcpServers` in your Claude Desktop config (the exact
+path depends on your OS; see Claude Desktop's docs). Since the transport is
+HTTP, use the [`mcp-remote`](https://www.npmjs.com/package/mcp-remote)
+bridge to expose it as a local MCP stdio server:
+
+```json
+{
+  "mcpServers": {
+    "lurker": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://<your-lurker>/mcp",
+        "--header",
+        "Authorization: Bearer <your-token>"
+      ]
+    }
+  }
+}
+```
+
+After restarting Claude Desktop, the eight Lurker tools appear in the
+tool picker and can be invoked directly.
+
+### curl roundtrip
+
+```sh
+# Initialize.
+curl -X POST https://<your-lurker>/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+
+# List the eight tools.
+curl -X POST https://<your-lurker>/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+# Read the last 20 messages in #lurker on network 1.
+curl -X POST https://<your-lurker>/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc":"2.0","id":3,"method":"tools/call",
+    "params":{"name":"recent_messages",
+              "arguments":{"networkId":1,"target":"#lurker","limit":20}}
+  }'
+```
+
+## Revocation
+
+Revoke a token from the settings pane at any time. Soft revocation: the
+row stays in the listing with a `revoked` marker (so you can see whether a
+specific name was previously issued and torn down). The token immediately
+stops authenticating against `/mcp`. There is no token rotation flow —
+revoke the old one and mint a new one.
+
+## What's not here
+
+Intentionally outside the scope of this surface:
+
+- **Streaming subscriptions** (`subscribe_events`, push notifications over
+  MCP). Agents that want to react to live activity should poll
+  `recent_messages` with a `before`/since cursor on a schedule.
+- **Channel membership** (`join_channel`, `part_channel`). The operator
+  manages this through the browser UI; agents that join channels without
+  the operator noticing are a footgun.
+- **Per-message read state** (`mark_read`, `get_unread`). Defer until a
+  concrete agent needs it.
+- **WHOIS / channel-member listings**. Derive from `recent_messages`; IRC
+  member lists are unstable anyway.
+- **REST endpoints for non-MCP HTTP clients.** MCP is the only HTTP
+  surface here. If you need a non-MCP HTTP integration, file an issue
+  describing the use case.

--- a/MCP.md
+++ b/MCP.md
@@ -108,6 +108,20 @@ malformed envelope, unknown method, missing tool name.
 
 ## Examples
 
+### Claude Code
+
+Claude Code's MCP client speaks streamable HTTP natively, so the setup is a
+single command — no stdio bridge needed:
+
+```sh
+claude mcp add --transport http lurker https://<your-lurker>/mcp \
+  --header "Authorization: Bearer <your-token>"
+```
+
+`claude mcp list` confirms the entry. MCP servers load at session start, so
+restart Claude Code (start a new session) before the eight Lurker tools
+appear in tool calls. To remove it later, `claude mcp remove lurker`.
+
 ### Claude Desktop
 
 Add an entry under `mcpServers` in your Claude Desktop config (the exact

--- a/server/db/apiTokens.js
+++ b/server/db/apiTokens.js
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import crypto from 'crypto';
+import db from './index.js';
+
+// Raw token is 32 random bytes, base64url-encoded — high enough entropy that
+// the storage hash can be a plain SHA-256 (no salt, no Argon2). The raw value
+// is returned once on create and never persisted; lookups always hash the
+// presented bearer first.
+function generateRawToken() {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+export function hashToken(raw) {
+  return crypto.createHash('sha256').update(raw, 'utf8').digest('hex');
+}
+
+const VALID_SCOPES = new Set(['read', 'read-write']);
+
+const insertStmt = db.prepare(`
+  INSERT INTO api_tokens (user_id, name, token_hash, scope)
+  VALUES (@userId, @name, @tokenHash, @scope)
+`);
+
+const findByHashStmt = db.prepare(`
+  SELECT id, user_id AS userId, name, scope, created_at AS createdAt,
+         last_used_at AS lastUsedAt, revoked_at AS revokedAt
+  FROM api_tokens
+  WHERE token_hash = ? AND revoked_at IS NULL
+`);
+
+const listForUserStmt = db.prepare(`
+  SELECT id, name, scope, created_at AS createdAt,
+         last_used_at AS lastUsedAt, revoked_at AS revokedAt
+  FROM api_tokens
+  WHERE user_id = ?
+  ORDER BY id DESC
+`);
+
+const revokeStmt = db.prepare(`
+  UPDATE api_tokens
+     SET revoked_at = datetime('now')
+   WHERE id = ? AND user_id = ? AND revoked_at IS NULL
+`);
+
+// Mirror users.touchUserLastSeen: throttle in SQL so a busy client doesn't
+// rewrite the row on every call. No in-memory Map needed.
+const touchStmt = db.prepare(`
+  UPDATE api_tokens
+     SET last_used_at = datetime('now')
+   WHERE id = ?
+     AND (last_used_at IS NULL OR last_used_at < datetime('now', '-60 seconds'))
+`);
+
+export function createToken({ userId, name, scope }) {
+  if (!VALID_SCOPES.has(scope)) throw new Error(`invalid scope: ${scope}`);
+  const trimmedName = (name || '').trim();
+  if (!trimmedName) throw new Error('name required');
+  const raw = generateRawToken();
+  const tokenHash = hashToken(raw);
+  const info = insertStmt.run({ userId, name: trimmedName, tokenHash, scope });
+  return {
+    id: info.lastInsertRowid,
+    userId,
+    name: trimmedName,
+    scope,
+    token: raw,
+  };
+}
+
+export function findActiveByHash(tokenHash) {
+  return findByHashStmt.get(tokenHash) || null;
+}
+
+export function listForUser(userId) {
+  return listForUserStmt.all(userId);
+}
+
+export function revoke(id, userId) {
+  return revokeStmt.run(id, userId).changes > 0;
+}
+
+export function touchLastUsed(id) {
+  touchStmt.run(id);
+}

--- a/server/db/apiTokens.test.js
+++ b/server/db/apiTokens.test.js
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-api-tokens-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let createUser;
+let deleteUser;
+let createToken;
+let findActiveByHash;
+let hashToken;
+let listForUser;
+let revoke;
+let touchLastUsed;
+
+beforeAll(async () => {
+  ({ createUser, deleteUser } = await import('./users.js'));
+  ({
+    createToken,
+    findActiveByHash,
+    hashToken,
+    listForUser,
+    revoke,
+    touchLastUsed,
+  } = await import('./apiTokens.js'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('apiTokens', () => {
+  it('createToken returns a raw token that is base64url and findable by hash', () => {
+    const u = createUser('tok-alice');
+    const created = createToken({ userId: u.id, name: 'desktop', scope: 'read' });
+    expect(created.token).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(created.scope).toBe('read');
+    const row = findActiveByHash(hashToken(created.token));
+    expect(row).toMatchObject({ id: created.id, userId: u.id, scope: 'read', name: 'desktop' });
+  });
+
+  it('rejects invalid scope and empty name', () => {
+    const u = createUser('tok-bob');
+    expect(() => createToken({ userId: u.id, name: 'x', scope: 'admin' })).toThrow();
+    expect(() => createToken({ userId: u.id, name: '   ', scope: 'read' })).toThrow();
+  });
+
+  it('listForUser returns metadata only (no token, no hash) newest-first', () => {
+    const u = createUser('tok-carol');
+    createToken({ userId: u.id, name: 'first', scope: 'read' });
+    createToken({ userId: u.id, name: 'second', scope: 'read-write' });
+    const list = listForUser(u.id);
+    expect(list.map((r) => r.name)).toEqual(['second', 'first']);
+    for (const row of list) {
+      expect(row).not.toHaveProperty('token');
+      expect(row).not.toHaveProperty('token_hash');
+      expect(row).not.toHaveProperty('tokenHash');
+    }
+  });
+
+  it('revoke filters the token from findActiveByHash but keeps the row in listForUser', () => {
+    const u = createUser('tok-dave');
+    const t = createToken({ userId: u.id, name: 'temp', scope: 'read' });
+    expect(findActiveByHash(hashToken(t.token))).not.toBeNull();
+    expect(revoke(t.id, u.id)).toBe(true);
+    expect(findActiveByHash(hashToken(t.token))).toBeNull();
+    // Historical record still shown in admin list with revokedAt populated.
+    const list = listForUser(u.id);
+    const row = list.find((r) => r.id === t.id);
+    expect(row.revokedAt).not.toBeNull();
+  });
+
+  it('revoke is scoped to the owning user (cannot revoke someone else\'s token)', () => {
+    const owner = createUser('tok-eve');
+    const intruder = createUser('tok-intruder');
+    const t = createToken({ userId: owner.id, name: 'ev', scope: 'read' });
+    expect(revoke(t.id, intruder.id)).toBe(false);
+    expect(findActiveByHash(hashToken(t.token))).not.toBeNull();
+  });
+
+  it('touchLastUsed populates last_used_at on first call', () => {
+    const u = createUser('tok-frank');
+    const t = createToken({ userId: u.id, name: 'cli', scope: 'read' });
+    expect(findActiveByHash(hashToken(t.token)).lastUsedAt).toBeNull();
+    touchLastUsed(t.id);
+    expect(findActiveByHash(hashToken(t.token)).lastUsedAt).not.toBeNull();
+  });
+
+  it('cascades on user delete', () => {
+    const u = createUser('tok-gina');
+    const t = createToken({ userId: u.id, name: 'doomed', scope: 'read' });
+    expect(findActiveByHash(hashToken(t.token))).not.toBeNull();
+    deleteUser(u.id);
+    expect(findActiveByHash(hashToken(t.token))).toBeNull();
+    expect(listForUser(u.id)).toEqual([]);
+  });
+
+  it('two tokens never collide on token_hash (sanity check on randomness)', () => {
+    const u = createUser('tok-helen');
+    const a = createToken({ userId: u.id, name: 'a', scope: 'read' });
+    const b = createToken({ userId: u.id, name: 'b', scope: 'read' });
+    expect(a.token).not.toBe(b.token);
+    expect(hashToken(a.token)).not.toBe(hashToken(b.token));
+  });
+});

--- a/server/db/exportSchema.js
+++ b/server/db/exportSchema.js
@@ -262,6 +262,11 @@ export const EXPORT_TABLES = Object.freeze({
     reason: 'admin/instance-scoped invitation state, not user data',
   },
 
+  api_tokens: {
+    mode: 'skip',
+    reason: 'bearer-token credentials bound to this instance; user re-issues tokens on the target instance',
+  },
+
   peer_presence_state: {
     mode: 'skip',
     reason: 'transient cache; rebuilt by IRC events on next connect',

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -392,6 +392,24 @@ function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_user_bookmarks_user_msg
       ON user_bookmarks(user_id, message_id DESC);
+
+    -- Per-user bearer tokens for the HTTP API + MCP server. token_hash is the
+    -- hex SHA-256 of the raw token; the raw value is shown once at creation
+    -- time and never stored. scope is 'read' (read-only verbs) or 'read-write'
+    -- (also allows send/set verbs). Revocation is soft via revoked_at so the
+    -- admin UI can still display the token name in the historical list.
+    CREATE TABLE IF NOT EXISTS api_tokens (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      token_hash TEXT NOT NULL UNIQUE,
+      scope TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_used_at TEXT,
+      revoked_at TEXT,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
   `);
 }
 

--- a/server/db/messages.js
+++ b/server/db/messages.js
@@ -152,6 +152,24 @@ export function listBufferTargets(networkId) {
     .map((r) => r.target);
 }
 
+// Per-(network, target) summary for the MCP list_buffers verb. Aggregates
+// every target that has at least one message, with the freshest message
+// timestamp. Pseudo-buffers (':server:*') are filtered at the SQL layer so
+// they never leak into the agent-facing surface; clients reach them via the
+// snapshot only.
+export function listBuffersForNetwork(networkId) {
+  return db
+    .prepare(
+      `SELECT target, MAX(time) AS lastMessageAt
+         FROM messages
+        WHERE network_id = ?
+          AND target NOT LIKE ':server:%'
+        GROUP BY target
+        ORDER BY lastMessageAt DESC`
+    )
+    .all(networkId);
+}
+
 // (target, max_id) per buffer in this network. Used by /mark-all-read so the
 // server can clamp every buffer's read pointer to its tail in one pass.
 export function maxIdByBuffer(networkId) {

--- a/server/middleware/apiAuth.js
+++ b/server/middleware/apiAuth.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { findActiveByHash, hashToken, touchLastUsed } from '../db/apiTokens.js';
+import { findUserById } from '../db/users.js';
+
+// Sibling of middleware/auth.js#requireAuth, but for bearer-token clients
+// (HTTP API + MCP). Tokens are HTTP-only by design — the WebSocket endpoint
+// remains cookie-only so the in-process plugin runtime question stays
+// deferred without re-auth gymnastics. `req.user` is populated to the same
+// shape `requireAuth` sets so downstream handlers can't tell the transport
+// apart; `req.session` is intentionally absent.
+export function requireApiAuth(req, res, next) {
+  const header = req.headers.authorization || '';
+  const match = /^Bearer\s+(\S+)$/.exec(header);
+  if (!match) return res.status(401).json({ error: 'unauthorized' });
+  const raw = match[1];
+  const tokenRow = findActiveByHash(hashToken(raw));
+  if (!tokenRow) return res.status(401).json({ error: 'unauthorized' });
+  const user = findUserById(tokenRow.userId);
+  if (!user) return res.status(401).json({ error: 'unauthorized' });
+  req.user = user;
+  req.apiToken = { id: tokenRow.id, scope: tokenRow.scope };
+  touchLastUsed(tokenRow.id);
+  next();
+}

--- a/server/middleware/apiAuth.test.js
+++ b/server/middleware/apiAuth.test.js
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('middleware-api-auth');
+
+let app;
+let createUser;
+let createToken;
+let revoke;
+let deleteUser;
+
+beforeAll(async () => {
+  ({ createUser, deleteUser } = await import('../db/users.js'));
+  ({ createToken, revoke } = await import('../db/apiTokens.js'));
+  const { requireApiAuth } = await import('./apiAuth.js');
+  app = express();
+  app.use(express.json());
+  app.get('/protected', requireApiAuth, (req, res) => {
+    res.json({
+      userId: req.user?.id,
+      username: req.user?.username,
+      hasSession: 'session' in req,
+      tokenScope: req.apiToken?.scope,
+    });
+  });
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('requireApiAuth', () => {
+  it('401 when Authorization header is missing', async () => {
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(401);
+  });
+
+  it('401 when header is not Bearer-shaped', async () => {
+    const res = await request(app).get('/protected').set('Authorization', 'Basic foo');
+    expect(res.status).toBe(401);
+  });
+
+  it('401 when token is bogus (no DB row)', async () => {
+    const res = await request(app).get('/protected').set('Authorization', 'Bearer notarealtoken');
+    expect(res.status).toBe(401);
+  });
+
+  it('authenticates a valid token and populates req.user without req.session', async () => {
+    const u = createUser('mw-alice');
+    const t = createToken({ userId: u.id, name: 'mw', scope: 'read-write' });
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${t.token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.userId).toBe(u.id);
+    expect(res.body.username).toBe('mw-alice');
+    expect(res.body.tokenScope).toBe('read-write');
+    expect(res.body.hasSession).toBe(false);
+  });
+
+  it('rejects a revoked token', async () => {
+    const u = createUser('mw-bob');
+    const t = createToken({ userId: u.id, name: 'rev', scope: 'read' });
+    revoke(t.id, u.id);
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${t.token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a token whose owning user has been deleted', async () => {
+    const u = createUser('mw-carol');
+    const t = createToken({ userId: u.id, name: 'orphan', scope: 'read' });
+    deleteUser(u.id);
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${t.token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('passes scope through from token row', async () => {
+    const u = createUser('mw-dave');
+    const tRead = createToken({ userId: u.id, name: 'r', scope: 'read' });
+    const tRW = createToken({ userId: u.id, name: 'rw', scope: 'read-write' });
+    const r1 = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${tRead.token}`);
+    const r2 = await request(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${tRW.token}`);
+    expect(r1.body.tokenScope).toBe('read');
+    expect(r2.body.tokenScope).toBe('read-write');
+  });
+});

--- a/server/routes/apiTokens.js
+++ b/server/routes/apiTokens.js
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import {
+  createToken,
+  listForUser,
+  revoke,
+} from '../db/apiTokens.js';
+
+// Admin UI for managing per-user MCP/API bearer tokens. Sibling of bookmarks.js:
+// authenticated through the browser session cookie (not the bearer it manages),
+// because this is where you mint tokens from. The middleware/apiAuth path is
+// the read path used by /mcp; this router is the write path used by the
+// browser-side settings pane.
+
+const router = Router();
+router.use(requireAuth);
+
+const VALID_SCOPES = new Set(['read', 'read-write']);
+const MAX_NAME_LEN = 64;
+
+router.get('/', (req, res) => {
+  res.json({ items: listForUser(req.user.id) });
+});
+
+router.post('/', (req, res) => {
+  const name = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
+  const scope = typeof req.body?.scope === 'string' ? req.body.scope : '';
+  if (!name) return res.status(400).json({ error: 'name required' });
+  if (name.length > MAX_NAME_LEN) {
+    return res.status(400).json({ error: `name too long (max ${MAX_NAME_LEN})` });
+  }
+  if (!VALID_SCOPES.has(scope)) {
+    return res.status(400).json({ error: 'invalid scope' });
+  }
+  // createToken returns { id, name, scope, token } — the raw token is shown
+  // exactly once here and never persisted. UI shows it in a one-time-reveal
+  // modal; after the modal closes there's no API path to recover it.
+  const created = createToken({ userId: req.user.id, name, scope });
+  res.status(201).json(created);
+});
+
+router.delete('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) return res.status(400).json({ error: 'invalid id' });
+  const ok = revoke(id, req.user.id);
+  if (!ok) return res.status(404).json({ error: 'not found' });
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server/routes/apiTokens.test.js
+++ b/server/routes/apiTokens.test.js
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('routes-api-tokens');
+
+let app;
+let agent;
+let intruderAgent;
+let user;
+let intruder;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const router = (await import('./apiTokens.js')).default;
+
+  user = createUser('tok-routes-alice');
+  intruder = createUser('tok-routes-intruder');
+  app = createTestApp({ '/api/api-tokens': router });
+  agent = await createAuthedAgent(app, user.id);
+  intruderAgent = await createAuthedAgent(app, intruder.id);
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('GET /api/api-tokens (auth)', () => {
+  it('401 when no session cookie', async () => {
+    const res = await request(app).get('/api/api-tokens');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns an empty list for a new user', async () => {
+    const res = await agent.get('/api/api-tokens');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+  });
+});
+
+describe('POST /api/api-tokens', () => {
+  it('rejects missing name', async () => {
+    const res = await agent.post('/api/api-tokens').send({ scope: 'read' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid scope', async () => {
+    const res = await agent.post('/api/api-tokens').send({ name: 'x', scope: 'admin' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an overlong name', async () => {
+    const res = await agent.post('/api/api-tokens').send({ name: 'a'.repeat(200), scope: 'read' });
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a token and returns the raw value exactly once', async () => {
+    const res = await agent.post('/api/api-tokens').send({ name: 'cli', scope: 'read-write' });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ name: 'cli', scope: 'read-write' });
+    expect(typeof res.body.token).toBe('string');
+    expect(res.body.token.length).toBeGreaterThan(20);
+    expect(typeof res.body.id).toBe('number');
+
+    // The follow-up GET must not include the raw token in any row.
+    const list = await agent.get('/api/api-tokens');
+    const row = list.body.items.find((r) => r.id === res.body.id);
+    expect(row).toBeDefined();
+    expect(row).not.toHaveProperty('token');
+    expect(row).not.toHaveProperty('token_hash');
+    expect(row).not.toHaveProperty('tokenHash');
+  });
+});
+
+describe('DELETE /api/api-tokens/:id', () => {
+  it('revokes the caller\'s own token (soft, listed with revokedAt set)', async () => {
+    const create = await agent.post('/api/api-tokens').send({ name: 'temp', scope: 'read' });
+    const id = create.body.id;
+    const del = await agent.delete(`/api/api-tokens/${id}`);
+    expect(del.status).toBe(200);
+    const list = await agent.get('/api/api-tokens');
+    const row = list.body.items.find((r) => r.id === id);
+    expect(row.revokedAt).not.toBeNull();
+  });
+
+  it('404 when attempting to revoke another user\'s token', async () => {
+    const mine = await agent.post('/api/api-tokens').send({ name: 'mine', scope: 'read' });
+    const del = await intruderAgent.delete(`/api/api-tokens/${mine.body.id}`);
+    expect(del.status).toBe(404);
+  });
+
+  it('400 for an invalid id', async () => {
+    const res = await agent.delete('/api/api-tokens/not-a-number');
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/server.js
+++ b/server/server.js
@@ -20,6 +20,7 @@ import adminRouter from './routes/admin.js';
 import uploadsRouter from './routes/uploads.js';
 import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
+import apiTokensRouter from './routes/apiTokens.js';
 import ircManager from './services/ircManager.js';
 import { attachWsHub } from './services/wsHub.js';
 import './services/verbs/index.js';
@@ -57,6 +58,7 @@ app.use('/api/uploads', uploadsRouter);
 app.use('/api/drafts', draftsRouter);
 app.use('/api/exports', exportsRouter);
 app.use('/api/imports', importRouter);
+app.use('/api/api-tokens', apiTokensRouter);
 
 app.use('/mcp', requireApiAuth, mcpRouter);
 

--- a/server/server.js
+++ b/server/server.js
@@ -23,6 +23,8 @@ import { exportsRouter, importRouter } from './routes/exports.js';
 import ircManager from './services/ircManager.js';
 import { attachWsHub } from './services/wsHub.js';
 import './services/verbs/index.js';
+import mcpRouter from './services/mcpServer.js';
+import { requireApiAuth } from './middleware/apiAuth.js';
 import systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
@@ -55,6 +57,8 @@ app.use('/api/uploads', uploadsRouter);
 app.use('/api/drafts', draftsRouter);
 app.use('/api/exports', exportsRouter);
 app.use('/api/imports', importRouter);
+
+app.use('/mcp', requireApiAuth, mcpRouter);
 
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok', time: new Date().toISOString() });

--- a/server/server.js
+++ b/server/server.js
@@ -22,6 +22,7 @@ import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import ircManager from './services/ircManager.js';
 import { attachWsHub } from './services/wsHub.js';
+import './services/verbs/index.js';
 import systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';

--- a/server/services/mcpServer.js
+++ b/server/services/mcpServer.js
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import express from 'express';
+import { callVerb, listVerbs } from './verbRegistry.js';
+
+// Hand-rolled MCP-over-HTTP. The transport spec ("Streamable HTTP") is mostly
+// JSON-RPC 2.0 with two extras we don't need yet: server→client streaming via
+// SSE (we have no subscriptions), and resumable sessions via Mcp-Session-Id
+// (we're stateless — every request reauthenticates by bearer token). Single
+// POST per call carries the request and returns the response inline.
+//
+// We implement four methods:
+//   initialize                 — capability handshake.
+//   notifications/initialized  — client ack of initialize. No response.
+//   tools/list                 — enumerate verbs the caller can invoke.
+//   tools/call                 — invoke a verb by name with arguments.
+//
+// JSON-RPC errors are reserved for protocol problems (bad envelope, unknown
+// method, missing tool name). Verb-level failures (`{ ok: false, error: ...}`
+// from send_message, `unknown_network` from the registry boundary) come back
+// as a normal tool result so the agent can branch on the value rather than
+// catching a protocol error.
+
+const PROTOCOL_VERSION = '2025-06-18';
+const SERVER_INFO = { name: 'lurker', version: '0.1.0' };
+
+const router = express.Router();
+
+function jsonRpcError(id, code, message, data) {
+  const error = { code, message };
+  if (data !== undefined) error.data = data;
+  return { jsonrpc: '2.0', id, error };
+}
+
+router.post('/', (req, res) => {
+  const body = req.body;
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return res.json(jsonRpcError(null, -32600, 'Invalid Request'));
+  }
+  const id = body.id ?? null;
+  const isNotification = !('id' in body);
+
+  if (body.jsonrpc !== '2.0' || typeof body.method !== 'string') {
+    if (isNotification) return res.status(204).end();
+    return res.json(jsonRpcError(id, -32600, 'Invalid Request'));
+  }
+
+  try {
+    let result;
+    switch (body.method) {
+      case 'initialize': {
+        // Client passes its preferred protocolVersion in params; we echo back
+        // the one we implement. Mismatches are negotiated client-side.
+        result = {
+          protocolVersion: PROTOCOL_VERSION,
+          capabilities: { tools: {} },
+          serverInfo: SERVER_INFO,
+        };
+        break;
+      }
+      case 'notifications/initialized': {
+        return res.status(204).end();
+      }
+      case 'tools/list': {
+        result = { tools: listVerbs(req.apiToken.scope) };
+        break;
+      }
+      case 'tools/call': {
+        const params = body.params || {};
+        const name = params.name;
+        const args = params.arguments || {};
+        if (typeof name !== 'string' || !name) {
+          return res.json(jsonRpcError(id, -32602, 'Missing tool name'));
+        }
+        let toolPayload;
+        let isError = false;
+        try {
+          toolPayload = callVerb(
+            name,
+            { userId: req.user.id, scope: req.apiToken.scope, transport: 'mcp' },
+            args,
+          );
+        } catch (err) {
+          isError = true;
+          toolPayload = { error: err.code || 'error', message: err.message };
+        }
+        result = {
+          content: [{ type: 'text', text: JSON.stringify(toolPayload) }],
+          isError,
+        };
+        break;
+      }
+      default: {
+        if (isNotification) return res.status(204).end();
+        return res.json(jsonRpcError(id, -32601, `Method not found: ${body.method}`));
+      }
+    }
+    if (isNotification) return res.status(204).end();
+    return res.json({ jsonrpc: '2.0', id, result });
+  } catch (err) {
+    if (isNotification) return res.status(204).end();
+    return res.json(jsonRpcError(id, -32603, 'Internal error', err.message));
+  }
+});
+
+export default router;

--- a/server/services/mcpServer.test.js
+++ b/server/services/mcpServer.test.js
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('mcp-server');
+
+let app;
+let owner;
+let net;
+let readToken;
+let rwToken;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { createNetwork } = await import('../db/networks.js');
+  const { insertMessage } = await import('../db/messages.js');
+  const { createToken } = await import('../db/apiTokens.js');
+  // Register verbs as a side effect.
+  await import('./verbs/index.js');
+  const { default: mcpRouter } = await import('./mcpServer.js');
+  const { requireApiAuth } = await import('../middleware/apiAuth.js');
+
+  app = express();
+  app.use(express.json({ limit: '1mb' }));
+  app.use('/mcp', requireApiAuth, mcpRouter);
+
+  owner = createUser('mcp-owner');
+  net = createNetwork(owner.id, {
+    name: 'libera', host: 'h', port: 6697, tls: true, nick: 'owner',
+  });
+  insertMessage({
+    networkId: net.id, target: '#chan', time: new Date().toISOString(),
+    type: 'message', nick: 'alice', text: 'hello', self: false,
+  });
+  readToken = createToken({ userId: owner.id, name: 'r', scope: 'read' });
+  rwToken = createToken({ userId: owner.id, name: 'rw', scope: 'read-write' });
+});
+
+afterAll(() => ctx.cleanup());
+
+function rpc(token, body) {
+  return request(app)
+    .post('/mcp')
+    .set('Authorization', `Bearer ${token}`)
+    .set('Content-Type', 'application/json')
+    .send(body);
+}
+
+describe('MCP server', () => {
+  it('401 without a bearer token', async () => {
+    const res = await request(app).post('/mcp').send({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    expect(res.status).toBe(401);
+  });
+
+  it('initialize returns protocolVersion + serverInfo + tools capability', async () => {
+    const res = await rpc(readToken.token, {
+      jsonrpc: '2.0', id: 1, method: 'initialize', params: {},
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        capabilities: { tools: {} },
+        serverInfo: { name: 'lurker' },
+      },
+    });
+    expect(typeof res.body.result.protocolVersion).toBe('string');
+  });
+
+  it('tools/list with a read token only advertises read verbs', async () => {
+    const res = await rpc(readToken.token, {
+      jsonrpc: '2.0', id: 2, method: 'tools/list',
+    });
+    const names = res.body.result.tools.map((t) => t.name);
+    expect(names).toContain('list_networks');
+    expect(names).toContain('recent_messages');
+    expect(names).not.toContain('send_message');
+    expect(names).not.toContain('set_nick_note');
+  });
+
+  it('tools/list with a read-write token advertises the full surface', async () => {
+    const res = await rpc(rwToken.token, {
+      jsonrpc: '2.0', id: 3, method: 'tools/list',
+    });
+    const names = res.body.result.tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      'get_nick_note',
+      'list_buffers',
+      'list_networks',
+      'recent_messages',
+      'search_messages',
+      'send_action',
+      'send_message',
+      'set_nick_note',
+    ]);
+    // Each entry carries an inputSchema usable by an MCP client.
+    for (const tool of res.body.result.tools) {
+      expect(tool.inputSchema.type).toBe('object');
+    }
+  });
+
+  it('tools/call list_networks returns the user\'s networks as a JSON text block', async () => {
+    const res = await rpc(readToken.token, {
+      jsonrpc: '2.0', id: 4, method: 'tools/call',
+      params: { name: 'list_networks', arguments: {} },
+    });
+    expect(res.body.result.isError).toBe(false);
+    const payload = JSON.parse(res.body.result.content[0].text);
+    expect(payload).toHaveLength(1);
+    expect(payload[0]).toMatchObject({ id: net.id, name: 'libera' });
+  });
+
+  it('tools/call set_nick_note writes and round-trips through get_nick_note', async () => {
+    const setRes = await rpc(rwToken.token, {
+      jsonrpc: '2.0', id: 5, method: 'tools/call',
+      params: {
+        name: 'set_nick_note',
+        arguments: { networkId: net.id, nick: 'alice', note: 'works at Acme' },
+      },
+    });
+    expect(setRes.body.result.isError).toBe(false);
+    const setPayload = JSON.parse(setRes.body.result.content[0].text);
+    expect(setPayload).toMatchObject({ networkId: net.id, nick: 'alice', note: 'works at Acme' });
+
+    const getRes = await rpc(readToken.token, {
+      jsonrpc: '2.0', id: 6, method: 'tools/call',
+      params: { name: 'get_nick_note', arguments: { networkId: net.id, nick: 'alice' } },
+    });
+    const getPayload = JSON.parse(getRes.body.result.content[0].text);
+    expect(getPayload.note).toBe('works at Acme');
+  });
+
+  it('tools/call set_nick_note rejected with a read token, surfaced as isError result', async () => {
+    const res = await rpc(readToken.token, {
+      jsonrpc: '2.0', id: 7, method: 'tools/call',
+      params: { name: 'set_nick_note', arguments: { networkId: net.id, nick: 'bob', note: 'denied' } },
+    });
+    expect(res.body.result.isError).toBe(true);
+    const payload = JSON.parse(res.body.result.content[0].text);
+    expect(payload.error).toBe('forbidden');
+  });
+
+  it('tools/call against another user\'s networkId returns unknown_network as isError result', async () => {
+    const { createUser } = await import('../db/users.js');
+    const { createNetwork } = await import('../db/networks.js');
+    const other = createUser('mcp-other');
+    const otherNet = createNetwork(other.id, {
+      name: 'oftc', host: 'h', port: 6697, tls: true, nick: 'o',
+    });
+    const res = await rpc(rwToken.token, {
+      jsonrpc: '2.0', id: 8, method: 'tools/call',
+      params: { name: 'list_buffers', arguments: { networkId: otherNet.id } },
+    });
+    expect(res.body.result.isError).toBe(true);
+    const payload = JSON.parse(res.body.result.content[0].text);
+    expect(payload.error).toBe('unknown_network');
+  });
+
+  it('unknown method returns JSON-RPC -32601', async () => {
+    const res = await rpc(readToken.token, {
+      jsonrpc: '2.0', id: 9, method: 'wat',
+    });
+    expect(res.body.error.code).toBe(-32601);
+  });
+
+  it('tools/call without a name returns JSON-RPC -32602', async () => {
+    const res = await rpc(readToken.token, {
+      jsonrpc: '2.0', id: 10, method: 'tools/call', params: {},
+    });
+    expect(res.body.error.code).toBe(-32602);
+  });
+
+  it('notifications/initialized is acknowledged with 204 and no body', async () => {
+    const res = await rpc(rwToken.token, {
+      jsonrpc: '2.0', method: 'notifications/initialized',
+    });
+    expect(res.status).toBe(204);
+    expect(res.text).toBe('');
+  });
+
+  it('bogus envelope (missing jsonrpc field) returns Invalid Request', async () => {
+    const res = await rpc(readToken.token, { id: 11, method: 'initialize' });
+    expect(res.body.error.code).toBe(-32600);
+  });
+});

--- a/server/services/verbRegistry.js
+++ b/server/services/verbRegistry.js
@@ -47,11 +47,12 @@ export function listVerbs(callerScope) {
   return out;
 }
 
-// Universal boundary: scope check + network-ownership check. Verbs trust ctx
-// to carry an authenticated userId and the granted scope. Anything with a
-// numeric networkId in the input gets ownership-checked here rather than at
-// each call site; verbs are still free to do additional structural validation
-// in their handlers.
+// Universal boundary: scope check + required-field check + network-ownership
+// check. Verbs trust ctx to carry an authenticated userId and the granted
+// scope. Anything with a numeric networkId in the input gets ownership-checked
+// here rather than at each call site; verbs are still free to do additional
+// structural validation in their handlers (e.g. rejecting empty-after-trim
+// strings that the JSON Schema can't express).
 export function callVerb(name, ctx, input) {
   const verb = verbs.get(name);
   if (!verb) {
@@ -63,6 +64,21 @@ export function callVerb(name, ctx, input) {
     const err = new Error(`scope insufficient: ${name} requires read-write`);
     err.code = 'forbidden';
     throw err;
+  }
+  // Required-field check from the verb's declared JSON Schema. Without this
+  // the ownership check below could be bypassed simply by omitting networkId,
+  // and the handler would coerce undefined to NaN and surface a confusing
+  // downstream error instead of a clean invalid_input.
+  const required = Array.isArray(verb.input?.required) ? verb.input.required : null;
+  if (required) {
+    const payload = input || {};
+    for (const field of required) {
+      if (payload[field] == null) {
+        const err = new Error(`missing required field: ${field}`);
+        err.code = 'invalid_input';
+        throw err;
+      }
+    }
   }
   if (input && input.networkId != null) {
     const networkId = Number(input.networkId);

--- a/server/services/verbRegistry.js
+++ b/server/services/verbRegistry.js
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { ownsNetwork } from '../db/networks.js';
+
+// Single registry of transport-agnostic verbs the MCP server and (where it
+// makes sense) the WS hub both call into. Each verb declares a name, a
+// human-readable description, a scope ('read' or 'read-write'), a JSON
+// Schema describing its inputs (published verbatim through MCP tools/list),
+// and a handler.
+//
+// Registration happens at module import time inside each verb file under
+// services/verbs/. The aggregator services/verbs/index.js imports all of them
+// so a single side-effecting import wires up the full surface.
+
+const verbs = new Map();
+
+const VALID_SCOPES = new Set(['read', 'read-write']);
+
+export function registerVerb({ name, description, scope, input, handler }) {
+  if (typeof name !== 'string' || !name) throw new Error('verb name required');
+  if (verbs.has(name)) throw new Error(`duplicate verb: ${name}`);
+  if (!VALID_SCOPES.has(scope)) throw new Error(`invalid scope for ${name}: ${scope}`);
+  if (typeof handler !== 'function') throw new Error(`handler required for ${name}`);
+  verbs.set(name, {
+    name,
+    description: description || '',
+    scope,
+    input: input || { type: 'object', properties: {}, additionalProperties: false },
+    handler,
+  });
+}
+
+export function getVerb(name) {
+  return verbs.get(name) || null;
+}
+
+// Lists verbs the caller can actually invoke. A read-only token sees only
+// read verbs in tools/list — there's no point advertising a tool the agent
+// will be 403'd on.
+export function listVerbs(callerScope) {
+  const out = [];
+  for (const verb of verbs.values()) {
+    if (verb.scope === 'read-write' && callerScope !== 'read-write') continue;
+    out.push({ name: verb.name, description: verb.description, inputSchema: verb.input });
+  }
+  return out;
+}
+
+// Universal boundary: scope check + network-ownership check. Verbs trust ctx
+// to carry an authenticated userId and the granted scope. Anything with a
+// numeric networkId in the input gets ownership-checked here rather than at
+// each call site; verbs are still free to do additional structural validation
+// in their handlers.
+export function callVerb(name, ctx, input) {
+  const verb = verbs.get(name);
+  if (!verb) {
+    const err = new Error(`unknown verb: ${name}`);
+    err.code = 'unknown_verb';
+    throw err;
+  }
+  if (verb.scope === 'read-write' && ctx.scope !== 'read-write') {
+    const err = new Error(`scope insufficient: ${name} requires read-write`);
+    err.code = 'forbidden';
+    throw err;
+  }
+  if (input && input.networkId != null) {
+    const networkId = Number(input.networkId);
+    if (!Number.isInteger(networkId) || networkId <= 0 || !ownsNetwork(ctx.userId, networkId)) {
+      const err = new Error('unknown network');
+      err.code = 'unknown_network';
+      throw err;
+    }
+  }
+  return verb.handler(ctx, input || {});
+}
+
+// Test-only: wipe the registry between cases. Real code should never call
+// this; the registry is intended to be populated once at process start.
+export function __resetForTests() {
+  verbs.clear();
+}

--- a/server/services/verbRegistry.test.js
+++ b/server/services/verbRegistry.test.js
@@ -108,4 +108,38 @@ describe('verbRegistry', () => {
     const entry = listVerbs('read').find((v) => v.name === 'sch');
     expect(entry.inputSchema).toEqual(schema);
   });
+
+  it('callVerb rejects missing required fields declared in the input schema', () => {
+    registerVerb({
+      name: 'req-net',
+      scope: 'read',
+      input: { type: 'object', properties: { networkId: { type: 'integer' } }, required: ['networkId'] },
+      handler: () => 'should-not-run',
+    });
+    try {
+      callVerb('req-net', { userId: 1, scope: 'read' }, {});
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('invalid_input');
+      expect(err.message).toMatch(/networkId/);
+    }
+  });
+
+  it('the required-field check fires before the ownership check (so missing networkId is invalid_input, not unknown_network)', () => {
+    // Reproduces Copilot review comment: omitting networkId entirely used to
+    // bypass the ownership branch and let the handler see NaN. Now the
+    // registry rejects it cleanly with a distinguishable error code.
+    registerVerb({
+      name: 'needs-net',
+      scope: 'read',
+      input: { type: 'object', properties: { networkId: { type: 'integer' } }, required: ['networkId'] },
+      handler: () => 'never',
+    });
+    try {
+      callVerb('needs-net', { userId: 1, scope: 'read' }, { somethingElse: 'x' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('invalid_input');
+    }
+  });
 });

--- a/server/services/verbRegistry.test.js
+++ b/server/services/verbRegistry.test.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-verb-registry-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let createUser;
+let createNetwork;
+let registerVerb;
+let callVerb;
+let listVerbs;
+let getVerb;
+let __resetForTests;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  ({ createNetwork } = await import('../db/networks.js'));
+  ({ registerVerb, callVerb, listVerbs, getVerb, __resetForTests } =
+    await import('./verbRegistry.js'));
+});
+
+beforeEach(() => {
+  __resetForTests();
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('verbRegistry', () => {
+  it('registerVerb + getVerb round-trips', () => {
+    registerVerb({
+      name: 'noop',
+      description: 'does nothing',
+      scope: 'read',
+      input: { type: 'object' },
+      handler: () => 'ok',
+    });
+    expect(getVerb('noop').description).toBe('does nothing');
+  });
+
+  it('registerVerb rejects duplicates, invalid scope, missing handler', () => {
+    registerVerb({ name: 'dup', scope: 'read', handler: () => null });
+    expect(() => registerVerb({ name: 'dup', scope: 'read', handler: () => null })).toThrow();
+    expect(() => registerVerb({ name: 'bad', scope: 'admin', handler: () => null })).toThrow();
+    expect(() => registerVerb({ name: 'no-handler', scope: 'read' })).toThrow();
+  });
+
+  it('callVerb throws unknown_verb when the name is not registered', () => {
+    try {
+      callVerb('ghost', { userId: 1, scope: 'read' }, {});
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('unknown_verb');
+    }
+  });
+
+  it('callVerb enforces scope: read-write verbs reject read scope', () => {
+    registerVerb({
+      name: 'mutate',
+      scope: 'read-write',
+      handler: () => 'wrote',
+    });
+    expect(() => callVerb('mutate', { userId: 1, scope: 'read' }, {})).toThrow(/scope insufficient/);
+    expect(callVerb('mutate', { userId: 1, scope: 'read-write' }, {})).toBe('wrote');
+  });
+
+  it('callVerb rejects unknown networkId at the boundary (other-user ownership leak)', () => {
+    const owner = createUser('vr-owner');
+    const intruder = createUser('vr-intruder');
+    const net = createNetwork(owner.id, {
+      name: 'libera', host: 'h', port: 6697, tls: true, nick: 'o',
+    });
+    registerVerb({
+      name: 'read-net',
+      scope: 'read',
+      handler: (ctx, input) => ({ saw: input.networkId }),
+    });
+    // Owner can call against their own network.
+    expect(callVerb('read-net', { userId: owner.id, scope: 'read' }, { networkId: net.id }))
+      .toEqual({ saw: net.id });
+    // Intruder cannot.
+    try {
+      callVerb('read-net', { userId: intruder.id, scope: 'read' }, { networkId: net.id });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('unknown_network');
+    }
+  });
+
+  it('listVerbs filters read-write verbs from a read-only caller', () => {
+    registerVerb({ name: 'r', description: 'r', scope: 'read', handler: () => null });
+    registerVerb({ name: 'w', description: 'w', scope: 'read-write', handler: () => null });
+    const readSet = listVerbs('read').map((v) => v.name);
+    const rwSet = listVerbs('read-write').map((v) => v.name);
+    expect(readSet).toEqual(['r']);
+    expect(rwSet.sort()).toEqual(['r', 'w']);
+  });
+
+  it('listVerbs entries carry the inputSchema declared at registration', () => {
+    const schema = { type: 'object', properties: { x: { type: 'integer' } } };
+    registerVerb({ name: 'sch', description: 'with schema', scope: 'read', input: schema, handler: () => null });
+    const entry = listVerbs('read').find((v) => v.name === 'sch');
+    expect(entry.inputSchema).toEqual(schema);
+  });
+});

--- a/server/services/verbs/getNickNote.js
+++ b/server/services/verbs/getNickNote.js
@@ -20,7 +20,11 @@ registerVerb({
   handler(ctx, input) {
     const networkId = Number(input.networkId);
     const nick = typeof input.nick === 'string' ? input.nick.trim() : '';
-    if (!nick) return { networkId, nick: '', note: '', updatedAt: null };
+    if (!nick) {
+      const err = new Error('nick is empty or whitespace');
+      err.code = 'invalid_input';
+      throw err;
+    }
     const row = getNote({ userId: ctx.userId, networkId, nick });
     return {
       networkId,

--- a/server/services/verbs/getNickNote.js
+++ b/server/services/verbs/getNickNote.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import { getNote } from '../../db/nickNotes.js';
+
+registerVerb({
+  name: 'get_nick_note',
+  description: 'Read the caller\'s free-form note about a nick on a network. Returns an empty note string when no note exists.',
+  scope: 'read',
+  input: {
+    type: 'object',
+    properties: {
+      networkId: { type: 'integer' },
+      nick: { type: 'string' },
+    },
+    required: ['networkId', 'nick'],
+    additionalProperties: false,
+  },
+  handler(ctx, input) {
+    const networkId = Number(input.networkId);
+    const nick = typeof input.nick === 'string' ? input.nick.trim() : '';
+    if (!nick) return { networkId, nick: '', note: '', updatedAt: null };
+    const row = getNote({ userId: ctx.userId, networkId, nick });
+    return {
+      networkId,
+      nick,
+      note: row?.note || '',
+      updatedAt: row?.updatedAt || null,
+    };
+  },
+});

--- a/server/services/verbs/index.js
+++ b/server/services/verbs/index.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Side-effect aggregator. Importing this module registers every verb with the
+// shared registry. server.js imports it once at startup so both the WS
+// delegators and the MCP server see the full surface.
+import './listNetworks.js';
+import './listBuffers.js';
+import './recentMessages.js';
+import './searchMessages.js';
+import './getNickNote.js';
+import './setNickNote.js';
+import './sendMessage.js';
+import './sendAction.js';

--- a/server/services/verbs/listBuffers.js
+++ b/server/services/verbs/listBuffers.js
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import { listNetworksForUser } from '../../db/networks.js';
+import { listBuffersForNetwork } from '../../db/messages.js';
+
+function bufferKind(target) {
+  if (target.startsWith('#')) return 'channel';
+  return 'dm';
+}
+
+registerVerb({
+  name: 'list_buffers',
+  description: 'List the caller\'s open buffers (channels and DMs) across one or all networks, with the most recent message timestamp.',
+  scope: 'read',
+  input: {
+    type: 'object',
+    properties: {
+      networkId: {
+        type: 'integer',
+        description: 'Optional. Restrict the listing to a single network. If omitted, returns buffers across every network the caller owns.',
+      },
+    },
+    additionalProperties: false,
+  },
+  handler(ctx, input) {
+    // Network ownership for the filtered case is enforced by the registry
+    // boundary; we just walk the caller's networks here.
+    const networks = listNetworksForUser(ctx.userId);
+    const filterId = input.networkId != null ? Number(input.networkId) : null;
+    const out = [];
+    for (const net of networks) {
+      if (filterId !== null && net.id !== filterId) continue;
+      for (const row of listBuffersForNetwork(net.id)) {
+        out.push({
+          networkId: net.id,
+          target: row.target,
+          kind: bufferKind(row.target),
+          lastMessageAt: row.lastMessageAt,
+        });
+      }
+    }
+    return out;
+  },
+});

--- a/server/services/verbs/listNetworks.js
+++ b/server/services/verbs/listNetworks.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import { listNetworksForUser } from '../../db/networks.js';
+import ircManager from '../ircManager.js';
+
+registerVerb({
+  name: 'list_networks',
+  description: 'List the IRC networks configured for the caller, with live connection state and current nick.',
+  scope: 'read',
+  input: {
+    type: 'object',
+    properties: {},
+    additionalProperties: false,
+  },
+  handler(ctx) {
+    return listNetworksForUser(ctx.userId).map((net) => {
+      const conn = ircManager.getConnection(ctx.userId, net.id);
+      return {
+        id: net.id,
+        name: net.name,
+        connected: conn?.state === 'connected',
+        nick: conn?.client?.user?.nick || net.nick,
+      };
+    });
+  },
+});

--- a/server/services/verbs/recentMessages.js
+++ b/server/services/verbs/recentMessages.js
@@ -36,8 +36,12 @@ registerVerb({
   },
   handler(ctx, input) {
     const networkId = Number(input.networkId);
-    const target = typeof input.target === 'string' ? input.target : '';
-    if (!target) return { messages: [], hasOlder: false };
+    const target = typeof input.target === 'string' ? input.target.trim() : '';
+    if (!target) {
+      const err = new Error('target is empty or whitespace');
+      err.code = 'invalid_input';
+      throw err;
+    }
     const limit = Math.min(Math.max(Number(input.limit) || 100, 1), 500);
     const before = input.before ? Number(input.before) : undefined;
     const events = listMessages(networkId, target, { before, limit })

--- a/server/services/verbs/recentMessages.js
+++ b/server/services/verbs/recentMessages.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import { listMessages, hasOlderRow } from '../../db/messages.js';
+import { decorateMessage } from '../wsHub.js';
+
+registerVerb({
+  name: 'recent_messages',
+  description: 'Fetch a window of recent messages for one buffer, oldest-first. Paginate backwards by passing the lowest id from a previous result as `before`.',
+  scope: 'read',
+  input: {
+    type: 'object',
+    properties: {
+      networkId: {
+        type: 'integer',
+        description: 'The network id (from list_networks).',
+      },
+      target: {
+        type: 'string',
+        description: 'The buffer target — a channel name like "#foo" or a peer nick for a DM.',
+      },
+      limit: {
+        type: 'integer',
+        description: 'How many messages to return. Default 100, max 500.',
+        minimum: 1,
+        maximum: 500,
+      },
+      before: {
+        type: 'integer',
+        description: 'Optional. Return only messages with id < before, for backward pagination.',
+      },
+    },
+    required: ['networkId', 'target'],
+    additionalProperties: false,
+  },
+  handler(ctx, input) {
+    const networkId = Number(input.networkId);
+    const target = typeof input.target === 'string' ? input.target : '';
+    if (!target) return { messages: [], hasOlder: false };
+    const limit = Math.min(Math.max(Number(input.limit) || 100, 1), 500);
+    const before = input.before ? Number(input.before) : undefined;
+    const events = listMessages(networkId, target, { before, limit })
+      .map((e) => decorateMessage(ctx.userId, e));
+    const oldestId = events.length ? events[0].id : 0;
+    return {
+      messages: events,
+      hasOlder: oldestId > 0 && hasOlderRow(networkId, target, oldestId),
+    };
+  },
+});

--- a/server/services/verbs/searchMessages.js
+++ b/server/services/verbs/searchMessages.js
@@ -44,17 +44,22 @@ registerVerb({
   },
   handler(ctx, input) {
     const limit = Math.min(Math.max(Number(input.limit) || 50, 1), 100);
-    const results = searchMessages(ctx.userId, {
+    // Fetch one extra row to know whether more matches exist without a second
+    // FTS scan. The bare `results.length === limit` heuristic the WS code
+    // used for years produces a false-positive when the total match count is
+    // exactly `limit`; recent_messages was fixed the same way during the
+    // Phase 2 extraction.
+    const rows = searchMessages(ctx.userId, {
       query: typeof input.query === 'string' ? input.query : '',
       networkId: input.networkId ? Number(input.networkId) : undefined,
       target: typeof input.target === 'string' && input.target ? input.target : undefined,
       nick: typeof input.nick === 'string' && input.nick ? input.nick : undefined,
       before: input.before ? Number(input.before) : undefined,
-      limit,
-    }).map((e) => decorateMessage(ctx.userId, e));
-    return {
-      messages: results,
-      hasMore: results.length === limit,
-    };
+      limit: limit + 1,
+    });
+    const hasMore = rows.length > limit;
+    const messages = (hasMore ? rows.slice(0, limit) : rows)
+      .map((e) => decorateMessage(ctx.userId, e));
+    return { messages, hasMore };
   },
 });

--- a/server/services/verbs/searchMessages.js
+++ b/server/services/verbs/searchMessages.js
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import { searchMessages } from '../../db/messages.js';
+import { decorateMessage } from '../wsHub.js';
+
+registerVerb({
+  name: 'search_messages',
+  description: 'Full-text search across the caller\'s message history. Returns matches newest-first; paginate by passing the lowest id as `before`.',
+  scope: 'read',
+  input: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'Free-text query. Multiple whitespace-separated terms are ANDed together.',
+      },
+      networkId: {
+        type: 'integer',
+        description: 'Optional. Restrict the search to a single network. Omit to search every network the caller owns.',
+      },
+      target: {
+        type: 'string',
+        description: 'Optional. Restrict to a single buffer target (channel name or peer nick).',
+      },
+      nick: {
+        type: 'string',
+        description: 'Optional. Restrict to messages from a specific nick.',
+      },
+      limit: {
+        type: 'integer',
+        description: 'How many matches to return. Default 50, max 100.',
+        minimum: 1,
+        maximum: 100,
+      },
+      before: {
+        type: 'integer',
+        description: 'Optional. Return only matches with id < before, for backward pagination.',
+      },
+    },
+    required: ['query'],
+    additionalProperties: false,
+  },
+  handler(ctx, input) {
+    const limit = Math.min(Math.max(Number(input.limit) || 50, 1), 100);
+    const results = searchMessages(ctx.userId, {
+      query: typeof input.query === 'string' ? input.query : '',
+      networkId: input.networkId ? Number(input.networkId) : undefined,
+      target: typeof input.target === 'string' && input.target ? input.target : undefined,
+      nick: typeof input.nick === 'string' && input.nick ? input.nick : undefined,
+      before: input.before ? Number(input.before) : undefined,
+      limit,
+    }).map((e) => decorateMessage(ctx.userId, e));
+    return {
+      messages: results,
+      hasMore: results.length === limit,
+    };
+  },
+});

--- a/server/services/verbs/sendAction.js
+++ b/server/services/verbs/sendAction.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import ircManager from '../ircManager.js';
+
+registerVerb({
+  name: 'send_action',
+  description: 'Send a CTCP ACTION ("/me ...") to a channel or peer on a network. Returns { ok: false, error: "not-connected" } when the network is offline.',
+  scope: 'read-write',
+  input: {
+    type: 'object',
+    properties: {
+      networkId: { type: 'integer' },
+      target: {
+        type: 'string',
+        description: 'A channel name like "#foo" or a peer nick.',
+      },
+      text: { type: 'string' },
+    },
+    required: ['networkId', 'target', 'text'],
+    additionalProperties: false,
+  },
+  handler(ctx, input) {
+    const networkId = Number(input.networkId);
+    const target = typeof input.target === 'string' ? input.target : '';
+    const text = typeof input.text === 'string' ? input.text : '';
+    if (!target || !text) return { ok: false, error: 'empty-target-or-text' };
+    const ok = ircManager.action(ctx.userId, networkId, target, text);
+    return ok ? { ok: true } : { ok: false, error: 'not-connected' };
+  },
+});

--- a/server/services/verbs/sendMessage.js
+++ b/server/services/verbs/sendMessage.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import ircManager from '../ircManager.js';
+
+registerVerb({
+  name: 'send_message',
+  description: 'Send a PRIVMSG to a channel or peer on a network. Returns { ok: false, error: "not-connected" } when the network is offline — the caller should not retry blindly.',
+  scope: 'read-write',
+  input: {
+    type: 'object',
+    properties: {
+      networkId: { type: 'integer' },
+      target: {
+        type: 'string',
+        description: 'A channel name like "#foo" or a peer nick.',
+      },
+      text: { type: 'string' },
+    },
+    required: ['networkId', 'target', 'text'],
+    additionalProperties: false,
+  },
+  handler(ctx, input) {
+    const networkId = Number(input.networkId);
+    const target = typeof input.target === 'string' ? input.target : '';
+    const text = typeof input.text === 'string' ? input.text : '';
+    if (!target || !text) return { ok: false, error: 'empty-target-or-text' };
+    const ok = ircManager.send(ctx.userId, networkId, target, text);
+    return ok ? { ok: true } : { ok: false, error: 'not-connected' };
+  },
+});

--- a/server/services/verbs/setNickNote.js
+++ b/server/services/verbs/setNickNote.js
@@ -26,7 +26,11 @@ registerVerb({
   handler(ctx, input) {
     const networkId = Number(input.networkId);
     const nick = typeof input.nick === 'string' ? input.nick.trim() : '';
-    if (!nick) return { networkId, nick: '', note: '', updatedAt: null };
+    if (!nick) {
+      const err = new Error('nick is empty or whitespace');
+      err.code = 'invalid_input';
+      throw err;
+    }
     const raw = typeof input.note === 'string' ? input.note : '';
     const note = raw.length > 4096 ? raw.slice(0, 4096) : raw;
     const saved = ircManager.setNickNote(ctx.userId, networkId, nick, note);

--- a/server/services/verbs/setNickNote.js
+++ b/server/services/verbs/setNickNote.js
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import ircManager from '../ircManager.js';
+import { fanOutToUser } from '../wsHub.js';
+
+registerVerb({
+  name: 'set_nick_note',
+  description: 'Write a free-form note about a nick on a network. Pass an empty string to clear the note. Notes are capped at 4096 chars.',
+  scope: 'read-write',
+  input: {
+    type: 'object',
+    properties: {
+      networkId: { type: 'integer' },
+      nick: { type: 'string' },
+      note: {
+        type: 'string',
+        description: 'The note body. Empty/whitespace string deletes the note.',
+        maxLength: 4096,
+      },
+    },
+    required: ['networkId', 'nick', 'note'],
+    additionalProperties: false,
+  },
+  handler(ctx, input) {
+    const networkId = Number(input.networkId);
+    const nick = typeof input.nick === 'string' ? input.nick.trim() : '';
+    if (!nick) return { networkId, nick: '', note: '', updatedAt: null };
+    const raw = typeof input.note === 'string' ? input.note : '';
+    const note = raw.length > 4096 ? raw.slice(0, 4096) : raw;
+    const saved = ircManager.setNickNote(ctx.userId, networkId, nick, note);
+    const result = {
+      networkId,
+      nick,
+      note: saved ? saved.note : '',
+      updatedAt: saved ? saved.updatedAt : null,
+    };
+    // Fan out to every open WS tab of this user — both transports converge on
+    // the same `nick-note-updated` event so the UI reacts identically whether
+    // the change came from the browser or an agent.
+    fanOutToUser(ctx.userId, { kind: 'nick-note-updated', ...result });
+    return result;
+  },
+});

--- a/server/services/verbs/verbs.test.js
+++ b/server/services/verbs/verbs.test.js
@@ -114,6 +114,26 @@ describe('recent_messages', () => {
       networkId: otherNet.id, target: '#chan', limit: 5,
     })).toThrow(/unknown network/);
   });
+
+  it('throws invalid_input when networkId is omitted (registry-level required check)', () => {
+    try {
+      callVerb('recent_messages', rCtx(owner.id), { target: '#chan' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('invalid_input');
+      expect(err.message).toMatch(/networkId/);
+    }
+  });
+
+  it('throws invalid_input when target is empty after trim', () => {
+    try {
+      callVerb('recent_messages', rCtx(owner.id), { networkId: net.id, target: '   ' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('invalid_input');
+      expect(err.message).toMatch(/target/);
+    }
+  });
 });
 
 describe('search_messages', () => {
@@ -128,6 +148,38 @@ describe('search_messages', () => {
   it('returns empty when nothing matches', () => {
     const result = callVerb('search_messages', rCtx(owner.id), { query: 'xyzzy-no-such-term' });
     expect(result.messages).toEqual([]);
+  });
+
+  it('reports hasMore=false when total matches equal the requested limit exactly', () => {
+    // Seed a fresh user + network so the message count is deterministic.
+    const u = createUser('search-limit-edge');
+    const n = createNetwork(u.id, { name: 'l', host: 'h', port: 6697, tls: true, nick: 'u' });
+    const t = new Date().toISOString();
+    for (let i = 0; i < 3; i += 1) {
+      insertMessage({
+        networkId: n.id, target: '#c', time: t, type: 'message',
+        nick: 'u', text: `needle-${i}`, self: false,
+      });
+    }
+    const res = callVerb('search_messages', rCtx(u.id), { query: 'needle', limit: 3 });
+    expect(res.messages).toHaveLength(3);
+    // The pre-fix heuristic (length === limit) would report true here.
+    expect(res.hasMore).toBe(false);
+  });
+
+  it('reports hasMore=true when there is at least one extra match beyond the limit', () => {
+    const u = createUser('search-limit-overflow');
+    const n = createNetwork(u.id, { name: 'l', host: 'h', port: 6697, tls: true, nick: 'u' });
+    const t = new Date().toISOString();
+    for (let i = 0; i < 5; i += 1) {
+      insertMessage({
+        networkId: n.id, target: '#c', time: t, type: 'message',
+        nick: 'u', text: `morsel-${i}`, self: false,
+      });
+    }
+    const res = callVerb('search_messages', rCtx(u.id), { query: 'morsel', limit: 3 });
+    expect(res.messages).toHaveLength(3);
+    expect(res.hasMore).toBe(true);
   });
 });
 
@@ -162,6 +214,27 @@ describe('get_nick_note / set_nick_note', () => {
     expect(() => callVerb('set_nick_note', rCtx(owner.id), {
       networkId: net.id, nick: 'eve', note: 'denied',
     })).toThrow(/scope insufficient/);
+  });
+
+  it('set_nick_note throws invalid_input on empty/whitespace nick (not silent success)', () => {
+    try {
+      callVerb('set_nick_note', rwCtx(owner.id), {
+        networkId: net.id, nick: '   ', note: 'orphan',
+      });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('invalid_input');
+      expect(err.message).toMatch(/nick/);
+    }
+  });
+
+  it('get_nick_note throws invalid_input on empty nick', () => {
+    try {
+      callVerb('get_nick_note', rCtx(owner.id), { networkId: net.id, nick: '' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err.code).toBe('invalid_input');
+    }
   });
 });
 

--- a/server/services/verbs/verbs.test.js
+++ b/server/services/verbs/verbs.test.js
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-verbs-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let createUser;
+let createNetwork;
+let insertMessage;
+let callVerb;
+
+let owner;
+let intruder;
+let net;
+let otherNet;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../../db/users.js'));
+  ({ createNetwork } = await import('../../db/networks.js'));
+  ({ insertMessage } = await import('../../db/messages.js'));
+  // Importing the verbs aggregator triggers registration as a side effect.
+  await import('./index.js');
+  ({ callVerb } = await import('../verbRegistry.js'));
+
+  owner = createUser('verbs-owner');
+  intruder = createUser('verbs-intruder');
+  net = createNetwork(owner.id, {
+    name: 'libera', host: 'h', port: 6697, tls: true, nick: 'owner',
+  });
+  otherNet = createNetwork(intruder.id, {
+    name: 'oftc', host: 'h', port: 6697, tls: true, nick: 'intruder',
+  });
+
+  const t = new Date().toISOString();
+  insertMessage({ networkId: net.id, target: '#chan', time: t, type: 'message', nick: 'alice', text: 'hello world', self: false });
+  insertMessage({ networkId: net.id, target: '#chan', time: t, type: 'message', nick: 'bob', text: 'second message', self: false });
+  insertMessage({ networkId: net.id, target: '#chan', time: t, type: 'message', nick: 'alice', text: 'deployment ready', self: false });
+  insertMessage({ networkId: net.id, target: 'bob', time: t, type: 'message', nick: 'bob', text: 'private msg', self: false });
+  insertMessage({ networkId: net.id, target: ':server:libera', time: t, type: 'notice', nick: null, text: 'motd', self: false });
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const rwCtx = (userId) => ({ userId, scope: 'read-write', transport: 'ws' });
+const rCtx = (userId) => ({ userId, scope: 'read', transport: 'ws' });
+
+describe('list_networks', () => {
+  it('returns the caller\'s networks with connected=false when no live connection', () => {
+    const result = callVerb('list_networks', rCtx(owner.id), {});
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: net.id, name: 'libera', connected: false, nick: 'owner' });
+  });
+
+  it('is user-scoped — never leaks another user\'s networks', () => {
+    const result = callVerb('list_networks', rCtx(intruder.id), {});
+    expect(result.map((n) => n.id)).toEqual([otherNet.id]);
+  });
+});
+
+describe('list_buffers', () => {
+  it('returns the caller\'s buffers and excludes :server:* pseudo-buffers', () => {
+    const result = callVerb('list_buffers', rCtx(owner.id), {});
+    const targets = result.map((b) => b.target).sort();
+    expect(targets).toEqual(['#chan', 'bob']);
+    expect(result.find((b) => b.target === '#chan').kind).toBe('channel');
+    expect(result.find((b) => b.target === 'bob').kind).toBe('dm');
+  });
+
+  it('honors the networkId filter and rejects another user\'s networkId at the boundary', () => {
+    const only = callVerb('list_buffers', rCtx(owner.id), { networkId: net.id });
+    expect(only.every((b) => b.networkId === net.id)).toBe(true);
+    expect(() => callVerb('list_buffers', rCtx(owner.id), { networkId: otherNet.id }))
+      .toThrow(/unknown network/);
+  });
+});
+
+describe('recent_messages', () => {
+  it('returns oldest-first with hasOlder=false when buffer has fewer rows than limit', () => {
+    const result = callVerb('recent_messages', rCtx(owner.id), {
+      networkId: net.id, target: '#chan', limit: 10,
+    });
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[0].text).toBe('hello world');
+    expect(result.messages[2].text).toBe('deployment ready');
+    expect(result.hasOlder).toBe(false);
+  });
+
+  it('hasOlder=true when more rows exist before the window', () => {
+    const result = callVerb('recent_messages', rCtx(owner.id), {
+      networkId: net.id, target: '#chan', limit: 1,
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe('deployment ready');
+    expect(result.hasOlder).toBe(true);
+  });
+
+  it('decorates each message with the dm/matched/notify flags', () => {
+    const result = callVerb('recent_messages', rCtx(owner.id), {
+      networkId: net.id, target: 'bob', limit: 10,
+    });
+    expect(result.messages[0]).toHaveProperty('dm', true);
+    expect(result.messages[0]).toHaveProperty('notify');
+  });
+
+  it('rejects another user\'s networkId at the boundary', () => {
+    expect(() => callVerb('recent_messages', rCtx(owner.id), {
+      networkId: otherNet.id, target: '#chan', limit: 5,
+    })).toThrow(/unknown network/);
+  });
+});
+
+describe('search_messages', () => {
+  it('matches against FTS index, decorates results, scopes to the caller', () => {
+    const result = callVerb('search_messages', rCtx(owner.id), { query: 'deployment' });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].text).toBe('deployment ready');
+    // Caller's network only.
+    expect(result.messages[0].networkId).toBe(net.id);
+  });
+
+  it('returns empty when nothing matches', () => {
+    const result = callVerb('search_messages', rCtx(owner.id), { query: 'xyzzy-no-such-term' });
+    expect(result.messages).toEqual([]);
+  });
+});
+
+describe('get_nick_note / set_nick_note', () => {
+  it('get returns an empty note when none is set; set writes and round-trips', () => {
+    const empty = callVerb('get_nick_note', rCtx(owner.id), { networkId: net.id, nick: 'alice' });
+    expect(empty.note).toBe('');
+    expect(empty.updatedAt).toBeNull();
+    const set = callVerb('set_nick_note', rwCtx(owner.id), {
+      networkId: net.id, nick: 'alice', note: 'works at Acme',
+    });
+    expect(set.note).toBe('works at Acme');
+    expect(set.updatedAt).not.toBeNull();
+    const got = callVerb('get_nick_note', rCtx(owner.id), { networkId: net.id, nick: 'alice' });
+    expect(got.note).toBe('works at Acme');
+  });
+
+  it('set with empty string deletes the note', () => {
+    callVerb('set_nick_note', rwCtx(owner.id), { networkId: net.id, nick: 'carol', note: 'to delete' });
+    callVerb('set_nick_note', rwCtx(owner.id), { networkId: net.id, nick: 'carol', note: '' });
+    const got = callVerb('get_nick_note', rCtx(owner.id), { networkId: net.id, nick: 'carol' });
+    expect(got.note).toBe('');
+  });
+
+  it('set_nick_note caps body at 4096 chars', () => {
+    const long = 'x'.repeat(5000);
+    const result = callVerb('set_nick_note', rwCtx(owner.id), { networkId: net.id, nick: 'dave', note: long });
+    expect(result.note.length).toBe(4096);
+  });
+
+  it('set_nick_note rejected when caller has read-only scope', () => {
+    expect(() => callVerb('set_nick_note', rCtx(owner.id), {
+      networkId: net.id, nick: 'eve', note: 'denied',
+    })).toThrow(/scope insufficient/);
+  });
+});
+
+describe('send_message / send_action', () => {
+  it('returns ok=false, error=not-connected when no live IRC connection', () => {
+    const result = callVerb('send_message', rwCtx(owner.id), {
+      networkId: net.id, target: '#chan', text: 'hi',
+    });
+    expect(result).toEqual({ ok: false, error: 'not-connected' });
+  });
+
+  it('send_action shares the same error shape', () => {
+    const result = callVerb('send_action', rwCtx(owner.id), {
+      networkId: net.id, target: '#chan', text: 'waves',
+    });
+    expect(result).toEqual({ ok: false, error: 'not-connected' });
+  });
+
+  it('send_message is rejected for read-only scope', () => {
+    expect(() => callVerb('send_message', rCtx(owner.id), {
+      networkId: net.id, target: '#chan', text: 'hi',
+    })).toThrow(/scope insufficient/);
+  });
+
+  it('rejects empty target or text without round-tripping ircManager', () => {
+    expect(callVerb('send_message', rwCtx(owner.id), {
+      networkId: net.id, target: '', text: 'hi',
+    })).toEqual({ ok: false, error: 'empty-target-or-text' });
+    expect(callVerb('send_message', rwCtx(owner.id), {
+      networkId: net.id, target: '#chan', text: '',
+    })).toEqual({ ok: false, error: 'empty-target-or-text' });
+  });
+});

--- a/server/services/wsHub.js
+++ b/server/services/wsHub.js
@@ -14,7 +14,7 @@ import { matchesAny as matchesIgnoreMask } from './maskMatch.js';
 import { listMasks as listIgnoredMasks } from '../db/ignoredMasks.js';
 import { findSession } from '../db/sessions.js';
 import { findUserById, touchUserLastSeen } from '../db/users.js';
-import { listMessages, listMessagesAround, hasOlderRow, hasNewerRow, listBufferTargets, listSpeakers, countNewer, countHighlightsNewer, maxIdByBuffer, searchMessages, COUNTABLE_TYPES } from '../db/messages.js';
+import { listMessages, listMessagesAround, hasOlderRow, hasNewerRow, listBufferTargets, listSpeakers, countNewer, countHighlightsNewer, maxIdByBuffer, COUNTABLE_TYPES } from '../db/messages.js';
 import { listReadStateForUser, getReadState, setReadState } from '../db/bufferReads.js';
 import { addEntry as addInputHistory, listRecent as listRecentInputHistory } from '../db/inputHistory.js';
 import {
@@ -41,6 +41,7 @@ import * as chanlistDb from '../db/chanlist.js';
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from './settingsRegistry.js';
 import { SESSION_COOKIE } from '../middleware/auth.js';
+import { callVerb } from './verbRegistry.js';
 
 function effectiveSetting(userId, key) {
   const overrides = getUserSettings(userId);
@@ -150,7 +151,7 @@ function isDirect(event) {
 // wire so clients can route toast/sound per signal type; `notify` is the
 // union and is the single gate consulted by push delivery and the in-client
 // notifier.
-function decorateMessage(userId, event) {
+export function decorateMessage(userId, event) {
   if (!event || typeof event !== 'object') return event;
   const matched = !!event.matched;
   const matchedRuleId = event.matchedRuleId ?? null;
@@ -175,9 +176,43 @@ function computeUnreadFor(userId, networkId, target, lastReadId) {
   };
 }
 
+// Per-user socket bookkeeping lives at module scope so the verb registry can
+// reach into fanOut without importing the WSS instance. The state is still
+// owned by attachWsHub at runtime (it's the only writer to socketsByUser via
+// addSocket/removeSocket); the registry just reads through it.
+const socketsByUser = new Map();
+
+function send(ws, payload) {
+  if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
+}
+
+function fanOut(userId, payload, opts = {}) {
+  const set = socketsByUser.get(userId);
+  if (!set) return;
+  const json = JSON.stringify(payload);
+  const eventId = typeof payload.id === 'number' ? payload.id : null;
+  for (const ws of set) {
+    if (opts.exceptWs && ws === opts.exceptWs) continue;
+    if (ws.readyState === ws.OPEN) {
+      ws.send(json);
+      // Advance the per-socket cursor so a subsequent sendSnapshot ships
+      // only the gap newer than what this socket has already received.
+      if (eventId != null && eventId > (ws.sinceId || 0)) {
+        ws.sinceId = eventId;
+      }
+    }
+  }
+}
+
+// Public alias for verb handlers that produce a value via MCP but still want
+// the user's open WS tabs to react (e.g. set_nick_note). Same signature as
+// the private fanOut; named to make the cross-module call site read clearly.
+export function fanOutToUser(userId, payload, opts = {}) {
+  fanOut(userId, payload, opts);
+}
+
 export function attachWsHub(httpServer, sessionSecret) {
   const wss = new WebSocketServer({ noServer: true });
-  const socketsByUser = new Map();
   // Per-user pending auto-away timers. Set when a user goes from 1→0 sockets;
   // cleared on 0→1 or when the timer fires.
   const autoAwayTimers = new Map();
@@ -236,28 +271,6 @@ export function attachWsHub(httpServer, sessionSecret) {
     if (set.size === 0) {
       socketsByUser.delete(userId);
       scheduleAutoAway(userId);
-    }
-  }
-
-  function send(ws, payload) {
-    if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
-  }
-
-  function fanOut(userId, payload, opts = {}) {
-    const set = socketsByUser.get(userId);
-    if (!set) return;
-    const json = JSON.stringify(payload);
-    const eventId = typeof payload.id === 'number' ? payload.id : null;
-    for (const ws of set) {
-      if (opts.exceptWs && ws === opts.exceptWs) continue;
-      if (ws.readyState === ws.OPEN) {
-        ws.send(json);
-        // Advance the per-socket cursor so a subsequent sendSnapshot ships
-        // only the gap newer than what this socket has already received.
-        if (eventId != null && eventId > (ws.sinceId || 0)) {
-          ws.sinceId = eventId;
-        }
-      }
     }
   }
 
@@ -654,17 +667,25 @@ export function attachWsHub(httpServer, sessionSecret) {
       case 'presence':
         ws.presence = { visible: !!msg.visible };
         break;
-      case 'send': {
-        const ok = ircManager.send(userId, msg.networkId, msg.target, msg.text);
-        if (msg.clientId) {
-          send(ws, { kind: 'send-result', clientId: msg.clientId, ok, error: ok ? undefined : 'not-connected' });
-        }
-        break;
-      }
+      case 'send':
       case 'action': {
-        const ok = ircManager.action(userId, msg.networkId, msg.target, msg.text);
+        // Both share the same shape and the same WS-only echo on clientId.
+        // The verb returns { ok, error? }; we translate to send-result on
+        // behalf of the originating tab so its optimistic bubble can resolve.
+        const verbName = msg.type === 'send' ? 'send_message' : 'send_action';
+        let result;
+        try {
+          result = callVerb(verbName, { userId, scope: 'read-write', transport: 'ws' }, {
+            networkId: msg.networkId, target: msg.target, text: msg.text,
+          });
+        } catch (err) {
+          result = { ok: false, error: err.code || 'error' };
+        }
         if (msg.clientId) {
-          send(ws, { kind: 'send-result', clientId: msg.clientId, ok, error: ok ? undefined : 'not-connected' });
+          send(ws, {
+            kind: 'send-result', clientId: msg.clientId,
+            ok: !!result.ok, error: result.ok ? undefined : result.error,
+          });
         }
         break;
       }
@@ -912,21 +933,14 @@ export function attachWsHub(httpServer, sessionSecret) {
         break;
       }
       case 'set-nick-note': {
-        const networkId = Number(msg.networkId);
-        const nick = typeof msg.nick === 'string' ? msg.nick.trim() : '';
-        // Notes are operator scratch space — cap at 4 KB so a misclick can't
-        // wedge unbounded payloads through the WS. Empty body deletes the row.
-        const rawNote = typeof msg.note === 'string' ? msg.note : '';
-        const note = rawNote.length > 4096 ? rawNote.slice(0, 4096) : rawNote;
-        if (!networkId || !nick) break;
-        const saved = ircManager.setNickNote(userId, networkId, nick, note);
-        fanOut(userId, {
-          kind: 'nick-note-updated',
-          networkId,
-          nick,
-          note: saved ? saved.note : '',
-          updatedAt: saved ? saved.updatedAt : null,
-        });
+        // Verb owns the 4 KB cap, the empty-string-deletes rule, and the
+        // fanOut to other open tabs. WS handler is now a thin delegator —
+        // identical behavior whether the change came from this tab or MCP.
+        try {
+          callVerb('set_nick_note', { userId, scope: 'read-write', transport: 'ws' }, {
+            networkId: msg.networkId, nick: msg.nick, note: msg.note,
+          });
+        } catch (_) { /* boundary already filtered bad networkId; ignore */ }
         break;
       }
       case 'set-bookmark': {
@@ -1061,42 +1075,53 @@ export function attachWsHub(httpServer, sessionSecret) {
           break;
         }
 
-        // 'before' (default, legacy). Reply keeps the historical `hasMore`
-        // field set to hasMoreOlder so older clients keep working.
+        // 'before' (default, legacy). Delegates to the recent_messages verb —
+        // shared with MCP — and wraps the value in the WS history reply shape
+        // (mode/token/speakers + historical hasMore alias).
         const before = msg.before ? Number(msg.before) : undefined;
-        const events = listMessages(msg.networkId, msg.target, { before, limit })
-          .map((e) => decorateMessage(userId, e));
-        const hasMoreOlder = events.length === limit;
+        let result;
+        try {
+          result = callVerb('recent_messages', { userId, scope: 'read-write', transport: 'ws' }, {
+            networkId: msg.networkId, target: msg.target, before, limit,
+          });
+        } catch (_) {
+          send(ws, { kind: 'error', text: 'history fetch failed' });
+          break;
+        }
         send(ws, {
           ...baseReply,
           before: msg.before || null,
-          events,
-          hasMoreOlder,
+          events: result.messages,
+          hasMoreOlder: result.hasOlder,
           hasMoreNewer: false,
-          hasMore: hasMoreOlder,
+          hasMore: result.hasOlder,
         });
         break;
       }
       case 'search': {
-        // Full-text message search. The networkId boundary guard above already
-        // validated ownership when a network filter is present; searchMessages
-        // scopes the global case to the caller's own networks via the networks
-        // join, so no extra access-control check is needed here.
-        const limit = Math.min(Math.max(Number(msg.limit) || 50, 1), 100);
-        const results = searchMessages(userId, {
-          query: typeof msg.query === 'string' ? msg.query : '',
-          networkId: msg.networkId || undefined,
-          target: typeof msg.target === 'string' && msg.target ? msg.target : undefined,
-          nick: typeof msg.nick === 'string' && msg.nick ? msg.nick : undefined,
-          before: msg.before ? Number(msg.before) : undefined,
-          limit,
-        }).map((e) => decorateMessage(userId, e));
+        // Delegates to the search_messages verb. The boundary check above
+        // already validated networkId ownership when a network filter was
+        // present; searchMessages itself self-scopes the global case to the
+        // caller's networks via its SQL join.
+        let result;
+        try {
+          result = callVerb('search_messages', { userId, scope: 'read-write', transport: 'ws' }, {
+            query: msg.query,
+            networkId: msg.networkId || undefined,
+            target: typeof msg.target === 'string' && msg.target ? msg.target : undefined,
+            nick: typeof msg.nick === 'string' && msg.nick ? msg.nick : undefined,
+            before: msg.before ? Number(msg.before) : undefined,
+            limit: msg.limit,
+          });
+        } catch (_) {
+          send(ws, { kind: 'error', text: 'search failed' });
+          break;
+        }
         send(ws, {
           kind: 'search-result',
-          // Echoed so the client can drop results for a superseded query.
           token: msg.token ?? null,
-          results,
-          hasMore: results.length === limit,
+          results: result.messages,
+          hasMore: result.hasMore,
           before: msg.before || null,
         });
         break;

--- a/shared/settingsRegistry.js
+++ b/shared/settingsRegistry.js
@@ -1100,6 +1100,7 @@ export const CATEGORIES = Object.freeze([
   { id: 'users',         label: 'Users',         kind: 'bespoke', adminOnly: true },
   { id: 'networks',      label: 'Networks',      kind: 'bespoke'  },
   { id: 'account',       label: 'Account',       kind: 'bespoke'  },
+  { id: 'api-tokens',    label: 'API tokens',    kind: 'bespoke'  },
   { id: 'data',          label: 'Data',          kind: 'bespoke'  },
   { id: 'about',         label: 'About',         kind: 'bespoke'  },
 ]);

--- a/vue_client/src/components/settings-panes/ApiTokensPane.vue
+++ b/vue_client/src/components/settings-panes/ApiTokensPane.vue
@@ -1,0 +1,234 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  Per-user bearer tokens for the MCP server and HTTP API. Mints a token,
+  reveals it inline exactly once, lists active + revoked tokens, allows soft
+  revoke. Mirrors AccountPane's structure for the device-list + form patterns.
+-->
+
+<template>
+  <section id="api-tokens" class="settings-pane">
+    <h2>api tokens</h2>
+    <p class="section-desc">
+      Bearer tokens grant scripts and AI agents access to your Lurker data
+      through the MCP endpoint at <code>/mcp</code>. Each token belongs to your
+      account only and can be revoked at any time. The token itself is shown
+      <strong>once</strong> on creation — copy it before closing the row.
+    </p>
+    <p v-if="error" class="error inline">{{ error }}</p>
+
+    <h3 class="subhead">create new token</h3>
+    <form class="create-form" @submit.prevent="onCreate">
+      <label>
+        <span>Name</span>
+        <input
+          v-model="newName"
+          type="text"
+          maxlength="64"
+          placeholder="e.g. claude-desktop, autonotes"
+        />
+      </label>
+      <label class="check">
+        <input v-model="newAllowWrite" type="checkbox" />
+        <span>Allow this token to send messages and write notes</span>
+      </label>
+      <div class="create-actions">
+        <button class="link" type="submit" :disabled="busy || !newName.trim()">
+          create token
+        </button>
+      </div>
+    </form>
+
+    <div v-if="revealed" class="reveal">
+      <p class="reveal-warning">
+        <strong>{{ revealed.name }}</strong> — copy this token now. It will
+        not be shown again.
+      </p>
+      <div class="reveal-row">
+        <code class="token">{{ revealed.token }}</code>
+        <button class="link" type="button" @click="onCopy">
+          {{ copied ? 'copied' : 'copy' }}
+        </button>
+        <button class="link" type="button" @click="revealed = null">dismiss</button>
+      </div>
+    </div>
+
+    <h3 class="subhead">existing tokens</h3>
+    <ul v-if="tokens.length" class="device-list">
+      <li v-for="t in tokens" :key="t.id" class="device token-row">
+        <span class="ua">
+          <span class="name">{{ t.name }}</span>
+          <span class="scope">{{ t.scope }}</span>
+          <span v-if="t.revokedAt" class="revoked">revoked</span>
+        </span>
+        <span class="last-seen" :title="t.lastUsedAt || t.createdAt">
+          {{ t.lastUsedAt ? `last used ${formatRelative(t.lastUsedAt)}` : `created ${formatRelative(t.createdAt)}` }}
+        </span>
+        <button
+          v-if="!t.revokedAt"
+          class="link danger"
+          :disabled="busy"
+          @click="onRevoke(t)"
+        >revoke</button>
+        <span v-else class="placeholder" />
+      </li>
+    </ul>
+    <p v-else class="muted small">No API tokens yet.</p>
+  </section>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { api } from '../../api.js';
+import { formatRelative } from '../../utils/timestamp.js';
+
+const tokens = ref([]);
+const newName = ref('');
+const newAllowWrite = ref(false);
+const revealed = ref(null);
+const copied = ref(false);
+const busy = ref(false);
+const error = ref('');
+
+onMounted(() => { refresh(); });
+
+async function refresh() {
+  error.value = '';
+  try {
+    const { items } = await api('/api/api-tokens');
+    tokens.value = items;
+  } catch (e) {
+    error.value = e.message || 'failed to load tokens';
+  }
+}
+
+async function onCreate() {
+  if (!newName.value.trim()) return;
+  error.value = '';
+  busy.value = true;
+  try {
+    const created = await api('/api/api-tokens', {
+      method: 'POST',
+      body: {
+        name: newName.value.trim(),
+        scope: newAllowWrite.value ? 'read-write' : 'read',
+      },
+    });
+    revealed.value = { name: created.name, token: created.token };
+    copied.value = false;
+    newName.value = '';
+    newAllowWrite.value = false;
+    await refresh();
+  } catch (e) {
+    error.value = e.message || 'failed to create token';
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function onCopy() {
+  if (!revealed.value) return;
+  try {
+    await navigator.clipboard.writeText(revealed.value.token);
+    copied.value = true;
+  } catch (_) {
+    // Clipboard permission denied (rare; mostly insecure-context). The user
+    // can still select+copy from the rendered <code>.
+    error.value = 'clipboard unavailable — select and copy the token manually';
+  }
+}
+
+async function onRevoke(token) {
+  if (!confirm(`Revoke ${token.name}? Scripts using this token will lose access.`)) return;
+  error.value = '';
+  busy.value = true;
+  try {
+    await api(`/api/api-tokens/${token.id}`, { method: 'DELETE' });
+    await refresh();
+  } catch (e) {
+    error.value = e.message || 'revoke failed';
+  } finally {
+    busy.value = false;
+  }
+}
+</script>
+
+<style src="./panes.css"></style>
+<style scoped>
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 4px;
+  max-width: 360px;
+}
+.create-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--fg-muted);
+}
+.create-form label.check {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  color: var(--fg);
+}
+.create-form label span {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.85em;
+}
+.create-form label.check span {
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: inherit;
+}
+.create-actions {
+  display: flex;
+  gap: 1ch;
+  align-items: center;
+  margin-top: 2px;
+}
+
+.reveal {
+  margin: 12px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--accent);
+  background: var(--bg-soft);
+}
+.reveal-warning { margin: 0 0 6px; color: var(--fg); }
+.reveal-row {
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+  flex-wrap: wrap;
+}
+.token {
+  flex: 1 1 auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  word-break: break-all;
+  user-select: all;
+  background: var(--bg);
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  min-width: 0;
+}
+
+.token-row .ua {
+  display: flex;
+  align-items: center;
+  gap: 1ch;
+}
+.token-row .name { color: var(--fg); }
+.token-row .scope {
+  color: var(--fg-muted);
+  font-variant: small-caps;
+}
+.token-row .revoked {
+  color: var(--bad);
+  font-variant: small-caps;
+}
+.token-row .placeholder { width: 0; }
+</style>

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -54,6 +54,7 @@ import IgnoresPane from '../components/settings-panes/IgnoresPane.vue';
 import UsersPane from '../components/settings-panes/UsersPane.vue';
 import NetworksPane from '../components/settings-panes/NetworksPane.vue';
 import AccountPane from '../components/settings-panes/AccountPane.vue';
+import ApiTokensPane from '../components/settings-panes/ApiTokensPane.vue';
 import DataPane from '../components/settings-panes/DataPane.vue';
 import AboutPane from '../components/settings-panes/AboutPane.vue';
 
@@ -76,6 +77,7 @@ const BESPOKE_PANES = {
   users: UsersPane,
   networks: NetworksPane,
   account: AccountPane,
+  'api-tokens': ApiTokensPane,
   data: DataPane,
   about: AboutPane,
 };


### PR DESCRIPTION
Closes #1.

## Summary

- Per-user revocable bearer tokens (`api_tokens` table) with `read` / `read-write` scopes — `Authorization: Bearer …` on the HTTP side, sibling of the existing cookie/WebAuthn auth.
- Transport-agnostic verb registry extracted from `wsHub.js`'s switch statement. Eight verbs ship: `list_networks`, `list_buffers`, `recent_messages`, `search_messages`, `get_nick_note`, `set_nick_note`, `send_message`, `send_action`.
- Hand-rolled MCP-over-HTTP server at `/mcp` (JSON-RPC 2.0, ~100 LOC, no SDK dep). `tools/list` filters by token scope so a read-only token never sees write verbs advertised.
- Settings pane for minting / revoking tokens with a one-time reveal on creation.
- `MCP.md` for operators: token flow, endpoint URL, tool catalog, Claude Desktop + curl examples, explicit list of deliberate non-features.

## Scope cuts (from the original card)

- No REST endpoints — MCP is the only new transport. Defer until a non-MCP consumer asks.
- No `subscribe_events` / streaming over MCP. Agents poll `recent_messages` with a `before` cursor.
- No per-verb scopes — two scopes, enforced centrally in `callVerb`.
- No WS auth via bearer token. Tokens are HTTP-only by design; WebSocket stays cookie-only.
- No rate limiting / per-token expiry / IP allowlist — trusted-friends threat model.

The auto-notes example app ships separately in a follow-up PR on top of this surface.

## What changed in `wsHub.js`

`socketsByUser`, `send`, and `fanOut` lift to module scope; `fanOutToUser` and `decorateMessage` are now exported so verbs can broadcast to open browser tabs and apply identical dm/matched/notify flags regardless of which transport invoked them.

Five switch cases delegate to the registry: `send`, `action`, `history` (only the `before` mode — the `around`/`after`/`latest` modes are UI-only and stay inline), `search`, `set-nick-note`. The other ~25 cases (presence, snapshot resume, drafts, typing, mark-read, pins, chanlist, ignore masks, channel-notify, etc.) stay put because they're WS-stateful and have no MCP equivalent.

Incidental fix in `history` 'before' mode: now uses an indexed `hasOlderRow` probe instead of the `events.length === limit` heuristic. The heuristic was a false-positive when a buffer contained exactly `limit` rows.

## End-to-end smoke test

Wired into Claude Code via `claude mcp add --transport http`. Roundtrip verified: \`list_networks\` → \`list_buffers\` → \`recent_messages\` → \`send_message\` to a live IRC channel, message persisted and appeared in an open browser tab through the WS fanout.

## Test plan

- [x] Build green (server + Vue client)
- [x] Full test suite green: 527 passing (was 481, +46 new across 4 new files)
- [x] Existing wsHub-driven verbs still behave identically over WS after the refactor
- [x] MCP roundtrip exercised end-to-end via supertest: initialize → tools/list → tools/call (read + write) → scope rejection → boundary ownership rejection → JSON-RPC method-not-found
- [x] Real-client smoke test against Claude Code's MCP HTTP transport
- [ ] Operator-side smoke test against Claude Desktop's MCP config (after merge — needs a deployed instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)