### PR TITLE
Mobile: re-remove buffer name from topic bar, scope search/highlights (#222)

### DIFF
--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -55,9 +55,18 @@ const emit = defineEmits<{
   jump: [payload: { networkId: number; target: string; messageId: number }];
 }>();
 
+// `scope` (set when opened from a buffer's topic bar) runs the highlights feed
+// filtered to this buffer. Unlike search this loads immediately — highlights is
+// a filtered feed, not a type-to-search box, so the channel's highlights should
+// be visible at a glance. The global session is snapshotted and restored on
+// close so the list-bar highlights modal is unaffected.
+const props = defineProps<{ scope?: string | null }>();
+const scoped = !!props.scope;
+
 const settings = useSettingsStore();
 const store = useHighlightsStore();
 const ignores = useIgnoresStore();
+let scopedSnapshot: typeof store.$state | null = null;
 
 const listEl = ref<HTMLUListElement | null>(null);
 
@@ -78,7 +87,7 @@ let autoFillFetched = 0;
 // Local mirror of the store's raw filter so we can debounce the reload without
 // debouncing the text field itself. Seeded from the store so a closed-then-
 // reopened modal keeps the active filter.
-const queryInput = ref(store.query);
+const queryInput = ref(scoped ? `${props.scope} ` : store.query);
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 watch(queryInput, (val) => {
   store.setQuery(val);
@@ -90,6 +99,8 @@ watch(queryInput, (val) => {
 });
 onBeforeUnmount(() => {
   if (debounceTimer) clearTimeout(debounceTimer);
+  // Discard the scoped session, restoring the store for the global modal.
+  if (scoped && scopedSnapshot) store.$patch(scopedSnapshot);
 });
 
 function onScroll(): void {
@@ -121,6 +132,12 @@ async function toggleSound(): Promise<void> {
 }
 
 onMounted(() => {
+  if (scoped) {
+    // Snapshot the global session, then seed the scoped filter before the
+    // initial load so the feed opens showing this buffer's highlights.
+    scopedSnapshot = { ...store.$state };
+    store.setQuery(queryInput.value);
+  }
   store.loadInitial();
 });
 

--- a/vue_client/src/components/SearchModal.vue
+++ b/vue_client/src/components/SearchModal.vue
@@ -50,8 +50,16 @@ const emit = defineEmits<{
   jump: [payload: { networkId: number; target: string; messageId: number }];
 }>();
 
+// When `scope` is set (opened from a buffer's topic bar) the modal runs as an
+// ephemeral, pre-filtered session: it seeds the in:/on: filter, starts from a
+// clean slate, and restores the store on close so the *global* search modal's
+// persisted "where I was" survives untouched.
+const props = defineProps<{ scope?: string | null }>();
+const scoped = !!props.scope;
+
 const store = useSearchStore();
 const ignores = useIgnoresStore();
+let scopedSnapshot: typeof store.$state | null = null;
 
 // The server already drops senders ignored when the message arrived (the
 // insert-time from_ignored stamp). This second, live pass also hides anyone
@@ -69,8 +77,8 @@ const listEl = ref<HTMLUListElement | null>(null);
 const selected = ref(store.selectedIndex);
 
 // Local mirror of the store's raw query so we can debounce dispatch without
-// debouncing the text field itself.
-const queryInput = ref(store.query);
+// debouncing the text field itself. Scoped opens seed the prefilled filter.
+const queryInput = ref(scoped ? `${props.scope} ` : store.query);
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 watch(queryInput, (val) => {
   store.setQuery(val);
@@ -139,9 +147,33 @@ function onScroll() {
 }
 
 onMounted(() => {
+  if (scoped) {
+    // Snapshot the global session, then patch in a clean scoped slate so the
+    // prefilled filter shows the "type to search" prompt rather than the
+    // previous global results bleeding through.
+    scopedSnapshot = { ...store.$state };
+    store.$patch({
+      query: queryInput.value,
+      results: [],
+      hasMore: false,
+      nextBefore: null,
+      loading: false,
+      error: '',
+      searched: false,
+      scrollTop: 0,
+      selectedIndex: 0,
+    });
+  }
   setTimeout(() => {
     inputEl.value?.focus();
-    inputEl.value?.select();
+    if (scoped) {
+      // Cursor after the filter (not select-all) so the first keystroke adds a
+      // search term instead of wiping the scope.
+      const len = inputEl.value?.value.length ?? 0;
+      inputEl.value?.setSelectionRange(len, len);
+    } else {
+      inputEl.value?.select();
+    }
   }, 0);
   // Restore the scroll position after the list has rendered. The cursor was
   // already seeded from the store via the `selected` ref's initial value.
@@ -153,6 +185,12 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   if (debounceTimer) clearTimeout(debounceTimer);
+  if (scoped && scopedSnapshot) {
+    // Discard the scoped session and hand the store back to the global modal
+    // exactly as we found it.
+    store.$patch(scopedSnapshot);
+    return;
+  }
   // Persist DOM-only state back to the store so the next open restores it.
   // The Pinia store already keeps query, results, hasMore, nextBefore, and
   // searched across opens; this rounds out the user-perceived "where I was".

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -131,8 +131,8 @@ import type { EmojiMatch } from '../utils/emojiData.js';
 withDefaults(
   defineProps<{
     // Mobile/petite mode: drops the clock and buffer-name segments entirely
-    // (the buffer name is already in the mobile header, the clock isn't worth
-    // the row), and renders the self identity (nick + channel-prefix + user
+    // (the buffer name is already in the input placeholder, the clock isn't
+    // worth the row), and renders the self identity (nick + channel-prefix + user
     // modes + away) here instead — freeing the input row to be just `>`,
     // textarea, and the paperclip. Also hides lag so the typing/split/upload
     // signals stay legible at phone widths. (The scroll affordances —

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -13,10 +13,10 @@
         </button>
         <span v-if="!connected" class="status off" title="Disconnected">●</span>
         <span class="spacer"></span>
-        <button class="icon" title="Search messages" @click="showSearch = true">
+        <button class="icon" title="Search messages" @click="openSearch(false)">
           <i class="fa-solid fa-magnifying-glass"></i>
         </button>
-        <button class="icon" title="Highlights" @click="showHighlights = true">
+        <button class="icon" title="Highlights" @click="openHighlights(false)">
           <i class="fa-regular fa-bell"></i>
         </button>
         <button class="icon" title="Saved messages" @click="showBookmarks = true">
@@ -43,25 +43,24 @@
         <button class="icon back" title="Back" @click="goList">
           <i class="fa-solid fa-arrow-left"></i>
         </button>
-        <!-- The buffer label sits up top again now that the header has room;
-             the system console shows a static "System console" since it has no
-             buffer. The remaining buffer/topic/server actions fold into the
-             kebab menu to keep the tight header uncluttered, while
-             search/highlights/saved/uploads and the channel members toggle stay
-             inline — they're global or frequently reached. -->
-        <span class="title">{{ isSystemConsole ? 'System console' : bufferLabel }}</span>
+        <!-- Channels and DMs drop the name here — the message input's
+             placeholder carries net/#chan on mobile, so a header copy is just
+             redundant clutter (#222). The server buffer (placeholder is
+             "try /help") and the system console (no input row at all) have no
+             other persistent label, so they keep an explicit title. Otherwise
+             the bar holds only buffer-scoped actions: search & highlights open
+             pre-filtered to this buffer (in:<target> on:<network>), members
+             toggles the roster, the rest folds into the kebab. The *global*
+             search / highlights / saved / uploads live on the list top bar. -->
+        <span v-if="isServerBuffer || isSystemConsole" class="title">{{
+          isSystemConsole ? 'System console' : bufferLabel
+        }}</span>
         <span class="spacer"></span>
-        <button class="icon" title="Search messages" @click="showSearch = true">
+        <button class="icon" title="Search this buffer" @click="openSearch(true)">
           <i class="fa-solid fa-magnifying-glass"></i>
         </button>
-        <button class="icon" title="Highlights" @click="showHighlights = true">
+        <button class="icon" title="Highlights in this buffer" @click="openHighlights(true)">
           <i class="fa-regular fa-bell"></i>
-        </button>
-        <button class="icon" title="Saved messages" @click="showBookmarks = true">
-          <i class="fa-regular fa-bookmark"></i>
-        </button>
-        <button class="icon" title="Recent uploads" @click="showUploads = true">
-          <i class="fa-solid fa-paperclip"></i>
         </button>
         <button
           v-if="isChannel"
@@ -109,6 +108,7 @@
     />
     <HighlightsModal
       v-if="showHighlights"
+      :scope="highlightScope"
       @close="showHighlights = false"
       @jump="onJumpToMessage"
     />
@@ -125,7 +125,12 @@
       @close="channelListModal.close()"
     />
     <RecentUploadsModal v-if="showUploads" @close="showUploads = false" />
-    <SearchModal v-if="showSearch" @close="showSearch = false" @jump="onJumpToMessage" />
+    <SearchModal
+      v-if="showSearch"
+      :scope="searchScope"
+      @close="showSearch = false"
+      @jump="onJumpToMessage"
+    />
     <ImageViewerModal
       v-if="imageModal.isOpen && imageModal.url !== null"
       :url="imageModal.url"
@@ -222,9 +227,37 @@ const showBookmarks = ref(false);
 const showTopic = ref(false);
 const showUploads = ref(false);
 const showSearch = ref(false);
+const searchScope = ref<string | null>(null);
+const highlightScope = ref<string | null>(null);
 const pendingScrollId = ref<number | null>(null);
 const messageInputRef = ref<{ focus: () => void } | null>(null);
 const bufferCogBtn = ref<HTMLElement | null>(null);
+
+// in:/on: filter that scopes search & highlights to the current buffer when
+// they're opened from the topic bar. Null for the server buffer / system
+// console (no per-buffer scope there). The network name is omitted when it
+// contains whitespace — the filter parser splits tokens on spaces, so
+// `on:<name>` couldn't round-trip; `in:<target>` alone still scopes by
+// channel/nick in that case.
+const bufferScope = computed<string | null>(() => {
+  const a = active.value;
+  if (!a || isServerBuffer.value || isSystemConsole.value || !a.target) return null;
+  const netName = (a.network as { name?: string } | null)?.name;
+  const onTok = netName && !/\s/.test(netName) ? ` on:${netName}` : '';
+  return `in:${a.target}${onTok}`;
+});
+
+// Topic-bar buttons pass scoped=true so the modal opens pre-filtered to this
+// buffer; the buffer-list top bar passes false for the global view. Both share
+// one modal instance — the scope ref is what differentiates the two entries.
+function openSearch(scoped: boolean) {
+  searchScope.value = scoped ? bufferScope.value : null;
+  showSearch.value = true;
+}
+function openHighlights(scoped: boolean) {
+  highlightScope.value = scoped ? bufferScope.value : null;
+  showHighlights.value = true;
+}
 
 // Mobile folds the remaining buffer/topic/server actions behind one kebab menu
 // to keep the header uncluttered (Members is an inline header button — see


### PR DESCRIPTION
Closes #222.

## What

Declutters the mobile **topic bar** (the buffer header) and makes its search/highlights buffer-aware.

**Topic bar now: back · search · highlights · members · kebab.**

- **Channel name removed** for channels/DMs — it was duplicating the message-input placeholder (`net/#chan`) and, alongside six icons, got crushed to `#…` on narrow screens. The **server buffer** (placeholder is `try /help`) and the **system console** (no input row at all) have no other persistent label, so they keep an explicit title.
- **Saved messages** and **Recent uploads** removed from the topic bar — both still live on the buffer-list top bar, so nothing becomes unreachable.
- **Search & highlights are now buffer-scoped from the topic bar:** tapping them opens the modal pre-filtered to the current buffer (`in:<target> on:<network>`). The buffer-list top bar keeps the **global** versions. Same icon, different context — not redundant.

## How

- New optional `scope?: string \| null` prop on `SearchModal` and `HighlightsModal`. `MobileChat` builds the filter from the active buffer (`in:#channel`/`in:<nick>`, plus `on:<network>` when the network name has no spaces — the parser splits tokens on whitespace) and passes it from the topic-bar buttons; the list-bar buttons pass nothing.
- Scoping **reuses the existing `from:/in:/on:` filter syntax**, so there are **no server changes**.
- A scoped open runs as an **ephemeral session**: it snapshots the modal's Pinia store, patches in a clean scoped slate, and restores the snapshot on close — so the global modal's persisted "where I was" is untouched.
- **Search** prefills the filter and waits for a term (cursor placed after the filter, not select-all). **Highlights** loads the buffer's feed immediately (it's a filtered feed, not a type-to-search box).

## Verification

UI-only change. `npm run check` (server + client typecheck, oxlint, oxfmt) and `vite build` pass. The two oxlint warnings are pre-existing in untouched files. No component test harness exists in the repo (client tests cover pure `utils/` only), and the filter parser is unchanged, so no new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)