### PR TITLE
Mobile buffer header: inline uploads + members, restore label, kebab menu

### DIFF
--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -45,10 +45,11 @@
         </button>
         <!-- The system console has no composer (so no placeholder to carry a
              name) and no buffer actions — it keeps a plain title. Real buffers
-             drop the name (it moves to the input placeholder) and fold every
-             buffer/topic/member/server action into the single cog, since the
-             mobile header is already tight. Search/highlights/saved stay inline
-             as they're global and frequently reached. -->
+             drop the name (it moves to the input placeholder) and fold the
+             remaining buffer/topic/server actions into the single cog, since the
+             mobile header is already tight. Search/highlights/saved/uploads and
+             the channel members toggle stay inline — they're global or
+             frequently reached. -->
         <span v-if="isSystemConsole" class="title">System console</span>
         <span class="spacer"></span>
         <button class="icon" title="Search messages" @click="showSearch = true">
@@ -59,6 +60,18 @@
         </button>
         <button class="icon" title="Saved messages" @click="showBookmarks = true">
           <i class="fa-regular fa-bookmark"></i>
+        </button>
+        <button class="icon" title="Recent uploads" @click="showUploads = true">
+          <i class="fa-solid fa-paperclip"></i>
+        </button>
+        <button
+          v-if="isChannel"
+          class="icon"
+          title="Members"
+          aria-label="Members"
+          @click="screen = 'members'"
+        >
+          <i class="fa-solid fa-users"></i>
         </button>
         <button
           v-if="active"
@@ -214,12 +227,13 @@ const pendingScrollId = ref<number | null>(null);
 const messageInputRef = ref<{ focus: () => void } | null>(null);
 const bufferCogBtn = ref<HTMLElement | null>(null);
 
-// Mobile folds every buffer/topic/member/server action behind one cog to keep
-// the header uncluttered. The menu is assembled per buffer type: view-topic and
-// members are navigation shortcuts unique to this layout, then either the shared
-// buffer-actions menu (pin/notify/profile/note/close) for channels & DMs, or the
-// server controls (browse/connect/edit) for server buffers. Anchored under the
-// cog like the desktop sidebar menu; ContextMenu clamps it to the viewport.
+// Mobile folds the remaining buffer/topic/server actions behind one cog to keep
+// the header uncluttered (Members is an inline header button — see template).
+// The menu is assembled per buffer type: view-topic is a navigation shortcut
+// unique to this layout, then either the shared buffer-actions menu
+// (pin/notify/profile/note/close) for channels & DMs, or the server controls
+// (browse/connect/edit) for server buffers. Anchored under the cog like the
+// desktop sidebar menu; ContextMenu clamps it to the viewport.
 function openBufferActions() {
   const a = active.value;
   const el = bufferCogBtn.value;
@@ -249,15 +263,6 @@ function openBufferActions() {
       { label: 'Edit network', icon: 'fa-solid fa-gear', onClick: editActiveNetwork },
     );
   } else {
-    if (isChannel.value) {
-      items.push({
-        label: 'Members',
-        icon: 'fa-solid fa-users',
-        onClick: () => {
-          screen.value = 'members';
-        },
-      });
-    }
     const bufItems = bufferActions.buildItems(activeBuf.value as BufferLike);
     if (items.length && bufItems.length) items.push({ divider: true });
     items.push(...bufItems);

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -43,14 +43,13 @@
         <button class="icon back" title="Back" @click="goList">
           <i class="fa-solid fa-arrow-left"></i>
         </button>
-        <!-- The system console has no composer (so no placeholder to carry a
-             name) and no buffer actions — it keeps a plain title. Real buffers
-             drop the name (it moves to the input placeholder) and fold the
-             remaining buffer/topic/server actions into the single cog, since the
-             mobile header is already tight. Search/highlights/saved/uploads and
-             the channel members toggle stay inline — they're global or
-             frequently reached. -->
-        <span v-if="isSystemConsole" class="title">System console</span>
+        <!-- The buffer label sits up top again now that the header has room;
+             the system console shows a static "System console" since it has no
+             buffer. The remaining buffer/topic/server actions fold into the
+             kebab menu to keep the tight header uncluttered, while
+             search/highlights/saved/uploads and the channel members toggle stay
+             inline — they're global or frequently reached. -->
+        <span class="title">{{ isSystemConsole ? 'System console' : bufferLabel }}</span>
         <span class="spacer"></span>
         <button class="icon" title="Search messages" @click="showSearch = true">
           <i class="fa-solid fa-magnifying-glass"></i>
@@ -81,7 +80,7 @@
           aria-label="Buffer actions"
           @click="openBufferActions"
         >
-          <i class="fa-solid fa-gear"></i>
+          <i class="fa-solid fa-ellipsis-vertical"></i>
         </button>
       </header>
       <SystemConsole v-if="isSystemConsole" />
@@ -227,12 +226,12 @@ const pendingScrollId = ref<number | null>(null);
 const messageInputRef = ref<{ focus: () => void } | null>(null);
 const bufferCogBtn = ref<HTMLElement | null>(null);
 
-// Mobile folds the remaining buffer/topic/server actions behind one cog to keep
-// the header uncluttered (Members is an inline header button — see template).
-// The menu is assembled per buffer type: view-topic is a navigation shortcut
-// unique to this layout, then either the shared buffer-actions menu
+// Mobile folds the remaining buffer/topic/server actions behind one kebab menu
+// to keep the header uncluttered (Members is an inline header button — see
+// template). The menu is assembled per buffer type: view-topic is a navigation
+// shortcut unique to this layout, then either the shared buffer-actions menu
 // (pin/notify/profile/note/close) for channels & DMs, or the server controls
-// (browse/connect/edit) for server buffers. Anchored under the cog like the
+// (browse/connect/edit) for server buffers. Anchored under the kebab like the
 // desktop sidebar menu; ContextMenu clamps it to the viewport.
 function openBufferActions() {
   const a = active.value;


### PR DESCRIPTION
Tidies up the **mobile** buffer header bar.

## Changes

1. **Recent Uploads (paperclip) now in-buffer.** The uploads icon only ever lived in the channel-list screen header (added in `a276c4a`) — it was never in the in-buffer header. Added inline with search / highlights / saved.
2. **Members toggle back out of the menu.** PR #196 folded the channel members toggle into the cog/context menu; restored it as a standalone inline `fa-users` button (shown on channels) and removed the `Members` item from the menu — matching desktop.
3. **Buffer label back in the top bar.** Now that the header has room, the active buffer's label is shown again (system console keeps its static "System console" title).
4. **Cog → kebab.** The "Buffer actions" button used a gear (`fa-gear`), but it opens a context menu of buffer actions, not settings. Swapped to a kebab (`fa-ellipsis-vertical`), matching the buffer-list and member-list action menus. The genuine Settings / Edit-network gears are untouched.

Comments updated to match. Verified with `npm run typecheck:client`, `oxlint`, and `oxfmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
