### PR TITLE
Move composer overlays into StatusBar

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1153,8 +1153,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'Use the mobile-style horizontal suggestion strip on desktop instead of ' +
       'the @-triggered popup menu. The strip surfaces matching nicks above the ' +
       "input as you type any 2+ character prefix (no '@' required), tap or " +
-      'click a nick to insert it. Mobile uses the strip unconditionally; this ' +
-      'setting lets desktop users opt into the same behavior.',
+      'click a nick to insert it.',
   },
 
   // ─── Input bar (formatting) ──────────────────────────────────────────

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -64,13 +64,11 @@
     >
       <i class="fa-solid fa-palette"></i>
     </div>
-    <MircColorPicker
-      v-if="showFormatButton"
-      :open="colorPickerOpen"
-      @apply="onApplyColor"
-      @reset="onPickReset"
-      @close="closeColorPicker"
-    />
+    <!-- The nick / emoji suggestion strips and the mIRC colour picker render
+         inside StatusBar (they overlay it visually) — see useComposerOverlay
+         for the cross-component state contract. Only the desktop @-popup
+         lives in the form, because it's a position:fixed popover anchored
+         to the form rather than to StatusBar. -->
     <NickPicker
       ref="nickPickerEl"
       :open="pickerOpen"
@@ -81,25 +79,6 @@
       @select="onPickerSelect"
       @close="closePicker"
     />
-    <NickSuggestionStrip
-      v-show="stripOpen"
-      :query="stripQuery"
-      :buffer="buffer"
-      :self-nick="ownNick"
-      @select="onStripSelect"
-    />
-    <SuggestionStrip
-      v-show="emojiStripOpen"
-      ref="emojiStripEl"
-      :items="emojiItems"
-      :key-for="emojiKeyFor"
-      @select="onEmojiSelect"
-    >
-      <template #chip="{ item }">
-        <span class="emoji-glyph">{{ item.emoji }}</span>
-        <span class="emoji-name">:{{ item.name }}:</span>
-      </template>
-    </SuggestionStrip>
     <Teleport to="body">
       <LongMessageUploadModal
         v-if="longMessageModalOpen"
@@ -137,12 +116,19 @@ import {
 } from '../utils/emojiShortcodes.js';
 import type { EmojiMatch } from '../utils/emojiData.js';
 import NickPicker from './NickPicker.vue';
-import NickSuggestionStrip from './NickSuggestionStrip.vue';
-import SuggestionStrip from './SuggestionStrip.vue';
 import LongMessageUploadModal from './LongMessageUploadModal.vue';
-import MircColorPicker from './MircColorPicker.vue';
 import { useSelfLabel } from '../composables/useSelfLabel.js';
 import { useViewport } from '../composables/useViewport.js';
+import {
+  useComposerOverlay,
+  setComposerOverlayHandlers,
+  setNickStrip,
+  setEmojiStrip,
+  setColorPickerOpen,
+  moveEmojiActive,
+  confirmEmojiActive,
+  hasEmojiCandidates,
+} from '../composables/useComposerOverlay.js';
 import type { Buffer } from '../stores/buffers.js';
 
 const networks = useNetworksStore();
@@ -162,29 +148,19 @@ const pickerQuery = ref('');
 const nickPickerEl = ref<InstanceType<typeof NickPicker> | null>(null);
 let pickerTokenStart = -1;
 let pickerTokenEnd = -1;
-const stripOpen = ref(false);
-const stripQuery = ref('');
+// Suggestion-strip and colour-picker visibility / contents live in
+// useComposerOverlay so StatusBar can render them as overlays without prop
+// drilling. Token-span book-keeping (which slice of the draft a pick
+// replaces) stays here — it's pure MessageInput state.
+const overlay = useComposerOverlay();
 let stripTokenStart = -1;
 let stripTokenEnd = -1;
-const colorPickerOpen = ref(false);
-
-// Slack-style `:shortcode:` emoji suggester. The strip floats over the
-// StatusBar (the same slot as the mobile nick strip) but is keyboard-navigable
-// like the desktop NickPicker. `emojiToken{Start,End}` mark the `:query` span
-// in the draft that a pick or inline auto-convert replaces. The ~1,900-entry
-// emoji table is a lazily-loaded chunk (see `loadEmoji`), so nothing here
-// pulls it into the initial bundle.
-type StripHandle = {
-  moveActive: (delta: number) => void;
-  confirmActive: () => void;
-  hasCandidates: () => boolean;
-};
-const emojiStripOpen = ref(false);
-const emojiItems = ref<EmojiMatch[]>([]);
-const emojiStripEl = ref<StripHandle | null>(null);
+// Slack-style `:shortcode:` emoji suggester. `emojiToken{Start,End}` mark
+// the `:query` span in the draft that a pick or inline auto-convert
+// replaces. The ~1,900-entry emoji table is a lazily-loaded chunk (see
+// `loadEmoji`), so nothing here pulls it into the initial bundle.
 let emojiTokenStart = -1;
 let emojiTokenEnd = -1;
-const emojiKeyFor = (m: EmojiMatch): string => m.name;
 
 const active = computed(() => networks.activeBuffer);
 
