### PR TITLE
Guard nick-regain MONITOR teardown behind useMonitor (#384)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -414,6 +414,77 @@ describe('addPeerWatch live presence seed (#302)', () => {
   });
 });
 
+describe('nick-regain MONITOR teardown gating (#384)', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'nick',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  // Repro for #384: we connected under a fallback nick (the configured nick was
+  // taken, so a regain watch is armed) on a server with no MONITOR, then the
+  // user changes nick. The self-nick handler tears the regain watch down — but
+  // the matching `MONITOR +` was never sent (it's gated on useMonitor), so a
+  // blind `MONITOR -` here only earns a 421 "MONITOR Unknown command" banner.
+  it('sends no MONITOR - on a self-nick change when the server lacks MONITOR', () => {
+    const conn = makeConn();
+    conn.useMonitor = false;
+    conn.state = 'connected';
+    conn.regainNick = 'nick'; // the primary we still want back
+    conn.pendingRegainSetup = true;
+    conn.client.user.nick = 'nick1'; // currently on the fallback
+    conn.publish = vi.fn<(event: unknown) => void>(); // we assert on the wire, not the buffer
+    const raw = vi.fn<(...args: unknown[]) => void>();
+    conn.client.raw = raw;
+
+    // Reclaim the primary: old nick 'nick1' (our current), new nick 'nick'.
+    conn.client.emit('nick', { nick: 'nick1', new_nick: 'nick' });
+
+    expect(raw.mock.calls.flat(Infinity).join(' ')).not.toContain('MONITOR');
+    expect(conn.regainNick).toBeNull(); // watch state is still cleared
+  });
+
+  // On a MONITOR-capable server the teardown must still fire, releasing the
+  // server-side watch for the (now reclaimed) regain nick.
+  it('still sends MONITOR - on a self-nick change when the server supports MONITOR', () => {
+    const conn = makeConn();
+    conn.useMonitor = true;
+    conn.monitorLimit = 100;
+    conn.state = 'connected';
+    conn.regainNick = 'nick';
+    conn.pendingRegainSetup = false;
+    conn.client.user.nick = 'nick1';
+    conn.publish = vi.fn<(event: unknown) => void>();
+    const raw = vi.fn<(...args: unknown[]) => void>();
+    conn.client.raw = raw;
+
+    conn.client.emit('nick', { nick: 'nick1', new_nick: 'nick' });
+
+    // removeMonitor() emits the line as args: ['MONITOR', '-', 'nick'].
+    expect(raw.mock.calls.flat(Infinity).join(' ')).toContain('MONITOR - nick');
+    expect(conn.regainNick).toBeNull();
+  });
+});
+
 describe('formatSocketCloseErrorMessage', () => {
   const where = 'irc.example.test:6697';
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1172,10 +1172,17 @@ export class IrcConnection {
         // silently). Either way the watch is now stale.
         if (this.regainNick) {
           const reclaimed = newLower === this.regainNick.toLowerCase();
-          try {
-            this.client.removeMonitor(this.regainNick);
-          } catch (_) {
-            /* ignore */
+          // Only tear down a watch we could actually have placed. The regain
+          // `MONITOR +` is gated on `useMonitor` (set from ISUPPORT), so on a
+          // server without MONITOR — or before ISUPPORT lands — nothing was
+          // ever watched and a blind `MONITOR -` here just draws a 421
+          // "MONITOR Unknown command" (#384). Skipping it is a true no-op.
+          if (this.useMonitor) {
+            try {
+              this.client.removeMonitor(this.regainNick);
+            } catch (_) {
+              /* ignore */
+            }
           }
           if (reclaimed) {
             this.publish({


### PR DESCRIPTION
Fixes #384.

## Problem

On a server with **no `MONITOR` support**, a user who connected under a fallback nick (their configured nick was taken) would get a `MONITOR Unknown command` banner + console line the moment they changed their nick:

```
MONITOR Unknown command
!!unknown_command MONITOR — Unknown command
```

## Root cause

Lurker already gates MONITOR behind capability detection: `useMonitor` flips true only when ISUPPORT (`005`) advertises a `MONITOR` token, and every MONITOR wire write is supposed to check it first. Almost all do — the regain `addMonitor`, the seed batch, `addPeerWatch`, and `teardownPeerWatch` are all gated.

The **one exception** was the nick-regain teardown in the self-nick handler (`ircConnection.ts`), which called `this.client.removeMonitor(this.regainNick)` **unconditionally**. Since `regainNick` is armed at registration (independent of MONITOR support) but the matching `MONITOR +` is gated on `useMonitor`, a non-MONITOR server never had anything watched — yet the blind `MONITOR -` still went out and drew `421 MONITOR :Unknown command`, which the 421 handler surfaces as a toast/banner.

## Repro conditions

Narrower than "any nick change":
1. Server has no `MONITOR`, **and**
2. The configured nick was taken at connect, so a fallback nick was used and a regain watch was armed (`regainNick` is only ever set under `if (fallbackUsed)`), **and**
3. The user then changes nick → self-nick handler fires the blind teardown.

## Fix

Gate the teardown on `useMonitor`, matching every other MONITOR write. On a non-MONITOR server (or before ISUPPORT lands) nothing was ever watched, so skipping the `MONITOR -` is a true no-op; on a MONITOR-capable server it proceeds unchanged. Also closes the same race if a nick change happens before ISUPPORT arrives.

## Tests

Adds a `nick-regain MONITOR teardown gating (#384)` block:
- non-MONITOR server → self-nick change sends **no** `MONITOR -` (verified to fail without the fix)
- MONITOR-capable server → teardown still fires (`MONITOR - nick`)

`npm run typecheck`, `oxlint`, `oxfmt --check`, and the `ircConnection` suite (61 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)