### PR TITLE
1.0.3: fix /list modal (#335) + Firefox composer autosize (#336)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@simplewebauthn/server": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -266,30 +266,31 @@ const text = computed({
   },
 });
 // Firefox (desktop + mobile) doesn't support CSS `field-sizing: content` (#336),
-// so the native content-driven grow leaves the composer stuck at rows="1". Fall
-// back to a JS measure-and-set there; Chrome/Safari keep the native single-pass
-// path untouched (autosize() no-ops when field-sizing is supported).
+// so the native content-driven grow leaves the composer stuck at rows="1". Wire
+// a JS measure-and-set fallback ONLY where it's needed — Chrome/Safari keep the
+// native single-pass path and register nothing, so there's no per-keystroke
+// microtask on the browsers that don't need it.
 const supportsFieldSizing =
   typeof CSS !== 'undefined' &&
   typeof CSS.supports === 'function' &&
   CSS.supports('field-sizing', 'content');
 
-function autosizeInput(): void {
-  if (supportsFieldSizing) return;
-  const el = inputEl.value;
-  if (!el) return;
-  // Reset, then lock to the content height — done synchronously so the browser
-  // never paints the transient one-row state. CSS max-height + overflow-y:auto
-  // cap growth at 16 rows and scroll beyond it.
-  el.style.height = 'auto';
-  el.style.height = `${el.scrollHeight}px`;
+if (!supportsFieldSizing) {
+  const autosizeInput = (): void => {
+    const el = inputEl.value;
+    if (!el) return;
+    // Reset, then lock to the content height — done synchronously so the browser
+    // never paints the transient one-row state. CSS max-height + overflow-y:auto
+    // cap growth at 16 rows and scroll beyond it.
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  };
+  // Re-measure whenever the visible text changes — typing (the v-model setter),
+  // programmatic edits (history recall, send-clear), and buffer switches that
+  // swap in a different draft (the getter changes without firing the setter).
+  watch(text, () => nextTick(autosizeInput));
+  onMounted(() => nextTick(autosizeInput));
 }
-
-// Re-measure whenever the visible text changes — typing (the v-model setter),
-// programmatic edits (history recall, send-clear), and buffer switches that swap
-// in a different draft (the getter changes without firing the setter).
-watch(text, () => nextTick(autosizeInput));
-onMounted(() => nextTick(autosizeInput));
 
 const buffer = computed(() =>
   active.value ? buffers.byKey(`${active.value.networkId}::${active.value.target}`) : null,

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -123,7 +123,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount, onMounted } from 'vue';
+import { ref, computed, watch, onBeforeUnmount, onMounted, nextTick } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useAuthStore } from '../stores/auth.js';
@@ -135,6 +135,8 @@ import { useToastsStore } from '../stores/toasts.js';
 import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
 import { parseIgnoreArgs } from '../../../shared/parseIgnore.js';
 import { useWhoisStore } from '../stores/whois.js';
+import { useChanlistStore } from '../stores/chanlist.js';
+import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
 import { requestScrollToBottom } from '../composables/useScrollState.js';
 import { setComposingState } from '../composables/useComposing.js';
@@ -181,6 +183,8 @@ const settings = useSettingsStore();
 const uploads = useUploadsStore();
 const toasts = useToastsStore();
 const ignores = useIgnoresStore();
+const chanlist = useChanlistStore();
+const channelListModal = useChannelListModal();
 const nickColors = useNickColors();
 
 // The ignore rules visible from this network, in /ignore-listing order: globals
@@ -261,6 +265,32 @@ const text = computed({
     onInput();
   },
 });
+// Firefox (desktop + mobile) doesn't support CSS `field-sizing: content` (#336),
+// so the native content-driven grow leaves the composer stuck at rows="1". Fall
+// back to a JS measure-and-set there; Chrome/Safari keep the native single-pass
+// path untouched (autosize() no-ops when field-sizing is supported).
+const supportsFieldSizing =
+  typeof CSS !== 'undefined' &&
+  typeof CSS.supports === 'function' &&
+  CSS.supports('field-sizing', 'content');
+
+function autosizeInput(): void {
+  if (supportsFieldSizing) return;
+  const el = inputEl.value;
+  if (!el) return;
+  // Reset, then lock to the content height — done synchronously so the browser
+  // never paints the transient one-row state. CSS max-height + overflow-y:auto
+  // cap growth at 16 rows and scroll beyond it.
+  el.style.height = 'auto';
+  el.style.height = `${el.scrollHeight}px`;
+}
+
+// Re-measure whenever the visible text changes — typing (the v-model setter),
+// programmatic edits (history recall, send-clear), and buffer switches that swap
+// in a different draft (the getter changes without firing the setter).
+watch(text, () => nextTick(autosizeInput));
+onMounted(() => nextTick(autosizeInput));
+
 const buffer = computed(() =>
   active.value ? buffers.byKey(`${active.value.networkId}::${active.value.target}`) : null,
 );
@@ -2071,11 +2101,16 @@ function handleCommand(line: string, networkId: number, target: string): boolean
         localInfo(networkId, target, `/reconnect failed: ${err.message || 'could not reconnect'}`);
       });
       return true;
-    case 'list':
-      return sendOrToast(
-        { type: 'raw', networkId, line: argLine ? `LIST ${argLine}` : 'LIST' },
-        line,
-      );
+    case 'list': {
+      // Open the channel-list browser (the same surface as the network context
+      // menu) rather than piping a raw LIST into the buffer (#335). The modal
+      // self-fetches on open; an argument pre-seeds its filter via the chanlist
+      // store, which the modal reads as its initial query.
+      const q = argLine.trim();
+      if (q) chanlist.setQuery(networkId, q);
+      channelListModal.open(networkId);
+      return true;
+    }
     case 'ignore': {
       // No-arg form: dump the ignore rules visible here (globals + this
       // network's) into the active buffer as system messages, with an index for


### PR DESCRIPTION
A small point release on the road to 1.1.0 — two bug fixes from the milestone plus the version bump.

## Fixes

**#335 — `/list` no longer opens the channel list modal.** The `/list` command was sending a raw `LIST` line, which streamed results into the chanlist store but never opened the modal (matching the "opening in the background, just doesn't appear" report). It now calls `channelListModal.open(networkId)` — the same path as the network context menu — and the modal self-fetches on open. `/list <filter>` pre-seeds the modal's filter via the chanlist store.

**#336 — Firefox composer stuck at one line.** The textarea auto-grows via CSS `field-sizing: content`, which Firefox (desktop + mobile) doesn't support, so it never grew past `rows="1"`. Added a JS measure-and-set fallback gated on `CSS.supports('field-sizing', 'content')` — only Firefox runs it; Chrome/Safari keep the native single-pass path untouched. It re-measures on every visible text change (typing, history recall, send-clear, and buffer switches that swap in a different draft).

## Version
Bumped 1.0.2 → 1.0.3 across root + client `package.json` and both lockfiles.

## Verification
Typecheck, lint, and oxfmt all clean. Both fixes are browser/DOM behavior best confirmed by QA — the `/list` modal opening, and the Firefox composer growing line-by-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)