### PR TITLE
Bind IRC egress to a configurable source address (LURKER_IRC_OUTGOING_ADDR)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1,9 +1,32 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { ircLineParser } from 'irc-framework';
-import { computeFallbackNick, formatServerNumeric } from './ircConnection.js';
+import { computeFallbackNick, formatServerNumeric, ircOutgoingAddr } from './ircConnection.js';
+
+describe('ircOutgoingAddr', () => {
+  const original = process.env.LURKER_IRC_OUTGOING_ADDR;
+  afterEach(() => {
+    if (original === undefined) delete process.env.LURKER_IRC_OUTGOING_ADDR;
+    else process.env.LURKER_IRC_OUTGOING_ADDR = original;
+  });
+
+  it('is undefined when the env var is unset', () => {
+    delete process.env.LURKER_IRC_OUTGOING_ADDR;
+    expect(ircOutgoingAddr()).toBeUndefined();
+  });
+
+  it('is undefined for an empty or whitespace-only value', () => {
+    process.env.LURKER_IRC_OUTGOING_ADDR = '   ';
+    expect(ircOutgoingAddr()).toBeUndefined();
+  });
+
+  it('returns the trimmed source address when set', () => {
+    process.env.LURKER_IRC_OUTGOING_ADDR = '  10.18.0.5  ';
+    expect(ircOutgoingAddr()).toBe('10.18.0.5');
+  });
+});
 
 describe('computeFallbackNick', () => {
   it('appends 1..9 in order', () => {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1696,6 +1696,11 @@ export class IrcConnection {
       gecos: this.network.realname || nick,
       password: this.network.server_password || undefined,
       account,
+      // Bind the outbound socket to the cell's configured source IP so every
+      // network this cell serves egresses from one stable address (its Reserved
+      // IP via the DO anchor). undefined off the hosted service → OS picks, as
+      // before. irc-framework reads this as `outgoing_addr` (→ localAddress).
+      outgoing_addr: ircOutgoingAddr(),
       auto_reconnect: true,
       auto_reconnect_max_retries: 0,
       // Request the `chghost` cap so SASL-cloaked vhost changes (Libera et al.)
@@ -1883,6 +1888,19 @@ function isPrefixMode(letter: string): boolean {
 // dance — modern ircds allow long nicks so the legacy 9-char cap is moot, and
 // `bob1` reads more clearly than `bob___`. Returns null once exhausted so the
 // caller can give up and notify the user.
+// The source address the cell binds its outbound IRC sockets to (irc-framework
+// forwards this as the socket's `localAddress` — see its transports/net.js). On
+// a hosted cell this is set to the droplet's DigitalOcean anchor IP, which DO
+// NATs to the cell's stable Reserved IP — so the IP that networks rDNS-resolve
+// and query identd on survives a droplet rebuild (control-plane #47). Left unset
+// on self-host and in dev, where the OS picks the source as before; a
+// whitespace-only value is treated as unset. The app stays cloud-agnostic — it
+// binds whatever address it's handed and never reasons about DO itself.
+export function ircOutgoingAddr(): string | undefined {
+  const addr = (process.env.LURKER_IRC_OUTGOING_ADDR || '').trim();
+  return addr || undefined;
+}
+
 const NICK_FALLBACK_MAX = 9;
 export function computeFallbackNick(
   base: string | undefined | null,

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1882,12 +1882,6 @@ function isPrefixMode(letter: string): boolean {
   return PREFIX_MODES.has(letter);
 }
 
-// Pure helper for the pre-registration nick-fallback ladder. The configured
-// nick is attempt -1 (already tried by `connect()` itself); on each subsequent
-// ERR_NICKNAMEINUSE we ask for index 0..N-1 here. Digits-only, no underscore
-// dance — modern ircds allow long nicks so the legacy 9-char cap is moot, and
-// `bob1` reads more clearly than `bob___`. Returns null once exhausted so the
-// caller can give up and notify the user.
 // The source address the cell binds its outbound IRC sockets to (irc-framework
 // forwards this as the socket's `localAddress` — see its transports/net.js). On
 // a hosted cell this is set to the droplet's DigitalOcean anchor IP, which DO
@@ -1901,6 +1895,12 @@ export function ircOutgoingAddr(): string | undefined {
   return addr || undefined;
 }
 
+// Pure helper for the pre-registration nick-fallback ladder. The configured
+// nick is attempt -1 (already tried by `connect()` itself); on each subsequent
+// ERR_NICKNAMEINUSE we ask for index 0..N-1 here. Digits-only, no underscore
+// dance — modern ircds allow long nicks so the legacy 9-char cap is moot, and
+// `bob1` reads more clearly than `bob___`. Returns null once exhausted so the
+// caller can give up and notify the user.
 const NICK_FALLBACK_MAX = 9;
 export function computeFallbackNick(
   base: string | undefined | null,

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -22,6 +22,10 @@ declare module 'irc-framework' {
     account?: { account: string; password: string };
     auto_reconnect?: boolean;
     auto_reconnect_max_retries?: number;
+    // Source address to bind the outbound socket to (the transport forwards it
+    // as net/tls.connect's `localAddress`). Used to pin a hosted cell's IRC
+    // egress to its stable Reserved IP. Omitted → OS picks the source.
+    outgoing_addr?: string;
     enable_chghost?: boolean;
     enable_setname?: boolean;
     enable_echomessage?: boolean;


### PR DESCRIPTION
Prerequisite for control-plane #47 (stable per-cell public identity), which is the fix for the disaster-recovery / rebuild gap surfaced while planning the #42 cell migration.

## Why

A cell's IRC identity hangs entirely on the **outbound source IP** of its connections — it's the IP the network does the **rDNS** lookup on (`roswell.lurker.chat`) and the one it queries **identd** back on (`:113`). Nothing pinned it, so `client.connect()` let the OS pick the droplet's *primary, ephemeral* IP. A rebuilt/re-provisioned cell therefore comes up on a **new IP** with stale rDNS and an identd query that lands on the wrong address — stranding every reconnecting user until DNS is manually repointed and propagates.

## What

- New exported helper `ircOutgoingAddr()` reads `LURKER_IRC_OUTGOING_ADDR` (trimmed; empty/whitespace → `undefined`).
- Wired into `connect()` as irc-framework's `outgoing_addr`, which the transport forwards to `net.connect`/`tls.connect` as `localAddress` (`irc-framework/src/transports/net.js:137,144`).
- Declared `outgoing_addr` on `ConnectOptions` in the hand-written `server/types/irc-framework.d.ts` (the package ships no types; the option is real at runtime but undeclared upstream).

On a hosted cell this is set to the droplet's **DigitalOcean anchor IP**, which DO NATs to the cell's stable **Reserved IP** — so the cell's IRC identity survives a rebuild. **Unset on self-host / dev → OS picks the source, exactly as today** (the library already read `options.outgoing_addr`, previously always `undefined`, so behavior is unchanged when unset). The app stays cloud-agnostic: it binds whatever source address it's handed and never reasons about DigitalOcean itself.

Benefits self-host too — an operator on a multi-homed box can pin which interface IRC egresses from.

## Testing

- `npm run typecheck` — clean
- `npx vitest run server/services/` — 242/242 pass (3 new `ircOutgoingAddr` cases: unset, whitespace-only, trimmed value)
- lint + format clean

## Not in this PR

The control-plane side (allocate/assign the Reserved IP, discover the anchor IP from DO metadata and set the env in `cell-cloud-init.sh`, set rDNS once) and the **anchor-IP egress spike** to confirm DO NATs outbound correctly — tracked in control-plane #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)