### PR TITLE
Paused accounts: read-only mode

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -33,6 +33,7 @@ const USERS_SKIPPED_COLUMNS: Record<string, string> = Object.freeze({
   role: 'first-user-becomes-admin rule on the target side reassigns roles',
   last_seen_at: 'tracked locally by each instance',
   created_at: 'tracked locally by each instance',
+  is_paused: 'account access state, owned by the local instance / control plane',
 });
 
 // scope values control how the exporter filters rows for a given userId.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -493,6 +493,12 @@ ensureColumn('networks', 'connect_commands', 'TEXT');
 ensureColumn('networks', 'position', 'INTEGER NOT NULL DEFAULT 0');
 ensureColumn('users', 'password_hash', 'TEXT');
 ensureColumn('users', 'last_seen_at', 'TEXT');
+// Account access state, orthogonal to role. A paused account keeps all its data
+// but is disconnected from IRC and barred from reconnecting or sending — it can
+// still browse history read-only. Set by the operator (standalone) or by the
+// control plane (node edition) when a hosted account is suspended / past-due /
+// canceled; the cell stays billing-blind and only mirrors this one verdict.
+ensureColumn('users', 'is_paused', 'INTEGER NOT NULL DEFAULT 0');
 
 // Roles: 'admin' can manage invites and other users; 'user' is everyone else.
 // On a fresh install the first user (created via /api/auth/setup) is promoted

--- a/server/db/users.ts
+++ b/server/db/users.ts
@@ -13,23 +13,32 @@ export interface User {
   role: UserRole;
   created_at: string;
   last_seen_at: string | null;
+  // 0 | 1. Paused accounts are disconnected from IRC and barred from
+  // reconnecting/sending, but retain read-only access to their history.
+  is_paused: number;
 }
 
 export function findUserByUsername(username: string): User | undefined {
   return db
-    .prepare('SELECT id, username, role, created_at, last_seen_at FROM users WHERE username = ?')
+    .prepare(
+      'SELECT id, username, role, created_at, last_seen_at, is_paused FROM users WHERE username = ?',
+    )
     .get(username) as User | undefined;
 }
 
 export function findUserById(id: number | bigint): User | undefined {
   return db
-    .prepare('SELECT id, username, role, created_at, last_seen_at FROM users WHERE id = ?')
+    .prepare(
+      'SELECT id, username, role, created_at, last_seen_at, is_paused FROM users WHERE id = ?',
+    )
     .get(id) as User | undefined;
 }
 
 export function listUsers(): User[] {
   return db
-    .prepare('SELECT id, username, role, created_at, last_seen_at FROM users ORDER BY id')
+    .prepare(
+      'SELECT id, username, role, created_at, last_seen_at, is_paused FROM users ORDER BY id',
+    )
     .all() as User[];
 }
 
@@ -76,6 +85,17 @@ export function userHasPassword(userId: number): boolean {
 
 export function setPasswordHash(userId: number, hash: string | null): boolean {
   const info = db.prepare('UPDATE users SET password_hash = ? WHERE id = ?').run(hash, userId);
+  return info.changes > 0;
+}
+
+// Flip account access state. Returns false only when no row matched (unknown
+// id); an idempotent set to the same value still returns true. The caller owns
+// the side effects of a transition — tearing down / re-establishing IRC — since
+// this only writes the row.
+export function setUserPaused(userId: number, paused: boolean): boolean {
+  const info = db
+    .prepare('UPDATE users SET is_paused = ? WHERE id = ?')
+    .run(paused ? 1 : 0, userId);
   return info.changes > 0;
 }
 

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -63,3 +63,16 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction): v
   }
   next();
 }
+
+// Read-only gate for paused accounts. Stack on top of requireAuth. GET/HEAD
+// reads fall through so a paused user can still browse their history; any
+// mutating method gets a clean 403. The authoritative block on IRC traffic is
+// the startNetwork gate in ircManager — this just turns what would be a silent
+// no-op into a clear error and stops a paused user from mutating network config.
+export function blockWritesWhenPaused(req: Request, res: Response, next: NextFunction): void {
+  if (req.user?.is_paused && req.method !== 'GET' && req.method !== 'HEAD') {
+    res.status(403).json({ error: 'account paused' });
+    return;
+  }
+  next();
+}

