### PR TITLE
lint: teach vitest/expect-expect about expectVerbError helper

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -15,7 +15,8 @@
       "error",
       { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrors": "none" }
     ],
-    "import/no-unassigned-import": "off"
+    "import/no-unassigned-import": "off",
+    "vitest/expect-expect": ["error", { "assertFunctionNames": ["expect", "expectVerbError"] }]
   },
   "ignorePatterns": ["**/dist/**", "coverage/**", "vue_client/public/sw.js", "vue_client/src/sw.js"]
 }


### PR DESCRIPTION
oxlint 1.69 (incoming via Dependabot #339) tightened vitest/expect-expect and now errors on the tenant-isolation verb tests, which assert through the custom expectVerbError() wrapper rather than a bare expect(). Whitelist the helper via assertFunctionNames so #339's lint goes green on rebase.