### PR TITLE
Add opt-in setting to show user@host on join/part/quit/nick events (#322)

### DIFF
--- a/server/db/closedBuffers.test.ts
+++ b/server/db/closedBuffers.test.ts
@@ -53,4 +53,12 @@ describe('closedKeySetForUser', () => {
     expect(set.has(`${net!.id}::#a`)).toBe(true);
     expect(set.has(`${net!.id}::#b`)).toBe(true);
   });
+
+  // Keys are case-folded so a buffer closed under one casing still matches a
+  // history row stored under another (#289/#319). Callers fold on lookup too.
+  it('case-folds target keys', () => {
+    closedBuffers.closeBuffer(user.id, net!.id, '#MixedCase');
+    const set = closedBuffers.closedKeySetForUser(user.id);
+    expect(set.has(`${net!.id}::#mixedcase`)).toBe(true);
+  });
 });

--- a/server/db/closedBuffers.ts
+++ b/server/db/closedBuffers.ts
@@ -36,11 +36,16 @@ export function isClosed(userId: number, networkId: number, target: string): boo
 }
 
 // Returns Set of `${networkId}::${target}` keys for fast snapshot filtering.
+// Targets are case-folded so the lookup tolerates servers handing us
+// inconsistently-cased channel/nick names (#289/#319) — a DM closed as `Bob`
+// still matches a `bob` history row. Callers must fold the target on lookup too
+// (see isHiddenClosedBuffer in wsHub). IRC targets are case-insensitive, so
+// folding can't collide two genuinely distinct buffers.
 export function closedKeySetForUser(userId: number): Set<string> {
   const set = new Set<string>();
   const rows = listForUserStmt.all(userId) as Array<{ networkId: number; target: string }>;
   for (const row of rows) {
-    set.add(`${row.networkId}::${row.target}`);
+    set.add(`${row.networkId}::${row.target.toLowerCase()}`);
   }
   return set;
 }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -391,12 +391,31 @@ export function buildOfflineBacklogFrames(
     for (const target of targets) {
       // Server pseudo-buffer is uncloseable; otherwise honor a closed flag.
       // Nothing is joined on an offline network, so there's no autorejoin race
-      // to defend against here (unlike the live loop in sendSnapshot).
-      if (!target.startsWith(':server:') && closed.has(`${net.id}::${target}`)) continue;
+      // to defend against here (unlike the live loop in sendSnapshot). The
+      // closed set is case-folded, so fold the target on lookup too.
+      if (!target.startsWith(':server:') && closed.has(`${net.id}::${target.toLowerCase()}`))
+        continue;
       frames.push(buildBufferBacklog(userId, net.id, target));
     }
   }
   return frames;
+}
+
+// A buffer the user closed and isn't currently joined to is hidden from the
+// sidebar; broadcasting or seeding a frame for it would resurrect it (#319).
+// Centralizes the live-loop carve-out shared by the snapshot and mark-all-read
+// so the two sites can't drift. The closed set is case-folded
+// (closedKeySetForUser), so fold the target here too — servers hand us
+// inconsistently-cased names (#289). A currently-joined channel always beats a
+// stale closed flag (defensive against autorejoin/state races).
+function isHiddenClosedBuffer(
+  closed: Set<string>,
+  joined: { has(name: string): boolean },
+  networkId: number,
+  target: string,
+): boolean {
+  const lower = target.toLowerCase();
+  return closed.has(`${networkId}::${lower}`) && !joined.has(lower);
 }
 
 // Handles a client `open-buffer` request (a clicked channel name). Resolves
