### PR TITLE
RPE2E Phase 2: channel key rotation + REKEY distribution

### DIFF
--- a/server/services/e2e/manager.test.ts
+++ b/server/services/e2e/manager.test.ts
@@ -348,3 +348,149 @@ describe('E2eManager review hardening', () => {
     expect(mgr.verifyInfo(alice, aliceNet, BOB_H)).toBeNull();
   });
 });
+
+// ─── Phase 2: channel key rotation / REKEY distribution ──────────────────────
+describe('E2eManager key rotation (Phase 2)', () => {
+  // A third account so rotation can target one peer while keeping another.
+  let carol: number;
+  let carolNet: number;
+  const CAROL_H = '~carol@c.host';
+
+  beforeAll(() => {
+    carol = createUser('mgr-carol').id;
+    carolNet = createNetwork(carol, {
+      name: 'libera',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    })!.id;
+  });
+
+  // Bidirectional handshake of (uid,net,handle,nick) with Alice on `channel`,
+  // both auto-accept — leaves Alice holding `handle` as an outgoing recipient
+  // (the precondition for rotation to target them).
+  function handshakeWithAlice(
+    uid: number,
+    net: number,
+    handle: string,
+    nick: string,
+    channel: string,
+  ): void {
+    // The keyring (DB) is shared across tests; clear any pin/session a prior
+    // test left (e.g. a revoke) so this is a clean first-contact handshake
+    // regardless of test order.
+    mgr.forgetPeer(alice, aliceNet, handle);
+    mgr.forgetPeer(uid, net, ALICE_H);
+    mgr.setChannelConfig(alice, aliceNet, channel, true, 'auto-accept');
+    mgr.setChannelConfig(uid, net, channel, true, 'auto-accept');
+    const aOut = mgr.handleHandshakeBody(
+      alice,
+      aliceNet,
+      handle,
+      nick,
+      mgr.buildKeyReq(uid, net, channel)!,
+    )!;
+    expect(aOut.replies).toHaveLength(2); // KEYRSP + reciprocal KEYREQ
+    mgr.handleHandshakeBody(uid, net, ALICE_H, 'alice', aOut.replies[0]); // installs Alice's key
+    const peerOut = mgr.handleHandshakeBody(uid, net, ALICE_H, 'alice', aOut.replies[1])!;
+    if (peerOut.replies.length) {
+      mgr.handleHandshakeBody(alice, aliceNet, handle, nick, peerOut.replies[0]); // Alice installs theirs
+    }
+  }
+
+  it('lazy-rotates on revoke and distributes a REKEY to the remaining recipient only', () => {
+    const ch = '#rot-revoke';
+    handshakeWithAlice(bob, bobNet, BOB_H, 'bob', ch);
+    handshakeWithAlice(carol, carolNet, CAROL_H, 'carol', ch);
+
+    // Before any rotation: both peers read Alice's message, nothing queued.
+    const first = encLines(alice, aliceNet, ch, 'before revoke');
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, ch, first[0])).toMatchObject({
+      kind: 'plaintext',
+    });
+    expect(mgr.decryptIncoming(carol, carolNet, ALICE_H, ch, first[0])).toMatchObject({
+      kind: 'plaintext',
+    });
+    expect(mgr.takePendingRekeySends(alice, aliceNet)).toEqual([]);
+
+    // Revoke Bob → the next send rotates the key and ships a REKEY to Carol ONLY.
+    expect(mgr.revokePeer(alice, aliceNet, BOB_H)).toBe(true);
+    const second = encLines(alice, aliceNet, ch, 'after revoke');
+    const sends = mgr.takePendingRekeySends(alice, aliceNet);
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toMatchObject({ channel: ch, targetHandle: CAROL_H });
+    // Draining is one-shot.
+    expect(mgr.takePendingRekeySends(alice, aliceNet)).toEqual([]);
+
+    // Carol applies the REKEY (installs silently) and reads the new message;
+    // Bob, cut off, can no longer decrypt Alice's post-revoke traffic.
+    expect(mgr.handleHandshakeBody(carol, carolNet, ALICE_H, 'alice', sends[0].body)).toEqual({
+      replies: [],
+    });
+    expect(mgr.decryptIncoming(carol, carolNet, ALICE_H, ch, second[0])).toMatchObject({
+      kind: 'plaintext',
+      text: 'after revoke',
+    });
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, ch, second[0]).kind).not.toBe('plaintext');
+  });
+
+  it('rotateChannel queues a REKEY for every current recipient on the next send', () => {
+    const ch = '#rot-manual';
+    handshakeWithAlice(bob, bobNet, BOB_H, 'bob', ch);
+    handshakeWithAlice(carol, carolNet, CAROL_H, 'carol', ch);
+
+    expect(mgr.rotateChannel(alice, aliceNet, ch)).toBe(true);
+    const lines = encLines(alice, aliceNet, ch, 'rotated');
+    const sends = mgr.takePendingRekeySends(alice, aliceNet);
+    expect(sends.map((s) => s.targetHandle).sort()).toEqual([BOB_H, CAROL_H].sort());
+
+    // Every peer applies its REKEY and reads the message under the fresh key.
+    for (const s of sends) {
+      const peer =
+        s.targetHandle === BOB_H ? { uid: bob, net: bobNet } : { uid: carol, net: carolNet };
+      mgr.handleHandshakeBody(peer.uid, peer.net, ALICE_H, 'alice', s.body);
+      expect(mgr.decryptIncoming(peer.uid, peer.net, ALICE_H, ch, lines[0])).toMatchObject({
+        kind: 'plaintext',
+        text: 'rotated',
+      });
+    }
+  });
+
+  it('rotateChannel is a no-op (false) when there is no outgoing session yet', () => {
+    expect(mgr.rotateChannel(alice, aliceNet, '#rot-never')).toBe(false);
+    expect(mgr.takePendingRekeySends(alice, aliceNet)).toEqual([]);
+  });
+
+  it('rejects a replayed REKEY (nonce-LRU) so a superseded key cannot be reinstalled', () => {
+    const ch = '#rot-replay';
+    handshakeWithAlice(carol, carolNet, CAROL_H, 'carol', ch);
+
+    // First rotation → REKEY #1 to Carol; she installs it.
+    mgr.rotateChannel(alice, aliceNet, ch);
+    encLines(alice, aliceNet, ch, 'r1');
+    const rekey1 = mgr.takePendingRekeySends(alice, aliceNet)[0].body;
+    mgr.handleHandshakeBody(carol, carolNet, ALICE_H, 'alice', rekey1);
+
+    // Second rotation → REKEY #2; Carol now reads under the newest key.
+    mgr.rotateChannel(alice, aliceNet, ch);
+    const msg2 = encLines(alice, aliceNet, ch, 'r2');
+    const rekey2 = mgr.takePendingRekeySends(alice, aliceNet)[0].body;
+    mgr.handleHandshakeBody(carol, carolNet, ALICE_H, 'alice', rekey2);
+    expect(mgr.decryptIncoming(carol, carolNet, ALICE_H, ch, msg2[0])).toMatchObject({
+      kind: 'plaintext',
+      text: 'r2',
+    });
+
+    // Replaying the FIRST REKEY is ignored (nonce already seen) and must NOT
+    // reinstall the superseded key — Carol still reads Alice's current traffic.
+    expect(mgr.handleHandshakeBody(carol, carolNet, ALICE_H, 'alice', rekey1)).toEqual({
+      replies: [],
+    });
+    const msg3 = encLines(alice, aliceNet, ch, 'r3');
+    expect(mgr.decryptIncoming(carol, carolNet, ALICE_H, ch, msg3[0])).toMatchObject({
+      kind: 'plaintext',
+      text: 'r3',
+    });
+  });
+});

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -26,10 +26,16 @@ import { buildAad } from './aad.js';
 import * as aead from './aead.js';
 import { splitPlaintext } from './chunker.js';
 import { DEFAULT_TS_TOLERANCE_SECS, rekeyInfo, wrapInfo } from './constants.js';
