### PR TITLE
Add mIRC background colours and spoiler support (#5)

### DIFF
--- a/vue_client/src/components/HistoryMessageRow.vue
+++ b/vue_client/src/components/HistoryMessageRow.vue
@@ -26,7 +26,7 @@
     <div class="body">
       <span class="nick" :style="nickStyle">{{ message.nick }}</span>
       <span class="sep">|</span>
-      <span class="text">{{ message.text }}</span>
+      <span class="text"><LinkedText :text="message.text ?? ''" /></span>
     </div>
     <button
       v-if="removable"
@@ -48,6 +48,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { formatTimestamp, formatDate } from '../utils/timestamp.js';
+import LinkedText from './LinkedText.vue';
 
 // Shared row shape from search/highlights/bookmarks. All callers pass at
 // minimum { id, networkId, target, nick, time, text }; `self` and

--- a/vue_client/src/components/KeyboardHelpModal.vue
+++ b/vue_client/src/components/KeyboardHelpModal.vue
@@ -54,6 +54,7 @@ const shortcuts = computed<ShortcutRow[]>(() => [
   { keys: [MOD, 'B'], label: 'Bold (wraps selection with mIRC code)' },
   { keys: [MOD, 'I'], label: 'Italic (wraps selection with mIRC code)' },
   { keys: [MOD, 'U'], label: 'Underline (wraps selection with mIRC code)' },
+  { keys: ['||text||'], label: 'Spoiler — hidden until clicked' },
   { keys: [MOD, '/'], label: 'Show this help panel' },
 ]);
 </script>

--- a/vue_client/src/components/LinkedText.vue
+++ b/vue_client/src/components/LinkedText.vue
@@ -5,8 +5,9 @@
 
 <template>
   <template v-for="(seg, i) in segments" :key="i">
+    <SpoilerText v-if="seg.spoiler" :seg="seg" />
     <a
-      v-if="seg.url"
+      v-else-if="seg.url"
       class="msg-link"
       :href="seg.url"
       target="_blank"
@@ -24,6 +25,7 @@ import { computed } from 'vue';
 import type { CSSProperties } from 'vue';
 import type { RenderSegment } from '../utils/nickColor.js';
 import { splitTextByTokens, segmentInlineStyle, segmentHasStyle } from '../utils/nickColor.js';
+import SpoilerText from './SpoilerText.vue';
 
 // Renders a plain-text string with URLs auto-linked and IRC formatting
 // (bold/italic/underline/strike + mIRC fg colours) applied. Used by every

--- a/vue_client/src/components/LinkedText.vue
+++ b/vue_client/src/components/LinkedText.vue
@@ -4,35 +4,21 @@
 -->
 
 <template>
-  <template v-for="(seg, i) in segments" :key="i">
-    <SpoilerText v-if="seg.spoiler" :seg="seg" />
-    <a
-      v-else-if="seg.url"
-      class="msg-link"
-      :href="seg.url"
-      target="_blank"
-      rel="noreferrer noopener"
-      :style="styleFor(seg)"
-      >{{ seg.text }}</a
-    >
-    <span v-else-if="hasStyle(seg)" :style="styleFor(seg)">{{ seg.text }}</span>
-    <template v-else>{{ seg.text }}</template>
-  </template>
+  <RenderSegments :segments="segments" />
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { CSSProperties } from 'vue';
-import type { RenderSegment } from '../utils/nickColor.js';
-import { splitTextByTokens, segmentInlineStyle, segmentHasStyle } from '../utils/nickColor.js';
-import SpoilerText from './SpoilerText.vue';
+import { splitTextByTokens } from '../utils/nickColor.js';
+import RenderSegments from './RenderSegments.vue';
 
 // Renders a plain-text string with URLs auto-linked and IRC formatting
-// (bold/italic/underline/strike + mIRC fg colours) applied. Used by every
-// line type in MessageList that doesn't go through nick coloring (motd,
-// errors, part reasons, etc.) and by the topic bar in Chat.vue. Lines that
-// DO get nick coloring (message/notice/action) call splitTextByTokens
-// directly with a real nickSet.
+// (bold/italic/underline/strike + mIRC fg/bg colours + spoilers) applied.
+// Used by every line type in MessageList that doesn't go through nick
+// coloring (motd, errors, part reasons, etc.) and by the topic bar. Lines
+// that DO get nick coloring (message/notice/action) build their segments
+// with a real nickSet and hand them straight to RenderSegments — the actual
+// segment rendering is shared, only the splitting differs.
 const props = withDefaults(
   defineProps<{
     text?: string;
@@ -41,10 +27,4 @@ const props = withDefaults(
 );
 
 const segments = computed(() => splitTextByTokens(props.text, null, null, null));
-function styleFor(seg: RenderSegment): CSSProperties {
-  return segmentInlineStyle(seg, null) as CSSProperties;
-}
-function hasStyle(seg: RenderSegment) {
-  return segmentHasStyle(seg);
-}
 </script>

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -67,7 +67,7 @@
     <MircColorPicker
       v-if="showFormatButton"
       :open="colorPickerOpen"
-      @color="onPickColor"
+      @apply="onApplyColor"
       @reset="onPickReset"
       @close="closeColorPicker"
     />
@@ -115,6 +115,7 @@ import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
 import { requestScrollToBottom } from '../composables/useScrollState.js';
 import { setComposingState } from '../composables/useComposing.js';
 import { chunkCountForSay, chunkCountForAction } from '../utils/messageSplit.js';
+import { applySpoilerMarkup } from '../utils/spoilerMarkup.js';
 import { buildNickCandidates } from '../utils/nickCompletion.js';
 import NickPicker from './NickPicker.vue';
 import NickSuggestionStrip from './NickSuggestionStrip.vue';
@@ -244,9 +245,11 @@ const longMessageUploading = ref(false);
 function bodyForSplit(raw: string): { body: string; isAction: boolean } {
   if (!raw) return { body: '', isAction: false };
   // // escape: `//foo` is a literal `/foo` message, not a command, so it does
-  // pass through PRIVMSG and is subject to the splitter.
-  if (raw.startsWith('//')) return { body: raw.slice(1), isAction: false };
-  if (raw[0] !== '/') return { body: raw, isAction: false };
+  // pass through PRIVMSG and is subject to the splitter. Plain and //-escaped
+  // messages also get the `||spoiler||` rewrite on send, so count the
+  // post-rewrite bytes here or the split estimate drifts low.
+  if (raw.startsWith('//')) return { body: applySpoilerMarkup(raw.slice(1)), isAction: false };
+  if (raw[0] !== '/') return { body: applySpoilerMarkup(raw), isAction: false };
   const m = raw.match(/^\/(\w+)\s*(.*)$/s);
   if (!m) return { body: '', isAction: false };
   const cmd = m[1].toLowerCase();
@@ -514,11 +517,16 @@ function closeColorPicker() {
   colorPickerOpen.value = false;
 }
 
-function onPickColor(code: string): void {
-  // `code` is a 2-digit string ("00".."15"). A bare \x03 with no digits would
-  // close any open colour run, but for a deliberate pick we always emit
-  // digits so the colour actually takes effect.
-  wrapOrInsertFormatting(FMT_COLOR + code, FMT_COLOR);
+function onApplyColor(fg: string | null, bg: string | null): void {
+  // `fg`/`bg` are 2-digit codes ("00".."15") staged in the picker, either of
+  // which may be null. Build one \x03 code from them: with both set the text
+  // keeps the chosen foreground over the chosen background; a background-only
+  // pick emits foreground 99 (mIRC "default") so just the background fills in.
+  let opening: string;
+  if (fg && bg) opening = `${FMT_COLOR}${fg},${bg}`;
+  else if (fg) opening = FMT_COLOR + fg;
+  else opening = `${FMT_COLOR}99,${bg}`;
+  wrapOrInsertFormatting(opening, FMT_COLOR);
   closeColorPicker();
 }
 
@@ -1064,7 +1072,10 @@ async function submit() {
 
   if (!sendable.value) return;
 
-  const wireText = escapedSlash ? raw.slice(1) : raw;
+  // Rewrite `||spoiler||` into IRC spoiler codes on the way out. History keeps
+  // the typed `||…||` form (commitInput is given `raw`), so up-arrow
+  // round-trips the editable text rather than raw control codes.
+  const wireText = applySpoilerMarkup(escapedSlash ? raw.slice(1) : raw);
   const pending = socketSendWithAck({ type: 'send', networkId, target, text: wireText });
   if (!pending) {
     // Socket isn't open — don't clear the input, don't pollute history. The

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -102,8 +102,9 @@
           <span class="body" :class="bodyClass(row.m)">
             <template v-if="hasInlineText(row.m)">
               <template v-for="(seg, j) in textSegments(row.m)" :key="j">
+                <SpoilerText v-if="seg.spoiler" :seg="seg" />
                 <a
-                  v-if="seg.url"
+                  v-else-if="seg.url"
                   class="msg-link"
                   :href="seg.url"
                   target="_blank"
@@ -201,6 +202,7 @@ import type { ConsolidationGroup, NickEntry, RenameEntry } from '../../../shared
 import { collapseDisplay } from '../utils/collapseDisplay.js';
 import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';
+import SpoilerText from './SpoilerText.vue';
 import IgnoreModal from './IgnoreModal.vue';
 import { useMessageActions } from '../composables/useMessageActions.js';
 import type { MessageContext } from '../composables/useMessageActions.js';

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -75,20 +75,7 @@
             }}</span>
           </div>
           <span class="body" :class="bodyClass(row.m)">
-            <template v-for="(seg, j) in textSegments(row.m)" :key="j">
-              <SpoilerText v-if="seg.spoiler" :seg="seg" />
-              <a
-                v-else-if="seg.url"
-                class="msg-link"
-                :href="seg.url"
-                target="_blank"
-                rel="noreferrer noopener"
-                :style="segStyle(seg)"
-                >{{ seg.text }}</a
-              >
-              <span v-else-if="segHasStyle(seg)" :style="segStyle(seg)">{{ seg.text }}</span>
-              <template v-else>{{ seg.text }}</template>
-            </template>
+            <RenderSegments :segments="textSegments(row.m)" :self-color="selfColor" />
           </span>
           <span class="time">{{ row.continuationTime ? '' : time(row.m?.time) }}</span>
         </template>
@@ -101,22 +88,11 @@
             >{{ row.continuationAuthor ? '' : prefixText(row.m) }}</span
           >
           <span class="body" :class="bodyClass(row.m)">
-            <template v-if="hasInlineText(row.m)">
-              <template v-for="(seg, j) in textSegments(row.m)" :key="j">
-                <SpoilerText v-if="seg.spoiler" :seg="seg" />
-                <a
-                  v-else-if="seg.url"
-                  class="msg-link"
-                  :href="seg.url"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  :style="segStyle(seg)"
-                  >{{ seg.text }}</a
-                >
-                <span v-else-if="segHasStyle(seg)" :style="segStyle(seg)">{{ seg.text }}</span>
-                <template v-else>{{ seg.text }}</template>
-              </template>
-            </template>
+            <RenderSegments
+              v-if="hasInlineText(row.m)"
+              :segments="textSegments(row.m)"
+              :self-color="selfColor"
+            />
             <template v-else-if="row.m?.type === 'join'"
               ><NickRef :nick="row.m.nick ?? ''" /> joined</template
             >
@@ -196,14 +172,13 @@ import {
   useScrollState,
 } from '../composables/useScrollState.js';
 import type { RenderSegment } from '../utils/nickColor.js';
-import { segmentInlineStyle, segmentHasStyle } from '../utils/nickColor.js';
 import { formatTimestamp, formatDuration, formatDate, formatDayLabel } from '../utils/timestamp.js';
 import { consolidateRows } from '../utils/consolidate.js';
 import type { ConsolidationGroup, NickEntry, RenameEntry } from '../../../shared/consolidate.js';
 import { collapseDisplay } from '../utils/collapseDisplay.js';
 import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';
-import SpoilerText from './SpoilerText.vue';
+import RenderSegments from './RenderSegments.vue';
 import IgnoreModal from './IgnoreModal.vue';
 import { useMessageActions } from '../composables/useMessageActions.js';
 import type { MessageContext } from '../composables/useMessageActions.js';
@@ -276,7 +251,9 @@ const nicks = useNickColors();
 const { isMobile } = useViewport();
 
 const actionItalic = computed(() => !!settings.effective('look.action.italic'));
-const selfColor = computed(() => settings.effective('look.nick.self_color'));
+const selfColor = computed<string | null>(
+  () => (settings.effective('look.nick.self_color') as string | undefined) ?? null,
+);
 // Compact mode uses its own format setting so users can run the per-line
 // time column at lower precision (default HH:mm) without affecting their
 // standard-layout timestamps. Note: `tsFormat` is referenced via `time()`
@@ -719,13 +696,6 @@ function textSegments(m: ChatMessage | undefined): RenderSegment[] {
     ) as RenderSegment[];
   }
   return nicks.splitText(m.text || '', nickSet.value, selfLower.value) as RenderSegment[];
-}
-
-function segStyle(seg: RenderSegment): CSSProperties {
-  return segmentInlineStyle(seg, selfColor.value as string | null) as CSSProperties;
-}
-function segHasStyle(seg: RenderSegment) {
-  return segmentHasStyle(seg);
 }
 
 // Template helpers for consolidation row items — vue-tsc can't narrow

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -76,8 +76,9 @@
           </div>
           <span class="body" :class="bodyClass(row.m)">
             <template v-for="(seg, j) in textSegments(row.m)" :key="j">
+              <SpoilerText v-if="seg.spoiler" :seg="seg" />
               <a
-                v-if="seg.url"
+                v-else-if="seg.url"
                 class="msg-link"
                 :href="seg.url"
                 target="_blank"

--- a/vue_client/src/components/MircColorPicker.vue
+++ b/vue_client/src/components/MircColorPicker.vue
@@ -10,19 +10,60 @@
          soft keyboard stays up while the user picks a colour. Action fires on
          `click` (end of touch), not pointerdown, so closing the popover
          mid-touch can't redirect the second event to whatever's underneath. -->
+    <!-- The picker stages a foreground and a background and stays open while
+         it does, so both can be set before "apply" inserts one combined
+         \x03fg,bg code. Picking a swatch fills whichever slot is selected. -->
+    <div class="row slots">
+      <div
+        role="button"
+        class="slot"
+        :class="{ active: slot === 'fg' }"
+        :aria-pressed="slot === 'fg'"
+        title="Pick the text colour"
+        @mousedown.prevent
+        @click="slot = 'fg'"
+      >
+        <span class="chip" :style="chipStyle(staged.fg)"></span>
+        fg
+      </div>
+      <div
+        role="button"
+        class="slot"
+        :class="{ active: slot === 'bg' }"
+        :aria-pressed="slot === 'bg'"
+        title="Pick the background colour"
+        @mousedown.prevent
+        @click="slot = 'bg'"
+      >
+        <span class="chip" :style="chipStyle(staged.bg)"></span>
+        bg
+      </div>
+    </div>
     <div class="swatch-grid">
       <div
         v-for="entry in swatches"
         :key="entry.code"
         role="button"
         class="swatch"
+        :class="{ picked: staged[slot] === entry.code }"
         :style="{ backgroundColor: entry.hex }"
         :title="`mIRC ${entry.code}`"
         @mousedown.prevent
-        @click="emit('color', entry.code)"
+        @click="pick(entry.code)"
       ></div>
     </div>
     <div class="row">
+      <div
+        role="button"
+        class="action apply"
+        :class="{ disabled: !hasPick }"
+        :aria-disabled="!hasPick"
+        title="Insert the picked colour"
+        @mousedown.prevent
+        @click="apply"
+      >
+        apply
+      </div>
       <div
         role="button"
         class="action"
@@ -40,6 +81,11 @@
 </template>
 
 <script setup lang="ts">
+import { ref, reactive, computed, watch } from 'vue';
+
+// 'fg' is the text colour slot, 'bg' the background colour slot.
+type ColorTarget = 'fg' | 'bg';
+
 // The 16-color palette here mirrors MIRC_PALETTE in utils/nickColor.js — those
 // are the only codes our renderer styles, so anything outside 0-15 wouldn't
 // round-trip visibly anyway.
@@ -62,7 +108,7 @@ const PALETTE = [
   { code: '15', hex: '#d2d2d2' },
 ];
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     open?: boolean;
   }>(),
@@ -70,12 +116,49 @@ withDefaults(
 );
 
 const emit = defineEmits<{
-  color: [code: string];
+  // The staged foreground / background codes ("00".."15"), either of which
+  // may be null when that slot was left untouched.
+  apply: [fg: string | null, bg: string | null];
   reset: [];
   close: [];
 }>();
 
 const swatches = PALETTE;
+const slot = ref<ColorTarget>('fg');
+const staged = reactive<{ fg: string | null; bg: string | null }>({ fg: null, bg: null });
+const hasPick = computed(() => !!staged.fg || !!staged.bg);
+
+// A fresh open starts with nothing staged — last session's picks shouldn't
+// silently ride along into the next message.
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (!isOpen) return;
+    staged.fg = null;
+    staged.bg = null;
+    slot.value = 'fg';
+  },
+);
+
+// A filled chip when the slot holds a colour, a hollow one (border only) when
+// it doesn't — so the slot buttons double as a preview of the staged colour.
+function chipStyle(code: string | null): Record<string, string> {
+  const hex = code ? PALETTE.find((p) => p.code === code)?.hex : undefined;
+  return hex ? { backgroundColor: hex } : {};
+}
+
+function pick(code: string): void {
+  staged[slot.value] = code;
+  // After choosing a text colour, advance to the background slot so the
+  // common "pick both" flow is just click-click-apply. A background pick
+  // stays put — there's nowhere left to advance to.
+  if (slot.value === 'fg') slot.value = 'bg';
+}
+
+function apply(): void {
+  if (!hasPick.value) return;
+  emit('apply', staged.fg, staged.bg);
+}
 </script>
 
 <style scoped>
