### PR TITLE
Add /clear buffer command (closes #107)

### DIFF
--- a/server/db/bufferReads.test.ts
+++ b/server/db/bufferReads.test.ts
@@ -60,3 +60,72 @@ describe('listReadStateForUser', () => {
     expect(map[`${net!.id}::#b`]).toBe(9);
   });
 });
+
+describe('setClearedState / getClearedState', () => {
+  it('returns the no-clear state when no row exists', () => {
+    const state = bufferReads.getClearedState(user.id, net!.id, '#never-cleared');
+    expect(state).toEqual({ clearedBeforeId: 0, clearedAt: null });
+  });
+
+  it('persists boundary id and timestamp, and round-trips', () => {
+    const ts = '2026-05-26T12:00:00.000Z';
+    const out = bufferReads.setClearedState(user.id, net!.id, '#c', 42, ts);
+    expect(out).toEqual({ clearedBeforeId: 42, clearedAt: ts });
+    expect(bufferReads.getClearedState(user.id, net!.id, '#c')).toEqual({
+      clearedBeforeId: 42,
+      clearedAt: ts,
+    });
+  });
+
+  it("does not clobber the read pointer when /clear writes to a row that also tracks read state", () => {
+    bufferReads.setReadState(user.id, net!.id, '#mixed', 80);
+    bufferReads.setClearedState(user.id, net!.id, '#mixed', 80, '2026-05-26T12:00:00.000Z');
+    expect(bufferReads.getReadState(user.id, net!.id, '#mixed')).toBe(80);
+    expect(bufferReads.getClearedState(user.id, net!.id, '#mixed').clearedBeforeId).toBe(80);
+  });
+
+  it("does not clobber the clear marker when setReadState writes to the same row", () => {
+    bufferReads.setClearedState(user.id, net!.id, '#mixed2', 50, '2026-05-26T12:00:00.000Z');
+    bufferReads.setReadState(user.id, net!.id, '#mixed2', 90);
+    expect(bufferReads.getClearedState(user.id, net!.id, '#mixed2')).toEqual({
+      clearedBeforeId: 50,
+      clearedAt: '2026-05-26T12:00:00.000Z',
+    });
+  });
+
+  it('boundary id <= 0 clears the marker (used by /clear off)', () => {
+    bufferReads.setClearedState(user.id, net!.id, '#undo', 25, '2026-05-26T12:00:00.000Z');
+    const out = bufferReads.setClearedState(user.id, net!.id, '#undo', 0, null);
+    expect(out).toEqual({ clearedBeforeId: 0, clearedAt: null });
+    expect(bufferReads.getClearedState(user.id, net!.id, '#undo')).toEqual({
+      clearedBeforeId: 0,
+      clearedAt: null,
+    });
+  });
+
+  it('overwrites an existing marker when /clear runs again', () => {
+    bufferReads.setClearedState(user.id, net!.id, '#again', 10, '2026-05-26T11:00:00.000Z');
+    const out = bufferReads.setClearedState(user.id, net!.id, '#again', 30, '2026-05-26T12:00:00.000Z');
+    expect(out).toEqual({ clearedBeforeId: 30, clearedAt: '2026-05-26T12:00:00.000Z' });
+  });
+});
+
+describe('listClearedStateForUser', () => {
+  it('returns only buffers with an active clear marker', () => {
+    bufferReads.setClearedState(user.id, net!.id, '#has', 100, '2026-05-26T12:00:00.000Z');
+    bufferReads.setReadState(user.id, net!.id, '#read-only', 5);
+    const map = bufferReads.listClearedStateForUser(user.id);
+    expect(map[`${net!.id}::#has`]).toEqual({
+      clearedBeforeId: 100,
+      clearedAt: '2026-05-26T12:00:00.000Z',
+    });
+    expect(map[`${net!.id}::#read-only`]).toBeUndefined();
+  });
+
+  it('drops a buffer after its clear is undone', () => {
+    bufferReads.setClearedState(user.id, net!.id, '#vanish', 7, '2026-05-26T12:00:00.000Z');
+    bufferReads.setClearedState(user.id, net!.id, '#vanish', 0, null);
+    const map = bufferReads.listClearedStateForUser(user.id);
+    expect(map[`${net!.id}::#vanish`]).toBeUndefined();
+  });
+});

--- a/server/db/bufferReads.test.ts
+++ b/server/db/bufferReads.test.ts
@@ -77,14 +77,14 @@ describe('setClearedState / getClearedState', () => {
     });
   });
 
