### PR TITLE
Autonotes: scan trace panel + Sonnet 4.6

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -174,6 +174,18 @@ curl -X POST https://<your-lurker>/mcp \
   }'
 ```
 
+### Auto-notes — reference integration
+
+The repo includes a small standalone web app at
+[`integrations/autonotes/`](integrations/autonotes/) that uses the MCP API
+to propose updates to your nick-notes from recent channel chatter. It's
+useful on its own, but more importantly it serves as a worked example of
+consuming Lurker's MCP API from outside the server. If you're building
+your own integration, [`lib/mcpClient.js`](integrations/autonotes/lib/mcpClient.js)
+shows the wire protocol end-to-end and
+[`lib/agent.js`](integrations/autonotes/lib/agent.js) shows how to wrap
+MCP verbs as Anthropic tool definitions for an agentic loop.
+
 ## Revocation
 
 Revoke a token from the settings pane at any time. Soft revocation: the

--- a/integrations/autonotes/.env.example
+++ b/integrations/autonotes/.env.example
@@ -1,0 +1,5 @@
+# Required: Anthropic API key for the agentic workflow.
+ANTHROPIC_API_KEY=
+
+# Optional: port the integration's web UI listens on.
+PORT=5173

--- a/integrations/autonotes/.gitignore
+++ b/integrations/autonotes/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+config.json

--- a/integrations/autonotes/README.md
+++ b/integrations/autonotes/README.md
@@ -1,0 +1,76 @@
+# Lurker Auto-notes — sample MCP integration
+
+A small standalone web app that uses Lurker's MCP API to propose updates to
+your nick-notes from recent channel backlog. The operator picks a channel and
+depth; Claude reads the backlog, looks up existing notes, and proposes
+per-nick merges with evidence linked to the source messages. You review,
+edit, and apply.
+
+This app also doubles as the **canonical example of consuming Lurker's MCP
+API from an external program**. If you're building your own Lurker
+integration, start by reading:
+
+- [`lib/mcpClient.js`](lib/mcpClient.js) — the entire MCP wire protocol in
+  ~70 lines (hand-rolled JSON-RPC over `fetch`, no SDK dependency)
+- [`lib/agent.js`](lib/agent.js) — how to expose MCP verbs to Claude as
+  Anthropic tools and run an agentic tool-use loop
+
+The app lives outside the Lurker server process. It talks to Lurker over
+the public MCP endpoint and to Anthropic for the agentic workflow.
+
+## Setup
+
+```sh
+cd integrations/autonotes
+npm install
+cp .env.example .env
+# edit .env, set ANTHROPIC_API_KEY
+```
+
+## Run
+
+```sh
+npm start
+```
+
+Then open <http://localhost:5173>.
+
+1. **Config** — paste your Lurker **MCP** URL and an API token. The URL is
+   your Lurker base URL with `/mcp` appended (e.g. `http://localhost:8010/mcp`
+   or `https://lurker.example.com/mcp`). Mint a token at
+   `/settings/api-tokens` in Lurker; pick **read-write** if you want to
+   actually apply the proposals. The app will hit `tools/list` to verify
+   and tell you the token's scope.
+2. **Scan** — pick a network, a buffer, and a backlog depth (default 200).
+   Click Scan.
+3. **Review** — one card per proposed update. Each card shows the current
+   note, the proposed merge (editable), Claude's rationale, and the source
+   messages it cited as evidence. Edit, accept, or reject per card; or
+   "Apply all remaining" at the bottom.
+
+## How the agent works
+
+The app gives Claude the **read** MCP verbs as tools:
+
+- `recent_messages` — to pull the backlog
+- `search_messages` — to fetch extra context on a specific nick
+- `get_nick_note` — to read each speaker's existing note
+- `list_buffers`, `list_networks` — included but rarely used during a scan
+
+Claude calls these autonomously, decides which speakers need updates, and
+emits a final JSON block with proposed merges plus message-id evidence. The
+write verbs (`set_nick_note`, `send_message`, `send_action`) are **not**
+exposed to Claude — writes only happen when the operator clicks Apply, and
+go through the app's own MCP client.
+
+## Things this sample deliberately doesn't do
+
+- Persist scans across restarts. In-memory only.
+- Stream Claude's tokens to the browser. The UI polls every 2s.
+- Concurrent scans. One at a time per operator.
+- Automated tests. The agent is non-deterministic; verify by hand against
+  a low-traffic channel.
+
+## License
+
+Same as the rest of Lurker — see `../../LICENSE`.

--- a/integrations/autonotes/README.md
+++ b/integrations/autonotes/README.md
@@ -67,7 +67,9 @@ go through the app's own MCP client.
 
 - Persist scans across restarts. In-memory only.
 - Stream Claude's tokens to the browser. The UI polls every 2s.
-- Concurrent scans. One at a time per operator.
+- Guard against concurrent scans. Nothing rejects a second `POST /api/scan`
+  while one is running — the app just assumes a single operator runs one
+  scan at a time.
 - Automated tests. The agent is non-deterministic; verify by hand against
   a low-traffic channel.
 

--- a/integrations/autonotes/lib/agent.js
+++ b/integrations/autonotes/lib/agent.js
@@ -364,6 +364,8 @@ function extractProposals(content) {
         : [],
     }))
     // Drop malformed proposals — an empty nick or note would render a broken
-    // review card and make /api/apply call set_nick_note with junk.
-    .filter((p) => p.nick && p.proposedNote);
+    // review card and make /api/apply call set_nick_note with junk. Evidence
+    // is required too: the prompt forbids proposing without it, and the review
+    // UI is built around showing the cited messages per card.
+    .filter((p) => p.nick && p.proposedNote && p.evidence.length > 0);
 }

