### PR TITLE
Add per-channel "Mute" for the buffer list

### DIFF
--- a/server/db/channelNotify.test.ts
+++ b/server/db/channelNotify.test.ts
@@ -12,14 +12,21 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 let createUser: typeof import('./users.js').createUser;
 let createNetwork: typeof import('./networks.js').createNetwork;
 let getChannelNotifyAlways: typeof import('./channelNotify.js').getChannelNotifyAlways;
+let getChannelMuted: typeof import('./channelNotify.js').getChannelMuted;
 let listChannelNotifyForUser: typeof import('./channelNotify.js').listChannelNotifyForUser;
 let setChannelNotifyAlways: typeof import('./channelNotify.js').setChannelNotifyAlways;
+let setChannelMuted: typeof import('./channelNotify.js').setChannelMuted;
 
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
-  ({ getChannelNotifyAlways, listChannelNotifyForUser, setChannelNotifyAlways } =
-    await import('./channelNotify.js'));
+  ({
+    getChannelNotifyAlways,
+    getChannelMuted,
+    listChannelNotifyForUser,
+    setChannelNotifyAlways,
+    setChannelMuted,
+  } = await import('./channelNotify.js'));
 });
 
 afterAll(() => {
@@ -66,7 +73,35 @@ describe('channelNotify', () => {
     setChannelNotifyAlways(u.id, a!.id, '#one', true);
     setChannelNotifyAlways(u.id, b!.id, '#two', true);
     const byNetwork = listChannelNotifyForUser(u.id);
-    expect(byNetwork.get(a!.id)).toEqual({ '#one': { notifyAlways: true } });
-    expect(byNetwork.get(b!.id)).toEqual({ '#two': { notifyAlways: true } });
+    expect(byNetwork.get(a!.id)).toEqual({ '#one': { notifyAlways: true, muted: false } });
+    expect(byNetwork.get(b!.id)).toEqual({ '#two': { notifyAlways: true, muted: false } });
+  });
+
+  it('records and reads back a per-channel muted flag', () => {
+    const u = createUser('cn-erin');
+    const net = mkNetwork(u.id, 'libera');
+    setChannelMuted(u.id, net!.id, '#radio', true);
+    expect(getChannelMuted(u.id, net!.id, '#radio')).toBe(true);
+    expect(getChannelNotifyAlways(u.id, net!.id, '#radio')).toBe(false);
+  });
+
+  it('keeps the row alive while either flag is set, deletes only when both clear', () => {
+    const u = createUser('cn-frank');
+    const net = mkNetwork(u.id, 'libera');
+    // Both flags on the same channel — orthogonal, so both must persist.
+    setChannelNotifyAlways(u.id, net!.id, '#mix', true);
+    setChannelMuted(u.id, net!.id, '#mix', true);
+    expect(listChannelNotifyForUser(u.id).get(net!.id)).toEqual({
+      '#mix': { notifyAlways: true, muted: true },
+    });
+    // Clearing one leaves the row (the other flag still holds it).
+    setChannelNotifyAlways(u.id, net!.id, '#mix', false);
+    expect(getChannelMuted(u.id, net!.id, '#mix')).toBe(true);
+    expect(listChannelNotifyForUser(u.id).get(net!.id)).toEqual({
+      '#mix': { notifyAlways: false, muted: true },
+    });
+    // Clearing the last flag drops the row entirely.
+    setChannelMuted(u.id, net!.id, '#mix', false);
+    expect(listChannelNotifyForUser(u.id).size).toBe(0);
   });
 });

--- a/server/db/channelNotify.ts
+++ b/server/db/channelNotify.ts
@@ -9,36 +9,44 @@ export interface ChannelNotifySetting {
   network_id: number;
   target: string;
   notify_always: number;
+  muted: number;
   updated_at: string;
 }
 
-/** Per-target notify settings shape returned to callers. */
+/** Per-target settings shape returned to callers. */
 export interface ChannelNotifyShape {
   notifyAlways: boolean;
+  muted: boolean;
 }
 
