### PR TITLE
Route /help to the server HELP system; move local cheatsheet to /commands

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1587,7 +1587,7 @@ function localInfo(networkId: number, target: string, lineText: string): void {
   });
 }
 
-const HELP_LINES = [
+const COMMANDS_LINES = [
   'commands:',
   '  /me <text>             — emote in the current buffer',
   '  /slap <nick>           — slap someone around a bit with a large trout',
@@ -2103,7 +2103,7 @@ function handleCommand(line: string, networkId: number, target: string): boolean
       );
     }
     case 'commands':
-      for (const helpLine of HELP_LINES) localInfo(networkId, target, helpLine);
+      for (const commandLine of COMMANDS_LINES) localInfo(networkId, target, commandLine);
       return true;
     default:
       return sendOrToast({ type: 'raw', networkId, line: line.slice(1) }, line);

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -249,20 +249,20 @@ const placeholder = computed(() => {
   if (isPaused.value) return 'Account paused — read only';
   const a = active.value;
   if (!a) return 'Select a buffer';
-  // `/raw <line>` was cryptic; `/help` is the discoverable entry point and the
-  // server buffer is exactly where someone goes looking for it.
-  if (isServer.value) return 'try /help';
+  // `/raw <line>` was cryptic; `/commands` is the discoverable entry point and
+  // the server buffer is exactly where someone goes looking for it.
+  if (isServer.value) return 'try /commands';
   // Mobile shows network/channel in the compact status bar now, so the
   // placeholder carries the self identity (nick + channel-prefix) instead, with
   // the away marker appended when set. User modes are dropped here to match the
   // compact status bar hiding channel modes on narrow screens; the desktop
-  // prompt still renders them. Desktop keeps `try /help` since the prompt
+  // prompt still renders them. Desktop keeps `try /commands` since the prompt
   // already shows the identity there.
   if (isMobile.value) {
     const self = promptLabelNoModes.value;
     return awayLabel.value ? `${self} ${awayLabel.value}` : self;
   }
-  return 'try /help';
+  return 'try /commands';
 });
 // HTML attribute values for the system text features. spellcheck is the only
 // one the browser parses as a boolean; the others take "on"/"off" or an enum.
@@ -1575,7 +1575,7 @@ function onLongMessageCancel() {
 }
 
 // Drop a synthetic, non-persisted info line into the current buffer so the
-// user sees the output of client-resolved commands like /help or argument
+// user sees the output of client-resolved commands like /commands or argument
 // validation errors. id-less so pushMessage's replay guard doesn't trip.
 function localInfo(networkId: number, target: string, lineText: string): void {
   buffers.pushMessage({
@@ -1614,12 +1614,12 @@ const HELP_LINES = [
   '  /reconnect             — reconnect to current network',
   '  /list                  — list channels on current network',
   '  /who [mask]            — find users (also /whowas /userhost /ison /names)',
-  '  /motd /version /time   — server info (also /admin /info /lusers /links /map /stats)',
+  '  /motd /version /time   — server info (also /admin /info /lusers /links /map /stats /help)',
   '  /jitsi                 — start a video call (alias: /talk)',
   '  /ignore [mask]         — list current ignores, or add (nick or nick!user@host)',
   '  /unignore <mask>       — remove an ignore entry',
   '  /raw <line>            — send a raw IRC line (alias: /quote)',
-  '  /help                  — this list',
+  '  /commands              — this list',
   '  //text                 — send literal "/text" as a message (escape)',
 ];
 
@@ -2074,7 +2074,7 @@ function handleCommand(line: string, networkId: number, target: string): boolean
     }
     // Info/query commands. These already function via the raw fallback now that
     // unhandled server numerics surface in the server buffer (#269) — listing
-    // them explicitly uppercases the verb, documents them in /help, and gives a
+    // them explicitly uppercases the verb, documents them in /commands, and gives a
     // single home for any future per-command argument handling. Each forwards
     // its IRC verb plus whatever args were typed (server/target/mask/nick…); a
     // missing-arg server error (e.g. bare /whowas) now surfaces on its own.
@@ -2091,14 +2091,18 @@ function handleCommand(line: string, networkId: number, target: string): boolean
     case 'map':
     case 'stats':
     case 'userhost':
-    case 'ison': {
+    case 'ison':
+    // `/help` queries the network's own HELP system (704/705/706 render in the
+    // server buffer like any other server reply); the local slash-command
+    // cheatsheet lives under `/commands` below (#316).
+    case 'help': {
       const verb = cmd.toUpperCase();
       return sendOrToast(
         { type: 'raw', networkId, line: argLine ? `${verb} ${argLine}` : verb },
         line,
       );
     }
-    case 'help':
+    case 'commands':
       for (const helpLine of HELP_LINES) localInfo(networkId, target, helpLine);
       return true;
     default:

--- a/vue_client/src/stores/inputHistory.ts
+++ b/vue_client/src/stores/inputHistory.ts
@@ -8,7 +8,7 @@ function key(networkId: number | string, target: string) {
 }
 
 // Per-buffer history of every line submitted through the input bar (chat,
-// /commands, /raw, even client-only lines like /help). Server is the source of
+// /raw, even client-only lines like /commands). Server is the source of
 // truth; this store mirrors the most-recent slice the server ships on snapshot
 // plus optimistic local appends on submit. MessageInput drives up/down recall
 // off `forBuffer`.

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -45,7 +45,7 @@
         </button>
         <!-- Channels and DMs drop the name here — the compact status bar
              carries net/#chan on mobile, so a header copy is just redundant
-             clutter (#222). The server buffer (input placeholder is "try /help")
+             clutter (#222). The server buffer (input placeholder is "try /commands")
              and the system console (no input row at all) have no
              other persistent label, so they keep an explicit title. Otherwise
              the bar holds only buffer-scoped actions: search & highlights open


### PR DESCRIPTION
## What

Resolves #316. `/help` was intercepted client-side and printed Lurker's own slash-command cheatsheet, so the network's `HELP` system was unreachable through it — even though the 704/705/706 reply numerics now render in the server buffer (from #312/#281).

Per the issue discussion:

- **`/help` → server `HELP`** — joins the existing info/query passthrough group in `MessageInput.vue`, forwarding `HELP` (uppercased, plus any args) to the network like `/motd`, `/info`, `/links`, etc. Its reply renders in the server buffer via the numerics already shipped.
- **`/commands` → local cheatsheet** — the old `/help` body verbatim, just renamed.
- Input placeholder changes `try /help` → `try /commands`; `HELP_LINES`, the `inputHistory`/`MobileChat` comments are updated, and `/help` is now listed among the server-info commands in the cheatsheet.

## Testing

- `npm run typecheck:client` (vue-tsc) clean, `oxfmt --check` clean, `oxlint` clean (only pre-existing unrelated warnings).
- No client tests or command registries reference these command names.

Closes #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)