### PR TITLE
Polish mobile bars, dial in jump-to-unread, default image viewer on

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -785,7 +785,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     category: 'chat',
     group: 'viewing',
     type: 'bool',
-    default: false,
+    default: true,
     description:
       'When enabled, clicking a URL to an image opens it in an in-app viewer instead ' +
       'of a new browser tab. Cmd/Ctrl-click always opens in a new tab.',

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -268,16 +268,14 @@ const placeholder = computed(() => {
   // `/raw <line>` was cryptic; `/help` is the discoverable entry point and the
   // server buffer is exactly where someone goes looking for it.
   if (isServer.value) return 'try /help';
-  // Mobile drops the buffer name from the header and the compact status bar
-  // shows self/away instead, so the channel/peer context has no persistent home
-  // — the placeholder carries it, mirroring the desktop status bar's
-  // `network/target`. Modes are left off: they're volatile and belong in the
-  // status bar, not a glanceable hint. Desktop keeps `try /help` since the
-  // status bar already shows the buffer there.
+  // Mobile shows network/channel in the compact status bar now, so the
+  // placeholder carries the self identity (nick + channel-prefix + user modes)
+  // instead, with the away marker appended when set — mirroring what the input
+  // prompt renders on desktop. Desktop keeps `try /help` since the prompt
+  // already shows the identity there.
   if (isMobile.value) {
-    const net = a.network?.name;
-    // Network forced lowercase to match the status bar's `net/#chan` styling.
-    return net ? `${net.toLowerCase()}/${a.target}` : a.target;
+    const self = promptLabel.value;
+    return awayLabel.value ? `${self} ${awayLabel.value}` : self;
   }
   return 'try /help';
 });
@@ -304,11 +302,11 @@ const systemFeatures = computed(() => {
     autocapitalize: autocorrectOn ? 'sentences' : 'off',
   };
 });
-// Prompt identity (nick + channel prefix + user modes) and away marker are
-// shared with the compact status bar — see useSelfLabel. On mobile we don't
-// render the prompt label here at all (the status bar carries it instead);
-// the local computed is gated on !isMobile so we ship just `>` in mobile
-// mode and free the input row for the textarea.
+// Prompt identity (nick + channel prefix + user modes) and away marker — see
+// useSelfLabel. On mobile we don't render the prompt label inline here (the
+// template gates it on !isMobile so the input row stays just `>` + textarea);
+// instead it feeds the placeholder above, since the compact status bar now
+// shows network/channel rather than the self identity.
 const { promptLabel, awayLabel } = useSelfLabel();
 const { isMobile } = useViewport();
 

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -305,28 +305,78 @@ const stickToBottom = ref(true);
 const { scrollToBottomToken, scrollToUnreadToken } = useScrollState();
 
 // Unread-divider visibility tracking. The divider is pinned for the whole
-// visit (dividerAfterId snapshot), so once the user has scrolled it into view
-// we stop nagging them with the "Jump to unread" button for the rest of the
-// visit — reset on buffer switch. An IntersectionObserver on the (single)
-// divider element drives setUnreadAnchor: off-screen-and-unseen surfaces the
-// button with an up/down arrow, on-screen clears it and flips unreadSeen.
+// visit (dividerAfterId snapshot). The "Jump to unread" button exists to catch
+// the case where you land in a channel and the marker is off-screen, so it
+// surfaces only while the marker has neither been seen nor timed out this
+// visit, and auto-retires UNREAD_BUTTON_TTL_MS after it first appears so it
+// doesn't linger obnoxiously (#246). All of seen/expired/element reset on
+// buffer switch. An IntersectionObserver on the (single) divider element
+// drives setUnreadAnchor: off-screen-and-unseen surfaces the button with an
+// up/down arrow, on-screen clears it and flips unreadSeen.
 let unreadDividerEl: HTMLElement | null = null;
 let unreadObserver: IntersectionObserver | null = null;
 let unreadSeen = false;
