### PR TITLE
RPE2E crypto core: byte-compatible protocol port + golden-vector tests (#382)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "1.0.5",
       "license": "MPL-2.0",
       "dependencies": {
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@scure/bip39": "^2.2.0",
         "@simplewebauthn/server": "^13.3.1",
         "archiver": "^8.0.0",
         "better-sqlite3": "^12.10.1",
@@ -1172,14 +1176,40 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1899,6 +1929,19 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@paralleldrive/cuid2/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@peculiar/asn1-android": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
@@ -2348,6 +2391,28 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@simplewebauthn/server": {
       "version": "13.3.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
   ],
   "license": "MPL-2.0",
   "dependencies": {
+    "@noble/ciphers": "^2.2.0",
+    "@noble/curves": "^2.2.0",
+    "@noble/hashes": "^2.2.0",
+    "@scure/bip39": "^2.2.0",
     "@simplewebauthn/server": "^13.3.1",
     "archiver": "^8.0.0",
     "better-sqlite3": "^12.10.1",

--- a/server/services/e2e/aad.test.ts
+++ b/server/services/e2e/aad.test.ts
@@ -59,6 +59,11 @@ describe('buildAad', () => {
     expect(() => buildAad('#chan', new Uint8Array(5), 100, 1, 3)).toThrow(/msgid must be/);
   });
 
+  it('rejects an out-of-range part/total instead of silently truncating', () => {
+    expect(() => buildAad('#chan', msgid(1), 100, 300, 3)).toThrow(/part must be 0\.\.255/);
+    expect(() => buildAad('#chan', msgid(1), 100, 1, 300)).toThrow(/total must be 0\.\.255/);
+  });
+
   // Rust clamps the u16 length prefix to 0xFFFF and appends the full channel;
   // a >65535-byte channel must not throw a RangeError from writeUInt16BE.
   it('clamps an over-long channel length prefix instead of throwing', () => {

--- a/server/services/e2e/aad.test.ts
+++ b/server/services/e2e/aad.test.ts
@@ -25,18 +25,21 @@ describe('buildAad', () => {
   // wire.rs::build_aad_golden_vector. The weechat/Perl scripts produce the
   // same 40 bytes for these inputs — if this changes, interop breaks.
   it('matches the cross-client golden byte sequence', () => {
+    const expected =
+      '52504532453031' + // "RPE2E01"
+      '0005' +
+      '236368616e' + // be16(5) || "#chan"
+      '0008' +
+      '0101010101010101' + // be16(8) || msgid (8x 0x01)
+      '0008' +
+      '0000000000000064' + // be16(8) || ts=100 (i64 be)
+      '0001' +
+      '01' + // be16(1) || part=1
+      '0001' +
+      '03'; // be16(1) || total=3
     const got = buildAad('#chan', msgid(1), 100, 1, 3);
-    // prettier-ignore
-    const expected = [
-      0x52, 0x50, 0x45, 0x32, 0x45, 0x30, 0x31, // "RPE2E01"
-      0x00, 0x05, 0x23, 0x63, 0x68, 0x61, 0x6e, // be16(5) || "#chan"
-      0x00, 0x08, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, // be16(8) || msgid
-      0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, // be16(8) || ts=100 be64
-      0x00, 0x01, 0x01, // be16(1) || part=1
-      0x00, 0x01, 0x03, // be16(1) || total=3
-    ];
     expect(got.length).toBe(40);
-    expect(Array.from(got)).toEqual(expected);
+    expect(Buffer.from(got).toString('hex')).toBe(expected);
   });
 
   // The length-prefixed layout keeps a channel containing ':' distinct from
@@ -46,5 +49,19 @@ describe('buildAad', () => {
     const b = buildAad('#a', msgid(1), 100, 1, 3);
     expect(a).not.toEqual(b);
     expect(a.length).not.toBe(b.length);
+  });
+
+  it('rejects a fractional ts instead of throwing a raw BigInt error', () => {
+    expect(() => buildAad('#chan', msgid(1), 100.5, 1, 3)).toThrow(/ts must be an integer/);
+  });
+
+  it('rejects a wrong-length msgid', () => {
+    expect(() => buildAad('#chan', new Uint8Array(5), 100, 1, 3)).toThrow(/msgid must be/);
+  });
+
+  // Rust clamps the u16 length prefix to 0xFFFF and appends the full channel;
+  // a >65535-byte channel must not throw a RangeError from writeUInt16BE.
+  it('clamps an over-long channel length prefix instead of throwing', () => {
+    expect(() => buildAad('#' + 'a'.repeat(70000), msgid(1), 100, 1, 3)).not.toThrow();
   });
 });

--- a/server/services/e2e/aad.test.ts
+++ b/server/services/e2e/aad.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { buildAad } from './aad.js';
+
+const msgid = (b: number) => new Uint8Array(8).fill(b);
+
+describe('buildAad', () => {
+  it('is deterministic', () => {
+    expect(buildAad('#chan', msgid(1), 100, 1, 3)).toEqual(buildAad('#chan', msgid(1), 100, 1, 3));
+  });
+
+  it('is sensitive to every field', () => {
+    const base = buildAad('#chan', msgid(1), 100, 1, 3);
+    expect(base).not.toEqual(buildAad('#other', msgid(1), 100, 1, 3));
+    expect(base).not.toEqual(buildAad('#chan', msgid(2), 100, 1, 3));
+    expect(base).not.toEqual(buildAad('#chan', msgid(1), 101, 1, 3));
+    expect(base).not.toEqual(buildAad('#chan', msgid(1), 100, 2, 3));
+    expect(base).not.toEqual(buildAad('#chan', msgid(1), 100, 1, 4));
+  });
+
+  // Cross-client interop golden vector, taken verbatim from repartee's
+  // wire.rs::build_aad_golden_vector. The weechat/Perl scripts produce the
+  // same 40 bytes for these inputs — if this changes, interop breaks.
+  it('matches the cross-client golden byte sequence', () => {
+    const got = buildAad('#chan', msgid(1), 100, 1, 3);
+    // prettier-ignore
+    const expected = [
+      0x52, 0x50, 0x45, 0x32, 0x45, 0x30, 0x31, // "RPE2E01"
+      0x00, 0x05, 0x23, 0x63, 0x68, 0x61, 0x6e, // be16(5) || "#chan"
+      0x00, 0x08, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, // be16(8) || msgid
+      0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, // be16(8) || ts=100 be64
+      0x00, 0x01, 0x01, // be16(1) || part=1
+      0x00, 0x01, 0x03, // be16(1) || total=3
+    ];
+    expect(got.length).toBe(40);
+    expect(Array.from(got)).toEqual(expected);
+  });
+
+  // The length-prefixed layout keeps a channel containing ':' distinct from
+  // any other arrangement that happens to concatenate the same bytes.
+  it('length-prefix defeats colon ambiguity', () => {
+    const a = buildAad('#a:b', msgid(1), 100, 1, 3);
+    const b = buildAad('#a', msgid(1), 100, 1, 3);
+    expect(a).not.toEqual(b);
+    expect(a.length).not.toBe(b.length);
+  });
+});

--- a/server/services/e2e/aad.ts
+++ b/server/services/e2e/aad.ts
@@ -46,6 +46,16 @@ function toI64(ts: number | bigint): bigint {
   return ts;
 }
 
+/** Validate a single-byte (u8) field so it can't be silently truncated. The
+ *  1..total relationship is the encoder's job (matching repartee's split); here
+ *  we only guarantee the value fits in the byte the AAD encodes. */
+function u8(n: number, field: string): number {
+  if (!Number.isInteger(n) || n < 0 || n > 0xff) {
+    throw wireError(`${field} must be 0..255, got ${n}`);
+  }
+  return n;
+}
+
 /**
  * Build the AAD for a single chunk. `msgid` must be exactly 8 bytes; `ts` is
  * unix seconds (encoded as a big-endian i64); `part`/`total` are 1-indexed.
@@ -75,8 +85,8 @@ export function buildAad(
     be16(8),
     tsBuf,
     be16(1),
-    Buffer.from([part & 0xff]),
+    Buffer.from([u8(part, 'part')]),
     be16(1),
-    Buffer.from([total & 0xff]),
+    Buffer.from([u8(total, 'total')]),
   ]);
 }

--- a/server/services/e2e/aad.ts
+++ b/server/services/e2e/aad.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Additional Authenticated Data (AAD) construction for an RPE2E01 chunk.
+//
+// AAD layout (length-prefixed, big-endian):
+//
+//   PROTO(7 bytes, fixed)
+//     || be16(channel.len) || channel
+//     || be16(8)           || msgid (8 bytes)
+//     || be16(8)           || ts_be (8 bytes, i64)
+//     || be16(1)           || part  (1 byte)
+//     || be16(1)           || total (1 byte)
+//
+// Every non-const field carries a u16 big-endian length prefix — even the
+// fixed-size ones — so the layout is position-independent and no crafted
+// channel name (e.g. one containing ':') can shift later fields. The 7-byte
+// PROTO prefix is constant and therefore not length-prefixed.
+//
+// The sender handle is deliberately NOT in the AAD: sender authentication is
+// enforced at the keyring layer (decrypt looks up the session by
+// (handle_from_IRC_prefix, channel)), and the sender does not always know its
+// own ident@host before encrypting. This mirrors repartee exactly; the golden
+// vector in aad.test.ts pins the byte sequence for interop.
+
+import { PROTO } from './constants.js';
+
+const utf8 = new TextEncoder();
+
+function be16(n: number): Buffer {
+  const b = Buffer.alloc(2);
+  b.writeUInt16BE(n);
+  return b;
+}
+
+/**
+ * Build the AAD for a single chunk. `msgid` must be exactly 8 bytes; `ts` is
+ * unix seconds (encoded as a big-endian i64); `part`/`total` are 1-indexed.
+ */
+export function buildAad(
+  channel: string,
+  msgid: Uint8Array,
+  ts: number | bigint,
+  part: number,
+  total: number,
+): Uint8Array {
+  const chan = utf8.encode(channel);
+  const tsBuf = Buffer.alloc(8);
+  tsBuf.writeBigInt64BE(BigInt(ts));
+
+  return Buffer.concat([
+    utf8.encode(PROTO), // "RPE2E01" (7 bytes, not length-prefixed)
+    be16(chan.length),
+    chan,
+    be16(8),
+    Buffer.from(msgid),
+    be16(8),
+    tsBuf,
+    be16(1),
+    Buffer.from([part & 0xff]),
+    be16(1),
+    Buffer.from([total & 0xff]),
+  ]);
+}

--- a/server/services/e2e/aad.ts
+++ b/server/services/e2e/aad.ts
@@ -23,14 +23,27 @@
 // own ident@host before encrypting. This mirrors repartee exactly; the golden
 // vector in aad.test.ts pins the byte sequence for interop.
 
-import { PROTO } from './constants.js';
+import { MSGID_LEN, PROTO } from './constants.js';
+import { utf8 } from './encoding.js';
+import { wireError } from './errors.js';
 
-const utf8 = new TextEncoder();
+const I64_MIN = -(2n ** 63n);
+const I64_MAX = 2n ** 63n - 1n;
 
 function be16(n: number): Buffer {
   const b = Buffer.alloc(2);
   b.writeUInt16BE(n);
   return b;
+}
+
+/** Validate `ts` is an exact integer within the i64 range and return it as a bigint. */
+function toI64(ts: number | bigint): bigint {
+  if (typeof ts === 'number') {
+    if (!Number.isSafeInteger(ts)) throw wireError(`ts must be an integer, got ${ts}`);
+    return BigInt(ts);
+  }
+  if (ts < I64_MIN || ts > I64_MAX) throw wireError(`ts out of i64 range: ${ts}`);
+  return ts;
 }
 
 /**
@@ -44,13 +57,18 @@ export function buildAad(
   part: number,
   total: number,
 ): Uint8Array {
-  const chan = utf8.encode(channel);
+  if (msgid.length !== MSGID_LEN) {
+    throw wireError(`msgid must be ${MSGID_LEN} bytes, got ${msgid.length}`);
+  }
   const tsBuf = Buffer.alloc(8);
-  tsBuf.writeBigInt64BE(BigInt(ts));
+  tsBuf.writeBigInt64BE(toI64(ts));
 
+  const chan = utf8.encode(channel);
   return Buffer.concat([
     utf8.encode(PROTO), // "RPE2E01" (7 bytes, not length-prefixed)
-    be16(chan.length),
+    // Clamp the length prefix to u16::MAX as repartee does; the full channel
+    // bytes still follow, so honest peers agree byte-for-byte even past 65535.
+    be16(Math.min(chan.length, 0xffff)),
     chan,
     be16(8),
     Buffer.from(msgid),

--- a/server/services/e2e/aead.test.ts
+++ b/server/services/e2e/aead.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from 'vitest';
 
 import { decrypt, encrypt, generateSessionKey, KEY_LEN, NONCE_LEN } from './aead.js';
+import { E2eError } from './errors.js';
 
 const enc = new TextEncoder();
 
@@ -44,5 +45,23 @@ describe('aead (XChaCha20-Poly1305)', () => {
     const { nonce, ciphertext } = encrypt(key, aad, enc.encode('secret message'));
     ciphertext[0] ^= 0x01;
     expect(() => decrypt(key, nonce, aad, ciphertext)).toThrow(/aead decrypt/);
+  });
+
+  it('surfaces a wrong-length key/nonce as a crypto E2eError, not a raw RangeError', () => {
+    const aad = enc.encode('ctx');
+    let caught: unknown;
+    try {
+      encrypt(new Uint8Array(16), aad, enc.encode('x'));
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(E2eError);
+    expect((caught as E2eError).kind).toBe('crypto');
+    expect(() =>
+      decrypt(new Uint8Array(16), new Uint8Array(NONCE_LEN), aad, new Uint8Array(20)),
+    ).toThrow(/key must be/);
+    expect(() =>
+      decrypt(new Uint8Array(KEY_LEN), new Uint8Array(10), aad, new Uint8Array(20)),
+    ).toThrow(/nonce must be/);
   });
 });

--- a/server/services/e2e/aead.test.ts
+++ b/server/services/e2e/aead.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { decrypt, encrypt, generateSessionKey, KEY_LEN, NONCE_LEN } from './aead.js';
+
+const enc = new TextEncoder();
+
+describe('aead (XChaCha20-Poly1305)', () => {
+  it('round-trips plaintext bound to AAD', () => {
+    const key = generateSessionKey();
+    const aad = enc.encode('RPE2E01:sender@host:#chan:msgid:ts:1:1');
+    const pt = enc.encode('hello world');
+    const { nonce, ciphertext } = encrypt(key, aad, pt);
+    expect(nonce.length).toBe(NONCE_LEN);
+    expect(decrypt(key, nonce, aad, ciphertext)).toEqual(pt);
+  });
+
+  it('generates a 32-byte key and a fresh nonce each call', () => {
+    expect(generateSessionKey().length).toBe(KEY_LEN);
+    const key = generateSessionKey();
+    const aad = enc.encode('ctx');
+    const a = encrypt(key, aad, enc.encode('x'));
+    const b = encrypt(key, aad, enc.encode('x'));
+    expect(a.nonce).not.toEqual(b.nonce);
+  });
+
+  it('fails on an AAD mismatch', () => {
+    const key = generateSessionKey();
+    const { nonce, ciphertext } = encrypt(key, enc.encode('ctx-1'), enc.encode('secret'));
+    expect(() => decrypt(key, nonce, enc.encode('ctx-2'), ciphertext)).toThrow(/aead decrypt/);
+  });
+
+  it('fails with the wrong key', () => {
+    const aad = enc.encode('ctx');
+    const { nonce, ciphertext } = encrypt(generateSessionKey(), aad, enc.encode('secret'));
+    expect(() => decrypt(generateSessionKey(), nonce, aad, ciphertext)).toThrow(/aead decrypt/);
+  });
+
+  it('fails on a tampered ciphertext', () => {
+    const key = generateSessionKey();
+    const aad = enc.encode('ctx');
+    const { nonce, ciphertext } = encrypt(key, aad, enc.encode('secret message'));
+    ciphertext[0] ^= 0x01;
+    expect(() => decrypt(key, nonce, aad, ciphertext)).toThrow(/aead decrypt/);
+  });
+});

--- a/server/services/e2e/aead.ts
+++ b/server/services/e2e/aead.ts
@@ -25,9 +25,14 @@ export interface Sealed {
  * per call. Returns the nonce and the ciphertext (which includes the tag).
  */
 export function encrypt(key: Uint8Array, aad: Uint8Array, plaintext: Uint8Array): Sealed {
+  if (key.length !== KEY_LEN) throw cryptoError(`key must be ${KEY_LEN} bytes, got ${key.length}`);
   const nonce = new Uint8Array(randomBytes(NONCE_LEN));
-  const ciphertext = xchacha20poly1305(key, nonce, aad).encrypt(plaintext);
-  return { nonce, ciphertext };
+  try {
+    const ciphertext = xchacha20poly1305(key, nonce, aad).encrypt(plaintext);
+    return { nonce, ciphertext };
+  } catch (err) {
+    throw cryptoError(`aead encrypt: ${(err as Error).message}`);
+  }
 }
 
 /**
@@ -40,6 +45,10 @@ export function decrypt(
   aad: Uint8Array,
   ciphertext: Uint8Array,
 ): Uint8Array {
+  if (key.length !== KEY_LEN) throw cryptoError(`key must be ${KEY_LEN} bytes, got ${key.length}`);
+  if (nonce.length !== NONCE_LEN) {
+    throw cryptoError(`nonce must be ${NONCE_LEN} bytes, got ${nonce.length}`);
+  }
   try {
     return xchacha20poly1305(key, nonce, aad).decrypt(ciphertext);
   } catch (err) {

--- a/server/services/e2e/aead.ts
+++ b/server/services/e2e/aead.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// XChaCha20-Poly1305 AEAD, used for both message encryption and session-key
+// wrapping. 32-byte key, 24-byte nonce (fresh-random per call), Poly1305 tag
+// appended to the ciphertext. This is a single well-defined algorithm, so any
+// conformant implementation (repartee's Rust, the weechat/Perl scripts) that
+// agrees on key, nonce, and AAD produces interoperable ciphertext.
+
+import { randomBytes } from 'node:crypto';
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js';
+
+import { cryptoError } from './errors.js';
+
+export const KEY_LEN = 32;
+export const NONCE_LEN = 24;
+
+export interface Sealed {
+  nonce: Uint8Array;
+  ciphertext: Uint8Array;
+}
+
+/**
+ * Encrypt `plaintext` binding `aad`. A fresh random 24-byte nonce is generated
+ * per call. Returns the nonce and the ciphertext (which includes the tag).
+ */
+export function encrypt(key: Uint8Array, aad: Uint8Array, plaintext: Uint8Array): Sealed {
+  const nonce = new Uint8Array(randomBytes(NONCE_LEN));
+  const ciphertext = xchacha20poly1305(key, nonce, aad).encrypt(plaintext);
+  return { nonce, ciphertext };
+}
+
+/**
+ * Decrypt `ciphertext` using `nonce` and `aad`. Throws `E2eError('crypto')`
+ * on tag mismatch (wrong key, tampered ciphertext, or wrong AAD).
+ */
+export function decrypt(
+  key: Uint8Array,
+  nonce: Uint8Array,
+  aad: Uint8Array,
+  ciphertext: Uint8Array,
+): Uint8Array {
+  try {
+    return xchacha20poly1305(key, nonce, aad).decrypt(ciphertext);
+  } catch (err) {
+    throw cryptoError(`aead decrypt: ${(err as Error).message}`);
+  }
+}
+
+/** Generate a fresh 32-byte symmetric session key. */
+export function generateSessionKey(): Uint8Array {
+  return new Uint8Array(randomBytes(KEY_LEN));
+}

--- a/server/services/e2e/chunker.test.ts
+++ b/server/services/e2e/chunker.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { splitPlaintext } from './chunker.js';
+import { MAX_PLAINTEXT_PER_CHUNK } from './constants.js';
+
+const dec = new TextDecoder();
+
+describe('chunker', () => {
+  it('keeps a short message as one chunk', () => {
+    const chunks = splitPlaintext('hello');
+    expect(chunks.length).toBe(1);
+    expect(dec.decode(chunks[0])).toBe('hello');
+  });
+
+  it('refuses empty plaintext', () => {
+    expect(() => splitPlaintext('')).toThrow(/empty plaintext/);
+  });
+
+  it('splits a long message into multiple chunks that rejoin exactly', () => {
+    const s = 'x'.repeat(500);
+    const chunks = splitPlaintext(s);
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    const rejoined = chunks.map((c) => dec.decode(c)).join('');
+    expect(rejoined).toBe(s);
+  });
+
+  it('never splits inside a multi-byte UTF-8 character', () => {
+    // Each pile-of-poo is 4 bytes; pad to force a split near the boundary.
+    const prefix = 'x'.repeat(MAX_PLAINTEXT_PER_CHUNK - 2);
+    const s = `${prefix}💩${prefix}`;
+    const chunks = splitPlaintext(s);
+    for (const c of chunks) {
+      // Decoding with fatal:true throws if a chunk severs a character.
+      expect(() => new TextDecoder('utf-8', { fatal: true }).decode(c)).not.toThrow();
+    }
+    expect(chunks.map((c) => dec.decode(c)).join('')).toBe(s);
+  });
+
+  it('errors when the message exceeds the chunk cap', () => {
+    expect(() => splitPlaintext('a'.repeat(MAX_PLAINTEXT_PER_CHUNK * 17))).toThrow(
+      /too many chunks/,
+    );
+  });
+});

--- a/server/services/e2e/chunker.ts
+++ b/server/services/e2e/chunker.ts
@@ -30,8 +30,10 @@ export function splitPlaintext(plaintext: string): Uint8Array[] {
 
   while (cursor < bytes.length) {
     let end = Math.min(cursor + MAX_PLAINTEXT_PER_CHUNK, bytes.length);
-    // Walk back to a UTF-8 boundary if we landed mid-sequence.
-    while (end > cursor && isContinuation(bytes[end])) {
+    // Walk back to a UTF-8 boundary if we landed mid-sequence. `end < length`
+    // is explicit (the end of the buffer is always a boundary) rather than
+    // relying on `bytes[length]` coercing to `undefined`.
+    while (end > cursor && end < bytes.length && isContinuation(bytes[end])) {
       end -= 1;
     }
     if (end === cursor) {

--- a/server/services/e2e/chunker.ts
+++ b/server/services/e2e/chunker.ts
@@ -7,9 +7,8 @@
 // reassembles (architecture spec section 6).
 
 import { MAX_CHUNKS, MAX_PLAINTEXT_PER_CHUNK } from './constants.js';
+import { utf8 } from './encoding.js';
 import { chunkLimitError, wireError } from './errors.js';
-
-const utf8 = new TextEncoder();
 
 /** True if `byte` is a UTF-8 continuation byte (0b10xxxxxx). */
 function isContinuation(byte: number): boolean {

--- a/server/services/e2e/chunker.ts
+++ b/server/services/e2e/chunker.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Stateless plaintext chunker. Splits a message into N <= MAX_CHUNKS pieces,
+// each at most MAX_PLAINTEXT_PER_CHUNK bytes, on UTF-8 character boundaries.
+// Each chunk becomes an independent encrypted line — the receiver never
+// reassembles (architecture spec section 6).
+
+import { MAX_CHUNKS, MAX_PLAINTEXT_PER_CHUNK } from './constants.js';
+import { chunkLimitError, wireError } from './errors.js';
+
+const utf8 = new TextEncoder();
+
+/** True if `byte` is a UTF-8 continuation byte (0b10xxxxxx). */
+function isContinuation(byte: number): boolean {
+  return (byte & 0xc0) === 0x80;
+}
+
+/**
+ * Split `plaintext` into UTF-8 chunks. Empty input is refused (so a caller
+ * cannot ship a zero-length-ciphertext chunk that renders as a blank line).
+ * Throws if a single character exceeds the chunk budget or the message needs
+ * more than MAX_CHUNKS chunks.
+ */
+export function splitPlaintext(plaintext: string): Uint8Array[] {
+  if (plaintext.length === 0) throw wireError('empty plaintext');
+
+  const bytes = utf8.encode(plaintext);
+  const chunks: Uint8Array[] = [];
+  let cursor = 0;
+
+  while (cursor < bytes.length) {
+    let end = Math.min(cursor + MAX_PLAINTEXT_PER_CHUNK, bytes.length);
+    // Walk back to a UTF-8 boundary if we landed mid-sequence.
+    while (end > cursor && isContinuation(bytes[end])) {
+      end -= 1;
+    }
+    if (end === cursor) {
+      throw wireError('cannot split: single UTF-8 char exceeds chunk budget');
+    }
+    chunks.push(bytes.subarray(cursor, end));
+    cursor = end;
+
+    if (chunks.length > MAX_CHUNKS) throw chunkLimitError(chunks.length);
+  }
+
+  if (chunks.length > MAX_CHUNKS) throw chunkLimitError(chunks.length);
+  return chunks;
+}

--- a/server/services/e2e/constants.ts
+++ b/server/services/e2e/constants.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Protocol-wide constants for RPE2E01. These are load-bearing for cross-client
+// interop: every value here must match repartee's reference implementation
+// (and the weechat/Perl scripts) byte-for-byte. See the protocol notes in
+// docs and issue #382. Do not "tidy" these without a matching change upstream.
+
+/** Protocol version string embedded in the wire format and the AAD. */
+export const PROTO = 'RPE2E01';
+
+/** Wire prefix magic for an encrypted message chunk. */
+export const WIRE_PREFIX = '+RPE2E01';
+
+/** CTCP tag for handshake messages (KEYREQ/KEYRSP/REKEY), framed in `\x01..\x01`. */
+export const CTCP_TAG = 'RPEE2E';
+
+/** Handshake protocol version (the `v=` field). */
+export const PROTO_VERSION = 1;
+
+/** Max chunks per logical message (hard cap for the sender). */
+export const MAX_CHUNKS = 16;
+
+/** Max plaintext bytes per chunk before ciphertext expansion. Chosen so a chunk
+ *  fits in ~400 bytes of IRC payload after base64. */
+export const MAX_PLAINTEXT_PER_CHUNK = 180;
+
+/** Default replay-protection window for the `ts` field, in seconds. */
+export const DEFAULT_TS_TOLERANCE_SECS = 300;
+
+/** HKDF salt for wrap-key derivation (constant across all contexts). */
+export const HKDF_WRAP_SALT = 'RPE2E01-WRAP';
+
+/** HKDF info string for the KEYREQ/KEYRSP wrap-key on a given channel. */
+export const wrapInfo = (channel: string): string => `RPE2E01-WRAP:${channel}`;
+
+/** HKDF info string for the REKEY distribution wrap-key on a given channel. */
+export const rekeyInfo = (channel: string): string => `RPE2E01-REKEY:${channel}`;
+
+/** Fingerprint domain-separation prefix (hashed ahead of the public key). */
+export const FP_PREFIX = 'RPE2E01-FP:';

--- a/server/services/e2e/constants.ts
+++ b/server/services/e2e/constants.ts
@@ -18,6 +18,9 @@ export const CTCP_TAG = 'RPEE2E';
 /** Handshake protocol version (the `v=` field). */
 export const PROTO_VERSION = 1;
 
+/** Length of a message id, in bytes. */
+export const MSGID_LEN = 8;
+
 /** Max chunks per logical message (hard cap for the sender). */
 export const MAX_CHUNKS = 16;
 

--- a/server/services/e2e/context.test.ts
+++ b/server/services/e2e/context.test.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { contextKey } from './context.js';
+
+describe('contextKey', () => {
+  it('passes channel targets through unchanged', () => {
+    expect(contextKey('#rust', '~bob@b.host')).toBe('#rust');
+    expect(contextKey('&local', '~bob@b.host')).toBe('&local');
+    expect(contextKey('!HXYZ', '~bob@b.host')).toBe('!HXYZ');
+    expect(contextKey('+modeless', '~bob@b.host')).toBe('+modeless');
+  });
+
+  it('maps a PM target to the @ident@host pseudochannel', () => {
+    expect(contextKey('bob', '~bob@home.example.org')).toBe('@~bob@home.example.org');
+  });
+
+  it('distinguishes the same nick from different hosts', () => {
+    expect(contextKey('bob', '~bob@home.example.org')).not.toBe(
+      contextKey('bob', '~bob@vpn.example.org'),
+    );
+  });
+});

--- a/server/services/e2e/context.ts
+++ b/server/services/e2e/context.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Derive the keyring "channel" context for a conversation.
+//
+// Real IRC channels (prefixes # & ! +) pass through unchanged. Private
+// messages become the pseudochannel `@<peer_handle>` (architecture spec
+// section 6), where peer_handle is the server-stamped ident@host of the
+// remote peer — never their nick. Two peers that share a nick across
+// different hosts (or one peer reconnecting from a new host) therefore live
+// under distinct keyring rows instead of colliding under a bare nick.
+
+const CHANNEL_PREFIXES = ['#', '&', '!', '+'];
+
+/**
+ * @param target      the IRC target (channel name or a peer nick)
+ * @param peerHandle  the remote peer's server-stamped ident@host (PM only)
+ */
+export function contextKey(target: string, peerHandle: string): string {
+  if (CHANNEL_PREFIXES.some((p) => target.startsWith(p))) {
+    return target;
+  }
+  return `@${peerHandle}`;
+}

--- a/server/services/e2e/ecdh.test.ts
+++ b/server/services/e2e/ecdh.test.ts
@@ -34,6 +34,17 @@ describe('ecdh wrap-key derivation', () => {
     const k2 = deriveWrapKey(alice.secretKey, bob.publicKey, enc.encode('ctx-2'));
     expect(k1).not.toEqual(k2);
   });
+
+  it('surfaces an invalid (all-zero / small-order) peer public as an E2eError', () => {
+    const me = generateEphemeral();
+    expect(() => deriveWrapKey(me.secretKey, new Uint8Array(32), enc.encode('ctx'))).toThrow(
+      /derive wrap key/,
+    );
+  });
+
+  it('surfaces an invalid Ed25519 point as an E2eError', () => {
+    expect(() => ed25519PubToX25519(new Uint8Array(32).fill(0xff))).toThrow(/invalid ed25519 pub/);
+  });
 });
 
 // RFC 8032 section 7.1 seeds, also used by ed25519-dalek's tests and by

--- a/server/services/e2e/ecdh.test.ts
+++ b/server/services/e2e/ecdh.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { x25519 } from '@noble/curves/ed25519.js';
+
+import {
+  deriveWrapKey,
+  ed25519PubToX25519,
+  ed25519SeedToX25519,
+  generateEphemeral,
+  WRAP_KEY_LEN,
+} from './ecdh.js';
+import { identityFromSeed } from './identity.js';
+
+const enc = new TextEncoder();
+const hex = (s: string) => new Uint8Array(Buffer.from(s, 'hex'));
+
+describe('ecdh wrap-key derivation', () => {
+  it('both sides derive the same 32-byte wrap key', () => {
+    const alice = generateEphemeral();
+    const bob = generateEphemeral();
+    const info = enc.encode('test-context');
+    const kAB = deriveWrapKey(alice.secretKey, bob.publicKey, info);
+    const kBA = deriveWrapKey(bob.secretKey, alice.publicKey, info);
+    expect(kAB).toEqual(kBA);
+    expect(kAB.length).toBe(WRAP_KEY_LEN);
+  });
+
+  it('different info strings yield different keys', () => {
+    const alice = generateEphemeral();
+    const bob = generateEphemeral();
+    const k1 = deriveWrapKey(alice.secretKey, bob.publicKey, enc.encode('ctx-1'));
+    const k2 = deriveWrapKey(alice.secretKey, bob.publicKey, enc.encode('ctx-2'));
+    expect(k1).not.toEqual(k2);
+  });
+});
+
+// RFC 8032 section 7.1 seeds, also used by ed25519-dalek's tests and by
+// repartee's ecdh.rs::ed25519_to_x25519_rfc8032_vectors. Asserting these
+// guarantees byte-for-byte agreement with libsodium-based peers (the
+// Perl/Python scripts) on the Ed25519 -> X25519 birational map.
+describe('Ed25519 -> X25519 conversion (RFC 8032 vectors)', () => {
+  const seedA = hex('9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60');
+  const seedB = hex('4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb');
+  const pubA = hex('d85e07ec22b0ad881537c2f44d662d1a143cf830c57aca4305d85c7a90f6b62e');
+  const pubB = hex('25c704c594b88afc00a76b69d1ed2b984d7e22550f3ed0802d04fbcd07d38d47');
+  const shared = hex('5166f24a6918368e2af831a4affadd97af0ac326bdf143596c045967cc00230e');
+
+  it('derives the known X25519 public from the Ed25519 seed (secret side)', () => {
+    expect(x25519.getPublicKey(ed25519SeedToX25519(seedA))).toEqual(pubA);
+    expect(x25519.getPublicKey(ed25519SeedToX25519(seedB))).toEqual(pubB);
+  });
+
+  it('derives the known X25519 public from the Ed25519 public (point side)', () => {
+    const edPubA = identityFromSeed(seedA).publicKey;
+    const edPubB = identityFromSeed(seedB).publicKey;
+    expect(ed25519PubToX25519(edPubA)).toEqual(pubA);
+    expect(ed25519PubToX25519(edPubB)).toEqual(pubB);
+  });
+
+  it('reaches the RFC shared secret from both directions', () => {
+    const scalarA = ed25519SeedToX25519(seedA);
+    const scalarB = ed25519SeedToX25519(seedB);
+    expect(x25519.getSharedSecret(scalarA, pubB)).toEqual(shared);
+    expect(x25519.getSharedSecret(scalarB, pubA)).toEqual(shared);
+  });
+});

--- a/server/services/e2e/ecdh.ts
+++ b/server/services/e2e/ecdh.ts
@@ -17,10 +17,11 @@ import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 import { HKDF_WRAP_SALT } from './constants.js';
+import { utf8 } from './encoding.js';
+import { cryptoError } from './errors.js';
 
 export const WRAP_KEY_LEN = 32;
 
-const utf8 = new TextEncoder();
 const WRAP_SALT = utf8.encode(HKDF_WRAP_SALT);
 
 export interface EphemeralKeypair {
@@ -46,16 +47,31 @@ export function deriveWrapKey(
   peerPublic: Uint8Array,
   info: Uint8Array,
 ): Uint8Array {
-  const shared = x25519.getSharedSecret(mySecret, peerPublic);
-  return hkdf(sha256, shared, WRAP_SALT, info, WRAP_KEY_LEN);
+  try {
+    // noble rejects an all-zero / small-order peer public (x25519-dalek would
+    // instead return a degenerate shared secret). Keeping the reject is safer;
+    // we just surface it as E2eError so callers can branch on `kind`.
+    const shared = x25519.getSharedSecret(mySecret, peerPublic);
+    return hkdf(sha256, shared, WRAP_SALT, info, WRAP_KEY_LEN);
+  } catch (err) {
+    throw cryptoError(`derive wrap key: ${(err as Error).message}`);
+  }
 }
 
 /** Convert an Ed25519 public key to its X25519 (Montgomery) counterpart. */
 export function ed25519PubToX25519(edPub: Uint8Array): Uint8Array {
-  return ed25519.utils.toMontgomery(edPub);
+  try {
+    return ed25519.utils.toMontgomery(edPub);
+  } catch (err) {
+    throw cryptoError(`invalid ed25519 pub: ${(err as Error).message}`);
+  }
 }
 
 /** Convert an Ed25519 secret seed to its X25519 scalar. */
 export function ed25519SeedToX25519(edSeed: Uint8Array): Uint8Array {
-  return ed25519.utils.toMontgomerySecret(edSeed);
+  try {
+    return ed25519.utils.toMontgomerySecret(edSeed);
+  } catch (err) {
+    throw cryptoError(`invalid ed25519 seed: ${(err as Error).message}`);
+  }
 }

--- a/server/services/e2e/ecdh.ts
+++ b/server/services/e2e/ecdh.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// X25519 ECDH + HKDF-SHA256 wrap-key derivation, and the RFC 7748 Appendix A
+// birational map between Ed25519 and X25519 keys.
+//
+// The wrap key is derived from an X25519 Diffie-Hellman shared secret expanded
+// with HKDF-SHA256 (constant salt "RPE2E01-WRAP", per-context info string).
+// The Ed25519 -> X25519 conversion lets the REKEY distribution path encrypt to
+// a peer whose only stable key is their Ed25519 identity; it matches
+// libsodium's crypto_sign_ed25519_{pk,sk}_to_curve25519 so libsodium-based
+// peers (the Perl/Python scripts) derive the same keypair.
+
+import { randomBytes } from 'node:crypto';
+import { ed25519, x25519 } from '@noble/curves/ed25519.js';
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import { HKDF_WRAP_SALT } from './constants.js';
+
+export const WRAP_KEY_LEN = 32;
+
+const utf8 = new TextEncoder();
+const WRAP_SALT = utf8.encode(HKDF_WRAP_SALT);
+
+export interface EphemeralKeypair {
+  /** 32-byte X25519 secret. */
+  secretKey: Uint8Array;
+  /** 32-byte X25519 public key. */
+  publicKey: Uint8Array;
+}
+
+/** Generate a fresh ephemeral X25519 keypair for a handshake. */
+export function generateEphemeral(): EphemeralKeypair {
+  const secretKey = new Uint8Array(randomBytes(32));
+  return { secretKey, publicKey: x25519.getPublicKey(secretKey) };
+}
+
+/**
+ * Derive a 32-byte wrap key from an X25519 ECDH of our secret with the peer's
+ * public, expanded via HKDF-SHA256. `info` binds the key to the protocol and
+ * handshake context (use `wrapInfo`/`rekeyInfo` from constants).
+ */
+export function deriveWrapKey(
+  mySecret: Uint8Array,
+  peerPublic: Uint8Array,
+  info: Uint8Array,
+): Uint8Array {
+  const shared = x25519.getSharedSecret(mySecret, peerPublic);
+  return hkdf(sha256, shared, WRAP_SALT, info, WRAP_KEY_LEN);
+}
+
+/** Convert an Ed25519 public key to its X25519 (Montgomery) counterpart. */
+export function ed25519PubToX25519(edPub: Uint8Array): Uint8Array {
+  return ed25519.utils.toMontgomery(edPub);
+}
+
+/** Convert an Ed25519 secret seed to its X25519 scalar. */
+export function ed25519SeedToX25519(edSeed: Uint8Array): Uint8Array {
+  return ed25519.utils.toMontgomerySecret(edSeed);
+}

--- a/server/services/e2e/encoding.ts
+++ b/server/services/e2e/encoding.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared low-level encoding helpers for the e2e modules.
+//
+// Node's `Buffer.from(s, 'base64'|'base64url')` silently drops invalid
+// characters and tolerates bad padding, whereas repartee's Rust uses strict
+// base64 engines that reject such input. These decoders validate the alphabet
+// and shape first and return `null` on anything the reference would reject, so
+// each caller can surface the right `E2eError` kind. They keep the divergence
+// in *which malformed inputs are rejected* from leaking past the wire/handshake
+// boundary (valid messages always decode identically).
+
+/** Single shared UTF-8 encoder (avoids a `new TextEncoder()` per module). */
+export const utf8 = new TextEncoder();
+
+// Standard base64 with canonical padding; url-safe base64 with no padding.
+const STD_B64 = /^[A-Za-z0-9+/]*={0,2}$/;
+const URL_B64 = /^[A-Za-z0-9_-]*$/;
+
+/** Strict standard-base64 decode (the message wire format). `null` if invalid. */
+export function tryDecodeStdBase64(s: string): Uint8Array | null {
+  if (s.length % 4 !== 0 || !STD_B64.test(s)) return null;
+  return new Uint8Array(Buffer.from(s, 'base64'));
+}
+
+/** Strict url-safe-no-pad base64 decode (handshake fields). `null` if invalid. */
+export function tryDecodeUrlBase64(s: string): Uint8Array | null {
+  // A trailing single base64 char (len % 4 === 1) can never be valid.
+  if (s.length % 4 === 1 || !URL_B64.test(s)) return null;
+  return new Uint8Array(Buffer.from(s, 'base64url'));
+}
+
+/**
+ * Parse a canonical unsigned decimal integer. Returns `null` for non-canonical
+ * forms that `Number()` would otherwise accept (hex `0xa`, exponent `1e0`,
+ * decimal `1.0`, leading sign) or values beyond the safe-integer range. This
+ * matches Rust's typed integer parse, which rejects all of the above.
+ */
+export function parseUintStrict(s: string): number | null {
+  if (!/^\d+$/.test(s)) return null;
+  const n = Number(s);
+  return Number.isSafeInteger(n) ? n : null;
+}

--- a/server/services/e2e/errors.ts
+++ b/server/services/e2e/errors.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Error taxonomy for the RPE2E crypto core. Mirrors the variants of
+// repartee's `E2eError` (Rust) so failures map cleanly across the two
+// implementations and callers can branch on `kind` without string-matching.
+
+export type E2eErrorKind = 'wire' | 'handshake' | 'crypto' | 'chunk-limit' | 'keyring';
+
+export class E2eError extends Error {
+  readonly kind: E2eErrorKind;
+
+  constructor(kind: E2eErrorKind, message: string) {
+    super(message);
+    this.name = 'E2eError';
+    this.kind = kind;
+  }
+}
+
+export const wireError = (msg: string): E2eError => new E2eError('wire', msg);
+export const handshakeError = (msg: string): E2eError => new E2eError('handshake', msg);
+export const cryptoError = (msg: string): E2eError => new E2eError('crypto', msg);
+export const chunkLimitError = (count: number): E2eError =>
+  new E2eError('chunk-limit', `too many chunks: ${count}`);

--- a/server/services/e2e/fingerprint.test.ts
+++ b/server/services/e2e/fingerprint.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import { fingerprint, fingerprintHex, fingerprintWords, FP_LEN } from './fingerprint.js';
+
+describe('fingerprint', () => {
+  it('is 16 bytes', () => {
+    expect(fingerprint(new Uint8Array(32)).length).toBe(FP_LEN);
+  });
+
+  it('is deterministic', () => {
+    const pk = new Uint8Array(32).fill(42);
+    expect(fingerprint(pk)).toEqual(fingerprint(pk));
+  });
+
+  it('is domain-separated (not a raw SHA-256 of the key)', () => {
+    const pk = new Uint8Array(32).fill(7);
+    const raw = sha256(pk).subarray(0, 16);
+    expect(fingerprint(pk)).not.toEqual(raw);
+  });
+
+  it('renders lowercase hex', () => {
+    expect(fingerprintHex(new Uint8Array([0xab, 0xcd]))).toBe('abcd');
+  });
+});
+
+describe('fingerprintWords (BIP-39 SAS)', () => {
+  it('produces exactly 6 words', () => {
+    expect(fingerprintWords(new Uint8Array(16).fill(0xab)).split(' ').length).toBe(6);
+  });
+
+  it('is deterministic', () => {
+    const fp = new Uint8Array(16).fill(0xcd);
+    expect(fingerprintWords(fp)).toBe(fingerprintWords(fp));
+  });
+
+  // BIP-39 known-answer test: 16 zero bytes is the canonical all-zero entropy
+  // whose English mnemonic begins "abandon abandon ... about". This pins our
+  // wordlist + checksum to the standard, hence to repartee's bip39 crate.
+  it('matches the BIP-39 standard wordlist (zero-entropy KAT)', () => {
+    expect(fingerprintWords(new Uint8Array(16))).toBe(
+      'abandon abandon abandon abandon abandon abandon',
+    );
+  });
+});

--- a/server/services/e2e/fingerprint.ts
+++ b/server/services/e2e/fingerprint.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Identity fingerprint + human-readable verification string (SAS).
+//
+// fingerprint = SHA-256("RPE2E01-FP:" || pubkey)[..16]   (domain-separated)
+// SAS         = first 6 words of the BIP-39 English mnemonic of those 16 bytes
+//
+// The domain-separation prefix means the fingerprint is not a raw SHA-256 of
+// the key, and the SAS gives users six dictionary words to read aloud when
+// verifying a peer out-of-band. Both derivations match repartee exactly.
+
+import { sha256 } from '@noble/hashes/sha2.js';
+import { entropyToMnemonic } from '@scure/bip39';
+import { wordlist as englishWordlist } from '@scure/bip39/wordlists/english.js';
+
+import { FP_PREFIX } from './constants.js';
+
+export const FP_LEN = 16;
+
+const utf8 = new TextEncoder();
+
+/** 16-byte truncated, domain-separated SHA-256 of an Ed25519 public key. */
+export function fingerprint(pubkey: Uint8Array): Uint8Array {
+  const input = new Uint8Array(FP_PREFIX.length + pubkey.length);
+  input.set(utf8.encode(FP_PREFIX), 0);
+  input.set(pubkey, FP_PREFIX.length);
+  return sha256(input).subarray(0, FP_LEN);
+}
+
+/** Lowercase-hex rendering of a fingerprint. */
+export function fingerprintHex(fp: Uint8Array): string {
+  return Buffer.from(fp).toString('hex');
+}
+
+/**
+ * Six-word BIP-39 SAS for a 16-byte fingerprint. The 16 bytes are encoded as a
+ * standard 12-word English mnemonic; we keep the first 6 words for a compact
+ * string to read aloud during verification.
+ */
+export function fingerprintWords(fp: Uint8Array): string {
+  const mnemonic = entropyToMnemonic(fp, englishWordlist);
+  return mnemonic.split(' ').slice(0, 6).join(' ');
+}

--- a/server/services/e2e/fingerprint.ts
+++ b/server/services/e2e/fingerprint.ts
@@ -15,10 +15,9 @@ import { entropyToMnemonic } from '@scure/bip39';
 import { wordlist as englishWordlist } from '@scure/bip39/wordlists/english.js';
 
 import { FP_PREFIX } from './constants.js';
+import { utf8 } from './encoding.js';
 
 export const FP_LEN = 16;
-
-const utf8 = new TextEncoder();
 
 /** 16-byte truncated, domain-separated SHA-256 of an Ed25519 public key. */
 export function fingerprint(pubkey: Uint8Array): Uint8Array {

--- a/server/services/e2e/handshake.test.ts
+++ b/server/services/e2e/handshake.test.ts
@@ -107,6 +107,11 @@ describe('handshake codec', () => {
     expect(() => parseHandshake(line)).toThrow(/invalid base64/);
   });
 
+  it('fails fast on a wrong-length field at encode time', () => {
+    expect(() => encodeKeyReq({ ...sampleReq(), pubkey: fill(16, 1) })).toThrow(/p: expected 32/);
+    expect(() => encodeKeyRsp({ ...sampleRsp(), sig: fill(10, 1) })).toThrow(/s: expected 64/);
+  });
+
   it('binds the ephemeral X25519 into the KEYREQ signed payload', () => {
     const p1 = sigPayloadKeyReq('#x', fill(32, 1), fill(32, 9), fill(16, 2));
     const p2 = sigPayloadKeyReq('#x', fill(32, 1), fill(32, 8), fill(16, 2));

--- a/server/services/e2e/handshake.test.ts
+++ b/server/services/e2e/handshake.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  encodeKeyRekey,
+  encodeKeyReq,
+  encodeKeyRsp,
+  type KeyRekey,
+  type KeyReq,
+  type KeyRsp,
+  parseHandshake,
+  sigPayloadKeyRekey,
+  sigPayloadKeyReq,
+} from './handshake.js';
+
+const fill = (n: number, b: number) => new Uint8Array(n).fill(b);
+const b64 = (bytes: Uint8Array) => Buffer.from(bytes).toString('base64url');
+
+function sampleReq(): KeyReq {
+  return {
+    channel: '#x',
+    pubkey: fill(32, 1),
+    ephX25519: fill(32, 9),
+    nonce: fill(16, 2),
+    sig: fill(64, 3),
+  };
+}
+function sampleRsp(): KeyRsp {
+  return {
+    channel: '#x',
+    pubkey: fill(32, 12),
+    ephemeralPub: fill(32, 4),
+    wrapNonce: fill(24, 5),
+    wrapCt: new Uint8Array([6, 7, 8, 9]),
+    nonce: fill(16, 10),
+    sig: fill(64, 11),
+  };
+}
+function sampleRekey(): KeyRekey {
+  return {
+    channel: '#x',
+    pubkey: fill(32, 13),
+    ephPub: fill(32, 14),
+    wrapNonce: fill(24, 15),
+    wrapCt: new Uint8Array([16, 17, 18, 19, 20]),
+    nonce: fill(16, 21),
+    sig: fill(64, 22),
+  };
+}
+
+describe('handshake codec', () => {
+  it('round-trips KEYREQ', () => {
+    const parsed = parseHandshake(encodeKeyReq(sampleReq()));
+    expect(parsed).toEqual({ kind: 'KEYREQ', msg: sampleReq() });
+  });
+
+  it('round-trips KEYRSP', () => {
+    const parsed = parseHandshake(encodeKeyRsp(sampleRsp()));
+    expect(parsed).toEqual({ kind: 'KEYRSP', msg: sampleRsp() });
+  });
+
+  it('round-trips REKEY', () => {
+    const parsed = parseHandshake(encodeKeyRekey(sampleRekey()));
+    expect(parsed).toEqual({ kind: 'REKEY', msg: sampleRekey() });
+  });
+
+  it('returns null for a non-RPEE2E body', () => {
+    expect(parseHandshake('SOMETHING ELSE')).toBeNull();
+    expect(parseHandshake('')).toBeNull();
+  });
+
+  it('rejects a duplicate key (would let a crafted body shift the channel)', () => {
+    const line =
+      `RPEE2E KEYREQ v=1 c=#a c=#b p=${b64(fill(32, 0))} e=${b64(fill(32, 0))} ` +
+      `n=${b64(fill(16, 0))} s=${b64(fill(64, 0))}`;
+    expect(() => parseHandshake(line)).toThrow(/duplicate key: c/);
+  });
+
+  it('rejects a duplicate wrap field in KEYRSP', () => {
+    const line =
+      `RPEE2E KEYRSP v=1 c=#x p=${b64(fill(32, 0))} e=${b64(fill(32, 0))} ` +
+      `wn=${b64(fill(24, 0))} w=${b64(fill(4, 0))} w=${b64(fill(4, 1))} ` +
+      `n=${b64(fill(16, 0))} s=${b64(fill(64, 0))}`;
+    expect(() => parseHandshake(line)).toThrow(/duplicate key: w/);
+  });
+
+  it('rejects an unsupported version', () => {
+    const line =
+      `RPEE2E KEYREQ v=9 c=#x p=${b64(fill(32, 0))} e=${b64(fill(32, 0))} ` +
+      `n=${b64(fill(16, 0))} s=${b64(fill(64, 0))}`;
+    expect(() => parseHandshake(line)).toThrow(/unsupported version/);
+  });
+
+  it('binds the ephemeral X25519 into the KEYREQ signed payload', () => {
+    const p1 = sigPayloadKeyReq('#x', fill(32, 1), fill(32, 9), fill(16, 2));
+    const p2 = sigPayloadKeyReq('#x', fill(32, 1), fill(32, 8), fill(16, 2));
+    expect(p1).not.toEqual(p2);
+  });
+
+  it('binds the ephemeral and ciphertext into the REKEY signed payload', () => {
+    const base = sigPayloadKeyRekey(
+      '#x',
+      fill(32, 1),
+      fill(32, 2),
+      fill(24, 3),
+      new Uint8Array([4, 5]),
+      fill(16, 6),
+    );
+    const diffEph = sigPayloadKeyRekey(
+      '#x',
+      fill(32, 1),
+      fill(32, 9),
+      fill(24, 3),
+      new Uint8Array([4, 5]),
+      fill(16, 6),
+    );
+    const diffCt = sigPayloadKeyRekey(
+      '#x',
+      fill(32, 1),
+      fill(32, 2),
+      fill(24, 3),
+      new Uint8Array([4, 6]),
+      fill(16, 6),
+    );
+    expect(base).not.toEqual(diffEph);
+    expect(base).not.toEqual(diffCt);
+  });
+
+  it('KEYRSP fits under the 512-byte IRC line limit even with a long prefix', () => {
+    const rsp: KeyRsp = { ...sampleRsp(), channel: '#irc.al', wrapCt: fill(48, 6) };
+    const body = `\x01${encodeKeyRsp(rsp)}\x01`;
+    const prefix = ':nick!^prostatut@2a14:7584:44e4:7af6:c219:38d4:e5b7:1c63 NOTICE kofany_ :';
+    expect(`${prefix}${body}\r\n`.length).toBeLessThanOrEqual(512);
+  });
+});

--- a/server/services/e2e/handshake.test.ts
+++ b/server/services/e2e/handshake.test.ts
@@ -93,6 +93,20 @@ describe('handshake codec', () => {
     expect(() => parseHandshake(line)).toThrow(/unsupported version/);
   });
 
+  it('rejects a non-canonical version that Number() would accept (1.0)', () => {
+    const line =
+      `RPEE2E KEYREQ v=1.0 c=#x p=${b64(fill(32, 0))} e=${b64(fill(32, 0))} ` +
+      `n=${b64(fill(16, 0))} s=${b64(fill(64, 0))}`;
+    expect(() => parseHandshake(line)).toThrow(/bad v/);
+  });
+
+  it('rejects invalid base64 in a field', () => {
+    const line =
+      `RPEE2E KEYREQ v=1 c=#x p=not*valid*b64 e=${b64(fill(32, 0))} ` +
+      `n=${b64(fill(16, 0))} s=${b64(fill(64, 0))}`;
+    expect(() => parseHandshake(line)).toThrow(/invalid base64/);
+  });
+
   it('binds the ephemeral X25519 into the KEYREQ signed payload', () => {
     const p1 = sigPayloadKeyReq('#x', fill(32, 1), fill(32, 9), fill(16, 2));
     const p2 = sigPayloadKeyReq('#x', fill(32, 1), fill(32, 8), fill(16, 2));

--- a/server/services/e2e/handshake.ts
+++ b/server/services/e2e/handshake.ts
@@ -128,9 +128,21 @@ function b64Fixed(s: string, n: number, field: string): Uint8Array {
   return raw;
 }
 
+/** Fail fast if an encode field is the wrong size — a public wire codec should
+ *  never silently serialize a non-interoperable handshake line. */
+function assertLen(bytes: Uint8Array, n: number, field: string): void {
+  if (bytes.length !== n) {
+    throw handshakeError(`${field}: expected ${n} bytes, got ${bytes.length}`);
+  }
+}
+
 // ─── encode ──────────────────────────────────────────────────────────────────
 
 export function encodeKeyReq(req: KeyReq): string {
+  assertLen(req.pubkey, 32, 'p');
+  assertLen(req.ephX25519, 32, 'e');
+  assertLen(req.nonce, 16, 'n');
+  assertLen(req.sig, 64, 's');
   return (
     `${CTCP_TAG} KEYREQ v=${PROTO_VERSION} c=${req.channel} ` +
     `p=${b64(req.pubkey)} e=${b64(req.ephX25519)} n=${b64(req.nonce)} s=${b64(req.sig)}`
@@ -138,6 +150,11 @@ export function encodeKeyReq(req: KeyReq): string {
 }
 
 export function encodeKeyRsp(rsp: KeyRsp): string {
+  assertLen(rsp.pubkey, 32, 'p');
+  assertLen(rsp.ephemeralPub, 32, 'e');
+  assertLen(rsp.wrapNonce, NONCE_LEN, 'wn');
+  assertLen(rsp.nonce, 16, 'n');
+  assertLen(rsp.sig, 64, 's');
   return (
     `${CTCP_TAG} KEYRSP v=${PROTO_VERSION} c=${rsp.channel} ` +
     `p=${b64(rsp.pubkey)} e=${b64(rsp.ephemeralPub)} wn=${b64(rsp.wrapNonce)} ` +
@@ -146,6 +163,11 @@ export function encodeKeyRsp(rsp: KeyRsp): string {
 }
 
 export function encodeKeyRekey(rk: KeyRekey): string {
+  assertLen(rk.pubkey, 32, 'p');
+  assertLen(rk.ephPub, 32, 'e');
+  assertLen(rk.wrapNonce, NONCE_LEN, 'wn');
+  assertLen(rk.nonce, 16, 'n');
+  assertLen(rk.sig, 64, 's');
   return (
     `${CTCP_TAG} REKEY v=${PROTO_VERSION} c=${rk.channel} ` +
     `p=${b64(rk.pubkey)} e=${b64(rk.ephPub)} wn=${b64(rk.wrapNonce)} ` +
@@ -226,7 +248,14 @@ export function parseHandshake(body: string): HandshakeMsg | null {
   }
 }
 
-/** Parse `k=v` fields, rejecting any duplicate key. */
+/**
+ * Parse `k=v` fields, rejecting any duplicate key. The duplicate-key error is
+ * intentionally `wireError` (kind `'wire'`), not `handshakeError`, to mirror
+ * repartee's `parse_kv`, which returns `E2eError::Wire` here — a structural
+ * key/value parse failure, conceptually shared with the chunk parser. Keeping
+ * the kind aligned with the reference is deliberate; do not "fix" it to
+ * `'handshake'`.
+ */
 function parseKv(fields: string[]): Map<string, string> {
   const out = new Map<string, string>();
   for (const f of fields) {

--- a/server/services/e2e/handshake.ts
+++ b/server/services/e2e/handshake.ts
@@ -15,9 +15,16 @@
 // the sender's long-term Ed25519 identity; `e` is an ephemeral X25519 public.
 // The ephemeral is bound into the signature so a MitM cannot swap it without
 // breaking the Ed25519 signature.
+//
+// NOTE: repartee's handshake rate limiter (handshake.rs §5.4 — 3 incoming
+// KEYREQ/min then a 5-minute backoff, 30s outgoing gap) is intentionally NOT
+// here. It is stateful manager-layer policy; this module is the pure wire codec
+// per index.ts. It MUST be implemented in the manager layer before E2E goes
+// live, since it gates the expensive Ed25519 verify against KEYREQ floods.
 
 import { NONCE_LEN } from './aead.js';
 import { CTCP_TAG, PROTO_VERSION } from './constants.js';
+import { parseUintStrict, tryDecodeUrlBase64, utf8 } from './encoding.js';
 import { handshakeError, wireError } from './errors.js';
 
 export interface KeyReq {
@@ -55,11 +62,16 @@ export type HandshakeMsg =
 
 // ─── canonical signed payloads ───────────────────────────────────────────────
 
-const utf8 = new TextEncoder();
 const COLON = Uint8Array.of(0x3a);
 
-function joinBytes(parts: Uint8Array[]): Uint8Array {
-  return Uint8Array.from(Buffer.concat(parts));
+// `<LABEL>:` || channel || (':' || part) for each part. One builder for all
+// three message types — the KEYRSP and REKEY layouts are byte-identical but for
+// the label, so a single source keeps them from silently drifting apart from
+// the reference (and thus producing signatures that no longer verify).
+function buildSigPayload(label: string, channel: string, ...parts: Uint8Array[]): Uint8Array {
+  const chunks: Uint8Array[] = [utf8.encode(`${label}:`), utf8.encode(channel)];
+  for (const p of parts) chunks.push(COLON, p);
+  return Buffer.concat(chunks);
 }
 
 /** `"KEYREQ:" || channel || ':' || pubkey || ':' || eph_x25519 || ':' || nonce` */
@@ -69,16 +81,7 @@ export function sigPayloadKeyReq(
   ephX25519: Uint8Array,
   nonce: Uint8Array,
 ): Uint8Array {
-  return joinBytes([
-    utf8.encode('KEYREQ:'),
-    utf8.encode(channel),
-    COLON,
-    pubkey,
-    COLON,
-    ephX25519,
-    COLON,
-    nonce,
-  ]);
+  return buildSigPayload('KEYREQ', channel, pubkey, ephX25519, nonce);
 }
 
 /** `"KEYRSP:" || channel || ':' || pubkey || ':' || eph_pub || ':' || wrap_nonce || ':' || wrap_ct || ':' || nonce` */
@@ -90,20 +93,7 @@ export function sigPayloadKeyRsp(
   wrapCt: Uint8Array,
   nonce: Uint8Array,
 ): Uint8Array {
-  return joinBytes([
-    utf8.encode('KEYRSP:'),
-    utf8.encode(channel),
-    COLON,
-    pubkey,
-    COLON,
-    ephPub,
-    COLON,
-    wrapNonce,
-    COLON,
-    wrapCt,
-    COLON,
-    nonce,
-  ]);
+  return buildSigPayload('KEYRSP', channel, pubkey, ephPub, wrapNonce, wrapCt, nonce);
 }
 
 /** `"REKEY:" || channel || ':' || pubkey || ':' || eph_pub || ':' || wrap_nonce || ':' || wrap_ct || ':' || nonce` */
@@ -115,20 +105,7 @@ export function sigPayloadKeyRekey(
   wrapCt: Uint8Array,
   nonce: Uint8Array,
 ): Uint8Array {
-  return joinBytes([
-    utf8.encode('REKEY:'),
-    utf8.encode(channel),
-    COLON,
-    pubkey,
-    COLON,
-    ephPub,
-    COLON,
-    wrapNonce,
-    COLON,
-    wrapCt,
-    COLON,
-    nonce,
-  ]);
+  return buildSigPayload('REKEY', channel, pubkey, ephPub, wrapNonce, wrapCt, nonce);
 }
 
 // ─── base64url helpers ───────────────────────────────────────────────────────
@@ -137,12 +114,14 @@ function b64(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString('base64url');
 }
 
-function b64Decode(s: string): Uint8Array {
-  return new Uint8Array(Buffer.from(s, 'base64url'));
+function b64Decode(s: string, field: string): Uint8Array {
+  const raw = tryDecodeUrlBase64(s);
+  if (!raw) throw handshakeError(`${field}: invalid base64`);
+  return raw;
 }
 
 function b64Fixed(s: string, n: number, field: string): Uint8Array {
-  const raw = b64Decode(s);
+  const raw = b64Decode(s, field);
   if (raw.length !== n) {
     throw handshakeError(`${field}: expected ${n} bytes, got ${raw.length}`);
   }
@@ -194,8 +173,8 @@ export function parseHandshake(body: string): HandshakeMsg | null {
 
   const vStr = kv.get('v');
   if (vStr === undefined) throw handshakeError('missing v');
-  const v = Number(vStr);
-  if (!Number.isInteger(v)) throw handshakeError(`bad v: ${vStr}`);
+  const v = parseUintStrict(vStr);
+  if (v === null) throw handshakeError(`bad v: ${vStr}`);
   if (v !== PROTO_VERSION) throw handshakeError(`unsupported version ${v}`);
 
   const get = (key: string): string => {
@@ -224,7 +203,7 @@ export function parseHandshake(body: string): HandshakeMsg | null {
           pubkey: b64Fixed(get('p'), 32, 'p'),
           ephemeralPub: b64Fixed(get('e'), 32, 'e'),
           wrapNonce: b64Fixed(get('wn'), NONCE_LEN, 'wn'),
-          wrapCt: b64Decode(get('w')),
+          wrapCt: b64Decode(get('w'), 'w'),
           nonce: b64Fixed(get('n'), 16, 'n'),
           sig: b64Fixed(get('s'), 64, 's'),
         },
@@ -237,7 +216,7 @@ export function parseHandshake(body: string): HandshakeMsg | null {
           pubkey: b64Fixed(get('p'), 32, 'p'),
           ephPub: b64Fixed(get('e'), 32, 'e'),
           wrapNonce: b64Fixed(get('wn'), NONCE_LEN, 'wn'),
-          wrapCt: b64Decode(get('w')),
+          wrapCt: b64Decode(get('w'), 'w'),
           nonce: b64Fixed(get('n'), 16, 'n'),
           sig: b64Fixed(get('s'), 64, 's'),
         },

--- a/server/services/e2e/handshake.ts
+++ b/server/services/e2e/handshake.ts
@@ -1,0 +1,262 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// RPE2E CTCP handshake: KEYREQ / KEYRSP / REKEY encode + parse, plus the
+// canonical signed-payload builders.
+//
+// Wire form (inside the CTCP `\x01 ... \x01` framing, sent via NOTICE):
+//
+//   RPEE2E KEYREQ v=1 c=#x p=<b64u32> e=<b64u32> n=<b64u16> s=<b64u64>
+//   RPEE2E KEYRSP v=1 c=#x p=<b64u32> e=<b64u32> wn=<b64u24> w=<b64u> n=<b64u16> s=<b64u64>
+//   RPEE2E REKEY  v=1 c=#x p=<b64u32> e=<b64u32> wn=<b64u24> w=<b64u> n=<b64u16> s=<b64u64>
+//
+// All fields use URL-safe base64 WITHOUT padding (NOTE: the message wire format
+// in wire.ts uses standard base64 — the two are deliberately different). `p` is
+// the sender's long-term Ed25519 identity; `e` is an ephemeral X25519 public.
+// The ephemeral is bound into the signature so a MitM cannot swap it without
+// breaking the Ed25519 signature.
+
+import { NONCE_LEN } from './aead.js';
+import { CTCP_TAG, PROTO_VERSION } from './constants.js';
+import { handshakeError, wireError } from './errors.js';
+
+export interface KeyReq {
+  channel: string;
+  pubkey: Uint8Array; // 32 — initiator Ed25519 identity
+  ephX25519: Uint8Array; // 32 — initiator ephemeral X25519
+  nonce: Uint8Array; // 16 — anti-replay
+  sig: Uint8Array; // 64
+}
+
+export interface KeyRsp {
+  channel: string;
+  pubkey: Uint8Array; // 32 — responder Ed25519 identity
+  ephemeralPub: Uint8Array; // 32 — responder ephemeral X25519
+  wrapNonce: Uint8Array; // 24
+  wrapCt: Uint8Array; // variable — wrapped session key
+  nonce: Uint8Array; // 16
+  sig: Uint8Array; // 64
+}
+
+export interface KeyRekey {
+  channel: string;
+  pubkey: Uint8Array; // 32 — sender Ed25519 identity
+  ephPub: Uint8Array; // 32 — fresh ephemeral X25519
+  wrapNonce: Uint8Array; // 24
+  wrapCt: Uint8Array; // variable
+  nonce: Uint8Array; // 16
+  sig: Uint8Array; // 64
+}
+
+export type HandshakeMsg =
+  | { kind: 'KEYREQ'; msg: KeyReq }
+  | { kind: 'KEYRSP'; msg: KeyRsp }
+  | { kind: 'REKEY'; msg: KeyRekey };
+
+// ─── canonical signed payloads ───────────────────────────────────────────────
+
+const utf8 = new TextEncoder();
+const COLON = Uint8Array.of(0x3a);
+
+function joinBytes(parts: Uint8Array[]): Uint8Array {
+  return Uint8Array.from(Buffer.concat(parts));
+}
+
+/** `"KEYREQ:" || channel || ':' || pubkey || ':' || eph_x25519 || ':' || nonce` */
+export function sigPayloadKeyReq(
+  channel: string,
+  pubkey: Uint8Array,
+  ephX25519: Uint8Array,
+  nonce: Uint8Array,
+): Uint8Array {
+  return joinBytes([
+    utf8.encode('KEYREQ:'),
+    utf8.encode(channel),
+    COLON,
+    pubkey,
+    COLON,
+    ephX25519,
+    COLON,
+    nonce,
+  ]);
+}
+
+/** `"KEYRSP:" || channel || ':' || pubkey || ':' || eph_pub || ':' || wrap_nonce || ':' || wrap_ct || ':' || nonce` */
+export function sigPayloadKeyRsp(
+  channel: string,
+  pubkey: Uint8Array,
+  ephPub: Uint8Array,
+  wrapNonce: Uint8Array,
+  wrapCt: Uint8Array,
+  nonce: Uint8Array,
+): Uint8Array {
+  return joinBytes([
+    utf8.encode('KEYRSP:'),
+    utf8.encode(channel),
+    COLON,
+    pubkey,
+    COLON,
+    ephPub,
+    COLON,
+    wrapNonce,
+    COLON,
+    wrapCt,
+    COLON,
+    nonce,
+  ]);
+}
+
+/** `"REKEY:" || channel || ':' || pubkey || ':' || eph_pub || ':' || wrap_nonce || ':' || wrap_ct || ':' || nonce` */
+export function sigPayloadKeyRekey(
+  channel: string,
+  pubkey: Uint8Array,
+  ephPub: Uint8Array,
+  wrapNonce: Uint8Array,
+  wrapCt: Uint8Array,
+  nonce: Uint8Array,
+): Uint8Array {
+  return joinBytes([
+    utf8.encode('REKEY:'),
+    utf8.encode(channel),
+    COLON,
+    pubkey,
+    COLON,
+    ephPub,
+    COLON,
+    wrapNonce,
+    COLON,
+    wrapCt,
+    COLON,
+    nonce,
+  ]);
+}
+
+// ─── base64url helpers ───────────────────────────────────────────────────────
+
+function b64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64url');
+}
+
+function b64Decode(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, 'base64url'));
+}
+
+function b64Fixed(s: string, n: number, field: string): Uint8Array {
+  const raw = b64Decode(s);
+  if (raw.length !== n) {
+    throw handshakeError(`${field}: expected ${n} bytes, got ${raw.length}`);
+  }
+  return raw;
+}
+
+// ─── encode ──────────────────────────────────────────────────────────────────
+
+export function encodeKeyReq(req: KeyReq): string {
+  return (
+    `${CTCP_TAG} KEYREQ v=${PROTO_VERSION} c=${req.channel} ` +
+    `p=${b64(req.pubkey)} e=${b64(req.ephX25519)} n=${b64(req.nonce)} s=${b64(req.sig)}`
+  );
+}
+
+export function encodeKeyRsp(rsp: KeyRsp): string {
+  return (
+    `${CTCP_TAG} KEYRSP v=${PROTO_VERSION} c=${rsp.channel} ` +
+    `p=${b64(rsp.pubkey)} e=${b64(rsp.ephemeralPub)} wn=${b64(rsp.wrapNonce)} ` +
+    `w=${b64(rsp.wrapCt)} n=${b64(rsp.nonce)} s=${b64(rsp.sig)}`
+  );
+}
+
+export function encodeKeyRekey(rk: KeyRekey): string {
+  return (
+    `${CTCP_TAG} REKEY v=${PROTO_VERSION} c=${rk.channel} ` +
+    `p=${b64(rk.pubkey)} e=${b64(rk.ephPub)} wn=${b64(rk.wrapNonce)} ` +
+    `w=${b64(rk.wrapCt)} n=${b64(rk.nonce)} s=${b64(rk.sig)}`
+  );
+}
+
+// ─── parse ───────────────────────────────────────────────────────────────────
+
+/**
+ * Parse the body inside the `\x01...\x01` CTCP framing. Returns `null` when the
+ * body is not an RPEE2E message (so callers can fall through to other CTCP
+ * handling). Throws `E2eError` on a malformed/unsupported RPEE2E message.
+ *
+ * Duplicate keys are rejected outright: an ambiguous body like `c=#a c=#b`
+ * could otherwise shift the semantic channel of an already-signed message.
+ */
+export function parseHandshake(body: string): HandshakeMsg | null {
+  const parts = body.split(/\s+/).filter((p) => p.length > 0);
+  if (parts.length === 0 || parts[0] !== CTCP_TAG) return null;
+  if (parts.length < 2) throw handshakeError('missing type');
+  const kind = parts[1];
+
+  const kv = parseKv(parts.slice(2));
+
+  const vStr = kv.get('v');
+  if (vStr === undefined) throw handshakeError('missing v');
+  const v = Number(vStr);
+  if (!Number.isInteger(v)) throw handshakeError(`bad v: ${vStr}`);
+  if (v !== PROTO_VERSION) throw handshakeError(`unsupported version ${v}`);
+
+  const get = (key: string): string => {
+    const val = kv.get(key);
+    if (val === undefined) throw handshakeError(`missing field: ${key}`);
+    return val;
+  };
+
+  switch (kind) {
+    case 'KEYREQ':
+      return {
+        kind: 'KEYREQ',
+        msg: {
+          channel: get('c'),
+          pubkey: b64Fixed(get('p'), 32, 'p'),
+          ephX25519: b64Fixed(get('e'), 32, 'e'),
+          nonce: b64Fixed(get('n'), 16, 'n'),
+          sig: b64Fixed(get('s'), 64, 's'),
+        },
+      };
+    case 'KEYRSP':
+      return {
+        kind: 'KEYRSP',
+        msg: {
+          channel: get('c'),
+          pubkey: b64Fixed(get('p'), 32, 'p'),
+          ephemeralPub: b64Fixed(get('e'), 32, 'e'),
+          wrapNonce: b64Fixed(get('wn'), NONCE_LEN, 'wn'),
+          wrapCt: b64Decode(get('w')),
+          nonce: b64Fixed(get('n'), 16, 'n'),
+          sig: b64Fixed(get('s'), 64, 's'),
+        },
+      };
+    case 'REKEY':
+      return {
+        kind: 'REKEY',
+        msg: {
+          channel: get('c'),
+          pubkey: b64Fixed(get('p'), 32, 'p'),
+          ephPub: b64Fixed(get('e'), 32, 'e'),
+          wrapNonce: b64Fixed(get('wn'), NONCE_LEN, 'wn'),
+          wrapCt: b64Decode(get('w')),
+          nonce: b64Fixed(get('n'), 16, 'n'),
+          sig: b64Fixed(get('s'), 64, 's'),
+        },
+      };
+    default:
+      throw handshakeError(`unknown type ${kind}`);
+  }
+}
+
+/** Parse `k=v` fields, rejecting any duplicate key. */
+function parseKv(fields: string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const f of fields) {
+    const eq = f.indexOf('=');
+    if (eq < 0) continue;
+    const k = f.slice(0, eq);
+    const v = f.slice(eq + 1);
+    if (out.has(k)) throw wireError(`duplicate key: ${k}`);
+    out.set(k, v);
+  }
+  return out;
+}

--- a/server/services/e2e/identity.test.ts
+++ b/server/services/e2e/identity.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  generateIdentity,
+  identityFromSeed,
+  PUBLIC_LEN,
+  SECRET_LEN,
+  sign,
+  verify,
+} from './identity.js';
+
+const enc = new TextEncoder();
+
+describe('identity (Ed25519)', () => {
+  it('generates 32-byte secret and public keys', () => {
+    const id = generateIdentity();
+    expect(id.secretKey.length).toBe(SECRET_LEN);
+    expect(id.publicKey.length).toBe(PUBLIC_LEN);
+  });
+
+  it('derives a deterministic public key from a seed', () => {
+    const seed = new Uint8Array(32).fill(7);
+    expect(identityFromSeed(seed).publicKey).toEqual(identityFromSeed(seed).publicKey);
+  });
+
+  it('produces distinct public keys for distinct seeds', () => {
+    const a = identityFromSeed(new Uint8Array(32).fill(1));
+    const b = identityFromSeed(new Uint8Array(32).fill(2));
+    expect(a.publicKey).not.toEqual(b.publicKey);
+  });
+
+  it('signs and verifies a round-trip', () => {
+    const id = generateIdentity();
+    const msg = enc.encode('handshake payload');
+    expect(verify(id.publicKey, msg, sign(id.secretKey, msg))).toBe(true);
+  });
+
+  it('rejects a tampered message', () => {
+    const id = generateIdentity();
+    const sig = sign(id.secretKey, enc.encode('orig'));
+    expect(verify(id.publicKey, enc.encode('tampered'), sig)).toBe(false);
+  });
+
+  it('rejects a signature from the wrong key', () => {
+    const a = generateIdentity();
+    const b = generateIdentity();
+    const sig = sign(a.secretKey, enc.encode('msg'));
+    expect(verify(b.publicKey, enc.encode('msg'), sig)).toBe(false);
+  });
+});

--- a/server/services/e2e/identity.ts
+++ b/server/services/e2e/identity.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Long-term Ed25519 identity keypair, plus signature helpers for the
+// handshake. The secret is the raw 32-byte seed (NOT an expanded key), and
+// the public key is the 32-byte compressed point — the same serialization
+// repartee and libsodium-based peers use, so identities are portable.
+
+import { randomBytes } from 'node:crypto';
+import { ed25519 } from '@noble/curves/ed25519.js';
+
+import { cryptoError } from './errors.js';
+
+export const SECRET_LEN = 32;
+export const PUBLIC_LEN = 32;
+export const SIG_LEN = 64;
+
+export interface Identity {
+  /** 32-byte Ed25519 secret seed. */
+  secretKey: Uint8Array;
+  /** 32-byte Ed25519 public key. */
+  publicKey: Uint8Array;
+}
+
+/** Generate a fresh identity from the OS CSPRNG. */
+export function generateIdentity(): Identity {
+  return identityFromSeed(new Uint8Array(randomBytes(SECRET_LEN)));
+}
+
+/** Load an identity from a raw 32-byte secret seed. */
+export function identityFromSeed(seed: Uint8Array): Identity {
+  if (seed.length !== SECRET_LEN) {
+    throw cryptoError(`identity seed must be ${SECRET_LEN} bytes, got ${seed.length}`);
+  }
+  return { secretKey: seed, publicKey: ed25519.getPublicKey(seed) };
+}
+
+/** Sign `message` with an identity's secret key. Returns a 64-byte signature. */
+export function sign(secretKey: Uint8Array, message: Uint8Array): Uint8Array {
+  return ed25519.sign(message, secretKey);
+}
+
+/** Verify a 64-byte Ed25519 signature. Returns false on any failure. */
+export function verify(publicKey: Uint8Array, message: Uint8Array, sig: Uint8Array): boolean {
+  try {
+    return ed25519.verify(sig, message, publicKey);
+  } catch {
+    return false;
+  }
+}

--- a/server/services/e2e/identity.ts
+++ b/server/services/e2e/identity.ts
@@ -37,7 +37,14 @@ export function identityFromSeed(seed: Uint8Array): Identity {
 
 /** Sign `message` with an identity's secret key. Returns a 64-byte signature. */
 export function sign(secretKey: Uint8Array, message: Uint8Array): Uint8Array {
-  return ed25519.sign(message, secretKey);
+  if (secretKey.length !== SECRET_LEN) {
+    throw cryptoError(`secret key must be ${SECRET_LEN} bytes, got ${secretKey.length}`);
+  }
+  try {
+    return ed25519.sign(message, secretKey);
+  } catch (err) {
+    throw cryptoError(`sign: ${(err as Error).message}`);
+  }
 }
 
 /** Verify a 64-byte Ed25519 signature. Returns false on any failure. */

--- a/server/services/e2e/index.ts
+++ b/server/services/e2e/index.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// RPE2E — Repartee End-to-End encryption (v1.0), crypto core.
+//
+// A byte-compatible TypeScript port of repartee's RPE2E01 protocol primitives:
+// Ed25519 identities (TOFU-pinned), X25519 ECDH key-wrap, XChaCha20-Poly1305
+// message encryption, and the signed CTCP-NOTICE handshake codec. This module
+// is pure crypto + wire format — no IRC, DB, or UI wiring. See issue #382.
+//
+// Interop notes (load-bearing — see the per-module sources):
+//  - message wire format uses STANDARD base64; handshakes use URL-safe-no-pad.
+//  - AAD is length-prefixed big-endian; golden vector pinned in aad.test.ts.
+//  - HKDF-SHA256 salt is the constant "RPE2E01-WRAP".
+
+export * from './constants.js';
+export * from './errors.js';
+export * from './aad.js';
+export * from './aead.js';
+export * from './wire.js';
+export * from './chunker.js';
+export * from './identity.js';
+export * from './fingerprint.js';
+export * from './ecdh.js';
+export * from './handshake.js';
+export * from './context.js';

--- a/server/services/e2e/wire.test.ts
+++ b/server/services/e2e/wire.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { encodeChunk, freshMsgid, parseChunk, type WireChunk } from './wire.js';
+import { WIRE_PREFIX } from './constants.js';
+
+function sampleChunk(): WireChunk {
+  return {
+    msgid: new Uint8Array(8).fill(0xab),
+    ts: 1_712_000_000,
+    part: 1,
+    total: 1,
+    nonce: new Uint8Array(24).fill(0x42),
+    ciphertext: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+  };
+}
+
+describe('wire format', () => {
+  it('encodes with the RPE2E01 prefix', () => {
+    expect(encodeChunk(sampleChunk()).startsWith(WIRE_PREFIX)).toBe(true);
+  });
+
+  it('round-trips encode -> parse', () => {
+    const c = sampleChunk();
+    const parsed = parseChunk(encodeChunk(c));
+    expect(parsed).toEqual(c);
+  });
+
+  it('returns null for cleartext lines', () => {
+    expect(parseChunk('hello world')).toBeNull();
+    expect(parseChunk('')).toBeNull();
+  });
+
+  it('rejects invalid part/total on encode', () => {
+    expect(() => encodeChunk({ ...sampleChunk(), total: 0 })).toThrow(/invalid total/);
+    expect(() => encodeChunk({ ...sampleChunk(), total: 17 })).toThrow(/invalid total/);
+    expect(() => encodeChunk({ ...sampleChunk(), total: 3, part: 4 })).toThrow(
+      /invalid part\/total/,
+    );
+  });
+
+  it('rejects a bad nonce length on parse', () => {
+    // "YWJj" decodes to 3 bytes, not 24.
+    expect(() => parseChunk('+RPE2E01 abababababababab 1712000000 1/1 YWJj:ZGVm')).toThrow(
+      /nonce must be 24 bytes/,
+    );
+  });
+
+  it('rejects extra fields', () => {
+    const line = encodeChunk(sampleChunk()) + ' extra';
+    expect(() => parseChunk(line)).toThrow(/extra fields/);
+  });
+
+  it('uses standard base64 (padded) on the wire', () => {
+    // A 24-byte nonce base64-encodes to 32 chars with standard alphabet; the
+    // 4-byte ciphertext here pads with '='. Confirms STANDARD, not url-safe.
+    const line = encodeChunk(sampleChunk());
+    const body = line.split(' ').at(-1)!;
+    expect(body).toContain('=');
+  });
+
+  it('freshMsgid produces 8 random-ish bytes', () => {
+    const a = freshMsgid();
+    expect(a.length).toBe(8);
+    expect(a).not.toEqual(freshMsgid());
+  });
+});

--- a/server/services/e2e/wire.test.ts
+++ b/server/services/e2e/wire.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 
 import { encodeChunk, freshMsgid, parseChunk, type WireChunk } from './wire.js';
 import { WIRE_PREFIX } from './constants.js';
+import { E2eError } from './errors.js';
 
 function sampleChunk(): WireChunk {
   return {
@@ -33,11 +34,31 @@ describe('wire format', () => {
     expect(parseChunk('')).toBeNull();
   });
 
-  it('rejects invalid part/total on encode', () => {
-    expect(() => encodeChunk({ ...sampleChunk(), total: 0 })).toThrow(/invalid total/);
-    expect(() => encodeChunk({ ...sampleChunk(), total: 17 })).toThrow(/invalid total/);
+  it('rejects an out-of-range total as a chunk-limit error (encode)', () => {
+    for (const total of [0, 17]) {
+      let caught: unknown;
+      try {
+        encodeChunk({ ...sampleChunk(), total });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(E2eError);
+      expect((caught as E2eError).kind).toBe('chunk-limit');
+    }
+  });
+
+  it('rejects an invalid part/total relationship (encode)', () => {
     expect(() => encodeChunk({ ...sampleChunk(), total: 3, part: 4 })).toThrow(
       /invalid part\/total/,
+    );
+  });
+
+  it('rejects a wrong-length msgid or nonce (encode)', () => {
+    expect(() => encodeChunk({ ...sampleChunk(), msgid: new Uint8Array(5) })).toThrow(
+      /msgid must be/,
+    );
+    expect(() => encodeChunk({ ...sampleChunk(), nonce: new Uint8Array(20) })).toThrow(
+      /nonce must be/,
     );
   });
 
@@ -51,6 +72,25 @@ describe('wire format', () => {
   it('rejects extra fields', () => {
     const line = encodeChunk(sampleChunk()) + ' extra';
     expect(() => parseChunk(line)).toThrow(/extra fields/);
+  });
+
+  it('rejects a ts that cannot be represented exactly (>2^53)', () => {
+    // Number('9007199254740993') silently rounds to ...992 — reject instead of
+    // round-tripping a ts that would break the reconstructed AAD.
+    const line = encodeChunk(sampleChunk()).replace(' 1712000000 ', ' 9007199254740993 ');
+    expect(() => parseChunk(line)).toThrow(/ts out of range/);
+  });
+
+  it('rejects non-canonical part/total that Number() would accept', () => {
+    const line = encodeChunk(sampleChunk()).replace(' 1/1 ', ' 0x1/0x1 ');
+    expect(() => parseChunk(line)).toThrow(/bad part\/total/);
+  });
+
+  it('rejects invalid base64 in the ciphertext field', () => {
+    const line = encodeChunk(sampleChunk());
+    expect(() => parseChunk(line.replace(/:[^:]*$/, ':not*valid*b64'))).toThrow(
+      /invalid ciphertext base64/,
+    );
   });
 
   it('uses standard base64 (padded) on the wire', () => {

--- a/server/services/e2e/wire.ts
+++ b/server/services/e2e/wire.ts
@@ -7,14 +7,18 @@
 // immediately, with no reassembly state. The nonce and ciphertext use STANDARD
 // base64 (with padding) — NOTE this differs from the handshake messages, which
 // use URL-safe-no-pad. `msgid` is 8 random bytes, lowercase-hex on the wire.
+//
+// Rust gets length/range invariants for free from its fixed-size array types
+// (`[u8;8]`, `[u8;24]`); this port re-establishes them with explicit guards so
+// malformed/oversize input is rejected as `E2eError` rather than producing a
+// silently-malformed line or escaping as a raw RangeError.
 
 import { randomBytes } from 'node:crypto';
 
-import { MAX_CHUNKS, WIRE_PREFIX } from './constants.js';
-import { wireError } from './errors.js';
-
-export const MSGID_LEN = 8;
-const NONCE_LEN = 24;
+import { NONCE_LEN } from './aead.js';
+import { MAX_CHUNKS, MSGID_LEN, WIRE_PREFIX } from './constants.js';
+import { parseUintStrict, tryDecodeStdBase64 } from './encoding.js';
+import { chunkLimitError, wireError } from './errors.js';
 
 export interface WireChunk {
   /** 8-byte message id, shared across all chunks of one logical message. */
@@ -34,12 +38,17 @@ export interface WireChunk {
 /** Serialize a chunk into a single IRC-safe line (no trailing newline). */
 export function encodeChunk(chunk: WireChunk): string {
   const { msgid, ts, part, total, nonce, ciphertext } = chunk;
-  if (total === 0 || total > MAX_CHUNKS) {
-    throw wireError(`invalid total: ${total}`);
+  if (msgid.length !== MSGID_LEN) {
+    throw wireError(`msgid must be ${MSGID_LEN} bytes, got ${msgid.length}`);
   }
-  if (part === 0 || part > total) {
-    throw wireError(`invalid part/total: ${part}/${total}`);
+  if (nonce.length !== NONCE_LEN) {
+    throw wireError(`nonce must be ${NONCE_LEN} bytes, got ${nonce.length}`);
   }
+  // total out of range is a chunk-limit condition (matches repartee's
+  // ChunkLimit), distinct from an invalid part/total relationship.
+  if (total === 0 || total > MAX_CHUNKS) throw chunkLimitError(total);
+  if (part === 0 || part > total) throw wireError(`invalid part/total: ${part}/${total}`);
+
   const msgidHex = Buffer.from(msgid).toString('hex');
   const nonceB64 = Buffer.from(nonce).toString('base64');
   const ctB64 = Buffer.from(ciphertext).toString('base64');
@@ -64,16 +73,19 @@ export function parseChunk(line: string): WireChunk | null {
   }
   const msgid = new Uint8Array(Buffer.from(msgidHex, 'hex'));
 
+  // i64 on the wire; reject anything we can't represent exactly (a >2^53 ts
+  // would silently lose precision and break the reconstructed AAD).
   if (!/^-?\d+$/.test(tsStr)) throw wireError(`bad ts: ${tsStr}`);
   const ts = Number(tsStr);
+  if (!Number.isSafeInteger(ts)) throw wireError(`ts out of range: ${tsStr}`);
 
   const slash = partTot.indexOf('/');
   if (slash < 0) throw wireError('part/total missing slash');
-  const part = Number(partTot.slice(0, slash));
-  const total = Number(partTot.slice(slash + 1));
+  const part = parseUintStrict(partTot.slice(0, slash));
+  const total = parseUintStrict(partTot.slice(slash + 1));
   if (
-    !Number.isInteger(part) ||
-    !Number.isInteger(total) ||
+    part === null ||
+    total === null ||
     total === 0 ||
     total > MAX_CHUNKS ||
     part === 0 ||
@@ -84,11 +96,12 @@ export function parseChunk(line: string): WireChunk | null {
 
   const colon = body.indexOf(':');
   if (colon < 0) throw wireError('missing nonce:ct separator');
-  const nonce = new Uint8Array(Buffer.from(body.slice(0, colon), 'base64'));
-  if (nonce.length !== NONCE_LEN) {
-    throw wireError(`nonce must be 24 bytes, got ${nonce.length}`);
+  const nonce = tryDecodeStdBase64(body.slice(0, colon));
+  if (!nonce || nonce.length !== NONCE_LEN) {
+    throw wireError(`nonce must be ${NONCE_LEN} bytes, got ${nonce?.length ?? 'invalid base64'}`);
   }
-  const ciphertext = new Uint8Array(Buffer.from(body.slice(colon + 1), 'base64'));
+  const ciphertext = tryDecodeStdBase64(body.slice(colon + 1));
+  if (!ciphertext) throw wireError('invalid ciphertext base64');
 
   return { msgid, ts, part, total, nonce, ciphertext };
 }

--- a/server/services/e2e/wire.ts
+++ b/server/services/e2e/wire.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// RPE2E01 wire format: encode/parse `+RPE2E01 <msgid> <ts> <part>/<total> <nonce_b64>:<ct_b64>`.
+//
+// Each chunk is a standalone cryptographic unit — receivers decrypt and render
+// immediately, with no reassembly state. The nonce and ciphertext use STANDARD
+// base64 (with padding) — NOTE this differs from the handshake messages, which
+// use URL-safe-no-pad. `msgid` is 8 random bytes, lowercase-hex on the wire.
+
+import { randomBytes } from 'node:crypto';
+
+import { MAX_CHUNKS, WIRE_PREFIX } from './constants.js';
+import { wireError } from './errors.js';
+
+export const MSGID_LEN = 8;
+const NONCE_LEN = 24;
+
+export interface WireChunk {
+  /** 8-byte message id, shared across all chunks of one logical message. */
+  msgid: Uint8Array;
+  /** Unix seconds (i64 on the wire / in the AAD). */
+  ts: number;
+  /** 1-indexed chunk number. */
+  part: number;
+  /** Total chunk count (1..=16). */
+  total: number;
+  /** 24-byte XChaCha20 nonce. */
+  nonce: Uint8Array;
+  /** AEAD ciphertext (includes the Poly1305 tag). */
+  ciphertext: Uint8Array;
+}
+
+/** Serialize a chunk into a single IRC-safe line (no trailing newline). */
+export function encodeChunk(chunk: WireChunk): string {
+  const { msgid, ts, part, total, nonce, ciphertext } = chunk;
+  if (total === 0 || total > MAX_CHUNKS) {
+    throw wireError(`invalid total: ${total}`);
+  }
+  if (part === 0 || part > total) {
+    throw wireError(`invalid part/total: ${part}/${total}`);
+  }
+  const msgidHex = Buffer.from(msgid).toString('hex');
+  const nonceB64 = Buffer.from(nonce).toString('base64');
+  const ctB64 = Buffer.from(ciphertext).toString('base64');
+  return `${WIRE_PREFIX} ${msgidHex} ${ts} ${part}/${total} ${nonceB64}:${ctB64}`;
+}
+
+/**
+ * Parse an incoming line. Returns `null` if it is not an RPE2E01 chunk (i.e.
+ * cleartext), or throws `E2eError('wire')` if it is malformed.
+ */
+export function parseChunk(line: string): WireChunk | null {
+  if (!line.startsWith(WIRE_PREFIX)) return null;
+  const rest = line.slice(WIRE_PREFIX.length);
+  const fields = rest.split(/\s+/).filter((f) => f.length > 0);
+  if (fields.length !== 4) {
+    throw wireError(fields.length < 4 ? 'missing fields' : 'extra fields');
+  }
+  const [msgidHex, tsStr, partTot, body] = fields;
+
+  if (msgidHex.length !== MSGID_LEN * 2 || !/^[0-9a-fA-F]+$/.test(msgidHex)) {
+    throw wireError('msgid must be 16 hex chars');
+  }
+  const msgid = new Uint8Array(Buffer.from(msgidHex, 'hex'));
+
+  if (!/^-?\d+$/.test(tsStr)) throw wireError(`bad ts: ${tsStr}`);
+  const ts = Number(tsStr);
+
+  const slash = partTot.indexOf('/');
+  if (slash < 0) throw wireError('part/total missing slash');
+  const part = Number(partTot.slice(0, slash));
+  const total = Number(partTot.slice(slash + 1));
+  if (
+    !Number.isInteger(part) ||
+    !Number.isInteger(total) ||
+    total === 0 ||
+    total > MAX_CHUNKS ||
+    part === 0 ||
+    part > total
+  ) {
+    throw wireError(`bad part/total ${partTot}`);
+  }
+
+  const colon = body.indexOf(':');
+  if (colon < 0) throw wireError('missing nonce:ct separator');
+  const nonce = new Uint8Array(Buffer.from(body.slice(0, colon), 'base64'));
+  if (nonce.length !== NONCE_LEN) {
+    throw wireError(`nonce must be 24 bytes, got ${nonce.length}`);
+  }
+  const ciphertext = new Uint8Array(Buffer.from(body.slice(colon + 1), 'base64'));
+
+  return { msgid, ts, part, total, nonce, ciphertext };
+}
+
+/** Generate a fresh 8-byte random message id. */
+export function freshMsgid(): Uint8Array {
+  return new Uint8Array(randomBytes(MSGID_LEN));
+}


### PR DESCRIPTION
## RPE2E crypto core (phase 0 of #382)

A byte-compatible TypeScript port of [repartee's RPE2E01](https://repart.ee/docs/rpe2e) end-to-end-encryption **primitives**, under `server/services/e2e/`. This is **pure crypto + wire format** — no IRC, DB, or UI wiring yet. It exists so the interop-load-bearing layer is locked down and independently testable before anything depends on it.

The architectural decision from the issue thread is assumed: **cell-side (model A)** — the cell holds keys and sees plaintext, so every Lurker feature (backlog, FTS, push, multi-device) survives and only the *IRC network* sees ciphertext. Not E2E vs. the hosted operator by design; we never market it as "we can't read your messages."

### What's here

| Module | Purpose |
|---|---|
| `constants` | protocol constants, HKDF salt/info builders, limits |
| `aad` | length-prefixed big-endian AAD |
| `aead` | XChaCha20-Poly1305 (`@noble/ciphers`), 24-byte random nonce |
| `wire` | `+RPE2E01` chunk encode/parse |
| `chunker` | UTF-8-safe stateless chunking (180 B × 16) |
| `identity` | Ed25519 gen / sign / verify (`@noble/curves`) |
| `fingerprint` | `SHA256("RPE2E01-FP:"‖pub)[..16]` + 6-word BIP-39 SAS (`@scure/bip39`) |
| `ecdh` | X25519 ECDH + HKDF-SHA256 wrap; Ed25519↔X25519 map |
| `handshake` | KEYREQ/KEYRSP/REKEY codec + canonical signed payloads |
| `context` | `@ident@host` DM pseudochannel rule |
| `encoding` / `errors` / `index` | shared utf8 + strict base64, typed `E2eError`, barrel |

Adds `@noble/{curves,hashes,ciphers}` and `@scure/bip39` — audited, zero-dep, browser-safe (keeps a future client-side "model B" reuse open).

### Interop is pinned, not assumed

Three tests are **cross-language golden vectors taken verbatim from the reference impl** — this is what makes it a *byte-compatible* port:
- the **40-byte AAD** sequence for `#chan`,
- the **RFC 8032 X25519** conversion (both key sides + the shared secret),
- the **BIP-39 zero-entropy KAT** pinning the wordlist + checksum.

⚠️ Two deliberately different base64 alphabets: **standard (padded)** on the message wire (`wire.ts`) vs. **URL-safe, no padding** in the handshake (`handshake.ts`). Mixing them silently breaks interop against repartee.

### Review hardening

An in-depth review confirmed valid messages interop byte-for-byte, and flagged that malformed/adversarial input wasn't honoring the `E2eError` contract (Rust's fixed-size array types give length/range invariants for free; the port took `Uint8Array`/`number` without re-establishing them). Second commit re-adds those guards at every public boundary and wraps every noble/Buffer throw as `E2eError`.

### Deliberately deferred (not in this PR)
- the handshake **RateLimiter** (stateful manager-layer policy — documented in `handshake.ts` as a must-land gate before E2E goes live),
- everything DB/IRC/UI: keyring tables, the NOTICE handshake transport, the `send`/decrypt hooks, `/e2e` commands, the 🔒 indicator.

End-to-end ciphertext interop against a live repartee/weechat peer is the Phase 1 validation step per the issue.

### Checks
`66 tests` passing; typecheck / oxlint / oxfmt clean. Nothing user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