@@ -106,10 +189,42 @@ const swatches = PALETTE;
 .swatch:hover {
   outline: 1px solid var(--accent);
 }
+.swatch.picked {
+  outline: 2px solid var(--accent);
+}
 .row {
   display: flex;
   justify-content: space-between;
   gap: 12px;
+}
+.slots {
+  gap: 4px;
+}
+.slot {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 1px 0;
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  user-select: none;
+  touch-action: manipulation;
+}
+.slot:hover {
+  color: var(--accent);
+}
+.slot.active {
+  color: var(--fg);
+  border-color: var(--accent);
+}
+.chip {
+  width: 0.9em;
+  height: 0.9em;
+  border: 1px solid var(--border);
+  border-radius: 2px;
 }
 .action {
   color: var(--fg-muted);
@@ -119,5 +234,12 @@ const swatches = PALETTE;
 }
 .action:hover {
   color: var(--accent);
+}
+.action.apply {
+  color: var(--accent);
+}
+.action.apply.disabled {
+  color: var(--fg-muted);
+  cursor: default;
 }
 </style>

--- a/vue_client/src/components/MircColorPicker.vue
+++ b/vue_client/src/components/MircColorPicker.vue
@@ -17,11 +17,14 @@
       <div
         role="button"
         class="slot"
