### PR TITLE
Treat unread DMs as highlights (yellow buffer-list treatment)

### DIFF
--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -101,6 +101,16 @@ describe('buildBufferBacklog', () => {
     expect(buildBufferBacklog(userId, networkId, 'carol').joined).toBe(true);
   });
 
+  it('counts every unread DM line as a highlight (yellow row treatment, like the system buffer)', () => {
+    seed('erin', 'one');
+    seed('erin', 'two');
+    const frame = buildBufferBacklog(userId, networkId, 'erin');
+    // No highlight rule matched these lines, yet a DM still reports highlights
+    // == unread so the buffer-list row lights up yellow with the ● badge.
+    expect(frame.unread).toBe(2);
+    expect(frame.highlights).toBe(2);
+  });
+
   it('omits clear-state by default (no marker)', () => {
     seed('#noclear', 'just a message');
     const frame = buildBufferBacklog(userId, networkId, '#noclear');

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -234,15 +234,19 @@ function isInQuietWindow(currentMin: number, startMin: number, endMin: number): 
 
 const DM_ELIGIBLE_TYPES = new Set(['message', 'action', 'notice']);
 
-// Structural DM detection: ircConnection routes any direct message into a
-// buffer keyed by the *other* person's nick, so by the time we see an event
-// here the target is no longer your own nick. Anything that's not a channel
-// (`#…`) and not a server pseudo-buffer (`:server:…`) is a direct conversation
-// — that bucket includes both incoming DMs and your own outgoing DMs.
+// Structural DM detection from a target string: ircConnection routes any direct
+// message into a buffer keyed by the *other* person's nick, so a target that's
+// not a channel (`#…`) and not a server pseudo-buffer (`:server:…`) is a direct
+// conversation — that bucket includes both incoming DMs and your own outgoing
+// DMs. Shared by isDirect (event path) and computeUnreadFor (read-state counts)
+// so the two never drift on what counts as a DM.
+function isDmTarget(target: string): boolean {
+  return !!target && !target.startsWith('#') && !target.startsWith(':server:');
+}
+
 function isDirect(event: MessageEvent): boolean {
   if (!DM_ELIGIBLE_TYPES.has(event.type)) return false;
-  const target = event.target || '';
-  return !!target && !target.startsWith('#') && !target.startsWith(':server:');
+  return isDmTarget(event.target || '');
 }
 
 // Match state is persisted on each message at insert time (see
@@ -303,12 +307,20 @@ function computeUnreadFor(
   }
   const nid = networkId as number;
   const unread = countNewer(nid, target, lastReadId);
-  const highlights = unread === 0 ? 0 : countHighlightsNewer(nid, target, lastReadId);
+  // A DM is inherently a mention of you, so — like the system buffer — every
+  // unread line counts as a highlight. This lights the buffer-list row up in
+  // the highlight color and shows the ● badge, surfacing unread DMs above
+  // ordinary channel traffic. Display-only: notification/push decisions are
+  // made per-message in highlightEngine and are unaffected. Channels keep their
+  // real mention-only highlight count (an indexed query, no scan cap).
+  let highlights = 0;
+  if (unread > 0) {
+    highlights = isDmTarget(target) ? unread : countHighlightsNewer(nid, target, lastReadId);
+  }
   return {
     lastReadId: lastReadId || 0,
     unread,
     highlights,
-    // Both counts are now indexed queries — no scan cap, no undercount.
     highlightsCapped: false,
   };
 }


### PR DESCRIPTION
## What

Unread DMs now get the same yellow buffer-list treatment as the system buffer: the row lights up in the highlight color, shows the ● highlight badge, and surfaces above ordinary channel traffic.

Requested by a user (and felt by the operator): it was hard to notice unread DMs versus channel activity, even though DMs are more important.

## How

A single server-side rule. `computeUnreadFor()` in `server/services/wsHub.ts` now reports `highlights == unread` for DM targets — exactly the rule the system buffer already uses. The yellow look is entirely driven by `buf.highlighted` on the client (row color via `rowClasses`, the ● badge, the unread-count display, the off-screen edge arrows, **and** the Friends panel rows), so setting the count once on the server lights all of them up consistently with **no client changes**.

Also extracted the DM-target predicate out of `isDirect()` into a shared `isDmTarget()` helper so the event path and the read-state count path can't drift on what counts as a DM.

## Why this is display-only / safe

Notification and push decisions are made **per-message** in `highlightEngine.ts` + `channel_notify_settings`, not from this aggregate read-state count. So DMs don't gain any new notification behavior — they just look more important in the list. Channels keep their real mention-only highlight count. All four read-state broadcast paths route through `computeUnreadFor`, so live DMs and reopened buffers behave identically.

## Tests

- New test in `wsHub.test.ts`: a DM backlog frame reports `highlights === unread` (channels still report `0` for unmatched lines).
- `wsHub.test.ts` 21/21, plus `highlightEngine` / `insertDecisions` / `messages` 57/57.
- typecheck ✅ · format:check (oxfmt) ✅ · lint ✅ (no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)