### PR TITLE
DigitalOcean one-shot deploy with optional Caddy HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ For a public, HTTPS-enabled Lurker on a fresh droplet — no SSH required:
 
 TLS via Let's Encrypt is provisioned automatically by Caddy. Leave `LURKER_DOMAIN` empty (and skip step 1) for a plain-HTTP deployment on port 8015. Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
 
+**Updating:** SSH in (or open the DigitalOcean web console) and run:
+
+```bash
+cd /opt/lurker
+docker compose pull && docker compose up -d
+```
+
+That's the same command whether or not you enabled HTTPS — the deploy script records the Caddy overlay in `.env`, so `docker compose` picks it up automatically. Your `data/` directory is left untouched.
+
 ## Manual Install (without Docker)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ docker compose up -d
 
 Then open <http://localhost:8015> and create your admin account. Username + password is the default; passkeys are optional. See [SELF_HOSTING.md](SELF_HOSTING.md) for the full guide — reverse proxy + HTTPS, enabling passkeys, push notifications, updating, and backups.
 
+## Deploy on DigitalOcean (one-shot)
+
+For a public, HTTPS-enabled Lurker on a fresh droplet — no SSH required:
+
+1. Point a domain (e.g. `irc.yourdomain.com`) at a fresh droplet's IP.
+2. Create a droplet — the Docker Marketplace image at the smallest size is fine (vanilla Ubuntu 24.04 LTS works too).
+3. Paste the contents of [`deploy/digitalocean-cloud-init.sh`](deploy/digitalocean-cloud-init.sh) into the **User Data** field at droplet creation, after editing `LURKER_DOMAIN` at the top of the script.
+4. Create the droplet, wait ~90 seconds, then visit your domain.
+
+TLS via Let's Encrypt is provisioned automatically by Caddy. Leave `LURKER_DOMAIN` empty (and skip step 1) for a plain-HTTP deployment on port 8015. Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
+
 ## Manual Install (without Docker)
 
 ```bash

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -36,6 +36,8 @@ docker compose pull
 docker compose up -d
 ```
 