+        tabindex="0"
         :class="{ active: slot === 'fg' }"
         :aria-pressed="slot === 'fg'"
         title="Pick the text colour"
         @mousedown.prevent
         @click="slot = 'fg'"
+        @keydown.enter.prevent="slot = 'fg'"
+        @keydown.space.prevent="slot = 'fg'"
       >
         <span class="chip" :style="chipStyle(staged.fg)"></span>
         fg
@@ -29,11 +32,14 @@
       <div
         role="button"
         class="slot"
+        tabindex="0"
         :class="{ active: slot === 'bg' }"
         :aria-pressed="slot === 'bg'"
         title="Pick the background colour"
         @mousedown.prevent
         @click="slot = 'bg'"
+        @keydown.enter.prevent="slot = 'bg'"
+        @keydown.space.prevent="slot = 'bg'"
       >
         <span class="chip" :style="chipStyle(staged.bg)"></span>
         bg
@@ -45,35 +51,54 @@
         :key="entry.code"
         role="button"
         class="swatch"
+        tabindex="0"
         :class="{ picked: staged[slot] === entry.code }"
         :style="{ backgroundColor: entry.hex }"
         :title="`mIRC ${entry.code}`"
+        :aria-label="`mIRC colour ${entry.code}`"
         @mousedown.prevent
         @click="pick(entry.code)"
