### PR TITLE
Accessibility: combobox + listbox ARIA for nick completion (#55)

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -27,6 +27,7 @@
       :spellcheck="systemFeatures.spellcheck"
       :autocorrect="systemFeatures.autocorrect"
       :autocapitalize="systemFeatures.autocapitalize"
+      v-bind="comboboxAttrs"
       @keydown="onKeydown"
       @paste="onPaste"
       @blur="onBlur"
@@ -78,8 +79,10 @@
       :buffer="buffer"
       :self-nick="ownNick"
       :anchor="formEl"
+      :listbox-id="nickListboxId"
       @select="onPickerSelect"
       @close="closePicker"
+      @active-change="pickerActiveOptionId = $event"
     />
     <NickSuggestionStrip
       v-show="stripOpen"
@@ -114,7 +117,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount, onMounted } from 'vue';
+import { ref, computed, watch, onBeforeUnmount, onMounted, useId } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
@@ -161,6 +164,27 @@ const pickerQuery = ref('');
 const nickPickerEl = ref<InstanceType<typeof NickPicker> | null>(null);
 let pickerTokenStart = -1;
 let pickerTokenEnd = -1;
+// ARIA combobox wiring for the @-picker (issue #55). The textarea is the
+// combobox; the picker panel is the listbox popup. The id is generated once
+// per MessageInput instance and shared with NickPicker so the textarea can
+// point aria-controls / aria-activedescendant at matching elements. The
+// active option id is mirrored from NickPicker's `active-change` emit —
+// empty string when the picker is closed or has no rows, which we surface
+// as `undefined` on the attribute so it doesn't reference a missing element.
+const nickListboxId = useId();
+const pickerActiveOptionId = ref('');
+const comboboxAttrs = computed(() =>
+  pickerOpen.value
+    ? ({
+        role: 'combobox',
+        'aria-haspopup': 'listbox',
+        'aria-autocomplete': 'list',
+        'aria-expanded': 'true',
+        'aria-controls': nickListboxId,
+        'aria-activedescendant': pickerActiveOptionId.value || undefined,
+      } as const)
+    : {},
+);
 const stripOpen = ref(false);
 const stripQuery = ref('');
 let stripTokenStart = -1;

--- a/vue_client/src/components/NickPicker.vue
+++ b/vue_client/src/components/NickPicker.vue
@@ -4,11 +4,19 @@
 -->
 
 <template>
+  <!-- ARIA combobox + listbox pattern: focus stays on the host textarea
+       (which carries role="combobox") while this panel renders the listbox
+       popup. The textarea announces the active row via aria-activedescendant
+       pointing at an option's id — see `optionId()` below for the format the
+       host is expected to mirror. -->
   <div
     v-if="open && rows.length"
     ref="panelEl"
     class="nick-picker"
     :style="panelStyle"
+    role="listbox"
+    :id="listboxId"
+    aria-label="Nick completion suggestions"
     @pointerdown.stop
   >
     <div
@@ -16,6 +24,9 @@
       :key="row.lc + ':' + row.index"
       class="row"
       :class="{ active: row.index === activeIndex }"
+      role="option"
+      :id="optionId(row.index)"
+      :aria-selected="row.index === activeIndex"
       @pointerdown.prevent="pick(row.nick)"
       @mouseenter="activeIndex = row.index"
     >
@@ -39,6 +50,10 @@ const props = withDefaults(
     buffer?: Buffer | null;
     selfNick?: string;
     anchor?: HTMLElement | null;
+    // ARIA wiring: the host (MessageInput) owns the id namespace so its
+    // textarea can set aria-controls / aria-activedescendant against
+    // matching ids without timing or ref-unwrap gymnastics.
+    listboxId?: string;
   }>(),
   {
     open: false,
@@ -46,12 +61,18 @@ const props = withDefaults(
     buffer: null,
     selfNick: '',
     anchor: null,
+    listboxId: '',
   },
 );
 
 const emit = defineEmits<{
   select: [nick: string];
   close: [];
+  // Fires whenever the active option id changes — either because the user
+  // moved the highlight or because the candidate list rebuilt. Empty string
+  // means no active option (picker closed or no rows). The host mirrors this
+  // value into the textarea's aria-activedescendant.
+  'active-change': [optionId: string];
 }>();
 
 const ignores = useIgnoresStore();
@@ -94,6 +115,13 @@ const renderedRows = computed(() => rows.value.slice().reverse());
 
 function pick(nick: string) {
   emit('select', nick);
+}
+
+// Stable per-row id for aria-activedescendant. Indexes the original
+// candidate order, not the reversed render order, so the host's "active"
+// pointer matches `activeIndex` directly.
+function optionId(index: number): string {
+  return `${props.listboxId}-opt-${index}`;
 }
 
 // Keyboard navigation, driven from MessageInput's textarea keydown handler:
@@ -196,6 +224,15 @@ watch(
     }
   },
 );
