### PR TITLE
Replace /whois motd dump with user profile modal (#92)

### DIFF
--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1179,20 +1179,15 @@ export class IrcConnection {
     });
 
     // irc-framework aggregates RPL_WHOIS* (311/312/317/319/330/...) into a
-    // single 'whois' event when RPL_ENDOFWHOIS arrives. We fan it out as
-    // motd-style lines on the server buffer so the user actually sees the
-    // result of /whois (raw fall-through alone hides everything because the
-    // numerics are consumed by irc-framework instead of becoming messages).
-    // irc-framework aggregates RPL_WHOIS* (311/312/317/319/330/...) into a
-    // single 'whois' event when RPL_ENDOFWHOIS arrives. WHOIS is now purely
-    // user-driven output — presence comes from MONITOR + away-notify, not
-    // whois — so this handler just formats the reply into motd lines.
+    // single 'whois' event when RPL_ENDOFWHOIS arrives. We fan it out as a
+    // structured `whois_result` event so the client can render it in the
+    // user-profile modal (issue #92). It's ephemeral — the modal pulls it
+    // from a per-nick cache, no scrollback noise. `error: 'not_found'`
+    // surfaces here too (irc-framework synthesizes a whois event with that
+    // shape on ERR_NOSUCHNICK) so the modal can flip to its empty state.
     c.on('whois', (event: Record<string, unknown>) => {
       if (!event || !event.nick) return;
-      const lines = formatWhoisLines(event);
-      for (const text of lines) {
-        this.publish({ type: 'motd', target: this.serverTarget(), text });
-      }
+      this.publishEphemeral({ type: 'whois_result', whois: event });
     });
 
     // Channel list (`/LIST`). irc-framework batches RPL_LIST every 50 rows and
@@ -1782,45 +1777,6 @@ export function computeFallbackNick(
   if (!base) return null;
   if (attemptIndex < 0 || attemptIndex >= NICK_FALLBACK_MAX) return null;
   return `${base}${attemptIndex + 1}`;
-}
-
-// Render irc-framework's aggregated `whois` event into a small block of
-// human-readable lines. Order roughly mirrors what other IRC clients show:
-// identity → realname → host/ip → connection security → server → channels →
-// modes → idle/signon → registered/account/oper/bot → secure/certfp.
-function formatWhoisLines(w: Record<string, unknown>): string[] {
-  const lines: string[] = [];
-  if (w.error === 'not_found') {
-    lines.push(`whois: no such nick ${w.nick}`);
-    return lines;
-  }
-  const userhost = [w.ident, w.hostname].filter(Boolean).join('@');
-  lines.push(`whois ${w.nick}${userhost ? ` (${userhost})` : ''}`);
-  if (w.real_name) lines.push(`  realname: ${w.real_name}`);
-  if (w.actual_hostname || w.actual_ip) {
-    const parts = [w.actual_hostname, w.actual_ip].filter(Boolean).join(' ');
-    lines.push(`  host: ${parts}`);
-  }
-  if (w.server) {
-    const info = w.server_info ? ` (${w.server_info})` : '';
-    lines.push(`  server: ${w.server}${info}`);
-  }
-  if (w.channels) lines.push(`  channels: ${w.channels}`);
-  if (w.modes) lines.push(`  modes: ${w.modes}`);
-  if (w.account) lines.push(`  account: ${w.account}`);
-  if (w.registered_nick) lines.push(`  registered: ${w.registered_nick}`);
-  if (w.operator) lines.push(`  oper: ${w.operator}`);
-  if (w.helpop) lines.push(`  helpop: ${w.helpop}`);
-  if (w.bot) lines.push(`  bot: ${w.bot}`);
-  if (w.secure) lines.push('  secure: yes');
-  if (w.certfp) lines.push(`  certfp: ${w.certfp}`);
-  if (w.away) lines.push(`  away: ${w.away}`);
-  if (w.idle != null) {
-    const idleSec = Number(w.idle);
-    const signonStr = w.logon ? ` (signon ${new Date(Number(w.logon) * 1000).toISOString()})` : '';
-    lines.push(`  idle: ${Number.isFinite(idleSec) ? `${idleSec}s` : w.idle}${signonStr}`);
-  }
-  return lines;
 }
 
 // Convert a server-sourced numeric reply (parsed IrcMessage) into a single

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -123,6 +123,7 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore, onInsertUrl } from '../stores/uploads.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { useIgnoresStore } from '../stores/ignores.js';
+import { useWhoisStore } from '../stores/whois.js';
 import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
 import { requestScrollToBottom } from '../composables/useScrollState.js';
 import { setComposingState } from '../composables/useComposing.js';
@@ -1462,7 +1463,11 @@ function handleCommand(line: string, networkId: number, target: string): boolean
         localInfo(networkId, target, 'usage: /whois <nick>');
         return true;
       }
