### PR TITLE
Disable the send button when the composer is empty (#366)

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -43,7 +43,7 @@
     <button
       type="button"
       class="send-btn"
-      :disabled="!canCompose"
+      :disabled="!canCompose || !hasComposerContent"
       title="send message"
       @mousedown.prevent
       @click="submit"
@@ -341,6 +341,10 @@ const sendable = computed(() => !!active.value && !isServer.value && !isPaused.v
 // enabled state on this instead, which also lights up for the system buffer
 // (unless the account is paused / read-only).
 const canCompose = computed(() => sendable.value || (isSystemBuffer.value && !isPaused.value));
+// #366: the Send button stays disabled until there's something to send — any
+// non-whitespace in the composer (slash commands count). Mirrors submit()'s own
+// `!raw.trim()` bail; canCompose gates buffer/pause state on top of this.
+const hasComposerContent = computed(() => text.value.trim().length > 0);
 const placeholder = computed(() => {
   if (isPaused.value) return 'Account paused — read only';
   if (isSystemBuffer.value) return 'try /commands';


### PR DESCRIPTION
Closes #366.

## What

A one-line polish: the Send button now stays disabled until there's something to send.

- Was: `:disabled="!canCompose"` (only buffer/pause state).
- Now: `:disabled="!canCompose || !hasComposerContent"`, where `hasComposerContent = text.value.trim().length > 0`.

This mirrors `submit()`'s own `!raw.trim()` bail, so the button's enabled state matches what would actually send. Slash commands count as content (they're sendable from the buffer/system buffer). The computed reads the same `text` model the textarea is bound to, so it tracks drafts per-buffer and the system buffer alike.

Reuses the existing `.send-btn:disabled` styling (opacity 0.4, muted color, default cursor) — no new CSS.

## QA

- Empty composer → Send dimmed/disabled; type a char → enabled; clear it → disabled again.
- Whitespace-only input stays disabled.
- After a successful send (input clears) → returns to disabled.
- System buffer: disabled until you type a command; channel/DM: same.

## Verification

- `typecheck:client`, `lint`, `format:check` clean; full suite **1133** green (template/computed change, no new tests — consistent with how the SFC is covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)