### PR TITLE
Fix friend-list presence + unread coloring (#302, #307)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -386,8 +386,9 @@ describe('addPeerWatch live presence seed (#302)', () => {
 
     conn.trackFriend('offlinepal', 42);
 
-    expect(raw).toHaveBeenCalledWith('MONITOR + offlinepal');
-    expect(raw).toHaveBeenCalledWith('MONITOR S');
+    // Order matters: the nick must be added before MONITOR S, or the status
+    // dump won't include it.
+    expect(raw.mock.calls.map((c) => c[0])).toEqual(['MONITOR + offlinepal', 'MONITOR S']);
   });
 
   it('issues no MONITOR traffic when the server does not support it', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -346,6 +346,63 @@ describe('tls certificate trust setting', () => {
   });
 });
 
+describe('addPeerWatch live presence seed (#302)', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'nick',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  // A friend added while connected must get a MONITOR S follow-up: the server
+  // only SHOULD (not MUST) volunteer current state in reply to MONITOR +, so
+  // without the explicit status query a freshly-added offline friend lands with
+  // no state and renders as if online until a reconnect re-seeds.
+  it('follows MONITOR + with MONITOR S when a friend is tracked on a live connection', () => {
+    const conn = makeConn();
+    conn.useMonitor = true;
+    conn.monitorLimit = 100;
+    conn.state = 'connected';
+    const raw = vi.fn<(...args: string[]) => void>();
+    conn.client.raw = raw;
+
+    conn.trackFriend('offlinepal', 42);
+
+    expect(raw).toHaveBeenCalledWith('MONITOR + offlinepal');
+    expect(raw).toHaveBeenCalledWith('MONITOR S');
+  });
+
+  it('issues no MONITOR traffic when the server does not support it', () => {
+    const conn = makeConn();
+    conn.useMonitor = false;
+    conn.state = 'connected';
+    const raw = vi.fn<(...args: string[]) => void>();
+    conn.client.raw = raw;
+
+    conn.trackFriend('offlinepal', 42);
+
+    expect(raw).not.toHaveBeenCalled();
+  });
+});
+
 describe('formatSocketCloseErrorMessage', () => {
   const where = 'irc.example.test:6697';
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1732,6 +1732,15 @@ export class IrcConnection {
     }
     try {
       this.client.raw('MONITOR + ' + nick);
+      // Same belt-and-suspenders as seedMonitorWatch: per IRCv3 the server only
+      // SHOULD (not MUST) volunteer the nick's current state in reply to
+      // MONITOR +, so a freshly-added watch can land with no state. That leaves
+      // the peer at 'unknown' on the client, which the friends list renders
+      // undimmed — i.e. indistinguishable from online — until a reconnect
+      // re-seeds. MONITOR S asks for every monitored nick's state explicitly;
+      // markPeerEvent's idempotency gate eats the duplicate replies for nicks we
+      // already had state for, so it's safe to send on every add. (#302)
+      this.client.raw('MONITOR S');
     } catch (_) {
       /* ignore */
     }

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -526,8 +526,15 @@ function friendRowClasses(c: Contact): Record<string, boolean> {
   // Reflect the PRIMARY DM's presence — that's the buffer this row opens, so an
   // alt being online elsewhere must not make the row look reachable.
   const state = friends.primaryPresence(c.id);
+  // Mirror rowClasses so an unread/highlighted friend DM colors its name like
+  // any other buffer (DMs are never muted, so no mute gate). An offline/away
+  // friend with unread still dims to gray — the peer-state rule wins on source
+  // order — but the accent-colored unread badge still flags it. (#307)
+  const buf = friendDmBuffer(c);
   return {
     active: isFriendDmActive(c),
+    unread: !!buf && buf.unread > 0,
+    highlighted: !!buf && buf.highlighted > 0,
     'peer-offline': state === 'offline',
     'peer-away': state === 'away',
   };


### PR DESCRIPTION
Fixes two bugs in the friends list, both rooted in the friend-row rendering path.

## #307 — accent color not affecting friend nicknames
Friend rows used a separate `friendRowClasses()` that only set `peer-offline`/`peer-away`, never `unread`/`highlighted` — so the unread **badge** rendered but the nick text color never changed. Now mirrors the regular-buffer `rowClasses()`: friend rows get `unread`/`highlighted` classes so an unread friend DM colors its name like any other buffer (DMs are never muted, so no mute gate).

An offline/away friend with unread still dims to gray — the peer-state CSS rule wins on source order, matching how regular offline DMs render — but the accent-colored unread badge still flags it.

## #302 — newly-added offline friend shows online until refresh
The friends list renders a peer with no known presence (`unknown`) in full foreground color — visually identical to online. When you add a friend on a live connection, `addPeerWatch()` sent only `MONITOR + <nick>`; per IRCv3 the server only *SHOULD* (not MUST) volunteer current state in reply, so the offline state often never arrived live and the peer stayed `unknown` (= looks online) until a reconnect re-seeded on refresh.

The bulk connect-time path (`seedMonitorWatch`) already guards against this with a follow-up `MONITOR S`; the dynamic single-add path just forgot it. Fixed by sending the same `MONITOR S` — idempotent, since `markPeerEvent`'s gate eats duplicate replies. Covers DM peers too, since both flow through `addPeerWatch`.

## Tests
- Added 2 regression tests: `MONITOR S` fires on a live track, and no MONITOR traffic is sent when the server lacks support.
- Full suite green (928 tests), `npm run check` clean.

Closes #302
Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)