### PR TITLE
issue #85: drop the position:fixed + visualViewport translate workaround

### DIFF
--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -14,7 +14,6 @@ import { onMounted } from 'vue';
 import { useAuthStore } from './stores/auth.js';
 import { useSettingsStore } from './stores/settings.js';
 import { useTheme } from './composables/useTheme.js';
-import { useVisualViewportHeight } from './composables/useViewport.js';
 import ToastContainer from './components/ToastContainer.vue';
 import ContextMenu from './components/ContextMenu.vue';
 
@@ -22,13 +21,6 @@ const auth = useAuthStore();
 const settings = useSettingsStore();
 
 useTheme();
-
-// Pin --viewport-h / --viewport-y to the visualViewport at the app root so both
-// the mobile and desktop shells stay glued to the visible region when iOS
-// shifts the layout viewport (URL-bar collapse, soft-keyboard open). Mobile
-// originally owned this; iPad runs the desktop layout (width > 768px) and
-// needs the same accounting — see issue #11.
-useVisualViewportHeight();
 
 onMounted(() => {
   auth.fetchMe();

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -76,7 +76,11 @@
 html,
 body,
 #app {
-  height: 100%;
+  /* `100dvh` tracks the dynamic viewport on iOS — shrinks when the soft
+     keyboard opens. Without this, body/html stay at full layout-viewport
+     height while the shell (also `100dvh`) shrinks, leaving body area
+     below the shell that iOS's auto-scroll exposes. See issue #85. */
+  height: 100dvh;
   margin: 0;
   background: var(--bg);
   color: var(--fg);
@@ -89,9 +93,15 @@ body,
   text-rendering: optimizeLegibility;
 }
 
-/* Whole app behaves like a CLI window — no body-level scroll. */
+/* Whole app behaves like a CLI window — no document-level scroll.
+   `overscroll-behavior: none` kills the rubber-band bounce at the
+   edges. (Earlier attempts to use `position: fixed` on body to fully
+   lock iOS drag-scroll didn't help — iOS overrides it for keyboard
+   accommodation. See issue #85.) */
+html,
 body {
   overflow: hidden;
+  overscroll-behavior: none;
 }
 
 a {

--- a/vue_client/src/components/AppModal.vue
+++ b/vue_client/src/components/AppModal.vue
@@ -99,18 +99,12 @@ onMounted(() => {
 
 <style scoped>
 .modal {
-  /* Size to the visualViewport rather than the layout viewport. On iOS
-     Safari `inset: 0` + bare `100vh` overshoots — the layout viewport
-     includes the URL-bar zone, so the modal box (and the card centered
-     inside it) extended below the visible bottom on iPad. --viewport-h /
-     --viewport-y come from useVisualViewportHeight() in App.vue; on real
-     desktops both are no-ops. See issue #11. */
+  /* Overlay the page, sized to the dynamic viewport. See issue #85:
+     previous `transform: translateY(--viewport-y)` workaround was
+     removed because it caused visible jank. */
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: var(--viewport-h, 100dvh);
-  transform: translateY(var(--viewport-y, 0));
+  inset: 0;
+  height: 100dvh;
   background: var(--bg);
   display: flex;
   justify-content: center;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -971,8 +971,8 @@ watch(scrollToBottomToken, async () => {
 });
 
 // Anything that shrinks MessageList's clientHeight (iOS soft keyboard sliding
-// up via --viewport-h; the message-input textarea auto-growing past one row;
-// the desktop window resizing) shrinks the visible window from the bottom
+// up and scrolling the page; the message-input textarea auto-growing past one
+// row; the desktop window resizing) shrinks the visible window from the bottom
 // without moving scrollTop — so a user pinned to the latest message ends up
 // with the tail of the conversation hidden behind whatever just grew.
 // ResizeObserver fires after layout settles, so scrollHeight is current; the

--- a/vue_client/src/composables/useViewport.ts
+++ b/vue_client/src/composables/useViewport.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type { Ref } from 'vue';
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { ref } from 'vue';
 
 // Mobile breakpoint. The desktop layout is a 220 + 1fr + 180 = 400px-of-chrome
 // grid, so anything below ~720px gets squeezed beyond repair. 768px is a
@@ -37,47 +37,4 @@ function onChange(e: MediaQueryListEvent): void {
 export function useViewport(): ViewportState {
   ensureInit();
   return { isMobile };
-}
-
-function update(): void {
-  const vv = window.visualViewport;
-  const h = vv ? vv.height : window.innerHeight;
-  const y = vv ? vv.offsetTop : 0;
-  document.documentElement.style.setProperty('--viewport-h', `${h}px`);
-  document.documentElement.style.setProperty('--viewport-y', `${y}px`);
-}
-
-// visualViewport tracks the actual visible area, which on iOS Safari shrinks
-// when the soft keyboard opens. We write both:
-//
-//   --viewport-h: visible height. Lets the mobile shell shrink so the input
-//   ends up just above the keyboard instead of below it.
-//
-//   --viewport-y: how far the visual viewport has been pushed down inside
-//   the layout viewport. When the user focuses an input, iOS Safari scrolls
-//   the layout viewport upward to keep the input visible — for a fixed-
-//   position element that would mean it scrolls offscreen with the page.
-//   translateY-ing the shell by --viewport-y undoes that auto-scroll so the
-//   shell stays glued to the actual visible area.
-//
-// Together with position: fixed on .mchat, these defeat the iOS quirk where
-// focusing an input pushes the whole app up and leaves a gray gutter below.
-export function useVisualViewportHeight(): void {
-  onMounted(() => {
-    if (typeof window === 'undefined') return;
-    update();
-    if (window.visualViewport) {
-      window.visualViewport.addEventListener('resize', update);
-      window.visualViewport.addEventListener('scroll', update);
-    }
-    window.addEventListener('resize', update);
-  });
-  onBeforeUnmount(() => {
-    if (typeof window === 'undefined') return;
-    if (window.visualViewport) {
-      window.visualViewport.removeEventListener('resize', update);
-      window.visualViewport.removeEventListener('scroll', update);
-    }
-    window.removeEventListener('resize', update);
-  });
 }

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -396,19 +396,12 @@ useChatBootstrap({ onJump: onJumpToMessage });
     'sidebar messages members'
     'sidebar status   status'
     'sidebar input    input';
-  /* iPad runs this layout (width > 768px). Mirror .mchat's shell discipline:
-     pin to the visualViewport so the URL-bar collapse / soft-keyboard scroll
-     can't push the top or bottom of the grid offscreen. --viewport-h tracks
-     the actually-visible height; --viewport-y cancels iOS's auto-scroll on
-     focus. Both vars come from useVisualViewportHeight() in App.vue, with
-     100dvh / 0 as first-paint fallbacks. On real desktops the visualViewport
-     equals the window, so this is a no-op there. See issue #11. */
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: var(--viewport-h, 100dvh);
-  transform: translateY(var(--viewport-y, 0));
+  /* Height sized to the dynamic viewport. iOS scrolls the page
+     naturally when the keyboard opens; the input row at the bottom
+     stays visible above the keyboard, and the upper portion (sidebar,
+     topic, older messages) scrolls off the top of the visible area.
+     See issue #85. */
+  height: 100dvh;
   overflow: hidden;
 }
 .chat.sidebar-collapsed {

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -267,25 +267,15 @@ useChatBootstrap({ onJump: onJumpToMessage });
 </script>
 
 <style scoped>
-/* The shell is a fixed-position single-column flex stack pinned to the
-   *visual* viewport, not the layout viewport. This is what defeats iOS
-   Safari's keyboard-opens-and-scrolls-the-page-up behavior:
-     - position: fixed + top: 0 alone isn't enough — iOS still scrolls the
-       layout viewport when an input is focused, dragging fixed elements
-       along with it.
-     - height: var(--viewport-h) shrinks the shell to the visible area so
-       the input sits above the keyboard instead of behind it.
-     - translateY(var(--viewport-y)) cancels out Safari's auto-scroll so
-       the top of the shell lines up with the top of the visible area.
-   The 100dvh / 0 fallbacks keep the layout sensible on first paint and on
-   browsers without visualViewport. */
+/* Single-column flex stack sized to the dynamic viewport. iOS scrolls
+   the page naturally when the keyboard opens; the textarea at the
+   bottom of the shell stays visible just above the keyboard, and the
+   upper content (sidebar / topic / older messages) scrolls off the
+   top of the visible area until the user dismisses the keyboard. See
+   issue #85 for the full investigation — multiple workarounds were
+   tried and each made things worse on at least one device. */
 .mchat {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: var(--viewport-h, 100dvh);
-  transform: translateY(var(--viewport-y, 0));
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -166,19 +166,11 @@ watch(
 
 <style scoped>
 .settings-page {
-  /* Same shell discipline as .chat / .mchat / .modal: pin to the
-     visualViewport so the page shrinks when the iOS soft keyboard opens
-     (otherwise on iPad-in-desktop-layout, fields below the keyboard fall
-     under it and become unreachable), and translateY by --viewport-y so
-     focusing an input doesn't push the whole page offscreen. --viewport-h
-     and --viewport-y are set globally by useVisualViewportHeight() in
-     App.vue; on real desktops both are no-ops. See issue #11. */
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: var(--viewport-h, 100dvh);
-  transform: translateY(var(--viewport-y, 0));
+  /* See issue #85: previous `position: fixed + transform: translateY`
+     workaround caused visible jank and was removed. iOS scrolls the
+     page naturally when an input is focused; fields above the
+     auto-scroll point may end up offscreen above. */
+  height: 100dvh;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
Closes #85.

## What changed

The `position: fixed` + `transform: translateY(--viewport-y)` machinery from PR #11 is gone. All four shells (`.mchat`, `.chat`, `.modal`, `.settings-page`) now use plain `height: 100dvh` with normal block / flex / grid layout. `useVisualViewportHeight` is deleted; `--viewport-h` and `--viewport-y` no longer exist. `body` gains `overscroll-behavior: none` to suppress rubber-band bounce.

Net: **+39 / −111 lines** across 8 files.

## Why

Live-instrumented this session on iPad Safari and iPhone Safari. The data showed unambiguously that the original workaround was the *cause* of the visible jank, not a defense against it. During the ~70–130ms between `focusin` and `visualViewport.resize` firing, iOS auto-scrolls the layout viewport and drags the `position: fixed` shell to viewport-y `-498` (offscreen above). The counter-translate then snaps it back in a single frame — that's the vanish/reslide.

Removing the workaround means iOS scrolls the page naturally; the textarea (at the bottom of each shell) ends up just above the keyboard chrome; older content scrolls off the top until the user dismisses the keyboard. No JS animation, no CSS transitions to tune, no race with iOS's compositor.

Full investigation summary is in the issue close-out.

## Verification

- iPad Safari: smooth keyboard slide, no jank during open or close.
- iPhone Safari: smooth keyboard slide, no jank.
- `vue-tsc --noEmit` clean.

## Known cosmetic limitations (accepted, see issue close-out)

- **iPhone Safari**: dragging the page down with the keyboard up exposes a small band of bg between the input row and the keyboard's form-nav chrome. iOS chrome adjustment we can't suppress.
- **Modal + Settings on iPad with keyboard open**: inner fields above iOS's auto-scroll point can end up offscreen. Right fix is scrollable inner content — filing as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)