### PR TITLE
Standardize hardcoded CSS values into design tokens

### DIFF
--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -15,7 +15,7 @@ Settings UI writes them onto the page live (via `useTheme()`), so changing a
 color in Settings re-themes the whole app instantly. The values in `main.css`
 are just the defaults for the first paint.
 
-**2. Internal tokens** — spacing, z-index, scrim, radius. These are *not* user
+**2. Internal tokens** — spacing, z-index, scrim, radius. These are _not_ user
 settings; they exist purely so the same value isn't retyped in 80 places. They
 are intentionally fixed. (Changing one of these is a code change, not a
 setting.)
@@ -24,14 +24,14 @@ setting.)
 
 ## Color (themeable)
 
-| Token | Role |
-|---|---|
-| `--bg`, `--bg-soft` | page background, raised surfaces |
-| `--fg`, `--fg-muted` | primary text, secondary/de-emphasized text |
-| `--accent` | links, focus, primary highlight |
-| `--good`, `--warn`, `--bad` | success / warning / error |
-| `--border` | hairline borders |
-| `--member-owner/admin/op/halfop/voice` | IRC member-list mode colors |
+| Token                                  | Role                                       |
+| -------------------------------------- | ------------------------------------------ |
+| `--bg`, `--bg-soft`                    | page background, raised surfaces           |
+| `--fg`, `--fg-muted`                   | primary text, secondary/de-emphasized text |
+| `--accent`                             | links, focus, primary highlight            |
+| `--good`, `--warn`, `--bad`            | success / warning / error                  |
+| `--border`                             | hairline borders                           |
+| `--member-owner/admin/op/halfop/voice` | IRC member-list mode colors                |
 
 **Hierarchy is expressed with color and weight, never font size.** There is one
 font size across the whole UI. To make text recede, use `color: var(--fg-muted)`;
@@ -44,13 +44,13 @@ large responsive size.)
 Used for gaps, padding, and margins. Everything should land on one of these
 steps so the layout breathes on a consistent grid.
 
-| Token | px | Token | px |
-|---|---|---|---|
-| `--space-1` | 2 | `--space-6` | 12 |
-| `--space-2` | 4 | `--space-7` | 16 |
-| `--space-3` | 6 | `--space-8` | 20 |
-| `--space-4` | 8 | `--space-9` | 24 |
-| `--space-5` | 10 | `--space-10` | 32 |
+| Token       | px  | Token        | px  |
+| ----------- | --- | ------------ | --- |
+| `--space-1` | 2   | `--space-6`  | 12  |
+| `--space-2` | 4   | `--space-7`  | 16  |
+| `--space-3` | 6   | `--space-8`  | 20  |
+| `--space-4` | 8   | `--space-9`  | 24  |
+| `--space-5` | 10  | `--space-10` | 32  |
 
 (Borders stay a literal `1px`, and a few hairline `1px` paddings in very dense
 rows are deliberate — those aren't on the scale by design.)
@@ -60,24 +60,24 @@ rows are deliberate — those aren't on the scale by design.)
 Named by role, so it's clear what sits above what. Higher in the list = closer
 to the viewer.
 
-| Token | Role |
-|---|---|
-| `--z-base` | in-flow lift (sticky headers, background layers) |
-| `--z-raised` | lifts above sibling content within a component |
-| `--z-modal` | modal / overlay shells (dialogs, quick switcher) |
-| `--z-toast` | toast notifications (above modals, so they stay visible) |
-| `--z-menu` | context menus |
-| `--z-popover` | input autocomplete (nick picker) — top of the stack |
+| Token         | Role                                                     |
+| ------------- | -------------------------------------------------------- |
+| `--z-base`    | in-flow lift (sticky headers, background layers)         |
+| `--z-raised`  | lifts above sibling content within a component           |
+| `--z-modal`   | modal / overlay shells (dialogs, quick switcher)         |
+| `--z-toast`   | toast notifications (above modals, so they stay visible) |
+| `--z-menu`    | context menus                                            |
+| `--z-popover` | input autocomplete (nick picker) — top of the stack      |
 
 ## Radius (internal)
 
 The app is intentionally flat — most things are square corners.
 
-| Token | px | Use |
-|---|---|---|
-| `--radius-sm` | 2 | subtle softening (chips, small buttons) |
-| `--radius-md` | 6 | floating popups |
-| `--radius-pill` | 999 | fully-rounded pills |
+| Token           | px  | Use                                     |
+| --------------- | --- | --------------------------------------- |
+| `--radius-sm`   | 2   | subtle softening (chips, small buttons) |
+| `--radius-md`   | 6   | floating popups                         |
+| `--radius-pill` | 999 | fully-rounded pills                     |
 
 (`50%` is used directly for circles.)
 
@@ -91,10 +91,10 @@ The app is intentionally flat — most things are square corners.
 
 When something looks off, the most actionable feedback names the token:
 
-- *"The buffer-list rows feel cramped — try `--space-5` instead of `--space-4`
-  for the row padding."*
-- *"That label should recede — give it `--fg-muted` rather than a smaller font."*
-- *"The modal corners should be a touch softer — `--radius-md`?"*
+- _"The buffer-list rows feel cramped — try `--space-5` instead of `--space-4`
+  for the row padding."_
+- _"That label should recede — give it `--fg-muted` rather than a smaller font."_
+- _"The modal corners should be a touch softer — `--radius-md`?"_
 
 If a value you want isn't on a scale (e.g. a spacing step between two existing
 ones), that's worth a conversation — we add scale steps deliberately rather

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -1,0 +1,102 @@
+# Lurker Design Tokens
+
+Lurker's visual system is built on a small set of **design tokens** — named CSS
+custom properties — instead of hardcoded values scattered through components.
+This is the shared vocabulary for talking about layout and style: instead of
+"make that gap 10 instead of 8 pixels," you can say "bump that gap from
+`--space-4` to `--space-5`."
+
+All tokens live in one file: [`vue_client/src/assets/main.css`](../vue_client/src/assets/main.css).
+
+## Two tiers of token
+
+**1. Themeable tokens** — colors and fonts. These are user-configurable: the
+Settings UI writes them onto the page live (via `useTheme()`), so changing a
+color in Settings re-themes the whole app instantly. The values in `main.css`
+are just the defaults for the first paint.
+
+**2. Internal tokens** — spacing, z-index, scrim, radius. These are *not* user
+settings; they exist purely so the same value isn't retyped in 80 places. They
+are intentionally fixed. (Changing one of these is a code change, not a
+setting.)
+
+---
+
+## Color (themeable)
+
+| Token | Role |
+|---|---|
+| `--bg`, `--bg-soft` | page background, raised surfaces |
+| `--fg`, `--fg-muted` | primary text, secondary/de-emphasized text |
+| `--accent` | links, focus, primary highlight |
+| `--good`, `--warn`, `--bad` | success / warning / error |
+| `--border` | hairline borders |
+| `--member-owner/admin/op/halfop/voice` | IRC member-list mode colors |
+
+**Hierarchy is expressed with color and weight, never font size.** There is one
+font size across the whole UI. To make text recede, use `color: var(--fg-muted)`;
+to emphasize, use `font-weight: 600`. (The only exception is big hero/brand
+display titles — the login screen, modal titles — which use a deliberately
+large responsive size.)
+
+## Spacing (internal) — a 4px rhythm
+
+Used for gaps, padding, and margins. Everything should land on one of these
+steps so the layout breathes on a consistent grid.
+
+| Token | px | Token | px |
+|---|---|---|---|
+| `--space-1` | 2 | `--space-6` | 12 |
+| `--space-2` | 4 | `--space-7` | 16 |
+| `--space-3` | 6 | `--space-8` | 20 |
+| `--space-4` | 8 | `--space-9` | 24 |
+| `--space-5` | 10 | `--space-10` | 32 |
+
+(Borders stay a literal `1px`, and a few hairline `1px` paddings in very dense
+rows are deliberate — those aren't on the scale by design.)
+
+## z-index (internal) — a layering ladder
+
+Named by role, so it's clear what sits above what. Higher in the list = closer
+to the viewer.
+
+| Token | Role |
+|---|---|
+| `--z-base` | in-flow lift (sticky headers, background layers) |
+| `--z-raised` | lifts above sibling content within a component |
+| `--z-modal` | modal / overlay shells (dialogs, quick switcher) |
+| `--z-toast` | toast notifications (above modals, so they stay visible) |
+| `--z-menu` | context menus |
+| `--z-popover` | input autocomplete (nick picker) — top of the stack |
+
+## Radius (internal)
+
+The app is intentionally flat — most things are square corners.
+
+| Token | px | Use |
+|---|---|---|
+| `--radius-sm` | 2 | subtle softening (chips, small buttons) |
+| `--radius-md` | 6 | floating popups |
+| `--radius-pill` | 999 | fully-rounded pills |
+
+(`50%` is used directly for circles.)
+
+## Scrim
+
+`--scrim` is the dimmed backdrop behind overlays (e.g. the quick switcher).
+
+---
+
+## Giving feedback in token terms
+
+When something looks off, the most actionable feedback names the token:
+
+- *"The buffer-list rows feel cramped — try `--space-5` instead of `--space-4`
+  for the row padding."*
+- *"That label should recede — give it `--fg-muted` rather than a smaller font."*
+- *"The modal corners should be a touch softer — `--radius-md`?"*
+
+If a value you want isn't on a scale (e.g. a spacing step between two existing
+ones), that's worth a conversation — we add scale steps deliberately rather
+than sprinkling one-off pixel values, which is the drift this system exists to
+prevent.

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -78,9 +78,18 @@
   --z-menu: 300;
   --z-popover: 1000;
 
-  /* Modal/overlay scrim — the dimmed backdrop behind context menus, the
-     quick switcher, toasts, etc. Was raw rgba(0,0,0,~0.5) in four places. */
+  /* Modal/overlay scrim — the dimmed backdrop behind a full-screen overlay.
+     Currently the QuickSwitcher; AppModal uses a solid --bg backdrop, and the
+     rgba(0,0,0,*) on context menus / toasts / the nick picker are drop
+     shadows, not scrims. */
   --scrim: rgba(0, 0, 0, 0.5);
+
+  /* Icon sizing. Icons are graphics, not text, so they're allowed to scale
+     independently of the one-font-size rule (which governs text hierarchy).
+     em-relative so they track the base size. Use on icon-only controls where
+     a glyph needs more presence than body text. */
+  --icon-md: 1.1em;
+  --icon-lg: 1.2em;
 
   /* Corner radii. The app is intentionally flat (most things are square);
      these are the few deliberate exceptions. */

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -34,6 +34,58 @@
   --mono: 'Input Mono', 'Input', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --font-size: 14px;
   --font-weight: 400;