+Run these from the directory holding your `docker-compose.yml`. If you used the [one-shot DigitalOcean deploy](README.md#deploy-on-digitalocean-one-shot), that's `/opt/lurker` — `cd` there first; the command is identical whether or not you enabled HTTPS.
+
 Lurker auto-migrates its SQLite schema on boot, so updates are a pull + restart. The `data/` directory is not touched.
 
 If something goes wrong, your `data/` directory still has your last-known-good state — back it up before major updates if you want a clean rollback path.

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -66,6 +66,8 @@ Lurker is a single-user-per-account always-on IRC client — most operators want
 - Works behind CGNAT, on a residential network, or anywhere with outbound HTTPS
 - Free for personal use
 
+> **Starting from a blank VPS?** If you don't already have a host, the [one-shot DigitalOcean deploy](README.md#deploy-on-digitalocean-one-shot) brings up a fresh droplet with Lurker and automatic HTTPS (via Caddy) from a single pasted script — no SSH, no manual Docker install. The rest of this section covers exposing an instance you're already running.
+
 ### Setup
 
 1. **Own a domain on Cloudflare.** You don't need to buy one through Cloudflare, but the DNS does need to be managed there. (Cloudflare's free plan is fine.)

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 Brad Root
+# SPDX-License-Identifier: Elastic-2.0
+#
+# Minimal Caddy config that fronts Lurker with automatic HTTPS.
+#
+# LURKER_DOMAIN and ACME_EMAIL are passed into the Caddy container by
+# docker-compose.caddy.yml; Caddy fills the {$VAR} placeholders below from
+# its own environment at startup, then provisions a Let's Encrypt
+# certificate for the domain automatically.
+{
+	email {$ACME_EMAIL}
+}
+
+{$LURKER_DOMAIN} {
+	encode gzip
+
+	# reverse_proxy upgrades WebSocket connections transparently, so
+	# Lurker's ws:// stream needs no extra configuration here.
+	reverse_proxy lurker:8015
+}

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -167,16 +167,19 @@ deploy() {
     curl -fsSL -o docker-compose.caddy.yml "$REPO_RAW/docker-compose.caddy.yml"
     curl -fsSL -o Caddyfile "$REPO_RAW/deploy/Caddyfile"
 
-    # Compose interpolates these into docker-compose.caddy.yml, and Caddy
-    # reads them from its container environment to fill the Caddyfile.
+    # Compose interpolates LURKER_DOMAIN/ACME_EMAIL into docker-compose.caddy.yml
+    # (and Caddy reads them to fill the Caddyfile). COMPOSE_FILE records the
+    # overlay so plain `docker compose` commands — including future updates —
+    # pick up Caddy automatically, no `-f` flags needed.
     cat > .env <<EOF
 LURKER_DOMAIN=${LURKER_DOMAIN}
 ACME_EMAIL=${ACME_EMAIL}
+COMPOSE_FILE=docker-compose.yml:docker-compose.caddy.yml
 EOF
 
-    compose -f docker-compose.yml -f docker-compose.caddy.yml pull
-    compose -f docker-compose.yml -f docker-compose.caddy.yml up -d
-    compose -f docker-compose.yml -f docker-compose.caddy.yml ps
+    compose pull
+    compose up -d
+    compose ps
   else
     log "LURKER_DOMAIN is empty — deploying plain HTTP on port 8015."
     compose pull

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Copyright (c) 2026 Brad Root
+# SPDX-License-Identifier: Elastic-2.0
+#
+# Lurker — DigitalOcean one-shot deploy (cloud-init user-data)
+# ============================================================
+#
+# Paste the ENTIRE contents of this file into the "User Data" field when
+# creating a DigitalOcean droplet (Advanced Options → Add Initialization
+# scripts). On first boot the droplet will, with no SSH:
+#
+#   * install Docker + the Compose plugin (skipped if already present, so
+#     this works on both the Docker Marketplace image and vanilla Ubuntu)
+#   * fetch Lurker and start it under Docker Compose
+#   * optionally front it with Caddy for automatic HTTPS (Let's Encrypt)
+#   * add a small swapfile on low-RAM droplets and configure the firewall
+#
+# Everything is logged to /var/log/lurker-deploy.log — view that from the
+# DigitalOcean droplet console if a deploy doesn't come up as expected.
+#
+# ─── Edit these two values before pasting ───────────────────────────────────
+
+# Public domain for an HTTPS deployment, e.g. "irc.example.com".
+#   * Set it → Lurker is served over HTTPS via Caddy. The domain must
+#              already have a DNS A/AAAA record pointing at this droplet.
+#   * Empty  → Lurker is served over plain HTTP on port 8015.
+LURKER_DOMAIN=""
+
+# Let's Encrypt contact address (used only when LURKER_DOMAIN is set).
+# Leave empty to default to admin@<LURKER_DOMAIN>.
+ACME_EMAIL=""
+
+# ─── No edits needed below this line ────────────────────────────────────────
+
+set -euo pipefail
+
+REPO_RAW="https://raw.githubusercontent.com/amiantos/lurker/main"
+INSTALL_DIR="/opt/lurker"
+DEPLOY_LOG="/var/log/lurker-deploy.log"
+
+# cloud-init runs headless, so mirror all output into a log file that can be
+# read back later from the droplet console.
+exec > >(tee -a "$DEPLOY_LOG") 2>&1
+
+log() { echo "[lurker-deploy $(date -u +%H:%M:%S)] $*"; }
+
+log "=== Lurker deploy started $(date -u +%FT%TZ) ==="
+
+# ── Prerequisites ───────────────────────────────────────────────────────────
+
+ensure_curl() {
+  if command -v curl >/dev/null 2>&1; then
+    return
+  fi
+  log "Installing curl..."
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -y
+  apt-get install -y curl ca-certificates
+}
+
+install_docker() {
+  if command -v docker >/dev/null 2>&1; then
+    log "Docker already installed ($(docker --version)) — skipping install."
+    return
+  fi
+  log "Docker not found — installing via the official convenience script."
+  export DEBIAN_FRONTEND=noninteractive
+  curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+  sh /tmp/get-docker.sh
+  rm -f /tmp/get-docker.sh
+  systemctl enable --now docker
+}
+
+# On the Docker Marketplace image the daemon may still be settling when
+# cloud-init runs; wait for it rather than assuming the socket is ready.
+wait_for_docker() {
+  log "Waiting for the Docker daemon..."
+  local i
+  for i in $(seq 1 30); do
+    if docker info >/dev/null 2>&1; then
+      log "Docker daemon is ready."
+      return
+    fi
+    sleep 2
+  done
+  log "ERROR: Docker daemon did not become ready within 60s."
+  exit 1
+}
+
+# Prefer the Compose v2 plugin; fall back to the legacy v1 binary for older
+# images. Every compose invocation below goes through this wrapper.
+compose() {
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+  else
+    log "ERROR: no Docker Compose (v2 plugin or v1 binary) found."
+    exit 1
+  fi
+}
+
+# ── Host setup ──────────────────────────────────────────────────────────────
+
+# The cheapest droplets ship 512MB–1GB of RAM; a small swapfile keeps the
+# image pull and Node runtime comfortable.
+ensure_swap() {
+  local mem_kb
+  mem_kb=$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)
+  if [ "$mem_kb" -ge 2000000 ]; then
+    log "RAM is $((mem_kb / 1024))MB (>= 2GB) — no swapfile needed."
+    return
+  fi
+  if swapon --show 2>/dev/null | grep -q .; then
+    log "Swap already active — leaving it alone."
+    return
+  fi
+  log "RAM is $((mem_kb / 1024))MB (< 2GB) — adding a 1GB swapfile."
+  fallocate -l 1G /swapfile || dd if=/dev/zero of=/swapfile bs=1M count=1024
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+  if ! grep -q '^/swapfile ' /etc/fstab; then
+    echo '/swapfile none swap sw 0 0' >> /etc/fstab
+  fi
+}
+
+# UFW: open SSH *first* so a bad rule can't lock us out, then the ports the
+# chosen deployment mode actually needs.
+#
+# Note: Docker publishes container ports straight into iptables, bypassing
+# UFW — so the real isolation of Lurker's 8015 in HTTPS mode comes from
+# docker-compose.caddy.yml dropping its host port binding, not from the
+# `ufw deny` below (kept only as belt-and-suspenders).
+configure_firewall() {
+  if ! command -v ufw >/dev/null 2>&1; then
+    log "ufw not installed — skipping firewall configuration."
+    return
+  fi
+  log "Configuring UFW firewall (SSH allowed first)..."
+  ufw allow 22/tcp
+  if [ -n "$LURKER_DOMAIN" ]; then
+    ufw allow 80/tcp
+    ufw allow 443/tcp
+    ufw deny 8015/tcp
+  else
+    ufw allow 8015/tcp
+  fi
+  ufw --force enable
+  ufw status verbose || true
+}
+
+# ── Deploy ──────────────────────────────────────────────────────────────────
+
+deploy() {
+  mkdir -p "$INSTALL_DIR"
+  cd "$INSTALL_DIR"
+
+  log "Fetching docker-compose.yml..."
+  curl -fsSL -o docker-compose.yml "$REPO_RAW/docker-compose.yml"
+
+  if [ -n "$LURKER_DOMAIN" ]; then
+    if [ -z "$ACME_EMAIL" ]; then
+      ACME_EMAIL="admin@${LURKER_DOMAIN}"
+    fi
+    log "LURKER_DOMAIN is set ($LURKER_DOMAIN) — deploying with Caddy + HTTPS."
+    curl -fsSL -o docker-compose.caddy.yml "$REPO_RAW/docker-compose.caddy.yml"
+    curl -fsSL -o Caddyfile "$REPO_RAW/deploy/Caddyfile"
+
+    # Compose interpolates these into docker-compose.caddy.yml, and Caddy
+    # reads them from its container environment to fill the Caddyfile.
+    cat > .env <<EOF
+LURKER_DOMAIN=${LURKER_DOMAIN}
+ACME_EMAIL=${ACME_EMAIL}
+EOF
+
+    compose -f docker-compose.yml -f docker-compose.caddy.yml pull
+    compose -f docker-compose.yml -f docker-compose.caddy.yml up -d
+    compose -f docker-compose.yml -f docker-compose.caddy.yml ps
+  else
+    log "LURKER_DOMAIN is empty — deploying plain HTTP on port 8015."
+    compose pull
+    compose up -d
+    compose ps
+  fi
+}
+
+# ── Run ─────────────────────────────────────────────────────────────────────
+
+ensure_curl
+install_docker
+wait_for_docker
+ensure_swap
+deploy
+configure_firewall
+
+log "=== Lurker deploy finished $(date -u +%FT%TZ) ==="
+if [ -n "$LURKER_DOMAIN" ]; then
+  log "Open https://${LURKER_DOMAIN} — the first request can take ~60s while"
+  log "Caddy obtains a Let's Encrypt certificate, then create your admin account."
+  log "To enable passkeys / web push, see SELF_HOSTING.md (Optional features)."
+else
+  PUBLIC_IP=$(curl -fsS --max-time 5 \
+    http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address \
+    2>/dev/null || echo "<droplet-ip>")
+  log "Open http://${PUBLIC_IP}:8015 and create your admin account."
+fi

