### PR TITLE
Reap dead WebSockets so auto-away fires for vanished clients

### DIFF
--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -80,6 +80,23 @@ describe('GET /api/admin/users', () => {
   });
 });
 
+describe('GET /api/admin/presence', () => {
+  it('403 for a non-admin', async () => {
+    expect((await userAgent.get('/api/admin/presence')).status).toBe(403);
+  });
+
+  it('returns an empty presence list when no sockets are connected', async () => {
+    // The route reads wsHub's live socket registry; this harness mounts the
+    // router without attaching a WS server, so the registry is empty. That's
+    // exactly the "everyone gone" baseline — the response is a well-formed
+    // empty list, not an error.
+    const res = await adminAgent.get('/api/admin/presence');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.presence)).toBe(true);
+    expect(res.body.presence).toHaveLength(0);
+  });
+});
+
 describe('DELETE /api/admin/users/:id', () => {
   it('400 on a non-integer id', async () => {
     const res = await adminAgent.delete('/api/admin/users/abc');

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -7,6 +7,7 @@ import { requireAuth, requireAdmin } from '../middleware/auth.js';
 import { listUsers, findUserById, deleteUser, countAdmins, setUserPaused } from '../db/users.js';
 import { createInvite, listInvites, deleteInvite, getInvite } from '../db/invites.js';
 import ircManager from '../services/ircManager.js';
+import { presenceDiagnostics } from '../services/wsHub.js';
 import { isNodeMode } from '../utils/edition.js';
 
 const router = Router();
@@ -154,6 +155,20 @@ router.post('/users/:id/resume', (req: Request, res: Response) => {
   setUserPaused(id, false);
   ircManager.resumeUser(id);
   res.json({ ok: true });
+});
+
+// Read-only presence diagnostic. Surfaces, per connected user, how many WS
+// sockets are open vs. how many the server believes are visible — the value
+// auto-away keys on — plus the persisted away row. An open socket count that
+// stays above visible/away counts, or a visible socket for a user who's
+// plainly gone, is the zombie-socket signature the heartbeat reaps. Safe in
+// both editions: it mutates nothing (unlike pause/resume, which are node-gated).
+router.get('/presence', (_req: Request, res: Response) => {
+  const presence = presenceDiagnostics().map((row) => {
+    const u = findUserById(row.userId);
+    return { ...row, username: u?.username ?? null };
+  });
+  res.json({ presence });
 });
 
 router.get('/invites', (req: Request, res: Response) => {

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -18,6 +18,7 @@ let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
 let buildResumeSlice: typeof import('./wsHub.js').buildResumeSlice;
 let buildOfflineBacklogFrames: typeof import('./wsHub.js').buildOfflineBacklogFrames;
 let handleOpenBuffer: typeof import('./wsHub.js').handleOpenBuffer;
+let sweepWsHeartbeat: typeof import('./wsHub.js').sweepWsHeartbeat;
 
 let userId: number;
 let networkId: number;
@@ -28,8 +29,13 @@ beforeAll(async () => {
   ({ insertMessage } = await import('../db/messages.js'));
   ({ closeBuffer, isClosed } = await import('../db/closedBuffers.js'));
   ({ setClearedState } = await import('../db/bufferReads.js'));
-  ({ buildBufferBacklog, buildResumeSlice, buildOfflineBacklogFrames, handleOpenBuffer } =
-    await import('./wsHub.js'));
+  ({
+    buildBufferBacklog,
+    buildResumeSlice,
+    buildOfflineBacklogFrames,
+    handleOpenBuffer,
+    sweepWsHeartbeat,
+  } = await import('./wsHub.js'));
 
   userId = createUser('alice').id;
   const net = createNetwork(userId, {
@@ -255,5 +261,69 @@ describe('handleOpenBuffer', () => {
     handleOpenBuffer(ws, userId, networkId, '');
     handleOpenBuffer(ws, userId, 0, '#x');
     expect(frames).toHaveLength(0);
+  });
+});
+
+// A minimal ws stand-in that counts ping/terminate calls. isAlive mirrors the
+// real per-socket flag the reaper reads and writes.
+function hbWs(isAlive: boolean) {
+  const calls = { ping: 0, terminate: 0 };
+  const ws = {
+    isAlive,
+    ping() {
+      calls.ping += 1;
+    },
+    terminate() {
+      calls.terminate += 1;
+    },
+  };
+  return { ws, calls };
+}
+
+// sweepWsHeartbeat is typed for real LurkerWebSockets; the mocks only carry the
+// three fields it touches, so cast at the boundary.
+function sweep(wss: Array<ReturnType<typeof hbWs>['ws']>): number {
+  return sweepWsHeartbeat(wss as unknown as Parameters<typeof sweepWsHeartbeat>[0]);
+}
+
+describe('sweepWsHeartbeat', () => {
+  it('pings a live socket and re-arms it as pending (isAlive=false)', () => {
+    const { ws, calls } = hbWs(true);
+    const terminated = sweep([ws]);
+    expect(calls.ping).toBe(1);
+    expect(calls.terminate).toBe(0);
+    expect(ws.isAlive).toBe(false);
+    expect(terminated).toBe(0);
+  });
+
+  it('terminates a socket that never ponged (isAlive still false next sweep)', () => {
+    const { ws, calls } = hbWs(true);
+    sweep([ws]); // ping; isAlive -> false
+    const terminated = sweep([ws]); // no pong arrived -> reap
+    expect(calls.terminate).toBe(1);
+    // A reaped socket is not re-pinged in the same sweep.
+    expect(calls.ping).toBe(1);
+    expect(terminated).toBe(1);
+  });
+
+  it('spares a socket that ponged between sweeps', () => {
+    const { ws, calls } = hbWs(true);
+    sweep([ws]); // ping; isAlive -> false
+    ws.isAlive = true; // simulate the pong handler firing
+    sweep([ws]); // still alive -> ping again, no terminate
+    expect(calls.terminate).toBe(0);
+    expect(calls.ping).toBe(2);
+  });
+
+  it('handles a mixed batch and reports the terminated count', () => {
+    const live = hbWs(true); // answered last round
+    const dead1 = hbWs(false); // missed last round's pong
+    const dead2 = hbWs(false);
+    const terminated = sweep([live.ws, dead1.ws, dead2.ws]);
+    expect(terminated).toBe(2);
+    expect(live.calls.terminate).toBe(0);
+    expect(live.calls.ping).toBe(1);
+    expect(dead1.calls.terminate).toBe(1);
+    expect(dead2.calls.terminate).toBe(1);
   });
 });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -515,6 +515,11 @@ export function presenceDiagnostics(): PresenceDiagnosticRow[] {
       openSockets += 1;
       if (ws.presence?.visible) visibleSockets += 1;
     }
+    // A user key lingers while their set is non-empty, but every socket in it
+    // can be mid-teardown (CLOSING/CLOSED) before the 'close' handler prunes it.
+    // Skip those transient all-zero rows so the diagnostic only lists users with
+    // a genuinely live socket — matching what this function claims to report.
+    if (openSockets === 0) continue;
     const awayRow = getUserAwayState(userId);
     rows.push({
       userId,

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -73,6 +73,15 @@ interface LurkerWebSocket extends WebSocket {
   userId?: number;
   sinceId?: number;
   presence?: { visible: boolean };
+  // Liveness flag for the heartbeat reaper (see sweepWsHeartbeat). Set true on
+  // connect and on every pong; set false right before each ping. A socket still
+  // false at the next sweep missed a full interval's pong and is terminated as
+  // dead. Without this, a client that dies uncleanly — a laptop sleeping with
+  // the tab foregrounded, a phone dropping off the network — never sends a TCP
+  // close, so the socket lingers OPEN with its last-reported presence (often
+  // visible=true) and userHasVisibleClient() stays true forever, permanently
+  // suppressing auto-away.
+  isAlive?: boolean;
   // Mirrors the account's is_paused at connect time, then flipped live by the
   // user-suspended / user-resumed handlers so the read-only write guard never
   // needs a per-message DB read. (Named accountPaused, not isPaused, to avoid
@@ -451,6 +460,79 @@ export function fanOutToUser(userId: number, payload: WsPayload, opts: FanOutOpt
   fanOut(userId, payload, opts);
 }
 
+// One sweep of the liveness heartbeat over a batch of sockets. A socket that
+// hasn't ponged since the previous sweep (isAlive still false) is terminated —
+// firing its 'close' handler → removeSocket → evaluatePresence, which lets
+// auto-away schedule normally. A socket that did pong is re-armed (isAlive set
+// false) and pinged again. The browser WebSocket API answers ping frames
+// automatically, so no client code participates. Exported (and pure over its
+// argument) so the terminate/ping decision is unit-testable without a live WSS.
+export function sweepWsHeartbeat(sockets: Iterable<LurkerWebSocket>): number {
+  let terminated = 0;
+  for (const ws of sockets) {
+    if (ws.isAlive === false) {
+      ws.terminate();
+      terminated += 1;
+      continue;
+    }
+    ws.isAlive = false;
+    try {
+      ws.ping();
+    } catch (_) {
+      // A ping can throw if the socket is already tearing down; the isAlive
+      // flag we just set means the next sweep terminates it regardless.
+    }
+  }
+  return terminated;
+}
+
+// Read-only introspection of the live socket registry for the admin presence
+// diagnostic. For each user with at least one open socket it reports how many
+// sockets are open and how many currently claim presence.visible=true — the
+// exact quantity auto-away keys on — alongside the persisted away row. Lets an
+// operator watch a dead socket (e.g. a slept laptop) get reaped by the
+// heartbeat and the user flip to away, confirming the fix on a live cell.
+// Mutates nothing.
+export interface PresenceDiagnosticRow {
+  userId: number;
+  openSockets: number;
+  visibleSockets: number;
+  away: {
+    active: boolean;
+    autoSet: boolean;
+    since: string | null;
+    message: string | null;
+  } | null;
+}
+
+export function presenceDiagnostics(): PresenceDiagnosticRow[] {
+  const rows: PresenceDiagnosticRow[] = [];
+  for (const [userId, set] of socketsByUser) {
+    let openSockets = 0;
+    let visibleSockets = 0;
+    for (const ws of set) {
+      if (ws.readyState !== ws.OPEN) continue;
+      openSockets += 1;
+      if (ws.presence?.visible) visibleSockets += 1;
+    }
+    const awayRow = getUserAwayState(userId);
+    rows.push({
+      userId,
+      openSockets,
+      visibleSockets,
+      away: awayRow
+        ? {
+            active: !!(awayRow.away_datetime && !awayRow.back_datetime),
+            autoSet: !!awayRow.auto_set,
+            since: awayRow.away_datetime ?? null,
+            message: awayRow.away_message ?? null,
+          }
+        : null,
+    });
+  }
+  return rows;
+}
+
 function parseSinceParam(rawUrl: string): number {
   try {
     const url = new URL(rawUrl, 'http://localhost');
@@ -474,6 +556,19 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
   // DB, and so a crash mid-/LIST self-clears on next process boot (the set
   // resets but the meta row can be cleaned by the next start handler).
   const chanlistInFlight = new Set();
+
+  // Liveness heartbeat. Every interval, ping each open socket and reap any that
+  // failed to pong since the previous sweep. This is the only thing that
+  // detects a peer that vanished without a TCP close (slept laptop, dropped
+  // mobile link) — and reaping such a socket is what finally lets auto-away
+  // fire for a user who's actually gone. unref() so it never holds the process
+  // open; matches the purgeExpiredSessions timer in server.ts.
+  const HEARTBEAT_MS = 30_000;
+  const heartbeat = setInterval(() => {
+    for (const set of socketsByUser.values()) sweepWsHeartbeat(set);
+  }, HEARTBEAT_MS);
+  heartbeat.unref?.();
+  wss.on('close', () => clearInterval(heartbeat));
 
   function clearAutoAwayTimer(userId: number): void {
     const t = autoAwayTimers.get(userId);
@@ -833,6 +928,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       lurkerWs.userId = user.id;
       lurkerWs.sinceId = initialSinceId;
       lurkerWs.presence = { visible: false };
+      lurkerWs.isAlive = true;
       lurkerWs.accountPaused = user.is_paused === 1;
       addSocket(user.id, lurkerWs);
       onConnection(lurkerWs, user);
@@ -851,6 +947,12 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         return;
       }
       handleClientMessage(ws, user, msg);
+    });
+
+    // The browser auto-answers ping frames; this just records that the answer
+    // arrived so the next heartbeat sweep spares the socket.
+    ws.on('pong', () => {
+      ws.isAlive = true;
     });
 
     ws.on('close', () => removeSocket(user.id, ws));


### PR DESCRIPTION
## Why

You noticed users staying "present" on IRC while clearly AFK — most tellingly, someone whose laptop was closed/asleep all night never went away, while others did. That split is the signature of a specific gap, not a config issue (`away.auto.enabled` defaults **true**, delay 900s).

Auto-away keys entirely on `userHasVisibleClient()`, which is true while **any** open socket reports `presence.visible=true`. A client that dies *uncleanly* (slept laptop with the tab foregrounded, phone dropping off the network) never sends a TCP close, and `visibilitychange → {visible:false}` can't flush before the OS suspends the process. The browser↔server WebSocket had **no ping/pong**, so that socket lingered `OPEN` with its last-reported presence forever → `userHasVisibleClient()` stayed true → auto-away was never even scheduled. A deploy/restart flushed the zombies, which is why it felt like "worked right after the June 9 deploy, degraded since."

(The clients that *did* go away reported `visible:false` cleanly or closed cleanly — same code, different kind of death.)

## What

- **Liveness heartbeat** in `wsHub.ts`: every 30s, ping each open socket and `terminate()` any that missed the previous sweep's pong. `terminate()` fires the existing `close` path → `removeSocket` → `evaluatePresence`, so auto-away schedules normally ~one interval after the client actually vanishes. Browsers answer ping frames automatically, so **no client change** is needed. The per-socket decision is extracted to a pure, exported `sweepWsHeartbeat()` for unit testing. Interval is `unref()`'d (matches the `purgeExpiredSessions` timer).
- **Read-only diagnostic** `GET /api/admin/presence`: per connected user, `{ openSockets, visibleSockets, away }` (+ username). Lets you watch a dead socket get reaped and the user flip to away on the live cell. Mutates nothing; safe in both editions (unlike pause/resume, which are node-gated).

## Verification path on the cell

After deploy, hit `/api/admin/presence` and watch a known-AFK user: `openSockets` should drop (socket reaped) and `away.active` flip true within ~heartbeat + the 900s auto-away delay. This is the precise version of the `/proc/net/tcp` connection count from our debugging.

## Tests
- `sweepWsHeartbeat`: pings live sockets, terminates ones that missed a pong, spares ones that ponged, reports the terminated count over a mixed batch.
- `GET /api/admin/presence`: 403 for non-admins; well-formed empty list when nothing is connected.
- Full suite green (828 tests), typecheck + oxlint + oxfmt clean.

## Not covered (deliberate)
A genuinely *foreground* client where the person walked away from the keyboard (tab visible, machine awake) still counts as present — that needs an input-idle timer and is a separate product call. Your overnight case was a slept laptop, which this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)