### PR TITLE
Rework topic-bar actions + mobile placeholder (#196)

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -229,8 +229,22 @@ const isPaused = computed(() => auth.isPaused);
 const sendable = computed(() => !!active.value && !isServer.value && !isPaused.value);
 const placeholder = computed(() => {
   if (isPaused.value) return 'Account paused — read only';
-  if (!active.value) return 'Select a buffer';
-  if (isServer.value) return '/raw <line>';
+  const a = active.value;
+  if (!a) return 'Select a buffer';
+  // `/raw <line>` was cryptic; `/help` is the discoverable entry point and the
+  // server buffer is exactly where someone goes looking for it.
+  if (isServer.value) return 'try /help';
+  // Mobile drops the buffer name from the header and the compact status bar
+  // shows self/away instead, so the channel/peer context has no persistent home
+  // — the placeholder carries it, mirroring the desktop status bar's
+  // `network/target`. Modes are left off: they're volatile and belong in the
+  // status bar, not a glanceable hint. Desktop keeps `try /help` since the
+  // status bar already shows the buffer there.
+  if (isMobile.value) {
+    const net = a.network?.name;
+    // Network forced lowercase to match the status bar's `net/#chan` styling.
+    return net ? `${net.toLowerCase()}/${a.target}` : a.target;
+  }
   return 'try /help';
 });
 // Opt-in palette icon. The keyboard shortcuts in onKeydown ignore this gate —

--- a/vue_client/src/composables/useBufferActions.ts
+++ b/vue_client/src/composables/useBufferActions.ts
@@ -52,15 +52,17 @@ export function useBufferActions(): BufferActionsAPI {
     if (isChannel) {
       const isAlwaysNotify = channelNotify.notifyAlways(buf.networkId, buf.target);
       items.push(
+        // Icon reflects current state (solid = always-notifying, regular = not)
+        // to match the topic-bar toggle; the label states the action.
         isAlwaysNotify
           ? {
               label: 'Stop always notifying',
-              icon: 'fa-solid fa-bell-slash',
+              icon: 'fa-solid fa-bell',
               onClick: () => channelNotify.setNotifyAlways(buf.networkId, buf.target, false),
             }
           : {
               label: 'Always notify',
-              icon: 'fa-solid fa-bell',
+              icon: 'fa-regular fa-bell',
               onClick: () => channelNotify.setNotifyAlways(buf.networkId, buf.target, true),
             },
       );

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -135,9 +135,9 @@
           <button
             class="link"
             :title="showMembers ? 'Hide members' : 'Show members'"
+            :aria-label="showMembers ? 'Hide members' : 'Show members'"
             @click="toggleMembers"
           >
-            <i class="fa-solid fa-users"></i>
           </button>
           <span
             v-if="memberCount != null"

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -64,16 +64,7 @@
     </header>
     <header v-else-if="active" class="topic">
       <div class="topic-meta">
-        <button
-          v-if="isDmHeader"
-          type="button"
-          class="buffer link"
-          title="View profile"
-          @click="openDmProfile"
-        >
-          {{ bufferLabel }}
-        </button>
-        <span v-else class="buffer">{{ bufferLabel }}</span>
+        <span class="buffer">{{ bufferLabel }}</span>
         <template v-if="topic">
           <span class="sep">│</span>
           <button
@@ -110,29 +101,51 @@
             <i class="fa-solid fa-gear"></i>
           </button>
         </template>
-        <button
-          v-if="showBufferCog"
-          ref="bufferCogBtn"
-          class="link"
-          title="Buffer actions"
-          @click="openBufferActions"
-        >
-          <i class="fa-solid fa-gear"></i>
-        </button>
-        <button
-          v-if="isChannel"
-          class="link"
-          :title="showMembers ? 'Hide members' : 'Show members'"
-          @click="toggleMembers"
-        >
-          <i class="fa-solid fa-users"></i>
-        </button>
-        <span
-          v-if="isChannel && memberCount != null"
-          class="member-count"
-          :title="`${memberCount} ${memberCount === 1 ? 'user' : 'users'} in channel`"
-          >{{ memberCount }}</span
-        >
+        <template v-else-if="isDmHeader">
+          <button
+            type="button"
+            class="link"
+            title="View profile"
+            aria-label="View profile"
+            @click="openDmProfile"
+          >
+            <i class="fa-solid fa-id-card"></i>
+          </button>
+          <button
+            type="button"
+            class="link"
+            :title="dmNoteLabel"
+            :aria-label="dmNoteLabel"
+            @click="openDmNote"
+          >
+            <i class="fa-solid fa-note-sticky"></i>
+          </button>
+        </template>
+        <template v-else-if="isChannel">
+          <button
+            type="button"
+            class="link notify"
+            :class="{ on: channelNotifyAlways }"
+            :title="channelNotifyLabel"
+            :aria-label="channelNotifyLabel"
+            @click="toggleChannelNotify"
+          >
+            <i :class="channelNotifyAlways ? 'fa-solid fa-bell' : 'fa-regular fa-bell'"></i>
+          </button>
+          <button
+            class="link"
+            :title="showMembers ? 'Hide members' : 'Show members'"
+            @click="toggleMembers"
+          >
+            <i class="fa-solid fa-users"></i>
+          </button>
+          <span
+            v-if="memberCount != null"
+            class="member-count"
+            :title="`${memberCount} ${memberCount === 1 ? 'user' : 'users'} in channel`"
+            >{{ memberCount }}</span
+          >
+        </template>
       </div>
     </header>
     <div v-if="active || isSystemConsole" class="topic-divider"></div>
@@ -193,7 +206,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue';
 import type { Network } from '../stores/networks.js';
-import type { BufferLike } from '../composables/useBufferActions.js';
 import type { Buffer } from '../stores/buffers.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useSocket } from '../composables/useSocket.js';
@@ -223,7 +235,7 @@ import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts.js';
 import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useWhoisStore } from '../stores/whois.js';
-import { useBufferActions } from '../composables/useBufferActions.js';
+import { useChannelNotifyStore } from '../stores/channelNotify.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { useImageModal } from '../composables/useImageModal.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
@@ -241,7 +253,7 @@ const settings = useSettingsStore();
 const nicklistCollapse = useNicklistCollapseStore();
 const nickNotes = useNickNotesStore();
 const whois = useWhoisStore();
-const bufferActions = useBufferActions();
+const channelNotify = useChannelNotifyStore();
 
 const channelListModal = reactive(useChannelListModal());
 const imageModal = reactive(useImageModal());
@@ -256,19 +268,6 @@ const showKbdHelp = ref(false);
 const pendingScrollId = ref<number | null>(null);
 const messageInputRef = ref<{ focus: () => void } | null>(null);
 const messageListRef = ref<{ scrollByPage: (dir: number) => void } | null>(null);
-const bufferCogBtn = ref<HTMLElement | null>(null);
-
-// The cog opens the same menu as right-clicking the sidebar row — exposed
-// here so the actions are reachable for the currently-open buffer without a
-// trip to the sidebar (and so mobile users, who have no right-click, can get
-// at them at all). Server buffers already have dedicated controls in this
-// bar, so the cog is for channels and DMs only.
-const showBufferCog = computed(() => !!active.value && !isServerBuffer.value);
-
-function openBufferActions() {
-  if (!activeBuf.value) return;
-  bufferActions.openMenuFromButton(activeBuf.value as BufferLike, bufferCogBtn.value);
-}
 
 // Any modal open? Type-ahead must not steal focus from a modal's own fields.
 const anyModalOpen = computed(
@@ -362,6 +361,38 @@ const isDmHeader = computed(() => {
 function openDmProfile() {
   if (!active.value) return;
   whois.openViewer(active.value.networkId, active.value.target);
+}
+// DM note button — mirrors the old context-menu entry, surfaced inline so the
+// per-peer note is one click from the conversation. Label flips once a note
+// exists so the button doubles as a "has a note" tell.
+const dmNoteLabel = computed(() =>
+  active.value && nickNotes.hasNote(active.value.networkId, active.value.target)
+    ? 'Edit note'
+    : 'Add note',
+);
+function openDmNote() {
+  if (!active.value) return;
+  nickNotes.openEditor(active.value.networkId, active.value.target);
+}
+
+// Channel "always notify" toggle — the one non-pin, non-close action from the
+// buffer menu, promoted to an inline button (pin/close stay buffer-list
+// concerns, reachable by right-clicking the sidebar row). The bell fills and
+// goes accent when the override is on.
+const channelNotifyAlways = computed(() => {
+  if (!isChannel.value || !active.value) return false;
+  return channelNotify.notifyAlways(active.value.networkId, active.value.target);
+});
+const channelNotifyLabel = computed(() =>
+  channelNotifyAlways.value ? 'Stop always notifying' : 'Always notify',
+);
+function toggleChannelNotify() {
+  if (!isChannel.value || !active.value) return;
+  channelNotify.setNotifyAlways(
+    active.value.networkId,
+    active.value.target,
+    !channelNotifyAlways.value,
+  );
 }
 
 // User count for the active channel buffer. Sits in the topic bar (next to
@@ -634,16 +665,6 @@ useChatBootstrap({ onJump: onJumpToMessage });
 .topic .buffer {
   color: var(--accent);
 }
-/* DM headers double as a "view profile" trigger. Strip the .link padding so
-   the button-rendered label sits exactly where the span used to, and only
-   underline on hover so it doesn't read as a link in steady state. */
-button.buffer.link {
-  padding: 0;
-}
-button.buffer.link:hover {
-  text-decoration: underline;
-  color: var(--accent);
-}
 .topic .sep {
   color: var(--border);
 }
@@ -704,6 +725,15 @@ button.buffer.link:hover {
   align-items: baseline;
   gap: var(--space-4);
   flex-shrink: 0;
+}
+/* The always-notify bell reads as off (muted) until the override is on, when
+   it fills and switches to accent — distinct from the always-accent toggle
+   buttons beside it. */
+.topic-actions .notify {
+  color: var(--fg-muted);
+}
+.topic-actions .notify.on {
+  color: var(--accent);
 }
 .topic .member-count {
   color: var(--fg-muted);

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -43,20 +43,14 @@
         <button class="icon back" title="Back" @click="goList">
           <i class="fa-solid fa-arrow-left"></i>
         </button>
-        <button
-          v-if="isDmHeader"
-          type="button"
-          class="title title-btn"
-          title="View profile"
-          @click="openDmProfile"
-        >
-          {{ bufferLabel }}
-        </button>
-        <span v-else class="title">{{ isSystemConsole ? 'System console' : bufferLabel }}</span>
+        <!-- The system console has no composer (so no placeholder to carry a
+             name) and no buffer actions — it keeps a plain title. Real buffers
+             drop the name (it moves to the input placeholder) and fold every
+             buffer/topic/member/server action into the single cog, since the
+             mobile header is already tight. Search/highlights/saved stay inline
+             as they're global and frequently reached. -->
+        <span v-if="isSystemConsole" class="title">System console</span>
         <span class="spacer"></span>
-        <button v-if="topic" class="icon" title="View topic" @click="showTopic = true">
-          <i class="fa-solid fa-circle-info"></i>
-        </button>
         <button class="icon" title="Search messages" @click="showSearch = true">
           <i class="fa-solid fa-magnifying-glass"></i>
         </button>
@@ -67,38 +61,13 @@
           <i class="fa-regular fa-bookmark"></i>
         </button>
         <button
-          v-if="isServerBuffer"
-          type="button"
-          class="icon"
-          title="Channel list"
-          aria-label="Channel list"
-          @click="active && channelListModal.open(active.networkId)"
-        >
-          <i class="fa-solid fa-hashtag"></i>
-        </button>
-        <button
-          v-if="isServerBuffer"
-          type="button"
-          class="icon"
-          :title="serverConnectActionLabel"
-          :aria-label="serverConnectActionLabel"
-          @click="toggleServerConnection"
-        >
-          <i :class="serverConnectActionIcon"></i>
-        </button>
-        <button
-          v-if="showBufferCog"
+          v-if="active"
           ref="bufferCogBtn"
           class="icon"
           title="Buffer actions"
+          aria-label="Buffer actions"
           @click="openBufferActions"
         >
-          <i class="fa-solid fa-gear"></i>
-        </button>
-        <button v-if="isChannel" class="icon" title="Members" @click="screen = 'members'">
-          <i class="fa-solid fa-users"></i>
-        </button>
-        <button v-if="isServerBuffer" class="icon" title="Edit network" @click="editActiveNetwork">
           <i class="fa-solid fa-gear"></i>
         </button>
       </header>
@@ -175,6 +144,8 @@ import { useSocket } from '../composables/useSocket.js';
 import { useChatBootstrap } from '../composables/useChatBootstrap.js';
 import { useActiveBuffer } from '../composables/useActiveBuffer.js';
 import { useBufferActions } from '../composables/useBufferActions.js';
+import { useContextMenu } from '../composables/useContextMenu.js';
+import type { ContextMenuItem } from '../composables/useContextMenu.js';
 import BufferList from '../components/BufferList.vue';
 import MessageList from '../components/MessageList.vue';
 import SystemConsole from '../components/SystemConsole.vue';
@@ -213,6 +184,7 @@ const {
   isSystemConsole,
 } = useActiveBuffer();
 const bufferActions = useBufferActions();
+const menu = useContextMenu();
 const nickNotes = useNickNotesStore();
 const whois = useWhoisStore();
 
@@ -242,25 +214,57 @@ const pendingScrollId = ref<number | null>(null);
 const messageInputRef = ref<{ focus: () => void } | null>(null);
 const bufferCogBtn = ref<HTMLElement | null>(null);
 
-// Server buffers already have a dedicated browse-channels action in the bar;
-// the cog is for channel/DM buffer-level actions (pin, always-notify).
-const showBufferCog = computed(() => !!active.value && !isServerBuffer.value);
-
-// True when the active buffer is a DM. Drives the clickable title that
-// opens the user profile modal — channel titles stay non-interactive.
-const isDmHeader = computed(() => {
-  if (!active.value) return false;
-  if (isChannel.value || isServerBuffer.value || isSystemConsole.value) return false;
-  return true;
-});
-function openDmProfile() {
-  if (!active.value) return;
-  whois.openViewer(active.value.networkId, active.value.target);
-}
-
+// Mobile folds every buffer/topic/member/server action behind one cog to keep
+// the header uncluttered. The menu is assembled per buffer type: view-topic and
+// members are navigation shortcuts unique to this layout, then either the shared
+// buffer-actions menu (pin/notify/profile/note/close) for channels & DMs, or the
+// server controls (browse/connect/edit) for server buffers. Anchored under the
+// cog like the desktop sidebar menu; ContextMenu clamps it to the viewport.
 function openBufferActions() {
-  if (!activeBuf.value) return;
-  bufferActions.openMenuFromButton(activeBuf.value as BufferLike, bufferCogBtn.value);
+  const a = active.value;
+  const el = bufferCogBtn.value;
+  if (!a || !el) return;
+  const items: ContextMenuItem[] = [];
+  if (topic.value) {
+    items.push({
+      label: 'View topic',
+      icon: 'fa-solid fa-circle-info',
+      onClick: () => {
+        showTopic.value = true;
+      },
+    });
+  }
+  if (isServerBuffer.value) {
+    items.push(
+      {
+        label: 'Channel list',
+        icon: 'fa-solid fa-hashtag',
+        onClick: () => channelListModal.open(a.networkId),
+      },
+      {
+        label: serverConnectActionLabel.value,
+        icon: serverConnectActionIcon.value,
+        onClick: toggleServerConnection,
+      },
+      { label: 'Edit network', icon: 'fa-solid fa-gear', onClick: editActiveNetwork },
+    );
+  } else {
+    if (isChannel.value) {
+      items.push({
+        label: 'Members',
+        icon: 'fa-solid fa-users',
+        onClick: () => {
+          screen.value = 'members';
+        },
+      });
+    }
+    const bufItems = bufferActions.buildItems(activeBuf.value as BufferLike);
+    if (items.length && bufItems.length) items.push({ divider: true });
+    items.push(...bufItems);
+  }
+  if (items.length === 0) return;
+  const rect = el.getBoundingClientRect();
+  menu.open(items, rect.left, rect.bottom + 2, el);
 }
 
 function openAddNetwork() {
@@ -402,19 +406,6 @@ useChatBootstrap({ onJump: onJumpToMessage });
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
-}
-/* DM headers double as a "view profile" trigger — match the .title look,
-   underline on tap. */
-.title-btn {
-  background: none;
-  border: none;
-  font: inherit;
-  cursor: pointer;
-  text-align: left;
-  padding: 0;
-}
-.title-btn:active {
-  text-decoration: underline;
 }
 .spacer {
   flex: 1;


### PR DESCRIPTION
Closes #196.

Started from the issue's placeholder idea and grew into a small topic-bar UX pass.

## Input placeholder
- **Mobile** channel/DM buffers now show the buffer's `network/target` (e.g. `libera/#chan`, network forced lowercase to match the status bar) instead of `try /help`. On mobile the buffer name is dropped from the header and the compact status bar shows self/away, so the placeholder is where buffer context now lives.
- **Server buffers** show `try /help` instead of the cryptic `/raw <line>`.
- **Desktop** keeps `try /help` — the status bar already carries the buffer name there.

## Desktop topic bar
- DM cog → inline **View profile** + **Add/Edit note** buttons.
- Channel **Always notify** promoted to an inline bell toggle (solid/accent when on, muted regular bell when off).
- Pin/Close stay buffer-list actions (sidebar right-click); the generic buffer cog is gone on desktop.
- Channel name is retained in the header (`#channel │ topic`).

## Mobile header
- Buffer/topic/member/server actions collapse into a **single cog menu** to keep the tight header uncluttered; Search/Highlights/Saved stay inline. System console keeps its title (it has no composer).

## Context menu
- Always-notify bell icon now matches the topic-bar toggle (solid = on, regular = off) rather than reading backward.

## Verification
`npm run typecheck` and `npm run build` are clean. Not exercised live (dev server autoconnects to real IRC) — worth a quick look on a phone for the mobile cog menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)