### PR TITLE
Small wins: account username, /msg input, desktop right-click, toast flood

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -926,7 +926,12 @@ function toastSendFailure(error: string, body: string): void {
 function commitInput(raw: string, networkId: number, target: string): void {
   inputHistory.add(networkId, target, raw);
   socketSend({ type: 'input-history-add', networkId, target, text: raw });
-  text.value = '';
+  // Clear the draft for the buffer the send came FROM, addressed explicitly
+  // rather than through `text.value` (whose setter targets whatever buffer is
+  // active *now*). A command like `/msg nick text` calls buffers.activate()
+  // before we reach here, so writing through `text.value` would clear the new
+  // DM's draft and strand the command in the channel's input. See issue #4.
+  drafts.setLocal(networkId, target, '');
   // Empty the draft on the server immediately rather than waiting on the
   // debounce — otherwise a quick send + buffer-close race could leave the
   // row with the old body. flushBuffer drains the pending timer.

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -373,6 +373,10 @@ function menuContext(m: ChatMessage): MessageContext {
 }
 
 function onLineContextMenu(e: MouseEvent, m: ChatMessage | undefined) {
+  // Desktop keeps the browser's native right-click menu — message actions are
+  // reachable from the hover three-dots button. The in-app menu is a touch
+  // affordance, opened via long-press on mobile. See issue #20.
+  if (!isMobile.value) return;
   if (!eligibleForActions(m)) return;
   e.preventDefault();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/vue_client/src/components/settings-panes/AccountPane.vue
+++ b/vue_client/src/components/settings-panes/AccountPane.vue
@@ -6,6 +6,9 @@
 <template>
   <section id="account" class="settings-pane">
     <h2>account</h2>
+    <p v-if="auth.user" class="account-identity">
+      Signed in as <strong>{{ auth.user.username }}</strong>
+    </p>
     <p class="section-desc">
       You can sign in with a passkey, a password, or both. Removing your last sign-in method would
       lock you out, so it's blocked.
@@ -243,6 +246,14 @@ async function signOut() {
 
 <style src="./panes.css"></style>
 <style scoped>
+.account-identity {
+  margin: 0 0 12px;
+  color: var(--fg-muted);
+}
+.account-identity strong {
+  color: var(--fg);
+  font-weight: 600;
+}
 .passkey .ua input[type='text'] {
   width: 100%;
   background: transparent;

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -52,6 +52,24 @@ function pickKindKey(event: NotifyEvent): ToastKind | null {
   return null;
 }
 
+// Per-source notification throttle. A burst from one sender — the classic
+// case is ChanServ answering /HELP with a dozen back-to-back NOTICEs — should
+// land as a single toast + sound rather than a wall of them. Once a source
+// notifies, repeats from that same source within this window are dropped
+// outright (no queue). The key is per network + buffer + nick + kind, so
+// distinct senders are unaffected: two people pinging you still both fire.
+const NOTIFY_THROTTLE_MS = 3000;
+const lastNotifyAt = new Map<string, number>();
+
+function throttled(event: NotifyEvent, kind: ToastKind): boolean {
+  const key = `${event.networkId}::${event.target ?? ''}::${event.nick ?? '?'}::${kind}`;
+  const now = Date.now();
+  const prev = lastNotifyAt.get(key);
+  if (prev !== undefined && now - prev < NOTIFY_THROTTLE_MS) return true;
+  lastNotifyAt.set(key, now);
+  return false;
+}
+
 export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   if (!event || event.self) return;
   const kindKey = pickKindKey(event);
@@ -71,6 +89,9 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
 
   const settings = useSettingsStore();
   if (!settings.effective(`notifications.${kindKey}.enabled`)) return;
+
+  // Collapse a rapid burst from one source into a single toast + sound.
+  if (throttled(event, kindKey)) return;
 
   const networks = useNetworksStore();
   const toasts = useToastsStore();


### PR DESCRIPTION
A batch of four small, independent UX fixes.

## #12 — Account screen shows current username
The account settings pane never displayed who you were signed in as. Added a "Signed in as **<username>**" line at the top of the pane, sourced from the auth store (`auth.user.username`).

## #4 — `/msg` from a channel buffer does not clear input on send
`commitInput()` cleared the draft via `text.value = ''`, whose setter targets whatever buffer is *active*. But `/msg nick text` calls `buffers.activate()` to switch to the DM **before** `commitInput()` runs — so the clear hit the new DM's draft and left the `/msg …` command stranded in the channel's input. Now `commitInput()` clears the draft for the buffer the send actually came from, addressed explicitly by `(networkId, target)`.

## #20 — Desktop: message context menu takes over native right-click
`onLineContextMenu()` unconditionally called `preventDefault()` and opened the in-app menu, suppressing the browser's native right-click menu on desktop. The in-app menu is now a touch affordance only: on desktop, right-click falls through to the native menu, and message actions remain reachable via the hover three-dots button. Mobile long-press behavior is unchanged (gated on `useViewport().isMobile`).

## #3 — ChanServ HELP toast floods
A burst of NOTICEs from one sender (ChanServ answering `/HELP`) produced one toast + one sound per line. `notifyForEvent()` now throttles per source — keyed on network + buffer + nick + notification kind — dropping repeats within a 3s window. Distinct senders are unaffected, so two different people pinging you still both fire. Sounds are throttled alongside toasts.

## Testing
- `npm run check` (typecheck server + client, lint, format) — clean
- `npm test` — 535/535 pass

No automated coverage added — these are UI-level changes; manual QA recommended for each.

Closes #12
Closes #4
Closes #20
Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
