### PR TITLE
RPE2E keyring storage layer: DB tables + CRUD + at-rest sealing (#382)

### DIFF
--- a/server/db/e2e.test.ts
+++ b/server/db/e2e.test.ts
@@ -182,6 +182,30 @@ describe('incoming sessions + strict TOFU', () => {
     expect(e2e.deleteIncomingSessionsForHandle(userId, netA, '~multi@h')).toBe(2);
     expect(e2e.getIncomingSession(userId, netA, '~multi@h', '#a')).toBeNull();
   });
+
+  it('a same-fingerprint re-handshake rotates the key but preserves trust + created_at', () => {
+    e2e.setIncomingSession(userId, netA, {
+      handle: '~keep@h',
+      channel: '#keep',
+      fingerprint: fp(80),
+      sk: key(80),
+      status: 'trusted',
+      createdAt: 5,
+    });
+    // Same fingerprint, NEW key, caller passes the default 'pending' + a new ts.
+    e2e.installIncomingSessionStrict(userId, netA, {
+      handle: '~keep@h',
+      channel: '#keep',
+      fingerprint: fp(80),
+      sk: key(81),
+      status: 'pending',
+      createdAt: 999,
+    });
+    const got = e2e.getIncomingSession(userId, netA, '~keep@h', '#keep')!;
+    expect(got.sk).toEqual(key(81)); // key rotated
+    expect(got.status).toBe('trusted'); // trust NOT downgraded
+    expect(got.createdAt).toBe(5); // original install time preserved
+  });
 });
 
 describe('outgoing sessions', () => {
@@ -240,8 +264,14 @@ describe('autotrust', () => {
     expect(e2e.autotrustMatches(userId, netA, '~nope@evil.com', '#secret')).toBe(false);
   });
 
-  it('removes by pattern', () => {
-    e2e.removeAutotrust(userId, netA, '*@trusted.org');
+  it('removes one rule by (scope, pattern), leaving a same-pattern rule in another scope', () => {
+    e2e.addAutotrust(userId, netA, 'global', '~dup@*', 1);
+    e2e.addAutotrust(userId, netA, '#room', '~dup@*', 1);
+    e2e.removeAutotrust(userId, netA, 'global', '~dup@*');
+    // The channel-scoped rule survives; the global one is gone.
+    expect(e2e.autotrustMatches(userId, netA, '~dup@x', '#room')).toBe(true);
+    expect(e2e.autotrustMatches(userId, netA, '~dup@x', '#elsewhere')).toBe(false);
+    e2e.removeAutotrust(userId, netA, 'global', '*@trusted.org');
     expect(e2e.autotrustMatches(userId, netA, '~bob@trusted.org', '#anywhere')).toBe(false);
   });
 });
@@ -314,7 +344,7 @@ describe('review hardening', () => {
     // handle mismatch, not a silent second row.
     expect(() =>
       e2e.installIncomingSessionStrict(userId, netA, sess('~cf@h', '#case', 61, 'pending')),
-    ).toThrow(/handle mismatch/);
+    ).toThrow(/fingerprint changed/);
     // Case-flipped lookup finds the one row.
     expect(e2e.getIncomingSession(userId, netA, '~CF@h', '#CASE')!.fingerprint).toEqual(fp(60));
   });

--- a/server/db/e2e.test.ts
+++ b/server/db/e2e.test.ts
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Isolate the DB at a throwaway file, and configure a secret key so the at-rest
+// sealing path is exercised — set BOTH before any db-touching module loads.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-e2e-keyring-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+process.env.LURKER_SECRET_KEY = Buffer.alloc(32, 9).toString('base64');
+
+let e2e: typeof import('./e2e.js');
+let db: typeof import('./index.js').default;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+
+let userId: number;
+let otherUserId: number;
+let netA: number;
+let netB: number;
+
+const key = (b: number) => new Uint8Array(32).fill(b);
+const fp = (b: number) => new Uint8Array(16).fill(b);
+
+beforeAll(async () => {
+  e2e = await import('./e2e.js');
+  db = (await import('./index.js')).default;
+  ({ createUser } = await import('./users.js'));
+  ({ createNetwork } = await import('./networks.js'));
+
+  userId = createUser('keyring-alice').id;
+  otherUserId = createUser('keyring-bob').id;
+  const mkNet = (uid: number, name: string) =>
+    createNetwork(uid, { name, host: 'h', port: 6697, tls: true, nick: 'n' })!.id;
+  netA = mkNet(userId, 'libera');
+  netB = mkNet(userId, 'oftc');
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('identity (per account, shared across networks)', () => {
+  it('round-trips and is the same identity regardless of network', () => {
+    e2e.saveIdentity(userId, {
+      pubkey: key(1),
+      privkey: key(2),
+      fingerprint: fp(3),
+      createdAt: 1000,
+    });
+    const loaded = e2e.loadIdentity(userId)!;
+    expect(loaded.pubkey).toEqual(key(1));
+    expect(loaded.privkey).toEqual(key(2));
+    expect(loaded.fingerprint).toEqual(fp(3));
+    expect(loaded.createdAt).toBe(1000);
+  });
+
+  it('seals the private key at rest (stored column is an lk1 envelope, not raw hex)', () => {
+    const row = db.prepare(`SELECT privkey FROM e2e_identity WHERE user_id = ?`).get(userId) as {
+      privkey: string;
+    };
+    expect(row.privkey.startsWith('lk1.')).toBe(true); // sealed, not raw hex
+  });
+
+  it('upserts (one row per account)', () => {
+    e2e.saveIdentity(userId, { pubkey: key(5), privkey: key(6), fingerprint: fp(7), createdAt: 2 });
+    const n = db.prepare(`SELECT COUNT(*) c FROM e2e_identity WHERE user_id = ?`).get(userId) as {
+      c: number;
+    };
+    expect(n.c).toBe(1);
+    expect(e2e.loadIdentity(userId)!.pubkey).toEqual(key(5));
+  });
+
+  it('returns null for an account with no identity', () => {
+    expect(e2e.loadIdentity(otherUserId)).toBeNull();
+  });
+});
+
+describe('peers', () => {
+  const peer = (fpb: number, handle: string | null, lastSeen: number) => ({
+    fingerprint: fp(fpb),
+    pubkey: key(fpb),
+    lastHandle: handle,
+    lastNick: handle,
+    firstSeen: 100,
+    lastSeen,
+    globalStatus: 'pending' as const,
+  });
+
+  it('upserts and preserves first_seen on conflict', () => {
+    e2e.upsertPeer(userId, netA, peer(10, '~bob@a', 100));
+    e2e.upsertPeer(userId, netA, { ...peer(10, '~bob@b', 200), firstSeen: 999 });
+    const got = e2e.getPeerByFingerprint(userId, netA, fp(10))!;
+    expect(got.lastHandle).toBe('~bob@b');
+    expect(got.firstSeen).toBe(100); // preserved, not 999
+    expect(got.lastSeen).toBe(200);
+  });
+
+  it('reverse-lookup by handle returns the most recently seen', () => {
+    e2e.upsertPeer(userId, netA, peer(11, '~dup@x', 50));
+    e2e.upsertPeer(userId, netA, peer(12, '~dup@x', 300));
+    expect(e2e.getPeerByHandle(userId, netA, '~dup@x')!.fingerprint).toEqual(fp(12));
+  });
+
+  it('deletes by fingerprint and lists in first_seen order', () => {
+    e2e.deletePeerByFingerprint(userId, netA, fp(10));
+    expect(e2e.getPeerByFingerprint(userId, netA, fp(10))).toBeNull();
+    const fps = e2e.listPeers(userId, netA).map((p) => p.fingerprint[0]);
+    expect(fps).toEqual([11, 12]);
+  });
+});
+
+describe('incoming sessions + strict TOFU', () => {
+  const sess = (handle: string, channel: string, fpb: number) => ({
+    handle,
+    channel,
+    fingerprint: fp(fpb),
+    sk: key(fpb),
+    status: 'pending' as const,
+    createdAt: 1,
+  });
+
+  it('installs, seals the session key, and round-trips', () => {
+    e2e.installIncomingSessionStrict(userId, netA, sess('~p@h', '#chan', 20));
+    const got = e2e.getIncomingSession(userId, netA, '~p@h', '#chan')!;
+    expect(got.sk).toEqual(key(20));
+    const raw = db
+      .prepare(
+        `SELECT sk FROM e2e_incoming_sessions WHERE user_id=? AND network_id=? AND handle=? AND channel=?`,
+      )
+      .get(userId, netA, '~p@h', '#chan') as { sk: string };
+    expect(raw.sk.startsWith('lk1.')).toBe(true);
+  });
+
+  it('idempotent refresh with the same fingerprint is allowed', () => {
+    expect(() =>
+      e2e.installIncomingSessionStrict(userId, netA, { ...sess('~p@h', '#chan', 20), sk: key(99) }),
+    ).not.toThrow();
+    expect(e2e.getIncomingSession(userId, netA, '~p@h', '#chan')!.sk).toEqual(key(99));
+  });
+
+  it('rejects a different fingerprint for the same (handle, channel)', () => {
+    let err: unknown;
+    try {
+      e2e.installIncomingSessionStrict(userId, netA, sess('~p@h', '#chan', 77));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(e2e.HandleMismatchError);
+    expect((err as InstanceType<typeof e2e.HandleMismatchError>).kind).toBe('keyring');
+    // existing row untouched
+    expect(e2e.getIncomingSession(userId, netA, '~p@h', '#chan')!.fingerprint).toEqual(fp(20));
+  });
+
+  it('transitions status and filters trusted-for-channel', () => {
+    e2e.setIncomingSession(userId, netA, sess('~q@h', '#chan', 30));
+    e2e.updateIncomingStatus(userId, netA, '~p@h', '#chan', 'trusted');
+    const trusted = e2e.listTrustedSessionsForChannel(userId, netA, '#chan').map((s) => s.handle);
+    expect(trusted).toEqual(['~p@h']); // ~q@h still pending
+  });
+
+  it('deletes all sessions for a handle and reports the count', () => {
+    e2e.setIncomingSession(userId, netA, sess('~multi@h', '#a', 40));
+    e2e.setIncomingSession(userId, netA, sess('~multi@h', '#b', 40));
+    expect(e2e.deleteIncomingSessionsForHandle(userId, netA, '~multi@h')).toBe(2);
+    expect(e2e.getIncomingSession(userId, netA, '~multi@h', '#a')).toBeNull();
+  });
+});
+
+describe('outgoing sessions', () => {
+  it('sets, seals, and round-trips with pending_rotation default false', () => {
+    e2e.setOutgoingSession(userId, netA, '#out', key(50), 123);
+    const got = e2e.getOutgoingSession(userId, netA, '#out')!;
+    expect(got.sk).toEqual(key(50));
+    expect(got.pendingRotation).toBe(false);
+  });
+
+  it('marks and clears pending rotation', () => {
+    e2e.markOutgoingPendingRotation(userId, netA, '#out');
+    expect(e2e.getOutgoingSession(userId, netA, '#out')!.pendingRotation).toBe(true);
+    e2e.clearOutgoingPendingRotation(userId, netA, '#out');
+    expect(e2e.getOutgoingSession(userId, netA, '#out')!.pendingRotation).toBe(false);
+  });
+
+  it('re-setting a session resets pending_rotation to false', () => {
+    e2e.markOutgoingPendingRotation(userId, netA, '#out');
+    e2e.setOutgoingSession(userId, netA, '#out', key(51), 200);
+    expect(e2e.getOutgoingSession(userId, netA, '#out')!.pendingRotation).toBe(false);
+  });
+});
+
+describe('channel config', () => {
+  it('sets and reads enabled + mode', () => {
+    e2e.setChannelConfig(userId, netA, { channel: '#c', enabled: true, mode: 'auto-accept' });
+    const got = e2e.getChannelConfig(userId, netA, '#c')!;
+    expect(got.enabled).toBe(true);
+    expect(got.mode).toBe('auto-accept');
+  });
+
+  it('returns null when unconfigured', () => {
+    expect(e2e.getChannelConfig(userId, netA, '#nope')).toBeNull();
+  });
+});
+
+describe('autotrust', () => {
+  it('adds idempotently and lists', () => {
+    e2e.addAutotrust(userId, netA, 'global', '*@trusted.org', 1);
+    e2e.addAutotrust(userId, netA, 'global', '*@trusted.org', 2); // dup ignored
+    expect(e2e.listAutotrust(userId, netA)).toHaveLength(1);
+  });
+
+  it('matches via glob, honoring scope', () => {
+    e2e.addAutotrust(userId, netA, '#secret', '~admin@*', 1);
+    expect(e2e.autotrustMatches(userId, netA, '~bob@trusted.org', '#anywhere')).toBe(true); // global
+    expect(e2e.autotrustMatches(userId, netA, '~admin@box', '#secret')).toBe(true); // channel-scoped
+    expect(e2e.autotrustMatches(userId, netA, '~admin@box', '#other')).toBe(false); // wrong channel
+    expect(e2e.autotrustMatches(userId, netA, '~nope@evil.com', '#secret')).toBe(false);
+  });
+
+  it('removes by pattern', () => {
+    e2e.removeAutotrust(userId, netA, '*@trusted.org');
+    expect(e2e.autotrustMatches(userId, netA, '~bob@trusted.org', '#anywhere')).toBe(false);
+  });
+});
+
+describe('outgoing recipients', () => {
+  it('records idempotently, preserves first_sent_at, lists by age', () => {
+    e2e.recordOutgoingRecipient(userId, netA, '#r', '~a@h', fp(1), 100);
+    e2e.recordOutgoingRecipient(userId, netA, '#r', '~b@h', fp(2), 200);
+    e2e.recordOutgoingRecipient(userId, netA, '#r', '~a@h', fp(9), 999); // updates fp, keeps order
+    const recips = e2e.listOutgoingRecipients(userId, netA, '#r');
+    expect(recips.map((r) => r.handle)).toEqual(['~a@h', '~b@h']);
+    expect(recips[0].fingerprint).toEqual(fp(9));
+  });
+
+  it('removes one and deletes-for-handle with a count', () => {
+    e2e.removeOutgoingRecipient(userId, netA, '#r', '~b@h');
+    expect(e2e.listOutgoingRecipients(userId, netA, '#r').map((r) => r.handle)).toEqual(['~a@h']);
+    expect(e2e.deleteOutgoingRecipientsForHandle(userId, netA, '~a@h')).toBe(1);
+  });
+});
+
+describe('scoping isolation', () => {
+  it('keeps (user, network) data from leaking across networks or tenants', () => {
+    e2e.setChannelConfig(userId, netA, { channel: '#iso', enabled: true, mode: 'normal' });
+    // same user, different network
+    expect(e2e.getChannelConfig(userId, netB, '#iso')).toBeNull();
+    // different user entirely (would need their own network, but the scope check
+    // is on user_id + network_id, so netA under otherUserId yields nothing)
+    expect(e2e.getChannelConfig(otherUserId, netA, '#iso')).toBeNull();
+  });
+});
+
+describe('glob + enum parsing (pure helpers)', () => {
+  it('globMatchCi handles * and ? case-insensitively', () => {
+    expect(e2e.globMatchCi('*@host', '~Bob@HOST')).toBe(true);
+    expect(e2e.globMatchCi('~a?@*', '~ab@anything')).toBe(true);
+    expect(e2e.globMatchCi('exact', 'exact')).toBe(true);
+    expect(e2e.globMatchCi('a*c', 'abd')).toBe(false);
+    expect(e2e.globMatchCi('?', 'ab')).toBe(false);
+  });
+
+  it('enum parsing falls back to safe defaults like repartee', () => {
+    expect(e2e.parseTrustStatus('bogus')).toBe('pending');
+    expect(e2e.parseChannelMode('bogus')).toBe('normal');
+    expect(e2e.parseChannelMode('auto')).toBe('auto-accept'); // alias
+  });
+});

--- a/server/db/e2e.test.ts
+++ b/server/db/e2e.test.ts
@@ -21,6 +21,7 @@ let userId: number;
 let otherUserId: number;
 let netA: number;
 let netB: number;
+let otherNet: number;
 
 const key = (b: number) => new Uint8Array(32).fill(b);
 const fp = (b: number) => new Uint8Array(16).fill(b);
@@ -37,6 +38,7 @@ beforeAll(async () => {
     createNetwork(uid, { name, host: 'h', port: 6697, tls: true, nick: 'n' })!.id;
   netA = mkNet(userId, 'libera');
   netB = mkNet(userId, 'oftc');
+  otherNet = mkNet(otherUserId, 'libera');
 });
 
 afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
@@ -109,6 +111,20 @@ describe('peers', () => {
     const fps = e2e.listPeers(userId, netA).map((p) => p.fingerprint[0]);
     expect(fps).toEqual([11, 12]);
   });
+
+  it('does not downgrade global_status on a routine re-upsert; setPeerStatus is explicit', () => {
+    e2e.upsertPeer(userId, netA, { ...peer(15, '~t@h', 10), globalStatus: 'trusted' });
+    // A routine re-sighting refreshing last_handle/last_seen passes the caller's
+    // default 'pending' — must NOT clobber the trusted status.
+    e2e.upsertPeer(userId, netA, peer(15, '~t@h2', 20));
+    let got = e2e.getPeerByFingerprint(userId, netA, fp(15))!;
+    expect(got.globalStatus).toBe('trusted');
+    expect(got.lastHandle).toBe('~t@h2');
+    // Explicit change still works.
+    e2e.setPeerStatus(userId, netA, fp(15), 'revoked');
+    got = e2e.getPeerByFingerprint(userId, netA, fp(15))!;
+    expect(got.globalStatus).toBe('revoked');
+  });
 });
 
 describe('incoming sessions + strict TOFU', () => {
@@ -174,6 +190,12 @@ describe('outgoing sessions', () => {
     const got = e2e.getOutgoingSession(userId, netA, '#out')!;
     expect(got.sk).toEqual(key(50));
     expect(got.pendingRotation).toBe(false);
+    const raw = db
+      .prepare(
+        `SELECT sk FROM e2e_outgoing_sessions WHERE user_id=? AND network_id=? AND channel=?`,
+      )
+      .get(userId, netA, '#out') as { sk: string };
+    expect(raw.sk.startsWith('lk1.')).toBe(true); // sealed, not raw hex
   });
 
   it('marks and clears pending rotation', () => {
@@ -242,13 +264,21 @@ describe('outgoing recipients', () => {
 });
 
 describe('scoping isolation', () => {
-  it('keeps (user, network) data from leaking across networks or tenants', () => {
+  it('does not leak across networks (same user)', () => {
     e2e.setChannelConfig(userId, netA, { channel: '#iso', enabled: true, mode: 'normal' });
-    // same user, different network
     expect(e2e.getChannelConfig(userId, netB, '#iso')).toBeNull();
-    // different user entirely (would need their own network, but the scope check
-    // is on user_id + network_id, so netA under otherUserId yields nothing)
-    expect(e2e.getChannelConfig(otherUserId, netA, '#iso')).toBeNull();
+  });
+
+  it('does not leak across tenants (the user_id predicate actually bites)', () => {
+    // Seed a row under a DIFFERENT tenant's own network, then confirm our user
+    // can't read it — if a query dropped its user_id predicate this would fail.
+    e2e.setChannelConfig(otherUserId, otherNet, {
+      channel: '#tenant',
+      enabled: true,
+      mode: 'quiet',
+    });
+    expect(e2e.getChannelConfig(otherUserId, otherNet, '#tenant')).not.toBeNull();
+    expect(e2e.getChannelConfig(userId, otherNet, '#tenant')).toBeNull();
   });
 });
 
@@ -265,5 +295,88 @@ describe('glob + enum parsing (pure helpers)', () => {
     expect(e2e.parseTrustStatus('bogus')).toBe('pending');
     expect(e2e.parseChannelMode('bogus')).toBe('normal');
     expect(e2e.parseChannelMode('auto')).toBe('auto-accept'); // alias
+  });
+});
+
+describe('review hardening', () => {
+  const sess = (handle: string, channel: string, fpb: number, status: 'pending' | 'trusted') => ({
+    handle,
+    channel,
+    fingerprint: fp(fpb),
+    sk: key(fpb),
+    status,
+    createdAt: 1,
+  });
+
+  it('folds IRC target case — strict TOFU catches a case-flipped channel (C1)', () => {
+    e2e.installIncomingSessionStrict(userId, netA, sess('~cf@h', '#Case', 60, 'pending'));
+    // Same logical channel, different casing, DIFFERENT fingerprint: must be a
+    // handle mismatch, not a silent second row.
+    expect(() =>
+      e2e.installIncomingSessionStrict(userId, netA, sess('~cf@h', '#case', 61, 'pending')),
+    ).toThrow(/handle mismatch/);
+    // Case-flipped lookup finds the one row.
+    expect(e2e.getIncomingSession(userId, netA, '~CF@h', '#CASE')!.fingerprint).toEqual(fp(60));
+  });
+
+  it('folds case for channel-config lookups (C1)', () => {
+    e2e.setChannelConfig(userId, netA, { channel: '#FoldMe', enabled: true, mode: 'auto-accept' });
+    expect(e2e.getChannelConfig(userId, netA, '#foldme')!.enabled).toBe(true);
+  });
+
+  it('rejects a wrong-length key on the write side (C3)', () => {
+    expect(() => e2e.setOutgoingSession(userId, netA, '#bad', new Uint8Array(16), 1)).toThrow(
+      /key must be 32 bytes/,
+    );
+  });
+
+  it('enforces blob length at the schema via CHECK (C3)', () => {
+    expect(() =>
+      e2e.upsertPeer(userId, netA, {
+        fingerprint: new Uint8Array(15),
+        pubkey: key(1),
+        lastHandle: null,
+        lastNick: null,
+        firstSeen: 1,
+        lastSeen: 1,
+        globalStatus: 'pending',
+      }),
+    ).toThrow(/constraint/);
+  });
+
+  it('skips an unreadable trusted session instead of dropping the channel (C6)', () => {
+    e2e.setIncomingSession(userId, netA, sess('~ok@h', '#mix', 62, 'trusted'));
+    e2e.setIncomingSession(userId, netA, sess('~bad@h', '#mix', 63, 'trusted'));
+    db.prepare(
+      `UPDATE e2e_incoming_sessions SET sk = 'not-decryptable'
+       WHERE user_id=? AND network_id=? AND handle=? AND channel=?`,
+    ).run(userId, netA, '~bad@h', '#mix');
+    expect(e2e.listTrustedSessionsForChannel(userId, netA, '#mix').map((s) => s.handle)).toEqual([
+      '~ok@h',
+    ]);
+  });
+
+  it('backfill re-seals a plaintext-hex secret from a keyless window (C2)', () => {
+    // Simulate a keyless write: raw plaintext hex straight into the column.
+    const rawHex = Buffer.from(key(70)).toString('hex');
+    db.prepare(
+      `INSERT INTO e2e_identity (user_id, pubkey, privkey, fingerprint, created_at) VALUES (?, ?, ?, ?, 1)`,
+    ).run(otherUserId, Buffer.from(key(70)), rawHex, Buffer.from(fp(70)));
+    const before = db
+      .prepare(`SELECT privkey FROM e2e_identity WHERE user_id=?`)
+      .get(otherUserId) as {
+      privkey: string;
+    };
+    expect(before.privkey.startsWith('lk1.')).toBe(false);
+
+    expect(e2e.backfillEncryptE2eSecrets().encrypted).toBeGreaterThanOrEqual(1);
+
+    const after = db
+      .prepare(`SELECT privkey FROM e2e_identity WHERE user_id=?`)
+      .get(otherUserId) as {
+      privkey: string;
+    };
+    expect(after.privkey.startsWith('lk1.')).toBe(true);
+    expect(e2e.loadIdentity(otherUserId)!.privkey).toEqual(key(70)); // still round-trips
   });
 });

--- a/server/db/e2e.ts
+++ b/server/db/e2e.ts
@@ -75,7 +75,7 @@ export class HandleMismatchError extends E2eError {
   readonly expected: string;
   readonly got: string;
   constructor(expected: string, got: string) {
-    super('keyring', `handle mismatch: pinned ${expected}, got ${got}`);
+    super('keyring', `fingerprint changed for this handle+channel: pinned ${expected}, got ${got}`);
     this.name = 'HandleMismatchError';
     this.expected = expected;
     this.got = got;
@@ -297,6 +297,12 @@ const getIncomingFpStmt = db.prepare(
   `SELECT fingerprint FROM e2e_incoming_sessions
    WHERE user_id = ? AND network_id = ? AND handle = ? AND channel = ?`,
 );
+// Rotate just the session key for an established peer, preserving their trust
+// status and original install time.
+const refreshIncomingKeyStmt = db.prepare(
+  `UPDATE e2e_incoming_sessions SET sk = ?
+   WHERE user_id = ? AND network_id = ? AND handle = ? AND channel = ?`,
+);
 const getIncomingStmt = db.prepare(
   `SELECT * FROM e2e_incoming_sessions
    WHERE user_id = ? AND network_id = ? AND handle = ? AND channel = ?`,
@@ -358,9 +364,13 @@ export function setIncomingSession(userId: number, networkId: number, s: Incomin
 }
 
 /**
- * Install under strict TOFU: if a row already exists for `(handle, channel)`
- * with a different fingerprint, throw `HandleMismatchError` and leave the
- * existing row untouched. Same fingerprint (idempotent refresh) upserts.
+ * Install under strict TOFU. If a row already exists for `(handle, channel)`:
+ * a DIFFERENT fingerprint throws `HandleMismatchError` and leaves the row
+ * untouched; the SAME fingerprint (an established peer re-handshaking) rotates
+ * only the session key, preserving the existing trust status and original
+ * install time — a re-handshake must never silently downgrade trust or reset
+ * `created_at` (trust changes only through `updateIncomingStatus`). A brand-new
+ * `(handle, channel)` is inserted with the provided status.
  */
 export function installIncomingSessionStrict(
   userId: number,
@@ -374,6 +384,8 @@ export function installIncomingSessionStrict(
     const pinned = Buffer.from(existing.fingerprint).toString('hex');
     const incoming = Buffer.from(s.fingerprint).toString('hex');
     if (pinned !== incoming) throw new HandleMismatchError(pinned, incoming);
+    refreshIncomingKeyStmt.run(sealKey(s.sk), userId, networkId, s.handle, s.channel);
+    return;
   }
   upsertIncomingStmt.run(incomingBind(userId, networkId, s));
 }
@@ -574,7 +586,8 @@ const listAutotrustStmt = db.prepare(
   `SELECT scope, handle_pattern FROM e2e_autotrust WHERE user_id = ? AND network_id = ?`,
 );
 const removeAutotrustStmt = db.prepare(
-  `DELETE FROM e2e_autotrust WHERE user_id = ? AND network_id = ? AND handle_pattern = ?`,
+  `DELETE FROM e2e_autotrust
+   WHERE user_id = ? AND network_id = ? AND scope = ? AND handle_pattern = ?`,
 );
 const matchAutotrustStmt = db.prepare(
   `SELECT handle_pattern FROM e2e_autotrust
@@ -602,8 +615,16 @@ export function listAutotrust(userId: number, networkId: number): AutotrustRule[
   ).map((r) => ({ scope: r.scope, handlePattern: r.handle_pattern }));
 }
 
-export function removeAutotrust(userId: number, networkId: number, handlePattern: string): void {
-  removeAutotrustStmt.run(userId, networkId, handlePattern);
+/** Remove one autotrust rule, identified by its full (scope, pattern) — the
+ *  same pattern can exist in more than one scope (e.g. global + a channel), so
+ *  scope is required to target a single rule. */
+export function removeAutotrust(
+  userId: number,
+  networkId: number,
+  scope: string,
+  handlePattern: string,
+): void {
+  removeAutotrustStmt.run(userId, networkId, scope, handlePattern);
 }
 
 /**
@@ -717,7 +738,7 @@ const E2E_SEALED_COLUMNS: ReadonlyArray<readonly [string, string]> = [
  * (the documented self-host→hosted migration, or a key added post-hoc). The
  * lazy on-write seal only fires at creation, so without this a privkey/sk
  * written keyless would stay cleartext in SQLite — and Litestream ships that to
- * R2 ([[project_cell_secret_key]] is the whole reason these are sealed). The
+ * R2 (the whole reason these columns are sealed under LURKER_SECRET_KEY). The
  * analog of networks.ts::backfillEncryptNetworkSecrets; run once at boot. No-op
  * without a key (every self-host), and the isEncrypted() guard skips already-
  * sealed rows so a fully-sealed table does zero writes.

--- a/server/db/e2e.ts
+++ b/server/db/e2e.ts
@@ -13,8 +13,9 @@
 // module is pure storage + CRUD; handshake orchestration, trust policy, and the
 // rate limiter live in the (not-yet-built) E2eManager.
 
+import { globToRegexSource } from '../../shared/textMatch.js';
 import { E2eError } from '../services/e2e/errors.js';
-import { decryptSecret, encryptSecret } from '../utils/secretCrypto.js';
+import { decryptSecret, encryptSecret, hasSecretKey, isEncrypted } from '../utils/secretCrypto.js';
 import db from './index.js';
 
 // ─── types ───────────────────────────────────────────────────────────────────
@@ -83,18 +84,45 @@ export class HandleMismatchError extends E2eError {
 
 // ─── value mapping ───────────────────────────────────────────────────────────
 
+const KEY_LEN = 32;
+
 const toBlob = (u8: Uint8Array): Buffer => Buffer.from(u8);
-const fromBlob = (b: unknown): Uint8Array => new Uint8Array(b as Buffer);
+
+/** Wrap a DB blob as bytes, asserting the expected length so a truncated /
+ *  corrupt restore fails loud here instead of deep in crypto (mirrors the
+ *  reference's read-time length guards). */
+function fromBlob(b: unknown, len: number): Uint8Array {
+  const u8 = new Uint8Array(b as Buffer);
+  if (u8.length !== len) {
+    throw new E2eError('keyring', `expected ${len}-byte blob, got ${u8.length}`);
+  }
+  return u8;
+}
 
 /** Seal a raw key to a secretCrypto envelope (hex → encrypted TEXT). */
 function sealKey(key: Uint8Array): string {
+  if (key.length !== KEY_LEN) {
+    throw new E2eError('keyring', `key must be ${KEY_LEN} bytes, got ${key.length}`);
+  }
   return encryptSecret(Buffer.from(key).toString('hex'))!;
 }
-/** Open a sealed key back to raw bytes. */
-function openKey(stored: string): Uint8Array {
-  const hex = decryptSecret(stored);
+
+/** Open a sealed key back to raw bytes. Every failure surfaces as
+ *  `E2eError('keyring')` so callers can branch on `kind` — including an
+ *  undecryptable envelope after a LURKER_SECRET_KEY change (DR rebuild). */
+function openKey(stored: string, len = KEY_LEN): Uint8Array {
+  let hex: string | null;
+  try {
+    hex = decryptSecret(stored);
+  } catch (err) {
+    throw new E2eError('keyring', `failed to unseal key: ${(err as Error).message}`);
+  }
   if (!hex) throw new E2eError('keyring', 'sealed key is empty or unreadable');
-  return new Uint8Array(Buffer.from(hex, 'hex'));
+  const u8 = new Uint8Array(Buffer.from(hex, 'hex'));
+  if (u8.length !== len) {
+    throw new E2eError('keyring', `sealed key wrong length: expected ${len}, got ${u8.length}`);
+  }
+  return u8;
 }
 
 // Lenient enum parsing, mirroring repartee (unknown → safe default; `auto` is an
@@ -137,9 +165,9 @@ export function loadIdentity(userId: number): IdentityRow | null {
     | undefined;
   if (!r) return null;
   return {
-    pubkey: fromBlob(r.pubkey),
+    pubkey: fromBlob(r.pubkey, 32),
     privkey: openKey(r.privkey),
-    fingerprint: fromBlob(r.fingerprint),
+    fingerprint: fromBlob(r.fingerprint, 16),
     createdAt: r.created_at,
   };
 }
@@ -153,8 +181,15 @@ const upsertPeerStmt = db.prepare(`
     (@userId, @networkId, @fingerprint, @pubkey, @lastHandle, @lastNick, @firstSeen, @lastSeen, @globalStatus)
   ON CONFLICT(user_id, network_id, fingerprint) DO UPDATE SET
     last_handle = excluded.last_handle, last_nick = excluded.last_nick,
-    last_seen = excluded.last_seen, global_status = excluded.global_status
+    last_seen = excluded.last_seen
 `);
+// global_status is deliberately NOT touched on conflict — a routine re-sighting
+// (refresh last_seen/last_handle) must never downgrade a peer the user marked
+// trusted back to the caller's default. Explicit trust changes go through
+// setPeerStatus.
+const setPeerStatusStmt = db.prepare(
+  `UPDATE e2e_peers SET global_status = ? WHERE user_id = ? AND network_id = ? AND fingerprint = ?`,
+);
 const getPeerByFpStmt = db.prepare(
   `SELECT * FROM e2e_peers WHERE user_id = ? AND network_id = ? AND fingerprint = ?`,
 );
@@ -180,8 +215,8 @@ interface PeerRow {
 }
 function mapPeer(r: PeerRow): PeerRecord {
   return {
-    fingerprint: fromBlob(r.fingerprint),
-    pubkey: fromBlob(r.pubkey),
+    fingerprint: fromBlob(r.fingerprint, 16),
+    pubkey: fromBlob(r.pubkey, 32),
     lastHandle: r.last_handle,
     lastNick: r.last_nick,
     firstSeen: r.first_seen,
@@ -202,6 +237,17 @@ export function upsertPeer(userId: number, networkId: number, peer: PeerRecord):
     lastSeen: peer.lastSeen,
     globalStatus: peer.globalStatus,
   });
+}
+
+/** Set a peer's global trust status (the explicit trust/revoke path; the
+ *  routine upsert never changes it). */
+export function setPeerStatus(
+  userId: number,
+  networkId: number,
+  fingerprint: Uint8Array,
+  status: TrustStatus,
+): void {
+  setPeerStatusStmt.run(status, userId, networkId, toBlob(fingerprint));
 }
 
 export function getPeerByFingerprint(
@@ -287,7 +333,7 @@ function mapIncoming(r: IncomingRow): IncomingSession {
   return {
     handle: r.handle,
     channel: r.channel,
-    fingerprint: fromBlob(r.fingerprint),
+    fingerprint: fromBlob(r.fingerprint, 16),
     sk: openKey(r.sk),
     status: parseTrustStatus(r.status),
     createdAt: r.created_at,
@@ -371,15 +417,25 @@ export function deleteIncomingSessionsForHandle(
   return deleteIncomingForHandleStmt.run(userId, networkId, handle).changes;
 }
 
-/** Trusted incoming sessions for a channel (the decrypt hot path). */
+/** Trusted incoming sessions for a channel (the decrypt hot path). A single
+ *  unreadable row (corrupt blob, or an envelope undecryptable after a key
+ *  rotation) is skipped, not allowed to drop the whole channel's decryption. */
 export function listTrustedSessionsForChannel(
   userId: number,
   networkId: number,
   channel: string,
 ): IncomingSession[] {
-  return (listTrustedForChannelStmt.all(userId, networkId, channel) as IncomingRow[]).map(
-    mapIncoming,
-  );
+  const out: IncomingSession[] = [];
+  for (const r of listTrustedForChannelStmt.all(userId, networkId, channel) as IncomingRow[]) {
+    try {
+      out.push(mapIncoming(r));
+    } catch (err) {
+      console.warn(
+        `e2e keyring: skipping unreadable incoming session ${r.handle}/${r.channel}: ${(err as Error).message}`,
+      );
+    }
+  }
+  return out;
 }
 
 export function listIncomingSessions(userId: number, networkId: number): IncomingSession[] {
@@ -566,30 +622,11 @@ export function autotrustMatches(
   return rows.some((r) => globMatchCi(r.handle_pattern, handle));
 }
 
-/** Minimal case-insensitive glob: `*` matches any run, `?` one char, else literal. */
+/** Whole-string, case-insensitive glob (`*` any run, `?` one char) via the
+ *  shared `globToRegexSource` — one source of truth for IRC wildcard semantics,
+ *  and surrogate-safe (the regex `u` flag matches by code point). */
 export function globMatchCi(pattern: string, input: string): boolean {
-  const p = pattern.toLowerCase();
-  const s = input.toLowerCase();
-  let pi = 0;
-  let si = 0;
-  let star = -1;
-  let mark = 0;
-  while (si < s.length) {
-    if (pi < p.length && (p[pi] === '?' || p[pi] === s[si])) {
-      pi++;
-      si++;
-    } else if (pi < p.length && p[pi] === '*') {
-      star = pi++;
-      mark = si;
-    } else if (star !== -1) {
-      pi = star + 1;
-      si = ++mark;
-    } else {
-      return false;
-    }
-  }
-  while (pi < p.length && p[pi] === '*') pi++;
-  return pi === p.length;
+  return new RegExp(`^${globToRegexSource(pattern)}$`, 'iu').test(input);
 }
 
 // ─── outgoing recipients (for lazy-rotate distribution) ──────────────────────
@@ -644,7 +681,7 @@ export function listOutgoingRecipients(
       handle: string;
       fingerprint: Buffer;
     }>
-  ).map((r) => ({ handle: r.handle, fingerprint: fromBlob(r.fingerprint) }));
+  ).map((r) => ({ handle: r.handle, fingerprint: fromBlob(r.fingerprint, 16) }));
 }
 
 export function removeOutgoingRecipient(
@@ -662,4 +699,49 @@ export function deleteOutgoingRecipientsForHandle(
   handle: string,
 ): number {
   return deleteRecipientsForHandleStmt.run(userId, networkId, handle).changes;
+}
+
+// ─── at-rest backfill ────────────────────────────────────────────────────────
+
+// (table, secret-column) pairs holding sealed key material. All are rowid
+// tables, so the re-seal can address rows by rowid regardless of their
+// composite PK.
+const E2E_SEALED_COLUMNS: ReadonlyArray<readonly [string, string]> = [
+  ['e2e_identity', 'privkey'],
+  ['e2e_incoming_sessions', 'sk'],
+  ['e2e_outgoing_sessions', 'sk'],
+];
+
+/**
+ * Re-seal any e2e secret columns left as plaintext hex from a keyless window
+ * (the documented self-host→hosted migration, or a key added post-hoc). The
+ * lazy on-write seal only fires at creation, so without this a privkey/sk
+ * written keyless would stay cleartext in SQLite — and Litestream ships that to
+ * R2 ([[project_cell_secret_key]] is the whole reason these are sealed). The
+ * analog of networks.ts::backfillEncryptNetworkSecrets; run once at boot. No-op
+ * without a key (every self-host), and the isEncrypted() guard skips already-
+ * sealed rows so a fully-sealed table does zero writes.
+ */
+export function backfillEncryptE2eSecrets(): { scanned: number; encrypted: number } {
+  if (!hasSecretKey()) return { scanned: 0, encrypted: 0 };
+  let scanned = 0;
+  let encrypted = 0;
+  const tx = db.transaction(() => {
+    for (const [table, col] of E2E_SEALED_COLUMNS) {
+      const rows = db.prepare(`SELECT rowid AS rid, ${col} AS v FROM ${table}`).all() as Array<{
+        rid: number;
+        v: string | null;
+      }>;
+      const update = db.prepare(`UPDATE ${table} SET ${col} = ? WHERE rowid = ?`);
+      for (const row of rows) {
+        scanned += 1;
+        if (typeof row.v === 'string' && row.v !== '' && !isEncrypted(row.v)) {
+          update.run(encryptSecret(row.v), row.rid);
+          encrypted += 1;
+        }
+      }
+    }
+  });
+  tx();
+  return { scanned, encrypted };
 }

--- a/server/db/e2e.ts
+++ b/server/db/e2e.ts
@@ -1,0 +1,665 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// RPE2E keyring — the persistent storage layer for end-to-end encryption
+// (issue #382). A faithful port of repartee's `keyring.rs`, adapted for
+// Lurker's multi-tenant cell: the identity is per-ACCOUNT (`user_id`) and
+// everything else is scoped per `(user_id, network_id)`.
+//
+// Secret columns (the identity private key and the session keys) are sealed
+// with the existing `secretCrypto` at-rest scheme (the same `lk1.*` envelope
+// used for network credentials) — important because hosted cell DBs ship to R2
+// backups. Public material (pubkeys, fingerprints) is stored as BLOB. This
+// module is pure storage + CRUD; handshake orchestration, trust policy, and the
+// rate limiter live in the (not-yet-built) E2eManager.
+
+import { E2eError } from '../services/e2e/errors.js';
+import { decryptSecret, encryptSecret } from '../utils/secretCrypto.js';
+import db from './index.js';
+
+// ─── types ───────────────────────────────────────────────────────────────────
+
+export type TrustStatus = 'pending' | 'trusted' | 'revoked';
+export type ChannelMode = 'auto-accept' | 'normal' | 'quiet';
+
+export interface IdentityInput {
+  pubkey: Uint8Array;
+  /** 32-byte Ed25519 seed (sealed at rest). */
+  privkey: Uint8Array;
+  fingerprint: Uint8Array;
+  createdAt: number;
+}
+export type IdentityRow = IdentityInput;
+
+export interface PeerRecord {
+  fingerprint: Uint8Array;
+  pubkey: Uint8Array;
+  lastHandle: string | null;
+  lastNick: string | null;
+  firstSeen: number;
+  lastSeen: number;
+  globalStatus: TrustStatus;
+}
+
+export interface IncomingSession {
+  handle: string;
+  channel: string;
+  fingerprint: Uint8Array;
+  /** 32-byte session key (sealed at rest). */
+  sk: Uint8Array;
+  status: TrustStatus;
+  createdAt: number;
+}
+
+export interface OutgoingSession {
+  channel: string;
+  /** 32-byte session key (sealed at rest). */
+  sk: Uint8Array;
+  createdAt: number;
+  pendingRotation: boolean;
+}
+
+export interface ChannelConfig {
+  channel: string;
+  enabled: boolean;
+  mode: ChannelMode;
+}
+
+/**
+ * Thrown by `installIncomingSessionStrict` when a session already exists for
+ * `(handle, channel)` under a DIFFERENT fingerprint — the strict-TOFU signal a
+ * caller turns into a "key changed, /e2e reverify to accept" warning.
+ */
+export class HandleMismatchError extends E2eError {
+  readonly expected: string;
+  readonly got: string;
+  constructor(expected: string, got: string) {
+    super('keyring', `handle mismatch: pinned ${expected}, got ${got}`);
+    this.name = 'HandleMismatchError';
+    this.expected = expected;
+    this.got = got;
+  }
+}
+
+// ─── value mapping ───────────────────────────────────────────────────────────
+
+const toBlob = (u8: Uint8Array): Buffer => Buffer.from(u8);
+const fromBlob = (b: unknown): Uint8Array => new Uint8Array(b as Buffer);
+
+/** Seal a raw key to a secretCrypto envelope (hex → encrypted TEXT). */
+function sealKey(key: Uint8Array): string {
+  return encryptSecret(Buffer.from(key).toString('hex'))!;
+}
+/** Open a sealed key back to raw bytes. */
+function openKey(stored: string): Uint8Array {
+  const hex = decryptSecret(stored);
+  if (!hex) throw new E2eError('keyring', 'sealed key is empty or unreadable');
+  return new Uint8Array(Buffer.from(hex, 'hex'));
+}
+
+// Lenient enum parsing, mirroring repartee (unknown → safe default; `auto` is an
+// accepted alias for `auto-accept`).
+export function parseTrustStatus(s: string): TrustStatus {
+  return s === 'trusted' ? 'trusted' : s === 'revoked' ? 'revoked' : 'pending';
+}
+export function parseChannelMode(s: string): ChannelMode {
+  if (s === 'auto-accept' || s === 'auto') return 'auto-accept';
+  if (s === 'quiet') return 'quiet';
+  return 'normal';
+}
+
+// ─── identity (per account) ──────────────────────────────────────────────────
+
+const upsertIdentityStmt = db.prepare(`
+  INSERT INTO e2e_identity (user_id, pubkey, privkey, fingerprint, created_at)
+  VALUES (@userId, @pubkey, @privkey, @fingerprint, @createdAt)
+  ON CONFLICT(user_id) DO UPDATE SET
+    pubkey = excluded.pubkey, privkey = excluded.privkey,
+    fingerprint = excluded.fingerprint, created_at = excluded.created_at
+`);
+const loadIdentityStmt = db.prepare(
+  `SELECT pubkey, privkey, fingerprint, created_at FROM e2e_identity WHERE user_id = ?`,
+);
+
+export function saveIdentity(userId: number, id: IdentityInput): void {
+  upsertIdentityStmt.run({
+    userId,
+    pubkey: toBlob(id.pubkey),
+    privkey: sealKey(id.privkey),
+    fingerprint: toBlob(id.fingerprint),
+    createdAt: id.createdAt,
+  });
+}
+
+export function loadIdentity(userId: number): IdentityRow | null {
+  const r = loadIdentityStmt.get(userId) as
+    | { pubkey: Buffer; privkey: string; fingerprint: Buffer; created_at: number }
+    | undefined;
+  if (!r) return null;
+  return {
+    pubkey: fromBlob(r.pubkey),
+    privkey: openKey(r.privkey),
+    fingerprint: fromBlob(r.fingerprint),
+    createdAt: r.created_at,
+  };
+}
+
+// ─── peers ───────────────────────────────────────────────────────────────────
+
+const upsertPeerStmt = db.prepare(`
+  INSERT INTO e2e_peers
+    (user_id, network_id, fingerprint, pubkey, last_handle, last_nick, first_seen, last_seen, global_status)
+  VALUES
+    (@userId, @networkId, @fingerprint, @pubkey, @lastHandle, @lastNick, @firstSeen, @lastSeen, @globalStatus)
+  ON CONFLICT(user_id, network_id, fingerprint) DO UPDATE SET
+    last_handle = excluded.last_handle, last_nick = excluded.last_nick,
+    last_seen = excluded.last_seen, global_status = excluded.global_status
+`);
+const getPeerByFpStmt = db.prepare(
+  `SELECT * FROM e2e_peers WHERE user_id = ? AND network_id = ? AND fingerprint = ?`,
+);
+const getPeerByHandleStmt = db.prepare(
+  `SELECT * FROM e2e_peers WHERE user_id = ? AND network_id = ? AND last_handle = ?
+   ORDER BY last_seen DESC LIMIT 1`,
+);
+const deletePeerStmt = db.prepare(
+  `DELETE FROM e2e_peers WHERE user_id = ? AND network_id = ? AND fingerprint = ?`,
+);
+const listPeersStmt = db.prepare(
+  `SELECT * FROM e2e_peers WHERE user_id = ? AND network_id = ? ORDER BY first_seen ASC`,
+);
+
+interface PeerRow {
+  fingerprint: Buffer;
+  pubkey: Buffer;
+  last_handle: string | null;
+  last_nick: string | null;
+  first_seen: number;
+  last_seen: number;
+  global_status: string;
+}
+function mapPeer(r: PeerRow): PeerRecord {
+  return {
+    fingerprint: fromBlob(r.fingerprint),
+    pubkey: fromBlob(r.pubkey),
+    lastHandle: r.last_handle,
+    lastNick: r.last_nick,
+    firstSeen: r.first_seen,
+    lastSeen: r.last_seen,
+    globalStatus: parseTrustStatus(r.global_status),
+  };
+}
+
+export function upsertPeer(userId: number, networkId: number, peer: PeerRecord): void {
+  upsertPeerStmt.run({
+    userId,
+    networkId,
+    fingerprint: toBlob(peer.fingerprint),
+    pubkey: toBlob(peer.pubkey),
+    lastHandle: peer.lastHandle,
+    lastNick: peer.lastNick,
+    firstSeen: peer.firstSeen,
+    lastSeen: peer.lastSeen,
+    globalStatus: peer.globalStatus,
+  });
+}
+
+export function getPeerByFingerprint(
+  userId: number,
+  networkId: number,
+  fingerprint: Uint8Array,
+): PeerRecord | null {
+  const r = getPeerByFpStmt.get(userId, networkId, toBlob(fingerprint)) as PeerRow | undefined;
+  return r ? mapPeer(r) : null;
+}
+
+/** Reverse lookup by handle (most recently seen), for the TOFU "known
+ *  fingerprint, new handle" check. */
+export function getPeerByHandle(
+  userId: number,
+  networkId: number,
+  handle: string,
+): PeerRecord | null {
+  const r = getPeerByHandleStmt.get(userId, networkId, handle) as PeerRow | undefined;
+  return r ? mapPeer(r) : null;
+}
+
+export function deletePeerByFingerprint(
+  userId: number,
+  networkId: number,
+  fingerprint: Uint8Array,
+): void {
+  deletePeerStmt.run(userId, networkId, toBlob(fingerprint));
+}
+
+export function listPeers(userId: number, networkId: number): PeerRecord[] {
+  return (listPeersStmt.all(userId, networkId) as PeerRow[]).map(mapPeer);
+}
+
+// ─── incoming sessions (per sender, per channel) ─────────────────────────────
+
+const upsertIncomingStmt = db.prepare(`
+  INSERT INTO e2e_incoming_sessions
+    (user_id, network_id, handle, channel, fingerprint, sk, status, created_at)
+  VALUES
+    (@userId, @networkId, @handle, @channel, @fingerprint, @sk, @status, @createdAt)
+  ON CONFLICT(user_id, network_id, handle, channel) DO UPDATE SET
+    fingerprint = excluded.fingerprint, sk = excluded.sk,
+    status = excluded.status, created_at = excluded.created_at
+`);
+const getIncomingFpStmt = db.prepare(
+  `SELECT fingerprint FROM e2e_incoming_sessions
+   WHERE user_id = ? AND network_id = ? AND handle = ? AND channel = ?`,
+);
+const getIncomingStmt = db.prepare(
+  `SELECT * FROM e2e_incoming_sessions
+   WHERE user_id = ? AND network_id = ? AND handle = ? AND channel = ?`,
+);
+const updateIncomingStatusStmt = db.prepare(
+  `UPDATE e2e_incoming_sessions SET status = ?
+   WHERE user_id = ? AND network_id = ? AND handle = ? AND channel = ?`,
+);
+const deleteIncomingStmt = db.prepare(
+  `DELETE FROM e2e_incoming_sessions
+   WHERE user_id = ? AND network_id = ? AND handle = ? AND channel = ?`,
+);
+const deleteIncomingForHandleStmt = db.prepare(
+  `DELETE FROM e2e_incoming_sessions WHERE user_id = ? AND network_id = ? AND handle = ?`,
+);
+const listTrustedForChannelStmt = db.prepare(
+  `SELECT * FROM e2e_incoming_sessions
+   WHERE user_id = ? AND network_id = ? AND channel = ? AND status = 'trusted'`,
+);
+const listIncomingStmt = db.prepare(
+  `SELECT * FROM e2e_incoming_sessions WHERE user_id = ? AND network_id = ?
+   ORDER BY channel ASC, handle ASC`,
+);
+
+interface IncomingRow {
+  handle: string;
+  channel: string;
+  fingerprint: Buffer;
+  sk: string;
+  status: string;
+  created_at: number;
+}
+function mapIncoming(r: IncomingRow): IncomingSession {
+  return {
+    handle: r.handle,
+    channel: r.channel,
+    fingerprint: fromBlob(r.fingerprint),
+    sk: openKey(r.sk),
+    status: parseTrustStatus(r.status),
+    createdAt: r.created_at,
+  };
+}
+function incomingBind(userId: number, networkId: number, s: IncomingSession) {
+  return {
+    userId,
+    networkId,
+    handle: s.handle,
+    channel: s.channel,
+    fingerprint: toBlob(s.fingerprint),
+    sk: sealKey(s.sk),
+    status: s.status,
+    createdAt: s.createdAt,
+  };
+}
+
+/** Unconditional upsert (override / import / test path). */
+export function setIncomingSession(userId: number, networkId: number, s: IncomingSession): void {
+  upsertIncomingStmt.run(incomingBind(userId, networkId, s));
+}
+
+/**
+ * Install under strict TOFU: if a row already exists for `(handle, channel)`
+ * with a different fingerprint, throw `HandleMismatchError` and leave the
+ * existing row untouched. Same fingerprint (idempotent refresh) upserts.
+ */
+export function installIncomingSessionStrict(
+  userId: number,
+  networkId: number,
+  s: IncomingSession,
+): void {
+  const existing = getIncomingFpStmt.get(userId, networkId, s.handle, s.channel) as
+    | { fingerprint: Buffer }
+    | undefined;
+  if (existing) {
+    const pinned = Buffer.from(existing.fingerprint).toString('hex');
+    const incoming = Buffer.from(s.fingerprint).toString('hex');
+    if (pinned !== incoming) throw new HandleMismatchError(pinned, incoming);
+  }
+  upsertIncomingStmt.run(incomingBind(userId, networkId, s));
+}
+
+export function getIncomingSession(
+  userId: number,
+  networkId: number,
+  handle: string,
+  channel: string,
+): IncomingSession | null {
+  const r = getIncomingStmt.get(userId, networkId, handle, channel) as IncomingRow | undefined;
+  return r ? mapIncoming(r) : null;
+}
+
+export function updateIncomingStatus(
+  userId: number,
+  networkId: number,
+  handle: string,
+  channel: string,
+  status: TrustStatus,
+): void {
+  updateIncomingStatusStmt.run(status, userId, networkId, handle, channel);
+}
+
+export function deleteIncomingSession(
+  userId: number,
+  networkId: number,
+  handle: string,
+  channel: string,
+): void {
+  deleteIncomingStmt.run(userId, networkId, handle, channel);
+}
+
+/** Delete every incoming session for a handle (across channels); returns the
+ *  number removed, for a user-facing reverify summary. */
+export function deleteIncomingSessionsForHandle(
+  userId: number,
+  networkId: number,
+  handle: string,
+): number {
+  return deleteIncomingForHandleStmt.run(userId, networkId, handle).changes;
+}
+
+/** Trusted incoming sessions for a channel (the decrypt hot path). */
+export function listTrustedSessionsForChannel(
+  userId: number,
+  networkId: number,
+  channel: string,
+): IncomingSession[] {
+  return (listTrustedForChannelStmt.all(userId, networkId, channel) as IncomingRow[]).map(
+    mapIncoming,
+  );
+}
+
+export function listIncomingSessions(userId: number, networkId: number): IncomingSession[] {
+  return (listIncomingStmt.all(userId, networkId) as IncomingRow[]).map(mapIncoming);
+}
+
+// ─── outgoing sessions (our key, per channel) ────────────────────────────────
+
+const upsertOutgoingStmt = db.prepare(`
+  INSERT INTO e2e_outgoing_sessions (user_id, network_id, channel, sk, created_at, pending_rotation)
+  VALUES (@userId, @networkId, @channel, @sk, @createdAt, 0)
+  ON CONFLICT(user_id, network_id, channel) DO UPDATE SET
+    sk = excluded.sk, created_at = excluded.created_at, pending_rotation = 0
+`);
+const getOutgoingStmt = db.prepare(
+  `SELECT * FROM e2e_outgoing_sessions WHERE user_id = ? AND network_id = ? AND channel = ?`,
+);
+const setPendingRotationStmt = db.prepare(
+  `UPDATE e2e_outgoing_sessions SET pending_rotation = ?
+   WHERE user_id = ? AND network_id = ? AND channel = ?`,
+);
+const listOutgoingStmt = db.prepare(
+  `SELECT * FROM e2e_outgoing_sessions WHERE user_id = ? AND network_id = ? ORDER BY channel ASC`,
+);
+
+interface OutgoingRow {
+  channel: string;
+  sk: string;
+  created_at: number;
+  pending_rotation: number;
+}
+function mapOutgoing(r: OutgoingRow): OutgoingSession {
+  return {
+    channel: r.channel,
+    sk: openKey(r.sk),
+    createdAt: r.created_at,
+    pendingRotation: r.pending_rotation === 1,
+  };
+}
+
+export function setOutgoingSession(
+  userId: number,
+  networkId: number,
+  channel: string,
+  sk: Uint8Array,
+  createdAt: number,
+): void {
+  upsertOutgoingStmt.run({ userId, networkId, channel, sk: sealKey(sk), createdAt });
+}
+
+export function getOutgoingSession(
+  userId: number,
+  networkId: number,
+  channel: string,
+): OutgoingSession | null {
+  const r = getOutgoingStmt.get(userId, networkId, channel) as OutgoingRow | undefined;
+  return r ? mapOutgoing(r) : null;
+}
+
+export function markOutgoingPendingRotation(
+  userId: number,
+  networkId: number,
+  channel: string,
+): void {
+  setPendingRotationStmt.run(1, userId, networkId, channel);
+}
+
+export function clearOutgoingPendingRotation(
+  userId: number,
+  networkId: number,
+  channel: string,
+): void {
+  setPendingRotationStmt.run(0, userId, networkId, channel);
+}
+
+export function listOutgoingSessions(userId: number, networkId: number): OutgoingSession[] {
+  return (listOutgoingStmt.all(userId, networkId) as OutgoingRow[]).map(mapOutgoing);
+}
+
+// ─── channel config ──────────────────────────────────────────────────────────
+
+const upsertChannelConfigStmt = db.prepare(`
+  INSERT INTO e2e_channel_config (user_id, network_id, channel, enabled, mode)
+  VALUES (@userId, @networkId, @channel, @enabled, @mode)
+  ON CONFLICT(user_id, network_id, channel) DO UPDATE SET
+    enabled = excluded.enabled, mode = excluded.mode
+`);
+const getChannelConfigStmt = db.prepare(
+  `SELECT * FROM e2e_channel_config WHERE user_id = ? AND network_id = ? AND channel = ?`,
+);
+const listChannelConfigsStmt = db.prepare(
+  `SELECT * FROM e2e_channel_config WHERE user_id = ? AND network_id = ? ORDER BY channel ASC`,
+);
+
+interface ChannelConfigRow {
+  channel: string;
+  enabled: number;
+  mode: string;
+}
+function mapChannelConfig(r: ChannelConfigRow): ChannelConfig {
+  return { channel: r.channel, enabled: r.enabled === 1, mode: parseChannelMode(r.mode) };
+}
+
+export function setChannelConfig(userId: number, networkId: number, cfg: ChannelConfig): void {
+  upsertChannelConfigStmt.run({
+    userId,
+    networkId,
+    channel: cfg.channel,
+    enabled: cfg.enabled ? 1 : 0,
+    mode: cfg.mode,
+  });
+}
+
+export function getChannelConfig(
+  userId: number,
+  networkId: number,
+  channel: string,
+): ChannelConfig | null {
+  const r = getChannelConfigStmt.get(userId, networkId, channel) as ChannelConfigRow | undefined;
+  return r ? mapChannelConfig(r) : null;
+}
+
+export function listChannelConfigs(userId: number, networkId: number): ChannelConfig[] {
+  return (listChannelConfigsStmt.all(userId, networkId) as ChannelConfigRow[]).map(
+    mapChannelConfig,
+  );
+}
+
+// ─── autotrust ───────────────────────────────────────────────────────────────
+
+const addAutotrustStmt = db.prepare(`
+  INSERT OR IGNORE INTO e2e_autotrust (user_id, network_id, scope, handle_pattern, created_at)
+  VALUES (?, ?, ?, ?, ?)
+`);
+const listAutotrustStmt = db.prepare(
+  `SELECT scope, handle_pattern FROM e2e_autotrust WHERE user_id = ? AND network_id = ?`,
+);
+const removeAutotrustStmt = db.prepare(
+  `DELETE FROM e2e_autotrust WHERE user_id = ? AND network_id = ? AND handle_pattern = ?`,
+);
+const matchAutotrustStmt = db.prepare(
+  `SELECT handle_pattern FROM e2e_autotrust
+   WHERE user_id = ? AND network_id = ? AND (scope = 'global' OR scope = ?)`,
+);
+
+export interface AutotrustRule {
+  scope: string;
+  handlePattern: string;
+}
+
+export function addAutotrust(
+  userId: number,
+  networkId: number,
+  scope: string,
+  handlePattern: string,
+  createdAt: number,
+): void {
+  addAutotrustStmt.run(userId, networkId, scope, handlePattern, createdAt);
+}
+
+export function listAutotrust(userId: number, networkId: number): AutotrustRule[] {
+  return (
+    listAutotrustStmt.all(userId, networkId) as Array<{ scope: string; handle_pattern: string }>
+  ).map((r) => ({ scope: r.scope, handlePattern: r.handle_pattern }));
+}
+
+export function removeAutotrust(userId: number, networkId: number, handlePattern: string): void {
+  removeAutotrustStmt.run(userId, networkId, handlePattern);
+}
+
+/**
+ * True if any autotrust rule (global, or scoped to `channel`) matches `handle`.
+ * Patterns use minimal case-insensitive glob: `*` any run, `?` one char.
+ */
+export function autotrustMatches(
+  userId: number,
+  networkId: number,
+  handle: string,
+  channel: string,
+): boolean {
+  const rows = matchAutotrustStmt.all(userId, networkId, channel) as Array<{
+    handle_pattern: string;
+  }>;
+  return rows.some((r) => globMatchCi(r.handle_pattern, handle));
+}
+
+/** Minimal case-insensitive glob: `*` matches any run, `?` one char, else literal. */
+export function globMatchCi(pattern: string, input: string): boolean {
+  const p = pattern.toLowerCase();
+  const s = input.toLowerCase();
+  let pi = 0;
+  let si = 0;
+  let star = -1;
+  let mark = 0;
+  while (si < s.length) {
+    if (pi < p.length && (p[pi] === '?' || p[pi] === s[si])) {
+      pi++;
+      si++;
+    } else if (pi < p.length && p[pi] === '*') {
+      star = pi++;
+      mark = si;
+    } else if (star !== -1) {
+      pi = star + 1;
+      si = ++mark;
+    } else {
+      return false;
+    }
+  }
+  while (pi < p.length && p[pi] === '*') pi++;
+  return pi === p.length;
+}
+
+// ─── outgoing recipients (for lazy-rotate distribution) ──────────────────────
+
+const recordRecipientStmt = db.prepare(`
+  INSERT INTO e2e_outgoing_recipients (user_id, network_id, channel, handle, fingerprint, first_sent_at)
+  VALUES (@userId, @networkId, @channel, @handle, @fingerprint, @firstSentAt)
+  ON CONFLICT(user_id, network_id, channel, handle) DO UPDATE SET fingerprint = excluded.fingerprint
+`);
+const listRecipientsStmt = db.prepare(
+  `SELECT handle, fingerprint FROM e2e_outgoing_recipients
+   WHERE user_id = ? AND network_id = ? AND channel = ? ORDER BY first_sent_at ASC`,
+);
+const removeRecipientStmt = db.prepare(
+  `DELETE FROM e2e_outgoing_recipients
+   WHERE user_id = ? AND network_id = ? AND channel = ? AND handle = ?`,
+);
+const deleteRecipientsForHandleStmt = db.prepare(
+  `DELETE FROM e2e_outgoing_recipients WHERE user_id = ? AND network_id = ? AND handle = ?`,
+);
+
+export interface OutgoingRecipient {
+  handle: string;
+  fingerprint: Uint8Array;
+}
+
+export function recordOutgoingRecipient(
+  userId: number,
+  networkId: number,
+  channel: string,
+  handle: string,
+  fingerprint: Uint8Array,
+  firstSentAt: number,
+): void {
+  recordRecipientStmt.run({
+    userId,
+    networkId,
+    channel,
+    handle,
+    fingerprint: toBlob(fingerprint),
+    firstSentAt,
+  });
+}
+
+export function listOutgoingRecipients(
+  userId: number,
+  networkId: number,
+  channel: string,
+): OutgoingRecipient[] {
+  return (
+    listRecipientsStmt.all(userId, networkId, channel) as Array<{
+      handle: string;
+      fingerprint: Buffer;
+    }>
+  ).map((r) => ({ handle: r.handle, fingerprint: fromBlob(r.fingerprint) }));
+}
+
+export function removeOutgoingRecipient(
+  userId: number,
+  networkId: number,
+  channel: string,
+  handle: string,
+): void {
+  removeRecipientStmt.run(userId, networkId, channel, handle);
+}
+
+export function deleteOutgoingRecipientsForHandle(
+  userId: number,
+  networkId: number,
+  handle: string,
+): number {
+  return deleteRecipientsForHandleStmt.run(userId, networkId, handle).changes;
+}

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -435,6 +435,47 @@ export const EXPORT_TABLES = Object.freeze({
       'system-buffer log (server lifecycle events + global notices); ' +
       'transient operational state rebuilt by the live instance, not portable user data',
   },
+
+  // RPE2E keyring (#382). Deliberately NOT in the bulk user data export. The
+  // export DECRYPTS at-rest secrets to plaintext for cross-instance portability
+  // (see exportService.ts) — so including these would drop the identity PRIVATE
+  // KEY into every routine "download my data" artifact. Unlike a rotatable IRC
+  // password, a leaked identity key lets someone impersonate you to every peer
+  // until you rotate it AND each peer re-verifies your new fingerprint — too
+  // high-consequence to bundle by default into an export most users take
+  // without even using E2E. Keyring portability is therefore a separate,
+  // explicitly-warned `/e2e export` (mirrors repartee's standalone keyring
+  // export) that MUST ship when E2E goes live, so migrating users keep their
+  // identity + trust pins rather than silently resetting them.
+  e2e_identity: {
+    mode: 'skip',
+    reason:
+      'E2E identity private key; cryptographic secret, exported via the dedicated /e2e export',
+  },
+  e2e_peers: {
+    mode: 'skip',
+    reason: 'E2E peer TOFU pins; part of the keyring, exported via the dedicated /e2e export',
+  },
+  e2e_incoming_sessions: {
+    mode: 'skip',
+    reason: 'E2E per-sender session keys; cryptographic secrets, exported via /e2e export',
+  },
+  e2e_outgoing_sessions: {
+    mode: 'skip',
+    reason: 'E2E per-channel session keys; cryptographic secrets, exported via /e2e export',
+  },
+  e2e_channel_config: {
+    mode: 'skip',
+    reason: 'E2E per-channel encryption policy; part of the keyring, exported via /e2e export',
+  },
+  e2e_autotrust: {
+    mode: 'skip',
+    reason: 'E2E autotrust rules; part of the keyring, exported via /e2e export',
+  },
+  e2e_outgoing_recipients: {
+    mode: 'skip',
+    reason: 'E2E key-distribution bookkeeping; transient keyring state, exported via /e2e export',
+  },
 });
 
 // Insertion order on import. Each table must come after every table it

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -559,28 +559,34 @@ function migrate() {
     -- RPE2E end-to-end-encryption keyring (issue #382). Secrets — the identity
     -- private key and the session keys — are stored as secretCrypto envelopes
     -- (TEXT, the same lk1.* at-rest scheme as network credentials); public
-    -- material (pubkeys, fingerprints) is BLOB. The identity is per-ACCOUNT (one
-    -- keypair shared across a user's networks, so a peer verifies the fingerprint
-    -- once); everything else is scoped per (user, network) since IRC handles and
-    -- channels are network-specific. See server/db/e2e.ts.
+    -- material (pubkeys, fingerprints) is BLOB with a length CHECK so a
+    -- truncated/corrupt restore fails loud here, not deep in crypto. The
+    -- identity is per-ACCOUNT (one keypair shared across a user's networks, so a
+    -- peer verifies the fingerprint once); everything else is scoped per (user,
+    -- network) since IRC handles and channels are network-specific. IRC-target
+    -- columns (handle / channel / scope / last_handle / last_nick) are
+    -- COLLATE NOCASE per house style — servers send inconsistent casing, so the
+    -- composite PKs dedupe and lookups fold case (the E2eManager still owns the
+    -- exact on-the-wire casing that goes into the AAD). See server/db/e2e.ts.
     CREATE TABLE IF NOT EXISTS e2e_identity (
       user_id INTEGER PRIMARY KEY,
-      pubkey BLOB NOT NULL,
+      pubkey BLOB NOT NULL CHECK (length(pubkey) = 32),
       privkey TEXT NOT NULL,
-      fingerprint BLOB NOT NULL,
+      fingerprint BLOB NOT NULL CHECK (length(fingerprint) = 16),
       created_at INTEGER NOT NULL,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
     CREATE TABLE IF NOT EXISTS e2e_peers (
       user_id INTEGER NOT NULL,
       network_id INTEGER NOT NULL,
-      fingerprint BLOB NOT NULL,
-      pubkey BLOB NOT NULL,
-      last_handle TEXT,
-      last_nick TEXT,
+      fingerprint BLOB NOT NULL CHECK (length(fingerprint) = 16),
+      pubkey BLOB NOT NULL CHECK (length(pubkey) = 32),
+      last_handle TEXT COLLATE NOCASE,
+      last_nick TEXT COLLATE NOCASE,
       first_seen INTEGER NOT NULL,
       last_seen INTEGER NOT NULL,
-      global_status TEXT NOT NULL DEFAULT 'pending',
+      global_status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (global_status IN ('pending', 'trusted', 'revoked')),
       PRIMARY KEY (user_id, network_id, fingerprint),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
@@ -590,11 +596,12 @@ function migrate() {
     CREATE TABLE IF NOT EXISTS e2e_incoming_sessions (
       user_id INTEGER NOT NULL,
       network_id INTEGER NOT NULL,
-      handle TEXT NOT NULL,
-      channel TEXT NOT NULL,
-      fingerprint BLOB NOT NULL,
+      handle TEXT NOT NULL COLLATE NOCASE,
+      channel TEXT NOT NULL COLLATE NOCASE,
+      fingerprint BLOB NOT NULL CHECK (length(fingerprint) = 16),
       sk TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'pending',
+      status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'trusted', 'revoked')),
       created_at INTEGER NOT NULL,
       PRIMARY KEY (user_id, network_id, handle, channel),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
@@ -605,7 +612,7 @@ function migrate() {
     CREATE TABLE IF NOT EXISTS e2e_outgoing_sessions (
       user_id INTEGER NOT NULL,
       network_id INTEGER NOT NULL,
-      channel TEXT NOT NULL,
+      channel TEXT NOT NULL COLLATE NOCASE,
       sk TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       pending_rotation INTEGER NOT NULL DEFAULT 0,
@@ -616,9 +623,10 @@ function migrate() {
     CREATE TABLE IF NOT EXISTS e2e_channel_config (
       user_id INTEGER NOT NULL,
       network_id INTEGER NOT NULL,
-      channel TEXT NOT NULL,
+      channel TEXT NOT NULL COLLATE NOCASE,
       enabled INTEGER NOT NULL DEFAULT 0,
-      mode TEXT NOT NULL DEFAULT 'normal',
+      mode TEXT NOT NULL DEFAULT 'normal'
+        CHECK (mode IN ('auto-accept', 'normal', 'quiet')),
       PRIMARY KEY (user_id, network_id, channel),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
@@ -627,7 +635,7 @@ function migrate() {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id INTEGER NOT NULL,
       network_id INTEGER NOT NULL,
-      scope TEXT NOT NULL,
+      scope TEXT NOT NULL COLLATE NOCASE,
       handle_pattern TEXT NOT NULL,
       created_at INTEGER NOT NULL,
       UNIQUE (user_id, network_id, scope, handle_pattern),
@@ -637,14 +645,16 @@ function migrate() {
     CREATE TABLE IF NOT EXISTS e2e_outgoing_recipients (
       user_id INTEGER NOT NULL,
       network_id INTEGER NOT NULL,
-      channel TEXT NOT NULL,
-      handle TEXT NOT NULL,
-      fingerprint BLOB NOT NULL,
+      channel TEXT NOT NULL COLLATE NOCASE,
+      handle TEXT NOT NULL COLLATE NOCASE,
+      fingerprint BLOB NOT NULL CHECK (length(fingerprint) = 16),
       first_sent_at INTEGER NOT NULL,
       PRIMARY KEY (user_id, network_id, channel, handle),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
     );
+    CREATE INDEX IF NOT EXISTS idx_e2e_recipients_handle
+      ON e2e_outgoing_recipients(user_id, network_id, handle);
   `);
 }
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -555,6 +555,96 @@ function migrate() {
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_system_messages_recent ON system_messages(user_id, id);
+
+    -- RPE2E end-to-end-encryption keyring (issue #382). Secrets — the identity
+    -- private key and the session keys — are stored as secretCrypto envelopes
+    -- (TEXT, the same lk1.* at-rest scheme as network credentials); public
+    -- material (pubkeys, fingerprints) is BLOB. The identity is per-ACCOUNT (one
+    -- keypair shared across a user's networks, so a peer verifies the fingerprint
+    -- once); everything else is scoped per (user, network) since IRC handles and
+    -- channels are network-specific. See server/db/e2e.ts.
+    CREATE TABLE IF NOT EXISTS e2e_identity (
+      user_id INTEGER PRIMARY KEY,
+      pubkey BLOB NOT NULL,
+      privkey TEXT NOT NULL,
+      fingerprint BLOB NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS e2e_peers (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      fingerprint BLOB NOT NULL,
+      pubkey BLOB NOT NULL,
+      last_handle TEXT,
+      last_nick TEXT,
+      first_seen INTEGER NOT NULL,
+      last_seen INTEGER NOT NULL,
+      global_status TEXT NOT NULL DEFAULT 'pending',
+      PRIMARY KEY (user_id, network_id, fingerprint),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_e2e_peers_handle
+      ON e2e_peers(user_id, network_id, last_handle);
+    CREATE TABLE IF NOT EXISTS e2e_incoming_sessions (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      handle TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      fingerprint BLOB NOT NULL,
+      sk TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (user_id, network_id, handle, channel),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_e2e_incoming_channel
+      ON e2e_incoming_sessions(user_id, network_id, channel);
+    CREATE TABLE IF NOT EXISTS e2e_outgoing_sessions (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      channel TEXT NOT NULL,
+      sk TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      pending_rotation INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (user_id, network_id, channel),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS e2e_channel_config (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      channel TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 0,
+      mode TEXT NOT NULL DEFAULT 'normal',
+      PRIMARY KEY (user_id, network_id, channel),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS e2e_autotrust (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      scope TEXT NOT NULL,
+      handle_pattern TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      UNIQUE (user_id, network_id, scope, handle_pattern),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS e2e_outgoing_recipients (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      channel TEXT NOT NULL,
+      handle TEXT NOT NULL,
+      fingerprint BLOB NOT NULL,
+      first_sent_at INTEGER NOT NULL,
+      PRIMARY KEY (user_id, network_id, channel, handle),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
   `);
 }
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -13,6 +13,7 @@ import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { backfillEncryptNetworkSecrets } from './db/networks.js';
+import { backfillEncryptE2eSecrets } from './db/e2e.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
@@ -81,6 +82,15 @@ const wrapped = backfillEncryptNetworkSecrets();
 if (wrapped.encrypted > 0) {
   console.log(`[lurker] encrypted ${wrapped.encrypted} network-secret row(s) at rest`);
   systemLog.log({ scope: 'server', text: `Encrypted ${wrapped.encrypted} network-secret row(s)` });
+}
+
+// Same re-seal for the RPE2E keyring's secret columns (identity privkey +
+// session keys), so a keyless-written cell that later gains a key never leaves
+// the identity private key as cleartext in the R2 backup (#382).
+const wrappedE2e = backfillEncryptE2eSecrets();
+if (wrappedE2e.encrypted > 0) {
+  console.log(`[lurker] encrypted ${wrappedE2e.encrypted} e2e key row(s) at rest`);
+  systemLog.log({ scope: 'server', text: `Encrypted ${wrappedE2e.encrypted} e2e key row(s)` });
 }
 
 ircManager.initAll();


### PR DESCRIPTION
## RPE2E keyring storage layer (phase 1a of #382)

The persistent storage for the E2E keyring — a faithful port of repartee's `keyring.rs`, adapted for Lurker's multi-tenant cell. **Pure storage + CRUD**: no handshake orchestration, IRC wiring, or UI (those are later phases). Builds on the merged crypto core (#394).

### Schema — 7 `e2e_*` tables (`db/index.ts` `migrate()`)
- **`e2e_identity` keyed by `user_id`** — the identity is per-account (one keypair shared across a user's networks, so a peer verifies the fingerprint once).
- `e2e_peers`, `e2e_incoming_sessions`, `e2e_outgoing_sessions`, `e2e_channel_config`, `e2e_autotrust`, `e2e_outgoing_recipients` — all scoped `(user_id, network_id)`, FK-cascaded.
- **Secrets** (identity `privkey`, session `sk`s) are `TEXT` holding `secretCrypto` `lk1.*` envelopes (same at-rest scheme as network creds — matters because hosted cell DBs ship to R2). **Public material** (pubkeys, fingerprints) is `BLOB` with a `length()` `CHECK`.
- **`COLLATE NOCASE`** on every IRC-target column (`handle`/`channel`/`scope`/`last_handle`/`last_nick`) per house style — servers send inconsistent casing, so the PKs dedupe and lookups fold. The manager still owns the exact on-the-wire casing for the AAD.

### `server/db/e2e.ts` — keyring CRUD
Identity save/load, peer upsert + reverse-handle lookup + explicit `setPeerStatus`, incoming sessions with **strict TOFU** (`installIncomingSessionStrict` → `HandleMismatchError` on a changed fingerprint), trust-status transitions, outgoing sessions + lazy-rotation flag, channel config, autotrust (+ glob match via the shared `globToRegexSource`), and recipient tracking. Plus `backfillEncryptE2eSecrets()` (run at boot) to re-seal any keyless-written secrets.

### `exportSchema.ts` — keyring is `skip`
Deliberately **excluded from the bulk user data export**: the export decrypts secrets to plaintext for portability, so bundling these would drop the identity private key into every routine "download my data" artifact — too high-consequence (impersonation, vs. a rotatable password). Keyring portability will be a separate, explicitly-warned `/e2e export`, required when E2E goes live. (Also satisfies the schema-completeness guard.)

### Reviewed
Two passes folded in (second commit): `COLLATE NOCASE` case-folding, the boot re-seal backfill (identity key never lingers cleartext in R2), read-time length validation + schema `CHECK`s, `E2eError`-wrapped fail-loud reads with a resilient trusted-session read, and `upsertPeer` no longer clobbering trust status.

### Deferred
`replace_all_for_import` (the portable JSON import) lands with the `/e2e export` feature.

### Checks
Full server suite **1078 tests** pass (33 in the keyring suite); typecheck / oxlint / oxfmt clean. Nothing user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
