### PR TITLE
Add nick change event

### DIFF
--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1111,6 +1111,7 @@ export class IrcConnection {
           this.regainNick = null;
           this.pendingRegainSetup = false;
         }
+        this.publish({ type: 'own-nick', nick: eventNewNick });
       }
       const userhost = buildUserhost(event);
       for (const ch of this.channels.values()) {

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -141,6 +141,9 @@ function applyEvent(event: any): void {
       if (!buffers.pushMessage(event)) break;
       buffers.renameMember(event.networkId, event.target, event.nick, event.newNick);
       break;
+    case 'own-nick':
+      networks.applyOwnNick(event);
+      break;
     case 'topic':
       if (!buffers.pushMessage(event)) break;
       buffers.setTopic(event.networkId, event.target, event.text);

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -169,6 +169,11 @@ export const useNetworksStore = defineStore('networks', {
         nick: event.nick || existing.nick,
       };
     },
+    applyOwnNick(event: any) {
+      const existing = this.states[event.networkId];
+      if (!existing || !event.nick) return;
+      this.states[event.networkId] = { ...existing, nick: event.nick };
+    },
     applyUserMode(event: any) {
       const existing = this.states[event.networkId] || { networkId: event.networkId, channels: [] };
       this.states[event.networkId] = {


### PR DESCRIPTION
Previously, changing your own nick wouldn't update the input bar. This commit adds an event that updates the nick in the network states.

Fixes #305.