### PR TITLE
IRCv3 draft/multiline support (#381)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1122,3 +1122,235 @@ describe('away/back presence logging (#310)', () => {
     expect(texts).not.toContain('Presence: stranger away (nope)');
   });
 });
+
+describe('IRCv3 draft/multiline (#381)', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'me',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  // Enable the cap pair (and optionally advertise limits) the way the registered
+  // server would, so multilineLimits()/supportsMultiline()/the send path light up.
+  function enableMultiline(conn: IrcConnection, advertised = 'max-bytes=4096,max-lines=24'): void {
+    (
+      conn.client as unknown as {
+        network: { cap: { enabled: string[]; available: Map<string, string> } };
+      }
+    ).network = {
+      cap: {
+        enabled: ['message-tags', 'batch', 'draft/multiline'],
+        available: new Map([['draft/multiline', advertised]]),
+      },
+    };
+  }
+
+  it('requests batch and draft/multiline (alongside message-tags)', () => {
+    const conn = makeConn();
+    const caps = (conn as unknown as { client: { request_extra_caps: string[] } }).client
+      .request_extra_caps;
+    expect(caps).toContain('batch');
+    expect(caps).toContain('draft/multiline');
+    expect(caps).toContain('message-tags');
+  });
+
+  describe('receive (reassembly)', () => {
+    function makeReceiver(): { conn: IrcConnection; publish: ReturnType<typeof vi.fn> } {
+      const conn = makeConn();
+      const publish = vi.fn<(event: unknown) => void>();
+      conn.publish = publish;
+      // Channel chatter calls markPeerEvent; stub it so the bare (un-inserted)
+      // network row doesn't trip the peer_presence_state FK.
+      conn.markPeerEvent = vi.fn<typeof conn.markPeerEvent>();
+      conn.trackDmPeer = vi.fn<typeof conn.trackDmPeer>();
+      conn.client.user.nick = 'me';
+      return { conn, publish };
+    }
+
+    function fragment(id: string, message: string, extra: Record<string, unknown> = {}) {
+      return {
+        nick: 'alice',
+        target: '#chan',
+        type: 'privmsg',
+        message,
+        batch: { id, type: 'draft/multiline' },
+        ...extra,
+      };
+    }
+
+    it('buffers fragments and flushes ONE message joined with newlines on batch end', () => {
+      const { conn, publish } = makeReceiver();
+      conn.client.emit('message', fragment('b1', 'line one'));
+      conn.client.emit('message', fragment('b1', 'line two'));
+      // Nothing surfaces until the batch closes.
+      expect(publish).not.toHaveBeenCalled();
+      conn.client.emit('batch end draft/multiline', { id: 'b1' });
+      expect(publish).toHaveBeenCalledTimes(1);
+      expect(publish.mock.calls[0][0]).toMatchObject({
+        type: 'message',
+        target: '#chan',
+        nick: 'alice',
+        text: 'line one\nline two',
+        self: false,
+      });
+    });
+
+    it('honors draft/multiline-concat — continuations rejoin with NO newline', () => {
+      const { conn, publish } = makeReceiver();
+      conn.client.emit('message', fragment('b2', 'hello '));
+      conn.client.emit(
+        'message',
+        fragment('b2', 'world', { tags: { 'draft/multiline-concat': '' } }),
+      );
+      conn.client.emit('batch end draft/multiline', { id: 'b2' });
+      expect(publish.mock.calls[0][0]).toMatchObject({ text: 'hello world' });
+    });
+
+    it('still skips a self-authored multiline batch (no duplicate of our own echo)', () => {
+      const { conn, publish } = makeReceiver();
+      conn.client.emit('message', fragment('b3', 'a', { nick: 'me' }));
+      conn.client.emit('message', fragment('b3', 'b', { nick: 'me' }));
+      conn.client.emit('batch end draft/multiline', { id: 'b3' });
+      expect(publish).not.toHaveBeenCalled();
+    });
+
+    it('a batch end with no buffered fragments is a no-op', () => {
+      const { conn, publish } = makeReceiver();
+      conn.client.emit('batch end draft/multiline', { id: 'nope' });
+      expect(publish).not.toHaveBeenCalled();
+    });
+
+    it('does not interleave two concurrent batches', () => {
+      const { conn, publish } = makeReceiver();
+      conn.client.emit('message', fragment('A', 'a1'));
+      conn.client.emit('message', fragment('B', 'b1'));
+      conn.client.emit('message', fragment('A', 'a2'));
+      conn.client.emit('batch end draft/multiline', { id: 'B' });
+      conn.client.emit('batch end draft/multiline', { id: 'A' });
+      expect(publish.mock.calls.map((c) => (c[0] as { text: string }).text)).toEqual([
+        'b1',
+        'a1\na2',
+      ]);
+    });
+  });
+
+  describe('send (framing)', () => {
+    it('frames a multi-line body as BATCH + … tagged PRIVMSGs … BATCH - and echoes it', () => {
+      const conn = makeConn();
+      enableMultiline(conn);
+      const raw = vi.fn<(line: string) => void>();
+      conn.client.raw = raw;
+      const echoes = conn.sendMultiline('#chan', 'line one\nline two');
+      const lines = raw.mock.calls.map((c) => c[0]);
+      expect(lines[0]).toMatch(/^BATCH \+[0-9a-f]{16} draft\/multiline #chan$/);
+      const ref = lines[0].match(/^BATCH \+(\S+)/)![1];
+      expect(lines[1]).toBe(`@batch=${ref} PRIVMSG #chan :line one`);
+      expect(lines[2]).toBe(`@batch=${ref} PRIVMSG #chan :line two`);
+      expect(lines[3]).toBe(`BATCH -${ref}`);
+      expect(lines).toHaveLength(4);
+      // One batch → one self-echo carrying the reassembled text.
+      expect(echoes).toEqual(['line one\nline two']);
+    });
+
+    it('preserves a blank line as an empty PRIVMSG with a trailing colon', () => {
+      const conn = makeConn();
+      enableMultiline(conn);
+      const raw = vi.fn<(line: string) => void>();
+      conn.client.raw = raw;
+      conn.sendMultiline('#chan', 'a\n\nb');
+      const lines = raw.mock.calls.map((c) => c[0]);
+      const ref = lines[0].match(/^BATCH \+(\S+)/)![1];
+      expect(lines[1]).toBe(`@batch=${ref} PRIVMSG #chan :a`);
+      expect(lines[2]).toBe(`@batch=${ref} PRIVMSG #chan :`);
+      expect(lines[3]).toBe(`@batch=${ref} PRIVMSG #chan :b`);
+    });
+
+    it('marks the continuation of an over-long line with draft/multiline-concat', () => {
+      const conn = makeConn();
+      enableMultiline(conn);
+      const raw = vi.fn<(line: string) => void>();
+      conn.client.raw = raw;
+      conn.sendMultiline('#chan', `short\n${'a'.repeat(400)}`);
+      const lines = raw.mock.calls.map((c) => c[0]);
+      const ref = lines[0].match(/^BATCH \+(\S+)/)![1];
+      expect(lines[2]).toBe(`@batch=${ref} PRIVMSG #chan :${'a'.repeat(350)}`);
+      expect(lines[3]).toBe(
+        `@batch=${ref};draft/multiline-concat PRIVMSG #chan :${'a'.repeat(50)}`,
+      );
+    });
+
+    it('splits an over-limit body into multiple batches, each with its own ref', () => {
+      const conn = makeConn();
+      enableMultiline(conn, 'max-bytes=4096,max-lines=2');
+      const raw = vi.fn<(line: string) => void>();
+      conn.client.raw = raw;
+      // 3 lines, max-lines 2 → batch [a,b], then batch [c].
+      const echoes = conn.sendMultiline('#chan', 'a\nb\nc');
+      const lines = raw.mock.calls.map((c) => c[0]);
+      const ref1 = lines[0].match(/^BATCH \+(\S+)/)![1];
+      expect(lines.slice(0, 4)).toEqual([
+        `BATCH +${ref1} draft/multiline #chan`,
+        `@batch=${ref1} PRIVMSG #chan :a`,
+        `@batch=${ref1} PRIVMSG #chan :b`,
+        `BATCH -${ref1}`,
+      ]);
+      const ref2 = lines[4].match(/^BATCH \+(\S+)/)![1];
+      expect(ref2).not.toBe(ref1);
+      expect(lines.slice(4)).toEqual([
+        `BATCH +${ref2} draft/multiline #chan`,
+        `@batch=${ref2} PRIVMSG #chan :c`,
+        `BATCH -${ref2}`,
+      ]);
+      // One self-echo per batch — the channel sees two messages, not three lines.
+      expect(echoes).toEqual(['a\nb', 'c']);
+    });
+
+    it('sends nothing when the cap is not negotiated', () => {
+      const conn = makeConn();
+      const raw = vi.fn<(line: string) => void>();
+      conn.client.raw = raw;
+      expect(conn.sendMultiline('#chan', 'a\nb')).toEqual([]);
+      expect(raw).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('limits + support gate', () => {
+    it('multilineLimits is null / supportsMultiline false until both caps are negotiated', () => {
+      const conn = makeConn();
+      expect(conn.multilineLimits()).toBeNull();
+      expect(conn.supportsMultiline()).toBe(false);
+    });
+
+    it('parses advertised max-bytes / max-lines and reports support', () => {
+      const conn = makeConn();
+      enableMultiline(conn, 'max-bytes=100,max-lines=3');
+      expect(conn.multilineLimits()).toEqual({ maxBytes: 100, maxLines: 3 });
+      expect(conn.supportsMultiline()).toBe(true);
+    });
+
+    it('falls back to conservative defaults when a dimension is omitted', () => {
+      const conn = makeConn();
+      enableMultiline(conn, '');
+      expect(conn.multilineLimits()).toEqual({ maxBytes: 4096, maxLines: 24 });
+    });
+  });
+});

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1342,8 +1342,8 @@ describe('IRCv3 draft/multiline (#381)', () => {
 
     it('parses advertised max-bytes / max-lines and reports support', () => {
       const conn = makeConn();
-      enableMultiline(conn, 'max-bytes=100,max-lines=3');
-      expect(conn.multilineLimits()).toEqual({ maxBytes: 100, maxLines: 3 });
+      enableMultiline(conn, 'max-bytes=512,max-lines=3');
+      expect(conn.multilineLimits()).toEqual({ maxBytes: 512, maxLines: 3 });
       expect(conn.supportsMultiline()).toBe(true);
     });
 
@@ -1351,6 +1351,16 @@ describe('IRCv3 draft/multiline (#381)', () => {
       const conn = makeConn();
       enableMultiline(conn, '');
       expect(conn.multilineLimits()).toEqual({ maxBytes: 4096, maxLines: 24 });
+    });
+
+    it('reports no support when advertised max-bytes is below one wire line', () => {
+      // A server that can't hold a single 350B PRIVMSG in a batch isn't usefully
+      // multiline — null limits send the body via the legacy splitter instead of
+      // framing batches the server would FAIL+drop.
+      const conn = makeConn();
+      enableMultiline(conn, 'max-bytes=100,max-lines=24');
+      expect(conn.multilineLimits()).toBeNull();
+      expect(conn.supportsMultiline()).toBe(false);
     });
   });
 });

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1362,5 +1362,21 @@ describe('IRCv3 draft/multiline (#381)', () => {
       expect(conn.multilineLimits()).toBeNull();
       expect(conn.supportsMultiline()).toBe(false);
     });
+
+    it('reports no support without message-tags (the batch reference rides a tag)', () => {
+      const conn = makeConn();
+      (
+        conn.client as unknown as {
+          network: { cap: { enabled: string[]; available: Map<string, string> } };
+        }
+      ).network = {
+        cap: {
+          enabled: ['batch', 'draft/multiline'], // no message-tags
+          available: new Map([['draft/multiline', 'max-bytes=4096,max-lines=24']]),
+        },
+      };
+      expect(conn.multilineLimits()).toBeNull();
+      expect(conn.supportsMultiline()).toBe(false);
+    });
   });
 });

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -26,6 +26,8 @@ import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent } from '../utils/ident.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled } from './identd.js';
+import { partitionMultiline, reassembleMultiline } from './messageSplit.js';
+import { randomBytes } from 'node:crypto';
 
 // Optional source address for outbound IRC connections (LURKER_OUTGOING_ADDR),
 // passed to irc-framework as `outgoing_addr` → the socket's localAddress. Lets a