-      return sendOrToast({ type: 'raw', networkId, line: `WHOIS ${who}` }, line);
+      // openViewer kicks the WHOIS itself (issue #92) so we don't double-fire.
+      // The modal renders whatever's cached immediately and replaces it when
+      // the new whois_result lands.
+      useWhoisStore().openViewer(networkId, who);
+      return true;
     }
     case 'kick': {
       // /kick <nick> [reason]            (in a channel buffer)

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -118,22 +118,38 @@
         </div>
       </section>
 
-      <!-- Empty / loading state -->
-      <section v-if="!hasIdentity && !hasActivity" class="section status">
-        <p v-if="isNotFound" class="muted">
-          No such nick — {{ nick }} isn't on the network right now.
-        </p>
-        <p v-else class="muted">
+      <!-- Transient waiting state — only while we're genuinely in the dark.
+           If we already know they're offline (MONITOR or not_found whois)
+           the presence dot in the header carries that, so we skip the
+           redundant line and let "Your note" stand on its own. -->
+      <section v-if="!hasIdentity && !hasActivity && !isOffline" class="section status">
+        <p class="muted">
           <i class="fa-solid fa-circle-notch fa-spin"></i> Waiting for whois reply…
         </p>
       </section>
     </div>
 
     <footer class="footer">
-      <button type="button" class="btn-secondary" @click="onSendDm" :disabled="isSelf">
+      <!-- Send DM and Ignore are meaningless while the peer is offline —
+           DMs would bounce and there's no hostmask to build an ignore rule
+           from. Hide entirely rather than disable so the modal doesn't read
+           as "you could do this if only…". -->
+      <button
+        v-if="!isOffline"
+        type="button"
+        class="btn-secondary"
+        @click="onSendDm"
+        :disabled="isSelf"
+      >
         <i class="fa-solid fa-envelope"></i> Send DM
       </button>
-      <button type="button" class="btn-secondary" @click="onIgnore" :disabled="isSelf">
+      <button
+        v-if="!isOffline"
+        type="button"
+        class="btn-secondary"
+        @click="onIgnore"
+        :disabled="isSelf"
+      >
         <i class="fa-solid fa-ban"></i> Ignore…
       </button>
       <span class="spacer"></span>
@@ -220,6 +236,10 @@ const presenceLabel = computed(() => {
 const isNotFound = computed(
   () => (whois.value as { error?: string } | null)?.error === 'not_found',
 );
+// "Offline" for footer/empty-state purposes: either MONITOR has confirmed
+// they're not on the network, or WHOIS came back with no-such-nick. Both
+// mean Send DM / Ignore have nothing to bite on.
+const isOffline = computed(() => isPeerOffline(peer.value) || isNotFound.value);
 
 const hostmask = computed(() => {
   if (!whois.value) return '';

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -6,9 +6,9 @@
 <!--
   Replaces the old /whois motd dump (issue #92). Opens from the slash
   command, the nicklist menu, the DM context menu, and the DM header.
-  Renders the cached whois entry immediately and shows a refreshing
-  indicator until the new result lands; if no whois ever arrives the
-  empty state explains why.
+  Renders the cached whois entry immediately and silently overwrites it
+  when the new reply arrives; while we have nothing cached the empty
+  state shows a spinner (or "offline" if MONITOR already knows).
 
   Note editor lives in NickNoteModal — the "Edit note" button opens
   that instead of duplicating the editor here, so the editor has a
@@ -366,11 +366,10 @@ function onRefresh() {
 function copyHostmask() {
   const text = hostmask.value;
   if (!text) return;
-  try {
-    void navigator.clipboard?.writeText(text);
-  } catch (_) {
-    /* ignore — older browsers without clipboard API just don't copy */
-  }
+  // Best-effort: writeText returns a rejected promise when permissions are
+  // denied (and the clipboard API itself can be missing on older browsers),
+  // so swallow both paths quietly — copy isn't load-bearing.
+  navigator.clipboard?.writeText(text).catch(() => {});
 }
 </script>
 

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -1,0 +1,544 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Replaces the old /whois motd dump (issue #92). Opens from the slash
+  command, the nicklist menu, the DM context menu, and the DM header.
+  Renders the cached whois entry immediately and shows a refreshing
+  indicator until the new result lands; if no whois ever arrives the
+  empty state explains why.
+
+  Note editor lives in NickNoteModal — the "Edit note" button opens
+  that instead of duplicating the editor here, so the editor has a
+  single source of truth.
+-->
+
+<template>
+  <AppModal word="profile" :title="nick" size="md" align="top" @close="onClose">
+    <template #subtitle>
+      <span :class="['presence', presenceClass]">
+        <span class="dot" aria-hidden="true"></span>
+        {{ presenceLabel }}
+      </span>
+      <span v-if="awayMessage" class="away-msg">— {{ awayMessage }}</span>
+    </template>
+
+    <div class="body">
+      <!-- Identity -->
+      <section v-if="hasIdentity" class="section">
+        <h3>Identity</h3>
+        <dl>
+          <template v-if="whois?.real_name">
+            <dt>Real name</dt>
+            <dd>{{ whois.real_name }}</dd>
+          </template>
+          <template v-if="hostmask">
+            <dt>Hostmask</dt>
+            <dd>
+              <code>{{ hostmask }}</code>
+              <button type="button" class="link inline" title="Copy hostmask" @click="copyHostmask">
+                <i class="fa-solid fa-copy"></i>
+              </button>
+            </dd>
+          </template>
+          <template v-if="actualHost">
+            <dt>Connected from</dt>
+            <dd>
+              <code>{{ actualHost }}</code>
+            </dd>
+          </template>
+          <template v-if="whois?.account">
+            <dt>Account</dt>
+            <dd>{{ whois.account }}</dd>
+          </template>
+        </dl>
+        <div v-if="chips.length" class="chips">
+          <span v-for="c in chips" :key="c.label" :class="['chip', c.tone]">
+            <i v-if="c.icon" :class="c.icon"></i> {{ c.label }}
+          </span>
+        </div>
+      </section>
+
+      <!-- Activity -->
+      <section v-if="hasActivity" class="section">
+        <h3>Activity</h3>
+        <dl>
+          <template v-if="idleLabel">
+            <dt>Idle</dt>
+            <dd>{{ idleLabel }}</dd>
+          </template>
+          <template v-if="signonLabel">
+            <dt>Signed on</dt>
+            <dd>{{ signonLabel }}</dd>
+          </template>
+          <template v-if="whois?.server">
+            <dt>Server</dt>
+            <dd>
+              {{ whois.server }}
+              <span v-if="whois.server_info" class="muted">({{ whois.server_info }})</span>
+            </dd>
+          </template>
+          <template v-if="channelsList.length">
+            <dt>Channels</dt>
+            <dd class="channels">
+              <button
+                v-for="ch in channelsList"
+                :key="ch.name"
+                type="button"
+                class="link channel"
+                @click="onChannelClick(ch.name)"
+              >
+                <span class="ch-prefix">{{ ch.prefix }}</span
+                >{{ ch.name }}
+              </button>
+            </dd>
+          </template>
+        </dl>
+      </section>
+
+      <!-- Your note -->
+      <section class="section">
+        <h3>Your note</h3>
+        <div v-if="noteText" class="note">
+          <p class="note-body">{{ noteText }}</p>
+          <p class="meta">
+            <span v-if="noteUpdatedAt">Updated {{ formatDateTime(noteUpdatedAt) }}</span>
+            <button type="button" class="link inline" @click="openNoteEditor">
+              <i class="fa-solid fa-pen"></i> Edit
+            </button>
+          </p>
+        </div>
+        <div v-else class="note empty">
+          <p class="muted">No note yet.</p>
+          <button type="button" class="link inline" @click="openNoteEditor">
+            <i class="fa-solid fa-plus"></i> Add note
+          </button>
+        </div>
+      </section>
+
+      <!-- Empty / loading state -->
+      <section v-if="!hasIdentity && !hasActivity" class="section status">
+        <p v-if="isNotFound" class="muted">
+          No such nick — {{ nick }} isn't on the network right now.
+        </p>
+        <p v-else class="muted">
+          <i class="fa-solid fa-circle-notch fa-spin"></i> Waiting for whois reply…
+        </p>
+      </section>
+    </div>
+
+    <footer class="footer">
+      <button type="button" class="btn-secondary" @click="onSendDm" :disabled="isSelf">
+        <i class="fa-solid fa-envelope"></i> Send DM
+      </button>
+      <button type="button" class="btn-secondary" @click="onIgnore" :disabled="isSelf">
+        <i class="fa-solid fa-ban"></i> Ignore…
+      </button>
+      <span class="spacer"></span>
+      <button type="button" class="btn-secondary" @click="onRefresh" title="Re-run whois">
+        <i class="fa-solid fa-arrows-rotate"></i> Refresh
+      </button>
+    </footer>
+
+    <IgnoreModal
+      v-if="ignoreOpen"
+      :nick="nick"
+      :user="(whois?.ident as string | null) ?? null"
+      :host="(whois?.hostname as string | null) ?? null"
+      :network-id="networkId"
+      @close="ignoreOpen = false"
+    />
+  </AppModal>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import AppModal from './AppModal.vue';
+import IgnoreModal from './IgnoreModal.vue';
+import { useWhoisStore } from '../stores/whois.js';
+import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useNetworksStore } from '../stores/networks.js';
+import { useBuffersStore } from '../stores/buffers.js';
+import { socketSend } from '../composables/useSocket.js';
+import { formatDateTime } from '../utils/timestamp.js';
+import { isPeerAway, isPeerOffline, isPeerOnline } from '../utils/peerPresence.js';
+
+const props = defineProps<{
+  nick: string;
+  networkId: number;
+}>();
+
+const whoisStore = useWhoisStore();
+const nickNotes = useNickNotesStore();
+const networks = useNetworksStore();
+const buffers = useBuffersStore();
+const ignoreOpen = ref(false);
+
+const entry = computed(() => whoisStore.entryFor(props.networkId, props.nick));
+const whois = computed(() => entry.value?.data ?? null);
+
+const selfNick = computed(() => networks.states[props.networkId]?.nick ?? null);
+const isSelf = computed(
+  () => !!selfNick.value && selfNick.value.toLowerCase() === props.nick.toLowerCase(),
+);
+
+const peer = computed(
+  () => networks.states[props.networkId]?.peerPresence?.[props.nick.toLowerCase()] ?? null,
+);
+const awayMessage = computed(() => {
+  // Prefer the live away-notify payload (peer-presence), fall back to the
+  // whois reply's away line — the latter is only populated when whois ran
+  // while the peer was away, so peer-presence is the more current source.
+  const fromPresence = peer.value?.awayMessage || '';
+  if (fromPresence) return fromPresence;
+  return (whois.value?.away as string) || '';
+});
+
+const presenceClass = computed(() => {
+  if (isPeerOffline(peer.value)) return 'offline';
+  if (isPeerAway(peer.value) || awayMessage.value) return 'away';
+  if (isPeerOnline(peer.value)) return 'online';
+  // No presence data — if whois returned an identity we know they're online.
+  if (whois.value && !isNotFound.value) return 'online';
+  return 'unknown';
+});
+const presenceLabel = computed(() => {
+  switch (presenceClass.value) {
+    case 'online':
+      return 'Online';
+    case 'away':
+      return 'Away';
+    case 'offline':
+      return 'Offline';
+    default:
+      return 'Unknown';
+  }
+});
+
+const isNotFound = computed(
+  () => (whois.value as { error?: string } | null)?.error === 'not_found',
+);
+
+const hostmask = computed(() => {
+  if (!whois.value) return '';
+  const ident = (whois.value.ident as string) || '';
+  const host = (whois.value.hostname as string) || '';
+  if (!ident && !host) return '';
+  return `${props.nick}!${ident || '*'}@${host || '*'}`;
+});
+
+const actualHost = computed(() => {
+  if (!whois.value) return '';
+  return [whois.value.actual_hostname, whois.value.actual_ip].filter(Boolean).join(' ');
+});
+
+interface Chip {
+  label: string;
+  tone: 'good' | 'neutral' | 'warn';
+  icon?: string;
+}
+const chips = computed<Chip[]>(() => {
+  const w = whois.value;
+  if (!w) return [];
+  const out: Chip[] = [];
+  if (w.secure) out.push({ label: 'TLS', tone: 'good', icon: 'fa-solid fa-lock' });
+  if (w.bot) out.push({ label: 'Bot', tone: 'neutral', icon: 'fa-solid fa-robot' });
+  if (w.operator)
+    out.push({ label: 'IRC operator', tone: 'warn', icon: 'fa-solid fa-shield-halved' });
+  if (w.helpop) out.push({ label: 'Help', tone: 'neutral', icon: 'fa-solid fa-circle-info' });
+  if (w.registered_nick)
+    out.push({ label: 'Registered', tone: 'good', icon: 'fa-solid fa-id-badge' });
+  return out;
+});
+
+const idleLabel = computed(() => {
+  const idle = whois.value?.idle;
+  if (idle == null) return '';
+  const n = Number(idle);
+  if (!Number.isFinite(n)) return '';
+  return humanDuration(n);
+});
+
+const signonLabel = computed(() => {
+  const logon = whois.value?.logon;
+  if (logon == null) return '';
+  const n = Number(logon);
+  if (!Number.isFinite(n)) return '';
+  return formatDateTime(new Date(n * 1000).toISOString());
+});
+
+// irc-framework hands `channels` back as a single string of prefix+name
+// tokens separated by spaces, e.g. "@#foo +#bar #baz". Split on whitespace
+// and peel any leading mode-prefix glyphs off so the name itself is clean
+// for join/switch.
+const channelsList = computed(() => {
+  const raw = (whois.value?.channels as string) || '';
+  if (!raw) return [] as { prefix: string; name: string }[];
+  return raw
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((token) => {
+      const m = token.match(/^([~&@%+]*)(.*)$/);
+      return { prefix: m?.[1] || '', name: m?.[2] || token };
+    });
+});
+
+const hasIdentity = computed(
+  () => !!(whois.value && (whois.value.real_name || hostmask.value || whois.value.account)),
+);
+const hasActivity = computed(
+  () =>
+    !!(
+      whois.value &&
+      (idleLabel.value || signonLabel.value || whois.value.server || channelsList.value.length)
+    ),
+);
+
+const noteEntry = computed(() => nickNotes.entryFor(props.networkId, props.nick));
+const noteText = computed(() => noteEntry.value?.note || '');
+const noteUpdatedAt = computed(() => noteEntry.value?.updatedAt || '');
+
+function humanDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.max(0, Math.round(seconds))}s`;
+  const min = Math.floor(seconds / 60);
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  const rm = min % 60;
+  if (h < 24) return rm ? `${h}h ${rm}m` : `${h}h`;
+  const d = Math.floor(h / 24);
+  const rh = h % 24;
+  return rh ? `${d}d ${rh}h` : `${d}d`;
+}
+
+function onClose() {
+  whoisStore.closeViewer();
+}
+
+function onSendDm() {
+  if (isSelf.value) return;
+  buffers.activate(props.networkId, props.nick);
+  whoisStore.closeViewer();
+}
+
+function onIgnore() {
+  if (isSelf.value) return;
+  ignoreOpen.value = true;
+}
+
+function openNoteEditor() {
+  nickNotes.openEditor(props.networkId, props.nick);
+}
+
+function onChannelClick(channel: string) {
+  // Send a JOIN — if we're already on it the server is a no-op and the
+  // existing buffer activation will surface it.
+  socketSend({ type: 'join', networkId: props.networkId, channel });
+  buffers.activate(props.networkId, channel);
+  whoisStore.closeViewer();
+}
+
+function onRefresh() {
+  socketSend({ type: 'raw', networkId: props.networkId, line: `WHOIS ${props.nick}` });
+}
+
+function copyHostmask() {
+  const text = hostmask.value;
+  if (!text) return;
+  try {
+    void navigator.clipboard?.writeText(text);
+  } catch (_) {
+    /* ignore — older browsers without clipboard API just don't copy */
+  }
+}
+</script>
+
+<style scoped>
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  /* Break out of card padding so the scrollbar sits against the card
+     border; padding keeps section content visually aligned. */
+  margin: 0 calc(-1 * var(--card-pad-x));
+  padding: 0 var(--card-pad-x) 8px;
+}
+
+.presence {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg);
+  font-weight: 600;
+}
+.presence .dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-muted);
+}
+.presence.online .dot {
+  background: var(--good, #4ec27e);
+}
+.presence.away .dot {
+  background: var(--warn, #d4a256);
+}
+.presence.offline .dot {
+  background: var(--bad);
+}
+.presence.unknown .dot {
+  background: var(--fg-muted);
+}
+.away-msg {
+  margin-left: 8px;
+  color: var(--fg-muted);
+  font-weight: 400;
+}
+
+.section h3 {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-weight: 700;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 16px;
+  row-gap: 6px;
+  margin: 0;
+}
+dt {
+  color: var(--fg-muted);
+  font-weight: 400;
+}
+dd {
+  margin: 0;
+  color: var(--fg);
+  min-width: 0;
+  word-break: break-word;
+}
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  background: var(--bg-soft);
+  padding: 1px 6px;
+}
+.muted {
+  color: var(--fg-muted);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+  color: var(--fg);
+}
+.chip.good {
+  border-color: var(--good, #4ec27e);
+  color: var(--good, #4ec27e);
+}
+.chip.warn {
+  border-color: var(--warn, #d4a256);
+  color: var(--warn, #d4a256);
+}
+
+.channels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+}
+.channel {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+}
+.channel:hover {
+  text-decoration: underline;
+}
+.ch-prefix {
+  color: var(--fg-muted);
+  margin-right: 1px;
+}
+
+.note .note-body {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.note.empty {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.meta {
+  margin: 8px 0 0;
+  color: var(--fg-muted);
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.link.inline {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0 4px;
+}
+.link.inline:hover {
+  text-decoration: underline;
+}
+
+.status {
+  padding: 12px 0;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.footer .spacer {
+  flex: 1;
+}
+.btn-secondary {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  padding: 6px 12px;
+  cursor: pointer;
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.btn-secondary:hover:not(:disabled) {
+  background: var(--bg-soft);
+}
+.btn-secondary:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+</style>

--- a/vue_client/src/composables/useBufferActions.ts
+++ b/vue_client/src/composables/useBufferActions.ts
@@ -5,6 +5,7 @@ import type { ContextMenuItem } from './useContextMenu.js';
 import { usePinsStore } from '../stores/pins.js';
 import { useChannelNotifyStore } from '../stores/channelNotify.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useWhoisStore } from '../stores/whois.js';
 import { useContextMenu } from './useContextMenu.js';
 import { socketSend } from './useSocket.js';
 
@@ -27,6 +28,7 @@ export function useBufferActions(): BufferActionsAPI {
   const pins = usePinsStore();
   const channelNotify = useChannelNotifyStore();
   const nickNotes = useNickNotesStore();
+  const whois = useWhoisStore();
   const menu = useContextMenu();
 
   function buildItems(buf: BufferLike | null | undefined): ContextMenuItem[] {
@@ -63,10 +65,16 @@ export function useBufferActions(): BufferActionsAPI {
             },
       );
     } else {
-      // DM target is the peer's nick — open the note editor directly. Channels
-      // can't carry a per-nick note from this menu (which nick?), so the entry
-      // is DM-only; in-channel nick notes flow through the member list menu.
+      // DM target is the peer's nick — open the profile/note actions directly.
+      // Channels can't carry a per-nick action from this menu (which nick?),
+      // so these are DM-only; in-channel equivalents flow through the member
+      // list menu.
       const hasNote = nickNotes.hasNote(buf.networkId, buf.target);
+      items.push({
+        label: 'View profile…',
+        icon: 'fa-solid fa-id-card',
+        onClick: () => whois.openViewer(buf.networkId, buf.target),
+      });
       items.push({
         label: hasNote ? 'Edit note…' : 'Add note…',
         icon: 'fa-solid fa-note-sticky',

--- a/vue_client/src/composables/useMemberActions.ts
+++ b/vue_client/src/composables/useMemberActions.ts
@@ -4,6 +4,7 @@
 import type { ContextMenuItem } from './useContextMenu.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useWhoisStore } from '../stores/whois.js';
 import { useContextMenu } from './useContextMenu.js';
 
 export interface MemberLike {
@@ -51,6 +52,7 @@ function nickOf(m: MemberLike | string): string {
 export function useMemberActions(): MemberActionsAPI {
   const buffers = useBuffersStore();
   const nickNotes = useNickNotesStore();
+  const whois = useWhoisStore();
   const menu = useContextMenu();
 
   function buildItems(
@@ -61,6 +63,11 @@ export function useMemberActions(): MemberActionsAPI {
     const nick = nickOf(member);
     const hasNote = nickNotes.hasNote(ctx.networkId, nick);
     const items: ContextMenuItem[] = [
+      {
+        label: 'View profile…',
+        icon: 'fa-solid fa-id-card',
+        onClick: () => whois.openViewer(ctx.networkId, nick),
+      },
       {
         label: 'Send DM',
         icon: 'fa-solid fa-envelope',

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -17,6 +17,7 @@ import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useChannelNotifyStore } from '../stores/channelNotify.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useSystemLogStore } from '../stores/systemLog.js';
 import { notifyForEvent } from './useHighlightNotifier.js';
@@ -184,6 +185,11 @@ function applyEvent(event: any): void {
     case 'error':
       buffers.pushMessage({ ...event, target: event.target || `:server:${event.networkId}` });
       break;
+    case 'whois_result': {
+      const whois = useWhoisStore();
+      whois.applyResult(event.networkId, event.whois || {});
+      break;
+    }
     case 'chanlist-start': {
       const chanlist = useChanlistStore();
       chanlist.applyStart(event.networkId);

--- a/vue_client/src/stores/whois.ts
+++ b/vue_client/src/stores/whois.ts
@@ -44,7 +44,6 @@ export interface WhoisData {
 
 export interface WhoisEntry {
   data: WhoisData;
-  receivedAt: string;
 }
 
 export interface WhoisViewerState {
@@ -69,10 +68,7 @@ export const useWhoisStore = defineStore('whois', {
     applyResult(networkId: number | string, data: WhoisData) {
       const nick = (data && (data.nick as string)) || '';
       if (!networkId || !nick) return;
-      this.byKey[key(networkId, nick)] = {
-        data,
-        receivedAt: new Date().toISOString(),
-      };
+      this.byKey[key(networkId, nick)] = { data };
     },
     openViewer(networkId: number | string, nick: string) {
       if (!networkId || !nick) return;

--- a/vue_client/src/stores/whois.ts
+++ b/vue_client/src/stores/whois.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineStore } from 'pinia';
+import { socketSend } from '../composables/useSocket.js';
+
+// Cache of the most recent `whois_result` for each (network, nick), plus the
+// open/close state for the UserProfileModal. The modal mounts once at the top
+// of the chat view and watches `viewer.open`, so any call site (slash
+// command, nicklist, DM header, message-body nick click) can open it without
+// owning the component — same pattern as nickNotes.editor.
+//
+// The store does NOT persist whois data across page reloads — IRC presence
+// is volatile and a stale cache is more misleading than no cache. On open
+// the modal triggers a fresh `whois` and re-renders when the result arrives.
+function key(networkId: number | string, nick: string) {
+  return `${networkId}::${(nick || '').toLowerCase()}`;
+}
+
+export interface WhoisData {
+  nick?: string;
+  ident?: string;
+  hostname?: string;
+  real_name?: string;
+  actual_hostname?: string;
+  actual_ip?: string;
+  server?: string;
+  server_info?: string;
+  channels?: string;
+  modes?: string;
+  account?: string;
+  registered_nick?: string;
+  operator?: string;
+  helpop?: string;
+  bot?: string;
+  secure?: boolean;
+  certfp?: string;
+  away?: string;
+  idle?: number;
+  logon?: number;
+  error?: string;
+  [key: string]: unknown;
+}
+
+export interface WhoisEntry {
+  data: WhoisData;
+  receivedAt: string;
+}
+
+export interface WhoisViewerState {
+  open: boolean;
+  networkId: number | null;
+  nick: string;
+}
+
+export const useWhoisStore = defineStore('whois', {
+  state: () => ({
+    byKey: {} as Record<string, WhoisEntry>,
+    viewer: { open: false, networkId: null, nick: '' } as WhoisViewerState,
+    // Tracks the nicks we've kicked a refresh for during this open viewer
+    // session, so reopening a different nick triggers its own refresh.
+    refreshingKey: null as string | null,
+  }),
+  getters: {
+    entryFor: (state) => (networkId: number | string, nick: string) =>
+      state.byKey[key(networkId, nick)] || null,
+  },
+  actions: {
+    applyResult(networkId: number | string, data: WhoisData) {
+      const nick = (data && (data.nick as string)) || '';
+      if (!networkId || !nick) return;
+      this.byKey[key(networkId, nick)] = {
+        data,
+        receivedAt: new Date().toISOString(),
+      };
+    },
+    openViewer(networkId: number | string, nick: string) {
+      if (!networkId || !nick) return;
+      const k = key(networkId, nick);
+      this.viewer = { open: true, networkId: Number(networkId), nick };
+      // Always kick a fresh whois on open. The cached entry (if any) renders
+      // immediately for instant feedback; the new data overwrites it when it
+      // arrives. Skip the refresh only if we already refreshed this exact
+      // (nick, network) during this viewer session — keeps reopens on the
+      // same nick from spamming the server.
+      if (this.refreshingKey !== k) {
+        this.refreshingKey = k;
+        socketSend({ type: 'raw', networkId, line: `WHOIS ${nick}` });
+      }
+    },
+    closeViewer() {
+      this.viewer = { open: false, networkId: null, nick: '' };
+      this.refreshingKey = null;
+    },
+  },
+});

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -63,7 +63,16 @@
       <span class="buffer">System console</span>
     </header>
     <header v-else-if="active" class="topic">
-      <span class="buffer">{{ bufferLabel }}</span>
+      <button
+        v-if="isDmHeader"
+        type="button"
+        class="buffer link"
+        title="View profile"
+        @click="openDmProfile"
+      >
+        {{ bufferLabel }}
+      </button>
+      <span v-else class="buffer">{{ bufferLabel }}</span>
       <template v-if="topic">
         <span class="sep">│</span>
         <button type="button" class="topic-text" title="View full topic" @click="showTopic = true">
@@ -147,6 +156,14 @@
     <QuickSwitcher v-if="showSwitcher" @close="showSwitcher = false" />
     <SearchModal v-if="showSearch" @close="showSearch = false" @jump="onJumpToMessage" />
     <KeyboardHelpModal v-if="showKbdHelp" @close="showKbdHelp = false" />
+    <UserProfileModal
+      v-if="whois.viewer.open && whois.viewer.networkId != null"
+      :nick="whois.viewer.nick"
+      :network-id="whois.viewer.networkId"
+    />
+    <!-- NickNoteModal comes last so when both are open (edit-note-from-profile)
+         it lands on top — AppModal uses a fixed z-index, so DOM order is the
+         tiebreaker. -->
     <NickNoteModal
       v-if="nickNotes.editor.open && nickNotes.editor.networkId != null"
       :nick="nickNotes.editor.nick"
@@ -182,9 +199,11 @@ import QuickSwitcher from '../components/QuickSwitcher.vue';
 import SearchModal from '../components/SearchModal.vue';
 import KeyboardHelpModal from '../components/KeyboardHelpModal.vue';
 import NickNoteModal from '../components/NickNoteModal.vue';
+import UserProfileModal from '../components/UserProfileModal.vue';
 import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts.js';
 import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useWhoisStore } from '../stores/whois.js';
 import { useBufferActions } from '../composables/useBufferActions.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
 
@@ -199,6 +218,7 @@ function openSystemConsole() {
 const settings = useSettingsStore();
 const nicklistCollapse = useNicklistCollapseStore();
 const nickNotes = useNickNotesStore();
+const whois = useWhoisStore();
 const bufferActions = useBufferActions();
 
 const showNetworkForm = ref(false);
@@ -307,6 +327,19 @@ watch(showChannels, async (open) => {
   void measureFootWrap();
 });
 onMounted(measureFootWrap);
+
+// True when the active buffer is a DM (not a channel, not the network's
+// server buffer). Drives the clickable DM header that opens the user
+// profile modal — channel headers stay non-interactive.
+const isDmHeader = computed(() => {
+  if (!active.value) return false;
+  if (isChannel.value || isServerBuffer.value) return false;
+  return true;
+});
+function openDmProfile() {
+  if (!active.value) return;
+  whois.openViewer(active.value.networkId, active.value.target);
+}
 
 // User count for the active channel buffer. Sits in the topic bar (next to
 // the members-toggle button) rather than the status bar — the count is a
@@ -577,6 +610,16 @@ useChatBootstrap({ onJump: onJumpToMessage });
   height: 1px;
 }
 .topic .buffer {
+  color: var(--accent);
+}
+/* DM headers double as a "view profile" trigger. Strip the .link padding so
+   the button-rendered label sits exactly where the span used to, and only
+   underline on hover so it doesn't read as a link in steady state. */
+button.buffer.link {
+  padding: 0;
+}
+button.buffer.link:hover {
+  text-decoration: underline;
   color: var(--accent);
 }
 .topic .sep {

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -43,7 +43,16 @@
         <button class="icon back" title="Back" @click="goList">
           <i class="fa-solid fa-arrow-left"></i>
         </button>
-        <span class="title">{{ isSystemConsole ? 'System console' : bufferLabel }}</span>
+        <button
+          v-if="isDmHeader"
+          type="button"
+          class="title title-btn"
+          title="View profile"
+          @click="openDmProfile"
+        >
+          {{ bufferLabel }}
+        </button>
+        <span v-else class="title">{{ isSystemConsole ? 'System console' : bufferLabel }}</span>
         <span class="spacer"></span>
         <button v-if="topic" class="icon" title="View topic" @click="showTopic = true">
           <i class="fa-solid fa-circle-info"></i>
@@ -130,6 +139,14 @@
     />
     <RecentUploadsModal v-if="showUploads" @close="showUploads = false" />
     <SearchModal v-if="showSearch" @close="showSearch = false" @jump="onJumpToMessage" />
+    <UserProfileModal
+      v-if="whois.viewer.open && whois.viewer.networkId != null"
+      :nick="whois.viewer.nick"
+      :network-id="whois.viewer.networkId"
+    />
+    <!-- NickNoteModal comes last so when both are open (edit-note-from-profile)
+         it lands on top — AppModal uses a fixed z-index, so DOM order is the
+         tiebreaker. -->
     <NickNoteModal
       v-if="nickNotes.editor.open && nickNotes.editor.networkId != null"
       :nick="nickNotes.editor.nick"
@@ -161,7 +178,9 @@ import ChannelListModal from '../components/ChannelListModal.vue';
 import RecentUploadsModal from '../components/RecentUploadsModal.vue';
 import SearchModal from '../components/SearchModal.vue';
 import NickNoteModal from '../components/NickNoteModal.vue';
+import UserProfileModal from '../components/UserProfileModal.vue';
 import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useWhoisStore } from '../stores/whois.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
 
 const networks = useNetworksStore();
@@ -178,6 +197,7 @@ const {
 } = useActiveBuffer();
 const bufferActions = useBufferActions();
 const nickNotes = useNickNotesStore();
+const whois = useWhoisStore();
 
 function openSystemConsole() {
   networks.activateSystem();
@@ -208,6 +228,18 @@ const bufferCogBtn = ref<HTMLElement | null>(null);
 // Server buffers already have a dedicated browse-channels action in the bar;
 // the cog is for channel/DM buffer-level actions (pin, always-notify).
 const showBufferCog = computed(() => !!active.value && !isServerBuffer.value);
+
+// True when the active buffer is a DM. Drives the clickable title that
+// opens the user profile modal — channel titles stay non-interactive.
+const isDmHeader = computed(() => {
+  if (!active.value) return false;
+  if (isChannel.value || isServerBuffer.value || isSystemConsole.value) return false;
+  return true;
+});
+function openDmProfile() {
+  if (!active.value) return;
+  whois.openViewer(active.value.networkId, active.value.target);
+}
 
 function openBufferActions() {
   if (!activeBuf.value) return;
@@ -347,6 +379,19 @@ useChatBootstrap({ onJump: onJumpToMessage });
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+}
+/* DM headers double as a "view profile" trigger — match the .title look,
+   underline on tap. */
+.title-btn {
+  background: none;
+  border: none;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  padding: 0;
+}
+.title-btn:active {
+  text-decoration: underline;
 }
 .spacer {
   flex: 1;


### PR DESCRIPTION
Closes #92.

## Summary
- Server: `WHOIS` reply now fans out as a structured `whois_result` ephemeral event instead of a block of motd lines (`server/services/ircConnection.ts`). Removed the now-unused `formatWhoisLines`.
- Client: new `useWhoisStore` Pinia store caches the latest whois per `(networkId, nicklower)`, owns the viewer open/close state, and kicks a fresh `WHOIS` on open so cached data renders instantly and is replaced when the new reply lands.
- New `UserProfileModal.vue` (wraps `AppModal`): identity (real name / hostmask / connected-from / account + TLS/Bot/Operator/Registered chips), activity (idle / signon / server / clickable channels), and "Your note" — the Edit button delegates to the existing `NickNoteModal` so the editor has one source of truth.
- Triggers: `/whois <nick>` opens the modal, "View profile…" added to the nicklist and DM context menus, and the DM header is clickable on both desktop and mobile (channels/server headers stay non-interactive).

## Test plan
- [x] `npm run check` (typecheck server + client, oxlint, oxfmt) — clean
- [x] `npm test` — 625/625
- [x] `npm run client:build` — clean
- [x] Eyeball pass against a live ircd: confirm channels parse for your network (irc-framework's `channels` field varies), TLS/Bot/Operator chips render for known accounts, presence dot reflects MONITOR state for an offline peer
- [ ] Edit-note from profile shows the note editor on top of the profile (z-index fix verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)