+
+// The id the host should expose via aria-activedescendant. Empty when the
+// picker isn't actually showing anything (closed or no rows) so the host
+// can clear the attribute and not point at a non-existent element.
+const activeOptionId = computed(() =>
+  props.open && rows.value.length > 0 ? optionId(activeIndex.value) : '',
+);
+
+watch(activeOptionId, (id) => emit('active-change', id), { immediate: true });
 </script>
 
 <style scoped>

--- a/vue_client/src/components/NickSuggestionStrip.vue
+++ b/vue_client/src/components/NickSuggestionStrip.vue
@@ -4,9 +4,15 @@
 -->
 
 <template>
+  <!-- Listbox semantics so the strip reads as a group of completion options
+       under VoiceOver/TalkBack rather than a row of stray buttons. The strip
+       has no active state (it's tap-only — keyboard nav lives on the desktop
+       NickPicker), so chips carry role="option" but no aria-selected. -->
   <div
     class="nick-suggestion-strip"
     :class="{ visible: rows.length > 0 }"
+    role="listbox"
+    aria-label="Nick suggestions"
     @pointerdown.stop
     @mousedown.prevent.stop
   >
@@ -24,7 +30,7 @@
     <div
       v-for="row in rows"
       :key="row.lc"
-      role="button"
+      role="option"
       class="chip"
       :style="row.color ? { color: row.color } : null"
       @mousedown.prevent


### PR DESCRIPTION
Closes #55.

Adopts the W3C [combobox-with-listbox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) pattern across the two nick completion UIs so screen reader users can actually perceive and use them. Focus stays on the textarea while either picker is open, so the active row has to be announced via `aria-activedescendant` — a partial fix (just `role=option`/`aria-selected`) wouldn't have helped, which is the reason this was split out of #53 in the first place.

## What changed

- **`NickPicker.vue`** (desktop @-picker)
  - Panel: `role="listbox"`, host-provided `id`, `aria-label="Nick completion suggestions"`.
  - Rows: `role="option"`, stable `id` (`${listboxId}-opt-${index}`), `aria-selected` on the active row.
  - New `active-change` emit so the host can mirror the active option id into `aria-activedescendant`.
- **`NickSuggestionStrip.vue`** (mobile strip, tap-only)
  - Container: `role="listbox"`, `aria-label="Nick suggestions"`.
  - Chips: `role="option"` instead of `role="button"` — they're completion options inside a listbox, not standalone buttons. No `aria-selected` since the strip has no active state.
- **`MessageInput.vue`**
  - One `useId()` generates the listbox id per MessageInput instance, passed to NickPicker and referenced from `aria-controls`.
  - `pickerActiveOptionId` mirrors NickPicker's `active-change` into `aria-activedescendant`.
  - The textarea wears combobox semantics (`role`, `aria-haspopup`, `aria-autocomplete=list`, `aria-expanded`, `aria-controls`, `aria-activedescendant`) **only while the picker is open** — plain chat typing isn't overpromised as a combobox.

## Out of scope

The emoji `SuggestionStrip` has the same shape and would benefit from the same treatment, but the issue is scoped to nick completion UIs — left for a follow-up.

## How to QA

**Desktop (VoiceOver on macOS, or NVDA on Windows):**

1. Focus the message input. With VO on, you should hear "edit text" (plain textarea — no combobox announcement yet).
2. Type `@a` (or `@` followed by a few letters that match nicks in the channel). VO should now announce something like "combobox, expanded, … selected, 1 of N" — the picker is now a listbox of options and the textarea reports as a combobox.
3. Press Up/Down arrows. Each move should be announced as the new nick + "selected" + the position. The visual highlight and the announced selection must agree.
4. Press Tab or Enter to confirm — picker closes, combobox collapses (next focus event should report plain "edit text" again).
5. Press `@` and type something with no matches (`@zzz...`). Picker shouldn't render; the combobox role/expanded attrs should not appear in DOM. Inspect with devtools.
6. **DOM spot-check:** with the picker open, inspect the textarea — should have `role=combobox`, `aria-expanded=true`, `aria-controls` pointing at the listbox's id, `aria-activedescendant` pointing at an existing `<div role=option>` id. Arrow up/down should change `aria-activedescendant` to the next option's id.

**Mobile (VoiceOver on iOS):**

1. Focus the message input on a phone-width layout (the mobile strip lives above the StatusBar).
2. Type `@` + letters. Swipe right past the textarea; VO should announce "Nick suggestions, list" and then read each chip as "$nick, 1 of N".
3. Double-tap a chip — completion inserts and keyboard stays up (no regression on the existing iOS focus-preservation work).

**Regression sanity (no AT):**
- Arrow keys still navigate the desktop picker; Tab/Enter still confirm; click/hover still work.
- Mobile strip taps still complete without dismissing the keyboard.
- `npm run check` passes; `npm test` is green (624/624).

🤖 Generated with [Claude Code](https://claude.com/claude-code)