### PR TITLE
Fix DNS/IP ordering trap in DigitalOcean deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For a public, HTTPS-enabled Lurker on a fresh droplet — no SSH required:
 3. Once the droplet exists, copy its public IP and add a DNS `A` record pointing your domain at it.
 4. Give it a few minutes, then visit your domain.
 
-You don't need the droplet's IP before creating it: the droplet boots and starts Caddy *before* DNS exists, and Caddy keeps retrying Let's Encrypt until your `A` record resolves — so HTTPS comes up automatically a few minutes after you set the DNS record. (If you'd rather the certificate be ready the moment the droplet boots, reserve a [Reserved IP](https://docs.digitalocean.com/products/networking/reserved-ips/) first, point DNS at it, then create the droplet and assign that Reserved IP.)
+You don't need the droplet's IP before creating it: the droplet boots and starts Caddy _before_ DNS exists, and Caddy keeps retrying Let's Encrypt until your `A` record resolves — so HTTPS comes up automatically a few minutes after you set the DNS record. (If you'd rather the certificate be ready the moment the droplet boots, reserve a [Reserved IP](https://docs.digitalocean.com/products/networking/reserved-ips/) first, point DNS at it, then create the droplet and assign that Reserved IP.)
 
 Leave `LURKER_DOMAIN` empty for a plain-HTTP deployment instead — skip the DNS steps and open `http://<droplet-ip>:8015` directly. Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ Then open <http://localhost:8015> and create your admin account. Username + pass
 
 For a public, HTTPS-enabled Lurker on a fresh droplet — no SSH required:
 
-1. Point a domain (e.g. `irc.yourdomain.com`) at a fresh droplet's IP.
-2. Create a droplet — the Docker Marketplace image at the smallest size is fine (vanilla Ubuntu 24.04 LTS works too).
-3. At droplet creation, expand **Additional Options** and enable **User Scripts** (DigitalOcean's label for cloud-init user data — older guides call it "User data" or "Startup scripts"). Paste in the contents of [`deploy/digitalocean-cloud-init.sh`](deploy/digitalocean-cloud-init.sh), after editing `LURKER_DOMAIN` at the top of the script.
-4. Create the droplet, wait ~90 seconds, then visit your domain.
+1. Create a droplet — the Docker Marketplace image at the smallest size is fine (vanilla Ubuntu 24.04 LTS works too).
+2. At droplet creation, expand **Additional Options** and enable **User Scripts** (DigitalOcean's label for cloud-init user data — older guides call it "User data" or "Startup scripts"). Paste in the contents of [`deploy/digitalocean-cloud-init.sh`](deploy/digitalocean-cloud-init.sh), after editing `LURKER_DOMAIN` near the top of the script to your domain (e.g. `irc.yourdomain.com`).
+3. Once the droplet exists, copy its public IP and add a DNS `A` record pointing your domain at it.
+4. Give it a few minutes, then visit your domain.
 
-TLS via Let's Encrypt is provisioned automatically by Caddy. Leave `LURKER_DOMAIN` empty (and skip step 1) for a plain-HTTP deployment on port 8015. Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
+You don't need the droplet's IP before creating it: the droplet boots and starts Caddy *before* DNS exists, and Caddy keeps retrying Let's Encrypt until your `A` record resolves — so HTTPS comes up automatically a few minutes after you set the DNS record. (If you'd rather the certificate be ready the moment the droplet boots, reserve a [Reserved IP](https://docs.digitalocean.com/products/networking/reserved-ips/) first, point DNS at it, then create the droplet and assign that Reserved IP.)
+
+Leave `LURKER_DOMAIN` empty for a plain-HTTP deployment instead — skip the DNS steps and open `http://<droplet-ip>:8015` directly. Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
 
 **Updating:** SSH in (or open the DigitalOcean web console) and run:
 

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -200,8 +200,9 @@ configure_firewall
 
 log "=== Lurker deploy finished $(date -u +%FT%TZ) ==="
 if [ -n "$LURKER_DOMAIN" ]; then
-  log "Open https://${LURKER_DOMAIN} — the first request can take ~60s while"
-  log "Caddy obtains a Let's Encrypt certificate, then create your admin account."
+  log "Lurker is running. If a DNS A record for ${LURKER_DOMAIN} isn't already"
+  log "pointing at this droplet's IP, add it now — Caddy retries Let's Encrypt"
+  log "until it resolves, then https://${LURKER_DOMAIN} serves over HTTPS."
   log "To enable passkeys / web push, see SELF_HOSTING.md (Optional features)."
 else
   PUBLIC_IP=$(curl -fsS --max-time 5 \


### PR DESCRIPTION
Follow-up to #23 / #25.

## Problem

The "Deploy on DigitalOcean" steps told users to **point DNS at the droplet's IP before creating the droplet** — impossible, since the IP doesn't exist until the droplet is created. Reported by @amiantos.

## Fix

Reordered the steps to the flow that actually works:

1. Create the droplet (with the user-data script, `LURKER_DOMAIN` set).
2. Copy the droplet's public IP.
3. Add a DNS `A` record pointing the domain at it.
4. Wait a few minutes — HTTPS comes up on its own.

There's no real ordering dependency: the droplet boots and starts Caddy *before* DNS exists, and Caddy retries Let's Encrypt automatically until the `A` record resolves. The deploy never depends on DNS — only the certificate does, and that's self-healing.

Also documents the **Reserved IP** alternative for anyone who wants the certificate ready the instant the droplet boots, and updates the deploy script's closing log message to match the new flow.

Docs/comments only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)