### PR TITLE
Unpin closed buffers so pinned reorder stays in sync (#112)

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -273,8 +273,11 @@ function migrate() {
     -- Per-(user, network) pinned buffer list. Pinned channels/DMs float to the
     -- top of the sidebar in user-controlled order; position is a dense integer
     -- scoped per (user_id, network_id), rewritten in full on each reorder so we
-    -- don't have to chase sparse gaps. Pin survives part/close — the row is
-    -- only removed by an explicit unpin (or user/network deletion via cascade).
+    -- don't have to chase sparse gaps. Pin survives part (the channel stays in
+    -- the sidebar) but not close — the client filters the pinned section by
+    -- open buffers, so a row without an open buffer is invisible and would
+    -- desync the client's pin set from ours. Close-buffer therefore implies
+    -- unpin (see wsHub close-buffer handler).
     CREATE TABLE IF NOT EXISTS pinned_buffers (
       user_id INTEGER NOT NULL,
       network_id INTEGER NOT NULL,
@@ -504,7 +507,7 @@ ensureColumn('messages', 'alt', 'INTEGER NOT NULL DEFAULT 0');
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 const schemaVersionRow = db
   .prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`)
   .get() as { value: string } | undefined;
@@ -755,6 +758,42 @@ if (schemaVersion < 6) {
     }
   });
   seed();
+}
+
+if (schemaVersion < 7) {
+  // Issue #112 backfill: before this version, close-buffer left the
+  // pinned_buffers row intact. The client filters the pinned section by open
+  // buffers, so the orphan was invisible — but it made the client's pin set
+  // smaller than the server's, and the next reorder failed the set-match
+  // check in reorderPins and snapped back. Drop the orphans (target also in
+  // closed_buffers), then renumber positions per (user, network) so they
+  // stay dense (0..n-1) as the rest of the code assumes.
+  db.exec(`
+    DELETE FROM pinned_buffers
+    WHERE EXISTS (
+      SELECT 1 FROM closed_buffers c
+      WHERE c.user_id = pinned_buffers.user_id
+        AND c.network_id = pinned_buffers.network_id
+        AND c.target = pinned_buffers.target
+    )
+  `);
+  db.exec(`
+    WITH renum AS (
+      SELECT user_id, network_id, target,
+             ROW_NUMBER() OVER (
+               PARTITION BY user_id, network_id
+               ORDER BY position ASC, target ASC
+             ) - 1 AS new_pos
+      FROM pinned_buffers
+    )
+    UPDATE pinned_buffers
+    SET position = (
+      SELECT new_pos FROM renum
+      WHERE renum.user_id = pinned_buffers.user_id
+        AND renum.network_id = pinned_buffers.network_id
+        AND renum.target = pinned_buffers.target
+    )
+  `);
 }
 
 if (schemaVersion < SCHEMA_VERSION) {

--- a/server/db/pinnedBuffers.test.ts
+++ b/server/db/pinnedBuffers.test.ts
@@ -11,7 +11,9 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 
 let createUser: typeof import('./users.js').createUser;
 let createNetwork: typeof import('./networks.js').createNetwork;
+let closeBuffer: typeof import('./closedBuffers.js').closeBuffer;
 let pinned: typeof import('./pinnedBuffers.js');
+let db: typeof import('./index.js').default;
 let user: ReturnType<typeof import('./users.js').createUser>;
 let net: ReturnType<typeof import('./networks.js').createNetwork>;
 let net2: ReturnType<typeof import('./networks.js').createNetwork>;
@@ -19,7 +21,9 @@ let net2: ReturnType<typeof import('./networks.js').createNetwork>;
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
+  ({ closeBuffer } = await import('./closedBuffers.js'));
   pinned = await import('./pinnedBuffers.js');
+  db = (await import('./index.js')).default;
   user = createUser('pin-alice');
   net = createNetwork(user.id, { name: 'libera', host: 'h', port: 6697, tls: true, nick: 'a' });
   net2 = createNetwork(user.id, { name: 'oftc', host: 'h2', port: 6697, tls: true, nick: 'a' });
@@ -72,5 +76,88 @@ describe('listPinnedForUser', () => {
     const grouped = pinned.listPinnedForUser(user.id);
     expect(grouped.get(net!.id)).toEqual(['#d', '#c']);
     expect(grouped.get(net2!.id)).toEqual(['#meta']);
+  });
+});
+
+// Mirrors the schemaVersion < 7 cleanup in db/index.ts. Kept here as a string
+// so the test can replay it against orphan rows that the public API can no
+// longer create (close-buffer now implies unpin).
+const PURGE_ORPHANS_SQL = `
+  DELETE FROM pinned_buffers
+  WHERE EXISTS (
+    SELECT 1 FROM closed_buffers c
+    WHERE c.user_id = pinned_buffers.user_id
+      AND c.network_id = pinned_buffers.network_id
+      AND c.target = pinned_buffers.target
+  )
+`;
+const RENUMBER_PINS_SQL = `
+  WITH renum AS (
+    SELECT user_id, network_id, target,
+           ROW_NUMBER() OVER (
+             PARTITION BY user_id, network_id
+             ORDER BY position ASC, target ASC
+           ) - 1 AS new_pos
+    FROM pinned_buffers
+  )
+  UPDATE pinned_buffers
+  SET position = (
+    SELECT new_pos FROM renum
+    WHERE renum.user_id = pinned_buffers.user_id
+      AND renum.network_id = pinned_buffers.network_id
+      AND renum.target = pinned_buffers.target
+  )
+`;
+
+describe('schemaVersion < 7 orphan cleanup (issue #112)', () => {
+  it('drops pinned rows whose target is also closed, then renumbers positions per (user, network)', () => {
+    // Fresh user/networks so we don't entangle with the suite-wide state above.
+    const bob = createUser('pin-bob');
+    const netA = createNetwork(bob.id, {
+      name: 'a',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'b',
+    });
+    const netB = createNetwork(bob.id, {
+      name: 'b',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'b',
+    });
+
+    pinned.pinBuffer(bob.id, netA!.id, '#x');
+    pinned.pinBuffer(bob.id, netA!.id, '#y');
+    pinned.pinBuffer(bob.id, netA!.id, '#z');
+    pinned.pinBuffer(bob.id, netB!.id, '#solo');
+
+    // Simulate the pre-fix bug: close a pinned buffer without unpinning it,
+    // leaving an orphan pinned_buffers row pointing at a closed buffer.
+    closeBuffer(bob.id, netA!.id, '#y');
+    closeBuffer(bob.id, netB!.id, '#solo');
+
+    db.exec(PURGE_ORPHANS_SQL);
+    db.exec(RENUMBER_PINS_SQL);
+
+    expect(pinned.listPinnedForUserNetwork(bob.id, netA!.id)).toEqual(['#x', '#z']);
+    expect(pinned.listPinnedForUserNetwork(bob.id, netB!.id)).toEqual([]);
+
+    // Positions must be dense (0..n-1) so a subsequent pin appends at the
+    // correct slot — listPinnedForUserNetwork already orders by position,
+    // but reorderPins relies on the underlying numbering being gap-free.
+    const rows = db
+      .prepare(`SELECT target, position FROM pinned_buffers WHERE user_id = ? AND network_id = ?`)
+      .all(bob.id, netA!.id) as Array<{ target: string; position: number }>;
+    expect(rows.toSorted((a, b) => a.position - b.position)).toEqual([
+      { target: '#x', position: 0 },
+      { target: '#z', position: 1 },
+    ]);
+
+    // Pinning a new buffer after the cleanup lands at position 2, not 3
+    // (which is what would happen if renumber missed a gap).
+    pinned.pinBuffer(bob.id, netA!.id, '#w');
+    expect(pinned.listPinnedForUserNetwork(bob.id, netA!.id)).toEqual(['#x', '#z', '#w']);
   });
 });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -861,6 +861,14 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // Server pseudo-buffer can't be closed (it's the per-network log).
         if (!networkId || !target || target.startsWith(':server:')) break;
         closeBuffer(userId, networkId, target);
+        // The client renders the pinned section by intersecting pins with open
+        // buffers, so a pin on a now-closed buffer is invisible — and leaving
+        // the row would diverge the client's pin set from ours, snapping the
+        // next reorder back as a mismatch (issue #112). Close implies unpin.
+        if (listPinnedForUserNetwork(userId, networkId).includes(target)) {
+          const pinned = unpinBuffer(userId, networkId, target);
+          fanOut(userId, { kind: 'pins-changed', networkId, pinned });
+        }
         if (target.startsWith('#')) {
           // Send PART if connected; partChannel also flips channels.joined=0.
           // If disconnected, partChannel is a no-op, so explicitly mark the


### PR DESCRIPTION
## Summary

Fixes #112 — reordering pinned buffers stops working after a pinned buffer is closed.

- **Root cause**: `close-buffer` used to leave the `pinned_buffers` row intact (the schema comment even claimed "pin survives close"). But the client renders the pinned section by intersecting pins with open buffers, so an orphan pin is invisible to the user. The next reorder ships a subset of the server's pin set, `reorderPins` rejects the set-mismatch, and the drag snaps back.
- **Fix**: in the `close-buffer` handler, also call `unpinBuffer` when the buffer was pinned and fan out `pins-changed`. Close now implies unpin.
- **Backfill**: bump `SCHEMA_VERSION` to 7 and drop orphaned `pinned_buffers` rows (target in `closed_buffers`), then renumber `position` per `(user, network)` via `ROW_NUMBER()` so existing buggy DBs heal at next boot. No per-user action needed.
- Updated the `pinned_buffers` schema comment to reflect the new contract.

## Test plan

- [x] `npm test` — 626 tests pass
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual repro on a freshly-built server: pin a few buffers, `/close` one of the pinned ones, confirm it leaves the pinned section immediately and that reorder still works
- [ ] Restart server against a DB known to have orphan rows from the old behavior and confirm the pinned section is consistent and reorder works without recreating the orphan

🤖 Generated with [Claude Code](https://claude.com/claude-code)