### PR TITLE
Lock mobile shell so iOS keyboard doesn't expose a gap

### DIFF
--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -48,6 +48,27 @@
   }
 }
 
+/* Home-indicator clearance for desktop-layout shells (DesktopChat on iPad
+   PWA landscape, Settings, modals). Mobile chat's .mchat handles its own
+   inset via .composer-host so it's deliberately not listed here. Only
+   applies in PWA standalone — Mobile Safari's bottom chrome already
+   covers the home indicator. The :root[data-keyboard-open] override
+   collapses the inset when the soft keyboard is up (keyboard covers the
+   home-indicator zone). */
+@media (display-mode: standalone) {
+  .chat,
+  .settings-page,
+  .modal {
+    box-sizing: border-box;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+}
+:root[data-keyboard-open='true'] .chat,
+:root[data-keyboard-open='true'] .settings-page,
+:root[data-keyboard-open='true'] .modal {
+  padding-bottom: 0;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -48,27 +48,6 @@
   }
 }
 
-/* Home-indicator clearance: needed only in PWA standalone mode (no browser
-   chrome below the content, so without this the input bar would sit on top
-   of the iOS gesture zone at the bottom of the screen). Safari proper has
-   its own bottom chrome that already keeps content above the home indicator,
-   so applying env(safe-area-inset-bottom) there just leaves a redundant gap
-   below the input and can let Safari's bottom chrome clip the input when
-   the keyboard is up. Inside this @media, focus state zeroes the padding —
-   on iOS, a focused text input means the keyboard is up and there's no home
-   indicator to clear. */
-@media (display-mode: standalone) {
-  .mchat,
-  .chat {
-    box-sizing: border-box;
-    padding-bottom: env(safe-area-inset-bottom);
-  }
-  :root:has(input:focus, textarea:focus, [contenteditable]:focus) .mchat,
-  :root:has(input:focus, textarea:focus, [contenteditable]:focus) .chat {
-    padding-bottom: 0;
-  }
-}
-
 * {
   box-sizing: border-box;
 }
@@ -76,11 +55,11 @@
 html,
 body,
 #app {
-  /* `100dvh` tracks the dynamic viewport on iOS — shrinks when the soft
-     keyboard opens. Without this, body/html stay at full layout-viewport
-     height while the shell (also `100dvh`) shrinks, leaving body area
-     below the shell that iOS's auto-scroll exposes. See issue #85. */
-  height: 100dvh;
+  /* 100% (not 100dvh) here — html/body fill the layout viewport and stay
+     locked. The shell (.mchat / .chat / .settings-page) uses 100dvh so
+     it shrinks with the iOS soft keyboard while the document underneath
+     stays put. */
+  height: 100%;
   margin: 0;
   background: var(--bg);
   color: var(--fg);
