### PR TITLE
Up/Down navigate visual rows in a multi-line composer (#367)

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -515,106 +515,23 @@ function setInputAndCaretEnd(value: string): void {
   });
 }
 
-// Style properties that influence where a textarea wraps text — copied onto the
-// measuring mirror below so its line breaks match the real composer's.
-const CARET_MIRROR_PROPS = [
-  'font-family',
-  'font-size',
-  'font-weight',
-  'font-style',
-  'font-variant',
-  'font-stretch',
-  'font-feature-settings',
-  'font-kerning',
-  'font-variant-ligatures',
-  'text-rendering',
-  'line-height',
-  'letter-spacing',
-  'word-spacing',
-  'text-transform',
-  'text-indent',
-  'tab-size',
-  'word-break',
-];
-
-// History-nav edge detection across VISUAL rows: Up walks history only when the
-// caret is on the first visual row of the composer, Down only on the last — so
-// within a multi-line OR a soft-wrapped draft the arrows move the caret between
-// rows like any editor, instead of jumping to history (#367). Textareas expose
-// no caret-row API, so we reproduce the wrap in an offscreen mirror and compare
-// the caret row's top to the first/last row's. Returns true (= at edge) if the
-// element can't be measured.
-function atHistoryEdge(key: string): boolean {
-  const el = inputEl.value;
-  if (!el) return true;
-  const value = el.value;
-  if (!value) return true;
-  const caret = key === 'ArrowUp' ? (el.selectionStart ?? 0) : (el.selectionEnd ?? value.length);
-
-  const cs = getComputedStyle(el);
-  let lineHeight = parseFloat(cs.lineHeight);
-  if (!Number.isFinite(lineHeight)) lineHeight = (parseFloat(cs.fontSize) || 16) * 1.4;
-  const contentWidth =
-    el.clientWidth - (parseFloat(cs.paddingLeft) || 0) - (parseFloat(cs.paddingRight) || 0);
-  if (contentWidth <= 0) return true;
-
-  const mirror = document.createElement('div');
-  const s = mirror.style;
-  for (const prop of CARET_MIRROR_PROPS) s.setProperty(prop, cs.getPropertyValue(prop));
-  s.boxSizing = 'content-box';
-  s.width = `${contentWidth}px`;
-  s.padding = '0';
-  s.border = '0';
-  s.whiteSpace = 'pre-wrap';
-  s.overflowWrap = 'break-word';
-  s.position = 'absolute';
-  s.top = '0';
-  s.left = '-9999px';
-  s.visibility = 'hidden';
-
-  // Zero-width markers at the start, the caret, and the end. Comparing their
-  // offsetTop tells us which visual row the caret shares.
-  const zwsp = '\u200b';
-  const startMark = document.createElement('span');
-  const caretMark = document.createElement('span');
-  const endMark = document.createElement('span');
-  startMark.textContent = zwsp;
-  caretMark.textContent = zwsp;
-  endMark.textContent = zwsp;
-  mirror.append(
-    startMark,
-    document.createTextNode(value.slice(0, caret)),
-    caretMark,
-    document.createTextNode(value.slice(caret)),
-    endMark,
-  );
-  document.body.appendChild(mirror);
-  const firstTop = startMark.offsetTop;
-  const caretTop = caretMark.offsetTop;
-  const lastTop = endMark.offsetTop;
-  mirror.remove();
-
-  // Compare ROW INDICES, not raw pixels: offsetTop is a rounded integer while
-  // lineHeight is fractional (e.g. 19.6), so `caretTop - firstTop < lineHeight`
-  // wrongly flags the 2nd row as the 1st right at the boundary. Quantizing the
-  // gap to whole rows is robust to that ±0.5px rounding (#367).
-  return key === 'ArrowUp'
-    ? Math.round((caretTop - firstTop) / lineHeight) <= 0 // caret on the first visual row
-    : Math.round((lastTop - caretTop) / lineHeight) <= 0; // caret on the last visual row
-}
-
-function handleHistoryNav(e: KeyboardEvent): void {
+// Walk input history. Called only after the browser's native arrow move was a
+// no-op (the caret was already at the very start for Up / the very end for
+// Down — see the arrow handling in onKeydown), so within a multi-line OR a
+// soft-wrapped draft the arrows move the caret between rows first and only fall
+// through to history at the true top/bottom (#367). No preventDefault: the
+// native move already ran and did nothing, so we just swap the draft.
+function walkHistory(key: 'ArrowUp' | 'ArrowDown'): void {
   if (!active.value) return;
   const { networkId, target } = active.value;
   const list = inputHistory.forBuffer(networkId, target);
   if (!list.length) return;
-  e.preventDefault();
   resetCompletion();
   closePicker();
   closeStrip();
   closeChannelPicker();
 
-  if (e.key === 'ArrowUp') {
+  if (key === 'ArrowUp') {
     if (historyIndex === null) {
       historyDraft = text.value;
       historyIndex = list.length - 1;
@@ -1010,12 +927,21 @@ function onKeydown(e: KeyboardEvent): void {
     if (e.altKey || e.metaKey || e.ctrlKey) return;
     // Leave the arrows to an active IME — they navigate its candidate window.
     if (e.isComposing) return;
-    // Multi-line textarea: only walk history at the logical-line edges, so
-    // arrows still move the caret between newline-separated lines within
-    // the draft. Up = at first logical line (no \n before caret).
-    // Down = at last logical line (no \n after caret).
-    if (!atHistoryEdge(e.key)) return;
-    handleHistoryNav(e);
+    const el = inputEl.value;
+    // Only consider history with a collapsed caret (no selection). Don't
+    // preventDefault — let the browser move the caret natively first. That
+    // handles soft-wrapped rows AND \n lines correctly, with no fragile mirror
+    // measurement. On the next frame, if the caret couldn't move (already at the
+    // very start for Up / the very end for Down), THEN walk history (#367).
+    if (el && el.selectionStart === el.selectionEnd) {
+      const before = el.selectionStart ?? 0;
+      const key = e.key;
+      requestAnimationFrame(() => {
+        if (el.isConnected && el.selectionStart === before && el.selectionEnd === before) {
+          walkHistory(key);
+        }
+      });
+    }
     return;
   }
   // Home / End — and the macOS Cmd+←/→ equivalents — jump the caret to the

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -515,12 +515,12 @@ function setInputAndCaretEnd(value: string): void {
   });
 }
 
-// Walk input history. Called only after the browser's native arrow move was a
-// no-op (the caret was already at the very start for Up / the very end for
-// Down — see the arrow handling in onKeydown), so within a multi-line OR a
-// soft-wrapped draft the arrows move the caret between rows first and only fall
-// through to history at the true top/bottom (#367). No preventDefault: the
-// native move already ran and did nothing, so we just swap the draft.
+// Walk input history. Called only after the browser's native arrow move left
+// the caret unchanged (nothing above it for Up / below it for Down — see the
+// arrow handling in onKeydown), so within a multi-line OR a soft-wrapped draft
+// the arrows move the caret between rows first and only fall through to history
+// at the true top/bottom (#367). No preventDefault: the native move already ran
+// and didn't move the caret, so we just swap the draft.
 function walkHistory(key: 'ArrowUp' | 'ArrowDown'): void {
   if (!active.value) return;
   const { networkId, target } = active.value;
@@ -922,17 +922,17 @@ function onKeydown(e: KeyboardEvent): void {
     return;
   }
   if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-    // Bare arrows only — Alt+Arrow is buffer navigation (handled globally in
-    // useKeyboardShortcuts), so don't hijack it for input history here.
-    if (e.altKey || e.metaKey || e.ctrlKey) return;
+    // Bare arrows only — Alt+Arrow is buffer navigation (useKeyboardShortcuts),
+    // and Shift+Arrow extends the selection; neither should hijack history.
+    if (e.altKey || e.metaKey || e.ctrlKey || e.shiftKey) return;
     // Leave the arrows to an active IME — they navigate its candidate window.
     if (e.isComposing) return;
     const el = inputEl.value;
     // Only consider history with a collapsed caret (no selection). Don't
     // preventDefault — let the browser move the caret natively first. That
     // handles soft-wrapped rows AND \n lines correctly, with no fragile mirror
-    // measurement. On the next frame, if the caret couldn't move (already at the
-    // very start for Up / the very end for Down), THEN walk history (#367).
+    // measurement. On the next frame, if the caret didn't move (nothing above it
+    // for Up / below it for Down), walk input history (#367).
     if (el && el.selectionStart === el.selectionEnd) {
       const before = el.selectionStart ?? 0;
       const key = e.key;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -515,21 +515,83 @@ function setInputAndCaretEnd(value: string): void {
   });
 }
 
-// IRCCloud-style edge detection for history nav: Up at the first logical
-// line / Down at the last logical line walks history. Otherwise the arrow
-// is left alone so it can move the caret between lines within a multi-line
-// draft. "Logical line" = explicit \n in the text; visual wrapping is not
-// counted (a single long wrapped line still triggers history, which matches
-// IRCCloud's behavior).
+// Style properties that influence where a textarea wraps text — copied onto the
+// measuring mirror below so its line breaks match the real composer's.
+const CARET_MIRROR_PROPS = [
+  'font-family',
+  'font-size',
+  'font-weight',
+  'font-style',
+  'font-variant',
+  'line-height',
+  'letter-spacing',
+  'word-spacing',
+  'text-transform',
+  'text-indent',
+  'tab-size',
+  'word-break',
+];
+
+// History-nav edge detection across VISUAL rows: Up walks history only when the
+// caret is on the first visual row of the composer, Down only on the last — so
+// within a multi-line OR a soft-wrapped draft the arrows move the caret between
+// rows like any editor, instead of jumping to history (#367). Textareas expose
+// no caret-row API, so we reproduce the wrap in an offscreen mirror and compare
+// the caret row's top to the first/last row's. Returns true (= at edge) if the
+// element can't be measured.
 function atHistoryEdge(key: string): boolean {
   const el = inputEl.value;
   if (!el) return true;
-  const value = text.value;
-  const caret = el.selectionStart ?? value.length;
-  if (key === 'ArrowUp') {
-    return !value.slice(0, caret).includes('\n');
-  }
-  return !value.slice(caret).includes('\n');
+  const value = el.value;
+  if (!value) return true;
+  const caret = key === 'ArrowUp' ? (el.selectionStart ?? 0) : (el.selectionEnd ?? value.length);
+
+  const cs = getComputedStyle(el);
+  let lineHeight = parseFloat(cs.lineHeight);
+  if (!Number.isFinite(lineHeight)) lineHeight = (parseFloat(cs.fontSize) || 16) * 1.4;
+  const contentWidth =
+    el.clientWidth - (parseFloat(cs.paddingLeft) || 0) - (parseFloat(cs.paddingRight) || 0);
+  if (contentWidth <= 0) return true;
+
+  const mirror = document.createElement('div');
+  const s = mirror.style;
+  for (const prop of CARET_MIRROR_PROPS) s.setProperty(prop, cs.getPropertyValue(prop));
+  s.boxSizing = 'content-box';
+  s.width = `${contentWidth}px`;
+  s.padding = '0';
+  s.border = '0';
+  s.whiteSpace = 'pre-wrap';
+  s.overflowWrap = 'break-word';
+  s.position = 'absolute';
+  s.top = '0';
+  s.left = '-9999px';
+  s.visibility = 'hidden';
+
+  // Zero-width markers at the start, the caret, and the end. Comparing their
+  // offsetTop tells us which visual row the caret shares.
+  const zwsp = '\u200b';
+  const startMark = document.createElement('span');
+  const caretMark = document.createElement('span');
+  const endMark = document.createElement('span');
+  startMark.textContent = zwsp;
+  caretMark.textContent = zwsp;
+  endMark.textContent = zwsp;
+  mirror.append(
+    startMark,
+    document.createTextNode(value.slice(0, caret)),
+    caretMark,
+    document.createTextNode(value.slice(caret)),
+    endMark,
+  );
+  document.body.appendChild(mirror);
+  const firstTop = startMark.offsetTop;
+  const caretTop = caretMark.offsetTop;
+  const lastTop = endMark.offsetTop;
+  mirror.remove();
+
+  return key === 'ArrowUp'
+    ? caretTop - firstTop < lineHeight // caret on the first visual row
+    : lastTop - caretTop < lineHeight; // caret on the last visual row
 }
 
 function handleHistoryNav(e: KeyboardEvent): void {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -523,6 +523,11 @@ const CARET_MIRROR_PROPS = [
   'font-weight',
   'font-style',
   'font-variant',
+  'font-stretch',
+  'font-feature-settings',
+  'font-kerning',
+  'font-variant-ligatures',
+  'text-rendering',
   'line-height',
   'letter-spacing',
   'word-spacing',
@@ -589,9 +594,13 @@ function atHistoryEdge(key: string): boolean {
   const lastTop = endMark.offsetTop;
   mirror.remove();
 
+  // Compare ROW INDICES, not raw pixels: offsetTop is a rounded integer while
+  // lineHeight is fractional (e.g. 19.6), so `caretTop - firstTop < lineHeight`
+  // wrongly flags the 2nd row as the 1st right at the boundary. Quantizing the
+  // gap to whole rows is robust to that ±0.5px rounding (#367).
   return key === 'ArrowUp'
-    ? caretTop - firstTop < lineHeight // caret on the first visual row
-    : lastTop - caretTop < lineHeight; // caret on the last visual row
+    ? Math.round((caretTop - firstTop) / lineHeight) <= 0 // caret on the first visual row
+    : Math.round((lastTop - caretTop) / lineHeight) <= 0; // caret on the last visual row
 }
 
 function handleHistoryNav(e: KeyboardEvent): void {


### PR DESCRIPTION
Closes #367.

## Problem

Up/Down history-nav was gated on **logical** lines (explicit `\n`). In a soft-wrapped draft — a long message wrapping across several visual rows with no newline — pressing Up from a lower visual row jumped to input history instead of moving the caret up a row.

## Approach (after a couple of iterations)

I first tried an offscreen **mirror** that reproduced the textarea's wrapping to detect the caret's visual row. It couldn't match the real wrapping closely enough across cases (caret-space reservation, sub-pixel content width, font metrics), so mixed wrapped-`+`-`\n` drafts still mis-detected the row near the top edge and jumped early.

Final approach: **delegate to the browser's native caret movement**, which is always correct for wrapped rows and `\n` lines alike.

On a bare Up/Down with a collapsed caret (no modifiers, no IME, no selection):
- **Don't** `preventDefault` — let the browser move the caret natively.
- On the next animation frame, if the caret **didn't move** (already at position 0 for Up / at the end for Down), walk input history.

So within a multi-line or soft-wrapped draft the arrows move the caret between rows like any editor, and only fall through to history once the caret is already at the very top/bottom. No fragile measurement — it relies on the browser's own layout. Net **−74 lines** vs the mirror version.

`Alt`/`Cmd`/`Ctrl`+Arrow (buffer nav) and IME composition are still skipped, unchanged.

## Tests

No unit test: this delegates to native textarea caret movement, which jsdom doesn't implement (no layout; arrow keys don't move the caret there). Verified by manual QA in Safari — wrapped paragraphs, explicit multi-line, and mixed wrapped-`+`-newline drafts all walk every row to the top/bottom before recalling history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)