-// Per-(user, network, channel) notification overrides. Only the
-// `notify_always` flag is exposed today: when set, every message in the
-// channel is treated like a notification trigger for push/toast purposes,
-// without lighting the channel up as a visual highlight. Absent rows mean
-// all flags are 0 (default off).
+// Per-(user, network, channel) overrides. Two independent flags live here:
+//   notify_always — treat every message in the channel like a notification
+//                   trigger for push/toast purposes (no visual highlight).
+//   muted         — buffer-list display only: suppress the plain-unread signal
+//                   (count + row color + off-screen unread arrow). Highlights
+//                   and notifications are untouched.
+// The flags are orthogonal, so a row persists as long as EITHER is set; the
+// row is deleted only when both fall back to 0 (absent row = all flags off).
 
 const getStmt = db.prepare(`
-  SELECT notify_always FROM channel_notify_settings
+  SELECT notify_always, muted FROM channel_notify_settings
   WHERE user_id = ? AND network_id = ? AND target = ?
 `);
 
 const listForUserStmt = db.prepare(`
-  SELECT network_id AS networkId, target, notify_always AS notifyAlways
+  SELECT network_id AS networkId, target,
+         notify_always AS notifyAlways, muted AS muted
   FROM channel_notify_settings
   WHERE user_id = ?
 `);
 
 const upsertStmt = db.prepare(`
-  INSERT INTO channel_notify_settings (user_id, network_id, target, notify_always, updated_at)
-  VALUES (?, ?, ?, ?, datetime('now'))
+  INSERT INTO channel_notify_settings (user_id, network_id, target, notify_always, muted, updated_at)
+  VALUES (?, ?, ?, ?, ?, datetime('now'))
   ON CONFLICT(user_id, network_id, target)
-  DO UPDATE SET notify_always = excluded.notify_always, updated_at = excluded.updated_at
+  DO UPDATE SET notify_always = excluded.notify_always,
+                muted = excluded.muted,
+                updated_at = excluded.updated_at
 `);
 
 const deleteStmt = db.prepare(`
@@ -46,13 +54,57 @@ const deleteStmt = db.prepare(`
   WHERE user_id = ? AND network_id = ? AND target = ?
 `);
 
-export function getChannelNotifyAlways(userId: number, networkId: number, target: string): boolean {
-  const row = getStmt.get(userId, networkId, target) as { notify_always: number } | undefined;
-  return !!(row && row.notify_always);
+/** Current flags for a channel as 0/1 ints (both 0 when no row exists). */
+function currentFlags(
+  userId: number,
+  networkId: number,
+  target: string,
+): { notifyAlways: number; muted: number } {
+  const row = getStmt.get(userId, networkId, target) as
+    | { notify_always: number; muted: number }
+    | undefined;
+  return {
+    notifyAlways: row && row.notify_always ? 1 : 0,
+    muted: row && row.muted ? 1 : 0,
+  };
 }
 
-// Map<networkId, { [target]: { notifyAlways: boolean } }> snapshot for the
-// whole user, shaped to drop straight into the client's channelNotify store.
+// Write the resulting flag pair: upsert while either flag is set, delete the
+// row outright once both are 0 so we never leave all-default rows behind.
+function write(
+  userId: number,
+  networkId: number,
+  target: string,
+  notifyAlways: number,
+  muted: number,
+): void {
+  if (notifyAlways || muted) {
+    upsertStmt.run(userId, networkId, target, notifyAlways, muted);
+  } else {
+    deleteStmt.run(userId, networkId, target);
+  }
+}
+
+export function getChannelNotifyAlways(userId: number, networkId: number, target: string): boolean {
+  return !!currentFlags(userId, networkId, target).notifyAlways;
+}
+
+export function getChannelMuted(userId: number, networkId: number, target: string): boolean {
+  return !!currentFlags(userId, networkId, target).muted;
+}
+
+/** Both flags for a channel — used by the WS layer to broadcast full state. */
+export function getChannelFlags(
+  userId: number,
+  networkId: number,
+  target: string,
+): ChannelNotifyShape {
+  const f = currentFlags(userId, networkId, target);
+  return { notifyAlways: !!f.notifyAlways, muted: !!f.muted };
+}
+
+// Map<networkId, { [target]: { notifyAlways, muted } }> snapshot for the whole
+// user, shaped to drop straight into the client's channelNotify store.
 export function listChannelNotifyForUser(
   userId: number,
 ): Map<number, Record<string, ChannelNotifyShape>> {
@@ -61,11 +113,13 @@ export function listChannelNotifyForUser(
     networkId: number;
     target: string;
     notifyAlways: number;
+    muted: number;
   }>) {
     if (!byNetwork.has(row.networkId)) byNetwork.set(row.networkId, {});
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     byNetwork.get(row.networkId)![row.target] = {
       notifyAlways: !!row.notifyAlways,
+      muted: !!row.muted,
     };
   }
   return byNetwork;
@@ -77,13 +131,16 @@ export function setChannelNotifyAlways(
   target: string,
   notifyAlways: boolean,
 ): void {
-  if (notifyAlways) {
-    upsertStmt.run(userId, networkId, target, 1);
-  } else {
-    // Row deleted rather than set to 0 — absence is the default, so we
-    // don't leave dead rows sitting in the table. If a future column gets
-    // added (e.g. muted), this branch needs to revisit: a "muted but not
-    // always-notify" row would still need to exist.
-    deleteStmt.run(userId, networkId, target);
-  }
+  const cur = currentFlags(userId, networkId, target);
+  write(userId, networkId, target, notifyAlways ? 1 : 0, cur.muted);
+}
+
+export function setChannelMuted(
+  userId: number,
+  networkId: number,
+  target: string,
+  muted: boolean,
+): void {
+  const cur = currentFlags(userId, networkId, target);
+  write(userId, networkId, target, cur.notifyAlways, muted ? 1 : 0);
 }

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -292,7 +292,7 @@ export const EXPORT_TABLES = Object.freeze({
     scope: 'user_id',
     section: 'data',
     fkRekey: { user_id: 'users', network_id: 'networks' },
-    columns: ['user_id', 'network_id', 'target', 'notify_always', 'updated_at'],
+    columns: ['user_id', 'network_id', 'target', 'notify_always', 'muted', 'updated_at'],
   },
 
   user_drafts: {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -524,6 +524,13 @@ if (columnExists('peer_presence_state', 'offline_datetime')) {
 // marker. Nullable; only meaningful when state='away'.
 ensureColumn('peer_presence_state', 'away_message', 'TEXT');
 
+// Per-channel "mute" for the buffer list: suppresses the plain-unread signal
+// (count + row color + off-screen unread arrow) for this channel without
+// touching highlights or notifications. Display-only — the server stores and
+// syncs it but never acts on it. Sits in channel_notify_settings alongside
+// notify_always; a row now persists if EITHER flag is set (see channelNotify.ts).
+ensureColumn('channel_notify_settings', 'muted', 'INTEGER NOT NULL DEFAULT 0');
+
 ensureColumn('messages', 'extra', 'TEXT');
 // nick!user@host of the sender, captured at ingest so client-side hostmask
 // ignore filters can match incoming and persisted messages. NULL for system

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -54,7 +54,12 @@ import {
 } from '../db/pinnedBuffers.js';
 import { setNicklistCollapsed } from '../db/nicklistCollapsed.js';
 import { addBookmark, removeBookmark, listBookmarkIdsForUser } from '../db/bookmarks.js';
-import { getChannelNotifyAlways, setChannelNotifyAlways } from '../db/channelNotify.js';
+import {
+  getChannelNotifyAlways,
+  setChannelNotifyAlways,
+  setChannelMuted,
+  getChannelFlags,
+} from '../db/channelNotify.js';
 import { getUserAwayState } from '../db/userAwayState.js';
 import { upsertChannel, ownsNetwork, listNetworksForUser } from '../db/networks.js';
 import * as chanlistDb from '../db/chanlist.js';
@@ -1352,13 +1357,29 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // Always-notify is a channel-level concept. DMs are blanket-controlled
         // by notifications.dm.enabled; server pseudo-buffers can't carry it.
         if (!networkId || !target.startsWith('#')) break;
-        const notifyAlways = !!msg.notifyAlways;
-        setChannelNotifyAlways(userId, networkId, target, notifyAlways);
+        setChannelNotifyAlways(userId, networkId, target, !!msg.notifyAlways);
+        // Broadcast the full flag pair (notifyAlways + muted) so the muted flag
+        // isn't clobbered when only notify_always changed, and vice versa.
         fanOut(userId, {
           kind: 'channel-notify-changed',
           networkId,
           target,
-          notifyAlways,
+          ...getChannelFlags(userId, networkId, target),
+        });
+        break;
+      }
+      case 'set-channel-muted': {
+        const networkId = Number(msg.networkId);
+        const target = typeof msg.target === 'string' ? msg.target : '';
+        // Mute is a buffer-list display concern and channel-only — DMs always
+        // want their unread shown, server pseudo-buffers can't carry it.
+        if (!networkId || !target.startsWith('#')) break;
+        setChannelMuted(userId, networkId, target, !!msg.muted);
+        fanOut(userId, {
+          kind: 'channel-notify-changed',
+          networkId,
+          target,
+          ...getChannelFlags(userId, networkId, target),
         });
         break;
       }

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -99,8 +99,8 @@
                 :title="`${buf.highlighted} highlight${buf.highlighted === 1 ? '' : 's'}`"
                 >●</span
               >
-              <span v-if="countFor(buf.unread, buf.highlighted) > 0" class="badge">{{
-                unreadLabel(countFor(buf.unread, buf.highlighted))
+              <span v-if="displayCount(buf) > 0" class="badge">{{
+                unreadLabel(displayCount(buf))
               }}</span>
               <button
                 v-if="!isServerBuffer(buf) && !hasUnreadIndicator(buf)"
@@ -147,8 +147,8 @@
               :title="`${buf.highlighted} highlight${buf.highlighted === 1 ? '' : 's'}`"
               >●</span
             >
-            <span v-if="countFor(buf.unread, buf.highlighted) > 0" class="badge">{{
-              unreadLabel(countFor(buf.unread, buf.highlighted))
+            <span v-if="displayCount(buf) > 0" class="badge">{{
+              unreadLabel(displayCount(buf))
             }}</span>
             <button
               v-if="!isServerBuffer(buf) && !hasUnreadIndicator(buf)"
@@ -205,6 +205,7 @@ import { useNetworksStore, type Network, type PeerPresenceEntry } from '../store
 import { useBuffersStore, type Buffer } from '../stores/buffers.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { usePinsStore } from '../stores/pins.js';
+import { useChannelNotifyStore } from '../stores/channelNotify.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useBufferActions } from '../composables/useBufferActions.js';
 import { useNetworkActions } from '../composables/useNetworkActions.js';
@@ -217,6 +218,7 @@ const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const drafts = useDraftStore();
 const pins = usePinsStore();
+const channelNotify = useChannelNotifyStore();
 const settings = useSettingsStore();
 const bufferActions = useBufferActions();
 const networkActions = useNetworkActions();
@@ -240,15 +242,30 @@ function countFor(unread: number, highlights: number): number {
   return 0;
 }
 
+// A muted channel drops the plain-unread signal from the buffer list: a "full"
+// count downgrades to highlights-only so ordinary traffic stops incrementing
+// the badge, and the `unread` row class (color + bold + off-screen arrow) is
+// withheld below. Highlights pass through untouched — they still color the row
+// and show the ● per the global display mode, which is the whole point of
+// muting a busy-but-followed room. Mute is channel-only; DMs/server never muted.
+function isChannelMuted(buf: Buffer | null): boolean {
+  return !!buf && buf.target.startsWith('#') && channelNotify.muted(buf.networkId, buf.target);
+}
+function displayCount(buf: Buffer): number {
+  const mode =
+    isChannelMuted(buf) && unreadDisplay.value === 'full' ? 'highlights' : unreadDisplay.value;
+  if (mode === 'full') return buf.unread;
+  if (mode === 'highlights') return buf.highlighted;
+  return 0;
+}
+
 // Hover-revealed kebab lives in the same right-edge slot as the unread/
 // highlight badges. When the row has unread state, the badge wins — the
 // kebab stays hidden so it doesn't overlay the indicator the user is
 // scanning for. Right-click on the row still opens the same action menu.
 function hasUnreadIndicator(buf: Buffer | null): boolean {
   if (!buf) return false;
-  return (
-    (buf.highlighted > 0 && showHighlightBadge.value) || countFor(buf.unread, buf.highlighted) > 0
-  );
+  return (buf.highlighted > 0 && showHighlightBadge.value) || displayCount(buf) > 0;
 }
 
 // Per-network local mirror of the pinned buffer list, kept as concrete buffer
@@ -375,7 +392,10 @@ function onRowActionsClick(e: MouseEvent, buf: Buffer): void {
 function rowClasses(buf: Buffer, networkId: number): Record<string, boolean> {
   return {
     active: isActive(networkId, buf.target),
-    unread: buf.unread > 0,
+    // Muted channels withhold the plain-unread cue (color/bold/edge arrow all
+    // key off this class). `highlighted` is left untouched so mentions still
+    // light the row up in the highlight color.
+    unread: buf.unread > 0 && !isChannelMuted(buf),
     highlighted: buf.highlighted > 0,
     'not-joined': isUnjoined(buf, networkId),
     'peer-away': isPeerAway(buf),

--- a/vue_client/src/composables/useBufferActions.ts
+++ b/vue_client/src/composables/useBufferActions.ts
@@ -66,6 +66,24 @@ export function useBufferActions(): BufferActionsAPI {
               onClick: () => channelNotify.setNotifyAlways(buf.networkId, buf.target, true),
             },
       );
+      // Mute hides the unread count + row color for ordinary traffic, leaving
+      // highlights (and notifications) intact — for busy rooms you want to stay
+      // in but not have nagging at you. Icon mirrors the always-notify pattern:
+      // solid bell-slash = muted, regular bell-slash = not.
+      const isMuted = channelNotify.muted(buf.networkId, buf.target);
+      items.push(
+        isMuted
+          ? {
+              label: 'Unmute channel',
+              icon: 'fa-solid fa-bell-slash',
+              onClick: () => channelNotify.setMuted(buf.networkId, buf.target, false),
+            }
+          : {
+              label: 'Mute channel',
+              icon: 'fa-regular fa-bell-slash',
+              onClick: () => channelNotify.setMuted(buf.networkId, buf.target, true),
+            },
+      );
     } else {
       // DM target is the peer's nick — open the profile/note actions directly.
       // Channels can't carry a per-nick action from this menu (which nick?),

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -446,7 +446,10 @@ function handleMessage(raw: string): void {
   }
   if (payload.kind === 'channel-notify-changed') {
     const channelNotify = useChannelNotifyStore();
-    channelNotify.applyChange(payload.networkId, payload.target, !!payload.notifyAlways);
+    channelNotify.applyChange(payload.networkId, payload.target, {
+      notifyAlways: !!payload.notifyAlways,
+      muted: !!payload.muted,
+    });
     return;
   }
   if (payload.kind === 'ignore-list-updated') {

--- a/vue_client/src/stores/channelNotify.ts
+++ b/vue_client/src/stores/channelNotify.ts
@@ -4,14 +4,19 @@
 import { defineStore } from 'pinia';
 import { socketSend } from '../composables/useSocket.js';
 
-// Per-channel notification overrides. Today only `notifyAlways` is tracked:
-// when set, every message in the channel is treated as a notification trigger
-// for push/toast purposes (without lighting the channel up as a highlight).
-// The server is the source of truth — toggle sends a WS message, and the
-// `channel-notify-changed` echo updates state on all the user's tabs.
+// Per-channel overrides. Two independent flags are tracked:
+//   notifyAlways — every message in the channel is a notification trigger for
+//                  push/toast (without lighting the channel up as a highlight).
+//   muted        — buffer-list display only: suppress the plain-unread signal
+//                  (count + row color + off-screen unread arrow); highlights
+//                  and notifications are untouched.
+// The server is the source of truth — toggles send a WS message, and the
+// `channel-notify-changed` echo (carrying both flags) updates state on all the
+// user's tabs.
 
 export interface ChannelNotifyFlags {
   notifyAlways: boolean;
+  muted: boolean;
 }
 
 export interface ChannelNotifyEntry {
@@ -21,13 +26,15 @@ export interface ChannelNotifyEntry {
 
 export const useChannelNotifyStore = defineStore('channelNotify', {
   state: () => ({
-    // { [networkId]: { [target]: { notifyAlways: boolean } } } — only
-    // channels with any flag set live here; absent entries default to off.
+    // { [networkId]: { [target]: { notifyAlways, muted } } } — only channels
+    // with any flag set live here; absent entries default to all-off.
     byNetwork: {} as Record<number | string, Record<string, ChannelNotifyFlags>>,
   }),
   getters: {
     notifyAlways: (state) => (networkId: number | string, target: string) =>
       !!state.byNetwork[networkId]?.[target]?.notifyAlways,
+    muted: (state) => (networkId: number | string, target: string) =>
+      !!state.byNetwork[networkId]?.[target]?.muted,
     // List of { networkId, target } for all channels that currently have
     // always-notify enabled — used by the Settings panel's "always-notify
     // channels" audit list.
@@ -49,16 +56,23 @@ export const useChannelNotifyStore = defineStore('channelNotify', {
       }
       this.byNetwork = next;
     },
-    applyChange(networkId: number | string, target: string, notifyAlways: boolean) {
+    applyChange(networkId: number | string, target: string, flags: ChannelNotifyFlags) {
       if (!this.byNetwork[networkId]) this.byNetwork[networkId] = {};
-      if (notifyAlways) {
-        this.byNetwork[networkId][target] = { notifyAlways: true };
+      if (flags.notifyAlways || flags.muted) {
+        this.byNetwork[networkId][target] = {
+          notifyAlways: !!flags.notifyAlways,
+          muted: !!flags.muted,
+        };
       } else {
+        // Both flags off — drop the entry so it mirrors the server's row delete.
         delete this.byNetwork[networkId][target];
       }
     },
     setNotifyAlways(networkId: number | string, target: string, notifyAlways: boolean) {
       socketSend({ type: 'set-channel-notify-always', networkId, target, notifyAlways });
+    },
+    setMuted(networkId: number | string, target: string, muted: boolean) {
+      socketSend({ type: 'set-channel-muted', networkId, target, muted });
     },
   },
 });


### PR DESCRIPTION
Closes #251.

## What

Adds a **Mute channel** action to the buffer context menu. Muting suppresses the *plain-unread* signal for a channel — the unread count, the row color/bold, and the off-screen unread arrow — while leaving **highlights (mentions) and notifications fully intact**.

It's the per-buffer answer to a busy room you want to stay in but not be nagged by — e.g. a `#radio` channel whose unread count ticks up with every song.

## How it works

This is a **display** concern, modeled as a per-buffer override of `look.buffer_list.unread_display`: a muted channel behaves as `highlights` mode for ordinary traffic. Highlights still color the channel name and show the ● per the global display mode.

The whole behavior hinges on one predicate — `isChannelMuted(buf)` gates the `unread` row class in `BufferList.vue`. Color, bold, and the off-screen unread arrows all key off that class, so withholding it cascades cleanly. The `highlighted` class is deliberately left untouched so mentions still light the row up.

**Never noisier than your global setting:** the count only downgrades `full → highlights`. If you've globally set `badge`/`off`, muting just removes the plain-unread color and leaves the rest — always a reduction, never a surprise increase.

## Persistence

Stored server-side alongside `notify_always` in `channel_notify_settings`, so it **syncs across a user's devices/tabs** like pins and always-notify. The two flags are orthogonal — the row now persists while *either* is set and is deleted only when both clear. The server only stores and broadcasts mute; it never acts on it (notifications/decoration untouched).

## Changes

- **db:** new `muted` column (`ensureColumn` additive migration) + added to the export-schema column list so it round-trips in `.lurk` exports
- **`channelNotify.ts`:** two-flag get/set/list; row kept alive by either flag, deleted only when both clear
- **`wsHub`:** new `set-channel-muted` verb; both verbs now broadcast the full flag pair so neither clobbers the other
- **client store:** `muted` getter, `setMuted` action, `applyChange` carries both flags
- **`BufferList.vue`:** `isChannelMuted` gates the `unread` row class; `displayCount` downgrades a `full` count to highlights-only for muted channels
- **buffer context menu:** Mute / Unmute channel item (channels only), bell-slash icon mirroring the always-notify toggle

## Verification

- Server + client typecheck, lint, format all clean
- Full suite green (822 tests), including 3 new `channelNotify` cases covering the muted flag, the two-flags-coexist row lifecycle, and the snapshot shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)