### PR TITLE
Add node-mode edition flag + public /api/config (A1)

### DIFF
--- a/server/routes/config.test.ts
+++ b/server/routes/config.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+// Edition is resolved from LURKER_EDITION the first time getEdition() runs and
+// then cached for the process. vitest runs each test file in its own process, so
+// setting it here before importing the router scopes it to this file and lets us
+// assert the endpoint reflects the hosted-node edition.
+process.env.LURKER_EDITION = 'node';
+
+import type { Express } from 'express';
+import { createTestApp, createAnonAgent } from '../test-utils/testApp.js';
+
+let app: Express;
+
+beforeAll(async () => {
+  const router = (await import('./config.js')).default;
+  app = createTestApp({ '/api/config': router });
+});
+
+afterAll(() => {
+  delete process.env.LURKER_EDITION;
+});
+
+describe('GET /api/config', () => {
+  it('is public (no auth) and reports the edition', async () => {
+    const res = await createAnonAgent(app).get('/api/config');
+    expect(res.status).toBe(200);
+    expect(res.body.edition).toBe('node');
+  });
+});

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { getEdition } from '../utils/edition.js';
+
+const router = Router();
+
+// Public, unauthenticated bootstrap config the client can read before login so
+// the UI can branch on deployment edition (self-hosted vs hosted node). Keep
+// this lean and strictly non-sensitive — it is served to anyone who hits the
+// origin. Edition is the only field today; A3 consumes it client-side.
+router.get('/', (_req: Request, res: Response) => {
+  res.json({ edition: getEdition() });
+});
+
+export default router;

--- a/server/server.ts
+++ b/server/server.ts
@@ -21,6 +21,7 @@ import uploadsRouter from './routes/uploads.js';
 import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
+import configRouter from './routes/config.js';
 import ircManager from './services/ircManager.js';
 import { attachWsHub } from './services/wsHub.js';
 import './services/verbs/index.js';
@@ -29,12 +30,15 @@ import { requireApiAuth } from './middleware/apiAuth.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
+import { getEdition } from './utils/edition.js';
 
 const PORT = Number(process.env.PORT || 8010);
+const EDITION = getEdition();
 const { secret: SESSION_SECRET, source: sessionSecretSource } = resolveSessionSecret();
 if (sessionSecretSource === 'generated') {
   console.log('[lurker] generated new session secret in data/session-secret.key');
 }
+console.log(`[lurker] edition: ${EDITION}`);
 
 const app = express();
 
@@ -56,6 +60,7 @@ app.use('/api/drafts', draftsRouter);
 app.use('/api/exports', exportsRouter);
 app.use('/api/imports', importRouter);
 app.use('/api/api-tokens', apiTokensRouter);
+app.use('/api/config', configRouter);
 
 app.use('/mcp', requireApiAuth, mcpRouter);
 
@@ -84,7 +89,7 @@ attachWsHub(server, SESSION_SECRET);
 purgeExpiredSessions();
 setInterval(purgeExpiredSessions, 60 * 60 * 1000).unref();
 