+        @keydown.enter.prevent="pick(entry.code)"
+        @keydown.space.prevent="pick(entry.code)"
       ></div>
     </div>
     <div class="row">
       <div
         role="button"
         class="action apply"
+        tabindex="0"
         :class="{ disabled: !hasPick }"
         :aria-disabled="!hasPick"
         title="Insert the picked colour"
         @mousedown.prevent
         @click="apply"
+        @keydown.enter.prevent="apply"
+        @keydown.space.prevent="apply"
       >
         apply
       </div>
       <div
         role="button"
         class="action"
+        tabindex="0"
         title="Clear formatting (inserts reset)"
         @mousedown.prevent
         @click="emit('reset')"
+        @keydown.enter.prevent="emit('reset')"
+        @keydown.space.prevent="emit('reset')"
       >
         clear
       </div>
-      <div role="button" class="action" title="Close" @mousedown.prevent @click="emit('close')">
+      <div
+        role="button"
+        class="action"
+        tabindex="0"
+        title="Close"
+        @mousedown.prevent
+        @click="emit('close')"
+        @keydown.enter.prevent="emit('close')"
+        @keydown.space.prevent="emit('close')"
+      >
         close
       </div>
     </div>
@@ -192,6 +217,10 @@ function apply(): void {
 .swatch.picked {
   outline: 2px solid var(--accent);
 }
+.swatch:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 .row {
   display: flex;
   justify-content: space-between;
@@ -220,6 +249,10 @@ function apply(): void {
   color: var(--fg);
   border-color: var(--accent);
 }
+.slot:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
 .chip {
   width: 0.9em;
   height: 0.9em;
@@ -234,6 +267,10 @@ function apply(): void {
 }
 .action:hover {
   color: var(--accent);
+}
+.action:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
 }
 .action.apply {
   color: var(--accent);

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -1,0 +1,54 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<template>
+  <template v-for="(seg, i) in segments" :key="i">
+    <SpoilerText v-if="seg.spoiler" :seg="seg" />
+    <a
+      v-else-if="seg.url"
+      class="msg-link"
+      :href="seg.url"
+      target="_blank"
+      rel="noreferrer noopener"
+      :style="styleFor(seg)"
+      >{{ seg.text }}</a
+    >
+    <span v-else-if="hasStyle(seg)" :style="styleFor(seg)">{{ seg.text }}</span>
+    <template v-else>{{ seg.text }}</template>
+  </template>
+</template>
+
+<script setup lang="ts">
+import type { CSSProperties } from 'vue';
+import type { RenderSegment } from '../utils/nickColor.js';
+import { segmentInlineStyle, segmentHasStyle } from '../utils/nickColor.js';
+import SpoilerText from './SpoilerText.vue';
+
+// The single renderer for an array of RenderSegments (the output of
+// splitTextByTokens): URLs, mIRC fg/bg colour, bold/italic/underline/strike,
+// nick coloring, and spoilers. Every message-list layout and LinkedText
+// funnel their segments through here, so a new segment kind only has to be
+// handled in one place — no render path can silently miss it.
+//
+// Branch order matters: spoiler is matched first because a spoiler segment
+// must never fall through to the plain <span>/text branches, which would
+// reveal the hidden content. `selfColor` tints segments belonging to the
+// current user; pass null where there's no message context (topic bar,
+// motd, part reasons, etc.).
+const props = withDefaults(
+  defineProps<{
+    segments: RenderSegment[];
+    selfColor?: string | null;
+  }>(),
+  { selfColor: null },
+);
+
+function styleFor(seg: RenderSegment): CSSProperties {
+  return segmentInlineStyle(seg, props.selfColor ?? null) as CSSProperties;
+}
+function hasStyle(seg: RenderSegment): boolean {
+  return segmentHasStyle(seg);
+}
+</script>

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -6,6 +6,10 @@
 <template>
   <template v-for="(seg, i) in segments" :key="i">
     <SpoilerText v-if="seg.spoiler" :seg="seg" />
+    <!-- @click.stop: this component renders inside clickable rows (a history
+         row jumps to the message on click), and a link activation shouldn't
+         also fire the row's handler. Propagation only — the link still
+         opens. -->
     <a
       v-else-if="seg.url"
       class="msg-link"
@@ -13,6 +17,7 @@
       target="_blank"
       rel="noreferrer noopener"
       :style="styleFor(seg)"
+      @click.stop
       >{{ seg.text }}</a
     >
     <span v-else-if="hasStyle(seg)" :style="styleFor(seg)">{{ seg.text }}</span>

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -1,0 +1,81 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<template>
+  <span
+    class="spoiler"
+    :class="{ revealed }"
+    :role="revealed ? undefined : 'button'"
+    :tabindex="revealed ? undefined : 0"
+    :aria-expanded="revealed ? undefined : 'false'"
+    :aria-label="revealed ? undefined : 'Hidden spoiler, activate to reveal'"
+    :title="revealed ? undefined : 'Hidden spoiler — click to reveal'"
+    @click="reveal"
+    @keydown.enter.prevent="reveal"
+    @keydown.space.prevent="reveal"
+    ><span class="spoiler-body" :style="bodyStyle" :aria-hidden="revealed ? undefined : 'true'">{{
+      seg.text
+    }}</span></span
+  >
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { CSSProperties } from 'vue';
+import type { RenderSegment } from '../utils/nickColor.js';
+
+// Renders an IRC spoiler run (fg===bg, i.e. text deliberately coloured to be
+// invisible) as a Discord-style blacked-out box. The content is kept out of
+// the accessible name (aria-hidden) until revealed so a screen reader doesn't
+// read the secret aloud. Reveal is one-way: once a user deliberately opens a
+// spoiler, re-hiding it isn't a behaviour anyone expects.
+const props = defineProps<{ seg: RenderSegment }>();
+
+const revealed = ref(false);
+function reveal(): void {
+  revealed.value = true;
+}
+
+// The spoiler run still carries any bold/italic/underline/strike toggles that
+// were active — apply them so the revealed text matches how it was sent.
+const bodyStyle = computed<CSSProperties>(() => {
+  const s: CSSProperties = {};
+  if (props.seg.bold) s.fontWeight = 'bold';
+  if (props.seg.italic) s.fontStyle = 'italic';
+  const decos: string[] = [];
+  if (props.seg.underline) decos.push('underline');
+  if (props.seg.strike) decos.push('line-through');
+  if (decos.length) s.textDecoration = decos.join(' ');
+  return s;
+});
+</script>
+
+<style scoped>
+.spoiler {
+  border-radius: 3px;
+  padding: 0 3px;
+  background: var(--fg-muted);
+  transition: background-color 0.1s ease;
+}
+.spoiler:not(.revealed) {
+  cursor: pointer;
+}
+.spoiler:not(.revealed) .spoiler-body {
+  color: transparent;
+  /* Stop a drag-select from revealing the text — click is the only reveal. */
+  user-select: none;
+}
+.spoiler:not(.revealed):hover {
+  background: var(--fg);
+}
+.spoiler.revealed {
+  /* A faint tint so it still reads as "this was a spoiler" once opened. */
+  background: color-mix(in srgb, var(--fg-muted) 22%, transparent);
+}
+.spoiler:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+</style>

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -34,7 +34,13 @@ import type { RenderSegment } from '../utils/nickColor.js';
 const props = defineProps<{ seg: RenderSegment }>();
 
 const revealed = ref(false);
-function reveal(): void {
+function reveal(e: Event): void {
+  if (revealed.value) return;
+  // While hidden, swallow the event so revealing a spoiler embedded in a
+  // clickable row (e.g. a search result that jumps to the message on click)
+  // doesn't also fire the row's handler. Once revealed it's plain text again
+  // and lets clicks through.
+  e.stopPropagation();
   revealed.value = true;
 }
 

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { splitTextByTokens, segmentInlineStyle, segmentHasStyle } from './nickColor.js';
+
+// IRC formatting control bytes used to build test fixtures.
+const C = '\x03'; // colour
+const RESET = '\x0f'; // reset all
+const BOLD = '\x02';
+
+// Run the formatting-only path (no nick set / colouring).
+function parse(text: string) {
+  return splitTextByTokens(text, null, null, null);
+}
+
+describe('splitTextByTokens — background colour', () => {
+  it('keeps both foreground and background of a \\x03FG,BG run', () => {
+    const segs = parse(`${C}04,08hi${C}`);
+    expect(segs).toEqual([{ text: 'hi', fg: 4, bg: 8 }]);
+  });
+
+  it('leaves the background unchanged when a later code sets only a foreground', () => {
+    // \x0308,02 sets fg+bg; \x0304 then recolours the text but keeps bg=2.
+    const segs = parse(`${C}08,02a${C}04b`);
+    expect(segs).toEqual([
+      { text: 'a', fg: 8, bg: 2 },
+      { text: 'b', fg: 4, bg: 2 },
+    ]);
+  });
+
+  it('resets both fg and bg on a bare \\x03', () => {
+    const segs = parse(`${C}04,08a${C}b`);
+    expect(segs).toEqual([{ text: 'a', fg: 4, bg: 8 }, { text: 'b' }]);
+  });
+
+  it('resets both fg and bg on \\x0F', () => {
+    const segs = parse(`${C}04,08a${RESET}b`);
+    expect(segs).toEqual([{ text: 'a', fg: 4, bg: 8 }, { text: 'b' }]);
+  });
+});
+
+describe('splitTextByTokens — spoiler detection', () => {
+  it('emits a single spoiler segment when fg equals bg', () => {
+    const segs = parse(`${C}01,01secret${C}`);
+    expect(segs).toEqual([{ text: 'secret', spoiler: true }]);
+  });
+
+  it('treats any matching fg/bg pair as a spoiler, not just 01,01', () => {
+    const segs = parse(`${C}04,04hidden${C}`);
+    expect(segs).toEqual([{ text: 'hidden', spoiler: true }]);
+  });
+
+  it('does not split a URL out of a spoiler run (no leak)', () => {
+    const segs = parse(`${C}01,01see https://example.com${C}`);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]).toEqual({ text: 'see https://example.com', spoiler: true });
+    expect(segs[0].url).toBeUndefined();
+  });
+
+  it('keeps active bold/italic toggles on the spoiler segment', () => {
+    const segs = parse(`${BOLD}${C}01,01x${C}`);
+    expect(segs).toEqual([{ text: 'x', spoiler: true, bold: true }]);
+  });
+
+  it('does not treat differing fg/bg as a spoiler', () => {
+    const segs = parse(`${C}01,02x${C}`);
+    expect(segs).toEqual([{ text: 'x', fg: 1, bg: 2 }]);
+  });
+});
+
+describe('segmentInlineStyle / segmentHasStyle — background colour', () => {
+  it('maps a background code to a backgroundColor', () => {
+    expect(segmentInlineStyle({ text: 'x', fg: 4, bg: 8 }, null)).toEqual({
+      color: '#ff0000',
+      backgroundColor: '#ffff00',
+    });
+  });
+
+  it('renders a background even when the foreground is the default (99)', () => {
+    // \x0399,01 — default text on a black background.
+    const style = segmentInlineStyle({ text: 'x', fg: 99, bg: 1 }, null);
+    expect(style.color).toBeUndefined();
+    expect(style.backgroundColor).toBe('#000000');
+  });
+
+  it('reports a background-only segment as styled', () => {
+    expect(segmentHasStyle({ text: 'x', bg: 8 })).toBe(true);
+    expect(segmentHasStyle({ text: 'x' })).toBe(false);
+  });
+});

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -218,6 +218,7 @@ interface IrcRun {
   underline: boolean;
   strike: boolean;
   fg: number | null;
+  bg: number | null;
 }
 
 // Walk the IRC formatting state machine and emit runs of text, each tagged
@@ -227,7 +228,7 @@ interface IrcRun {
 //   \x11 monospace                                       — consumed (no-op,
 //                                                          we're already mono)
 //   \x0F                                                 — reset all
-//   \x03[FG[,BG]] mIRC colour                            — FG kept, BG dropped
+//   \x03[FG[,BG]] mIRC colour                            — FG and BG kept
 //   \x04[hex6[,hex6]] truecolour                         — consumed, dropped
 function parseIrcFormatting(text: string): IrcRun[] {
   const runs: IrcRun[] = [];
@@ -236,10 +237,11 @@ function parseIrcFormatting(text: string): IrcRun[] {
     underline = false,
     strike = false;
   let fg: number | null = null;
+  let bg: number | null = null;
   let buf = '';
   const flush = (): void => {
     if (!buf) return;
-    runs.push({ text: buf, bold, italic, underline, strike, fg });
+    runs.push({ text: buf, bold, italic, underline, strike, fg, bg });
     buf = '';
   };
   let i = 0;
@@ -278,6 +280,7 @@ function parseIrcFormatting(text: string): IrcRun[] {
       flush();
       bold = italic = underline = strike = false;
       fg = null;
+      bg = null;
       i++;
       continue;
     }
@@ -289,17 +292,22 @@ function parseIrcFormatting(text: string): IrcRun[] {
         digits += text[i++];
       }
       if (digits === '') {
+        // A bare \x03 closes the colour run — resets both fg and bg.
         fg = null;
+        bg = null;
       } else {
         fg = parseInt(digits, 10);
         if (text[i] === ',' && text[i + 1] >= '0' && text[i + 1] <= '9') {
-          // Consume background but don't render it.
           i++;
           let bgDigits = '';
           while (bgDigits.length < 2 && i < text.length && text[i] >= '0' && text[i] <= '9') {
             bgDigits += text[i++];
           }
+          bg = parseInt(bgDigits, 10);
         }
+        // A foreground with no trailing background leaves bg as-is, per the
+        // modern IRC formatting spec — \x0304 recolours text but keeps
+        // whatever background was already in effect.
       }
       continue;
     }
@@ -325,6 +333,7 @@ function parseIrcFormatting(text: string): IrcRun[] {
 
 export interface TextSegmentStyle {
   color?: string;
+  backgroundColor?: string;
   fontWeight?: string;
   fontStyle?: string;
   textDecoration?: string;
@@ -340,6 +349,11 @@ export interface RenderSegment {
   underline?: boolean;
   strike?: boolean;
   fg?: number | null;
+  bg?: number | null;
+  // A run whose fg and bg are the same colour: invisible text the renderer
+  // shows as a click-to-reveal spoiler. Carries no fg/bg — SpoilerText draws
+  // its own box — but keeps any bold/italic/underline/strike for the reveal.
+  spoiler?: boolean;
 }
 
 // Build a Vue inline-style object for a segment. Colour precedence: an
@@ -355,6 +369,9 @@ export function segmentInlineStyle(seg: RenderSegment, selfColor: string | null)
   } else if (seg.self && selfColor) {
     style.color = selfColor;
   }
+  if (seg.bg != null && MIRC_PALETTE[seg.bg]) {
+    style.backgroundColor = MIRC_PALETTE[seg.bg];
+  }
   if (seg.bold) style.fontWeight = 'bold';
   if (seg.italic) style.fontStyle = 'italic';
   const decos: string[] = [];
@@ -369,6 +386,7 @@ export function segmentHasStyle(seg: RenderSegment): boolean {
     seg.color ||
     seg.self ||
     seg.fg != null ||
+    seg.bg != null ||
     seg.bold ||
     seg.italic ||
     seg.underline ||
@@ -407,9 +425,11 @@ function splitRunIntoSegments(
 // nick splitting run on the cleaned text inside each formatting run.
 //
 // Returned segment shapes (callers branch on these in order):
+//   { text, spoiler, ...fmt }           — hidden run (fg===bg); render as a
+//                                         click-to-reveal box, never an <a>
 //   { url, text, ...fmt }               — clickable link (with formatting)
 //   { text, color?, self?, ...fmt }     — nick / plain text (with formatting)
-// where fmt is { bold?, italic?, underline?, strike?, fg? }.
+// where fmt is { bold?, italic?, underline?, strike?, fg?, bg? }.
 export function splitTextByTokens(
   text: string | null | undefined,
   nickSet: Set<string> | null | undefined,
@@ -426,7 +446,16 @@ export function splitTextByTokens(
     if (run.italic) fmt.italic = true;
     if (run.underline) fmt.underline = true;
     if (run.strike) fmt.strike = true;
+    // A run whose foreground and background are the same colour is invisible
+    // text — the IRC spoiler convention. Emit it as one opaque segment and
+    // skip URL / nick splitting: a linked URL or a coloured nick rendered
+    // inside the run would stay visible and leak the hidden content.
+    if (run.fg != null && run.bg != null && run.fg === run.bg) {
+      out.push({ text: run.text, spoiler: true, ...fmt });
+      continue;
+    }
     if (run.fg != null) fmt.fg = run.fg;
+    if (run.bg != null) fmt.bg = run.bg;
     for (const seg of splitRunIntoSegments(run.text, nickSet, selfLower, colorFn)) {
       out.push({ ...seg, ...fmt });
     }

--- a/vue_client/src/utils/spoilerMarkup.test.ts
+++ b/vue_client/src/utils/spoilerMarkup.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { applySpoilerMarkup } from './spoilerMarkup.js';
+
+// A spoiler on the wire is colour code 01 (black) on background 01.
+const OPEN = '\x0301,01';
+const CLOSE = '\x03';
+
+describe('applySpoilerMarkup', () => {
+  it('leaves text with no double-pipes untouched', () => {
+    expect(applySpoilerMarkup('hello world')).toBe('hello world');
+    expect(applySpoilerMarkup('')).toBe('');
+    expect(applySpoilerMarkup('a | b')).toBe('a | b');
+  });
+
+  it('rewrites a basic ||spoiler|| into IRC spoiler codes', () => {
+    expect(applySpoilerMarkup('||secret||')).toBe(`${OPEN}secret${CLOSE}`);
+  });
+
+  it('preserves the text around a spoiler', () => {
+    expect(applySpoilerMarkup('the answer is ||42|| ok?')).toBe(
+      `the answer is ${OPEN}42${CLOSE} ok?`,
+    );
+  });
+
+  it('rewrites multiple spoilers in one message', () => {
+    expect(applySpoilerMarkup('||a|| and ||b||')).toBe(`${OPEN}a${CLOSE} and ${OPEN}b${CLOSE}`);
+  });
+
+  it('pairs non-greedily — the nearest closing || wins', () => {
+    // ||a||b||c|| -> spoiler(a), literal b, spoiler(c)
+    expect(applySpoilerMarkup('||a||b||c||')).toBe(`${OPEN}a${CLOSE}b${OPEN}c${CLOSE}`);
+  });
+
+  it('leaves an unmatched || literal', () => {
+    expect(applySpoilerMarkup('||unclosed')).toBe('||unclosed');
+    expect(applySpoilerMarkup('trailing||')).toBe('trailing||');
+  });
+
+  it('leaves an empty |||| literal', () => {
+    expect(applySpoilerMarkup('||||')).toBe('||||');
+  });
+
+  it('treats \\|| as an escape, emitting a literal || and no spoiler', () => {
+    expect(applySpoilerMarkup('exit code \\|| 1')).toBe('exit code || 1');
+    expect(applySpoilerMarkup('\\||not a spoiler\\||')).toBe('||not a spoiler||');
+  });
+
+  it('allows an escaped || inside a real spoiler', () => {
+    expect(applySpoilerMarkup('||has \\|| inside||')).toBe(`${OPEN}has || inside${CLOSE}`);
+  });
+
+  it('leaves a lone backslash literal', () => {
+    expect(applySpoilerMarkup('a \\ b')).toBe('a \\ b');
+    expect(applySpoilerMarkup('path\\to\\file')).toBe('path\\to\\file');
+  });
+});

--- a/vue_client/src/utils/spoilerMarkup.ts
+++ b/vue_client/src/utils/spoilerMarkup.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Discord-style `||spoiler||` → IRC spoiler codes, applied to outgoing plain
+// messages. A spoiler on the wire is a run whose foreground and background
+// colour are identical (mIRC code 01 on 01: black on black) — invisible text
+// in any IRC client, which Lurker's renderer (splitTextByTokens in
+// nickColor.ts) upgrades into a click-to-reveal box. Closing with a bare \x03
+// resets the colour without disturbing any bold/italic still in effect.
+//
+// `\||` is an escape: it emits a literal `||` and never acts as a delimiter,
+// so a message that genuinely needs a double-pipe (`exit code \|| 1`) can opt
+// out. There is no escape for the backslash itself — a lone `\` is always
+// literal, so `\||` is the only sequence treated specially.
+
+const SPOILER_OPEN = '\x0301,01';
+const SPOILER_CLOSE = '\x03';
+
+interface Token {
+  delim: boolean;
+  value: string;
+}
+
+// Split into literal-text and `||`-delimiter tokens, resolving `\||` escapes
+// into a literal `||` inside the text tokens as we go.
+function tokenize(text: string): Token[] {
+  const tokens: Token[] = [];
+  let buf = '';
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] === '\\' && text[i + 1] === '|' && text[i + 2] === '|') {
+      buf += '||';
+      i += 3;
+      continue;
+    }
+    if (text[i] === '|' && text[i + 1] === '|') {
+      if (buf) {
+        tokens.push({ delim: false, value: buf });
+        buf = '';
+      }
+      tokens.push({ delim: true, value: '||' });
+      i += 2;
+      continue;
+    }
+    buf += text[i++];
+  }
+  if (buf) tokens.push({ delim: false, value: buf });
+  return tokens;
+}
+
+// Rewrite every `||spoiler||` pair in `text` into IRC spoiler codes. Pairing
+// is non-greedy (the nearest closing `||` wins) and an empty pair (`||||`) is
+// left literal, matching how Discord treats both cases.
+export function applySpoilerMarkup(text: string): string {
+  if (!text.includes('||')) return text;
+  const tokens = tokenize(text);
+  let out = '';
+  let i = 0;
+  while (i < tokens.length) {
+    const tok = tokens[i];
+    if (!tok.delim) {
+      out += tok.value;
+      i++;
+      continue;
+    }
+    // An opening `||`: gather everything up to the next delimiter.
+    let content = '';
+    let close = -1;
+    for (let j = i + 1; j < tokens.length; j++) {
+      if (tokens[j].delim) {
+        close = j;
+        break;
+      }
+      content += tokens[j].value;
+    }
+    if (close !== -1 && content.length > 0) {
+      out += SPOILER_OPEN + content + SPOILER_CLOSE;
+      i = close + 1;
+    } else {
+      // Unmatched, or an empty `||||` — the opening `||` is just literal text.
+      out += '||';
+      i++;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #5.

The IRC formatting parser was parsing the `,BG` half of mIRC colour codes but discarding it — so inbound background colours never rendered, and spoiler text (which relies on a matching foreground/background) couldn't work at all.

## Background colour

- `parseIrcFormatting` now tracks background colour through the state machine. A bare `\x03` and `\x0F` reset both fg and bg; a foreground-only code (`\x0304`) leaves the background as-is, per the modern IRC formatting spec.
- `segmentInlineStyle` / `segmentHasStyle` render it as `backgroundColor`.

## Spoilers

- A run whose foreground and background are the **same colour** is invisible text — the universal IRC spoiler convention. `splitTextByTokens` emits it as a single opaque segment, deliberately skipping URL/nick splitting so a link or coloured nick inside can't leak the hidden content.
- New reusable `SpoilerText.vue` renders it as a Discord-style blacked-out box; click or keyboard-activate reveals it. The content stays `aria-hidden` until revealed so screen readers don't read the secret aloud. While hidden it swallows the click, so revealing a spoiler inside a clickable row (e.g. a search result) doesn't also navigate.
- Discord-style `||spoiler||` typed in the input is rewritten to IRC spoiler codes on send (`applySpoilerMarkup`). `\||` escapes a literal double-pipe. Input history keeps the typed `||…||` form so up-arrow round-trips.

## Colour picker

`MircColorPicker` is now a staged builder instead of insert-on-first-click: it stays open while you stage a foreground and a background, previews each as a chip, and inserts one combined `\x03fg,bg` code on **apply**. Picking a foreground auto-advances to the `bg` slot, so "coloured text on a coloured background" is click → click → apply. Staging resets each time the picker opens. The picker is fully keyboard-operable — slots, swatches, and actions have `tabindex`, Enter/Space handlers, and focus-visible outlines (kept as `role="button"` divs rather than `<button>` to preserve the `@mousedown.prevent` that stops iOS from dismissing the keyboard).

## Shared rendering

The spoiler / URL / styled-text / plain-text segment branch used to be duplicated across three render paths. It's now a single `RenderSegments.vue` that every message surface funnels through — standard layout, compact layout, topic bar, motd/part reasons, **and** history rows (search results, highlights, bookmarks, which previously showed raw control codes). A new segment kind can now only be missed in one place. Segment *production* still differs per call site (plain text vs. nick-coloured), which is inherent — only the rendering is shared.

## Tests

- `nickColor.test.ts` — background parsing, fg-only-keeps-bg, resets, spoiler detection, no-leak segmentation.
- `spoilerMarkup.test.ts` — the `||…||` rewrite, non-greedy pairing, empty/unmatched literals, and `\||` escaping.
- Keyboard-help modal documents the `||text||` syntax.

## Scoped out (deliberately)

- The `||spoiler||` shortcut applies to plain messages, not slash commands (`/me ||x||` sends literal pipes).
- Reverse video (`\x16`) stays a consumed no-op as before.
- History rows don't nick-colour mentions in the body — they're out-of-buffer with no member list.

## Verification

`npm run check` (typecheck ×2, lint, format) ✅ · client build ✅ · full suite 582 tests pass (22 new) ✅. No live UI check — the dev server autoconnects to a real IRC network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
