### PR TITLE
issue #11: pin top-level shells to the visualViewport so iPad runs the desktop layout correctly

### DIFF
--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -14,6 +14,7 @@ import { onMounted } from 'vue';
 import { useAuthStore } from './stores/auth.js';
 import { useSettingsStore } from './stores/settings.js';
 import { useTheme } from './composables/useTheme.js';
+import { useVisualViewportHeight } from './composables/useViewport.js';
 import ToastContainer from './components/ToastContainer.vue';
 import ContextMenu from './components/ContextMenu.vue';
 
@@ -21,6 +22,13 @@ const auth = useAuthStore();
 const settings = useSettingsStore();
 
 useTheme();
+
+// Pin --viewport-h / --viewport-y to the visualViewport at the app root so both
+// the mobile and desktop shells stay glued to the visible region when iOS
+// shifts the layout viewport (URL-bar collapse, soft-keyboard open). Mobile
+// originally owned this; iPad runs the desktop layout (width > 768px) and
+// needs the same accounting — see issue #11.
+useVisualViewportHeight();
 
 onMounted(() => {
   auth.fetchMe();

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -58,11 +58,13 @@
    on iOS, a focused text input means the keyboard is up and there's no home
    indicator to clear. */
 @media (display-mode: standalone) {
-  .mchat {
+  .mchat,
+  .chat {
     box-sizing: border-box;
     padding-bottom: env(safe-area-inset-bottom);
   }
-  :root:has(input:focus, textarea:focus, [contenteditable]:focus) .mchat {
+  :root:has(input:focus, textarea:focus, [contenteditable]:focus) .mchat,
+  :root:has(input:focus, textarea:focus, [contenteditable]:focus) .chat {
     padding-bottom: 0;
   }
 }

--- a/vue_client/src/components/AppModal.vue
+++ b/vue_client/src/components/AppModal.vue
@@ -99,8 +99,18 @@ onMounted(() => {
 
 <style scoped>
 .modal {
+  /* Size to the visualViewport rather than the layout viewport. On iOS
+     Safari `inset: 0` + bare `100vh` overshoots — the layout viewport
+     includes the URL-bar zone, so the modal box (and the card centered
+     inside it) extended below the visible bottom on iPad. --viewport-h /
+     --viewport-y come from useVisualViewportHeight() in App.vue; on real
+     desktops both are no-ops. See issue #11. */
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--viewport-h, 100dvh);
+  transform: translateY(var(--viewport-y, 0));
   background: var(--bg);
   display: flex;
   justify-content: center;
@@ -113,13 +123,15 @@ onMounted(() => {
 }
 .modal.align-top {
   align-items: flex-start;
-  padding-top: 2vh;
+  padding-top: 2dvh;
 }
-/* Match the 2vh top so a fully-tall card has equal breathing room
-   above and below. Default .card max-height: 85vh would otherwise
-   leave a ~13vh gap at the bottom. */
+/* Match the 2dvh top so a fully-tall card has equal breathing room
+   above and below. Default .card max-height: 85dvh would otherwise
+   leave a ~13dvh gap at the bottom. dvh (dynamic viewport height)
+   tracks the visible area as the iPad URL bar collapses; plain vh
+   would lock to the layout viewport and overflow. */
 .modal.align-top .card {
-  max-height: 96vh;
+  max-height: 96dvh;
 }
 
 /* On mobile every modal becomes a full-screen sheet — the card fills the
@@ -146,7 +158,8 @@ onMounted(() => {
 .card {
   position: relative;
   width: min(720px, 92vw);
-  max-height: 85vh;
+  /* dvh, not vh — see the note on .modal above. */
+  max-height: 85dvh;
   display: flex;
   flex-direction: column;
   background: var(--bg);

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -575,8 +575,14 @@ onBeforeUnmount(() => {
   cursor: pointer;
   border-left: 2px solid transparent;
 }
-.net-head:hover {
-  background: var(--bg-soft);
+/* Gate :hover behind (hover: hover) so iPad-in-desktop-layout (width > 768px,
+   touch-only) doesn't get the iOS sticky-hover two-tap: with bare :hover the
+   first tap is consumed as a hover preview, only the second activates. See
+   issue #11. */
+@media (hover: hover) {
+  .net-head:hover {
+    background: var(--bg-soft);
+  }
 }
 .net-head.active {
   background: var(--bg-soft);
@@ -656,8 +662,10 @@ onBeforeUnmount(() => {
   border-left: 1px solid var(--border);
   pointer-events: none;
 }
-.channels li:hover {
-  background: var(--bg-soft);
+@media (hover: hover) {
+  .channels li:hover {
+    background: var(--bg-soft);
+  }
 }
 .channels li.active {
   background: var(--bg-soft);
@@ -736,12 +744,20 @@ onBeforeUnmount(() => {
   opacity: 0;
   transition: opacity 80ms linear;
 }
-.channels li:hover .row-actions,
+/* Reveal the row-actions button on hover (desktop) or keyboard focus (a11y).
+   No touch path here on purpose — long-press fires `contextmenu` on the row,
+   which already opens the same buffer-actions menu, so iPad users reach
+   identical functionality without paying the sticky-hover two-tap tax. */
+@media (hover: hover) {
+  .channels li:hover .row-actions {
+    opacity: 1;
+  }
+  .channels .row-actions:hover {
+    color: var(--fg);
+  }
+}
 .channels .row-actions:focus-visible {
   opacity: 1;
-}
-.channels .row-actions:hover {
-  color: var(--fg);
 }
 @media (max-width: 768px) {
   .channels .row-actions {

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -396,7 +396,19 @@ useChatBootstrap({ onJump: onJumpToMessage });
     'sidebar messages members'
     'sidebar status   status'
     'sidebar input    input';
-  height: 100vh;
+  /* iPad runs this layout (width > 768px). Mirror .mchat's shell discipline:
+     pin to the visualViewport so the URL-bar collapse / soft-keyboard scroll
+     can't push the top or bottom of the grid offscreen. --viewport-h tracks
+     the actually-visible height; --viewport-y cancels iOS's auto-scroll on
+     focus. Both vars come from useVisualViewportHeight() in App.vue, with
+     100dvh / 0 as first-paint fallbacks. On real desktops the visualViewport
+     equals the window, so this is a no-op there. See issue #11. */
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--viewport-h, 100dvh);
+  transform: translateY(var(--viewport-y, 0));
   overflow: hidden;
 }
 .chat.sidebar-collapsed {

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -136,7 +136,6 @@ import type { Network } from '../stores/networks.js';
 import type { BufferLike } from '../composables/useBufferActions.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useSocket } from '../composables/useSocket.js';
-import { useVisualViewportHeight } from '../composables/useViewport.js';
 import { useChatBootstrap } from '../composables/useChatBootstrap.js';
 import { useActiveBuffer } from '../composables/useActiveBuffer.js';
 import { useBufferActions } from '../composables/useBufferActions.js';
@@ -180,10 +179,6 @@ function openSystemConsole() {
   // directly so the second tap behaves like the first.
   screen.value = 'buffer';
 }
-
-// Pin --viewport-h to the visualViewport height so the shell stays glued to
-// the visible region when the iOS soft keyboard pushes content up.
-useVisualViewportHeight();
 
 // `list` (default) → tap a buffer → `buffer` → tap members icon → `members`.
 // Back arrows walk the stack backwards. We don't sync this to the URL — the

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -166,7 +166,19 @@ watch(
 
 <style scoped>
 .settings-page {
-  height: 100vh;
+  /* Same shell discipline as .chat / .mchat / .modal: pin to the
+     visualViewport so the page shrinks when the iOS soft keyboard opens
+     (otherwise on iPad-in-desktop-layout, fields below the keyboard fall
+     under it and become unreachable), and translateY by --viewport-y so
+     focusing an input doesn't push the whole page offscreen. --viewport-h
+     and --viewport-y are set globally by useVisualViewportHeight() in
+     App.vue; on real desktops both are no-ops. See issue #11. */
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--viewport-h, 100dvh);
+  transform: translateY(var(--viewport-y, 0));
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
Fixes #11.

## Diagnosis

iPad sits above the 768px mobile breakpoint in most modes, so it renders the **desktop** layout — but `DesktopChat.vue` hard-coded `height: 100vh` and never wired `useVisualViewportHeight()`. On iOS Safari, `100vh` measures the *layout* viewport (taller than the visible area, includes the URL-bar zone), so the bottom of the grid (status row, input bar, sidebar foot) hung below the screen until interaction. Any focus / scroll then auto-shifted the layout viewport upward, which clipped the top bar instead.

## Approach

Hoist `useVisualViewportHeight()` to `App.vue` so `--viewport-h` / `--viewport-y` are published globally, then apply the same shell discipline `.mchat` already uses to the other top-level shells:

```css
position: fixed;
top: 0; left: 0; right: 0;
height: var(--viewport-h, 100dvh);
transform: translateY(var(--viewport-y, 0));
```

On real desktops `visualViewport == window`, so both vars are no-ops there — desktop behaviour is unchanged. Mirror the `@media (display-mode: standalone)` safe-area-inset-bottom rule from `.mchat` to `.chat` so iPad-as-PWA gets home-indicator clearance.

## Two follow-ons surfaced during iPad QA, folded into the same PR

- **`AppModal`** — inner `vh` units → `dvh`, and the outer `.modal` box adopts the shell discipline above. Without this, a content-heavy modal extended past the visible bottom on iPad (centered inside the *layout* viewport rather than the *visible* viewport).
- **`BufferList`** — `:hover` rules on `.channels li`, `.net-head`, and the `.row-actions` reveal are gated behind `@media (hover: hover)`. On iPad-in-desktop-layout the unguarded `:hover` triggered the iOS sticky-hover two-tap (first tap = hover preview, second = activate). Long-press still opens the buffer-actions context menu via the existing `@contextmenu` handler, so iPad reaches the same actions the hover-only `.row-actions` button gave to desktop.
- **`Settings`** — same shell discipline applied to `.settings-page` so the keyboard opening doesn't hide fields below it: `--viewport-h` shrinks → page shrinks → the existing `overflow-y: auto` content scroller exposes the now-occluded fields.

## Follow-on filed separately

QA surfaced a visual jank where the iOS keyboard slide-up animation is out of phase with our transform updates, producing a brief "shell vanishes and re-slides" effect on focus. This pre-existed on iPhone (`.mchat` has used the same pattern for a while) and is now also observable on iPad after this PR. Tracked as #85.

## Verification (real iPad)

- [x] iPad Safari portrait: status row, input bar, sidebar foot all visible without scrolling on first load; topic bar stays visible after focusing the textarea.
- [x] iPad Safari landscape: same.
- [x] iPad PWA (Add to Home Screen): home-indicator clearance correct; input sits flush at the bottom when keyboard is up.
- [x] Modal with a lot of content (recent uploads, channel list, settings panes) — fits within the visible viewport with the card at visible center.
- [x] Tap a buffer in the buffer list — activates on the first tap.
- [x] Open a settings pane with a text field — focus it, keyboard appears, fields below remain reachable by scrolling within the panel.
- Long-press buffer rows still opens the buffer-actions context menu (unchanged path).
- Desktop (macOS Chrome / Safari): layout, modals, context menu all unchanged.

## Footprint

7 files, +82 / -24. Typecheck and `vite build` clean; `oxfmt` and `oxlint` happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)