### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@simplewebauthn/server": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts a patch release, **v1.0.1**, covering the updates landed since v1.0.0 — most notably the new **Friends list** buffer.

Bumps the version in all four spots so it's consistent across both packages and their lockfiles:

- `package.json` (root) → feeds the server's `APP_VERSION` (`server/utils/userAgent.ts`, used in the HTTP User-Agent, CTCP VERSION, and orchestrator/node registration payloads)
- `vue_client/package.json` → feeds the client's build-time `APP_VERSION` (`vue_client/vite.config.ts`)
- `package-lock.json` + `vue_client/package-lock.json` → version field only, no dependency churn

## Notes

Version-only change; no code or dependency changes. Tag `v1.0.1` can be cut from `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)