-  it("does not clobber the read pointer when /clear writes to a row that also tracks read state", () => {
+  it('does not clobber the read pointer when /clear writes to a row that also tracks read state', () => {
     bufferReads.setReadState(user.id, net!.id, '#mixed', 80);
     bufferReads.setClearedState(user.id, net!.id, '#mixed', 80, '2026-05-26T12:00:00.000Z');
     expect(bufferReads.getReadState(user.id, net!.id, '#mixed')).toBe(80);
     expect(bufferReads.getClearedState(user.id, net!.id, '#mixed').clearedBeforeId).toBe(80);
   });
 
-  it("does not clobber the clear marker when setReadState writes to the same row", () => {
+  it('does not clobber the clear marker when setReadState writes to the same row', () => {
     bufferReads.setClearedState(user.id, net!.id, '#mixed2', 50, '2026-05-26T12:00:00.000Z');
     bufferReads.setReadState(user.id, net!.id, '#mixed2', 90);
     expect(bufferReads.getClearedState(user.id, net!.id, '#mixed2')).toEqual({
@@ -105,7 +105,13 @@ describe('setClearedState / getClearedState', () => {
 
   it('overwrites an existing marker when /clear runs again', () => {
     bufferReads.setClearedState(user.id, net!.id, '#again', 10, '2026-05-26T11:00:00.000Z');
-    const out = bufferReads.setClearedState(user.id, net!.id, '#again', 30, '2026-05-26T12:00:00.000Z');
+    const out = bufferReads.setClearedState(
+      user.id,
+      net!.id,
+      '#again',
+      30,
+      '2026-05-26T12:00:00.000Z',
+    );
     expect(out).toEqual({ clearedBeforeId: 30, clearedAt: '2026-05-26T12:00:00.000Z' });
   });
 });

--- a/server/db/bufferReads.ts
+++ b/server/db/bufferReads.ts
@@ -10,6 +10,13 @@ export interface BufferRead {
   target: string;
   last_read_message_id: number;
   updated_at: string;
+  cleared_before_message_id: number | null;
+  cleared_at: string | null;
+}
+
+export interface ClearedState {
+  clearedBeforeId: number;
+  clearedAt: string | null;
 }
 
 const upsertStmt = db.prepare(`
@@ -63,4 +70,91 @@ export function setReadState(
   if (!Number.isFinite(id) || id <= 0) return getReadState(userId, networkId, target);
   upsertStmt.run(userId, networkId, target, id);
   return getReadState(userId, networkId, target);
+}
+
+// --- /clear marker state ---------------------------------------------------
+//
+// The clear marker lives on the same buffer_reads row as the read pointer
+// (one row per user/buffer is enough), but it's controlled separately:
+// /clear writes only the cleared_* columns and never touches the read
+// pointer — hiding a message doesn't mark it read.
+
+const upsertClearedStmt = db.prepare(`
+  INSERT INTO buffer_reads
+    (user_id, network_id, target, last_read_message_id,
+     cleared_before_message_id, cleared_at, updated_at)
+  VALUES (?, ?, ?, 0, ?, ?, datetime('now'))
+  ON CONFLICT(user_id, network_id, target) DO UPDATE SET
+    cleared_before_message_id = excluded.cleared_before_message_id,
+    cleared_at = excluded.cleared_at,
+    updated_at = excluded.updated_at
+`);
+
+const getClearedStmt = db.prepare(`
+  SELECT
+    cleared_before_message_id AS clearedBeforeId,
+    cleared_at AS clearedAt
+  FROM buffer_reads
+  WHERE user_id = ? AND network_id = ? AND target = ?
+`);
+
+const listClearedStmt = db.prepare(`
+  SELECT network_id AS networkId, target,
+         cleared_before_message_id AS clearedBeforeId,
+         cleared_at AS clearedAt
+  FROM buffer_reads
+  WHERE user_id = ?
+    AND cleared_before_message_id IS NOT NULL
+    AND cleared_before_message_id > 0
+`);
+
+export function getClearedState(
+  userId: number,
+  networkId: number,
+  target: string,
+): ClearedState {
+  const row = getClearedStmt.get(userId, networkId, target) as
+    | { clearedBeforeId: number | null; clearedAt: string | null }
+    | undefined;
+  if (!row || !row.clearedBeforeId) return { clearedBeforeId: 0, clearedAt: null };
+  return { clearedBeforeId: row.clearedBeforeId, clearedAt: row.clearedAt };
+}
+
+// boundaryId === 0 (or null) clears the marker — equivalent to "Show earlier
+// messages" / `/clear off`. Otherwise the boundary id is the largest id the
+// user wants hidden; clearedAt is shown in the divider above the first
+// surviving row.
+export function setClearedState(
+  userId: number,
+  networkId: number,
+  target: string,
+  boundaryId: number,
+  clearedAt: string | null,
+): ClearedState {
+  const id = Number(boundaryId);
+  if (!Number.isFinite(id) || id <= 0) {
+    upsertClearedStmt.run(userId, networkId, target, null, null);
+    return { clearedBeforeId: 0, clearedAt: null };
+  }
+  upsertClearedStmt.run(userId, networkId, target, id, clearedAt);
+  return getClearedState(userId, networkId, target);
+}
+
+// Map keyed by `${networkId}::${target}` for buffers with an active clear
+// marker. Sparse — buffers that have never been cleared aren't returned, so
+// callers default to the no-clear state for missing keys.
+export function listClearedStateForUser(userId: number): Record<string, ClearedState> {
+  const out: Record<string, ClearedState> = {};
+  for (const row of listClearedStmt.all(userId) as Array<{
+    networkId: number;
+    target: string;
+    clearedBeforeId: number;
+    clearedAt: string | null;
+  }>) {
+    out[`${row.networkId}::${row.target}`] = {
+      clearedBeforeId: row.clearedBeforeId,
+      clearedAt: row.clearedAt,
+    };
+  }
+  return out;
 }

--- a/server/db/bufferReads.ts
+++ b/server/db/bufferReads.ts
@@ -108,11 +108,7 @@ const listClearedStmt = db.prepare(`
     AND cleared_before_message_id > 0
 `);
 
-export function getClearedState(
-  userId: number,
-  networkId: number,
-  target: string,
-): ClearedState {
+export function getClearedState(userId: number, networkId: number, target: string): ClearedState {
   const row = getClearedStmt.get(userId, networkId, target) as
     | { clearedBeforeId: number | null; clearedAt: string | null }
     | undefined;

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -134,8 +134,25 @@ export const EXPORT_TABLES = Object.freeze({
     // needs the messages id map. The importer auto-defers any table whose
     // fkRekey targets 'messages'. Settings-only imports drop these rows
     // (last_read_message_id is NOT NULL — no anchor, no row).
-    fkRekey: { user_id: 'users', network_id: 'networks', last_read_message_id: 'messages' },
-    columns: ['user_id', 'network_id', 'target', 'last_read_message_id', 'updated_at'],
+    // cleared_before_message_id is nullable; the rekey helper skips nulls,
+    // and a missing-in-map id falls through to undefined → null, which is
+    // the right fallback (the boundary message is gone, the clear can't
+    // sensibly persist).
+    fkRekey: {
+      user_id: 'users',
+      network_id: 'networks',
+      last_read_message_id: 'messages',
+      cleared_before_message_id: 'messages',
+    },
+    columns: [
+      'user_id',
+      'network_id',
+      'target',
+      'last_read_message_id',
+      'updated_at',
+      'cleared_before_message_id',
+      'cleared_at',
+    ],
   },
 
   user_away_state: {

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -134,16 +134,17 @@ export const EXPORT_TABLES = Object.freeze({
     // needs the messages id map. The importer auto-defers any table whose
     // fkRekey targets 'messages'. Settings-only imports drop these rows
     // (last_read_message_id is NOT NULL — no anchor, no row).
-    // cleared_before_message_id is nullable; the rekey helper skips nulls,
-    // and a missing-in-map id falls through to undefined → null, which is
-    // the right fallback (the boundary message is gone, the clear can't
-    // sensibly persist).
     fkRekey: {
       user_id: 'users',
       network_id: 'networks',
       last_read_message_id: 'messages',
       cleared_before_message_id: 'messages',
     },
+    // cleared_before_message_id is a /clear marker, not the read pointer:
+    // if the boundary message can't be resolved (missing from the messages
+    // map), preserve the row with a NULL marker rather than dropping it
+    // and losing the still-valid last_read_message_id alongside.
+    fkRekeyNullable: ['cleared_before_message_id'],
     columns: [
       'user_id',
       'network_id',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -513,6 +513,16 @@ ensureColumn('messages', 'alt', 'INTEGER NOT NULL DEFAULT 0');
 // they remain visible/countable, matching pre-fix behavior.
 ensureColumn('messages', 'from_ignored', 'INTEGER NOT NULL DEFAULT 0');
 
+// Per-(user, buffer) /clear marker. cleared_before_message_id is the highest
+// message id hidden from the live view; messages with id > it remain visible.
+// cleared_at is the wall-clock time the user issued /clear (shown in the
+// divider). Both NULL means the buffer has never been cleared (or the user
+// undid the clear). Stored on buffer_reads so the per-buffer state stays in
+// one row — close-buffer doesn't touch buffer_reads, so the clear survives
+// reopen.
+ensureColumn('buffer_reads', 'cleared_before_message_id', 'INTEGER');
+ensureColumn('buffer_reads', 'cleared_at', 'TEXT');
+
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -18,6 +18,7 @@ let searchMessages: typeof import('./messages.js').searchMessages;
 let countNewer: typeof import('./messages.js').countNewer;
 let countHighlightsNewer: typeof import('./messages.js').countHighlightsNewer;
 let listUserHighlights: typeof import('./messages.js').listUserHighlights;
+let maxIdForBuffer: typeof import('./messages.js').maxIdForBuffer;
 
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
@@ -30,6 +31,7 @@ beforeAll(async () => {
     countNewer,
     countHighlightsNewer,
     listUserHighlights,
+    maxIdForBuffer,
   } = await import('./messages.js'));
 });
 
@@ -573,5 +575,42 @@ describe('from_ignored excludes ignored senders from unread/highlight counts', (
       { nick: 'alice', fromIgnored: false },
       { nick: 'spammer', fromIgnored: true },
     ]);
+  });
+});
+
+describe('maxIdForBuffer', () => {
+  it('returns 0 for a buffer with no rows', () => {
+    const user = createUser('mfb-empty');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    expect(maxIdForBuffer(net.id, '#nope')).toBe(0);
+  });
+
+  it('returns the largest id in the buffer, ignoring other targets and networks', () => {
+    const user = createUser('mfb-multi');
+    const net1 = createNetwork(user.id, {
+      name: 'n1',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    const net2 = createNetwork(user.id, {
+      name: 'n2',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    chat(net1.id, '#a', 'alice', 'a1');
+    const a2 = chat(net1.id, '#a', 'alice', 'a2');
+    chat(net1.id, '#b', 'bob', 'b1');
+    chat(net2.id, '#a', 'eve', 'e1');
+    expect(maxIdForBuffer(net1.id, '#a')).toBe(a2.id);
   });
 });

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -276,6 +276,15 @@ export function maxIdByBuffer(networkId: number): MaxIdByBufferRow[] {
     .all(networkId) as MaxIdByBufferRow[];
 }
 
+// MAX(id) for a single buffer, or 0 when the buffer has no rows. Used by
+// /clear to anchor the marker at the current tail.
+export function maxIdForBuffer(networkId: number, target: string): number {
+  const row = db
+    .prepare('SELECT MAX(id) AS maxId FROM messages WHERE network_id = ? AND target = ?')
+    .get(networkId, target) as { maxId: number | null } | undefined;
+  return row?.maxId || 0;
+}
+
 // Cheap "does the user have any history with this target?" check used by the
 // no_such_nick router: only route a DM-shaped error into a per-nick buffer if
 // the user has actually conversed with that nick. Stops typo /whois replies

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -24,6 +24,8 @@ let pinBuffer: typeof import('../db/pinnedBuffers.js').pinBuffer;
 let addMask: typeof import('../db/ignoredMasks.js').addMask;
 let addBookmark: typeof import('../db/bookmarks.js').addBookmark;
 let setReadState: typeof import('../db/bufferReads.js').setReadState;
+let setClearedState: typeof import('../db/bufferReads.js').setClearedState;
+let getClearedState: typeof import('../db/bufferReads.js').getClearedState;
 let insertUpload: typeof import('../db/uploadHistory.js').insertUpload;
 let setNicklistCollapsed: typeof import('../db/nicklistCollapsed.js').setNicklistCollapsed;
 let setChannelNotifyAlways: typeof import('../db/channelNotify.js').setChannelNotifyAlways;
@@ -49,7 +51,7 @@ beforeAll(async () => {
   ({ pinBuffer } = await import('../db/pinnedBuffers.js'));
   ({ addMask } = await import('../db/ignoredMasks.js'));
   ({ addBookmark } = await import('../db/bookmarks.js'));
-  ({ setReadState } = await import('../db/bufferReads.js'));
+  ({ setReadState, setClearedState, getClearedState } = await import('../db/bufferReads.js'));
   ({ setNicklistCollapsed } = await import('../db/nicklistCollapsed.js'));
   ({ setChannelNotifyAlways } = await import('../db/channelNotify.js'));
   ({ upsertDraft } = await import('../db/drafts.js'));
@@ -299,6 +301,124 @@ describe('importFromZipBuffer — roundtrip', () => {
     const msg = db
       .prepare('SELECT id FROM messages WHERE id = ?')
       .get(reads[0].last_read_message_id);
+    expect(msg).toBeDefined();
+  });
+
+  it('round-trips the /clear marker (cleared_before_message_id, cleared_at) through export+import', async () => {
+    const { alice, net } = seedAlice();
+    // Anchor a /clear at the second message in #general (m2 id = m1 + 1).
+    const ts = '2026-05-26T12:34:56.000Z';
+    const m2Id = (
+      db
+        .prepare(`SELECT MAX(id) AS id FROM messages WHERE network_id = ? AND target = ?`)
+        .get(net.id, '#general') as { id: number }
+    ).id;
+    setClearedState(alice.id, net.id, '#general', m2Id, ts);
+
+    const ned = createUser(`ned_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+    const buf = await exportToBuffer(alice.id, { includeMessages: true });
+    await importFromZipBuffer(ned.id, buf);
+
+    // Find the rekeyed message that corresponds to the source boundary.
+    const importedRead = db.prepare('SELECT * FROM buffer_reads WHERE user_id = ?').get(ned.id) as {
+      last_read_message_id: number;
+      cleared_before_message_id: number | null;
+      cleared_at: string | null;
+    };
+    expect(importedRead.cleared_at).toBe(ts);
+    expect(importedRead.cleared_before_message_id).not.toBeNull();
+    // The boundary points to a real message row in the imported user's space.
+    const msg = db
+      .prepare('SELECT id FROM messages WHERE id = ?')
+      .get(importedRead.cleared_before_message_id);
+    expect(msg).toBeDefined();
+  });
+
+  it('preserves the read pointer when the /clear boundary message is missing from the import', async () => {
+    // Surgically construct a malformed archive: a buffer_reads row whose
+    // cleared_before_message_id references a message id that DOES NOT exist
+    // in messages.ndjson. The naive fkRekey path would drop the entire row
+    // (and lose last_read_message_id along with it); fkRekeyNullable should
+    // keep the row with NULL clear instead.
+    const { alice } = seedAlice();
+    const buf = await exportToBuffer(alice.id, { includeMessages: true });
+    const yauzl = await import('yauzl');
+    const { ZipArchive } = await import('archiver');
+
+    const entries = await new Promise<Map<string, Buffer>>((resolve, reject) => {
+      yauzl.fromBuffer(buf, { lazyEntries: true }, (err, zip) => {
+        if (err) return reject(err);
+        const out = new Map<string, Buffer>();
+        zip.readEntry();
+        zip.on('entry', (entry) => {
+          if (entry.fileName.endsWith('/')) {
+            zip.readEntry();
+            return;
+          }
+          zip.openReadStream(entry, (e2, stream) => {
+            if (e2) return reject(e2);
+            const chunks: Buffer[] = [];
+            stream.on('data', (c: Buffer) => chunks.push(c));
+            stream.on('end', () => {
+              out.set(entry.fileName, Buffer.concat(chunks));
+              zip.readEntry();
+            });
+            stream.on('error', reject);
+          });
+        });
+        zip.on('end', () => resolve(out));
+        zip.on('error', reject);
+      });
+    });
+
+    const data = JSON.parse(entries.get('data.json')!.toString('utf8'));
+    // Inject a clear marker pointing at id 999999 — guaranteed missing from
+    // messages.ndjson (which only carries alice's two seeded messages).
+    expect(data.buffer_reads.length).toBe(1);
+    const originalLastRead = data.buffer_reads[0].last_read_message_id;
+    data.buffer_reads[0].cleared_before_message_id = 999999;
+    data.buffer_reads[0].cleared_at = '2026-05-26T12:34:56.000Z';
+    entries.set('data.json', Buffer.from(JSON.stringify(data)));
+
+    const archive = new ZipArchive();
+    const rebuiltChunks: Buffer[] = [];
+    archive.on('data', (c: Buffer) => rebuiltChunks.push(c));
+    for (const [name, content] of entries) archive.append(content, { name });
+    await archive.finalize();
+    const rebuilt = Buffer.concat(rebuiltChunks);
+
+    const olive = createUser(`olive_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+    await importFromZipBuffer(olive.id, rebuilt);
+
+    // The row must survive — losing it would also strand a valid read pointer.
+    const importedRead = db
+      .prepare('SELECT * FROM buffer_reads WHERE user_id = ?')
+      .get(olive.id) as
+      | {
+          last_read_message_id: number;
+          cleared_before_message_id: number | null;
+          cleared_at: string | null;
+        }
+      | undefined;
+    expect(importedRead).toBeDefined();
+    // Boundary nulls out (FK target was missing); cleared_at is a stale
+    // scalar but the read path masks it via the boundary check, so callers
+    // see a clean no-clear state.
+    expect(importedRead!.cleared_before_message_id).toBeNull();
+    const importedNetworkId = (
+      db.prepare('SELECT id FROM networks WHERE user_id = ?').get(olive.id) as { id: number }
+    ).id;
+    expect(getClearedState(olive.id, importedNetworkId, '#general')).toEqual({
+      clearedBeforeId: 0,
+      clearedAt: null,
+    });
+    // The rekeyed read pointer must land on a real message row in olive's
+    // imported network (not the original alice id; that would be a leaked
+    // foreign id from before rekey).
+    expect(importedRead!.last_read_message_id).not.toBe(originalLastRead);
+    const msg = db
+      .prepare('SELECT id FROM messages WHERE id = ?')
+      .get(importedRead!.last_read_message_id);
     expect(msg).toBeDefined();
   });
 

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -24,6 +24,12 @@ interface ExportTableDefFull {
   blobColumns?: string[];
   rekeyOnImport?: boolean;
   fkRekey?: Record<string, string>;
+  // FK columns that should be set to NULL — rather than causing the whole
+  // row to be dropped — when their referenced id is missing from the map.
+  // Used for nullable foreign keys whose absence is recoverable (e.g. a
+  // /clear marker whose boundary message is gone; the rest of the
+  // buffer_reads row, including the read pointer, is still valid).
+  fkRekeyNullable?: string[];
 }
 
 export class ImportError extends Error {
@@ -102,6 +108,7 @@ function rekeyRow(
 ): Record<string, unknown> {
   const out = { ...row };
   if (!def.fkRekey) return out;
+  const nullable = new Set(def.fkRekeyNullable ?? []);
   for (const [col, target] of Object.entries(def.fkRekey)) {
     if (out[col] == null) continue;
     if (target === 'users') {
@@ -111,9 +118,15 @@ function rekeyRow(
       // settings-only archive has no messages map, so buffer_reads rows
       // can't find their last_read_message_id). Treat the same as a row
       // missing from a populated map: leave undefined, let the caller drop.
+      // Columns flagged nullable map missing → null instead, so the rest
+      // of the row (other FKs, scalar data) survives.
       const map = idMaps[target];
       const mapped = map ? map.get(out[col]) : undefined;
-      out[col] = mapped === undefined ? undefined : mapped;
+      if (mapped === undefined) {
+        out[col] = nullable.has(col) ? null : undefined;
+      } else {
+        out[col] = mapped;
+      }
     }
   }
   return out;

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -13,6 +13,7 @@ let createNetwork: typeof import('../db/networks.js').createNetwork;
 let insertMessage: typeof import('../db/messages.js').insertMessage;
 let closeBuffer: typeof import('../db/closedBuffers.js').closeBuffer;
 let isClosed: typeof import('../db/closedBuffers.js').isClosed;
+let setClearedState: typeof import('../db/bufferReads.js').setClearedState;
 let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
 let handleOpenBuffer: typeof import('./wsHub.js').handleOpenBuffer;
 
@@ -24,6 +25,7 @@ beforeAll(async () => {
   ({ createNetwork } = await import('../db/networks.js'));
   ({ insertMessage } = await import('../db/messages.js'));
   ({ closeBuffer, isClosed } = await import('../db/closedBuffers.js'));
+  ({ setClearedState } = await import('../db/bufferReads.js'));
   ({ buildBufferBacklog, handleOpenBuffer } = await import('./wsHub.js'));
 
   userId = createUser('alice').id;
@@ -78,6 +80,26 @@ describe('buildBufferBacklog', () => {
   it('reports a non-channel buffer (DM) as joined', () => {
     seed('carol', 'hi');
     expect(buildBufferBacklog(userId, networkId, 'carol').joined).toBe(true);
+  });
+
+  it('omits clear-state by default (no marker)', () => {
+    seed('#noclear', 'just a message');
+    const frame = buildBufferBacklog(userId, networkId, '#noclear');
+    expect(frame.clearedBeforeId).toBe(0);
+    expect(frame.clearedAt).toBeNull();
+  });
+
+  it('ships the /clear marker in the backlog so the client can restore the filter after a reconnect', () => {
+    seed('#clear', 'one');
+    seed('#clear', 'two');
+    const beforeFrame = buildBufferBacklog(userId, networkId, '#clear');
+    const boundary = (beforeFrame.events as Array<{ id: number }>).at(-1)!.id;
+    const ts = '2026-05-27T12:00:00.000Z';
+    setClearedState(userId, networkId, '#clear', boundary, ts);
+
+    const frame = buildBufferBacklog(userId, networkId, '#clear');
+    expect(frame.clearedBeforeId).toBe(boundary);
+    expect(frame.clearedAt).toBe(ts);
   });
 });
 

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -30,9 +30,17 @@ import {
   countNewer,
   countHighlightsNewer,
   maxIdByBuffer,
+  maxIdForBuffer,
   COUNTABLE_TYPES,
 } from '../db/messages.js';
-import { listReadStateForUser, getReadState, setReadState } from '../db/bufferReads.js';
+import {
+  listReadStateForUser,
+  getReadState,
+  setReadState,
+  listClearedStateForUser,
+  getClearedState,
+  setClearedState,
+} from '../db/bufferReads.js';
 import {
   addEntry as addInputHistory,
   listRecent as listRecentInputHistory,
@@ -238,6 +246,7 @@ export function buildBufferBacklog(userId: number, networkId: number, target: st
   );
   const lastReadId = getReadState(userId, networkId, target);
   const counts = computeUnreadFor(userId, networkId, target, lastReadId);
+  const cleared = getClearedState(userId, networkId, target);
   return {
     kind: 'backlog',
     networkId,
@@ -252,6 +261,8 @@ export function buildBufferBacklog(userId: number, networkId: number, target: st
     unread: counts.unread,
     highlights: counts.highlights,
     highlightsCapped: counts.highlightsCapped,
+    clearedBeforeId: cleared.clearedBeforeId,
+    clearedAt: cleared.clearedAt,
     inputHistory: listRecentInputHistory(userId, networkId, target, 200),
   };
 }
@@ -708,6 +719,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // return resync is harmless.
     send(ws, { kind: 'system-log-snapshot', lines: systemLog.getRecent(userId) });
     const readState = listReadStateForUser(userId);
+    const clearedState = listClearedStateForUser(userId);
     const closed = closedKeySetForUser(userId);
     let maxSentId = ws.sinceId || 0;
     for (const conn of ircManager.listConnections(userId)) {
@@ -749,6 +761,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         const speakers = listSpeakers(conn.network.id, target);
         const lastReadId = readState[`${conn.network.id}::${target}`] || 0;
         const counts = computeUnreadFor(userId, conn.network.id, target, lastReadId);
+        const cleared = clearedState[`${conn.network.id}::${target}`] ?? {
+          clearedBeforeId: 0,
+          clearedAt: null,
+        };
         // Per-buffer input history is unbounded on disk; ship a recent slice
         // for up-arrow recall. Older entries stay in the DB and could be
         // paginated in later if the slice ever proves too small.
@@ -767,6 +783,8 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           unread: counts.unread,
           highlights: counts.highlights,
           highlightsCapped: counts.highlightsCapped,
+          clearedBeforeId: cleared.clearedBeforeId,
+          clearedAt: cleared.clearedAt,
           inputHistory,
         });
       }
@@ -1004,6 +1022,43 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         if (!networkId || !target || !Number.isFinite(requested) || requested <= 0) break;
         const lastReadId = setReadState(userId, networkId, target, requested);
         broadcastReadState(userId, networkId, target, lastReadId);
+        break;
+      }
+      case 'clear-buffer': {
+        // /clear: anchor the marker at the current tail. Server-computed so
+        // a message persisted between client send and server receive gets
+        // hidden too — the user's intent is "everything visible right now."
+        const networkId = Number(msg.networkId);
+        const target = typeof msg.target === 'string' ? msg.target : '';
+        if (!networkId || !target) break;
+        const boundary = maxIdForBuffer(networkId, target);
+        // Empty buffer: nothing to clear; don't write a no-op row.
+        if (boundary <= 0) break;
+        const next = setClearedState(userId, networkId, target, boundary, new Date().toISOString());
+        fanOut(userId, {
+          kind: 'buffer-cleared',
+          networkId,
+          target,
+          clearedBeforeId: next.clearedBeforeId,
+          clearedAt: next.clearedAt,
+        });
+        break;
+      }
+      case 'unclear-buffer': {
+        // Drop the clear marker so previously-hidden messages reappear.
+        // Fired by the "Show earlier messages" affordance on the divider
+        // and by `/clear off`.
+        const networkId = Number(msg.networkId);
+        const target = typeof msg.target === 'string' ? msg.target : '';
+        if (!networkId || !target) break;
+        setClearedState(userId, networkId, target, 0, null);
+        fanOut(userId, {
+          kind: 'buffer-cleared',
+          networkId,
+          target,
+          clearedBeforeId: 0,
+          clearedAt: null,
+        });
         break;
       }
       case 'mark-all-read': {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1346,6 +1346,7 @@ const HELP_LINES = [
   '  /join <#chan>          — join a channel',
   '  /part [#chan] [reason] — leave channel (keeps buffer; alias: /leave)',
   '  /close                 — close current buffer (parts if channel)',
+  '  /clear [off]           — hide buffer up to now (off = undo, show again)',
   '  /away [message]        — set away across every network (no arg clears)',
   '  /back                  — clear away',
   '  /whois <nick>          — query user info (renders in server buffer)',
@@ -1449,6 +1450,17 @@ function handleCommand(line: string, networkId: number, target: string): boolean
       // Close the current buffer. For channels this also PARTs; for DMs it
       // just hides the buffer. Server pseudo-buffers can't be closed.
       return sendOrToast({ type: 'close-buffer', networkId, target }, line);
+    case 'clear': {
+      // /clear            — hide everything currently in the buffer up to now;
+      //                     a "cleared at …" divider and an undo affordance
+      //                     replace the hidden region.
+      // /clear off|undo   — drop the marker so hidden messages reappear.
+      const arg = argLine.trim().toLowerCase();
+      if (arg === 'off' || arg === 'undo') {
+        return sendOrToast({ type: 'unclear-buffer', networkId, target }, line);
+      }
+      return sendOrToast({ type: 'clear-buffer', networkId, target }, line);
+    }
     case 'raw':
     case 'quote':
       return sendOrToast({ type: 'raw', networkId, line: argLine }, line);

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -26,6 +26,12 @@
         — back (gone {{ formatDuration(row.awayAt ?? '', row.backAt ?? '') }}) —
       </div>
       <div v-else-if="row.divider === 'date'" class="notice date-divider">{{ row.dateStr }}</div>
+      <div v-else-if="row.divider === 'cleared'" class="notice cleared-divider">
+        cleared {{ formatDateTime(row.clearedAt ?? '') }}
+        <button type="button" class="cleared-undo" @click="onUnclearClick">
+          Show earlier messages
+        </button>
+      </div>
       <div
         v-else-if="row.consolidation"
         class="line"
@@ -170,7 +176,13 @@ import {
   useScrollState,
 } from '../composables/useScrollState.js';
 import type { RenderSegment } from '../utils/nickColor.js';
-import { formatTimestamp, formatDuration, formatDate, formatDayLabel } from '../utils/timestamp.js';
+import {
+  formatTimestamp,
+  formatDuration,
+  formatDate,
+  formatDateTime,
+  formatDayLabel,
+} from '../utils/timestamp.js';
 import { consolidateRows } from '../utils/consolidate.js';
 import type { ConsolidationGroup, NickEntry, RenameEntry } from '../../../shared/consolidate.js';
 import { collapseDisplay } from '../utils/collapseDisplay.js';
@@ -214,6 +226,7 @@ interface RenderRow {
   awayMessage?: string;
   awayAt?: string;
   backAt?: string;
+  clearedAt?: string;
   // Consolidation row (from consolidateRows)
   consolidation?: boolean;
   groups?: ConsolidationGroup[];
@@ -293,6 +306,15 @@ const nickSet = computed((): Set<string> => {
 
 function time(iso: string | undefined): string {
   return formatTimestamp(iso ?? '', (tsFormat.value as string) ?? '');
+}
+
+// Drops the /clear marker for the currently-active buffer. Wired to the
+// "Show earlier messages" button on the cleared divider; the server's
+// buffer-cleared fan-out echoes back and clearedBeforeId reverts to 0.
+function onUnclearClick(): void {
+  const b = buffer.value;
+  if (!b) return;
+  buffers.unclearBuffer(b.networkId, b.target);
 }
 
 function rowClass(row: RenderRow) {
@@ -453,6 +475,19 @@ const renderRows = computed((): RenderRow[] => {
   // time you're seeing this").
   let dividerInserted = dividerAfterId === 0;
 
+  // /clear marker. Filter is suppressed while the buffer is detached — a
+  // search/highlight jump shows context around its anchor regardless of the
+  // marker, so the user can peek without losing their fresh slate. clearedAt
+  // gating means a buffer with no active clear emits no divider; we still
+  // run the loop normally.
+  const clearedBeforeId = buf?.detached ? 0 : buf?.clearedBeforeId || 0;
+  const clearedAt = buf?.detached ? null : buf?.clearedAt || null;
+  let clearedInserted = !clearedAt;
+  const pushClearedDivider = () => {
+    if (!clearedAt) return;
+    out.push({ divider: 'cleared', clearedAt, key: 'cleared-divider' });
+  };
+
   // Self-presence anchors. The away divider lands before the first message
   // newer than the user's last /away time; the back divider lands before the
   // first message newer than the matching /back. Anchoring by message time
@@ -498,6 +533,10 @@ const renderRows = computed((): RenderRow[] => {
     const key = m.id ?? `live:${i}`;
     let hidden = false;
 
+    // /clear filter (hard hide). Comes first so the divider, when emitted
+    // below, lands above every other filter's surviving rows.
+    if (clearedBeforeId > 0 && m.id != null && Number(m.id) <= clearedBeforeId) continue;
+
     // Render-time ignore filter. Self-authored events are never hidden (the
     // user always sees their own activity), and the matcher is fed both the
     // bare nick and the full nick!user@host so hostmask entries can fire.
@@ -528,6 +567,13 @@ const renderRows = computed((): RenderRow[] => {
     }
 
     if (hidden) continue;
+
+    // Cleared divider sits at the very top of the visible region — above the
+    // day-change marker so the user sees "cleared at …" before any date.
+    if (!clearedInserted) {
+      pushClearedDivider();
+      clearedInserted = true;
+    }
 
     // Day-change marker before the first visible row of each local day.
     const dayKey = formatDate(m.time ?? '');
@@ -560,6 +606,9 @@ const renderRows = computed((): RenderRow[] => {
   // message and nothing has arrived yet).
   if (!awayInserted) pushAwayDivider();
   if (!backInserted) pushBackDivider();
+  // Every loaded row got filtered by /clear (or the buffer is empty) — drop
+  // the divider at the end so the user still sees an undo affordance.
+  if (!clearedInserted) pushClearedDivider();
 
   // Final pass: merge consecutive join/part/quit/nick rows into a single
   // summary row when consolidation is enabled. Dividers break runs (we want
@@ -1375,7 +1424,8 @@ watch(
    but in the muted fg color since they're informational rather than
    action-required. */
 .presence-divider,
-.date-divider {
+.date-divider,
+.cleared-divider {
   font-style: normal;
   font-size: 0.85em;
   letter-spacing: 0.08em;
@@ -1388,10 +1438,29 @@ watch(
 .presence-divider::before,
 .presence-divider::after,
 .date-divider::before,
-.date-divider::after {
+.date-divider::after,
+.cleared-divider::before,
+.cleared-divider::after {
   content: '';
   flex: 1;
   border-top: 1px dashed var(--fg-muted);
   opacity: 0.6;
+}
+
+/* Undo affordance on the /clear divider — text-only button styled inline
+   with the label so the whole line reads as one structural anchor. */
+.cleared-undo {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+.cleared-undo:hover {
+  color: var(--accent);
 }
 </style>

--- a/vue_client/src/composables/useJumpToMessage.ts
+++ b/vue_client/src/composables/useJumpToMessage.ts
@@ -27,10 +27,13 @@ export interface JumpToMessageOptions {
 //   1. Reject :server: pseudo-buffers (no per-message anchor).
 //   2. Reject closed buffers with the existing toast.
 //   3. Activate the buffer.
-//   4. If the target id is already in buf.messages, set pendingScrollId
-//      directly (current happy path; no fetch needed).
+//   4. If the target id is already in buf.messages AND not hidden by the
+//      /clear marker, set pendingScrollId directly (current happy path; no
+//      fetch needed).
 //   5. Otherwise, loadAround() — detaching the buffer to a bounded ~200-row
 //      historical slice — and arm pendingScrollId once the slice lands.
+//      Detached mode suppresses the /clear filter in MessageList, so a row
+//      below the marker becomes visible without disturbing the marker.
 export function useJumpToMessage({ pendingScrollId, afterActivate }: JumpToMessageOptions = {}): (
   args: JumpTarget,
 ) => void {
@@ -54,7 +57,16 @@ export function useJumpToMessage({ pendingScrollId, afterActivate }: JumpToMessa
 
     const buf = buffers.byKey(`${networkId}::${target}`) as any;
     const hasMessage = buf?.messages?.some((m: any) => m.id === messageId);
+    // A row at or below the /clear marker is loaded but filtered out at
+    // render time. Detaching the buffer suppresses the filter — no fetch
+    // needed since the row is already in memory — and the next render pass
+    // mounts the DOM node pendingScrollId is waiting to scroll to.
+    const hiddenByClear =
+      typeof buf?.clearedBeforeId === 'number' &&
+      buf.clearedBeforeId > 0 &&
+      messageId <= buf.clearedBeforeId;
     if (hasMessage) {
+      if (hiddenByClear) buffers.detachForJump(networkId, target);
       if (pendingScrollId) pendingScrollId.value = messageId;
       return;
     }

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -254,6 +254,8 @@ function applyBacklog(payload: any): void {
       unread: payload.unread,
       highlights: payload.highlights,
       highlightsCapped: payload.highlightsCapped,
+      clearedBeforeId: payload.clearedBeforeId,
+      clearedAt: payload.clearedAt,
     },
     payload.joined,
   );
@@ -339,6 +341,14 @@ function handleMessage(raw: string): void {
       unread: payload.unread,
       highlights: payload.highlights,
       highlightsCapped: payload.highlightsCapped,
+    });
+    return;
+  }
+  if (payload.kind === 'buffer-cleared') {
+    const buffers = useBuffersStore();
+    buffers.applyClearedState(payload.networkId, payload.target, {
+      clearedBeforeId: payload.clearedBeforeId,
+      clearedAt: payload.clearedAt,
     });
     return;
   }

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -81,6 +81,13 @@ export interface Buffer {
   highlightsCapped: boolean;
   lastReadId: number;
   dividerAfterId: number | null;
+  // /clear marker. Render-time filter hides messages with id <= clearedBeforeId
+  // (0 = no clear). clearedAt is the wall-clock time the user issued /clear,
+  // shown in the "cleared at …" divider; null when no clear is in effect.
+  // Filter only applies in live tail — detached/jump views ignore it so
+  // search/highlight navigation always lands on the target row.
+  clearedBeforeId: number;
+  clearedAt: string | null;
   typing: Record<string, TypingEntry>;
   oldestId: number | null;
   newestId: number | null;
@@ -123,6 +130,10 @@ function ensureBuffer(
       // with this id; it stays pinned until switch-away (matching WeeChat),
       // not advanced live as new messages arrive in the focused buffer.
       dividerAfterId: null,
+      // /clear marker — server-owned, mirrored here for render-time filtering.
+      // 0 / null mean no clear active.
+      clearedBeforeId: 0,
+      clearedAt: null,
       typing: {},
       oldestId: null,
       // Symmetric to oldestId. Only authoritative while detached or mid-page-
@@ -338,6 +349,19 @@ export const useBuffersStore = defineStore('buffers', {
       buf.hasMoreNewer = !!hasMoreNewer;
       buf.loadingHistory = false;
       if (speakers !== undefined) this.seedSpeakers(networkId, target, speakers);
+    },
+    // Flip the buffer into detached mode without fetching a slice. Used by
+    // jump-to-message when the target row is already loaded but filtered out
+    // at render time (today: hidden by the /clear marker). The MessageList
+    // filter is suppressed while detached, so the row becomes visible and
+    // pendingScrollId can scroll to it on the next tick — no around-fetch
+    // needed, and the "Return to present" affordance shows up the same way
+    // it does after a real jump.
+    detachForJump(networkId: number | string, target: string) {
+      const buf = ensureBuffer(this, networkId, target);
+      if (buf.detached) return;
+      buf.detached = true;
+      buf.liveDuringDetach = 0;
     },
     // Jump-to-message entry point. Synchronously flips the buffer into
     // detached mode before the WS send so that any live fanOut arriving
@@ -587,6 +611,36 @@ export const useBuffersStore = defineStore('buffers', {
       // deactivate; the count refreshes live, the divider stays pinned.
       if (buf.dividerAfterId == null) buf.lastReadId = lastReadId;
       else buf.lastReadId = Math.max(buf.lastReadId, lastReadId);
+      // The /clear marker rides in the same payload on backlog frames so the
+      // filter survives reconnects. Only honor it when both keys are present —
+      // a plain read-state broadcast (no clear fields) shouldn't stomp the
+      // current marker.
+      if (
+        Object.prototype.hasOwnProperty.call(payload ?? {}, 'clearedBeforeId') ||
+        Object.prototype.hasOwnProperty.call(payload ?? {}, 'clearedAt')
+      ) {
+        buf.clearedBeforeId = Number(payload?.clearedBeforeId) || 0;
+        buf.clearedAt = payload?.clearedAt || null;
+      }
+    },
+    // Dedicated dispatch for the `buffer-cleared` fan-out (both set-clear and
+    // unset-clear). Distinct from applyReadState so a buffer-cleared frame
+    // that doesn't carry read-state fields doesn't blank them out.
+    applyClearedState(networkId: number | string, target: string, payload: any) {
+      const buf = ensureBuffer(this, networkId, target);
+      buf.clearedBeforeId = Number(payload?.clearedBeforeId) || 0;
+      buf.clearedAt = payload?.clearedAt || null;
+    },
+    // /clear: anchor the marker at the current tail (server picks the exact
+    // boundary id). Best-effort send; the server's fan-out echoes back and
+    // applyClearedState moves the local mirror to the authoritative value.
+    clearBuffer(networkId: number | string, target: string) {
+      socketSend({ type: 'clear-buffer', networkId, target });
+    },
+    // Drop the /clear marker so hidden messages reappear. Fired by the
+    // "Show earlier messages" affordance on the divider and by `/clear off`.
+    unclearBuffer(networkId: number | string, target: string) {
+      socketSend({ type: 'unclear-buffer', networkId, target });
     },
     // Switch to a buffer. We mark the entered buffer read on focus-IN (not
     // on focus-OUT of the previous one) so that a tab close / reload / lost


### PR DESCRIPTION
## Summary
- Adds `/clear` — anchors a per-(user, buffer) marker at the current tail; rows at or below it are filtered out at render time and a "cleared at …" divider with a "Show earlier messages" undo replaces the hidden region.
- State lives on `buffer_reads` (`cleared_before_message_id`, `cleared_at`) so the marker survives reconnects, syncs across the user's tabs/devices, and stays orthogonal to read state (hiding ≠ marking read).
- Render-time filter is suppressed while the buffer is `detached` (search/highlight jump), so jumping to a hidden message reveals it without disturbing the marker. An in-memory hidden target detaches without re-fetching so the scroll lands on the row even in light buffers.

## Behavior
- `/clear` — hide everything up to the current tail.
- `/clear off` (or `/clear undo`) — drop the marker; same as the divider's undo button.
- New messages arriving after `/clear` appear normally below the divider.
- Jumping to a hidden message via search/highlight detaches the buffer (filter off) and pulses to the row; "Return to present" puts the marker back in effect.
- Empty buffer + `/clear` = no-op (server skips when `MAX(id)` is 0).

## Implementation notes
- Server picks the boundary id at `/clear` time (`MAX(id)` for the buffer), so a message persisted in the gap between client send and server receive still gets hidden — matches user intent of "everything visible right now".
- Backup/restore: the two new columns are wired into `exportSchema` with `cleared_before_message_id` as an `fkRekey: 'messages'` target. A vanished boundary message falls through to NULL (no clear) rather than dangling.
- Migration: `ensureColumn` adds both columns nullable; existing rows default to the no-clear state.

## Test plan
- [x] `server/db/bufferReads.test.ts` — set/get round-trip, no-clobber between read pointer and clear marker in both directions, `/clear off`, re-clear overwrites, `listClearedStateForUser` is sparse-on-active-only and drops on undo.
- [x] Full server test suite (640 tests) — green.
- [x] Client typecheck + build — green.
- [ ] Manual: `/clear` in a busy buffer, refresh, expect marker persists.
- [ ] Manual: open the same buffer on another tab/device, expect marker syncs.
- [ ] Manual: search → click result behind the marker, expect it scrolls into view; "Return to present" puts the filter back.
- [ ] Manual: `/clear off` and the undo button both restore the hidden rows.
- [ ] Manual: `/clear` in an empty buffer is a no-op.

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)