--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -16,7 +16,7 @@ const ctx = setupTestDb('routes-admin');
 
 const fakeManager = {
   disposed: [] as Array<[number, string]>,
-  suspended: [] as Array<[number, string]>,
+  suspended: [] as number[],
   resumed: [] as number[],
   reset() {
     this.disposed = [];
@@ -26,8 +26,10 @@ const fakeManager = {
   disposeUser(userId: number, reason: string) {
     this.disposed.push([userId, reason]);
   },
-  suspendUser(userId: number, reason: string) {
-    this.suspended.push([userId, reason]);
+  // Mirrors the real ircManager.suspendUser(userId) — one arg, no reason (the
+  // QUIT uses the default message).
+  suspendUser(userId: number) {
+    this.suspended.push(userId);
   },
   resumeUser(userId: number) {
     this.resumed.push(userId);
@@ -161,7 +163,7 @@ describe('POST /api/admin/users/:id/pause and /resume', () => {
     const res = await adminAgent.post(`/api/admin/users/${target.id}/pause`);
     expect(res.status).toBe(200);
     expect(findUserById(target.id)?.is_paused).toBe(1);
-    expect(fakeManager.suspended.find(([uid]) => uid === target.id)).toBeTruthy();
+    expect(fakeManager.suspended).toContain(target.id);
 
     const list = await adminAgent.get('/api/admin/users');
     const row = list.body.users.find((u: { id: number }) => u.id === target.id);

--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -16,11 +16,21 @@ const ctx = setupTestDb('routes-admin');
 
 const fakeManager = {
   disposed: [] as Array<[number, string]>,
+  suspended: [] as Array<[number, string]>,
+  resumed: [] as number[],
   reset() {
     this.disposed = [];
+    this.suspended = [];
+    this.resumed = [];
   },
   disposeUser(userId: number, reason: string) {
     this.disposed.push([userId, reason]);
+  },
+  suspendUser(userId: number, reason: string) {
+    this.suspended.push([userId, reason]);
+  },
+  resumeUser(userId: number) {
+    this.resumed.push(userId);
   },
 };
 vi.mock('../services/ircManager.js', () => ({ default: fakeManager }));
@@ -141,6 +151,59 @@ describe('DELETE /api/admin/users/:id', () => {
     const res = await adminAgent.delete(`/api/admin/users/${target.id}`);
     expect(res.status).toBe(200);
     expect(fakeManager.disposed.find(([uid]) => uid === target.id)).toBeTruthy();
+  });
+});
+
+describe('POST /api/admin/users/:id/pause and /resume', () => {
+  it('pauses a user: flips is_paused, suspends IRC, and surfaces it in the list', async () => {
+    const { createUser, findUserById } = await import('../db/users.js');
+    const target = createUser('to-be-paused');
+    const res = await adminAgent.post(`/api/admin/users/${target.id}/pause`);
+    expect(res.status).toBe(200);
+    expect(findUserById(target.id)?.is_paused).toBe(1);
+    expect(fakeManager.suspended.find(([uid]) => uid === target.id)).toBeTruthy();
+
+    const list = await adminAgent.get('/api/admin/users');
+    const row = list.body.users.find((u: { id: number }) => u.id === target.id);
+    expect(row.isPaused).toBe(true);
+  });
+
+  it('resumes a paused user: clears is_paused and re-inits their networks', async () => {
+    const { createUser, findUserById, setUserPaused } = await import('../db/users.js');
+    const target = createUser('to-be-resumed');
+    setUserPaused(target.id, true);
+    const res = await adminAgent.post(`/api/admin/users/${target.id}/resume`);
+    expect(res.status).toBe(200);
+    expect(findUserById(target.id)?.is_paused).toBe(0);
+    expect(fakeManager.resumed).toContain(target.id);
+  });
+
+  it('refuses to pause yourself (409)', async () => {
+    const res = await adminAgent.post(`/api/admin/users/${admin.id}/pause`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/yourself/);
+  });
+
+  it('404s an unknown id and 400s a non-integer id', async () => {
+    expect((await adminAgent.post('/api/admin/users/999999/pause')).status).toBe(404);
+    expect((await adminAgent.post('/api/admin/users/abc/pause')).status).toBe(400);
+  });
+
+  it('requires admin — a regular user gets 403', async () => {
+    const { createUser } = await import('../db/users.js');
+    const victim = createUser('pause-victim');
+    expect((await userAgent.post(`/api/admin/users/${victim.id}/pause`)).status).toBe(403);
+  });
+
+  it('is idempotent: re-pausing stays paused and does not re-suspend', async () => {
+    const { createUser } = await import('../db/users.js');
+    const target = createUser('pause-twice-admin');
+    await adminAgent.post(`/api/admin/users/${target.id}/pause`);
+    fakeManager.reset();
+    const again = await adminAgent.post(`/api/admin/users/${target.id}/pause`);
+    expect(again.status).toBe(200);
+    expect(again.body.alreadyPaused).toBe(true);
+    expect(fakeManager.suspended.length).toBe(0);
   });
 });
 

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -4,9 +4,10 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
-import { listUsers, findUserById, deleteUser, countAdmins } from '../db/users.js';
+import { listUsers, findUserById, deleteUser, countAdmins, setUserPaused } from '../db/users.js';
 import { createInvite, listInvites, deleteInvite, getInvite } from '../db/invites.js';
 import ircManager from '../services/ircManager.js';
+import { isNodeMode } from '../utils/edition.js';
 
 const router = Router();
 router.use(requireAuth, requireAdmin);
@@ -54,6 +55,7 @@ router.get('/users', (_req: Request, res: Response) => {
       role: u.role,
       createdAt: u.created_at,
       lastSeenAt: u.last_seen_at,
+      isPaused: !!u.is_paused,
     })),
   });
 });
