### PR TITLE
Unify return-to-present, add jump-to-unread (#202)

### DIFF
--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -317,9 +317,12 @@ function evaluateUnread(entry: IntersectionObserverEntry): void {
 
 // Vue function ref on the unread divider: called with the element when it
 // mounts and null when it unmounts (e.g. dividerAfterId reset to 0). Keep the
-// observer pointed at the live element across re-renders.
+// observer pointed at the live element across re-renders. The param type is
+// Vue's VNodeRef union; this ref only ever binds a native <div>, but guard
+// with instanceof so the observer is never handed a non-Element (a no-op,
+// not a throw, if a component instance ever slipped through).
 function setUnreadDividerEl(el: Element | ComponentPublicInstance | null): void {
-  const next = (el as HTMLElement) || null;
+  const next = el instanceof HTMLElement ? el : null;
   if (next === unreadDividerEl) return;
   if (unreadDividerEl && unreadObserver) unreadObserver.unobserve(unreadDividerEl);
   unreadDividerEl = next;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -18,7 +18,7 @@
     <div v-if="!buffer?.hasMoreOlder && messages.length" class="notice">— start of history —</div>
     <p v-if="!messages.length" class="notice empty">No messages yet.</p>
     <template v-for="row in renderRows" :key="row.key">
-      <div v-if="row.divider === 'unread'" class="notice unread-divider">
+      <div v-if="row.divider === 'unread'" :ref="setUnreadDividerEl" class="notice unread-divider">
         <span class="notice-label">unread</span>
       </div>
       <div v-else-if="row.divider === 'away'" class="notice presence-divider">
@@ -171,7 +171,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
-import type { CSSProperties } from 'vue';
+import type { CSSProperties, ComponentPublicInstance } from 'vue';
 import { useNetworksStore, type AwayState } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
@@ -183,6 +183,7 @@ import {
   setStuckToBottom,
   bumpNewBelow,
   resetScrollState,
+  setUnreadAnchor,
   useScrollState,
 } from '../composables/useScrollState.js';
 import type { RenderSegment } from '../utils/nickColor.js';
@@ -287,7 +288,44 @@ const tsFormat = computed(() =>
 
 const scroller = ref<HTMLElement | null>(null);
 const stickToBottom = ref(true);
-const { scrollToBottomToken } = useScrollState();
+const { scrollToBottomToken, scrollToUnreadToken } = useScrollState();
+
+// Unread-divider visibility tracking. The divider is pinned for the whole
+// visit (dividerAfterId snapshot), so once the user has scrolled it into view
+// we stop nagging them with the "Jump to unread" button for the rest of the
+// visit — reset on buffer switch. An IntersectionObserver on the (single)
+// divider element drives setUnreadAnchor: off-screen-and-unseen surfaces the
+// button with an up/down arrow, on-screen clears it and flips unreadSeen.
+let unreadDividerEl: HTMLElement | null = null;
+let unreadObserver: IntersectionObserver | null = null;
+let unreadSeen = false;
+
+function evaluateUnread(entry: IntersectionObserverEntry): void {
+  if (entry.isIntersecting) {
+    unreadSeen = true;
+    setUnreadAnchor(null);
+    return;
+  }
+  if (unreadSeen) {
+    setUnreadAnchor(null);
+    return;
+  }
+  const top = entry.boundingClientRect.top;
+  const rootTop = entry.rootBounds?.top ?? scroller.value?.getBoundingClientRect().top ?? 0;
+  setUnreadAnchor(top < rootTop ? 'up' : 'down');
+}
+
+// Vue function ref on the unread divider: called with the element when it
+// mounts and null when it unmounts (e.g. dividerAfterId reset to 0). Keep the
+// observer pointed at the live element across re-renders.
+function setUnreadDividerEl(el: Element | ComponentPublicInstance | null): void {
+  const next = (el as HTMLElement) || null;
+  if (next === unreadDividerEl) return;
+  if (unreadDividerEl && unreadObserver) unreadObserver.unobserve(unreadDividerEl);
+  unreadDividerEl = next;
+  if (next && unreadObserver) unreadObserver.observe(next);
+  else if (!next) setUnreadAnchor(null);
+}
 
 const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
 const messages = computed(() => buffer.value?.messages || []);
@@ -1000,6 +1038,7 @@ watch(
   () => networks.activeKey,
   async () => {
     stickToBottom.value = true;
+    unreadSeen = false;
     resetScrollState();
     await nextTick();
     scrollToBottom();
@@ -1017,14 +1056,29 @@ watch(compactMode, async () => {
   if (stickToBottom.value) scrollToBottom();
 });
 
-// StatusBar's "[N new ↓]" click increments scrollToBottomToken. Watching the
-// token (rather than wiring a callback) keeps the composable stateless and
-// avoids leaking refs to MessageList's DOM out of the component.
+// StatusBar's "Return to present ↓" click increments scrollToBottomToken.
+// Watching the token (rather than wiring a callback) keeps the composable
+// stateless and avoids leaking refs to MessageList's DOM out of the component.
 watch(scrollToBottomToken, async () => {
   await nextTick();
   stickToBottom.value = true;
   setStuckToBottom(true);
   scrollToBottom();
+});
+
+// StatusBar's "Jump to unread" click increments scrollToUnreadToken. Center
+// the pinned divider; mark not-stuck so a live message can't yank us back to
+// the tail mid-read. The observer flips unreadSeen once the divider lands in
+// view, which retires the button for the rest of the visit.
+watch(scrollToUnreadToken, async () => {
+  await nextTick();
+  const el = scroller.value;
+  if (!el) return;
+  const target = el.querySelector('.unread-divider');
+  if (!target) return;
+  stickToBottom.value = false;
+  setStuckToBottom(false);
+  target.scrollIntoView({ block: 'center', behavior: 'smooth' });
 });
 
 // Anything that shrinks MessageList's clientHeight (iOS soft keyboard sliding
@@ -1063,6 +1117,18 @@ onMounted(() => {
     scrollerObserver = new ResizeObserver(onScrollerResize);
     scrollerObserver.observe(scroller.value);
   }
+  if (typeof IntersectionObserver !== 'undefined' && scroller.value) {
+    unreadObserver = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (entry) evaluateUnread(entry);
+      },
+      { root: scroller.value, threshold: 0 },
+    );
+    // The divider may already be mounted (immediate activeKey render) before
+    // the observer exists — pick it up now if so.
+    if (unreadDividerEl) unreadObserver.observe(unreadDividerEl);
+  }
   nowTimer = setInterval(() => {
     now.value = Date.now();
   }, 60_000);
@@ -1073,6 +1139,10 @@ onBeforeUnmount(() => {
   if (scrollerObserver) {
     scrollerObserver.disconnect();
     scrollerObserver = null;
+  }
+  if (unreadObserver) {
+    unreadObserver.disconnect();
+    unreadObserver = null;
   }
   if (nowTimer) {
     clearInterval(nowTimer);

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -31,10 +31,13 @@
          applies. Detached → reattach to live; scrolled-up → snap down. Renders
          in both modes — merging the former desktop-only [N new ↓] button in
          means mobile finally gets a way back to the present too. -->
-      <button v-if="showPresent" class="seg return-present" type="button" @click="onReturnToPresent">
-        Return to present<template v-if="presentCount > 0">
-          ({{ presentCount }} new)</template
-        >
+      <button
+        v-if="showPresent"
+        class="seg return-present"
+        type="button"
+        @click="onReturnToPresent"
+      >
+        Return to present<template v-if="presentCount > 0"> ({{ presentCount }} new)</template>
         ↓
       </button>
       <span v-if="peerStatusLabel" class="seg peer-status" :class="peerStatusClass">{{

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -18,15 +18,22 @@
         ><span class="name">{{ promptLabel }}</span
         ><span v-if="awayLabel" class="away">&nbsp;{{ awayLabel }}</span></span
       >
-      <!-- Detached-jump indicator. Sits adjacent to the self/nick segment on
-         compact (mobile) per agreed placement, where it's the only exit
-         from a detached buffer back to live. On desktop seg.self is hidden,
-         so this lands right after the buffer name — also a natural spot.
-         Unlike [N new ↓] (which is hidden on compact), this button renders
-         in both modes. -->
-      <button v-if="detached" class="seg return-present" type="button" @click="onReturnToPresent">
-        Return to present<template v-if="liveDuringDetach > 0">
-          ({{ liveDuringDetach }} new)</template
+      <!-- Jump-to-unread. Scrolls (usually up) to the pinned unread divider
+         when it's off-screen and the user hasn't scrolled it into view yet
+         this visit. Renders in both modes — catching up matters as much on
+         mobile. -->
+      <button v-if="unreadAnchor" class="seg jump-unread" type="button" @click="onJumpToUnread">
+        Jump to unread {{ unreadArrow }}
+      </button>
+      <!-- Return-to-present: the single downward affordance. Shows whenever the
+         buffer is detached (viewing a historical slice) OR the user has
+         scrolled up off the live tail; the count badge reflects whichever
+         applies. Detached → reattach to live; scrolled-up → snap down. Renders
+         in both modes — merging the former desktop-only [N new ↓] button in
+         means mobile finally gets a way back to the present too. -->
+      <button v-if="showPresent" class="seg return-present" type="button" @click="onReturnToPresent">
+        Return to present<template v-if="presentCount > 0">
+          ({{ presentCount }} new)</template
         >
         ↓
       </button>
@@ -37,14 +44,6 @@
       <span v-if="uploadLabel" class="seg upload" :class="{ failed: uploads.failedAt }">{{
         uploadLabel
       }}</span>
-      <button
-        v-if="newBelow > 0 && !compact"
-        class="seg jump"
-        type="button"
-        @click="onJumpToBottom"
-      >
-        {{ newBelow }} new ↓
-      </button>
       <span v-if="splitLabel" class="seg split" :class="splitClass">{{ splitLabel }}</span>
       <span v-if="typingSegments.length" class="seg typing"
         >Typing:
@@ -102,7 +101,11 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore } from '../stores/uploads.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useNickColors } from '../composables/useNickColors.js';
-import { useScrollState, requestScrollToBottom } from '../composables/useScrollState.js';
+import {
+  useScrollState,
+  requestScrollToBottom,
+  requestScrollToUnread,
+} from '../composables/useScrollState.js';
 import { useComposing } from '../composables/useComposing.js';
 import { useSelfLabel } from '../composables/useSelfLabel.js';
 import { formatTimestamp } from '../utils/timestamp.js';
@@ -128,8 +131,9 @@ withDefaults(
     // (the buffer name is already in the mobile header, the clock isn't worth
     // the row), and renders the self identity (nick + channel-prefix + user
     // modes + away) here instead — freeing the input row to be just `>`,
-    // textarea, and the paperclip. Also hides lag and the "new ↓" jump button
-    // so the typing/split/upload signals stay legible at phone widths.
+    // textarea, and the paperclip. Also hides lag so the typing/split/upload
+    // signals stay legible at phone widths. (The scroll affordances —
+    // jump-to-unread and return-to-present — render in both modes.)
     compact?: boolean;
   }>(),
   { compact: false },
@@ -165,7 +169,7 @@ const uploadLabel = computed(() => {
   }
   return '';
 });
-const { newBelow } = useScrollState();
+const { newBelow, stuckToBottom, unreadAnchor } = useScrollState();
 
 const active = computed(() => networks.activeBuffer);
 const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
@@ -317,23 +321,35 @@ onBeforeUnmount(() => {
 });
 const clock = computed(() => formatTimestamp(now.value.toISOString(), tsFormat.value));
 
-function onJumpToBottom() {
-  requestScrollToBottom();
-}
-
 const detached = computed(() => !!buffer.value?.detached);
 const liveDuringDetach = computed(() => buffer.value?.liveDuringDetach || 0);
+
+// One downward affordance covering both "scrolled up on the live tail" and
+// "viewing a detached historical slice". Detached forces stickToBottom false
+// when the slice lands, but the user can scroll to the bottom OF THE SLICE
+// (stuck=true) while still off the live tail — so detached must be its own
+// arm of the condition, not folded into !stuckToBottom.
+const showPresent = computed(() => detached.value || !stuckToBottom.value);
+// Count badge: messages that arrived while detached, else the live unread-
+// below count tracked by the scroll state.
+const presentCount = computed(() => (detached.value ? liveDuringDetach.value : newBelow.value));
 
 function onReturnToPresent() {
   const buf = buffer.value;
   if (!buf) return;
-  buffers.reattachToLive(buf.networkId, buf.target);
-  // The reattach response will replace messages and trip the wholesale-
-  // replace branch in MessageList's watcher (which snaps to bottom and
-  // resets stickToBottom). The explicit token here is belt-and-suspenders:
-  // if the response is slow, the user clicking again still requests a
-  // bottom snap once the slice eventually lands.
+  // Only a detached buffer needs to re-fetch the live tail; a plain scrolled-
+  // up live buffer just snaps down. The reattach response replaces messages
+  // and trips the wholesale-replace branch in MessageList's watcher (which
+  // snaps to bottom and resets stickToBottom); the token is belt-and-
+  // suspenders for a slow response.
+  if (buf.detached) buffers.reattachToLive(buf.networkId, buf.target);
   requestScrollToBottom();
+}
+
+const unreadArrow = computed(() => (unreadAnchor.value === 'down' ? '↓' : '↑'));
+
+function onJumpToUnread() {
+  requestScrollToUnread();
 }
 </script>
 
@@ -429,7 +445,7 @@ function onReturnToPresent() {
 .seg.split.bad {
   color: var(--bad);
 }
-.seg.jump,
+.seg.jump-unread,
 .seg.return-present {
   background: none;
   border: none;
@@ -438,7 +454,7 @@ function onReturnToPresent() {
   padding: 0;
   cursor: pointer;
 }
-.seg.jump:hover,
+.seg.jump-unread:hover,
 .seg.return-present:hover {
   color: var(--fg);
 }

--- a/vue_client/src/composables/useScrollState.ts
+++ b/vue_client/src/composables/useScrollState.ts
@@ -4,20 +4,30 @@
 import type { Ref } from 'vue';
 import { ref } from 'vue';
 
+// Direction from the viewport to the pinned unread divider when it's off
+// screen and not yet seen this visit: 'up' = above the viewport, 'down' =
+// below it. null means there's nothing to jump to — no divider, it's on
+// screen, or the user already scrolled it into view this visit.
+export type UnreadAnchor = 'up' | 'down' | null;
+
 // Bridges MessageList's scroll position into the StatusBar without a prop drill.
 // MessageList writes via the setters; StatusBar reads the refs.
 const stuckToBottom = ref(true);
 const newBelow = ref(0);
 const scrollToBottomToken = ref(0);
+const unreadAnchor = ref<UnreadAnchor>(null);
+const scrollToUnreadToken = ref(0);
 
 export interface ScrollState {
   stuckToBottom: Ref<boolean>;
   newBelow: Ref<number>;
   scrollToBottomToken: Ref<number>;
+  unreadAnchor: Ref<UnreadAnchor>;
+  scrollToUnreadToken: Ref<number>;
 }
 
 export function useScrollState(): ScrollState {
-  return { stuckToBottom, newBelow, scrollToBottomToken };
+  return { stuckToBottom, newBelow, scrollToBottomToken, unreadAnchor, scrollToUnreadToken };
 }
 
 export function setStuckToBottom(v: boolean): void {
@@ -32,8 +42,17 @@ export function bumpNewBelow(): void {
 export function resetScrollState(): void {
   stuckToBottom.value = true;
   newBelow.value = 0;
+  unreadAnchor.value = null;
 }
 
 export function requestScrollToBottom(): void {
   scrollToBottomToken.value += 1;
+}
+
+export function setUnreadAnchor(dir: UnreadAnchor): void {
+  unreadAnchor.value = dir;
+}
+
+export function requestScrollToUnread(): void {
+  scrollToUnreadToken.value += 1;
 }


### PR DESCRIPTION
Closes #202.

Two status-bar scroll affordances, reworked around the existing `useScrollState` bridge.

## Return-to-present (request #1) — merged, not added
Previously the `Return to present ↓` button showed only for **detached** buffers (search/bookmark/highlight jumps), and a separate desktop-only `[N new ↓]` button handled the live scrolled-up case. These are collapsed into **one downward button**:

- **Visibility:** `detached || !stuckToBottom` — any scroll away from the live tail surfaces it. (`detached` has to be its own arm: a user can scroll to the bottom *of a detached slice*, flipping `stuckToBottom` true while still off the live tail.)
- **Handler:** re-fetches the tail (`reattachToLive`) only when actually detached; a plain scrolled-up live buffer just snaps down.
- **Count badge:** `liveDuringDetach` when detached, else `newBelow`.
- Renders in **both layouts** now — mobile finally gets a way back to the present after scrolling up (the old `[N new ↓]` was desktop-only).

## Jump-to-unread (request #2) — new
An `IntersectionObserver` (root = scroller) on the single `.unread-divider` element publishes a new `unreadAnchor` signal (`'up' | 'down' | null`). When the pinned unread marker is off-screen, an upward `Jump to unread ↑` button appears; clicking it centers the divider.

The divider is pinned for the whole visit (the `dividerAfterId` snapshot), so once the user scrolls it into view the button **retires for the rest of the visit** (`unreadSeen`, reset on buffer switch) rather than nagging after catch-up. Re-arms when you switch away and back.

## Files
- `composables/useScrollState.ts` — new `unreadAnchor` + `scrollToUnreadToken` signals/setters; `resetScrollState` clears the anchor.
- `components/MessageList.vue` — producer: IntersectionObserver lifecycle + `scrollToUnreadToken` watcher.
- `components/StatusBar.vue` — consumer: the merged present button + new unread button.

## Testing
`vue-tsc` typecheck clean, `vite build` green. Verified manually in the running client: jump-to-unread arrow direction, retire-after-seen behavior, and the merged return-to-present across detached and live scrolled-up states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)