### PR TITLE
Filter typing notifications for ignored users

### DIFF
--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1323,6 +1323,7 @@ export class IrcConnection {
         target,
         nick: eventNick,
         state: typing,
+        userhost: buildUserhost(event),
       });
     });
   }

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -55,6 +55,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore } from '../stores/uploads.js';
+import { useIgnoresStore } from '../stores/ignores.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useScrollState, requestScrollToBottom } from '../composables/useScrollState.js';
 import { useComposing } from '../composables/useComposing.js';
@@ -79,6 +80,7 @@ const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const settings = useSettingsStore();
 const uploads = useUploadsStore();
+const ignores = useIgnoresStore();
 const nickColors = useNickColors();
 const composing = useComposing();
 const { promptLabel, awayLabel } = useSelfLabel();
@@ -168,7 +170,11 @@ const peerStatusClass = computed(() => {
 const typingNicks = computed(() => {
   const t = buffer.value?.typing;
   if (!t) return [];
-  return Object.keys(t);
+  const networkId = active.value?.networkId;
+  if (!networkId) return Object.keys(t);
+  return Object.entries(t)
+    .filter(([nick, entry]) => !ignores.isIgnored(networkId, nick, entry.userhost ?? ''))
+    .map(([nick]) => nick);
 });
 
 function nickSeg(nick: string): { text: string; color: string | null } {

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -172,7 +172,13 @@ function applyEvent(event: any): void {
       buffers.setMembers(event.networkId, event.target, []);
       break;
     case 'typing':
-      buffers.setTyping(event.networkId, event.target, event.nick, event.state);
+      buffers.setTyping(
+        event.networkId,
+        event.target,
+        event.nick,
+        event.state,
+        event.userhost ?? null,
+      );
       break;
     case 'peer-presence':
       networks.applyPeerPresence(event.networkId, event.nick, {

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -51,6 +51,7 @@ export interface BufferMember {
 export interface TypingEntry {
   state: string;
   expiresAt: number;
+  userhost: string | null;
 }
 
 export interface SpeakerEntry {
@@ -740,7 +741,13 @@ export const useBuffersStore = defineStore('buffers', {
         socketSend({ type: 'probe-presence', networkId, nick: target });
       }
     },
-    setTyping(networkId: number | string, target: string, nick: string, state: string) {
+    setTyping(
+      networkId: number | string,
+      target: string,
+      nick: string,
+      state: string,
+      userhost: string | null = null,
+    ) {
       if (!nick) return;
       const buf = ensureBuffer(this, networkId, target);
       clearTypingTimer(networkId, target, nick);
@@ -752,7 +759,7 @@ export const useBuffersStore = defineStore('buffers', {
 
       const duration = TYPING_DURATIONS[state];
       if (!duration) return;
-      buf.typing[nick] = { state, expiresAt: Date.now() + duration };
+      buf.typing[nick] = { state, expiresAt: Date.now() + duration, userhost };
 
       const timer = setTimeout(() => {
         const b = this.buffers[key(networkId, target)];


### PR DESCRIPTION
## Summary
- Pipe `userhost` through the server-side typing event so the client can match host-glob ignore masks, not just plain nicks
- Filter `typingNicks` at render time in `StatusBar.vue` via `ignores.isIgnored(networkId, nick, userhost)` — same pattern `MessageList` uses, so `/unignore` reveals a still-active typer without waiting for the next typing event
- Extend `TypingEntry` and `setTyping()` to carry userhost alongside state/expiry

Closes #128

## Test plan
- [x] `npm run check` (typecheck + lint + format) — clean
- [x] `npm test` — 646/646 pass
- [ ] Manual: ignore a nick on a busy channel, confirm their typing indicator disappears from the status bar; `/unignore` and confirm it reappears live
- [ ] Manual: host-glob mask (e.g. `*!*@badhost`) — confirm typing from that hostmask is suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)