### PR TITLE
/network: manage networks from the input bar (#356)

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -124,8 +124,10 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount, onMounted, nextTick } from 'vue';
-import { useNetworksStore } from '../stores/networks.js';
+import { useNetworksStore, type Network } from '../stores/networks.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
+import { parseNetworkCommand } from '../lib/commands/network.js';
+import { formatColumns } from '../lib/commands/output.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
@@ -1888,6 +1890,12 @@ const COMMANDS_LINES = [
   '      LEVELS: ALL PUBLIC MSGS NOTICES ACTIONS JOINS PARTS QUITS NICKS KICKS MODES TOPICS NOHIGHLIGHT',
   '      e.g. /ignore bob NOHIGHLIGHT   ·   /ignore -network -regexp -pattern (foo|bar) #chan',
   '  /unignore <index|mask> — remove an ignore (index from /ignore list)',
+  '  /network [list]        — manage networks (alias: /net); runs from the system buffer',
+  '      add [-host <addr>] [-port <n>] [-tls|-notls] [-nick <n>] [-user <u>] [-realname <name>]',
+  '          [-sasl_username <u>] [-sasl_password <p>] [-password <serverpass>]',
+  "          [-autosendcmd '<cmds>'] [-channel <#chan>] [-auto|-noauto] <name>",
+  '      modify <name> [-flags…]   ·   remove <name>   ·   move <name> <position>',
+  '      connect <name>   ·   disconnect <name>   (Lurker folds irssi /server into these)',
   '  /raw <line>            — send a raw IRC line (alias: /quote)',
   '  /commands              — this list',
   '  //text                 — send literal "/text" as a message (escape)',
@@ -2039,6 +2047,105 @@ function runUnignore(argLine: string, networkId: number | null, target: string):
   return true;
 }
 