@@ -1047,10 +1066,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       for (const target of targets) {
         if (target.startsWith(':server:')) {
           // Server pseudo-buffer is uncloseable — never filter.
-        } else if (
-          closed.has(`${conn.network.id}::${target}`) &&
-          !conn.channels.has(target.toLowerCase())
-        ) {
+        } else if (isHiddenClosedBuffer(closed, conn.channels, conn.network.id, target)) {
           continue;
         }
         // Resume cursor: ship the gap the client missed (id > sinceId), or a
@@ -1445,10 +1461,12 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // don't broadcast a no-op read-state to every tab.
         //
         // maxIdByBuffer returns every target with history, including closed
-        // buffers. Skip those (mirroring the snapshot filter): broadcasting a
-        // read-state for a closed buffer would otherwise resurrect it in the
-        // sidebar (#319). A currently-joined channel beats a stale closed flag,
-        // same carve-out as the snapshot.
+        // buffers. "Mark all read" means *all*, so we still clamp the read
+        // pointer for a closed buffer (otherwise reopening it later resurfaces
+        // the stale unread the user just cleared) — but we must NOT broadcast a
+        // read-state for one that's closed-and-not-joined: the client would
+        // re-materialize it and pop it back into the sidebar (#319). So clamp
+        // first, then skip only the broadcast.
         const closed = closedKeySetForUser(userId);
         for (const conn of ircManager.listConnections(userId)) {
           const networkId = conn.network.id;
@@ -1456,11 +1474,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
             const target = row.target;
             const maxId = Number(row.maxId);
             if (!target || !Number.isFinite(maxId) || maxId <= 0) continue;
-            if (closed.has(`${networkId}::${target}`) && !conn.channels.has(target.toLowerCase()))
-              continue;
             const before = getReadState(userId, networkId, target);
             if (before >= maxId) continue;
             const after = setReadState(userId, networkId, target, maxId);
+            if (isHiddenClosedBuffer(closed, conn.channels, networkId, target)) continue;
             broadcastReadState(userId, networkId, target, after);
           }
         }

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -689,7 +689,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
   {
     key: 'chat.show_event_host',
-    label: 'Show user@host on join/part/quit',
+    label: 'Show user@host on join/part/quit/nick',
     category: 'chat',
     group: 'consolidate',
     type: 'bool',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -688,17 +688,18 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'are preferred when picking which names to show.',
   },
   {
-    key: 'chat.show_join_host',
-    label: 'Show user@host on joins',
+    key: 'chat.show_event_host',
+    label: 'Show user@host on join/part/quit',
     category: 'chat',
     group: 'consolidate',
     type: 'bool',
     default: false,
     description:
-      'Show the joining user’s user@host next to their nick on JOIN lines ' +
-      '(e.g. "alice (~alice@host.example.net) joined") — useful for channel ops ' +
-      'spotting ban masks. Applies to individual join lines only; bursts that ' +
-      'collapse into the consolidation summary above don’t show host masks.',
+      'Show the affected user’s user@host next to their nick on JOIN, PART, ' +
+      'QUIT, and nick-change lines (e.g. "alice (~alice@host.example.net) ' +
+      'joined") — useful for channel ops spotting ban masks. Applies to ' +
+      'individual lines only; events that collapse into the consolidation ' +
+      'summary above stay host-less. Regular chat messages are unaffected.',
   },
 
   // ─── Composing (outgoing message guardrails) ─────────────────────────

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -687,6 +687,19 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       '"and N others". Recent speakers (those tracked for nick completion) ' +
       'are preferred when picking which names to show.',
   },
+  {
+    key: 'chat.show_join_host',
+    label: 'Show user@host on joins',
+    category: 'chat',
+    group: 'consolidate',
+    type: 'bool',
+    default: false,
+    description:
+      'Show the joining user’s user@host next to their nick on JOIN lines ' +
+      '(e.g. "alice (~alice@host.example.net) joined") — useful for channel ops ' +
+      'spotting ban masks. Applies to individual join lines only; bursts that ' +
+      'collapse into the consolidation summary above don’t show host masks.',
+  },
 
   // ─── Composing (outgoing message guardrails) ─────────────────────────
   // irc-framework splits anything past ~350 bytes into multiple PRIVMSGs on

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -799,17 +799,18 @@ function prefixText(m: ChatMessage | undefined): string {
 }
 
 // When the "Show user@host on joins" setting is on, return the joining user's