@@ -552,11 +528,11 @@ function wrapOrInsertFormatting(opening: string, closing: string): void {
 
 function onToggleColorPicker() {
   if (!sendable.value) return;
-  colorPickerOpen.value = !colorPickerOpen.value;
+  setColorPickerOpen(!overlay.colorPickerOpen);
 }
 
 function closeColorPicker() {
-  colorPickerOpen.value = false;
+  setColorPickerOpen(false);
 }
 
 function onApplyColor(fg: string | null, bg: string | null): void {
@@ -597,7 +573,7 @@ function onKeydown(e: KeyboardEvent): void {
       return;
     }
   }
-  if (e.key === 'Escape' && colorPickerOpen.value) {
+  if (e.key === 'Escape' && overlay.colorPickerOpen) {
     e.preventDefault();
     closeColorPicker();
     return;
@@ -639,7 +615,7 @@ function onKeydown(e: KeyboardEvent): void {
   // during an IME composition. The emoji strip and the nick picker are never
   // open at once (refreshPicker closes one before opening the other), so the
   // two blocks can't both fire.
-  if (emojiStripOpen.value && !e.isComposing && emojiStripEl.value?.hasCandidates()) {
+  if (overlay.emojiOpen && !e.isComposing && hasEmojiCandidates()) {
     if (e.key === 'Escape') {
       e.preventDefault();
       closeEmojiStrip();
@@ -654,16 +630,16 @@ function onKeydown(e: KeyboardEvent): void {
       if (!e.altKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         const forward = e.key === 'ArrowDown' || e.key === 'ArrowRight';
-        emojiStripEl.value.moveActive(forward ? 1 : -1);
+        moveEmojiActive(forward ? 1 : -1);
         return;
       }
     } else if (e.key === 'Tab') {
       e.preventDefault();
-      emojiStripEl.value.confirmActive();
+      confirmEmojiActive();
       return;
     } else if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      emojiStripEl.value.confirmActive();
+      confirmEmojiActive();
       return;
     }
   }
@@ -743,15 +719,13 @@ function closePicker() {
 }
 
 function closeStrip() {
-  stripOpen.value = false;
-  stripQuery.value = '';
+  setNickStrip(false);
   stripTokenStart = -1;
   stripTokenEnd = -1;
 }
 
 function closeEmojiStrip() {
-  emojiStripOpen.value = false;
-  emojiItems.value = [];
+  setEmojiStrip(false);
   emojiTokenStart = -1;
   emojiTokenEnd = -1;
 }
@@ -782,10 +756,9 @@ async function showEmojiStrip() {
     closeEmojiStrip();
     return;
   }
-  emojiItems.value = matches;
+  setEmojiStrip(true, matches);
   emojiTokenStart = sc.start;
   emojiTokenEnd = sc.end;
-  emojiStripOpen.value = true;
 }
 
 // Replace the `:query` token with the picked emoji. No trailing space — emoji
@@ -883,19 +856,25 @@ function refreshPicker() {
     return;
   }
 
-  // Desktop users can opt into the mobile-style strip via this setting;
-  // mobile always uses the strip regardless.
-  const useStrip = isMobile.value || !!settings.effective('input.suggestion_strip_on_desktop');
+  // Mobile runs both UIs concurrently — an `@`-prefixed token routes to the
+  // vertical picker, anything else routes to the horizontal strip. Desktop
+  // is picker-only by default; the setting opts into the strip globally.
+  const useStrip = isMobile.value
+    ? !token.startsWith('@')
+    : !!settings.effective('input.suggestion_strip_on_desktop');
 
   if (useStrip) {
+    // On mobile both UIs are live, so dropping the `@` (which switched us
+    // from the picker branch to here) needs to actively close the picker
+    // — the picker branch below never runs to do it for us.
+    if (pickerOpen.value) closePicker();
     // Strip replaces the @-popup with an always-on suggestion row.
     // Leading '@' is tolerated as muscle-memory but stripped from the query
     // so the prefix matches plain typing. Min length 2 keeps the strip from
     // flashing on every single-letter word.
     const prefix = token.startsWith('@') ? token.slice(1) : token;
     if (prefix.length >= 2) {
-      stripOpen.value = true;
-      stripQuery.value = prefix;
+      setNickStrip(true, prefix);
       stripTokenStart = start;
       stripTokenEnd = end;
     } else {
@@ -908,6 +887,9 @@ function refreshPicker() {
     if (pickerOpen.value) closePicker();
     return;
   }
+  // Symmetric mobile case — typing `@` after a bare prefix should close the
+  // strip the previous keystroke opened.
+  if (overlay.nickOpen) closeStrip();
   pickerOpen.value = true;
   pickerQuery.value = token.slice(1);
   pickerTokenStart = start;
@@ -1068,6 +1050,12 @@ onBeforeUnmount(() => {
     unsubInsert = null;
   }
   if (typeof window !== 'undefined') window.removeEventListener('pagehide', onPagehide);
+  // Overlay state lives in a module-level singleton, so an unmounted
+  // MessageInput would otherwise leak its last open strip/picker into the
+  // next instance (e.g. switching to system console and back).
+  closeStrip();
+  closeEmojiStrip();
+  closeColorPicker();
 });
 
 function insertUrlAtCaret(url: string): void {
@@ -1100,6 +1088,16 @@ let unsubInsert: (() => boolean) | null = null;
 onMounted(() => {
   unsubInsert = onInsertUrl(insertUrlAtCaret);
   if (typeof window !== 'undefined') window.addEventListener('pagehide', onPagehide);
+  // Route picks from StatusBar's overlay-rendered popovers back to the
+  // textarea-mutation logic that owns the draft. Re-registered on every
+  // mount so closures bind to the live `text`/`inputEl`.
+  setComposerOverlayHandlers({
+    onNickSelect: onStripSelect,
+    onEmojiSelect,
+    onColorApply: onApplyColor,
+    onColorReset: onPickReset,
+    onColorClose: closeColorPicker,
+  });
 });
 
 function blobFromClipboardItem(item: DataTransferItem): File | null {
@@ -1638,8 +1636,8 @@ function handleCommand(line: string, networkId: number, target: string): boolean
   align-items: flex-start;
   gap: 1ch;
   padding: 8px 12px;
-  /* Anchors the NickSuggestionStrip's `position: absolute; bottom: 100%`
-     so it floats just above this form, over the StatusBar. */
+  /* Containing block for the desktop NickPicker's anchor logic — the
+     position:fixed picker still reads coordinates off the form. */
   position: relative;
 }
 .input.drag-over {
@@ -1691,13 +1689,6 @@ function handleCommand(line: string, networkId: number, target: string): boolean
 }
 .file-hidden {
   display: none;
-}
-/* Emoji suggester chip body — the glyph leads, the `:shortcode:` trails as a
-   muted label so two near-identical emoji stay distinguishable. Styled here
-   (not in SuggestionStrip) because slot content carries this component's
-   scope. */
-.emoji-name {
-  opacity: 0.6;
 }
 textarea {
   flex: 1;

--- a/vue_client/src/components/MircColorPicker.vue
+++ b/vue_client/src/components/MircColorPicker.vue
@@ -181,10 +181,10 @@ function apply(): void {
 </script>
 
 <style scoped>
-/* Anchored to the bottom-right of StatusBar's .status-wrap, so the picker
-   pops up out of the bar toward the message list (extending upward, since
-   the bar's content area is short). The 6px bottom offset gives a small
-   gap between the picker and the composer underneath. */
+/* Anchored to StatusBar's bottom-right, so the picker pops up out of the
+   bar toward the message list (extending upward, since the bar's content
+   area is short). The 6px bottom offset gives a small gap between the
+   picker and the composer underneath. */
 .mirc-picker {
   position: absolute;
   right: 12px;

--- a/vue_client/src/components/MircColorPicker.vue
+++ b/vue_client/src/components/MircColorPicker.vue
@@ -181,11 +181,14 @@ function apply(): void {
 </script>
 
 <style scoped>
+/* Anchored to the bottom-right of StatusBar's .status-wrap, so the picker
+   pops up out of the bar toward the message list (extending upward, since
+   the bar's content area is short). The 6px bottom offset gives a small
+   gap between the picker and the composer underneath. */
 .mirc-picker {
   position: absolute;
   right: 12px;
-  bottom: 100%;
-  margin-bottom: 6px;
+  bottom: 6px;
   background: var(--bg);
   border: 1px solid var(--border);
   padding: 6px;

--- a/vue_client/src/components/NickPicker.vue
+++ b/vue_client/src/components/NickPicker.vue
@@ -10,13 +10,23 @@
     class="nick-picker"
     :style="panelStyle"
     @pointerdown.stop
+    @mousedown.prevent.stop
   >
+    <!-- iOS keyboard preservation, same rationale as NickSuggestionStrip:
+         fire on `click` (end of touch), keep `@mousedown.prevent` on the row
+         so focus never leaves the textarea, and use a plain <div role=button>
+         rather than a focusable <button>. Emitting on pointerdown would close
+         the picker (v-if) mid-touch, sending the synthesized mousedown to
+         whatever lands underneath and defeating @mousedown.prevent — that's
+         what was stealing iOS focus before. -->
     <div
       v-for="row in renderedRows"
       :key="row.lc + ':' + row.index"
+      role="button"
       class="row"
       :class="{ active: row.index === activeIndex }"
-      @pointerdown.prevent="pick(row.nick)"
+      @mousedown.prevent
+      @click="pick(row.nick)"
       @mouseenter="activeIndex = row.index"
     >
       <span class="nick" :style="row.color ? { color: row.color } : null">{{ row.nick }}</span>

--- a/vue_client/src/components/NickSuggestionStrip.vue
+++ b/vue_client/src/components/NickSuggestionStrip.vue
@@ -82,7 +82,7 @@ const rows = computed(() => {
 /* Overlays StatusBar's row with the same chrome — same padding, same
    border-top, same background as the shell — so the bar visually disappears
    under the strip while it's active. Positioned absolute to fill the
-   parent .status-wrap (StatusBar's positioning container). */
+   parent .status-bar (StatusBar's component root). */
 .nick-suggestion-strip {
   position: absolute;
   inset: 0;

--- a/vue_client/src/components/NickSuggestionStrip.vue
+++ b/vue_client/src/components/NickSuggestionStrip.vue
@@ -79,14 +79,13 @@ const rows = computed(() => {
 </script>
 
 <style scoped>
-/* Mirrors StatusBar's row so this strip reads as the same chrome with its
-   contents swapped — same padding, same border-top, same background as the
-   shell so it cleanly covers the bar underneath. */
+/* Overlays StatusBar's row with the same chrome — same padding, same
+   border-top, same background as the shell — so the bar visually disappears
+   under the strip while it's active. Positioned absolute to fill the
+   parent .status-wrap (StatusBar's positioning container). */
 .nick-suggestion-strip {
   position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 100%;
+  inset: 0;
   display: flex;
   align-items: center;
   gap: 1ch;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -4,8 +4,8 @@
 -->
 
 <template>
-  <div v-if="active" class="status-wrap">
-    <div class="status-bar" :class="{ compact }">
+  <div v-if="active" class="status-bar">
+    <div class="bar" :class="{ compact }">
       <span v-if="!compact" class="seg clock">{{ clock }}</span>
       <span v-if="!compact" class="seg buffer"
         ><template v-if="targetLabel"
@@ -336,15 +336,17 @@ function onReturnToPresent() {
 </script>
 
 <style scoped>
-/* Positioning context for the composer overlays. The wrap has no chrome of
-   its own — it's just there so the strips can pin to .status-bar's bounds
-   via `position: absolute; inset: 0;` and the colour picker can anchor to
-   the wrap's bottom-right with overflow no longer in the way. */
-.status-wrap {
+/* The component root carries no chrome of its own — it's a positioning
+   context so the strips can pin to the inner bar via `position: absolute;
+   inset: 0;` and the colour picker can anchor to the bottom-right without
+   the inner row's `overflow: hidden` clipping it. Keeping the `.status-bar`
+   class on the root preserves the contract with consumers' scoped-CSS
+   selectors (DesktopChat's grid placement, MobileChat's flex sizing). */
+.status-bar {
   position: relative;
   flex: 0 0 auto;
 }
-.status-bar {
+.bar {
   display: flex;
   align-items: center;
   gap: 1ch;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -4,48 +4,88 @@
 -->
 
 <template>
-  <div v-if="active" class="status-bar" :class="{ compact }">
-    <span v-if="!compact" class="seg clock">{{ clock }}</span>
-    <span v-if="!compact" class="seg buffer"
-      ><template v-if="targetLabel"
-        ><span v-if="networkLabel" class="net">{{ networkLabel }}/</span
-        ><span class="name">{{ targetLabel }}</span></template
-      ><span v-else class="name">{{ networkLabel }}</span
-      ><span v-if="modeSuffix" class="modes">{{ modeSuffix }}</span></span
-    >
-    <span v-if="compact" class="seg self"
-      ><span class="name">{{ promptLabel }}</span
-      ><span v-if="awayLabel" class="away">&nbsp;{{ awayLabel }}</span></span
-    >
-    <!-- Detached-jump indicator. Sits adjacent to the self/nick segment on
+  <div v-if="active" class="status-wrap">
+    <div class="status-bar" :class="{ compact }">
+      <span v-if="!compact" class="seg clock">{{ clock }}</span>
+      <span v-if="!compact" class="seg buffer"
+        ><template v-if="targetLabel"
+          ><span v-if="networkLabel" class="net">{{ networkLabel }}/</span
+          ><span class="name">{{ targetLabel }}</span></template
+        ><span v-else class="name">{{ networkLabel }}</span
+        ><span v-if="modeSuffix" class="modes">{{ modeSuffix }}</span></span
+      >
+      <span v-if="compact" class="seg self"
+        ><span class="name">{{ promptLabel }}</span
+        ><span v-if="awayLabel" class="away">&nbsp;{{ awayLabel }}</span></span
+      >
+      <!-- Detached-jump indicator. Sits adjacent to the self/nick segment on
          compact (mobile) per agreed placement, where it's the only exit
          from a detached buffer back to live. On desktop seg.self is hidden,
          so this lands right after the buffer name — also a natural spot.
          Unlike [N new ↓] (which is hidden on compact), this button renders
          in both modes. -->
-    <button v-if="detached" class="seg return-present" type="button" @click="onReturnToPresent">
-      Return to present<template v-if="liveDuringDetach > 0">
-        ({{ liveDuringDetach }} new)</template
+      <button v-if="detached" class="seg return-present" type="button" @click="onReturnToPresent">
+        Return to present<template v-if="liveDuringDetach > 0">
+          ({{ liveDuringDetach }} new)</template
+        >
+        ↓
+      </button>
+      <span v-if="peerStatusLabel" class="seg peer-status" :class="peerStatusClass">{{
+        peerStatusLabel
+      }}</span>
+      <span v-if="lagLabel && !compact" class="seg lag" :class="lagClass">{{ lagLabel }}</span>
+      <span v-if="uploadLabel" class="seg upload" :class="{ failed: uploads.failedAt }">{{
+        uploadLabel
+      }}</span>
+      <button
+        v-if="newBelow > 0 && !compact"
+        class="seg jump"
+        type="button"
+        @click="onJumpToBottom"
       >
-      ↓
-    </button>
-    <span v-if="peerStatusLabel" class="seg peer-status" :class="peerStatusClass">{{
-      peerStatusLabel
-    }}</span>
-    <span v-if="lagLabel && !compact" class="seg lag" :class="lagClass">{{ lagLabel }}</span>
-    <span v-if="uploadLabel" class="seg upload" :class="{ failed: uploads.failedAt }">{{
-      uploadLabel
-    }}</span>
-    <button v-if="newBelow > 0 && !compact" class="seg jump" type="button" @click="onJumpToBottom">
-      {{ newBelow }} new ↓
-    </button>
-    <span v-if="splitLabel" class="seg split" :class="splitClass">{{ splitLabel }}</span>
-    <span v-if="typingSegments.length" class="seg typing"
-      >Typing:
-      <template v-for="(seg, i) in typingSegments" :key="i"
-        ><span :style="seg.color ? { color: seg.color } : null">{{ seg.text }}</span></template
-      ></span
+        {{ newBelow }} new ↓
+      </button>
+      <span v-if="splitLabel" class="seg split" :class="splitClass">{{ splitLabel }}</span>
+      <span v-if="typingSegments.length" class="seg typing"
+        >Typing:
+        <template v-for="(seg, i) in typingSegments" :key="i"
+          ><span :style="seg.color ? { color: seg.color } : null">{{ seg.text }}</span></template
+        ></span
+      >
+    </div>
+    <!-- Composer overlays — the nick/emoji suggestion strips replace the bar's
+         content while active (same chrome, swapped contents); the mIRC colour
+         picker pops up from the bar's bottom edge. State and the "where the
+         pick gets applied" logic live in useComposerOverlay so MessageInput
+         (which owns the textarea) and StatusBar (which renders the popover)
+         stay decoupled. -->
+    <NickSuggestionStrip
+      v-show="overlay.nickOpen"
+      :query="overlay.nickQuery"
+      :buffer="buffer"
+      :self-nick="ownNick"
+      @select="selectNick"
+    />
+    <SuggestionStrip
+      v-show="overlay.emojiOpen"
+      :items="overlay.emojiItems"
+      :key-for="emojiKeyFor"
+      :active-index="overlay.emojiActiveIndex"
+      @select="selectEmoji"
+      @hover="setEmojiActive"
     >
+      <template #chip="{ item }">
+        <span class="emoji-glyph">{{ item.emoji }}</span>
+        <span class="emoji-name">:{{ item.name }}:</span>
+      </template>
+    </SuggestionStrip>
+    <MircColorPicker
+      v-if="overlay.colorPickerOpen"
+      :open="overlay.colorPickerOpen"
+      @apply="applyColor"
+      @reset="resetColor"
+      @close="closeColorPicker"
+    />
   </div>
 </template>
 
@@ -62,6 +102,19 @@ import { useComposing } from '../composables/useComposing.js';
 import { useSelfLabel } from '../composables/useSelfLabel.js';
 import { formatTimestamp } from '../utils/timestamp.js';
 import { isPeerOffline, isPeerAway } from '../utils/peerPresence.js';
+import NickSuggestionStrip from './NickSuggestionStrip.vue';
+import SuggestionStrip from './SuggestionStrip.vue';
+import MircColorPicker from './MircColorPicker.vue';
+import {
+  useComposerOverlay,
+  selectNick,
+  selectEmoji,
+  setEmojiActive,
+  applyColor,
+  resetColor,
+  closeColorPicker,
+} from '../composables/useComposerOverlay.js';
+import type { EmojiMatch } from '../utils/emojiData.js';
 
 withDefaults(
   defineProps<{
@@ -110,6 +163,18 @@ const { newBelow } = useScrollState();
 
 const active = computed(() => networks.activeBuffer);
 const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
+
+// Composer-overlay state and the props the popovers need. ownNick and
+// `buffer` aren't routed through the composable because they're always the
+// active buffer / network's — derive them here from the same stores
+// MessageInput reads.
+const overlay = useComposerOverlay();
+const ownNick = computed(() => {
+  const a = active.value;
+  if (!a) return '';
+  return networks.states[a.networkId]?.nick || '';
+});
+const emojiKeyFor = (m: EmojiMatch): string => m.name;
 
 const isServerBuffer = computed(() => !!active.value?.target?.startsWith(':server:'));
 const isChannel = computed(() => !!active.value?.target?.startsWith('#'));
@@ -271,6 +336,14 @@ function onReturnToPresent() {
 </script>
 
 <style scoped>
+/* Positioning context for the composer overlays. The wrap has no chrome of
+   its own — it's just there so the strips can pin to .status-bar's bounds
+   via `position: absolute; inset: 0;` and the colour picker can anchor to
+   the wrap's bottom-right with overflow no longer in the way. */
+.status-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
 .status-bar {
   display: flex;
   align-items: center;
@@ -364,5 +437,11 @@ function onReturnToPresent() {
 .seg.jump:hover,
 .seg.return-present:hover {
   color: var(--fg);
+}
+/* Emoji suggester chip body — the glyph leads, the `:shortcode:` trails
+   muted so two near-identical emoji stay distinguishable. Styled here (not
+   in SuggestionStrip) because slot content carries this component's scope. */
+.emoji-name {
+  opacity: 0.6;
 }
 </style>

--- a/vue_client/src/components/SuggestionStrip.vue
+++ b/vue_client/src/components/SuggestionStrip.vue
@@ -124,9 +124,9 @@ watch(
      would then push the emoji glyph above the StatusBar's text baseline. */
   padding: 0 6px;
   /* Emoji glyphs sit higher in their line box than letter forms — even
-     with the chip's box centered, the glyph reads ~2px above the bar's
-     text baseline. Nudge the whole chip down to compensate. */
-  transform: translateY(2px);
+     with the chip's box centered, the glyph reads above the bar's text
+     baseline. Nudge the whole chip down to compensate. */
+  transform: translateY(1px);
   font: inherit;
   color: var(--fg);
   cursor: pointer;

--- a/vue_client/src/components/SuggestionStrip.vue
+++ b/vue_client/src/components/SuggestionStrip.vue
@@ -85,7 +85,7 @@ watch(
 /* Overlays StatusBar's row with the same chrome — same padding, same
    border-top, same background — so the bar visually disappears under the
    strip while it's active. Positioned absolute to fill the parent
-   .status-wrap (StatusBar's positioning container). */
+   .status-bar (StatusBar's component root). */
 .suggestion-strip {
   position: absolute;
   inset: 0;

--- a/vue_client/src/components/SuggestionStrip.vue
+++ b/vue_client/src/components/SuggestionStrip.vue
@@ -119,7 +119,10 @@ watch(
   gap: 0.5ch;
   background: none;
   border: none;
-  padding: 2px 6px;
+  /* Horizontal padding only — vertical padding would make the chip taller
+     than the nick strip's chips, and `align-items: center` on the strip
+     would then push the emoji glyph above the StatusBar's text baseline. */
+  padding: 0 6px;
   font: inherit;
   color: var(--fg);
   cursor: pointer;

--- a/vue_client/src/components/SuggestionStrip.vue
+++ b/vue_client/src/components/SuggestionStrip.vue
@@ -123,10 +123,6 @@ watch(
      than the nick strip's chips, and `align-items: center` on the strip
      would then push the emoji glyph above the StatusBar's text baseline. */
   padding: 0 6px;
-  /* Emoji glyphs sit higher in their line box than letter forms — even
-     with the chip's box centered, the glyph reads above the bar's text
-     baseline. Nudge the whole chip down to compensate. */
-  transform: translateY(1px);
   font: inherit;
   color: var(--fg);
   cursor: pointer;

--- a/vue_client/src/components/SuggestionStrip.vue
+++ b/vue_client/src/components/SuggestionStrip.vue
@@ -123,6 +123,10 @@ watch(
      than the nick strip's chips, and `align-items: center` on the strip
      would then push the emoji glyph above the StatusBar's text baseline. */
   padding: 0 6px;
+  /* Emoji glyphs sit higher in their line box than letter forms — even
+     with the chip's box centered, the glyph reads ~2px above the bar's
+     text baseline. Nudge the whole chip down to compensate. */
+  transform: translateY(2px);
   font: inherit;
   color: var(--fg);
   cursor: pointer;

--- a/vue_client/src/components/SuggestionStrip.vue
+++ b/vue_client/src/components/SuggestionStrip.vue
@@ -4,16 +4,16 @@
 -->
 
 <!--
-  Generic horizontal suggestion strip that floats over the StatusBar — the
+  Generic horizontal suggestion strip rendered as a StatusBar overlay — the
   IRCCloud-style autocomplete bar. Visually it mirrors NickSuggestionStrip
-  (same chrome as the bar it covers); behaviourally it adds keyboard
-  navigation, exposing the same `moveActive` / `confirmActive` /
-  `hasCandidates` interface as the desktop NickPicker so a host's textarea
-  keydown handler can drive it.
+  (same chrome as the bar it covers); behaviourally it's keyboard-navigable
+  via an externally-owned activeIndex so the host's keydown handler can
+  drive it without an imperative ref.
 
-  The strip is content-agnostic: callers pass an `items` array and a `keyFor`
-  function, and render each chip's body through the `chip` slot. The emoji
-  suggester is the first consumer; NickSuggestionStrip could later adopt it.
+  The strip is content-agnostic: callers pass an `items` array, a `keyFor`
+  function, and the current `activeIndex`, and render each chip's body
+  through the `chip` slot. The emoji suggester is the first consumer;
+  NickSuggestionStrip could later adopt it.
 -->
 
 <template>
@@ -36,7 +36,7 @@
       :class="{ active: i === activeIndex }"
       @mousedown.prevent
       @click="emit('select', item)"
-      @mouseenter="activeIndex = i"
+      @mouseenter="emit('hover', i)"
     >
       <slot name="chip" :item="item" />
     </div>
@@ -47,66 +47,48 @@
 import { ref, watch, nextTick } from 'vue';
 
 const props = defineProps<{
-  items: T[];
+  /** Readonly so a reactive readonly source (e.g. useComposerOverlay) can
+      be passed through without a cast — the strip never mutates it. */
+  items: readonly T[];
   /** Stable :key for each item — the strip is content-agnostic. */
   keyFor: (item: T) => string;
+  /** Highlighted chip; the host owns the index so keyboard nav lives
+      outside this component. */
+  activeIndex: number;
 }>();
 
 const emit = defineEmits<{
   select: [item: T];
+  /** Mouse hover claimed a chip — host updates activeIndex so mouse and
+      keyboard share the same highlight. */
+  hover: [index: number];
 }>();
 
-// The highlighted chip. Keyboard nav (driven by the host's keydown handler)
-// walks this; hovering a chip with the mouse adopts it too, so the two input
-// modes share one highlight and can't disagree.
-const activeIndex = ref(0);
 const rootEl = ref<HTMLElement | null>(null);
 
-// A changed candidate set restarts the highlight at the first chip: a fresh
-// query shouldn't inherit a stale position, and a shrunk list shouldn't
-// strand the index past the end.
+// When the host shifts activeIndex via keyboard nav, pull the chip into
+// view if the row has overflowed horizontally. Watching the prop keeps the
+// strip declarative — no imperative ref method needed.
 watch(
-  () => props.items,
+  () => props.activeIndex,
   () => {
-    activeIndex.value = 0;
+    nextTick(() => {
+      rootEl.value
+        ?.querySelector('.chip.active')
+        ?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    });
   },
 );
-
-// `delta` is in chip-index space — +1 steps to the next chip, -1 to the
-// previous — and wraps at both ends so a held arrow cycles the whole row.
-function moveActive(delta: number): void {
-  const n = props.items.length;
-  if (n === 0) return;
-  activeIndex.value = (activeIndex.value + delta + n) % n;
-  // The strip scrolls horizontally once the candidates overflow; pull a
-  // keyboard-selected chip back into view.
-  nextTick(() => {
-    rootEl.value
-      ?.querySelector('.chip.active')
-      ?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-  });
-}
-
-function confirmActive(): void {
-  const item = props.items[activeIndex.value];
-  if (item !== undefined) emit('select', item);
-}
-
-function hasCandidates(): boolean {
-  return props.items.length > 0;
-}
-
-defineExpose({ moveActive, confirmActive, hasCandidates });
 </script>
 
 <style scoped>
-/* Mirrors NickSuggestionStrip / StatusBar — same padding, border-top and
-   background as the shell, so it cleanly covers the bar underneath. */
+/* Overlays StatusBar's row with the same chrome — same padding, same
+   border-top, same background — so the bar visually disappears under the
+   strip while it's active. Positioned absolute to fill the parent
+   .status-wrap (StatusBar's positioning container). */
 .suggestion-strip {
   position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 100%;
+  inset: 0;
   display: flex;
   align-items: center;
   gap: 1ch;
@@ -148,9 +130,9 @@ defineExpose({ moveActive, confirmActive, hasCandidates });
 /* Highlight matches a selected buffer row in the buffer list — a flat
    --bg-soft fill with square edges — so the suggester reads as the same kind
    of selection affordance used elsewhere. Single rule shared by mouse and
-   keyboard: hovering sets activeIndex (see @mouseenter), so `.active` alone
-   covers both with no separate :hover rule that could double-highlight during
-   keyboard nav. */
+   keyboard: hovering emits `hover` (see @mouseenter) which the host maps to
+   activeIndex, so `.active` alone covers both with no separate :hover rule
+   that could double-highlight during keyboard nav. */
 .chip.active {
   background: var(--bg-soft);
 }

--- a/vue_client/src/composables/useComposerOverlay.ts
+++ b/vue_client/src/composables/useComposerOverlay.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Cross-component state for the composer's overlay popovers — the nick and
+// emoji suggestion strips and the mIRC colour picker. They live in
+// StatusBar's DOM (visually they overlay the bar) but their state and the
+// "what to do when the user picks" logic belong with MessageInput (which
+// owns the textarea content). Same module-level singleton shape as
+// useComposing — there is only ever one composer on screen at a time.
+
+import { reactive, readonly, type DeepReadonly } from 'vue';
+import type { EmojiMatch } from '../utils/emojiData.js';
+
+export interface ComposerOverlayState {
+  // Nick suggestion strip — mobile by default, opt-in on desktop. The buffer
+  // and self-nick the strip needs are derived by the renderer from the
+  // active-buffer stores; they're always the active buffer's, so there's no
+  // need to pipe them through this state.
+  nickOpen: boolean;
+  nickQuery: string;
+  // Emoji `:shortcode:` strip.
+  emojiOpen: boolean;
+  emojiItems: EmojiMatch[];
+  emojiActiveIndex: number;
+  // mIRC colour picker.
+  colorPickerOpen: boolean;
+}
+
+const state = reactive<ComposerOverlayState>({
+  nickOpen: false,
+  nickQuery: '',
+  emojiOpen: false,
+  emojiItems: [],
+  emojiActiveIndex: 0,
+  colorPickerOpen: false,
+});
+
+type NickSelectHandler = (nick: string) => void;
+type EmojiSelectHandler = (item: EmojiMatch) => void;
+type ColorApplyHandler = (fg: string | null, bg: string | null) => void;
+type VoidHandler = () => void;
+
+// Handlers MessageInput registers on mount. Defaults are no-ops so a pick
+// before registration is dropped silently rather than crashing.
+let onNickSelect: NickSelectHandler = () => {};
+let onEmojiSelect: EmojiSelectHandler = () => {};
+let onColorApply: ColorApplyHandler = () => {};
+let onColorReset: VoidHandler = () => {};
+let onColorClose: VoidHandler = () => {};
+
+export interface ComposerOverlayHandlers {
+  onNickSelect?: NickSelectHandler;
+  onEmojiSelect?: EmojiSelectHandler;
+  onColorApply?: ColorApplyHandler;
+  onColorReset?: VoidHandler;
+  onColorClose?: VoidHandler;
+}
+
+export function setComposerOverlayHandlers(h: ComposerOverlayHandlers): void {
+  if (h.onNickSelect) onNickSelect = h.onNickSelect;
+  if (h.onEmojiSelect) onEmojiSelect = h.onEmojiSelect;
+  if (h.onColorApply) onColorApply = h.onColorApply;
+  if (h.onColorReset) onColorReset = h.onColorReset;
+  if (h.onColorClose) onColorClose = h.onColorClose;
+}
+
+export function setNickStrip(open: boolean, query = ''): void {
+  state.nickOpen = open;
+  state.nickQuery = query;
+}
+
+export function setEmojiStrip(open: boolean, items: EmojiMatch[] = []): void {
+  state.emojiOpen = open;
+  state.emojiItems = items;
+  state.emojiActiveIndex = 0;
+}
+
+export function setColorPickerOpen(open: boolean): void {
+  state.colorPickerOpen = open;
+}
+
+// Emoji-strip keyboard navigation, driven from MessageInput's keydown.
+// Wraps at both ends so a held arrow cycles the whole row.
+export function moveEmojiActive(delta: number): void {
+  const n = state.emojiItems.length;
+  if (n === 0) return;
+  state.emojiActiveIndex = (state.emojiActiveIndex + delta + n) % n;
+}
+
+export function setEmojiActive(index: number): void {
+  if (index >= 0 && index < state.emojiItems.length) state.emojiActiveIndex = index;
+}
+
+export function confirmEmojiActive(): void {
+  const item = state.emojiItems[state.emojiActiveIndex];
+  if (item !== undefined) onEmojiSelect(item);
+}
+
+export function hasEmojiCandidates(): boolean {
+  return state.emojiItems.length > 0;
+}
+
+// Renderer-side dispatchers — bound by StatusBar's popover event handlers,
+// route back through the registered MessageInput callbacks.
+export function selectNick(nick: string): void {
+  onNickSelect(nick);
+}
+export function selectEmoji(item: EmojiMatch): void {
+  onEmojiSelect(item);
+}
+export function applyColor(fg: string | null, bg: string | null): void {
+  onColorApply(fg, bg);
+}
+export function resetColor(): void {
+  onColorReset();
+}
+export function closeColorPicker(): void {
+  onColorClose();
+}
+
+export function useComposerOverlay(): DeepReadonly<ComposerOverlayState> {
+  return readonly(state);
+}


### PR DESCRIPTION
Closes #130 
Closes #127 

## Summary

Fixes the nick suggester (#130) and the mIRC colour picker (#127) not appearing on mobile. Both were positioned `bottom: 100%` inside MessageInput's form, which is wrapped by `.composer-host` (overflow-y: scroll, the iOS keyboard scroll-target trick added in #126). That wrapper clips everything overflowing upward, so neither popover was ever visible.

Rather than fight the overflow with Teleports or wrapper gymnastics, the popovers move into StatusBar where they belong architecturally — they were always overlays of that row, sharing its chrome and position. State and the "apply the pick to the textarea" logic stay with MessageInput via a new \`useComposerOverlay\` composable (same module-level singleton shape as the existing \`useComposing\`).

Also enables the desktop @-picker on mobile **concurrent with** the suggestion strip:
- Type \`@foo\` → vertical @-picker (same as desktop).
- Type bare \`foo\` (2+ chars) → horizontal strip across the StatusBar.
- Each branch closes the other across transitions so backspacing the \`@\` doesn't leak a stale picker.

NickPicker's row taps move to the same \`@mousedown.prevent\` + \`@click\` pattern the strip chips use, so iOS keeps the soft keyboard up when picking a nick.

## Files

- **new** \`useComposerOverlay.ts\` — reactive state + setters + dispatchers for the three popovers.
- \`MessageInput.vue\` — popover components and their local refs removed; calls into the composable, registers handlers on mount, closes overlays on unmount.
- \`StatusBar.vue\` — now hosts the three popovers under a new \`.status-wrap\` positioning context.
- \`NickSuggestionStrip.vue\`, \`SuggestionStrip.vue\`, \`MircColorPicker.vue\` — positioning updated to anchor to \`.status-wrap\` (overlay-style); SuggestionStrip is now presentational with \`activeIndex\` as a prop.
- \`NickPicker.vue\` — iOS focus-preservation fix for row taps.
- \`settingsRegistry.ts\` — drop a stale sentence in the desktop strip-toggle description that referenced mobile being strip-only.

## Test plan

- [ ] iOS Safari (mobile viewport): type 2+ chars without \`@\` → horizontal strip appears over StatusBar, tap a chip → keyboard stays up, nick inserts.
- [ ] iOS Safari: type \`@\` then a prefix → vertical @-picker appears above the textarea, tap a row → keyboard stays up, nick inserts.
- [ ] iOS Safari: type \`@\`, then backspace it → picker closes.
- [ ] iOS Safari: \`:smile:\`-style emoji suggester opens, tap a chip → inserts emoji, keyboard stays up.
- [ ] iOS Safari: enable \`input.show_format_button\`, tap the palette icon → colour picker appears above the input bar, applying inserts the code and keyboard stays up.
- [ ] Desktop: no behavior change by default (picker still @-triggered, strip opt-in via \`input.suggestion_strip_on_desktop\`).
- [ ] Switch buffers while a strip / picker is open → state clears on the new buffer.
- [ ] Switch to system console and back → no stale overlay survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)