### PR TITLE
Customizable mIRC palette + preserve spoiler colors

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -237,6 +237,41 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     default: '#38353b',
     description: 'Subtle horizontal/vertical separators between regions.',
   },
+  {
+    key: 'look.color.mirc_colors',
+    label: 'mIRC color palette',
+    category: 'appearance',
+    group: 'palette',
+    type: 'string-list',
+    // 16 entries, one per mIRC color code 0..15. The chromatic slots default
+    // to the closest hue from look.nick.colors so coloured chat text harmonises
+    // with the rest of the theme; the four mono-ish slots (white, black, gray,
+    // light gray) use theme variables so they stay legible on any background.
+    default: [
+      'var(--fg)', //                                       0  white
+      'var(--bg)', //                                       1  black
+      '#6799f3', //                                         2  navy
+      '#a9dc76', //                                         3  green
+      '#ff6188', //                                         4  red
+      '#ed6c89', //                                         5  maroon
+      '#ab9df2', //                                         6  purple
+      '#fc9867', //                                         7  orange
+      '#ffd866', //                                         8  yellow
+      '#b3db82', //                                         9  lime
+      '#78dce8', //                                         10 teal
+      '#a0f1ff', //                                         11 cyan
+      '#7ba4ff', //                                         12 blue
+      '#ff7494', //                                         13 magenta
+      'var(--fg-muted)', //                                 14 gray
+      'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
+    ],
+    description:
+      'How the 16 mIRC color codes (0-15) render in chat. One CSS color per line, ' +
+      'in order: white, black, navy, green, red, maroon, purple, orange, yellow, ' +
+      'lime, teal, cyan, blue, magenta, gray, light gray. Defaults pick the ' +
+      'closest hue from your nick palette so coloured text matches the rest of ' +
+      'the theme. Any CSS color value works (hex, rgb(), var(--name), color-mix()).',
+  },
 
   // ─── Alternating message rows ─────────────────────────────────────────
   {

--- a/vue_client/src/components/MircColorPicker.vue
+++ b/vue_client/src/components/MircColorPicker.vue
@@ -53,7 +53,7 @@
         class="swatch"
         tabindex="0"
         :class="{ picked: staged[slot] === entry.code }"
-        :style="{ backgroundColor: entry.hex }"
+        :style="{ backgroundColor: entry.color }"
         :title="`mIRC ${entry.code}`"
         :aria-label="`mIRC colour ${entry.code}`"
         @mousedown.prevent
@@ -120,7 +120,10 @@ const mircPalette = useMircPalette();
 const swatches = computed(() =>
   Array.from({ length: 16 }, (_, i) => ({
     code: i.toString().padStart(2, '0'),
-    hex: mircColor(i, mircPalette.value) ?? '#ffffff',
+    // Any CSS colour value the user's palette resolves to — hex, rgb(),
+    // var(--name), color-mix(...). Falls back to white only if the lookup
+    // returns null, which shouldn't happen for indices 0-15.
+    color: mircColor(i, mircPalette.value) ?? '#ffffff',
   })),
 );
 
@@ -159,8 +162,8 @@ watch(
 // it doesn't — so the slot buttons double as a preview of the staged colour.
 function chipStyle(code: string | null): Record<string, string> {
   if (!code) return {};
-  const hex = swatches.value.find((p) => p.code === code)?.hex;
-  return hex ? { backgroundColor: hex } : {};
+  const c = swatches.value.find((p) => p.code === code)?.color;
+  return c ? { backgroundColor: c } : {};
 }
 
 function pick(code: string): void {

--- a/vue_client/src/components/MircColorPicker.vue
+++ b/vue_client/src/components/MircColorPicker.vue
@@ -107,31 +107,22 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, watch } from 'vue';
+import { mircColor } from '../utils/nickColor.js';
+import { useMircPalette } from '../composables/useNickColors.js';
 
 // 'fg' is the text colour slot, 'bg' the background colour slot.
 type ColorTarget = 'fg' | 'bg';
 
-// The 16-color palette here mirrors MIRC_PALETTE in utils/nickColor.js — those
-// are the only codes our renderer styles, so anything outside 0-15 wouldn't
-// round-trip visibly anyway.
-const PALETTE = [
-  { code: '00', hex: '#ffffff' },
-  { code: '01', hex: '#000000' },
-  { code: '02', hex: '#00007f' },
-  { code: '03', hex: '#009300' },
-  { code: '04', hex: '#ff0000' },
-  { code: '05', hex: '#7f0000' },
-  { code: '06', hex: '#9c009c' },
-  { code: '07', hex: '#fc7f00' },
-  { code: '08', hex: '#ffff00' },
-  { code: '09', hex: '#00fc00' },
-  { code: '10', hex: '#009393' },
-  { code: '11', hex: '#00ffff' },
-  { code: '12', hex: '#0000fc' },
-  { code: '13', hex: '#ff00ff' },
-  { code: '14', hex: '#7f7f7f' },
-  { code: '15', hex: '#d2d2d2' },
-];
+// Swatches reflect the user-overridable mIRC palette so what they pick here
+// matches what the renderer will draw. The wire format is still the standard
+// mIRC code ("00".."15") — only the local preview colour changes.
+const mircPalette = useMircPalette();
+const swatches = computed(() =>
+  Array.from({ length: 16 }, (_, i) => ({
+    code: i.toString().padStart(2, '0'),
+    hex: mircColor(i, mircPalette.value) ?? '#ffffff',
+  })),
+);
 
 const props = withDefaults(
   defineProps<{
@@ -148,7 +139,6 @@ const emit = defineEmits<{
   close: [];
 }>();
 
-const swatches = PALETTE;
 const slot = ref<ColorTarget>('fg');
 const staged = reactive<{ fg: string | null; bg: string | null }>({ fg: null, bg: null });
 const hasPick = computed(() => !!staged.fg || !!staged.bg);
@@ -168,7 +158,8 @@ watch(
 // A filled chip when the slot holds a colour, a hollow one (border only) when
 // it doesn't — so the slot buttons double as a preview of the staged colour.
 function chipStyle(code: string | null): Record<string, string> {
-  const hex = code ? PALETTE.find((p) => p.code === code)?.hex : undefined;
+  if (!code) return {};
+  const hex = swatches.value.find((p) => p.code === code)?.hex;
   return hex ? { backgroundColor: hex } : {};
 }
 

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -45,6 +45,7 @@ import type { CSSProperties } from 'vue';
 import type { RenderSegment } from '../utils/nickColor.js';
 import { segmentInlineStyle, segmentHasStyle } from '../utils/nickColor.js';
 import { useBuffersStore } from '../stores/buffers.js';
+import { useMircPalette } from '../composables/useNickColors.js';
 import { socketSend } from '../composables/useSocket.js';
 import SpoilerText from './SpoilerText.vue';
 
@@ -71,9 +72,10 @@ const props = withDefaults(
 );
 
 const buffers = useBuffersStore();
+const mircPalette = useMircPalette();
 
 function styleFor(seg: RenderSegment): CSSProperties {
-  return segmentInlineStyle(seg, props.selfColor ?? null) as CSSProperties;
+  return segmentInlineStyle(seg, props.selfColor ?? null, mircPalette.value) as CSSProperties;
 }
 function hasStyle(seg: RenderSegment): boolean {
   return segmentHasStyle(seg);

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -63,7 +63,15 @@ const color = computed(() => {
 
 const wrapperStyle = computed<CSSProperties>(() => {
   const c = color.value;
-  if (!c) return {};
+  if (!c) {
+    // No chosen colour to honour (out-of-range mIRC index, or a RenderSegment
+    // hand-built without fg). Keep the wrapper inheriting the .spoiler base
+    // background (var(--fg-muted)) unrevealed, then fade to the neutral tint
+    // on reveal — same behaviour as before customisation.
+    return revealed.value
+      ? { background: 'color-mix(in srgb, var(--fg-muted) 22%, transparent)' }
+      : {};
+  }
   return revealed.value
     ? // Faint tint of the chosen colour so the affordance survives the reveal.
       { background: `color-mix(in srgb, ${c} 22%, transparent)` }

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -7,6 +7,7 @@
   <span
     class="spoiler"
     :class="{ revealed }"
+    :style="wrapperStyle"
     :role="revealed ? undefined : 'button'"
     :tabindex="revealed ? undefined : 0"
     :aria-expanded="revealed ? undefined : 'false'"
@@ -25,13 +26,20 @@
 import { ref, computed } from 'vue';
 import type { CSSProperties } from 'vue';
 import type { RenderSegment } from '../utils/nickColor.js';
+import { mircColor } from '../utils/nickColor.js';
+import { useMircPalette } from '../composables/useNickColors.js';
 
 // Renders an IRC spoiler run (fg===bg, i.e. text deliberately coloured to be
 // invisible) as a Discord-style blacked-out box. The content is kept out of
 // the accessible name (aria-hidden) until revealed so a screen reader doesn't
 // read the secret aloud. Reveal is one-way: once a user deliberately opens a
-// spoiler, re-hiding it isn't a behaviour anyone expects.
+// spoiler, re-hiding it isn't a behaviour anyone expects. The colour the
+// sender picked rides through on seg.fg (== seg.bg by construction) — we use
+// it to paint the unrevealed box and the revealed text/tint so the chatter's
+// colour intent is preserved instead of being flattened to gray.
 const props = defineProps<{ seg: RenderSegment }>();
+
+const mircPalette = useMircPalette();
 
 const revealed = ref(false);
 function reveal(e: Event): void {
@@ -44,10 +52,30 @@ function reveal(e: Event): void {
   revealed.value = true;
 }
 
+// Resolve the sender's chosen mIRC colour to a CSS value. Null when fg is
+// absent (older snapshots without the field) — we then fall back to the old
+// neutral gray.
+const color = computed(() => {
+  const fg = props.seg.fg;
+  if (fg == null) return null;
+  return mircColor(fg, mircPalette.value);
+});
+
+const wrapperStyle = computed<CSSProperties>(() => {
+  const c = color.value;
+  if (!c) return {};
+  return revealed.value
+    ? // Faint tint of the chosen colour so the affordance survives the reveal.
+      { background: `color-mix(in srgb, ${c} 22%, transparent)` }
+    : { background: c };
+});
+
 // The spoiler run still carries any bold/italic/underline/strike toggles that
-// were active — apply them so the revealed text matches how it was sent.
+// were active — apply them so the revealed text matches how it was sent. Once
+// revealed, the text takes the chosen colour against the faded backdrop.
 const bodyStyle = computed<CSSProperties>(() => {
   const s: CSSProperties = {};
+  if (revealed.value && color.value) s.color = color.value;
   if (props.seg.bold) s.fontWeight = 'bold';
   if (props.seg.italic) s.fontStyle = 'italic';
   const decos: string[] = [];
@@ -62,6 +90,8 @@ const bodyStyle = computed<CSSProperties>(() => {
 .spoiler {
   border-radius: 3px;
   padding: 0 3px;
+  /* Wrapper-style overrides this for coloured spoilers; the var(--fg-muted)
+     fallback covers older snapshots whose segments lack fg. */
   background: var(--fg-muted);
   transition: background-color 0.1s ease;
 }
@@ -73,12 +103,15 @@ const bodyStyle = computed<CSSProperties>(() => {
   /* Stop a drag-select from revealing the text — click is the only reveal. */
   user-select: none;
 }
-.spoiler:not(.revealed):hover {
-  background: var(--fg);
-}
-.spoiler.revealed {
-  /* A faint tint so it still reads as "this was a spoiler" once opened. */
-  background: color-mix(in srgb, var(--fg-muted) 22%, transparent);
+/* Hover affordance is desktop-only: on touch devices, sticky-:hover would
+   make the first tap apply the hover state instead of revealing, so we skip
+   the hover rule entirely and let the single tap reveal. We brighten via
+   `filter` rather than overriding `background` because the wrapper's inline
+   style (chosen mIRC colour) would otherwise win the cascade. */
+@media (hover: hover) and (pointer: fine) {
+  .spoiler:not(.revealed):hover {
+    filter: brightness(1.2);
+  }
 }
 .spoiler:focus-visible {
   outline: 1px solid var(--accent);

--- a/vue_client/src/composables/useNickColors.ts
+++ b/vue_client/src/composables/useNickColors.ts
@@ -34,3 +34,12 @@ export function useNickColors(): NickColorsAPI {
 
   return { color, splitText, selfColor };
 }
+
+// Reactive accessor for the user-overridable mIRC palette (look.color.mirc_colors).
+// Returned as a ComputedRef<string[]> — 16 entries, one per mIRC colour code 0..15.
+// Callers hand this to segmentInlineStyle() / mircColor() so rendered colours
+// update live when the user edits the palette in Settings.
+export function useMircPalette(): ComputedRef<string[]> {
+  const settings = useSettingsStore();
+  return computed(() => settings.effective('look.color.mirc_colors') as string[]);
+}

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -41,26 +41,26 @@ describe('splitTextByTokens — background colour', () => {
 });
 
 describe('splitTextByTokens — spoiler detection', () => {
-  it('emits a single spoiler segment when fg equals bg', () => {
+  it('emits a single spoiler segment when fg equals bg, preserving the chosen colour', () => {
     const segs = parse(`${C}01,01secret${C}`);
-    expect(segs).toEqual([{ text: 'secret', spoiler: true }]);
+    expect(segs).toEqual([{ text: 'secret', spoiler: true, fg: 1 }]);
   });
 
   it('treats any matching fg/bg pair as a spoiler, not just 01,01', () => {
     const segs = parse(`${C}04,04hidden${C}`);
-    expect(segs).toEqual([{ text: 'hidden', spoiler: true }]);
+    expect(segs).toEqual([{ text: 'hidden', spoiler: true, fg: 4 }]);
   });
 
   it('does not split a URL out of a spoiler run (no leak)', () => {
     const segs = parse(`${C}01,01see https://example.com${C}`);
     expect(segs).toHaveLength(1);
-    expect(segs[0]).toEqual({ text: 'see https://example.com', spoiler: true });
+    expect(segs[0]).toEqual({ text: 'see https://example.com', spoiler: true, fg: 1 });
     expect(segs[0].url).toBeUndefined();
   });
 
   it('keeps active bold/italic toggles on the spoiler segment', () => {
     const segs = parse(`${BOLD}${C}01,01x${C}`);
-    expect(segs).toEqual([{ text: 'x', spoiler: true, bold: true }]);
+    expect(segs).toEqual([{ text: 'x', spoiler: true, fg: 1, bold: true }]);
   });
 
   it('does not treat differing fg/bg as a spoiler', () => {
@@ -145,18 +145,28 @@ describe('splitTextByTokens — channel detection', () => {
 });
 
 describe('segmentInlineStyle / segmentHasStyle — background colour', () => {
-  it('maps a background code to a backgroundColor', () => {
+  it('maps fg and bg codes to CSS colours via the fallback palette', () => {
+    // No palette argument → fall back to MIRC_PALETTE_FALLBACK. Slot 4 is
+    // red, slot 8 is yellow.
     expect(segmentInlineStyle({ text: 'x', fg: 4, bg: 8 }, null)).toEqual({
-      color: '#ff0000',
-      backgroundColor: '#ffff00',
+      color: '#ff6188',
+      backgroundColor: '#ffd866',
     });
   });
 
   it('renders a background even when the foreground is the default (99)', () => {
-    // \x0399,01 — default text on a black background.
+    // \x0399,01 — default text on the "black" slot. The fallback "black" is
+    // var(--bg) so the box adapts to whatever theme is active.
     const style = segmentInlineStyle({ text: 'x', fg: 99, bg: 1 }, null);
     expect(style.color).toBeUndefined();
-    expect(style.backgroundColor).toBe('#000000');
+    expect(style.backgroundColor).toBe('var(--bg)');
+  });
+
+  it('honours a caller-supplied palette over the fallback', () => {
+    const palette = Array(16).fill('#abcdef');
+    palette[4] = '#deadbe';
+    const style = segmentInlineStyle({ text: 'x', fg: 4 }, null, palette);
+    expect(style.color).toBe('#deadbe');
   });
 
   it('reports a background-only segment as styled', () => {

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -231,28 +231,45 @@ function colorNicksInText(
   return out;
 }
 
-// mIRC's classic 16-colour foreground palette. Indices 16-98 (extended) and
-// the \x04 hex variant aren't widely used and clash badly with custom themes,
-// so we don't render those — we just consume the escape so the digits don't
-// leak into the output.
-const MIRC_PALETTE: Record<number, string> = {
-  0: '#ffffff',
-  1: '#000000',
-  2: '#00007f',
-  3: '#009300',
-  4: '#ff0000',
-  5: '#7f0000',
-  6: '#9c009c',
-  7: '#fc7f00',
-  8: '#ffff00',
-  9: '#00fc00',
-  10: '#009393',
-  11: '#00ffff',
-  12: '#0000fc',
-  13: '#ff00ff',
-  14: '#7f7f7f',
-  15: '#d2d2d2',
-};
+// Fallback for the 16 mIRC colour slots, used when no caller-supplied palette
+// covers a given index. The chromatic slots match nick.colors defaults so a
+// renderer without a settings store (tests, MOTD pre-paint) still produces
+// theme-friendly colours; the four mono-ish slots fall back to theme vars.
+// Indices 16-98 (extended) and the \x04 hex variant aren't widely used and
+// clash badly with custom themes, so we don't render those — we just consume
+// the escape so the digits don't leak into the output.
+export const MIRC_PALETTE_FALLBACK: readonly string[] = [
+  'var(--fg)', //                                       0  white
+  'var(--bg)', //                                       1  black
+  '#6799f3', //                                         2  navy
+  '#a9dc76', //                                         3  green
+  '#ff6188', //                                         4  red
+  '#ed6c89', //                                         5  maroon
+  '#ab9df2', //                                         6  purple
+  '#fc9867', //                                         7  orange
+  '#ffd866', //                                         8  yellow
+  '#b3db82', //                                         9  lime
+  '#78dce8', //                                         10 teal
+  '#a0f1ff', //                                         11 cyan
+  '#7ba4ff', //                                         12 blue
+  '#ff7494', //                                         13 magenta
+  'var(--fg-muted)', //                                 14 gray
+  'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
+];
+
+// Look up a mIRC colour slot in a caller-supplied palette, falling back to
+// MIRC_PALETTE_FALLBACK when the palette is missing the entry or empty. Out-
+// of-range indices (16-98, plus the hex \x04 variant) return null so the
+// renderer can drop them without leaking digits into the output.
+export function mircColor(
+  index: number,
+  palette: readonly string[] | null | undefined,
+): string | null {
+  if (index < 0 || index > 15) return null;
+  const supplied = palette?.[index];
+  if (supplied) return supplied;
+  return MIRC_PALETTE_FALLBACK[index] ?? null;
+}
 
 interface IrcRun {
   text: string;
@@ -407,17 +424,26 @@ export interface RenderSegment {
 // explicit IRC fg wins over nick coloring, which wins over the self-color.
 // Pass selfColor=null when rendering outside the message context (topic bar,
 // motd, etc.) — those callers never produce nick / self segments anyway.
-export function segmentInlineStyle(seg: RenderSegment, selfColor: string | null): TextSegmentStyle {
+// `mircPalette` is the user-overridable 16-colour mIRC palette from settings;
+// pass null to fall back to MIRC_PALETTE_FALLBACK (handy in tests and pre-
+// store render paths).
+export function segmentInlineStyle(
+  seg: RenderSegment,
+  selfColor: string | null,
+  mircPalette: readonly string[] | null = null,
+): TextSegmentStyle {
   const style: TextSegmentStyle = {};
-  if (seg.fg != null && MIRC_PALETTE[seg.fg]) {
-    style.color = MIRC_PALETTE[seg.fg];
+  const fg = seg.fg != null ? mircColor(seg.fg, mircPalette) : null;
+  if (fg) {
+    style.color = fg;
   } else if (seg.color) {
     style.color = seg.color;
   } else if (seg.self && selfColor) {
     style.color = selfColor;
   }
-  if (seg.bg != null && MIRC_PALETTE[seg.bg]) {
-    style.backgroundColor = MIRC_PALETTE[seg.bg];
+  if (seg.bg != null) {
+    const bg = mircColor(seg.bg, mircPalette);
+    if (bg) style.backgroundColor = bg;
   }
   if (seg.bold) style.fontWeight = 'bold';
   if (seg.italic) style.fontStyle = 'italic';
@@ -513,9 +539,11 @@ export function splitTextByTokens(
     // A run whose foreground and background are the same colour is invisible
     // text — the IRC spoiler convention. Emit it as one opaque segment and
     // skip URL / nick splitting: a linked URL or a coloured nick rendered
-    // inside the run would stay visible and leak the hidden content.
+    // inside the run would stay visible and leak the hidden content. Keep the
+    // chosen colour on the segment so SpoilerText can paint the box in the
+    // sender's colour rather than a generic gray.
     if (run.fg != null && run.bg != null && run.fg === run.bg) {
-      out.push({ text: run.text, spoiler: true, ...fmt });
+      out.push({ text: run.text, spoiler: true, fg: run.fg, ...fmt });
       continue;
     }
     if (run.fg != null) fmt.fg = run.fg;


### PR DESCRIPTION
## Summary
- New `look.color.mirc_colors` string-list: 16 entries, one per mIRC code (0–15). Defaults map `look.nick.colors` hues onto the chromatic slots so coloured chat text harmonises with the theme; mono slots (white/black/gray/light gray) use `var(--fg)` / `var(--bg)` / `var(--fg-muted)` / a `color-mix` of `--fg` so they stay legible across themes. Users can override any slot in Settings → Appearance → Palette.
- Spoiler runs (`fg == bg`) now carry the chosen colour on the segment. `SpoilerText.vue` paints the unrevealed box in that colour and, on reveal, shows the text in that colour against a faded `color-mix` tint — replacing the previous flat `var(--fg-muted)` gray.
- Spoiler hover preview is now gated to `@media (hover: hover) and (pointer: fine)`. On iOS the sticky-:hover state was being applied on the first tap instead of revealing — single tap now reveals immediately on touch devices, and the hover-darken is implemented via `filter: brightness()` so it composes over the inline background colour.
- `MircColorPicker.vue` reads from the same `useMircPalette()` composable so the swatches you pick from match the renderer's output exactly.

## Test plan
- [x] `npm run check` (typecheck both projects, lint, format-check)
- [x] `npm run test` — 626 tests pass; spoiler-detection tests updated for the new `fg`-on-segment shape, added coverage for caller-supplied palette overriding the fallback
- [x] `npm run client:build`
- [ ] Smoke test in the running app: send `\x0304,04hello`, `\x0303hello`, `\x0301,01secret`; tap a spoiler on mobile and confirm one tap reveals it
- [ ] Override a slot in Settings → Appearance → Palette → "mIRC color palette" and confirm chat renders with the new colour live

Closes #106
Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)