### PR TITLE
feat: per-host outbound IRC connect throttle (#236)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,18 @@ VAPID_SUBJECT=mailto:you@example.com
 # ---------------------------------------------------------------------------
 # LURKER_IDENTD_ENABLED=true
 # LURKER_IDENTD_PORT=113
+
+# ---------------------------------------------------------------------------
+# Outbound connect throttle. On (re)start Lurker auto-connects every user's
+# autoconnect networks; on a busy multi-user instance many land on the SAME IRC
+# network from one IP in the same instant, tripping registration-flood limits.
+# This spaces those bulk (cold-start + un-pause) connects out, keyed per
+# destination host. Defaults are a near no-op for a single-user self-host (the
+# first connect to any host fires at once; only repeats to the same host wait)
+# and protective at cell density. Interactive single-network connects are never
+# throttled. Tune down for a small instance, up to be gentler on a network.
+# ---------------------------------------------------------------------------
+# LURKER_CONNECT_THROTTLE_PER_HOST_MS=2000   # min spacing between same-host connects
+# LURKER_CONNECT_THROTTLE_JITTER_MS=2000     # random extra [0,N) added per host wait
+# LURKER_CONNECT_THROTTLE_GLOBAL_MS=150      # min spacing between ANY two connects
+# LURKER_CONNECT_THROTTLE_DISABLED=true      # bypass entirely (connect with no stagger)

--- a/server/services/connectScheduler.test.ts
+++ b/server/services/connectScheduler.test.ts
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { ConnectScheduler } from './connectScheduler.js';
+
+// A deterministic virtual clock + timer harness. The scheduler is purely
+// timing-driven, so we inject `now`/`setTimer`/`clearTimer` and drive time by
+// hand rather than leaning on real timers (flaky) or vitest fake timers (which
+// the rest of this codebase doesn't use).
+function makeHarness() {
+  interface Pending {
+    fireAt: number;
+    fn: () => void;
+    cancelled: boolean;
+  }
+  let clock = 0;
+  const timers: Pending[] = [];
+
+  const now = () => clock;
+  const setTimer = (fn: () => void, ms: number) => {
+    const p: Pending = { fireAt: clock + Math.max(0, ms), fn, cancelled: false };
+    timers.push(p);
+    return p as unknown as ReturnType<typeof setTimeout>;
+  };
+  const clearTimer = (h: ReturnType<typeof setTimeout>) => {
+    (h as unknown as Pending).cancelled = true;
+  };
+  // Advance virtual time by `ms`, firing every due (non-cancelled) timer in
+  // chronological order. Re-reads the list each step because firing a timer can
+  // synchronously schedule the next one.
+  const advance = (ms: number) => {
+    const target = clock + ms;
+    for (let guard = 0; guard < 100000; guard++) {
+      const due = timers.filter((t) => !t.cancelled).toSorted((a, b) => a.fireAt - b.fireAt)[0];
+      if (!due || due.fireAt > target) break;
+      clock = Math.max(clock, due.fireAt);
+      due.cancelled = true;
+      due.fn();
+    }
+    clock = target;
+  };
+
+  return { now, setTimer, clearTimer, advance };
+}
+
+describe('ConnectScheduler', () => {
+  it('launches the first connect to a host at once, then spaces same-host connects by perHostMs', () => {
+    const h = makeHarness();
+    const launches: number[] = [];
+    const s = new ConnectScheduler({
+      perHostMs: 2000,
+      jitterMs: 0,
+      globalMs: 0,
+      now: h.now,
+      setTimer: h.setTimer,
+      clearTimer: h.clearTimer,
+    });
+
+    for (let i = 0; i < 3; i++) s.schedule('irc.libera.chat', () => launches.push(h.now()));
+
+    h.advance(0);
+    expect(launches).toEqual([0]);
+    h.advance(2000);
+    expect(launches).toEqual([0, 2000]);
+    h.advance(2000);
+    expect(launches).toEqual([0, 2000, 4000]);
+    expect(s.pendingCount()).toBe(0);
+  });
+
+  it('adds jitter on top of the per-host base so a synchronised herd de-syncs', () => {
+    const h = makeHarness();
+    const launches: number[] = [];
+    // random pinned at 0.5 → jitter = floor(0.5 * 2000) = 1000 → spacing 3000.
+    const s = new ConnectScheduler({
+      perHostMs: 2000,
+      jitterMs: 2000,
+      globalMs: 0,
+      random: () => 0.5,
+      now: h.now,
+      setTimer: h.setTimer,
+      clearTimer: h.clearTimer,
+    });
+
+    for (let i = 0; i < 3; i++) s.schedule('irc.example.org', () => launches.push(h.now()));
+
+    h.advance(0);
+    h.advance(3000);
+    h.advance(3000);
+    expect(launches).toEqual([0, 3000, 6000]);
+  });
+
+  it('lets distinct hosts connect right away — only the global floor spaces them, not the per-host gate', () => {
+    const h = makeHarness();
+    const log: Array<[string, number]> = [];
+    const s = new ConnectScheduler({
+      perHostMs: 2000,
+      jitterMs: 0,
+      globalMs: 150,
+      now: h.now,
+      setTimer: h.setTimer,
+      clearTimer: h.clearTimer,
+    });
+
+    s.schedule('host-a', () => log.push(['A1', h.now()]));
+    s.schedule('host-b', () => log.push(['B1', h.now()]));
+    s.schedule('host-a', () => log.push(['A2', h.now()]));
+
+    h.advance(0); // A1
+    h.advance(150); // B1 — held only by the 150ms global floor, NOT host-a's 2s gate
+    h.advance(2000); // A2 — held by host-a's per-host gate
+
+    expect(log).toEqual([
+      ['A1', 0],
+      ['B1', 150],
+      ['A2', 2000],
+    ]);
+  });
+
+  it('drains same-host connects in FIFO arrival order', () => {
+    const h = makeHarness();
+    const order: string[] = [];
+    const s = new ConnectScheduler({
+      perHostMs: 1000,
+      jitterMs: 0,
+      globalMs: 0,
+      now: h.now,
+      setTimer: h.setTimer,
+      clearTimer: h.clearTimer,
+    });
+
+    s.schedule('x', () => order.push('first'));
+    s.schedule('x', () => order.push('second'));
+    s.schedule('x', () => order.push('third'));
+
+    h.advance(0);
+    h.advance(1000);
+    h.advance(1000);
+    expect(order).toEqual(['first', 'second', 'third']);
+  });
+
+  it('keys on the host case-insensitively (same remote, different casing = one bucket)', () => {
+    const h = makeHarness();
+    const launches: number[] = [];
+    const s = new ConnectScheduler({
+      perHostMs: 2000,
+      jitterMs: 0,
+      globalMs: 0,
+      now: h.now,
+      setTimer: h.setTimer,
+      clearTimer: h.clearTimer,
+    });
+
+    s.schedule('IRC.Libera.Chat', () => launches.push(h.now()));
+    s.schedule('irc.libera.chat', () => launches.push(h.now()));
+
+    h.advance(0);
+    expect(launches).toEqual([0]); // second is throttled behind the first
+    h.advance(2000);
+    expect(launches).toEqual([0, 2000]);
+  });
+
+  it('runs inline and synchronously when disabled', () => {
+    const h = makeHarness();
+    let ran = false;
+    const s = new ConnectScheduler({
+      perHostMs: 9999,
+      disabled: true,
+      now: h.now,
+      setTimer: h.setTimer,
+      clearTimer: h.clearTimer,
+    });
+
+    s.schedule('x', () => {
+      ran = true;
+    });
+
+    expect(ran).toBe(true); // no advance needed
+    expect(s.pendingCount()).toBe(0);
+  });
+
+  it('reset() drops queued launches and cancels the pending timer', () => {
+    const h = makeHarness();
+    const launches: number[] = [];
+    const s = new ConnectScheduler({
+      perHostMs: 2000,
+      jitterMs: 0,
+      globalMs: 0,
+      now: h.now,
+      setTimer: h.setTimer,
+      clearTimer: h.clearTimer,
+    });
+
+    s.schedule('x', () => launches.push(h.now()));
+    s.schedule('x', () => launches.push(h.now()));
+    h.advance(0);
+    expect(launches.length).toBe(1);
+    expect(s.pendingCount()).toBe(1);
+
+    s.reset();
+    expect(s.pendingCount()).toBe(0);
+    h.advance(100000);
+    expect(launches.length).toBe(1); // the queued second launch never fired
+  });
+
+  it('does not strand a fresh-host connect behind another host’s far-future gate', () => {
+    const h = makeHarness();
+    const log: Array<[string, number]> = [];
+    const s = new ConnectScheduler({
+      perHostMs: 100000,
+      jitterMs: 0,
+      globalMs: 0,
+      now: h.now,
+      setTimer: h.setTimer,
+      clearTimer: h.clearTimer,
+    });
+
+    // host-a's second connect gets pushed ~100s out after the first launches.
+    s.schedule('host-a', () => log.push(['A1', h.now()]));
+    s.schedule('host-a', () => log.push(['A2', h.now()]));
+    h.advance(0);
+    expect(log).toEqual([['A1', 0]]);
+
+    // A connect to a brand-new host arrives while host-a's gate is far away. It
+    // must launch promptly (its own host is unthrottled) — not wait for the
+    // pending far-future timer.
+    s.schedule('host-b', () => log.push(['B1', h.now()]));
+    h.advance(0);
+    expect(log).toEqual([
+      ['A1', 0],
+      ['B1', 0],
+    ]);
+  });
+
+  it('logs a staggering line once a host is contended (operator visibility)', () => {
+    const h = makeHarness();
+    const logs: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a) => {
+      logs.push(a.map(String).join(' '));
+    });
+    try {
+      const s = new ConnectScheduler({
+        perHostMs: 2000,
+        jitterMs: 0,
+        globalMs: 0,
+        now: h.now,
+        setTimer: h.setTimer,
+        clearTimer: h.clearTimer,
+      });
+      s.schedule('irc.libera.chat', () => {});
+      s.schedule('irc.libera.chat', () => {});
+      expect(logs.some((l) => l.includes('staggering') && l.includes('irc.libera.chat'))).toBe(
+        true,
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/server/services/connectScheduler.ts
+++ b/server/services/connectScheduler.ts
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Cross-connection outbound IRC (re)connect throttle. See issue #236.
+//
+// On a process (re)start the cell auto-connects every user's autoconnect
+// networks in one synchronous burst (ircManager.initAll → startNetwork → a
+// tight loop of conn.connect()). At cell density many of those land on the same
+// IRC network (e.g. Libera) from one IP in the same tick — a burst of dozens of
+// registrations that trips the server's registration-flood / per-IP throttle.
+// That is bad-netizen behaviour, risks K-lines, and (because a connection that
+// is refused before it registers gets NO auto-reconnect from irc-framework)
+// can leave our own users silently disconnected until the next restart.
+// irc-framework's per-connection backoff smooths ONE flapping link, not the
+// herd, so this scheduler sits ABOVE the connections and spaces the cold-start
+// / bulk-resume launches out.
+//
+// Model: a rate limiter, not a concurrency pool. We never await a connect's
+// completion (the socket establishes asynchronously and may never register), so
+// a true in-flight cap would leak slots. Instead we enforce a MINIMUM SPACING
+// between successive launches — per destination host (the axis the remote
+// throttles) plus a gentler global floor (so a 100-network cell doesn't fire
+// 100 TLS handshakes in one tick and spike CPU on a small node). Each per-host
+// wait gets random jitter so a synchronised herd de-synchronises.
+//
+// Defaults are effectively a no-op for a single-user standalone: the first
+// launch to any given host fires immediately, and the global floor only spaces
+// distinct hosts a few hundred ms apart. Only the 2nd+ launch to the SAME host
+// within the window actually waits — which is exactly the cell-density case
+// this protects.
+//
+// In-process and stateless across restarts by design: a restart is precisely
+// when the throttle matters, so re-running cold-start from an empty scheduler
+// is correct. No persistence, no worker threads.
+
+export interface ConnectSchedulerOptions {
+  // Minimum spacing between two launches to the SAME destination host.
+  perHostMs?: number;
+  // Random extra wait in [0, jitterMs) added to each per-host gate, so a herd
+  // that arrived together doesn't reconverge on the same launch instants.
+  jitterMs?: number;
+  // Minimum spacing between ANY two launches regardless of host — caps the
+  // TLS-handshake burst a small node sees on a fleet-wide cold start.
+  globalMs?: number;
+  // Bypass entirely: every task runs inline, synchronously, on schedule().
+  disabled?: boolean;
+  // Injectable clock + timer hooks (tests drive these deterministically).
+  now?: () => number;
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+  // Injectable jitter source in [0, 1) (tests pin it; production uses random).
+  random?: () => number;
+}
+
+interface Task {
+  hostKey: string;
+  run: () => void;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function envFlag(name: string): boolean {
+  return /^(1|true|yes|on)$/i.test((process.env[name] || '').trim());
+}
+
+export class ConnectScheduler {
+  private readonly perHostMs: number;
+  private readonly jitterMs: number;
+  private readonly globalMs: number;
+  private readonly disabled: boolean;
+  private readonly now: () => number;
+  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void;
+  private readonly random: () => number;
+
+  private readonly queue: Task[] = [];
+  // Earliest timestamp a launch to this host is allowed (last launch + gate).
+  private readonly hostNextAt = new Map<string, number>();
+  // Earliest timestamp ANY launch is allowed (last launch + global floor).
+  private globalNextAt = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(opts: ConnectSchedulerOptions = {}) {
+    this.perHostMs = opts.perHostMs ?? 0;
+    this.jitterMs = opts.jitterMs ?? 0;
+    this.globalMs = opts.globalMs ?? 0;
+    this.disabled = opts.disabled ?? false;
+    this.now = opts.now ?? (() => Date.now());
+    this.setTimer = opts.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = opts.clearTimer ?? ((h) => clearTimeout(h));
+    this.random = opts.random ?? (() => Math.random());
+  }
+
+  // Build the singleton from env. Gentle defaults: 2s per-host base + up to 2s
+  // jitter (so 2–4s between same-host connects), 150ms global floor.
+  static fromEnv(): ConnectScheduler {
+    return new ConnectScheduler({
+      perHostMs: envInt('LURKER_CONNECT_THROTTLE_PER_HOST_MS', 2000),
+      jitterMs: envInt('LURKER_CONNECT_THROTTLE_JITTER_MS', 2000),
+      globalMs: envInt('LURKER_CONNECT_THROTTLE_GLOBAL_MS', 150),
+      disabled: envFlag('LURKER_CONNECT_THROTTLE_DISABLED'),
+    });
+  }
+
+  // Enqueue a connect launch keyed by destination host. The task itself owns
+  // any revalidation (the connection may be torn down before its slot comes up)
+  // — the scheduler only governs WHEN it runs, never WHETHER it still should.
+  schedule(host: string, run: () => void): void {
+    if (this.disabled) {
+      run();
+      return;
+    }
+    const hostKey = (host || '').trim().toLowerCase();
+    const pendingForHost = this.queue.reduce((n, t) => (t.hostKey === hostKey ? n + 1 : n), 0);
+    this.queue.push({ hostKey, run });
+    if (pendingForHost > 0) {
+      // At least one connect to this host is already waiting, so this one gets
+      // spaced out behind it — surface the herd size so an operator can see the
+      // throttle working on a dense restart ("staggering N connects to Libera").
+      console.log(
+        `[connect-scheduler] staggering outbound connects to ${hostKey || '(unknown)'} — ` +
+          `${pendingForHost + 1} queued`,
+      );
+    }
+    this.schedulePump();
+  }
+
+  pendingCount(): number {
+    return this.queue.length;
+  }
+
+  // Drop everything pending and cancel the timer. Called on shutdown (queued
+  // launches would otherwise fire against torn-down connections) and by tests.
+  reset(): void {
+    this.queue.length = 0;
+    this.hostNextAt.clear();
+    this.globalNextAt = 0;
+    if (this.timer != null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+  }
+
+  // (Re)arm the single pump timer for the soonest moment any queued task can
+  // launch. Always recomputes from scratch (clearing any pending timer) so a
+  // newly-scheduled connect to a fresh host isn't stranded behind an unrelated
+  // host's far-future gate — e.g. a resume that lands mid-drain of an earlier
+  // batch. The clear/re-arm cost is one timer swap per schedule(), negligible.
+  private schedulePump(): void {
+    if (this.timer != null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+    if (this.queue.length === 0) return;
+    const now = this.now();
+    let soonest = Infinity;
+    for (const task of this.queue) {
+      const at = Math.max(this.globalNextAt, this.hostNextAt.get(task.hostKey) ?? 0);
+      if (at < soonest) soonest = at;
+      if (soonest <= now) break;
+    }
+    const delay = Math.max(0, soonest - now);
+    this.timer = this.setTimer(() => this.pump(), delay);
+  }
+
+  private pump(): void {
+    this.timer = null;
+    if (this.queue.length === 0) return;
+    const now = this.now();
+    // Pick the FIFO-earliest task whose host AND the global floor are ready.
+    // Scanning in arrival order keeps same-host launches in order and is fair
+    // across users (one user's 20 networks don't jump ahead of another's).
+    let pickIdx = -1;
+    for (let i = 0; i < this.queue.length; i++) {
+      const at = Math.max(this.globalNextAt, this.hostNextAt.get(this.queue[i].hostKey) ?? 0);
+      if (at <= now) {
+        pickIdx = i;
+        break;
+      }
+    }
+    if (pickIdx >= 0) {
+      const [task] = this.queue.splice(pickIdx, 1);
+      this.launch(task, now);
+    }
+    // Re-arm for the next eligible task (a launch just pushed both gates
+    // forward, so the next pump naturally honours the global floor).
+    this.schedulePump();
+  }
+
+  private launch(task: Task, now: number): void {
+    const jitter = this.jitterMs > 0 ? Math.floor(this.random() * this.jitterMs) : 0;
+    this.hostNextAt.set(task.hostKey, now + this.perHostMs + jitter);
+    this.globalNextAt = now + this.globalMs;
+    try {
+      task.run();
+    } catch (err) {
+      console.error('[connect-scheduler] launch task threw', err);
+    }
+  }
+}
+
+// Process-wide singleton used by ircManager. Tests construct their own
+// instances with injected clocks/config rather than poking this one.
+const connectScheduler = ConnectScheduler.fromEnv();
+export default connectScheduler;

--- a/server/services/connectScheduler.ts
+++ b/server/services/connectScheduler.ts
@@ -118,13 +118,15 @@ export class ConnectScheduler {
     const hostKey = (host || '').trim().toLowerCase();
     const pendingForHost = this.queue.reduce((n, t) => (t.hostKey === hostKey ? n + 1 : n), 0);
     this.queue.push({ hostKey, run });
-    if (pendingForHost > 0) {
-      // At least one connect to this host is already waiting, so this one gets
-      // spaced out behind it — surface the herd size so an operator can see the
-      // throttle working on a dense restart ("staggering N connects to Libera").
+    if (pendingForHost === 1) {
+      // Log ONCE, the moment this host first becomes contended (its 2nd queued
+      // connect) — not per excess connect, which would spam O(N) lines on a
+      // dense restart and drown out other operational logs. The per-connection
+      // "Starting connection" lines (spaced out as they launch) carry the drain
+      // detail; this is just the "throttle engaged for this host" marker.
       console.log(
-        `[connect-scheduler] staggering outbound connects to ${hostKey || '(unknown)'} — ` +
-          `${pendingForHost + 1} queued`,
+        `[connect-scheduler] staggering outbound connects to ${hostKey || '(unknown)'} ` +
+          `to avoid a registration flood`,
       );
     }
     this.schedulePump();

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { setupTestDb } from '../test-utils/testApp.js';
 
 // The startNetwork gate is the linchpin of the pause feature: a paused account
@@ -11,17 +11,26 @@ import { setupTestDb } from '../test-utils/testApp.js';
 const ctx = setupTestDb('services-ircmanager');
 
 let ircManager: typeof import('./ircManager.js').default;
+let connectScheduler: typeof import('./connectScheduler.js').default;
+let systemLog: typeof import('./systemLog.js').default;
 let createUser: typeof import('../db/users.js').createUser;
 let setUserPaused: typeof import('../db/users.js').setUserPaused;
 let createNetwork: typeof import('../db/networks.js').createNetwork;
 
 beforeAll(async () => {
   ircManager = (await import('./ircManager.js')).default;
+  connectScheduler = (await import('./connectScheduler.js')).default;
+  systemLog = (await import('./systemLog.js')).default;
   ({ createUser, setUserPaused } = await import('../db/users.js'));
   ({ createNetwork } = await import('../db/networks.js'));
 });
 
 afterAll(() => ctx.cleanup());
+
+// Any deferrable startNetwork leaves a launch queued in the process-wide
+// scheduler (and a pending timer). Drain it between tests so a staggered
+// launch never fires against a torn-down connection in a later test.
+afterEach(() => connectScheduler.reset());
 
 describe('ircManager pause linchpin', () => {
   it('startNetwork refuses a paused user and creates no connection', () => {
@@ -83,5 +92,63 @@ describe('ircManager.snapshotForUser offline networks', () => {
     expect(snap).toHaveLength(1);
     expect(snap[0].networkId).toBe(net.id);
     expect(snap[0].state).toBe('disconnected');
+  });
+});
+
+describe('ircManager deferrable connect (issue #236 throttle seam)', () => {
+  function makeAutoconnectNetwork(handle: string) {
+    const user = createUser(handle);
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.invalid',
+      port: 6697,
+      tls: true,
+      nick: 'x',
+      autoconnect: true,
+    });
+    if (!net) throw new Error('createNetwork returned undefined');
+    return { user, net };
+  }
+
+  it('deferrable startNetwork enqueues the connect instead of opening a socket synchronously', () => {
+    const { user, net } = makeAutoconnectNetwork('defer-enqueue');
+
+    const before = connectScheduler.pendingCount();
+    const conn = ircManager.startNetwork(user.id, net.id, { deferrable: true });
+
+    // The connection object exists and is registered in the manager, but the
+    // socket-opening launch is queued in the scheduler — not run inline. (The
+    // afterEach reset() cancels the pending timer, so no socket ever opens.)
+    expect(conn).not.toBeNull();
+    expect(ircManager.getConnection(user.id, net.id)).toBe(conn);
+    expect(connectScheduler.pendingCount()).toBe(before + 1);
+
+    // Cancel the queued 0ms launch synchronously, before the timer macrotask can
+    // fire — so this test never opens a real socket to irc.example.invalid.
+    connectScheduler.reset();
+    expect(connectScheduler.pendingCount()).toBe(0);
+  });
+
+  it('a queued launch is skipped when its connection was disposed before its slot fired', async () => {
+    const { user, net } = makeAutoconnectNetwork('defer-disposed');
+
+    const conn = ircManager.startNetwork(user.id, net.id, { deferrable: true });
+    expect(conn).not.toBeNull();
+
+    // Tear the connection down while it still sits in the scheduler queue. The
+    // default singleton fires the first per-host launch on a 0ms timer, so we
+    // dispose first, then let that timer run.
+    ircManager.disposeNetwork(user.id, net.id);
+    expect(conn!.disposed).toBe(true);
+    expect(ircManager.getConnection(user.id, net.id)).toBeNull();
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    // The launch guard short-circuited: the queue drained without ever logging
+    // a "Starting connection" line (which only the connect path emits) and
+    // nothing is left pending.
+    expect(connectScheduler.pendingCount()).toBe(0);
+    const lines = systemLog.getRecent(user.id);
+    expect(lines.some((l) => /Starting connection/.test(l.text))).toBe(false);
   });
 });

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -32,6 +32,17 @@ afterAll(() => ctx.cleanup());
 // launch never fires against a torn-down connection in a later test.
 afterEach(() => connectScheduler.reset());
 
+// Poll until a condition holds, bounded by a timeout — for awaiting a scheduler
+// timer to fire without betting on a fixed real-time delay (a 0ms timer can
+// slip well past a hard-coded sleep under CI load).
+async function waitUntil(pred: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitUntil: condition not met in time');
+    await new Promise((resolve) => setTimeout(resolve, 2));
+  }
+}
+
 describe('ircManager pause linchpin', () => {
   it('startNetwork refuses a paused user and creates no connection', () => {
     const user = createUser('irc-paused');
@@ -142,12 +153,13 @@ describe('ircManager deferrable connect (issue #236 throttle seam)', () => {
     expect(conn!.disposed).toBe(true);
     expect(ircManager.getConnection(user.id, net.id)).toBeNull();
 
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Let the scheduler's queued 0ms launch fire — pump() splices the task out
+    // of the queue and runs it, so the count returning to 0 means the launch
+    // ran (and its guard short-circuited).
+    await waitUntil(() => connectScheduler.pendingCount() === 0);
 
-    // The launch guard short-circuited: the queue drained without ever logging
-    // a "Starting connection" line (which only the connect path emits) and
-    // nothing is left pending.
-    expect(connectScheduler.pendingCount()).toBe(0);
+    // The launch guard short-circuited: it ran without ever logging a "Starting
+    // connection" line (which only the connect path emits).
     const lines = systemLog.getRecent(user.id);
     expect(lines.some((l) => /Starting connection/.test(l.text))).toBe(false);
   });

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -4,6 +4,7 @@
 import { EventEmitter } from 'events';
 import { IrcConnection } from './ircConnection.js';
 import * as systemLog from './systemLog.js';
+import connectScheduler from './connectScheduler.js';
 import {
   listNetworksForUser,
   getNetwork,
@@ -82,8 +83,13 @@ class IrcManager extends EventEmitter {
   }
 
   initForUser(userId: number): void {
+    // Bulk path — cold-start autoconnect (via initAll) and un-pause resume. The
+    // herd of connects this fans out is exactly what issue #236 throttles, so
+    // route it through the per-host scheduler. Interactive single-network
+    // connect/reconnect routes call startNetwork directly (deferrable omitted)
+    // and stay immediate.
     for (const network of listNetworksForUser(userId)) {
-      if (network.autoconnect) this.startNetwork(userId, network.id);
+      if (network.autoconnect) this.startNetwork(userId, network.id, { deferrable: true });
     }
   }
 
@@ -95,7 +101,11 @@ class IrcManager extends EventEmitter {
     for (const id of userIds) this.initForUser(id);
   }
 
-  startNetwork(userId: number, networkId: number): IrcConnection | null {
+  startNetwork(
+    userId: number,
+    networkId: number,
+    opts: { deferrable?: boolean } = {},
+  ): IrcConnection | null {
     // Paused accounts never hold a live IRC connection. This single gate is the
     // linchpin of the pause feature: it covers boot-time autoconnect
     // (initForUser → initAll), the explicit connect/reconnect routes, and
@@ -113,18 +123,36 @@ class IrcManager extends EventEmitter {
       onEvent: (event) => this.emit('event', event),
     });
     this.connectionsForUser(userId).set(networkId, conn);
-    systemLog.log({
-      userId,
-      scope: `net:${network.name}`,
-      text: `Starting connection to ${network.host}:${network.port}${network.tls ? ' (TLS)' : ''}`,
-    });
     // Seed self-presence from the per-user truth before the IRC handshake. The
     // 'registered' handler in IrcConnection re-asserts AWAY off of this state,
-    // so it must be in place before connect() resolves the socket.
+    // so it must be in place before connect() resolves the socket. Safe to set
+    // now even when the actual connect() is deferred — it only mutates
+    // in-memory state and publishes (no AWAY emitted while disconnected).
     conn.applyAwayState(awayStateFromRow(getUserAwayState(userId) as AwayStateRow | null));
-    conn.connect();
 
     const connRef = conn;
+    // Open the socket. Logged here (not at enqueue) so the "Starting connection"
+    // line lands when the connect actually fires, and revalidated because a
+    // deferred launch may have sat in the scheduler queue while the connection
+    // was paused/suspended, disposed, stopped, or replaced by restartNetwork —
+    // in every one of those cases the user's map no longer points at this exact
+    // object, so we bail instead of opening an orphan socket.
+    const launch = (): void => {
+      if (this.getConnection(userId, networkId) !== connRef || connRef.disposed) return;
+      systemLog.log({
+        userId,
+        scope: `net:${network.name}`,
+        text: `Starting connection to ${network.host}:${network.port}${network.tls ? ' (TLS)' : ''}`,
+      });
+      connRef.connect();
+    };
+    if (opts.deferrable) {
+      // Stagger bulk (re)connects per destination host so a fleet-wide restart
+      // doesn't flood one IRC network from our IP. See connectScheduler / #236.
+      connectScheduler.schedule(network.host, launch);
+    } else {
+      launch();
+    }
     conn.client.on('registered', () => {
       const names = listChannels(networkId)
         .filter((c) => c.joined)
@@ -401,6 +429,9 @@ class IrcManager extends EventEmitter {
   }
 
   shutdown(): void {
+    // Drop any queued (not-yet-fired) connect launches first — otherwise a
+    // staggered launch could fire against a connection we're about to tear down.
+    connectScheduler.reset();
     for (const userMap of this.byUser.values()) {
       for (const conn of userMap.values()) {
         try {


### PR DESCRIPTION
Closes #236.

## Problem

On a process (re)start the cell auto-connects every user's autoconnect networks in one synchronous burst (`ircManager.initAll` → `startNetwork` loop, `conn.connect()` with no cross-user stagger). At cell density many of those land on the **same** IRC network (e.g. Libera) from one IP in the same tick — a burst of dozens of registrations that trips the server's registration-flood / per-IP throttle. That's bad-netizen behaviour, risks K-lines, and (because irc-framework gives a connection that's refused *before* registering **no** auto-reconnect) can leave our own users silently disconnected until the next restart. Per-connection backoff smooths one flapping link, not the herd.

## Approach

A cross-connection scheduler that sits **above** the connections and spaces the bulk (re)connect launches out — a queue, not per-connection backoff.

- **`server/services/connectScheduler.ts`** — a **rate-limit** model, not a concurrency pool (we never await a connect's completion, so an in-flight cap would leak slots). Enforces a minimum spacing **per destination host** (the axis the remote throttles) plus a gentler **global floor** (so a fleet-wide cold start doesn't fire 100 TLS handshakes in one tick and spike a small node's CPU). Each per-host wait gets random jitter so a synchronised herd de-syncs. Injectable clock/timers for deterministic tests; env-configured singleton; in-process and stateless (a restart is exactly when it's needed).
- **`server/services/ircManager.ts`** — `startNetwork` gains `{ deferrable }`. **Only `initForUser` defers**, which covers both `initAll` cold-start **and** `resumeUser` (un-pause / bulk resume). The socket open is wrapped in a `launch` closure that **revalidates** before connecting — a queued launch may have been paused, disposed, stopped, or replaced by `restartNetwork` while it waited (confirmed `disconnect()`/`dispose()` are safe on a never-connected conn). `shutdown()` drains the queue.
- **Interactive single-network connect/reconnect routes stay immediate** — they call `startNetwork` directly (no `deferrable`), so a user clicking "connect" never queues behind the herd.

## Scope notes

- Applies identically to **hosted cells and standalone self-hosts** — which is why it lives here in lurker, split out of control-plane B12.
- **Defaults are a near no-op for a single-user standalone** (first connect to any host is immediate; only repeats to the same host wait) and protective at cell density. Tunable via `LURKER_CONNECT_THROTTLE_*` (documented in `.env.example`): per-host `2000ms` + up to `2000ms` jitter, global floor `150ms`, plus `LURKER_CONNECT_THROTTLE_DISABLED`.
- **v1 limitation (documented, not a blocker):** FIFO arrival order, not per-user round-robin. Fair at scale (bounded queue, no starvation); the only soft spot is one user with many networks on the *same* host briefly queuing ahead of others — the issue marked round-robin minor.
- Governs the cold-start/restart path. irc-framework's own 1–6s reconnect jitter still handles the server-side-netsplit reconnect herd; the out-of-scope operator drain/staged-resume stays in control-plane B12.

## Tests

- `connectScheduler.test.ts` — deterministic fake-clock unit tests: per-host spacing, jitter bounds, global floor, distinct-host immediacy, FIFO order, case-insensitive host keying, disabled bypass, `reset()`, a regression test for a fresh-host connect not being stranded behind another host's far-future gate, and the staggering log.
- `ircManager.test.ts` — the deferrable seam: a deferrable `startNetwork` enqueues instead of opening a socket synchronously, and a queued launch whose connection was disposed before its slot is skipped (no "Starting connection" line).

Full suite green (`npm run check` + 811 existing + new tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)