@@ -86,6 +88,71 @@ router.delete('/users/:id', (req: Request, res: Response) => {
   // FOREIGN KEY violation in messages.network_id.
   ircManager.disposeUser(id, 'user deleted');
   deleteUser(id);
+  res.json({ ok: true });
+});
+
+// Pause/resume another account (self-hosted moderation): drop their live IRC and
+// make them read-only, keeping all data — the same mechanism the control plane
+// drives in node edition. Gated to standalone: in node edition the CP is the
+// source of truth, and a cell-side pause would desync it (CP reconciliation
+// re-asserts pauses but never resumes), so we refuse and let the CP own it.
+router.post('/users/:id/pause', (req: Request, res: Response) => {
+  if (isNodeMode()) {
+    res
+      .status(409)
+      .json({ error: 'account state is managed by the control plane in node edition' });
+    return;
+  }
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const target = findUserById(id);
+  if (!target) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  // Pausing yourself would lock you read-only with no obvious way back; the UI
+  // disables it too, but guard the route as the source of truth.
+  if (target.id === req.user!.id) {
+    res.status(409).json({ error: 'cannot pause yourself' });
+    return;
+  }
+  if (target.is_paused) {
+    res.json({ ok: true, alreadyPaused: true });
+    return;
+  }
+  // Flag first so the startNetwork gate is closed before suspendUser drops the
+  // connections (no window for an in-flight reconnect to slip back in).
+  setUserPaused(id, true);
+  ircManager.suspendUser(id);
+  res.json({ ok: true });
+});
+
+router.post('/users/:id/resume', (req: Request, res: Response) => {
+  if (isNodeMode()) {
+    res
+      .status(409)
+      .json({ error: 'account state is managed by the control plane in node edition' });
+    return;
+  }
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const target = findUserById(id);
+  if (!target) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  if (!target.is_paused) {
+    res.json({ ok: true, alreadyActive: true });
+    return;
+  }
+  setUserPaused(id, false);
+  ircManager.resumeUser(id);
   res.json({ ok: true });
 });
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -540,7 +540,14 @@ router.post('/logout', (req: Request, res: Response) => {
 });
 
 router.get('/me', requireAuth, (req: Request, res: Response) => {
-  res.json({ user: { id: req.user!.id, username: req.user!.username, role: req.user!.role } });
+  res.json({
+    user: {
+      id: req.user!.id,
+      username: req.user!.username,
+      role: req.user!.role,
+      is_paused: !!req.user!.is_paused,
+    },
+  });
 });
 
 // ---------- passkey management (authed) ----------

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -129,6 +129,39 @@ describe('POST /api/networks', () => {
   });
 });
 