--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Brad Root
+# SPDX-License-Identifier: Elastic-2.0
+#
+# Caddy overlay — fronts Lurker with an automatic-HTTPS reverse proxy.
+#
+# Layer it on top of the base compose file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.caddy.yml up -d
+#
+# Requires a `.env` file beside this compose defining LURKER_DOMAIN (and,
+# optionally, ACME_EMAIL), plus the Caddyfile from this repo's deploy/
+# directory saved next to it. Caddy obtains a Let's Encrypt certificate for
+# LURKER_DOMAIN automatically — the domain must already resolve to this host.
+#
+# deploy/digitalocean-cloud-init.sh wires all of this up unattended; see the
+# "Deploy on DigitalOcean" section of the README.
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: lurker-caddy
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    environment:
+      # Caddy substitutes these into the Caddyfile's {$VAR} placeholders.
+      LURKER_DOMAIN: ${LURKER_DOMAIN}
+      ACME_EMAIL: ${ACME_EMAIL:-admin@${LURKER_DOMAIN}}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - lurker
+
+  lurker:
+    # Caddy reverse-proxies to Lurker over the internal Compose network, so
+    # the base file's `8015:8015` host binding is dropped here — Lurker is
+    # then reachable only through Caddy, i.e. only over HTTPS.
+    ports: !reset []
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
Closes #23.

