### PR TITLE
Cell registers to /_cp/cells/register (#247 coordination)

### DIFF
--- a/server/services/orchestratorClient.test.ts
+++ b/server/services/orchestratorClient.test.ts
@@ -70,14 +70,14 @@ describe('buildRegistration', () => {
 });
 
 describe('reportToOrchestrator', () => {
-  it('posts to /api/cells/register with the bearer and returns true on 2xx', async () => {
+  it('posts to /_cp/cells/register with the bearer and returns true on 2xx', async () => {
     const fetchMock = vi.fn<FetchMock>().mockResolvedValue({ ok: true });
     vi.stubGlobal('fetch', fetchMock);
     const cfg = mod.readOrchestratorConfig()!;
     expect(await mod.reportToOrchestrator(cfg)).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, opts] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string> }];
-    expect(url).toBe('http://orchestrator:8020/api/cells/register');
+    expect(url).toBe('http://orchestrator:8020/_cp/cells/register');
     expect(opts.headers.Authorization).toBe('Bearer fleet-secret');
     expect(opts.headers['User-Agent']).toMatch(/^Lurker\//);
   });

--- a/server/services/orchestratorClient.ts
+++ b/server/services/orchestratorClient.ts
@@ -69,7 +69,7 @@ export function buildRegistration(cfg: OrchestratorConfig): {
 // false on any non-2xx or network error — never throws.
 export async function reportToOrchestrator(cfg: OrchestratorConfig): Promise<boolean> {
   try {
-    const res = await fetch(`${cfg.url.replace(/\/+$/, '')}/api/cells/register`, {
+    const res = await fetch(`${cfg.url.replace(/\/+$/, '')}/_cp/cells/register`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Coupled OSS half of **lurker-control-plane #247** (Reserve `/_cp/*` for the control plane).

The control plane has vacated `/api/*` — which the cell owns end-to-end (its Vue app calls `/api/auth/me`, `/ws`, etc.) — and moved its own endpoints under the reserved `/_cp` prefix. This points the **node-edition** cell's `orchestratorClient` at `POST /_cp/cells/register` to match (was `/api/cells/register`).

- **node-edition only** — standalone self-host never registers with an orchestrator, so zero self-host impact.
- Coordinated with control-plane #247 (already on its `main`); the two deploy together. Clean flag day — no live cells.
- `orchestratorClient.test.ts` updated; `vitest run` green (6/6), `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)