### PR TITLE
Replace message kebab menu with hover action bar (#117)

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1159,6 +1159,12 @@ function onStripSelect(nick: string): void {
 // so iOS raises the keyboard from the originating tap.
 function addressInComposer(nick: string): void {
   if (!active.value || !nick) return;
+  // A Reply click bypasses the keystroke handlers that normally clear these,
+  // and setInputAndCaretEnd suppresses onInput (its `cycling` guard) — so clear
+  // them here or a stale Tab-completion / Up-Down history walk would act on the
+  // old text afterward. Same reset onHistorySelect does for the same reason.
+  resetCompletion();
+  resetHistoryNav();
   const prefix = `${nick}: `;
   const cur = text.value;
   const next = cur.startsWith(prefix) ? cur : cur ? `${prefix}${cur}` : prefix;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1152,6 +1152,20 @@ function onStripSelect(nick: string): void {
   });
 }
 
+// Reply action from the message list's action bar: prepend `nick: ` to the
+// current draft (unless it's already addressed to them) and focus the
+// composer. Mirrors the history-recall focus dance — setInputAndCaretEnd owns
+// the `cycling` guard, and the focus()-in-a-microtask matches onHistorySelect
+// so iOS raises the keyboard from the originating tap.
+function addressInComposer(nick: string): void {
+  if (!active.value || !nick) return;
+  const prefix = `${nick}: `;
+  const cur = text.value;
+  const next = cur.startsWith(prefix) ? cur : cur ? `${prefix}${cur}` : prefix;
+  setInputAndCaretEnd(next);
+  queueMicrotask(() => inputEl.value?.focus());
+}
+
 // Tap on the `>` prompt: toggle the recall menu. Opening it closes the other
 // suggesters so only one overlay is ever up (mirrors how they close each
 // other). Gated on history existing — the prompt button only renders when
@@ -1344,6 +1358,7 @@ onMounted(() => {
     onColorApply: onApplyColor,
     onColorReset: onPickReset,
     onColorClose: closeColorPicker,
+    onAddress: addressInComposer,
   });
 });
 

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -159,7 +159,7 @@
             :class="{ active: a.active }"
             :title="a.label"
             :aria-label="a.label"
-            @click.stop="a.onClick()"
+            @click.stop="runAction(a.key, row.m)"
             @contextmenu.stop.prevent
           >
             <i :class="a.icon"></i>
@@ -211,7 +211,11 @@ import LinkedText from './LinkedText.vue';
 import RenderSegments from './RenderSegments.vue';
 import IgnoreModal from './IgnoreModal.vue';
 import { useMessageActions } from '../composables/useMessageActions.js';
-import type { MessageContext, MessageAction } from '../composables/useMessageActions.js';
+import type {
+  MessageContext,
+  MessageAction,
+  MessageActionKey,
+} from '../composables/useMessageActions.js';
 import { addressNick } from '../composables/useComposerOverlay.js';
 import { setViewedBuffer } from '../composables/useViewedBuffer.js';
 
@@ -416,28 +420,37 @@ function parseUserHost(userhost: string | null | undefined): {
   return { user: rest.slice(0, at) || null, host: rest.slice(at + 1) || null };
 }
 
