### PR TITLE
Make the case-fold buffer repair re-runnable; fold DMs too (#289)

### DIFF
--- a/server/db/foldBufferCase.test.ts
+++ b/server/db/foldBufferCase.test.ts
@@ -113,6 +113,21 @@ describe('foldBufferCase', () => {
     expect(reads[0].lr).toBe(10); // MAX of the two merged pointers
   });
 
+  it('still folds with report:false (the migration path), returning an empty report', () => {
+    const net = freshNetwork();
+    seed(net, '#CoolChan', 3);
+    seed(net, '#coolchan', 1);
+    seed(net, 'Bob', 2);
+    seed(net, 'bob', 1);
+
+    const report = foldBufferCase(db, { scope: 'all', report: false });
+
+    // The merge still happens; only the human-facing summary is skipped.
+    expect(targetCounts(net)).toEqual({ '#CoolChan': 4, Bob: 3 });
+    expect(report.forks).toEqual([]);
+    expect(report.rowsAffected).toEqual({});
+  });
+
   it('is a no-op on an unforked database (idempotent)', () => {
     const net = freshNetwork();
     seed(net, '#solo', 3);

--- a/server/db/foldBufferCase.test.ts
+++ b/server/db/foldBufferCase.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: Elastic-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type DatabaseType from 'better-sqlite3';
+
+// Stand up the real schema in a temp DB (the migrate() in index.ts runs on
+// first import), then exercise the extracted fold against it — an integration
+// test over the actual tables, not a hand-rolled subset.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-foldcase-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: DatabaseType.Database;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+let insertMessage: typeof import('./messages.js').insertMessage;
+let setReadState: typeof import('./bufferReads.js').setReadState;
+let foldBufferCase: typeof import('./foldBufferCase.js').foldBufferCase;
+let userId: number;
+
+const T = '2026-06-01T00:00:00.000Z';
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  ({ createUser } = await import('./users.js'));
+  ({ createNetwork } = await import('./networks.js'));
+  ({ insertMessage } = await import('./messages.js'));
+  ({ setReadState } = await import('./bufferReads.js'));
+  ({ foldBufferCase } = await import('./foldBufferCase.js'));
+  userId = createUser('fold-alice').id;
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function freshNetwork(): number {
+  return createNetwork(userId, { name: 'libera', host: 'h', port: 6697, tls: true, nick: 'a' })!.id;
+}
+function seed(networkId: number, target: string, count: number) {
+  for (let i = 0; i < count; i++)
+    insertMessage({ networkId, target, time: T, type: 'message', nick: 'x', text: 'hi' });
+}
+function targetCounts(networkId: number): Record<string, number> {
+  const rows = db
+    .prepare(`SELECT target, COUNT(*) AS n FROM messages WHERE network_id = ? GROUP BY target`)
+    .all(networkId) as { target: string; n: number }[];
+  return Object.fromEntries(rows.map((r) => [r.target, r.n]));
+}
+
+describe('foldBufferCase', () => {
+  it('dry run reports forks without mutating', () => {
+    const net = freshNetwork();
+    seed(net, '#CoolChan', 3);
+    seed(net, '#coolchan', 1); // stray case
+    seed(net, 'Bob', 2);
+    seed(net, 'bob', 1); // stray-case DM
+
+    const report = foldBufferCase(db, { scope: 'all', dryRun: true });
+
+    expect(report.applied).toBe(false);
+    expect(report.rowsAffected.messages).toBeGreaterThan(0);
+    // Both forks surface, each folding to the most-messages casing.
+    const chan = report.forks.find((f) => f.networkId === net && f.lkey === '#coolchan');
+    const dm = report.forks.find((f) => f.networkId === net && f.lkey === 'bob');
+    expect(chan?.canonical).toBe('#CoolChan');
+    expect(dm?.canonical).toBe('Bob');
+    // Nothing was written — both casings still present.
+    expect(targetCounts(net)).toEqual({ '#CoolChan': 3, '#coolchan': 1, Bob: 2, bob: 1 });
+  });
+
+  it('folds channel and DM forks to the most-messages casing', () => {
+    const net = freshNetwork();
+    seed(net, '#CoolChan', 3);
+    seed(net, '#coolchan', 1);
+    seed(net, 'Bob', 2);
+    seed(net, 'bob', 1);
+
+    foldBufferCase(db, { scope: 'all' });
+
+    // Channel and DM each collapse onto the majority casing; no stray rows left.
+    expect(targetCounts(net)).toEqual({ '#CoolChan': 4, Bob: 3 });
+  });
+
+  it('channels-only scope leaves DM forks untouched', () => {
+    const net = freshNetwork();
+    seed(net, '#CoolChan', 2);
+    seed(net, '#coolchan', 1);
+    seed(net, 'Bob', 2);
+    seed(net, 'bob', 1);
+
+    foldBufferCase(db, { scope: 'channels' });
+
+    // The channel folds; the DM casings stay split (v9 behavior).
+    expect(targetCounts(net)).toEqual({ '#CoolChan': 3, Bob: 2, bob: 1 });
+  });
+
+  it('merges buffer_reads keeping the furthest read pointer', () => {
+    const net = freshNetwork();
+    seed(net, '#Chan', 2);
+    seed(net, '#chan', 1); // stray, lower message count -> not canonical
+    setReadState(userId, net, '#Chan', 5);
+    setReadState(userId, net, '#chan', 10); // further read pointer on the stray case
+
+    foldBufferCase(db, { scope: 'all' });
+
+    const reads = db
+      .prepare(`SELECT target, last_read_message_id AS lr FROM buffer_reads WHERE network_id = ?`)
+      .all(net) as { target: string; lr: number }[];
+    expect(reads).toHaveLength(1);
+    expect(reads[0].target).toBe('#Chan');
+    expect(reads[0].lr).toBe(10); // MAX of the two merged pointers
+  });
+
+  it('is a no-op on an unforked database (idempotent)', () => {
+    const net = freshNetwork();
+    seed(net, '#solo', 3);
+    seed(net, 'Carol', 2);
+
+    const report = foldBufferCase(db, { scope: 'all' });
+
+    expect(report.forks).toHaveLength(0);
+    expect(report.rowsAffected.messages).toBe(0);
+    expect(targetCounts(net)).toEqual({ '#solo': 3, Carol: 2 });
+  });
+});

--- a/server/db/foldBufferCase.ts
+++ b/server/db/foldBufferCase.ts
@@ -59,7 +59,8 @@ export interface FoldReport {
   scope: FoldScope;
   applied: boolean;
   // Per-table count of rows that were (or, in dryRun, would be) rewritten or
-  // dropped — the authoritative "what changes". Keyed by table name.
+  // dropped — the authoritative "what changes". Keyed by table name. Empty when
+  // the caller passed report:false (the migration), which skips its computation.
   rowsAffected: Record<string, number>;
   // Human-facing fork summary derived from message counts: each lkey that has
   // more than one message-cased variant, with the chosen canonical. A fork whose
@@ -84,10 +85,15 @@ const TARGET_TABLES = [
 
 export function foldBufferCase(
   db: Database.Database,
-  opts: { scope?: FoldScope; dryRun?: boolean } = {},
+  opts: { scope?: FoldScope; dryRun?: boolean; report?: boolean } = {},
 ): FoldReport {
   const scope: FoldScope = opts.scope ?? 'channels';
   const dryRun = opts.dryRun ?? false;
+  // The migration discards the return, so it opts out (report:false) to skip the
+  // two extra full `messages` scans the report costs — the per-table COUNTs and
+  // the variant GROUP BY. The operator script keeps it (default true); it prints
+  // the report in both dry-run and apply. The apply path needs only _buf_canon.
+  const wantReport = opts.report ?? true;
 
   // Which targets the fold considers. 'channels' restricts to #-prefixed
   // channels; 'all' covers every real buffer — every channel prefix (#, &, +, !)
@@ -122,59 +128,64 @@ export function foldBufferCase(
       ) WHERE rn = 1
     `);
 
-    // ---- Report (computed pre-apply so counts reflect what will change) ----
+    // ---- Report (computed pre-apply so counts reflect what will change).
+    // Skipped entirely when the caller doesn't want it (the migration), since
+    // these queries scan `messages` twice more on top of _buf_canon. ----
     const rowsAffected: Record<string, number> = {};
-    for (const t of TARGET_TABLES) {
-      rowsAffected[t] = (
-        db.prepare(`SELECT COUNT(*) AS n FROM ${t} WHERE ${needsFold(t)}`).get() as { n: number }
-      ).n;
-    }
-    rowsAffected['channels'] = (
-      db
-        .prepare(
-          `SELECT COUNT(*) AS n FROM channels
-             WHERE ${pred('name')} AND EXISTS (
-               SELECT 1 FROM _buf_canon c
-               WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
-                 AND c.canon <> channels.name)`,
-        )
-        .get() as { n: number }
-    ).n;
-
-    const variantRows = db
-      .prepare(
-        `SELECT m.network_id AS networkId, lower(m.target) AS lkey, m.target AS target,
-                COUNT(*) AS messages
-           FROM messages m WHERE ${pred('m.target')}
-           GROUP BY m.network_id, m.target`,
-      )
-      .all() as { networkId: number; lkey: string; target: string; messages: number }[];
-    const canonByKey = new Map<string, string>();
-    for (const r of db
-      .prepare(`SELECT network_id AS networkId, lkey, canon FROM _buf_canon`)
-      .all() as {
-      networkId: number;
-      lkey: string;
-      canon: string;
-    }[]) {
-      canonByKey.set(`${r.networkId}::${r.lkey}`, r.canon);
-    }
-    const grouped = new Map<string, FoldGroup>();
-    for (const r of variantRows) {
-      const k = `${r.networkId}::${r.lkey}`;
-      let g = grouped.get(k);
-      if (!g) {
-        g = {
-          networkId: r.networkId,
-          lkey: r.lkey,
-          canonical: canonByKey.get(k) ?? r.target,
-          variants: [],
-        };
-        grouped.set(k, g);
+    let forks: FoldGroup[] = [];
+    if (wantReport) {
+      for (const t of TARGET_TABLES) {
+        rowsAffected[t] = (
+          db.prepare(`SELECT COUNT(*) AS n FROM ${t} WHERE ${needsFold(t)}`).get() as { n: number }
+        ).n;
       }
-      g.variants.push({ target: r.target, messages: r.messages });
+      rowsAffected['channels'] = (
+        db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM channels
+               WHERE ${pred('name')} AND EXISTS (
+                 SELECT 1 FROM _buf_canon c
+                 WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
+                   AND c.canon <> channels.name)`,
+          )
+          .get() as { n: number }
+      ).n;
+
+      const variantRows = db
+        .prepare(
+          `SELECT m.network_id AS networkId, lower(m.target) AS lkey, m.target AS target,
+                  COUNT(*) AS messages
+             FROM messages m WHERE ${pred('m.target')}
+             GROUP BY m.network_id, m.target`,
+        )
+        .all() as { networkId: number; lkey: string; target: string; messages: number }[];
+      const canonByKey = new Map<string, string>();
+      for (const r of db
+        .prepare(`SELECT network_id AS networkId, lkey, canon FROM _buf_canon`)
+        .all() as {
+        networkId: number;
+        lkey: string;
+        canon: string;
+      }[]) {
+        canonByKey.set(`${r.networkId}::${r.lkey}`, r.canon);
+      }
+      const grouped = new Map<string, FoldGroup>();
+      for (const r of variantRows) {
+        const k = `${r.networkId}::${r.lkey}`;
+        let g = grouped.get(k);
+        if (!g) {
+          g = {
+            networkId: r.networkId,
+            lkey: r.lkey,
+            canonical: canonByKey.get(k) ?? r.target,
+            variants: [],
+          };
+          grouped.set(k, g);
+        }
+        g.variants.push({ target: r.target, messages: r.messages });
+      }
+      forks = [...grouped.values()].filter((g) => g.variants.length > 1);
     }
-    const forks = [...grouped.values()].filter((g) => g.variants.length > 1);
 
     if (!dryRun) {
       // id-keyed (target not unique) — straight rewrite. messages_fts only indexes

--- a/server/db/foldBufferCase.ts
+++ b/server/db/foldBufferCase.ts
@@ -1,0 +1,276 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: Elastic-2.0
+
+import type Database from 'better-sqlite3';
+
+// Case-fold repair for forked buffers (#268 channels, #289/#327 generalization).
+//
+// IRC targets are case-insensitive, but some servers relay a different case than
+// the one we joined/opened with (DALnet's registered #Christian vs the
+// #christian we joined; a DM peer presented as `bob` vs the `Bob` we /query'd).
+// Buffers used to key by exact case, so a stray case forked a second,
+// metadata-less buffer with state split across the two casings. The live paths
+// now fold case (canonicalChannelTarget server-side; the buffers store
+// client-side), but already-forked rows linger in the DB across every
+// target-keyed table.
+//
+// This is the one repair routine, shared by:
+//   - the schema-version-9 one-shot migration (server/db/index.ts), scope 'all'
+//     — merges every forked buffer (channels and DMs) when a DB upgrades past
+//     v9; and
+//   - the manual `tools/fold-buffer-case.ts` operator script — a re-runnable
+//     fallback (scope 'all' by default, --channels-only to narrow) for forks
+//     that appear after the migration already ran.
+//
+// Canonical case = the variant carrying the most messages (the buffer you
+// actually used = the case you joined/opened with), ties broken by `target ASC`
+// purely for determinism. A target that never drifted (a single case) maps to
+// itself and is left untouched, so #idleRPG stays #idleRPG. The flat ':'-virtual
+// buffers (`:server:`, `:friends:`…) are never folded. Composite-PK tables merge
+// conflict-aware (furthest read pointer + clear marker, joined flag, junk-close
+// dropped). The whole apply runs in one transaction; dryRun computes the same
+// report without mutating.
+
+// The schema version this fold was last audited against. The schema-version-9
+// migration in index.ts calls foldBufferCase mid-upgrade (before the version row
+// is written), so it can't be gated — but the manual operator script refuses to
+// run unless the DB sits exactly here. A future migration that adds or reshapes
+// a buffer-keyed table must re-check TARGET_TABLES (and the channels/buffer_reads
+// merges) below, then deliberately bump this in lockstep with SCHEMA_VERSION in
+// index.ts — so the script can never silently fold an out-of-date table set.
+export const FOLD_VALIDATED_SCHEMA_VERSION = 9;
+
+export type FoldScope = 'channels' | 'all';
+
+export interface FoldVariant {
+  target: string;
+  messages: number;
+}
+
+export interface FoldGroup {
+  networkId: number;
+  // Lowercased target the variants share (the SQL `lower()` key).
+  lkey: string;
+  canonical: string;
+  variants: FoldVariant[];
+}
+
+export interface FoldReport {
+  scope: FoldScope;
+  applied: boolean;
+  // Per-table count of rows that were (or, in dryRun, would be) rewritten or
+  // dropped — the authoritative "what changes". Keyed by table name.
+  rowsAffected: Record<string, number>;
+  // Human-facing fork summary derived from message counts: each lkey that has
+  // more than one message-cased variant, with the chosen canonical. A fork whose
+  // stray case carries no messages (only e.g. a draft) still gets folded — it
+  // shows in rowsAffected — but won't appear here, since groups are message-based.
+  forks: FoldGroup[];
+}
+
+// Tables keyed by a per-buffer `target` column (channels live in `channels.name`,
+// handled separately). Order matters only for readability; each fold is
+// independent.
+const TARGET_TABLES = [
+  'messages',
+  'input_history',
+  'buffer_reads',
+  'closed_buffers',
+  'pinned_buffers',
+  'nicklist_collapsed',
+  'channel_notify_settings',
+  'user_drafts',
+] as const;
+
+export function foldBufferCase(
+  db: Database.Database,
+  opts: { scope?: FoldScope; dryRun?: boolean } = {},
+): FoldReport {
+  const scope: FoldScope = opts.scope ?? 'channels';
+  const dryRun = opts.dryRun ?? false;
+
+  // Which targets the fold considers. 'channels' restricts to #-prefixed
+  // channels; 'all' covers every real buffer — every channel prefix (#, &, +, !)
+  // and DM nicks — while still excluding the ':'-virtual buffers.
+  const pred = (col: string) => (scope === 'all' ? `${col} NOT LIKE ':%'` : `${col} LIKE '#%'`);
+
+  // Resolves a row's canonical case from the temp table; matches only off-case
+  // rows that have a canonical to fold into (so single-case targets and virtuals
+  // are skipped). Table names are literals from TARGET_TABLES, never user input.
+  const canonExpr = (t: string) =>
+    `(SELECT c.canon FROM _buf_canon c
+        WHERE c.network_id = ${t}.network_id AND c.lkey = lower(${t}.target))`;
+  const needsFold = (t: string) =>
+    `${pred(`${t}.target`)} AND EXISTS (SELECT 1 FROM _buf_canon c
+        WHERE c.network_id = ${t}.network_id AND c.lkey = lower(${t}.target)
+          AND c.canon <> ${t}.target)`;
+
+  const work = (): FoldReport => {
+    // Connection-local temp table; drop defensively in case a prior run in this
+    // same connection left one behind.
+    db.exec(`DROP TABLE IF EXISTS _buf_canon`);
+    db.exec(`
+      CREATE TEMP TABLE _buf_canon AS
+      SELECT network_id, lower(target) AS lkey, target AS canon FROM (
+        SELECT network_id, target,
+               ROW_NUMBER() OVER (
+                 PARTITION BY network_id, lower(target)
+                 ORDER BY COUNT(*) DESC, target ASC
+               ) AS rn
+        FROM messages WHERE ${pred('target')}
+        GROUP BY network_id, target
+      ) WHERE rn = 1
+    `);
+
+    // ---- Report (computed pre-apply so counts reflect what will change) ----
+    const rowsAffected: Record<string, number> = {};
+    for (const t of TARGET_TABLES) {
+      rowsAffected[t] = (
+        db.prepare(`SELECT COUNT(*) AS n FROM ${t} WHERE ${needsFold(t)}`).get() as { n: number }
+      ).n;
+    }
+    rowsAffected['channels'] = (
+      db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM channels
+             WHERE ${pred('name')} AND EXISTS (
+               SELECT 1 FROM _buf_canon c
+               WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
+                 AND c.canon <> channels.name)`,
+        )
+        .get() as { n: number }
+    ).n;
+
+    const variantRows = db
+      .prepare(
+        `SELECT m.network_id AS networkId, lower(m.target) AS lkey, m.target AS target,
+                COUNT(*) AS messages
+           FROM messages m WHERE ${pred('m.target')}
+           GROUP BY m.network_id, m.target`,
+      )
+      .all() as { networkId: number; lkey: string; target: string; messages: number }[];
+    const canonByKey = new Map<string, string>();
+    for (const r of db
+      .prepare(`SELECT network_id AS networkId, lkey, canon FROM _buf_canon`)
+      .all() as {
+      networkId: number;
+      lkey: string;
+      canon: string;
+    }[]) {
+      canonByKey.set(`${r.networkId}::${r.lkey}`, r.canon);
+    }
+    const grouped = new Map<string, FoldGroup>();
+    for (const r of variantRows) {
+      const k = `${r.networkId}::${r.lkey}`;
+      let g = grouped.get(k);
+      if (!g) {
+        g = {
+          networkId: r.networkId,
+          lkey: r.lkey,
+          canonical: canonByKey.get(k) ?? r.target,
+          variants: [],
+        };
+        grouped.set(k, g);
+      }
+      g.variants.push({ target: r.target, messages: r.messages });
+    }
+    const forks = [...grouped.values()].filter((g) => g.variants.length > 1);
+
+    if (!dryRun) {
+      // id-keyed (target not unique) — straight rewrite. messages_fts only indexes
+      // text, so the AFTER UPDATE trigger reindexes identical text (harmless).
+      for (const t of ['messages', 'input_history']) {
+        db.exec(`UPDATE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
+      }
+
+      // channels: UNIQUE(network_id, name). Fold to canon (joined if ANY variant
+      // was joined, earliest created_at), then drop the off-case variant.
+      db.exec(`
+        INSERT INTO channels (network_id, name, joined, created_at)
+          SELECT ch.network_id, c.canon, ch.joined, ch.created_at
+          FROM channels ch JOIN _buf_canon c
+            ON c.network_id = ch.network_id AND c.lkey = lower(ch.name)
+          WHERE ${pred('ch.name')} AND c.canon <> ch.name
+        ON CONFLICT(network_id, name) DO UPDATE SET
+          joined = MAX(channels.joined, excluded.joined),
+          created_at = MIN(channels.created_at, excluded.created_at)
+      `);
+      db.exec(`
+        DELETE FROM channels WHERE ${pred('name')} AND EXISTS (
+          SELECT 1 FROM _buf_canon c
+          WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
+            AND c.canon <> channels.name)
+      `);
+
+      // buffer_reads: composite PK. Merge keeping the furthest read pointer and any
+      // clear marker, then drop the variant so nothing resurfaces as unread.
+      db.exec(`
+        INSERT INTO buffer_reads
+          (user_id, network_id, target, last_read_message_id, updated_at,
+           cleared_before_message_id, cleared_at)
+          SELECT br.user_id, br.network_id, c.canon, br.last_read_message_id, br.updated_at,
+                 br.cleared_before_message_id, br.cleared_at
+          FROM buffer_reads br JOIN _buf_canon c
+            ON c.network_id = br.network_id AND c.lkey = lower(br.target)
+          WHERE ${pred('br.target')} AND c.canon <> br.target
+        ON CONFLICT(user_id, network_id, target) DO UPDATE SET
+          last_read_message_id =
+            MAX(buffer_reads.last_read_message_id, excluded.last_read_message_id),
+          -- Keep the *furthest* /clear boundary (and its matching cleared_at) so
+          -- folding can't un-clear messages the user cleared in the other variant.
+          -- NULLIF restores NULL when neither row had a marker.
+          cleared_before_message_id = NULLIF(
+            MAX(COALESCE(buffer_reads.cleared_before_message_id, 0),
+                COALESCE(excluded.cleared_before_message_id, 0)), 0),
+          cleared_at = CASE
+            WHEN COALESCE(excluded.cleared_before_message_id, 0)
+                 > COALESCE(buffer_reads.cleared_before_message_id, 0)
+            THEN excluded.cleared_at ELSE buffer_reads.cleared_at END,
+          updated_at = MAX(buffer_reads.updated_at, excluded.updated_at)
+      `);
+      db.exec(`DELETE FROM buffer_reads WHERE ${needsFold('buffer_reads')}`);
+
+      // closed_buffers: a stray-cased row was the junk buffer the user closed; the
+      // canonical buffer's own open/closed state wins, so drop the off-case rows.
+      db.exec(`DELETE FROM closed_buffers WHERE ${needsFold('closed_buffers')}`);
+
+      // Remaining per-(user, network, target) state: move to canon, or drop if a
+      // canon row already exists (its state wins).
+      for (const t of [
+        'pinned_buffers',
+        'nicklist_collapsed',
+        'channel_notify_settings',
+        'user_drafts',
+      ]) {
+        db.exec(`UPDATE OR IGNORE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
+        db.exec(`DELETE FROM ${t} WHERE ${needsFold(t)}`);
+      }
+
+      // Keep pin positions dense per (user, network): a dropped duplicate pin can
+      // leave a gap, and reorderPins assumes 0..n-1 (same fix as schemaVersion 7).
+      db.exec(`
+        WITH renum AS (
+          SELECT user_id, network_id, target,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY user_id, network_id ORDER BY position ASC, target ASC
+                 ) - 1 AS new_pos
+          FROM pinned_buffers
+        )
+        UPDATE pinned_buffers SET position = (
+          SELECT new_pos FROM renum
+          WHERE renum.user_id = pinned_buffers.user_id
+            AND renum.network_id = pinned_buffers.network_id
+            AND renum.target = pinned_buffers.target
+        )
+      `);
+    }
+
+    db.exec(`DROP TABLE _buf_canon`);
+    return { scope, applied: !dryRun, rowsAffected, forks };
+  };
+
+  // dryRun only reads (plus a connection-local temp table), so it runs outside a
+  // transaction; apply wraps the whole rewrite in one so a failure can't leave a
+  // half-folded buffer.
+  return dryRun ? work() : db.transaction(work)();
+}

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -952,7 +952,9 @@ if (schemaVersion < 9) {
   // still pre-9, so folding everything here cleans them on upgrade without a
   // separate migration. The logic lives in foldBufferCase() so the operator
   // script (tools/fold-buffer-case.ts) re-runs the exact same merge on demand.
-  foldBufferCase(db, { scope: 'all' });
+  // report:false skips the human-facing fork summary (two extra `messages`
+  // scans) the migration would only discard.
+  foldBufferCase(db, { scope: 'all', report: false });
 }
 
 if (schemaVersion < SCHEMA_VERSION) {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -5,6 +5,7 @@ import Database from 'better-sqlite3';
 import path from 'path';
 import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
+import { foldBufferCase } from './foldBufferCase.js';
 
 const dbPath = process.env.DATABASE_PATH || path.join(import.meta.dirname, '../../data/lurker.db');
 // Absolute path to the SQLite file, exported so the export worker can open its
@@ -936,132 +937,22 @@ if (schemaVersion < 7) {
 }
 
 if (schemaVersion < 9) {
-  // Issue #268 repair: a server relaying a different case than we joined with
-  // (DALnet's registered #Christian vs the #christian we joined) forked a
-  // second, metadata-less buffer keyed by the stray case. The code now folds
-  // stray-case channel events into the case we joined with; this one-shot merges
-  // any already-forked buffers into their canonical case across every
-  // target-keyed table. Canonical = the case variant carrying the most messages
-  // — i.e. the buffer you actually used, which is the case you joined with. Ties
-  // (equal message counts) break by `target ASC`, purely for determinism — that
-  // tie-break is arbitrary, not meaningful. Channels that never drifted (a
-  // single case) map to themselves and are left untouched, so #idleRPG stays
-  // #idleRPG. DM targets (no '#' prefix) are never touched. Fresh installs match
-  // no rows.
-  const foldChannelCase = db.transaction(() => {
-    db.exec(`
-      CREATE TEMP TABLE _chan_canon AS
-      SELECT network_id, lower(target) AS lkey, target AS canon FROM (
-        SELECT network_id, target,
-               ROW_NUMBER() OVER (
-                 PARTITION BY network_id, lower(target)
-                 ORDER BY COUNT(*) DESC, target ASC
-               ) AS rn
-        FROM messages WHERE target LIKE '#%'
-        GROUP BY network_id, target
-      ) WHERE rn = 1
-    `);
-    // SQL fragments shared across the per-table folds. canonExpr resolves a
-    // row's canonical channel case; needsFold matches only off-case channel rows
-    // (so single-case channels and DMs are skipped). Table names are literals.
-    const canonExpr = (t: string) =>
-      `(SELECT c.canon FROM _chan_canon c
-        WHERE c.network_id = ${t}.network_id AND c.lkey = lower(${t}.target))`;
-    const needsFold = (t: string) =>
-      `${t}.target LIKE '#%' AND EXISTS (SELECT 1 FROM _chan_canon c
-        WHERE c.network_id = ${t}.network_id AND c.lkey = lower(${t}.target)
-          AND c.canon <> ${t}.target)`;
-
-    // id-keyed (target not unique) — straight rewrite. messages_fts only indexes
-    // text, so the AFTER UPDATE trigger reindexes identical text (harmless).
-    for (const t of ['messages', 'input_history']) {
-      db.exec(`UPDATE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
-    }
-
-    // channels: UNIQUE(network_id, name). Fold to canon (joined if ANY variant
-    // was joined, earliest created_at), then drop the off-case variant.
-    db.exec(`
-      INSERT INTO channels (network_id, name, joined, created_at)
-        SELECT ch.network_id, c.canon, ch.joined, ch.created_at
-        FROM channels ch JOIN _chan_canon c
-          ON c.network_id = ch.network_id AND c.lkey = lower(ch.name)
-        WHERE ch.name LIKE '#%' AND c.canon <> ch.name
-      ON CONFLICT(network_id, name) DO UPDATE SET
-        joined = MAX(channels.joined, excluded.joined),
-        created_at = MIN(channels.created_at, excluded.created_at)
-    `);
-    db.exec(`
-      DELETE FROM channels WHERE name LIKE '#%' AND EXISTS (
-        SELECT 1 FROM _chan_canon c
-        WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
-          AND c.canon <> channels.name)
-    `);
-
-    // buffer_reads: composite PK. Merge keeping the furthest read pointer and any
-    // clear marker, then drop the variant so nothing resurfaces as unread.
-    db.exec(`
-      INSERT INTO buffer_reads
-        (user_id, network_id, target, last_read_message_id, updated_at,
-         cleared_before_message_id, cleared_at)
-        SELECT br.user_id, br.network_id, c.canon, br.last_read_message_id, br.updated_at,
-               br.cleared_before_message_id, br.cleared_at
-        FROM buffer_reads br JOIN _chan_canon c
-          ON c.network_id = br.network_id AND c.lkey = lower(br.target)
-        WHERE br.target LIKE '#%' AND c.canon <> br.target
-      ON CONFLICT(user_id, network_id, target) DO UPDATE SET
-        last_read_message_id =
-          MAX(buffer_reads.last_read_message_id, excluded.last_read_message_id),
-        -- Keep the *furthest* /clear boundary (and its matching cleared_at) so
-        -- folding can't un-clear messages the user cleared in the other variant.
-        -- NULLIF restores NULL when neither row had a marker.
-        cleared_before_message_id = NULLIF(
-          MAX(COALESCE(buffer_reads.cleared_before_message_id, 0),
-              COALESCE(excluded.cleared_before_message_id, 0)), 0),
-        cleared_at = CASE
-          WHEN COALESCE(excluded.cleared_before_message_id, 0)
-               > COALESCE(buffer_reads.cleared_before_message_id, 0)
-          THEN excluded.cleared_at ELSE buffer_reads.cleared_at END,
-        updated_at = MAX(buffer_reads.updated_at, excluded.updated_at)
-    `);
-    db.exec(`DELETE FROM buffer_reads WHERE ${needsFold('buffer_reads')}`);
-
-    // closed_buffers: a stray-cased row was the junk buffer the user closed; the
-    // canonical buffer's own open/closed state wins, so drop the off-case rows.
-    db.exec(`DELETE FROM closed_buffers WHERE ${needsFold('closed_buffers')}`);
-
-    // Remaining per-(user, network, target) state: move to canon, or drop if a
-    // canon row already exists (its state wins).
-    for (const t of [
-      'pinned_buffers',
-      'nicklist_collapsed',
-      'channel_notify_settings',
-      'user_drafts',
-    ]) {
-      db.exec(`UPDATE OR IGNORE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
-      db.exec(`DELETE FROM ${t} WHERE ${needsFold(t)}`);
-    }
-
-    // Keep pin positions dense per (user, network): a dropped duplicate pin can
-    // leave a gap, and reorderPins assumes 0..n-1 (same fix as schemaVersion 7).
-    db.exec(`
-      WITH renum AS (
-        SELECT user_id, network_id, target,
-               ROW_NUMBER() OVER (
-                 PARTITION BY user_id, network_id ORDER BY position ASC, target ASC
-               ) - 1 AS new_pos
-        FROM pinned_buffers
-      )
-      UPDATE pinned_buffers SET position = (
-        SELECT new_pos FROM renum
-        WHERE renum.user_id = pinned_buffers.user_id
-          AND renum.network_id = pinned_buffers.network_id
-          AND renum.target = pinned_buffers.target
-      )
-    `);
-
-    db.exec(`DROP TABLE _chan_canon`);
-  });
-  foldChannelCase();
+  // Issue #268/#289/#327 repair: a server relaying a different case than we
+  // joined/opened with (DALnet's registered #Christian vs the #christian we
+  // joined; a DM peer presented as `bob` vs the `Bob` we /query'd) forked a
+  // second, metadata-less buffer keyed by the stray case. The live paths now
+  // fold case forward; this one-shot merges any already-forked buffers into
+  // their canonical case across every target-keyed table. Canonical = the case
+  // variant carrying the most messages — i.e. the buffer you actually used. Ties
+  // (equal counts) break by `target ASC`, purely for determinism. A target that
+  // never drifted (a single case) maps to itself and is left untouched, so
+  // #idleRPG stays #idleRPG. The ':'-virtual buffers are never folded; fresh
+  // installs match no rows. scope 'all' covers channels AND DMs (and &/+/!
+  // channels): the DM fork was found later (#289/#327) but the affected DBs are
+  // still pre-9, so folding everything here cleans them on upgrade without a
+  // separate migration. The logic lives in foldBufferCase() so the operator
+  // script (tools/fold-buffer-case.ts) re-runs the exact same merge on demand.
+  foldBufferCase(db, { scope: 'all' });
 }
 
 if (schemaVersion < SCHEMA_VERSION) {

--- a/tools/fold-buffer-case.ts
+++ b/tools/fold-buffer-case.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: Elastic-2.0
+
+// Operator fallback for case-forked buffers (#289).
+//
+// The schema-version-9 migration folds mixed-case buffers into one canonical
+// case, but it's a one-shot — a fork that appears *after* it ran (a misbehaving
+// server relaying a stray case) has nothing to clean it up. This re-runs the
+// exact same merge (foldBufferCase) on demand, and additionally covers DMs and
+// non-`#` channel prefixes the one-shot skipped.
+//
+// Usage (inside the cell container):
+//   tsx tools/fold-buffer-case.ts                 # dry-run report, channels + DMs
+//   tsx tools/fold-buffer-case.ts --apply         # actually fold
+//   tsx tools/fold-buffer-case.ts --channels-only # restrict to '#' channels
+//
+// DATABASE_PATH selects the DB (same env the server uses); falls back to
+// ../data/lurker.db relative to this file. Safe to run while the cell is live —
+// the fold is one WAL transaction with a busy timeout — but quiet time is ideal.
+
+import Database from 'better-sqlite3';
+import path from 'path';
+import {
+  foldBufferCase,
+  FOLD_VALIDATED_SCHEMA_VERSION,
+  type FoldReport,
+} from '../server/db/foldBufferCase.js';
+
+const argv = process.argv.slice(2);
+if (argv.includes('--help') || argv.includes('-h')) {
+  console.log(
+    [
+      'Fold case-forked buffers into their canonical (most-messages) casing.',
+      '',
+      'Usage: tsx tools/fold-buffer-case.ts [--apply] [--channels-only]',
+      '',
+      '  (no flags)        Dry run: report what would be folded, change nothing.',
+      '  --apply           Apply the fold in a single transaction.',
+      '  --channels-only   Only #-prefixed channels (the v9 migration scope).',
+      '                    Default also folds DMs and &/+/! channel prefixes.',
+      '',
+      'DATABASE_PATH selects the database.',
+    ].join('\n'),
+  );
+  process.exit(0);
+}
+
+const apply = argv.includes('--apply');
+const scope = argv.includes('--channels-only') ? 'channels' : 'all';
+
+const dbPath = process.env.DATABASE_PATH || path.join(import.meta.dirname, '../data/lurker.db');
+
+const db = new Database(dbPath);
+db.pragma('journal_mode = WAL');
+db.pragma('busy_timeout = 5000');
+db.pragma('foreign_keys = ON');
+
+// Refuse to run unless the DB is at the exact schema version the fold was
+// audited against. A later migration could add a buffer-keyed table this fold
+// doesn't know about — running blind would merge an incomplete set and leave a
+// half-folded buffer. Bumping FOLD_VALIDATED_SCHEMA_VERSION (after re-auditing
+// the table list) is the deliberate gate that re-enables the tool.
+const hasMeta = db
+  .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'app_meta'`)
+  .get();
+const schemaVersion = hasMeta
+  ? Number(
+      (
+        db.prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`).get() as
+          | { value: string }
+          | undefined
+      )?.value ?? 0,
+    )
+  : 0;
+if (schemaVersion !== FOLD_VALIDATED_SCHEMA_VERSION) {
+  console.error(
+    `Refusing to run: database schema_version is ${schemaVersion}, but this tool was ` +
+      `validated against ${FOLD_VALIDATED_SCHEMA_VERSION}.`,
+  );
+  console.error(
+    'The schema has changed since the fold was last audited. Re-check that foldBufferCase ' +
+      'still covers every buffer-keyed table, then bump FOLD_VALIDATED_SCHEMA_VERSION.',
+  );
+  db.close();
+  process.exit(1);
+}
+
+function printReport(report: FoldReport): void {
+  const totalRows = Object.values(report.rowsAffected).reduce((a, b) => a + b, 0);
+  console.log(`\nDatabase: ${dbPath}`);
+  console.log(`Scope:    ${report.scope === 'all' ? 'channels + DMs' : 'channels only'}`);
+  console.log(`Mode:     ${report.applied ? 'APPLIED' : 'dry run (no changes written)'}\n`);
+
+  if (report.forks.length === 0 && totalRows === 0) {
+    console.log('No forked buffers found — nothing to fold.\n');
+    return;
+  }
+
+  if (report.forks.length > 0) {
+    console.log(`Forked buffers (${report.forks.length}):`);
+    for (const f of report.forks) {
+      const variants = f.variants
+        .slice()
+        .sort((a, b) => b.messages - a.messages)
+        .map((v) => `${v.target}=${v.messages}`)
+        .join(', ');
+      console.log(`  net ${f.networkId}: [${variants}]  ->  ${f.canonical}`);
+    }
+    console.log('');
+  }
+
+  console.log(`Rows ${report.applied ? 'folded' : 'to fold'} per table:`);
+  for (const [table, n] of Object.entries(report.rowsAffected)) {
+    if (n > 0) console.log(`  ${table.padEnd(24)} ${n}`);
+  }
+  console.log(`  ${'TOTAL'.padEnd(24)} ${totalRows}\n`);
+
+  if (!report.applied && totalRows > 0) {
+    console.log('Re-run with --apply to write these changes.\n');
+  }
+}
+
+try {
+  const report = foldBufferCase(db, { scope, dryRun: !apply });
+  printReport(report);
+} finally {
+  db.close();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  // Server + shared code. Run directly with `tsx`; this config is the
-  // type-check gate (`npm run typecheck`).
+  // Server + shared code, plus operator scripts in tools/. Run directly with
+  // `tsx`; this config is the type-check gate (`npm run typecheck`).
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     // nodenext matches how Node + tsx actually resolve ESM: relative imports
@@ -12,6 +12,6 @@
     "lib": ["es2023"],
     "types": ["node"]
   },
-  "include": ["server/**/*.ts", "shared/**/*.ts"],
+  "include": ["server/**/*.ts", "shared/**/*.ts", "tools/**/*.ts"],
   "exclude": ["node_modules", "vue_client", "integrations", "coverage"]
 }


### PR DESCRIPTION
Closes #289.

## Background

The schema-version-9 migration from #269 (`f682ab8`) already merges case-forked **channel** buffers into one canonical case — but it's a **one-shot**, gated on `schemaVersion < 9`, and it only touches `#`-channels. So:
- a fork that appears *after* the one-shot ran has no cleanup path, and
- **DM** forks (the #327 family — the server never canonicalizes DM casing) were never covered at all.

#289 asks for a way to re-trigger that repair. This delivers it, and also broadens the migration itself.

## Changes

- **Extract** the fold SQL into `server/db/foldBufferCase.ts` — `foldBufferCase(db, { scope, dryRun })`. The migration and the operator script now share **one tested implementation**, so the script provably folds the same way the migration does.
- **Broaden the v9 migration to `scope: 'all'`** — fold every non-virtual buffer (channels, DMs, and `&`/`+`/`!` channels), not just `#`. Canonical case is unchanged: the variant with the most messages (the buffer you actually used), ties broken `target ASC`. The affected DBs are still pre-9, so they get DM forks cleaned on upgrade — no new migration block needed.
- **Operator script `tools/fold-buffer-case.ts`** — the re-runnable fallback for forks that appear *after* the migration ran. Dry-run report by default, `--apply` to commit (one WAL transaction), `--channels-only` to narrow, `--help`.
- **Schema-version guard** — the script refuses to run unless the DB's `schema_version` exactly equals `FOLD_VALIDATED_SCHEMA_VERSION`. A future migration that adds or reshapes a buffer-keyed table moves prod past that, so the tool blocks until someone re-audits the table list and bumps the constant — it can never silently fold an out-of-date set. (The guard lives in the script, not the shared function: the migration calls `foldBufferCase` mid-upgrade, before the version row is written, so gating the function would block the migration itself.)
- Add `tools/**/*.ts` to the typecheck gate so the script is covered.

## Coverage

Channels-keyed tables already covered by the fold: `messages`, `input_history`, `channels`, `buffer_reads`, `closed_buffers`, `pinned_buffers`, `nicklist_collapsed`, `channel_notify_settings`, `user_drafts` — verified that's every target-keyed table (`peer_presence_state` is `COLLATE NOCASE`, so it can't fork). The `scope: 'all'` change just widens the target predicate from `LIKE '#%'` to `NOT LIKE ':%'`.

## Usage

```
tsx tools/fold-buffer-case.ts                 # dry-run report (channels + DMs)
tsx tools/fold-buffer-case.ts --apply         # fold, in one transaction
tsx tools/fold-buffer-case.ts --channels-only # restrict to '#' channels
```

## Known tradeoff

A DB **already** at v9 (an updated user) with a DM fork won't be auto-folded — the v9 block won't re-run on it. The manual script is the cleanup path for that case (consistent with the issue framing: affected users are believed to be on pre-9 builds).

## Tests

`server/db/foldBufferCase.test.ts` — integration over the real schema: dry-run doesn't mutate, channel + DM fold to the majority casing, `channels`-scope leaves DMs untouched, `buffer_reads` merge keeps the furthest read pointer, no-op on an unforked DB. Plus a manual end-to-end run of the CLI (seed → dry-run → apply → verify → guard).

`npm run typecheck` (incl. `tools/`), 214 `server/db` tests, lint, and format all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
