### PR TITLE
Fix backlog gap when resume exceeds the per-buffer cap (#205)

### DIFF
--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -15,6 +15,7 @@ let closeBuffer: typeof import('../db/closedBuffers.js').closeBuffer;
 let isClosed: typeof import('../db/closedBuffers.js').isClosed;
 let setClearedState: typeof import('../db/bufferReads.js').setClearedState;
 let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
+let buildResumeSlice: typeof import('./wsHub.js').buildResumeSlice;
 let buildOfflineBacklogFrames: typeof import('./wsHub.js').buildOfflineBacklogFrames;
 let handleOpenBuffer: typeof import('./wsHub.js').handleOpenBuffer;
 
@@ -27,7 +28,7 @@ beforeAll(async () => {
   ({ insertMessage } = await import('../db/messages.js'));
   ({ closeBuffer, isClosed } = await import('../db/closedBuffers.js'));
   ({ setClearedState } = await import('../db/bufferReads.js'));
-  ({ buildBufferBacklog, buildOfflineBacklogFrames, handleOpenBuffer } =
+  ({ buildBufferBacklog, buildResumeSlice, buildOfflineBacklogFrames, handleOpenBuffer } =
     await import('./wsHub.js'));
 
   userId = createUser('alice').id;
@@ -43,16 +44,18 @@ beforeAll(async () => {
 
 afterAll(() => testDb.cleanup());
 
-function seed(target: string, text: string): void {
-  insertMessage({
-    networkId,
-    target,
-    time: new Date().toISOString(),
-    type: 'message',
-    nick: 'bob',
-    text,
-    self: false,
-  });
+function seed(target: string, text: string): number {
+  return Number(
+    insertMessage({
+      networkId,
+      target,
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'bob',
+      text,
+      self: false,
+    }).id,
+  );
 }
 
 // A WebSocket stand-in that records the frames send() writes. send() gates on
@@ -102,6 +105,48 @@ describe('buildBufferBacklog', () => {
     const frame = buildBufferBacklog(userId, networkId, '#clear');
     expect(frame.clearedBeforeId).toBe(boundary);
     expect(frame.clearedAt).toBe(ts);
+  });
+});
+
+describe('buildResumeSlice', () => {
+  // Mirrors the server-side constants in wsHub.ts. If those change, these move.
+  const RESUME_GAP_CAP = 500;
+  const RESUME_LATEST_LIMIT = 200;
+
+  it('ships just the missed gap and does not reset when it fits the cap', () => {
+    const since = seed('#resumeSmall', 'm0');
+    const ids: number[] = [];
+    for (let i = 1; i <= 5; i++) ids.push(seed('#resumeSmall', `m${i}`));
+    const slice = buildResumeSlice(userId, networkId, '#resumeSmall', since);
+    expect(slice.reset).toBe(false);
+    expect(slice.events.length).toBe(5);
+    // The gap, oldest-first — exactly the rows after the cursor.
+    expect((slice.events[0] as { id: number }).id).toBe(ids[0]);
+    expect((slice.events.at(-1) as { id: number }).id).toBe(ids.at(-1));
+    // A non-reset frame doesn't drive hasMoreOlder (the client keeps its own).
+    expect(slice.hasMoreOlder).toBe(false);
+  });
+
+  it('resets to the latest slice when the gap overflows the cap (issue #205)', () => {
+    const since = seed('#resumeBig', 'm0');
+    let lastId = since;
+    // One more than the cap so the gap is provably truncated.
+    for (let i = 1; i <= RESUME_GAP_CAP + 10; i++) lastId = seed('#resumeBig', `m${i}`);
+    const slice = buildResumeSlice(userId, networkId, '#resumeBig', since);
+    expect(slice.reset).toBe(true);
+    // Latest contiguous slice, NOT the oldest-after-cursor rows.
+    expect(slice.events.length).toBe(RESUME_LATEST_LIMIT);
+    expect((slice.events.at(-1) as { id: number }).id).toBe(lastId);
+    // There's older history beyond the latest slice — the client can page up.
+    expect(slice.hasMoreOlder).toBe(true);
+  });
+
+  it('ships the latest slice without reset on first connect (sinceId=0)', () => {
+    seed('#resumeFresh', 'a');
+    seed('#resumeFresh', 'b');
+    const slice = buildResumeSlice(userId, networkId, '#resumeFresh', 0);
+    expect(slice.reset).toBe(false);
+    expect(slice.events.length).toBe(2);
   });
 });
 

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -295,6 +295,62 @@ export function buildBufferBacklog(userId: number, networkId: number, target: st
   };
 }
 
+// Upper bound on how many missed rows a resume frame ships per buffer. Wider
+// than the first-connect default so a normal flap fills in one shot, but
+// bounded so a long disconnect can't produce an unbounded payload.
+const RESUME_GAP_CAP = 500;
+// When the gap exceeds the cap we fall back to a fresh latest slice; size it
+// to match the first-connect default.
+const RESUME_LATEST_LIMIT = 200;
+
+// Decide the slice a resume snapshot ships for ONE buffer.
+//
+// Normal case: ship just the gap the client missed (id > sinceId). The client
+// appends it to its existing tail (replaceBacklog's gap-fill path).
+//
+// The catch: that gap is capped at RESUME_GAP_CAP to bound the payload, and
+// the client only retains MAX_PER_BUFFER rows anyway. So if the buffer took on
+// MORE than the cap while the client was away, appending the oldest slice of
+// the gap would splice a PERMANENT hole between the client's stale tail and the
+// live tail (the dropped middle is never re-sent — fanOut only carries events
+// created after reconnect). That's issue #205: a "big gap" only a full reload
+// clears. Because message ids are a single global sequence, the client can't
+// detect the hole from id-sparseness alone (a quiet buffer is legitimately
+// sparse) — only the server knows it truncated. So when we detect truncation we
+// ship the LATEST contiguous slice instead and flag `reset`, telling the client
+// to replace the buffer wholesale (land on live tail, page upward for older)
+// rather than append into a gap.
+export function buildResumeSlice(
+  userId: number,
+  networkId: number,
+  target: string,
+  sinceId: number,
+): { events: DecoratedEvent[]; reset: boolean; hasMoreOlder: boolean } {
+  if (sinceId > 0) {
+    const gap = listMessages(networkId, target, { afterId: sinceId, limit: RESUME_GAP_CAP });
+    const lastGapId = gap.length ? (gap[gap.length - 1].id ?? sinceId) : sinceId;
+    const truncated = gap.length >= RESUME_GAP_CAP && hasNewerRow(networkId, target, lastGapId);
+    if (!truncated) {
+      return {
+        events: gap.map((e) => decorateMessage(userId, e)),
+        reset: false,
+        hasMoreOlder: false,
+      };
+    }
+    // Truncated: fall through to the latest-slice replace below.
+  }
+  const latest = listMessages(networkId, target, { limit: RESUME_LATEST_LIMIT });
+  const oldestId = latest.length ? (latest[0].id ?? 0) : 0;
+  return {
+    events: latest.map((e) => decorateMessage(userId, e)),
+    // Only signal a replace on a real resume. First connect (sinceId<=0) lands
+    // on the client's empty-buffer seed path, which already replaces — flagging
+    // reset there is harmless but needlessly noisy.
+    reset: sinceId > 0,
+    hasMoreOlder: oldestId > 0 && hasOlderRow(networkId, target, oldestId),
+  };
+}
+
 // Backlog frames for every network the user owns that has NO live connection —
 // a paused account (the is_paused gate forbids connecting), a manually
 // disconnected network (stopNetwork deletes the connection), or one that was
@@ -843,17 +899,19 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         ) {
           continue;
         }
-        // Resume cursor: ship only the gap (id > sinceId) when the client has
-        // local state to merge with. Cap at 500 — a wider net than the
-        // 200-row first-connect default — to cover longer flaps without
-        // unbounded payloads. If the gap is larger than 500, the client's
-        // dedupe still makes a later full re-fetch safe.
-        const sinceId = ws.sinceId || 0;
-        const events = (
-          sinceId > 0 && !isFreshNetwork
-            ? listMessages(conn.network.id, target, { afterId: sinceId, limit: 500 })
-            : listMessages(conn.network.id, target, { limit: 200 })
-        ).map((e) => decorateMessage(userId, e));
+        // Resume cursor: ship the gap the client missed (id > sinceId), or a
+        // fresh latest slice + reset flag when that gap exceeds the cap (see
+        // buildResumeSlice for the gap/reset rationale). isFreshNetwork forces
+        // the latest path: ws.sinceId was advanced by other networks' live
+        // events this session, so a cursor read here would wrongly return
+        // nothing and starve a just-connected network of its backlog.
+        const slice = buildResumeSlice(
+          userId,
+          conn.network.id,
+          target,
+          isFreshNetwork ? 0 : ws.sinceId || 0,
+        );
+        const events = slice.events;
         for (const e of events) {
           if (e.id != null && e.id > maxSentId) maxSentId = e.id;
         }
@@ -873,6 +931,11 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           networkId: conn.network.id,
           target,
           events,
+          // reset=true means the resume gap overflowed the cap and `events` is
+          // a fresh latest slice — the client must replace its buffer, not
+          // append, or it splices a permanent hole (issue #205).
+          reset: slice.reset,
+          hasMoreOlder: slice.hasMoreOlder,
           speakers,
           // For channels: are we currently joined? Drives the dim/active style
           // in the buffer list. Non-channel buffers (DMs, :server:) have no

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -283,6 +283,9 @@ function applyBacklog(payload: any): void {
       clearedAt: payload.clearedAt,
     },
     payload.joined,
+    // reset: the resume gap overflowed the server cap, so `events` is a fresh
+    // latest slice meant to replace the buffer rather than gap-fill onto it.
+    { reset: !!payload.reset, hasMoreOlder: payload.hasMoreOlder },
   );
   if (payload.inputHistory) {
     const inputHistory = useInputHistoryStore();

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -254,6 +254,7 @@ export const useBuffersStore = defineStore('buffers', {
       speakers: SpeakerEntry[] | undefined,
       readState: any,
       joined: boolean | undefined,
+      opts: { reset?: boolean; hasMoreOlder?: boolean } = {},
     ) {
       const buf = ensureBuffer(this, networkId, target);
       // Detached: snapshot resume during detach is a no-op. The gap-fill
@@ -280,6 +281,16 @@ export const useBuffersStore = defineStore('buffers', {
         // pre-flap). Take the backlog wholesale.
         buf.messages = filtered.slice(-MAX_PER_BUFFER);
         buf.hasMoreOlder = filtered.length >= 50;
+      } else if (opts.reset) {
+        // The resume gap exceeded the server's cap, so it sent a fresh latest
+        // slice instead of the missed-since-cursor rows. Appending would splice
+        // a permanent hole between our stale tail and this slice — and the
+        // dropped middle is larger than MAX_PER_BUFFER anyway, so we'd evict it
+        // immediately. Replace wholesale; the user lands on the live tail and
+        // pages upward (hasMoreOlder) for the rest. This is the self-healing
+        // path for issue #205 — no full reload required.
+        buf.messages = filtered.slice(-MAX_PER_BUFFER);
+        buf.hasMoreOlder = opts.hasMoreOlder ?? filtered.length >= 50;
       } else {
         // Gap-fill on reconnect: filter to events newer than what we already
         // have and append. Keeps live state intact when the server's backlog


### PR DESCRIPTION
Fixes #205.

## The bug

"Sometimes (on mobile usually) the buffer backlog does not load in new messages properly... a big gap in the message history, which fills in with a full reload."

It's not a loader that fails to fire — it's the **resume protocol handing the client a history with a hole in it.**

When the PWA returns from background it resyncs (a fresh socket with `?since=<lastSeenEventId>`, or an in-band `{type:'snapshot'}` after >30s hidden). Both run, per buffer:

```
listMessages(networkId, target, { afterId: sinceId, limit: 500 })
// WHERE id > sinceId ORDER BY id ASC LIMIT 500
```

If a buffer took on **more than 500 messages** during the disconnect, the server ships the oldest 500 after the cursor, then advances `ws.sinceId` past them. The newest missed rows are never re-sent — `fanOut` only carries events created *after* reconnect — so the client ends up with `[old tail][500 catch-up rows][HOLE][live tail]`. The client's `replaceBacklog` gap-fill blindly concatenates `[...existing, ...fresh]` with no contiguity check, so the hole sticks until a full reload (which takes the clean `limit: 200` latest path).

Two conditions have to coincide — a resync **and** >500 messages in one buffer during a single background window — which is exactly the "sometimes, on mobile" (e.g. overnight on a busy channel) signature.

## Why the fix is server-side

Message `id` is a single global `AUTOINCREMENT` sequence, so a quiet buffer legitimately has sparse ids (`5000 → 5801` is normal). The client **cannot** distinguish "sparse because quiet" from "sparse because the server truncated my gap." Only the server knows it applied `LIMIT 500` with more rows behind it — so the truncation has to be detected and signalled server-side.

The previous code comment claimed *"the client's dedupe still makes a later full re-fetch safe"* — but there is no automatic re-fetch; the only thing that healed it was the user manually reloading, which is the symptom.

## The change

- **Server (`wsHub.ts`)**: new `buildResumeSlice()` owns the per-buffer decision — gap fits the cap → ship the missed rows (`reset: false`, unchanged append path); gap **overflows** the cap (detected with `hasNewerRow`) → ship the **latest contiguous slice** + `reset: true` + `hasMoreOlder`. `sendSnapshot` stamps those onto the backlog frame.
- **Client (`buffers.ts` / `useSocket.ts`)**: `replaceBacklog` honors `reset` by replacing the buffer wholesale (lands on live tail, pages upward for older) instead of appending into a hole. Server read-state is still applied, so **unread is preserved** — no spurious mark-read.

Net: the >500 case self-heals on resync instead of waiting for a manual reload. The common case (gap ≤ cap, usually 0) is untouched.

## Testing

- 3 new integration cases in `wsHub.test.ts` against a real DB: fits cap → no reset, ships the gap; overflows cap (seeds 510 rows) → reset + latest slice + `hasMoreOlder`; first connect → latest, no reset.
- `npm run typecheck` + `typecheck:client` clean; full suite **783 passed** (wsHub 9 → 12); `format:check` clean; lint clean (only 2 pre-existing warnings in untouched files).

Note: this is hard to reproduce on demand (needs a real >500-message background window), so the integration tests pin the truncation/reset logic directly rather than relying on a manual repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)