### PR TITLE
Bump version to v1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@simplewebauthn/server": "^13.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Cuts a release for production carrying the work merged since v1.0.4:

- **identd race/grace fixes** (#378) — pre-TLS ident registration + RFC-1413 4-tuple match hardening.
- **Highlight system overhaul** (#379) — scoped rules, `/highlight` command, formatting/Unicode matcher fixes.

Version bumped to `1.0.5` in the root and `vue_client` `package.json` (+ their lockfile root entries) via `npm version`. No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)