### PR TITLE
Add optional bind addresses for web, identd, and outbound IRC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 PORT=8010
 NODE_ENV=development
 
+# Optional bind address for the web/API server. Unset listens on all interfaces
+# (the default). Set to 127.0.0.1 to keep Lurker private behind a local reverse
+# proxy or tunnel (Caddy, cloudflared, etc.) that terminates TLS in front of it.
+# HOST=127.0.0.1
+
 # SQLite database location
 DATABASE_PATH=./data/lurker.db
 
@@ -83,6 +88,22 @@ VAPID_SUBJECT=mailto:you@example.com
 # ---------------------------------------------------------------------------
 # LURKER_IDENTD_ENABLED=true
 # LURKER_IDENTD_PORT=113
+#
+# Optional bind address for the identd listener. Unset binds every interface
+# (the default). Pin it to one local address — typically a dedicated IPv6 — to
+# run Lurker's identd alongside a host ident daemon (e.g. oidentd) that serves
+# the host's other addresses: each answers :113 on its own IP, no port clash.
+# Pair it with LURKER_OUTGOING_ADDR (below) so the network's ident callback
+# reaches this listener.
+# LURKER_IDENTD_BIND=2001:db8::dead
+#
+# Optional source address for OUTBOUND IRC connections. irc-framework binds the
+# socket's localAddress to this, so the connection — and the network's RFC 1413
+# callback to :113 — originates from this IP. Set it to the same dedicated
+# address as LURKER_IDENTD_BIND so the network's ident lookup lands on Lurker's
+# identd rather than the host's. (The bound address must be reachable over the
+# family it implies — an IPv6 here means the network is reached over IPv6.)
+# LURKER_OUTGOING_ADDR=2001:db8::dead
 
 # ---------------------------------------------------------------------------
 # Outbound connect throttle. On (re)start Lurker auto-connects every user's

--- a/server/server.ts
+++ b/server/server.ts
@@ -17,7 +17,13 @@ import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
 import { startModerationReporter, stopModerationReporter } from './services/moderationReport.js';
