### PR TITLE
Name the rejected command in unknown-command errors + toast (#203)

### DIFF
--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1350,7 +1350,13 @@ export class IrcConnection {
         });
         return;
       }
-      const ctx = [eventNick, event?.channel, event?.server].filter(Boolean).join(' ');
+      // ERR_UNKNOWNCOMMAND (421) carries the rejected command name in
+      // event.command (irc-framework parses it from the numeric's params).
+      // Include it so the buffer line names the offending command —
+      // "unknown_command FOO — Unknown command" — instead of just the tag.
+      const ctx = [eventNick, event?.channel, event?.command, event?.server]
+        .filter(Boolean)
+        .join(' ');
       const parts = [tag];
       if (ctx) parts.push(ctx);
       if (reason) parts.push(`— ${reason}`);
@@ -1361,6 +1367,16 @@ export class IrcConnection {
         target: this.serverTarget(),
         text,
         raw: event,
+        // Unknown slash commands are forwarded verbatim as raw IRC (see
+        // MessageInput's default case), so this 421 is the first sign the
+        // command was bad — and it lands in the server buffer, easy to miss
+        // when you typed in a channel. Tag it so the client can also raise a
+        // toast where the user is actually looking. Scoped to
+        // ERR_UNKNOWNCOMMAND with a known command name; other server errors
+        // stay buffer-only to keep toast noise down.
+        ...(tag === 'unknown_command' && event?.command
+          ? { unknownCommand: event.command as string }
+          : {}),
       });
     });
 

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -21,6 +21,7 @@ import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useSystemLogStore } from '../stores/systemLog.js';
 import { useDataExportStore } from '../stores/dataExport.js';
+import { useToastsStore } from '../stores/toasts.js';
 import { notifyForEvent } from './useHighlightNotifier.js';
 
 export interface AckResult {
@@ -189,9 +190,26 @@ function applyEvent(event: any): void {
       });
       break;
     case 'motd':
-    case 'error':
-      buffers.pushMessage({ ...event, target: event.target || `:server:${event.networkId}` });
+    case 'error': {
+      const decorated = { ...event, target: event.target || `:server:${event.networkId}` };
+      const fresh = buffers.pushMessage(decorated);
+      // An unrecognized slash command (forwarded as raw IRC) only fails once
+      // the server 421s, and that lands in the server buffer — invisible if
+      // you typed in a channel. Mirror it as a toast so the feedback shows up
+      // where you're looking. Gated on `fresh` so a resume-gap replay of the
+      // same error can't re-fire it (same guard the message path uses).
+      if (fresh && event.unknownCommand) {
+        useToastsStore().push({
+          kind: 'warn',
+          title: 'Unknown command',
+          body: event.unknownCommand,
+          networkId: event.networkId,
+          target: decorated.target,
+          ttlMs: 6000,
+        });
+      }
       break;
+    }
     case 'whois_result': {
       const whois = useWhoisStore();
       whois.applyResult(event.networkId, event.whois || {});


### PR DESCRIPTION
Closes #203.

## Problem

Typing an unrecognized `/command` produced the useless server-buffer line:

```
!! unknown_command — Unknown command
```

…with no indication of *which* command was rejected, and nothing surfaced in the buffer you actually typed in.

## Root cause

The client deliberately forwards any unrecognized `/command` to the server as a **raw IRC line** (`MessageInput.vue` `default` case) — that's how power-user raws like `/stats`, `/whowas`, `/links` work. The server rejects unknowns with numeric **421 ERR_UNKNOWNCOMMAND**, which `ircConnection.ts` renders into the server buffer.

irc-framework *does* parse the rejected command into `event.command`, but the `irc error` handler built its context from `[nick, channel, server]` only — throwing the command name away.

## Changes

1. **Name the command.** Add `event.command` to the error context, so the line now reads:
   ```
   !! unknown_command FOO — Unknown command
   ```
   Consistent with how every other IRC error renders (`<tag> <ctx> — <reason>`).

2. **Toast for immediate feedback.** The 421 lands in the server buffer — invisible if you typed in a channel. The server now tags unknown-command errors so the client raises a transient `warn` toast (click-through to the server buffer):
   - Scoped to `ERR_UNKNOWNCOMMAND` only — other server errors stay buffer-only to keep toast noise down. (The only non-user-typed raws we send are standard/guarded, e.g. MONITOR is ISUPPORT-gated.)
   - The `unknownCommand` discriminator is never persisted (not in `extractExtras`), so it rides only the live broadcast — backlog/resume can't re-toast.
   - Gated on event freshness (`pushMessage` returning non-dupe), the same guard the message path uses for highlight notifications.

## Testing

- `npm run typecheck` + `npm run typecheck:client` ✅
- `npm run lint` (only pre-existing unrelated warnings) ✅
- `oxfmt --check` on touched files ✅
- Full suite: 780 tests passing ✅

Not runtime-verified against a live IRC server (per the project's don't-run-the-dev-server constraint — it autoconnects to real IRC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)