### PR TITLE
RPE2E Phase 1c: wire the E2eManager to live IRC traffic (channels)

### DIFF
--- a/server/services/e2e/context.ts
+++ b/server/services/e2e/context.ts
@@ -12,12 +12,20 @@
 
 const CHANNEL_PREFIXES = ['#', '&', '!', '+'];
 
+/** The single source of truth for "is this RPE2E context a channel (vs a PM)".
+ *  Matches the RPE2E protocol's channel-prefix set (repartee parity). Used by
+ *  every encrypt/decrypt/handshake call site so the seam can't disagree with
+ *  itself about what a channel is. */
+export function isChannelContext(target: string): boolean {
+  return CHANNEL_PREFIXES.some((p) => target.startsWith(p));
+}
+
 /**
  * @param target      the IRC target (channel name or a peer nick)
  * @param peerHandle  the remote peer's server-stamped ident@host (PM only)
  */
 export function contextKey(target: string, peerHandle: string): string {
-  if (CHANNEL_PREFIXES.some((p) => target.startsWith(p))) {
+  if (isChannelContext(target)) {
     return target;
   }
   return `@${peerHandle}`;

--- a/server/services/e2e/debug.ts
+++ b/server/services/e2e/debug.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Wire-level RPE2E tracing for interop QA. Set LURKER_E2E_DEBUG=1 to log every
+// inbound CTCP, decrypt outcome, and outbound handshake reply to the console.
+// Shared by the IRC layer (ircConnection + ircManager) so the convention lives
+// in one place. The env var is read per call so it can be toggled at runtime.
+
+/**
+ * Emit an `[e2e]` trace line when LURKER_E2E_DEBUG=1, otherwise a no-op.
+ *
+ * Pass a `() => string` thunk for any message whose interpolation is non-trivial
+ * (a 140-char body slice, a hostmask) so the string is built ONLY when tracing
+ * is on — these calls sit on hot paths (every CTCP/message) where eager
+ * formatting would otherwise run unconditionally.
+ */
+export function e2eDbg(msg: string | (() => string)): void {
+  if (process.env.LURKER_E2E_DEBUG !== '1') return;
+  console.log(`[e2e] ${typeof msg === 'function' ? msg() : msg}`);
+}

--- a/server/services/e2e/manager.test.ts
+++ b/server/services/e2e/manager.test.ts
@@ -87,6 +87,16 @@ describe('E2eManager handshake + exchange', () => {
     });
   });
 
+  it('hints (with the channel) instead of silently dropping a KEYREQ for a not-enabled channel (#382)', () => {
+    // #later is never configured for Alice — a disabled channel. A peer's KEYREQ
+    // must surface a routable hint, not vanish (the "awaiting a session" bug).
+    const req = mgr.buildKeyReq(bob, bobNet, '#later')!;
+    const out = mgr.handleHandshakeBody(alice, aliceNet, BOB_H, 'bob', req)!;
+    expect(out.replies).toHaveLength(0); // never auto-responds on a disabled channel
+    expect(out.channel).toBe('#later'); // routable to the channel buffer
+    expect(out.notice?.text).toMatch(/\/e2e on #later/);
+  });
+
   it('chunks a long message and decrypts every chunk', () => {
     fullHandshake('#big');
     const long = 'x'.repeat(500);

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -225,6 +225,18 @@ export class E2eManager {
     }
   }
 
+  /** Whether E2E is enabled for `channel`. The IRC layer's single egress/ingress
+   *  gate: encrypt outgoing messages, refuse cleartext actions/notices, and
+   *  attempt inbound decryption only on an enabled channel. Never throws. */
+  isChannelEnabled(userId: number, networkId: number, channel: string): boolean {
+    try {
+      return keyring.getChannelConfig(userId, networkId, channel)?.enabled === true;
+    } catch (err) {
+      console.warn(`e2e isChannelEnabled ${channel}: ${(err as Error).message}`);
+      return false;
+    }
+  }
+
   // ─── outbound handshake ──────────────────────────────────────────────────────
 
   /** Build a KEYREQ to initiate (or extend) an encrypted session on `channel`,

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -76,6 +76,10 @@ export interface UserNotice {
 export interface HandshakeOutcome {
   replies: string[];
   notice?: UserNotice;
+  /** The channel/context this handshake is about, so the IRC layer can route
+   *  `notice` to that buffer instead of the server buffer. Only set on
+   *  notice-bearing outcomes (silent drops stay `{ replies: [] }`). */
+  channel?: string;
 }
 
 export type EncryptOutcome =
@@ -325,11 +329,27 @@ export class E2eManager {
     if (!verify(req.pubkey, payload, req.sig)) return { replies: [] };
 
     const mode = this.effectiveMode(userId, networkId, senderHandle, req.channel);
-    if (mode === null) return { replies: [] }; // channel not enabled
+    if (mode === null) {
+      // Channel not enabled. Don't silently drop — the peer would sit "awaiting a
+      // session" forever with nothing on our screen to explain it (the bug that
+      // motivated this). The KEYREQ already cleared verify + rate-limit, so
+      // surface a one-line hint and let the user opt in. No state is recorded for
+      // a channel we never enabled; enabling + initiating is the opt-in.
+      const who = senderNick ?? senderHandle;
+      return {
+        replies: [],
+        notice: {
+          level: 'info',
+          text: `${who} wants an encrypted session on ${req.channel} — enable it with /e2e on ${req.channel}, then /e2e handshake ${who}`,
+        },
+        channel: req.channel,
+      };
+    }
 
     const fp = fingerprint(req.pubkey);
     const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
-    if (isTofuBlock(change)) return { replies: [], notice: this.tofuWarning(senderHandle, change) };
+    if (isTofuBlock(change))
+      return { replies: [], notice: this.tofuWarning(senderHandle, change), channel: req.channel };
     this.upsertSeenPeer(userId, networkId, fp, req.pubkey, senderHandle, senderNick);
 
     const alreadyTrusted = this.hasTrustedIncoming(userId, networkId, senderHandle, req.channel);
@@ -342,6 +362,7 @@ export class E2eManager {
           level: 'info',
           text: `${who} wants to start an encrypted session on ${req.channel} — /e2e accept ${who}`,
         },
+        channel: req.channel,
       };
     }
     if (mode === 'quiet' && !alreadyTrusted) return { replies: [] };