-import { startIdentd, stopIdentd, isIdentdEnabled, identdPort } from './services/identd.js';
+import {
+  startIdentd,
+  stopIdentd,
+  isIdentdEnabled,
+  identdPort,
+  identdBindHost,
+} from './services/identd.js';
 import {
   recoverInterruptedExports,
   startExportSweeper,
@@ -26,6 +32,10 @@ import {
 import { startIgnoreSweeper, stopIgnoreSweeper } from './services/ignoreSweeper.js';
 
 const PORT = Number(process.env.PORT || 8010);
+// Optional bind address for the web/API server (HOST). Unset keeps upstream
+// behaviour (listen on all interfaces); set HOST=127.0.0.1 to keep Lurker
+// private behind a local reverse proxy / tunnel such as cloudflared.
+const HOST = process.env.HOST?.trim() || undefined;
 const EDITION = getEdition();
 const { secret: SESSION_SECRET, source: sessionSecretSource } = resolveSessionSecret();
 if (sessionSecretSource === 'generated') {
@@ -61,7 +71,7 @@ systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${ED
 // needs it so IRC networks can attribute each user behind the shared IP; bind
 // it before connections register their idents.
 if (isIdentdEnabled()) {
-  startIdentd(identdPort());
+  startIdentd(identdPort(), identdBindHost());
 }
 
 // Wrap any plaintext network secrets at rest now that the DB schema is ready
@@ -91,8 +101,8 @@ startOrchestratorClient();
 // didn't reach the control plane at upload time. No-op in standalone.
 startModerationReporter();
 
-server.listen(PORT, () => {
-  console.log(`[lurker] listening on http://localhost:${PORT}`);
+server.listen(PORT, HOST, () => {
+  console.log(`[lurker] listening on http://${HOST || '0.0.0.0'}:${PORT}`);
   systemLog.log({ scope: 'server', text: `Listening on port ${PORT}` });
 });
 

--- a/server/services/identd.test.ts
+++ b/server/services/identd.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import net from 'net';
 import {
   createIdentdServer,
@@ -10,6 +10,7 @@ import {
   isPrivateAddress,
   getIdentdMetrics,
   resetIdentdMetrics,
+  identdBindHost,
 } from './identd.js';
 
 let server: net.Server;
@@ -363,5 +364,28 @@ describe('isPrivateAddress', () => {
 
   it('treats an empty/unknown address as not private', () => {
     expect(isPrivateAddress('')).toBe(false);
+  });
+});
+
+describe('identdBindHost', () => {
+  const prev = process.env.LURKER_IDENTD_BIND;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.LURKER_IDENTD_BIND;
+    else process.env.LURKER_IDENTD_BIND = prev;
+  });
+
+  it('is undefined when unset', () => {
+    delete process.env.LURKER_IDENTD_BIND;
+    expect(identdBindHost()).toBeUndefined();
+  });
+
+  it('returns the trimmed address when set', () => {
+    process.env.LURKER_IDENTD_BIND = '  2001:db8::dead  ';
+    expect(identdBindHost()).toBe('2001:db8::dead');
+  });
+
+  it('treats a whitespace-only value as unset', () => {
+    process.env.LURKER_IDENTD_BIND = '   ';
+    expect(identdBindHost()).toBeUndefined();
   });
 });

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -446,7 +446,7 @@ function startSummary(): void {
   summaryTimer.unref();
 }
 
-export function startIdentd(port: number): void {
+export function startIdentd(port: number, bindHost?: string): void {
   if (server) return;
   const srv = createIdentdServer();
   srv.on('error', (err: Error) => {
@@ -458,14 +458,16 @@ export function startIdentd(port: number): void {
     if (srv.listening) srv.close();
     if (server === srv) server = null;
   });
-  srv.listen(port, () => {
+  const onListen = () => {
     console.log(
-      `[identd] listening on :${port} — verifying idents against the full RFC 1413 4-tuple, with a ${GRACE_MS}ms grace window to absorb the connect/registration race; relies on the container seeing IRC servers' real inbound source IPs (Docker bridge preserves them; if idents fail wholesale, run with network_mode: host)`,
+      `[identd] listening on ${bindHost ? `[${bindHost}]:` : ':'}${port} — verifying idents against the full RFC 1413 4-tuple, with a ${GRACE_MS}ms grace window to absorb the connect/registration race; relies on the container seeing IRC servers' real inbound source IPs (Docker bridge preserves them; if idents fail wholesale, run with network_mode: host)`,
     );
     // Only once we're actually listening — a failed bind shouldn't leave a stray
     // interval ticking for a service that never came up.
     startSummary();
-  });
+  };
+  if (bindHost) srv.listen(port, bindHost, onListen);
+  else srv.listen(port, onListen);
   server = srv;
 }
 
@@ -487,4 +489,14 @@ export function isIdentdEnabled(): boolean {
 export function identdPort(): number {
   const p = Number(process.env.LURKER_IDENTD_PORT);
   return Number.isInteger(p) && p > 0 ? p : 113;
+}
+
+// Optional bind address for the identd listener (LURKER_IDENTD_BIND). A
+// multi-homed host can pin the identd to a single local address (e.g. a
+// dedicated IPv6) so it coexists with another ident daemon serving the host's
+// other addresses — each answers :113 on its own IP. Unset (the default) binds
+// every interface.
+export function identdBindHost(): string | undefined {
+  const host = (process.env.LURKER_IDENTD_BIND || '').trim();
+  return host || undefined;
 }

--- a/server/services/identd.ts
+++ b/server/services/identd.ts
@@ -459,8 +459,10 @@ export function startIdentd(port: number, bindHost?: string): void {
     if (server === srv) server = null;
   });
   const onListen = () => {
+    // Bracket notation is IPv6-only; an IPv4 bind host must print bare.
+    const where = bindHost ? (net.isIPv6(bindHost) ? `[${bindHost}]:` : `${bindHost}:`) : ':';
     console.log(
-      `[identd] listening on ${bindHost ? `[${bindHost}]:` : ':'}${port} — verifying idents against the full RFC 1413 4-tuple, with a ${GRACE_MS}ms grace window to absorb the connect/registration race; relies on the container seeing IRC servers' real inbound source IPs (Docker bridge preserves them; if idents fail wholesale, run with network_mode: host)`,
+      `[identd] listening on ${where}${port} — verifying idents against the full RFC 1413 4-tuple, with a ${GRACE_MS}ms grace window to absorb the connect/registration race; relies on the container seeing IRC servers' real inbound source IPs (Docker bridge preserves them; if idents fail wholesale, run with network_mode: host)`,
     );
     // Only once we're actually listening — a failed bind shouldn't leave a stray
     // interval ticking for a service that never came up.

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -23,6 +23,7 @@ import {
   joinRejectionMessageByTag,
   sendRejectionTargetKind,
   sendRejectionText,
+  outgoingAddr,
 } from './ircConnection.js';
 import { createIdentdServer, unregisterIdent } from './identd.js';
 import { createUser } from '../db/users.js';
@@ -937,5 +938,28 @@ describe('self nick updates the input bar (#362)', () => {
     conn.currentNick = 'amiantos1';
     conn.client.emit('nick', { nick: 'amiantos1', new_nick: 'amiantos' });
     expect(conn.snapshot()).toMatchObject({ nick: 'amiantos' });
+  });
+});
+
+describe('outgoingAddr', () => {
+  const prev = process.env.LURKER_OUTGOING_ADDR;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.LURKER_OUTGOING_ADDR;
+    else process.env.LURKER_OUTGOING_ADDR = prev;
+  });
+
+  it('is undefined when unset', () => {
+    delete process.env.LURKER_OUTGOING_ADDR;
+    expect(outgoingAddr()).toBeUndefined();
+  });
+
+  it('returns the trimmed address when set', () => {
+    process.env.LURKER_OUTGOING_ADDR = '  2001:db8::dead  ';
+    expect(outgoingAddr()).toBe('2001:db8::dead');
+  });
+
+  it('treats a whitespace-only value as unset', () => {
+    process.env.LURKER_OUTGOING_ADDR = '   ';
+    expect(outgoingAddr()).toBeUndefined();
   });
 });

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2030,6 +2030,12 @@ export class IrcConnection {
       // — irc-framework overwrites client.options with this dict, so passing
       // it to the constructor doesn't survive. See client.js:202.
       enable_chghost: true,
+      // Source-bind outbound IRC to a dedicated local address when configured
+      // (LURKER_OUTGOING_ADDR). irc-framework forwards this as the socket's
+      // localAddress, so the IRC server's RFC 1413 callback lands on that
+      // address's :113 — where the built-in identd answers per-user. Unset =
+      // kernel default source, the upstream behaviour.
+      outgoing_addr: (process.env.LURKER_OUTGOING_ADDR || '').trim() || undefined,
     });
   }
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -27,6 +27,16 @@ import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent } from '../utils/ident.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled } from './identd.js';
 
+// Optional source address for outbound IRC connections (LURKER_OUTGOING_ADDR),
+// passed to irc-framework as `outgoing_addr` → the socket's localAddress. Lets a
+// multi-homed host choose which local IP (and therefore which identd) a
+// connection originates from. Unset = kernel default source. Mirrors the
+// identdBindHost() helper in identd.ts.
+export function outgoingAddr(): string | undefined {
+  const addr = (process.env.LURKER_OUTGOING_ADDR || '').trim();
+  return addr || undefined;
+}
+
 // Shown to peers as the QUIT reason on a clean disconnect. Most IRC clients
 // surface this in JOIN/PART messages, so it doubles as a Lurker
 // announcement — gives operators a quick read on what client + version is
@@ -2030,12 +2040,10 @@ export class IrcConnection {
       // — irc-framework overwrites client.options with this dict, so passing
       // it to the constructor doesn't survive. See client.js:202.
       enable_chghost: true,
-      // Source-bind outbound IRC to a dedicated local address when configured
-      // (LURKER_OUTGOING_ADDR). irc-framework forwards this as the socket's
-      // localAddress, so the IRC server's RFC 1413 callback lands on that
-      // address's :113 — where the built-in identd answers per-user. Unset =
-      // kernel default source, the upstream behaviour.
-      outgoing_addr: (process.env.LURKER_OUTGOING_ADDR || '').trim() || undefined,
+      // Source-bind outbound IRC when LURKER_OUTGOING_ADDR is set, so the
+      // network's RFC 1413 callback lands on the built-in identd rather than the
+      // host's (outgoingAddr → irc-framework outgoing_addr → socket localAddress).
+      outgoing_addr: outgoingAddr(),
     });
   }
 

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -27,6 +27,13 @@ declare module 'irc-framework' {
     enable_setname?: boolean;
     enable_echomessage?: boolean;
     version?: string;
+    /**
+     * Local source address to bind the outgoing socket to. irc-framework's net
+     * transport forwards this as the socket's `localAddress` (and derives the
+     * address family from it), letting a multi-homed host choose which local IP
+     * — and therefore which identd — a connection appears to originate from.
+     */
+    outgoing_addr?: string;
   }
 
   /** Options passed to the Client constructor. */


