### PR TITLE
Desktop vertical emoji picker, with a frequently-used set on `:` (#348)

### DIFF
--- a/vue_client/src/components/EmojiPicker.vue
+++ b/vue_client/src/components/EmojiPicker.vue
@@ -1,0 +1,112 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Desktop `:shortcode:` emoji completion menu (issue #348) — the vertical
+  counterpart to the mobile suggestion strip, giving `:` the same panel UX as
+  `@` (NickPicker) and `#` (ChannelPicker). Thin wrapper over VerticalPopover:
+  it owns only the candidate list + row look; the shared popover owns
+  positioning, dismissal, the iOS focus contract, and keyboard nav.
+
+  Opens as soon as `:` is typed: with no query yet it shows a static
+  frequently-used set (see frequentEmoji), then filters as the user types.
+  `reverse` puts the best match at the bottom, nearest the input, matching the
+  other pickers.
+-->
+
+<template>
+  <VerticalPopover
+    ref="popover"
+    :open="open"
+    :rows="rows"
+    :anchor="anchor"
+    :ignore="[anchor]"
+    reverse
+    :row-key="rowKey"
+    @select="onSelect"
+    @close="emit('close')"
+  >
+    <template #row="{ row }">
+      <span class="emoji-line">
+        <span class="emoji-glyph">{{ row.emoji }}</span>
+        <span class="emoji-name">:{{ row.name }}:</span>
+      </span>
+    </template>
+  </VerticalPopover>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { searchEmojiSync, frequentEmoji } from '../utils/emojiShortcodes.js';
+import { emojiFn } from '../composables/useEmoji.js';
+import VerticalPopover from './VerticalPopover.vue';
+import type { PopoverNav } from './popoverNav.js';
+import type { EmojiMatch } from '../utils/emojiData.js';
+
+const props = withDefaults(
+  defineProps<{
+    open?: boolean;
+    // The shortcode body under the caret (no colons); '' for a bare `:`.
+    query?: string;
+    anchor?: HTMLElement | null;
+  }>(),
+  {
+    open: false,
+    query: '',
+    anchor: null,
+  },
+);
+
+const emit = defineEmits<{
+  select: [item: EmojiMatch];
+  close: [];
+}>();
+
+const rows = computed<EmojiMatch[]>(() => {
+  // emojiFn() reads the reactive emoji-ready signal (and is null until the
+  // lazily-loaded table lands), so rows recompute once it's available. The
+  // table is preloaded at app start, so it's normally ready by the first `:`.
+  if (!props.open || !emojiFn()) return [];
+  const q = props.query.trim();
+  return q ? searchEmojiSync(q, 30) : frequentEmoji(24);
+});
+
+function rowKey(row: EmojiMatch): string {
+  return row.name;
+}
+function onSelect(row: EmojiMatch): void {
+  emit('select', row);
+}
+
+// Forward keyboard nav to the popover so MessageInput's textarea keydown
+// handler can drive it (the textarea keeps focus while the menu is open).
+const popover = ref<PopoverNav | null>(null);
+defineExpose({
+  moveActive: (delta: number) => popover.value?.moveActive(delta),
+  confirmActive: () => popover.value?.confirmActive(),
+  hasCandidates: () => popover.value?.hasCandidates() ?? false,
+});
+</script>
+
+<style scoped>
+/* Group the glyph + shortcode on the left. VerticalPopover's .row uses
+   justify-content: space-between (for NickPicker's right-aligned badge); a
+   single wrapper child keeps the pair left-aligned without restyling .row. */
+.emoji-line {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  min-width: 0;
+}
+.emoji-glyph {
+  flex: none;
+}
+.emoji-name {
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -97,6 +97,18 @@
       @select="onHistorySelect"
       @close="closeHistoryPicker"
     />
+    <!-- Desktop `:shortcode:` emoji panel (issue #348). The vertical-popover
+         counterpart to the mobile emoji strip — refreshPicker opens this on
+         desktop and the StatusBar strip on mobile. Opens on a bare `:` with a
+         frequently-used set, then filters as you type. -->
+    <EmojiPicker
+      ref="emojiPickerEl"
+      :open="emojiPickerOpen"
+      :query="emojiPickerQuery"
+      :anchor="formEl"
+      @select="onEmojiSelect"
+      @close="closeEmojiPicker"
+    />
     <Teleport to="body">
       <LongMessageUploadModal
         v-if="longMessageModalOpen"
@@ -139,6 +151,7 @@ import type { EmojiMatch } from '../utils/emojiData.js';
 import NickPicker from './NickPicker.vue';
 import ChannelPicker from './ChannelPicker.vue';
 import HistoryPicker from './HistoryPicker.vue';
+import EmojiPicker from './EmojiPicker.vue';
 import LongMessageUploadModal from './LongMessageUploadModal.vue';
 import { useSelfLabel } from '../composables/useSelfLabel.js';
 import { useViewport } from '../composables/useViewport.js';
@@ -207,6 +220,14 @@ let stripTokenEnd = -1;
 // `loadEmoji`), so nothing here pulls it into the initial bundle.
 let emojiTokenStart = -1;
 let emojiTokenEnd = -1;
+// Desktop `:` emoji picker (issue #348) — the vertical-popover counterpart to
+// the mobile strip. Like the nick/channel pickers it's a position:fixed popover
+// anchored to the form, so its open/query state lives here; the mobile strip
+// keeps using the useComposerOverlay emoji state. refreshPicker routes to one or
+// the other by platform, and both share the emojiToken{Start,End} span above.
+const emojiPickerOpen = ref(false);
+const emojiPickerQuery = ref('');
+const emojiPickerEl = ref<InstanceType<typeof EmojiPicker> | null>(null);
 
 const active = computed(() => networks.activeBuffer);
 
@@ -548,6 +569,7 @@ function onBlur() {
   // StatusBar — picking a chip keeps focus (mousedown.prevent) so this never
   // races a selection.
   closeEmojiStrip();
+  closeEmojiPicker();
   // Force the active buffer's draft to the server now rather than waiting on
   // the debounce timer — covers refocus into a different tab or mobile
   // app-switch without losing the in-progress text.
@@ -785,6 +807,23 @@ function onKeydown(e: KeyboardEvent): void {
       return;
     }
   }
+  // Desktop emoji picker (issue #348): while open with candidates it owns the
+  // nav keys — arrows move the highlight, Tab/Enter confirm; Escape is left to
+  // the popover's own document listener. Mobile uses the emoji-strip block
+  // above instead (the two are never open at once). Shift+Enter still newlines.
+  if (emojiPickerOpen.value && !e.isComposing && emojiPickerEl.value?.hasCandidates()) {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      if (!e.altKey && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        emojiPickerEl.value.moveActive(e.key === 'ArrowUp' ? -1 : 1);
+        return;
+      }
+    } else if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+      e.preventDefault();
+      emojiPickerEl.value.confirmActive();
+      return;
+    }
+  }
   // The previous-input recall menu (the `>` prompt's popover) owns the nav keys
   // while it's open with entries: arrows move the highlighted line, Tab or Enter
   // recall it into the composer, Escape is left to the popover's own document
@@ -954,6 +993,13 @@ function closeEmojiStrip() {
   emojiTokenEnd = -1;
 }
 
+function closeEmojiPicker() {
+  emojiPickerOpen.value = false;
+  emojiPickerQuery.value = '';
+  emojiTokenStart = -1;
+  emojiTokenEnd = -1;
+}
+
 // Open/refresh the emoji suggester for the shortcode under the caret. Async
 // because the emoji table is a lazily-loaded chunk; the candidate set is
 // re-derived from live text once it resolves, so a fast typist (or an
@@ -995,9 +1041,12 @@ function onEmojiSelect(item: EmojiMatch): void {
   // re-sync the span via refreshPicker, but the async strip refresh leaves a
   // brief window). Mirrors the re-check maybeConvertShortcode already does;
   // on a mismatch, no-op rather than splice blind into the wrong span.
-  const sc = emojiTokenStart >= 0 ? findActiveShortcode(value, emojiTokenEnd) : null;
+  // allowEmpty: a desktop pick from the bare-`:` frequently-used set has an
+  // empty query, so the captured span is just the `:` — still valid.
+  const sc = emojiTokenStart >= 0 ? findActiveShortcode(value, emojiTokenEnd, true) : null;
   if (!sc || sc.start !== emojiTokenStart) {
     closeEmojiStrip();
+    closeEmojiPicker();
     return;
   }
   const before = value.slice(0, sc.start);
@@ -1006,6 +1055,7 @@ function onEmojiSelect(item: EmojiMatch): void {
   text.value = before + item.emoji + after;
   cycling = false;
   closeEmojiStrip();
+  closeEmojiPicker();
   queueMicrotask(() => {
     const el = inputEl.value;
     if (!el) return;
@@ -1061,17 +1111,31 @@ function refreshPicker() {
   const cursor = el.selectionStart ?? value.length;
 
   // An in-progress `:shortcode:` owns the suggester slot — it isn't a nick
-  // token, and the emoji strip and the nick picker/strip share one slot over
-  // the StatusBar. Min length 2 keeps the strip from flashing on a lone `:x`.
-  const shortcode = findActiveShortcode(value, cursor);
-  if (shortcode && shortcode.name.length >= 2) {
+  // token, and both emoji UIs and the nick picker/strip share one slot over the
+  // StatusBar. Desktop opens the vertical EmojiPicker (issue #348) the moment
+  // `:` is typed (empty query → a frequently-used set); mobile keeps the
+  // horizontal strip, gated at 2+ chars so a lone `:` — or an emoticon like
+  // `:)` — doesn't flash it.
+  const emojiOnStrip = isMobile.value;
+  const shortcode = findActiveShortcode(value, cursor, !emojiOnStrip);
+  if (shortcode && (!emojiOnStrip || shortcode.name.length >= 2)) {
     closePicker();
     closeStrip();
     closeChannelPicker();
-    void showEmojiStrip();
+    if (emojiOnStrip) {
+      closeEmojiPicker();
+      void showEmojiStrip();
+    } else {
+      closeEmojiStrip();
+      emojiPickerOpen.value = true;
+      emojiPickerQuery.value = shortcode.name;
+      emojiTokenStart = shortcode.start;
+      emojiTokenEnd = shortcode.end;
+    }
     return;
   }
   closeEmojiStrip();
+  closeEmojiPicker();
 
   const { token, start, end } = tokenAtCursor(value, cursor);
 
@@ -1259,6 +1323,7 @@ function toggleHistory(): void {
   closeStrip();
   closeChannelPicker();
   closeEmojiStrip();
+  closeEmojiPicker();
   closeColorPicker();
   historyPickerOpen.value = true;
 }
@@ -1345,6 +1410,7 @@ watch(active, (newActive, oldActive) => {
   closeStrip();
   closeChannelPicker();
   closeEmojiStrip();
+  closeEmojiPicker();
   closeColorPicker();
   closeHistoryPicker();
   resetHistoryNav();
@@ -1395,6 +1461,7 @@ onBeforeUnmount(() => {
   // next instance (e.g. switching to system console and back).
   closeStrip();
   closeEmojiStrip();
+  closeEmojiPicker();
   closeColorPicker();
 });
 
@@ -1545,6 +1612,7 @@ async function submit() {
   closeStrip();
   closeChannelPicker();
   closeEmojiStrip();
+  closeEmojiPicker();
   closeColorPicker();
   closeHistoryPicker();
   const raw = text.value;

--- a/vue_client/src/utils/emojiShortcodes.test.ts
+++ b/vue_client/src/utils/emojiShortcodes.test.ts
@@ -6,9 +6,11 @@ import {
   emojiGlyph,
   findActiveShortcode,
   findCompletedShortcode,
+  frequentEmoji,
   loadEmoji,
   onEmojiLoaded,
   rankShortcodes,
+  searchEmojiSync,
   shortcodeScanRegex,
 } from './emojiShortcodes.js';
 
@@ -31,6 +33,20 @@ describe('findActiveShortcode', () => {
     expect(findActiveShortcode('hello world', 11)).toBeNull();
     expect(findActiveShortcode('', 0)).toBeNull();
     expect(findActiveShortcode(':', 1)).toBeNull();
+  });
+
+  it('matches a bare `:` with an empty name when allowEmpty (issue #348)', () => {
+    expect(findActiveShortcode(':', 1, true)).toEqual({ name: '', start: 0, end: 1 });
+    expect(findActiveShortcode('hi :', 4, true)).toEqual({ name: '', start: 3, end: 4 });
+  });
+
+  it('still captures a partial query under allowEmpty', () => {
+    expect(findActiveShortcode(':sm', 3, true)).toEqual({ name: 'sm', start: 0, end: 3 });
+  });
+
+  it('does not match a `:` glued to a word or number even under allowEmpty', () => {
+    expect(findActiveShortcode('word:', 5, true)).toBeNull();
+    expect(findActiveShortcode('12:', 3, true)).toBeNull();
   });
 
   it('does not trigger mid-word or after a digit', () => {
@@ -171,6 +187,38 @@ describe('emojiGlyph', () => {
   it('returns null for an unknown shortcode', async () => {
     await loadEmoji();
     expect(emojiGlyph('definitely_not_an_emoji')).toBeNull();
+  });
+});
+
+describe('searchEmojiSync', () => {
+  it('returns ranked matches once the table has loaded', async () => {
+    await loadEmoji();
+    expect(searchEmojiSync('tada')[0]).toEqual({ name: 'tada', emoji: '🎉' });
+  });
+
+  it('respects the limit', async () => {
+    await loadEmoji();
+    expect(searchEmojiSync('a', 5).length).toBeLessThanOrEqual(5);
+  });
+
+  it('returns nothing for a non-matching query', async () => {
+    await loadEmoji();
+    expect(searchEmojiSync('definitely_not_an_emoji')).toEqual([]);
+  });
+});
+
+describe('frequentEmoji', () => {
+  it('returns a non-empty static set, every entry resolving to a real glyph', async () => {
+    await loadEmoji();
+    const f = frequentEmoji();
+    expect(f.length).toBeGreaterThan(0);
+    expect(f.every((m) => typeof m.emoji === 'string' && m.emoji.length > 0)).toBe(true);
+    expect(f.some((m) => m.name === 'tada')).toBe(true);
+  });
+
+  it('respects the limit', async () => {
+    await loadEmoji();
+    expect(frequentEmoji(5).length).toBeLessThanOrEqual(5);
   });
 });
 

--- a/vue_client/src/utils/emojiShortcodes.ts
+++ b/vue_client/src/utils/emojiShortcodes.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import type { EmojiMatch } from './emojiData.js';
+
 // Slack-style `:shortcode:` emoji entry — the pure parsing + ranking helpers.
 // These never carry the emoji table itself, so MessageInput can import them
 // eagerly while the ~1,900-entry map in `emojiData.ts` stays a lazily-loaded
@@ -16,10 +18,18 @@
 // shortcode start. ASCII smileys fall out for free: `:-)` never closes at the
 // caret because `)` isn't a shortcode character.
 
-const NAME = '[a-z0-9_+-]+';
-// `(?<![a-z0-9_+-])` keeps the opening colon off the back of a word or number.
-const OPEN_RE = new RegExp(`(?<![a-z0-9_+-]):(${NAME})$`, 'i');
-const CLOSE_RE = new RegExp(`(?<![a-z0-9_+-]):(${NAME}):$`, 'i');
+// The gemoji shortcode character set (`:+1:`, `:e-mail:`, `:thumbsup:`). Defined
+// once so the body patterns and every opening-boundary lookbehind below can't
+// drift apart.
+const NAME_CHARS = '[a-z0-9_+-]';
+const NAME = `${NAME_CHARS}+`;
+// `(?<!${NAME_CHARS})` keeps the opening colon off the back of a word or number.
+const OPEN_RE = new RegExp(`(?<!${NAME_CHARS}):(${NAME})$`, 'i');
+const CLOSE_RE = new RegExp(`(?<!${NAME_CHARS}):(${NAME}):$`, 'i');
+// Like OPEN_RE but the body may be empty — matches a bare `:` just opened (the
+// desktop emoji picker uses this to pop a frequently-used set before any query
+// is typed). Same opening-boundary rule, so `word:` / `12:` still don't match.
+const OPEN_EMPTY_RE = new RegExp(`(?<!${NAME_CHARS}):(${NAME_CHARS}*)$`, 'i');
 
 // A *global* matcher for every completed `:name:` in a string, used by the
 // render-time emoji pass (`splitTextByEmoji` in nickColor). It shares NAME and
@@ -29,7 +39,7 @@ const CLOSE_RE = new RegExp(`(?<![a-z0-9_+-]):(${NAME}):$`, 'i');
 // fresh instance is returned per call because a global regex carries mutable
 // `lastIndex`.
 export function shortcodeScanRegex(): RegExp {
-  return new RegExp(`(?<![a-z0-9_+-]):(${NAME}):`, 'gi');
+  return new RegExp(`(?<!${NAME_CHARS}):(${NAME}):`, 'gi');
 }
 
 export interface ShortcodeToken {
@@ -44,8 +54,12 @@ export interface ShortcodeToken {
 // An *in-progress* shortcode ending at the caret: `:bo|` → { name: 'bo' }.
 // Returns null when the caret isn't sitting in a shortcode body. Drives the
 // suggester strip; the caller decides the minimum query length to act on.
-export function findActiveShortcode(text: string, caret: number): ShortcodeToken | null {
-  const m = OPEN_RE.exec(text.slice(0, caret));
+export function findActiveShortcode(
+  text: string,
+  caret: number,
+  allowEmpty = false,
+): ShortcodeToken | null {
+  const m = (allowEmpty ? OPEN_EMPTY_RE : OPEN_RE).exec(text.slice(0, caret));
   if (!m) return null;
   return { name: m[1].toLowerCase(), start: caret - m[1].length - 1, end: caret };
 }
@@ -93,6 +107,9 @@ let emojiModule: Promise<typeof import('./emojiData.js')> | null = null;
 // Stays null until the chunk lands; the render pass treats that as "no emoji
 // yet" and shows the literal `:name:` until a reload re-runs the split.
 let loadedTable: Record<string, string> | null = null;
+// The table's shortcode keys, cached once so the synchronous picker search
+// (`searchEmojiSync`) doesn't re-key the ~1,900-entry map on every keystroke.
+let loadedNames: string[] = [];
 // One-shot listeners fired when the table first becomes available, whichever
 // caller triggered the load. Lets the render layer (useEmoji) recover even if
 // its own preload failed: a later successful load from anywhere — the
@@ -111,6 +128,7 @@ export function loadEmoji(): Promise<typeof import('./emojiData.js')> {
     emojiModule
       .then((mod) => {
         loadedTable = mod.EMOJI;
+        loadedNames = Object.keys(mod.EMOJI);
         notifyEmojiLoaded();
         return mod;
       })
@@ -139,4 +157,52 @@ export function onEmojiLoaded(cb: () => void): void {
 // `emojiForShortcode` in emojiData.ts.
 export function emojiGlyph(name: string): string | null {
   return loadedTable?.[name.toLowerCase()] ?? null;
+}
+
+// Synchronous ranked search for the desktop emoji picker — mirrors emojiData's
+// `searchEmoji` but reads the cached table so it can run inside a Vue computed
+// (no await). Returns [] until the chunk has loaded; the picker gates on
+// emoji-readiness and recomputes when it lands.
+export function searchEmojiSync(query: string, limit = 30): EmojiMatch[] {
+  if (!loadedTable) return [];
+  const table = loadedTable;
+  return rankShortcodes(loadedNames, query)
+    .slice(0, limit)
+    .map((name) => ({ name, emoji: table[name] }));
+}
+
+// A small static "frequently used" set shown when the picker opens on a bare
+// `:` (no query yet). Deliberately not usage-tracked — a fixed common set keeps
+// it simple; frecency can come later. Only entries present in the loaded table
+// are returned, so a future gemoji revision can't surface a dangling shortcode.
+const FREQUENT_SHORTCODES = [
+  'joy',
+  'sob',
+  'heart',
+  'smile',
+  '+1',
+  'pray',
+  'fire',
+  'tada',
+  'rofl',
+  'sweat_smile',
+  'heart_eyes',
+  'thinking',
+  'eyes',
+  'pleading_face',
+  'ok_hand',
+  'raised_hands',
+  'sparkles',
+  'wave',
+  '100',
+  'clap',
+  'rocket',
+  'thumbsdown',
+];
+export function frequentEmoji(limit = 30): EmojiMatch[] {
+  if (!loadedTable) return [];
+  const table = loadedTable;
+  return FREQUENT_SHORTCODES.filter((name) => table[name] != null)
+    .slice(0, limit)
+    .map((name) => ({ name, emoji: table[name] }));
 }


### PR DESCRIPTION
Closes #348.

## What

Now that `VerticalPopover` exists (#212), give the `:shortcode:` trigger the same vertical-panel UX as `@` (NickPicker) and `#` (ChannelPicker) **on desktop**. It's the 4th consumer of the shared popover. **Mobile keeps the horizontal suggestion strip, unchanged.**

The desktop panel opens as soon as `:` is typed: with no query yet it shows a static **"frequently used"** set, then filters as you type (per the discussion — a fixed common set, no usage tracking).

## Behavior

| | trigger | UI | empty `:` |
|---|---|---|---|
| **Desktop** | `:` | `EmojiPicker` vertical panel | frequently-used set |
| **Mobile** | `:ab` (2+ chars) | horizontal strip (unchanged) | — |

Mobile keeps its 2-char threshold so a lone `:` or an emoticon like `:)` doesn't flash the strip. On desktop the panel does briefly flash open→closed for `:)` (it auto-closes the instant `)` makes it a non-shortcode), matching Slack — acceptable.

## How

- **`emojiShortcodes.ts`** — `searchEmojiSync` + `frequentEmoji` read the cached table (populated by the #314 preload) so the picker can derive rows inside a Vue `computed` without awaiting; `findActiveShortcode` gains an `allowEmpty` flag so a bare `:` parses. `frequentEmoji` is a fixed ~20-shortcode list filtered against the table — no frecency/tracking. `emojiData` stays a separate lazy chunk (verified in `client:build`).
- **`EmojiPicker.vue`** — thin `VerticalPopover` wrapper (glyph + `:name:` rows), gated on emoji-readiness via `emojiFn()`, forwarding nav through `PopoverNav`.
- **`MessageInput`** — `refreshPicker` routes desktop `:` to the popover and mobile to the strip; a keydown block drives the popover's arrows/Tab/Enter (mutually exclusive with the strip block); `onEmojiSelect` re-validates with `allowEmpty` so an empty-query pick from the frequent set splices correctly; `closeEmojiPicker` mirrors the strip at every reset spot (blur / submit / buffer-switch / history-toggle / unmount).

## Verification

`typecheck:client`, `oxlint`, `oxfmt --check`, full client test suite (**191/191**, +8 for `searchEmojiSync` / `frequentEmoji` / `findActiveShortcode allowEmpty`), and `client:build` all pass. No automated tests drive the composer UI, so a manual smoke is worth it before merge: desktop `:` (frequent set) → type to filter → arrows/Enter/Tab/click to pick → Escape/outside-tap to dismiss → `:)` flashes closed; mobile strip unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)