### PR TITLE
Release 1.0.0 (drop -beta)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.0-beta",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.0-beta",
+      "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@simplewebauthn/server": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.0-beta",
+  "version": "1.0.0",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.0-beta",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.0-beta",
+      "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.0-beta",
+  "version": "1.0.0",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Bumps `lurker` and `vue_client` from `1.0.0-beta` to `1.0.0`, removing the pre-release suffix.

There's no separate beta flag — the `-beta` suffix in `version` *is* the flag. The version string is read from `package.json` and surfaced in:

- the **About** pane (`version 1.0.0`)
- the IRC **user-agent**, **CTCP VERSION** reply, and **QUIT** message (`server/utils/userAgent.ts`)
- **node registration** / orchestrator client version reporting

## Changes
- `package.json` + `package-lock.json` → `1.0.0`
- `vue_client/package.json` + `vue_client/package-lock.json` → `1.0.0`

Lockfiles bumped alongside so `npm ci` stays in sync. Version-field-only change; no dependency or code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)