### PR TITLE
RPE2E E2eManager: handshake orchestration + encrypt/decrypt + rate limiter (#382)

### DIFF
--- a/server/db/e2e.ts
+++ b/server/db/e2e.ts
@@ -318,6 +318,14 @@ const deleteIncomingStmt = db.prepare(
 const deleteIncomingForHandleStmt = db.prepare(
   `DELETE FROM e2e_incoming_sessions WHERE user_id = ? AND network_id = ? AND handle = ?`,
 );
+const revokeIncomingForHandleStmt = db.prepare(
+  `UPDATE e2e_incoming_sessions SET status = 'revoked'
+   WHERE user_id = ? AND network_id = ? AND handle = ?`,
+);
+const incomingChannelsForHandleStmt = db.prepare(
+  `SELECT DISTINCT channel FROM e2e_incoming_sessions
+   WHERE user_id = ? AND network_id = ? AND handle = ?`,
+);
 const listTrustedForChannelStmt = db.prepare(
   `SELECT * FROM e2e_incoming_sessions
    WHERE user_id = ? AND network_id = ? AND channel = ? AND status = 'trusted'`,
@@ -427,6 +435,28 @@ export function deleteIncomingSessionsForHandle(
   handle: string,
 ): number {
   return deleteIncomingForHandleStmt.run(userId, networkId, handle).changes;
+}
+
+/** Mark every incoming session for a handle revoked, without unsealing any key.
+ *  Returns the number of rows changed. */
+export function revokeIncomingSessionsForHandle(
+  userId: number,
+  networkId: number,
+  handle: string,
+): number {
+  return revokeIncomingForHandleStmt.run(userId, networkId, handle).changes;
+}
+
+/** The distinct channels a handle has incoming sessions on (no unsealing) —
+ *  used to target outgoing-key rotation on revoke. */
+export function listIncomingChannelsForHandle(
+  userId: number,
+  networkId: number,
+  handle: string,
+): string[] {
+  return (
+    incomingChannelsForHandleStmt.all(userId, networkId, handle) as Array<{ channel: string }>
+  ).map((r) => r.channel);
 }
 
 /** Trusted incoming sessions for a channel (the decrypt hot path). A single

--- a/server/services/e2e/manager.test.ts
+++ b/server/services/e2e/manager.test.ts
@@ -59,7 +59,7 @@ function fullHandshake(channel: string): void {
   mgr.setChannelConfig(alice, aliceNet, channel, true, 'auto-accept');
   mgr.setChannelConfig(bob, bobNet, channel, true, 'auto-accept');
   // Bob → KEYREQ; Alice → KEYRSP + reciprocal KEYREQ.
-  const req = mgr.buildKeyReq(bob, bobNet, channel);
+  const req = mgr.buildKeyReq(bob, bobNet, channel)!;
   const aOut = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', req)!;
   expect(aOut.replies).toHaveLength(2);
   mgr.handleHandshakeBody(bob, bobNet, ALICE_H, 'alice', aOut.replies[0]); // KEYRSP → Bob installs Alice's key
@@ -132,7 +132,7 @@ describe('E2eManager trust modes', () => {
     mgr.setChannelConfig(alice, aliceNet, '#nrm', true, 'normal');
     mgr.setChannelConfig(bob, bobNet, '#nrm', true, 'auto-accept');
 
-    const req = mgr.buildKeyReq(bob, bobNet, '#nrm');
+    const req = mgr.buildKeyReq(bob, bobNet, '#nrm')!;
     const out = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', req)!;
     expect(out.replies).toHaveLength(0); // no auto-response in normal mode
     expect(out.notice?.text).toMatch(/wants to start an encrypted session/);
@@ -153,10 +153,19 @@ describe('E2eManager trust modes', () => {
 
   it('quiet mode silently ignores an unknown peer', () => {
     mgr.setChannelConfig(alice, aliceNet, '#qt', true, 'quiet');
-    const req = mgr.buildKeyReq(bob, bobNet, '#qt');
+    const req = mgr.buildKeyReq(bob, bobNet, '#qt')!;
     const out = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', req)!;
     expect(out.replies).toHaveLength(0);
     expect(out.notice).toBeUndefined();
+  });
+
+  it('accept folds case — different handle/channel casing still finds the cached KEYREQ', () => {
+    mgr.setChannelConfig(alice, aliceNet, '#NormCase', true, 'normal');
+    const req = mgr.buildKeyReq(bob, bobNet, '#NormCase')!;
+    mgr.handleHandshakeBody(alice, aliceNet, '~Bob@B.Host', 'Bob', req); // cached under one casing
+    // Accept with a different casing of both handle and channel.
+    const accepted = mgr.acceptPending(alice, aliceNet, '~bob@b.host', '#normcase');
+    expect(accepted.replies.length).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -173,7 +182,7 @@ describe('E2eManager TOFU + replay + window', () => {
       nick: 'm',
     })!.id;
     mgr.setChannelConfig(mallory, malloryNet, '#tofu', true, 'auto-accept');
-    const impostorReq = mgr.buildKeyReq(mallory, malloryNet, '#tofu');
+    const impostorReq = mgr.buildKeyReq(mallory, malloryNet, '#tofu')!;
 
     const out = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', impostorReq)!;
     expect(out.replies).toHaveLength(0); // refused
@@ -202,18 +211,18 @@ describe('E2eManager TOFU + replay + window', () => {
 
 describe('E2eManager identity + verify', () => {
   it('returns a stable per-account identity with a 6-word SAS', () => {
-    const a1 = mgr.getIdentity(alice);
-    const a2 = new mod.E2eManager({ now: () => clock }).getIdentity(alice); // reload from DB
+    const a1 = mgr.getIdentity(alice)!;
+    const a2 = new mod.E2eManager({ now: () => clock }).getIdentity(alice)!; // reload from DB
     expect(a2.fingerprintHex).toBe(a1.fingerprintHex);
     expect(a1.sas.split(' ')).toHaveLength(6);
     // Different account → different identity.
-    expect(mgr.getIdentity(bob).fingerprintHex).not.toBe(a1.fingerprintHex);
+    expect(mgr.getIdentity(bob)!.fingerprintHex).not.toBe(a1.fingerprintHex);
   });
 
   it('verifyInfo returns the peer fingerprint after a handshake', () => {
     fullHandshake('#vf');
     const info = mgr.verifyInfo(alice, aliceNet, BOB_H)!;
-    expect(info.fingerprintHex).toBe(mgr.getIdentity(bob).fingerprintHex);
+    expect(info.fingerprintHex).toBe(mgr.getIdentity(bob)!.fingerprintHex);
     expect(info.status).toBe('trusted');
   });
 
@@ -265,7 +274,7 @@ describe('E2eManager review hardening', () => {
   it('warns rather than silently auto-migrating when a known key reappears under a new handle (#3)', () => {
     fullHandshake('#hc'); // pins Bob's fp under BOB_H for Alice
     const NEW_BOB = '~bob@newhost';
-    const req = mgr.buildKeyReq(bob, bobNet, '#hc'); // Bob's identity, new handshake
+    const req = mgr.buildKeyReq(bob, bobNet, '#hc')!; // Bob's identity, new handshake
     const out = mgr.handleHandshakeBody(alice, aliceNet, NEW_BOB, 'bob', req)!;
     expect(out.replies).toHaveLength(0);
     expect(out.notice?.text).toMatch(/new handle/);
@@ -281,7 +290,7 @@ describe('E2eManager review hardening', () => {
       aliceNet,
       BOB_H,
       'bob',
-      mgr.buildKeyReq(bob, bobNet, '#stale', ALICE_H),
+      mgr.buildKeyReq(bob, bobNet, '#stale', ALICE_H)!,
     )!;
     // Bob answers Alice's reciprocal with his KEYRSP — capture but DON'T deliver.
     const bobRsp = mgr.handleHandshakeBody(bob, bobNet, ALICE_H, 'alice', aOut.replies[1])!

--- a/server/services/e2e/manager.test.ts
+++ b/server/services/e2e/manager.test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Isolate the DB at a throwaway file before any db-touching module loads. No
+// LURKER_SECRET_KEY is set — the keyring's sealing is a no-op passthrough, which
+// the manager doesn't care about (it gets the same bytes back) and which keeps
+// this file from leaking that env var into other test files.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-e2e-manager-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let mod: typeof import('./manager.js');
+let createUser: typeof import('../../db/users.js').createUser;
+let createNetwork: typeof import('../../db/networks.js').createNetwork;
+
+// Two Lurker accounts standing in for the two ends of an encrypted conversation.
+let alice: number;
+let bob: number;
+let aliceNet: number;
+let bobNet: number;
+const ALICE_H = '~alice@a.host';
+const BOB_H = '~bob@b.host';
+
+let clock: number;
+let mgr: import('./manager.js').E2eManager;
+
+beforeAll(async () => {
+  mod = await import('./manager.js');
+  ({ createUser } = await import('../../db/users.js'));
+  ({ createNetwork } = await import('../../db/networks.js'));
+  alice = createUser('mgr-alice').id;
+  bob = createUser('mgr-bob').id;
+  const mkNet = (uid: number) =>
+    createNetwork(uid, { name: 'libera', host: 'h', port: 6697, tls: true, nick: 'n' })!.id;
+  aliceNet = mkNet(alice);
+  bobNet = mkNet(bob);
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+beforeEach(() => {
+  clock = 1_700_000_000_000;
+  mgr = new mod.E2eManager({ now: () => clock });
+});
+
+// Drive a full bidirectional handshake on `channel` (auto-accept both ends).
+function fullHandshake(channel: string): void {
+  mgr.setChannelConfig(alice, aliceNet, channel, true, 'auto-accept');
+  mgr.setChannelConfig(bob, bobNet, channel, true, 'auto-accept');
+  // Bob → KEYREQ; Alice → KEYRSP + reciprocal KEYREQ.
+  const req = mgr.buildKeyReq(bob, bobNet, channel);
+  const aOut = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', req)!;
+  expect(aOut.replies).toHaveLength(2);
+  mgr.handleHandshakeBody(bob, bobNet, ALICE_H, 'alice', aOut.replies[0]); // KEYRSP → Bob installs Alice's key
+  const bOut = mgr.handleHandshakeBody(bob, bobNet, ALICE_H, 'alice', aOut.replies[1])!; // reciprocal
+  expect(bOut.replies).toHaveLength(1); // Bob already trusts Alice → no further reciprocal
+  mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', bOut.replies[0]); // KEYRSP → Alice installs Bob's key
+}
+
+describe('E2eManager handshake + exchange', () => {
+  it('completes a full handshake and exchanges encrypted messages both ways', () => {
+    fullHandshake('#x');
+
+    const aToB = mgr.encryptOutgoing(alice, aliceNet, '#x', 'hello bob')!;
+    expect(aToB).toHaveLength(1);
+    expect(aToB[0].startsWith('+RPE2E01')).toBe(true);
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#x', aToB[0])).toEqual({
+      kind: 'plaintext',
+      text: 'hello bob',
+    });
+
+    const bToA = mgr.encryptOutgoing(bob, bobNet, '#x', 'hi alice 👋')!;
+    expect(mgr.decryptIncoming(alice, aliceNet, BOB_H, '#x', bToA[0])).toEqual({
+      kind: 'plaintext',
+      text: 'hi alice 👋',
+    });
+  });
+
+  it('chunks a long message and decrypts every chunk', () => {
+    fullHandshake('#big');
+    const long = 'x'.repeat(500);
+    const lines = mgr.encryptOutgoing(alice, aliceNet, '#big', long)!;
+    expect(lines.length).toBeGreaterThan(1);
+    const decoded = lines.map((l) => {
+      const out = mgr.decryptIncoming(bob, bobNet, ALICE_H, '#big', l);
+      return out.kind === 'plaintext' ? out.text : `<${out.kind}>`;
+    });
+    expect(decoded.join('')).toBe(long);
+  });
+
+  it('returns null from encryptOutgoing when the channel is not enabled', () => {
+    expect(mgr.encryptOutgoing(alice, aliceNet, '#off', 'secret')).toBeNull();
+  });
+
+  it('passes a non-RPE2E line through as cleartext', () => {
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#x', 'just a normal line')).toEqual({
+      kind: 'cleartext',
+      text: 'just a normal line',
+    });
+  });
+
+  it('reports missing-key when no session exists for the sender', () => {
+    fullHandshake('#mk');
+    const line = mgr.encryptOutgoing(alice, aliceNet, '#mk', 'hi')![0];
+    // Bob has a session for ALICE_H, but not for a different handle.
+    expect(mgr.decryptIncoming(bob, bobNet, '~stranger@h', '#mk', line)).toEqual({
+      kind: 'missing-key',
+    });
+  });
+});
+
+describe('E2eManager trust modes', () => {
+  it('normal mode caches the KEYREQ and accepts on demand', () => {
+    mgr.setChannelConfig(alice, aliceNet, '#nrm', true, 'normal');
+    mgr.setChannelConfig(bob, bobNet, '#nrm', true, 'auto-accept');
+
+    const req = mgr.buildKeyReq(bob, bobNet, '#nrm');
+    const out = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', req)!;
+    expect(out.replies).toHaveLength(0); // no auto-response in normal mode
+    expect(out.notice?.text).toMatch(/wants to start an encrypted session/);
+
+    // Alice accepts → now she emits the KEYRSP (+ reciprocal).
+    const accepted = mgr.acceptPending(alice, aliceNet, BOB_H, '#nrm');
+    expect(accepted.replies.length).toBeGreaterThanOrEqual(1);
+    mgr.handleHandshakeBody(bob, bobNet, ALICE_H, 'alice', accepted.replies[0]); // Bob installs Alice's key
+
+    const line = mgr.encryptOutgoing(alice, aliceNet, '#nrm', 'now secured')![0];
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#nrm', line)).toEqual({
+      kind: 'plaintext',
+      text: 'now secured',
+    });
+  });
+
+  it('quiet mode silently ignores an unknown peer', () => {
+    mgr.setChannelConfig(alice, aliceNet, '#qt', true, 'quiet');
+    const req = mgr.buildKeyReq(bob, bobNet, '#qt');
+    const out = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', req)!;
+    expect(out.replies).toHaveLength(0);
+    expect(out.notice).toBeUndefined();
+  });
+});
+
+describe('E2eManager TOFU + replay + window', () => {
+  it('warns and refuses when a pinned handle presents a new fingerprint', () => {
+    fullHandshake('#tofu'); // pins Bob's fp under BOB_H for Alice
+    // A third identity (mallory) sends a KEYREQ impersonating BOB_H.
+    const mallory = createUser('mgr-mallory').id;
+    const malloryNet = createNetwork(mallory, {
+      name: 'libera',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'm',
+    })!.id;
+    mgr.setChannelConfig(mallory, malloryNet, '#tofu', true, 'auto-accept');
+    const impostorReq = mgr.buildKeyReq(mallory, malloryNet, '#tofu');
+
+    const out = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', impostorReq)!;
+    expect(out.replies).toHaveLength(0); // refused
+    expect(out.notice?.level).toBe('warn');
+    expect(out.notice?.text).toMatch(/key changed/);
+  });
+
+  it('flags a replayed chunk', () => {
+    fullHandshake('#rp');
+    const line = mgr.encryptOutgoing(alice, aliceNet, '#rp', 'once')![0];
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rp', line)).toEqual({
+      kind: 'plaintext',
+      text: 'once',
+    });
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rp', line)).toEqual({ kind: 'replay' });
+  });
+
+  it('rejects a chunk whose ts is outside the tolerance window', () => {
+    fullHandshake('#win');
+    const line = mgr.encryptOutgoing(alice, aliceNet, '#win', 'stale')![0];
+    clock += 1000 * 1000; // advance 1000s, well past the 300s default tolerance
+    const out = mgr.decryptIncoming(bob, bobNet, ALICE_H, '#win', line);
+    expect(out.kind).toBe('rejected');
+  });
+});
+
+describe('E2eManager identity + verify', () => {
+  it('returns a stable per-account identity with a 6-word SAS', () => {
+    const a1 = mgr.getIdentity(alice);
+    const a2 = new mod.E2eManager({ now: () => clock }).getIdentity(alice); // reload from DB
+    expect(a2.fingerprintHex).toBe(a1.fingerprintHex);
+    expect(a1.sas.split(' ')).toHaveLength(6);
+    // Different account → different identity.
+    expect(mgr.getIdentity(bob).fingerprintHex).not.toBe(a1.fingerprintHex);
+  });
+
+  it('verifyInfo returns the peer fingerprint after a handshake', () => {
+    fullHandshake('#vf');
+    const info = mgr.verifyInfo(alice, aliceNet, BOB_H)!;
+    expect(info.fingerprintHex).toBe(mgr.getIdentity(bob).fingerprintHex);
+    expect(info.status).toBe('trusted');
+  });
+
+  it('revoke stops decryption; reverify clears the pin', () => {
+    fullHandshake('#rv');
+    const line = mgr.encryptOutgoing(alice, aliceNet, '#rv', 'pre-revoke')![0];
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rv', line).kind).toBe('plaintext');
+
+    expect(mgr.revokePeer(bob, bobNet, ALICE_H)).toBe(true);
+    const line2 = mgr.encryptOutgoing(alice, aliceNet, '#rv', 'post-revoke')![0];
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rv', line2).kind).toBe('rejected');
+
+    expect(mgr.reverifyPeer(bob, bobNet, ALICE_H)).toBeGreaterThan(0);
+    // After reverify the session is gone entirely.
+    const line3 = mgr.encryptOutgoing(alice, aliceNet, '#rv', 'after-reverify')![0];
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rv', line3)).toEqual({
+      kind: 'missing-key',
+    });
+  });
+});

--- a/server/services/e2e/manager.test.ts
+++ b/server/services/e2e/manager.test.ts
@@ -47,6 +47,13 @@ beforeEach(() => {
   mgr = new mod.E2eManager({ now: () => clock });
 });
 
+// Encrypt and assert it produced wire lines (the happy path).
+function encLines(uid: number, net: number, channel: string, text: string): string[] {
+  const r = mgr.encryptOutgoing(uid, net, channel, text);
+  if (r.kind !== 'encrypted') throw new Error(`expected encrypted, got ${r.kind}`);
+  return r.lines;
+}
+
 // Drive a full bidirectional handshake on `channel` (auto-accept both ends).
 function fullHandshake(channel: string): void {
   mgr.setChannelConfig(alice, aliceNet, channel, true, 'auto-accept');
@@ -65,7 +72,7 @@ describe('E2eManager handshake + exchange', () => {
   it('completes a full handshake and exchanges encrypted messages both ways', () => {
     fullHandshake('#x');
 
-    const aToB = mgr.encryptOutgoing(alice, aliceNet, '#x', 'hello bob')!;
+    const aToB = encLines(alice, aliceNet, '#x', 'hello bob');
     expect(aToB).toHaveLength(1);
     expect(aToB[0].startsWith('+RPE2E01')).toBe(true);
     expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#x', aToB[0])).toEqual({
@@ -73,7 +80,7 @@ describe('E2eManager handshake + exchange', () => {
       text: 'hello bob',
     });
 
-    const bToA = mgr.encryptOutgoing(bob, bobNet, '#x', 'hi alice 👋')!;
+    const bToA = encLines(bob, bobNet, '#x', 'hi alice 👋');
     expect(mgr.decryptIncoming(alice, aliceNet, BOB_H, '#x', bToA[0])).toEqual({
       kind: 'plaintext',
       text: 'hi alice 👋',
@@ -83,7 +90,7 @@ describe('E2eManager handshake + exchange', () => {
   it('chunks a long message and decrypts every chunk', () => {
     fullHandshake('#big');
     const long = 'x'.repeat(500);
-    const lines = mgr.encryptOutgoing(alice, aliceNet, '#big', long)!;
+    const lines = encLines(alice, aliceNet, '#big', long);
     expect(lines.length).toBeGreaterThan(1);
     const decoded = lines.map((l) => {
       const out = mgr.decryptIncoming(bob, bobNet, ALICE_H, '#big', l);
@@ -92,8 +99,15 @@ describe('E2eManager handshake + exchange', () => {
     expect(decoded.join('')).toBe(long);
   });
 
-  it('returns null from encryptOutgoing when the channel is not enabled', () => {
-    expect(mgr.encryptOutgoing(alice, aliceNet, '#off', 'secret')).toBeNull();
+  it('reports disabled (not plaintext) when the channel is not enabled', () => {
+    expect(mgr.encryptOutgoing(alice, aliceNet, '#off', 'secret')).toEqual({ kind: 'disabled' });
+  });
+
+  it('reports error (never plaintext) when the message is too long to chunk', () => {
+    fullHandshake('#toolong');
+    const huge = 'x'.repeat(180 * 16 + 1); // exceeds MAX_CHUNKS * MAX_PLAINTEXT
+    const r = mgr.encryptOutgoing(alice, aliceNet, '#toolong', huge);
+    expect(r.kind).toBe('error');
   });
 
   it('passes a non-RPE2E line through as cleartext', () => {
@@ -105,7 +119,7 @@ describe('E2eManager handshake + exchange', () => {
 
   it('reports missing-key when no session exists for the sender', () => {
     fullHandshake('#mk');
-    const line = mgr.encryptOutgoing(alice, aliceNet, '#mk', 'hi')![0];
+    const line = encLines(alice, aliceNet, '#mk', 'hi')[0];
     // Bob has a session for ALICE_H, but not for a different handle.
     expect(mgr.decryptIncoming(bob, bobNet, '~stranger@h', '#mk', line)).toEqual({
       kind: 'missing-key',
@@ -128,11 +142,13 @@ describe('E2eManager trust modes', () => {
     expect(accepted.replies.length).toBeGreaterThanOrEqual(1);
     mgr.handleHandshakeBody(bob, bobNet, ALICE_H, 'alice', accepted.replies[0]); // Bob installs Alice's key
 
-    const line = mgr.encryptOutgoing(alice, aliceNet, '#nrm', 'now secured')![0];
+    const line = encLines(alice, aliceNet, '#nrm', 'now secured')[0];
     expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#nrm', line)).toEqual({
       kind: 'plaintext',
       text: 'now secured',
     });
+    // Accepting promotes the peer to trusted (#11).
+    expect(mgr.verifyInfo(alice, aliceNet, BOB_H)?.status).toBe('trusted');
   });
 
   it('quiet mode silently ignores an unknown peer', () => {
@@ -167,7 +183,7 @@ describe('E2eManager TOFU + replay + window', () => {
 
   it('flags a replayed chunk', () => {
     fullHandshake('#rp');
-    const line = mgr.encryptOutgoing(alice, aliceNet, '#rp', 'once')![0];
+    const line = encLines(alice, aliceNet, '#rp', 'once')[0];
     expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rp', line)).toEqual({
       kind: 'plaintext',
       text: 'once',
@@ -177,7 +193,7 @@ describe('E2eManager TOFU + replay + window', () => {
 
   it('rejects a chunk whose ts is outside the tolerance window', () => {
     fullHandshake('#win');
-    const line = mgr.encryptOutgoing(alice, aliceNet, '#win', 'stale')![0];
+    const line = encLines(alice, aliceNet, '#win', 'stale')[0];
     clock += 1000 * 1000; // advance 1000s, well past the 300s default tolerance
     const out = mgr.decryptIncoming(bob, bobNet, ALICE_H, '#win', line);
     expect(out.kind).toBe('rejected');
@@ -203,18 +219,78 @@ describe('E2eManager identity + verify', () => {
 
   it('revoke stops decryption; reverify clears the pin', () => {
     fullHandshake('#rv');
-    const line = mgr.encryptOutgoing(alice, aliceNet, '#rv', 'pre-revoke')![0];
+    const line = encLines(alice, aliceNet, '#rv', 'pre-revoke')[0];
     expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rv', line).kind).toBe('plaintext');
 
     expect(mgr.revokePeer(bob, bobNet, ALICE_H)).toBe(true);
-    const line2 = mgr.encryptOutgoing(alice, aliceNet, '#rv', 'post-revoke')![0];
+    const line2 = encLines(alice, aliceNet, '#rv', 'post-revoke')[0];
     expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rv', line2).kind).toBe('rejected');
 
     expect(mgr.reverifyPeer(bob, bobNet, ALICE_H)).toBeGreaterThan(0);
     // After reverify the session is gone entirely.
-    const line3 = mgr.encryptOutgoing(alice, aliceNet, '#rv', 'after-reverify')![0];
+    const line3 = encLines(alice, aliceNet, '#rv', 'after-reverify')[0];
     expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, '#rv', line3)).toEqual({
       kind: 'missing-key',
     });
+  });
+});
+
+describe('E2eManager review hardening', () => {
+  it('does not crash the singleton on a crafted all-zero ephemeral (#1/#2)', async () => {
+    const hs = await import('./handshake.js');
+    const idmod = await import('./identity.js');
+    mgr.setChannelConfig(alice, aliceNet, '#az', true, 'auto-accept');
+    // A real (self-signed) attacker KEYREQ whose ephemeral is the all-zero
+    // X25519 point — noble rejects it inside deriveWrapKey.
+    const atk = idmod.generateIdentity();
+    const nonce = new Uint8Array(16);
+    const zeroEph = new Uint8Array(32);
+    const sig = idmod.sign(
+      atk.secretKey,
+      hs.sigPayloadKeyReq('#az', atk.publicKey, zeroEph, nonce),
+    );
+    const body = hs.encodeKeyReq({
+      channel: '#az',
+      pubkey: atk.publicKey,
+      ephX25519: zeroEph,
+      nonce,
+      sig,
+    });
+    // Must drop, not throw out of the shared singleton.
+    expect(mgr.handleHandshakeBody(alice, aliceNet, '~atk@h', 'atk', body)).toEqual({
+      replies: [],
+    });
+  });
+
+  it('warns rather than silently auto-migrating when a known key reappears under a new handle (#3)', () => {
+    fullHandshake('#hc'); // pins Bob's fp under BOB_H for Alice
+    const NEW_BOB = '~bob@newhost';
+    const req = mgr.buildKeyReq(bob, bobNet, '#hc'); // Bob's identity, new handshake
+    const out = mgr.handleHandshakeBody(alice, aliceNet, NEW_BOB, 'bob', req)!;
+    expect(out.replies).toHaveLength(0);
+    expect(out.notice?.text).toMatch(/new handle/);
+  });
+
+  it('reverify drops the outbound pending so a stale KEYRSP cannot re-trust (#8)', () => {
+    mgr.setChannelConfig(alice, aliceNet, '#stale', true, 'auto-accept');
+    mgr.setChannelConfig(bob, bobNet, '#stale', true, 'auto-accept');
+    // Bob → KEYREQ; Alice → KEYRSP + reciprocal (the reciprocal stores Alice's
+    // pending, peerHandle = BOB_H).
+    const aOut = mgr.handleHandshakeBody(
+      alice,
+      aliceNet,
+      BOB_H,
+      'bob',
+      mgr.buildKeyReq(bob, bobNet, '#stale', ALICE_H),
+    )!;
+    // Bob answers Alice's reciprocal with his KEYRSP — capture but DON'T deliver.
+    const bobRsp = mgr.handleHandshakeBody(bob, bobNet, ALICE_H, 'alice', aOut.replies[1])!
+      .replies[0];
+
+    mgr.reverifyPeer(alice, aliceNet, BOB_H); // clears Alice's pending for BOB_H
+
+    // The stale KEYRSP now finds no pending → dropped, no re-trust.
+    expect(mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', bobRsp)).toEqual({ replies: [] });
+    expect(mgr.verifyInfo(alice, aliceNet, BOB_H)).toBeNull();
   });
 });

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -142,8 +142,11 @@ export class E2eManager {
     return Math.floor(this.now() / 1000);
   }
 
+  // IRC identifiers are case-insensitive (the DB layer is COLLATE NOCASE), so
+  // fold the handle here too — otherwise a case-varied handle gets its own
+  // rate-limit bucket and the throttle is bypassed for the same peer.
   private rlKey(userId: number, networkId: number, handle: string): string {
-    return `${userId}:${networkId}:${handle}`;
+    return `${userId}:${networkId}:${handle.toLowerCase()}`;
   }
 
   // ─── identity ──────────────────────────────────────────────────────────────
@@ -179,37 +182,63 @@ export class E2eManager {
     return id;
   }
 
-  /** Public identity info for `/e2e fingerprint` / the lock UI. */
-  getIdentity(userId: number): IdentityInfo {
-    const id = this.loadIdentity(userId);
-    const fp = fingerprint(id.publicKey);
-    return {
-      publicKey: id.publicKey,
-      fingerprint: fp,
-      fingerprintHex: fingerprintHex(fp),
-      sas: fingerprintWords(fp),
-    };
+  /** Public identity info for `/e2e fingerprint` / the lock UI. `null` if the
+   *  identity can't be loaded (e.g. an unreadable sealed key after a key
+   *  rotation) — never throws (singleton safety). */
+  getIdentity(userId: number): IdentityInfo | null {
+    try {
+      const id = this.loadIdentity(userId);
+      const fp = fingerprint(id.publicKey);
+      return {
+        publicKey: id.publicKey,
+        fingerprint: fp,
+        fingerprintHex: fingerprintHex(fp),
+        sas: fingerprintWords(fp),
+      };
+    } catch (err) {
+      console.warn(`e2e getIdentity: ${(err as Error).message}`);
+      return null;
+    }
   }
 
   // ─── channel config ──────────────────────────────────────────────────────────
 
+  /** Enable/disable E2E for a channel. Returns false (rather than throwing) if
+   *  the write fails — singleton safety. */
   setChannelConfig(
     userId: number,
     networkId: number,
     channel: string,
     enabled: boolean,
     mode: keyring.ChannelMode,
-  ): void {
-    keyring.setChannelConfig(userId, networkId, { channel, enabled, mode });
+  ): boolean {
+    try {
+      keyring.setChannelConfig(userId, networkId, { channel, enabled, mode });
+      return true;
+    } catch (err) {
+      console.warn(`e2e setChannelConfig ${channel}: ${(err as Error).message}`);
+      return false;
+    }
   }
 
   // ─── outbound handshake ──────────────────────────────────────────────────────
 
   /** Build a KEYREQ to initiate (or extend) an encrypted session on `channel`,
-   *  returning the CTCP body to NOTICE to the peer. Stores the pending ephemeral
-   *  secret so the matching KEYRSP can be unwrapped. */
-  buildKeyReq(userId: number, networkId: number, channel: string, peerHandle?: string): string {
-    return encodeKeyReq(this.buildKeyReqStruct(userId, networkId, channel, peerHandle ?? null));
+   *  returning the CTCP body to NOTICE to the peer (or `null` if the identity /
+   *  crypto failed — never throws). Stores the pending ephemeral secret so the
+   *  matching KEYRSP can be unwrapped. */
+  buildKeyReq(
+    userId: number,
+    networkId: number,
+    channel: string,
+    peerHandle?: string,
+  ): string | null {
+    try {
+      return encodeKeyReq(this.buildKeyReqStruct(userId, networkId, channel, peerHandle ?? null));
+    } catch (err) {
+      console.warn(`e2e buildKeyReq ${channel}: ${(err as Error).message}`);
+      return null;
+    }
   }
 
   private buildKeyReqStruct(
@@ -869,8 +898,10 @@ export class E2eManager {
     }
   }
 
+  // Fold case so `/e2e accept` finds the cached KEYREQ even if the handle/
+  // channel casing differs between the inbound message and the accept command.
   private inboundKey(userId: number, networkId: number, handle: string, channel: string): string {
-    return `${userId}:${networkId}:${handle}:${channel}`;
+    return `${userId}:${networkId}:${handle.toLowerCase()}:${channel.toLowerCase()}`;
   }
 
   private tofuWarning(handle: string, change: ClassifyResult): UserNotice {

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -12,10 +12,15 @@
 // wire, or a decrypt outcome. The IRC layer (a later phase) owns the actual
 // NOTICE/PRIVMSG plumbing and the channel-vs-@handle `context` derivation.
 //
-// Security ordering, mirrored from the reference: rate-limit BEFORE crypto;
-// verify signatures BEFORE touching state; install sessions under strict TOFU.
+// CRITICAL — this is a SHARED singleton: an uncaught throw crashes the cell for
+// every tenant. So every public entry point is wrapped to turn an unexpected
+// error (e.g. an attacker-crafted ephemeral that noble rejects, or an
+// undecryptable sealed key after a LURKER_SECRET_KEY rotation) into a safe
+// outcome. Security ordering, mirrored from the reference: rate-limit BEFORE
+// crypto; verify signatures BEFORE touching state; install under strict TOFU.
 
 import { randomBytes } from 'node:crypto';
+import { equalBytes } from '@noble/curves/utils.js';
 
 import { buildAad } from './aad.js';
 import * as aead from './aead.js';
@@ -38,17 +43,18 @@ import {
 import { generateIdentity, type Identity, identityFromSeed, sign, verify } from './identity.js';
 import { encodeChunk, freshMsgid, parseChunk } from './wire.js';
 import * as keyring from '../../db/e2e.js';
-import { HandleMismatchError } from '../../db/e2e.js';
 import { RateLimiter } from './rateLimiter.js';
 import { ReplayCache } from './replayCache.js';
 
 const decoder = new TextDecoder('utf-8', { fatal: true });
 
-function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-  return true;
-}
+// In-memory state bounds (this is a long-lived multi-tenant singleton).
+const PENDING_TTL_MS = 10 * 60_000; // outbound handshakes expire if unanswered
+const PENDING_MAX = 4096;
+const PENDING_INBOUND_TTL_MS = 30 * 60_000; // normal-mode prompts await /e2e accept
+const PENDING_INBOUND_MAX = 4096;
+
+const eqLower = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
 
 // ─── public result shapes ────────────────────────────────────────────────────
 
@@ -72,6 +78,11 @@ export interface HandshakeOutcome {
   notice?: UserNotice;
 }
 
+export type EncryptOutcome =
+  | { kind: 'disabled' } // E2E off for this channel — caller MAY send plaintext
+  | { kind: 'encrypted'; lines: string[] }
+  | { kind: 'error'; reason: string }; // enabled but failed — caller must NOT send plaintext
+
 export type DecryptOutcome =
   | { kind: 'plaintext'; text: string }
   | { kind: 'cleartext'; text: string } // not an RPE2E line — pass through
@@ -87,9 +98,23 @@ interface PendingHandshake {
   channel: string;
   peerHandle: string | null;
   ephSecret: Uint8Array; // initiator's ephemeral X25519 secret
+  createdAt: number; // epoch ms, for TTL expiry
 }
 
-type ClassifyResult = 'new' | 'known' | 'fingerprint-changed' | 'revoked';
+interface PendingInbound {
+  userId: number;
+  networkId: number;
+  handle: string;
+  channel: string;
+  req: KeyReq;
+  createdAt: number;
+}
+
+type ClassifyResult = 'new' | 'known' | 'handle-changed' | 'fingerprint-changed' | 'revoked';
+
+function isTofuBlock(c: ClassifyResult): boolean {
+  return c === 'revoked' || c === 'fingerprint-changed' || c === 'handle-changed';
+}
 
 export interface E2eManagerOptions {
   /** Epoch-ms clock, injectable for tests. */
@@ -102,7 +127,7 @@ export class E2eManager {
   private readonly tsToleranceSecs: number;
   private readonly identities = new Map<number, Identity>();
   private readonly pending = new Map<string, PendingHandshake>();
-  private readonly pendingInbound = new Map<string, KeyReq>(); // normal-mode cached KEYREQs
+  private readonly pendingInbound = new Map<string, PendingInbound>();
   private readonly rateLimiter: RateLimiter;
   private readonly replay: ReplayCache;
 
@@ -110,7 +135,7 @@ export class E2eManager {
     this.now = opts.now ?? Date.now;
     this.tsToleranceSecs = opts.tsToleranceSecs ?? DEFAULT_TS_TOLERANCE_SECS;
     this.rateLimiter = new RateLimiter(this.now);
-    this.replay = new ReplayCache(8192, this.now);
+    this.replay = new ReplayCache(100_000, this.now);
   }
 
   private nowUnix(): number {
@@ -135,10 +160,10 @@ export class E2eManager {
       // Self-consistency: a stored pubkey/fingerprint that doesn't match the
       // secret means the keyring drifted — fail loud rather than sign with a
       // mismatched identity.
-      if (!bytesEqual(id.publicKey, row.pubkey)) {
+      if (!equalBytes(id.publicKey, row.pubkey)) {
         throw new Error('e2e: stored identity pubkey does not match secret');
       }
-      if (!bytesEqual(fingerprint(id.publicKey), row.fingerprint)) {
+      if (!equalBytes(fingerprint(id.publicKey), row.fingerprint)) {
         throw new Error('e2e: stored identity fingerprint does not match pubkey');
       }
     } else {
@@ -184,8 +209,7 @@ export class E2eManager {
    *  returning the CTCP body to NOTICE to the peer. Stores the pending ephemeral
    *  secret so the matching KEYRSP can be unwrapped. */
   buildKeyReq(userId: number, networkId: number, channel: string, peerHandle?: string): string {
-    const req = this.buildKeyReqStruct(userId, networkId, channel, peerHandle ?? null);
-    return encodeKeyReq(req);
+    return encodeKeyReq(this.buildKeyReqStruct(userId, networkId, channel, peerHandle ?? null));
   }
 
   private buildKeyReqStruct(
@@ -197,10 +221,10 @@ export class E2eManager {
     const id = this.loadIdentity(userId);
     const nonce = new Uint8Array(randomBytes(16));
     const eph = generateEphemeral();
-    const pubkey = id.publicKey;
-    const sigPayload = sigPayloadKeyReq(channel, pubkey, eph.publicKey, nonce);
+    const sigPayload = sigPayloadKeyReq(channel, id.publicKey, eph.publicKey, nonce);
     const sig = sign(id.secretKey, sigPayload);
 
+    this.sweepPending();
     const nonceHex = Buffer.from(nonce).toString('hex');
     this.pending.set(`${userId}:${networkId}:${channel}:${nonceHex}`, {
       userId,
@@ -208,17 +232,18 @@ export class E2eManager {
       channel,
       peerHandle,
       ephSecret: eph.secretKey,
+      createdAt: this.now(),
     });
 
-    return { channel, pubkey, ephX25519: eph.publicKey, nonce, sig };
+    return { channel, pubkey: id.publicKey, ephX25519: eph.publicKey, nonce, sig };
   }
 
   // ─── inbound handshake dispatch ──────────────────────────────────────────────
 
   /**
    * Process an inbound RPEE2E CTCP body. Returns `null` if it is not an RPEE2E
-   * message (caller falls through to other CTCP handling), otherwise the bodies
-   * to NOTICE back to `senderHandle`'s nick plus an optional user notice.
+   * message, otherwise the bodies to NOTICE back to `senderHandle`'s nick plus
+   * an optional user notice. Never throws (singleton safety).
    */
   handleHandshakeBody(
     userId: number,
@@ -234,15 +259,22 @@ export class E2eManager {
       return { replies: [] }; // malformed RPEE2E — drop quietly
     }
     if (!parsed) return null;
-    switch (parsed.kind) {
-      case 'KEYREQ':
-        return this.handleKeyReq(userId, networkId, senderHandle, senderNick, parsed.msg);
-      case 'KEYRSP':
-        return this.handleKeyRsp(userId, networkId, senderHandle, parsed.msg);
-      case 'REKEY':
-        return this.handleRekey(userId, networkId, senderHandle, parsed.msg);
-      default:
-        return { replies: [] };
+    try {
+      switch (parsed.kind) {
+        case 'KEYREQ':
+          return this.handleKeyReq(userId, networkId, senderHandle, senderNick, parsed.msg);
+        case 'KEYRSP':
+          return this.handleKeyRsp(userId, networkId, senderHandle, parsed.msg);
+        case 'REKEY':
+          return this.handleRekey(userId, networkId, senderHandle, parsed.msg);
+        default:
+          return { replies: [] };
+      }
+    } catch (err) {
+      // Attacker-crafted ephemeral noble rejects, undecryptable sealed key, etc.
+      // — drop, never crash the singleton.
+      console.warn(`e2e handshake from ${senderHandle}: ${(err as Error).message}`);
+      return { replies: [] };
     }
   }
 
@@ -257,6 +289,8 @@ export class E2eManager {
     if (!this.rateLimiter.allowIncoming(this.rlKey(userId, networkId, senderHandle))) {
       return { replies: [] };
     }
+    // Never handshake with ourselves (a replayed copy of our own KEYREQ).
+    if (equalBytes(req.pubkey, this.loadIdentity(userId).publicKey)) return { replies: [] };
     // Verify the signature (binds the ephemeral) before touching any state.
     const payload = sigPayloadKeyReq(req.channel, req.pubkey, req.ephX25519, req.nonce);
     if (!verify(req.pubkey, payload, req.sig)) return { replies: [] };
@@ -266,15 +300,12 @@ export class E2eManager {
 
     const fp = fingerprint(req.pubkey);
     const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
-    if (change === 'revoked' || change === 'fingerprint-changed') {
-      return { replies: [], notice: this.tofuWarning(senderHandle, change) };
-    }
+    if (isTofuBlock(change)) return { replies: [], notice: this.tofuWarning(senderHandle, change) };
     this.upsertSeenPeer(userId, networkId, fp, req.pubkey, senderHandle, senderNick);
 
     const alreadyTrusted = this.hasTrustedIncoming(userId, networkId, senderHandle, req.channel);
     if (mode === 'normal' && !alreadyTrusted) {
-      // Cache for `/e2e accept`, prompt the user, and don't respond yet.
-      this.pendingInbound.set(this.inboundKey(userId, networkId, senderHandle, req.channel), req);
+      this.cachePendingInbound(userId, networkId, senderHandle, req);
       const who = senderNick ?? senderHandle;
       return {
         replies: [],
@@ -286,8 +317,8 @@ export class E2eManager {
     }
     if (mode === 'quiet' && !alreadyTrusted) return { replies: [] };
 
-    // auto-accept, or normal/quiet with an already-trusted peer → respond.
-    return this.buildKeyRspAndReciprocal(userId, networkId, senderHandle, req);
+    // auto-accept, or an already-trusted peer → respond.
+    return this.buildKeyRspAndReciprocal(userId, networkId, senderHandle, req, alreadyTrusted);
   }
 
   private handleKeyRsp(
@@ -296,6 +327,11 @@ export class E2eManager {
     senderHandle: string,
     rsp: KeyRsp,
   ): HandshakeOutcome {
+    // Cheap pre-filter: a KEYRSP for a channel we never initiated on is dropped
+    // BEFORE the expensive verify + trial-ECDH, defeating a KEYRSP flood without
+    // throttling legitimate handshakes.
+    if (!this.hasPendingForChannel(userId, networkId, rsp.channel)) return { replies: [] };
+
     const payload = sigPayloadKeyRsp(
       rsp.channel,
       rsp.pubkey,
@@ -311,9 +347,8 @@ export class E2eManager {
 
     const fp = fingerprint(rsp.pubkey);
     const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
-    if (change === 'revoked' || change === 'fingerprint-changed') {
-      return { replies: [], notice: this.tofuWarning(senderHandle, change) };
-    }
+    if (isTofuBlock(change)) return { replies: [], notice: this.tofuWarning(senderHandle, change) };
+
     // We initiated, so receiving the response is our consent → trust the peer.
     const now = this.nowUnix();
     keyring.upsertPeer(userId, networkId, {
@@ -323,24 +358,12 @@ export class E2eManager {
       lastNick: null,
       firstSeen: now,
       lastSeen: now,
-      globalStatus: 'trusted',
+      globalStatus: 'pending', // creates the row; setPeerStatus is the authority
     });
     keyring.setPeerStatus(userId, networkId, fp, 'trusted');
 
-    try {
-      keyring.installIncomingSessionStrict(userId, networkId, {
-        handle: senderHandle,
-        channel: rsp.channel,
-        fingerprint: fp,
-        sk,
-        status: 'trusted',
-        createdAt: now,
-      });
-    } catch (err) {
-      if (err instanceof HandleMismatchError) {
-        return { replies: [], notice: this.tofuWarning(senderHandle, 'fingerprint-changed') };
-      }
-      throw err;
+    if (!this.installIncoming(userId, networkId, senderHandle, rsp.channel, fp, sk, now)) {
+      return { replies: [], notice: this.tofuWarning(senderHandle, 'fingerprint-changed') };
     }
     return {
       replies: [],
@@ -354,6 +377,11 @@ export class E2eManager {
     senderHandle: string,
     rekey: KeyRekey,
   ): HandshakeOutcome {
+    // REKEY is infrequent (channel rotation) — a plain rate gate is fine here.
+    if (!this.rateLimiter.allowIncoming(this.rlKey(userId, networkId, senderHandle))) {
+      return { replies: [] };
+    }
+    if (equalBytes(rekey.pubkey, this.loadIdentity(userId).publicKey)) return { replies: [] };
     const payload = sigPayloadKeyRekey(
       rekey.channel,
       rekey.pubkey,
@@ -364,20 +392,21 @@ export class E2eManager {
     );
     if (!verify(rekey.pubkey, payload, rekey.sig)) return { replies: [] };
 
+    // NOTE: REKEY carries a signed 16-byte nonce but we don't yet track it, and
+    // there's no ts window on this path — a captured REKEY from a known peer is
+    // replayable (re-installs an old key). Latent for now (no REKEY distribution
+    // is wired); add nonce-LRU + ts-skew here when Phase-2 channel rotation ships.
     const fp = fingerprint(rekey.pubkey);
     const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
     // A REKEY from a peer we've never handshaked with is illegitimate.
     if (change === 'new') return { replies: [] };
-    if (change === 'revoked' || change === 'fingerprint-changed') {
-      return { replies: [], notice: this.tofuWarning(senderHandle, change) };
-    }
+    if (isTofuBlock(change)) return { replies: [], notice: this.tofuWarning(senderHandle, change) };
 
     // ECDH from OUR Ed25519 identity (converted to X25519) with their fresh
     // ephemeral, HKDF under the REKEY domain separator.
     const id = this.loadIdentity(userId);
-    const myScalar = ed25519SeedToX25519(id.secretKey);
     const info = utf8.encode(rekeyInfo(rekey.channel));
-    const wrapKey = deriveWrapKey(myScalar, rekey.ephPub, info);
+    const wrapKey = deriveWrapKey(ed25519SeedToX25519(id.secretKey), rekey.ephPub, info);
     let sk: Uint8Array;
     try {
       sk = aead.decrypt(wrapKey, rekey.wrapNonce, info, rekey.wrapCt);
@@ -386,20 +415,10 @@ export class E2eManager {
     }
     if (sk.length !== 32) return { replies: [] };
 
-    try {
-      keyring.installIncomingSessionStrict(userId, networkId, {
-        handle: senderHandle,
-        channel: rekey.channel,
-        fingerprint: fp,
-        sk,
-        status: 'trusted',
-        createdAt: this.nowUnix(),
-      });
-    } catch (err) {
-      if (err instanceof HandleMismatchError) {
-        return { replies: [], notice: this.tofuWarning(senderHandle, 'fingerprint-changed') };
-      }
-      throw err;
+    if (
+      !this.installIncoming(userId, networkId, senderHandle, rekey.channel, fp, sk, this.nowUnix())
+    ) {
+      return { replies: [], notice: this.tofuWarning(senderHandle, 'fingerprint-changed') };
     }
     return { replies: [] };
   }
@@ -411,25 +430,41 @@ export class E2eManager {
     senderHandle: string,
     channel: string,
   ): HandshakeOutcome {
-    const key = this.inboundKey(userId, networkId, senderHandle, channel);
-    const req = this.pendingInbound.get(key);
-    if (!req) {
-      return { replies: [], notice: { level: 'warn', text: 'no pending handshake to accept' } };
+    try {
+      const key = this.inboundKey(userId, networkId, senderHandle, channel);
+      const entry = this.pendingInbound.get(key);
+      if (!entry) {
+        return { replies: [], notice: { level: 'warn', text: 'no pending handshake to accept' } };
+      }
+      this.pendingInbound.delete(key);
+      const alreadyTrusted = this.hasTrustedIncoming(userId, networkId, senderHandle, channel);
+      return this.buildKeyRspAndReciprocal(
+        userId,
+        networkId,
+        senderHandle,
+        entry.req,
+        alreadyTrusted,
+      );
+    } catch (err) {
+      console.warn(`e2e accept ${senderHandle}: ${(err as Error).message}`);
+      return { replies: [] };
     }
-    this.pendingInbound.delete(key);
-    return this.buildKeyRspAndReciprocal(userId, networkId, senderHandle, req);
   }
 
   // Build the KEYRSP (wrapping our outgoing key) for `req`, plus a reciprocal
-  // KEYREQ so the peer sends us their key too (symmetric handshake).
+  // KEYREQ so the peer sends us their key too (symmetric handshake). Responding
+  // is our consent, so the peer is promoted to trusted.
   private buildKeyRspAndReciprocal(
     userId: number,
     networkId: number,
     senderHandle: string,
     req: KeyReq,
+    alreadyTrusted: boolean,
   ): HandshakeOutcome {
     const id = this.loadIdentity(userId);
     const fp = fingerprint(req.pubkey);
+    keyring.setPeerStatus(userId, networkId, fp, 'trusted');
+
     const ourSk = this.getOrGenerateOutgoingKey(userId, networkId, req.channel);
     keyring.recordOutgoingRecipient(
       userId,
@@ -467,7 +502,7 @@ export class E2eManager {
     const replies = [encodeKeyRsp(rsp)];
     // Reciprocal KEYREQ unless we already hold their key, rate-limited.
     if (
-      !this.hasTrustedIncoming(userId, networkId, senderHandle, req.channel) &&
+      !alreadyTrusted &&
       this.rateLimiter.allowOutgoing(this.rlKey(userId, networkId, senderHandle))
     ) {
       replies.push(
@@ -482,6 +517,7 @@ export class E2eManager {
     networkId: number,
     rsp: KeyRsp,
   ): Uint8Array | null {
+    this.sweepPending();
     const info = utf8.encode(wrapInfo(rsp.channel));
     for (const [key, ph] of this.pending) {
       if (ph.userId !== userId || ph.networkId !== networkId || ph.channel !== rsp.channel)
@@ -493,48 +529,87 @@ export class E2eManager {
         this.pending.delete(key); // consume only on success
         return sk;
       } catch {
-        // Not the matching pending entry — the AEAD tag discriminates.
+        // Not the matching pending entry (or a bad ephemeral) — keep trying.
         continue;
       }
     }
     return null;
   }
 
+  // Install an incoming session under strict TOFU. Returns false on a
+  // fingerprint mismatch (caller surfaces the TOFU warning).
+  private installIncoming(
+    userId: number,
+    networkId: number,
+    handle: string,
+    channel: string,
+    fp: Uint8Array,
+    sk: Uint8Array,
+    createdAt: number,
+  ): boolean {
+    try {
+      keyring.installIncomingSessionStrict(userId, networkId, {
+        handle,
+        channel,
+        fingerprint: fp,
+        sk,
+        status: 'trusted',
+        createdAt,
+      });
+      return true;
+    } catch (err) {
+      if (err instanceof keyring.HandleMismatchError) return false;
+      throw err;
+    }
+  }
+
   // ─── encrypt / decrypt ───────────────────────────────────────────────────────
 
-  /** Encrypt `plaintext` for `channel` into `+RPE2E01` wire lines, or `null`
-   *  if E2E is not enabled for the channel. */
+  /** Encrypt `plaintext` for `channel`. `disabled` means the caller may send
+   *  plaintext; `error` means E2E is on but encryption failed — the caller must
+   *  NOT fall back to plaintext (that would leak on an E2E channel). */
   encryptOutgoing(
     userId: number,
     networkId: number,
     channel: string,
     plaintext: string,
-  ): string[] | null {
-    const cfg = keyring.getChannelConfig(userId, networkId, channel);
-    if (!cfg || !cfg.enabled) return null;
+  ): EncryptOutcome {
+    try {
+      const cfg = keyring.getChannelConfig(userId, networkId, channel);
+      if (!cfg || !cfg.enabled) return { kind: 'disabled' };
 
-    const sk = this.getOrGenerateOutgoingKey(userId, networkId, channel);
-    const chunks = splitPlaintext(plaintext);
-    const total = chunks.length;
-    const msgid = freshMsgid();
-    const ts = this.nowUnix();
+      let chunks: Uint8Array[];
+      try {
+        chunks = splitPlaintext(plaintext);
+      } catch (e) {
+        return { kind: 'error', reason: (e as Error).message };
+      }
 
-    return chunks.map((chunk, idx) => {
-      const part = idx + 1;
-      const aad = buildAad(channel, msgid, ts, part, total);
-      const sealed = aead.encrypt(sk, aad, chunk);
-      return encodeChunk({
-        msgid,
-        ts,
-        part,
-        total,
-        nonce: sealed.nonce,
-        ciphertext: sealed.ciphertext,
+      const sk = this.getOrGenerateOutgoingKey(userId, networkId, channel);
+      const total = chunks.length;
+      const msgid = freshMsgid();
+      const ts = this.nowUnix();
+      const lines = chunks.map((chunk, idx) => {
+        const part = idx + 1;
+        const aad = buildAad(channel, msgid, ts, part, total);
+        const sealed = aead.encrypt(sk, aad, chunk);
+        return encodeChunk({
+          msgid,
+          ts,
+          part,
+          total,
+          nonce: sealed.nonce,
+          ciphertext: sealed.ciphertext,
+        });
       });
-    });
+      return { kind: 'encrypted', lines };
+    } catch (err) {
+      console.warn(`e2e encrypt ${channel}: ${(err as Error).message}`);
+      return { kind: 'error', reason: 'internal error' };
+    }
   }
 
-  /** Decrypt one inbound wire line. */
+  /** Decrypt one inbound wire line. Never throws (singleton safety). */
   decryptIncoming(
     userId: number,
     networkId: number,
@@ -542,46 +617,51 @@ export class E2eManager {
     channel: string,
     line: string,
   ): DecryptOutcome {
-    let wire;
     try {
-      wire = parseChunk(line);
-    } catch {
-      return { kind: 'rejected', reason: 'malformed RPE2E line' };
-    }
-    if (!wire) return { kind: 'cleartext', text: line };
+      let wire;
+      try {
+        wire = parseChunk(line);
+      } catch {
+        return { kind: 'rejected', reason: 'malformed RPE2E line' };
+      }
+      if (!wire) return { kind: 'cleartext', text: line };
 
-    const skew = Math.abs(this.nowUnix() - wire.ts);
-    if (skew > this.tsToleranceSecs) {
-      return { kind: 'rejected', reason: `ts outside tolerance window (${skew}s skew)` };
-    }
+      const skew = Math.abs(this.nowUnix() - wire.ts);
+      if (skew > this.tsToleranceSecs) {
+        return { kind: 'rejected', reason: `ts outside tolerance window (${skew}s skew)` };
+      }
 
-    const sess = keyring.getIncomingSession(userId, networkId, senderHandle, channel);
-    if (!sess) return { kind: 'missing-key' };
-    if (sess.status !== 'trusted') return { kind: 'rejected', reason: `peer not trusted` };
+      const sess = keyring.getIncomingSession(userId, networkId, senderHandle, channel);
+      if (!sess) return { kind: 'missing-key' };
+      if (sess.status !== 'trusted') return { kind: 'rejected', reason: 'peer not trusted' };
 
-    const aad = buildAad(channel, wire.msgid, wire.ts, wire.part, wire.total);
-    let pt: Uint8Array;
-    try {
-      pt = aead.decrypt(sess.sk, wire.nonce, aad, wire.ciphertext);
-    } catch {
-      return { kind: 'rejected', reason: 'authentication failed' };
-    }
-    let text: string;
-    try {
-      text = decoder.decode(pt);
-    } catch {
-      return { kind: 'rejected', reason: 'invalid utf-8' };
-    }
+      const aad = buildAad(channel, wire.msgid, wire.ts, wire.part, wire.total);
+      let pt: Uint8Array;
+      try {
+        pt = aead.decrypt(sess.sk, wire.nonce, aad, wire.ciphertext);
+      } catch {
+        return { kind: 'rejected', reason: 'authentication failed' };
+      }
+      let text: string;
+      try {
+        text = decoder.decode(pt);
+      } catch {
+        return { kind: 'rejected', reason: 'invalid utf-8' };
+      }
 
-    // Replay check only AFTER a chunk authenticates, so unauthenticated traffic
-    // can't poison the cache. ttl past the ts window covers the replay horizon.
-    const replayKey = `${userId}:${networkId}:${channel}:${senderHandle}:${Buffer.from(
-      wire.msgid,
-    ).toString('hex')}:${wire.part}`;
-    if (!this.replay.observe(replayKey, (this.tsToleranceSecs * 2 + 5) * 1000)) {
-      return { kind: 'replay' };
+      // Replay check only AFTER a chunk authenticates, so unauthenticated
+      // traffic can't poison the cache. ttl past the ts window covers the horizon.
+      const replayKey = `${userId}:${networkId}:${channel}:${senderHandle}:${Buffer.from(
+        wire.msgid,
+      ).toString('hex')}:${wire.part}`;
+      if (!this.replay.observe(replayKey, (this.tsToleranceSecs * 2 + 5) * 1000)) {
+        return { kind: 'replay' };
+      }
+      return { kind: 'plaintext', text };
+    } catch (err) {
+      console.warn(`e2e decrypt ${channel} from ${senderHandle}: ${(err as Error).message}`);
+      return { kind: 'rejected', reason: 'internal error' };
     }
-    return { kind: 'plaintext', text };
   }
 
   // ─── trust operations ────────────────────────────────────────────────────────
@@ -592,46 +672,58 @@ export class E2eManager {
     networkId: number,
     handle: string,
   ): { fingerprintHex: string; sas: string; status: keyring.TrustStatus } | null {
-    const peer = keyring.getPeerByHandle(userId, networkId, handle);
-    if (!peer) return null;
-    return {
-      fingerprintHex: fingerprintHex(peer.fingerprint),
-      sas: fingerprintWords(peer.fingerprint),
-      status: peer.globalStatus,
-    };
+    try {
+      const peer = keyring.getPeerByHandle(userId, networkId, handle);
+      if (!peer) return null;
+      return {
+        fingerprintHex: fingerprintHex(peer.fingerprint),
+        sas: fingerprintWords(peer.fingerprint),
+        status: peer.globalStatus,
+      };
+    } catch (err) {
+      console.warn(`e2e verifyInfo ${handle}: ${(err as Error).message}`);
+      return null;
+    }
   }
 
-  /** Revoke a peer: mark the global peer + every session for the handle revoked,
-   *  so we stop decrypting their traffic. */
+  /** Revoke a peer: mark them + their sessions revoked (no unsealing), and trip
+   *  outgoing-key rotation on the affected channels so the revoked peer can no
+   *  longer decrypt our FUTURE messages. */
   revokePeer(userId: number, networkId: number, handle: string): boolean {
-    const peer = keyring.getPeerByHandle(userId, networkId, handle);
-    if (peer) keyring.setPeerStatus(userId, networkId, peer.fingerprint, 'revoked');
-    let found = false;
-    for (const s of keyring.listIncomingSessions(userId, networkId)) {
-      if (s.handle.toLowerCase() === handle.toLowerCase()) {
-        keyring.updateIncomingStatus(userId, networkId, s.handle, s.channel, 'revoked');
-        found = true;
+    try {
+      const peer = keyring.getPeerByHandle(userId, networkId, handle);
+      if (peer) keyring.setPeerStatus(userId, networkId, peer.fingerprint, 'revoked');
+      const channels = keyring.listIncomingChannelsForHandle(userId, networkId, handle);
+      const revoked = keyring.revokeIncomingSessionsForHandle(userId, networkId, handle);
+      for (const channel of channels) {
+        keyring.markOutgoingPendingRotation(userId, networkId, channel);
+        keyring.removeOutgoingRecipient(userId, networkId, channel, handle);
       }
+      return peer !== null || revoked > 0;
+    } catch (err) {
+      console.warn(`e2e revoke ${handle}: ${(err as Error).message}`);
+      return false;
     }
-    return found || peer !== null;
   }
 
   /** Forget a peer entirely so the next handshake re-pins (TOFU reset). Returns
-   *  the number of rows cleared. */
+   *  the number of rows / pending entries cleared. */
   reverifyPeer(userId: number, networkId: number, handle: string): number {
-    let cleared = 0;
-    const peer = keyring.getPeerByHandle(userId, networkId, handle);
-    if (peer) {
-      keyring.deletePeerByFingerprint(userId, networkId, peer.fingerprint);
-      cleared += 1;
+    try {
+      let cleared = 0;
+      const peer = keyring.getPeerByHandle(userId, networkId, handle);
+      if (peer) {
+        keyring.deletePeerByFingerprint(userId, networkId, peer.fingerprint);
+        cleared += 1;
+      }
+      cleared += keyring.deleteIncomingSessionsForHandle(userId, networkId, handle);
+      cleared += keyring.deleteOutgoingRecipientsForHandle(userId, networkId, handle);
+      cleared += this.clearPendingForHandle(userId, networkId, handle);
+      return cleared;
+    } catch (err) {
+      console.warn(`e2e reverify ${handle}: ${(err as Error).message}`);
+      return 0;
     }
-    cleared += keyring.deleteIncomingSessionsForHandle(userId, networkId, handle);
-    cleared += keyring.deleteOutgoingRecipientsForHandle(userId, networkId, handle);
-    const inboundPrefix = `${userId}:${networkId}:${handle}:`;
-    for (const key of this.pendingInbound.keys()) {
-      if (key.startsWith(inboundPrefix)) this.pendingInbound.delete(key);
-    }
-    return cleared;
   }
 
   // ─── private helpers ─────────────────────────────────────────────────────────
@@ -658,6 +750,9 @@ export class E2eManager {
     return cfg.mode;
   }
 
+  // by-fingerprint first (matching the reference): a known fp returns
+  // known/handle-changed/revoked; only an UNKNOWN fp consults the by-handle
+  // pin to detect a key substitution.
   private classifyPeerChange(
     userId: number,
     networkId: number,
@@ -665,10 +760,14 @@ export class E2eManager {
     handle: string,
   ): ClassifyResult {
     const byFp = keyring.getPeerByFingerprint(userId, networkId, fp);
-    if (byFp && byFp.globalStatus === 'revoked') return 'revoked';
+    if (byFp) {
+      if (byFp.globalStatus === 'revoked') return 'revoked';
+      if (byFp.lastHandle && !eqLower(byFp.lastHandle, handle)) return 'handle-changed';
+      return 'known';
+    }
     const byHandle = keyring.getPeerByHandle(userId, networkId, handle);
-    if (byHandle && !bytesEqual(byHandle.fingerprint, fp)) return 'fingerprint-changed';
-    return byFp ? 'known' : 'new';
+    if (byHandle && !equalBytes(byHandle.fingerprint, fp)) return 'fingerprint-changed';
+    return 'new';
   }
 
   private upsertSeenPeer(
@@ -697,8 +796,77 @@ export class E2eManager {
     handle: string,
     channel: string,
   ): boolean {
-    const s = keyring.getIncomingSession(userId, networkId, handle, channel);
-    return s?.status === 'trusted';
+    return keyring.getIncomingSession(userId, networkId, handle, channel)?.status === 'trusted';
+  }
+
+  private hasPendingForChannel(userId: number, networkId: number, channel: string): boolean {
+    for (const ph of this.pending.values()) {
+      if (ph.userId === userId && ph.networkId === networkId && ph.channel === channel) return true;
+    }
+    return false;
+  }
+
+  private cachePendingInbound(
+    userId: number,
+    networkId: number,
+    handle: string,
+    req: KeyReq,
+  ): void {
+    this.sweepPendingInbound();
+    this.pendingInbound.set(this.inboundKey(userId, networkId, handle, req.channel), {
+      userId,
+      networkId,
+      handle,
+      channel: req.channel,
+      req,
+      createdAt: this.now(),
+    });
+  }
+
+  private clearPendingForHandle(userId: number, networkId: number, handle: string): number {
+    let cleared = 0;
+    for (const [key, ph] of this.pending) {
+      if (
+        ph.userId === userId &&
+        ph.networkId === networkId &&
+        ph.peerHandle &&
+        eqLower(ph.peerHandle, handle)
+      ) {
+        this.pending.delete(key);
+        cleared += 1;
+      }
+    }
+    for (const [key, pi] of this.pendingInbound) {
+      if (pi.userId === userId && pi.networkId === networkId && eqLower(pi.handle, handle)) {
+        this.pendingInbound.delete(key);
+        cleared += 1;
+      }
+    }
+    return cleared;
+  }
+
+  private sweepPending(): void {
+    const now = this.now();
+    for (const [k, ph] of this.pending) {
+      if (now - ph.createdAt > PENDING_TTL_MS) this.pending.delete(k);
+    }
+    this.cap(this.pending, PENDING_MAX);
+  }
+
+  private sweepPendingInbound(): void {
+    const now = this.now();
+    for (const [k, pi] of this.pendingInbound) {
+      if (now - pi.createdAt > PENDING_INBOUND_TTL_MS) this.pendingInbound.delete(k);
+    }
+    this.cap(this.pendingInbound, PENDING_INBOUND_MAX);
+  }
+
+  private cap(map: Map<string, unknown>, max: number): void {
+    while (map.size > max) {
+      const oldest = map.keys().next().value;
+      if (oldest === undefined) break;
+      map.delete(oldest);
+    }
   }
 
   private inboundKey(userId: number, networkId: number, handle: string, channel: string): string {
@@ -708,6 +876,12 @@ export class E2eManager {
   private tofuWarning(handle: string, change: ClassifyResult): UserNotice {
     if (change === 'revoked') {
       return { level: 'warn', text: `Ignoring encrypted handshake from revoked peer ${handle}` };
+    }
+    if (change === 'handle-changed') {
+      return {
+        level: 'warn',
+        text: `⚠ a known encryption key appeared under a new handle (${handle}) — verify, then /e2e reverify ${handle}`,
+      };
     }
     return {
       level: 'warn',

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -1,0 +1,721 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// E2eManager — the orchestration layer that ties the RPE2E crypto primitives
+// (server/services/e2e/*) to the keyring (server/db/e2e.ts). A faithful port of
+// repartee's manager.rs, adapted for Lurker's multi-tenant cell: it is a single
+// process-wide instance whose in-memory state (pending handshakes, rate limiter,
+// replay cache, identity cache) is keyed by (userId, networkId).
+//
+// It is IRC-agnostic: callers hand it parsed inbound bodies / plaintext / wire
+// lines and it returns the bodies to send back, the wire lines to put on the
+// wire, or a decrypt outcome. The IRC layer (a later phase) owns the actual
+// NOTICE/PRIVMSG plumbing and the channel-vs-@handle `context` derivation.
+//
+// Security ordering, mirrored from the reference: rate-limit BEFORE crypto;
+// verify signatures BEFORE touching state; install sessions under strict TOFU.
+
+import { randomBytes } from 'node:crypto';
+
+import { buildAad } from './aad.js';
+import * as aead from './aead.js';
+import { splitPlaintext } from './chunker.js';
+import { DEFAULT_TS_TOLERANCE_SECS, rekeyInfo, wrapInfo } from './constants.js';
+import { deriveWrapKey, ed25519SeedToX25519, generateEphemeral } from './ecdh.js';
+import { utf8 } from './encoding.js';
+import { fingerprint, fingerprintHex, fingerprintWords } from './fingerprint.js';
+import {
+  encodeKeyReq,
+  encodeKeyRsp,
+  type KeyRekey,
+  type KeyReq,
+  type KeyRsp,
+  parseHandshake,
+  sigPayloadKeyRekey,
+  sigPayloadKeyReq,
+  sigPayloadKeyRsp,
+} from './handshake.js';
+import { generateIdentity, type Identity, identityFromSeed, sign, verify } from './identity.js';
+import { encodeChunk, freshMsgid, parseChunk } from './wire.js';
+import * as keyring from '../../db/e2e.js';
+import { HandleMismatchError } from '../../db/e2e.js';
+import { RateLimiter } from './rateLimiter.js';
+import { ReplayCache } from './replayCache.js';
+
+const decoder = new TextDecoder('utf-8', { fatal: true });
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+// ─── public result shapes ────────────────────────────────────────────────────
+
+export interface IdentityInfo {
+  publicKey: Uint8Array;
+  fingerprint: Uint8Array;
+  fingerprintHex: string;
+  /** Six-word BIP-39 short-authentication-string for out-of-band verification. */
+  sas: string;
+}
+
+export interface UserNotice {
+  level: 'info' | 'warn';
+  text: string;
+}
+
+/** The result of handling an inbound handshake body: bodies to NOTICE back to
+ *  the sender, and an optional user-facing notice for the buffer. */
+export interface HandshakeOutcome {
+  replies: string[];
+  notice?: UserNotice;
+}
+
+export type DecryptOutcome =
+  | { kind: 'plaintext'; text: string }
+  | { kind: 'cleartext'; text: string } // not an RPE2E line — pass through
+  | { kind: 'missing-key' }
+  | { kind: 'replay' }
+  | { kind: 'rejected'; reason: string };
+
+// ─── internal state ──────────────────────────────────────────────────────────
+
+interface PendingHandshake {
+  userId: number;
+  networkId: number;
+  channel: string;
+  peerHandle: string | null;
+  ephSecret: Uint8Array; // initiator's ephemeral X25519 secret
+}
+
+type ClassifyResult = 'new' | 'known' | 'fingerprint-changed' | 'revoked';
+
+export interface E2eManagerOptions {
+  /** Epoch-ms clock, injectable for tests. */
+  now?: () => number;
+  tsToleranceSecs?: number;
+}
+
+export class E2eManager {
+  private readonly now: () => number;
+  private readonly tsToleranceSecs: number;
+  private readonly identities = new Map<number, Identity>();
+  private readonly pending = new Map<string, PendingHandshake>();
+  private readonly pendingInbound = new Map<string, KeyReq>(); // normal-mode cached KEYREQs
+  private readonly rateLimiter: RateLimiter;
+  private readonly replay: ReplayCache;
+
+  constructor(opts: E2eManagerOptions = {}) {
+    this.now = opts.now ?? Date.now;
+    this.tsToleranceSecs = opts.tsToleranceSecs ?? DEFAULT_TS_TOLERANCE_SECS;
+    this.rateLimiter = new RateLimiter(this.now);
+    this.replay = new ReplayCache(8192, this.now);
+  }
+
+  private nowUnix(): number {
+    return Math.floor(this.now() / 1000);
+  }
+
+  private rlKey(userId: number, networkId: number, handle: string): string {
+    return `${userId}:${networkId}:${handle}`;
+  }
+
+  // ─── identity ──────────────────────────────────────────────────────────────
+
+  /** Load (or first-time generate + persist) this account's identity. Cached. */
+  private loadIdentity(userId: number): Identity {
+    const cached = this.identities.get(userId);
+    if (cached) return cached;
+
+    const row = keyring.loadIdentity(userId);
+    let id: Identity;
+    if (row) {
+      id = identityFromSeed(row.privkey);
+      // Self-consistency: a stored pubkey/fingerprint that doesn't match the
+      // secret means the keyring drifted — fail loud rather than sign with a
+      // mismatched identity.
+      if (!bytesEqual(id.publicKey, row.pubkey)) {
+        throw new Error('e2e: stored identity pubkey does not match secret');
+      }
+      if (!bytesEqual(fingerprint(id.publicKey), row.fingerprint)) {
+        throw new Error('e2e: stored identity fingerprint does not match pubkey');
+      }
+    } else {
+      id = generateIdentity();
+      keyring.saveIdentity(userId, {
+        pubkey: id.publicKey,
+        privkey: id.secretKey,
+        fingerprint: fingerprint(id.publicKey),
+        createdAt: this.nowUnix(),
+      });
+    }
+    this.identities.set(userId, id);
+    return id;
+  }
+
+  /** Public identity info for `/e2e fingerprint` / the lock UI. */
+  getIdentity(userId: number): IdentityInfo {
+    const id = this.loadIdentity(userId);
+    const fp = fingerprint(id.publicKey);
+    return {
+      publicKey: id.publicKey,
+      fingerprint: fp,
+      fingerprintHex: fingerprintHex(fp),
+      sas: fingerprintWords(fp),
+    };
+  }
+
+  // ─── channel config ──────────────────────────────────────────────────────────
+
+  setChannelConfig(
+    userId: number,
+    networkId: number,
+    channel: string,
+    enabled: boolean,
+    mode: keyring.ChannelMode,
+  ): void {
+    keyring.setChannelConfig(userId, networkId, { channel, enabled, mode });
+  }
+
+  // ─── outbound handshake ──────────────────────────────────────────────────────
+
+  /** Build a KEYREQ to initiate (or extend) an encrypted session on `channel`,
+   *  returning the CTCP body to NOTICE to the peer. Stores the pending ephemeral
+   *  secret so the matching KEYRSP can be unwrapped. */
+  buildKeyReq(userId: number, networkId: number, channel: string, peerHandle?: string): string {
+    const req = this.buildKeyReqStruct(userId, networkId, channel, peerHandle ?? null);
+    return encodeKeyReq(req);
+  }
+
+  private buildKeyReqStruct(
+    userId: number,
+    networkId: number,
+    channel: string,
+    peerHandle: string | null,
+  ): KeyReq {
+    const id = this.loadIdentity(userId);
+    const nonce = new Uint8Array(randomBytes(16));
+    const eph = generateEphemeral();
+    const pubkey = id.publicKey;
+    const sigPayload = sigPayloadKeyReq(channel, pubkey, eph.publicKey, nonce);
+    const sig = sign(id.secretKey, sigPayload);
+
+    const nonceHex = Buffer.from(nonce).toString('hex');
+    this.pending.set(`${userId}:${networkId}:${channel}:${nonceHex}`, {
+      userId,
+      networkId,
+      channel,
+      peerHandle,
+      ephSecret: eph.secretKey,
+    });
+
+    return { channel, pubkey, ephX25519: eph.publicKey, nonce, sig };
+  }
+
+  // ─── inbound handshake dispatch ──────────────────────────────────────────────
+
+  /**
+   * Process an inbound RPEE2E CTCP body. Returns `null` if it is not an RPEE2E
+   * message (caller falls through to other CTCP handling), otherwise the bodies
+   * to NOTICE back to `senderHandle`'s nick plus an optional user notice.
+   */
+  handleHandshakeBody(
+    userId: number,
+    networkId: number,
+    senderHandle: string,
+    senderNick: string | null,
+    body: string,
+  ): HandshakeOutcome | null {
+    let parsed;
+    try {
+      parsed = parseHandshake(body);
+    } catch {
+      return { replies: [] }; // malformed RPEE2E — drop quietly
+    }
+    if (!parsed) return null;
+    switch (parsed.kind) {
+      case 'KEYREQ':
+        return this.handleKeyReq(userId, networkId, senderHandle, senderNick, parsed.msg);
+      case 'KEYRSP':
+        return this.handleKeyRsp(userId, networkId, senderHandle, parsed.msg);
+      case 'REKEY':
+        return this.handleRekey(userId, networkId, senderHandle, parsed.msg);
+      default:
+        return { replies: [] };
+    }
+  }
+
+  private handleKeyReq(
+    userId: number,
+    networkId: number,
+    senderHandle: string,
+    senderNick: string | null,
+    req: KeyReq,
+  ): HandshakeOutcome {
+    // Rate-limit gate FIRST — reject a flood before any crypto work.
+    if (!this.rateLimiter.allowIncoming(this.rlKey(userId, networkId, senderHandle))) {
+      return { replies: [] };
+    }
+    // Verify the signature (binds the ephemeral) before touching any state.
+    const payload = sigPayloadKeyReq(req.channel, req.pubkey, req.ephX25519, req.nonce);
+    if (!verify(req.pubkey, payload, req.sig)) return { replies: [] };
+
+    const mode = this.effectiveMode(userId, networkId, senderHandle, req.channel);
+    if (mode === null) return { replies: [] }; // channel not enabled
+
+    const fp = fingerprint(req.pubkey);
+    const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
+    if (change === 'revoked' || change === 'fingerprint-changed') {
+      return { replies: [], notice: this.tofuWarning(senderHandle, change) };
+    }
+    this.upsertSeenPeer(userId, networkId, fp, req.pubkey, senderHandle, senderNick);
+
+    const alreadyTrusted = this.hasTrustedIncoming(userId, networkId, senderHandle, req.channel);
+    if (mode === 'normal' && !alreadyTrusted) {
+      // Cache for `/e2e accept`, prompt the user, and don't respond yet.
+      this.pendingInbound.set(this.inboundKey(userId, networkId, senderHandle, req.channel), req);
+      const who = senderNick ?? senderHandle;
+      return {
+        replies: [],
+        notice: {
+          level: 'info',
+          text: `${who} wants to start an encrypted session on ${req.channel} — /e2e accept ${who}`,
+        },
+      };
+    }
+    if (mode === 'quiet' && !alreadyTrusted) return { replies: [] };
+
+    // auto-accept, or normal/quiet with an already-trusted peer → respond.
+    return this.buildKeyRspAndReciprocal(userId, networkId, senderHandle, req);
+  }
+
+  private handleKeyRsp(
+    userId: number,
+    networkId: number,
+    senderHandle: string,
+    rsp: KeyRsp,
+  ): HandshakeOutcome {
+    const payload = sigPayloadKeyRsp(
+      rsp.channel,
+      rsp.pubkey,
+      rsp.ephemeralPub,
+      rsp.wrapNonce,
+      rsp.wrapCt,
+      rsp.nonce,
+    );
+    if (!verify(rsp.pubkey, payload, rsp.sig)) return { replies: [] };
+
+    const sk = this.consumePendingForKeyRsp(userId, networkId, rsp);
+    if (!sk) return { replies: [] }; // no matching pending handshake
+
+    const fp = fingerprint(rsp.pubkey);
+    const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
+    if (change === 'revoked' || change === 'fingerprint-changed') {
+      return { replies: [], notice: this.tofuWarning(senderHandle, change) };
+    }
+    // We initiated, so receiving the response is our consent → trust the peer.
+    const now = this.nowUnix();
+    keyring.upsertPeer(userId, networkId, {
+      fingerprint: fp,
+      pubkey: rsp.pubkey,
+      lastHandle: senderHandle,
+      lastNick: null,
+      firstSeen: now,
+      lastSeen: now,
+      globalStatus: 'trusted',
+    });
+    keyring.setPeerStatus(userId, networkId, fp, 'trusted');
+
+    try {
+      keyring.installIncomingSessionStrict(userId, networkId, {
+        handle: senderHandle,
+        channel: rsp.channel,
+        fingerprint: fp,
+        sk,
+        status: 'trusted',
+        createdAt: now,
+      });
+    } catch (err) {
+      if (err instanceof HandleMismatchError) {
+        return { replies: [], notice: this.tofuWarning(senderHandle, 'fingerprint-changed') };
+      }
+      throw err;
+    }
+    return {
+      replies: [],
+      notice: { level: 'info', text: `Encrypted session established with ${senderHandle}` },
+    };
+  }
+
+  private handleRekey(
+    userId: number,
+    networkId: number,
+    senderHandle: string,
+    rekey: KeyRekey,
+  ): HandshakeOutcome {
+    const payload = sigPayloadKeyRekey(
+      rekey.channel,
+      rekey.pubkey,
+      rekey.ephPub,
+      rekey.wrapNonce,
+      rekey.wrapCt,
+      rekey.nonce,
+    );
+    if (!verify(rekey.pubkey, payload, rekey.sig)) return { replies: [] };
+
+    const fp = fingerprint(rekey.pubkey);
+    const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
+    // A REKEY from a peer we've never handshaked with is illegitimate.
+    if (change === 'new') return { replies: [] };
+    if (change === 'revoked' || change === 'fingerprint-changed') {
+      return { replies: [], notice: this.tofuWarning(senderHandle, change) };
+    }
+
+    // ECDH from OUR Ed25519 identity (converted to X25519) with their fresh
+    // ephemeral, HKDF under the REKEY domain separator.
+    const id = this.loadIdentity(userId);
+    const myScalar = ed25519SeedToX25519(id.secretKey);
+    const info = utf8.encode(rekeyInfo(rekey.channel));
+    const wrapKey = deriveWrapKey(myScalar, rekey.ephPub, info);
+    let sk: Uint8Array;
+    try {
+      sk = aead.decrypt(wrapKey, rekey.wrapNonce, info, rekey.wrapCt);
+    } catch {
+      return { replies: [] };
+    }
+    if (sk.length !== 32) return { replies: [] };
+
+    try {
+      keyring.installIncomingSessionStrict(userId, networkId, {
+        handle: senderHandle,
+        channel: rekey.channel,
+        fingerprint: fp,
+        sk,
+        status: 'trusted',
+        createdAt: this.nowUnix(),
+      });
+    } catch (err) {
+      if (err instanceof HandleMismatchError) {
+        return { replies: [], notice: this.tofuWarning(senderHandle, 'fingerprint-changed') };
+      }
+      throw err;
+    }
+    return { replies: [] };
+  }
+
+  /** Accept a normal-mode KEYREQ cached for `/e2e accept`. */
+  acceptPending(
+    userId: number,
+    networkId: number,
+    senderHandle: string,
+    channel: string,
+  ): HandshakeOutcome {
+    const key = this.inboundKey(userId, networkId, senderHandle, channel);
+    const req = this.pendingInbound.get(key);
+    if (!req) {
+      return { replies: [], notice: { level: 'warn', text: 'no pending handshake to accept' } };
+    }
+    this.pendingInbound.delete(key);
+    return this.buildKeyRspAndReciprocal(userId, networkId, senderHandle, req);
+  }
+
+  // Build the KEYRSP (wrapping our outgoing key) for `req`, plus a reciprocal
+  // KEYREQ so the peer sends us their key too (symmetric handshake).
+  private buildKeyRspAndReciprocal(
+    userId: number,
+    networkId: number,
+    senderHandle: string,
+    req: KeyReq,
+  ): HandshakeOutcome {
+    const id = this.loadIdentity(userId);
+    const fp = fingerprint(req.pubkey);
+    const ourSk = this.getOrGenerateOutgoingKey(userId, networkId, req.channel);
+    keyring.recordOutgoingRecipient(
+      userId,
+      networkId,
+      req.channel,
+      senderHandle,
+      fp,
+      this.nowUnix(),
+    );
+
+    const ourEph = generateEphemeral();
+    const info = utf8.encode(wrapInfo(req.channel));
+    const wrapKey = deriveWrapKey(ourEph.secretKey, req.ephX25519, info);
+    const sealed = aead.encrypt(wrapKey, info, ourSk);
+
+    const rspNonce = new Uint8Array(randomBytes(16));
+    const rspPayload = sigPayloadKeyRsp(
+      req.channel,
+      id.publicKey,
+      ourEph.publicKey,
+      sealed.nonce,
+      sealed.ciphertext,
+      rspNonce,
+    );
+    const rsp: KeyRsp = {
+      channel: req.channel,
+      pubkey: id.publicKey,
+      ephemeralPub: ourEph.publicKey,
+      wrapNonce: sealed.nonce,
+      wrapCt: sealed.ciphertext,
+      nonce: rspNonce,
+      sig: sign(id.secretKey, rspPayload),
+    };
+
+    const replies = [encodeKeyRsp(rsp)];
+    // Reciprocal KEYREQ unless we already hold their key, rate-limited.
+    if (
+      !this.hasTrustedIncoming(userId, networkId, senderHandle, req.channel) &&
+      this.rateLimiter.allowOutgoing(this.rlKey(userId, networkId, senderHandle))
+    ) {
+      replies.push(
+        encodeKeyReq(this.buildKeyReqStruct(userId, networkId, req.channel, senderHandle)),
+      );
+    }
+    return { replies };
+  }
+
+  private consumePendingForKeyRsp(
+    userId: number,
+    networkId: number,
+    rsp: KeyRsp,
+  ): Uint8Array | null {
+    const info = utf8.encode(wrapInfo(rsp.channel));
+    for (const [key, ph] of this.pending) {
+      if (ph.userId !== userId || ph.networkId !== networkId || ph.channel !== rsp.channel)
+        continue;
+      try {
+        const wrapKey = deriveWrapKey(ph.ephSecret, rsp.ephemeralPub, info);
+        const sk = aead.decrypt(wrapKey, rsp.wrapNonce, info, rsp.wrapCt);
+        if (sk.length !== 32) continue;
+        this.pending.delete(key); // consume only on success
+        return sk;
+      } catch {
+        // Not the matching pending entry — the AEAD tag discriminates.
+        continue;
+      }
+    }
+    return null;
+  }
+
+  // ─── encrypt / decrypt ───────────────────────────────────────────────────────
+
+  /** Encrypt `plaintext` for `channel` into `+RPE2E01` wire lines, or `null`
+   *  if E2E is not enabled for the channel. */
+  encryptOutgoing(
+    userId: number,
+    networkId: number,
+    channel: string,
+    plaintext: string,
+  ): string[] | null {
+    const cfg = keyring.getChannelConfig(userId, networkId, channel);
+    if (!cfg || !cfg.enabled) return null;
+
+    const sk = this.getOrGenerateOutgoingKey(userId, networkId, channel);
+    const chunks = splitPlaintext(plaintext);
+    const total = chunks.length;
+    const msgid = freshMsgid();
+    const ts = this.nowUnix();
+
+    return chunks.map((chunk, idx) => {
+      const part = idx + 1;
+      const aad = buildAad(channel, msgid, ts, part, total);
+      const sealed = aead.encrypt(sk, aad, chunk);
+      return encodeChunk({
+        msgid,
+        ts,
+        part,
+        total,
+        nonce: sealed.nonce,
+        ciphertext: sealed.ciphertext,
+      });
+    });
+  }
+
+  /** Decrypt one inbound wire line. */
+  decryptIncoming(
+    userId: number,
+    networkId: number,
+    senderHandle: string,
+    channel: string,
+    line: string,
+  ): DecryptOutcome {
+    let wire;
+    try {
+      wire = parseChunk(line);
+    } catch {
+      return { kind: 'rejected', reason: 'malformed RPE2E line' };
+    }
+    if (!wire) return { kind: 'cleartext', text: line };
+
+    const skew = Math.abs(this.nowUnix() - wire.ts);
+    if (skew > this.tsToleranceSecs) {
+      return { kind: 'rejected', reason: `ts outside tolerance window (${skew}s skew)` };
+    }
+
+    const sess = keyring.getIncomingSession(userId, networkId, senderHandle, channel);
+    if (!sess) return { kind: 'missing-key' };
+    if (sess.status !== 'trusted') return { kind: 'rejected', reason: `peer not trusted` };
+
+    const aad = buildAad(channel, wire.msgid, wire.ts, wire.part, wire.total);
+    let pt: Uint8Array;
+    try {
+      pt = aead.decrypt(sess.sk, wire.nonce, aad, wire.ciphertext);
+    } catch {
+      return { kind: 'rejected', reason: 'authentication failed' };
+    }
+    let text: string;
+    try {
+      text = decoder.decode(pt);
+    } catch {
+      return { kind: 'rejected', reason: 'invalid utf-8' };
+    }
+
+    // Replay check only AFTER a chunk authenticates, so unauthenticated traffic
+    // can't poison the cache. ttl past the ts window covers the replay horizon.
+    const replayKey = `${userId}:${networkId}:${channel}:${senderHandle}:${Buffer.from(
+      wire.msgid,
+    ).toString('hex')}:${wire.part}`;
+    if (!this.replay.observe(replayKey, (this.tsToleranceSecs * 2 + 5) * 1000)) {
+      return { kind: 'replay' };
+    }
+    return { kind: 'plaintext', text };
+  }
+
+  // ─── trust operations ────────────────────────────────────────────────────────
+
+  /** Their fingerprint + SAS for `/e2e verify <nick>`, or null if unknown. */
+  verifyInfo(
+    userId: number,
+    networkId: number,
+    handle: string,
+  ): { fingerprintHex: string; sas: string; status: keyring.TrustStatus } | null {
+    const peer = keyring.getPeerByHandle(userId, networkId, handle);
+    if (!peer) return null;
+    return {
+      fingerprintHex: fingerprintHex(peer.fingerprint),
+      sas: fingerprintWords(peer.fingerprint),
+      status: peer.globalStatus,
+    };
+  }
+
+  /** Revoke a peer: mark the global peer + every session for the handle revoked,
+   *  so we stop decrypting their traffic. */
+  revokePeer(userId: number, networkId: number, handle: string): boolean {
+    const peer = keyring.getPeerByHandle(userId, networkId, handle);
+    if (peer) keyring.setPeerStatus(userId, networkId, peer.fingerprint, 'revoked');
+    let found = false;
+    for (const s of keyring.listIncomingSessions(userId, networkId)) {
+      if (s.handle.toLowerCase() === handle.toLowerCase()) {
+        keyring.updateIncomingStatus(userId, networkId, s.handle, s.channel, 'revoked');
+        found = true;
+      }
+    }
+    return found || peer !== null;
+  }
+
+  /** Forget a peer entirely so the next handshake re-pins (TOFU reset). Returns
+   *  the number of rows cleared. */
+  reverifyPeer(userId: number, networkId: number, handle: string): number {
+    let cleared = 0;
+    const peer = keyring.getPeerByHandle(userId, networkId, handle);
+    if (peer) {
+      keyring.deletePeerByFingerprint(userId, networkId, peer.fingerprint);
+      cleared += 1;
+    }
+    cleared += keyring.deleteIncomingSessionsForHandle(userId, networkId, handle);
+    cleared += keyring.deleteOutgoingRecipientsForHandle(userId, networkId, handle);
+    const inboundPrefix = `${userId}:${networkId}:${handle}:`;
+    for (const key of this.pendingInbound.keys()) {
+      if (key.startsWith(inboundPrefix)) this.pendingInbound.delete(key);
+    }
+    return cleared;
+  }
+
+  // ─── private helpers ─────────────────────────────────────────────────────────
+
+  private getOrGenerateOutgoingKey(userId: number, networkId: number, channel: string): Uint8Array {
+    const sess = keyring.getOutgoingSession(userId, networkId, channel);
+    if (sess && !sess.pendingRotation) return sess.sk;
+    // No session yet, or a rotation is pending — generate a fresh key. (REKEY
+    // distribution to existing recipients is a Phase-2 channel feature.)
+    const fresh = aead.generateSessionKey();
+    keyring.setOutgoingSession(userId, networkId, channel, fresh, this.nowUnix());
+    return fresh;
+  }
+
+  private effectiveMode(
+    userId: number,
+    networkId: number,
+    handle: string,
+    channel: string,
+  ): keyring.ChannelMode | null {
+    const cfg = keyring.getChannelConfig(userId, networkId, channel);
+    if (!cfg || !cfg.enabled) return null;
+    if (keyring.autotrustMatches(userId, networkId, handle, channel)) return 'auto-accept';
+    return cfg.mode;
+  }
+
+  private classifyPeerChange(
+    userId: number,
+    networkId: number,
+    fp: Uint8Array,
+    handle: string,
+  ): ClassifyResult {
+    const byFp = keyring.getPeerByFingerprint(userId, networkId, fp);
+    if (byFp && byFp.globalStatus === 'revoked') return 'revoked';
+    const byHandle = keyring.getPeerByHandle(userId, networkId, handle);
+    if (byHandle && !bytesEqual(byHandle.fingerprint, fp)) return 'fingerprint-changed';
+    return byFp ? 'known' : 'new';
+  }
+
+  private upsertSeenPeer(
+    userId: number,
+    networkId: number,
+    fp: Uint8Array,
+    pubkey: Uint8Array,
+    handle: string,
+    nick: string | null,
+  ): void {
+    const now = this.nowUnix();
+    keyring.upsertPeer(userId, networkId, {
+      fingerprint: fp,
+      pubkey,
+      lastHandle: handle,
+      lastNick: nick,
+      firstSeen: now,
+      lastSeen: now,
+      globalStatus: 'pending', // only the insert uses this; conflicts preserve
+    });
+  }
+
+  private hasTrustedIncoming(
+    userId: number,
+    networkId: number,
+    handle: string,
+    channel: string,
+  ): boolean {
+    const s = keyring.getIncomingSession(userId, networkId, handle, channel);
+    return s?.status === 'trusted';
+  }
+
+  private inboundKey(userId: number, networkId: number, handle: string, channel: string): string {
+    return `${userId}:${networkId}:${handle}:${channel}`;
+  }
+
+  private tofuWarning(handle: string, change: ClassifyResult): UserNotice {
+    if (change === 'revoked') {
+      return { level: 'warn', text: `Ignoring encrypted handshake from revoked peer ${handle}` };
+    }
+    return {
+      level: 'warn',
+      text: `⚠ encryption key changed for ${handle} — verify out-of-band, then /e2e reverify ${handle} to accept`,
+    };
+  }
+}
+
+/** Process-wide singleton used by the IRC layer. Tests construct their own
+ *  instances (with an injected clock) to drive time-dependent paths. */
+export const e2eManager = new E2eManager();

--- a/server/services/e2e/rateLimiter.test.ts
+++ b/server/services/e2e/rateLimiter.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { RateLimiter } from './rateLimiter.js';
+
+describe('RateLimiter', () => {
+  it('enforces a 30s outgoing gap per peer, independently', () => {
+    let t = 0;
+    const rl = new RateLimiter(() => t);
+    expect(rl.allowOutgoing('p')).toBe(true);
+    expect(rl.allowOutgoing('p')).toBe(false);
+    t = 29_999;
+    expect(rl.allowOutgoing('p')).toBe(false);
+    t = 30_000;
+    expect(rl.allowOutgoing('p')).toBe(true);
+    // A different peer has its own gap.
+    expect(rl.allowOutgoing('q')).toBe(true);
+  });
+
+  it('allows 3 incoming per minute then backs off for 5 minutes', () => {
+    let t = 0;
+    const rl = new RateLimiter(() => t);
+    expect(rl.allowIncoming('p')).toBe(true);
+    expect(rl.allowIncoming('p')).toBe(true);
+    expect(rl.allowIncoming('p')).toBe(true);
+    expect(rl.allowIncoming('p')).toBe(false); // 4th trips the backoff
+    t = 60_000;
+    expect(rl.allowIncoming('p')).toBe(false); // still inside the 5-min backoff
+    t = 300_001;
+    expect(rl.allowIncoming('p')).toBe(true); // backoff expired, window reset
+  });
+
+  it('keeps incoming buckets independent per peer', () => {
+    let t = 0;
+    const rl = new RateLimiter(() => t);
+    for (let i = 0; i < 3; i++) rl.allowIncoming('p');
+    expect(rl.allowIncoming('p')).toBe(false);
+    expect(rl.allowIncoming('q')).toBe(true);
+  });
+});

--- a/server/services/e2e/rateLimiter.ts
+++ b/server/services/e2e/rateLimiter.ts
@@ -29,9 +29,22 @@ export class RateLimiter {
   private lastSent = new Map<string, number>();
   private incoming = new Map<string, IncomingBucket>();
   private readonly now: () => number;
+  private readonly maxKeys: number;
 
-  constructor(now: () => number = Date.now) {
+  // `maxKeys` caps each map so an attacker churning nicks can't allocate
+  // unbounded buckets (the incoming bucket is created BEFORE signature
+  // verification). Maps preserve insertion order, so eviction drops the oldest.
+  constructor(now: () => number = Date.now, maxKeys = 50_000) {
     this.now = now;
+    this.maxKeys = maxKeys;
+  }
+
+  private cap(map: Map<string, unknown>): void {
+    while (map.size > this.maxKeys) {
+      const oldest = map.keys().next().value;
+      if (oldest === undefined) break;
+      map.delete(oldest);
+    }
   }
 
   /** True if sending a KEYREQ to `key` is allowed now; records the attempt. */
@@ -40,6 +53,7 @@ export class RateLimiter {
     const ts = this.lastSent.get(key);
     if (ts !== undefined && now - ts < OUTGOING_GAP_MS) return false;
     this.lastSent.set(key, now);
+    this.cap(this.lastSent);
     return true;
   }
 
@@ -50,6 +64,7 @@ export class RateLimiter {
     if (!bucket) {
       bucket = { recent: [], backoffUntil: null };
       this.incoming.set(key, bucket);
+      this.cap(this.incoming);
     }
     if (bucket.backoffUntil !== null) {
       if (now < bucket.backoffUntil) return false;

--- a/server/services/e2e/rateLimiter.ts
+++ b/server/services/e2e/rateLimiter.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Per-peer rate limiter for RPE2E handshake traffic (a port of repartee's
+// handshake.rs RateLimiter, deferred from the crypto-core PR to the manager
+// layer where it belongs). Two limits:
+//   - outgoing: a minimum 30s gap between KEYREQs to the same peer, so we don't
+//     flood passive/offline nicks.
+//   - incoming: max 3 KEYREQs per peer per 60s; exceeding that drops the peer
+//     into a 5-minute backoff during which every further KEYREQ is rejected
+//     WITHOUT any crypto work — cheap to reject a signature flood before the
+//     expensive Ed25519 verify runs.
+//
+// `now` (epoch ms) is injectable so tests can drive the clock without sleeping.
+
+const OUTGOING_GAP_MS = 30_000;
+const INCOMING_WINDOW_MS = 60_000;
+const INCOMING_MAX_PER_WINDOW = 3;
+const INCOMING_BACKOFF_MS = 5 * 60_000;
+
+interface IncomingBucket {
+  /** Epoch-ms of recent KEYREQs (sliding 60s window). */
+  recent: number[];
+  /** When set, the peer is in backoff — reject all until this time. */
+  backoffUntil: number | null;
+}
+
+export class RateLimiter {
+  private lastSent = new Map<string, number>();
+  private incoming = new Map<string, IncomingBucket>();
+  private readonly now: () => number;
+
+  constructor(now: () => number = Date.now) {
+    this.now = now;
+  }
+
+  /** True if sending a KEYREQ to `key` is allowed now; records the attempt. */
+  allowOutgoing(key: string): boolean {
+    const now = this.now();
+    const ts = this.lastSent.get(key);
+    if (ts !== undefined && now - ts < OUTGOING_GAP_MS) return false;
+    this.lastSent.set(key, now);
+    return true;
+  }
+
+  /** True if we should respond to an incoming KEYREQ from `key`. */
+  allowIncoming(key: string): boolean {
+    const now = this.now();
+    let bucket = this.incoming.get(key);
+    if (!bucket) {
+      bucket = { recent: [], backoffUntil: null };
+      this.incoming.set(key, bucket);
+    }
+    if (bucket.backoffUntil !== null) {
+      if (now < bucket.backoffUntil) return false;
+      bucket.backoffUntil = null;
+      bucket.recent = [];
+    }
+    // Evict entries older than the sliding window.
+    bucket.recent = bucket.recent.filter((t) => now - t <= INCOMING_WINDOW_MS);
+    if (bucket.recent.length >= INCOMING_MAX_PER_WINDOW) {
+      bucket.backoffUntil = now + INCOMING_BACKOFF_MS;
+      return false;
+    }
+    bucket.recent.push(now);
+    return true;
+  }
+}

--- a/server/services/e2e/replayCache.test.ts
+++ b/server/services/e2e/replayCache.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import { ReplayCache } from './replayCache.js';
+
+describe('ReplayCache', () => {
+  it('observes a fresh key once, then flags a replay within the ttl', () => {
+    let t = 0;
+    const c = new ReplayCache(100, () => t);
+    expect(c.observe('k', 1000)).toBe(true); // fresh
+    expect(c.observe('k', 1000)).toBe(false); // live replay
+    t = 1001;
+    expect(c.observe('k', 1000)).toBe(true); // expired → fresh again
+  });
+
+  it('evicts the oldest entry when over capacity', () => {
+    let t = 0;
+    const c = new ReplayCache(2, () => t);
+    c.observe('a', 10_000);
+    c.observe('b', 10_000);
+    expect(c.observe('b', 10_000)).toBe(false); // b still live
+    c.observe('c', 10_000); // size 3 > cap 2 → evict oldest (a)
+    expect(c.observe('a', 10_000)).toBe(true); // a was evicted → fresh
+  });
+});

--- a/server/services/e2e/replayCache.ts
+++ b/server/services/e2e/replayCache.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Replay protection — the seen-msgid LRU that closes a documented gap in the
+// reference (issue #382 protocol note 1). AEAD prevents forgery, not replay:
+// an on-path party (or the IRC server) can re-inject a captured `+RPE2E01`
+// chunk within the ±ts-tolerance window and the receiver would decrypt and
+// render it a second time. We track each chunk's identity — (context, sender,
+// msgid, part) — for the length of the replay window and reject a repeat.
+//
+// Bounded: entries expire after `ttlMs` (slightly past the ts window) and the
+// map is capped, evicting expired-then-oldest. `now` (epoch ms) is injectable.
+
+export class ReplayCache {
+  private seen = new Map<string, number>(); // key → expiry (epoch ms)
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+
+  constructor(maxEntries = 8192, now: () => number = Date.now) {
+    this.maxEntries = maxEntries;
+    this.now = now;
+  }
+
+  /**
+   * Record `key` as seen for `ttlMs`. Returns `true` if it is fresh (first
+   * sighting) or `false` if it is a live replay of an entry seen within the
+   * window.
+   */
+  observe(key: string, ttlMs: number): boolean {
+    const now = this.now();
+    const expiry = this.seen.get(key);
+    if (expiry !== undefined && expiry > now) return false; // live replay
+    this.seen.set(key, now + ttlMs);
+    if (this.seen.size > this.maxEntries) this.evict(now);
+    return true;
+  }
+
+  private evict(now: number): void {
+    for (const [k, exp] of this.seen) {
+      if (exp <= now) this.seen.delete(k);
+    }
+    // Map preserves insertion order — drop oldest until back under the cap.
+    while (this.seen.size > this.maxEntries) {
+      const oldest = this.seen.keys().next().value;
+      if (oldest === undefined) break;
+      this.seen.delete(oldest);
+    }
+  }
+}

--- a/server/services/e2e/replayCache.ts
+++ b/server/services/e2e/replayCache.ts
@@ -16,7 +16,10 @@ export class ReplayCache {
   private readonly maxEntries: number;
   private readonly now: () => number;
 
-  constructor(maxEntries = 8192, now: () => number = Date.now) {
+  // Generous default so a busy tenant's within-window traffic doesn't evict
+  // another tenant's still-live entry under realistic load (the cap is a
+  // backstop; window expiry does the real eviction).
+  constructor(maxEntries = 100_000, now: () => number = Date.now) {
     this.maxEntries = maxEntries;
     this.now = now;
   }
@@ -30,16 +33,22 @@ export class ReplayCache {
     const now = this.now();
     const expiry = this.seen.get(key);
     if (expiry !== undefined && expiry > now) return false; // live replay
+    // Delete-then-set so a refreshed (expired) key moves to the end — keeping
+    // Map insertion order aligned with expiry order under a constant ttl.
+    if (expiry !== undefined) this.seen.delete(key);
     this.seen.set(key, now + ttlMs);
-    if (this.seen.size > this.maxEntries) this.evict(now);
+    this.evict(now);
     return true;
   }
 
   private evict(now: number): void {
+    // Insertion order ≈ expiry order, so the expired entries are at the front;
+    // stop at the first live one rather than scanning the whole map.
     for (const [k, exp] of this.seen) {
-      if (exp <= now) this.seen.delete(k);
+      if (exp > now) break;
+      this.seen.delete(k);
     }
-    // Map preserves insertion order — drop oldest until back under the cap.
+    // Backstop cap: drop oldest (soonest-to-expire) until back under the cap.
     while (this.seen.size > this.maxEntries) {
       const oldest = this.seen.keys().next().value;
       if (oldest === undefined) break;


### PR DESCRIPTION
## RPE2E E2eManager (phase 1b of #382)

The orchestration layer that ties the merged crypto core (#394) and keyring (#397) together — a faithful port of repartee's `manager.rs`, adapted for Lurker's multi-tenant cell. **Still no IRC wiring**: callers hand it parsed bodies / plaintext / wire lines and it returns bodies to send back, wire lines, or a decrypt outcome. The IRC layer + `/e2e` commands are the next phase.

### `manager.ts` — `E2eManager`
A process-wide singleton, state keyed by `(userId, networkId)`:
- **identity** load-or-generate per account (+ the reference's self-consistency check),
- **handshake**: `buildKeyReq` → `handleHandshakeBody` dispatcher; KEYREQ verifies → mode-gates (auto/normal/quiet) + autotrust → TOFU-classifies → wraps our key into a KEYRSP → queues a **reciprocal KEYREQ** so the bidirectional session converges; KEYRSP consumes the matching pending ephemeral (AEAD tag discriminates), pins the peer trusted, installs under strict TOFU; REKEY inbound handled,
- **encrypt/decrypt** with the ts-window, trusted-only, and a **replay cache** (only authenticated chunks count),
- **trust ops**: acceptPending, revoke (rotates the outgoing key), verifyInfo (fp + SAS), reverify,
- security ordering mirrored: rate-limit → verify-sig → touch-state; and **every public method is crash-guarded** (a shared singleton must never die on one tenant's bad input).

### `rateLimiter.ts` / `replayCache.ts`
The RateLimiter deferred from the crypto-core PR (30s outgoing gap; 3 incoming/min then 5-min backoff; bounded maps). The seen-msgid LRU closing repartee's documented no-replay gap (window-based eviction + cap).

### Reviewed (second commit)
An in-depth review hardened the singleton: per-method crash boundaries (an attacker's all-zero ephemeral or a post-key-rotation undecryptable key no longer crashes the cell), the reference's `handle-changed` TOFU state restored, revoke now rotates the outgoing key, `encryptOutgoing` can't silently fall back to plaintext, KEYRSP/REKEY flood defenses, bounded in-memory state, self-pubkey reflection guard, and a stale-KEYRSP-after-reverify fix.

### Deferred
REKEY *distribution* / channel key rotation (Phase 2); all IRC wiring + `/e2e` commands + UI (next phase). A `NOTE` marks the REKEY replay hardening to add when distribution ships.

### Checks
**124 e2e tests** (crypto core + manager/rate-limiter/replay); full server suite **1101**; typecheck / oxlint / oxfmt clean. The headline test: two accounts complete a full **bidirectional handshake and exchange messages both ways**, plus trust modes, TOFU impersonation/handle-change, replay, ts-window, revoke/reverify, and the crafted-all-zero-ephemeral non-crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
