### PR TITLE
Fix Shift+Esc resurrecting closed buffers (#319)

### DIFF
--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1443,12 +1443,21 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // Clamp every buffer's read pointer to its tail across all of this
         // user's networks. Skip buffers already at-or-past the tail so we
         // don't broadcast a no-op read-state to every tab.
+        //
+        // maxIdByBuffer returns every target with history, including closed
+        // buffers. Skip those (mirroring the snapshot filter): broadcasting a
+        // read-state for a closed buffer would otherwise resurrect it in the
+        // sidebar (#319). A currently-joined channel beats a stale closed flag,
+        // same carve-out as the snapshot.
+        const closed = closedKeySetForUser(userId);
         for (const conn of ircManager.listConnections(userId)) {
           const networkId = conn.network.id;
           for (const row of maxIdByBuffer(networkId)) {
             const target = row.target;
             const maxId = Number(row.maxId);
             if (!target || !Number.isFinite(maxId) || maxId <= 0) continue;
+            if (closed.has(`${networkId}::${target}`) && !conn.channels.has(target.toLowerCase()))
+              continue;
             const before = getReadState(userId, networkId, target);
             if (before >= maxId) continue;
             const after = setReadState(userId, networkId, target, maxId);

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+// buffers.ts reaches into the networks/toasts stores and the socket. applyReadState
+// only consults useNetworksStore().activeKey, so a minimal mutable mock covers it;
+// toasts/socket are stubbed so importing the store doesn't stand up the rest of the
+// graph.
+const h = vi.hoisted(() => ({ activeKey: null as string | null }));
+
+vi.mock('./networks.js', () => ({
+  useNetworksStore: () => ({
+    get activeKey() {
+      return h.activeKey;
+    },
+  }),
+}));
+vi.mock('./toasts.js', () => ({ useToastsStore: () => ({ push: vi.fn<() => void>() }) }));
+vi.mock('../composables/useSocket.js', () => ({ socketSend: vi.fn<(payload: unknown) => void>() }));
+
+import { useBuffersStore } from './buffers.js';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  h.activeKey = null;
+});
+
+describe('applyReadState', () => {
+  // Regression for #319: mark-all-read fans out a read-state for every target
+  // with history, including closed buffers (absent from the store). Applying
+  // one must NOT materialize the buffer, or the closed buffer pops back into
+  // the sidebar.
+  it('does not create a buffer that is not open', () => {
+    const store = useBuffersStore();
+    expect(store.isOpen(1, '#closed')).toBe(false);
+
+    store.applyReadState(1, '#closed', { lastReadId: 10, unread: 5, highlights: 2 });
+
+    expect(store.isOpen(1, '#closed')).toBe(false);
+    expect(store.list).toHaveLength(0);
+  });
+
+  it('updates the badge on an open buffer', () => {
+    const store = useBuffersStore();
+    // replaceBacklog ensures the buffer exists (the snapshot path), so this is
+    // an "open" buffer.
+    store.replaceBacklog(1, '#open', [], undefined, undefined, undefined);
+    expect(store.isOpen(1, '#open')).toBe(true);
+
+    store.applyReadState(1, '#open', { lastReadId: 42, unread: 3, highlights: 1 });
+
+    const buf = store.byKey('1::#open')!;
+    expect(buf.unread).toBe(3);
+    expect(buf.highlighted).toBe(1);
+    expect(buf.lastReadId).toBe(42);
+  });
+
+  it('suppresses the unread badge for the active buffer', () => {
+    const store = useBuffersStore();
+    store.replaceBacklog(1, '#here', [], undefined, undefined, undefined);
+    h.activeKey = '1::#here';
+
+    store.applyReadState(1, '#here', { lastReadId: 42, unread: 9, highlights: 4 });
+
+    const buf = store.byKey('1::#here')!;
+    expect(buf.unread).toBe(0);
+    expect(buf.highlighted).toBe(0);
+  });
+});

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -747,7 +747,14 @@ export const useBuffersStore = defineStore('buffers', {
     // — the server fires one after each countable message and after every
     // mark-read, so badges stay in sync without client-side increments.
     applyReadState(networkId: number | string, target: string, payload: any) {
-      const buf = ensureBuffer(this, networkId, target);
+      // Update an existing buffer only — never materialize one. A closed buffer
+      // is absent from the store (see isOpen), and a stray read-state broadcast
+      // for it (e.g. mark-all-read fans out over every target with history, open
+      // or not) would otherwise re-create the entry and pop it back into the
+      // sidebar (#319). A buffer that isn't open has no badge to update anyway.
+      // Snapshot callers (replaceBacklog) ensureBuffer before delegating here.
+      const buf = this.buffers[key(networkId, target)];
+      if (!buf) return;
       const lastReadId = Number(payload?.lastReadId) || 0;
       const networks = useNetworksStore();
       const isActive = networks.activeKey === `${networkId}::${target}`;


### PR DESCRIPTION
## Problem

Shift+Esc (mark-all-read) was meant to clear unread badges, but it also caused previously-closed buffers to reappear in the sidebar (#319).

## Root cause

Two-part interaction:

- **Server** — `mark-all-read` (`wsHub.ts`) loops over `maxIdByBuffer(networkId)`, which is *every target with history* (a bare `GROUP BY target`, no open/closed filter), and broadcasts a `read-state` for each — including buffers the user has closed.
- **Client** — `applyReadState` (`stores/buffers.ts`) started with `ensureBuffer(...)`, which **creates** a missing buffer. Since a closed buffer is defined as one *absent from the store* (see the `isOpen` getter) and the sidebar is just `Object.values(state.buffers)`, the broadcast re-materialized every closed buffer's entry.

It was transient — a reload cleared them, because the snapshot path correctly filters closed buffers (`closedKeySetForUser`). This wasn't really Shift+Esc-specific; it's the `mark-all-read` path, and Shift+Esc is its only trigger.

## Fix (both halves)

- **Client:** `applyReadState` updates an existing buffer only — never materializes one. A buffer that isn't open has no badge to update anyway, and snapshot callers (`replaceBacklog`) already `ensureBuffer` before delegating here. This neutralizes the whole *class* — any future read-state for a closed buffer is harmless.
- **Server:** `mark-all-read` now skips closed buffers, mirroring the snapshot filter exactly (a currently-joined channel still beats a stale closed flag), so the pointless broadcast never happens.

## Tests

Adds `vue_client/src/stores/buffers.test.ts` covering `applyReadState`: it must not create a missing buffer (the regression), still updates an open buffer's badge, and still suppresses the badge for the active buffer.

`npm run check` (typecheck server + client, lint, format) clean; related suites (wsHub, closedBuffers, friends, buffers) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)