### PR TITLE
Post-TS-migration cleanup: store interface type-gaps + verb-file casts

### DIFF
--- a/server/services/verbs/listNetworks.ts
+++ b/server/services/verbs/listNetworks.ts
@@ -23,8 +23,7 @@ registerVerb({
   },
   handler(ctx: VerbContext, _input: Record<string, unknown>) {
     return listNetworksForUser(ctx.userId).map((net) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const conn = ircManager.getConnection(ctx.userId, net.id) as any;
+      const conn = ircManager.getConnection(ctx.userId, net.id);
       return {
         id: net.id,
         name: net.name,

--- a/server/services/verbs/sendAction.ts
+++ b/server/services/verbs/sendAction.ts
@@ -33,8 +33,7 @@ registerVerb({
     const target = typeof input.target === 'string' ? input.target : '';
     const text = typeof input.text === 'string' ? input.text : '';
     if (!target || !text) return { ok: false, error: 'empty-target-or-text' };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ok = (ircManager as any).action(ctx.userId, networkId, target, text) as boolean;
+    const ok = ircManager.action(ctx.userId, networkId, target, text);
     return ok ? { ok: true } : { ok: false, error: 'not-connected' };
   },
 });

--- a/server/services/verbs/sendMessage.ts
+++ b/server/services/verbs/sendMessage.ts
@@ -33,8 +33,7 @@ registerVerb({
     const target = typeof input.target === 'string' ? input.target : '';
     const text = typeof input.text === 'string' ? input.text : '';
     if (!target || !text) return { ok: false, error: 'empty-target-or-text' };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const ok = (ircManager as any).send(ctx.userId, networkId, target, text) as boolean;
+    const ok = ircManager.send(ctx.userId, networkId, target, text);
     return ok ? { ok: true } : { ok: false, error: 'not-connected' };
   },
 });

--- a/server/services/verbs/setNickNote.ts
+++ b/server/services/verbs/setNickNote.ts
@@ -38,11 +38,7 @@ registerVerb({
     }
     const raw = typeof input.note === 'string' ? input.note : '';
     const note = raw.length > 4096 ? raw.slice(0, 4096) : raw;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const saved = (ircManager as any).setNickNote(ctx.userId, networkId, nick, note) as {
-      note: string;
-      updatedAt: string;
-    } | null;
+    const saved = ircManager.setNickNote(ctx.userId, networkId, nick, note);
     const result = {
       networkId,
       nick,

--- a/vue_client/src/components/BookmarksModal.vue
+++ b/vue_client/src/components/BookmarksModal.vue
@@ -42,15 +42,8 @@ const emit = defineEmits<{
 const store = useBookmarksStore();
 const ignores = useIgnoresStore();
 
-// The API response includes `userhost` alongside the declared BookmarkMessage
-// fields. Cast the store items to HistoryMessage (which has an open index
-// signature) so they're compatible with HistoryMessageRow's :message prop.
-type BookmarkRow = HistoryMessage & { userhost?: string | null };
-
 const visibleItems = computed(() =>
-  (store.items as BookmarkRow[]).filter(
-    (m) => !ignores.isIgnored(m.networkId, m.nick, m.userhost ?? ''),
-  ),
+  store.items.filter((m) => !ignores.isIgnored(m.networkId, m.nick, m.userhost ?? '')),
 );
 
 onMounted(() => {

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -132,7 +132,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue';
 import draggable from 'vuedraggable';
-import { useNetworksStore } from '../stores/networks.js';
+import { useNetworksStore, type PeerPresenceEntry } from '../stores/networks.js';
 import { useBuffersStore, type Buffer } from '../stores/buffers.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { usePinsStore } from '../stores/pins.js';
@@ -322,10 +322,8 @@ function isUnjoined(buf: Buffer, networkId: number): boolean {
   return networks.states[networkId]?.state !== 'connected';
 }
 
-function peerOf(buf: Buffer): { state?: string; stateAt?: string } | null {
-  const entry = networks.states[buf.networkId]?.peerPresence?.[buf.target.toLowerCase()];
-  if (!entry) return null;
-  return { state: entry.state ?? undefined, stateAt: entry.stateAt ?? undefined };
+function peerOf(buf: Buffer): PeerPresenceEntry | null {
+  return networks.states[buf.networkId]?.peerPresence?.[buf.target.toLowerCase()] ?? null;
 }
 function isPeerOffline(buf: Buffer): boolean {
   return isDmBuffer(buf) && derivePeerOffline(peerOf(buf));

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -52,15 +52,8 @@ const settings = useSettingsStore();
 const store = useHighlightsStore();
 const ignores = useIgnoresStore();
 
-// The API response includes `userhost` alongside the declared HighlightItem
-// fields. Cast the store items to HistoryMessage (open index signature) so
-// they're compatible with HistoryMessageRow's :message prop.
-type HighlightRow = HistoryMessage & { userhost?: string | null };
-
 const visibleItems = computed(() =>
-  (store.items as HighlightRow[]).filter(
-    (m) => !ignores.isIgnored(m.networkId, m.nick, m.userhost ?? ''),
-  ),
+  store.items.filter((m) => !ignores.isIgnored(m.networkId, m.nick, m.userhost ?? '')),
 );
 
 const soundEnabled = computed(() => !!settings.effective('notifications.highlight.sound.enabled'));

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -48,30 +48,26 @@ import { useMemberActions } from '../composables/useMemberActions.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import IgnoreModal from './IgnoreModal.vue';
 
-// BufferMember in the store omits user/host fields that the server sends.
-// Extend locally to reflect the actual wire shape.
-type Member = BufferMember & { user?: string | null; host?: string | null };
-
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const nicks = useNickColors();
 const memberActions = useMemberActions();
 const ignores = useIgnoresStore();
-const modalMember = ref<Member | null>(null);
+const modalMember = ref<BufferMember | null>(null);
 
 const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
-const members = computed((): Member[] => (buffer.value?.members as Member[]) || []);
+const members = computed((): BufferMember[] => buffer.value?.members || []);
 const selfNick = computed(() => {
   const b = buffer.value;
   if (!b) return null;
   return networks.states[b.networkId]?.nick || null;
 });
 
-function isSelf(m: Member): boolean {
+function isSelf(m: BufferMember): boolean {
   const sn = selfNick.value;
   return !!sn && nickOf(m).toLowerCase() === sn.toLowerCase();
 }
-function nickStyle(m: Member): { color: string } | null {
+function nickStyle(m: BufferMember): { color: string } | null {
   // Away members render in a flat muted color — the .away CSS rule wins
   // regardless of inline style, but skipping the inline color keeps the DOM
   // honest.
@@ -83,16 +79,16 @@ function nickStyle(m: Member): { color: string } | null {
 
 const PREFIX_ORDER = ['~', '&', '@', '%', '+', ''];
 
-function nickOf(m: Member): string {
+function nickOf(m: BufferMember): string {
   return m.nick;
 }
-function userOf(m: Member): string | null {
+function userOf(m: BufferMember): string | null {
   return m.user ?? null;
 }
-function hostOf(m: Member): string | null {
+function hostOf(m: BufferMember): string | null {
   return m.host ?? null;
 }
-function modesOf(m: Member): string[] {
+function modesOf(m: BufferMember): string[] {
   return Array.isArray(m?.modes) ? m.modes : [];
 }
 
@@ -105,24 +101,24 @@ function menuContext() {
   return {
     networkId: buffer.value?.networkId ?? 0,
     isSelf,
-    onIgnore: (m: Member) => {
+    onIgnore: (m: BufferMember) => {
       modalMember.value = m;
     },
   };
 }
-function onRowClick(e: MouseEvent, m: Member): void {
+function onRowClick(e: MouseEvent, m: BufferMember): void {
   if (!buffer.value || isSelf(m)) return;
   memberActions.openMenuFor(m, menuContext(), e.clientX, e.clientY);
 }
-function onRowContextMenu(e: MouseEvent, m: Member): void {
+function onRowContextMenu(e: MouseEvent, m: BufferMember): void {
   if (!buffer.value || isSelf(m)) return;
   memberActions.openMenuFor(m, menuContext(), e.clientX, e.clientY);
 }
-function onActionsClick(e: MouseEvent, m: Member): void {
+function onActionsClick(e: MouseEvent, m: BufferMember): void {
   if (!buffer.value || isSelf(m)) return;
   memberActions.openMenuFromButton(m, menuContext(), e.currentTarget as Element);
 }
-function prefixOf(m: Member): string {
+function prefixOf(m: BufferMember): string {
   const modes = modesOf(m);
   if (modes.includes('q')) return '~';
   if (modes.includes('a')) return '&';
@@ -131,14 +127,14 @@ function prefixOf(m: Member): string {
   if (modes.includes('v')) return '+';
   return '';
 }
-function prefixClass(m: Member): string {
+function prefixClass(m: BufferMember): string {
   const p = prefixOf(m);
   return p ? `mode-${p}` : '';
 }
-function isAway(m: Member): boolean {
+function isAway(m: BufferMember): boolean {
   return !!m?.away;
 }
-function liClass(m: Member): string[] {
+function liClass(m: BufferMember): string[] {
   const classes: string[] = [];
   const p = prefixClass(m);
   if (p) classes.push(p);

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -180,7 +180,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
 import type { CSSProperties } from 'vue';
-import { useNetworksStore } from '../stores/networks.js';
+import { useNetworksStore, type AwayState } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useIgnoresStore } from '../stores/ignores.js';
@@ -454,21 +454,10 @@ const effectiveCollapseTimestamps = computed(() => collapseTimestampsEnabled.val
 // is equivalent to reading user state. The server pseudo-buffer doesn't get
 // presence markers — it's noise-only.
 
-// The `away` field in NetworkState is typed as `string | null` but the runtime
-// value is this richer object (applyAwayState sets it from ircManager's shape).
-interface AwayStateObject {
-  active: boolean;
-  message: string | null;
-  since: string | null;
-  autoSet: boolean;
-  backAt: string | null;
-}
-
-const awayState = computed((): AwayStateObject | null => {
+const awayState = computed((): AwayState | null => {
   const b = buffer.value;
   if (!b || b.target.startsWith(':server:')) return null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (networks.states[b.networkId]?.away as any) || null;
+  return networks.states[b.networkId]?.away || null;
 });
 
 // Away/back markers stop being useful once the user has been back a while —

--- a/vue_client/src/components/SearchModal.vue
+++ b/vue_client/src/components/SearchModal.vue
@@ -57,7 +57,7 @@ const ignores = useIgnoresStore();
 // filtered after results arrive so /unignore restores the rows without
 // re-issuing the query.
 const visibleResults = computed(() =>
-  store.results.filter((m) => !ignores.isIgnored(m.networkId, m.nick, (m as any).userhost ?? '')),
+  store.results.filter((m) => !ignores.isIgnored(m.networkId, m.nick, m.userhost ?? '')),
 );
 
 const inputEl = ref<HTMLInputElement | null>(null);

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -153,19 +153,16 @@ const peerStatusLabel = computed(() => {
   if (!peer) return '';
   const a = active.value;
   if (!a) return '';
-  // Cast through unknown to satisfy PeerPresenceRow's `state?: string` vs PeerPresenceEntry's `state: string | null`.
-  const p = peer as { state?: string; awayMessage?: string | null };
-  if (isPeerOffline(p)) return `${a.target} is offline`;
-  if (isPeerAway(p)) {
-    return p.awayMessage ? `${a.target} is away: ${p.awayMessage}` : `${a.target} is away`;
+  if (isPeerOffline(peer)) return `${a.target} is offline`;
+  if (isPeerAway(peer)) {
+    return peer.awayMessage ? `${a.target} is away: ${peer.awayMessage}` : `${a.target} is away`;
   }
   return '';
 });
 const peerStatusClass = computed(() => {
   const peer = peerForActive.value;
   if (!peer) return '';
-  const p = peer as { state?: string };
-  return isPeerOffline(p) ? 'offline' : 'away';
+  return isPeerOffline(peer) ? 'offline' : 'away';
 });
 
 const typingNicks = computed(() => {

--- a/vue_client/src/composables/useSelfLabel.ts
+++ b/vue_client/src/composables/useSelfLabel.ts
@@ -28,14 +28,13 @@ export function useSelfLabel(): SelfLabelState {
   const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
 
   const channelPrefix = computed(() => {
-    const buf = buffer.value as any;
-    if (!buf || !buf.target?.startsWith('#')) return '';
-    const state = (networks.states as any)[buf.networkId];
-    const nick = state?.nick;
+    const buf = buffer.value;
+    if (!buf || !buf.target.startsWith('#')) return '';
+    const nick = networks.states[buf.networkId]?.nick;
     if (!nick) return '';
     const lc = nick.toLowerCase();
-    const me = (buf.members || []).find((m: any) => (m.nick || m).toLowerCase() === lc);
-    const modes = me && typeof me === 'object' ? me.modes || [] : [];
+    const me = buf.members.find((m) => m.nick.toLowerCase() === lc);
+    const modes = me?.modes ?? [];
     for (const letter of PROMPT_PREFIX_RANK) {
       if (modes.includes(letter)) return PROMPT_PREFIX[letter];
     }
@@ -44,7 +43,7 @@ export function useSelfLabel(): SelfLabelState {
 
   const promptLabel = computed(() => {
     if (!active.value) return '—';
-    const state = (networks.states as any)[active.value.networkId];
+    const state = networks.states[active.value.networkId];
     const nick = state?.nick;
     if (!nick) return '—';
     const modes = state?.userModes || '';
@@ -57,7 +56,7 @@ export function useSelfLabel(): SelfLabelState {
     // The server keeps `message` populated after /back so the buffer dividers
     // can render the completed pair — gate on `active` so the label
     // disappears when the user is no longer away.
-    const away = (networks.states as any)[active.value.networkId]?.away;
+    const away = networks.states[active.value.networkId]?.away;
     return away?.active && away.message ? `(${away.message})` : '';
   });
 

--- a/vue_client/src/stores/bookmarks.ts
+++ b/vue_client/src/stores/bookmarks.ts
@@ -20,6 +20,8 @@ export interface BookmarkMessage {
   nick: string;
   body: string;
   createdAt: string;
+  // Sender hostmask, when known — drives client-side ignore filtering.
+  userhost?: string | null;
 }
 
 export const useBookmarksStore = defineStore('bookmarks', {

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -42,6 +42,10 @@ export interface BufferMember {
   nick: string;
   modes: string[];
   away: boolean;
+  // user/host are sent by the server alongside the nicklist; they're optional
+  // because pre-upgrade backlog and bare JOIN-derived members may lack them.
+  user?: string | null;
+  host?: string | null;
 }
 
 export interface TypingEntry {

--- a/vue_client/src/stores/highlights.ts
+++ b/vue_client/src/stores/highlights.ts
@@ -13,6 +13,8 @@ export interface HighlightItem {
   nick: string;
   body: string;
   createdAt: string;
+  // Sender hostmask, when known — drives client-side ignore filtering.
+  userhost?: string | null;
 }
 
 export const useHighlightsStore = defineStore('highlights', {

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -21,13 +21,25 @@ export interface PeerPresenceEntry {
   awayMessage: string | null;
 }
 
+// User-level self-presence, broadcast per network from the away-state stream.
+// Mirrors the in-memory shape ircManager/IrcConnection hold (`AwayState`
+// there); `message` and `since` stay populated after /back so the buffer
+// dividers can render the completed away→back pair.
+export interface AwayState {
+  active: boolean;
+  message: string | null;
+  since: string | null;
+  autoSet: boolean;
+  backAt: string | null;
+}
+
 export interface NetworkState {
   networkId: number;
   channels: string[];
   state?: string;
   nick?: string;
   userModes?: string;
-  away?: string | null;
+  away?: AwayState | null;
   peerPresence?: Record<string, PeerPresenceEntry>;
   lagMs?: number | null;
 }

--- a/vue_client/src/stores/search.ts
+++ b/vue_client/src/stores/search.ts
@@ -15,6 +15,8 @@ export interface SearchResult {
   nick: string;
   body: string;
   createdAt: string;
+  // Sender hostmask, when known — drives client-side ignore filtering.
+  userhost?: string | null;
 }
 
 // Full-text message search. WS-based (like chanlist) rather than REST — the

--- a/vue_client/src/utils/nickCompletion.ts
+++ b/vue_client/src/utils/nickCompletion.ts
@@ -24,8 +24,8 @@
 
 interface MemberObject {
   nick?: string;
-  user?: string;
-  host?: string;
+  user?: string | null;
+  host?: string | null;
 }
 
 type Member = string | MemberObject;

--- a/vue_client/src/utils/peerPresence.ts
+++ b/vue_client/src/utils/peerPresence.ts
@@ -1,14 +1,15 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// Derive UX state from a peer presence row. The row carries only the most
-// recent transition ({ state, stateAt }); these helpers translate that to
-// the boolean states BufferList / StatusBar care about.
+// Derive UX state from a peer presence entry. An entry records the most
+// recent transition; these helpers translate its `state` into the boolean
+// states BufferList / StatusBar care about.
 
-interface PeerPresenceRow {
-  state?: string;
-  stateAt?: string;
-}
+import type { PeerPresenceEntry } from '../stores/networks.js';
+
+// Only `state` is consulted here — narrow to it so callers can pass a full
+// PeerPresenceEntry without the two shapes drifting apart.
+type PeerPresenceRow = Pick<PeerPresenceEntry, 'state'>;
 
 export function isPeerOffline(peer: PeerPresenceRow | null | undefined): boolean {
   return peer?.state === 'offline';


### PR DESCRIPTION
Addresses sections 1 and 2 of #17 — the type-tightening half of the post-migration cleanup. No behavior change; all polish.

## Section 1 — store interface type-gaps

Fixing the interfaces at the store removes the downstream component casts:

- **`NetworkState.away`** was typed `string | null` but the runtime value is an object. Added an `AwayState` interface (mirroring the shape `ircManager`/`IrcConnection` already hold) and typed the field properly. `MessageList.vue` and `useSelfLabel.ts` drop their `as any` casts; `MessageList`'s duplicate local `AwayStateObject` interface is gone.
- **`PeerPresenceEntry`** (store) and **`PeerPresenceRow`** (`utils/peerPresence.ts`) are reconciled to one shape — `PeerPresenceRow` is now a `Pick<PeerPresenceEntry, 'state'>`, so the two definitionally agree. `BufferList.vue` and `StatusBar.vue` drop their presence casts.
- Added the fields the server actually sends: `user`/`host` on `BufferMember`; `userhost` on `BookmarkMessage` / `HighlightItem` / `SearchResult`. `MemberList.vue`, `SearchModal.vue`, `BookmarksModal.vue` and `HighlightsModal.vue` drop their local intersection-type bridges. `nickCompletion.ts`'s `MemberObject` widens `user`/`host` to `string | null` to agree with the wire shape.

## Section 2 — `as any` in the verb handlers

The `send` / `action` / `setNickNote` / `getConnection` verbs cast `ircManager` through `any` — a leftover from when `ircManager` was an untyped JS module. It's now a typed class with all of these on its public surface, so the casts (plus their result-shape re-casts and `eslint-disable` comments) were pure noise. Removed.

The remaining `as any` casts (raw WebSocket payloads, the `api()` HTTP helper, still-untyped modules like `webauthnCredentials`/`invites`) are left as-is — they're at genuinely-dynamic boundaries.

Section 3 (oxlint warnings) is intentionally left for a separate PR.

## Verification

- `tsc` (server) + `vue-tsc` (client) type-check clean
- `oxlint` clean (137 advisory warnings, unchanged — section 3)
- `oxfmt --check` clean
- Test suite: 535 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)