### PR TITLE
Node edition: gate operator-only settings UI (A3)

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -27,6 +27,11 @@ interface BaseOption {
   category: string;
   group: string;
   description: string;
+  // Operator-only: hidden from the Settings UI in the hosted (node) edition,
+  // where the cell — not the tenant — owns this knob. The server ignores the
+  // flag; it is purely a client-side rendering gate (A3). Self-hosted
+  // (standalone) instances show everything as before.
+  selfHostedOnly?: boolean;
 }
 
 /** Free-text settings: plain strings, CSS colors, and write-only secrets. */
@@ -74,6 +79,8 @@ export interface SettingCategory {
   label: string;
   kind: 'registry' | 'bespoke';
   adminOnly?: boolean;
+  // As on BaseOption: hide the whole category in the hosted (node) edition.
+  selfHostedOnly?: boolean;
 }
 
 export const REGISTRY: readonly SettingOption[] = Object.freeze([
@@ -811,6 +818,10 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'enum',
     choices: ['x0', 'catbox', 'hoarder'],
     default: 'x0',
+    // Node edition forces the operator's in-house uploader (A8); a tenant never
+    // picks a host, so this and the provider-credential settings below are
+    // hidden in the hosted edition.
+    selfHostedOnly: true,
     description:
       'Where pasted/picked images are uploaded. x0.at and catbox.moe are ' +
       'anonymous public hosts. hoarder uploads to your own self-hosted ' +
@@ -871,6 +882,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'catbox',
     type: 'secret',
     default: '',
+    selfHostedOnly: true,
     description:
       'Optional catbox.moe account hash. Uploads made with a userhash can ' +
       'be managed from your catbox account; without one they are anonymous.',
@@ -882,6 +894,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'hoarder',
     type: 'string',
     default: '',
+    selfHostedOnly: true,
     description:
       'Base URL of your Hoarder instance (e.g. https://upload.example.com). ' +
       'Only used when the upload provider is set to hoarder.',
@@ -893,6 +906,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'hoarder',
     type: 'secret',
     default: '',
+    selfHostedOnly: true,
     description:
       'API key for your Hoarder instance. Generate one on the Hoarder server ' +
       'with `node scripts/gen-api-key.js` and add it to ' +
@@ -1230,7 +1244,10 @@ export const CATEGORIES: readonly SettingCategory[] = Object.freeze([
   { id: 'users', label: 'Users', kind: 'bespoke', adminOnly: true },
   { id: 'networks', label: 'Networks', kind: 'bespoke' },
   { id: 'account', label: 'Account', kind: 'bespoke' },
-  { id: 'api-tokens', label: 'API tokens', kind: 'bespoke' },
+  // Disabled in node edition: bearer clients can't be routed through the
+  // per-cell proxy, so the server doesn't mount /api/api-tokens or /mcp there
+  // (A7). Hide the whole category in the hosted edition.
+  { id: 'api-tokens', label: 'API tokens', kind: 'bespoke', selfHostedOnly: true },
   { id: 'data', label: 'Data', kind: 'bespoke' },
   { id: 'about', label: 'About', kind: 'bespoke' },
 ]);

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -836,6 +836,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     min: 256,
     max: 8192,
     default: 2048,
+    // Cost/abuse lever — operator-controlled in node edition (enforced
+    // server-side in A8), not a tenant knob.
+    selfHostedOnly: true,
     description:
       'Longest-edge limit for static images before they are re-encoded as JPEG. ' +
       'Animated GIF/WebP/APNG bypass this and are uploaded verbatim.',
@@ -849,6 +852,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     min: 30,
     max: 100,
     default: 85,
+    selfHostedOnly: true,
     description: 'JPEG quality for the re-encode pass on static images (30–100).',
   },
   {
@@ -860,6 +864,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     min: 1,
     max: 200,
     default: 25,
+    selfHostedOnly: true,
     description:
       'Hard cap on the raw upload size in megabytes. Anything larger is ' +
       'rejected before the optimization pipeline runs.',

--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -13,17 +13,20 @@
 import { onMounted } from 'vue';
 import { useAuthStore } from './stores/auth.js';
 import { useSettingsStore } from './stores/settings.js';
+import { useConfigStore } from './stores/config.js';
 import { useTheme } from './composables/useTheme.js';
 import ToastContainer from './components/ToastContainer.vue';
 import ContextMenu from './components/ContextMenu.vue';
 
 const auth = useAuthStore();
 const settings = useSettingsStore();
+const config = useConfigStore();
 
 useTheme();
 
 onMounted(() => {
   auth.fetchMe();
+  if (!config.checked) config.fetch().catch(() => {});
   if (!settings.loaded) settings.fetchAll().catch(() => {});
 });
 </script>

--- a/vue_client/src/components/settings-panes/AccountPane.vue
+++ b/vue_client/src/components/settings-panes/AccountPane.vue
@@ -9,88 +9,96 @@
     <p v-if="auth.user" class="account-identity">
       Signed in as <strong>{{ auth.user.username }}</strong>
     </p>
-    <p class="section-desc">
+    <p v-if="config.isNode" class="section-desc">
+      Your account sign-in is managed at
+      <a href="https://lurker.chat" target="_blank" rel="noopener">lurker.chat</a> — passkeys and
+      passwords are set on your account there, not on this server.
+    </p>
+    <p v-else class="section-desc">
       You can sign in with a passkey, a password, or both. Removing your last sign-in method would
       lock you out, so it's blocked.
     </p>
-    <p v-if="passkeyError" class="error inline">{{ passkeyError }}</p>
 
-    <h3 class="subhead">passkeys</h3>
-    <ul v-if="passkeys.length" class="device-list">
-      <li v-for="pk in passkeys" :key="pk.id" class="device passkey">
-        <span class="ua">
-          <input
-            type="text"
-            :value="pk.label || ''"
-            :placeholder="defaultPasskeyLabel(pk)"
-            @change="onRenamePasskey(pk, ($event.target as HTMLInputElement).value)"
-          />
-        </span>
-        <span class="last-seen" :title="pk.lastUsedAt || pk.createdAt">
-          {{
-            pk.lastUsedAt
-              ? `last used ${formatRelative(pk.lastUsedAt)}`
-              : `added ${formatRelative(pk.createdAt)}`
-          }}
-        </span>
-        <button
-          class="link danger"
-          :disabled="!canRemovePasskey || passkeyBusy"
-          :title="removePasskeyTitle"
-          @click="onRemovePasskey(pk)"
-        >
-          remove
-        </button>
-      </li>
-    </ul>
-    <p v-else class="muted small">No passkeys registered.</p>
-    <div class="passkey-add">
-      <button class="link" :disabled="passkeyBusy" @click="onAddPasskey">add passkey</button>
-    </div>
+    <template v-if="!config.isNode">
+      <p v-if="passkeyError" class="error inline">{{ passkeyError }}</p>
 
-    <h3 class="subhead">password</h3>
-    <p v-if="passwordError" class="error inline">{{ passwordError }}</p>
-    <p v-if="passwordNotice" class="muted small">{{ passwordNotice }}</p>
-    <p v-if="!hasPassword" class="muted small">No password set.</p>
-    <p v-else class="muted small">Password is set.</p>
-    <form class="password-form" @submit.prevent="onSavePassword">
-      <label v-if="hasPassword">
-        <span>Current password</span>
-        <input v-model="currentPasswordInput" type="password" autocomplete="current-password" />
-      </label>
-      <label>
-        <span>{{ hasPassword ? 'New password' : 'Password' }}</span>
-        <input
-          v-model="newPasswordInput"
-          type="password"
-          autocomplete="new-password"
-          minlength="8"
-        />
-      </label>
-      <div class="password-actions">
-        <button
-          class="link"
-          type="submit"
-          :disabled="passwordBusy || !newPasswordInput || (hasPassword && !currentPasswordInput)"
-        >
-          {{ hasPassword ? 'change password' : 'set password' }}
-        </button>
-        <button
-          v-if="hasPassword"
-          type="button"
-          class="link danger"
-          :disabled="passwordBusy || passkeys.length === 0"
-          :title="
-            passkeys.length === 0
-              ? 'add a passkey before removing your password'
-              : 'remove password'
-          "
-          @click="onRemovePassword"
-        >
-          remove password
-        </button>
+      <h3 class="subhead">passkeys</h3>
+      <ul v-if="passkeys.length" class="device-list">
+        <li v-for="pk in passkeys" :key="pk.id" class="device passkey">
+          <span class="ua">
+            <input
+              type="text"
+              :value="pk.label || ''"
+              :placeholder="defaultPasskeyLabel(pk)"
+              @change="onRenamePasskey(pk, ($event.target as HTMLInputElement).value)"
+            />
+          </span>
+          <span class="last-seen" :title="pk.lastUsedAt || pk.createdAt">
+            {{
+              pk.lastUsedAt
+                ? `last used ${formatRelative(pk.lastUsedAt)}`
+                : `added ${formatRelative(pk.createdAt)}`
+            }}
+          </span>
+          <button
+            class="link danger"
+            :disabled="!canRemovePasskey || passkeyBusy"
+            :title="removePasskeyTitle"
+            @click="onRemovePasskey(pk)"
+          >
+            remove
+          </button>
+        </li>
+      </ul>
+      <p v-else class="muted small">No passkeys registered.</p>
+      <div class="passkey-add">
+        <button class="link" :disabled="passkeyBusy" @click="onAddPasskey">add passkey</button>
       </div>
-    </form>
+
+      <h3 class="subhead">password</h3>
+      <p v-if="passwordError" class="error inline">{{ passwordError }}</p>
+      <p v-if="passwordNotice" class="muted small">{{ passwordNotice }}</p>
+      <p v-if="!hasPassword" class="muted small">No password set.</p>
+      <p v-else class="muted small">Password is set.</p>
+      <form class="password-form" @submit.prevent="onSavePassword">
+        <label v-if="hasPassword">
+          <span>Current password</span>
+          <input v-model="currentPasswordInput" type="password" autocomplete="current-password" />
+        </label>
+        <label>
+          <span>{{ hasPassword ? 'New password' : 'Password' }}</span>
+          <input
+            v-model="newPasswordInput"
+            type="password"
+            autocomplete="new-password"
+            minlength="8"
+          />
+        </label>
+        <div class="password-actions">
+          <button
+            class="link"
+            type="submit"
+            :disabled="passwordBusy || !newPasswordInput || (hasPassword && !currentPasswordInput)"
+          >
+            {{ hasPassword ? 'change password' : 'set password' }}
+          </button>
+          <button
+            v-if="hasPassword"
+            type="button"
+            class="link danger"
+            :disabled="passwordBusy || passkeys.length === 0"
+            :title="
+              passkeys.length === 0
+                ? 'add a passkey before removing your password'
+                : 'remove password'
+            "
+            @click="onRemovePassword"
+          >
+            remove password
+          </button>
+        </div>
+      </form>
+    </template>
 
     <div class="signout-row">
       <button class="link danger" @click="signOut">sign out</button>
@@ -102,6 +110,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useAuthStore } from '../../stores/auth.js';
+import { useConfigStore } from '../../stores/config.js';
 import { formatRelative } from '../../utils/timestamp.js';
 
 // The auth store's Passkey interface covers the core fields; the server also
@@ -115,6 +124,7 @@ interface PasskeyRow {
 }
 
 const auth = useAuthStore();
+const config = useConfigStore();
 const router = useRouter();
 
 const passkeys = ref<PasskeyRow[]>([]);
@@ -139,6 +149,9 @@ const removePasskeyTitle = computed(() => {
 });
 
 onMounted(() => {
+  // In node edition sign-in lives at the control plane (lurker.chat); the cell
+  // exposes no passkey/password management, so skip those lookups entirely.
+  if (config.isNode) return;
   refreshPasskeys();
   refreshPasswordStatus();
 });

--- a/vue_client/src/components/settings-panes/RegistryPane.vue
+++ b/vue_client/src/components/settings-panes/RegistryPane.vue
@@ -37,13 +37,15 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { useSettingsStore } from '../../stores/settings.js';
-import { CATEGORIES, GROUPS } from '../../utils/settingsRegistry.js';
+import { useConfigStore } from '../../stores/config.js';
+import { CATEGORIES, GROUPS, optionVisible } from '../../utils/settingsRegistry.js';
 import type { SettingOption, SettingValue } from '../../../../shared/settingsRegistry.js';
 import SettingsRow from '../SettingsRow.vue';
 
 const props = defineProps<{ categoryId: string }>();
 
 const settings = useSettingsStore();
+const config = useConfigStore();
 const error = ref('');
 
 const categoryLabel = computed(() => {
@@ -52,7 +54,9 @@ const categoryLabel = computed(() => {
 });
 
 const groups = computed(() => {
-  const items = settings.registry.filter((opt) => opt.category === props.categoryId);
+  const items = settings.registry.filter(
+    (opt) => opt.category === props.categoryId && optionVisible(opt, { isNode: config.isNode }),
+  );
   if (!items.length) return [];
   const groupsMap = new Map<string, SettingOption[]>();
   for (const opt of items) {

--- a/vue_client/src/stores/config.ts
+++ b/vue_client/src/stores/config.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Deployment config the client reads once at boot from the public /api/config
+// endpoint. Today it carries only the edition (self-hosted standalone vs a
+// hosted lurker.chat cell), which the Settings UI uses to gate operator-only
+// surfaces (A3). Defaults to 'standalone' so a fetch failure degrades to the
+// fully-featured self-hosted experience rather than hiding things wrongly.
+
+import { defineStore } from 'pinia';
+import { api } from '../api.js';
+
+export type Edition = 'standalone' | 'node';
+
+export const useConfigStore = defineStore('config', {
+  state: () => ({
+    edition: 'standalone' as Edition,
+    checked: false,
+  }),
+  getters: {
+    // True when this client is talking to a hosted cell, not a self-hosted box.
+    isNode: (s): boolean => s.edition === 'node',
+  },
+  actions: {
+    async fetch(): Promise<Edition> {
+      try {
+        const data = await api<{ edition?: string }>('/api/config');
+        this.edition = data.edition === 'node' ? 'node' : 'standalone';
+      } catch (_err) {
+        this.edition = 'standalone';
+      } finally {
+        this.checked = true;
+      }
+      return this.edition;
+    },
+  },
+});

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { CATEGORIES, REGISTRY, categoryVisible, optionVisible } from './settingsRegistry.js';
+
+const cat = (id: string) => CATEGORIES.find((c) => c.id === id)!;
+const opt = (key: string) => REGISTRY.find((o) => o.key === key)!;
+
+describe('categoryVisible', () => {
+  const standalone = { isAdmin: false, isNode: false };
+  const node = { isAdmin: false, isNode: true };
+
+  it('hides adminOnly categories from non-admins, shows them to admins', () => {
+    expect(categoryVisible(cat('users'), { isAdmin: false, isNode: false })).toBe(false);
+    expect(categoryVisible(cat('users'), { isAdmin: true, isNode: false })).toBe(true);
+  });
+
+  it('hides selfHostedOnly categories in node edition only', () => {
+    expect(categoryVisible(cat('api-tokens'), standalone)).toBe(true);
+    expect(categoryVisible(cat('api-tokens'), node)).toBe(false);
+    // selfHostedOnly is independent of role — a node-edition admin still can't
+    // see it (the route isn't mounted there anyway).
+    expect(categoryVisible(cat('api-tokens'), { isAdmin: true, isNode: true })).toBe(false);
+  });
+
+  it('shows ordinary categories in both editions', () => {
+    expect(categoryVisible(cat('appearance'), standalone)).toBe(true);
+    expect(categoryVisible(cat('appearance'), node)).toBe(true);
+  });
+});
+
+describe('optionVisible', () => {
+  it('hides selfHostedOnly settings in node edition, shows them standalone', () => {
+    expect(optionVisible(opt('uploads.provider'), { isNode: false })).toBe(true);
+    expect(optionVisible(opt('uploads.provider'), { isNode: true })).toBe(false);
+    expect(optionVisible(opt('uploads.hoarder.api_key'), { isNode: true })).toBe(false);
+  });
+
+  it('keeps the upload pipeline settings visible in node edition', () => {
+    // Tenant-relevant prefs (quality, paste behavior), not provider config —
+    // these must survive the gating that hides the provider + credentials.
+    expect(optionVisible(opt('uploads.image.quality'), { isNode: true })).toBe(true);
+    expect(optionVisible(opt('uploads.paste.enabled'), { isNode: true })).toBe(true);
+  });
+});

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -37,10 +37,17 @@ describe('optionVisible', () => {
     expect(optionVisible(opt('uploads.hoarder.api_key'), { isNode: true })).toBe(false);
   });
 
-  it('keeps the upload pipeline settings visible in node edition', () => {
-    // Tenant-relevant prefs (quality, paste behavior), not provider config —
-    // these must survive the gating that hides the provider + credentials.
-    expect(optionVisible(opt('uploads.image.quality'), { isNode: true })).toBe(true);
+  it('hides the cost/abuse pipeline knobs in node edition (operator-controlled)', () => {
+    // dimension / quality / max size are enforced server-side in node edition
+    // (A8); the tenant must not be able to set them, here or via the API.
+    expect(optionVisible(opt('uploads.image.max_dimension'), { isNode: true })).toBe(false);
+    expect(optionVisible(opt('uploads.image.quality'), { isNode: true })).toBe(false);
+    expect(optionVisible(opt('uploads.image.max_upload_mb'), { isNode: true })).toBe(false);
+    // ...but they stay visible on a self-hosted box.
+    expect(optionVisible(opt('uploads.image.quality'), { isNode: false })).toBe(true);
+  });
+
+  it('keeps paste-to-upload (a client UX pref, not a cost knob) visible in node edition', () => {
     expect(optionVisible(opt('uploads.paste.enabled'), { isNode: true })).toBe(true);
   });
 });

--- a/vue_client/src/utils/settingsRegistry.ts
+++ b/vue_client/src/utils/settingsRegistry.ts
@@ -12,11 +12,38 @@ import {
   CATEGORIES,
   GROUPS,
 } from '../../../shared/settingsRegistry.js';
-import type { SettingValue } from '../../../shared/settingsRegistry.js';
+import type {
+  SettingValue,
+  SettingOption,
+  SettingCategory,
+} from '../../../shared/settingsRegistry.js';
 
 export { REGISTRY, getOption, defaultsAsObject, CATEGORIES, GROUPS };
 
 export function getDefault(key: string): SettingValue | undefined {
   const opt = getOption(key);
   return opt ? opt.default : undefined;
+}
+
+/** Edition/role context that decides which settings surfaces are visible. */
+export interface VisibilityContext {
+  isAdmin: boolean;
+  isNode: boolean;
+}
+
+/**
+ * Whether a settings category shows in the sidebar. `adminOnly` categories are
+ * hidden from non-admins; `selfHostedOnly` ones are hidden in the hosted (node)
+ * edition where the operator, not the tenant, owns them.
+ */
+export function categoryVisible(cat: SettingCategory, ctx: VisibilityContext): boolean {
+  if (cat.adminOnly && !ctx.isAdmin) return false;
+  if (cat.selfHostedOnly && ctx.isNode) return false;
+  return true;
+}
+
+/** Whether an individual registry setting renders, given the edition. */
+export function optionVisible(opt: SettingOption, ctx: Pick<VisibilityContext, 'isNode'>): boolean {
+  if (opt.selfHostedOnly && ctx.isNode) return false;
+  return true;
 }

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -48,8 +48,9 @@ import type { Component } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useSettingsStore } from '../stores/settings.js';
 import { useAuthStore } from '../stores/auth.js';
+import { useConfigStore } from '../stores/config.js';
 import { useSocket } from '../composables/useSocket.js';
-import { CATEGORIES, GROUPS, REGISTRY } from '../utils/settingsRegistry.js';
+import { CATEGORIES, GROUPS, REGISTRY, categoryVisible } from '../utils/settingsRegistry.js';
 import SettingsSidebar from '../components/SettingsSidebar.vue';
 import RegistryPane from '../components/settings-panes/RegistryPane.vue';
 import NotificationsPane from '../components/settings-panes/NotificationsPane.vue';
@@ -66,6 +67,7 @@ useSocket();
 
 const settings = useSettingsStore();
 const auth = useAuthStore();
+const config = useConfigStore();
 const route = useRoute();
 const router = useRouter();
 
@@ -86,7 +88,9 @@ const BESPOKE_PANES: Record<string, Component> = {
   about: AboutPane,
 };
 
-const visibleCategories = computed(() => CATEGORIES.filter((c) => !c.adminOnly || isAdmin.value));
+const visibleCategories = computed(() =>
+  CATEGORIES.filter((c) => categoryVisible(c, { isAdmin: isAdmin.value, isNode: config.isNode })),
+);
 
 const firstCategoryId = computed(() => visibleCategories.value[0]?.id || 'appearance');
 
@@ -129,7 +133,10 @@ const appearanceSubsections = computed<SettingsSubsection[]>(() => {
 watch(
   [() => route.params.category, activeCategoryId, isAdmin],
   ([param, active], _old, onCleanup) => {
-    if (!auth.checked) return;
+    // Wait until both the user and the edition are known, so we never redirect
+    // based on a category set that's about to change (e.g. a node tenant before
+    // /api/config resolves still hides nothing).
+    if (!auth.checked || !config.checked) return;
     if (param !== active) {
       router.replace({ name: 'settings', params: { category: active } });
     }


### PR DESCRIPTION
The third node-mode gating card. Client-side UI gating that complements the server changes in #163 (A7/A8). Standalone is unchanged.

## Foundation: edition on the client
A new **`config` pinia store** fetches the public `GET /api/config` once at boot (App.vue) and exposes `edition` / `isNode`. It **defaults to `standalone`** on any fetch failure, so a self-hosted instance is never wrongly stripped of features.

## Registry-driven gating
A new **`selfHostedOnly`** flag on settings categories + options (shared registry; the server ignores it — purely a render gate). Two pure helpers — **`categoryVisible`** and **`optionVisible`** — centralize the rule (`adminOnly && !isAdmin` → hide; `selfHostedOnly && isNode` → hide), are shared by `Settings.vue` and `RegistryPane.vue`, and unit-tested directly.

### What's hidden in node edition
- **Upload provider + credentials** — `uploads.provider` and the catbox/hoarder secret settings. Node forces the operator's in-house uploader (#163, A8).
- **Upload pipeline knobs** — `max_dimension`, `quality`, `max_upload_mb`. These are cost/abuse levers (storage, bandwidth, size cap), not tenant prefs, so they're operator-controlled in the hosted edition. **Hiding them here is only the UI half — the server enforces operator values in #163**, since a client-only gate wouldn't stop a direct `PUT /api/settings` write. Only **`paste.enabled`** (a client paste-behavior pref, no cost angle) stays tenant-facing.
- **API tokens** — the whole category. The route isn't mounted in node (#163, A7).
- **Account panel** — passkey + password management are hidden and the help text is reworded to point sign-in management at **lurker.chat**. The cell session is minted by the control plane, so those controls are meaningless on the proxy session. (The passkey/password lookups are also skipped on mount in node edition.)

### What needs no change
Admin / server-config / invite management is already `adminOnly`, and A6 guarantees a node tenant is never an admin — so it's already hidden for tenants.

## Tests
`vue_client/src/utils/settingsRegistry.test.ts` covers the helpers: `adminOnly` role gating still works; `selfHostedOnly` hides the API-tokens category, the upload provider/credentials, and the cost/abuse pipeline knobs in node only; `paste.enabled` and ordinary categories survive in both editions.

Full suite green, typecheck (server + client), lint, format clean, and `client:build` succeeds. Component-level `v-if`s aren't unit-tested — there's no component-mount harness in the repo (existing client tests are pure-util only), so I kept the testable logic in pure helpers rather than ship aspirational component tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