@@ -230,6 +232,11 @@ export class IrcConnection {
   // the 'wholist' handler consumes these silently. Any wholist NOT in this set
   // is a user-typed /who and gets rendered to the server buffer (#342).
   autoWhoTargets: Set<string>;
+  // In-flight inbound `draft/multiline` batches, keyed by batch reference. Each
+  // entry holds the first fragment's event envelope plus the text accumulated
+  // so far; flushed as one reassembled message on 'batch end draft/multiline'
+  // and cleared on socket close so a never-closed batch can't leak. (#381)
+  multilineBatches: Map<string, { event: Record<string, unknown>; text: string }>;
 
   constructor({ network, onEvent }: { network: Network; onEvent: (event: EnrichedEvent) => void }) {
     this.network = network;
@@ -249,6 +256,13 @@ export class IrcConnection {
     // the cap — irc-framework only emits a CAP REQ for caps the server lists in
     // CAP LS. (#310)
     this.client.requestCap('extended-monitor');
+    // batch + draft/multiline (IRCv3): lets a multi-line compose travel as one
+    // logical message instead of N fragmented PRIVMSGs, and lets us reassemble
+    // the same from peers (e.g. Ergo). requestCap is a no-op where the server
+    // doesn't advertise them; draft/multiline also rides message-tags (above)
+    // and batch, so all three are requested. (#381)
+    this.client.requestCap('batch');
+    this.client.requestCap('draft/multiline');
     this.state = 'disconnected';
     this.channels = new Map();
     this.userModes = new Set();
@@ -296,6 +310,7 @@ export class IrcConnection {
     this.unsendableTargets = new Set();
     this.lastUserSendAt = new Map();
     this.autoWhoTargets = new Set();
+    this.multilineBatches = new Map();
     this.bind();
   }
 
@@ -662,6 +677,7 @@ export class IrcConnection {
       this.identdId = null;
       this.userModes.clear();
       this.autoWhoTargets.clear();
+      this.multilineBatches.clear();
       this.stopLagPinger();
       this.cancelPendingConnectCommands();
       this.lagMs = null;
@@ -965,6 +981,13 @@ export class IrcConnection {
       ) {
         return;
       }
+      // A `draft/multiline` batch is one logical message fragmented across N
+      // PRIVMSGs (#381). Buffer the fragments and flush a single reassembled
+      // message on 'batch end draft/multiline' instead of rendering N lines.
+      if (batchType === 'draft/multiline') {
+        this.accumulateMultiline(event);
+        return;
+      }
       const me = c.user?.nick;
       const eventNick = event.nick as string | undefined;
       const eventTarget = event.target as string | undefined;
@@ -1029,6 +1052,14 @@ export class IrcConnection {
         this.trackDmPeer(eventNick);
       }
       if (eventNick) this.markPeerEvent(eventNick, 'online');
+    });
+
+    c.on('batch end draft/multiline', (info: Record<string, unknown>) => {
+      // irc-framework buffers a batch's PRIVMSGs and replays them (each firing
+      // the 'message' handler above with event.batch set) before emitting this
+      // close event — so accumulateMultiline already holds every fragment. (#381)
+      const id = info?.id as string | undefined;
+      if (id) this.flushMultiline(id);
     });
 
     c.on('join', (event: Record<string, unknown>) => {
@@ -2097,6 +2128,102 @@ export class IrcConnection {
     this.client.notice(target, text);
   }
 
+  // --- IRCv3 draft/multiline (#381) ------------------------------------------
+  // Send a multi-line compose as one logical message on servers that support
+  // the cap pair (e.g. Ergo), and reassemble the same from peers, with a clean
+  // fallback to per-line splitting everywhere else.
+
+  // The server's advertised limits for a multiline batch, or null when the cap
+  // pair isn't negotiated. A dimension the server omits falls back to a
+  // conservative default so we never overflow it — worst case a very large
+  // paste takes the legacy split path instead of a batch.
+  multilineLimits(): { maxBytes: number; maxLines: number } | null {
+    const cap = this.client.network?.cap as
+      | { enabled?: string[]; available?: Map<string, string> }
+      | undefined;
+    const enabled = cap?.enabled ?? [];
+    if (!enabled.includes('batch') || !enabled.includes('draft/multiline')) return null;
+    let maxBytes = 4096;
+    let maxLines = 24;
+    const advertised = cap?.available?.get('draft/multiline') ?? '';
+    for (const part of advertised.split(',')) {
+      const [key, val] = part.split('=');
+      const n = Number(val);
+      if (!Number.isFinite(n) || n <= 0) continue;
+      if (key === 'max-bytes') maxBytes = n;
+      else if (key === 'max-lines') maxLines = n;
+    }
+    return { maxBytes, maxLines };
+  }
+
+  // Whether this connection negotiated the draft/multiline cap pair. The caller
+  // gates multi-line plain sends on this; over-budget bodies don't fall back to
+  // raw splitting, they just span multiple batches (see sendMultiline).
+  supportsMultiline(): boolean {
+    return this.multilineLimits() != null;
+  }
+
+  // Send `text` as one-or-more draft/multiline batches: each is BATCH +ref …
+  // one tagged PRIVMSG per line … BATCH -ref. The body is partitioned to the
+  // server's max-lines / max-bytes, so a big paste lands as N logical messages
+  // rather than N raw lines. Blank lines are preserved (an empty trailing param
+  // round-trips as a blank line); an over-long single line is byte-split with
+  // draft/multiline-concat on the continuations so the receiver rejoins it with
+  // no spurious newline. Returns the per-batch display text so the caller can
+  // echo one self bubble per batch, matching what the channel sees. All lines
+  // go through raw() so embedded CR/LF/NUL is stripped. (#381)
+  sendMultiline(target: string, text: string): string[] {
+    if (isDmTargetName(target)) this.trackDmPeer(target);
+    this.noteUserSend(target);
+    const limits = this.multilineLimits();
+    if (!limits) return [];
+    const echoes: string[] = [];
+    for (const batch of partitionMultiline(text, limits)) {
+      const ref = randomBytes(8).toString('hex');
+      this.raw(`BATCH +${ref} draft/multiline ${target}`);
+      for (const line of batch) {
+        const tag = line.concat ? `batch=${ref};draft/multiline-concat` : `batch=${ref}`;
+        this.raw(`@${tag} PRIVMSG ${target} :${line.content}`);
+      }
+      this.raw(`BATCH -${ref}`);
+      echoes.push(reassembleMultiline(batch));
+    }
+    return echoes;
+  }
+
+  // Buffer one PRIVMSG of an inbound draft/multiline batch, keyed by its batch
+  // reference. Lines join with '\n' except where draft/multiline-concat says to
+  // glue with none. flushMultiline emits the reassembled message on batch end.
+  accumulateMultiline(event: Record<string, unknown>): void {
+    const id = (event.batch as { id?: string } | undefined)?.id;
+    if (!id) {
+      // No reference to group by — surface it as a standalone message rather
+      // than dropping it. (Shouldn't happen: irc-framework always sets batch.id.)
+      this.client.emit('message', { ...event, batch: undefined });
+      return;
+    }
+    const line = (event.message as string | undefined) ?? '';
+    const existing = this.multilineBatches.get(id);
+    if (!existing) {
+      this.multilineBatches.set(id, { event, text: line });
+      return;
+    }
+    const tags = event.tags as Record<string, string> | undefined;
+    const concat = !!tags && 'draft/multiline-concat' in tags;
+    existing.text += concat ? line : `\n${line}`;
+  }
+
+  // Emit the reassembled multiline message through the normal 'message' path
+  // with the batch stripped, so it flows through self-echo, routing and
+  // presence exactly like a standalone PRIVMSG. (WeeChat takes the same
+  // reconstruct-then-redispatch approach.) (#381)
+  flushMultiline(id: string): void {
+    const buf = this.multilineBatches.get(id);
+    if (!buf) return;
+    this.multilineBatches.delete(id);
+    this.client.emit('message', { ...buf.event, message: buf.text, batch: undefined });
+  }
+
   // Record that the user just sent a real message to `target`. handleSendRejection
   // reads this to tell an actual failed message from an automated TAGMSG/typing
   // bounce — the rejection numeric alone doesn't say which command it refused.
@@ -2289,6 +2416,11 @@ export class IrcConnection {
       nick: this.currentNick || this.network.nick,
       userModes: [...this.userModes].join(''),
       lagMs: this.lagMs,
+      // Negotiated draft/multiline limits (or null) so the composer can gate its
+      // split/flood hint and upload-as-.txt prompt on what will actually go on
+      // the wire. Computed post-registration, which is when this snapshot is
+      // pushed (setState('connected') fires after CAP). (#381)
+      multilineLimits: this.multilineLimits(),
       away: a.since
         ? {
             active: a.active,

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2135,18 +2135,26 @@ export class IrcConnection {
   // fallback to per-line splitting everywhere else.
 
   // The server's advertised limits for a multiline batch, or null when multiline
-  // isn't usable here: the cap pair wasn't negotiated, or the advertised
-  // max-bytes is below one full wire line (MESSAGE_MAX_BYTES) and so can't carry
-  // a single PRIVMSG inside a batch — in which case the send path falls back to
-  // the legacy splitter rather than framing batches the server would FAIL+drop.
-  // An omitted dimension defaults conservatively; once non-null, the body always
-  // rides batches (spanning as many as the limits require), never the legacy path.
+  // isn't usable here: the cap trio (batch + draft/multiline + message-tags —
+  // the batch reference rides a message tag, so framing is impossible without
+  // it) wasn't negotiated, or the advertised max-bytes is below one full wire
+  // line (MESSAGE_MAX_BYTES) and so can't carry a single PRIVMSG inside a batch.
+  // In either case the send path falls back to the legacy splitter rather than
+  // framing batches the server would FAIL+drop. An omitted dimension defaults
+  // conservatively; once non-null, the body always rides batches (spanning as
+  // many as the limits require), never the legacy path.
   multilineLimits(): MultilineLimits | null {
     const cap = this.client.network?.cap as
       | { enabled?: string[]; available?: Map<string, string> }
       | undefined;
     const enabled = cap?.enabled ?? [];
-    if (!enabled.includes('batch') || !enabled.includes('draft/multiline')) return null;
+    if (
+      !enabled.includes('batch') ||
+      !enabled.includes('draft/multiline') ||
+      !enabled.includes('message-tags')
+    ) {
+      return null;
+    }
     let maxBytes = 4096;
     let maxLines = 24;
     const advertised = cap?.available?.get('draft/multiline') ?? '';

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -26,7 +26,7 @@ import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent } from '../utils/ident.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled } from './identd.js';
-import { partitionMultiline, reassembleMultiline } from './messageSplit.js';
+import { MESSAGE_MAX_BYTES, partitionMultiline, reassembleMultiline } from './messageSplit.js';
 import type { MultilineLimits } from './messageSplit.js';
 import { randomBytes } from 'node:crypto';
 
@@ -2134,10 +2134,13 @@ export class IrcConnection {
   // the cap pair (e.g. Ergo), and reassemble the same from peers, with a clean
   // fallback to per-line splitting everywhere else.
 
-  // The server's advertised limits for a multiline batch, or null when the cap
-  // pair isn't negotiated. A dimension the server omits falls back to a
-  // conservative default so we never overflow it — worst case a very large
-  // paste takes the legacy split path instead of a batch.
+  // The server's advertised limits for a multiline batch, or null when multiline
+  // isn't usable here: the cap pair wasn't negotiated, or the advertised
+  // max-bytes is below one full wire line (MESSAGE_MAX_BYTES) and so can't carry
+  // a single PRIVMSG inside a batch — in which case the send path falls back to
+  // the legacy splitter rather than framing batches the server would FAIL+drop.
+  // An omitted dimension defaults conservatively; once non-null, the body always
+  // rides batches (spanning as many as the limits require), never the legacy path.
   multilineLimits(): MultilineLimits | null {
     const cap = this.client.network?.cap as
       | { enabled?: string[]; available?: Map<string, string> }
@@ -2154,6 +2157,7 @@ export class IrcConnection {
       if (key === 'max-bytes') maxBytes = n;
       else if (key === 'max-lines') maxLines = n;
     }
+    if (maxBytes < MESSAGE_MAX_BYTES) return null;
     return { maxBytes, maxLines };
   }
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -27,6 +27,7 @@ import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent } from '../utils/ident.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled } from './identd.js';
 import { partitionMultiline, reassembleMultiline } from './messageSplit.js';
+import type { MultilineLimits } from './messageSplit.js';
 import { randomBytes } from 'node:crypto';
 
 // Optional source address for outbound IRC connections (LURKER_OUTGOING_ADDR),
@@ -2137,7 +2138,7 @@ export class IrcConnection {
   // pair isn't negotiated. A dimension the server omits falls back to a
   // conservative default so we never overflow it — worst case a very large
   // paste takes the legacy split path instead of a batch.
-  multilineLimits(): { maxBytes: number; maxLines: number } | null {
+  multilineLimits(): MultilineLimits | null {
     const cap = this.client.network?.cap as
       | { enabled?: string[]; available?: Map<string, string> }
       | undefined;
@@ -2196,12 +2197,10 @@ export class IrcConnection {
   // glue with none. flushMultiline emits the reassembled message on batch end.
   accumulateMultiline(event: Record<string, unknown>): void {
     const id = (event.batch as { id?: string } | undefined)?.id;
-    if (!id) {
-      // No reference to group by — surface it as a standalone message rather
-      // than dropping it. (Shouldn't happen: irc-framework always sets batch.id.)
-      this.client.emit('message', { ...event, batch: undefined });
-      return;
-    }
+    // irc-framework always sets batch.id alongside batch.type, so a multiline
+    // event without an id can't occur; guard rather than re-dispatch (which
+    // would be 'message' re-entrancy) and move on.
+    if (!id) return;
     const line = (event.message as string | undefined) ?? '';
     const existing = this.multilineBatches.get(id);
     if (!existing) {

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -273,6 +273,19 @@ class IrcManager extends EventEmitter {
   send(userId: number, networkId: number, target: string, text: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
+    // A multi-line compose rides draft/multiline batches where the server
+    // supports the cap: it lands as one logical message per batch (the body is
+    // partitioned to the server's limits, so a big paste is N messages, not N
+    // raw lines), and the sender echoes one bubble per batch to match. Networks
+    // without the cap fall through to the per-line split that mirrors what
+    // irc-framework actually puts on the wire. (#381)
+    if (/\r\n|\n|\r/.test(text) && conn.supportsMultiline()) {
+      const nick = conn.client.user?.nick;
+      for (const echo of conn.sendMultiline(target, text)) {
+        conn.publish({ type: 'message', target, nick, text: echo, kind: 'privmsg', self: true });
+      }
+      return true;
+    }
     const chunks = splitSay(text);
     for (const chunk of chunks) {
       conn.say(target, chunk);

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -37,7 +37,7 @@ import {
   findContactIdByTarget,
 } from '../db/contacts.js';
 import type { ContactRecord } from '../db/contacts.js';
-import { splitSay, splitAction } from './messageSplit.js';
+import { splitSay, splitAction, hasInteriorNewline } from './messageSplit.js';
 import db from '../db/index.js';
 
 // User away state row shape from userAwayState.ts (that file isn't typed yet).
@@ -278,8 +278,11 @@ class IrcManager extends EventEmitter {
     // partitioned to the server's limits, so a big paste is N messages, not N
     // raw lines), and the sender echoes one bubble per batch to match. Networks
     // without the cap fall through to the per-line split that mirrors what
-    // irc-framework actually puts on the wire. (#381)
-    if (/\r\n|\n|\r/.test(text) && conn.supportsMultiline()) {
+    // irc-framework actually puts on the wire. We gate on an INTERIOR newline
+    // (not a bare newline) so "hello\n" stays a single-line send — splitMultiline
+    // trims edge blanks, and the client's multilineMessageCount gates the same
+    // way, so the two stay in sync. (#381)
+    if (hasInteriorNewline(text) && conn.supportsMultiline()) {
       const nick = conn.client.user?.nick;
       for (const echo of conn.sendMultiline(target, text)) {
         conn.publish({ type: 'message', target, nick, text: echo, kind: 'privmsg', self: true });

--- a/server/services/messageSplit.test.ts
+++ b/server/services/messageSplit.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { splitSay, splitAction } from './messageSplit.js';
+import {
+  splitSay,
+  splitAction,
+  splitMultiline,
+  partitionMultiline,
+  reassembleMultiline,
+} from './messageSplit.js';
 
 const MESSAGE_MAX_BYTES = 350;
 const ACTION_MAX_BYTES = 341;
@@ -112,5 +118,128 @@ describe('splitAction', () => {
   it('returns [] for empty input', () => {
     expect(splitAction('')).toEqual([]);
     expect(splitAction(null)).toEqual([]);
+  });
+});
+
+describe('splitMultiline', () => {
+  it('returns [] for empty / null input', () => {
+    expect(splitMultiline('')).toEqual([]);
+    expect(splitMultiline(null)).toEqual([]);
+    expect(splitMultiline(undefined)).toEqual([]);
+  });
+
+  it('emits one non-concat message per line', () => {
+    expect(splitMultiline('one\ntwo\nthree')).toEqual([
+      { content: 'one', concat: false },
+      { content: 'two', concat: false },
+      { content: 'three', concat: false },
+    ]);
+    expect(splitMultiline('one\r\ntwo\rthree')).toEqual([
+      { content: 'one', concat: false },
+      { content: 'two', concat: false },
+      { content: 'three', concat: false },
+    ]);
+  });
+
+  it('PRESERVES interior blank lines (unlike splitSay, which drops them)', () => {
+    // A blank line round-trips as an empty PRIVMSG, so a pasted paragraph break
+    // survives. splitSay('a\n\nb') would be ['a','b']; multiline keeps the gap.
+    expect(splitMultiline('a\n\nb')).toEqual([
+      { content: 'a', concat: false },
+      { content: '', concat: false },
+      { content: 'b', concat: false },
+    ]);
+  });
+
+  it('byte-splits an over-long line and marks the continuations concat', () => {
+    // One logical line over the per-message budget: the 2nd+ chunks carry
+    // concat so the receiver rejoins them without inserting a newline.
+    const long = 'a'.repeat(MESSAGE_MAX_BYTES * 2 + 50);
+    const parts = splitMultiline(long);
+    expect(parts.length).toBeGreaterThanOrEqual(3);
+    expect(parts[0].concat).toBe(false);
+    expect(parts.slice(1).every((p) => p.concat)).toBe(true);
+    for (const p of parts) {
+      expect(byteLen(p.content)).toBeLessThanOrEqual(MESSAGE_MAX_BYTES);
+    }
+    // Joining the content back (concat = no separator) reconstructs the line.
+    expect(parts.map((p) => p.content).join('')).toBe(long);
+  });
+
+  it('only the first chunk of each line is non-concat', () => {
+    // Two over-long lines: each line restarts with a non-concat head, then
+    // concat continuations — so reassembly inserts exactly one newline between.
+    const a = 'a'.repeat(MESSAGE_MAX_BYTES + 10);
+    const b = 'b'.repeat(MESSAGE_MAX_BYTES + 10);
+    const parts = splitMultiline(`${a}\n${b}`);
+    const heads = parts.filter((p) => !p.concat);
+    expect(heads).toHaveLength(2);
+    expect(heads[0].content.startsWith('a')).toBe(true);
+    expect(heads[1].content.startsWith('b')).toBe(true);
+  });
+});
+
+describe('partitionMultiline', () => {
+  const big = { maxBytes: 4096, maxLines: 24 };
+
+  it('returns [] for empty input', () => {
+    expect(partitionMultiline('', big)).toEqual([]);
+    expect(partitionMultiline(null, big)).toEqual([]);
+  });
+
+  it('keeps a body within the limits as a single batch', () => {
+    expect(partitionMultiline('one\ntwo\nthree', big)).toEqual([
+      [
+        { content: 'one', concat: false },
+        { content: 'two', concat: false },
+        { content: 'three', concat: false },
+      ],
+    ]);
+  });
+
+  it('splits into multiple batches past the line budget', () => {
+    const batches = partitionMultiline('a\nb\nc\nd\ne', { maxBytes: 4096, maxLines: 2 });
+    expect(batches.map((b) => b.map((w) => w.content))).toEqual([['a', 'b'], ['c', 'd'], ['e']]);
+  });
+
+  it('splits into multiple batches past the byte budget', () => {
+    // Three ~60-byte lines, max-bytes 100 → one line per batch.
+    const body = `${'a'.repeat(60)}\n${'b'.repeat(60)}\n${'c'.repeat(60)}`;
+    const batches = partitionMultiline(body, { maxBytes: 100, maxLines: 24 });
+    expect(batches).toHaveLength(3);
+  });
+
+  it('never tears a byte-split (concat) logical line across batches', () => {
+    // 'a'*400 → [350 + 50(concat)] = 2 wire messages, one logical line. Even at
+    // max-lines 1 it stays together in one batch; the next line opens a new one.
+    const batches = partitionMultiline(`${'a'.repeat(400)}\nb`, { maxBytes: 4096, maxLines: 1 });
+    expect(batches).toHaveLength(2);
+    expect(batches[0]).toEqual([
+      { content: 'a'.repeat(350), concat: false },
+      { content: 'a'.repeat(50), concat: true },
+    ]);
+    expect(batches[1]).toEqual([{ content: 'b', concat: false }]);
+  });
+});
+
+describe('reassembleMultiline', () => {
+  it('joins with newlines except across concat continuations', () => {
+    expect(
+      reassembleMultiline([
+        { content: 'line one', concat: false },
+        { content: 'line two', concat: false },
+      ]),
+    ).toBe('line one\nline two');
+    expect(
+      reassembleMultiline([
+        { content: 'hello ', concat: false },
+        { content: 'world', concat: true },
+      ]),
+    ).toBe('hello world');
+  });
+
+  it('round-trips a partitioned batch back to its source text', () => {
+    const [batch] = partitionMultiline('a\n\nb', { maxBytes: 4096, maxLines: 24 });
+    expect(reassembleMultiline(batch)).toBe('a\n\nb');
   });
 });

--- a/server/services/messageSplit.test.ts
+++ b/server/services/messageSplit.test.ts
@@ -151,6 +151,18 @@ describe('splitMultiline', () => {
     ]);
   });
 
+  it('trims leading/trailing blank lines (no spurious edge messages)', () => {
+    // 'hello\n' must not send a trailing empty PRIVMSG the legacy path would
+    // drop. Interior blanks still survive; pure-blank input is empty.
+    expect(splitMultiline('hello\n')).toEqual([{ content: 'hello', concat: false }]);
+    expect(splitMultiline('\na\n\nb\n')).toEqual([
+      { content: 'a', concat: false },
+      { content: '', concat: false },
+      { content: 'b', concat: false },
+    ]);
+    expect(splitMultiline('\n\n')).toEqual([]);
+  });
+
   it('byte-splits an over-long line and marks the continuations concat', () => {
     // One logical line over the per-message budget: the 2nd+ chunks carry
     // concat so the receiver rejoins them without inserting a newline.
@@ -209,16 +221,39 @@ describe('partitionMultiline', () => {
     expect(batches).toHaveLength(3);
   });
 
-  it('never tears a byte-split (concat) logical line across batches', () => {
-    // 'a'*400 → [350 + 50(concat)] = 2 wire messages, one logical line. Even at
-    // max-lines 1 it stays together in one batch; the next line opens a new one.
-    const batches = partitionMultiline(`${'a'.repeat(400)}\nb`, { maxBytes: 4096, maxLines: 1 });
-    expect(batches).toHaveLength(2);
+  it('keeps a byte-split (concat) logical line whole when it fits a batch', () => {
+    // 'a'*400 → [350 + 50(concat)] = 2 wire messages, 400 bytes — well within
+    // the budget, so it stays in one batch alongside the next line.
+    const batches = partitionMultiline(`${'a'.repeat(400)}\nb`, big);
+    expect(batches).toHaveLength(1);
     expect(batches[0]).toEqual([
       { content: 'a'.repeat(350), concat: false },
       { content: 'a'.repeat(50), concat: true },
+      { content: 'b', concat: false },
     ]);
-    expect(batches[1]).toEqual([{ content: 'b', concat: false }]);
+  });
+
+  it('tears a single line that is bigger than a whole batch (no overflow, no data loss)', () => {
+    // max-lines 1 can't hold the 2-wire line whole, so it must split across
+    // batches rather than emit one over-budget batch the server would reject.
+    const byLines = partitionMultiline(`${'a'.repeat(400)}\nb`, { maxBytes: 4096, maxLines: 1 });
+    expect(byLines.map((b) => b.map((w) => w.content))).toEqual([
+      ['a'.repeat(350)],
+      ['a'.repeat(50)],
+      ['b'],
+    ]);
+
+    // Same when the byte budget is the binding constraint.
+    const byBytes = partitionMultiline('a'.repeat(400), { maxBytes: 380, maxLines: 24 });
+    expect(byBytes.map((b) => b.map((w) => w.content))).toEqual([
+      ['a'.repeat(350)],
+      ['a'.repeat(50)],
+    ]);
+    // Every batch is within budget — the whole point.
+    for (const batch of byBytes) {
+      const bytes = batch.reduce((n, w) => n + new TextEncoder().encode(w.content).byteLength, 0);
+      expect(bytes).toBeLessThanOrEqual(380);
+    }
   });
 });
 

--- a/server/services/messageSplit.test.ts
+++ b/server/services/messageSplit.test.ts
@@ -8,6 +8,7 @@ import {
   splitMultiline,
   partitionMultiline,
   reassembleMultiline,
+  hasInteriorNewline,
 } from './messageSplit.js';
 
 const MESSAGE_MAX_BYTES = 350;
@@ -296,5 +297,21 @@ describe('reassembleMultiline', () => {
   it('round-trips a partitioned batch back to its source text', () => {
     const [batch] = partitionMultiline('a\n\nb', { maxBytes: 4096, maxLines: 24 });
     expect(reassembleMultiline(batch)).toBe('a\n\nb');
+  });
+});
+
+describe('hasInteriorNewline', () => {
+  it('is false for single-line input or edge-only newlines', () => {
+    expect(hasInteriorNewline('hello')).toBe(false);
+    expect(hasInteriorNewline('hello\n')).toBe(false); // trailing edge
+    expect(hasInteriorNewline('\nhello')).toBe(false); // leading edge
+    expect(hasInteriorNewline('\n\nhello\n\n')).toBe(false);
+    expect(hasInteriorNewline('')).toBe(false);
+  });
+
+  it('is true when a newline sits between content (a real multi-line body)', () => {
+    expect(hasInteriorNewline('a\nb')).toBe(true);
+    expect(hasInteriorNewline('a\n\nb')).toBe(true); // interior blank counts
+    expect(hasInteriorNewline('hello\nworld\n')).toBe(true); // edges trimmed, interior remains
   });
 });

--- a/server/services/messageSplit.test.ts
+++ b/server/services/messageSplit.test.ts
@@ -255,6 +255,26 @@ describe('partitionMultiline', () => {
       expect(bytes).toBeLessThanOrEqual(380);
     }
   });
+
+  it('re-chunks wire content so no batch overflows even when max-bytes < 350', () => {
+    // Pathological server (max-bytes 100 < a full wire line): a single wire
+    // message is normally ≤350B, so it would overflow a 100B batch — partition
+    // must re-chunk it smaller. (Production gates this to legacy via
+    // multilineLimits, but the partition must never emit an over-budget batch.)
+    const batches = partitionMultiline('a'.repeat(900), { maxBytes: 100, maxLines: 24 });
+    expect(batches.length).toBeGreaterThan(1);
+    for (const batch of batches) {
+      const bytes = batch.reduce((n, w) => n + new TextEncoder().encode(w.content).byteLength, 0);
+      expect(bytes).toBeLessThanOrEqual(100);
+    }
+    // No content lost — joining every wire reconstructs the original line.
+    expect(
+      batches
+        .flat()
+        .map((w) => w.content)
+        .join(''),
+    ).toBe('a'.repeat(900));
+  });
 });
 
 describe('reassembleMultiline', () => {

--- a/server/services/messageSplit.ts
+++ b/server/services/messageSplit.ts
@@ -50,3 +50,96 @@ export function splitAction(text: string | null | undefined): string[] {
   if (text == null || text === '') return [];
   return chunk(text, ACTION_MAX_BYTES);
 }
+
+// One PRIVMSG inside a `draft/multiline` batch. `concat` true means the line
+// re-joins the previous one with NO newline — used when a single logical line
+// overflowed the per-message byte budget and had to be split across the wire.
+// The receiver reassembles by joining with '\n' except where concat is set.
+export interface MultilineWireMessage {
+  content: string;
+  concat: boolean;
+}
+
+// Split a multi-line body into the sequence of PRIVMSGs that make up a
+// `draft/multiline` batch. Unlike splitSay, we PRESERVE blank lines (an empty
+// PRIVMSG with a trailing `:` round-trips as a blank line) so a pasted
+// paragraph survives intact. Each source line is byte-chunked the same way the
+// wire splitter does; the 2nd+ chunk of an over-long line carries concat so the
+// receiver glues it back without inserting a newline mid-line. max-bytes /
+// max-lines (the whole-batch budget the server advertises) is enforced by the
+// caller — here we only respect the per-message wire limit.
+export function splitMultiline(text: string | null | undefined): MultilineWireMessage[] {
+  if (text == null || text === '') return [];
+  const out: MultilineWireMessage[] = [];
+  for (const line of text.split(/\r\n|\n|\r/)) {
+    if (line === '') {
+      out.push({ content: '', concat: false });
+      continue;
+    }
+    chunk(line, MESSAGE_MAX_BYTES).forEach((part, i) => {
+      out.push({ content: part, concat: i > 0 });
+    });
+  }
+  return out;
+}
+
+function byteLen(s: string): number {
+  return Buffer.byteLength(s, 'utf8');
+}
+
+export interface MultilineLimits {
+  maxBytes: number;
+  maxLines: number;
+}
+
+// Partition a multi-line body into one-or-more draft/multiline batches, each
+// within the server's advertised max-lines (count of wire PRIVMSGs) and
+// max-bytes (sum of content bytes). A logical line that had to be byte-split
+// into concat continuations is kept whole inside a single batch so it never
+// tears across a boundary. Returns one WireMessage[] per batch — so a body that
+// fits is a single batch (one logical message), and a larger one becomes N
+// batches instead of degrading to N raw lines. (#381)
+export function partitionMultiline(
+  text: string | null | undefined,
+  limits: MultilineLimits,
+): MultilineWireMessage[][] {
+  const wires = splitMultiline(text);
+  if (wires.length === 0) return [];
+  // Re-group wire messages into logical lines (a head plus its concat tail).
+  const logical: MultilineWireMessage[][] = [];
+  for (const w of wires) {
+    if (!w.concat || logical.length === 0) logical.push([w]);
+    else logical[logical.length - 1].push(w);
+  }
+  const batches: MultilineWireMessage[][] = [];
+  let cur: MultilineWireMessage[] = [];
+  let curBytes = 0;
+  for (const line of logical) {
+    const lineBytes = line.reduce((n, w) => n + byteLen(w.content), 0);
+    if (
+      cur.length > 0 &&
+      (cur.length + line.length > limits.maxLines || curBytes + lineBytes > limits.maxBytes)
+    ) {
+      batches.push(cur);
+      cur = [];
+      curBytes = 0;
+    }
+    cur.push(...line);
+    curBytes += lineBytes;
+  }
+  if (cur.length > 0) batches.push(cur);
+  return batches;
+}
+
+// Inverse of the receiver's reassembly: collapse a batch's wire messages back
+// into the display text a multiline-capable peer would show (join with '\n'
+// except across concat continuations). Used for the sender's local echo so each
+// self bubble matches what the channel sees, one per batch. (#381)
+export function reassembleMultiline(wires: MultilineWireMessage[]): string {
+  let text = '';
+  wires.forEach((w, i) => {
+    if (i === 0) text = w.content;
+    else text += w.concat ? w.content : `\n${w.content}`;
+  });
+  return text;
+}

--- a/server/services/messageSplit.ts
+++ b/server/services/messageSplit.ts
@@ -18,7 +18,7 @@
 // name's leading space and the two \x01 SOH chars).
 import { lineBreak } from 'irc-framework/src/linebreak.js';
 
-const MESSAGE_MAX_BYTES = 350;
+export const MESSAGE_MAX_BYTES = 350;
 const ACTION_MAX_BYTES = MESSAGE_MAX_BYTES - ('ACTION'.length + 3);
 
 function chunk(text: string, bytes: number): string[] {
@@ -148,9 +148,21 @@ export function partitionMultiline(
       curBytes += lineBytes;
     } else {
       // Bigger than a whole batch on its own — tear it across batches at wire
-      // boundaries so no single batch exceeds the server's budget.
+      // boundaries so no single batch exceeds the server's budget. A wire
+      // message is ≤350B, so it can exceed maxBytes only if the server set
+      // max-bytes below a full wire line; re-chunk it smaller in that case so a
+      // batch never overflows. (The caller gates max-bytes < 350 to the legacy
+      // splitter, so this is a belt-and-suspenders.)
       flush();
-      for (const w of line) {
+      const pieces = line.flatMap((w) =>
+        byteLen(w.content) > limits.maxBytes
+          ? chunk(w.content, limits.maxBytes).map((c, i) => ({
+              content: c,
+              concat: i > 0 || w.concat,
+            }))
+          : [w],
+      );
+      for (const w of pieces) {
         const wBytes = byteLen(w.content);
         if (
           cur.length > 0 &&

--- a/server/services/messageSplit.ts
+++ b/server/services/messageSplit.ts
@@ -179,6 +179,15 @@ export function partitionMultiline(
   return batches;
 }
 
+// True when `text` carries a newline that isn't just a leading/trailing edge —
+// i.e. it would actually become a multi-line draft/multiline send once
+// splitMultiline trims edge blanks. The send path gates multiline on this (not a
+// bare newline test) so "hello\n" stays a single-line legacy send and the server
+// agrees with the client's multilineMessageCount, which trims the same way. (#381)
+export function hasInteriorNewline(text: string): boolean {
+  return /\r\n|\n|\r/.test(text.replace(/^(?:\r\n|\r|\n)+/, '').replace(/(?:\r\n|\r|\n)+$/, ''));
+}
+
 // Inverse of the receiver's reassembly: collapse a batch's wire messages back
 // into the display text a multiline-capable peer would show (join with '\n'
 // except across concat continuations). Used for the sender's local echo so each

--- a/server/services/messageSplit.ts
+++ b/server/services/messageSplit.ts
@@ -61,13 +61,15 @@ export interface MultilineWireMessage {
 }
 
 // Split a multi-line body into the sequence of PRIVMSGs that make up a
-// `draft/multiline` batch. Unlike splitSay, we PRESERVE blank lines (an empty
-// PRIVMSG with a trailing `:` round-trips as a blank line) so a pasted
-// paragraph survives intact. Each source line is byte-chunked the same way the
-// wire splitter does; the 2nd+ chunk of an over-long line carries concat so the
-// receiver glues it back without inserting a newline mid-line. max-bytes /
-// max-lines (the whole-batch budget the server advertises) is enforced by the
-// caller — here we only respect the per-message wire limit.
+// `draft/multiline` batch. Unlike splitSay, we PRESERVE interior blank lines (an
+// empty PRIVMSG with a trailing `:` round-trips as a blank line) so a pasted
+// paragraph's breaks survive intact. Leading/trailing blank lines are trimmed,
+// though — they'd otherwise send a spurious empty message that the legacy
+// splitSay path drops, making the two send paths disagree at newline edges
+// (#381 review). Each source line is byte-chunked the same way the wire splitter
+// does; the 2nd+ chunk of an over-long line carries concat so the receiver glues
+// it back without inserting a newline mid-line. The whole-batch max-bytes /
+// max-lines budget is enforced by partitionMultiline, not here.
 export function splitMultiline(text: string | null | undefined): MultilineWireMessage[] {
   if (text == null || text === '') return [];
   const out: MultilineWireMessage[] = [];
@@ -79,6 +81,12 @@ export function splitMultiline(text: string | null | undefined): MultilineWireMe
     chunk(line, MESSAGE_MAX_BYTES).forEach((part, i) => {
       out.push({ content: part, concat: i > 0 });
     });
+  }
+  // Drop blank wire messages at the edges (a concat continuation is never empty,
+  // so the !concat guard is belt-and-suspenders).
+  while (out.length > 0 && out[0].content === '' && !out[0].concat) out.shift();
+  while (out.length > 0 && out[out.length - 1].content === '' && !out[out.length - 1].concat) {
+    out.pop();
   }
   return out;
 }
@@ -95,10 +103,14 @@ export interface MultilineLimits {
 // Partition a multi-line body into one-or-more draft/multiline batches, each
 // within the server's advertised max-lines (count of wire PRIVMSGs) and
 // max-bytes (sum of content bytes). A logical line that had to be byte-split
-// into concat continuations is kept whole inside a single batch so it never
-// tears across a boundary. Returns one WireMessage[] per batch — so a body that
-// fits is a single batch (one logical message), and a larger one becomes N
-// batches instead of degrading to N raw lines. (#381)
+// into concat continuations is kept whole inside a single batch WHEN IT FITS —
+// but a single line bigger than one whole batch is torn across batches at wire
+// boundaries rather than packed into one over-budget batch. Overflowing a batch
+// would make the server reject it (`FAIL BATCH MULTILINE_MAX_BYTES`) and drop
+// the message entirely while we've already echoed it locally — silent data loss
+// (#381 review). Returns one WireMessage[] per batch — a body that fits is a
+// single batch (one logical message), a larger one becomes N batches instead of
+// degrading to N raw lines.
 export function partitionMultiline(
   text: string | null | undefined,
   limits: MultilineLimits,
@@ -114,20 +126,44 @@ export function partitionMultiline(
   const batches: MultilineWireMessage[][] = [];
   let cur: MultilineWireMessage[] = [];
   let curBytes = 0;
-  for (const line of logical) {
-    const lineBytes = line.reduce((n, w) => n + byteLen(w.content), 0);
-    if (
-      cur.length > 0 &&
-      (cur.length + line.length > limits.maxLines || curBytes + lineBytes > limits.maxBytes)
-    ) {
+  const flush = (): void => {
+    if (cur.length > 0) {
       batches.push(cur);
       cur = [];
       curBytes = 0;
     }
-    cur.push(...line);
-    curBytes += lineBytes;
+  };
+  for (const line of logical) {
+    const lineBytes = line.reduce((n, w) => n + byteLen(w.content), 0);
+    // Close the current batch if appending this whole line would overflow it.
+    if (
+      cur.length > 0 &&
+      (cur.length + line.length > limits.maxLines || curBytes + lineBytes > limits.maxBytes)
+    ) {
+      flush();
+    }
+    if (line.length <= limits.maxLines && lineBytes <= limits.maxBytes) {
+      // Fits in one batch — keep the (possibly concat-split) line whole.
+      cur.push(...line);
+      curBytes += lineBytes;
+    } else {
+      // Bigger than a whole batch on its own — tear it across batches at wire
+      // boundaries so no single batch exceeds the server's budget.
+      flush();
+      for (const w of line) {
+        const wBytes = byteLen(w.content);
+        if (
+          cur.length > 0 &&
+          (cur.length + 1 > limits.maxLines || curBytes + wBytes > limits.maxBytes)
+        ) {
+          flush();
+        }
+        cur.push(w);
+        curBytes += wBytes;
+      }
+    }
   }
-  if (cur.length > 0) batches.push(cur);
+  flush();
   return batches;
 }
 

--- a/vue_client/src/components/LongMessageUploadModal.vue
+++ b/vue_client/src/components/LongMessageUploadModal.vue
@@ -6,13 +6,21 @@
 <template>
   <AppModal
     word="flood"
-    :title="`message will flood ${chunks} lines`"
+    :title="
+      multiline ? `message will send as ${chunks} messages` : `message will flood ${chunks} lines`
+    "
     size="md"
     @close="$emit('cancel')"
   >
     <p class="desc">
-      IRC will split this into {{ chunks }} separate lines. Upload it as a <code>.txt</code> file
-      instead?
+      <template v-if="multiline">
+        This will send as {{ chunks }} separate messages. Upload it as a <code>.txt</code> file
+        instead?
+      </template>
+      <template v-else>
+        IRC will split this into {{ chunks }} separate lines. Upload it as a <code>.txt</code> file
+        instead?
+      </template>
     </p>
     <pre class="preview">{{ content }}</pre>
     <footer class="modal-footer">
@@ -38,9 +46,11 @@ withDefaults(
   defineProps<{
     content: string;
     chunks: number;
+    multiline?: boolean;
     uploading?: boolean;
   }>(),
   {
+    multiline: false,
     uploading: false,
   },
 );

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -114,6 +114,7 @@
         v-if="longMessageModalOpen"
         :content="longMessageContent"
         :chunks="longMessageChunks"
+        :multiline="longMessageMultiline"
         :uploading="longMessageUploading"
         @confirm="onLongMessageConfirm"
         @cancel="onLongMessageCancel"
@@ -150,7 +151,11 @@ import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
 import { requestScrollToBottom } from '../composables/useScrollState.js';
 import { setComposingState } from '../composables/useComposing.js';
-import { chunkCountForSay, chunkCountForAction } from '../utils/messageSplit.js';
+import {
+  chunkCountForSay,
+  chunkCountForAction,
+  multilineMessageCount,
+} from '../utils/messageSplit.js';
 import { applySpoilerMarkup } from '../utils/spoilerMarkup.js';
 import { buildNickCandidates } from '../utils/nickCompletion.js';
 import { buildChannelCandidates } from '../utils/channelCompletion.js';
@@ -433,6 +438,9 @@ let pendingSplitConfirm = false;
 const longMessageModalOpen = ref(false);
 const longMessageContent = ref('');
 const longMessageChunks = ref(0);
+// Whether the flooding draft will go as draft/multiline batches (messages) vs
+// raw wire lines — flips the modal's wording. (#381)
+const longMessageMultiline = ref(false);
 const longMessageUploading = ref(false);
 
 // Strip a leading slash command (/me, /msg <who>) so chunk counting reflects
@@ -466,6 +474,41 @@ function computeChunks(raw: string): { chunks: number; isAction: boolean } {
   const { body, isAction } = bodyForSplit(raw);
   const chunks = isAction ? chunkCountForAction(body) : chunkCountForSay(body);
   return { chunks, isAction };
+}
+
+// Whether the active network advertised draft/multiline limits. Drives the
+// multiline-aware split gating below. (#381)
+function currentMultilineLimits(): { maxBytes: number; maxLines: number } | null {
+  const nid = active.value?.networkId;
+  if (nid == null) return null;
+  return networks.states[nid]?.multilineLimits ?? null;
+}
+
+// How many draft/multiline messages `raw` will become on this network: 0 when
+// it won't be a multiline send (a slash command, /me, no newline, or the
+// network lacks the cap), 1 for a single batch, ≥2 for that many logical
+// messages. Mirrors the server partition in ircManager.send so the indicator
+// and the upload-as-.txt gate count messages-the-channel-sees, not raw wire
+// lines. (#381)
+function multilineCountFor(raw: string): number {
+  const isPlainSend = !raw.startsWith('/') || raw.startsWith('//');
+  if (!isPlainSend) return 0;
+  const wireBody = applySpoilerMarkup(raw.startsWith('//') ? raw.slice(1) : raw);
+  return multilineMessageCount(wireBody, currentMultilineLimits());
+}
+
+// Recompute and broadcast the composing state (drives StatusBar). Single source
+// for the live keystroke path and the bare buffer-switch so both stay in sync.
+// On a multiline network `chunks` carries the batch (message) count and
+// `multiline` is set; otherwise it's the legacy wire-PRIVMSG estimate.
+function publishComposing(raw: string): void {
+  const batches = multilineCountFor(raw);
+  if (batches > 0) {
+    setComposingState({ chunks: batches, isAction: false, multiline: true });
+    return;
+  }
+  const { chunks, isAction } = computeChunks(raw);
+  setComposingState({ chunks, isAction, multiline: false });
 }
 
 function sendTyping(networkId: number, target: string, state: string): void {
@@ -1458,8 +1501,7 @@ function onInput() {
   // Republish composing state on every keystroke so StatusBar's SPLIT/FLOOD
   // indicator stays live. We do this even on :server: buffers and slash
   // commands (computeChunks handles both — most return 0 chunks).
-  const { chunks, isAction } = computeChunks(text.value);
-  setComposingState({ chunks, isAction });
+  publishComposing(text.value);
   if (!sendable.value || !active.value) return;
   if (completion) resetCompletion();
   // Inline-convert a just-completed `:shortcode:`, then refresh the suggester
@@ -1530,8 +1572,7 @@ watch(active, (newActive, oldActive) => {
   // switch doesn't run the setter, so StatusBar's SPLIT/FLOOD indicator
   // would otherwise carry over stale state from the previous buffer.
   if (newActive) {
-    const { chunks, isAction } = computeChunks(text.value);
-    setComposingState({ chunks, isAction });
+    publishComposing(text.value);
   } else {
     setComposingState({ chunks: 0, isAction: false });
   }
@@ -1734,17 +1775,22 @@ async function submit() {
   if (!active.value) return;
   const { networkId, target } = active.value;
 
-  // Outgoing-split gate. irc-framework will break anything past ~350 bytes
-  // into multiple PRIVMSGs on the wire, which on a busy channel reads as a
-  // flood. Three tiers:
-  //   - /me with 2+ chunks: hard block (CTCP ACTION can't reasonably split)
-  //   - 3+ chunks: always require a second Send press (flood)
-  //   - 2 chunks: gated by chat.allow_split_messages (off → require second
-  //     press; on → send silently)
-  // computeChunks() returns 0 for slash commands we don't route through
-  // PRIVMSG, so /join, /raw, etc. fall right through.
-  const { chunks, isAction } = computeChunks(raw);
-  if (isAction && chunks > 1) {
+  // Outgoing-flood gate, measured in messages-the-channel-sees: on a multiline
+  // network that's the draft/multiline batch count (a big paste is N logical
+  // messages, not N raw lines); elsewhere it's the wire-PRIVMSG split estimate.
+  // Three tiers:
+  //   - /me over one line: hard block (CTCP ACTION can't reasonably split)
+  //   - 3+ messages: offer the upload-as-.txt modal (flood)
+  //   - 2 messages: gated by chat.allow_split_messages (off → require a second
+  //     Send press; on → send silently)
+  // computeChunks()/multilineCountFor() return 0 for slash commands we don't
+  // route through PRIVMSG, so /join, /raw, etc. fall right through. A draft that
+  // fits one multiline batch is exactly one message and skips the gate. (#381)
+  const { chunks: wireChunks, isAction } = computeChunks(raw);
+  const batches = multilineCountFor(raw);
+  const multiline = batches > 0;
+  const count = multiline ? batches : wireChunks;
+  if (isAction && wireChunks > 1) {
     toasts.push({
       title: 'Action message too long',
       body: "Actions can't be split across IRC lines — shorten it and try again.",
@@ -1753,25 +1799,28 @@ async function submit() {
     });
     return;
   }
-  if (chunks > 1) {
-    const flood = chunks >= 3;
+  if (count > 1) {
+    const flood = count >= 3;
     const allowSplit = !!settings.effective('chat.allow_split_messages');
     const blocked = flood || !allowSplit;
     if (blocked && !pendingSplitConfirm) {
       pendingSplitConfirm = true;
       if (flood) {
-        // 3+ chunks: offer the upload-as-.txt modal. If they cancel, the
+        // 3+ messages: offer the upload-as-.txt modal. If they cancel, the
         // already-set pendingSplitConfirm makes the next Send press the
         // override (matching the prior send-again-to-confirm behavior).
         longMessageContent.value = raw;
-        longMessageChunks.value = chunks;
+        longMessageChunks.value = count;
+        longMessageMultiline.value = multiline;
         longMessageModalOpen.value = true;
       } else {
-        // 2 chunks with chat.allow_split_messages=off: keep the existing
-        // toast confirmation — uploading would be overkill for a one-line
-        // overflow.
+        // 2 messages with chat.allow_split_messages=off: keep the existing
+        // toast confirmation — uploading would be overkill for a two-message
+        // send.
         toasts.push({
-          title: `Will split into ${chunks} lines — Send again to confirm`,
+          title: multiline
+            ? `Will send as ${count} messages — Send again to confirm`
+            : `Will split into ${count} lines — Send again to confirm`,
           body: 'Enable "Allow auto-split messages" in Settings to send splits without confirming.',
           kind: 'warn',
           ttlMs: 7000,

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -155,6 +155,7 @@ import {
   chunkCountForSay,
   chunkCountForAction,
   multilineMessageCount,
+  type MultilineLimits,
 } from '../utils/messageSplit.js';
 import { applySpoilerMarkup } from '../utils/spoilerMarkup.js';
 import { buildNickCandidates } from '../utils/nickCompletion.js';
@@ -478,7 +479,7 @@ function computeChunks(raw: string): { chunks: number; isAction: boolean } {
 
 // Whether the active network advertised draft/multiline limits. Drives the
 // multiline-aware split gating below. (#381)
-function currentMultilineLimits(): { maxBytes: number; maxLines: number } | null {
+function currentMultilineLimits(): MultilineLimits | null {
   const nid = active.value?.networkId;
   if (nid == null) return null;
   return networks.states[nid]?.multilineLimits ?? null;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -191,13 +191,23 @@ const composing = useComposing();
 
 // SPLIT (warn) at 2 chunks, FLOOD (bad) at 3+. Lives just before the typing
 // indicator so heavy composers can see it without taking their eyes off the
-// input. Empty / single-chunk drafts render nothing.
+// input. Empty / single-chunk drafts render nothing. On a multiline network
+// `composing.chunks` is the batch (message) count: 1 → a neutral MULTILINE
+// chip (lands as one logical message), 2 → MULTILINE ×2 (warn), 3+ →
+// MULTILINE ×N (bad, where the upload-as-.txt gate kicks in). (#381)
 const splitLabel = computed(() => {
+  if (composing.multiline) {
+    return composing.chunks <= 1 ? 'MULTILINE' : `MULTILINE ×${composing.chunks}`;
+  }
   if (composing.chunks <= 1) return '';
   if (composing.isAction) return 'ACTION TOO LONG';
   return composing.chunks >= 3 ? `FLOOD (${composing.chunks})` : 'SPLIT';
 });
 const splitClass = computed(() => {
+  if (composing.multiline) {
+    if (composing.chunks >= 3) return 'bad';
+    return composing.chunks === 2 ? 'warn' : '';
+  }
   if (composing.chunks <= 1) return '';
   if (composing.isAction || composing.chunks >= 3) return 'bad';
   return 'warn';

--- a/vue_client/src/composables/useComposing.ts
+++ b/vue_client/src/composables/useComposing.ts
@@ -11,22 +11,28 @@
 // produce on the wire. 0 = empty, 1 = single line, ≥2 = the SPLIT/FLOOD
 // indicator should appear. `isAction` flips when the user has typed /me so
 // downstream code can pick the tighter ACTION byte budget if it wants.
+// `multiline` is true when the draft will ride a single draft/multiline batch
+// (the network supports it and the body fits its limits) — so it lands as one
+// logical message and the SPLIT/FLOOD hint should stand down. (#381)
 
 import { reactive, readonly } from 'vue';
 
 export interface ComposingState {
   chunks: number;
   isAction: boolean;
+  multiline?: boolean;
 }
 
-const state = reactive<ComposingState>({
+const state = reactive<Required<ComposingState>>({
   chunks: 0,
   isAction: false,
+  multiline: false,
 });
 
-export function setComposingState({ chunks, isAction }: ComposingState): void {
+export function setComposingState({ chunks, isAction, multiline = false }: ComposingState): void {
   state.chunks = chunks;
   state.isAction = isAction;
+  state.multiline = multiline;
 }
 
 export function useComposing(): Readonly<ComposingState> {

--- a/vue_client/src/composables/useComposing.ts
+++ b/vue_client/src/composables/useComposing.ts
@@ -11,9 +11,12 @@
 // produce on the wire. 0 = empty, 1 = single line, ≥2 = the SPLIT/FLOOD
 // indicator should appear. `isAction` flips when the user has typed /me so
 // downstream code can pick the tighter ACTION byte budget if it wants.
-// `multiline` is true when the draft will ride a single draft/multiline batch
-// (the network supports it and the body fits its limits) — so it lands as one
-// logical message and the SPLIT/FLOOD hint should stand down. (#381)
+// `multiline` is true when the draft will be sent as draft/multiline batches
+// (the network negotiated the cap and the body has an interior newline). In
+// that mode `chunks` is the batch (message) count, not the wire-PRIVMSG count:
+// StatusBar shows 1 → a neutral MULTILINE chip and 2+ → MULTILINE ×N escalating
+// to warn/bad. The legacy SPLIT/FLOOD wording is used only when `multiline` is
+// false. (#381)
 
 import { reactive, readonly } from 'vue';
 

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -44,6 +44,10 @@ export interface NetworkState {
   away?: AwayState | null;
   peerPresence?: Record<string, PeerPresenceEntry>;
   lagMs?: number | null;
+  // Advertised draft/multiline limits when the network negotiated the cap,
+  // else null/absent. Drives the composer's multiline-aware SPLIT/FLOOD hint
+  // and upload-as-.txt gate. Refreshed by the snapshot pushed on connect. (#381)
+  multilineLimits?: { maxBytes: number; maxLines: number } | null;
 }
 
 export interface ActiveBuffer {

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -5,6 +5,7 @@ import { defineStore } from 'pinia';
 import { api } from '../api.js';
 import { useAuthStore } from './auth.js';
 import { isVirtualKey } from '../lib/virtualBuffers.js';
+import type { MultilineLimits } from '../utils/messageSplit.js';
 
 export interface Network {
   id: number;
@@ -47,7 +48,7 @@ export interface NetworkState {
   // Advertised draft/multiline limits when the network negotiated the cap,
   // else null/absent. Drives the composer's multiline-aware SPLIT/FLOOD hint
   // and upload-as-.txt gate. Refreshed by the snapshot pushed on connect. (#381)
-  multilineLimits?: { maxBytes: number; maxLines: number } | null;
+  multilineLimits?: MultilineLimits | null;
 }
 
 export interface ActiveBuffer {

--- a/vue_client/src/utils/messageSplit.test.ts
+++ b/vue_client/src/utils/messageSplit.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 import {
   chunkCountForSay,
   chunkCountForAction,
+  multilineMessageCount,
   MESSAGE_MAX_BYTES,
   ACTION_MAX_BYTES,
 } from './messageSplit.js';
@@ -81,5 +82,50 @@ describe('chunkCountForAction', () => {
 
   it('returns 0 for empty', () => {
     expect(chunkCountForAction('')).toBe(0);
+  });
+});
+
+describe('multilineMessageCount', () => {
+  const limits = { maxBytes: 4096, maxLines: 24 };
+
+  it('is 0 without negotiated limits', () => {
+    expect(multilineMessageCount('a\nb', null)).toBe(0);
+    expect(multilineMessageCount('a\nb', undefined)).toBe(0);
+  });
+
+  it('is 0 for a single-line body (not a multiline send)', () => {
+    expect(multilineMessageCount('just one line', limits)).toBe(0);
+    expect(multilineMessageCount('a'.repeat(1000), limits)).toBe(0);
+  });
+
+  it('is 1 for a multi-line body within the limits', () => {
+    expect(multilineMessageCount('line one\nline two', limits)).toBe(1);
+    expect(multilineMessageCount('a\n\nb', limits)).toBe(1); // blank line counts
+  });
+
+  it('counts the batches when the body exceeds the line budget', () => {
+    // 25 single-line entries, max-lines 24 → 2 batches (24 + 1).
+    const lines = Array.from({ length: 25 }, (_, i) => `l${i}`).join('\n');
+    expect(multilineMessageCount(lines, { maxBytes: 4096, maxLines: 24 })).toBe(2);
+    // 49 entries → 3 batches.
+    const more = Array.from({ length: 49 }, (_, i) => `l${i}`).join('\n');
+    expect(multilineMessageCount(more, { maxBytes: 4096, maxLines: 24 })).toBe(3);
+  });
+
+  it('counts the batches when the body exceeds the byte budget', () => {
+    // Two 60-byte lines, max-bytes 100 → 2 batches (one line each).
+    expect(
+      multilineMessageCount(`${'a'.repeat(60)}\n${'b'.repeat(60)}`, {
+        maxBytes: 100,
+        maxLines: 24,
+      }),
+    ).toBe(2);
+  });
+
+  it('counts utf-8 bytes, not characters, for the byte budget', () => {
+    // 15 × 4-byte emoji per line = 60 bytes each.
+    const body = `${'🔥'.repeat(15)}\n${'🔥'.repeat(15)}`;
+    expect(multilineMessageCount(body, { maxBytes: 100, maxLines: 24 })).toBe(2); // 120 > 100
+    expect(multilineMessageCount(body, { maxBytes: 200, maxLines: 24 })).toBe(1); // 120 ≤ 200
   });
 });

--- a/vue_client/src/utils/messageSplit.test.ts
+++ b/vue_client/src/utils/messageSplit.test.ts
@@ -128,4 +128,18 @@ describe('multilineMessageCount', () => {
     expect(multilineMessageCount(body, { maxBytes: 100, maxLines: 24 })).toBe(2); // 120 > 100
     expect(multilineMessageCount(body, { maxBytes: 200, maxLines: 24 })).toBe(1); // 120 ≤ 200
   });
+
+  it('ignores a trailing newline (matches splitMultiline edge-trim)', () => {
+    // 'hello\n' trims to one line → not a multiline send.
+    expect(multilineMessageCount('hello\n', limits)).toBe(0);
+    expect(multilineMessageCount('\na\nb\n', limits)).toBe(1); // edges trimmed, a/b survive
+  });
+
+  it('counts an oversized single line as the batches it spans', () => {
+    // 'a'*900 is a single word → word-greedy gives 3 wire lines (350+350+200);
+    // with max-lines 2 it can't fit one batch, so it spans 2. The leading short
+    // line opens a batch first → 3 total.
+    const body = `x\n${'a'.repeat(900)}`;
+    expect(multilineMessageCount(body, { maxBytes: 4096, maxLines: 2 })).toBe(3);
+  });
 });

--- a/vue_client/src/utils/messageSplit.test.ts
+++ b/vue_client/src/utils/messageSplit.test.ts
@@ -113,20 +113,26 @@ describe('multilineMessageCount', () => {
   });
 
   it('counts the batches when the body exceeds the byte budget', () => {
-    // Two 60-byte lines, max-bytes 100 → 2 batches (one line each).
+    // Two 300-byte lines, max-bytes 400 → 2 batches (600 > 400, one line each).
     expect(
-      multilineMessageCount(`${'a'.repeat(60)}\n${'b'.repeat(60)}`, {
-        maxBytes: 100,
+      multilineMessageCount(`${'a'.repeat(300)}\n${'b'.repeat(300)}`, {
+        maxBytes: 400,
         maxLines: 24,
       }),
     ).toBe(2);
   });
 
   it('counts utf-8 bytes, not characters, for the byte budget', () => {
-    // 15 × 4-byte emoji per line = 60 bytes each.
-    const body = `${'🔥'.repeat(15)}\n${'🔥'.repeat(15)}`;
-    expect(multilineMessageCount(body, { maxBytes: 100, maxLines: 24 })).toBe(2); // 120 > 100
-    expect(multilineMessageCount(body, { maxBytes: 200, maxLines: 24 })).toBe(1); // 120 ≤ 200
+    // 100 × 4-byte emoji per line = 400 bytes each, 800 total. If it counted
+    // characters (200) it would never split — bytes are what bind.
+    const body = `${'🔥'.repeat(100)}\n${'🔥'.repeat(100)}`;
+    expect(multilineMessageCount(body, { maxBytes: 500, maxLines: 24 })).toBe(2); // 800 > 500
+    expect(multilineMessageCount(body, { maxBytes: 900, maxLines: 24 })).toBe(1); // 800 ≤ 900
+  });
+
+  it('is 0 when max-bytes is below one wire line (matches the server gate)', () => {
+    expect(multilineMessageCount('a\nb', { maxBytes: 100, maxLines: 24 })).toBe(0);
+    expect(multilineMessageCount('a\nb', { maxBytes: 349, maxLines: 24 })).toBe(0);
   });
 
   it('ignores a trailing newline (matches splitMultiline edge-trim)', () => {

--- a/vue_client/src/utils/messageSplit.ts
+++ b/vue_client/src/utils/messageSplit.ts
@@ -98,3 +98,47 @@ export function chunkCountForAction(text: string | null | undefined): number {
   if (!text) return 0;
   return chunksForLine(text, ACTION_MAX_BYTES);
 }
+
+export interface MultilineLimits {
+  maxBytes: number;
+  maxLines: number;
+}
+
+// How many draft/multiline batches a plain multi-line body will produce on a
+// network that negotiated the cap — i.e. how many logical messages the channel
+// will see. Returns 0 when the send won't be multiline at all (no embedded
+// newline, or the network lacks the cap), so callers treat 0 as "fall back to
+// the wire-chunk estimate". 1 = a single batch (no flood); ≥2 = that many
+// messages, NOT N raw lines.
+//
+// This mirrors the server's partitionMultiline (server/services/messageSplit):
+// pack logical lines into batches under max-lines (count of wire PRIVMSGs) and
+// max-bytes (utf-8 content bytes). The per-line wire count is approximated as
+// ceil(bytes / MESSAGE_MAX_BYTES) rather than the word-greedy split — exact for
+// the common case (lines under the wire limit) and close enough otherwise; the
+// hint is guidance, the wire-level partition still happens server-side.
+export function multilineMessageCount(
+  text: string | null | undefined,
+  limits: MultilineLimits | null | undefined,
+): number {
+  if (!text || !limits) return 0;
+  if (!/\r\n|\n|\r/.test(text)) return 0;
+  let batches = 1;
+  let curLines = 0;
+  let curBytes = 0;
+  for (const line of text.split(/\r\n|\n|\r/)) {
+    const lineBytes = byteLen(line);
+    const wireLines = Math.max(1, Math.ceil(lineBytes / MESSAGE_MAX_BYTES));
+    if (
+      curLines > 0 &&
+      (curLines + wireLines > limits.maxLines || curBytes + lineBytes > limits.maxBytes)
+    ) {
+      batches += 1;
+      curLines = 0;
+      curBytes = 0;
+    }
+    curLines += wireLines;
+    curBytes += lineBytes;
+  }
+  return batches;
+}

--- a/vue_client/src/utils/messageSplit.ts
+++ b/vue_client/src/utils/messageSplit.ts
@@ -106,39 +106,55 @@ export interface MultilineLimits {
 
 // How many draft/multiline batches a plain multi-line body will produce on a
 // network that negotiated the cap — i.e. how many logical messages the channel
-// will see. Returns 0 when the send won't be multiline at all (no embedded
+// will see. Returns 0 when the send won't be multiline at all (no interior
 // newline, or the network lacks the cap), so callers treat 0 as "fall back to
 // the wire-chunk estimate". 1 = a single batch (no flood); ≥2 = that many
 // messages, NOT N raw lines.
 //
-// This mirrors the server's partitionMultiline (server/services/messageSplit):
-// pack logical lines into batches under max-lines (count of wire PRIVMSGs) and
-// max-bytes (utf-8 content bytes). The per-line wire count is approximated as
-// ceil(bytes / MESSAGE_MAX_BYTES) rather than the word-greedy split — exact for
-// the common case (lines under the wire limit) and close enough otherwise; the
-// hint is guidance, the wire-level partition still happens server-side.
+// Mirrors the server's partitionMultiline (server/services/messageSplit): pack
+// lines into batches under max-lines (count of wire PRIVMSGs) and max-bytes
+// (utf-8 content bytes), tearing a single line that's bigger than a whole batch
+// across batches. Per-line wire count reuses chunksForLine (the same word-greedy
+// splitter behind chunkCountForSay) so the multiline count and the SPLIT/FLOOD
+// count agree. Edge blank lines are trimmed to match splitMultiline.
 export function multilineMessageCount(
   text: string | null | undefined,
   limits: MultilineLimits | null | undefined,
 ): number {
   if (!text || !limits) return 0;
-  if (!/\r\n|\n|\r/.test(text)) return 0;
-  let batches = 1;
+  const body = text.replace(/^(?:\r\n|\r|\n)+/, '').replace(/(?:\r\n|\r|\n)+$/, '');
+  if (!/\r\n|\n|\r/.test(body)) return 0;
+  let batches = 0;
   let curLines = 0;
   let curBytes = 0;
-  for (const line of text.split(/\r\n|\n|\r/)) {
-    const lineBytes = byteLen(line);
-    const wireLines = Math.max(1, Math.ceil(lineBytes / MESSAGE_MAX_BYTES));
-    if (
-      curLines > 0 &&
-      (curLines + wireLines > limits.maxLines || curBytes + lineBytes > limits.maxBytes)
-    ) {
+  const flush = (): void => {
+    if (curLines > 0) {
       batches += 1;
       curLines = 0;
       curBytes = 0;
     }
+  };
+  for (const line of body.split(/\r\n|\n|\r/)) {
+    const wireLines = Math.max(1, chunksForLine(line, MESSAGE_MAX_BYTES));
+    const lineBytes = byteLen(line);
+    if (
+      curLines > 0 &&
+      (curLines + wireLines > limits.maxLines || curBytes + lineBytes > limits.maxBytes)
+    ) {
+      flush();
+    }
+    if (wireLines > limits.maxLines || lineBytes > limits.maxBytes) {
+      // A single line too big for one batch spans several on its own.
+      flush();
+      batches += Math.max(
+        Math.ceil(wireLines / limits.maxLines),
+        Math.ceil(lineBytes / limits.maxBytes),
+      );
+      continue;
+    }
     curLines += wireLines;
     curBytes += lineBytes;
   }
+  flush();
   return batches;
 }

--- a/vue_client/src/utils/messageSplit.ts
+++ b/vue_client/src/utils/messageSplit.ts
@@ -122,6 +122,9 @@ export function multilineMessageCount(
   limits: MultilineLimits | null | undefined,
 ): number {
   if (!text || !limits) return 0;
+  // A max-bytes below one full wire line can't carry a PRIVMSG in a batch — the
+  // server reports null limits for it, but guard here too so the count matches.
+  if (limits.maxBytes < MESSAGE_MAX_BYTES) return 0;
   const body = text.replace(/^(?:\r\n|\r|\n)+/, '').replace(/(?:\r\n|\r|\n)+$/, '');
   if (!/\r\n|\n|\r/.test(body)) return 0;
   let batches = 0;


### PR DESCRIPTION
Closes #381.

Adds IRCv3 `draft/multiline` support — receiving fragmented batches as one
message, and sending a multi-line compose as one-or-more logical messages
instead of N flooded lines — with a clean fallback everywhere the cap isn't
negotiated. Server-side only on the wire; the client already renders embedded
newlines (`.body { white-space: pre-wrap }`).

## Receive (reassembly)
- Requests `batch` + `draft/multiline` caps.
- irc-framework buffers a batch and replays each PRIVMSG (tagged `event.batch`)
  then fires `batch end draft/multiline`, so we accumulate fragments per batch
  ref — joining with `\n` except across `draft/multiline-concat` — and flush one
  reassembled message through the normal `message` path (self-echo/routing/
  presence all behave as for a standalone PRIVMSG). In-flight batches clear on
  socket close.

## Send (framing)
- When the network negotiated the cap and the body has a newline, it rides
  `draft/multiline` batches. `partitionMultiline` packs lines into batches under
  the advertised `max-lines`/`max-bytes`, so a big paste lands as N logical
  messages rather than N raw lines; the sender echoes one bubble per batch.
- A single line bigger than a whole batch is torn across batches (never an
  over-budget batch the server would FAIL+drop).
- Networks without the cap fall back to the existing per-line `splitSay`.

## Composer (multiline-aware split/flood UX)
- The negotiated limits reach the client via the connect snapshot; the composer
  mirrors the server partition so the SPLIT/FLOOD hint and the upload-as-`.txt`
  gate count **messages the channel sees** (batch count), not wire lines. One
  batch shows a neutral `MULTILINE` chip and skips the gate; 2+ shows
  `MULTILINE ×N` and gates in message units.

## Scope / deferrals
- Trigger is an actual newline; a single long line keeps today's byte-splitting.
- Actions/CTCP stay single-line (spec disallows multiline CTCP).
- Mid-session `CAP NEW`/`CAP DEL` can desync the client gate until reconnect
  (limits only refresh on the connect snapshot) — low-risk follow-up.

## Testing
- New unit suites for `splitMultiline` / `partitionMultiline` /
  `reassembleMultiline` (server) and `multilineMessageCount` (client), plus
  integration-style receive-reassembly / concat / self-skip / multi-batch send
  framing tests driving the real irc-framework client.
- Verified against irc-framework 4.14.0 batch/cap/tag shapes.
- Includes a self-review pass (second commit) fixing a partition-overflow data-
  loss bug, edge-blank parity, and client count accuracy.

Server typecheck + `vue-tsc` + oxlint + oxfmt clean; 104 server + 21 client
unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)