### PR TITLE
Message-list nick mode-prefix glyph + interactivity (#376, #238)

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -542,6 +542,17 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     default: 'djb2-32',
     description: 'Hash algorithm used to map nicknames to palette colors.',
   },
+  {
+    key: 'look.nick.show_mode_prefix',
+    label: 'Show mode prefix on nicks',
+    category: 'appearance',
+    group: 'nicks',
+    type: 'bool',
+    default: false,
+    description:
+      'Show the channel user-mode prefix (@ op, + voice, % halfop, ~ owner, & admin) before a ' +
+      "speaker's nick in the message list. Reflects the user's current status in that channel.",
+  },
 
   // ─── Misc look ────────────────────────────────────────────────────────
   {

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -239,6 +239,18 @@ a {
   border-radius: 2px;
 }
 
+/* Coloured nick mentions inside message text. Clickable to open the member
+   menu (Reply, whois, DM, …), the same affordance as the nicklist. The nick
+   keeps its inline colour; pointer + hover underline are the only added cues.
+   Left selectable so the message text stays copyable. */
+.msg-nick {
+  cursor: pointer;
+}
+.msg-nick:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 /* Button language (#355): accent = actionable, gray = disabled. Buttons carry
    the accent color, brighten to --fg on hover (no gray fill), and drop to the
    muted gray on :disabled — so "gray" unambiguously means "you can't click

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -241,14 +241,11 @@ a {
 
 /* Coloured nick mentions inside message text. Clickable to open the member
    menu (Reply, whois, DM, …), the same affordance as the nicklist. The nick
-   keeps its inline colour; pointer + hover underline are the only added cues.
-   Left selectable so the message text stays copyable. */
+   keeps its inline colour; a pointer cursor is the only added cue — no hover
+   underline, to match the author and event-line nicks. Left selectable so the
+   message text stays copyable. */
 .msg-nick {
   cursor: pointer;
-}
-.msg-nick:hover {
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }
 
 /* Button language (#355): accent = actionable, gray = disabled. Buttons carry

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -45,6 +45,11 @@ import { useBuffersStore, type BufferMember } from '../stores/buffers.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useMemberActions } from '../composables/useMemberActions.js';
 import { useIgnoresStore } from '../stores/ignores.js';
+import {
+  PREFIX_ORDER,
+  prefixOf as modePrefixOf,
+  prefixClass as modePrefixClass,
+} from '../utils/memberPrefix.js';
 import IgnoreModal from './IgnoreModal.vue';
 
 const networks = useNetworksStore();
@@ -93,8 +98,6 @@ function nickStyle(m: BufferMember): { color: string } | null {
   return c ? { color: c } : null;
 }
 
-const PREFIX_ORDER = ['~', '&', '@', '%', '+', ''];
-
 function nickOf(m: BufferMember): string {
   return m.nick;
 }
@@ -137,17 +140,10 @@ function onActionsClick(e: MouseEvent, m: BufferMember): void {
   memberActions.openMenuFromButton(m, menuContext(), e.currentTarget as Element);
 }
 function prefixOf(m: BufferMember): string {
-  const modes = modesOf(m);
-  if (modes.includes('q')) return '~';
-  if (modes.includes('a')) return '&';
-  if (modes.includes('o')) return '@';
-  if (modes.includes('h')) return '%';
-  if (modes.includes('v')) return '+';
-  return '';
+  return modePrefixOf(modesOf(m));
 }
 function prefixClass(m: BufferMember): string {
-  const p = prefixOf(m);
-  return p ? `mode-${p}` : '';
+  return modePrefixClass(modesOf(m));
 }
 function isAway(m: BufferMember): boolean {
   return !!m?.away;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -62,19 +62,19 @@
                 ><NickRef
                   :nick="asRename(item).from"
                   interactive
-                  @click.stop.prevent="onNickClick(asRename(item).from)"
+                  @click.stop.prevent="onNickMenu($event, asRename(item).from)"
                   @contextmenu.stop.prevent="onNickMenu($event, asRename(item).from)" />
                 →
                 <NickRef
                   :nick="asRename(item).to"
                   interactive
-                  @click.stop.prevent="onNickClick(asRename(item).to)"
+                  @click.stop.prevent="onNickMenu($event, asRename(item).to)"
                   @contextmenu.stop.prevent="onNickMenu($event, asRename(item).to)" /></template
               ><template v-else
                 ><NickRef
                   :nick="asNick(item).nick"
                   interactive
-                  @click.stop.prevent="onNickClick(asNick(item).nick)"
+                  @click.stop.prevent="onNickMenu($event, asNick(item).nick)"
                   @contextmenu.stop.prevent="
                     onNickMenu($event, asNick(item).nick)
                   " /></template></template
@@ -101,7 +101,7 @@
                 :modes="authorModes(row.m)"
                 :show-prefix="showModePrefix"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
             /></span>
           </div>
@@ -126,7 +126,7 @@
                 :modes="authorModes(row.m)"
                 :show-prefix="showModePrefix"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /></template
             ><template v-else>{{ row.continuationAuthor ? '' : prefixText(row.m) }}</template></span
           >
@@ -141,7 +141,7 @@
               ><NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               />{{ eventHostSuffix(row.m) }} joined</template
             >
@@ -149,7 +149,7 @@
               ><NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               />{{ eventHostSuffix(row.m) }} left<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
@@ -159,7 +159,7 @@
               ><NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               />{{ eventHostSuffix(row.m) }} quit<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
@@ -169,14 +169,14 @@
               ><NickRef
                 :nick="row.m.kicked ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.kicked)"
+                @click.stop.prevent="onNickMenu($event, row.m?.kicked)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.kicked)"
               />
               kicked by
               <NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               /><template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
@@ -186,14 +186,14 @@
               ><NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               />
               is now
               <NickRef
                 :nick="row.m.newNick ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.newNick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.newNick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.newNick, row.m)"
               />{{ eventHostSuffix(row.m) }}</template
             >
@@ -202,7 +202,7 @@
               <NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
                 v-if="row.m.text"
                 >: <LinkedText :text="row.m.text" /></template
@@ -212,7 +212,7 @@
               <NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
                 @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
                 v-if="row.m.text"
                 >: <LinkedText :text="row.m.text" /></template
@@ -598,11 +598,10 @@ function runAction(key: MessageActionKey, m: ChatMessage | undefined | null): vo
 }
 
 // ─── Nick interactivity (#238) + mode-prefix glyph (#376) ──────────────────
-// Message-list nicks reuse the member-list action menu and the same composer
-// hand-off, so a speaker's nick behaves like its nicklist entry: tap inserts
-// "nick: " into the composer; long-press / right-click opens the action menu
-// (whois, DM, note, friend, ignore, and op-gated kick/ban/op/voice). The menu
-// and ignore modal are owned here, mirroring MemberList's pattern.
+// Message-list nicks behave exactly like their nicklist entry: a tap (or
+// right-click / long-press) opens the shared member-action menu — Reply, Copy
+// Nickname, whois, DM, note, friend, ignore, and op-gated kick/ban/op/voice.
+// The menu and ignore modal are owned here, mirroring MemberList's pattern.
 const memberActions = useMemberActions();
 
 const showModePrefix = computed(() => !!settings.effective('look.nick.show_mode_prefix'));
@@ -657,10 +656,6 @@ function nickMenuContext(): MemberContext {
     channel: buffer.value?.target ?? null,
     selfModes: selfModes.value,
   };
-}
-
-function onNickClick(nick: string | undefined): void {
-  if (nick) addressNick(nick);
 }
 
 // `m` is the source message, used only to recover a userhost for a speaker who

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -110,6 +110,8 @@
               :segments="textSegments(row.m)"
               :self-color="selfColor"
               :network-id="buffer?.networkId ?? null"
+              interactive-nicks
+              @nick-click="onMentionMenu"
             />
           </span>
           <span class="time">{{ row.continuationTime ? '' : time(row.m?.time) }}</span>
@@ -136,6 +138,8 @@
               :segments="textSegments(row.m)"
               :self-color="selfColor"
               :network-id="buffer?.networkId ?? null"
+              interactive-nicks
+              @nick-click="onMentionMenu"
             />
             <template v-else-if="row.m?.type === 'join'"
               ><NickRef
@@ -669,6 +673,14 @@ function onNickMenu(e: MouseEvent, nick: string | undefined, m?: ChatMessage): v
   // actionable.
   const member: MemberLike = nickMember(nick) ?? { nick, ...parseUserHost(m?.userhost) };
   memberActions.openMenuFor(member, nickMenuContext(), e.clientX, e.clientY);
+}
+
+// A coloured nick mention inside message text (emitted by RenderSegments). The
+// mentioned user isn't the message author, so there's no userhost to recover
+// from the row — pass the nick alone and let onNickMenu resolve a live member
+// (or fall back to a bare-nick menu).
+function onMentionMenu(nick: string, e: MouseEvent): void {
+  onNickMenu(e, nick);
 }
 
 const smartFilterEnabled = computed(() => !!settings.effective('chat.smart_filter'));

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -59,9 +59,25 @@
                 ii === g.visible.length - 1 && g.hidden === 0 ? ' and ' : ', '
               }}</template
               ><template v-if="g.kind === 'renamed'"
-                ><NickRef :nick="asRename(item).from" /> →
-                <NickRef :nick="asRename(item).to" /></template
-              ><template v-else><NickRef :nick="asNick(item).nick" /></template></template
+                ><NickRef
+                  :nick="asRename(item).from"
+                  interactive
+                  @click.stop.prevent="onNickClick(asRename(item).from)"
+                  @contextmenu.stop.prevent="onNickMenu($event, asRename(item).from)" />
+                →
+                <NickRef
+                  :nick="asRename(item).to"
+                  interactive
+                  @click.stop.prevent="onNickClick(asRename(item).to)"
+                  @contextmenu.stop.prevent="onNickMenu($event, asRename(item).to)" /></template
+              ><template v-else
+                ><NickRef
+                  :nick="asNick(item).nick"
+                  interactive
+                  @click.stop.prevent="onNickClick(asNick(item).nick)"
+                  @contextmenu.stop.prevent="
+                    onNickMenu($event, asNick(item).nick)
+                  " /></template></template
             ><template v-if="g.hidden > 0"
               >, and {{ g.hidden }} {{ g.hidden === 1 ? 'other' : 'others' }}</template
             ><template v-if="g.kind === 'joined'"> joined</template
@@ -79,9 +95,15 @@
              author continuations so a run of same-author messages reads
              as one block, but every body row still shows its own time. -->
           <div v-if="!row.continuationAuthor" class="head">
-            <span class="prefix" :class="prefixClass(row.m)" :style="prefixStyle(row.m)">{{
-              row.m?.nick
-            }}</span>
+            <span class="prefix" :class="prefixClass(row.m)"
+              ><NickRef
+                :nick="row.m?.nick ?? ''"
+                :modes="authorModes(row.m)"
+                :show-prefix="showModePrefix"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
+            /></span>
           </div>
           <span class="body" :class="bodyClass(row.m)">
             <RenderSegments
@@ -97,8 +119,16 @@
           <span
             class="prefix"
             :class="prefixClass(row.m)"
-            :style="row.continuationAuthor ? null : prefixStyle(row.m)"
-            >{{ row.continuationAuthor ? '' : prefixText(row.m) }}</span
+            :style="row.continuationAuthor || row.m?.type === 'message' ? null : prefixStyle(row.m)"
+            ><template v-if="row.m?.type === 'message' && !row.continuationAuthor"
+              ><NickRef
+                :nick="row.m?.nick ?? ''"
+                :modes="authorModes(row.m)"
+                :show-prefix="showModePrefix"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /></template
+            ><template v-else>{{ row.continuationAuthor ? '' : prefixText(row.m) }}</template></span
           >
           <span class="body" :class="bodyClass(row.m)">
             <RenderSegments
@@ -108,39 +138,83 @@
               :network-id="buffer?.networkId ?? null"
             />
             <template v-else-if="row.m?.type === 'join'"
-              ><NickRef :nick="row.m.nick ?? ''" />{{ eventHostSuffix(row.m) }} joined</template
+              ><NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
+              />{{ eventHostSuffix(row.m) }} joined</template
             >
             <template v-else-if="row.m?.type === 'part'"
-              ><NickRef :nick="row.m.nick ?? ''" />{{ eventHostSuffix(row.m) }} left<template
-                v-if="row.m.text"
-              >
+              ><NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
+              />{{ eventHostSuffix(row.m) }} left<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
             <template v-else-if="row.m?.type === 'quit'"
-              ><NickRef :nick="row.m.nick ?? ''" />{{ eventHostSuffix(row.m) }} quit<template
-                v-if="row.m.text"
-              >
+              ><NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
+              />{{ eventHostSuffix(row.m) }} quit<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
             <template v-else-if="row.m?.type === 'kick'"
-              ><NickRef :nick="row.m.kicked ?? ''" /> kicked by
-              <NickRef :nick="row.m.nick ?? ''" /><template v-if="row.m.text">
+              ><NickRef
+                :nick="row.m.kicked ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.kicked)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.kicked)"
+              />
+              kicked by
+              <NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
+              /><template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
             <template v-else-if="row.m?.type === 'nick'"
-              ><NickRef :nick="row.m.nick ?? ''" /> is now <NickRef :nick="row.m.newNick ?? ''" />{{
-                eventHostSuffix(row.m)
-              }}</template
+              ><NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
+              />
+              is now
+              <NickRef
+                :nick="row.m.newNick ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.newNick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.newNick, row.m)"
+              />{{ eventHostSuffix(row.m) }}</template
             >
             <template v-else-if="row.m?.type === 'mode'"
-              >mode by <NickRef :nick="row.m.nick ?? ''" /><template v-if="row.m.text"
+              >mode by
+              <NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
+                v-if="row.m.text"
                 >: <LinkedText :text="row.m.text" /></template
             ></template>
             <template v-else-if="row.m?.type === 'topic'"
-              >topic set by <NickRef :nick="row.m.nick ?? ''" /><template v-if="row.m.text"
+              >topic set by
+              <NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickClick(row.m?.nick)"
+                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
+                v-if="row.m.text"
                 >: <LinkedText :text="row.m.text" /></template
             ></template>
             <template v-else-if="row.m?.type === 'motd' || row.m?.type === 'system'"
@@ -188,7 +262,7 @@
 import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
 import type { CSSProperties, ComponentPublicInstance } from 'vue';
 import { useNetworksStore, type AwayState } from '../stores/networks.js';
-import { useBuffersStore } from '../stores/buffers.js';
+import { useBuffersStore, type BufferMember } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
@@ -223,6 +297,8 @@ import type {
   MessageAction,
   MessageActionKey,
 } from '../composables/useMessageActions.js';
+import { useMemberActions } from '../composables/useMemberActions.js';
+import type { MemberContext, MemberLike } from '../composables/useMemberActions.js';
 import { addressNick } from '../composables/useComposerOverlay.js';
 import { setViewedBuffer } from '../composables/useViewedBuffer.js';
 
@@ -519,6 +595,85 @@ function runAction(key: MessageActionKey, m: ChatMessage | undefined | null): vo
   if (!m) return;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   messageActions.run(key, m as any, actionContext);
+}
+
+// ─── Nick interactivity (#238) + mode-prefix glyph (#376) ──────────────────
+// Message-list nicks reuse the member-list action menu and the same composer
+// hand-off, so a speaker's nick behaves like its nicklist entry: tap inserts
+// "nick: " into the composer; long-press / right-click opens the action menu
+// (whois, DM, note, friend, ignore, and op-gated kick/ban/op/voice). The menu
+// and ignore modal are owned here, mirroring MemberList's pattern.
+const memberActions = useMemberActions();
+
+const showModePrefix = computed(() => !!settings.effective('look.nick.show_mode_prefix'));
+
+// Look up a speaker in the active buffer by case-folded nick — servers send
+// case-variant nicks, so we never key on exact casing.
+function nickMember(nick: string): BufferMember | undefined {
+  const b = buffer.value;
+  if (!b || !nick) return undefined;
+  const lc = nick.toLowerCase();
+  return b.members?.find((m) => m.nick.toLowerCase() === lc);
+}
+
+// The current user's own modes in the active channel, gating the operator
+// actions in the nick menu (mirrors MemberList's selfModes).
+const selfModes = computed<string[]>(() => {
+  const sl = selfLower.value;
+  if (!sl) return [];
+  const me = buffer.value?.members?.find((m) => m.nick.toLowerCase() === sl);
+  return me && Array.isArray(me.modes) ? me.modes : [];
+});
+
+// The author's channel modes for the prefix glyph — channel buffers only (DMs
+// and the system buffer carry no modes). Returns undefined (no glyph) when the
+// speaker isn't a current member, e.g. backlog from someone who has since left.
+function authorModes(m: ChatMessage | undefined): string[] | undefined {
+  if (!m?.nick) return undefined;
+  const b = buffer.value;
+  if (!b || !b.target?.startsWith('#')) return undefined;
+  return nickMember(m.nick)?.modes;
+}
+
+function nickIsSelf(member: MemberLike | string): boolean {
+  const sl = selfLower.value;
+  const nick = typeof member === 'string' ? member : member.nick;
+  return !!sl && !!nick && nick.toLowerCase() === sl;
+}
+
+function nickMenuContext(): MemberContext {
+  return {
+    networkId: buffer.value?.networkId ?? 0,
+    isSelf: nickIsSelf,
+    onIgnore: (member) => {
+      const nick = typeof member === 'string' ? member : member.nick;
+      ignoreTarget.value = {
+        nick,
+        user: typeof member === 'string' ? null : (member.user ?? null),
+        host: typeof member === 'string' ? null : (member.host ?? null),
+        networkId: buffer.value?.networkId ?? undefined,
+      };
+    },
+    channel: buffer.value?.target ?? null,
+    selfModes: selfModes.value,
+  };
+}
+
+function onNickClick(nick: string | undefined): void {
+  if (nick) addressNick(nick);
+}
+
+// `m` is the source message, used only to recover a userhost for a speaker who
+// is no longer in the member list — so whois/ban masks still work on backlog.
+// Omit it for nicks where the message's userhost belongs to someone else (e.g.
+// the kicked user in a kick line).
+function onNickMenu(e: MouseEvent, nick: string | undefined, m?: ChatMessage): void {
+  if (!nick || !buffer.value) return;
+  // Prefer the live member (modes for op-gating, host for a clean ban mask);
+  // fall back to the message's own userhost so a departed speaker stays
+  // actionable.
+  const member: MemberLike = nickMember(nick) ?? { nick, ...parseUserHost(m?.userhost) };
+  memberActions.openMenuFor(member, nickMenuContext(), e.clientX, e.clientY);
 }
 
 const smartFilterEnabled = computed(() => !!settings.effective('chat.smart_filter'));

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -631,8 +631,10 @@ const selfModes = computed<string[]>(() => {
 // The author's channel modes for the prefix glyph — channel buffers only (DMs
 // and the system buffer carry no modes). Returns undefined (no glyph) when the
 // speaker isn't a current member, e.g. backlog from someone who has since left.
+// Called per message row at render, so short-circuit when the glyph is off (the
+// default) to skip the per-row member-list scan entirely.
 function authorModes(m: ChatMessage | undefined): string[] | undefined {
-  if (!m?.nick) return undefined;
+  if (!showModePrefix.value || !m?.nick) return undefined;
   const b = buffer.value;
   if (!b || !b.target?.startsWith('#')) return undefined;
   return nickMember(m.nick)?.modes;

--- a/vue_client/src/components/NickRef.vue
+++ b/vue_client/src/components/NickRef.vue
@@ -62,6 +62,11 @@ const style = computed(() => {
 }
 .nick-ref.interactive {
   cursor: pointer;
+  /* Right-clicking to open the menu otherwise selects the word under the
+     cursor (the selection happens on pointer-down, before @contextmenu.prevent
+     can fire), which reads as a glitch. Matches the member list, where rows are
+     likewise unselectable. */
+  user-select: none;
 }
 /* The mode glyph reuses the nicklist's per-mode colors so it reads as a status
    marker rather than part of the (separately-colored) nick. */

