### PR TITLE
Async data export + streaming import (#175, #180)

### DIFF
--- a/server/db/dataExports.ts
+++ b/server/db/dataExports.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Data-access for the data_exports table — per-user export jobs and their
+// on-disk .lurk artifacts. See db/index.ts for the schema and
+// services/exportJobs.ts for the lifecycle that drives these rows.
+
+import { randomBytes } from 'crypto';
+import db from './index.js';
+
+export type ExportStatus = 'pending' | 'running' | 'done' | 'error';
+
+export interface ExportJob {
+  id: number;
+  user_id: number;
+  status: ExportStatus;
+  include_messages: number;
+  total_rows: number;
+  processed_rows: number;
+  filename: string | null;
+  file_path: string | null;
+  byte_size: number | null;
+  token: string;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  expires_at: string | null;
+  downloaded_at: string | null;
+}
+
+const insertStmt = db.prepare(`
+  INSERT INTO data_exports (user_id, status, include_messages, token)
+  VALUES (?, 'pending', ?, ?)
+`);
+
+export function createExportJob(userId: number, includeMessages: boolean): ExportJob {
+  // 24 bytes hex = 48 chars; unguessable on-disk filename. Auth + ownership
+  // still gate the download endpoint — the token only keeps the path opaque.
+  const token = randomBytes(24).toString('hex');
+  const res = insertStmt.run(userId, includeMessages ? 1 : 0, token);
+  return getExportJob(Number(res.lastInsertRowid))!;
+}
+
+export function getExportJob(id: number): ExportJob | undefined {
+  return db.prepare('SELECT * FROM data_exports WHERE id = ?').get(id) as ExportJob | undefined;
+}
+
+/** The job for `id` only if it belongs to `userId` — the download authorization check. */
+export function getExportJobForUser(id: number, userId: number): ExportJob | undefined {
+  return db.prepare('SELECT * FROM data_exports WHERE id = ? AND user_id = ?').get(id, userId) as
+    | ExportJob
+    | undefined;
+}
+
+/** An in-flight (pending/running) job for the user, if any — enforces one-at-a-time. */
+export function getActiveJobForUser(userId: number): ExportJob | undefined {
+  return db
+    .prepare(
+      `SELECT * FROM data_exports
+       WHERE user_id = ? AND status IN ('pending', 'running')
+       ORDER BY id DESC LIMIT 1`,
+    )
+    .get(userId) as ExportJob | undefined;
+}
+
+/** The most recent job for the user (any status) — what the UI restores on load. */
+export function getLatestJobForUser(userId: number): ExportJob | undefined {
+  return db
+    .prepare('SELECT * FROM data_exports WHERE user_id = ? ORDER BY id DESC LIMIT 1')
+    .get(userId) as ExportJob | undefined;
+}
+
+export function markRunning(id: number, totalRows: number): void {
+  db.prepare(
+    `UPDATE data_exports
+     SET status = 'running', total_rows = ?, started_at = datetime('now')
+     WHERE id = ?`,
+  ).run(totalRows, id);
+}
+
+export function updateProgress(id: number, processedRows: number): void {
+  db.prepare('UPDATE data_exports SET processed_rows = ? WHERE id = ?').run(processedRows, id);
+}
+
+export function markDone(
+  id: number,
+  opts: { filePath: string; filename: string; byteSize: number; ttlHours: number },
+): void {
+  // expires_at is computed in SQLite's own datetime format (UTC, no 'T'/'Z') so
+  // the sweep's `expires_at < datetime('now')` comparison is apples-to-apples.
+  // The sign is explicit so a non-positive ttl yields a valid '-N hours'
+  // modifier rather than the malformed '+-N hours' SQLite would resolve to NULL.
+  const sign = opts.ttlHours >= 0 ? '+' : '-';
+  const modifier = `${sign}${Math.abs(opts.ttlHours)} hours`;
+  db.prepare(
+    `UPDATE data_exports
+     SET status = 'done', file_path = ?, filename = ?, byte_size = ?,
+         expires_at = datetime('now', ?), completed_at = datetime('now')
+     WHERE id = ?`,
+  ).run(opts.filePath, opts.filename, opts.byteSize, modifier, id);
+}
+
+export function markError(id: number, message: string): void {
+  db.prepare(
+    `UPDATE data_exports
+     SET status = 'error', error = ?, completed_at = datetime('now')
+     WHERE id = ?`,
+  ).run(message.slice(0, 1000), id);
+}
+
+export function markDownloaded(id: number): void {
+  db.prepare(`UPDATE data_exports SET downloaded_at = datetime('now') WHERE id = ?`).run(id);
+}
+
+export function deleteJob(id: number): void {
+  db.prepare('DELETE FROM data_exports WHERE id = ?').run(id);
+}
+
+/** Completed jobs whose artifact TTL has lapsed — their files + rows get swept. */
+export function listExpiredJobs(): ExportJob[] {
+  return db
+    .prepare(
+      `SELECT * FROM data_exports
+       WHERE status = 'done' AND expires_at IS NOT NULL AND expires_at < datetime('now')`,
+    )
+    .all() as ExportJob[];
+}
+
+/** Jobs still marked in-flight — used on boot to fail anything a restart orphaned. */
+export function listInflightJobs(): ExportJob[] {
+  return db
+    .prepare(`SELECT * FROM data_exports WHERE status IN ('pending', 'running')`)
+    .all() as ExportJob[];
+}
+
+/** Older completed jobs for a user, excluding `keepId` — superseded artifacts to clean up. */
+export function listSupersededDoneJobs(userId: number, keepId: number): ExportJob[] {
+  return db
+    .prepare(
+      `SELECT * FROM data_exports
+       WHERE user_id = ? AND status = 'done' AND id <> ?`,
+    )
+    .all(userId, keepId) as ExportJob[];
+}

--- a/server/db/dataExports.ts
+++ b/server/db/dataExports.ts
@@ -79,8 +79,20 @@ export function markRunning(id: number, totalRows: number): void {
   ).run(totalRows, id);
 }
 
-export function updateProgress(id: number, processedRows: number): void {
-  db.prepare('UPDATE data_exports SET processed_rows = ? WHERE id = ?').run(processedRows, id);
+export function updateProgress(id: number, processedRows: number, totalRows?: number): void {
+  // Keep total_rows in sync with the worker's own denominator when it reports
+  // one (> 0). The initial markRunning count is a main-thread estimate on a
+  // different snapshot; the worker's count is authoritative, and persisting it
+  // keeps the UI from ever showing processed > total.
+  if (typeof totalRows === 'number' && totalRows > 0) {
+    db.prepare('UPDATE data_exports SET processed_rows = ?, total_rows = ? WHERE id = ?').run(
+      processedRows,
+      totalRows,
+      id,
+    );
+  } else {
+    db.prepare('UPDATE data_exports SET processed_rows = ? WHERE id = ?').run(processedRows, id);
+  }
 }
 
 export function markDone(

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -19,6 +19,24 @@
 
 export const EXPORT_FORMAT_VERSION = 1;
 
+// Columns holding IRC network secrets that are encrypted at rest on hosted
+// cells (see server/utils/secretCrypto.ts). connect_commands is included
+// because it routinely carries `/msg NickServ identify <password>` and oper
+// passwords — IRCCloud encrypts it for the same reason. Encryption is a no-op
+// (plaintext passthrough) unless LURKER_SECRET_KEY is configured, so self-host
+// is unaffected.
+//
+// Lives here (a db-singleton-free module) rather than in db/networks.ts so the
+// worker-safe export builder can import it without pulling the db connection
+// into a worker thread's import graph. db/networks.ts re-exports it for the
+// callers that still reach for it there.
+export const ENCRYPTED_NETWORK_COLUMNS = [
+  'server_password',
+  'sasl_account',
+  'sasl_password',
+  'connect_commands',
+] as const;
+
 // FTS5 maintains its own shadow tables (messages_fts_data, _idx, _content,
 // _docsize, _config). Only the virtual `messages_fts` itself surfaces in
 // sqlite_master as a row the registry needs to address; the shadows are
@@ -364,6 +382,13 @@ export const EXPORT_TABLES = Object.freeze({
   app_meta: {
     mode: 'skip',
     reason: 'instance-level metadata (schema_version, etc.), not user data',
+  },
+
+  data_exports: {
+    mode: 'skip',
+    reason:
+      'per-user export job + artifact bookkeeping (status/progress/file path/TTL); ' +
+      'instance-local operational state, not portable user data',
   },
 });
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -7,6 +7,10 @@ import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
 
 const dbPath = process.env.DATABASE_PATH || path.join(import.meta.dirname, '../../data/lurker.db');
+// Absolute path to the SQLite file, exported so the export worker can open its
+// own readonly connection to the exact same database (and so exportJobs can
+// site the data/exports/ artifact dir next to it) without re-deriving the path.
+export const DATABASE_FILE = dbPath;
 const dbDir = path.dirname(dbPath);
 if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true });
 
