### PR TITLE
docs: add hosted lurker.chat option to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,7 @@ Lurker runs as an always-on server that stays connected to IRC on your behalf, k
 
 # Installation
 
-## Hosted (no setup)
-
-Don't want to run a server? **[lurker.chat](https://lurker.chat)** is official managed hosting: a private, always-on Lurker with backups, updates, and HTTPS handled for you — **$5/mo**, with a 14-day money-back guarantee.
-
-Prefer to self-host? Everything below is free, forever.
-
-## Install (Docker — Recommended)
+## Install (Docker)
 
 ```bash
 curl -O https://raw.githubusercontent.com/amiantos/lurker/main/docker-compose.yml
@@ -55,6 +49,10 @@ docker compose up -d
 ```
 
 Then open <http://localhost:8015> and create your admin account. Username + password is the default; passkeys are optional. See [SELF_HOSTING.md](docs/SELF_HOSTING.md) for the full guide — reverse proxy + HTTPS, enabling passkeys, push notifications, updating, and backups.
+
+## Lurker.Chat Managed Hosting
+
+Don't want to run a server yourself? **[Lurker.Chat](https://lurker.chat)** is official managed hosting: an always-on Lurker instance with backups, updates, and HTTPS handled for you — **$5/mo**, with a 14-day money-back guarantee.
 
 ## Deploy on DigitalOcean
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Lurker runs as an always-on server that stays connected to IRC on your behalf, k
 
 # Installation
 
+## Hosted (no setup)
+
+Don't want to run a server? **[lurker.chat](https://lurker.chat)** is official managed hosting: a private, always-on Lurker with backups, updates, and HTTPS handled for you — **$5/mo**, with a 14-day money-back guarantee.
+
+Prefer to self-host? Everything below is free, forever.
+
 ## Install (Docker — Recommended)
 
 ```bash


### PR DESCRIPTION
## What

Adds a brief **Hosted (no setup)** subsection as the first option under `# Installation`, pointing at the official managed service ([lurker.chat](https://lurker.chat) — $5/mo, 14-day money-back), with a one-line reassurance that self-hosting stays free forever.

## Why

The README was positioned purely as self-hosted with no mention of the hosted service. Now that the paid service is soft-launched, a tasteful pointer is the standard OSS pattern and a free top-of-funnel — placed where readers are already deciding how to run Lurker, rather than as a pitch at the top.

## Note

Copy/positioning only — no code. Framing keeps the OSS-as-free-tier ethos ("paying to skip the ops," not a different/better product).

🤖 Generated with [Claude Code](https://claude.com/claude-code)