### PR TITLE
Wrap in-channel marker labels; drop redundant em-dashes (#144)

### DIFF
--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -27,7 +27,9 @@
         >
       </div>
       <div v-else-if="row.divider === 'back'" class="notice presence-divider">
-        <span class="notice-label">back (gone {{ formatDuration(row.awayAt ?? '', row.backAt ?? '') }})</span>
+        <span class="notice-label"
+          >back (gone {{ formatDuration(row.awayAt ?? '', row.backAt ?? '') }})</span
+        >
       </div>
       <div v-else-if="row.divider === 'date'" class="notice date-divider">
         <span class="notice-label">{{ row.dateStr }}</span>

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -18,19 +18,27 @@
     <div v-if="!buffer?.hasMoreOlder && messages.length" class="notice">— start of history —</div>
     <p v-if="!messages.length" class="notice empty">No messages yet.</p>
     <template v-for="row in renderRows" :key="row.key">
-      <div v-if="row.divider === 'unread'" class="notice unread-divider">— unread —</div>
+      <div v-if="row.divider === 'unread'" class="notice unread-divider">
+        <span class="notice-label">unread</span>
+      </div>
       <div v-else-if="row.divider === 'away'" class="notice presence-divider">
-        — away<template v-if="row.awayMessage">: {{ row.awayMessage }}</template> —
+        <span class="notice-label"
+          >away<template v-if="row.awayMessage">: {{ row.awayMessage }}</template></span
+        >
       </div>
       <div v-else-if="row.divider === 'back'" class="notice presence-divider">
-        — back (gone {{ formatDuration(row.awayAt ?? '', row.backAt ?? '') }}) —
+        <span class="notice-label">back (gone {{ formatDuration(row.awayAt ?? '', row.backAt ?? '') }})</span>
       </div>
-      <div v-else-if="row.divider === 'date'" class="notice date-divider">{{ row.dateStr }}</div>
+      <div v-else-if="row.divider === 'date'" class="notice date-divider">
+        <span class="notice-label">{{ row.dateStr }}</span>
+      </div>
       <div v-else-if="row.divider === 'cleared'" class="notice cleared-divider">
-        cleared {{ formatDateTime(row.clearedAt ?? '') }}
-        <button type="button" class="cleared-undo" @click="onUnclearClick">
-          Show earlier messages
-        </button>
+        <span class="notice-label"
+          >cleared {{ formatDateTime(row.clearedAt ?? '') }}
+          <button type="button" class="cleared-undo" @click="onUnclearClick">
+            Show earlier messages
+          </button></span
+        >
       </div>
       <div
         v-else-if="row.consolidation"
@@ -1412,6 +1420,7 @@ watch(
 .unread-divider::after {
   content: '';
   flex: 1;
+  min-width: var(--space-7);
   border-top: 1px dashed var(--warn);
   opacity: 0.6;
 }
@@ -1439,8 +1448,22 @@ watch(
 .cleared-divider::after {
   content: '';
   flex: 1;
+  min-width: var(--space-7);
   border-top: 1px dashed var(--fg-muted);
   opacity: 0.6;
+}
+
+/* Center label for all flanked markers. Shrinks and wraps as a centered block
+   between the two rules (which floor at min-width and stay vertically centered),
+   so long labels — the unbounded /away reason worst case — wrap cleanly instead
+   of crowding out the lines. overflow-wrap: anywhere only breaks mid-word as a
+   last resort for an unbreakable token; word boundaries are preferred so the
+   uppercase + letter-spacing styling stays readable. */
+.notice-label {
+  flex: 0 1 auto;
+  min-width: 0;
+  text-align: center;
+  overflow-wrap: anywhere;
 }
 
 /* Undo affordance on the /clear divider — text-only button styled inline


### PR DESCRIPTION
Closes #144.

The structural markers in `MessageList.vue` (unread / away / back / date / cleared) render as a center label flanked by `flex: 1` dashed rules. The center label had no wrap or truncation strategy, so long labels — the unbounded `/away` reason worst case, plus `back (gone 3 hours 20 minutes)` and the cleared marker's embedded button — crowded out the flanking rules or wrapped awkwardly (uppercase + `letter-spacing` makes mid-word wraps read especially badly).

## Strategy

Center label wraps as a centered block; the flanking dashed rules stay vertically centered and floor at a small `min-width` so they never collapse to nothing. Chosen over ellipsis-with-tooltip because the away reason is unbounded user text and a tooltip hides it permanently on mobile (no hover) — wrapping never loses information.

## Changes

- Wrap each marker's center content in a single `.notice-label` span (the cleared marker's "Show earlier messages" button now lives *inside* it, so the whole center group wraps as one block between the rules).
- `.notice-label` shrinks (`min-width: 0`) and wraps as a centered block; `overflow-wrap: anywhere` breaks mid-word only as a last resort so word boundaries are preferred and the uppercase + `letter-spacing` styling stays readable.
- Floor the `::before`/`::after` rules at `min-width: var(--space-7)` so they degrade to visible stubs instead of vanishing when the label is long.
- String audit: drop the literal `—` em-dashes from `unread`/`away`/`back` — the dashed rules already supply the flanking, so the dashes were doubled. All five flanked markers now read uniformly (`date`/`cleared` already omitted them). The plain `— start of history —` notice keeps its dashes since it has no rules.

`away:` (colon, free-text reason) vs `back (…)` (parens, computed duration) punctuation is kept intentionally distinct.

## Testing

- `npm run typecheck` clean (vue-tsc compiles the templates).
- Visual wrap behavior on a long `/away` reason at narrow widths not yet eyeballed in a running client — worth a quick look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)