### PR TITLE
Stop ignored senders from triggering unread and highlight markers

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -121,6 +121,7 @@ export const EXPORT_TABLES = Object.freeze({
       'userhost',
       'matched_rule_id',
       'alt',
+      'from_ignored',
     ],
   },
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -504,6 +504,15 @@ db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_matched
 // styled with .line.alt. See schemaVersion < 2 backfill below.
 ensureColumn('messages', 'alt', 'INTEGER NOT NULL DEFAULT 0');
 
+// Sender matched the network owner's ignore list at insert time. Stamped on
+// the row so countNewer/countHighlightsNewer can exclude ignored senders
+// without doing a JS-side mask scan over every unread row — the client's
+// render-time ignore filter only covers what's already on screen, so badge
+// counts (and the highlights modal) needed their own path. Set once at
+// insert; never recomputed. Old rows default to 0, which is conservative —
+// they remain visible/countable, matching pre-fix behavior.
+ensureColumn('messages', 'from_ignored', 'INTEGER NOT NULL DEFAULT 0');
+
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -15,12 +15,22 @@ let insertMessage: typeof import('./messages.js').insertMessage;
 let listMessages: typeof import('./messages.js').listMessages;
 let listMessagesAround: typeof import('./messages.js').listMessagesAround;
 let searchMessages: typeof import('./messages.js').searchMessages;
+let countNewer: typeof import('./messages.js').countNewer;
+let countHighlightsNewer: typeof import('./messages.js').countHighlightsNewer;
+let listUserHighlights: typeof import('./messages.js').listUserHighlights;
 
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
-  ({ insertMessage, listMessages, listMessagesAround, searchMessages } =
-    await import('./messages.js'));
+  ({
+    insertMessage,
+    listMessages,
+    listMessagesAround,
+    searchMessages,
+    countNewer,
+    countHighlightsNewer,
+    listUserHighlights,
+  } = await import('./messages.js'));
 });
 
 afterAll(() => {
@@ -481,5 +491,87 @@ describe('messages.alt parity (insert result)', () => {
     expect(first.alt).toBe(false);
     expect(second.alt).toBe(true);
     expect(sysEvt.alt).toBe(false);
+  });
+});
+
+describe('from_ignored excludes ignored senders from unread/highlight counts', () => {
+  function chatWith(
+    networkId: number,
+    opts: { nick: string; matched?: number; ignored?: boolean },
+  ) {
+    return insertMessage({
+      networkId,
+      target: '#ig',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: opts.nick,
+      text: 'hello',
+      self: false,
+      matchedRuleId: opts.matched ?? null,
+      fromIgnored: opts.ignored === true,
+    });
+  }
+
+  it('countNewer excludes from_ignored rows', () => {
+    const user = createUser('ig-count');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    chatWith(net.id, { nick: 'alice' });
+    chatWith(net.id, { nick: 'spammer', ignored: true });
+    chatWith(net.id, { nick: 'bob' });
+    expect(countNewer(net.id, '#ig', 0)).toBe(2);
+  });
+
+  it('countHighlightsNewer excludes from_ignored rows even when they matched a rule', () => {
+    const user = createUser('ig-hl-count');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    chatWith(net.id, { nick: 'alice', matched: 7 });
+    chatWith(net.id, { nick: 'spammer', matched: 7, ignored: true });
+    chatWith(net.id, { nick: 'bob', matched: 7 });
+    expect(countHighlightsNewer(net.id, '#ig', 0)).toBe(2);
+  });
+
+  it('listUserHighlights hides from_ignored rows', () => {
+    const user = createUser('ig-hl-list');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    chatWith(net.id, { nick: 'alice', matched: 7 });
+    chatWith(net.id, { nick: 'spammer', matched: 7, ignored: true });
+    const items = listUserHighlights(user.id);
+    expect(items.map((r) => r.nick)).toEqual(['alice']);
+  });
+
+  it('fromIgnored round-trips through rowToEvent', () => {
+    const user = createUser('ig-roundtrip');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    chatWith(net.id, { nick: 'alice' });
+    chatWith(net.id, { nick: 'spammer', ignored: true });
+    const rows = listMessages(net.id, '#ig', { limit: 50 });
+    expect(rows.map((r) => ({ nick: r.nick, fromIgnored: r.fromIgnored }))).toEqual([
+      { nick: 'alice', fromIgnored: false },
+      { nick: 'spammer', fromIgnored: true },
+    ]);
   });
 });

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -18,6 +18,7 @@ interface MessageRow {
   userhost: string | null;
   alt: number;
   matched_rule_id: number | null;
+  from_ignored: number;
 }
 
 /** A raw message row joined with network_name. */
@@ -40,6 +41,7 @@ export interface MessageEvent {
   alt: boolean;
   matched: boolean;
   matchedRuleId: number | null;
+  fromIgnored: boolean;
   [key: string]: unknown;
 }
 
@@ -62,6 +64,7 @@ export interface MessageInput {
   extra?: Record<string, any> | null; // untyped IRC extra fields
   matchedRuleId?: number | null;
   userhost?: string | null;
+  fromIgnored?: boolean;
 }
 
 /** Buffer summary row for MCP list_buffers. */
