### PR TITLE
Post-TS-migration cleanup: clear all oxlint warnings

### DIFF
--- a/integrations/autonotes/lib/agent.ts
+++ b/integrations/autonotes/lib/agent.ts
@@ -396,7 +396,9 @@ function extractProposals(content: Anthropic.ContentBlock[]): Proposal[] {
   try {
     parsed = JSON.parse(jsonStr);
   } catch (err) {
-    throw new Error(`Agent did not return parseable JSON: ${(err as Error).message}`);
+    throw new Error(`Agent did not return parseable JSON: ${(err as Error).message}`, {
+      cause: err,
+    });
   }
   const p = parsed as { proposals?: unknown[] } | null;
   if (!p || !Array.isArray(p.proposals)) {

--- a/integrations/autonotes/public/app.js
+++ b/integrations/autonotes/public/app.js
@@ -70,11 +70,11 @@ function showView(name) {
 // ---------------- Router ----------------
 
 function route() {
-  const h = location.hash || '';
-  if (h.startsWith('#review/')) {
-    const id = h.slice('#review/'.length);
+  const hash = location.hash || '';
+  if (hash.startsWith('#review/')) {
+    const id = hash.slice('#review/'.length);
     enterReview(id);
-  } else if (h === '#scan') {
+  } else if (hash === '#scan') {
     enterScan();
   } else {
     enterConfig();
@@ -146,6 +146,12 @@ async function enterScan() {
   }
 }
 
+// Stable handler ref so populateNetworks can remove-then-add it idempotently
+// — the function runs on every visit to the Scan view.
+function onNetworkChange() {
+  loadBuffers(null);
+}
+
 function populateNetworks(lastNetworkId, lastTarget, lastDepth) {
   const netSel = els.scanForm.networkId;
   netSel.innerHTML = '';
@@ -159,10 +165,9 @@ function populateNetworks(lastNetworkId, lastTarget, lastDepth) {
     netSel.value = String(lastNetworkId);
   }
   els.scanForm.depth.value = lastDepth || 200;
-  // Assign rather than addEventListener — populateNetworks() runs on every
-  // visit to the Scan view, and addEventListener would stack a new handler
-  // each time.
-  netSel.onchange = () => loadBuffers(null);
+  // remove-then-add so repeated visits to the Scan view don't stack handlers.
+  netSel.removeEventListener('change', onNetworkChange);
+  netSel.addEventListener('change', onNetworkChange);
   loadBuffers(lastTarget || null);
 }
 

--- a/integrations/autonotes/server.ts
+++ b/integrations/autonotes/server.ts
@@ -32,53 +32,71 @@ async function buildMcpClient(): Promise<McpClient> {
   return new McpClient({ url: cfg.lurkerUrl, token: cfg.lurkerToken });
 }
 
-app.get('/api/config', async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
-  try {
-    const cfg = await loadConfig();
-    res.json({
-      lurkerUrl: cfg.lurkerUrl,
-      lurkerToken: cfg.lurkerToken ? maskToken(cfg.lurkerToken) : '',
-      hasToken: Boolean(cfg.lurkerToken),
-      anthropicKeyPresent: Boolean(process.env.ANTHROPIC_API_KEY),
-      lastNetworkId: cfg.lastNetworkId,
-      lastTarget: cfg.lastTarget,
-      lastDepth: cfg.lastDepth,
-    });
-  } catch (err) {
-    next(err);
-  }
-});
-
-app.post('/api/config', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  try {
-    // Trim — pasted URLs and tokens routinely carry a trailing newline, which
-    // saves a "valid-looking" config that then fails auth later.
-    const lurkerUrl = typeof req.body?.lurkerUrl === 'string' ? req.body.lurkerUrl.trim() : '';
-    const lurkerToken =
-      typeof req.body?.lurkerToken === 'string' ? req.body.lurkerToken.trim() : '';
-    if (!lurkerUrl || !lurkerToken) {
-      res.status(400).json({ error: 'lurkerUrl and lurkerToken are required' });
-      return;
+// Express 4 does not catch rejected promises from async handlers — wrap them
+// so a rejection is forwarded to the error middleware instead of crashing.
+const asyncHandler =
+  (fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>) =>
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      await fn(req, res, next);
+    } catch (err) {
+      next(err);
     }
-    const probe = new McpClient({ url: lurkerUrl, token: lurkerToken });
-    const tools = await probe.toolsList();
-    const toolNames = (tools?.tools ?? []).map((t) => t.name);
-    const scope = toolNames.includes('set_nick_note') ? 'read-write' : 'read';
+  };
 
-    await saveConfig({ lurkerUrl, lurkerToken });
-    res.json({ ok: true, scope, toolNames });
-  } catch (err) {
-    if (err instanceof McpError) {
-      res.status(400).json({ error: err.message });
-      return;
+app.get(
+  '/api/config',
+  asyncHandler(async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const cfg = await loadConfig();
+      res.json({
+        lurkerUrl: cfg.lurkerUrl,
+        lurkerToken: cfg.lurkerToken ? maskToken(cfg.lurkerToken) : '',
+        hasToken: Boolean(cfg.lurkerToken),
+        anthropicKeyPresent: Boolean(process.env.ANTHROPIC_API_KEY),
+        lastNetworkId: cfg.lastNetworkId,
+        lastTarget: cfg.lastTarget,
+        lastDepth: cfg.lastDepth,
+      });
+    } catch (err) {
+      next(err);
     }
-    next(err);
-  }
-});
+  }),
+);
+
+app.post(
+  '/api/config',
+  asyncHandler(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      // Trim — pasted URLs and tokens routinely carry a trailing newline, which
+      // saves a "valid-looking" config that then fails auth later.
+      const lurkerUrl = typeof req.body?.lurkerUrl === 'string' ? req.body.lurkerUrl.trim() : '';
+      const lurkerToken =
+        typeof req.body?.lurkerToken === 'string' ? req.body.lurkerToken.trim() : '';
+      if (!lurkerUrl || !lurkerToken) {
+        res.status(400).json({ error: 'lurkerUrl and lurkerToken are required' });
+        return;
+      }
+      const probe = new McpClient({ url: lurkerUrl, token: lurkerToken });
+      const tools = await probe.toolsList();
+      const toolNames = (tools?.tools ?? []).map((t) => t.name);
+      const scope = toolNames.includes('set_nick_note') ? 'read-write' : 'read';
+
+      await saveConfig({ lurkerUrl, lurkerToken });
+      res.json({ ok: true, scope, toolNames });
+    } catch (err) {
+      if (err instanceof McpError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      next(err);
+    }
+  }),
+);
 
 app.get(
   '/api/networks',
-  async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+  asyncHandler(async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       const mcp = await buildMcpClient();
       const result = await mcp.toolCall('list_networks', {});
@@ -87,66 +105,72 @@ app.get(
     } catch (err) {
       next(err);
     }
-  },
+  }),
 );
 
-app.get('/api/buffers', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  try {
-    const mcp = await buildMcpClient();
-    const networkId = req.query.networkId ? Number(req.query.networkId) : undefined;
-    const args: Record<string, unknown> = networkId ? { networkId } : {};
-    const result = await mcp.toolCall('list_buffers', args);
-    const r = result as { buffers?: unknown[] } | null;
-    res.json(Array.isArray(result) ? result : (r?.buffers ?? []));
-  } catch (err) {
-    next(err);
-  }
-});
-
-app.post('/api/scan', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  try {
-    const { networkId, depth } = (req.body ?? {}) as { networkId?: unknown; depth?: unknown };
-    // Number.isFinite rather than typeof — NaN/Infinity are both "number".
-    const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
-    if (!Number.isFinite(networkId) || !target) {
-      res.status(400).json({ error: 'networkId (number) and target (string) are required' });
-      return;
+app.get(
+  '/api/buffers',
+  asyncHandler(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const mcp = await buildMcpClient();
+      const networkId = req.query.networkId ? Number(req.query.networkId) : undefined;
+      const args: Record<string, unknown> = networkId ? { networkId } : {};
+      const result = await mcp.toolCall('list_buffers', args);
+      const r = result as { buffers?: unknown[] } | null;
+      res.json(Array.isArray(result) ? result : (r?.buffers ?? []));
+    } catch (err) {
+      next(err);
     }
-    const cleanDepth = Math.max(1, Math.min(500, Number(depth) || 200));
+  }),
+);
 
-    const scan = createScan({ networkId: networkId as number, target, depth: cleanDepth });
-    await saveConfig({
-      lastNetworkId: networkId as number,
-      lastTarget: target,
-      lastDepth: cleanDepth,
-    });
-    res.json({ scanId: scan.id });
-
-    // Fire-and-forget: agent runs while the HTTP response has already returned.
-    // The UI polls /api/scan/:id for progress.
-    void (async () => {
-      try {
-        const mcp = await buildMcpClient();
-        const { proposals, messages } = await runScan({
-          scan,
-          mcpClient: mcp,
-          onProgress: (s) => {
-            updateScan(s.id, { toolCallCount: s.toolCallCount });
-          },
-          onEvent: (ev) => {
-            appendEvent(scan.id, ev);
-          },
-        });
-        finishScan(scan.id, { proposals, messages });
-      } catch (err) {
-        console.error(`[scan ${scan.id}] failed:`, err);
-        errorScan(scan.id, err);
+app.post(
+  '/api/scan',
+  asyncHandler(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const { networkId, depth } = (req.body ?? {}) as { networkId?: unknown; depth?: unknown };
+      // Number.isFinite rather than typeof — NaN/Infinity are both "number".
+      const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+      if (!Number.isFinite(networkId) || !target) {
+        res.status(400).json({ error: 'networkId (number) and target (string) are required' });
+        return;
       }
-    })();
-  } catch (err) {
-    next(err);
-  }
-});
+      const cleanDepth = Math.max(1, Math.min(500, Number(depth) || 200));
+
+      const scan = createScan({ networkId: networkId as number, target, depth: cleanDepth });
+      await saveConfig({
+        lastNetworkId: networkId as number,
+        lastTarget: target,
+        lastDepth: cleanDepth,
+      });
+      res.json({ scanId: scan.id });
+
+      // Fire-and-forget: agent runs while the HTTP response has already returned.
+      // The UI polls /api/scan/:id for progress.
+      void (async () => {
+        try {
+          const mcp = await buildMcpClient();
+          const { proposals, messages } = await runScan({
+            scan,
+            mcpClient: mcp,
+            onProgress: (s) => {
+              updateScan(s.id, { toolCallCount: s.toolCallCount });
+            },
+            onEvent: (ev) => {
+              appendEvent(scan.id, ev);
+            },
+          });
+          finishScan(scan.id, { proposals, messages });
+        } catch (err) {
+          console.error(`[scan ${scan.id}] failed:`, err);
+          errorScan(scan.id, err);
+        }
+      })();
+    } catch (err) {
+      next(err);
+    }
+  }),
+);
 
 app.get('/api/scan/:id', (req: Request, res: Response): void => {
   const scan = getScan(req.params.id);
@@ -170,43 +194,46 @@ app.get('/api/scan/:id', (req: Request, res: Response): void => {
   });
 });
 
