### PR TITLE
Restyle context menu to match the message action bar

### DIFF
--- a/vue_client/src/components/ContextMenu.vue
+++ b/vue_client/src/components/ContextMenu.vue
@@ -143,14 +143,17 @@ onBeforeUnmount(() => {
      ignores the viewport constraint and sizes to the widest unwrapped item, so
      the clamp logic then sees the real width and repositions correctly. */
   width: max-content;
-  /* --bg-soft elevates the menu visually above the page (which uses --bg) so
-     the popup reads as a distinct surface without needing a visible border
-     (--border resolves to --bg-soft in the default theme, so a plain border
-     against page bg was invisible anyway). The drop shadow + the brighter
-     surface together do the floating-layer job. */
-  background: var(--bg-soft);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.55);
-  padding: 0;
+  /* Same floating-card chrome as the per-message action bar (.row-actions in
+     MessageList.vue): a --bg surface with a real 1px border, rounded corners,
+     and the lighter drop shadow — so both popups read as the same family of
+     floating surface. The vertical padding gives the list breathing room above
+     the first row and below the last; the small horizontal padding insets the
+     rounded item-hover chips from the card edge (Slack-style roomy menu). */
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  padding: var(--space-2) var(--space-1);
   color: var(--fg);
   user-select: none;
 }