+
+  /* ----------------------------------------------------------------------
+     Internal design tokens.
+
+     Everything ABOVE this line is user-themeable: useTheme() rewrites it on
+     :root from the settings store. Everything BELOW is static — internal
+     consistency only, deliberately NOT wired into the settings registry.
+     Don't add these to COLOR_VARS / settingsRegistry; they're for us, not
+     the user.
+     ---------------------------------------------------------------------- */
+
+  /* Spacing — a 4px-derived rhythm (2px steps at the low end where the dense
+     IRC chrome needs them, 4px steps higher up). These are the values that
+     were already in use across the components; tokenizing them just stops a
+     stray 7px or 13px from sneaking in unnoticed. Use for gap / padding /
+     margin only — NOT for borders (always 1px) or one-off layout widths. */
+  --space-1: 2px;
+  --space-2: 4px;
+  --space-3: 6px;
+  --space-4: 8px;
+  --space-5: 10px;
+  --space-6: 12px;
+  --space-7: 16px;
+  --space-8: 20px;
+  --space-9: 24px;
+  --space-10: 32px;
+
+  /* z-index ladder — named by role so stacking order is legible at the call
+     site and there's one place to see the whole hierarchy. Values preserve
+     the order the app already shipped with; add new layers here rather than
+     inventing bare numbers in components.
+       base    in-flow lift (sticky headers, bg layers)
+       raised  lifts above sibling content within a component
+       modal   modal/overlay shells (AppModal, QuickSwitcher)
+       toast   toast stack — sits above modals so notifications stay visible
+       menu    context menus
+       popover input autocomplete (NickPicker) — top of the stack */
+  --z-base: 1;
+  --z-raised: 5;
+  --z-modal: 100;
+  --z-toast: 200;
+  --z-menu: 300;
+  --z-popover: 1000;
+
+  /* Modal/overlay scrim — the dimmed backdrop behind context menus, the
+     quick switcher, toasts, etc. Was raw rgba(0,0,0,~0.5) in four places. */
+  --scrim: rgba(0, 0, 0, 0.5);
+
+  /* Corner radii. The app is intentionally flat (most things are square);
+     these are the few deliberate exceptions. */
+  --radius-sm: 2px;
+  --radius-pill: 999px;
 }
 
 /* Mobile bumps the base size to 16px. Two reasons: iOS Safari auto-zooms

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -85,6 +85,7 @@
   /* Corner radii. The app is intentionally flat (most things are square);
      these are the few deliberate exceptions. */
   --radius-sm: 2px;
+  --radius-md: 6px;
   --radius-pill: 999px;
 }
 