+// Resolve a /network ref to a configured network. Prefer a case-insensitive
+// name match (folds inconsistent server casing like the rest of the app), then
+// fall back to a numeric id so `/network connect 3` works too.
+function resolveNetwork(nameOrId: string): Network | null {
+  const lower = nameOrId.toLowerCase();
+  const byName = networks.networks.find((n) => n.name.toLowerCase() === lower);
+  if (byName) return byName;
+  const id = Number(nameOrId);
+  return Number.isInteger(id) ? networks.networkById(id) : null;
+}
+
+// Render the configured networks as an aligned table into the system buffer.
+function listNetworks(networkId: number | null, target: string): void {
+  const list = networks.networks;
+  if (!list.length) {
+    localInfo(
+      networkId,
+      target,
+      'no networks configured — /network add -host <address> -nick <nick> <name>',
+    );
+    return;
+  }
+  const rows = [
+    ['#', 'NAME', 'ADDRESS', 'NICK', 'STATE'],
+    ...list.map((n, i) => [
+      String(i + 1),
+      n.name,
+      `${n.host}:${n.port}${n.tls ? ' (tls)' : ''}`,
+      n.nick,
+      networks.states[n.id]?.state ?? 'off',
+    ]),
+  ];
+  for (const line of formatColumns(rows)) localInfo(networkId, target, line);
+}
+
+// Move a network to a 1-based position by rebuilding the full id order and
+// handing it to reorder() — the same store action the drag-to-reorder UI uses.
+async function moveNetwork(net: Network, position: number): Promise<void> {
+  const ids = networks.networks.map((n) => n.id).filter((id) => id !== net.id);
+  ids.splice(Math.min(position - 1, ids.length), 0, net.id);
+  await networks.reorder(ids);
+}
+
+// /network — manage IRC networks from the input bar, driving the same store as
+// the Settings → Networks pane (#356, slash-command-first per #353). It's
+// network-agnostic (runs from the system buffer); output lands in the buffer the
+// command came from. Store writes are async, so — like ackedSend — we kick them
+// off and report success/failure via localInfo when they settle.
+async function runNetwork(
+  argLine: string,
+  networkId: number | null,
+  target: string,
+): Promise<void> {
+  const cmd = parseNetworkCommand(argLine);
+  const reply = (msg: string) => localInfo(networkId, target, msg);
+
+  if (cmd.kind === 'error') return reply(`/network: ${cmd.message}`);
+  if (cmd.kind === 'list') return listNetworks(networkId, target);
+
+  if (cmd.kind === 'add') {
+    try {
+      const net = await networks.create({ ...cmd.input, name: cmd.name } as Partial<Network>);
+      const tls = cmd.input.tls ? ' (tls)' : '';
+      // create() is an explicit "save & connect" server-side, so it dials now.
+      reply(`added ${net.name} — ${cmd.input.host}:${cmd.input.port}${tls}, connecting…`);
+    } catch (err) {
+      reply(`/network add failed: ${err instanceof Error ? err.message : 'unknown error'}`);
+    }
+    return;
+  }
+
+  // Everything else acts on an existing network — resolve it up front so a typo
+  // gives a clean "no network matching" instead of a raw 404.
+  const net = resolveNetwork(cmd.ref);
+  if (!net) return reply(`/network: no network matching "${cmd.ref}"`);
+
+  try {
+    switch (cmd.kind) {
+      case 'modify':
+        await networks.update(net.id, cmd.input as Partial<Network>);
+        return reply(`updated ${net.name}`);
+      case 'remove':
+        await networks.remove(net.id);
+        return reply(`removed ${net.name}`);
+      case 'connect':
+        await networks.connect(net.id);
+        return reply(`connecting to ${net.name}…`);
+      case 'disconnect':
+        await networks.disconnect(net.id);
+        return reply(`disconnecting from ${net.name}…`);
+      case 'move':
+        await moveNetwork(net, cmd.position);
+        return reply(`moved ${net.name} to position ${cmd.position}`);
+    }
+  } catch (err) {
+    reply(`/network ${cmd.kind} failed: ${err instanceof Error ? err.message : 'unknown error'}`);
+  }
+}
+
 function handleCommand(line: string, networkId: number | null, target: string): boolean {
   const [cmd, ...rest] = line.slice(1).split(/\s+/);
   const argLine = line.slice(1 + cmd.length).trim();
@@ -2063,6 +2170,13 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       return runIgnore(argLine, networkId, target);
     case 'unignore':
       return runUnignore(argLine, networkId, target);
+    case 'network':
+    case 'net':
+      // Network CRUD + connection control. REST-backed and async, so fire it
+      // off and let it report into the buffer when it settles; the command is
+      // "handled" the moment we recognize it. runNetwork catches its own errors.
+      void runNetwork(argLine, networkId, target);
+      return true;
   }
 
   // Everything else acts on a specific network/buffer.

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2084,10 +2084,14 @@ function listNetworks(networkId: number | null, target: string): void {
 
 // Move a network to a 1-based position by rebuilding the full id order and
 // handing it to reorder() — the same store action the drag-to-reorder UI uses.
-async function moveNetwork(net: Network, position: number): Promise<void> {
+// Returns the effective (clamped) 1-based position so the caller reports where
+// it actually landed, not the requested slot.
+async function moveNetwork(net: Network, position: number): Promise<number> {
   const ids = networks.networks.map((n) => n.id).filter((id) => id !== net.id);
-  ids.splice(Math.min(position - 1, ids.length), 0, net.id);
+  const index = Math.min(position - 1, ids.length);
+  ids.splice(index, 0, net.id);
   await networks.reorder(ids);
+  return index + 1;
 }
 
 // /network — manage IRC networks from the input bar, driving the same store as
@@ -2137,9 +2141,10 @@ async function runNetwork(
       case 'disconnect':
         await networks.disconnect(net.id);
         return reply(`disconnecting from ${net.name}…`);
-      case 'move':
-        await moveNetwork(net, cmd.position);
-        return reply(`moved ${net.name} to position ${cmd.position}`);
+      case 'move': {
+        const landed = await moveNetwork(net, cmd.position);
+        return reply(`moved ${net.name} to position ${landed}`);
+      }
     }
   } catch (err) {
     reply(`/network ${cmd.kind} failed: ${err instanceof Error ? err.message : 'unknown error'}`);

--- a/vue_client/src/lib/commands/network.test.ts
+++ b/vue_client/src/lib/commands/network.test.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { parseNetworkCommand } from './network.js';
+
+describe('parseNetworkCommand', () => {
+  it('treats no args and `list`/`ls` as a list', () => {
+    expect(parseNetworkCommand('')).toEqual({ kind: 'list' });
+    expect(parseNetworkCommand('   ')).toEqual({ kind: 'list' });
+    expect(parseNetworkCommand('list')).toEqual({ kind: 'list' });
+    expect(parseNetworkCommand('ls')).toEqual({ kind: 'list' });
+  });
+
+  describe('add', () => {
+    it('maps irssi-style flags onto the network payload', () => {
+      expect(
+        parseNetworkCommand(
+          'add -host irc.libera.chat -port 6697 -tls -nick mynick -user me ' +
+            `-realname "My Name" -sasl_username acct -sasl_password s3cr3t Libera`,
+        ),
+      ).toEqual({
+        kind: 'add',
+        name: 'Libera',
+        input: {
+          host: 'irc.libera.chat',
+          port: 6697,
+          tls: true,
+          nick: 'mynick',
+          username: 'me',
+          realname: 'My Name',
+          sasl_account: 'acct',
+          sasl_password: 's3cr3t',
+        },
+      });
+    });
+
+    it('defaults to TLS on 6697 when neither is given', () => {
+      const cmd = parseNetworkCommand('add -host irc.libera.chat -nick bob Libera');
+      expect(cmd).toMatchObject({ kind: 'add', input: { tls: true, port: 6697 } });
+    });
+
+    it('defaults to the plaintext port when -notls and no -port', () => {
+      const cmd = parseNetworkCommand('add -host irc.example.org -nick bob -notls Net');
+      expect(cmd).toMatchObject({ kind: 'add', input: { tls: false, port: 6667 } });
+    });
+
+    it('honors an explicit -port even with -notls', () => {
+      const cmd = parseNetworkCommand('add -host h -nick n -notls -port 7000 Net');
+      expect(cmd).toMatchObject({ kind: 'add', input: { tls: false, port: 7000 } });
+    });
+
+    it('maps a quoted multi-word network name', () => {
+      const cmd = parseNetworkCommand('add -host h -nick n "Libera Chat"');
+      expect(cmd).toMatchObject({ kind: 'add', name: 'Libera Chat' });
+    });
+
+    it('requires a name, a host, and a nick', () => {
+      expect(parseNetworkCommand('add -host h -nick n')).toMatchObject({ kind: 'error' });
+      expect(parseNetworkCommand('add -nick n Libera')).toEqual({
+        kind: 'error',
+        message: '/network add needs -host <address>',
+      });
+      expect(parseNetworkCommand('add -host h Libera')).toEqual({
+        kind: 'error',
+        message: '/network add needs -nick <nick>',
+      });
+    });
+
+    it('rejects an invalid port', () => {
+      expect(parseNetworkCommand('add -host h -nick n -port abc Net')).toEqual({
+        kind: 'error',
+        message: 'invalid port: abc',
+      });
+      expect(parseNetworkCommand('add -host h -nick n -port 99999 Net')).toMatchObject({
+        kind: 'error',
+      });
+    });
+
+    it('rejects conflicting tls flags', () => {
+      expect(parseNetworkCommand('add -host h -nick n -tls -notls Net')).toEqual({
+        kind: 'error',
+        message: 'cannot combine -tls and -notls',
+      });
+    });
+
+    it('rejects an unknown option', () => {
+      expect(parseNetworkCommand('add -host h -nick n -bogus x Net')).toEqual({
+        kind: 'error',
+        message: 'unknown option: -bogus',
+      });
+    });
+
+    it('errors when a value flag is missing its argument', () => {
+      expect(parseNetworkCommand('add -host h -nick')).toEqual({
+        kind: 'error',
+        message: '-nick needs a value',
+      });
+    });
+
+    it('flags an unquoted multi-word name as ambiguous', () => {
+      expect(parseNetworkCommand('add -host h -nick n Libera Chat')).toMatchObject({
+        kind: 'error',
+      });
+    });
+  });
+
+  describe('modify', () => {
+    it('parses a partial update by name', () => {
+      expect(parseNetworkCommand('modify Libera -nick newnick -notls')).toEqual({
+        kind: 'modify',
+        ref: 'Libera',
+        input: { nick: 'newnick', tls: false },
+      });
+    });
+
+    it('accepts `edit` as an alias', () => {
+      expect(parseNetworkCommand('edit Libera -port 6667')).toMatchObject({
+        kind: 'modify',
+        ref: 'Libera',
+        input: { port: 6667 },
+      });
+    });
+
+    it('errors when no changes are given', () => {
+      expect(parseNetworkCommand('modify Libera')).toEqual({
+        kind: 'error',
+        message: '/network modify Libera: no changes given',
+      });
+    });
+
+    it('rejects -channel on modify (create-only field)', () => {
+      expect(parseNetworkCommand('modify Libera -channel #foo')).toEqual({
+        kind: 'error',
+        message: '-channel can only be set when adding a network',
+      });
+    });
+  });
+
+  describe('remove / connect / disconnect', () => {
+    it('parses each with a single ref and supports remove aliases', () => {
+      expect(parseNetworkCommand('remove Libera')).toEqual({ kind: 'remove', ref: 'Libera' });
+      expect(parseNetworkCommand('rm Libera')).toEqual({ kind: 'remove', ref: 'Libera' });
+      expect(parseNetworkCommand('del 3')).toEqual({ kind: 'remove', ref: '3' });
+      expect(parseNetworkCommand('connect Libera')).toEqual({ kind: 'connect', ref: 'Libera' });
+      expect(parseNetworkCommand('disconnect Libera')).toEqual({
+        kind: 'disconnect',
+        ref: 'Libera',
+      });
+    });
+
+    it('requires a ref', () => {
+      expect(parseNetworkCommand('connect')).toEqual({
+        kind: 'error',
+        message: '/network connect needs a network name',
+      });
+    });
+  });
+
+  describe('move', () => {
+    it('parses a name and a 1-based position', () => {
+      expect(parseNetworkCommand('move Libera 1')).toEqual({
+        kind: 'move',
+        ref: 'Libera',
+        position: 1,
+      });
+    });
+
+    it('rejects a non-positive or non-integer position', () => {
+      expect(parseNetworkCommand('move Libera 0')).toMatchObject({ kind: 'error' });
+      expect(parseNetworkCommand('move Libera x')).toMatchObject({ kind: 'error' });
+    });
+
+    it('needs both a name and a position', () => {
+      expect(parseNetworkCommand('move Libera')).toMatchObject({ kind: 'error' });
+    });
+  });
+
+  it('errors on an unknown subcommand', () => {
+    expect(parseNetworkCommand('frobnicate Libera')).toMatchObject({ kind: 'error' });
+  });
+});

--- a/vue_client/src/lib/commands/network.test.ts
+++ b/vue_client/src/lib/commands/network.test.ts
@@ -98,6 +98,25 @@ describe('parseNetworkCommand', () => {
       });
     });
 