--- a/vue_client/src/components/NickRef.vue
+++ b/vue_client/src/components/NickRef.vue
@@ -4,7 +4,10 @@
 -->
 
 <template>
-  <span class="nick-ref" :style="style">{{ nick }}</span>
+  <span class="nick-ref" :class="{ interactive }" :style="style"
+    ><span v-if="glyph" class="mode-glyph" :class="glyphClass">{{ glyph }}</span
+    >{{ nick }}</span
+  >
 </template>
 
 <script setup lang="ts">
@@ -12,14 +15,26 @@ import { computed } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useNickColors } from '../composables/useNickColors.js';
+import { prefixOf } from '../utils/memberPrefix.js';
 
 const props = defineProps<{
   nick: string;
+  // Channel user-mode glyph (#376). Both must be supplied for the glyph to
+  // render; callers that aren't a channel speaker just omit them.
+  modes?: string[];
+  showPrefix?: boolean;
+  // Pointer affordance for clickable nicks (#238). The click/contextmenu
+  // handlers are attached by the consumer and reach the root span via Vue's
+  // attribute fallthrough — this prop only drives the cursor styling.
+  interactive?: boolean;
 }>();
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const nicks = useNickColors();
+
+const glyph = computed(() => (props.showPrefix ? prefixOf(props.modes) : ''));
+const glyphClass = computed(() => `mode-${glyph.value}`);
 
 const selfLower = computed(() => {
   const key = networks.activeKey;
@@ -44,5 +59,25 @@ const style = computed(() => {
 <style scoped>
 .nick-ref {
   color: inherit;
+}
+.nick-ref.interactive {
+  cursor: pointer;
+}
+/* The mode glyph reuses the nicklist's per-mode colors so it reads as a status
+   marker rather than part of the (separately-colored) nick. */
+.mode-glyph.mode-\~ {
+  color: var(--member-owner);
+}
+.mode-glyph.mode-\& {
+  color: var(--member-admin);
+}
+.mode-glyph.mode-\@ {
+  color: var(--member-op);
+}
+.mode-glyph.mode-\% {
+  color: var(--member-halfop);
+}
+.mode-glyph.mode-\+ {
+  color: var(--member-voice);
 }
 </style>

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -35,6 +35,20 @@
       @keydown.space.prevent="openChannel(seg.channel)"
       >{{ seg.text }}</span
     >
+    <!-- A coloured nick mention (seg.color / seg.self are exclusive to the nick
+         pass). Interactive only when the caller opts in (the message list),
+         where a click opens the same member menu as the nicklist — Reply,
+         whois, DM, etc. Elsewhere nick segments fall through to the styled-span
+         branch below and render exactly as before. Kept selectable so message
+         text stays copyable. -->
+    <span
+      v-else-if="interactiveNicks && (seg.color != null || seg.self)"
+      class="msg-nick"
+      :style="styleFor(seg)"
+      @click.stop="$emit('nickClick', seg.text, $event)"
+      @contextmenu.stop.prevent="$emit('nickClick', seg.text, $event)"
+      >{{ seg.text }}</span
+    >
     <span v-else-if="hasStyle(seg)" :style="styleFor(seg)">{{ seg.text }}</span>
     <template v-else>{{ seg.text }}</template>
   </template>
@@ -70,9 +84,17 @@ const props = withDefaults(
     segments: RenderSegment[];
     selfColor?: string | null;
     networkId?: number | null;
+    // Opt-in: render coloured nick mentions as clickable (emits `nickClick`).
+    // Off everywhere except the message list, so other callers (topic bar,
+    // motd, history rows) keep nick segments inert.
+    interactiveNicks?: boolean;
   }>(),
-  { selfColor: null, networkId: null },
+  { selfColor: null, networkId: null, interactiveNicks: false },
 );
+
+defineEmits<{
+  nickClick: [nick: string, ev: MouseEvent];
+}>();
 
 const buffers = useBuffersStore();
 const settings = useSettingsStore();

--- a/vue_client/src/composables/useMemberActions.ts
+++ b/vue_client/src/composables/useMemberActions.ts
@@ -8,6 +8,7 @@ import { useFriendsStore } from '../stores/friends.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useContextMenu } from './useContextMenu.js';
 import { socketSend } from './useSocket.js';
+import { addressNick } from './useComposerOverlay.js';
 
 export interface MemberLike {
   nick: string;
@@ -109,15 +110,33 @@ export function useMemberActions(): MemberActionsAPI {
     const isSelf = ctx.isSelf(member);
     const hasNote = nickNotes.hasNote(ctx.networkId, nick);
     // Self gets a trimmed menu: you can view your own profile and note yourself,
-    // but Send DM, Ignore, and the moderation actions are all meaningless or
-    // nonsensical aimed at yourself, so they're left off below.
-    const items: ContextMenuItem[] = [
-      {
-        label: 'View Profile…',
-        icon: 'fa-solid fa-id-card',
-        onClick: () => whois.openViewer(ctx.networkId, nick),
+    // but Reply, Send DM, Ignore, and the moderation actions are all meaningless
+    // or nonsensical aimed at yourself, so they're left off below.
+    const items: ContextMenuItem[] = [];
+    // Reply addresses the speaker in the active composer — the same composer
+    // hand-off as the message action bar's Reply.
+    if (!isSelf) {
+      items.push({
+        label: `Reply to ${nick}`,
+        icon: 'fa-solid fa-reply',
+        onClick: () => addressNick(nick),
+      });
+    }
+    items.push({
+      label: 'Copy Nickname',
+      icon: 'fa-regular fa-copy',
+      // Best-effort: writeText rejects without clipboard permission or in an
+      // insecure context, and the API can be absent on older browsers.
+      onClick: () => {
+        navigator.clipboard?.writeText(nick).catch(() => {});
       },
-    ];
+    });
+    items.push({ divider: true });
+    items.push({
+      label: 'View Profile…',
+      icon: 'fa-solid fa-id-card',
+      onClick: () => whois.openViewer(ctx.networkId, nick),
+    });
     if (!isSelf) {
       items.push({
         label: 'Send DM',

--- a/vue_client/src/composables/useSelfLabel.ts
+++ b/vue_client/src/composables/useSelfLabel.ts
@@ -5,6 +5,7 @@ import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
+import { prefixOf } from '../utils/memberPrefix.js';
 
 export interface SelfLabelState {
   promptLabel: ComputedRef<string>;
@@ -18,9 +19,6 @@ export interface SelfLabelState {
 //
 // The channel-prefix is the user's own op/voice marker derived from the
 // active channel's member list. For DMs / server buffers it's empty.
-const PROMPT_PREFIX: Record<string, string> = { o: '@', h: '%', v: '+', a: '&', q: '~' };
-const PROMPT_PREFIX_RANK = ['q', 'a', 'o', 'h', 'v'];
-
 export function useSelfLabel(): SelfLabelState {
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
@@ -35,11 +33,7 @@ export function useSelfLabel(): SelfLabelState {
     if (!nick) return '';
     const lc = nick.toLowerCase();
     const me = buf.members.find((m) => m.nick.toLowerCase() === lc);
-    const modes = me?.modes ?? [];
-    for (const letter of PROMPT_PREFIX_RANK) {
-      if (modes.includes(letter)) return PROMPT_PREFIX[letter];
-    }
-    return '';
+    return prefixOf(me?.modes ?? []);
   });
 
   // Identity without the trailing user-mode parens. Feeds the mobile input

--- a/vue_client/src/utils/memberPrefix.test.ts
+++ b/vue_client/src/utils/memberPrefix.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { PREFIX_ORDER, prefixOf, prefixClass } from './memberPrefix.js';
+
+describe('prefixOf', () => {
+  it('returns the single highest-ranked glyph', () => {
+    expect(prefixOf(['q'])).toBe('~');
+    expect(prefixOf(['a'])).toBe('&');
+    expect(prefixOf(['o'])).toBe('@');
+    expect(prefixOf(['h'])).toBe('%');
+    expect(prefixOf(['v'])).toBe('+');
+  });
+
+  it('ranks owner > admin > op > halfop > voice when several are held', () => {
+    expect(prefixOf(['v', 'o'])).toBe('@');
+    expect(prefixOf(['h', 'v'])).toBe('%');
+    expect(prefixOf(['o', 'a', 'q'])).toBe('~');
+  });
+
+  it('returns empty string for no prefix modes', () => {
+    expect(prefixOf([])).toBe('');
+    expect(prefixOf(['x', 'b'])).toBe('');
+  });
+
+  it('tolerates null/undefined', () => {
+    expect(prefixOf(null)).toBe('');
+    expect(prefixOf(undefined)).toBe('');
+  });
+});
+
+describe('prefixClass', () => {
+  it('builds a mode-<glyph> class or empty string', () => {
+    expect(prefixClass(['o'])).toBe('mode-@');
+    expect(prefixClass(['q'])).toBe('mode-~');
+    expect(prefixClass([])).toBe('');
+  });
+});
+
+describe('PREFIX_ORDER', () => {
+  it('lists glyphs high-to-low with empty last, so indexOf sorts members by rank', () => {
+    expect(PREFIX_ORDER).toEqual(['~', '&', '@', '%', '+', '']);
+    expect(PREFIX_ORDER.indexOf(prefixOf(['o']))).toBeLessThan(
+      PREFIX_ORDER.indexOf(prefixOf(['v'])),
+    );
+    expect(PREFIX_ORDER.indexOf(prefixOf([]))).toBe(PREFIX_ORDER.length - 1);
+  });
+});

--- a/vue_client/src/utils/memberPrefix.ts
+++ b/vue_client/src/utils/memberPrefix.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Channel user-mode prefixes, highest rank first. Shared by the member list,
+// the self-identity prompt, and the message list so the @/+/%/~/& glyph stays
+// consistent everywhere it appears.
+//
+// NOTE: the q/a/o/h/v → ~/&/@/%/+ mapping is the conventional RFC/ISUPPORT
+// default and is hardcoded fleet-wide; we don't yet read a network's ISUPPORT
+// PREFIX, so a server that diverges from the standard ordering won't be honored.
+export const PREFIX_ORDER: readonly string[] = ['~', '&', '@', '%', '+', ''];
+
+const PREFIX_GLYPH: Record<string, string> = { q: '~', a: '&', o: '@', h: '%', v: '+' };
+// Highest mode wins; ranked owner > admin > op > halfop > voice.
+const PREFIX_RANK = ['q', 'a', 'o', 'h', 'v'];
+
+// The single highest-ranked prefix glyph for a set of channel modes, or '' when
+// the member holds none.
+export function prefixOf(modes: string[] | null | undefined): string {
+  if (!Array.isArray(modes)) return '';
+  for (const letter of PREFIX_RANK) {
+    if (modes.includes(letter)) return PREFIX_GLYPH[letter];
+  }
+  return '';
+}
+
+// CSS class for the glyph color (e.g. `mode-@`), or '' when there's no prefix.
+export function prefixClass(modes: string[] | null | undefined): string {
+  const p = prefixOf(modes);
+  return p ? `mode-${p}` : '';
+}


### PR DESCRIPTION
Implements **#376** (mode-prefix glyph on nicks) and **#238** (message-list nick interactivity) together, since both target the same nick surface and the same per-channel membership data.

## #376 — mode-prefix glyph
- New boolean setting `look.nick.show_mode_prefix` (default **off**), auto-wired into `/set`, `/get`, and the Appearance → nicks settings pane via the shared registry.
- When on, the channel user-mode glyph (`@` op, `+` voice, `%` halfop, `~` owner, `&` admin) renders before a speaker's nick on **channel message rows**, colored from the existing nicklist mode vars (`--member-op`, etc.).
- Reflects the author's **current** status in that channel (the only state we have). DMs, event lines, and backlog from a member who has since left show no glyph — the universal IRC-client convention.

## #238 — nick interactivity
Nicks in the message list now behave like their nicklist entry: **a tap/click (or right-click / long-press) opens the shared member action menu** — the same `useMemberActions` menu the nicklist uses. This covers:
- **Author nicks** (message rows).
- **Event-line nicks** — join / part / quit / nick-change / kick / mode / topic, plus consolidation summaries.
- **Colored nick mentions inside message body text** (via an opt-in `interactive-nicks` mode on `RenderSegments`).

The menu gained two items, in the shared builder so the nicklist gets them too:
- **Reply to &lt;nick&gt;** → inserts `nick: ` into the composer (the same hand-off as the message action bar's Reply). This replaces the original "tap inserts `nick:`" idea — keeping a single, consistent interaction (tap = menu) and matching the nicklist.
- **Copy Nickname** → best-effort clipboard write.

Alongside the existing View Profile / whois, Send DM, Note, Friend, Ignore, and op-gated Kick / Ban / Op / Voice. A departed speaker stays actionable by falling back to the message's own `userhost` for a clean ban mask.

## Refactor
- Extracts the mode→glyph mapping that was duplicated in `MemberList.vue` and `useSelfLabel.ts` into a shared `utils/memberPrefix.ts`, with unit tests. No change to the tested `nickColor.ts` — `color`/`self` already discriminate nick segments.

## Design notes / scope
- **Interaction model changed during review** from the original "tap = address, long-press = menu" to **tap = menu everywhere**, matching the nicklist (and sidestepping a right-click word-selection glitch). Reply moved into the menu.
- **Mentions are now interactive** (an intentional expansion past the original "mentions stay inert" plan, to remove the inconsistency of colored-but-inert in-message nicks). Mentions stay text-selectable so messages remain copyable; pointer cursor is the only added cue. Standalone author/event chips are `user-select: none`.
- Notice/action author *glyphs* (`-nick-`, `*`) remain inert.
- The `q/a/o/h/v → ~&@%+` mapping is still hardcoded fleet-wide (no per-network ISUPPORT `PREFIX`) — pre-existing, candidate follow-up.
- **Keyboard accessibility deferred:** these menus mirror the nicklist rows, which are pointer/touch-only today. Adding `tabindex` to every nick in scrollback would flood keyboard navigation, and the menu anchors on pointer coords — so full keyboard support belongs as a separate card covering the whole nick-menu surface (nicklist + message nicks), not an unverified bolt-on here. (A `<button>` is deliberately *not* used: it steals composer focus on iOS, which is why these are `role`-less spans.)

## Verification
- ✅ `npm run check` (root + client typecheck, oxlint, oxfmt --check) clean.
- ✅ New `memberPrefix.test.ts` — 6/6 pass.
- ✅ `npm run client:build` compiles.
- Manual QA (against a real network): `/set look.nick.show_mode_prefix on` → op/voice glyphs appear before channel author nicks; tap any nick (author, event line, or in-message mention) → menu with Reply / Copy Nickname / whois / DM / …, plus kick/ban/op/voice when you hold an op mode; DMs show no glyph; selecting + copying a message that contains a mention still grabs the mention text.

Closes #376
Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)