### PR DESCRIPTION
## What

Three **opt-in** environment variables that control which local address Lurker's network-facing sockets bind to. Each is a no-op when unset, so existing single-address deployments behave exactly as today.

| Var | Effect |
|-----|--------|
| `HOST` | Bind address for the web/API server. Unset = all interfaces (current behaviour); set to `127.0.0.1` to keep Lurker private behind a local reverse proxy / tunnel that terminates TLS in front of it. |
| `LURKER_IDENTD_BIND` | Bind address for the built-in identd. Unset = all interfaces. |
| `LURKER_OUTGOING_ADDR` | Source address for outbound IRC connections — passed through to irc-framework's `outgoing_addr`, which sets the socket's `localAddress`. |

## Why

The built-in identd (`LURKER_IDENTD_ENABLED`) is the clean way to attribute each user behind a single IP — but binding `:113` claims the host's port 113 on every address. On a box that already runs a system ident daemon (e.g. `oidentd`) for *other* services, the two collide.

These vars resolve that by **giving Lurker its own IP**: pin the identd to a dedicated address and source outbound IRC from that same address, so each network's RFC 1413 callback comes back to Lurker's identd, while the host daemon keeps serving every other address. No shared `:113`, and per-user idents never leak into the host daemon. Nothing changes for anyone who doesn't set them.

