### PR TITLE
Node uploads: reject SVG, thumbnails to R2, moderation reporting + takedown

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -240,6 +240,7 @@ export const EXPORT_TABLES = Object.freeze({
       'height',
       'thumbnail',
       'thumbnail_url',
+      'synced_to_cp',
       'created_at',
     ],
   },

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -241,6 +241,7 @@ export const EXPORT_TABLES = Object.freeze({
       'thumbnail',
       'thumbnail_url',
       'synced_to_cp',
+      'removed',
       'created_at',
     ],
   },

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -226,6 +226,7 @@ export const EXPORT_TABLES = Object.freeze({
     fkRekey: { user_id: 'users' },
     // thumbnail BLOB is written to thumbnails/<id>.jpg in the zip rather than
     // base64-inlined; the row carries a hasThumbnail boolean in data.json.
+    // thumbnail_url (node edition) is a plain string column carried as-is.
     blobColumns: ['thumbnail'],
     columns: [
       'id',
@@ -238,6 +239,7 @@ export const EXPORT_TABLES = Object.freeze({
       'width',
       'height',
       'thumbnail',
+      'thumbnail_url',
       'created_at',
     ],
   },

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -218,7 +218,12 @@ export const EXPORT_TABLES = Object.freeze({
   },
 
   upload_history: {
-    mode: 'export',
+    // 'partial': synced_to_cp and removed are operational/instance-local state
+    // (see skippedColumns), so they're left out of the portable contract —
+    // which also keeps imports of older archives working: both are
+    // INTEGER NOT NULL, and since they're not in the INSERT the DB default (0)
+    // applies rather than a NULL that would fail the constraint.
+    mode: 'partial',
     scope: 'user_id',
     section: 'data',
     pk: 'id',
@@ -240,10 +245,12 @@ export const EXPORT_TABLES = Object.freeze({
       'height',
       'thumbnail',
       'thumbnail_url',
-      'synced_to_cp',
-      'removed',
       'created_at',
     ],
+    skippedColumns: {
+      synced_to_cp: 'operational: cell↔control-plane moderation-sync bookkeeping, not portable',
+      removed: 'instance/CP-owned moderation state; a fresh instance starts it at the default 0',
+    },
   },
 
   pinned_buffers: {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -547,6 +547,12 @@ ensureColumn('buffer_reads', 'cleared_at', 'TEXT');
 // to serving the BLOB via /api/uploads/:id/thumb.
 ensureColumn('upload_history', 'thumbnail_url', 'TEXT');
 
+// Node edition reports each upload to the control plane's moderation index. This
+// flag tracks whether that report landed; a periodic flush retries rows still at
+// 0 so a CP outage never silently drops a record. Standalone leaves it at 0 and
+// never reads it — the flush is node-gated, so it has no effect there.
+ensureColumn('upload_history', 'synced_to_cp', 'INTEGER NOT NULL DEFAULT 0');
+
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -553,6 +553,11 @@ ensureColumn('upload_history', 'thumbnail_url', 'TEXT');
 // never reads it — the flush is node-gated, so it has no effect there.
 ensureColumn('upload_history', 'synced_to_cp', 'INTEGER NOT NULL DEFAULT 0');
 
+// Set when the control plane takes the upload down for moderation. The row stays
+// (so the owner sees a "removed by moderation" tombstone instead of a dead
+// image), but the bytes are gone from storage. Standalone never sets it.
+ensureColumn('upload_history', 'removed', 'INTEGER NOT NULL DEFAULT 0');
+
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -540,6 +540,13 @@ ensureColumn('messages', 'from_ignored', 'INTEGER NOT NULL DEFAULT 0');
 ensureColumn('buffer_reads', 'cleared_before_message_id', 'INTEGER');
 ensureColumn('buffer_reads', 'cleared_at', 'TEXT');
 
+// Node-edition uploads store the thumbnail as a remote CDN object under a
+// `thumbs/` prefix instead of an inline BLOB, so it doesn't bloat the cell DB
+// (and every D3 R2 backup snapshot). Standalone leaves this NULL and keeps the
+// BLOB. When set, it's the public thumbnail URL; when NULL, the API falls back
+// to serving the BLOB via /api/uploads/:id/thumb.
+ensureColumn('upload_history', 'thumbnail_url', 'TEXT');
+
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.

--- a/server/db/uploadHistory.ts
+++ b/server/db/uploadHistory.ts
@@ -36,6 +36,9 @@ export interface UploadListRow {
   created_at: string;
   has_thumbnail: number;
   thumbnail_url: string | null;
+  // 1 once the control plane has moderated the upload away. The row stays so the
+  // owner sees a tombstone, but its bytes are gone from storage.
+  removed: number;
 }
 
 /** Fields passed to insertUpload. */
@@ -87,7 +90,7 @@ export function listUploads(
       .prepare(
         `
       SELECT id, provider, url, filename, mime, byte_size, width, height, created_at,
-             thumbnail_url, (thumbnail IS NOT NULL) AS has_thumbnail
+             thumbnail_url, removed, (thumbnail IS NOT NULL) AS has_thumbnail
       FROM upload_history
       WHERE user_id = ? AND id < ?
       ORDER BY id DESC
@@ -100,7 +103,7 @@ export function listUploads(
     .prepare(
       `
     SELECT id, provider, url, filename, mime, byte_size, width, height, created_at,
-           thumbnail_url, (thumbnail IS NOT NULL) AS has_thumbnail
+           thumbnail_url, removed, (thumbnail IS NOT NULL) AS has_thumbnail
     FROM upload_history
     WHERE user_id = ?
     ORDER BY id DESC
@@ -162,4 +165,16 @@ export function listUnsyncedUploads(limit = 50): UnsyncedUploadRow[] {
 
 export function markUploadSynced(id: number): void {
   db.prepare('UPDATE upload_history SET synced_to_cp = 1 WHERE id = ?').run(Number(id));
+}
+
+// Control-plane-driven moderation takedown, addressed by the cell's own upload
+// id (what the cell reported as cell_upload_id). Flips the row to `removed` and
+// drops any inline thumbnail BLOB so the bytes are gone locally too — the row
+// stays as a tombstone. Not user-scoped: this is a privileged node-API action,
+// never a tenant request. Idempotent; returns whether a row matched.
+export function markUploadRemovedById(id: number): boolean {
+  const info = db
+    .prepare('UPDATE upload_history SET removed = 1, thumbnail = NULL WHERE id = ?')
+    .run(Number(id));
+  return info.changes > 0;
 }

--- a/server/db/uploadHistory.ts
+++ b/server/db/uploadHistory.ts
@@ -131,3 +131,35 @@ export function deleteUpload(userId: number, id: number): boolean {
     .run(userId, Number(id));
   return info.changes > 0;
 }
+
+/** A row the moderation reporter still needs to push to the control plane. */
+export interface UnsyncedUploadRow {
+  id: number;
+  user_id: number;
+  url: string;
+  thumbnail_url: string | null;
+  mime: string;
+  byte_size: number;
+  width: number | null;
+  height: number | null;
+}
+
+// Node-edition rows not yet acknowledged by the control plane's moderation
+// index. Drained by the periodic flush so a CP outage at upload time is
+// eventually reconciled rather than losing the record. Oldest first.
+export function listUnsyncedUploads(limit = 50): UnsyncedUploadRow[] {
+  const lim = Math.max(1, Math.min(500, Number(limit) || 50));
+  return db
+    .prepare(
+      `SELECT id, user_id, url, thumbnail_url, mime, byte_size, width, height
+       FROM upload_history
+       WHERE synced_to_cp = 0
+       ORDER BY id ASC
+       LIMIT ?`,
+    )
+    .all(lim) as UnsyncedUploadRow[];
+}
+
+export function markUploadSynced(id: number): void {
+  db.prepare('UPDATE upload_history SET synced_to_cp = 1 WHERE id = ?').run(Number(id));
+}

--- a/server/db/uploadHistory.ts
+++ b/server/db/uploadHistory.ts
@@ -15,10 +15,15 @@ export interface UploadHistoryRow {
   width: number | null;
   height: number | null;
   thumbnail: Buffer | null;
+  thumbnail_url: string | null;
   created_at: string;
 }
 
-/** List row shape — omits the thumbnail blob, adds has_thumbnail flag. */
+/**
+ * List row shape — omits the thumbnail blob, adds has_thumbnail flag. Carries
+ * thumbnail_url so the API can prefer a remote CDN thumbnail (node edition) over
+ * the local BLOB-serving route.
+ */
 export interface UploadListRow {
   id: number;
   provider: string;
@@ -30,6 +35,7 @@ export interface UploadListRow {
   height: number | null;
   created_at: string;
   has_thumbnail: number;
+  thumbnail_url: string | null;
 }
 
 /** Fields passed to insertUpload. */
@@ -41,13 +47,16 @@ export interface InsertUploadFields {
   byte_size: number;
   width?: number | null;
   height?: number | null;
+  // Exactly one of thumbnail (inline BLOB, standalone) or thumbnail_url (remote
+  // CDN object, node edition) is set; both null for thumbnail-less uploads (txt).
   thumbnail: Buffer | null;
+  thumbnail_url?: string | null;
 }
 
 const insertStmt = db.prepare(`
   INSERT INTO upload_history
-    (user_id, provider, url, filename, mime, byte_size, width, height, thumbnail)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    (user_id, provider, url, filename, mime, byte_size, width, height, thumbnail, thumbnail_url)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 export function insertUpload(userId: number, row: InsertUploadFields): number {
@@ -61,6 +70,7 @@ export function insertUpload(userId: number, row: InsertUploadFields): number {
     row.width ?? null,
     row.height ?? null,
     row.thumbnail,
+    row.thumbnail_url ?? null,
   );
   return Number(info.lastInsertRowid);
 }
@@ -77,7 +87,7 @@ export function listUploads(
       .prepare(
         `
       SELECT id, provider, url, filename, mime, byte_size, width, height, created_at,
-             (thumbnail IS NOT NULL) AS has_thumbnail
+             thumbnail_url, (thumbnail IS NOT NULL) AS has_thumbnail
       FROM upload_history
       WHERE user_id = ? AND id < ?
       ORDER BY id DESC
@@ -90,7 +100,7 @@ export function listUploads(
     .prepare(
       `
     SELECT id, provider, url, filename, mime, byte_size, width, height, created_at,
-           (thumbnail IS NOT NULL) AS has_thumbnail
+           thumbnail_url, (thumbnail IS NOT NULL) AS has_thumbnail
     FROM upload_history
     WHERE user_id = ?
     ORDER BY id DESC

--- a/server/routes/node.test.ts
+++ b/server/routes/node.test.ts
@@ -263,3 +263,62 @@ describe('node control API — pause/resume', () => {
     expect(res.status).toBe(401);
   });
 });
+
+describe('node control API — upload takedown', () => {
+  it('flips an upload to removed and drops its inline thumbnail', async () => {
+    const { insertUpload, listUploads, getThumbnail } = await import('../db/uploadHistory.js');
+    const user = createUser('takedown-owner');
+    const uploadId = insertUpload(user.id, {
+      provider: 'hoarder',
+      url: 'https://cdn.test/x.jpg',
+      filename: 'x.png',
+      mime: 'image/jpeg',
+      byte_size: 100,
+      width: 10,
+      height: 10,
+      thumbnail: Buffer.from([1, 2, 3]),
+    });
+
+    const res = await createAnonAgent(app)
+      .post(`/api/node/uploads/${uploadId}/takedown`)
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(200);
+
+    const row = listUploads(user.id).find((r) => r.id === uploadId)!;
+    expect(row.removed).toBe(1);
+    // Bytes gone: the inline thumbnail BLOB was cleared.
+    expect(getThumbnail(user.id, uploadId)?.thumbnail).toBeNull();
+  });
+
+  it('is idempotent — re-takedown still 200', async () => {
+    const { insertUpload } = await import('../db/uploadHistory.js');
+    const user = createUser('takedown-twice');
+    const uploadId = insertUpload(user.id, {
+      provider: 'hoarder',
+      url: 'https://cdn.test/y.jpg',
+      mime: 'image/jpeg',
+      byte_size: 1,
+      thumbnail: null,
+    });
+    const first = await createAnonAgent(app)
+      .post(`/api/node/uploads/${uploadId}/takedown`)
+      .set('Authorization', AUTH);
+    const second = await createAnonAgent(app)
+      .post(`/api/node/uploads/${uploadId}/takedown`)
+      .set('Authorization', AUTH);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+  });
+
+  it('404 for an unknown upload id', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/node/uploads/999999/takedown')
+      .set('Authorization', AUTH);
+    expect(res.status).toBe(404);
+  });
+
+  it('requires the node secret', async () => {
+    const res = await createAnonAgent(app).post('/api/node/uploads/1/takedown');
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/routes/node.ts
+++ b/server/routes/node.ts
@@ -15,6 +15,7 @@ import {
   findUserByUsername,
   setUserPaused,
 } from '../db/users.js';
+import { markUploadRemovedById } from '../db/uploadHistory.js';
 import ircManager from '../services/ircManager.js';
 import { sign as signCookie } from 'cookie-signature';
 import { createSession } from '../db/sessions.js';
@@ -186,6 +187,24 @@ router.post('/users/:id/resume', (req: Request, res: Response) => {
   }
   setUserPaused(id, false);
   ircManager.resumeUser(id);
+  res.json({ ok: true });
+});
+
+// Moderation takedown: the control plane has removed an upload's object from
+// storage and tells the cell to tombstone the owner's history row (flip it to
+// `removed`, drop any inline thumbnail). `:id` is the cell's own upload_history
+// id. Idempotent; a missing row is a 404 the CP treats as success (nothing to
+// tombstone), mirroring the pause/deprovision endpoints.
+router.post('/uploads/:id/takedown', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  if (!markUploadRemovedById(id)) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
   res.json({ ok: true });
 });
 

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -28,12 +28,26 @@ const stub = {
   id: 'stub',
   requiresSecrets: false,
   capturedSecrets: null as Record<string, string> | null,
+  // Lets a test simulate the remote thumbnail upload failing so we can assert
+  // the BLOB fallback. Reset per-test by the specs that touch it.
+  thumbShouldThrow: false,
+  // Records the `kind` of every upload call in a request (undefined for the
+  // full image, 'thumb' for the thumbnail) so we can prove the thumb is sent
+  // as its own object flagged kind=thumb.
+  lastKinds: [] as (string | undefined)[],
   async upload(
     _buffer: Buffer,
-    meta: { filename: string; mime: string },
+    meta: { filename: string; mime: string; kind?: string },
     secrets?: Record<string, string>,
   ) {
     stub.capturedSecrets = secrets ?? null;
+    stub.lastKinds.push(meta.kind);
+    if (meta.kind === 'thumb') {
+      if (stub.thumbShouldThrow) {
+        throw Object.assign(new Error('thumb store down'), { code: 'PROVIDER_ERROR' });
+      }
+      return { url: `https://stub.example/thumbs/${meta.filename}` };
+    }
     return { url: `https://stub.example/${meta.filename}` };
   },
 };
@@ -49,9 +63,11 @@ vi.mock('../services/uploadProviders/index.js', () => ({
 // Mock the sharp pipeline so we can capture the maxDim/quality the route passes
 // it (the real pipeline runs in uploads.test.ts). Lets us assert those come
 // from the operator env, not the tenant's settings.
-const pipelineCapture = { opts: null as { maxDim: number; quality: number } | null };
+const pipelineCapture = {
+  opts: null as { maxDim: number; quality: number; rasterOnly?: boolean } | null,
+};
 vi.mock('../services/imagePipeline.js', () => ({
-  optimize: async (_buf: Buffer, opts: { maxDim: number; quality: number }) => {
+  optimize: async (_buf: Buffer, opts: { maxDim: number; quality: number; rasterOnly?: boolean }) => {
     pipelineCapture.opts = opts;
     return {
       buffer: Buffer.from('x'),
@@ -62,7 +78,9 @@ vi.mock('../services/imagePipeline.js', () => ({
       height: 10,
     };
   },
-  thumbnail: async () => null,
+  // A non-empty buffer so the route exercises the (node-edition) remote thumb
+  // upload + BLOB-fallback paths.
+  thumbnail: async () => Buffer.from('fake-jpeg-thumb-bytes'),
 }));
 
 let app: Express;
@@ -160,7 +178,50 @@ describe('POST /api/uploads (node edition)', () => {
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'dims.png', contentType: 'image/png' });
     expect(res.status).toBe(200);
-    // Operator env (512 / 40), not the tenant's 8192 / 100.
-    expect(pipelineCapture.opts).toEqual({ maxDim: 512, quality: 40 });
+    // Operator env (512 / 40), not the tenant's 8192 / 100. rasterOnly is on in
+    // node edition (raster + .txt only; SVG rejected).
+    expect(pipelineCapture.opts).toEqual({ maxDim: 512, quality: 40, rasterOnly: true });
+  });
+
+  it('stores the thumbnail as a remote thumbs/ object, not an inline BLOB', async () => {
+    stub.thumbShouldThrow = false;
+    stub.lastKinds = [];
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'thumbed.png', contentType: 'image/png' });
+    expect(res.status).toBe(200);
+    // The POST response advertises the remote thumbnail immediately so the
+    // client never round-trips through the cell for it.
+    expect(res.body.thumbnail_url).toMatch(/^https:\/\/stub\.example\/thumbs\//);
+    // The thumb went up as its own object flagged kind=thumb.
+    expect(stub.lastKinds).toContain('thumb');
+
+    const list = await agent.get('/api/uploads');
+    const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
+    expect(row.thumbnail_url).toMatch(/^https:\/\/stub\.example\/thumbs\//);
+    // No inline BLOB was stored, so the local thumb route has nothing to serve.
+    const thumbRes = await agent.get(`/api/uploads/${res.body.id}/thumb`);
+    expect(thumbRes.status).toBe(404);
+  });
+
+  it('falls back to an inline BLOB when the remote thumb upload fails', async () => {
+    stub.thumbShouldThrow = true;
+    stub.lastKinds = [];
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'fallback.png', contentType: 'image/png' });
+    expect(res.status).toBe(200);
+    // A thumb hiccup must never block the user's upload, and no remote
+    // thumbnail is advertised.
+    expect(res.body.thumbnail_url).toBeUndefined();
+    stub.thumbShouldThrow = false;
+
+    const list = await agent.get('/api/uploads');
+    const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
+    // GET falls back to the local BLOB-serving route, which now serves bytes.
+    expect(row.thumbnail_url).toBe(`/api/uploads/${res.body.id}/thumb`);
+    const thumbRes = await agent.get(`/api/uploads/${res.body.id}/thumb`);
+    expect(thumbRes.status).toBe(200);
+    expect(thumbRes.headers['content-type']).toBe('image/jpeg');
   });
 });

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -67,7 +67,10 @@ const pipelineCapture = {
   opts: null as { maxDim: number; quality: number; rasterOnly?: boolean } | null,
 };
 vi.mock('../services/imagePipeline.js', () => ({
-  optimize: async (_buf: Buffer, opts: { maxDim: number; quality: number; rasterOnly?: boolean }) => {
+  optimize: async (
+    _buf: Buffer,
+    opts: { maxDim: number; quality: number; rasterOnly?: boolean },
+  ) => {
     pipelineCapture.opts = opts;
     return {
       buffer: Buffer.from('x'),

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -224,7 +224,11 @@ router.get('/', (req: Request, res: Response) => {
   const rows: UploadListRow[] = listUploads(req.user!.id, { before, limit });
   res.json({
     items: rows.map((r) => {
-      const { has_thumbnail, thumbnail_url, ...rest } = r;
+      const { has_thumbnail, thumbnail_url, removed, ...rest } = r;
+      // A moderated-away upload keeps its row as a tombstone, but its bytes are
+      // gone (remote object deleted, BLOB cleared) — advertise no thumbnail so
+      // the client renders the tombstone instead of chasing a dead URL.
+      if (removed) return { ...rest, removed: true };
       // Prefer a remote CDN thumbnail (node edition); otherwise fall back to the
       // local BLOB-serving route when an inline thumbnail exists.
       const thumb = thumbnail_url || (has_thumbnail ? `/api/uploads/${r.id}/thumb` : null);

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -19,6 +19,7 @@ import type { UploadListRow } from '../db/uploadHistory.js';
 import { insertUpload, listUploads, getThumbnail, deleteUpload } from '../db/uploadHistory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { isNodeMode } from '../utils/edition.js';
+import { reportUploadSoon } from '../services/moderationReport.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -193,6 +194,22 @@ router.post(
         thumbnail: thumbnailBlob,
         thumbnail_url: thumbnailUrl,
       });
+
+      // Node edition: report the upload to the control plane's moderation index.
+      // Fire-and-forget — never blocks the response; the flush reconciles if the
+      // CP is unreachable. No-op in standalone.
+      if (isNodeMode()) {
+        reportUploadSoon({
+          cell_upload_id: id,
+          cell_user_id: req.user!.id,
+          url: result.url,
+          thumb_url: thumbnailUrl,
+          mime: outMime,
+          byte_size: outByteSize,
+          width: outWidth,
+          height: outHeight,
+        });
+      }
 
       res.json({ id, url: result.url, ...(thumbnailUrl ? { thumbnail_url: thumbnailUrl } : {}) });
     } catch (err) {

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -111,6 +111,10 @@ router.post(
               ? limits.maxDim
               : Number(settings['uploads.image.max_dimension']) || 2048,
             quality: limits ? limits.quality : Number(settings['uploads.image.quality']) || 85,
+            // Hosted service is raster images + .txt only — reject SVG (the one
+            // non-raster format sharp would otherwise pass through). Standalone
+            // keeps SVG passthrough.
+            rasterOnly: isNodeMode(),
           });
         } catch (err) {
           const e = err as { code?: string; message?: string };
@@ -155,6 +159,29 @@ router.post(
         return;
       }
 
+      // In node edition the thumbnail goes to remote storage (a `thumbs/` prefix
+      // on the in-house dropper) instead of an inline BLOB, so it doesn't bloat
+      // the cell DB / R2 backups and is served straight from the CDN. Best-effort:
+      // a thumb-upload failure falls back to storing the BLOB (standalone path),
+      // so a hiccup never blocks the user's upload.
+      let thumbnailBlob: Buffer | null = thumb;
+      let thumbnailUrl: string | null = null;
+      if (isNodeMode() && thumb) {
+        try {
+          const tRes = await provider.upload(
+            thumb,
+            { filename: 'thumb.jpg', mime: 'image/jpeg', kind: 'thumb' },
+            secrets,
+          );
+          if (tRes && typeof tRes.url === 'string') {
+            thumbnailUrl = tRes.url;
+            thumbnailBlob = null;
+          }
+        } catch {
+          // keep thumbnailBlob — fall back to the inline BLOB
+        }
+      }
+
       const id = insertUpload(req.user!.id, {
         provider: providerId,
         url: result.url,
@@ -163,10 +190,11 @@ router.post(
         byte_size: outByteSize,
         width: outWidth,
         height: outHeight,
-        thumbnail: thumb,
+        thumbnail: thumbnailBlob,
+        thumbnail_url: thumbnailUrl,
       });
 
-      res.json({ id, url: result.url });
+      res.json({ id, url: result.url, ...(thumbnailUrl ? { thumbnail_url: thumbnailUrl } : {}) });
     } catch (err) {
       next(err);
     }
@@ -179,8 +207,11 @@ router.get('/', (req: Request, res: Response) => {
   const rows: UploadListRow[] = listUploads(req.user!.id, { before, limit });
   res.json({
     items: rows.map((r) => {
-      const { has_thumbnail, ...rest } = r;
-      return has_thumbnail ? { ...rest, thumbnail_url: `/api/uploads/${r.id}/thumb` } : rest;
+      const { has_thumbnail, thumbnail_url, ...rest } = r;
+      // Prefer a remote CDN thumbnail (node edition); otherwise fall back to the
+      // local BLOB-serving route when an inline thumbnail exists.
+      const thumb = thumbnail_url || (has_thumbnail ? `/api/uploads/${r.id}/thumb` : null);
+      return thumb ? { ...rest, thumbnail_url: thumb } : rest;
     }),
     providers: providerIds,
   });
@@ -188,7 +219,9 @@ router.get('/', (req: Request, res: Response) => {
 
 router.get('/:id/thumb', (req: Request, res: Response) => {
   const row = getThumbnail(req.user!.id, Number(req.params.id));
-  if (!row) {
+  // No inline BLOB → nothing to serve here. Node-edition uploads keep their
+  // thumbnail as a remote CDN object (thumbnail_url) the client uses directly.
+  if (!row || !row.thumbnail) {
     res.status(404).json({ error: 'not found' });
     return;
   }

--- a/server/server.ts
+++ b/server/server.ts
@@ -16,6 +16,10 @@ import { backfillEncryptNetworkSecrets } from './db/networks.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
+import {
+  startModerationReporter,
+  stopModerationReporter,
+} from './services/moderationReport.js';
 import { startIdentd, stopIdentd, isIdentdEnabled, identdPort } from './services/identd.js';
 
 const PORT = Number(process.env.PORT || 8010);
@@ -72,6 +76,10 @@ ircManager.initAll();
 // heartbeat on an interval). No-op in standalone or when unconfigured.
 startOrchestratorClient();
 
+// In node edition, periodically reconcile any upload moderation records that
+// didn't reach the control plane at upload time. No-op in standalone.
+startModerationReporter();
+
 server.listen(PORT, () => {
   console.log(`[lurker] listening on http://localhost:${PORT}`);
   systemLog.log({ scope: 'server', text: `Listening on port ${PORT}` });
@@ -81,6 +89,7 @@ function shutdown(signal: string): void {
   console.log(`[lurker] received ${signal}, shutting down`);
   systemLog.log({ scope: 'server', level: 'warn', text: `Received ${signal}, shutting down` });
   stopOrchestratorClient();
+  stopModerationReporter();
   stopIdentd();
   ircManager.shutdown();
   server.close(() => process.exit(0));

--- a/server/server.ts
+++ b/server/server.ts
@@ -16,10 +16,7 @@ import { backfillEncryptNetworkSecrets } from './db/networks.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
-import {
-  startModerationReporter,
-  stopModerationReporter,
-} from './services/moderationReport.js';
+import { startModerationReporter, stopModerationReporter } from './services/moderationReport.js';
 import { startIdentd, stopIdentd, isIdentdEnabled, identdPort } from './services/identd.js';
 
 const PORT = Number(process.env.PORT || 8010);

--- a/server/services/imagePipeline.test.ts
+++ b/server/services/imagePipeline.test.ts
@@ -73,6 +73,25 @@ describe('imagePipeline.optimize', () => {
       code: 'UNSUPPORTED_FORMAT',
     });
   });
+
+  it('passes SVG through unchanged in standalone (rasterOnly off)', async () => {
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>',
+    );
+    const out = await optimize(svg, { maxDim: 1024, quality: 80 });
+    expect(out.mime).toBe('image/svg+xml');
+    expect(out.ext).toBe('svg');
+    expect(Buffer.compare(out.buffer, svg)).toBe(0);
+  });
+
+  it('rejects SVG with UNSUPPORTED_FORMAT when rasterOnly (node edition)', async () => {
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>',
+    );
+    await expect(
+      optimize(svg, { maxDim: 1024, quality: 80, rasterOnly: true }),
+    ).rejects.toMatchObject({ code: 'UNSUPPORTED_FORMAT' });
+  });
 });
 
 describe('imagePipeline.thumbnail', () => {

--- a/server/services/imagePipeline.ts
+++ b/server/services/imagePipeline.ts
@@ -45,7 +45,7 @@ export function extensionFor(mime: string, fallback = 'bin'): string {
 // WebP / APNG don't lose animation on the way through Lurker.
 export async function optimize(
   buffer: Buffer,
-  { maxDim, quality }: { maxDim: number; quality: number },
+  { maxDim, quality, rasterOnly = false }: { maxDim: number; quality: number; rasterOnly?: boolean },
 ): Promise<OptimizeResult> {
   let meta: sharp.Metadata;
   try {
@@ -82,6 +82,15 @@ export async function optimize(
   // SVG is a static vector — we pass it through unchanged. sharp can rasterize
   // it but doing so silently strips interactivity and inflates the byte size.
   if (meta.format === 'svg') {
+    // The hosted (node) service stores raster images + .txt only: serving a
+    // user-uploaded SVG from the operator's CDN domain is a stored-XSS / abuse
+    // vector. Reject via the same UNSUPPORTED_FORMAT path the route already maps
+    // to a 415. Standalone keeps the passthrough below.
+    if (rasterOnly) {
+      const err = new Error('SVG uploads are not supported') as Error & { code: string };
+      err.code = 'UNSUPPORTED_FORMAT';
+      throw err;
+    }
     return {
       buffer,
       mime: fmt.mime,

--- a/server/services/imagePipeline.ts
+++ b/server/services/imagePipeline.ts
@@ -45,7 +45,11 @@ export function extensionFor(mime: string, fallback = 'bin'): string {
 // WebP / APNG don't lose animation on the way through Lurker.
 export async function optimize(
   buffer: Buffer,
-  { maxDim, quality, rasterOnly = false }: { maxDim: number; quality: number; rasterOnly?: boolean },
+  {
+    maxDim,
+    quality,
+    rasterOnly = false,
+  }: { maxDim: number; quality: number; rasterOnly?: boolean },
 ): Promise<OptimizeResult> {
   let meta: sharp.Metadata;
   try {

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -198,13 +198,23 @@ describe('importFromZipBuffer — roundtrip', () => {
 
     const bobUploads = db
       .prepare('SELECT * FROM upload_history WHERE user_id = ?')
-      .all(bob.id) as Array<{ url: string; thumbnail: Buffer | null }>;
+      .all(bob.id) as Array<{
+      url: string;
+      thumbnail: Buffer | null;
+      synced_to_cp: number;
+      removed: number;
+    }>;
     expect(bobUploads.length).toBe(1);
     expect(bobUploads[0].url).toBe('https://example.com/foo.jpg');
     // Thumbnail blob was re-attached from the zip entry.
     expect(bobUploads[0].thumbnail).not.toBeNull();
     expect(Buffer.from(bobUploads[0].thumbnail!).length).toBeGreaterThan(0);
     expect(result.thumbnailsAttached).toBe(1);
+    // synced_to_cp and removed are operational state left out of the portable
+    // contract, so the imported row gets the schema defaults (0) — not a NULL
+    // that would fail the NOT NULL constraint (the old-archive import hazard).
+    expect(bobUploads[0].synced_to_cp).toBe(0);
+    expect(bobUploads[0].removed).toBe(0);
   });
 
   it('refuses to import into a non-empty account', async () => {

--- a/server/services/moderationReport.test.ts
+++ b/server/services/moderationReport.test.ts
@@ -125,8 +125,10 @@ describe('reportUploadSoon', () => {
       width: null,
       height: null,
     });
-    // Fire-and-forget — let the resolved-promise microtask settle.
-    await new Promise((r) => setTimeout(r, 20));
-    expect(listUnsyncedUploads(500).some((r) => r.id === id)).toBe(false);
+    // Fire-and-forget — poll until the inline report has marked the row synced
+    // (deterministic; no fixed sleep that could flake on a loaded CI).
+    await vi.waitFor(() => {
+      expect(listUnsyncedUploads(500).some((r) => r.id === id)).toBe(false);
+    });
   });
 });

--- a/server/services/moderationReport.test.ts
+++ b/server/services/moderationReport.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+// Node edition + orchestrator config before importing the module under test.
+process.env.LURKER_EDITION = 'node';
+process.env.LURKER_NODE_SECRET = 'fleet-secret';
+process.env.LURKER_ORCHESTRATOR_URL = 'http://orchestrator:8020';
+process.env.LURKER_NODE_NAME = 'cell-test';
+
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('moderation-report');
+
+type FetchMock = (...args: unknown[]) => Promise<{ ok: boolean }>;
+
+let mod: typeof import('./moderationReport.js');
+let insertUpload: typeof import('../db/uploadHistory.js').insertUpload;
+let listUnsyncedUploads: typeof import('../db/uploadHistory.js').listUnsyncedUploads;
+let userId: number;
+
+function seedUpload(uploadId: string): number {
+  return insertUpload(userId, {
+    provider: 'hoarder',
+    url: `https://cdn.test/${uploadId}.jpg`,
+    filename: `${uploadId}.png`,
+    mime: 'image/jpeg',
+    byte_size: 1000,
+    width: 100,
+    height: 100,
+    thumbnail: null,
+    thumbnail_url: `https://cdn.test/thumbs/${uploadId}.jpg`,
+  });
+}
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  mod = await import('./moderationReport.js');
+  ({ insertUpload, listUnsyncedUploads } = await import('../db/uploadHistory.js'));
+  userId = createUser('mod-reporter-alice').id;
+});
+
+afterAll(() => {
+  ctx.cleanup();
+  vi.unstubAllGlobals();
+  delete process.env.LURKER_EDITION;
+});
+
+describe('reportUpload', () => {
+  it('posts to /_cp/moderation/uploads with the bearer + cell-stamped body', async () => {
+    const fetchMock = vi.fn<FetchMock>().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    const ok = await mod.reportUpload({
+      cell_upload_id: 42,
+      cell_user_id: userId,
+      url: 'https://cdn.test/x.jpg',
+      thumb_url: 'https://cdn.test/thumbs/x.jpg',
+      mime: 'image/jpeg',
+      byte_size: 1234,
+      width: 800,
+      height: 600,
+    });
+    expect(ok).toBe(true);
+    const [url, opts] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string>; body: string }];
+    expect(url).toBe('http://orchestrator:8020/_cp/moderation/uploads');
+    expect(opts.headers.Authorization).toBe('Bearer fleet-secret');
+    const body = JSON.parse(opts.body);
+    expect(body).toMatchObject({ cell: 'cell-test', cell_upload_id: 42, cell_user_id: userId });
+  });
+
+  it('returns false (never throws) when the control plane is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn<FetchMock>().mockRejectedValue(new Error('ECONNREFUSED')));
+    const ok = await mod.reportUpload({
+      cell_upload_id: 43,
+      cell_user_id: userId,
+      url: 'https://cdn.test/y.jpg',
+      thumb_url: null,
+      mime: 'image/jpeg',
+      byte_size: 1,
+      width: null,
+      height: null,
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe('flushUnsyncedUploads', () => {
+  it('drains unsynced rows and marks them synced when the CP accepts them', async () => {
+    const id1 = seedUpload('flush-a');
+    const id2 = seedUpload('flush-b');
+    expect(listUnsyncedUploads(500).some((r) => r.id === id1)).toBe(true);
+
+    vi.stubGlobal('fetch', vi.fn<FetchMock>().mockResolvedValue({ ok: true }));
+    const synced = await mod.flushUnsyncedUploads();
+    expect(synced).toBeGreaterThanOrEqual(2);
+
+    const stillUnsynced = listUnsyncedUploads(500).map((r) => r.id);
+    expect(stillUnsynced).not.toContain(id1);
+    expect(stillUnsynced).not.toContain(id2);
+  });
+
+  it('leaves rows unsynced when the CP is down (retried next tick)', async () => {
+    const id = seedUpload('flush-down');
+    vi.stubGlobal('fetch', vi.fn<FetchMock>().mockResolvedValue({ ok: false }));
+    await mod.flushUnsyncedUploads();
+    expect(listUnsyncedUploads(500).some((r) => r.id === id)).toBe(true);
+  });
+});

--- a/server/services/moderationReport.test.ts
+++ b/server/services/moderationReport.test.ts
@@ -62,7 +62,10 @@ describe('reportUpload', () => {
       height: 600,
     });
     expect(ok).toBe(true);
-    const [url, opts] = fetchMock.mock.calls[0] as [string, { headers: Record<string, string>; body: string }];
+    const [url, opts] = fetchMock.mock.calls[0] as [
+      string,
+      { headers: Record<string, string>; body: string },
+    ];
     expect(url).toBe('http://orchestrator:8020/_cp/moderation/uploads');
     expect(opts.headers.Authorization).toBe('Bearer fleet-secret');
     const body = JSON.parse(opts.body);
@@ -105,5 +108,25 @@ describe('flushUnsyncedUploads', () => {
     vi.stubGlobal('fetch', vi.fn<FetchMock>().mockResolvedValue({ ok: false }));
     await mod.flushUnsyncedUploads();
     expect(listUnsyncedUploads(500).some((r) => r.id === id)).toBe(true);
+  });
+});
+
+describe('reportUploadSoon', () => {
+  it('reports inline (fire-and-forget) and marks the row synced on success', async () => {
+    const id = seedUpload('soon');
+    vi.stubGlobal('fetch', vi.fn<FetchMock>().mockResolvedValue({ ok: true }));
+    mod.reportUploadSoon({
+      cell_upload_id: id,
+      cell_user_id: userId,
+      url: 'https://cdn.test/soon.jpg',
+      thumb_url: null,
+      mime: 'image/jpeg',
+      byte_size: 1,
+      width: null,
+      height: null,
+    });
+    // Fire-and-forget — let the resolved-promise microtask settle.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(listUnsyncedUploads(500).some((r) => r.id === id)).toBe(false);
   });
 });

--- a/server/services/moderationReport.ts
+++ b/server/services/moderationReport.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// In node edition the cell reports every upload to the control plane's
+// moderation index so the operator (who carries DMCA/abuse liability for the
+// objects in their R2 bucket) can browse and take down uploads. The cell stamps
+// its own name + the uploader's local user id; the CP resolves the account from
+// the (cell_id, cell_user_id) mapping it already owns.
+//
+// Reporting is best-effort and NEVER blocks or fails a user's upload: the inline
+// call after each insert is fire-and-forget, and a `synced_to_cp` flag plus a
+// periodic flush reconcile any report that didn't land (CP was down). This is
+// the OUTBOUND moderation half; the inbound takedown is routes/node.ts.
+//
+// Everything fails soft, exactly like orchestratorClient: not a node, or no
+// orchestrator configured → no-op.
+
+import { isNodeMode } from '../utils/edition.js';
+import { USER_AGENT } from '../utils/userAgent.js';
+import { listUnsyncedUploads, markUploadSynced } from '../db/uploadHistory.js';
+import * as systemLog from './systemLog.js';
+
+interface ReporterConfig {
+  url: string;
+  name: string;
+  secret: string;
+}
+
+// Same env as orchestratorClient (one fleet membership secret, one orchestrator
+// URL). Any gap → null → no-op.
+function readConfig(): ReporterConfig | null {
+  if (!isNodeMode()) return null;
+  const url = (process.env.LURKER_ORCHESTRATOR_URL || '').trim();
+  const name = (process.env.LURKER_NODE_NAME || '').trim();
+  const secret = (process.env.LURKER_NODE_SECRET || '').trim();
+  if (!url || !name || !secret) return null;
+  return { url, name, secret };
+}
+
+/** The per-upload moderation record the control plane indexes. */
+export interface UploadReport {
+  cell_upload_id: number;
+  cell_user_id: number;
+  url: string;
+  thumb_url: string | null;
+  mime: string;
+  byte_size: number;
+  width: number | null;
+  height: number | null;
+}
+
+// POST one upload's record to the control plane. Returns true on a 2xx, false on
+// any non-2xx or network error — never throws.
+export async function reportUpload(rec: UploadReport): Promise<boolean> {
+  const cfg = readConfig();
+  if (!cfg) return false;
+  try {
+    const res = await fetch(`${cfg.url.replace(/\/+$/, '')}/_cp/moderation/uploads`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${cfg.secret}`,
+        'User-Agent': USER_AGENT,
+      },
+      body: JSON.stringify({ cell: cfg.name, ...rec }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// Fire-and-forget report immediately after an upload; marks the row synced on
+// success so the flush skips it. Safe to call in any edition (no-op when not a
+// configured node).
+export function reportUploadSoon(rec: UploadReport): void {
+  if (!readConfig()) return;
+  void reportUpload(rec).then((ok) => {
+    if (ok) markUploadSynced(rec.cell_upload_id);
+  });
+}
+
+// Drain rows the CP hasn't acknowledged (it was down at upload time). One batch
+// per call; the timer calls it again next tick. Stops at the first failure so we
+// don't hammer a CP that's still down.
+export async function flushUnsyncedUploads(batch = 50): Promise<number> {
+  if (!readConfig()) return 0;
+  let synced = 0;
+  for (const r of listUnsyncedUploads(batch)) {
+    const ok = await reportUpload({
+      cell_upload_id: r.id,
+      cell_user_id: r.user_id,
+      url: r.url,
+      thumb_url: r.thumbnail_url,
+      mime: r.mime,
+      byte_size: r.byte_size,
+      width: r.width,
+      height: r.height,
+    });
+    if (!ok) break;
+    markUploadSynced(r.id);
+    synced++;
+  }
+  return synced;
+}
+
+const DEFAULT_INTERVAL_MS = 60_000;
+let timer: ReturnType<typeof setInterval> | null = null;
+
+// Periodically reconcile unsynced uploads. No-op when not a configured node, so
+// it's safe to call unconditionally at startup.
+export function startModerationReporter(intervalMs = DEFAULT_INTERVAL_MS): void {
+  stopModerationReporter();
+  if (!readConfig()) return;
+  const tick = async (): Promise<void> => {
+    try {
+      const n = await flushUnsyncedUploads();
+      if (n > 0) {
+        systemLog.log({ scope: 'node', text: `synced ${n} upload record(s) to moderation index` });
+      }
+    } catch {
+      /* best-effort; retried next tick */
+    }
+  };
+  void tick();
+  timer = setInterval(() => void tick(), intervalMs);
+  timer.unref?.();
+}
+
+export function stopModerationReporter(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/server/services/moderationReport.ts
+++ b/server/services/moderationReport.ts
@@ -77,6 +77,7 @@ export function reportUploadSoon(rec: UploadReport): void {
   if (!readConfig()) return;
   void reportUpload(rec).then((ok) => {
     if (ok) markUploadSynced(rec.cell_upload_id);
+    return ok;
   });
 }
 

--- a/server/services/uploadProviders/hoarder.ts
+++ b/server/services/uploadProviders/hoarder.ts
@@ -14,7 +14,7 @@ export const requiresSecrets = true;
 
 export async function upload(
   buffer: Buffer,
-  { filename, mime }: { filename: string; mime: string },
+  { filename, mime, kind }: { filename: string; mime: string; kind?: string },
   secrets: { url?: string; api_key?: string } = {},
 ): Promise<{ url: string }> {
   if (!secrets.url) {
@@ -30,6 +30,8 @@ export async function upload(
 
   const base = secrets.url.replace(/\/+$/, '');
   const form = new FormData();
+  // Text fields before the file so multipart parsers populate req.body reliably.
+  if (kind) form.append('kind', kind);
   form.append('file', new Blob([new Uint8Array(buffer)], { type: mime }), filename);
 
   const resp = await fetch(`${base}/api/upload`, {

--- a/server/services/uploadProviders/index.ts
+++ b/server/services/uploadProviders/index.ts
@@ -11,7 +11,10 @@ export interface UploadProvider {
   requiresSecrets: boolean;
   upload(
     buffer: Buffer,
-    meta: { filename: string; mime: string },
+    // `kind` is an optional hint forwarded to the in-house dropper so a thumbnail
+    // lands under a `thumbs/` prefix. Hosts that don't understand it ignore the
+    // extra form field.
+    meta: { filename: string; mime: string; kind?: string },
     secrets?: Record<string, string>,
   ): Promise<{ url: string }>;
 }

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -9,8 +9,14 @@
 
     <div ref="listEl" class="list-wrap" @scroll="onScroll">
       <ul v-if="recentRows.length" class="list">
-        <li v-for="u in recentRows" :key="u.id" class="row">
+        <li v-for="u in recentRows" :key="u.id" class="row" :class="{ removed: u.removed }">
+          <!-- Moderated-away upload: the object is gone, so show a tombstone
+               instead of a link to a dead URL. -->
+          <div v-if="u.removed" class="thumb thumb-placeholder" title="removed by moderation">
+            <i class="fa-solid fa-gavel fa-2x"></i>
+          </div>
           <a
+            v-else
             :href="u.url"
             target="_blank"
             rel="noreferrer noopener"
@@ -30,7 +36,8 @@
           </a>
           <div class="meta">
             <div class="filename" :title="u.filename || ''">{{ u.filename || '(pasted)' }}</div>
-            <div class="url" :title="u.url">{{ u.url }}</div>
+            <div v-if="u.removed" class="url removed-note">Removed by moderation</div>
+            <div v-else class="url" :title="u.url">{{ u.url }}</div>
             <div class="sub">
               <span v-if="u.provider">{{ u.provider }}</span>
               <span v-if="u.created_at">· {{ formatRelative(u.created_at) }}</span>
@@ -39,14 +46,17 @@
             </div>
           </div>
           <div class="row-actions">
-            <button class="link" @click="onInsert(u)" title="insert URL into input">insert</button>
-            <button
-              class="link"
-              @click="onCopy(u)"
-              :title="copiedId === u.id ? 'copied' : 'copy URL'"
-            >
-              {{ copiedId === u.id ? 'copied' : 'copy' }}
-            </button>
+            <!-- A removed upload's URL is dead — only allow clearing it from history. -->
+            <template v-if="!u.removed">
+              <button class="link" @click="onInsert(u)" title="insert URL into input">insert</button>
+              <button
+                class="link"
+                @click="onCopy(u)"
+                :title="copiedId === u.id ? 'copied' : 'copy URL'"
+              >
+                {{ copiedId === u.id ? 'copied' : 'copy' }}
+              </button>
+            </template>
             <button
               class="link danger"
               @click="onDelete(u)"
@@ -218,6 +228,12 @@ function formatBytes(n: number) {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.removed-note {
+  color: var(--bad);
+}
+.row.removed .filename {
+  color: var(--fg-muted);
 }
 .sub {
   color: var(--fg-muted);

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -48,7 +48,9 @@
           <div class="row-actions">
             <!-- A removed upload's URL is dead — only allow clearing it from history. -->
             <template v-if="!u.removed">
-              <button class="link" @click="onInsert(u)" title="insert URL into input">insert</button>
+              <button class="link" @click="onInsert(u)" title="insert URL into input">
+                insert
+              </button>
               <button
                 class="link"
                 @click="onCopy(u)"

--- a/vue_client/src/stores/uploads.ts
+++ b/vue_client/src/stores/uploads.ts
@@ -36,6 +36,9 @@ export interface UploadItem {
   filename: string | null;
   mime: string | null;
   thumbnail_url?: string;
+  // True when the hosted operator has moderated the upload away. The row stays
+  // as a tombstone; its bytes are gone from storage.
+  removed?: boolean;
 }
 
 export const useUploadsStore = defineStore('uploads', {

--- a/vue_client/src/stores/uploads.ts
+++ b/vue_client/src/stores/uploads.ts
@@ -71,19 +71,22 @@ export const useUploadsStore = defineStore('uploads', {
           },
         });
         emitInsert(result.url);
-        // Prepend the new row optimistically without a refetch. The list shape
-        // matches the server's GET response (sans `thumbnail_url`, which the
-        // server only advertises when a thumbnail blob actually exists — same
-        // gate we apply here based on the file's mime).
+        // Prepend the new row optimistically without a refetch. Prefer a remote
+        // thumbnail URL the server returned (node edition stores thumbs on the
+        // CDN); otherwise, for images, fall back to the local BLOB-serving route
+        // — the same gate the server's GET response applies. Text uploads have
+        // no thumbnail.
         if (this.loaded) {
           const isImage = typeof file.type === 'string' && file.type.startsWith('image/');
+          const thumbnail_url =
+            result.thumbnail_url || (isImage ? `/api/uploads/${result.id}/thumb` : undefined);
           this.recent.unshift({
             id: result.id,
             provider: undefined, // server-only field; recent-uploads modal will re-fetch if it cares
             url: result.url,
             filename,
             mime: file.type || null,
-            ...(isImage ? { thumbnail_url: `/api/uploads/${result.id}/thumb` } : {}),
+            ...(thumbnail_url ? { thumbnail_url } : {}),
           });
         }
         return result;


### PR DESCRIPTION
Cell-side of the node uploader hardening. Companion control-plane + dropper PR: amiantos/lurker-control-plane#35.

## What's here (cell + client)
- **Policy: raster + `.txt` only.** `imagePipeline.optimize()` gains `rasterOnly` (set in node mode) that rejects SVG via the existing `UNSUPPORTED_FORMAT` → 415 path. Standalone keeps SVG passthrough.
- **Thumbnails to remote storage.** In node mode the cell uploads the thumbnail to the dropper (`kind=thumb`) and stores `thumbnail_url` in a new `upload_history` column instead of an inline BLOB, so thumbs stop bloating the cell DB / every R2 backup. **Best-effort with BLOB fallback** — a thumb hiccup never blocks the upload — so it's zero-risk and migration-free. `GET /api/uploads` prefers the remote URL; the client prefers it too.
- **Moderation reporting.** After each node upload the cell reports it to the CP's moderation index, stamping its name + the uploader's local user id. Fire-and-forget + a `synced_to_cp` flag and periodic flush so a CP outage never silently drops a record. No-op in standalone.
- **Takedown.** `POST /api/node/uploads/:id/takedown` (node API): flips the row to `removed`, drops any inline thumbnail BLOB. `GET /api/uploads` flags removed rows and advertises no thumbnail; the recent-uploads modal shows a "Removed by moderation" tombstone.

All new behavior is node-edition only; standalone is unchanged.

## Tests
756 pass (new SVG-policy, thumb-to-R2 + BLOB-fallback, moderation-report, and node-takedown coverage). Typecheck + lint clean; client builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)