### PR TITLE
Document the selfHostedOnly convention (presentation vs enforcement)

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -31,6 +31,14 @@ interface BaseOption {
   // where the cell — not the tenant — owns this knob. The server ignores the
   // flag; it is purely a client-side rendering gate (A3). Self-hosted
   // (standalone) instances show everything as before.
+  //
+  // CONVENTION: this is presentation only — it does NOT stop a tenant from
+  // writing the setting via PUT /api/settings. That's fine for *cosmetic*
+  // knobs, but any cost / abuse / security lever marked selfHostedOnly MUST
+  // ALSO be enforced server-side in node edition (e.g. the cell sourcing the
+  // value from operator config and ignoring the tenant's), or the gate is
+  // trivially bypassable. The upload pipeline limits (uploads.image.*) are the
+  // reference pattern: hidden here, enforced in the cell's upload route.
   selfHostedOnly?: boolean;
 }
 


### PR DESCRIPTION
Small doc follow-up to the node-edition gating work (after #164 merged).

`selfHostedOnly` hides a setting/category from the hosted (node) edition UI, but the **server ignores the flag** — it's a client-side render gate, so it does not stop a tenant from writing the value via `PUT /api/settings`. That's fine for cosmetic knobs, but a footgun for cost/abuse/security levers, where a hidden-but-writable setting reads as a guarantee it isn't.

This adds a `CONVENTION:` note on the `selfHostedOnly` field spelling that out, and points at the upload pipeline limits (`uploads.image.*`) as the reference pattern: hidden in the UI here, enforced server-side in the cell's upload route (#163). No behavior change — comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)