--- a/integrations/autonotes/lib/agent.js
+++ b/integrations/autonotes/lib/agent.js
@@ -1,0 +1,245 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { McpToolError } from "./mcpClient.js";
+
+const MODEL = "claude-opus-4-7";
+const MAX_TOOL_CALLS = 20;
+const MAX_TOKENS = 16000;
+
+// Read-only MCP verbs exposed to Claude. Shapes copied from Lurker's
+// tools/list (server/services/verbs/*.js). Hardcoded rather than fetched at
+// runtime so the prompt prefix stays byte-identical across scans — that's
+// what makes prompt caching on the system block actually pay off.
+const TOOLS = [
+  {
+    name: "recent_messages",
+    description:
+      "Fetch a window of recent messages for one buffer (channel or DM) on a network. Returns { messages: [...], hasOlder: boolean }. Each message has id, time (Unix ms), nick, text, type, self, dm. Paginate backwards with `before`. Use this first to pull the backlog.",
+    input_schema: {
+      type: "object",
+      properties: {
+        networkId: { type: "integer", description: "Network id (from list_networks)" },
+        target: { type: "string", description: "Channel name (e.g. '#lurker') or peer nick" },
+        limit: { type: "integer", description: "Default 100, max 500" },
+        before: { type: "integer", description: "Lowest id from prior page, for older messages" },
+      },
+      required: ["networkId", "target"],
+    },
+  },
+  {
+    name: "search_messages",
+    description:
+      "Full-text search across message history. Use after recent_messages when you need extra context on a specific nick (e.g. pass nick + a topic keyword). Returns same message shape as recent_messages.",
+    input_schema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Free-text query (SQLite FTS5; multiple terms ANDed)" },
+        networkId: { type: "integer" },
+        target: { type: "string" },
+        nick: { type: "string", description: "Restrict to messages from this nick" },
+        limit: { type: "integer", description: "Default 50, max 100" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "get_nick_note",
+    description:
+      "Read the operator's existing free-form note about a nick on a network. Returns { networkId, nick, note, updatedAt }. note is empty string when none exists.",
+    input_schema: {
+      type: "object",
+      properties: {
+        networkId: { type: "integer" },
+        nick: { type: "string" },
+      },
+      required: ["networkId", "nick"],
+    },
+  },
+  {
+    name: "list_buffers",
+    description:
+      "List channels and DMs with history on the operator's account, optionally filtered by networkId. Rarely needed during a scan — the buffer is already chosen.",
+    input_schema: {
+      type: "object",
+      properties: {
+        networkId: { type: "integer" },
+      },
+    },
+  },
+  {
+    name: "list_networks",
+    description:
+      "List networks with connection state and the operator's current nick. Useful only if you need the operator's own nick to filter (you can already use message.self).",
+    input_schema: { type: "object", properties: {} },
+  },
+];
+
+const SYSTEM_PROMPT = `You are an assistant that proposes refined nick-notes for an IRC operator based on recent channel chatter.
+
+The operator keeps short free-form notes about individual nicks — facts and observations like "lives in oslo, runs lurker dev, uses neovim". A good nick-note is terse, factual, and mergeable across many small additions over time. It is NOT a summary of what someone said today.
+
+Your job for each scan:
+
+1. Call recent_messages on the chosen buffer to pull the backlog at the requested depth.
+2. Identify the speakers. Skip any message where self is true (those are the operator). Skip nicks with fewer than 3 substantive messages — small samples lead to bad notes.
+3. For each remaining nick, call get_nick_note to read the existing note.
+4. Optionally call search_messages with the nick (and a topic keyword) when you need more context to justify or merge an update.
+5. Propose an updated note ONLY when the new backlog reveals something useful that isn't already captured. Skip nicks where the existing note is already accurate and the backlog adds nothing.
+
+Hard rules:
+- Cite specific message ids as evidence for every proposed change. Never propose without evidence.
+- Preserve existing facts in the proposed note unless they contradict newer evidence — additions should read as merges.
+- Keep proposed notes terse. One line. Comma-separated facts, lower-case, no first-person.
+- Do not invent biographical details. If a fact isn't in the cited messages, do not include it.
+- You have a budget of about ${MAX_TOOL_CALLS} tool calls per scan. Spend them on backlog ingest and a small number of targeted searches.
+
+When you have finished investigating, stop calling tools and emit exactly one final message containing a single \`\`\`json fenced code block with this shape:
+
+\`\`\`json
+{
+  "proposals": [
+    {
+      "nick": "string",
+      "currentNote": "string (empty if none)",
+      "proposedNote": "string",
+      "rationale": "one short sentence explaining the merge",
+      "evidence": [<messageId>, <messageId>, ...]
+    }
+  ]
+}
+\`\`\`
+
+If you have nothing useful to propose for this scan, emit \`{ "proposals": [] }\` — that is a valid outcome.`;
+
+export async function runScan({ scan, mcpClient, onProgress }) {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error("ANTHROPIC_API_KEY is not set in the integration's environment");
+  }
+  const client = new Anthropic();
+
+  // Track every message Claude sees, keyed by id, so the review UI can render
+  // the evidence linked to each proposal without re-fetching.
+  const messageCache = new Map();
+
+  const messages = [
+    {
+      role: "user",
+      content: `Analyze the buffer \`${scan.target}\` on network ${scan.networkId} at depth ${scan.depth}. Start with recent_messages.`,
+    },
+  ];
+
+  for (let turn = 0; turn < MAX_TOOL_CALLS + 2; turn++) {
+    const response = await client.messages.create({
+      model: MODEL,
+      max_tokens: MAX_TOKENS,
+      thinking: { type: "adaptive" },
+      output_config: { effort: "high" },
+      system: [
+        {
+          type: "text",
+          text: SYSTEM_PROMPT,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      tools: TOOLS,
+      messages,
+    });
+
+    messages.push({ role: "assistant", content: response.content });
+
+    if (response.stop_reason === "end_turn") {
+      const proposals = extractProposals(response.content);
+      return { proposals, messages: messageCacheToObject(messageCache) };
+    }
+
+    if (response.stop_reason !== "tool_use") {
+      throw new Error(`Unexpected stop_reason from agent: ${response.stop_reason}`);
+    }
+
+    const toolUses = response.content.filter((b) => b.type === "tool_use");
+    if (toolUses.length === 0) {
+      throw new Error("Agent stopped on tool_use with no tool blocks");
+    }
+
+    if (scan.toolCallCount + toolUses.length > MAX_TOOL_CALLS) {
+      throw new Error(
+        `Agent exceeded tool-call budget (${MAX_TOOL_CALLS}). Try a smaller depth.`,
+      );
+    }
+
+    const toolResults = [];
+    for (const tu of toolUses) {
+      const result = await invokeTool(mcpClient, tu, messageCache);
+      toolResults.push(result);
+      scan.toolCallCount += 1;
+      onProgress?.(scan);
+    }
+
+    messages.push({ role: "user", content: toolResults });
+  }
+
+  throw new Error("Agent loop ran past safety bound without producing proposals");
+}
+
+async function invokeTool(mcpClient, toolUse, messageCache) {
+  try {
+    const payload = await mcpClient.toolCall(toolUse.name, toolUse.input ?? {});
+    cacheMessagesFromPayload(toolUse.name, payload, messageCache);
+    return {
+      type: "tool_result",
+      tool_use_id: toolUse.id,
+      content: JSON.stringify(payload),
+    };
+  } catch (err) {
+    const body =
+      err instanceof McpToolError
+        ? JSON.stringify(err.payload ?? { error: err.message })
+        : JSON.stringify({ error: err.message });
+    return {
+      type: "tool_result",
+      tool_use_id: toolUse.id,
+      content: body,
+      is_error: true,
+    };
+  }
+}
+
+function cacheMessagesFromPayload(toolName, payload, messageCache) {
+  if (toolName !== "recent_messages" && toolName !== "search_messages") return;
+  const list = Array.isArray(payload?.messages) ? payload.messages : [];
+  for (const m of list) {
+    if (typeof m?.id === "number") messageCache.set(m.id, m);
+  }
+}
+
+function messageCacheToObject(messageCache) {
+  const out = {};
+  for (const [id, msg] of messageCache) out[id] = msg;
+  return out;
+}
+
+function extractProposals(content) {
+  const text = content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+
+  const fence = text.match(/```json\s*([\s\S]*?)```/);
+  const jsonStr = fence ? fence[1].trim() : text.trim();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch (err) {
+    throw new Error(`Agent did not return parseable JSON: ${err.message}`);
+  }
+  if (!parsed || !Array.isArray(parsed.proposals)) {
+    throw new Error("Agent JSON missing 'proposals' array");
+  }
+  return parsed.proposals.map((p) => ({
+    nick: String(p.nick ?? ""),
+    currentNote: String(p.currentNote ?? ""),
+    proposedNote: String(p.proposedNote ?? ""),
+    rationale: String(p.rationale ?? ""),
+    evidence: Array.isArray(p.evidence) ? p.evidence.filter((id) => typeof id === "number") : [],
+  }));
+}

--- a/integrations/autonotes/lib/agent.js
+++ b/integrations/autonotes/lib/agent.js
@@ -269,8 +269,11 @@ function summarizeToolResult(name, payload) {
     const msgs = Array.isArray(payload.messages) ? payload.messages : [];
     if (msgs.length === 0) return "0 messages";
     const nicks = new Set(msgs.map((m) => m.nick).filter(Boolean));
-    const oldest = formatTs(msgs[0]?.time);
-    const newest = formatTs(msgs[msgs.length - 1]?.time);
+    // Derive the range from the timestamps, not array position: recent_messages
+    // returns oldest-first but search_messages returns newest-first.
+    const times = msgs.map((m) => m.time).filter((t) => typeof t === "number");
+    const oldest = formatTs(times.length ? Math.min(...times) : undefined);
+    const newest = formatTs(times.length ? Math.max(...times) : undefined);
     const more =
       "hasOlder" in payload
         ? `hasOlder=${payload.hasOlder}`

--- a/integrations/autonotes/lib/agent.js
+++ b/integrations/autonotes/lib/agent.js
@@ -1,7 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { McpToolError } from "./mcpClient.js";
 
-const MODEL = "claude-opus-4-7";
+// Sonnet 4.6 is well-matched to this workload (structured analysis with
+// tools, not intelligence-demanding). Opus 4.7 works but burns ~3x the cost
+// for marginal quality gains. If you bump the model, update PRICING in
+// public/app.js so the trace's cost estimate stays accurate.
+const MODEL = "claude-sonnet-4-6";
 const MAX_TOOL_CALLS = 20;
 const MAX_TOKENS = 16000;
 
@@ -110,15 +114,23 @@ When you have finished investigating, stop calling tools and emit exactly one fi
 
 If you have nothing useful to propose for this scan, emit \`{ "proposals": [] }\` — that is a valid outcome.`;
 
-export async function runScan({ scan, mcpClient, onProgress }) {
+export async function runScan({ scan, mcpClient, onProgress, onEvent }) {
   if (!process.env.ANTHROPIC_API_KEY) {
     throw new Error("ANTHROPIC_API_KEY is not set in the integration's environment");
   }
   const client = new Anthropic();
+  const emit = (ev) => onEvent?.(ev);
 
   // Track every message Claude sees, keyed by id, so the review UI can render
   // the evidence linked to each proposal without re-fetching.
   const messageCache = new Map();
+
+  const totals = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+  };
 
   const messages = [
     {
@@ -128,6 +140,7 @@ export async function runScan({ scan, mcpClient, onProgress }) {
   ];
 
   for (let turn = 0; turn < MAX_TOOL_CALLS + 2; turn++) {
+    const turnStartedAt = Date.now();
     const response = await client.messages.create({
       model: MODEL,
       max_tokens: MAX_TOKENS,
@@ -143,6 +156,35 @@ export async function runScan({ scan, mcpClient, onProgress }) {
       tools: TOOLS,
       messages,
     });
+
+    accumulateUsage(totals, response.usage);
+    emit({
+      type: "turn",
+      turn,
+      stopReason: response.stop_reason,
+      durationMs: Date.now() - turnStartedAt,
+      usage: pickUsage(response.usage),
+      totals: { ...totals },
+    });
+
+    // Walk content blocks in order so the trace reads top-to-bottom: thinking,
+    // any narration text, then tool calls — matching what Claude actually did
+    // during this turn.
+    for (const block of response.content) {
+      if (block.type === "thinking" && block.thinking) {
+        emit({ type: "thinking", turn, text: block.thinking });
+      } else if (block.type === "text" && block.text) {
+        emit({ type: "text", turn, text: block.text });
+      } else if (block.type === "tool_use") {
+        emit({
+          type: "tool_use",
+          turn,
+          id: block.id,
+          name: block.name,
+          input: block.input ?? {},
+        });
+      }
+    }
 
     messages.push({ role: "assistant", content: response.content });
 
@@ -168,9 +210,21 @@ export async function runScan({ scan, mcpClient, onProgress }) {
 
     const toolResults = [];
     for (const tu of toolUses) {
-      const result = await invokeTool(mcpClient, tu, messageCache);
-      toolResults.push(result);
+      const { resultBlock, summary, isError } = await invokeTool(
+        mcpClient,
+        tu,
+        messageCache,
+      );
+      toolResults.push(resultBlock);
       scan.toolCallCount += 1;
+      emit({
+        type: "tool_result",
+        turn,
+        toolUseId: tu.id,
+        name: tu.name,
+        summary,
+        isError,
+      });
       onProgress?.(scan);
     }
 
@@ -185,22 +239,83 @@ async function invokeTool(mcpClient, toolUse, messageCache) {
     const payload = await mcpClient.toolCall(toolUse.name, toolUse.input ?? {});
     cacheMessagesFromPayload(toolUse.name, payload, messageCache);
     return {
-      type: "tool_result",
-      tool_use_id: toolUse.id,
-      content: JSON.stringify(payload),
+      resultBlock: {
+        type: "tool_result",
+        tool_use_id: toolUse.id,
+        content: JSON.stringify(payload),
+      },
+      summary: summarizeToolResult(toolUse.name, payload),
+      isError: false,
     };
   } catch (err) {
-    const body =
-      err instanceof McpToolError
-        ? JSON.stringify(err.payload ?? { error: err.message })
-        : JSON.stringify({ error: err.message });
+    const payload = err instanceof McpToolError ? err.payload : { error: err.message };
     return {
-      type: "tool_result",
-      tool_use_id: toolUse.id,
-      content: body,
-      is_error: true,
+      resultBlock: {
+        type: "tool_result",
+        tool_use_id: toolUse.id,
+        content: JSON.stringify(payload ?? { error: err.message }),
+        is_error: true,
+      },
+      summary: `error: ${err.message}`,
+      isError: true,
     };
   }
+}
+
+function summarizeToolResult(name, payload) {
+  if (!payload || typeof payload !== "object") return String(payload).slice(0, 120);
+
+  if (name === "recent_messages" || name === "search_messages") {
+    const msgs = Array.isArray(payload.messages) ? payload.messages : [];
+    if (msgs.length === 0) return "0 messages";
+    const nicks = new Set(msgs.map((m) => m.nick).filter(Boolean));
+    const oldest = formatTs(msgs[0]?.time);
+    const newest = formatTs(msgs[msgs.length - 1]?.time);
+    const more =
+      "hasOlder" in payload
+        ? `hasOlder=${payload.hasOlder}`
+        : "hasMore" in payload
+          ? `hasMore=${payload.hasMore}`
+          : "";
+    return `${msgs.length} msgs from ${nicks.size} nicks (${oldest} → ${newest})${more ? `, ${more}` : ""}`;
+  }
+
+  if (name === "get_nick_note") {
+    const note = String(payload.note ?? "");
+    return note ? `note: ${truncate(note, 100)}` : "(no existing note)";
+  }
+
+  if (Array.isArray(payload)) return `${payload.length} item${payload.length === 1 ? "" : "s"}`;
+
+  return truncate(JSON.stringify(payload), 120);
+}
+
+function formatTs(t) {
+  if (typeof t !== "number") return "?";
+  return new Date(t).toISOString().slice(0, 16).replace("T", " ");
+}
+
+function truncate(s, n) {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+function accumulateUsage(totals, usage) {
+  if (!usage) return;
+  for (const k of Object.keys(totals)) {
+    totals[k] += usage[k] || 0;
+  }
+}
+
+function pickUsage(usage) {
+  if (!usage) return null;
+  const { input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens } =
+    usage;
+  return {
+    input_tokens: input_tokens || 0,
+    output_tokens: output_tokens || 0,
+    cache_creation_input_tokens: cache_creation_input_tokens || 0,
+    cache_read_input_tokens: cache_read_input_tokens || 0,
+  };
 }
 
 function cacheMessagesFromPayload(toolName, payload, messageCache) {

--- a/integrations/autonotes/lib/agent.js
+++ b/integrations/autonotes/lib/agent.js
@@ -350,11 +350,17 @@ function extractProposals(content) {
   if (!parsed || !Array.isArray(parsed.proposals)) {
     throw new Error("Agent JSON missing 'proposals' array");
   }
-  return parsed.proposals.map((p) => ({
-    nick: String(p.nick ?? ""),
-    currentNote: String(p.currentNote ?? ""),
-    proposedNote: String(p.proposedNote ?? ""),
-    rationale: String(p.rationale ?? ""),
-    evidence: Array.isArray(p.evidence) ? p.evidence.filter((id) => typeof id === "number") : [],
-  }));
+  return parsed.proposals
+    .map((p) => ({
+      nick: String(p.nick ?? "").trim(),
+      currentNote: String(p.currentNote ?? ""),
+      proposedNote: String(p.proposedNote ?? "").trim(),
+      rationale: String(p.rationale ?? ""),
+      evidence: Array.isArray(p.evidence)
+        ? p.evidence.filter((id) => typeof id === "number")
+        : [],
+    }))
+    // Drop malformed proposals — an empty nick or note would render a broken
+    // review card and make /api/apply call set_nick_note with junk.
+    .filter((p) => p.nick && p.proposedNote);
 }

--- a/integrations/autonotes/lib/config.js
+++ b/integrations/autonotes/lib/config.js
@@ -1,0 +1,37 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = resolve(here, "..", "config.json");
+
+const EMPTY = {
+  lurkerUrl: "",
+  lurkerToken: "",
+  lastNetworkId: null,
+  lastTarget: "",
+  lastDepth: 200,
+};
+
+export async function loadConfig() {
+  try {
+    const raw = await readFile(CONFIG_PATH, "utf8");
+    return { ...EMPTY, ...JSON.parse(raw) };
+  } catch (err) {
+    if (err.code === "ENOENT") return { ...EMPTY };
+    throw err;
+  }
+}
+
+export async function saveConfig(patch) {
+  const current = await loadConfig();
+  const next = { ...current, ...patch };
+  await writeFile(CONFIG_PATH, JSON.stringify(next, null, 2) + "\n", "utf8");
+  return next;
+}
+
+export function maskToken(token) {
+  if (!token) return "";
+  if (token.length <= 8) return "•".repeat(token.length);
+  return `${token.slice(0, 4)}…${token.slice(-4)}`;
+}

--- a/integrations/autonotes/lib/config.js
+++ b/integrations/autonotes/lib/config.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, chmod } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
@@ -26,7 +26,14 @@ export async function loadConfig() {
 export async function saveConfig(patch) {
   const current = await loadConfig();
   const next = { ...current, ...patch };
-  await writeFile(CONFIG_PATH, JSON.stringify(next, null, 2) + "\n", "utf8");
+  // config.json holds the Lurker API token — keep it owner-only. The mode on
+  // writeFile only applies when the file is created, so chmod afterwards to
+  // also tighten a file that already existed.
+  await writeFile(CONFIG_PATH, JSON.stringify(next, null, 2) + "\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await chmod(CONFIG_PATH, 0o600);
   return next;
 }
 

--- a/integrations/autonotes/lib/mcpClient.js
+++ b/integrations/autonotes/lib/mcpClient.js
@@ -1,0 +1,89 @@
+// Minimal MCP HTTP client for Lurker's /mcp endpoint.
+//
+// Lurker's MCP surface is JSON-RPC 2.0 over a single POST per request — no
+// session state on the server. We hand-roll the wire format here (rather than
+// pulling in @modelcontextprotocol/sdk) so the sample stays readable and the
+// transport doesn't drift if the upstream SDK rev-locks.
+
+export class McpError extends Error {
+  constructor(message, { code, data } = {}) {
+    super(message);
+    this.name = "McpError";
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export class McpToolError extends Error {
+  constructor(message, { payload } = {}) {
+    super(message);
+    this.name = "McpToolError";
+    this.payload = payload;
+  }
+}
+
+export class McpClient {
+  constructor({ url, token }) {
+    if (!url) throw new Error("McpClient: url is required");
+    if (!token) throw new Error("McpClient: token is required");
+    this.url = url.replace(/\/$/, "");
+    this.token = token;
+    this.rpcId = 0;
+  }
+
+  async call(method, params = {}) {
+    const id = ++this.rpcId;
+    const res = await fetch(this.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json",
+        authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new McpError(`HTTP ${res.status} from ${this.url}: ${body.slice(0, 400)}`, {
+        code: res.status,
+      });
+    }
+
+    const envelope = await res.json();
+    if (envelope.error) {
+      throw new McpError(envelope.error.message ?? "MCP error", {
+        code: envelope.error.code,
+        data: envelope.error.data,
+      });
+    }
+    return envelope.result;
+  }
+
+  async toolsList() {
+    return this.call("tools/list", {});
+  }
+
+  // Returns the unwrapped tool payload (parsed JSON from the first text block).
+  // Throws McpToolError when the tool replied with isError: true.
+  async toolCall(name, args = {}) {
+    const result = await this.call("tools/call", { name, arguments: args });
+    const payload = extractToolPayload(result);
+    if (result?.isError) {
+      throw new McpToolError(`MCP tool ${name} returned error`, { payload });
+    }
+    return payload;
+  }
+}
+
+function extractToolPayload(result) {
+  const block = Array.isArray(result?.content) ? result.content[0] : null;
+  if (!block || block.type !== "text" || typeof block.text !== "string") {
+    return result;
+  }
+  try {
+    return JSON.parse(block.text);
+  } catch {
+    return { text: block.text };
+  }
+}

--- a/integrations/autonotes/lib/scans.js
+++ b/integrations/autonotes/lib/scans.js
@@ -1,0 +1,53 @@
+// In-memory scan store. One operator, one in-flight scan at a time — sample
+// scope. Restart drops history; that's acceptable here.
+
+import { randomUUID } from "node:crypto";
+
+const scans = new Map();
+
+export function createScan({ networkId, target, depth }) {
+  const id = randomUUID();
+  const scan = {
+    id,
+    networkId,
+    target,
+    depth,
+    status: "running",
+    toolCallCount: 0,
+    proposals: null,
+    messages: null, // map of messageId -> message, for evidence rendering
+    error: null,
+    startedAt: Date.now(),
+    finishedAt: null,
+  };
+  scans.set(id, scan);
+  return scan;
+}
+
+export function getScan(id) {
+  return scans.get(id) ?? null;
+}
+
+export function updateScan(id, patch) {
+  const scan = scans.get(id);
+  if (!scan) return null;
+  Object.assign(scan, patch);
+  return scan;
+}
+
+export function finishScan(id, { proposals, messages }) {
+  return updateScan(id, {
+    status: "done",
+    proposals,
+    messages,
+    finishedAt: Date.now(),
+  });
+}
+
+export function errorScan(id, error) {
+  return updateScan(id, {
+    status: "error",
+    error: error?.message ?? String(error),
+    finishedAt: Date.now(),
+  });
+}

--- a/integrations/autonotes/lib/scans.js
+++ b/integrations/autonotes/lib/scans.js
@@ -16,11 +16,19 @@ export function createScan({ networkId, target, depth }) {
     toolCallCount: 0,
     proposals: null,
     messages: null, // map of messageId -> message, for evidence rendering
+    events: [], // ordered trace of model turns / tool calls; consumed by the UI
     error: null,
     startedAt: Date.now(),
     finishedAt: null,
   };
   scans.set(id, scan);
+  return scan;
+}
+
+export function appendEvent(id, event) {
+  const scan = scans.get(id);
+  if (!scan) return null;
+  scan.events.push({ ...event, at: Date.now() });
   return scan;
 }
 

--- a/integrations/autonotes/package-lock.json
+++ b/integrations/autonotes/package-lock.json
@@ -1,0 +1,892 @@
+{
+  "name": "lurker-autonotes",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lurker-autonotes",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.65.0",
+        "dotenv": "^16.4.5",
+        "express": "^4.21.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.65.0.tgz",
+      "integrity": "sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/integrations/autonotes/package.json
+++ b/integrations/autonotes/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "lurker-autonotes",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Sample MCP integration for Lurker: proposes nick-note updates from channel backlog using an agentic Claude workflow.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.65.0",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.1"
+  }
+}

--- a/integrations/autonotes/public/app.js
+++ b/integrations/autonotes/public/app.js
@@ -40,6 +40,7 @@ const state = {
   scan: null,
   cards: new Map(), // nick -> { proposal, status, note }
   pollHandle: null,
+  activeScanId: null, // scan whose review route is currently active
   renderedEventCount: 0, // index up to which the trace has been rendered
   turnEls: new Map(), // turn number -> { container, body }
   isApplyingAll: false, // true while the apply-all loop is in flight
@@ -219,6 +220,7 @@ els.scanForm.addEventListener("submit", async (e) => {
 function enterReview(scanId) {
   showView("review");
   stopPolling();
+  state.activeScanId = scanId;
   state.cards.clear();
   state.renderedEventCount = 0;
   state.turnEls.clear();
@@ -232,6 +234,10 @@ function enterReview(scanId) {
 }
 
 function stopPolling() {
+  // Clear activeScanId too — an in-flight pollScan() fetch will resolve after
+  // this runs and would otherwise schedule a fresh timeout that outlives the
+  // navigation. pollScan() checks this id before scheduling the next tick.
+  state.activeScanId = null;
   if (state.pollHandle) {
     clearTimeout(state.pollHandle);
     state.pollHandle = null;
@@ -239,8 +245,11 @@ function stopPolling() {
 }
 
 async function pollScan(scanId) {
+  if (scanId !== state.activeScanId) return;
   try {
     const scan = await api(`/api/scan/${scanId}`);
+    // The user may have navigated away while the fetch was in flight.
+    if (scanId !== state.activeScanId) return;
     state.scan = scan;
     renderTrace(scan);
 
@@ -255,6 +264,7 @@ async function pollScan(scanId) {
     }
     renderReview(scan);
   } catch (err) {
+    if (scanId !== state.activeScanId) return;
     setStatus(els.reviewSummary, err.message, "err");
   }
 }

--- a/integrations/autonotes/public/app.js
+++ b/integrations/autonotes/public/app.js
@@ -1,0 +1,428 @@
+// Single-page UI for the autonotes integration. Three views, hash router,
+// no framework. Talks to the Express server in ../server.js, which proxies
+// the operator's commands to Lurker's MCP endpoint.
+
+const $ = (id) => document.getElementById(id);
+const els = {
+  config: $("view-config"),
+  scan: $("view-scan"),
+  review: $("view-review"),
+  configForm: $("config-form"),
+  configStatus: $("config-status"),
+  envWarning: $("env-warning"),
+  scanForm: $("scan-form"),
+  scanStatus: $("scan-status"),
+  scanSubmit: $("scan-submit"),
+  reviewSummary: $("review-summary"),
+  reviewList: $("review-list"),
+  reviewActions: $("review-actions"),
+  applyAll: $("apply-all"),
+};
+
+const state = {
+  scope: null,
+  networks: [],
+  buffersByNetwork: new Map(),
+  scan: null,
+  cards: new Map(), // nick -> { proposal, status, note }
+  pollHandle: null,
+};
+
+async function api(path, opts = {}) {
+  const res = await fetch(path, {
+    headers: { "content-type": "application/json" },
+    ...opts,
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body?.error || `${res.status} ${res.statusText}`);
+  return body;
+}
+
+function setStatus(el, msg, kind = "") {
+  el.textContent = msg;
+  el.className = "status" + (kind ? ` ${kind}` : "");
+}
+
+function showView(name) {
+  for (const v of ["config", "scan", "review"]) {
+    els[v].hidden = v !== name;
+  }
+}
+
+// ---------------- Router ----------------
+
+function route() {
+  const h = location.hash || "";
+  if (h.startsWith("#review/")) {
+    const id = h.slice("#review/".length);
+    enterReview(id);
+  } else if (h === "#scan") {
+    enterScan();
+  } else {
+    enterConfig();
+  }
+}
+
+window.addEventListener("hashchange", route);
+
+// ---------------- Config view ----------------
+
+async function enterConfig() {
+  showView("config");
+  stopPolling();
+  try {
+    const cfg = await api("/api/config");
+    if (cfg.lurkerUrl) els.configForm.lurkerUrl.value = cfg.lurkerUrl;
+    if (cfg.hasToken) {
+      els.configForm.lurkerToken.placeholder = `current: ${cfg.lurkerToken}`;
+    }
+    els.envWarning.hidden = Boolean(cfg.anthropicKeyPresent);
+    if (cfg.hasToken && state.scope === null) {
+      setStatus(els.configStatus, "Token saved. Re-test to confirm scope.");
+    }
+  } catch (err) {
+    setStatus(els.configStatus, err.message, "err");
+  }
+}
+
+els.configForm.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  setStatus(els.configStatus, "Testing connection…");
+  const fd = new FormData(els.configForm);
+  try {
+    const result = await api("/api/config", {
+      method: "POST",
+      body: JSON.stringify({
+        lurkerUrl: fd.get("lurkerUrl"),
+        lurkerToken: fd.get("lurkerToken"),
+      }),
+    });
+    state.scope = result.scope;
+    setStatus(
+      els.configStatus,
+      `Connected. Token scope: ${result.scope}. ${result.toolNames.length} tools visible.`,
+      "ok",
+    );
+    setTimeout(() => (location.hash = "#scan"), 400);
+  } catch (err) {
+    setStatus(els.configStatus, err.message, "err");
+  }
+});
+
+// ---------------- Scan view ----------------
+
+async function enterScan() {
+  showView("scan");
+  stopPolling();
+  setStatus(els.scanStatus, "");
+  try {
+    const cfg = await api("/api/config");
+    if (!cfg.hasToken) {
+      location.hash = "#config";
+      return;
+    }
+    state.networks = await api("/api/networks");
+    populateNetworks(cfg.lastNetworkId, cfg.lastTarget, cfg.lastDepth);
+  } catch (err) {
+    setStatus(els.scanStatus, err.message, "err");
+  }
+}
+
+function populateNetworks(lastNetworkId, lastTarget, lastDepth) {
+  const netSel = els.scanForm.networkId;
+  netSel.innerHTML = "";
+  for (const n of state.networks) {
+    const opt = document.createElement("option");
+    opt.value = String(n.id);
+    opt.textContent = `${n.name} (${n.connected ? "connected" : "offline"} as ${n.nick})`;
+    netSel.appendChild(opt);
+  }
+  if (lastNetworkId != null && state.networks.some((n) => n.id === lastNetworkId)) {
+    netSel.value = String(lastNetworkId);
+  }
+  els.scanForm.depth.value = lastDepth || 200;
+  netSel.addEventListener("change", () => loadBuffers(null));
+  loadBuffers(lastTarget || null);
+}
+
+async function loadBuffers(preferredTarget) {
+  const networkId = Number(els.scanForm.networkId.value);
+  if (!networkId) return;
+  const bufSel = els.scanForm.target;
+  bufSel.innerHTML = "<option>loading…</option>";
+  try {
+    let buffers = state.buffersByNetwork.get(networkId);
+    if (!buffers) {
+      buffers = await api(`/api/buffers?networkId=${networkId}`);
+      state.buffersByNetwork.set(networkId, buffers);
+    }
+    bufSel.innerHTML = "";
+    for (const b of buffers) {
+      const opt = document.createElement("option");
+      opt.value = b.target;
+      opt.textContent = `${b.target} (${b.kind})`;
+      bufSel.appendChild(opt);
+    }
+    if (preferredTarget && buffers.some((b) => b.target === preferredTarget)) {
+      bufSel.value = preferredTarget;
+    }
+  } catch (err) {
+    bufSel.innerHTML = "";
+    setStatus(els.scanStatus, err.message, "err");
+  }
+}
+
+els.scanForm.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  els.scanSubmit.disabled = true;
+  setStatus(els.scanStatus, "Starting scan…");
+  try {
+    const body = {
+      networkId: Number(els.scanForm.networkId.value),
+      target: els.scanForm.target.value,
+      depth: Number(els.scanForm.depth.value),
+    };
+    const { scanId } = await api("/api/scan", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    location.hash = `#review/${scanId}`;
+  } catch (err) {
+    setStatus(els.scanStatus, err.message, "err");
+  } finally {
+    els.scanSubmit.disabled = false;
+  }
+});
+
+// ---------------- Review view ----------------
+
+function enterReview(scanId) {
+  showView("review");
+  state.cards.clear();
+  els.reviewList.innerHTML = "";
+  els.reviewActions.hidden = true;
+  setStatus(els.reviewSummary, "Running scan…");
+  pollScan(scanId);
+}
+
+function stopPolling() {
+  if (state.pollHandle) {
+    clearTimeout(state.pollHandle);
+    state.pollHandle = null;
+  }
+}
+
+async function pollScan(scanId) {
+  try {
+    const scan = await api(`/api/scan/${scanId}`);
+    state.scan = scan;
+    if (scan.status === "running") {
+      setStatus(els.reviewSummary, `Running… ${scan.toolCallCount} tool calls so far`);
+      state.pollHandle = setTimeout(() => pollScan(scanId), 2000);
+      return;
+    }
+    if (scan.status === "error") {
+      setStatus(els.reviewSummary, `Scan failed: ${scan.error}`, "err");
+      return;
+    }
+    renderReview(scan);
+  } catch (err) {
+    setStatus(els.reviewSummary, err.message, "err");
+  }
+}
+
+function renderReview(scan) {
+  const proposals = scan.proposals || [];
+  if (proposals.length === 0) {
+    setStatus(els.reviewSummary, "Scan complete. No proposed changes.", "ok");
+    return;
+  }
+  setStatus(
+    els.reviewSummary,
+    `Scan complete. ${proposals.length} proposal${proposals.length === 1 ? "" : "s"}. Review and apply.`,
+    "ok",
+  );
+  els.reviewList.innerHTML = "";
+  for (const p of proposals) {
+    const card = buildCard(p, scan.messages || {});
+    state.cards.set(p.nick, { proposal: p, status: "pending", card });
+    els.reviewList.appendChild(card.root);
+  }
+  els.reviewActions.hidden = false;
+  updateApplyAll();
+}
+
+function buildCard(p, messages) {
+  const root = document.createElement("div");
+  root.className = "card";
+
+  root.appendChild(
+    h(`<div class="card-head"><span class="nick">${escapeHtml(p.nick)}</span></div>`),
+  );
+
+  const currentField = document.createElement("div");
+  currentField.className = "field";
+  currentField.innerHTML = `<div class="field-label">Current note</div>`;
+  const currentNote = document.createElement("div");
+  currentNote.className = "current-note" + (p.currentNote ? "" : " empty");
+  currentNote.textContent = p.currentNote || "(none)";
+  currentField.appendChild(currentNote);
+  root.appendChild(currentField);
+
+  const proposedField = document.createElement("div");
+  proposedField.className = "field";
+  proposedField.innerHTML = `<div class="field-label">Proposed note (editable)</div>`;
+  const textarea = document.createElement("textarea");
+  textarea.className = "proposed-textarea";
+  textarea.rows = 2;
+  textarea.value = p.proposedNote;
+  proposedField.appendChild(textarea);
+  root.appendChild(proposedField);
+
+  if (p.rationale) {
+    const r = document.createElement("div");
+    r.className = "field rationale";
+    r.textContent = p.rationale;
+    root.appendChild(r);
+  }
+
+  if (p.evidence && p.evidence.length > 0) {
+    const toggle = document.createElement("button");
+    toggle.className = "evidence-toggle";
+    toggle.type = "button";
+    toggle.textContent = `Show ${p.evidence.length} evidence message${p.evidence.length === 1 ? "" : "s"}`;
+    root.appendChild(toggle);
+
+    const evidence = document.createElement("div");
+    evidence.className = "evidence";
+    evidence.hidden = true;
+    for (const id of p.evidence) {
+      const msg = messages[id];
+      const line = document.createElement("div");
+      line.className = "evidence-line";
+      if (msg) {
+        const ts = new Date(msg.time).toISOString().replace("T", " ").slice(0, 16);
+        line.innerHTML = `<span class="ts">${ts}</span><strong>${escapeHtml(msg.nick)}:</strong> ${escapeHtml(msg.text)}`;
+      } else {
+        line.textContent = `[message ${id} not in cache]`;
+      }
+      evidence.appendChild(line);
+    }
+    root.appendChild(evidence);
+
+    toggle.addEventListener("click", () => {
+      evidence.hidden = !evidence.hidden;
+      toggle.textContent = evidence.hidden
+        ? `Show ${p.evidence.length} evidence message${p.evidence.length === 1 ? "" : "s"}`
+        : "Hide evidence";
+    });
+  }
+
+  const actions = document.createElement("div");
+  actions.className = "card-actions";
+  const applyBtn = document.createElement("button");
+  applyBtn.textContent = "Apply";
+  const rejectBtn = document.createElement("button");
+  rejectBtn.className = "secondary";
+  rejectBtn.textContent = "Reject";
+  actions.appendChild(applyBtn);
+  actions.appendChild(rejectBtn);
+  root.appendChild(actions);
+
+  const result = document.createElement("div");
+  result.className = "result";
+  result.hidden = true;
+  root.appendChild(result);
+
+  applyBtn.addEventListener("click", () => applyCard(p.nick, textarea.value));
+  rejectBtn.addEventListener("click", () => rejectCard(p.nick));
+
+  return { root, textarea, applyBtn, rejectBtn, result };
+}
+
+async function applyCard(nick, note) {
+  const entry = state.cards.get(nick);
+  if (!entry) return;
+  entry.card.applyBtn.disabled = true;
+  entry.card.rejectBtn.disabled = true;
+  try {
+    const resp = await api("/api/apply", {
+      method: "POST",
+      body: JSON.stringify({ scanId: state.scan.id, items: [{ nick, note }] }),
+    });
+    const r = resp.results?.[0];
+    if (r?.ok) {
+      entry.status = "applied";
+      entry.card.root.classList.add("applied");
+      entry.card.result.hidden = false;
+      entry.card.result.className = "result ok";
+      entry.card.result.textContent = "Applied.";
+    } else {
+      entry.status = "failed";
+      entry.card.root.classList.add("failed");
+      entry.card.result.hidden = false;
+      entry.card.result.className = "result err";
+      entry.card.result.textContent = `Failed: ${r?.error || "unknown error"}`;
+      entry.card.applyBtn.disabled = false;
+      entry.card.rejectBtn.disabled = false;
+    }
+  } catch (err) {
+    entry.card.result.hidden = false;
+    entry.card.result.className = "result err";
+    entry.card.result.textContent = err.message;
+    entry.card.applyBtn.disabled = false;
+    entry.card.rejectBtn.disabled = false;
+  }
+  updateApplyAll();
+}
+
+function rejectCard(nick) {
+  const entry = state.cards.get(nick);
+  if (!entry) return;
+  entry.status = "rejected";
+  entry.card.root.classList.add("rejected");
+  entry.card.applyBtn.disabled = true;
+  entry.card.rejectBtn.disabled = true;
+  entry.card.result.hidden = false;
+  entry.card.result.className = "result";
+  entry.card.result.textContent = "Rejected (not written).";
+  updateApplyAll();
+}
+
+function updateApplyAll() {
+  const remaining = [...state.cards.values()].filter((e) => e.status === "pending");
+  els.applyAll.disabled = remaining.length === 0;
+  els.applyAll.textContent =
+    remaining.length === 0
+      ? "Nothing left to apply"
+      : `Apply all remaining (${remaining.length})`;
+}
+
+els.applyAll.addEventListener("click", async () => {
+  const remaining = [...state.cards.values()].filter((e) => e.status === "pending");
+  if (remaining.length === 0) return;
+  els.applyAll.disabled = true;
+  for (const entry of remaining) {
+    // serial so the UI updates card-by-card and Lurker sees the writes in order
+    await applyCard(entry.proposal.nick, entry.card.textarea.value);
+  }
+});
+
+// ---------------- helpers ----------------
+
+function h(html) {
+  const t = document.createElement("template");
+  t.innerHTML = html.trim();
+  return t.content.firstChild;
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+route();

--- a/integrations/autonotes/public/app.js
+++ b/integrations/autonotes/public/app.js
@@ -17,6 +17,20 @@ const els = {
   reviewList: $("review-list"),
   reviewActions: $("review-actions"),
   applyAll: $("apply-all"),
+  tracePanel: $("trace-panel"),
+  traceList: $("trace-list"),
+  traceTotals: $("trace-totals"),
+};
+
+// Sonnet 4.6 pricing per million tokens. Used purely for the audit-view cost
+// readout — actual billing comes from Anthropic, this is informational. If
+// you change MODEL in lib/agent.js, update these to match (e.g. Opus 4.7 is
+// 5 / 25 / 0.5 / 6.25).
+const PRICING = {
+  input: 3,
+  output: 15,
+  cacheRead: 0.3,
+  cacheWrite5m: 3.75,
 };
 
 const state = {
@@ -26,6 +40,8 @@ const state = {
   scan: null,
   cards: new Map(), // nick -> { proposal, status, note }
   pollHandle: null,
+  renderedEventCount: 0, // index up to which the trace has been rendered
+  turnEls: new Map(), // turn number -> { container, body }
 };
 
 async function api(path, opts = {}) {
@@ -199,7 +215,12 @@ els.scanForm.addEventListener("submit", async (e) => {
 function enterReview(scanId) {
   showView("review");
   state.cards.clear();
+  state.renderedEventCount = 0;
+  state.turnEls.clear();
   els.reviewList.innerHTML = "";
+  els.traceList.innerHTML = "";
+  els.traceTotals.textContent = "";
+  els.tracePanel.hidden = true;
   els.reviewActions.hidden = true;
   setStatus(els.reviewSummary, "Running scan…");
   pollScan(scanId);
@@ -216,6 +237,8 @@ async function pollScan(scanId) {
   try {
     const scan = await api(`/api/scan/${scanId}`);
     state.scan = scan;
+    renderTrace(scan);
+
     if (scan.status === "running") {
       setStatus(els.reviewSummary, `Running… ${scan.toolCallCount} tool calls so far`);
       state.pollHandle = setTimeout(() => pollScan(scanId), 2000);
@@ -228,6 +251,111 @@ async function pollScan(scanId) {
     renderReview(scan);
   } catch (err) {
     setStatus(els.reviewSummary, err.message, "err");
+  }
+}
+
+function renderTrace(scan) {
+  const events = scan.events || [];
+  if (events.length === 0) return;
+  els.tracePanel.hidden = false;
+
+  // Append only events we haven't drawn yet — keeps the polling cheap and
+  // avoids the DOM flicker of re-rendering the whole trace on every tick.
+  for (let i = state.renderedEventCount; i < events.length; i++) {
+    appendTraceEvent(events[i]);
+  }
+  state.renderedEventCount = events.length;
+
+  // The last `turn` event carries the running totals; surface them in the summary.
+  let lastTurn = null;
+  for (const ev of events) if (ev.type === "turn") lastTurn = ev;
+  if (lastTurn?.totals) {
+    els.traceTotals.textContent = formatTotalsLine(lastTurn.totals);
+  }
+}
+
+function appendTraceEvent(ev) {
+  if (ev.type === "turn") {
+    const wrap = document.createElement("div");
+    wrap.className = "turn";
+    const head = document.createElement("div");
+    head.className = "turn-head";
+    head.textContent = `Turn ${ev.turn + 1} · ${formatUsageLine(ev.usage)} · ${ev.durationMs}ms · stop=${ev.stopReason}`;
+    const body = document.createElement("div");
+    body.className = "turn-body";
+    wrap.appendChild(head);
+    wrap.appendChild(body);
+    els.traceList.appendChild(wrap);
+    state.turnEls.set(ev.turn, { container: wrap, body });
+    return;
+  }
+
+  const turnEl = state.turnEls.get(ev.turn);
+  if (!turnEl) return;
+  const body = turnEl.body;
+
+  if (ev.type === "thinking") {
+    const div = document.createElement("div");
+    div.className = "trace-thinking";
+    div.innerHTML = `<span class="trace-tag">thinking</span> <span class="trace-text"></span>`;
+    div.querySelector(".trace-text").textContent = ev.text;
+    body.appendChild(div);
+  } else if (ev.type === "text") {
+    const div = document.createElement("div");
+    div.className = "trace-text-block";
+    div.innerHTML = `<span class="trace-tag">say</span> <span class="trace-text"></span>`;
+    div.querySelector(".trace-text").textContent = ev.text;
+    body.appendChild(div);
+  } else if (ev.type === "tool_use") {
+    const div = document.createElement("div");
+    div.className = "trace-tool";
+    div.dataset.toolUseId = ev.id;
+    const args = formatToolArgs(ev.input);
+    div.innerHTML = `<div class="trace-tool-call"><span class="trace-tag">tool</span> <code class="tool-name"></code><code class="tool-args"></code></div><div class="trace-tool-result trace-pending">running…</div>`;
+    div.querySelector(".tool-name").textContent = ev.name;
+    div.querySelector(".tool-args").textContent = args;
+    body.appendChild(div);
+  } else if (ev.type === "tool_result") {
+    const target = body.querySelector(`.trace-tool[data-tool-use-id="${ev.toolUseId}"] .trace-tool-result`);
+    if (target) {
+      target.classList.remove("trace-pending");
+      target.classList.toggle("trace-error", Boolean(ev.isError));
+      target.textContent = `→ ${ev.summary}`;
+    }
+  }
+}
+
+function formatUsageLine(u) {
+  if (!u) return "";
+  const parts = [
+    `${formatNumber(u.input_tokens)} in`,
+    `${formatNumber(u.output_tokens)} out`,
+  ];
+  if (u.cache_creation_input_tokens) parts.push(`${formatNumber(u.cache_creation_input_tokens)} cache-w`);
+  if (u.cache_read_input_tokens) parts.push(`${formatNumber(u.cache_read_input_tokens)} cache-r`);
+  return parts.join(" · ");
+}
+
+function formatTotalsLine(t) {
+  const cost =
+    (t.input_tokens * PRICING.input +
+      t.output_tokens * PRICING.output +
+      t.cache_read_input_tokens * PRICING.cacheRead +
+      t.cache_creation_input_tokens * PRICING.cacheWrite5m) /
+    1e6;
+  return `${formatNumber(t.input_tokens)} in · ${formatNumber(t.output_tokens)} out · ${formatNumber(t.cache_creation_input_tokens)} cache-w · ${formatNumber(t.cache_read_input_tokens)} cache-r · ~$${cost.toFixed(4)}`;
+}
+
+function formatNumber(n) {
+  return (n || 0).toLocaleString();
+}
+
+function formatToolArgs(input) {
+  try {
+    const compact = JSON.stringify(input);
+    return compact.length > 140 ? compact.slice(0, 139) + "…" : compact;
+  } catch {
+    return "{}";
   }
 }
 

--- a/integrations/autonotes/public/app.js
+++ b/integrations/autonotes/public/app.js
@@ -42,6 +42,7 @@ const state = {
   pollHandle: null,
   renderedEventCount: 0, // index up to which the trace has been rendered
   turnEls: new Map(), // turn number -> { container, body }
+  isApplyingAll: false, // true while the apply-all loop is in flight
 };
 
 async function api(path, opts = {}) {
@@ -157,7 +158,10 @@ function populateNetworks(lastNetworkId, lastTarget, lastDepth) {
     netSel.value = String(lastNetworkId);
   }
   els.scanForm.depth.value = lastDepth || 200;
-  netSel.addEventListener("change", () => loadBuffers(null));
+  // Assign rather than addEventListener — populateNetworks() runs on every
+  // visit to the Scan view, and addEventListener would stack a new handler
+  // each time.
+  netSel.onchange = () => loadBuffers(null);
   loadBuffers(lastTarget || null);
 }
 
@@ -214,6 +218,7 @@ els.scanForm.addEventListener("submit", async (e) => {
 
 function enterReview(scanId) {
   showView("review");
+  stopPolling();
   state.cards.clear();
   state.renderedEventCount = 0;
   state.turnEls.clear();
@@ -519,7 +524,10 @@ function rejectCard(nick) {
 
 function updateApplyAll() {
   const remaining = [...state.cards.values()].filter((e) => e.status === "pending");
-  els.applyAll.disabled = remaining.length === 0;
+  // Stay disabled while an apply-all loop is running — each applyCard() call
+  // ends in updateApplyAll(), which would otherwise re-enable the button
+  // mid-loop and allow a second, overlapping run.
+  els.applyAll.disabled = remaining.length === 0 || state.isApplyingAll;
   els.applyAll.textContent =
     remaining.length === 0
       ? "Nothing left to apply"
@@ -528,11 +536,17 @@ function updateApplyAll() {
 
 els.applyAll.addEventListener("click", async () => {
   const remaining = [...state.cards.values()].filter((e) => e.status === "pending");
-  if (remaining.length === 0) return;
+  if (remaining.length === 0 || state.isApplyingAll) return;
+  state.isApplyingAll = true;
   els.applyAll.disabled = true;
-  for (const entry of remaining) {
-    // serial so the UI updates card-by-card and Lurker sees the writes in order
-    await applyCard(entry.proposal.nick, entry.card.textarea.value);
+  try {
+    for (const entry of remaining) {
+      // serial so the UI updates card-by-card and Lurker sees the writes in order
+      await applyCard(entry.proposal.nick, entry.card.textarea.value);
+    }
+  } finally {
+    state.isApplyingAll = false;
+    updateApplyAll();
   }
 });
 

--- a/integrations/autonotes/public/index.html
+++ b/integrations/autonotes/public/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lurker Auto-notes</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <h1>Lurker Auto-notes</h1>
+      <nav>
+        <a href="#config">Config</a>
+        <a href="#scan">Scan</a>
+      </nav>
+    </header>
+
+    <main>
+      <section id="view-config" class="view" hidden>
+        <h2>Connection</h2>
+        <p class="hint">
+          Point this app at your Lurker instance's MCP endpoint (the URL must
+          end in <code>/mcp</code>). Mint a read-write API token in Lurker →
+          Settings → API tokens; paste it here.
+        </p>
+        <form id="config-form">
+          <label>
+            Lurker MCP URL
+            <input
+              type="url"
+              name="lurkerUrl"
+              required
+              placeholder="https://lurker.example.com/mcp"
+            />
+          </label>
+          <label>
+            API token
+            <input
+              type="password"
+              name="lurkerToken"
+              required
+              autocomplete="off"
+            />
+          </label>
+          <button type="submit">Test &amp; save</button>
+        </form>
+        <div id="config-status" class="status"></div>
+        <p id="env-warning" class="warning" hidden>
+          ⚠ <code>ANTHROPIC_API_KEY</code> is not set in this integration's
+          environment. Scans will fail until you set it in <code>.env</code>
+          and restart the server.
+        </p>
+      </section>
+
+      <section id="view-scan" class="view" hidden>
+        <h2>Scan a channel</h2>
+        <form id="scan-form">
+          <label>
+            Network
+            <select name="networkId" required></select>
+          </label>
+          <label>
+            Buffer
+            <select name="target" required></select>
+          </label>
+          <label>
+            Backlog depth
+            <input
+              type="number"
+              name="depth"
+              min="10"
+              max="500"
+              value="200"
+              required
+            />
+          </label>
+          <button type="submit" id="scan-submit">Scan</button>
+        </form>
+        <div id="scan-status" class="status"></div>
+      </section>
+
+      <section id="view-review" class="view" hidden>
+        <h2>Proposed updates</h2>
+        <div id="review-summary" class="status"></div>
+        <div id="review-list"></div>
+        <div class="footer-actions" hidden id="review-actions">
+          <button id="apply-all">Apply all remaining</button>
+        </div>
+      </section>
+    </main>
+
+    <script src="/app.js" type="module"></script>
+  </body>
+</html>

--- a/integrations/autonotes/public/index.html
+++ b/integrations/autonotes/public/index.html
@@ -82,6 +82,13 @@
       <section id="view-review" class="view" hidden>
         <h2>Proposed updates</h2>
         <div id="review-summary" class="status"></div>
+        <details id="trace-panel" open hidden>
+          <summary>
+            <span class="summary-label">Trace</span>
+            <span id="trace-totals" class="trace-totals"></span>
+          </summary>
+          <div id="trace-list"></div>
+        </details>
         <div id="review-list"></div>
         <div class="footer-actions" hidden id="review-actions">
           <button id="apply-all">Apply all remaining</button>

--- a/integrations/autonotes/public/style.css
+++ b/integrations/autonotes/public/style.css
@@ -233,3 +233,111 @@ button.secondary {
   border-top: 1px solid var(--line);
   margin-top: 1rem;
 }
+
+/* Trace panel */
+#trace-panel {
+  margin: 0.75rem 0 1rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #fdfcf8;
+}
+
+#trace-panel summary {
+  padding: 0.55rem 0.85rem;
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  list-style: none;
+}
+
+#trace-panel summary::-webkit-details-marker { display: none; }
+
+#trace-panel summary::before {
+  content: "▸";
+  color: var(--muted);
+  width: 0.75rem;
+}
+
+#trace-panel[open] summary::before {
+  content: "▾";
+}
+
+.summary-label {
+  font-weight: 600;
+}
+
+.trace-totals {
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+  font-size: 0.92em;
+}
+
+#trace-list {
+  padding: 0 0.85rem 0.85rem;
+}
+
+.turn {
+  margin-top: 0.85rem;
+  border-top: 1px dashed var(--line);
+  padding-top: 0.6rem;
+}
+
+.turn:first-child {
+  margin-top: 0.25rem;
+  border-top: none;
+  padding-top: 0;
+}
+
+.turn-head {
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+  font-size: 0.9em;
+  margin-bottom: 0.35rem;
+}
+
+.turn-body > div {
+  margin: 0.3rem 0;
+  font-size: 0.93em;
+  line-height: 1.45;
+}
+
+.trace-tag {
+  display: inline-block;
+  min-width: 4.5em;
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.trace-thinking .trace-text {
+  color: #555;
+  font-style: italic;
+}
+
+.trace-tool-call code {
+  font-family: ui-monospace, monospace;
+}
+
+.trace-tool-call .tool-name {
+  font-weight: 600;
+  color: var(--accent);
+  margin-right: 0.25rem;
+}
+
+.trace-tool-call .tool-args {
+  color: var(--muted);
+  word-break: break-all;
+}
+
+.trace-tool-result {
+  margin-left: 4.7em;
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+  font-size: 0.92em;
+}
+
+.trace-tool-result.trace-pending { font-style: italic; }
+.trace-tool-result.trace-error { color: var(--err); }

--- a/integrations/autonotes/public/style.css
+++ b/integrations/autonotes/public/style.css
@@ -1,0 +1,235 @@
+:root {
+  --bg: #fafaf7;
+  --fg: #1c1c1c;
+  --muted: #666;
+  --accent: #b54a2e;
+  --ok: #2a7a3c;
+  --err: #a02c2c;
+  --line: #d8d4cc;
+  --card: #ffffff;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--fg);
+  background: var(--bg);
+  line-height: 1.45;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--line);
+  background: #fff;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.topbar nav a {
+  color: var(--muted);
+  text-decoration: none;
+  margin-left: 1.25rem;
+}
+
+.topbar nav a:hover { color: var(--accent); }
+
+main {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.view h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.hint {
+  color: var(--muted);
+  margin: 0 0 1rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  max-width: 28rem;
+}
+
+#scan-form { max-width: 36rem; }
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: var(--muted);
+}
+
+input, select, textarea, button {
+  font: inherit;
+  color: inherit;
+}
+
+input, select, textarea {
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: #fff;
+  padding: 0.45rem 0.55rem;
+}
+
+textarea { resize: vertical; min-height: 2.4rem; }
+
+button {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #fff;
+  padding: 0.45rem 0.9rem;
+  border-radius: 4px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+button:hover { filter: brightness(0.92); }
+button:disabled { opacity: 0.55; cursor: not-allowed; }
+
+button.secondary {
+  background: transparent;
+  color: var(--fg);
+  border-color: var(--line);
+}
+
+.status {
+  margin: 0.75rem 0;
+  color: var(--muted);
+}
+
+.status.ok { color: var(--ok); }
+.status.err { color: var(--err); }
+
+.warning {
+  margin-top: 1rem;
+  padding: 0.6rem 0.8rem;
+  background: #fff7e6;
+  border: 1px solid #e6c98e;
+  border-radius: 4px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 1rem 1.1rem;
+  margin: 0.85rem 0;
+}
+
+.card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.card-head .nick {
+  font-weight: 600;
+  font-family: ui-monospace, monospace;
+}
+
+.card-head .meta { color: var(--muted); }
+
+.field {
+  margin: 0.6rem 0;
+}
+
+.field-label {
+  color: var(--muted);
+  margin-bottom: 0.2rem;
+}
+
+.current-note {
+  font-family: ui-monospace, monospace;
+  color: var(--muted);
+  padding: 0.35rem 0.5rem;
+  background: #f3f1ec;
+  border-radius: 3px;
+  white-space: pre-wrap;
+}
+
+.current-note.empty { font-style: italic; }
+
+.proposed-textarea {
+  width: 100%;
+  font-family: ui-monospace, monospace;
+}
+
+.rationale {
+  color: var(--muted);
+  font-size: 0.95em;
+}
+
+.evidence-toggle {
+  background: none;
+  border: none;
+  color: var(--accent);
+  padding: 0;
+  cursor: pointer;
+  font-size: 0.95em;
+}
+
+.evidence {
+  margin-top: 0.4rem;
+  padding-left: 0.8rem;
+  border-left: 2px solid var(--line);
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+  font-size: 0.92em;
+}
+
+.evidence-line { padding: 0.15rem 0; }
+
+.evidence-line .ts { margin-right: 0.5em; }
+
+.card-actions {
+  margin-top: 0.85rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.card.applied {
+  background: #f0f5ee;
+  border-color: var(--ok);
+}
+
+.card.rejected {
+  opacity: 0.55;
+}
+
+.card.failed {
+  border-color: var(--err);
+}
+
+.card .result {
+  margin-top: 0.5rem;
+  font-size: 0.95em;
+}
+
+.card .result.ok { color: var(--ok); }
+.card .result.err { color: var(--err); }
+
+.footer-actions {
+  position: sticky;
+  bottom: 0;
+  background: var(--bg);
+  padding: 0.8rem 0;
+  border-top: 1px solid var(--line);
+  margin-top: 1rem;
+}

--- a/integrations/autonotes/server.js
+++ b/integrations/autonotes/server.js
@@ -98,8 +98,10 @@ app.get("/api/buffers", async (req, res, next) => {
 
 app.post("/api/scan", async (req, res, next) => {
   try {
-    const { networkId, target, depth } = req.body ?? {};
-    if (typeof networkId !== "number" || !target) {
+    const { networkId, depth } = req.body ?? {};
+    // Number.isFinite rather than typeof — NaN/Infinity are both "number".
+    const target = typeof req.body?.target === "string" ? req.body.target.trim() : "";
+    if (!Number.isFinite(networkId) || !target) {
       return res.status(400).json({ error: "networkId (number) and target (string) are required" });
     }
     const cleanDepth = Math.max(1, Math.min(500, Number(depth) || 200));
@@ -188,6 +190,11 @@ app.use((err, _req, res, _next) => {
   res.status(status).json({ error: err.message ?? "internal error" });
 });
 
-app.listen(PORT, () => {
-  console.log(`autonotes listening on http://localhost:${PORT}`);
+// Bind localhost by default — this app has no auth and holds the operator's
+// Lurker + Anthropic credentials, so it must not be reachable from the LAN
+// unless the operator explicitly opts in via HOST.
+const HOST = process.env.HOST || "127.0.0.1";
+
+app.listen(PORT, HOST, () => {
+  console.log(`autonotes listening on http://${HOST}:${PORT}`);
 });

--- a/integrations/autonotes/server.js
+++ b/integrations/autonotes/server.js
@@ -6,7 +6,14 @@ import { dirname, resolve } from "node:path";
 import { loadConfig, saveConfig, maskToken } from "./lib/config.js";
 import { McpClient, McpError } from "./lib/mcpClient.js";
 import { runScan } from "./lib/agent.js";
-import { createScan, getScan, updateScan, finishScan, errorScan } from "./lib/scans.js";
+import {
+  createScan,
+  getScan,
+  updateScan,
+  finishScan,
+  errorScan,
+  appendEvent,
+} from "./lib/scans.js";
 
 const PORT = Number(process.env.PORT) || 5173;
 const here = dirname(fileURLToPath(import.meta.url));
@@ -106,6 +113,7 @@ app.post("/api/scan", async (req, res, next) => {
           scan,
           mcpClient: mcp,
           onProgress: (s) => updateScan(s.id, { toolCallCount: s.toolCallCount }),
+          onEvent: (ev) => appendEvent(scan.id, ev),
         });
         finishScan(scan.id, { proposals, messages });
       } catch (err) {
@@ -130,6 +138,7 @@ app.get("/api/scan/:id", (req, res) => {
     toolCallCount: scan.toolCallCount,
     proposals: scan.proposals,
     messages: scan.messages,
+    events: scan.events,
     error: scan.error,
     startedAt: scan.startedAt,
     finishedAt: scan.finishedAt,

--- a/integrations/autonotes/server.js
+++ b/integrations/autonotes/server.js
@@ -1,0 +1,180 @@
+import "dotenv/config";
+import express from "express";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+import { loadConfig, saveConfig, maskToken } from "./lib/config.js";
+import { McpClient, McpError } from "./lib/mcpClient.js";
+import { runScan } from "./lib/agent.js";
+import { createScan, getScan, updateScan, finishScan, errorScan } from "./lib/scans.js";
+
+const PORT = Number(process.env.PORT) || 5173;
+const here = dirname(fileURLToPath(import.meta.url));
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+app.use(express.static(resolve(here, "public")));
+
+async function buildMcpClient() {
+  const cfg = await loadConfig();
+  if (!cfg.lurkerUrl || !cfg.lurkerToken) {
+    const err = new Error("Lurker URL and token are not configured");
+    err.statusCode = 400;
+    throw err;
+  }
+  return new McpClient({ url: cfg.lurkerUrl, token: cfg.lurkerToken });
+}
+
+app.get("/api/config", async (_req, res, next) => {
+  try {
+    const cfg = await loadConfig();
+    res.json({
+      lurkerUrl: cfg.lurkerUrl,
+      lurkerToken: cfg.lurkerToken ? maskToken(cfg.lurkerToken) : "",
+      hasToken: Boolean(cfg.lurkerToken),
+      anthropicKeyPresent: Boolean(process.env.ANTHROPIC_API_KEY),
+      lastNetworkId: cfg.lastNetworkId,
+      lastTarget: cfg.lastTarget,
+      lastDepth: cfg.lastDepth,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post("/api/config", async (req, res, next) => {
+  try {
+    const { lurkerUrl, lurkerToken } = req.body ?? {};
+    if (!lurkerUrl || !lurkerToken) {
+      return res.status(400).json({ error: "lurkerUrl and lurkerToken are required" });
+    }
+    const probe = new McpClient({ url: lurkerUrl, token: lurkerToken });
+    const tools = await probe.toolsList();
+    const toolNames = (tools?.tools ?? []).map((t) => t.name);
+    const scope = toolNames.includes("set_nick_note") ? "read-write" : "read";
+
+    await saveConfig({ lurkerUrl, lurkerToken });
+    res.json({ ok: true, scope, toolNames });
+  } catch (err) {
+    if (err instanceof McpError) {
+      return res.status(400).json({ error: err.message });
+    }
+    next(err);
+  }
+});
+
+app.get("/api/networks", async (_req, res, next) => {
+  try {
+    const mcp = await buildMcpClient();
+    const result = await mcp.toolCall("list_networks", {});
+    res.json(Array.isArray(result) ? result : result?.networks ?? []);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get("/api/buffers", async (req, res, next) => {
+  try {
+    const mcp = await buildMcpClient();
+    const networkId = req.query.networkId ? Number(req.query.networkId) : undefined;
+    const args = networkId ? { networkId } : {};
+    const result = await mcp.toolCall("list_buffers", args);
+    res.json(Array.isArray(result) ? result : result?.buffers ?? []);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post("/api/scan", async (req, res, next) => {
+  try {
+    const { networkId, target, depth } = req.body ?? {};
+    if (typeof networkId !== "number" || !target) {
+      return res.status(400).json({ error: "networkId (number) and target (string) are required" });
+    }
+    const cleanDepth = Math.max(1, Math.min(500, Number(depth) || 200));
+
+    const scan = createScan({ networkId, target, depth: cleanDepth });
+    await saveConfig({ lastNetworkId: networkId, lastTarget: target, lastDepth: cleanDepth });
+    res.json({ scanId: scan.id });
+
+    // Fire-and-forget: agent runs while the HTTP response has already returned.
+    // The UI polls /api/scan/:id for progress.
+    (async () => {
+      try {
+        const mcp = await buildMcpClient();
+        const { proposals, messages } = await runScan({
+          scan,
+          mcpClient: mcp,
+          onProgress: (s) => updateScan(s.id, { toolCallCount: s.toolCallCount }),
+        });
+        finishScan(scan.id, { proposals, messages });
+      } catch (err) {
+        console.error(`[scan ${scan.id}] failed:`, err);
+        errorScan(scan.id, err);
+      }
+    })();
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get("/api/scan/:id", (req, res) => {
+  const scan = getScan(req.params.id);
+  if (!scan) return res.status(404).json({ error: "scan not found" });
+  res.json({
+    id: scan.id,
+    status: scan.status,
+    networkId: scan.networkId,
+    target: scan.target,
+    depth: scan.depth,
+    toolCallCount: scan.toolCallCount,
+    proposals: scan.proposals,
+    messages: scan.messages,
+    error: scan.error,
+    startedAt: scan.startedAt,
+    finishedAt: scan.finishedAt,
+  });
+});
+
+app.post("/api/apply", async (req, res, next) => {
+  try {
+    const { scanId, items } = req.body ?? {};
+    const scan = getScan(scanId);
+    if (!scan) return res.status(404).json({ error: "scan not found" });
+    if (!Array.isArray(items) || items.length === 0) {
+      return res.status(400).json({ error: "items must be a non-empty array" });
+    }
+
+    const mcp = await buildMcpClient();
+    const results = [];
+    for (const item of items) {
+      if (typeof item?.nick !== "string" || typeof item?.note !== "string") {
+        results.push({ nick: item?.nick, ok: false, error: "invalid item" });
+        continue;
+      }
+      try {
+        const written = await mcp.toolCall("set_nick_note", {
+          networkId: scan.networkId,
+          nick: item.nick,
+          note: item.note,
+        });
+        results.push({ nick: item.nick, ok: true, note: written?.note ?? item.note });
+      } catch (err) {
+        results.push({ nick: item.nick, ok: false, error: err.message });
+      }
+    }
+    res.json({ results });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.use((err, _req, res, _next) => {
+  console.error(err);
+  const status = err.statusCode ?? 500;
+  res.status(status).json({ error: err.message ?? "internal error" });
+});
+
+app.listen(PORT, () => {
+  console.log(`autonotes listening on http://localhost:${PORT}`);
+});

--- a/integrations/autonotes/server.js
+++ b/integrations/autonotes/server.js
@@ -51,7 +51,11 @@ app.get("/api/config", async (_req, res, next) => {
 
 app.post("/api/config", async (req, res, next) => {
   try {
-    const { lurkerUrl, lurkerToken } = req.body ?? {};
+    // Trim — pasted URLs and tokens routinely carry a trailing newline, which
+    // saves a "valid-looking" config that then fails auth later.
+    const lurkerUrl = typeof req.body?.lurkerUrl === "string" ? req.body.lurkerUrl.trim() : "";
+    const lurkerToken =
+      typeof req.body?.lurkerToken === "string" ? req.body.lurkerToken.trim() : "";
     if (!lurkerUrl || !lurkerToken) {
       return res.status(400).json({ error: "lurkerUrl and lurkerToken are required" });
     }


### PR DESCRIPTION
## Summary
- Adds a collapsible **trace panel** to the autonotes review screen showing every turn the model takes — thinking, tool calls with argument summaries, tool-result lines, plus running token totals and a cost estimate.
- Switches the agent model from Opus 4.7 to **Sonnet 4.6**. This workload is structured tool-use, not intelligence-bound, so the 3× cost difference wasn't buying anything. Comments in `lib/agent.js` and `public/app.js` flag both files together if the model is ever bumped again.
- Agent emits structured events (`turn`, `thinking`, `text`, `tool_use`, `tool_result`) into the scan; the UI appends incrementally on each poll so the DOM doesn't re-render.

## Test plan
- [ ] Run a scan against a real nick and confirm the trace panel populates turn-by-turn as polling proceeds.
- [ ] Confirm tool-call argument summary and `→ result` line render together, with errors styled in red.
- [ ] Confirm running totals + `~$x.xxxx` cost line update each turn and roughly match Anthropic's reported usage.
- [ ] Confirm proposals still render and Apply / Apply-all still work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)