-function actionContext(m: ChatMessage): MessageContext {
-  return {
-    networkId: buffer.value?.networkId ?? 0,
-    onReply: (msg) => {
-      if (msg.nick) addressNick(msg.nick);
-    },
-    onIgnore: (msg) => {
-      const { user, host } = parseUserHost(msg.userhost);
-      ignoreTarget.value = {
-        nick: msg.nick,
-        user,
-        host,
-        networkId: buffer.value?.networkId,
-      };
-    },
-  };
-}
+// One stable context for every row — the handlers read `buffer.value` at call
+// time, so there's no need to rebuild it per message (the bar re-evaluates for
+// up to 500 rows on each render). `run()` is handed this on click.
+const actionContext: MessageContext = {
+  get networkId() {
+    return buffer.value?.networkId ?? 0;
+  },
+  onReply: (msg) => {
+    if (msg.nick) addressNick(msg.nick);
+  },
+  onIgnore: (msg) => {
+    const { user, host } = parseUserHost(msg.userhost);
+    ignoreTarget.value = {
+      nick: msg.nick,
+      user,
+      host,
+      networkId: buffer.value?.networkId,
+    };
+  },
+};
 
 function actionsFor(m: ChatMessage | undefined | null): MessageAction[] {
   if (!m) return [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return messageActions.buildActions(m as any, actionContext(m));
+  return messageActions.buildActions(m as any);
+}
+
+function runAction(key: MessageActionKey, m: ChatMessage | undefined | null): void {
+  if (!m) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  messageActions.run(key, m as any, actionContext);
 }
 
 const smartFilterEnabled = computed(() => !!settings.effective('chat.smart_filter'));

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -145,17 +145,26 @@
             /></template>
           </span>
         </template>
-        <button
+        <div
           v-if="eligibleForActions(row.m)"
-          type="button"
           class="row-actions"
-          title="Message actions"
+          role="group"
           aria-label="Message actions"
-          @click.stop="onActionsClick($event, row.m)"
-          @contextmenu.stop.prevent
         >
-          <i class="fa-solid fa-ellipsis-vertical"></i>
-        </button>
+          <button
+            v-for="a in actionsFor(row.m)"
+            :key="a.key"
+            type="button"
+            class="row-action"
+            :class="{ active: a.active }"
+            :title="a.label"
+            :aria-label="a.label"
+            @click.stop="a.onClick()"
+            @contextmenu.stop.prevent
+          >
+            <i :class="a.icon"></i>
+          </button>
+        </div>
       </div>
     </template>
   </div>
@@ -202,7 +211,8 @@ import LinkedText from './LinkedText.vue';
 import RenderSegments from './RenderSegments.vue';
 import IgnoreModal from './IgnoreModal.vue';
 import { useMessageActions } from '../composables/useMessageActions.js';
-import type { MessageContext } from '../composables/useMessageActions.js';
+import type { MessageContext, MessageAction } from '../composables/useMessageActions.js';
+import { addressNick } from '../composables/useComposerOverlay.js';
 import { setViewedBuffer } from '../composables/useViewedBuffer.js';
 
 // Extended BufferMessage fields accessed in the template and script
@@ -380,11 +390,10 @@ function rowClass(row: RenderRow) {
   };
 }
 
-// Per-message context menu wiring. Same items surface via right-click,
-// mobile long-press, and the hover three-dots button — every path funnels
-// through useMessageActions. The ignore confirmation modal is owned here so
-// the menu callback can hand off without needing to know which view it lives
-// in (mirrors MemberList's pattern).
+// Per-message action-bar wiring (issue #117). The hover bar renders the
+// actions built by useMessageActions; the ignore confirmation modal and the
+// reply hand-off to the composer are owned here so the action callbacks don't
+// need to know which view they live in (mirrors MemberList's pattern).
 const messageActions = useMessageActions();
 const ignoreTarget = ref<IgnoreTarget | null>(null);
 
@@ -407,9 +416,12 @@ function parseUserHost(userhost: string | null | undefined): {
   return { user: rest.slice(0, at) || null, host: rest.slice(at + 1) || null };
 }
 
