### PR TITLE
Add node control API for orchestrator-driven cell management (A2)

### DIFF
--- a/server/middleware/nodeAuth.ts
+++ b/server/middleware/nodeAuth.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { timingSafeEqual } from 'crypto';
+import type { NextFunction, Request, Response } from 'express';
+
+// Authenticates the orchestrator (control plane) to a cell's node-control API
+// over a pre-shared secret injected at deploy time as LURKER_NODE_SECRET. This
+// is a SEPARATE trust channel from user sessions and api_tokens — it is never
+// reachable by a tenant, and the routes it guards are mounted only in node
+// edition. (A4 may later support an orchestrator-rotated secret persisted in
+// app_meta under NODE_META.secret; the env value is the source of truth today.)
+
+export function getNodeSecret(): string | null {
+  const raw = (process.env.LURKER_NODE_SECRET || '').trim();
+  return raw || null;
+}
+
+function secretsMatch(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  // timingSafeEqual throws on a length mismatch; comparing lengths first keeps
+  // a wrong-length guess from crashing the handler and leaks nothing via timing.
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function requireNodeAuth(req: Request, res: Response, next: NextFunction): void {
+  const expected = getNodeSecret();
+  if (!expected) {
+    // Fail closed: node edition without a configured secret means the control
+    // surface is unconfigured, not open to the world.
+    res.status(503).json({ error: 'node control API not configured' });
+    return;
+  }
+  const match = /^Bearer\s+(\S+)$/.exec(req.headers.authorization || '');
+  const presented = match ? match[1] : '';
+  if (!presented || !secretsMatch(presented, expected)) {
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+  next();
+}

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -25,6 +25,7 @@ import {
   setPasswordHash,
 } from '../db/users.js';
 import { inviteStatus, consumeInvite } from '../db/invites.js';
+import { isValidUsername } from '../utils/username.js';
 import {
   listForUser as listCredentialsForUser,
   findByCredentialId,
@@ -61,13 +62,6 @@ function setChallengeCookie(res: Response, token: string): void {
 
 function clearChallengeCookie(res: Response): void {
   res.clearCookie(CHALLENGE_COOKIE, { ...challengeCookieOptions(), maxAge: undefined });
-}
-
-function isValidUsername(name: unknown): boolean {
-  if (typeof name !== 'string') return false;
-  const trimmed = name.trim();
-  if (trimmed.length < 1 || trimmed.length > 64) return false;
-  return /^[A-Za-z0-9_.\- ]+$/.test(trimmed);
 }
 
 // webauthnCredentials.ts is still untyped — credential shape inferred as any

--- a/server/routes/node.test.ts
+++ b/server/routes/node.test.ts
@@ -91,6 +91,14 @@ describe('node control API — provision', () => {
     expect(res.status).toBe(400);
   });
 
+  it('rejects a username with disallowed characters (400)', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username: 'no/slashes' });
+    expect(res.status).toBe(400);
+  });
+
   it('409s on a duplicate username and surfaces the existing id', async () => {
     const first = await createAnonAgent(app)
       .post('/api/node/users')

--- a/server/routes/node.test.ts
+++ b/server/routes/node.test.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+// Edition + node secret are read at request time; set them before importing the
+// router. vitest runs each test file in its own process, so this is scoped here.
+process.env.LURKER_EDITION = 'node';
+process.env.LURKER_NODE_SECRET = 'test-node-secret';
+
+import type { Express } from 'express';
+import { setupTestDb, createTestApp, createAnonAgent } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('routes-node');
+const AUTH = 'Bearer test-node-secret';
+
+let app: Express;
+let findUserById: typeof import('../db/users.js').findUserById;
+let createUser: typeof import('../db/users.js').createUser;
+
+beforeAll(async () => {
+  const users = await import('../db/users.js');
+  findUserById = users.findUserById;
+  createUser = users.createUser;
+  const router = (await import('./node.js')).default;
+  app = createTestApp({ '/api/node': router });
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('node control API — auth', () => {
+  it('rejects requests with no bearer (401)', async () => {
+    expect((await createAnonAgent(app).get('/api/node/status')).status).toBe(401);
+  });
+
+  it('rejects a wrong secret (401)', async () => {
+    const res = await createAnonAgent(app)
+      .get('/api/node/status')
+      .set('Authorization', 'Bearer nope');
+    expect(res.status).toBe(401);
+  });
+
+  it('503s when no node secret is configured', async () => {
+    const saved = process.env.LURKER_NODE_SECRET;
+    delete process.env.LURKER_NODE_SECRET;
+    try {
+      const res = await createAnonAgent(app).get('/api/node/status').set('Authorization', AUTH);
+      expect(res.status).toBe(503);
+    } finally {
+      process.env.LURKER_NODE_SECRET = saved;
+    }
+  });
+});
+
+describe('node control API — status', () => {
+  it('reports edition + user count with a valid secret', async () => {
+    const res = await createAnonAgent(app).get('/api/node/status').set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.edition).toBe('node');
+    expect(typeof res.body.users.count).toBe('number');
+    expect(typeof res.body.version).toBe('string');
+  });
+});
+
+describe('node control API — provision', () => {
+  it('creates a tenant account as role=user and returns its id', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username: 'tenant-alice' });
+    expect(res.status).toBe(201);
+    expect(res.body.username).toBe('tenant-alice');
+    expect(typeof res.body.id).toBe('number');
+    expect(findUserById(res.body.id)?.role).toBe('user');
+  });
+
+  it('never mints an admin, even if the body asks for one', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username: 'tenant-mallory', role: 'admin' });
+    expect(res.status).toBe(201);
+    expect(findUserById(res.body.id)?.role).toBe('user');
+  });
+
+  it('rejects a missing username (400)', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('409s on a duplicate username and surfaces the existing id', async () => {
+    const first = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username: 'tenant-dupe' });
+    expect(first.status).toBe(201);
+    const second = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username: 'tenant-dupe' });
+    expect(second.status).toBe(409);
+    expect(second.body.id).toBe(first.body.id);
+  });
+});
+
+describe('node control API — deprovision', () => {
+  it('deletes a tenant account', async () => {
+    const created = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username: 'tenant-bob' });
+    const id = created.body.id;
+    const del = await createAnonAgent(app)
+      .delete(`/api/node/users/${id}`)
+      .set('Authorization', AUTH);
+    expect(del.status).toBe(200);
+    expect(findUserById(id)).toBeUndefined();
+  });
+
+  it('404s on an unknown user', async () => {
+    const res = await createAnonAgent(app)
+      .delete('/api/node/users/999999')
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+
+  it('refuses to delete an admin (the operator) via the node API', async () => {
+    const admin = createUser('operator', { role: 'admin' });
+    const res = await createAnonAgent(app)
+      .delete(`/api/node/users/${admin.id}`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(409);
+    expect(findUserById(admin.id)).toBeDefined();
+  });
+});

--- a/server/routes/node.ts
+++ b/server/routes/node.ts
@@ -1,11 +1,12 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import fs from 'fs';
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireNodeAuth } from '../middleware/nodeAuth.js';
 import { getEdition } from '../utils/edition.js';