+let unreadExpired = false;
+let unreadExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+
+// The button earns its keep in the first moments after you land in a channel
+// and can't see the marker; if you don't jump then, you probably won't — so it
+// gets a few seconds in the sun, then retires for the rest of the visit (#246).
+const UNREAD_BUTTON_TTL_MS = 5000;
+
+function startUnreadExpiry(): void {
+  if (unreadExpiryTimer || unreadExpired) return;
+  unreadExpiryTimer = setTimeout(() => {
+    unreadExpiryTimer = null;
+    unreadExpired = true;
+    setUnreadAnchor(null);
+  }, UNREAD_BUTTON_TTL_MS);
+}
+
+function clearUnreadExpiry(): void {
+  if (unreadExpiryTimer) {
+    clearTimeout(unreadExpiryTimer);
+    unreadExpiryTimer = null;
+  }
+}
 
 function evaluateUnread(entry: IntersectionObserverEntry): void {
   if (entry.isIntersecting) {
     unreadSeen = true;
+    clearUnreadExpiry();
     setUnreadAnchor(null);
     return;
   }
-  if (unreadSeen) {
+  // Off-screen. Stay quiet once the marker has been seen this visit OR the
+  // button has already had its run — new messages shoving the divider off the
+  // top (while you read the live tail) must not re-summon it (#246).
+  if (unreadSeen || unreadExpired) {
     setUnreadAnchor(null);
     return;
   }
   const top = entry.boundingClientRect.top;
   const rootTop = entry.rootBounds?.top ?? scroller.value?.getBoundingClientRect().top ?? 0;
   setUnreadAnchor(top < rootTop ? 'up' : 'down');
+  startUnreadExpiry();
+}
+
+// At buffer entry the IntersectionObserver hasn't delivered its first callback
+// yet — and if new messages shove the marker off-screen before it does, the
+// only state IO ever reports is "off-screen", which would wrongly surface the
+// button (#246). Seed unreadSeen synchronously from the divider's geometry
+// right after the entry scroll settles, so a marker that was on screen when you
+// arrived counts as seen even if it scrolls away a moment later.
+function seedUnreadSeen(): void {
+  const el = scroller.value;
+  const divider = unreadDividerEl;
+  if (!el || !divider) return;
+  const er = el.getBoundingClientRect();
+  const dr = divider.getBoundingClientRect();
+  if (dr.bottom > er.top && dr.top < er.bottom) {
+    unreadSeen = true;
+    clearUnreadExpiry();
+    setUnreadAnchor(null);
+  }
 }
 
 // Vue function ref on the unread divider: called with the element when it
@@ -1063,9 +1113,12 @@ watch(
   async () => {
     stickToBottom.value = true;
     unreadSeen = false;
+    unreadExpired = false;
+    clearUnreadExpiry();
     resetScrollState();
     await nextTick();
     scrollToBottom();
+    seedUnreadSeen();
     ensureViewportFilled();
   },
   { immediate: true },
@@ -1190,7 +1243,12 @@ onMounted(() => {
   if (typeof IntersectionObserver !== 'undefined' && scroller.value) {
     unreadObserver = new IntersectionObserver(
       (entries) => {
-        const entry = entries[entries.length - 1];
+        // Honor a "was visible" entry anywhere in the batch: a visible→hidden
+        // pair can land together when new messages shove the marker off the top
+        // in the same frame, and taking only the last entry would drop the
+        // "seen" half and wrongly keep the button alive (#246). Fall back to
+        // the latest position when nothing in the batch was intersecting.
+        const entry = entries.find((e) => e.isIntersecting) ?? entries[entries.length - 1];
         if (entry) evaluateUnread(entry);
       },
       { root: scroller.value, threshold: 0 },
@@ -1214,6 +1272,7 @@ onBeforeUnmount(() => {
     unreadObserver.disconnect();
     unreadObserver = null;
   }
+  clearUnreadExpiry();
   if (nowTimer) {
     clearInterval(nowTimer);
     nowTimer = null;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -7,16 +7,12 @@
   <div v-if="active" class="status-bar">
     <div class="bar" :class="{ compact }">
       <span v-if="!compact" class="seg clock">{{ clock }}</span>
-      <span v-if="!compact" class="seg buffer"
+      <span class="seg buffer"
         ><template v-if="targetLabel"
           ><span v-if="networkLabel" class="net">{{ networkLabel }}/</span
           ><span class="name">{{ targetLabel }}</span></template
         ><span v-else class="name">{{ networkLabel }}</span
         ><span v-if="modeSuffix" class="modes">{{ modeSuffix }}</span></span
-      >
-      <span v-if="compact" class="seg self"
-        ><span class="name">{{ promptLabel }}</span
-        ><span v-if="awayLabel" class="away">&nbsp;{{ awayLabel }}</span></span
       >
       <!-- Jump-to-unread. Scrolls (usually up) to the pinned unread divider
          when it's off-screen and the user hasn't scrolled it into view yet
@@ -110,7 +106,6 @@ import {
   requestScrollToUnread,
 } from '../composables/useScrollState.js';
 import { useComposing } from '../composables/useComposing.js';
-import { useSelfLabel } from '../composables/useSelfLabel.js';
 import { formatTimestamp } from '../utils/timestamp.js';
 import { isPeerOffline, isPeerAway } from '../utils/peerPresence.js';
 import SuggestionStrip from './SuggestionStrip.vue';
@@ -130,13 +125,13 @@ import type { EmojiMatch } from '../utils/emojiData.js';
 
 withDefaults(
   defineProps<{
-    // Mobile/petite mode: drops the clock and buffer-name segments entirely
-    // (the buffer name is already in the input placeholder, the clock isn't
-    // worth the row), and renders the self identity (nick + channel-prefix + user
-    // modes + away) here instead — freeing the input row to be just `>`,
-    // textarea, and the paperclip. Also hides lag so the typing/split/upload
-    // signals stay legible at phone widths. (The scroll affordances —
-    // jump-to-unread and return-to-present — render in both modes.)
+    // Mobile/petite mode: drops the clock segment (not worth the row at phone
+    // widths) and hides lag so the typing/split/upload signals stay legible.
+    // The buffer name (network/channel + modes) renders in both modes; the
+    // self identity (nick + channel-prefix + user modes + away) moves to the
+    // input placeholder on mobile, freeing the input row to be just `>`,
+    // textarea, and the paperclip. (The scroll affordances — jump-to-unread
+    // and return-to-present — render in both modes.)
     compact?: boolean;
   }>(),
   { compact: false },
@@ -149,7 +144,6 @@ const uploads = useUploadsStore();
 const ignores = useIgnoresStore();
 const nickColors = useNickColors();
 const composing = useComposing();
-const { promptLabel, awayLabel } = useSelfLabel();
 
 // SPLIT (warn) at 2 chunks, FLOOD (bad) at 3+. Lives just before the typing
 // indicator so heavy composers can see it without taking their eyes off the
@@ -408,14 +402,6 @@ function onJumpToUnread() {
 }
 .seg.buffer .modes {
   color: var(--fg-muted);
-}
-/* Mobile-only self identity. Accent for the nick to mirror how the
-   input prompt rendered it on desktop; warn-colored away tail. */
-.seg.self .name {
-  color: var(--accent);
-}
-.seg.self .away {
-  color: var(--warn);
 }
 .seg.lag {
   color: var(--fg-muted);

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -43,10 +43,10 @@
         <button class="icon back" title="Back" @click="goList">
           <i class="fa-solid fa-arrow-left"></i>
         </button>
-        <!-- Channels and DMs drop the name here — the message input's
-             placeholder carries net/#chan on mobile, so a header copy is just
-             redundant clutter (#222). The server buffer (placeholder is
-             "try /help") and the system console (no input row at all) have no
+        <!-- Channels and DMs drop the name here — the compact status bar
+             carries net/#chan on mobile, so a header copy is just redundant
+             clutter (#222). The server buffer (input placeholder is "try /help")
+             and the system console (no input row at all) have no
              other persistent label, so they keep an explicit title. Otherwise
              the bar holds only buffer-scoped actions: search & highlights open
              pre-filtered to this buffer (in:<target> on:<network>), members


### PR DESCRIPTION
Three small UI/UX changes.

## 1. Mobile status bar ↔ input placeholder flip
On mobile, the **status bar** now shows `network/#channel` (+ channel modes) and the **input placeholder** carries the **self identity** (`@nick(modes)` + away marker) — flipped from before. Desktop is unchanged.

- `StatusBar.vue`: the buffer segment renders in both modes; the compact-only self-identity segment (and its now-unused `useSelfLabel` import + dead `.seg.self` CSS) are removed.
- `MessageInput.vue`: mobile placeholder = self identity instead of `network/channel`.

## 2. Jump-to-unread improvements — closes #246
- **Bug fix:** the marker scrolling off-screen no longer wrongly surfaces the button. `seedUnreadSeen()` checks the divider geometry synchronously at buffer entry (covering the race where the IntersectionObserver's first callback only ever reports "off-screen" because new messages shoved the marker away first), and the observer now honors a "was visible" entry anywhere in a batch.
- **Less persistent:** the button auto-retires 5s after it first appears and stays quiet once the marker has been seen or the button has expired this visit — so it only shows right when you land in a channel and can't see the marker.

## 3. Image viewer on by default
`chat.image_modal.enabled` default flipped `false → true`. Users who explicitly disabled it keep their choice; only the unset default changes.

Also refreshed a stale `MobileChat.vue` comment that referenced the old "placeholder carries net/#chan" design.

## Verification
`npm run check` passes (server + client typecheck, lint, format) and the settings registry test passes. Dev server not run (per project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)