-app.post('/api/apply', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-  try {
-    const { scanId, items } = (req.body ?? {}) as { scanId?: unknown; items?: unknown };
-    const scan = getScan(scanId as string);
-    if (!scan) {
-      res.status(404).json({ error: 'scan not found' });
-      return;
-    }
-    if (!Array.isArray(items) || items.length === 0) {
-      res.status(400).json({ error: 'items must be a non-empty array' });
-      return;
-    }
+app.post(
+  '/api/apply',
+  asyncHandler(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const { scanId, items } = (req.body ?? {}) as { scanId?: unknown; items?: unknown };
+      const scan = getScan(scanId as string);
+      if (!scan) {
+        res.status(404).json({ error: 'scan not found' });
+        return;
+      }
+      if (!Array.isArray(items) || items.length === 0) {
+        res.status(400).json({ error: 'items must be a non-empty array' });
+        return;
+      }
 
-    const mcp = await buildMcpClient();
-    const results: Array<{ nick: unknown; ok: boolean; error?: string; note?: unknown }> = [];
-    for (const item of items as Array<Record<string, unknown>>) {
-      if (typeof item?.nick !== 'string' || typeof item?.note !== 'string') {
-        results.push({ nick: item?.nick, ok: false, error: 'invalid item' });
-        continue;
+      const mcp = await buildMcpClient();
+      const results: Array<{ nick: unknown; ok: boolean; error?: string; note?: unknown }> = [];
+      for (const item of items as Array<Record<string, unknown>>) {
+        if (typeof item?.nick !== 'string' || typeof item?.note !== 'string') {
+          results.push({ nick: item?.nick, ok: false, error: 'invalid item' });
+          continue;
+        }
+        try {
+          const written = await mcp.toolCall('set_nick_note', {
+            networkId: scan.networkId,
+            nick: item.nick,
+            note: item.note,
+          });
+          const w = written as { note?: unknown } | null;
+          results.push({ nick: item.nick, ok: true, note: w?.note ?? item.note });
+        } catch (err) {
+          results.push({ nick: item.nick, ok: false, error: (err as Error).message });
+        }
       }
-      try {
-        const written = await mcp.toolCall('set_nick_note', {
-          networkId: scan.networkId,
-          nick: item.nick,
-          note: item.note,
-        });
-        const w = written as { note?: unknown } | null;
-        results.push({ nick: item.nick, ok: true, note: w?.note ?? item.note });
-      } catch (err) {
-        results.push({ nick: item.nick, ok: false, error: (err as Error).message });
-      }
+      res.json({ results });
+    } catch (err) {
+      next(err);
     }
-    res.json({ results });
-  } catch (err) {
-    next(err);
-  }
-});
+  }),
+);
 
 const errorHandler: express.ErrorRequestHandler = (err: unknown, _req, res, _next) => {
   console.error(err);

--- a/server/db/highlightRules.test.ts
+++ b/server/db/highlightRules.test.ts
@@ -74,7 +74,7 @@ describe('upsertAutoNickRule', () => {
         `SELECT network_id FROM highlight_rule_networks WHERE rule_id = ? ORDER BY network_id`,
       )
       .all(rule!.id) as Array<{ network_id: number }>;
-    expect(links.map((l) => l.network_id).sort()).toEqual([net1!.id, net2!.id].sort());
+    expect(links.map((l) => l.network_id).toSorted()).toEqual([net1!.id, net2!.id].toSorted());
   });
 
   it("switching a network's nick detaches the old auto rule and sweeps it when orphaned", () => {

--- a/server/db/ignoredMasks.test.ts
+++ b/server/db/ignoredMasks.test.ts
@@ -51,6 +51,6 @@ describe('listAllForUser', () => {
     mod.addMask({ userId: user.id, networkId: net1!.id, mask: '*!*@spam.example' });
     mod.addMask({ userId: user.id, networkId: net2!.id, mask: 'trolla' });
     const all = mod.listAllForUser(user.id);
-    expect(all.map((r) => r.mask).sort()).toEqual(['*!*@spam.example', 'trolla']);
+    expect(all.map((r) => r.mask).toSorted()).toEqual(['*!*@spam.example', 'trolla']);
   });
 });

