### PR TITLE
Fix #186: connect on network create regardless of autoconnect

### DIFF
--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -125,6 +125,17 @@ describe('POST /api/networks', () => {
     expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(true);
   });
 
+  it('500s and does not connect if createNetwork returns undefined', async () => {
+    const networksDb = await import('../db/networks.js');
+    const spy = vi.spyOn(networksDb, 'createNetwork').mockReturnValueOnce(undefined);
+    fakeManager.reset();
+    const res = await makeNet(aliceAgent, { name: 'doomed-create' });
+    expect(res.status).toBe(500);
+    // A failed creation must not leave a dangling connection attempt behind.
+    expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(false);
+    spy.mockRestore();
+  });
+
   it('upserts default_channel into the channels list', async () => {
     const created = await makeNet(aliceAgent, { name: 'with-default', default_channel: '#dev' });
     expect(

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -109,16 +109,20 @@ describe('POST /api/networks', () => {
     expect(res.status).toBe(400);
   });
 
-  it('starts the connection when autoconnect is true', async () => {
+  // Creating a network is the explicit "Save & connect" action, so it connects
+  // now whether or not autoconnect is set. autoconnect only governs automatic
+  // connection at cold-start / un-pause resume, not this initial setup.
+  it('starts the connection on create when autoconnect is true', async () => {
     const res = await makeNet(aliceAgent, { autoconnect: true, name: 'autoconn' });
     expect(res.status).toBe(201);
     expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(true);
   });
 
-  it('does NOT start the connection when autoconnect is false', async () => {
+  it('still starts the connection on create when autoconnect is false (#186)', async () => {
     fakeManager.reset();
-    await makeNet(aliceAgent, { autoconnect: false, name: 'no-autoconn' });
-    expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(false);
+    const res = await makeNet(aliceAgent, { autoconnect: false, name: 'no-autoconn' });
+    expect(res.status).toBe(201);
+    expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(true);
   });
 
   it('upserts default_channel into the channels list', async () => {

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -129,11 +129,15 @@ describe('POST /api/networks', () => {
     const networksDb = await import('../db/networks.js');
     const spy = vi.spyOn(networksDb, 'createNetwork').mockReturnValueOnce(undefined);
     fakeManager.reset();
-    const res = await makeNet(aliceAgent, { name: 'doomed-create' });
-    expect(res.status).toBe(500);
-    // A failed creation must not leave a dangling connection attempt behind.
-    expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(false);
-    spy.mockRestore();
+    try {
+      const res = await makeNet(aliceAgent, { name: 'doomed-create' });
+      expect(res.status).toBe(500);
+      // A failed creation must not leave a dangling connection attempt behind.
+      expect(fakeManager.calls.some(([m]) => m === 'startNetwork')).toBe(false);
+    } finally {
+      // Restore in finally so a thrown assertion can't leak the spy into later tests.
+      spy.mockRestore();
+    }
   });
 
   it('upserts default_channel into the channels list', async () => {

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -77,9 +77,18 @@ router.post('/', (req: Request, res: Response) => {
     sasl_password,
     connect_commands,
   });
+  if (!network) {
+    res.status(500).json({ error: 'failed to create network' });
+    return;
+  }
   const channel = (default_channel || '').trim();
-  if (channel) upsertChannel(network!.id, channel, true);
-  if (network?.autoconnect) ircManager.startNetwork(req.user!.id, network.id);
+  if (channel) upsertChannel(network.id, channel, true);
+  // Creating a network is an explicit "Save & connect" action, so connect now
+  // regardless of `autoconnect`. The `autoconnect` flag governs only whether a
+  // network is connected automatically at cold-start (connectScheduler /
+  // ircManager.initAll) and on un-pause resume — not whether this initial,
+  // user-initiated setup connects.
+  ircManager.startNetwork(req.user!.id, network.id);
   res.status(201).json({ network: networkPayload(network) });
 });
 


### PR DESCRIPTION
Closes #186.

## The bug

Setting up a brand-new server with **"Reconnect automatically" unchecked** saved the network but never connected — even though the only button on the create form is **"Save & connect"**. The label was a lie in that path.

## Root cause

`POST /api/networks` only started the connection when `autoconnect` was truthy:

```ts
if (network?.autoconnect) ircManager.startNetwork(req.user!.id, network.id);
```

But `autoconnect` is the **future automatic-reconnection** gate — it's what `connectScheduler` checks on cold start and what `ircManager` checks after a drop. It was being overloaded to also gate the one-time, user-initiated connect that "Save & connect" promises.

## Fix

Decouple the two. Creating a network is an explicit action, so always connect now; let `autoconnect` decide only what happens on later restarts/drops:

```ts
if (network) ircManager.startNetwork(req.user!.id, network.id);
```

This matches the create form, which offers no "save without connecting" option — only "Save & connect" / "Cancel".

## Tests

Updated the route test that previously asserted the buggy behavior (`does NOT start the connection when autoconnect is false` → now asserts it **does** start on create). Full suite green (812 tests), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)