@@ -94,14 +73,31 @@ body,
 }
 
 /* Whole app behaves like a CLI window — no document-level scroll.
-   `overscroll-behavior: none` kills the rubber-band bounce at the
-   edges. (Earlier attempts to use `position: fixed` on body to fully
-   lock iOS drag-scroll didn't help — iOS overrides it for keyboard
-   accommodation. See issue #85.) */
+   overflow:hidden + overscroll-behavior:none gets us most of the way,
+   but iOS Safari will still let the user drag-scroll the document
+   despite both of those (a documented iOS quirk). `touch-action: none`
+   on body is the load-bearing line that blocks that — children with
+   their own scroll behaviors (MessageList, modal scroll areas) re-enable
+   via `touch-action: pan-y`. Without this, focusing the input on iOS
+   Safari and dragging up would scroll the document and leave a
+   persistent gap below the shell (issue #114). */
 html,
 body {
   overflow: hidden;
   overscroll-behavior: none;
+}
+body {
+  touch-action: none;
+}
+
+/* Scrollable regions explicitly re-enable vertical pan — body's
+   touch-action:none disables it for descendants by default. Add to this
+   list when introducing a new scroll container. overscroll-behavior:
+   contain stops scroll chaining from these regions back to the document. */
+.message-list,
+.scroll-region {
+  overscroll-behavior: contain;
+  touch-action: pan-y;
 }
 
 a {

--- a/vue_client/src/composables/useVisualViewport.ts
+++ b/vue_client/src/composables/useVisualViewport.ts
@@ -113,5 +113,9 @@ export function installVisualViewport(): void {
 }
 
 export function useVisualViewport(): VisualViewportState {
+  // Self-init so callers don't have to remember to bootstrap separately —
+  // the `initialized` guard inside makes this idempotent with the explicit
+  // call in main.ts. Matches the pattern in useViewport.
+  installVisualViewport();
   return { keyboardOpen };
 }

--- a/vue_client/src/composables/useVisualViewport.ts
+++ b/vue_client/src/composables/useVisualViewport.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { ref, type Ref } from 'vue';
+
+// Soft-keyboard detector. Exposes a reactive `keyboardOpen` ref and
+// mirrors it to a `data-keyboard-open="true"` attribute on <html>.
+// Consumer: MobileChat's .composer-host binds `.keyboard-open` from the
+// ref so the safe-area inset padding collapses when the keyboard is up
+// (the keyboard already covers the home-indicator zone, so leaving the
+// inset in place would push the input bar partway behind the keyboard).
+//
+// We deliberately don't use this to drive positioning math (e.g. a JS
+// --kb-bottom variable bound to `bottom: ...`): production chat apps
+// have converged on plain `100dvh` shells, since `100dvh` already tracks
+// the keyboard in current Safari and a JS-driven `bottom` value gets
+// bitten by a known iOS 26 visualViewport regression that returns
+// phantom offsets after keyboard dismiss.
+//
+// Three signals feed `open`; ANY of them sets it true:
+//   - visualViewport.height delta > threshold (Android, current iOS Safari)
+//   - visualViewport.offsetTop > 50 (iOS Safari edge case where iOS
+//     auto-scrolls the visible viewport rather than shrinking its height)
+//   - a text-like input has focus (the reliable fallback for iOS PWA,
+//     where visualViewport.resize doesn't fire when the keyboard opens)
+// :focus-visible alone would partially work but Chrome Android can
+// retain it after keyboard dismiss in focus-shuffle scenarios; combining
+// it with the viewport signals avoids that false positive.
+
+const keyboardOpen = ref(false);
+
+// Threshold for "keyboard is up." Smaller height deltas are attributed to
+// URL-bar collapse, browser zoom, or sub-pixel rounding. 150px clears every
+// soft keyboard we've measured while ignoring the ~80px Android URL bar.
+const KEYBOARD_HEIGHT_THRESHOLD_PX = 150;
+
+let initialized = false;
+
+export interface VisualViewportState {
+  keyboardOpen: Ref<boolean>;
+}
+
+export function installVisualViewport(): void {
+  if (initialized || typeof window === 'undefined') return;
+  initialized = true;
+
+  const root = document.documentElement;
+
+  const isTextInputFocused = (): boolean => {
+    const el = document.activeElement;
+    if (!(el instanceof HTMLElement)) return false;
+    if (el.tagName === 'TEXTAREA') return true;
+    if (el.isContentEditable) return true;
+    if (el.tagName === 'INPUT') {
+      const type = (el as HTMLInputElement).type;
+      return (
+        type === 'text' ||
+        type === 'search' ||
+        type === 'email' ||
+        type === 'tel' ||
+        type === 'url' ||
+        type === 'password' ||
+        type === 'number'
+      );
+    }
+    return false;
+  };
+
+  const update = () => {
+    const vv = window.visualViewport;
+    const height = vv ? vv.height : window.innerHeight;
+    const offsetTop = vv ? vv.offsetTop : 0;
+    // Three signals; ANY of them sets open=true. iOS PWA doesn't always
+    // fire a meaningful visualViewport.resize when the keyboard opens
+    // (the height delta can stay near zero), so we also accept:
+    //   - vv.offsetTop > 50 (iOS auto-scrolled the visible viewport)
+    //   - a text-like input has focus (mobile keyboard MUST be up)
+    // Desktop with a focused input is a false positive, but .composer-host
+    // is mobile-only so there's no visible side effect.
+    const heightOpen =
+      window.innerHeight - height > KEYBOARD_HEIGHT_THRESHOLD_PX;
+    const offsetOpen = offsetTop > 50;
+    const focusOpen = isTextInputFocused();
+    const open = heightOpen || offsetOpen || focusOpen;
+    keyboardOpen.value = open;
+    if (open) root.setAttribute('data-keyboard-open', 'true');
+    else root.removeAttribute('data-keyboard-open');
+  };
+
+  update();
+
+  const vv = window.visualViewport;
+  if (vv) {
+    vv.addEventListener('resize', update);
+    vv.addEventListener('scroll', update);
+  }
+  // Covers desktop browsers and the handful of mobile UAs that don't fire
+  // visualViewport events reliably; harmless double-fire elsewhere.
+  window.addEventListener('resize', update);
+  window.addEventListener('orientationchange', update);
+  // Focus changes drive the iOS-PWA fallback signal — without these, the
+  // focus-based detection would only update on visualViewport events,
+  // which iOS PWA may not fire when the keyboard opens. The setTimeout
+  // on blur gives focus a chance to move to another input first (so
+  // tabbing between fields doesn't briefly flicker keyboardOpen to false).
+  document.addEventListener('focusin', update, true);
+  document.addEventListener(
+    'focusout',
+    () => {
+      setTimeout(update, 50);
+    },
+    true,
+  );
+}
+
+export function useVisualViewport(): VisualViewportState {
+  return { keyboardOpen };
+}

--- a/vue_client/src/composables/useVisualViewport.ts
+++ b/vue_client/src/composables/useVisualViewport.ts
@@ -77,8 +77,7 @@ export function installVisualViewport(): void {
     //   - a text-like input has focus (mobile keyboard MUST be up)
     // Desktop with a focused input is a false positive, but .composer-host
     // is mobile-only so there's no visible side effect.
-    const heightOpen =
-      window.innerHeight - height > KEYBOARD_HEIGHT_THRESHOLD_PX;
+    const heightOpen = window.innerHeight - height > KEYBOARD_HEIGHT_THRESHOLD_PX;
     const offsetOpen = offsetTop > 50;
     const focusOpen = isTextInputFocused();
     const open = heightOpen || offsetOpen || focusOpen;

--- a/vue_client/src/main.ts
+++ b/vue_client/src/main.ts
@@ -9,7 +9,7 @@ import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
 import '@fortawesome/fontawesome-free/css/solid.min.css';
 import '@fortawesome/fontawesome-free/css/regular.min.css';
 import './assets/main.css';
-import { installVisualViewport } from './composables/useVisualViewport';
+import { installVisualViewport } from './composables/useVisualViewport.js';
 
 installVisualViewport();
 

--- a/vue_client/src/main.ts
+++ b/vue_client/src/main.ts
@@ -9,6 +9,9 @@ import '@fortawesome/fontawesome-free/css/fontawesome.min.css';
 import '@fortawesome/fontawesome-free/css/solid.min.css';
 import '@fortawesome/fontawesome-free/css/regular.min.css';
 import './assets/main.css';
+import { installVisualViewport } from './composables/useVisualViewport';
+
+installVisualViewport();
 
 const app = createApp(App);
 app.use(createPinia());

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -343,8 +343,8 @@ useChatBootstrap({ onJump: onJumpToMessage });
    regression (returns phantom positive values after keyboard dismiss).
    The body-level `touch-action: none` (see main.css) is what stops iOS
    from drag-scrolling the document despite overflow:hidden. Safe-area
-   home-indicator clearance lives on the input element (see
-   MessageInput.vue) so it can't compete with the shell's geometry. */
+   home-indicator clearance lives on .composer-host (below) — wrapping
+   MessageInput so it can't compete with the shell's geometry. */
 .mchat {
   height: 100dvh;
   display: flex;
@@ -479,10 +479,17 @@ useChatBootstrap({ onJump: onJumpToMessage });
   -webkit-overflow-scrolling: touch;
   touch-action: pan-y;
   scrollbar-width: none;
-  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 .composer-host::-webkit-scrollbar {
   display: none;
+}
+/* env(safe-area-inset-bottom) only applies in PWA standalone. Mobile
+   Safari's own bottom chrome already keeps content above the home
+   indicator, so applying the inset there leaves a redundant gap. */
+@media (display-mode: standalone) {
+  .composer-host {
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
 }
 .composer-host.keyboard-open {
   padding-bottom: 0;

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -101,7 +101,13 @@
       <SystemConsole v-if="isSystemConsole" />
       <MessageList v-else :pending-scroll-id="pendingScrollId" />
       <StatusBar compact />
-      <MessageInput v-if="!isSystemConsole" ref="messageInputRef" />
+      <div
+        v-if="!isSystemConsole"
+        class="composer-host"
+        :class="{ 'keyboard-open': keyboardOpen }"
+      >
+        <MessageInput ref="messageInputRef" />
+      </div>
     </section>
 
     <!-- Screen: members -->
@@ -182,9 +188,11 @@ import UserProfileModal from '../components/UserProfileModal.vue';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
+import { useVisualViewport } from '../composables/useVisualViewport.js';
 
 const networks = useNetworksStore();
 const { connected } = useSocket();
+const { keyboardOpen } = useVisualViewport();
 const {
   active,
   activeKey,
@@ -330,13 +338,17 @@ useChatBootstrap({ onJump: onJumpToMessage });
 </script>
 
 <style scoped>
-/* Single-column flex stack sized to the dynamic viewport. iOS scrolls
-   the page naturally when the keyboard opens; the textarea at the
-   bottom of the shell stays visible just above the keyboard, and the
-   upper content (sidebar / topic / older messages) scrolls off the
-   top of the visible area until the user dismisses the keyboard. See
-   issue #85 for the full investigation — multiple workarounds were
-   tried and each made things worse on at least one device. */
+/* Single-column flex stack sized to 100dvh. On current iOS Safari the
+   dynamic-viewport unit shrinks with the soft keyboard, so the shell
+   contracts and the input bar (last flex child) rides up flush against
+   the keyboard with no extra plumbing. We deliberately do NOT use
+   position: fixed or a JS-tracked --kb-bottom here — those approaches
+   fight iOS auto-scroll, env() shifts, and a known iOS 26 visualViewport
+   regression (returns phantom positive values after keyboard dismiss).
+   The body-level `touch-action: none` (see main.css) is what stops iOS
+   from drag-scrolling the document despite overflow:hidden. Safe-area
+   home-indicator clearance lives on the input element (see
+   MessageInput.vue) so it can't compete with the shell's geometry. */
 .mchat {
   height: 100dvh;
   display: flex;
@@ -446,7 +458,40 @@ useChatBootstrap({ onJump: onJumpToMessage });
 .buffer :deep(.status-bar) {
   flex: 0 0 auto;
 }
-.buffer :deep(.input) {
+
+/* iOS Safari scroll-target trick. When an input is focused, iOS scrolls
+   the input's nearest scrollable ancestor to bring it into view, leaving
+   a comfort margin between the input and the keyboard top. If no
+   scrollable ancestor exists, iOS falls back to scrolling the
+   *visualViewport* itself — that's where the previous gap came from.
+   `overflow-y: scroll` here gives iOS a scrollable target. There's
+   nothing actually to scroll (the inner input fits exactly), so the
+   scroll is a no-op — but iOS targets this element instead of the
+   viewport, so no gap appears.
+
+   padding-bottom carries the home-indicator safe-area inset (only
+   non-zero in PWA standalone) and collapses to 0 when the keyboard is
+   up via the .keyboard-open class — the keyboard already covers the
+   home-indicator zone. .keyboard-open is bound from the keyboardOpen
+   ref in script setup, which combines three signals (visualViewport
+   height delta, visualViewport offsetTop, and focused-input fallback)
+   so iOS PWA — where visualViewport.resize doesn't fire reliably — is
+   still caught. */
+.composer-host {
+  flex: 0 0 auto;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
+  scrollbar-width: none;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+.composer-host::-webkit-scrollbar {
+  display: none;
+}
+.composer-host.keyboard-open {
+  padding-bottom: 0;
+}
+.composer-host :deep(.input) {
   flex: 0 0 auto;
 }
 

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -101,11 +101,7 @@
       <SystemConsole v-if="isSystemConsole" />
       <MessageList v-else :pending-scroll-id="pendingScrollId" />
       <StatusBar compact />
-      <div
-        v-if="!isSystemConsole"
-        class="composer-host"
-        :class="{ 'keyboard-open': keyboardOpen }"
-      >
+      <div v-if="!isSystemConsole" class="composer-host" :class="{ 'keyboard-open': keyboardOpen }">
         <MessageInput ref="messageInputRef" />
       </div>
     </section>


### PR DESCRIPTION
## Summary

- Mobile shell goes back to plain `100dvh` + flex column. The iOS gap is closed by wrapping `MessageInput` in a `.composer-host` that has `overflow-y: scroll` — iOS picks this as the focused input's scrollable ancestor and no longer scrolls the visualViewport itself.
- `useVisualViewport` exposes a `keyboardOpen` ref that combines visualViewport height delta, visualViewport offsetTop, and active-input focus — the third signal is what catches iOS PWA, where `visualViewport.resize` doesn't fire on keyboard open.
- `body { touch-action: none }` blocks iOS Safari's drag-scroll of the document (`overflow: hidden` alone doesn't); `.message-list` / `.scroll-region` re-enable `touch-action: pan-y` for real scrolling.
- Safe-area inset for PWA home-indicator clearance moves to the composer-host's `padding-bottom: env(safe-area-inset-bottom)`, collapsed via a `.keyboard-open` class bound directly from the Vue ref (sidesteps Vue scoped-CSS quirks with `:root[data-attr]`).

Closes #114.

## Test plan

- [ ] Android Chrome (emulator or device) — focus input, send a link, dismiss/reopen keyboard; input bar stays put.
- [ ] iOS Safari — focus input, drag up on the input area: no document scroll, no exposed gap below.
- [ ] iOS Safari PWA — focus input: input flush against keyboard top, no visible gap below.
- [ ] iOS PWA, no keyboard: input clears home indicator (safe-area padding visible).
- [ ] iOS PWA, keyboard up: safe-area padding collapses (no extra gap above keyboard).
- [ ] Message list still scrolls on mobile.
- [ ] Desktop layout unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)