### PR TITLE
Fold IRC target case across the buffer identity surface (#327)

### DIFF
--- a/vue_client/src/composables/useJumpToMessage.ts
+++ b/vue_client/src/composables/useJumpToMessage.ts
@@ -65,7 +65,12 @@ export function useJumpToMessage({ pendingScrollId, afterActivate }: JumpToMessa
     buffers.activate(networkId, target);
     if (typeof afterActivate === 'function') afterActivate();
 
-    const buf = buffers.byKey(`${networkId}::${target}`) as any;
+    // Resolve case-insensitively (#327): the jump target may be the raw
+    // server-cased name (push deep-link, search hit) while the buffer is stored
+    // under a different casing. An exact-key byKey() would miss it, skipping the
+    // in-memory scroll fast path and stranding the message-landed watch on a
+    // null buffer. findByTarget folds to the canonical buffer activate() opened.
+    const buf = buffers.findByTarget(networkId, target) as any;
     const hasMessage = buf?.messages?.some((m: any) => m.id === messageId);
     // A row at or below the /clear marker is loaded but filtered out at
     // render time. Detaching the buffer suppresses the filter — no fetch

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -4,10 +4,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 
-// buffers.ts reaches into the networks/toasts stores and the socket. applyReadState
-// only consults useNetworksStore().activeKey, so a minimal mutable mock covers it;
-// toasts/socket are stubbed so importing the store doesn't stand up the rest of the
-// graph.
+// buffers.ts reaches into the networks/toasts stores and the socket. The actions
+// under test only consult useNetworksStore().activeKey and setActive(), so a
+// minimal mutable mock covers it; toasts/socket are stubbed so importing the
+// store doesn't stand up the rest of the graph.
 const h = vi.hoisted(() => ({ activeKey: null as string | null }));
 
 vi.mock('./networks.js', () => ({
@@ -15,16 +15,25 @@ vi.mock('./networks.js', () => ({
     get activeKey() {
       return h.activeKey;
     },
+    set activeKey(v: string | null) {
+      h.activeKey = v;
+    },
+    // Mirrors the real store: activeKey = `${networkId}::${target}`.
+    setActive(networkId: number | string, target: string) {
+      h.activeKey = `${networkId}::${target}`;
+    },
   }),
 }));
 vi.mock('./toasts.js', () => ({ useToastsStore: () => ({ push: vi.fn<() => void>() }) }));
 vi.mock('../composables/useSocket.js', () => ({ socketSend: vi.fn<(payload: unknown) => void>() }));
 
 import { useBuffersStore } from './buffers.js';
+import { socketSend } from '../composables/useSocket.js';
 
 beforeEach(() => {
   setActivePinia(createPinia());
   h.activeKey = null;
+  vi.mocked(socketSend).mockClear();
 });
 
 describe('applyReadState', () => {
@@ -84,7 +93,7 @@ describe('applyReadState', () => {
     expect(buf.unread).toBe(4);
     expect(buf.highlighted).toBe(1);
     expect(buf.lastReadId).toBe(7);
-    expect(store.isOpen(1, '#chan')).toBe(false); // no phantom lowercase fork
+    expect(store.byKey('1::#chan')).toBeNull(); // no phantom lowercase entry
     expect(store.list).toHaveLength(1);
   });
 
@@ -103,5 +112,123 @@ describe('applyReadState', () => {
 
     store.applyReadState(1, '#pinned', { lastReadId: 70, unread: 0, highlights: 0 });
     expect(buf.lastReadId).toBe(70);
+  });
+});
+
+// Regression for #327: IRC targets are case-insensitive but buffer identity used
+// to key by exact case, so a live DM (or a member-list/`/query` activation)
+// arriving under a different nick-case than the open buffer forked a duplicate.
+// ensureBuffer/activate/isOpen/drop now fold case via resolveExistingKey, so
+// every write, the active-buffer pointer, the open/closed guard, and the close
+// all resolve to the single canonical (first-seen) buffer. "No fork" is asserted
+// with the exact-key byKey() (which stays a key primitive), since isOpen() now
+// correctly reports the canonical buffer as open under any casing.
+describe('case-insensitive buffer identity (#327)', () => {
+  const dm = (target: string, id: number, nick = target) => ({
+    networkId: 1,
+    target,
+    id,
+    type: 'message',
+    nick,
+    body: 'x',
+  });
+
+  it('appends a live DM under a divergent nick-case to the existing buffer', () => {
+    const store = useBuffersStore();
+    store.pushMessage(dm('Bob', 1));
+    expect(store.isOpen(1, 'Bob')).toBe(true);
+
+    // Same peer, server-relayed under a different casing — must land in the open
+    // buffer rather than fork a second `bob` entry.
+    const fresh = store.pushMessage(dm('bob', 2));
+    expect(fresh).toBe(true);
+
+    expect(store.list).toHaveLength(1);
+    expect(store.byKey('1::Bob')!.messages).toHaveLength(2);
+    expect(store.byKey('1::bob')).toBeNull(); // no lowercase fork
+  });
+
+  it('records a speaker under a divergent case without forking a buffer', () => {
+    const store = useBuffersStore();
+    store.pushMessage(dm('Bob', 1));
+
+    // recordSpeaker is the sibling side effect fired right after pushMessage in
+    // the socket handler; it funnels through ensureBuffer too, so it must not
+    // fork its own lowercase shell.
+    store.recordSpeaker(1, 'bob', 'bob', 1000);
+
+    expect(store.list).toHaveLength(1);
+    expect(store.byKey('1::bob')).toBeNull(); // no lowercase fork
+    expect(store.byKey('1::Bob')!.speakers['bob']).toBeTruthy();
+  });
+
+  it('keeps live read-sync on the active buffer when the inbound DM case diverges', () => {
+    const store = useBuffersStore();
+    store.pushMessage(dm('Bob', 1));
+    h.activeKey = '1::Bob';
+
+    store.pushMessage(dm('bob', 2));
+
+    // The read pointer advances and a mark-read goes out under the buffer's
+    // canonical target, even though the event arrived as `bob`.
+    expect(store.byKey('1::Bob')!.lastReadId).toBe(2);
+    expect(socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'mark-read', networkId: 1, target: 'Bob', messageId: 2 }),
+    );
+  });
+
+  it('activates the existing buffer under a divergent case and keeps activeKey canonical', () => {
+    const store = useBuffersStore();
+    store.replaceBacklog(1, 'Bob', [dm('Bob', 5)], undefined, undefined, undefined);
+    expect(store.isOpen(1, 'Bob')).toBe(true);
+
+    store.activate(1, 'bob');
+
+    // activeKey must point at the key the buffer is actually stored under, or
+    // useActiveBuffer's byKey(activeKey) returns null and blanks the chat view.
+    expect(h.activeKey).toBe('1::Bob');
+    expect(store.byKey(h.activeKey!)).toBeTruthy();
+    expect(store.list).toHaveLength(1);
+    expect(store.byKey('1::bob')).toBeNull(); // no lowercase fork
+  });
+
+  it('isOpen resolves a buffer open under a divergent case (toast/jump focus guard)', () => {
+    const store = useBuffersStore();
+    store.pushMessage(dm('Bob', 1));
+
+    // ToastContainer/useJumpToMessage gate activate() on isOpen() with the raw
+    // server-cased target (highlight toast → event.target, friend-online →
+    // event.nick). Folding keeps a live buffer from being reported "closed" and
+    // refusing to focus its own notification — the regression the read-path
+    // fold otherwise introduces by merging the fork away.
+    expect(store.isOpen(1, 'bob')).toBe(true);
+    expect(store.isOpen(1, 'BOB')).toBe(true);
+    expect(store.byKey('1::bob')).toBeNull(); // still one canonical buffer
+  });
+
+  it('drop removes the buffer when the close target case diverges', () => {
+    const store = useBuffersStore();
+    store.pushMessage(dm('Bob', 1));
+    expect(store.list).toHaveLength(1);
+
+    // The server doesn't canonicalize DM casing, so a buffer-closed broadcast
+    // can carry a different case than the stored buffer; an exact-key delete
+    // would leave a sidebar ghost.
+    store.drop(1, 'bob');
+
+    expect(store.list).toHaveLength(0);
+    expect(store.isOpen(1, 'Bob')).toBe(false);
+  });
+
+  it('setJoined resolves a divergently-cased channel target', () => {
+    const store = useBuffersStore();
+    store.replaceBacklog(1, '#Chan', [], undefined, undefined, true);
+    const buf = store.byKey('1::#Chan')!;
+    expect(buf.joined).toBe(true);
+
+    store.setJoined(1, '#chan', false);
+
+    expect(buf.joined).toBe(false);
+    expect(store.list).toHaveLength(1);
   });
 });

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -37,6 +37,29 @@ function key(networkId: number | string, target: string) {
   return `${networkId}::${target}`;
 }
 
+// Resolve the storage key of an already-open buffer for (networkId, target),
+// folding case so an inconsistently-cased name reuses the open buffer instead
+// of forking a second one. IRC targets are case-insensitive and some servers
+// hand us divergent casing (#289 for channels; #327 for live DMs), so exact-key
+// identity alone forks duplicates. Exact key is tried first as the common fast
+// path; the O(n) folded scan only runs on a miss. The flat ':'-sentinels
+// (`:server:`, `:friends:`…) are fixed keys — exact only, never folded.
+function resolveExistingKey(
+  buffers: Record<string, Buffer>,
+  networkId: number | string,
+  target: string,
+): string | null {
+  const exact = key(networkId, target);
+  if (buffers[exact]) return exact;
+  if (target.startsWith(':')) return null;
+  const nid = Number(networkId);
+  const lower = target.toLowerCase();
+  for (const [k, b] of Object.entries(buffers)) {
+    if (b.networkId === nid && b.target.toLowerCase() === lower) return k;
+  }
+  return null;
+}
+
 function typingKey(networkId: number | string, target: string, nick: string) {
   return `${networkId}::${target}::${nick.toLowerCase()}`;
 }
@@ -184,10 +207,14 @@ function ensureBuffer(
   networkId: number | string,
   target: string,
 ): Buffer {
+  // Resolve case-insensitively before creating: a DM/channel already open under
+  // a different casing is the same buffer (#327), so reuse it rather than fork a
+  // second entry. Only materialize when nothing exists under any casing — and
+  // then under the target's own casing, so the first writer's case is canonical.
+  const existing = resolveExistingKey(state.buffers, networkId, target);
+  if (existing) return state.buffers[existing];
   const k = key(networkId, target);
-  if (!state.buffers[k]) {
-    state.buffers[k] = makeBuffer(networkId, target);
-  }
+  state.buffers[k] = makeBuffer(networkId, target);
   return state.buffers[k];
 }
 
@@ -198,12 +225,17 @@ export const useBuffersStore = defineStore('buffers', {
   getters: {
     list: (state) => Object.values(state.buffers),
     byKey: (state) => (k: string) => state.buffers[k] || null,
-    // True only while the buffer is live in the store. A closed buffer is
-    // dropped entirely (see drop()), so this is how callers tell "open" from
-    // "closed/parted-away" before activating — activate() would otherwise
-    // recreate an empty shell and strand the UI in a half-state.
+    // True only while a buffer for (networkId, target) is live in the store,
+    // resolved case-insensitively (#327) like its findByTarget/findDm siblings.
+    // A closed buffer is dropped entirely (see drop()), so this is how callers
+    // tell "open" from "closed/parted-away" before activating — activate() would
+    // otherwise recreate an empty shell and strand the UI in a half-state. The
+    // case fold matters because the toast/jump focus guards gate activate() on
+    // the raw server-cased target (highlight toast → event.target, friend-online
+    // → event.nick): an exact-key lookup would report a buffer that's open under
+    // a different casing as closed and refuse to focus its own notification.
     isOpen: (state) => (networkId: number | string, target: string) =>
-      !!state.buffers[`${networkId}::${target}`],
+      resolveExistingKey(state.buffers, networkId, target) !== null,
     forNetwork: (state) => (networkId: number | string) =>
       Object.values(state.buffers).filter((b) => b.networkId === networkId),
     // The open DM buffer for a (network, nick), matched case-insensitively so we
@@ -235,16 +267,8 @@ export const useBuffersStore = defineStore('buffers', {
     findByTarget:
       (state) =>
       (networkId: number | string, target: string): Buffer | null => {
-        const exact = state.buffers[`${networkId}::${target}`];
-        if (exact) return exact;
-        if (target.startsWith(':')) return null;
-        const nid = Number(networkId);
-        const lower = target.toLowerCase();
-        return (
-          Object.values(state.buffers).find(
-            (b) => b.networkId === nid && b.target.toLowerCase() === lower,
-          ) ?? null
-        );
+        const k = resolveExistingKey(state.buffers, networkId, target);
+        return k ? state.buffers[k] : null;
       },
   },
   actions: {
@@ -276,7 +300,12 @@ export const useBuffersStore = defineStore('buffers', {
       if (buf.oldestId == null && event.id != null) buf.oldestId = event.id;
       if (event.id != null) {
         const networks = useNetworksStore();
-        const isActive = networks.activeKey === `${event.networkId}::${event.target}`;
+        // Compare against the resolved buffer's canonical key, not the event's
+        // (possibly divergently-cased) target — otherwise a live DM arriving as
+        // `bob` while the user sits in the `Bob` buffer reads as inactive and
+        // the divider/read-sync below silently skips (#327). Mirrors the same
+        // resolve-then-compare applyReadState does.
+        const isActive = networks.activeKey === `${buf.networkId}::${buf.target}`;
         if (isActive) {
           // While the user is sitting in this buffer, keep the divider
           // tracking the bottom UNLESS there's already an unread boundary
@@ -295,8 +324,8 @@ export const useBuffersStore = defineStore('buffers', {
             buf.lastReadId = event.id;
             socketSend({
               type: 'mark-read',
-              networkId: event.networkId,
-              target: event.target,
+              networkId: buf.networkId,
+              target: buf.target,
               messageId: event.id,
             });
           }
@@ -304,7 +333,10 @@ export const useBuffersStore = defineStore('buffers', {
       }
       const speakerKey = event.nick?.toLowerCase();
       if (speakerKey && buf.typing[speakerKey]) {
-        clearTypingTimer(event.networkId, event.target, event.nick!);
+        // Key off the resolved buffer's target, not event.target — setTyping
+        // armed the expiry timer under buf.target, so a divergently-cased event
+        // would otherwise miss it and strand the timer (#327).
+        clearTypingTimer(buf.networkId, buf.target, event.nick!);
         delete buf.typing[speakerKey];
       }
       return true;
@@ -650,17 +682,26 @@ export const useBuffersStore = defineStore('buffers', {
       buf.speakers = next;
     },
     drop(networkId: number | string, target: string) {
+      // Resolve case-insensitively (#327) so a divergently-cased close target
+      // (the server doesn't canonicalize DM casing — the #327 root cause) still
+      // removes the buffer instead of silently leaving a sidebar ghost. Key all
+      // bookkeeping off the resolved buffer's canonical target below.
+      const bufKey = resolveExistingKey(this.buffers, networkId, target);
+      if (!bufKey) return;
+      const buf = this.buffers[bufKey];
       // Cancel any pending typing-expiry timers for this buffer before it (and
       // its typing entries) vanishes — otherwise a timer armed while a peer was
-      // typing sits in the module-level map until it fires on its own.
-      const prefix = `${networkId}::${target}::`;
+      // typing sits in the module-level map until it fires on its own. Timers
+      // are keyed by the canonical target (setTyping uses buf.target), so the
+      // prefix has to match that, not the raw close-event casing.
+      const prefix = `${buf.networkId}::${buf.target}::`;
       for (const [k, id] of typingTimers) {
         if (k.startsWith(prefix)) {
           clearTimeout(id);
           typingTimers.delete(k);
         }
       }
-      delete this.buffers[key(networkId, target)];
+      delete this.buffers[bufKey];
     },
     // Called from useSessionReset before $reset(). The state reset will wipe
     // every buffer (and therefore every typing indicator), but the
@@ -738,7 +779,11 @@ export const useBuffersStore = defineStore('buffers', {
       return ok;
     },
     setJoined(networkId: number | string, target: string, joined: boolean) {
-      const buf = this.buffers[key(networkId, target)];
+      // Resolve case-insensitively (#327): channel-joined/-parted already arrive
+      // canonical from the server (canonicalChannelTarget), but fold here too so
+      // a divergently-cased target never misses the open buffer and leaves it
+      // stuck rendering dimmed.
+      const buf = this.findByTarget(networkId, target);
       if (!buf) return;
       buf.joined = !!joined;
     },
@@ -816,7 +861,17 @@ export const useBuffersStore = defineStore('buffers', {
     // focused (see pushMessage), so leaving it just drops local state.
     activate(networkId: number | string, target: string) {
       const networks = useNetworksStore();
-      const newKey = `${networkId}::${target}`;
+      // Resolve to the canonical open buffer first (case-insensitive): a DM
+      // activated from a member-list nick, /query, the profile modal, or a
+      // deep-link may carry a different casing than the buffer that's already
+      // open (#327). Focusing the raw casing would fork a duplicate via
+      // ensureBuffer and — worse — point activeKey at a key no buffer is stored
+      // under, so useActiveBuffer's byKey(activeKey) returns null and blanks the
+      // chat view. canonTarget is the existing buffer's casing, or the raw
+      // target when none is open yet (first writer's case becomes canonical).
+      const existing = this.findByTarget(networkId, target);
+      const canonTarget = existing ? existing.target : target;
+      const newKey = `${networkId}::${canonTarget}`;
       const prevKey = networks.activeKey;
       if (prevKey && prevKey !== newKey) {
         const prev = this.buffers[prevKey];
@@ -835,8 +890,8 @@ export const useBuffersStore = defineStore('buffers', {
             this.clearDetached(prev.networkId, prev.target, { wipeMessages: true });
         }
       }
-      networks.setActive(networkId, target);
-      const buf = ensureBuffer(this, networkId, target);
+      networks.setActive(networkId, canonTarget);
+      const buf = ensureBuffer(this, networkId, canonTarget);
       // Snapshot the divider from the CURRENT lastReadId before we advance
       // it below. The divider stays pinned to this snapshot for the
       // duration of the visit (cleared on switch-away).
@@ -861,7 +916,7 @@ export const useBuffersStore = defineStore('buffers', {
           socketSend({
             type: 'mark-read',
             networkId,
-            target,
+            target: canonTarget,
             messageId: lastId,
           });
         }
@@ -872,7 +927,7 @@ export const useBuffersStore = defineStore('buffers', {
       // do its own mark-read against the new tail.
       if (buf.pendingRefetch) {
         buf.pendingRefetch = false;
-        this.reattachToLive(networkId, target);
+        this.reattachToLive(networkId, canonTarget);
       } else if (
         buf.messages.length === 0 &&
         buf.hasMoreOlder &&
@@ -896,14 +951,14 @@ export const useBuffersStore = defineStore('buffers', {
         // that leaves messages.length=0 but flips hasMoreOlder to false —
         // without this guard we'd refire the same empty fetch on every
         // re-activate.
-        this.reattachToLive(networkId, target);
+        this.reattachToLive(networkId, canonTarget);
       }
       // For DMs, ask the server to WHOIS-probe the peer so the banner/sidebar
       // dim reflect current state rather than a possibly-stale cached value.
       // The probe is silent (no /whois reply in the server buffer); only the
       // resulting peer-presence event flows back to update local state.
-      if (target && !target.startsWith('#') && !target.startsWith(':server:')) {
-        socketSend({ type: 'probe-presence', networkId, nick: target });
+      if (canonTarget && !canonTarget.startsWith('#') && !canonTarget.startsWith(':server:')) {
+        socketSend({ type: 'probe-presence', networkId, nick: canonTarget });
       }
     },
     setTyping(


### PR DESCRIPTION
Closes #327.

## Problem

Buffer identity keyed by **exact case**, but IRC targets are case-insensitive and some servers relay an inconsistently-cased name (#289 for channels; this issue for live DMs). The read paths were folded case-insensitively in earlier work (#289/#319/#292), but the **create/activate seam** stayed exact-case — so a live DM (or a member-list / `/query` activation) arriving under a different nick-case than the open buffer forked a **second, duplicate DM buffer** with the conversation split across the two casings.

## Fix

Centralize at the buffer-identity primitive and fold every remaining exact-case site, establishing one invariant: *at most one buffer per (network, target), resolved case-insensitively to its first-seen casing.*

- **`resolveExistingKey()`** — new helper: exact-key fast path → folded scan (`:`-sentinels exact-only). `ensureBuffer` resolves through it before creating, so every mutator (`pushMessage`, `recordSpeaker`, `setMembers`, `setTopic`, `addMember`, …) reuses the canonical buffer. `findByTarget` reuses it too (DRY).
- **`activate`** resolves the canonical target → `activeKey` always equals a real buffer key (otherwise `useActiveBuffer`'s `byKey(activeKey)` returns null and blanks the chat view). Also fixes the same fork on the member-list / `/query` / profile-modal / deep-link activation paths.
- **`pushMessage`** compares `isActive`, sends mark-read, and clears the typing timer under the resolved buffer's target — not the event's divergent case (keeps the live divider/read-sync correct).
- **`isOpen`** folds case, so the toast/jump `activate()` guards (`ToastContainer`, `useJumpToMessage`) don't report a buffer open under a different casing as **closed** and refuse to focus its own notification.
- **`useJumpToMessage`** resolves via `findByTarget` instead of an exact-key `byKey`, restoring the in-memory scroll fast path.
- **`drop` / `setJoined`** resolve case-insensitively for symmetry (the server doesn't canonicalize DM casing, so a divergently-cased close target would otherwise leave a sidebar ghost).

## Tests

Regression coverage across the live-DM, `recordSpeaker`, `activate`, read-sync, `isOpen`, `drop`, and `setJoined` paths. "No fork" is asserted with the exact-key `byKey()` (which stays a key primitive), since `isOpen()` now correctly reports the canonical buffer as open under any casing.

All 176 client tests pass; `typecheck:client`, lint, and `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
