### PR TITLE
Unify modal & overlay styling into one floating-surface system

### DIFF
--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -310,6 +310,40 @@ button:disabled {
   }
 }
 
+/* Modal action footer — a toolbar pinned to the bottom of the card. AppModal's
+   card is a flex column with a capped height, so a footer placed as the last
+   flex child (after a flex:1 scrollable body) stays pinned and visible while
+   the body scrolls. One system, promoted out of the per-modal .footer/.actions/
+   .foot copies that had drifted — same move the .btn-* block made in #267.
+
+   Right-aligned by default (the Cancel/Save dialog case). A flex `.spacer`
+   shifts items left for toolbar-style footers (profile, network), and
+   margin-right:auto on a lone destructive button pushes it away from the
+   positive actions. The border-top mirrors the head's divider on the far edge;
+   like the head it stays inset by the card padding rather than breaking out. */
+.modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-4);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border);
+}
+.modal-footer .spacer {
+  flex: 1;
+}
+
+/* A form (or wrapper) that fills the modal card so its own `.modal-footer` pins
+   to the bottom: it becomes the card's growable flex column, with a scrollable
+   body above the footer sibling. Keeping the footer inside the form preserves
+   native Enter-to-submit (the submit button stays form-associated). */
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 input,
 select,
 textarea {

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -96,6 +96,14 @@
   --radius-sm: 2px;
   --radius-md: 6px;
   --radius-pill: 999px;
+
+  /* Elevation. Floating surfaces (context menus, the action bar, toasts, modal
+     and Cmd-K cards) share one drop shadow so they read as the same family.
+     The input autocomplete pickers open *above* the composer, so they cast
+     upward — same softness, flipped direction. Internal tokens (like spacing
+     and z-index); not in the settings registry. */
+  --shadow-popover: 0 4px 14px rgba(0, 0, 0, 0.45);
+  --shadow-popover-up: 0 -4px 12px rgba(0, 0, 0, 0.4);
 }
 
 /* Mobile bumps the base size to 16px. Two reasons: iOS Safari auto-zooms
@@ -153,6 +161,22 @@ body,
   -webkit-font-smoothing: var(--font-smoothing-webkit, auto);
   -moz-osx-font-smoothing: var(--font-smoothing-moz, auto);
   text-rendering: optimizeLegibility;
+}
+
+/* Headings inherit the base size like every other piece of text — the
+   one-font-size rule covers header text too. Without this, <h1>–<h6> fall back
+   to the browser's default heading sizes (which is why the modal title and the
+   profile section headers were rendering larger than body text). Hierarchy is
+   carried by weight/color/position, not size. The two intentionally oversized
+   titles — the login brand and the word backdrop — set their own font-size in
+   scoped styles, which outranks this bare-element rule. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: var(--font-size);
 }
 
 /* Whole app behaves like a CLI window — no document-level scroll.
@@ -231,6 +255,59 @@ button:hover:not(:disabled) {
 button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* Action buttons — modal footers, confirmations, the profile panel. One
+   system, promoted out of the per-modal copies that had drifted. Outline style
+   throughout: accent is the only color cue (primary = accent, danger = bad),
+   keeping the flat aesthetic and the menus' "accent for emphasis, not fill"
+   language. inline-flex so any button can carry a leading icon. */
+.btn-primary,
+.btn-secondary {
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  padding: var(--space-3) var(--space-6);
+  cursor: pointer;
+}
+.btn-secondary:hover:not(:disabled) {
+  background: var(--bg-soft);
+}
+.btn-primary {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.btn-primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+.btn-primary.danger,
+.btn-secondary.danger {
+  border-color: var(--bad);
+  color: var(--bad);
+}
+.btn-primary.danger:hover:not(:disabled),
+.btn-secondary.danger:hover:not(:disabled) {
+  border-color: var(--bad);
+  background: color-mix(in srgb, var(--bad) 15%, transparent);
+}
+.btn-primary:disabled,
+.btn-secondary:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+/* On mobile, footer buttons that pair an icon with a text label collapse to
+   icon-only to save room — wrap the label in <span class="label"> to opt in.
+   Text-only buttons (no .label) keep their text. */
+@media (max-width: 768px) {
+  .btn-primary .label,
+  .btn-secondary .label {
+    display: none;
+  }
 }
 
 input,

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -302,11 +302,23 @@ button:disabled {
 }
 /* On mobile, footer buttons that pair an icon with a text label collapse to
    icon-only to save room — wrap the label in <span class="label"> to opt in.
-   Text-only buttons (no .label) keep their text. */
+   Text-only buttons (no .label) keep their text.
+
+   Clip the label out of view rather than `display: none` so it stays in the
+   accessibility tree: the button is icon-only to the eye but still has a text
+   accessible name for screen readers, no per-call-site aria-label needed. */
 @media (max-width: 768px) {
   .btn-primary .label,
   .btn-secondary .label {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 }
 

--- a/vue_client/src/components/AppModal.vue
+++ b/vue_client/src/components/AppModal.vue
@@ -18,7 +18,6 @@
 <template>
   <div
     class="modal"
-    :class="[`align-${align}`]"
     tabindex="-1"
     ref="modalEl"
     @click.self="onBackdropClick"
@@ -67,7 +66,6 @@ const props = withDefaults(
     word?: string;
     title?: string;
     size?: string;
-    align?: string;
     closeOnBackdrop?: boolean;
     closeTitle?: string;
     // Pin the card to full height on desktop (mobile is already a full sheet),
@@ -78,7 +76,6 @@ const props = withDefaults(
     word: '',
     title: '',
     size: 'lg',
-    align: 'center',
     closeOnBackdrop: true,
     closeTitle: 'close',
     fillHeight: false,
@@ -117,45 +114,15 @@ onMounted(() => {
   background: var(--bg);
   display: flex;
   justify-content: center;
+  /* Every modal centers vertically — one positioning rule, no center/top split.
+     Scrollable "browser" modals stay put while filtering by locking their
+     height (.fill-height) rather than top-anchoring, so a filtering list never
+     shifts the header and an empty list reads as a stable centered card instead
+     of being stranded at the top. */
+  align-items: center;
   z-index: var(--z-modal);
   overflow: hidden;
   outline: none;
-}
-.modal.align-center {
-  align-items: center;
-}
-.modal.align-top {
-  align-items: flex-start;
-  padding-top: 2dvh;
-}
-/* Match the 2dvh top so a fully-tall card has equal breathing room
-   above and below. Default .card max-height: 85dvh would otherwise
-   leave a ~13dvh gap at the bottom. dvh (dynamic viewport height)
-   tracks the visible area as the iPad URL bar collapses; plain vh
-   would lock to the layout viewport and overflow. */
-.modal.align-top .card {
-  max-height: 96dvh;
-}
-
-/* On mobile every modal becomes a full-screen sheet — the card fills the
-   viewport so the title is glued to the top and the body extends to the
-   bottom. Vertical centering reads as "off-center" when the card already
-   takes ~92vw of horizontal space. */
-@media (max-width: 768px) {
-  .modal,
-  .modal.align-top {
-    align-items: stretch;
-    padding: var(--space-7);
-  }
-  .card,
-  .card.size-sm,
-  .card.size-md,
-  .card.size-lg,
-  .card.size-xl {
-    width: 100%;
-    max-height: none;
-    height: 100%;
-  }
 }
 
 .card {
@@ -166,7 +133,14 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   background: var(--bg);
-  border: 1px solid var(--accent);
+  /* Same floating-surface chrome as the context menu / action bar / Cmd-K:
+     a subtle --border (not the old loud --accent), a hair of radius, and the
+     shared drop shadow — so a dialog reads as the same family of surface, just
+     larger. The card floats on the tiled WordBackdrop rather than being welded
+     to it by an accent frame. */
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
   /* Card horizontal padding lives in a custom property so scrolling
      children can break out with margin: 0 calc(-1 * var(--card-pad-x))
      and have their scrollbar sit against the card border. */
@@ -187,24 +161,47 @@ onMounted(() => {
   width: min(900px, 92vw);
 }
 
+/* On mobile every modal is a full-frame sheet. Placed AFTER the .card.size-*
+   widths on purpose: the overrides share their specificity, so they have to
+   come later in source order to win — otherwise the size-specific 92vw widths
+   leave a left/right margin. The card fills the viewport edge-to-edge. */
+@media (max-width: 768px) {
+  .modal {
+    align-items: stretch;
+    /* Full-frame — no wallpaper sliver, and the card drops its border/radius
+       below (see the .card overrides). */
+    padding: 0;
+  }
+  .card,
+  .card.size-sm,
+  .card.size-md,
+  .card.size-lg,
+  .card.size-xl {
+    width: 100%;
+    max-height: none;
+    height: 100%;
+    border: none;
+    border-radius: 0;
+  }
+}
+
 /* Pin to full height on desktop so content changes (e.g. a filtering list)
-   don't resize the modal. min-width so the mobile full-sheet rules above win. */
+   don't resize the modal. */
 @media (min-width: 769px) {
   .card.fill-height {
     height: 85dvh;
-  }
-  .modal.align-top .card.fill-height {
-    height: 96dvh;
   }
 }
 
 .head {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: var(--space-6);
-  padding: 0 0 var(--space-7);
-  margin-bottom: var(--space-7);
+  /* Compact header bar. Tightened now that the title is base-size — it used to
+     hold the clamp() giant title, which needed the extra room above the rule. */
+  padding: 0 0 var(--space-5);
+  margin-bottom: var(--space-6);
   border-bottom: 1px solid var(--border);
 }
 .title-wrap {
@@ -214,14 +211,15 @@ onMounted(() => {
 .title-wrap :slotted(h2),
 .title-wrap h2 {
   margin: 0;
+  /* No font-size override — the title inherits the user's base size like every
+     other piece of text (the one-font-size rule; this retires the last
+     clamp() exception). De-bolded too: accent color alone marks it as the
+     title. Hierarchy comes from the accent color + position (alone atop the
+     card, above the divider rule), not size or weight. */
   color: var(--accent);
-  font-weight: 700;
+  font-weight: var(--font-weight);
   text-transform: lowercase;
-  font-size: clamp(2rem, 4.5vw, 3rem);
-  /* Needs headroom for descenders (g/y/p) — line-height: 1 clips them
-     because the h2 itself has overflow: hidden for the ellipsis. */
-  line-height: 1.15;
-  letter-spacing: -0.02em;
+  letter-spacing: 0.02em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/vue_client/src/components/BookmarksModal.vue
+++ b/vue_client/src/components/BookmarksModal.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-  <AppModal word="bookmarks" title="bookmarks" size="lg" align="top" @close="$emit('close')">
+  <AppModal word="bookmarks" title="bookmarks" size="lg" fill-height @close="$emit('close')">
     <p v-if="store.error" class="error inline">{{ store.error }}</p>
     <ul v-if="visibleItems.length" class="match-list">
       <HistoryMessageRow

--- a/vue_client/src/components/ChannelListModal.vue
+++ b/vue_client/src/components/ChannelListModal.vue
@@ -4,7 +4,13 @@
 -->
 
 <template>
-  <AppModal word="channels" :title="`channels — ${networkLabel}`" size="xl" @close="$emit('close')">
+  <AppModal
+    word="channels"
+    :title="`channels — ${networkLabel}`"
+    size="xl"
+    fill-height
+    @close="$emit('close')"
+  >
     <div class="controls">
       <input
         ref="filterEl"

--- a/vue_client/src/components/ChannelPicker.vue
+++ b/vue_client/src/components/ChannelPicker.vue
@@ -211,12 +211,7 @@ watch(
   padding: var(--space-6);
   min-height: 44px;
   cursor: pointer;
-  /* Thin separator between each suggestion — same --border as the panel edge. */
-  border-bottom: 1px solid var(--border);
   user-select: none;
-}
-.row:last-child {
-  border-bottom: none;
 }
 /* Single highlight, shared by mouse and keyboard: hovering a row sets
    activeIndex (see @mouseenter), so .active alone covers both — no separate

--- a/vue_client/src/components/ChannelPicker.vue
+++ b/vue_client/src/components/ChannelPicker.vue
@@ -199,10 +199,10 @@ watch(
   margin: 0 auto;
   max-height: 50vh;
   overflow-y: auto;
-  background: var(--bg-soft);
+  background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover-up);
   z-index: var(--z-popover);
 }
 .row {
@@ -211,6 +211,7 @@ watch(
   padding: var(--space-6);
   min-height: 44px;
   cursor: pointer;
+  /* Thin separator between each suggestion — same --border as the panel edge. */
   border-bottom: 1px solid var(--border);
   user-select: none;
 }
@@ -219,9 +220,10 @@ watch(
 }
 /* Single highlight, shared by mouse and keyboard: hovering a row sets
    activeIndex (see @mouseenter), so .active alone covers both — no separate
-   :hover rule that could double-highlight during keyboard nav. */
+   :hover rule that could double-highlight during keyboard nav. Soft neutral
+   fill matches the context menu / Cmd-K list. */
 .row.active {
-  background: var(--bg);
+  background: var(--bg-soft);
 }
 .channel {
   font-weight: 500;

--- a/vue_client/src/components/ConfigureFriendModal.vue
+++ b/vue_client/src/components/ConfigureFriendModal.vue
@@ -5,60 +5,68 @@
 
 <template>
   <AppModal word="friend" :title="title" size="md" @close="onClose">
-    <form class="body" @submit.prevent="confirm">
-      <label class="field">
-        <span class="label">Display name</span>
-        <input v-model="displayName" type="text" maxlength="128" placeholder="e.g. Darc" />
-      </label>
+    <form class="modal-form" @submit.prevent="confirm">
+      <div class="body">
+        <label class="field">
+          <span class="label">Display name</span>
+          <input v-model="displayName" type="text" maxlength="128" placeholder="e.g. Darc" />
+        </label>
 
-      <fieldset class="targets-field">
-        <legend>Watch nicks</legend>
-        <p v-if="!networks.networks.length" class="meta">Add a network first to watch a friend.</p>
-        <template v-else>
-          <div v-for="(row, i) in rows" :key="row.key" class="target-row">
-            <select v-model.number="row.networkId" class="net-select" aria-label="Network">
-              <option v-for="n in networks.networks" :key="n.id" :value="n.id">
-                {{ n.name }}
-              </option>
-            </select>
-            <input v-model="row.nick" type="text" class="nick-input" placeholder="nick" />
-            <label class="primary-toggle" title="Open this DM when the friend is clicked">
-              <input
-                type="radio"
-                name="primary-target"
-                :value="row.key"
-                v-model.number="primaryKey"
-              />
-              <span>primary</span>
-            </label>
-            <button
-              type="button"
-              class="row-remove"
-              title="Remove nick"
-              aria-label="Remove nick"
-              @click="removeRow(i)"
-            >
-              <i class="fa-solid fa-xmark"></i>
+        <!-- Plain div, not <fieldset>: a fieldset inside a flex column triggers a
+             Chrome initial-layout bug where its block size is mis-measured until a
+             reflow, leaving a phantom gap below the form. role+aria-label keep the
+             grouping semantics a fieldset/legend would have provided. -->
+        <div class="targets-field" role="group" aria-label="Watch nicks">
+          <div class="targets-legend" aria-hidden="true">Watch nicks</div>
+          <p v-if="!networks.networks.length" class="meta">
+            Add a network first to watch a friend.
+          </p>
+          <template v-else>
+            <div v-for="(row, i) in rows" :key="row.key" class="target-row">
+              <select v-model.number="row.networkId" class="net-select" aria-label="Network">
+                <option v-for="n in networks.networks" :key="n.id" :value="n.id">
+                  {{ n.name }}
+                </option>
+              </select>
+              <input v-model="row.nick" type="text" class="nick-input" placeholder="nick" />
+              <label class="primary-toggle" title="Open this DM when the friend is clicked">
+                <input
+                  type="radio"
+                  name="primary-target"
+                  :value="row.key"
+                  v-model.number="primaryKey"
+                />
+                <span>primary</span>
+              </label>
+              <button
+                type="button"
+                class="row-remove"
+                title="Remove nick"
+                aria-label="Remove nick"
+                @click="removeRow(i)"
+              >
+                <i class="fa-solid fa-xmark"></i>
+              </button>
+            </div>
+            <button type="button" class="add-row" @click="addRow">
+              <i class="fa-solid fa-plus"></i> Add nick
             </button>
-          </div>
-          <button type="button" class="add-row" @click="addRow">
-            <i class="fa-solid fa-plus"></i> Add nick
-          </button>
-          <p class="meta">The primary nick is the DM that opens when you click the friend.</p>
-        </template>
-      </fieldset>
+            <p class="meta">The primary nick is the DM that opens when you click the friend.</p>
+          </template>
+        </div>
 
-      <label class="notify">
-        <input v-model="notifyOnline" type="checkbox" />
-        <span>Notify me when they come online</span>
-      </label>
+        <label class="notify">
+          <input v-model="notifyOnline" type="checkbox" />
+          <span>Notify me when they come online</span>
+        </label>
 
-      <p class="meta">
-        Due to differences in network support for MONITOR and AWAY, presence tracking may be
-        unreliable. Away state tracking depends on sharing a channel with your friend.
-      </p>
+        <p class="meta">
+          Due to differences in network support for MONITOR and AWAY, presence tracking may be
+          unreliable.
+        </p>
+      </div>
 
-      <div class="actions">
+      <footer class="modal-footer">
         <button
           v-if="isEditing"
           type="button"
@@ -69,7 +77,7 @@
         </button>
         <button type="button" class="btn-secondary" @click="onClose">Cancel</button>
         <button type="submit" class="btn-primary" :disabled="!canSave">Save</button>
-      </div>
+      </footer>
     </form>
   </AppModal>
 </template>
@@ -178,12 +186,15 @@ function onClose() {
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
-  /* A friend can have many watch nicks; on the full-height mobile sheet (and a
-     short desktop window) let the form scroll inside the card instead of
-     overflowing it and pushing Save out of reach. */
+  /* A friend can have many watch nicks; let the body scroll inside the card so a
+     long list of targets never pushes the content past the modal — the footer
+     actions stay pinned below regardless (see .modal-form / .modal-footer). */
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  /* Breathing room so the last content doesn't butt against the footer divider
+     when scrolled to the bottom. */
+  padding-bottom: var(--space-7);
 }
 .field {
   display: flex;
@@ -213,9 +224,8 @@ input[type='text']:disabled {
   flex-direction: column;
   gap: var(--space-4);
 }
-.targets-field legend {
+.targets-legend {
   color: var(--fg-muted);
-  padding: 0 var(--space-2);
 }
 .target-row {
   display: flex;
@@ -275,16 +285,9 @@ input[type='text']:disabled {
   margin: 0;
   color: var(--fg-muted);
 }
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: var(--space-4);
-  margin-top: var(--space-2);
-}
 /* Push Remove to the far left, away from Cancel/Save, so the destructive action
    isn't adjacent to the positive ones. */
-.actions .remove {
+.modal-footer .remove {
   margin-right: auto;
 }
 

--- a/vue_client/src/components/ConfigureFriendModal.vue
+++ b/vue_client/src/components/ConfigureFriendModal.vue
@@ -287,36 +287,6 @@ input[type='text']:disabled {
 .actions .remove {
   margin-right: auto;
 }
-.btn-primary,
-.btn-secondary {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--fg);
-  padding: var(--space-3) var(--space-6);
-  cursor: pointer;
-  font: inherit;
-}
-.btn-primary {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-.btn-primary:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-.btn-primary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 15%, transparent);
-}
-.btn-secondary:hover {
-  background: var(--bg-soft);
-}
-.btn-secondary.danger {
-  color: var(--bad);
-  border-color: var(--bad);
-}
-.btn-secondary.danger:hover {
-  background: color-mix(in srgb, var(--bad) 15%, transparent);
-}
 
 /* The four target controls don't fit one line on a phone (the network select's
    8em min + the "primary" label + the nick input + the remove button overflow

--- a/vue_client/src/components/ContextMenu.vue
+++ b/vue_client/src/components/ContextMenu.vue
@@ -152,7 +152,7 @@ onBeforeUnmount(() => {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--shadow-popover);
   padding: var(--space-2) var(--space-1);
   color: var(--fg);
   user-select: none;

--- a/vue_client/src/components/HighlightsModal.vue
+++ b/vue_client/src/components/HighlightsModal.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-  <AppModal word="highlights" title="highlights" size="lg" align="top" @close="$emit('close')">
+  <AppModal word="highlights" title="highlights" size="lg" fill-height @close="$emit('close')">
     <template #actions>
       <button
         class="link sound-toggle"

--- a/vue_client/src/components/HistoryMessageRow.vue
+++ b/vue_client/src/components/HistoryMessageRow.vue
@@ -21,23 +21,25 @@
         >
         <span v-else class="net">{{ networkLabel }}</span>
       </div>
-      <span class="time">{{ time }}</span>
+      <div class="meta">
+        <span class="time">{{ time }}</span>
+        <button
+          v-if="removable"
+          type="button"
+          class="remove"
+          title="Remove"
+          aria-label="Remove"
+          @click.stop="$emit('remove', message)"
+        >
+          <i class="fa-solid fa-xmark"></i>
+        </button>
+      </div>
     </div>
     <div class="body">
       <span class="nick" :style="nickStyle">{{ message.nick }}</span>
       <span class="sep">|</span>
       <span class="text"><LinkedText :text="message.text ?? ''" /></span>
     </div>
-    <button
-      v-if="removable"
-      type="button"
-      class="remove"
-      title="Remove"
-      aria-label="Remove"
-      @click.stop="$emit('remove', message)"
-    >
-      <i class="fa-solid fa-xmark"></i>
-    </button>
   </li>
 </template>
 
@@ -124,7 +126,6 @@ const nickStyle = computed((): CSSProperties | null => {
 
 <style scoped>
 .row {
-  position: relative;
   /* No horizontal padding — the list already insets to the card's content edge
      (padding: 0 var(--card-pad-x) on its scroll container), so the row content
      sits flush with its full-width separators rather than adding a second inset.
@@ -136,35 +137,6 @@ const nickStyle = computed((): CSSProperties | null => {
   cursor: pointer;
 }
 
-.remove {
-  position: absolute;
-  top: var(--space-3);
-  right: var(--space-3);
-  background: var(--bg);
-  border: 1px solid var(--border);
-  color: var(--fg-muted);
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  opacity: 0;
-  padding: 0;
-  border-radius: var(--radius-sm);
-}
-.row:hover .remove {
-  opacity: 1;
-}
-.remove:hover {
-  color: var(--bad);
-}
-@media (hover: none) {
-  .remove {
-    opacity: 1;
-  }
-}
-
 .head {
   display: flex;
   align-items: baseline;
@@ -172,6 +144,25 @@ const nickStyle = computed((): CSSProperties | null => {
   gap: var(--space-4);
   color: var(--fg-muted);
   margin-bottom: var(--space-3);
+}
+/* Time + remove icon, grouped at the right edge of the header strip — the
+   xmark sits in the top-right corner and the date is nudged left to clear it. */
+.meta {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-5);
+  flex-shrink: 0;
+}
+.remove {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.remove:hover {
+  color: var(--bad);
 }
 .where {
   min-width: 0;
@@ -196,5 +187,14 @@ const nickStyle = computed((): CSSProperties | null => {
 .sep {
   color: var(--border);
   margin: 0 0.5ch;
+}
+/* Mirror the channel-list rows: the message text sits at the secondary fg and
+   lifts to full fg on row hover, so the row still has a hover tell even though
+   the nick keeps its own color. */
+.text {
+  color: var(--fg-muted);
+}
+.row:hover .text {
+  color: var(--fg);
 }
 </style>

--- a/vue_client/src/components/HistoryMessageRow.vue
+++ b/vue_client/src/components/HistoryMessageRow.vue
@@ -12,7 +12,7 @@
 -->
 
 <template>
-  <li :class="{ row: true, active }" @click="$emit('jump', message)" @mouseenter="$emit('hover')">
+  <li class="row" @click="$emit('jump', message)">
     <div class="head">
       <div class="where">
         <template v-if="targetLabel"
@@ -68,15 +68,13 @@ export interface HistoryMessage {
 const props = withDefaults(
   defineProps<{
     message: HistoryMessage;
-    active?: boolean;
     removable?: boolean;
   }>(),
-  { active: false, removable: false },
+  { removable: false },
 );
 
 defineEmits<{
   jump: [message: HistoryMessage];
-  hover: [];
   remove: [message: HistoryMessage];
 }>();
 
@@ -127,13 +125,15 @@ const nickStyle = computed((): CSSProperties | null => {
 <style scoped>
 .row {
   position: relative;
-  padding: var(--space-4) var(--space-5);
+  /* No horizontal padding — the list already insets to the card's content edge
+     (padding: 0 var(--card-pad-x) on its scroll container), so the row content
+     sits flush with its full-width separators rather than adding a second inset.
+     Roomy padding-bottom above the separator plus a margin below it space the
+     rows well apart. */
+  padding: var(--space-4) 0 var(--space-8);
   border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-4);
   cursor: pointer;
-}
-.row:hover,
-.row.active {
-  background: var(--bg-soft);
 }
 
 .remove {
@@ -192,9 +192,6 @@ const nickStyle = computed((): CSSProperties | null => {
 .body {
   white-space: pre-wrap;
   word-break: break-word;
-}
-.nick {
-  font-weight: 600;
 }
 .sep {
   color: var(--border);

--- a/vue_client/src/components/HistoryPicker.vue
+++ b/vue_client/src/components/HistoryPicker.vue
@@ -175,12 +175,7 @@ watch(
   padding: var(--space-6);
   min-height: 44px;
   cursor: pointer;
-  /* Thin separator between each suggestion — same --border as the panel edge. */
-  border-bottom: 1px solid var(--border);
   user-select: none;
-}
-.row:last-child {
-  border-bottom: none;
 }
 /* Tap-only menu — no externally driven activeIndex to coordinate with, so a
    plain :hover highlight is fine (unlike the nick/channel pickers, which avoid

--- a/vue_client/src/components/HistoryPicker.vue
+++ b/vue_client/src/components/HistoryPicker.vue
@@ -163,10 +163,10 @@ watch(
   margin: 0 auto;
   max-height: 50vh;
   overflow-y: auto;
-  background: var(--bg-soft);
+  background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover-up);
   z-index: var(--z-popover);
 }
 .row {
@@ -175,6 +175,7 @@ watch(
   padding: var(--space-6);
   min-height: 44px;
   cursor: pointer;
+  /* Thin separator between each suggestion — same --border as the panel edge. */
   border-bottom: 1px solid var(--border);
   user-select: none;
 }
@@ -183,9 +184,10 @@ watch(
 }
 /* Tap-only menu — no externally driven activeIndex to coordinate with, so a
    plain :hover highlight is fine (unlike the nick/channel pickers, which avoid
-   :hover to dodge double-highlighting during keyboard nav). */
+   :hover to dodge double-highlighting during keyboard nav). Soft neutral fill
+   matches the context menu / Cmd-K list. */
 .row:hover {
-  background: var(--bg);
+  background: var(--bg-soft);
 }
 /* Recalled lines can be long — keep each row to a single line, clipped with an
    ellipsis. The full text is in the row's title and lands in the composer on

--- a/vue_client/src/components/IgnoreModal.vue
+++ b/vue_client/src/components/IgnoreModal.vue
@@ -5,30 +5,32 @@
 
 <template>
   <AppModal word="ignore" :title="`ignore ${nick}`" size="md" @close="$emit('close')">
-    <form class="body" @submit.prevent="confirm">
-      <label class="field">
-        <span class="label-text">Mask</span>
-        <input
-          ref="inputEl"
-          v-model="mask"
-          type="text"
-          spellcheck="false"
-          autocapitalize="off"
-          autocomplete="off"
-        />
-      </label>
-      <p class="hint">
-        Plain nick (e.g. <code>{{ nick }}</code
-        >) or <code>nick!user@host</code> with <code>*</code> wildcards. The default targets this
-        user's identity (<code>user@host</code>) so it survives nick changes.
-      </p>
-      <p class="preview">
-        Messages matching <code>{{ mask || '∅' }}</code> will be hidden on this network.
-      </p>
-      <div class="actions">
+    <form class="modal-form" @submit.prevent="confirm">
+      <div class="body">
+        <label class="field">
+          <span class="label-text">Mask</span>
+          <input
+            ref="inputEl"
+            v-model="mask"
+            type="text"
+            spellcheck="false"
+            autocapitalize="off"
+            autocomplete="off"
+          />
+        </label>
+        <p class="hint">
+          Plain nick (e.g. <code>{{ nick }}</code
+          >) or <code>nick!user@host</code> with <code>*</code> wildcards. The default targets this
+          user's identity (<code>user@host</code>) so it survives nick changes.
+        </p>
+        <p class="preview">
+          Messages matching <code>{{ mask || '∅' }}</code> will be hidden on this network.
+        </p>
+      </div>
+      <footer class="modal-footer">
         <button type="button" class="btn-secondary" @click="$emit('close')">Cancel</button>
         <button type="submit" class="btn-primary" :disabled="!mask.trim()">Ignore</button>
-      </div>
+      </footer>
     </form>
   </AppModal>
 </template>
@@ -79,6 +81,12 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  /* Breathing room so the last content doesn't butt against the footer divider
+     when scrolled to the bottom. */
+  padding-bottom: var(--space-7);
 }
 .field {
   display: flex;
@@ -113,11 +121,5 @@ code {
   background: var(--bg-soft);
   padding: 0 var(--space-2);
   border-radius: var(--radius-sm);
-}
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-4);
-  margin-top: var(--space-2);
 }
 </style>

--- a/vue_client/src/components/IgnoreModal.vue
+++ b/vue_client/src/components/IgnoreModal.vue
@@ -120,27 +120,4 @@ code {
   gap: var(--space-4);
   margin-top: var(--space-2);
 }
-.btn-primary,
-.btn-secondary {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--fg);
-  padding: var(--space-3) var(--space-6);
-  cursor: pointer;
-  font: inherit;
-}
-.btn-primary {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-.btn-primary:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-.btn-primary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 15%, transparent);
-}
-.btn-secondary:hover {
-  background: var(--bg-soft);
-}
 </style>

--- a/vue_client/src/components/LongMessageUploadModal.vue
+++ b/vue_client/src/components/LongMessageUploadModal.vue
@@ -15,7 +15,7 @@
       instead?
     </p>
     <pre class="preview">{{ content }}</pre>
-    <footer class="foot">
+    <footer class="modal-footer">
       <button type="button" class="btn-secondary" @click="$emit('cancel')">Cancel</button>
       <button
         ref="primaryBtn"
@@ -79,12 +79,5 @@ onMounted(() => {
   word-break: break-word;
   font-family: inherit;
   color: var(--fg-muted);
-}
-.foot {
-  padding-top: var(--space-6);
-  border-top: 1px solid var(--border);
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-4);
 }
 </style>

--- a/vue_client/src/components/LongMessageUploadModal.vue
+++ b/vue_client/src/components/LongMessageUploadModal.vue
@@ -16,11 +16,11 @@
     </p>
     <pre class="preview">{{ content }}</pre>
     <footer class="foot">
-      <button type="button" class="btn secondary" @click="$emit('cancel')">Cancel</button>
+      <button type="button" class="btn-secondary" @click="$emit('cancel')">Cancel</button>
       <button
         ref="primaryBtn"
         type="button"
-        class="btn primary"
+        class="btn-primary"
         :disabled="uploading"
         @click="$emit('confirm')"
       >
@@ -86,28 +86,5 @@ onMounted(() => {
   display: flex;
   justify-content: flex-end;
   gap: var(--space-4);
-}
-.btn {
-  background: var(--bg-soft);
-  border: 1px solid var(--border);
-  color: var(--fg);
-  cursor: pointer;
-  font: inherit;
-  padding: var(--space-3) var(--space-6);
-}
-.btn:hover:not(:disabled) {
-  border-color: var(--accent);
-}
-.btn:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-.btn.primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: var(--bg);
-}
-.btn.primary:hover:not(:disabled) {
-  filter: brightness(1.1);
 }
 </style>

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1396,7 +1396,7 @@ watch(
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--shadow-popover);
   padding: var(--space-1);
   opacity: 0;
   pointer-events: none;

--- a/vue_client/src/components/NetworkForm.vue
+++ b/vue_client/src/components/NetworkForm.vue
@@ -13,116 +13,132 @@
   >
     <NetworkPicker v-if="step === 'pick'" @select="onPick" @manual="onManual" />
 
-    <form v-else class="net-form" @submit.prevent="submit">
-      <button v-if="!isEdit" type="button" class="back-link" @click="step = 'pick'">
-        ← {{ picked ? picked.name : 'pick a network' }}
-      </button>
-      <label>
-        <span>Name</span>
-        <input v-model="form.name" placeholder="Libera" required />
-      </label>
-      <div class="row">
-        <label class="grow">
-          <span>Host</span>
-          <input v-model="form.host" placeholder="irc.libera.chat" required />
-        </label>
-        <label class="port">
-          <span>Port</span>
-          <input v-model.number="form.port" type="number" min="1" max="65535" />
-        </label>
-        <label class="tls">
-          <span>TLS</span>
-          <input v-model="form.tls" type="checkbox" />
-        </label>
-      </div>
-      <label>
-        <span>Nick</span>
-        <input v-model="form.nick" required />
-      </label>
-      <label>
-        <span>Real name (optional)</span>
-        <input v-model="form.realname" />
-      </label>
-      <p v-if="showSaslHint" class="sasl-hint">
-        <strong>{{ picked?.name }}</strong> blocks unauthenticated connections from hosted servers,
-        so the SASL account and password below are <strong>not optional</strong> — register your
-        nick with the network first, then enter it here.
-      </p>
-      <div class="row">
-        <label class="grow">
-          <span>SASL account{{ saslRequired ? '' : ' (optional)' }}</span>
-          <input
-            v-model="form.sasl_account"
-            :placeholder="form.nick || 'defaults to nick'"
-            autocomplete="off"
-          />
-        </label>
-        <label class="grow">
-          <span>SASL password{{ saslRequired ? '' : ' (optional)' }}</span>
-          <input
-            v-model="form.sasl_password"
-            type="password"
-            autocomplete="off"
-            :placeholder="
-              isEdit && props.network?.has_sasl_password ? '(saved — type to replace)' : ''
-            "
-          />
-        </label>
-      </div>
-      <button type="button" class="advanced-toggle" @click="showAdvanced = !showAdvanced">
-        {{ showAdvanced ? '− Advanced options' : '+ Advanced options' }}
-      </button>
-      <div v-if="showAdvanced" class="advanced">
+    <form v-else class="modal-form" @submit.prevent="submit">
+      <div class="net-form">
+        <button v-if="!isEdit" type="button" class="back-link" @click="step = 'pick'">
+          ← {{ picked ? picked.name : 'pick a network' }}
+        </button>
         <label>
-          <span>Server password (optional)</span>
-          <input
-            v-model="form.server_password"
-            type="password"
-            autocomplete="off"
-            :placeholder="isEdit && props.network?.has_password ? '(saved — type to replace)' : ''"
-          />
+          <span>Name</span>
+          <input v-model="form.name" placeholder="Libera" required />
         </label>
-        <label v-if="!isEdit">
-          <span>Default channel</span>
-          <input v-model="form.default_channel" :placeholder="channelPlaceholder" />
+        <div class="row">
+          <label class="grow">
+            <span>Host</span>
+            <input v-model="form.host" placeholder="irc.libera.chat" required />
+          </label>
+          <label class="port">
+            <span>Port</span>
+            <input v-model.number="form.port" type="number" min="1" max="65535" />
+          </label>
+          <label class="tls">
+            <span>TLS</span>
+            <input v-model="form.tls" type="checkbox" />
+          </label>
+        </div>
+        <label>
+          <span>Nick</span>
+          <input v-model="form.nick" required />
         </label>
         <label>
-          <span>Commands to run on connect</span>
-          <textarea
-            v-model="form.connect_commands"
-            rows="4"
-            autocomplete="off"
-            spellcheck="false"
-            placeholder="AUTH <user> <password> etc…"
-          />
-          <small
-            >One per line, e.g. for opering up on connect. If you need to add a (eg, 15 sec) delay
-            between commands, you can write: WAIT 15</small
-          >
+          <span>Real name (optional)</span>
+          <input v-model="form.realname" />
         </label>
-        <label class="check">
-          <input v-model="form.autoconnect" type="checkbox" />
-          <span>Reconnect automatically</span>
-        </label>
-        <label class="check">
-          <input v-model="form.trusted_certificates" type="checkbox" />
-          <span>Only allow trusted certificates</span>
-        </label>
+        <p v-if="showSaslHint" class="sasl-hint">
+          <strong>{{ picked?.name }}</strong> blocks unauthenticated connections from hosted
+          servers, so the SASL account and password below are <strong>not optional</strong> —
+          register your nick with the network first, then enter it here.
+        </p>
+        <div class="row">
+          <label class="grow">
+            <span>SASL account{{ saslRequired ? '' : ' (optional)' }}</span>
+            <input
+              v-model="form.sasl_account"
+              :placeholder="form.nick || 'defaults to nick'"
+              autocomplete="off"
+            />
+          </label>
+          <label class="grow">
+            <span>SASL password{{ saslRequired ? '' : ' (optional)' }}</span>
+            <input
+              v-model="form.sasl_password"
+              type="password"
+              autocomplete="off"
+              :placeholder="
+                isEdit && props.network?.has_sasl_password ? '(saved — type to replace)' : ''
+              "
+            />
+          </label>
+        </div>
+        <button type="button" class="advanced-toggle" @click="showAdvanced = !showAdvanced">
+          {{ showAdvanced ? '− Advanced options' : '+ Advanced options' }}
+        </button>
+        <div v-if="showAdvanced" class="advanced">
+          <label>
+            <span>Server password (optional)</span>
+            <input
+              v-model="form.server_password"
+              type="password"
+              autocomplete="off"
+              :placeholder="
+                isEdit && props.network?.has_password ? '(saved — type to replace)' : ''
+              "
+            />
+          </label>
+          <label v-if="!isEdit">
+            <span>Default channel</span>
+            <input v-model="form.default_channel" :placeholder="channelPlaceholder" />
+          </label>
+          <label>
+            <span>Commands to run on connect</span>
+            <textarea
+              v-model="form.connect_commands"
+              rows="4"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="AUTH <user> <password> etc…"
+            />
+            <small
+              >One per line, e.g. for opering up on connect. If you need to add a (eg, 15 sec) delay
+              between commands, you can write: WAIT 15</small
+            >
+          </label>
+          <label class="check">
+            <input v-model="form.autoconnect" type="checkbox" />
+            <span>Reconnect automatically</span>
+          </label>
+          <label class="check">
+            <input v-model="form.trusted_certificates" type="checkbox" />
+            <span>Only allow trusted certificates</span>
+          </label>
+        </div>
+        <p v-if="error" class="error">{{ error }}</p>
       </div>
-      <p v-if="error" class="error">{{ error }}</p>
-      <div class="actions">
-        <button v-if="isEdit" type="button" class="danger" :disabled="loading" @click="remove">
+      <footer class="modal-footer">
+        <button
+          v-if="isEdit"
+          type="button"
+          class="btn-secondary danger"
+          :disabled="loading"
+          @click="remove"
+        >
           Delete
         </button>
-        <button v-if="isEdit" type="button" class="ghost" :disabled="loading" @click="reconnect">
+        <button
+          v-if="isEdit"
+          type="button"
+          class="btn-secondary"
+          :disabled="loading"
+          @click="reconnect"
+        >
           Reconnect
         </button>
         <span class="spacer"></span>
-        <button type="button" class="ghost" @click="$emit('close')">Cancel</button>
-        <button type="submit" :disabled="loading">
+        <button type="button" class="btn-secondary" @click="$emit('close')">Cancel</button>
+        <button type="submit" class="btn-primary" :disabled="loading">
           {{ loading ? 'Saving…' : isEdit ? 'Save' : 'Save & connect' }}
         </button>
-      </div>
+      </footer>
     </form>
   </AppModal>
 </template>
@@ -304,9 +320,10 @@ async function remove(): Promise<void> {
   min-height: 0;
   overflow-y: auto;
   /* Match the breakout pattern from SearchModal/RecentUploadsModal so the
-     scrollbar sits against the card border instead of inside the padding. */
+     scrollbar sits against the card border instead of inside the padding.
+     Bottom padding keeps the last field off the footer divider when scrolled. */
   margin: 0 calc(-1 * var(--card-pad-x));
-  padding: 0 var(--card-pad-x);
+  padding: 0 var(--card-pad-x) var(--space-7);
 }
 label {
   display: flex;
@@ -401,27 +418,6 @@ label small {
   letter-spacing: normal;
   color: var(--fg);
   font-size: inherit;
-}
-.actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-  margin-top: var(--space-3);
-}
-.spacer {
-  flex: 1;
-}
-.ghost {
-  border-color: var(--border);
-}
-.danger {
-  color: var(--bad);
-  border-color: var(--bad);
-}
-.danger:hover:not(:disabled) {
-  background: var(--bad);
-  color: var(--bg);
-  border-color: var(--bad);
 }
 .error {
   color: var(--bad);

--- a/vue_client/src/components/NickNoteModal.vue
+++ b/vue_client/src/components/NickNoteModal.vue
@@ -5,27 +5,29 @@
 
 <template>
   <AppModal word="note" :title="`note on ${nick}`" size="md" @close="onClose">
-    <form class="body" @submit.prevent="confirm">
-      <textarea
-        ref="inputEl"
-        v-model="draft"
-        spellcheck="true"
-        autocapitalize="sentences"
-        rows="8"
-        :maxlength="MAX_LEN"
-        placeholder="e.g. lives in Berlin, works at Acme, spouse: Pat…"
-      ></textarea>
-      <p class="meta">
-        <span v-if="entry?.updatedAt">Updated {{ formattedUpdatedAt }}</span>
-        <span v-else>Notes are private to you and synced across your devices.</span>
-      </p>
-      <div class="actions">
+    <form class="modal-form" @submit.prevent="confirm">
+      <div class="body">
+        <textarea
+          ref="inputEl"
+          v-model="draft"
+          spellcheck="true"
+          autocapitalize="sentences"
+          rows="8"
+          :maxlength="MAX_LEN"
+          placeholder="e.g. lives in Berlin, works at Acme, spouse: Pat…"
+        ></textarea>
+        <p class="meta">
+          <span v-if="entry?.updatedAt">Updated {{ formattedUpdatedAt }}</span>
+          <span v-else>Notes are private to you and synced across your devices.</span>
+        </p>
+      </div>
+      <footer class="modal-footer">
         <button type="button" class="btn-secondary" @click="onClose">Cancel</button>
         <button v-if="hasExistingNote" type="button" class="btn-secondary danger" @click="onDelete">
           Delete
         </button>
         <button type="submit" class="btn-primary" :disabled="!dirty">Save</button>
-      </div>
+      </footer>
     </form>
   </AppModal>
 </template>
@@ -90,6 +92,12 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  /* Breathing room so the last content doesn't butt against the footer divider
+     when scrolled to the bottom. */
+  padding-bottom: var(--space-7);
 }
 textarea {
   background: var(--bg-soft);
@@ -107,11 +115,5 @@ textarea:focus {
 .meta {
   margin: 0;
   color: var(--fg-muted);
-}
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--space-4);
-  margin-top: var(--space-2);
 }
 </style>

--- a/vue_client/src/components/NickNoteModal.vue
+++ b/vue_client/src/components/NickNoteModal.vue
@@ -114,34 +114,4 @@ textarea:focus {
   gap: var(--space-4);
   margin-top: var(--space-2);
 }
-.btn-primary,
-.btn-secondary {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--fg);
-  padding: var(--space-3) var(--space-6);
-  cursor: pointer;
-  font: inherit;
-}
-.btn-primary {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-.btn-primary:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-.btn-primary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 15%, transparent);
-}
-.btn-secondary:hover {
-  background: var(--bg-soft);
-}
-.btn-secondary.danger {
-  color: var(--bad);
-  border-color: var(--bad);
-}
-.btn-secondary.danger:hover {
-  background: color-mix(in srgb, var(--bad) 15%, transparent);
-}
 </style>

--- a/vue_client/src/components/NickPicker.vue
+++ b/vue_client/src/components/NickPicker.vue
@@ -230,12 +230,7 @@ watch(
   padding: var(--space-6);
   min-height: 44px;
   cursor: pointer;
-  /* Thin separator between each suggestion — same --border as the panel edge. */
-  border-bottom: 1px solid var(--border);
   user-select: none;
-}
-.row:last-child {
-  border-bottom: none;
 }
 /* Single highlight, shared by mouse and keyboard: hovering a row sets
    activeIndex (see @mouseenter), so .active alone covers both — no separate

--- a/vue_client/src/components/NickPicker.vue
+++ b/vue_client/src/components/NickPicker.vue
@@ -217,10 +217,10 @@ watch(
   margin: 0 auto;
   max-height: 50vh;
   overflow-y: auto;
-  background: var(--bg-soft);
+  background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover-up);
   z-index: var(--z-popover);
 }
 .row {
@@ -230,6 +230,7 @@ watch(
   padding: var(--space-6);
   min-height: 44px;
   cursor: pointer;
+  /* Thin separator between each suggestion — same --border as the panel edge. */
   border-bottom: 1px solid var(--border);
   user-select: none;
 }
@@ -238,9 +239,10 @@ watch(
 }
 /* Single highlight, shared by mouse and keyboard: hovering a row sets
    activeIndex (see @mouseenter), so .active alone covers both — no separate
-   :hover rule that could double-highlight during keyboard nav. */
+   :hover rule that could double-highlight during keyboard nav. Soft neutral
+   fill matches the context menu / Cmd-K list. */
 .row.active {
-  background: var(--bg);
+  background: var(--bg-soft);
 }
 .nick {
   font-weight: 500;

--- a/vue_client/src/components/QuickSwitcher.vue
+++ b/vue_client/src/components/QuickSwitcher.vue
@@ -195,8 +195,14 @@ onMounted(() => {
   z-index: var(--z-modal);
 }
 .card {
+  /* "A big context menu" — same floating-surface chrome as ContextMenu and the
+     dialog cards (subtle --border, hair of radius, shared shadow), over the
+     --scrim backdrop above (no WordBackdrop: a fast switcher should keep the
+     app visible behind it). */
   background: var(--bg);
-  border: 1px solid var(--accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
   width: min(560px, 92vw);
   max-height: 70vh;
   display: flex;

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -38,33 +38,19 @@
             <div class="filename" :title="u.filename || ''">{{ u.filename || '(pasted)' }}</div>
             <div v-if="u.removed" class="url removed-note">Removed by moderation</div>
             <div v-else class="url" :title="u.url">{{ u.url }}</div>
-            <div class="sub">
-              <span v-if="u.provider">{{ u.provider }}</span>
-              <span v-if="u.created_at">· {{ formatRelative(u.created_at) }}</span>
-              <span v-if="u.byte_size">· {{ formatBytes(u.byte_size) }}</span>
-              <span v-if="u.width && u.height">· {{ u.width }}×{{ u.height }}</span>
-            </div>
+            <div class="sub">{{ metaLine(u) }}</div>
           </div>
           <div class="row-actions">
-            <!-- A removed upload's URL is dead — only allow clearing it from history. -->
-            <template v-if="!u.removed">
-              <button class="link" @click="onInsert(u)" title="insert URL into input">
-                insert
-              </button>
-              <button
-                class="link"
-                @click="onCopy(u)"
-                :title="copiedId === u.id ? 'copied' : 'copy URL'"
-              >
-                {{ copiedId === u.id ? 'copied' : 'copy' }}
-              </button>
-            </template>
+            <!-- A removed upload's URL is dead, so there's nothing to copy. -->
             <button
-              class="link danger"
-              @click="onDelete(u)"
-              title="remove from history (does not delete from host)"
+              v-if="!u.removed"
+              class="link copy"
+              :class="{ copied: copiedId === u.id }"
+              @click="onCopy(u)"
+              :title="copiedId === u.id ? 'copied' : 'copy URL'"
+              :aria-label="copiedId === u.id ? 'copied' : 'copy URL'"
             >
-              delete
+              <i :class="copiedId === u.id ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
             </button>
           </div>
         </li>
@@ -94,7 +80,7 @@ interface UploadRow extends UploadItem {
   height?: number;
 }
 
-const emit = defineEmits<{
+defineEmits<{
   close: [];
 }>();
 const uploads = useUploadsStore();
@@ -118,11 +104,6 @@ function onScroll() {
   }
 }
 
-function onInsert(u: UploadRow) {
-  uploads.requestInsert(u.url);
-  emit('close');
-}
-
 async function onCopy(u: UploadRow) {
   try {
     await navigator.clipboard.writeText(u.url);
@@ -136,18 +117,23 @@ async function onCopy(u: UploadRow) {
   }
 }
 
-async function onDelete(u: UploadRow) {
-  try {
-    await uploads.remove(u.id);
-  } catch (_) {
-    /* listError set */
-  }
-}
-
 function formatBytes(n: number) {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Build the metadata sub-line in JS so the " · " separators keep their spaces —
+// Vue's whitespace condensing strips the gaps between adjacent inline spans.
+function metaLine(u: UploadRow): string {
+  return [
+    u.provider,
+    u.created_at && formatRelative(u.created_at),
+    u.byte_size && formatBytes(u.byte_size),
+    u.width && u.height && `${u.width}×${u.height}`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
 }
 </script>
 
@@ -162,9 +148,6 @@ function formatBytes(n: number) {
 }
 .link:hover {
   color: var(--accent);
-}
-.link.danger:hover {
-  color: var(--bad);
 }
 
 .error {
@@ -196,8 +179,11 @@ function formatBytes(n: number) {
   column-gap: var(--space-2);
   row-gap: var(--space-4);
   align-items: center;
-  padding: var(--space-4) 0;
+  /* Roomy padding-bottom above the separator plus a margin below it to space the
+     rows well apart, matching HistoryMessageRow. */
+  padding: var(--space-4) 0 var(--space-8);
   border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-4);
 }
 .thumb-link {
   display: block;
@@ -247,23 +233,18 @@ function formatBytes(n: number) {
   align-items: center;
   margin-left: var(--space-6);
 }
-
-/* Phone widths: stack the actions under the thumb+meta block instead of
-   trying to fit a third column. Bumps the tap target padding so the
-   tiny text links aren't a coin-toss to hit with a thumb. */
-@media (max-width: 768px) {
-  .row {
-    grid-template-columns: 80px 1fr;
-    row-gap: var(--space-4);
-  }
-  .row-actions {
-    grid-column: 1 / -1;
-    justify-content: flex-end;
-    margin-left: 0;
-  }
-  .row-actions .link {
-    padding: var(--space-3) var(--space-5);
-  }
+/* Copy is the lone row action now, so it stays in its own column on every
+   width — a single icon needs no separate mobile bar. Padding gives it a
+   comfortable tap target. */
+.copy {
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--icon-md);
+}
+.copy.copied {
+  color: var(--good);
+}
+.copy.copied:hover {
+  color: var(--good);
 }
 
 .empty {

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-  <AppModal word="uploads" title="recent uploads" size="xl" @close="$emit('close')">
+  <AppModal word="uploads" title="recent uploads" size="xl" fill-height @close="$emit('close')">
     <p v-if="uploads.listError" class="error">{{ uploads.listError }}</p>
 
     <div ref="listEl" class="list-wrap" @scroll="onScroll">

--- a/vue_client/src/components/SearchModal.vue
+++ b/vue_client/src/components/SearchModal.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-  <AppModal word="search" title="search" size="lg" align="top" @close="$emit('close')">
+  <AppModal word="search" title="search" size="lg" fill-height @close="$emit('close')">
     <div class="search-row">
       <input
         ref="inputEl"
@@ -14,18 +14,15 @@
         placeholder="search messages — from:nick in:#channel on:network"
         autocomplete="off"
         spellcheck="false"
-        @keydown="onKeydown"
       />
     </div>
     <p v-if="store.error" class="error inline">{{ store.error }}</p>
     <ul v-if="visibleResults.length" ref="listEl" class="match-list" @scroll="onScroll">
       <HistoryMessageRow
-        v-for="(m, i) in visibleResults"
+        v-for="m in visibleResults"
         :key="`${m.networkId}::${m.target}::${m.id}`"
         :message="m"
-        :active="i === selected"
         @jump="onJump"
-        @hover="selected = i"
       />
       <li v-if="store.loading" class="more">Loading…</li>
     </ul>
@@ -71,10 +68,6 @@ const visibleResults = computed(() =>
 
 const inputEl = ref<HTMLInputElement | null>(null);
 const listEl = ref<HTMLUListElement | null>(null);
-// Hydrated from the store on mount so a closed-then-reopened modal lands
-// on the same row the user was last on. Mirrored back into the store on
-// unmount.
-const selected = ref(store.selectedIndex);
 
 // Local mirror of the store's raw query so we can debounce dispatch without
 // debouncing the text field itself. Scoped opens seed the prefilled filter.
@@ -88,54 +81,10 @@ watch(queryInput, (val) => {
   }, 200);
 });
 
-// Reset the keyboard cursor whenever the visible result set is replaced
-// (a fresh search), but leave it alone on pagination appends. Clamp to
-// in-range when the set shrinks (e.g. a result becomes ignored) so the
-// restored selectedIndex never points past the end.
-watch(
-  () => visibleResults.value.length,
-  (len, prev) => {
-    if (len === 0) {
-      selected.value = 0;
-      return;
-    }
-    if (len < prev || prev === 0) selected.value = 0;
-    if (selected.value >= len) selected.value = len - 1;
-  },
-);
-
 function onJump(m: HistoryMessage | SearchResult) {
   const id = typeof m.id === 'number' ? m.id : 0;
   emit('jump', { networkId: m.networkId, target: m.target, messageId: id });
   emit('close');
-}
-
-function scrollSelectedIntoView() {
-  nextTick(() => {
-    const el = listEl.value;
-    if (!el) return;
-    el.children[selected.value]?.scrollIntoView({ block: 'nearest' });
-  });
-}
-
-function onKeydown(e: KeyboardEvent) {
-  const rows = visibleResults.value;
-  if (e.key === 'ArrowDown') {
-    e.preventDefault();
-    if (!rows.length) return;
-    selected.value = (selected.value + 1) % rows.length;
-    scrollSelectedIntoView();
-  } else if (e.key === 'ArrowUp') {
-    e.preventDefault();
-    if (!rows.length) return;
-    selected.value = (selected.value - 1 + rows.length) % rows.length;
-    scrollSelectedIntoView();
-  } else if (e.key === 'Enter') {
-    e.preventDefault();
-    const row = rows[selected.value];
-    if (row) onJump(row);
-  }
-  // Esc handled by AppModal's keydown listener on the modal root.
 }
 
 function onScroll() {
@@ -161,7 +110,6 @@ onMounted(() => {
       error: '',
       searched: false,
       scrollTop: 0,
-      selectedIndex: 0,
     });
   }
   setTimeout(() => {
@@ -175,8 +123,7 @@ onMounted(() => {
       inputEl.value?.select();
     }
   }, 0);
-  // Restore the scroll position after the list has rendered. The cursor was
-  // already seeded from the store via the `selected` ref's initial value.
+  // Restore the scroll position after the list has rendered.
   nextTick(() => {
     const el = listEl.value;
     if (el && store.scrollTop > 0) el.scrollTop = store.scrollTop;
@@ -195,7 +142,6 @@ onBeforeUnmount(() => {
   // The Pinia store already keeps query, results, hasMore, nextBefore, and
   // searched across opens; this rounds out the user-perceived "where I was".
   store.scrollTop = listEl.value?.scrollTop || 0;
-  store.selectedIndex = selected.value;
 });
 </script>
 

--- a/vue_client/src/components/ToastContainer.vue
+++ b/vue_client/src/components/ToastContainer.vue
@@ -66,7 +66,7 @@ function onClick(t: Toast) {
   border: 1px solid var(--border);
   border-left: 4px solid var(--toast-accent, var(--accent));
   padding: var(--space-5) var(--space-6);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--shadow-popover);
   color: var(--fg);
   animation: toast-in 160ms ease-out;
 }

--- a/vue_client/src/components/TopicModal.vue
+++ b/vue_client/src/components/TopicModal.vue
@@ -13,10 +13,11 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import AppModal from './AppModal.vue';
 import LinkedText from './LinkedText.vue';
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     topic?: string;
     label?: string;
@@ -28,17 +29,19 @@ defineEmits<{
   close: [];
 }>();
 
-// The label is the channel name and includes characters like '#' that
-// don't tile as nicely as a plain word, so just say "topic" on the wall.
-const word = 'topic';
+// Tile the channel name itself on the wall (WordBackdrop uppercases it), e.g.
+// "#LURKER". Falls back to "topic" if we somehow open without a channel label.
+const word = computed(() => props.label || 'topic');
 </script>
 
 <style scoped>
 .body {
   /* Break out of card padding so the scrollbar sits against the card
-     border; padding keeps content visually aligned with the rest. */
+     border; padding keeps content visually aligned with the rest. The head
+     already supplies the gap below the divider, so the top padding is just a
+     hair to keep the topic text from crowding it. */
   margin: 0 calc(-1 * var(--card-pad-x));
-  padding: var(--space-7) var(--card-pad-x) 0;
+  padding: var(--space-2) var(--card-pad-x) 0;
   overflow-y: auto;
   flex: 1;
   min-height: 0;

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -16,19 +16,24 @@
 -->
 
 <template>
-  <AppModal word="profile" :title="nick" size="md" @close="onClose">
-    <template #subtitle>
-      <span :class="['presence', presenceClass]">
-        <span class="dot" aria-hidden="true"></span>
-        {{ presenceLabel }}
-      </span>
-      <span v-if="awayMessage" class="away-msg">— {{ awayMessage }}</span>
+  <AppModal word="profile" size="md" @close="onClose">
+    <template #title>
+      <h2>
+        <span
+          class="dot"
+          :class="presenceClass"
+          role="img"
+          :aria-label="presenceLabel"
+          :title="presenceLabel"
+        ></span
+        >{{ nick }}<span v-if="awayMessage" class="away">&nbsp;({{ awayMessage }})</span>
+      </h2>
     </template>
 
     <div class="body">
-      <!-- Identity -->
-      <section v-if="hasIdentity" class="section">
-        <h3>Identity</h3>
+      <!-- Identity + activity merged into one headerless table; the status pills
+           sit under the table (below Channels), then the note section follows. -->
+      <section v-if="hasDetails" class="section">
         <dl>
           <template v-if="whois?.real_name">
             <dt>Real name</dt>
@@ -53,18 +58,13 @@
             <dt>Account</dt>
             <dd>{{ whois.account }}</dd>
           </template>
-        </dl>
-        <div v-if="chips.length" class="chips">
-          <span v-for="c in chips" :key="c.label" :class="['chip', c.tone]">
-            <i v-if="c.icon" :class="c.icon"></i> {{ c.label }}
-          </span>
-        </div>
-      </section>
-
-      <!-- Activity -->
-      <section v-if="hasActivity" class="section">
-        <h3>Activity</h3>
-        <dl>
+          <template v-if="whois?.server">
+            <dt>Server</dt>
+            <dd>
+              {{ whois.server }}
+              <span v-if="whois.server_info" class="muted">({{ whois.server_info }})</span>
+            </dd>
+          </template>
           <template v-if="idleLabel">
             <dt>Idle</dt>
             <dd>{{ idleLabel }}</dd>
@@ -72,13 +72,6 @@
           <template v-if="signonLabel">
             <dt>Signed on</dt>
             <dd>{{ signonLabel }}</dd>
-          </template>
-          <template v-if="whois?.server">
-            <dt>Server</dt>
-            <dd>
-              {{ whois.server }}
-              <span v-if="whois.server_info" class="muted">({{ whois.server_info }})</span>
-            </dd>
           </template>
           <template v-if="channelsList.length">
             <dt>Channels</dt>
@@ -96,25 +89,25 @@
             </dd>
           </template>
         </dl>
+        <div v-if="chips.length" class="chips">
+          <span v-for="c in chips" :key="c.label" :class="['chip', c.tone]">
+            <i v-if="c.icon" :class="c.icon"></i> {{ c.label }}
+          </span>
+        </div>
       </section>
 
-      <!-- Your note -->
-      <section class="section">
-        <h3>Your note</h3>
-        <div v-if="noteText" class="note">
-          <p class="note-body">{{ noteText }}</p>
+      <!-- Your note — headingless; a divider sets it off from the details above
+           (only when there are details to divide from). -->
+      <section class="section note-section" :class="{ divided: hasDetails }">
+        <div class="note">
+          <p v-if="noteText" class="note-body">{{ noteText }}</p>
           <p class="meta">
             <span v-if="noteUpdatedAt">Updated {{ formatDateTime(noteUpdatedAt) }}</span>
             <button type="button" class="link inline" @click="openNoteEditor">
-              <i class="fa-solid fa-pen"></i> Edit
+              <i :class="noteText ? 'fa-solid fa-pen' : 'fa-solid fa-plus'"></i>
+              {{ noteText ? 'Edit' : 'Add note' }}
             </button>
           </p>
-        </div>
-        <div v-else class="note empty">
-          <p class="muted">No note yet.</p>
-          <button type="button" class="link inline" @click="openNoteEditor">
-            <i class="fa-solid fa-plus"></i> Add note
-          </button>
         </div>
       </section>
 
@@ -122,35 +115,33 @@
            If we already know they're offline (MONITOR or not_found whois)
            the presence dot in the header carries that, so we skip the
            redundant line and let "Your note" stand on its own. -->
-      <section v-if="!hasIdentity && !hasActivity && !isOffline" class="section status">
+      <section v-if="!hasDetails && !isOffline" class="section status">
         <p class="muted">
           <i class="fa-solid fa-circle-notch fa-spin"></i> Waiting for whois reply…
         </p>
       </section>
     </div>
 
-    <footer class="footer">
-      <!-- Send DM and Ignore are meaningless while the peer is offline —
-           DMs would bounce and there's no hostmask to build an ignore rule
-           from. Hide entirely rather than disable so the modal doesn't read
-           as "you could do this if only…". -->
+    <footer class="modal-footer">
+      <!-- Send DM and Ignore are meaningless on yourself and while the peer is
+           offline — DMs would bounce and there's no hostmask to build an ignore
+           rule from. Hide entirely rather than disable (matching Add Friend) so
+           the modal doesn't read as "you could do this if only…". -->
       <button
-        v-if="!isOffline"
+        v-if="!isOffline && !isSelf"
         type="button"
         class="btn-secondary"
         title="Send DM"
         @click="onSendDm"
-        :disabled="isSelf"
       >
         <i class="fa-solid fa-envelope"></i> <span class="label">Send DM</span>
       </button>
       <button
-        v-if="!isOffline"
+        v-if="!isOffline && !isSelf"
         type="button"
         class="btn-secondary"
         title="Ignore…"
         @click="onIgnore"
-        :disabled="isSelf"
       >
         <i class="fa-solid fa-ban"></i> <span class="label">Ignore…</span>
       </button>
@@ -321,14 +312,21 @@ const channelsList = computed(() => {
     });
 });
 
-const hasIdentity = computed(
-  () => !!(whois.value && (whois.value.real_name || hostmask.value || whois.value.account)),
-);
-const hasActivity = computed(
+// Any detail row present → render the table. Covers every row (identity +
+// activity, including actual host) so the headerless table shows whenever we
+// have anything at all to display.
+const hasDetails = computed(
   () =>
     !!(
       whois.value &&
-      (idleLabel.value || signonLabel.value || whois.value.server || channelsList.value.length)
+      (whois.value.real_name ||
+        hostmask.value ||
+        actualHost.value ||
+        whois.value.account ||
+        whois.value.server ||
+        idleLabel.value ||
+        signonLabel.value ||
+        channelsList.value.length)
     ),
 );
 
@@ -404,49 +402,47 @@ function copyHostmask() {
   flex: 1;
   min-height: 0;
   /* Break out of card padding so the scrollbar sits against the card
-     border; padding keeps section content visually aligned. */
+     border; padding keeps section content visually aligned. The bottom padding
+     gives the note area breathing room above the footer divider. */
   margin: 0 calc(-1 * var(--card-pad-x));
-  padding: 0 var(--card-pad-x) var(--space-4);
+  padding: 0 var(--card-pad-x) var(--space-7);
 }
 
-.presence {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-3);
-  color: var(--fg);
-  font-weight: 600;
-}
-.presence .dot {
+/* Presence dot sits just left of the nick in the title. The class is applied to
+   the dot itself now (no wrapping .presence label), so colour keys off it. */
+.dot {
   display: inline-block;
   width: 8px;
   height: 8px;
   border-radius: 50%;
   background: var(--fg-muted);
+  margin-right: var(--space-3);
+  vertical-align: middle;
 }
-.presence.online .dot {
+.dot.online {
   background: var(--good);
 }
-.presence.away .dot {
+.dot.away {
   background: var(--warn);
 }
-.presence.offline .dot {
+.dot.offline {
   background: var(--bad);
 }
-.presence.unknown .dot {
+.dot.unknown {
   background: var(--fg-muted);
 }
-.away-msg {
-  margin-left: var(--space-4);
-  color: var(--fg-muted);
-  font-weight: 400;
+/* Away message beside the nick, matching the input-bar prompt: warn-coloured and
+   exempt from the title's lowercase transform so the message reads verbatim. */
+.away {
+  color: var(--warn);
+  text-transform: none;
 }
 
-.section h3 {
-  margin: 0 0 var(--space-4);
-  color: var(--accent);
-  font-weight: 700;
-  text-transform: lowercase;
-  letter-spacing: 0.02em;
+/* Divider above the note section, mirroring the head's rule on the opposite
+   edge. Only applied when there's a details section above it to separate from. */
+.note-section.divided {
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-7);
 }
 
 dl {
@@ -525,17 +521,17 @@ code {
   white-space: pre-wrap;
   word-break: break-word;
 }
-.note.empty {
-  display: flex;
-  align-items: center;
-  gap: var(--space-6);
-}
 .meta {
-  margin: var(--space-4) 0 0;
+  margin: 0;
   color: var(--fg-muted);
   display: flex;
   gap: var(--space-6);
   align-items: baseline;
+}
+/* Only space the meta line off the note body when a note is present; with no
+   note the Add-note button sits on its own with no superfluous top gap. */
+.note-body + .meta {
+  margin-top: var(--space-4);
 }
 
 .link.inline {
@@ -552,16 +548,5 @@ code {
 
 .status {
   padding: var(--space-6) 0;
-}
-
-.footer {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-  padding-top: var(--space-7);
-  border-top: 1px solid var(--border);
-}
-.footer .spacer {
-  flex: 1;
 }
 </style>

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -16,7 +16,7 @@
 -->
 
 <template>
-  <AppModal word="profile" :title="nick" size="md" align="top" @close="onClose">
+  <AppModal word="profile" :title="nick" size="md" @close="onClose">
     <template #subtitle>
       <span :class="['presence', presenceClass]">
         <span class="dot" aria-hidden="true"></span>
@@ -138,28 +138,37 @@
         v-if="!isOffline"
         type="button"
         class="btn-secondary"
+        title="Send DM"
         @click="onSendDm"
         :disabled="isSelf"
       >
-        <i class="fa-solid fa-envelope"></i> Send DM
+        <i class="fa-solid fa-envelope"></i> <span class="label">Send DM</span>
       </button>
       <button
         v-if="!isOffline"
         type="button"
         class="btn-secondary"
+        title="Ignore…"
         @click="onIgnore"
         :disabled="isSelf"
       >
-        <i class="fa-solid fa-ban"></i> Ignore…
+        <i class="fa-solid fa-ban"></i> <span class="label">Ignore…</span>
       </button>
       <!-- Friending works regardless of presence — you can watch an offline
            peer — so this isn't gated on isOffline like Send DM / Ignore. -->
-      <button v-if="!isSelf" type="button" class="btn-secondary" @click="onAddFriend">
-        <i class="fa-solid fa-user-group"></i> {{ isFriend ? 'Edit Friend' : 'Add Friend' }}
+      <button
+        v-if="!isSelf"
+        type="button"
+        class="btn-secondary"
+        :title="isFriend ? 'Edit Friend' : 'Add Friend'"
+        @click="onAddFriend"
+      >
+        <i class="fa-solid fa-user-group"></i>
+        <span class="label">{{ isFriend ? 'Edit Friend' : 'Add Friend' }}</span>
       </button>
       <span class="spacer"></span>
       <button type="button" class="btn-secondary" @click="onRefresh" title="Re-run whois">
-        <i class="fa-solid fa-arrows-rotate"></i> Refresh
+        <i class="fa-solid fa-arrows-rotate"></i> <span class="label">Refresh</span>
       </button>
     </footer>
 
@@ -554,23 +563,5 @@ code {
 }
 .footer .spacer {
   flex: 1;
-}
-.btn-secondary {
-  background: none;
-  border: 1px solid var(--border);
-  color: var(--fg);
-  padding: var(--space-3) var(--space-6);
-  cursor: pointer;
-  font: inherit;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-3);
-}
-.btn-secondary:hover:not(:disabled) {
-  background: var(--bg-soft);
-}
-.btn-secondary:disabled {
-  opacity: 0.4;
-  cursor: default;
 }
 </style>

--- a/vue_client/src/stores/search.ts
+++ b/vue_client/src/stores/search.ts
@@ -44,7 +44,6 @@ export const useSearchStore = defineStore('search', {
     // of "search → reference → close → reopen → next result" reads feels
     // continuous. Reset by runSearch() — a brand-new query starts fresh.
     scrollTop: 0,
-    selectedIndex: 0,
   }),
   actions: {
     setQuery(raw: string) {
@@ -89,7 +88,6 @@ export const useSearchStore = defineStore('search', {
       this.nextBefore = null;
       this.error = '';
       this.scrollTop = 0;
-      this.selectedIndex = 0;
       const payload = this.buildPayload(null);
       if (!payload) {
         this.loading = false;
@@ -139,7 +137,6 @@ export const useSearchStore = defineStore('search', {
       this.error = '';
       this.searched = false;
       this.scrollTop = 0;
-      this.selectedIndex = 0;
     },
   },
 });

--- a/vue_client/src/utils/builtinNetworks.json
+++ b/vue_client/src/utils/builtinNetworks.json
@@ -605,6 +605,17 @@
     "tags": ["turkish"]
   },
   {
+    "name": "IRC4Fun",
+    "host": "irc.irc4fun.net",
+    "port": 6697,
+    "tls": true,
+    "website": "https://www.irc4fun.net/",
+    "users": 470,
+    "channels": 220,
+    "saslLikelyRequired": false,
+    "tags": []
+  },
+  {
     "name": "BOLChat",
     "host": "irc.bol-chat.com",
     "port": 6667,

--- a/vue_client/src/utils/builtinNetworks.json
+++ b/vue_client/src/utils/builtinNetworks.json
@@ -613,7 +613,7 @@
     "users": 470,
     "channels": 220,
     "saslLikelyRequired": false,
-    "tags": []
+    "tags": ["activism", "international", "tech"]
   },
   {
     "name": "BOLChat",

--- a/vue_client/src/views/InviteAccept.vue
+++ b/vue_client/src/views/InviteAccept.vue
@@ -5,8 +5,9 @@
 
 <template>
   <div class="invite">
+    <WordBackdrop word="welcome" />
     <div class="card">
-      <h1>Lurker</h1>
+      <h1>lurker</h1>
 
       <template v-if="checking">
         <p class="subtitle">Checking invite…</p>
@@ -46,7 +47,7 @@
             />
           </label>
           <p class="hint">8+ characters. You can add a passkey later in settings.</p>
-          <button type="submit" :disabled="working || !canSubmit">
+          <button type="submit" class="btn-primary" :disabled="working || !canSubmit">
             {{ submitLabel }}
           </button>
         </form>
@@ -60,6 +61,7 @@
 import { ref, computed, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useAuthStore } from '../stores/auth.js';
+import WordBackdrop from '../components/WordBackdrop.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -115,23 +117,37 @@ async function onAccept() {
 
 <style scoped>
 .invite {
+  position: relative;
   min-height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
 }
 .card {
-  border: 1px solid var(--accent);
-  padding: var(--space-8) var(--space-9);
-  width: 360px;
+  position: relative;
+  z-index: var(--z-base);
+  width: min(380px, 92vw);
+  background: var(--bg);
+  /* Floating-surface chrome shared with the modals (AppModal .card): a subtle
+     --border (not the old loud accent frame), a hair of radius, and the shared
+     drop shadow — the card floats on the WordBackdrop. */
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
+  padding: var(--space-9);
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
 }
 h1 {
-  margin: 0;
+  margin: 0 0 var(--space-2);
   color: var(--accent);
-  font-weight: 600;
+  font-weight: 700;
+  text-transform: lowercase;
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
 }
 .subtitle {
   margin: 0;
@@ -164,10 +180,6 @@ label {
 label span {
   text-transform: uppercase;
   letter-spacing: 0.04em;
-}
-button {
-  cursor: pointer;
-  padding: var(--space-4) var(--space-6);
 }
 .error {
   margin: 0;

--- a/vue_client/src/views/Login.vue
+++ b/vue_client/src/views/Login.vue
@@ -40,7 +40,7 @@
             />
           </label>
           <p class="hint">8+ characters. You can add a passkey later in settings.</p>
-          <button type="submit" :disabled="working">
+          <button type="submit" class="btn-primary" :disabled="working">
             {{ submitLabel }}
           </button>
         </form>
@@ -49,24 +49,11 @@
       <!-- Normal login -->
       <template v-else>
         <p class="subtitle">Sign in to your IRC client.</p>
-        <button v-if="authMethods.passkey" class="primary" :disabled="working" @click="onLogin">
+        <button v-if="authMethods.passkey" class="btn-primary" :disabled="working" @click="onLogin">
           {{ working && loginMode === 'passkey' ? 'Waiting for passkey…' : 'Sign in with passkey' }}
         </button>
 
-        <button
-          v-if="authMethods.passkey && !showPasswordForm"
-          type="button"
-          class="link toggle-link"
-          @click="showPasswordForm = true"
-        >
-          or sign in with password
-        </button>
-
-        <form
-          v-if="showPasswordForm || !authMethods.passkey"
-          @submit.prevent="onPasswordLogin"
-          class="password-form"
-        >
+        <form @submit.prevent="onPasswordLogin" class="password-form">
           <label>
             <span>Username</span>
             <input v-model="username" autocomplete="username" required />
@@ -75,7 +62,7 @@
             <span>Password</span>
             <input v-model="password" type="password" autocomplete="current-password" required />
           </label>
-          <button type="submit" :disabled="working">
+          <button type="submit" class="btn-primary" :disabled="working">
             {{ working && loginMode === 'password' ? 'Signing in…' : 'Sign in with password' }}
           </button>
         </form>
@@ -106,7 +93,6 @@ const router = useRouter();
 const route = useRoute();
 const setup = ref<SetupStatus | null>(null);
 const authMethods = ref<AuthMethods>({ passkey: false });
-const showPasswordForm = ref(false);
 const loginMode = ref<'passkey' | 'password' | null>(null);
 
 const submitLabel = computed(() => (working.value ? 'Creating account…' : 'Create account'));
@@ -119,7 +105,6 @@ onMounted(async () => {
   setup.value = await auth.fetchSetupStatus();
   if (!setup.value?.needsSetup) {
     authMethods.value = await auth.fetchAuthMethods();
-    if (!authMethods.value.passkey) showPasswordForm.value = true;
   }
   loadingStatus.value = false;
 });
@@ -191,10 +176,15 @@ async function onCreateUser() {
 .card {
   position: relative;
   z-index: var(--z-base);
+  width: min(380px, 92vw);
   background: var(--bg);
-  border: 1px solid var(--accent);
+  /* Floating-surface chrome shared with the modals (AppModal .card): a subtle
+     --border (not the old loud accent frame), a hair of radius, and the shared
+     drop shadow — the card floats on the WordBackdrop. */
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
   padding: var(--space-9);
-  width: 360px;
   display: flex;
   flex-direction: column;
   gap: var(--space-6);
@@ -235,26 +225,9 @@ label span {
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-button {
-  cursor: pointer;
-}
-button.primary {
-  padding: var(--space-4) var(--space-6);
-}
 .error {
   margin: 0;
   color: var(--bad);
-}
-.toggle-link {
-  background: none;
-  border: none;
-  color: var(--accent);
-  padding: 0;
-  text-align: left;
-  cursor: pointer;
-}
-.toggle-link:hover {
-  color: var(--fg);
 }
 .password-form {
   margin-top: var(--space-2);


### PR DESCRIPTION
Unifies every floating surface — modals, the Cmd-K switcher, context menus, toasts, autocomplete pickers, and the auth cards — onto one shared "floating-surface" chrome: a subtle `--border` (retiring the loud `--accent` frame), a hair of radius, and a shared `--shadow-popover` token.

Closes #267 
Closes #143 

## What changed
- **Shared chrome**: new `--shadow-popover` / `--shadow-popover-up` elevation tokens; AppModal, QuickSwitcher, ContextMenu, ToastContainer, the input pickers, and the Login/InviteAccept cards all reference them instead of hand-rolled shadows + accent borders.
- **One font size everywhere**: global `h1..h6 { font-size: var(--font-size) }` retires the last `clamp()` modal-title exception; hierarchy now rides on weight/color/position. The login brand and the word backdrop keep their own oversized scoped sizing.
- **Promoted shared button + footer system**: `.btn-primary` / `.btn-secondary` (outline style) and `.modal-footer` / `.modal-form` move into `main.css`, replacing the per-modal `.actions`/`.foot`/`.btn` copies that had drifted across ConfigureFriend, Ignore, NickNote, NetworkForm, UserProfile, LongMessageUpload.
- **AppModal**: dropped the `align` prop and the center/top split — every modal centers, and scrollable "browser" modals use `fill-height` so a filtering list never shifts the header. Mobile modals are now edge-to-edge full-frame sheets.
- **UserProfileModal**: identity + activity merged into one headerless table; presence dot + away message moved into the title.
- **RecentUploadsModal**: trimmed to copy-only row actions (insert/delete intentionally dropped).
- **SearchModal**: simplified to click-to-jump (keyboard result-nav removed alongside the HistoryMessageRow `active`/`hover` props).
- **Login**: when a passkey is registered the password form now renders alongside the passkey button instead of behind an "or sign in with password" toggle — one fewer click. Passkey-only login is unaffected (the passkey button is a separate `type="button"`, so the always-present `required` password fields don't block it).
- **builtinNetworks**: added IRC4Fun.

## Notes for review
Reviewed at xhigh effort — typecheck passes, no correctness bugs. The intentional scope-creep items (RecentUploads insert/delete removal, SearchModal keyboard-nav removal, the Login password-form-always-shown change) are deliberate. One side-effect to eyeball: the global heading rule also brings the Settings-pane titles (`panes.css`, untouched here) down to base size, consistent with the one-font-size system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)