### PR TITLE
Slash-command foundation: quote-aware tokenizer + column formatter

### DIFF
--- a/vue_client/src/lib/commands/output.test.ts
+++ b/vue_client/src/lib/commands/output.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { formatColumns } from './output.js';
+
+describe('formatColumns', () => {
+  it('returns an empty array for no rows', () => {
+    expect(formatColumns([])).toEqual([]);
+  });
+
+  it('pads each column to its widest cell and leaves no trailing whitespace', () => {
+    const out = formatColumns([
+      ['Libera', 'irc.libera.chat', 'connected'],
+      ['OFTC', 'irc.oftc.net', 'off'],
+    ]);
+    expect(out).toEqual(['Libera  irc.libera.chat  connected', 'OFTC    irc.oftc.net     off']);
+    for (const line of out) expect(line).toBe(line.replace(/\s+$/, ''));
+  });
+
+  it('honors a custom gap between columns', () => {
+    expect(
+      formatColumns(
+        [
+          ['a', 'b'],
+          ['cc', 'd'],
+        ],
+        1,
+      ),
+    ).toEqual(['a  b', 'cc d']);
+  });
+
+  it('handles ragged rows by treating missing cells as empty', () => {
+    expect(formatColumns([['key', 'value'], ['lonely']])).toEqual(['key     value', 'lonely']);
+  });
+
+  it('does not pad a single-column grid', () => {
+    expect(formatColumns([['alpha'], ['b']])).toEqual(['alpha', 'b']);
+  });
+});

--- a/vue_client/src/lib/commands/output.test.ts
+++ b/vue_client/src/lib/commands/output.test.ts
@@ -37,4 +37,14 @@ describe('formatColumns', () => {
   it('does not pad a single-column grid', () => {
     expect(formatColumns([['alpha'], ['b']])).toEqual(['alpha', 'b']);
   });
+
+  it('emits no trailing whitespace when the final cell is empty', () => {
+    expect(formatColumns([['a', '']])).toEqual(['a']);
+    expect(
+      formatColumns([
+        ['key', 'value'],
+        ['empty', ''],
+      ]),
+    ).toEqual(['key    value', 'empty']);
+  });
 });

