### PR TITLE
Defer pin drag-to-reorder on touch so list scroll wins

### DIFF
--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -31,6 +31,12 @@
           }}</span>
         </div>
 
+        <!-- Touch delay (200ms, touch-only) so a quick swipe over the pinned
+             section scrolls the channel list instead of starting a reorder.
+             Press-and-hold still initiates drag — the iOS/Discord/Slack
+             reorder convention. touchStartThreshold cancels the pending drag
+             if the finger moves more than 5px during the delay, so scroll
+             intent is recognised early. Desktop mouse drag stays instant. -->
         <draggable
           v-if="(pinnedBufsByNet[net.id] || []).length"
           :list="pinnedBufsByNet[net.id]"
@@ -39,6 +45,9 @@
           class="channels pinned"
           :animation="120"
           ghost-class="drag-ghost"
+          :delay="200"
+          :delay-on-touch-only="true"
+          :touch-start-threshold="5"
           @start="dragging = true"
           @end="onPinDragEnd(net.id)"
         >


### PR DESCRIPTION
Fixes #65.

## Problem
The pinned-section `<draggable>` in `BufferList.vue` caught touch immediately, so on a long channel list any swipe that started over a pinned row started a reorder gesture instead of scrolling — you couldn't get past the pinned section on mobile.

## Fix
Pass SortableJS's `delay` (200ms) + `delayOnTouchOnly` through vuedraggable. Quick swipe → scroll; press-and-hold → reorder, matching the iOS / Discord / Slack convention. `touchStartThreshold: 5` cancels the pending drag the moment the finger moves more than 5px during the delay window, so scroll intent is recognised early and the long-press is still forgiving of small jitter.

Desktop mouse drag stays instant because `delayOnTouchOnly: true`.

## Verification
- [x] `npm run check` (typecheck server + client, oxlint, oxfmt) — clean
- [x] `npm run client:build` — clean
- [x] Manual: on mobile, swipe over the pinned section scrolls the list; long-press still initiates a reorder
- [x] Manual: desktop mouse drag is unchanged (no perceived delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)