### PR TITLE
Add orchestrator client: cell registers + heartbeats (A4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,22 @@ VAPID_SUBJECT=mailto:you@example.com
 # so external service operators can reach you if Lurker misbehaves. May be a
 # URL or mailto:. Leave unset to fall back to the upstream project link.
 # USER_AGENT_CONTACT=https://lurker.example.com
+
+# ---------------------------------------------------------------------------
+# Node mode (hosted lurker.chat service) — leave ALL of this unset for normal
+# self-hosting. A standalone instance ignores it entirely.
+# ---------------------------------------------------------------------------
+# Deployment edition: 'standalone' (default) or 'node' (a cell managed by an
+# orchestrator / control plane). Unknown values fall back to standalone.
+# LURKER_EDITION=node
+#
+# Shared fleet secret. Authenticates the orchestrator's inbound calls to this
+# cell's /api/node API, and is reused as the bearer when this cell reports out
+# to the orchestrator. Set the same value as FLEET_SECRET on the control plane.
+# LURKER_NODE_SECRET=replace-me-with-a-long-random-string
+#
+# Where the orchestrator lives, and how this cell identifies itself to it.
+# LURKER_ORCHESTRATOR_URL=http://orchestrator:8020
+# LURKER_NODE_NAME=cell-1
+# LURKER_NODE_CONTROL_URL=http://cell-1:8015   # how the orchestrator reaches THIS cell
+# LURKER_NODE_CAPACITY=500                      # soft cap on accounts (fill-then-pin)

--- a/server/server.ts
+++ b/server/server.ts
@@ -33,6 +33,7 @@ import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
+import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
 
 const PORT = Number(process.env.PORT || 8010);
 const EDITION = getEdition();
@@ -106,6 +107,10 @@ systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${ED
 
 ircManager.initAll();
 
+// In node edition, start reporting to the orchestrator (register on boot +
+// heartbeat on an interval). No-op in standalone or when unconfigured.
+startOrchestratorClient();
+
 server.listen(PORT, () => {
   console.log(`[lurker] listening on http://localhost:${PORT}`);
   systemLog.log({ scope: 'server', text: `Listening on port ${PORT}` });
@@ -114,6 +119,7 @@ server.listen(PORT, () => {
 function shutdown(signal: string): void {
   console.log(`[lurker] received ${signal}, shutting down`);
   systemLog.log({ scope: 'server', level: 'warn', text: `Received ${signal}, shutting down` });
+  stopOrchestratorClient();
   ircManager.shutdown();
   server.close(() => process.exit(0));
   setTimeout(() => process.exit(1), 5000).unref();

--- a/server/services/orchestratorClient.test.ts
+++ b/server/services/orchestratorClient.test.ts
@@ -78,7 +78,8 @@ describe('reportToOrchestrator', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, opts] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
     expect(url).toBe('http://orchestrator:8020/api/cells/register');
-    expect(opts.headers.authorization).toBe('Bearer fleet-secret');
+    expect(opts.headers.Authorization).toBe('Bearer fleet-secret');
+    expect(opts.headers['User-Agent']).toMatch(/^Lurker\//);
   });
 
   it('returns false (never throws) when the orchestrator is unreachable', async () => {

--- a/server/services/orchestratorClient.test.ts
+++ b/server/services/orchestratorClient.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+// Set edition + node config before importing the module under test. vitest runs
+// each file in its own process, so this is scoped here.
+process.env.LURKER_EDITION = 'node';
+process.env.LURKER_NODE_SECRET = 'fleet-secret';
+process.env.LURKER_ORCHESTRATOR_URL = 'http://orchestrator:8020';
+process.env.LURKER_NODE_NAME = 'cell-test';
+process.env.LURKER_NODE_CONTROL_URL = 'http://cell-test:8015';
+process.env.LURKER_NODE_CAPACITY = '250';
+
+import { setupTestDb } from '../test-utils/testApp.js';
+
+// countUsers() reads the DB, so a test DB must exist before the import below.
+const ctx = setupTestDb('orchestrator-client');
+
+// Loose signature for the global fetch mock — reportToOrchestrator only reads
+// `.ok` off the response.
+type FetchMock = (...args: unknown[]) => Promise<{ ok: boolean }>;
+
+let mod: typeof import('./orchestratorClient.js');
+
+beforeAll(async () => {
+  mod = await import('./orchestratorClient.js');
+});
+
+afterAll(() => {
+  ctx.cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('readOrchestratorConfig', () => {
+  it('returns a full config when node mode + env are set', () => {
+    expect(mod.readOrchestratorConfig()).toMatchObject({
+      url: 'http://orchestrator:8020',
+      name: 'cell-test',
+      controlUrl: 'http://cell-test:8015',
+      capacity: 250,
+      secret: 'fleet-secret',
+    });
+  });
+
+  it('is null (client no-ops) when a required var is missing', () => {
+    const saved = process.env.LURKER_ORCHESTRATOR_URL;
+    delete process.env.LURKER_ORCHESTRATOR_URL;
+    try {
+      expect(mod.readOrchestratorConfig()).toBeNull();
+    } finally {
+      process.env.LURKER_ORCHESTRATOR_URL = saved;
+    }
+  });
+});
+
+describe('buildRegistration', () => {
+  it('advertises identity, capacity, version, and a live user count', () => {
+    const cfg = mod.readOrchestratorConfig();
+    expect(cfg).not.toBeNull();
+    const reg = mod.buildRegistration(cfg!);
+    expect(reg).toMatchObject({
+      name: 'cell-test',
+      control_url: 'http://cell-test:8015',
+      capacity: 250,
+    });
+    expect(typeof reg.version).toBe('string');
+    expect(typeof reg.user_count).toBe('number');
+  });
+});
+
+describe('reportToOrchestrator', () => {
+  it('posts to /api/cells/register with the bearer and returns true on 2xx', async () => {
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const cfg = mod.readOrchestratorConfig()!;
+    expect(await mod.reportToOrchestrator(cfg)).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
+    expect(url).toBe('http://orchestrator:8020/api/cells/register');
+    expect(opts.headers.authorization).toBe('Bearer fleet-secret');
+  });
+
+  it('returns false (never throws) when the orchestrator is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn<FetchMock>().mockRejectedValue(new Error('ECONNREFUSED')));
+    const cfg = mod.readOrchestratorConfig()!;
+    expect(await mod.reportToOrchestrator(cfg)).toBe(false);
+  });
+
+  it('returns false on a non-2xx response', async () => {
+    vi.stubGlobal('fetch', vi.fn<FetchMock>().mockResolvedValue({ ok: false }));
+    const cfg = mod.readOrchestratorConfig()!;
+    expect(await mod.reportToOrchestrator(cfg)).toBe(false);
+  });
+});

--- a/server/services/orchestratorClient.ts
+++ b/server/services/orchestratorClient.ts
@@ -13,7 +13,7 @@
 // orchestrator never takes the cell down with it.
 
 import { isNodeMode } from '../utils/edition.js';
-import { APP_VERSION } from '../utils/userAgent.js';
+import { APP_VERSION, USER_AGENT } from '../utils/userAgent.js';
 import { countUsers } from '../db/users.js';
 import * as systemLog from './systemLog.js';
 
@@ -72,8 +72,11 @@ export async function reportToOrchestrator(cfg: OrchestratorConfig): Promise<boo
     const res = await fetch(`${cfg.url.replace(/\/+$/, '')}/api/cells/register`, {
       method: 'POST',
       headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${cfg.secret}`,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${cfg.secret}`,
+        // Identify these calls in control-plane logs, same as our other
+        // outbound HTTP (upload providers).
+        'User-Agent': USER_AGENT,
       },
       body: JSON.stringify(buildRegistration(cfg)),
     });
@@ -88,6 +91,9 @@ let timer: ReturnType<typeof setInterval> | null = null;
 // Register on boot, then re-register on an interval. No-op when not a configured
 // node, so it's safe to call unconditionally at startup.
 export function startOrchestratorClient(intervalMs = DEFAULT_INTERVAL_MS): void {
+  // Idempotent: clear any prior interval first so a double-start (re-init path,
+  // tests, future refactors) can't leak timers or run concurrent heartbeats.
+  stopOrchestratorClient();
   const cfg = readOrchestratorConfig();
   if (!cfg) return;
   const tick = async (): Promise<void> => {
@@ -96,7 +102,7 @@ export function startOrchestratorClient(intervalMs = DEFAULT_INTERVAL_MS): void 
       systemLog.log({
         scope: 'node',
         level: 'warn',
-        text: `orchestrator unreachable at ${cfg.url} — will retry`,
+        text: `failed to report to orchestrator at ${cfg.url} (unreachable or non-2xx) — will retry`,
       });
     }
   };

--- a/server/services/orchestratorClient.ts
+++ b/server/services/orchestratorClient.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// In node edition, a cell reports itself to the orchestrator (control plane) so
+// the fleet knows it exists, where to reach it, and how loaded it is. This is
+// the OUTBOUND half of node mode — the inbound control API (provision/
+// deprovision) is routes/node.ts. On boot the cell registers; on an interval it
+// re-registers, which the orchestrator treats as an idempotent upsert, so the
+// same call doubles as a heartbeat and self-heals if the control plane restarts.
+//
+// Everything here fails soft: a node-edition cell with no orchestrator
+// configured (e.g. local dev) simply does nothing, and an unreachable
+// orchestrator never takes the cell down with it.
+
+import { isNodeMode } from '../utils/edition.js';
+import { APP_VERSION } from '../utils/userAgent.js';
+import { countUsers } from '../db/users.js';
+import * as systemLog from './systemLog.js';
+
+interface OrchestratorConfig {
+  /** Base URL of the control plane, e.g. http://orchestrator:8020. */
+  url: string;
+  /** This cell's stable name in the fleet. */
+  name: string;
+  /** How the orchestrator reaches THIS cell's /api/node API + proxies to it. */
+  controlUrl: string;
+  /** Soft cap on accounts this cell should hold (drives fill-then-pin). */
+  capacity: number;
+  /** Shared fleet secret — same value LURKER_NODE_SECRET authenticates the
+   *  inbound node API with, reused as the bearer for this outbound report. */
+  secret: string;
+}
+
+const DEFAULT_CAPACITY = 500;
+const DEFAULT_INTERVAL_MS = 30_000;
+
+// Returns config only when this instance is a node AND every required piece is
+// present. Any gap → null → the client is a no-op.
+export function readOrchestratorConfig(): OrchestratorConfig | null {
+  if (!isNodeMode()) return null;
+  const url = (process.env.LURKER_ORCHESTRATOR_URL || '').trim();
+  const name = (process.env.LURKER_NODE_NAME || '').trim();
+  const controlUrl = (process.env.LURKER_NODE_CONTROL_URL || '').trim();
+  const secret = (process.env.LURKER_NODE_SECRET || '').trim();
+  if (!url || !name || !controlUrl || !secret) return null;
+  const capacityRaw = Number(process.env.LURKER_NODE_CAPACITY);
+  const capacity = Number.isFinite(capacityRaw) && capacityRaw > 0 ? capacityRaw : DEFAULT_CAPACITY;
+  return { url, name, controlUrl, capacity, secret };
+}
+
+/** The payload a cell advertises: identity + current load. */
+export function buildRegistration(cfg: OrchestratorConfig): {
+  name: string;
+  control_url: string;
+  capacity: number;
+  version: string;
+  user_count: number;
+} {
+  return {
+    name: cfg.name,
+    control_url: cfg.controlUrl,
+    capacity: cfg.capacity,
+    version: APP_VERSION,
+    user_count: countUsers(),
+  };
+}
+
+// POST the cell's identity + load to the orchestrator. Returns true on a 2xx,
+// false on any non-2xx or network error — never throws.
+export async function reportToOrchestrator(cfg: OrchestratorConfig): Promise<boolean> {
+  try {
+    const res = await fetch(`${cfg.url.replace(/\/+$/, '')}/api/cells/register`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${cfg.secret}`,
+      },
+      body: JSON.stringify(buildRegistration(cfg)),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+// Register on boot, then re-register on an interval. No-op when not a configured
+// node, so it's safe to call unconditionally at startup.
+export function startOrchestratorClient(intervalMs = DEFAULT_INTERVAL_MS): void {
+  const cfg = readOrchestratorConfig();
+  if (!cfg) return;
+  const tick = async (): Promise<void> => {
+    const ok = await reportToOrchestrator(cfg);
+    if (!ok) {
+      systemLog.log({
+        scope: 'node',
+        level: 'warn',
+        text: `orchestrator unreachable at ${cfg.url} — will retry`,
+      });
+    }
+  };
+  void tick();
+  timer = setInterval(() => void tick(), intervalMs);
+  timer.unref?.();
+  systemLog.log({
+    scope: 'node',
+    text: `reporting to orchestrator at ${cfg.url} as "${cfg.name}"`,
+  });
+}
+
+export function stopOrchestratorClient(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}


### PR DESCRIPTION
The outbound half of node mode (builds on the `LURKER_EDITION` flag from #156; independent of the inbound node control API in #158).

When a Lurker instance runs as a **node**, it reports itself to the orchestrator (control plane) so the fleet knows it exists, where to reach it, and how loaded it is.

## What's here
- **`services/orchestratorClient.ts`**
  - `readOrchestratorConfig()` — env-driven (`LURKER_ORCHESTRATOR_URL`, `LURKER_NODE_NAME`, `LURKER_NODE_CONTROL_URL`, `LURKER_NODE_CAPACITY`, `LURKER_NODE_SECRET`). Returns `null` — so the client is a **no-op** — unless this is a node edition instance with everything configured. A node with no orchestrator (local dev) just runs normally.
  - `buildRegistration()` — advertises name, control_url, capacity, version, and a live `user_count`.
  - `reportToOrchestrator()` — POSTs to the control plane's `/api/cells/register`. **Never throws**: any non-2xx or network error returns `false`, so a flaky/down orchestrator can't take the cell down with it.
  - `start/stopOrchestratorClient()` — register on boot, then re-register on a 30s interval. The orchestrator treats `/register` as an idempotent upsert, so it doubles as a heartbeat and self-heals if the control plane restarts.
- **`server.ts`** — `startOrchestratorClient()` after `ircManager.initAll()`; `stopOrchestratorClient()` on shutdown.
- **`.env.example`** — documents the node-mode env vars (all unset = normal self-hosting).

Auth uses the shared fleet secret (`LURKER_NODE_SECRET`), matching `FLEET_SECRET` on the control plane.

## Compatibility
Standalone self-hosting is entirely unaffected — the client no-ops unless `LURKER_EDITION=node` and the orchestrator vars are set.

6 tests (config gating, registration payload, success/failure/unreachable handling). Full suite green; typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)