--- a/vue_client/src/components/AppModal.vue
+++ b/vue_client/src/components/AppModal.vue
@@ -209,7 +209,6 @@ onMounted(() => {
 .subtitle {
   margin: var(--space-4) 0 0;
   color: var(--fg-muted);
-  font-size: 0.9em;
 }
 .head-actions {
   display: flex;
@@ -223,7 +222,7 @@ onMounted(() => {
   color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  font-size: 1.2em;
+  font-weight: 600;
   padding: var(--space-2) var(--space-4);
 }
 .close-btn:hover {

--- a/vue_client/src/components/AppModal.vue
+++ b/vue_client/src/components/AppModal.vue
@@ -222,7 +222,9 @@ onMounted(() => {
   color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  font-weight: 600;
+  /* Icon-only button — size the glyph, not text weight (fa-solid is already
+     weight 900). */
+  font-size: var(--icon-lg);
   padding: var(--space-2) var(--space-4);
 }
 .close-btn:hover {

--- a/vue_client/src/components/AppModal.vue
+++ b/vue_client/src/components/AppModal.vue
@@ -108,7 +108,7 @@ onMounted(() => {
   background: var(--bg);
   display: flex;
   justify-content: center;
-  z-index: 100;
+  z-index: var(--z-modal);
   overflow: hidden;
   outline: none;
 }
@@ -136,7 +136,7 @@ onMounted(() => {
   .modal,
   .modal.align-top {
     align-items: stretch;
-    padding: 16px;
+    padding: var(--space-7);
   }
   .card,
   .card.size-sm,
@@ -162,7 +162,7 @@ onMounted(() => {
      children can break out with margin: 0 calc(-1 * var(--card-pad-x))
      and have their scrollbar sit against the card border. */
   --card-pad-x: 28px;
-  padding: 24px var(--card-pad-x);
+  padding: var(--space-9) var(--card-pad-x);
   outline: none;
 }
 .card.size-sm {
@@ -182,9 +182,9 @@ onMounted(() => {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 12px;
-  padding: 0 0 16px;
-  margin-bottom: 16px;
+  gap: var(--space-6);
+  padding: 0 0 var(--space-7);
+  margin-bottom: var(--space-7);
   border-bottom: 1px solid var(--border);
 }
 .title-wrap {
@@ -207,14 +207,14 @@ onMounted(() => {
   text-overflow: ellipsis;
 }
 .subtitle {
-  margin: 8px 0 0;
+  margin: var(--space-4) 0 0;
   color: var(--fg-muted);
   font-size: 0.9em;
 }
 .head-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
   flex-shrink: 0;
 }
 .close-btn {
@@ -224,7 +224,7 @@ onMounted(() => {
   cursor: pointer;
   font: inherit;
   font-size: 1.2em;
-  padding: 4px 8px;
+  padding: var(--space-2) var(--space-4);
 }
 .close-btn:hover {
   color: var(--accent);

--- a/vue_client/src/components/AppModal.vue
+++ b/vue_client/src/components/AppModal.vue
@@ -161,7 +161,7 @@ onMounted(() => {
   /* Card horizontal padding lives in a custom property so scrolling
      children can break out with margin: 0 calc(-1 * var(--card-pad-x))
      and have their scrollbar sit against the card border. */
-  --card-pad-x: 28px;
+  --card-pad-x: var(--space-9);
   padding: var(--space-9) var(--card-pad-x);
   outline: none;
 }

--- a/vue_client/src/components/BookmarksModal.vue
+++ b/vue_client/src/components/BookmarksModal.vue
@@ -69,7 +69,7 @@ function onRemove(m: HistoryMessage): void {
   color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  padding: 0 4px;
+  padding: 0 var(--space-2);
 }
 .link:hover {
   color: var(--accent);
@@ -91,16 +91,16 @@ function onRemove(m: HistoryMessage): void {
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 32px;
+  padding: var(--space-10);
 }
 .error.inline {
   color: var(--bad);
-  padding: 8px 0;
+  padding: var(--space-4) 0;
   margin: 0;
 }
 .foot {
   border-top: 1px solid var(--border);
-  padding: 8px 0;
+  padding: var(--space-4) 0;
   display: flex;
   justify-content: center;
 }

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -770,7 +770,6 @@ onBeforeUnmount(() => {
    highlight badges for attention. */
 .badge.draft {
   color: var(--fg-muted);
-  font-size: 0.85em;
 }
 
 /* Hover three-dots: absolute-positioned so it doesn't displace badges on

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -549,7 +549,7 @@ onBeforeUnmount(() => {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  padding: 4px 0;
+  padding: var(--space-2) 0;
 }
 /* IRCCloud-style affordance: a thin accent bar pinned to the top or bottom
    edge of the list when unread buffers are scrolled out of view that way.
@@ -567,7 +567,7 @@ onBeforeUnmount(() => {
   border: none;
   background: transparent;
   cursor: pointer;
-  z-index: 5;
+  z-index: var(--z-raised);
 }
 /* The global `button:hover` paints `--bg-soft`, which would show as a 12px
    strip over the buffer list. Keep the button transparent — the ::before
@@ -609,17 +609,17 @@ onBeforeUnmount(() => {
   outline-offset: -1px;
 }
 .net {
-  padding: 4px 0 6px;
+  padding: var(--space-2) 0 var(--space-3);
 }
 .net + .net {
   border-top: 1px solid var(--border);
-  margin-top: 4px;
+  margin-top: var(--space-2);
 }
 .net-head {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-5);
   color: var(--fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -668,8 +668,8 @@ onBeforeUnmount(() => {
 .channels li {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 2px 10px 2px 24px;
+  gap: var(--space-3);
+  padding: var(--space-1) var(--space-5) var(--space-1) var(--space-9);
   cursor: pointer;
   border-left: 2px solid transparent;
   position: relative;
@@ -680,7 +680,7 @@ onBeforeUnmount(() => {
 .channels li::before {
   content: '';
   position: absolute;
-  left: 12px;
+  left: var(--space-6);
   top: 0;
   height: 50%;
   width: 8px;
@@ -692,7 +692,7 @@ onBeforeUnmount(() => {
 .channels li:not(:last-child)::after {
   content: '';
   position: absolute;
-  left: 12px;
+  left: var(--space-6);
   top: 50%;
   bottom: 0;
   width: 0;
@@ -706,7 +706,7 @@ onBeforeUnmount(() => {
 .channels.pinned:has(+ .pin-divider) li:last-child::after {
   content: '';
   position: absolute;
-  left: 12px;
+  left: var(--space-6);
   top: 50%;
   bottom: 0;
   width: 0;
@@ -750,7 +750,7 @@ onBeforeUnmount(() => {
 .peer-mark {
   color: var(--fg-muted);
   font-weight: 600;
-  margin-left: 2px;
+  margin-left: var(--space-1);
 }
 .label {
   flex: 1;
@@ -760,7 +760,7 @@ onBeforeUnmount(() => {
 }
 .badge {
   color: var(--accent);
-  padding: 0 2px;
+  padding: 0 var(--space-1);
 }
 .badge.highlight {
   color: var(--buffer-highlight);
@@ -782,10 +782,10 @@ onBeforeUnmount(() => {
    DMs) or single-tap (members) instead. */
 .channels .row-actions {
   position: absolute;
-  right: 4px;
+  right: var(--space-2);
   top: 50%;
   transform: translateY(-50%);
-  padding: 0 4px;
+  padding: 0 var(--space-2);
   background: var(--bg-soft);
   border: none;
   color: var(--fg-muted);
@@ -817,7 +817,7 @@ onBeforeUnmount(() => {
 }
 
 .empty {
-  padding: 12px;
+  padding: var(--space-6);
   color: var(--fg-muted);
   font-style: italic;
 }
@@ -838,7 +838,7 @@ onBeforeUnmount(() => {
 .pin-divider::before {
   content: '';
   position: absolute;
-  left: 12px;
+  left: var(--space-6);
   top: 0;
   bottom: 0;
   border-left: 1px solid var(--border);
@@ -846,8 +846,8 @@ onBeforeUnmount(() => {
 .pin-divider::after {
   content: '';
   position: absolute;
-  left: 12px;
-  right: 12px;
+  left: var(--space-6);
+  right: var(--space-6);
   top: 50%;
   border-top: 1px solid var(--border);
 }

--- a/vue_client/src/components/ChannelListModal.vue
+++ b/vue_client/src/components/ChannelListModal.vue
@@ -237,7 +237,6 @@ onBeforeUnmount(() => {
 }
 .meta {
   color: var(--fg-muted);
-  font-size: 0.9em;
 }
 
 /* On mobile the filter + refresh button consume the full row; push the
@@ -258,7 +257,6 @@ onBeforeUnmount(() => {
 }
 .sort-label {
   color: var(--fg-muted);
-  font-size: 0.85em;
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
@@ -323,13 +321,11 @@ onBeforeUnmount(() => {
 }
 .list-item-meta {
   color: var(--fg-muted);
-  font-size: 0.9em;
   white-space: nowrap;
   flex-shrink: 0;
 }
 .list-item-sub {
   color: var(--fg-muted);
-  font-size: 0.9em;
   margin-top: var(--space-1);
   line-height: 1.4;
   word-break: break-word;

--- a/vue_client/src/components/ChannelListModal.vue
+++ b/vue_client/src/components/ChannelListModal.vue
@@ -200,9 +200,9 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
-  padding-bottom: 8px;
-  margin-bottom: 8px;
+  gap: var(--space-4);
+  padding-bottom: var(--space-4);
+  margin-bottom: var(--space-4);
   border-bottom: 1px solid var(--border);
 }
 .filter {
@@ -211,7 +211,7 @@ onBeforeUnmount(() => {
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
-  padding: 4px 8px;
+  padding: var(--space-2) var(--space-4);
   font: inherit;
 }
 .filter:focus {
@@ -223,7 +223,7 @@ onBeforeUnmount(() => {
   border: 1px solid var(--border);
   color: var(--fg);
   font: inherit;
-  padding: 4px 10px;
+  padding: var(--space-2) var(--space-5);
   cursor: pointer;
   white-space: nowrap;
 }
@@ -252,9 +252,9 @@ onBeforeUnmount(() => {
 .sort-bar {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding-bottom: 8px;
-  margin-bottom: 4px;
+  gap: var(--space-6);
+  padding-bottom: var(--space-4);
+  margin-bottom: var(--space-2);
 }
 .sort-label {
   color: var(--fg-muted);
@@ -300,7 +300,7 @@ onBeforeUnmount(() => {
   padding: 0;
 }
 .list-item {
-  padding: 8px 8px;
+  padding: var(--space-4) var(--space-4);
   border-bottom: 1px solid var(--border);
   cursor: pointer;
 }
@@ -311,7 +311,7 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-6);
 }
 .list-item-title {
   color: var(--accent);
@@ -330,7 +330,7 @@ onBeforeUnmount(() => {
 .list-item-sub {
   color: var(--fg-muted);
   font-size: 0.9em;
-  margin-top: 2px;
+  margin-top: var(--space-1);
   line-height: 1.4;
   word-break: break-word;
 }
@@ -341,13 +341,13 @@ onBeforeUnmount(() => {
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 8px;
+  padding: var(--space-4);
   list-style: none;
 }
 .empty {
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 32px;
+  padding: var(--space-10);
 }
 </style>

--- a/vue_client/src/components/ContextMenu.vue
+++ b/vue_client/src/components/ContextMenu.vue
@@ -135,7 +135,7 @@ onBeforeUnmount(() => {
 <style scoped>
 .context-menu {
   position: fixed;
-  z-index: 300;
+  z-index: var(--z-menu);
   min-width: 160px;
   /* `width: auto` on a position:fixed element near the right edge gets
      shrink-wrapped to the available viewport space, which wraps long labels
@@ -157,12 +157,12 @@ onBeforeUnmount(() => {
 .item {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-5);
   width: 100%;
   /* Asymmetric horizontal padding: more on the right so the label has
      breathing room from the menu edge — reads tight at 12px once the menu
      widens out for a long label. */
-  padding: 8px 16px 8px 14px;
+  padding: var(--space-4) var(--space-7) var(--space-4) 14px;
   background: none;
   border: none;
   color: inherit;

--- a/vue_client/src/components/ContextMenu.vue
+++ b/vue_client/src/components/ContextMenu.vue
@@ -162,7 +162,7 @@ onBeforeUnmount(() => {
   /* Asymmetric horizontal padding: more on the right so the label has
      breathing room from the menu edge — reads tight at 12px once the menu
      widens out for a long label. */
-  padding: var(--space-4) var(--space-7) var(--space-4) 14px;
+  padding: var(--space-4) var(--space-7) var(--space-4) var(--space-6);
   background: none;
   border: none;
   color: inherit;

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -115,7 +115,7 @@ function onJump(m: HistoryMessage): void {
   cursor: default;
 }
 .sound-toggle {
-  font-size: 1.1em;
+  font-weight: 600;
 }
 
 .match-list {

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -115,7 +115,9 @@ function onJump(m: HistoryMessage): void {
   cursor: default;
 }
 .sound-toggle {
-  font-weight: 600;
+  /* Icon-only button — size the glyph (fa-solid is already weight 900, so
+     font-weight here would be a no-op). */
+  font-size: var(--icon-md);
 }
 
 .match-list {

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -105,7 +105,7 @@ function onJump(m: HistoryMessage): void {
   color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  padding: 0 4px;
+  padding: 0 var(--space-2);
 }
 .link:hover {
   color: var(--accent);
@@ -132,17 +132,17 @@ function onJump(m: HistoryMessage): void {
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 8px;
+  padding: var(--space-4);
 }
 .empty {
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 32px;
+  padding: var(--space-10);
 }
 .error.inline {
   color: var(--bad);
-  padding: 8px 0;
+  padding: var(--space-4) 0;
   margin: 0;
 }
 </style>

--- a/vue_client/src/components/HistoryMessageRow.vue
+++ b/vue_client/src/components/HistoryMessageRow.vue
@@ -127,7 +127,7 @@ const nickStyle = computed((): CSSProperties | null => {
 <style scoped>
 .row {
   position: relative;
-  padding: 8px 10px;
+  padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--border);
   cursor: pointer;
 }
@@ -138,8 +138,8 @@ const nickStyle = computed((): CSSProperties | null => {
 
 .remove {
   position: absolute;
-  top: 6px;
-  right: 6px;
+  top: var(--space-3);
+  right: var(--space-3);
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--fg-muted);
@@ -169,9 +169,9 @@ const nickStyle = computed((): CSSProperties | null => {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-4);
   color: var(--fg-muted);
-  margin-bottom: 6px;
+  margin-bottom: var(--space-3);
 }
 .where {
   min-width: 0;

--- a/vue_client/src/components/HistoryMessageRow.vue
+++ b/vue_client/src/components/HistoryMessageRow.vue
@@ -151,7 +151,7 @@ const nickStyle = computed((): CSSProperties | null => {
   cursor: pointer;
   opacity: 0;
   padding: 0;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
 }
 .row:hover .remove {
   opacity: 1;

--- a/vue_client/src/components/IgnoreModal.vue
+++ b/vue_client/src/components/IgnoreModal.vue
@@ -87,7 +87,6 @@ onMounted(() => {
 }
 .label-text {
   color: var(--fg-muted);
-  font-size: 0.85em;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -105,7 +104,6 @@ input:focus {
 .preview {
   margin: 0;
   color: var(--fg-muted);
-  font-size: 0.9em;
   line-height: 1.45;
 }
 .preview {

--- a/vue_client/src/components/IgnoreModal.vue
+++ b/vue_client/src/components/IgnoreModal.vue
@@ -78,12 +78,12 @@ onMounted(() => {
 .body {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-6);
 }
 .field {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-2);
 }
 .label-text {
   color: var(--fg-muted);
@@ -95,7 +95,7 @@ input {
   background: var(--bg-soft);
   color: var(--fg);
   border: 1px solid var(--border);
-  padding: 6px 8px;
+  padding: var(--space-3) var(--space-4);
   font: inherit;
 }
 input:focus {
@@ -113,21 +113,21 @@ input:focus {
 }
 code {
   background: var(--bg-soft);
-  padding: 0 4px;
-  border-radius: 2px;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
 }
 .actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 4px;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
 }
 .btn-primary,
 .btn-secondary {
   background: none;
   border: 1px solid var(--border);
   color: var(--fg);
-  padding: 6px 14px;
+  padding: var(--space-3) 14px;
   cursor: pointer;
   font: inherit;
 }

--- a/vue_client/src/components/IgnoreModal.vue
+++ b/vue_client/src/components/IgnoreModal.vue
@@ -125,7 +125,7 @@ code {
   background: none;
   border: 1px solid var(--border);
   color: var(--fg);
-  padding: var(--space-3) 14px;
+  padding: var(--space-3) var(--space-6);
   cursor: pointer;
   font: inherit;
 }

--- a/vue_client/src/components/KeyboardHelpModal.vue
+++ b/vue_client/src/components/KeyboardHelpModal.vue
@@ -88,12 +88,11 @@ const shortcuts = computed<ShortcutRow[]>(() => [
 }
 kbd {
   font: inherit;
-  font-size: 0.85em;
   background: var(--bg-soft);
   border: 1px solid var(--border);
   padding: 1px var(--space-3);
   margin: 0 1px;
-  color: var(--fg);
+  color: var(--fg-muted);
 }
 .plus {
   color: var(--fg-muted);

--- a/vue_client/src/components/KeyboardHelpModal.vue
+++ b/vue_client/src/components/KeyboardHelpModal.vue
@@ -74,7 +74,7 @@ const shortcuts = computed<ShortcutRow[]>(() => [
   border-collapse: collapse;
 }
 .list td {
-  padding: 6px 0;
+  padding: var(--space-3) 0;
   border-bottom: 1px solid var(--border);
   vertical-align: middle;
 }
@@ -84,20 +84,20 @@ const shortcuts = computed<ShortcutRow[]>(() => [
 .keys {
   white-space: nowrap;
   width: 1%;
-  padding-right: 16px;
+  padding-right: var(--space-7);
 }
 kbd {
   font: inherit;
   font-size: 0.85em;
   background: var(--bg-soft);
   border: 1px solid var(--border);
-  padding: 1px 6px;
+  padding: 1px var(--space-3);
   margin: 0 1px;
   color: var(--fg);
 }
 .plus {
   color: var(--fg-muted);
-  margin: 0 2px;
+  margin: 0 var(--space-1);
 }
 .label {
   color: var(--fg);

--- a/vue_client/src/components/LongMessageUploadModal.vue
+++ b/vue_client/src/components/LongMessageUploadModal.vue
@@ -78,8 +78,7 @@ onMounted(() => {
   white-space: pre-wrap;
   word-break: break-word;
   font-family: inherit;
-  font-size: 0.95em;
-  color: var(--fg);
+  color: var(--fg-muted);
 }
 .foot {
   padding-top: var(--space-6);

--- a/vue_client/src/components/LongMessageUploadModal.vue
+++ b/vue_client/src/components/LongMessageUploadModal.vue
@@ -58,17 +58,17 @@ onMounted(() => {
 
 <style scoped>
 .desc {
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-6);
   color: var(--fg-muted);
 }
 .desc code {
   background: var(--bg-soft);
-  padding: 1px 4px;
-  border-radius: 2px;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
 }
 .preview {
-  margin: 0 0 12px;
-  padding: 8px 12px;
+  margin: 0 0 var(--space-6);
+  padding: var(--space-4) var(--space-6);
   background: var(--bg-soft);
   border: 1px solid var(--border);
   overflow: auto;
@@ -82,11 +82,11 @@ onMounted(() => {
   color: var(--fg);
 }
 .foot {
-  padding-top: 12px;
+  padding-top: var(--space-6);
   border-top: 1px solid var(--border);
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--space-4);
 }
 .btn {
   background: var(--bg-soft);
@@ -94,7 +94,7 @@ onMounted(() => {
   color: var(--fg);
   cursor: pointer;
   font: inherit;
-  padding: 6px 14px;
+  padding: var(--space-3) 14px;
 }
 .btn:hover:not(:disabled) {
   border-color: var(--accent);

--- a/vue_client/src/components/LongMessageUploadModal.vue
+++ b/vue_client/src/components/LongMessageUploadModal.vue
@@ -93,7 +93,7 @@ onMounted(() => {
   color: var(--fg);
   cursor: pointer;
   font: inherit;
-  padding: var(--space-3) 14px;
+  padding: var(--space-3) var(--space-6);
 }
 .btn:hover:not(:disabled) {
   border-color: var(--accent);

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -176,7 +176,7 @@ const sorted = computed(() => {
 ul {
   list-style: none;
   margin: 0;
-  padding: 4px 0;
+  padding: var(--space-2) 0;
   overflow: auto;
   flex: 1;
   min-height: 0;
@@ -184,8 +184,8 @@ ul {
 li {
   display: flex;
   align-items: baseline;
-  gap: 2px;
-  padding: 1px 10px;
+  gap: var(--space-1);
+  padding: 1px var(--space-5);
   min-width: 0;
   user-select: none;
   cursor: pointer;
@@ -208,7 +208,7 @@ li:hover {
   bottom: 0;
   display: flex;
   align-items: center;
-  padding: 0 8px 0 16px;
+  padding: 0 var(--space-4) 0 var(--space-7);
   background: linear-gradient(to right, transparent 0, var(--bg-soft) 12px);
   border: none;
   color: var(--fg-muted);

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1696,7 +1696,7 @@ function handleCommand(line: string, networkId: number, target: string): boolean
      first line as the textarea grows downward across multiple lines. */
   align-items: flex-start;
   gap: 1ch;
-  padding: 8px 12px;
+  padding: var(--space-4) var(--space-6);
   /* Containing block for the desktop NickPicker's anchor logic — the
      position:fixed picker still reads coordinates off the form. */
   position: relative;
@@ -1721,7 +1721,7 @@ function handleCommand(line: string, networkId: number, target: string): boolean
   border: none;
   color: var(--fg-muted);
   cursor: pointer;
-  padding: 0 2px;
+  padding: 0 var(--space-1);
   font-size: inherit;
   line-height: 1.4;
 }
@@ -1735,7 +1735,7 @@ function handleCommand(line: string, networkId: number, target: string): boolean
 .format-btn {
   color: var(--fg-muted);
   cursor: pointer;
-  padding: 0 2px;
+  padding: 0 var(--space-1);
   line-height: 1.4;
   user-select: none;
   /* Avoids iOS double-tap-zoom delay so the picker opens promptly on touch. */

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1401,7 +1401,6 @@ watch(
 .unread-divider {
   color: var(--warn);
   font-style: normal;
-  font-size: 0.85em;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   padding: var(--space-2) 0;
@@ -1425,7 +1424,6 @@ watch(
 .date-divider,
 .cleared-divider {
   font-style: normal;
-  font-size: 0.85em;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   padding: var(--space-2) 0;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1126,7 +1126,7 @@ watch(
      prepend watcher in <script setup> handles position preservation
      manually with a known-stable anchor (the OLD first message). */
   overflow-anchor: none;
-  padding: 4px 12px;
+  padding: var(--space-2) var(--space-6);
   display: grid;
   /* Nick column has a 16ch floor (matching the most common modern NICKLEN)
      so the layout is consistent across buffers regardless of who's talking,
@@ -1173,7 +1173,7 @@ watch(
 .row-actions {
   position: absolute;
   top: 50%;
-  right: 4px;
+  right: var(--space-2);
   transform: translateY(-50%);
   background: var(--bg);
   border: 1px solid var(--border);
@@ -1186,7 +1186,7 @@ watch(
   cursor: pointer;
   opacity: 0;
   pointer-events: none;
-  z-index: 1;
+  z-index: var(--z-base);
   padding: 0;
   border-radius: 3px;
 }
@@ -1296,7 +1296,7 @@ watch(
 @media (max-width: 768px) {
   .message-list:not(.compact) {
     grid-template-columns: minmax(0, max-content) minmax(0, 1fr);
-    padding: 4px 8px;
+    padding: var(--space-2) var(--space-4);
   }
   .message-list:not(.compact) .time {
     display: none;
@@ -1317,7 +1317,7 @@ watch(
 .message-list.compact {
   /* Single content column — the 3-col subgrid alignment goes away. */
   grid-template-columns: minmax(0, 1fr);
-  padding: 4px 8px;
+  padding: var(--space-2) var(--space-4);
 }
 .message-list.compact .line {
   /* Per-row grid: head spans both content columns above the body row;
@@ -1333,13 +1333,13 @@ watch(
   align-items: baseline;
   column-gap: 0.75ch;
   row-gap: 0;
-  padding: 2px 0;
+  padding: var(--space-1) 0;
   /* Group separator: every non-continuation line marks the start of a new
      visual cluster (message head, action, notice, system event,
      consolidation summary). Transparent (not padding) so adjacent hover
      backgrounds don't touch across the gap. Adjacent siblings collapse
      vertical margins, so back-to-back clusters get one 10px gap, not 20px. */
-  margin-top: 10px;
+  margin-top: var(--space-5);
 }
 /* Continuation message rows render only body + time — no head, no cluster
    start — and should sit tight under the previous line. */
@@ -1349,7 +1349,7 @@ watch(
 /* Client-side dividers (unread/away/back/date) also mark a cluster boundary,
    so give them the same top gap as .line in compact mode. */
 .message-list.compact .notice {
-  margin-top: 10px;
+  margin-top: var(--space-5);
 }
 .message-list.compact .line > .head {
   grid-area: head;
@@ -1390,7 +1390,7 @@ watch(
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 6px 0;
+  padding: var(--space-3) 0;
   margin: 0;
 }
 
@@ -1404,10 +1404,10 @@ watch(
   font-size: 0.85em;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 4px 0;
+  padding: var(--space-2) 0;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 .unread-divider::before,
 .unread-divider::after {
@@ -1428,10 +1428,10 @@ watch(
   font-size: 0.85em;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 4px 0;
+  padding: var(--space-2) 0;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 .presence-divider::before,
 .presence-divider::after,

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1188,7 +1188,7 @@ watch(
   pointer-events: none;
   z-index: var(--z-base);
   padding: 0;
-  border-radius: 3px;
+  border-radius: var(--radius-sm);
 }
 .line:hover .row-actions,
 .row-actions:focus-visible {

--- a/vue_client/src/components/MircColorPicker.vue
+++ b/vue_client/src/components/MircColorPicker.vue
@@ -187,21 +187,21 @@ function apply(): void {
    picker and the composer underneath. */
 .mirc-picker {
   position: absolute;
-  right: 12px;
-  bottom: 6px;
+  right: var(--space-6);
+  bottom: var(--space-3);
   background: var(--bg);
   border: 1px solid var(--border);
-  padding: 6px;
+  padding: var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  z-index: 6;
+  gap: var(--space-3);
+  z-index: var(--z-raised);
 }
 .swatch-grid {
   display: grid;
   grid-template-columns: repeat(8, 1.4em);
   grid-auto-rows: 1.4em;
-  gap: 4px;
+  gap: var(--space-2);
 }
 .swatch {
   border: 1px solid var(--border);
@@ -221,17 +221,17 @@ function apply(): void {
 .row {
   display: flex;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-6);
 }
 .slots {
-  gap: 4px;
+  gap: var(--space-2);
 }
 .slot {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: var(--space-2);
   padding: 1px 0;
   color: var(--fg-muted);
   border: 1px solid var(--border);
@@ -254,7 +254,7 @@ function apply(): void {
   width: 0.9em;
   height: 0.9em;
   border: 1px solid var(--border);
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
 }
 .action {
   color: var(--fg-muted);

--- a/vue_client/src/components/NetworkForm.vue
+++ b/vue_client/src/components/NetworkForm.vue
@@ -233,7 +233,7 @@ async function remove(): Promise<void> {
 .net-form {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-5);
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -268,7 +268,7 @@ label textarea {
 }
 label small {
   color: var(--fg-muted);
-  margin-top: 2px;
+  margin-top: var(--space-1);
   text-transform: none;
   letter-spacing: normal;
 }
@@ -276,7 +276,7 @@ label small {
   align-self: flex-start;
   background: transparent;
   border: 0;
-  padding: 4px 0;
+  padding: var(--space-2) 0;
   color: var(--accent);
   cursor: pointer;
   text-transform: lowercase;
@@ -287,11 +287,11 @@ label small {
 .advanced {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-5);
 }
 .row {
   display: flex;
-  gap: 8px;
+  gap: var(--space-4);
   align-items: end;
 }
 /* min-width:0 lets a flex item shrink below its content's intrinsic width —
@@ -314,7 +314,7 @@ label small {
 .check {
   flex-direction: row;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 .check input {
   width: auto;
@@ -328,8 +328,8 @@ label small {
 .actions {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 6px;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
 }
 .spacer {
   flex: 1;

--- a/vue_client/src/components/NetworkForm.vue
+++ b/vue_client/src/components/NetworkForm.vue
@@ -245,7 +245,7 @@ async function remove(): Promise<void> {
 label {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: var(--space-2);
   color: var(--fg-muted);
 }
 label span {

--- a/vue_client/src/components/NickNoteModal.vue
+++ b/vue_client/src/components/NickNoteModal.vue
@@ -107,7 +107,6 @@ textarea:focus {
 .meta {
   margin: 0;
   color: var(--fg-muted);
-  font-size: 0.9em;
 }
 .actions {
   display: flex;

--- a/vue_client/src/components/NickNoteModal.vue
+++ b/vue_client/src/components/NickNoteModal.vue
@@ -89,13 +89,13 @@ onMounted(() => {
 .body {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-6);
 }
 textarea {
   background: var(--bg-soft);
   color: var(--fg);
   border: 1px solid var(--border);
-  padding: 8px 10px;
+  padding: var(--space-4) var(--space-5);
   font: inherit;
   resize: vertical;
   min-height: 8em;
@@ -112,15 +112,15 @@ textarea:focus {
 .actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 4px;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
 }
 .btn-primary,
 .btn-secondary {
   background: none;
   border: 1px solid var(--border);
   color: var(--fg);
-  padding: 6px 14px;
+  padding: var(--space-3) 14px;
   cursor: pointer;
   font: inherit;
 }

--- a/vue_client/src/components/NickNoteModal.vue
+++ b/vue_client/src/components/NickNoteModal.vue
@@ -119,7 +119,7 @@ textarea:focus {
   background: none;
   border: 1px solid var(--border);
   color: var(--fg);
-  padding: var(--space-3) 14px;
+  padding: var(--space-3) var(--space-6);
   cursor: pointer;
   font: inherit;
 }

--- a/vue_client/src/components/NickPicker.vue
+++ b/vue_client/src/components/NickPicker.vue
@@ -246,7 +246,6 @@ watch(
   font-weight: 500;
 }
 .badge {
-  font-size: 0.85em;
   color: var(--fg-muted);
   font-style: italic;
 }

--- a/vue_client/src/components/NickPicker.vue
+++ b/vue_client/src/components/NickPicker.vue
@@ -211,8 +211,8 @@ watch(
 <style scoped>
 .nick-picker {
   position: fixed;
-  left: 8px;
-  right: 8px;
+  left: var(--space-4);
+  right: var(--space-4);
   max-width: 480px;
   margin: 0 auto;
   max-height: 50vh;
@@ -221,13 +221,13 @@ watch(
   border: 1px solid var(--border);
   border-radius: 6px;
   box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
-  z-index: 1000;
+  z-index: var(--z-popover);
 }
 .row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 14px;
+  padding: var(--space-6) 14px;
   min-height: 44px;
   cursor: pointer;
   border-bottom: 1px solid var(--border);

--- a/vue_client/src/components/NickPicker.vue
+++ b/vue_client/src/components/NickPicker.vue
@@ -219,7 +219,7 @@ watch(
   overflow-y: auto;
   background: var(--bg-soft);
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
   z-index: var(--z-popover);
 }
@@ -227,7 +227,7 @@ watch(
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-6) 14px;
+  padding: var(--space-6);
   min-height: 44px;
   cursor: pointer;
   border-bottom: 1px solid var(--border);

--- a/vue_client/src/components/QuickSwitcher.vue
+++ b/vue_client/src/components/QuickSwitcher.vue
@@ -173,12 +173,12 @@ onMounted(() => {
 .modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--scrim);
   display: flex;
   align-items: flex-start;
   justify-content: center;
   padding-top: 12vh;
-  z-index: 100;
+  z-index: var(--z-modal);
 }
 .card {
   background: var(--bg);
@@ -192,8 +192,8 @@ onMounted(() => {
 .head {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
   border-bottom: 1px solid var(--border);
 }
 .filter {
@@ -202,7 +202,7 @@ onMounted(() => {
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
-  padding: 4px 8px;
+  padding: var(--space-2) var(--space-4);
   font: inherit;
 }
 .filter:focus {
@@ -215,7 +215,7 @@ onMounted(() => {
   color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  padding: 0 4px;
+  padding: 0 var(--space-2);
 }
 .link:hover {
   color: var(--fg);
@@ -232,8 +232,8 @@ onMounted(() => {
 .row {
   display: flex;
   align-items: baseline;
-  gap: 6px;
-  padding: 4px 12px;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-6);
   cursor: pointer;
 }
 .row.active {
@@ -257,6 +257,6 @@ onMounted(() => {
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 24px;
+  padding: var(--space-9);
 }
 </style>

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -215,14 +215,12 @@ function formatBytes(n: number) {
 }
 .url {
   color: var(--fg-muted);
-  font-size: 0.9em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .sub {
   color: var(--fg-muted);
-  font-size: 0.85em;
   margin-top: var(--space-1);
 }
 .row-actions {
@@ -257,6 +255,6 @@ function formatBytes(n: number) {
 }
 .empty.small {
   padding: var(--space-4) 0;
-  font-size: 0.9em;
+  color: var(--fg-muted);
 }
 </style>

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -146,7 +146,7 @@ function formatBytes(n: number) {
   color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  padding: 0 4px;
+  padding: 0 var(--space-2);
 }
 .link:hover {
   color: var(--accent);
@@ -156,8 +156,8 @@ function formatBytes(n: number) {
 }
 
 .error {
-  margin: 0 0 8px;
-  padding: 8px 0;
+  margin: 0 0 var(--space-4);
+  padding: var(--space-4) 0;
   color: var(--bad);
   border-bottom: 1px solid var(--border);
 }
@@ -181,10 +181,10 @@ function formatBytes(n: number) {
   grid-template-columns: 80px 1fr max-content;
   /* Tight column-gap so the thumb hugs the meta text. The meta→actions
      edge gets its own breathing room via margin-left on .row-actions. */
-  column-gap: 4px;
-  row-gap: 8px;
+  column-gap: var(--space-2);
+  row-gap: var(--space-4);
   align-items: center;
-  padding: 8px 0;
+  padding: var(--space-4) 0;
   border-bottom: 1px solid var(--border);
 }
 .thumb-link {
@@ -223,13 +223,13 @@ function formatBytes(n: number) {
 .sub {
   color: var(--fg-muted);
   font-size: 0.85em;
-  margin-top: 2px;
+  margin-top: var(--space-1);
 }
 .row-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-4);
   align-items: center;
-  margin-left: 12px;
+  margin-left: var(--space-6);
 }
 
 /* Phone widths: stack the actions under the thumb+meta block instead of
@@ -238,7 +238,7 @@ function formatBytes(n: number) {
 @media (max-width: 768px) {
   .row {
     grid-template-columns: 80px 1fr;
-    row-gap: 8px;
+    row-gap: var(--space-4);
   }
   .row-actions {
     grid-column: 1 / -1;
@@ -246,17 +246,17 @@ function formatBytes(n: number) {
     margin-left: 0;
   }
   .row-actions .link {
-    padding: 6px 10px;
+    padding: var(--space-3) var(--space-5);
   }
 }
 
 .empty {
-  padding: 24px 0;
+  padding: var(--space-9) 0;
   color: var(--fg-muted);
   text-align: center;
 }
 .empty.small {
-  padding: 8px 0;
+  padding: var(--space-4) 0;
   font-size: 0.9em;
 }
 </style>

--- a/vue_client/src/components/SearchModal.vue
+++ b/vue_client/src/components/SearchModal.vue
@@ -162,14 +162,14 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .search-row {
-  margin-bottom: 12px;
+  margin-bottom: var(--space-6);
 }
 .filter {
   width: 100%;
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
-  padding: 8px 10px;
+  padding: var(--space-4) var(--space-5);
   font: inherit;
 }
 .filter:focus {
@@ -191,17 +191,17 @@ onBeforeUnmount(() => {
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 8px;
+  padding: var(--space-4);
 }
 .empty {
   text-align: center;
   color: var(--fg-muted);
   font-style: italic;
-  padding: 32px;
+  padding: var(--space-10);
 }
 .error.inline {
   color: var(--bad);
-  padding: 8px 0;
+  padding: var(--space-4) 0;
   margin: 0;
 }
 </style>

--- a/vue_client/src/components/SettingsRow.vue
+++ b/vue_client/src/components/SettingsRow.vue
@@ -159,7 +159,6 @@ function formatDefault(opt: SettingOption): string {
   border: 1px solid var(--border);
   padding: 0 var(--space-2);
   text-transform: lowercase;
-  font-size: 0.85em;
 }
 .key-sub code {
   color: var(--fg-muted);
@@ -215,7 +214,6 @@ function formatDefault(opt: SettingOption): string {
 }
 .default-line {
   color: var(--fg-muted);
-  font-size: 0.9em;
 }
 .default-line code {
   background: var(--bg-soft);
@@ -243,6 +241,6 @@ function formatDefault(opt: SettingOption): string {
   color: var(--bad);
 }
 .link.reset {
-  font-size: 0.85em;
+  color: var(--fg-muted);
 }
 </style>

--- a/vue_client/src/components/SettingsRow.vue
+++ b/vue_client/src/components/SettingsRow.vue
@@ -127,8 +127,8 @@ function formatDefault(opt: SettingOption): string {
 .row {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 8px 0 8px 8px;
+  gap: var(--space-2);
+  padding: var(--space-4) 0 var(--space-4) var(--space-4);
   border-top: 1px solid var(--border);
   border-left: 2px solid transparent;
   list-style: none;
@@ -149,7 +149,7 @@ function formatDefault(opt: SettingOption): string {
 .head {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-5);
 }
 .headline {
   font-weight: 600;
@@ -157,21 +157,21 @@ function formatDefault(opt: SettingOption): string {
 .type {
   color: var(--fg-muted);
   border: 1px solid var(--border);
-  padding: 0 4px;
+  padding: 0 var(--space-2);
   text-transform: lowercase;
   font-size: 0.85em;
 }
 .key-sub code {
   color: var(--fg-muted);
   background: var(--bg-soft);
-  padding: 0 4px;
+  padding: 0 var(--space-2);
 }
 .desc {
   color: var(--fg-muted);
 }
 
 .editor {
-  margin-top: 2px;
+  margin-top: var(--space-1);
 }
 .editor input[type='text'],
 .editor select {
@@ -188,18 +188,18 @@ function formatDefault(opt: SettingOption): string {
 .editor .bool {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-3);
   cursor: pointer;
 }
 .editor .color-edit {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 .editor .secret-edit {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 .editor .secret-edit input {
   flex: 1;
@@ -219,7 +219,7 @@ function formatDefault(opt: SettingOption): string {
 }
 .default-line code {
   background: var(--bg-soft);
-  padding: 0 4px;
+  padding: 0 var(--space-2);
 }
 
 .link {

--- a/vue_client/src/components/SettingsSidebar.vue
+++ b/vue_client/src/components/SettingsSidebar.vue
@@ -265,7 +265,6 @@ watch(searchEl, (el) => {
   color: var(--fg-muted);
   text-decoration: none;
   padding: var(--space-2) var(--space-7) var(--space-2) 30px;
-  font-size: 0.9em;
   line-height: 1.35;
   text-transform: lowercase;
   letter-spacing: 0.03em;
@@ -322,13 +321,11 @@ watch(searchEl, (el) => {
   color: var(--fg-muted);
   text-transform: lowercase;
   letter-spacing: 0.04em;
-  font-size: 0.85em;
 }
 .result-key {
   color: var(--fg-muted);
   background: var(--bg-soft);
   padding: 0 var(--space-2);
-  font-size: 0.85em;
   align-self: flex-start;
   max-width: 100%;
   overflow-wrap: anywhere;

--- a/vue_client/src/components/SettingsSidebar.vue
+++ b/vue_client/src/components/SettingsSidebar.vue
@@ -204,19 +204,19 @@ watch(searchEl, (el) => {
   flex: 0 0 auto;
   width: 14em;
   border-right: 1px solid var(--border);
-  padding: 8px 0;
+  padding: var(--space-4) 0;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
 
 .search-wrap {
-  padding: 4px 12px 8px;
+  padding: var(--space-2) var(--space-6) var(--space-4);
 }
 .search {
   width: 100%;
   font: inherit;
-  padding: 4px 6px;
+  padding: var(--space-2) var(--space-3);
   line-height: 1.4;
 }
 .search:focus {
@@ -227,7 +227,7 @@ watch(searchEl, (el) => {
 .sidebar-link {
   color: var(--fg-muted);
   text-decoration: none;
-  padding: 4px 16px;
+  padding: var(--space-2) var(--space-7);
   text-transform: lowercase;
   letter-spacing: 0.04em;
   border-left: 2px solid transparent;
@@ -246,7 +246,7 @@ watch(searchEl, (el) => {
   display: flex;
   flex: 0 0 auto;
   flex-direction: column;
-  margin-bottom: 4px;
+  margin-bottom: var(--space-2);
   max-height: 240px;
   overflow: hidden;
 }
@@ -264,7 +264,7 @@ watch(searchEl, (el) => {
 .sidebar-sublink {
   color: var(--fg-muted);
   text-decoration: none;
-  padding: 4px 16px 4px 30px;
+  padding: var(--space-2) var(--space-7) var(--space-2) 30px;
   font-size: 0.9em;
   line-height: 1.35;
   text-transform: lowercase;
@@ -305,7 +305,7 @@ watch(searchEl, (el) => {
   text-align: left;
   font: inherit;
   cursor: pointer;
-  padding: 6px 16px;
+  padding: var(--space-3) var(--space-7);
   display: flex;
   flex-direction: column;
   gap: 1px;
@@ -327,7 +327,7 @@ watch(searchEl, (el) => {
 .result-key {
   color: var(--fg-muted);
   background: var(--bg-soft);
-  padding: 0 4px;
+  padding: 0 var(--space-2);
   font-size: 0.85em;
   align-self: flex-start;
   max-width: 100%;
@@ -336,7 +336,7 @@ watch(searchEl, (el) => {
 
 .no-match {
   color: var(--fg-muted);
-  padding: 8px 16px;
+  padding: var(--space-4) var(--space-7);
 }
 
 /* The compact picker is mobile-only — the full vertical list of RouterLinks
@@ -355,14 +355,14 @@ watch(searchEl, (el) => {
   .mobile-picker {
     display: block;
     width: calc(100% - 24px);
-    margin: 0 12px 8px;
+    margin: 0 var(--space-6) var(--space-4);
     font: inherit;
     /* Strip the native dropdown chrome so the select sizes identically to the
        search input above (UA select styling otherwise trims its vertical
        size below an <input>'s, even with the same padding/border). */
     appearance: none;
     -webkit-appearance: none;
-    padding: 4px 24px 4px 6px;
+    padding: var(--space-2) var(--space-9) var(--space-2) var(--space-3);
     line-height: 1.4;
     /* Inline SVG chevron replaces the now-stripped native arrow so the user
        still has a visual "I can tap this" cue. Color follows --fg-muted. */

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -96,8 +96,8 @@ const bodyStyle = computed<CSSProperties>(() => {
 
 <style scoped>
 .spoiler {
-  border-radius: 3px;
-  padding: 0 3px;
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-2);
   /* Wrapper-style overrides this for coloured spoilers; the var(--fg-muted)
      fallback covers older snapshots whose segments lack fg. */
   background: var(--fg-muted);

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -352,7 +352,7 @@ function onReturnToPresent() {
   display: flex;
   align-items: center;
   gap: 1ch;
-  padding: 1ch 12px 0;
+  padding: 1ch var(--space-6) 0;
   border-top: 1px solid var(--border);
   color: var(--fg-muted);
   white-space: nowrap;

--- a/vue_client/src/components/SuggestionStrip.vue
+++ b/vue_client/src/components/SuggestionStrip.vue
@@ -129,7 +129,7 @@ watch(
   display: flex;
   align-items: center;
   gap: 1ch;
-  padding: 1ch 12px 0;
+  padding: 1ch var(--space-6) 0;
   background: var(--bg);
   border-top: 1px solid var(--border);
   white-space: nowrap;
@@ -137,7 +137,7 @@ watch(
   overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
-  z-index: 5;
+  z-index: var(--z-raised);
   opacity: 0;
   pointer-events: none;
   transition: opacity 80ms linear;
@@ -159,7 +159,7 @@ watch(
   /* Horizontal padding only — vertical padding would make the chip taller
      than the nick strip's chips, and `align-items: center` on the strip
      would then push the emoji glyph above the StatusBar's text baseline. */
-  padding: 0 6px;
+  padding: 0 var(--space-3);
   font: inherit;
   color: var(--fg);
   cursor: pointer;

--- a/vue_client/src/components/SystemConsole.vue
+++ b/vue_client/src/components/SystemConsole.vue
@@ -75,19 +75,19 @@ watch(
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 6px 12px;
+  padding: var(--space-3) var(--space-6);
   font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   line-height: 1.4;
 }
 .notice.empty {
   color: var(--fg-muted);
   font-style: italic;
-  padding: 12px;
+  padding: var(--space-6);
 }
 .row {
   display: grid;
   grid-template-columns: auto auto 1fr;
-  gap: 8px;
+  gap: var(--space-4);
   align-items: baseline;
 }
 .time {
@@ -103,9 +103,9 @@ watch(
   word-break: break-word;
 }
 .row.lvl-warn .text {
-  color: var(--warn, #d9a300);
+  color: var(--warn);
 }
 .row.lvl-error .text {
-  color: var(--bad, #d33);
+  color: var(--bad);
 }
 </style>

--- a/vue_client/src/components/ToastContainer.vue
+++ b/vue_client/src/components/ToastContainer.vue
@@ -51,21 +51,21 @@ function onClick(t: Toast) {
 <style scoped>
 .toast-stack {
   position: fixed;
-  top: 12px;
-  right: 12px;
+  top: var(--space-6);
+  right: var(--space-6);
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  z-index: 200;
+  gap: var(--space-4);
+  z-index: var(--z-toast);
   pointer-events: none;
-  max-width: min(360px, calc(100vw - 24px));
+  max-width: min(360px, calc(100vw - var(--space-9)));
 }
 .toast {
   pointer-events: auto;
   background: var(--bg);
   border: 1px solid var(--border);
   border-left: 4px solid var(--toast-accent, var(--accent));
-  padding: 10px 12px;
+  padding: var(--space-5) var(--space-6);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
   color: var(--fg);
   animation: toast-in 160ms ease-out;
@@ -101,7 +101,7 @@ function onClick(t: Toast) {
 .row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 .title {
   flex: 1;
@@ -120,7 +120,7 @@ function onClick(t: Toast) {
   color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  padding: 0 2px;
+  padding: 0 var(--space-1);
   line-height: 1;
 }
 .x:hover {
@@ -128,7 +128,7 @@ function onClick(t: Toast) {
 }
 .body {
   color: var(--fg);
-  margin-top: 4px;
+  margin-top: var(--space-2);
   white-space: pre-wrap;
   word-break: break-word;
   display: -webkit-box;

--- a/vue_client/src/components/TopicModal.vue
+++ b/vue_client/src/components/TopicModal.vue
@@ -38,7 +38,7 @@ const word = 'topic';
   /* Break out of card padding so the scrollbar sits against the card
      border; padding keeps content visually aligned with the rest. */
   margin: 0 calc(-1 * var(--card-pad-x));
-  padding: 16px var(--card-pad-x) 0;
+  padding: var(--space-7) var(--card-pad-x) 0;
   overflow-y: auto;
   flex: 1;
   min-height: 0;

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -377,20 +377,20 @@ function copyHostmask() {
 .body {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: var(--space-8);
   overflow-y: auto;
   flex: 1;
   min-height: 0;
   /* Break out of card padding so the scrollbar sits against the card
      border; padding keeps section content visually aligned. */
   margin: 0 calc(-1 * var(--card-pad-x));
-  padding: 0 var(--card-pad-x) 8px;
+  padding: 0 var(--card-pad-x) var(--space-4);
 }
 
 .presence {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-3);
   color: var(--fg);
   font-weight: 600;
 }
@@ -402,10 +402,10 @@ function copyHostmask() {
   background: var(--fg-muted);
 }
 .presence.online .dot {
-  background: var(--good, #4ec27e);
+  background: var(--good);
 }
 .presence.away .dot {
-  background: var(--warn, #d4a256);
+  background: var(--warn);
 }
 .presence.offline .dot {
   background: var(--bad);
@@ -414,13 +414,13 @@ function copyHostmask() {
   background: var(--fg-muted);
 }
 .away-msg {
-  margin-left: 8px;
+  margin-left: var(--space-4);
   color: var(--fg-muted);
   font-weight: 400;
 }
 
 .section h3 {
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-4);
   color: var(--accent);
   font-weight: 700;
   text-transform: lowercase;
@@ -430,8 +430,8 @@ function copyHostmask() {
 dl {
   display: grid;
   grid-template-columns: max-content 1fr;
-  column-gap: 16px;
-  row-gap: 6px;
+  column-gap: var(--space-7);
+  row-gap: var(--space-3);
   margin: 0;
 }
 dt {
@@ -456,31 +456,31 @@ code {
 .chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 10px;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
 }
 .chip {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-2);
   border: 1px solid var(--border);
-  padding: 2px 8px;
-  border-radius: 999px;
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--radius-pill);
   color: var(--fg);
 }
 .chip.good {
-  border-color: var(--good, #4ec27e);
-  color: var(--good, #4ec27e);
+  border-color: var(--good);
+  color: var(--good);
 }
 .chip.warn {
-  border-color: var(--warn, #d4a256);
-  color: var(--warn, #d4a256);
+  border-color: var(--warn);
+  color: var(--warn);
 }
 
 .channels {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 10px;
+  gap: var(--space-2) var(--space-5);
 }
 .channel {
   background: none;
@@ -506,13 +506,13 @@ code {
 .note.empty {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-6);
 }
 .meta {
-  margin: 8px 0 0;
+  margin: var(--space-4) 0 0;
   color: var(--fg-muted);
   display: flex;
-  gap: 12px;
+  gap: var(--space-6);
   align-items: baseline;
 }
 
@@ -522,21 +522,21 @@ code {
   color: var(--accent);
   cursor: pointer;
   font: inherit;
-  padding: 0 4px;
+  padding: 0 var(--space-2);
 }
 .link.inline:hover {
   text-decoration: underline;
 }
 
 .status {
-  padding: 12px 0;
+  padding: var(--space-6) 0;
 }
 
 .footer {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding-top: 16px;
+  gap: var(--space-4);
+  padding-top: var(--space-7);
   border-top: 1px solid var(--border);
 }
 .footer .spacer {
@@ -546,12 +546,12 @@ code {
   background: none;
   border: 1px solid var(--border);
   color: var(--fg);
-  padding: 6px 12px;
+  padding: var(--space-3) var(--space-6);
   cursor: pointer;
   font: inherit;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-3);
 }
 .btn-secondary:hover:not(:disabled) {
   background: var(--bg-soft);

--- a/vue_client/src/components/settings-panes/AboutPane.vue
+++ b/vue_client/src/components/settings-panes/AboutPane.vue
@@ -71,7 +71,6 @@ const appVersion = APP_VERSION;
 .about-links .about-label {
   color: var(--fg-muted);
   text-transform: uppercase;
-  font-size: 0.8em;
   letter-spacing: 0.04em;
   min-width: 60px;
 }

--- a/vue_client/src/components/settings-panes/AboutPane.vue
+++ b/vue_client/src/components/settings-panes/AboutPane.vue
@@ -49,24 +49,24 @@ const appVersion = APP_VERSION;
 <style src="./panes.css"></style>
 <style scoped>
 .about-warning {
-  margin: 20px 0 0;
-  padding: 8px 10px;
+  margin: var(--space-8) 0 0;
+  padding: var(--space-4) var(--space-5);
   border: 1px solid var(--warn, var(--accent));
   color: var(--warn, var(--accent));
   background: transparent;
 }
 .about-links {
   list-style: none;
-  margin: 8px 0 0;
+  margin: var(--space-4) 0 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-3);
 }
 .about-links li {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: var(--space-5);
 }
 .about-links .about-label {
   color: var(--fg-muted);

--- a/vue_client/src/components/settings-panes/AccountPane.vue
+++ b/vue_client/src/components/settings-panes/AccountPane.vue
@@ -285,7 +285,6 @@ async function signOut() {
 .password-form label span {
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 0.85em;
 }
 .password-actions {
   display: flex;

--- a/vue_client/src/components/settings-panes/AccountPane.vue
+++ b/vue_client/src/components/settings-panes/AccountPane.vue
@@ -247,7 +247,7 @@ async function signOut() {
 <style src="./panes.css"></style>
 <style scoped>
 .account-identity {
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-6);
   color: var(--fg-muted);
 }
 .account-identity strong {
@@ -259,27 +259,27 @@ async function signOut() {
   background: transparent;
   border: 1px solid transparent;
   color: var(--fg);
-  padding: 2px 4px;
+  padding: var(--space-1) var(--space-2);
 }
 .passkey .ua input[type='text']:hover,
 .passkey .ua input[type='text']:focus {
   border-color: var(--border);
 }
 .passkey-add {
-  padding-top: 8px;
+  padding-top: var(--space-4);
 }
 
 .password-form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 4px;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
   max-width: 360px;
 }
 .password-form label {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-1);
   color: var(--fg-muted);
 }
 .password-form label span {
@@ -291,10 +291,10 @@ async function signOut() {
   display: flex;
   gap: 1ch;
   align-items: center;
-  margin-top: 2px;
+  margin-top: var(--space-1);
 }
 .signout-row {
-  margin-top: 16px;
+  margin-top: var(--space-7);
   display: flex;
   justify-content: flex-start;
 }

--- a/vue_client/src/components/settings-panes/ApiTokensPane.vue
+++ b/vue_client/src/components/settings-panes/ApiTokensPane.vue
@@ -191,7 +191,6 @@ async function onRevoke(token: ApiToken) {
 .create-form label span {
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 0.85em;
 }
 .create-form label.check span {
   text-transform: none;

--- a/vue_client/src/components/settings-panes/ApiTokensPane.vue
+++ b/vue_client/src/components/settings-panes/ApiTokensPane.vue
@@ -172,20 +172,20 @@ async function onRevoke(token: ApiToken) {
 .create-form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 4px;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
   max-width: 360px;
 }
 .create-form label {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-1);
   color: var(--fg-muted);
 }
 .create-form label.check {
   flex-direction: row;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
   color: var(--fg);
 }
 .create-form label span {
@@ -202,17 +202,17 @@ async function onRevoke(token: ApiToken) {
   display: flex;
   gap: 1ch;
   align-items: center;
-  margin-top: 2px;
+  margin-top: var(--space-1);
 }
 
 .reveal {
-  margin: 12px 0;
-  padding: 10px 12px;
+  margin: var(--space-6) 0;
+  padding: var(--space-5) var(--space-6);
   border: 1px solid var(--accent);
   background: var(--bg-soft);
 }
 .reveal-warning {
-  margin: 0 0 6px;
+  margin: 0 0 var(--space-3);
   color: var(--fg);
 }
 .reveal-row {
@@ -227,7 +227,7 @@ async function onRevoke(token: ApiToken) {
   word-break: break-all;
   user-select: all;
   background: var(--bg);
-  padding: 4px 8px;
+  padding: var(--space-2) var(--space-4);
   border: 1px solid var(--border);
   min-width: 0;
 }

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -176,36 +176,36 @@ function formatBytes(n: number): string {
 <style scoped>
 .counts {
   list-style: disc;
-  padding-left: 24px;
-  margin: 4px 0 10px;
+  padding-left: var(--space-9);
+  margin: var(--space-2) 0 var(--space-5);
   color: var(--fg-muted);
 }
 .counts li {
-  padding: 2px 0;
+  padding: var(--space-1) 0;
 }
 
 .opt {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 0;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
 }
 
 .actions {
   display: flex;
   gap: 1ch;
   align-items: center;
-  padding-top: 6px;
+  padding-top: var(--space-3);
 }
 
 .picker {
-  padding-top: 6px;
+  padding-top: var(--space-3);
 }
 .chosen-row {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 6px 0;
+  gap: var(--space-6);
+  padding: var(--space-3) 0;
 }
 .chosen-row .filename {
   color: var(--fg);

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -183,7 +183,6 @@ async function onRuleAdd() {
   color: var(--fg-muted);
 }
 .lock {
-  font-size: 12px;
   color: var(--fg-muted);
   text-align: center;
 }

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -169,8 +169,8 @@ async function onRuleAdd() {
   display: grid;
   grid-template-columns: 18px minmax(120px, 1fr) max-content max-content max-content max-content;
   align-items: center;
-  gap: 8px;
-  padding: 6px 0;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
   border-top: 1px solid var(--border);
 }
 .rule:first-child {
@@ -190,15 +190,15 @@ async function onRuleAdd() {
 .rule .ck {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-2);
   color: var(--fg-muted);
   cursor: pointer;
 }
 .rule-add {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding-top: 10px;
+  gap: var(--space-4);
+  padding-top: var(--space-5);
 }
 .rule-add input[type='text'] {
   flex: 1;

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -140,8 +140,8 @@ function onIgnoreRemove(networkId: number, mask: string) {
 .rule-add {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding-top: 10px;
+  gap: var(--space-4);
+  padding-top: var(--space-5);
 }
 .rule-add input[type='text'] {
   flex: 1;

--- a/vue_client/src/components/settings-panes/NetworksPane.vue
+++ b/vue_client/src/components/settings-panes/NetworksPane.vue
@@ -95,9 +95,9 @@ async function onDragEnd() {
 .network {
   display: grid;
   grid-template-columns: max-content max-content 1fr;
-  gap: 12px;
+  gap: var(--space-6);
   align-items: center;
-  padding: 8px 4px;
+  padding: var(--space-4) var(--space-2);
   border-top: 1px solid var(--border);
 }
 .network:first-child {
@@ -109,7 +109,7 @@ async function onDragEnd() {
 .grip {
   color: var(--fg-muted);
   cursor: grab;
-  padding: 0 2px;
+  padding: 0 var(--space-1);
 }
 .grip:active {
   cursor: grabbing;

--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -445,7 +445,6 @@ function formatUA(ua: string | null | undefined): string {
 }
 .notif-signal-title {
   margin: 0 0 var(--space-2);
-  font-size: 0.92em;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--fg);

--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -430,8 +430,8 @@ function formatUA(ua: string | null | undefined): string {
 .this-client {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 0 0 10px;
+  gap: var(--space-6);
+  padding: 0 0 var(--space-5);
 }
 .this-label {
   color: var(--fg-muted);
@@ -444,7 +444,7 @@ function formatUA(ua: string | null | undefined): string {
   border-top: 1px dashed var(--border);
 }
 .notif-signal-title {
-  margin: 0 0 4px;
+  margin: 0 0 var(--space-2);
   font-size: 0.92em;
   text-transform: uppercase;
   letter-spacing: 0.04em;

--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -439,8 +439,8 @@ function formatUA(ua: string | null | undefined): string {
 }
 
 .notif-signal + .notif-signal {
-  margin-top: 18px;
-  padding-top: 14px;
+  margin-top: var(--space-7);
+  padding-top: var(--space-6);
   border-top: 1px dashed var(--border);
 }
 .notif-signal-title {

--- a/vue_client/src/components/settings-panes/UsersPane.vue
+++ b/vue_client/src/components/settings-panes/UsersPane.vue
@@ -183,7 +183,6 @@ function copyInviteUrl(url: string) {
   border: 1px solid var(--accent);
   padding: 0 var(--space-2);
   margin-left: var(--space-3);
-  font-size: 0.85em;
   text-transform: uppercase;
 }
 .invite-actions {
@@ -198,7 +197,6 @@ function copyInviteUrl(url: string) {
   align-items: center;
   gap: var(--space-3);
   color: var(--fg-muted);
-  font-size: 0.95em;
 }
 .invite-fresh code {
   background: var(--bg-soft);
@@ -215,11 +213,11 @@ function copyInviteUrl(url: string) {
   background: var(--bg-soft);
   padding: 1px var(--space-2);
   word-break: break-all;
-  font-size: 0.9em;
+  color: var(--fg-muted);
 }
 .invite-status {
   text-transform: uppercase;
-  font-size: 0.8em;
+  color: var(--fg-muted);
   padding: 0 var(--space-2);
   border: 1px solid var(--border);
 }

--- a/vue_client/src/components/settings-panes/UsersPane.vue
+++ b/vue_client/src/components/settings-panes/UsersPane.vue
@@ -181,46 +181,46 @@ function copyInviteUrl(url: string) {
 .user-row .role-tag {
   color: var(--accent);
   border: 1px solid var(--accent);
-  padding: 0 4px;
-  margin-left: 6px;
+  padding: 0 var(--space-2);
+  margin-left: var(--space-3);
   font-size: 0.85em;
   text-transform: uppercase;
 }
 .invite-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 0 0 10px;
+  gap: var(--space-6);
+  padding: 0 0 var(--space-5);
   flex-wrap: wrap;
 }
 .invite-fresh {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-3);
   color: var(--fg-muted);
   font-size: 0.95em;
 }
 .invite-fresh code {
   background: var(--bg-soft);
-  padding: 1px 4px;
+  padding: 1px var(--space-2);
   word-break: break-all;
 }
 .invite-row .ua {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-3);
 }
 .invite-url {
   background: var(--bg-soft);
-  padding: 1px 4px;
+  padding: 1px var(--space-2);
   word-break: break-all;
   font-size: 0.9em;
 }
 .invite-status {
   text-transform: uppercase;
   font-size: 0.8em;
-  padding: 0 4px;
+  padding: 0 var(--space-2);
   border: 1px solid var(--border);
 }
 .invite-status.status-pending {

--- a/vue_client/src/components/settings-panes/panes.css
+++ b/vue_client/src/components/settings-panes/panes.css
@@ -18,7 +18,6 @@
   color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  font-size: 1.05em;
   font-weight: 600;
 }
 .settings-pane .section-desc {
@@ -30,7 +29,6 @@
   color: var(--fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  font-size: 0.9em;
   font-weight: 600;
 }
 .settings-pane > .subhead:first-of-type {
@@ -67,7 +65,7 @@
   font-style: italic;
 }
 .settings-pane .muted.small {
-  font-size: 0.95em;
+  color: var(--fg-muted);
   padding: var(--space-2) 0;
   font-style: normal;
 }
@@ -97,7 +95,6 @@
 }
 .settings-pane .device .last-seen {
   color: var(--fg-muted);
-  font-size: 0.95em;
 }
 
 .settings-pane .hl-sep {

--- a/vue_client/src/components/settings-panes/panes.css
+++ b/vue_client/src/components/settings-panes/panes.css
@@ -8,13 +8,13 @@
  */
 
 .settings-pane {
-  padding: 16px;
+  padding: var(--space-7);
 }
 .settings-pane > * {
   max-width: 70ch;
 }
 .settings-pane h2 {
-  margin: 0 0 6px;
+  margin: 0 0 var(--space-3);
   color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -23,10 +23,10 @@
 }
 .settings-pane .section-desc {
   color: var(--fg-muted);
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-6);
 }
 .settings-pane .subhead {
-  margin: 18px 0 6px;
+  margin: 18px 0 var(--space-3);
   color: var(--fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -34,14 +34,14 @@
   font-weight: 600;
 }
 .settings-pane > .subhead:first-of-type {
-  margin-top: 4px;
+  margin-top: var(--space-2);
 }
 
 .settings-pane .link {
   background: none;
   border: none;
   color: var(--accent);
-  padding: 2px 6px;
+  padding: var(--space-1) var(--space-3);
   cursor: pointer;
   font: inherit;
 }
@@ -58,17 +58,17 @@
 
 .settings-pane .error.inline {
   color: var(--bad);
-  padding: 0 0 6px;
+  padding: 0 0 var(--space-3);
   margin: 0;
 }
 .settings-pane .muted {
   color: var(--fg-muted);
-  padding: 16px;
+  padding: var(--space-7);
   font-style: italic;
 }
 .settings-pane .muted.small {
   font-size: 0.95em;
-  padding: 4px 0;
+  padding: var(--space-2) 0;
   font-style: normal;
 }
 
@@ -81,9 +81,9 @@
 .settings-pane .device {
   display: grid;
   grid-template-columns: 1fr max-content max-content;
-  gap: 12px;
+  gap: var(--space-6);
   align-items: center;
-  padding: 6px 0;
+  padding: var(--space-3) 0;
   border-top: 1px solid var(--border);
 }
 .settings-pane .device:first-child {
@@ -112,13 +112,13 @@
 .settings-pane .hl-notif {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 4px 0 0;
+  gap: var(--space-3);
+  padding: var(--space-2) 0 0;
 }
 .settings-pane .hl-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-5);
 }
 .settings-pane .hl-row select {
   min-width: 160px;

--- a/vue_client/src/components/settings-panes/panes.css
+++ b/vue_client/src/components/settings-panes/panes.css
@@ -25,7 +25,7 @@
   margin: 0 0 var(--space-6);
 }
 .settings-pane .subhead {
-  margin: 18px 0 var(--space-3);
+  margin: var(--space-7) 0 var(--space-3);
   color: var(--fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -100,7 +100,7 @@
 .settings-pane .hl-sep {
   border: none;
   border-top: 1px solid var(--border);
-  margin: 28px 0 22px;
+  margin: var(--space-9) 0 var(--space-9);
   width: 100%;
 }
 

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -496,11 +496,11 @@ useChatBootstrap({ onJump: onJumpToMessage });
   flex-direction: column;
 }
 .sidebar-head {
-  padding: 8px 12px;
+  padding: var(--space-4) var(--space-6);
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 .head-spacer {
   flex: 1;
@@ -539,13 +539,13 @@ useChatBootstrap({ onJump: onJumpToMessage });
    (issue #64). */
 .sidebar-foot {
   margin-top: auto;
-  padding: 1ch 12px 8px;
+  padding: 1ch var(--space-6) var(--space-4);
   border-top: 1px solid var(--border);
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: var(--space-4);
   /* Match the input bar's line-height (1.4) — the body default of 1.55
      would leave the foot's content row visibly taller than the input's
      content row at the same font size. See the matching override on
@@ -566,13 +566,13 @@ useChatBootstrap({ onJump: onJumpToMessage });
    center everything in the 36px column. Foot icons keep their muscle-memory
    spot at the bottom of the sidebar; the toggle chevron sits up top. */
 .sidebar.collapsed .sidebar-head {
-  padding: 8px 0;
+  padding: var(--space-4) 0;
   justify-content: center;
 }
 .sidebar.collapsed .sidebar-foot {
   flex-direction: column;
-  padding: 8px 0;
-  gap: 8px;
+  padding: var(--space-4) 0;
+  gap: var(--space-4);
   justify-content: flex-end;
 }
 
@@ -580,7 +580,7 @@ useChatBootstrap({ onJump: onJumpToMessage });
   background: none;
   border: none;
   color: var(--accent);
-  padding: 0 4px;
+  padding: 0 var(--space-2);
   cursor: pointer;
   font: inherit;
   text-decoration: none;
@@ -597,7 +597,7 @@ useChatBootstrap({ onJump: onJumpToMessage });
 
 .topic {
   grid-area: topic;
-  padding: 8px 12px;
+  padding: var(--space-4) var(--space-6);
   display: flex;
   align-items: baseline;
   gap: 1ch;
@@ -676,25 +676,25 @@ button.buffer.link:hover {
 .topic .buffer-cog,
 .topic .server-right-start {
   margin-left: auto;
-  padding-left: 8px;
+  padding-left: var(--space-4);
 }
 .topic .network-cog {
-  padding-left: 8px;
+  padding-left: var(--space-4);
 }
 .topic .buffer-cog + .members-toggle {
   margin-left: 0;
-  padding-left: 4px;
+  padding-left: var(--space-2);
 }
 .topic .members-toggle {
   margin-left: auto;
-  padding-left: 8px;
+  padding-left: var(--space-4);
 }
 /* Word-button styling for the server-buffer affordances (Channel List,
    Disconnect/Reconnect). They cluster on the right alongside the
    network-cog — the first one (Channel List) carries margin-left:auto via
    .server-right-start, and the rest follow it in DOM order. */
 .topic .link.word {
-  padding: 0 6px;
+  padding: 0 var(--space-3);
 }
 .topic .member-count {
   color: var(--fg-muted);

--- a/vue_client/src/views/InviteAccept.vue
+++ b/vue_client/src/views/InviteAccept.vue
@@ -179,6 +179,5 @@ button {
 .hint {
   margin: 0;
   color: var(--fg-muted);
-  font-size: 0.9em;
 }
 </style>

--- a/vue_client/src/views/InviteAccept.vue
+++ b/vue_client/src/views/InviteAccept.vue
@@ -122,11 +122,11 @@ async function onAccept() {
 }
 .card {
   border: 1px solid var(--accent);
-  padding: 20px 24px;
+  padding: var(--space-8) var(--space-9);
   width: 360px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-6);
 }
 h1 {
   margin: 0;
@@ -144,7 +144,7 @@ h1 {
 }
 .warning {
   margin: 0;
-  padding: 8px 10px;
+  padding: var(--space-4) var(--space-5);
   border: 1px solid var(--warn, var(--accent));
   color: var(--warn, var(--accent));
   background: transparent;
@@ -152,7 +152,7 @@ h1 {
 form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-6);
   margin: 0;
 }
 label {
@@ -167,7 +167,7 @@ label span {
 }
 button {
   cursor: pointer;
-  padding: 8px 12px;
+  padding: var(--space-4) var(--space-6);
 }
 .error {
   margin: 0;

--- a/vue_client/src/views/InviteAccept.vue
+++ b/vue_client/src/views/InviteAccept.vue
@@ -158,7 +158,7 @@ form {
 label {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: var(--space-2);
   color: var(--fg-muted);
 }
 label span {

--- a/vue_client/src/views/Login.vue
+++ b/vue_client/src/views/Login.vue
@@ -262,6 +262,5 @@ button.primary {
 .hint {
   margin: 0;
   color: var(--fg-muted);
-  font-size: 0.9em;
 }
 </style>

--- a/vue_client/src/views/Login.vue
+++ b/vue_client/src/views/Login.vue
@@ -190,17 +190,17 @@ async function onCreateUser() {
 }
 .card {
   position: relative;
-  z-index: 1;
+  z-index: var(--z-base);
   background: var(--bg);
   border: 1px solid var(--accent);
-  padding: 24px 28px;
+  padding: var(--space-9) 28px;
   width: 360px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-6);
 }
 h1 {
-  margin: 0 0 4px;
+  margin: 0 0 var(--space-2);
   color: var(--accent);
   font-weight: 700;
   text-transform: lowercase;
@@ -214,7 +214,7 @@ h1 {
 }
 .warning {
   margin: 0;
-  padding: 8px 10px;
+  padding: var(--space-4) var(--space-5);
   border: 1px solid var(--warn, var(--accent));
   color: var(--warn, var(--accent));
   background: transparent;
@@ -222,7 +222,7 @@ h1 {
 form {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--space-6);
   margin: 0;
 }
 label {
@@ -239,7 +239,7 @@ button {
   cursor: pointer;
 }
 button.primary {
-  padding: 8px 12px;
+  padding: var(--space-4) var(--space-6);
 }
 .error {
   margin: 0;
@@ -257,7 +257,7 @@ button.primary {
   color: var(--fg);
 }
 .password-form {
-  margin-top: 4px;
+  margin-top: var(--space-2);
 }
 .hint {
   margin: 0;

--- a/vue_client/src/views/Login.vue
+++ b/vue_client/src/views/Login.vue
@@ -193,7 +193,7 @@ async function onCreateUser() {
   z-index: var(--z-base);
   background: var(--bg);
   border: 1px solid var(--accent);
-  padding: var(--space-9) 28px;
+  padding: var(--space-9);
   width: 360px;
   display: flex;
   flex-direction: column;
@@ -228,7 +228,7 @@ form {
 label {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: var(--space-2);
   color: var(--fg-muted);
 }
 label span {

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -364,8 +364,8 @@ useChatBootstrap({ onJump: onJumpToMessage });
 .bar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: var(--space-4);
+  padding: var(--space-5) var(--space-6);
   border-bottom: 1px solid var(--border);
   flex: 0 0 auto;
 }
@@ -408,7 +408,7 @@ useChatBootstrap({ onJump: onJumpToMessage });
   background: none;
   border: none;
   color: var(--accent);
-  padding: 4px 8px;
+  padding: var(--space-2) var(--space-4);
   cursor: pointer;
   font: inherit;
   text-decoration: none;
@@ -435,7 +435,7 @@ useChatBootstrap({ onJump: onJumpToMessage });
   color: var(--accent);
   cursor: pointer;
   font: inherit;
-  padding: 4px 8px;
+  padding: var(--space-2) var(--space-4);
   min-height: 36px;
   white-space: nowrap;
 }


### PR DESCRIPTION
Standardizes the hardcoded values scattered through the client CSS into a documented design-token system. Prompted by designer feedback that the codebase had a lot of one-off pixel values. Feature set is stable, so this is a consistency/maintainability pass with no functional changes.

## Structure — four commits, the visual ones isolated for easy revert

| Commit | What | Visual change |
|---|---|---|
| Tokenize spacing, z-index, scrim, fallbacks | `--space-1..10` scale (~356 values), role-named z-index ladder, `--scrim`, dropped stale color fallbacks | **None** — exact-equivalent mapping |
| Collapse font-size overrides | 40 `font-size` overrides removed across 22 files; hierarchy via `--fg-muted`/weight | Yes — isolated |
| Snap off-grid spacing and radii | off-grid `14/18/28/22/3px` → nearest scale step; add `--radius-sm/md` | Yes — isolated |
| Add design-token reference doc | `docs/DESIGN_TOKENS.md` | None |

## Key ideas
- **Two token tiers.** Themeable tokens (colors/font) flow through `useTheme()` from the settings registry. New **internal** tokens (spacing, z-index, scrim, radius) are deliberately *not* wired into settings — they're for consistency, not user theming.
- **One font size, enforced.** The "hierarchy via color/weight, not size" principle is now actually true in the code. Hero/brand `clamp()` display titles (Login, modal headers, WordBackdrop) are the documented exception.
- **z-index by role**, with values preserving the shipped stacking order.

## What was deliberately left literal
Borders (`1px`), one-off layout dimensions/breakpoints, shadow/transform geometry, `1px` hairline paddings in dense rows, SettingsSidebar's tree-guide positioning, and relative units. Tokenizing these would add indirection with no consistency payoff.

## Verification
`typecheck` (server + client), `lint`, `format:check`, and `client:build` all pass. The two visual commits were reviewed locally in the running app.

## Follow-ups
- #143 — tokenize box-shadows (the last untokenized style family)
- #144 — better word-wrap strategy for in-channel markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)