### PR TITLE
fix(identd): pre-TLS registration + full RFC 1413 4-tuple match

### DIFF
--- a/deploy/digitalocean-cloud-init.sh
+++ b/deploy/digitalocean-cloud-init.sh
@@ -50,11 +50,17 @@ ADMIN_EMAIL=""
 # single-user instance that doesn't need it.
 #
 # Requires a Lurker image that includes identd (ghcr.io/amiantos/lurker:latest
-# once that lands). Docker note: the IRC server's :113 callback has to map back
-# to the exact source port of the outbound IRC connection; Docker's bridge NAT
-# preserves source ports at normal scale, so this works as-is — if you ever see
-# unverified idents under heavy concurrency, run the lurker service with
-# `network_mode: host` instead.
+# once that lands). Docker note: the :113 callback is matched against the full
+# connection 4-tuple (both addresses + both ports), so the container has to see
+# the IRC server's real source IP and the outbound connection's source port.
+# Docker's default bridge (iptables DNAT) preserves both for external callbacks,
+# so this works as-is. If you ever see unverified idents — under heavy
+# concurrency (source-port reuse), or if your host routes :113 through the
+# userland proxy so callbacks appear to come from the docker gateway — run the
+# lurker service with `network_mode: host` instead, so the container shares the
+# host's addresses directly. The cell logs `[identd] <ports> matched a live
+# connection but query address <ip> did not` on every such mismatch, which is the
+# signal to switch.
 ENABLE_IDENTD=""
 
 # ─── No edits needed below this line ────────────────────────────────────────

