### PR TITLE
Ignore system overhaul: global-by-default scoping + full settings panel (#350)

### DIFF
--- a/server/db/ignoredMasks.test.ts
+++ b/server/db/ignoredMasks.test.ts
@@ -113,8 +113,8 @@ describe('removeRuleById / removeRuleByMask', () => {
       networkId: net1!.id,
       rule: rule({ mask: 'byid' }),
     });
-    expect(mod.removeRuleById({ userId: user.id, networkId: net1!.id, id })).toBe(true);
-    expect(mod.removeRuleById({ userId: user.id, networkId: net1!.id, id })).toBe(false);
+    expect(mod.removeRuleById({ userId: user.id, id })).toBe(true);
+    expect(mod.removeRuleById({ userId: user.id, id })).toBe(false);
   });
 
   it('removes every rule matching a mask (case-insensitive, possibly multiple)', () => {
@@ -193,5 +193,60 @@ describe('sweepExpired', () => {
       .map((r) => r.mask)
       .toSorted();
     expect(remaining).toEqual(['stays', 'timed']);
+  });
+});
+
+describe('global scope (network_id NULL, #350)', () => {
+  it('a global rule lands in listGlobalRules, not a network listRules', () => {
+    const u = createUser('ig-glob1');
+    const n = createNetwork(u.id, { name: 'a', host: 'h', port: 6697, tls: true, nick: 'g' })!;
+    mod.addRule({ userId: u.id, networkId: null, rule: rule({ mask: 'globaltroll' }) });
+    expect(mod.listGlobalRules(u.id).map((r) => r.mask)).toEqual(['globaltroll']);
+    expect(mod.listRules({ userId: u.id, networkId: n.id })).toHaveLength(0);
+  });
+
+  it('listScopedRules unions globals with the network’s own rules', () => {
+    const u = createUser('ig-glob2');
+    const n = createNetwork(u.id, { name: 'a', host: 'h', port: 6697, tls: true, nick: 'g' })!;
+    mod.addRule({ userId: u.id, networkId: null, rule: rule({ mask: 'everywhere' }) });
+    mod.addRule({ userId: u.id, networkId: n.id, rule: rule({ mask: 'hereonly' }) });
+    expect(
+      mod
+        .listScopedRules({ userId: u.id, networkId: n.id })
+        .map((r) => r.mask)
+        .toSorted(),
+    ).toEqual(['everywhere', 'hereonly']);
+  });
+
+  it('the same rule is distinct at global vs network scope (dedupe is scope-aware)', () => {
+    const u = createUser('ig-glob3');
+    const n = createNetwork(u.id, { name: 'a', host: 'h', port: 6697, tls: true, nick: 'g' })!;
+    const g = mod.addRule({ userId: u.id, networkId: null, rule: rule({ mask: 'dupe' }) });
+    const net = mod.addRule({ userId: u.id, networkId: n.id, rule: rule({ mask: 'dupe' }) });
+    expect(g.created && net.created).toBe(true);
+    expect(g.id).not.toBe(net.id);
+  });
+
+  it('listAllRulesForUser reports a global rule with networkId null', () => {
+    const u = createUser('ig-glob4');
+    mod.addRule({ userId: u.id, networkId: null, rule: rule({ mask: 'g' }) });
+    expect(mod.listAllRulesForUser(u.id)).toContainEqual(
+      expect.objectContaining({ mask: 'g', networkId: null }),
+    );
+  });
+
+  it('removeRuleByMask at a network scope clears both the global and that network’s mask', () => {
+    const u = createUser('ig-glob5');
+    const n = createNetwork(u.id, { name: 'a', host: 'h', port: 6697, tls: true, nick: 'g' })!;
+    const other = createNetwork(u.id, { name: 'b', host: 'h2', port: 6697, tls: true, nick: 'g' })!;
+    mod.addRule({ userId: u.id, networkId: null, rule: rule({ mask: 'spammer' }) });
+    mod.addRule({ userId: u.id, networkId: n.id, rule: rule({ mask: 'spammer' }) });
+    mod.addRule({ userId: u.id, networkId: other.id, rule: rule({ mask: 'spammer' }) });
+    // From network n: removes the global + n's, leaves the other network's.
+    expect(mod.removeRuleByMask({ userId: u.id, networkId: n.id, mask: 'spammer' })).toBe(2);
+    expect(mod.listRules({ userId: u.id, networkId: other.id }).map((r) => r.mask)).toEqual([
+      'spammer',
+    ]);
+    expect(mod.listGlobalRules(u.id)).toHaveLength(0);
   });
 });

--- a/server/db/ignoredMasks.ts
+++ b/server/db/ignoredMasks.ts
@@ -22,7 +22,8 @@ export interface IgnoreRuleRow {
 }
 
 export interface IgnoreRuleRowWithNetwork extends IgnoreRuleRow {
-  networkId: number;
+  // null = a global rule (applies on every network); a number scopes it to one.
+  networkId: number | null;
 }
 
 /** Fields needed to create a rule (id/createdAt are assigned by the DB). */