@@ -82,9 +85,9 @@ export interface MaxIdByBufferRow {
 // Non-striped types pass through with alt=0; the value is meaningless for them
 // and the client never reads it.
 const insertStmt = db.prepare(`
-  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, alt)
+  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, alt)
   VALUES (
-    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost,
+    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored,
     CASE WHEN @type IN ('message', 'action', 'notice')
          THEN 1 - COALESCE(
            (SELECT alt FROM messages
@@ -112,6 +115,7 @@ export function insertMessage(row: MessageInput): { id: number | bigint; alt: bo
     extra: row.extra ? JSON.stringify(row.extra) : null,
     matchedRuleId: row.matchedRuleId ?? null,
     userhost: row.userhost ?? null,
+    fromIgnored: row.fromIgnored ? 1 : 0,
   });
   const id = result.lastInsertRowid;
   const altRow = altByIdStmt.get(id) as { alt: number } | undefined;
@@ -133,6 +137,7 @@ function rowToEvent(row: MessageRow): MessageEvent {
     alt: row.alt === 1,
     matched: row.matched_rule_id != null,
     matchedRuleId: row.matched_rule_id,
+    fromIgnored: row.from_ignored === 1,
   };
   if (row.extra) {
     try {
@@ -306,7 +311,8 @@ export function countNewer(networkId: number, target: string, afterId: number): 
       .prepare(
         `SELECT COUNT(*) AS n FROM messages
      WHERE network_id = ? AND target = ? AND id > ?
-       AND type IN ${COUNTABLE_TYPES_SQL}`,
+       AND type IN ${COUNTABLE_TYPES_SQL}
+       AND from_ignored = 0`,
       )
       .get(networkId, target, afterId || 0) as { n: number }
   ).n;
@@ -314,14 +320,16 @@ export function countNewer(networkId: number, target: string, afterId: number): 
 
 // Cheap indexed count of unread highlights since `afterId`. Uses the partial
 // idx_messages_matched index — the old scan+decorate approach was replaced
