### PR TITLE
Add /ns and /cs shortcuts for messaging NickServ/ChanServ

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1139,6 +1139,8 @@ const HELP_LINES = [
   'commands:',
   '  /me <text>             — emote in the current buffer',
   '  /msg <nick> <text>     — open a DM and send (alias: /query)',
+  '  /ns <text>             — message NickServ (e.g. identify <pass>)',
+  '  /cs <text>             — message ChanServ',
   '  /join <#chan>          — join a channel',
   '  /part [#chan] [reason] — leave channel (keeps buffer; alias: /leave)',
   '  /close                 — close current buffer (parts if channel)',
@@ -1212,6 +1214,19 @@ function handleCommand(line: string, networkId: number, target: string): boolean
       }
       buffers.activate(networkId, who);
       return true;
+    }
+    case 'ns':
+    case 'cs': {
+      // /ns and /cs are the near-universal shortcuts for messaging NickServ
+      // and ChanServ. Route as a raw PRIVMSG rather than a `send` so the body
+      // (often `identify <password>`) is never echoed into a buffer and no
+      // service DM buffer is forced open.
+      const service = cmd.toLowerCase() === 'ns' ? 'NickServ' : 'ChanServ';
+      if (!argLine) {
+        localInfo(networkId, target, `usage: /${cmd.toLowerCase()} <text> — message ${service}`);
+        return true;
+      }
+      return sendOrToast({ type: 'raw', networkId, line: `PRIVMSG ${service} :${argLine}` }, line);
     }
     case 'join':
       if (rest[0]) {


### PR DESCRIPTION
Closes #63.

Adds the near-universal IRC shortcuts:

- `/ns <text>` → `PRIVMSG NickServ :<text>` (e.g. `/ns identify hunter2`)
- `/cs <text>` → `PRIVMSG ChanServ :<text>`

## Notes

- Routed as a **raw PRIVMSG**, not a `send`. This keeps the body — often `identify <password>` — from being echoed into a buffer, and avoids forcing open a NickServ/ChanServ DM buffer on every auth. Service responses still arrive as NOTICEs the way they do today.
- No-arg invocation (`/ns`) prints a usage line into the current buffer instead of sending an empty message.
- Both commands added to `/help`.

## Testing

- `npm run typecheck` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)