### PR TITLE
Add mode/moderation slash shortcuts, /cycle, /notice, /slap, info commands

### DIFF
--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1799,6 +1799,12 @@ export class IrcConnection {
     if (isDmTargetName(target)) this.trackDmPeer(target);
     this.client.action(target, text);
   }
+  notice(target: string, text: string): void {
+    // Unlike say/action we don't trackDmPeer here: outgoing NOTICEs mirror the
+    // inbound rule (NOTICEs don't establish a tracked DM peer), so notice-ing a
+    // service or bot doesn't spin up presence tracking for it.
+    this.client.notice(target, text);
+  }
   raw(line: string): void {
     // Strip CR/LF/NUL before the line hits the socket. irc-framework's
     // writeLine appends its own \r\n and writes verbatim, so any embedded

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -294,6 +294,28 @@ class IrcManager extends EventEmitter {
     return true;
   }
 
+  // IRC servers don't echo your own NOTICE back (and Lurker doesn't request the
+  // echo-message cap), so — exactly like send/action — we publish a self copy
+  // locally per wire chunk. splitSay applies because NOTICE shares PRIVMSG's
+  // length budget.
+  notice(userId: number, networkId: number, target: string, text: string): boolean {
+    const conn = this.getConnection(userId, networkId);
+    if (!conn) return false;
+    const chunks = splitSay(text);
+    for (const chunk of chunks) {
+      conn.notice(target, chunk);
+      conn.publish({
+        type: 'notice',
+        target,
+        nick: conn.client.user?.nick,
+        text: chunk,
+        kind: 'notice',
+        self: true,
+      });
+    }
+    return true;
+  }
+
   typing(userId: number, networkId: number, target: string, state: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;

--- a/server/services/mcpServer.test.ts
+++ b/server/services/mcpServer.test.ts
@@ -120,6 +120,7 @@ describe('MCP server', () => {
       'search_messages',
       'send_action',
       'send_message',
+      'send_notice',
       'set_nick_note',
     ]);
     // Each entry carries an inputSchema usable by an MCP client.

--- a/server/services/verbs/index.ts
+++ b/server/services/verbs/index.ts
@@ -12,3 +12,4 @@ import './getNickNote.js';
 import './setNickNote.js';
 import './sendMessage.js';
 import './sendAction.js';
+import './sendNotice.js';

--- a/server/services/verbs/sendNotice.ts
+++ b/server/services/verbs/sendNotice.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import ircManager from '../ircManager.js';
+
+/** Authenticated caller context passed to every verb handler. */
+interface VerbContext {
+  userId: number;
+  scope: string;
+}
+
+registerVerb({
+  name: 'send_notice',
+  description:
+    'Send a NOTICE to a channel or peer on a network. Like send_message but uses NOTICE semantics (no auto-reply expected). Returns { ok: false, error: "not-connected" } when the network is offline.',
+  scope: 'read-write',
+  input: {
+    type: 'object',
+    properties: {
+      networkId: { type: 'integer' },
+      target: {
+        type: 'string',
+        description: 'A channel name like "#foo" or a peer nick.',
+      },
+      text: { type: 'string' },
+    },
+    required: ['networkId', 'target', 'text'],
+    additionalProperties: false,
+  },
+  handler(ctx: VerbContext, input: Record<string, unknown>) {
+    const networkId = Number(input.networkId);
+    const target = typeof input.target === 'string' ? input.target : '';
+    const text = typeof input.text === 'string' ? input.text : '';
+    if (!target || !text) return { ok: false, error: 'empty-target-or-text' };
+    const ok = ircManager.notice(ctx.userId, networkId, target, text);
+    return ok ? { ok: true } : { ok: false, error: 'not-connected' };
+  },
+});

--- a/server/services/verbs/verbs.test.ts
+++ b/server/services/verbs/verbs.test.ts
@@ -411,6 +411,35 @@ describe('send_message / send_action', () => {
     expect(result).toEqual({ ok: false, error: 'not-connected' });
   });
 
+  it('send_notice shares the same error shape', () => {
+    const result = callVerb('send_notice', rwCtx(owner.id), {
+      networkId: net.id,
+      target: '#chan',
+      text: 'heads up',
+    });
+    expect(result).toEqual({ ok: false, error: 'not-connected' });
+  });
+
+  it('send_notice is rejected for read-only scope', () => {
+    expect(() =>
+      callVerb('send_notice', rCtx(owner.id), {
+        networkId: net.id,
+        target: '#chan',
+        text: 'heads up',
+      }),
+    ).toThrow(/scope insufficient/);
+  });
+
+  it('send_notice rejects empty target or text', () => {
+    expect(
+      callVerb('send_notice', rwCtx(owner.id), {
+        networkId: net.id,
+        target: '',
+        text: 'hi',
+      }),
+    ).toEqual({ ok: false, error: 'empty-target-or-text' });
+  });
+
   it('send_message is rejected for read-only scope', () => {
     expect(() =>
       callVerb('send_message', rCtx(owner.id), {

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1089,9 +1089,12 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       const networkId = Number(msg.networkId);
       if (!Number.isInteger(networkId) || !ownsNetwork(userId, networkId)) {
         send(ws, { kind: 'error', text: 'unknown network' });
-        // Surface the failure on the originating send/action so the client
-        // can stop pretending the message succeeded.
-        if (msg.clientId && (msg.type === 'send' || msg.type === 'action')) {
+        // Surface the failure on the originating send/action/notice so the
+        // client can stop pretending the message succeeded.
+        if (
+          msg.clientId &&
+          (msg.type === 'send' || msg.type === 'action' || msg.type === 'notice')
+        ) {
           send(ws, {
             kind: 'send-result',
             clientId: msg.clientId,
@@ -1109,7 +1112,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // as pending instead of hanging forever.
     if (ws.accountPaused && PAUSED_BLOCKED_TYPES.has(msg.type as string)) {
       send(ws, { kind: 'error', text: 'account paused' });
-      if (msg.clientId && (msg.type === 'send' || msg.type === 'action')) {
+      if (msg.clientId && (msg.type === 'send' || msg.type === 'action' || msg.type === 'notice')) {
         send(ws, {
           kind: 'send-result',
           clientId: msg.clientId,
@@ -1158,12 +1161,14 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         break;
       }
       case 'notice': {
-        // Fire-and-forget like 'raw': the verb sends the NOTICE and publishes a
-        // self-copy that fans out to every tab, so there's no optimistic bubble
-        // to resolve and no send-result to return. A closed/paused connection
-        // just yields { ok:false } we ignore here, matching raw's best-effort.
+        // The verb sends the NOTICE and publishes a self-copy that fans out to
+        // every tab, so there's no optimistic bubble — but we still resolve the
+        // originating tab's ACK on clientId (like send/action) so a not-connected
+        // or validation failure surfaces as a toast instead of the input just
+        // clearing with nothing happening.
+        let result: { ok: boolean; error?: string };
         try {
-          callVerb(
+          result = callVerb(
             'send_notice',
             { userId, scope: 'read-write', transport: 'ws' },
             {
@@ -1171,9 +1176,17 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
               target: msg.target,
               text: msg.text,
             },
-          );
-        } catch {
-          /* not-connected / empty — best-effort, nothing to surface */
+          ) as { ok: boolean; error?: string };
+        } catch (err) {
+          result = { ok: false, error: (err as NodeJS.ErrnoException).code || 'error' };
+        }
+        if (msg.clientId) {
+          send(ws, {
+            kind: 'send-result',
+            clientId: msg.clientId,
+            ok: !!result.ok,
+            error: result.ok ? undefined : result.error,
+          });
         }
         break;
       }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -103,6 +103,7 @@ type WsPayload = Record<string, unknown>;
 const PAUSED_BLOCKED_TYPES = new Set([
   'send',
   'action',
+  'notice',
   'join',
   'open-buffer',
   'close-buffer',
@@ -1153,6 +1154,26 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
             ok: !!result.ok,
             error: result.ok ? undefined : result.error,
           });
+        }
+        break;
+      }
+      case 'notice': {
+        // Fire-and-forget like 'raw': the verb sends the NOTICE and publishes a
+        // self-copy that fans out to every tab, so there's no optimistic bubble
+        // to resolve and no send-result to return. A closed/paused connection
+        // just yields { ok:false } we ignore here, matching raw's best-effort.
+        try {
+          callVerb(
+            'send_notice',
+            { userId, scope: 'read-write', transport: 'ws' },
+            {
+              networkId: msg.networkId,
+              target: msg.target,
+              text: msg.text,
+            },
+          );
+        } catch {
+          /* not-connected / empty — best-effort, nothing to surface */
         }
         break;
       }

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -107,6 +107,9 @@ declare module 'irc-framework' {
     /** Send a CTCP ACTION (/me). */
     action(target: string, message: string): void;
 
+    /** Send a NOTICE. */
+    notice(target: string, message: string, tags?: Record<string, string>): void;
+
     /** Send a TAGMSG (IRCv3 message tags with no visible text). */
     tagmsg(target: string, tags?: Record<string, string>): void;
 

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -16,7 +16,6 @@
         <span class="prefix">{{ prefixOf(m) }}</span>
         <span class="nick" :style="nickStyle(m)" :title="nickOf(m)">{{ nickOf(m) }}</span>
         <button
-          v-if="!isSelf(m)"
           type="button"
           class="row-actions"
           title="Actions"
@@ -117,15 +116,15 @@ function menuContext() {
   };
 }
 function onRowClick(e: MouseEvent, m: BufferMember): void {
-  if (!buffer.value || isSelf(m)) return;
+  if (!buffer.value) return;
   memberActions.openMenuFor(m, menuContext(), e.clientX, e.clientY);
 }
 function onRowContextMenu(e: MouseEvent, m: BufferMember): void {
-  if (!buffer.value || isSelf(m)) return;
+  if (!buffer.value) return;
   memberActions.openMenuFor(m, menuContext(), e.clientX, e.clientY);
 }
 function onActionsClick(e: MouseEvent, m: BufferMember): void {
-  if (!buffer.value || isSelf(m)) return;
+  if (!buffer.value) return;
   memberActions.openMenuFromButton(m, menuContext(), e.currentTarget as Element);
 }
 function prefixOf(m: BufferMember): string {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2046,8 +2046,10 @@ function handleCommand(line: string, networkId: number, target: string): boolean
     case 'cycle':
     case 'hop': {
       // Part then immediately rejoin the CURRENT channel; the whole arg line is
-      // an optional part reason. IRC processes the two lines in order, so no
-      // rejoin race.
+      // an optional part reason. Both legs go through the structured part/join
+      // WS types — NOT a raw JOIN — so the persisted joined flag flips false and
+      // back to true. A raw JOIN bypasses ircManager.joinChannel and would leave
+      // joined=false in the DB, breaking reconnect auto-join after a cycle.
       if (!isChannelTarget(target)) {
         localInfo(networkId, target, 'usage: /cycle [reason] — run inside a channel');
         return true;
@@ -2055,12 +2057,15 @@ function handleCommand(line: string, networkId: number, target: string): boolean
       if (!sendOrToast({ type: 'part', networkId, channel: target, reason: argLine }, line)) {
         return false;
       }
-      return sendOrToast({ type: 'raw', networkId, line: `JOIN ${target}` }, line);
+      return sendOrToast({ type: 'join', networkId, channel: target }, line);
     }
     case 'notice': {
       // Routed through the server's send_notice verb (not a raw NOTICE) so it
       // publishes a self-copy back to every tab — IRC servers don't echo your
       // own NOTICE, so a raw forward would vanish with nothing in the buffer.
+      // ackedSend (not sendOrToast) so a not-connected / validation failure
+      // surfaces as a toast instead of silently clearing the input — there's no
+      // optimistic bubble, the server's self-publish is what renders on success.
       const who = rest[0];
       // Preserve the body's internal spacing by slicing past the target rather
       // than re-joining the \s+-split rest (mirrors /topic).
@@ -2073,7 +2078,7 @@ function handleCommand(line: string, networkId: number, target: string): boolean
         localInfo(networkId, target, 'usage: /notice <target> <text>');
         return true;
       }
-      return sendOrToast({ type: 'notice', networkId, target: who, text: body }, body);
+      return ackedSend({ type: 'notice', networkId, target: who, text: body }, body);
     }
     case 'slap': {
       // mIRC's classic: a CTCP ACTION with the canonical trout line, so it rides

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1613,7 +1613,9 @@ function localInfo(networkId: number, target: string, lineText: string): void {
 const HELP_LINES = [
   'commands:',
   '  /me <text>             — emote in the current buffer',
+  '  /slap <nick>           — slap someone around a bit with a large trout',
   '  /msg <nick> <text>     — open a DM and send (alias: /query)',
+  '  /notice <tgt> <text>   — send a NOTICE to a channel or nick',
   '  /ns <text>             — message NickServ (e.g. identify <pass>)',
   '  /cs <text>             — message ChanServ',
   '  /join <#chan>          — join a channel',
@@ -1624,12 +1626,18 @@ const HELP_LINES = [
   '  /back                  — clear away',
   '  /whois <nick>          — query user info (renders in server buffer)',
   '  /kick <nick> [reason]  — kick from current channel',
+  '  /kickban <nick> [msg]  — kick and ban in one step',
+  '  /op <nick…>            — give op (also /deop /voice /devoice /halfop /dehalfop)',
+  '  /ban <nick|mask>       — ban (also /unban /quiet /unquiet)',
+  '  /cycle [reason]        — part and rejoin this channel (alias: /hop)',
   '  /mode <target> <flags> — set modes (target defaults to current channel)',
   '  /topic [text]          — set/clear topic on current channel',
   '  /nick <newnick>        — change your nick',
   '  /quit [reason]         — disconnect from current network',
   '  /reconnect             — reconnect to current network',
   '  /list                  — list channels on current network',
+  '  /who [mask]            — find users (also /whowas /userhost /ison /names)',
+  '  /motd /version /time   — server info (also /admin /info /lusers /links /map /stats)',
   '  /jitsi                 — start a video call (alias: /talk)',
   '  /ignore [mask]         — list current ignores, or add (nick or nick!user@host)',
   '  /unignore <mask>       — remove an ignore entry',
@@ -1640,6 +1648,41 @@ const HELP_LINES = [
 
 function isChannelTarget(t: string): boolean {
   return typeof t === 'string' && t.startsWith('#');
+}
+
+// Shared builder for the op/voice/ban-family MODE shortcuts (/op, /voice, /ban,
+// …). The channel defaults to the current buffer; an explicit #chan may lead
+// the args (so `/op #other alice` works from anywhere). Each nick/mask consumes
+// one mode letter, so `/op a b` → `MODE #c +oo a b`. Bare nicks passed to +b/+q
+// are left verbatim — ircds auto-complete them to `nick!*@*`.
+function modeShortcut(
+  networkId: number,
+  target: string,
+  rest: string[],
+  sign: '+' | '-',
+  letter: string,
+  usage: string,
+  line: string,
+): boolean {
+  let channel = isChannelTarget(target) ? target : null;
+  let args = rest;
+  if (rest[0] && rest[0].startsWith('#')) {
+    channel = rest[0];
+    args = rest.slice(1);
+  }
+  if (!channel) {
+    localInfo(networkId, target, `${usage} — no channel context`);
+    return true;
+  }
+  if (!args.length) {
+    localInfo(networkId, target, usage);
+    return true;
+  }
+  const flags = sign + letter.repeat(args.length);
+  return sendOrToast(
+    { type: 'raw', networkId, line: `MODE ${channel} ${flags} ${args.join(' ')}` },
+    line,
+  );
 }
 
 function randomRoomId(): string {
@@ -1897,6 +1940,181 @@ function handleCommand(line: string, networkId: number, target: string): boolean
       }
       const url = `https://meet.jit.si/lurker-${randomRoomId()}`;
       return ackedSend({ type: 'send', networkId, target, text: url }, url);
+    }
+    case 'op':
+      return modeShortcut(networkId, target, rest, '+', 'o', 'usage: /op [#chan] <nick…>', line);
+    case 'deop':
+      return modeShortcut(networkId, target, rest, '-', 'o', 'usage: /deop [#chan] <nick…>', line);
+    case 'voice':
+      return modeShortcut(networkId, target, rest, '+', 'v', 'usage: /voice [#chan] <nick…>', line);
+    case 'devoice':
+      return modeShortcut(
+        networkId,
+        target,
+        rest,
+        '-',
+        'v',
+        'usage: /devoice [#chan] <nick…>',
+        line,
+      );
+    case 'halfop':
+      return modeShortcut(
+        networkId,
+        target,
+        rest,
+        '+',
+        'h',
+        'usage: /halfop [#chan] <nick…>',
+        line,
+      );
+    case 'dehalfop':
+      return modeShortcut(
+        networkId,
+        target,
+        rest,
+        '-',
+        'h',
+        'usage: /dehalfop [#chan] <nick…>',
+        line,
+      );
+    case 'ban':
+      return modeShortcut(
+        networkId,
+        target,
+        rest,
+        '+',
+        'b',
+        'usage: /ban [#chan] <nick|mask>',
+        line,
+      );
+    case 'unban':
+      return modeShortcut(networkId, target, rest, '-', 'b', 'usage: /unban [#chan] <mask>', line);
+    case 'quiet':
+      return modeShortcut(
+        networkId,
+        target,
+        rest,
+        '+',
+        'q',
+        'usage: /quiet [#chan] <nick|mask>',
+        line,
+      );
+    case 'unquiet':
+      return modeShortcut(
+        networkId,
+        target,
+        rest,
+        '-',
+        'q',
+        'usage: /unquiet [#chan] <mask>',
+        line,
+      );
+    case 'kickban': {
+      // Ban first (so they can't instantly rejoin), then kick. A leading #chan
+      // is optional; otherwise the current channel is used.
+      let channel = isChannelTarget(target) ? target : null;
+      let args = rest;
+      if (rest[0] && rest[0].startsWith('#')) {
+        channel = rest[0];
+        args = rest.slice(1);
+      }
+      if (!channel) {
+        localInfo(
+          networkId,
+          target,
+          'usage: /kickban [#chan] <nick> [reason] — no channel context',
+        );
+        return true;
+      }
+      const nick = args[0];
+      if (!nick) {
+        localInfo(networkId, target, 'usage: /kickban [#chan] <nick> [reason]');
+        return true;
+      }
+      const reason = args.slice(1).join(' ');
+      const trailer = reason ? ` :${reason}` : '';
+      // The ban send returns false only if the socket is closed — skip the KICK
+      // so we don't half-apply against a dead connection.
+      if (!sendOrToast({ type: 'raw', networkId, line: `MODE ${channel} +b ${nick}` }, line)) {
+        return false;
+      }
+      return sendOrToast(
+        { type: 'raw', networkId, line: `KICK ${channel} ${nick}${trailer}` },
+        line,
+      );
+    }
+    case 'cycle':
+    case 'hop': {
+      // Part then immediately rejoin the CURRENT channel; the whole arg line is
+      // an optional part reason. IRC processes the two lines in order, so no
+      // rejoin race.
+      if (!isChannelTarget(target)) {
+        localInfo(networkId, target, 'usage: /cycle [reason] — run inside a channel');
+        return true;
+      }
+      if (!sendOrToast({ type: 'part', networkId, channel: target, reason: argLine }, line)) {
+        return false;
+      }
+      return sendOrToast({ type: 'raw', networkId, line: `JOIN ${target}` }, line);
+    }
+    case 'notice': {
+      // Routed through the server's send_notice verb (not a raw NOTICE) so it
+      // publishes a self-copy back to every tab — IRC servers don't echo your
+      // own NOTICE, so a raw forward would vanish with nothing in the buffer.
+      const who = rest[0];
+      // Preserve the body's internal spacing by slicing past the target rather
+      // than re-joining the \s+-split rest (mirrors /topic).
+      const body = line
+        .slice(1 + cmd.length)
+        .trim()
+        .slice(who?.length ?? 0)
+        .trim();
+      if (!who || !body) {
+        localInfo(networkId, target, 'usage: /notice <target> <text>');
+        return true;
+      }
+      return sendOrToast({ type: 'notice', networkId, target: who, text: body }, body);
+    }
+    case 'slap': {
+      // mIRC's classic: a CTCP ACTION with the canonical trout line, so it rides
+      // the same path as /me into the current channel or DM.
+      if (isServer.value) {
+        localInfo(networkId, target, 'usage: /slap <nick> — run inside a channel or DM');
+        return true;
+      }
+      const who = rest[0];
+      if (!who) {
+        localInfo(networkId, target, 'usage: /slap <nick>');
+        return true;
+      }
+      const slapText = `slaps ${who} around a bit with a large trout`;
+      return ackedSend({ type: 'action', networkId, target, text: slapText }, slapText);
+    }
+    // Info/query commands. These already function via the raw fallback now that
+    // unhandled server numerics surface in the server buffer (#269) — listing
+    // them explicitly uppercases the verb, documents them in /help, and gives a
+    // single home for any future per-command argument handling. Each forwards
+    // its IRC verb plus whatever args were typed (server/target/mask/nick…); a
+    // missing-arg server error (e.g. bare /whowas) now surfaces on its own.
+    case 'time':
+    case 'version':
+    case 'motd':
+    case 'names':
+    case 'who':
+    case 'whowas':
+    case 'admin':
+    case 'info':
+    case 'lusers':
+    case 'links':
+    case 'map':
+    case 'stats':
+    case 'userhost':
+    case 'ison': {
+      const verb = cmd.toUpperCase();
+      return sendOrToast(
+        { type: 'raw', networkId, line: argLine ? `${verb} ${argLine}` : verb },
+        line,
+      );
     }
     case 'help':
       for (const helpLine of HELP_LINES) localInfo(networkId, target, helpLine);

--- a/vue_client/src/composables/useMemberActions.ts
+++ b/vue_client/src/composables/useMemberActions.ts
@@ -102,40 +102,48 @@ export function useMemberActions(): MemberActionsAPI {
     member: MemberLike | string | null | undefined,
     ctx: MemberContext | null | undefined,
   ): ContextMenuItem[] {
-    if (!member || !ctx || ctx.isSelf(member)) return [];
+    if (!member || !ctx) return [];
     const nick = nickOf(member);
+    const isSelf = ctx.isSelf(member);
     const hasNote = nickNotes.hasNote(ctx.networkId, nick);
+    // Self gets a trimmed menu: you can view your own profile and note yourself,
+    // but Send DM, Ignore, and the moderation actions are all meaningless or
+    // nonsensical aimed at yourself, so they're left off below.
     const items: ContextMenuItem[] = [
       {
         label: 'View Profile…',
         icon: 'fa-solid fa-id-card',
         onClick: () => whois.openViewer(ctx.networkId, nick),
       },
-      {
+    ];
+    if (!isSelf) {
+      items.push({
         label: 'Send DM',
         icon: 'fa-solid fa-envelope',
         onClick: () => buffers.activate(ctx.networkId, nick),
-      },
-      {
-        label: hasNote ? 'Edit Note…' : 'Add Note…',
-        icon: 'fa-solid fa-note-sticky',
-        onClick: () => nickNotes.openEditor(ctx.networkId, nick),
-      },
-      {
+      });
+    }
+    items.push({
+      label: hasNote ? 'Edit Note…' : 'Add Note…',
+      icon: 'fa-solid fa-note-sticky',
+      onClick: () => nickNotes.openEditor(ctx.networkId, nick),
+    });
+    if (!isSelf) {
+      items.push({
         label: 'Ignore…',
         icon: 'fa-solid fa-ban',
         onClick: () => ctx.onIgnore(member),
-      },
-    ];
+      });
+    }
 
     // Channel-operator actions, gated on the current user's own modes in this
     // channel. Each sends a raw IRC line and lets the server's MODE/KICK echo
     // update state — the same path the /kick and /mode slash commands use, so
-    // no optimistic mutation here.
+    // no optimistic mutation here. Never offered against yourself.
     const channel =
       typeof ctx.channel === 'string' && ctx.channel.startsWith('#') ? ctx.channel : null;
     const selfModes = Array.isArray(ctx.selfModes) ? ctx.selfModes : [];
-    if (channel && hasAny(selfModes, MODERATE_MODES)) {
+    if (!isSelf && channel && hasAny(selfModes, MODERATE_MODES)) {
       const networkId = ctx.networkId;
       const targetModes = modesOf(member);
       const send = (l: string) => socketSend({ type: 'raw', networkId, line: l });


### PR DESCRIPTION
Fleshes out slash-command coverage toward standard IRC clients (closes #263) and adds the mIRC `/slap` (closes #266). Also folds in a small nicklist self-menu fix (see below).

## Client (`MessageInput.vue`)

**Mode / moderation shortcuts** (pure client-side raw MODE/KICK builders):
- `/op` `/deop` `/voice` `/devoice` `/halfop` `/dehalfop` — via a shared `modeShortcut()` helper. Channel defaults to the current buffer; a leading `#chan` is accepted. One mode letter per nick, so `/op a b` → `MODE #c +oo a b`.
- `/ban` `/unban` `/quiet` `/unquiet` — same helper; bare nicks are left verbatim for the ircd to auto-complete to `nick!*@*`.
- `/kickban <nick> [reason]` — bans then kicks, skipping the kick if the socket is closed so it never half-applies.
- `/cycle` (alias `/hop`) — part + rejoin the current channel.

**Messaging:**
- `/slap <nick>` — CTCP ACTION trout line, rides the `/me` path.
- `/notice <target> <text>` — see below.

**Info / query block** — `/time` `/version` `/motd` `/names` `/who` `/whowas` `/admin` `/info` `/lusers` `/links` `/map` `/stats` `/userhost` `/ison`. One shared `case` that uppercases the verb and forwards args. These work now that unhandled server numerics surface in the server buffer (#269) — the explicit cases add `/help` discoverability and a single home for future per-command handling. A missing-arg server error (e.g. bare `/whowas`) now surfaces on its own.

`HELP_LINES` updated throughout (the 14 info commands folded into two grouped lines so `/help` doesn't balloon). There's no slash-command tab-completion today, so nothing to sync there.

## `/notice` is server-routed on purpose

IRC servers don't echo your own NOTICE back, and Lurker doesn't request the `echo-message` cap — so a raw `NOTICE` forward would vanish with nothing in the buffer. Instead `/notice` goes through a new `send_notice` verb that sends the NOTICE **and** publishes a `self: true` copy that fans out to every tab, exactly mirroring how `send`/`action` already echo. This is the forward-compatible shape for a future `echo-message` capability (which would reconcile the same self-copy by label rather than dropping it).

## Server

- `ircConnection.notice()` wrapper + `irc-framework.d.ts` type.
- `ircManager.notice()` — splits like `send()` and self-publishes a `notice` per wire chunk.
- `send_notice` verb (+ registry import); `wsHub` `'notice'` dispatch and `PAUSED_BLOCKED_TYPES` entry.

## Nicklist self-menu

You previously couldn't click your own row in the member list — the menu built empty for self, the three-dots affordance was hidden, and the row handlers bailed on `isSelf`. Now clicking yourself opens a trimmed menu: **View Profile…** and **Add/Edit Note…**. `Send DM`, `Ignore…`, and the operator actions (op/voice/kick/ban) stay off, since they're meaningless or nonsensical aimed at yourself. The "self is always visible" nicklist filter is unchanged. (`useMemberActions` is consumed only by `MemberList`, so this is contained to the nicklist — clicking nicks in messages goes through a separate path.)

## Tests / checks

- New `send_notice` verb tests (not-connected / read-only scope / empty-arg).
- MCP surface assertion updated (`send_notice` now advertised alongside `send_message`/`send_action`).
- `typecheck` + `typecheck:client` + `lint` + `format` clean; full suite **844/844** green.

Not run live (dev server hits a real IRC connection); verified by typecheck/lint/tests.

## Out of scope (deferred from #263)

`/oper`, `/setname` (SETNAME-cap trailing-colon format), `/knock` (ties into #260), `/remove`, and the oper-only `/sa*`/`/kill`/`/rehash` (low priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)