-// user@host — the `ident@host` portion of the stored `nick!ident@host` — for
-// display next to their nick on a JOIN line (#322). Returns null when the
-// setting is off, the userhost is missing (pre-upgrade backlog rows, or a
-// JOIN with no prefix), or it can't be parsed.
+// `user@host` for display next to their nick on a JOIN line (#322). Returns
+// null when the setting is off, the userhost is missing (pre-upgrade backlog
+// rows, or a JOIN with no prefix), or either half is absent — the server stores
+// an empty ident/host when it lacks one (`nick!@host` / `nick!ident@`), and a
+// half-mask like `(@host)` reads worse than nothing, so we only render when
+// both pieces are present. Reuses parseUserHost so parsing matches the ignore
+// flow exactly.
 function joinHost(m: ChatMessage | undefined): string | null {
   if (!showJoinHost.value) return null;
-  const uh = m?.userhost;
-  if (!uh) return null;
-  const bang = uh.indexOf('!');
-  if (bang === -1) return null;
-  return uh.slice(bang + 1) || null;
+  const { user, host } = parseUserHost(m?.userhost);
+  if (!user || !host) return null;
+  return `${user}@${host}`;
 }
 
 function prefixClass(m: ChatMessage | undefined) {

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -108,7 +108,10 @@
               :network-id="buffer?.networkId ?? null"
             />
             <template v-else-if="row.m?.type === 'join'"
-              ><NickRef :nick="row.m.nick ?? ''" /> joined</template
+              ><NickRef :nick="row.m.nick ?? ''" /><template v-if="joinHost(row.m)">
+                ({{ joinHost(row.m) }})</template
+              >
+              joined</template
             >
             <template v-else-if="row.m?.type === 'part'"
               ><NickRef :nick="row.m.nick ?? ''" /> left<template v-if="row.m.text">
@@ -519,6 +522,8 @@ const consolidateMaxNames = computed(
   () => (settings.effective('chat.consolidate_max_names') as number) || 5,
 );
 
+const showJoinHost = computed(() => !!settings.effective('chat.show_join_host'));
+
 const collapseAuthorsEnabled = computed(
   () => !!settings.effective('look.message.collapse_authors'),
 );
@@ -791,6 +796,20 @@ function prefixText(m: ChatMessage | undefined): string {
     default:
       return '';
   }
+}
+
+// When the "Show user@host on joins" setting is on, return the joining user's
+// user@host — the `ident@host` portion of the stored `nick!ident@host` — for
+// display next to their nick on a JOIN line (#322). Returns null when the
+// setting is off, the userhost is missing (pre-upgrade backlog rows, or a
+// JOIN with no prefix), or it can't be parsed.
+function joinHost(m: ChatMessage | undefined): string | null {
+  if (!showJoinHost.value) return null;
+  const uh = m?.userhost;
+  if (!uh) return null;
+  const bang = uh.indexOf('!');
+  if (bang === -1) return null;
+  return uh.slice(bang + 1) || null;
 }
 
 function prefixClass(m: ChatMessage | undefined) {

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -801,7 +801,7 @@ function prefixText(m: ChatMessage | undefined): string {
   }
 }
 
-// When the "Show user@host on join/part/quit" setting is on, return the
+// When the "Show user@host on join/part/quit/nick" setting is on, return the
 // affected user's ` (user@host)` suffix (leading space + parens, ready to drop
 // straight after the nick) for a presence event line — join, part, quit, nick
 // (#322). Returns '' when the setting is off, the userhost is missing

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -108,24 +108,19 @@
               :network-id="buffer?.networkId ?? null"
             />
             <template v-else-if="row.m?.type === 'join'"
