### PR TITLE
Add a grace window + outcome metrics to the built-in identd (#374)

### DIFF
--- a/server/services/identd.test.ts
+++ b/server/services/identd.test.ts
@@ -43,16 +43,19 @@ const LOOPBACK = '127.0.0.1';
 
 const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
-// Send one ident query line and collect the reply.
-function query(line: string): Promise<string> {
+// Send one ident query line to `p` and collect the reply. halfClose mirrors an
+// RFC 1413 querier that shutdown(SHUT_WR)s right after the query (write + FIN).
+function queryOn(p: number, line: string, halfClose = false): Promise<string> {
   return new Promise((resolve, reject) => {
-    const c = net.connect(port, '127.0.0.1', () => c.write(line));
+    const c = net.connect(p, '127.0.0.1', () => (halfClose ? c.end(line) : c.write(line)));
     let out = '';
     c.on('data', (d) => (out += d.toString()));
     c.on('end', () => resolve(out));
     c.on('error', reject);
   });
 }
+
+const query = (line: string): Promise<string> => queryOn(port, line);
 
 describe('built-in identd', () => {
   it('returns USERID when the full 4-tuple matches a registered connection', async () => {
@@ -222,15 +225,7 @@ describe('identd grace window (registration race)', () => {
 
   afterAll(() => graceServer.close());
 
-  function graceQuery(line: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const c = net.connect(gracePort, '127.0.0.1', () => c.write(line));
-      let out = '';
-      c.on('data', (d) => (out += d.toString()));
-      c.on('end', () => resolve(out));
-      c.on('error', reject);
-    });
-  }
+  const graceQuery = (line: string): Promise<string> => queryOn(gracePort, line);
 
   // The core fix: a query that arrives before the outbound connection registers
   // its 4-tuple must wait out the window, not get an instant NO-USER.
@@ -248,10 +243,49 @@ describe('identd grace window (registration race)', () => {
     expect(getIdentdMetrics().rescued).toBeGreaterThanOrEqual(1);
   });
 
+  // A querier that half-closes its write side after the query (shutdown(SHUT_WR))
+  // must STILL receive a grace-rescued USERID. With the server socket's
+  // allowHalfOpen=false (the net default), the peer's FIN auto-ends our writable
+  // side before the delayed reply is written, silently dropping it — which would
+  // defeat the grace window for exactly the race it targets.
+  it('delivers a grace-rescued USERID even when the querier half-closes after the query', async () => {
+    const pending = queryOn(gracePort, '42103, 6667\r\n', true); // write + FIN
+    await delay(120);
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 42103,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667,
+      ident: 'halfclose',
+    });
+    expect(await pending).toContain('USERID : UNIX : halfclose');
+  });
+
   it('answers NO-USER when nothing registers before the window expires', async () => {
     const before = getIdentdMetrics().silentMiss;
     expect(await graceQuery('42199, 6667\r\n')).toContain('ERROR : NO-USER');
     expect(getIdentdMetrics().silentMiss).toBe(before + 1);
+  });
+
+  // A query whose connection is RESET mid-grace (peer crashes / network breaks
+  // before a verdict) must be metered as `abandoned`, not vanish — and not be
+  // mistaken for `noData` (which means no query line was ever sent). NB a
+  // graceful half-close (FIN) is NOT an abandonment: with allowHalfOpen the
+  // server rides out the window and answers (see the half-close test above), so
+  // this forces a true RST via resetAndDestroy.
+  it('meters a query whose socket is reset mid-grace as `abandoned`, not noData', async () => {
+    const before = getIdentdMetrics();
+    const c = net.connect(gracePort, '127.0.0.1', () => c.write('42198, 6667\r\n'));
+    c.on('error', () => {});
+    await delay(80); // query parsed, inside the 600ms window, nothing registered
+    c.resetAndDestroy(); // RST, not a graceful FIN
+    // Poll (not a fixed sleep) for the server-side close to be processed.
+    for (let i = 0; i < 50 && getIdentdMetrics().abandoned === before.abandoned; i++) {
+      await delay(10);
+    }
+    const after = getIdentdMetrics();
+    expect(after.abandoned).toBe(before.abandoned + 1);
+    expect(after.noData).toBe(before.noData);
   });
 
   // A first-lookup hit must answer without entering the grace recheck loop.

--- a/server/services/identd.test.ts
+++ b/server/services/identd.test.ts
@@ -3,17 +3,29 @@
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import net from 'net';
-import { createIdentdServer, registerIdent, unregisterIdent, isPrivateAddress } from './identd.js';
+import {
+  createIdentdServer,
+  registerIdent,
+  unregisterIdent,
+  isPrivateAddress,
+  getIdentdMetrics,
+  resetIdentdMetrics,
+} from './identd.js';
 
 let server: net.Server;
 let port: number;
 
 beforeAll(async () => {
-  // The address-mismatch tests deliberately exercise the NO-USER diagnostic
-  // path (which logs); keep the run output clean.
+  // The address-mismatch tests exercise the NO-USER diagnostic path (warn/error)
+  // and the grace path logs a line on every rescue; mute all three so the run
+  // output stays clean.
   vi.spyOn(console, 'warn').mockImplementation(() => {});
   vi.spyOn(console, 'error').mockImplementation(() => {});
-  server = createIdentdServer();
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  // A short grace window keeps the legitimate-miss cases (which now route
+  // through the grace path before answering NO-USER) fast; the dedicated
+  // grace-window describe below pins the timing behavior itself.
+  server = createIdentdServer({ graceMs: 150, graceStepMs: 30 });
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   port = (server.address() as net.AddressInfo).port;
 });
@@ -28,6 +40,8 @@ afterAll(() => {
 // register with those so the 4-tuple matches. (In production the registered
 // remote address is the IRC server, and the query legitimately arrives FROM it.)
 const LOOPBACK = '127.0.0.1';
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 // Send one ident query line and collect the reply.
 function query(line: string): Promise<string> {
@@ -178,6 +192,88 @@ describe('built-in identd', () => {
 
     expect(await query('41001, 6667\r\n')).toContain('USERID : UNIX : lu1');
     expect(await query('41002, 6667\r\n')).toContain('USERID : UNIX : lu2');
+  });
+});
+
+// The residual ~7% failure after the pre-TLS-registration fix: the IRC server's
+// :113 callback can beat our own registerIdent through a busy event loop, so the
+// query arrives before any matching 4-tuple exists. Answering NO-USER on that
+// first miss is the bug; the grace window holds the socket and re-checks so a
+// registration that lands a few ms late still yields USERID. (issue #374)
+describe('identd grace window (registration race)', () => {
+  let graceServer: net.Server;
+  let gracePort: number;
+
+  beforeAll(async () => {
+    resetIdentdMetrics();
+    // Short window so the race cases stay fast and deterministic.
+    graceServer = createIdentdServer({ graceMs: 600, graceStepMs: 40, graceMaxPending: 4 });
+    await new Promise<void>((resolve) => graceServer.listen(0, '127.0.0.1', resolve));
+    gracePort = (graceServer.address() as net.AddressInfo).port;
+  });
+
+  afterAll(() => graceServer.close());
+
+  function graceQuery(line: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const c = net.connect(gracePort, '127.0.0.1', () => c.write(line));
+      let out = '';
+      c.on('data', (d) => (out += d.toString()));
+      c.on('end', () => resolve(out));
+      c.on('error', reject);
+    });
+  }
+
+  // The core fix: a query that arrives before the outbound connection registers
+  // its 4-tuple must wait out the window, not get an instant NO-USER.
+  it('rescues a query when registration lands during the grace window', async () => {
+    const pending = graceQuery('42100, 6667\r\n'); // nothing registered yet
+    await delay(120); // a few rechecks in, still well inside the 600ms window
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 42100,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667,
+      ident: 'raced',
+    });
+    expect(await pending).toContain('USERID : UNIX : raced');
+    expect(getIdentdMetrics().rescued).toBeGreaterThanOrEqual(1);
+  });
+
+  it('answers NO-USER when nothing registers before the window expires', async () => {
+    const before = getIdentdMetrics().silentMiss;
+    expect(await graceQuery('42199, 6667\r\n')).toContain('ERROR : NO-USER');
+    expect(getIdentdMetrics().silentMiss).toBe(before + 1);
+  });
+
+  it('answers an exact match immediately without sitting through the window', async () => {
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 42101,
+      remoteAddress: LOOPBACK,
+      remotePort: 6667,
+      ident: 'fast',
+    });
+    const t0 = Date.now();
+    expect(await graceQuery('42101, 6667\r\n')).toContain('USERID : UNIX : fast');
+    expect(Date.now() - t0).toBeLessThan(300); // did not wait the 600ms grace
+  });
+
+  // Enumeration protection must not be softened by the grace window: a ports
+  // match with the wrong source address is refused at once, not held open.
+  it('still refuses an address mismatch instantly (no grace for enumeration)', async () => {
+    registerIdent({
+      localAddress: LOOPBACK,
+      localPort: 42102,
+      remoteAddress: '198.51.100.9', // a different server than the loopback querier
+      remotePort: 6667,
+      ident: 'secret',
+    });
+    const t0 = Date.now();
+    const res = await graceQuery('42102, 6667\r\n');
+    expect(res).toContain('ERROR : NO-USER');
+    expect(res).not.toContain('secret');
+    expect(Date.now() - t0).toBeLessThan(300);
   });
 });
 

