### PR TITLE
Encrypt stored network credentials at rest (hosted cells)

### DIFF
--- a/server/db/networkSecrets.test.ts
+++ b/server/db/networkSecrets.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Point the DB layer at a throwaway file and configure an encryption key before
+// importing anything that touches them — db/index.js reads DATABASE_PATH and
+// secretCrypto.js reads LURKER_SECRET_KEY on first use.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-netsecrets-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+process.env.LURKER_SECRET_KEY = Buffer.alloc(32, 9).toString('base64');
+
+let db: typeof import('./index.js').default;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+let updateNetwork: typeof import('./networks.js').updateNetwork;
+let getNetwork: typeof import('./networks.js').getNetwork;
+let listNetworksForUser: typeof import('./networks.js').listNetworksForUser;
+let backfillEncryptNetworkSecrets: typeof import('./networks.js').backfillEncryptNetworkSecrets;
+let isEncrypted: typeof import('../utils/secretCrypto.js').isEncrypted;
+
+const SECRETS = {
+  server_password: 'srv-pw',
+  sasl_account: 'alice-acct',
+  sasl_password: 'sasl-pw',
+  connect_commands: 'PRIVMSG NickServ :identify nickserv-pw',
+};
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  ({ createUser } = await import('./users.js'));
+  ({
+    createNetwork,
+    updateNetwork,
+    getNetwork,
+    listNetworksForUser,
+    backfillEncryptNetworkSecrets,
+  } = await import('./networks.js'));
+  ({ isEncrypted } = await import('../utils/secretCrypto.js'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Read the raw on-disk row, bypassing the decrypt chokepoint.
+function rawRow(id: number): Record<string, string | null> {
+  return db.prepare('SELECT * FROM networks WHERE id = ?').get(id) as Record<string, string | null>;
+}
+
+const SECRET_COLS = Object.keys(SECRETS) as (keyof typeof SECRETS)[];
+
+describe('network secret encryption at rest (key configured)', () => {
+  it('stores ciphertext at rest but returns plaintext from the accessors', () => {
+    const alice = createUser('alice');
+    const net = createNetwork(alice.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'alice',
+      ...SECRETS,
+    })!;
+
+    const raw = rawRow(net.id);
+    for (const col of SECRET_COLS) {
+      expect(isEncrypted(raw[col])).toBe(true);
+      expect(raw[col]).not.toBe(SECRETS[col]);
+    }
+
+    // getNetwork and listNetworksForUser both decrypt.
+    const fetched = getNetwork(net.id, alice.id)!;
+    const listed = listNetworksForUser(alice.id).find((n) => n.id === net.id)!;
+    for (const col of SECRET_COLS) {
+      expect(fetched[col]).toBe(SECRETS[col]);
+      expect(listed[col]).toBe(SECRETS[col]);
+    }
+  });
+
+  it('re-encrypts on update and can clear a secret to null', () => {
+    const bob = createUser('bob');
+    const net = createNetwork(bob.id, {
+      name: 'oftc',
+      host: 'irc.oftc.net',
+      port: 6697,
+      tls: true,
+      nick: 'bob',
+      server_password: 'old-pw',
+    })!;
+
+    updateNetwork(net.id, bob.id, { server_password: 'new-pw', sasl_password: null });
+    const raw = rawRow(net.id);
+    expect(isEncrypted(raw.server_password)).toBe(true);
+    expect(raw.sasl_password).toBeNull();
+
+    const fetched = getNetwork(net.id, bob.id)!;
+    expect(fetched.server_password).toBe('new-pw');
+    expect(fetched.sasl_password).toBeNull();
+  });
+
+  it('backfill wraps pre-existing plaintext rows and is idempotent', () => {
+    const carol = createUser('carol');
+    const net = createNetwork(carol.id, {
+      name: 'snoonet',
+      host: 'irc.snoonet.org',
+      port: 6697,
+      tls: true,
+      nick: 'carol',
+    })!;
+    // Simulate a legacy plaintext row (written before the key was configured).
+    db.prepare('UPDATE networks SET server_password = ?, connect_commands = ? WHERE id = ?').run(
+      'legacy-plain',
+      'PRIVMSG NickServ :identify legacy',
+      net.id,
+    );
+    expect(isEncrypted(rawRow(net.id).server_password)).toBe(false);
+
+    const first = backfillEncryptNetworkSecrets();
+    expect(first.encrypted).toBeGreaterThanOrEqual(1);
+    const raw = rawRow(net.id);
+    expect(isEncrypted(raw.server_password)).toBe(true);
+    expect(isEncrypted(raw.connect_commands)).toBe(true);
+    expect(getNetwork(net.id, carol.id)!.server_password).toBe('legacy-plain');
+
+    // Second run finds nothing left to wrap.
+    expect(backfillEncryptNetworkSecrets().encrypted).toBe(0);
+  });
+});

--- a/server/db/networks.test.ts
+++ b/server/db/networks.test.ts
@@ -12,15 +12,18 @@ import path from 'path';
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
 process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 
+let db: typeof import('./index.js').default;
 let createUser: typeof import('./users.js').createUser;
 let createNetwork: typeof import('./networks.js').createNetwork;
+let getNetwork: typeof import('./networks.js').getNetwork;
 let ownsNetwork: typeof import('./networks.js').ownsNetwork;
 let listNetworksForUser: typeof import('./networks.js').listNetworksForUser;
 let reorderNetworks: typeof import('./networks.js').reorderNetworks;
 
 beforeAll(async () => {
+  db = (await import('./index.js')).default;
   ({ createUser } = await import('./users.js'));
-  ({ createNetwork, ownsNetwork, listNetworksForUser, reorderNetworks } =
+  ({ createNetwork, getNetwork, ownsNetwork, listNetworksForUser, reorderNetworks } =
     await import('./networks.js'));
 });
 
@@ -147,5 +150,30 @@ describe('reorderNetworks', () => {
     expect(reorderNetworks(henri.id, [gNet!.id, hNet!.id])).toBeNull();
     expect(listNetworksForUser(gina.id).map((n) => n.id)).toEqual([gNet!.id]);
     expect(listNetworksForUser(henri.id).map((n) => n.id)).toEqual([hNet!.id]);
+  });
+});
+
+describe('network secrets without an encryption key (self-host)', () => {
+  it('stores and returns secrets as plaintext (no envelope)', () => {
+    // This suite sets no LURKER_SECRET_KEY, so encryption is a no-op.
+    const iris = createUser('iris');
+    const net = createNetwork(iris.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'iris',
+      server_password: 'plain-srv',
+      sasl_password: 'plain-sasl',
+      connect_commands: 'PRIVMSG NickServ :identify plain',
+    })!;
+    const raw = db.prepare('SELECT * FROM networks WHERE id = ?').get(net.id) as Record<
+      string,
+      string | null
+    >;
+    expect(raw.server_password).toBe('plain-srv');
+    expect(raw.sasl_password).toBe('plain-sasl');
+    expect(raw.connect_commands).toBe('PRIVMSG NickServ :identify plain');
+    expect(getNetwork(net.id, iris.id)!.server_password).toBe('plain-srv');
   });
 });

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -2,6 +2,29 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { encryptSecret, decryptSecret, isEncrypted, hasSecretKey } from '../utils/secretCrypto.js';
+
+// Columns holding IRC network secrets that are encrypted at rest on hosted
+// cells (see server/utils/secretCrypto.ts). connect_commands is included
+// because it routinely carries `/msg NickServ identify <password>` and oper
+// passwords — IRCCloud encrypts it for the same reason. Encryption is a no-op
+// (plaintext passthrough) unless LURKER_SECRET_KEY is configured, so self-host
+// is unaffected.
+export const ENCRYPTED_NETWORK_COLUMNS = [
+  'server_password',
+  'sasl_account',
+  'sasl_password',
+  'connect_commands',
+] as const;
+
+// Decrypt the secret columns on a freshly-read row, in place. No-op for legacy
+// plaintext and when no key is configured (decryptSecret passes those through).
+function decryptRow<T extends Network | undefined>(row: T): T {
+  if (!row) return row;
+  const r = row as unknown as Record<string, string | null>;
+  for (const col of ENCRYPTED_NETWORK_COLUMNS) r[col] = decryptSecret(r[col]);
+  return row;
+}
 
 /** A row from the `networks` table. */
 export interface Network {
@@ -49,15 +72,19 @@ export interface NetworkFields {
 }
 
 export function listNetworksForUser(userId: number): Network[] {
-  return db
-    .prepare('SELECT * FROM networks WHERE user_id = ? ORDER BY position ASC, id ASC')
-    .all(userId) as Network[];
+  return (
+    db
+      .prepare('SELECT * FROM networks WHERE user_id = ? ORDER BY position ASC, id ASC')
+      .all(userId) as Network[]
+  ).map((row) => decryptRow(row));
 }
 
 export function getNetwork(id: number | bigint, userId: number): Network | undefined {
-  return db.prepare('SELECT * FROM networks WHERE id = ? AND user_id = ?').get(id, userId) as
-    | Network
-    | undefined;
+  return decryptRow(
+    db.prepare('SELECT * FROM networks WHERE id = ? AND user_id = ?').get(id, userId) as
+      | Network
+      | undefined,
+  );
 }
 
 const ownsNetworkStmt = db.prepare('SELECT 1 FROM networks WHERE id = ? AND user_id = ? LIMIT 1');
@@ -100,11 +127,11 @@ export function createNetwork(userId: number, fields: NetworkFields): Network | 
       nick,
       username || null,
       realname || null,
-      server_password || null,
+      encryptSecret(server_password || null),
       autoconnect === false ? 0 : 1,
-      sasl_account || null,
-      sasl_password || null,
-      connect_commands || null,
+      encryptSecret(sasl_account || null),
+      encryptSecret(sasl_password || null),
+      encryptSecret(connect_commands || null),
       next,
     );
   return getNetwork(result.lastInsertRowid, userId);
