### PR TITLE
Status bar & input bar layout fixes + mobile polish

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2110,8 +2110,9 @@ function handleCommand(line: string, networkId: number, target: string): boolean
 <style scoped>
 .input {
   display: flex;
-  /* flex-start so the prompt label and send button stay pinned to the
-     first line as the textarea grows downward across multiple lines. */
+  /* flex-start so the prompt label stays pinned to the first line as the
+     textarea grows downward across multiple lines. The send button overrides
+     this (align-self: flex-end) to track the bottom of the input area. */
   align-items: flex-start;
   gap: 1ch;
   padding: var(--space-4) var(--space-6);
@@ -2164,6 +2165,9 @@ function handleCommand(line: string, networkId: number, target: string): boolean
   padding: 0 var(--space-1);
   font-size: inherit;
   line-height: 1.4;
+  /* Stick to the bottom of the input area as the textarea grows multi-line,
+     instead of riding the first line with the prompt (issue #295). */
+  align-self: flex-end;
 }
 .send-btn:hover:not(:disabled) {
   color: var(--accent);

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -253,12 +253,13 @@ const placeholder = computed(() => {
   // server buffer is exactly where someone goes looking for it.
   if (isServer.value) return 'try /help';
   // Mobile shows network/channel in the compact status bar now, so the
-  // placeholder carries the self identity (nick + channel-prefix + user modes)
-  // instead, with the away marker appended when set — mirroring what the input
-  // prompt renders on desktop. Desktop keeps `try /help` since the prompt
+  // placeholder carries the self identity (nick + channel-prefix) instead, with
+  // the away marker appended when set. User modes are dropped here to match the
+  // compact status bar hiding channel modes on narrow screens; the desktop
+  // prompt still renders them. Desktop keeps `try /help` since the prompt
   // already shows the identity there.
   if (isMobile.value) {
-    const self = promptLabel.value;
+    const self = promptLabelNoModes.value;
     return awayLabel.value ? `${self} ${awayLabel.value}` : self;
   }
   return 'try /help';
@@ -285,9 +286,9 @@ const systemFeatures = computed(() => {
 // Prompt identity (nick + channel prefix + user modes) and away marker — see
 // useSelfLabel. On mobile we don't render the prompt label inline here (the
 // template gates it on !isMobile so the input row stays just `>` + composer);
-// instead it feeds the placeholder above, since the compact status bar now
-// shows network/channel rather than the self identity.
-const { promptLabel, awayLabel } = useSelfLabel();
+// instead the modeless variant feeds the placeholder above, since the compact
+// status bar now shows network/channel rather than the self identity.
+const { promptLabel, promptLabelNoModes, awayLabel } = useSelfLabel();
 const { isMobile } = useViewport();
 
 let typingState: string | null = null;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -51,7 +51,7 @@
         }}</span>
         <span v-if="splitLabel" class="seg split" :class="splitClass">{{ splitLabel }}</span>
         <span v-if="typingSegments.length" class="seg typing"
-          ><i class="fa-regular fa-keyboard" title="Typing"></i>
+          ><i class="fa-regular fa-keyboard" role="img" aria-label="Typing" title="Typing"></i>
           <template v-for="(seg, i) in typingSegments" :key="i"
             ><span :style="seg.color ? { color: seg.color } : null">{{ seg.text }}</span></template
           ></span
@@ -69,6 +69,7 @@
           class="tool-btn"
           :disabled="!sendable"
           title="upload image"
+          aria-label="upload image"
           @click="onPickFile"
         >
           <i class="fa-solid fa-paperclip"></i>
@@ -82,6 +83,7 @@
           class="tool-btn"
           :disabled="!sendable"
           title="mIRC formatting (Cmd/Ctrl+B/I/U for bold/italic/underline)"
+          aria-label="mIRC formatting"
           @mousedown.prevent
           @click="onToggleColorPicker"
         >

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -385,7 +385,7 @@ function onReturnToPresent() {
 }
 
 const unreadArrow = computed(() => (unreadAnchor.value === 'down' ? '↓' : '↑'));
-const jumpUnreadLabel = computed(() => `Jump to unread ${unreadArrow.value}`);
+const jumpUnreadLabel = computed(() => `Unread ${unreadArrow.value}`);
 
 function onJumpToUnread() {
   requestScrollToUnread();

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -19,9 +19,16 @@
            when it's off-screen and the user hasn't scrolled it into view yet
            this visit. Renders in both modes — catching up matters as much on
            mobile. -->
-        <button v-if="unreadAnchor" class="seg jump-unread" type="button" @click="onJumpToUnread">
-          Jump to unread {{ unreadArrow }}
-        </button>
+        <!-- Label bound via v-text (not inline text) so the formatter can't put
+             content on its own indented line, whose newline would render as a
+             stray leading space after the `|` separator pseudo-element. -->
+        <button
+          v-if="unreadAnchor"
+          class="seg jump-unread"
+          type="button"
+          v-text="jumpUnreadLabel"
+          @click="onJumpToUnread"
+        ></button>
         <!-- Return-to-present: the single downward affordance. Shows whenever the
            buffer is detached (viewing a historical slice) OR the user has
            scrolled up off the live tail; the count badge reflects whichever
@@ -32,11 +39,9 @@
           v-if="showPresent"
           class="seg return-present"
           type="button"
+          v-text="returnPresentLabel"
           @click="onReturnToPresent"
-        >
-          Return to present<template v-if="presentCount > 0"> ({{ presentCount }} new)</template>
-          ↓
-        </button>
+        ></button>
         <span v-if="peerStatusLabel" class="seg peer-status" :class="peerStatusClass">{{
           peerStatusLabel
         }}</span>
@@ -359,6 +364,13 @@ const showPresent = computed(() => detached.value || !stuckToBottom.value);
 // Count badge: messages that arrived while detached, else the live unread-
 // below count tracked by the scroll state.
 const presentCount = computed(() => (detached.value ? liveDuringDetach.value : newBelow.value));
+// Built as a single string (and bound with v-text in the template) rather than
+// inline template text so no formatter-injected indentation whitespace can
+// leak into the rendered label — see the button markup for why that matters.
+const returnPresentLabel = computed(() => {
+  const count = presentCount.value > 0 ? ` (${presentCount.value} new)` : '';
+  return `Return to present${count} ↓`;
+});
 
 function onReturnToPresent() {
   const buf = buffer.value;
@@ -373,6 +385,7 @@ function onReturnToPresent() {
 }
 
 const unreadArrow = computed(() => (unreadAnchor.value === 'down' ? '↓' : '↑'));
+const jumpUnreadLabel = computed(() => `Jump to unread ${unreadArrow.value}`);
 
 function onJumpToUnread() {
   requestScrollToUnread();
@@ -422,6 +435,12 @@ function onToggleColorPicker() {
   flex: 1 1 auto;
   white-space: nowrap;
   overflow: hidden;
+  /* Segments live here now (the send-button PR moved them out of `.bar`).
+     The `|` separators get their right-side space from the `::before`
+     margin, but rely on this gap for the matching left-side space — without
+     it the pipe sits flush against the previous segment and floats off the
+     next one. Mirrors the `gap` `.bar` carries between main + tools. */
+  gap: 1ch;
 }
 .bar-tools {
   display: flex;
@@ -441,8 +460,12 @@ function onToggleColorPicker() {
 .seg.clock {
   color: var(--fg-muted);
 }
+/* Shrink-only (grow: 0): the buffer name takes its natural width and lets the
+   segments after it (peer-status/lag/upload/split/typing) pack immediately to
+   its right — left-aligned — instead of being shoved against the tool buttons.
+   It still shrinks + ellipsis-truncates when the row is too tight to fit. */
 .seg.buffer {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   color: var(--fg-muted);
   min-width: 0;
   overflow: hidden;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -511,6 +511,11 @@ function onToggleColorPicker() {
 .seg.split.bad {
   color: var(--bad);
 }
+/* Keyboard glyph standing in for the old "Typing:" label — nudge it off the
+   first nick (a bare inline space sits too tight against the icon). */
+.seg.typing i {
+  margin-right: 0.5ch;
+}
 .seg.jump-unread,
 .seg.return-present {
   background: none;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -58,18 +58,24 @@
         >
       </div>
       <div class="bar-tools">
-        <!-- @mousedown.prevent keeps the composer focused (and the iOS keyboard
-             up) when tapping these tools — same affordance as the send button. -->
+        <!-- No @mousedown.prevent here (unlike the palette/send buttons): this
+             opens the native iOS file picker, which dismisses the soft keyboard
+             no matter what. Preventing the tap-blur only delays that dismissal a
+             beat — keyboard stays up, then drops as the picker sheet animates in
+             — which reads as jank. Letting the tap blur gives one clean
+             dismissal instead. -->
         <button
           type="button"
           class="tool-btn"
           :disabled="!sendable"
           title="upload image"
-          @mousedown.prevent
           @click="onPickFile"
         >
           <i class="fa-solid fa-paperclip"></i>
         </button>
+        <!-- @mousedown.prevent keeps the composer focused (and the iOS keyboard
+             up): this opens the in-app colour picker overlay, not a native
+             sheet, so the keyboard should stay — same affordance as send. -->
         <button
           v-if="showFormatButton"
           type="button"

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -58,11 +58,14 @@
         >
       </div>
       <div class="bar-tools">
+        <!-- @mousedown.prevent keeps the composer focused (and the iOS keyboard
+             up) when tapping these tools — same affordance as the send button. -->
         <button
           type="button"
           class="tool-btn"
           :disabled="!sendable"
           title="upload image"
+          @mousedown.prevent
           @click="onPickFile"
         >
           <i class="fa-solid fa-paperclip"></i>
@@ -73,6 +76,7 @@
           class="tool-btn"
           :disabled="!sendable"
           title="mIRC formatting (Cmd/Ctrl+B/I/U for bold/italic/underline)"
+          @mousedown.prevent
           @click="onToggleColorPicker"
         >
           <i class="fa-solid fa-palette"></i>

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -13,7 +13,7 @@
             ><span v-if="networkLabel" class="net">{{ networkLabel }}/</span
             ><span class="name">{{ targetLabel }}</span></template
           ><span v-else class="name">{{ networkLabel }}</span
-          ><span v-if="modeSuffix" class="modes">{{ modeSuffix }}</span></span
+          ><span v-if="modeSuffix && !compact" class="modes">{{ modeSuffix }}</span></span
         >
         <!-- Jump-to-unread. Scrolls (usually up) to the pinned unread divider
            when it's off-screen and the user hasn't scrolled it into view yet
@@ -51,7 +51,7 @@
         }}</span>
         <span v-if="splitLabel" class="seg split" :class="splitClass">{{ splitLabel }}</span>
         <span v-if="typingSegments.length" class="seg typing"
-          >Typing:
+          ><i class="fa-regular fa-keyboard" title="Typing"></i>
           <template v-for="(seg, i) in typingSegments" :key="i"
             ><span :style="seg.color ? { color: seg.color } : null">{{ seg.text }}</span></template
           ></span
@@ -369,7 +369,7 @@ const presentCount = computed(() => (detached.value ? liveDuringDetach.value : n
 // leak into the rendered label — see the button markup for why that matters.
 const returnPresentLabel = computed(() => {
   const count = presentCount.value > 0 ? ` (${presentCount.value} new)` : '';
-  return `Return to present${count} ↓`;
+  return `Return${count} ↓`;
 });
 
 function onReturnToPresent() {

--- a/vue_client/src/composables/useSelfLabel.ts
+++ b/vue_client/src/composables/useSelfLabel.ts
@@ -8,6 +8,7 @@ import { useBuffersStore } from '../stores/buffers.js';
 
 export interface SelfLabelState {
   promptLabel: ComputedRef<string>;
+  promptLabelNoModes: ComputedRef<string>;
   awayLabel: ComputedRef<string>;
 }
 
@@ -41,14 +42,23 @@ export function useSelfLabel(): SelfLabelState {
     return '';
   });
 
-  const promptLabel = computed(() => {
-    if (!active.value) return '—';
-    const state = networks.states[active.value.networkId];
-    const nick = state?.nick;
+  // Identity without the trailing user-mode parens. Feeds the mobile input
+  // placeholder, which mirrors the compact status bar's choice to drop modes
+  // on narrow screens; the desktop prompt (promptLabel) keeps them.
+  const promptLabelNoModes = computed(() => {
+    const a = active.value;
+    if (!a) return '—';
+    const nick = networks.states[a.networkId]?.nick;
     if (!nick) return '—';
-    const modes = state?.userModes || '';
-    const parens = modes ? `(${modes})` : '';
-    return `${channelPrefix.value}${nick}${parens}`;
+    return `${channelPrefix.value}${nick}`;
+  });
+
+  const promptLabel = computed(() => {
+    const base = promptLabelNoModes.value;
+    const a = active.value;
+    if (!a || base === '—') return base;
+    const modes = networks.states[a.networkId]?.userModes || '';
+    return modes ? `${base}(${modes})` : base;
   });
 
   const awayLabel = computed(() => {
@@ -60,5 +70,5 @@ export function useSelfLabel(): SelfLabelState {
     return away?.active && away.message ? `(${away.message})` : '';
   });
 
-  return { promptLabel, awayLabel };
+  return { promptLabel, promptLabelNoModes, awayLabel };
 }


### PR DESCRIPTION
Started as a fix for the status-bar regressions from the send-button PR (#284) and grew into a small status-bar / input-bar polish pass, mostly for mobile width.

Closes #294. Closes #295.

## Status bar regressions from #284 (closes #294)
- **Segments shoved right:** `.seg.buffer` had `flex: 1 1 auto` and grew to absorb all free space, pushing the temporary segments (peer-status, lag, upload, split, typing) against the tool buttons. → `flex: 0 1 auto` (shrink-only) so they pack left; the name still ellipsis-truncates.
- **Lopsided `|` separators:** the `gap: 1ch` that spaced the separators was left on `.bar` when segments moved into `.bar-main`. → restored on `.bar-main`.
- **Extra space around the scroll buttons:** their `|` is a `::before` pseudo-element, so the formatter's indentation newline rendered as a stray leading space. → labels bound via `v-text` so the buttons have no child text nodes to reflow.

## Mobile width polish
- Condensed the scroll-affordance buttons: **`Return ↓`** (count badge kept, e.g. `Return (3 new) ↓`) and **`Unread ↑`** (dynamic arrow kept).
- Replaced the **`Typing:`** text label with a keyboard glyph (`fa-regular fa-keyboard`) + a small right margin.
- Hide the **channel mode suffix** (`(+nt)`) in compact/mobile mode, matching the clock/lag segments.
- Drop **user modes** from the mobile input placeholder (new `promptLabelNoModes` in `useSelfLabel`); desktop prompt keeps them.

## iOS keyboard affordances (status-bar tools)
- Palette (in-app colour picker overlay): `@mousedown.prevent` keeps the composer focused / keyboard up.
- Paperclip (native file picker): no prevent — iOS dismisses the keyboard for the native sheet regardless, so the prevent only delayed it into a two-step jank. Letting the tap blur gives one clean dismissal.

## Send button position (closes #295)
Send button sticks to the bottom of the input area on multi-line drafts (`align-self: flex-end`) instead of riding the first line; the `>` prompt stays pinned up top.

## Testing
`oxfmt --check`, `vue-tsc`, `oxlint`, and client build all clean. Not yet eyeballed in a running app (no dev server per local workflow) — the CSS/label changes are low-risk, but worth a quick device check of the mobile status-bar width, the multi-line send-button position, and the iOS keyboard behavior on the paperclip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)