### PR TITLE
/set and /get over the settings registry (#357)

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2158,25 +2158,31 @@ async function runNetwork(
   }
 }
 
-// Edition-aware registry lookup: return the option only if it's visible in this
-// build (selfHostedOnly knobs are hidden in the hosted edition), so /set, /get,
-// and the listing expose exactly the same surface as the Settings panes (#357).
-function lookupSetting(key: string): SettingOption | null {
-  const opt = getOption(key);
-  if (!opt) return null;
-  return optionVisible(opt, { isNode: config.isNode }) ? opt : null;
+// Whether a registry option is exposed to /set, /get, and the listing — the
+// same surface the Settings UI shows. An option qualifies only if it lives under
+// a real sidebar category (this excludes internal keys whose category is
+// intentionally absent from CATEGORIES, e.g. system.timezone, which the client
+// auto-syncs) AND is visible in this edition (selfHostedOnly knobs are hidden in
+// the hosted build). Category *kind* is irrelevant: bespoke panes like
+// Notifications still own registry-backed keys, which belong in the surface.
+function settingExposed(opt: SettingOption): boolean {
+  return (
+    CATEGORIES.some((c) => c.id === opt.category) && optionVisible(opt, { isNode: config.isNode })
+  );
 }
 
-// /set with no value lists every visible registry key + current value, grouped
+function lookupSetting(key: string): SettingOption | null {
+  const opt = getOption(key);
+  return opt && settingExposed(opt) ? opt : null;
+}
+
+// /set with no value lists every exposed registry key + current value, grouped
 // by Settings category. Passkeys, push subscriptions, and drag-to-reorder stay
 // GUI-only by design (#357) — they aren't registry-driven, so they don't appear.
 function listSettings(networkId: number | null, target: string): void {
   localInfo(networkId, target, 'settings — /set <key> <value> to change, /get <key> to read:');
   for (const cat of CATEGORIES) {
-    if (cat.kind !== 'registry') continue;
-    const opts = REGISTRY.filter(
-      (o) => o.category === cat.id && optionVisible(o, { isNode: config.isNode }),
-    );
+    const opts = REGISTRY.filter((o) => o.category === cat.id && settingExposed(o));
     if (!opts.length) continue;
     localInfo(networkId, target, `${cat.label.toLowerCase()}:`);
     const rows = opts.map((o) => [`  ${o.key}`, formatSettingValue(o, settings.effective(o.key))]);

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -127,7 +127,11 @@ import { ref, computed, watch, onBeforeUnmount, onMounted, nextTick } from 'vue'
 import { useNetworksStore, type Network } from '../stores/networks.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { parseNetworkCommand } from '../lib/commands/network.js';
+import { splitSetArgs, coerceSettingValue, formatSettingValue } from '../lib/commands/settings.js';
 import { formatColumns } from '../lib/commands/output.js';
+import { REGISTRY, getOption, optionVisible, CATEGORIES } from '../utils/settingsRegistry.js';
+import type { SettingOption } from '../../../shared/settingsRegistry.js';
+import { useConfigStore } from '../stores/config.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
@@ -183,6 +187,7 @@ const auth = useAuthStore();
 const inputHistory = useInputHistoryStore();
 const drafts = useDraftStore();
 const settings = useSettingsStore();
+const config = useConfigStore();
 const uploads = useUploadsStore();
 const toasts = useToastsStore();
 const ignores = useIgnoresStore();
@@ -1896,6 +1901,8 @@ const COMMANDS_LINES = [
   "          [-autosendcmd '<cmds>'] [-channel <#chan>] [-auto|-noauto] <name>",
   '      modify <name> [-flags…]   ·   remove <name>   ·   move <name> <position>',
   '      connect <name>   ·   disconnect <name>   (Lurker folds irssi /server into these)',
+  '  /set <key> <value…>    — change a setting; /set (or /set ?) lists all keys',
+  '  /get <key>             — read a setting back (output in the system buffer)',
   '  /raw <line>            — send a raw IRC line (alias: /quote)',
   '  /commands              — this list',
   '  //text                 — send literal "/text" as a message (escape)',
@@ -2151,6 +2158,66 @@ async function runNetwork(
   }
 }
 
+// Edition-aware registry lookup: return the option only if it's visible in this
+// build (selfHostedOnly knobs are hidden in the hosted edition), so /set, /get,
+// and the listing expose exactly the same surface as the Settings panes (#357).
+function lookupSetting(key: string): SettingOption | null {
+  const opt = getOption(key);
+  if (!opt) return null;
+  return optionVisible(opt, { isNode: config.isNode }) ? opt : null;
+}
+
+// /set with no value lists every visible registry key + current value, grouped
+// by Settings category. Passkeys, push subscriptions, and drag-to-reorder stay
+// GUI-only by design (#357) — they aren't registry-driven, so they don't appear.
+function listSettings(networkId: number | null, target: string): void {
+  localInfo(networkId, target, 'settings — /set <key> <value> to change, /get <key> to read:');
+  for (const cat of CATEGORIES) {
+    if (cat.kind !== 'registry') continue;
+    const opts = REGISTRY.filter(
+      (o) => o.category === cat.id && optionVisible(o, { isNode: config.isNode }),
+    );
+    if (!opts.length) continue;
+    localInfo(networkId, target, `${cat.label.toLowerCase()}:`);
+    const rows = opts.map((o) => [`  ${o.key}`, formatSettingValue(o, settings.effective(o.key))]);
+    for (const line of formatColumns(rows)) localInfo(networkId, target, line);
+  }
+}
+
+// /set <key> <value> — coerce to the typed value and write through the same
+// store the Settings panes use. /set alone (or `?`) lists keys (#357).
+function runSet(argLine: string, networkId: number | null, target: string): void {
+  const reply = (msg: string) => localInfo(networkId, target, msg);
+  const args = splitSetArgs(argLine);
+  if (args.kind === 'list') return listSettings(networkId, target);
+  const opt = lookupSetting(args.key);
+  if (!opt) return reply(`/set: unknown setting "${args.key}" — /set lists available keys`);
+  if (args.kind === 'keyonly') {
+    return reply(`usage: /set ${opt.key} <value>  (or /get ${opt.key} to read it)`);
+  }
+  const coerced = coerceSettingValue(opt, args.rawValue);
+  if (!coerced.ok) return reply(`/set: ${coerced.error}`);
+  settings
+    .setValue(opt.key, coerced.value)
+    .then(() => reply(`set ${opt.key} = ${formatSettingValue(opt, coerced.value)}`))
+    .catch((err: unknown) =>
+      reply(`/set failed: ${err instanceof Error ? err.message : 'unknown error'}`),
+    );
+}
+
+// /get <key> — read a setting into the buffer, noting the default when changed.
+function runGet(argLine: string, networkId: number | null, target: string): void {
+  const reply = (msg: string) => localInfo(networkId, target, msg);
+  const key = argLine.trim().split(/\s+/)[0] ?? '';
+  if (!key) return reply('usage: /get <key>  (/set lists available keys)');
+  const opt = lookupSetting(key);
+  if (!opt) return reply(`/get: unknown setting "${key}" — /set lists available keys`);
+  reply(`${opt.key} = ${formatSettingValue(opt, settings.effective(opt.key))}`);
+  if (settings.isModified(opt.key)) {
+    reply(`  default: ${formatSettingValue(opt, opt.default)}`);
+  }
+}
+
 function handleCommand(line: string, networkId: number | null, target: string): boolean {
   const [cmd, ...rest] = line.slice(1).split(/\s+/);
   const argLine = line.slice(1 + cmd.length).trim();
@@ -2181,6 +2248,13 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // off and let it report into the buffer when it settles; the command is
       // "handled" the moment we recognize it. runNetwork catches its own errors.
       void runNetwork(argLine, networkId, target);
+      return true;
+    case 'set':
+      // Registry-wide setting writes (#357), app-scoped like the others.
+      runSet(argLine, networkId, target);
+      return true;
+    case 'get':
+      runGet(argLine, networkId, target);
       return true;
   }
 

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2208,10 +2208,13 @@ function runSet(argLine: string, networkId: number | null, target: string): void
 // /get <key> — read a setting into the buffer, noting the default when changed.
 function runGet(argLine: string, networkId: number | null, target: string): void {
   const reply = (msg: string) => localInfo(networkId, target, msg);
-  const key = argLine.trim().split(/\s+/)[0] ?? '';
-  if (!key) return reply('usage: /get <key>  (/set lists available keys)');
-  const opt = lookupSetting(key);
-  if (!opt) return reply(`/get: unknown setting "${key}" — /set lists available keys`);
+  const parts = argLine.trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return reply('usage: /get <key>  (/set lists available keys)');
+  // Reject extra tokens (parity with /network) so a missing-quote typo doesn't
+  // silently read just the first word.
+  if (parts.length > 1) return reply('usage: /get <key>  (one key at a time)');
+  const opt = lookupSetting(parts[0]);
+  if (!opt) return reply(`/get: unknown setting "${parts[0]}" — /set lists available keys`);
   reply(`${opt.key} = ${formatSettingValue(opt, settings.effective(opt.key))}`);
   if (settings.isModified(opt.key)) {
     reply(`  default: ${formatSettingValue(opt, opt.default)}`);

--- a/vue_client/src/lib/commands/settings.test.ts
+++ b/vue_client/src/lib/commands/settings.test.ts
@@ -8,7 +8,7 @@ import type { SettingOption } from '../../../../shared/settingsRegistry.js';
 // Minimal registry options for each type — keeps the coercion/format tests
 // independent of the real registry's contents.
 const base = { label: 'x', category: 'c', group: 'g', description: 'd' };
-const boolOpt = { ...base, key: 'a.bool', type: 'bool', default: false } as SettingOption;
+const boolOpt = { ...base, key: 'a.bool', type: 'bool', default: false } satisfies SettingOption;
 const intOpt = {
   ...base,
   key: 'a.int',
@@ -16,17 +16,22 @@ const intOpt = {
   min: 9,
   max: 32,
   default: 14,
-} as SettingOption;
+} satisfies SettingOption;
 const enumOpt = {
   ...base,
   key: 'a.enum',
   type: 'enum',
   choices: ['left', 'right'],
   default: 'left',
-} as SettingOption;
-const listOpt = { ...base, key: 'a.list', type: 'string-list', default: [] } as SettingOption;
-const strOpt = { ...base, key: 'a.str', type: 'string', default: '' } as SettingOption;
-const secretOpt = { ...base, key: 'a.secret', type: 'secret', default: '' } as SettingOption;
+} satisfies SettingOption;
+const listOpt = {
+  ...base,
+  key: 'a.list',
+  type: 'string-list',
+  default: [],
+} satisfies SettingOption;
+const strOpt = { ...base, key: 'a.str', type: 'string', default: '' } satisfies SettingOption;
+const secretOpt = { ...base, key: 'a.secret', type: 'secret', default: '' } satisfies SettingOption;
 
 describe('splitSetArgs', () => {
   it('treats empty and `?` as a list request', () => {

--- a/vue_client/src/lib/commands/settings.test.ts
+++ b/vue_client/src/lib/commands/settings.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { splitSetArgs, coerceSettingValue, formatSettingValue } from './settings.js';
+import type { SettingOption } from '../../../../shared/settingsRegistry.js';
+
+// Minimal registry options for each type — keeps the coercion/format tests
+// independent of the real registry's contents.
+const base = { label: 'x', category: 'c', group: 'g', description: 'd' };
+const boolOpt = { ...base, key: 'a.bool', type: 'bool', default: false } as SettingOption;
+const intOpt = {
+  ...base,
+  key: 'a.int',
+  type: 'int',
+  min: 9,
+  max: 32,
+  default: 14,
+} as SettingOption;
+const enumOpt = {
+  ...base,
+  key: 'a.enum',
+  type: 'enum',
+  choices: ['left', 'right'],
+  default: 'left',
+} as SettingOption;
+const listOpt = { ...base, key: 'a.list', type: 'string-list', default: [] } as SettingOption;
+const strOpt = { ...base, key: 'a.str', type: 'string', default: '' } as SettingOption;
+const secretOpt = { ...base, key: 'a.secret', type: 'secret', default: '' } as SettingOption;
+
+describe('splitSetArgs', () => {
+  it('treats empty and `?` as a list request', () => {
+    expect(splitSetArgs('')).toEqual({ kind: 'list' });
+    expect(splitSetArgs('   ')).toEqual({ kind: 'list' });
+    expect(splitSetArgs('?')).toEqual({ kind: 'list' });
+  });
+
+  it('returns keyonly when no value follows the key', () => {
+    expect(splitSetArgs('look.font.size')).toEqual({ kind: 'keyonly', key: 'look.font.size' });
+  });
+
+  it('takes the rest of the line as the value (no quoting needed)', () => {
+    expect(splitSetArgs('look.font.family Input Mono, ui-monospace')).toEqual({
+      kind: 'pair',
+      key: 'look.font.family',
+      rawValue: 'Input Mono, ui-monospace',
+    });
+  });
+
+  it('strips one layer of surrounding quotes', () => {
+    expect(splitSetArgs('k "a b c"')).toEqual({ kind: 'pair', key: 'k', rawValue: 'a b c' });
+    expect(splitSetArgs("k 'a b'")).toEqual({ kind: 'pair', key: 'k', rawValue: 'a b' });
+    // one-sided quote left intact
+    expect(splitSetArgs('k "a b')).toEqual({ kind: 'pair', key: 'k', rawValue: '"a b' });
+  });
+});
+
+describe('coerceSettingValue', () => {
+  it('coerces booleans from many spellings', () => {
+    for (const t of ['true', 'on', 'YES', '1']) {
+      expect(coerceSettingValue(boolOpt, t)).toEqual({ ok: true, value: true });
+    }
+    for (const f of ['false', 'off', 'No', '0']) {
+      expect(coerceSettingValue(boolOpt, f)).toEqual({ ok: true, value: false });
+    }
+    expect(coerceSettingValue(boolOpt, 'maybe')).toMatchObject({ ok: false });
+  });
+
+  it('coerces and range-checks integers', () => {
+    expect(coerceSettingValue(intOpt, '16')).toEqual({ ok: true, value: 16 });
+    expect(coerceSettingValue(intOpt, '8')).toMatchObject({ ok: false });
+    expect(coerceSettingValue(intOpt, '40')).toMatchObject({ ok: false });
+    expect(coerceSettingValue(intOpt, '1.5')).toMatchObject({ ok: false });
+    expect(coerceSettingValue(intOpt, 'abc')).toMatchObject({ ok: false });
+  });
+
+  it('validates enums against their choices', () => {
+    expect(coerceSettingValue(enumOpt, 'right')).toEqual({ ok: true, value: 'right' });
+    expect(coerceSettingValue(enumOpt, 'up')).toEqual({
+      ok: false,
+      error: 'a.enum must be one of: left, right',
+    });
+  });
+
+  it('splits string-lists on commas and trims, dropping empties', () => {
+    expect(coerceSettingValue(listOpt, 'a, b ,c,')).toEqual({ ok: true, value: ['a', 'b', 'c'] });
+    expect(coerceSettingValue(listOpt, '   ')).toEqual({ ok: true, value: [] });
+  });
+
+  it('passes strings, colors, and secrets through verbatim', () => {
+    expect(coerceSettingValue(strOpt, "'Input Mono', monospace")).toEqual({
+      ok: true,
+      value: "'Input Mono', monospace",
+    });
+    expect(coerceSettingValue(secretOpt, 'sk-123')).toEqual({ ok: true, value: 'sk-123' });
+  });
+});
+
+describe('formatSettingValue', () => {
+  it('masks secrets rather than revealing them', () => {
+    expect(formatSettingValue(secretOpt, 'sk-123')).toBe('(set)');
+    expect(formatSettingValue(secretOpt, '')).toBe('(unset)');
+  });
+
+  it('renders booleans, lists, and empties readably', () => {
+    expect(formatSettingValue(boolOpt, true)).toBe('true');
+    expect(formatSettingValue(listOpt, ['a', 'b'])).toBe('a, b');
+    expect(formatSettingValue(listOpt, [])).toBe('(empty)');
+    expect(formatSettingValue(strOpt, '')).toBe('(empty)');
+    expect(formatSettingValue(intOpt, 14)).toBe('14');
+  });
+});

--- a/vue_client/src/lib/commands/settings.ts
+++ b/vue_client/src/lib/commands/settings.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Argument parsing, coercion, and display for the /set and /get commands (#357)
+// — a single pair that operates over the whole settings registry, so the GUI
+// panes and the commands are two front-ends over one source (per #353). As
+// settings are added to the registry the commands cover them automatically.
+//
+// Pure (no store, no Vue): operates on a SettingOption handed in by the caller,
+// so it unit-tests in isolation. The SFC's runSet/runGet resolve the key against
+// the registry (respecting edition visibility) and apply via the settings store.
+
+import type { SettingOption, SettingValue } from '../../../../shared/settingsRegistry.js';
+
+const BOOL_TRUE = new Set(['true', 'on', 'yes', '1']);
+const BOOL_FALSE = new Set(['false', 'off', 'no', '0']);
+
+/** The shape of a /set invocation, before the key is resolved against the registry. */
+export type SetArgs =
+  | { kind: 'list' }
+  | { kind: 'pair'; key: string; rawValue: string }
+  | { kind: 'keyonly'; key: string };
+
+// Strip one layer of matching surrounding quotes, so `/set k "a b"` stores `a b`
+// rather than the quotes. A value that's only quoted on one side is left as-is.
+function stripQuotes(s: string): string {
+  if (s.length >= 2) {
+    const a = s[0];
+    const b = s[s.length - 1];
+    if ((a === '"' && b === '"') || (a === "'" && b === "'")) return s.slice(1, -1);
+  }
+  return s;
+}
+
+/**
+ * Parse the /set argument string into a shape. The value is "the rest of the
+ * line" after the key (irssi's /set convention), so spaces and commas need no
+ * quoting; an outer pair of quotes is stripped for the spaces-with-trim case.
+ *
+ * - empty or `?` → list all keys
+ * - `<key>` alone → keyonly (the caller reports usage / suggests /get)
+ * - `<key> <value…>` → pair
+ */
+export function splitSetArgs(argLine: string): SetArgs {
+  const trimmed = argLine.trim();
+  if (!trimmed || trimmed === '?') return { kind: 'list' };
+  const sp = trimmed.search(/\s/);
+  if (sp === -1) return { kind: 'keyonly', key: trimmed };
+  const key = trimmed.slice(0, sp);
+  const rawValue = stripQuotes(trimmed.slice(sp + 1).trim());
+  return { kind: 'pair', key, rawValue };
+}
+
+/** Coerce a raw string into the typed value a setting expects, per its type. */
+export function coerceSettingValue(
+  opt: SettingOption,
+  raw: string,
+): { ok: true; value: SettingValue } | { ok: false; error: string } {
+  switch (opt.type) {
+    case 'bool': {
+      const v = raw.trim().toLowerCase();
+      if (BOOL_TRUE.has(v)) return { ok: true, value: true };
+      if (BOOL_FALSE.has(v)) return { ok: true, value: false };
+      return { ok: false, error: `${opt.key} expects a boolean (on/off, true/false, yes/no, 1/0)` };
+    }
+    case 'int': {
+      const n = Number(raw.trim());
+      if (!Number.isInteger(n)) return { ok: false, error: `${opt.key} expects an integer` };
+      if (n < opt.min || n > opt.max) {
+        return { ok: false, error: `${opt.key} must be between ${opt.min} and ${opt.max}` };
+      }
+      return { ok: true, value: n };
+    }
+    case 'enum': {
+      if (!opt.choices.includes(raw)) {
+        return { ok: false, error: `${opt.key} must be one of: ${opt.choices.join(', ')}` };
+      }
+      return { ok: true, value: raw };
+    }
+    case 'string-list': {
+      const list = raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      return { ok: true, value: list };
+    }
+    case 'string':
+    case 'color':
+    case 'secret':
+      return { ok: true, value: raw };
+    default:
+      return { ok: false, error: `${(opt as SettingOption).key}: unsupported setting type` };
+  }
+}
+
+/**
+ * Render a setting's value for display in /get and the /set listing. Secrets are
+ * masked to `(set)`/`(unset)` so they never land in a buffer or input history;
+ * lists join with commas; empty strings/lists read as `(empty)`.
+ */
+export function formatSettingValue(opt: SettingOption, value: SettingValue | undefined): string {
+  if (opt.type === 'secret') {
+    return typeof value === 'string' && value.length > 0 ? '(set)' : '(unset)';
+  }
+  if (Array.isArray(value)) return value.length ? value.join(', ') : '(empty)';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (value === undefined) return '(unset)';
+  const s = String(value);
+  return s === '' ? '(empty)' : s;
+}

--- a/vue_client/src/lib/commands/settings.ts
+++ b/vue_client/src/lib/commands/settings.ts
@@ -88,8 +88,12 @@ export function coerceSettingValue(
     case 'color':
     case 'secret':
       return { ok: true, value: raw };
-    default:
-      return { ok: false, error: `${(opt as SettingOption).key}: unsupported setting type` };
+    default: {
+      // Compile-time exhaustiveness: add a SettingType without a case above and
+      // `opt` is no longer `never`, so this assignment fails to build.
+      const unhandled: never = opt;
+      return { ok: false, error: `${String(unhandled)}: unsupported setting type` };
+    }
   }
 }
 


### PR DESCRIPTION
Closes #357. PR 3 of 3 in the slash-command-first push (#353), built on the foundation from #364.

## What

A single command pair that operates over the **whole** settings registry — so the Settings panes and the input bar are two front-ends over one source (per #353), and new keys are covered automatically as the registry grows.

```
/set                   list every visible key + current value, grouped by category
/set ?                 (same)
/set <key> <value…>    coerce per the key's type and write via the settings store
/get <key>             read it back (notes the default when the value is modified)
```

Like irssi's `/set`, the value is "the rest of the line", so spaces and commas need no quoting (`/set look.font.family Input Mono, ui-monospace`); an outer pair of quotes is stripped.

## Coercion (mirrors the server's `validate()`)

- **bool** — `on/off`, `true/false`, `yes/no`, `1/0`
- **int** — parsed and range-checked against the registry `min`/`max`
- **enum** — validated against `choices` (the error lists them)
- **string-list** — comma-split, trimmed, empties dropped
- **string / color / secret** — verbatim

## Safety / parity

- **Secrets are masked** to `(set)`/`(unset)` in `/get` and the listing — they never print into a buffer.
- **Edition visibility honored** — `selfHostedOnly` knobs are hidden in the hosted edition, so the command surface matches what the GUI shows.
- **Deliberately GUI-only** (#357): passkeys/passwords, push subscriptions, and drag-to-reorder aren't registry-driven, so they don't appear here.

## Design

- Pure, unit-tested `lib/commands/settings.ts`: `splitSetArgs`, `coerceSettingValue`, `formatSettingValue` (operate on a `SettingOption` handed in — no store/Vue, testable in isolation).
- `runSet`/`runGet`/`listSettings` in `MessageInput.vue` resolve the key (respecting visibility), coerce, and write through `useSettingsStore`; list output uses the foundation's `formatColumns()`.

## QA (in the system buffer)

```
/set                                              → grouped listing
/get look.font.size                               → look.font.size = 14
/set look.font.size 18                            → set look.font.size = 18
/get look.font.size                               → 18  +  default: 14
/set look.font.size 99                            → error: must be between 9 and 32
/set chat.allow_split_messages on                 → set … = true
/set look.font.family 'Input Mono', ui-monospace, monospace
/get bogus.key                                    → unknown setting
/get                                              → usage hint
```

## Tests / verification

- 11 unit tests in `settings.test.ts` (shape parse, every-type coercion + ranges, secret masking)
- Full suite green: **1133 tests** · `npm run check` (typecheck client+server, lint, format) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)