### PR TITLE
Render :emoji: shortcodes as glyphs in the message list (#314)

### DIFF
--- a/vue_client/src/components/LinkedText.vue
+++ b/vue_client/src/components/LinkedText.vue
@@ -10,6 +10,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { splitTextByTokens } from '../utils/nickColor.js';
+import { emojiFn } from '../composables/useEmoji.js';
 import RenderSegments from './RenderSegments.vue';
 
 // Renders a plain-text string with URLs auto-linked and IRC formatting
@@ -26,5 +27,7 @@ const props = withDefaults(
   { text: '' },
 );
 
-const segments = computed(() => splitTextByTokens(props.text, null, null, null));
+// emojiFn() makes this reactive to the emoji table loading, so a topic/motd
+// containing a `:shortcode:` repaints with the glyph once it's ready.
+const segments = computed(() => splitTextByTokens(props.text, null, null, null, emojiFn()));
 </script>

--- a/vue_client/src/composables/useEmoji.ts
+++ b/vue_client/src/composables/useEmoji.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { ref } from 'vue';
-import { emojiGlyph, loadEmoji } from '../utils/emojiShortcodes.js';
+import { emojiGlyph, loadEmoji, onEmojiLoaded } from '../utils/emojiShortcodes.js';
 
 // Render-time `:shortcode:` → emoji glyph for the message list. The ~1,900-entry
 // table lives in a lazily-loaded chunk (emojiData.ts); `preloadEmoji` kicks the
@@ -16,13 +16,18 @@ import { emojiGlyph, loadEmoji } from '../utils/emojiShortcodes.js';
 // verbatim.
 const emojiReady = ref(false);
 
-export async function preloadEmoji(): Promise<void> {
-  try {
-    await loadEmoji();
-    emojiReady.value = true;
-  } catch {
-    // loadEmoji clears its own cache on failure; a later preload retries.
-  }
+// Flip the gate on load completion from *any* caller (not just our preload), so
+// render-time parsing recovers even if the initial preload failed offline and
+// the table is later loaded by the composer. onEmojiLoaded fires once.
+onEmojiLoaded(() => {
+  emojiReady.value = true;
+});
+
+export function preloadEmoji(): void {
+  // Fire-and-forget; the ready flip is handled by onEmojiLoaded above. A failed
+  // load clears loadEmoji's cache, so any later load (here or elsewhere) retries
+  // and still notifies.
+  void loadEmoji().catch(() => {});
 }
 
 // The synchronous shortcode resolver once the table has loaded, else null.

--- a/vue_client/src/composables/useEmoji.ts
+++ b/vue_client/src/composables/useEmoji.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { ref } from 'vue';
+import { emojiGlyph, loadEmoji } from '../utils/emojiShortcodes.js';
+
+// Render-time `:shortcode:` → emoji glyph for the message list. The ~1,900-entry
+// table lives in a lazily-loaded chunk (emojiData.ts); `preloadEmoji` kicks the
+// fetch off once at app start — during the initial connect / buffer-load pause —
+// so the glyphs are ready before (or shortly after) the first paint.
+//
+// `emojiReady` is the single reactive signal that flips when the chunk resolves.
+// `emojiFn` reads it, so any render/computed that calls `emojiFn()` re-runs its
+// segment split when the table arrives: a row that briefly showed the literal
+// `:tada:` repaints as 🎉. Until then `emojiFn()` is null and shortcodes render
+// verbatim.
+const emojiReady = ref(false);
+
+export async function preloadEmoji(): Promise<void> {
+  try {
+    await loadEmoji();
+    emojiReady.value = true;
+  } catch {
+    // loadEmoji clears its own cache on failure; a later preload retries.
+  }
+}
+
+// The synchronous shortcode resolver once the table has loaded, else null.
+// Call this inside a render or computed so the dependency on `emojiReady` is
+// tracked and the split re-runs when the table lands.
+export function emojiFn(): ((name: string) => string | null) | null {
+  return emojiReady.value ? emojiGlyph : null;
+}

--- a/vue_client/src/composables/useNickColors.ts
+++ b/vue_client/src/composables/useNickColors.ts
@@ -5,6 +5,7 @@ import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
 import { useSettingsStore } from '../stores/settings.js';
 import { nickColor, splitTextByTokens } from '../utils/nickColor.js';
+import { emojiFn } from './useEmoji.js';
 
 export interface NickColorsAPI {
   color(nick: string): string | null;
@@ -29,7 +30,9 @@ export function useNickColors(): NickColorsAPI {
   }
 
   function splitText(text: string, nickSet: Set<string>, selfLower: string | null): unknown[] {
-    return splitTextByTokens(text, nickSet, selfLower, color);
+    // emojiFn() reads the reactive emoji-ready signal, so message rows re-run
+    // this split (showing glyphs) once the emoji table finishes loading.
+    return splitTextByTokens(text, nickSet, selfLower, color, emojiFn());
   }
 
   return { color, splitText, selfColor };

--- a/vue_client/src/main.ts
+++ b/vue_client/src/main.ts
@@ -10,6 +10,7 @@ import '@fortawesome/fontawesome-free/css/solid.min.css';
 import '@fortawesome/fontawesome-free/css/regular.min.css';
 import './assets/main.css';
 import { installVisualViewport } from './composables/useVisualViewport.js';
+import { preloadEmoji } from './composables/useEmoji.js';
 
 installVisualViewport();
 
@@ -17,3 +18,8 @@ const app = createApp(App);
 app.use(createPinia());
 app.use(router);
 app.mount('#app');
+
+// Fetch the emoji table up front (during the initial connect/buffer-load pause)
+// so render-time `:shortcode:` parsing has it ready. Render falls back to the
+// literal text until it lands, then repaints — see useEmoji.ts.
+preloadEmoji();

--- a/vue_client/src/utils/emojiShortcodes.test.ts
+++ b/vue_client/src/utils/emojiShortcodes.test.ts
@@ -7,6 +7,7 @@ import {
   findActiveShortcode,
   findCompletedShortcode,
   loadEmoji,
+  onEmojiLoaded,
   rankShortcodes,
   shortcodeScanRegex,
 } from './emojiShortcodes.js';
@@ -170,5 +171,25 @@ describe('emojiGlyph', () => {
   it('returns null for an unknown shortcode', async () => {
     await loadEmoji();
     expect(emojiGlyph('definitely_not_an_emoji')).toBeNull();
+  });
+});
+
+describe('onEmojiLoaded', () => {
+  it('notifies a listener once the table is available', async () => {
+    let notified = false;
+    onEmojiLoaded(() => {
+      notified = true;
+    });
+    await loadEmoji();
+    expect(notified).toBe(true);
+  });
+
+  it('fires immediately when the table is already loaded', async () => {
+    await loadEmoji();
+    let notified = false;
+    onEmojiLoaded(() => {
+      notified = true;
+    });
+    expect(notified).toBe(true);
   });
 });

--- a/vue_client/src/utils/emojiShortcodes.test.ts
+++ b/vue_client/src/utils/emojiShortcodes.test.ts
@@ -3,10 +3,12 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  emojiGlyph,
   findActiveShortcode,
   findCompletedShortcode,
   loadEmoji,
   rankShortcodes,
+  shortcodeScanRegex,
 } from './emojiShortcodes.js';
 
 describe('findActiveShortcode', () => {
@@ -125,5 +127,48 @@ describe('loadEmoji', () => {
     const mod = await first;
     expect(typeof mod.searchEmoji).toBe('function');
     expect(typeof mod.emojiForShortcode).toBe('function');
+  });
+});
+
+describe('shortcodeScanRegex', () => {
+  // Collect every shortcode body the global matcher finds in `text`.
+  function scan(text: string): string[] {
+    const re = shortcodeScanRegex();
+    const out: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) out.push(m[1]);
+    return out;
+  }
+
+  it('matches every completed :name: in a string', () => {
+    expect(scan('a :smile: b :tada:')).toEqual(['smile', 'tada']);
+  });
+
+  it('matches names containing + and -', () => {
+    expect(scan(':+1: and :e-mail:')).toEqual(['+1', 'e-mail']);
+  });
+
+  it('skips a colon glued to a preceding word or number', () => {
+    expect(scan('word:smile: 12:00:00')).toEqual([]);
+  });
+
+  it('returns a fresh, independent regex each call', () => {
+    const a = shortcodeScanRegex();
+    a.exec(':smile:'); // advances a.lastIndex
+    expect(shortcodeScanRegex().exec(':tada:')?.[1]).toBe('tada');
+  });
+});
+
+describe('emojiGlyph', () => {
+  it('resolves a known shortcode (case-insensitive) once the table is loaded', async () => {
+    await loadEmoji();
+    expect(emojiGlyph('tada')).toBe('🎉');
+    expect(emojiGlyph('TADA')).toBe('🎉');
+    expect(emojiGlyph('thumbsup')).toBe('👍');
+  });
+
+  it('returns null for an unknown shortcode', async () => {
+    await loadEmoji();
+    expect(emojiGlyph('definitely_not_an_emoji')).toBeNull();
   });
 });

--- a/vue_client/src/utils/emojiShortcodes.ts
+++ b/vue_client/src/utils/emojiShortcodes.ts
@@ -93,12 +93,25 @@ let emojiModule: Promise<typeof import('./emojiData.js')> | null = null;
 // Stays null until the chunk lands; the render pass treats that as "no emoji
 // yet" and shows the literal `:name:` until a reload re-runs the split.
 let loadedTable: Record<string, string> | null = null;
+// One-shot listeners fired when the table first becomes available, whichever
+// caller triggered the load. Lets the render layer (useEmoji) recover even if
+// its own preload failed: a later successful load from anywhere — the
+// composer's suggester or auto-convert — still flips the render gate, no
+// reload needed. Cleared on success; a failed load keeps them registered so
+// the next attempt still notifies.
+const loadedListeners = new Set<() => void>();
+function notifyEmojiLoaded(): void {
+  const cbs = [...loadedListeners];
+  loadedListeners.clear();
+  for (const cb of cbs) cb();
+}
 export function loadEmoji(): Promise<typeof import('./emojiData.js')> {
   if (!emojiModule) {
     emojiModule = import('./emojiData.js');
     emojiModule
       .then((mod) => {
         loadedTable = mod.EMOJI;
+        notifyEmojiLoaded();
         return mod;
       })
       .catch(() => {
@@ -106,6 +119,16 @@ export function loadEmoji(): Promise<typeof import('./emojiData.js')> {
       });
   }
   return emojiModule;
+}
+
+// Register a callback for when the emoji table is available. Fires immediately
+// if it's already loaded, otherwise once the (current or a later) load resolves.
+export function onEmojiLoaded(cb: () => void): void {
+  if (loadedTable) {
+    cb();
+    return;
+  }
+  loadedListeners.add(cb);
 }
 
 // Synchronous `:shortcode:` → glyph resolver for the render-time pass. Returns

--- a/vue_client/src/utils/emojiShortcodes.ts
+++ b/vue_client/src/utils/emojiShortcodes.ts
@@ -21,6 +21,17 @@ const NAME = '[a-z0-9_+-]+';
 const OPEN_RE = new RegExp(`(?<![a-z0-9_+-]):(${NAME})$`, 'i');
 const CLOSE_RE = new RegExp(`(?<![a-z0-9_+-]):(${NAME}):$`, 'i');
 
+// A *global* matcher for every completed `:name:` in a string, used by the
+// render-time emoji pass (`splitTextByEmoji` in nickColor). It shares NAME and
+// the same opening-boundary rule as OPEN_RE/CLOSE_RE, so the renderer
+// recognises exactly what the composer auto-converts on send — a clock
+// (`12:00`), an `http://` URL, or `word:bone` never reads as a shortcode. A
+// fresh instance is returned per call because a global regex carries mutable
+// `lastIndex`.
+export function shortcodeScanRegex(): RegExp {
+  return new RegExp(`(?<![a-z0-9_+-]):(${NAME}):`, 'gi');
+}
+
 export interface ShortcodeToken {
   /** The shortcode body, lowercased, colons stripped. */
   name: string;
@@ -78,12 +89,31 @@ export function rankShortcodes(names: string[], query: string): string[] {
 // A failed import (offline, etc.) clears the cache so the next caller retries
 // rather than being stuck with a permanently-rejected promise.
 let emojiModule: Promise<typeof import('./emojiData.js')> | null = null;
+// The resolved table, cached for synchronous render-time lookups (`emojiGlyph`).
+// Stays null until the chunk lands; the render pass treats that as "no emoji
+// yet" and shows the literal `:name:` until a reload re-runs the split.
+let loadedTable: Record<string, string> | null = null;
 export function loadEmoji(): Promise<typeof import('./emojiData.js')> {
   if (!emojiModule) {
     emojiModule = import('./emojiData.js');
-    emojiModule.catch(() => {
-      emojiModule = null;
-    });
+    emojiModule
+      .then((mod) => {
+        loadedTable = mod.EMOJI;
+        return mod;
+      })
+      .catch(() => {
+        emojiModule = null;
+      });
   }
   return emojiModule;
+}
+
+// Synchronous `:shortcode:` → glyph resolver for the render-time pass. Returns
+// null when `name` isn't a known emoji, or when the table chunk hasn't loaded
+// yet — so render stays synchronous and a not-yet-loaded shortcode falls
+// through as literal text. Callers kick the load off up front (`preloadEmoji`)
+// and re-render once it resolves. Matching is case-insensitive, mirroring
+// `emojiForShortcode` in emojiData.ts.
+export function emojiGlyph(name: string): string | null {
+  return loadedTable?.[name.toLowerCase()] ?? null;
 }

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -174,3 +174,88 @@ describe('segmentInlineStyle / segmentHasStyle — background colour', () => {
     expect(segmentHasStyle({ text: 'x' })).toBe(false);
   });
 });
+
+describe('splitTextByTokens — emoji shortcodes', () => {
+  // A stand-in for the emoji table so the render-time pass is deterministic
+  // without loading the real ~1,900-entry chunk. The real resolver (emojiGlyph)
+  // is exercised in emojiShortcodes.test.ts.
+  const FAKE: Record<string, string> = {
+    smile: '😄',
+    tada: '🎉',
+    '+1': '👍',
+    'e-mail': '📧',
+  };
+  const emoji = (name: string): string | null => FAKE[name.toLowerCase()] ?? null;
+  const parseEmoji = (text: string) => splitTextByTokens(text, null, null, null, emoji);
+
+  it('replaces a known :shortcode: with its glyph', () => {
+    expect(parseEmoji(':smile:')).toEqual([{ text: '😄' }]);
+  });
+
+  it('replaces a shortcode mid-sentence, keeping the surrounding text', () => {
+    expect(parseEmoji('well :tada: done')).toEqual([
+      { text: 'well ' },
+      { text: '🎉' },
+      { text: ' done' },
+    ]);
+  });
+
+  it('matches a case-insensitive shortcode', () => {
+    expect(parseEmoji(':TADA:')).toEqual([{ text: '🎉' }]);
+  });
+
+  it('handles + and - inside the shortcode name', () => {
+    expect(parseEmoji('nice :+1: then :e-mail:')).toEqual([
+      { text: 'nice ' },
+      { text: '👍' },
+      { text: ' then ' },
+      { text: '📧' },
+    ]);
+  });
+
+  it('converts adjacent shortcodes', () => {
+    expect(parseEmoji(':+1::+1:')).toEqual([{ text: '👍' }, { text: '👍' }]);
+  });
+
+  it('leaves an unknown shortcode literal', () => {
+    expect(parseEmoji('what :nope: is')).toEqual([{ text: 'what :nope: is' }]);
+  });
+
+  it('does not convert when the opening colon hugs a preceding word char', () => {
+    // The composer's boundary rule: "word:smile:" is not a shortcode start.
+    expect(parseEmoji('word:smile:')).toEqual([{ text: 'word:smile:' }]);
+  });
+
+  it('does not convert a clock like 12:00:00', () => {
+    expect(parseEmoji('at 12:00:00 sharp')).toEqual([{ text: 'at 12:00:00 sharp' }]);
+  });
+
+  it('passes text through unchanged when no emojiFn is supplied', () => {
+    // The 4-arg form (LinkedText pre-load, composer-less callers) never converts.
+    expect(splitTextByTokens(':smile:', null, null, null)).toEqual([{ text: ':smile:' }]);
+  });
+
+  it('carries active IRC formatting onto an emoji glyph', () => {
+    expect(splitTextByTokens(`${BOLD}:tada:`, null, null, null, emoji)).toEqual([
+      { text: '🎉', bold: true },
+    ]);
+  });
+
+  it('runs after channel splitting — a shortcode after a #channel still converts', () => {
+    expect(parseEmoji('#chan :tada:')).toEqual([
+      { text: '#chan', channel: '#chan' },
+      { text: ' ' },
+      { text: '🎉' },
+    ]);
+  });
+
+  it('still colours a nick that follows an emoji', () => {
+    const nickSet = new Set(['alice']);
+    const color = (n: string): string | null => (n.toLowerCase() === 'alice' ? '#f00' : null);
+    expect(splitTextByTokens(':tada: alice', nickSet, null, color, emoji)).toEqual([
+      { text: '🎉' },
+      { text: ' ' },
+      { text: 'alice', color: '#f00', self: false },
+    ]);
+  });
+});

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { createUrlRegex } from '../../../shared/urlPattern.js';
+import { shortcodeScanRegex } from './emojiShortcodes.js';
 
 // Deterministic nick coloring. Mirrors weechat's gui_nick_find_color:
 // trim stop chars, lowercase, hash, modulo a palette.
@@ -181,6 +182,42 @@ function splitTextByChannels(text: string): ChannelOrTextSegment[] {
   }
   if (lastIdx < text.length) out.push({ kind: 'text', text: text.slice(lastIdx) });
   return out;
+}
+
+interface EmojiOrTextPiece {
+  text: string;
+  // true when `text` is an emoji glyph that replaced a `:shortcode:` — the
+  // caller emits it as-is and skips the nick pass (a glyph has no nick inside).
+  emoji?: boolean;
+}
+
+// Replace every resolvable `:shortcode:` with its emoji glyph, splitting the
+// run into literal / glyph pieces. `emojiFn` (typically `emojiGlyph`) is the
+// injected lookup; it's null until the emoji table loads and in non-message
+// callers, in which case the text passes through untouched. Unknown shortcodes
+// (`:foo:` with no match) are left literal. Uses the composer's grammar via
+// `shortcodeScanRegex`, so what we auto-convert on send we render on receive.
+// Runs on text that has already had URLs and channels split out, so a
+// `http://x:y:z` or `#chan:foo` token never reaches this pass.
+function splitTextByEmoji(
+  text: string,
+  emojiFn: ((name: string) => string | null) | null | undefined,
+): EmojiOrTextPiece[] {
+  if (!emojiFn || !text) return [{ text }];
+  const re = shortcodeScanRegex();
+  const out: EmojiOrTextPiece[] = [];
+  let lastIdx = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const glyph = emojiFn(m[1]);
+    if (glyph == null) continue; // not a known emoji — leave `:name:` literal
+    const start = m.index;
+    if (start > lastIdx) out.push({ text: text.slice(lastIdx, start) });
+    out.push({ text: glyph, emoji: true });
+    lastIdx = start + m[0].length;
+  }
+  if (lastIdx < text.length) out.push({ text: text.slice(lastIdx) });
+  return out.length ? out : [{ text }];
 }
 
 interface NickTextSegment {
@@ -467,14 +504,19 @@ export function segmentHasStyle(seg: RenderSegment): boolean {
   );
 }
 
