### PR TITLE
issue #91: allow filter-only message search

### DIFF
--- a/server/services/verbs/searchMessages.ts
+++ b/server/services/verbs/searchMessages.ts
@@ -21,7 +21,8 @@ registerVerb({
     properties: {
       query: {
         type: 'string',
-        description: 'Free-text query. Multiple whitespace-separated terms are ANDed together.',
+        description:
+          'Free-text query. Multiple whitespace-separated terms are ANDed together. Optional when at least one structured filter (networkId/target/nick) is provided — filter-only searches return matches without an FTS pass.',
       },
       networkId: {
         type: 'integer',
@@ -47,7 +48,6 @@ registerVerb({
         description: 'Optional. Return only matches with id < before, for backward pagination.',
       },
     },
-    required: ['query'],
     additionalProperties: false,
   },
   handler(ctx: VerbContext, input: Record<string, unknown>) {

--- a/server/services/verbs/verbs.test.ts
+++ b/server/services/verbs/verbs.test.ts
@@ -233,6 +233,19 @@ describe('search_messages', () => {
     expect(result.messages).toEqual([]);
   });
 
+  // Regression for #91: the inline `from:nick` / `in:#chan` / `on:network`
+  // syntax sends a filter-only payload (no `query`). The schema used to mark
+  // `query` required, which rejected these as invalid_input and silently hung
+  // the modal — the handler and DB layer have always tolerated a missing query
+  // as long as at least one structured filter is present.
+  it('accepts filter-only searches with no free-text query', () => {
+    const result = callVerb('search_messages', rCtx(owner.id), { nick: 'alice' }) as {
+      messages: Array<{ nick: string }>;
+    };
+    expect(result.messages.length).toBeGreaterThan(0);
+    expect(result.messages.every((m) => m.nick === 'alice')).toBe(true);
+  });
+
   it('reports hasMore=false when total matches equal the requested limit exactly', () => {
     // Seed a fresh user + network so the message count is deterministic.
     const u = createUser('search-limit-edge');

--- a/server/services/verbs/verbs.test.ts
+++ b/server/services/verbs/verbs.test.ts
@@ -240,10 +240,15 @@ describe('search_messages', () => {
   // as long as at least one structured filter is present.
   it('accepts filter-only searches with no free-text query', () => {
     const result = callVerb('search_messages', rCtx(owner.id), { nick: 'alice' }) as {
-      messages: Array<{ nick: string }>;
+      messages: Array<{ text: string }>;
     };
-    expect(result.messages.length).toBeGreaterThan(0);
-    expect(result.messages.every((m) => m.nick === 'alice')).toBe(true);
+    // Pin to message text, not nick — `m.nick = ? COLLATE NOCASE` would still
+    // match if the seed casing ever changed, but a nick-equality assertion
+    // wouldn't.
+    expect(result.messages.map((m) => m.text).toSorted()).toEqual([
+      'deployment ready',
+      'hello world',
+    ]);
   });
 
   it('reports hasMore=false when total matches equal the requested limit exactly', () => {


### PR DESCRIPTION
## Summary

- The `search_messages` verb schema marked `query` as required, but the client legitimately omits `payload.query` when the user enters only structured filters (`from:nick`, `in:#chan`, `on:network`). The verb registry rejected these as `invalid_input`; `wsHub` swallowed the throw and sent a generic `{kind:'error'}`; the WS client only handles `search-result`, so the modal hung in `loading` with no results. (Regression introduced in d62a6cb, "harden verb input validation".)
- Dropped `query` from the schema's `required` list. The handler already coerces missing `query` to `''` (`searchMessages.ts:61`) and the DB layer (`messages.ts:400`, `:406`) already skips the FTS join when text is empty and short-circuits to `[]` only when *no* filters are present either. So this is the minimal correct fix — the tolerant code path always existed; the schema gate was the bug.
- Added a verb-level regression test (`verbs.test.ts`) calling `search_messages` with only `{ nick: 'alice' }` — mirroring the existing DB-level filter-only test at `messages.test.ts:243` that already passes.

## Test plan

- [x] `npx vitest run` — 625 / 625 pass (including new regression test)
- [x] `npm run check` — typecheck + lint + format clean
- [x] Manual: open the search modal in a running Lurker, type `from:<a known nick>` with no free text, confirm results appear instead of the previous indefinite-loading state. Repeat with `in:#<known channel>` and `on:<known network>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)