-              ><NickRef :nick="row.m.nick ?? ''" /><template v-if="eventHost(row.m)">
-                ({{ eventHost(row.m) }})</template
-              >
-              joined</template
+              ><NickRef :nick="row.m.nick ?? ''" />{{ eventHostSuffix(row.m) }} joined</template
             >
             <template v-else-if="row.m?.type === 'part'"
-              ><NickRef :nick="row.m.nick ?? ''" /><template v-if="eventHost(row.m)">
-                ({{ eventHost(row.m) }})</template
+              ><NickRef :nick="row.m.nick ?? ''" />{{ eventHostSuffix(row.m) }} left<template
+                v-if="row.m.text"
               >
-              left<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
             <template v-else-if="row.m?.type === 'quit'"
-              ><NickRef :nick="row.m.nick ?? ''" /><template v-if="eventHost(row.m)">
-                ({{ eventHost(row.m) }})</template
+              ><NickRef :nick="row.m.nick ?? ''" />{{ eventHostSuffix(row.m) }} quit<template
+                v-if="row.m.text"
               >
-              quit<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
@@ -136,10 +131,9 @@
               ></template
             >
             <template v-else-if="row.m?.type === 'nick'"
-              ><NickRef :nick="row.m.nick ?? ''" /> is now
-              <NickRef :nick="row.m.newNick ?? ''" /><template v-if="eventHost(row.m)">
-                ({{ eventHost(row.m) }})</template
-              ></template
+              ><NickRef :nick="row.m.nick ?? ''" /> is now <NickRef :nick="row.m.newNick ?? ''" />{{
+                eventHostSuffix(row.m)
+              }}</template
             >
             <template v-else-if="row.m?.type === 'mode'"
               >mode by <NickRef :nick="row.m.nick ?? ''" /><template v-if="row.m.text"
@@ -808,18 +802,22 @@ function prefixText(m: ChatMessage | undefined): string {
 }
 
 // When the "Show user@host on join/part/quit" setting is on, return the
