### PR TITLE
Fix broken invite links: don't bounce public-page 401s to login

### DIFF
--- a/vue_client/src/api.test.ts
+++ b/vue_client/src/api.test.ts
@@ -6,23 +6,32 @@ import { shouldBounceToLogin } from './api.js';
 
 describe('shouldBounceToLogin', () => {
   it('bounces to sign-in on a 401 from a normal authed call', () => {
-    expect(shouldBounceToLogin('/api/networks', 401, false)).toBe(true);
-    expect(shouldBounceToLogin('/api/buffers/1', 401, false)).toBe(true);
+    expect(shouldBounceToLogin('/api/networks', 401, false, '/')).toBe(true);
+    expect(shouldBounceToLogin('/api/buffers/1', 401, false, '/settings/account')).toBe(true);
   });
 
   it('does not bounce on non-401 statuses', () => {
-    expect(shouldBounceToLogin('/api/networks', 403, false)).toBe(false);
-    expect(shouldBounceToLogin('/api/networks', 500, false)).toBe(false);
-    expect(shouldBounceToLogin('/api/networks', 200, false)).toBe(false);
+    expect(shouldBounceToLogin('/api/networks', 403, false, '/')).toBe(false);
+    expect(shouldBounceToLogin('/api/networks', 500, false, '/')).toBe(false);
+    expect(shouldBounceToLogin('/api/networks', 200, false, '/')).toBe(false);
   });
 
   it('bounces at most once per tab', () => {
-    expect(shouldBounceToLogin('/api/networks', 401, true)).toBe(false);
+    expect(shouldBounceToLogin('/api/networks', 401, true, '/')).toBe(false);
   });
 
   it('ignores auth + control-plane endpoints (they 401 by design before sign-in)', () => {
-    expect(shouldBounceToLogin('/api/auth/me', 401, false)).toBe(false);
-    expect(shouldBounceToLogin('/api/auth/login', 401, false)).toBe(false);
-    expect(shouldBounceToLogin('/_cp/auth/logout', 401, false)).toBe(false);
+    expect(shouldBounceToLogin('/api/auth/me', 401, false, '/')).toBe(false);
+    expect(shouldBounceToLogin('/api/auth/login', 401, false, '/')).toBe(false);
+    expect(shouldBounceToLogin('/_cp/auth/logout', 401, false, '/')).toBe(false);
+  });
+
+  it('does not bounce off a public page — App.vue settings/config fetches 401 by design when logged out', () => {
+    // The invite-link regression: a logged-out visitor on /invite/<token> would
+    // otherwise be ejected to /login?next=/ by the background /api/settings 401.
+    expect(shouldBounceToLogin('/api/settings/bootstrap', 401, false, '/invite/abc123')).toBe(
+      false,
+    );
+    expect(shouldBounceToLogin('/api/settings/bootstrap', 401, false, '/login')).toBe(false);
   });
 });

--- a/vue_client/src/api.ts
+++ b/vue_client/src/api.ts
@@ -16,15 +16,31 @@ export interface ApiRequestOptions {
 // One-shot guard so an unrecoverable 401 can't loop the page reload.
 const AUTH_RECOVERY_FLAG = 'lurker:authRecoveryAttempted';
 
+// Public routes that render without a session (mirror router.ts). A background
+// 401 while sitting on one of these is the expected "not signed in yet" state,
+// NOT a stale session — bouncing would eject an invite/sign-in visitor to
+// `/login?next=/` before their page can even mount.
+function isPublicPath(pathname: string): boolean {
+  return pathname === '/login' || pathname.startsWith('/invite/');
+}
+
 // Pure decision (exported for tests): a 401 from a normal authed call means the
 // session is dead — on a hosted cell the cell has already cleared the stale
 // lurker_session + cp_session, so we send the user back to `/` to sign in again.
 // Skip the auth / control-plane endpoints (they 401 by design before sign-in),
-// and only bounce once per tab so a genuinely-unrecoverable 401 falls through to
-// the app's normal logged-out handling instead of reloading forever.
-export function shouldBounceToLogin(url: string, status: number, alreadyTried: boolean): boolean {
+// skip 401s on a public page (App.vue fires settings/config fetches on every
+// route, including /invite — those 401 by design when logged out), and only
+// bounce once per tab so a genuinely-unrecoverable 401 falls through to the
+// app's normal logged-out handling instead of reloading forever.
+export function shouldBounceToLogin(
+  url: string,
+  status: number,
+  alreadyTried: boolean,
+  pathname: string,
+): boolean {
   if (status !== 401 || alreadyTried) return false;
   if (url.startsWith('/api/auth/') || url.startsWith('/_cp/')) return false;
+  if (isPublicPath(pathname)) return false;
   return true;
 }
 
@@ -35,7 +51,7 @@ function bounceToLoginOnAuthFailure(url: string, status: number): void {
   } catch {
     return; // no sessionStorage (private-mode edge) → don't risk a reload loop
   }
-  if (!shouldBounceToLogin(url, status, alreadyTried)) return;
+  if (!shouldBounceToLogin(url, status, alreadyTried, window.location.pathname)) return;
   try {
     sessionStorage.setItem(AUTH_RECOVERY_FLAG, '1');
   } catch {


### PR DESCRIPTION
## The bug

Hitting a standalone invite link like `https://irc.bradroot.me/invite/<token>` logged out immediately redirects to `/login?next=/`, so nobody can sign up with their invite. Reproducible locally.

## Root cause

A regression from #233 (`a4c00fa`, cell stale-session recovery). That PR added a global 401 handler in `vue_client/src/api.ts` (`bounceToLoginOnAuthFailure`) that sends the user to `/` on **any** 401 outside `/api/auth/` and `/_cp/`, to recover a hosted cell whose `SESSION_SECRET` rotated.

But `App.vue`'s `onMounted` runs on **every** route — including `/invite/<token>` — and fires `settings.fetchAll()` → `GET /api/settings/bootstrap`, which is `requireAuth`. Logged out, that 401s by design. The bounce then:

1. `window.location.assign('/')`
2. lands on `/` (a `requiresAuth` route, no user)
3. router guard → `/login?next=/`

The invite view's own `/api/auth/invite/...` call is excluded from the bounce, but the settings 401 races ahead and ejects the visitor before the invite view mounts. The `next=/` — not `next=/invite/...` — is the tell: the redirect fires from `/`, after the assign, not from the invite route. It looks invite-specific only because on `/login` the same bounce lands you right back on login, invisibly.

## The fix

The recovery bounce is for an *authenticated* user whose session went stale — it must not fire on a public page, where a background 401 just means "not signed in yet." `shouldBounceToLogin` now takes the current pathname and suppresses the bounce on `/login` and `/invite/` (mirroring the public routes in `router.ts`). The real DR recovery on `/` and `/settings/...` is unchanged.

Cell/node mode disables invites entirely, so this is standalone-only.

## Test

- Extended the `shouldBounceToLogin` unit test with the public-page regression case.
- `npm run typecheck:client`, `oxlint`, `oxfmt --check`, and the api test all pass.
- Manual: logged out, `/invite/<token>` now renders the signup form instead of bouncing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)