### PR TITLE
Gate typing TAGMSGs on the message-tags capability

### DIFF
--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1738,7 +1738,7 @@ export class IrcConnection {
     // ERR_UNKNOWNCOMMAND, which our 'irc error' handler surfaces as a toast —
     // so an ungated send spams an error on each keystroke. Typing indicators
     // are a best-effort nicety; no cap, no send.
-    if (!this.client.network.cap.enabled.includes('message-tags')) return;
+    if (!(this.client.network?.cap?.enabled || []).includes('message-tags')) return;
     // Suppress typing TAGMSGs to peers we know are offline — otherwise each
     // keystroke generates an ERR_NOSUCHNICK reply that lands as a persisted
     // error in the DM buffer (and pings push subscribers). The user finds

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1732,6 +1732,13 @@ export class IrcConnection {
     this.client.raw(line.replace(/[\u000d\u000a\u0000]/g, ''));
   }
   sendTyping(target: string, state: string): void {
+    // +typing is a client-only tag carried over TAGMSG, which only exists when
+    // the server negotiated the message-tags capability. Networks that don't
+    // speak it (DALnet and other non-IRCv3 servers) answer every TAGMSG with
+    // ERR_UNKNOWNCOMMAND, which our 'irc error' handler surfaces as a toast —
+    // so an ungated send spams an error on each keystroke. Typing indicators
+    // are a best-effort nicety; no cap, no send.
+    if (!this.client.network.cap.enabled.includes('message-tags')) return;
     // Suppress typing TAGMSGs to peers we know are offline — otherwise each
     // keystroke generates an ERR_NOSUCHNICK reply that lands as a persisted
     // error in the DM buffer (and pings push subscribers). The user finds


### PR DESCRIPTION
## Problem

`sendTyping()` fired a `+typing` `TAGMSG` on every keystroke regardless of whether the server could understand it. `+typing` is a client-only tag carried over `TAGMSG`, which only exists when the **`message-tags`** capability has been negotiated. DALnet (and other non-IRCv3 servers) don't speak it, so they answer each `TAGMSG` with `ERR_UNKNOWNCOMMAND (421)`. That numeric flows through the `'irc error'` handler, which special-cases `unknown_command` to also raise a toast — so the user got an error popup on basically every keystroke.

This is the bug reported in #258.

## Fix

Guard the send on the already-tracked negotiated cap set (`client.network.cap.enabled`, the same source we read at `ircConnection.ts:451` for the "Negotiated capabilities" line). No `message-tags`, no send.

```ts
if (!this.client.network.cap.enabled.includes('message-tags')) return;
```

Server-side no-op is sufficient — the client can keep emitting its `typing` WS event harmlessly; it just stops hitting the wire.

## Scope note

I audited the other IRCv3 send paths (MONITOR is gated on ISUPPORT, away-notify is receive-side, chghost is requested via CAP). `sendTyping` was the only outbound cap-dependent command that wasn't consulting the cap state. So this is the complete fix, not a band-aid — there's no broader "feature detection" system missing; this one call site just wasn't using the one we already have.

## Testing

- `npm run typecheck` ✅
- `oxlint` ✅
- Not unit-tested: exercising this needs a fake server toggling `message-tags`, which is heavier than the one-line guard warrants.

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)