### PR TITLE
Fix "Jump to unread" stalling on large backlogs (#216)

### DIFF
--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1123,8 +1123,13 @@ watch(scrollToUnreadToken, async () => {
     const wantKey = networks.activeKey;
     buffers.loadAround(buf.networkId, buf.target, dividerAfterId);
     // loadAround rolls loadingHistory back to false synchronously if the send
-    // failed (offline) — nothing is in flight, so don't arm the watcher.
-    if (!buf.loadingHistory) return;
+    // failed (offline) — nothing will land to drive the scroll, and there's no
+    // more history to pull, so fall back to centering the top-pinned divider so
+    // the click still has a visible effect.
+    if (!buf.loadingHistory) {
+      scrollDividerIntoView();
+      return;
+    }
     // applyAroundSlice clears loadingHistory when the around response replaces
     // buf.messages; that false transition is our "slice landed" signal (more
     // reliable than messages.length, which can be unchanged when both the live

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1090,19 +1090,60 @@ watch(scrollToBottomToken, async () => {
   scrollToBottom();
 });
 
-// StatusBar's "Jump to unread" click increments scrollToUnreadToken. Center
-// the pinned divider; mark not-stuck so a live message can't yank us back to
-// the tail mid-read. The observer flips unreadSeen once the divider lands in
-// view, which retires the button for the rest of the visit.
-watch(scrollToUnreadToken, async () => {
-  await nextTick();
-  const el = scroller.value;
-  if (!el) return;
-  const target = el.querySelector('.unread-divider');
+// Center the (single) unread divider element, marking not-stuck first so a
+// live message can't yank us back to the tail mid-read. The observer flips
+// unreadSeen once the divider lands in view, retiring the button.
+function scrollDividerIntoView() {
+  const target = scroller.value?.querySelector('.unread-divider');
   if (!target) return;
   stickToBottom.value = false;
   setStuckToBottom(false);
   target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+}
+
+// StatusBar's "Jump to unread" click increments scrollToUnreadToken.
+//
+// The divider only sits at the real read/unread seam when some loaded row is
+// at or below the boundary (dividerAfterId). In a large backlog every loaded
+// row is newer than the boundary, so renderRows pins the divider to the TOP
+// of the slice instead — scrolling to that fiction lands at scrollTop≈0, trips
+// the history pager, and stalls before reaching the seam (issue #216). In that
+// case fetch a slice centered on the boundary first — the same loadAround path
+// jump-to-message uses — then center the real divider once it lands.
+watch(scrollToUnreadToken, async () => {
+  await nextTick();
+  if (!scroller.value) return;
+  const buf = buffer.value;
+  const dividerAfterId = buf?.dividerAfterId || 0;
+  const dividerPinnedToTop =
+    dividerAfterId > 0 && buf != null && buf.oldestId != null && buf.oldestId > dividerAfterId;
+  if (dividerPinnedToTop && buf.hasMoreOlder && !buf.loadingHistory) {
+    stickToBottom.value = false;
+    setStuckToBottom(false);
+    const wantKey = networks.activeKey;
+    buffers.loadAround(buf.networkId, buf.target, dividerAfterId);
+    // loadAround rolls loadingHistory back to false synchronously if the send
+    // failed (offline) — nothing is in flight, so don't arm the watcher.
+    if (!buf.loadingHistory) return;
+    // applyAroundSlice clears loadingHistory when the around response replaces
+    // buf.messages; that false transition is our "slice landed" signal (more
+    // reliable than messages.length, which can be unchanged when both the live
+    // window and the slice sit at MAX_PER_BUFFER).
+    const stop = watch(
+      () => buf.loadingHistory,
+      async (loading) => {
+        if (loading) return;
+        stop();
+        // Bail if the user switched buffers while the slice was in flight —
+        // the scroller now belongs to a different buffer.
+        if (networks.activeKey !== wantKey) return;
+        await nextTick();
+        scrollDividerIntoView();
+      },
+    );
+    return;
+  }
+  scrollDividerIntoView();
 });
 
 // Anything that shrinks MessageList's clientHeight (iOS soft keyboard sliding


### PR DESCRIPTION
## Problem

Closes #216. "Jump to unread" stalls when a channel has more unread messages than the in-memory window holds (~200 on fresh load, capped at `MAX_PER_BUFFER = 500`). The `>999` in the issue title is just the BufferList badge cap — the real trigger is "unread exceeds the loaded window."

**Root cause:** the unread divider is anchored to `dividerAfterId` (the last-read id), but it only *renders* before the first loaded row whose `id > dividerAfterId`. In a large backlog every loaded row is newer than the boundary, so `renderRows` pins the divider to the **top** of the loaded slice rather than at the real read/unread seam. Scrolling that fiction into view lands at `scrollTop≈0`, trips `maybeRequestHistory`, and the prepended page pushes the divider back off-screen — but the one-shot `scrollIntoView` has already finished. Stall.

## Fix

Route the broken case through the same `loadAround` path that **jump-to-message** already uses:

- If some loaded row is at/below the boundary, the divider is at the real seam → keep today's direct `scrollIntoView` (the common, cheap case).
- If the boundary sits above the loaded window (`oldestId > dividerAfterId`) and there's older history (`hasMoreOlder`), `loadAround(dividerAfterId)` fetches a bounded slice centered on the boundary, then we center the now-correctly-placed divider once the slice lands.

Landing is detected via the `loadingHistory` true→false transition (more reliable than `messages.length`, which can be unchanged when both the live window and the slice sit at `MAX_PER_BUFFER`). Guards: offline send-failure bails without arming the watcher; a buffer switch mid-flight bails without scrolling; an evicted boundary (`!hasMoreOlder`) falls back to centering the top-pinned divider rather than fetching an empty around-slice.

No server changes — `mode: 'around'` already existed. The `dividerAfterId === 0` case (brand-new buffer) renders no divider and offers no button, so it can't reach this path.

## Testing

- `npm run typecheck` (client) — clean
- `oxlint` / `oxfmt` — clean
- `npm test` — 790 passed

Client-side scroll behavior; verified by reasoning against the existing `loadAround`/`applyAroundSlice`/detached machinery. No MessageList component-test harness exists, and the underlying `around` mode is already covered by `wsHub.test.ts` / `messages.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)