### PR TITLE
issue #93: unify modal scrolling + restyle network form

### DIFF
--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import AppModal from './AppModal.vue';
 import HistoryMessageRow, { type HistoryMessage } from './HistoryMessageRow.vue';
 import { useSettingsStore } from '../stores/settings.js';
@@ -61,6 +61,22 @@ function onScroll(): void {
     store.loadMore();
   }
 }
+
+// If the entire loaded page is from ignored users the scroll container is not
+// rendered, so the user can't trigger pagination themselves — quietly fetch
+// the next page in their stead. Capped so a single very prolific ignored
+// source can't drag the modal into an unbounded fetch loop.
+const AUTO_FILL_MAX_PAGES = 5;
+let autoFillFetched = 0;
+watch(
+  () => [visibleItems.value.length, store.loading, store.hasMore] as const,
+  ([visible, loading, hasMore]) => {
+    if (visible === 0 && hasMore && !loading && autoFillFetched < AUTO_FILL_MAX_PAGES) {
+      autoFillFetched += 1;
+      store.loadMore();
+    }
+  },
+);
 
 const soundEnabled = computed(() => !!settings.effective('notifications.highlight.sound.enabled'));
 

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -16,27 +16,23 @@
     </template>
 
     <p v-if="store.error" class="error inline">{{ store.error }}</p>
-    <ul v-if="visibleItems.length" class="match-list">
+    <ul v-if="visibleItems.length" ref="listEl" class="match-list" @scroll="onScroll">
       <HistoryMessageRow
         v-for="m in visibleItems"
         :key="`${m.networkId}::${m.target}::${m.id}`"
         :message="m"
         @jump="onJump"
       />
+      <li v-if="store.loading" class="more">Loading…</li>
     </ul>
     <p v-else-if="store.loading" class="empty">Loading…</p>
     <p v-else-if="store.items.length" class="empty">All highlights are from ignored users.</p>
     <p v-else class="empty">No highlights yet.</p>
-    <footer v-if="store.hasMore || store.loading" class="foot">
-      <button class="link" :disabled="store.loading || !store.hasMore" @click="store.loadMore()">
-        {{ store.loading ? 'Loading…' : 'Load more' }}
-      </button>
-    </footer>
   </AppModal>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import AppModal from './AppModal.vue';
 import HistoryMessageRow, { type HistoryMessage } from './HistoryMessageRow.vue';
 import { useSettingsStore } from '../stores/settings.js';
@@ -52,9 +48,19 @@ const settings = useSettingsStore();
 const store = useHighlightsStore();
 const ignores = useIgnoresStore();
 
+const listEl = ref<HTMLUListElement | null>(null);
+
 const visibleItems = computed(() =>
   store.items.filter((m) => !ignores.isIgnored(m.networkId, m.nick, m.userhost ?? '')),
 );
+
+function onScroll(): void {
+  const el = listEl.value;
+  if (!el) return;
+  if (el.scrollHeight - el.scrollTop - el.clientHeight < 120) {
+    store.loadMore();
+  }
+}
 
 const soundEnabled = computed(() => !!settings.effective('notifications.highlight.sound.enabled'));
 
@@ -106,6 +112,12 @@ function onJump(m: HistoryMessage): void {
   flex: 1;
   min-height: 0;
 }
+.more {
+  text-align: center;
+  color: var(--fg-muted);
+  font-style: italic;
+  padding: 8px;
+}
 .empty {
   text-align: center;
   color: var(--fg-muted);
@@ -116,11 +128,5 @@ function onJump(m: HistoryMessage): void {
   color: var(--bad);
   padding: 8px 0;
   margin: 0;
-}
-.foot {
-  border-top: 1px solid var(--border);
-  padding: 8px 0;
-  display: flex;
-  justify-content: center;
 }
 </style>

--- a/vue_client/src/components/NetworkForm.vue
+++ b/vue_client/src/components/NetworkForm.vue
@@ -4,9 +4,13 @@
 -->
 
 <template>
-  <div class="modal" @click.self="$emit('close')">
-    <form class="card" @submit.prevent="submit">
-      <h2>{{ isEdit ? 'Edit network' : 'Add network' }}</h2>
+  <AppModal
+    :word="isEdit ? 'edit' : 'network'"
+    :title="isEdit ? 'edit network' : 'add network'"
+    size="sm"
+    @close="$emit('close')"
+  >
+    <form class="net-form" @submit.prevent="submit">
       <label>
         <span>Name</span>
         <input v-model="form.name" placeholder="Libera" required />
@@ -105,11 +109,12 @@
         </button>
       </div>
     </form>
-  </div>
+  </AppModal>
 </template>
 
 <script setup lang="ts">
 import { reactive, ref, computed } from 'vue';
+import AppModal from './AppModal.vue';
 import { useNetworksStore, type Network } from '../stores/networks.js';
 
 const props = withDefaults(
@@ -223,29 +228,19 @@ async function remove(): Promise<void> {
 </script>
 
 <style scoped>
-.modal {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-}
-.card {
-  background: var(--bg);
-  border: 1px solid var(--accent);
-  padding: 16px 20px;
-  width: 400px;
+/* Scroll within the card when advanced options stretch the form past the
+   modal's max-height; the AppModal shell already clips and centers. */
+.net-form {
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-h2 {
-  margin: 0 0 4px;
-  color: var(--accent);
-  text-transform: lowercase;
-  font-weight: 600;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  /* Match the breakout pattern from SearchModal/RecentUploadsModal so the
+     scrollbar sits against the card border instead of inside the padding. */
+  margin: 0 calc(-1 * var(--card-pad-x));
+  padding: 0 var(--card-pad-x);
 }
 label {
   display: flex;


### PR DESCRIPTION
Closes #93.

## Summary
- **Highlights modal**: drop the footer "Load more" button; wire `@scroll` on the match-list using the same 120px threshold + inline "Loading…" sentinel as `SearchModal`. The store's existing `loadMore()` guards against re-entry.
- **NetworkForm**: wrap in `AppModal size="sm"` so add/edit network gets the same word-backdrop, header, close-X, and mobile-fullscreen behavior as the rest of the modals. Strip the bespoke `.modal`/`.card`/`h2` styles. The form scrolls inside the card (with the standard `var(--card-pad-x)` breakout so the scrollbar sits flush with the card border) when advanced options push it past the 85dvh cap.

## Test plan
- [x] Open highlights modal, scroll to bottom — next page auto-loads, "Loading…" sentinel briefly appears, scroll position preserved
- [x] Highlights empty state still reads correctly (no items, all-ignored, error)
- [x] Add network modal opens with the standard word backdrop + close X
- [x] Edit network modal opens with the same chrome and auto-expands advanced when fields are populated
- [x] Mobile (≤768px): NetworkForm becomes fullscreen like the other modals
- [x] Expand all advanced options on a short viewport — form scrolls cleanly within the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)