### PR TITLE
Add cell session-mint endpoint for the proxy (A5)

### DIFF
--- a/server/routes/node.test.ts
+++ b/server/routes/node.test.ts
@@ -9,7 +9,13 @@ process.env.LURKER_EDITION = 'node';
 process.env.LURKER_NODE_SECRET = 'test-node-secret';
 
 import type { Express } from 'express';
-import { setupTestDb, createTestApp, createAnonAgent } from '../test-utils/testApp.js';
+import { unsign } from 'cookie-signature';
+import {
+  setupTestDb,
+  createTestApp,
+  createAnonAgent,
+  TEST_SESSION_SECRET,
+} from '../test-utils/testApp.js';
 
 const ctx = setupTestDb('routes-node');
 const AUTH = 'Bearer test-node-secret';
@@ -142,5 +148,54 @@ describe('node control API — deprovision', () => {
       .set('Authorization', AUTH);
     expect(res.status).toBe(409);
     expect(findUserById(admin.id)).toBeDefined();
+  });
+});
+
+describe('node control API — mint session', () => {
+  it('mints a signed lurker_session cookie that maps to a real session for the user', async () => {
+    const created = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username: 'mint-me' });
+    const id = created.body.id;
+
+    const res = await createAnonAgent(app)
+      .post(`/api/node/users/${id}/session`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.cookieName).toBe('lurker_session');
+    expect(typeof res.body.value).toBe('string');
+    expect(res.body.value.startsWith('s:')).toBe(true);
+
+    // The signed value must unsign with the cell's secret and resolve to a real
+    // session row owned by this user — i.e. the cell's own auth will accept it.
+    const token = unsign(res.body.value.slice(2), TEST_SESSION_SECRET);
+    expect(token).not.toBe(false);
+    const { findSession } = await import('../db/sessions.js');
+    expect(findSession(token as string)?.user_id).toBe(id);
+  });
+
+  it('404s minting for an unknown user', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/node/users/999999/session')
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+
+  it('refuses to mint a session for an admin', async () => {
+    const admin = createUser('mint-admin', { role: 'admin' });
+    const res = await createAnonAgent(app)
+      .post(`/api/node/users/${admin.id}/session`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(409);
+  });
+
+  it('requires the node secret', async () => {
+    const created = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username: 'mint-noauth' });
+    const res = await createAnonAgent(app).post(`/api/node/users/${created.body.id}/session`);
+    expect(res.status).toBe(401);
   });
 });

--- a/server/routes/node.ts
+++ b/server/routes/node.ts
@@ -15,6 +15,10 @@ import {
   findUserByUsername,
 } from '../db/users.js';
 import ircManager from '../services/ircManager.js';
+import { sign as signCookie } from 'cookie-signature';
+import { createSession } from '../db/sessions.js';
+import { resolveSessionSecret } from '../utils/sessionSecret.js';
+import { SESSION_COOKIE } from '../middleware/auth.js';
 
 // Orchestrator-driven control surface for a cell. Mounted only in node edition
 // (see server.ts behind isNodeMode()), and every route requires the node secret
@@ -83,6 +87,35 @@ router.delete('/users/:id', (req: Request, res: Response) => {
   ircManager.disposeUser(id, 'deprovisioned');
   deleteUser(id);
   res.json({ ok: true });
+});
+
+// Mint a real cell session for a provisioned tenant and return the signed
+// `lurker_session` cookie value. The reverse proxy sets this on the customer's
+// browser, so the cell authenticates them through its OWN existing session
+// logic — HTTP (requireAuth) and the WS upgrade alike — with no new trust path.
+// Fleet-authenticated; never reachable by a tenant.
+const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+router.post('/users/:id/session', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const target = findUserById(id);
+  if (!target) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  // The operator's admin account is not a tenant — never mint a session for it
+  // through the node API (D1 × node-mode invariant).
+  if (target.role === 'admin') {
+    res.status(409).json({ error: 'refusing to mint a session for an admin account' });
+    return;
+  }
+  const { secret } = resolveSessionSecret();
+  const { token } = createSession(id);
+  const value = 's:' + signCookie(token, secret);
+  res.json({ cookieName: SESSION_COOKIE, value, maxAgeMs: SESSION_MAX_AGE_MS });
 });
 
 export default router;

