### PR TITLE
fix: copy tsconfig.base.json into the Vue builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ COPY vue_client/ ./
 # so the shared/ tree has to land at /app/shared regardless of which stage
 # is doing the work.
 COPY shared/ /app/shared/
+# vue_client/tsconfig.json extends ../tsconfig.base.json; Vite reads the
+# resolved tsconfig during build, so the base file has to land at /app too.
+COPY tsconfig.base.json /app/tsconfig.base.json
 RUN npm run build
 
 # Stage 2: Install server dependencies


### PR DESCRIPTION
## Problem

The Docker build broke after the TypeScript migration:

```
[vite:build-html] failed to resolve "extends":"../tsconfig.base.json" in /app/vue_client/tsconfig.json
```

The migration added a root `tsconfig.base.json` and pointed `vue_client/tsconfig.json` at it via `"extends": "../tsconfig.base.json"`. Vite reads the resolved tsconfig during `vite build`, but the `vue-builder` Docker stage only copies `vue_client/` and `shared/` — never the base config — so the `extends` resolved to a nonexistent `/app/tsconfig.base.json` and `npm run build` exited 1.

## Fix

Copy `tsconfig.base.json` into `/app` in the `vue-builder` stage, alongside the existing `shared/` copy.

Stage 3 (runtime) was already unaffected — it does `COPY tsconfig*.json ./`, which globs in the base file for the `tsx`-run server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)