-// once match state moved to insert time.
+// once match state moved to insert time. Ignored senders are excluded so the
+// red highlight pip doesn't fire for someone the user can't see.
 export function countHighlightsNewer(networkId: number, target: string, afterId: number): number {
   return (
     db
       .prepare(
         `SELECT COUNT(*) AS n FROM messages
      WHERE network_id = ? AND target = ? AND id > ?
-       AND matched_rule_id IS NOT NULL`,
+       AND matched_rule_id IS NOT NULL
+       AND from_ignored = 0`,
       )
       .get(networkId, target, afterId || 0) as { n: number }
   ).n;
@@ -340,6 +348,7 @@ export function listUserHighlights(
        JOIN networks n ON n.id = m.network_id
        WHERE n.user_id = ?
          AND m.matched_rule_id IS NOT NULL
+         AND m.from_ignored = 0
          AND m.id < ?
        ORDER BY m.id DESC
        LIMIT ?`
@@ -348,6 +357,7 @@ export function listUserHighlights(
        JOIN networks n ON n.id = m.network_id
        WHERE n.user_id = ?
          AND m.matched_rule_id IS NOT NULL
+         AND m.from_ignored = 0
        ORDER BY m.id DESC
        LIMIT ?`;
   const params = before ? [userId, before, limit] : [userId, limit];

--- a/server/routes/highlights.test.ts
+++ b/server/routes/highlights.test.ts
@@ -55,6 +55,20 @@ function chat(target: string, nick: string, text: string, matchedRuleId: number 
   });
 }
 
+function chatIgnored(target: string, nick: string, text: string, matchedRuleId: number | null) {
+  return insertMessage({
+    networkId: net.id,
+    target,
+    time: new Date().toISOString(),
+    type: 'message',
+    nick,
+    text,
+    self: false,
+    matchedRuleId,
+    fromIgnored: true,
+  });
+}
+
 describe('GET /api/highlights', () => {
   it('requires authentication', async () => {
     const res = await createAnonAgent(app).get('/api/highlights');
@@ -93,5 +107,15 @@ describe('GET /api/highlights', () => {
     const res = await agent.get('/api/highlights?limit=99999');
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body.items)).toBe(true);
+  });
+
+  it('omits matched rows whose sender was ignored at insert time', async () => {
+    const visible = chat('#ig', 'eve', 'alice ping', 99).id;
+    const hidden = chatIgnored('#ig', 'spammer', 'alice ping', 99).id;
+    const res = await agent.get('/api/highlights?limit=50');
+    expect(res.status).toBe(200);
+    const ids = res.body.items.map((r: { id: number }) => r.id);
+    expect(ids).toContain(visible);
+    expect(ids).not.toContain(hidden);
   });
 });

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -263,6 +263,9 @@ export async function importFromZipBuffer(
         // matched_rule_id is nullable; if its target rule wasn't in the
         // export, fall back to null.
         if (row.matched_rule_id === undefined) row.matched_rule_id = null;
+        // from_ignored was added later; older archives don't carry it, and
+        // the column is NOT NULL so a missing key would fail the insert.
+        if (row.from_ignored === undefined) row.from_ignored = 0;
         const result = insertOne(stmt, cols, row);
         idMaps.messages.set(original.id, result.lastInsertRowid);
         inserted += 1;

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3,7 +3,12 @@
 
 import IRC, { ircLineParser } from 'irc-framework';
 import type { Client as IrcClient } from 'irc-framework';
-import { insertMessage, hasMessageForTarget, listBufferTargets } from '../db/messages.js';
+import {
+  insertMessage,
+  hasMessageForTarget,
+  listBufferTargets,
+  COUNTABLE_TYPES,
+} from '../db/messages.js';
 import type { Network } from '../db/networks.js';
 import { upsertChannel } from '../db/networks.js';
 import { isClosed as isBufferClosed } from '../db/closedBuffers.js';
@@ -266,11 +271,13 @@ export class IrcConnection {
         console.warn('[highlight] match-on-insert failed:', (e as Error)?.message || e);
       }
       // Stamp from_ignored at insert time so unread/highlight counts can
-      // exclude ignored senders without a per-query mask scan. Self messages
-      // can't be ignored; nick-less system rows have no sender to match.
+      // exclude ignored senders without a per-query mask scan. Only the
+      // countable chat types ever read this column — gating to COUNTABLE_TYPES
+      // skips the DB lookup on high-churn JOIN/PART/QUIT/NICK/KICK/etc.
+      // Self messages can't be ignored; nick-less system rows have no sender.
       let fromIgnored = false;
       const nick = event.nick as string | null | undefined;
-      if (nick && !event.self) {
+      if (COUNTABLE_TYPES.has(event.type) && nick && !event.self) {
         try {
           const masks = listIgnoredMasks({
             userId: this.network.user_id,

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -17,6 +17,8 @@ import {
 } from '../db/peerPresence.js';
 import highlightRulesService from './highlightRulesService.js';
 import { matchEvent } from './highlightEngine.js';
+import { matchesAny as matchesIgnoreMask } from './maskMatch.js';
+import { listMasks as listIgnoredMasks } from '../db/ignoredMasks.js';
 import * as systemLog from './systemLog.js';
 import { IRC_VERSION, APP_VERSION } from '../utils/userAgent.js';
 
@@ -263,6 +265,28 @@ export class IrcConnection {
       } catch (e) {
         console.warn('[highlight] match-on-insert failed:', (e as Error)?.message || e);
       }
+      // Stamp from_ignored at insert time so unread/highlight counts can
+      // exclude ignored senders without a per-query mask scan. Self messages
+      // can't be ignored; nick-less system rows have no sender to match.
+      let fromIgnored = false;
+      const nick = event.nick as string | null | undefined;
+      if (nick && !event.self) {
+        try {
+          const masks = listIgnoredMasks({
+            userId: this.network.user_id,
+            networkId: this.network.id,
+          });
+          if (masks.length) {
+            fromIgnored = matchesIgnoreMask(
+              masks,
+              nick,
+              (event.userhost as string | null | undefined) ?? null,
+            );
+          }
+        } catch (e) {
+          console.warn('[ignore] match-on-insert failed:', (e as Error)?.message || e);
+        }
+      }
       const { id, alt } = insertMessage({
         networkId: this.network.id,
         target: event.target as string,
@@ -275,6 +299,7 @@ export class IrcConnection {
         extra: extractExtras(event),
         matchedRuleId,
         userhost: (event.userhost as string | null | undefined) ?? null,
+        fromIgnored,
       });
       enriched.id = id;
       enriched.alt = alt;


### PR DESCRIPTION
Closes #111.

## Summary
- Stamp a new `messages.from_ignored` column at insert time (network owner's `ignored_masks` checked once per insert, paralleling the existing `matched_rule_id` flow).
- Filter `from_ignored = 0` in `countNewer`, `countHighlightsNewer`, and `listUserHighlights` so the unread badge, the red highlight pip, and the highlights modal all stop reacting to senders the user has ignored.
- No retroactive backfill: rows present before the column existed default to 0 (visible), which matches pre-fix behavior. Adding an ignore now does not retroactively clear past unread counts — mark-read wipes them as usual.

The render-time client filter is untouched; this only corrects server-computed counts and the highlights feed. Toast / sound notifications were already gated client-side and are unaffected.

## Test plan
- [x] `npm test` — 632 tests pass, including 5 new tests:
  - `countNewer` excludes ignored rows
  - `countHighlightsNewer` excludes ignored rows even when they matched a rule
  - `listUserHighlights` hides ignored rows
  - `fromIgnored` round-trips through `rowToEvent`
  - `GET /api/highlights` omits ignored matched rows
- [x] `npm run check` — typecheck (server + client), lint, format all clean.
- [ ] Manual: ignore a user, have them mention your nick in a channel — buffer no longer shows highlight pip, badge no longer increments, highlights modal does not list the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)