### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@simplewebauthn/server": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Bumps the app version 1.0.1 → 1.0.2 for the 1.0.2 patch release.

- `package.json` (root) and `vue_client/package.json` → `1.0.2`
- Both lockfiles updated (version field only — no dependency changes)

The client surfaces the version through the Vite `APP_VERSION` define sourced from `vue_client/package.json` (`vite.config.ts`), so this is the value shown in-app.

Wraps up the **1.0.2** milestone — #234 and #88 already landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)