### PR TITLE
Fix compact timestamp collapse and buffer-list hover priority

### DIFF
--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -77,7 +77,7 @@
                 unreadLabel(countFor(buf.unread, buf.highlighted))
               }}</span>
               <button
-                v-if="!isServerBuffer(buf)"
+                v-if="!isServerBuffer(buf) && !hasUnreadIndicator(buf)"
                 type="button"
                 class="row-actions"
                 title="Actions"
@@ -125,7 +125,7 @@
               unreadLabel(countFor(buf.unread, buf.highlighted))
             }}</span>
             <button
-              v-if="!isServerBuffer(buf)"
+              v-if="!isServerBuffer(buf) && !hasUnreadIndicator(buf)"
               type="button"
               class="row-actions"
               title="Actions"
@@ -206,6 +206,16 @@ function countFor(unread: number, highlights: number): number {
   if (unreadDisplay.value === 'full') return unread;
   if (unreadDisplay.value === 'highlights') return highlights;
   return 0;
+}
+
+// Hover-revealed kebab lives in the same right-edge slot as the unread/
+// highlight badges. When the row has unread state, the badge wins — the
+// kebab stays hidden so it doesn't overlay the indicator the user is
+// scanning for. Right-click on the row still opens the same action menu.
+function hasUnreadIndicator(buf: Buffer): boolean {
+  return (
+    (buf.highlighted > 0 && showHighlightBadge.value) || countFor(buf.unread, buf.highlighted) > 0
+  );
 }
 
 // Per-network local mirror of the pinned buffer list, kept as concrete buffer

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -628,15 +628,13 @@ const renderRows = computed((): RenderRow[] => {
   // Per-row display collapsing (nick + timestamp dedupe). Runs over the same
   // row shape consolidateRows emits and tags rows in place — the template
   // checks row.continuationAuthor / row.continuationTime to render empty
-  // prefix/time cells (subgrid stays aligned). compactMode tells the util
-  // to skip hidden continuation rows when tracking the time chain.
+  // prefix/time cells (subgrid stays aligned).
   if (effectiveCollapseAuthors.value || effectiveCollapseTimestamps.value) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     collapseDisplay(final as any, {
       collapseAuthors: effectiveCollapseAuthors.value,
       authorWindowMs: collapseAuthorsWindowMs.value,
       collapseTimestamps: effectiveCollapseTimestamps.value,
-      compactMode: compactMode.value,
       formatTime: (iso) => time(iso),
     });
   }

--- a/vue_client/src/utils/collapseDisplay.test.ts
+++ b/vue_client/src/utils/collapseDisplay.test.ts
@@ -213,13 +213,12 @@ describe('collapseDisplay — timestamp collapsing', () => {
   });
 });
 
