### PR TITLE
Filterable highlights: from:/in:/on: + free-text (#223)

### DIFF
--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -383,6 +383,60 @@ describe('searchMessages', () => {
   });
 });
 
+describe('searchMessages matched (highlights)', () => {
+  function hl(networkId: number, nick: string, text: string, matched: number | null) {
+    return insertMessage({
+      networkId,
+      target: '#hl',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick,
+      text,
+      self: false,
+      matchedRuleId: matched,
+    });
+  }
+
+  it('returns only matched rows, and all of them with no other filter', () => {
+    const user = createUser('hl-matched');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'hl-matched',
+    })!;
+    hl(net.id, 'alice', 'a highlight', 7);
+    hl(net.id, 'bob', 'not a highlight', null);
+    hl(net.id, 'carol', 'another highlight', 9);
+
+    const hits = searchMessages(user.id, { matched: true });
+    expect(hits.map((m) => m.nick).toSorted()).toEqual(['alice', 'carol']);
+  });
+
+  it('combines matched with free text and from:/in: filters', () => {
+    const user = createUser('hl-matched-filter');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'hl-matched-filter',
+    })!;
+    hl(net.id, 'alice', 'deploy finished', 7);
+    hl(net.id, 'bob', 'deploy finished', 7);
+    hl(net.id, 'alice', 'lunch plans', 7);
+
+    expect(searchMessages(user.id, { matched: true, nick: 'alice' }).map((m) => m.text)).toEqual([
+      'lunch plans',
+      'deploy finished',
+    ]);
+    expect(
+      searchMessages(user.id, { matched: true, query: 'deploy', nick: 'alice' }).map((m) => m.text),
+    ).toEqual(['deploy finished']);
+  });
+});
+
 describe('listMessagesAround', () => {
   it('centers a slice on the anchor with hasMore=false when total fits in halfLimit', () => {
     const user = createUser('around-fits');

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -399,6 +399,11 @@ function toFtsMatch(text: string): string {
 // via the insert-time from_ignored stamp (same as listUserHighlights / the
 // unread counts) so an ignored user stays ignored everywhere, including for
 // non-UI consumers of the search verb that have no client-side ignore filter.
+//
+// `matched: true` restricts to highlight rows (matched_rule_id IS NOT NULL) —
+// this is what powers filterable highlights, which reuse the same from:/in:/on:
+// + free-text machinery as search. Unlike plain search, an all-empty filter set
+// is valid when `matched` is set: it means "all my highlights".
 export function searchMessages(
   userId: number,
   {
@@ -406,6 +411,7 @@ export function searchMessages(
     networkId,
     target,
     nick,
+    matched,
     before,
     limit = 50,
   }: {
@@ -413,13 +419,15 @@ export function searchMessages(
     networkId?: number;
     target?: string;
     nick?: string;
+    matched?: boolean;
     before?: number;
     limit?: number;
   } = {},
 ): MessageEventWithNetwork[] {
   const text = typeof query === 'string' ? query.trim() : '';
-  // Nothing to search on — no free text and no structured filter.
-  if (!text && !networkId && !target && !nick) return [];
+  // Nothing to search on — no free text and no structured filter. With
+  // `matched` the empty case is meaningful ("all my highlights"), so skip it.
+  if (!text && !networkId && !target && !nick && !matched) return [];
 
   let from = 'messages m JOIN networks n ON n.id = m.network_id';
   const where: string[] = [
@@ -428,6 +436,12 @@ export function searchMessages(
     'm.from_ignored = 0',
   ];
   const params: (string | number)[] = [userId];
+
+  // Placed before the FTS join so the partial idx_messages_matched index
+  // (WHERE matched_rule_id IS NOT NULL) is available to the planner.
+  if (matched) {
+    where.push('m.matched_rule_id IS NOT NULL');
+  }
 
   if (text) {
     const match = toFtsMatch(text);

--- a/server/routes/highlights.test.ts
+++ b/server/routes/highlights.test.ts
@@ -20,10 +20,11 @@ let agent: LurkerTestAgent;
 let user: User;
 let net: Network;
 let insertMessage: typeof import('../db/messages.js').insertMessage;
+let createNetwork: typeof import('../db/networks.js').createNetwork;
 
 beforeAll(async () => {
   const { createUser } = await import('../db/users.js');
-  const { createNetwork } = await import('../db/networks.js');
+  ({ createNetwork } = await import('../db/networks.js'));
   ({ insertMessage } = await import('../db/messages.js'));
   const router = (await import('./highlights.js')).default;
 
@@ -117,5 +118,53 @@ describe('GET /api/highlights', () => {
     const ids = res.body.items.map((r: { id: number }) => r.id);
     expect(ids).toContain(visible);
     expect(ids).not.toContain(hidden);
+  });
+
+  it('filters by nick (from:)', async () => {
+    chat('#fromf', 'zara', 'alice ping', 50);
+    chat('#fromf', 'yann', 'alice ping', 50);
+    const res = await agent.get('/api/highlights?nick=ZARA');
+    expect(res.status).toBe(200);
+    expect(res.body.items.map((r: { nick: string }) => r.nick)).toEqual(['zara']);
+  });
+
+  it('filters by target (in:)', async () => {
+    chat('#in-a', 'mara', 'alice ping', 51);
+    chat('#in-b', 'mara', 'alice ping', 51);
+    const res = await agent.get('/api/highlights?target=%23in-a');
+    expect(res.status).toBe(200);
+    expect(res.body.items.map((r: { target: string }) => r.target)).toEqual(['#in-a']);
+  });
+
+  it('filters by free text (q) over the FTS index', async () => {
+    chat('#qf', 'nina', 'needlexyz spotted', 52);
+    chat('#qf', 'nina', 'haystack only here', 52);
+    const res = await agent.get('/api/highlights?q=needlexyz');
+    expect(res.status).toBe(200);
+    expect(res.body.items.map((r: { text: string }) => r.text)).toEqual(['needlexyz spotted']);
+  });
+
+  it('filters by networkId (on:)', async () => {
+    const net2 = createNetwork(user.id, {
+      name: 'oftc',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'alice',
+    })!;
+    insertMessage({
+      networkId: net2.id,
+      target: '#onf',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'pat',
+      text: 'alice ping',
+      self: false,
+      matchedRuleId: 53,
+    });
+    const res = await agent.get(`/api/highlights?networkId=${net2.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.items.every((r: { networkId: number }) => r.networkId === net2.id)).toBe(true);
+    expect(res.body.items).toHaveLength(1);
   });
 });

--- a/server/routes/highlights.ts
+++ b/server/routes/highlights.ts
@@ -4,7 +4,7 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth } from '../middleware/auth.js';
-import { listUserHighlights } from '../db/messages.js';
+import { searchMessages } from '../db/messages.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -12,14 +12,31 @@ router.use(requireAuth);
 const MAX_LIMIT = 200;
 const DEFAULT_LIMIT = 50;
 
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v ? v : undefined;
+}
+
 router.get('/', (req: Request, res: Response) => {
   const rawLimit = Number(req.query.limit);
   const limit =
     Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, MAX_LIMIT) : DEFAULT_LIMIT;
   const rawBefore = Number(req.query.before);
   const before = Number.isFinite(rawBefore) && rawBefore > 0 ? rawBefore : undefined;
+  const rawNetworkId = Number(req.query.networkId);
+  const networkId = Number.isFinite(rawNetworkId) && rawNetworkId > 0 ? rawNetworkId : undefined;
 
-  const items = listUserHighlights(req.user!.id, { before, limit });
+  // Highlights are matched messages; the optional q / nick / target / networkId
+  // params are the same from:/in:/on: + free-text filters search uses, so this
+  // shares searchMessages() (FTS index included) rather than a parallel query.
+  const items = searchMessages(req.user!.id, {
+    matched: true,
+    query: str(req.query.q),
+    nick: str(req.query.nick),
+    target: str(req.query.target),
+    networkId,
+    before,
+    limit,
+  });
   // Cursor for the next page is the id of the oldest row in this page; null
   // when the page didn't fill the limit (there's nothing older).
   const nextBefore = items.length === limit ? items[items.length - 1].id : null;

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -15,6 +15,16 @@
       </button>
     </template>
 
+    <div class="search-row">
+      <input
+        v-model="queryInput"
+        class="filter"
+        type="text"
+        placeholder="filter highlights — from:nick in:#channel on:network"
+        autocomplete="off"
+        spellcheck="false"
+      />
+    </div>
     <p v-if="store.error" class="error inline">{{ store.error }}</p>
     <ul v-if="visibleItems.length" ref="listEl" class="match-list" @scroll="onScroll">
       <HistoryMessageRow
@@ -27,12 +37,13 @@
     </ul>
     <p v-else-if="store.loading" class="empty">Loading…</p>
     <p v-else-if="store.items.length" class="empty">All highlights are from ignored users.</p>
+    <p v-else-if="hasFilter" class="empty">No highlights match your filter.</p>
     <p v-else class="empty">No highlights yet.</p>
   </AppModal>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import AppModal from './AppModal.vue';
 import HistoryMessageRow, { type HistoryMessage } from './HistoryMessageRow.vue';
 import { useSettingsStore } from '../stores/settings.js';
@@ -54,6 +65,33 @@ const visibleItems = computed(() =>
   store.items.filter((m) => !ignores.isIgnored(m.networkId, m.nick, m.userhost ?? '')),
 );
 
+const hasFilter = computed(() => store.query.trim().length > 0);
+
+// If the entire loaded page is from ignored users the scroll container is not
+// rendered, so the user can't trigger pagination themselves — quietly fetch
+// the next page in their stead. Capped so a single very prolific ignored
+// source can't drag the modal into an unbounded fetch loop; reset whenever the
+// filter changes so a fresh result set gets its own budget.
+const AUTO_FILL_MAX_PAGES = 5;
+let autoFillFetched = 0;
+
+// Local mirror of the store's raw filter so we can debounce the reload without
+// debouncing the text field itself. Seeded from the store so a closed-then-
+// reopened modal keeps the active filter.
+const queryInput = ref(store.query);
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+watch(queryInput, (val) => {
+  store.setQuery(val);
+  autoFillFetched = 0; // New filter — let auto-fill work again.
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    store.loadInitial();
+  }, 200);
+});
+onBeforeUnmount(() => {
+  if (debounceTimer) clearTimeout(debounceTimer);
+});
+
 function onScroll(): void {
   const el = listEl.value;
   if (!el) return;
@@ -62,12 +100,6 @@ function onScroll(): void {
   }
 }
 
-// If the entire loaded page is from ignored users the scroll container is not
-// rendered, so the user can't trigger pagination themselves — quietly fetch
-// the next page in their stead. Capped so a single very prolific ignored
-// source can't drag the modal into an unbounded fetch loop.
-const AUTO_FILL_MAX_PAGES = 5;
-let autoFillFetched = 0;
 watch(
   () => [visibleItems.value.length, store.loading, store.hasMore] as const,
   ([visible, loading, hasMore]) => {
@@ -118,6 +150,22 @@ function onJump(m: HistoryMessage): void {
   /* Icon-only button — size the glyph (fa-solid is already weight 900, so
      font-weight here would be a no-op). */
   font-size: var(--icon-md);
+}
+
+.search-row {
+  margin-bottom: var(--space-6);
+}
+.filter {
+  width: 100%;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: var(--space-4) var(--space-5);
+  font: inherit;
+}
+.filter:focus {
+  outline: none;
+  border-color: var(--accent);
 }
 
 .match-list {

--- a/vue_client/src/stores/highlights.ts
+++ b/vue_client/src/stores/highlights.ts
@@ -3,6 +3,8 @@
 
 import { defineStore } from 'pinia';
 import { api } from '../api.js';
+import { useNetworksStore } from './networks.js';
+import { parseSearchQuery } from '../utils/searchQuery.js';
 
 const PAGE_SIZE = 50;
 
@@ -17,44 +19,82 @@ export interface HighlightItem {
   userhost?: string | null;
 }
 
+// Highlights feed. REST-based (the highlights route owns the FTS query). The
+// optional from:/in:/on: + free-text filter reuses the same parser as search;
+// `on:` resolves a network name to its id client-side, mirroring the search
+// store, since the API takes a numeric networkId.
 export const useHighlightsStore = defineStore('highlights', {
   state: () => ({
+    query: '', // Raw filter input, including the from:/in:/on: syntax.
     items: [] as HighlightItem[],
     nextBefore: null as number | null,
     loading: false,
     error: '',
+    // Monotonic token tagged onto each fresh load; a response whose token has
+    // been superseded (the filter changed mid-flight) is dropped. Pagination
+    // reuses the current token so it continues the active filter.
+    token: 0,
   }),
   getters: {
     hasMore: (state) => state.nextBefore != null,
   },
   actions: {
+    setQuery(raw: string) {
+      this.query = raw;
+    },
+    // Build the request URL from the raw filter. `before` continues the current
+    // page; null starts fresh.
+    buildUrl(before: number | null): string {
+      const params = new URLSearchParams();
+      params.set('limit', String(PAGE_SIZE));
+      const parsed = parseSearchQuery(this.query);
+      if (parsed.query) params.set('q', parsed.query);
+      if (parsed.from) params.set('nick', parsed.from);
+      if (parsed.in) params.set('target', parsed.in);
+      if (parsed.on) {
+        const networks = useNetworksStore();
+        const match = networks.networks.find(
+          (n) => n.name.toLowerCase() === parsed.on.toLowerCase(),
+        );
+        if (match) params.set('networkId', String(match.id));
+      }
+      if (before) params.set('before', String(before));
+      return `/api/highlights?${params.toString()}`;
+    },
+    // Fresh load for the current filter — resets the list and pagination.
     async loadInitial() {
-      this.loading = true;
+      const token = (this.token += 1);
+      this.items = [];
+      this.nextBefore = null;
       this.error = '';
+      this.loading = true;
       try {
-        const { items, nextBefore } = await api(`/api/highlights?limit=${PAGE_SIZE}`);
+        const { items, nextBefore } = await api(this.buildUrl(null));
+        if (token !== this.token) return; // Superseded by a newer filter.
         this.items = items || [];
         this.nextBefore = nextBefore ?? null;
       } catch (e: any) {
+        if (token !== this.token) return;
         this.error = e.message || 'failed to load highlights';
       } finally {
-        this.loading = false;
+        if (token === this.token) this.loading = false;
       }
     },
     async loadMore() {
       if (this.loading || this.nextBefore == null) return;
+      const token = this.token;
       this.loading = true;
       this.error = '';
       try {
-        const { items, nextBefore } = await api(
-          `/api/highlights?limit=${PAGE_SIZE}&before=${this.nextBefore}`,
-        );
+        const { items, nextBefore } = await api(this.buildUrl(this.nextBefore));
+        if (token !== this.token) return; // Filter changed while paging.
         this.items = this.items.concat(items || []);
         this.nextBefore = nextBefore ?? null;
       } catch (e: any) {
+        if (token !== this.token) return;
         this.error = e.message || 'failed to load more highlights';
       } finally {
-        this.loading = false;
+        if (token === this.token) this.loading = false;
       }
     },
   },


### PR DESCRIPTION
Closes #223.

> ⚠️ **Stacked on #224** (base is `search-filter-ignored-senders`, not `main`). #223 depends on that PR's `from_ignored` gate in `searchMessages()`. Merge #224 first, then this rebases onto main.

## What

Adds the search bar's `from:` / `in:` / `on:` filters to the highlights view. Highlights are matched messages in the same FTS-indexed `messages` table as search, so rather than a parallel query this routes the highlights endpoint through `searchMessages()` with a new `matched: true` flag.

The issue guessed keyword search wasn't feasible ("the highlights table is likely not set up with that index") — but there's no separate highlights table, so **free-text search comes for free** alongside the structured filters. Included it.

## Server

- `searchMessages()` gains `matched?: boolean` — adds `matched_rule_id IS NOT NULL` and treats an all-empty filter set as valid ("all my highlights"). Placed before the FTS join so the partial `idx_messages_matched` index stays usable.
- `GET /api/highlights` parses `q` / `nick` / `target` / `networkId` and delegates to `searchMessages({ matched: true, ... })`. **Identical response shape** (`rowToEvent` + `networkName`), so nothing changes on the wire. `listUserHighlights()` stays for its other consumer (`bookmarks.ts`).

## Client

- highlights store mirrors the search store: `parseSearchQuery()` on the raw input, resolves `on:network` → `networkId` via the networks store, and carries a token to drop superseded responses when the filter changes mid-typing.
- `HighlightsModal` gets the same debounced (200ms) filter input as `SearchModal`, a "No highlights match your filter." empty state, and resets the ignored-page auto-fill budget on each new filter.

Ignored senders are excluded server-side too (via the `from_ignored` gate from #224), so highlights honor `/ignore` everywhere.

## Verification

- new db-level tests for the `matched` flag + 4 new route tests (`from:` / `in:` / `on:` / free-text)
- full suite **790/790**, server + client typecheck clean, lint + format clean

⚠️ **Not manually UI-tested** — per project policy I don't run the dev server (it autoconnects to live IRC). The filter input / debounce / empty-states want a human eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)