+    it('treats a following recognized flag as a missing value (-nick -tls)', () => {
+      expect(parseNetworkCommand('add -host h -nick -tls Libera')).toEqual({
+        kind: 'error',
+        message: '-nick needs a value',
+      });
+    });
+
+    it('still accepts a dash-leading value that is not a known flag', () => {
+      // odd-but-valid value, and irssi's bare `-` sentinel to clear a field
+      expect(parseNetworkCommand('add -host h -nick n -password -weird Net')).toMatchObject({
+        kind: 'add',
+        input: { server_password: '-weird' },
+      });
+      expect(parseNetworkCommand('add -host h -nick n -password - Net')).toMatchObject({
+        kind: 'add',
+        input: { server_password: '-' },
+      });
+    });
+
     it('flags an unquoted multi-word name as ambiguous', () => {
       expect(parseNetworkCommand('add -host h -nick n Libera Chat')).toMatchObject({
         kind: 'error',

--- a/vue_client/src/lib/commands/network.ts
+++ b/vue_client/src/lib/commands/network.ts
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Argument parser for the /network command (#356) — the slash-command front-end
+// for network management, sharing the networks store with the Settings →
+// Networks pane (one core, two front-ends per #353).
+//
+// The grammar follows irssi's /network option style (the way /ignore mirrors
+// irssi), e.g.
+//   /network add -host irc.libera.chat -tls -nick mynick Libera
+// with one deliberate divergence: irssi splits a network (identity: nick/SASL)
+// from a server (address: host/port/tls), one network → many servers. Lurker
+// collapses both into a single network row, so the address lives here and
+// connection control folds into `/network connect|disconnect` rather than a
+// separate /server command.
+//
+// This module is pure (no store, no Vue) so the grammar unit-tests in isolation;
+// the SFC's runNetwork() turns the parsed intent into store calls + system-buffer
+// output.
+
+import { tokenizeArgs } from './tokenize.js';
+
+/** The network fields a /network add|modify can set, post-mapping from flags. */
+export interface NetworkInput {
+  host?: string;
+  port?: number;
+  tls?: boolean;
+  nick?: string;
+  username?: string;
+  realname?: string;
+  sasl_account?: string;
+  sasl_password?: string;
+  server_password?: string;
+  connect_commands?: string;
+  default_channel?: string;
+  autoconnect?: boolean;
+}
+
+/** The parsed intent of a /network invocation. `error` carries a user message. */
+export type NetworkCommand =
+  | { kind: 'list' }
+  | { kind: 'add'; name: string; input: NetworkInput }
+  | { kind: 'modify'; ref: string; input: NetworkInput }
+  | { kind: 'remove'; ref: string }
+  | { kind: 'connect'; ref: string }
+  | { kind: 'disconnect'; ref: string }
+  | { kind: 'move'; ref: string; position: number }
+  | { kind: 'error'; message: string };
+
+// irssi-style options. Value flags consume the following token; bool flags
+// stand alone. `-user`/`-sasl_username` map onto Lurker's column names below.
+const VALUE_FLAGS = new Set([
+  'host',
+  'port',
+  'nick',
+  'user',
+  'realname',
+  'sasl_username',
+  'sasl_password',
+  'password',
+  'autosendcmd',
+  'channel',
+]);
+const BOOL_FLAGS = new Set(['tls', 'notls', 'auto', 'noauto']);
+
+interface Flags {
+  values: Record<string, string>;
+  bools: Set<string>;
+  positional: string[];
+  error?: string;
+}
+
+function parseFlags(tokens: string[]): Flags {
+  const values: Record<string, string> = {};
+  const bools = new Set<string>();
+  const positional: string[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    if (tok.startsWith('-') && tok.length > 1) {
+      const name = tok.slice(1).toLowerCase();
+      if (VALUE_FLAGS.has(name)) {
+        const val = tokens[i + 1];
+        if (val === undefined)
+          return { values, bools, positional, error: `-${name} needs a value` };
+        values[name] = val;
+        i++;
+      } else if (BOOL_FLAGS.has(name)) {
+        bools.add(name);
+      } else {
+        return { values, bools, positional, error: `unknown option: ${tok}` };
+      }
+    } else {
+      positional.push(tok);
+    }
+  }
+  return { values, bools, positional };
+}
+
+// Map parsed flags onto the network payload. Returns an error string for a
+// conflicting/invalid flag (e.g. -tls and -notls together, a bad port).
+function buildInput(flags: Flags): NetworkInput | { error: string } {
+  const { values, bools } = flags;
+  const input: NetworkInput = {};
+
+  if (values.host !== undefined) input.host = values.host;
+  if (values.nick !== undefined) input.nick = values.nick;
+  if (values.user !== undefined) input.username = values.user;
+  if (values.realname !== undefined) input.realname = values.realname;
+  if (values.sasl_username !== undefined) input.sasl_account = values.sasl_username;
+  if (values.sasl_password !== undefined) input.sasl_password = values.sasl_password;
+  if (values.password !== undefined) input.server_password = values.password;
+  if (values.autosendcmd !== undefined) input.connect_commands = values.autosendcmd;
+  if (values.channel !== undefined) input.default_channel = values.channel;
+
+  if (values.port !== undefined) {
+    const port = Number(values.port);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return { error: `invalid port: ${values.port}` };
+    }
+    input.port = port;
+  }
+
+  if (bools.has('tls') && bools.has('notls')) return { error: 'cannot combine -tls and -notls' };
+  if (bools.has('tls')) input.tls = true;
+  if (bools.has('notls')) input.tls = false;
+
+  if (bools.has('auto') && bools.has('noauto')) {
+    return { error: 'cannot combine -auto and -noauto' };
+  }
+  if (bools.has('auto')) input.autoconnect = true;
+  if (bools.has('noauto')) input.autoconnect = false;
+
+  return input;
+}
+
+// A single network name/ref. Names with spaces must be quoted, so a ref is
+// exactly one token; more than one is almost always a missing-quote mistake.
+function singleRef(positional: string[], verb: string): string | { error: string } {
+  if (!positional.length) return { error: `/network ${verb} needs a network name` };
+  if (positional.length > 1) {
+    return { error: `/network ${verb}: one network name (quote it if it contains spaces)` };
+  }
+  return positional[0];
+}
+
+export function parseNetworkCommand(argLine: string): NetworkCommand {
+  const tokens = tokenizeArgs(argLine);
+  if (!tokens.length) return { kind: 'list' };
+
+  const sub = tokens[0].toLowerCase();
+  const rest = tokens.slice(1);
+
+  switch (sub) {
+    case 'list':
+    case 'ls':
+      return { kind: 'list' };
+
+    case 'add': {
+      const flags = parseFlags(rest);
+      if (flags.error) return { kind: 'error', message: flags.error };
+      const name = singleRef(flags.positional, 'add');
+      if (typeof name !== 'string') return { kind: 'error', message: name.error };
+      const built = buildInput(flags);
+      if ('error' in built) return { kind: 'error', message: built.error };
+      // A merged network row needs an address to dial and a nick to dial as.
+      if (!built.host) return { kind: 'error', message: '/network add needs -host <address>' };
+      if (!built.nick) return { kind: 'error', message: '/network add needs -nick <nick>' };
+      // Default to TLS (and the matching well-known port) unless told otherwise,
+      // so a bare add doesn't silently produce a plaintext-on-6697 mismatch.
+      if (built.tls === undefined) built.tls = true;
+      if (built.port === undefined) built.port = built.tls ? 6697 : 6667;
+      return { kind: 'add', name, input: built };
+    }
+
+    case 'modify':
+    case 'edit': {
+      const flags = parseFlags(rest);
+      if (flags.error) return { kind: 'error', message: flags.error };
+      const ref = singleRef(flags.positional, 'modify');
+      if (typeof ref !== 'string') return { kind: 'error', message: ref.error };
+      const built = buildInput(flags);
+      if ('error' in built) return { kind: 'error', message: built.error };
+      // -channel sets a default/autojoin channel, which the server only wires up
+      // at create time; the update path ignores it. Reject rather than silently
+      // report a no-op success.
+      if (built.default_channel !== undefined) {
+        return { kind: 'error', message: '-channel can only be set when adding a network' };
+      }
+      if (!Object.keys(built).length) {
+        return { kind: 'error', message: `/network modify ${ref}: no changes given` };
+      }
+      return { kind: 'modify', ref, input: built };
+    }
+
+    case 'remove':
+    case 'rm':
+    case 'del':
+    case 'delete': {
+      const ref = singleRef(rest, 'remove');
+      if (typeof ref !== 'string') return { kind: 'error', message: ref.error };
+      return { kind: 'remove', ref };
+    }
+
+    case 'connect': {
+      const ref = singleRef(rest, 'connect');
+      if (typeof ref !== 'string') return { kind: 'error', message: ref.error };
+      return { kind: 'connect', ref };
+    }
+
+    case 'disconnect': {
+      const ref = singleRef(rest, 'disconnect');
+      if (typeof ref !== 'string') return { kind: 'error', message: ref.error };
+      return { kind: 'disconnect', ref };
+    }
+
+    case 'move': {
+      if (rest.length < 2) {
+        return { kind: 'error', message: '/network move <name> <position>' };
+      }
+      if (rest.length > 2) {
+        return {
+          kind: 'error',
+          message: '/network move: one name and one position (quote a name with spaces)',
+        };
+      }
+      const position = Number(rest[1]);
+      if (!Number.isInteger(position) || position < 1) {
+        return { kind: 'error', message: `invalid position: ${rest[1]} (1-based)` };
+      }
+      return { kind: 'move', ref: rest[0], position };
+    }
+
+    default:
+      return {
+        kind: 'error',
+        message: `unknown /network subcommand: ${sub} — try list, add, modify, remove, connect, disconnect, move`,
+      };
+  }
+}

--- a/vue_client/src/lib/commands/network.ts
+++ b/vue_client/src/lib/commands/network.ts
@@ -63,6 +63,10 @@ const VALUE_FLAGS = new Set([
 ]);
 const BOOL_FLAGS = new Set(['tls', 'notls', 'auto', 'noauto']);
 
+function isKnownFlag(name: string): boolean {
+  return VALUE_FLAGS.has(name) || BOOL_FLAGS.has(name);
+}
+
 interface Flags {
   values: Record<string, string>;
   bools: Set<string>;
@@ -80,8 +84,18 @@ function parseFlags(tokens: string[]): Flags {
       const name = tok.slice(1).toLowerCase();
       if (VALUE_FLAGS.has(name)) {
         const val = tokens[i + 1];
-        if (val === undefined)
+        // Treat a following *recognized* option as a missing value (e.g.
+        // `-nick -tls`) instead of silently swallowing it. A dash-leading value
+        // that isn't a known flag (an odd password, irssi's bare `-` sentinel)
+        // is still accepted — quote it if it collides with a real flag name.
+        const nextIsFlag =
+          val !== undefined &&
+          val.length > 1 &&
+          val.startsWith('-') &&
+          isKnownFlag(val.slice(1).toLowerCase());
+        if (val === undefined || nextIsFlag) {
           return { values, bools, positional, error: `-${name} needs a value` };
+        }
         values[name] = val;
         i++;
       } else if (BOOL_FLAGS.has(name)) {


### PR DESCRIPTION
Closes #356. PR 2 of 3 in the slash-command-first push (#353), built on the foundation from #364.

## What

`/network` (alias `/net`) brings full network management to the input bar / system buffer, driving the **same store** as the Settings → Networks pane — one core, two front-ends (per #353), no parallel implementation.

```
/network [list]                      list networks + connection state
/network add  [-flags…] <name>       create (and "save & connect")
/network modify <name> [-flags…]     partial update
/network remove <name>               delete
/network connect|disconnect <name>   connection control
/network move <name> <position>      reorder (1-based)
```

`add`/`modify` flags follow irssi's `/network` option grammar (the way `/ignore` mirrors irssi):
`-host -port -tls/-notls -nick -user -realname -sasl_username -sasl_password -password -autosendcmd -channel -auto/-noauto`. Names with spaces are quoted (`"Libera Chat"`); refs resolve case-insensitively by name or by id.

## Deliberate divergence from irssi (documented in help)

irssi splits a **network** (identity: nick/SASL/realname) from a **server** (address: host/port/tls), one network → many servers. Lurker collapses both into a single network row, so there's nothing for a `/server add` to add — connection control folds into `/network connect`/`disconnect`. (Issue #356 updated to match.)

## Design

- **Pure parser** (`lib/commands/network.ts`) turns the arg string into a typed `NetworkCommand` intent — all the flag/grammar fiddliness is here and unit-tested in isolation (the SFC can't be unit-tested due to the mkcert/vitest segfault).
- **`runNetwork()`** in `MessageInput.vue` maps the intent onto `networks` store actions (`create`/`update`/`remove`/`connect`/`disconnect`/`reorder`) and renders output via the foundation's `formatColumns()`. REST-backed, so it's fire-and-forget with results reported into the buffer when they settle (same shape as `ackedSend`).
- **Sensible defaults:** a bare `add` defaults to TLS on 6697 (avoids a silent plaintext-on-6697 mismatch); `-notls` with no `-port` uses 6667.
- **`-channel` is create-only** (the server's PATCH path ignores it) — rejected on `modify` rather than reporting a no-op success.

## QA (try it in the system buffer)

```
/network                                              → empty-state hint
/network add -host irc.libera.chat -nick yourmnick Libera
/network                                              → table: # NAME ADDRESS NICK STATE
/network modify Libera -nick othernick
/network disconnect Libera   /network connect Libera
/network move Libera 1
/network remove Libera
```
Error paths: missing `-host`/`-nick`, bad `-port`, `-tls -notls` together, unknown option, unknown network name.

## Tests / verification

- 22 unit tests in `network.test.ts` (grammar, flag mapping, defaults, every error path)
- Full suite green: **1119 tests** · `npm run check` (typecheck client+server, lint, format) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)