### PR TITLE
Mobile-specific font size: `look.font.size.mobile` (#82)

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -98,7 +98,23 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     min: 9,
     max: 32,
     default: 14,
-    description: 'Base font size in pixels for the whole UI.',
+    description:
+      'Base font size in pixels for the whole UI. ' +
+      'Phone-sized viewports use `look.font.size.mobile` instead.',
+  },
+  {
+    key: 'look.font.size.mobile',
+    label: 'Font size (mobile)',
+    category: 'appearance',
+    group: 'fonts',
+    type: 'int',
+    min: 9,
+    max: 32,
+    default: 14,
+    description:
+      'Base font size in pixels used on phone-sized viewports (≤768px). ' +
+      'Lets the desktop and mobile UIs scale independently — a large desktop ' +
+      'setting need not be inherited on a phone, or vice versa.',
   },
   {
     key: 'look.font.weight',

--- a/vue_client/src/composables/useTheme.ts
+++ b/vue_client/src/composables/useTheme.ts
@@ -3,6 +3,7 @@
 
 import { watchEffect } from 'vue';
 import { useSettingsStore } from '../stores/settings.js';
+import { useViewport } from './useViewport.js';
 
 // Maps each settings key to the CSS custom property it controls. Anything in
 // here is live-rewritten on :root whenever the settings store changes, so the
@@ -35,6 +36,7 @@ export function useTheme(): void {
   if (installed) return;
   installed = true;
   const settings = useSettingsStore();
+  const { isMobile } = useViewport();
   const root = document.documentElement;
 
   watchEffect(() => {
@@ -42,7 +44,11 @@ export function useTheme(): void {
       root.style.setProperty(cssVar, String(settings.effective(key)));
     }
     root.style.setProperty('--mono', String(settings.effective('look.font.family')));
-    root.style.setProperty('--font-size', `${settings.effective('look.font.size')}px`);
+    // Mobile gets its own size so a large desktop setting (and the large icons
+    // that come with it) doesn't have to follow you onto a phone. The viewport
+    // breakpoint flips live, so resizing across it re-applies the right value.
+    const fontSizeKey = isMobile.value ? 'look.font.size.mobile' : 'look.font.size';
+    root.style.setProperty('--font-size', `${settings.effective(fontSizeKey)}px`);
     root.style.setProperty('--font-weight', String(settings.effective('look.font.weight')));
     const macSmoothing = !!settings.effective('look.font.smoothing_macos');
     root.style.setProperty(


### PR DESCRIPTION
Closes #82.

Adds a sibling to `look.font.size` that's used on phone-sized viewports (the existing ≤768px breakpoint from `useViewport`). Defaults to 14 — same as the desktop key — so behavior is unchanged until the user sets one or the other.

## Why

If you crank `look.font.size` up on a 4K desktop and then open the PWA on a phone, the mobile UI inherits that — which doesn't read well on a small screen. And vice versa: pumping up mobile for one-handed reading shouldn't force a huge desktop UI. Two independent keys let each viewport scale on its own.

## What changed

- **`shared/settingsRegistry.ts`** — new `look.font.size.mobile` entry (int 9–32, default 14). Description on the existing `look.font.size` updated to point at it.
- **`vue_client/src/composables/useTheme.ts`** — picks the active key based on `useViewport().isMobile`. Because `isMobile` is a live ref, `watchEffect` re-applies `--font-size` when the user crosses the breakpoint (e.g. responsive devtools, rotating a tablet).

DesktopChat's foot-wrap watcher still listens on `look.font.size` only — it's `v-else`'d off below the breakpoint, so the mobile key can never be the active one there.

## How to QA

1. Open Lurker on a desktop window narrower than 768px (or use devtools responsive mode at, say, 400px wide). Note current font size.
2. Settings → Appearance → Fonts → change "Font size (mobile)" to something obviously different (e.g. 22). UI should re-scale immediately.
3. Resize the window wider than 768px (or toggle out of responsive mode). UI should snap back to the desktop "Font size" value live, no reload needed.
4. Set them to different obvious values (desktop 12, mobile 22) and resize across the breakpoint a few times — they should swap cleanly each direction.
5. Reset both to default; both should disappear from the user's `effective` overrides and the UI should return to 14px on either side of the breakpoint.

`npm run check` and `npm test` pass (624/624).

🤖 Generated with [Claude Code](https://claude.com/claude-code)