### PR TITLE
In-app toast + sound only for a visible tab on a non-active buffer

### DIFF
--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -205,6 +205,7 @@ import IgnoreModal from './IgnoreModal.vue';
 import { useMessageActions } from '../composables/useMessageActions.js';
 import type { MessageContext } from '../composables/useMessageActions.js';
 import { useLongPress } from '../composables/useLongPress.js';
+import { setViewedBuffer } from '../composables/useViewedBuffer.js';
 
 // Extended BufferMessage fields accessed in the template and script
 // (beyond the core BufferMessage definition which uses [key: string]: unknown).
@@ -1042,6 +1043,18 @@ function onScrollerResize() {
   el.scrollTop = el.scrollHeight;
 }
 
+// Report which buffer's messages are on screen so toast suppression can tell
+// "looking at this buffer" apart from networks.activeKey's looser "last-opened
+// buffer" (see useHighlightNotifier.shouldNotifyInApp). This component mounts
+// only while a buffer's messages are actually rendered, so its lifecycle is
+// the signal: follow activeKey while mounted, clear on unmount (Settings
+// route, mobile list/members screen, system console).
+watch(
+  () => networks.activeKey,
+  (key) => setViewedBuffer(key),
+  { immediate: true },
+);
+
 onMounted(() => {
   if (typeof ResizeObserver !== 'undefined' && scroller.value) {
     lastClientHeight = scroller.value.clientHeight;
@@ -1054,6 +1067,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  setViewedBuffer(null);
   if (scrollerObserver) {
     scrollerObserver.disconnect();
     scrollerObserver = null;

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -7,6 +7,10 @@
 // each signal type has its own master `enabled` toggle and sound sub-toggle in
 // settings, so toast/sound delivery is fully decoupled from how the signal
 // was generated. Settings are read live so quick-toggles take effect at once.
+//
+// Both toast and sound are skipped when the user is already focused on the
+// buffer the event belongs to — the message is in plain view, so an alert
+// would be redundant (see viewingEventBuffer).
 
 import { useToastsStore, type ToastKind } from '../stores/toasts.js';
 import { useSettingsStore } from '../stores/settings.js';
@@ -70,10 +74,29 @@ function throttled(event: NotifyEvent, kind: ToastKind): boolean {
   return false;
 }
 
+// True when the user is looking right at the buffer this event belongs to:
+// the Lurker window has OS focus AND the event's buffer is the active one.
+// The message is already materializing in plain view, so a toast + sound
+// would be pure noise — Discord and Slack mute the focused channel the same
+// way. Push is unaffected: it's gated server-side and only fires when the
+// user has no visible client at all (wsHub.maybePush), a strictly stronger
+// "absent" condition than this render-time "present" one. document.hasFocus()
+// (not just `!document.hidden`) is the signal because a visible-but-unfocused
+// tab — Lurker sitting behind another window — still warrants the toast.
+function viewingEventBuffer(event: NotifyEvent): boolean {
+  if (typeof document === 'undefined' || !document.hasFocus()) return false;
+  const networks = useNetworksStore();
+  return networks.activeKey === `${event.networkId}::${event.target}`;
+}
+
 export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   if (!event || event.self) return;
   const kindKey = pickKindKey(event);
   if (!kindKey) return;
+
+  // Already watching this conversation in a focused window → no toast, no
+  // sound. The message lands in view on its own (see viewingEventBuffer).
+  if (viewingEventBuffer(event)) return;
 
   // Ignored sender → no toast, no sound. Push is gated server-side in
   // wsHub.maybePush since push fires while no client is open and a

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -8,9 +8,8 @@
 // settings, so toast/sound delivery is fully decoupled from how the signal
 // was generated. Settings are read live so quick-toggles take effect at once.
 //
-// Both toast and sound are skipped when the user is already viewing the
-// event's buffer in the foreground tab/window — the message is in plain
-// view, so an alert would be redundant (see viewingEventBuffer).
+// The in-app toast + sound fire only for a visible tab on a buffer other than
+// the active one — see shouldNotifyInApp for the two cases that suppress them.
 
 import { useToastsStore, type ToastKind } from '../stores/toasts.js';
 import { useSettingsStore } from '../stores/settings.js';
@@ -74,24 +73,28 @@ function throttled(event: NotifyEvent, kind: ToastKind): boolean {
   return false;
 }
 
-// True when the user is already looking at the buffer this event belongs to:
-// the Lurker tab/window is in the foreground AND the event's buffer is the
-// active one. The message is materializing in plain view, so a toast + sound
-// would be redundant — Discord and Slack mute the focused channel the same
-// way. Push is unaffected: it's gated server-side and only fires when the
-// user has no visible client at all (wsHub.maybePush).
+// The in-app toast + sound only reach a user whose tab is in the foreground.
+// Two cases produce no in-app notification:
 //
-// "Foreground" is the Page Visibility API — the same signal usePresence
-// reports to the server and the push gate keys off, so toast suppression and
-// push delivery agree on what "present" means. document.hasFocus() would
-// additionally catch "Lurker visible but behind another window", but it has
-// no change event and is unreliable for installed PWAs (it can report a
-// backgrounded window as still focused), so we use the coarser but dependable
-// visibility signal instead.
-function viewingEventBuffer(event: NotifyEvent): boolean {
-  if (typeof document === 'undefined' || document.hidden) return false;
+//   - Tab hidden: a hidden tab can't render a toast, and browsers throttle or
+//     defer a background tab's audio — so this path would fire unreliably (the
+//     toast/sound only "catch up" when the tab is refocused). The server-side
+//     push owns the hidden case: wsHub.maybePush fires precisely when the user
+//     has no visible client. Letting the in-app path fire here too would just
+//     double up with push, badly.
+//   - Active buffer: the message is already materializing in plain view, so an
+//     alert would be redundant (issue #50) — Discord and Slack mute the
+//     focused channel the same way.
+//
+// Visibility is the Page Visibility API — the same signal usePresence reports
+// to the server — so the in-app path and the push path agree on "present" and
+// never both fire for one event. document.hasFocus() would also catch "Lurker
+// visible but behind another window", but it has no change event and is
+// unreliable for installed PWAs, so we use the dependable visibility signal.
+function shouldNotifyInApp(event: NotifyEvent): boolean {
+  if (typeof document !== 'undefined' && document.hidden) return false;
   const networks = useNetworksStore();
-  return networks.activeKey === `${event.networkId}::${event.target}`;
+  return networks.activeKey !== `${event.networkId}::${event.target}`;
 }
 
 export function notifyForEvent(event: NotifyEvent | null | undefined): void {
@@ -99,9 +102,9 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   const kindKey = pickKindKey(event);
   if (!kindKey) return;
 
-  // Already viewing this conversation in the foreground → no toast, no sound.
-  // The message lands in view on its own (see viewingEventBuffer).
-  if (viewingEventBuffer(event)) return;
+  // Toast + sound only for a visible tab on a non-active buffer: a hidden tab
+  // is the push path's job, and the active buffer is already in plain view.
+  if (!shouldNotifyInApp(event)) return;
 
   // Ignored sender → no toast, no sound. Push is gated server-side in
   // wsHub.maybePush since push fires while no client is open and a

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -8,8 +8,9 @@
 // settings, so toast/sound delivery is fully decoupled from how the signal
 // was generated. Settings are read live so quick-toggles take effect at once.
 //
-// The in-app toast + sound fire only for a visible tab on a buffer other than
-// the active one — see shouldNotifyInApp for the two cases that suppress them.
+// The in-app toast + sound fire only for a visible tab when the event's
+// buffer isn't the one on screen — see shouldNotifyInApp for the three cases
+// that suppress them.
 
 import { useToastsStore, type ToastKind } from '../stores/toasts.js';
 import { useSettingsStore } from '../stores/settings.js';
@@ -78,8 +79,8 @@ function throttled(event: NotifyEvent, kind: ToastKind): boolean {
 // and not already looking at the buffer the event belongs to. Three things
 // suppress them:
 //
-//   - No document: a non-browser context can't show a toast at all. Treated
-//     as not notifiable, matching usePresence.currentVisible().
+//   - No document: a non-browser context (SSR, tests) has no DOM to render a
+//     toast into, so this returns false — matching usePresence.currentVisible().
 //   - Tab hidden: a hidden tab can't render a toast, and browsers throttle or
 //     defer a background tab's audio — so this path would fire unreliably (the
 //     toast/sound only "catch up" when the tab is refocused). The server-side

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -15,6 +15,7 @@ import { useToastsStore, type ToastKind } from '../stores/toasts.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useIgnoresStore } from '../stores/ignores.js';
+import { viewedBuffer } from './useViewedBuffer.js';
 
 export interface NotifyEvent {
   self?: boolean;
@@ -73,28 +74,33 @@ function throttled(event: NotifyEvent, kind: ToastKind): boolean {
   return false;
 }
 
-// The in-app toast + sound only reach a user whose tab is in the foreground.
-// Two cases produce no in-app notification:
+// The in-app toast + sound only reach a user whose tab is in the foreground
+// and not already looking at the buffer the event belongs to. Three things
+// suppress them:
 //
+//   - No document: a non-browser context can't show a toast at all. Treated
+//     as not notifiable, matching usePresence.currentVisible().
 //   - Tab hidden: a hidden tab can't render a toast, and browsers throttle or
 //     defer a background tab's audio — so this path would fire unreliably (the
 //     toast/sound only "catch up" when the tab is refocused). The server-side
 //     push owns the hidden case: wsHub.maybePush fires precisely when the user
 //     has no visible client. Letting the in-app path fire here too would just
-//     double up with push, badly.
-//   - Active buffer: the message is already materializing in plain view, so an
-//     alert would be redundant (issue #50) — Discord and Slack mute the
+//     double up with push, badly. Visibility is the Page Visibility API — the
+//     same signal usePresence reports to the server — so the in-app and push
+//     paths agree on "present" and never both fire for one event.
+//   - Viewed buffer: the event's buffer is the one whose message list is on
+//     screen right now, so the message is already materializing in plain view
+//     and a toast would be redundant (issue #50) — Discord and Slack mute the
 //     focused channel the same way.
 //
-// Visibility is the Page Visibility API — the same signal usePresence reports
-// to the server — so the in-app path and the push path agree on "present" and
-// never both fire for one event. document.hasFocus() would also catch "Lurker
-// visible but behind another window", but it has no change event and is
-// unreliable for installed PWAs, so we use the dependable visibility signal.
+// "Viewed buffer" is viewedBuffer(), owned by MessageList — NOT networks
+// .activeKey. activeKey only tracks the last-opened buffer and lingers across
+// route / mobile-screen changes, so keying off it would wrongly suppress a
+// toast while the user sits on the Settings route or the mobile buffer list,
+// where no message list is mounted.
 function shouldNotifyInApp(event: NotifyEvent): boolean {
-  if (typeof document !== 'undefined' && document.hidden) return false;
-  const networks = useNetworksStore();
-  return networks.activeKey !== `${event.networkId}::${event.target}`;
+  if (typeof document === 'undefined' || document.hidden) return false;
+  return viewedBuffer() !== `${event.networkId}::${event.target}`;
 }
 
 export function notifyForEvent(event: NotifyEvent | null | undefined): void {
@@ -102,8 +108,9 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   const kindKey = pickKindKey(event);
   if (!kindKey) return;
 
-  // Toast + sound only for a visible tab on a non-active buffer: a hidden tab
-  // is the push path's job, and the active buffer is already in plain view.
+  // Toast + sound only when the tab is visible and the event's buffer isn't
+  // the one on screen — a hidden tab is the push path's job, and the viewed
+  // buffer is already in plain view. See shouldNotifyInApp.
   if (!shouldNotifyInApp(event)) return;
 
   // Ignored sender → no toast, no sound. Push is gated server-side in

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -8,9 +8,9 @@
 // settings, so toast/sound delivery is fully decoupled from how the signal
 // was generated. Settings are read live so quick-toggles take effect at once.
 //
-// Both toast and sound are skipped when the user is already focused on the
-// buffer the event belongs to — the message is in plain view, so an alert
-// would be redundant (see viewingEventBuffer).
+// Both toast and sound are skipped when the user is already viewing the
+// event's buffer in the foreground tab/window — the message is in plain
+// view, so an alert would be redundant (see viewingEventBuffer).
 
 import { useToastsStore, type ToastKind } from '../stores/toasts.js';
 import { useSettingsStore } from '../stores/settings.js';
@@ -74,17 +74,22 @@ function throttled(event: NotifyEvent, kind: ToastKind): boolean {
   return false;
 }
 
-// True when the user is looking right at the buffer this event belongs to:
-// the Lurker window has OS focus AND the event's buffer is the active one.
-// The message is already materializing in plain view, so a toast + sound
-// would be pure noise — Discord and Slack mute the focused channel the same
+// True when the user is already looking at the buffer this event belongs to:
+// the Lurker tab/window is in the foreground AND the event's buffer is the
+// active one. The message is materializing in plain view, so a toast + sound
+// would be redundant — Discord and Slack mute the focused channel the same
 // way. Push is unaffected: it's gated server-side and only fires when the
-// user has no visible client at all (wsHub.maybePush), a strictly stronger
-// "absent" condition than this render-time "present" one. document.hasFocus()
-// (not just `!document.hidden`) is the signal because a visible-but-unfocused
-// tab — Lurker sitting behind another window — still warrants the toast.
+// user has no visible client at all (wsHub.maybePush).
+//
+// "Foreground" is the Page Visibility API — the same signal usePresence
+// reports to the server and the push gate keys off, so toast suppression and
+// push delivery agree on what "present" means. document.hasFocus() would
+// additionally catch "Lurker visible but behind another window", but it has
+// no change event and is unreliable for installed PWAs (it can report a
+// backgrounded window as still focused), so we use the coarser but dependable
+// visibility signal instead.
 function viewingEventBuffer(event: NotifyEvent): boolean {
-  if (typeof document === 'undefined' || !document.hasFocus()) return false;
+  if (typeof document === 'undefined' || document.hidden) return false;
   const networks = useNetworksStore();
   return networks.activeKey === `${event.networkId}::${event.target}`;
 }
@@ -94,8 +99,8 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   const kindKey = pickKindKey(event);
   if (!kindKey) return;
 
-  // Already watching this conversation in a focused window → no toast, no
-  // sound. The message lands in view on its own (see viewingEventBuffer).
+  // Already viewing this conversation in the foreground → no toast, no sound.
+  // The message lands in view on its own (see viewingEventBuffer).
   if (viewingEventBuffer(event)) return;
 
   // Ignored sender → no toast, no sound. Push is gated server-side in

--- a/vue_client/src/composables/useViewedBuffer.ts
+++ b/vue_client/src/composables/useViewedBuffer.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The buffer key (`networkId::target`) whose message list is actually
+// rendered on screen right now, or null when none is. MessageList owns it:
+// it reports its buffer while mounted and clears it on unmount — so this is
+// null whenever MessageList isn't mounted, which covers the Settings route,
+// the mobile buffer-list / members screens, and the system console.
+//
+// Deliberately NOT networks.activeKey. activeKey only tracks the last-opened
+// buffer and lingers across route and mobile-screen changes, so it still
+// reads as "in view" while the user sits on Settings or the buffer list.
+// Toast suppression keys off this instead (useHighlightNotifier
+// .shouldNotifyInApp) so a highlight in the last-opened buffer still toasts
+// while that buffer's messages aren't actually on screen.
+//
+// A plain module variable (not a ref): the only reader, shouldNotifyInApp,
+// polls it imperatively when an event arrives — there's nothing to react to.
+let viewedBufferKey: string | null = null;
+
+export function setViewedBuffer(key: string | null): void {
+  viewedBufferKey = key;
+}
+
+export function viewedBuffer(): string | null {
+  return viewedBufferKey;
+}


### PR DESCRIPTION
Closes #50.

## What

In-app notification (the corner toast + its sound) now fires **only for a visible tab when the event's buffer is not the one whose message list is currently on screen**:

| State | In-app toast + sound | Notes |
|---|---|---|
| Tab visible, **another** buffer on screen | ✅ fires | normal case |
| Tab visible, the **event's** buffer on screen | ❌ suppressed | issue #50 — message is in plain view; Discord/Slack mute the focused channel the same way |
| Tab **hidden** | ❌ suppressed | server-side push owns this case |

## Why the hidden-tab case

A hidden tab previously still ran `notifyForEvent`: it pushed a toast (invisible — the browser doesn't paint a hidden tab) and called `playSound` (throttled/deferred by background-tab policy, so it only "catches up" when refocused). It also doubled up with the server-side push, which already owns the hidden case — `wsHub.maybePush` fires precisely when the user has no visible client. Lurker's notification design is a presence gate that picks **one** channel: visible → in-app toast/sound; not visible → push.

## How

A single `shouldNotifyInApp()` guard in `useHighlightNotifier.notifyForEvent()` returns early unless the tab is visible **and** the event's buffer isn't the one on screen.

- **Tab visibility** uses the Page Visibility API (`document.hidden`), not `document.hasFocus()` — `hasFocus()` has no change event and is unreliable for installed PWAs. Page Visibility is the same signal `usePresence` reports to the server, so the in-app path and the push path agree on what "present" means and never both fire for one event. No `document` at all is treated as not-notifiable, matching `usePresence.currentVisible()`.
- **"Buffer on screen"** uses a new `useViewedBuffer` module, *not* `networks.activeKey`. `activeKey` only tracks the last-*opened* buffer and lingers across route / mobile-screen changes — so keying off it would wrongly suppress a toast while the user is on the Settings route or the mobile buffer-list / members screens, where no message list is mounted. `MessageList` mounts only while a buffer's messages are actually rendered, so it owns `viewedBuffer`: follows `activeKey` while mounted, clears on unmount.
- The guard sits before the throttle check, so a suppressed event doesn't consume a throttle slot.

## Known limitations

- A tab that is *visible but sitting behind another window* still counts as "present." No reliable web API distinguishes that case (`hasFocus()` would, but it's the unreliable one).
- A full-screen modal open over the chat leaves `MessageList` mounted, so a toast for the on-screen buffer is still suppressed while the modal covers it. Minor — modals are transient and the message is right there on dismiss.

## Testing

- `npm run typecheck:client`, `npm run lint`, `npm run format:check` — all clean
- `npm test` — 535/535 pass

No client-side composable test harness exists (client tests cover pure utils only), so this is verified via typecheck + the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