@@ -136,6 +163,9 @@ export function updateNetwork(
       setClauses.push(`${key} = ?`);
       let value: unknown = fields[key];
       if (key === 'tls' || key === 'autoconnect') value = value ? 1 : 0;
+      else if ((ENCRYPTED_NETWORK_COLUMNS as readonly string[]).includes(key)) {
+        value = encryptSecret(value as string | null);
+      }
       params.push(value);
     }
   }
@@ -149,6 +179,45 @@ export function updateNetwork(
 
 export function deleteNetwork(id: number, userId: number): void {
   db.prepare('DELETE FROM networks WHERE id = ? AND user_id = ?').run(id, userId);
+}
+
+// One-time, idempotent wrap of any plaintext secret columns once an encryption
+// key is configured. The chokepoint above encrypts rows written after the key
+// is set; this catches rows that predate it (or arrive plaintext via import) so
+// no cleartext secret lingers in the next Litestream backup. No-op without a key
+// (every self-host). Safe to run on every boot — the isEncrypted() guard skips
+// already-wrapped values, so a fully-encrypted table does zero writes. Called
+// once from server boot (server/server.ts), after the schema is ready and
+// before IRC connects.
+export function backfillEncryptNetworkSecrets(): { scanned: number; encrypted: number } {
+  if (!hasSecretKey()) return { scanned: 0, encrypted: 0 };
+  const cols = ENCRYPTED_NETWORK_COLUMNS;
+  const rows = db.prepare(`SELECT id, ${cols.join(', ')} FROM networks`).all() as Array<
+    Record<string, string | null> & { id: number }
+  >;
+  const update = db.prepare(
+    `UPDATE networks SET ${cols.map((c) => `${c} = ?`).join(', ')} WHERE id = ?`,
+  );
+  let encrypted = 0;
+  const tx = db.transaction(() => {
+    for (const row of rows) {
+      let dirty = false;
+      const next = cols.map((col) => {
+        const v = row[col];
+        if (typeof v === 'string' && v !== '' && !isEncrypted(v)) {
+          dirty = true;
+          return encryptSecret(v);
+        }
+        return v;
+      });
+      if (dirty) {
+        update.run(...next, row.id);
+        encrypted += 1;
+      }
+    }
+  });
+  tx();
+  return { scanned: rows.length, encrypted };
 }
 
 // Rewrite the sidebar order for one user. The caller must supply exactly the

--- a/server/server.ts
+++ b/server/server.ts
@@ -12,6 +12,7 @@ import { getNodeSecret } from './middleware/nodeAuth.js';
 import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
+import { backfillEncryptNetworkSecrets } from './db/networks.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
@@ -54,6 +55,15 @@ systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${ED
 // it before connections register their idents.
 if (isIdentdEnabled()) {
   startIdentd(identdPort());
+}
+
+// Wrap any plaintext network secrets at rest now that the DB schema is ready
+// and before IRC connects. No-op unless LURKER_SECRET_KEY is configured (hosted
+// cells); self-host instances keep secrets in plaintext.
+const wrapped = backfillEncryptNetworkSecrets();
+if (wrapped.encrypted > 0) {
+  console.log(`[lurker] encrypted ${wrapped.encrypted} network-secret row(s) at rest`);
+  systemLog.log({ scope: 'server', text: `Encrypted ${wrapped.encrypted} network-secret row(s)` });
 }
 
 ircManager.initAll();

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -12,6 +12,8 @@ import { Readable } from 'stream';
 import { ZipArchive } from 'archiver';
 import db from '../db/index.js';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION } from '../db/exportSchema.js';
+import { ENCRYPTED_NETWORK_COLUMNS } from '../db/networks.js';
+import { decryptSecret } from '../utils/secretCrypto.js';
 
 interface ExportTableDefWithScope {
   scope: string;
@@ -166,6 +168,17 @@ export async function buildExportZip(
     if (d.mode !== 'export' && d.mode !== 'partial') continue;
     if (d.section && d.section !== 'data') continue;
     const rows = selectAll(table, d, userId);
+    // Network secrets live encrypted at rest on hosted cells; decrypt them so
+    // the export is portable plaintext (restorable on a self-host without the
+    // key) — same content the user sees in the app. No-op on a self-host
+    // (values are already plaintext).
+    if (table === 'networks') {
+      for (const row of rows) {
+        for (const col of ENCRYPTED_NETWORK_COLUMNS) {
+          row[col] = decryptSecret(row[col] as string | null);
+        }
+      }
+    }
     data[table] = rows.map((row) => projectRow(row, d));
     counts[table] = rows.length;
 

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -14,6 +14,8 @@ import yauzl from 'yauzl';
 import type { Statement, RunResult } from 'better-sqlite3';
 import db from '../db/index.js';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION, IMPORT_ORDER } from '../db/exportSchema.js';
+import { ENCRYPTED_NETWORK_COLUMNS } from '../db/networks.js';
+import { encryptSecret } from '../utils/secretCrypto.js';
 
 interface ExportTableDefFull {
   mode: string;
@@ -216,6 +218,14 @@ export async function importFromZipBuffer(
       let inserted = 0;
       for (const original of rows) {
         const row = rekeyRow(original, def, idMaps, targetUserId);
+
+        // Export carries network secrets as plaintext; re-encrypt them at rest
+        // when importing onto a keyed (hosted) cell. No-op without a key.
+        if (table === 'networks') {
+          for (const col of ENCRYPTED_NETWORK_COLUMNS) {
+            if (typeof row[col] === 'string') row[col] = encryptSecret(row[col] as string);
+          }
+        }
 
         // If any required FK ended up undefined (referenced row wasn't in the
         // export), drop the row.

--- a/server/services/networkSecretsRoundtrip.test.ts
+++ b/server/services/networkSecretsRoundtrip.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Export must carry network secrets as portable PLAINTEXT (so an export is
+// restorable on a self-host without the key), and import onto a keyed cell must
+// re-encrypt them at rest. Exercises both raw-SQL bypass paths end to end.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { PassThrough } from 'stream';
+import yauzl from 'yauzl';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-secrets-rt-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+process.env.LURKER_SECRET_KEY = Buffer.alloc(32, 5).toString('base64');
+
+let db: typeof import('../db/index.js').default;
+let createUser: typeof import('../db/users.js').createUser;
+let createNetwork: typeof import('../db/networks.js').createNetwork;
+let getNetwork: typeof import('../db/networks.js').getNetwork;
+let isEncrypted: typeof import('../utils/secretCrypto.js').isEncrypted;
+let buildExportZip: typeof import('./exportService.js').buildExportZip;
+let importFromZipBuffer: typeof import('./importService.js').importFromZipBuffer;
+
+const SECRETS = {
+  server_password: 'hunter2',
+  sasl_account: 'alice-acct',
+  sasl_password: 'sasl-secret',
+  connect_commands: 'PRIVMSG NickServ :identify supersecret',
+};
+const SECRET_COLS = Object.keys(SECRETS) as (keyof typeof SECRETS)[];
+
+beforeAll(async () => {
+  db = (await import('../db/index.js')).default;
+  ({ createUser } = await import('../db/users.js'));
+  ({ createNetwork, getNetwork } = await import('../db/networks.js'));
+  ({ isEncrypted } = await import('../utils/secretCrypto.js'));
+  ({ buildExportZip } = await import('./exportService.js'));
+  ({ importFromZipBuffer } = await import('./importService.js'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function exportToBuffer(userId: number): Promise<Buffer> {
+  const sink = new PassThrough();
+  const chunks: Buffer[] = [];
+  sink.on('data', (c: Buffer) => chunks.push(c));
+  await buildExportZip(userId, { includeMessages: false }, sink);
+  return Buffer.concat(chunks);
+}
+
+function readZipEntry(buffer: Buffer, name: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    yauzl.fromBuffer(buffer, { lazyEntries: true }, (err, zip) => {
+      if (err) return reject(err);
+      zip.readEntry();
+      zip.on('entry', (entry) => {
+        if (entry.fileName !== name) return zip.readEntry();
+        zip.openReadStream(entry, (e2, stream) => {
+          if (e2) return reject(e2);
+          const chunks: Buffer[] = [];
+          stream.on('data', (c: Buffer) => chunks.push(c));
+          stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+          stream.on('error', reject);
+        });
+      });
+      zip.on('end', () => reject(new Error(`entry ${name} not found`)));
+      zip.on('error', reject);
+    });
+  });
+}
+
+describe('network secret export/import round-trip (key configured)', () => {
+  it('exports plaintext and re-encrypts on import', async () => {
+    const alice = createUser('alice');
+    const net = createNetwork(alice.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'alice',
+      ...SECRETS,
+    })!;
+    // Stored encrypted at rest.
+    const aliceRaw = db.prepare('SELECT * FROM networks WHERE id = ?').get(net.id) as Record<
+      string,
+      string | null
+    >;
+    expect(isEncrypted(aliceRaw.server_password)).toBe(true);
+
+    // ---- export carries plaintext ----
+    const buf = await exportToBuffer(alice.id);
+    const data = JSON.parse(await readZipEntry(buf, 'data.json')) as {
+      networks: Record<string, string>[];
+    };
+    const exported = data.networks[0];
+    for (const col of SECRET_COLS) {
+      expect(exported[col]).toBe(SECRETS[col]);
+    }
+
+    // ---- import re-encrypts on a fresh, keyed account ----
+    const bob = createUser('bob');
+    await importFromZipBuffer(bob.id, buf);
+    const bobNet = db.prepare('SELECT * FROM networks WHERE user_id = ?').get(bob.id) as Record<
+      string,
+      string | null
+    >;
+    for (const col of SECRET_COLS) {
+      expect(isEncrypted(bobNet[col])).toBe(true);
+    }
+    const bobFetched = getNetwork(bobNet.id as unknown as number, bob.id)!;
+    for (const col of SECRET_COLS) {
+      expect(bobFetched[col]).toBe(SECRETS[col]);
+    }
+  });
+});

--- a/server/utils/secretCrypto.test.ts
+++ b/server/utils/secretCrypto.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+// A deterministic 32-byte key (base64). The registry is built lazily on first
+// use, so setting this before any test runs is enough.
+const GOOD_KEY = Buffer.alloc(32, 7).toString('base64');
+process.env.LURKER_SECRET_KEY = GOOD_KEY;
+
+import {
+  encryptSecret,
+  decryptSecret,
+  isEncrypted,
+  hasSecretKey,
+  resetKeyRegistryForTests,
+} from './secretCrypto.js';
+
+describe('secretCrypto (key configured)', () => {
+  it('round-trips a secret through encrypt → decrypt', () => {
+    const plain = 'hunter2 🔒 with spaces';
+    const wrapped = encryptSecret(plain)!;
+    expect(wrapped).not.toBe(plain);
+    expect(decryptSecret(wrapped)).toBe(plain);
+  });
+
+  it('produces a self-describing lk1 envelope', () => {
+    const wrapped = encryptSecret('x')!;
+    expect(isEncrypted(wrapped)).toBe(true);
+    expect(wrapped.split('.')).toHaveLength(3);
+    expect(wrapped.startsWith('lk1.')).toBe(true);
+  });
+
+  it('uses a random IV (same plaintext encrypts to different ciphertext)', () => {
+    expect(encryptSecret('same')).not.toBe(encryptSecret('same'));
+  });
+
+  it('passes null and empty string through untouched', () => {
+    expect(encryptSecret(null)).toBeNull();
+    expect(encryptSecret('')).toBe('');
+    expect(decryptSecret(null)).toBeNull();
+  });
+
+  it('treats a non-envelope value as legacy plaintext on decrypt', () => {
+    expect(decryptSecret('plain-legacy-password')).toBe('plain-legacy-password');
+  });
+
+  it('never double-wraps an already-encrypted value', () => {
+    const wrapped = encryptSecret('once')!;
+    expect(encryptSecret(wrapped)).toBe(wrapped);
+  });
+
+  it('reports a configured key', () => {
+    expect(hasSecretKey()).toBe(true);
+  });
+
+  it('throws when the ciphertext has been tampered with', () => {
+    const [prefix, keyid, payloadB64] = encryptSecret('tamper-me')!.split('.');
+    const bytes = Buffer.from(payloadB64, 'base64url');
+    bytes[bytes.length - 1] ^= 0xff; // flip the last ciphertext byte
+    const tampered = `${prefix}.${keyid}.${bytes.toString('base64url')}`;
+    expect(() => decryptSecret(tampered)).toThrow(/failed to decrypt/);
+  });
+
+  it('throws on an unknown key id', () => {
+    const wrapped = encryptSecret('whatever')!;
+    const parts = wrapped.split('.');
+    parts[1] = 'deadbeef';
+    expect(() => decryptSecret(parts.join('.'))).toThrow(/no key for id/);
+  });
+
+  it('fails loud when the configured key is malformed', () => {
+    try {
+      process.env.LURKER_SECRET_KEY = 'too-short';
+      resetKeyRegistryForTests();
+      expect(() => hasSecretKey()).toThrow(/must decode to 32 bytes/);
+    } finally {
+      process.env.LURKER_SECRET_KEY = GOOD_KEY;
+      resetKeyRegistryForTests();
+    }
+  });
+});

--- a/server/utils/secretCrypto.test.ts
+++ b/server/utils/secretCrypto.test.ts
@@ -45,6 +45,21 @@ describe('secretCrypto (key configured)', () => {
     expect(decryptSecret('plain-legacy-password')).toBe('plain-legacy-password');
   });
 
+  it('does not misclassify plaintext that merely starts with "lk1."', () => {
+    // Only the full lk1.<8-hex-keyid>.<base64url> shape counts as ciphertext; a
+    // plaintext secret that just starts with "lk1." is left alone — otherwise
+    // encryptSecret would skip wrapping it and decryptSecret would throw on read.
+    expect(isEncrypted('lk1.connect to nickserv')).toBe(false); // space → wrong shape
+    expect(isEncrypted('lk1.zzzzzzzz.payload')).toBe(false); // keyid not hex
+    expect(isEncrypted('lk1.deadbeef')).toBe(false); // no payload segment
+    expect(decryptSecret('lk1.not-an-envelope')).toBe('lk1.not-an-envelope'); // passthrough, no throw
+    // Such a value still gets wrapped on encrypt (round-trips), not skipped.
+    const plain = 'lk1.my actual password';
+    const wrapped = encryptSecret(plain)!;
+    expect(isEncrypted(wrapped)).toBe(true);
+    expect(decryptSecret(wrapped)).toBe(plain);
+  });
+
   it('never double-wraps an already-encrypted value', () => {
     const wrapped = encryptSecret('once')!;
     expect(encryptSecret(wrapped)).toBe(wrapped);

--- a/server/utils/secretCrypto.ts
+++ b/server/utils/secretCrypto.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// At-rest encryption for the handful of IRC network secrets a cell stores
+// (server password, SASL account/password, connect-time commands). The hosted
+// service continuously replicates each cell's SQLite to R2 via Litestream, so a
+// leaked/misconfigured backup would otherwise expose every customer's network
+// passwords in cleartext. We wrap those columns with AES-256-GCM under a key
+// held in the cell's environment (LURKER_SECRET_KEY), NOT in the DB — so the
+// replicated SQLite file holds only ciphertext.
+//
+//   key present  → encrypt on write, decrypt on read (hosted cells).
+//   key absent   → plaintext, exactly as before (every self-host install).
+//
+// Honest scope: this defends backups / disk snapshots / DB dumps. It does NOT
+// defend a live RCE on the running cell — the app must decrypt to use a secret.
+// Never claim "we can't read it"; only account passwords are one-way (scrypt).
+//
+// Stored form is a self-describing envelope string, so no schema column or
+// migration is needed and key rotation stays additive:
+//
+//   lk1.<keyid>.<base64url(iv | tag | ciphertext)>
+//
+// where keyid = the first 8 hex of sha256(key), iv = 12 random bytes, and tag =
+// the 16-byte GCM auth tag. A value that doesn't start with `lk1.` is treated as
+// legacy plaintext and returned unchanged on read (lazy migration; the boot-time
+// backfill in db/networks.ts wraps such rows once a key is configured).
+
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+
+const ENVELOPE_PREFIX = 'lk1';
+const ALGORITHM = 'aes-256-gcm';
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const PRIMARY_KEY_ENV = 'LURKER_SECRET_KEY';
+
+interface KeyEntry {
+  keyid: string;
+  key: Buffer;
+}
+
+interface Registry {
+  primary: KeyEntry;
+  byId: Map<string, KeyEntry>;
+}
+
+// Decode an operator-supplied key string into exactly 32 bytes. Accepts base64
+// / base64url (the usual `openssl rand -base64 32` output) or a 64-char hex
+// string. Throws on anything that isn't 32 bytes so a misconfigured key fails
+// loud at boot rather than silently downgrading a hosted cell to plaintext.
+function decodeKey(raw: string): Buffer {
+  const trimmed = raw.trim();
+  const buf = /^[0-9a-fA-F]{64}$/.test(trimmed)
+    ? Buffer.from(trimmed, 'hex')
+    : Buffer.from(trimmed, 'base64'); // Buffer.from tolerates base64 and base64url
+  if (buf.length !== KEY_BYTES) {
+    throw new Error(
+      `${PRIMARY_KEY_ENV} must decode to ${KEY_BYTES} bytes (got ${buf.length}); ` +
+        `generate one with: openssl rand -base64 32`,
+    );
+  }
+  return buf;
+}
+
+function fingerprint(key: Buffer): string {
+  return createHash('sha256').update(key).digest('hex').slice(0, 8);
+}
+
+// Built once, lazily, from the environment. `primary` is the key new writes are
+// encrypted under; `byId` also carries any retired keys (future rotation) so
+// existing ciphertext stays readable. null when no key is configured.
+let registry: Registry | null = null;
+let registryBuilt = false;
+
+function buildRegistry(): Registry | null {
+  const primaryRaw = process.env[PRIMARY_KEY_ENV];
+  if (!primaryRaw || primaryRaw.trim() === '') return null;
+  const key = decodeKey(primaryRaw);
+  const primary: KeyEntry = { keyid: fingerprint(key), key };
+  return { primary, byId: new Map([[primary.keyid, primary]]) };
+}
+
+function getRegistry(): Registry | null {
+  if (!registryBuilt) {
+    registry = buildRegistry();
+    registryBuilt = true;
+  }
+  return registry;
+}
+
+/** Reset the cached key registry. Test-only: lets a suite flip LURKER_SECRET_KEY. */
+export function resetKeyRegistryForTests(): void {
+  registry = null;
+  registryBuilt = false;
+}
+
+/** True when a network-secret encryption key is configured (hosted cells). */
+export function hasSecretKey(): boolean {
+  return getRegistry() !== null;
+}
+
+/** True if `value` is one of our encrypted envelopes (vs legacy plaintext). */
+export function isEncrypted(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.startsWith(`${ENVELOPE_PREFIX}.`);
+}
+
+// Encrypt a single secret for storage. null / empty-string pass through
+// untouched (an empty value is "no secret", nothing to wrap). With no key
+// configured the value is returned as-is, so self-host stays plaintext. An
+// already-encrypted value is returned unchanged (never double-wrap).
+export function encryptSecret(plain: string | null): string | null {
+  if (plain == null || plain === '') return plain;
+  if (isEncrypted(plain)) return plain;
+  const reg = getRegistry();
+  if (!reg) return plain;
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, reg.primary.key, iv);
+  const ct = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  const payload = Buffer.concat([iv, tag, ct]).toString('base64url');
+  return `${ENVELOPE_PREFIX}.${reg.primary.keyid}.${payload}`;
+}
+
+// Decrypt a stored secret back to plaintext. null and legacy plaintext (no
+// envelope prefix) pass through unchanged. Throws on a malformed envelope, an
+// unknown key id, or a failed auth tag (tampering / wrong key): a hosted cell
+// that can't decrypt its own secrets is misconfigured and must fail loud rather
+// than hand ciphertext to an IRC server or render it in the UI.
+export function decryptSecret(stored: string | null): string | null {
+  if (stored == null || !isEncrypted(stored)) return stored;
+  const parts = stored.split('.');
+  if (parts.length !== 3) throw new Error('secretCrypto: malformed envelope');
+  const [, keyid, payloadB64] = parts;
+  const entry = getRegistry()?.byId.get(keyid);
+  if (!entry) {
+    throw new Error(
+      `secretCrypto: no key for id "${keyid}" — is ${PRIMARY_KEY_ENV} set to the right value?`,
+    );
+  }
+  const payload = Buffer.from(payloadB64, 'base64url');
+  if (payload.length < IV_BYTES + TAG_BYTES) throw new Error('secretCrypto: truncated envelope');
+  const iv = payload.subarray(0, IV_BYTES);
+  const tag = payload.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
+  const ct = payload.subarray(IV_BYTES + TAG_BYTES);
+  try {
+    const decipher = createDecipheriv(ALGORITHM, entry.key, iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8');
+  } catch (err) {
+    throw new Error(
+      `secretCrypto: failed to decrypt (wrong key or tampered ciphertext): ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+}

--- a/server/utils/secretCrypto.ts
+++ b/server/utils/secretCrypto.ts
@@ -33,7 +33,16 @@ const ALGORITHM = 'aes-256-gcm';
 const KEY_BYTES = 32;
 const IV_BYTES = 12;
 const TAG_BYTES = 16;
+const KEYID_HEX_LEN = 8; // length of the keyid (sha256(key) prefix) in the envelope
 const PRIMARY_KEY_ENV = 'LURKER_SECRET_KEY';
+
+// The full envelope shape: lk1.<8-hex-keyid>.<base64url>. Matching the whole
+// shape — not just the `lk1.` prefix — means a legitimate plaintext secret that
+// merely starts with "lk1." isn't misclassified as ciphertext (which would make
+// encryptSecret skip wrapping it and decryptSecret throw on read).
+const ENVELOPE_RE = new RegExp(
+  `^${ENVELOPE_PREFIX}\\.[0-9a-f]{${KEYID_HEX_LEN}}\\.[A-Za-z0-9_-]+$`,
+);
 
 interface KeyEntry {
   keyid: string;
@@ -64,12 +73,15 @@ function decodeKey(raw: string): Buffer {
 }
 
 function fingerprint(key: Buffer): string {
-  return createHash('sha256').update(key).digest('hex').slice(0, 8);
+  return createHash('sha256').update(key).digest('hex').slice(0, KEYID_HEX_LEN);
 }
 
 // Built once, lazily, from the environment. `primary` is the key new writes are
-// encrypted under; `byId` also carries any retired keys (future rotation) so
-// existing ciphertext stays readable. null when no key is configured.
+// encrypted under, and `byId` indexes keys by keyid for decryption. Today only
+// the single LURKER_SECRET_KEY is loaded, so changing it makes existing
+// ciphertext undecryptable; the envelope carries a keyid purely so multi-key
+// rotation (load retired keys into byId here, re-wrap on next write) can be ADDED
+// later without a format change. null when no key is configured.
 let registry: Registry | null = null;
 let registryBuilt = false;
 
@@ -102,7 +114,7 @@ export function hasSecretKey(): boolean {
 
 /** True if `value` is one of our encrypted envelopes (vs legacy plaintext). */
 export function isEncrypted(value: string | null | undefined): boolean {
-  return typeof value === 'string' && value.startsWith(`${ENVELOPE_PREFIX}.`);
+  return typeof value === 'string' && ENVELOPE_RE.test(value);
 }
 
 // Encrypt a single secret for storage. null / empty-string pass through


### PR DESCRIPTION
Closes amiantos/lurker-control-plane#9 (D3, M2 security track).

## Why
Hosted cells continuously replicate their SQLite to R2 via Litestream (B8), so the IRC network secrets stored in the `networks` table were exposed as **cleartext** in any leaked/misconfigured backup. Fine for self-host (trusted box); the backup vector is what this closes — before beta users store real passwords.

Encrypted columns: `server_password`, `sasl_account`, `sasl_password`, and **`connect_commands`** (it routinely carries `/msg NickServ identify <password>` / oper passwords — IRCCloud encrypts it for the same reason).

## How
- **AES-256-GCM** under a key held in the cell's environment (`LURKER_SECRET_KEY`), **not** in the DB, so the replicated file holds only ciphertext.
- Self-describing envelope `lk1.<keyid>.<base64url(iv|tag|ct)>` — **no schema column or migration**; `keyid = sha256(key)[:8]` so key rotation stays additive.
- **Key presence is the toggle:** present → encrypt; absent (every self-host) → plaintext, zero behavior change. A set-but-malformed key **fails loud at boot** rather than silently downgrading to plaintext.
- **Transparent chokepoint** in `server/db/networks.ts`: encrypt on create/update, decrypt on `getNetwork`/`listNetworksForUser`, so the rest of the app and the IRC connect path always see plaintext. No route/UX change (`routes/networks.ts` still strips passwords; `connect_commands`/`sasl_account` are still round-tripped to the client, now decrypted).
- The two **raw-SQL bypass paths**: export **decrypts** (portable plaintext export, same as today — restorable on a self-host), import **re-encrypts** when a key is present.
- `backfillEncryptNetworkSecrets()` wraps any pre-existing plaintext rows once a key is configured — idempotent (the `lk1.` prefix is the guard), called once from server boot after the schema is ready and before IRC connects.

## Honest scope
Defends backups / disk snapshots / DB dumps. Does **not** defend a live RCE on the cell — the running app must decrypt to use a secret. Policy may say "encrypted at rest (service-decryptable to use)"; never "we can't read it".

## Tests
`secretCrypto.test.ts` (round-trip, random IV, null/empty passthrough, legacy-plaintext passthrough, tamper → throws, unknown keyid, malformed key); `networkSecrets.test.ts` (ciphertext at rest vs decrypted accessor reads, update re-encrypts / clears to null, backfill wraps + idempotent); `networks.test.ts` (no-key plaintext regression); `networkSecretsRoundtrip.test.ts` (export carries plaintext, import re-encrypts end to end). Full suite green (**743**), typecheck + oxlint + oxfmt clean.

## Follow-up (not in this PR)
Once merged, flip the `lurker-marketing` privacy/FAQ wording from "not encrypted at rest" to "encrypted at rest (service-decryptable to use)" — pushing marketing deploys it live, so it must not claim the property before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)