+import { APP_VERSION } from '../utils/userAgent.js';
+import { isValidUsername } from '../utils/username.js';
 import {
   countUsers,
   createUser,
@@ -22,21 +23,10 @@ import ircManager from '../services/ircManager.js';
 const router = Router();
 router.use(requireNodeAuth);
 
-const APP_VERSION: string = (() => {
-  try {
-    const pkg = JSON.parse(
-      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
-    ) as { version?: string };
-    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
-  } catch {
-    return 'unknown';
-  }
-})();
-
-const MAX_USERNAME_LEN = 64;
-
-// Health + capacity. The control plane polls this to drive fill-then-pin
-// placement (A4 will push the same shape on a heartbeat).
+// Health + capacity. `users.count` is the TOTAL provisioned accounts on this
+// cell (not currently-online users) — that's the figure fill-then-pin placement
+// keys on, since a cell's load is the tenants assigned to it. A4 will push the
+// same shape on a heartbeat.
 router.get('/status', (_req: Request, res: Response) => {
   res.json({
     edition: getEdition(),
@@ -52,12 +42,10 @@ router.get('/status', (_req: Request, res: Response) => {
 // any role in the body is deliberately ignored.
 router.post('/users', (req: Request, res: Response) => {
   const username = typeof req.body?.username === 'string' ? req.body.username.trim() : '';
-  if (!username) {
-    res.status(400).json({ error: 'username required' });
-    return;
-  }
-  if (username.length > MAX_USERNAME_LEN) {
-    res.status(400).json({ error: `username too long (max ${MAX_USERNAME_LEN})` });
+  // Same rule as the human signup/auth flows so a node-provisioned account is
+  // valid everywhere (length bounds + charset, no control characters).
+  if (!isValidUsername(username)) {
+    res.status(400).json({ error: 'invalid username' });
     return;
   }
   const existing = findUserByUsername(username);

--- a/server/routes/node.ts
+++ b/server/routes/node.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import fs from 'fs';
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { requireNodeAuth } from '../middleware/nodeAuth.js';
+import { getEdition } from '../utils/edition.js';
+import {
+  countUsers,
+  createUser,
+  deleteUser,
+  findUserById,
+  findUserByUsername,
+} from '../db/users.js';
+import ircManager from '../services/ircManager.js';
+
+// Orchestrator-driven control surface for a cell. Mounted only in node edition
+// (see server.ts behind isNodeMode()), and every route requires the node secret
+// — a trust channel entirely separate from tenant sessions/api_tokens. A tenant
+// can never reach this.
+const router = Router();
+router.use(requireNodeAuth);
+
+const APP_VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+    ) as { version?: string };
+    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+})();
+
+const MAX_USERNAME_LEN = 64;
+
+// Health + capacity. The control plane polls this to drive fill-then-pin
+// placement (A4 will push the same shape on a heartbeat).
+router.get('/status', (_req: Request, res: Response) => {
+  res.json({
+    edition: getEdition(),
+    version: APP_VERSION,
+    users: { count: countUsers() },
+  });
+});
+
+// Provision a tenant account. The orchestrator owns identity, so this creates
+// the bare account row only; wiring how a provisioned user gets a session on
+// the cell is the routing/session-ownership work (B3). Role is ALWAYS 'user' —
+// a SaaS tenant must never be admin (the cell's lone admin is the operator), so
+// any role in the body is deliberately ignored.
+router.post('/users', (req: Request, res: Response) => {
+  const username = typeof req.body?.username === 'string' ? req.body.username.trim() : '';
+  if (!username) {
+    res.status(400).json({ error: 'username required' });
+    return;
+  }
+  if (username.length > MAX_USERNAME_LEN) {
+    res.status(400).json({ error: `username too long (max ${MAX_USERNAME_LEN})` });
+    return;
+  }
+  const existing = findUserByUsername(username);
+  if (existing) {
+    // Surface the existing id so a retried provision can reconcile rather than
+    // guess. Deliberately not an idempotent 200 — a real username clash should
+    // be visible to the orchestrator.
+    res.status(409).json({ error: 'username already exists', id: existing.id });
+    return;
+  }
+  const user = createUser(username); // role defaults to 'user'
+  res.status(201).json({ id: user.id, username: user.username });
+});
+
+// Deprovision a tenant account: tear down live IRC + WS first (mirrors the
+// admin delete path, so an in-flight PRIVMSG can't hit a FK violation on the
+// about-to-vanish rows), then hard-delete — per-user FKs cascade.
+router.delete('/users/:id', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const target = findUserById(id);
+  if (!target) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  // The orchestrator manages tenants, never the operator — refuse to delete an
+  // admin through the node API.
+  if (target.role === 'admin') {
+    res.status(409).json({ error: 'refusing to delete an admin account' });
+    return;
+  }
+  ircManager.disposeUser(id, 'deprovisioned');
+  deleteUser(id);
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server/server.ts
+++ b/server/server.ts
@@ -22,15 +22,17 @@ import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
 import configRouter from './routes/config.js';
+import nodeRouter from './routes/node.js';
 import ircManager from './services/ircManager.js';
 import { attachWsHub } from './services/wsHub.js';
 import './services/verbs/index.js';
 import mcpRouter from './services/mcpServer.js';
 import { requireApiAuth } from './middleware/apiAuth.js';
+import { getNodeSecret } from './middleware/nodeAuth.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
-import { getEdition } from './utils/edition.js';
+import { getEdition, isNodeMode } from './utils/edition.js';
 
 const PORT = Number(process.env.PORT || 8010);
 const EDITION = getEdition();
@@ -39,6 +41,11 @@ if (sessionSecretSource === 'generated') {
   console.log('[lurker] generated new session secret in data/session-secret.key');
 }
 console.log(`[lurker] edition: ${EDITION}`);
+if (isNodeMode() && !getNodeSecret()) {
+  console.warn(
+    '[lurker] node edition is active but LURKER_NODE_SECRET is unset — the node control API will reject every request (503) until it is configured',
+  );
+}
 
 const app = express();
 
@@ -61,6 +68,12 @@ app.use('/api/exports', exportsRouter);
 app.use('/api/imports', importRouter);
 app.use('/api/api-tokens', apiTokensRouter);
 app.use('/api/config', configRouter);
+
+// Orchestrator-only control surface. Mounted exclusively in node edition so a
+// standalone self-hosted instance never exposes it at all.
+if (isNodeMode()) {
+  app.use('/api/node', nodeRouter);
+}
 
 app.use('/mcp', requireApiAuth, mcpRouter);
 

--- a/server/utils/username.ts
+++ b/server/utils/username.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The single source of truth for what a valid account username is. Shared by
+// the human signup/auth flows (routes/auth.ts) and the orchestrator's node
+// provisioning API (routes/node.ts) so an account created by either path is
+// valid everywhere it surfaces — the UI, IRC registration, etc. The charset is
+// deliberately conservative (no control characters, no exotic Unicode).
+
+export const MAX_USERNAME_LENGTH = 64;
+
+export function isValidUsername(name: unknown): boolean {
+  if (typeof name !== 'string') return false;
+  const trimmed = name.trim();
+  if (trimmed.length < 1 || trimmed.length > MAX_USERNAME_LENGTH) return false;
+  return /^[A-Za-z0-9_.\- ]+$/.test(trimmed);
+}


### PR DESCRIPTION
Adds the orchestrator-facing control surface a Lurker instance exposes when it runs as a **node** (a cell in a managed multi-instance deployment). Builds directly on the `LURKER_EDITION` flag from #156.

## What's here
A new `/api/node/*` API, **mounted only in node edition** — a standalone self-hosted instance never exposes it at all — authenticated by a pre-shared **`LURKER_NODE_SECRET`**. This is a trust channel entirely separate from tenant sessions and API tokens; a tenant can never reach it.

- **`middleware/nodeAuth.ts`** — `requireNodeAuth` + `getNodeSecret`. Constant-time secret compare; **fails closed** with `503` when no secret is configured (node edition without a secret is *unconfigured*, not open).
- **`routes/node.ts`**
  - `GET /status` — edition, version, and live user count (control-plane polls this for fill-then-pin placement).
  - `POST /users` — provision a tenant account. Role is **always `user`** — a SaaS tenant must never be admin (the cell's lone admin is the operator), so any `role` in the body is ignored. `409` with the existing id on a duplicate username.
  - `DELETE /users/:id` — deprovision: tears down live IRC + WS first (mirrors the admin delete path) then hard-deletes (per-user FKs cascade). **Refuses to delete an admin** via this API.
- **`server.ts`** — conditional mount behind `isNodeMode()`, plus a boot warning if node edition is active without a secret.

## Scope / deferred
- **suspend** (vs delete) needs a persisted flag + an auth gate; it pairs with billing, so it's deferred.
- The **node → orchestrator** registration + heartbeat is A4 (this PR is the inbound direction only).
- Provisioned accounts are bare rows; wiring how a provisioned user gets a *session* on the cell is the routing/session-ownership work (B3).

11 new tests (auth 401/503, status, provision incl. the never-admin invariant + dup handling, deprovision incl. admin-refusal). Full suite green (70 files, 673 tests); typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)