### PR TITLE
Fix stale nick in the input bar after a taken-nick fallback (#362)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -863,3 +863,79 @@ describe('disconnect quit message (#324)', () => {
     expect(quit).toHaveBeenCalledWith('see ya');
   });
 });
+
+describe('self nick updates the input bar (#362)', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'amiantos',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  it('publishes own-nick for a self NICK change (covers /nick, forced, reclaim)', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'amiantos';
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.client.emit('nick', { nick: 'amiantos', new_nick: 'amiantos_' });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'own-nick', nick: 'amiantos_' }),
+    );
+  });
+
+  it('reports the registered fallback nick on connect, not the requested primary', () => {
+    const conn = makeConn();
+    conn.startLagPinger = () => {}; // don't leave an interval running
+    // irc-framework starts a periodic ping on 'registered'; with an unconnected
+    // test client its interval is NaN (a noisy TimeoutNaNWarning) — stub it out.
+    (conn.client as unknown as { startPeriodicPing: () => void }).startPeriodicPing = () => {};
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.client.changeNick = vi.fn<(nick: string) => void>(); // don't touch a real socket
+    // Configured nick is taken → Lurker's fallback ladder renames us.
+    conn.client.user.nick = 'amiantos';
+    conn.client.emit('nick in use', { nick: 'amiantos' });
+    expect(conn.client.changeNick).toHaveBeenCalledWith('amiantos1');
+
+    // Crucial timing (#362): irc-framework updates c.user.nick from its OWN
+    // 'registered' listener, which runs AFTER the 'all' proxy that drives ours
+    // — so c.user.nick is still the STALE primary here. RPL_WELCOME carries the
+    // real nick as event.nick.
+    conn.client.emit('registered', { nick: 'amiantos1' });
+    conn.stopLagPinger();
+
+    const connectedStates = publish.mock.calls
+      .map((c) => c[0] as { type?: string; state?: string; nick?: string })
+      .filter((e) => e?.type === 'state' && e?.state === 'connected');
+    expect(connectedStates.at(-1)).toMatchObject({ nick: 'amiantos1' });
+    // The snapshot wsHub re-sends on 'connected' must agree — reading the stale
+    // c.user.nick here is what clobbered the input bar back to the primary.
+    expect(conn.snapshot()).toMatchObject({ nick: 'amiantos1' });
+  });
+
+  it('snapshot tracks a self nick change', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'amiantos1';
+    conn.currentNick = 'amiantos1';
+    conn.client.emit('nick', { nick: 'amiantos1', new_nick: 'amiantos' });
+    expect(conn.snapshot()).toMatchObject({ nick: 'amiantos' });
+  });
+});

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -187,6 +187,14 @@ export class IrcConnection {
   lagPendingSentAt: number;
   preRegistered: boolean;
   nickAttempt: number;
+  // Our live nick on this network, tracked independently of irc-framework's
+  // c.user.nick. The framework updates c.user.nick from its OWN 'registered'
+  // listener, which runs AFTER the 'all' proxy that drives our handler — so
+  // during the 'connected' dispatch (and the snapshot it triggers) c.user.nick
+  // is still the stale configured primary. We set this from the reliable
+  // RPL_WELCOME nick / NICK-event new nick so snapshot() can't ship a stale
+  // nick that clobbers the input bar after a taken-nick fallback (#362).
+  currentNick: string;
   regainNick: string | null;
   pendingRegainSetup: boolean;
   // Handle for this connection's entry in the identd map, while identd is
@@ -255,6 +263,9 @@ export class IrcConnection {
     // because a later 'nick in use' is the user's own /nick attempt.
     this.preRegistered = true;
     this.nickAttempt = 0;
+    // Seed with the configured nick; the registration/NICK handlers replace it
+    // with the live value once the server confirms one.
+    this.currentNick = network.nick;
     // Nick-regain state. When set, we're sitting on a fallback nick and have a
     // server-side MONITOR watch on the configured primary. Cleared once we
     // reclaim it, or the user manually picks a different nick, or the socket
@@ -530,6 +541,10 @@ export class IrcConnection {
       // `c.user.nick` is still the configured primary — useless for detecting
       // fallback. Take the confirmed nick straight from the RPL_WELCOME payload.
       const registeredNick = (event?.nick as string | undefined) || c.user.nick;
+      // Record the live nick BEFORE setState below — that publish triggers a
+      // synchronous snapshot (wsHub re-snapshots on 'connected'), and snapshot()
+      // must report the registered nick, not the stale c.user.nick (#362).
+      this.currentNick = registeredNick;
       const fallbackUsed = this.nickAttempt > 0 && registeredNick !== this.network.nick;
       this.startLagPinger();
       // Hydrate the DM-peer tracking set from open DM buffers — the union
@@ -1163,6 +1178,7 @@ export class IrcConnection {
           this.regainNick = null;
           this.pendingRegainSetup = false;
         }
+        this.currentNick = eventNewNick;
         this.publish({ type: 'own-nick', nick: eventNewNick });
       }
       const userhost = buildUserhost(event);
@@ -2226,7 +2242,11 @@ export class IrcConnection {
     return {
       networkId: this.network.id,
       state: this.state,
-      nick: this.client.user?.nick || this.network.nick,
+      // this.currentNick (server-tracked) not c.user.nick — the framework lags
+      // updating c.user.nick during the 'connected' dispatch that triggers this
+      // snapshot, which would otherwise ship a stale nick and clobber the input
+      // bar after a taken-nick fallback (#362).
+      nick: this.currentNick || this.network.nick,
       userModes: [...this.userModes].join(''),
       lagMs: this.lagMs,
       away: a.since


### PR DESCRIPTION
Closes #362.

## Symptom

Connect to a network whose configured nick is already taken → the server registers you as the numbered fallback (`amiantos` → `amiantos1`), but the input-bar prompt keeps showing `amiantos`. Worse, it shows it with the **other** user's `@` prefix — because `useSelfLabel`'s `channelPrefix` resolves the prefix by looking the prompt nick up in the channel member list, finds the real `amiantos` (an op), and prepends `@`. So `networks.states[networkId].nick` was flatly wrong (`amiantos`, not `amiantos1`).

## Root cause — a snapshot clobber, not the state event

The `connected` state event itself is correct: the `registered` handler reads the nick from RPL_WELCOME (`event.nick`) and publishes `state: connected, nick: amiantos1`, which `applyState` stores correctly.

But wsHub **re-sends a full network snapshot on every `connected` event** (so parted / pre-session buffers reappear without a refresh — `wsHub.ts:1055`), and the client's `applySnapshot` *replaces* `networks.states` wholesale. That snapshot read the nick from irc-framework's `client.user.nick` — and the framework updates `client.user.nick` from its **own** `registered` listener, which runs **after** the `all` proxy that drives our handler. So during the `connected` dispatch (and the snapshot it triggers synchronously) `client.user.nick` is still the stale configured primary. The snapshot shipped `amiantos` and clobbered the correct nick the state event had just set.

That's also why `/nick` worked but this didn't: `/nick`, network-forced renames, and reclaims all go through the NICK-message → `own-nick` path (fixed in `cb9ca5f`, #305); only the connect-fallback path went through the snapshot.

## Fix

Track the live nick on `IrcConnection` itself (`this.currentNick`), set from the reliable sources — the RPL_WELCOME nick in the `registered` handler (before the `setState` that triggers the snapshot) and the new nick in the self-`NICK` handler — and have `snapshot()` use `this.currentNick` instead of the race-prone `client.user.nick`.

## Audit (the issue asked to cover all paths)

| Path | Mechanism | |
|---|---|---|
| `/nick` | NICK msg → `own-nick` | ✅ pre-existing (#305) |
| Network-forced rename | same NICK→own-nick path | ✅ |
| Reclaim (regain primary) | same path | ✅ |
| **Connect fallback** | `registered` → state + snapshot, both now use `currentNick` | ✅ **this PR** |

## Tests / verification

- New regression tests: a `registered` event with a **stale** `client.user.nick` still has `snapshot()` report the fallback nick (fails without the fix); a self `NICK` change is reflected in `snapshot()`.
- Full suite green: **1141** tests · `npm run check` clean.
- Verified live in local QA (connect as a taken nick → prompt now shows the numbered fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)