### PR TITLE
Extract VerticalPopover from the three composer pickers (#212)

### DIFF
--- a/vue_client/src/components/ChannelPicker.vue
+++ b/vue_client/src/components/ChannelPicker.vue
@@ -3,39 +3,39 @@
   SPDX-License-Identifier: MPL-2.0
 -->
 
+<!--
+  `#`-channel completion menu. Thin wrapper over VerticalPopover (issue #212):
+  it owns only the channel candidate list (joined channels, no /LIST directory —
+  issue #154); the shared popover owns positioning, dismissal, the iOS focus
+  contract, and keyboard nav. `:ignore` is the anchor so a tap on the input bar
+  keeps the menu open. `reverse` puts the best match at the bottom, nearest the
+  input.
+-->
+
 <template>
-  <div
-    v-if="open && rows.length"
-    ref="panelEl"
-    class="channel-picker"
-    :style="panelStyle"
-    @pointerdown.stop
-    @mousedown.prevent.stop
+  <VerticalPopover
+    ref="popover"
+    :open="open"
+    :rows="rows"
+    :anchor="anchor"
+    :ignore="[anchor]"
+    reverse
+    :row-key="rowKey"
+    @select="onSelect"
+    @close="emit('close')"
   >
-    <!-- Same iOS focus-preservation contract as NickPicker: act on `click`
-         (end of touch), keep `@mousedown.prevent` so focus never leaves the
-         textarea, and use a plain <div role=button> rather than a focusable
-         <button>. Emitting on pointerdown would close the picker (v-if)
-         mid-touch and defeat the focus guard. -->
-    <div
-      v-for="row in renderedRows"
-      :key="row.name + ':' + row.index"
-      role="button"
-      class="row"
-      :class="{ active: row.index === activeIndex }"
-      @mousedown.prevent
-      @click="pick(row.name)"
-      @mouseenter="activeIndex = row.index"
-    >
-      <span class="channel">{{ row.name }}</span>
-    </div>
-  </div>
+    <template #row="{ row }">
+      <span class="channel">{{ row }}</span>
+    </template>
+  </VerticalPopover>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
+import { ref, computed } from 'vue';
 import { useBuffersStore } from '../stores/buffers.js';
 import { buildChannelCandidates } from '../utils/channelCompletion.js';
+import VerticalPopover from './VerticalPopover.vue';
+import type { PopoverNav } from './popoverNav.js';
 
 const props = withDefaults(
   defineProps<{
@@ -60,166 +60,33 @@ const emit = defineEmits<{
 }>();
 
 const buffers = useBuffersStore();
-const panelEl = ref<HTMLElement | null>(null);
-const panelBottom = ref(8);
 
-// Index into `rows` (candidate order, 0 = best match) of the keyboard-
-// highlighted entry. Rows render bottom-up — see `renderedRows` — so index 0
-// sits visually at the bottom, nearest the input bar.
-const activeIndex = ref(0);
-
-const rows = computed(() => {
-  // Bail before touching the buffers store while closed: a computed only
-  // tracks the deps it reads, so this early return keeps `rows` (and the watch
-  // that subscribes to it) from rebuilding the candidate list on every buffer
-  // mutation behind a closed picker. The panel's v-if gates on `open` anyway,
-  // so returning [] here is behavior-neutral.
+const rows = computed<string[]>(() => {
+  // Bail before touching the buffers store while closed so the candidate list
+  // doesn't rebuild on every buffer mutation behind a closed picker. The
+  // popover hides when closed anyway, so returning [] here is behavior-neutral.
   if (!props.open || props.networkId == null) return [];
-  return buildChannelCandidates(buffers.forNetwork(props.networkId), props.query)
-    .slice(0, 50)
-    .map((name, index) => ({ name, index }));
+  return buildChannelCandidates(buffers.forNetwork(props.networkId), props.query).slice(0, 50);
 });
 
-// The panel opens upward, so render candidates worst-to-best top-to-bottom —
-// the most likely pick lands at the bottom, right under the user's eye and
-// closest to the input bar.
-const renderedRows = computed(() => rows.value.slice().reverse());
-
-function pick(channel: string) {
-  emit('select', channel);
+function rowKey(row: string): string {
+  return row;
+}
+function onSelect(row: string): void {
+  emit('select', row);
 }
 
-// Keyboard navigation, driven from MessageInput's textarea keydown handler:
-// the textarea keeps focus while the picker is open, so the picker never
-// receives key events itself. `delta` is in candidate-index space — +1 steps
-// toward worse matches (visually up), -1 toward the best match (visually
-// down) — and clamps at both ends rather than wrapping.
-function moveActive(delta: number) {
-  const n = rows.value.length;
-  if (n === 0) return;
-  activeIndex.value = Math.min(Math.max(activeIndex.value + delta, 0), n - 1);
-  // Keyboard moves can land on a row scrolled out of the panel — pull it back
-  // in. Mouse hover also sets activeIndex (see @mouseenter) but a hovered row
-  // is necessarily already visible, so the scroll lives here rather than in a
-  // blanket watch(activeIndex).
-  nextTick(scrollActiveIntoView);
-}
-
-function confirmActive() {
-  const row = rows.value[activeIndex.value];
-  if (row) pick(row.name);
-}
-
-function hasCandidates() {
-  return rows.value.length > 0;
-}
-
-defineExpose({ moveActive, confirmActive, hasCandidates });
-
-function scrollActiveIntoView() {
-  const el = panelEl.value?.querySelector('.row.active');
-  if (el) (el as HTMLElement).scrollIntoView({ block: 'nearest' });
-}
-
-function recomputePosition() {
-  // Anchor the picker just above the input bar, riding above the iOS soft
-  // keyboard via visualViewport.height. Without this, the picker gets occluded
-  // as soon as the keyboard slides up.
-  const anchor = props.anchor;
-  if (!anchor) {
-    panelBottom.value = 8;
-    return;
-  }
-  const rect = anchor.getBoundingClientRect();
-  const vv = window.visualViewport;
-  const viewportHeight = vv ? vv.height : window.innerHeight;
-  // Distance from bottom of viewport to top of anchor.
-  const distance = viewportHeight - rect.top;
-  panelBottom.value = Math.max(distance + 4, 8);
-}
-
-const panelStyle = computed(() => ({ bottom: `${panelBottom.value}px` }));
-
-function onDocPointerDown(e: PointerEvent) {
-  if (!props.open) return;
-  const panel = panelEl.value;
-  const anchor = props.anchor;
-  if (panel && panel.contains(e.target as Node)) return;
-  if (anchor && anchor.contains(e.target as Node)) return;
-  emit('close');
-}
-
-function onKey(e: KeyboardEvent) {
-  if (!props.open) return;
-  if (e.key === 'Escape') emit('close');
-}
-
-onMounted(() => {
-  recomputePosition();
-  window.addEventListener('resize', recomputePosition);
-  window.visualViewport?.addEventListener('resize', recomputePosition);
-  window.visualViewport?.addEventListener('scroll', recomputePosition);
-  document.addEventListener('pointerdown', onDocPointerDown);
-  document.addEventListener('keydown', onKey);
+// Forward keyboard nav to the popover so MessageInput's textarea keydown
+// handler can drive it (the textarea keeps focus while the menu is open).
+const popover = ref<PopoverNav | null>(null);
+defineExpose({
+  moveActive: (delta: number) => popover.value?.moveActive(delta),
+  confirmActive: () => popover.value?.confirmActive(),
+  hasCandidates: () => popover.value?.hasCandidates() ?? false,
 });
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', recomputePosition);
-  window.visualViewport?.removeEventListener('resize', recomputePosition);
-  window.visualViewport?.removeEventListener('scroll', recomputePosition);
-  document.removeEventListener('pointerdown', onDocPointerDown);
-  document.removeEventListener('keydown', onKey);
-});
-
-// A new candidate set (the query changed, or buffers were re-filtered)
-// re-anchors the highlight on the best match and pulls it back into view.
-watch(rows, () => {
-  activeIndex.value = 0;
-  nextTick(scrollActiveIntoView);
-});
-
-watch(
-  () => props.open,
-  (v) => {
-    if (v) {
-      activeIndex.value = 0;
-      recomputePosition();
-      nextTick(scrollActiveIntoView);
-    }
-  },
-);
 </script>
 
 <style scoped>
-.channel-picker {
-  position: fixed;
-  left: var(--space-4);
-  right: var(--space-4);
-  max-width: 480px;
-  margin: 0 auto;
-  max-height: 50vh;
-  overflow-y: auto;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-popover-up);
-  z-index: var(--z-popover);
-}
-.row {
-  display: flex;
-  align-items: center;
-  padding: var(--space-6);
-  min-height: 44px;
-  cursor: pointer;
-  user-select: none;
-}
-/* Single highlight, shared by mouse and keyboard: hovering a row sets
-   activeIndex (see @mouseenter), so .active alone covers both — no separate
-   :hover rule that could double-highlight during keyboard nav. Soft neutral
-   fill matches the context menu / Cmd-K list. */
-.row.active {
-  background: var(--bg-soft);
-}
 .channel {
   font-weight: 500;
 }

--- a/vue_client/src/components/HistoryPicker.vue
+++ b/vue_client/src/components/HistoryPicker.vue
@@ -4,48 +4,41 @@
 -->
 
 <!--
-  Previous-input recall menu — the pointer-driven counterpart to Up-arrow
-  history. Opened by tapping the `>` prompt (see MessageInput), it lists the
-  buffer's recent submitted lines so mobile users, who have no arrow keys, can
-  still reach their input history (issue #204). Picking a row replaces the
-  composer outright, exactly like an Up-arrow recall — editable, not sent.
+  Previous-input recall menu — opened by tapping the `>` prompt (see
+  MessageInput), it lists the buffer's recent submitted lines so mobile users,
+  who have no arrow keys, can still reach their input history (issue #204).
+  Picking a row replaces the composer outright, exactly like an Up-arrow
+  recall — editable, not sent.
 
-  Modelled on ChannelPicker: a position:fixed popover anchored above the input
-  bar and kept clear of the iOS soft keyboard via visualViewport. Tap-only by
-  design — Up/Down already serve keyboard users — so there's no externally
-  driven activeIndex; a plain :hover highlight is enough.
+  Thin wrapper over VerticalPopover (issue #212): it owns only the entry list +
+  row look; the shared popover owns positioning, dismissal, the iOS focus
+  contract, and keyboard nav (the `>` toggle and Up/Down still recall inline
+  when the menu is closed; once it's open, Up/Down move the selection). `:ignore`
+  is the toggle button — its own click handler owns open/close, so a tap there
+  must not also dismiss. Entries arrive oldest-first, so the newest (likeliest
+  recall) renders at the bottom, nearest the input — no `reverse`.
 -->
 
 <template>
-  <div
-    v-if="open && rows.length"
-    ref="panelEl"
-    class="history-picker"
-    :style="panelStyle"
-    @pointerdown.stop
-    @mousedown.prevent.stop
+  <VerticalPopover
+    ref="popover"
+    :open="open"
+    :rows="rows"
+    :anchor="anchor"
+    :ignore="[toggleEl]"
+    @select="onSelect"
+    @close="emit('close')"
   >
-    <!-- Same iOS focus-preservation contract as ChannelPicker: act on `click`
-         (end of touch), keep `@mousedown.prevent` so focus never leaves the
-         textarea, and use a plain <div role=button> rather than a focusable
-         <button>. Emitting on pointerdown would close the picker (v-if)
-         mid-touch and defeat the focus guard. -->
-    <div
-      v-for="(entry, i) in rows"
-      :key="i + ':' + entry"
-      role="button"
-      class="row"
-      :title="entry"
-      @mousedown.prevent
-      @click="pick(entry)"
-    >
-      <span class="entry">{{ entry }}</span>
-    </div>
-  </div>
+    <template #row="{ row }">
+      <span class="entry" :title="row">{{ row }}</span>
+    </template>
+  </VerticalPopover>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
+import { ref, computed } from 'vue';
+import VerticalPopover from './VerticalPopover.vue';
+import type { PopoverNav } from './popoverNav.js';
 
 const props = withDefaults(
   defineProps<{
@@ -73,117 +66,26 @@ const emit = defineEmits<{
   close: [];
 }>();
 
-const panelEl = ref<HTMLElement | null>(null);
-const panelBottom = ref(8);
-
 // Cap the list so a long-lived buffer doesn't render hundreds of rows. The
 // newest entries are the likeliest recalls, so keep the tail (oldest first ->
 // newest last) and let the panel scroll for the rest.
-const rows = computed(() => (props.open ? props.entries.slice(-50) : []));
+const rows = computed<readonly string[]>(() => (props.open ? props.entries.slice(-50) : []));
 
-function pick(entry: string) {
-  emit('select', entry);
+function onSelect(row: string): void {
+  emit('select', row);
 }
 
-function recomputePosition() {
-  // Anchor the picker just above the input bar, riding above the iOS soft
-  // keyboard via visualViewport.height. Without this, the picker gets occluded
-  // as soon as the keyboard slides up.
-  const anchor = props.anchor;
-  if (!anchor) {
-    panelBottom.value = 8;
-    return;
-  }
-  const rect = anchor.getBoundingClientRect();
-  const vv = window.visualViewport;
-  const viewportHeight = vv ? vv.height : window.innerHeight;
-  // Distance from bottom of viewport to top of anchor.
-  const distance = viewportHeight - rect.top;
-  panelBottom.value = Math.max(distance + 4, 8);
-}
-
-const panelStyle = computed(() => ({ bottom: `${panelBottom.value}px` }));
-
-function onDocPointerDown(e: PointerEvent) {
-  if (!props.open) return;
-  const panel = panelEl.value;
-  const toggle = props.toggleEl;
-  if (panel && panel.contains(e.target as Node)) return;
-  // The toggle owns open/close — let its click handler decide, don't double-
-  // fire a close here. Tapping anywhere else (including the textarea) dismisses.
-  if (toggle && toggle.contains(e.target as Node)) return;
-  emit('close');
-}
-
-function onKey(e: KeyboardEvent) {
-  if (!props.open) return;
-  if (e.key === 'Escape') emit('close');
-}
-
-onMounted(() => {
-  recomputePosition();
-  window.addEventListener('resize', recomputePosition);
-  window.visualViewport?.addEventListener('resize', recomputePosition);
-  window.visualViewport?.addEventListener('scroll', recomputePosition);
-  document.addEventListener('pointerdown', onDocPointerDown);
-  document.addEventListener('keydown', onKey);
+// Forward keyboard nav to the popover so MessageInput's textarea keydown
+// handler can drive it (the textarea keeps focus while the menu is open).
+const popover = ref<PopoverNav | null>(null);
+defineExpose({
+  moveActive: (delta: number) => popover.value?.moveActive(delta),
+  confirmActive: () => popover.value?.confirmActive(),
+  hasCandidates: () => popover.value?.hasCandidates() ?? false,
 });
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', recomputePosition);
-  window.visualViewport?.removeEventListener('resize', recomputePosition);
-  window.visualViewport?.removeEventListener('scroll', recomputePosition);
-  document.removeEventListener('pointerdown', onDocPointerDown);
-  document.removeEventListener('keydown', onKey);
-});
-
-watch(
-  () => props.open,
-  (v) => {
-    if (!v) return;
-    recomputePosition();
-    // Open scrolled to the bottom — the newest entry sits there, nearest the
-    // input, and it's the likeliest recall. Without this the overflow scroller
-    // defaults to the top (oldest), unlike the nick/channel pickers which pull
-    // their best match (rendered at the bottom) into view on open.
-    nextTick(() => {
-      const panel = panelEl.value;
-      if (panel) panel.scrollTop = panel.scrollHeight;
-    });
-  },
-);
 </script>
 
 <style scoped>
-.history-picker {
-  position: fixed;
-  left: var(--space-4);
-  right: var(--space-4);
-  max-width: 480px;
-  margin: 0 auto;
-  max-height: 50vh;
-  overflow-y: auto;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-popover-up);
-  z-index: var(--z-popover);
-}
-.row {
-  display: flex;
-  align-items: center;
-  padding: var(--space-6);
-  min-height: 44px;
-  cursor: pointer;
-  user-select: none;
-}
-/* Tap-only menu — no externally driven activeIndex to coordinate with, so a
-   plain :hover highlight is fine (unlike the nick/channel pickers, which avoid
-   :hover to dodge double-highlighting during keyboard nav). Soft neutral fill
-   matches the context menu / Cmd-K list. */
-.row:hover {
-  background: var(--bg-soft);
-}
 /* Recalled lines can be long — keep each row to a single line, clipped with an
    ellipsis. The full text is in the row's title and lands in the composer on
    pick, so nothing is lost. */

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -89,6 +89,7 @@
          (issue #204). Anchored to the form like the pickers above; `toggle-el`
          is the prompt button so its own taps don't double-dismiss. -->
     <HistoryPicker
+      ref="historyPickerEl"
       :open="historyPickerOpen"
       :entries="historyEntries"
       :anchor="formEl"
@@ -191,6 +192,7 @@ let channelPickerTokenEnd = -1;
 // lists the whole buffer history. `promptBtnEl` is that toggle, kept here so
 // HistoryPicker can exclude it from its outside-tap dismissal.
 const historyPickerOpen = ref(false);
+const historyPickerEl = ref<InstanceType<typeof HistoryPicker> | null>(null);
 const promptBtnEl = ref<HTMLElement | null>(null);
 // Suggestion-strip and colour-picker visibility / contents live in
 // useComposerOverlay so StatusBar can render them as overlays without prop
@@ -679,7 +681,7 @@ function onKeydown(e: KeyboardEvent): void {
     if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
       if (!e.altKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
-        nickPickerEl.value.moveActive(e.key === 'ArrowUp' ? 1 : -1);
+        nickPickerEl.value.moveActive(e.key === 'ArrowUp' ? -1 : 1);
         return;
       }
     } else if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
@@ -699,7 +701,7 @@ function onKeydown(e: KeyboardEvent): void {
     if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
       if (!e.altKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
-        channelPickerEl.value.moveActive(e.key === 'ArrowUp' ? 1 : -1);
+        channelPickerEl.value.moveActive(e.key === 'ArrowUp' ? -1 : 1);
         return;
       }
     } else if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
@@ -780,6 +782,26 @@ function onKeydown(e: KeyboardEvent): void {
     } else if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
       e.preventDefault();
       confirmEmojiActive();
+      return;
+    }
+  }
+  // The previous-input recall menu (the `>` prompt's popover) owns the nav keys
+  // while it's open with entries: arrows move the highlighted line, Tab or Enter
+  // recall it into the composer, Escape is left to the popover's own document
+  // listener. This runs ahead of the inline Up/Down history walk and Enter-
+  // submit below, so an open menu takes precedence over walking history in
+  // place. Gated on hasCandidates() like the nick/channel pickers; skipped
+  // mid-IME. Shift+Enter still newlines.
+  if (historyPickerOpen.value && !e.isComposing && historyPickerEl.value?.hasCandidates()) {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      if (!e.altKey && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        historyPickerEl.value.moveActive(e.key === 'ArrowUp' ? -1 : 1);
+        return;
+      }
+    } else if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+      e.preventDefault();
+      historyPickerEl.value.confirmActive();
       return;
     }
   }

--- a/vue_client/src/components/NickPicker.vue
+++ b/vue_client/src/components/NickPicker.vue
@@ -3,44 +3,48 @@
   SPDX-License-Identifier: MPL-2.0
 -->
 
+<!--
+  `@`-mention completion menu. Thin wrapper over VerticalPopover (issue #212):
+  it owns only the nick candidate list + row look; the shared popover owns
+  positioning, dismissal, the iOS focus contract, and keyboard nav. `:ignore`
+  is the anchor so a tap on the input bar (where the user is typing) keeps the
+  menu open. `reverse` puts the best match at the bottom, nearest the input.
+-->
+
 <template>
-  <div
-    v-if="open && rows.length"
-    ref="panelEl"
-    class="nick-picker"
-    :style="panelStyle"
-    @pointerdown.stop
-    @mousedown.prevent.stop
+  <VerticalPopover
+    ref="popover"
+    :open="open"
+    :rows="rows"
+    :anchor="anchor"
+    :ignore="[anchor]"
+    reverse
+    :row-key="rowKey"
+    @select="onSelect"
+    @close="emit('close')"
   >
-    <!-- iOS keyboard preservation, same rationale as SuggestionStrip:
-         fire on `click` (end of touch), keep `@mousedown.prevent` on the row
-         so focus never leaves the textarea, and use a plain <div role=button>
-         rather than a focusable <button>. Emitting on pointerdown would close
-         the picker (v-if) mid-touch, sending the synthesized mousedown to
-         whatever lands underneath and defeating @mousedown.prevent — that's
-         what was stealing iOS focus before. -->
-    <div
-      v-for="row in renderedRows"
-      :key="row.lc + ':' + row.index"
-      role="button"
-      class="row"
-      :class="{ active: row.index === activeIndex }"
-      @mousedown.prevent
-      @click="pick(row.nick)"
-      @mouseenter="activeIndex = row.index"
-    >
+    <template #row="{ row }">
       <span class="nick" :style="row.color ? { color: row.color } : null">{{ row.nick }}</span>
       <span v-if="row.recent" class="badge">recent</span>
-    </div>
-  </div>
+    </template>
+  </VerticalPopover>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
+import { ref, computed } from 'vue';
 import { buildNickCandidates } from '../utils/nickCompletion.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useNickColors } from '../composables/useNickColors.js';
+import VerticalPopover from './VerticalPopover.vue';
+import type { PopoverNav } from './popoverNav.js';
 import type { Buffer } from '../stores/buffers.js';
+
+interface NickRow {
+  nick: string;
+  lc: string;
+  recent: boolean;
+  color: string | null;
+}
 
 const props = withDefaults(
   defineProps<{
@@ -66,21 +70,13 @@ const emit = defineEmits<{
 
 const ignores = useIgnoresStore();
 const nickColors = useNickColors();
-const panelEl = ref<HTMLElement | null>(null);
-const panelBottom = ref(8);
 
-// Index into `rows` (candidate order, 0 = best match) of the keyboard-
-// highlighted entry. Rows render bottom-up — see `renderedRows` — so index 0
-// sits visually at the bottom, nearest the input bar.
-const activeIndex = ref(0);
-
-const rows = computed(() => {
+const rows = computed<NickRow[]>(() => {
   // Bail before touching buffer/query/ignores while closed: a computed only
-  // tracks the deps it reads, so this early return keeps `rows` (and the
-  // watch that subscribes to it) from rebuilding the whole candidate list and
-  // re-coloring every nick on each speakers/members update behind a closed
-  // picker. Nothing renders when closed anyway — the panel's v-if gates on
-  // `open` — so returning [] here is behavior-neutral.
+  // tracks the deps it reads, so this early return keeps the candidate list
+  // from rebuilding (and re-coloring every nick) on each speakers/members
+  // update behind a closed picker. The popover hides when closed anyway, so
+  // returning [] here is behavior-neutral.
   if (!props.open) return [];
   const networkId = props.buffer?.networkId;
   const isIgnored = networkId
@@ -88,157 +84,32 @@ const rows = computed(() => {
     : null;
   return buildNickCandidates(props.buffer, props.selfNick, props.query, isIgnored)
     .slice(0, 50)
-    .map((c, index) => ({
+    .map((c) => ({
       nick: c.nick,
       lc: c.nick.toLowerCase(),
       recent: c.recent,
-      index,
       color: nickColors.color(c.nick),
     }));
 });
 
-// The panel opens upward, so render candidates worst-to-best top-to-bottom —
-// the most likely pick lands at the bottom, right under the user's eye and
-// closest to the input bar.
-const renderedRows = computed(() => rows.value.slice().reverse());
-
-function pick(nick: string) {
-  emit('select', nick);
+function rowKey(row: NickRow): string {
+  return row.lc;
+}
+function onSelect(row: NickRow): void {
+  emit('select', row.nick);
 }
 
-// Keyboard navigation, driven from MessageInput's textarea keydown handler:
-// the textarea keeps focus while the picker is open, so the picker never
-// receives key events itself. `delta` is in candidate-index space — +1 steps
-// toward worse matches (visually up), -1 toward the best match (visually
-// down) — and clamps at both ends rather than wrapping.
-function moveActive(delta: number) {
-  const n = rows.value.length;
-  if (n === 0) return;
-  activeIndex.value = Math.min(Math.max(activeIndex.value + delta, 0), n - 1);
-  // Keyboard moves can land on a row scrolled out of the panel — pull it
-  // back in. Mouse hover also sets activeIndex (see @mouseenter) but a
-  // hovered row is necessarily already visible, so the scroll lives here
-  // rather than in a blanket watch(activeIndex) that would also fire — as a
-  // wasted no-op — on every cursor move across the list.
-  nextTick(scrollActiveIntoView);
-}
-
-function confirmActive() {
-  const row = rows.value[activeIndex.value];
-  if (row) pick(row.nick);
-}
-
-function hasCandidates() {
-  return rows.value.length > 0;
-}
-
-defineExpose({ moveActive, confirmActive, hasCandidates });
-
-function scrollActiveIntoView() {
-  const el = panelEl.value?.querySelector('.row.active');
-  if (el) (el as HTMLElement).scrollIntoView({ block: 'nearest' });
-}
-
-function recomputePosition() {
-  // Anchor the picker just above the input bar, riding above the iOS soft
-  // keyboard via visualViewport.height. Without this, the picker gets
-  // occluded as soon as the keyboard slides up.
-  const anchor = props.anchor;
-  if (!anchor) {
-    panelBottom.value = 8;
-    return;
-  }
-  const rect = anchor.getBoundingClientRect();
-  const vv = window.visualViewport;
-  const viewportHeight = vv ? vv.height : window.innerHeight;
-  // Distance from bottom of viewport to top of anchor.
-  const distance = viewportHeight - rect.top;
-  panelBottom.value = Math.max(distance + 4, 8);
-}
-
-const panelStyle = computed(() => ({ bottom: `${panelBottom.value}px` }));
-
-function onDocPointerDown(e: PointerEvent) {
-  if (!props.open) return;
-  const panel = panelEl.value;
-  const anchor = props.anchor;
-  if (panel && panel.contains(e.target as Node)) return;
-  if (anchor && anchor.contains(e.target as Node)) return;
-  emit('close');
-}
-
-function onKey(e: KeyboardEvent) {
-  if (!props.open) return;
-  if (e.key === 'Escape') emit('close');
-}
-
-onMounted(() => {
-  recomputePosition();
-  window.addEventListener('resize', recomputePosition);
-  window.visualViewport?.addEventListener('resize', recomputePosition);
-  window.visualViewport?.addEventListener('scroll', recomputePosition);
-  document.addEventListener('pointerdown', onDocPointerDown);
-  document.addEventListener('keydown', onKey);
+// Forward keyboard nav to the popover so MessageInput's textarea keydown
+// handler can drive it (the textarea keeps focus while the menu is open).
+const popover = ref<PopoverNav | null>(null);
+defineExpose({
+  moveActive: (delta: number) => popover.value?.moveActive(delta),
+  confirmActive: () => popover.value?.confirmActive(),
+  hasCandidates: () => popover.value?.hasCandidates() ?? false,
 });
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', recomputePosition);
-  window.visualViewport?.removeEventListener('resize', recomputePosition);
-  window.visualViewport?.removeEventListener('scroll', recomputePosition);
-  document.removeEventListener('pointerdown', onDocPointerDown);
-  document.removeEventListener('keydown', onKey);
-});
-
-// A new candidate set (the query changed, or rows were re-filtered) re-anchors
-// the highlight on the best match and pulls it back into view.
-watch(rows, () => {
-  activeIndex.value = 0;
-  nextTick(scrollActiveIntoView);
-});
-
-watch(
-  () => props.open,
-  (v) => {
-    if (v) {
-      activeIndex.value = 0;
-      recomputePosition();
-      nextTick(scrollActiveIntoView);
-    }
-  },
-);
 </script>
 
 <style scoped>
-.nick-picker {
-  position: fixed;
-  left: var(--space-4);
-  right: var(--space-4);
-  max-width: 480px;
-  margin: 0 auto;
-  max-height: 50vh;
-  overflow-y: auto;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--shadow-popover-up);
-  z-index: var(--z-popover);
-}
-.row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-6);
-  min-height: 44px;
-  cursor: pointer;
-  user-select: none;
-}
-/* Single highlight, shared by mouse and keyboard: hovering a row sets
-   activeIndex (see @mouseenter), so .active alone covers both — no separate
-   :hover rule that could double-highlight during keyboard nav. Soft neutral
-   fill matches the context menu / Cmd-K list. */
-.row.active {
-  background: var(--bg-soft);
-}
 .nick {
   font-weight: 500;
 }

--- a/vue_client/src/components/VerticalPopover.vue
+++ b/vue_client/src/components/VerticalPopover.vue
@@ -1,0 +1,248 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  The shared composer popover behind NickPicker (`@`), ChannelPicker (`#`) and
+  HistoryPicker (`>`). It owns every mechanic those three used to reimplement
+  (issue #212):
+
+    - a position:fixed panel anchored just above the input bar, riding above the
+      iOS soft keyboard via visualViewport (resize/scroll re-anchoring)
+    - outside-tap dismissal (a document pointerdown, excluding the panel and any
+      `ignore` elements — an anchor or a toggle button) plus Escape-to-close
+    - the iOS focus-preservation contract: `@mousedown.prevent` on the panel and
+      every row so focus never leaves the textarea, acting on `click` (end of
+      touch) with a plain <div role=button> rather than a focusable <button>.
+      Emitting on pointerdown would close the panel (v-if) mid-touch and send the
+      synthesized mousedown to whatever lands underneath — what stole iOS focus
+      before.
+    - keyboard navigation (activeIndex + moveActive/confirmActive, exposed so
+      MessageInput's textarea keydown handler can drive it while the textarea
+      keeps focus), the active row kept scrolled into view, and one .active
+      highlight shared by mouse hover and the keyboard.
+
+  Callers supply only their data: the `rows` array, a `#row` template for a
+  row's contents, and a `select` handler. `reverse` opens the list bottom-up so
+  the primary candidate (best match / newest line) sits at the bottom nearest
+  the input; the active row defaults there too.
+-->
+
+<template>
+  <div
+    v-if="visible"
+    ref="panelEl"
+    class="vertical-popover"
+    :style="panelStyle"
+    @pointerdown.stop
+    @mousedown.prevent.stop
+  >
+    <div
+      v-for="(row, i) in displayRows"
+      :key="keyFor(row, i)"
+      role="button"
+      class="row"
+      :class="{ active: i === activeIndex }"
+      @mousedown.prevent
+      @click="pick(i)"
+      @mouseenter="activeIndex = i"
+    >
+      <slot name="row" :row="row" :index="i" :active="i === activeIndex" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts" generic="Row">
+import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
+import type { PopoverNav } from './popoverNav.js';
+
+const props = withDefaults(
+  defineProps<{
+    open?: boolean;
+    rows?: readonly Row[];
+    // Element to anchor the panel above (the input form). Positioning only —
+    // not auto-excluded from dismissal; pass it in `ignore` if a tap on it
+    // should keep the panel open.
+    anchor?: HTMLElement | null;
+    // Elements whose taps must NOT dismiss the panel, besides the panel itself:
+    // the anchor (nick/channel keep open while typing) or the toggle button
+    // (history — its own click handler owns open/close).
+    ignore?: readonly (HTMLElement | null)[];
+    // Render bottom-up so the primary candidate sits at the bottom, nearest the
+    // input bar and under the user's eye.
+    reverse?: boolean;
+    // Stable :key for a row; defaults to its display position.
+    rowKey?: (row: Row, index: number) => string | number;
+  }>(),
+  {
+    open: false,
+    rows: () => [],
+    anchor: null,
+    ignore: () => [],
+    reverse: false,
+    rowKey: undefined,
+  },
+);
+
+const emit = defineEmits<{
+  select: [row: Row];
+  close: [];
+}>();
+
+const panelEl = ref<HTMLElement | null>(null);
+const panelBottom = ref(8);
+
+const displayRows = computed<readonly Row[]>(() =>
+  props.reverse ? props.rows.toReversed() : props.rows,
+);
+// Hidden when closed or empty, so a no-match token never shows an empty box.
+const visible = computed(() => props.open && displayRows.value.length > 0);
+
+function keyFor(row: Row, index: number): string | number {
+  return props.rowKey ? props.rowKey(row, index) : index;
+}
+
+// Index into displayRows (0 = top) of the highlighted row. Defaults to the
+// bottom row — the primary candidate, nearest the input — and clamps rather
+// than wraps.
+const activeIndex = ref(0);
+function defaultActive(): number {
+  return Math.max(displayRows.value.length - 1, 0);
+}
+
+function pick(index: number): void {
+  const row = displayRows.value[index];
+  if (row !== undefined) emit('select', row);
+}
+
+// Driven from MessageInput's textarea keydown handler — the textarea keeps
+// focus while the panel is open, so the panel never receives keys itself.
+// `delta` is in visual rows: -1 moves up, +1 down. Clamps at both ends.
+function moveActive(delta: number): void {
+  const n = displayRows.value.length;
+  if (n === 0) return;
+  activeIndex.value = Math.min(Math.max(activeIndex.value + delta, 0), n - 1);
+  // A keyboard move can land on a row scrolled out of the panel — pull it back
+  // in. Hover also sets activeIndex (see @mouseenter) but a hovered row is
+  // necessarily already visible, so the scroll lives here, not in a blanket
+  // watch(activeIndex) that would also fire as a no-op on every cursor move.
+  nextTick(scrollActiveIntoView);
+}
+
+function confirmActive(): void {
+  pick(activeIndex.value);
+}
+
+function hasCandidates(): boolean {
+  return displayRows.value.length > 0;
+}
+
+defineExpose<PopoverNav>({ moveActive, confirmActive, hasCandidates });
+
+function scrollActiveIntoView(): void {
+  const el = panelEl.value?.querySelector('.row.active');
+  if (el) (el as HTMLElement).scrollIntoView({ block: 'nearest' });
+}
+
+function recomputePosition(): void {
+  // Anchor just above the input bar, riding above the iOS soft keyboard via
+  // visualViewport.height — without this the panel is occluded as the keyboard
+  // slides up.
+  const anchor = props.anchor;
+  if (!anchor) {
+    panelBottom.value = 8;
+    return;
+  }
+  const rect = anchor.getBoundingClientRect();
+  const vv = window.visualViewport;
+  const viewportHeight = vv ? vv.height : window.innerHeight;
+  // Distance from the bottom of the viewport to the top of the anchor.
+  const distance = viewportHeight - rect.top;
+  panelBottom.value = Math.max(distance + 4, 8);
+}
+
+const panelStyle = computed(() => ({ bottom: `${panelBottom.value}px` }));
+
+function onDocPointerDown(e: PointerEvent): void {
+  if (!visible.value) return;
+  const target = e.target as Node;
+  if (panelEl.value?.contains(target)) return;
+  for (const el of props.ignore) {
+    if (el?.contains(target)) return;
+  }
+  emit('close');
+}
+
+function onKey(e: KeyboardEvent): void {
+  if (!visible.value) return;
+  if (e.key === 'Escape') emit('close');
+}
+
+onMounted(() => {
+  recomputePosition();
+  window.addEventListener('resize', recomputePosition);
+  window.visualViewport?.addEventListener('resize', recomputePosition);
+  window.visualViewport?.addEventListener('scroll', recomputePosition);
+  document.addEventListener('pointerdown', onDocPointerDown);
+  document.addEventListener('keydown', onKey);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', recomputePosition);
+  window.visualViewport?.removeEventListener('resize', recomputePosition);
+  window.visualViewport?.removeEventListener('scroll', recomputePosition);
+  document.removeEventListener('pointerdown', onDocPointerDown);
+  document.removeEventListener('keydown', onKey);
+});
+
+// A new candidate set (the query changed, or rows were re-filtered) re-anchors
+// the highlight on the primary (bottom) row and pulls it into view.
+watch(displayRows, () => {
+  activeIndex.value = defaultActive();
+  nextTick(scrollActiveIntoView);
+});
+
+watch(
+  () => props.open,
+  (v) => {
+    if (!v) return;
+    activeIndex.value = defaultActive();
+    recomputePosition();
+    nextTick(scrollActiveIntoView);
+  },
+);
+</script>
+
+<style scoped>
+.vertical-popover {
+  position: fixed;
+  left: var(--space-4);
+  right: var(--space-4);
+  max-width: 480px;
+  margin: 0 auto;
+  max-height: 50vh;
+  overflow-y: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover-up);
+  z-index: var(--z-popover);
+}
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-6);
+  min-height: 44px;
+  cursor: pointer;
+  user-select: none;
+}
+/* Single highlight shared by mouse and keyboard: hovering a row sets activeIndex
+   (see @mouseenter), so .active alone covers both — no separate :hover rule that
+   could double-highlight during keyboard nav. Soft neutral fill matches the
+   context menu / Cmd-K list. */
+.row.active {
+  background: var(--bg-soft);
+}
+</style>

--- a/vue_client/src/components/popoverNav.ts
+++ b/vue_client/src/components/popoverNav.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The keyboard-nav API VerticalPopover exposes (and the three pickers forward to
+// MessageInput). Declared here rather than read via `InstanceType<typeof
+// VerticalPopover>` because VerticalPopover is a generic SFC, which isn't
+// constructor-typed — so InstanceType can't be applied to it. The pickers type
+// their popover ref as `PopoverNav | null`; the textarea keeps focus while a
+// menu is open, so MessageInput drives these from its keydown handler.
+export interface PopoverNav {
+  // Move the highlight by `delta` visual rows (-1 up, +1 down), clamped.
+  moveActive: (delta: number) => void;
+  // Pick the currently highlighted row.
+  confirmActive: () => void;
+  // Whether there are any rows to navigate.
+  hasCandidates: () => boolean;
+}


### PR DESCRIPTION
Closes #212.

## What

`NickPicker` (`@`), `ChannelPicker` (`#`), and `HistoryPicker` (`>`) each reimplemented the same anchored-popover mechanics. This extracts one shared **`VerticalPopover`** that owns all of it; the three pickers become thin wrappers that supply only their data.

The mechanics now living in one place (previously copied 3×):
- `position: fixed` panel anchored above the input bar, riding above the iOS soft keyboard via `visualViewport` (resize/scroll re-anchoring)
- outside-tap dismissal + Escape-to-close
- the iOS focus-preservation contract (`@mousedown.prevent`, act on `click`, `<div role=button>`)
- bottom-up ordering (primary candidate nearest the input)
- a single `.active` highlight shared by mouse hover and keyboard
- keyboard navigation (`moveActive`/`confirmActive`/`hasCandidates`)

## How

- **`VerticalPopover.vue`** — generic (`generic="Row"`) anchored list popover. Props: `open`, `rows`, `anchor` (positioning), `ignore[]` (elements whose taps don't dismiss — the anchor for nick/channel, the toggle for history), `reverse` (open bottom-up). Default `#row` scoped slot for a row's contents; emits `select(row)` / `close`.
- The exposed nav API is typed via a small **`popoverNav.ts`** interface rather than `InstanceType<typeof VerticalPopover>` — a generic SFC isn't constructor-typed, so `InstanceType` can't be applied to it.
- The **three pickers** drop from ~200–250 lines each to ~100, keeping only their candidate-building and row markup, and forward nav via `defineExpose`.
- **`MessageInput`** — the nav delta is now visual-space (`ArrowUp = -1`), and a history-menu keyboard-nav block was added ahead of the inline Up/Down history walk.

## Behavior change (intentional)

The issue originally said "no behavior change," but per discussion we decided to **fully unify** — so **`HistoryPicker` is no longer tap-only**: when open it now supports arrow/Enter/Tab navigation, matching the nick/channel pickers (today it relied on a `:hover` highlight). **Nick and channel behavior is unchanged** (same default highlight, same Up/Down/Enter/Tab semantics, same dismissal).

## Verification

`typecheck:client`, `oxlint`, `oxfmt --check`, `client:build`, and the full client test suite (183/183) all pass. The emoji chunk still code-splits cleanly. No automated tests cover these UI components; the nick/channel keyboard paths were preserved 1:1 and the math is documented inline — worth a manual smoke of `@`/`#`/`>` nav + dismissal before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)