### PR TITLE
Node edition: never auto-promote a tenant to admin

### DIFF
--- a/server/db/firstAdminBackfill.test.ts
+++ b/server/db/firstAdminBackfill.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import Database from 'better-sqlite3';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -13,10 +14,30 @@ process.env.LURKER_EDITION = 'node';
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-firstadmin-'));
 process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 
+// Seed tenant users (no admin) BEFORE importing ./index.js, so the module-load
+// migration runs against an existing population — i.e. the real cell-restart
+// path, where migrate() + backfillFirstAdmin() see pre-existing rows.
+{
+  const seed = new Database(process.env.DATABASE_PATH);
+  seed.exec(
+    `CREATE TABLE users (
+       id INTEGER PRIMARY KEY AUTOINCREMENT,
+       username TEXT UNIQUE NOT NULL,
+       created_at TEXT NOT NULL DEFAULT (datetime('now'))
+     )`,
+  );
+  const insert = seed.prepare('INSERT INTO users (username) VALUES (?)');
+  insert.run('tenant-a');
+  insert.run('tenant-b');
+  seed.close();
+}
+
 let index: typeof import('./index.js');
 let users: typeof import('./users.js');
 
 beforeAll(async () => {
+  // Importing ./index.js runs migrate() + backfillFirstAdmin() against the
+  // already-seeded users — exactly what happens when a node cell restarts.
   index = await import('./index.js');
   users = await import('./users.js');
 });
@@ -24,12 +45,13 @@ beforeAll(async () => {
 afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
 describe('backfillFirstAdmin in node edition', () => {
-  it('never promotes a tenant to admin (no operator-admin on a cell)', () => {
-    users.createUser('tenant-a');
-    users.createUser('tenant-b');
+  it('does not promote a pre-existing tenant on startup (the cell-restart path)', () => {
+    // The startup migration just ran against two seeded tenants — neither should
+    // have been promoted, and the role column should default everyone to 'user'.
     expect(users.countAdmins()).toBe(0);
+    expect(users.listUsers().every((u) => u.role === 'user')).toBe(true);
 
-    // Simulates a cell restart's migration step — must remain a no-op here.
+    // An explicit re-run remains a no-op too.
     index.backfillFirstAdmin();
     expect(users.countAdmins()).toBe(0);
   });

--- a/server/db/firstAdminBackfill.test.ts
+++ b/server/db/firstAdminBackfill.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Node edition + a throwaway DB, set before any db import. In node edition a
+// cell has no operator-admin, so the "promote the first user" recovery must NOT
+// fire — otherwise a restart would silently make a tenant an admin.
+process.env.LURKER_EDITION = 'node';
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-firstadmin-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let index: typeof import('./index.js');
+let users: typeof import('./users.js');
+
+beforeAll(async () => {
+  index = await import('./index.js');
+  users = await import('./users.js');
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('backfillFirstAdmin in node edition', () => {
+  it('never promotes a tenant to admin (no operator-admin on a cell)', () => {
+    users.createUser('tenant-a');
+    users.createUser('tenant-b');
+    expect(users.countAdmins()).toBe(0);
+
+    // Simulates a cell restart's migration step — must remain a no-op here.
+    index.backfillFirstAdmin();
+    expect(users.countAdmins()).toBe(0);
+  });
+});

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -4,6 +4,7 @@
 import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
+import { isNodeMode } from '../utils/edition.js';
 
 const dbPath = process.env.DATABASE_PATH || path.join(import.meta.dirname, '../../data/lurker.db');
 const dbDir = path.dirname(dbPath);
@@ -434,6 +435,23 @@ function columnExists(table: string, column: string): boolean {
   return !!cols.find((c) => c.name === column);
 }
 
+// Recovery for pre-role SELF-HOSTED installs: if no admin exists, promote the
+// earliest user so a single-user install that pre-dates the role column keeps
+// control. Deliberately SKIPPED in node edition — a cell is managed by the
+// orchestrator and has no operator-admin, so auto-promoting a tenant would
+// breach the hosted tenant/admin boundary (a tenant must never become admin).
+export function backfillFirstAdmin(): void {
+  if (isNodeMode()) return;
+  const adminCount = (
+    db.prepare(`SELECT COUNT(*) AS n FROM users WHERE role = 'admin'`).get() as { n: number }
+  ).n;
+  if (adminCount === 0) {
+    // Promote the earliest-created user (id ASC) if any exist.
+    db.exec(`UPDATE users SET role = 'admin'
+             WHERE id = (SELECT id FROM users ORDER BY id LIMIT 1)`);
+  }
+}
+
 migrate();
 
 // One-shot rebuild for peer_presence_state schema change. Old layout had
@@ -481,14 +499,7 @@ ensureColumn('users', 'last_seen_at', 'TEXT');
 // to admin by routes/auth.js. On an existing single-user install pre-dating
 // this column, backfill that lone user to admin so they retain control.
 ensureColumn('users', 'role', `TEXT NOT NULL DEFAULT 'user'`);
-const adminCount = (
-  db.prepare(`SELECT COUNT(*) AS n FROM users WHERE role = 'admin'`).get() as { n: number }
-).n;
-if (adminCount === 0) {
-  // Promote the earliest-created user (id ASC) if any exist.
-  db.exec(`UPDATE users SET role = 'admin'
-           WHERE id = (SELECT id FROM users ORDER BY id LIMIT 1)`);
-}
+backfillFirstAdmin();
 
 // Persist which rule matched each message so the highlights modal can read
 // from disk instead of scanning whatever happens to be loaded in client memory.


### PR DESCRIPTION
The DB migration's "if there's no admin, promote the earliest user" step is a **self-hosted** recovery (so a single-user install that pre-dates the role column keeps control). On a **node** cell that assumption is wrong: a cell is managed by the orchestrator and has **no operator-admin by design**, so on a restart this backfill would silently promote a *tenant* to admin — breaching the hosted tenant/admin boundary the D1 audit established.

- Extracts the logic into `backfillFirstAdmin()` and **skips it in node edition** (`isNodeMode()`).
- Standalone self-hosting is unchanged (the guard is `!isNodeMode()`).
- Test: a node-edition cell with users but no admin stays at zero admins across a simulated restart.

Full suite green (685); typecheck, lint, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)