### PR TITLE
Harden the DigitalOcean one-shot deploy (HTTPS-only, passkeys + push)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ Then open <http://localhost:8015> and create your admin account. Username + pass
 For a public, HTTPS-enabled Lurker on a fresh droplet — no SSH required:
 
 1. Create a droplet — the Docker Marketplace image at the smallest size is fine (vanilla Ubuntu 24.04 LTS works too).
-2. At droplet creation, expand **Additional Options** and enable **User Scripts** (DigitalOcean's label for cloud-init user data — older guides call it "User data" or "Startup scripts"). Paste in the contents of [`deploy/digitalocean-cloud-init.sh`](deploy/digitalocean-cloud-init.sh), after editing `LURKER_DOMAIN` near the top of the script to your domain (e.g. `irc.yourdomain.com`).
+2. At droplet creation, expand **Additional Options** and enable **User Scripts** (DigitalOcean's label for cloud-init user data — older guides call it "User data" or "Startup scripts"). Paste in the contents of [`deploy/digitalocean-cloud-init.sh`](deploy/digitalocean-cloud-init.sh), after filling in the two required values near the top of the script — `LURKER_DOMAIN` (your domain, e.g. `irc.yourdomain.com`) and `ADMIN_EMAIL` (your email address).
 3. Once the droplet exists, copy its public IP and add a DNS `A` record pointing your domain at it.
 4. Give it a few minutes, then visit your domain.
 
 You don't need the droplet's IP before creating it: the droplet boots and starts Caddy _before_ DNS exists, and Caddy keeps retrying Let's Encrypt until your `A` record resolves — so HTTPS comes up automatically a few minutes after you set the DNS record. (If you'd rather the certificate be ready the moment the droplet boots, reserve a [Reserved IP](https://docs.digitalocean.com/products/networking/reserved-ips/) first, point DNS at it, then create the droplet and assign that Reserved IP.)
 
-Passkeys and web push are configured automatically on HTTPS deployments — the deploy derives the WebAuthn and push settings from your domain and contact email — so you can enable them per device from Lurker's in-app settings without touching the server.
+Passkeys and web push notifications are configured automatically — the deploy derives the WebAuthn and push settings from your domain and email — so you can enable them per device from Lurker's in-app settings without touching the server.
 
-Leave `LURKER_DOMAIN` empty for a plain-HTTP deployment instead — skip the DNS steps and open `http://<droplet-ip>:8015` directly. Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
+Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
 
 **Updating:** SSH in (or open the DigitalOcean web console) and run:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ For a public, HTTPS-enabled Lurker on a fresh droplet — no SSH required:
 
 You don't need the droplet's IP before creating it: the droplet boots and starts Caddy _before_ DNS exists, and Caddy keeps retrying Let's Encrypt until your `A` record resolves — so HTTPS comes up automatically a few minutes after you set the DNS record. (If you'd rather the certificate be ready the moment the droplet boots, reserve a [Reserved IP](https://docs.digitalocean.com/products/networking/reserved-ips/) first, point DNS at it, then create the droplet and assign that Reserved IP.)
 
+Passkeys and web push are configured automatically on HTTPS deployments — the deploy derives the WebAuthn and push settings from your domain and contact email — so you can enable them per device from Lurker's in-app settings without touching the server.
+
 Leave `LURKER_DOMAIN` empty for a plain-HTTP deployment instead — skip the DNS steps and open `http://<droplet-ip>:8015` directly. Deploy progress is logged to `/var/log/lurker-deploy.log` on the droplet.
 
 **Updating:** SSH in (or open the DigitalOcean web console) and run:

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -124,7 +124,7 @@ If you already run Caddy, Traefik, nginx, or another reverse proxy with an autom
 
 ### Passkeys (WebAuthn)
 
-Lurker works fine with just username + password — passkeys are a quality-of-life addition (fingerprint / Face ID / hardware key login). To enable them, set three environment variables that match the public origin your browsers actually hit:
+Lurker works fine with just username + password — passkeys are a quality-of-life addition (fingerprint / Face ID / hardware key login). (The [one-shot DigitalOcean deploy](README.md#deploy-on-digitalocean-one-shot) sets these up for you.) To enable them elsewhere, set three environment variables that match the public origin your browsers actually hit:
 
 ```yaml
 environment:
@@ -141,7 +141,7 @@ Restart Lurker, log in with your password, then visit **Settings → Passkeys** 
 
 ### Web Push notifications
 
-Lurker supports background push notifications for highlights and DMs, delivered to your installed PWA even when the tab is closed. To enable:
+Lurker supports background push notifications for highlights and DMs, delivered to your installed PWA even when the tab is closed. (The [one-shot DigitalOcean deploy](README.md#deploy-on-digitalocean-one-shot) sets `VAPID_SUBJECT` for you.) To enable it elsewhere:
 
 1. Set a valid `VAPID_SUBJECT` (the contact address embedded in outgoing push JWTs — APNs requires a real domain):
 

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -12,24 +12,33 @@
 #
 #   * install Docker + the Compose plugin (skipped if already present, so
 #     this works on both the Docker Marketplace image and vanilla Ubuntu)
-#   * fetch Lurker and start it under Docker Compose
-#   * optionally front it with Caddy for automatic HTTPS (Let's Encrypt)
+#   * fetch Lurker, front it with Caddy for automatic HTTPS (Let's Encrypt),
+#     and start everything under Docker Compose
+#   * configure passkeys and web push — HTTPS makes both possible, so the
+#     instance comes up feature-complete with no post-install server admin
 #   * add a small swapfile on low-RAM droplets and configure the firewall
 #
 # Everything is logged to /var/log/lurker-deploy.log — view that from the
 # DigitalOcean droplet console if a deploy doesn't come up as expected.
 #
-# ─── Edit these two values before pasting ───────────────────────────────────
+# ─── Required: fill in BOTH values before pasting ───────────────────────────
+#
+# This deploy always serves Lurker over HTTPS. HTTPS isn't a nicety here — it
+# is what makes passkeys, web push, and secure browser sessions work — so
+# there is no plain-HTTP option, and both values below are required. The
+# script aborts if either is left blank.
 
-# Public domain for an HTTPS deployment, e.g. "irc.example.com".
-#   * Set it → Lurker is served over HTTPS via Caddy. The domain must
-#              already have a DNS A/AAAA record pointing at this droplet.
-#   * Empty  → Lurker is served over plain HTTP on port 8015.
+# The public domain Lurker will be served on, e.g. "irc.example.com".
+# Caddy obtains a Let's Encrypt certificate for it automatically. Once the
+# droplet exists, point a DNS A record for this domain at the droplet's IP
+# (the deploy log prints it); Caddy keeps retrying until that record resolves.
 LURKER_DOMAIN=""
 
-# Let's Encrypt contact address (used only when LURKER_DOMAIN is set).
-# Leave empty to default to admin@<LURKER_DOMAIN>.
-ACME_EMAIL=""
+# Your email address. It is used for two things, both of which need a real,
+# reachable address: the Let's Encrypt certificate contact (renewal and
+# expiry notices), and the contact embedded in web-push messages, which
+# Apple, Google, and Mozilla's push services require.
+ADMIN_EMAIL=""
 
 # ─── No edits needed below this line ────────────────────────────────────────
 
@@ -46,6 +55,25 @@ exec > >(tee -a "$DEPLOY_LOG") 2>&1
 log() { echo "[lurker-deploy $(date -u +%H:%M:%S)] $*"; }
 
 log "=== Lurker deploy started $(date -u +%FT%TZ) ==="
+
+# Both settings are mandatory. Fail early and loudly — before installing
+# anything — rather than half-deploying; the log is the only place this
+# message will surface, since cloud-init runs with no console.
+require_config() {
+  local missing=0
+  if [ -z "$LURKER_DOMAIN" ]; then
+    log "ERROR: LURKER_DOMAIN is empty — set it near the top of this script."
+    missing=1
+  fi
+  if [ -z "$ADMIN_EMAIL" ]; then
+    log "ERROR: ADMIN_EMAIL is empty — set it near the top of this script."
+    missing=1
+  fi
+  if [ "$missing" -ne 0 ]; then
+    log "Aborting: LURKER_DOMAIN and ADMIN_EMAIL are both required."
+    exit 1
+  fi
+}
 
 # ── Prerequisites ───────────────────────────────────────────────────────────
 
@@ -126,13 +154,13 @@ ensure_swap() {
   fi
 }
 
-# UFW: open SSH *first* so a bad rule can't lock us out, then the ports the
-# chosen deployment mode actually needs.
+# UFW: open SSH *first* so a bad rule can't lock us out, then HTTP/HTTPS for
+# Caddy. Lurker's own 8015 is never published on the host (the Caddy overlay
+# drops that binding), so it stays internal to the Docker network.
 #
 # Note: Docker publishes container ports straight into iptables, bypassing
-# UFW — so the real isolation of Lurker's 8015 in HTTPS mode comes from
-# docker-compose.caddy.yml dropping its host port binding, not from the
-# `ufw deny` below (kept only as belt-and-suspenders).
+# UFW — so the `ufw deny 8015` below is only belt-and-suspenders; the real
+# isolation comes from docker-compose.caddy.yml not binding 8015 at all.
 configure_firewall() {
   if ! command -v ufw >/dev/null 2>&1; then
     log "ufw not installed — skipping firewall configuration."
@@ -140,13 +168,9 @@ configure_firewall() {
   fi
   log "Configuring UFW firewall (SSH allowed first)..."
   ufw allow 22/tcp
-  if [ -n "$LURKER_DOMAIN" ]; then
-    ufw allow 80/tcp
-    ufw allow 443/tcp
-    ufw deny 8015/tcp
-  else
-    ufw allow 8015/tcp
-  fi
+  ufw allow 80/tcp
+  ufw allow 443/tcp
+  ufw deny 8015/tcp
   ufw --force enable
   ufw status verbose || true
 }
@@ -157,40 +181,29 @@ deploy() {
   mkdir -p "$INSTALL_DIR"
   cd "$INSTALL_DIR"
 
-  log "Fetching docker-compose.yml..."
+  log "Fetching compose files and Caddyfile..."
   curl -fsSL -o docker-compose.yml "$REPO_RAW/docker-compose.yml"
+  curl -fsSL -o docker-compose.caddy.yml "$REPO_RAW/docker-compose.caddy.yml"
+  curl -fsSL -o Caddyfile "$REPO_RAW/deploy/Caddyfile"
 
-  if [ -n "$LURKER_DOMAIN" ]; then
-    if [ -z "$ACME_EMAIL" ]; then
-      ACME_EMAIL="admin@${LURKER_DOMAIN}"
-    fi
-    log "LURKER_DOMAIN is set ($LURKER_DOMAIN) — deploying with Caddy + HTTPS."
-    curl -fsSL -o docker-compose.caddy.yml "$REPO_RAW/docker-compose.caddy.yml"
-    curl -fsSL -o Caddyfile "$REPO_RAW/deploy/Caddyfile"
-
-    # Compose interpolates LURKER_DOMAIN/ACME_EMAIL into docker-compose.caddy.yml
-    # (and Caddy reads them to fill the Caddyfile). COMPOSE_FILE records the
-    # overlay so plain `docker compose` commands — including future updates —
-    # pick up Caddy automatically, no `-f` flags needed.
-    cat > .env <<EOF
+  # Compose interpolates LURKER_DOMAIN/ADMIN_EMAIL into docker-compose.caddy.yml
+  # — Caddy reads them for TLS, Lurker reads them for passkeys and push.
+  # COMPOSE_FILE records the overlay so plain `docker compose` commands —
+  # including future `pull` + `up -d` updates — pick up Caddy automatically.
+  cat > .env <<EOF
 LURKER_DOMAIN=${LURKER_DOMAIN}
-ACME_EMAIL=${ACME_EMAIL}
+ADMIN_EMAIL=${ADMIN_EMAIL}
 COMPOSE_FILE=docker-compose.yml:docker-compose.caddy.yml
 EOF
 
-    compose pull
-    compose up -d
-    compose ps
-  else
-    log "LURKER_DOMAIN is empty — deploying plain HTTP on port 8015."
-    compose pull
-    compose up -d
-    compose ps
-  fi
+  compose pull
+  compose up -d
+  compose ps
 }
 
 # ── Run ─────────────────────────────────────────────────────────────────────
 
+require_config
 ensure_curl
 install_docker
 wait_for_docker
@@ -198,16 +211,13 @@ ensure_swap
 deploy
 configure_firewall
 
+PUBLIC_IP=$(curl -fsS --max-time 5 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address \
+  2>/dev/null || echo "this droplet's public IP")
+
 log "=== Lurker deploy finished $(date -u +%FT%TZ) ==="
-if [ -n "$LURKER_DOMAIN" ]; then
-  log "Lurker is running. If a DNS A record for ${LURKER_DOMAIN} isn't already"
-  log "pointing at this droplet's IP, add it now — Caddy retries Let's Encrypt"
-  log "until it resolves, then https://${LURKER_DOMAIN} serves over HTTPS."
-  log "Passkeys and web push are already configured for this HTTPS deploy —"
-  log "just opt in per device from Lurker's settings once you've signed in."
-else
-  PUBLIC_IP=$(curl -fsS --max-time 5 \
-    http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address \
-    2>/dev/null || echo "<droplet-ip>")
-  log "Open http://${PUBLIC_IP}:8015 and create your admin account."
-fi
+log "Lurker is running. Point a DNS A record for ${LURKER_DOMAIN} at"
+log "${PUBLIC_IP} if you haven't already — Caddy retries Let's Encrypt"
+log "until it resolves, then https://${LURKER_DOMAIN} serves over HTTPS."
+log "Passkeys and web push are pre-configured; once you've created your"
+log "admin account, opt in per device from Lurker's settings."

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -203,7 +203,8 @@ if [ -n "$LURKER_DOMAIN" ]; then
   log "Lurker is running. If a DNS A record for ${LURKER_DOMAIN} isn't already"
   log "pointing at this droplet's IP, add it now — Caddy retries Let's Encrypt"
   log "until it resolves, then https://${LURKER_DOMAIN} serves over HTTPS."
-  log "To enable passkeys / web push, see SELF_HOSTING.md (Optional features)."
+  log "Passkeys and web push are already configured for this HTTPS deploy —"
+  log "just opt in per device from Lurker's settings once you've signed in."
 else
   PUBLIC_IP=$(curl -fsS --max-time 5 \
     http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address \

--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -7,10 +7,10 @@
 #
 #   docker compose -f docker-compose.yml -f docker-compose.caddy.yml up -d
 #
-# Requires a `.env` file beside this compose defining LURKER_DOMAIN (and,
-# optionally, ACME_EMAIL), plus the Caddyfile from this repo's deploy/
-# directory saved next to it. Caddy obtains a Let's Encrypt certificate for
-# LURKER_DOMAIN automatically — the domain must already resolve to this host.
+# Requires a `.env` file beside this compose defining LURKER_DOMAIN and
+# ADMIN_EMAIL, plus the Caddyfile from this repo's deploy/ directory saved
+# next to it. Caddy obtains a Let's Encrypt certificate for LURKER_DOMAIN
+# automatically — the domain must already resolve to this host.
 #
 # deploy/digitalocean-cloud-init.sh wires all of this up unattended; see the
 # "Deploy on DigitalOcean" section of the README.
@@ -24,9 +24,11 @@ services:
       - '80:80'
       - '443:443'
     environment:
-      # Caddy substitutes these into the Caddyfile's {$VAR} placeholders.
+      # Caddy substitutes these into the Caddyfile's {$VAR} placeholders. The
+      # container var stays ACME_EMAIL (the Caddyfile reads {$ACME_EMAIL}); its
+      # value is the operator's ADMIN_EMAIL from the .env file.
       LURKER_DOMAIN: ${LURKER_DOMAIN}
-      ACME_EMAIL: ${ACME_EMAIL:-admin@${LURKER_DOMAIN}}
+      ACME_EMAIL: ${ADMIN_EMAIL}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
@@ -48,7 +50,7 @@ services:
       - WEBAUTHN_RP_ID=${LURKER_DOMAIN}
       - WEBAUTHN_RP_NAME=Lurker
       - WEBAUTHN_ORIGIN=https://${LURKER_DOMAIN}
-      - VAPID_SUBJECT=mailto:${ACME_EMAIL:-admin@${LURKER_DOMAIN}}
+      - VAPID_SUBJECT=mailto:${ADMIN_EMAIL}
 
 volumes:
   caddy_data:

--- a/docker-compose.caddy.yml
+++ b/docker-compose.caddy.yml
@@ -39,6 +39,16 @@ services:
     # the base file's `8015:8015` host binding is dropped here — Lurker is
     # then reachable only through Caddy, i.e. only over HTTPS.
     ports: !reset []
+    # A public domain with HTTPS is exactly what passkeys (WebAuthn) and web
+    # push need, so configure both here from the same .env values Caddy uses.
+    # An HTTPS deployment is then feature-complete with no further admin —
+    # users just opt in per device from Lurker's settings. These entries
+    # merge into the environment list from the base compose file.
+    environment:
+      - WEBAUTHN_RP_ID=${LURKER_DOMAIN}
+      - WEBAUTHN_RP_NAME=Lurker
+      - WEBAUTHN_ORIGIN=https://${LURKER_DOMAIN}
+      - VAPID_SUBJECT=mailto:${ACME_EMAIL:-admin@${LURKER_DOMAIN}}
 
 volumes:
   caddy_data:


### PR DESCRIPTION
Follow-up work on the DigitalOcean one-shot deploy, on the `more-do-fixes` branch.

## 1. Auto-configure passkeys & web push

The deploy already collects a public domain and a contact email, and an HTTPS deployment is the hard prerequisite for both passkeys and web push — yet the deploy previously left them unconfigured and told users to SSH in and set env vars by hand.

`docker-compose.caddy.yml` now sets, on the `lurker` service:

- `WEBAUTHN_RP_ID` = `${LURKER_DOMAIN}`
- `WEBAUTHN_RP_NAME` = `Lurker`
- `WEBAUTHN_ORIGIN` = `https://${LURKER_DOMAIN}`
- `VAPID_SUBJECT` = `mailto:${ADMIN_EMAIL}`

They live in the Caddy overlay, so they apply only to HTTPS deployments — which is correct, since neither feature works without HTTPS. `COOKIE_SECURE` is deliberately left off (Caddy terminates TLS and speaks plain HTTP to the container, so the `Secure` flag would break sessions).

## 2. HTTPS-only, with required configuration

The one-shot deploy's purpose is a *fully functioning* instance, so the degraded paths are gone:

- **No plain-HTTP option.** The deploy script always deploys behind Caddy with TLS — the plain-HTTP branch is removed from the deploy logic, firewall rules, and final message.
- **`LURKER_DOMAIN` and the email are required.** The script aborts early (logged — cloud-init is headless) if either is blank, instead of silently degrading.
- **`ACME_EMAIL` → `ADMIN_EMAIL`.** The email now feeds both the Let's Encrypt contact *and* the web-push VAPID subject, so the ACME-specific name no longer fits. The Caddy *container* var stays `ACME_EMAIL` (the Caddyfile reads `{$ACME_EMAIL}`); only the `.env` key and compose interpolation change.
- The closing log line now prints the droplet's public IP, so the operator has it ready for the DNS `A` record.

## Validation

- `docker compose -f docker-compose.yml -f docker-compose.caddy.yml config` — `ADMIN_EMAIL` resolves into Caddy's `ACME_EMAIL` and Lurker's `VAPID_SUBJECT`; the four passkey/push vars merge alongside the base environment.
- `require_config` aborts with exit 1 and a clear message on a blank value, passes when both are set.
- `bash -n` and `oxfmt --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
