### PR TITLE
Drop server-pushed CHATHISTORY/playback replays

### DIFF
--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -732,6 +732,22 @@ export class IrcConnection {
     });
 
     c.on('message', (event: Record<string, unknown>) => {
+      // Drop server-pushed history replays. Some networks (e.g. Ergo with
+      // `relaymsg`/replay enabled, mansionNET) blindly resend recent messages
+      // inside a CHATHISTORY (or ZNC playback) BATCH on every reconnect.
+      // We don't request the CHATHISTORY cap or command anywhere, so anything
+      // arriving in one of these batches is unsolicited replay — and without
+      // a dedupe path it inserts duplicates carrying the original (past)
+      // server-time. Ignoring the whole batch is the right call.
+      const batch = event.batch as { type?: string } | undefined;
+      const batchType = batch?.type;
+      if (
+        batchType === 'chathistory' ||
+        batchType === 'draft/chathistory' ||
+        batchType === 'znc.in/playback'
+      ) {
+        return;
+      }
       const me = c.user?.nick;
       const eventNick = event.nick as string | undefined;
       const eventTarget = event.target as string | undefined;


### PR DESCRIPTION
## Summary
- Closes #121
- Some networks (Ergo, mansionNET) auto-replay recent messages inside a CHATHISTORY (or ZNC playback) BATCH on every reconnect, even though Lurker never requests the cap or issues the command
- With no dedupe path those messages re-insert into the DB carrying their original server-time, surfacing as duplicates in the buffer
- Filter at the `'message'` handler entry: if `event.batch.type` is `chathistory` / `draft/chathistory` / `znc.in/playback`, drop it before publish/persist

## Test plan
- [ ] Reconnect to mansionNET and confirm no duplicate messages appear in active buffers
- [ ] Reconnect to a network without replay (Libera) and confirm normal messages still arrive
- [ ] If we ever add a real CHATHISTORY request flow, revisit this filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)