-systemLog.log({ scope: 'server', text: 'Lurker server starting up' });
+systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${EDITION})` });
 
 ircManager.initAll();
 

--- a/server/utils/edition.test.ts
+++ b/server/utils/edition.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { parseEdition } from './edition.js';
+
+describe('parseEdition', () => {
+  it('defaults to standalone when unset or blank', () => {
+    expect(parseEdition(undefined)).toBe('standalone');
+    expect(parseEdition('')).toBe('standalone');
+    expect(parseEdition('   ')).toBe('standalone');
+  });
+
+  it('accepts the known editions, case- and whitespace-insensitively', () => {
+    expect(parseEdition('standalone')).toBe('standalone');
+    expect(parseEdition('node')).toBe('node');
+    expect(parseEdition('NODE')).toBe('node');
+    expect(parseEdition('  Node ')).toBe('node');
+  });
+
+  it('warns and falls back to standalone on an unknown value', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseEdition('cell')).toBe('standalone');
+    expect(parseEdition('hosted')).toBe('standalone');
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+});

--- a/server/utils/edition.ts
+++ b/server/utils/edition.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Deployment edition for this Lurker instance — the single source of truth for
+// "is this a self-hosted instance, or a cell in the hosted lurker.chat service?"
+//
+//   'standalone' — the default, and the only mode self-hosters ever run: one
+//     instance, one operator, fully featured (admin UI, invites, and server
+//     config all visible). Unchanged behavior for every existing deploy.
+//   'node'       — this instance is a *cell* in the hosted service, managed by a
+//     remote orchestrator (the control plane). Node mode gates operator-only UI
+//     (A3), exposes an orchestrator-authenticated control API (A2), and
+//     registers + heartbeats to the control plane (A4).
+//
+// Edition is fixed for the process lifetime: it is read once from LURKER_EDITION
+// and cached. Anything that never sets the var stays 'standalone', so this is a
+// zero-impact addition for self-hosted installs.
+
+export type Edition = 'standalone' | 'node';
+
+const EDITIONS: readonly Edition[] = ['standalone', 'node'];
+
+/**
+ * Parse a raw LURKER_EDITION value into an Edition. Pure (no env access) so the
+ * parsing rules can be unit-tested directly. Empty/unset means standalone; an
+ * unrecognized value warns and falls back to standalone rather than refusing to
+ * boot — an instance should always come up in the safe, fully-featured mode.
+ */
+export function parseEdition(raw: string | undefined): Edition {
+  const value = (raw ?? '').trim().toLowerCase();
+  if (value === '') return 'standalone';
+  if ((EDITIONS as readonly string[]).includes(value)) return value as Edition;
+  console.warn(
+    `[lurker] unknown LURKER_EDITION='${raw}', falling back to 'standalone' (valid: ${EDITIONS.join(', ')})`,
+  );
+  return 'standalone';
+}
+
+let cached: Edition | null = null;
+
+/** The resolved edition for this process (cached after first call). */
+export function getEdition(): Edition {
+  if (cached === null) cached = parseEdition(process.env.LURKER_EDITION);
+  return cached;
+}
+
+/** True when this instance is a cell under an orchestrator. */
+export function isNodeMode(): boolean {
+  return getEdition() === 'node';
+}
+
+// app_meta keys reserved for node identity. Populated by the orchestrator
+// handshake (A2) and the registration/heartbeat client (A4); never written in
+// standalone. Centralized here so the cell and its control surfaces agree on the
+// key names instead of scattering string literals.
+export const NODE_META = {
+  /** Stable id the control plane assigns this cell at first registration. */
+  id: 'node.id',
+  /** Base URL of the orchestrator this cell reports to. */
+  orchestratorUrl: 'node.orchestrator_url',
+  /** Shared secret authenticating the cell↔orchestrator channel. */
+  secret: 'node.secret',
+} as const;


### PR DESCRIPTION
Introduces a **deployment-edition** concept so a Lurker instance can know whether it's a standalone self-hosted install or a cell ("node") in a managed deployment governed by a remote orchestrator.

This is foundational plumbing only — it changes no behavior for existing deploys.

## What's here
- **`server/utils/edition.ts`** — `getEdition()` / `isNodeMode()` plus a pure, unit-tested `parseEdition()`. Reads `LURKER_EDITION` (default `standalone`; unknown values warn and fall back to `standalone`, so an instance always boots in the safe, fully-featured mode). Also defines `NODE_META` app_meta key constants reserved for later node-identity wiring.
- **`server/routes/config.ts`** — public, unauthenticated `GET /api/config` returning `{ edition }`: the client's pre-login bootstrap hook so the UI can branch on edition.
- **`server.ts`** — resolves and logs the edition at boot (console + system log) and mounts the route.
- Tests for both modules.

## Compatibility
Any instance that doesn't set `LURKER_EDITION` stays `standalone` — **zero behavior change for every existing self-hosted deploy.**

Full suite green (649 tests), typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)