@@ -410,6 +414,38 @@ function migrate() {
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
+
+    -- Per-user data-export jobs. A request to export account data spawns a
+    -- background worker (separate readonly SQLite connection) that builds the
+    -- .lurk archive to disk under data/exports/<token>.lurk; the row tracks
+    -- status/progress/artifact so a "ready" export survives reloads and an
+    -- interrupted job is recoverable after a restart. status is one of
+    -- 'pending' | 'running' | 'done' | 'error'. token names the on-disk file
+    -- (unguessable); the download endpoint still gates on session + ownership.
+    -- expires_at drives the TTL sweep; the artifact is deleted once it lapses.
+    -- Not part of the export contract (instance-local operational state) — see
+    -- the 'skip' entry in db/exportSchema.ts.
+    CREATE TABLE IF NOT EXISTS data_exports (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      include_messages INTEGER NOT NULL DEFAULT 0,
+      total_rows INTEGER NOT NULL DEFAULT 0,
+      processed_rows INTEGER NOT NULL DEFAULT 0,
+      filename TEXT,
+      file_path TEXT,
+      byte_size INTEGER,
+      token TEXT NOT NULL,
+      error TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      started_at TEXT,
+      completed_at TEXT,
+      expires_at TEXT,
+      downloaded_at TEXT,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_data_exports_user ON data_exports(user_id, id DESC);
+    CREATE INDEX IF NOT EXISTS idx_data_exports_expires ON data_exports(expires_at);
   `);
 }
 

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -3,19 +3,13 @@
 
 import db from './index.js';
 import { encryptSecret, decryptSecret, isEncrypted, hasSecretKey } from '../utils/secretCrypto.js';
+import { ENCRYPTED_NETWORK_COLUMNS } from './exportSchema.js';
 
-// Columns holding IRC network secrets that are encrypted at rest on hosted
-// cells (see server/utils/secretCrypto.ts). connect_commands is included
-// because it routinely carries `/msg NickServ identify <password>` and oper
-// passwords — IRCCloud encrypts it for the same reason. Encryption is a no-op
-// (plaintext passthrough) unless LURKER_SECRET_KEY is configured, so self-host
-// is unaffected.
-export const ENCRYPTED_NETWORK_COLUMNS = [
-  'server_password',
-  'sasl_account',
-  'sasl_password',
-  'connect_commands',
-] as const;
+// The list of encrypted network-secret columns lives in db/exportSchema.ts (a
+// db-singleton-free module) so the worker-safe export builder can import it
+// without pulling this module's db connection into a worker. Re-exported here
+// for the callers that have always reached for it via db/networks.js.
+export { ENCRYPTED_NETWORK_COLUMNS };
 
 // Decrypt the secret columns on a freshly-read row, in place. No-op for legacy
 // plaintext and when no key is configured (decryptSecret passes those through).

--- a/server/routes/exports.test.ts
+++ b/server/routes/exports.test.ts
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import { PassThrough } from 'stream';
+import Database from 'better-sqlite3';
 import type { LurkerTestAgent } from '../test-utils/testApp.js';
 import type { Express } from 'express';
 import {
@@ -22,11 +25,63 @@ let alice: User;
 let bob: User;
 let aliceNet: Network;
 
+let exportJobs: typeof import('../services/exportJobs.js');
+let buildExportZip: typeof import('../services/exportService.js').buildExportZip;
+
+// Build an export buffer the same way the worker would, but in-process (vitest
+// can't transform a .ts worker entry loaded via node:worker_threads).
+async function exportToBuffer(userId: number, includeMessages: boolean): Promise<Buffer> {
+  const reader = new Database(ctx.dbPath, { readonly: true });
+  const sink = new PassThrough();
+  const chunks: Buffer[] = [];
+  sink.on('data', (c: Buffer) => chunks.push(c));
+  try {
+    await buildExportZip(reader, userId, { includeMessages }, sink);
+  } finally {
+    reader.close();
+  }
+  return Buffer.concat(chunks);
+}
+
+function waitForStatus(agent: LurkerTestAgent, want: string, timeoutMs = 5000): Promise<any> {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = async () => {
+      const res = await agent.get('/api/exports/latest');
+      const job = res.body.job;
+      if (job && (job.status === want || job.status === 'error')) return resolve(job);
+      if (Date.now() - started > timeoutMs) return reject(new Error(`timeout waiting for ${want}`));
+      setTimeout(tick, 15);
+    };
+    void tick();
+  });
+}
+
 beforeAll(async () => {
   const { createUser } = await import('../db/users.js');
   const { createNetwork } = await import('../db/networks.js');
   const { insertMessage } = await import('../db/messages.js');
   const { exportsRouter, importRouter } = await import('./exports.js');
+  exportJobs = await import('../services/exportJobs.js');
+  ({ buildExportZip } = await import('../services/exportService.js'));
+
+  // Run the background build in-process on its own readonly connection.
+  exportJobs.setExportBuildRunnerForTests(async (spec, onProgress) => {
+    const reader = new Database(ctx.dbPath, { readonly: true });
+    try {
+      const out = fs.createWriteStream(spec.outPath);
+      await buildExportZip(
+        reader,
+        spec.userId,
+        { includeMessages: spec.includeMessages },
+        out,
+        onProgress,
+      );
+      return { byteSize: fs.statSync(spec.outPath).size };
+    } finally {
+      reader.close();
+    }
+  });
 
   alice = createUser('exports-alice');
   bob = createUser('exports-bob');
@@ -37,7 +92,6 @@ beforeAll(async () => {
     tls: true,
     nick: 'alice',
   })!;
-  // Seed messages so the export has something interesting to dump.
   for (let i = 0; i < 3; i += 1) {
     insertMessage({
       networkId: aliceNet.id,
@@ -54,7 +108,10 @@ beforeAll(async () => {
   bobAgent = await createAuthedAgent(app, bob.id);
 });
 
-afterAll(() => ctx.cleanup());
+afterAll(() => {
+  exportJobs.setExportBuildRunnerForTests(null);
+  ctx.cleanup();
+});
 
 describe('GET /api/exports/preview', () => {
   it('requires auth', async () => {
@@ -66,30 +123,49 @@ describe('GET /api/exports/preview', () => {
     const res = await aliceAgent.get('/api/exports/preview');
     expect(res.status).toBe(200);
     expect(res.body.username).toBe('exports-alice');
-    expect(typeof res.body.settingsOnly).toBe('object');
-    expect(typeof res.body.withMessages).toBe('object');
-    // Messages flavor should report >= settings-only by definition.
     const so = (Object.values(res.body.settingsOnly) as number[]).reduce((s, n) => s + n, 0);
     const wm = (Object.values(res.body.withMessages) as number[]).reduce((s, n) => s + n, 0);
     expect(wm).toBeGreaterThanOrEqual(so);
   });
 });
 
-describe('GET /api/exports', () => {
-  it('streams a non-empty zip', async () => {
-    const res = await aliceAgent
-      .get('/api/exports?include_messages=1')
+describe('export job flow', () => {
+  it('requires auth to start', async () => {
+    const res = await createAnonAgent(app).post('/api/exports').send({ include_messages: true });
+    expect(res.status).toBe(401);
+  });
+
+  it('starts a build, finishes it, and serves the artifact', async () => {
+    const start = await aliceAgent.post('/api/exports').send({ include_messages: true });
+    expect(start.status).toBe(202);
+    expect(['pending', 'running', 'done']).toContain(start.body.job.status);
+    const jobId = start.body.job.id;
+
+    const done = await waitForStatus(aliceAgent, 'done');
+    expect(done.status).toBe('done');
+    expect(done.id).toBe(jobId);
+    expect(done.byteSize).toBeGreaterThan(0);
+    expect(done.downloadable).toBe(true);
+
+    const dl = await aliceAgent
+      .get(`/api/exports/${jobId}/download`)
       .buffer(true)
       .parse((stream, cb) => {
         const chunks: Buffer[] = [];
         stream.on('data', (c: Buffer) => chunks.push(c));
         stream.on('end', () => cb(null, Buffer.concat(chunks)));
       });
-    expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toMatch(/octet-stream/);
-    expect(res.body.length).toBeGreaterThan(50);
-    // PK zip signature.
-    expect(res.body.slice(0, 2).toString()).toBe('PK');
+    expect(dl.status).toBe(200);
+    expect(dl.headers['content-disposition']).toMatch(/attachment/);
+    expect((dl.body as Buffer).slice(0, 2).toString()).toBe('PK');
+  });
+
+  it("refuses to download another user's export", async () => {
+    const start = await aliceAgent.post('/api/exports').send({ include_messages: false });
+    const jobId = start.body.job.id;
+    await waitForStatus(aliceAgent, 'done');
+    const res = await bobAgent.get(`/api/exports/${jobId}/download`);
+    expect(res.status).toBe(404);
   });
 });
 
@@ -108,45 +184,32 @@ describe('POST /api/imports', () => {
   });
 
   it('refuses import when the account already has data', async () => {
-    // Alice has networks → not empty. Export her data then try to re-import.
-    const exp = await aliceAgent
-      .get('/api/exports?include_messages=1')
-      .buffer(true)
-      .parse((stream, cb) => {
-        const chunks: Buffer[] = [];
-        stream.on('data', (c: Buffer) => chunks.push(c));
-        stream.on('end', () => cb(null, Buffer.concat(chunks)));
-      });
+    const buf = await exportToBuffer(alice.id, true);
     const res = await aliceAgent
       .post('/api/imports')
-      .attach('archive', exp.body, { filename: 'export.lurk' });
+      .attach('archive', buf, { filename: 'export.lurk' });
     expect(res.status).toBe(409);
     expect(res.body.code).toBe('account_not_empty');
   });
 
   it('round-trips an export into a fresh account', async () => {
-    const exp = await aliceAgent
-      .get('/api/exports?include_messages=1')
-      .buffer(true)
-      .parse((stream, cb) => {
-        const chunks: Buffer[] = [];
-        stream.on('data', (c: Buffer) => chunks.push(c));
-        stream.on('end', () => cb(null, Buffer.concat(chunks)));
-      });
-    // Bob is empty (no networks).
-    const res = await bobAgent
+    const { createUser } = await import('../db/users.js');
+    const carol = createUser('exports-carol');
+    const carolAgent = await createAuthedAgent(app, carol.id);
+    const buf = await exportToBuffer(alice.id, true);
+
+    const res = await carolAgent
       .post('/api/imports')
-      .attach('archive', exp.body, { filename: 'alice.lurk' });
+      .attach('archive', buf, { filename: 'alice.lurk' });
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
 
-    // Verify Bob now has alice's network and messages.
     const { listNetworksForUser } = await import('../db/networks.js');
     const { listMessages } = await import('../db/messages.js');
-    const bobNets = listNetworksForUser(bob.id);
-    expect(bobNets.length).toBe(1);
-    expect(bobNets[0].name).toBe('libera');
-    const bobMsgs = listMessages(bobNets[0].id, '#general', { limit: 100 });
-    expect(bobMsgs.length).toBe(3);
+    const carolNets = listNetworksForUser(carol.id);
+    expect(carolNets.length).toBe(1);
+    expect(carolNets[0].name).toBe('libera');
+    const carolMsgs = listMessages(carolNets[0].id, '#general', { limit: 100 });
+    expect(carolMsgs.length).toBe(3);
   });
 });

--- a/server/routes/exports.ts
+++ b/server/routes/exports.ts
@@ -1,42 +1,47 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// Per-user data export/import endpoints. Lets a user download a zip
-// containing all of their data, and restore it on a fresh account on a
-// different Lurker instance. See server/db/exportSchema.js for the
-// per-table contract that drives both directions.
+// Per-user data export/import endpoints.
+//
+// Export is asynchronous: POST starts a background build (a worker thread on
+// its own readonly db connection — see services/exportJobs.ts), progress is
+// pushed over the WebSocket, and the finished .lurk artifact is fetched from a
+// separate authenticated, resumable download endpoint. Building the zip inline
+// on the request (and on the shared db connection) is what crashed the process
+// on large exports — lurker#175.
+//
+// Import restores an export zip into a fresh account. See
+// server/db/exportSchema.js for the per-table contract that drives both
+// directions.
 
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import multer from 'multer';
 import { requireAuth } from '../middleware/auth.js';
-import {
-  buildExportZip,
-  buildExportFilename,
-  computeExportPreview,
-} from '../services/exportService.js';
-import { importFromZipBuffer, ImportError } from '../services/importService.js';
+import db from '../db/index.js';
+import { computeExportPreview } from '../services/exportService.js';
+import { startExport, toClientJob, exportArtifactPath } from '../services/exportJobs.js';
+import { getLatestJobForUser, getExportJobForUser, markDownloaded } from '../db/dataExports.js';
+import { importFromZipFile, ImportError } from '../services/importService.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 
 const router = Router();
 router.use(requireAuth);
 
-// Cap import zip size. 500 MB is generous for "a single user's logs"; if a
-// user trips this we want to see the report rather than silently accept
-// something unbounded. Streaming import is a follow-up; for now multer
-// buffers the whole zip in memory.
-const HARD_IMPORT_LIMIT = 500 * 1024 * 1024;
-const upload = multer({
-  storage: multer.memoryStorage(),
-  limits: { fileSize: HARD_IMPORT_LIMIT, files: 1 },
-});
+function parseBool(v: unknown): boolean {
+  const s = String(v ?? '').toLowerCase();
+  return v === true || s === '1' || s === 'true';
+}
 
 // GET /api/exports/preview — return row counts for both flavors so the
 // client can show what's about to be downloaded.
 router.get('/preview', (req: Request, res: Response, next: NextFunction) => {
   try {
-    const settingsOnly = computeExportPreview(req.user!.id, { includeMessages: false });
-    const withMessages = computeExportPreview(req.user!.id, { includeMessages: true });
+    const settingsOnly = computeExportPreview(db, req.user!.id, { includeMessages: false });
+    const withMessages = computeExportPreview(db, req.user!.id, { includeMessages: true });
     res.json({
       settingsOnly,
       withMessages,
@@ -47,36 +52,82 @@ router.get('/preview', (req: Request, res: Response, next: NextFunction) => {
   }
 });
 
-// GET /api/exports?include_messages=1 — stream the zip to the response.
-router.get(
-  '/',
-  asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
-    const includeMessages =
-      String(req.query.include_messages || '').toLowerCase() === '1' ||
-      String(req.query.include_messages || '').toLowerCase() === 'true';
-    const filename = buildExportFilename(req.user!.username, { includeMessages });
-    // octet-stream (not application/zip) so Safari's "open safe files after
-    // downloading" preference doesn't auto-unarchive the .lurk file.
-    res.setHeader('Content-Type', 'application/octet-stream');
-    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
-    try {
-      await buildExportZip(req.user!.id, { includeMessages }, res);
-    } catch (err) {
-      // Headers are already out — best we can do is close the connection.
-      // The downstream will see a truncated zip and surface it as a corrupt
-      // download. Logging makes it diagnosable server-side.
-      console.error('[lurker] export failed:', err);
-      if (!res.headersSent) {
-        next(err);
-        return;
-      }
-      res.destroy();
+// GET /api/exports/latest — the user's most recent export job (any status), so
+// the client can restore "preparing…" / "ready to download" on page load.
+router.get('/latest', (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const job = getLatestJobForUser(req.user!.id);
+    res.json({ job: job ? toClientJob(job) : null });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /api/exports { include_messages } — start a background export. Refuses
+// to start a second concurrent build for the same user (returns the in-flight
+// job with alreadyRunning=true). Allowed for paused accounts too: exporting
+// your own data is the one thing a suspended user must always be able to do.
+router.post('/', (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const includeMessages = parseBool(req.body?.include_messages ?? req.query.include_messages);
+    const { job, alreadyRunning } = startExport(req.user!.id, includeMessages);
+    res.status(alreadyRunning ? 200 : 202).json({ job: toClientJob(job), alreadyRunning });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /api/exports/:id/download — stream a finished artifact. Authenticated +
+// ownership-checked; supports HTTP Range (via res.download → sendFile) so an
+// interrupted download resumes instead of restarting.
+router.get('/:id/download', (req: Request, res: Response, next: NextFunction) => {
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'bad export id' });
+    return;
+  }
+  const job = getExportJobForUser(id, req.user!.id);
+  if (!job) {
+    res.status(404).json({ error: 'export not found' });
+    return;
+  }
+  if (job.status !== 'done') {
+    res.status(409).json({ error: 'export is not ready', status: job.status });
+    return;
+  }
+  const filePath = job.file_path || exportArtifactPath(job.token);
+  if (!fs.existsSync(filePath)) {
+    // Row says done but the artifact is gone (expired sweep, or a stale row).
+    res.status(410).json({ error: 'export artifact is no longer available' });
+    return;
+  }
+  // res.download sets Content-Disposition: attachment and an octet-stream
+  // Content-Type for the unknown .lurk extension (so Safari won't try to
+  // auto-unarchive it), and honors Range requests.
+  res.download(filePath, job.filename || 'lurker-export.lurk', (err) => {
+    if (err) {
+      // Client aborted or the file vanished mid-send; headers are likely out.
+      if (!res.headersSent) next(err);
+      return;
     }
-  }),
-);
+    markDownloaded(job.id);
+  });
+});
 
 const importRouter = Router();
 importRouter.use(requireAuth);
+
+// Cap import zip size. 500 MB is generous for "a single user's logs"; if a
+// user trips this we want to see the report rather than silently accept
+// something unbounded. The upload streams to a temp file (not memory) and the
+// importer reads it from disk, so peak memory stays flat regardless of size.
+const HARD_IMPORT_LIMIT = 500 * 1024 * 1024;
+const IMPORT_TMP_DIR = path.join(os.tmpdir(), 'lurker-imports');
+fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true });
+const upload = multer({
+  dest: IMPORT_TMP_DIR,
+  limits: { fileSize: HARD_IMPORT_LIMIT, files: 1 },
+});
 
 // POST /api/imports — upload an export zip and restore it into the
 // caller's account. Refuses if the account already has data.
@@ -89,7 +140,7 @@ importRouter.post(
         res.status(400).json({ error: 'no archive uploaded' });
         return;
       }
-      const result = await importFromZipBuffer(req.user!.id, req.file.buffer);
+      const result = await importFromZipFile(req.user!.id, req.file.path);
       res.json({ ok: true, ...result });
     } catch (err) {
       if (err instanceof ImportError) {
@@ -119,6 +170,9 @@ importRouter.post(
         return;
       }
       next(err);
+    } finally {
+      // Drop the multer temp upload whether the import succeeded or failed.
+      if (req.file?.path) fs.promises.unlink(req.file.path).catch(() => {});
     }
   }),
 );

--- a/server/routes/exports.ts
+++ b/server/routes/exports.ts
@@ -123,7 +123,10 @@ importRouter.use(requireAuth);
 // importer reads it from disk, so peak memory stays flat regardless of size.
 const HARD_IMPORT_LIMIT = 500 * 1024 * 1024;
 const IMPORT_TMP_DIR = path.join(os.tmpdir(), 'lurker-imports');
-fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true });
+// Owner-only — an uploaded .lurk holds the source account's decrypted network
+// passwords, so other local users on a shared host mustn't be able to read the
+// staged upload. Matches the 0700/0600 posture on the export side.
+fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true, mode: 0o700 });
 const upload = multer({
   dest: IMPORT_TMP_DIR,
   limits: { fileSize: HARD_IMPORT_LIMIT, files: 1 },

--- a/server/server.ts
+++ b/server/server.ts
@@ -18,6 +18,11 @@ import { getEdition, isNodeMode } from './utils/edition.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
 import { startModerationReporter, stopModerationReporter } from './services/moderationReport.js';
 import { startIdentd, stopIdentd, isIdentdEnabled, identdPort } from './services/identd.js';
+import {
+  recoverInterruptedExports,
+  startExportSweeper,
+  shutdownExportJobs,
+} from './services/exportJobs.js';
 
 const PORT = Number(process.env.PORT || 8010);
 const EDITION = getEdition();
@@ -69,6 +74,11 @@ if (wrapped.encrypted > 0) {
 
 ircManager.initAll();
 
+// Fail any export job a prior crash/restart left mid-flight, drop partial
+// artifacts + expired ones, then sweep finished exports on an interval.
+recoverInterruptedExports();
+startExportSweeper();
+
 // In node edition, start reporting to the orchestrator (register on boot +
 // heartbeat on an interval). No-op in standalone or when unconfigured.
 startOrchestratorClient();
@@ -88,6 +98,7 @@ function shutdown(signal: string): void {
   stopOrchestratorClient();
   stopModerationReporter();
   stopIdentd();
+  shutdownExportJobs();
   ircManager.shutdown();
   server.close(() => process.exit(0));
   setTimeout(() => process.exit(1), 5000).unref();

--- a/server/services/exportJobs.test.ts
+++ b/server/services/exportJobs.test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+import type { Network } from '../db/networks.js';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-exportjobs-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let createUser: typeof import('../db/users.js').createUser;
+let createNetwork: typeof import('../db/networks.js').createNetwork;
+let jobs: typeof import('./exportJobs.js');
+let dataExports: typeof import('../db/dataExports.js');
+
+beforeAll(async () => {
+  await import('../db/index.js');
+  ({ createUser } = await import('../db/users.js'));
+  ({ createNetwork } = await import('../db/networks.js'));
+  jobs = await import('./exportJobs.js');
+  dataExports = await import('../db/dataExports.js');
+  const { buildExportZip } = await import('./exportService.js');
+
+  // In-process build runner: same separate-readonly-connection semantics as the
+  // production worker, but runnable under vitest.
+  jobs.setExportBuildRunnerForTests(async (spec, onProgress) => {
+    const reader = new Database(process.env.DATABASE_PATH!, { readonly: true });
+    try {
+      const out = fs.createWriteStream(spec.outPath);
+      await buildExportZip(
+        reader,
+        spec.userId,
+        { includeMessages: spec.includeMessages },
+        out,
+        onProgress,
+      );
+      return { byteSize: fs.statSync(spec.outPath).size };
+    } finally {
+      reader.close();
+    }
+  });
+});
+
+afterAll(() => {
+  jobs.setExportBuildRunnerForTests(null);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function waitFor(pred: () => boolean, timeoutMs = 5000): Promise<void> {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() - started > timeoutMs) return reject(new Error('timeout'));
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+describe('exportJobs lifecycle', () => {
+  it('builds an artifact on disk and marks the job done', async () => {
+    const u = createUser('jobs-alice');
+    createNetwork(u.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'a',
+    }) as Network;
+
+    const { job, alreadyRunning } = jobs.startExport(u.id, false);
+    expect(alreadyRunning).toBe(false);
+
+    await waitFor(() => dataExports.getExportJob(job.id)?.status === 'done');
+    const done = dataExports.getExportJob(job.id)!;
+    expect(done.status).toBe('done');
+    expect(done.byte_size).toBeGreaterThan(0);
+    expect(done.file_path).toBeTruthy();
+    expect(fs.existsSync(done.file_path!)).toBe(true);
+    expect(done.expires_at).toBeTruthy();
+  });
+
+  it('refuses a second concurrent export for the same user', () => {
+    const u = createUser('jobs-bob');
+    const existing = dataExports.createExportJob(u.id, false);
+    dataExports.markRunning(existing.id, 0);
+
+    const { job, alreadyRunning } = jobs.startExport(u.id, false);
+    expect(alreadyRunning).toBe(true);
+    expect(job.id).toBe(existing.id);
+  });
+
+  it('keeps only the newest completed export per user', async () => {
+    const u = createUser('jobs-erin');
+    createNetwork(u.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'e',
+    });
+
+    const first = jobs.startExport(u.id, false).job;
+    await waitFor(() => dataExports.getExportJob(first.id)?.status === 'done');
+    const firstPath = dataExports.getExportJob(first.id)!.file_path!;
+
+    const second = jobs.startExport(u.id, false).job;
+    await waitFor(() => dataExports.getExportJob(second.id)?.status === 'done');
+
+    // The earlier export's row + artifact are gone; only the newest survives.
+    expect(dataExports.getExportJob(first.id)).toBeUndefined();
+    expect(fs.existsSync(firstPath)).toBe(false);
+    expect(dataExports.getExportJob(second.id)?.status).toBe('done');
+  });
+
+  it('sweeps expired artifacts', () => {
+    const u = createUser('jobs-carol');
+    const j = dataExports.createExportJob(u.id, false);
+    const p = jobs.exportArtifactPath(j.token);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, 'artifact');
+    // ttlHours -1 → expires_at is in the past.
+    dataExports.markDone(j.id, { filePath: p, filename: 'x.lurk', byteSize: 8, ttlHours: -1 });
+
+    const removed = jobs.sweepExpiredExports();
+    expect(removed).toBeGreaterThanOrEqual(1);
+    expect(fs.existsSync(p)).toBe(false);
+    expect(dataExports.getExportJob(j.id)).toBeUndefined();
+  });
+
+  it('fails interrupted jobs and drops partials on boot recovery', () => {
+    const u = createUser('jobs-dave');
+    const j = dataExports.createExportJob(u.id, true);
+    dataExports.markRunning(j.id, 100);
+    const p = jobs.exportArtifactPath(j.token);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, 'partial');
+
+    jobs.recoverInterruptedExports();
+
+    const after = dataExports.getExportJob(j.id)!;
+    expect(after.status).toBe('error');
+    expect(after.error).toMatch(/restart/i);
+    expect(fs.existsSync(p)).toBe(false);
+  });
+});

--- a/server/services/exportJobs.test.ts
+++ b/server/services/exportJobs.test.ts
@@ -13,6 +13,7 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 
 let createUser: typeof import('../db/users.js').createUser;
 let createNetwork: typeof import('../db/networks.js').createNetwork;
+let insertMessage: typeof import('../db/messages.js').insertMessage;
 let jobs: typeof import('./exportJobs.js');
 let dataExports: typeof import('../db/dataExports.js');
 
@@ -20,6 +21,7 @@ beforeAll(async () => {
   await import('../db/index.js');
   ({ createUser } = await import('../db/users.js'));
   ({ createNetwork } = await import('../db/networks.js'));
+  ({ insertMessage } = await import('../db/messages.js'));
   jobs = await import('./exportJobs.js');
   dataExports = await import('../db/dataExports.js');
   const { buildExportZip } = await import('./exportService.js');
@@ -82,6 +84,51 @@ describe('exportJobs lifecycle', () => {
     expect(done.file_path).toBeTruthy();
     expect(fs.existsSync(done.file_path!)).toBe(true);
     expect(done.expires_at).toBeTruthy();
+  });
+
+  it('persists the worker-reported total so progress never exceeds 100%', async () => {
+    const u = createUser('jobs-total');
+    const net = createNetwork(u.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 't',
+    }) as Network;
+    for (let i = 0; i < 2500; i += 1) {
+      insertMessage({
+        networkId: net.id,
+        target: '#t',
+        time: '2026-05-17T10:00:00Z',
+        type: 'message',
+        nick: 't',
+        text: `m ${i}`,
+        self: false,
+      });
+    }
+
+    const { job } = jobs.startExport(u.id, true);
+    await waitFor(() => dataExports.getExportJob(job.id)?.status === 'done');
+    const done = dataExports.getExportJob(job.id)!;
+    expect(done.total_rows).toBe(2500);
+    expect(done.processed_rows).toBe(2500);
+    // The invariant the relay fix guarantees: the denominator never trails.
+    expect(done.processed_rows).toBeLessThanOrEqual(done.total_rows);
+  });
+
+  it('updateProgress overwrites a stale initial total with the worker-reported one', () => {
+    // Guards the relay fix deterministically: the worker's count is
+    // authoritative, so a progress frame carrying a total corrects a wrong
+    // initial markRunning estimate; a frame without one leaves it intact.
+    const u = createUser('jobs-progress');
+    const j = dataExports.createExportJob(u.id, true);
+    dataExports.markRunning(j.id, 1); // deliberately wrong estimate
+    dataExports.updateProgress(j.id, 2000, 5000);
+    expect(dataExports.getExportJob(j.id)!.total_rows).toBe(5000);
+    expect(dataExports.getExportJob(j.id)!.processed_rows).toBe(2000);
+    dataExports.updateProgress(j.id, 3000);
+    expect(dataExports.getExportJob(j.id)!.total_rows).toBe(5000);
+    expect(dataExports.getExportJob(j.id)!.processed_rows).toBe(3000);
   });
 
   it('refuses a second concurrent export for the same user', () => {

--- a/server/services/exportJobs.ts
+++ b/server/services/exportJobs.ts
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Lifecycle for per-user data-export jobs.
+//
+// A request to export account data creates a data_exports row and kicks off a
+// background build that runs OFF the main event loop and OFF the shared db
+// connection — a worker_thread with its own readonly SQLite connection (see
+// services/exportWorker.ts). The worker writes a .lurk archive to
+// data/exports/<token>.lurk; this module updates the row, relays progress to
+// the user's open tabs over the WebSocket, and serves the lifecycle endpoints.
+//
+// This module runs on the main thread, so importing the db singleton here is
+// fine (and necessary — it relays to wsHub, reads/writes data_exports). Only
+// the worker must avoid the singleton.
+
+import { Worker } from 'node:worker_threads';
+import fs from 'node:fs';
+import path from 'node:path';
+import db, { DATABASE_FILE } from '../db/index.js';
+import { fanOutToUser } from './wsHub.js';
+import { buildExportFilename, countExportMessages } from './exportService.js';
+import * as systemLog from './systemLog.js';
+import {
+  createExportJob,
+  getExportJob,
+  getActiveJobForUser,
+  markRunning,
+  updateProgress,
+  markDone,
+  markError,
+  listExpiredJobs,
+  listInflightJobs,
+  listSupersededDoneJobs,
+  deleteJob,
+  type ExportJob,
+} from '../db/dataExports.js';
+
+// Artifacts live next to the database, under data/exports/. data/ is already
+// gitignored; the dir is created 0700 (owner-only) on boot.
+const EXPORTS_DIR = path.join(path.dirname(DATABASE_FILE), 'exports');
+// How long a finished artifact survives before the sweep deletes it. Generous
+// enough to re-download from another device, short enough that a file full of
+// decrypted network passwords doesn't linger.
+const TTL_HOURS = 24;
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+// WS fan-out is throttled to this cadence (the worker already only reports
+// every PROGRESS_EVERY rows); status changes always emit immediately.
+const PROGRESS_THROTTLE_MS = 800;
+
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+// Live workers keyed by job id, so shutdown can terminate them.
+const activeWorkers = new Map<number, Worker>();
+const lastEmitAt = new Map<number, number>();
+
+function ensureExportsDir(): void {
+  fs.mkdirSync(EXPORTS_DIR, { recursive: true, mode: 0o700 });
+}
+
+function artifactPath(token: string): string {
+  return path.join(EXPORTS_DIR, `${token}.lurk`);
+}
+
+function safeUnlink(filePath: string | null | undefined): void {
+  if (!filePath) return;
+  try {
+    fs.unlinkSync(filePath);
+  } catch (_) {
+    /* already gone */
+  }
+}
+
+function getUsername(userId: number): string {
+  const row = db.prepare('SELECT username FROM users WHERE id = ?').get(userId) as
+    | { username: string }
+    | undefined;
+  return row?.username || 'user';
+}
+
+// SQLite stores datetimes as 'YYYY-MM-DD HH:MM:SS' in UTC. Hand the client an
+// ISO-8601 UTC string it can parse and render relatively.
+function toIso(sqliteDatetime: string | null): string | null {
+  return sqliteDatetime ? sqliteDatetime.replace(' ', 'T') + 'Z' : null;
+}
+
+/** Serialize a job row into the shape the client store/WS consume. */
+export function toClientJob(row: ExportJob): Record<string, unknown> {
+  return {
+    id: row.id,
+    status: row.status,
+    includeMessages: !!row.include_messages,
+    total: row.total_rows,
+    processed: row.processed_rows,
+    filename: row.filename,
+    byteSize: row.byte_size,
+    error: row.error,
+    createdAt: toIso(row.created_at),
+    expiresAt: toIso(row.expires_at),
+    downloadable: row.status === 'done',
+  };
+}
+
+function emit(userId: number, jobId: number): void {
+  const row = getExportJob(jobId);
+  if (!row) return;
+  fanOutToUser(userId, { kind: 'export', job: toClientJob(row) });
+}
+
+// ---- build runner (injectable for tests) ----
+//
+// In production this spawns the worker_thread. Tests swap in an in-process
+// runner that opens its own readonly connection and builds directly — same
+// separate-connection semantics, but runnable under vitest (which doesn't
+// transform .ts files loaded by node:worker_threads).
+
+export interface BuildSpec {
+  jobId: number;
+  dbPath: string;
+  userId: number;
+  includeMessages: boolean;
+  outPath: string;
+}
+export type BuildRunner = (
+  spec: BuildSpec,
+  onProgress: (processed: number, total: number) => void,
+) => Promise<{ byteSize: number }>;
+
+function spawnWorkerBuild(
+  spec: BuildSpec,
+  onProgress: (processed: number, total: number) => void,
+): Promise<{ byteSize: number }> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL('./exportWorker.js', import.meta.url), {
+      workerData: {
+        dbPath: spec.dbPath,
+        userId: spec.userId,
+        includeMessages: spec.includeMessages,
+        outPath: spec.outPath,
+      },
+    });
+    activeWorkers.set(spec.jobId, worker);
+    let settled = false;
+    worker.on(
+      'message',
+      (msg: {
+        type: string;
+        processed?: number;
+        total?: number;
+        byteSize?: number;
+        message?: string;
+      }) => {
+        if (msg.type === 'progress') {
+          onProgress(msg.processed ?? 0, msg.total ?? 0);
+        } else if (msg.type === 'done') {
+          settled = true;
+          resolve({ byteSize: msg.byteSize ?? 0 });
+        } else if (msg.type === 'error') {
+          settled = true;
+          reject(new Error(msg.message || 'export worker failed'));
+        }
+      },
+    );
+    worker.on('error', (err) => {
+      if (!settled) reject(err);
+    });
+    worker.on('exit', (code) => {
+      if (!settled) reject(new Error(`export worker exited (code ${code}) before completing`));
+    });
+  });
+}
+
+let buildRunner: BuildRunner = spawnWorkerBuild;
+
+/** Test seam: override the build runner (pass null to restore the worker). */
+export function setExportBuildRunnerForTests(fn: BuildRunner | null): void {
+  buildRunner = fn ?? spawnWorkerBuild;
+}
+
+function relayProgress(jobId: number, userId: number, processed: number): void {
+  updateProgress(jobId, processed);
+  const now = Date.now();
+  if (now - (lastEmitAt.get(jobId) ?? 0) < PROGRESS_THROTTLE_MS) return;
+  lastEmitAt.set(jobId, now);
+  emit(userId, jobId);
+}
+
+async function runBuild(
+  job: ExportJob,
+  opts: { userId: number; includeMessages: boolean; outPath: string; filename: string },
+): Promise<void> {
+  try {
+    const { byteSize } = await buildRunner(
+      {
+        jobId: job.id,
+        dbPath: DATABASE_FILE,
+        userId: opts.userId,
+        includeMessages: opts.includeMessages,
+        outPath: opts.outPath,
+      },
+      (processed) => relayProgress(job.id, opts.userId, processed),
+    );
+    markDone(job.id, {
+      filePath: opts.outPath,
+      filename: opts.filename,
+      byteSize,
+      ttlHours: TTL_HOURS,
+    });
+    // Keep only the freshest export per user — delete the artifacts (and rows)
+    // of any earlier completed job.
+    for (const old of listSupersededDoneJobs(opts.userId, job.id)) {
+      safeUnlink(old.file_path);
+      deleteJob(old.id);
+    }
+    emit(opts.userId, job.id);
+  } catch (err) {
+    markError(job.id, err instanceof Error ? err.message : String(err));
+    safeUnlink(opts.outPath);
+    emit(opts.userId, job.id);
+    systemLog.log({
+      scope: 'export',
+      level: 'warn',
+      text: `Export job ${job.id} failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+  } finally {
+    activeWorkers.delete(job.id);
+    lastEmitAt.delete(job.id);
+  }
+}
+
+/**
+ * Start an export for `userId`. Refuses (returns the existing job) if one is
+ * already pending/running — one export at a time per user. The heavy build
+ * runs in the background; this returns as soon as the job row exists.
+ */
+export function startExport(
+  userId: number,
+  includeMessages: boolean,
+): { job: ExportJob; alreadyRunning: boolean } {
+  const active = getActiveJobForUser(userId);
+  if (active) return { job: active, alreadyRunning: true };
+
+  ensureExportsDir();
+  const job = createExportJob(userId, includeMessages);
+  const total = includeMessages ? countExportMessages(db, userId) : 0;
+  markRunning(job.id, total);
+  const outPath = artifactPath(job.token);
+  const filename = buildExportFilename(getUsername(userId), { includeMessages });
+  emit(userId, job.id);
+
+  // Fire-and-forget; runBuild owns all terminal state transitions + WS events.
+  void runBuild(getExportJob(job.id)!, { userId, includeMessages, outPath, filename });
+  return { job: getExportJob(job.id)!, alreadyRunning: false };
+}
+
+/** Delete expired artifacts + their rows. Called on an interval and on boot. */
+export function sweepExpiredExports(): number {
+  let removed = 0;
+  for (const job of listExpiredJobs()) {
+    safeUnlink(job.file_path);
+    deleteJob(job.id);
+    removed += 1;
+  }
+  return removed;
+}
+
+// Delete any file in the exports dir that no live row claims — partials left by
+// a crash, or artifacts whose row was already swept.
+function sweepOrphanFiles(): void {
+  let names: string[];
+  try {
+    names = fs.readdirSync(EXPORTS_DIR);
+  } catch (_) {
+    return; // dir doesn't exist yet
+  }
+  const claimed = new Set(
+    (db.prepare(`SELECT token FROM data_exports`).all() as { token: string }[]).map(
+      (r) => `${r.token}.lurk`,
+    ),
+  );
+  for (const name of names) {
+    if (!claimed.has(name)) safeUnlink(path.join(EXPORTS_DIR, name));
+  }
+}
+
+/**
+ * Boot recovery: any job still marked pending/running was orphaned by a
+ * restart (its worker died with the process). Fail it, drop its partial file,
+ * then sweep expired artifacts and orphan files. Call once at startup.
+ */
+export function recoverInterruptedExports(): void {
+  ensureExportsDir();
+  for (const job of listInflightJobs()) {
+    safeUnlink(artifactPath(job.token));
+    markError(job.id, 'interrupted by a server restart');
+  }
+  sweepExpiredExports();
+  sweepOrphanFiles();
+}
+
+export function startExportSweeper(): void {
+  if (sweepTimer) return;
+  sweepTimer = setInterval(sweepExpiredExports, SWEEP_INTERVAL_MS);
+  sweepTimer.unref();
+}
+
+export function stopExportSweeper(): void {
+  if (sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}
+
+/** Terminate any in-flight worker. Called on graceful shutdown. */
+export function shutdownExportJobs(): void {
+  stopExportSweeper();
+  for (const worker of activeWorkers.values()) {
+    void worker.terminate();
+  }
+  activeWorkers.clear();
+}
+
+/** The absolute path an artifact would live at — used by the download route. */
+export function exportArtifactPath(token: string): string {
+  return artifactPath(token);
+}

--- a/server/services/exportJobs.ts
+++ b/server/services/exportJobs.ts
@@ -176,8 +176,8 @@ export function setExportBuildRunnerForTests(fn: BuildRunner | null): void {
   buildRunner = fn ?? spawnWorkerBuild;
 }
 
-function relayProgress(jobId: number, userId: number, processed: number): void {
-  updateProgress(jobId, processed);
+function relayProgress(jobId: number, userId: number, processed: number, total: number): void {
+  updateProgress(jobId, processed, total);
   const now = Date.now();
   if (now - (lastEmitAt.get(jobId) ?? 0) < PROGRESS_THROTTLE_MS) return;
   lastEmitAt.set(jobId, now);
@@ -197,7 +197,7 @@ async function runBuild(
         includeMessages: opts.includeMessages,
         outPath: opts.outPath,
       },
-      (processed) => relayProgress(job.id, opts.userId, processed),
+      (processed, total) => relayProgress(job.id, opts.userId, processed, total),
     );
     markDone(job.id, {
       filePath: opts.outPath,

--- a/server/services/exportService.test.ts
+++ b/server/services/exportService.test.ts
@@ -7,6 +7,7 @@ import os from 'os';
 import path from 'path';
 import { PassThrough } from 'stream';
 import yauzl from 'yauzl';
+import Database from 'better-sqlite3';
 import type { User } from '../db/users.js';
 import type { Network } from '../db/networks.js';
 
@@ -83,7 +84,7 @@ async function runExport(userId: number, opts: { includeMessages: boolean }): Pr
   const sink = new PassThrough();
   const chunks: Buffer[] = [];
   sink.on('data', (c: Buffer) => chunks.push(c));
-  await buildExportZip(userId, opts, sink);
+  await buildExportZip(db, userId, opts, sink);
   return Buffer.concat(chunks);
 }
 
@@ -240,6 +241,70 @@ describe('buildExportZip', () => {
   });
 });
 
+describe('export under concurrent IRC writes (lurker#175 regression)', () => {
+  it('does not throw "database connection is busy" when the bouncer writes mid-export', async () => {
+    const u = createUser('concurrent-writer');
+    const net = createNetwork(u.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'c',
+    }) as Network;
+    for (let i = 0; i < 3000; i += 1) {
+      insertMessage({
+        networkId: net.id,
+        target: '#c',
+        time: '2026-05-17T10:00:00Z',
+        type: 'message',
+        nick: 'c',
+        text: `seed ${i}`,
+        self: false,
+      });
+    }
+
+    const sink = new PassThrough();
+    const chunks: Buffer[] = [];
+    let liveWrites = 0;
+    let writeError: unknown = null;
+    sink.on('data', (chunk: Buffer) => {
+      chunks.push(chunk);
+      // The readonly export cursor is open right now. On the old single shared
+      // connection this insert threw "database connection is busy" and crashed
+      // the process (lurker#175); on a separate connection it must succeed.
+      if (liveWrites < 100) {
+        try {
+          insertMessage({
+            networkId: net.id,
+            target: '#c',
+            time: '2026-05-17T10:05:00Z',
+            type: 'message',
+            nick: 'c',
+            text: `live ${liveWrites}`,
+            self: false,
+          });
+          liveWrites += 1;
+        } catch (e) {
+          writeError = e;
+        }
+      }
+    });
+
+    // The export reads from its OWN readonly connection (as the worker does);
+    // insertMessage writes on the shared singleton. WAL lets them coexist.
+    const reader = new Database(process.env.DATABASE_PATH as string, { readonly: true });
+    try {
+      await buildExportZip(reader, u.id, { includeMessages: true }, sink);
+    } finally {
+      reader.close();
+    }
+
+    expect(writeError).toBeNull();
+    expect(liveWrites).toBeGreaterThan(0);
+    expect(Buffer.concat(chunks).slice(0, 2).toString()).toBe('PK');
+  });
+});
+
 describe('buildExportFilename', () => {
   it('includes username and date and a settings suffix when no messages', () => {
     const name = buildExportFilename('alice', { includeMessages: false });
@@ -260,7 +325,7 @@ describe('computeExportPreview', () => {
     const aliceRow = db.prepare(`SELECT id FROM users WHERE username = 'alice'`).get() as {
       id: number;
     };
-    const counts = computeExportPreview(aliceRow.id, { includeMessages: false });
+    const counts = computeExportPreview(db, aliceRow.id, { includeMessages: false });
     expect(counts.messages).toBe(0);
     expect(counts.networks).toBeGreaterThan(0);
   });
@@ -268,7 +333,7 @@ describe('computeExportPreview', () => {
     const aliceRow = db.prepare(`SELECT id FROM users WHERE username = 'alice'`).get() as {
       id: number;
     };
-    const counts = computeExportPreview(aliceRow.id, { includeMessages: true });
+    const counts = computeExportPreview(db, aliceRow.id, { includeMessages: true });
     expect(counts.messages).toBeGreaterThan(0);
   });
 });

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -1,18 +1,31 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// Per-user data export. Streams a zip to a writable destination (typically
-// the HTTP response). Driven entirely by EXPORT_TABLES — if a table is
-// declared as exported there, it lands in the zip; if it's declared as
-// skipped, it doesn't. The schema tripwire in exportSchema.test.js
-// guarantees the registry covers every live table.
+// Per-user data export. Streams a zip to a writable destination (a file on
+// disk, written by the background export worker — or, in tests, a PassThrough).
+// Driven entirely by EXPORT_TABLES — if a table is declared as exported there,
+// it lands in the zip; if it's declared as skipped, it doesn't. The schema
+// tripwire in exportSchema.test.js guarantees the registry covers every live
+// table.
+//
+// IMPORTANT: this module is connection-agnostic — every function takes the
+// `better-sqlite3` connection to read from as its first argument and this file
+// deliberately does NOT import the db singleton (`db/index.ts`). That keeps it
+// safe to import inside a worker thread, which opens its OWN readonly
+// connection to the same WAL file. Holding a streaming `.iterate()` cursor open
+// on the *shared* connection while the IRC bouncer writes is what crashed the
+// process before (better-sqlite3 throws "database connection is busy"); a
+// separate reader connection makes that collision structurally impossible.
 
 import type { Writable } from 'stream';
 import { Readable } from 'stream';
+import type { Database } from 'better-sqlite3';
 import { ZipArchive } from 'archiver';
-import db from '../db/index.js';
-import { EXPORT_TABLES, EXPORT_FORMAT_VERSION } from '../db/exportSchema.js';
-import { ENCRYPTED_NETWORK_COLUMNS } from '../db/networks.js';
+import {
+  EXPORT_TABLES,
+  EXPORT_FORMAT_VERSION,
+  ENCRYPTED_NETWORK_COLUMNS,
+} from '../db/exportSchema.js';
 import { decryptSecret } from '../utils/secretCrypto.js';
 
 interface ExportTableDefWithScope {
@@ -25,6 +38,9 @@ interface ExportTableDefWithScope {
   rekeyOnImport?: boolean;
   fkRekey?: Record<string, string>;
 }
+
+/** Called periodically as messages stream out so the job row + WS can report progress. */
+export type ExportProgressFn = (processed: number, total: number) => void;
 
 // SQL fragment that filters a table to a single user's rows. Returned as
 // `{ where, params }` so callers can splice it into a SELECT.
@@ -49,7 +65,7 @@ function scopeFilter(scope: string, userId: number): { where: string; params: nu
   }
 }
 
-function countRows(table: string, scope: string, userId: number): number {
+function countRows(db: Database, table: string, scope: string, userId: number): number {
   const { where, params } = scopeFilter(scope, userId);
   return (db.prepare(`SELECT COUNT(*) AS n FROM ${table} ${where}`).get(...params) as { n: number })
     .n;
@@ -73,9 +89,16 @@ function projectRow(
   return out;
 }
 
+// How often to fire the progress callback while streaming messages. Cheap to
+// emit (the job manager throttles WS fan-out on top of this), but no point
+// calling it for every single row.
+const PROGRESS_EVERY = 2000;
+
 function* messagesNdjsonGenerator(
+  db: Database,
   userId: number,
-  networkIdToCount: { total: number },
+  total: number,
+  onProgress?: ExportProgressFn,
 ): Generator<string> {
   const def = EXPORT_TABLES.messages as ExportTableDefWithScope;
   const { where, params } = scopeFilter(def.scope, userId);
@@ -83,13 +106,17 @@ function* messagesNdjsonGenerator(
   const cursor = db
     .prepare(`SELECT ${cols} FROM messages ${where} ORDER BY id ASC`)
     .iterate(...params);
+  let processed = 0;
   for (const row of cursor) {
-    networkIdToCount.total += 1;
+    processed += 1;
+    if (onProgress && processed % PROGRESS_EVERY === 0) onProgress(processed, total);
     yield JSON.stringify(projectRow(row as Record<string, unknown>, def)) + '\n';
   }
+  if (onProgress) onProgress(processed, total);
 }
 
 function selectAll(
+  db: Database,
   table: string,
   def: ExportTableDefWithScope,
   userId: number,
@@ -104,6 +131,7 @@ function selectAll(
 }
 
 export function computeExportPreview(
+  db: Database,
   userId: number,
   { includeMessages = false } = {},
 ): Record<string, number> {
@@ -119,12 +147,22 @@ export function computeExportPreview(
       counts[table] = 0;
       continue;
     }
-    counts[table] = countRows(table, d.scope, userId);
+    counts[table] = countRows(db, table, d.scope, userId);
   }
   return counts;
 }
 
-function getSchemaVersion(): number {
+/** Total messages a with-history export will write for `userId` (the progress denominator). */
+export function countExportMessages(db: Database, userId: number): number {
+  return countRows(
+    db,
+    'messages',
+    (EXPORT_TABLES.messages as ExportTableDefWithScope).scope,
+    userId,
+  );
+}
+
+function getSchemaVersion(db: Database): number {
   const row = db.prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`).get() as
     | { value: string }
     | undefined;
@@ -135,14 +173,17 @@ function getSchemaVersion(): number {
 // archive has been finalized (every byte is in destStream's buffer or
 // further downstream). Rejects if archiver emits an error.
 //
-// The destination is typically the express `res` object; the caller is
-// responsible for setting Content-Type and Content-Disposition before
-// calling this. We don't set them here so the function is reusable from
-// tests that pipe into a `PassThrough`.
+// `db` is the connection to read from. In production this is the export
+// worker's own readonly connection; in tests it can be the singleton or a
+// second connection. The caller owns Content-Type / Content-Disposition (when
+// piping to an HTTP response) — we don't set them here so the function stays
+// reusable from the worker (piping to a file) and tests (piping to a stream).
 export async function buildExportZip(
+  db: Database,
   userId: number,
   { includeMessages = false } = {},
   destStream: Writable,
+  onProgress?: ExportProgressFn,
 ): Promise<void> {
   const archive = new ZipArchive({ zlib: { level: 6 } });
   const archiveDone = new Promise<void>((resolve, reject) => {
@@ -167,7 +208,7 @@ export async function buildExportZip(
     const d = def as ExportTableDefWithScope;
     if (d.mode !== 'export' && d.mode !== 'partial') continue;
     if (d.section && d.section !== 'data') continue;
-    const rows = selectAll(table, d, userId);
+    const rows = selectAll(db, table, d, userId);
     // Network secrets live encrypted at rest on hosted cells; decrypt them so
     // the export is portable plaintext (restorable on a self-host without the
     // key) — same content the user sees in the app. No-op on a self-host
@@ -195,24 +236,19 @@ export async function buildExportZip(
   // ---- messages.ndjson ----
   if (includeMessages) {
     sections.push('messages');
-    const totalRef = { total: 0 };
-    const messagesStream = Readable.from(messagesNdjsonGenerator(userId, totalRef), {
+    // COUNT(*) up front gives the progress denominator and the manifest count;
+    // it's cheap on the indexed selection and known before the stream drains.
+    const total = countExportMessages(db, userId);
+    counts.messages = total;
+    const messagesStream = Readable.from(messagesNdjsonGenerator(db, userId, total, onProgress), {
       encoding: 'utf8',
     });
     archive.append(messagesStream, { name: 'messages.ndjson' });
-    // We populate counts.messages from the registry preview, since the
-    // generator-based count is only known after the stream drains. The
-    // preview path uses COUNT(*) which is cheap for any indexed selection.
-    counts.messages = countRows(
-      'messages',
-      (EXPORT_TABLES.messages as ExportTableDefWithScope).scope,
-      userId,
-    );
 
     // ---- bookmarks.json ----
     sections.push('bookmarks');
     const bookmarksDef = EXPORT_TABLES.user_bookmarks as ExportTableDefWithScope;
-    const bookmarkRows = selectAll('user_bookmarks', bookmarksDef, userId).map((row) =>
+    const bookmarkRows = selectAll(db, 'user_bookmarks', bookmarksDef, userId).map((row) =>
       projectRow(row, bookmarksDef),
     );
     archive.append(JSON.stringify(bookmarkRows, null, 2), { name: 'bookmarks.json' });
@@ -227,7 +263,7 @@ export async function buildExportZip(
   // ---- manifest.json ----
   const manifest = {
     export_format_version: EXPORT_FORMAT_VERSION,
-    db_schema_version: getSchemaVersion(),
+    db_schema_version: getSchemaVersion(db),
     exported_at: new Date().toISOString(),
     source_user_id: userId,
     sections,

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -109,10 +109,15 @@ function* messagesNdjsonGenerator(
   let processed = 0;
   for (const row of cursor) {
     processed += 1;
-    if (onProgress && processed % PROGRESS_EVERY === 0) onProgress(processed, total);
+    // `total` is a COUNT(*) taken just before this iteration; a write committing
+    // between the two can make the stream yield more rows than the count. Report
+    // max(total, processed) so the denominator never trails the numerator.
+    if (onProgress && processed % PROGRESS_EVERY === 0) {
+      onProgress(processed, Math.max(total, processed));
+    }
     yield JSON.stringify(projectRow(row as Record<string, unknown>, def)) + '\n';
   }
-  if (onProgress) onProgress(processed, total);
+  if (onProgress) onProgress(processed, Math.max(total, processed));
 }
 
 function selectAll(

--- a/server/services/exportWorker.ts
+++ b/server/services/exportWorker.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Background worker that builds a user's data-export .lurk archive.
+//
+// Runs in a worker_thread spawned by services/exportJobs.ts. It opens its OWN
+// readonly better-sqlite3 connection to the same WAL database the main process
+// is writing to. WAL allows a concurrent reader alongside the live writer, so
+// the streaming `.iterate()` cursor that backs messages.ndjson never touches
+// the connection the IRC bouncer inserts on. That separation is the whole
+// point: building the export inline on the shared connection is what threw
+// "this database connection is busy executing a query" and crashed the process
+// (lurker#175).
+//
+// It MUST NOT import the db singleton (db/index.ts) — doing so would open a
+// second writer connection in the worker and re-run migrations. exportService
+// is deliberately connection-agnostic so this worker can pass its own handle.
+
+import { parentPort, workerData } from 'node:worker_threads';
+import { createWriteStream, statSync } from 'node:fs';
+import Database from 'better-sqlite3';
+import { buildExportZip } from './exportService.js';
+
+export interface ExportWorkerData {
+  dbPath: string;
+  userId: number;
+  includeMessages: boolean;
+  outPath: string;
+}
+
+export type ExportWorkerMessage =
+  | { type: 'progress'; processed: number; total: number }
+  | { type: 'done'; byteSize: number }
+  | { type: 'error'; message: string };
+
+function post(msg: ExportWorkerMessage): void {
+  // worker_threads postMessage has no targetOrigin (that's window.postMessage);
+  // the lint rule doesn't distinguish the two.
+  // oxlint-disable-next-line unicorn/require-post-message-target-origin
+  parentPort?.postMessage(msg);
+}
+
+async function run(): Promise<void> {
+  const { dbPath, userId, includeMessages, outPath } = workerData as ExportWorkerData;
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    // 0600 — the artifact carries decrypted network passwords; keep it readable
+    // only by the cell's own user (it's served back over the authenticated
+    // download endpoint, never directly).
+    const out = createWriteStream(outPath, { mode: 0o600 });
+    await buildExportZip(db, userId, { includeMessages }, out, (processed, total) => {
+      post({ type: 'progress', processed, total });
+    });
+    const byteSize = statSync(outPath).size;
+    post({ type: 'done', byteSize });
+  } finally {
+    db.close();
+  }
+}
+
+run().catch((err: unknown) => {
+  post({ type: 'error', message: err instanceof Error ? err.message : String(err) });
+  process.exitCode = 1;
+});

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -72,7 +72,7 @@ async function exportToBuffer(userId: number, opts: { includeMessages: boolean }
   const sink = new PassThrough();
   const chunks: Buffer[] = [];
   sink.on('data', (c: Buffer) => chunks.push(c));
-  await buildExportZip(userId, opts, sink);
+  await buildExportZip(db, userId, opts, sink);
   return Buffer.concat(chunks);
 }
 

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -2,20 +2,41 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Per-user data import. Reads a zip produced by exportService and replays it
-// into the database under the *importing* user's id. Refuses to import into
-// an account that already has data — keep the flow simple and predictable:
-// fresh accounts only.
+// into the database under the *importing* user's id. Refuses to import into an
+// account that already has data — keep the flow simple and predictable: fresh
+// accounts only.
 //
-// The whole import runs inside a single db.transaction() so a malformed
-// archive (or a row that violates a FK constraint) rolls back cleanly and
-// leaves the user's account empty for a retry.
+// The archive is read straight from disk (yauzl.open, not fromBuffer) and the
+// potentially-huge messages.ndjson is streamed line-by-line, inserted in
+// batched transactions with a yield to the event loop between batches. That's
+// the fix for lurker#180: the old path buffered the whole zip in memory and
+// inserted every message in ONE synchronous transaction, which froze the event
+// loop (and starved every other user's WebSocket/IRC) on a large restore.
+//
+// We can no longer wrap the entire import in a single transaction (you can't
+// `await` a yield inside better-sqlite3's synchronous transaction), so atomicity
+// is preserved differently: on any failure we wipe the account back to empty
+// (resetImportedData) so the user can retry — same end state the single
+// transaction's rollback used to give.
 
 import yauzl from 'yauzl';
+import type { ZipFile, Entry } from 'yauzl';
+import readline from 'node:readline';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { setImmediate as yieldToEventLoop } from 'node:timers/promises';
 import type { Statement, RunResult } from 'better-sqlite3';
 import db from '../db/index.js';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION, IMPORT_ORDER } from '../db/exportSchema.js';
 import { ENCRYPTED_NETWORK_COLUMNS } from '../db/networks.js';
 import { encryptSecret } from '../utils/secretCrypto.js';
+
+// Messages inserted per transaction before yielding to the event loop. Big
+// enough that per-tx overhead is negligible, small enough that the loop never
+// stalls long enough to drop a heartbeat.
+const MESSAGE_BATCH = 1000;
 
 interface ExportTableDefFull {
   mode: string;
@@ -28,9 +49,6 @@ interface ExportTableDefFull {
   fkRekey?: Record<string, string>;
   // FK columns that should be set to NULL — rather than causing the whole
   // row to be dropped — when their referenced id is missing from the map.
-  // Used for nullable foreign keys whose absence is recoverable (e.g. a
-  // /clear marker whose boundary message is gone; the rest of the
-  // buffer_reads row, including the read pointer, is still valid).
   fkRekeyNullable?: string[];
 }
 
@@ -42,40 +60,62 @@ export class ImportError extends Error {
   }
 }
 
-function readZipToMap(buffer: Buffer): Promise<Map<string, Buffer>> {
+// Enumerate every entry in the zip up front (reads the central directory only —
+// no entry bodies). yauzl Entry objects stay valid for openReadStream while the
+// ZipFile is open, so we can then read entries in the order WE need (manifest +
+// data before messages), not the order archiver happened to write them.
+function openZipEntries(zipPath: string): Promise<{ zip: ZipFile; entries: Map<string, Entry> }> {
   return new Promise((resolve, reject) => {
-    yauzl.fromBuffer(buffer, { lazyEntries: true }, (err, zip) => {
-      if (err) return reject(new ImportError('not_a_zip', 'file is not a valid zip archive'));
-      const out = new Map<string, Buffer>();
-      zip.readEntry();
+    // autoClose:false — we enumerate ALL entries first (reading past the last
+    // entry), then openReadStream them in our own order. With the default
+    // autoClose the ZipFile would close as soon as enumeration finished and
+    // every later openReadStream would throw "closed". We close it ourselves in
+    // importFromZipFile's finally.
+    yauzl.open(zipPath, { lazyEntries: true, autoClose: false }, (err, zip) => {
+      if (err || !zip) {
+        reject(new ImportError('not_a_zip', 'file is not a valid zip archive'));
+        return;
+      }
+      const entries = new Map<string, Entry>();
       zip.on('error', reject);
-      zip.on('entry', (entry) => {
-        if (entry.fileName.endsWith('/')) {
-          zip.readEntry();
-          return;
-        }
-        zip.openReadStream(entry, (e2, stream) => {
-          if (e2) return reject(e2);
-          const chunks: Buffer[] = [];
-          stream.on('data', (c: Buffer) => chunks.push(c));
-          stream.on('end', () => {
-            out.set(entry.fileName, Buffer.concat(chunks));
-            zip.readEntry();
-          });
-          stream.on('error', reject);
-        });
+      zip.on('entry', (entry: Entry) => {
+        if (!entry.fileName.endsWith('/')) entries.set(entry.fileName, entry);
+        zip.readEntry();
       });
-      zip.on('end', () => resolve(out));
+      zip.on('end', () => resolve({ zip, entries }));
+      zip.readEntry();
     });
   });
+}
+
+function openEntryStream(zip: ZipFile, entry: Entry): Promise<NodeJS.ReadableStream> {
+  return new Promise((resolve, reject) => {
+    zip.openReadStream(entry, (err, stream) => {
+      if (err || !stream) reject(err || new Error('failed to open zip entry'));
+      else resolve(stream);
+    });
+  });
+}
+
+async function readEntryBuffer(zip: ZipFile, entry: Entry): Promise<Buffer> {
+  const stream = await openEntryStream(zip, entry);
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks);
+}
+
+function parseJson<T>(buf: Buffer, code: string, label: string): T {
+  try {
+    return JSON.parse(buf.toString('utf8')) as T;
+  } catch (_) {
+    throw new ImportError(code, `${label} is not valid JSON`);
+  }
 }
 
 // "Empty" means the user hasn't set up IRC on this instance yet. We
 // deliberately don't check user_settings because the client auto-syncs
 // system.timezone on every bootstrap, so a fresh account always has at
-// least one row there. user_settings inserts use INSERT OR REPLACE so the
-// imported timezone wins. Networks is the meaningful signal — if the user
-// has zero networks they haven't started using the app yet.
+// least one row there. Networks is the meaningful signal.
 function accountIsEmpty(userId: number): boolean {
   const row = db.prepare('SELECT COUNT(*) AS n FROM networks WHERE user_id = ?').get(userId) as {
     n: number;
@@ -83,17 +123,14 @@ function accountIsEmpty(userId: number): boolean {
   return row.n === 0;
 }
 
-// Build a positional INSERT for the columns we actually have. Always skips
-// an autoincrement PK so the target DB assigns a fresh id (rekeyOnImport
-// controls whether we *track* the old→new mapping for FKs, not whether we
-// reuse the old id).
+// Build a positional INSERT for the columns we actually have. Always skips an
+// autoincrement PK so the target DB assigns a fresh id.
 function buildInsertStatement(
   table: string,
   def: ExportTableDefFull,
 ): { stmt: Statement; cols: string[] } {
   const skipCols = new Set<string>();
   if (def.pk) skipCols.add(def.pk);
-  // upload_history's thumbnail is written separately from the thumbnails/ entries.
   if (def.blobColumns) for (const c of def.blobColumns) skipCols.add(c);
 
   const cols = def.columns.filter((c) => !skipCols.has(c));
@@ -116,12 +153,6 @@ function rekeyRow(
     if (target === 'users') {
       out[col] = targetUserId;
     } else {
-      // An absent map means the referenced table wasn't imported (e.g. a
-      // settings-only archive has no messages map, so buffer_reads rows
-      // can't find their last_read_message_id). Treat the same as a row
-      // missing from a populated map: leave undefined, let the caller drop.
-      // Columns flagged nullable map missing → null instead, so the rest
-      // of the row (other FKs, scalar data) survives.
       const map = idMaps[target];
       const mapped = map ? map.get(out[col]) : undefined;
       if (mapped === undefined) {
@@ -143,220 +174,284 @@ function dependsOnMessages(def: ExportTableDefFull): boolean {
   return !!(def.fkRekey && Object.values(def.fkRekey).includes('messages'));
 }
 
-export async function importFromZipBuffer(
+// Insert all rows of one data.json table, building its id map for FK rekeying.
+// Caller runs this inside a transaction.
+function insertTable(
+  table: string,
+  data: Record<string, Record<string, unknown>[]>,
+  idMaps: Record<string, Map<unknown, unknown>>,
+  counts: Record<string, number>,
   targetUserId: number,
-  zipBuffer: Buffer,
-): Promise<{
-  manifest: Record<string, unknown>;
-  counts: Record<string, number>;
-  thumbnailsAttached: number;
-}> {
-  const entries = await readZipToMap(zipBuffer);
+): void {
+  const def = EXPORT_TABLES[table as keyof typeof EXPORT_TABLES] as ExportTableDefFull;
+  const rows = data[table] || [];
+  const { stmt, cols } = buildInsertStatement(table, def);
 
-  // ---- manifest ----
-  if (!entries.has('manifest.json')) {
-    throw new ImportError('missing_manifest', 'archive does not contain manifest.json');
-  }
-  let manifest: Record<string, unknown>;
-  try {
-    manifest = JSON.parse(entries.get('manifest.json')!.toString('utf8')) as Record<
-      string,
-      unknown
-    >;
-  } catch (_) {
-    throw new ImportError('bad_manifest', 'manifest.json is not valid JSON');
-  }
-  if (typeof manifest.export_format_version !== 'number') {
-    throw new ImportError('bad_manifest', 'manifest is missing export_format_version');
-  }
-  if (manifest.export_format_version > EXPORT_FORMAT_VERSION) {
-    throw new ImportError(
-      'format_too_new',
-      `archive uses export_format_version ${manifest.export_format_version}; this server understands up to ${EXPORT_FORMAT_VERSION}`,
-    );
-  }
+  let inserted = 0;
+  for (const original of rows) {
+    const row = rekeyRow(original, def, idMaps, targetUserId);
 
-  // ---- data.json ----
-  if (!entries.has('data.json')) {
-    throw new ImportError('missing_data', 'archive does not contain data.json');
-  }
-  let data: Record<string, Record<string, unknown>[]>;
-  try {
-    data = JSON.parse(entries.get('data.json')!.toString('utf8')) as Record<
-      string,
-      Record<string, unknown>[]
-    >;
-  } catch (_) {
-    throw new ImportError('bad_data', 'data.json is not valid JSON');
-  }
-
-  // ---- empty-account guard ----
-  if (!accountIsEmpty(targetUserId)) {
-    throw new ImportError(
-      'account_not_empty',
-      'target account already has data; imports require a fresh account',
-    );
-  }
-
-  const counts: Record<string, number> = {};
-  const insertedThumbs: number[] = [];
-
-  // Run the whole import in one transaction.
-  const tx = db.transaction(() => {
-    const idMaps: Record<string, Map<unknown, unknown>> = {};
-
-    // The client auto-syncs system.timezone on every bootstrap, so a fresh
-    // account usually has 1+ rows in user_settings already. Wipe before we
-    // insert the imported settings — the import replaces, doesn't merge.
-    db.prepare('DELETE FROM user_settings WHERE user_id = ?').run(targetUserId);
-
-    function insertTable(table: string): void {
-      const def = EXPORT_TABLES[table as keyof typeof EXPORT_TABLES] as ExportTableDefFull;
-      const rows = data[table] || [];
-      const { stmt, cols } = buildInsertStatement(table, def);
-
-      let inserted = 0;
-      for (const original of rows) {
-        const row = rekeyRow(original, def, idMaps, targetUserId);
-
-        // Export carries network secrets as plaintext; re-encrypt them at rest
-        // when importing onto a keyed (hosted) cell. No-op without a key.
-        if (table === 'networks') {
-          for (const col of ENCRYPTED_NETWORK_COLUMNS) {
-            if (typeof row[col] === 'string') row[col] = encryptSecret(row[col] as string);
-          }
-        }
-
-        // If any required FK ended up undefined (referenced row wasn't in the
-        // export), drop the row.
-        let drop = false;
-        if (def.fkRekey) {
-          for (const col of Object.keys(def.fkRekey)) {
-            if (row[col] === undefined) {
-              drop = true;
-              break;
-            }
-          }
-        }
-        if (drop) continue;
-
-        const result = insertOne(stmt, cols, row);
-
-        if (def.rekeyOnImport && def.pk) {
-          idMaps[table] ??= new Map();
-          idMaps[table].set(original[def.pk], result.lastInsertRowid);
-        }
-        inserted += 1;
+    // Export carries network secrets as plaintext; re-encrypt them at rest when
+    // importing onto a keyed (hosted) cell. No-op without a key.
+    if (table === 'networks') {
+      for (const col of ENCRYPTED_NETWORK_COLUMNS) {
+        if (typeof row[col] === 'string') row[col] = encryptSecret(row[col] as string);
       }
-      counts[table] = inserted;
     }
 
-    // First pass: data.json tables that don't depend on messages.
-    for (const table of IMPORT_ORDER) {
-      const def = EXPORT_TABLES[table as keyof typeof EXPORT_TABLES] as
-        | ExportTableDefFull
-        | undefined;
-      if (!def || def.mode === 'skip') continue;
-      if (def.section === 'messages' || def.section === 'bookmarks') continue;
-      if (dependsOnMessages(def)) continue;
-      insertTable(table);
-    }
-
-    // ---- messages.ndjson ----
-    if (entries.has('messages.ndjson')) {
-      const def = EXPORT_TABLES.messages as ExportTableDefFull;
-      const { stmt, cols } = buildInsertStatement('messages', def);
-      idMaps.messages = new Map();
-      const lines = entries
-        .get('messages.ndjson')!
-        .toString('utf8')
-        .split('\n')
-        .filter((l) => l.length > 0);
-      let inserted = 0;
-      for (const line of lines) {
-        let original: Record<string, unknown>;
-        try {
-          original = JSON.parse(line) as Record<string, unknown>;
-        } catch (_) {
-          throw new ImportError('bad_messages', 'messages.ndjson contains a non-JSON line');
+    // If any required FK ended up undefined (referenced row wasn't in the
+    // export), drop the row.
+    let drop = false;
+    if (def.fkRekey) {
+      for (const col of Object.keys(def.fkRekey)) {
+        if (row[col] === undefined) {
+          drop = true;
+          break;
         }
-        const row = rekeyRow(original, def, idMaps, targetUserId);
-        // network_id is required; if it didn't map, drop the row.
-        if (row.network_id === undefined) continue;
-        // matched_rule_id is nullable; if its target rule wasn't in the
-        // export, fall back to null.
-        if (row.matched_rule_id === undefined) row.matched_rule_id = null;
-        // from_ignored was added later; older archives don't carry it, and
-        // the column is NOT NULL so a missing key would fail the insert.
-        if (row.from_ignored === undefined) row.from_ignored = 0;
-        const result = insertOne(stmt, cols, row);
-        idMaps.messages.set(original.id, result.lastInsertRowid);
-        inserted += 1;
       }
-      counts.messages = inserted;
-    } else {
-      counts.messages = 0;
     }
+    if (drop) continue;
 
-    // ---- bookmarks.json ----
-    if (entries.has('bookmarks.json')) {
-      const def = EXPORT_TABLES.user_bookmarks as ExportTableDefFull;
-      const { stmt, cols } = buildInsertStatement('user_bookmarks', def);
-      let bookmarks: Record<string, unknown>[];
+    const result = insertOne(stmt, cols, row);
+
+    if (def.rekeyOnImport && def.pk) {
+      idMaps[table] ??= new Map();
+      idMaps[table].set(original[def.pk], result.lastInsertRowid);
+    }
+    inserted += 1;
+  }
+  counts[table] = inserted;
+}
+
+// Stream messages.ndjson line-by-line and insert in batched transactions,
+// yielding to the event loop between batches so a large restore never stalls
+// the loop. Returns the number of rows inserted. Throws ImportError on a
+// malformed line (the caller wipes + retries).
+async function streamMessagesInBatches(
+  zip: ZipFile,
+  entry: Entry,
+  targetUserId: number,
+  idMaps: Record<string, Map<unknown, unknown>>,
+): Promise<number> {
+  const def = EXPORT_TABLES.messages as ExportTableDefFull;
+  const { stmt, cols } = buildInsertStatement('messages', def);
+  const messagesMap = idMaps.messages;
+  let inserted = 0;
+
+  const flush = db.transaction((lines: string[]) => {
+    for (const line of lines) {
+      if (line.length === 0) continue;
+      let original: Record<string, unknown>;
       try {
-        bookmarks = JSON.parse(entries.get('bookmarks.json')!.toString('utf8')) as Record<
-          string,
-          unknown
-        >[];
+        original = JSON.parse(line) as Record<string, unknown>;
       } catch (_) {
-        throw new ImportError('bad_bookmarks', 'bookmarks.json is not valid JSON');
+        throw new ImportError('bad_messages', 'messages.ndjson contains a non-JSON line');
       }
-      let inserted = 0;
-      for (const original of bookmarks) {
-        const row = rekeyRow(original, def, idMaps, targetUserId);
-        if (row.message_id === undefined) continue;
-        insertOne(stmt, cols, row);
-        inserted += 1;
-      }
-      counts.user_bookmarks = inserted;
-    } else {
-      counts.user_bookmarks = 0;
-    }
-
-    // Second pass: data.json tables that depend on the messages id map.
-    // Rows whose last_read_message_id (etc.) didn't make it into the
-    // export are dropped silently by the FK-undefined check.
-    for (const table of IMPORT_ORDER) {
-      const def = EXPORT_TABLES[table as keyof typeof EXPORT_TABLES] as
-        | ExportTableDefFull
-        | undefined;
-      if (!def || def.mode === 'skip') continue;
-      if (def.section === 'messages' || def.section === 'bookmarks') continue;
-      if (!dependsOnMessages(def)) continue;
-      insertTable(table);
-    }
-
-    // ---- thumbnails ----
-    if (idMaps.upload_history) {
-      const update = db.prepare('UPDATE upload_history SET thumbnail = ? WHERE id = ?');
-      for (const [filename, buf] of entries) {
-        const m = filename.match(/^thumbnails\/(\d+)\.jpg$/);
-        if (!m) continue;
-        const oldId = parseInt(m[1], 10);
-        const newId = idMaps.upload_history.get(oldId);
-        if (newId == null) continue;
-        update.run(buf, newId);
-        insertedThumbs.push(Number(newId));
-      }
+      const row = rekeyRow(original, def, idMaps, targetUserId);
+      // network_id is required; if it didn't map, drop the row.
+      if (row.network_id === undefined) continue;
+      // matched_rule_id is nullable; fall back to null if its rule wasn't exported.
+      if (row.matched_rule_id === undefined) row.matched_rule_id = null;
+      // from_ignored was added later; older archives omit it and the column is
+      // NOT NULL, so a missing key would fail the insert.
+      if (row.from_ignored === undefined) row.from_ignored = 0;
+      const result = insertOne(stmt, cols, row);
+      messagesMap.set(original.id, result.lastInsertRowid);
+      inserted += 1;
     }
   });
 
-  try {
-    tx();
-  } catch (err) {
-    if (err instanceof ImportError) throw err;
-    throw new ImportError('insert_failed', `import failed: ${(err as Error).message}`);
+  const stream = await openEntryStream(zip, entry);
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+  let batch: string[] = [];
+  for await (const line of rl) {
+    batch.push(line);
+    if (batch.length >= MESSAGE_BATCH) {
+      flush(batch);
+      batch = [];
+      await yieldToEventLoop();
+    }
   }
+  if (batch.length) flush(batch);
+  return inserted;
+}
 
-  return { manifest, counts, thumbnailsAttached: insertedThumbs.length };
+// Roll a partial import back to an empty account so the user can retry.
+// Deleting the user's networks cascades every network-scoped table
+// (channels/messages/buffer_reads/pinned_buffers/drafts/ignores/notes/
+// input_history/highlight_rule_networks, and user_bookmarks via messages); the
+// remaining tables are user-scoped roots that only cascade on user deletion, so
+// we clear them explicitly. Must cover every importable user-scoped root in
+// EXPORT_TABLES.
+function resetImportedData(userId: number): void {
+  const wipe = db.transaction(() => {
+    db.prepare('DELETE FROM networks WHERE user_id = ?').run(userId);
+    db.prepare('DELETE FROM highlight_rules WHERE user_id = ?').run(userId);
+    db.prepare('DELETE FROM user_settings WHERE user_id = ?').run(userId);
+    db.prepare('DELETE FROM upload_history WHERE user_id = ?').run(userId);
+    db.prepare('DELETE FROM user_away_state WHERE user_id = ?').run(userId);
+  });
+  wipe();
+}
+
+export interface ImportResult {
+  manifest: Record<string, unknown>;
+  counts: Record<string, number>;
+  thumbnailsAttached: number;
+}
+
+export async function importFromZipFile(
+  targetUserId: number,
+  zipPath: string,
+): Promise<ImportResult> {
+  const { zip, entries } = await openZipEntries(zipPath);
+  try {
+    // ---- manifest ----
+    const manifestEntry = entries.get('manifest.json');
+    if (!manifestEntry) {
+      throw new ImportError('missing_manifest', 'archive does not contain manifest.json');
+    }
+    const manifest = parseJson<Record<string, unknown>>(
+      await readEntryBuffer(zip, manifestEntry),
+      'bad_manifest',
+      'manifest.json',
+    );
+    if (typeof manifest.export_format_version !== 'number') {
+      throw new ImportError('bad_manifest', 'manifest is missing export_format_version');
+    }
+    if (manifest.export_format_version > EXPORT_FORMAT_VERSION) {
+      throw new ImportError(
+        'format_too_new',
+        `archive uses export_format_version ${manifest.export_format_version}; this server understands up to ${EXPORT_FORMAT_VERSION}`,
+      );
+    }
+
+    // ---- data.json ----
+    const dataEntry = entries.get('data.json');
+    if (!dataEntry) {
+      throw new ImportError('missing_data', 'archive does not contain data.json');
+    }
+    const data = parseJson<Record<string, Record<string, unknown>[]>>(
+      await readEntryBuffer(zip, dataEntry),
+      'bad_data',
+      'data.json',
+    );
+
+    // ---- empty-account guard ----
+    if (!accountIsEmpty(targetUserId)) {
+      throw new ImportError(
+        'account_not_empty',
+        'target account already has data; imports require a fresh account',
+      );
+    }
+
+    // ---- bookmarks.json (optional, small) ----
+    const bookmarksEntry = entries.get('bookmarks.json');
+    const bookmarks = bookmarksEntry
+      ? parseJson<Record<string, unknown>[]>(
+          await readEntryBuffer(zip, bookmarksEntry),
+          'bad_bookmarks',
+          'bookmarks.json',
+        )
+      : null;
+
+    // ---- thumbnails (small JPEGs) — read up front so phase C can apply them
+    // inside a synchronous transaction. ----
+    const thumbs = new Map<number, Buffer>();
+    for (const [name, entry] of entries) {
+      const m = name.match(/^thumbnails\/(\d+)\.jpg$/);
+      if (m) thumbs.set(parseInt(m[1], 10), await readEntryBuffer(zip, entry));
+    }
+
+    const counts: Record<string, number> = {};
+    const idMaps: Record<string, Map<unknown, unknown>> = {};
+    let thumbnailsAttached = 0;
+
+    try {
+      // ---- Phase A: data.json tables that don't depend on messages (one tx). ----
+      db.transaction(() => {
+        // Fresh accounts usually have an auto-synced system.timezone row; wipe
+        // before insert — import replaces, doesn't merge.
+        db.prepare('DELETE FROM user_settings WHERE user_id = ?').run(targetUserId);
+        for (const table of IMPORT_ORDER) {
+          const def = EXPORT_TABLES[table as keyof typeof EXPORT_TABLES] as
+            | ExportTableDefFull
+            | undefined;
+          if (!def || def.mode === 'skip') continue;
+          if (def.section === 'messages' || def.section === 'bookmarks') continue;
+          if (dependsOnMessages(def)) continue;
+          insertTable(table, data, idMaps, counts, targetUserId);
+        }
+      })();
+
+      // ---- Phase B: messages.ndjson (batched, yielding). ----
+      idMaps.messages = new Map();
+      const messagesEntry = entries.get('messages.ndjson');
+      counts.messages = messagesEntry
+        ? await streamMessagesInBatches(zip, messagesEntry, targetUserId, idMaps)
+        : 0;
+
+      // ---- Phase C: bookmarks + message-dependent tables + thumbnails (one tx). ----
+      db.transaction(() => {
+        if (bookmarks) {
+          const def = EXPORT_TABLES.user_bookmarks as ExportTableDefFull;
+          const { stmt, cols } = buildInsertStatement('user_bookmarks', def);
+          let inserted = 0;
+          for (const original of bookmarks) {
+            const row = rekeyRow(original, def, idMaps, targetUserId);
+            if (row.message_id === undefined) continue;
+            insertOne(stmt, cols, row);
+            inserted += 1;
+          }
+          counts.user_bookmarks = inserted;
+        } else {
+          counts.user_bookmarks = 0;
+        }
+
+        for (const table of IMPORT_ORDER) {
+          const def = EXPORT_TABLES[table as keyof typeof EXPORT_TABLES] as
+            | ExportTableDefFull
+            | undefined;
+          if (!def || def.mode === 'skip') continue;
+          if (def.section === 'messages' || def.section === 'bookmarks') continue;
+          if (!dependsOnMessages(def)) continue;
+          insertTable(table, data, idMaps, counts, targetUserId);
+        }
+
+        if (idMaps.upload_history && thumbs.size) {
+          const update = db.prepare('UPDATE upload_history SET thumbnail = ? WHERE id = ?');
+          for (const [oldId, buf] of thumbs) {
+            const newId = idMaps.upload_history.get(oldId);
+            if (newId == null) continue;
+            update.run(buf, newId);
+            thumbnailsAttached += 1;
+          }
+        }
+      })();
+    } catch (err) {
+      resetImportedData(targetUserId);
+      if (err instanceof ImportError) throw err;
+      throw new ImportError('insert_failed', `import failed: ${(err as Error).message}`);
+    }
+
+    return { manifest, counts, thumbnailsAttached };
+  } finally {
+    zip.close();
+  }
+}
+
+// Back-compat entrypoint: accepts an in-memory buffer (used by tests and any
+// caller that already has the bytes). Spills to a temp file and delegates to
+// the streaming path so there's a single import implementation.
+export async function importFromZipBuffer(
+  targetUserId: number,
+  zipBuffer: Buffer,
+): Promise<ImportResult> {
+  const tmp = path.join(os.tmpdir(), `lurker-import-${randomBytes(8).toString('hex')}.lurk`);
+  await fs.promises.writeFile(tmp, zipBuffer);
+  try {
+    return await importFromZipFile(targetUserId, tmp);
+  } finally {
+    await fs.promises.unlink(tmp).catch(() => {});
+  }
 }

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -448,7 +448,9 @@ export async function importFromZipBuffer(
   zipBuffer: Buffer,
 ): Promise<ImportResult> {
   const tmp = path.join(os.tmpdir(), `lurker-import-${randomBytes(8).toString('hex')}.lurk`);
-  await fs.promises.writeFile(tmp, zipBuffer);
+  // 0600 — the archive carries decrypted network passwords; don't leave it
+  // world-readable under a permissive umask.
+  await fs.promises.writeFile(tmp, zipBuffer, { mode: 0o600 });
   try {
     return await importFromZipFile(targetUserId, tmp);
   } finally {

--- a/server/services/networkSecretsRoundtrip.test.ts
+++ b/server/services/networkSecretsRoundtrip.test.ts
@@ -49,7 +49,7 @@ async function exportToBuffer(userId: number): Promise<Buffer> {
   const sink = new PassThrough();
   const chunks: Buffer[] = [];
   sink.on('data', (c: Buffer) => chunks.push(c));
-  await buildExportZip(userId, { includeMessages: false }, sink);
+  await buildExportZip(db, userId, { includeMessages: false }, sink);
   return Buffer.concat(chunks);
 }
 

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -24,12 +24,37 @@
         </li>
       </ul>
       <label class="opt">
-        <input type="checkbox" v-model="includeMessages" />
+        <input type="checkbox" v-model="includeMessages" :disabled="isBuilding" />
         Include message history ({{ preview.withMessages.messages.toLocaleString() }})
       </label>
-      <div class="actions">
-        <button class="link" @click="onDownload">download export</button>
+
+      <!-- Building: large exports run in the background; progress arrives over
+           the WebSocket. -->
+      <div v-if="isBuilding" class="export-state">
+        <p class="muted small">Preparing your export… {{ progressLabel }}</p>
       </div>
+
+      <!-- Ready: the artifact is on the server; download it from the
+           authenticated, resumable endpoint. -->
+      <div v-else-if="readyJob" class="export-state">
+        <p class="muted small">
+          Export ready — {{ formatBytes(readyJob.byteSize || 0)
+          }}<span v-if="readyJob.includeMessages"> with message history</span>{{ expiryNote }}.
+        </p>
+        <div class="actions">
+          <a class="link" :href="`/api/exports/${readyJob.id}/download`">download .lurk</a>
+          <button class="link" @click="onStart">rebuild</button>
+        </div>
+      </div>
+
+      <!-- Idle / after a failure: offer to (re)start. -->
+      <div v-else class="actions">
+        <button class="link" @click="onStart">prepare export</button>
+      </div>
+
+      <p v-if="failedJob" class="error inline">
+        Export failed: {{ failedJob.error || 'unknown error' }}.
+      </p>
     </div>
 
     <hr class="hl-sep" />
@@ -69,6 +94,7 @@ import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { api, apiMultipart } from '../../api.js';
 import { resetSession } from '../../composables/useSessionReset.js';
+import { useDataExportStore } from '../../stores/dataExport.js';
 
 interface ExportPreview {
   settingsOnly: Record<string, number>;
@@ -80,6 +106,32 @@ const router = useRouter();
 const preview = ref<ExportPreview | null>(null);
 const exportError = ref('');
 const includeMessages = ref(false);
+
+// Background-export job state, kept live by `export` WS events (see useSocket).
+const exportStore = useDataExportStore();
+const job = computed(() => exportStore.job);
+const isBuilding = computed(
+  () => job.value?.status === 'pending' || job.value?.status === 'running',
+);
+const readyJob = computed(() => (job.value?.status === 'done' ? job.value : null));
+const failedJob = computed(() => (job.value?.status === 'error' ? job.value : null));
+const progressLabel = computed(() => {
+  const j = job.value;
+  if (!j) return '';
+  if (j.includeMessages && j.total > 0) {
+    const pct = Math.min(100, Math.round((j.processed / j.total) * 100));
+    return `${j.processed.toLocaleString()} / ${j.total.toLocaleString()} messages (${pct}%)`;
+  }
+  return 'almost done';
+});
+const expiryNote = computed(() => {
+  const iso = readyJob.value?.expiresAt;
+  if (!iso) return '';
+  const ms = new Date(iso).getTime() - Date.now();
+  if (!Number.isFinite(ms) || ms <= 0) return '';
+  const hours = Math.round(ms / (60 * 60 * 1000));
+  return hours >= 1 ? `, expires in ~${hours}h` : ', expires soon';
+});
 
 const fileInputEl = ref<HTMLInputElement | null>(null);
 const chosenFile = ref<File | null>(null);
@@ -106,12 +158,27 @@ onMounted(async () => {
   } catch (e: any) {
     exportError.value = e.message || 'failed to load export preview';
   }
+  // Restore any in-flight or ready export so the pane reflects reality on load
+  // (WS events keep it current after this).
+  try {
+    const res = await api('/api/exports/latest');
+    if (res.job) exportStore.apply(res.job);
+  } catch {
+    /* non-fatal — the pane just starts in the idle state */
+  }
 });
 
-function onDownload() {
-  const qs = includeMessages.value ? '?include_messages=1' : '';
-  // Plain navigation; the browser handles the Content-Disposition.
-  window.location.href = `/api/exports${qs}`;
+async function onStart() {
+  exportError.value = '';
+  try {
+    const res = await api('/api/exports', {
+      method: 'POST',
+      body: { include_messages: includeMessages.value },
+    });
+    exportStore.apply(res.job);
+  } catch (e: any) {
+    exportError.value = e.message || 'failed to start export';
+  }
 }
 
 function onFileChosen(e: Event) {
@@ -195,6 +262,10 @@ function formatBytes(n: number): string {
   display: flex;
   gap: 1ch;
   align-items: center;
+  padding-top: var(--space-3);
+}
+
+.export-state {
   padding-top: var(--space-3);
 }
 

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -20,6 +20,7 @@ import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useSystemLogStore } from '../stores/systemLog.js';
+import { useDataExportStore } from '../stores/dataExport.js';
 import { notifyForEvent } from './useHighlightNotifier.js';
 
 export interface AckResult {
@@ -477,6 +478,12 @@ function handleMessage(raw: string): void {
   if (payload.kind === 'system-log') {
     const systemLog = useSystemLogStore();
     systemLog.applyLine(payload.line);
+    return;
+  }
+  if (payload.kind === 'export') {
+    // Background data-export progress / completion. The data settings pane
+    // renders from this store; it stays current even when that pane is closed.
+    useDataExportStore().apply(payload.job);
     return;
   }
 }

--- a/vue_client/src/stores/dataExport.ts
+++ b/vue_client/src/stores/dataExport.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineStore } from 'pinia';
+
+// Mirror of the user's current/most-recent data-export job. Seeded from
+// GET /api/exports/latest when the data settings pane mounts, kept live by the
+// `export` WebSocket events the server fans out as the background build
+// progresses. One job per user at a time, so a single slot is enough.
+export interface ClientExportJob {
+  id: number;
+  status: 'pending' | 'running' | 'done' | 'error';
+  includeMessages: boolean;
+  total: number;
+  processed: number;
+  filename: string | null;
+  byteSize: number | null;
+  error: string | null;
+  createdAt: string | null;
+  expiresAt: string | null;
+  downloadable: boolean;
+}
+
+export const useDataExportStore = defineStore('dataExport', {
+  state: () => ({
+    job: null as ClientExportJob | null,
+  }),
+  actions: {
+    apply(job: ClientExportJob | null) {
+      // Ignore an out-of-order update for an older job than the one we track
+      // (e.g. a late progress frame after the user kicked off a rebuild).
+      if (job && this.job && job.id < this.job.id) return;
+      this.job = job;
+    },
+    clear() {
+      this.job = null;
+    },
+  },
+});


### PR DESCRIPTION
## What

Reworks data export + import so a large account no longer takes the process down, and squares both sides away for beta.

Closes #175. Closes #180.

## The bug (#175)

Export streamed the zip **inline on the request**, pulling messages with an `.iterate()` cursor held open on the **single shared `better-sqlite3` connection** for the whole (backpressured) download. While that cursor was open, every inbound IRC line's `insertMessage` threw:

```
TypeError: This database connection is busy executing a query
    at insertMessage (server/db/messages.ts:106)
    at IrcConnection.publish (server/services/ircConnection.ts:305)
```

That insert isn't wrapped in a try/catch, so it was an uncaught exception → process exit → `restart: unless-stopped` → every network reconnects. Reproduced on any active account with a large export.

## The fix — async export

- **`POST /api/exports`** starts a build in a **`worker_thread`** that opens its **own readonly connection** to the same WAL file. WAL allows a concurrent reader alongside the live writer, so the streaming cursor never touches the connection the IRC bouncer writes on. This is the structural fix, not a mitigation.
- The artifact is written to **`data/exports/<token>.lurk`** (`0600`, dir `0700`) and served from **`GET /api/exports/:id/download`** — `requireAuth` + ownership check, with **HTTP Range** support so a flaky download resumes instead of restarting.
- Progress is pushed over the existing WebSocket (`kind: 'export'`); the data settings pane shows *preparing → ready* and restores state from `GET /api/exports/latest` on load.
- A **`data_exports`** table tracks job state. A TTL sweep (24h) + boot recovery clean up expired/interrupted artifacts; one export at a time per user.
- Kept on disk for both editions — no R2/signed-URL dependency. Artifacts contain *decrypted* network passwords, but backups are Litestream-of-the-DB only (not a `data/` copy), so the artifacts never reach R2; tight perms + short TTL cover the rest.

## Import (#180), the sibling problem

Import had the same disease — it buffered the whole zip in memory and inserted every message in **one synchronous transaction**, freezing the loop on a large restore. Now it reads the zip from disk (`yauzl.open`), streams `messages.ndjson`, and inserts in **batched transactions that yield to the event loop** between batches. A failure rolls the account back to empty so a retry stays clean.

## Notable refactor

`exportService` is now **connection-agnostic** (takes a `db` handle, no db-singleton import) so the worker can pass its own connection without opening a second writer / re-running migrations. `ENCRYPTED_NETWORK_COLUMNS` moved to the db-singleton-free `exportSchema` module (re-exported from `db/networks`).

## Tests

- **#175 regression**: an export build runs on a separate readonly connection while `insertMessage` is hammered on the shared connection mid-stream — asserts no throw. This fails on the old single-connection design and passes now.
- Job lifecycle: build → done (artifact on disk), one-at-a-time refusal, TTL sweep, boot recovery of interrupted jobs.
- Download: auth + ownership (user B can't fetch user A's export) + Range.
- Import round-trip through the new streaming path; existing import/round-trip suites adapted to the new signatures.
- Full suite green (765). Also smoke-tested the **real** `worker_thread` path under `tsx` (outside vitest): worker built a 31KB archive on its own connection while 140 writes landed on the main connection — zero "database connection is busy".

## Not in scope

`worker_thread`-path is exercised by a manual smoke test, not the unit suite (vitest can't transform a `.ts` worker entry loaded via `node:worker_threads`); the build logic itself is covered via the in-process runner. Worth a quick manual download test on a real instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
