### PR TITLE
Restore vanished nicklist toggle icon (#218)

### DIFF
--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -137,7 +137,9 @@
             :title="showMembers ? 'Hide members' : 'Show members'"
             :aria-label="showMembers ? 'Hide members' : 'Show members'"
             @click="toggleMembers"
-          ></button>
+          >
+            <i class="fa-solid fa-users"></i>
+          </button>
           <span
             v-if="memberCount != null"
             class="member-count"


### PR DESCRIPTION
## Problem

Fixes #218. The clustered-people icon for toggling the nicklist in the channel topic bar vanished in last night's release.

## Cause

In commit `815981b` ("Potential fix for pull request finding", a Copilot-review tweak on the #196 topic-bar work), the edit added the `aria-label` line to the members-toggle button but deleted its `<i class="fa-solid fa-users"></i>` in the same change — leaving an empty, zero-content button that still toggles but renders nothing.

## Fix

Re-add the `fa-solid fa-users` icon inside the button. One-line restore; no behavior change.

Verified with `npm run typecheck:client` and `oxfmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)