### PR TITLE
Configurable default quit message (#324)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -6,7 +6,7 @@
 // at module-load time). Without this, the IrcConnections built in these tests
 // write straight into the real data/lurker.db.
 import '../test-utils/isolateDb.js';
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 import net from 'net';
 import { ircLineParser } from 'irc-framework';
 import type { ConnectOptions } from 'irc-framework';
@@ -26,6 +26,7 @@ import {
 } from './ircConnection.js';
 import { createIdentdServer, unregisterIdent } from './identd.js';
 import { createUser } from '../db/users.js';
+import { setUserSetting, deleteUserSetting } from '../db/settings.js';
 
 // The bare IrcConnections built below carry user_id: 1, and their join/part
 // handlers write system_messages (FK → users.id). Seed user id 1 in the
@@ -803,5 +804,62 @@ describe('built-in identd registration', () => {
     } finally {
       if (prev !== undefined) process.env.LURKER_IDENTD_ENABLED = prev;
     }
+  });
+});
+
+describe('disconnect quit message (#324)', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'nick',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  afterEach(() => deleteUserSetting(1, 'chat.quit_message'));
+
+  it('falls back to the built-in Lurker default when chat.quit_message is unset', () => {
+    const conn = makeConn();
+    const quit = vi.fn<(reason?: string) => void>();
+    conn.client.quit = quit;
+    conn.disconnect();
+    const reason = quit.mock.calls[0][0] ?? '';
+    expect(reason).toContain('Lurker');
+    expect(reason).toContain('https://lurker.chat');
+  });
+
+  it('uses the configured chat.quit_message when set', () => {
+    setUserSetting(1, 'chat.quit_message', 'bbl');
+    const conn = makeConn();
+    const quit = vi.fn<(reason?: string) => void>();
+    conn.client.quit = quit;
+    conn.disconnect();
+    expect(quit).toHaveBeenCalledWith('bbl');
+  });
+
+  it('lets an explicit reason override the configured message', () => {
+    setUserSetting(1, 'chat.quit_message', 'bbl');
+    const conn = makeConn();
+    const quit = vi.fn<(reason?: string) => void>();
+    conn.client.quit = quit;
+    conn.disconnect('see ya');
+    expect(quit).toHaveBeenCalledWith('see ya');
   });
 });

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -20,6 +20,7 @@ import highlightRulesService from './highlightRulesService.js';
 import ignoreRulesService from './ignoreRulesService.js';
 import { decideStamp } from './insertDecisions.js';
 import * as systemLog from './systemLog.js';
+import { effectiveSetting } from './settingsService.js';
 import { IRC_VERSION, APP_VERSION } from '../utils/userAgent.js';
 import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
@@ -2152,8 +2153,17 @@ export class IrcConnection {
     this.publishAwayState();
   }
 
