### PR TITLE
Exclude ignored senders from message search

### DIFF
--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -354,6 +354,33 @@ describe('searchMessages', () => {
     const hits = searchMessages(user.id, { query: 'banana' });
     expect(hits[0].networkName).toBe('OFTC');
   });
+
+  it('excludes from_ignored senders', () => {
+    const user = createUser('search-ignored');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'search-ignored',
+    });
+    chat(net!.id, '#a', 'alice', 'shared keyword here');
+    insertMessage({
+      networkId: net!.id,
+      target: '#a',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'spammer',
+      text: 'shared keyword here',
+      self: false,
+      fromIgnored: true,
+    });
+
+    // Free-text search skips the ignored row...
+    expect(searchMessages(user.id, { query: 'keyword' }).map((m) => m.nick)).toEqual(['alice']);
+    // ...and so does a structured-only filter (no FTS join).
+    expect(searchMessages(user.id, { target: '#a' }).map((m) => m.nick)).toEqual(['alice']);
+  });
 });
 
 describe('listMessagesAround', () => {

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -395,7 +395,10 @@ function toFtsMatch(text: string): string {
 // join scopes every result to the caller's own networks — this is the
 // access-control boundary, so a missing networkId means "all my networks", not
 // "all networks". Cursor pagination via `before` (a message id); rows ordered
-// newest-first, restricted to chat-shaped types.
+// newest-first, restricted to chat-shaped types. Ignored senders are excluded
+// via the insert-time from_ignored stamp (same as listUserHighlights / the
+// unread counts) so an ignored user stays ignored everywhere, including for
+// non-UI consumers of the search verb that have no client-side ignore filter.
 export function searchMessages(
   userId: number,
   {
@@ -419,7 +422,11 @@ export function searchMessages(
   if (!text && !networkId && !target && !nick) return [];
 
   let from = 'messages m JOIN networks n ON n.id = m.network_id';
-  const where: string[] = ['n.user_id = ?', `m.type IN ${COUNTABLE_TYPES_SQL}`];
+  const where: string[] = [
+    'n.user_id = ?',
+    `m.type IN ${COUNTABLE_TYPES_SQL}`,
+    'm.from_ignored = 0',
+  ];
   const params: (string | number)[] = [userId];
 
   if (text) {

--- a/vue_client/src/components/SearchModal.vue
+++ b/vue_client/src/components/SearchModal.vue
@@ -53,9 +53,10 @@ const emit = defineEmits<{
 const store = useSearchStore();
 const ignores = useIgnoresStore();
 
-// Search runs against the full message history; ignored senders are
-// filtered after results arrive so /unignore restores the rows without
-// re-issuing the query.
+// The server already drops senders ignored when the message arrived (the
+// insert-time from_ignored stamp). This second, live pass also hides anyone
+// ignored *after* those messages were stored, and reactively restores rows on
+// /unignore without re-issuing the query.
 const visibleResults = computed(() =>
   store.results.filter((m) => !ignores.isIgnored(m.networkId, m.nick, m.userhost ?? '')),
 );


### PR DESCRIPTION
## What

`searchMessages()` returned rows from ignored senders, unlike `listUserHighlights()` and the unread/highlight counts (`countNewer`, `countHighlightsNewer`) — all of which already gate on the insert-time `from_ignored` stamp.

The search modal hid this in the UI via a live client-side filter, but the `search_messages` verb is `read`-scope and reachable by agent/API/MCP consumers that have **no** client-side filter. So an ignored user was still visible there. This makes "ignored means ignored everywhere" true server-side.

## Changes

- `server/db/messages.ts` — add `m.from_ignored = 0` to the `searchMessages()` WHERE clause; update the doc comment.
- `server/db/messages.test.ts` — new test covering both the FTS (`query:`) and structured-only (`target:`) paths.
- `vue_client/src/components/SearchModal.vue` — correct the now-stale comment; the client pass is the live/retroactive layer on top of the server pre-filter.

## Note on `/unignore`

`from_ignored` is stamped at insert time (no backfill). Messages received *before* an ignore stay `from_ignored = 0`, so they're still returned and restored on `/unignore` (unchanged). Messages received *while* a mask was active are now hidden server-side permanently — identical to how highlights already behaves.

## Verification

- `messages.test.ts` 28/28 pass
- server + client typecheck clean
- lint clean (2 warnings are pre-existing, unrelated files)

Foundation for #223 (filterable highlights can route through `searchMessages({ matched: true })` and inherit this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)