--- a/server/services/identd.test.ts
+++ b/server/services/identd.test.ts
@@ -1,14 +1,18 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import net from 'net';
-import { createIdentdServer, registerIdent, unregisterIdent } from './identd.js';
+import { createIdentdServer, registerIdent, unregisterIdent, isPrivateAddress } from './identd.js';
 
 let server: net.Server;
 let port: number;
 
 beforeAll(async () => {
+  // The address-mismatch tests deliberately exercise the NO-USER diagnostic
+  // path (which logs); keep the run output clean.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
   server = createIdentdServer();
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   port = (server.address() as net.AddressInfo).port;
@@ -16,7 +20,14 @@ beforeAll(async () => {
 
 afterAll(() => {
   server.close();
+  vi.restoreAllMocks();
 });
+
+// The query connects from loopback to the loopback listener, so the identd
+// server sees both the local and remote address of the query as 127.0.0.1 —
+// register with those so the 4-tuple matches. (In production the registered
+// remote address is the IRC server, and the query legitimately arrives FROM it.)
+const LOOPBACK = '127.0.0.1';
 
 // Send one ident query line and collect the reply.
 function query(line: string): Promise<string> {
@@ -30,8 +41,14 @@ function query(line: string): Promise<string> {
 }
 
 describe('built-in identd', () => {
-  it('returns USERID for a registered local port', async () => {
-    registerIdent(40001, 'u42');
+  it('returns USERID when the full 4-tuple matches a registered connection', async () => {
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 40001,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667,
+      ident: 'u42',
+    });
     const res = await query('40001, 6667\r\n');
     expect(res.trim()).toBe('40001, 6667 : USERID : UNIX : u42');
   });
@@ -41,9 +58,15 @@ describe('built-in identd', () => {
     expect(res.trim()).toBe('40002, 6667 : ERROR : NO-USER');
   });
 
-  it('returns NO-USER after the port is unregistered', async () => {
-    registerIdent(40003, 'u9');
-    unregisterIdent(40003);
+  it('returns NO-USER after the entry is unregistered by its handle', async () => {
+    const id = registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 40003,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667,
+      ident: 'u9',
+    });
+    unregisterIdent(id);
     const res = await query('40003, 6667\r\n');
     expect(res).toContain('ERROR : NO-USER');
   });
@@ -54,8 +77,145 @@ describe('built-in identd', () => {
   });
 
   it('tolerates loose whitespace in the query', async () => {
-    registerIdent(40004, 'u1');
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 40004,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667,
+      ident: 'u1',
+    });
     const res = await query('  40004 , 6667 \r\n');
     expect(res).toContain('USERID : UNIX : u1');
+  });
+
+  // GHSA-g49q-jw42-6x85: matching ports alone leaks idents to anyone who can
+  // reach :113. A query whose ports match but whose remote address is not the
+  // server the connection goes to must get NO-USER, never the user's ident.
+  it('refuses to answer when ports match but the remote address does not (no enumeration)', async () => {
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 40005,
+      remoteAddress: '198.51.100.7', // a different server than the loopback querier
+      remotePort: 6667,
+      ident: 'secret',
+    });
+    const res = await query('40005, 6667\r\n');
+    expect(res).toContain('ERROR : NO-USER');
+    expect(res).not.toContain('secret');
+  });
+
+  it('refuses when the foreign port differs — it is part of the identifying tuple', async () => {
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 40006,
+      remoteAddress: LOOPBACK,
+      remotePort: 6697,
+      ident: 'u6',
+    });
+    const res = await query('40006, 9999\r\n'); // right local port, wrong foreign port
+    expect(res).toContain('ERROR : NO-USER');
+  });
+
+  it('matches across IPv4-mapped-IPv6 vs bare IPv4 representation', async () => {
+    registerIdent({
+      localAddress: '::ffff:127.0.0.1',
+      localPort: 40007,
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 6667,
+      ident: 'mapped',
+    });
+    const res = await query('40007, 6667\r\n'); // querier reports bare 127.0.0.1
+    expect(res).toContain('USERID : UNIX : mapped');
+  });
+
+  // Two simultaneous connections legally sharing a local source port (to
+  // different servers) must each resolve to their own ident, and closing one
+  // must not delete the other — the failure mode of port-only keying.
+  it('keeps colliding local ports distinct and unregisters them independently', async () => {
+    const idA = registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 40008,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667, // "server A"
+      ident: 'alice',
+    });
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 40008, // same local port…
+      remoteAddress: LOOPBACK,
+      remotePort: 7000, // …different server B
+      ident: 'bob',
+    });
+
+    expect(await query('40008, 6667\r\n')).toContain('USERID : UNIX : alice');
+    expect(await query('40008, 7000\r\n')).toContain('USERID : UNIX : bob');
+
+    // Closing A must leave B answerable.
+    unregisterIdent(idA);
+    expect(await query('40008, 6667\r\n')).toContain('ERROR : NO-USER');
+    expect(await query('40008, 7000\r\n')).toContain('USERID : UNIX : bob');
+  });
+
+  // The canonical multi-user case identd exists for: two users on the SAME
+  // network from one cell. The OS forces their local source ports to differ (the
+  // 4-tuple to an identical destination must be unique), so identd tells them
+  // apart by port. No cross-talk.
+  it('disambiguates two users on the same network by their distinct local ports', async () => {
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 41001,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667,
+      ident: 'lu1',
+    });
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 41002,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667, // same server as lu1
+      ident: 'lu2',
+    });
+
+    expect(await query('41001, 6667\r\n')).toContain('USERID : UNIX : lu1');
+    expect(await query('41002, 6667\r\n')).toContain('USERID : UNIX : lu2');
+  });
+});
+
+// Drives the one-time "idents failing wholesale" diagnostic: a callback whose
+// source is a private/gateway address means the container isn't seeing real
+// source IPs. Getting a range boundary wrong here would either miss the Docker
+// case or cry wolf on real public servers, so pin the classification.
+describe('isPrivateAddress', () => {
+  it('flags loopback, RFC 1918, and link-local IPv4', () => {
+    expect(isPrivateAddress('127.0.0.1')).toBe(true);
+    expect(isPrivateAddress('10.1.2.3')).toBe(true);
+    expect(isPrivateAddress('192.168.1.1')).toBe(true);
+    expect(isPrivateAddress('169.254.10.20')).toBe(true);
+  });
+
+  it('flags the whole 172.16.0.0/12 Docker-bridge range but not its edges', () => {
+    expect(isPrivateAddress('172.16.0.1')).toBe(true);
+    expect(isPrivateAddress('172.17.0.1')).toBe(true); // Docker's default gateway
+    expect(isPrivateAddress('172.31.255.255')).toBe(true);
+    expect(isPrivateAddress('172.15.0.1')).toBe(false); // just below /12
+    expect(isPrivateAddress('172.32.0.1')).toBe(false); // just above /12
+  });
+
+  it('treats real public IPv4 as public', () => {
+    expect(isPrivateAddress('8.8.8.8')).toBe(false);
+    expect(isPrivateAddress('198.51.100.7')).toBe(false);
+    expect(isPrivateAddress('1.2.3.4')).toBe(false);
+  });
+
+  it('flags loopback, ULA, and link-local IPv6 but not global IPv6', () => {
+    expect(isPrivateAddress('::1')).toBe(true);
+    expect(isPrivateAddress('fc00::1')).toBe(true);
+    expect(isPrivateAddress('fd12:3456::1')).toBe(true);
+    expect(isPrivateAddress('fe80::1')).toBe(true);
+    expect(isPrivateAddress('2001:db8::1')).toBe(false);
+  });
+
+  it('treats an empty/unknown address as not private', () => {
+    expect(isPrivateAddress('')).toBe(false);
   });
 });

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -15,22 +15,126 @@
 
 import net from 'net';
 