-function menuContext(m: ChatMessage): MessageContext {
+function actionContext(m: ChatMessage): MessageContext {
   return {
     networkId: buffer.value?.networkId ?? 0,
+    onReply: (msg) => {
+      if (msg.nick) addressNick(msg.nick);
+    },
     onIgnore: (msg) => {
       const { user, host } = parseUserHost(msg.userhost);
       ignoreTarget.value = {
@@ -422,14 +434,10 @@ function menuContext(m: ChatMessage): MessageContext {
   };
 }
 
-function onActionsClick(e: MouseEvent, m: ChatMessage | undefined) {
-  if (!eligibleForActions(m)) return;
+function actionsFor(m: ChatMessage | undefined | null): MessageAction[] {
+  if (!m) return [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  messageActions.openMenuFromButton(
-    m as any,
-    menuContext(m!),
-    (e.currentTarget as Element) || null,
-  );
+  return messageActions.buildActions(m as any, actionContext(m));
 }
 
 const smartFilterEnabled = computed(() => !!settings.effective('chat.smart_filter'));
@@ -1248,39 +1256,58 @@ watch(
   background: var(--bg-soft);
 }
 
-/* Hover-revealed three-dots button on eligible rows. Sits in the gutter on
-   the right edge of the line. Mobile reaches the menu via the same hover
-   path: iOS Safari's sticky :hover makes the first tap on a row reveal the
-   dots, and a second tap on the dots opens the menu. Long-press is left to
-   the browser's native text-callout so users can select message text. */
+/* Hover-revealed action bar on eligible rows (issue #117). A small floating
+   toolbar — same card treatment as the toast stack (bg + border + drop
+   shadow) — anchored to the top-right of the line, floating just above it so
+   the bar barely overlaps the top edge instead of covering the message text.
+   Mobile reaches it via the same sticky-:hover path the old kebab used: iOS
+   Safari's sticky :hover makes the first tap on a row reveal the bar, and a
+   second tap hits an action. Long-press is left to the browser's native
+   text-callout so users can still select message text. */
 .row-actions {
   position: absolute;
-  top: 50%;
-  right: var(--space-2);
-  transform: translateY(-50%);
-  background: var(--bg);
-  border: 1px solid var(--border);
-  color: var(--fg-muted);
-  width: 22px;
-  height: 22px;
+  /* Sit the bar fully above the row, then nudge down a few px so its bottom
+     edge just clips the top of the line — anchors it to its own row without
+     obscuring the text. */
+  top: var(--space-2);
+  right: var(--space-3);
+  transform: translateY(-100%);
   display: flex;
   align-items: center;
-  justify-content: center;
-  cursor: pointer;
+  gap: var(--space-1);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  padding: var(--space-1);
   opacity: 0;
   pointer-events: none;
   z-index: var(--z-base);
-  padding: 0;
-  border-radius: var(--radius-sm);
 }
 .line:hover .row-actions,
-.row-actions:focus-visible {
+.row-actions:focus-within {
   opacity: 1;
   pointer-events: auto;
 }
-.row-actions:hover {
+.row-action {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: var(--radius-sm);
+}
+.row-action:hover {
   color: var(--fg);
   background: var(--bg-soft);
+}
+.row-action.active {
+  color: var(--accent);
 }
 
 /* Matched highlight (rule fired): warm background tint. Sits above .alt so

--- a/vue_client/src/composables/useComposerOverlay.ts
+++ b/vue_client/src/composables/useComposerOverlay.ts
@@ -53,6 +53,10 @@ let onEmojiSelect: EmojiSelectHandler = () => {};
 let onColorApply: ColorApplyHandler = () => {};
 let onColorReset: VoidHandler = () => {};
 let onColorClose: VoidHandler = () => {};
+// Address a nick from outside the composer (the message action bar's Reply).
+// Same signature as a nick pick, but it prepends `nick: ` to the whole draft
+// rather than splicing at a token span, so it gets its own handler.
+let onAddress: NickSelectHandler = () => {};
 
 export interface ComposerOverlayHandlers {
   onNickSelect?: NickSelectHandler;
@@ -60,6 +64,7 @@ export interface ComposerOverlayHandlers {
   onColorApply?: ColorApplyHandler;
   onColorReset?: VoidHandler;
   onColorClose?: VoidHandler;
+  onAddress?: NickSelectHandler;
 }
 
 export function setComposerOverlayHandlers(h: ComposerOverlayHandlers): void {
@@ -68,6 +73,7 @@ export function setComposerOverlayHandlers(h: ComposerOverlayHandlers): void {
   if (h.onColorApply) onColorApply = h.onColorApply;
   if (h.onColorReset) onColorReset = h.onColorReset;
   if (h.onColorClose) onColorClose = h.onColorClose;
+  if (h.onAddress) onAddress = h.onAddress;
 }
 
 export function setNickStrip(open: boolean, items: NickStripItem[] = []): void {
@@ -132,6 +138,11 @@ export function hasNickCandidates(): boolean {
 // route back through the registered MessageInput callbacks.
 export function selectNick(nick: string): void {
   onNickSelect(nick);
+}
+// Reply affordance: route an "address this nick" request to MessageInput,
+// which owns the draft text and the focus/caret dance.
+export function addressNick(nick: string): void {
+  onAddress(nick);
 }
 export function selectEmoji(item: EmojiMatch): void {
   onEmojiSelect(item);

--- a/vue_client/src/composables/useMessageActions.ts
+++ b/vue_client/src/composables/useMessageActions.ts
@@ -19,63 +19,52 @@ export interface MessageContext {
   onIgnore(message: MessageLike): void;
 }
 
+export type MessageActionKey = 'reply' | 'copy' | 'save' | 'ignore';
+
 export interface MessageAction {
-  key: 'reply' | 'copy' | 'save' | 'ignore';
+  key: MessageActionKey;
   // Tooltip + accessible label for the icon button.
   label: string;
   // Font Awesome classes for the button glyph.
   icon: string;
-  onClick(): void;
   // Toggles the "lit" treatment — currently only the bookmark when saved.
   active?: boolean;
 }
 
 export interface MessageActionsAPI {
-  buildActions(
-    message: MessageLike | null | undefined,
-    ctx: MessageContext | null | undefined,
-  ): MessageAction[];
+  buildActions(message: MessageLike | null | undefined): MessageAction[];
+  run(key: MessageActionKey, message: MessageLike, ctx: MessageContext): void;
 }
 
 // Single source of truth for the per-message actions rendered as the hover
 // action bar in MessageList (issue #117 — replaced the kebab + context menu).
-// The caller owns the component-local UI for the ignore confirmation
-// (mirrors useMemberActions) and the reply hand-off to the composer, passing
-// both in via `context`.
+//
+// buildActions() returns plain descriptors (no per-row handler closures) so
+// the bar — re-evaluated for up to MAX_PER_BUFFER rows on every render — stays
+// allocation-light; clicks are dispatched through run() with a context the
+// caller builds once. The caller owns the component-local UI for the ignore
+// confirmation (mirrors useMemberActions) and the reply hand-off to the
+// composer, supplying both via that context.
 //
 // `message` shape: { id, nick, text, self, userhost, network_id|networkId, ... }
 // `context` shape: { networkId, onReply(message), onIgnore(message) }
 export function useMessageActions(): MessageActionsAPI {
   const bookmarks = useBookmarksStore();
 
-  function buildActions(
-    message: MessageLike | null | undefined,
-    ctx: MessageContext | null | undefined,
-  ): MessageAction[] {
-    if (!message || !ctx) return [];
+  function buildActions(message: MessageLike | null | undefined): MessageAction[] {
+    if (!message) return [];
     const actions: MessageAction[] = [];
 
-    // Reply: prepend `nick: ` to the composer. Addressing your own line is
-    // pointless, so self rows skip it (same gate as Ignore).
-    if (!message.self && message.nick) {
-      actions.push({
-        key: 'reply',
-        label: `Reply to ${message.nick}`,
-        icon: 'fa-solid fa-reply',
-        onClick: () => ctx.onReply(message),
-      });
+    // Reply and Ignore both address another user: pointless on your own line,
+    // and the server uses the hostmask for delivery, not ignore filtering.
+    const addressable = !message.self && !!message.nick;
+
+    if (addressable) {
+      actions.push({ key: 'reply', label: `Reply to ${message.nick}`, icon: 'fa-solid fa-reply' });
     }
 
     if (message.text) {
-      actions.push({
-        key: 'copy',
-        label: 'Copy text',
-        icon: 'fa-regular fa-copy',
-        onClick: () => {
-          if (!navigator.clipboard) return;
-          navigator.clipboard.writeText(String(message.text || '')).catch(() => {});
-        },
-      });
+      actions.push({ key: 'copy', label: 'Copy text', icon: 'fa-regular fa-copy' });
     }
 
     // Bookmarks are only meaningful for messages with a stable server id.
@@ -86,23 +75,34 @@ export function useMessageActions(): MessageActionsAPI {
         label: saved ? 'Remove bookmark' : 'Save message',
         icon: saved ? 'fa-solid fa-bookmark' : 'fa-regular fa-bookmark',
         active: saved,
-        onClick: () => bookmarks.toggle(message),
       });
     }
 
-    // Ignoring your own messages doesn't make sense; the server uses the
-    // user's hostmask for delivery, not ignore filtering.
-    if (!message.self && message.nick) {
-      actions.push({
-        key: 'ignore',
-        label: `Ignore ${message.nick}…`,
-        icon: 'fa-solid fa-ban',
-        onClick: () => ctx.onIgnore(message),
-      });
+    if (addressable) {
+      actions.push({ key: 'ignore', label: `Ignore ${message.nick}…`, icon: 'fa-solid fa-ban' });
     }
 
     return actions;
   }
 
-  return { buildActions };
+  function run(key: MessageActionKey, message: MessageLike, ctx: MessageContext): void {
+    switch (key) {
+      case 'reply':
+        ctx.onReply(message);
+        break;
+      case 'copy':
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(String(message.text || '')).catch(() => {});
+        }
+        break;
+      case 'save':
+        bookmarks.toggle(message);
+        break;
+      case 'ignore':
+        ctx.onIgnore(message);
+        break;
+    }
+  }
+
+  return { buildActions, run };
 }

--- a/vue_client/src/composables/useMessageActions.ts
+++ b/vue_client/src/composables/useMessageActions.ts
@@ -1,9 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import type { ContextMenuItem } from './useContextMenu.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
-import { useContextMenu } from './useContextMenu.js';
 
 export interface MessageLike {
   id?: number | null;
@@ -17,47 +15,60 @@ export interface MessageLike {
 
 export interface MessageContext {
   networkId: number;
+  onReply(message: MessageLike): void;
   onIgnore(message: MessageLike): void;
 }
 
-export interface MessageActionsAPI {
-  buildItems(
-    message: MessageLike | null | undefined,
-    ctx: MessageContext | null | undefined,
-  ): ContextMenuItem[];
-  openMenuFor(
-    message: MessageLike | null | undefined,
-    ctx: MessageContext | null | undefined,
-    x: number,
-    y: number,
-  ): void;
-  openMenuFromButton(
-    message: MessageLike | null | undefined,
-    ctx: MessageContext | null | undefined,
-    buttonEl: Element | null,
-  ): void;
+export interface MessageAction {
+  key: 'reply' | 'copy' | 'save' | 'ignore';
+  // Tooltip + accessible label for the icon button.
+  label: string;
+  // Font Awesome classes for the button glyph.
+  icon: string;
+  onClick(): void;
+  // Toggles the "lit" treatment — currently only the bookmark when saved.
+  active?: boolean;
 }
 
-// Shared per-message context menu actions. Right-click, mobile long-press, and
-// the hover three-dots affordance all surface the same items. The caller owns
-// component-local UI for the ignore confirmation (mirrors useMemberActions)
-// and passes it in via `context.onIgnore(message)`.
-//
-// `message` shape: { id, nick, text, self, userhost, network_id|networkId, ... }
-// `context` shape: { networkId, onIgnore(message) }
-export function useMessageActions(): MessageActionsAPI {
-  const bookmarks = useBookmarksStore();
-  const menu = useContextMenu();
-
-  function buildItems(
+export interface MessageActionsAPI {
+  buildActions(
     message: MessageLike | null | undefined,
     ctx: MessageContext | null | undefined,
-  ): ContextMenuItem[] {
+  ): MessageAction[];
+}
+
+// Single source of truth for the per-message actions rendered as the hover
+// action bar in MessageList (issue #117 — replaced the kebab + context menu).
+// The caller owns the component-local UI for the ignore confirmation
+// (mirrors useMemberActions) and the reply hand-off to the composer, passing
+// both in via `context`.
+//
+// `message` shape: { id, nick, text, self, userhost, network_id|networkId, ... }
+// `context` shape: { networkId, onReply(message), onIgnore(message) }
+export function useMessageActions(): MessageActionsAPI {
+  const bookmarks = useBookmarksStore();
+
+  function buildActions(
+    message: MessageLike | null | undefined,
+    ctx: MessageContext | null | undefined,
+  ): MessageAction[] {
     if (!message || !ctx) return [];
-    const items: ContextMenuItem[] = [];
+    const actions: MessageAction[] = [];
+
+    // Reply: prepend `nick: ` to the composer. Addressing your own line is
+    // pointless, so self rows skip it (same gate as Ignore).
+    if (!message.self && message.nick) {
+      actions.push({
+        key: 'reply',
+        label: `Reply to ${message.nick}`,
+        icon: 'fa-solid fa-reply',
+        onClick: () => ctx.onReply(message),
+      });
+    }
 
     if (message.text) {
-      items.push({
+      actions.push({
+        key: 'copy',
         label: 'Copy text',
         icon: 'fa-regular fa-copy',
         onClick: () => {
@@ -67,54 +78,31 @@ export function useMessageActions(): MessageActionsAPI {
       });
     }
 
+    // Bookmarks are only meaningful for messages with a stable server id.
+    if (message.id != null) {
+      const saved = bookmarks.isSaved(message.id);
+      actions.push({
+        key: 'save',
+        label: saved ? 'Remove bookmark' : 'Save message',
+        icon: saved ? 'fa-solid fa-bookmark' : 'fa-regular fa-bookmark',
+        active: saved,
+        onClick: () => bookmarks.toggle(message),
+      });
+    }
+
     // Ignoring your own messages doesn't make sense; the server uses the
     // user's hostmask for delivery, not ignore filtering.
     if (!message.self && message.nick) {
-      items.push({
+      actions.push({
+        key: 'ignore',
         label: `Ignore ${message.nick}…`,
         icon: 'fa-solid fa-ban',
         onClick: () => ctx.onIgnore(message),
       });
     }
 
-    // Bookmarks are only meaningful for messages with a stable server id.
-    // Locally-echoed rows that haven't been persisted yet (rare) get a
-    // disabled placeholder so the menu shape stays predictable.
-    if (message.id != null) {
-      const saved = bookmarks.isSaved(message.id);
-      items.push({ divider: true });
-      items.push({
-        label: saved ? 'Remove bookmark' : 'Save message',
-        icon: saved ? 'fa-solid fa-bookmark' : 'fa-regular fa-bookmark',
-        onClick: () => bookmarks.toggle(message),
-      });
-    }
-
-    return items;
+    return actions;
   }
 
-  function openMenuFor(
-    message: MessageLike | null | undefined,
-    ctx: MessageContext | null | undefined,
-    x: number,
-    y: number,
-  ): void {
-    const items = buildItems(message, ctx);
-    if (items.length === 0) return;
-    menu.open(items, x, y);
-  }
-
-  function openMenuFromButton(
-    message: MessageLike | null | undefined,
-    ctx: MessageContext | null | undefined,
-    buttonEl: Element | null,
-  ): void {
-    if (!buttonEl) return;
-    const items = buildItems(message, ctx);
-    if (items.length === 0) return;
-    const rect = buttonEl.getBoundingClientRect();
-    menu.open(items, rect.left, rect.bottom + 2, buttonEl);
-  }
-
-  return { buildItems, openMenuFor, openMenuFromButton };
+  return { buildActions };
 }


### PR DESCRIPTION
Closes #117.

Replaces the per-message three-dot kebab + context menu with an inline, hover-revealed **action bar**: **reply · copy · save · ignore**.

### Why
With no reactions in IRC, the message action set is small and fixed (~3–5 ever), so the interesting move isn't "kebab → Slack bar with overflow" — it's surfacing the actions inline and dropping the menu round-trip entirely. The bar is more discoverable than a mystery three-dot and shaves a tap off the common path (row → action, instead of row → kebab → menu item).

### Behaviour
- **Reveal** is unchanged from the kebab: `.line:hover` on desktop, and on touch the same iOS sticky-`:hover` first-tap that revealed the dots now reveals the bar — so mobile keeps working with no new gesture. Long-press is still left to the native text-selection callout.
- **Reply** prepends `nick: ` to the composer draft (skipped if it already starts that way) and focuses the input, reusing the history-recall focus/caret dance so iOS raises the keyboard from the originating tap.
- **Copy / Save / Ignore** are unchanged in behaviour; Save lights up when the message is bookmarked. Reply and Ignore are hidden on your own messages.

### Styling
A small floating card matching the toast stack (`--bg` + border + the toast's drop shadow), anchored top-right and floating just above the row so it barely overlaps the top edge without covering the message text.

### Implementation notes
- `useMessageActions` now returns a flat, ordered `MessageAction[]` — the single source of truth for the bar — instead of `ContextMenu` items.
- Reply is routed through `useComposerOverlay`'s existing MessageInput-handler hub (new `onAddress`), so `MessageInput` keeps ownership of the draft text + focus.
- The shared `ContextMenu` primitive is **untouched** and still drives the buffer / member / network kebab menus.
- `MessageList` + `MessageInput` are shared by `DesktopChat` and `MobileChat`, so this lands on both.

### Known edge case
The bar floats above the row, so a message pinned flush to the very top of the scroller (nothing above it) could clip the bar's overhang. In normal scroll positions and below the "— start of history —" notice it's a non-issue; easy to special-case the first row later if it ever bites.

### Verification
`npm run check` (server + client typecheck, oxlint, oxfmt) and the client build all pass. Not run live — please eyeball the bar on desktop + phone before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)