### PR TITLE
Add #channel autocomplete menu (closes #154)

### DIFF
--- a/vue_client/src/components/ChannelPicker.vue
+++ b/vue_client/src/components/ChannelPicker.vue
@@ -1,0 +1,229 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<template>
+  <div
+    v-if="open && rows.length"
+    ref="panelEl"
+    class="channel-picker"
+    :style="panelStyle"
+    @pointerdown.stop
+    @mousedown.prevent.stop
+  >
+    <!-- Same iOS focus-preservation contract as NickPicker: act on `click`
+         (end of touch), keep `@mousedown.prevent` so focus never leaves the
+         textarea, and use a plain <div role=button> rather than a focusable
+         <button>. Emitting on pointerdown would close the picker (v-if)
+         mid-touch and defeat the focus guard. -->
+    <div
+      v-for="row in renderedRows"
+      :key="row.name + ':' + row.index"
+      role="button"
+      class="row"
+      :class="{ active: row.index === activeIndex }"
+      @mousedown.prevent
+      @click="pick(row.name)"
+      @mouseenter="activeIndex = row.index"
+    >
+      <span class="channel">{{ row.name }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
+import { useBuffersStore } from '../stores/buffers.js';
+import { buildChannelCandidates } from '../utils/channelCompletion.js';
+
+const props = withDefaults(
+  defineProps<{
+    open?: boolean;
+    // The raw `#`-prefixed token under the cursor; the leading '#' stays in
+    // both the match filter and the inserted result.
+    query?: string;
+    networkId?: number | null;
+    anchor?: HTMLElement | null;
+  }>(),
+  {
+    open: false,
+    query: '',
+    networkId: null,
+    anchor: null,
+  },
+);
+
+const emit = defineEmits<{
+  select: [channel: string];
+  close: [];
+}>();
+
+const buffers = useBuffersStore();
+const panelEl = ref<HTMLElement | null>(null);
+const panelBottom = ref(8);
+
+// Index into `rows` (candidate order, 0 = best match) of the keyboard-
+// highlighted entry. Rows render bottom-up — see `renderedRows` — so index 0
+// sits visually at the bottom, nearest the input bar.
+const activeIndex = ref(0);
+
+const rows = computed(() => {
+  // Bail before touching the buffers store while closed: a computed only
+  // tracks the deps it reads, so this early return keeps `rows` (and the watch
+  // that subscribes to it) from rebuilding the candidate list on every buffer
+  // mutation behind a closed picker. The panel's v-if gates on `open` anyway,
+  // so returning [] here is behavior-neutral.
+  if (!props.open || props.networkId == null) return [];
+  return buildChannelCandidates(buffers.forNetwork(props.networkId), props.query)
+    .slice(0, 50)
+    .map((name, index) => ({ name, index }));
+});
+
+// The panel opens upward, so render candidates worst-to-best top-to-bottom —
+// the most likely pick lands at the bottom, right under the user's eye and
+// closest to the input bar.
+const renderedRows = computed(() => rows.value.slice().reverse());
+
+function pick(channel: string) {
+  emit('select', channel);
+}
+
+// Keyboard navigation, driven from MessageInput's textarea keydown handler:
+// the textarea keeps focus while the picker is open, so the picker never
+// receives key events itself. `delta` is in candidate-index space — +1 steps
+// toward worse matches (visually up), -1 toward the best match (visually
+// down) — and clamps at both ends rather than wrapping.
+function moveActive(delta: number) {
+  const n = rows.value.length;
+  if (n === 0) return;
+  activeIndex.value = Math.min(Math.max(activeIndex.value + delta, 0), n - 1);
+  // Keyboard moves can land on a row scrolled out of the panel — pull it back
+  // in. Mouse hover also sets activeIndex (see @mouseenter) but a hovered row
+  // is necessarily already visible, so the scroll lives here rather than in a
+  // blanket watch(activeIndex).
+  nextTick(scrollActiveIntoView);
+}
+
+function confirmActive() {
+  const row = rows.value[activeIndex.value];
+  if (row) pick(row.name);
+}
+
+function hasCandidates() {
+  return rows.value.length > 0;
+}
+
+defineExpose({ moveActive, confirmActive, hasCandidates });
+
+function scrollActiveIntoView() {
+  const el = panelEl.value?.querySelector('.row.active');
+  if (el) (el as HTMLElement).scrollIntoView({ block: 'nearest' });
+}
+
+function recomputePosition() {
+  // Anchor the picker just above the input bar, riding above the iOS soft
+  // keyboard via visualViewport.height. Without this, the picker gets occluded
+  // as soon as the keyboard slides up.
+  const anchor = props.anchor;
+  if (!anchor) {
+    panelBottom.value = 8;
+    return;
+  }
+  const rect = anchor.getBoundingClientRect();
+  const vv = window.visualViewport;
+  const viewportHeight = vv ? vv.height : window.innerHeight;
+  // Distance from bottom of viewport to top of anchor.
+  const distance = viewportHeight - rect.top;
+  panelBottom.value = Math.max(distance + 4, 8);
+}
+
+const panelStyle = computed(() => ({ bottom: `${panelBottom.value}px` }));
+
+function onDocPointerDown(e: PointerEvent) {
+  if (!props.open) return;
+  const panel = panelEl.value;
+  const anchor = props.anchor;
+  if (panel && panel.contains(e.target as Node)) return;
+  if (anchor && anchor.contains(e.target as Node)) return;
+  emit('close');
+}
+
+function onKey(e: KeyboardEvent) {
+  if (!props.open) return;
+  if (e.key === 'Escape') emit('close');
+}
+
+onMounted(() => {
+  recomputePosition();
+  window.addEventListener('resize', recomputePosition);
+  window.visualViewport?.addEventListener('resize', recomputePosition);
+  window.visualViewport?.addEventListener('scroll', recomputePosition);
+  document.addEventListener('pointerdown', onDocPointerDown);
+  document.addEventListener('keydown', onKey);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', recomputePosition);
+  window.visualViewport?.removeEventListener('resize', recomputePosition);
+  window.visualViewport?.removeEventListener('scroll', recomputePosition);
+  document.removeEventListener('pointerdown', onDocPointerDown);
+  document.removeEventListener('keydown', onKey);
+});
+
+// A new candidate set (the query changed, or buffers were re-filtered)
+// re-anchors the highlight on the best match and pulls it back into view.
+watch(rows, () => {
+  activeIndex.value = 0;
+  nextTick(scrollActiveIntoView);
+});
+
+watch(
+  () => props.open,
+  (v) => {
+    if (v) {
+      activeIndex.value = 0;
+      recomputePosition();
+      nextTick(scrollActiveIntoView);
+    }
+  },
+);
+</script>
+
+<style scoped>
+.channel-picker {
+  position: fixed;
+  left: var(--space-4);
+  right: var(--space-4);
+  max-width: 480px;
+  margin: 0 auto;
+  max-height: 50vh;
+  overflow-y: auto;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
+  z-index: var(--z-popover);
+}
+.row {
+  display: flex;
+  align-items: center;
+  padding: var(--space-6);
+  min-height: 44px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  user-select: none;
+}
+.row:last-child {
+  border-bottom: none;
+}
+/* Single highlight, shared by mouse and keyboard: hovering a row sets
+   activeIndex (see @mouseenter), so .active alone covers both — no separate
+   :hover rule that could double-highlight during keyboard nav. */
+.row.active {
+  background: var(--bg);
+}
+.channel {
+  font-weight: 500;
+}
+</style>

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -79,6 +79,18 @@
       @select="onPickerSelect"
       @close="closePicker"
     />
+    <!-- `#channel` completion. Identical popover on desktop and mobile — there
+         is no compact-strip variant for channels (issue #154). Independent of
+         the nick picker; refreshPicker keeps the two from being open at once. -->
+    <ChannelPicker
+      ref="channelPickerEl"
+      :open="channelPickerOpen"
+      :query="channelPickerQuery"
+      :network-id="active?.networkId ?? null"
+      :anchor="formEl"
+      @select="onChannelPickerSelect"
+      @close="closeChannelPicker"
+    />
     <Teleport to="body">
       <LongMessageUploadModal
         v-if="longMessageModalOpen"
@@ -109,6 +121,7 @@ import { setComposingState } from '../composables/useComposing.js';
 import { chunkCountForSay, chunkCountForAction } from '../utils/messageSplit.js';
 import { applySpoilerMarkup } from '../utils/spoilerMarkup.js';
 import { buildNickCandidates } from '../utils/nickCompletion.js';
+import { buildChannelCandidates } from '../utils/channelCompletion.js';
 import {
   findActiveShortcode,
   findCompletedShortcode,
@@ -116,6 +129,7 @@ import {
 } from '../utils/emojiShortcodes.js';
 import type { EmojiMatch } from '../utils/emojiData.js';
 import NickPicker from './NickPicker.vue';
+import ChannelPicker from './ChannelPicker.vue';
 import LongMessageUploadModal from './LongMessageUploadModal.vue';
 import { useSelfLabel } from '../composables/useSelfLabel.js';
 import { useViewport } from '../composables/useViewport.js';
@@ -154,6 +168,15 @@ const pickerQuery = ref('');
 const nickPickerEl = ref<InstanceType<typeof NickPicker> | null>(null);
 let pickerTokenStart = -1;
 let pickerTokenEnd = -1;
+// `#channel` picker — a sibling of the nick picker with the same local-state
+// shape (open flag, query, replaced-token span). Like the nick picker it's a
+// position:fixed popover anchored to the form, not a StatusBar overlay, so its
+// state lives here rather than in useComposerOverlay.
+const channelPickerOpen = ref(false);
+const channelPickerQuery = ref('');
+const channelPickerEl = ref<InstanceType<typeof ChannelPicker> | null>(null);
+let channelPickerTokenStart = -1;
+let channelPickerTokenEnd = -1;
 // Suggestion-strip and colour-picker visibility / contents live in
 // useComposerOverlay so StatusBar can render them as overlays without prop
 // drilling. Token-span book-keeping (which slice of the draft a pick
@@ -383,6 +406,7 @@ function handleHistoryNav(e: KeyboardEvent): void {
   resetCompletion();
   closePicker();
   closeStrip();
+  closeChannelPicker();
 
   if (e.key === 'ArrowUp') {
     if (historyIndex === null) {
@@ -450,12 +474,7 @@ function buildNickStripItems(buf: Buffer, networkId: number, prefix: string): Ni
 }
 
 function buildChannelMatches(networkId: number, prefix: string): string[] {
-  const lower = prefix.toLowerCase();
-  return buffers
-    .forNetwork(networkId)
-    .map((b) => b.target)
-    .filter((t) => t.startsWith('#') && t.toLowerCase().startsWith(lower))
-    .toSorted((a, b) => a.localeCompare(b));
+  return buildChannelCandidates(buffers.forNetwork(networkId), prefix);
 }
 
 function applyCompletion() {
@@ -467,6 +486,7 @@ function applyCompletion() {
   // fire, so they wouldn't close on their own).
   closePicker();
   closeStrip();
+  closeChannelPicker();
   cycling = true;
   text.value = completion.prefix + pick + suffix + completion.tail;
   cycling = false;
@@ -619,6 +639,25 @@ function onKeydown(e: KeyboardEvent): void {
       return;
     }
   }
+  // The `#`-channel picker mirrors the nick picker above: while open with
+  // candidates it owns arrows (move highlight) and Tab (confirm), Enter still
+  // sends, and Escape is left to ChannelPicker's own document listener. Gated
+  // on hasCandidates() so a no-match `#zzz` lets Tab fall through to in-place
+  // completion below. refreshPicker keeps this and the nick picker from being
+  // open at once, so the two blocks can't both fire.
+  if (channelPickerOpen.value && !e.isComposing && channelPickerEl.value?.hasCandidates()) {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      if (!e.altKey && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        channelPickerEl.value.moveActive(e.key === 'ArrowUp' ? 1 : -1);
+        return;
+      }
+    } else if (e.key === 'Tab') {
+      e.preventDefault();
+      channelPickerEl.value.confirmActive();
+      return;
+    }
+  }
   // The mobile/compact nick strip owns navigation keys while open with
   // candidates — same shape as the emoji block below, and as the desktop
   // @-picker above. All four arrows cycle the highlight (Down/Right next,
@@ -764,6 +803,13 @@ function closePicker() {
   pickerTokenEnd = -1;
 }
 
+function closeChannelPicker() {
+  channelPickerOpen.value = false;
+  channelPickerQuery.value = '';
+  channelPickerTokenStart = -1;
+  channelPickerTokenEnd = -1;
+}
+
 function closeStrip() {
   setNickStrip(false);
   stripTokenStart = -1;
@@ -876,6 +922,7 @@ function refreshPicker() {
     closePicker();
     closeStrip();
     closeEmojiStrip();
+    closeChannelPicker();
     return;
   }
   const value = text.value;
@@ -888,12 +935,32 @@ function refreshPicker() {
   if (shortcode && shortcode.name.length >= 2) {
     closePicker();
     closeStrip();
+    closeChannelPicker();
     void showEmojiStrip();
     return;
   }
   closeEmojiStrip();
 
   const { token, start, end } = tokenAtCursor(value, cursor);
+
+  // `#channel` token → the channel picker, on every platform (no compact-strip
+  // variant; see issue #154). It's a standalone popover, so the nick picker
+  // and both StatusBar strips close while it's up. Opens as soon as `#` is
+  // typed so you get the full joined-channel list; the picker self-hides when
+  // nothing matches (its v-if gates on candidate count), so a stray `#5` or a
+  // channel you're not in just shows no popover.
+  if (token.startsWith('#')) {
+    closePicker();
+    closeStrip();
+    channelPickerOpen.value = true;
+    channelPickerQuery.value = token;
+    channelPickerTokenStart = start;
+    channelPickerTokenEnd = end;
+    return;
+  }
+  // Any other token means a channel isn't being edited — tear down a picker the
+  // previous keystroke may have opened before routing to the nick UIs below.
+  closeChannelPicker();
 
   // Slash commands never trigger nick completion in either UI.
   if (token.startsWith('/')) {
@@ -971,6 +1038,31 @@ function onPickerSelect(nick: string): void {
     const el = inputEl.value;
     if (!el) return;
     const caret = before.length + nick.length + suffix.length;
+    el.focus();
+    el.setSelectionRange(caret, caret);
+  });
+}
+
+function onChannelPickerSelect(channel: string): void {
+  const value = text.value;
+  if (channelPickerTokenStart < 0) {
+    closeChannelPicker();
+    return;
+  }
+  const before = value.slice(0, channelPickerTokenStart);
+  const after = value.slice(channelPickerTokenEnd);
+  // Channels just get a trailing space — there's no "addressing" form like
+  // nicks' ': ', and the '#' is already part of the inserted name. The sent
+  // `#channel` renders as a clickable join link for the recipient
+  // (RenderSegments → openChannel), which is the whole point (issue #154).
+  cycling = true;
+  text.value = before + channel + ' ' + after;
+  cycling = false;
+  closeChannelPicker();
+  queueMicrotask(() => {
+    const el = inputEl.value;
+    if (!el) return;
+    const caret = before.length + channel.length + 1;
     el.focus();
     el.setSelectionRange(caret, caret);
   });
@@ -1059,6 +1151,7 @@ watch(active, (newActive, oldActive) => {
   resetCompletion();
   closePicker();
   closeStrip();
+  closeChannelPicker();
   closeEmojiStrip();
   closeColorPicker();
   resetHistoryNav();
@@ -1255,6 +1348,7 @@ async function submit() {
   resetCompletion();
   closePicker();
   closeStrip();
+  closeChannelPicker();
   closeEmojiStrip();
   closeColorPicker();
   const raw = text.value;

--- a/vue_client/src/utils/channelCompletion.ts
+++ b/vue_client/src/utils/channelCompletion.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared candidate builder for channel completion — used by both Tab-completion
+// in MessageInput and the `#`-triggered ChannelPicker. Returns the targets of
+// joined channels matching `prefix` (case-insensitive), sorted alphabetically.
+//
+// `prefix` includes the leading '#' (it's the raw token under the cursor), and
+// the '#' stays in every result — unlike nicks' '@' sugar, '#' is part of the
+// channel name.
+//
+// Candidate source is deliberately just the buffers the user is already in:
+// the point of channel completion is to quickly reference a channel you can
+// tell someone else to join (the inserted `#channel` renders as a clickable
+// join link for the recipient — see issue #154), so "joined channels" is
+// exactly the right set. There is no /LIST-backed directory of channels you
+// haven't joined.
+
+interface ChannelBuffer {
+  target?: string;
+}
+
+export function buildChannelCandidates(buffers: ChannelBuffer[], prefix: string): string[] {
+  const lower = prefix.toLowerCase();
+  return buffers
+    .map((b) => b.target ?? '')
+    .filter((t) => t.startsWith('#') && t.toLowerCase().startsWith(lower))
+    .toSorted((a, b) => a.localeCompare(b));
+}


### PR DESCRIPTION
## What

Adds channel autocomplete, mirroring the existing `@`-nick picker. Typing `#` in the message input opens a popover of **joined channels** to pick from — on **both desktop and mobile** (no compact-strip variant). Selecting inserts the full `#channel` followed by a space.

Closes #154.

## Why this shape

The use case is "quickly tell another user to join a channel you're in," so the candidate source is deliberately just your joined channels — no `/LIST`-backed directory of channels you haven't joined. The inserted `#channel` already renders as a clickable join link for the recipient (`RenderSegments → openChannel`), which closes the loop.

## Changes

- **`ChannelPicker.vue`** — a near-exact mirror of `NickPicker.vue` (same upward popover, keyboard-driven highlight, iOS soft-keyboard anchoring, `@mousedown.prevent` focus preservation), minus the nick-only colors and "recent" badge.
- **`channelCompletion.ts`** — a shared `buildChannelCandidates()` matcher (joined channels, `#`-prefix, alpha-sorted). The existing Tab-completion path now uses it too, so Tab and the menu can't drift apart.
- **`MessageInput.vue`** — `refreshPicker()` routes `#` tokens to the new picker on every platform; keyboard nav (↑/↓ move, Tab confirms, Enter still sends, Esc closes); teardown at every reset point (buffer switch, submit, history nav, Tab-completion takeover).

## Behavior notes

- Opens as soon as `#` is typed, showing the full joined-channel list (same as `@` for nicks); keep typing to filter.
- Inserts `#channel ` — no `: ` addressing suffix (nick-specific), and the `#` stays since it's part of the name.
- Few false positives: the popover only renders when a joined channel actually matches, so `C#` (token doesn't start with `#`), `#5`, or a random hashtag show nothing unless you're in such a channel.
- Inline Tab completion for `#chan` still works regardless of the menu.

## Verification

`typecheck:client`, `lint`, `format:check`, `client:build`, and `npm test` (714 passing) all green. Confirmed working locally on desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)