### PR TITLE
Fix #137: return to buffer list when closing the active buffer on mobile

### DIFF
--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -358,7 +358,7 @@ function closeNetworkForm() {
 watch(activeKey, (next) => {
   if (next && (screen.value === 'list' || screen.value === 'members')) {
     screen.value = 'buffer';
-  } else if (!next && screen.value !== 'list') {
+  } else if (next === null && screen.value !== 'list') {
     // The active buffer went away (closed it, or its network was removed) while
     // we were viewing it — activeKey only nulls in those "no buffer" cases, so
     // fall back to the list instead of stranding the user on an empty buffer or

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -358,6 +358,13 @@ function closeNetworkForm() {
 watch(activeKey, (next) => {
   if (next && (screen.value === 'list' || screen.value === 'members')) {
     screen.value = 'buffer';
+  } else if (!next && screen.value !== 'list') {
+    // The active buffer went away (closed it, or its network was removed) while
+    // we were viewing it — activeKey only nulls in those "no buffer" cases, so
+    // fall back to the list instead of stranding the user on an empty buffer/
+    // members screen (#137). Buffer-to-buffer switches set activeKey directly
+    // (no null transition), so this never flickers mid-switch.
+    screen.value = 'list';
   }
 });
 

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -361,7 +361,7 @@ watch(activeKey, (next) => {
   } else if (!next && screen.value !== 'list') {
     // The active buffer went away (closed it, or its network was removed) while
     // we were viewing it — activeKey only nulls in those "no buffer" cases, so
-    // fall back to the list instead of stranding the user on an empty buffer/
+    // fall back to the list instead of stranding the user on an empty buffer or
     // members screen (#137). Buffer-to-buffer switches set activeKey directly
     // (no null transition), so this never flickers mid-switch.
     screen.value = 'list';


### PR DESCRIPTION
Closes #137.

## The bug

On mobile, closing the buffer you're currently viewing leaves you on an empty buffer screen instead of taking you back to the buffer list.

## Root cause

The mobile shell (`MobileChat.vue`) stacks screens `list → buffer → members`, driven by a watcher on `activeKey`:

```ts
watch(activeKey, (next) => {
  if (next && (screen.value === 'list' || screen.value === 'members')) {
    screen.value = 'buffer';
  }
});
```

It only handled `activeKey` becoming **truthy** (advance to the buffer screen). When you close the active buffer, the `buffer-closed` socket handler nulls `activeKey` (`useSocket.ts:396`) — but `screen` stays `'buffer'`, so you're parked on a buffer view with no buffer → empty screen.

## Fix

Add the retreat case: when `activeKey` clears while we're past the list, drop back to the list.

```ts
} else if (!next && screen.value !== 'list') {
  screen.value = 'list';
}
```

This is safe because `activeKey` only goes null in genuine "no active buffer" cases — closing the active buffer (`useSocket.ts:396`) or removing its network (`networks.ts:110`). Buffer-to-buffer switches set `activeKey` directly (`networks.ts:133`) with no null transition, so it never flickers to the list mid-switch. (Audited every `activeKey` assignment to confirm.)

## Testing

Typecheck (`vue-tsc`) + lint clean. The client has no component/view test harness (only utility unit tests), so there's no existing place to assert view navigation without standing up `@vue/test-utils` — disproportionate for a 3-line watcher branch, so this isn't covered by an automated test.

**Manual verify** (mobile / narrow viewport): open a channel → open its context menu → Close → you should land on the buffer list, not an empty buffer screen. Also covers the DM-close and network-remove paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)