### PR TITLE
Show offline buffers when a network is disconnected (#207)

### DIFF
--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -42,3 +42,46 @@ describe('ircManager pause linchpin', () => {
     expect(ircManager.getConnection(user.id, net.id)).toBeNull();
   });
 });
+
+describe('ircManager.snapshotForUser offline networks', () => {
+  it('returns a disconnected blob for a network with no live connection', () => {
+    const user = createUser('snap-offline');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.invalid',
+      port: 6697,
+      tls: true,
+      nick: 'zoe',
+      autoconnect: false,
+    });
+    if (!net) throw new Error('createNetwork returned undefined');
+
+    const snap = ircManager.snapshotForUser(user.id) as Array<Record<string, unknown>>;
+    expect(snap).toHaveLength(1);
+    expect(snap[0].networkId).toBe(net.id);
+    expect(snap[0].state).toBe('disconnected');
+    expect(snap[0].nick).toBe('zoe');
+    expect(snap[0].channels).toEqual([]);
+  });
+
+  it('still snapshots a paused user’s networks so their buffers stay readable', () => {
+    const user = createUser('snap-paused');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.invalid',
+      port: 6697,
+      tls: true,
+      nick: 'p',
+      autoconnect: false,
+    });
+    if (!net) throw new Error('createNetwork returned undefined');
+    setUserPaused(user.id, true);
+
+    // The pause gate forbids a connection, yet the snapshot must not be empty —
+    // otherwise the "you can read your history" banner has nothing to show.
+    const snap = ircManager.snapshotForUser(user.id) as Array<Record<string, unknown>>;
+    expect(snap).toHaveLength(1);
+    expect(snap[0].networkId).toBe(net.id);
+    expect(snap[0].state).toBe('disconnected');
+  });
+});

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -419,15 +419,45 @@ class IrcManager extends EventEmitter {
     const notifyByNetwork = listChannelNotifyForUser(userId);
     const ignoresByNetwork = ignoresGrouped(userId);
     const notesByNetwork = listNickNotesGrouped(userId);
-    return this.listConnections(userId).map((conn) => {
-      const snap = conn.snapshot();
-      const pinned = pinsByNetwork.get(snap.networkId) || [];
-      const collapsedNicklists = collapsedByNetwork.get(snap.networkId) || {};
-      const channelNotify = notifyByNetwork.get(snap.networkId) || {};
-      const ignoredMasks = ignoresByNetwork.get(snap.networkId) || [];
-      const nickNotes = notesByNetwork.get(snap.networkId) || [];
-      return { ...snap, pinned, collapsedNicklists, channelNotify, ignoredMasks, nickNotes };
-    });
+    // Attach the per-network user-preference blobs to a base snapshot. Shared by
+    // the live-connection and offline branches so both shapes stay identical.
+    const withExtras = <T extends { networkId: number }>(snap: T) => {
+      const networkId = snap.networkId;
+      return {
+        ...snap,
+        pinned: pinsByNetwork.get(networkId) || [],
+        collapsedNicklists: collapsedByNetwork.get(networkId) || {},
+        channelNotify: notifyByNetwork.get(networkId) || {},
+        ignoredMasks: ignoresByNetwork.get(networkId) || [],
+        nickNotes: notesByNetwork.get(networkId) || [],
+      };
+    };
+    const live = this.listConnections(userId);
+    const liveIds = new Set(live.map((conn) => conn.network.id));
+    const out: unknown[] = live.map((conn) => withExtras(conn.snapshot()));
+    // Networks with no live connection (paused account, manually disconnected,
+    // or never autoconnected) still own persisted buffers. Synthesize a
+    // disconnected blob matching conn.snapshot()'s shape so the client renders
+    // their buffers read-only (state !== 'connected' drives the dim styling)
+    // instead of hiding them until a connection exists. Buffer rows themselves
+    // arrive via the backlog frames, so channels can be empty here — members
+    // are meaningless offline and topic/members repopulate on reconnect.
+    for (const net of listNetworksForUser(userId)) {
+      if (liveIds.has(net.id)) continue;
+      out.push(
+        withExtras({
+          networkId: net.id,
+          state: 'disconnected',
+          nick: net.nick,
+          userModes: '',
+          lagMs: null,
+          away: null,
+          channels: [],
+          peerPresence: {},
+        }),
+      );
+    }
+    return out;
   }
 
   addIgnore(userId: number, networkId: number, mask: string): unknown {

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -15,6 +15,7 @@ let closeBuffer: typeof import('../db/closedBuffers.js').closeBuffer;
 let isClosed: typeof import('../db/closedBuffers.js').isClosed;
 let setClearedState: typeof import('../db/bufferReads.js').setClearedState;
 let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
+let buildOfflineBacklogFrames: typeof import('./wsHub.js').buildOfflineBacklogFrames;
 let handleOpenBuffer: typeof import('./wsHub.js').handleOpenBuffer;
 
 let userId: number;
@@ -26,7 +27,8 @@ beforeAll(async () => {
   ({ insertMessage } = await import('../db/messages.js'));
   ({ closeBuffer, isClosed } = await import('../db/closedBuffers.js'));
   ({ setClearedState } = await import('../db/bufferReads.js'));
-  ({ buildBufferBacklog, handleOpenBuffer } = await import('./wsHub.js'));
+  ({ buildBufferBacklog, buildOfflineBacklogFrames, handleOpenBuffer } =
+    await import('./wsHub.js'));
 
   userId = createUser('alice').id;
   const net = createNetwork(userId, {
@@ -100,6 +102,79 @@ describe('buildBufferBacklog', () => {
     const frame = buildBufferBacklog(userId, networkId, '#clear');
     expect(frame.clearedBeforeId).toBe(boundary);
     expect(frame.clearedAt).toBe(ts);
+  });
+});
+
+describe('buildOfflineBacklogFrames', () => {
+  // Tests run with no live IRC connection, so every network is "offline" — the
+  // exact case a paused/disconnected user hits. Each test uses a fresh network
+  // so it doesn't depend on history seeded by sibling tests.
+  it('ships persisted buffers for a network with no live connection', () => {
+    const net = createNetwork(userId, {
+      name: 'offnet',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'alice',
+    });
+    const offId = net!.id;
+    const seedOff = (target: string, text: string): void => {
+      insertMessage({
+        networkId: offId,
+        target,
+        time: new Date().toISOString(),
+        type: 'message',
+        nick: 'bob',
+        text,
+        self: false,
+      });
+    };
+    seedOff('#offline', 'a');
+    seedOff('#offline', 'b');
+    seedOff('dave', 'dm');
+
+    const byTarget = new Map(
+      buildOfflineBacklogFrames(userId)
+        .filter((f) => f.networkId === offId)
+        .map((f) => [f.target as string, f]),
+    );
+
+    // Channel history is shipped, marked parted (no live connection tracks it).
+    const chan = byTarget.get('#offline')!;
+    expect(chan.kind).toBe('backlog');
+    expect((chan.events as unknown[]).length).toBe(2);
+    expect(chan.joined).toBe(false);
+    // DM buffers have no join concept → reported joined so they never dim.
+    expect(byTarget.get('dave')!.joined).toBe(true);
+    // The uncloseable server pseudo-buffer is always present.
+    expect(byTarget.has(`:server:${offId}`)).toBe(true);
+  });
+
+  it('skips a closed buffer but never the server pseudo-buffer', () => {
+    const net = createNetwork(userId, {
+      name: 'offnet2',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'alice',
+    });
+    const offId = net!.id;
+    insertMessage({
+      networkId: offId,
+      target: '#hidden',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'bob',
+      text: 'x',
+      self: false,
+    });
+    closeBuffer(userId, offId, '#hidden');
+
+    const targets = buildOfflineBacklogFrames(userId)
+      .filter((f) => f.networkId === offId)
+      .map((f) => f.target);
+    expect(targets).not.toContain('#hidden');
+    expect(targets).toContain(`:server:${offId}`);
   });
 });
 

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -303,9 +303,14 @@ export function buildBufferBacklog(userId: number, networkId: number, target: st
 // connection exists — which a paused user can never establish. Reuses
 // buildBufferBacklog, which reads purely from the DB and reports joined:false
 // when no connection is tracking the channel.
-export function buildOfflineBacklogFrames(userId: number): WsPayload[] {
+// `closed` defaults to a fresh query so standalone callers (tests) stay simple;
+// sendSnapshot passes the Set it already computed for the live loop to avoid a
+// redundant DB read per snapshot.
+export function buildOfflineBacklogFrames(
+  userId: number,
+  closed: Set<string> = closedKeySetForUser(userId),
+): WsPayload[] {
   const liveIds = new Set(ircManager.listConnections(userId).map((c) => c.network.id));
-  const closed = closedKeySetForUser(userId);
   const frames: WsPayload[] = [];
   for (const net of listNetworksForUser(userId)) {
     if (liveIds.has(net.id)) continue;
@@ -886,7 +891,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // Offline networks (no live connection) still ship their persisted buffers
     // so a paused/disconnected user can read history. Frames carry joined:false
     // and the client dims them via the network's disconnected snapshot state.
-    for (const frame of buildOfflineBacklogFrames(userId)) {
+    for (const frame of buildOfflineBacklogFrames(userId, closed)) {
       for (const e of frame.events as Array<{ id?: number | null }>) {
         if (e.id != null && e.id > maxSentId) maxSentId = e.id;
       }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -56,7 +56,7 @@ import { setNicklistCollapsed } from '../db/nicklistCollapsed.js';
 import { addBookmark, removeBookmark, listBookmarkIdsForUser } from '../db/bookmarks.js';
 import { getChannelNotifyAlways, setChannelNotifyAlways } from '../db/channelNotify.js';
 import { getUserAwayState } from '../db/userAwayState.js';
-import { upsertChannel, ownsNetwork } from '../db/networks.js';
+import { upsertChannel, ownsNetwork, listNetworksForUser } from '../db/networks.js';
 import * as chanlistDb from '../db/chanlist.js';
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from './settingsRegistry.js';
@@ -293,6 +293,33 @@ export function buildBufferBacklog(userId: number, networkId: number, target: st
     clearedAt: cleared.clearedAt,
     inputHistory: listRecentInputHistory(userId, networkId, target, 200),
   };
+}
+
+// Backlog frames for every network the user owns that has NO live connection —
+// a paused account (the is_paused gate forbids connecting), a manually
+// disconnected network (stopNetwork deletes the connection), or one that was
+// never autoconnected. The live snapshot path is connection-driven, so without
+// these frames an offline network's persisted buffers stay invisible until a
+// connection exists — which a paused user can never establish. Reuses
+// buildBufferBacklog, which reads purely from the DB and reports joined:false
+// when no connection is tracking the channel.
+export function buildOfflineBacklogFrames(userId: number): WsPayload[] {
+  const liveIds = new Set(ircManager.listConnections(userId).map((c) => c.network.id));
+  const closed = closedKeySetForUser(userId);
+  const frames: WsPayload[] = [];
+  for (const net of listNetworksForUser(userId)) {
+    if (liveIds.has(net.id)) continue;
+    const targets = new Set(listBufferTargets(net.id));
+    targets.add(`:server:${net.id}`);
+    for (const target of targets) {
+      // Server pseudo-buffer is uncloseable; otherwise honor a closed flag.
+      // Nothing is joined on an offline network, so there's no autorejoin race
+      // to defend against here (unlike the live loop in sendSnapshot).
+      if (!target.startsWith(':server:') && closed.has(`${net.id}::${target}`)) continue;
+      frames.push(buildBufferBacklog(userId, net.id, target));
+    }
+  }
+  return frames;
 }
 
 // Handles a client `open-buffer` request (a clicked channel name). Resolves
@@ -855,6 +882,15 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           inputHistory,
         });
       }
+    }
+    // Offline networks (no live connection) still ship their persisted buffers
+    // so a paused/disconnected user can read history. Frames carry joined:false
+    // and the client dims them via the network's disconnected snapshot state.
+    for (const frame of buildOfflineBacklogFrames(userId)) {
+      for (const e of frame.events as Array<{ id?: number | null }>) {
+        if (e.id != null && e.id > maxSentId) maxSentId = e.id;
+      }
+      send(ws, frame);
     }
     // Advance the resume cursor past everything we just shipped, so the next
     // sendSnapshot (in-band 'snapshot' request, or another IRC-state trigger)

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -137,8 +137,7 @@
             :title="showMembers ? 'Hide members' : 'Show members'"
             :aria-label="showMembers ? 'Hide members' : 'Show members'"
             @click="toggleMembers"
-          >
-          </button>
+          ></button>
           <span
             v-if="memberCount != null"
             class="member-count"


### PR DESCRIPTION
Fixes #207.

## Problem

When the client loads and a network has **no live IRC connection**, the buffers under that network are hidden — you see the network header but nothing to click into. This hits hardest on a **paused account**: the `is_paused` gate in `startNetwork` is the linchpin of the pause feature, so a paused user can *never* hold a connection, yet `PausedBanner` promises *"You can read your history…"* — a check the read path couldn't cash. The same gap affects any network the user has manually disconnected (`stopNetwork` deletes the connection object) or never autoconnected.

**Root cause:** the buffer/backlog read path was coupled to *connection liveness*, not persisted state. On socket open, `wsHub.sendSnapshot` built everything from `ircManager.listConnections()`:
- `snapshotForUser` mapped only over live connections → empty when none.
- the backlog loop iterated `listConnections` → shipped zero `backlog` frames.

The buffers store is populated *only* by those frames, so it stayed empty and `BufferList.vue` rendered no channels. (The network *list* comes from REST `GET /api/networks`, so headers still showed — confirming this is a buffer-content problem.)

## Fix (server-side only)

Source from the DB when no connection exists:

- **`ircManager.snapshotForUser`** appends a synthesized `state: 'disconnected'` blob (matching `conn.snapshot()`'s shape) for each of the user's networks without a live connection.
- **`wsHub.buildOfflineBacklogFrames`** (new, exported) ships persisted backlog for those networks, reusing `buildBufferBacklog` — which reads purely from the DB and reports `joined: false` when no connection tracks the channel. `sendSnapshot` emits these after the live-connection loop.

The live-connection loop is untouched (keeps its sinceId/fresh-network resume optimization); connected networks are unaffected. This generalizes to *every* disconnected network, matching the issue title rather than special-casing paused.

## Why no frontend changes

The client already handles this — `isUnjoined` (BufferList.vue) dims any buffer whose network `state !== 'connected'`, and the channel-list "+" button is `:disabled` when not connected. Feed it disconnected networks and it renders them read-only and dimmed, exactly as intended.

## Tests

- `ircManager.test.ts`: `snapshotForUser` returns a `disconnected` blob for a network with no connection; paused-user variant (the issue's primary case).
- `wsHub.test.ts`: `buildOfflineBacklogFrames` ships persisted buffers with `joined: false`, includes the `:server:` pseudo-buffer, and skips closed buffers.
- Full server suite green (646 tests); typecheck/lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)