### PR TITLE
Give buffer-list auto-scroll breathing room (#182)

### DIFF
--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -674,6 +674,18 @@ onBeforeUnmount(() => {
   border-left-color: var(--accent);
 }
 
+/* Auto-scroll look-ahead (#182): ensureActiveVisible() uses
+   scrollIntoView({ block: 'nearest' }), which by default slams the selected
+   row flush against the viewport edge — so Alt+arrow nav into an off-screen
+   buffer reveals nothing about what's coming. scroll-margin expands each row's
+   box, so 'nearest' leaves this much breathing room on the leading edge while
+   still no-op'ing for rows already comfortably in view. Rows are
+   intrinsic-height (no fixed row token); 72px ≈ 3 rows of look-ahead. */
+.net-head,
+.channels li {
+  scroll-margin-block: 72px;
+}
+
 /* Hover action buttons on network rows — mirrors .channels .row-actions pattern. */
 .net-actions {
   position: absolute;


### PR DESCRIPTION
Closes #182.

### Problem
On a small display, Alt+Up/Down nav into an off-screen buffer scrolled the list just enough to bump the selection flush against the viewport edge — `scrollIntoView({ block: 'nearest' })`. You got zero look-ahead at the buffers (and their unread/highlight state) you were about to scroll into.

### Fix
Add `scroll-margin-block: 72px` to the network (`.net-head`) and channel (`.channels li`) rows. `scrollIntoView` treats each row's box as expanded by its scroll-margin, so `'nearest'` now leaves ~3 rows of breathing room on the leading edge — scrolloff-style (à la vim `scrolloff` / VS Code `cursorSurroundingLines`) — while still no-op'ing when the row is already comfortably in view.

Chose the breathing-room approach over centering deliberately: centering repositions the list on every keystroke even mid-list, which is more visual churn; scrolloff only moves the list as you approach an edge.

### Notes
- CSS-only — no change to `ensureActiveVisible()` or the scroll JS.
- Used `scroll-margin` on the rows rather than `scroll-padding` on the scroller, since `scroll-margin` + `scrollIntoView` is honored reliably across Safari/Firefox/Chrome.
- Rows are intrinsic-height (no fixed row-height token); 72px ≈ 3 rows at the 14px/1.55 base.
- The one-shot unread-jump (`block: 'center'`) is intentionally left as-is — a deliberate jump should center; continuous arrow-nav shouldn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)