### PR TITLE
Use server default quit message for bare /quit

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1546,7 +1546,10 @@ function handleCommand(line: string, networkId: number, target: string): boolean
       // ircManager.stopNetwork → client.quit()), which sets irc-framework's
       // requested_disconnect flag. Sending a raw QUIT line instead leaves that
       // flag unset, so the socket close looks unexpected and auto-reconnects.
-      const reason = argLine || 'lurker';
+      // With no reason given, send none so the server falls back to its
+      // default quit message (DEFAULT_QUIT_MESSAGE) — the same line used for
+      // an auto-disconnect.
+      const reason = argLine || undefined;
       networks.disconnect(networkId, reason).catch((err) => {
         localInfo(networkId, target, `/quit failed: ${err.message || 'could not disconnect'}`);
       });


### PR DESCRIPTION
## What

Closes #74.

A bare `/quit` (no reason argument) sent the literal string `lurker` as the QUIT message. An auto-disconnect, by contrast, uses `DEFAULT_QUIT_MESSAGE`:

```
Lurker <version> (the truth is out there) https://github.com/amiantos/lurker
```

These should match.

## Why it's a one-line client fix

The whole disconnect chain already falls back to `DEFAULT_QUIT_MESSAGE` when no reason is supplied:

- `networks.disconnect(id, reason?)` omits the request body when `reason` is falsy
- the `POST /:id/disconnect` route passes `req.body?.reason` → `undefined`
- `ircManager.stopNetwork` → `IrcConnection.disconnect(reason = DEFAULT_QUIT_MESSAGE)` applies the default

The `/quit` command handler in `MessageInput.vue` was the only thing overriding that, by substituting `'lurker'` for an empty `argLine`.

## Change

`const reason = argLine || 'lurker'` → `const reason = argLine || undefined`, so a bare `/quit` lets the server default apply. A `/quit <reason>` still sends the user's text unchanged.

`typecheck:client`, `lint`, and `format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)