### PR TITLE
Recover from a stale lurker_session: clear both cookies, bounce to sign-in

### DIFF
--- a/server/middleware/auth.test.ts
+++ b/server/middleware/auth.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Router } from 'express';
+import request from 'supertest';
+import type { Express } from 'express';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  type TestDbContext,
+} from '../test-utils/testApp.js';
+
+const ctx: TestDbContext = setupTestDb('auth-mw');
+
+let app: Express;
+let userId: number;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { requireAuth } = await import('./auth.js');
+  userId = createUser('alice').id;
+  const router = Router();
+  router.get('/', requireAuth, (_req, res) => {
+    res.json({ ok: true });
+  });
+  app = createTestApp({ '/protected': router });
+});
+
+afterAll(() => ctx.cleanup());
+
+// clearCookie emits the cookie with an expiry in the past; the value is a signed
+// empty string (getCookieOptions has signed:true), so match on name + past Expires.
+const clears = (setCookie: string[] | undefined, name: string): boolean =>
+  (setCookie ?? []).some((c) => c.startsWith(`${name}=`) && /Expires=Thu, 01 Jan 1970/i.test(c));
+
+describe('requireAuth stale-session recovery', () => {
+  it('lets a valid session through', async () => {
+    const agent = await createAuthedAgent(app, userId);
+    const res = await agent.get('/protected');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('clears BOTH lurker_session and cp_session on a stale (bad-signature) cookie', async () => {
+    // A cookie signed with a different secret — what a rebuilt cell with a fresh
+    // SESSION_SECRET sees from a browser holding the old lurker_session.
+    const res = await request(app)
+      .get('/protected')
+      .set('Cookie', 'lurker_session=s%3Astale.deadbeefbadsignature');
+    expect(res.status).toBe(401);
+    const setCookie = res.headers['set-cookie'] as unknown as string[] | undefined;
+    expect(clears(setCookie, 'lurker_session')).toBe(true);
+    expect(clears(setCookie, 'cp_session')).toBe(true);
+  });
+
+  it('does not clear cookies when no session cookie was sent', async () => {
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(401);
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+});

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -8,6 +8,15 @@ import { findUserById, touchUserLastSeen } from '../db/users.js';
 import type { User } from '../db/users.js';
 
 export const SESSION_COOKIE = 'lurker_session';
+// The control plane's session cookie (mirrors lurker-control-plane's
+// middleware/session.ts CP_SESSION_COOKIE; same cookie options as ours). On a
+// hosted cell a tenant request only reaches us because the reverse proxy
+// accepted cp_session and then injected the lurker_session it minted — so when
+// we can't honor that lurker_session (e.g. the cell's SESSION_SECRET rotated on
+// a rebuild, invalidating the signature), the fix is to clear BOTH cookies and
+// let the client bounce to the sign-in page for a clean re-auth, rather than
+// leave a valid cp_session paired with a dead lurker_session that never recovers.
+export const CP_SESSION_COOKIE = 'cp_session';
 
 export function getCookieOptions(): CookieOptions {
   // Secure is opt-in via COOKIE_SECURE=true. Tying it to NODE_ENV silently
@@ -40,6 +49,26 @@ export function loadSession(req: Request): { session: Session; user: User } | nu
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
   const ctx = loadSession(req);
   if (!ctx) {
+    // If the request carried a lurker_session we can't honor — a stale cookie
+    // whose signature no longer verifies (cell SESSION_SECRET rotated on a
+    // rebuild → it lands in req.cookies, not req.signedCookies) or whose session
+    // row is gone — clear it AND cp_session. A refresh then deletes both dead
+    // cookies and the reverse proxy serves the sign-in page, so the user re-auths
+    // cleanly instead of getting wedged with a good cp_session + dead session.
+    // A request with NO lurker_session never reaches here on a hosted cell (the
+    // proxy mints one when absent), and on standalone there's no cp_session to
+    // clear — so gating the clear on "a session cookie was present" is safe.
+    // Detect that from the RAW Cookie header: cookie-parser drops a
+    // bad-signature signed cookie from both req.cookies and req.signedCookies
+    // (the SESSION_SECRET-rotation case), so neither reflects that one was sent.
+    const hadStaleSession = (req.headers.cookie ?? '')
+      .split(/;\s*/)
+      .some((c) => c.startsWith(`${SESSION_COOKIE}=`));
+    if (hadStaleSession) {
+      const clearOpts = { ...getCookieOptions(), maxAge: undefined };
+      res.clearCookie(SESSION_COOKIE, clearOpts);
+      res.clearCookie(CP_SESSION_COOKIE, clearOpts);
+    }
     res.status(401).json({ error: 'unauthorized' });
     return;
   }

--- a/vue_client/src/api.test.ts
+++ b/vue_client/src/api.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { shouldBounceToLogin } from './api.js';
+
+describe('shouldBounceToLogin', () => {
+  it('bounces to sign-in on a 401 from a normal authed call', () => {
+    expect(shouldBounceToLogin('/api/networks', 401, false)).toBe(true);
+    expect(shouldBounceToLogin('/api/buffers/1', 401, false)).toBe(true);
+  });
+
+  it('does not bounce on non-401 statuses', () => {
+    expect(shouldBounceToLogin('/api/networks', 403, false)).toBe(false);
+    expect(shouldBounceToLogin('/api/networks', 500, false)).toBe(false);
+    expect(shouldBounceToLogin('/api/networks', 200, false)).toBe(false);
+  });
+
+  it('bounces at most once per tab', () => {
+    expect(shouldBounceToLogin('/api/networks', 401, true)).toBe(false);
+  });
+
+  it('ignores auth + control-plane endpoints (they 401 by design before sign-in)', () => {
+    expect(shouldBounceToLogin('/api/auth/me', 401, false)).toBe(false);
+    expect(shouldBounceToLogin('/api/auth/login', 401, false)).toBe(false);
+    expect(shouldBounceToLogin('/_cp/auth/logout', 401, false)).toBe(false);
+  });
+});

--- a/vue_client/src/api.ts
+++ b/vue_client/src/api.ts
@@ -13,6 +13,47 @@ export interface ApiRequestOptions {
   headers?: Record<string, string>;
 }
 
+// One-shot guard so an unrecoverable 401 can't loop the page reload.
+const AUTH_RECOVERY_FLAG = 'lurker:authRecoveryAttempted';
+
+// Pure decision (exported for tests): a 401 from a normal authed call means the
+// session is dead — on a hosted cell the cell has already cleared the stale
+// lurker_session + cp_session, so we send the user back to `/` to sign in again.
+// Skip the auth / control-plane endpoints (they 401 by design before sign-in),
+// and only bounce once per tab so a genuinely-unrecoverable 401 falls through to
+// the app's normal logged-out handling instead of reloading forever.
+export function shouldBounceToLogin(url: string, status: number, alreadyTried: boolean): boolean {
+  if (status !== 401 || alreadyTried) return false;
+  if (url.startsWith('/api/auth/') || url.startsWith('/_cp/')) return false;
+  return true;
+}
+
+function bounceToLoginOnAuthFailure(url: string, status: number): void {
+  let alreadyTried = false;
+  try {
+    alreadyTried = sessionStorage.getItem(AUTH_RECOVERY_FLAG) === '1';
+  } catch {
+    return; // no sessionStorage (private-mode edge) → don't risk a reload loop
+  }
+  if (!shouldBounceToLogin(url, status, alreadyTried)) return;
+  try {
+    sessionStorage.setItem(AUTH_RECOVERY_FLAG, '1');
+  } catch {
+    /* ignore — best effort */
+  }
+  window.location.assign('/');
+}
+
+function clearAuthRecoveryGuard(): void {
+  // A request succeeded → the session works; clear the marker so a later session
+  // loss can recover again.
+  try {
+    sessionStorage.removeItem(AUTH_RECOVERY_FLAG);
+  } catch {
+    /* ignore */
+  }
+}
+
 // The API speaks untyped JSON, so the response type defaults to `any`. Callers
 // that want a checked shape can pass it explicitly: `api<{ user: User }>(url)`.
 export async function api<T = any>(
@@ -39,12 +80,14 @@ export async function api<T = any>(
     }
   }
   if (!res.ok) {
+    bounceToLoginOnAuthFailure(url, res.status);
     const message = (data && data.error) || res.statusText || 'request failed';
     const err = new Error(message) as ApiError;
     err.status = res.status;
     err.data = data;
     throw err;
   }
+  clearAuthRecoveryGuard();
   return data as T;
 }
 
@@ -80,8 +123,10 @@ export function apiMultipart<T = any>(
         }
       }
       if (xhr.status >= 200 && xhr.status < 300) {
+        clearAuthRecoveryGuard();
         resolve(data as T);
       } else {
+        bounceToLoginOnAuthFailure(url, xhr.status);
         const message = (data && data.error) || xhr.statusText || 'upload failed';
         const err = new Error(message) as ApiError;
         err.status = xhr.status;


### PR DESCRIPTION
## Problem

When a hosted cell's `SESSION_SECRET` rotates — e.g. a DR rebuild that couldn't preserve it — every browser still holds a `lurker_session` signed with the **dead** secret. The reverse proxy (`lurker-control-plane` `proxy.ts`) only mints a fresh `lurker_session` when the cookie is **absent**, so it forwards the stale one, the cell 401s, and — with a still-valid `cp_session` and no client-side 401 handling — the user is wedged: authenticated to the proxy, rejected by the cell, no path back.

## Fix

Make a dead session self-clear into a clean re-auth (no clever re-mint, just predictable "log in again"):

- **Cell** (`server/middleware/auth.ts`): on a 401 where a `lurker_session` **was** sent, clear **both** `lurker_session` and `cp_session`. Detection reads the **raw `Cookie` header** — cookie-parser drops a bad-signature *signed* cookie from both `req.cookies` and `req.signedCookies`, so neither reflects that one was sent. `cp_session` uses cookie options identical to ours, so `clearCookie` matches and deletes it.
- **Client** (`vue_client/src/api.ts`): on a 401 from a normal authed call, bounce to `/` **once per tab** (sessionStorage-guarded so an unrecoverable 401 can't loop; `/api/auth/*` and `/_cp/*` excluded since they 401 by design before sign-in). The guard clears on the next successful request. With both cookies cleared by the cell, `/` serves the sign-in page → clean re-login.

So: stale cookie → cell clears both → client lands on sign-in → re-auth. No wedged state.

## Why not transparent re-mint

The proxy *could* re-mint silently (no re-login), but the explicit "clear + sign in again" path is simpler to reason about and operate, and was the chosen behavior.

## Testing

- `npm run typecheck` + `npm run typecheck:client` — clean
- `server/middleware/auth.test.ts` — stale (bad-signature) cookie → 401 **and both cookies cleared**; valid session still 200; no cookie → no clear (3/3)
- `vue_client/src/api.test.ts` — `shouldBounceToLogin` matrix (4/4)
- lint + format clean

## Operational note

The immediate unstick for an already-affected browser (no deploy needed) is to delete the `lurker_session` cookie and reload — the proxy re-mints from the still-valid `cp_session`. This PR makes that automatic. A follow-up (control-plane) will have the CP store each cell's `SESSION_SECRET` so a rebuild preserves sessions and avoids the churn entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)