+describe('paused accounts are read-only', () => {
+  it('blocks every write with 403 but still serves reads', async () => {
+    const { createUser, setUserPaused } = await import('../db/users.js');
+    const paula = createUser('net-paula');
+    const paulaAgent = await createAuthedAgent(app, paula.id);
+
+    // Create a network while still active, capture its id, then pause.
+    const net = await makeNet(paulaAgent, { name: 'paula-net' });
+    expect(net.status).toBe(201);
+    const netId = net.body.network.id;
+    setUserPaused(paula.id, true);
+    fakeManager.reset();
+
+    // Reads still work — the sidebar must render for read-only browsing.
+    const list = await paulaAgent.get('/api/networks');
+    expect(list.status).toBe(200);
+
+    // Every mutation is blocked with a clean 403, and no IRC call leaks through.
+    expect((await paulaAgent.post(`/api/networks/${netId}/connect`)).status).toBe(403);
+    expect((await paulaAgent.post(`/api/networks/${netId}/reconnect`)).status).toBe(403);
+    expect(
+      (await paulaAgent.post(`/api/networks/${netId}/join`).send({ channel: '#x' })).status,
+    ).toBe(403);
+    expect((await makeNet(paulaAgent, { name: 'should-fail' })).status).toBe(403);
+    expect(fakeManager.calls.length).toBe(0);
+
+    // Un-pausing restores write access.
+    setUserPaused(paula.id, false);
+    expect((await paulaAgent.post(`/api/networks/${netId}/connect`)).status).toBe(200);
+    expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(true);
+  });
+});
+
 describe('PATCH /api/networks/:id', () => {
   it("404s on someone else's network", async () => {
     const bobNet = await makeNet(bobAgent, { name: 'bobs' });

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -3,7 +3,7 @@
 
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-import { requireAuth } from '../middleware/auth.js';
+import { requireAuth, blockWritesWhenPaused } from '../middleware/auth.js';
 import type { Network } from '../db/networks.js';
 import {
   listNetworksForUser,
@@ -19,6 +19,10 @@ import ircManager from '../services/ircManager.js';
 
 const router = Router();
 router.use(requireAuth);
+// Paused accounts are read-only: every connect/reconnect/join/part and all
+// network-config mutation here is blocked, while GET listing still works so the
+// sidebar renders. See blockWritesWhenPaused.
+router.use(blockWritesWhenPaused);
 
 function networkPayload(network: Network | undefined | null): Record<string, unknown> | null {
   if (!network) return null;

--- a/server/routes/node.test.ts
+++ b/server/routes/node.test.ts
@@ -199,3 +199,67 @@ describe('node control API — mint session', () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe('node control API — pause/resume', () => {
+  async function provision(username: string): Promise<number> {
+    const res = await createAnonAgent(app)
+      .post('/api/node/users')
+      .set('Authorization', AUTH)
+      .send({ username });
+    return res.body.id;
+  }
+
+  it('pauses a tenant and flips is_paused', async () => {
+    const id = await provision('pause-me');
+    expect(findUserById(id)?.is_paused).toBe(0);
+    const res = await createAnonAgent(app)
+      .post(`/api/node/users/${id}/pause`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(findUserById(id)?.is_paused).toBe(1);
+  });
+
+  it('is idempotent — re-pausing stays paused and still 200s', async () => {
+    const id = await provision('pause-twice');
+    await createAnonAgent(app).post(`/api/node/users/${id}/pause`).set('Authorization', AUTH);
+    const again = await createAnonAgent(app)
+      .post(`/api/node/users/${id}/pause`)
+      .set('Authorization', AUTH);
+    expect(again.status).toBe(200);
+    expect(findUserById(id)?.is_paused).toBe(1);
+  });
+
+  it('resumes a paused tenant and clears is_paused', async () => {
+    const id = await provision('resume-me');
+    await createAnonAgent(app).post(`/api/node/users/${id}/pause`).set('Authorization', AUTH);
+    expect(findUserById(id)?.is_paused).toBe(1);
+    const res = await createAnonAgent(app)
+      .post(`/api/node/users/${id}/resume`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+    expect(findUserById(id)?.is_paused).toBe(0);
+  });
+
+  it('404s pausing an unknown user', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/node/users/999999/pause')
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+
+  it('refuses to pause an admin (the operator)', async () => {
+    const admin = createUser('pause-admin', { role: 'admin' });
+    const res = await createAnonAgent(app)
+      .post(`/api/node/users/${admin.id}/pause`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(409);
+    expect(findUserById(admin.id)?.is_paused).toBe(0);
+  });
+
+  it('requires the node secret', async () => {
+    const id = await provision('pause-noauth');
+    const res = await createAnonAgent(app).post(`/api/node/users/${id}/pause`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/routes/node.ts
+++ b/server/routes/node.ts
@@ -13,6 +13,7 @@ import {
   deleteUser,
   findUserById,
   findUserByUsername,
+  setUserPaused,
 } from '../db/users.js';
 import ircManager from '../services/ircManager.js';
 import { sign as signCookie } from 'cookie-signature';
@@ -121,6 +122,71 @@ router.post('/users/:id/session', (req: Request, res: Response) => {
   const { token } = createSession(id);
   const value = 's:' + signCookie(token, secret);
   res.json({ cookieName: SESSION_COOKIE, value, maxAgeMs: getCookieOptions().maxAge });
+});
+
+// Pause a tenant account: flip the read-only flag and tear down live IRC, but
+// keep all data and the session (the opposite of DELETE). The control plane
+// calls this when an account is suspended / past-due / canceled — the cell
+// stays billing-blind and only mirrors this one verdict. Idempotent: re-pausing
+// an already-paused account is a no-op success, which is what the orchestrator's
+// reconciliation sweep relies on.
+router.post('/users/:id/pause', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const target = findUserById(id);
+  if (!target) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  // The operator's admin account is not a tenant — never let the orchestrator
+  // pause it (mirrors the delete/session guards).
+  if (target.role === 'admin') {
+    res.status(409).json({ error: 'refusing to pause an admin account' });
+    return;
+  }
+  // Already paused → quiet no-op. The orchestrator's reconciliation re-pushes
+  // pauses on every cell heartbeat; short-circuiting here keeps that sweep from
+  // re-running suspendUser + re-fanning the read-only event every 30s.
+  if (target.is_paused) {
+    res.json({ ok: true, alreadyPaused: true });
+    return;
+  }
+  // Flag first so the startNetwork gate is already closed before suspendUser
+  // drops the connections — no window for an in-flight reconnect to slip back in.
+  setUserPaused(id, true);
+  ircManager.suspendUser(id);
+  res.json({ ok: true });
+});
+
+// Resume a paused tenant account: clear the flag, then re-establish autoconnect
+// networks. Idempotent. Order matters — setUserPaused(false) must land before
+// resumeUser so the startNetwork gate lets the reconnect through.
+router.post('/users/:id/resume', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const target = findUserById(id);
+  if (!target) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  if (target.role === 'admin') {
+    res.status(409).json({ error: 'refusing to resume an admin account' });
+    return;
+  }
+  // Already active → quiet no-op, so a redundant resume doesn't re-init networks.
+  if (!target.is_paused) {
+    res.json({ ok: true, alreadyActive: true });
+    return;
+  }
+  setUserPaused(id, false);
+  ircManager.resumeUser(id);
+  res.json({ ok: true });
 });
 
 export default router;

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+// The startNetwork gate is the linchpin of the pause feature: a paused account
+// can never construct an IrcConnection, so every downstream send/join/action
+// no-ops for free. We can assert the paused path without opening a socket
+// because it returns before connect() is ever reached.
+const ctx = setupTestDb('services-ircmanager');
+
+let ircManager: typeof import('./ircManager.js').default;
+let createUser: typeof import('../db/users.js').createUser;
+let setUserPaused: typeof import('../db/users.js').setUserPaused;
+let createNetwork: typeof import('../db/networks.js').createNetwork;
+
+beforeAll(async () => {
+  ircManager = (await import('./ircManager.js')).default;
+  ({ createUser, setUserPaused } = await import('../db/users.js'));
+  ({ createNetwork } = await import('../db/networks.js'));
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('ircManager pause linchpin', () => {
+  it('startNetwork refuses a paused user and creates no connection', () => {
+    const user = createUser('irc-paused');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.invalid',
+      port: 6697,
+      tls: true,
+      nick: 'x',
+      autoconnect: false,
+    });
+    if (!net) throw new Error('createNetwork returned undefined');
+
+    setUserPaused(user.id, true);
+
+    expect(ircManager.startNetwork(user.id, net.id)).toBeNull();
+    expect(ircManager.getConnection(user.id, net.id)).toBeNull();
+  });
+});

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -12,6 +12,7 @@ import {
   deleteChannel,
 } from '../db/networks.js';
 import { reopenBuffer } from '../db/closedBuffers.js';
+import { findUserById } from '../db/users.js';
 import { getUserAwayState, writeAwayMarker, writeBackMarker } from '../db/userAwayState.js';
 import { listPinnedForUser } from '../db/pinnedBuffers.js';
 import { listCollapsedForUser } from '../db/nicklistCollapsed.js';
@@ -95,6 +96,13 @@ class IrcManager extends EventEmitter {
   }
 
   startNetwork(userId: number, networkId: number): IrcConnection | null {
+    // Paused accounts never hold a live IRC connection. This single gate is the
+    // linchpin of the pause feature: it covers boot-time autoconnect
+    // (initForUser → initAll), the explicit connect/reconnect routes, and
+    // restartNetwork — so a paused user can produce no IRC traffic no matter
+    // which path is taken. The boundary guards (REST/WS) exist only to return a
+    // clean "account paused" instead of a silent no-op.
+    if (findUserById(userId)?.is_paused) return null;
     const network = getNetwork(networkId, userId);
     if (!network) return null;
     let conn = this.getConnection(userId, networkId);
@@ -351,6 +359,45 @@ class IrcManager extends EventEmitter {
       this.byUser.delete(userId);
     }
     this.emit('user-disposed', { userId });
+  }
+
+  // Pause: tear down the user's live IRC connections but leave their WS sockets
+  // and session untouched — the opposite of disposeUser, which fires right
+  // before a row delete and closes everything. A paused user keeps read-only
+  // access; only their IRC presence goes away. Emits 'user-suspended' so wsHub
+  // can flip already-open tabs into read-only in place. Call setUserPaused(id,
+  // true) BEFORE this so the startNetwork gate won't immediately re-establish
+  // anything (e.g. an in-flight reconnect timer).
+  suspendUser(userId: number): void {
+    const userMap = this.byUser.get(userId);
+    if (userMap) {
+      for (const conn of userMap.values()) {
+        try {
+          // disconnect(), NOT dispose(): dispose() sets disposed=true before the
+          // QUIT, which makes publish() swallow the 'disconnected' state event —
+          // so the still-open client (pause keeps the WS) would keep showing the
+          // network as connected. disconnect() leaves publish() live, so the
+          // socket-close handler's setState('disconnected') reaches the client,
+          // and it quits with DEFAULT_QUIT_MESSAGE rather than a "paused" reason.
+          // (dispose()'s disposed-guard matters for deletion, where a late write
+          // would hit a FK violation; here the row stays, so it's harmless.)
+          conn.disconnect();
+        } catch (_) {
+          /* ignore */
+        }
+      }
+      this.byUser.delete(userId);
+    }
+    this.emit('user-suspended', { userId });
+  }
+
+  // Resume: re-establish autoconnect networks for an account that was just
+  // un-paused. Call AFTER setUserPaused(id, false) so the startNetwork gate
+  // lets the connections through. Emits 'user-resumed' so wsHub clears the
+  // read-only banner on open tabs.
+  resumeUser(userId: number): void {
+    this.initForUser(userId);
+    this.emit('user-resumed', { userId });
   }
 
   shutdown(): void {

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -82,12 +82,16 @@ type WsPayload = Record<string, unknown>;
 // A paused account is read-only, so these are rejected while reads (snapshot,
 // history, search, chanlist-search) and local view state (read markers, pins,
 // drafts, bookmarks, nicklist collapse) still work. open-buffer can resolve to
-// a JOIN, so it's blocked too.
+// a JOIN, so it's blocked; close-buffer is blocked because its disconnected
+// fallback flips channels.joined=0 — a network-state mutation a read-only
+// account shouldn't make (no PART goes out, since paused accounts hold no
+// connection, but the persisted join intent would still change).
 const PAUSED_BLOCKED_TYPES = new Set([
   'send',
   'action',
   'join',
   'open-buffer',
+  'close-buffer',
   'part',
   'raw',
   'probe-presence',

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -68,10 +68,34 @@ interface LurkerWebSocket extends WebSocket {
   userId?: number;
   sinceId?: number;
   presence?: { visible: boolean };
+  // Mirrors the account's is_paused at connect time, then flipped live by the
+  // user-suspended / user-resumed handlers so the read-only write guard never
+  // needs a per-message DB read. (Named accountPaused, not isPaused, to avoid
+  // colliding with the ws library's own WebSocket.isPaused.)
+  accountPaused?: boolean;
 }
 
 // Generic payload for outgoing WS messages.
 type WsPayload = Record<string, unknown>;
+
+// Inbound message types that mutate IRC state or produce outbound IRC traffic.
+// A paused account is read-only, so these are rejected while reads (snapshot,
+// history, search, chanlist-search) and local view state (read markers, pins,
+// drafts, bookmarks, nicklist collapse) still work. open-buffer can resolve to
+// a JOIN, so it's blocked too.
+const PAUSED_BLOCKED_TYPES = new Set([
+  'send',
+  'action',
+  'join',
+  'open-buffer',
+  'part',
+  'raw',
+  'probe-presence',
+  'list-channels',
+  'away',
+  'back',
+  'typing',
+]);
 
 // Options bag for fanOut.
 interface FanOutOpts {
@@ -655,6 +679,30 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     systemLog.dropUser(userId);
   });
 
+  // Pause: the user keeps their session and sockets — unlike a delete. Flip
+  // every open tab to read-only in place and drop the pending auto-away timer.
+  // The IrcConnections were already torn down by ircManager.suspendUser; here
+  // we only react on the socket layer.
+  ircManager.on('user-suspended', ({ userId }) => {
+    const set = socketsByUser.get(userId);
+    if (set) {
+      for (const ws of set) ws.accountPaused = true;
+    }
+    clearAutoAwayTimer(userId);
+    fanOut(userId, { kind: 'account-state', paused: true });
+  });
+
+  // Resume: clear the read-only flag on open tabs and drop the banner.
+  // ircManager.resumeUser has already re-established autoconnect networks, whose
+  // connection lifecycle events fan out through the normal snapshot/event path.
+  ircManager.on('user-resumed', ({ userId }) => {
+    const set = socketsByUser.get(userId);
+    if (set) {
+      for (const ws of set) ws.accountPaused = false;
+    }
+    fanOut(userId, { kind: 'account-state', paused: false });
+  });
+
   function authenticateRequest(req: IncomingMessage): User | null | undefined {
     const header = req.headers.cookie;
     if (!header) return null;
@@ -688,6 +736,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       lurkerWs.userId = user.id;
       lurkerWs.sinceId = initialSinceId;
       lurkerWs.presence = { visible: false };
+      lurkerWs.accountPaused = user.is_paused === 1;
       addSocket(user.id, lurkerWs);
       onConnection(lurkerWs, user);
     });
@@ -832,6 +881,22 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         return;
       }
       msg.networkId = networkId;
+    }
+    // Read-only guard for paused accounts. Reject anything that would touch IRC;
+    // reads and local view state fall through to the switch. Resolve the
+    // optimistic bubble on send/action so the originating tab stops showing it
+    // as pending instead of hanging forever.
+    if (ws.accountPaused && PAUSED_BLOCKED_TYPES.has(msg.type as string)) {
+      send(ws, { kind: 'error', text: 'account paused' });
+      if (msg.clientId && (msg.type === 'send' || msg.type === 'action')) {
+        send(ws, {
+          kind: 'send-result',
+          clientId: msg.clientId,
+          ok: false,
+          error: 'account-paused',
+        });
+      }
+      return;
     }
     switch (msg.type) {
       case 'presence': {

--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -4,7 +4,10 @@
 -->
 
 <template>
-  <RouterView />
+  <div class="app-shell" :class="{ 'is-paused': auth.isPaused }">
+    <PausedBanner v-if="auth.isPaused" />
+    <RouterView />
+  </div>
   <ToastContainer />
   <ContextMenu />
 </template>
@@ -17,6 +20,7 @@ import { useConfigStore } from './stores/config.js';
 import { useTheme } from './composables/useTheme.js';
 import ToastContainer from './components/ToastContainer.vue';
 import ContextMenu from './components/ContextMenu.vue';
+import PausedBanner from './components/PausedBanner.vue';
 
 const auth = useAuthStore();
 const settings = useSettingsStore();

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -269,3 +269,23 @@ textarea:focus {
   scrollbar-color: var(--bg-soft) transparent;
   scrollbar-width: thin;
 }
+
+/* Paused-account read-only shell. The wrapper is invisible to layout until the
+   account is paused (display:contents), so the unpaused app renders exactly as
+   before. When paused it becomes a flex column: PausedBanner takes its natural
+   height at the top and the route view fills the rest — overriding each view's
+   own 100dvh root, which would otherwise overflow below the banner. The child
+   selector's 3-class specificity wins over a view's own (scoped) height rule. */
+.app-shell {
+  display: contents;
+}
+.app-shell.is-paused {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+}
+.app-shell.is-paused > :not(.paused-banner) {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
+}

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -23,7 +23,7 @@
       v-model="text"
       rows="1"
       :placeholder="placeholder"
-      :disabled="!active"
+      :disabled="!active || isPaused"
       :spellcheck="systemFeatures.spellcheck"
       :autocorrect="systemFeatures.autocorrect"
       :autocapitalize="systemFeatures.autocapitalize"
@@ -108,6 +108,7 @@
 import { ref, computed, watch, onBeforeUnmount, onMounted } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
+import { useAuthStore } from '../stores/auth.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { useSettingsStore } from '../stores/settings.js';
@@ -152,6 +153,7 @@ import type { Buffer } from '../stores/buffers.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
+const auth = useAuthStore();
 const inputHistory = useInputHistoryStore();
 const drafts = useDraftStore();
 const settings = useSettingsStore();
@@ -220,8 +222,13 @@ const ownNick = computed(() => {
   return networks.states[a.networkId]?.nick || '';
 });
 const isServer = computed(() => active.value?.target?.startsWith(':server:'));
-const sendable = computed(() => !!active.value && !isServer.value);
+// Paused accounts are read-only — no buffer is sendable. The server also
+// rejects any send that slips through, but gating here keeps the affordance
+// honest (disabled composer, no optimistic bubble).
+const isPaused = computed(() => auth.isPaused);
+const sendable = computed(() => !!active.value && !isServer.value && !isPaused.value);
 const placeholder = computed(() => {
+  if (isPaused.value) return 'Account paused — read only';
   if (!active.value) return 'Select a buffer';
   if (isServer.value) return '/raw <line>';
   return 'try /help';

--- a/vue_client/src/components/PausedBanner.vue
+++ b/vue_client/src/components/PausedBanner.vue
@@ -1,0 +1,56 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Persistent top-of-app banner shown while the account is paused (read-only).
+  Mounted by App.vue inside the .app-shell wrapper, which reflows the route view
+  beneath it. The copy is mode-aware: a self-hosted (standalone) user is told to
+  contact their admin, while a hosted (node) tenant gets a link to their account
+  page to reactivate.
+-->
+
+<template>
+  <div class="paused-banner" role="status">
+    <span class="paused-banner__text"><strong>Account paused.</strong> {{ detail }}</span>
+    <a v-if="config.isNode" class="paused-banner__link" :href="ACCOUNT_URL">Reactivate</a>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useConfigStore } from '../stores/config.js';
+
+const config = useConfigStore();
+
+// The hosted account/billing page. It doesn't exist yet (B4/B5), but the URL is
+// stable, so the link is correct ahead of the page landing.
+const ACCOUNT_URL = 'https://app.lurker.chat/account';
+
+const detail = computed(() =>
+  config.isNode
+    ? 'You can read your history, but sending is disabled until you reactivate.'
+    : 'You can read your history, but sending is disabled. Contact the administrator to restore access.',
+);
+</script>
+
+<style scoped>
+.paused-banner {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-6);
+  padding: var(--space-3) var(--space-6);
+  background: var(--warn);
+  color: var(--bg);
+  text-align: center;
+}
+.paused-banner__link {
+  color: var(--bg);
+  font-weight: 600;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+</style>

--- a/vue_client/src/components/settings-panes/UsersPane.vue
+++ b/vue_client/src/components/settings-panes/UsersPane.vue
@@ -18,6 +18,7 @@
         <span class="ua">
           {{ u.username }}
           <span v-if="u.role === 'admin'" class="role-tag">admin</span>
+          <span v-if="u.isPaused" class="paused-tag">paused</span>
         </span>
         <span
           class="last-seen"
@@ -26,6 +27,21 @@
           <template v-if="u.lastSeenAt">last seen {{ formatRelative(u.lastSeenAt) }}</template>
           <template v-else>joined {{ formatRelative(u.createdAt) }}</template>
         </span>
+        <button
+          v-if="!config.isNode"
+          class="link"
+          :disabled="u.id === auth.user?.id || adminBusy"
+          :title="
+            u.id === auth.user?.id
+              ? 'cannot pause yourself'
+              : u.isPaused
+                ? 'resume — reconnect to IRC'
+                : 'pause — disconnect from IRC and make read-only'
+          "
+          @click="u.isPaused ? onResumeUser(u) : onPauseUser(u)"
+        >
+          {{ u.isPaused ? 'resume' : 'pause' }}
+        </button>
         <button
           class="link danger"
           :disabled="u.id === auth.user?.id || adminBusy"
@@ -83,6 +99,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useAuthStore } from '../../stores/auth.js';
 import { useAdminStore } from '../../stores/admin.js';
+import { useConfigStore } from '../../stores/config.js';
 import type { AdminUser, AdminInvite } from '../../stores/admin.js';
 import { formatRelative } from '../../utils/timestamp.js';
 
@@ -103,6 +120,9 @@ interface AdminInviteRow extends AdminInvite {
 
 const auth = useAuthStore();
 const adminStore = useAdminStore();
+// Pause/resume is a self-hosted control only — in node edition the control plane
+// owns account state, so the buttons are hidden.
+const config = useConfigStore();
 
 // The store types these as the base interfaces; cast to the extended rows that
 // include fields the server returns but the interfaces don't declare yet.
@@ -167,6 +187,36 @@ async function onDeleteUser(user: AdminUserRow) {
   }
 }
 
+async function onPauseUser(user: AdminUserRow) {
+  if (
+    !confirm(
+      `Pause ${user.username}? They'll be disconnected from IRC and read-only until resumed.`,
+    )
+  )
+    return;
+  adminError.value = '';
+  adminBusy.value = true;
+  try {
+    await adminStore.pauseUser(user.id);
+  } catch (e: any) {
+    adminError.value = e.message || 'failed to pause user';
+  } finally {
+    adminBusy.value = false;
+  }
+}
+
+async function onResumeUser(user: AdminUserRow) {
+  adminError.value = '';
+  adminBusy.value = true;
+  try {
+    await adminStore.resumeUser(user.id);
+  } catch (e: any) {
+    adminError.value = e.message || 'failed to resume user';
+  } finally {
+    adminBusy.value = false;
+  }
+}
+
 function copyInviteUrl(url: string) {
   if (navigator.clipboard?.writeText) {
     navigator.clipboard.writeText(url).catch(() => {
@@ -181,6 +231,13 @@ function copyInviteUrl(url: string) {
 .user-row .role-tag {
   color: var(--accent);
   border: 1px solid var(--accent);
+  padding: 0 var(--space-2);
+  margin-left: var(--space-3);
+  text-transform: uppercase;
+}
+.user-row .paused-tag {
+  color: var(--warn);
+  border: 1px solid var(--warn);
   padding: 0 var(--space-2);
   margin-left: var(--space-3);
   text-transform: uppercase;

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -330,6 +330,13 @@ function handleMessage(raw: string): void {
     applyEvent(payload);
     return;
   }
+  if (payload.kind === 'account-state') {
+    // The account was paused/resumed out-of-band (operator or control plane).
+    // Flip the whole UI into/out of read-only in place; the server has already
+    // torn down or re-established the IRC connections.
+    useAuthStore().setPaused(!!payload.paused);
+    return;
+  }
   if (payload.kind === 'settings') {
     const settings = useSettingsStore();
     settings.applyRemote(payload);

--- a/vue_client/src/stores/admin.ts
+++ b/vue_client/src/stores/admin.ts
@@ -8,6 +8,7 @@ export interface AdminUser {
   id: number;
   username: string;
   createdAt: string;
+  isPaused?: boolean;
 }
 
 export interface AdminInvite {
@@ -41,6 +42,16 @@ export const useAdminStore = defineStore('admin', {
     async deleteUser(id: number) {
       await api(`/api/admin/users/${id}`, { method: 'DELETE' });
       this.users = this.users.filter((u) => u.id !== id);
+    },
+    async pauseUser(id: number) {
+      await api(`/api/admin/users/${id}/pause`, { method: 'POST' });
+      const u = this.users.find((x) => x.id === id);
+      if (u) u.isPaused = true;
+    },
+    async resumeUser(id: number) {
+      await api(`/api/admin/users/${id}/resume`, { method: 'POST' });
+      const u = this.users.find((x) => x.id === id);
+      if (u) u.isPaused = false;
     },
     async fetchInvites() {
       this.error = '';

--- a/vue_client/src/stores/auth.ts
+++ b/vue_client/src/stores/auth.ts
@@ -10,6 +10,10 @@ export interface AuthUser {
   id: number;
   username: string;
   role: 'admin' | 'user';
+  // Read-only account: still authenticated and able to browse history, but
+  // disconnected from IRC and barred from sending. Seeded by /api/auth/me and
+  // flipped live by the server's 'account-state' WS event (see setPaused).
+  is_paused?: boolean;
 }
 
 export interface SetupStatus {
@@ -31,7 +35,17 @@ export const useAuthStore = defineStore('auth', {
     error: null as string | null,
     setupStatus: null as SetupStatus | null, // { needsSetup, mode?, username? }
   }),
+  getters: {
+    // Whole-UI read-only gate. Components key their disabled/banner state off
+    // this rather than poking at user?.is_paused directly.
+    isPaused: (s): boolean => s.user?.is_paused === true,
+  },
   actions: {
+    // Live flip from the server's 'account-state' WS event, so an open tab
+    // enters/leaves read-only without a reload.
+    setPaused(paused: boolean) {
+      if (this.user) this.user.is_paused = paused;
+    },
     async fetchMe() {
       try {
         const { user } = await api('/api/auth/me');

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -3,6 +3,7 @@
 
 import { defineStore } from 'pinia';
 import { api } from '../api.js';
+import { useAuthStore } from './auth.js';
 
 export interface Network {
   id: number;
@@ -108,16 +109,24 @@ export const useNetworksStore = defineStore('networks', {
       delete this.states[id];
       if (this.activeKey?.startsWith(`${id}::`)) this.activeKey = null;
     },
+    // The IRC connection toggles are the writes most reachable from the
+    // read-only browse view (header toggle, network context menu), so they get
+    // a client-side short-circuit to avoid firing a request the server would
+    // 403 anyway. Config mutations (create/update/remove) are reached only from
+    // editing UI a paused user shouldn't be in, and stay server-enforced.
     async connect(id: number) {
+      if (useAuthStore().isPaused) return;
       await api(`/api/networks/${id}/connect`, { method: 'POST' });
     },
     async disconnect(id: number, reason?: string) {
+      if (useAuthStore().isPaused) return;
       await api(`/api/networks/${id}/disconnect`, {
         method: 'POST',
         ...(reason ? { body: { reason } } : {}),
       });
     },
     async reconnect(id: number) {
+      if (useAuthStore().isPaused) return;
       await api(`/api/networks/${id}/reconnect`, { method: 'POST' });
     },
     setActive(networkId: number | string, target: string) {


### PR DESCRIPTION
## What & why

Adds a **paused account** state: the account stays signed in and can browse its history **read-only**, but is disconnected from IRC and can't reconnect or send. This is the cell-side enforcement + UI for the hosted service's pause feature (the foundation for paid/free accounts) — and it's also wired into the self-hosted admin UI, since pausing a misbehaving user is useful standalone too.

Paired with the control-plane side: amiantos/lurker-control-plane#8.

## How it works

- **Source of truth**: `users.is_paused`. In hosted mode the control plane drives it via the node API; in standalone an admin drives it from **Settings → Users**.
- **Linchpin**: `ircManager.startNetwork()` refuses paused users → no IRC connection can exist → every send/join/typing no-ops for free. The boundary guards (WS write-type guard, `blockWritesWhenPaused` on the networks router) just return clean errors and drive the UI.
- **Live flip**: pausing fans an `account-state` WS event to open tabs → banner + read-only in place, no reload. `suspendUser` uses `conn.disconnect()` (not `dispose()`) so the still-connected client actually sees the network go disconnected, and a default QUIT message is sent rather than "paused".
- **Read-only, not dark**: history, search, and local prefs still work; only IRC send/connect and network config are blocked.
- **Standalone admin pause is gated to standalone** — node edition stays control-plane-driven so a cell-side pause can't desync the CP (whose reconciliation re-asserts pauses but never resumes).
- Frontend: mode-aware `PausedBanner` (standalone = "contact admin", node = link to `app.lurker.chat/account`), disabled composer, read-only store guards.

## Test plan

- [x] `npm run typecheck` + `typecheck:client` clean
- [x] full server suite green (728 tests; new tests for node + admin pause/resume, the `startNetwork` gate, the read-only networks guard, and export-schema coverage)
- [x] client builds; lint + format clean
- [x] Manually verified in a standalone instance: admin pauses a second account → its tab flips to read-only live (banner, composer disabled), networks show disconnected; resume reconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