-// local source port -> ident. Populated as IRC sockets connect, cleared as they
-// close. Module-scoped so the connection layer and the server share one map.
-const idents = new Map<number, string>();
-
-export function registerIdent(localPort: number, ident: string): void {
-  if (localPort > 0 && ident) idents.set(localPort, ident);
+// One registered outbound IRC connection's identity. Keyed by a unique id, NOT
+// the local port: two simultaneous connections may legally share a local source
+// port (TCP only requires the full 4-tuple to be unique), so keying on the port
+// alone lets one clobber the other's ident — and closing one would delete the
+// other's still-live mapping. Module-scoped so the connection layer and the
+// server share one map.
+interface IdentEntry {
+  localAddress: string;
+  localPort: number;
+  remoteAddress: string;
+  remotePort: number;
+  ident: string;
 }
 
-export function unregisterIdent(localPort: number | null): void {
-  if (localPort && localPort > 0) idents.delete(localPort);
+const idents = new Map<number, IdentEntry>();
+let nextIdentId = 0;
+
+// Collapse IPv4-mapped IPv6 (::ffff:1.2.3.4) to plain IPv4 so an address compares
+// equal whether the kernel reported it mapped (common on dual-stack listeners) or
+// bare — otherwise the inbound query address and the stored outbound address can
+// disagree on representation alone and never match.
+function normalizeAddress(address: string | undefined | null): string {
+  if (!address) return '';
+  const m = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(address);
+  return m && net.isIPv4(m[1]) ? m[1] : address;
+}
+
+// Register an outbound connection's identity. Returns a handle used later to
+// unregister this exact entry (or 0 when the entry is unusable). Addresses are
+// normalized up front so lookups match regardless of v4/v6-mapped representation.
+export function registerIdent(entry: IdentEntry): number {
+  if (!(entry.localPort > 0) || !entry.ident) return 0;
+  const id = ++nextIdentId;
+  idents.set(id, {
+    localAddress: normalizeAddress(entry.localAddress),
+    localPort: entry.localPort,
+    remoteAddress: normalizeAddress(entry.remoteAddress),
+    remotePort: entry.remotePort,
+    ident: entry.ident,
+  });
+  return id;
+}
+
+export function unregisterIdent(id: number | null): void {
+  if (id) idents.delete(id);
+}
+
+// Resolve the ident for an RFC 1413 query. The identifying tuple is BOTH
+// addresses and BOTH ports, not just the ports. Matching ports alone (a) returns
+// the wrong user when two connections share a local port and (b) lets anyone who
+// can reach :113 enumerate every active ident by scanning local ports against
+// 6667/6697 (TheLounge GHSA-g49q-jw42-6x85). Requiring the querier's address to
+// be the server the connection actually goes to closes both. `addrMiss` flags the
+// diagnostic case where the ports matched a live connection but the address did
+// not.
+function lookupIdent(
+  lport: number,
+  rport: number,
+  localAddress: string,
+  remoteAddress: string,
+): { ident?: string; addrMiss: boolean } {
+  let addrMiss = false;
+  for (const e of idents.values()) {
+    if (e.localPort !== lport || e.remotePort !== rport) continue;
+    if (e.localAddress === localAddress && e.remoteAddress === remoteAddress) {
+      return { ident: e.ident, addrMiss: false };
+    }
+    addrMiss = true;
+  }
+  return { addrMiss };
+}
+
+// True for loopback / RFC 1918 / link-local / IPv6 ULA & link-local — the address
+// families a NAT gateway (notably Docker's bridge gateway, typically 172.x)
+// substitutes for a real public source. Inputs are already normalized, so
+// v4-mapped IPv6 has been collapsed to plain IPv4 before we get here.
+export function isPrivateAddress(address: string): boolean {
+  if (!address) return false;
+  if (net.isIPv4(address)) {
+    const [a, b] = address.split('.').map(Number);
+    return (
+      a === 127 || // loopback
+      a === 10 || // 10.0.0.0/8
+      (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12 (Docker's default bridge)
+      (a === 192 && b === 168) || // 192.168.0.0/16
+      (a === 169 && b === 254) // 169.254.0.0/16 link-local
+    );
+  }
+  const v6 = address.toLowerCase();
+  return v6 === '::1' || v6.startsWith('fc') || v6.startsWith('fd') || /^fe[89ab]/.test(v6);
+}
+
+// A query whose ports match a live connection but whose source address doesn't is
+// usually harmless — a :113 scan the address check correctly refuses. But when
+// that source is a PRIVATE address while our connections go to public servers,
+// the container almost certainly isn't seeing real inbound source IPs (e.g.
+// Docker routing :113 through its userland proxy, so every callback appears to
+// come from the bridge gateway). In that state EVERY ident verification fails, so
+// we escalate from the per-query warn to a one-time, actionable error rather than
+// letting an operator rediscover the cause from scratch during a rebuild.
+let wholesaleFailureWarned = false;
+function noteAddrMiss(lport: number, rport: number, queryRemoteAddress: string): void {
+  console.warn(
+    `[identd] ${lport},${rport} matched a live connection but query address ${queryRemoteAddress} did not — answering NO-USER`,
+  );
+  if (!wholesaleFailureWarned && isPrivateAddress(queryRemoteAddress)) {
+    wholesaleFailureWarned = true;
+    console.error(
+      `[identd] idents are failing for ALL connections: the :113 callback came from ${queryRemoteAddress}, a private address — this container is not seeing IRC servers' real source IPs. Docker is most likely routing :113 through its userland proxy instead of preserving the source. Fix: run the cell with network_mode: host (see deploy/CELL_REBUILD.md).`,
+    );
+  }
 }
 
 // RFC 1413: the querying server sends "<our-port> , <their-port>"; we reply
-// "<our-port>, <their-port> : USERID : UNIX : <ident>" or ERROR : NO-USER.
+// "<our-port>, <their-port> : USERID : UNIX : <ident>" or ERROR : NO-USER. The
+// query connection's own addresses complete the 4-tuple we match on.
 function handleConnection(socket: net.Socket): void {
   socket.setTimeout(10_000);
+  const queryLocalAddress = normalizeAddress(socket.localAddress);
+  const queryRemoteAddress = normalizeAddress(socket.remoteAddress);
   let buf = '';
   socket.on('data', (chunk: Buffer) => {
     buf += chunk.toString('latin1');
@@ -46,7 +150,8 @@ function handleConnection(socket: net.Socket): void {
     }
     const lport = Number(m[1]);
     const rport = Number(m[2]);
-    const ident = idents.get(lport);
+    const { ident, addrMiss } = lookupIdent(lport, rport, queryLocalAddress, queryRemoteAddress);
+    if (!ident && addrMiss) noteAddrMiss(lport, rport, queryRemoteAddress);
     socket.end(
       ident
         ? `${lport}, ${rport} : USERID : UNIX : ${ident}\r\n`
@@ -76,7 +181,11 @@ export function startIdentd(port: number): void {
     if (srv.listening) srv.close();
     if (server === srv) server = null;
   });
-  srv.listen(port, () => console.log(`[identd] listening on :${port}`));
+  srv.listen(port, () =>
+    console.log(
+      `[identd] listening on :${port} — verifying idents against the full RFC 1413 4-tuple; this relies on the container seeing IRC servers' real inbound source IPs (Docker bridge preserves them; if idents fail wholesale, run with network_mode: host)`,
+    ),
+  );
   server = srv;
 }
 

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -84,6 +84,11 @@ function lookupIdent(
   localAddress: string,
   remoteAddress: string,
 ): { ident?: string; addrMiss: boolean } {
+  // Linear scan, deliberately: N is the cell's live-connection count, which is
+  // capacity-capped (NODE_CAPACITY) and dwarfed by each query's TCP-accept + parse
+  // cost, so a query flood is bounded by connection volume (a firewall/rate-limit
+  // concern), not by this. An index would add register/unregister bookkeeping to
+  // keep in sync — the very dual-state that the port-only bug came from.
   let addrMiss = false;
   for (const e of idents.values()) {
     if (e.localPort !== lport || e.remotePort !== rport) continue;

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -70,6 +70,14 @@ export function unregisterIdent(id: number | null): void {
 // be the server the connection actually goes to closes both. `addrMiss` flags the
 // diagnostic case where the ports matched a live connection but the address did
 // not.
+//
+// The cost of that strictness, accepted deliberately: a network whose ident
+// callback originates from a different IP than its IRC listener (a
+// multi-homed/load-balanced ircd, or one behind its own NAT) won't match, so its
+// users go unverified. There is no fallback that ignores the address without
+// reopening the enumeration hole. Mainstream ircds (solanum/charybdis/InspIRCd)
+// call back from the accepting socket's IP, so this is rare — and noteAddrMiss()
+// escalates loudly when it does happen, rather than failing silently.
 function lookupIdent(
   lport: number,
   rport: number,
@@ -108,22 +116,34 @@ export function isPrivateAddress(address: string): boolean {
 }
 
 // A query whose ports match a live connection but whose source address doesn't is
-// usually harmless — a :113 scan the address check correctly refuses. But when
-// that source is a PRIVATE address while our connections go to public servers,
-// the container almost certainly isn't seeing real inbound source IPs (e.g.
-// Docker routing :113 through its userland proxy, so every callback appears to
-// come from the bridge gateway). In that state EVERY ident verification fails, so
-// we escalate from the per-query warn to a one-time, actionable error rather than
-// letting an operator rediscover the cause from scratch during a rebuild.
+// usually harmless — a :113 scan the address check correctly refuses. But the same
+// signal also marks the two wholesale failures that are hardest to diagnose from
+// scattered warns, so on the FIRST such miss we escalate once with a message
+// tailored to the likely cause:
+//   - a PRIVATE/loopback source means the container isn't seeing real inbound IPs
+//     (e.g. Docker routing :113 through its userland proxy, so every callback
+//     looks like it came from the bridge gateway);
+//   - a PUBLIC source that still doesn't match points at the network's ident
+//     callback originating from a different IP than the server we connected to (a
+//     multi-homed/load-balanced ircd; see lookupIdent) — those users can't be
+//     verified, and there's no fallback that wouldn't reopen :113 enumeration.
+// Escalating on any miss (not just the private one) is what surfaces the public
+// case, which is the wholesale failure with no otherwise-obvious cause; the
+// once-per-process gate keeps a stray scan hit from becoming log spam.
 let wholesaleFailureWarned = false;
 function noteAddrMiss(lport: number, rport: number, queryRemoteAddress: string): void {
   console.warn(
     `[identd] ${lport},${rport} matched a live connection but query address ${queryRemoteAddress} did not — answering NO-USER`,
   );
-  if (!wholesaleFailureWarned && isPrivateAddress(queryRemoteAddress)) {
-    wholesaleFailureWarned = true;
+  if (wholesaleFailureWarned) return;
+  wholesaleFailureWarned = true;
+  if (isPrivateAddress(queryRemoteAddress)) {
     console.error(
-      `[identd] idents are failing for ALL connections: the :113 callback came from ${queryRemoteAddress}, a private address — this container is not seeing IRC servers' real source IPs. Docker is most likely routing :113 through its userland proxy instead of preserving the source. Fix: run the cell with network_mode: host (see deploy/CELL_REBUILD.md).`,
+      `[identd] idents are failing wholesale: a :113 callback came from ${queryRemoteAddress}, a private address — this container is not seeing IRC servers' real source IPs. Docker is most likely routing :113 through its userland proxy instead of preserving the source. Fix: run the cell with network_mode: host.`,
+    );
+  } else {
+    console.error(
+      `[identd] a :113 callback from ${queryRemoteAddress} did not match the server it was issued for. If a whole network's users show as unverified, that network's ident daemon likely originates from a different IP than its IRC listener (multi-homed/load-balanced); the enumeration-safe 4-tuple match cannot answer those.`,
     );
   }
 }

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, vi } from 'vitest';
+import net from 'net';
 import { ircLineParser } from 'irc-framework';
 import type { ConnectOptions } from 'irc-framework';
 import {
@@ -17,6 +18,7 @@ import {
   sendRejectionTargetKind,
   sendRejectionText,
 } from './ircConnection.js';
+import { createIdentdServer, unregisterIdent } from './identd.js';
 
 describe('computeFallbackNick', () => {
   it('appends 1..9 in order', () => {
@@ -730,5 +732,111 @@ describe('refused-message handler routing (#283)', () => {
         text: 'This channel requires a registered nickname.',
       }),
     );
+  });
+});
+
+// identd must be wired to the *pre-TLS* connect event. The IRC server fires its
+// :113 ident callback the instant it accepts our TCP connection — concurrently
+// with the TLS handshake — so registering on the post-handshake 'socket
+// connected' event races (and frequently loses to) that callback on TLS
+// networks, leaving users unidentified behind the shared cell IP. irc-framework
+// emits 'raw socket connected' (with the underlying socket) at bare TCP connect
+// for exactly this purpose; these tests pin us to it.
+describe('built-in identd registration', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'nick',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  // Stand up the real identd server and ask it the same RFC 1413 question the IRC
+  // server would, so we assert the registration is observable end-to-end — not
+  // just that an internal field got set.
+  async function withIdentd(fn: (query: (line: string) => Promise<string>) => Promise<void>) {
+    const server = createIdentdServer();
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as net.AddressInfo).port;
+    const query = (line: string) =>
+      new Promise<string>((resolve, reject) => {
+        const c = net.connect(port, '127.0.0.1', () => c.write(line));
+        let out = '';
+        c.on('data', (d) => (out += d.toString()));
+        c.on('end', () => resolve(out));
+        c.on('error', reject);
+      });
+    try {
+      await fn(query);
+    } finally {
+      server.close();
+    }
+  }
+
+  it('registers the full 4-tuple on pre-TLS "raw socket connected" so the :113 callback resolves', async () => {
+    const prev = process.env.LURKER_IDENTD_ENABLED;
+    process.env.LURKER_IDENTD_ENABLED = '1';
+    let identId: number | null = null;
+    try {
+      await withIdentd(async (query) => {
+        const conn = makeConn();
+        // irc-framework hands us the raw socket at bare TCP connect (before the
+        // TLS handshake completes) with all four tuple fields populated.
+        // Simulate that with the loopback tuple the temp identd server will see
+        // from the query below.
+        conn.client.emit('raw socket connected', {
+          localAddress: '127.0.0.1',
+          localPort: 40010,
+          remoteAddress: '127.0.0.1',
+          remotePort: 6697,
+        });
+        identId = conn.identdId;
+        expect(identId).toBeGreaterThan(0);
+
+        const reply = await query('40010, 6697\r\n');
+        // A successful USERID reply with a non-empty ident — registration landed
+        // before any query could arrive. (The exact ident string is covered by
+        // ident.test.ts; here we only care that the tuple resolved.)
+        expect(reply.trim()).toMatch(/^40010, 6697 : USERID : UNIX : \S+$/);
+      });
+    } finally {
+      unregisterIdent(identId);
+      if (prev === undefined) delete process.env.LURKER_IDENTD_ENABLED;
+      else process.env.LURKER_IDENTD_ENABLED = prev;
+    }
+  });
+
+  it('stays opt-in: no registration when LURKER_IDENTD_ENABLED is unset', () => {
+    const prev = process.env.LURKER_IDENTD_ENABLED;
+    delete process.env.LURKER_IDENTD_ENABLED;
+    try {
+      const conn = makeConn();
+      conn.client.emit('raw socket connected', {
+        localAddress: '127.0.0.1',
+        localPort: 40011,
+        remoteAddress: '127.0.0.1',
+        remotePort: 6697,
+      });
+      expect(conn.identdId).toBeNull();
+    } finally {
+      if (prev !== undefined) process.env.LURKER_IDENTD_ENABLED = prev;
+    }
   });
 });

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -786,7 +786,7 @@ describe('built-in identd registration', () => {
     try {
       await fn(query);
     } finally {
-      server.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   }
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -194,9 +194,10 @@ export class IrcConnection {
   nickAttempt: number;
   regainNick: string | null;
   pendingRegainSetup: boolean;
-  // Local source port of the live socket, while identd is enabled — so we can
-  // unregister this connection's ident from the identd map when it closes.
-  identdLocalPort: number | null;
+  // Handle for this connection's entry in the identd map, while identd is
+  // enabled — so we can unregister exactly this connection's ident (not whatever
+  // else might share its local port) when it closes.
+  identdId: number | null;
   // Targets (channels or nicks) the server has refused our outgoing messages
   // to — a +R/+M channel that needs a registered nick to speak, a +R user, etc.
   // Learned from the first send rejection and used to stop firing typing
@@ -261,7 +262,7 @@ export class IrcConnection {
     // tells us the server supports it (005 arrives after 001/'registered').
     this.regainNick = null;
     this.pendingRegainSetup = false;
-    this.identdLocalPort = null;
+    this.identdId = null;
     this.unsendableTargets = new Set();
     this.lastUserSendAt = new Map();
     this.bind();
@@ -618,8 +619,8 @@ export class IrcConnection {
     c.on('close', () => {
       // Final safety net (clean disconnect/dispose may not always emit
       // 'socket close'); unregisterIdent is idempotent.
-      unregisterIdent(this.identdLocalPort);
-      this.identdLocalPort = null;
+      unregisterIdent(this.identdId);
+      this.identdId = null;
       this.userModes.clear();
       this.stopLagPinger();
       this.cancelPendingConnectCommands();
@@ -793,10 +794,10 @@ export class IrcConnection {
     // log line.
     c.on('socket close', (err: Record<string, unknown>) => {
       this.setState('disconnected');
-      // Release this socket's identd mapping (a reconnect gets a new local port
-      // via the 'socket connected' handler above).
-      unregisterIdent(this.identdLocalPort);
-      this.identdLocalPort = null;
+      // Release this socket's identd mapping (a reconnect re-registers via the
+      // 'raw socket connected' handler above and gets a fresh handle).
+      unregisterIdent(this.identdId);
+      this.identdId = null;
       if (err && (err.message || err.code)) {
         const where = `${this.network.host}:${this.network.port}`;
         const text = formatSocketCloseErrorMessage(
@@ -839,26 +840,46 @@ export class IrcConnection {
     // port → this user's ident so the identd server (services/identd.ts) can
     // answer the IRC server's :113 callback. Without it a multi-user gateway's
     // users are indistinguishable (and unverified) behind one shared IP.
-    c.on('socket connected', () => {
-      if (!isIdentdEnabled()) return;
-      const socket = (
-        this.client as unknown as {
-          connection?: { transport?: { socket?: { localPort?: number } } };
-        }
-      ).connection?.transport?.socket;
-      const localPort = socket?.localPort;
-      if (!localPort) return;
-      this.identdLocalPort = localPort;
-      registerIdent(
-        localPort,
-        deriveIdent({
-          nodeMode: isNodeMode(),
-          accountUsername: findUserById(this.network.user_id)?.username || '',
-          networkUsername: this.network.username,
-          nick: this.network.nick,
-        }),
-      );
-    });
+    //
+    // This MUST run on 'raw socket connected' (the bare TCP connect, before any
+    // TLS handshake) and not 'socket connected' (which irc-framework emits from
+    // the transport's 'open'/'secureConnect' — i.e. AFTER the handshake). The
+    // IRC server fires its ident query the instant it accepts our TCP
+    // connection, concurrently with the TLS handshake, so a post-handshake
+    // registration races the callback: on TLS networks the query frequently
+    // arrives first and identd answers NO-USER. irc-framework hands us the
+    // underlying socket here for exactly this purpose (its own comment:
+    // "ideal to read socket pairs for identd"); localPort is already populated
+    // at TCP-connect time on both plaintext and TLS sockets.
+    c.on(
+      'raw socket connected',
+      (socket?: {
+        localAddress?: string;
+        localPort?: number;
+        remoteAddress?: string;
+        remotePort?: number;
+      }) => {
+        if (!isIdentdEnabled()) return;
+        // The full 4-tuple identifies the connection to the identd server; the
+        // ports alone are ambiguous (see identd.ts). Both addresses and ports
+        // are already populated at TCP connect.
+        const localPort = socket?.localPort;
+        const remotePort = socket?.remotePort;
+        if (!localPort || !remotePort) return;
+        this.identdId = registerIdent({
+          localAddress: socket.localAddress || '',
+          localPort,
+          remoteAddress: socket.remoteAddress || '',
+          remotePort,
+          ident: deriveIdent({
+            nodeMode: isNodeMode(),
+            accountUsername: findUserById(this.network.user_id)?.username || '',
+            networkUsername: this.network.username,
+            nick: this.network.nick,
+          }),
+        });
+      },
+    );
 
     // RPL_UMODEIS arrives when the server sends our current umode (e.g. on
     // login or in response to /MODE <self>). irc-framework normalises it to

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -836,10 +836,11 @@ export class IrcConnection {
     });
     c.on('connecting', () => this.setState('connecting'));
 
-    // Built-in identd: the moment the raw socket connects, map its local source
-    // port → this user's ident so the identd server (services/identd.ts) can
-    // answer the IRC server's :113 callback. Without it a multi-user gateway's
-    // users are indistinguishable (and unverified) behind one shared IP.
+    // Built-in identd: the moment the raw socket connects, register this
+    // connection's full 4-tuple (both addresses + both ports) → this user's ident
+    // so the identd server (services/identd.ts) can answer the IRC server's :113
+    // callback. Without it a multi-user gateway's users are indistinguishable
+    // (and unverified) behind one shared IP.
     //
     // This MUST run on 'raw socket connected' (the bare TCP connect, before any
     // TLS handshake) and not 'socket connected' (which irc-framework emits from


### PR DESCRIPTION
## Problem

Idents were flaky in production (`app.lurker.chat`): connecting to IRC networks, ident frequently failed, and users showed up unidentified behind the shared cell IP.

## Root cause #1 — a TLS-handshake race

Ident was registered on irc-framework's `'socket connected'` event, which fires from the transport's `'open'`/`'secureConnect'` — i.e. **after** the TLS handshake. But an IRC server fires its RFC 1413 callback to `:113` the instant it accepts the TCP connection, concurrently with the handshake. So on TLS networks (≈ every modern IRC network) the query routinely arrived before the ident was registered → `ERROR : NO-USER`. Fast handshakes won the race, slow ones lost it = flaky.

**Fix:** register on `'raw socket connected'` — the bare TCP connect, *before* the handshake. irc-framework exposes this event specifically for identd (its own comment: *"ideal to read socket pairs for identd"*) and hands us the underlying socket, where `localPort` is already populated. This is exactly how The Lounge wires its identd. Verified with a local TLS probe that all four tuple fields are present at the pre-handshake `'connect'` event.

## Root cause #2 — port-only matching (hardening)

The lookup keyed only on the local port, which:

1. **Returns the wrong user** when two connections legally share a local source port to *different* servers (TCP uniqueness is the full 4-tuple), and `unregisterIdent(localPort)` on either close deletes the other's still-live entry → a connected user silently goes `NO-USER`.
2. **Allows enumeration:** anyone reaching `:113` could scan local ports against 6667/6697 to harvest active idents — the class covered by **TheLounge advisory GHSA-g49q-jw42-6x85**.

**Fix:** match the full RFC 1413 tuple (both addresses + both ports). Entries are now keyed by a unique handle; `IrcConnection` stores `identdId` and unregisters precisely, so collisions can't clobber. Addresses are normalized (`::ffff:1.2.3.4` → `1.2.3.4`) to avoid v4/v6-representation false negatives.

Two users on the *same* network are still disambiguated correctly — the OS forces their local source ports to differ — which is the canonical multi-user-behind-one-IP case identd exists for.

## Diagnostics

The strict match introduces a dependency: the cell must see IRC servers' real inbound source IPs. Standard Linux Docker bridge DNAT preserves them (so the prod cell, which runs `-p 113:113` to keep `:8015` VPC-only, works as-is). To make the failure modes loud instead of silent:

- A startup log line states the dependency.
- On the first address-miss against a live connection, a one-time error escalates with a cause-tailored message — Docker-userland-proxy guidance for a private/gateway source, multi-homed/load-balanced-ircd guidance for a public one.

## Known limitation (deliberate)

A network whose ident callback originates from a different IP than its IRC listener (multi-homed/load-balanced ircd) won't match and its users go unverified. There's no fallback that ignores the address without reopening enumeration; mainstream ircds (solanum/charybdis/InspIRCd) call back from the accepting socket's IP, so this is rare — and now surfaced loudly rather than failing silently. Documented at `lookupIdent`.

## Tests

End-to-end against a real identd server (not just internal fields): pre-TLS registration wiring, enumeration refusal, foreign-port mismatch, mapped-v6 normalization, local-port collision independence, same-network user disambiguation, and the `isPrivateAddress` classifier (incl. the 172.16/12 Docker-range boundaries).

Full server suite green (787 tests); typecheck/format/lint clean.

## Related

Operator runbook note added separately in `lurker-control-plane` (`deploy/CELL_REBUILD.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
