### PR TITLE
Built-in identd for per-user attribution (B11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,3 +73,13 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_NODE_UPLOAD_MAX_MB=25     # 1–200, default 25
 # LURKER_NODE_UPLOAD_MAX_DIM=2048  # 256–8192, default 2048
 # LURKER_NODE_UPLOAD_QUALITY=85    # 30–100, default 85
+#
+# ---------------------------------------------------------------------------
+# Built-in identd (RFC 1413). For MULTI-USER deployments connecting many users
+# to a network from one IP, so the network can attribute each user. Off by
+# default (binding :113 is privileged; single-user self-hosts don't need it).
+# Node-edition cells should enable it. Port 113 must be reachable by the IRC
+# server; to avoid root, set a high port and have the host's oidentd forward.
+# ---------------------------------------------------------------------------
+# LURKER_IDENTD_ENABLED=true
+# LURKER_IDENTD_PORT=113

--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -40,6 +40,23 @@ LURKER_DOMAIN=""
 # Apple, Google, and Mozilla's push services require.
 ADMIN_EMAIL=""
 
+# ─── Optional: built-in identd (RFC 1413) ───────────────────────────────────
+#
+# Set to "true" to run Lurker's built-in identd on port 113. For a MULTI-USER
+# instance this lets IRC networks attribute each user individually behind the
+# shared server IP (and is what networks like Libera ask of a hosted service) —
+# users then appear with a verified ident rather than an unverified "~ident".
+# The script publishes :113 and opens it in the firewall. Leave blank for a
+# single-user instance that doesn't need it.
+#
+# Requires a Lurker image that includes identd (ghcr.io/amiantos/lurker:latest
+# once that lands). Docker note: the IRC server's :113 callback has to map back
+# to the exact source port of the outbound IRC connection; Docker's bridge NAT
+# preserves source ports at normal scale, so this works as-is — if you ever see
+# unverified idents under heavy concurrency, run the lurker service with
+# `network_mode: host` instead.
+ENABLE_IDENTD=""
+
 # ─── No edits needed below this line ────────────────────────────────────────
 
 set -euo pipefail
@@ -171,6 +188,10 @@ configure_firewall() {
   ufw allow 80/tcp
   ufw allow 443/tcp
   ufw deny 8015/tcp
+  if [ "$ENABLE_IDENTD" = "true" ]; then
+    # IRC servers connect back to :113 to verify each user's ident.
+    ufw allow 113/tcp
+  fi
   ufw --force enable
   ufw status verbose || true
 }
@@ -186,14 +207,34 @@ deploy() {
   curl -fsSL -o docker-compose.caddy.yml "$REPO_RAW/docker-compose.caddy.yml"
   curl -fsSL -o Caddyfile "$REPO_RAW/deploy/Caddyfile"
 
+  local compose_files="docker-compose.yml:docker-compose.caddy.yml"
+
+  # identd overlay, layered AFTER Caddy (which resets the lurker ports), so it
+  # re-publishes :113 and turns on the built-in identd while the web port stays
+  # internal to Caddy. Generated locally so `pull` + `up -d` updates keep it.
+  if [ "$ENABLE_IDENTD" = "true" ]; then
+    log "identd enabled — publishing :113 and turning on the built-in identd."
+    cat > docker-compose.identd.yml <<'YAML'
+services:
+  lurker:
+    ports:
+      - '113:113'
+    environment:
+      - LURKER_IDENTD_ENABLED=true
+      - LURKER_IDENTD_PORT=113
+YAML
+    compose_files="${compose_files}:docker-compose.identd.yml"
+  fi
+
   # Compose interpolates LURKER_DOMAIN/ADMIN_EMAIL into docker-compose.caddy.yml
   # — Caddy reads them for TLS, Lurker reads them for passkeys and push.
-  # COMPOSE_FILE records the overlay so plain `docker compose` commands —
-  # including future `pull` + `up -d` updates — pick up Caddy automatically.
+  # COMPOSE_FILE records the overlay stack so plain `docker compose` commands —
+  # including future `pull` + `up -d` updates — pick up Caddy (and identd)
+  # automatically.
   cat > .env <<EOF
 LURKER_DOMAIN=${LURKER_DOMAIN}
 ADMIN_EMAIL=${ADMIN_EMAIL}
-COMPOSE_FILE=docker-compose.yml:docker-compose.caddy.yml
+COMPOSE_FILE=${compose_files}
 EOF
 
   compose pull
@@ -221,3 +262,7 @@ log "${PUBLIC_IP} if you haven't already — Caddy retries Let's Encrypt"
 log "until it resolves, then https://${LURKER_DOMAIN} serves over HTTPS."
 log "Passkeys and web push are pre-configured; once you've created your"
 log "admin account, opt in per device from Lurker's settings."
+if [ "$ENABLE_IDENTD" = "true" ]; then
+  log "Built-in identd is running on :113 — connect to a network and check that"
+  log "your ident shows up verified (no leading ~) via /whois on yourself."
+fi

--- a/server/server.ts
+++ b/server/server.ts
@@ -15,6 +15,7 @@ import { purgeExpiredSessions } from './db/sessions.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
+import { startIdentd, stopIdentd, isIdentdEnabled, identdPort } from './services/identd.js';
 
 const PORT = Number(process.env.PORT || 8010);
 const EDITION = getEdition();
@@ -33,6 +34,11 @@ if (isNodeMode() && !nodeUploadConfigured()) {
     '[lurker] node edition is active but LURKER_NODE_UPLOAD_URL / LURKER_NODE_UPLOAD_API_KEY are unset — image and text uploads will fail (400) until they are configured',
   );
 }
+if (isNodeMode() && !isIdentdEnabled()) {
+  console.warn(
+    '[lurker] node edition is active but LURKER_IDENTD_ENABLED is unset — IRC networks cannot attribute individual users; they will appear with an unverified ~ident behind the cell IP',
+  );
+}
 
 const app = buildApp(SESSION_SECRET);
 const server = http.createServer(app);
@@ -42,6 +48,13 @@ purgeExpiredSessions();
 setInterval(purgeExpiredSessions, 60 * 60 * 1000).unref();
 
 systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${EDITION})` });
+
+// Built-in identd (opt-in via LURKER_IDENTD_ENABLED). A multi-user gateway
+// needs it so IRC networks can attribute each user behind the shared IP; bind
+// it before connections register their idents.
+if (isIdentdEnabled()) {
+  startIdentd(identdPort());
+}
 
 ircManager.initAll();
 
@@ -58,6 +71,7 @@ function shutdown(signal: string): void {
   console.log(`[lurker] received ${signal}, shutting down`);
   systemLog.log({ scope: 'server', level: 'warn', text: `Received ${signal}, shutting down` });
   stopOrchestratorClient();
+  stopIdentd();
   ircManager.shutdown();
   server.close(() => process.exit(0));
   setTimeout(() => process.exit(1), 5000).unref();

--- a/server/services/identd.test.ts
+++ b/server/services/identd.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import net from 'net';
+import { createIdentdServer, registerIdent, unregisterIdent } from './identd.js';
+
+let server: net.Server;
+let port: number;
+
+beforeAll(async () => {
+  server = createIdentdServer();
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  port = (server.address() as net.AddressInfo).port;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+// Send one ident query line and collect the reply.
+function query(line: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const c = net.connect(port, '127.0.0.1', () => c.write(line));
+    let out = '';
+    c.on('data', (d) => (out += d.toString()));
+    c.on('end', () => resolve(out));
+    c.on('error', reject);
+  });
+}
+
+describe('built-in identd', () => {
+  it('returns USERID for a registered local port', async () => {
+    registerIdent(40001, 'u42');
+    const res = await query('40001, 6667\r\n');
+    expect(res.trim()).toBe('40001, 6667 : USERID : UNIX : u42');
+  });
+
+  it('returns NO-USER for an unregistered port', async () => {
+    const res = await query('40002, 6667\r\n');
+    expect(res.trim()).toBe('40002, 6667 : ERROR : NO-USER');
+  });
+
+  it('returns NO-USER after the port is unregistered', async () => {
+    registerIdent(40003, 'u9');
+    unregisterIdent(40003);
+    const res = await query('40003, 6667\r\n');
+    expect(res).toContain('ERROR : NO-USER');
+  });
+
+  it('rejects a malformed query', async () => {
+    const res = await query('not a query\r\n');
+    expect(res).toContain('ERROR : INVALID-PORT');
+  });
+
+  it('tolerates loose whitespace in the query', async () => {
+    registerIdent(40004, 'u1');
+    const res = await query('  40004 , 6667 \r\n');
+    expect(res).toContain('USERID : UNIX : u1');
+  });
+});

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -69,9 +69,12 @@ export function startIdentd(port: number): void {
   const srv = createIdentdServer();
   srv.on('error', (err: Error) => {
     // A failed bind (EACCES without the privilege to bind :113, or EADDRINUSE)
-    // must not take down the whole server — log and carry on without identd.
+    // must not take down the whole server — log and carry on without identd. If
+    // the error arrives after we were already listening, close the listener so
+    // it can't keep accepting connections once we drop our reference to it.
     console.error(`[identd] failed to listen on :${port}: ${err.message}`);
-    server = null;
+    if (srv.listening) srv.close();
+    if (server === srv) server = null;
   });
   srv.listen(port, () => console.log(`[identd] listening on :${port}`));
   server = srv;

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// A minimal built-in identd (RFC 1413). When a multi-user Lurker connects many
+// users to a network from one IP, the network can't tell them apart unless an
+// identd vouches for each connection's ident. This server answers the IRC
+// server's port-113 callback by mapping the connection's *local source port* to
+// the ident Lurker registered for it (see ircConnection.ts).
+//
+// Opt-in via LURKER_IDENTD_ENABLED — binding :113 is privileged and most
+// single-user self-hosts don't need it; the hosted (node) edition turns it on
+// per cell. Mirrors The Lounge's built-in identd: to avoid running as root you
+// can set LURKER_IDENTD_PORT to a high port and have the host's oidentd forward
+// to it (:113 must be reachable by the IRC server either way).
+
+import net from 'net';
+
+// local source port -> ident. Populated as IRC sockets connect, cleared as they
+// close. Module-scoped so the connection layer and the server share one map.
+const idents = new Map<number, string>();
+
+export function registerIdent(localPort: number, ident: string): void {
+  if (localPort > 0 && ident) idents.set(localPort, ident);
+}
+
+export function unregisterIdent(localPort: number | null): void {
+  if (localPort && localPort > 0) idents.delete(localPort);
+}
+
+// RFC 1413: the querying server sends "<our-port> , <their-port>"; we reply
+// "<our-port>, <their-port> : USERID : UNIX : <ident>" or ERROR : NO-USER.
+function handleConnection(socket: net.Socket): void {
+  socket.setTimeout(10_000);
+  let buf = '';
+  socket.on('data', (chunk: Buffer) => {
+    buf += chunk.toString('latin1');
+    const nl = buf.indexOf('\n');
+    if (nl === -1) {
+      if (buf.length > 100) socket.destroy(); // junk, no newline — bail
+      return;
+    }
+    const m = /^\s*(\d{1,5})\s*,\s*(\d{1,5})/.exec(buf.slice(0, nl));
+    if (!m) {
+      socket.end('0, 0 : ERROR : INVALID-PORT\r\n');
+      return;
+    }
+    const lport = Number(m[1]);
+    const rport = Number(m[2]);
+    const ident = idents.get(lport);
+    socket.end(
+      ident
+        ? `${lport}, ${rport} : USERID : UNIX : ${ident}\r\n`
+        : `${lport}, ${rport} : ERROR : NO-USER\r\n`,
+    );
+  });
+  socket.on('timeout', () => socket.destroy());
+  socket.on('error', () => {});
+}
+
+/** Build (but don't listen on) an identd server. Exposed for tests. */
+export function createIdentdServer(): net.Server {
+  return net.createServer(handleConnection);
+}
+
+let server: net.Server | null = null;
+
+export function startIdentd(port: number): void {
+  if (server) return;
+  const srv = createIdentdServer();
+  srv.on('error', (err: Error) => {
+    // A failed bind (EACCES without the privilege to bind :113, or EADDRINUSE)
+    // must not take down the whole server — log and carry on without identd.
+    console.error(`[identd] failed to listen on :${port}: ${err.message}`);
+    server = null;
+  });
+  srv.listen(port, () => console.log(`[identd] listening on :${port}`));
+  server = srv;
+}
+
+export function stopIdentd(): void {
+  if (server) {
+    server.close();
+    server = null;
+  }
+}
+
+export function isIdentdEnabled(): boolean {
+  return /^(1|true|yes|on)$/i.test((process.env.LURKER_IDENTD_ENABLED || '').trim());
+}
+
+export function identdPort(): number {
+  const p = Number(process.env.LURKER_IDENTD_PORT);
+  return Number.isInteger(p) && p > 0 ? p : 113;
+}

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -26,6 +26,10 @@ import { matchesAny as matchesIgnoreMask } from './maskMatch.js';
 import { listMasks as listIgnoredMasks } from '../db/ignoredMasks.js';
 import * as systemLog from './systemLog.js';
 import { IRC_VERSION, APP_VERSION } from '../utils/userAgent.js';
+import { findUserById } from '../db/users.js';
+import { isNodeMode } from '../utils/edition.js';
+import { deriveIdent } from '../utils/ident.js';
+import { registerIdent, unregisterIdent, isIdentdEnabled } from './identd.js';
 
 // Shown to peers as the QUIT reason on a clean disconnect. Most IRC clients
 // surface this in JOIN/PART messages, so it doubles as a Lurker
@@ -164,6 +168,9 @@ export class IrcConnection {
   nickAttempt: number;
   regainNick: string | null;
   pendingRegainSetup: boolean;
+  // Local source port of the live socket, while identd is enabled — so we can
+  // unregister this connection's ident from the identd map when it closes.
+  identdLocalPort: number | null;
 
   constructor({ network, onEvent }: { network: Network; onEvent: (event: EnrichedEvent) => void }) {
     this.network = network;
@@ -214,6 +221,7 @@ export class IrcConnection {
     // tells us the server supports it (005 arrives after 001/'registered').
     this.regainNick = null;
     this.pendingRegainSetup = false;
+    this.identdLocalPort = null;
     this.bind();
   }
 
@@ -479,6 +487,10 @@ export class IrcConnection {
       this.runConnectCommands();
     });
     c.on('close', () => {
+      // Final safety net (clean disconnect/dispose may not always emit
+      // 'socket close'); unregisterIdent is idempotent.
+      unregisterIdent(this.identdLocalPort);
+      this.identdLocalPort = null;
       this.userModes.clear();
       this.stopLagPinger();
       this.cancelPendingConnectCommands();
@@ -651,6 +663,10 @@ export class IrcConnection {
     // log line.
     c.on('socket close', (err: Record<string, unknown>) => {
       this.setState('disconnected');
+      // Release this socket's identd mapping (a reconnect gets a new local port
+      // via the 'socket connected' handler above).
+      unregisterIdent(this.identdLocalPort);
+      this.identdLocalPort = null;
       if (err && (err.message || err.code)) {
         const code = err.code ? `${err.code}: ` : '';
         const where = `${this.network.host}:${this.network.port}`;
@@ -685,6 +701,31 @@ export class IrcConnection {
       });
     });
     c.on('connecting', () => this.setState('connecting'));
+
+    // Built-in identd: the moment the raw socket connects, map its local source
+    // port → this user's ident so the identd server (services/identd.ts) can
+    // answer the IRC server's :113 callback. Without it a multi-user gateway's
+    // users are indistinguishable (and unverified) behind one shared IP.
+    c.on('socket connected', () => {
+      if (!isIdentdEnabled()) return;
+      const socket = (
+        this.client as unknown as {
+          connection?: { transport?: { socket?: { localPort?: number } } };
+        }
+      ).connection?.transport?.socket;
+      const localPort = socket?.localPort;
+      if (!localPort) return;
+      this.identdLocalPort = localPort;
+      registerIdent(
+        localPort,
+        deriveIdent({
+          nodeMode: isNodeMode(),
+          accountUsername: findUserById(this.network.user_id)?.username || '',
+          networkUsername: this.network.username,
+          nick: this.network.nick,
+        }),
+      );
+    });
 
     // RPL_UMODEIS arrives when the server sends our current umode (e.g. on
     // login or in response to /MODE <self>). irc-framework normalises it to

--- a/server/utils/ident.test.ts
+++ b/server/utils/ident.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { deriveIdent } from './ident.js';
+
+describe('deriveIdent', () => {
+  it('node edition surfaces the global account id from the acct-<id> username', () => {
+    expect(
+      deriveIdent({
+        nodeMode: true,
+        accountUsername: 'acct-42',
+        networkUsername: 'whatever',
+        nick: 'alice',
+      }),
+    ).toBe('u42');
+  });
+
+  it('node edition ignores the per-network username (uniqueness is forced)', () => {
+    // Two users who both picked the network username "bob" still get distinct
+    // idents, because node edition keys off the account, not their choice.
+    expect(
+      deriveIdent({
+        nodeMode: true,
+        accountUsername: 'acct-7',
+        networkUsername: 'bob',
+        nick: 'bob',
+      }),
+    ).toBe('u7');
+    expect(
+      deriveIdent({
+        nodeMode: true,
+        accountUsername: 'acct-8',
+        networkUsername: 'bob',
+        nick: 'bob',
+      }),
+    ).toBe('u8');
+  });
+
+  it('node edition falls back safely for a non-acct username (e.g. the operator)', () => {
+    expect(
+      deriveIdent({ nodeMode: true, accountUsername: 'brad', networkUsername: null, nick: 'brad' }),
+    ).toBe('brad');
+  });
+
+  it('standalone uses the configured network username', () => {
+    expect(
+      deriveIdent({
+        nodeMode: false,
+        accountUsername: 'acct-42',
+        networkUsername: 'alice',
+        nick: 'al',
+      }),
+    ).toBe('alice');
+  });
+
+  it('standalone falls back to the nick when no username is set', () => {
+    expect(
+      deriveIdent({
+        nodeMode: false,
+        accountUsername: 'acct-42',
+        networkUsername: null,
+        nick: 'al',
+      }),
+    ).toBe('al');
+  });
+
+  it('strips ident-invalid characters', () => {
+    expect(
+      deriveIdent({ nodeMode: false, accountUsername: '', networkUsername: 'a b@c!', nick: 'x' }),
+    ).toBe('abc');
+  });
+});

--- a/server/utils/ident.ts
+++ b/server/utils/ident.ts
@@ -26,7 +26,7 @@ export function deriveIdent(opts: {
 }): string {
   if (opts.nodeMode) {
     const m = /^acct-(\d+)$/.exec(opts.accountUsername.trim());
-    if (m) return `u${m[1]}`;
+    if (m) return sanitizeIdent(`u${m[1]}`);
     // Fallback (e.g. the operator's own admin account on a cell): stay stable +
     // ident-safe rather than inventing an id.
     return sanitizeIdent(opts.accountUsername) || 'user';

--- a/server/utils/ident.ts
+++ b/server/utils/ident.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Derives the IRC ident (the user part of nick!ident@host) that the built-in
+// identd reports for a connection.
+//
+//   node edition — the ident must identify the GLOBAL account, so it's stable
+//     across cell moves and unique fleet-wide. Cells are provisioned with the
+//     account username `acct-<controlPlaneAccountId>`, so we surface
+//     `u<controlPlaneAccountId>` (IRCCloud-style). Using the cell-local user id
+//     would change if an account were ever migrated to another cell.
+//   standalone — the operator's per-network choice wins (the configured
+//     username, else the nick), matching how a single-user bouncer behaves.
+
+const NON_IDENT_CHARS = /[^A-Za-z0-9._-]/g;
+
+function sanitizeIdent(value: string): string {
+  return value.replace(NON_IDENT_CHARS, '').slice(0, 16);
+}
+
+export function deriveIdent(opts: {
+  nodeMode: boolean;
+  accountUsername: string;
+  networkUsername: string | null;
+  nick: string;
+}): string {
+  if (opts.nodeMode) {
+    const m = /^acct-(\d+)$/.exec(opts.accountUsername.trim());
+    if (m) return `u${m[1]}`;
+    // Fallback (e.g. the operator's own admin account on a cell): stay stable +
+    // ident-safe rather than inventing an id.
+    return sanitizeIdent(opts.accountUsername) || 'user';
+  }
+  return sanitizeIdent(opts.networkUsername || opts.nick) || 'user';
+}


### PR DESCRIPTION
A multi-user Lurker that connects many users to a network from one IP can't be told apart by that network unless an identd vouches for each connection — Libera requires a working identd for a hosted service, and it's useful for any multi-user self-host too. This adds a built-in one (RFC 1413), mirroring The Lounge's approach.

## How it works
- **`services/identd.ts`** — a `:113` server that, on the IRC server's callback (`<our-port> , <their-port>`), maps the connection's **local source port → the registered ident** and replies `USERID : UNIX : <ident>` (or `ERROR : NO-USER`). Register/unregister + start/stop + env helpers. Mirrors The Lounge (can also run on a high port behind the host's oidentd to avoid root).
- **`utils/ident.ts` — `deriveIdent()`**: the ident each connection reports.
  - **node edition** → `u<controlPlaneAccountId>`, parsed from the cell's `acct-<id>` account username. This is the **globally-unique, migration-stable** id — if an account ever moves to another cell it keeps the same ident (cell-local `users.id` would change/collide), so Libera bans/attribution stay continuous.
  - **standalone** → the network's configured username, else the nick (matches a single-user bouncer).
- **`ircConnection.ts`** — registers on irc-framework's `'socket connected'` (reads `socket.localPort`), unregisters on `'socket close'` / `'close'`.
- **`server.ts`** — starts/stops with the lifecycle; warns in node edition if it's left disabled.

## Opt-in
`LURKER_IDENTD_ENABLED` (port via `LURKER_IDENTD_PORT`, default 113). Off by default — binding :113 is privileged and single-user self-hosts don't need it, so **CI/dev/standalone are unaffected**. Node-edition cells enable it; the prod cell droplet opens :113 + grants `NET_BIND_SERVICE` (B8).

## Tests / verification
`server/services/identd.test.ts` drives the server directly (USERID / NO-USER / unregister / malformed / loose whitespace); `server/utils/ident.test.ts` covers `deriveIdent` (node `u<id>`, forced uniqueness, standalone username/nick, sanitization). `npm run check` clean; **714 tests pass**.

> identd can't be exercised through the local QA stack (the cell's IRC egress is your home NAT IP, unreachable on :113); validate it on a throwaway cell droplet with a public IP — snippet to follow in the deploy docs. (B11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)