-// affected user's `user@host` for display next to their nick on a presence
-// event line — join, part, quit, nick (#322). Returns null when the setting is
-// off, the userhost is missing (pre-upgrade backlog rows, or an event with no
-// prefix), or either half is absent — the server stores an empty ident/host
-// when it lacks one (`nick!@host` / `nick!ident@`), and a half-mask like
-// `(@host)` reads worse than nothing, so we only render when both pieces are
-// present. Reuses parseUserHost so parsing matches the ignore flow exactly.
-function eventHost(m: ChatMessage | undefined): string | null {
-  if (!showEventHost.value) return null;
+// affected user's ` (user@host)` suffix (leading space + parens, ready to drop
+// straight after the nick) for a presence event line — join, part, quit, nick
+// (#322). Returns '' when the setting is off, the userhost is missing
+// (pre-upgrade backlog rows, or an event with no prefix), or either half is
+// absent — the server stores an empty ident/host when it lacks one
+// (`nick!@host` / `nick!ident@`), and a half-mask like `(@host)` reads worse
+// than nothing, so we only render when both pieces are present. The full
+// formatting (leading space + parens) lives here so the four presence-line
+// templates share one source of truth and each call it once (only the matching
+// branch renders per row); reuses parseUserHost so parsing matches the ignore
+// flow exactly.
+function eventHostSuffix(m: ChatMessage | undefined): string {
+  if (!showEventHost.value) return '';
   const { user, host } = parseUserHost(m?.userhost);
-  if (!user || !host) return null;
-  return `${user}@${host}`;
+  if (!user || !host) return '';
+  return ` (${user}@${host})`;
 }
 
 function prefixClass(m: ChatMessage | undefined) {

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -108,18 +108,24 @@
               :network-id="buffer?.networkId ?? null"
             />
             <template v-else-if="row.m?.type === 'join'"
-              ><NickRef :nick="row.m.nick ?? ''" /><template v-if="joinHost(row.m)">
-                ({{ joinHost(row.m) }})</template
+              ><NickRef :nick="row.m.nick ?? ''" /><template v-if="eventHost(row.m)">
+                ({{ eventHost(row.m) }})</template
               >
               joined</template
             >
             <template v-else-if="row.m?.type === 'part'"
-              ><NickRef :nick="row.m.nick ?? ''" /> left<template v-if="row.m.text">
+              ><NickRef :nick="row.m.nick ?? ''" /><template v-if="eventHost(row.m)">
+                ({{ eventHost(row.m) }})</template
+              >
+              left<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
             <template v-else-if="row.m?.type === 'quit'"
-              ><NickRef :nick="row.m.nick ?? ''" /> quit<template v-if="row.m.text">
+              ><NickRef :nick="row.m.nick ?? ''" /><template v-if="eventHost(row.m)">
+                ({{ eventHost(row.m) }})</template
+              >
+              quit<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
@@ -130,8 +136,11 @@
               ></template
             >
             <template v-else-if="row.m?.type === 'nick'"
-              ><NickRef :nick="row.m.nick ?? ''" /> is now <NickRef :nick="row.m.newNick ?? ''"
-            /></template>
+              ><NickRef :nick="row.m.nick ?? ''" /> is now
+              <NickRef :nick="row.m.newNick ?? ''" /><template v-if="eventHost(row.m)">
+                ({{ eventHost(row.m) }})</template
+              ></template
+            >
             <template v-else-if="row.m?.type === 'mode'"
               >mode by <NickRef :nick="row.m.nick ?? ''" /><template v-if="row.m.text"
                 >: <LinkedText :text="row.m.text" /></template
@@ -522,7 +531,7 @@ const consolidateMaxNames = computed(
   () => (settings.effective('chat.consolidate_max_names') as number) || 5,
 );
 
-const showJoinHost = computed(() => !!settings.effective('chat.show_join_host'));
+const showEventHost = computed(() => !!settings.effective('chat.show_event_host'));
 
 const collapseAuthorsEnabled = computed(
   () => !!settings.effective('look.message.collapse_authors'),
@@ -798,16 +807,16 @@ function prefixText(m: ChatMessage | undefined): string {
   }
 }
 
-// When the "Show user@host on joins" setting is on, return the joining user's
-// `user@host` for display next to their nick on a JOIN line (#322). Returns
-// null when the setting is off, the userhost is missing (pre-upgrade backlog
-// rows, or a JOIN with no prefix), or either half is absent — the server stores
-// an empty ident/host when it lacks one (`nick!@host` / `nick!ident@`), and a
-// half-mask like `(@host)` reads worse than nothing, so we only render when
-// both pieces are present. Reuses parseUserHost so parsing matches the ignore
-// flow exactly.
-function joinHost(m: ChatMessage | undefined): string | null {
-  if (!showJoinHost.value) return null;
+// When the "Show user@host on join/part/quit" setting is on, return the
+// affected user's `user@host` for display next to their nick on a presence
+// event line — join, part, quit, nick (#322). Returns null when the setting is
+// off, the userhost is missing (pre-upgrade backlog rows, or an event with no
+// prefix), or either half is absent — the server stores an empty ident/host
+// when it lacks one (`nick!@host` / `nick!ident@`), and a half-mask like
+// `(@host)` reads worse than nothing, so we only render when both pieces are
+// present. Reuses parseUserHost so parsing matches the ignore flow exactly.
+function eventHost(m: ChatMessage | undefined): string | null {
+  if (!showEventHost.value) return null;
   const { user, host } = parseUserHost(m?.userhost);
   if (!user || !host) return null;
   return `${user}@${host}`;

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -68,4 +68,40 @@ describe('applyReadState', () => {
     expect(buf.unread).toBe(0);
     expect(buf.highlighted).toBe(0);
   });
+
+  // Servers hand us inconsistently-cased channel/nick names (#289). A read-state
+  // broadcast whose target case differs from the buffer's stored key must still
+  // resolve to the open buffer (findByTarget), not silently drop the badge or
+  // fork a phantom lowercase entry.
+  it('updates a buffer opened under a different target case', () => {
+    const store = useBuffersStore();
+    store.replaceBacklog(1, '#Chan', [], undefined, undefined, undefined);
+    expect(store.isOpen(1, '#Chan')).toBe(true);
+
+    store.applyReadState(1, '#chan', { lastReadId: 7, unread: 4, highlights: 1 });
+
+    const buf = store.byKey('1::#Chan')!;
+    expect(buf.unread).toBe(4);
+    expect(buf.highlighted).toBe(1);
+    expect(buf.lastReadId).toBe(7);
+    expect(store.isOpen(1, '#chan')).toBe(false); // no phantom lowercase fork
+    expect(store.list).toHaveLength(1);
+  });
+
+  // While a buffer is active its unread divider is pinned (dividerAfterId set on
+  // activate); a late read-state carrying a lower lastReadId must not slide the
+  // divider backward out from under the reader (the Math.max branch).
+  it('does not move lastReadId backwards while the divider is pinned', () => {
+    const store = useBuffersStore();
+    store.replaceBacklog(1, '#pinned', [], undefined, undefined, undefined);
+    const buf = store.byKey('1::#pinned')!;
+    buf.dividerAfterId = 100;
+    buf.lastReadId = 50;
+
+    store.applyReadState(1, '#pinned', { lastReadId: 30, unread: 0, highlights: 0 });
+    expect(buf.lastReadId).toBe(50);
+
+    store.applyReadState(1, '#pinned', { lastReadId: 70, unread: 0, highlights: 0 });
+    expect(buf.lastReadId).toBe(70);
+  });
 });

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -751,13 +751,20 @@ export const useBuffersStore = defineStore('buffers', {
       // is absent from the store (see isOpen), and a stray read-state broadcast
       // for it (e.g. mark-all-read fans out over every target with history, open
       // or not) would otherwise re-create the entry and pop it back into the
-      // sidebar (#319). A buffer that isn't open has no badge to update anyway.
-      // Snapshot callers (replaceBacklog) ensureBuffer before delegating here.
-      const buf = this.buffers[key(networkId, target)];
+      // sidebar (#319). findByTarget resolves case-insensitively and returns null
+      // when nothing is open, so a broadcast whose target case differs from the
+      // open buffer's key (servers hand us inconsistently-cased names, #289)
+      // still lands on the right buffer instead of silently dropping the badge —
+      // the same resolve-don't-materialize the typing path uses. Snapshot callers
+      // (replaceBacklog) ensureBuffer before delegating here.
+      const buf = this.findByTarget(networkId, target);
       if (!buf) return;
       const lastReadId = Number(payload?.lastReadId) || 0;
       const networks = useNetworksStore();
-      const isActive = networks.activeKey === `${networkId}::${target}`;
+      // Compare against the resolved buffer's canonical key, not the (possibly
+      // differently-cased) broadcast target, so badge suppression tracks the
+      // buffer the user is actually sitting in.
+      const isActive = networks.activeKey === `${buf.networkId}::${buf.target}`;
       // Suppress the unread badge for the buffer the user is sitting in.
       // A read-state broadcast can briefly carry a non-zero unread for the
       // active buffer when an IRC event lands before the mark-read echo;


### PR DESCRIPTION
Closes #322.

## What

Adds an opt-in client setting, **`chat.show_event_host`** (bool, default **off**), under the *Join/part consolidation* settings group. When on, presence/identity event lines render the affected user's `user@host` next to their nick:

> `--> alice (~alice@host.example.net) joined`
> `<-- alice (~alice@host.example.net) left (bye)`
> `<-- alice (~alice@host.example.net) quit (Ping timeout)`
> `-- alice is now bob (~alice@host.example.net)`

When off (default), every line is byte-for-byte identical to today.

## Why

Channel ops and network staff often want a user's full `user@host` at a glance — e.g. to spot ban masks — without running `/whois`. Originally requested for joins in #322, extended here to "anywhere a nick appears" in a presence event.

## How

These events **already** persist `userhost` (`nick!ident@host`) and already flow to the client (live via the decorated event, history via `rowToEvent`, stored whole by `pushMessage`). So this is purely a render + setting change — no protocol, serialization, or DB work.

- `shared/settingsRegistry.ts` — new `chat.show_event_host` bool, next to the consolidation settings since the two interact.
- `vue_client/src/components/MessageList.vue` — `showEventHost` computed + an `eventHost(m)` helper that reuses the existing `parseUserHost()` to pull `user@host` out of the stored `nick!ident@host`, and adds the parenthetical to the join/part/quit/nick templates.

## Scope decisions

- **Applies to join / part / quit / nick** — single-subject presence/identity events. Host goes after the subject nick (after the *new* nick on a rename).
- **kick excluded** — a KICK only carries the **kicker's** host, not the kicked user's. Rendering it on a "X kicked by Y" line would imply it's X's host — misleading for ban-hunting — so we show nothing rather than the wrong host.
- **mode / topic excluded** — the server sends no `userhost` for them.
- **Regular chat messages untouched** — host on every message line would wreck readability; this is meta/event lines only.

## Interactions / edge cases

- **Consolidation:** host shows only on un-consolidated (lone) events. A burst that collapses into the consolidation summary line stays host-less — deliberately, so floods don't spam hostmasks.
- **Malformed / partial masks:** `eventHost()` returns null unless *both* `user` and `host` are present, so a stored half-mask (`nick!@host` / `nick!ident@`) leaves the line unchanged instead of rendering `(@host)` / `(ident@)`. Backlog rows with no `userhost` also render as before.
- **Italics:** the whole meta line is already italic (`.body.meta-body`), so the host matches the nick/verb styling — intentionally not singled out.

## Verification

- `npm run check` (server + client typecheck, oxlint, oxfmt) — clean.
- Full test suite green (settings registry server+client, maskMatch, consolidate).
- Compiled each of the join/part/quit/nick template fragments with Vue's `condense` whitespace mode to confirm the render output (`nick (host) joined`, `nick (host) left (reason)`, etc.) and that each is byte-identical to before when the setting is off.

## Follow-up: code-review hardening (commits 50e6cb9, 7e3f347)

A review pass on the changed read-state path surfaced a few coupled fixes, included here since they live in the same code this PR already touches:

- **mark-all-read** now clamps *every* buffer's read pointer (closed ones too) and skips only the *broadcast* for closed-and-not-joined buffers — previously a closed buffer was skipped entirely, so reopening it after "mark all read" resurfaced the stale unread the user just cleared (while the #319 resurrection stays fixed).
- **`applyReadState`** resolves the target via the existing case-insensitive `findByTarget` (the resolver `setTyping` already uses for #289/#292) instead of an exact-case key lookup, so a read-state whose target case differs from the open buffer's key still updates it instead of silently dropping the badge.
- **closed-buffer filtering** case-folds `closedKeySetForUser` keys and routes the snapshot + mark-all-read carve-out through one `isHiddenClosedBuffer` helper, so the two sites can't drift.
- `eventHost()` → `eventHostSuffix()` (returns the formatted ` (user@host)` suffix) so each presence branch is a single call rather than a `v-if` + interpolation.
- Tests added for the case-mismatch read-state, the divider-pinned `Math.max` branch, and the case-folded closed-set keys.

The deeper message-ingest forking (same case class, but in `pushMessage`/`ensureBuffer`) is tracked separately in #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
