### PR TITLE
Seed buffer history on first activate (fix #104)

### DIFF
--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -349,10 +349,11 @@ export const useBuffersStore = defineStore('buffers', {
     loadAround(networkId: number | string, target: string, anchorId: number, halfLimit = 100) {
       const buf = ensureBuffer(this, networkId, target);
       const token = nextHistoryToken();
+      const wasDetached = buf.detached;
       buf.detached = true;
       buf.pendingHistoryToken = token;
       buf.loadingHistory = true;
-      socketSend({
+      const sent = socketSend({
         type: 'history',
         mode: 'around',
         networkId,
@@ -361,6 +362,15 @@ export const useBuffersStore = defineStore('buffers', {
         token,
         limit: halfLimit,
       });
+      // Same rollback rationale as reattachToLive — a failed send leaves no
+      // response to clear the loading flag. Restoring detached to its prior
+      // state too (rather than forcing false) avoids stomping on a buffer
+      // that was already detached from a previous jump.
+      if (!sent) {
+        buf.loadingHistory = false;
+        buf.pendingHistoryToken = null;
+        buf.detached = wasDetached;
+      }
     },
     // Token-guarded replace for the 'around' response. A mismatched token
     // means a fresher request superseded this one — drop the stale slice
@@ -393,7 +403,7 @@ export const useBuffersStore = defineStore('buffers', {
       const token = nextHistoryToken();
       buf.pendingHistoryToken = token;
       buf.loadingHistory = true;
-      socketSend({
+      const sent = socketSend({
         type: 'history',
         mode: 'latest',
         networkId,
@@ -401,6 +411,17 @@ export const useBuffersStore = defineStore('buffers', {
         token,
         limit,
       });
+      // socketSend returns false when the socket isn't open. No response will
+      // arrive to clear loadingHistory, and there's no reconnect handler that
+      // resets it per-buffer — so without this rollback the buffer would be
+      // permanently stranded "loading" and every subsequent fetch guard
+      // (this function's early-return, MessageList's requestMoreHistory) would
+      // block forever. Relevant when activate fires before the socket has
+      // (re)connected, e.g. push-notification deep-link into a cold PWA.
+      if (!sent) {
+        buf.loadingHistory = false;
+        buf.pendingHistoryToken = null;
+      }
     },
     applyLatestReplace(networkId: number | string, target: string, payload: any) {
       const buf = ensureBuffer(this, networkId, target);
@@ -632,7 +653,12 @@ export const useBuffersStore = defineStore('buffers', {
       if (buf.pendingRefetch) {
         buf.pendingRefetch = false;
         this.reattachToLive(networkId, target);
-      } else if (buf.messages.length === 0 && !buf.detached && !buf.loadingHistory) {
+      } else if (
+        buf.messages.length === 0 &&
+        buf.hasMoreOlder &&
+        !buf.detached &&
+        !buf.loadingHistory
+      ) {
         // First-load fetch. The buffer shell exists but has no messages —
         // either it's brand new (profile-modal "Send DM" to a nick we've
         // never DM'd before) or it was pre-created by a side channel
@@ -644,6 +670,12 @@ export const useBuffersStore = defineStore('buffers', {
         // here so every entry path is uniformly seeded — the MessageList
         // lifecycle's ensureViewportFilled() goes back to being a safety
         // net rather than the load-bearing initial-fetch trigger.
+        //
+        // hasMoreOlder gates against the truly-empty case: a brand-new
+        // DM/channel with no server history returns an empty latest slice
+        // that leaves messages.length=0 but flips hasMoreOlder to false —
+        // without this guard we'd refire the same empty fetch on every
+        // re-activate.
         this.reattachToLive(networkId, target);
       }
       // For DMs, ask the server to WHOIS-probe the peer so the banner/sidebar

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -632,6 +632,19 @@ export const useBuffersStore = defineStore('buffers', {
       if (buf.pendingRefetch) {
         buf.pendingRefetch = false;
         this.reattachToLive(networkId, target);
+      } else if (buf.messages.length === 0 && !buf.detached && !buf.loadingHistory) {
+        // First-load fetch. The buffer shell exists but has no messages —
+        // either it's brand new (profile-modal "Send DM" to a nick we've
+        // never DM'd before) or it was pre-created by a side channel
+        // (presence/typing/MONITOR events touch ensureBuffer without
+        // seeding history) and the initial backlog snapshot only covers
+        // buffers that were already open at socket-connect. Push-notification
+        // deep-links land here too, since isOpen() is satisfied by any shell
+        // in the store regardless of message contents. Kick a latest fetch
+        // here so every entry path is uniformly seeded — the MessageList
+        // lifecycle's ensureViewportFilled() goes back to being a safety
+        // net rather than the load-bearing initial-fetch trigger.
+        this.reattachToLive(networkId, target);
       }
       // For DMs, ask the server to WHOIS-probe the peer so the banner/sidebar
       // dim reflect current state rather than a possibly-stale cached value.


### PR DESCRIPTION
## Summary
- `activate()` previously relied on either the initial websocket backlog snapshot (only covers buffers open at connect-time) or `MessageList.ensureViewportFilled()` to populate history. Two entry paths bypass both:
  - **Profile-modal "Send DM"** for a nick the user has never DM'd — `ensureBuffer()` mints an empty shell with no `pendingRefetch`, so `activate()` no-ops.
  - **Push-notification deep-link** — `useJumpToMessage`'s `isOpen()` check is satisfied by any shell in the store (presence/typing/MONITOR side channels routinely pre-create shells without seeding messages), so the "buffer is closed" bail doesn't catch this case.
- In both flows, the buffer falls through to MessageList's lifecycle-driven fetch, which races against mount/scroller readiness and intermittently leaves the user staring at an empty buffer that has history on the server.
- Fix: when `activate()` lands on a non-detached buffer with `messages.length === 0` and no fetch already in flight, kick `reattachToLive()` directly. `reattachToLive` already guards on `loadingHistory`, so this is duplicate-fetch-safe. `ensureViewportFilled()` goes back to being a safety net rather than the load-bearing initial-fetch trigger.

Closes #104.

## Test plan
- [ ] Cold-load app, click a nick in a channel → "Send DM" from the new profile modal for a nick you've never DM'd → buffer opens with history populated immediately (no empty state).
- [ ] Push notification for a channel that wasn't open at the most recent socket-connect → tapping it opens the buffer with history populated.
- [ ] Regression: normal sidebar click on a buffer with existing messages still works (no double-fetch, no flash).
- [ ] Regression: "Return to present" from a detached buffer still re-fetches via the existing `pendingRefetch` branch.
- [ ] Regression: re-activating the currently-active buffer does not trigger an extra fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)