-import { deriveWrapKey, ed25519SeedToX25519, generateEphemeral } from './ecdh.js';
+import {
+  deriveWrapKey,
+  ed25519PubToX25519,
+  ed25519SeedToX25519,
+  generateEphemeral,
+} from './ecdh.js';
 import { utf8 } from './encoding.js';
 import { fingerprint, fingerprintHex, fingerprintWords } from './fingerprint.js';
 import {
+  encodeKeyRekey,
   encodeKeyReq,
   encodeKeyRsp,
   type KeyRekey,
@@ -55,8 +61,19 @@ const PENDING_INBOUND_TTL_MS = 30 * 60_000; // normal-mode prompts await /e2e ac
 const PENDING_INBOUND_MAX = 4096;
 const KEYCHANGE_TTL_MS = 30 * 60_000; // a remembered key/handle change awaits /e2e reverify
 const KEYCHANGE_MAX = 4096;
+// A REKEY carries a signed 16-byte nonce but no timestamp. We remember each
+// nonce we've accepted so a captured REKEY can't be re-injected to re-install a
+// superseded key (a DoS, not a confidentiality break — the key is authentic).
+// Generous TTL since REKEYs are infrequent; bounded so a churn of peers can't
+// grow it unbounded. Resets on cell restart (same exposure the reference has,
+// which tracks nothing at all).
+const REKEY_REPLAY_TTL_MS = 24 * 60 * 60_000;
+const REKEY_REPLAY_MAX = 10_000;
 
 const eqLower = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+
+// Compact, stable string form of raw bytes for use as an in-memory map key.
+const b64 = (b: Uint8Array): string => Buffer.from(b).toString('base64');
 
 // ─── public result shapes ────────────────────────────────────────────────────
 
@@ -111,6 +128,15 @@ export type EncryptOutcome =
   | { kind: 'disabled' } // E2E off for this channel — caller MAY send plaintext
   | { kind: 'encrypted'; lines: string[] }
   | { kind: 'error'; reason: string }; // enabled but failed — caller must NOT send plaintext
+
+/** A REKEY CTCP produced by a lazy rotation, waiting for the IRC layer to ship.
+ *  `body` is UNFRAMED (the IRC layer wraps it in `\x01..\x01` and resolves
+ *  `targetHandle` → a current nick on `channel` before sending it as a NOTICE). */
+export interface PendingRekeySend {
+  channel: string;
+  targetHandle: string;
+  body: string;
+}
 
 export type DecryptOutcome =
   | { kind: 'plaintext'; text: string }
@@ -169,14 +195,19 @@ export class E2eManager {
   private readonly pending = new Map<string, PendingHandshake>();
   private readonly pendingInbound = new Map<string, PendingInbound>();
   private readonly pendingKeyChange = new Map<string, PendingKeyChange>();
+  // REKEY CTCPs queued by a lazy rotation, keyed by tenant (`userId:networkId`).
+  // The IRC layer drains this right after each send (see takePendingRekeySends).
+  private readonly pendingRekey = new Map<string, PendingRekeySend[]>();
   private readonly rateLimiter: RateLimiter;
   private readonly replay: ReplayCache;
+  private readonly rekeyReplay: ReplayCache;
 
   constructor(opts: E2eManagerOptions = {}) {
     this.now = opts.now ?? Date.now;
     this.tsToleranceSecs = opts.tsToleranceSecs ?? DEFAULT_TS_TOLERANCE_SECS;
     this.rateLimiter = new RateLimiter(this.now);
     this.replay = new ReplayCache(100_000, this.now);
+    this.rekeyReplay = new ReplayCache(REKEY_REPLAY_MAX, this.now);
   }
 
   private nowUnix(): number {
@@ -193,6 +224,10 @@ export class E2eManager {
 
   private rlKey(userId: number, networkId: number, handle: string): string {
     return this.peerKey(userId, networkId, handle);
+  }
+
+  private tenantKey(userId: number, networkId: number): string {
+    return `${userId}:${networkId}`;
   }
 
   // ─── identity ──────────────────────────────────────────────────────────────
@@ -541,10 +576,14 @@ export class E2eManager {
     );
     if (!verify(rekey.pubkey, payload, rekey.sig)) return { replies: [] };
 
-    // NOTE: REKEY carries a signed 16-byte nonce but we don't yet track it, and
-    // there's no ts window on this path — a captured REKEY from a known peer is
-    // replayable (re-installs an old key). Latent for now (no REKEY distribution
-    // is wired); add nonce-LRU + ts-skew here when Phase-2 channel rotation ships.
+    // Replay guard: the REKEY nonce is signed, so it can't be tampered with;
+    // reject a repeat so a captured REKEY can't be re-injected to re-install a
+    // superseded key. Checked AFTER signature verify (an unsigned packet can't
+    // poison the cache) and BEFORE any state change. There's no ts field on a
+    // REKEY, so this is a nonce-LRU, not a skew window. See REKEY_REPLAY_TTL_MS.
+    const replayKey = `${this.peerKey(userId, networkId, senderHandle)}:${b64(rekey.nonce)}`;
+    if (!this.rekeyReplay.observe(replayKey, REKEY_REPLAY_TTL_MS)) return { replies: [] };
+
     const fp = fingerprint(rekey.pubkey);
     const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
     // A REKEY from a peer we've never handshaked with is illegitimate.
@@ -1207,16 +1246,133 @@ export class E2eManager {
     }
   }
 
+  // ─── key rotation ────────────────────────────────────────────────────────────
+
+  /** Flag `channel`'s outgoing key for rotation (the `/e2e rotate` command). The
+   *  fresh key is generated AND distributed lazily on the next send to the
+   *  channel — matching the reference's lazy-rotate model, and the same path
+   *  `/e2e revoke` already uses. Returns false if there's no outgoing session yet
+   *  (nothing to rotate — the first send generates a fresh key regardless). */
+  rotateChannel(userId: number, networkId: number, channel: string): boolean {
+    try {
+      if (!keyring.getOutgoingSession(userId, networkId, channel)) return false;
+      keyring.markOutgoingPendingRotation(userId, networkId, channel);
+      return true;
+    } catch (err) {
+      console.warn(`e2e rotate ${channel}: ${(err as Error).message}`);
+      return false;
+    }
+  }
+
+  /** Drain the REKEY CTCPs queued by a lazy rotation for this tenant. The IRC
+   *  layer calls this right after each send: it resolves each entry's
+   *  `targetHandle` → a current nick on `channel` and ships `body` as a framed
+   *  NOTICE. Never throws (shared singleton). */
+  takePendingRekeySends(userId: number, networkId: number): PendingRekeySend[] {
+    try {
+      const key = this.tenantKey(userId, networkId);
+      const queue = this.pendingRekey.get(key);
+      if (!queue || queue.length === 0) return [];
+      this.pendingRekey.delete(key);
+      return queue;
+    } catch (err) {
+      console.warn(`e2e takePendingRekeySends: ${(err as Error).message}`);
+      return [];
+    }
+  }
+
   // ─── private helpers ─────────────────────────────────────────────────────────
 
   private getOrGenerateOutgoingKey(userId: number, networkId: number, channel: string): Uint8Array {
     const sess = keyring.getOutgoingSession(userId, networkId, channel);
     if (sess && !sess.pendingRotation) return sess.sk;
-    // No session yet, or a rotation is pending — generate a fresh key. (REKEY
-    // distribution to existing recipients is a Phase-2 channel feature.)
+    // No session yet, or a rotation is pending — generate a fresh key. When this
+    // is a ROTATION (an existing session flagged pendingRotation by /e2e revoke
+    // or /e2e rotate) we must hand the new key to every remaining recipient via a
+    // REKEY CTCP so they can keep decrypting us. Capture the rotation flag BEFORE
+    // setOutgoingSession clears it. Distribution is queued for the IRC layer to
+    // drain + ship (it owns handle → nick resolution and the wire).
+    const rotating = sess?.pendingRotation === true;
     const fresh = aead.generateSessionKey();
+    if (rotating) this.queueRekeyDistribution(userId, networkId, channel, fresh);
     keyring.setOutgoingSession(userId, networkId, channel, fresh, this.nowUnix());
     return fresh;
+  }
+
+  // Build a REKEY CTCP for every remaining recipient of our outgoing key on
+  // `channel`, delivering `freshSk`, and queue them for the IRC layer. The
+  // recipients table is kept in lock-step with consent (recordOutgoingRecipient
+  // on KEYRSP-build, removeOutgoingRecipient on revoke/forget), so a revoked
+  // peer is already gone from it and never gets the new key. A recipient with no
+  // peer pin (shouldn't happen) or whose key won't build is skipped, not fatal.
+  private queueRekeyDistribution(
+    userId: number,
+    networkId: number,
+    channel: string,
+    freshSk: Uint8Array,
+  ): void {
+    const recipients = keyring.listOutgoingRecipients(userId, networkId, channel);
+    if (recipients.length === 0) return;
+    const sends: PendingRekeySend[] = [];
+    for (const r of recipients) {
+      const peer = keyring.getPeerByFingerprint(userId, networkId, r.fingerprint);
+      if (!peer) {
+        console.warn(`e2e rekey: no peer pin for recipient ${r.handle} on ${channel}; skipping`);
+        continue;
+      }
+      try {
+        const body = this.buildRekeyBody(userId, networkId, channel, peer.pubkey, freshSk);
+        sends.push({ channel, targetHandle: r.handle, body });
+      } catch (err) {
+        console.warn(`e2e rekey build for ${r.handle} on ${channel}: ${(err as Error).message}`);
+      }
+    }
+    if (sends.length === 0) return;
+    const key = this.tenantKey(userId, networkId);
+    const queue = this.pendingRekey.get(key);
+    if (queue) queue.push(...sends);
+    else this.pendingRekey.set(key, sends);
+  }
+
+  // Encode a single KeyRekey delivering `freshSk` for `channel` to `recipientEdPub`.
+  // Fresh ephemeral X25519 → ECDH against the recipient's static identity (their
+  // Ed25519 pubkey mapped to X25519), HKDF under the REKEY domain separator, AEAD
+  // seal, sign with our identity. Mirrors buildKeyRspAndReciprocal's wrap, but
+  // wrapping to a STATIC peer key (not a per-handshake ephemeral) — that's why
+  // the recipient unwraps with their long-term key in handleRekey.
+  private buildRekeyBody(
+    userId: number,
+    networkId: number,
+    channel: string,
+    recipientEdPub: Uint8Array,
+    freshSk: Uint8Array,
+  ): string {
+    const id = this.loadIdentity(userId);
+    const ourEph = generateEphemeral();
+    const recipientX = ed25519PubToX25519(recipientEdPub);
+    const info = utf8.encode(rekeyInfo(channel));
+    const wrapKey = deriveWrapKey(ourEph.secretKey, recipientX, info);
+    const sealed = aead.encrypt(wrapKey, info, freshSk);
+
+    const nonce = new Uint8Array(randomBytes(16));
+    const payload = sigPayloadKeyRekey(
+      channel,
+      id.publicKey,
+      ourEph.publicKey,
+      sealed.nonce,
+      sealed.ciphertext,
+      nonce,
+    );
+    const rk: KeyRekey = {
+      channel,
+      pubkey: id.publicKey,
+      ephPub: ourEph.publicKey,
+      wrapNonce: sealed.nonce,
+      wrapCt: sealed.ciphertext,
+      nonce,
+      sig: sign(id.secretKey, payload),
+    };
+    return encodeKeyRekey(rk);
   }
 
   private effectiveMode(

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -580,8 +580,12 @@ export class E2eManager {
     // reject a repeat so a captured REKEY can't be re-injected to re-install a
     // superseded key. Checked AFTER signature verify (an unsigned packet can't
     // poison the cache) and BEFORE any state change. There's no ts field on a
-    // REKEY, so this is a nonce-LRU, not a skew window. See REKEY_REPLAY_TTL_MS.
-    const replayKey = `${this.peerKey(userId, networkId, senderHandle)}:${b64(rekey.nonce)}`;
+    // REKEY, so this is a nonce-LRU, not a skew window. Scoped by CHANNEL too: a
+    // REKEY only installs a key for its own channel (the channel is in the signed
+    // payload + the HKDF wrap info), so replay only matters per-channel and the
+    // scope avoids a cross-channel nonce collision dropping a legit REKEY. See
+    // REKEY_REPLAY_TTL_MS.
+    const replayKey = `${this.peerKey(userId, networkId, senderHandle)}:${rekey.channel.toLowerCase()}:${b64(rekey.nonce)}`;
     if (!this.rekeyReplay.observe(replayKey, REKEY_REPLAY_TTL_MS)) return { replies: [] };
 
     const fp = fingerprint(rekey.pubkey);
@@ -1322,7 +1326,13 @@ export class E2eManager {
       }
       try {
         const body = this.buildRekeyBody(userId, networkId, channel, peer.pubkey, freshSk);
-        sends.push({ channel, targetHandle: r.handle, body });
+        // Address the REKEY to the peer's CURRENT pinned handle (peer is looked up
+        // by the stable fingerprint), not the recipient row's snapshot handle —
+        // the row handle can lag a handle change and fail nickForHandle, orphaning
+        // the peer. They're in sync today (a reverify drops stale recipient rows),
+        // but this is the right semantic and survives future drift. Fall back to
+        // the row handle.
+        sends.push({ channel, targetHandle: peer.lastHandle ?? r.handle, body });
       } catch (err) {
         console.warn(`e2e rekey build for ${r.handle} on ${channel}: ${(err as Error).message}`);
       }

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2360,6 +2360,37 @@ export class IrcConnection {
     return `${m.user}@${m.host}`;
   }
 
+  // The reverse of resolvePeerHandle: a peer's keyring handle (ident@host) → their
+  // CURRENT nick on `channel`, via channel membership. Needed because a REKEY is
+  // addressed to a handle but a NOTICE is sent to a nick. Null if they aren't a
+  // visible member (e.g. they left between handshake and rotation).
+  nickForHandle(channel: string, handle: string): string | null {
+    const ch = this.channels.get(channel.toLowerCase());
+    if (!ch) return null;
+    const want = handle.toLowerCase();
+    for (const m of ch.members.values()) {
+      if (m.user && m.host && `${m.user}@${m.host}`.toLowerCase() === want) return m.nick;
+    }
+    return null;
+  }
+
+  // Ship any REKEY CTCPs a lazy rotation queued during the just-completed send
+  // (see E2eManager.getOrGenerateOutgoingKey). Each goes out as a framed NOTICE to
+  // the recipient's current nick on the rotated channel; a recipient who has left
+  // is dropped (they re-handshake on next ciphertext if they return).
+  flushE2eRekeys(): void {
+    if (this.disposed) return;
+    const sends = e2eManager.takePendingRekeySends(this.network.user_id, this.network.id);
+    for (const s of sends) {
+      const nick = this.nickForHandle(s.channel, s.targetHandle);
+      if (!nick) {
+        e2eDbg(() => `rekey drop: no nick for ${s.targetHandle} on ${s.channel}`);
+        continue;
+      }
+      this.sendHandshakeReply(nick, s.body);
+    }
+  }
+
   // Dispatch a `/e2e …` subcommand. All output is ephemeral status routed to the
   // issuing buffer; handshake/accept put real CTCP NOTICEs on the wire. Channels
   // only this phase (#382) — DM contexts are rejected with a hint.
@@ -2543,6 +2574,17 @@ export class IrcConnection {
         info(ok ? `unrevoked ${r.nick} — trust restored` : `${r.nick} isn't revoked`);
         return;
       }
+      case 'rotate': {
+        const chan = needChannel();
+        if (!chan) return;
+        const ok = e2eManager.rotateChannel(uid, nid, chan);
+        info(
+          ok
+            ? `rotating ${chan}'s key — your trusted peers get the fresh key on your next message`
+            : `nothing to rotate on ${chan} (no encrypted session yet)`,
+        );
+        return;
+      }
       case 'decline': {
         const r = chanNickHandle();
         if (!r) return;
@@ -2721,7 +2763,7 @@ export class IrcConnection {
           '/e2e commands:',
           '   on [#chan] [auto|normal|quiet] · off [#chan] · mode <auto|normal|quiet>',
           '   handshake <nick> · accept <nick> · decline <nick>',
-          '   revoke <nick> · unrevoke <nick> · reverify <nick>',
+          '   revoke <nick> · unrevoke <nick> · reverify <nick> · rotate [#chan]',
           '   forget [-all] <nick|handle> · verify <nick> · fingerprint',
           '   status · list [-all]',
           '   autotrust <list | add <scope> <pattern> | remove <pattern>>',

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -69,6 +69,7 @@ describe('outbound encrypt (ircManager.send)', () => {
       publish,
       client: { user: { nick: 'alice' } },
       supportsMultiline: () => false,
+      flushE2eRekeys: () => {},
     } as unknown as IrcConnection;
     vi.spyOn(ircManager, 'getConnection').mockReturnValue(fakeConn);
     e2eManager.setChannelConfig(1, 1, '#enc', true, 'normal');
@@ -105,6 +106,7 @@ describe('outbound encrypt (ircManager.send)', () => {
       publish,
       client: { user: { nick: 'alice' } },
       supportsMultiline: () => false,
+      flushE2eRekeys: () => {},
     } as unknown as IrcConnection;
     vi.spyOn(ircManager, 'getConnection').mockReturnValue(fakeConn);
 
@@ -115,6 +117,42 @@ describe('outbound encrypt (ircManager.send)', () => {
       expect.objectContaining({ type: 'message', target: '#plain', text: 'hello world' }),
     );
     expect(publish.mock.calls[0][0]).not.toHaveProperty('e2e', true);
+    vi.restoreAllMocks();
+  });
+});
+
+describe('rekey distribution ship (flushE2eRekeys)', () => {
+  it('ships a queued REKEY as a framed NOTICE to the nick resolved from its handle', () => {
+    const conn = makeConn();
+    conn.publish = vi.fn<(event: unknown) => void>();
+    const notice = vi.fn<(target: string, text: string) => void>();
+    conn.client.notice = notice;
+    // A JOIN populates membership so the recipient handle resolves to a nick.
+    conn.client.emit('join', { channel: '#x', nick: 'carol', ident: 'c', hostname: 'c.host' });
+    vi.spyOn(e2eManager, 'takePendingRekeySends').mockReturnValue([
+      { channel: '#x', targetHandle: 'c@c.host', body: 'RPEE2E REKEY v=1 c=#x' },
+    ]);
+
+    conn.flushE2eRekeys();
+
+    expect(notice).toHaveBeenCalledTimes(1);
+    expect(notice).toHaveBeenCalledWith('carol', `${CTCP}RPEE2E REKEY v=1 c=#x${CTCP}`);
+    vi.restoreAllMocks();
+  });
+
+  it('drops a REKEY whose recipient is no longer a visible member (no NOTICE)', () => {
+    const conn = makeConn();
+    conn.publish = vi.fn<(event: unknown) => void>();
+    const notice = vi.fn<(target: string, text: string) => void>();
+    conn.client.notice = notice;
+    // No JOIN for the target handle → it can't be resolved to a nick.
+    vi.spyOn(e2eManager, 'takePendingRekeySends').mockReturnValue([
+      { channel: '#gone', targetHandle: 'x@left.host', body: 'RPEE2E REKEY v=1 c=#gone' },
+    ]);
+
+    conn.flushE2eRekeys();
+
+    expect(notice).not.toHaveBeenCalled();
     vi.restoreAllMocks();
   });
 });

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -293,6 +293,11 @@ class IrcManager extends EventEmitter {
           `outbound ${target}: ${outcome.kind}` +
           (outcome.kind === 'encrypted' ? ` (${outcome.lines.length} line(s))` : ''),
       );
+      // A lazy rotation (from /e2e revoke or /e2e rotate) regenerates the key
+      // inside encryptOutgoing and queues a REKEY for each remaining trusted
+      // peer; ship them now, while this channel's membership is current. Safe on
+      // every outcome kind — the queue is empty unless a rotation actually fired.
+      conn.flushE2eRekeys();
       if (outcome.kind === 'error') {
         conn.publishEphemeral({
           type: 'e2e',

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2000,7 +2000,7 @@ const COMMANDS_LINES = [
   '      on [#chan] [auto|normal|quiet]   ·   off [#chan]   ·   mode <auto|normal|quiet>',
   '      handshake <nick>   ·   accept <nick>   ·   decline <nick>',
   '      revoke <nick>   ·   unrevoke <nick>   ·   reverify <nick>   ·   verify <nick>',
-  '      forget [-all] <nick|handle>   ·   fingerprint   ·   status   ·   list [-all]',
+  '      rotate [#chan]   ·   forget [-all] <nick|handle>   ·   fingerprint   ·   status   ·   list [-all]',
   '      autotrust <list | add <scope> <pattern> | remove <pattern>>',
   '  /commands              — this list',
   '  //text                 — send literal "/text" as a message (escape)',


### PR DESCRIPTION
Closes out the deferred rotation work after Phase 1d (#408). This is the one piece of the protocol that was modeled but never lived.

## The gap
`/e2e revoke` already flagged the outgoing key `pendingRotation` and dropped the peer from the recipients table — but the next send silently minted a fresh key **without telling the remaining peers**, orphaning them (they'd hold the old key and stop being able to decrypt you). This wires the reference's **lazy-rotate** model end to end.

## What changed

**Manager (`services/e2e/manager.ts`)**
- `getOrGenerateOutgoingKey` now **distributes** on rotation: when an existing session is flagged `pendingRotation`, it builds a signed `REKEY` CTCP for every remaining recipient (fresh ephemeral X25519 → ECDH against the recipient's static Ed25519 identity via `ed25519PubToX25519`, HKDF under the `RPE2E01-REKEY:` domain, AEAD seal) and queues them per tenant. The rotation flag is captured **before** `setOutgoingSession` clears it.
- `takePendingRekeySends(userId, networkId)` drains the queue for the IRC layer.
- `rotateChannel(userId, networkId, channel)` backs `/e2e rotate` (marks `pendingRotation`; returns false when there's no session yet — distribution is lazy, on the next send, same path `revoke` uses).
- `handleRekey` now **rejects a replayed REKEY** via a dedicated nonce-LRU (`rekeyReplay` cache keyed by `peerKey:b64(nonce)`), checked **after** signature verify and **before** any state change. A REKEY carries a signed nonce but no timestamp, so this is a nonce cache, not a skew window — DoS-only hardening (the key is authentic, so no confidentiality break), beyond the reference, which tracks nothing. Replaces the latent NOTE.
- New exported type `PendingRekeySend { channel, targetHandle, body }` (`body` is UNFRAMED — the IRC layer wraps it in `\x01..\x01`).

**IRC wiring**
- `ircConnection.nickForHandle` (reverse of `resolvePeerHandle`: handle → current nick via channel membership) + `flushE2eRekeys()` ship each queued REKEY as a framed NOTICE to the resolved nick on the rotated channel, dropping anyone who has left (with a debug line).
- `ircManager.send` drains via `conn.flushE2eRekeys()` right after `encryptOutgoing`, while the channel's membership is current.
- `/e2e rotate [#chan]` command (after `unrevoke` in `runE2eCommand`) + help line; client cheatsheet entry.

## Scope
Channels only — DMs and `/e2e export`·`import` stay deferred to later phases. "Per-sender channel keys" was already the model (each member has their own outgoing key; incoming sessions are keyed per-handle), so no change there.

## Testing
- Manager rotation suite: revoke distributes to remaining peers **only** (and cuts off the revoked one); manual `rotate` hits all recipients; no-op when there's no session; a replayed REKEY is rejected (newest key survives).
- IRC ship/drop wiring tests (a JOIN populates membership so `nickForHandle` resolves; a missing member is dropped, no NOTICE).
- Full server suite green (**1147 tests**); typecheck (server + client) + oxlint + oxfmt clean.
- **Live interop:** rotation verified against a real repartee peer on a channel — revoking one peer rotated the key and the remaining peer kept reading seamlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)