### PR TITLE
Surface SASL account/password outside Advanced options (#168)

### DIFF
--- a/vue_client/src/components/NetworkForm.vue
+++ b/vue_client/src/components/NetworkForm.vue
@@ -155,9 +155,7 @@ const form = reactive({
 // forces the section open.
 const showAdvanced = ref(
   !!props.network &&
-    (!!netRaw?.has_password ||
-      !!netRaw?.connect_commands ||
-      netRaw?.autoconnect === false),
+    (!!netRaw?.has_password || !!netRaw?.connect_commands || netRaw?.autoconnect === false),
 );
 
 const loading = ref(false);

--- a/vue_client/src/components/NetworkForm.vue
+++ b/vue_client/src/components/NetworkForm.vue
@@ -37,6 +37,27 @@
         <span>Real name (optional)</span>
         <input v-model="form.realname" />
       </label>
+      <div class="row">
+        <label class="grow">
+          <span>SASL account (optional)</span>
+          <input
+            v-model="form.sasl_account"
+            :placeholder="form.nick || 'defaults to nick'"
+            autocomplete="off"
+          />
+        </label>
+        <label class="grow">
+          <span>SASL password (optional)</span>
+          <input
+            v-model="form.sasl_password"
+            type="password"
+            autocomplete="off"
+            :placeholder="
+              isEdit && props.network?.has_sasl_password ? '(saved — type to replace)' : ''
+            "
+          />
+        </label>
+      </div>
       <button type="button" class="advanced-toggle" @click="showAdvanced = !showAdvanced">
         {{ showAdvanced ? '− Advanced options' : '+ Advanced options' }}
       </button>
@@ -50,27 +71,6 @@
             :placeholder="isEdit && props.network?.has_password ? '(saved — type to replace)' : ''"
           />
         </label>
-        <div class="row">
-          <label class="grow">
-            <span>SASL account (optional)</span>
-            <input
-              v-model="form.sasl_account"
-              :placeholder="form.nick || 'defaults to nick'"
-              autocomplete="off"
-            />
-          </label>
-          <label class="grow">
-            <span>SASL password (optional)</span>
-            <input
-              v-model="form.sasl_password"
-              type="password"
-              autocomplete="off"
-              :placeholder="
-                isEdit && props.network?.has_sasl_password ? '(saved — type to replace)' : ''
-              "
-            />
-          </label>
-        </div>
         <label v-if="!isEdit">
           <span>Default channel</span>
           <input v-model="form.default_channel" placeholder="#lurker" />
@@ -151,12 +151,11 @@ const form = reactive({
 
 // Auto-expand advanced when editing a row that already has any advanced value
 // set, so the user doesn't have to hunt for a saved password or connect script
-// they configured previously.
+// they configured previously. SASL now lives outside advanced, so it no longer
+// forces the section open.
 const showAdvanced = ref(
   !!props.network &&
     (!!netRaw?.has_password ||
-      !!netRaw?.has_sasl_password ||
-      !!netRaw?.sasl_account ||
       !!netRaw?.connect_commands ||
       netRaw?.autoconnect === false),
 );


### PR DESCRIPTION
Closes #168.

### Problem
The SASL account/password fields were buried inside the "Advanced options" disclosure in the network setup form. But SASL is the standard authentication path on most modern IRC networks (Libera **requires** it) — not a power-user edge case. The original issue framed this as a node-mode concern (a cloud-hosted node will need SASL on most networks), but it's the wrong default for every edition.

### Change
- Move the SASL account / SASL password row **out** of the advanced block, up next to Nick / Real name — always visible.
- Drop the now-redundant `has_sasl_password` / `sasl_account` conditions from the `showAdvanced` auto-expand check, so editing a SASL-only network no longer needlessly pops "Advanced" open.
- No node-mode branching — applies to all editions, which is simpler than the original per-edition idea floated in the issue.

Server password, default channel, connect commands, and autoconnect stay under Advanced.

### Verification
- `npm run typecheck` ✓
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)