### PR TITLE
chore: harden dependency supply chain (cooldown + npm ci)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,16 @@ version: 2
 #     compromises (chalk/debug phishing, the Shai-Hulud worm) were live for
 #     only hours before being pulled, so even a few days of cooldown sidesteps
 #     them. Security updates ignore cooldown, so real CVEs still come through.
-#   * groups — collapse low-risk minor/patch bumps into a single PR per
-#     ecosystem (one lockfile rebase instead of N conflicting ones). Major
-#     bumps stay as individual PRs so they each get a manual look.
+#   * groups — collapse low-risk minor/patch bumps into a single PR per npm
+#     ecosystem (one lockfile rebase instead of N conflicting ones); major
+#     bumps still arrive as individual PRs so they each get a manual look.
+#     NOTE: the npm groups intentionally use `update-types` with NO `patterns`
+#     selector. Adding `patterns: ['*']` would mark every matched dependency
+#     "handled" and can silently suppress its major-version PR entirely
+#     (dependabot-core#14202); update-types alone leaves majors as individual
+#     PRs, per the docs. The github-actions group has no update-types limit, so
+#     it bundles ALL action updates (majors included) — those are few and
+#     low-risk, and grouping them avoids that suppression edge case entirely.
 updates:
   # Server (root) npm dependencies
   - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,4 +52,4 @@ updates:
     groups:
       actions:
         patterns:
-          - "*"
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,55 @@
 version: 2
+
+# Supply-chain hardening notes:
+#   * cooldown — don't surface a new version until it has been public long
+#     enough for a malicious or yanked release to be caught. The 2025 npm
+#     compromises (chalk/debug phishing, the Shai-Hulud worm) were live for
+#     only hours before being pulled, so even a few days of cooldown sidesteps
+#     them. Security updates ignore cooldown, so real CVEs still come through.
+#   * groups — collapse low-risk minor/patch bumps into a single PR per
+#     ecosystem (one lockfile rebase instead of N conflicting ones). Major
+#     bumps stay as individual PRs so they each get a manual look.
 updates:
+  # Server (root) npm dependencies
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Client (vue_client) npm dependencies
   - package-ecosystem: npm
     directory: /vue_client
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
           cache: 'npm'
 
       - name: Install root dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install client dependencies
-        run: npm install --prefix vue_client
+        run: npm ci --prefix vue_client
 
       - name: Type-check (server)
         run: npm run typecheck
@@ -49,7 +49,7 @@ jobs:
           cache: 'npm'
 
       - name: Install root dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint
         run: npm run lint
@@ -68,7 +68,7 @@ jobs:
           cache: 'npm'
 
       - name: Install root dependencies
-        run: npm install
+        run: npm ci
 
       - name: Check formatting
         run: npm run format:check
@@ -87,10 +87,10 @@ jobs:
           cache: 'npm'
 
       - name: Install root dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install client dependencies
-        run: npm install --prefix vue_client
+        run: npm ci --prefix vue_client
 
       - name: Run tests
         run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM node:22-slim AS vue-builder
 WORKDIR /app/vue_client
 
 COPY vue_client/package*.json ./
-RUN npm install
+RUN npm ci
 
 COPY vue_client/ ./
 # Vue and server both import shared/settingsRegistry.js via relative paths,
@@ -35,7 +35,7 @@ FROM node:22-slim AS server-deps
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install --omit=dev
+RUN npm ci --omit=dev
 
 # Stage 3: Runtime image
 FROM node:22-slim


### PR DESCRIPTION
## Why

Recent npm supply-chain attacks (the Sept 2025 chalk/debug maintainer-phishing incident and the Shai-Hulud worm) share one property: the **malicious version is only live for a few hours** before it's caught and yanked. The behavior that gets you bitten is pulling the newest version the instant it ships. This PR adds the standard mitigations without turning Dependabot off.

## Changes

**`.github/dependabot.yml`**
- **Cooldown (minimum release age):** don't surface a new version until it's been public long enough for a bad release to be caught — `patch=3d`, `minor=7d`, `major=14d`, default `7d`. Security updates **bypass** cooldown, so real CVEs still come through immediately.
- **Grouping:** collapse `minor`/`patch` bumps into a single PR per ecosystem (one lockfile rebase instead of N conflicting ones). Major bumps stay individual so each gets a manual look.

**`.github/workflows/test.yml` + `Dockerfile`**
- Replace `npm install` → `npm ci` everywhere. `npm ci` installs *exactly* what's pinned in the committed lockfile and fails loudly if `package.json` and the lock disagree — deterministic, tamper-evident builds.

## Safety / verification

- Both lockfiles are in sync with their `package.json` (`npm ci --dry-run` succeeds in `/` and `/vue_client`).
- The prod Docker stage (`npm ci --omit=dev`) is behavior-preserving: verified `tsx` is **not** dev-pruned, so the `CMD ["node_modules/.bin/tsx", ...]` runtime still resolves exactly as it does today.
- `cooldown` schema confirmed against the [GitHub Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference) (feature shipped July 2025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)