### PR TITLE
Make #channel names in the message list clickable

### DIFF
--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -13,7 +13,6 @@ let createNetwork: typeof import('../db/networks.js').createNetwork;
 let insertMessage: typeof import('../db/messages.js').insertMessage;
 let closeBuffer: typeof import('../db/closedBuffers.js').closeBuffer;
 let isClosed: typeof import('../db/closedBuffers.js').isClosed;
-let isChannelTarget: typeof import('./wsHub.js').isChannelTarget;
 let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
 let handleOpenBuffer: typeof import('./wsHub.js').handleOpenBuffer;
 
@@ -25,7 +24,7 @@ beforeAll(async () => {
   ({ createNetwork } = await import('../db/networks.js'));
   ({ insertMessage } = await import('../db/messages.js'));
   ({ closeBuffer, isClosed } = await import('../db/closedBuffers.js'));
-  ({ isChannelTarget, buildBufferBacklog, handleOpenBuffer } = await import('./wsHub.js'));
+  ({ buildBufferBacklog, handleOpenBuffer } = await import('./wsHub.js'));
 
   userId = createUser('alice').id;
   const net = createNetwork(userId, {
@@ -59,15 +58,6 @@ function mockWs() {
   const ws = { OPEN: 1, readyState: 1, send: (s: string) => frames.push(JSON.parse(s)) };
   return { ws: ws as unknown as Parameters<typeof handleOpenBuffer>[0], frames };
 }
-
-describe('isChannelTarget', () => {
-  it('recognizes # and & prefixes, rejects nicks and server buffers', () => {
-    expect(isChannelTarget('#general')).toBe(true);
-    expect(isChannelTarget('&local')).toBe(true);
-    expect(isChannelTarget('alice')).toBe(false);
-    expect(isChannelTarget(':server:1')).toBe(false);
-  });
-});
 
 describe('buildBufferBacklog', () => {
   it('builds a backlog frame from a buffer’s persisted history', () => {

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+// setupTestDb sets DATABASE_PATH before any dynamic import touches db/index.js,
+// so it must run at module top level.
+const testDb = setupTestDb('wshub');
+
+let createUser: typeof import('../db/users.js').createUser;
+let createNetwork: typeof import('../db/networks.js').createNetwork;
+let insertMessage: typeof import('../db/messages.js').insertMessage;
+let closeBuffer: typeof import('../db/closedBuffers.js').closeBuffer;
+let isClosed: typeof import('../db/closedBuffers.js').isClosed;
+let isChannelTarget: typeof import('./wsHub.js').isChannelTarget;
+let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
+let handleOpenBuffer: typeof import('./wsHub.js').handleOpenBuffer;
+
+let userId: number;
+let networkId: number;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  ({ createNetwork } = await import('../db/networks.js'));
+  ({ insertMessage } = await import('../db/messages.js'));
+  ({ closeBuffer, isClosed } = await import('../db/closedBuffers.js'));
+  ({ isChannelTarget, buildBufferBacklog, handleOpenBuffer } = await import('./wsHub.js'));
+
+  userId = createUser('alice').id;
+  const net = createNetwork(userId, {
+    name: 'libera',
+    host: 'h',
+    port: 6697,
+    tls: true,
+    nick: 'alice',
+  });
+  networkId = net!.id;
+});
+
+afterAll(() => testDb.cleanup());
+
+function seed(target: string, text: string): void {
+  insertMessage({
+    networkId,
+    target,
+    time: new Date().toISOString(),
+    type: 'message',
+    nick: 'bob',
+    text,
+    self: false,
+  });
+}
+
+// A WebSocket stand-in that records the frames send() writes. send() gates on
+// `readyState === OPEN`, so the two must match for a frame to be captured.
+function mockWs() {
+  const frames: Array<Record<string, unknown>> = [];
+  const ws = { OPEN: 1, readyState: 1, send: (s: string) => frames.push(JSON.parse(s)) };
+  return { ws: ws as unknown as Parameters<typeof handleOpenBuffer>[0], frames };
+}
+
+describe('isChannelTarget', () => {
+  it('recognizes # and & prefixes, rejects nicks and server buffers', () => {
+    expect(isChannelTarget('#general')).toBe(true);
+    expect(isChannelTarget('&local')).toBe(true);
+    expect(isChannelTarget('alice')).toBe(false);
+    expect(isChannelTarget(':server:1')).toBe(false);
+  });
+});
+
+describe('buildBufferBacklog', () => {
+  it('builds a backlog frame from a buffer’s persisted history', () => {
+    seed('#bl', 'one');
+    seed('#bl', 'two');
+    seed('#bl', 'three');
+    const frame = buildBufferBacklog(userId, networkId, '#bl');
+    expect(frame.kind).toBe('backlog');
+    expect(frame.networkId).toBe(networkId);
+    expect(frame.target).toBe('#bl');
+    expect((frame.events as unknown[]).length).toBe(3);
+    // No live IRC connection in the test → the channel reads as parted.
+    expect(frame.joined).toBe(false);
+    expect(frame.unread).toBe(3);
+    expect(frame.highlights).toBe(0);
+  });
+
+  it('reports a non-channel buffer (DM) as joined', () => {
+    seed('carol', 'hi');
+    expect(buildBufferBacklog(userId, networkId, 'carol').joined).toBe(true);
+  });
+});
+
+describe('handleOpenBuffer', () => {
+  it('reopens a since-closed channel without re-JOINing, resolving casing case-insensitively', () => {
+    seed('#reopen', 'history line');
+    closeBuffer(userId, networkId, '#reopen');
+    expect(isClosed(userId, networkId, '#reopen')).toBe(true);
+
+    // Clicked with different casing than the stored target.
+    const { ws, frames } = mockWs();
+    handleOpenBuffer(ws, userId, networkId, '#ReOpen');
+
+    // The closed flag is cleared — the buffer is reopened.
+    expect(isClosed(userId, networkId, '#reopen')).toBe(false);
+    // A backlog frame plus a buffer-opened frame, both keyed by the canonical
+    // stored casing rather than the casing that was clicked.
+    expect(frames.find((f) => f.kind === 'backlog')?.target).toBe('#reopen');
+    expect(frames.find((f) => f.kind === 'buffer-opened')?.target).toBe('#reopen');
+  });
+
+  it('joins a channel with no history instead of reopening', () => {
+    const { ws, frames } = mockWs();
+    handleOpenBuffer(ws, userId, networkId, '#never-visited');
+    // No history → no backlog frame, just a buffer-opened for the clicked target.
+    expect(frames.some((f) => f.kind === 'backlog')).toBe(false);
+    expect(frames.find((f) => f.kind === 'buffer-opened')?.target).toBe('#never-visited');
+  });
+
+  it('ignores blank, zero-network, and server-buffer requests', () => {
+    const { ws, frames } = mockWs();
+    handleOpenBuffer(ws, userId, networkId, ':server:1');
+    handleOpenBuffer(ws, userId, networkId, '');
+    handleOpenBuffer(ws, userId, 0, '#x');
+    expect(frames).toHaveLength(0);
+  });
+});

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -174,6 +174,11 @@ function isInQuietWindow(currentMin: number, startMin: number, endMin: number): 
 
 const DM_ELIGIBLE_TYPES = new Set(['message', 'action', 'notice']);
 
+// IRC channel names start with '#' (or '&' for server-local channels).
+function isChannelTarget(target: string): boolean {
+  return target.startsWith('#') || target.startsWith('&');
+}
+
 // Structural DM detection: ircConnection routes any direct message into a
 // buffer keyed by the *other* person's nick, so by the time we see an event
 // here the target is no longer your own nick. Anything that's not a channel
@@ -731,7 +736,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     target: string,
   ): void {
     const conn = ircManager.getConnection(userId, networkId);
-    if (!conn) return;
     const events = listMessages(networkId, target, { limit: 200 }).map((e) =>
       decorateMessage(userId, e),
     );
@@ -743,7 +747,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       target,
       events,
       speakers: listSpeakers(networkId, target),
-      joined: target.startsWith('#') ? conn.channels.has(target.toLowerCase()) : true,
+      // A channel counts as joined only while a live connection is tracking
+      // it; a stopped/offline network has no connection, so treat it as
+      // parted rather than refusing to ship the history at all.
+      joined: isChannelTarget(target) ? !!conn?.channels.has(target.toLowerCase()) : true,
       lastReadId: counts.lastReadId,
       unread: counts.unread,
       highlights: counts.highlights,
@@ -814,20 +821,28 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         ircManager.joinChannel(userId, msg.networkId as number, msg.channel as string);
         break;
       case 'open-buffer': {
-        // A clicked channel name. If the channel has persisted history — even
-        // one the user has since /closed — reopen its buffer and re-seed it
-        // without re-JOINing (mirrors IRCCloud: clicking a channel you've been
-        // in just takes you to its buffer). A channel with no history is one
-        // we've never visited, so clicking it joins.
+        // A clicked channel name. Resolve it against buffers that already
+        // have persisted history — case-insensitively, since IRC channel
+        // names are case-insensitive but message rows store one canonical
+        // casing. A match (even a since-/closed buffer) is reopened and
+        // re-seeded without a re-JOIN — mirrors IRCCloud: clicking a channel
+        // you've been in just takes you to its buffer. A channel with no
+        // history anywhere is one we've never visited, so it gets joined.
+        // Either way we reply `buffer-opened` with the resolved target so the
+        // requesting tab focuses the right buffer without guessing the casing.
         const networkId = Number(msg.networkId);
-        const target = typeof msg.target === 'string' ? msg.target : '';
-        if (!networkId || !target || target.startsWith(':server:')) break;
-        const hasHistory = listMessages(networkId, target, { limit: 1 }).length > 0;
-        if (hasHistory) {
-          reopenBuffer(userId, networkId, target);
-          sendBufferBacklog(ws, userId, networkId, target);
-        } else if (target.startsWith('#') || target.startsWith('&')) {
-          ircManager.joinChannel(userId, networkId, target);
+        const requested = typeof msg.target === 'string' ? msg.target : '';
+        if (!networkId || !requested || requested.startsWith(':server:')) break;
+        const canonical = listBufferTargets(networkId).find(
+          (t) => t.toLowerCase() === requested.toLowerCase(),
+        );
+        if (canonical) {
+          reopenBuffer(userId, networkId, canonical);
+          sendBufferBacklog(ws, userId, networkId, canonical);
+          send(ws, { kind: 'buffer-opened', networkId, target: canonical });
+        } else if (isChannelTarget(requested)) {
+          ircManager.joinChannel(userId, networkId, requested);
+          send(ws, { kind: 'buffer-opened', networkId, target: requested });
         }
         break;
       }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -174,11 +174,6 @@ function isInQuietWindow(currentMin: number, startMin: number, endMin: number): 
 
 const DM_ELIGIBLE_TYPES = new Set(['message', 'action', 'notice']);
 
-// IRC channel names start with '#' (or '&' for server-local channels).
-export function isChannelTarget(target: string): boolean {
-  return target.startsWith('#') || target.startsWith('&');
-}
-
 // Structural DM detection: ircConnection routes any direct message into a
 // buffer keyed by the *other* person's nick, so by the time we see an event
 // here the target is no longer your own nick. Anything that's not a channel
@@ -252,7 +247,7 @@ export function buildBufferBacklog(userId: number, networkId: number, target: st
     // A channel counts as joined only while a live connection is tracking it;
     // a stopped/offline network has no connection, so treat it as parted
     // rather than refusing to ship the history at all.
-    joined: isChannelTarget(target) ? !!conn?.channels.has(target.toLowerCase()) : true,
+    joined: target.startsWith('#') ? !!conn?.channels.has(target.toLowerCase()) : true,
     lastReadId: counts.lastReadId,
     unread: counts.unread,
     highlights: counts.highlights,
@@ -283,7 +278,7 @@ export function handleOpenBuffer(
     reopenBuffer(userId, networkId, canonical);
     send(ws, buildBufferBacklog(userId, networkId, canonical));
     send(ws, { kind: 'buffer-opened', networkId, target: canonical });
-  } else if (isChannelTarget(requested)) {
+  } else if (requested.startsWith('#')) {
     ircManager.joinChannel(userId, networkId, requested);
     send(ws, { kind: 'buffer-opened', networkId, target: requested });
   }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -175,7 +175,7 @@ function isInQuietWindow(currentMin: number, startMin: number, endMin: number): 
 const DM_ELIGIBLE_TYPES = new Set(['message', 'action', 'notice']);
 
 // IRC channel names start with '#' (or '&' for server-local channels).
-function isChannelTarget(target: string): boolean {
+export function isChannelTarget(target: string): boolean {
   return target.startsWith('#') || target.startsWith('&');
 }
 
@@ -230,6 +230,63 @@ function computeUnreadFor(_userId: number, networkId: number, target: string, la
     // Both counts are now indexed queries — no scan cap, no undercount.
     highlightsCapped: false,
   };
+}
+
+// Builds a one-off `backlog` frame for a single buffer — used when a closed
+// buffer is reopened (the user clicked its channel name). Unlike the snapshot
+// loop this ignores the resume cursor and always ships the recent slice; the
+// client dedupes by id, so it's safe even if the buffer is already open.
+export function buildBufferBacklog(userId: number, networkId: number, target: string): WsPayload {
+  const conn = ircManager.getConnection(userId, networkId);
+  const events = listMessages(networkId, target, { limit: 200 }).map((e) =>
+    decorateMessage(userId, e),
+  );
+  const lastReadId = getReadState(userId, networkId, target);
+  const counts = computeUnreadFor(userId, networkId, target, lastReadId);
+  return {
+    kind: 'backlog',
+    networkId,
+    target,
+    events,
+    speakers: listSpeakers(networkId, target),
+    // A channel counts as joined only while a live connection is tracking it;
+    // a stopped/offline network has no connection, so treat it as parted
+    // rather than refusing to ship the history at all.
+    joined: isChannelTarget(target) ? !!conn?.channels.has(target.toLowerCase()) : true,
+    lastReadId: counts.lastReadId,
+    unread: counts.unread,
+    highlights: counts.highlights,
+    highlightsCapped: counts.highlightsCapped,
+    inputHistory: listRecentInputHistory(userId, networkId, target, 200),
+  };
+}
+
+// Handles a client `open-buffer` request (a clicked channel name). Resolves
+// the requested target against buffers that already have persisted history —
+// case-insensitively, since IRC channel names are case-insensitive but
+// message rows store one canonical casing. A match (even a since-/closed
+// buffer) is reopened and re-seeded without a re-JOIN; a channel with no
+// history anywhere is one we've never visited, so it gets joined. Either way
+// the requesting socket is told the canonical target to focus, so it never
+// has to guess the casing.
+export function handleOpenBuffer(
+  ws: LurkerWebSocket,
+  userId: number,
+  networkId: number,
+  requested: string,
+): void {
+  if (!networkId || !requested || requested.startsWith(':server:')) return;
+  const canonical = listBufferTargets(networkId).find(
+    (t) => t.toLowerCase() === requested.toLowerCase(),
+  );
+  if (canonical) {
+    reopenBuffer(userId, networkId, canonical);
+    send(ws, buildBufferBacklog(userId, networkId, canonical));
+    send(ws, { kind: 'buffer-opened', networkId, target: canonical });
+  } else if (isChannelTarget(requested)) {
+    ircManager.joinChannel(userId, networkId, requested);
+    send(ws, { kind: 'buffer-opened', networkId, target: requested });
+  }
 }
 
 // Per-user socket bookkeeping lives at module scope so the verb registry can
@@ -725,40 +782,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     ws.sinceId = maxSentId;
   }
 
-  // One-off backlog frame for a single buffer — used when a closed buffer is
-  // reopened (the user clicked its channel name). Unlike sendSnapshot this
-  // ignores the resume cursor and always ships the recent slice; the client
-  // dedupes by id, so this is safe even if the buffer is already open.
-  function sendBufferBacklog(
-    ws: LurkerWebSocket,
-    userId: number,
-    networkId: number,
-    target: string,
-  ): void {
-    const conn = ircManager.getConnection(userId, networkId);
-    const events = listMessages(networkId, target, { limit: 200 }).map((e) =>
-      decorateMessage(userId, e),
-    );
-    const lastReadId = getReadState(userId, networkId, target);
-    const counts = computeUnreadFor(userId, networkId, target, lastReadId);
-    send(ws, {
-      kind: 'backlog',
-      networkId,
-      target,
-      events,
-      speakers: listSpeakers(networkId, target),
-      // A channel counts as joined only while a live connection is tracking
-      // it; a stopped/offline network has no connection, so treat it as
-      // parted rather than refusing to ship the history at all.
-      joined: isChannelTarget(target) ? !!conn?.channels.has(target.toLowerCase()) : true,
-      lastReadId: counts.lastReadId,
-      unread: counts.unread,
-      highlights: counts.highlights,
-      highlightsCapped: counts.highlightsCapped,
-      inputHistory: listRecentInputHistory(userId, networkId, target, 200),
-    });
-  }
-
   function handleClientMessage(ws: LurkerWebSocket, user: User, msg: WsPayload): void {
     const userId = user.id;
     // Any message that carries a networkId must reference a network the caller
@@ -820,32 +843,15 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       case 'join':
         ircManager.joinChannel(userId, msg.networkId as number, msg.channel as string);
         break;
-      case 'open-buffer': {
-        // A clicked channel name. Resolve it against buffers that already
-        // have persisted history — case-insensitively, since IRC channel
-        // names are case-insensitive but message rows store one canonical
-        // casing. A match (even a since-/closed buffer) is reopened and
-        // re-seeded without a re-JOIN — mirrors IRCCloud: clicking a channel
-        // you've been in just takes you to its buffer. A channel with no
-        // history anywhere is one we've never visited, so it gets joined.
-        // Either way we reply `buffer-opened` with the resolved target so the
-        // requesting tab focuses the right buffer without guessing the casing.
-        const networkId = Number(msg.networkId);
-        const requested = typeof msg.target === 'string' ? msg.target : '';
-        if (!networkId || !requested || requested.startsWith(':server:')) break;
-        const canonical = listBufferTargets(networkId).find(
-          (t) => t.toLowerCase() === requested.toLowerCase(),
+      case 'open-buffer':
+        // A clicked channel name — handleOpenBuffer resolves reopen-vs-join.
+        handleOpenBuffer(
+          ws,
+          userId,
+          Number(msg.networkId),
+          typeof msg.target === 'string' ? msg.target : '',
         );
-        if (canonical) {
-          reopenBuffer(userId, networkId, canonical);
-          sendBufferBacklog(ws, userId, networkId, canonical);
-          send(ws, { kind: 'buffer-opened', networkId, target: canonical });
-        } else if (isChannelTarget(requested)) {
-          ircManager.joinChannel(userId, networkId, requested);
-          send(ws, { kind: 'buffer-opened', networkId, target: requested });
-        }
         break;
-      }
       case 'part':
         ircManager.partChannel(
           userId,

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -720,6 +720,38 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     ws.sinceId = maxSentId;
   }
 
+  // One-off backlog frame for a single buffer — used when a closed buffer is
+  // reopened (the user clicked its channel name). Unlike sendSnapshot this
+  // ignores the resume cursor and always ships the recent slice; the client
+  // dedupes by id, so this is safe even if the buffer is already open.
+  function sendBufferBacklog(
+    ws: LurkerWebSocket,
+    userId: number,
+    networkId: number,
+    target: string,
+  ): void {
+    const conn = ircManager.getConnection(userId, networkId);
+    if (!conn) return;
+    const events = listMessages(networkId, target, { limit: 200 }).map((e) =>
+      decorateMessage(userId, e),
+    );
+    const lastReadId = getReadState(userId, networkId, target);
+    const counts = computeUnreadFor(userId, networkId, target, lastReadId);
+    send(ws, {
+      kind: 'backlog',
+      networkId,
+      target,
+      events,
+      speakers: listSpeakers(networkId, target),
+      joined: target.startsWith('#') ? conn.channels.has(target.toLowerCase()) : true,
+      lastReadId: counts.lastReadId,
+      unread: counts.unread,
+      highlights: counts.highlights,
+      highlightsCapped: counts.highlightsCapped,
+      inputHistory: listRecentInputHistory(userId, networkId, target, 200),
+    });
+  }
+
   function handleClientMessage(ws: LurkerWebSocket, user: User, msg: WsPayload): void {
     const userId = user.id;
     // Any message that carries a networkId must reference a network the caller
@@ -781,6 +813,24 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       case 'join':
         ircManager.joinChannel(userId, msg.networkId as number, msg.channel as string);
         break;
+      case 'open-buffer': {
+        // A clicked channel name. If the channel has persisted history — even
+        // one the user has since /closed — reopen its buffer and re-seed it
+        // without re-JOINing (mirrors IRCCloud: clicking a channel you've been
+        // in just takes you to its buffer). A channel with no history is one
+        // we've never visited, so clicking it joins.
+        const networkId = Number(msg.networkId);
+        const target = typeof msg.target === 'string' ? msg.target : '';
+        if (!networkId || !target || target.startsWith(':server:')) break;
+        const hasHistory = listMessages(networkId, target, { limit: 1 }).length > 0;
+        if (hasHistory) {
+          reopenBuffer(userId, networkId, target);
+          sendBufferBacklog(ws, userId, networkId, target);
+        } else if (target.startsWith('#') || target.startsWith('&')) {
+          ircManager.joinChannel(userId, networkId, target);
+        }
+        break;
+      }
       case 'part':
         ircManager.partChannel(
           userId,

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -109,10 +109,9 @@ a {
   text-decoration-color: var(--link);
 }
 
-/* Auto-linked IRC channel names in chat messages. Coloured like a link but
-   underlined only on hover, so they read as distinct from URLs. */
+/* Auto-linked IRC channel names in chat messages. Kept at the normal message
+   text colour — the pointer cursor and hover underline are the only cues. */
 .msg-channel {
-  color: var(--link);
   cursor: pointer;
 }
 .msg-channel:hover {

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -109,6 +109,22 @@ a {
   text-decoration-color: var(--link);
 }
 
+/* Auto-linked IRC channel names in chat messages. Coloured like a link but
+   underlined only on hover, so they read as distinct from URLs. */
+.msg-channel {
+  color: var(--link);
+  cursor: pointer;
+}
+.msg-channel:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.msg-channel:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  border-radius: 2px;
+}
+
 button {
   font: inherit;
   background: transparent;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -75,7 +75,11 @@
             }}</span>
           </div>
           <span class="body" :class="bodyClass(row.m)">
-            <RenderSegments :segments="textSegments(row.m)" :self-color="selfColor" />
+            <RenderSegments
+              :segments="textSegments(row.m)"
+              :self-color="selfColor"
+              :network-id="buffer?.networkId ?? null"
+            />
           </span>
           <span class="time">{{ row.continuationTime ? '' : time(row.m?.time) }}</span>
         </template>
@@ -92,6 +96,7 @@
               v-if="hasInlineText(row.m)"
               :segments="textSegments(row.m)"
               :self-color="selfColor"
+              :network-id="buffer?.networkId ?? null"
             />
             <template v-else-if="row.m?.type === 'join'"
               ><NickRef :nick="row.m.nick ?? ''" /> joined</template

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -79,22 +79,24 @@ function hasStyle(seg: RenderSegment): boolean {
   return segmentHasStyle(seg);
 }
 
-// Clicking a channel name mirrors IRCCloud. If the buffer is already open in
-// this client, just switch to it. Otherwise hand off to the server, which
-// decides (see the `open-buffer` handler): a channel with persisted history —
-// even one the user has since /closed — is reopened and re-seeded without
-// re-JOINing; a channel we've genuinely never visited gets joined. The client
-// can't make this call itself — closed buffers are filtered out of its
-// snapshot, so a since-closed channel is locally indistinguishable from a
-// brand-new one.
+// Clicking a channel name mirrors IRCCloud. IRC channel names are
+// case-insensitive but a buffer is keyed by one canonical casing, so match
+// the network's open buffers case-insensitively: if one already exists here,
+// just switch to it. Otherwise hand off to the server (`open-buffer`), which
+// reopens a since-closed buffer — re-seeding its history, no re-JOIN — or
+// joins a never-visited channel, then replies `buffer-opened` with the
+// canonical target for us to focus. We don't activate optimistically: the
+// message's casing may differ from the canonical one, and a mis-cased
+// activate would leave a stray empty buffer behind.
 function openChannel(channel: string): void {
   const nid = props.networkId;
   if (nid == null) return;
-  if (buffers.byKey(`${nid}::${channel}`)) {
-    buffers.activate(nid, channel);
+  const lower = channel.toLowerCase();
+  const existing = buffers.forNetwork(nid).find((b) => b.target.toLowerCase() === lower);
+  if (existing) {
+    buffers.activate(nid, existing.target);
     return;
   }
   socketSend({ type: 'open-buffer', networkId: nid, target: channel });
-  buffers.activate(nid, channel);
 }
 </script>

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -20,6 +20,21 @@
       @click.stop
       >{{ seg.text }}</a
     >
+    <!-- Channel name: clickable only when a network is in scope (the message
+         list passes one). Without a network — topic bar, motd — it falls
+         through to the plain-text branch. @click.stop for the same row-jump
+         reason as links above. -->
+    <span
+      v-else-if="seg.channel && networkId != null"
+      class="msg-channel"
+      role="button"
+      tabindex="0"
+      :style="styleFor(seg)"
+      @click.stop="openChannel(seg.channel)"
+      @keydown.enter.prevent="openChannel(seg.channel)"
+      @keydown.space.prevent="openChannel(seg.channel)"
+      >{{ seg.text }}</span
+    >
     <span v-else-if="hasStyle(seg)" :style="styleFor(seg)">{{ seg.text }}</span>
     <template v-else>{{ seg.text }}</template>
   </template>
@@ -29,31 +44,50 @@
 import type { CSSProperties } from 'vue';
 import type { RenderSegment } from '../utils/nickColor.js';
 import { segmentInlineStyle, segmentHasStyle } from '../utils/nickColor.js';
+import { useBuffersStore } from '../stores/buffers.js';
+import { socketSend } from '../composables/useSocket.js';
 import SpoilerText from './SpoilerText.vue';
 
 // The single renderer for an array of RenderSegments (the output of
 // splitTextByTokens): URLs, mIRC fg/bg colour, bold/italic/underline/strike,
-// nick coloring, and spoilers. Every message-list layout and LinkedText
-// funnel their segments through here, so a new segment kind only has to be
-// handled in one place — no render path can silently miss it.
+// nick coloring, channel names, and spoilers. Every message-list layout and
+// LinkedText funnel their segments through here, so a new segment kind only
+// has to be handled in one place — no render path can silently miss it.
 //
 // Branch order matters: spoiler is matched first because a spoiler segment
 // must never fall through to the plain <span>/text branches, which would
 // reveal the hidden content. `selfColor` tints segments belonging to the
 // current user; pass null where there's no message context (topic bar,
-// motd, part reasons, etc.).
+// motd, part reasons, etc.). `networkId` scopes clickable channel names to
+// the network the text belongs to — pass null and channels render as plain
+// text.
 const props = withDefaults(
   defineProps<{
     segments: RenderSegment[];
     selfColor?: string | null;
+    networkId?: number | null;
   }>(),
-  { selfColor: null },
+  { selfColor: null, networkId: null },
 );
+
+const buffers = useBuffersStore();
 
 function styleFor(seg: RenderSegment): CSSProperties {
   return segmentInlineStyle(seg, props.selfColor ?? null) as CSSProperties;
 }
 function hasStyle(seg: RenderSegment): boolean {
   return segmentHasStyle(seg);
+}
+
+// Clicking a channel name mirrors IRCCloud: if a buffer for it already exists
+// — you've been there before, even if since parted — just switch to it;
+// otherwise JOIN, which both enters the channel and opens its buffer.
+function openChannel(channel: string): void {
+  const nid = props.networkId;
+  if (nid == null) return;
+  if (!buffers.byKey(`${nid}::${channel}`)) {
+    socketSend({ type: 'join', networkId: nid, channel });
+  }
+  buffers.activate(nid, channel);
 }
 </script>

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -79,15 +79,22 @@ function hasStyle(seg: RenderSegment): boolean {
   return segmentHasStyle(seg);
 }
 
-// Clicking a channel name mirrors IRCCloud: if a buffer for it already exists
-// — you've been there before, even if since parted — just switch to it;
-// otherwise JOIN, which both enters the channel and opens its buffer.
+// Clicking a channel name mirrors IRCCloud. If the buffer is already open in
+// this client, just switch to it. Otherwise hand off to the server, which
+// decides (see the `open-buffer` handler): a channel with persisted history —
+// even one the user has since /closed — is reopened and re-seeded without
+// re-JOINing; a channel we've genuinely never visited gets joined. The client
+// can't make this call itself — closed buffers are filtered out of its
+// snapshot, so a since-closed channel is locally indistinguishable from a
+// brand-new one.
 function openChannel(channel: string): void {
   const nid = props.networkId;
   if (nid == null) return;
-  if (!buffers.byKey(`${nid}::${channel}`)) {
-    socketSend({ type: 'join', networkId: nid, channel });
+  if (buffers.byKey(`${nid}::${channel}`)) {
+    buffers.activate(nid, channel);
+    return;
   }
+  socketSend({ type: 'open-buffer', networkId: nid, target: channel });
   buffers.activate(nid, channel);
 }
 </script>

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -418,6 +418,16 @@ function handleMessage(raw: string): void {
     bookmarks.applyUpdate({ messageId: payload.messageId, saved: !!payload.saved });
     return;
   }
+  if (payload.kind === 'buffer-opened') {
+    // Reply to our own `open-buffer` request: the server resolved the
+    // canonical target — reopened a since-closed buffer, or joined a new
+    // channel. Focus it now. For a reopen the `backlog` frame sent just
+    // before this already recreated the buffer; for a join the channel-joined
+    // flow will. activate() ensures the buffer exists either way.
+    const buffers = useBuffersStore();
+    buffers.activate(payload.networkId, payload.target);
+    return;
+  }
   if (payload.kind === 'buffer-reopened') {
     // Server cleared the closed flag because a new persisted message landed.
     // The client doesn't need to do anything here — the matching `irc` event

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -97,6 +97,14 @@ describe('splitTextByTokens — channel detection', () => {
     ]);
   });
 
+  it('stops a channel name at a colon (RFC 2812 chanstring)', () => {
+    expect(parse('ping #ops:admins now')).toEqual([
+      { text: 'ping ' },
+      { text: '#ops', channel: '#ops' },
+      { text: ':admins now' },
+    ]);
+  });
+
   it('trims trailing sentence punctuation off a channel', () => {
     expect(parse('see (#foo).')).toEqual([
       { text: 'see (' },

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -122,19 +122,8 @@ describe('splitTextByTokens — channel detection', () => {
     expect(parse('I write C# daily')).toEqual([{ text: 'I write C# daily' }]);
   });
 
-  it('does not treat the "&" in "AT&T" as a channel', () => {
-    expect(parse('call AT&T today')).toEqual([{ text: 'call AT&T today' }]);
-  });
-
   it('does not treat a bare "#" as a channel', () => {
     expect(parse('a # b')).toEqual([{ text: 'a # b' }]);
-  });
-
-  it('detects an &-prefixed local channel', () => {
-    expect(parse('&local rules')).toEqual([
-      { text: '&local', channel: '&local' },
-      { text: ' rules' },
-    ]);
   });
 
   it('leaves a # fragment inside a URL alone', () => {

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -105,6 +105,11 @@ describe('splitTextByTokens — channel detection', () => {
     ]);
   });
 
+  it('ignores a token that trims down to just the bare prefix', () => {
+    // "#." matches the regex but trims to "#" — not enough to be a channel.
+    expect(parse('look at #. ok')).toEqual([{ text: 'look at #. ok' }]);
+  });
+
   it('trims trailing sentence punctuation off a channel', () => {
     expect(parse('see (#foo).')).toEqual([
       { text: 'see (' },

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -69,6 +69,79 @@ describe('splitTextByTokens — spoiler detection', () => {
   });
 });
 
+describe('splitTextByTokens — channel detection', () => {
+  it('splits a #channel into its own segment carrying a channel field', () => {
+    expect(parse('join #general now')).toEqual([
+      { text: 'join ' },
+      { text: '#general', channel: '#general' },
+      { text: ' now' },
+    ]);
+  });
+
+  it('keeps the whole token for a ##-prefixed channel', () => {
+    expect(parse('##python is great')).toEqual([
+      { text: '##python', channel: '##python' },
+      { text: ' is great' },
+    ]);
+  });
+
+  it('matches a channel at the very start of the text', () => {
+    expect(parse('#foo')).toEqual([{ text: '#foo', channel: '#foo' }]);
+  });
+
+  it('keeps dashes and dots inside a channel name', () => {
+    expect(parse('try #my-cool.chan ok')).toEqual([
+      { text: 'try ' },
+      { text: '#my-cool.chan', channel: '#my-cool.chan' },
+      { text: ' ok' },
+    ]);
+  });
+
+  it('trims trailing sentence punctuation off a channel', () => {
+    expect(parse('see (#foo).')).toEqual([
+      { text: 'see (' },
+      { text: '#foo', channel: '#foo' },
+      { text: ').' },
+    ]);
+  });
+
+  it('does not treat "C#" as a channel — the # follows a word char', () => {
+    expect(parse('I write C# daily')).toEqual([{ text: 'I write C# daily' }]);
+  });
+
+  it('does not treat the "&" in "AT&T" as a channel', () => {
+    expect(parse('call AT&T today')).toEqual([{ text: 'call AT&T today' }]);
+  });
+
+  it('does not treat a bare "#" as a channel', () => {
+    expect(parse('a # b')).toEqual([{ text: 'a # b' }]);
+  });
+
+  it('detects an &-prefixed local channel', () => {
+    expect(parse('&local rules')).toEqual([
+      { text: '&local', channel: '&local' },
+      { text: ' rules' },
+    ]);
+  });
+
+  it('leaves a # fragment inside a URL alone', () => {
+    expect(parse('docs https://example.com/page#install here')).toEqual([
+      { text: 'docs ' },
+      {
+        url: 'https://example.com/page#install',
+        text: 'https://example.com/page#install',
+      },
+      { text: ' here' },
+    ]);
+  });
+
+  it('carries active IRC formatting onto a channel segment', () => {
+    expect(parse(`${BOLD}#bold-chan`)).toEqual([
+      { text: '#bold-chan', channel: '#bold-chan', bold: true },
+    ]);
+  });
+});
+
 describe('segmentInlineStyle / segmentHasStyle — background colour', () => {
   it('maps a background code to a backgroundColor', () => {
     expect(segmentInlineStyle({ text: 'x', fg: 4, bg: 8 }, null)).toEqual({

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -149,16 +149,18 @@ interface ChannelSegment {
 type ChannelOrTextSegment = ChannelSegment | TextSegment;
 
 // Split text on IRC channel names. A channel token is a `#`/`&` prefix
-// followed by a run of non-space, non-comma characters; trailing sentence
-// punctuation is trimmed the same way URLs are. The prefix must not sit
-// directly after a word character, so "C#" and "AT&T" don't read as channels.
-// `##anime`-style double-hash names work because the second `#` is just an
-// ordinary body character. Runs on text that has already had URLs split out,
-// so a `#anchor` inside a link never reaches this pass.
+// followed by a run of characters valid in an IRC channel name: per RFC 2812
+// that rules out whitespace, commas, and colons (`:` begins the optional
+// channel mask). Trailing sentence punctuation is trimmed the same way URLs
+// are. The prefix must not sit directly after a word character, so "C#" and
+// "AT&T" don't read as channels. `##anime`-style double-hash names work
+// because the second `#` is just an ordinary body character. Runs on text
+// that has already had URLs split out, so a `#anchor` inside a link never
+// reaches this pass.
 function splitTextByChannels(text: string): ChannelOrTextSegment[] {
   const out: ChannelOrTextSegment[] = [];
   if (!text) return out;
-  const re = /(?<![A-Za-z0-9_])[#&][^\s,]+/g;
+  const re = /(?<![A-Za-z0-9_])[#&][^\s,:]+/g;
   let lastIdx = 0;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -148,19 +148,21 @@ interface ChannelSegment {
 
 type ChannelOrTextSegment = ChannelSegment | TextSegment;
 
-// Split text on IRC channel names. A channel token is a `#`/`&` prefix
-// followed by a run of characters valid in an IRC channel name: per RFC 2812
-// that rules out whitespace, commas, and colons (`:` begins the optional
-// channel mask). Trailing sentence punctuation is trimmed the same way URLs
-// are. The prefix must not sit directly after a word character, so "C#" and
-// "AT&T" don't read as channels. `##anime`-style double-hash names work
-// because the second `#` is just an ordinary body character. Runs on text
-// that has already had URLs split out, so a `#anchor` inside a link never
-// reaches this pass.
+// Split text on IRC channel names. A channel token is a `#` prefix followed
+// by a run of characters valid in an IRC channel name: per RFC 2812 that
+// rules out whitespace, commas, and colons (`:` begins the optional channel
+// mask). Trailing sentence punctuation is trimmed the same way URLs are. The
+// prefix must not sit directly after a word character, so "C#" doesn't read
+// as a channel. `##anime`-style double-hash names work because the second
+// `#` is just an ordinary body character. `&`-prefixed local channels and
+// other rare prefixes aren't supported here, matching the rest of the app
+// (BufferList sort/render, the buffer-actions menu, etc.) which all
+// hard-code `#`. Runs on text that has already had URLs split out, so a
+// `#anchor` inside a link never reaches this pass.
 function splitTextByChannels(text: string): ChannelOrTextSegment[] {
   const out: ChannelOrTextSegment[] = [];
   if (!text) return out;
-  const re = /(?<![A-Za-z0-9_])[#&][^\s,:]+/g;
+  const re = /(?<![A-Za-z0-9_])#[^\s,:]+/g;
   let lastIdx = 0;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -58,14 +58,15 @@ function escapeRegex(s: string): string {
 
 // URL detection lives in shared/urlPattern.ts so the server's highlight
 // engine can exclude links from highlight matching using the same definition.
-// trimUrlTail (below) then strips trailing sentence punctuation so
+// trimTrailingPunctuation (below) then strips trailing sentence punctuation so
 // "see https://example.com." doesn't keep the period.
 
 // Strip trailing punctuation that's almost certainly part of the surrounding
-// sentence rather than the URL. Closing brackets are only stripped when they'd
-// be unbalanced inside the URL — `https://en.wikipedia.org/wiki/Foo_(bar)`
-// keeps its trailing ')', but `(see https://example.com)` doesn't.
-function trimUrlTail(s: string): string {
+// sentence rather than the token. Closing brackets are only stripped when
+// they'd be unbalanced inside the token — `https://en.wikipedia.org/wiki/Foo_(bar)`
+// keeps its trailing ')', but `(see https://example.com)` doesn't. Shared by
+// the URL and channel-name splitters.
+function trimTrailingPunctuation(s: string): string {
   const PAIRS: Record<string, string> = { ')': '(', ']': '[', '}': '{' };
   let end = s.length;
   while (end > 0) {
@@ -124,7 +125,7 @@ function splitTextByUrls(text: string): UrlOrTextSegment[] {
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
     const start = m.index;
-    const matched = trimUrlTail(m[0]);
+    const matched = trimTrailingPunctuation(m[0]);
     if (!matched) {
       // The whole match was punctuation (shouldn't happen given the regex
       // requires a scheme/www prefix, but guard anyway).
@@ -134,6 +135,44 @@ function splitTextByUrls(text: string): UrlOrTextSegment[] {
     re.lastIndex = start + matched.length;
     if (start > lastIdx) out.push({ kind: 'text', text: text.slice(lastIdx, start) });
     out.push({ kind: 'url', text: matched, href: urlHref(matched) });
+    lastIdx = start + matched.length;
+  }
+  if (lastIdx < text.length) out.push({ kind: 'text', text: text.slice(lastIdx) });
+  return out;
+}
+
+interface ChannelSegment {
+  kind: 'channel';
+  text: string;
+}
+
+type ChannelOrTextSegment = ChannelSegment | TextSegment;
+
+// Split text on IRC channel names. A channel token is a `#`/`&` prefix
+// followed by a run of non-space, non-comma characters; trailing sentence
+// punctuation is trimmed the same way URLs are. The prefix must not sit
+// directly after a word character, so "C#" and "AT&T" don't read as channels.
+// `##anime`-style double-hash names work because the second `#` is just an
+// ordinary body character. Runs on text that has already had URLs split out,
+// so a `#anchor` inside a link never reaches this pass.
+function splitTextByChannels(text: string): ChannelOrTextSegment[] {
+  const out: ChannelOrTextSegment[] = [];
+  if (!text) return out;
+  const re = /(?<![A-Za-z0-9_])[#&][^\s,]+/g;
+  let lastIdx = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const start = m.index;
+    const matched = trimTrailingPunctuation(m[0]);
+    // A token that trims down to the bare prefix (e.g. "#." mid-sentence) is
+    // not a channel — it needs the prefix plus at least one body character.
+    if (matched.length < 2) {
+      re.lastIndex = start + 1;
+      continue;
+    }
+    re.lastIndex = start + matched.length;
+    if (start > lastIdx) out.push({ kind: 'text', text: text.slice(lastIdx, start) });
+    out.push({ kind: 'channel', text: matched });
     lastIdx = start + matched.length;
   }
   if (lastIdx < text.length) out.push({ kind: 'text', text: text.slice(lastIdx) });
@@ -354,6 +393,10 @@ export interface RenderSegment {
   // shows as a click-to-reveal spoiler. Carries no fg/bg — SpoilerText draws
   // its own box — but keeps any bold/italic/underline/strike for the reveal.
   spoiler?: boolean;
+  // An IRC channel name (#/&-prefixed). `text` holds the same string; the
+  // renderer turns it into a clickable join/switch affordance when it has a
+  // network to act on, otherwise it renders as plain text.
+  channel?: string;
 }
 
 // Build a Vue inline-style object for a segment. Colour precedence: an
@@ -394,6 +437,29 @@ export function segmentHasStyle(seg: RenderSegment): boolean {
   );
 }
 
+// Channel detection then nick detection over a plain (URL-free) text run.
+// Channels are matched first because a channel token can't contain a nick
+// (nicks never start with #/&), so the order is unambiguous.
+function splitPlainText(
+  text: string,
+  nickSet: Set<string> | null | undefined,
+  selfLower: string | null | undefined,
+  colorFn: ((nick: string) => string | null) | null | undefined,
+): RenderSegment[] {
+  const out: RenderSegment[] = [];
+  for (const seg of splitTextByChannels(text)) {
+    if (seg.kind === 'channel') {
+      out.push({ text: seg.text, channel: seg.text });
+      continue;
+    }
+    if (!seg.text) continue;
+    for (const ns of colorNicksInText(seg.text, nickSet, selfLower, colorFn)) {
+      if (ns.text) out.push(ns);
+    }
+  }
+  return out;
+}
+
 function splitRunIntoSegments(
   text: string,
   nickSet: Set<string> | null | undefined,
@@ -401,21 +467,14 @@ function splitRunIntoSegments(
   colorFn: ((nick: string) => string | null) | null | undefined,
 ): RenderSegment[] {
   if (!text) return [];
-  const urlSegments = splitTextByUrls(text);
-  if (urlSegments.length === 0) {
-    return colorNicksInText(text, nickSet, selfLower, colorFn).filter((s) => s.text);
-  }
   const out: RenderSegment[] = [];
-  for (const seg of urlSegments) {
+  for (const seg of splitTextByUrls(text)) {
     if (seg.kind === 'url') {
       out.push({ url: seg.href, text: seg.text });
       continue;
     }
     if (!seg.text) continue;
-    const nickSegs = colorNicksInText(seg.text, nickSet, selfLower, colorFn);
-    for (const ns of nickSegs) {
-      if (ns.text) out.push(ns);
-    }
+    out.push(...splitPlainText(seg.text, nickSet, selfLower, colorFn));
   }
   return out;
 }
@@ -428,6 +487,7 @@ function splitRunIntoSegments(
 //   { text, spoiler, ...fmt }           — hidden run (fg===bg); render as a
 //                                         click-to-reveal box, never an <a>
 //   { url, text, ...fmt }               — clickable link (with formatting)
+//   { channel, text, ...fmt }           — clickable IRC channel name
 //   { text, color?, self?, ...fmt }     — nick / plain text (with formatting)
 // where fmt is { bold?, italic?, underline?, strike?, fg?, bg? }.
 export function splitTextByTokens(


### PR DESCRIPTION
## What

Closes #21. `#channel` names in chat messages are now clickable — click to switch to, reopen, or join that channel.

## Tokenizer

A channel-name pass is added to the message tokenizer (`utils/nickColor.ts`), alongside the existing URL and nick passes:

- `splitTextByChannels` detects `#`-prefixed tokens. The token body follows RFC 2812 chanstring rules — no whitespace, commas, or colons (`#foo:bar` → `#foo` + `:bar`). `##anime`-style double-hash names are supported (the second `#` is just an ordinary body character). The prefix must not directly follow a word character, so `C#` doesn't read as a channel. Trailing sentence punctuation is trimmed with the same balanced-bracket helper URLs use (`trimUrlTail` → renamed `trimTrailingPunctuation`, now shared).
- Only `#` is supported — `&`/`+`/`!` channels aren't detected, matching the rest of the app (BufferList sorting, the buffer-actions menu, etc.) which all hard-code `#`.
- Runs **after** URL splitting, so a `#anchor` inside a link is never mistaken for a channel.
- `RenderSegment` gains a `channel` field. `RenderSegments.vue` renders it as a clickable, keyboard-accessible ref — but only when given a `networkId` (the message list passes the active buffer's network; topic bar / motd pass none and channels render as plain text there).

## Click behavior

Mirrors IRCCloud. IRC channel names are case-insensitive, so the client matches the network's open buffers case-insensitively:

- A buffer is **already open** for the channel (any casing) → switch to it.
- Otherwise → send the server an `open-buffer` request. The server resolves it against buffers with persisted history (case-insensitively):
  - **History exists** — even a channel the user has since `/close`d → reopen the buffer and re-seed its history. **No re-JOIN.** You land in a history view (last event "yournick left").
  - **No history anywhere** — a channel never visited → **JOIN** it.
  - Either way the server replies `buffer-opened` with the canonical target, which the requesting tab focuses — so the casing is always correct and no stray mis-cased buffer is created.

This is a server-side decision because closed buffers are filtered out of the client snapshot — the client can't itself distinguish a since-closed channel from a brand-new one.

## Styling

`.msg-channel` keeps the **normal message text colour** — the pointer cursor and a hover underline are the only cues. Keyboard-accessible (`role="button"`, `tabindex`, Enter/Space).

## Tests

Tokenizer tests cover detection, `##` names, start-of-text, dashes/dots, the colon boundary, punctuation trimming, the `C#` / bare-`#` negatives, URL-fragment exclusion, the trim-to-bare-prefix case, and IRC-formatting passthrough. A new `wsHub.test.ts` drives `handleOpenBuffer` / `buildBufferBacklog` against a real test DB — reopen-vs-join, case-insensitive canonical resolution, and the guard for blank/server-buffer targets. Full suite: 624 passing. `typecheck` (server + client), `lint`, `format:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)