`HOST` is the companion for the common "Lurker behind cloudflared/Caddy" setup — keep the app on loopback and let the tunnel be the only public door.

## Example: Lurker's identd coexisting with host `oidentd` on a dedicated IPv6

Give Lurker a dedicated address from the host's IPv6 block, e.g. `2001:db8::dead`, then:

```ini
# .env
LURKER_IDENTD_ENABLED=true
LURKER_IDENTD_PORT=113
LURKER_IDENTD_BIND=2001:db8::dead    # identd answers :113 on this IP only
LURKER_OUTGOING_ADDR=2001:db8::dead   # IRC goes out from this IP, so callbacks return here
HOST=127.0.0.1                        # web stays behind the tunnel
```

Now keep the host ident daemon off that one address so the two don't fight over `:113`.

**`oidentd` via systemd socket activation** — a drop-in that binds every address *except* Lurker's (an IPv4 wildcard does not cover IPv6, so Lurker's v6 is left free):

```ini
# /etc/systemd/system/oidentd.socket.d/split.conf
[Socket]
ListenStream=                        # reset the inherited wildcard :113
ListenStream=0.0.0.0:113             # all IPv4
ListenStream=[2001:db8::1]:113       # each existing host IPv6...
# (repeat for the host's other addresses; omit 2001:db8::dead)
```

```sh
systemctl daemon-reload && systemctl restart oidentd.socket
```

**`oidentd` as a plain daemon** — bind it explicitly with `-a` instead of the wildcard, omitting Lurker's address:

```ini
# /etc/default/oidentd
OIDENT_OPTIONS="-a 0.0.0.0 -a 2001:db8::1 ..."   # no 2001:db8::dead
```

Result: a network's ident lookup to `2001:db8::dead:113` reaches Lurker's per-user identd; lookups to every other host IP reach `oidentd` exactly as before.

## Notes

- No behaviour change when the vars are unset.
- `outgoing_addr` is added to the in-repo `irc-framework` ambient types (`server/types/irc-framework.d.ts`); `identdBindHost()` mirrors the existing `identdPort()` / `isIdentdEnabled()` helpers and has unit tests.
- `npm run check` and `npm test` pass locally (1193 tests).

Happy to split this into separate PRs (web `HOST` vs the identd/outbound pair) if you'd prefer.
