### PR TITLE
Change node-edition ident from u&lt;id&gt; to lu&lt;id&gt;

### DIFF
--- a/server/utils/ident.test.ts
+++ b/server/utils/ident.test.ts
@@ -13,7 +13,7 @@ describe('deriveIdent', () => {
         networkUsername: 'whatever',
         nick: 'alice',
       }),
-    ).toBe('u42');
+    ).toBe('lu42');
   });
 
   it('node edition ignores the per-network username (uniqueness is forced)', () => {
@@ -26,7 +26,7 @@ describe('deriveIdent', () => {
         networkUsername: 'bob',
         nick: 'bob',
       }),
-    ).toBe('u7');
+    ).toBe('lu7');
     expect(
       deriveIdent({
         nodeMode: true,
@@ -34,7 +34,7 @@ describe('deriveIdent', () => {
         networkUsername: 'bob',
         nick: 'bob',
       }),
-    ).toBe('u8');
+    ).toBe('lu8');
   });
 
   it('node edition falls back safely for a non-acct username (e.g. the operator)', () => {

--- a/server/utils/ident.ts
+++ b/server/utils/ident.ts
@@ -7,8 +7,9 @@
 //   node edition — the ident must identify the GLOBAL account, so it's stable
 //     across cell moves and unique fleet-wide. Cells are provisioned with the
 //     account username `acct-<controlPlaneAccountId>`, so we surface
-//     `u<controlPlaneAccountId>` (IRCCloud-style). Using the cell-local user id
-//     would change if an account were ever migrated to another cell.
+//     `lu<controlPlaneAccountId>` ("lu" = Lurker user, so a network operator can
+//     tell at a glance it's one of ours). Using the cell-local user id would
+//     change if an account were ever migrated to another cell.
 //   standalone — the operator's per-network choice wins (the configured
 //     username, else the nick), matching how a single-user bouncer behaves.
 
@@ -26,7 +27,7 @@ export function deriveIdent(opts: {
 }): string {
   if (opts.nodeMode) {
     const m = /^acct-(\d+)$/.exec(opts.accountUsername.trim());
-    if (m) return sanitizeIdent(`u${m[1]}`);
+    if (m) return sanitizeIdent(`lu${m[1]}`);
     // Fallback (e.g. the operator's own admin account on a cell): stay stable +
     // ident-safe rather than inventing an id.
     return sanitizeIdent(opts.accountUsername) || 'user';


### PR DESCRIPTION
Hosted (node-edition) cells now present the per-account IRC ident as `lu<accountId>` instead of `u<accountId>`. **"lu" = Lurker user**, so a network operator can tell at a glance the connection is one of ours — `u` was too terse/ambiguous, `lurker` too wordy/advertiser-y.

So a hosted user goes from `nick!u1234@roswell.lurker.chat` → `nick!lu1234@roswell.lurker.chat`.

### Changes
- `server/utils/ident.ts` — node-mode branch returns `sanitizeIdent(\`lu${id}\`)`; updated the doc comment.
- `server/utils/ident.test.ts` — expectations updated to `lu42` / `lu7` / `lu8` (6/6 passing).

`identd.test.ts` was left alone — its `u42`/`u9`/`u1` values are arbitrary protocol-echo fixtures, not the derivation contract.

### Notes
- `lu` + up to 12 digits = 16 chars, exactly `sanitizeIdent`'s cap, so no realistic account id truncates.
- Done **before any beta users connect**: the ident is the stable handle operators ban against (`*!lu1234@*`), so changing it after people attach to a format would invalidate existing bans and change their on-network identity. The hosted service is currently torn down, so it's costless now.

The matching operator-facing docs (`/networks`, `/abuse`, `/faq`) are updated in the `lurker-marketing` repo.

Closes amiantos/lurker-control-plane#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)