--- a/server/services/identd.test.ts
+++ b/server/services/identd.test.ts
@@ -90,6 +90,14 @@ describe('built-in identd', () => {
     expect(res).toContain('ERROR : INVALID-PORT');
   });
 
+  // A syntactically-valid but out-of-range port (the regex allows 5 digits)
+  // must fail fast as INVALID-PORT, not fall into the grace window — otherwise a
+  // scanner could pin grace slots with 99999,99999.
+  it('rejects an out-of-range port as INVALID-PORT', async () => {
+    const res = await query('99999, 6667\r\n');
+    expect(res).toContain('ERROR : INVALID-PORT');
+  });
+
   it('tolerates loose whitespace in the query', async () => {
     registerIdent({
       localAddress: LOOPBACK,
@@ -246,7 +254,10 @@ describe('identd grace window (registration race)', () => {
     expect(getIdentdMetrics().silentMiss).toBe(before + 1);
   });
 
-  it('answers an exact match immediately without sitting through the window', async () => {
+  // A first-lookup hit must answer without entering the grace recheck loop.
+  // Asserted via the metrics (served up, rescued unchanged) rather than a
+  // wall-clock threshold, which flakes on a loaded CI runner.
+  it('answers an exact match on the first lookup (no grace recheck)', async () => {
     registerIdent({
       localAddress: LOOPBACK,
       localPort: 42101,
@@ -254,14 +265,17 @@ describe('identd grace window (registration race)', () => {
       remotePort: 6667,
       ident: 'fast',
     });
-    const t0 = Date.now();
+    const before = getIdentdMetrics();
     expect(await graceQuery('42101, 6667\r\n')).toContain('USERID : UNIX : fast');
-    expect(Date.now() - t0).toBeLessThan(300); // did not wait the 600ms grace
+    const after = getIdentdMetrics();
+    expect(after.served).toBe(before.served + 1);
+    expect(after.rescued).toBe(before.rescued);
   });
 
   // Enumeration protection must not be softened by the grace window: a ports
-  // match with the wrong source address is refused at once, not held open.
-  it('still refuses an address mismatch instantly (no grace for enumeration)', async () => {
+  // match with the wrong source address is refused on the first lookup, not held
+  // open. Asserted by addrMiss up + rescued unchanged (never entered the loop).
+  it('refuses an address mismatch on the first lookup (no grace for enumeration)', async () => {
     registerIdent({
       localAddress: LOOPBACK,
       localPort: 42102,
@@ -269,11 +283,13 @@ describe('identd grace window (registration race)', () => {
       remotePort: 6667,
       ident: 'secret',
     });
-    const t0 = Date.now();
+    const before = getIdentdMetrics();
     const res = await graceQuery('42102, 6667\r\n');
     expect(res).toContain('ERROR : NO-USER');
     expect(res).not.toContain('secret');
-    expect(Date.now() - t0).toBeLessThan(300);
+    const after = getIdentdMetrics();
+    expect(after.addrMiss).toBe(before.addrMiss + 1);
+    expect(after.rescued).toBe(before.rescued);
   });
 });
 

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -49,9 +49,10 @@ interface IdentdMetrics {
   rescued: number; // answered USERID only after waiting out the registration race
   silentMiss: number; // no 4-tuple match even after the grace window — answered NO-USER
   addrMiss: number; // ports matched a live connection but the source address did not
-  invalid: number; // malformed query line
+  invalid: number; // malformed or out-of-range query line
   noData: number; // connection closed/timed out before sending a query line
   graceSkipped: number; // grace window declined because too many were already pending
+  abandoned: number; // a parsed query whose socket closed mid-grace before a verdict
 }
 
 const metrics: IdentdMetrics = {
@@ -64,6 +65,7 @@ const metrics: IdentdMetrics = {
   invalid: 0,
   noData: 0,
   graceSkipped: 0,
+  abandoned: 0,
 };
 
 export function getIdentdMetrics(): Readonly<IdentdMetrics> {
@@ -196,10 +198,18 @@ export function isPrivateAddress(address: string): boolean {
 // case, which is the wholesale failure with no otherwise-obvious cause; the
 // once-per-process gate keeps a stray scan hit from becoming log spam.
 let wholesaleFailureWarned = false;
+let lastAddrMissWarnAt = 0;
 function noteAddrMiss(lport: number, rport: number, queryRemoteAddress: string): void {
-  console.warn(
-    `[identd] ${lport},${rport} matched a live connection but query address ${queryRemoteAddress} did not — answering NO-USER`,
-  );
+  // Rate-limit the per-miss warn (a :113 scan hitting a live connection's ports
+  // from the wrong address could otherwise flood it); the addrMiss counter at the
+  // call site stays unthrottled.
+  const now = Date.now();
+  if (now - lastAddrMissWarnAt > 10_000) {
+    lastAddrMissWarnAt = now;
+    console.warn(
+      `[identd] ${lport},${rport} matched a live connection but query address ${queryRemoteAddress} did not — answering NO-USER`,
+    );
+  }
   if (wholesaleFailureWarned) return;
   wholesaleFailureWarned = true;
   if (isPrivateAddress(queryRemoteAddress)) {
@@ -234,7 +244,9 @@ const noUserReply = (lport: number, rport: number): string =>
 // case and answered NO-USER at once (see lookupIdent / noteAddrMiss).
 function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
   metrics.accepted++;
-  socket.setTimeout(10_000);
+  // Keep the idle timeout safely above the grace window so a raised graceMs can't
+  // let the socket time out mid-rescue.
+  socket.setTimeout(Math.max(10_000, cfg.graceMs + 1_000));
   const queryLocalAddress = normalizeAddress(socket.localAddress);
   const queryRemoteAddress = normalizeAddress(socket.remoteAddress);
   let buf = '';
@@ -242,18 +254,23 @@ function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
   let graceTimer: ReturnType<typeof setTimeout> | null = null;
   let pendingCounted = false;
 
-  // Single exit: clear any pending grace timer, release the pending slot, reply.
-  // Every gracePending decrement goes through the pendingCounted guard so the
-  // grace-timer path and the socket 'close' path can't double-count.
+  // Release this socket's grace slot exactly once (the slot-leak defense). The
+  // pendingCounted guard makes repeat calls — from finish() and the abandonment
+  // paths — no-ops, so gracePending can't drift and wedge the window shut.
+  const releasePending = (): void => {
+    if (pendingCounted) {
+      gracePending--;
+      pendingCounted = false;
+    }
+  };
+
+  // Single exit: clear any pending grace timer, release the slot, reply.
   const finish = (line: string): void => {
     if (graceTimer) {
       clearTimeout(graceTimer);
       graceTimer = null;
     }
-    if (pendingCounted) {
-      gracePending--;
-      pendingCounted = false;
-    }
+    releasePending();
     socket.end(line);
   };
 
@@ -308,8 +325,10 @@ function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
     // Total miss: most likely our outbound registration hasn't landed yet.
     // Decline the wait under overload so a scan can't pin sockets open.
     if (gracePending >= cfg.graceMaxPending) {
+      // Deliberate backpressure, NOT a race loss — kept out of silentMiss (and
+      // thus the win-rate) so a :113 scan can't make the race look like it's
+      // failing.
       metrics.graceSkipped++;
-      metrics.silentMiss++;
       finish(noUserReply(lport, rport));
       return;
     }
@@ -319,10 +338,10 @@ function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
     const recheck = (): void => {
       graceTimer = null;
       if (socket.destroyed) {
-        if (pendingCounted) {
-          gracePending--;
-          pendingCounted = false;
-        }
+        // Peer abandoned the query mid-wait. Meter it (it was counted in
+        // `queries`) and release the slot.
+        if (pendingCounted) metrics.abandoned++;
+        releasePending();
         return;
       }
       const again = lookupIdent(lport, rport, queryLocalAddress, queryRemoteAddress);
@@ -335,8 +354,11 @@ function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
         return;
       }
       if (again.addrMiss) {
+        // A late same-port/different-address registration. Count it, but do NOT
+        // run noteAddrMiss here: only a FIRST-lookup addrMiss is a trustworthy
+        // wholesale-failure signal — escalating from this benign connect-race
+        // artifact would cry wolf and burn the once-per-process alarm.
         metrics.addrMiss++;
-        noteAddrMiss(lport, rport, queryRemoteAddress);
         finish(noUserReply(lport, rport));
         return;
       }
@@ -363,10 +385,9 @@ function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
       clearTimeout(graceTimer);
       graceTimer = null;
     }
-    if (pendingCounted) {
-      gracePending--;
-      pendingCounted = false;
-    }
+    // A grace-pending socket closing before a verdict was abandoned mid-wait.
+    if (pendingCounted) metrics.abandoned++;
+    releasePending();
     // Accepted but never delivered a query line — the starvation/connectivity
     // signature, distinct from a query we did answer with NO-USER.
     if (!answered) metrics.noData++;
@@ -382,7 +403,15 @@ export function createIdentdServer(opts: Partial<GraceConfig> = {}): net.Server 
     graceStepMs: opts.graceStepMs ?? GRACE_STEP_MS,
     graceMaxPending: opts.graceMaxPending ?? GRACE_MAX_PENDING,
   };
-  return net.createServer((socket) => handleConnection(socket, cfg));
+  // allowHalfOpen: true is REQUIRED for the grace window. RFC 1413 queriers
+  // commonly half-close (shutdown(SHUT_WR)) right after writing the query; with
+  // the net default (false) that inbound FIN auto-ends our writable side, so a
+  // grace-delayed socket.end(reply) — fired a tick or more later — is silently
+  // discarded and the rescued user stays unverified. We always close explicitly
+  // (every path goes through finish()/destroy(), backstopped by the idle
+  // timeout), so holding the writable side open across the peer's half-close is
+  // safe.
+  return net.createServer({ allowHalfOpen: true }, (socket) => handleConnection(socket, cfg));
 }
 
 let server: net.Server | null = null;
@@ -395,20 +424,22 @@ const SUMMARY_INTERVAL_MS = 10 * 60 * 1000;
 
 function startSummary(): void {
   if (summaryTimer) return;
-  let prevAccepted = 0;
+  // Seed from the current cumulative total so the first tick after a restart
+  // doesn't replay stale totals as if they were new activity.
+  let prevAccepted = metrics.accepted;
   summaryTimer = setInterval(() => {
     if (metrics.accepted === prevAccepted) return;
     prevAccepted = metrics.accepted;
     // "race win-rate" = of the queries matching a real connection we could win or
     // lose (served+rescued vs silentMiss), how many we answered. Deliberately
-    // excludes addrMiss/noData (mostly :113 scans) so scan traffic can't drag the
-    // headline number — those are printed raw on the same line.
+    // excludes addrMiss / noData / graceSkipped (scans + backpressure) so they
+    // can't drag the headline number — every raw counter is on the same line.
     const resolved = metrics.served + metrics.rescued + metrics.silentMiss;
     const winRate = resolved
-      ? Math.round(((metrics.served + metrics.rescued) / resolved) * 100)
-      : 100;
+      ? `${Math.round(((metrics.served + metrics.rescued) / resolved) * 100)}%`
+      : 'n/a';
     console.log(
-      `[identd] stats: served=${metrics.served} rescued=${metrics.rescued} silentMiss=${metrics.silentMiss} addrMiss=${metrics.addrMiss} noData=${metrics.noData} graceSkipped=${metrics.graceSkipped} — race win-rate ${winRate}%`,
+      `[identd] stats: accepted=${metrics.accepted} queries=${metrics.queries} served=${metrics.served} rescued=${metrics.rescued} silentMiss=${metrics.silentMiss} addrMiss=${metrics.addrMiss} invalid=${metrics.invalid} noData=${metrics.noData} graceSkipped=${metrics.graceSkipped} abandoned=${metrics.abandoned} — race win-rate ${winRate}`,
     );
   }, SUMMARY_INTERVAL_MS);
   // Don't let the summary timer keep the process alive on its own.

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -262,7 +262,14 @@ function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
     buf += chunk.toString('latin1');
     const nl = buf.indexOf('\n');
     if (nl === -1) {
-      if (buf.length > 100) socket.destroy(); // junk, no newline — bail
+      // Junk flood with no newline — bail. Mark answered + count as invalid (not
+      // a silent probe) so it doesn't pollute noData, which is the starvation
+      // signal we read for the DALnet-class follow-up.
+      if (buf.length > 100) {
+        answered = true;
+        metrics.invalid++;
+        socket.destroy();
+      }
       return;
     }
     const m = /^\s*(\d{1,5})\s*,\s*(\d{1,5})/.exec(buf.slice(0, nl));
@@ -273,9 +280,18 @@ function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
       return;
     }
     answered = true;
-    metrics.queries++;
     const lport = Number(m[1]);
     const rport = Number(m[2]);
+    // `\d{1,5}` lets a 5-digit value like 99999 through; an out-of-range port can
+    // never identify a real connection, so reject it as INVALID-PORT up front
+    // rather than letting it fall into the grace window and burn a grace slot
+    // (and a held socket) for a scanner.
+    if (lport < 1 || lport > 65535 || rport < 1 || rport > 65535) {
+      metrics.invalid++;
+      finish(`${lport}, ${rport} : ERROR : INVALID-PORT\r\n`);
+      return;
+    }
+    metrics.queries++;
 
     const first = lookupIdent(lport, rport, queryLocalAddress, queryRemoteAddress);
     if (first.ident) {
@@ -383,10 +399,16 @@ function startSummary(): void {
   summaryTimer = setInterval(() => {
     if (metrics.accepted === prevAccepted) return;
     prevAccepted = metrics.accepted;
+    // "race win-rate" = of the queries matching a real connection we could win or
+    // lose (served+rescued vs silentMiss), how many we answered. Deliberately
+    // excludes addrMiss/noData (mostly :113 scans) so scan traffic can't drag the
+    // headline number — those are printed raw on the same line.
     const resolved = metrics.served + metrics.rescued + metrics.silentMiss;
-    const ok = resolved ? Math.round(((metrics.served + metrics.rescued) / resolved) * 100) : 100;
+    const winRate = resolved
+      ? Math.round(((metrics.served + metrics.rescued) / resolved) * 100)
+      : 100;
     console.log(
-      `[identd] stats: served=${metrics.served} rescued=${metrics.rescued} silentMiss=${metrics.silentMiss} addrMiss=${metrics.addrMiss} noData=${metrics.noData} graceSkipped=${metrics.graceSkipped} — ident success ${ok}%`,
+      `[identd] stats: served=${metrics.served} rescued=${metrics.rescued} silentMiss=${metrics.silentMiss} addrMiss=${metrics.addrMiss} noData=${metrics.noData} graceSkipped=${metrics.graceSkipped} — race win-rate ${winRate}%`,
     );
   }, SUMMARY_INTERVAL_MS);
   // Don't let the summary timer keep the process alive on its own.
@@ -405,13 +427,15 @@ export function startIdentd(port: number): void {
     if (srv.listening) srv.close();
     if (server === srv) server = null;
   });
-  srv.listen(port, () =>
+  srv.listen(port, () => {
     console.log(
       `[identd] listening on :${port} — verifying idents against the full RFC 1413 4-tuple, with a ${GRACE_MS}ms grace window to absorb the connect/registration race; relies on the container seeing IRC servers' real inbound source IPs (Docker bridge preserves them; if idents fail wholesale, run with network_mode: host)`,
-    ),
-  );
+    );
+    // Only once we're actually listening — a failed bind shouldn't leave a stray
+    // interval ticking for a service that never came up.
+    startSummary();
+  });
   server = srv;
-  startSummary();
 }
 
 export function stopIdentd(): void {

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -32,6 +32,66 @@ interface IdentEntry {
 const idents = new Map<number, IdentEntry>();
 let nextIdentId = 0;
 
+// ---------------------------------------------------------------------------
+// Outcome metrics
+// ---------------------------------------------------------------------------
+
+// The residual ident failures are otherwise invisible: when a query matched no
+// live 4-tuple the old code answered NO-USER and logged nothing, so there was no
+// way to tell a registration race (the query beat our own connect callback
+// through the event loop) from a connection that never reached us. These
+// counters — surfaced in `docker logs` by the periodic summary in startIdentd —
+// make the served / rescued / missed split greppable in prod.
+interface IdentdMetrics {
+  accepted: number; // inbound :113 connections accepted
+  queries: number; // well-formed query lines parsed
+  served: number; // answered USERID on the first lookup
+  rescued: number; // answered USERID only after waiting out the registration race
+  silentMiss: number; // no 4-tuple match even after the grace window — answered NO-USER
+  addrMiss: number; // ports matched a live connection but the source address did not
+  invalid: number; // malformed query line
+  noData: number; // connection closed/timed out before sending a query line
+  graceSkipped: number; // grace window declined because too many were already pending
+}
+
+const metrics: IdentdMetrics = {
+  accepted: 0,
+  queries: 0,
+  served: 0,
+  rescued: 0,
+  silentMiss: 0,
+  addrMiss: 0,
+  invalid: 0,
+  noData: 0,
+  graceSkipped: 0,
+};
+
+export function getIdentdMetrics(): Readonly<IdentdMetrics> {
+  return { ...metrics };
+}
+
+// Tests reset between cases; production never calls this.
+export function resetIdentdMetrics(): void {
+  for (const k of Object.keys(metrics) as (keyof IdentdMetrics)[]) metrics[k] = 0;
+}
+
+// Grace window for the registration race. The IRC server fires its :113 callback
+// the instant it accepts our TCP connection, which can beat our own 'raw socket
+// connected' handler (where registerIdent runs) through a busy event loop — a
+// reconnect storm right after a deploy is the worst case. RFC 1413 servers wait
+// seconds for a reply (DALnet observed at ~30s, solanum similar), so on a TOTAL
+// miss we hold the socket and re-check briefly instead of answering NO-USER at
+// once. A first-lookup hit still answers instantly; only the failure path waits.
+// GRACE_MAX_PENDING bounds how many sockets a :113 scan can pin open.
+const GRACE_MS = 1500;
+const GRACE_STEP_MS = 150;
+const GRACE_MAX_PENDING = 256;
+let gracePending = 0;
+
+// Throttle for the silent-miss warning so a :113 scan can't flood the log; the
+// counter still increments on every miss, only the log line is rate-limited.
+let lastSilentMissWarnAt = 0;
+
 // Collapse IPv4-mapped IPv6 (::ffff:1.2.3.4) to plain IPv4 so an address compares
 // equal whether the kernel reported it mapped (common on dual-stack listeners) or
 // bare — otherwise the inbound query address and the stored outbound address can
@@ -153,15 +213,52 @@ function noteAddrMiss(lport: number, rport: number, queryRemoteAddress: string):
   }
 }
 
+interface GraceConfig {
+  graceMs: number;
+  graceStepMs: number;
+  graceMaxPending: number;
+}
+
+// RFC 1413 reply lines. The query echoes its own port pair back ahead of the
+// verdict, so both halves carry <lport>, <rport>.
+const useridReply = (lport: number, rport: number, ident: string): string =>
+  `${lport}, ${rport} : USERID : UNIX : ${ident}\r\n`;
+const noUserReply = (lport: number, rport: number): string =>
+  `${lport}, ${rport} : ERROR : NO-USER\r\n`;
+
 // RFC 1413: the querying server sends "<our-port> , <their-port>"; we reply
 // "<our-port>, <their-port> : USERID : UNIX : <ident>" or ERROR : NO-USER. The
-// query connection's own addresses complete the 4-tuple we match on.
-function handleConnection(socket: net.Socket): void {
+// query connection's own addresses complete the 4-tuple we match on. A TOTAL
+// miss (no entry with these ports) is treated as a possible registration race
+// and given the grace window; an ADDRESS mismatch is the enumeration-refusal
+// case and answered NO-USER at once (see lookupIdent / noteAddrMiss).
+function handleConnection(socket: net.Socket, cfg: GraceConfig): void {
+  metrics.accepted++;
   socket.setTimeout(10_000);
   const queryLocalAddress = normalizeAddress(socket.localAddress);
   const queryRemoteAddress = normalizeAddress(socket.remoteAddress);
   let buf = '';
+  let answered = false;
+  let graceTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingCounted = false;
+
+  // Single exit: clear any pending grace timer, release the pending slot, reply.
+  // Every gracePending decrement goes through the pendingCounted guard so the
+  // grace-timer path and the socket 'close' path can't double-count.
+  const finish = (line: string): void => {
+    if (graceTimer) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+    if (pendingCounted) {
+      gracePending--;
+      pendingCounted = false;
+    }
+    socket.end(line);
+  };
+
   socket.on('data', (chunk: Buffer) => {
+    if (answered) return;
     buf += chunk.toString('latin1');
     const nl = buf.indexOf('\n');
     if (nl === -1) {
@@ -170,29 +267,131 @@ function handleConnection(socket: net.Socket): void {
     }
     const m = /^\s*(\d{1,5})\s*,\s*(\d{1,5})/.exec(buf.slice(0, nl));
     if (!m) {
-      socket.end('0, 0 : ERROR : INVALID-PORT\r\n');
+      answered = true;
+      metrics.invalid++;
+      finish('0, 0 : ERROR : INVALID-PORT\r\n');
       return;
     }
+    answered = true;
+    metrics.queries++;
     const lport = Number(m[1]);
     const rport = Number(m[2]);
-    const { ident, addrMiss } = lookupIdent(lport, rport, queryLocalAddress, queryRemoteAddress);
-    if (!ident && addrMiss) noteAddrMiss(lport, rport, queryRemoteAddress);
-    socket.end(
-      ident
-        ? `${lport}, ${rport} : USERID : UNIX : ${ident}\r\n`
-        : `${lport}, ${rport} : ERROR : NO-USER\r\n`,
-    );
+
+    const first = lookupIdent(lport, rport, queryLocalAddress, queryRemoteAddress);
+    if (first.ident) {
+      metrics.served++;
+      finish(useridReply(lport, rport, first.ident));
+      return;
+    }
+    if (first.addrMiss) {
+      metrics.addrMiss++;
+      noteAddrMiss(lport, rport, queryRemoteAddress);
+      finish(noUserReply(lport, rport));
+      return;
+    }
+    // Total miss: most likely our outbound registration hasn't landed yet.
+    // Decline the wait under overload so a scan can't pin sockets open.
+    if (gracePending >= cfg.graceMaxPending) {
+      metrics.graceSkipped++;
+      metrics.silentMiss++;
+      finish(noUserReply(lport, rport));
+      return;
+    }
+    gracePending++;
+    pendingCounted = true;
+    const startedAt = Date.now();
+    const recheck = (): void => {
+      graceTimer = null;
+      if (socket.destroyed) {
+        if (pendingCounted) {
+          gracePending--;
+          pendingCounted = false;
+        }
+        return;
+      }
+      const again = lookupIdent(lport, rport, queryLocalAddress, queryRemoteAddress);
+      if (again.ident) {
+        metrics.rescued++;
+        console.log(
+          `[identd] ${lport},${rport} matched after ${Date.now() - startedAt}ms — outbound registration landed late (connect race); answering USERID`,
+        );
+        finish(useridReply(lport, rport, again.ident));
+        return;
+      }
+      if (again.addrMiss) {
+        metrics.addrMiss++;
+        noteAddrMiss(lport, rport, queryRemoteAddress);
+        finish(noUserReply(lport, rport));
+        return;
+      }
+      if (Date.now() - startedAt >= cfg.graceMs) {
+        metrics.silentMiss++;
+        const now = Date.now();
+        if (now - lastSilentMissWarnAt > 10_000) {
+          lastSilentMissWarnAt = now;
+          console.warn(
+            `[identd] no live connection for ${lport},${rport} from ${queryRemoteAddress} after ${cfg.graceMs}ms — answering NO-USER (silentMiss=${metrics.silentMiss})`,
+          );
+        }
+        finish(noUserReply(lport, rport));
+        return;
+      }
+      graceTimer = setTimeout(recheck, cfg.graceStepMs);
+    };
+    graceTimer = setTimeout(recheck, cfg.graceStepMs);
   });
+
   socket.on('timeout', () => socket.destroy());
+  socket.on('close', () => {
+    if (graceTimer) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+    if (pendingCounted) {
+      gracePending--;
+      pendingCounted = false;
+    }
+    // Accepted but never delivered a query line — the starvation/connectivity
+    // signature, distinct from a query we did answer with NO-USER.
+    if (!answered) metrics.noData++;
+  });
   socket.on('error', () => {});
 }
 
-/** Build (but don't listen on) an identd server. Exposed for tests. */
-export function createIdentdServer(): net.Server {
-  return net.createServer(handleConnection);
+/** Build (but don't listen on) an identd server. Exposed for tests, which pass
+ * a short grace window to keep the race cases fast and deterministic. */
+export function createIdentdServer(opts: Partial<GraceConfig> = {}): net.Server {
+  const cfg: GraceConfig = {
+    graceMs: opts.graceMs ?? GRACE_MS,
+    graceStepMs: opts.graceStepMs ?? GRACE_STEP_MS,
+    graceMaxPending: opts.graceMaxPending ?? GRACE_MAX_PENDING,
+  };
+  return net.createServer((socket) => handleConnection(socket, cfg));
 }
 
 let server: net.Server | null = null;
+let summaryTimer: ReturnType<typeof setInterval> | null = null;
+
+// Roll the outcome counters into one greppable line every 10 minutes, but only
+// when something happened since the last tick — an idle cell stays quiet. This
+// is how the race/miss rate becomes observable in prod without per-query spam.
+const SUMMARY_INTERVAL_MS = 10 * 60 * 1000;
+
+function startSummary(): void {
+  if (summaryTimer) return;
+  let prevAccepted = 0;
+  summaryTimer = setInterval(() => {
+    if (metrics.accepted === prevAccepted) return;
+    prevAccepted = metrics.accepted;
+    const resolved = metrics.served + metrics.rescued + metrics.silentMiss;
+    const ok = resolved ? Math.round(((metrics.served + metrics.rescued) / resolved) * 100) : 100;
+    console.log(
+      `[identd] stats: served=${metrics.served} rescued=${metrics.rescued} silentMiss=${metrics.silentMiss} addrMiss=${metrics.addrMiss} noData=${metrics.noData} graceSkipped=${metrics.graceSkipped} — ident success ${ok}%`,
+    );
+  }, SUMMARY_INTERVAL_MS);
+  // Don't let the summary timer keep the process alive on its own.
+  summaryTimer.unref();
+}
 
 export function startIdentd(port: number): void {
   if (server) return;
@@ -208,16 +407,21 @@ export function startIdentd(port: number): void {
   });
   srv.listen(port, () =>
     console.log(
-      `[identd] listening on :${port} — verifying idents against the full RFC 1413 4-tuple; this relies on the container seeing IRC servers' real inbound source IPs (Docker bridge preserves them; if idents fail wholesale, run with network_mode: host)`,
+      `[identd] listening on :${port} — verifying idents against the full RFC 1413 4-tuple, with a ${GRACE_MS}ms grace window to absorb the connect/registration race; relies on the container seeing IRC servers' real inbound source IPs (Docker bridge preserves them; if idents fail wholesale, run with network_mode: host)`,
     ),
   );
   server = srv;
+  startSummary();
 }
 
 export function stopIdentd(): void {
   if (server) {
     server.close();
     server = null;
+  }
+  if (summaryTimer) {
+    clearInterval(summaryTimer);
+    summaryTimer = null;
   }
 }
 


### PR DESCRIPTION
Closes the **registration-race** class of ident failures on hosted cells (part of #374).

## Evidence (prod cell DB + gap analysis)

The `*** Checking Ident` / `*** No/Got Ident response` notices persist to the server buffer, so the cell DB gives the real rate **and** the gap between probe and verdict:

- **May 14 – Jun 4:** ~100% ident failure.
- **Jun 5 (pre-TLS registration fix):** drops to **0 fails / 71 checks** through Jun 14.
- **Jun 15 → 22:** ~7% residual, spread across Libera / Rizon / DALnet.

Matching each `No Ident response` to its `Checking Ident` (same network) and bucketing the gap:

- **3–10s, 121/126** — this is the *confirmed-race era*, where our identd received the query and answered `NO-USER` instantly. So a multi-second gap is the **server's pipeline/DNS latency before it flushes the notice**, not the ident round-trip. → solanum **race** (Libera 2s, Rizon 3s). **This PR fixes it.**
- **~30s, DALnet only (2 recent)** — bahamut's ident-check timeout firing = the probe got **no answer at all**. Our identd answers instantly whenever a query reaches it (a DALnet fail at **0s** proves that), so a full-timeout means **DALnet's probe never reached our `:113`**. Verified our-side-clean: IPv4 connect, `:113` listening on both families at backlog 4096, firewall open. → **DALnet-side** (its 10-server round-robin includes hosts with broken/unreachable ident). **Not fixed here, by design** — separate, likely-unfixable-from-the-cell follow-up.

Cause of the race: the IRC server's `:113` callback can beat our own `registerIdent` (fired on `raw socket connected`) through a busy event loop during a deploy reconnect storm, so the query finds no 4-tuple yet — and the old code answered `NO-USER` instantly and logged nothing.

## Change

1. **Grace window** — on a TOTAL miss, hold the socket and re-check for up to GRACE_MS=1500ms (well under any ircd ident timeout; bahamut waits ~30s) before answering NO-USER. A first-lookup hit still answers instantly; an address mismatch (enumeration refusal) is still refused at once; bounded by GRACE_MAX_PENDING so a `:113` scan can't pin sockets open.
2. **Outcome metrics** — served / rescued / silentMiss / addrMiss / noData / graceSkipped, summarized every 10 min as `[identd] stats…`. The `rescued` counter (+ per-rescue log) is self-verifying: rescues > 0 in prod ⇒ the race was real and the grace caught it.

All gated on `LURKER_IDENTD_ENABLED` — self-hosters unaffected; hosted cells only.

## Tests

`server/services/identd.test.ts` — 4 new cases (rescue-during-grace, expire-to-NO-USER, exact-match-instant, addr-mismatch-instant). 19/19 in-file; `ircConnection` consumer suite green (75/75 combined). Typecheck / lint / format clean.

## Explicitly NOT in scope (follow-ups)

- **DALnet 30s timeouts** — our-side-clean; likely DALnet-side ident reachability. Low priority.
- **NOTICE-AUTH detection + bounded reconnect recovery** — hold until metrics show grace isn't enough.
- **Listen backlog / somaxconn** — backlog already 4096 on the cell; no change needed unless `noData` shows starvation.

## Verify after deploy

`docker logs <cell> | grep '\[identd\] stats'` — watch `rescued` climb and `silentMiss` stay low; re-run the per-day gap query to confirm the solanum tail closes (DALnet's 30s entries will remain — expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)