### PR TITLE
Node edition: gate API tokens/MCP and force the in-house uploader (A7, A8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,9 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_NODE_NAME=cell-1
 # LURKER_NODE_CONTROL_URL=http://cell-1:8015   # how the orchestrator reaches THIS cell
 # LURKER_NODE_CAPACITY=500                      # soft cap on accounts (fill-then-pin)
+#
+# In-house uploader (node edition only). The cell forces every upload through
+# the operator's R2-backed dropper instead of letting a tenant choose a host;
+# these supply its base URL + API key. Uploads fail (400) until both are set.
+# LURKER_NODE_UPLOAD_URL=https://upload.lurker.chat
+# LURKER_NODE_UPLOAD_API_KEY=replace-me-with-the-dropper-api-key

--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,12 @@ VAPID_SUBJECT=mailto:you@example.com
 # these supply its base URL + API key. Uploads fail (400) until both are set.
 # LURKER_NODE_UPLOAD_URL=https://upload.lurker.chat
 # LURKER_NODE_UPLOAD_API_KEY=replace-me-with-the-dropper-api-key
+#
+# Image-pipeline limits in node edition are operator-controlled (not tenant
+# settings): max raw upload size, longest-edge before JPEG re-encode, and JPEG
+# quality. Each is optional — unset falls back to the built-in default and any
+# value is clamped to the setting's registry bounds. Standalone uses per-user
+# settings instead.
+# LURKER_NODE_UPLOAD_MAX_MB=25     # 1–200, default 25
+# LURKER_NODE_UPLOAD_MAX_DIM=2048  # 256–8192, default 2048
+# LURKER_NODE_UPLOAD_QUALITY=85    # 30–100, default 85

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
+import type { Express } from 'express';
+import request from 'supertest';
+import { setupTestDb, TEST_SESSION_SECRET } from './test-utils/testApp.js';
+
+// buildApp gates routes on the cached edition, resolved once per module
+// instance. vi.resetModules() between builds hands each call a fresh edition
+// module that re-reads LURKER_EDITION, so both editions can be exercised in one
+// process — letting us assert the gating is two-sided (off in node, on in
+// standalone) rather than just that a route happens to be missing.
+const ctx = setupTestDb('app-gating');
+
+afterAll(() => ctx.cleanup());
+afterEach(() => {
+  delete process.env.LURKER_EDITION;
+});
+
+async function buildFor(edition: 'standalone' | 'node'): Promise<Express> {
+  vi.resetModules();
+  process.env.LURKER_EDITION = edition;
+  const { buildApp } = await import('./app.js');
+  return buildApp(TEST_SESSION_SECRET);
+}
+
+describe('buildApp route gating by edition', () => {
+  describe('node edition', () => {
+    it('does not mount /api/api-tokens', async () => {
+      const app = await buildFor('node');
+      // 404 (no route), distinct from the 401 a mounted-but-authless route gives.
+      const res = await request(app).get('/api/api-tokens');
+      expect(res.status).toBe(404);
+    });
+
+    it('does not mount the MCP server at /mcp', async () => {
+      const app = await buildFor('node');
+      const res = await request(app)
+        .post('/mcp')
+        .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+      expect(res.status).toBe(404);
+    });
+
+    it('mounts the orchestrator control surface /api/node', async () => {
+      const app = await buildFor('node');
+      // requireNodeAuth rejects (503 with no secret configured), but the router
+      // IS mounted — the point is it does not 404.
+      const res = await request(app).get('/api/node/status');
+      expect(res.status).not.toBe(404);
+    });
+  });
+
+  describe('standalone edition', () => {
+    it('mounts /api/api-tokens (requireAuth → 401, not 404)', async () => {
+      const app = await buildFor('standalone');
+      const res = await request(app).get('/api/api-tokens');
+      expect(res.status).toBe(401);
+    });
+
+    it('mounts the MCP server (requireApiAuth → 401 without a bearer token)', async () => {
+      const app = await buildFor('standalone');
+      const res = await request(app)
+        .post('/mcp')
+        .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+      expect(res.status).toBe(401);
+    });
+
+    it('does not mount the orchestrator control surface /api/node', async () => {
+      const app = await buildFor('standalone');
+      const res = await request(app).get('/api/node/status');
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -42,6 +42,14 @@ describe('buildApp route gating by edition', () => {
       expect(res.status).toBe(404);
     });
 
+    it('404s GET /mcp too (not swallowed by the SPA fallback)', async () => {
+      const app = await buildFor('node');
+      // `mcp` is excluded from the SPA catch-all, so a disabled /mcp is
+      // consistently absent rather than served index.html.
+      const res = await request(app).get('/mcp');
+      expect(res.status).toBe(404);
+    });
+
     it('mounts the orchestrator control surface /api/node', async () => {
       const app = await buildFor('node');
       // requireNodeAuth rejects (503 with no secret configured), but the router

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Express app construction, split out from server.ts so the route wiring can be
+// built and exercised in isolation (integration tests) without booting the HTTP
+// server, WebSocket hub, or IRC manager. server.ts owns the process lifecycle;
+// this module owns "what routes exist and how requests are handled" — including
+// the edition-aware gating of operator-only surfaces.
+
+import express from 'express';
+import type { Express, ErrorRequestHandler } from 'express';
+import cookieParser from 'cookie-parser';
+import cors from 'cors';
+import path from 'path';
+
+import authRouter from './routes/auth.js';
+import networksRouter from './routes/networks.js';
+import settingsRouter from './routes/settings.js';
+import highlightRulesRouter from './routes/highlightRules.js';
+import highlightsRouter from './routes/highlights.js';
+import bookmarksRouter from './routes/bookmarks.js';
+import pushRouter from './routes/push.js';
+import adminRouter from './routes/admin.js';
+import uploadsRouter from './routes/uploads.js';
+import draftsRouter from './routes/drafts.js';
+import { exportsRouter, importRouter } from './routes/exports.js';
+import apiTokensRouter from './routes/apiTokens.js';
+import configRouter from './routes/config.js';
+import nodeRouter from './routes/node.js';
+import mcpRouter from './services/mcpServer.js';
+import { requireApiAuth } from './middleware/apiAuth.js';
+import { isNodeMode } from './utils/edition.js';
+
+const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+  console.error('[lurker] error:', err);
+  if (res.headersSent) return next(err);
+  res.status(500).json({ error: 'internal error' });
+};
+
+/**
+ * Build the fully-wired Express app. `sessionSecret` keys cookie-parser for the
+ * signed `lurker_session` cookie (the same secret server.ts hands to the WS
+ * hub). Route gating reads the cached edition, so set LURKER_EDITION before the
+ * first getEdition() call.
+ */
+export function buildApp(sessionSecret: string): Express {
+  const app = express();
+
+  const corsOrigin = process.env.CORS_ORIGIN || 'https://irc.local.bradroot.me:5173';
+  app.use(cors({ origin: corsOrigin, credentials: true }));
+  app.use(express.json({ limit: '1mb' }));
+  app.use(cookieParser(sessionSecret));
+
+  app.use('/api/auth', authRouter);
+  app.use('/api/networks', networksRouter);
+  app.use('/api/settings', settingsRouter);
+  app.use('/api/highlight-rules', highlightRulesRouter);
+  app.use('/api/highlights', highlightsRouter);
+  app.use('/api/bookmarks', bookmarksRouter);
+  app.use('/api/push', pushRouter);
+  app.use('/api/admin', adminRouter);
+  app.use('/api/uploads', uploadsRouter);
+  app.use('/api/drafts', draftsRouter);
+  app.use('/api/exports', exportsRouter);
+  app.use('/api/imports', importRouter);
+  app.use('/api/config', configRouter);
+
+  // API tokens + the MCP server are bearer-authenticated surfaces. The hosted
+  // service routes a customer to their cell by the cp_session cookie, but a
+  // bearer client carries no such cookie, so neither endpoint can be addressed
+  // through the per-cell proxy (A7). Disable them entirely in node edition —
+  // A3 hides the matching UI. Standalone keeps both fully featured.
+  if (!isNodeMode()) {
+    app.use('/api/api-tokens', apiTokensRouter);
+    app.use('/mcp', requireApiAuth, mcpRouter);
+  }
+
+  // Orchestrator-only control surface. Mounted exclusively in node edition so a
+  // standalone self-hosted instance never exposes it at all.
+  if (isNodeMode()) {
+    app.use('/api/node', nodeRouter);
+  }
+
+  app.get('/api/health', (_req, res) => {
+    res.json({ status: 'ok', time: new Date().toISOString() });
+  });
+
+  const clientDist = path.join(import.meta.dirname, '../vue_client/dist');
+  app.use(express.static(clientDist));
+  app.get(/^\/(?!api|ws).*/, (_req, res, next) => {
+    res.sendFile(path.join(clientDist, 'index.html'), (err) => {
+      if (err) next();
+    });
+  });
+
+  app.use(errorHandler);
+
+  return app;
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -65,11 +65,13 @@ export function buildApp(sessionSecret: string): Express {
   app.use('/api/imports', importRouter);
   app.use('/api/config', configRouter);
 
-  // API tokens + the MCP server are bearer-authenticated surfaces. The hosted
-  // service routes a customer to their cell by the cp_session cookie, but a
-  // bearer client carries no such cookie, so neither endpoint can be addressed
-  // through the per-cell proxy (A7). Disable them entirely in node edition —
-  // A3 hides the matching UI. Standalone keeps both fully featured.
+  // The HTTP API-token feature and the MCP server are the two ends of the same
+  // bearer-token model: /api/api-tokens (session-cookie auth) mints the tokens,
+  // and /mcp (bearer auth) consumes them. The hosted service routes a customer
+  // to their cell by the cp_session cookie, but a bearer client carries no such
+  // cookie — so /mcp can't be addressed through the per-cell proxy, which makes
+  // the tokens unusable there. Disable both in node edition (A7); A3 hides the
+  // matching UI. Standalone keeps them fully featured.
   if (!isNodeMode()) {
     app.use('/api/api-tokens', apiTokensRouter);
     app.use('/mcp', requireApiAuth, mcpRouter);
@@ -85,9 +87,13 @@ export function buildApp(sessionSecret: string): Express {
     res.json({ status: 'ok', time: new Date().toISOString() });
   });
 
+  // SPA fallback for client-side routes. `mcp` joins `api`/`ws` in the exclusion
+  // so that in node edition — where /mcp isn't mounted — a stray GET /mcp 404s
+  // instead of being served index.html; it's a disabled endpoint, not a page.
+  // (In standalone the mounted /mcp middleware handles it before this anyway.)
   const clientDist = path.join(import.meta.dirname, '../vue_client/dist');
   app.use(express.static(clientDist));
-  app.get(/^\/(?!api|ws).*/, (_req, res, next) => {
+  app.get(/^\/(?!api|ws|mcp).*/, (_req, res, next) => {
     res.sendFile(path.join(clientDist, 'index.html'), (err) => {
       if (err) next();
     });

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import type { Express } from 'express';
+import sharp from 'sharp';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+
+// Resolve to node edition + operator upload creds before the route reads them.
+// Edition caches on first getEdition(); vitest gives this file its own process.
+process.env.LURKER_EDITION = 'node';
+process.env.LURKER_NODE_UPLOAD_URL = 'https://dropper.test';
+process.env.LURKER_NODE_UPLOAD_API_KEY = 'operator-key-123';
+
+const ctx = setupTestDb('routes-uploads-node');
+
+// Same stub pattern as uploads.test.ts: capture the secrets the route hands the
+// provider so we can prove node edition sources them from the environment
+// (nodeUploadSecrets), never from the per-user secretsForProvider below.
+const stub = {
+  id: 'stub',
+  requiresSecrets: false,
+  capturedSecrets: null as Record<string, string> | null,
+  async upload(
+    _buffer: Buffer,
+    meta: { filename: string; mime: string },
+    secrets?: Record<string, string>,
+  ) {
+    stub.capturedSecrets = secrets ?? null;
+    return { url: `https://stub.example/${meta.filename}` };
+  },
+};
+
+vi.mock('../services/uploadProviders/index.js', () => ({
+  providerIds: ['x0', 'catbox', 'hoarder'],
+  getProvider: () => stub,
+  // A distinctive sentinel: if node edition ever fell back to per-user secrets,
+  // the credential assertion below would fail loudly.
+  secretsForProvider: () => ({ from: 'user-settings' }),
+}));
+
+let app: Express;
+let agent: LurkerTestAgent;
+let user: User;
+let smallPng: Buffer;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { setUserSetting } = await import('../db/settings.js');
+  const router = (await import('./uploads.js')).default;
+
+  user = createUser('upload-node-alice');
+  // A non-default tenant choice that node edition must IGNORE (default is x0;
+  // forcing to hoarder is only meaningful when the user picked something else).
+  setUserSetting(user.id, 'uploads.provider', 'catbox');
+
+  app = createTestApp({ '/api/uploads': router });
+  agent = await createAuthedAgent(app, user.id);
+
+  smallPng = await sharp({
+    create: { width: 16, height: 16, channels: 3, background: { r: 255, g: 0, b: 0 } },
+  })
+    .png()
+    .toBuffer();
+});
+
+afterAll(() => {
+  ctx.cleanup();
+  delete process.env.LURKER_EDITION;
+  delete process.env.LURKER_NODE_UPLOAD_URL;
+  delete process.env.LURKER_NODE_UPLOAD_API_KEY;
+});
+
+describe('POST /api/uploads (node edition)', () => {
+  it('forces the in-house provider regardless of the tenant setting', async () => {
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'photo.png', contentType: 'image/png' });
+    expect(res.status).toBe(200);
+
+    const list = await agent.get('/api/uploads');
+    const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
+    // Recorded as the forced in-house provider, not the tenant's 'catbox' pick.
+    expect(row.provider).toBe('hoarder');
+  });
+
+  it('hands the provider operator env credentials, not per-user settings', async () => {
+    stub.capturedSecrets = null;
+    await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'creds.png', contentType: 'image/png' });
+    expect(stub.capturedSecrets).toEqual({
+      url: 'https://dropper.test',
+      api_key: 'operator-key-123',
+    });
+  });
+});

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -8,11 +8,16 @@ import sharp from 'sharp';
 import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
 import type { User } from '../db/users.js';
 
-// Resolve to node edition + operator upload creds before the route reads them.
+// Resolve to node edition + operator upload config before the route reads it.
 // Edition caches on first getEdition(); vitest gives this file its own process.
 process.env.LURKER_EDITION = 'node';
 process.env.LURKER_NODE_UPLOAD_URL = 'https://dropper.test';
 process.env.LURKER_NODE_UPLOAD_API_KEY = 'operator-key-123';
+// Operator-controlled pipeline limits, deliberately tighter than both the
+// registry defaults and the conflicting tenant settings seeded below.
+process.env.LURKER_NODE_UPLOAD_MAX_MB = '1';
+process.env.LURKER_NODE_UPLOAD_MAX_DIM = '512';
+process.env.LURKER_NODE_UPLOAD_QUALITY = '40';
 
 const ctx = setupTestDb('routes-uploads-node');
 
@@ -41,6 +46,25 @@ vi.mock('../services/uploadProviders/index.js', () => ({
   secretsForProvider: () => ({ from: 'user-settings' }),
 }));
 
+// Mock the sharp pipeline so we can capture the maxDim/quality the route passes
+// it (the real pipeline runs in uploads.test.ts). Lets us assert those come
+// from the operator env, not the tenant's settings.
+const pipelineCapture = { opts: null as { maxDim: number; quality: number } | null };
+vi.mock('../services/imagePipeline.js', () => ({
+  optimize: async (_buf: Buffer, opts: { maxDim: number; quality: number }) => {
+    pipelineCapture.opts = opts;
+    return {
+      buffer: Buffer.from('x'),
+      mime: 'image/jpeg',
+      ext: 'jpg',
+      byteSize: 1,
+      width: 10,
+      height: 10,
+    };
+  },
+  thumbnail: async () => null,
+}));
+
 let app: Express;
 let agent: LurkerTestAgent;
 let user: User;
@@ -52,9 +76,12 @@ beforeAll(async () => {
   const router = (await import('./uploads.js')).default;
 
   user = createUser('upload-node-alice');
-  // A non-default tenant choice that node edition must IGNORE (default is x0;
-  // forcing to hoarder is only meaningful when the user picked something else).
+  // Non-default tenant choices that node edition must IGNORE: a different
+  // provider, and pipeline limits looser than the operator env above.
   setUserSetting(user.id, 'uploads.provider', 'catbox');
+  setUserSetting(user.id, 'uploads.image.max_upload_mb', 200);
+  setUserSetting(user.id, 'uploads.image.max_dimension', 8192);
+  setUserSetting(user.id, 'uploads.image.quality', 100);
 
   app = createTestApp({ '/api/uploads': router });
   agent = await createAuthedAgent(app, user.id);
@@ -71,6 +98,9 @@ afterAll(() => {
   delete process.env.LURKER_EDITION;
   delete process.env.LURKER_NODE_UPLOAD_URL;
   delete process.env.LURKER_NODE_UPLOAD_API_KEY;
+  delete process.env.LURKER_NODE_UPLOAD_MAX_MB;
+  delete process.env.LURKER_NODE_UPLOAD_MAX_DIM;
+  delete process.env.LURKER_NODE_UPLOAD_QUALITY;
 });
 
 describe('POST /api/uploads (node edition)', () => {
@@ -95,5 +125,24 @@ describe('POST /api/uploads (node edition)', () => {
       url: 'https://dropper.test',
       api_key: 'operator-key-123',
     });
+  });
+
+  it('caps upload size by the operator env, ignoring the higher tenant setting', async () => {
+    // Tenant set 200 MB; operator env caps at 1 MB, so a ~2 MB upload must 413.
+    const big = Buffer.alloc(2 * 1024 * 1024, 1);
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', big, { filename: 'big.png', contentType: 'image/png' });
+    expect(res.status).toBe(413);
+  });
+
+  it('uses operator env dimension + quality for the pipeline, ignoring tenant settings', async () => {
+    pipelineCapture.opts = null;
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'dims.png', contentType: 'image/png' });
+    expect(res.status).toBe(200);
+    // Operator env (512 / 40), not the tenant's 8192 / 100.
+    expect(pipelineCapture.opts).toEqual({ maxDim: 512, quality: 40 });
   });
 });

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -127,6 +127,24 @@ describe('POST /api/uploads (node edition)', () => {
     });
   });
 
+  it('503s with a clear message (no per-user key names) when the operator env is unset', async () => {
+    const savedUrl = process.env.LURKER_NODE_UPLOAD_URL;
+    const savedKey = process.env.LURKER_NODE_UPLOAD_API_KEY;
+    delete process.env.LURKER_NODE_UPLOAD_URL;
+    delete process.env.LURKER_NODE_UPLOAD_API_KEY;
+    try {
+      const res = await agent
+        .post('/api/uploads')
+        .attach('image', smallPng, { filename: 'noconfig.png', contentType: 'image/png' });
+      expect(res.status).toBe(503);
+      // Must not leak the per-user hoarder settings a tenant can't configure.
+      expect(res.body.error).not.toMatch(/uploads\.hoarder/);
+    } finally {
+      process.env.LURKER_NODE_UPLOAD_URL = savedUrl;
+      process.env.LURKER_NODE_UPLOAD_API_KEY = savedKey;
+    }
+  });
+
   it('caps upload size by the operator env, ignoring the higher tenant setting', async () => {
     // Tenant set 200 MB; operator env caps at 1 MB, so a ~2 MB upload must 413.
     const big = Buffer.alloc(2 * 1024 * 1024, 1);

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -9,9 +9,14 @@ import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from '../services/settingsRegistry.js';
 import * as imagePipeline from '../services/imagePipeline.js';
 import { getProvider, providerIds, secretsForProvider } from '../services/uploadProviders/index.js';
+import {
+  NODE_UPLOAD_PROVIDER_ID,
+  nodeUploadSecrets,
+} from '../services/uploadProviders/nodeUpload.js';
 import type { UploadListRow } from '../db/uploadHistory.js';
 import { insertUpload, listUploads, getThumbnail, deleteUpload } from '../db/uploadHistory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
+import { isNodeMode } from '../utils/edition.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -50,7 +55,12 @@ router.post(
         return;
       }
 
-      const providerId = String(settings['uploads.provider'] ?? '');
+      // In node edition the operator forces the in-house uploader and supplies
+      // its credentials from the environment — a tenant never picks a host or
+      // sees the keys. Standalone honors the user's chosen provider as before.
+      const providerId = isNodeMode()
+        ? NODE_UPLOAD_PROVIDER_ID
+        : String(settings['uploads.provider'] ?? '');
       const provider = getProvider(providerId);
       if (!provider) {
         res.status(400).json({ error: `unknown provider: ${providerId}` });
@@ -105,7 +115,9 @@ router.post(
       const baseName = originalName.replace(/\.[^.]+$/, '') || `upload-${Date.now()}`;
       const filename = `${baseName}.${outExt}`;
 
-      const secrets = secretsForProvider(providerId, settings as Record<string, string>);
+      const secrets: Record<string, string> = isNodeMode()
+        ? nodeUploadSecrets()
+        : secretsForProvider(providerId, settings as Record<string, string>);
       // provider.upload is from an untyped JS module
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let result: any;

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -13,6 +13,7 @@ import {
   NODE_UPLOAD_PROVIDER_ID,
   nodeUploadSecrets,
   nodeUploadLimits,
+  nodeUploadConfigured,
 } from '../services/uploadProviders/nodeUpload.js';
 import type { UploadListRow } from '../db/uploadHistory.js';
 import { insertUpload, listUploads, getThumbnail, deleteUpload } from '../db/uploadHistory.js';
@@ -46,6 +47,15 @@ router.post(
     try {
       if (!req.file) {
         res.status(400).json({ error: 'no file uploaded' });
+        return;
+      }
+
+      // In node edition the operator must have configured the in-house uploader.
+      // Without it the forced provider would throw an error naming per-user
+      // settings a tenant can't see — fail fast with a clear, server-side signal
+      // instead. The boot warning already tells the operator what to set.
+      if (isNodeMode() && !nodeUploadConfigured()) {
+        res.status(503).json({ error: 'uploads are not configured on this server' });
         return;
       }
 

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -12,6 +12,7 @@ import { getProvider, providerIds, secretsForProvider } from '../services/upload
 import {
   NODE_UPLOAD_PROVIDER_ID,
   nodeUploadSecrets,
+  nodeUploadLimits,
 } from '../services/uploadProviders/nodeUpload.js';
 import type { UploadListRow } from '../db/uploadHistory.js';
 import { insertUpload, listUploads, getThumbnail, deleteUpload } from '../db/uploadHistory.js';
@@ -49,7 +50,12 @@ router.post(
       }
 
       const settings = effectiveSettings(req.user!.id);
-      const maxMb = Number(settings['uploads.image.max_upload_mb']) || 25;
+      // The image-pipeline limits (size cap, max dimension, JPEG quality) are
+      // operator-controlled in node edition — sourced from env, not the tenant's
+      // settings, so a tenant can't lift their own cap or inflate storage. A3
+      // hides the matching UI. Standalone keeps these as per-user settings.
+      const limits = isNodeMode() ? nodeUploadLimits() : null;
+      const maxMb = limits ? limits.maxMb : Number(settings['uploads.image.max_upload_mb']) || 25;
       if (req.file.size > maxMb * 1024 * 1024) {
         res.status(413).json({ error: `file exceeds ${maxMb} MB` });
         return;
@@ -91,8 +97,10 @@ router.post(
         let optimized: any;
         try {
           optimized = await imagePipeline.optimize(req.file.buffer, {
-            maxDim: Number(settings['uploads.image.max_dimension']) || 2048,
-            quality: Number(settings['uploads.image.quality']) || 85,
+            maxDim: limits
+              ? limits.maxDim
+              : Number(settings['uploads.image.max_dimension']) || 2048,
+            quality: limits ? limits.quality : Number(settings['uploads.image.quality']) || 85,
           });
         } catch (err) {
           const e = err as { code?: string; message?: string };

--- a/server/server.ts
+++ b/server/server.ts
@@ -3,32 +3,13 @@
 
 import 'dotenv/config';
 import http from 'http';
-import express from 'express';
-import type { ErrorRequestHandler } from 'express';
-import cookieParser from 'cookie-parser';
-import cors from 'cors';
-import path from 'path';
 
-import authRouter from './routes/auth.js';
-import networksRouter from './routes/networks.js';
-import settingsRouter from './routes/settings.js';
-import highlightRulesRouter from './routes/highlightRules.js';
-import highlightsRouter from './routes/highlights.js';
-import bookmarksRouter from './routes/bookmarks.js';
-import pushRouter from './routes/push.js';
-import adminRouter from './routes/admin.js';
-import uploadsRouter from './routes/uploads.js';
-import draftsRouter from './routes/drafts.js';
-import { exportsRouter, importRouter } from './routes/exports.js';
-import apiTokensRouter from './routes/apiTokens.js';
-import configRouter from './routes/config.js';
-import nodeRouter from './routes/node.js';
+import { buildApp } from './app.js';
 import ircManager from './services/ircManager.js';
 import { attachWsHub } from './services/wsHub.js';
 import './services/verbs/index.js';
-import mcpRouter from './services/mcpServer.js';
-import { requireApiAuth } from './middleware/apiAuth.js';
 import { getNodeSecret } from './middleware/nodeAuth.js';
+import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
@@ -47,56 +28,13 @@ if (isNodeMode() && !getNodeSecret()) {
     '[lurker] node edition is active but LURKER_NODE_SECRET is unset — the node control API will reject every request (503) until it is configured',
   );
 }
-
-const app = express();
-
-const corsOrigin = process.env.CORS_ORIGIN || 'https://irc.local.bradroot.me:5173';
-app.use(cors({ origin: corsOrigin, credentials: true }));
-app.use(express.json({ limit: '1mb' }));
-app.use(cookieParser(SESSION_SECRET));
-
-app.use('/api/auth', authRouter);
-app.use('/api/networks', networksRouter);
-app.use('/api/settings', settingsRouter);
-app.use('/api/highlight-rules', highlightRulesRouter);
-app.use('/api/highlights', highlightsRouter);
-app.use('/api/bookmarks', bookmarksRouter);
-app.use('/api/push', pushRouter);
-app.use('/api/admin', adminRouter);
-app.use('/api/uploads', uploadsRouter);
-app.use('/api/drafts', draftsRouter);
-app.use('/api/exports', exportsRouter);
-app.use('/api/imports', importRouter);
-app.use('/api/api-tokens', apiTokensRouter);
-app.use('/api/config', configRouter);
-
-// Orchestrator-only control surface. Mounted exclusively in node edition so a
-// standalone self-hosted instance never exposes it at all.
-if (isNodeMode()) {
-  app.use('/api/node', nodeRouter);
+if (isNodeMode() && !nodeUploadConfigured()) {
+  console.warn(
+    '[lurker] node edition is active but LURKER_NODE_UPLOAD_URL / LURKER_NODE_UPLOAD_API_KEY are unset — image and text uploads will fail (400) until they are configured',
+  );
 }
 
-app.use('/mcp', requireApiAuth, mcpRouter);
-
-app.get('/api/health', (_req, res) => {
-  res.json({ status: 'ok', time: new Date().toISOString() });
-});
-
-const clientDist = path.join(import.meta.dirname, '../vue_client/dist');
-app.use(express.static(clientDist));
-app.get(/^\/(?!api|ws).*/, (_req, res, next) => {
-  res.sendFile(path.join(clientDist, 'index.html'), (err) => {
-    if (err) next();
-  });
-});
-
-const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
-  console.error('[lurker] error:', err);
-  if (res.headersSent) return next(err);
-  res.status(500).json({ error: 'internal error' });
-};
-app.use(errorHandler);
-
+const app = buildApp(SESSION_SECRET);
 const server = http.createServer(app);
 attachWsHub(server, SESSION_SECRET);
 

--- a/server/services/uploadProviders/nodeUpload.ts
+++ b/server/services/uploadProviders/nodeUpload.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// In the hosted (node) edition the cell never lets a tenant choose an upload
+// host: every upload goes through the operator-run in-house dropper — the same
+// R2-backed Hoarder service the `hoarder` provider already speaks to — using
+// operator-supplied credentials from the environment rather than per-user
+// settings. A tenant must never see or set these keys. This module centralizes
+// the env var names + secret lookup so the upload route and the boot-time
+// config check agree, and keeps it out of the (mockable) provider registry so
+// the route reads the real environment in tests.
+
+/** Provider id forced for every upload in node edition. */
+export const NODE_UPLOAD_PROVIDER_ID = 'hoarder';
+
+/**
+ * Operator-supplied in-house uploader credentials, read fresh from the
+ * environment (operator config is fixed for the process lifetime; reading on
+ * demand keeps this trivially testable). Shaped to match what the hoarder
+ * provider's `upload()` expects.
+ */
+export function nodeUploadSecrets(): { url: string; api_key: string } {
+  return {
+    url: (process.env.LURKER_NODE_UPLOAD_URL || '').trim(),
+    api_key: (process.env.LURKER_NODE_UPLOAD_API_KEY || '').trim(),
+  };
+}
+
+/** True only when both required env vars are present (drives the boot warning). */
+export function nodeUploadConfigured(): boolean {
+  const { url, api_key } = nodeUploadSecrets();
+  return Boolean(url && api_key);
+}

--- a/server/services/uploadProviders/nodeUpload.ts
+++ b/server/services/uploadProviders/nodeUpload.ts
@@ -54,8 +54,9 @@ function intOverride(envName: string, settingKey: string): number {
  * service these are NOT tenant settings — a tenant could otherwise inflate
  * storage/bandwidth or lift their own size cap with a direct settings write —
  * so the cell sources them from the environment, clamped to each setting's
- * registry bounds, with the registry defaults as the floor. A3 hides the
- * matching tenant UI; this is the enforcement behind it.
+ * registry [min,max] bounds and falling back to the registry default when an
+ * env var is unset or malformed. A3 hides the matching tenant UI; this is the
+ * enforcement behind it.
  */
 export function nodeUploadLimits(): { maxMb: number; maxDim: number; quality: number } {
   return {

--- a/server/services/uploadProviders/nodeUpload.ts
+++ b/server/services/uploadProviders/nodeUpload.ts
@@ -10,6 +10,8 @@
 // config check agree, and keeps it out of the (mockable) provider registry so
 // the route reads the real environment in tests.
 
+import { getOption } from '../settingsRegistry.js';
+
 /** Provider id forced for every upload in node edition. */
 export const NODE_UPLOAD_PROVIDER_ID = 'hoarder';
 
@@ -30,4 +32,35 @@ export function nodeUploadSecrets(): { url: string; api_key: string } {
 export function nodeUploadConfigured(): boolean {
   const { url, api_key } = nodeUploadSecrets();
   return Boolean(url && api_key);
+}
+
+// Read an operator-set integer override for a registry int setting: clamped to
+// that setting's [min,max] and falling back to its registry default when unset
+// or malformed. Operator env is trusted, but clamping stops a typo'd value from
+// breaking every upload on the cell.
+function intOverride(envName: string, settingKey: string): number {
+  const opt = getOption(settingKey);
+  const fallback = opt && typeof opt.default === 'number' ? opt.default : 0;
+  const raw = (process.env[envName] || '').trim();
+  const n = raw ? Math.floor(Number(raw)) : NaN;
+  if (!Number.isFinite(n)) return fallback;
+  const min = opt && 'min' in opt ? opt.min : n;
+  const max = opt && 'max' in opt ? opt.max : n;
+  return Math.min(Math.max(n, min), max);
+}
+
+/**
+ * Operator-controlled image-pipeline limits for node edition. In the hosted
+ * service these are NOT tenant settings — a tenant could otherwise inflate
+ * storage/bandwidth or lift their own size cap with a direct settings write —
+ * so the cell sources them from the environment, clamped to each setting's
+ * registry bounds, with the registry defaults as the floor. A3 hides the
+ * matching tenant UI; this is the enforcement behind it.
+ */
+export function nodeUploadLimits(): { maxMb: number; maxDim: number; quality: number } {
+  return {
+    maxMb: intOverride('LURKER_NODE_UPLOAD_MAX_MB', 'uploads.image.max_upload_mb'),
+    maxDim: intOverride('LURKER_NODE_UPLOAD_MAX_DIM', 'uploads.image.max_dimension'),
+    quality: intOverride('LURKER_NODE_UPLOAD_QUALITY', 'uploads.image.quality'),
+  };
 }


### PR DESCRIPTION
Closes the first two of the three node-mode gating cards. Server-side only; the matching client UI gating is **A3** (#164).

## A7 · API tokens + MCP server (`/api/api-tokens`, `/mcp`)
Both are **bearer-authenticated**. The hosted service routes a customer to their cell by the `cp_session` cookie, but a bearer client carries no such cookie — so neither endpoint can be addressed through the per-cell proxy. Per the card's recommended option (a), they're **disabled entirely in node edition**; standalone keeps them fully featured.

To make the gating testable, the Express app construction is extracted from `server/server.ts` into **`server/app.ts` (`buildApp(secret)`)**; `server.ts` keeps the http server / WS hub / IRC manager / lifecycle. No behavior change for standalone beyond a harmless mount-order tweak.

## A8 · Upload service (in-house R2)
In node edition every upload is **forced through the operator-run in-house dropper** — reusing the existing `hoarder` provider, which already speaks that R2-backed service's exact contract (`POST {base}/api/upload`, `Authorization: Bearer`, JSON `{url}`). Credentials come from **operator env** (`LURKER_NODE_UPLOAD_URL` / `LURKER_NODE_UPLOAD_API_KEY`), never per-user settings — a tenant can't pick a host or see the keys. The tenant's `uploads.provider` is ignored.

The **image-pipeline limits** are operator-controlled too: max upload size, max dimension, and JPEG quality come from env (`LURKER_NODE_UPLOAD_MAX_MB` / `_MAX_DIM` / `_QUALITY`), each clamped to the setting's registry bounds with the registry default as fallback, ignoring the tenant's values. This is the server-side enforcement behind A3's UI hiding (#164) — a client-only gate wouldn't stop a direct `PUT /api/settings` to lift a size cap or inflate storage.

Invariants kept: the **sharp pipeline and animated-image passthrough are untouched** (they run before/after provider selection). A boot warning fires in node edition if the upload credentials are unset (mirrors the existing `LURKER_NODE_SECRET` warning). `.env.example` documents all the new vars.

Standing up the actual Lurker-branded dropper + R2 bucket is tracked separately (board card B6).

## Tests
- `server/app.test.ts` — `buildApp` gating is **two-sided**: in node `/api/api-tokens` and `/mcp` return 404 while `/api/node` is mounted; in standalone the bearer routes are mounted (401 without creds) and `/api/node` is absent.
- `server/routes/uploads.node.test.ts` — node edition forces the provider (records `hoarder` even when the tenant chose `catbox`), hands the provider the env credentials, **caps size by the operator env (413) ignoring a higher tenant setting**, and passes the operator env dimension/quality to the pipeline (not the tenant's).

Full suite green (695), typecheck (server + client), lint, format all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