-  disconnect(reason: string = DEFAULT_QUIT_MESSAGE): void {
-    this.client.quit(reason);
+  disconnect(reason?: string): void {
+    this.client.quit(reason ?? this.defaultQuitMessage());
+  }
+
+  // The QUIT reason for a clean disconnect when the caller gave none (the bare
+  // /quit command, auto-disconnect, shutdown): the user's configured
+  // chat.quit_message, or the built-in Lurker default when blank. Read here
+  // rather than baked into a const so APP_VERSION stays live in the fallback.
+  private defaultQuitMessage(): string {
+    const custom = effectiveSetting(this.network.user_id, 'chat.quit_message');
+    return typeof custom === 'string' && custom.trim() ? custom : DEFAULT_QUIT_MESSAGE;
   }
 
   dispose(reason: string = 'network removed'): void {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2159,8 +2159,10 @@ export class IrcConnection {
 
   // The QUIT reason for a clean disconnect when the caller gave none (the bare
   // /quit command, auto-disconnect, shutdown): the user's configured
-  // chat.quit_message, or the built-in Lurker default when blank. Read here
-  // rather than baked into a const so APP_VERSION stays live in the fallback.
+  // chat.quit_message, or the built-in Lurker default when blank. The built-in
+  // default stays a single source of truth here (DEFAULT_QUIT_MESSAGE, composed
+  // with APP_VERSION) instead of being duplicated as a static string in the
+  // registry — which is why the registry default is '' rather than the version line.
   private defaultQuitMessage(): string {
     const custom = effectiveSetting(this.network.user_id, 'chat.quit_message');
     return typeof custom === 'string' && custom.trim() ? custom : DEFAULT_QUIT_MESSAGE;

--- a/server/services/settingsService.test.ts
+++ b/server/services/settingsService.test.ts
@@ -11,12 +11,15 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-settings-servi
 process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 
 let settingsService: typeof SettingsServiceModule.default;
+let effectiveSetting: typeof SettingsServiceModule.effectiveSetting;
 let createUser: typeof import('../db/users.js').createUser;
 let user: ReturnType<typeof createUser>;
 
 beforeAll(async () => {
   ({ createUser } = await import('../db/users.js'));
-  settingsService = (await import('./settingsService.js')).default;
+  const mod = await import('./settingsService.js');
+  settingsService = mod.default;
+  effectiveSetting = mod.effectiveSetting;
   user = createUser('ss-alice');
 });
 
@@ -67,5 +70,20 @@ describe('reset', () => {
     const res = settingsService.reset(user.id, 'no.such.key');
     expect(res.ok).toBe(false);
     expect(!res.ok && res.error).toMatch(/unknown/);
+  });
+});
+
+describe('effectiveSetting', () => {
+  it('returns the registry default when unset and the override when set', () => {
+    const u = createUser('ss-effective');
+    // chat.quit_message defaults to '' (blank = built-in Lurker quit message).
+    expect(effectiveSetting(u.id, 'chat.quit_message')).toBe('');
+    settingsService.update(u.id, { 'chat.quit_message': 'gone fishing' });
+    expect(effectiveSetting(u.id, 'chat.quit_message')).toBe('gone fishing');
+  });
+
+  it('returns undefined for an unknown key', () => {
+    const u = createUser('ss-effective-2');
+    expect(effectiveSetting(u.id, 'no.such.key')).toBeUndefined();
   });
 });

--- a/server/services/settingsService.ts
+++ b/server/services/settingsService.ts
@@ -8,11 +8,15 @@ import { setUserSetting, deleteUserSetting, getUserSettings } from '../db/settin
 
 // Resolve a single setting's effective value for a user: their stored override,
 // or the registry default. For code paths outside the request cycle (e.g. the
-// IRC quit reason) that have no client-supplied value to fall back on.
+// IRC quit reason) that have no client-supplied value to fall back on. Unknown
+// keys return undefined; the own-property check avoids treating inherited
+// names (toString, etc.) as overrides.
 export function effectiveSetting(userId: number, key: string): SettingValue | undefined {
+  const opt = getOption(key);
+  if (!opt) return undefined;
   const stored = getUserSettings(userId);
-  if (key in stored) return stored[key] as SettingValue;
-  return getOption(key)?.default;
+  if (Object.prototype.hasOwnProperty.call(stored, key)) return stored[key] as SettingValue;
+  return opt.default;
 }
 
 function valuesEqual(a: SettingValue, b: SettingValue): boolean {

--- a/server/services/settingsService.ts
+++ b/server/services/settingsService.ts
@@ -6,6 +6,15 @@ import type { SettingValue } from '../../shared/settingsRegistry.js';
 import { validate, getOption } from './settingsRegistry.js';
 import { setUserSetting, deleteUserSetting, getUserSettings } from '../db/settings.js';
 
+// Resolve a single setting's effective value for a user: their stored override,
+// or the registry default. For code paths outside the request cycle (e.g. the
+// IRC quit reason) that have no client-supplied value to fall back on.
+export function effectiveSetting(userId: number, key: string): SettingValue | undefined {
+  const stored = getUserSettings(userId);
+  if (key in stored) return stored[key] as SettingValue;
+  return getOption(key)?.default;
+}
+
 function valuesEqual(a: SettingValue, b: SettingValue): boolean {
   if (a === b) return true;
   if (Array.isArray(a) && Array.isArray(b)) {

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -805,6 +805,20 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'of a new browser tab. Cmd/Ctrl-click always opens in a new tab.',
   },
 
+  // ─── Connection ───────────────────────────────────────────────────────
+  {
+    key: 'chat.quit_message',
+    label: 'Quit message',
+    category: 'chat',
+    group: 'connection',
+    type: 'string',
+    default: '',
+    description:
+      'The QUIT reason others see when you disconnect from a network and no ' +
+      'explicit /quit message is given. Leave blank to use the Lurker default ' +
+      '(the version and project URL).',
+  },
+
   // ─── Auto-away (sets you AWAY when no client is connected) ────────────
   {
     key: 'away.auto.enabled',
@@ -1353,6 +1367,7 @@ export const GROUPS: Readonly<Record<string, string>> = Object.freeze({
   consolidate: 'Join/part consolidation',
   composing: 'Composing',
   'smart-filter': 'Smart filter',
+  connection: 'Connection',
   'auto-away': 'Auto-away',
   provider: 'Provider',
   pipeline: 'Image pipeline',


### PR DESCRIPTION
Closes #324.

## What

The default QUIT reason was hard-locked to `Lurker <version> (the truth is out there) https://lurker.chat`. This makes it a setting:

- **`chat.quit_message`** (string, default `''`), shown under **Chat → Connection**.
- **Blank = the built-in Lurker default** (version + project URL). Because that default interpolates the live `APP_VERSION`, it can't be a static registry default — so the registry default is `''` and the runtime fallback supplies the versioned string.
- Settable from the GUI **or** `/set chat.quit_message "gone fishing"` — free, thanks to the registry-driven `/set` (#357).

## Where it resolves

At the `disconnect()` chokepoint in `IrcConnection` (`server/services/ircConnection.ts`):

```
explicit /quit <reason>  →  that reason
otherwise                →  chat.quit_message, or DEFAULT_QUIT_MESSAGE when blank
```

`/quit` (no reason), auto-disconnect, and shutdown all route through `conn.disconnect()`, so they share one resolution. `dispose()` (network removal, reason `network removed`) is intentionally left alone — it's a distinct message, not "the default quit message."

## Supporting change

New exported `settingsService.effectiveSetting(userId, key)` — a user's stored override or the registry default — for reads outside the request cycle (mirrors the private helpers already in `wsHub`/`uploads`; left those untouched).

## QA

- Self-host: leave blank → peers see `Lurker x.y.z … https://lurker.chat` on `/quit`; set `chat.quit_message` (GUI or `/set`) → peers see your text; `/quit later!` → peers see `later!` regardless of the setting.

## Tests / verification

- `effectiveSetting`: override + registry default + unknown key
- `disconnect`: built-in default when unset, configured message when set, explicit reason overrides
- Full suite green: **1138 tests** · `npm run check` (typecheck client+server, lint, format) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)