--- a/vue_client/src/lib/commands/output.ts
+++ b/vue_client/src/lib/commands/output.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared formatters for command output that lands in the system buffer (#355).
+// Command handlers turn their results into plain strings here, then hand each
+// line to the SFC's localInfo() helper (a synthetic, non-persisted `motd`
+// line). Keeping the formatting pure — no store, no Vue — means it unit-tests
+// in isolation and stays consistent across commands.
+//
+// Consumed by the list-style output of /network (#356) and /set, /get (#357).
+
+/**
+ * Render a grid of cells as space-aligned, fixed-width text rows, sizing each
+ * column to its widest cell so they line up under the UI's monospace font.
+ *
+ * The final cell of each row is never padded, so there's no trailing
+ * whitespace. Ragged rows (differing column counts) are fine — missing cells
+ * are treated as empty.
+ *
+ * @param rows  one string[] per line; each entry is a column cell
+ * @param gap   spaces between columns (default 2)
+ */
+export function formatColumns(rows: string[][], gap = 2): string[] {
+  if (!rows.length) return [];
+
+  const colCount = Math.max(...rows.map((r) => r.length));
+  const widths: number[] = [];
+  for (let c = 0; c < colCount; c++) {
+    widths[c] = Math.max(0, ...rows.map((r) => (r[c] ?? '').length));
+  }
+
+  const sep = ' '.repeat(Math.max(0, gap));
+  return rows.map((row) => {
+    const last = row.length - 1;
+    return row.map((cell, c) => (c === last ? cell : cell.padEnd(widths[c]))).join(sep);
+  });
+}

--- a/vue_client/src/lib/commands/output.ts
+++ b/vue_client/src/lib/commands/output.ts
@@ -32,6 +32,10 @@ export function formatColumns(rows: string[][], gap = 2): string[] {
   const sep = ' '.repeat(Math.max(0, gap));
   return rows.map((row) => {
     const last = row.length - 1;
-    return row.map((cell, c) => (c === last ? cell : cell.padEnd(widths[c]))).join(sep);
+    const line = row.map((cell, c) => (c === last ? cell : cell.padEnd(widths[c]))).join(sep);
+    // An empty (or short) final cell still gets a separator in front of it, so
+    // strip any trailing spaces to keep the no-trailing-whitespace promise —
+    // e.g. [['a', '']] would otherwise format to 'a  '.
+    return line.replace(/ +$/, '');
   });
 }

--- a/vue_client/src/lib/commands/tokenize.test.ts
+++ b/vue_client/src/lib/commands/tokenize.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { tokenizeArgs } from './tokenize.js';
+
+describe('tokenizeArgs', () => {
+  it('splits on runs of whitespace', () => {
+    expect(tokenizeArgs('a b c')).toEqual(['a', 'b', 'c']);
+    expect(tokenizeArgs('  a \t b\n c  ')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty array for empty or whitespace-only input', () => {
+    expect(tokenizeArgs('')).toEqual([]);
+    expect(tokenizeArgs('   ')).toEqual([]);
+  });
+
+  it('keeps double- and single-quoted spans together', () => {
+    expect(tokenizeArgs('-name "Libera Chat" -host irc.libera.chat')).toEqual([
+      '-name',
+      'Libera Chat',
+      '-host',
+      'irc.libera.chat',
+    ]);
+    expect(tokenizeArgs("add 'My Network' x")).toEqual(['add', 'My Network', 'x']);
+  });
+
+  it('joins a quoted span to the surrounding token', () => {
+    expect(tokenizeArgs('-x"a b"y')).toEqual(['-xa by']);
+  });
+
+  it('treats an empty quoted string as a real empty token', () => {
+    // irssi uses '' to clear a value (e.g. -sasl_mechanism '').
+    expect(tokenizeArgs("-sasl_mechanism '' irc")).toEqual(['-sasl_mechanism', '', 'irc']);
+  });
+
+  it('preserves a quote of the other kind inside a quoted span', () => {
+    expect(tokenizeArgs(`-realname "O'Brien"`)).toEqual(['-realname', "O'Brien"]);
+    expect(tokenizeArgs(`-autosendcmd 'msg "hi there"'`)).toEqual([
+      '-autosendcmd',
+      'msg "hi there"',
+    ]);
+  });
+
+  it('honors backslash escapes', () => {
+    expect(tokenizeArgs('a\\ b')).toEqual(['a b']);
+    expect(tokenizeArgs('"a\\"b"')).toEqual(['a"b']);
+    expect(tokenizeArgs('a\\\\b')).toEqual(['a\\b']);
+  });
+
+  it('is lenient about an unterminated quote', () => {
+    expect(tokenizeArgs('-name "Libera Chat')).toEqual(['-name', 'Libera Chat']);
+  });
+
+  it('preserves a font-family stack as one value', () => {
+    expect(tokenizeArgs(`look.font.family "'Input Mono', ui-monospace, monospace"`)).toEqual([
+      'look.font.family',
+      "'Input Mono', ui-monospace, monospace",
+    ]);
+  });
+});

--- a/vue_client/src/lib/commands/tokenize.ts
+++ b/vue_client/src/lib/commands/tokenize.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Quote-aware argument tokenizer for slash commands. The historical dispatcher
+// splits on bare whitespace (`line.split(/\s+/)`), which can't carry values
+// that contain spaces — a network name like "Libera Chat", an autosendcmd
+// script, or a font-family stack. This mirrors the shell-ish parsing irssi uses
+// for its /network option args: single- and double-quoted spans group, and a
+// backslash escapes the next character verbatim.
+//
+// Pure and dependency-free so it unit-tests outside the Vue SFC. Shared by the
+// upcoming /network (#356) and /set, /get (#357) commands.
+
+const WHITESPACE = new Set([' ', '\t', '\n', '\r']);
+
+/**
+ * Split a command's argument string into tokens, honoring quotes and escapes.
+ *
+ * - Runs of whitespace separate tokens.
+ * - A `'` or `"` opens a quoted span; whitespace inside it is preserved and the
+ *   span joins the surrounding token (so `-x"a b"` is one token `-xa b`).
+ * - `\` escapes the following character (`\"`, `\'`, `\ `, `\\`) literally.
+ * - An empty quoted string (`""`) is a real, empty token.
+ * - An unterminated quote is lenient: the remainder becomes the final token.
+ */
+export function tokenizeArgs(argLine: string): string[] {
+  const tokens: string[] = [];
+  let cur = '';
+  let inToken = false;
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < argLine.length; i++) {
+    const ch = argLine[i];
+
+    if (ch === '\\' && i + 1 < argLine.length) {
+      cur += argLine[i + 1];
+      inToken = true;
+      i++;
+      continue;
+    }
+
+    if (quote) {
+      if (ch === quote) quote = null;
+      else cur += ch;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      // Opening a quote starts a token even if the span turns out empty, so a
+      // bare "" survives as a deliberate empty argument.
+      inToken = true;
+      continue;
+    }
+
+    if (WHITESPACE.has(ch)) {
+      if (inToken) {
+        tokens.push(cur);
+        cur = '';
+        inToken = false;
+      }
+      continue;
+    }
+
+    cur += ch;
+    inToken = true;
+  }
+
+  if (inToken) tokens.push(cur);
+  return tokens;
+}


### PR DESCRIPTION
## What

The shared foundation for the slash-command-first direction (#353): two pure, unit-tested primitives that the upcoming `/network` (#356) and `/set` / `/get` (#357) commands build on.

- **`tokenizeArgs()`** (`lib/commands/tokenize.ts`) — quote- and escape-aware argument splitter, replacing the dispatcher's naive `line.split(/\s+/)`. Keeps spaced values intact: `"Libera Chat"`, single/double quotes, backslash escapes, irssi's `''`-to-clear idiom, and a font-family stack as a single token.
- **`formatColumns()`** (`lib/commands/output.ts`) — aligned column formatter for list-style output that lands in the system buffer (`/network list`, `/set` key listings). Sizes each column to its widest cell, no trailing whitespace, ragged rows OK.

## Why now

This is PR 1 of 3. Both commands need the same quote-aware arg parsing and the same system-buffer output convention, so the shared bits land first as their own small reviewable unit. PRs 2 (`/network`) and 3 (`/set` / `/get`) consume these.

## Tests / verification

- 14 unit tests across `tokenize.test.ts` + `output.test.ts` — all passing
- `typecheck:client`, `lint`, `format:check` (oxfmt) all clean

No runtime importer yet by design — the tests are the exercise; the dispatcher wiring arrives with `/network`.

Refs #353, #356, #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)