--- a/server/db/inputHistory.ts
+++ b/server/db/inputHistory.ts
@@ -30,5 +30,5 @@ export function listRecent(
 ): string[] {
   return (listRecentStmt.all(userId, networkId, target, limit) as Array<{ text: string }>)
     .map((row) => row.text)
-    .reverse();
+    .toReversed();
 }

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -150,7 +150,7 @@ describe('searchMessages', () => {
     chat(net!.id, '#a', 'carol', 'another deadline slipped');
 
     const hits = searchMessages(user.id, { query: 'deadline' });
-    expect(hits.map((m) => m.text).sort()).toEqual([
+    expect(hits.map((m) => m.text).toSorted()).toEqual([
       'another deadline slipped',
       'the release deadline is friday',
     ]);
@@ -241,7 +241,7 @@ describe('searchMessages', () => {
     chat(net!.id, '#a', 'bob', 'third');
 
     const hits = searchMessages(user.id, { nick: 'alice' });
-    expect(hits.map((m) => m.text).sort()).toEqual(['first', 'second']);
+    expect(hits.map((m) => m.text).toSorted()).toEqual(['first', 'second']);
   });
 
   it('returns nothing when there is no free text and no filter', () => {

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -167,7 +167,7 @@ export function listMessages(
     : `SELECT * FROM messages WHERE network_id = ? AND target = ? ORDER BY id DESC LIMIT ?`;
   const params = before ? [networkId, target, before, limit] : [networkId, target, limit];
   const rows = db.prepare(sql).all(...params) as MessageRow[];
-  return rows.map(rowToEvent).reverse();
+  return rows.map(rowToEvent).toReversed();
 }
 
 // Bounded context window around an arbitrary message id. Used by the

--- a/server/db/peerPresence.test.ts
+++ b/server/db/peerPresence.test.ts
@@ -50,7 +50,7 @@ describe('writePeerState / getPeerPresence', () => {
 describe('listPeerPresenceForNetwork', () => {
   it('returns every peer for the network', () => {
     const list = pp.listPeerPresenceForNetwork(net!.id);
-    const nicks = list.map((p) => p!.nick).sort();
+    const nicks = list.map((p) => p!.nick).toSorted();
     expect(nicks).toEqual(expect.arrayContaining(['Carol', 'bob']));
   });
 });

--- a/server/db/users.test.ts
+++ b/server/db/users.test.ts
@@ -64,7 +64,7 @@ describe('listUsers', () => {
   it('orders by id ascending', () => {
     const list = users.listUsers();
     const ids = list.map((u) => u.id);
-    const sorted = [...ids].sort((a, b) => a - b);
+    const sorted = ids.toSorted((a, b) => a - b);
     expect(ids).toEqual(sorted);
   });
 });

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -44,6 +44,7 @@ import {
   isValidPassword,
   passwordRequirementsMessage,
 } from '../services/password.js';
+import { asyncHandler } from '../utils/asyncHandler.js';
 
 const CHALLENGE_COOKIE = 'lurker_webauthn_challenge';
 
@@ -103,103 +104,109 @@ router.get('/setup-status', (_req: Request, res: Response) => {
 // Open registration only while there are zero users. The first account
 // created here is promoted to admin and gets exclusive control over invites
 // and user management.
-router.post('/setup/options', async (req: Request, res: Response) => {
-  if (countUsers() > 0) {
-    res.status(409).json({ error: 'setup already complete' });
-    return;
-  }
-  const requested = (req.body?.username || '').trim();
-  if (!isValidUsername(requested)) {
-    res.status(400).json({ error: 'invalid username' });
-    return;
-  }
-  if (findUserByUsername(requested)) {
-    res.status(409).json({ error: 'username already taken' });
-    return;
-  }
-  const user = createUser(requested, { role: 'admin' });
-  const { rpID, rpName } = rpConfig();
-  const options = await generateRegistrationOptions({
-    rpName,
-    rpID,
-    userName: user.username,
-    userID: new Uint8Array(userIdToHandle(user.id)),
-    userDisplayName: user.username,
-    attestationType: 'none',
-    authenticatorSelection: {
-      residentKey: 'required',
-      userVerification: 'preferred',
-    },
-    excludeCredentials: [],
-  });
-
-  const token = saveChallenge({
-    purpose: 'setup',
-    challenge: options.challenge,
-    userId: user.id,
-  });
-  setChallengeCookie(res, token);
-  res.json({ options, mode: 'create-user', username: user.username });
-});
-
-router.post('/setup/verify', async (req: Request, res: Response) => {
-  const token = req.signedCookies?.[CHALLENGE_COOKIE];
-  const entry = consumeChallenge(token);
-  clearChallengeCookie(res);
-  if (!entry || entry.purpose !== 'setup') {
-    res.status(400).json({ error: 'no pending setup' });
-    return;
-  }
-  // Race guard: if another tab finished setup between options and verify,
-  // back out. We can't safely create credentials against the now-existing
-  // admin from an anonymous request.
-  if (countAllCredentials() > 0) {
-    res.status(409).json({ error: 'setup already complete' });
-    return;
-  }
-  const { rpID, expectedOrigin } = rpConfig();
-  let verification: VerifiedRegistrationResponse;
-  try {
-    verification = await verifyRegistrationResponse({
-      response: req.body?.response,
-      expectedChallenge: entry.challenge as string,
-      expectedOrigin,
-      expectedRPID: rpID,
-      requireUserVerification: false,
+router.post(
+  '/setup/options',
+  asyncHandler(async (req: Request, res: Response) => {
+    if (countUsers() > 0) {
+      res.status(409).json({ error: 'setup already complete' });
+      return;
+    }
+    const requested = (req.body?.username || '').trim();
+    if (!isValidUsername(requested)) {
+      res.status(400).json({ error: 'invalid username' });
+      return;
+    }
+    if (findUserByUsername(requested)) {
+      res.status(409).json({ error: 'username already taken' });
+      return;
+    }
+    const user = createUser(requested, { role: 'admin' });
+    const { rpID, rpName } = rpConfig();
+    const options = await generateRegistrationOptions({
+      rpName,
+      rpID,
+      userName: user.username,
+      userID: new Uint8Array(userIdToHandle(user.id)),
+      userDisplayName: user.username,
+      attestationType: 'none',
+      authenticatorSelection: {
+        residentKey: 'required',
+        userVerification: 'preferred',
+      },
+      excludeCredentials: [],
     });
-  } catch (err) {
-    const e = err as { message?: string };
-    res.status(400).json({ error: e.message || 'verification failed' });
-    return;
-  }
-  if (!verification.verified || !verification.registrationInfo) {
-    res.status(400).json({ error: 'verification failed' });
-    return;
-  }
 
-  const user = findUserById(entry.userId as number);
-  if (!user) {
-    res.status(500).json({ error: 'user vanished mid-setup' });
-    return;
-  }
+    const token = saveChallenge({
+      purpose: 'setup',
+      challenge: options.challenge,
+      userId: user.id,
+    });
+    setChallengeCookie(res, token);
+    res.json({ options, mode: 'create-user', username: user.username });
+  }),
+);
 
-  const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
-  const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
-  insertCredential({
-    userId: user.id,
-    credentialId: credential.id,
-    publicKey: Buffer.from(credential.publicKey),
-    counter: credential.counter,
-    transports: credential.transports || [],
-    deviceType: credentialDeviceType,
-    backedUp: credentialBackedUp,
-    label,
-  });
+router.post(
+  '/setup/verify',
+  asyncHandler(async (req: Request, res: Response) => {
+    const token = req.signedCookies?.[CHALLENGE_COOKIE];
+    const entry = consumeChallenge(token);
+    clearChallengeCookie(res);
+    if (!entry || entry.purpose !== 'setup') {
+      res.status(400).json({ error: 'no pending setup' });
+      return;
+    }
+    // Race guard: if another tab finished setup between options and verify,
+    // back out. We can't safely create credentials against the now-existing
+    // admin from an anonymous request.
+    if (countAllCredentials() > 0) {
+      res.status(409).json({ error: 'setup already complete' });
+      return;
+    }
+    const { rpID, expectedOrigin } = rpConfig();
+    let verification: VerifiedRegistrationResponse;
+    try {
+      verification = await verifyRegistrationResponse({
+        response: req.body?.response,
+        expectedChallenge: entry.challenge as string,
+        expectedOrigin,
+        expectedRPID: rpID,
+        requireUserVerification: false,
+      });
+    } catch (err) {
+      const e = err as { message?: string };
+      res.status(400).json({ error: e.message || 'verification failed' });
+      return;
+    }
+    if (!verification.verified || !verification.registrationInfo) {
+      res.status(400).json({ error: 'verification failed' });
+      return;
+    }
 
-  const { token: sessionToken } = createSession(user.id);
-  res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
-  res.json({ user: { id: user.id, username: user.username, role: user.role } });
-});
+    const user = findUserById(entry.userId as number);
+    if (!user) {
+      res.status(500).json({ error: 'user vanished mid-setup' });
+      return;
+    }
+
+    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+    const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
+    insertCredential({
+      userId: user.id,
+      credentialId: credential.id,
+      publicKey: Buffer.from(credential.publicKey),
+      counter: credential.counter,
+      transports: credential.transports || [],
+      deviceType: credentialDeviceType,
+      backedUp: credentialBackedUp,
+      label,
+    });
+
+    const { token: sessionToken } = createSession(user.id);
+    res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
+    res.json({ user: { id: user.id, username: user.username, role: user.role } });
+  }),
+);
 
 // Password-only first-admin setup. Mirrors /setup/options + /setup/verify but
 // skips the WebAuthn dance — operator picks a username and password and is
@@ -247,119 +254,125 @@ router.get('/invite/:token', (req: Request, res: Response) => {
   res.json({ valid: false });
 });
 
-router.post('/invite/:token/options', async (req: Request, res: Response) => {
-  const result = inviteStatus(req.params.token);
-  if (result.status !== 'valid') {
-    res.status(404).json({ error: 'invalid or used invite' });
-    return;
-  }
-  const requested = (req.body?.username || '').trim();
-  if (!isValidUsername(requested)) {
-    res.status(400).json({ error: 'invalid username' });
-    return;
-  }
-  if (findUserByUsername(requested)) {
-    res.status(409).json({ error: 'username already taken' });
-    return;
-  }
-  // Create the user up-front so we have a stable webauthn user handle for the
-  // registration options. If the user abandons the flow we end up with a
-  // username-squatter the admin can remove, mirroring the existing setup
-  // flow's tradeoff.
-  const user = createUser(requested, { role: 'user' });
-  const { rpID, rpName } = rpConfig();
-  const options = await generateRegistrationOptions({
-    rpName,
-    rpID,
-    userName: user.username,
-    userID: new Uint8Array(userIdToHandle(user.id)),
-    userDisplayName: user.username,
-    attestationType: 'none',
-    authenticatorSelection: {
-      residentKey: 'required',
-      userVerification: 'preferred',
-    },
-    excludeCredentials: [],
-  });
-  const token = saveChallenge({
-    purpose: 'invite',
-    challenge: options.challenge,
-    userId: user.id,
-    inviteToken: req.params.token,
-  });
-  setChallengeCookie(res, token);
-  res.json({ options, username: user.username });
-});
-
-router.post('/invite/:token/verify', async (req: Request, res: Response) => {
-  const challengeToken = req.signedCookies?.[CHALLENGE_COOKIE];
-  const entry = consumeChallenge(challengeToken);
-  clearChallengeCookie(res);
-  if (!entry || entry.purpose !== 'invite' || entry.inviteToken !== req.params.token) {
-    res.status(400).json({ error: 'no pending invite' });
-    return;
-  }
-  const entryUserId = entry.userId as number;
-  // Re-check the invite right before committing. Status may have changed
-  // between options and verify (admin revoke, parallel redemption).
-  if (inviteStatus(req.params.token).status !== 'valid') {
-    deleteUser(entryUserId);
-    res.status(409).json({ error: 'invite is no longer valid' });
-    return;
-  }
-  const { rpID, expectedOrigin } = rpConfig();
-  let verification: VerifiedRegistrationResponse;
-  try {
-    verification = await verifyRegistrationResponse({
-      response: req.body?.response,
-      expectedChallenge: entry.challenge as string,
-      expectedOrigin,
-      expectedRPID: rpID,
-      requireUserVerification: false,
+router.post(
+  '/invite/:token/options',
+  asyncHandler(async (req: Request, res: Response) => {
+    const result = inviteStatus(req.params.token);
+    if (result.status !== 'valid') {
+      res.status(404).json({ error: 'invalid or used invite' });
+      return;
+    }
+    const requested = (req.body?.username || '').trim();
+    if (!isValidUsername(requested)) {
+      res.status(400).json({ error: 'invalid username' });
+      return;
+    }
+    if (findUserByUsername(requested)) {
+      res.status(409).json({ error: 'username already taken' });
+      return;
+    }
+    // Create the user up-front so we have a stable webauthn user handle for the
+    // registration options. If the user abandons the flow we end up with a
+    // username-squatter the admin can remove, mirroring the existing setup
+    // flow's tradeoff.
+    const user = createUser(requested, { role: 'user' });
+    const { rpID, rpName } = rpConfig();
+    const options = await generateRegistrationOptions({
+      rpName,
+      rpID,
+      userName: user.username,
+      userID: new Uint8Array(userIdToHandle(user.id)),
+      userDisplayName: user.username,
+      attestationType: 'none',
+      authenticatorSelection: {
+        residentKey: 'required',
+        userVerification: 'preferred',
+      },
+      excludeCredentials: [],
     });
-  } catch (err) {
-    deleteUser(entryUserId);
-    const e = err as { message?: string };
-    res.status(400).json({ error: e.message || 'verification failed' });
-    return;
-  }
-  if (!verification.verified || !verification.registrationInfo) {
-    deleteUser(entryUserId);
-    res.status(400).json({ error: 'verification failed' });
-    return;
-  }
+    const token = saveChallenge({
+      purpose: 'invite',
+      challenge: options.challenge,
+      userId: user.id,
+      inviteToken: req.params.token,
+    });
+    setChallengeCookie(res, token);
+    res.json({ options, username: user.username });
+  }),
+);
 
-  const user = findUserById(entryUserId);
-  if (!user) {
-    res.status(500).json({ error: 'user vanished mid-setup' });
-    return;
-  }
+router.post(
+  '/invite/:token/verify',
+  asyncHandler(async (req: Request, res: Response) => {
+    const challengeToken = req.signedCookies?.[CHALLENGE_COOKIE];
+    const entry = consumeChallenge(challengeToken);
+    clearChallengeCookie(res);
+    if (!entry || entry.purpose !== 'invite' || entry.inviteToken !== req.params.token) {
+      res.status(400).json({ error: 'no pending invite' });
+      return;
+    }
+    const entryUserId = entry.userId as number;
+    // Re-check the invite right before committing. Status may have changed
+    // between options and verify (admin revoke, parallel redemption).
+    if (inviteStatus(req.params.token).status !== 'valid') {
+      deleteUser(entryUserId);
+      res.status(409).json({ error: 'invite is no longer valid' });
+      return;
+    }
+    const { rpID, expectedOrigin } = rpConfig();
+    let verification: VerifiedRegistrationResponse;
+    try {
+      verification = await verifyRegistrationResponse({
+        response: req.body?.response,
+        expectedChallenge: entry.challenge as string,
+        expectedOrigin,
+        expectedRPID: rpID,
+        requireUserVerification: false,
+      });
+    } catch (err) {
+      deleteUser(entryUserId);
+      const e = err as { message?: string };
+      res.status(400).json({ error: e.message || 'verification failed' });
+      return;
+    }
+    if (!verification.verified || !verification.registrationInfo) {
+      deleteUser(entryUserId);
+      res.status(400).json({ error: 'verification failed' });
+      return;
+    }
 
-  // Atomic consume — only one parallel redemption can win. If we lose,
-  // tear down the user we created and surface the conflict.
-  if (!consumeInvite(req.params.token, user.id)) {
-    deleteUser(user.id);
-    res.status(409).json({ error: 'invite is no longer valid' });
-    return;
-  }
+    const user = findUserById(entryUserId);
+    if (!user) {
+      res.status(500).json({ error: 'user vanished mid-setup' });
+      return;
+    }
 
-  const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
-  const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
-  insertCredential({
-    userId: user.id,
-    credentialId: credential.id,
-    publicKey: Buffer.from(credential.publicKey),
-    counter: credential.counter,
-    transports: credential.transports || [],
-    deviceType: credentialDeviceType,
-    backedUp: credentialBackedUp,
-    label,
-  });
+    // Atomic consume — only one parallel redemption can win. If we lose,
+    // tear down the user we created and surface the conflict.
+    if (!consumeInvite(req.params.token, user.id)) {
+      deleteUser(user.id);
+      res.status(409).json({ error: 'invite is no longer valid' });
+      return;
+    }
 
-  const { token: sessionToken } = createSession(user.id);
-  res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
-  res.json({ user: { id: user.id, username: user.username, role: user.role } });
-});
+    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+    const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
+    insertCredential({
+      userId: user.id,
+      credentialId: credential.id,
+      publicKey: Buffer.from(credential.publicKey),
+      counter: credential.counter,
+      transports: credential.transports || [],
+      deviceType: credentialDeviceType,
+      backedUp: credentialBackedUp,
+      label,
+    });
+
+    const { token: sessionToken } = createSession(user.id);
+    res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
+    res.json({ user: { id: user.id, username: user.username, role: user.role } });
+  }),
+);
 
 // Password redemption of an invite. Mirrors /invite/:token/options +
 // /invite/:token/verify but with no WebAuthn dance.
@@ -399,91 +412,97 @@ router.post('/invite/:token/password', (req: Request, res: Response) => {
 
 // ---------- login ----------
 
-router.post('/login/options', async (_req: Request, res: Response) => {
-  // Returns options only when at least one passkey exists. The client also
-  // probes /auth-methods to know whether to even surface the passkey button,
-  // so this 409 mostly guards against stale clients calling out of order.
-  if (countAllCredentials() === 0) {
-    res.status(409).json({ error: 'no passkeys registered' });
-    return;
-  }
-  const { rpID } = rpConfig();
-  const options = await generateAuthenticationOptions({
-    rpID,
-    userVerification: 'preferred',
-    // Empty allowCredentials lets the browser surface any discoverable
-    // (resident-key) passkey for this RP — no username field needed.
-    allowCredentials: [],
-  });
-  const token = saveChallenge({
-    purpose: 'login',
-    challenge: options.challenge,
-  });
-  setChallengeCookie(res, token);
-  res.json({ options });
-});
-
-router.post('/login/verify', async (req: Request, res: Response) => {
-  const token = req.signedCookies?.[CHALLENGE_COOKIE];
-  const entry = consumeChallenge(token);
-  clearChallengeCookie(res);
-  if (!entry || entry.purpose !== 'login') {
-    res.status(400).json({ error: 'no pending login' });
-    return;
-  }
-  const response = req.body?.response;
-  const credentialId = response?.id;
-  if (!credentialId) {
-    res.status(400).json({ error: 'missing credential id' });
-    return;
-  }
-
-  // webauthnCredentials.ts is untyped — stored is any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const stored = findByCredentialId(credentialId) as any;
-  if (!stored) {
-    res.status(401).json({ error: 'unknown credential' });
-    return;
-  }
-
-  const { rpID, expectedOrigin } = rpConfig();
-  let verification: VerifiedAuthenticationResponse;
-  try {
-    verification = await verifyAuthenticationResponse({
-      response,
-      expectedChallenge: entry.challenge as string,
-      expectedOrigin,
-      expectedRPID: rpID,
-      credential: {
-        id: stored.credentialId,
-        publicKey: new Uint8Array(stored.publicKey),
-        counter: stored.counter,
-        transports: stored.transports,
-      },
-      requireUserVerification: false,
+router.post(
+  '/login/options',
+  asyncHandler(async (_req: Request, res: Response) => {
+    // Returns options only when at least one passkey exists. The client also
+    // probes /auth-methods to know whether to even surface the passkey button,
+    // so this 409 mostly guards against stale clients calling out of order.
+    if (countAllCredentials() === 0) {
+      res.status(409).json({ error: 'no passkeys registered' });
+      return;
+    }
+    const { rpID } = rpConfig();
+    const options = await generateAuthenticationOptions({
+      rpID,
+      userVerification: 'preferred',
+      // Empty allowCredentials lets the browser surface any discoverable
+      // (resident-key) passkey for this RP — no username field needed.
+      allowCredentials: [],
     });
-  } catch (err) {
-    const e = err as { message?: string };
-    res.status(400).json({ error: e.message || 'verification failed' });
-    return;
-  }
-  if (!verification.verified) {
-    res.status(401).json({ error: 'verification failed' });
-    return;
-  }
+    const token = saveChallenge({
+      purpose: 'login',
+      challenge: options.challenge,
+    });
+    setChallengeCookie(res, token);
+    res.json({ options });
+  }),
+);
 
-  updateCounter(stored.id, verification.authenticationInfo.newCounter);
+router.post(
+  '/login/verify',
+  asyncHandler(async (req: Request, res: Response) => {
+    const token = req.signedCookies?.[CHALLENGE_COOKIE];
+    const entry = consumeChallenge(token);
+    clearChallengeCookie(res);
+    if (!entry || entry.purpose !== 'login') {
+      res.status(400).json({ error: 'no pending login' });
+      return;
+    }
+    const response = req.body?.response;
+    const credentialId = response?.id;
+    if (!credentialId) {
+      res.status(400).json({ error: 'missing credential id' });
+      return;
+    }
 
-  const user = findUserById(stored.userId);
-  if (!user) {
-    res.status(500).json({ error: 'user no longer exists' });
-    return;
-  }
+    // webauthnCredentials.ts is untyped — stored is any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stored = findByCredentialId(credentialId) as any;
+    if (!stored) {
+      res.status(401).json({ error: 'unknown credential' });
+      return;
+    }
 
-  const { token: sessionToken } = createSession(user.id);
-  res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
-  res.json({ user: { id: user.id, username: user.username, role: user.role } });
-});
+    const { rpID, expectedOrigin } = rpConfig();
+    let verification: VerifiedAuthenticationResponse;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response,
+        expectedChallenge: entry.challenge as string,
+        expectedOrigin,
+        expectedRPID: rpID,
+        credential: {
+          id: stored.credentialId,
+          publicKey: new Uint8Array(stored.publicKey),
+          counter: stored.counter,
+          transports: stored.transports,
+        },
+        requireUserVerification: false,
+      });
+    } catch (err) {
+      const e = err as { message?: string };
+      res.status(400).json({ error: e.message || 'verification failed' });
+      return;
+    }
+    if (!verification.verified) {
+      res.status(401).json({ error: 'verification failed' });
+      return;
+    }
+
+    updateCounter(stored.id, verification.authenticationInfo.newCounter);
+
+    const user = findUserById(stored.userId);
+    if (!user) {
+      res.status(500).json({ error: 'user no longer exists' });
+      return;
+    }
+
+    const { token: sessionToken } = createSession(user.id);
+    res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
+    res.json({ user: { id: user.id, username: user.username, role: user.role } });
+  }),
+);
 
 // Dummy hash with valid format and the real algorithm parameters. Verifying
 // against it on a username-miss costs the same scrypt work as a real verify,
@@ -536,77 +555,85 @@ router.get('/passkeys', requireAuth, (req: Request, res: Response) => {
   res.json({ passkeys: listCredentialsForUser(req.user!.id).map(publicCredential) });
 });
 
-router.post('/passkeys/options', requireAuth, async (req: Request, res: Response) => {
-  const { rpID, rpName } = rpConfig();
-  // listCredentialsForUser is untyped — credentials are any[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const existing = listCredentialsForUser(req.user!.id) as any[];
-  const options = await generateRegistrationOptions({
-    rpName,
-    rpID,
-    userName: req.user!.username,
-    userID: new Uint8Array(userIdToHandle(req.user!.id)),
-    userDisplayName: req.user!.username,
-    attestationType: 'none',
-    authenticatorSelection: {
-      residentKey: 'required',
-      userVerification: 'preferred',
-    },
-    excludeCredentials: existing.map((c) => ({
-      id: c.credentialId,
-      transports: c.transports,
-    })),
-  });
-  const token = saveChallenge({
-    purpose: 'add-passkey',
-    challenge: options.challenge,
-    userId: req.user!.id,
-  });
-  setChallengeCookie(res, token);
-  res.json({ options });
-});
-
-router.post('/passkeys/verify', requireAuth, async (req: Request, res: Response) => {
-  const token = req.signedCookies?.[CHALLENGE_COOKIE];
-  const entry = consumeChallenge(token);
-  clearChallengeCookie(res);
-  if (!entry || entry.purpose !== 'add-passkey' || (entry.userId as number) !== req.user!.id) {
-    res.status(400).json({ error: 'no pending registration' });
-    return;
-  }
-  const { rpID, expectedOrigin } = rpConfig();
-  let verification: VerifiedRegistrationResponse;
-  try {
-    verification = await verifyRegistrationResponse({
-      response: req.body?.response,
-      expectedChallenge: entry.challenge as string,
-      expectedOrigin,
-      expectedRPID: rpID,
-      requireUserVerification: false,
+router.post(
+  '/passkeys/options',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const { rpID, rpName } = rpConfig();
+    // listCredentialsForUser is untyped — credentials are any[]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const existing = listCredentialsForUser(req.user!.id) as any[];
+    const options = await generateRegistrationOptions({
+      rpName,
+      rpID,
+      userName: req.user!.username,
+      userID: new Uint8Array(userIdToHandle(req.user!.id)),
+      userDisplayName: req.user!.username,
+      attestationType: 'none',
+      authenticatorSelection: {
+        residentKey: 'required',
+        userVerification: 'preferred',
+      },
+      excludeCredentials: existing.map((c) => ({
+        id: c.credentialId,
+        transports: c.transports,
+      })),
     });
-  } catch (err) {
-    const e = err as { message?: string };
-    res.status(400).json({ error: e.message || 'verification failed' });
-    return;
-  }
-  if (!verification.verified || !verification.registrationInfo) {
-    res.status(400).json({ error: 'verification failed' });
-    return;
-  }
-  const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
-  const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
-  const stored = insertCredential({
-    userId: req.user!.id,
-    credentialId: credential.id,
-    publicKey: Buffer.from(credential.publicKey),
-    counter: credential.counter,
-    transports: credential.transports || [],
-    deviceType: credentialDeviceType,
-    backedUp: credentialBackedUp,
-    label,
-  });
-  res.json({ passkey: publicCredential(stored) });
-});
+    const token = saveChallenge({
+      purpose: 'add-passkey',
+      challenge: options.challenge,
+      userId: req.user!.id,
+    });
+    setChallengeCookie(res, token);
+    res.json({ options });
+  }),
+);
+
+router.post(
+  '/passkeys/verify',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const token = req.signedCookies?.[CHALLENGE_COOKIE];
+    const entry = consumeChallenge(token);
+    clearChallengeCookie(res);
+    if (!entry || entry.purpose !== 'add-passkey' || (entry.userId as number) !== req.user!.id) {
+      res.status(400).json({ error: 'no pending registration' });
+      return;
+    }
+    const { rpID, expectedOrigin } = rpConfig();
+    let verification: VerifiedRegistrationResponse;
+    try {
+      verification = await verifyRegistrationResponse({
+        response: req.body?.response,
+        expectedChallenge: entry.challenge as string,
+        expectedOrigin,
+        expectedRPID: rpID,
+        requireUserVerification: false,
+      });
+    } catch (err) {
+      const e = err as { message?: string };
+      res.status(400).json({ error: e.message || 'verification failed' });
+      return;
+    }
+    if (!verification.verified || !verification.registrationInfo) {
+      res.status(400).json({ error: 'verification failed' });
+      return;
+    }
+    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+    const label = (req.body?.label || '').toString().trim().slice(0, 64) || null;
+    const stored = insertCredential({
+      userId: req.user!.id,
+      credentialId: credential.id,
+      publicKey: Buffer.from(credential.publicKey),
+      counter: credential.counter,
+      transports: credential.transports || [],
+      deviceType: credentialDeviceType,
+      backedUp: credentialBackedUp,
+      label,
+    });
+    res.json({ passkey: publicCredential(stored) });
+  }),
+);
 
 router.patch('/passkeys/:id', requireAuth, (req: Request, res: Response) => {
   const id = Number(req.params.id);

--- a/server/routes/exports.ts
+++ b/server/routes/exports.ts
@@ -16,6 +16,7 @@ import {
   computeExportPreview,
 } from '../services/exportService.js';
 import { importFromZipBuffer, ImportError } from '../services/importService.js';
+import { asyncHandler } from '../utils/asyncHandler.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -47,29 +48,32 @@ router.get('/preview', (req: Request, res: Response, next: NextFunction) => {
 });
 
 // GET /api/exports?include_messages=1 — stream the zip to the response.
-router.get('/', async (req: Request, res: Response, next: NextFunction) => {
-  const includeMessages =
-    String(req.query.include_messages || '').toLowerCase() === '1' ||
-    String(req.query.include_messages || '').toLowerCase() === 'true';
-  const filename = buildExportFilename(req.user!.username, { includeMessages });
-  // octet-stream (not application/zip) so Safari's "open safe files after
-  // downloading" preference doesn't auto-unarchive the .lurk file.
-  res.setHeader('Content-Type', 'application/octet-stream');
-  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-  try {
-    await buildExportZip(req.user!.id, { includeMessages }, res);
-  } catch (err) {
-    // Headers are already out — best we can do is close the connection.
-    // The downstream will see a truncated zip and surface it as a corrupt
-    // download. Logging makes it diagnosable server-side.
-    console.error('[lurker] export failed:', err);
-    if (!res.headersSent) {
-      next(err);
-      return;
+router.get(
+  '/',
+  asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
+    const includeMessages =
+      String(req.query.include_messages || '').toLowerCase() === '1' ||
+      String(req.query.include_messages || '').toLowerCase() === 'true';
+    const filename = buildExportFilename(req.user!.username, { includeMessages });
+    // octet-stream (not application/zip) so Safari's "open safe files after
+    // downloading" preference doesn't auto-unarchive the .lurk file.
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    try {
+      await buildExportZip(req.user!.id, { includeMessages }, res);
+    } catch (err) {
+      // Headers are already out — best we can do is close the connection.
+      // The downstream will see a truncated zip and surface it as a corrupt
+      // download. Logging makes it diagnosable server-side.
+      console.error('[lurker] export failed:', err);
+      if (!res.headersSent) {
+        next(err);
+        return;
+      }
+      res.destroy();
     }
-    res.destroy();
-  }
-});
+  }),
+);
 
 const importRouter = Router();
 importRouter.use(requireAuth);
@@ -79,7 +83,7 @@ importRouter.use(requireAuth);
 importRouter.post(
   '/',
   upload.single('archive'),
-  async (req: Request, res: Response, next: NextFunction) => {
+  asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.file) {
         res.status(400).json({ error: 'no archive uploaded' });
@@ -116,7 +120,7 @@ importRouter.post(
       }
       next(err);
     }
-  },
+  }),
 );
 
 export { router as exportsRouter, importRouter };

--- a/server/routes/push.test.ts
+++ b/server/routes/push.test.ts
@@ -47,13 +47,13 @@ describe('GET /api/push/config', () => {
   });
 });
 
-describe('POST /api/push/subscriptions', () => {
-  const validBody = (suffix = 'a') => ({
-    endpoint: `https://example.test/${suffix}`,
-    keys: { p256dh: 'p256-key', auth: 'auth-key' },
-    userAgent: 'TestAgent/1.0',
-  });
+const validBody = (suffix = 'a') => ({
+  endpoint: `https://example.test/${suffix}`,
+  keys: { p256dh: 'p256-key', auth: 'auth-key' },
+  userAgent: 'TestAgent/1.0',
+});
 
+describe('POST /api/push/subscriptions', () => {
   it('rejects missing endpoint/keys', async () => {
     const res = await aliceAgent.post('/api/push/subscriptions').send({});
     expect(res.status).toBe(400);

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -11,6 +11,7 @@ import * as imagePipeline from '../services/imagePipeline.js';
 import { getProvider, providerIds, secretsForProvider } from '../services/uploadProviders/index.js';
 import type { UploadListRow } from '../db/uploadHistory.js';
 import { insertUpload, listUploads, getThumbnail, deleteUpload } from '../db/uploadHistory.js';
+import { asyncHandler } from '../utils/asyncHandler.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -35,7 +36,7 @@ const upload = multer({
 router.post(
   '/',
   upload.single('image'),
-  async (req: Request, res: Response, next: NextFunction) => {
+  asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.file) {
         res.status(400).json({ error: 'no file uploaded' });
@@ -139,7 +140,7 @@ router.post(
     } catch (err) {
       next(err);
     }
-  },
+  }),
 );
 
 router.get('/', (req: Request, res: Response) => {

--- a/server/server.ts
+++ b/server/server.ts
@@ -26,7 +26,7 @@ import { attachWsHub } from './services/wsHub.js';
 import './services/verbs/index.js';
 import mcpRouter from './services/mcpServer.js';
 import { requireApiAuth } from './middleware/apiAuth.js';
-import systemLog from './services/systemLog.js';
+import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 

--- a/server/services/highlightRulesService.ts
+++ b/server/services/highlightRulesService.ts
@@ -78,7 +78,7 @@ class HighlightRulesService extends EventEmitter {
       case_sensitive: !!fields.case_sensitive,
       enabled: fields.enabled !== false,
     });
-    this._invalidate(userId);
+    this.invalidate(userId);
     return { ok: true, rule };
   }
 
@@ -120,7 +120,7 @@ class HighlightRulesService extends EventEmitter {
       if (regexErr) return { ok: false, error: regexErr };
     }
     const rule = updateRule(id, userId, update);
-    this._invalidate(userId);
+    this.invalidate(userId);
     return { ok: true, rule };
   }
 
@@ -131,7 +131,7 @@ class HighlightRulesService extends EventEmitter {
       return { ok: false, error: 'cannot delete auto-managed rule', status: 400 };
     }
     deleteRule(id, userId);
-    this._invalidate(userId);
+    this.invalidate(userId);
     return { ok: true };
   }
 
@@ -142,7 +142,7 @@ class HighlightRulesService extends EventEmitter {
   ): HighlightRule | null {
     if (!nick) return null;
     const rule = upsertAutoNickRule(userId, networkId, nick);
-    this._invalidate(userId);
+    this.invalidate(userId);
     return rule;
   }
 
@@ -155,7 +155,7 @@ class HighlightRulesService extends EventEmitter {
     return compiled;
   }
 
-  _invalidate(userId: number): void {
+  invalidate(userId: number): void {
     this.cache.delete(userId);
     this.emit('change', { userId });
   }

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -144,7 +144,7 @@ describe('importFromZipBuffer — roundtrip', () => {
     const bobChannels = db
       .prepare('SELECT * FROM channels WHERE network_id = ?')
       .all(bobNets[0].id) as Array<{ name: string }>;
-    expect(bobChannels.map((c) => c.name).sort()).toEqual(['#dev', '#general']);
+    expect(bobChannels.map((c) => c.name).toSorted()).toEqual(['#dev', '#general']);
 
     const bobMessages = db
       .prepare('SELECT * FROM messages WHERE network_id = ? ORDER BY id ASC')
@@ -347,11 +347,45 @@ describe('importFromZipBuffer — roundtrip', () => {
 // then compared row-for-row across the two accounts. Columns that are
 // expected to differ (rekeyed FKs, autoincrement PKs, last_seen_at on users)
 // are projected out so the comparison fails *only* if the payload diverged.
-describe('importFromZipBuffer — end-to-end equivalence', () => {
-  function uniqueUsername(prefix: string): string {
-    return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-  }
+function uniqueUsername(prefix: string): string {
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
 
+// Internal helper type to access common properties across all table defs.
+type AnyTableDef = {
+  mode: string;
+  scope: string;
+  columns: string[];
+  pk?: string;
+  fkRekey?: Record<string, string>;
+  blobColumns?: string[];
+};
+
+// Columns that legitimately differ between the source and target accounts.
+// Per-table FK-rekey columns are taken from the registry; PKs of
+// autoincrement tables also differ; matched_rule_id can legitimately turn
+// to NULL on import if its rule wasn't carried over (it shouldn't here).
+function projectionFor(_table: string, def: AnyTableDef): string[] {
+  const skip = new Set<string>();
+  if (def.pk) skip.add(def.pk);
+  if (def.fkRekey) for (const col of Object.keys(def.fkRekey)) skip.add(col);
+  const blobColumns = def.blobColumns ?? [];
+  return def.columns.filter((c) => !skip.has(c) && !blobColumns.includes(c));
+}
+
+// Sort rows deterministically using their stable (non-rekeyed) columns so
+// the comparison doesn't depend on insertion order or autoincrement ids.
+function sortKey(row: Record<string, unknown>, keys: string[]): string {
+  return keys
+    .map((k) => {
+      const v = row[k];
+      if (v instanceof Buffer) return v.toString('base64');
+      return JSON.stringify(v ?? null);
+    })
+    .join('|');
+}
+
+describe('importFromZipBuffer — end-to-end equivalence', () => {
   // Seeds every table declared as 'export' or 'partial' so the equivalence
   // test exercises the full registry, not a subset.
   function seedComplete(): User {
@@ -465,28 +499,6 @@ describe('importFromZipBuffer — end-to-end equivalence', () => {
     return user;
   }
 
-  // Internal helper type to access common properties across all table defs.
-  type AnyTableDef = {
-    mode: string;
-    scope: string;
-    columns: string[];
-    pk?: string;
-    fkRekey?: Record<string, string>;
-    blobColumns?: string[];
-  };
-
-  // Columns that legitimately differ between the source and target accounts.
-  // Per-table FK-rekey columns are taken from the registry; PKs of
-  // autoincrement tables also differ; matched_rule_id can legitimately turn
-  // to NULL on import if its rule wasn't carried over (it shouldn't here).
-  function projectionFor(_table: string, def: AnyTableDef): string[] {
-    const skip = new Set<string>();
-    if (def.pk) skip.add(def.pk);
-    if (def.fkRekey) for (const col of Object.keys(def.fkRekey)) skip.add(col);
-    const blobColumns = def.blobColumns ?? [];
-    return def.columns.filter((c) => !skip.has(c) && !blobColumns.includes(c));
-  }
-
   function rowsFor(userId: number, table: string, def: AnyTableDef): Record<string, unknown>[] {
     let sql: string;
     switch (def.scope) {
@@ -510,18 +522,6 @@ describe('importFromZipBuffer — end-to-end equivalence', () => {
     return db.prepare(sql).all(userId) as Record<string, unknown>[];
   }
 
-  // Sort rows deterministically using their stable (non-rekeyed) columns so
-  // the comparison doesn't depend on insertion order or autoincrement ids.
-  function sortKey(row: Record<string, unknown>, keys: string[]): string {
-    return keys
-      .map((k) => {
-        const v = row[k];
-        if (v instanceof Buffer) return v.toString('base64');
-        return JSON.stringify(v ?? null);
-      })
-      .join('|');
-  }
-
   function projectRows(
     rows: Record<string, unknown>[],
     projection: string[],
@@ -532,7 +532,7 @@ describe('importFromZipBuffer — end-to-end equivalence', () => {
         for (const c of projection) out[c] = row[c];
         return out;
       })
-      .sort((a, b) => sortKey(a, projection).localeCompare(sortKey(b, projection)));
+      .toSorted((a, b) => sortKey(a, projection).localeCompare(sortKey(b, projection)));
   }
 
   // upload_history thumbnails ship as separate zip entries, but on the
@@ -543,7 +543,7 @@ describe('importFromZipBuffer — end-to-end equivalence', () => {
       .all(userId) as Array<{ thumbnail: Buffer | null }>;
     return rows
       .map((r) => (r.thumbnail ? Buffer.from(r.thumbnail).toString('base64') : null))
-      .sort();
+      .toSorted();
   }
 
   it('round-trips every exported table with payload-identical content', async () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -33,9 +33,9 @@ describe('computeFallbackNick', () => {
   });
 });
 
-describe('formatServerNumeric', () => {
-  const fmt = (line: string) => formatServerNumeric(ircLineParser(line));
+const fmt = (line: string) => formatServerNumeric(ircLineParser(line));
 
+describe('formatServerNumeric', () => {
   it('renders RPL_WELCOME (001) trailing text', () => {
     expect(
       fmt(

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -17,7 +17,7 @@ import {
 } from '../db/peerPresence.js';
 import highlightRulesService from './highlightRulesService.js';
 import { matchEvent } from './highlightEngine.js';
-import systemLog from './systemLog.js';
+import * as systemLog from './systemLog.js';
 import { IRC_VERSION, APP_VERSION } from '../utils/userAgent.js';
 
 // Shown to peers as the QUIT reason on a clean disconnect. Most IRC clients
@@ -298,14 +298,14 @@ export class IrcConnection {
   setState(state: string, extra: Record<string, unknown> = {}): void {
     this.state = state;
     this.publish({ type: 'state', state, ...extra });
-    this._logState(state, extra);
+    this.logState(state, extra);
   }
 
-  _scope(): string {
+  logScope(): string {
     return `net:${this.network.name}`;
   }
 
-  _logState(state: string, extra: Record<string, unknown>): void {
+  logState(state: string, extra: Record<string, unknown>): void {
     let text;
     switch (state) {
       case 'connecting':
@@ -325,7 +325,7 @@ export class IrcConnection {
     }
     systemLog.log({
       userId: this.network.user_id,
-      scope: this._scope(),
+      scope: this.logScope(),
       level: state === 'disconnected' ? 'warn' : 'info',
       text,
     });
@@ -408,7 +408,7 @@ export class IrcConnection {
       // CAP LS/REQ/ACK wire lines individually, but by the time 'registered'
       // fires the negotiated set is final on network.cap.enabled.
       try {
-        const enabled = (c.network?.cap?.enabled || []).slice().sort();
+        const enabled = (c.network?.cap?.enabled || []).toSorted();
         if (enabled.length > 0) {
           this.publish({
             type: 'motd',
@@ -529,7 +529,7 @@ export class IrcConnection {
       console.log(`[presence:${this.network.id}] MONITOR detected (limit ${limit})`);
       systemLog.log({
         userId: this.network.user_id,
-        scope: this._scope(),
+        scope: this.logScope(),
         text: `MONITOR (IRCv3 presence) supported, watch limit ${limit}`,
       });
       if (this.pendingRegainSetup && this.regainNick) {
@@ -545,10 +545,10 @@ export class IrcConnection {
         if (this.trackedDmPeers.size > 0) {
           systemLog.log({
             userId: this.network.user_id,
-            scope: this._scope(),
+            scope: this.logScope(),
             text: `Seeding MONITOR with ${this.trackedDmPeers.size} DM peer${this.trackedDmPeers.size === 1 ? '' : 's'}`,
           });
-          this._seedMonitorWatch();
+          this.seedMonitorWatch();
         }
       }
     });
@@ -564,7 +564,7 @@ export class IrcConnection {
       if (nicks.length > 0) {
         systemLog.log({
           userId: this.network.user_id,
-          scope: this._scope(),
+          scope: this.logScope(),
           text: `Presence: ${nicks.join(', ')} online`,
         });
       }
@@ -587,7 +587,7 @@ export class IrcConnection {
       if (nicks.length > 0) {
         systemLog.log({
           userId: this.network.user_id,
-          scope: this._scope(),
+          scope: this.logScope(),
           text: `Presence: ${nicks.join(', ')} offline`,
         });
       }
@@ -633,7 +633,7 @@ export class IrcConnection {
         });
         systemLog.log({
           userId: this.network.user_id,
-          scope: this._scope(),
+          scope: this.logScope(),
           level: 'error',
           text,
         });
@@ -798,7 +798,7 @@ export class IrcConnection {
         this.publish({ type: 'channel-joined', target: eventChannel });
         systemLog.log({
           userId: this.network.user_id,
-          scope: this._scope(),
+          scope: this.logScope(),
           text: `Joined ${eventChannel}`,
         });
         // Most servers volunteer 324 on join, but a few don't. Request it so
@@ -828,7 +828,7 @@ export class IrcConnection {
         this.publish({ type: 'channel-parted', target: eventChannel });
         systemLog.log({
           userId: this.network.user_id,
-          scope: this._scope(),
+          scope: this.logScope(),
           text: event.message
             ? `Parted ${eventChannel}: ${event.message as string}`
             : `Parted ${eventChannel}`,
@@ -1086,8 +1086,8 @@ export class IrcConnection {
         if (!letter) continue;
         next.add(letter);
       }
-      const before = [...ch.modes].sort().join('');
-      const after = [...next].sort().join('');
+      const before = [...ch.modes].toSorted().join('');
+      const after = [...next].toSorted().join('');
       if (before !== after) {
         ch.modes = next;
         this.publishChannelModes(ch);
@@ -1310,7 +1310,7 @@ export class IrcConnection {
   // Bail-out for transition writes: gate by tracked-peer set and self-nick.
   // Returns the eligible canonical nick (preserving the case as sent),
   // or null when the caller should no-op.
-  _eligiblePeer(nick: string | undefined | null): string | null {
+  eligiblePeer(nick: string | undefined | null): string | null {
     if (!nick) return null;
     const me = this.client.user?.nick;
     if (me && nick.toLowerCase() === me.toLowerCase()) return null;
@@ -1324,7 +1324,7 @@ export class IrcConnection {
   // updates for DMs the user dismissed (state still flows to
   // networks.states[networkId].peerPresence). The `nick` field carries the
   // routing key the client uses for its peerPresence map.
-  _publishPeerPresence(nick: string, row: PeerPresence | null): void {
+  publishPeerPresence(nick: string, row: PeerPresence | null): void {
     this.publishEphemeral({
       type: 'peer-presence',
       target: this.serverTarget(),
@@ -1350,7 +1350,7 @@ export class IrcConnection {
   // reason text. For other states it's ignored, and the DB column is
   // cleared so a stale message from a previous cycle can't bleed through.
   markPeerEvent(nick: string, state: PeerState, awayMessage: string | null = null): void {
-    const canonical = this._eligiblePeer(nick);
+    const canonical = this.eligiblePeer(nick);
     if (!canonical) {
       console.log(
         `[presence:${this.network.id}] markPeerEvent ${nick} → ${state} SKIP (not tracked)`,
@@ -1376,7 +1376,7 @@ export class IrcConnection {
     console.log(
       `[presence:${this.network.id}] markPeerEvent ${canonical} ${prevState || 'null'} → ${state}${message ? ` (${message})` : ''}`,
     );
-    this._publishPeerPresence(canonical, next);
+    this.publishPeerPresence(canonical, next);
   }
 
   // Bulk-seed the MONITOR watch list from the tracked DM peers set. Called
@@ -1387,7 +1387,7 @@ export class IrcConnection {
   // batching in ircManager.startNetwork). Any nicks beyond monitorLimit
   // are kept in the in-memory set but skipped on the wire; we surface a
   // notice so the user knows live presence is degraded for the overflow.
-  _seedMonitorWatch(): void {
+  seedMonitorWatch(): void {
     const peers = Array.from(this.trackedDmPeers);
     if (peers.length === 0) return;
     const cap = this.monitorLimit > 0 ? this.monitorLimit : peers.length;

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -3,7 +3,7 @@
 
 import { EventEmitter } from 'events';
 import { IrcConnection } from './ircConnection.js';
-import systemLog from './systemLog.js';
+import * as systemLog from './systemLog.js';
 import {
   listNetworksForUser,
   getNetwork,
@@ -63,7 +63,7 @@ class IrcManager extends EventEmitter {
     this.byUser = new Map();
   }
 
-  _userMap(userId: number): Map<number, IrcConnection> {
+  connectionsForUser(userId: number): Map<number, IrcConnection> {
     let m = this.byUser.get(userId);
     if (!m) {
       m = new Map();
@@ -77,7 +77,7 @@ class IrcManager extends EventEmitter {
   }
 
   listConnections(userId: number): IrcConnection[] {
-    return Array.from(this._userMap(userId).values());
+    return Array.from(this.connectionsForUser(userId).values());
   }
 
   initForUser(userId: number): void {
@@ -104,7 +104,7 @@ class IrcManager extends EventEmitter {
       network,
       onEvent: (event) => this.emit('event', event),
     });
-    this._userMap(userId).set(networkId, conn);
+    this.connectionsForUser(userId).set(networkId, conn);
     systemLog.log({
       userId,
       scope: `net:${network.name}`,
@@ -160,7 +160,7 @@ class IrcManager extends EventEmitter {
       text: reason ? `Stopping: ${reason}` : 'Stopping',
     });
     conn.disconnect(reason);
-    this._userMap(userId).delete(networkId);
+    this.connectionsForUser(userId).delete(networkId);
   }
 
   disposeNetwork(userId: number, networkId: number, reason?: string): void {
@@ -172,7 +172,7 @@ class IrcManager extends EventEmitter {
       text: reason ? `Disposing: ${reason}` : 'Disposing',
     });
     conn.dispose(reason);
-    this._userMap(userId).delete(networkId);
+    this.connectionsForUser(userId).delete(networkId);
   }
 
   // Force a fresh connection: dispose the existing IrcConnection (if any) and

--- a/server/services/mcpServer.test.ts
+++ b/server/services/mcpServer.test.ts
@@ -111,7 +111,7 @@ describe('MCP server', () => {
     });
     const names = (res.body.result.tools as Array<{ name: string; inputSchema: { type: string } }>)
       .map((t) => t.name)
-      .sort();
+      .toSorted();
     expect(names).toEqual([
       'get_nick_note',
       'list_buffers',

--- a/server/services/verbRegistry.test.ts
+++ b/server/services/verbRegistry.test.ts
@@ -17,17 +17,17 @@ let registerVerb: typeof import('./verbRegistry.js').registerVerb;
 let callVerb: typeof import('./verbRegistry.js').callVerb;
 let listVerbs: typeof import('./verbRegistry.js').listVerbs;
 let getVerb: typeof import('./verbRegistry.js').getVerb;
-let __resetForTests: typeof import('./verbRegistry.js').__resetForTests;
+let resetForTests: typeof import('./verbRegistry.js').resetForTests;
 
 beforeAll(async () => {
   ({ createUser } = await import('../db/users.js'));
   ({ createNetwork } = await import('../db/networks.js'));
-  ({ registerVerb, callVerb, listVerbs, getVerb, __resetForTests } =
+  ({ registerVerb, callVerb, listVerbs, getVerb, resetForTests } =
     await import('./verbRegistry.js'));
 });
 
 beforeEach(() => {
-  __resetForTests();
+  resetForTests();
 });
 
 afterAll(() => {
@@ -126,7 +126,7 @@ describe('verbRegistry', () => {
     const readSet = listVerbs('read').map((v) => v.name);
     const rwSet = listVerbs('read-write').map((v) => v.name);
     expect(readSet).toEqual(['r']);
-    expect(rwSet.sort()).toEqual(['r', 'w']);
+    expect(rwSet.toSorted()).toEqual(['r', 'w']);
   });
 
   it('listVerbs entries carry the inputSchema declared at registration', () => {

--- a/server/services/verbRegistry.ts
+++ b/server/services/verbRegistry.ts
@@ -135,6 +135,6 @@ export function callVerb(
 
 // Test-only: wipe the registry between cases. Real code should never call
 // this; the registry is intended to be populated once at process start.
-export function __resetForTests(): void {
+export function resetForTests(): void {
   verbs.clear();
 }

--- a/server/services/verbs/verbs.test.ts
+++ b/server/services/verbs/verbs.test.ts
@@ -131,7 +131,7 @@ describe('list_buffers', () => {
       target: string;
       kind: string;
     }>;
-    const targets = result.map((b) => b.target).sort();
+    const targets = result.map((b) => b.target).toSorted();
     expect(targets).toEqual(['#chan', 'bob']);
     expect(result.find((b) => b.target === '#chan')!.kind).toBe('channel');
     expect(result.find((b) => b.target === 'bob')!.kind).toBe('dm');

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -14,7 +14,7 @@ import ircManager from './ircManager.js';
 import settingsService from './settingsService.js';
 import highlightRulesService from './highlightRulesService.js';
 import draftsService from './draftsService.js';
-import systemLog from './systemLog.js';
+import * as systemLog from './systemLog.js';
 import * as pushService from './pushService.js';
 import { matchesAny as matchesIgnoreMask } from './maskMatch.js';
 import { listMasks as listIgnoredMasks } from '../db/ignoredMasks.js';
@@ -87,7 +87,9 @@ function effectiveSetting(userId: number, key: string): unknown {
 function isValidTimeZone(tz: unknown): tz is string {
   if (!tz || typeof tz !== 'string') return false;
   try {
-    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    // Called without `new` purely for validation — it throws RangeError on an
+    // unknown time zone, which the catch below turns into a false return.
+    Intl.DateTimeFormat('en-US', { timeZone: tz });
     return true;
   } catch {
     return false;
@@ -122,13 +124,14 @@ function tzOffsetMinutes(date: Date, timeZone: string | null): number {
   return Math.round((asUTC - date.getTime()) / 60000);
 }
 
+const pad = (n: number) => String(n).padStart(2, '0');
+
 // "afk since 2026-05-09 15:30:00-0500" — mirrors screen_away.py's default
 // time_format. Renders in `timeZone` when provided, otherwise server local.
 function fmtAwayTimestamp(date: Date, timeZone: unknown): string {
   const tz = isValidTimeZone(timeZone) ? timeZone : null;
   const p = wallClockParts(date, tz);
   const off = tzOffsetMinutes(date, tz);
-  const pad = (n: number) => String(n).padStart(2, '0');
   const sign = off >= 0 ? '+' : '-';
   const aoff = Math.abs(off);
   return `${p.year}-${p.month}-${p.day} ${p.hour}:${p.minute}:${p.second}${sign}${pad(Math.floor(aoff / 60))}${pad(aoff % 60)}`;
@@ -257,6 +260,18 @@ function fanOut(userId: number, payload: WsPayload, opts: FanOutOpts = {}): void
 // the private fanOut; named to make the cross-module call site read clearly.
 export function fanOutToUser(userId: number, payload: WsPayload, opts: FanOutOpts = {}): void {
   fanOut(userId, payload, opts);
+}
+
+function parseSinceParam(rawUrl: string): number {
+  try {
+    const url = new URL(rawUrl, 'http://localhost');
+    const raw = url.searchParams.get('since');
+    if (!raw) return 0;
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  } catch (_) {
+    return 0;
+  }
 }
 
 export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
@@ -557,18 +572,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     clearAutoAwayTimer(userId);
     systemLog.dropUser(userId);
   });
-
-  function parseSinceParam(rawUrl: string): number {
-    try {
-      const url = new URL(rawUrl, 'http://localhost');
-      const raw = url.searchParams.get('since');
-      if (!raw) return 0;
-      const n = Number.parseInt(raw, 10);
-      return Number.isFinite(n) && n > 0 ? n : 0;
-    } catch (_) {
-      return 0;
-    }
-  }
 
   function authenticateRequest(req: IncomingMessage): User | null | undefined {
     const header = req.headers.cookie;

--- a/server/test-utils/testApp.ts
+++ b/server/test-utils/testApp.ts
@@ -54,6 +54,11 @@ export function setupTestDb(suffix = ''): TestDbContext {
   };
 }
 
+const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+  if (res.headersSent) return next(err);
+  res.status(500).json({ error: (err as Error).message || 'internal error' });
+};
+
 // Build a minimal Express app that mirrors how server.js wires up middleware:
 // JSON body parsing, cookie-parser keyed to the test session secret, and the
 // requested router(s) mounted at their paths. routerMounts is { '/path':
@@ -66,10 +71,6 @@ export function createTestApp(routerMounts: Record<string, Router>): Express {
   for (const [mount, router] of Object.entries(routerMounts)) {
     app.use(mount, router);
   }
-  const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
-    if (res.headersSent) return next(err);
-    res.status(500).json({ error: (err as Error).message || 'internal error' });
-  };
   app.use(errorHandler);
   return app;
 }

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -143,8 +143,8 @@ declare module 'irc-framework' {
 
   // Default export in the package is an object with a `Client` property.
   // ircConnection.ts imports it as: import IRC from 'irc-framework'
-  const _default: { Client: typeof Client; ircLineParser: typeof ircLineParser };
-  export default _default;
+  const defaultExport: { Client: typeof Client; ircLineParser: typeof ircLineParser };
+  export default defaultExport;
 }
 
 declare module 'irc-framework/src/linebreak.js' {

--- a/server/utils/asyncHandler.ts
+++ b/server/utils/asyncHandler.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type { NextFunction, Request, Response } from 'express';
+
+// Express 4 does not catch rejected promises returned from async route
+// handlers — an unhandled rejection there crashes the process. Wrap an async
+// handler with this so any rejection is forwarded to the error middleware via
+// next() instead.
+type AsyncRouteHandler = (req: Request, res: Response, next: NextFunction) => Promise<unknown>;
+
+export function asyncHandler(fn: AsyncRouteHandler) {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      await fn(req, res, next);
+    } catch (err) {
+      next(err);
+    }
+  };
+}

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1038,7 +1038,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'string',
     default: '07:00',
     description:
-      'End of the quiet-hours window in HH:MM (24h), interpreted in your ' + 'system.timezone.',
+      'End of the quiet-hours window in HH:MM (24h), interpreted in your system.timezone.',
   },
 
   // ─── Input bar (system text features) ─────────────────────────────────

--- a/vue_client/src/api.ts
+++ b/vue_client/src/api.ts
@@ -65,11 +65,11 @@ export function apiMultipart<T = any>(
     xhr.open('POST', url, true);
     xhr.withCredentials = true;
     xhr.responseType = 'text';
-    xhr.upload.onprogress = (e) => {
+    xhr.upload.addEventListener('progress', (e) => {
       if (!onProgress || !e.lengthComputable) return;
       onProgress(Math.min(100, Math.round((e.loaded / e.total) * 100)));
-    };
-    xhr.onload = () => {
+    });
+    xhr.addEventListener('load', () => {
       const text = xhr.responseText || '';
       let data: any = null;
       if (text) {
@@ -88,9 +88,9 @@ export function apiMultipart<T = any>(
         err.data = data;
         reject(err);
       }
-    };
-    xhr.onerror = () => reject(new Error('network error'));
-    xhr.onabort = () => reject(new Error('upload aborted'));
+    });
+    xhr.addEventListener('error', () => reject(new Error('network error')));
+    xhr.addEventListener('abort', () => reject(new Error('upload aborted')));
     xhr.send(formData);
   });
 }

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -226,7 +226,7 @@ function unpinnedBufs(networkId: number): Buffer[] {
   return buffers
     .forNetwork(networkId)
     .filter((b) => !isServerBuffer(b) && !pinnedSet.has(b.target))
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       const oa = bufferOrder(a);
       const ob = bufferOrder(b);
       if (oa !== ob) return oa - ob;

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -157,7 +157,7 @@ const sorted = computed(() => {
         return !ignores.isIgnored(networkId, nick, userhost ?? '');
       })
     : list;
-  return [...filtered].sort((a, b) => {
+  return filtered.toSorted((a, b) => {
     const pa = PREFIX_ORDER.indexOf(prefixOf(a));
     const pb = PREFIX_ORDER.indexOf(prefixOf(b));
     if (pa !== pb) return pa - pb;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -239,13 +239,13 @@ const longMessageUploading = ref(false);
 // some other target, but the wire chunks are the same. Other slash commands
 // (/raw, /join, etc.) don't pass through the splitter — return null to
 // signal "no split risk".
-function bodyForSplit(text: string): { body: string; isAction: boolean } {
-  if (!text) return { body: '', isAction: false };
+function bodyForSplit(raw: string): { body: string; isAction: boolean } {
+  if (!raw) return { body: '', isAction: false };
   // // escape: `//foo` is a literal `/foo` message, not a command, so it does
   // pass through PRIVMSG and is subject to the splitter.
-  if (text.startsWith('//')) return { body: text.slice(1), isAction: false };
-  if (text[0] !== '/') return { body: text, isAction: false };
-  const m = text.match(/^\/(\w+)\s*(.*)$/s);
+  if (raw.startsWith('//')) return { body: raw.slice(1), isAction: false };
+  if (raw[0] !== '/') return { body: raw, isAction: false };
+  const m = raw.match(/^\/(\w+)\s*(.*)$/s);
   if (!m) return { body: '', isAction: false };
   const cmd = m[1].toLowerCase();
   if (cmd === 'me') return { body: m[2], isAction: true };
@@ -258,8 +258,8 @@ function bodyForSplit(text: string): { body: string; isAction: boolean } {
   return { body: '', isAction: false };
 }
 
-function computeChunks(text: string): { chunks: number; isAction: boolean } {
-  const { body, isAction } = bodyForSplit(text);
+function computeChunks(raw: string): { chunks: number; isAction: boolean } {
+  const { body, isAction } = bodyForSplit(raw);
   const chunks = isAction ? chunkCountForAction(body) : chunkCountForSay(body);
   return { chunks, isAction };
 }
@@ -323,7 +323,7 @@ function setInputAndCaretEnd(value: string): void {
   // Hold `cycling` across the watcher microtask so `onInput` sees it set and
   // skips the history-walk reset. Clearing it synchronously loses the walk
   // state on the very next Up/Down because Vue's `watch` runs after we return.
-  Promise.resolve().then(() => {
+  queueMicrotask(() => {
     cycling = false;
     const el = inputEl.value;
     if (!el) return;
@@ -408,7 +408,7 @@ function buildChannelMatches(networkId: number, prefix: string): string[] {
     .forNetwork(networkId)
     .map((b) => b.target)
     .filter((t) => t.startsWith('#') && t.toLowerCase().startsWith(lower))
-    .sort((a, b) => a.localeCompare(b));
+    .toSorted((a, b) => a.localeCompare(b));
 }
 
 function applyCompletion() {
@@ -426,7 +426,7 @@ function applyCompletion() {
   // Move caret to just after the inserted nick + suffix.
   const caret = completion.prefix.length + pick.length + suffix.length;
   // Set on the next tick so v-model has propagated.
-  Promise.resolve().then(() => {
+  queueMicrotask(() => {
     const el = inputEl.value;
     if (!el) return;
     el.setSelectionRange(caret, caret);
@@ -478,7 +478,7 @@ function wrapOrInsertFormatting(opening: string, closing: string): void {
   // body so the user can keep applying combinations (bold + italic + colour)
   // without re-highlighting. With no selection, drop the caret just after
   // the inserted code so they can type styled text.
-  Promise.resolve().then(() => {
+  queueMicrotask(() => {
     const e2 = inputEl.value;
     if (!e2) return;
     e2.focus();
@@ -680,7 +680,7 @@ function onPickerSelect(nick: string): void {
   text.value = before + nick + ' ' + after;
   cycling = false;
   closePicker();
-  Promise.resolve().then(() => {
+  queueMicrotask(() => {
     const el = inputEl.value;
     if (!el) return;
     const caret = before.length + nick.length + 1;
@@ -706,7 +706,7 @@ function onStripSelect(nick: string): void {
   text.value = before + nick + suffix + after;
   cycling = false;
   closeStrip();
-  Promise.resolve().then(() => {
+  queueMicrotask(() => {
     const el = inputEl.value;
     if (!el) return;
     const caret = before.length + nick.length + suffix.length;
@@ -833,7 +833,7 @@ function insertUrlAtCaret(url: string): void {
   cycling = true;
   text.value = `${before}${inserted}${after}`;
   cycling = false;
-  Promise.resolve().then(() => {
+  queueMicrotask(() => {
     const e2 = inputEl.value;
     if (!e2) return;
     const caret = before.length + inserted.length;
@@ -1064,12 +1064,12 @@ function onLongMessageCancel() {
 // Drop a synthetic, non-persisted info line into the current buffer so the
 // user sees the output of client-resolved commands like /help or argument
 // validation errors. id-less so pushMessage's replay guard doesn't trip.
-function localInfo(networkId: number, target: string, text: string): void {
+function localInfo(networkId: number, target: string, lineText: string): void {
   buffers.pushMessage({
     networkId,
     target,
     type: 'motd',
-    text,
+    text: lineText,
     time: new Date().toISOString(),
   });
 }
@@ -1130,6 +1130,7 @@ function ackedSend(payload: Record<string, unknown>, body: string): boolean {
   }
   pending.then((result) => {
     if (!result.ok) toastSendFailure(result.error ?? 'unknown', body);
+    return result;
   });
   return true;
 }
@@ -1324,7 +1325,7 @@ function handleCommand(line: string, networkId: number, target: string): boolean
       return ackedSend({ type: 'send', networkId, target, text: url }, url);
     }
     case 'help':
-      for (const text of HELP_LINES) localInfo(networkId, target, text);
+      for (const helpLine of HELP_LINES) localInfo(networkId, target, helpLine);
       return true;
     default:
       return sendOrToast({ type: 'raw', networkId, line: line.slice(1) }, line);

--- a/vue_client/src/components/settings-panes/AboutPane.vue
+++ b/vue_client/src/components/settings-panes/AboutPane.vue
@@ -43,7 +43,7 @@
 
 <script setup lang="ts">
 // Build-time constant injected by vite.config.js (define).
-const appVersion = __APP_VERSION__;
+const appVersion = APP_VERSION;
 </script>
 
 <style src="./panes.css"></style>

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -98,13 +98,13 @@ const ignoreGroups = computed<IgnoreGroup[]>(() => {
       masks,
     });
   }
-  return groups.sort((a, b) => a.networkName.localeCompare(b.networkName));
+  return groups.toSorted((a, b) => a.networkName.localeCompare(b.networkName));
 });
 
 const ignoreNetworkOptions = computed<NetworkOption[]>(() => {
   return (networksStore.networks || [])
     .map((n) => ({ id: n.id, name: n.name }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .toSorted((a, b) => a.name.localeCompare(b.name));
 });
 
 const newIgnoreNetworkId = ref<number | null>(null);

--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -314,7 +314,9 @@ const alwaysNotifyChannelList = computed(() => {
       key: `${entry.networkId}::${entry.target}`,
       networkName: networksStore.networkById(entry.networkId)?.name || `net:${entry.networkId}`,
     }))
-    .sort((a, b) => a.networkName.localeCompare(b.networkName) || a.target.localeCompare(b.target));
+    .toSorted(
+      (a, b) => a.networkName.localeCompare(b.networkName) || a.target.localeCompare(b.target),
+    );
 });
 
 async function refreshPushState() {

--- a/vue_client/src/composables/useKeyboardShortcuts.ts
+++ b/vue_client/src/composables/useKeyboardShortcuts.ts
@@ -16,6 +16,14 @@ export interface KeyboardShortcutsOptions {
   onScrollMessages?: (direction: number) => void;
 }
 
+function markAllRead(): void {
+  socketSend({ type: 'mark-all-read' });
+}
+
+function isCmd(e: KeyboardEvent): boolean {
+  return e.metaKey || e.ctrlKey;
+}
+
 // IRCCloud-style global shortcuts. Wired at the document level so they fire
 // even when focus is in the message input — preventDefault stops them from
 // also producing input-side effects (cursor by paragraph on Mac, etc.).
@@ -76,14 +84,6 @@ export function useKeyboardShortcuts({
     const next = (idx + delta + list.length) % list.length;
     const target = list[next];
     if (target) buffers.activate(target.networkId, target.target);
-  }
-
-  function markAllRead(): void {
-    socketSend({ type: 'mark-all-read' });
-  }
-
-  function isCmd(e: KeyboardEvent): boolean {
-    return e.metaKey || e.ctrlKey;
   }
 
   function onKeydown(e: KeyboardEvent): void {

--- a/vue_client/src/composables/useMemberActions.ts
+++ b/vue_client/src/composables/useMemberActions.ts
@@ -36,6 +36,10 @@ export interface MemberActionsAPI {
   ): void;
 }
 
+function nickOf(m: MemberLike | string): string {
+  return typeof m === 'string' ? m : m.nick;
+}
+
 // Shared menu items for a member of a channel. Exposed as a composable so
 // right-click, row-tap (mobile), and the hover three-dots (desktop) all
 // surface the same actions. The caller owns side-effect state that needs
@@ -48,10 +52,6 @@ export function useMemberActions(): MemberActionsAPI {
   const buffers = useBuffersStore();
   const nickNotes = useNickNotesStore();
   const menu = useContextMenu();
-
-  function nickOf(m: MemberLike | string): string {
-    return typeof m === 'string' ? m : m.nick;
-  }
 
   function buildItems(
     member: MemberLike | string | null | undefined,

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -22,7 +22,7 @@ import { resetScrollState } from './useScrollState.js';
 export function resetSession(): void {
   resetSocket();
   const buffers = useBuffersStore();
-  buffers._resetTimers();
+  buffers.resetTimers();
   buffers.$reset();
   useNetworksStore().$reset();
   useSettingsStore().$reset();
@@ -30,7 +30,7 @@ export function resetSession(): void {
   useHighlightRulesStore().$reset();
   useInputHistoryStore().$reset();
   const drafts = useDraftStore();
-  drafts._resetTimers();
+  drafts.resetTimers();
   drafts.$reset();
   usePushSubscriptionsStore().$reset();
   usePinsStore().$reset();

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -35,6 +35,10 @@ export interface SocketAPI {
 type AckResolver = (result: AckResult) => void;
 
 let socket: WebSocket | null = null;
+// Scopes the current socket's event listeners. Aborting it detaches all of
+// them at once — used by resetSocket to strip handlers before closing so the
+// 'close' reconnect arm can't fire.
+let socketListeners: AbortController | null = null;
 const connected = ref(false);
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 const openHandlers = new Set<() => void>();
@@ -445,49 +449,63 @@ function open() {
   )
     return;
   socket = new WebSocket(wsUrl());
-  socket.onopen = () => {
-    connected.value = true;
-    // Detached buffers won't survive a reconnect cleanly — the incoming
-    // snapshot/backlog would otherwise be short-circuited by replaceBacklog's
-    // detached guard, leaving the slice stale and the buffer cut off from
-    // live. Drop the detach (and wipe each slice) before any server message
-    // can arrive on the new socket so the snapshot reseeds them as live.
-    // Synchronous: messages from the new socket arrive on later event-loop
-    // turns, so the reseed sees the cleared state.
-    try {
-      const buffers = useBuffersStore();
-      for (const buf of buffers.list) {
-        if (buf.detached) {
-          buffers.clearDetached(buf.networkId, buf.target, { wipeMessages: true });
+  socketListeners = new AbortController();
+  const opts = { signal: socketListeners.signal };
+  socket.addEventListener(
+    'open',
+    () => {
+      connected.value = true;
+      // Detached buffers won't survive a reconnect cleanly — the incoming
+      // snapshot/backlog would otherwise be short-circuited by replaceBacklog's
+      // detached guard, leaving the slice stale and the buffer cut off from
+      // live. Drop the detach (and wipe each slice) before any server message
+      // can arrive on the new socket so the snapshot reseeds them as live.
+      // Synchronous: messages from the new socket arrive on later event-loop
+      // turns, so the reseed sees the cleared state.
+      try {
+        const buffers = useBuffersStore();
+        for (const buf of buffers.list) {
+          if (buf.detached) {
+            buffers.clearDetached(buf.networkId, buf.target, { wipeMessages: true });
+          }
+        }
+      } catch (_) {
+        /* store not yet initialized; nothing to clear */
+      }
+      for (const handler of openHandlers) {
+        try {
+          handler();
+        } catch (_) {
+          /* ignore */
         }
       }
-    } catch (_) {
-      /* store not yet initialized; nothing to clear */
-    }
-    for (const handler of openHandlers) {
-      try {
-        handler();
-      } catch (_) {
-        /* ignore */
+    },
+    opts,
+  );
+  socket.addEventListener('message', (ev) => handleMessage(ev.data), opts);
+  socket.addEventListener(
+    'close',
+    () => {
+      connected.value = false;
+      socket = null;
+      // Anything we were waiting on is gone with the socket. Settle every
+      // pending ACK as a disconnect so callers can surface the failure now
+      // instead of waiting out the timeout.
+      failAllPendingAcks('disconnected');
+      const auth = useAuthStore();
+      if (auth.user) {
+        reconnectTimer = setTimeout(open, 2000);
       }
-    }
-  };
-  socket.onmessage = (ev) => handleMessage(ev.data);
-  socket.onclose = () => {
-    connected.value = false;
-    socket = null;
-    // Anything we were waiting on is gone with the socket. Settle every
-    // pending ACK as a disconnect so callers can surface the failure now
-    // instead of waiting out the timeout.
-    failAllPendingAcks('disconnected');
-    const auth = useAuthStore();
-    if (auth.user) {
-      reconnectTimer = setTimeout(open, 2000);
-    }
-  };
-  socket.onerror = () => {
-    if (socket) socket.close();
-  };
+    },
+    opts,
+  );
+  socket.addEventListener(
+    'error',
+    () => {
+      if (socket) socket.close();
+    },
+    opts,
+  );
 }
 
 function send(payload: Record<string, unknown>): boolean {
@@ -526,21 +544,26 @@ export function socketSendWithAck(payload: Record<string, unknown>): Promise<Ack
   const clientId = makeClientId();
   const wire = { ...payload, clientId };
   return new Promise<AckResult>((resolve) => {
-    const timer = setTimeout(() => {
-      if (pendingAcks.delete(clientId)) resolve({ ok: false, error: 'timeout' });
-    }, ACK_TIMEOUT_MS);
-    pendingAcks.set(clientId, (result) => {
+    // Three racing paths can finish this send — server ACK, timeout, or a
+    // synchronous send failure. settle() lets whichever fires first win and
+    // makes the rest no-ops.
+    let settled = false;
+    const settle = (result: AckResult) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
       pendingAcks.delete(clientId);
+      // The `settled` flag above already makes this resolve run exactly once;
+      // the linter just can't see the guard across settle()'s call sites.
+      // eslint-disable-next-line promise/no-multiple-resolved
       resolve(result);
-    });
+    };
+    const timer = setTimeout(() => settle({ ok: false, error: 'timeout' }), ACK_TIMEOUT_MS);
+    pendingAcks.set(clientId, settle);
     try {
       socket!.send(JSON.stringify(wire));
     } catch (_) {
-      if (pendingAcks.delete(clientId)) {
-        clearTimeout(timer);
-        resolve({ ok: false, error: 'disconnected' });
-      }
+      settle({ ok: false, error: 'disconnected' });
     }
   });
 }
@@ -554,10 +577,9 @@ export function resetSocket(): void {
     reconnectTimer = null;
   }
   if (socket) {
-    socket.onopen = null;
-    socket.onmessage = null;
-    socket.onclose = null;
-    socket.onerror = null;
+    // Detach every listener at once so the 'close' reconnect arm can't fire.
+    socketListeners?.abort();
+    socketListeners = null;
     try {
       socket.close();
     } catch (_) {

--- a/vue_client/src/composables/useViewport.ts
+++ b/vue_client/src/composables/useViewport.ts
@@ -39,6 +39,14 @@ export function useViewport(): ViewportState {
   return { isMobile };
 }
 
+function update(): void {
+  const vv = window.visualViewport;
+  const h = vv ? vv.height : window.innerHeight;
+  const y = vv ? vv.offsetTop : 0;
+  document.documentElement.style.setProperty('--viewport-h', `${h}px`);
+  document.documentElement.style.setProperty('--viewport-y', `${y}px`);
+}
+
 // visualViewport tracks the actual visible area, which on iOS Safari shrinks
 // when the soft keyboard opens. We write both:
 //
@@ -55,13 +63,6 @@ export function useViewport(): ViewportState {
 // Together with position: fixed on .mchat, these defeat the iOS quirk where
 // focusing an input pushes the whole app up and leaves a gray gutter below.
 export function useVisualViewportHeight(): void {
-  function update(): void {
-    const vv = window.visualViewport;
-    const h = vv ? vv.height : window.innerHeight;
-    const y = vv ? vv.offsetTop : 0;
-    document.documentElement.style.setProperty('--viewport-h', `${h}px`);
-    document.documentElement.style.setProperty('--viewport-y', `${y}px`);
-  }
   onMounted(() => {
     if (typeof window === 'undefined') return;
     update();

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -536,7 +536,7 @@ export const useBuffersStore = defineStore('buffers', {
     // every buffer (and therefore every typing indicator), but the
     // module-level Map of pending setTimeouts isn't part of Pinia state —
     // clear it explicitly so timers don't linger after logout.
-    _resetTimers() {
+    resetTimers() {
       for (const id of typingTimers.values()) clearTimeout(id);
       typingTimers.clear();
     },

--- a/vue_client/src/stores/drafts.ts
+++ b/vue_client/src/stores/drafts.ts
@@ -16,7 +16,7 @@ function key(networkId: number | string, target: string) {
 
 // Debounce timers and the unflushed-pending tracker live module-local: they
 // aren't reactive state, and keeping them out of Pinia means $reset doesn't
-// have to handle non-serializable Map entries. `_resetTimers()` clears them
+// have to handle non-serializable Map entries. `resetTimers()` clears them
 // in concert with $reset on logout.
 const flushTimers = new Map<string, ReturnType<typeof setTimeout>>(); // key -> setTimeout id
 const pending = new Map<string, { networkId: number | string; target: string }>(); // key -> { networkId, target }
@@ -87,21 +87,21 @@ export const useDraftStore = defineStore('drafts', {
       if (text.length > 0) this.drafts[k] = text;
       else delete this.drafts[k];
       pending.set(k, { networkId, target });
-      this._scheduleFlush(networkId, target);
+      this.scheduleFlush(networkId, target);
     },
     // Force-flush a single buffer's pending write to the server immediately.
     // Called on buffer-switch, input blur, and right before clearing on send.
     flushBuffer(networkId: number | string, target: string) {
       const k = key(networkId, target);
       if (!pending.has(k)) return;
-      this._sendForBuffer(networkId, target);
+      this.sendForBuffer(networkId, target);
     },
     // Drop in-memory state for a closed buffer. The server-side row is also
     // cleared by wsHub's close-buffer handler, so no flush is needed.
     drop(networkId: number | string, target: string) {
       const k = key(networkId, target);
       delete this.drafts[k];
-      this._clearTimer(k);
+      this.clearTimer(k);
       pending.delete(k);
     },
     // Beacon path used on tab close: ship every un-flushed buffer in one POST
@@ -113,7 +113,7 @@ export const useDraftStore = defineStore('drafts', {
       for (const [k, ref] of pending) {
         const body = this.drafts[k] || '';
         drafts.push({ networkId: ref.networkId, target: ref.target, body });
-        this._clearTimer(k);
+        this.clearTimer(k);
       }
       pending.clear();
       try {
@@ -129,31 +129,31 @@ export const useDraftStore = defineStore('drafts', {
     },
     // Pinia's $reset wipes `drafts`, but the module-level timers/pending Maps
     // are out of band — useSessionReset calls this so they're cleared too.
-    _resetTimers() {
+    resetTimers() {
       for (const id of flushTimers.values()) clearTimeout(id);
       flushTimers.clear();
       pending.clear();
     },
-    _scheduleFlush(networkId: number | string, target: string) {
+    scheduleFlush(networkId: number | string, target: string) {
       const k = key(networkId, target);
-      this._clearTimer(k);
+      this.clearTimer(k);
       const id = setTimeout(() => {
         flushTimers.delete(k);
-        this._sendForBuffer(networkId, target);
+        this.sendForBuffer(networkId, target);
       }, FLUSH_DEBOUNCE_MS);
       flushTimers.set(k, id);
     },
-    _clearTimer(k: string) {
+    clearTimer(k: string) {
       const id = flushTimers.get(k);
       if (id) {
         clearTimeout(id);
         flushTimers.delete(k);
       }
     },
-    _sendForBuffer(networkId: number | string, target: string) {
+    sendForBuffer(networkId: number | string, target: string) {
       const k = key(networkId, target);
       pending.delete(k);
-      this._clearTimer(k);
+      this.clearTimer(k);
       const body = this.drafts[k] || '';
       if (body.length > 0) {
         socketSend({ type: 'draft-set', networkId, target, body });

--- a/vue_client/src/stores/search.ts
+++ b/vue_client/src/stores/search.ts
@@ -52,7 +52,7 @@ export const useSearchStore = defineStore('search', {
     },
     // Build the structured WS payload from the raw query. Returns null when
     // there's nothing to search on (no free text and no structured filter).
-    _buildPayload(before: number | null) {
+    buildPayload(before: number | null) {
       const parsed = parseSearchQuery(this.query);
       const payload: Record<string, unknown> = {
         type: 'search',
@@ -83,7 +83,7 @@ export const useSearchStore = defineStore('search', {
       this.error = '';
       this.scrollTop = 0;
       this.selectedIndex = 0;
-      const payload = this._buildPayload(null);
+      const payload = this.buildPayload(null);
       if (!payload) {
         this.loading = false;
         this.searched = false;
@@ -98,7 +98,7 @@ export const useSearchStore = defineStore('search', {
     },
     loadMore() {
       if (this.loading || !this.hasMore || this.nextBefore == null) return;
-      const payload = this._buildPayload(this.nextBefore);
+      const payload = this.buildPayload(this.nextBefore);
       if (!payload) return;
       this.loading = true;
       if (!socketSend(payload)) {

--- a/vue_client/src/stores/systemLog.ts
+++ b/vue_client/src/stores/systemLog.ts
@@ -38,7 +38,7 @@ export const useSystemLogStore = defineStore('systemLog', {
       for (const line of lines) {
         if (line && typeof line.id === 'number') byId.set(line.id, line);
       }
-      const merged = Array.from(byId.values()).sort((a, b) => a.id - b.id);
+      const merged = Array.from(byId.values()).toSorted((a, b) => a.id - b.id);
       this.lines = merged;
       this.maxId = merged.length ? merged[merged.length - 1].id : 0;
       this.trim();

--- a/vue_client/src/utils/bufferOrder.ts
+++ b/vue_client/src/utils/bufferOrder.ts
@@ -74,7 +74,7 @@ export function flattenBufferOrder({
 
     const unpinned = all
       .filter((b) => !isServerTarget(b.target) && !pinnedSet.has(b.target))
-      .sort((a, b) => {
+      .toSorted((a, b) => {
         const oa = bufferOrder(a.target);
         const ob = bufferOrder(b.target);
         if (oa !== ob) return oa - ob;

--- a/vue_client/src/utils/nickCompletion.ts
+++ b/vue_client/src/utils/nickCompletion.ts
@@ -76,7 +76,7 @@ export function buildNickCandidates(
 
   const out: NickCandidate[] = [];
 
-  const speakers = Object.values(buf.speakers || {}).sort((a, b) => b.lastTime - a.lastTime);
+  const speakers = Object.values(buf.speakers || {}).toSorted((a, b) => b.lastTime - a.lastTime);
   for (const s of speakers) {
     const lc = s.nick.toLowerCase();
     if (seen.has(lc)) continue;
@@ -87,7 +87,7 @@ export function buildNickCandidates(
     out.push({ nick: s.nick, recent: true });
   }
 
-  const sortedMembers = memberNames.slice().sort((a, b) => a.localeCompare(b));
+  const sortedMembers = memberNames.toSorted((a, b) => a.localeCompare(b));
   for (const n of sortedMembers) {
     const lc = n.toLowerCase();
     if (seen.has(lc)) continue;

--- a/vue_client/src/vite-env.d.ts
+++ b/vue_client/src/vite-env.d.ts
@@ -3,4 +3,4 @@
 /// <reference types="vite/client" />
 
 // Injected at build time by the `define` block in vite.config.ts.
-declare const __APP_VERSION__: string;
+declare const APP_VERSION: string;

--- a/vue_client/vite.config.ts
+++ b/vue_client/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig(({ mode }) => {
     // Build-time constant so the About panel can show the app version without
     // an API round-trip.
     define: {
-      __APP_VERSION__: JSON.stringify(pkg.version),
+      APP_VERSION: JSON.stringify(pkg.version),
     },
     server: {
       host: lanHost ? true : host,


### PR DESCRIPTION
Closes section 3 of #17 — the advisory oxlint pass. Takes oxlint from 137 warnings to **0**. Per the agreed approach: fix everything in code, no `.oxlintrc.json` changes.

Two commits:

## 1. `fix:` async Express handler crash risk — the one substantive item

Express 4 doesn't catch a rejected promise from an `async` route handler; it becomes an unhandled rejection and can crash the process. Added a small `asyncHandler` wrapper (`try/await/catch → next(err)`) and applied it to every async handler in `auth`, `exports`, `uploads`, and the `autonotes` integration. Success path unchanged — a thrown error now reaches the error middleware instead of taking the process down.

## 2. `style:` the remaining ~123 advisory warnings

All `suspicious`-category, no behaviour change:

- **no-array-sort / no-array-reverse** — `.sort()`/`.reverse()` → non-mutating `.toSorted()`/`.toReversed()` (every site was already on a fresh array or explicit copy).
- **no-underscore-dangle** — dropped the `_`-prefix convention: renamed the `_`-prefixed internal store actions / class methods / helpers to plain names (`_userMap` → `connectionsForUser`, `_scope` → `logScope`, `__APP_VERSION__` → `APP_VERSION`, …).
- **no-named-as-default-member** — `systemLog` is now a namespace import (`import * as systemLog`).
- **prefer-add-event-listener** — `onX =` → `addEventListener`. `useSocket` scopes its socket listeners with an `AbortController` so `resetSocket` still detaches them in one call; the autonotes `<select>` handler is remove-then-add so repeat binds don't stack.
- **consistent-function-scoping** — hoisted 12 nested helpers (that capture nothing) to module scope.
- **promise/always-return** — the deferred-microtask `Promise.resolve().then(...)` calls became `queueMicrotask(...)`; the one real chain returns its value.
- **promise/no-multiple-resolved** — `socketSendWithAck`'s three race paths funnel through one guarded `settle()`.
- **no-shadow / no-new / no-useless-concat / preserve-caught-error** — minor local fixes.

### One judgement call worth a look

`socketSendWithAck` has a promise with three legitimate race-to-settle paths (ack / timeout / send-failure), made single-resolve by a `settled` flag. `promise/no-multiple-resolved` can't see a runtime guard across the call sites, so that one `resolve()` has an `eslint-disable-next-line` with an explanatory comment. It's the only suppression in the PR — flagging it in case you'd rather restructure.

## Verification

- `oxlint` — **0 warnings**, exit 0
- `tsc` (server) + `vue-tsc` (client) + `tsc` (autonotes) — clean
- `oxfmt --check` — clean
- Test suite — 535 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)