@@ -159,12 +162,14 @@ onBeforeUnmount(() => {
   align-items: center;
   gap: var(--space-5);
   width: 100%;
-  /* Asymmetric horizontal padding: more on the right so the label has
-     breathing room from the menu edge — reads tight at 12px once the menu
-     widens out for a long label. */
-  padding: var(--space-4) var(--space-7) var(--space-4) var(--space-6);
+  /* Roomy padding (Slack-style), kept asymmetric — more on the right so the
+     label has trailing breathing room from the menu edge. */
+  padding: var(--space-4) var(--space-10) var(--space-4) var(--space-7);
   background: none;
   border: none;
+  /* Round the hover/focus fill into a chip inset within the padded card,
+     matching the action bar's rounded row buttons. */
+  border-radius: var(--radius-sm);
   color: inherit;
   font: inherit;
   text-align: left;
@@ -172,12 +177,15 @@ onBeforeUnmount(() => {
   cursor: pointer;
 }
 .item:hover:not(:disabled) {
-  /* Stronger wash now that the surface beneath is --bg-soft rather than --bg,
-     so the hover still reads against the elevated menu colour. */
-  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  /* Neutral --bg-soft fill on hover, matching the action bar's row buttons:
+     the row quiets to a soft background and the icon (below) pops to accent,
+     rather than washing the whole row in accent. */
+  background: var(--bg-soft);
 }
 .item:hover:not(:disabled) .icon {
-  color: var(--accent);
+  /* Brighten the muted icon to --fg on hover, matching the action bar's row
+     buttons — accent is reserved for active/on states, not plain hover. */
+  color: var(--fg);
 }
 .item:disabled {
   color: var(--fg-muted);
@@ -198,10 +206,11 @@ onBeforeUnmount(() => {
 }
 .divider {
   height: 1px;
-  /* Use --bg as the divider colour now that the menu surface is --bg-soft —
-     a 1px line in the page background colour cuts cleanly through the
-     elevated surface. */
-  background: var(--bg);
-  margin: 0;
+  /* --border cuts a clean line through the --bg card surface (the old --bg
+     divider would now vanish into the matching background). The vertical margin
+     sets the rule apart from the rows above and below it (e.g. between Mute
+     Channel and Close Channel) rather than letting them sit flush against it. */
+  background: var(--border);
+  margin: var(--space-2) 0;
 }
 </style>

--- a/vue_client/src/composables/useBufferActions.ts
+++ b/vue_client/src/composables/useBufferActions.ts
@@ -56,12 +56,12 @@ export function useBufferActions(): BufferActionsAPI {
         // to match the topic-bar toggle; the label states the action.
         isAlwaysNotify
           ? {
-              label: 'Stop always notifying',
+              label: 'Stop Always Notifying',
               icon: 'fa-solid fa-bell',
               onClick: () => channelNotify.setNotifyAlways(buf.networkId, buf.target, false),
             }
           : {
-              label: 'Always notify',
+              label: 'Always Notify',
               icon: 'fa-regular fa-bell',
               onClick: () => channelNotify.setNotifyAlways(buf.networkId, buf.target, true),
             },
@@ -74,12 +74,12 @@ export function useBufferActions(): BufferActionsAPI {
       items.push(
         isMuted
           ? {
-              label: 'Unmute channel',
+              label: 'Unmute Channel',
               icon: 'fa-solid fa-bell-slash',
               onClick: () => channelNotify.setMuted(buf.networkId, buf.target, false),
             }
           : {
-              label: 'Mute channel',
+              label: 'Mute Channel',
               icon: 'fa-regular fa-bell-slash',
               onClick: () => channelNotify.setMuted(buf.networkId, buf.target, true),
             },
@@ -91,12 +91,12 @@ export function useBufferActions(): BufferActionsAPI {
       // list menu.
       const hasNote = nickNotes.hasNote(buf.networkId, buf.target);
       items.push({
-        label: 'View profile…',
+        label: 'View Profile…',
         icon: 'fa-solid fa-id-card',
         onClick: () => whois.openViewer(buf.networkId, buf.target),
       });
       items.push({
-        label: hasNote ? 'Edit note…' : 'Add note…',
+        label: hasNote ? 'Edit Note…' : 'Add Note…',
         icon: 'fa-solid fa-note-sticky',
         onClick: () => nickNotes.openEditor(buf.networkId, buf.target),
       });

--- a/vue_client/src/composables/useMemberActions.ts
+++ b/vue_client/src/composables/useMemberActions.ts
@@ -107,7 +107,7 @@ export function useMemberActions(): MemberActionsAPI {
     const hasNote = nickNotes.hasNote(ctx.networkId, nick);
     const items: ContextMenuItem[] = [
       {
-        label: 'View profile…',
+        label: 'View Profile…',
         icon: 'fa-solid fa-id-card',
         onClick: () => whois.openViewer(ctx.networkId, nick),
       },
@@ -117,7 +117,7 @@ export function useMemberActions(): MemberActionsAPI {
         onClick: () => buffers.activate(ctx.networkId, nick),
       },
       {
-        label: hasNote ? 'Edit note…' : 'Add note…',
+        label: hasNote ? 'Edit Note…' : 'Add Note…',
         icon: 'fa-solid fa-note-sticky',
         onClick: () => nickNotes.openEditor(ctx.networkId, nick),
       },
@@ -146,7 +146,7 @@ export function useMemberActions(): MemberActionsAPI {
       if (hasAny(selfModes, OP_MODES)) {
         const opped = targetModes.includes('o');
         items.push({
-          label: opped ? 'Take op' : 'Give op',
+          label: opped ? 'Take Op' : 'Give Op',
           icon: 'fa-solid fa-shield-halved',
           onClick: () => send(`MODE ${ch} ${opped ? '-' : '+'}o ${nick}`),
         });
@@ -154,7 +154,7 @@ export function useMemberActions(): MemberActionsAPI {
 
       const voiced = targetModes.includes('v');
       items.push({
-        label: voiced ? 'Remove voice' : 'Give voice',
+        label: voiced ? 'Remove Voice' : 'Give Voice',
         icon: voiced ? 'fa-solid fa-microphone-slash' : 'fa-solid fa-microphone',
         onClick: () => send(`MODE ${ch} ${voiced ? '-' : '+'}v ${nick}`),
       });
@@ -176,7 +176,7 @@ export function useMemberActions(): MemberActionsAPI {
       });
 
       items.push({
-        label: 'Kick + ban…',
+        label: 'Kick + Ban…',
         icon: 'fa-solid fa-user-lock',
         onClick: () => {
           const reason = promptKickReason();


### PR DESCRIPTION
Closes #245.

Gives the right-click context menu the per-message action bar's floating-card identity, while keeping its layout and behavior unchanged. The two surfaces had quietly drifted into different visual families (square borderless `--bg-soft` slab vs. the bar's rounded `--bg` card); this brings them together.

## Changes

**`ContextMenu.vue` (visual skin only)**
- **Surface:** `--bg` + `1px --border` + `radius-sm` + the bar's lighter `0 4px 14px /.45` shadow, replacing the borderless square `--bg-soft` slab.
- **Hover:** neutral `--bg-soft` row fill with the icon brightening to `--fg` (was an accent wash) — accent is now reserved for active/on states, matching the bar. Rows render a rounded hover chip inset within the padded card.
- **Padding:** vertical breathing room on the menu *container* (separate from each row's own padding), roomy asymmetric row padding, and a little margin around the divider so it sits apart from the rows it separates.
- Divider recolored `--bg → --border` (the old `--bg` line was tuned for the `--bg-soft` slab and would vanish on the new `--bg` card).

**Label casing (`useBufferActions.ts`, `useMemberActions.ts`)**
- Title Case across all context-menu options for consistency: "Mute Channel", "Edit Network", "Give Op", "Give Voice", "Kick + Ban…", "Pin Channel", etc. `DM` stays uppercase as an acronym.

Positioning/clamp logic and all pointer/keyboard behavior are untouched.

## Testing
- `typecheck:client`, `lint`, `format:check` all clean (the 2 lint warnings are pre-existing, in untouched files).
- Visual: verified the longest menu (member right-click, with divider), hover states, and casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)