-describe('collapseDisplay — compact-mode time-chain skip', () => {
-  it('skips hidden continuation message rows when tracking the time chain', () => {
-    // In compact mode the second message hides its head (continuationAuthor=true
-    // for same nick within window), so its time isn't displayed. The third row
-    // is from a different nick — its time should compare against row 0's time
-    // (still displayed), not row 1's hidden time. With the same minute key for
-    // all three, the third row collapses against row 0 ⇒ continuationTime.
+describe('collapseDisplay — continuation rows participate in time chain', () => {
+  // continuationAuthor rows still render their own time span in the template
+  // (compact mode's head omission only hides the nick — the body row keeps a
+  // right-aligned time). So the time chain must track them like any other
+  // visible row, otherwise repeated timestamps fail to collapse.
+  it('flags continuationAuthor rows as continuationTime when times match', () => {
     const rows = [
       msg({ id: 1, nick: 'alice', time: '2026-05-16T10:00:00Z' }),
       msg({ id: 2, nick: 'alice', time: '2026-05-16T10:00:30Z' }),
@@ -229,36 +228,6 @@ describe('collapseDisplay — compact-mode time-chain skip', () => {
       collapseAuthors: true,
       authorWindowMs: 5 * 60_000,
       collapseTimestamps: true,
-      compactMode: true,
-      formatTime: minuteFormat,
-    });
-    expect(rows[0].continuationAuthor).toBeUndefined();
-    expect(rows[1].continuationAuthor).toBe(true);
-    expect(rows[2].continuationAuthor).toBeUndefined();
-    // Time chain: row 0 set baseline, row 1 skipped (hidden head),
-    // row 2 displayed time matches row 0 → continuationTime.
-    expect(rows[0].continuationTime).toBeUndefined();
-    expect(rows[1].continuationTime).toBeUndefined();
-    expect(rows[2].continuationTime).toBe(true);
-  });
-
-  it('without compactMode the same scenario tracks the hidden row in the chain', () => {
-    // Regression guard: in standard mode the continuation row still occupies
-    // the .time cell as an empty span; the util treats it as "would display
-    // empty" — but timeStr is the formatted string, not '' — so prevTimeStr
-    // gets updated. Row 2's continuationTime is set against row 1's tracked
-    // time (which equals row 0's, so still true here — but the chain went
-    // through row 1, exercising the non-compact path).
-    const rows = [
-      msg({ id: 1, nick: 'alice', time: '2026-05-16T10:00:00Z' }),
-      msg({ id: 2, nick: 'alice', time: '2026-05-16T10:00:30Z' }),
-      msg({ id: 3, nick: 'bob', time: '2026-05-16T10:00:45Z' }),
-    ];
-    collapseDisplay(rows, {
-      collapseAuthors: true,
-      authorWindowMs: 5 * 60_000,
-      collapseTimestamps: true,
-      compactMode: false,
       formatTime: minuteFormat,
     });
     expect(rows[1].continuationAuthor).toBe(true);

--- a/vue_client/src/utils/collapseDisplay.ts
+++ b/vue_client/src/utils/collapseDisplay.ts
@@ -49,7 +49,6 @@ export interface CollapseOptions {
   collapseTimestamps?: boolean;
   formatTime?: (iso: string | undefined) => string;
   authorWindowMs?: number;
-  compactMode?: boolean;
 }
 
 export function collapseDisplay(rows: DisplayRow[], options: CollapseOptions = {}): DisplayRow[] {
@@ -59,12 +58,6 @@ export function collapseDisplay(rows: DisplayRow[], options: CollapseOptions = {
 
   const formatTime = options.formatTime || ((): string => '');
   const authorWindowMs = Math.max(0, options.authorWindowMs ?? 0);
-  // In compact mode a message row tagged continuationAuthor hides its entire
-  // head (nick + time both disappear), so it must not participate in the
-  // time chain — otherwise the next visible time could be over-suppressed,
-  // or a head's time could be cleared because a hidden continuation row
-  // happened to match it.
-  const compactMode = !!options.compactMode;
 
   let prevAuthorKey: string | null = null;
   let prevAuthorTimeMs: number | null = null;
@@ -104,14 +97,11 @@ export function collapseDisplay(rows: DisplayRow[], options: CollapseOptions = {
     }
 
     if (collapseTimestamps) {
-      const timeHidden = compactMode && row.continuationAuthor;
-      if (!timeHidden) {
-        if (prevTimeSeen && prevTimeStr === timeStr && timeStr !== '') {
-          row.continuationTime = true;
-        }
-        prevTimeStr = timeStr;
-        prevTimeSeen = true;
+      if (prevTimeSeen && prevTimeStr === timeStr && timeStr !== '') {
+        row.continuationTime = true;
       }
+      prevTimeStr = timeStr;
+      prevTimeSeen = true;
     }
   }
 


### PR DESCRIPTION
## Summary

- **#124** — In compact mode with `collapse_timestamps` on, repeated timestamps weren't collapsing. `collapseDisplay` was skipping `continuationAuthor` rows from the time chain on the false premise that the template hides their time. The body row keeps a right-aligned time regardless; only the head (nick) is suppressed. Drop the compact-mode guard so every visible time participates in the chain.
- **#123** — Hide the hover-revealed kebab in the buffer list when a row has unread or highlight state, so the badge stays visible. Right-click on the row still opens the same action menu.

Closes #124
Closes #123

## Test plan

- [x] Compact mode + Collapse timestamps on: three same-minute messages render the time once on the first row, blank on subsequent rows
- [x] Standard mode unchanged
- [x] Buffer list: hovering a buffer with unread/highlight badge keeps the badge visible (no kebab overlay)
- [x] Buffer list: hovering a buffer with no unread reveals the kebab as before
- [x] Right-click on an unread buffer still opens the action menu
- [x] All 645 vitest tests pass
- [x] `npm run check` clean (typecheck + lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)