@@ -50,7 +51,7 @@ const addStmt = db.prepare(`
 // logical rule, not spawn a near-duplicate row (every timed add differs by ms).
 const findIdenticalStmt = db.prepare(`
   SELECT id, expires_at AS expiresAt FROM ignored_masks
-  WHERE user_id = @userId AND network_id = @networkId
+  WHERE user_id = @userId AND network_id IS @networkId
     AND IFNULL(mask, '') = IFNULL(@mask, '') COLLATE NOCASE
     AND IFNULL(channels, '') = IFNULL(@channels, '')
     AND IFNULL(pattern, '') = IFNULL(@pattern, '')
@@ -64,14 +65,20 @@ const updateExpiryStmt = db.prepare(`
   UPDATE ignored_masks SET expires_at = @expiresAt WHERE id = @id
 `);
 
+// id is a globally-unique PK, so user_id alone is the ownership guard — no need
+// to also match network_id (which would have to special-case NULL for globals).
 const removeByIdStmt = db.prepare(`
   DELETE FROM ignored_masks
-  WHERE user_id = @userId AND network_id = @networkId AND id = @id
+  WHERE user_id = @userId AND id = @id
 `);
 
+// Remove every rule matching the mask within the scope the caller can see: the
+// global rules plus the current network's. @networkId NULL collapses this to
+// globals only. IS handles the NULL compare that `=` can't.
 const removeByMaskStmt = db.prepare(`
   DELETE FROM ignored_masks
-  WHERE user_id = @userId AND network_id = @networkId AND mask = @mask COLLATE NOCASE
+  WHERE user_id = @userId AND mask = @mask COLLATE NOCASE
+    AND (network_id IS NULL OR network_id IS @networkId)
 `);
 
 const COLS = `id, mask, channels, pattern, pattern_kind AS patternKind, levels,
@@ -81,6 +88,23 @@ const listForNetworkStmt = db.prepare(`
   SELECT ${COLS}
   FROM ignored_masks
   WHERE user_id = ? AND network_id = ?
+  ORDER BY id ASC
+`);
+
+// Global rules only (network_id NULL) — the client's global bucket.
+const listGlobalStmt = db.prepare(`
+  SELECT ${COLS}
+  FROM ignored_masks
+  WHERE user_id = ? AND network_id IS NULL
+  ORDER BY id ASC
+`);
+
+// The effective set for one network: its own rules unioned with the globals.
+// This is what the matcher compiles on the insert hot path.
+const listForScopeStmt = db.prepare(`
+  SELECT ${COLS}
+  FROM ignored_masks
+  WHERE user_id = ? AND (network_id IS NULL OR network_id = ?)
   ORDER BY id ASC
 `);
 
@@ -107,7 +131,7 @@ const deleteExpiredStmt = db.prepare(`
 
 interface RawRuleRow {
   id: number;
-  networkId?: number;
+  networkId?: number | null;
   mask: string | null;
   channels: string | null;
   pattern: string | null;
@@ -142,7 +166,7 @@ function rowToRule(row: RawRuleRow): IgnoreRuleRow {
   };
 }
 
-function toParams(userId: number, networkId: number, rule: IgnoreRuleInput) {
+function toParams(userId: number, networkId: number | null, rule: IgnoreRuleInput) {
   return {
     userId,
     networkId,
@@ -166,7 +190,7 @@ export function addRule({
   rule,
 }: {
   userId: number;
-  networkId: number;
+  networkId: number | null;
   rule: IgnoreRuleInput;
 }): { id: number; created: boolean } {
   const params = toParams(userId, networkId, rule);
@@ -183,31 +207,28 @@ export function addRule({
   return { id: Number(result.lastInsertRowid), created: true };
 }
 
-export function removeRuleById({
-  userId,
-  networkId,
-  id,
-}: {
-  userId: number;
-  networkId: number;
-  id: number;
-}): boolean {
-  return removeByIdStmt.run({ userId, networkId, id }).changes > 0;
+export function removeRuleById({ userId, id }: { userId: number; id: number }): boolean {
+  return removeByIdStmt.run({ userId, id }).changes > 0;
 }
 
-/** Remove every rule whose mask matches (case-insensitively). Returns the count. */
+/**
+ * Remove every rule whose mask matches (case-insensitively) within the visible
+ * scope: globals plus the given network (networkId null = globals only). Returns
+ * the count.
+ */
 export function removeRuleByMask({
   userId,
   networkId,
   mask,
 }: {
   userId: number;
-  networkId: number;
+  networkId: number | null;
   mask: string;
 }): number {
   return removeByMaskStmt.run({ userId, networkId, mask }).changes;
 }
 
+/** A single network's own rules (network-scoped only, excludes globals). */
 export function listRules({
   userId,
   networkId,
@@ -218,21 +239,37 @@ export function listRules({
   return (listForNetworkStmt.all(userId, networkId) as RawRuleRow[]).map(rowToRule);
 }
 
+/** The user's global rules (network_id NULL). */
+export function listGlobalRules(userId: number): IgnoreRuleRow[] {
+  return (listGlobalStmt.all(userId) as RawRuleRow[]).map(rowToRule);
+}
+
+/** Effective set for a network: globals ∪ that network's rules (matcher input). */
+export function listScopedRules({
+  userId,
+  networkId,
+}: {
+  userId: number;
+  networkId: number;
+}): IgnoreRuleRow[] {
+  return (listForScopeStmt.all(userId, networkId) as RawRuleRow[]).map(rowToRule);
+}
+
 export function listAllRulesForUser(userId: number): IgnoreRuleRowWithNetwork[] {
   return (listAllStmt.all(userId) as RawRuleRow[]).map((r) => ({
     ...rowToRule(r),
-    networkId: r.networkId!,
+    networkId: r.networkId ?? null,
   }));
 }
 
 // Delete every lapsed rule and report the (user, network) pairs touched so the
 // caller can invalidate compiled caches and fan out updated lists.
-const sweep = db.transaction((): { userId: number; networkId: number }[] => {
-  const affected = listExpiredStmt.all() as { userId: number; networkId: number }[];
+const sweep = db.transaction((): { userId: number; networkId: number | null }[] => {
+  const affected = listExpiredStmt.all() as { userId: number; networkId: number | null }[];
   if (affected.length) deleteExpiredStmt.run();
   return affected;
 });
 
-export function sweepExpired(): { userId: number; networkId: number }[] {
+export function sweepExpired(): { userId: number; networkId: number | null }[] {
   return sweep();
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -357,8 +357,10 @@ function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_user_drafts_user ON user_drafts(user_id);
 
-    -- Per-(user, network) ignore list, irssi-style (issue #301). A rule AND-s
-    -- optional dimensions: mask (NULL/'*' = anyone; a bare nick globs the nick,
+    -- Per-user ignore list, irssi-style (issue #301, scoping #350). network_id
+    -- NULL = a global rule that applies on every network (the default); a real
+    -- network_id scopes the rule to that one network. A rule AND-s optional
+    -- dimensions: mask (NULL/'*' = anyone; a bare nick globs the nick,
     -- a nick!user@host form globs the hostmask), channels (NULL = all buffers;
     -- else CSV of channel globs), pattern (NULL = any text; matched per
     -- pattern_kind 'substr'|'full'|'regex'), and levels (CSV of event-type
@@ -369,7 +371,7 @@ function migrate() {
     CREATE TABLE IF NOT EXISTS ignored_masks (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id INTEGER NOT NULL,
-      network_id INTEGER NOT NULL,
+      network_id INTEGER,
       mask TEXT COLLATE NOCASE,
       channels TEXT,
       pattern TEXT,
@@ -656,7 +658,7 @@ ensureColumn('upload_history', 'removed', 'INTEGER NOT NULL DEFAULT 0');
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
-const SCHEMA_VERSION = 10;
+const SCHEMA_VERSION = 11;
 const schemaVersionRow = db
   .prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`)
   .get() as { value: string } | undefined;
@@ -1009,6 +1011,61 @@ if (schemaVersion < 10) {
       `);
       db.exec(`DROP TABLE ignored_masks`);
       db.exec(`ALTER TABLE ignored_masks_new RENAME TO ignored_masks`);
+    });
+    const prevFk = db.pragma('foreign_keys', { simple: true });
+    db.pragma('foreign_keys = OFF');
+    try {
+      rebuild();
+    } finally {
+      db.pragma(`foreign_keys = ${prevFk ? 'ON' : 'OFF'}`);
+    }
+  }
+}
+
+if (schemaVersion < 11) {
+  // Issue #350: make ignore scoping global-by-default. network_id was NOT NULL
+  // (every rule tied to one network); now NULL means a global rule that applies
+  // on every network. SQLite can't drop a NOT NULL via ALTER, so rebuild the
+  // table — same swap shape as the #301 migration. Existing rows keep their
+  // network_id verbatim (they stay network-scoped; nothing silently becomes
+  // global), only the column constraint changes. Fresh installs already have the
+  // nullable shape from the CREATE TABLE above, so detect the old NOT NULL via
+  // table_info and skip the rebuild when it's already nullable (copies zero work).
+  const netCol = (db.prepare(`PRAGMA table_info(ignored_masks)`).all() as TableInfoRow[]).find(
+    (c) => c.name === 'network_id',
+  );
+  if (netCol && netCol.notnull === 1) {
+    const rebuild = db.transaction(() => {
+      db.exec(`DROP INDEX IF EXISTS idx_ignored_masks_user_net`);
+      db.exec(`
+        CREATE TABLE ignored_masks_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER NOT NULL,
+          network_id INTEGER,
+          mask TEXT COLLATE NOCASE,
+          channels TEXT,
+          pattern TEXT,
+          pattern_kind TEXT NOT NULL DEFAULT 'substr',
+          levels TEXT NOT NULL DEFAULT 'ALL',
+          is_except INTEGER NOT NULL DEFAULT 0,
+          expires_at TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+          FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+        )
+      `);
+      db.exec(`
+        INSERT INTO ignored_masks_new
+          (id, user_id, network_id, mask, channels, pattern, pattern_kind, levels, is_except, expires_at, created_at)
+        SELECT
+          id, user_id, network_id, mask, channels, pattern, pattern_kind, levels, is_except, expires_at, created_at
+        FROM ignored_masks
+      `);
+      db.exec(`DROP TABLE ignored_masks`);
+      db.exec(`ALTER TABLE ignored_masks_new RENAME TO ignored_masks`);
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_ignored_masks_user_net ON ignored_masks(user_id, network_id)`,
+      );
     });
     const prevFk = db.pragma('foreign_keys', { simple: true });
     db.pragma('foreign_keys = OFF');

--- a/server/services/ignoreRulesService.test.ts
+++ b/server/services/ignoreRulesService.test.ts
@@ -98,4 +98,22 @@ describe('ignoreRulesService scoping + cache (#350)', () => {
     expect(evaluateIgnores(svc.getCompiled(u.id, n1.id), ctx).hide).toBe(true);
     expect(evaluateIgnores(svc.getCompiled(u.id, n2.id), ctx).hide).toBe(false);
   });
+
+  it('listGlobal returns only the global rules', () => {
+    const u = createUser('igsvc-listglobal');
+    const n = createNetwork(u.id, { name: 'a', host: 'h', port: 6697, tls: true, nick: 'g' })!;
+    svc.add(u.id, null, base({ mask: 'g1' }));
+    svc.add(u.id, n.id, base({ mask: 'netonly' }));
+    expect(svc.listGlobal(u.id).map((r) => r.mask)).toEqual(['g1']);
+  });
+
+  it('removeByMask at a network scope clears the global and that network’s match', () => {
+    const u = createUser('igsvc-rmmask');
+    const n = createNetwork(u.id, { name: 'a', host: 'h', port: 6697, tls: true, nick: 'g' })!;
+    svc.add(u.id, null, base({ mask: 'dup' }));
+    svc.add(u.id, n.id, base({ mask: 'dup' }));
+    expect(svc.removeByMask(u.id, n.id, 'dup')).toBe(2);
+    expect(svc.listGlobal(u.id)).toHaveLength(0);
+    expect(svc.list(u.id, n.id)).toHaveLength(0);
+  });
 });

--- a/server/services/ignoreRulesService.test.ts
+++ b/server/services/ignoreRulesService.test.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import type { IgnoreRuleInput } from '../db/ignoredMasks.js';
+import { evaluateIgnores, type IgnoreInput } from '../../shared/ignoreMatch.js';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-igsvc-'));
 process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
@@ -61,5 +62,40 @@ describe('ignoreRulesService.add validation', () => {
 
   it('rejects a rule with no valid levels', () => {
     expect(svc.add(user.id, net!.id, base({ levels: ['bogus'] }))).toMatchObject({ ok: false });
+  });
+});
+
+describe('ignoreRulesService scoping + cache (#350)', () => {
+  const ctxFor = (nick: string): IgnoreInput => ({
+    nick,
+    userhost: null,
+    target: '#x',
+    text: '',
+    type: 'message',
+    isDm: false,
+  });
+
+  it('a global rule applies on every network and invalidates already-compiled caches', () => {
+    const u = createUser('igsvc-glob');
+    const n1 = createNetwork(u.id, { name: 'a', host: 'h', port: 6697, tls: true, nick: 'g' })!;
+    const n2 = createNetwork(u.id, { name: 'b', host: 'h2', port: 6697, tls: true, nick: 'g' })!;
+    const ctx = ctxFor('globe');
+    // Warm n1's cache before the rule exists — proves the global add busts it.
+    expect(evaluateIgnores(svc.getCompiled(u.id, n1.id), ctx).hide).toBe(false);
+
+    expect(svc.add(u.id, null, base({ mask: 'globe' })).ok).toBe(true);
+
+    expect(evaluateIgnores(svc.getCompiled(u.id, n1.id), ctx).hide).toBe(true);
+    expect(evaluateIgnores(svc.getCompiled(u.id, n2.id), ctx).hide).toBe(true);
+  });
+
+  it('a network-scoped rule applies only on that network', () => {
+    const u = createUser('igsvc-net');
+    const n1 = createNetwork(u.id, { name: 'a', host: 'h', port: 6697, tls: true, nick: 'g' })!;
+    const n2 = createNetwork(u.id, { name: 'b', host: 'h2', port: 6697, tls: true, nick: 'g' })!;
+    const ctx = ctxFor('localonly');
+    expect(svc.add(u.id, n1.id, base({ mask: 'localonly' })).ok).toBe(true);
+    expect(evaluateIgnores(svc.getCompiled(u.id, n1.id), ctx).hide).toBe(true);
+    expect(evaluateIgnores(svc.getCompiled(u.id, n2.id), ctx).hide).toBe(false);
   });
 });

--- a/server/services/ignoreRulesService.ts
+++ b/server/services/ignoreRulesService.ts
@@ -12,6 +12,8 @@ import {
   removeRuleById,
   removeRuleByMask,
   listRules,
+  listGlobalRules,
+  listScopedRules,
   sweepExpired as sweepExpiredRows,
 } from '../db/ignoredMasks.js';
 import { compileIgnoreRules, canonicalizeLevels } from './ignoreMatch.js';
@@ -22,19 +24,27 @@ const ALLOWED_KINDS = new Set(['substr', 'full', 'regex']);
 const MAX_PATTERN_LENGTH = 512;
 
 class IgnoreRulesService {
+  // Keyed by `${userId}:${networkId}`; getCompiled is only ever called with a
+  // real networkId (from a live connection), so we never key on a null network.
   private cache = new Map<string, Compiled>();
 
   private key(userId: number, networkId: number): string {
     return `${userId}:${networkId}`;
   }
 
+  /** A single network's own rules (excludes globals) — for the per-network UI bucket. */
   list(userId: number, networkId: number): IgnoreRuleRow[] {
     return listRules({ userId, networkId });
   }
 
+  /** The user's global rules — for the global UI bucket. */
+  listGlobal(userId: number): IgnoreRuleRow[] {
+    return listGlobalRules(userId);
+  }
+
   add(
     userId: number,
-    networkId: number,
+    networkId: number | null,
     input: IgnoreRuleInput,
   ): { ok: false; error: string } | { ok: true; id: number; created: boolean } {
     if (!ALLOWED_KINDS.has(input.patternKind)) {
@@ -71,34 +81,44 @@ class IgnoreRulesService {
     return { ok: true, id, created };
   }
 
-  removeById(userId: number, networkId: number, id: number): boolean {
-    const ok = removeRuleById({ userId, networkId, id });
+  removeById(userId: number, networkId: number | null, id: number): boolean {
+    const ok = removeRuleById({ userId, id });
     if (ok) this.invalidate(userId, networkId);
     return ok;
   }
 
-  removeByMask(userId: number, networkId: number, mask: string): number {
+  removeByMask(userId: number, networkId: number | null, mask: string): number {
     const n = removeRuleByMask({ userId, networkId, mask });
-    if (n) this.invalidate(userId, networkId);
+    // A by-mask delete can touch both globals and the network's own rules, so
+    // drop every cache entry for the user rather than reason about which.
+    if (n) this.invalidate(userId, null);
     return n;
   }
 
+  // The compiled set for one network is globals ∪ that network's rules.
   getCompiled(userId: number, networkId: number): Compiled {
     const k = this.key(userId, networkId);
     const cached = this.cache.get(k);
     if (cached) return cached;
-    const compiled = compileIgnoreRules(listRules({ userId, networkId }));
+    const compiled = compileIgnoreRules(listScopedRules({ userId, networkId }));
     this.cache.set(k, compiled);
     return compiled;
   }
 
-  invalidate(userId: number, networkId: number): void {
-    this.cache.delete(this.key(userId, networkId));
+  // A global rule (networkId null) feeds every network's compiled set, so drop
+  // all of the user's entries; a network-scoped change drops only that one.
+  invalidate(userId: number, networkId: number | null): void {
+    if (networkId == null) {
+      const prefix = `${userId}:`;
+      for (const k of this.cache.keys()) if (k.startsWith(prefix)) this.cache.delete(k);
+    } else {
+      this.cache.delete(this.key(userId, networkId));
+    }
   }
 
   // Delete every lapsed rule, invalidate the caches it touched, and return the
   // affected (user, network) pairs so the caller can fan out updated lists.
-  sweepExpired(): { userId: number; networkId: number }[] {
+  sweepExpired(): { userId: number; networkId: number | null }[] {
     const affected = sweepExpiredRows();
     for (const { userId, networkId } of affected) this.invalidate(userId, networkId);
     return affected;

--- a/server/services/ignoreSweeper.ts
+++ b/server/services/ignoreSweeper.ts
@@ -7,27 +7,21 @@
 // to drop it from the list so it doesn't linger in /ignore or the settings pane.
 
 import ignoreRulesService from './ignoreRulesService.js';
-import ircManager from './ircManager.js';
-import { fanOutToUser } from './wsHub.js';
+import { fanOutIgnoreList } from './wsHub.js';
 
 const SWEEP_INTERVAL_MS = 60 * 1000;
 let timer: ReturnType<typeof setInterval> | null = null;
 
 export function sweepExpiredIgnores(): void {
-  let affected: { userId: number; networkId: number }[];
+  let affected: { userId: number; networkId: number | null }[];
   try {
     affected = ignoreRulesService.sweepExpired();
   } catch (e) {
     console.warn('[ignore] expiry sweep failed:', (e as Error)?.message || e);
     return;
   }
-  for (const { userId, networkId } of affected) {
-    fanOutToUser(userId, {
-      kind: 'ignore-list-updated',
-      networkId,
-      masks: ircManager.listIgnoredFor(userId, networkId),
-    });
-  }
+  // networkId null = a global rule lapsed; fanOutIgnoreList ships the right bucket.
+  for (const { userId, networkId } of affected) fanOutIgnoreList(userId, networkId);
 }
 
 export function startIgnoreSweeper(): void {

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -106,6 +106,43 @@ describe('ircManager.snapshotForUser offline networks', () => {
   });
 });
 
+describe('ircManager ignore scoping (#350)', () => {
+  const igRule = (mask: string) => ({
+    mask,
+    channels: null,
+    pattern: null,
+    patternKind: 'substr' as const,
+    levels: ['ALL'],
+    isExcept: false,
+    expiresAt: null,
+  });
+
+  it('keeps global rules out of per-network snapshot blobs and in listGlobalIgnoresFor', () => {
+    const user = createUser('irc-ignore-scope');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.invalid',
+      port: 6697,
+      tls: true,
+      nick: 'z',
+      autoconnect: false,
+    });
+    if (!net) throw new Error('createNetwork returned undefined');
+
+    ircManager.addIgnore(user.id, null, igRule('globalguy'));
+    ircManager.addIgnore(user.id, net.id, igRule('netguy'));
+
+    expect(ircManager.listGlobalIgnoresFor(user.id).map((r) => r.mask)).toEqual(['globalguy']);
+    expect(ircManager.listIgnoredFor(user.id, net.id).map((r) => r.mask)).toEqual(['netguy']);
+
+    const snap = ircManager.snapshotForUser(user.id) as Array<Record<string, unknown>>;
+    const blob = snap.find((b) => b.networkId === net.id)!;
+    const masks = (blob.ignoredMasks as Array<{ mask: string }>).map((m) => m.mask);
+    expect(masks).toContain('netguy');
+    expect(masks).not.toContain('globalguy');
+  });
+});
+
 describe('ircManager deferrable connect (issue #236 throttle seam)', () => {
   function makeAutoconnectNetwork(handle: string) {
     const user = createUser(handle);

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -520,9 +520,11 @@ class IrcManager extends EventEmitter {
     return out;
   }
 
+  // networkId null = a global rule (applies on every network); a number scopes
+  // it to that one. The default at the command/UI layer is global (#350).
   addIgnore(
     userId: number,
-    networkId: number,
+    networkId: number | null,
     rule: IgnoreRuleInput,
   ): { ok: false; error: string } | { ok: true; id: number; created: boolean } {
     return ignoreRulesService.add(userId, networkId, rule);
@@ -530,7 +532,7 @@ class IrcManager extends EventEmitter {
 
   removeIgnore(
     userId: number,
-    networkId: number,
+    networkId: number | null,
     by: { id?: number; mask?: string },
   ): boolean | number {
     if (typeof by.id === 'number') return ignoreRulesService.removeById(userId, networkId, by.id);
@@ -538,8 +540,14 @@ class IrcManager extends EventEmitter {
     return false;
   }
 
+  /** One network's own rules (excludes globals). */
   listIgnoredFor(userId: number, networkId: number): IgnoreRuleRow[] {
     return ignoreRulesService.list(userId, networkId);
+  }
+
+  /** The user's global rules (apply on every network). */
+  listGlobalIgnoresFor(userId: number): IgnoreRuleRow[] {
+    return ignoreRulesService.listGlobal(userId);
   }
 
   setNickNote(userId: number, networkId: number, nick: string, note: string): NoteResult | null {
@@ -650,6 +658,9 @@ function ignoresGrouped(userId: number): Map<number, IgnoreRuleRow[]> {
   const out = new Map<number, IgnoreRuleRow[]>();
   for (const row of listAllRulesForUser(userId)) {
     const { networkId, ...rule } = row;
+    // Global rules (networkId null) ride a separate snapshot field, not a
+    // per-network blob — skip them here.
+    if (networkId == null) continue;
     const list = out.get(networkId);
     if (list) list.push(rule);
     else out.set(networkId, [rule]);

--- a/server/services/parseIgnore.test.ts
+++ b/server/services/parseIgnore.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { parseIgnoreArgs } from '../../shared/parseIgnore.js';
+import { parseIgnoreArgs, durationToExpiry } from '../../shared/parseIgnore.js';
 
 const NOW = Date.parse('2026-06-18T00:00:00.000Z');
 const p = (s: string) => parseIgnoreArgs(s, NOW);
@@ -121,5 +121,17 @@ describe('parseIgnoreArgs — scope (#350)', () => {
       levels: ['JOINS'],
       scopeNetwork: true,
     });
+  });
+});
+
+describe('durationToExpiry (#350) — shared by the settings pane', () => {
+  it('computes an ISO expiry from a duration string', () => {
+    expect(durationToExpiry('7 days', NOW)).toBe('2026-06-25T00:00:00.000Z');
+    expect(durationToExpiry('300', NOW)).toBe('2026-06-18T00:05:00.000Z');
+  });
+
+  it('returns null for an unparseable or empty duration', () => {
+    expect(durationToExpiry('soon', NOW)).toBeNull();
+    expect(durationToExpiry('', NOW)).toBeNull();
   });
 });

--- a/server/services/parseIgnore.test.ts
+++ b/server/services/parseIgnore.test.ts
@@ -100,3 +100,26 @@ describe('parseIgnoreArgs — flags & errors', () => {
     expect(p('bob -pattern').error).toMatch(/pattern/);
   });
 });
+
+describe('parseIgnoreArgs — scope (#350)', () => {
+  it('defaults to global (scopeNetwork false)', () => {
+    expect(p('bob').scopeNetwork).toBe(false);
+  });
+
+  it('-network / -net scope to the current network', () => {
+    expect(p('-network bob').scopeNetwork).toBe(true);
+    expect(p('-net bob NOHIGHLIGHT').scopeNetwork).toBe(true);
+  });
+
+  it('-global is the explicit default', () => {
+    expect(p('-global bob').scopeNetwork).toBe(false);
+  });
+
+  it('scope flags do not leak into the other dimensions', () => {
+    expect(p('-network bob JOINS')).toMatchObject({
+      mask: 'bob',
+      levels: ['JOINS'],
+      scopeNetwork: true,
+    });
+  });
+});

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -482,6 +482,20 @@ export function fanOutToUser(userId: number, payload: WsPayload, opts: FanOutOpt
   fanOut(userId, payload, opts);
 }
 
+// Push the user's current ignore list for one scope to all their open tabs.
+// networkId null targets the global bucket; a number targets that network's own
+// rules. The client replaces the matching bucket and re-unions at match time.
+export function fanOutIgnoreList(userId: number, networkId: number | null): void {
+  fanOut(userId, {
+    kind: 'ignore-list-updated',
+    networkId,
+    masks:
+      networkId == null
+        ? ircManager.listGlobalIgnoresFor(userId)
+        : ircManager.listIgnoredFor(userId, networkId),
+  });
+}
+
 // One sweep of the liveness heartbeat over a batch of sockets. A socket that
 // hasn't ponged since the previous sweep (isAlive still false) is terminated —
 // firing its 'close' handler → removeSocket → evaluatePresence, which lets
@@ -1031,7 +1045,13 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     freshNetworkId: number | null = null,
   ): void {
     const networks = ircManager.snapshotForUser(userId);
-    send(ws, { kind: 'snapshot', networks });
+    // Global ignore rules (network_id NULL) aren't tied to any one network blob,
+    // so they ride alongside the per-network snapshot as their own field (#350).
+    send(ws, {
+      kind: 'snapshot',
+      networks,
+      globalIgnores: ircManager.listGlobalIgnoresFor(userId),
+    });
     // Drafts ship once per snapshot, separate from per-buffer backlog frames —
     // the keying is global to the user, not per-buffer, so a single message is
     // cheaper than fanning a body field into every backlog row.
@@ -1665,8 +1685,11 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         break;
       }
       case 'add-ignore': {
-        const networkId = Number(msg.networkId);
-        if (!networkId) break;
+        // null networkId = a global rule (every network); a positive number
+        // scopes it to one. `null` is a valid scope, so distinguish it from a
+        // malformed/missing id rather than the old truthiness check.
+        const networkId = msg.networkId == null ? null : Number(msg.networkId);
+        if (networkId !== null && !(networkId > 0)) break;
         // New clients send a full `rule` object; the quick-ignore modal and
         // older clients send a bare `mask` string (an ALL-level rule).
         const input =
@@ -1681,25 +1704,25 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // compiled cache so the insert path sees the new rule immediately.
         const result = ircManager.addIgnore(userId, networkId, input);
         if (!result.ok) break;
-        fanOut(userId, {
-          kind: 'ignore-list-updated',
-          networkId,
-          masks: ircManager.listIgnoredFor(userId, networkId),
-        });
+        fanOutIgnoreList(userId, networkId);
         break;
       }
       case 'remove-ignore': {
-        const networkId = Number(msg.networkId);
-        if (!networkId) break;
+        const networkId = msg.networkId == null ? null : Number(msg.networkId);
+        if (networkId !== null && !(networkId > 0)) break;
         const id = typeof msg.id === 'number' ? msg.id : undefined;
         const mask = typeof msg.mask === 'string' && msg.mask.trim() ? msg.mask.trim() : undefined;
         if (id === undefined && mask === undefined) break;
         ircManager.removeIgnore(userId, networkId, { id, mask });
-        fanOut(userId, {
-          kind: 'ignore-list-updated',
-          networkId,
-          masks: ircManager.listIgnoredFor(userId, networkId),
-        });
+        // A by-mask delete on a network scope clears matching globals AND that
+        // network's rules (removeByMask spans both), so refresh both buckets.
+        // by-id, or a global-scoped delete, touches just one.
+        if (mask !== undefined && networkId !== null) {
+          fanOutIgnoreList(userId, null);
+          fanOutIgnoreList(userId, networkId);
+        } else {
+          fanOutIgnoreList(userId, networkId);
+        }
         break;
       }
       case 'history': {

--- a/shared/parseIgnore.ts
+++ b/shared/parseIgnore.ts
@@ -22,6 +22,10 @@ export interface ParsedIgnore {
   levels: string[];
   isExcept: boolean;
   expiresAt: string | null;
+  // true = scope the rule to the current network (-network); false (default) =
+  // global, applying on every network (#350). Consumed by the command handler,
+  // which maps it to a networkId; the rule payload itself is scope-agnostic.
+  scopeNetwork: boolean;
   error?: string;
 }
 
@@ -68,6 +72,15 @@ function parseDuration(s: string | undefined): number | null {
   const ms = parseInt(m[1], 10) * mult;
   if (!Number.isFinite(ms) || ms > MAX_DURATION_MS) return null;
   return ms;
+}
+
+// Turn a duration string (e.g. "7 days", "30m") into an ISO expiry timestamp,
+// or null if it doesn't parse. Same grammar as the -time flag, exported so the
+// settings pane computes expiry identically to the command line.
+export function durationToExpiry(s: string, now: number = Date.now()): string | null {
+  const ms = parseDuration(s);
+  if (ms == null) return null;
+  return new Date(now + ms).toISOString();
 }
 
 // Tokenize on whitespace, but keep a "(…)" group (balanced) or a "quoted" string
@@ -121,6 +134,7 @@ export function parseIgnoreArgs(argLine: string, now: number = Date.now()): Pars
     levels: [],
     isExcept: false,
     expiresAt: null,
+    scopeNetwork: false,
   };
   const fail = (error: string): ParsedIgnore => ({ ...base, error });
 
@@ -146,6 +160,16 @@ export function parseIgnoreArgs(argLine: string, now: number = Date.now()): Pars
     }
     if (lower === '-except') {
       base.isExcept = true;
+      continue;
+    }
+    // Scope flags (#350). Default is global; -network/-net scopes to the current
+    // network, -global is the explicit opposite (a no-op but symmetric/discoverable).
+    if (lower === '-network' || lower === '-net') {
+      base.scopeNetwork = true;
+      continue;
+    }
+    if (lower === '-global') {
+      base.scopeNetwork = false;
       continue;
     }
     if (lower === '-replies') return fail('-replies is not supported');

--- a/vue_client/src/components/IgnoreModal.vue
+++ b/vue_client/src/components/IgnoreModal.vue
@@ -23,8 +23,29 @@
           >) or <code>nick!user@host</code> with <code>*</code> wildcards. The default targets this
           user's identity (<code>user@host</code>) so it survives nick changes.
         </p>
+        <div v-if="networkId" class="scope" role="radiogroup" aria-label="Scope">
+          <button
+            type="button"
+            role="radio"
+            :aria-checked="scope === 'global'"
+            :class="{ active: scope === 'global' }"
+            @click="scope = 'global'"
+          >
+            Everywhere
+          </button>
+          <button
+            type="button"
+            role="radio"
+            :aria-checked="scope === 'network'"
+            :class="{ active: scope === 'network' }"
+            @click="scope = 'network'"
+          >
+            This network
+          </button>
+        </div>
         <p class="preview">
-          Messages matching <code>{{ mask || '∅' }}</code> will be hidden on this network.
+          Messages matching <code>{{ mask || '∅' }}</code> will be hidden
+          {{ scope === 'network' ? 'on this network' : 'on every network' }}.
         </p>
       </div>
       <footer class="modal-footer">
@@ -58,6 +79,11 @@ const emit = defineEmits<{ close: [] }>();
 const ignores = useIgnoresStore();
 const inputEl = ref<HTMLInputElement | null>(null);
 
+// Scope: global (default, #350) hides the mask on every network; 'network'
+// scopes it to the buffer it was opened from. Only offered when we know the
+// network — otherwise it's always global.
+const scope = ref<'global' | 'network'>('global');
+
 // Default to a hostmask that hides the nick segment — IRCCloud convention.
 // If we don't have an observed user@host yet (member entered before WHO
 // completed and we never saw a join), fall back to nick!*@*.
@@ -65,8 +91,9 @@ const mask = ref(props.user && props.host ? `*!${props.user}@${props.host}` : `$
 
 function confirm() {
   const trimmed = mask.value.trim();
-  if (!trimmed || !props.networkId) return;
-  ignores.addMask(props.networkId, trimmed);
+  if (!trimmed) return;
+  const networkId = scope.value === 'network' ? props.networkId : null;
+  ignores.addMask(networkId, trimmed);
   emit('close');
 }
 
@@ -116,6 +143,24 @@ input:focus {
 }
 .preview {
   color: var(--fg);
+}
+.scope {
+  display: flex;
+  gap: var(--space-2);
+}
+.scope button {
+  flex: 1;
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-3);
+  font: inherit;
+  cursor: pointer;
+}
+.scope button.active {
+  color: var(--fg);
+  border-color: var(--accent);
+  outline: 1px solid var(--accent);
 }
 code {
   background: var(--bg-soft);

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -182,6 +182,18 @@ const uploads = useUploadsStore();
 const toasts = useToastsStore();
 const ignores = useIgnoresStore();
 const nickColors = useNickColors();
+
+// The ignore rules visible from this network, in /ignore-listing order: globals
+// first (scope null), then this network's own (scope = networkId). The index a
+// user sees in /ignore maps 1:1 to this array, so /unignore <n> resolves the
+// right rule and its scope.
+function combinedIgnores(networkId: number): { entry: IgnoreEntry; scope: number | null }[] {
+  const globals = ignores.global.map((entry) => ({ entry, scope: null as number | null }));
+  const own = ignores
+    .masksFor(networkId)
+    .map((entry) => ({ entry, scope: networkId as number | null }));
+  return [...globals, ...own];
+}
 const inputEl = ref<HTMLTextAreaElement | null>(null);
 const formEl = ref<HTMLElement | null>(null);
 const fileInputEl = ref<HTMLInputElement | null>(null);
@@ -1747,10 +1759,11 @@ function localInfo(networkId: number, target: string, lineText: string): void {
   });
 }
 
-// One indexed line for the /ignore listing: "  2. *zzz*  NICKS  #chan  [except]".
-// "*zzz*  NICKS  #chan  [except]" — the rule's dimensions, no index.
-function summarizeIgnoreEntry(entry: IgnoreEntry): string {
+// "*zzz*  [global]  NICKS  #chan  [except]" — the rule's dimensions, no index.
+// `global` tags rules that apply on every network (vs. this network's own).
+function summarizeIgnoreEntry(entry: IgnoreEntry, global = false): string {
   const parts: string[] = [entry.mask ?? '*'];
+  if (global) parts.push('[global]');
   if (entry.levels?.length) parts.push(entry.levels.join(','));
   if (entry.channels?.length) parts.push(entry.channels.join(','));
   if (entry.pattern) {
@@ -1761,9 +1774,9 @@ function summarizeIgnoreEntry(entry: IgnoreEntry): string {
   return parts.join('  ');
 }
 
-// One indexed line for the /ignore listing: "  2. *zzz*  NICKS  #chan".
-function formatIgnoreEntry(entry: IgnoreEntry, idx: number): string {
-  return `  ${idx}. ${summarizeIgnoreEntry(entry)}`;
+// One indexed line for the /ignore listing: "  2. *zzz*  [global]  NICKS  #chan".
+function formatIgnoreEntry(entry: IgnoreEntry, idx: number, global = false): string {
+  return `  ${idx}. ${summarizeIgnoreEntry(entry, global)}`;
 }
 
 const COMMANDS_LINES = [
@@ -1795,10 +1808,10 @@ const COMMANDS_LINES = [
   '  /who [mask]            — find users (also /whowas /userhost /ison /names)',
   '  /motd /version /time   — server info (also /admin /info /lusers /links /map /stats /help)',
   '  /jitsi                 — start a video call (alias: /talk)',
-  '  /ignore [opts] [mask|#chan] [LEVELS] — list, or add an ignore rule',
-  '      opts: -regexp -full -pattern <text> -except -time <dur>',
+  '  /ignore [opts] [mask|#chan] [LEVELS] — list, or add an ignore rule (global by default)',
+  '      opts: -network -regexp -full -pattern <text> -except -time <dur>',
   '      LEVELS: ALL PUBLIC MSGS NOTICES ACTIONS JOINS PARTS QUITS NICKS KICKS MODES TOPICS NOHIGHLIGHT',
-  '      e.g. /ignore bob NOHIGHLIGHT   ·   /ignore -regexp -pattern (foo|bar) #chan',
+  '      e.g. /ignore bob NOHIGHLIGHT   ·   /ignore -network -regexp -pattern (foo|bar) #chan',
   '  /unignore <index|mask> — remove an ignore (index from /ignore list)',
   '  /raw <line>            — send a raw IRC line (alias: /quote)',
   '  /commands              — this list',
@@ -2064,18 +2077,20 @@ function handleCommand(line: string, networkId: number, target: string): boolean
         line,
       );
     case 'ignore': {
-      // No-arg form: dump the current network's ignore list into the active
-      // buffer as system messages, with an index for /unignore. The store
-      // already has the list (snapshot + ignore-list-updated), so it's a purely
-      // client-side read — no server roundtrip.
+      // No-arg form: dump the ignore rules visible here (globals + this
+      // network's) into the active buffer as system messages, with an index for
+      // /unignore. The store already has the lists (snapshot +
+      // ignore-list-updated), so it's a purely client-side read.
       const args = argLine.trim();
       if (!args) {
-        const list = ignores.masksFor(networkId);
+        const list = combinedIgnores(networkId);
         if (!list.length) {
-          localInfo(networkId, target, 'ignore list is empty on this network.');
+          localInfo(networkId, target, 'ignore list is empty.');
         } else {
           localInfo(networkId, target, `ignore list (${list.length}):`);
-          list.forEach((entry, i) => localInfo(networkId, target, formatIgnoreEntry(entry, i + 1)));
+          list.forEach(({ entry, scope }, i) =>
+            localInfo(networkId, target, formatIgnoreEntry(entry, i + 1, scope === null)),
+          );
         }
         return true;
       }
@@ -2084,7 +2099,8 @@ function handleCommand(line: string, networkId: number, target: string): boolean
         localInfo(networkId, target, `/ignore: ${parsed.error}`);
         return true;
       }
-      ignores.addRule(networkId, parsed);
+      // Default scope is global (null); -network scopes to the current network.
+      ignores.addRule(parsed.scopeNetwork ? networkId : null, parsed);
       return true;
     }
     case 'unignore': {
@@ -2093,26 +2109,28 @@ function handleCommand(line: string, networkId: number, target: string): boolean
         localInfo(networkId, target, 'usage: /unignore <index|mask>  (index from /ignore)');
         return true;
       }
+      const list = combinedIgnores(networkId);
       if (/^\d+$/.test(arg)) {
-        const entry = ignores.masksFor(networkId)[Number(arg) - 1];
-        if (!entry) {
-          localInfo(
-            networkId,
-            target,
-            `/unignore: no ignore #${arg} on this network (see /ignore)`,
-          );
+        const item = list[Number(arg) - 1];
+        if (!item) {
+          localInfo(networkId, target, `/unignore: no ignore #${arg} (see /ignore)`);
           return true;
         }
-        ignores.removeRule(networkId, { id: entry.id });
-        localInfo(networkId, target, `removed ignore #${arg}: ${summarizeIgnoreEntry(entry)}`);
+        ignores.removeRule(item.scope, { id: item.entry.id });
+        localInfo(
+          networkId,
+          target,
+          `removed ignore #${arg}: ${summarizeIgnoreEntry(item.entry, item.scope === null)}`,
+        );
         return true;
       }
-      // Remove-by-mask matches the stored mask exactly (case-insensitive), the
-      // same rule the server applies — count local matches so we can confirm or
-      // report nothing-removed instead of failing silently.
-      const matches = ignores
-        .masksFor(networkId)
-        .filter((e) => (e.mask ?? '').toLowerCase() === arg.toLowerCase());
+      // Remove-by-mask matches the stored mask exactly (case-insensitive) across
+      // the visible scope (globals + this network) — the same set the server
+      // deletes. Count local matches so we confirm or report nothing-removed
+      // instead of failing silently.
+      const matches = list.filter(
+        ({ entry }) => (entry.mask ?? '').toLowerCase() === arg.toLowerCase(),
+      );
       if (!matches.length) {
         localInfo(networkId, target, `/unignore: no ignore with mask "${arg}" (see /ignore)`);
         return true;

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -201,6 +201,9 @@ const GRANULAR_LEVELS = CANONICAL_ORDER.filter(
   (l) => l !== 'ALL' && l !== 'CTCPS' && l !== 'NOHIGHLIGHT',
 );
 
+// Mirrors MAX_PATTERN_LENGTH in server/services/ignoreRulesService.ts.
+const MAX_PATTERN_LENGTH = 512;
+
 const networksStore = useNetworksStore();
 const ignores = useIgnoresStore();
 
@@ -330,6 +333,13 @@ function buildRule(): IgnoreRule | null {
   const channels = parseChannels(form.channels);
   const pattern = form.pattern.trim() || null;
   const patternKind = form.patternKind;
+  // Mirror the server's cap so the add can't be rejected after the edit's remove
+  // has already fired (which would lose the original rule). buildRule runs before
+  // the remove in submit(), so every check here is a safe pre-flight.
+  if (pattern && pattern.length > MAX_PATTERN_LENGTH) {
+    formError.value = `message text is too long (max ${MAX_PATTERN_LENGTH} characters).`;
+    return null;
+  }
   if (pattern && patternKind === 'regex') {
     try {
       void new RegExp(pattern);
@@ -339,10 +349,16 @@ function buildRule(): IgnoreRule | null {
     }
   }
   const levels = buildLevels();
-  // Guard the one footgun a GUI shouldn't make easy: a rule with no who/where/
-  // what AND ALL levels hides the entire feed. Broad-but-targeted rules (all
-  // notices, all joins on #chan) are fine.
-  if (!mask && !channels && !pattern && !form.isExcept && levels.includes('ALL')) {
+  // Guard the footgun rules a GUI shouldn't make easy. A rule with no who/where/
+  // what matches the whole feed: as a hide rule with ALL it hides everything; as
+  // an exception it whitelists everyone, neutralizing real ignores. Broad-but-
+  // targeted rules (all notices, all joins on #chan) stay fine.
+  const unscoped = !mask && !channels && !pattern;
+  if (unscoped && form.isExcept) {
+    formError.value = 'an exception needs a mask, channel, or text pattern to whitelist.';
+    return null;
+  }
+  if (unscoped && levels.includes('ALL')) {
     formError.value = 'that would hide everything — add a mask, channel, or text pattern.';
     return null;
   }

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -7,67 +7,210 @@
   <section id="ignores" class="settings-pane">
     <h2>ignores</h2>
     <p class="section-desc">
-      Ignore rules match by nick/hostmask (<code>nick!user@host</code> with
-      <code>*</code> wildcards), and can be scoped to channels, message text, and event types
-      (joins, public, notices, …). The full options live in the <code>/ignore</code> command; this
-      list shows what's active and lets you remove entries to reveal the history again.
+      Ignore rules hide matching messages. A rule matches by nick/hostmask (<code
+        >nick!user@host</code
+      >
+      with <code>*</code> wildcards) and can be narrowed to specific channels, message text, and
+      event types. Rules are <strong>global</strong> by default; scope one to a single network if
+      you only want it there. Everything here is also available through the
+      <code>/ignore</code> command.
     </p>
+
+    <p v-if="formError" class="error inline">{{ formError }}</p>
+
     <p v-if="!ignoreGroups.length" class="muted small">
-      No ignores yet. Right-click a nick in the member list, or type
+      No ignores yet. Add one below, right-click a nick in the member list, or type
       <code>/ignore &lt;nick&gt;</code> in any buffer.
     </p>
-    <template v-for="group in ignoreGroups" :key="group.networkId">
-      <h3 class="subhead">{{ group.networkName }}</h3>
+
+    <template v-for="group in ignoreGroups" :key="group.key">
+      <h3 class="subhead">{{ group.name }}</h3>
       <ul class="device-list">
-        <li v-for="entry in group.masks" :key="entry.id" class="device">
-          <span class="ua">{{ entry.mask ?? '*' }}</span>
-          <span class="muted small ignore-detail">{{ describe(entry) }}</span>
-          <button class="link danger" @click="onIgnoreRemove(group.networkId, entry.id)">
-            remove
-          </button>
+        <li v-for="entry in group.entries" :key="entry.id" class="device">
+          <span class="ua">
+            {{ entry.mask ?? '*' }}
+            <span class="muted small ignore-detail">{{ describe(entry) }}</span>
+          </span>
+          <button class="link" @click="startEdit(entry)">edit</button>
+          <button class="link danger" @click="onRemove(entry)">remove</button>
         </li>
       </ul>
     </template>
-    <h3 v-if="ignoreNetworkOptions.length" class="subhead">add</h3>
-    <div class="rule-add" v-if="ignoreNetworkOptions.length">
-      <select v-model="newIgnoreNetworkId">
-        <option :value="null" disabled>network…</option>
-        <option v-for="opt in ignoreNetworkOptions" :key="opt.id" :value="opt.id">
-          {{ opt.name }}
-        </option>
-      </select>
-      <input
-        v-model="newIgnoreMask"
-        type="text"
-        placeholder="nick or nick!user@host"
-        spellcheck="false"
-        autocapitalize="off"
-        autocomplete="off"
-        @keydown.enter="onIgnoreAdd"
-      />
-      <button
-        class="link"
-        :disabled="!newIgnoreNetworkId || !newIgnoreMask.trim()"
-        @click="onIgnoreAdd"
-      >
-        add
-      </button>
+
+    <h3 class="subhead">{{ editing ? 'edit ignore' : 'add ignore' }}</h3>
+    <div class="rule-form">
+      <!-- Scope -->
+      <div class="field">
+        <span class="field-label">Scope</span>
+        <div class="row">
+          <div class="seg" role="radiogroup" aria-label="Scope">
+            <button
+              type="button"
+              role="radio"
+              :aria-checked="scopeMode === 'global'"
+              :class="{ active: scopeMode === 'global' }"
+              @click="scopeMode = 'global'"
+            >
+              Global
+            </button>
+            <button
+              type="button"
+              role="radio"
+              :aria-checked="scopeMode === 'network'"
+              :class="{ active: scopeMode === 'network' }"
+              :disabled="!networkOptions.length"
+              @click="selectNetworkScope"
+            >
+              One network
+            </button>
+          </div>
+          <select v-if="scopeMode === 'network'" v-model.number="scopeNetworkId">
+            <option v-for="opt in networkOptions" :key="opt.id" :value="opt.id">
+              {{ opt.name }}
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Who -->
+      <label class="field">
+        <span class="field-label"
+          >Mask <span class="muted small">(who — blank = anyone)</span></span
+        >
+        <input
+          v-model="form.mask"
+          type="text"
+          placeholder="nick or nick!user@host"
+          spellcheck="false"
+          autocapitalize="off"
+          autocomplete="off"
+        />
+      </label>
+
+      <!-- Where -->
+      <label class="field">
+        <span class="field-label"
+          >Channels <span class="muted small">(where — blank = all buffers)</span></span
+        >
+        <input
+          v-model="form.channels"
+          type="text"
+          placeholder="#chan #other (space-separated)"
+          spellcheck="false"
+          autocapitalize="off"
+          autocomplete="off"
+        />
+      </label>
+
+      <!-- What -->
+      <div class="field">
+        <span class="field-label"
+          >Message text <span class="muted small">(what — blank = any)</span></span
+        >
+        <div class="row">
+          <input
+            v-model="form.pattern"
+            type="text"
+            class="grow"
+            placeholder="text to match in the message"
+            spellcheck="false"
+          />
+          <select v-model="form.patternKind">
+            <option value="substr">contains</option>
+            <option value="full">whole word</option>
+            <option value="regex">regex</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Which (levels) -->
+      <div class="field">
+        <span class="field-label">Event types</span>
+        <div class="chips">
+          <button
+            type="button"
+            class="chip"
+            :class="{ active: useAll }"
+            :aria-pressed="useAll"
+            @click="selectAllLevels"
+          >
+            ALL
+          </button>
+          <button
+            v-for="lvl in GRANULAR_LEVELS"
+            :key="lvl"
+            type="button"
+            class="chip"
+            :class="{ active: !useAll && form.levels.includes(lvl) }"
+            :aria-pressed="!useAll && form.levels.includes(lvl)"
+            @click="toggleLevel(lvl)"
+          >
+            {{ lvl }}
+          </button>
+        </div>
+        <label class="ck">
+          <input v-model="form.noHighlight" type="checkbox" />
+          <span>Suppress highlights only (don't hide) — NOHIGHLIGHT</span>
+        </label>
+      </div>
+
+      <!-- Modifiers -->
+      <div class="field">
+        <span class="field-label">Options</span>
+        <label class="ck">
+          <input v-model="form.isExcept" type="checkbox" />
+          <span>Exception (whitelist — keep these even if another rule would hide them)</span>
+        </label>
+        <div class="row">
+          <span class="muted small expiry-label">Expires in</span>
+          <input
+            v-model="form.expiry"
+            type="text"
+            class="expiry"
+            placeholder="e.g. 7 days — blank = never"
+            spellcheck="false"
+          />
+        </div>
+        <p v-if="editing && editingExpiresAt" class="muted small">
+          Currently expires {{ formatWhen(editingExpiresAt) }}. Leave blank to remove the expiry, or
+          enter a new duration to reset it.
+        </p>
+      </div>
+
+      <div class="actions">
+        <button v-if="editing" class="link" @click="cancelEdit">cancel</button>
+        <button class="link" :disabled="!canSubmit" @click="submit">
+          {{ editing ? 'save' : 'add ignore' }}
+        </button>
+      </div>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, reactive, computed } from 'vue';
 import { useNetworksStore } from '../../stores/networks.js';
 import { useIgnoresStore, type IgnoreEntryWithNetwork } from '../../stores/ignores.js';
+import type { IgnoreRule } from '../../utils/ignoreMatch.js';
+import { durationToExpiry, type IgnorePatternKind } from '../../../../shared/parseIgnore.js';
+import { CANONICAL_ORDER } from '../../../../shared/ignoreLevels.js';
+
+// Granular event types for the chip row: every level except the special ALL,
+// the never-surfaced CTCPS, and NOHIGHLIGHT (its own modifier checkbox).
+const GRANULAR_LEVELS = CANONICAL_ORDER.filter(
+  (l) => l !== 'ALL' && l !== 'CTCPS' && l !== 'NOHIGHLIGHT',
+);
+
+const networksStore = useNetworksStore();
+const ignores = useIgnoresStore();
 
 interface IgnoreGroup {
-  networkId: number;
-  networkName: string;
-  masks: IgnoreEntryWithNetwork[];
+  key: string;
+  name: string;
+  entries: IgnoreEntryWithNetwork[];
 }
 
-// One-line summary of a rule's non-mask dimensions for the settings list.
+// One-line summary of a rule's non-mask dimensions for the list.
 function describe(entry: IgnoreEntryWithNetwork): string {
   const parts: string[] = [];
   if (entry.levels?.length) parts.push(entry.levels.join(','));
@@ -76,87 +219,303 @@ function describe(entry: IgnoreEntryWithNetwork): string {
     parts.push(entry.patternKind === 'regex' ? `/${entry.pattern}/` : `"${entry.pattern}"`);
   }
   if (entry.isExcept) parts.push('except');
-  if (entry.expiresAt) parts.push(`expires ${entry.expiresAt}`);
+  if (entry.expiresAt) parts.push(`expires ${formatWhen(entry.expiresAt)}`);
   return parts.join('  ');
 }
 
-interface NetworkOption {
-  id: number;
-  name: string;
+function formatWhen(iso: string): string {
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? iso : new Date(t).toLocaleString();
 }
 
-const networksStore = useNetworksStore();
-const ignoresStore = useIgnoresStore();
-
-// Per-network ignore lists, sorted by network name. Each entry is
-// { networkId, networkName, masks: [{mask, createdAt}, ...] }. We render
-// only networks that actually have entries (no empty groups); the add form
-// lets users pick any network they own.
+// Global group first (networkId null), then per-network groups sorted by name.
 const ignoreGroups = computed<IgnoreGroup[]>(() => {
+  const globals: IgnoreEntryWithNetwork[] = [];
   const byNet = new Map<number, IgnoreEntryWithNetwork[]>();
-  for (const entry of ignoresStore.allEntries) {
-    const list = byNet.get(entry.networkId);
-    if (list) list.push(entry);
-    else byNet.set(entry.networkId, [entry]);
+  for (const entry of ignores.allEntries) {
+    if (entry.networkId == null) {
+      globals.push(entry);
+    } else {
+      const list = byNet.get(entry.networkId);
+      if (list) list.push(entry);
+      else byNet.set(entry.networkId, [entry]);
+    }
   }
   const groups: IgnoreGroup[] = [];
-  for (const [networkId, masks] of byNet) {
-    groups.push({
-      networkId,
-      networkName: networksStore.networkById(networkId)?.name || `net:${networkId}`,
-      masks,
+  if (globals.length)
+    groups.push({ key: 'global', name: 'Global (all networks)', entries: globals });
+  const netGroups: IgnoreGroup[] = [];
+  for (const [networkId, entries] of byNet) {
+    netGroups.push({
+      key: `net:${networkId}`,
+      name: networksStore.networkById(networkId)?.name || `net:${networkId}`,
+      entries,
     });
   }
-  return groups.toSorted((a, b) => a.networkName.localeCompare(b.networkName));
+  netGroups.sort((a, b) => a.name.localeCompare(b.name));
+  return [...groups, ...netGroups];
 });
 
-const ignoreNetworkOptions = computed<NetworkOption[]>(() => {
-  return (networksStore.networks || [])
+const networkOptions = computed(() =>
+  (networksStore.networks || [])
     .map((n) => ({ id: n.id, name: n.name }))
-    .toSorted((a, b) => a.name.localeCompare(b.name));
-});
-
-const newIgnoreNetworkId = ref<number | null>(null);
-const newIgnoreMask = ref('');
-
-watch(
-  ignoreNetworkOptions,
-  (opts) => {
-    if (opts.length === 1) {
-      newIgnoreNetworkId.value = opts[0].id;
-    } else if (newIgnoreNetworkId.value && !opts.some((o) => o.id === newIgnoreNetworkId.value)) {
-      newIgnoreNetworkId.value = null;
-    }
-  },
-  { immediate: true },
+    .toSorted((a, b) => a.name.localeCompare(b.name)),
 );
 
-function onIgnoreAdd() {
-  const networkId = Number(newIgnoreNetworkId.value);
-  const mask = newIgnoreMask.value.trim();
-  if (!networkId || !mask) return;
-  ignoresStore.addMask(networkId, mask);
-  newIgnoreMask.value = '';
+// ---- form state ----
+const scopeMode = ref<'global' | 'network'>('global');
+const scopeNetworkId = ref<number | null>(null);
+const useAll = ref(true);
+const editing = ref<{ id: number; scope: number | null } | null>(null);
+const editingExpiresAt = ref<string | null>(null);
+const formError = ref('');
+
+const form = reactive({
+  mask: '',
+  channels: '',
+  pattern: '',
+  patternKind: 'substr' as IgnorePatternKind,
+  levels: [] as string[],
+  noHighlight: false,
+  isExcept: false,
+  expiry: '',
+});
+
+const canSubmit = computed(() => {
+  if (scopeMode.value === 'network' && !scopeNetworkId.value) return false;
+  // A non-except rule needs at least one dimension or a level selection to do
+  // anything; an except rule needs a mask to whitelist someone.
+  return true;
+});
+
+function selectNetworkScope() {
+  if (!networkOptions.value.length) return;
+  scopeMode.value = 'network';
+  if (!scopeNetworkId.value) scopeNetworkId.value = networkOptions.value[0].id;
 }
 
-function onIgnoreRemove(networkId: number, id: number) {
-  ignoresStore.removeRule(networkId, { id });
+function selectAllLevels() {
+  useAll.value = true;
+  form.levels = [];
+}
+
+function toggleLevel(lvl: string) {
+  useAll.value = false;
+  const i = form.levels.indexOf(lvl);
+  if (i >= 0) form.levels.splice(i, 1);
+  else form.levels.push(lvl);
+  // Never leave the rule with no hide levels (unless NOHIGHLIGHT-only) — fall
+  // back to ALL so an empty selection isn't an inert rule.
+  if (form.levels.length === 0 && !form.noHighlight) useAll.value = true;
+}
+
+function parseChannels(s: string): string[] | null {
+  const list = s
+    .split(/[\s,]+/)
+    .map((c) => c.trim().toLowerCase())
+    .filter(Boolean);
+  return list.length ? list : null;
+}
+
+function buildLevels(): string[] {
+  const out: string[] = useAll.value ? ['ALL'] : [...form.levels];
+  if (form.noHighlight) out.push('NOHIGHLIGHT');
+  return out.length ? out : ['ALL'];
+}
+
+function buildRule(): IgnoreRule | null {
+  formError.value = '';
+  let mask: string | null = form.mask.trim() || null;
+  if (mask === '*') mask = null;
+  const channels = parseChannels(form.channels);
+  const pattern = form.pattern.trim() || null;
+  const patternKind = form.patternKind;
+  if (pattern && patternKind === 'regex') {
+    try {
+      void new RegExp(pattern);
+    } catch (e) {
+      formError.value = `invalid regex: ${(e as Error).message}`;
+      return null;
+    }
+  }
+  const levels = buildLevels();
+  // Guard the one footgun a GUI shouldn't make easy: a rule with no who/where/
+  // what AND ALL levels hides the entire feed. Broad-but-targeted rules (all
+  // notices, all joins on #chan) are fine.
+  if (!mask && !channels && !pattern && !form.isExcept && levels.includes('ALL')) {
+    formError.value = 'that would hide everything — add a mask, channel, or text pattern.';
+    return null;
+  }
+  let expiresAt: string | null = null;
+  const dur = form.expiry.trim();
+  if (dur) {
+    const iso = durationToExpiry(dur);
+    if (!iso) {
+      formError.value = `invalid duration: ${dur}`;
+      return null;
+    }
+    expiresAt = iso;
+  }
+  return { mask, channels, pattern, patternKind, levels, isExcept: form.isExcept, expiresAt };
+}
+
+function resetForm() {
+  form.mask = '';
+  form.channels = '';
+  form.pattern = '';
+  form.patternKind = 'substr';
+  form.levels = [];
+  form.noHighlight = false;
+  form.isExcept = false;
+  form.expiry = '';
+  useAll.value = true;
+  editing.value = null;
+  editingExpiresAt.value = null;
+}
+
+function startEdit(entry: IgnoreEntryWithNetwork) {
+  editing.value = { id: entry.id, scope: entry.networkId };
+  editingExpiresAt.value = entry.expiresAt ?? null;
+  form.mask = entry.mask ?? '';
+  form.channels = (entry.channels || []).join(' ');
+  form.pattern = entry.pattern ?? '';
+  form.patternKind = entry.patternKind;
+  form.isExcept = entry.isExcept;
+  form.expiry = '';
+  const lv = entry.levels || [];
+  useAll.value = lv.includes('ALL') || lv.every((l) => l === 'NOHIGHLIGHT');
+  form.levels = useAll.value ? [] : lv.filter((l) => l !== 'ALL' && l !== 'NOHIGHLIGHT');
+  form.noHighlight = lv.includes('NOHIGHLIGHT');
+  if (entry.networkId == null) {
+    scopeMode.value = 'global';
+  } else {
+    scopeMode.value = 'network';
+    scopeNetworkId.value = entry.networkId;
+  }
+  formError.value = '';
+}
+
+function cancelEdit() {
+  resetForm();
+  formError.value = '';
+}
+
+function submit() {
+  const rule = buildRule();
+  if (!rule) return;
+  const scope = scopeMode.value === 'network' ? scopeNetworkId.value : null;
+  if (scopeMode.value === 'network' && !scope) {
+    formError.value = 'choose a network';
+    return;
+  }
+  // Edit = remove the old rule (in its original scope) then add the new one.
+  if (editing.value) ignores.removeRule(editing.value.scope, { id: editing.value.id });
+  ignores.addRule(scope, rule);
+  resetForm();
+}
+
+function onRemove(entry: IgnoreEntryWithNetwork) {
+  if (editing.value?.id === entry.id) cancelEdit();
+  ignores.removeRule(entry.networkId, { id: entry.id });
 }
 </script>
 
 <style src="./panes.css"></style>
 <style scoped>
-.rule-add {
+.ignore-detail {
+  margin-left: var(--space-3);
+}
+.device .ua {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.rule-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding-top: var(--space-3);
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.field-label {
+  color: var(--fg-muted);
+}
+.row {
   display: flex;
   align-items: center;
   gap: var(--space-4);
-  padding-top: var(--space-5);
 }
-.rule-add input[type='text'] {
+.grow {
   flex: 1;
-  min-width: 200px;
+  min-width: 0;
 }
-.ignore-detail {
-  margin-left: var(--space-3);
+.rule-form input[type='text'] {
+  background: var(--bg-soft);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-3);
+  font: inherit;
+}
+.seg {
+  display: flex;
+  gap: var(--space-2);
+}
+.seg button {
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-4);
+  font: inherit;
+  cursor: pointer;
+}
+.seg button.active {
+  color: var(--fg);
+  border-color: var(--accent);
+  outline: 1px solid var(--accent);
+}
+.seg button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.chip {
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  padding: var(--space-1) var(--space-3);
+  font: inherit;
+  cursor: pointer;
+}
+.chip.active {
+  color: var(--fg);
+  border-color: var(--accent);
+  outline: 1px solid var(--accent);
+}
+.ck {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.expiry-label {
+  min-width: 6em;
+}
+.expiry {
+  flex: 1;
+  min-width: 0;
+}
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-4);
+  padding-top: var(--space-2);
 }
 </style>

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -311,7 +311,7 @@ function applyEvent(event: any): void {
   }
 }
 
-function applySnapshot(snapshot: any[]): void {
+function applySnapshot(snapshot: any[], globalIgnores: any[] = []): void {
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
   const pins = usePinsStore();
@@ -323,7 +323,7 @@ function applySnapshot(snapshot: any[]): void {
   pins.applySnapshot(snapshot);
   nicklistCollapse.applySnapshot(snapshot);
   channelNotify.applySnapshot(snapshot);
-  ignores.applySnapshot(snapshot);
+  ignores.applySnapshot(snapshot, globalIgnores);
   nickNotes.applySnapshot(snapshot);
   for (const net of snapshot) {
     for (const ch of net.channels) {
@@ -376,7 +376,7 @@ function handleMessage(raw: string): void {
   }
 
   if (payload.kind === 'snapshot') {
-    applySnapshot(payload.networks);
+    applySnapshot(payload.networks, payload.globalIgnores || []);
     return;
   }
   if (payload.kind === 'backlog') {

--- a/vue_client/src/stores/ignores.test.ts
+++ b/vue_client/src/stores/ignores.test.ts
@@ -92,3 +92,48 @@ describe('ignores store — global vs network scope (#350)', () => {
     );
   });
 });
+
+describe('ignores store — matcher getters union global + network', () => {
+  it('evaluate hides senders matched by either a global or a network rule', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot(
+      [{ networkId: 1, ignoredMasks: [entry({ id: 2, mask: 'neto', levels: ['PUBLIC'] })] }],
+      [entry({ id: 1, mask: 'globo' })],
+    );
+    expect(s.evaluate(1, ctx('globo')).hide).toBe(true);
+    expect(s.evaluate(1, ctx('neto')).hide).toBe(true);
+    expect(s.evaluate(1, ctx('nobody')).hide).toBe(false);
+  });
+
+  it('isMessageHidden honors a global rule for message-shaped result rows', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot([{ networkId: 1, ignoredMasks: [] }], [entry({ id: 1, mask: 'spam' })]);
+    expect(s.isMessageHidden(1, { nick: 'spam', target: '#x', body: 'hi' })).toBe(true);
+    expect(s.isMessageHidden(1, { nick: 'ok', target: '#x', body: 'hi' })).toBe(false);
+    expect(s.isMessageHidden(1, { nick: null, target: '#x' })).toBe(false);
+  });
+
+  it('isIgnored and isMemberHidden see a whole-identity global rule', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot([{ networkId: 1, ignoredMasks: [] }], [entry({ id: 1, mask: 'troll' })]);
+    expect(s.isIgnored(1, 'troll', '')).toBe(true);
+    expect(s.isMemberHidden(1, 'troll', null, '#x')).toBe(true);
+    expect(s.isMemberHidden(1, 'friend', null, '#x')).toBe(false);
+  });
+
+  it('removeRule / removeMask / addMask route to the socket with the right scope', () => {
+    const s = useIgnoresStore();
+    s.removeRule(null, { id: 9 });
+    expect(h.socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'remove-ignore', networkId: null, id: 9 }),
+    );
+    s.removeMask(3, 'bob');
+    expect(h.socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'remove-ignore', networkId: 3, mask: 'bob' }),
+    );
+    s.addMask(null, 'eve');
+    expect(h.socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'add-ignore', networkId: null, mask: 'eve' }),
+    );
+  });
+});

--- a/vue_client/src/stores/ignores.test.ts
+++ b/vue_client/src/stores/ignores.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+// The store only reaches the socket for mutations — mock it so we exercise the
+// store's own logic (global∪network union, snapshot/update routing, allEntries).
+const h = vi.hoisted(() => ({ socketSend: vi.fn<(payload: unknown) => void>() }));
+vi.mock('../composables/useSocket.js', () => ({ socketSend: h.socketSend }));
+
+import { useIgnoresStore, type IgnoreEntry } from './ignores.js';
+import type { IgnoreInput } from '../utils/ignoreMatch.js';
+
+function entry(over: Partial<IgnoreEntry> = {}): IgnoreEntry {
+  return {
+    id: 1,
+    mask: 'x',
+    channels: null,
+    pattern: null,
+    patternKind: 'substr',
+    levels: ['ALL'],
+    isExcept: false,
+    expiresAt: null,
+    createdAt: '',
+    ...over,
+  };
+}
+
+const ctx = (nick: string): IgnoreInput => ({
+  nick,
+  userhost: null,
+  target: '#x',
+  text: '',
+  type: 'message',
+  isDm: false,
+});
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  h.socketSend.mockClear();
+});
+
+describe('ignores store — global vs network scope (#350)', () => {
+  it('a global rule hides on every network; a network rule only on its own', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot(
+      [
+        { networkId: 1, ignoredMasks: [] },
+        { networkId: 2, ignoredMasks: [] },
+      ],
+      [entry({ id: 1, mask: 'globe' })],
+    );
+    expect(s.isHidden(1, ctx('globe'))).toBe(true);
+    expect(s.isHidden(2, ctx('globe'))).toBe(true);
+
+    s.applyUpdate(1, [entry({ id: 2, mask: 'localonly' })]);
+    expect(s.isHidden(1, ctx('localonly'))).toBe(true);
+    expect(s.isHidden(2, ctx('localonly'))).toBe(false);
+    // The global rule still applies on network 1 alongside its own rule.
+    expect(s.isHidden(1, ctx('globe'))).toBe(true);
+  });
+
+  it('applyUpdate(null) replaces the global bucket and re-unions on read', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot([{ networkId: 1, ignoredMasks: [] }], [entry({ id: 1, mask: 'a' })]);
+    expect(s.isHidden(1, ctx('a'))).toBe(true);
+    s.applyUpdate(null, []);
+    expect(s.isHidden(1, ctx('a'))).toBe(false);
+  });
+
+  it('allEntries lists globals with networkId null plus per-network entries', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot(
+      [{ networkId: 5, ignoredMasks: [entry({ id: 2, mask: 'net' })] }],
+      [entry({ id: 1, mask: 'glob' })],
+    );
+    const all = s.allEntries;
+    expect(all).toContainEqual(expect.objectContaining({ id: 1, mask: 'glob', networkId: null }));
+    expect(all).toContainEqual(expect.objectContaining({ id: 2, mask: 'net', networkId: 5 }));
+  });
+
+  it('addRule routes scope onto the wire (null = global, number = network)', () => {
+    const s = useIgnoresStore();
+    s.addRule(null, entry({ mask: 'g' }));
+    expect(h.socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'add-ignore', networkId: null }),
+    );
+    s.addRule(7, entry({ mask: 'n' }));
+    expect(h.socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'add-ignore', networkId: 7 }),
+    );
+  });
+});

--- a/vue_client/src/stores/ignores.ts
+++ b/vue_client/src/stores/ignores.ts
@@ -12,12 +12,17 @@ import {
   type IgnoreVerdict,
 } from '../utils/ignoreMatch.js';
 
-// Per-network ignore rules (issue #301). Server is the source of truth — adds/
-// removes ship over WS and the server fans an `ignore-list-updated` event to
-// every session (cross-device sync). Filtering happens client-side in
-// MessageList's renderRows computed, so /unignore reveals previously-hidden rows
-// without a backlog reload. Each entry is a full irssi-style rule (mask /
-// channels / pattern / levels / except / expiry); ignoreMatch.ts evaluates it.
+// Ignore rules (issue #301; global-vs-network scoping #350). Server is the
+// source of truth — adds/removes ship over WS and the server fans an
+// `ignore-list-updated` event to every session (cross-device sync). Filtering
+// happens client-side in MessageList's renderRows computed, so /unignore reveals
+// previously-hidden rows without a backlog reload. Each entry is a full
+// irssi-style rule (mask / channels / pattern / levels / except / expiry).
+//
+// Two buckets: `global` rules apply on every network (the default), `byNetwork`
+// rules are scoped to one. The effective set for a network is global ∪ that
+// network's rules — every matcher getter unions them, and the merge is compiled
+// once and cached so the render hot path stays cheap.
 
 export interface IgnoreEntry extends IgnoreRule {
   id: number;
@@ -25,15 +30,15 @@ export interface IgnoreEntry extends IgnoreRule {
 }
 
 export interface IgnoreEntryWithNetwork extends IgnoreEntry {
-  networkId: number;
+  // null = a global rule (applies on every network); a number scopes it to one.
+  networkId: number | null;
 }
 
 type Compiled = ReturnType<typeof compileIgnoreRules>;
 
 // Compile lazily, keyed by the entry-array identity. applySnapshot/applyUpdate
 // assign fresh arrays, so a replaced list misses the cache and recompiles; old
-// arrays are GC'd. No manual invalidation, and reads of byNetwork[networkId]
-// keep render-time computeds reactive.
+// arrays are GC'd.
 const compiledCache = new WeakMap<object, Compiled>();
 function compiledFor(list: IgnoreEntry[]): Compiled {
   let c = compiledCache.get(list);
@@ -44,30 +49,57 @@ function compiledFor(list: IgnoreEntry[]): Compiled {
   return c;
 }
 
+// Stable empty array so a network with no own rules keeps a constant identity
+// (otherwise the merge cache below would miss on every call).
+const EMPTY: IgnoreEntry[] = [];
+
+// The merged (global ∪ network) compiled set, memoized per network. Invalidates
+// only when either source array's identity changes — which is exactly when the
+// server pushes a new list — so steady-state reads are a Map lookup + two ===.
+const mergedCache = new Map<number, { g: IgnoreEntry[]; n: IgnoreEntry[]; c: Compiled }>();
+function mergedCompiled(globalList: IgnoreEntry[], netList: IgnoreEntry[], key: number): Compiled {
+  const hit = mergedCache.get(key);
+  if (hit && hit.g === globalList && hit.n === netList) return hit.c;
+  let c: Compiled;
+  if (globalList.length === 0) c = compiledFor(netList);
+  else if (netList.length === 0) c = compiledFor(globalList);
+  else c = [...compiledFor(globalList), ...compiledFor(netList)];
+  mergedCache.set(key, { g: globalList, n: netList, c });
+  return c;
+}
+
 export const useIgnoresStore = defineStore('ignores', {
   state: () => ({
     byNetwork: {} as Record<number | string, IgnoreEntry[]>,
+    global: [] as IgnoreEntry[],
   }),
   getters: {
+    // A network's own (network-scoped) rules, excluding globals — used by the
+    // settings pane's per-network grouping and the /ignore command listing.
     masksFor: (state) => (networkId: number | string) =>
-      state.byNetwork[networkId] || state.byNetwork[Number(networkId)] || [],
+      state.byNetwork[networkId] || state.byNetwork[Number(networkId)] || EMPTY,
 
     // The hot path called from MessageList. networkId may be a number or string
-    // depending on call site (Vue templates often stringify keys).
+    // depending on call site (Vue templates often stringify keys). Unions the
+    // global rules with this network's.
     evaluate:
       (state) =>
       (networkId: number | string, ctx: IgnoreInput): IgnoreVerdict => {
-        const list = state.byNetwork[networkId] || state.byNetwork[Number(networkId)] || [];
-        if (list.length === 0) return { hide: false, nohilight: false };
-        return evaluateIgnores(compiledFor(list), ctx);
+        const nid = Number(networkId);
+        const net = state.byNetwork[nid] || EMPTY;
+        const g = state.global;
+        if (g.length === 0 && net.length === 0) return { hide: false, nohilight: false };
+        return evaluateIgnores(mergedCompiled(g, net, nid), ctx);
       },
 
     isHidden:
       (state) =>
       (networkId: number | string, ctx: IgnoreInput): boolean => {
-        const list = state.byNetwork[networkId] || state.byNetwork[Number(networkId)] || [];
-        if (list.length === 0) return false;
-        return evaluateIgnores(compiledFor(list), ctx).hide;
+        const nid = Number(networkId);
+        const net = state.byNetwork[nid] || EMPTY;
+        const g = state.global;
+        if (g.length === 0 && net.length === 0) return false;
+        return evaluateIgnores(mergedCompiled(g, net, nid), ctx).hide;
       },
 
     // Full-context "is this message hidden?" for surfaces that hold the message
@@ -90,9 +122,11 @@ export const useIgnoresStore = defineStore('ignores', {
         },
       ): boolean => {
         if (!m.nick) return false;
-        const list = state.byNetwork[networkId] || state.byNetwork[Number(networkId)] || [];
-        if (list.length === 0) return false;
-        return evaluateIgnores(compiledFor(list), {
+        const nid = Number(networkId);
+        const net = state.byNetwork[nid] || EMPTY;
+        const g = state.global;
+        if (g.length === 0 && net.length === 0) return false;
+        return evaluateIgnores(mergedCompiled(g, net, nid), {
           nick: m.nick,
           userhost: m.userhost ?? null,
           target: m.target,
@@ -111,9 +145,11 @@ export const useIgnoresStore = defineStore('ignores', {
     isIgnored:
       (state) =>
       (networkId: number | string, nick: string, userhost: string): boolean => {
-        const list = state.byNetwork[networkId] || state.byNetwork[Number(networkId)] || [];
-        if (list.length === 0) return false;
-        return isMemberHidden(compiledFor(list), nick, userhost || null, '');
+        const nid = Number(networkId);
+        const net = state.byNetwork[nid] || EMPTY;
+        const g = state.global;
+        if (g.length === 0 && net.length === 0) return false;
+        return isMemberHidden(mergedCompiled(g, net, nid), nick, userhost || null, '');
       },
 
     // Nicklist filter — only whole-identity ALL rules remove a member (see
@@ -126,13 +162,18 @@ export const useIgnoresStore = defineStore('ignores', {
         userhost: string | null,
         channel: string,
       ): boolean => {
-        const list = state.byNetwork[networkId] || state.byNetwork[Number(networkId)] || [];
-        if (list.length === 0) return false;
-        return isMemberHidden(compiledFor(list), nick, userhost, channel);
+        const nid = Number(networkId);
+        const net = state.byNetwork[nid] || EMPTY;
+        const g = state.global;
+        if (g.length === 0 && net.length === 0) return false;
+        return isMemberHidden(mergedCompiled(g, net, nid), nick, userhost, channel);
       },
 
+    // Every rule for the settings pane. Globals come first with networkId null
+    // (the pane renders them under a "Global" group); per-network rules follow.
     allEntries: (state): IgnoreEntryWithNetwork[] => {
       const out: IgnoreEntryWithNetwork[] = [];
+      for (const entry of state.global) out.push({ ...entry, networkId: null });
       for (const [networkId, list] of Object.entries(state.byNetwork)) {
         for (const entry of list || []) out.push({ ...entry, networkId: Number(networkId) });
       }
@@ -140,37 +181,43 @@ export const useIgnoresStore = defineStore('ignores', {
     },
   },
   actions: {
-    applySnapshot(networks: any[]) {
+    applySnapshot(networks: any[], globalIgnores: IgnoreEntry[] = []) {
       const next: Record<number | string, IgnoreEntry[]> = {};
       for (const n of networks || []) {
         if (n?.networkId != null) next[n.networkId] = [...(n.ignoredMasks || [])];
       }
       this.byNetwork = next;
+      this.global = [...(globalIgnores || [])];
     },
-    applyUpdate(networkId: number | string, masks: IgnoreEntry[]) {
-      if (!networkId) return;
-      this.byNetwork[networkId] = [...(masks || [])];
+    // networkId null targets the global bucket; a number targets that network.
+    applyUpdate(networkId: number | string | null, masks: IgnoreEntry[]) {
+      if (networkId == null) {
+        this.global = [...(masks || [])];
+      } else {
+        this.byNetwork[networkId] = [...(masks || [])];
+      }
     },
-    // Add a full rule (from the /ignore parser). The server re-validates.
-    addRule(networkId: number | string, rule: IgnoreRule) {
-      if (!networkId) return;
+    // Add a full rule (from the /ignore parser). networkId null = global (the
+    // default); a number scopes it to that network. The server re-validates.
+    addRule(networkId: number | null, rule: IgnoreRule) {
       socketSend({ type: 'add-ignore', networkId, rule });
     },
-    // Remove by id (from the listed index) or by mask string.
-    removeRule(networkId: number | string, by: { id?: number; mask?: string }) {
-      if (!networkId) return;
+    // Remove by id (from the listed index) or by mask string. networkId is the
+    // scope for by-mask removal (server clears globals + that network); for
+    // by-id it just routes the fanned-out list back to the right bucket.
+    removeRule(networkId: number | null, by: { id?: number; mask?: string }) {
       if (by.id == null && !by.mask) return;
       socketSend({ type: 'remove-ignore', networkId, id: by.id, mask: by.mask });
     },
     // Shim for the quick-ignore modal, which only knows a mask: an ALL-level
-    // rule. The server expands a bare `mask` the same way.
-    addMask(networkId: number | string, mask: string) {
+    // rule. The server expands a bare `mask` the same way. Defaults to global.
+    addMask(networkId: number | null, mask: string) {
       const trimmed = (mask || '').trim();
-      if (!networkId || !trimmed) return;
+      if (!trimmed) return;
       socketSend({ type: 'add-ignore', networkId, mask: trimmed });
     },
     // Remove every rule matching a bare mask string (server deletes by mask).
-    removeMask(networkId: number | string, mask: string) {
+    removeMask(networkId: number | null, mask: string) {
       const trimmed = (mask || '').trim();
       if (!trimmed) return;
       this.removeRule(networkId, { mask: trimmed });


### PR DESCRIPTION
Closes #350.

## What

Overhauls the ignore system on both axes the card raises.

**1. Global-by-default scoping.** Ignore rules used to be hard-wired per-network. They're now **global by default** (apply on every network); `network_id` is nullable, where `NULL` = global. Opt into one-network scope with `/ignore -network …`, the quick-ignore modal's scope toggle, or the settings panel.
- `getCompiled(user, network)` unions the network's own rules with the user's globals; a global change invalidates every per-network compiled cache.
- Migration (schema v11) rebuilds `ignored_masks` to drop the `NOT NULL` on `network_id`. **Existing rows keep their `network_id`** — they stay network-scoped, nothing silently becomes global.

**2. Feature-complete settings panel.** `IgnoresPane` was "add a mask + delete one row." It now has full `/ignore` parity: scope, channels, content pattern + kind (contains/whole-word/regex), event-type level chips, NOHIGHLIGHT, exception/whitelist, expiry, and **edit**. It builds the same rule object the parser produces and sends it via the shared `addRule` path — one core, two front-ends (per #353), not a parallel implementation.

## Notes
- The shared matcher (`shared/ignoreMatch.ts`) is unchanged — scope is purely a storage/query/sync concern.
- `/ignore` and `/unignore` now list and resolve globals alongside the current network's rules (globals tagged `[global]`); `/unignore <mask>` clears matching globals + this network's.
- The panel reuses the parser's `durationToExpiry`, so `-time` and the form compute expiry identically.
- Quick-ignore modal now defaults to global with a scope toggle.

## Tests
- DB: global-scope listing, scope-aware dedupe, `removeByMask` spanning globals + a network.
- Service: global-rule cache invalidation across networks; network-scoped rule stays local.
- Parser: `-network`/`-global` flag.
- Client store: global∪network union, snapshot/update routing, `allEntries` grouping.
- Green: 849 server tests + 4 client store tests; server+client typecheck, lint, oxfmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)