--- a/server/routes/node.ts
+++ b/server/routes/node.ts
@@ -17,8 +17,7 @@ import {
 import ircManager from '../services/ircManager.js';
 import { sign as signCookie } from 'cookie-signature';
 import { createSession } from '../db/sessions.js';
-import { resolveSessionSecret } from '../utils/sessionSecret.js';
-import { SESSION_COOKIE } from '../middleware/auth.js';
+import { SESSION_COOKIE, getCookieOptions } from '../middleware/auth.js';
 
 // Orchestrator-driven control surface for a cell. Mounted only in node edition
 // (see server.ts behind isNodeMode()), and every route requires the node secret
@@ -94,7 +93,6 @@ router.delete('/users/:id', (req: Request, res: Response) => {
 // browser, so the cell authenticates them through its OWN existing session
 // logic — HTTP (requireAuth) and the WS upgrade alike — with no new trust path.
 // Fleet-authenticated; never reachable by a tenant.
-const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 router.post('/users/:id/session', (req: Request, res: Response) => {
   const id = Number(req.params.id);
   if (!Number.isInteger(id) || id <= 0) {
@@ -112,10 +110,17 @@ router.post('/users/:id/session', (req: Request, res: Response) => {
     res.status(409).json({ error: 'refusing to mint a session for an admin account' });
     return;
   }
-  const { secret } = resolveSessionSecret();
+  // Sign with the exact secret cookie-parser validates with (attached to req by
+  // the cookieParser middleware) — always accepted by the cell's normal auth,
+  // no per-request disk IO, no chance of divergence from the live key.
+  const secret = req.secret;
+  if (!secret) {
+    res.status(500).json({ error: 'session secret unavailable' });
+    return;
+  }
   const { token } = createSession(id);
   const value = 's:' + signCookie(token, secret);
-  res.json({ cookieName: SESSION_COOKIE, value, maxAgeMs: SESSION_MAX_AGE_MS });
+  res.json({ cookieName: SESSION_COOKIE, value, maxAgeMs: getCookieOptions().maxAge });
 });
 
 export default router;


### PR DESCRIPTION
The cell-side half of central-session auth for the hosted service. Builds on the node control API (#158).

When Lurker runs as a **node** behind the hosted service's reverse proxy, the proxy terminates the customer's control-plane session and needs the cell to authenticate that customer. Rather than teach the cell a new "trust this header" path through its auth, the proxy asks the cell to **mint a real session**:

## What's here
- **`POST /api/node/users/:id/session`** (node edition, fleet-secret auth): the cell calls its own `createSession()`, signs the token with its `SESSION_SECRET`, and returns the signed `lurker_session` cookie value (`{ cookieName, value, maxAgeMs }`). The proxy sets that cookie on the browser.

## Why this shape
- **The cell's audited auth is untouched.** `requireAuth` (HTTP) and the WS upgrade keep validating a *real* session exactly as before — the proxy just hands the browser a genuine cookie. WebSocket auth works with **zero changes** (browser sends the cookie on the `/ws` handshake → proxy forwards it → cell validates its own session).
- Keeps the cell "the unmodified app" — this is a new endpoint, not a new trust path.
- **Refuses to mint for an admin** (the operator) — the D1 × node-mode invariant (tenants only).
- Forged cookies are useless: signed with the cell's secret *and* the token must exist in the cell's `sessions` table; minting itself requires the fleet secret.

4 new tests, including unsigning the returned cookie and confirming it resolves to a real session row for that user. Full suite green (684); typecheck, lint, format clean. Standalone self-hosting is unaffected (endpoint only mounts in node edition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)