-// Channel detection then nick detection over a plain (URL-free) text run.
+// Channel, then emoji, then nick detection over a plain (URL-free) text run.
 // Channels are matched first because a channel token can't contain a nick
-// (nicks never start with #/&), so the order is unambiguous.
+// (nicks never start with #/&), so the order is unambiguous. Emoji shortcodes
+// run next so a glyph is emitted whole and the remaining literal text still
+// gets the nick pass — and a nick that happens to spell an emoji name (`:bone:`
+// vs a user "bone") can't collide, since the shortcode needs the surrounding
+// colons.
 function splitPlainText(
   text: string,
   nickSet: Set<string> | null | undefined,
   selfLower: string | null | undefined,
   colorFn: ((nick: string) => string | null) | null | undefined,
+  emojiFn: ((name: string) => string | null) | null | undefined,
 ): RenderSegment[] {
   const out: RenderSegment[] = [];
   for (const seg of splitTextByChannels(text)) {
@@ -483,8 +525,15 @@ function splitPlainText(
       continue;
     }
     if (!seg.text) continue;
-    for (const ns of colorNicksInText(seg.text, nickSet, selfLower, colorFn)) {
-      if (ns.text) out.push(ns);
+    for (const piece of splitTextByEmoji(seg.text, emojiFn)) {
+      if (piece.emoji) {
+        out.push({ text: piece.text });
+        continue;
+      }
+      if (!piece.text) continue;
+      for (const ns of colorNicksInText(piece.text, nickSet, selfLower, colorFn)) {
+        if (ns.text) out.push(ns);
+      }
     }
   }
   return out;
@@ -495,6 +544,7 @@ function splitRunIntoSegments(
   nickSet: Set<string> | null | undefined,
   selfLower: string | null | undefined,
   colorFn: ((nick: string) => string | null) | null | undefined,
+  emojiFn: ((name: string) => string | null) | null | undefined,
 ): RenderSegment[] {
   if (!text) return [];
   const out: RenderSegment[] = [];
@@ -504,27 +554,34 @@ function splitRunIntoSegments(
       continue;
     }
     if (!seg.text) continue;
-    out.push(...splitPlainText(seg.text, nickSet, selfLower, colorFn));
+    out.push(...splitPlainText(seg.text, nickSet, selfLower, colorFn, emojiFn));
   }
   return out;
 }
 
 // Split `text` into renderable segments. Formatting codes are parsed first so
-// each downstream segment carries its IRC formatting attrs; URL splitting then
-// nick splitting run on the cleaned text inside each formatting run.
+// each downstream segment carries its IRC formatting attrs; URL, then channel,
+// then emoji, then nick splitting run on the cleaned text inside each
+// formatting run.
+//
+// `emojiFn` (optional) resolves a `:shortcode:` to its glyph for the
+// client-side render-time emoji pass — pass `emojiGlyph` (once the table has
+// loaded) to turn `:tada:` into 🎉, or omit/null to leave shortcodes literal.
+// It's render-only: the stored message text is never mutated.
 //
 // Returned segment shapes (callers branch on these in order):
 //   { text, spoiler, ...fmt }           — hidden run (fg===bg); render as a
 //                                         click-to-reveal box, never an <a>
 //   { url, text, ...fmt }               — clickable link (with formatting)
 //   { channel, text, ...fmt }           — clickable IRC channel name
-//   { text, color?, self?, ...fmt }     — nick / plain text (with formatting)
+//   { text, color?, self?, ...fmt }     — nick / plain text / emoji glyph
 // where fmt is { bold?, italic?, underline?, strike?, fg?, bg? }.
 export function splitTextByTokens(
   text: string | null | undefined,
   nickSet: Set<string> | null | undefined,
   selfLower: string | null | undefined,
   colorFn: ((nick: string) => string | null) | null | undefined,
+  emojiFn?: ((name: string) => string | null) | null,
 ): RenderSegment[] {
   if (!text) return [{ text: '' }];
   const runs = parseIrcFormatting(text);
@@ -548,7 +605,7 @@ export function splitTextByTokens(
     }
     if (run.fg != null) fmt.fg = run.fg;
     if (run.bg != null) fmt.bg = run.bg;
-    for (const seg of splitRunIntoSegments(run.text, nickSet, selfLower, colorFn)) {
+    for (const seg of splitRunIntoSegments(run.text, nickSet, selfLower, colorFn, emojiFn)) {
       out.push({ ...seg, ...fmt });
     }
   }


### PR DESCRIPTION
Closes #314.

## What

Adds a **client-side, render-time** pass that turns resolvable `:shortcode:` tokens (e.g. `:tada:` → 🎉) into their emoji glyph when displaying a message. The stored message text is never touched — this is display only.

Since the composer already auto-converts shortcodes to glyphs on send, the value here is **interop**: shortcodes that arrive as literal text — messages from other IRC clients, pasted text, and anything the send-time convert didn't catch — now render the same way they do everywhere else.

## How

- **`emojiShortcodes.ts`** — caches the loaded `EMOJI` table for a synchronous `emojiGlyph(name)` lookup, and exposes `shortcodeScanRegex()` (a global matcher sharing the composer's `NAME` grammar + opening-boundary rule) so the renderer recognises *exactly* what the composer auto-converts. `12:00`, `http://…`, and `word:bone` never match.
- **`nickColor.ts`** — new `splitTextByEmoji` slots into `splitTextByTokens` **after URL + channel splitting, before nick coloring**, so links / channels / nicks can't collide with a shortcode, and spoiler runs (which short-circuit earlier) are untouched. The `emojiFn` lookup is **injected and optional**, keeping the util pure and testable; unknown shortcodes stay literal.
- **`useEmoji.ts`** (new) — `preloadEmoji()` fetches the lazy emoji chunk up front at app start (during the initial connect/buffer-load pause); `emojiReady` is a reactive signal so message rows that briefly showed `:tada:` repaint with 🎉 once the table lands. Wired through `useNickColors` and `LinkedText` (so topics/motd get emoji too) and kicked off in `main.ts`.

The emoji table **stays a separate ~39 kB lazy chunk** — confirmed via `client:build`, it is not pulled into the main bundle.

## Tests

`nickColor.test.ts` (render pass: replacement, mid-sentence, case-insensitive, `+`/`-` names, adjacency, unknown-stays-literal, `word:smile:`/`12:00:00` non-matches, no-emojiFn passthrough, formatting carry-over, post-channel, nick-after-emoji) and `emojiShortcodes.test.ts` (`shortcodeScanRegex` grammar + `emojiGlyph` resolution). **62/62 pass**; typecheck / lint / format clean.

## Follow-ups (separate issues, out of scope)

- #348 — desktop vertical suggester panel for `:` (gated on #212)

🤖 Generated with [Claude Code](https://claude.com/claude-code)