Makes Lurker deployable on a DigitalOcean droplet from cloud-init user-data — "create droplet" to working Lurker with TLS, no SSH.

## What's here

- **`deploy/digitalocean-cloud-init.sh`** — user-data script pasted into DO's droplet-creation form. Idempotent on both the Docker Marketplace image and vanilla Ubuntu 24.04: gates Docker install on `command -v docker`, waits out the daemon socket race, adds a 1GB swapfile under 2GB RAM, fetches compose files from `main`, configures UFW (SSH allowed first), and deploys. Everything tees to `/var/log/lurker-deploy.log`.
- **`docker-compose.caddy.yml`** — Caddy overlay. `ports: !reset []` drops Lurker's host port binding so it's reachable only via Caddy over HTTPS (same `!reset` pattern as the existing `docker-compose.override.yml.example`).
- **`deploy/Caddyfile`** — minimal `reverse_proxy lurker:8015` with gzip; WebSocket upgrades are transparent.
- **README / SELF_HOSTING.md** — "Deploy on DigitalOcean (one-shot)" section + a cross-reference.

## Notes / deviations from the issue spec

- **Port 8010 → 8015.** The issue's snippets said 8010, but the Docker image runs on 8015 (`docker-compose.yml` sets `PORT=8015`). The issue asked to confirm and adjust — done.
- **Caddy-native env substitution, no `envsubst`.** The issue was internally inconsistent (said "render with envsubst" *and* passed env vars to the Caddy container). `envsubst` would also mangle Caddy's own `{$VAR}` placeholder syntax. Went with the standard Dockerized-Caddy approach: the committed `Caddyfile` is valid as-is, the script writes a `.env` so future `docker compose up` calls keep working, and there's no `gettext-base` dependency. File is named `deploy/Caddyfile` rather than `.template` because nothing renders it.

## Validation (local, Docker Compose v2.32)

- `bash -n` on the script — clean.
- `docker compose -f docker-compose.yml -f docker-compose.caddy.yml config` — merges cleanly; `!reset` drops the port; the nested `${ACME_EMAIL:-admin@${LURKER_DOMAIN}}` default resolves with `ACME_EMAIL` unset.
- `caddy validate` against `caddy:2-alpine` — "Valid configuration", auto-HTTPS + HTTP→HTTPS redirect confirmed.

The droplet-side checklist in the issue (live TLS provisioning, WebSocket/push through Caddy, UFW behaviour) can only be confirmed on a real droplet after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)