### PR TITLE
Exclude URLs from highlight word matching

### DIFF
--- a/server/services/highlightEngine.test.ts
+++ b/server/services/highlightEngine.test.ts
@@ -102,6 +102,51 @@ describe('matchEvent — glob rules', () => {
   });
 });
 
+describe('matchEvent — URL exclusion', () => {
+  it('does not match a word that appears only inside a URL', () => {
+    const compiled = compileRules([rule({ pattern: 'amiantos' })]);
+    expect(matchEvent(event({ text: 'see https://amiantos.net for info' }), compiled).matched).toBe(
+      false,
+    );
+  });
+
+  it('does not match a word inside a URL path or query', () => {
+    const compiled = compileRules([rule({ pattern: 'amiantos' })]);
+    expect(
+      matchEvent(event({ text: 'https://example.com/users/amiantos' }), compiled).matched,
+    ).toBe(false);
+    expect(matchEvent(event({ text: 'https://example.com/?u=amiantos' }), compiled).matched).toBe(
+      false,
+    );
+  });
+
+  it('still matches the word when it also appears outside a URL', () => {
+    const compiled = compileRules([rule({ pattern: 'amiantos' })]);
+    expect(
+      matchEvent(event({ text: 'hey amiantos see https://amiantos.net' }), compiled).matched,
+    ).toBe(true);
+  });
+
+  it('ignores words inside www. hosts and bare emails', () => {
+    const compiled = compileRules([rule({ pattern: 'amiantos' })]);
+    expect(matchEvent(event({ text: 'visit www.amiantos.net' }), compiled).matched).toBe(false);
+    expect(matchEvent(event({ text: 'mail amiantos@example.com' }), compiled).matched).toBe(false);
+  });
+
+  it('replaces a stripped URL with whitespace so neighbours cannot fuse', () => {
+    const compiled = compileRules([rule({ pattern: 'amiantos' })]);
+    // 'ami' + URL + 'antos' must not collapse into 'amiantos' once the URL goes.
+    expect(matchEvent(event({ text: 'ami https://x.com antos' }), compiled).matched).toBe(false);
+  });
+
+  it('applies to glob and regex rules too', () => {
+    const glob = compileRules([rule({ kind: 'glob', pattern: 'ami*os' })]);
+    expect(matchEvent(event({ text: 'https://amiantos.net' }), glob).matched).toBe(false);
+    const regex = compileRules([rule({ kind: 'regex', pattern: 'amiantos' })]);
+    expect(matchEvent(event({ text: 'https://amiantos.net' }), regex).matched).toBe(false);
+  });
+});
+
 describe('matchEvent — eligibility gating', () => {
   it('does not match self-authored events', () => {
     const compiled: CompiledRule[] = compileRules([rule()]);

--- a/server/services/highlightEngine.ts
+++ b/server/services/highlightEngine.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import { createUrlRegex } from '../../shared/urlPattern.js';
+
 const ELIGIBLE_TYPES = new Set(['message', 'action']);
 
 interface HighlightRule {
@@ -66,6 +68,16 @@ export function compileRules(rules: HighlightRule[]): CompiledRule[] {
   return compiled;
 }
 
+// Blank out URLs before matching so a highlight word inside a link — e.g. a
+// nick that happens to appear in `https://example.com/nick` — doesn't trigger
+// a highlight. The URL is replaced with a space (not removed) so the words on
+// either side can't fuse into a false match. Uses the same URL definition the
+// client uses to auto-link, so "renders as a link" and "ignored for
+// highlights" stay in lockstep.
+function stripUrls(text: string): string {
+  return text.replace(createUrlRegex(), ' ');
+}
+
 export function matchEvent(
   event: MatchableEvent | null | undefined,
   compiled: CompiledRule[],
@@ -74,8 +86,9 @@ export function matchEvent(
   if (event.self) return { matched: false, ruleId: null };
   const text = event.text || '';
   if (!text) return { matched: false, ruleId: null };
+  const cleaned = stripUrls(text);
   for (const { id, test } of compiled) {
-    if (test(text)) return { matched: true, ruleId: id };
+    if (test(cleaned)) return { matched: true, ruleId: id };
   }
   return { matched: false, ruleId: null };
 }

--- a/server/services/highlightEngine.ts
+++ b/server/services/highlightEngine.ts
@@ -82,6 +82,9 @@ export function matchEvent(
   event: MatchableEvent | null | undefined,
   compiled: CompiledRule[],
 ): { matched: boolean; ruleId: number | null } {
+  // Cheapest guard first: with no rules there is nothing to match, so skip
+  // the eligibility checks and URL-stripping work entirely.
+  if (compiled.length === 0) return { matched: false, ruleId: null };
   if (!event || !ELIGIBLE_TYPES.has(event.type)) return { matched: false, ruleId: null };
   if (event.self) return { matched: false, ruleId: null };
   const text = event.text || '';

--- a/shared/urlPattern.test.ts
+++ b/shared/urlPattern.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { createUrlRegex } from './urlPattern.js';
+
+// Collect every URL the shared regex finds in a string.
+function urls(text: string): string[] {
+  return text.match(createUrlRegex()) ?? [];
+}
+
+describe('createUrlRegex', () => {
+  it('matches http(s) and ftp(s) URLs', () => {
+    expect(urls('see https://example.com/path here')).toEqual(['https://example.com/path']);
+    expect(urls('grab ftp://files.example.org/x and ftps://s.example.org')).toEqual([
+      'ftp://files.example.org/x',
+      'ftps://s.example.org',
+    ]);
+  });
+
+  it('matches bare www. hosts and mailto: links', () => {
+    expect(urls('visit www.example.com today')).toEqual(['www.example.com']);
+    expect(urls('write mailto:hi@example.com now')).toEqual(['mailto:hi@example.com']);
+  });
+
+  it('matches bare email addresses with a real TLD', () => {
+    expect(urls('mail bob@example.com please')).toEqual(['bob@example.com']);
+  });
+
+  it('does not match IRC-style host masks with no TLD', () => {
+    // `nick@server` has no dotted TLD — it must not be mistaken for an email.
+    expect(urls('kicked nick@server for spam')).toEqual([]);
+  });
+
+  it('stops a URL at whitespace and angle brackets', () => {
+    expect(urls('a https://example.com b')).toEqual(['https://example.com']);
+    expect(urls('<https://example.com>')).toEqual(['https://example.com']);
+  });
+
+  it('finds multiple URLs in one string', () => {
+    expect(urls('https://a.example and https://b.example')).toEqual([
+      'https://a.example',
+      'https://b.example',
+    ]);
+  });
+
+  it('is case-insensitive on the scheme', () => {
+    expect(urls('HTTPS://Example.com')).toEqual(['HTTPS://Example.com']);
+  });
+
+  it('returns a fresh, non-shared regex each call', () => {
+    const a = createUrlRegex();
+    const b = createUrlRegex();
+    expect(a).not.toBe(b);
+    // Advancing one instance's lastIndex must not leak into the other.
+    a.exec('https://example.com');
+    expect(a.lastIndex).toBeGreaterThan(0);
+    expect(b.lastIndex).toBe(0);
+  });
+});

--- a/shared/urlPattern.ts
+++ b/shared/urlPattern.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared URL detection. Pure, no DOM/Node deps — safe to import from the Vue
+// renderer and the Node server alike. Two consumers rely on the *same*
+// definition so they stay consistent:
+//   - vue_client/src/utils/nickColor.ts — auto-links URLs in rendered messages
+//   - server/services/highlightEngine.ts — excludes URLs from highlight word
+//     matching, so a nick appearing inside a link doesn't trigger a highlight
+//
+// Covers http(s)/ftp(s)/mailto, bare www.* hosts, and bare email addresses.
+// The body of a scheme/www match is "everything that isn't whitespace or an
+// HTML-ish bracket". The email branch requires a real TLD (2+ letters) to
+// avoid matching IRC-style host masks like `nick@server`.
+export const URL_PATTERN_SOURCE =
+  '(?:(?:https?|ftps?):\\/\\/|mailto:|www\\.)[^\\s<>`]+' +
+  '|\\b[A-Za-z0-9][A-Za-z0-9._%+-]*@[A-Za-z0-9][A-Za-z0-9.-]*\\.[A-Za-z]{2,}\\b';
+
+// A fresh regex per call — the `g` flag makes RegExp stateful via lastIndex,
+// so a shared instance can't be reused safely across calls.
+export function createUrlRegex(): RegExp {
+  return new RegExp(URL_PATTERN_SOURCE, 'gi');
+}

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import { createUrlRegex } from '../../../shared/urlPattern.js';
+
 // Deterministic nick coloring. Mirrors weechat's gui_nick_find_color:
 // trim stop chars, lowercase, hash, modulo a palette.
 //
@@ -54,18 +56,10 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-// URL detection. Covers http(s)/ftp(s)/mailto, bare www.* hosts, and bare
-// email addresses (turned into mailto: links by urlHref).
-// The body of a scheme/www match is "everything that isn't whitespace or an
-// HTML-ish bracket"; trimUrlTail then strips trailing sentence punctuation so
+// URL detection lives in shared/urlPattern.ts so the server's highlight
+// engine can exclude links from highlight matching using the same definition.
+// trimUrlTail (below) then strips trailing sentence punctuation so
 // "see https://example.com." doesn't keep the period.
-// The email branch requires a real TLD (2+ letters) to avoid linking
-// IRC-style host masks like `nick@server`.
-const URL_RE = new RegExp(
-  '(?:(?:https?|ftps?):\\/\\/|mailto:|www\\.)[^\\s<>`]+' +
-    '|\\b[A-Za-z0-9][A-Za-z0-9._%+-]*@[A-Za-z0-9][A-Za-z0-9.-]*\\.[A-Za-z]{2,}\\b',
-  'gi',
-);
 
 // Strip trailing punctuation that's almost certainly part of the surrounding
 // sentence rather than the URL. Closing brackets are only stripped when they'd
@@ -125,7 +119,7 @@ type UrlOrTextSegment = UrlSegment | TextSegment;
 function splitTextByUrls(text: string): UrlOrTextSegment[] {
   const out: UrlOrTextSegment[] = [];
   if (!text) return out;
-  const re = new RegExp(URL_RE.source, 'gi');
+  const re = createUrlRegex();
   let lastIdx = 0;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {


### PR DESCRIPTION
Closes #6.

## Problem

Highlight rules matched any word at a non-word (`\W`) boundary. URL characters — `/`, `:`, `.`, `?` — all count as `\W`, so a nick appearing inside a link (e.g. `https://example.com/nick`) triggered a self-highlight.

## Fix

Strip URLs from message text before running highlight rules.

The issue floated "only match words surrounded by spaces", but that would break the most common legitimate case — IRC addressing (`nick: hello` has a colon, not a space, after the nick). Stripping URLs targets the actual bug precisely: links are ignored, while a word with adjacent punctuation elsewhere still highlights.

The URL is replaced with a space (not removed) so words on either side can't fuse into a false match.

## Shared URL definition

The URL regex moves to `shared/urlPattern.ts`, imported by both:

- `server/services/highlightEngine.ts` — excludes URLs from highlight matching
- `vue_client/src/utils/nickColor.ts` — auto-links URLs in rendered messages

One source of truth keeps "renders as a link" and "ignored for highlights" in lockstep.

## Design note

URL stripping applies to **all** rule kinds, including `regex`. A power-user regex intentionally matching URLs would be affected, but that's a near-zero case and per-kind branching wasn't worth the complexity. Easy to revisit.

## Tests

- `highlightEngine.test.ts` (+6) — word only inside a URL, word in URL path/query, word still matching outside a URL when one is present, `www.`/bare-email hosts, no word-fusing after stripping, glob + regex kinds.
- `shared/urlPattern.test.ts` (+8, new) — pins the shared regex contract: scheme/`www.`/`mailto:`/email matching, the `nick@server` host-mask exclusion, multiple URLs, whitespace/bracket boundaries, case-insensitivity, fresh-instance guarantee.

14 new tests, all passing. Full suite (541 tests), server + client typecheck, lint, format, and client build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)