### PR TITLE
Add tap-to-recall input history menu on the `>` prompt (#204)

### DIFF
--- a/vue_client/src/components/HistoryPicker.vue
+++ b/vue_client/src/components/HistoryPicker.vue
@@ -1,0 +1,189 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Previous-input recall menu — the pointer-driven counterpart to Up-arrow
+  history. Opened by tapping the `>` prompt (see MessageInput), it lists the
+  buffer's recent submitted lines so mobile users, who have no arrow keys, can
+  still reach their input history (issue #204). Picking a row replaces the
+  composer outright, exactly like an Up-arrow recall — editable, not sent.
+
+  Modelled on ChannelPicker: a position:fixed popover anchored above the input
+  bar and kept clear of the iOS soft keyboard via visualViewport. Tap-only by
+  design — Up/Down already serve keyboard users — so there's no externally
+  driven activeIndex; a plain :hover highlight is enough.
+-->
+
+<template>
+  <div
+    v-if="open && rows.length"
+    ref="panelEl"
+    class="history-picker"
+    :style="panelStyle"
+    @pointerdown.stop
+    @mousedown.prevent.stop
+  >
+    <!-- Same iOS focus-preservation contract as ChannelPicker: act on `click`
+         (end of touch), keep `@mousedown.prevent` so focus never leaves the
+         textarea, and use a plain <div role=button> rather than a focusable
+         <button>. Emitting on pointerdown would close the picker (v-if)
+         mid-touch and defeat the focus guard. -->
+    <div
+      v-for="(entry, i) in rows"
+      :key="i + ':' + entry"
+      role="button"
+      class="row"
+      :title="entry"
+      @mousedown.prevent
+      @click="pick(entry)"
+    >
+      <span class="entry">{{ entry }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    open?: boolean;
+    // Buffer history in chronological order (oldest first) — the same slice
+    // Up-arrow walks. Rendered as-is so the newest line sits at the bottom,
+    // nearest the input bar and matching the first Up-arrow recall.
+    entries?: readonly string[];
+    // The input form, used to position the panel above the bar.
+    anchor?: HTMLElement | null;
+    // The `>` toggle button. Taps on it must not dismiss the panel (its own
+    // click handler owns open/close) — everything else outside the panel does.
+    toggleEl?: HTMLElement | null;
+  }>(),
+  {
+    open: false,
+    entries: () => [],
+    anchor: null,
+    toggleEl: null,
+  },
+);
+
+const emit = defineEmits<{
+  select: [entry: string];
+  close: [];
+}>();
+
+const panelEl = ref<HTMLElement | null>(null);
+const panelBottom = ref(8);
+
+// Cap the list so a long-lived buffer doesn't render hundreds of rows. The
+// newest entries are the likeliest recalls, so keep the tail (oldest first ->
+// newest last) and let the panel scroll for the rest.
+const rows = computed(() => (props.open ? props.entries.slice(-50) : []));
+
+function pick(entry: string) {
+  emit('select', entry);
+}
+
+function recomputePosition() {
+  // Anchor the picker just above the input bar, riding above the iOS soft
+  // keyboard via visualViewport.height. Without this, the picker gets occluded
+  // as soon as the keyboard slides up.
+  const anchor = props.anchor;
+  if (!anchor) {
+    panelBottom.value = 8;
+    return;
+  }
+  const rect = anchor.getBoundingClientRect();
+  const vv = window.visualViewport;
+  const viewportHeight = vv ? vv.height : window.innerHeight;
+  // Distance from bottom of viewport to top of anchor.
+  const distance = viewportHeight - rect.top;
+  panelBottom.value = Math.max(distance + 4, 8);
+}
+
+const panelStyle = computed(() => ({ bottom: `${panelBottom.value}px` }));
+
+function onDocPointerDown(e: PointerEvent) {
+  if (!props.open) return;
+  const panel = panelEl.value;
+  const toggle = props.toggleEl;
+  if (panel && panel.contains(e.target as Node)) return;
+  // The toggle owns open/close — let its click handler decide, don't double-
+  // fire a close here. Tapping anywhere else (including the textarea) dismisses.
+  if (toggle && toggle.contains(e.target as Node)) return;
+  emit('close');
+}
+
+function onKey(e: KeyboardEvent) {
+  if (!props.open) return;
+  if (e.key === 'Escape') emit('close');
+}
+
+onMounted(() => {
+  recomputePosition();
+  window.addEventListener('resize', recomputePosition);
+  window.visualViewport?.addEventListener('resize', recomputePosition);
+  window.visualViewport?.addEventListener('scroll', recomputePosition);
+  document.addEventListener('pointerdown', onDocPointerDown);
+  document.addEventListener('keydown', onKey);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', recomputePosition);
+  window.visualViewport?.removeEventListener('resize', recomputePosition);
+  window.visualViewport?.removeEventListener('scroll', recomputePosition);
+  document.removeEventListener('pointerdown', onDocPointerDown);
+  document.removeEventListener('keydown', onKey);
+});
+
+watch(
+  () => props.open,
+  (v) => {
+    if (v) recomputePosition();
+  },
+);
+</script>
+
+<style scoped>
+.history-picker {
+  position: fixed;
+  left: var(--space-4);
+  right: var(--space-4);
+  max-width: 480px;
+  margin: 0 auto;
+  max-height: 50vh;
+  overflow-y: auto;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
+  z-index: var(--z-popover);
+}
+.row {
+  display: flex;
+  align-items: center;
+  padding: var(--space-6);
+  min-height: 44px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  user-select: none;
+}
+.row:last-child {
+  border-bottom: none;
+}
+/* Tap-only menu — no externally driven activeIndex to coordinate with, so a
+   plain :hover highlight is fine (unlike the nick/channel pickers, which avoid
+   :hover to dodge double-highlighting during keyboard nav). */
+.row:hover {
+  background: var(--bg);
+}
+/* Recalled lines can be long — keep each row to a single line, clipped with an
+   ellipsis. The full text is in the row's title and lands in the composer on
+   pick, so nothing is lost. */
+.entry {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/vue_client/src/components/HistoryPicker.vue
+++ b/vue_client/src/components/HistoryPicker.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
 
 const props = withDefaults(
   defineProps<{
@@ -140,7 +140,16 @@ onBeforeUnmount(() => {
 watch(
   () => props.open,
   (v) => {
-    if (v) recomputePosition();
+    if (!v) return;
+    recomputePosition();
+    // Open scrolled to the bottom — the newest entry sits there, nearest the
+    // input, and it's the likeliest recall. Without this the overflow scroller
+    // defaults to the top (oldest), unlike the nick/channel pickers which pull
+    // their best match (rendered at the bottom) into view on open.
+    nextTick(() => {
+      const panel = panelEl.value;
+      if (panel) panel.scrollTop = panel.scrollHeight;
+    });
   },
 );
 </script>

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -16,7 +16,16 @@
       ><template v-if="!isMobile"
         >{{ promptLabel }}<span v-if="awayLabel" class="away">&nbsp;{{ awayLabel }}</span
         >&nbsp;</template
-      >&gt;</span
+      ><span
+        v-if="hasHistory"
+        ref="promptBtnEl"
+        role="button"
+        class="prompt-recall"
+        title="recall a previous input"
+        @mousedown.prevent
+        @click="toggleHistory"
+        >&gt;</span
+      ><template v-else>&gt;</template></span
     >
     <textarea
       ref="inputEl"
@@ -91,6 +100,18 @@
       @select="onChannelPickerSelect"
       @close="closeChannelPicker"
     />
+    <!-- Previous-input recall menu, opened by tapping the `>` prompt — the
+         pointer path to history for mobile, where Up-arrow is unreachable
+         (issue #204). Anchored to the form like the pickers above; `toggle-el`
+         is the prompt button so its own taps don't double-dismiss. -->
+    <HistoryPicker
+      :open="historyPickerOpen"
+      :entries="historyEntries"
+      :anchor="formEl"
+      :toggle-el="promptBtnEl"
+      @select="onHistorySelect"
+      @close="closeHistoryPicker"
+    />
     <Teleport to="body">
       <LongMessageUploadModal
         v-if="longMessageModalOpen"
@@ -131,6 +152,7 @@ import {
 import type { EmojiMatch } from '../utils/emojiData.js';
 import NickPicker from './NickPicker.vue';
 import ChannelPicker from './ChannelPicker.vue';
+import HistoryPicker from './HistoryPicker.vue';
 import LongMessageUploadModal from './LongMessageUploadModal.vue';
 import { useSelfLabel } from '../composables/useSelfLabel.js';
 import { useViewport } from '../composables/useViewport.js';
@@ -179,6 +201,12 @@ const channelPickerQuery = ref('');
 const channelPickerEl = ref<InstanceType<typeof ChannelPicker> | null>(null);
 let channelPickerTokenStart = -1;
 let channelPickerTokenEnd = -1;
+// Previous-input recall menu (issue #204). Unlike the nick/channel pickers it
+// isn't tied to a token under the cursor — it's a tap on the `>` prompt that
+// lists the whole buffer history. `promptBtnEl` is that toggle, kept here so
+// HistoryPicker can exclude it from its outside-tap dismissal.
+const historyPickerOpen = ref(false);
+const promptBtnEl = ref<HTMLElement | null>(null);
 // Suggestion-strip and colour-picker visibility / contents live in
 // useComposerOverlay so StatusBar can render them as overlays without prop
 // drilling. Token-span book-keeping (which slice of the draft a pick
@@ -216,6 +244,12 @@ const text = computed({
 const buffer = computed(() =>
   active.value ? buffers.byKey(`${active.value.networkId}::${active.value.target}`) : null,
 );
+// The active buffer's input history (chronological), surfaced to the `>` recall
+// menu. `hasHistory` gates the prompt's tap affordance — no history, no button.
+const historyEntries = computed(() =>
+  active.value ? inputHistory.forBuffer(active.value.networkId, active.value.target) : [],
+);
+const hasHistory = computed(() => historyEntries.value.length > 0);
 const ownNick = computed(() => {
   const a = active.value;
   if (!a) return '';
@@ -831,6 +865,10 @@ function closeChannelPicker() {
   channelPickerTokenEnd = -1;
 }
 
+function closeHistoryPicker() {
+  historyPickerOpen.value = false;
+}
+
 function closeStrip() {
   setNickStrip(false);
   stripTokenStart = -1;
@@ -938,6 +976,9 @@ async function maybeConvertShortcode() {
 }
 
 function refreshPicker() {
+  // Any keystroke (this runs from onInput) dismisses the tap-opened recall
+  // menu — it's a momentary affordance, not something you type underneath.
+  closeHistoryPicker();
   const el = inputEl.value;
   if (!el) {
     closePicker();
@@ -1114,6 +1155,35 @@ function onStripSelect(nick: string): void {
   });
 }
 
+// Tap on the `>` prompt: toggle the recall menu. Opening it closes the other
+// suggesters so only one overlay is ever up (mirrors how they close each
+// other). Gated on history existing — the prompt button only renders when
+// `hasHistory`, but guard anyway in case the list emptied between render and tap.
+function toggleHistory(): void {
+  if (historyPickerOpen.value) {
+    closeHistoryPicker();
+    return;
+  }
+  if (!hasHistory.value) return;
+  closePicker();
+  closeStrip();
+  closeChannelPicker();
+  closeEmojiStrip();
+  closeColorPicker();
+  historyPickerOpen.value = true;
+}
+
+// Pick a row: replace the composer outright and drop the caret at the end —
+// identical to an Up-arrow recall (reuses setInputAndCaretEnd). The current
+// draft is discarded, not stashed; the menu is a deliberate "jump to this past
+// line", not a reversible walk. `cycling` inside setInputAndCaretEnd keeps the
+// resulting onInput from firing a typing notification or resetting state.
+function onHistorySelect(entry: string): void {
+  closeHistoryPicker();
+  setInputAndCaretEnd(entry);
+  queueMicrotask(() => inputEl.value?.focus());
+}
+
 function onInput() {
   if (cycling) return;
   // User edited the recalled line — exit walk mode but keep what they typed.
@@ -1175,6 +1245,7 @@ watch(active, (newActive, oldActive) => {
   closeChannelPicker();
   closeEmojiStrip();
   closeColorPicker();
+  closeHistoryPicker();
   resetHistoryNav();
   // A switch between buffers swaps the draft text via the `text` computed,
   // but any unused split-confirm token doesn't transfer — a fresh buffer is
@@ -1372,6 +1443,7 @@ async function submit() {
   closeChannelPicker();
   closeEmojiStrip();
   closeColorPicker();
+  closeHistoryPicker();
   const raw = text.value;
   if (!raw.trim() || !active.value) return;
   const { networkId, target } = active.value;
@@ -1823,6 +1895,28 @@ function handleCommand(line: string, networkId: number, target: string): boolean
 }
 .prompt .away {
   color: var(--warn);
+}
+/* The `>` glyph doubles as the recall-menu toggle (issue #204). It stays a
+   bare glyph visually; the tap target is enlarged by a pseudo-element so the
+   hit box grows without any negative-margin reflow that could nudge the input
+   row height or the first-line baseline. */
+.prompt-recall {
+  position: relative;
+  cursor: pointer;
+  /* Disables the iOS double-tap-zoom heuristic and its ~300ms click delay. */
+  touch-action: manipulation;
+}
+.prompt-recall::before {
+  content: '';
+  position: absolute;
+  /* Expand the hittable area on all sides. The rightward bleed lands under the
+     textarea (a later sibling that paints on top), so it never steals caret
+     taps; the upward bleed sits below the StatusBar's suggestion strip, which
+     is z-raised and wins any overlap. */
+  top: -10px;
+  bottom: -10px;
+  left: -10px;
+  right: -8px;
 }
 .upload-btn {
   background: none;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -976,9 +976,6 @@ async function maybeConvertShortcode() {
 }
 
 function refreshPicker() {
-  // Any keystroke (this runs from onInput) dismisses the tap-opened recall
-  // menu — it's a momentary affordance, not something you type underneath.
-  closeHistoryPicker();
   const el = inputEl.value;
   if (!el) {
     closePicker();
@@ -1180,6 +1177,13 @@ function toggleHistory(): void {
 // resulting onInput from firing a typing notification or resetting state.
 function onHistorySelect(entry: string): void {
   closeHistoryPicker();
+  // The menu opens on a tap, bypassing the keystroke handlers that normally
+  // clear these — so a pick can land on top of a live Tab-completion session
+  // or an in-progress Up/Down walk. setInputAndCaretEnd suppresses onInput
+  // (its cycling guard), so clear them here or they'd act on the old text:
+  // Tab would keep cycling a stale completion, Down would restore a stale draft.
+  resetCompletion();
+  resetHistoryNav();
   setInputAndCaretEnd(entry);
   queueMicrotask(() => inputEl.value?.focus());
 }
@@ -1190,6 +1194,10 @@ function onInput() {
   // Done before the sendable gate so this still fires on :server: buffers
   // where `/raw` history is just as relevant.
   if (historyIndex !== null) resetHistoryNav();
+  // Same rationale: a keystroke dismisses the tap-opened recall menu, and it
+  // must fire before the sendable gate so it also closes on :server: buffers
+  // (editable but not "sendable"), where the menu can be open over /raw history.
+  closeHistoryPicker();
   // Any edit invalidates the "second press confirms" override — otherwise the
   // user could be holding a flood-confirm token from an entirely different
   // draft. Cheap to clear unconditionally.


### PR DESCRIPTION
Closes #204.

## Problem

Input history was reachable only via the **Up arrow** — invisible and unusable on mobile, where there are no arrow keys. That whole feature was effectively desktop-only.

## Approach

Tapping the **`>` prompt** now opens a vertical popover listing the buffer's recent inputs. Picking a row drops it into the composer — **editable and unsent**, identical to an Up-arrow recall (it literally reuses `setInputAndCaretEnd`).

We dropped the alternative idea of a typed `>` trigger (à la `@`/`#`): `>` isn't a semantically special character and it collides head-on with greentext/quoting (`> like this`), which is a common way to start a message.

### Why a vertical popover, not the horizontal suggestion strip

History entries are full message lines, not short tokens — a horizontal chip strip would show one-and-a-half of them. So `HistoryPicker` is modelled on **`ChannelPicker`** instead: a `position: fixed` popover anchored above the input bar, kept clear of the iOS soft keyboard via `visualViewport`. It's **tap-only by design** (Up/Down still serve keyboard users), so there's no keyboard-nav plumbing. Newest entry sits at the **bottom**, nearest the input — matching the first Up-arrow recall and `ChannelPicker`'s "best pick under your eye" ordering.

### Details

- The `>` glyph becomes the toggle, gated on history existing (`hasHistory` — no history, no button).
- Its hit area is enlarged via a `::before` pseudo-element, so the target grows **without** any negative-margin reflow nudging the input-row height or the first-line baseline. The rightward bleed lands under the textarea (a later sibling that paints on top, so it never steals caret taps); the upward bleed sits under the StatusBar strip (z-raised, wins any overlap).
- Replace-outright semantics: the current draft is discarded, not stashed — the menu is a deliberate "jump to this past line", not a reversible walk.
- The menu closes on outside tap, Escape, typing, send, and buffer switch. Mutually exclusive with the nick/channel/emoji suggesters.
- iOS focus preservation throughout: `<div role="button">` + `@mousedown.prevent`, acting on `click`, same contract as the existing pickers.

## Testing

- `npm run typecheck` — clean
- `npm run build` — clean

(No client-side test runner in this repo; the dev server was not run.)

## Follow-up

`NickPicker`, `ChannelPicker`, and now `HistoryPicker` are three near-duplicate vertical popovers (positioning, outside-tap dismissal, Escape, viewport re-anchoring). Filed as a separate refactor to extract a generic primitive rather than bundling it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)