### PR TITLE
Overhaul highlight system (#349): scoped rules, slash command, matcher fixes

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -234,6 +234,8 @@ export const EXPORT_TABLES = Object.freeze({
       'id',
       'user_id',
       'pattern',
+      'mask',
+      'channels',
       'kind',
       'case_sensitive',
       'enabled',

--- a/server/db/highlightRules.test.ts
+++ b/server/db/highlightRules.test.ts
@@ -184,4 +184,27 @@ describe('upsertAutoNickRule', () => {
     // The implementation guards !nick at runtime; cast for the type check
     expect(mod.upsertAutoNickRule(user.id, net1!.id, null as unknown as string).rule).toBeNull();
   });
+
+  it('a manual glob rule equal to the nick suppresses auto-creation', () => {
+    const u = createUser('hr-glob');
+    const n = createNetwork(u.id, { name: 'g', host: 'h', port: 6697, tls: true, nick: 'glo' });
+    mod.createRule(u.id, { pattern: 'glo', kind: 'glob' });
+    const out = mod.upsertAutoNickRule(u.id, n!.id, 'glo');
+    expect(out.rule).toBeNull();
+    expect(mod.listRules(u.id).some((r) => r.pattern === 'glo' && r.auto_managed)).toBe(false);
+  });
+
+  it('re-enables an auto rule left disabled by a pre-overhaul toggle', () => {
+    const u = createUser('hr-reenable');
+    const n = createNetwork(u.id, { name: 'r', host: 'h', port: 6697, tls: true, nick: 'zed' });
+    const { rule } = mod.upsertAutoNickRule(u.id, n!.id, 'zed');
+    db.prepare('UPDATE highlight_rules SET enabled = 0 WHERE id = ?').run(rule!.id);
+    expect(mod.getRule(rule!.id, u.id)!.enabled).toBe(false);
+    // Re-running the (otherwise no-op) upsert forces it back on and reports change.
+    const again = mod.upsertAutoNickRule(u.id, n!.id, 'zed');
+    expect(again.changed).toBe(true);
+    expect(mod.getRule(rule!.id, u.id)!.enabled).toBe(true);
+    // ...and a subsequent run is a true no-op again.
+    expect(mod.upsertAutoNickRule(u.id, n!.id, 'zed').changed).toBe(false);
+  });
 });

--- a/server/db/highlightRules.test.ts
+++ b/server/db/highlightRules.test.ts
@@ -53,6 +53,20 @@ describe('CRUD basics', () => {
     expect(mod.updateRule(r!.id, stranger.id, { enabled: false })).toBeNull();
   });
 
+  it('updateRule re-scopes between global and networks, id-stable', () => {
+    const r = mod.createRule(user.id, { pattern: 'scoped' }); // global
+    const id = r!.id;
+    expect(mod.getRule(id, user.id)!.networkIds).toEqual([]);
+    mod.updateRule(id, user.id, { networkId: net1!.id }); // global → net1
+    expect(mod.getRule(id, user.id)!.networkIds).toEqual([net1!.id]);
+    mod.updateRule(id, user.id, { networkId: net2!.id }); // net1 → net2
+    expect(mod.getRule(id, user.id)!.networkIds).toEqual([net2!.id]);
+    mod.updateRule(id, user.id, { networkId: null }); // net2 → global
+    expect(mod.getRule(id, user.id)!.networkIds).toEqual([]);
+    expect(mod.getRule(id, user.id)!.pattern).toBe('scoped'); // same row throughout
+    mod.deleteRule(id, user.id);
+  });
+
   it('round-trips a mask + channels rule (no keyword)', () => {
     const r = mod.createRule(user.id, {
       mask: 'bob!*@*',

--- a/server/db/highlightRules.test.ts
+++ b/server/db/highlightRules.test.ts
@@ -101,8 +101,9 @@ describe('listScopedRules — network scope', () => {
 });
 
 describe('upsertAutoNickRule', () => {
-  it('creates an auto rule and attaches the network', () => {
-    const rule = mod.upsertAutoNickRule(user.id, net1!.id, 'alice');
+  it('creates an auto rule and attaches the network (changed: true)', () => {
+    const { rule, changed } = mod.upsertAutoNickRule(user.id, net1!.id, 'alice');
+    expect(changed).toBe(true);
     expect(rule!.auto_managed).toBe(true);
     expect(rule!.pattern).toBe('alice');
     const links = db
@@ -111,10 +112,16 @@ describe('upsertAutoNickRule', () => {
     expect(links.map((l) => l.network_id)).toEqual([net1!.id]);
   });
 
+  it('is idempotent — re-attaching the same nick reports changed: false', () => {
+    const again = mod.upsertAutoNickRule(user.id, net1!.id, 'alice');
+    expect(again.changed).toBe(false);
+    expect(again.rule!.pattern).toBe('alice');
+  });
+
   it('attaches additional networks that share the same nick', () => {
     // Now set net2's nick to also be 'alice' and call upsert; the existing
     // auto rule should pick up net2.
-    const rule = mod.upsertAutoNickRule(user.id, net2!.id, 'alice');
+    const { rule } = mod.upsertAutoNickRule(user.id, net2!.id, 'alice');
     const links = db
       .prepare(
         `SELECT network_id FROM highlight_rule_networks WHERE rule_id = ? ORDER BY network_id`,
@@ -128,7 +135,7 @@ describe('upsertAutoNickRule', () => {
     // old auto rule for 'alice' loses net1, gains nothing for 'alice', and
     // the new auto rule for 'newbie' should appear.
     mod.upsertAutoNickRule(user.id, net1!.id, 'newbie');
-    const aliceRule = mod.upsertAutoNickRule(user.id, net2!.id, 'alice'); // ensure stable
+    const { rule: aliceRule } = mod.upsertAutoNickRule(user.id, net2!.id, 'alice'); // ensure stable
     const aliceLinks = db
       .prepare(`SELECT network_id FROM highlight_rule_networks WHERE rule_id = ?`)
       .all(aliceRule!.id) as Array<{ network_id: number }>;
@@ -141,22 +148,26 @@ describe('upsertAutoNickRule', () => {
     expect(newbieLinks.map((l) => l.network_id)).toEqual([net1!.id]);
   });
 
-  it('skips auto-creation when a matching manual rule already exists', () => {
+  it('skips auto-creation when a matching manual rule already exists (incl. substr default)', () => {
+    // The manual default is substr — it must still suppress the auto rule.
     const manual = mod.createRule(user.id, {
       pattern: 'override',
-      kind: 'full',
+      kind: 'substr',
       case_sensitive: false,
     });
     const out = mod.upsertAutoNickRule(user.id, net1!.id, 'override');
-    // upsert returned null because a manual rule covers it.
-    expect(out).toBeNull();
+    // No auto rule (rule null) because the manual substr rule covers it.
+    expect(out.rule).toBeNull();
+    expect(mod.listRules(user.id).some((r) => r.pattern === 'override' && r.auto_managed)).toBe(
+      false,
+    );
     // The manual rule was not converted to auto_managed.
     expect(mod.getRule(manual!.id, user.id)!.auto_managed).toBe(false);
   });
 
   it('null/empty nick returns null', () => {
-    expect(mod.upsertAutoNickRule(user.id, net1!.id, '')).toBeNull();
+    expect(mod.upsertAutoNickRule(user.id, net1!.id, '').rule).toBeNull();
     // The implementation guards !nick at runtime; cast for the type check
-    expect(mod.upsertAutoNickRule(user.id, net1!.id, null as unknown as string)).toBeNull();
+    expect(mod.upsertAutoNickRule(user.id, net1!.id, null as unknown as string).rule).toBeNull();
   });
 });

--- a/server/db/highlightRules.test.ts
+++ b/server/db/highlightRules.test.ts
@@ -37,7 +37,7 @@ afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
 describe('CRUD basics', () => {
   it('createRule + getRule + updateRule + deleteRule round-trip', () => {
-    const r = mod.createRule(user.id, { pattern: 'review', kind: 'plain' });
+    const r = mod.createRule(user.id, { pattern: 'review', kind: 'full' });
     expect(r).toMatchObject({ pattern: 'review', enabled: true, case_sensitive: false });
     expect(mod.getRule(r!.id, user.id)!.pattern).toBe('review');
     const updated = mod.updateRule(r!.id, user.id, { enabled: false });
@@ -51,6 +51,52 @@ describe('CRUD basics', () => {
     const stranger = createUser('hr-stranger');
     expect(mod.getRule(r!.id, stranger.id)).toBeNull();
     expect(mod.updateRule(r!.id, stranger.id, { enabled: false })).toBeNull();
+  });
+
+  it('round-trips a mask + channels rule (no keyword)', () => {
+    const r = mod.createRule(user.id, {
+      mask: 'bob!*@*',
+      channels: ['#ops', '#dev'],
+      kind: 'full',
+    });
+    const got = mod.getRule(r!.id, user.id)!;
+    expect(got.pattern).toBeNull();
+    expect(got.mask).toBe('bob!*@*');
+    expect(got.channels).toEqual(['#ops', '#dev']);
+  });
+});
+
+describe('listScopedRules — network scope', () => {
+  it('returns global rules plus rules attached to the network', () => {
+    const scopeUser = createUser('hr-scope');
+    const nA = createNetwork(scopeUser.id, {
+      name: 'a',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    });
+    const nB = createNetwork(scopeUser.id, {
+      name: 'b',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    });
+    const globalRule = mod.createRule(scopeUser.id, { pattern: 'global' });
+    const aRule = mod.createRule(scopeUser.id, { pattern: 'onlyA', networkId: nA!.id });
+
+    const scopedA = mod.listScopedRules(scopeUser.id, nA!.id).map((r) => r.pattern);
+    expect(scopedA).toContain('global');
+    expect(scopedA).toContain('onlyA');
+
+    const scopedB = mod.listScopedRules(scopeUser.id, nB!.id).map((r) => r.pattern);
+    expect(scopedB).toContain('global');
+    expect(scopedB).not.toContain('onlyA');
+
+    // networkIds is reported on the scoped/listed rules
+    expect(mod.getRule(globalRule!.id, scopeUser.id)!.networkIds).toEqual([]);
+    expect(mod.getRule(aRule!.id, scopeUser.id)!.networkIds).toEqual([nA!.id]);
   });
 });
 
@@ -98,7 +144,7 @@ describe('upsertAutoNickRule', () => {
   it('skips auto-creation when a matching manual rule already exists', () => {
     const manual = mod.createRule(user.id, {
       pattern: 'override',
-      kind: 'plain',
+      kind: 'full',
       case_sensitive: false,
     });
     const out = mod.upsertAutoNickRule(user.id, net1!.id, 'override');

--- a/server/db/highlightRules.ts
+++ b/server/db/highlightRules.ts
@@ -237,14 +237,15 @@ export function deleteRule(id: number, userId: number): void {
 // cross-tab refetch on real change, not on every no-op reconnect).
 //
 // A manual rule the user added for their nick suppresses the auto rule entirely.
-// The manual default is 'substr' now, so a substr/full/plain (case-insensitive,
-// no-mask) rule with pattern = nick all count as "covers the nick" — otherwise a
-// manual /highlight <ownnick> wouldn't suppress auto-creation and you'd get a
-// duplicate auto rule on the next reconnect.
+// Any case-insensitive, no-mask rule whose pattern is exactly the nick covers it,
+// regardless of kind: substr/full/plain, and glob too (a glob with no wildcards —
+// pattern literally equal to the nick — matches the nick the same as a literal).
+// Otherwise a manual /highlight <ownnick> wouldn't suppress auto-creation and
+// you'd get a duplicate auto rule on the next reconnect.
 const manualCoveringStmt = db.prepare(`
   SELECT id FROM highlight_rules
   WHERE user_id = ? AND pattern = ? AND mask IS NULL AND auto_managed = 0
-    AND kind IN ('full', 'substr', 'plain') AND case_sensitive = 0
+    AND kind IN ('full', 'substr', 'plain', 'glob') AND case_sensitive = 0
   LIMIT 1
 `);
 const autoForNickStmt = db.prepare(`
@@ -275,6 +276,12 @@ const sweepOrphanedAutoStmt = db.prepare(`
   WHERE user_id = ? AND auto_managed = 1
     AND id NOT IN (SELECT rule_id FROM highlight_rule_networks)
 `);
+// Auto rules are system-managed and (now) can't be toggled by the user, so they
+// must always be enabled. Re-enable one left disabled by a pre-overhaul toggle;
+// .changes is 0 when it was already enabled (so it doesn't count as a change).
+const enableAutoRuleStmt = db.prepare(`
+  UPDATE highlight_rules SET enabled = 1 WHERE id = ? AND auto_managed = 1 AND enabled = 0
+`);
 
 const upsertAutoNickRuleTx = db.transaction(
   (
@@ -296,9 +303,11 @@ const upsertAutoNickRuleTx = db.transaction(
     }
 
     // No manual override: this network should be attached to the auto rule for
-    // `nick`. If it already is, there's nothing to do.
+    // `nick`. If it already is, there's nothing to do — except re-enable a rule
+    // that was left disabled by a pre-overhaul toggle (the user can't anymore).
     if (currentAuto && currentAuto.pattern === nick) {
-      return { ruleId: currentAuto.id, changed: false };
+      const reEnabled = enableAutoRuleStmt.run(currentAuto.id).changes > 0;
+      return { ruleId: currentAuto.id, changed: reEnabled };
     }
     // Re-map: drop a stale auto attachment (old nick), then find-or-create the
     // auto rule for the current nick and attach this network.
@@ -307,6 +316,7 @@ const upsertAutoNickRuleTx = db.transaction(
     const ruleId: number | bigint = auto
       ? auto.id
       : insertAutoRuleStmt.run(userId, nick).lastInsertRowid;
+    if (auto) enableAutoRuleStmt.run(auto.id); // an existing auto rule may have been disabled
     attachNetworkStmt.run(ruleId, networkId);
     sweepOrphanedAutoStmt.run(userId);
     return { ruleId, changed: true };

--- a/server/db/highlightRules.ts
+++ b/server/db/highlightRules.ts
@@ -142,6 +142,9 @@ const insertRuleStmt = db.prepare(`
 const attachNetworkStmt = db.prepare(`
   INSERT OR IGNORE INTO highlight_rule_networks (rule_id, network_id) VALUES (?, ?)
 `);
+const clearRuleNetworksStmt = db.prepare(`
+  DELETE FROM highlight_rule_networks WHERE rule_id = ?
+`);
 
 export function createRule(userId: number, fields: RuleFields): HighlightRule | null {
   const {
@@ -196,11 +199,31 @@ export function updateRule(id: number, userId: number, fields: RuleFields): High
     setClauses.push('enabled = ?');
     params.push(fields.enabled ? 1 : 0);
   }
-  if (!setClauses.length) return getRule(id, userId);
-  params.push(id, userId);
-  db.prepare(
-    `UPDATE highlight_rules SET ${setClauses.join(', ')} WHERE id = ? AND user_id = ?`,
-  ).run(...params);
+  // Re-scope (network attachment) lives in the junction, not a column. Including
+  // it here lets an edit change scope atomically (single id-stable update) rather
+  // than the caller doing create-then-delete. A user rule is global (no rows) or
+  // scoped to exactly one network, so we clear then optionally re-attach.
+  const reScope = 'networkId' in fields;
+  if (!setClauses.length && !reScope) return getRule(id, userId);
+  const apply = db.transaction(() => {
+    if (setClauses.length) {
+      db.prepare(
+        `UPDATE highlight_rules SET ${setClauses.join(', ')} WHERE id = ? AND user_id = ?`,
+      ).run(...params, id, userId);
+    }
+    if (reScope) {
+      // Guard on ownership before touching the junction (UPDATE above is already
+      // user-scoped; a column-less re-scope must check it too).
+      const owned = db
+        .prepare('SELECT 1 FROM highlight_rules WHERE id = ? AND user_id = ?')
+        .get(id, userId);
+      if (owned) {
+        clearRuleNetworksStmt.run(id);
+        if (fields.networkId != null) attachNetworkStmt.run(id, fields.networkId);
+      }
+    }
+  });
+  apply();
   return getRule(id, userId);
 }
 

--- a/server/db/highlightRules.ts
+++ b/server/db/highlightRules.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { parseChannelList } from '../../shared/channels.js';
 
 /** A raw row from the `highlight_rules` table. */
 interface HighlightRuleRow {
@@ -51,10 +52,7 @@ export interface RuleFields {
 
 function splitChannels(csv: string | null): string[] | null {
   if (!csv) return null;
-  const parts = csv
-    .split(',')
-    .map((c) => c.trim())
-    .filter(Boolean);
+  const parts = parseChannelList(csv);
   return parts.length ? parts : null;
 }
 
@@ -211,14 +209,32 @@ export function deleteRule(id: number, userId: number): void {
 }
 
 // Auto-nick rules are shared across every network that currently uses the same
-// nick. We detach the network from any prior auto rule, find-or-create one for
-// the new nick, attach the network, then sweep any auto rule that no longer
-// has any networks attached. A manual rule matching the same nick (same
-// pattern + whole-word/case-insensitive) suppresses auto-creation, since the
-// manual rule already covers the highlight.
-const findExistingStmt = db.prepare(`
-  SELECT id, auto_managed FROM highlight_rules
-  WHERE user_id = ? AND pattern = ? AND mask IS NULL AND kind = 'full' AND case_sensitive = 0
+// nick. The upsert is idempotent: it makes this network's own-nick state correct
+// and reports whether it actually changed anything (so the caller only fans a
+// cross-tab refetch on real change, not on every no-op reconnect).
+//
+// A manual rule the user added for their nick suppresses the auto rule entirely.
+// The manual default is 'substr' now, so a substr/full/plain (case-insensitive,
+// no-mask) rule with pattern = nick all count as "covers the nick" — otherwise a
+// manual /highlight <ownnick> wouldn't suppress auto-creation and you'd get a
+// duplicate auto rule on the next reconnect.
+const manualCoveringStmt = db.prepare(`
+  SELECT id FROM highlight_rules
+  WHERE user_id = ? AND pattern = ? AND mask IS NULL AND auto_managed = 0
+    AND kind IN ('full', 'substr', 'plain') AND case_sensitive = 0
+  LIMIT 1
+`);
+const autoForNickStmt = db.prepare(`
+  SELECT id FROM highlight_rules
+  WHERE user_id = ? AND pattern = ? AND auto_managed = 1
+  LIMIT 1
+`);
+// The auto rule (if any) this network is currently attached to.
+const currentAutoAttachmentStmt = db.prepare(`
+  SELECT r.id AS id, r.pattern AS pattern
+  FROM highlight_rule_networks j
+  JOIN highlight_rules r ON r.id = j.rule_id
+  WHERE j.network_id = ? AND r.user_id = ? AND r.auto_managed = 1
   LIMIT 1
 `);
 const detachNetworkStmt = db.prepare(`
@@ -238,27 +254,39 @@ const sweepOrphanedAutoStmt = db.prepare(`
 `);
 
 const upsertAutoNickRuleTx = db.transaction(
-  (userId: number, networkId: number, nick: string): number | bigint | null => {
-    detachNetworkStmt.run(networkId, userId);
-    const existing = findExistingStmt.get(userId, nick) as
-      | { id: number; auto_managed: number }
+  (
+    userId: number,
+    networkId: number,
+    nick: string,
+  ): { ruleId: number | bigint | null; changed: boolean } => {
+    const manual = manualCoveringStmt.get(userId, nick) as { id: number } | undefined;
+    const currentAuto = currentAutoAttachmentStmt.get(networkId, userId) as
+      | { id: number; pattern: string }
       | undefined;
-    let ruleId: number | bigint | null = null;
-    if (existing) {
-      if (existing.auto_managed) {
-        attachNetworkStmt.run(existing.id, networkId);
-        ruleId = existing.id;
-      }
-      // Manual rule with the same triple already covers this nick — skip
-      // auto-creation. If the user later deletes their manual rule, the next
-      // reconnect / nick change will re-create the auto.
-    } else {
-      const result = insertAutoRuleStmt.run(userId, nick);
-      ruleId = result.lastInsertRowid;
-      attachNetworkStmt.run(ruleId, networkId);
+
+    if (manual) {
+      // A manual rule already covers this nick → this network must carry no auto.
+      if (!currentAuto) return { ruleId: null, changed: false }; // already correct
+      detachNetworkStmt.run(networkId, userId);
+      sweepOrphanedAutoStmt.run(userId);
+      return { ruleId: null, changed: true };
     }
+
+    // No manual override: this network should be attached to the auto rule for
+    // `nick`. If it already is, there's nothing to do.
+    if (currentAuto && currentAuto.pattern === nick) {
+      return { ruleId: currentAuto.id, changed: false };
+    }
+    // Re-map: drop a stale auto attachment (old nick), then find-or-create the
+    // auto rule for the current nick and attach this network.
+    if (currentAuto) detachNetworkStmt.run(networkId, userId);
+    const auto = autoForNickStmt.get(userId, nick) as { id: number } | undefined;
+    const ruleId: number | bigint = auto
+      ? auto.id
+      : insertAutoRuleStmt.run(userId, nick).lastInsertRowid;
+    attachNetworkStmt.run(ruleId, networkId);
     sweepOrphanedAutoStmt.run(userId);
-    return ruleId;
+    return { ruleId, changed: true };
   },
 );
 
@@ -266,8 +294,8 @@ export function upsertAutoNickRule(
   userId: number,
   networkId: number,
   nick: string,
-): HighlightRule | null {
-  if (!nick) return null;
-  const ruleId = upsertAutoNickRuleTx(userId, networkId, nick);
-  return ruleId ? getRule(ruleId, userId) : null;
+): { rule: HighlightRule | null; changed: boolean } {
+  if (!nick) return { rule: null, changed: false };
+  const { ruleId, changed } = upsertAutoNickRuleTx(userId, networkId, nick);
+  return { rule: ruleId ? getRule(ruleId, userId) : null, changed };
 }

--- a/server/db/highlightRules.ts
+++ b/server/db/highlightRules.ts
@@ -7,7 +7,9 @@ import db from './index.js';
 interface HighlightRuleRow {
   id: number;
   user_id: number;
-  pattern: string;
+  pattern: string | null;
+  mask: string | null;
+  channels: string | null;
   kind: string;
   case_sensitive: number;
   enabled: number;
@@ -15,45 +17,117 @@ interface HighlightRuleRow {
   created_at: string;
 }
 
-/** The public rule shape returned to callers (booleans coerced from SQLite integers). */
+/**
+ * The public rule shape returned to callers (booleans coerced from SQLite
+ * integers, channels split from CSV, network scope resolved from the junction).
+ * `networkIds` is empty for a global rule, or the list of networks the rule is
+ * scoped to (an auto-nick rule can span several).
+ */
 export interface HighlightRule {
   id: number;
   user_id: number;
-  pattern: string;
+  pattern: string | null;
+  mask: string | null;
+  channels: string[] | null;
   kind: string;
   case_sensitive: boolean;
   enabled: boolean;
   auto_managed: boolean;
   created_at: string;
+  networkIds: number[];
 }
 
 /** Fields accepted by createRule / updateRule. */
 export interface RuleFields {
-  pattern?: string;
+  pattern?: string | null;
+  mask?: string | null;
+  channels?: string[] | null;
   kind?: string;
   case_sensitive?: boolean;
   enabled?: boolean;
+  /** On create: attach the rule to this network (null = global). */
+  networkId?: number | null;
 }
 
-function rowToRule(row: HighlightRuleRow | undefined): HighlightRule | null {
-  if (!row) return null;
-  return {
+function splitChannels(csv: string | null): string[] | null {
+  if (!csv) return null;
+  const parts = csv
+    .split(',')
+    .map((c) => c.trim())
+    .filter(Boolean);
+  return parts.length ? parts : null;
+}
+
+function joinChannels(channels: string[] | null | undefined): string | null {
+  if (!channels || channels.length === 0) return null;
+  const parts = channels.map((c) => c.trim()).filter(Boolean);
+  return parts.length ? parts.join(',') : null;
+}
+
+// Network ids for a set of rules, keyed by rule id. One query for the whole set
+// rather than a per-row lookup.
+function networkIdsFor(ruleIds: number[]): Map<number, number[]> {
+  const map = new Map<number, number[]>();
+  if (ruleIds.length === 0) return map;
+  const placeholders = ruleIds.map(() => '?').join(',');
+  const rows = db
+    .prepare(
+      `SELECT rule_id, network_id FROM highlight_rule_networks WHERE rule_id IN (${placeholders})`,
+    )
+    .all(...ruleIds) as { rule_id: number; network_id: number }[];
+  for (const r of rows) {
+    const list = map.get(r.rule_id);
+    if (list) list.push(r.network_id);
+    else map.set(r.rule_id, [r.network_id]);
+  }
+  return map;
+}
+
+function rowsToRules(rows: HighlightRuleRow[]): HighlightRule[] {
+  const nets = networkIdsFor(rows.map((r) => r.id));
+  return rows.map((row) => ({
     id: row.id,
     user_id: row.user_id,
     pattern: row.pattern,
+    mask: row.mask,
+    channels: splitChannels(row.channels),
     kind: row.kind,
     case_sensitive: !!row.case_sensitive,
     enabled: !!row.enabled,
     auto_managed: !!row.auto_managed,
     created_at: row.created_at,
-  };
+    networkIds: nets.get(row.id) ?? [],
+  }));
+}
+
+function rowToRule(row: HighlightRuleRow | undefined): HighlightRule | null {
+  if (!row) return null;
+  return rowsToRules([row])[0];
 }
 
 export function listRules(userId: number): HighlightRule[] {
   const rows = db
     .prepare('SELECT * FROM highlight_rules WHERE user_id = ? ORDER BY id')
     .all(userId) as HighlightRuleRow[];
-  return rows.map(rowToRule).filter((r): r is HighlightRule => r !== null);
+  return rowsToRules(rows);
+}
+
+// The effective rule set for matching on one network: global rules (no junction
+// rows) plus rules attached to this network. This is what the highlight matcher
+// compiles against, mirroring ignore's listScopedRules.
+export function listScopedRules(userId: number, networkId: number): HighlightRule[] {
+  const rows = db
+    .prepare(
+      `SELECT r.* FROM highlight_rules r
+       WHERE r.user_id = ?
+         AND (
+           NOT EXISTS (SELECT 1 FROM highlight_rule_networks j WHERE j.rule_id = r.id)
+           OR EXISTS (SELECT 1 FROM highlight_rule_networks j WHERE j.rule_id = r.id AND j.network_id = ?)
+         )
+       ORDER BY r.id`,
+    )
+    .all(userId, networkId) as HighlightRuleRow[];
+  return rowsToRules(rows);
 }
 
 export function getRule(id: number | bigint, userId: number): HighlightRule | null {
@@ -63,30 +137,66 @@ export function getRule(id: number | bigint, userId: number): HighlightRule | nu
   return rowToRule(row);
 }
 
+const insertRuleStmt = db.prepare(`
+  INSERT INTO highlight_rules (user_id, pattern, mask, channels, kind, case_sensitive, enabled)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+`);
+const attachNetworkStmt = db.prepare(`
+  INSERT OR IGNORE INTO highlight_rule_networks (rule_id, network_id) VALUES (?, ?)
+`);
+
 export function createRule(userId: number, fields: RuleFields): HighlightRule | null {
-  const { pattern, kind = 'plain', case_sensitive = false, enabled = true } = fields;
-  const result = db
-    .prepare(
-      `
-      INSERT INTO highlight_rules (user_id, pattern, kind, case_sensitive, enabled)
-      VALUES (?, ?, ?, ?, ?)
-    `,
-    )
-    .run(userId, pattern, kind, case_sensitive ? 1 : 0, enabled ? 1 : 0);
-  return getRule(result.lastInsertRowid, userId);
+  const {
+    pattern = null,
+    mask = null,
+    channels = null,
+    kind = 'full',
+    case_sensitive = false,
+    enabled = true,
+    networkId = null,
+  } = fields;
+  const create = db.transaction((): number | bigint => {
+    const result = insertRuleStmt.run(
+      userId,
+      pattern,
+      mask,
+      joinChannels(channels),
+      kind,
+      case_sensitive ? 1 : 0,
+      enabled ? 1 : 0,
+    );
+    if (networkId != null) attachNetworkStmt.run(result.lastInsertRowid, networkId);
+    return result.lastInsertRowid;
+  });
+  return getRule(create(), userId);
 }
 
 export function updateRule(id: number, userId: number, fields: RuleFields): HighlightRule | null {
-  const allowed = ['pattern', 'kind', 'case_sensitive', 'enabled'] as const;
   const setClauses: string[] = [];
-  const params: (string | number)[] = [];
-  for (const key of allowed) {
-    if (key in fields) {
-      setClauses.push(`${key} = ?`);
-      const raw = fields[key];
-      const value = key === 'case_sensitive' || key === 'enabled' ? (raw ? 1 : 0) : (raw as string);
-      params.push(value);
-    }
+  const params: (string | number | null)[] = [];
+  if ('pattern' in fields) {
+    setClauses.push('pattern = ?');
+    params.push(fields.pattern ?? null);
+  }
+  if ('mask' in fields) {
+    setClauses.push('mask = ?');
+    params.push(fields.mask ?? null);
+  }
+  if ('channels' in fields) {
+    setClauses.push('channels = ?');
+    params.push(joinChannels(fields.channels));
+  }
+  if ('kind' in fields) {
+    setClauses.push('kind = ?');
+    params.push(fields.kind as string);
+  }
+  if ('case_sensitive' in fields) {
+    setClauses.push('case_sensitive = ?');
+    params.push(fields.case_sensitive ? 1 : 0);
+  }
+  if ('enabled' in fields) {
+    setClauses.push('enabled = ?');
+    params.push(fields.enabled ? 1 : 0);
   }
   if (!setClauses.length) return getRule(id, userId);
   params.push(id, userId);
@@ -104,11 +214,11 @@ export function deleteRule(id: number, userId: number): void {
 // nick. We detach the network from any prior auto rule, find-or-create one for
 // the new nick, attach the network, then sweep any auto rule that no longer
 // has any networks attached. A manual rule matching the same nick (same
-// pattern + plain/case-insensitive) suppresses auto-creation, since the
+// pattern + whole-word/case-insensitive) suppresses auto-creation, since the
 // manual rule already covers the highlight.
 const findExistingStmt = db.prepare(`
   SELECT id, auto_managed FROM highlight_rules
-  WHERE user_id = ? AND pattern = ? AND kind = 'plain' AND case_sensitive = 0
+  WHERE user_id = ? AND pattern = ? AND mask IS NULL AND kind = 'full' AND case_sensitive = 0
   LIMIT 1
 `);
 const detachNetworkStmt = db.prepare(`
@@ -117,12 +227,9 @@ const detachNetworkStmt = db.prepare(`
     AND rule_id IN (SELECT id FROM highlight_rules
                     WHERE user_id = ? AND auto_managed = 1)
 `);
-const attachNetworkStmt = db.prepare(`
-  INSERT OR IGNORE INTO highlight_rule_networks (rule_id, network_id) VALUES (?, ?)
-`);
 const insertAutoRuleStmt = db.prepare(`
   INSERT INTO highlight_rules (user_id, pattern, kind, case_sensitive, enabled, auto_managed)
-  VALUES (?, ?, 'plain', 0, 1, 1)
+  VALUES (?, ?, 'full', 0, 1, 1)
 `);
 const sweepOrphanedAutoStmt = db.prepare(`
   DELETE FROM highlight_rules

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -161,11 +161,20 @@ function migrate() {
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
 
+    -- A highlight rule marks a matching message (line accent + sidebar dot).
+    -- pattern is the keyword/regex (NULL for a pure mask rule); mask is an
+    -- optional nick!user@host glob that highlights every message from matching
+    -- senders; channels is an optional CSV scope. Network scope lives in the
+    -- highlight_rule_networks junction (no rows = global). kind is the unified
+    -- substr / full / regex vocabulary shared with ignore rules (glob rows still
+    -- match for back-compat).
     CREATE TABLE IF NOT EXISTS highlight_rules (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id INTEGER NOT NULL,
-      pattern TEXT NOT NULL,
-      kind TEXT NOT NULL DEFAULT 'plain',
+      pattern TEXT,
+      mask TEXT COLLATE NOCASE,
+      channels TEXT,
+      kind TEXT NOT NULL DEFAULT 'full',
       case_sensitive INTEGER NOT NULL DEFAULT 0,
       enabled INTEGER NOT NULL DEFAULT 1,
       auto_managed INTEGER NOT NULL DEFAULT 0,
@@ -705,7 +714,7 @@ ensureColumn('upload_history', 'removed', 'INTEGER NOT NULL DEFAULT 0');
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
-const SCHEMA_VERSION = 12;
+const SCHEMA_VERSION = 13;
 const schemaVersionRow = db
   .prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`)
   .get() as { value: string } | undefined;
@@ -1165,6 +1174,59 @@ if (schemaVersion < 11) {
       `);
       db.exec(`DROP TABLE buffer_reads`);
       db.exec(`ALTER TABLE buffer_reads_new RENAME TO buffer_reads`);
+    });
+    const prevFk = db.pragma('foreign_keys', { simple: true });
+    db.pragma('foreign_keys = OFF');
+    try {
+      rebuild();
+    } finally {
+      db.pragma(`foreign_keys = ${prevFk ? 'ON' : 'OFF'}`);
+    }
+  }
+}
+
+// Issue #349 highlight overhaul: `pattern` must be nullable so a pure -mask
+// rule (highlight everyone matching a nick!user@host) can carry no keyword, and
+// the table gains `mask` + `channels` scope columns. SQLite can't drop a NOT
+// NULL in place, so rebuild. The copy remaps the retired kind 'plain' (which
+// meant whole-word) to the unified 'full'. Shape-gated on pattern's notnull flag
+// — idempotent, self-heals a half-migrated DB, and won't touch a DB already on
+// the new shape. FKs off during the swap so the cascade from
+// highlight_rule_networks.rule_id doesn't wipe the junction; ids are preserved.
+{
+  const patternCol = (
+    db.prepare(`PRAGMA table_info(highlight_rules)`).all() as TableInfoRow[]
+  ).find((c) => c.name === 'pattern');
+  if (patternCol && patternCol.notnull === 1) {
+    const rebuild = db.transaction(() => {
+      db.exec(`DROP INDEX IF EXISTS idx_highlight_rules_user`);
+      db.exec(`DROP INDEX IF EXISTS idx_auto_rule_unique`);
+      db.exec(`
+        CREATE TABLE highlight_rules_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER NOT NULL,
+          pattern TEXT,
+          mask TEXT COLLATE NOCASE,
+          channels TEXT,
+          kind TEXT NOT NULL DEFAULT 'full',
+          case_sensitive INTEGER NOT NULL DEFAULT 0,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          auto_managed INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+      `);
+      db.exec(`
+        INSERT INTO highlight_rules_new
+          (id, user_id, pattern, mask, channels, kind, case_sensitive, enabled, auto_managed, created_at)
+        SELECT
+          id, user_id, pattern, NULL, NULL,
+          CASE WHEN kind = 'plain' THEN 'full' ELSE kind END,
+          case_sensitive, enabled, auto_managed, created_at
+        FROM highlight_rules
+      `);
+      db.exec(`DROP TABLE highlight_rules`);
+      db.exec(`ALTER TABLE highlight_rules_new RENAME TO highlight_rules`);
     });
     const prevFk = db.pragma('foreign_keys', { simple: true });
     db.pragma('foreign_keys = OFF');

--- a/server/routes/highlightRules.test.ts
+++ b/server/routes/highlightRules.test.ts
@@ -51,11 +51,11 @@ describe('GET /api/highlight-rules', () => {
 });
 
 describe('POST /api/highlight-rules', () => {
-  it('creates a plain rule by default', async () => {
+  it('creates a substr rule by default', async () => {
     const res = await aliceAgent.post('/api/highlight-rules').send({ pattern: 'review' });
     expect(res.status).toBe(201);
     expect(res.body.rule.pattern).toBe('review');
-    expect(res.body.rule.kind).toBe('plain');
+    expect(res.body.rule.kind).toBe('substr');
     expect(res.body.rule.enabled).toBe(true);
     expect(res.body.rule.case_sensitive).toBe(false);
   });

--- a/server/services/highlightEngine.test.ts
+++ b/server/services/highlightEngine.test.ts
@@ -189,6 +189,24 @@ describe('matchEvent — mask rules', () => {
     ).toBe(false);
   });
 
+  it('matches a mask-only rule with no message text (no cleaning needed)', () => {
+    const compiled = compileRules([
+      {
+        id: 11,
+        pattern: null,
+        mask: 'bob!*@*',
+        channels: null,
+        kind: 'full',
+        case_sensitive: false,
+        enabled: true,
+      },
+    ]);
+    expect(compiled[0].hasPattern).toBe(false);
+    expect(
+      matchEvent({ type: 'message', text: '', nick: 'bob', userhost: 'bob!u@h' }, compiled).matched,
+    ).toBe(true);
+  });
+
   it('matches a bare-nick mask case-insensitively', () => {
     const compiled = compileRules([
       {

--- a/server/services/highlightEngine.test.ts
+++ b/server/services/highlightEngine.test.ts
@@ -147,6 +147,105 @@ describe('matchEvent — URL exclusion', () => {
   });
 });
 
+describe('matchEvent — formatting and Unicode', () => {
+  it('matches a word wrapped in IRC color/bold codes', () => {
+    const compiled = compileRules([rule({ pattern: 'QUACK!' })]);
+    expect(matchEvent(event({ text: '\x0304QUACK!\x03' }), compiled).matched).toBe(true);
+    expect(matchEvent(event({ text: '\x02\x0304QUACK!\x0f' }), compiled).matched).toBe(true);
+    expect(matchEvent(event({ text: '\x02QUACK!\x02' }), compiled).matched).toBe(true);
+  });
+
+  it('does not match a keyword inside an accented word', () => {
+    const compiled = compileRules([rule({ pattern: 'em' })]);
+    expect(matchEvent(event({ text: 'zrozumiałem' }), compiled).matched).toBe(false);
+    expect(matchEvent(event({ text: 'say em now' }), compiled).matched).toBe(true);
+  });
+});
+
+describe('matchEvent — mask rules', () => {
+  it('highlights every message from a matching sender, regardless of text', () => {
+    const compiled = compileRules([
+      {
+        id: 7,
+        pattern: null,
+        mask: 'bob!*@*',
+        channels: null,
+        kind: 'full',
+        case_sensitive: false,
+        enabled: true,
+      },
+    ]);
+    expect(
+      matchEvent(
+        { type: 'message', text: 'anything at all', nick: 'bob', userhost: 'bob!u@h' },
+        compiled,
+      ).matched,
+    ).toBe(true);
+    expect(
+      matchEvent(
+        { type: 'message', text: 'anything at all', nick: 'carol', userhost: 'carol!u@h' },
+        compiled,
+      ).matched,
+    ).toBe(false);
+  });
+
+  it('matches a bare-nick mask case-insensitively', () => {
+    const compiled = compileRules([
+      {
+        id: 8,
+        pattern: null,
+        mask: 'Bob',
+        channels: null,
+        kind: 'full',
+        case_sensitive: false,
+        enabled: true,
+      },
+    ]);
+    expect(matchEvent({ type: 'message', text: 'hi', nick: 'bob' }, compiled).matched).toBe(true);
+  });
+
+  it('AND-s a mask with a keyword when both are set', () => {
+    const compiled = compileRules([
+      {
+        id: 9,
+        pattern: 'deploy',
+        mask: 'bob!*@*',
+        channels: null,
+        kind: 'full',
+        case_sensitive: false,
+        enabled: true,
+      },
+    ]);
+    const from = (nick: string, text: string) =>
+      matchEvent({ type: 'message', text, nick, userhost: `${nick}!u@h` }, compiled).matched;
+    expect(from('bob', 'time to deploy')).toBe(true);
+    expect(from('bob', 'just chatting')).toBe(false); // mask matches, keyword does not
+    expect(from('carol', 'time to deploy')).toBe(false); // keyword matches, mask does not
+  });
+});
+
+describe('matchEvent — channel scope', () => {
+  it('only matches in the listed channels', () => {
+    const compiled = compileRules([
+      {
+        id: 10,
+        pattern: 'foo',
+        mask: null,
+        channels: ['#ops'],
+        kind: 'full',
+        case_sensitive: false,
+        enabled: true,
+      },
+    ]);
+    expect(matchEvent({ type: 'message', text: 'foo', target: '#ops' }, compiled).matched).toBe(
+      true,
+    );
+    expect(matchEvent({ type: 'message', text: 'foo', target: '#random' }, compiled).matched).toBe(
+      false,
+    );
+  });
+});
+
 describe('matchEvent — eligibility gating', () => {
   it('does not match self-authored events', () => {
     const compiled: CompiledRule[] = compileRules([rule()]);

--- a/server/services/highlightEngine.ts
+++ b/server/services/highlightEngine.ts
@@ -1,62 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { buildTextTest, stripUrls, type TextKind } from './textMatch.js';
-
-const ELIGIBLE_TYPES = new Set(['message', 'action']);
-
-interface HighlightRule {
-  id: number;
-  enabled: boolean;
-  pattern: string;
-  kind: string;
-  case_sensitive: boolean;
-}
-
-export interface CompiledRule {
-  id: number;
-  test: (text: string) => boolean;
-}
-
-interface MatchableEvent {
-  type: string;
-  self?: boolean;
-  text?: string | null;
-}
-
-// Highlight rules use the 'plain' | 'glob' | 'regex' kinds (no 'substr'); an
-// unknown kind falls through to whole-word 'plain', matching prior behavior.
-function buildTest(rule: HighlightRule): ((text: string) => boolean) | null {
-  const kind: TextKind = rule.kind === 'regex' || rule.kind === 'glob' ? rule.kind : 'plain';
-  return buildTextTest(rule.pattern, kind, rule.case_sensitive);
-}
-
-export function compileRules(rules: HighlightRule[]): CompiledRule[] {
-  const compiled: CompiledRule[] = [];
-  for (const rule of rules) {
-    if (!rule.enabled) continue;
-    if (!rule.pattern) continue;
-    const test = buildTest(rule);
-    if (!test) continue;
-    compiled.push({ id: rule.id, test });
-  }
-  return compiled;
-}
-
-export function matchEvent(
-  event: MatchableEvent | null | undefined,
-  compiled: CompiledRule[],
-): { matched: boolean; ruleId: number | null } {
-  // Cheapest guard first: with no rules there is nothing to match, so skip
-  // the eligibility checks and URL-stripping work entirely.
-  if (compiled.length === 0) return { matched: false, ruleId: null };
-  if (!event || !ELIGIBLE_TYPES.has(event.type)) return { matched: false, ruleId: null };
-  if (event.self) return { matched: false, ruleId: null };
-  const text = event.text || '';
-  if (!text) return { matched: false, ruleId: null };
-  const cleaned = stripUrls(text);
-  for (const { id, test } of compiled) {
-    if (test(cleaned)) return { matched: true, ruleId: id };
-  }
-  return { matched: false, ruleId: null };
-}
+// Implementation moved to shared/ so the insert-time stamp and the client
+// render-time evaluation run the exact same matcher (no hand-mirrored drift).
+// This re-export keeps the local import path (./highlightEngine.js) stable.
+export * from '../../shared/highlightMatch.js';

--- a/server/services/highlightRulesService.test.ts
+++ b/server/services/highlightRulesService.test.ts
@@ -60,13 +60,13 @@ describe('update', () => {
     expect(!res.ok && res.status).toBe(404);
   });
 
-  it('refuses to edit pattern/kind/case_sensitive on an auto-managed rule', () => {
+  it('refuses to edit any field (incl. enabled) on an auto-managed rule', () => {
     const auto = highlightRulesService.upsertAutoNickRule(user.id, net.id, 'alice')!;
     expect(highlightRulesService.update(auto.id, user.id, { pattern: 'new' }).ok).toBe(false);
     expect(highlightRulesService.update(auto.id, user.id, { kind: 'regex' }).ok).toBe(false);
     expect(highlightRulesService.update(auto.id, user.id, { case_sensitive: true }).ok).toBe(false);
-    // enabled IS allowed on auto rules.
-    expect(highlightRulesService.update(auto.id, user.id, { enabled: false }).ok).toBe(true);
+    // Auto rules are fully system-managed: enable/disable is locked too.
+    expect(highlightRulesService.update(auto.id, user.id, { enabled: false }).ok).toBe(false);
   });
 
   it('validates regex on update when kind changes to regex', () => {

--- a/server/services/highlightRulesService.test.ts
+++ b/server/services/highlightRulesService.test.ts
@@ -51,6 +51,13 @@ describe('create', () => {
     expect(res.ok).toBe(false);
     expect(!res.ok && res.error).toMatch(/invalid regex/);
   });
+
+  it('accepts channels as an array or a CSV/space string', () => {
+    const arr = highlightRulesService.create(user.id, { pattern: 'a', channels: ['#Ops', '#dev'] });
+    expect(arr.ok && arr.rule!.channels).toEqual(['#ops', '#dev']);
+    const csv = highlightRulesService.create(user.id, { pattern: 'b', channels: '#ops, #dev' });
+    expect(csv.ok && csv.rule!.channels).toEqual(['#ops', '#dev']);
+  });
 });
 
 describe('update', () => {

--- a/server/services/highlightRulesService.test.ts
+++ b/server/services/highlightRulesService.test.ts
@@ -58,6 +58,27 @@ describe('create', () => {
     const csv = highlightRulesService.create(user.id, { pattern: 'b', channels: '#ops, #dev' });
     expect(csv.ok && csv.rule!.channels).toEqual(['#ops', '#dev']);
   });
+
+  it('scopes to an owned network but rejects an unknown/foreign one', () => {
+    const ok = highlightRulesService.create(user.id, { pattern: 'c', networkId: net.id });
+    expect(ok.ok && ok.rule!.networkIds).toEqual([net.id]);
+    // nonexistent id
+    expect(highlightRulesService.create(user.id, { pattern: 'd', networkId: 999999 }).ok).toBe(
+      false,
+    );
+    // another user's network
+    const bob = createUser('hrs-bob');
+    const bobNet = createNetwork(bob.id, {
+      name: 'oftc',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'b',
+    }) as Network;
+    expect(highlightRulesService.create(user.id, { pattern: 'e', networkId: bobNet.id }).ok).toBe(
+      false,
+    );
+  });
 });
 
 describe('update', () => {
@@ -84,6 +105,9 @@ describe('update', () => {
     expect(toNet.ok && toNet.rule!.networkIds).toEqual([net.id]);
     const toGlobal = highlightRulesService.update(id, user.id, { networkId: null });
     expect(toGlobal.ok && toGlobal.rule!.networkIds).toEqual([]);
+    // re-scope to an unknown network is rejected (not an FK 500)
+    const bad = highlightRulesService.update(id, user.id, { networkId: 999999 });
+    expect(bad.ok).toBe(false);
   });
 
   it('validates regex on update when kind changes to regex', () => {

--- a/server/services/highlightRulesService.test.ts
+++ b/server/services/highlightRulesService.test.ts
@@ -65,8 +65,18 @@ describe('update', () => {
     expect(highlightRulesService.update(auto.id, user.id, { pattern: 'new' }).ok).toBe(false);
     expect(highlightRulesService.update(auto.id, user.id, { kind: 'regex' }).ok).toBe(false);
     expect(highlightRulesService.update(auto.id, user.id, { case_sensitive: true }).ok).toBe(false);
-    // Auto rules are fully system-managed: enable/disable is locked too.
+    // Auto rules are fully system-managed: enable/disable and re-scope are locked too.
     expect(highlightRulesService.update(auto.id, user.id, { enabled: false }).ok).toBe(false);
+    expect(highlightRulesService.update(auto.id, user.id, { networkId: null }).ok).toBe(false);
+  });
+
+  it('re-scopes a user rule global↔network in one update', () => {
+    const created = highlightRulesService.create(user.id, { pattern: 'movable' });
+    const id = created.ok ? created.rule!.id : 0;
+    const toNet = highlightRulesService.update(id, user.id, { networkId: net.id });
+    expect(toNet.ok && toNet.rule!.networkIds).toEqual([net.id]);
+    const toGlobal = highlightRulesService.update(id, user.id, { networkId: null });
+    expect(toGlobal.ok && toGlobal.rule!.networkIds).toEqual([]);
   });
 
   it('validates regex on update when kind changes to regex', () => {

--- a/server/services/highlightRulesService.test.ts
+++ b/server/services/highlightRulesService.test.ts
@@ -43,7 +43,7 @@ describe('create', () => {
   it('validates kind', () => {
     const res = highlightRulesService.create(user.id, { pattern: 'x', kind: 'fuzzy' });
     expect(res.ok).toBe(false);
-    expect(!res.ok && res.error).toMatch(/plain, glob, or regex/);
+    expect(!res.ok && res.error).toMatch(/substr, full, glob, or regex/);
   });
 
   it('rejects an invalid regex up front', () => {
@@ -92,12 +92,12 @@ describe('remove', () => {
 
 describe('getCompiled (caching)', () => {
   it('returns a compiled engine and caches across calls until invalidated', () => {
-    const before = highlightRulesService.getCompiled(user.id);
-    const cached = highlightRulesService.getCompiled(user.id);
+    const before = highlightRulesService.getCompiled(user.id, net.id);
+    const cached = highlightRulesService.getCompiled(user.id, net.id);
     expect(cached).toBe(before);
     // Create a new rule → cache invalidated.
     highlightRulesService.create(user.id, { pattern: 'fresh' });
-    const after = highlightRulesService.getCompiled(user.id);
+    const after = highlightRulesService.getCompiled(user.id, net.id);
     expect(after).not.toBe(before);
   });
 });

--- a/server/services/highlightRulesService.ts
+++ b/server/services/highlightRulesService.ts
@@ -14,7 +14,7 @@ import {
 } from '../db/highlightRules.js';
 import type { CompiledRule } from './highlightEngine.js';
 import { compileRules } from './highlightEngine.js';
-import { normalizeChannelList } from '../../shared/channels.js';
+import { normalizeChannelList, parseChannelList } from '../../shared/channels.js';
 
 // Unified with ignore's pattern kinds; 'glob' is highlight-only and 'plain' is
 // the retired alias for 'full', both still accepted so old rules keep working.
@@ -44,7 +44,13 @@ function validateRegex(pattern: string | null): string | null {
 
 function normalizeChannels(raw: unknown): string[] | null {
   if (raw == null) return null;
-  const out = normalizeChannelList(Array.isArray(raw) ? raw : [raw]);
+  // The pane/command send an array, but a raw REST caller may send a CSV/space
+  // string (the DB column is CSV) — split that with the shared parser rather than
+  // treating the whole string as one channel.
+  const out =
+    typeof raw === 'string'
+      ? parseChannelList(raw)
+      : normalizeChannelList(Array.isArray(raw) ? raw : [raw]);
   return out.length ? out : null;
 }
 

--- a/server/services/highlightRulesService.ts
+++ b/server/services/highlightRulesService.ts
@@ -153,7 +153,13 @@ class HighlightRulesService extends EventEmitter {
       if (blocked) return blocked;
       update.case_sensitive = !!fields.case_sensitive;
     }
-    if ('enabled' in fields) update.enabled = !!fields.enabled;
+    if ('enabled' in fields) {
+      // Auto-managed nick rules are fully system-managed — no enable/disable
+      // either, so the 🔒 row is entirely read-only.
+      const blocked = blockAuto('enabled');
+      if (blocked) return blocked;
+      update.enabled = !!fields.enabled;
+    }
 
     const finalKind = update.kind || existing.kind;
     const finalPattern = update.pattern ?? existing.pattern;

--- a/server/services/highlightRulesService.ts
+++ b/server/services/highlightRulesService.ts
@@ -115,7 +115,8 @@ class HighlightRulesService extends EventEmitter {
     if (!existing) return { ok: false, error: 'rule not found', status: 404 };
     const isAutoManaged = !!existing.auto_managed;
     const update: RuleFields = {};
-    // Auto-managed rules track the network nick — only enable/disable is editable.
+    // Auto-managed rules track the network nick and are fully system-managed —
+    // every field (including enabled) is read-only to the user.
     const blockAuto = (field: string): { ok: false; error: string; status: number } | null =>
       isAutoManaged
         ? { ok: false, error: `cannot edit ${field} of auto-managed rule`, status: 400 }

--- a/server/services/highlightRulesService.ts
+++ b/server/services/highlightRulesService.ts
@@ -14,6 +14,7 @@ import {
 } from '../db/highlightRules.js';
 import type { CompiledRule } from './highlightEngine.js';
 import { compileRules } from './highlightEngine.js';
+import { normalizeChannelList } from '../../shared/channels.js';
 
 // Unified with ignore's pattern kinds; 'glob' is highlight-only and 'plain' is
 // the retired alias for 'full', both still accepted so old rules keep working.
@@ -34,8 +35,8 @@ function validateKind(kind: unknown): string | null {
 function validateRegex(pattern: string | null): string | null {
   if (!pattern) return null;
   try {
-    const compiled = new RegExp(pattern);
-    return compiled ? null : null;
+    void new RegExp(pattern);
+    return null;
   } catch (e) {
     return `invalid regex: ${(e as Error).message}`;
   }
@@ -43,10 +44,7 @@ function validateRegex(pattern: string | null): string | null {
 
 function normalizeChannels(raw: unknown): string[] | null {
   if (raw == null) return null;
-  const arr = Array.isArray(raw) ? raw : [raw];
-  const out = arr
-    .map((c) => (typeof c === 'string' ? c.trim() : ''))
-    .filter((c): c is string => !!c);
+  const out = normalizeChannelList(Array.isArray(raw) ? raw : [raw]);
   return out.length ? out : null;
 }
 
@@ -78,7 +76,11 @@ class HighlightRulesService extends EventEmitter {
     fields: CreateFields,
   ): { ok: false; error: string } | { ok: true; rule: HighlightRule | null } {
     const pattern = typeof fields.pattern === 'string' ? fields.pattern.trim() : '';
-    const mask = typeof fields.mask === 'string' ? fields.mask.trim() : '';
+    // A bare '*' mask means "anyone" — i.e. no sender constraint. On its own it
+    // would compile to a dead rule, so normalize it away and let the
+    // pattern-or-mask check below reject a '*'-only rule.
+    const rawMask = typeof fields.mask === 'string' ? fields.mask.trim() : '';
+    const mask = rawMask === '*' ? '' : rawMask;
     if (!pattern && !mask) return { ok: false, error: 'a pattern or mask is required' };
     if (pattern.length > MAX_PATTERN_LENGTH)
       return { ok: false, error: `pattern exceeds ${MAX_PATTERN_LENGTH} chars` };
@@ -132,7 +134,8 @@ class HighlightRulesService extends EventEmitter {
     if ('mask' in fields) {
       const blocked = blockAuto('mask');
       if (blocked) return blocked;
-      const mask = typeof fields.mask === 'string' ? fields.mask.trim() : '';
+      const rawMask = typeof fields.mask === 'string' ? fields.mask.trim() : '';
+      const mask = rawMask === '*' ? '' : rawMask;
       if (mask.length > MAX_MASK_LENGTH)
         return { ok: false, error: `mask exceeds ${MAX_MASK_LENGTH} chars` };
       update.mask = mask || null;
@@ -163,7 +166,10 @@ class HighlightRulesService extends EventEmitter {
     }
 
     const finalKind = update.kind || existing.kind;
-    const finalPattern = update.pattern ?? existing.pattern;
+    // Use `in` (not ??) so an explicit clear-to-null (PATCH {pattern:''}) is
+    // honored: otherwise the guard reads the stale existing value and a rule with
+    // neither pattern nor mask slips through and compiles to nothing.
+    const finalPattern = 'pattern' in update ? update.pattern : existing.pattern;
     const finalMask = 'mask' in update ? update.mask : existing.mask;
     if (!finalPattern && !finalMask) return { ok: false, error: 'a pattern or mask is required' };
     if (finalKind === 'regex') {
@@ -192,8 +198,12 @@ class HighlightRulesService extends EventEmitter {
     nick: string | null | undefined,
   ): HighlightRule | null {
     if (!nick) return null;
-    const rule = upsertAutoNickRule(userId, networkId, nick);
-    this.invalidate(userId);
+    // Only invalidate (→ cross-tab refetch fanout) when the upsert actually
+    // changed something. A reconnect re-attaches an already-attached nick rule
+    // (a no-op), so without this gate every reconnect storms all tabs with
+    // redundant GET /api/highlight-rules for zero change.
+    const { rule, changed } = upsertAutoNickRule(userId, networkId, nick);
+    if (changed) this.invalidate(userId);
     return rule;
   }
 

--- a/server/services/highlightRulesService.ts
+++ b/server/services/highlightRulesService.ts
@@ -5,6 +5,7 @@ import { EventEmitter } from 'events';
 import type { HighlightRule, RuleFields } from '../db/highlightRules.js';
 import {
   listRules,
+  listScopedRules,
   getRule,
   createRule,
   updateRule,
@@ -14,28 +15,24 @@ import {
 import type { CompiledRule } from './highlightEngine.js';
 import { compileRules } from './highlightEngine.js';
 
-const ALLOWED_KINDS = new Set(['plain', 'glob', 'regex']);
+// Unified with ignore's pattern kinds; 'glob' is highlight-only and 'plain' is
+// the retired alias for 'full', both still accepted so old rules keep working.
+const ALLOWED_KINDS = new Set(['substr', 'full', 'glob', 'plain', 'regex']);
 const MAX_PATTERN_LENGTH = 256;
+const MAX_MASK_LENGTH = 256;
 
 type ServiceResult<T = undefined> =
   | (T extends undefined ? { ok: true } : { ok: true } & { [K in keyof T]: T[K] })
   | { ok: false; error: string; status?: number };
 
-function validatePattern(pattern: unknown): string | null {
-  if (typeof pattern !== 'string') return 'pattern must be a string';
-  const trimmed = pattern.trim();
-  if (!trimmed) return 'pattern is required';
-  if (trimmed.length > MAX_PATTERN_LENGTH) return `pattern exceeds ${MAX_PATTERN_LENGTH} chars`;
-  return null;
-}
-
 function validateKind(kind: unknown): string | null {
   if (typeof kind !== 'string' || !ALLOWED_KINDS.has(kind))
-    return 'kind must be plain, glob, or regex';
+    return 'kind must be substr, full, glob, or regex';
   return null;
 }
 
-function validateRegex(pattern: string): string | null {
+function validateRegex(pattern: string | null): string | null {
+  if (!pattern) return null;
   try {
     const compiled = new RegExp(pattern);
     return compiled ? null : null;
@@ -44,15 +41,33 @@ function validateRegex(pattern: string): string | null {
   }
 }
 
+function normalizeChannels(raw: unknown): string[] | null {
+  if (raw == null) return null;
+  const arr = Array.isArray(raw) ? raw : [raw];
+  const out = arr
+    .map((c) => (typeof c === 'string' ? c.trim() : ''))
+    .filter((c): c is string => !!c);
+  return out.length ? out : null;
+}
+
 interface CreateFields {
   pattern?: unknown;
+  mask?: unknown;
+  channels?: unknown;
   kind?: unknown;
   case_sensitive?: unknown;
   enabled?: unknown;
+  networkId?: unknown;
 }
 
 class HighlightRulesService extends EventEmitter {
-  private cache = new Map<number, CompiledRule[]>();
+  // Compiled rule sets are scoped per (user, network): a network sees its own
+  // rules plus the user's global rules. Keyed "userId:networkId".
+  private cache = new Map<string, CompiledRule[]>();
+
+  private key(userId: number, networkId: number): string {
+    return `${userId}:${networkId}`;
+  }
 
   list(userId: number): HighlightRule[] {
     return listRules(userId);
@@ -62,21 +77,30 @@ class HighlightRulesService extends EventEmitter {
     userId: number,
     fields: CreateFields,
   ): { ok: false; error: string } | { ok: true; rule: HighlightRule | null } {
-    const pattern = ((fields.pattern as string) || '').trim();
-    const kind = (fields.kind as string) || 'plain';
-    const patternErr = validatePattern(pattern);
-    if (patternErr) return { ok: false, error: patternErr };
+    const pattern = typeof fields.pattern === 'string' ? fields.pattern.trim() : '';
+    const mask = typeof fields.mask === 'string' ? fields.mask.trim() : '';
+    if (!pattern && !mask) return { ok: false, error: 'a pattern or mask is required' };
+    if (pattern.length > MAX_PATTERN_LENGTH)
+      return { ok: false, error: `pattern exceeds ${MAX_PATTERN_LENGTH} chars` };
+    if (mask.length > MAX_MASK_LENGTH)
+      return { ok: false, error: `mask exceeds ${MAX_MASK_LENGTH} chars` };
+    const kind = typeof fields.kind === 'string' ? fields.kind : 'substr';
     const kindErr = validateKind(kind);
     if (kindErr) return { ok: false, error: kindErr };
     if (kind === 'regex') {
       const regexErr = validateRegex(pattern);
       if (regexErr) return { ok: false, error: regexErr };
     }
+    const networkId =
+      typeof fields.networkId === 'number' && fields.networkId > 0 ? fields.networkId : null;
     const rule = createRule(userId, {
-      pattern,
+      pattern: pattern || null,
+      mask: mask || null,
+      channels: normalizeChannels(fields.channels),
       kind,
       case_sensitive: !!fields.case_sensitive,
       enabled: fields.enabled !== false,
+      networkId,
     });
     this.invalidate(userId);
     return { ok: true, rule };
@@ -91,32 +115,52 @@ class HighlightRulesService extends EventEmitter {
     if (!existing) return { ok: false, error: 'rule not found', status: 404 };
     const isAutoManaged = !!existing.auto_managed;
     const update: RuleFields = {};
+    // Auto-managed rules track the network nick — only enable/disable is editable.
+    const blockAuto = (field: string): { ok: false; error: string; status: number } | null =>
+      isAutoManaged
+        ? { ok: false, error: `cannot edit ${field} of auto-managed rule`, status: 400 }
+        : null;
     if ('pattern' in fields) {
-      if (isAutoManaged)
-        return { ok: false, error: 'cannot edit pattern of auto-managed rule', status: 400 };
-      const pattern = ((fields.pattern as string) || '').trim();
-      const patternErr = validatePattern(pattern);
-      if (patternErr) return { ok: false, error: patternErr };
-      update.pattern = pattern;
+      const blocked = blockAuto('pattern');
+      if (blocked) return blocked;
+      const pattern = typeof fields.pattern === 'string' ? fields.pattern.trim() : '';
+      if (pattern.length > MAX_PATTERN_LENGTH)
+        return { ok: false, error: `pattern exceeds ${MAX_PATTERN_LENGTH} chars` };
+      update.pattern = pattern || null;
+    }
+    if ('mask' in fields) {
+      const blocked = blockAuto('mask');
+      if (blocked) return blocked;
+      const mask = typeof fields.mask === 'string' ? fields.mask.trim() : '';
+      if (mask.length > MAX_MASK_LENGTH)
+        return { ok: false, error: `mask exceeds ${MAX_MASK_LENGTH} chars` };
+      update.mask = mask || null;
+    }
+    if ('channels' in fields) {
+      const blocked = blockAuto('channels');
+      if (blocked) return blocked;
+      update.channels = normalizeChannels(fields.channels);
     }
     if ('kind' in fields) {
-      if (isAutoManaged)
-        return { ok: false, error: 'cannot edit kind of auto-managed rule', status: 400 };
+      const blocked = blockAuto('kind');
+      if (blocked) return blocked;
       const kindErr = validateKind(fields.kind);
       if (kindErr) return { ok: false, error: kindErr };
       update.kind = fields.kind as string;
     }
     if ('case_sensitive' in fields) {
-      if (isAutoManaged)
-        return { ok: false, error: 'cannot edit case_sensitive of auto-managed rule', status: 400 };
+      const blocked = blockAuto('case_sensitive');
+      if (blocked) return blocked;
       update.case_sensitive = !!fields.case_sensitive;
     }
     if ('enabled' in fields) update.enabled = !!fields.enabled;
 
     const finalKind = update.kind || existing.kind;
     const finalPattern = update.pattern ?? existing.pattern;
+    const finalMask = 'mask' in update ? update.mask : existing.mask;
+    if (!finalPattern && !finalMask) return { ok: false, error: 'a pattern or mask is required' };
     if (finalKind === 'regex') {
-      const regexErr = validateRegex(finalPattern);
+      const regexErr = validateRegex(finalPattern ?? null);
       if (regexErr) return { ok: false, error: regexErr };
     }
     const rule = updateRule(id, userId, update);
@@ -146,17 +190,21 @@ class HighlightRulesService extends EventEmitter {
     return rule;
   }
 
-  getCompiled(userId: number): CompiledRule[] {
-    const cached = this.cache.get(userId);
+  getCompiled(userId: number, networkId: number): CompiledRule[] {
+    const k = this.key(userId, networkId);
+    const cached = this.cache.get(k);
     if (cached) return cached;
-    const rules = listRules(userId);
-    const compiled = compileRules(rules);
-    this.cache.set(userId, compiled);
+    const compiled = compileRules(listScopedRules(userId, networkId));
+    this.cache.set(k, compiled);
     return compiled;
   }
 
+  // A global rule (no network scope) feeds every network's compiled set, so any
+  // change drops all of the user's cached networks. emit('change') drives the
+  // cross-device WS resync.
   invalidate(userId: number): void {
-    this.cache.delete(userId);
+    const prefix = `${userId}:`;
+    for (const key of this.cache.keys()) if (key.startsWith(prefix)) this.cache.delete(key);
     this.emit('change', { userId });
   }
 }

--- a/server/services/highlightRulesService.ts
+++ b/server/services/highlightRulesService.ts
@@ -164,6 +164,14 @@ class HighlightRulesService extends EventEmitter {
       if (blocked) return blocked;
       update.enabled = !!fields.enabled;
     }
+    if ('networkId' in fields) {
+      // Re-scope: makes an edit (incl. global↔network) a single atomic, id-stable
+      // update instead of create-then-delete. null = global.
+      const blocked = blockAuto('network scope');
+      if (blocked) return blocked;
+      update.networkId =
+        typeof fields.networkId === 'number' && fields.networkId > 0 ? fields.networkId : null;
+    }
 
     const finalKind = update.kind || existing.kind;
     // Use `in` (not ??) so an explicit clear-to-null (PATCH {pattern:''}) is

--- a/server/services/highlightRulesService.ts
+++ b/server/services/highlightRulesService.ts
@@ -15,6 +15,18 @@ import {
 import type { CompiledRule } from './highlightEngine.js';
 import { compileRules } from './highlightEngine.js';
 import { normalizeChannelList, parseChannelList } from '../../shared/channels.js';
+import { ownsNetwork } from '../db/networks.js';
+
+// Resolve a requested scope networkId: null/absent = global; otherwise it must be
+// a positive integer the user actually owns (else a bad id is a SQLite FK 500 and
+// a foreign id would create a cross-tenant junction row). Returns `false` when the
+// id is present but invalid/unowned.
+function resolveNetworkId(userId: number, raw: unknown): number | null | false {
+  if (raw == null) return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0 || !ownsNetwork(userId, n)) return false;
+  return n;
+}
 
 // Unified with ignore's pattern kinds; 'glob' is highlight-only and 'plain' is
 // the retired alias for 'full', both still accepted so old rules keep working.
@@ -99,8 +111,8 @@ class HighlightRulesService extends EventEmitter {
       const regexErr = validateRegex(pattern);
       if (regexErr) return { ok: false, error: regexErr };
     }
-    const networkId =
-      typeof fields.networkId === 'number' && fields.networkId > 0 ? fields.networkId : null;
+    const networkId = resolveNetworkId(userId, fields.networkId);
+    if (networkId === false) return { ok: false, error: 'unknown network' };
     const rule = createRule(userId, {
       pattern: pattern || null,
       mask: mask || null,
@@ -175,8 +187,9 @@ class HighlightRulesService extends EventEmitter {
       // update instead of create-then-delete. null = global.
       const blocked = blockAuto('network scope');
       if (blocked) return blocked;
-      update.networkId =
-        typeof fields.networkId === 'number' && fields.networkId > 0 ? fields.networkId : null;
+      const nid = resolveNetworkId(userId, fields.networkId);
+      if (nid === false) return { ok: false, error: 'unknown network', status: 400 };
+      update.networkId = nid;
     }
 
     const finalKind = update.kind || existing.kind;

--- a/server/services/insertDecisions.test.ts
+++ b/server/services/insertDecisions.test.ts
@@ -66,7 +66,7 @@ function stamp(event: {
       target: event.target,
       text: event.text,
     },
-    highlightRulesService.getCompiled(user.id),
+    highlightRulesService.getCompiled(user.id, net!.id),
     ignoreRulesService.getCompiled(user.id, net!.id),
     !!event.isDm,
   );

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -356,7 +356,7 @@ export class IrcConnection {
             text: event.text as string | null | undefined,
             self: event.self as boolean | undefined,
           },
-          highlightRulesService.getCompiled(this.network.user_id),
+          highlightRulesService.getCompiled(this.network.user_id, this.network.id),
           ignoreRulesService.getCompiled(this.network.user_id, this.network.id),
           isDmTargetName(event.target as string),
         );

--- a/server/services/parseHighlight.test.ts
+++ b/server/services/parseHighlight.test.ts
@@ -88,3 +88,12 @@ describe('parseHighlightArgs — errors', () => {
     expect(p('-regexp -full x').error).toMatch(/mutually exclusive/);
   });
 });
+
+describe('parseHighlightArgs — end-of-flags sentinel', () => {
+  it('treats tokens after -- as positional, allowing leading-dash keywords', () => {
+    const r = p('-- -Werror');
+    expect(r.error).toBeUndefined();
+    expect(r.pattern).toBe('-Werror');
+    expect(p('-full -- -v')).toMatchObject({ pattern: '-v', kind: 'full' });
+  });
+});

--- a/server/services/parseHighlight.test.ts
+++ b/server/services/parseHighlight.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { parseHighlightArgs } from '../../shared/parseHighlight.js';
+
+const p = (s: string) => parseHighlightArgs(s);
+
+describe('parseHighlightArgs — keyword rules', () => {
+  it('bare keyword defaults to substr, global, case-insensitive', () => {
+    expect(p('quack')).toMatchObject({
+      pattern: 'quack',
+      mask: null,
+      kind: 'substr',
+      caseSensitive: false,
+      scopeNetwork: false,
+      channels: null,
+    });
+  });
+
+  it('-full makes it whole-word', () => {
+    expect(p('-full quack')).toMatchObject({ pattern: 'quack', kind: 'full' });
+  });
+
+  it('-regexp makes it a regex', () => {
+    expect(p('-regexp qu+ack')).toMatchObject({ pattern: 'qu+ack', kind: 'regex' });
+  });
+
+  it('-matchcase sets case sensitivity', () => {
+    expect(p('-matchcase QUACK')).toMatchObject({ pattern: 'QUACK', caseSensitive: true });
+  });
+
+  it('joins a multi-word phrase into one pattern', () => {
+    expect(p('build failed')).toMatchObject({ pattern: 'build failed' });
+    expect(p('"build failed"')).toMatchObject({ pattern: 'build failed' });
+  });
+
+  it('keeps a balanced regex group as one token', () => {
+    expect(p('-regexp (foo|bar baz)')).toMatchObject({ pattern: '(foo|bar baz)', kind: 'regex' });
+  });
+
+  it('does NOT treat a leading # as a channel (keyword may be #release)', () => {
+    expect(p('#release')).toMatchObject({ pattern: '#release', channels: null });
+  });
+});
+
+describe('parseHighlightArgs — mask rules', () => {
+  it('-mask makes the positional a sender mask', () => {
+    expect(p('-mask bob!*@*')).toMatchObject({ mask: 'bob!*@*', pattern: null });
+  });
+});
+
+describe('parseHighlightArgs — scope', () => {
+  it('-network scopes to the current network', () => {
+    expect(p('-network quack')).toMatchObject({ scopeNetwork: true, pattern: 'quack' });
+  });
+
+  it('-global is the explicit default', () => {
+    expect(p('-global quack')).toMatchObject({ scopeNetwork: false });
+  });
+
+  it('-channels parses a comma list, lowercased', () => {
+    expect(p('-channels #Ops,#Dev quack')).toMatchObject({
+      channels: ['#ops', '#dev'],
+      pattern: 'quack',
+    });
+  });
+});
+
+describe('parseHighlightArgs — errors', () => {
+  it('rejects an unknown flag', () => {
+    expect(p('-bogus quack').error).toMatch(/unknown flag/);
+  });
+
+  it('requires a value after -channels', () => {
+    expect(p('-channels').error).toMatch(/-channels needs a value/);
+  });
+
+  it('requires a pattern when none given', () => {
+    expect(p('-full').error).toMatch(/pattern is required/);
+  });
+
+  it('requires a mask when -mask given with no positional', () => {
+    expect(p('-mask').error).toMatch(/mask is required/);
+  });
+
+  it('rejects -regexp combined with -full', () => {
+    expect(p('-regexp -full x').error).toMatch(/mutually exclusive/);
+  });
+});

--- a/server/services/textMatch.test.ts
+++ b/server/services/textMatch.test.ts
@@ -67,10 +67,17 @@ describe('buildTextTest — Unicode word boundaries', () => {
 });
 
 describe('stripFormatting / cleanForMatch', () => {
-  it('removes color, hex color, and toggle codes', () => {
+  it('removes color, hex color, and every toggle code (matching the renderer)', () => {
     expect(stripFormatting('\x0304,08QUACK!\x03')).toBe('QUACK!');
     expect(stripFormatting('\x02bold\x0f \x1ditalic\x1d')).toBe('bold italic');
     expect(stripFormatting('\x04FF0000red\x04000000')).toBe('red');
+    // every toggle the renderer handles: bold/mono/reverse/italic/strike/underline/reset
+    expect(stripFormatting('\x02\x11\x16\x1d\x1e\x1f a \x0f')).toBe(' a ');
+    // strike specifically (was missing from FORMAT_RE) — whole-word match sees through it
+    expect(stripFormatting('\x1estruck\x1e')).toBe('struck');
+    expect(buildTextTest('struck', 'plain', false)!(cleanForMatch('a \x1estruck\x1e word'))).toBe(
+      true,
+    );
   });
 
   it('lets whole-word matching see through formatting (the colored-QUACK bug)', () => {

--- a/server/services/textMatch.test.ts
+++ b/server/services/textMatch.test.ts
@@ -80,6 +80,14 @@ describe('stripFormatting / cleanForMatch', () => {
     expect(test(cleanForMatch('\x0304QUACK!\x03'))).toBe(true); // cleaned: matches
   });
 
+  it('treats a bare reset before digits/comma as a reset, not a color (matches the renderer)', () => {
+    // \x03 + up to 2 digits IS a color code, so the digits go with it...
+    expect(stripFormatting('see \x03123 done')).toBe('see 3 done');
+    // ...but \x03 immediately followed by ',NN' is a bare reset; the ',NN' is
+    // literal text (a bg with no fg is not a color code).
+    expect(stripFormatting('a \x03,12 b')).toBe('a ,12 b');
+  });
+
   it('cleanForMatch also strips URLs', () => {
     expect(cleanForMatch('see https://example.com/amiantos here')).not.toContain('amiantos');
   });

--- a/server/services/textMatch.test.ts
+++ b/server/services/textMatch.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { buildTextTest } from './textMatch.js';
+import { buildTextTest, stripFormatting, cleanForMatch } from './textMatch.js';
 
 describe('buildTextTest — substr', () => {
   it('matches case-insensitive substring by default', () => {
@@ -35,5 +35,52 @@ describe('buildTextTest — plain/glob/regex parity', () => {
   it('regex is raw and returns null on invalid', () => {
     expect(buildTextTest('^hi', 'regex', false)!('hi there')).toBe(true);
     expect(buildTextTest('(unclosed', 'regex', false)).toBeNull();
+  });
+});
+
+describe('buildTextTest — Unicode word boundaries', () => {
+  it('treats non-ASCII letters as word chars, not boundaries', () => {
+    // `\W`-based matching wrongly saw `ł` as a boundary and matched `em` inside.
+    const test = buildTextTest('em', 'plain', false)!;
+    expect(test('zrozumiałem')).toBe(false);
+    expect(test('łem')).toBe(false);
+    expect(test('say em now')).toBe(true);
+  });
+
+  it('matches whole accented words and respects their boundaries', () => {
+    const test = buildTextTest('café', 'plain', false)!;
+    expect(test('a café here')).toBe(true);
+    expect(test('cafés plural')).toBe(false);
+  });
+
+  it('matches a nick followed by punctuation but not inside a longer word', () => {
+    const test = buildTextTest('brad', 'plain', false)!;
+    expect(test('hey brad: hi')).toBe(true);
+    expect(test('bradley spoke')).toBe(false);
+  });
+
+  it('matches a keyword that itself ends in punctuation', () => {
+    const test = buildTextTest('QUACK!', 'plain', false)!;
+    expect(test('QUACK!')).toBe(true);
+    expect(test('the bot says QUACK! loudly')).toBe(true);
+  });
+});
+
+describe('stripFormatting / cleanForMatch', () => {
+  it('removes color, hex color, and toggle codes', () => {
+    expect(stripFormatting('\x0304,08QUACK!\x03')).toBe('QUACK!');
+    expect(stripFormatting('\x02bold\x0f \x1ditalic\x1d')).toBe('bold italic');
+    expect(stripFormatting('\x04FF0000red\x04000000')).toBe('red');
+  });
+
+  it('lets whole-word matching see through formatting (the colored-QUACK bug)', () => {
+    // Color code leaves a digit glued to the word, which broke the boundary.
+    const test = buildTextTest('QUACK!', 'plain', false)!;
+    expect(test('\x0304QUACK!\x03')).toBe(false); // raw text: boundary broken
+    expect(test(cleanForMatch('\x0304QUACK!\x03'))).toBe(true); // cleaned: matches
+  });
+
+  it('cleanForMatch also strips URLs', () => {
+    expect(cleanForMatch('see https://example.com/amiantos here')).not.toContain('amiantos');
   });
 });

--- a/shared/channels.ts
+++ b/shared/channels.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// One place to parse/normalize a channel-scope list so the /highlight parser,
+// the settings pane, the service, and the DB layer agree on splitting, trimming,
+// lowercasing (channel matching is case-insensitive), de-duping, and dropping
+// blanks. Previously this logic was reimplemented four times with inconsistent
+// casing.
+
+// Normalize an array of channel names: trim, lowercase, drop blanks, dedupe.
+// Non-string entries are ignored.
+export function normalizeChannelList(values: readonly unknown[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const c = (typeof v === 'string' ? v : '').trim().toLowerCase();
+    if (c && !seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+// Parse a free-form channel list (comma- and/or space-separated) into a
+// normalized array.
+export function parseChannelList(input: string): string[] {
+  return normalizeChannelList(input.split(/[\s,]+/));
+}

--- a/shared/highlightMatch.ts
+++ b/shared/highlightMatch.ts
@@ -20,10 +20,12 @@ interface HighlightRule {
 export interface CompiledRule {
   id: number;
   hasMask: boolean;
+  // false for a mask-only rule (no keyword) — lets matchEvent skip cleaning the
+  // text entirely, since a mask+channel hit is sufficient on its own.
+  hasPattern: boolean;
   matchesMask: (nick: string | null, userhost: string | null) => boolean;
   matchesChannel: (target: string) => boolean;
-  // Predicate over the cleaned message text. A mask-only rule (no keyword) tests
-  // always-true, so it highlights every in-scope message from the sender.
+  // Predicate over the cleaned message text (only consulted when hasPattern).
   test: (text: string) => boolean;
 }
 
@@ -54,6 +56,7 @@ export function compileRules(rules: HighlightRule[]): CompiledRule[] {
     compiled.push({
       id: rule.id,
       hasMask,
+      hasPattern: !!rule.pattern,
       matchesMask: buildMaskMatcher(rule.mask ?? null),
       matchesChannel: buildChannelMatcher(rule.channels ?? null),
       test,
@@ -74,12 +77,15 @@ export function matchEvent(
   const target = event.target || '';
   const nick = event.nick ?? null;
   const userhost = event.userhost ?? null;
-  // Clean the text lazily — a mask-only match never needs it.
+  // Clean the text lazily and at most once — a mask-only match never needs it,
+  // so the cost is skipped entirely unless a keyword rule is actually consulted.
   let cleaned: string | null = null;
   const text = () => (cleaned === null ? (cleaned = cleanForMatch(event.text || '')) : cleaned);
   for (const rule of compiled) {
     if (!rule.matchesChannel(target)) continue;
     if (rule.hasMask && !rule.matchesMask(nick, userhost)) continue;
+    // Mask-only rule: a mask + channel hit is sufficient, no text needed.
+    if (!rule.hasPattern) return { matched: true, ruleId: rule.id };
     if (rule.test(text())) return { matched: true, ruleId: rule.id };
   }
   return { matched: false, ruleId: null };

--- a/shared/highlightMatch.ts
+++ b/shared/highlightMatch.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { buildTextTest, cleanForMatch } from './textMatch.js';
+import { buildMaskMatcher, buildChannelMatcher, patternKindToTextKind } from './ignoreMatch.js';
+
+const ELIGIBLE_TYPES = new Set(['message', 'action']);
+
+// The structural shape the engine needs; the DB HighlightRule satisfies it.
+interface HighlightRule {
+  id: number;
+  enabled: boolean;
+  pattern: string | null;
+  mask?: string | null;
+  channels?: string[] | null;
+  kind: string;
+  case_sensitive: boolean;
+}
+
+export interface CompiledRule {
+  id: number;
+  hasMask: boolean;
+  matchesMask: (nick: string | null, userhost: string | null) => boolean;
+  matchesChannel: (target: string) => boolean;
+  // Predicate over the cleaned message text. A mask-only rule (no keyword) tests
+  // always-true, so it highlights every in-scope message from the sender.
+  test: (text: string) => boolean;
+}
+
+interface MatchableEvent {
+  type: string;
+  self?: boolean;
+  text?: string | null;
+  nick?: string | null;
+  userhost?: string | null;
+  target?: string;
+}
+
+export function compileRules(rules: HighlightRule[]): CompiledRule[] {
+  const compiled: CompiledRule[] = [];
+  for (const rule of rules) {
+    if (!rule.enabled) continue;
+    const hasMask = !!(rule.mask && rule.mask !== '*');
+    // A rule must do something — carry a sender mask or a keyword pattern.
+    if (!hasMask && !rule.pattern) continue;
+    let test: (text: string) => boolean;
+    if (!rule.pattern) {
+      test = () => true;
+    } else {
+      const t = buildTextTest(rule.pattern, patternKindToTextKind(rule.kind), rule.case_sensitive);
+      if (!t) continue; // invalid regex → drop the rule rather than throw
+      test = t;
+    }
+    compiled.push({
+      id: rule.id,
+      hasMask,
+      matchesMask: buildMaskMatcher(rule.mask ?? null),
+      matchesChannel: buildChannelMatcher(rule.channels ?? null),
+      test,
+    });
+  }
+  return compiled;
+}
+
+export function matchEvent(
+  event: MatchableEvent | null | undefined,
+  compiled: CompiledRule[],
+): { matched: boolean; ruleId: number | null } {
+  // Cheapest guard first: with no rules there is nothing to match, so skip the
+  // eligibility checks and text cleaning entirely.
+  if (compiled.length === 0) return { matched: false, ruleId: null };
+  if (!event || !ELIGIBLE_TYPES.has(event.type)) return { matched: false, ruleId: null };
+  if (event.self) return { matched: false, ruleId: null };
+  const target = event.target || '';
+  const nick = event.nick ?? null;
+  const userhost = event.userhost ?? null;
+  // Clean the text lazily — a mask-only match never needs it.
+  let cleaned: string | null = null;
+  const text = () => (cleaned === null ? (cleaned = cleanForMatch(event.text || '')) : cleaned);
+  for (const rule of compiled) {
+    if (!rule.matchesChannel(target)) continue;
+    if (rule.hasMask && !rule.matchesMask(nick, userhost)) continue;
+    if (rule.test(text())) return { matched: true, ruleId: rule.id };
+  }
+  return { matched: false, ruleId: null };
+}

--- a/shared/ignoreMatch.ts
+++ b/shared/ignoreMatch.ts
@@ -7,7 +7,7 @@
 // what (pattern), which (levels incl. the special NOHIGHLIGHT); is_except
 // inverts it into a longest-mask-wins whitelist entry, expires_at lapses it.
 
-import { buildTextTest, stripUrls, type TextKind } from './textMatch.js';
+import { buildTextTest, cleanForMatch, type TextKind } from './textMatch.js';
 import { LEVEL_DEFS, ALL_TYPES, HIGHLIGHTABLE } from './ignoreLevels.js';
 
 // Re-export the level helpers the store / parser / service pull from here.
@@ -43,6 +43,39 @@ function globToRegex(pattern: string, caseInsensitive: boolean): RegExp {
     .replace(/\*/g, '.*')
     .replace(/\?/g, '.');
   return new RegExp('^' + escaped + '$', caseInsensitive ? 'i' : '');
+}
+
+// Build a sender matcher from a mask. `null`/`*` matches anyone; a bare token is
+// a case-insensitive nick glob; a `nick!user@host` form globs each part. Shared
+// with the highlight engine so highlight `-mask` and ignore masks behave alike.
+export function buildMaskMatcher(
+  mask: string | null,
+): (nick: string | null, userhost: string | null) => boolean {
+  if (!mask || mask === '*') return () => true;
+  if (mask.includes('!') || mask.includes('@')) {
+    const { nick, user, host } = splitMask(mask);
+    const nickRe = globToRegex(nick, true);
+    const userRe = globToRegex(user, false);
+    const hostRe = globToRegex(host, false);
+    return (n, uh) => {
+      if (!n || !nickRe.test(n)) return false;
+      if (!uh) return user === '*' && host === '*';
+      const bang = uh.indexOf('!');
+      const at = uh.indexOf('@', bang + 1);
+      if (bang === -1 || at === -1) return user === '*' && host === '*';
+      return userRe.test(uh.slice(bang + 1, at)) && hostRe.test(uh.slice(at + 1));
+    };
+  }
+  const nickRe = globToRegex(mask, true);
+  return (n) => !!n && nickRe.test(n);
+}
+
+// Build a channel-scope matcher. `null`/empty matches every buffer; otherwise a
+// case-insensitive glob against each channel name. Shared with the highlight engine.
+export function buildChannelMatcher(channels: string[] | null): (target: string) => boolean {
+  if (!channels || channels.length === 0) return () => true;
+  const res = channels.map((c) => globToRegex(c, true));
+  return (t) => !!t && res.some((re) => re.test(t));
 }
 
 // ---- rule shape + evaluation -----------------------------------------------
@@ -89,9 +122,13 @@ export interface CompiledIgnoreRule {
   hideLevel: (type: string, isDm: boolean) => boolean;
 }
 
-function patternKindToTextKind(kind: string): TextKind {
+// Map a stored rule `kind` to the textMatch vocabulary. Ignore uses only
+// substr/full/regex; highlights add 'glob' and may carry the legacy 'plain'
+// alias, both handled here so the two engines share one mapping.
+export function patternKindToTextKind(kind: string): TextKind {
   if (kind === 'regex') return 'regex';
-  if (kind === 'full') return 'plain';
+  if (kind === 'glob') return 'glob';
+  if (kind === 'full' || kind === 'plain') return 'plain';
   return 'substr';
 }
 
@@ -103,34 +140,8 @@ export function compileIgnoreRules(rules: IgnoreRule[]): CompiledIgnoreRule[] {
     const hasAll = hideLevels.includes('ALL');
     const hides = hideLevels.length > 0;
 
-    let matchesNick: (nick: string | null, userhost: string | null) => boolean;
-    if (!rule.mask || rule.mask === '*') {
-      matchesNick = () => true;
-    } else if (rule.mask.includes('!') || rule.mask.includes('@')) {
-      const { nick, user, host } = splitMask(rule.mask);
-      const nickRe = globToRegex(nick, true);
-      const userRe = globToRegex(user, false);
-      const hostRe = globToRegex(host, false);
-      matchesNick = (n, uh) => {
-        if (!n || !nickRe.test(n)) return false;
-        if (!uh) return user === '*' && host === '*';
-        const bang = uh.indexOf('!');
-        const at = uh.indexOf('@', bang + 1);
-        if (bang === -1 || at === -1) return user === '*' && host === '*';
-        return userRe.test(uh.slice(bang + 1, at)) && hostRe.test(uh.slice(at + 1));
-      };
-    } else {
-      const nickRe = globToRegex(rule.mask, true);
-      matchesNick = (n) => !!n && nickRe.test(n);
-    }
-
-    let matchesChannel: (target: string) => boolean;
-    if (!rule.channels || rule.channels.length === 0) {
-      matchesChannel = () => true;
-    } else {
-      const res = rule.channels.map((c) => globToRegex(c, true));
-      matchesChannel = (t) => !!t && res.some((re) => re.test(t));
-    }
+    const matchesNick = buildMaskMatcher(rule.mask);
+    const matchesChannel = buildChannelMatcher(rule.channels);
 
     let matchesText: (text: string) => boolean;
     if (!rule.pattern) {
@@ -182,8 +193,8 @@ export function evaluateIgnores(
 ): IgnoreVerdict {
   if (compiled.length === 0) return { hide: false, nohilight: false };
   const { nick, userhost, target, type, isDm } = input;
-  // Only pay for URL-stripping when a rule actually matches text.
-  const text = input.text && anyHasPattern(compiled) ? stripUrls(input.text) : '';
+  // Only pay for the URL/formatting strip when a rule actually matches text.
+  const text = input.text && anyHasPattern(compiled) ? cleanForMatch(input.text) : '';
 
   let bestHide = -1;
   let bestHideExcept = -1;

--- a/shared/parseHighlight.ts
+++ b/shared/parseHighlight.ts
@@ -55,10 +55,22 @@ export function parseHighlightArgs(argLine: string): ParsedHighlight {
   let isMask = false;
   let sawRegexp = false;
   let sawFull = false;
+  // After a bare `--`, every remaining token is positional — lets a keyword that
+  // begins with `-` (e.g. `/highlight -- -Werror`) through the flag parser.
+  let endOfFlags = false;
 
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i];
     const lower = t.toLowerCase();
+
+    if (!endOfFlags && lower === '--') {
+      endOfFlags = true;
+      continue;
+    }
+    if (endOfFlags) {
+      positionals.push(t);
+      continue;
+    }
 
     if (lower === '-mask') {
       isMask = true;

--- a/shared/parseHighlight.ts
+++ b/shared/parseHighlight.ts
@@ -17,6 +17,7 @@
 // via -channels.
 
 import { tokenize } from './parseIgnore.js';
+import { parseChannelList } from './channels.js';
 
 export type HighlightKind = 'substr' | 'full' | 'regex';
 
@@ -29,13 +30,6 @@ export interface ParsedHighlight {
   // true = scope to the current network (-network); false (default) = global.
   scopeNetwork: boolean;
   error?: string;
-}
-
-function splitChannelList(value: string): string[] {
-  return value
-    .split(',')
-    .map((c) => c.trim().toLowerCase())
-    .filter(Boolean);
 }
 
 export function parseHighlightArgs(argLine: string): ParsedHighlight {
@@ -98,8 +92,10 @@ export function parseHighlightArgs(argLine: string): ParsedHighlight {
     }
     if (lower === '-channels' || lower === '-channel') {
       const val = tokens[++i];
-      if (val === undefined) return fail('-channels needs a value');
-      for (const c of splitChannelList(val)) channels.push(c);
+      // A value that's missing or itself a flag (channels never start with '-')
+      // means the user forgot the argument — don't silently swallow the next flag.
+      if (val === undefined || val.startsWith('-')) return fail('-channels needs a value');
+      for (const c of parseChannelList(val)) channels.push(c);
       continue;
     }
     if (t.startsWith('-') && t.length > 1) return fail(`unknown flag: ${t}`);

--- a/shared/parseHighlight.ts
+++ b/shared/parseHighlight.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Parser for the /highlight command line (issue #349), modeled on irssi's
+// /hilight but trimmed to the flags we support:
+//
+//   /highlight [-mask] [-full | -regexp] [-matchcase] [-network | -global]
+//              [-channels <#a,#b>] <text|mask>
+//
+// irssi's -nick/-word/-line (which control *what* to colorize) are omitted — we
+// always tint the whole line + sidebar dot. Lives in shared/ so the client
+// command handler and parity tests use one implementation. Pure: no DOM/clock.
+//
+// The positional is the keyword by default, or a nick!user@host sender mask when
+// -mask is given. Unlike /ignore, a leading '#' on a positional is NOT treated
+// as a channel (a keyword may legitimately be "#release"); channel scope is only
+// via -channels.
+
+import { tokenize } from './parseIgnore.js';
+
+export type HighlightKind = 'substr' | 'full' | 'regex';
+
+export interface ParsedHighlight {
+  pattern: string | null;
+  mask: string | null;
+  channels: string[] | null;
+  kind: HighlightKind;
+  caseSensitive: boolean;
+  // true = scope to the current network (-network); false (default) = global.
+  scopeNetwork: boolean;
+  error?: string;
+}
+
+function splitChannelList(value: string): string[] {
+  return value
+    .split(',')
+    .map((c) => c.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function parseHighlightArgs(argLine: string): ParsedHighlight {
+  const base: ParsedHighlight = {
+    pattern: null,
+    mask: null,
+    channels: null,
+    kind: 'substr',
+    caseSensitive: false,
+    scopeNetwork: false,
+  };
+  const fail = (error: string): ParsedHighlight => ({ ...base, error });
+
+  const tokens = tokenize(argLine.trim());
+  const positionals: string[] = [];
+  const channels: string[] = [];
+  let isMask = false;
+  let sawRegexp = false;
+  let sawFull = false;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    const lower = t.toLowerCase();
+
+    if (lower === '-mask') {
+      isMask = true;
+      continue;
+    }
+    if (lower === '-regexp' || lower === '-regex') {
+      sawRegexp = true;
+      continue;
+    }
+    if (lower === '-full' || lower === '-word') {
+      sawFull = true;
+      continue;
+    }
+    if (lower === '-matchcase' || lower === '-case') {
+      base.caseSensitive = true;
+      continue;
+    }
+    if (lower === '-network' || lower === '-net') {
+      base.scopeNetwork = true;
+      continue;
+    }
+    if (lower === '-global') {
+      base.scopeNetwork = false;
+      continue;
+    }
+    if (lower === '-channels' || lower === '-channel') {
+      const val = tokens[++i];
+      if (val === undefined) return fail('-channels needs a value');
+      for (const c of splitChannelList(val)) channels.push(c);
+      continue;
+    }
+    if (t.startsWith('-') && t.length > 1) return fail(`unknown flag: ${t}`);
+
+    positionals.push(t);
+  }
+
+  if (sawRegexp && sawFull) return fail('-regexp and -full are mutually exclusive');
+
+  const value = positionals.join(' ').trim();
+  if (!value) return fail(isMask ? 'a mask is required' : 'a pattern is required');
+
+  base.kind = sawRegexp ? 'regex' : sawFull ? 'full' : 'substr';
+  base.channels = channels.length ? channels : null;
+  if (isMask) {
+    base.mask = value;
+  } else {
+    base.pattern = value;
+  }
+  return base;
+}

--- a/shared/parseIgnore.ts
+++ b/shared/parseIgnore.ts
@@ -85,7 +85,8 @@ export function durationToExpiry(s: string, now: number = Date.now()): string | 
 
 // Tokenize on whitespace, but keep a "(…)" group (balanced) or a "quoted" string
 // as a single token so `-pattern (a|b c)` / `-pattern "two words"` survive.
-function tokenize(s: string): string[] {
+// Exported so the sibling /highlight parser shares the exact same tokenization.
+export function tokenize(s: string): string[] {
   const tokens: string[] = [];
   let i = 0;
   const n = s.length;

--- a/shared/textMatch.ts
+++ b/shared/textMatch.ts
@@ -86,18 +86,19 @@ export function stripUrls(text: string): string {
 }
 
 // mIRC/IRC formatting control codes: color (\x03[fg][,bg]), hex color
-// (\x04RRGGBB), and the toggles bold/italic/underline/reverse/reset/monospace.
-// These must be removed before whole-word matching: a colored word like
-// `\x0304QUACK!` leaves the digit `4` glued to the front of QUACK, which breaks
-// the word boundary and makes the highlight miss. The color form mirrors the
-// client renderer (vue_client/src/utils/nickColor.ts) exactly so the matcher
-// strips precisely what the user sees: \x03 with an optional 1-2 digit fg and an
-// optional ,bg — a bare \x03 is a reset, and \x03 followed by `,NN` (bg, no fg)
-// is NOT a color code, so its digits stay as text. Matching the control codes
-// literally is the whole point here, so the no-control-regex rule is moot.
+// (\x04RRGGBB), and the toggles. These must be removed before whole-word
+// matching: a colored word like `\x0304QUACK!` leaves the digit `4` glued to the
+// front of QUACK, which breaks the word boundary and makes the highlight miss.
+// The set mirrors the client renderer (vue_client/src/utils/nickColor.ts) EXACTLY
+// so the matcher strips precisely what the user sees — the toggles are bold
+// \x02, monospace \x11, reverse \x16, italic \x1d, strike \x1e, underline \x1f,
+// reset \x0f; and \x03 with an optional 1-2 digit fg + optional ,bg (a bare \x03
+// is a reset, and \x03 followed by `,NN` (bg, no fg) is NOT a color, so its digits
+// stay text). Matching control codes literally is the point, so no-control-regex
+// is moot.
 /* eslint-disable no-control-regex */
 const FORMAT_RE =
-  /\x03(?:\d{1,2}(?:,\d{1,2})?)?|\x04[0-9A-Fa-f]{6}|[\x02\x1d\x1f\x16\x0f\x11\x06]/g;
+  /\x03(?:\d{1,2}(?:,\d{1,2})?)?|\x04[0-9A-Fa-f]{6}|[\x02\x0f\x11\x16\x1d\x1e\x1f]/g;
 /* eslint-enable no-control-regex */
 
 export function stripFormatting(text: string): string {

--- a/shared/textMatch.ts
+++ b/shared/textMatch.ts
@@ -89,11 +89,16 @@ export function stripUrls(text: string): string {
 // (\x04RRGGBB), and the toggles bold/italic/underline/reverse/reset/monospace.
 // These must be removed before whole-word matching: a colored word like
 // `\x0304QUACK!` leaves the digit `4` glued to the front of QUACK, which breaks
-// the word boundary and makes the highlight miss. Color is stripped before the
-// toggles so the numeric arguments go with their \x03. Matching the control
-// codes literally is the whole point here, so the no-control-regex rule is moot.
-// eslint-disable-next-line no-control-regex
-const FORMAT_RE = /\x03\d{0,2}(?:,\d{1,2})?|\x04[0-9A-Fa-f]{6}|[\x02\x1d\x1f\x16\x0f\x11\x06]/g;
+// the word boundary and makes the highlight miss. The color form mirrors the
+// client renderer (vue_client/src/utils/nickColor.ts) exactly so the matcher
+// strips precisely what the user sees: \x03 with an optional 1-2 digit fg and an
+// optional ,bg — a bare \x03 is a reset, and \x03 followed by `,NN` (bg, no fg)
+// is NOT a color code, so its digits stay as text. Matching the control codes
+// literally is the whole point here, so the no-control-regex rule is moot.
+/* eslint-disable no-control-regex */
+const FORMAT_RE =
+  /\x03(?:\d{1,2}(?:,\d{1,2})?)?|\x04[0-9A-Fa-f]{6}|[\x02\x1d\x1f\x16\x0f\x11\x06]/g;
+/* eslint-enable no-control-regex */
 
 export function stripFormatting(text: string): string {
   return text.replace(FORMAT_RE, '');

--- a/shared/textMatch.ts
+++ b/shared/textMatch.ts
@@ -28,6 +28,16 @@ export function globToRegexSource(pattern: string): string {
   return out;
 }
 
+// A "word character" for whole-word matching: any Unicode letter or number, or
+// underscore. Crucially this is NOT JS's ASCII-only `\w`/`\W` — those treat any
+// accented or non-Latin letter (e.g. `ł`) as a boundary, so a keyword `em` would
+// wrongly match inside `zrozumiałem`. `\p{L}\p{N}` (with the `u` flag) keeps
+// non-ASCII letters as word chars. The prefix is a consuming negated class
+// rather than a lookbehind so the regex compiles on older engines (Safari < 16.4
+// lacks lookbehind — a throw there would silently drop the rule).
+const WORD_CHAR = '[\\p{L}\\p{N}_]';
+const NON_WORD_CHAR = '[^\\p{L}\\p{N}_]';
+
 // Compile a text pattern into a predicate. Returns null when the pattern can't
 // compile (invalid regex) so callers can drop the rule rather than throw.
 export function buildTextTest(
@@ -41,17 +51,22 @@ export function buildTextTest(
     return (text: string) => text.toLowerCase().includes(needle);
   }
   const flags = caseSensitive ? '' : 'i';
-  let source: string;
+  // Raw user regex compiles as-is (no `u` flag — a user pattern may use syntax
+  // that's invalid in Unicode mode, e.g. an unescaped `{`).
   if (kind === 'regex') {
-    source = pattern;
-  } else if (kind === 'glob') {
-    source = `(?:^|\\W)(?:${globToRegexSource(pattern)})(?=\\W|$)`;
-  } else {
-    // 'plain'
-    source = `(?:^|\\W)(?:${escapeRegex(pattern)})(?=\\W|$)`;
+    try {
+      const re = new RegExp(pattern, flags);
+      return (text: string) => re.test(text);
+    } catch {
+      return null;
+    }
   }
+  // 'plain' (literal whole-word) or 'glob' (whole-word with * and ?). We control
+  // the generated source, so the `u` flag is always safe here.
+  const body = kind === 'glob' ? globToRegexSource(pattern) : escapeRegex(pattern);
+  const source = `(?:^|${NON_WORD_CHAR})(?:${body})(?!${WORD_CHAR})`;
   try {
-    const re = new RegExp(source, flags);
+    const re = new RegExp(source, flags + 'u');
     return (text: string) => re.test(text);
   } catch {
     return null;
@@ -68,4 +83,25 @@ const URL_RE = createUrlRegex();
 // fuse into a false match.
 export function stripUrls(text: string): string {
   return text.replace(URL_RE, ' ');
+}
+
+// mIRC/IRC formatting control codes: color (\x03[fg][,bg]), hex color
+// (\x04RRGGBB), and the toggles bold/italic/underline/reverse/reset/monospace.
+// These must be removed before whole-word matching: a colored word like
+// `\x0304QUACK!` leaves the digit `4` glued to the front of QUACK, which breaks
+// the word boundary and makes the highlight miss. Color is stripped before the
+// toggles so the numeric arguments go with their \x03. Matching the control
+// codes literally is the whole point here, so the no-control-regex rule is moot.
+// eslint-disable-next-line no-control-regex
+const FORMAT_RE = /\x03\d{0,2}(?:,\d{1,2})?|\x04[0-9A-Fa-f]{6}|[\x02\x1d\x1f\x16\x0f\x11\x06]/g;
+
+export function stripFormatting(text: string): string {
+  return text.replace(FORMAT_RE, '');
+}
+
+// Normalize a message body for highlight/ignore-pattern matching: drop IRC
+// formatting codes, then blank out URLs. Both the highlight engine and the
+// ignore content matcher run this so they agree on what the "text" is.
+export function cleanForMatch(text: string): string {
+  return stripUrls(stripFormatting(text));
 }

--- a/vue_client/src/components/IconButton.vue
+++ b/vue_client/src/components/IconButton.vue
@@ -1,0 +1,57 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Compact icon-only action button (edit / remove / …) shared by the settings
+  panes' row lists. Icon-only buttons need an accessible name, so `label` drives
+  both the tooltip and aria-label; the glyph itself is aria-hidden. @click falls
+  through to the underlying <button>.
+-->
+<template>
+  <button
+    type="button"
+    class="icon-btn"
+    :class="{ danger }"
+    :disabled="disabled"
+    :title="label"
+    :aria-label="label"
+  >
+    <i :class="['fa-solid', icon]" aria-hidden="true"></i>
+  </button>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  /** Font Awesome glyph class, e.g. 'fa-pen'. */
+  icon: string;
+  /** Accessible name (tooltip + aria-label), e.g. 'edit'. */
+  label: string;
+  /** Render in the destructive color. */
+  danger?: boolean;
+  disabled?: boolean;
+}>();
+</script>
+
+<style scoped>
+.icon-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+.icon-btn:hover:not(:disabled) {
+  color: var(--fg);
+}
+.icon-btn.danger {
+  color: var(--bad);
+}
+.icon-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2176,10 +2176,12 @@ function runUnhighlight(argLine: string, networkId: number | null, target: strin
       .catch((e: any) => localInfo(networkId, target, `/unhighlight: ${e?.message || 'failed'}`));
     return true;
   }
-  // Remove by keyword/mask text (case-insensitive, exact match of pattern or mask).
+  // Remove by keyword/mask text (case-insensitive, exact match of pattern OR
+  // mask — check both, since a rule can carry both and `??` would hide the mask).
   const lc = arg.toLowerCase();
   const matches = list.filter(
-    ({ entry }) => (entry.pattern ?? entry.mask ?? '').toLowerCase() === lc,
+    ({ entry }) =>
+      (entry.pattern ?? '').toLowerCase() === lc || (entry.mask ?? '').toLowerCase() === lc,
   );
   const removable = matches.filter(({ entry }) => !entry.auto_managed);
   if (!matches.length) {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -140,7 +140,9 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore, onInsertUrl } from '../stores/uploads.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
+import { useHighlightRulesStore, type HighlightRule } from '../stores/highlightRules.js';
 import { parseIgnoreArgs } from '../../../shared/parseIgnore.js';
+import { parseHighlightArgs } from '../../../shared/parseHighlight.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChanlistStore } from '../stores/chanlist.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
@@ -191,6 +193,7 @@ const config = useConfigStore();
 const uploads = useUploadsStore();
 const toasts = useToastsStore();
 const ignores = useIgnoresStore();
+const highlightRules = useHighlightRulesStore();
 const chanlist = useChanlistStore();
 const channelListModal = useChannelListModal();
 const nickColors = useNickColors();
@@ -206,6 +209,23 @@ function combinedIgnores(networkId: number | null): { entry: IgnoreEntry; scope:
   if (networkId == null) return globals;
   const own = ignores
     .masksFor(networkId)
+    .map((entry) => ({ entry, scope: networkId as number | null }));
+  return [...globals, ...own];
+}
+
+// Highlight rules visible from this network, in /highlight-listing order: globals
+// first (scope null), then this network's own (scope = networkId). Mirrors
+// combinedIgnores so /unhighlight <n> maps 1:1 to the listed index. Auto-managed
+// (network-nick) rules are network-scoped, so they appear in the own section.
+function combinedHighlights(
+  networkId: number | null,
+): { entry: HighlightRule; scope: number | null }[] {
+  const globals = highlightRules.rules
+    .filter((r) => r.networkIds.length === 0)
+    .map((entry) => ({ entry, scope: null as number | null }));
+  if (networkId == null) return globals;
+  const own = highlightRules.rules
+    .filter((r) => r.networkIds.includes(networkId))
     .map((entry) => ({ entry, scope: networkId as number | null }));
   return [...globals, ...own];
 }
@@ -1862,6 +1882,31 @@ function formatIgnoreEntry(entry: IgnoreEntry, idx: number, global = false): str
   return `  ${idx}. ${summarizeIgnoreEntry(entry, global)}`;
 }
 
+// "QUACK!  [global]  [full]  #chan" — a highlight rule's dimensions, no index.
+function summarizeHighlightEntry(entry: HighlightRule, global = false): string {
+  const parts: string[] = [];
+  if (entry.mask) {
+    parts.push(entry.mask, '[mask]');
+  } else if (entry.pattern) {
+    parts.push(entry.kind === 'regex' ? `/${entry.pattern}/` : `"${entry.pattern}"`);
+  }
+  if (global) parts.push('[global]');
+  // Default match is substr; only call out the non-default kinds for keywords.
+  if (!entry.mask && entry.kind && entry.kind !== 'substr' && entry.kind !== 'regex') {
+    parts.push(`[${entry.kind}]`);
+  }
+  if (entry.case_sensitive) parts.push('[case]');
+  if (entry.channels?.length) parts.push(entry.channels.join(','));
+  if (entry.auto_managed) parts.push('[auto]');
+  if (!entry.enabled) parts.push('[disabled]');
+  return parts.join('  ');
+}
+
+// One indexed line for the /highlight listing.
+function formatHighlightEntry(entry: HighlightRule, idx: number, global = false): string {
+  return `  ${idx}. ${summarizeHighlightEntry(entry, global)}`;
+}
+
 const COMMANDS_LINES = [
   'commands:',
   '  /me <text>             — emote in the current buffer',
@@ -1896,6 +1941,10 @@ const COMMANDS_LINES = [
   '      LEVELS: ALL PUBLIC MSGS NOTICES ACTIONS JOINS PARTS QUITS NICKS KICKS MODES TOPICS NOHIGHLIGHT',
   '      e.g. /ignore bob NOHIGHLIGHT   ·   /ignore -network -regexp -pattern (foo|bar) #chan',
   '  /unignore <index|mask> — remove an ignore (index from /ignore list)',
+  '  /highlight [opts] <text> — list, or add a highlight rule (global by default; alias: /hilight)',
+  '      opts: -network -mask -full -regexp -matchcase -channels <#a,#b>',
+  '      e.g. /highlight QUACK!   ·   /highlight -mask bob!*@*   ·   /highlight -network -regexp qu+ack',
+  '  /unhighlight <index|text> — remove a highlight (index from /highlight list; alias: /dehilight)',
   '  /network [list]        — manage networks (alias: /net); runs from the system buffer',
   '      add [-host <addr>] [-port <n>] [-tls|-notls] [-nick <n>] [-user <u>] [-realname <name>]',
   '          [-sasl_username <u>] [-sasl_password <p>] [-password <serverpass>]',
@@ -2052,6 +2101,112 @@ function runUnignore(argLine: string, networkId: number | null, target: string):
     target,
     `removed ${matches.length} ignore${matches.length > 1 ? 's' : ''} matching "${arg}".`,
   );
+  return true;
+}
+
+// /highlight and /unhighlight manage the per-user highlight rules (global by
+// default; `-network` scopes to the active network), the same list the settings
+// pane edits. Network-agnostic, so they run from the system buffer too. CRUD is
+// REST-backed (async); the server fans `highlight-rules-changed` to keep other
+// sessions in sync.
+function runHighlight(argLine: string, networkId: number | null, target: string): boolean {
+  const args = argLine.trim();
+  if (!args) {
+    const list = combinedHighlights(networkId);
+    if (!list.length) {
+      localInfo(networkId, target, 'highlight list is empty.');
+    } else {
+      localInfo(networkId, target, `highlight list (${list.length}):`);
+      list.forEach(({ entry, scope }, i) =>
+        localInfo(networkId, target, formatHighlightEntry(entry, i + 1, scope === null)),
+      );
+    }
+    return true;
+  }
+  const parsed = parseHighlightArgs(args);
+  if (parsed.error) {
+    localInfo(networkId, target, `/highlight: ${parsed.error}`);
+    return true;
+  }
+  if (parsed.scopeNetwork && networkId == null) {
+    localInfo(
+      networkId,
+      target,
+      '/highlight -network needs an active network — switch to a channel or DM.',
+    );
+    return true;
+  }
+  highlightRules
+    .create({
+      pattern: parsed.pattern,
+      mask: parsed.mask,
+      channels: parsed.channels,
+      kind: parsed.kind,
+      case_sensitive: parsed.caseSensitive,
+      enabled: true,
+      networkId: parsed.scopeNetwork ? networkId : null,
+    })
+    .then((rule) => {
+      if (rule)
+        localInfo(
+          networkId,
+          target,
+          `highlight added: ${summarizeHighlightEntry(rule, rule.networkIds.length === 0)}`,
+        );
+      return rule;
+    })
+    .catch((e: any) => localInfo(networkId, target, `/highlight: ${e?.message || 'failed'}`));
+  return true;
+}
+
+function runUnhighlight(argLine: string, networkId: number | null, target: string): boolean {
+  const arg = argLine.trim();
+  if (!arg) {
+    localInfo(networkId, target, 'usage: /unhighlight <index|text>  (index from /highlight)');
+    return true;
+  }
+  const list = combinedHighlights(networkId);
+  const autoHint = 'auto-managed (your nick) — disable it in the Highlights settings pane instead';
+  if (/^\d+$/.test(arg)) {
+    const item = list[Number(arg) - 1];
+    if (!item) {
+      localInfo(networkId, target, `/unhighlight: no highlight #${arg} (see /highlight)`);
+      return true;
+    }
+    if (item.entry.auto_managed) {
+      localInfo(networkId, target, `/unhighlight: #${arg} is ${autoHint}`);
+      return true;
+    }
+    const summary = summarizeHighlightEntry(item.entry, item.scope === null);
+    highlightRules
+      .remove(item.entry.id)
+      .then(() => localInfo(networkId, target, `removed highlight #${arg}: ${summary}`))
+      .catch((e: any) => localInfo(networkId, target, `/unhighlight: ${e?.message || 'failed'}`));
+    return true;
+  }
+  // Remove by keyword/mask text (case-insensitive, exact match of pattern or mask).
+  const lc = arg.toLowerCase();
+  const matches = list.filter(
+    ({ entry }) => (entry.pattern ?? entry.mask ?? '').toLowerCase() === lc,
+  );
+  const removable = matches.filter(({ entry }) => !entry.auto_managed);
+  if (!matches.length) {
+    localInfo(networkId, target, `/unhighlight: no highlight matching "${arg}" (see /highlight)`);
+    return true;
+  }
+  if (!removable.length) {
+    localInfo(networkId, target, `/unhighlight: "${arg}" is ${autoHint}`);
+    return true;
+  }
+  Promise.all(removable.map(({ entry }) => highlightRules.remove(entry.id)))
+    .then(() =>
+      localInfo(
+        networkId,
+        target,
+        `removed ${removable.length} highlight${removable.length > 1 ? 's' : ''} matching "${arg}".`,
+      ),
+    )
+    .catch((e: any) => localInfo(networkId, target, `/unhighlight: ${e?.message || 'failed'}`));
   return true;
 }
 
@@ -2252,6 +2407,12 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       return runIgnore(argLine, networkId, target);
     case 'unignore':
       return runUnignore(argLine, networkId, target);
+    case 'highlight':
+    case 'hilight':
+      return runHighlight(argLine, networkId, target);
+    case 'unhighlight':
+    case 'dehilight':
+      return runUnhighlight(argLine, networkId, target);
     case 'network':
     case 'net':
       // Network CRUD + connection control. REST-backed and async, so fire it

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2158,7 +2158,8 @@ function runUnhighlight(argLine: string, networkId: number | null, target: strin
     return true;
   }
   const list = combinedHighlights(networkId);
-  const autoHint = 'auto-managed (your nick) — disable it in the Highlights settings pane instead';
+  const autoHint =
+    'auto-managed (tracks your nick) and read-only — it follows your nick automatically';
   if (/^\d+$/.test(arg)) {
     const item = list[Number(arg) - 1];
     if (!item) {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -143,6 +143,7 @@ import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
 import { useHighlightRulesStore, type HighlightRule } from '../stores/highlightRules.js';
 import { parseIgnoreArgs } from '../../../shared/parseIgnore.js';
 import { parseHighlightArgs } from '../../../shared/parseHighlight.js';
+import { highlightRuleDetailParts } from '../utils/highlightFormat.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChanlistStore } from '../stores/chanlist.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
@@ -1882,24 +1883,15 @@ function formatIgnoreEntry(entry: IgnoreEntry, idx: number, global = false): str
   return `  ${idx}. ${summarizeIgnoreEntry(entry, global)}`;
 }
 
-// "QUACK!  [global]  [full]  #chan" — a highlight rule's dimensions, no index.
+// "QUACK! · whole word · #chan" — a highlight rule's dimensions, no index. The
+// subject (mask/pattern) and scope are framed here; the secondary descriptors
+// come from the shared formatter the settings pane also uses.
 function summarizeHighlightEntry(entry: HighlightRule, global = false): string {
-  const parts: string[] = [];
-  if (entry.mask) {
-    parts.push(entry.mask, '[mask]');
-  } else if (entry.pattern) {
-    parts.push(entry.kind === 'regex' ? `/${entry.pattern}/` : `"${entry.pattern}"`);
-  }
-  if (global) parts.push('[global]');
-  // Default match is substr; only call out the non-default kinds for keywords.
-  if (!entry.mask && entry.kind && entry.kind !== 'substr' && entry.kind !== 'regex') {
-    parts.push(`[${entry.kind}]`);
-  }
-  if (entry.case_sensitive) parts.push('[case]');
-  if (entry.channels?.length) parts.push(entry.channels.join(','));
-  if (entry.auto_managed) parts.push('[auto]');
-  if (!entry.enabled) parts.push('[disabled]');
-  return parts.join('  ');
+  const subject = entry.mask ? `${entry.mask} (mask)` : (entry.pattern ?? '*');
+  const parts = [subject];
+  if (global) parts.push('global');
+  parts.push(...highlightRuleDetailParts(entry));
+  return parts.join(' · ');
 }
 
 // One indexed line for the /highlight listing.

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -701,13 +701,14 @@ const renderRows = computed((): RenderRow[] => {
       rowNohilight = verdict.nohilight;
     }
 
-    // Render-time highlight match (#349). The server already stamps m.matched at
-    // insert (drives notifications + the highlights feed); evaluating again here
-    // means a rule added/removed/toggled now re-colors on-screen rows live, and
-    // honors -network/-channels/-mask scope. Skip the work when the stamp already
-    // says matched, or for self rows.
+    // Render-time highlight match (#349). The server stamps m.matched at insert
+    // (drives notifications + the highlights feed). For the live tint we evaluate
+    // against the *current* rules instead, so adding a rule lights matching rows
+    // up AND removing/disabling one clears them — honoring -network/-channels/
+    // -mask scope. Client evaluation is authoritative once the rule store has
+    // loaded; until then we fall back to the server stamp.
     let rowHighlight = !!m.matched;
-    if (!rowHighlight && !m.self && networkId) {
+    if (highlights.loaded && !m.self && networkId) {
       rowHighlight = highlights.evaluate(networkId, {
         nick: m.nick,
         userhost: m.userhost ?? null,

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -191,6 +191,7 @@ import { useNetworksStore, type AwayState } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useIgnoresStore } from '../stores/ignores.js';
+import { useHighlightRulesStore } from '../stores/highlightRules.js';
 import { socketSend } from '../composables/useSocket.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useViewport } from '../composables/useViewport.js';
@@ -272,6 +273,9 @@ interface RenderRow {
   continuationTime?: boolean;
   // A NOHIGHLIGHT ignore rule matched — suppress the highlight tint (#301).
   nohilight?: boolean;
+  // A highlight rule matched — server stamp (m.matched) OR live client eval
+  // (#349), so a freshly added rule tints scrollback without a reload.
+  highlight?: boolean;
 }
 
 // Ignore-confirm modal target
@@ -293,6 +297,7 @@ const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const settings = useSettingsStore();
 const ignores = useIgnoresStore();
+const highlights = useHighlightRulesStore();
 const nicks = useNickColors();
 const { isMobile } = useViewport();
 
@@ -451,7 +456,7 @@ function rowClass(row: RenderRow) {
     [`type-${m?.type}`]: true,
     self: m?.self,
     alt: row.alt,
-    highlight: !!m?.matched && !row.nohilight,
+    highlight: !!row.highlight && !row.nohilight,
     'cont-author': !!row.continuationAuthor,
     'cont-time': !!row.continuationTime,
   };
@@ -696,6 +701,23 @@ const renderRows = computed((): RenderRow[] => {
       rowNohilight = verdict.nohilight;
     }
 
+    // Render-time highlight match (#349). The server already stamps m.matched at
+    // insert (drives notifications + the highlights feed); evaluating again here
+    // means a rule added/removed/toggled now re-colors on-screen rows live, and
+    // honors -network/-channels/-mask scope. Skip the work when the stamp already
+    // says matched, or for self rows.
+    let rowHighlight = !!m.matched;
+    if (!rowHighlight && !m.self && networkId) {
+      rowHighlight = highlights.evaluate(networkId, {
+        nick: m.nick,
+        userhost: m.userhost ?? null,
+        target: bufTarget,
+        text: m.text ?? '',
+        type: m.type,
+        self: m.self,
+      });
+    }
+
     if (filterOn && m.nick && !m.self) {
       const filterable =
         (m.type === 'join' && fJoin) ||
@@ -748,7 +770,13 @@ const renderRows = computed((): RenderRow[] => {
       out.push({ divider: 'unread', key: 'unread-divider' });
       dividerInserted = true;
     }
-    out.push({ m, alt: STRIPED_TYPES.has(m.type) && !!m.alt, key, nohilight: rowNohilight });
+    out.push({
+      m,
+      alt: STRIPED_TYPES.has(m.type) && !!m.alt,
+      key,
+      nohilight: rowNohilight,
+      highlight: rowHighlight,
+    });
   }
 
   // Both presence timestamps newer than every loaded message → markers land

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -44,7 +44,7 @@
                     ? 'enabled — click to disable'
                     : 'disabled — click to enable'
               "
-              :aria-label="entry.enabled ? 'enabled' : 'disabled'"
+              aria-label="toggle highlight rule"
               @click="toggleEnabled(entry, !entry.enabled)"
             >
               <i

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -27,9 +27,6 @@
       <ul class="device-list">
         <li v-for="entry in group.entries" :key="entry.id" class="device">
           <span class="ua">
-            <span v-if="entry.auto_managed" class="lock" title="auto-managed (network nick)"
-              >🔒</span
-            >
             {{ entry.mask ?? entry.pattern ?? '*' }}
             <span class="muted small hl-detail">{{ describe(entry) }}</span>
           </span>
@@ -446,9 +443,6 @@ async function onRemove(entry: HighlightRule) {
 .device .ua {
   min-width: 0;
   overflow-wrap: anywhere;
-}
-.lock {
-  margin-right: var(--space-1);
 }
 /* Enabled toggle: muted when off, accent when on; the glyph (toggle-on/off)
    plus aria-pressed carry the state. */

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -52,8 +52,8 @@
                 aria-hidden="true"
               ></i>
             </button>
-            <!-- Auto-managed (network nick) rules track your nick — only the
-                 enabled toggle applies, so edit/remove show disabled. -->
+            <!-- Auto-managed (network nick) rules are fully system-managed, so the
+                 toggle (above) and edit/remove are all disabled. -->
             <IconButton
               icon="fa-pen"
               label="edit"

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -7,227 +7,487 @@
   <section id="highlights" class="settings-pane">
     <h2>highlights</h2>
     <p class="section-desc">
-      Rules whose pattern matches an incoming message mark it as a highlight (line accent + sidebar
-      dot). Auto-managed entries track each network's current nick and can only be enabled/disabled.
-      For sender masks, per-network or per-channel scope, use the
-      <code>/highlight</code> command (e.g. <code>/highlight -mask bob!*@*</code>). Configure
-      notification delivery for matched highlights in the Notifications pane.
+      Highlight rules mark matching messages (line accent + sidebar dot). A rule matches a keyword
+      (<code>contains</code>, <code>whole word</code>, <code>glob</code>, or <code>regex</code>)
+      and/or a sender hostmask (<code>nick!user@host</code> with <code>*</code> wildcards), and can
+      be narrowed to specific channels. Rules are <strong>global</strong> by default; scope one to a
+      single network if you only want it there. Everything here is also available through the
+      <code>/highlight</code> command. Configure notification delivery in the Notifications pane.
     </p>
+
+    <p v-if="formError" class="error inline">{{ formError }}</p>
     <p v-if="rulesError" class="error inline">{{ rulesError }}</p>
-    <ul class="rule-list">
-      <li v-for="rule in rules" :key="rule.id" class="rule" :class="{ auto: rule.auto_managed }">
-        <span class="lock" :title="rule.auto_managed ? 'auto-managed (network nick)' : 'user rule'">
-          {{ rule.auto_managed ? '🔒' : '' }}
-        </span>
-        <div class="pat-cell">
-          <input
-            type="text"
-            class="pattern"
-            :value="rule.mask ?? rule.pattern ?? ''"
-            :disabled="rule.auto_managed || !!rule.mask"
-            @change="onRuleField(rule, 'pattern', ($event.target as HTMLInputElement).value)"
-            :placeholder="rule.mask ? 'mask' : 'pattern'"
-          />
-          <span v-if="ruleScopeLabel(rule)" class="scope">{{ ruleScopeLabel(rule) }}</span>
+
+    <p v-if="!highlightGroups.length" class="muted small">
+      No highlights yet. Add one below, or type <code>/highlight &lt;word&gt;</code> in any buffer.
+    </p>
+
+    <template v-for="group in highlightGroups" :key="group.key">
+      <h3 class="subhead">{{ group.name }}</h3>
+      <ul class="device-list">
+        <li v-for="entry in group.entries" :key="entry.id" class="device">
+          <span class="ua">
+            <span v-if="entry.auto_managed" class="lock" title="auto-managed (network nick)"
+              >🔒</span
+            >
+            {{ entry.mask ?? entry.pattern ?? '*' }}
+            <span class="muted small hl-detail">{{ describe(entry) }}</span>
+          </span>
+          <label class="ck inline" title="enabled">
+            <input
+              type="checkbox"
+              :checked="entry.enabled"
+              @change="toggleEnabled(entry, ($event.target as HTMLInputElement).checked)"
+            />
+            <span>{{ entry.enabled ? 'on' : 'off' }}</span>
+          </label>
+          <button v-if="!entry.auto_managed" class="link" @click="startEdit(entry)">edit</button>
+          <button v-if="!entry.auto_managed" class="link danger" @click="onRemove(entry)">
+            remove
+          </button>
+        </li>
+      </ul>
+    </template>
+
+    <h3 class="subhead">{{ editing ? 'edit highlight' : 'add highlight' }}</h3>
+    <div class="rule-form">
+      <!-- Scope -->
+      <div class="field">
+        <span class="field-label">Scope</span>
+        <div class="row">
+          <div class="seg" role="radiogroup" aria-label="Scope">
+            <button
+              type="button"
+              role="radio"
+              :aria-checked="scopeMode === 'global'"
+              :class="{ active: scopeMode === 'global' }"
+              @click="scopeMode = 'global'"
+            >
+              Global
+            </button>
+            <button
+              type="button"
+              role="radio"
+              :aria-checked="scopeMode === 'network'"
+              :class="{ active: scopeMode === 'network' }"
+              :disabled="!networkOptions.length"
+              @click="selectNetworkScope"
+            >
+              One network
+            </button>
+          </div>
+          <select v-if="scopeMode === 'network'" v-model.number="scopeNetworkId">
+            <option v-for="opt in networkOptions" :key="opt.id" :value="opt.id">
+              {{ opt.name }}
+            </option>
+          </select>
         </div>
-        <select
-          :value="rule.kind"
-          :disabled="rule.auto_managed || !!rule.mask"
-          @change="onRuleField(rule, 'kind', ($event.target as HTMLSelectElement).value)"
+      </div>
+
+      <!-- What (keyword) -->
+      <div class="field">
+        <span class="field-label"
+          >Highlight word
+          <span class="muted small">(what — blank to match by sender only)</span></span
         >
-          <option value="substr">substr</option>
-          <option value="full">full</option>
-          <option value="glob">glob</option>
-          <option value="regex">regex</option>
-        </select>
-        <label class="ck" title="case sensitive">
+        <div class="row">
           <input
-            type="checkbox"
-            :checked="rule.case_sensitive"
-            :disabled="rule.auto_managed || !!rule.mask"
-            @change="
-              onRuleField(rule, 'case_sensitive', ($event.target as HTMLInputElement).checked)
-            "
+            v-model="form.pattern"
+            type="text"
+            class="grow"
+            placeholder="word or phrase to highlight"
+            spellcheck="false"
           />
-          <span>Aa</span>
+          <select v-model="form.kind">
+            <option value="substr">contains</option>
+            <option value="full">whole word</option>
+            <option value="glob">glob</option>
+            <option value="regex">regex</option>
+          </select>
+        </div>
+        <label class="ck">
+          <input v-model="form.caseSensitive" type="checkbox" />
+          <span>Case-sensitive</span>
         </label>
-        <label class="ck" title="enabled">
-          <input
-            type="checkbox"
-            :checked="rule.enabled"
-            @change="onRuleField(rule, 'enabled', ($event.target as HTMLInputElement).checked)"
-          />
-          <span>{{ rule.enabled ? 'on' : 'off' }}</span>
-        </label>
-        <button
-          class="link danger"
-          :disabled="rule.auto_managed"
-          @click="onRuleDelete(rule)"
-          title="delete rule"
+      </div>
+
+      <!-- Who (mask) -->
+      <label class="field">
+        <span class="field-label"
+          >Sender mask <span class="muted small">(who — blank = anyone)</span></span
         >
-          delete
-        </button>
-      </li>
-    </ul>
-    <div class="rule-add">
-      <input
-        v-model="newPattern"
-        type="text"
-        placeholder="add highlight pattern…"
-        @keydown.enter="onRuleAdd"
-      />
-      <select v-model="newKind">
-        <option value="substr">substr</option>
-        <option value="full">full</option>
-        <option value="glob">glob</option>
-        <option value="regex">regex</option>
-      </select>
-      <label class="ck">
-        <input type="checkbox" v-model="newCaseSensitive" />
-        <span>Aa</span>
+        <input
+          v-model="form.mask"
+          type="text"
+          placeholder="nick or nick!user@host — highlights everything they say"
+          spellcheck="false"
+          autocapitalize="off"
+          autocomplete="off"
+        />
       </label>
-      <button class="link" :disabled="!newPattern.trim()" @click="onRuleAdd">add</button>
+
+      <!-- Where (channels) -->
+      <label class="field">
+        <span class="field-label"
+          >Channels <span class="muted small">(where — blank = all buffers)</span></span
+        >
+        <input
+          v-model="form.channels"
+          type="text"
+          placeholder="#chan #other (space-separated)"
+          spellcheck="false"
+          autocapitalize="off"
+          autocomplete="off"
+        />
+      </label>
+
+      <!-- Options -->
+      <div class="field">
+        <span class="field-label">Options</span>
+        <label class="ck">
+          <input v-model="form.enabled" type="checkbox" />
+          <span>Enabled</span>
+        </label>
+      </div>
+
+      <div class="actions">
+        <button v-if="editing" class="link" @click="cancelEdit">cancel</button>
+        <button class="link" :disabled="!canSubmit" @click="submit">
+          {{ editing ? 'save' : 'add highlight' }}
+        </button>
+      </div>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, reactive, computed, onMounted } from 'vue';
+import { useNetworksStore } from '../../stores/networks.js';
 import { useHighlightRulesStore } from '../../stores/highlightRules.js';
 import type { HighlightRule } from '../../stores/highlightRules.js';
-import { useNetworksStore } from '../../stores/networks.js';
 
 type RuleKind = 'substr' | 'full' | 'glob' | 'regex';
 
-const rulesStore = useHighlightRulesStore();
-const networks = useNetworksStore();
+// Mirrors MAX_PATTERN_LENGTH in server/services/highlightRulesService.ts.
+const MAX_PATTERN_LENGTH = 256;
 
-const rules = computed(() => rulesStore.rules);
+const networksStore = useNetworksStore();
+const rulesStore = useHighlightRulesStore();
 
 const rulesError = ref('');
-const newPattern = ref('');
-const newKind = ref<RuleKind>('substr');
-const newCaseSensitive = ref(false);
-
-// A muted descriptor for a rule's scope: channels and/or the networks it's
-// limited to. Empty for a plain global keyword rule (the common case), so the
-// row stays uncluttered.
-function ruleScopeLabel(rule: HighlightRule): string {
-  const parts: string[] = [];
-  if (rule.channels?.length) parts.push(rule.channels.join(', '));
-  if (rule.networkIds.length) {
-    parts.push(
-      rule.networkIds.map((id) => networks.networkById(id)?.name || `net:${id}`).join(', '),
-    );
-  }
-  return parts.join(' · ');
-}
-
 onMounted(() => {
   if (!rulesStore.loaded) {
     rulesStore.fetchAll().catch((e: any) => {
-      rulesError.value = e.message;
+      rulesError.value = e.message || 'failed to load rules';
     });
   }
 });
 
-async function onRuleField(rule: HighlightRule, field: string, value: string | boolean) {
-  rulesError.value = '';
+interface HighlightGroup {
+  key: string;
+  name: string;
+  entries: HighlightRule[];
+}
+
+function kindLabel(kind: string): string {
+  return kind === 'full'
+    ? 'whole word'
+    : kind === 'glob'
+      ? 'glob'
+      : kind === 'regex'
+        ? 'regex'
+        : 'contains';
+}
+
+// One-line summary of a rule's secondary dimensions for the list (the mask or
+// pattern is the main label rendered separately).
+function describe(entry: HighlightRule): string {
+  const parts: string[] = [];
+  // For a mask rule that ALSO has a keyword, surface the keyword here since the
+  // mask is the main label. For a pure keyword rule, show how it matches.
+  if (entry.mask && entry.pattern) {
+    parts.push(
+      entry.kind === 'regex'
+        ? `/${entry.pattern}/`
+        : `"${entry.pattern}" (${kindLabel(entry.kind)})`,
+    );
+  } else if (!entry.mask) {
+    parts.push(kindLabel(entry.kind));
+  }
+  if (entry.case_sensitive) parts.push('case-sensitive');
+  if (entry.channels?.length) parts.push(entry.channels.join(', '));
+  if (entry.auto_managed) parts.push('auto');
+  if (!entry.enabled) parts.push('disabled');
+  return parts.join(' · ');
+}
+
+// Global group first (no network scope), then per-network groups sorted by name.
+// A multi-network rule (an auto-nick rule spanning networks that share your nick)
+// appears under each of its networks — it genuinely applies to all of them.
+const highlightGroups = computed<HighlightGroup[]>(() => {
+  const globals: HighlightRule[] = [];
+  const byNet = new Map<number, HighlightRule[]>();
+  for (const entry of rulesStore.rules) {
+    if (entry.networkIds.length === 0) {
+      globals.push(entry);
+    } else {
+      for (const nid of entry.networkIds) {
+        const list = byNet.get(nid);
+        if (list) list.push(entry);
+        else byNet.set(nid, [entry]);
+      }
+    }
+  }
+  const groups: HighlightGroup[] = [];
+  if (globals.length)
+    groups.push({ key: 'global', name: 'Global (all networks)', entries: globals });
+  const netGroups: HighlightGroup[] = [];
+  for (const [networkId, entries] of byNet) {
+    netGroups.push({
+      key: `net:${networkId}`,
+      name: networksStore.networkById(networkId)?.name || `net:${networkId}`,
+      entries,
+    });
+  }
+  netGroups.sort((a, b) => a.name.localeCompare(b.name));
+  return [...groups, ...netGroups];
+});
+
+const networkOptions = computed(() =>
+  (networksStore.networks || [])
+    .map((n) => ({ id: n.id, name: n.name }))
+    .toSorted((a, b) => a.name.localeCompare(b.name)),
+);
+
+// ---- form state ----
+const scopeMode = ref<'global' | 'network'>('global');
+const scopeNetworkId = ref<number | null>(null);
+const editing = ref<{ id: number } | null>(null);
+const formError = ref('');
+
+const form = reactive({
+  mask: '',
+  channels: '',
+  pattern: '',
+  kind: 'substr' as RuleKind,
+  caseSensitive: false,
+  enabled: true,
+});
+
+const canSubmit = computed(() => {
+  if (scopeMode.value === 'network' && !scopeNetworkId.value) return false;
+  return !!form.pattern.trim() || !!form.mask.trim();
+});
+
+function selectNetworkScope() {
+  if (!networkOptions.value.length) return;
+  scopeMode.value = 'network';
+  if (!scopeNetworkId.value) scopeNetworkId.value = networkOptions.value[0].id;
+}
+
+function parseChannels(s: string): string[] | null {
+  const list = s
+    .split(/[\s,]+/)
+    .map((c) => c.trim().toLowerCase())
+    .filter(Boolean);
+  return list.length ? list : null;
+}
+
+interface BuiltFields {
+  pattern: string | null;
+  mask: string | null;
+  channels: string[] | null;
+  kind: RuleKind;
+  case_sensitive: boolean;
+  enabled: boolean;
+  networkId: number | null;
+}
+
+function buildFields(): BuiltFields | null {
+  formError.value = '';
+  const pattern = form.pattern.trim();
+  let mask = form.mask.trim();
+  if (mask === '*') mask = '';
+  if (!pattern && !mask) {
+    formError.value = 'enter a highlight word or a sender mask.';
+    return null;
+  }
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    formError.value = `highlight word is too long (max ${MAX_PATTERN_LENGTH} characters).`;
+    return null;
+  }
+  if (pattern && form.kind === 'regex') {
+    try {
+      void new RegExp(pattern);
+    } catch (e) {
+      formError.value = `invalid regex: ${(e as Error).message}`;
+      return null;
+    }
+  }
+  return {
+    pattern: pattern || null,
+    mask: mask || null,
+    channels: parseChannels(form.channels),
+    kind: form.kind,
+    case_sensitive: form.caseSensitive,
+    enabled: form.enabled,
+    networkId: scopeMode.value === 'network' ? scopeNetworkId.value : null,
+  };
+}
+
+function resetForm() {
+  form.mask = '';
+  form.channels = '';
+  form.pattern = '';
+  form.kind = 'substr';
+  form.caseSensitive = false;
+  form.enabled = true;
+  scopeMode.value = 'global';
+  scopeNetworkId.value = null;
+  editing.value = null;
+}
+
+function startEdit(entry: HighlightRule) {
+  editing.value = { id: entry.id };
+  form.mask = entry.mask ?? '';
+  form.channels = (entry.channels || []).join(' ');
+  form.pattern = entry.pattern ?? '';
+  form.kind = (entry.kind as RuleKind) || 'substr';
+  form.caseSensitive = entry.case_sensitive;
+  form.enabled = entry.enabled;
+  // A user rule is global or scoped to exactly one network (only auto rules span
+  // several, and those aren't editable).
+  if (entry.networkIds.length) {
+    scopeMode.value = 'network';
+    scopeNetworkId.value = entry.networkIds[0];
+  } else {
+    scopeMode.value = 'global';
+    scopeNetworkId.value = null;
+  }
+  formError.value = '';
+}
+
+function cancelEdit() {
+  resetForm();
+  formError.value = '';
+}
+
+// Edit = create the new version, then drop the old one. Create-then-remove (not
+// remove-then-create) so a server-side rejection leaves the original intact
+// rather than losing it. Scope changes can't be done via update (network scope
+// lives in a junction set on create), so an edit is always a replace.
+async function submit() {
+  const fields = buildFields();
+  if (!fields) return;
   try {
-    await rulesStore.update(rule.id, { [field]: value });
+    await rulesStore.create(fields);
+    if (editing.value) await rulesStore.remove(editing.value.id);
+    resetForm();
   } catch (e: any) {
-    rulesError.value = e.message || 'update failed';
+    formError.value = e.message || 'failed to save highlight';
+  }
+}
+
+async function toggleEnabled(entry: HighlightRule, value: boolean) {
+  formError.value = '';
+  try {
+    await rulesStore.update(entry.id, { enabled: value });
+  } catch (e: any) {
+    formError.value = e.message || 'update failed';
     rulesStore.fetchAll().catch(() => {
       /* ignore */
     });
   }
 }
 
-async function onRuleDelete(rule: HighlightRule) {
-  rulesError.value = '';
+async function onRemove(entry: HighlightRule) {
+  if (editing.value?.id === entry.id) cancelEdit();
+  formError.value = '';
   try {
-    await rulesStore.remove(rule.id);
+    await rulesStore.remove(entry.id);
   } catch (e: any) {
-    rulesError.value = e.message || 'delete failed';
-  }
-}
-
-async function onRuleAdd() {
-  const pattern = newPattern.value.trim();
-  if (!pattern) return;
-  rulesError.value = '';
-  try {
-    await rulesStore.create({
-      pattern,
-      kind: newKind.value,
-      case_sensitive: newCaseSensitive.value,
-      enabled: true,
-    });
-    newPattern.value = '';
-    newKind.value = 'substr';
-    newCaseSensitive.value = false;
-  } catch (e: any) {
-    rulesError.value = e.message || 'create failed';
+    formError.value = e.message || 'delete failed';
   }
 }
 </script>
 
 <style src="./panes.css"></style>
 <style scoped>
-.rule-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.hl-detail {
+  margin-left: var(--space-3);
 }
-.rule {
-  display: grid;
-  grid-template-columns: 18px minmax(120px, 1fr) max-content max-content max-content max-content;
-  align-items: center;
-  gap: var(--space-4);
-  padding: var(--space-3) 0;
-  border-top: 1px solid var(--border);
-}
-.rule:first-child {
-  border-top: none;
-}
-.rule:hover {
-  background: var(--bg-soft);
-}
-.rule.auto .pattern {
-  color: var(--fg-muted);
-}
-.pat-cell {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
+.device .ua {
   min-width: 0;
-}
-.pat-cell .pattern {
-  width: 100%;
-}
-/* Muted scope descriptor (channels / networks); color, not size, sets hierarchy. */
-.scope {
-  color: var(--fg-muted);
+  overflow-wrap: anywhere;
 }
 .lock {
-  color: var(--fg-muted);
-  text-align: center;
+  margin-right: var(--space-1);
 }
-.rule .ck {
+.ck.inline {
+  margin-left: auto;
+}
+.rule-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding-top: var(--space-3);
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.field-label {
+  color: var(--fg-muted);
+}
+.row {
   display: flex;
   align-items: center;
+  gap: var(--space-4);
+}
+.grow {
+  flex: 1;
+  min-width: 0;
+}
+.rule-form input[type='text'] {
+  background: var(--bg-soft);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-3);
+  font: inherit;
+}
+.seg {
+  display: flex;
   gap: var(--space-2);
+}
+.seg button {
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-4);
+  font: inherit;
+  cursor: pointer;
+}
+.seg button.active {
+  color: var(--fg);
+  border-color: var(--accent);
+  outline: 1px solid var(--accent);
+}
+.seg button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.ck {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
   color: var(--fg-muted);
   cursor: pointer;
 }
-.rule-add {
+.actions {
   display: flex;
-  align-items: center;
+  justify-content: flex-end;
   gap: var(--space-4);
-  padding-top: var(--space-5);
-}
-.rule-add input[type='text'] {
-  flex: 1;
-  min-width: 200px;
+  padding-top: var(--space-2);
 }
 </style>

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -78,11 +78,10 @@
       <div class="field">
         <span class="field-label">Scope</span>
         <div class="row">
-          <div class="seg" role="radiogroup" aria-label="Scope">
+          <div class="seg" role="group" aria-label="Scope">
             <button
               type="button"
-              role="radio"
-              :aria-checked="scopeMode === 'global'"
+              :aria-pressed="scopeMode === 'global'"
               :class="{ active: scopeMode === 'global' }"
               @click="scopeMode = 'global'"
             >
@@ -90,8 +89,7 @@
             </button>
             <button
               type="button"
-              role="radio"
-              :aria-checked="scopeMode === 'network'"
+              :aria-pressed="scopeMode === 'network'"
               :class="{ active: scopeMode === 'network' }"
               :disabled="!networkOptions.length"
               @click="selectNetworkScope"

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -38,8 +38,15 @@
               type="button"
               class="toggle"
               :class="{ on: entry.enabled }"
+              :disabled="entry.auto_managed"
               :aria-pressed="entry.enabled"
-              :title="entry.enabled ? 'enabled — click to disable' : 'disabled — click to enable'"
+              :title="
+                entry.auto_managed
+                  ? 'auto-managed (network nick) — always on'
+                  : entry.enabled
+                    ? 'enabled — click to disable'
+                    : 'disabled — click to enable'
+              "
               :aria-label="entry.enabled ? 'enabled' : 'disabled'"
               @click="toggleEnabled(entry, !entry.enabled)"
             >
@@ -456,6 +463,10 @@ async function onRemove(entry: HighlightRule) {
 }
 .toggle.on {
   color: var(--accent);
+}
+.toggle:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 .rule-form {
   display: flex;

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -190,6 +190,7 @@ import { useHighlightRulesStore } from '../../stores/highlightRules.js';
 import type { HighlightRule } from '../../stores/highlightRules.js';
 import IconButton from '../IconButton.vue';
 import { parseChannelList } from '../../../../shared/channels.js';
+import { highlightRuleDetailParts } from '../../utils/highlightFormat.js';
 
 type RuleKind = 'substr' | 'full' | 'glob' | 'regex';
 
@@ -214,36 +215,11 @@ interface HighlightGroup {
   entries: HighlightRule[];
 }
 
-function kindLabel(kind: string): string {
-  return kind === 'full'
-    ? 'whole word'
-    : kind === 'glob'
-      ? 'glob'
-      : kind === 'regex'
-        ? 'regex'
-        : 'contains';
-}
-
 // One-line summary of a rule's secondary dimensions for the list (the mask or
-// pattern is the main label rendered separately).
+// pattern is the main label rendered separately). Shared with the /highlight
+// command listing so the two never drift.
 function describe(entry: HighlightRule): string {
-  const parts: string[] = [];
-  // For a mask rule that ALSO has a keyword, surface the keyword here since the
-  // mask is the main label. For a pure keyword rule, show how it matches.
-  if (entry.mask && entry.pattern) {
-    parts.push(
-      entry.kind === 'regex'
-        ? `/${entry.pattern}/`
-        : `"${entry.pattern}" (${kindLabel(entry.kind)})`,
-    );
-  } else if (!entry.mask) {
-    parts.push(kindLabel(entry.kind));
-  }
-  if (entry.case_sensitive) parts.push('case-sensitive');
-  if (entry.channels?.length) parts.push(entry.channels.join(', '));
-  if (entry.auto_managed) parts.push('auto');
-  if (!entry.enabled) parts.push('disabled');
-  return parts.join(' · ');
+  return highlightRuleDetailParts(entry).join(' · ');
 }
 
 // Global group first (no network scope), then per-network groups sorted by name.
@@ -394,16 +370,18 @@ function cancelEdit() {
   formError.value = '';
 }
 
-// Edit = create the new version, then drop the old one. Create-then-remove (not
-// remove-then-create) so a server-side rejection leaves the original intact
-// rather than losing it. Scope changes can't be done via update (network scope
-// lives in a junction set on create), so an edit is always a replace.
+// Add = create; edit = a single atomic update (the service re-scopes via the
+// junction), so the rule keeps its id and list position and there's no
+// create-then-delete window that could orphan a duplicate.
 async function submit() {
   const fields = buildFields();
   if (!fields) return;
   try {
-    await rulesStore.create(fields);
-    if (editing.value) await rulesStore.remove(editing.value.id);
+    if (editing.value) {
+      await rulesStore.update(editing.value.id, fields);
+    } else {
+      await rulesStore.create(fields);
+    }
     resetForm();
   } catch (e: any) {
     formError.value = e.message || 'failed to save highlight';

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -33,18 +33,37 @@
             {{ entry.mask ?? entry.pattern ?? '*' }}
             <span class="muted small hl-detail">{{ describe(entry) }}</span>
           </span>
-          <label class="ck inline" title="enabled">
-            <input
-              type="checkbox"
-              :checked="entry.enabled"
-              @change="toggleEnabled(entry, ($event.target as HTMLInputElement).checked)"
+          <div class="row-actions">
+            <button
+              type="button"
+              class="toggle"
+              :class="{ on: entry.enabled }"
+              :aria-pressed="entry.enabled"
+              :title="entry.enabled ? 'enabled — click to disable' : 'disabled — click to enable'"
+              :aria-label="entry.enabled ? 'enabled' : 'disabled'"
+              @click="toggleEnabled(entry, !entry.enabled)"
+            >
+              <i
+                :class="['fa-solid', entry.enabled ? 'fa-toggle-on' : 'fa-toggle-off']"
+                aria-hidden="true"
+              ></i>
+            </button>
+            <!-- Auto-managed (network nick) rules track your nick — only the
+                 enabled toggle applies, so edit/remove show disabled. -->
+            <IconButton
+              icon="fa-pen"
+              label="edit"
+              :disabled="entry.auto_managed"
+              @click="startEdit(entry)"
             />
-            <span>{{ entry.enabled ? 'on' : 'off' }}</span>
-          </label>
-          <button v-if="!entry.auto_managed" class="link" @click="startEdit(entry)">edit</button>
-          <button v-if="!entry.auto_managed" class="link danger" @click="onRemove(entry)">
-            remove
-          </button>
+            <IconButton
+              icon="fa-trash"
+              label="remove"
+              danger
+              :disabled="entry.auto_managed"
+              @click="onRemove(entry)"
+            />
+          </div>
         </li>
       </ul>
     </template>
@@ -165,6 +184,7 @@ import { ref, reactive, computed, onMounted } from 'vue';
 import { useNetworksStore } from '../../stores/networks.js';
 import { useHighlightRulesStore } from '../../stores/highlightRules.js';
 import type { HighlightRule } from '../../stores/highlightRules.js';
+import IconButton from '../IconButton.vue';
 
 type RuleKind = 'substr' | 'full' | 'glob' | 'regex';
 
@@ -423,8 +443,19 @@ async function onRemove(entry: HighlightRule) {
 .lock {
   margin-right: var(--space-1);
 }
-.ck.inline {
-  margin-left: auto;
+/* Enabled toggle: muted when off, accent when on; the glyph (toggle-on/off)
+   plus aria-pressed carry the state. */
+.toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  padding: var(--space-1) var(--space-2);
+  color: var(--fg-muted);
+}
+.toggle.on {
+  color: var(--accent);
 }
 .rule-form {
   display: flex;

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -189,6 +189,7 @@ import { useNetworksStore } from '../../stores/networks.js';
 import { useHighlightRulesStore } from '../../stores/highlightRules.js';
 import type { HighlightRule } from '../../stores/highlightRules.js';
 import IconButton from '../IconButton.vue';
+import { parseChannelList } from '../../../../shared/channels.js';
 
 type RuleKind = 'substr' | 'full' | 'glob' | 'regex';
 
@@ -310,10 +311,7 @@ function selectNetworkScope() {
 }
 
 function parseChannels(s: string): string[] | null {
-  const list = s
-    .split(/[\s,]+/)
-    .map((c) => c.trim().toLowerCase())
-    .filter(Boolean);
+  const list = parseChannelList(s);
   return list.length ? list : null;
 }
 

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -9,7 +9,9 @@
     <p class="section-desc">
       Rules whose pattern matches an incoming message mark it as a highlight (line accent + sidebar
       dot). Auto-managed entries track each network's current nick and can only be enabled/disabled.
-      Configure notification delivery for matched highlights in the Notifications pane.
+      For sender masks, per-network or per-channel scope, use the
+      <code>/highlight</code> command (e.g. <code>/highlight -mask bob!*@*</code>). Configure
+      notification delivery for matched highlights in the Notifications pane.
     </p>
     <p v-if="rulesError" class="error inline">{{ rulesError }}</p>
     <ul class="rule-list">
@@ -17,20 +19,24 @@
         <span class="lock" :title="rule.auto_managed ? 'auto-managed (network nick)' : 'user rule'">
           {{ rule.auto_managed ? '🔒' : '' }}
         </span>
-        <input
-          type="text"
-          class="pattern"
-          :value="rule.pattern"
-          :disabled="rule.auto_managed"
-          @change="onRuleField(rule, 'pattern', ($event.target as HTMLInputElement).value)"
-          placeholder="pattern"
-        />
+        <div class="pat-cell">
+          <input
+            type="text"
+            class="pattern"
+            :value="rule.mask ?? rule.pattern ?? ''"
+            :disabled="rule.auto_managed || !!rule.mask"
+            @change="onRuleField(rule, 'pattern', ($event.target as HTMLInputElement).value)"
+            :placeholder="rule.mask ? 'mask' : 'pattern'"
+          />
+          <span v-if="ruleScopeLabel(rule)" class="scope">{{ ruleScopeLabel(rule) }}</span>
+        </div>
         <select
           :value="rule.kind"
-          :disabled="rule.auto_managed"
+          :disabled="rule.auto_managed || !!rule.mask"
           @change="onRuleField(rule, 'kind', ($event.target as HTMLSelectElement).value)"
         >
-          <option value="plain">plain</option>
+          <option value="substr">substr</option>
+          <option value="full">full</option>
           <option value="glob">glob</option>
           <option value="regex">regex</option>
         </select>
@@ -38,7 +44,7 @@
           <input
             type="checkbox"
             :checked="rule.case_sensitive"
-            :disabled="rule.auto_managed"
+            :disabled="rule.auto_managed || !!rule.mask"
             @change="
               onRuleField(rule, 'case_sensitive', ($event.target as HTMLInputElement).checked)
             "
@@ -71,7 +77,8 @@
         @keydown.enter="onRuleAdd"
       />
       <select v-model="newKind">
-        <option value="plain">plain</option>
+        <option value="substr">substr</option>
+        <option value="full">full</option>
         <option value="glob">glob</option>
         <option value="regex">regex</option>
       </select>
@@ -88,26 +95,33 @@
 import { ref, computed, onMounted } from 'vue';
 import { useHighlightRulesStore } from '../../stores/highlightRules.js';
 import type { HighlightRule } from '../../stores/highlightRules.js';
+import { useNetworksStore } from '../../stores/networks.js';
 
-// The store interface covers core fields; `kind` and `case_sensitive` are also
-// returned by the server but not yet typed in the shared interface.
-type RuleKind = 'plain' | 'glob' | 'regex';
-
-interface HighlightRuleRow extends HighlightRule {
-  kind: RuleKind;
-  case_sensitive: boolean;
-}
+type RuleKind = 'substr' | 'full' | 'glob' | 'regex';
 
 const rulesStore = useHighlightRulesStore();
+const networks = useNetworksStore();
 
-// The store types rules as HighlightRule[], but the server also returns
-// `kind` and `case_sensitive`; cast here so the template can use those fields.
-const rules = computed(() => rulesStore.rules as HighlightRuleRow[]);
+const rules = computed(() => rulesStore.rules);
 
 const rulesError = ref('');
 const newPattern = ref('');
-const newKind = ref<RuleKind>('plain');
+const newKind = ref<RuleKind>('substr');
 const newCaseSensitive = ref(false);
+
+// A muted descriptor for a rule's scope: channels and/or the networks it's
+// limited to. Empty for a plain global keyword rule (the common case), so the
+// row stays uncluttered.
+function ruleScopeLabel(rule: HighlightRule): string {
+  const parts: string[] = [];
+  if (rule.channels?.length) parts.push(rule.channels.join(', '));
+  if (rule.networkIds.length) {
+    parts.push(
+      rule.networkIds.map((id) => networks.networkById(id)?.name || `net:${id}`).join(', '),
+    );
+  }
+  return parts.join(' · ');
+}
 
 onMounted(() => {
   if (!rulesStore.loaded) {
@@ -117,7 +131,7 @@ onMounted(() => {
   }
 });
 
-async function onRuleField(rule: HighlightRuleRow, field: string, value: string | boolean) {
+async function onRuleField(rule: HighlightRule, field: string, value: string | boolean) {
   rulesError.value = '';
   try {
     await rulesStore.update(rule.id, { [field]: value });
@@ -129,7 +143,7 @@ async function onRuleField(rule: HighlightRuleRow, field: string, value: string 
   }
 }
 
-async function onRuleDelete(rule: HighlightRuleRow) {
+async function onRuleDelete(rule: HighlightRule) {
   rulesError.value = '';
   try {
     await rulesStore.remove(rule.id);
@@ -148,9 +162,9 @@ async function onRuleAdd() {
       kind: newKind.value,
       case_sensitive: newCaseSensitive.value,
       enabled: true,
-    } as Partial<HighlightRuleRow>);
+    });
     newPattern.value = '';
-    newKind.value = 'plain';
+    newKind.value = 'substr';
     newCaseSensitive.value = false;
   } catch (e: any) {
     rulesError.value = e.message || 'create failed';
@@ -180,6 +194,19 @@ async function onRuleAdd() {
   background: var(--bg-soft);
 }
 .rule.auto .pattern {
+  color: var(--fg-muted);
+}
+.pat-cell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+.pat-cell .pattern {
+  width: 100%;
+}
+/* Muted scope descriptor (channels / networks); color, not size, sets hierarchy. */
+.scope {
   color: var(--fg-muted);
 }
 .lock {

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -45,11 +45,10 @@
       <div class="field">
         <span class="field-label">Scope</span>
         <div class="row">
-          <div class="seg" role="radiogroup" aria-label="Scope">
+          <div class="seg" role="group" aria-label="Scope">
             <button
               type="button"
-              role="radio"
-              :aria-checked="scopeMode === 'global'"
+              :aria-pressed="scopeMode === 'global'"
               :class="{ active: scopeMode === 'global' }"
               @click="scopeMode = 'global'"
             >
@@ -57,8 +56,7 @@
             </button>
             <button
               type="button"
-              role="radio"
-              :aria-checked="scopeMode === 'network'"
+              :aria-pressed="scopeMode === 'network'"
               :class="{ active: scopeMode === 'network' }"
               :disabled="!networkOptions.length"
               @click="selectNetworkScope"

--- a/vue_client/src/components/settings-panes/IgnoresPane.vue
+++ b/vue_client/src/components/settings-panes/IgnoresPane.vue
@@ -31,8 +31,10 @@
             {{ entry.mask ?? '*' }}
             <span class="muted small ignore-detail">{{ describe(entry) }}</span>
           </span>
-          <button class="link" @click="startEdit(entry)">edit</button>
-          <button class="link danger" @click="onRemove(entry)">remove</button>
+          <div class="row-actions">
+            <IconButton icon="fa-pen" label="edit" @click="startEdit(entry)" />
+            <IconButton icon="fa-trash" label="remove" danger @click="onRemove(entry)" />
+          </div>
         </li>
       </ul>
     </template>
@@ -191,6 +193,7 @@
 import { ref, reactive, computed } from 'vue';
 import { useNetworksStore } from '../../stores/networks.js';
 import { useIgnoresStore, type IgnoreEntryWithNetwork } from '../../stores/ignores.js';
+import IconButton from '../IconButton.vue';
 import type { IgnoreRule } from '../../utils/ignoreMatch.js';
 import { durationToExpiry, type IgnorePatternKind } from '../../../../shared/parseIgnore.js';
 import { CANONICAL_ORDER } from '../../../../shared/ignoreLevels.js';

--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -156,12 +156,14 @@
     <ul v-else class="device-list">
       <li v-for="entry in alwaysNotifyChannelList" :key="entry.key" class="device">
         <span class="ua">{{ entry.networkName }} · {{ entry.target }}</span>
-        <IconButton
-          icon="fa-trash"
-          label="stop"
-          danger
-          @click="removeAlwaysNotify(entry.networkId, entry.target)"
-        />
+        <div class="row-actions">
+          <IconButton
+            icon="fa-trash"
+            label="stop"
+            danger
+            @click="removeAlwaysNotify(entry.networkId, entry.target)"
+          />
+        </div>
       </li>
     </ul>
 

--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -36,7 +36,13 @@
         <span class="last-seen" :title="sub.last_seen_at"
           >last seen {{ formatRelative(sub.last_seen_at) }}</span
         >
-        <button class="link danger" @click="onRemoveOther(sub)" :disabled="pushBusy">remove</button>
+        <IconButton
+          icon="fa-trash"
+          label="remove"
+          danger
+          :disabled="pushBusy"
+          @click="onRemoveOther(sub)"
+        />
       </li>
     </ul>
     <p v-else-if="pushSubsStore.loaded && thisClientEnabled" class="muted small">
@@ -233,6 +239,7 @@ import { useNetworksStore } from '../../stores/networks.js';
 import { formatRelative } from '../../utils/timestamp.js';
 import { getOption } from '../../utils/settingsRegistry.js';
 import { playSound } from '../../composables/useHighlightNotifier.js';
+import IconButton from '../IconButton.vue';
 import type { SettingValue, EnumOption } from '../../../../shared/settingsRegistry.js';
 import {
   isSupported as isPushSupported,

--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -156,9 +156,12 @@
     <ul v-else class="device-list">
       <li v-for="entry in alwaysNotifyChannelList" :key="entry.key" class="device">
         <span class="ua">{{ entry.networkName }} · {{ entry.target }}</span>
-        <button class="link danger" @click="removeAlwaysNotify(entry.networkId, entry.target)">
-          stop
-        </button>
+        <IconButton
+          icon="fa-trash"
+          label="stop"
+          danger
+          @click="removeAlwaysNotify(entry.networkId, entry.target)"
+        />
       </li>
     </ul>
 

--- a/vue_client/src/components/settings-panes/panes.css
+++ b/vue_client/src/components/settings-panes/panes.css
@@ -96,12 +96,16 @@
 .settings-pane .device .last-seen {
   color: var(--fg-muted);
 }
-/* Per-row action cluster (edit/remove icon buttons, optional toggle) kept in one
-   grid cell so they stay on a single line within the .device grid. */
+/* Per-row action cluster (edit/remove icon buttons, optional toggle). It's the
+   only thing after .ua, so span the .device grid's last two columns and right-
+   align — otherwise it lands in column 2 and the empty column 3 leaves a trailing
+   gap and the cluster floats off the right edge. */
 .settings-pane .row-actions {
   display: flex;
   align-items: center;
   gap: var(--space-3);
+  grid-column: 2 / -1;
+  justify-self: end;
 }
 
 .settings-pane .hl-sep {

--- a/vue_client/src/components/settings-panes/panes.css
+++ b/vue_client/src/components/settings-panes/panes.css
@@ -96,6 +96,13 @@
 .settings-pane .device .last-seen {
   color: var(--fg-muted);
 }
+/* Per-row action cluster (edit/remove icon buttons, optional toggle) kept in one
+   grid cell so they stay on a single line within the .device grid. */
+.settings-pane .row-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
 
 .settings-pane .hl-sep {
   border: none;

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -331,6 +331,14 @@ function applySnapshot(snapshot: any[], globalIgnores: any[] = []): void {
   channelNotify.applySnapshot(snapshot);
   ignores.applySnapshot(snapshot, globalIgnores);
   nickNotes.applySnapshot(snapshot);
+  // Highlight rules aren't in the snapshot; load them now so client-side
+  // render-time highlight evaluation (#349) works app-wide, not just after the
+  // settings pane has been opened.
+  useHighlightRulesStore()
+    .fetchAll()
+    .catch(() => {
+      /* ignore — server stamp (m.matched) still drives highlighting */
+    });
   for (const net of snapshot) {
     for (const ch of net.channels) {
       // Snapshot members are already { nick, modes } objects from the server.
@@ -451,8 +459,10 @@ function handleMessage(raw: string): void {
     return;
   }
   if (payload.kind === 'highlight-rules-changed') {
-    const rules = useHighlightRulesStore();
-    if (rules.loaded) rules.applyServerChanged();
+    // Re-fetch on any change (another tab/device, or an auto-nick rule created on
+    // (re)connect / nick change). Re-fetch unconditionally so the client-eval set
+    // stays current even if the settings pane was never opened.
+    useHighlightRulesStore().applyServerChanged();
     return;
   }
   if (payload.kind === 'read-state') {

--- a/vue_client/src/stores/highlightRules.ts
+++ b/vue_client/src/stores/highlightRules.ts
@@ -123,7 +123,7 @@ export const useHighlightRulesStore = defineStore('highlightRules', {
       this.rules = [...this.rules, rule];
       return rule as HighlightRule;
     },
-    async update(id: number, fields: Partial<HighlightRule>) {
+    async update(id: number, fields: Partial<HighlightRule> & { networkId?: number | null }) {
       const { rule } = await api(`/api/highlight-rules/${id}`, { method: 'PATCH', body: fields });
       this.rules = this.rules.map((r) => (r.id === id ? rule : r));
       return rule as HighlightRule;

--- a/vue_client/src/stores/highlightRules.ts
+++ b/vue_client/src/stores/highlightRules.ts
@@ -3,12 +3,61 @@
 
 import { defineStore } from 'pinia';
 import { api } from '../api.js';
+import { compileRules, matchEvent, type CompiledRule } from '../utils/highlightMatch.js';
+
+// Highlight rules (issue #349). CRUD goes over REST (the settings pane edits
+// fields inline); the server fans a `highlight-rules-changed` event so other
+// sessions re-fetch (cross-device sync). The server stamps matched_rule_id at
+// insert (drives notifications + the highlights feed + counts, which must work
+// with no tab open); the client ALSO evaluates here at render so adding/removing/
+// toggling a rule instantly re-colors messages already on screen — mirroring how
+// /ignore filters live. Each rule is a full irssi-style rule
+// (pattern / mask / channels / kind / case) with optional per-network scope.
 
 export interface HighlightRule {
   id: number;
-  pattern: string;
-  auto_managed: boolean;
+  pattern: string | null;
+  mask: string | null;
+  channels: string[] | null;
+  kind: string;
+  case_sensitive: boolean;
   enabled: boolean;
+  auto_managed: boolean;
+  // [] = global (every network); otherwise the networks the rule is scoped to
+  // (an auto-nick rule spans every network currently using that nick).
+  networkIds: number[];
+}
+
+// Minimal message shape the render hot path passes to evaluate().
+interface HighlightInput {
+  nick?: string | null;
+  userhost?: string | null;
+  target?: string;
+  type?: string;
+  text?: string | null;
+  self?: boolean;
+}
+
+// Compile lazily, memoized per network and invalidated whenever the rules array
+// identity changes. Every action below assigns a fresh array (never mutates in
+// place) so a change reliably busts this cache; steady-state reads are a Map hit.
+let cacheRef: HighlightRule[] | null = null;
+const perNetwork = new Map<number, CompiledRule[]>();
+function compiledFor(rules: HighlightRule[], networkId: number): CompiledRule[] {
+  if (cacheRef !== rules) {
+    perNetwork.clear();
+    cacheRef = rules;
+  }
+  let c = perNetwork.get(networkId);
+  if (!c) {
+    // Effective set for this network = global rules plus rules scoped to it.
+    const effective = rules.filter(
+      (r) => r.networkIds.length === 0 || r.networkIds.includes(networkId),
+    );
+    c = compileRules(effective);
+    perNetwork.set(networkId, c);
+  }
+  return c;
 }
 
 export const useHighlightRulesStore = defineStore('highlightRules', {
@@ -21,6 +70,37 @@ export const useHighlightRulesStore = defineStore('highlightRules', {
   getters: {
     userRules: (state) => state.rules.filter((r) => !r.auto_managed),
     autoRules: (state) => state.rules.filter((r) => r.auto_managed),
+
+    // The effective rules for a network (global ∪ network-scoped), for the
+    // /highlight command listing. networkId null lists only globals.
+    rulesFor: (state) => (networkId: number | null) =>
+      networkId == null
+        ? state.rules.filter((r) => r.networkIds.length === 0)
+        : state.rules.filter(
+            (r) => r.networkIds.length === 0 || r.networkIds.includes(Number(networkId)),
+          ),
+
+    // Render hot path called from MessageList: does any in-scope, enabled rule
+    // match this message? Mirrors the server's insert-time matchEvent so a freshly
+    // added rule lights up scrollback without a reload.
+    evaluate:
+      (state) =>
+      (networkId: number | string, msg: HighlightInput): boolean => {
+        const nid = Number(networkId);
+        const compiled = compiledFor(state.rules, nid);
+        if (compiled.length === 0) return false;
+        return matchEvent(
+          {
+            type: msg.type ?? 'message',
+            self: msg.self,
+            text: msg.text ?? null,
+            nick: msg.nick ?? null,
+            userhost: msg.userhost ?? null,
+            target: msg.target ?? '',
+          },
+          compiled,
+        ).matched;
+      },
   },
   actions: {
     async fetchAll() {
@@ -38,15 +118,14 @@ export const useHighlightRulesStore = defineStore('highlightRules', {
         this.loading = false;
       }
     },
-    async create(fields: Partial<HighlightRule>) {
+    async create(fields: Partial<HighlightRule> & { networkId?: number | null }) {
       const { rule } = await api('/api/highlight-rules', { method: 'POST', body: fields });
-      this.rules.push(rule);
+      this.rules = [...this.rules, rule];
       return rule as HighlightRule;
     },
     async update(id: number, fields: Partial<HighlightRule>) {
       const { rule } = await api(`/api/highlight-rules/${id}`, { method: 'PATCH', body: fields });
-      const idx = this.rules.findIndex((r) => r.id === id);
-      if (idx >= 0) this.rules[idx] = rule;
+      this.rules = this.rules.map((r) => (r.id === id ? rule : r));
       return rule as HighlightRule;
     },
     async remove(id: number) {
@@ -54,7 +133,8 @@ export const useHighlightRulesStore = defineStore('highlightRules', {
       this.rules = this.rules.filter((r) => r.id !== id);
     },
     applyServerChanged() {
-      // Re-fetch when the server signals rules changed (rare; another tab edited).
+      // Re-fetch when the server signals rules changed (another tab/device, or
+      // an auto-nick rule created on (re)connect / nick change).
       this.fetchAll().catch(() => {
         /* ignore */
       });

--- a/vue_client/src/utils/highlightFormat.ts
+++ b/vue_client/src/utils/highlightFormat.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared formatting for a highlight rule's human summary, used by both the
+// /highlight command listing (MessageInput) and the settings pane rows, so the
+// two presentations can't drift. Each caller adds its own subject/scope framing
+// (the command shows them inline; the pane shows the subject separately and
+// groups by scope); this owns the kind label and the secondary descriptors.
+
+export interface HighlightSummaryRule {
+  pattern: string | null;
+  mask: string | null;
+  channels: string[] | null;
+  kind: string;
+  case_sensitive: boolean;
+  auto_managed: boolean;
+  enabled: boolean;
+}
+
+export function highlightKindLabel(kind: string): string {
+  return kind === 'full'
+    ? 'whole word'
+    : kind === 'glob'
+      ? 'glob'
+      : kind === 'regex'
+        ? 'regex'
+        : 'contains';
+}
+
+// Secondary descriptors common to both surfaces: how a keyword matches, case
+// sensitivity, channel scope, and the auto/disabled flags. For a mask rule the
+// keyword (if any) is surfaced here since the mask is the subject; for a keyword
+// rule the match kind is shown.
+export function highlightRuleDetailParts(rule: HighlightSummaryRule): string[] {
+  const parts: string[] = [];
+  if (rule.mask) {
+    if (rule.pattern) {
+      parts.push(
+        rule.kind === 'regex'
+          ? `/${rule.pattern}/`
+          : `"${rule.pattern}" (${highlightKindLabel(rule.kind)})`,
+      );
+    }
+  } else {
+    parts.push(highlightKindLabel(rule.kind));
+  }
+  if (rule.case_sensitive) parts.push('case-sensitive');
+  if (rule.channels?.length) parts.push(rule.channels.join(', '));
+  if (rule.auto_managed) parts.push('auto');
+  if (!rule.enabled) parts.push('disabled');
+  return parts;
+}

--- a/vue_client/src/utils/highlightFormat.ts
+++ b/vue_client/src/utils/highlightFormat.ts
@@ -18,7 +18,8 @@ export interface HighlightSummaryRule {
 }
 
 export function highlightKindLabel(kind: string): string {
-  return kind === 'full'
+  // 'plain' is the retired alias for whole-word, still accepted server-side.
+  return kind === 'full' || kind === 'plain'
     ? 'whole word'
     : kind === 'glob'
       ? 'glob'

--- a/vue_client/src/utils/highlightMatch.ts
+++ b/vue_client/src/utils/highlightMatch.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Implementation lives in shared/ so the client render-time highlight check and
+// the server insert-time stamp run one shared copy. This re-export keeps the
+// local import path (../utils/highlightMatch.js) stable.
+export * from '../../../shared/highlightMatch.js';


### PR DESCRIPTION
Closes #349.

Brings highlights to parity with the irssi-style ignore system (#301) on the same shared infrastructure, and fixes two long-standing matching bugs.

## Matcher fixes (`shared/textMatch.ts` — also fixes the ignore `-pattern` matcher)
- **Colored/bold words now highlight.** The matcher stripped URLs but not IRC formatting codes, so a colored word (e.g. a bot's `QUACK!` → `\x0304QUACK!`) left a digit glued to the word and broke the `\W` boundary → missed. Added `stripFormatting()` + `cleanForMatch()`.
- **No more false positives inside accented words.** Switched whole-word boundaries from ASCII `\W` to a Unicode class `[\p{L}\p{N}_]` (`/u`), so `em` no longer matches inside `zrozumiałem`. Uses a consuming negated-class prefix instead of lookbehind for Safari < 16.4 compatibility.

## Scoped rule model + matching
- `highlight_rules` gains nullable `pattern` + `mask` + `channels`; v13 shape-gated migration remaps the retired `plain` kind to `full`. Network scope reuses the existing `highlight_rule_networks` junction (now read at match time — it was write-only).
- Engine moved to `shared/highlightMatch.ts`; `matchEvent` is mask/channel/scope aware and reuses the ignore matcher's mask/channel helpers. Kind vocabulary unified with ignore (`substr`/`full`/`regex`, + `glob`; default `substr`).

## Slash command (slash-command-first ethos #353)
- New `shared/parseHighlight.ts`; `/highlight` + `/unhighlight` (aliases `/hilight`, `/dehilight`) with `-mask -full -regexp -matchcase -network -channels`, driving the **same** store as the settings pane.

## Client
- Store mirrors the ignores store (compile cache + `evaluate`); `MessageList` evaluates highlights at render so adding/removing/toggling a rule re-colors scrollback live (notifications + the highlights feed stay server-driven). Rules load on connect; cross-device sync via `highlight-rules-changed`.
- Self-nick auto rule is now `full` kind and inherits the matcher fixes; auto rules are fully read-only (edit/remove/toggle all locked, enforced UI + server).

## Settings UX
- Highlights pane rebuilt to match the ignore pane: grouped list (Global, then per-network) + a full add/edit form (scope, sender mask, channels, keyword + kind, case-sensitivity).
- Shared `IconButton` primitive: `edit`/`remove` are now icons across the Ignores, Highlights, and Notifications panes (fixes a row-wrap bug); enabled is an `fa-toggle-on/off` toggle button.

## Behavior change to call out
Newly created rules default to **substring** match (matches irssi); pre-existing rules keep their whole-word behavior (the `plain → full` migration preserves it). Use `-full` / the "whole word" kind for whole-word.

## Verification
- 925+ server/shared tests pass (added coverage: formatting strip, Unicode boundaries, mask/channel/scope matching, the `/highlight` parser, DB scope round-trips, migration remap).
- Client `vue-tsc`, `oxlint`, `oxfmt`, and the production build all pass.
- Migration rebuild verified directly against an old-shape DB (fresh test DBs use the new `CREATE TABLE`, so the suite doesn't hit the upgrade path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)