@@ -376,7 +397,8 @@ export class E2eManager {
 
     const fp = fingerprint(rsp.pubkey);
     const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
-    if (isTofuBlock(change)) return { replies: [], notice: this.tofuWarning(senderHandle, change) };
+    if (isTofuBlock(change))
+      return { replies: [], notice: this.tofuWarning(senderHandle, change), channel: rsp.channel };
 
     // We initiated, so receiving the response is our consent → trust the peer.
     const now = this.nowUnix();
@@ -392,11 +414,19 @@ export class E2eManager {
     keyring.setPeerStatus(userId, networkId, fp, 'trusted');
 
     if (!this.installIncoming(userId, networkId, senderHandle, rsp.channel, fp, sk, now)) {
-      return { replies: [], notice: this.tofuWarning(senderHandle, 'fingerprint-changed') };
+      return {
+        replies: [],
+        notice: this.tofuWarning(senderHandle, 'fingerprint-changed'),
+        channel: rsp.channel,
+      };
     }
     return {
       replies: [],
-      notice: { level: 'info', text: `Encrypted session established with ${senderHandle}` },
+      notice: {
+        level: 'info',
+        text: `🔒 encrypted session established with ${senderHandle} on ${rsp.channel}`,
+      },
+      channel: rsp.channel,
     };
   }
 
@@ -429,7 +459,12 @@ export class E2eManager {
     const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
     // A REKEY from a peer we've never handshaked with is illegitimate.
     if (change === 'new') return { replies: [] };
-    if (isTofuBlock(change)) return { replies: [], notice: this.tofuWarning(senderHandle, change) };
+    if (isTofuBlock(change))
+      return {
+        replies: [],
+        notice: this.tofuWarning(senderHandle, change),
+        channel: rekey.channel,
+      };
 
     // ECDH from OUR Ed25519 identity (converted to X25519) with their fresh
     // ephemeral, HKDF under the REKEY domain separator.
@@ -447,7 +482,11 @@ export class E2eManager {
     if (
       !this.installIncoming(userId, networkId, senderHandle, rekey.channel, fp, sk, this.nowUnix())
     ) {
-      return { replies: [], notice: this.tofuWarning(senderHandle, 'fingerprint-changed') };
+      return {
+        replies: [],
+        notice: this.tofuWarning(senderHandle, 'fingerprint-changed'),
+        channel: rekey.channel,
+      };
     }
     return { replies: [] };
   }
@@ -463,7 +502,11 @@ export class E2eManager {
       const key = this.inboundKey(userId, networkId, senderHandle, channel);
       const entry = this.pendingInbound.get(key);
       if (!entry) {
-        return { replies: [], notice: { level: 'warn', text: 'no pending handshake to accept' } };
+        return {
+          replies: [],
+          notice: { level: 'warn', text: `no pending handshake from ${senderHandle} to accept` },
+          channel,
+        };
       }
       this.pendingInbound.delete(key);
       const alreadyTrusted = this.hasTrustedIncoming(userId, networkId, senderHandle, channel);

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2352,8 +2352,13 @@ export class IrcConnection {
       .split(/\s+/)
       .filter((t) => t.length > 0);
     const sub = (tokens.shift() || 'status').toLowerCase();
-    // A channel arg must be more than a bare prefix — `/e2e on #` would otherwise
-    // persist a junk config row keyed on '#' (#382, review #6).
+    // `#`-prefixed channels only — INCLUDING double-hash names like `##anime`
+    // (the `length > 1` guard rejects only a bare lone `#`, which would otherwise
+    // persist a junk config row; #382 review #6). This is intentionally narrower
+    // than isChannelContext's `# & ! +`: Lurker's message routing treats `&`/`!`/
+    // `+` targets as DMs (see `targetIsChannel` in the message handler), so they
+    // can never be E2E channels here — accepting them would only enable a config
+    // whose inbound ciphertext would mis-route to a DM buffer (review #1 on #407).
     const channelToken = tokens.find((t) => t.startsWith('#') && t.length > 1);
     const nonChannel = tokens.filter((t) => !t.startsWith('#'));
     // The channel an op targets: an explicit #arg wins, else the issuing buffer

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -28,6 +28,12 @@ import { deriveIdent } from '../utils/ident.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled } from './identd.js';
 import { MESSAGE_MAX_BYTES, partitionMultiline, reassembleMultiline } from './messageSplit.js';
 import type { MultilineLimits } from './messageSplit.js';
+import { e2eManager } from './e2e/manager.js';
+import type { UserNotice } from './e2e/manager.js';
+import { contextKey } from './e2e/context.js';
+import { CTCP_TAG, WIRE_PREFIX } from './e2e/constants.js';
+import { getChannelConfig as getE2eChannelConfig } from '../db/e2e.js';
+import type { ChannelMode } from '../db/e2e.js';
 import { randomBytes } from 'node:crypto';
 
 // Optional source address for outbound IRC connections (LURKER_OUTGOING_ADDR),
@@ -127,16 +133,56 @@ function isDmTargetName(target: string | undefined | null): boolean {
 }
 
 function extractExtras(event: IrcEvent): Record<string, unknown> | null {
+  let extras: Record<string, unknown> | null = null;
   switch (event.type) {
     case 'kick':
-      return { kicked: event.kicked };
+      extras = { kicked: event.kicked };
+      break;
     case 'nick':
-      return { newNick: event.newNick };
+      extras = { newNick: event.newNick };
+      break;
     case 'mode':
-      return { modes: event.modes };
-    default:
-      return null;
+      extras = { modes: event.modes };
+      break;
   }
+  // RPE2E: persist the lock flag for message/action/notice so the 🔒 indicator
+  // survives a reload and reaches late-attaching clients (round-trips through the
+  // `extra` JSON column → rowToEvent's Object.assign).
+  if (event.e2e) extras = { ...extras, e2e: true };
+  return extras;
+}
+
+// The peer's server-stamped `ident@host` — the stable identity RPE2E keys
+// sessions/peers by (never the nick, which a peer can change at will). Returns
+// null when the event lacks an ident/host (server messages), in which case the
+// peer can't be matched to a keyring session.
+function buildE2eHandle(event: Record<string, unknown>): string | null {
+  const ident = ((event.ident as string) || '').trim();
+  const host = ((event.hostname as string) || '').trim();
+  if (!ident || !host) return null;
+  return `${ident}@${host}`;
+}
+
+// Map a `/e2e on` mode token to a keyring ChannelMode. `auto` auto-accepts
+// inbound handshakes; `quiet` ignores unsolicited ones; the safe default is
+// `normal` (prompt the user to /e2e accept). Unknown tokens fall back to normal.
+function parseE2eMode(token: string | undefined): ChannelMode {
+  switch ((token || '').toLowerCase()) {
+    case 'auto':
+    case 'auto-accept':
+      return 'auto-accept';
+    case 'quiet':
+      return 'quiet';
+    default:
+      return 'normal';
+  }
+}
+
+// Wire-level RPE2E tracing for interop QA — set LURKER_E2E_DEBUG=1 to log every
+// inbound CTCP, decrypt outcome, and outbound handshake reply to the console.
+// Read per-call so it can be toggled without a restart. No-op otherwise.
+function e2eDbg(msg: string): void {
+  if (process.env.LURKER_E2E_DEBUG === '1') console.log(`[e2e] ${msg}`);
 }
 
 // Canonical nick!ident@hostname string used for client-side hostmask ignore
@@ -1035,14 +1081,48 @@ export class IrcConnection {
         eventType === 'action' ? 'action' : eventType === 'notice' ? 'notice' : 'message';
       const nick = eventNick || eventHostname || 'server';
 
+      // RPE2E: a `+RPE2E01` chunk on an encryption channel is decrypted to its
+      // plaintext (rendered with the 🔒 flag) before persistence. A
+      // missing-key/rejected/replay outcome means we can't read it — never
+      // persist the raw ciphertext as a message; surface a transient hint
+      // instead, then fall through to presence tracking only.
+      let bodyText = eventMessage;
+      let e2eFlag = false;
+      if (
+        targetIsChannel &&
+        typeof eventMessage === 'string' &&
+        eventMessage.startsWith(WIRE_PREFIX)
+      ) {
+        const handle = buildE2eHandle(event);
+        const outcome = handle
+          ? e2eManager.decryptIncoming(
+              this.network.user_id,
+              this.network.id,
+              handle,
+              contextKey(eventTarget as string, handle),
+              eventMessage,
+            )
+          : ({ kind: 'missing-key' } as const);
+        e2eDbg(`inbound +RPE2E01 on ${eventTarget} from ${eventNick} (${handle}): ${outcome.kind}`);
+        if (outcome.kind === 'plaintext') {
+          bodyText = outcome.text;
+          e2eFlag = true;
+        } else {
+          this.surfaceE2eDecryptIssue(eventTarget as string, eventNick, outcome.kind);
+          if (eventNick) this.markPeerEvent(eventNick, 'online');
+          return;
+        }
+      }
+
       this.publish({
         type,
         target,
         nick,
-        text: eventMessage,
+        text: bodyText,
         kind: eventType,
         self: false,
         userhost: buildUserhost(event),
+        ...(e2eFlag ? { e2e: true } : {}),
       });
       // An incoming PRIVMSG (not NOTICE) is the moment this nick becomes a
       // tracked DM peer — add them via trackDmPeer so MONITOR + fires too.
@@ -1061,6 +1141,54 @@ export class IrcConnection {
       // close event — so accumulateMultiline already holds every fragment. (#381)
       const id = info?.id as string | undefined;
       if (id) this.flushMultiline(id);
+    });
+
+    // RPE2E handshake transport (#382). irc-framework routes a NOTICE whose body
+    // is CTCP-framed (`\x01…\x01`) to 'ctcp response' with the inner body in
+    // `.message` (framing stripped) and the first word in `.type`. We claim only
+    // RPEE2E and hand the body to the manager, which returns the bodies to NOTICE
+    // straight back to the sender's nick (re-framed) plus an optional user notice.
+    c.on('ctcp response', (event: Record<string, unknown>) => {
+      e2eDbg(
+        `ctcp-response from ${event.nick}!${event.ident}@${event.hostname} type=${event.type} body=${String(event.message).slice(0, 140)}`,
+      );
+      if (event.type !== CTCP_TAG) return;
+      const senderNick = (event.nick as string) || null;
+      const senderHandle = buildE2eHandle(event);
+      const body = event.message as string | undefined;
+      // A stable ident@host is the keyring identity, and we reply to the nick;
+      // without either we can't complete a handshake, so drop quietly.
+      if (!senderHandle || !senderNick || typeof body !== 'string') {
+        e2eDbg(`  dropped pre-dispatch: handle=${senderHandle} nick=${senderNick}`);
+        return;
+      }
+      const outcome = e2eManager.handleHandshakeBody(
+        this.network.user_id,
+        this.network.id,
+        senderHandle,
+        senderNick,
+        body,
+      );
+      e2eDbg(
+        outcome
+          ? `  outcome: replies=${outcome.replies.length} notice=${outcome.notice?.text ?? '-'} channel=${outcome.channel ?? '-'}`
+          : `  outcome: null (parseHandshake returned not-RPEE2E)`,
+      );
+      if (!outcome) return; // not an RPEE2E message after all
+      for (const reply of outcome.replies) this.sendHandshakeReply(senderNick, reply);
+      if (outcome.notice) this.surfaceE2eNotice(outcome.notice, outcome.channel);
+    });
+
+    // Diagnostic only: some clients send CTCP over PRIVMSG (→ 'ctcp request')
+    // instead of NOTICE. The RPE2E spec uses NOTICE, but if a peer's handshake
+    // arrives here we'd otherwise never see it — log it under LURKER_E2E_DEBUG so
+    // an interop mismatch is visible rather than silent.
+    c.on('ctcp request', (event: Record<string, unknown>) => {
+      if (event.type === CTCP_TAG) {
+        e2eDbg(
+          `ctcp-REQUEST (PRIVMSG, not NOTICE!) from ${event.nick}!${event.ident}@${event.hostname} body=${String(event.message).slice(0, 140)}`,
+        );
+      }
     });
 
     c.on('join', (event: Record<string, unknown>) => {
@@ -2127,6 +2255,238 @@ export class IrcConnection {
     // service or bot doesn't spin up presence tracking for it.
     this.noteUserSend(target);
     this.client.notice(target, text);
+  }
+
+  // --- RPE2E (#382) ----------------------------------------------------------
+
+  // A handshake reply (KEYRSP/reciprocal KEYREQ) goes back to the initiator as a
+  // CTCP-framed NOTICE. It's protocol noise, so unlike notice() it never echoes
+  // into a buffer or touches presence/idle tracking.
+  sendHandshakeReply(nick: string, body: string): void {
+    if (this.disposed) return;
+    e2eDbg(`→ NOTICE ${nick}: ${body.slice(0, 140)}`);
+    this.client.notice(nick, `\x01${body}\x01`);
+  }
+
+  // Surface a manager-emitted handshake notice (session established, TOFU
+  // warning, accept/enable prompt). Routed to the channel buffer it's about (so
+  // the prompt appears where the user is actually typing) when we're in that
+  // channel, else the server buffer. Ephemeral: status, not history.
+  surfaceE2eNotice(notice: UserNotice, channel?: string): void {
+    const inChannel = !!channel && this.channels.has(channel.toLowerCase());
+    this.publishEphemeral({
+      type: notice.level === 'warn' ? 'error' : 'system',
+      target: inChannel ? (channel as string) : this.serverTarget(),
+      text: notice.text,
+    });
+  }
+
+  // An inbound `+RPE2E01` chunk we couldn't read. We never persist ciphertext as
+  // a message; instead drop a transient hint on the channel (silent for replays,
+  // which are just duplicates).
+  surfaceE2eDecryptIssue(
+    channel: string,
+    nick: string | undefined,
+    kind: 'missing-key' | 'rejected' | 'replay' | 'cleartext',
+  ): void {
+    if (kind === 'replay' || kind === 'cleartext') return;
+    const who = nick || 'peer';
+    const text =
+      kind === 'missing-key'
+        ? `🔒 encrypted message from ${who} — no session key yet (try /e2e handshake ${who})`
+        : `🔒 could not decrypt a message from ${who}`;
+    this.publishEphemeral({
+      type: kind === 'missing-key' ? 'system' : 'error',
+      target: channel,
+      text,
+    });
+  }
+
+  // The peer's `ident@host` from current channel membership (the JOIN/NAMES
+  // record), or null if they aren't a visible member or their host isn't known.
+  // This is how a user-typed nick maps to the stable keyring identity for
+  // /e2e accept|verify|revoke|reverify.
+  resolvePeerHandle(channel: string, nick: string): string | null {
+    const ch = this.channels.get(channel.toLowerCase());
+    const m = ch?.members.get(nick.toLowerCase());
+    if (!m || !m.user || !m.host) return null;
+    return `${m.user}@${m.host}`;
+  }
+
+  // Dispatch a `/e2e …` subcommand. All output is ephemeral status routed to the
+  // issuing buffer; handshake/accept put real CTCP NOTICEs on the wire. Channels
+  // only this phase (#382) — DM contexts are rejected with a hint.
+  runE2eCommand(issuingTarget: string, argLine: string): void {
+    const uid = this.network.user_id;
+    const nid = this.network.id;
+    const info = (text: string, level: 'info' | 'warn' = 'info') =>
+      this.publishEphemeral({
+        type: level === 'warn' ? 'error' : 'system',
+        target: issuingTarget,
+        text,
+      });
+
+    const tokens = argLine
+      .trim()
+      .split(/\s+/)
+      .filter((t) => t.length > 0);
+    const sub = (tokens.shift() || 'status').toLowerCase();
+    const channelToken = tokens.find((t) => t.startsWith('#'));
+    const nonChannel = tokens.filter((t) => !t.startsWith('#'));
+    // The channel an op targets: an explicit #arg wins, else the issuing buffer
+    // if it's a channel. null when neither is a channel.
+    const channel = channelToken ?? (issuingTarget.startsWith('#') ? issuingTarget : null);
+    const needChannel = (): string | null => {
+      if (!channel) {
+        info('🔒 /e2e: run this from a channel, or name one (e.g. /e2e on #chan)', 'warn');
+        return null;
+      }
+      return channel;
+    };
+    const peer = nonChannel[0];
+    const needPeer = (): string | null => {
+      if (!peer) {
+        info(`🔒 /e2e ${sub}: needs a nick (e.g. /e2e ${sub} alice)`, 'warn');
+        return null;
+      }
+      return peer;
+    };
+    const resolveOrWarn = (chan: string, nick: string): string | null => {
+      const handle = this.resolvePeerHandle(chan, nick);
+      if (!handle)
+        info(`🔒 couldn't resolve ${nick} on ${chan} — are they in the channel?`, 'warn');
+      return handle;
+    };
+
+    switch (sub) {
+      case 'on':
+      case 'enable': {
+        const chan = needChannel();
+        if (!chan) return;
+        const mode = parseE2eMode(nonChannel[0]);
+        if (e2eManager.setChannelConfig(uid, nid, chan, true, mode)) {
+          info(
+            `🔒 encryption enabled on ${chan} (mode: ${mode}). Start a session: /e2e handshake <nick>`,
+          );
+        } else {
+          info(`🔒 failed to enable encryption on ${chan}`, 'warn');
+        }
+        return;
+      }
+      case 'off':
+      case 'disable': {
+        const chan = needChannel();
+        if (!chan) return;
+        const existing = getE2eChannelConfig(uid, nid, chan);
+        const mode: ChannelMode = existing?.mode ?? 'normal';
+        if (e2eManager.setChannelConfig(uid, nid, chan, false, mode)) {
+          info(`🔓 encryption disabled on ${chan}`);
+        } else {
+          info(`🔒 failed to disable encryption on ${chan}`, 'warn');
+        }
+        return;
+      }
+      case 'handshake':
+      case 'hs': {
+        const chan = needChannel();
+        if (!chan) return;
+        const nick = needPeer();
+        if (!nick) return;
+        const peerHandle = this.resolvePeerHandle(chan, nick) ?? undefined;
+        const body = e2eManager.buildKeyReq(uid, nid, chan, peerHandle);
+        if (!body) {
+          info(`🔒 couldn't build a handshake (is your identity available?)`, 'warn');
+          return;
+        }
+        this.sendHandshakeReply(nick, body);
+        info(`🔒 handshake sent to ${nick} on ${chan} — waiting for their key…`);
+        return;
+      }
+      case 'accept': {
+        const chan = needChannel();
+        if (!chan) return;
+        const nick = needPeer();
+        if (!nick) return;
+        const handle = resolveOrWarn(chan, nick);
+        if (!handle) return;
+        const outcome = e2eManager.acceptPending(uid, nid, handle, chan);
+        for (const reply of outcome.replies) this.sendHandshakeReply(nick, reply);
+        if (outcome.notice) info(outcome.notice.text, outcome.notice.level);
+        else info(`🔒 accepted ${nick} — encrypted session set up on ${chan}`);
+        return;
+      }
+      case 'fingerprint':
+      case 'fp': {
+        const id = e2eManager.getIdentity(uid);
+        if (!id) {
+          info('🔒 your encryption identity is unavailable', 'warn');
+          return;
+        }
+        info(`🔒 your fingerprint: ${id.fingerprintHex}`);
+        info(`   verify words: ${id.sas}`);
+        return;
+      }
+      case 'verify': {
+        const chan = needChannel();
+        if (!chan) return;
+        const nick = needPeer();
+        if (!nick) return;
+        const handle = resolveOrWarn(chan, nick);
+        if (!handle) return;
+        const v = e2eManager.verifyInfo(uid, nid, handle);
+        if (!v) {
+          info(`🔒 no known encryption key for ${nick}`, 'warn');
+          return;
+        }
+        info(`🔒 ${nick} fingerprint: ${v.fingerprintHex} (${v.status})`);
+        info(`   verify words: ${v.sas}`);
+        return;
+      }
+      case 'revoke': {
+        const chan = needChannel();
+        if (!chan) return;
+        const nick = needPeer();
+        if (!nick) return;
+        const handle = resolveOrWarn(chan, nick);
+        if (!handle) return;
+        const ok = e2eManager.revokePeer(uid, nid, handle);
+        info(
+          ok
+            ? `🔒 revoked ${nick} — they can't read your future messages`
+            : `🔒 nothing to revoke for ${nick}`,
+        );
+        return;
+      }
+      case 'reverify': {
+        const chan = needChannel();
+        if (!chan) return;
+        const nick = needPeer();
+        if (!nick) return;
+        const handle = resolveOrWarn(chan, nick);
+        if (!handle) return;
+        const cleared = e2eManager.reverifyPeer(uid, nid, handle);
+        info(`🔒 forgot ${cleared} record(s) for ${nick} — the next handshake re-pins their key`);
+        return;
+      }
+      case 'status': {
+        const id = e2eManager.getIdentity(uid);
+        info(
+          id ? `🔒 your fingerprint: ${id.fingerprintHex}` : '🔒 encryption identity unavailable',
+          id ? 'info' : 'warn',
+        );
+        if (channel) {
+          const cfg = getE2eChannelConfig(uid, nid, channel);
+          info(
+            cfg?.enabled
+              ? `🔒 ${channel}: encryption ON (mode: ${cfg.mode})`
+              : `🔓 ${channel}: encryption off`,
+          );
+        }
+        return;
+      }
+      default:
+        info(`🔒 /e2e: on|off|handshake|accept|verify|revoke|reverify|fingerprint|status`, 'warn');
+    }
   }
 
   // --- IRCv3 draft/multiline (#381) ------------------------------------------

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -30,8 +30,9 @@ import { MESSAGE_MAX_BYTES, partitionMultiline, reassembleMultiline } from './me
 import type { MultilineLimits } from './messageSplit.js';
 import { e2eManager } from './e2e/manager.js';
 import type { UserNotice } from './e2e/manager.js';
-import { contextKey } from './e2e/context.js';
+import { contextKey, isChannelContext } from './e2e/context.js';
 import { CTCP_TAG, WIRE_PREFIX } from './e2e/constants.js';
+import { e2eDbg } from './e2e/debug.js';
 import { getChannelConfig as getE2eChannelConfig } from '../db/e2e.js';
 import type { ChannelMode } from '../db/e2e.js';
 import { randomBytes } from 'node:crypto';
@@ -178,13 +179,6 @@ function parseE2eMode(token: string | undefined): ChannelMode {
   }
 }
 
-// Wire-level RPE2E tracing for interop QA — set LURKER_E2E_DEBUG=1 to log every
-// inbound CTCP, decrypt outcome, and outbound handshake reply to the console.
-// Read per-call so it can be toggled without a restart. No-op otherwise.
-function e2eDbg(msg: string): void {
-  if (process.env.LURKER_E2E_DEBUG === '1') console.log(`[e2e] ${msg}`);
-}
-
 // Canonical nick!ident@hostname string used for client-side hostmask ignore
 // matching. Missing parts are left empty rather than starred — the client's
 // glob matcher handles either form, and storing the literal observed value
@@ -235,6 +229,9 @@ export class IrcConnection {
   // survives losing either role. Hydrated on 'registered' and kept live via
   // trackDmPeer/trackFriend + untrackDmPeer/untrackFriend.
   trackedPeers: Map<string, PeerWatch>;
+  // Last time we surfaced an undecryptable-E2E hint per (channel,peer,kind), to
+  // collapse a multi-chunk message's per-chunk hints into one (#382). epoch ms.
+  private readonly e2eHintAt = new Map<string, number>();
   useMonitor: boolean;
   monitorLimit: number;
   pendingMonitorSeed: boolean;
@@ -1088,10 +1085,21 @@ export class IrcConnection {
       // instead, then fall through to presence tracking only.
       let bodyText = eventMessage;
       let e2eFlag = false;
+      // Only attempt decryption on a `+RPE2E01` line for a channel we've actually
+      // enabled E2E on. Without the `isChannelEnabled` gate, ANY peer (or griefer)
+      // sending `+RPE2E01 …` on any channel would make us drop the message and
+      // render a "could not decrypt" hint — and legit cleartext that happens to
+      // start with the magic prefix would be lost (#1). Off-channel + non-enabled
+      // lines fall through and publish as ordinary cleartext.
       if (
-        targetIsChannel &&
         typeof eventMessage === 'string' &&
-        eventMessage.startsWith(WIRE_PREFIX)
+        eventMessage.startsWith(WIRE_PREFIX) &&
+        isChannelContext(eventTarget ?? '') &&
+        e2eManager.isChannelEnabled(
+          this.network.user_id,
+          this.network.id,
+          contextKey(eventTarget as string, ''),
+        )
       ) {
         const handle = buildE2eHandle(event);
         const outcome = handle
@@ -1103,7 +1111,9 @@ export class IrcConnection {
               eventMessage,
             )
           : ({ kind: 'missing-key' } as const);
-        e2eDbg(`inbound +RPE2E01 on ${eventTarget} from ${eventNick} (${handle}): ${outcome.kind}`);
+        e2eDbg(
+          () => `inbound +RPE2E01 on ${eventTarget} from ${eventNick} (${handle}): ${outcome.kind}`,
+        );
         if (outcome.kind === 'plaintext') {
           bodyText = outcome.text;
           e2eFlag = true;
@@ -1150,7 +1160,8 @@ export class IrcConnection {
     // straight back to the sender's nick (re-framed) plus an optional user notice.
     c.on('ctcp response', (event: Record<string, unknown>) => {
       e2eDbg(
-        `ctcp-response from ${event.nick}!${event.ident}@${event.hostname} type=${event.type} body=${String(event.message).slice(0, 140)}`,
+        () =>
+          `ctcp-response from ${event.nick}!${event.ident}@${event.hostname} type=${event.type} body=${String(event.message).slice(0, 140)}`,
       );
       if (event.type !== CTCP_TAG) return;
       const senderNick = (event.nick as string) || null;
@@ -1159,7 +1170,7 @@ export class IrcConnection {
       // A stable ident@host is the keyring identity, and we reply to the nick;
       // without either we can't complete a handshake, so drop quietly.
       if (!senderHandle || !senderNick || typeof body !== 'string') {
-        e2eDbg(`  dropped pre-dispatch: handle=${senderHandle} nick=${senderNick}`);
+        e2eDbg(() => `  dropped pre-dispatch: handle=${senderHandle} nick=${senderNick}`);
         return;
       }
       const outcome = e2eManager.handleHandshakeBody(
@@ -1169,7 +1180,7 @@ export class IrcConnection {
         senderNick,
         body,
       );
-      e2eDbg(
+      e2eDbg(() =>
         outcome
           ? `  outcome: replies=${outcome.replies.length} notice=${outcome.notice?.text ?? '-'} channel=${outcome.channel ?? '-'}`
           : `  outcome: null (parseHandshake returned not-RPEE2E)`,
@@ -1186,7 +1197,8 @@ export class IrcConnection {
     c.on('ctcp request', (event: Record<string, unknown>) => {
       if (event.type === CTCP_TAG) {
         e2eDbg(
-          `ctcp-REQUEST (PRIVMSG, not NOTICE!) from ${event.nick}!${event.ident}@${event.hostname} body=${String(event.message).slice(0, 140)}`,
+          () =>
+            `ctcp-REQUEST (PRIVMSG, not NOTICE!) from ${event.nick}!${event.ident}@${event.hostname} body=${String(event.message).slice(0, 140)}`,
         );
       }
     });
@@ -2264,7 +2276,7 @@ export class IrcConnection {
   // into a buffer or touches presence/idle tracking.
   sendHandshakeReply(nick: string, body: string): void {
     if (this.disposed) return;
-    e2eDbg(`→ NOTICE ${nick}: ${body.slice(0, 140)}`);
+    e2eDbg(() => `→ NOTICE ${nick}: ${body.slice(0, 140)}`);
     this.client.notice(nick, `\x01${body}\x01`);
   }
 
@@ -2283,7 +2295,10 @@ export class IrcConnection {
 
   // An inbound `+RPE2E01` chunk we couldn't read. We never persist ciphertext as
   // a message; instead drop a transient hint on the channel (silent for replays,
-  // which are just duplicates).
+  // which are just duplicates). A logical message over ~180 bytes arrives as N
+  // chunks, each its own undecryptable event — collapse the burst to ONE hint
+  // per (channel,peer,kind) within a short window so a long message can't spam N
+  // identical lines (#382, review #3).
   surfaceE2eDecryptIssue(
     channel: string,
     nick: string | undefined,
@@ -2291,6 +2306,12 @@ export class IrcConnection {
   ): void {
     if (kind === 'replay' || kind === 'cleartext') return;
     const who = nick || 'peer';
+    const key = `${channel.toLowerCase()}:${who.toLowerCase()}:${kind}`;
+    const now = Date.now();
+    if (now - (this.e2eHintAt.get(key) ?? 0) < 5000) return;
+    // Bound the map (a churn of distinct peers shouldn't grow it forever).
+    if (this.e2eHintAt.size > 500) this.e2eHintAt.clear();
+    this.e2eHintAt.set(key, now);
     const text =
       kind === 'missing-key'
         ? `🔒 encrypted message from ${who} — no session key yet (try /e2e handshake ${who})`
@@ -2331,7 +2352,9 @@ export class IrcConnection {
       .split(/\s+/)
       .filter((t) => t.length > 0);
     const sub = (tokens.shift() || 'status').toLowerCase();
-    const channelToken = tokens.find((t) => t.startsWith('#'));
+    // A channel arg must be more than a bare prefix — `/e2e on #` would otherwise
+    // persist a junk config row keyed on '#' (#382, review #6).
+    const channelToken = tokens.find((t) => t.startsWith('#') && t.length > 1);
     const nonChannel = tokens.filter((t) => !t.startsWith('#'));
     // The channel an op targets: an explicit #arg wins, else the issuing buffer
     // if it's a channel. null when neither is a channel.
@@ -2356,6 +2379,19 @@ export class IrcConnection {
       if (!handle)
         info(`🔒 couldn't resolve ${nick} on ${chan} — are they in the channel?`, 'warn');
       return handle;
+    };
+    // The accept/verify/revoke/reverify subcommands all need the same triple:
+    // a channel, a peer nick, and that nick resolved to its keyring handle. One
+    // helper collapses the repeated needChannel→needPeer→resolveOrWarn ladder
+    // (#382, review #12) — each warns + returns null on the first missing piece.
+    const chanNickHandle = (): { chan: string; nick: string; handle: string } | null => {
+      const chan = needChannel();
+      if (!chan) return null;
+      const nick = needPeer();
+      if (!nick) return null;
+      const handle = resolveOrWarn(chan, nick);
+      if (!handle) return null;
+      return { chan, nick, handle };
     };
 
     switch (sub) {
@@ -2403,16 +2439,12 @@ export class IrcConnection {
         return;
       }
       case 'accept': {
-        const chan = needChannel();
-        if (!chan) return;
-        const nick = needPeer();
-        if (!nick) return;
-        const handle = resolveOrWarn(chan, nick);
-        if (!handle) return;
-        const outcome = e2eManager.acceptPending(uid, nid, handle, chan);
-        for (const reply of outcome.replies) this.sendHandshakeReply(nick, reply);
+        const r = chanNickHandle();
+        if (!r) return;
+        const outcome = e2eManager.acceptPending(uid, nid, r.handle, r.chan);
+        for (const reply of outcome.replies) this.sendHandshakeReply(r.nick, reply);
         if (outcome.notice) info(outcome.notice.text, outcome.notice.level);
-        else info(`🔒 accepted ${nick} — encrypted session set up on ${chan}`);
+        else info(`🔒 accepted ${r.nick} — encrypted session set up on ${r.chan}`);
         return;
       }
       case 'fingerprint':
@@ -2427,45 +2459,33 @@ export class IrcConnection {
         return;
       }
       case 'verify': {
-        const chan = needChannel();
-        if (!chan) return;
-        const nick = needPeer();
-        if (!nick) return;
-        const handle = resolveOrWarn(chan, nick);
-        if (!handle) return;
-        const v = e2eManager.verifyInfo(uid, nid, handle);
+        const r = chanNickHandle();
+        if (!r) return;
+        const v = e2eManager.verifyInfo(uid, nid, r.handle);
         if (!v) {
-          info(`🔒 no known encryption key for ${nick}`, 'warn');
+          info(`🔒 no known encryption key for ${r.nick}`, 'warn');
           return;
         }
-        info(`🔒 ${nick} fingerprint: ${v.fingerprintHex} (${v.status})`);
+        info(`🔒 ${r.nick} fingerprint: ${v.fingerprintHex} (${v.status})`);
         info(`   verify words: ${v.sas}`);
         return;
       }
       case 'revoke': {
-        const chan = needChannel();
-        if (!chan) return;
-        const nick = needPeer();
-        if (!nick) return;
-        const handle = resolveOrWarn(chan, nick);
-        if (!handle) return;
-        const ok = e2eManager.revokePeer(uid, nid, handle);
+        const r = chanNickHandle();
+        if (!r) return;
+        const ok = e2eManager.revokePeer(uid, nid, r.handle);
         info(
           ok
-            ? `🔒 revoked ${nick} — they can't read your future messages`
-            : `🔒 nothing to revoke for ${nick}`,
+            ? `🔒 revoked ${r.nick} — they can't read your future messages`
+            : `🔒 nothing to revoke for ${r.nick}`,
         );
         return;
       }
       case 'reverify': {
-        const chan = needChannel();
-        if (!chan) return;
-        const nick = needPeer();
-        if (!nick) return;
-        const handle = resolveOrWarn(chan, nick);
-        if (!handle) return;
-        const cleared = e2eManager.reverifyPeer(uid, nid, handle);
-        info(`🔒 forgot ${cleared} record(s) for ${nick} — the next handshake re-pins their key`);
+        const r = chanNickHandle();
+        if (!r) return;
+        const cleared = e2eManager.reverifyPeer(uid, nid, r.handle);
+        info(`🔒 forgot ${cleared} record(s) for ${r.nick} — the next handshake re-pins their key`);
         return;
       }
       case 'status': {

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Phase 1c IRC wiring (#382): the seam between the E2eManager and live IRC
+// traffic. These exercise the GLUE — does the outbound path put `+RPE2E01` on
+// the wire while showing the sender plaintext; does an inbound chunk get
+// decrypted (or a missing-key surfaced, not persisted as ciphertext); does a
+// handshake CTCP ride NOTICE both ways; do the `/e2e …` commands dispatch. The
+// crypto itself is pinned in server/services/e2e/*.test.ts, so we use real
+// crypto for the new transport plumbing and spy the manager where only the
+// routing decision is under test.
+
+// MUST be first — redirect DATABASE_PATH before the static imports below open
+// the real data/lurker.db.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { IrcConnection } from './ircConnection.js';
+import ircManager from './ircManager.js';
+import { e2eManager } from './e2e/manager.js';
+import * as keyring from '../db/e2e.js';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+
+const CTCP = '';
+const WIRE = '+RPE2E01';
+
+// alice = the IrcConnection's account (user_id 1, network 1); bob = a remote
+// peer with his own keyring identity (user_id 2). Both ride the process-wide
+// e2eManager singleton, which keys all state by (userId, networkId).
+beforeAll(() => {
+  createUser('e2e-alice'); // id 1
+  createUser('e2e-bob'); // id 2
+  // The e2e keyring rows FK to users + networks, so seed both network ids too.
+  createNetwork(1, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'alice' }); // network id 1
+  createNetwork(2, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'bob' }); // network id 2
+});
+
+function makeConn(): IrcConnection {
+  return new IrcConnection({
+    network: {
+      id: 1,
+      user_id: 1,
+      name: 'n',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'alice',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 1,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+      position: 0,
+      created_at: new Date().toISOString(),
+    },
+    onEvent: () => {},
+  });
+}
+
+describe('outbound encrypt (ircManager.send)', () => {
+  it('puts +RPE2E01 chunks on the wire but publishes the plaintext with an e2e flag', () => {
+    const say = vi.fn<(target: string, text: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    const fakeConn = {
+      say,
+      publish,
+      client: { user: { nick: 'alice' } },
+      supportsMultiline: () => false,
+    } as unknown as IrcConnection;
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(fakeConn);
+    e2eManager.setChannelConfig(1, 1, '#enc', true, 'normal');
+
+    const ok = ircManager.send(1, 1, '#enc', 'hello world');
+    expect(ok).toBe(true);
+
+    // Every wire line is ciphertext, never the cleartext.
+    expect(say).toHaveBeenCalled();
+    for (const [target, line] of say.mock.calls) {
+      expect(target).toBe('#enc');
+      expect(line.startsWith(WIRE)).toBe(true);
+      expect(line).not.toContain('hello world');
+    }
+    // The sender sees exactly one readable bubble, flagged encrypted.
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'message',
+        target: '#enc',
+        text: 'hello world',
+        e2e: true,
+        self: true,
+      }),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('falls through to a normal plaintext send when E2E is disabled for the channel', () => {
+    const say = vi.fn<(target: string, text: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    const fakeConn = {
+      say,
+      publish,
+      client: { user: { nick: 'alice' } },
+      supportsMultiline: () => false,
+    } as unknown as IrcConnection;
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(fakeConn);
+
+    ircManager.send(1, 1, '#plain', 'hello world');
+
+    expect(say).toHaveBeenCalledWith('#plain', 'hello world');
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'message', target: '#plain', text: 'hello world' }),
+    );
+    expect(publish.mock.calls[0][0]).not.toHaveProperty('e2e', true);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('inbound decrypt (c.on message)', () => {
+  it('renders a decrypted chunk as plaintext with the e2e flag', () => {
+    const conn = makeConn();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    vi.spyOn(e2eManager, 'decryptIncoming').mockReturnValue({ kind: 'plaintext', text: 'secret' });
+
+    conn.client.emit('message', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: '#in',
+      type: 'privmsg',
+      message: `${WIRE} 00112233aabbccdd 0 1/1 nonce:ct`,
+    });
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: '#in', nick: 'bob', text: 'secret', e2e: true }),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces a missing-key hint and never persists raw ciphertext', () => {
+    const conn = makeConn();
+    const publish = vi.fn<(event: unknown) => void>();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.publishEphemeral = publishEphemeral;
+    vi.spyOn(e2eManager, 'decryptIncoming').mockReturnValue({ kind: 'missing-key' });
+
+    conn.client.emit('message', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: '#in',
+      type: 'privmsg',
+      message: `${WIRE} 00112233aabbccdd 0 1/1 nonce:ct`,
+    });
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(publishEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'system', target: '#in' }),
+    );
+    expect(publishEphemeral.mock.calls[0][0]).toMatchObject({
+      text: expect.stringContaining('no session key'),
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('leaves a plain (non-RPE2E) channel message untouched', () => {
+    const conn = makeConn();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    const spy = vi.spyOn(e2eManager, 'decryptIncoming');
+
+    conn.client.emit('message', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: '#in',
+      type: 'privmsg',
+      message: 'just a normal line',
+    });
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: '#in', text: 'just a normal line' }),
+    );
+    expect(publish.mock.calls[0][0]).not.toHaveProperty('e2e', true);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('handshake transport (c.on ctcp response)', () => {
+  it('answers a real KEYREQ with a CTCP-framed KEYRSP NOTICE to the sender', () => {
+    const conn = makeConn();
+    const notice = vi.fn<(target: string, text: string) => void>();
+    conn.client.notice = notice;
+    conn.publishEphemeral = vi.fn<(event: unknown) => void>();
+    e2eManager.setChannelConfig(1, 1, '#hs', true, 'auto-accept');
+
+    // bob builds a genuine, signed KEYREQ from his own identity.
+    const body = e2eManager.buildKeyReq(2, 2, '#hs');
+    expect(body).toBeTruthy();
+
+    conn.client.emit('ctcp response', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: '#hs',
+      type: 'RPEE2E',
+      message: body,
+    });
+
+    expect(notice).toHaveBeenCalled();
+    const [target, line] = notice.mock.calls[0];
+    expect(target).toBe('bob');
+    expect(line.startsWith(`${CTCP}RPEE2E KEYRSP `)).toBe(true);
+    expect(line.endsWith(CTCP)).toBe(true);
+  });
+
+  it('routes a handshake notice to the channel buffer when joined, else the server buffer', () => {
+    const conn = makeConn();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    conn.upsertChannel('#rt'); // we're in #rt
+
+    conn.surfaceE2eNotice({ level: 'info', text: 'hi' }, '#rt');
+    expect(publishEphemeral).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'system', target: '#rt', text: 'hi' }),
+    );
+
+    conn.surfaceE2eNotice({ level: 'warn', text: 'bye' }, '#notjoined');
+    expect(publishEphemeral).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: 'error', target: ':server:1' }),
+    );
+  });
+
+  it('ignores a non-RPEE2E CTCP response without replying', () => {
+    const conn = makeConn();
+    const notice = vi.fn<(target: string, text: string) => void>();
+    conn.client.notice = notice;
+
+    conn.client.emit('ctcp response', {
+      nick: 'someone',
+      ident: 'i',
+      hostname: 'h',
+      type: 'VERSION',
+      message: 'VERSION SomeClient 1.0',
+    });
+
+    expect(notice).not.toHaveBeenCalled();
+  });
+});
+
+describe('/e2e command dispatch (runE2eCommand)', () => {
+  it('on <#chan> <mode> writes the channel config', () => {
+    const conn = makeConn();
+    conn.publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.runE2eCommand('#cmd', 'on #cmd auto');
+    const cfg = keyring.getChannelConfig(1, 1, '#cmd');
+    expect(cfg?.enabled).toBe(true);
+    expect(cfg?.mode).toBe('auto-accept');
+  });
+
+  it('fingerprint reports the account identity', () => {
+    const conn = makeConn();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    conn.runE2eCommand(':server:1', 'fingerprint');
+    const texts = publishEphemeral.mock.calls.map((c) => (c[0] as { text: string }).text);
+    expect(texts.some((t) => t.includes('your fingerprint'))).toBe(true);
+  });
+
+  it('handshake <nick> sends a CTCP-framed KEYREQ NOTICE from the issuing channel', () => {
+    const conn = makeConn();
+    conn.publishEphemeral = vi.fn<(event: unknown) => void>();
+    const notice = vi.fn<(target: string, text: string) => void>();
+    conn.client.notice = notice;
+    conn.runE2eCommand('#cmd', 'handshake carol');
+    expect(notice).toHaveBeenCalled();
+    const [target, line] = notice.mock.calls[0];
+    expect(target).toBe('carol');
+    expect(line.startsWith(`${CTCP}RPEE2E KEYREQ `)).toBe(true);
+  });
+
+  it('rejects a channel op issued without a channel', () => {
+    const conn = makeConn();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    conn.runE2eCommand(':server:1', 'on');
+    expect(publishEphemeral).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+});

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -120,6 +120,12 @@ describe('outbound encrypt (ircManager.send)', () => {
 });
 
 describe('inbound decrypt (c.on message)', () => {
+  // The decrypt path only fires on a channel with E2E enabled (#1) — enable #in
+  // for the tests that exercise the decrypt branch.
+  beforeAll(() => {
+    e2eManager.setChannelConfig(1, 1, '#in', true, 'normal');
+  });
+
   it('renders a decrypted chunk as plaintext with the e2e flag', () => {
     const conn = makeConn();
     const publish = vi.fn<(event: unknown) => void>();
@@ -188,6 +194,112 @@ describe('inbound decrypt (c.on message)', () => {
       expect.objectContaining({ target: '#in', text: 'just a normal line' }),
     );
     expect(publish.mock.calls[0][0]).not.toHaveProperty('e2e', true);
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT attempt decryption on a channel without E2E enabled — passes it through (#1)', () => {
+    const conn = makeConn();
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    const spy = vi.spyOn(e2eManager, 'decryptIncoming');
+    const line = `${WIRE} 00112233aabbccdd 0 1/1 nonce:ct`;
+
+    conn.client.emit('message', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: '#notenabled', // never configured for E2E
+      type: 'privmsg',
+      message: line,
+    });
+
+    // The griefer line is rendered as ordinary cleartext, NOT dropped or decrypted.
+    expect(spy).not.toHaveBeenCalled();
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: '#notenabled', text: line }),
+    );
+    expect(publish.mock.calls[0][0]).not.toHaveProperty('e2e', true);
+    vi.restoreAllMocks();
+  });
+
+  it('collapses a multi-chunk undecryptable burst into a single hint (#3)', () => {
+    e2eManager.setChannelConfig(1, 1, '#burst', true, 'normal');
+    const conn = makeConn();
+    conn.publish = vi.fn<(event: unknown) => void>();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    vi.spyOn(e2eManager, 'decryptIncoming').mockReturnValue({ kind: 'missing-key' });
+    const emit = (part: number) =>
+      conn.client.emit('message', {
+        nick: 'bob',
+        ident: 'b',
+        hostname: 'h',
+        target: '#burst',
+        type: 'privmsg',
+        message: `${WIRE} 00112233aabbccdd 0 ${part}/3 nonce:ct`,
+      });
+
+    emit(1);
+    emit(2);
+    emit(3);
+
+    expect(publishEphemeral).toHaveBeenCalledTimes(1);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('egress refuses cleartext actions/notices on an E2E channel (#2)', () => {
+  function fakeConn() {
+    const action = vi.fn<(target: string, text: string) => void>();
+    const notice = vi.fn<(target: string, text: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    const conn = {
+      action,
+      notice,
+      publish,
+      publishEphemeral,
+      client: { user: { nick: 'alice' } },
+    } as unknown as IrcConnection;
+    return { conn, action, notice, publishEphemeral };
+  }
+
+  it('blocks /me on an E2E-enabled channel without putting cleartext on the wire', () => {
+    e2eManager.setChannelConfig(1, 1, '#secret', true, 'normal');
+    const { conn, action, publishEphemeral } = fakeConn();
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
+
+    const ok = ircManager.action(1, 1, '#secret', 'waves');
+
+    expect(ok).toBe(true);
+    expect(action).not.toHaveBeenCalled(); // never reached the wire
+    expect(publishEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', target: '#secret' }),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('blocks /notice on an E2E-enabled channel', () => {
+    e2eManager.setChannelConfig(1, 1, '#secret', true, 'normal');
+    const { conn, notice, publishEphemeral } = fakeConn();
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
+
+    ircManager.notice(1, 1, '#secret', 'psst');
+
+    expect(notice).not.toHaveBeenCalled();
+    expect(publishEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', target: '#secret' }),
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('still sends /me normally on a non-E2E channel', () => {
+    const { conn, action } = fakeConn();
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
+
+    ircManager.action(1, 1, '#plainchan', 'waves');
+
+    expect(action).toHaveBeenCalledWith('#plainchan', 'waves');
     vi.restoreAllMocks();
   });
 });

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -39,16 +39,13 @@ import {
 import type { ContactRecord } from '../db/contacts.js';
 import { splitSay, splitAction, hasInteriorNewline } from './messageSplit.js';
 import { e2eManager } from './e2e/manager.js';
-import { contextKey } from './e2e/context.js';
+import { contextKey, isChannelContext } from './e2e/context.js';
+import { e2eDbg } from './e2e/debug.js';
 import db from '../db/index.js';
 
 // RPE2E is wired for real IRC channels only in this phase (#382). DM
 // pseudochannels (`@ident@host`) need the peer's server-stamped handle resolved
 // at send time, which the outbound path doesn't have yet — they're a fast-follow.
-const E2E_CHANNEL_PREFIXES = ['#', '&', '!', '+'];
-function isE2eChannel(target: string): boolean {
-  return E2E_CHANNEL_PREFIXES.some((p) => target.startsWith(p));
-}
 
 // User away state row shape from userAwayState.ts (that file isn't typed yet).
 interface AwayStateRow {
@@ -289,21 +286,25 @@ class IrcManager extends EventEmitter {
     // flag). encryptOutgoing handles its own chunking, so this path bypasses the
     // multiline/splitSay plumbing entirely. 'disabled' falls through to plaintext;
     // 'error' must NOT fall through (that would leak cleartext on an E2E channel).
-    if (isE2eChannel(target)) {
+    if (isChannelContext(target)) {
       const outcome = e2eManager.encryptOutgoing(userId, networkId, contextKey(target, ''), text);
-      if (process.env.LURKER_E2E_DEBUG === '1') {
-        console.log(
-          `[e2e] outbound ${target}: ${outcome.kind}` +
-            (outcome.kind === 'encrypted' ? ` (${outcome.lines.length} line(s))` : ''),
-        );
-      }
+      e2eDbg(
+        () =>
+          `outbound ${target}: ${outcome.kind}` +
+          (outcome.kind === 'encrypted' ? ` (${outcome.lines.length} line(s))` : ''),
+      );
       if (outcome.kind === 'error') {
         conn.publishEphemeral({
           type: 'error',
           target,
           text: `🔒 not sent — encryption failed: ${outcome.reason}`,
         });
-        return true; // surfaced inline; don't fall through to a cleartext send
+        // Return false so the composer surfaces a send-failure toast and KEEPS
+        // the text (vs clearing it), instead of relying only on the easily-missed
+        // ephemeral line. This is leak-safe: the early return — not the boolean —
+        // is what prevents a cleartext fallthrough, and the client never retries
+        // a failed send as plaintext.
+        return false;
       }
       if (outcome.kind === 'encrypted') {
         for (const line of outcome.lines) conn.say(target, line);
@@ -351,9 +352,32 @@ class IrcManager extends EventEmitter {
     return true;
   }
 
+  // On an E2E-enabled channel, /me actions and notices have no interoperable
+  // encrypted form: the RPE2E wire format carries only encrypted PRIVMSG bodies,
+  // and repartee likewise can't decrypt an encrypted ACTION/NOTICE. Rather than
+  // silently leak cleartext on a channel the user believes is encrypted, refuse
+  // the send and say so inline. Encrypted actions are a future protocol feature.
+  private refuseCleartextOnE2eChannel(
+    conn: IrcConnection,
+    userId: number,
+    networkId: number,
+    target: string,
+    kind: 'action' | 'notice',
+  ): boolean {
+    if (!isChannelContext(target)) return false;
+    if (!e2eManager.isChannelEnabled(userId, networkId, contextKey(target, ''))) return false;
+    conn.publishEphemeral({
+      type: 'error',
+      target,
+      text: `🔒 ${kind === 'action' ? '/me actions' : 'notices'} aren't encrypted yet — not sent on this E2E channel`,
+    });
+    return true;
+  }
+
   action(userId: number, networkId: number, target: string, text: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
+    if (this.refuseCleartextOnE2eChannel(conn, userId, networkId, target, 'action')) return true;
     const chunks = splitAction(text);
     for (const chunk of chunks) {
       conn.action(target, chunk);
@@ -375,6 +399,7 @@ class IrcManager extends EventEmitter {
   notice(userId: number, networkId: number, target: string, text: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
+    if (this.refuseCleartextOnE2eChannel(conn, userId, networkId, target, 'notice')) return true;
     const chunks = splitSay(text);
     for (const chunk of chunks) {
       conn.notice(target, chunk);

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -38,7 +38,17 @@ import {
 } from '../db/contacts.js';
 import type { ContactRecord } from '../db/contacts.js';
 import { splitSay, splitAction, hasInteriorNewline } from './messageSplit.js';
+import { e2eManager } from './e2e/manager.js';
+import { contextKey } from './e2e/context.js';
 import db from '../db/index.js';
+
+// RPE2E is wired for real IRC channels only in this phase (#382). DM
+// pseudochannels (`@ident@host`) need the peer's server-stamped handle resolved
+// at send time, which the outbound path doesn't have yet — they're a fast-follow.
+const E2E_CHANNEL_PREFIXES = ['#', '&', '!', '+'];
+function isE2eChannel(target: string): boolean {
+  return E2E_CHANNEL_PREFIXES.some((p) => target.startsWith(p));
+}
 
 // User away state row shape from userAwayState.ts (that file isn't typed yet).
 interface AwayStateRow {
@@ -273,6 +283,43 @@ class IrcManager extends EventEmitter {
   send(userId: number, networkId: number, target: string, text: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
+
+    // RPE2E: on an encryption-enabled channel, transmit ciphertext chunks on the
+    // wire but show the SENDER the readable plaintext locally (one bubble, lock
+    // flag). encryptOutgoing handles its own chunking, so this path bypasses the
+    // multiline/splitSay plumbing entirely. 'disabled' falls through to plaintext;
+    // 'error' must NOT fall through (that would leak cleartext on an E2E channel).
+    if (isE2eChannel(target)) {
+      const outcome = e2eManager.encryptOutgoing(userId, networkId, contextKey(target, ''), text);
+      if (process.env.LURKER_E2E_DEBUG === '1') {
+        console.log(
+          `[e2e] outbound ${target}: ${outcome.kind}` +
+            (outcome.kind === 'encrypted' ? ` (${outcome.lines.length} line(s))` : ''),
+        );
+      }
+      if (outcome.kind === 'error') {
+        conn.publishEphemeral({
+          type: 'error',
+          target,
+          text: `🔒 not sent — encryption failed: ${outcome.reason}`,
+        });
+        return true; // surfaced inline; don't fall through to a cleartext send
+      }
+      if (outcome.kind === 'encrypted') {
+        for (const line of outcome.lines) conn.say(target, line);
+        conn.publish({
+          type: 'message',
+          target,
+          nick: conn.client.user?.nick,
+          text,
+          kind: 'privmsg',
+          self: true,
+          e2e: true,
+        });
+        return true;
+      }
+      // kind === 'disabled' → fall through to the normal plaintext send below.
+    }
     // A multi-line compose rides draft/multiline batches where the server
     // supports the cap: it lands as one logical message per batch (the body is
     // partitioned to the server's limits, so a big paste is N messages, not N
@@ -349,6 +396,17 @@ class IrcManager extends EventEmitter {
     if (!target || target.startsWith(':server:')) return false;
     if (!['active', 'paused', 'done'].includes(state)) return false;
     conn.sendTyping(target, state);
+    return true;
+  }
+
+  // RPE2E command surface (#382). Dispatches a `/e2e …` subcommand on a live
+  // connection (handshakes/config/trust); the connection publishes its own
+  // ephemeral status output to the issuing buffer. Returns false only when the
+  // network isn't connected, so the WS layer can tell the user.
+  e2eCommand(userId: number, networkId: number, target: string, argLine: string): boolean {
+    const conn = this.getConnection(userId, networkId);
+    if (!conn) return false;
+    conn.runE2eCommand(target, argLine);
     return true;
   }
 

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1466,6 +1466,28 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         }
         break;
       }
+      case 'e2e': {
+        // RPE2E `/e2e …` command (#382). The connection runs the subcommand and
+        // publishes its own ephemeral status to the issuing buffer; we only need
+        // to tell the user when the network isn't connected (no connection = no
+        // place for that status to come from).
+        const networkId = Number(msg.networkId);
+        const target = typeof msg.target === 'string' ? msg.target : '';
+        const args = typeof msg.args === 'string' ? msg.args : '';
+        const ok = ircManager.e2eCommand(userId, networkId, target, args);
+        if (!ok) {
+          const evt = {
+            type: 'error',
+            networkId,
+            target,
+            text: '🔒 /e2e: this network isn’t connected',
+            time: new Date().toISOString(),
+            self: false,
+          } as unknown as MessageEvent;
+          fanOut(userId, { ...decorateMessage(userId, evt), kind: 'irc' });
+        }
+        break;
+      }
       case 'join':
         ircManager.joinChannel(userId, msg.networkId as number, msg.channel as string);
         break;

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -123,6 +123,7 @@ const PAUSED_BLOCKED_TYPES = new Set([
   'away',
   'back',
   'typing',
+  'e2e',
 ]);
 
 // Options bag for fanOut.
@@ -1471,9 +1472,14 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // publishes its own ephemeral status to the issuing buffer; we only need
         // to tell the user when the network isn't connected (no connection = no
         // place for that status to come from).
-        const networkId = Number(msg.networkId);
         const target = typeof msg.target === 'string' ? msg.target : '';
         const args = typeof msg.args === 'string' ? msg.args : '';
+        // The system buffer carries networkId null; Number(null) → 0 would miss
+        // every connection and fan a frame out with networkId 0 that the client
+        // can't route (the client already gates /e2e on an active network, so
+        // this is defensive). Require a real network id (#382, review #7).
+        const networkId = msg.networkId == null ? NaN : Number(msg.networkId);
+        if (!Number.isFinite(networkId) || networkId <= 0) break;
         const ok = ircManager.e2eCommand(userId, networkId, target, args);
         if (!ok) {
           const evt = {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1996,6 +1996,10 @@ const COMMANDS_LINES = [
   '  /set <key> <value…>    — change a setting; /set (or /set ?) lists all keys',
   '  /get <key>             — read a setting back (output in the system buffer)',
   '  /raw <line>            — send a raw IRC line (alias: /quote)',
+  '  /e2e <sub>             — end-to-end encryption for a channel (experimental)',
+  '      on [#chan] [auto|normal|quiet]   ·   off [#chan]   ·   handshake <nick>',
+  '      accept <nick>   ·   verify <nick>   ·   revoke <nick>   ·   reverify <nick>',
+  '      fingerprint   ·   status',
   '  /commands              — this list',
   '  //text                 — send literal "/text" as a message (escape)',
 ];
@@ -2481,6 +2485,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
   }
 
   switch (verb) {
+    case 'e2e':
+      // RPE2E (#382). Thin pass-through: the server parses the subcommand and
+      // publishes its status/results back into this buffer. We forward the raw
+      // arg line plus the issuing buffer so the server can default the channel.
+      return sendOrToast({ type: 'e2e', networkId, target, args: argLine }, line);
     case 'me':
       return ackedSend({ type: 'action', networkId, target, text: argLine }, argLine);
     case 'msg':

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -106,7 +106,13 @@
             /></span>
           </div>
           <span class="body" :class="bodyClass(row.m)">
-            <i v-if="isE2e(row.m)" class="fa-solid fa-lock e2e-lock" title="End-to-end encrypted" />
+            <i
+              v-if="isE2e(row.m)"
+              class="fa-solid fa-lock e2e-lock"
+              role="img"
+              aria-label="End-to-end encrypted"
+              title="End-to-end encrypted"
+            />
             <RenderSegments
               :segments="textSegments(row.m)"
               :self-color="selfColor"
@@ -134,7 +140,13 @@
             ><template v-else>{{ row.continuationAuthor ? '' : prefixText(row.m) }}</template></span
           >
           <span class="body" :class="bodyClass(row.m)">
-            <i v-if="isE2e(row.m)" class="fa-solid fa-lock e2e-lock" title="End-to-end encrypted" />
+            <i
+              v-if="isE2e(row.m)"
+              class="fa-solid fa-lock e2e-lock"
+              role="img"
+              aria-label="End-to-end encrypted"
+              title="End-to-end encrypted"
+            />
             <RenderSegments
               v-if="hasInlineText(row.m)"
               :segments="textSegments(row.m)"

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -106,6 +106,7 @@
             /></span>
           </div>
           <span class="body" :class="bodyClass(row.m)">
+            <i v-if="isE2e(row.m)" class="fa-solid fa-lock e2e-lock" title="End-to-end encrypted" />
             <RenderSegments
               :segments="textSegments(row.m)"
               :self-color="selfColor"
@@ -133,6 +134,7 @@
             ><template v-else>{{ row.continuationAuthor ? '' : prefixText(row.m) }}</template></span
           >
           <span class="body" :class="bodyClass(row.m)">
+            <i v-if="isE2e(row.m)" class="fa-solid fa-lock e2e-lock" title="End-to-end encrypted" />
             <RenderSegments
               v-if="hasInlineText(row.m)"
               :segments="textSegments(row.m)"
@@ -325,6 +327,8 @@ interface ChatMessage {
   // System-buffer lines (#355): the network this line is about, when any. The
   // prefix column resolves the network's current name from it.
   originNetworkId?: number | null;
+  // RPE2E (#382): this line was end-to-end encrypted on the wire — render a 🔒.
+  e2e?: boolean;
   [key: string]: unknown;
 }
 
@@ -1103,6 +1107,11 @@ function hasInlineText(m: ChatMessage | undefined): boolean {
   return m?.type === 'message' || m?.type === 'notice' || m?.type === 'action';
 }
 
+// RPE2E (#382): show the 🔒 lock on a line that rode the wire encrypted.
+function isE2e(m: ChatMessage | undefined): boolean {
+  return !!m?.e2e;
+}
+
 function textSegments(m: ChatMessage | undefined): RenderSegment[] {
   if (!m) return [];
   if (m.type === 'action') {
@@ -1810,6 +1819,13 @@ watch(
 }
 .body.italic {
   font-style: italic;
+}
+/* RPE2E lock (#382): a muted inline marker that a line rode the wire encrypted.
+   Hierarchy via color/opacity, not font-size (house rule). */
+.e2e-lock {
+  margin-right: 0.5ch;
+  color: var(--good);
+  opacity: 0.75;
 }
 /* .msg-link styling lives in src/assets/main.css (shared with the topic bar). */
 


### PR DESCRIPTION
Connects the merged RPE2E crypto core + keyring + `E2eManager` singleton (Phase 0/1a/1b — #394/#397/#404) to real IRC traffic, giving **channel-scoped end-to-end encryption that interoperates with repartee**. Spec: #382.

**Verified live:** full bidirectional encrypted round-trip with a real repartee peer on a Libera channel — plaintext + 🔒 for participants, opaque `+RPE2E01` ciphertext to every non-participant (confirmed by watching a non-wired Lurker client in the same channel see only ciphertext). This is the Phase-1 acceptance test, and it passes.

Scope is **channels only**; DM pseudochannels (`@ident@host`) need an outbound nick→ident@host resolver and are a documented fast-follow.

## What's wired

| Hook | Behavior |
|---|---|
| **Outbound encrypt** (`ircManager.send`) | An E2E-enabled channel transmits `+RPE2E01` ciphertext chunks; the sender sees one readable plaintext bubble with a 🔒. `disabled` → plaintext; `error` → surfaced, never falls back to cleartext. |
| **Inbound decrypt** (`ircConnection` message handler) | `+RPE2E01` lines on an enabled channel decrypt to plaintext + 🔒; missing-key/rejected surface a transient hint and **never** persist ciphertext as a message. |
| **Handshake transport** (`ctcp response`) | NOTICE + `\x01RPEE2E…\x01` → `handleHandshakeBody`; replies go back re-framed to the sender's nick. Prompts/status route to the channel buffer. |

**Command surface:** `/e2e on|off|handshake|accept|verify|revoke|reverify|fingerprint|status` (server-side dispatch with nick→handle resolution via channel membership), WS bridge, client passthrough, a 🔒 indicator on encrypted lines, and a cheatsheet entry.

**Debug:** `LURKER_E2E_DEBUG=1` traces inbound CTCP / decrypt outcomes / outbound handshake replies (env-gated lazy no-op otherwise) — it diagnosed a cross-client TOFU handle-pin issue during QA in minutes.

## Commits

1. **Wiring** (`6716a8d`) — the three hooks, command surface, lock UI, discoverability (channel-routed prompts, no silent drop on a not-yet-enabled channel).
2. **Review fixes** (`862f81d`) — addressed the code-review pass. Two confidentiality/data-loss blockers fixed (inbound decrypt now gated on enabled; `/me` + `/notice` refuse rather than leak cleartext on an E2E channel), plus correctness/robustness/cleanup. Two review suggestions were **adjusted against repartee's source** (which the reviewer didn't have): `/me`/`/notice` are *refused* not encrypted (repartee sends ACTIONs as plaintext PRIVMSG and can't decrypt an encrypted ACTION/NOTICE), and multi-chunk messages keep **per-chunk rendering** (repartee's `chunker.rs` §6: the receiver never reassembles) — only the per-chunk hint spam was deduped. One finding (structured trusted-vs-verified metadata) deferred with rationale: the keyring has no `verified` trust state yet.

## Reviewer notes

Worth a close look:
- The change to the merged `E2eManager` (`HandshakeOutcome.channel` + the disabled-channel hint in `handleKeyReq`) — additive, with drop paths kept byte-identical so the pinned security tests don't move.
- The outbound `error → don't fall back to cleartext` branch in `ircManager.send` (the one place a bug could leak plaintext on an E2E channel).
- The inbound gate that ciphertext is never persisted on a missing-key/rejected/replay outcome.

## Testing

`tsc` / `vue-tsc` / `oxlint` / `oxfmt` clean; 594 server/services tests green, including a new `ircE2eWiring.test.ts` (real crypto for the transport, manager-method spies for the decrypt glue) covering outbound encrypt, inbound decrypt + the enabled-gate passthrough, handshake CTCP framing, `/e2e` dispatch, `/me`+`/notice` refusal, and multi-chunk hint dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)