### PR TITLE
Harden cell DB write path: synchronous=NORMAL + busy_timeout

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -16,6 +16,17 @@ if (!fs.existsSync(dbDir)) fs.mkdirSync(dbDir, { recursive: true });
 
 const db = new Database(dbPath);
 db.pragma('journal_mode = WAL');
+// WAL leaves synchronous at FULL, which fsyncs on every auto-commit write — and
+// better-sqlite3 is synchronous on the main thread, so that fsync blocks the same
+// event loop serving WS fan-out, IRC socket reads, and HTTP. NORMAL is safe under
+// WAL (a power-loss can lose only the last transaction, never corrupt the file)
+// and lifts the fsync off the hot path — the dominant win for a cell absorbing a
+// netsplit's burst of membership-churn inserts, which arrive correlated across
+// every tenant on the same network at once.
+db.pragma('synchronous = NORMAL');
+// Don't let a transient lock (a WAL checkpoint, or any future second connection)
+// surface as an immediate SQLITE_BUSY throw — wait up to 5s for it to clear.
+db.pragma('busy_timeout = 5000');
 db.pragma('foreign_keys = ON');
 
 function migrate() {

--- a/server/db/pragmas.test.ts
+++ b/server/db/pragmas.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// db/index.js reads DATABASE_PATH at module-load time and opens the connection
+// (applying these pragmas) on first import, so point it at an isolated temp DB
+// before any dynamic import touches it.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('connection pragmas', () => {
+  it('opens the database in WAL journal mode', () => {
+    expect(db.pragma('journal_mode', { simple: true })).toBe('wal');
+  });
+
+  it('sets synchronous to NORMAL so writes do not fsync the event loop', () => {
+    // PRAGMA synchronous reads back the numeric level: 0=OFF, 1=NORMAL, 2=FULL.
+    expect(db.pragma('synchronous', { simple: true })).toBe(1);
+  });
+
+  it('sets busy_timeout so a transient lock retries instead of throwing SQLITE_BUSY', () => {
+    expect(db.pragma('busy_timeout', { simple: true })).toBe(5000);
+  });
+
+  it('enforces foreign keys', () => {
+    expect(db.pragma('foreign_keys', { simple: true })).toBe(1);
+  });
+});


### PR DESCRIPTION
Implements the "do first" core of control-plane #41 (cell DB write-path hardening), filed from the per-cell capacity review (beta 7 users → planning for ~100 concurrent/cell).

## What

Two connection pragmas on the single `better-sqlite3` connection in `server/db/index.ts`:

- **`synchronous = NORMAL`** — WAL otherwise leaves this at FULL, fsyncing on every auto-commit insert. Since better-sqlite3 is synchronous on the main thread, that fsync blocks the same event loop serving WS fan-out, IRC socket reads, and HTTP. NORMAL is safe under WAL (a power-loss can lose only the last transaction, never corrupt the file) and lifts fsync off the hot path (~10× write headroom). This is the dominant win for a cell absorbing a **netsplit storm** — hundreds–thousands of QUIT inserts in a burst, correlated across every tenant on the same network.
- **`busy_timeout = 5000`** — cheap insurance: a transient lock (a WAL checkpoint, or any future second connection) waits up to 5s instead of throwing an immediate `SQLITE_BUSY` (the lurker#175 crash class).

Adds `server/db/pragmas.test.ts` asserting all four connection pragmas (`journal_mode=wal`, `synchronous=1`, `busy_timeout=5000`, `foreign_keys=1`) read back as set — the acceptance criterion.

## Note on the issue's premise

#41 cites "the export worker opens a second readonly connection" as a `SQLITE_BUSY` source. That's now **stale**: since lurker#183, the export runs in-process on the shared connection with keyset-paginated reads (`exportJobs.ts:11-23`), so there's a single writer. The pragmas on that one connection cover it; `busy_timeout` stays as forward-looking insurance.

## Deferred

The stretch goal (coalesce a tick's worth of IRC events into one `db.transaction()` so a 1000-QUIT netsplit is one commit) is **not** in this PR — it touches the IRC ingest/publish path (`ircConnection.ts:305`) and is a separate, riskier change. `synchronous=NORMAL` already cuts the per-row fsync cost that makes the burst expensive. Worth a follow-up issue.

## Testing

- `npm run typecheck` — clean
- `npx vitest run server/db/` — 190/190 pass (no regression)
- new `pragmas.test.ts` — 4/4 pass
- lint + format-check clean

Benefits self-host too (consider mirroring to the public OSS roadmap). No data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)