### PR TITLE
RPE2E: /e2e export·import — keyring portability (repartee-compatible)

### DIFF
--- a/server/db/e2e.ts
+++ b/server/db/e2e.ts
@@ -805,6 +805,62 @@ export function deleteOutgoingRecipientsForHandle(
   return deleteRecipientsForHandleStmt.run(userId, networkId, handle).changes;
 }
 
+// ─── bulk replace (portable import) ──────────────────────────────────────────
+
+const deleteAllPeersStmt = db.prepare(`DELETE FROM e2e_peers WHERE user_id = ? AND network_id = ?`);
+const deleteAllIncomingStmt = db.prepare(
+  `DELETE FROM e2e_incoming_sessions WHERE user_id = ? AND network_id = ?`,
+);
+const deleteAllOutgoingStmt = db.prepare(
+  `DELETE FROM e2e_outgoing_sessions WHERE user_id = ? AND network_id = ?`,
+);
+const deleteAllChannelConfigStmt = db.prepare(
+  `DELETE FROM e2e_channel_config WHERE user_id = ? AND network_id = ?`,
+);
+const deleteAllAutotrustStmt = db.prepare(
+  `DELETE FROM e2e_autotrust WHERE user_id = ? AND network_id = ?`,
+);
+const deleteAllRecipientsStmt = db.prepare(
+  `DELETE FROM e2e_outgoing_recipients WHERE user_id = ? AND network_id = ?`,
+);
+
+export interface ImportData {
+  identity: IdentityInput;
+  peers: PeerRecord[];
+  incoming: IncomingSession[];
+  outgoing: OutgoingSession[];
+  channels: ChannelConfig[];
+  autotrust: AutotrustRule[];
+}
+
+/** Atomically REPLACE this `(user, network)`'s keyring from a validated import,
+ *  and (re)set the account identity. Mirrors repartee's `replace_all_for_import`:
+ *  a full-snapshot swap in one transaction, so a failure can't leave a
+ *  half-populated keyring. Outgoing recipients (derived rotation state) are
+ *  cleared — they re-record on the next handshake. `now` stamps autotrust rows.
+ *  Caller MUST have validated `data` (byte lengths, enums) before calling. */
+export const replaceKeyringForImport = db.transaction(
+  (userId: number, networkId: number, data: ImportData, now: number) => {
+    saveIdentity(userId, data.identity);
+
+    deleteAllPeersStmt.run(userId, networkId);
+    deleteAllIncomingStmt.run(userId, networkId);
+    deleteAllOutgoingStmt.run(userId, networkId);
+    deleteAllChannelConfigStmt.run(userId, networkId);
+    deleteAllAutotrustStmt.run(userId, networkId);
+    deleteAllRecipientsStmt.run(userId, networkId);
+
+    for (const p of data.peers) upsertPeer(userId, networkId, p);
+    for (const s of data.incoming) setIncomingSession(userId, networkId, s);
+    for (const o of data.outgoing) {
+      setOutgoingSession(userId, networkId, o.channel, o.sk, o.createdAt);
+      if (o.pendingRotation) markOutgoingPendingRotation(userId, networkId, o.channel);
+    }
+    for (const c of data.channels) setChannelConfig(userId, networkId, c);
+    for (const a of data.autotrust) addAutotrust(userId, networkId, a.scope, a.handlePattern, now);
+  },
+);
+
 // ─── at-rest backfill ────────────────────────────────────────────────────────
 
 // (table, secret-column) pairs holding sealed key material. All are rowid

--- a/server/services/e2e/manager.test.ts
+++ b/server/services/e2e/manager.test.ts
@@ -494,3 +494,94 @@ describe('E2eManager key rotation (Phase 2)', () => {
     });
   });
 });
+
+// ─── keyring portability: /e2e export · import ───────────────────────────────
+describe('E2eManager keyring export/import', () => {
+  let dave: number;
+  let daveNet: number;
+
+  beforeAll(() => {
+    dave = createUser('mgr-dave').id;
+    daveNet = createNetwork(dave, {
+      name: 'libera',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    })!.id;
+  });
+
+  const strip = (json: string): Record<string, unknown> => {
+    const o = JSON.parse(json) as Record<string, unknown>;
+    delete o.exportedAt; // export time, not keyring content
+    return o;
+  };
+
+  it('round-trips a full keyring losslessly through the DB (export → import → export)', () => {
+    const ch = '#exp';
+    fullHandshake(ch); // alice gets an identity, a bob peer pin, sessions, a channel config
+    mgr.addAutotrust(alice, aliceNet, 'global', '*@trusted.host');
+
+    const e1 = mgr.exportKeyring(alice, aliceNet);
+    expect(e1.ok).toBe(true);
+    if (!e1.ok) return;
+    // Earlier tests share alice's keyring, so assert relationships, not absolutes.
+    expect(e1.counts.peers).toBeGreaterThanOrEqual(1);
+    expect(e1.counts.autotrust).toBeGreaterThanOrEqual(1);
+
+    // Import into a DIFFERENT account+network — a clean migration target.
+    const imp = mgr.importKeyring(dave, daveNet, e1.json);
+    expect(imp.ok).toBe(true);
+    if (!imp.ok) return;
+    expect(imp.identityChanged).toBe(true); // dave had no identity
+    expect(imp.counts).toEqual(e1.counts); // every row imported
+
+    // Re-exporting the imported keyring reproduces the same document (modulo the
+    // export timestamp) — proves the seal/unseal + replace path is lossless.
+    const e2 = mgr.exportKeyring(dave, daveNet);
+    expect(e2.ok).toBe(true);
+    if (!e2.ok) return;
+    expect(strip(e2.json)).toEqual(strip(e1.json));
+
+    // Dave now holds Alice's identity fingerprint.
+    expect(mgr.getIdentity(dave)?.fingerprintHex).toBe(mgr.getIdentity(alice)?.fingerprintHex);
+  });
+
+  it('reports identityChanged=false when re-importing the same identity', () => {
+    fullHandshake('#exp2');
+    const e = mgr.exportKeyring(alice, aliceNet);
+    expect(e.ok).toBe(true);
+    if (!e.ok) return;
+    mgr.importKeyring(dave, daveNet, e.json); // first import sets dave's identity
+    const again = mgr.importKeyring(dave, daveNet, e.json); // same identity again
+    expect(again.ok).toBe(true);
+    if (!again.ok) return;
+    expect(again.identityChanged).toBe(false);
+  });
+
+  it('rejects malformed input without touching the keyring', () => {
+    fullHandshake('#exp3');
+    const before = mgr.exportKeyring(alice, aliceNet);
+    expect(before.ok).toBe(true);
+    const bad = mgr.importKeyring(alice, aliceNet, '{ not valid json');
+    expect(bad.ok).toBe(false);
+    // Alice's keyring is unchanged (import validated-then-replaced; nothing ran).
+    const after = mgr.exportKeyring(alice, aliceNet);
+    expect(after.ok).toBe(true);
+    if (!before.ok || !after.ok) return;
+    expect(strip(after.json)).toEqual(strip(before.json));
+  });
+
+  it('exports ok:false when there is no identity yet', () => {
+    const fresh = createUser('mgr-noident').id;
+    const freshNet = createNetwork(fresh, {
+      name: 'libera',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'n',
+    })!.id;
+    const e = mgr.exportKeyring(fresh, freshNet);
+    expect(e.ok).toBe(false);
+  });
+});

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -47,6 +47,13 @@ import {
   sigPayloadKeyRsp,
 } from './handshake.js';
 import { generateIdentity, type Identity, identityFromSeed, sign, verify } from './identity.js';
+import {
+  buildPortable,
+  countsOf,
+  parseAndValidate,
+  type PortableCounts,
+  serializePortable,
+} from './portable.js';
 import { encodeChunk, freshMsgid, parseChunk } from './wire.js';
 import * as keyring from '../../db/e2e.js';
 import { RateLimiter } from './rateLimiter.js';
@@ -137,6 +144,17 @@ export interface PendingRekeySend {
   targetHandle: string;
   body: string;
 }
+
+/** Result of `exportKeyring` — the serialized JSON + row counts, or a reason. */
+export type ExportResult =
+  | { ok: true; json: string; counts: PortableCounts }
+  | { ok: false; reason: string };
+
+/** Result of `importKeyring`. `identityChanged` = the imported identity differs
+ *  from the current account identity (now applies to ALL networks). */
+export type ImportResult =
+  | { ok: true; counts: PortableCounts; identityChanged: boolean; fingerprintHex: string }
+  | { ok: false; reason: string };
 
 export type DecryptOutcome =
   | { kind: 'plaintext'; text: string }
@@ -1282,6 +1300,67 @@ export class E2eManager {
     } catch (err) {
       console.warn(`e2e takePendingRekeySends: ${(err as Error).message}`);
       return [];
+    }
+  }
+
+  // ─── keyring portability (export / import) ───────────────────────────────────
+
+  /** Serialize this account's identity + this network's peers/sessions/configs/
+   *  autotrust to a repartee-compatible portable JSON document (`/e2e export`).
+   *  WARNING: contains the identity private key + session keys in plaintext hex —
+   *  the caller must treat it like a password. `ok:false` if there's no identity
+   *  yet. Never throws (singleton). */
+  exportKeyring(userId: number, networkId: number): ExportResult {
+    try {
+      const identity = keyring.loadIdentity(userId);
+      if (!identity) return { ok: false, reason: 'no encryption identity yet — nothing to export' };
+      const doc = buildPortable({
+        identity,
+        peers: keyring.listPeers(userId, networkId),
+        incoming: keyring.listIncomingSessions(userId, networkId),
+        outgoing: keyring.listOutgoingSessions(userId, networkId),
+        channels: keyring.listChannelConfigs(userId, networkId),
+        autotrust: keyring.listAutotrust(userId, networkId),
+        exportedAt: this.nowUnix(),
+      });
+      return { ok: true, json: serializePortable(doc), counts: countsOf(doc) };
+    } catch (err) {
+      console.warn(`e2e export: ${(err as Error).message}`);
+      return { ok: false, reason: (err as Error).message };
+    }
+  }
+
+  /** Validate a portable JSON document and, if it's well-formed, REPLACE this
+   *  network's keyring + (re)set the account identity (`/e2e import`). Validation
+   *  is complete before any write, so a malformed import changes nothing.
+   *  `identityChanged` flags when the imported identity differs from the current
+   *  one (it becomes the account identity on ALL networks — the caller should
+   *  warn). Never throws (singleton). */
+  importKeyring(userId: number, networkId: number, json: string): ImportResult {
+    try {
+      const data = parseAndValidate(json);
+      const current = keyring.loadIdentity(userId);
+      const identityChanged =
+        !current || !equalBytes(current.fingerprint, data.identity.fingerprint);
+      keyring.replaceKeyringForImport(userId, networkId, data, this.nowUnix());
+      // The cached identity may now be stale (import can change it) — drop it so
+      // the next load re-reads the imported key.
+      this.identities.delete(userId);
+      return {
+        ok: true,
+        counts: {
+          peers: data.peers.length,
+          incoming: data.incoming.length,
+          outgoing: data.outgoing.length,
+          channels: data.channels.length,
+          autotrust: data.autotrust.length,
+        },
+        identityChanged,
+        fingerprintHex: fingerprintHex(data.identity.fingerprint),
+      };
+    } catch (err) {
+      console.warn(`e2e import: ${(err as Error).message}`);
+      return { ok: false, reason: (err as Error).message };
     }
   }
 

--- a/server/services/e2e/portable.test.ts
+++ b/server/services/e2e/portable.test.ts
@@ -8,6 +8,7 @@ import {
   countsOf,
   EXPORT_VERSION,
   type ExportInput,
+  MAX_IMPORT_BYTES,
   parseAndValidate,
   serializePortable,
 } from './portable.js';
@@ -134,6 +135,24 @@ describe('portable keyring export/import', () => {
   it('rejects malformed JSON and non-object documents', () => {
     expect(() => parseAndValidate('{not json')).toThrow(/parse json/);
     expect(() => parseAndValidate('42')).toThrow(/not a JSON object/);
+  });
+
+  it('rejects a non-string (non-null) nullable field instead of coercing to null', () => {
+    const doc = buildPortable(sampleInput()) as unknown as {
+      peers: Array<Record<string, unknown>>;
+    };
+    doc.peers[0].lastHandle = 123; // a number, not a string|null
+    expect(() => parseAndValidate(JSON.stringify(doc))).toThrow(/lastHandle.*string or null/);
+  });
+
+  it('rejects a non-integer numeric field instead of truncating it', () => {
+    const doc = buildPortable(sampleInput());
+    doc.identity.createdAt = 1.5;
+    expect(() => parseAndValidate(serializePortable(doc))).toThrow(/createdAt.*integer/);
+  });
+
+  it('rejects an oversized payload before parsing', () => {
+    expect(() => parseAndValidate('x'.repeat(MAX_IMPORT_BYTES + 1))).toThrow(/too large/);
   });
 
   it('rejects a non-array collection field', () => {

--- a/server/services/e2e/portable.test.ts
+++ b/server/services/e2e/portable.test.ts
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildPortable,
+  countsOf,
+  EXPORT_VERSION,
+  type ExportInput,
+  parseAndValidate,
+  serializePortable,
+} from './portable.js';
+
+const bytes = (len: number, fill: number): Uint8Array => new Uint8Array(len).fill(fill);
+
+// A representative keyring covering every row type.
+function sampleInput(): ExportInput {
+  return {
+    identity: {
+      pubkey: bytes(32, 1),
+      privkey: bytes(32, 2),
+      fingerprint: bytes(16, 3),
+      createdAt: 1_700_000_000,
+    },
+    peers: [
+      {
+        fingerprint: bytes(16, 4),
+        pubkey: bytes(32, 5),
+        lastHandle: '~bob@b.host',
+        lastNick: 'bob',
+        firstSeen: 1_700_000_100,
+        lastSeen: 1_700_000_200,
+        globalStatus: 'trusted',
+      },
+      {
+        fingerprint: bytes(16, 6),
+        pubkey: bytes(32, 7),
+        lastHandle: null,
+        lastNick: null,
+        firstSeen: 1_700_000_300,
+        lastSeen: 1_700_000_400,
+        globalStatus: 'revoked',
+      },
+    ],
+    incoming: [
+      {
+        handle: '~bob@b.host',
+        channel: '#x',
+        fingerprint: bytes(16, 4),
+        sk: bytes(32, 8),
+        status: 'trusted',
+        createdAt: 1_700_000_500,
+      },
+    ],
+    outgoing: [
+      { channel: '#x', sk: bytes(32, 9), createdAt: 1_700_000_600, pendingRotation: true },
+    ],
+    channels: [{ channel: '#x', enabled: true, mode: 'auto-accept' }],
+    autotrust: [{ scope: 'global', handlePattern: '*@trusted.host' }],
+    exportedAt: 1_700_000_700,
+  };
+}
+
+describe('portable keyring export/import', () => {
+  it('round-trips build → serialize → parse → validate losslessly', () => {
+    const input = sampleInput();
+    const doc = buildPortable(input);
+    expect(doc.version).toBe(EXPORT_VERSION);
+    expect(doc.exportedAt).toBe(input.exportedAt);
+
+    const v = parseAndValidate(serializePortable(doc));
+
+    // Identity bytes survive the hex round-trip.
+    expect(v.identity.pubkey).toEqual(input.identity.pubkey);
+    expect(v.identity.privkey).toEqual(input.identity.privkey);
+    expect(v.identity.fingerprint).toEqual(input.identity.fingerprint);
+    expect(v.identity.createdAt).toBe(input.identity.createdAt);
+
+    expect(v.peers).toHaveLength(2);
+    expect(v.peers[0]).toEqual(input.peers[0]);
+    expect(v.peers[1].globalStatus).toBe('revoked');
+    expect(v.peers[1].lastHandle).toBeNull();
+
+    expect(v.incoming[0]).toEqual(input.incoming[0]);
+    expect(v.outgoing[0]).toEqual(input.outgoing[0]);
+    expect(v.outgoing[0].pendingRotation).toBe(true);
+    expect(v.channels[0]).toEqual(input.channels[0]);
+    expect(v.autotrust[0]).toEqual(input.autotrust[0]);
+  });
+
+  it('emits lowercase-hex binary fields (repartee-compatible wire format)', () => {
+    const doc = buildPortable(sampleInput());
+    expect(doc.identity.pubkey).toBe('01'.repeat(32));
+    expect(doc.identity.fingerprint).toBe('03'.repeat(16));
+    expect(doc.peers[0].fingerprint).toBe('04'.repeat(16));
+    expect(doc.incomingSessions[0].sk).toBe('08'.repeat(32));
+    expect(countsOf(doc)).toEqual({
+      peers: 2,
+      incoming: 1,
+      outgoing: 1,
+      channels: 1,
+      autotrust: 1,
+    });
+  });
+
+  it('rejects an unsupported version before decoding anything', () => {
+    const doc = buildPortable(sampleInput());
+    const bad = serializePortable({ ...doc, version: 99 });
+    expect(() => parseAndValidate(bad)).toThrow(/unsupported export version/);
+  });
+
+  it('rejects a wrong-length hex field', () => {
+    const doc = buildPortable(sampleInput());
+    doc.identity.pubkey = 'aabb'; // 2 bytes, not 32
+    expect(() => parseAndValidate(serializePortable(doc))).toThrow(/identity\.pubkey.*expected 32/);
+  });
+
+  it('rejects non-hex characters', () => {
+    const doc = buildPortable(sampleInput());
+    doc.incomingSessions[0].sk = 'z'.repeat(64);
+    expect(() => parseAndValidate(serializePortable(doc))).toThrow(/invalid hex/);
+  });
+
+  it('coerces an unknown enum to the safe default (lenient, like the reference)', () => {
+    const doc = buildPortable(sampleInput());
+    doc.peers[0].globalStatus = 'bogus';
+    doc.channels[0].mode = 'bogus';
+    const v = parseAndValidate(serializePortable(doc));
+    expect(v.peers[0].globalStatus).toBe('pending'); // parseTrustStatus default
+    expect(v.channels[0].mode).toBe('normal'); // parseChannelMode default
+  });
+
+  it('rejects malformed JSON and non-object documents', () => {
+    expect(() => parseAndValidate('{not json')).toThrow(/parse json/);
+    expect(() => parseAndValidate('42')).toThrow(/not a JSON object/);
+  });
+
+  it('rejects a non-array collection field', () => {
+    const doc = buildPortable(sampleInput()) as unknown as Record<string, unknown>;
+    doc.peers = 'nope';
+    expect(() => parseAndValidate(JSON.stringify(doc))).toThrow(/peers must be an array/);
+  });
+});

--- a/server/services/e2e/portable.ts
+++ b/server/services/e2e/portable.ts
@@ -46,6 +46,11 @@ function parseMode(s: string): ChannelMode {
 /** Current schema version. Bump when a field is added or semantics change. */
 export const EXPORT_VERSION = 1;
 
+/** Hard ceiling on an import payload (bytes), enforced before parsing. Generous
+ *  vs a realistic keyring (≈ a few hundred KB even with hundreds of peers) — an
+ *  abuse backstop against an event-loop-blocking parse, not a usage limit. */
+export const MAX_IMPORT_BYTES = 4 * 1024 * 1024;
+
 // ─── on-disk document shapes (JSON, hex-encoded binary) ──────────────────────
 
 export interface PortableIdentity {
@@ -195,6 +200,12 @@ export function countsOf(doc: Portable): PortableCounts {
  *  strings) before returning decoded bytes — so a malformed import is rejected
  *  before the keyring is touched. Every failure is an `E2eError('keyring')`. */
 export function parseAndValidate(json: string): ValidatedKeyring {
+  // Bound the input BEFORE JSON.parse so a pathological payload can't block the
+  // event loop / spike memory. A real keyring is well under this (hundreds of
+  // peers ≈ a few hundred KB); the cap is an abuse backstop, not a usage limit.
+  if (json.length > MAX_IMPORT_BYTES) {
+    throw new E2eError('keyring', `import too large (max ${MAX_IMPORT_BYTES} bytes)`);
+  }
   let doc: Portable;
   try {
     doc = JSON.parse(json) as Portable;
@@ -233,8 +244,8 @@ export function parseAndValidate(json: string): ValidatedKeyring {
   const peers: PeerRecord[] = doc.peers.map((p, i) => ({
     fingerprint: parseHex(`peers[${i}].fingerprint`, p.fingerprint, 16),
     pubkey: parseHex(`peers[${i}].pubkey`, p.pubkey, 32),
-    lastHandle: nullableStr(p.lastHandle),
-    lastNick: nullableStr(p.lastNick),
+    lastHandle: nullableStr(`peers[${i}].lastHandle`, p.lastHandle),
+    lastNick: nullableStr(`peers[${i}].lastNick`, p.lastNick),
     firstSeen: intField(`peers[${i}].firstSeen`, p.firstSeen),
     lastSeen: intField(`peers[${i}].lastSeen`, p.lastSeen),
     globalStatus: parseStatus(strField(`peers[${i}].globalStatus`, p.globalStatus)),
@@ -292,13 +303,21 @@ function strField(field: string, s: unknown): string {
   return s;
 }
 
-function nullableStr(s: unknown): string | null {
-  return typeof s === 'string' ? s : null;
+/** A `string | null` field: null/absent → null, a string passes through, but any
+ *  other type (number/object/bool) is REJECTED rather than silently coerced to
+ *  null — a malformed export shouldn't import and quietly lose data. */
+function nullableStr(field: string, s: unknown): string | null {
+  if (s === null || s === undefined) return null;
+  if (typeof s === 'string') return s;
+  throw new E2eError('keyring', `${field}: expected a string or null`);
 }
 
+/** A strictly-integer field. Reject non-integers rather than `Math.trunc`-ing
+ *  them — the schema round-trips exact values, so a fractional timestamp is
+ *  malformed input, not something to silently rewrite. */
 function intField(field: string, n: unknown): number {
-  if (typeof n !== 'number' || !Number.isFinite(n)) {
-    throw new E2eError('keyring', `${field}: expected a number`);
+  if (typeof n !== 'number' || !Number.isInteger(n)) {
+    throw new E2eError('keyring', `${field}: expected an integer`);
   }
-  return Math.trunc(n);
+  return n;
 }

--- a/server/services/e2e/portable.ts
+++ b/server/services/e2e/portable.ts
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Portable JSON export / import for the RPE2E keyring — a byte-compatible port of
+// repartee's e2e/portable.rs (schema `version: 1`). Binary fields are lowercase
+// hex so the document diffs cleanly, can be hand-inspected, and moves losslessly
+// between Lurker and repartee.
+//
+// WARNING: the identity private key and every session key are written in
+// PLAINTEXT hex. Lurker stores them sealed at rest (secretCrypto), but an export
+// necessarily unseals them — it's a backup / migration escape hatch and must be
+// treated like a password (never redistributed). A future revision may add
+// passphrase-wrapping; v1 keeps the format transparent on purpose, matching the
+// reference.
+//
+// SCOPE: Lurker's keyring is per-`(user, network)` for everything EXCEPT the
+// identity, which is per-ACCOUNT (`user_id`). So an export is "this account's
+// identity + this network's peers / sessions / channel configs / autotrust", and
+// an import REPLACES that network's keyring and (re)sets the account identity.
+// (repartee has no network dimension; a single-network round-trip is lossless.)
+
+import type {
+  ChannelConfig,
+  ChannelMode,
+  IdentityRow,
+  IncomingSession,
+  OutgoingSession,
+  PeerRecord,
+  TrustStatus,
+} from '../../db/e2e.js';
+import { E2eError } from './errors.js';
+
+// Lenient enum parsing (unknown → safe default; `auto` aliases `auto-accept`),
+// mirroring db/e2e.ts. Inlined so this serialization module has NO runtime
+// dependency on the storage layer (only erased type-imports above) — keeping it
+// pure + unit-testable without opening a database.
+function parseStatus(s: string): TrustStatus {
+  return s === 'trusted' ? 'trusted' : s === 'revoked' ? 'revoked' : 'pending';
+}
+function parseMode(s: string): ChannelMode {
+  if (s === 'auto-accept' || s === 'auto') return 'auto-accept';
+  if (s === 'quiet') return 'quiet';
+  return 'normal';
+}
+
+/** Current schema version. Bump when a field is added or semantics change. */
+export const EXPORT_VERSION = 1;
+
+// ─── on-disk document shapes (JSON, hex-encoded binary) ──────────────────────
+
+export interface PortableIdentity {
+  pubkey: string;
+  privkey: string;
+  fingerprint: string;
+  createdAt: number;
+}
+export interface PortablePeer {
+  fingerprint: string;
+  pubkey: string;
+  lastHandle: string | null;
+  lastNick: string | null;
+  firstSeen: number;
+  lastSeen: number;
+  globalStatus: string;
+}
+export interface PortableIncoming {
+  handle: string;
+  channel: string;
+  fingerprint: string;
+  sk: string;
+  status: string;
+  createdAt: number;
+}
+export interface PortableOutgoing {
+  channel: string;
+  sk: string;
+  createdAt: number;
+  pendingRotation: boolean;
+}
+export interface PortableChannel {
+  channel: string;
+  enabled: boolean;
+  mode: string;
+}
+export interface PortableAutotrust {
+  scope: string;
+  handlePattern: string;
+}
+export interface Portable {
+  version: number;
+  exportedAt: number;
+  identity: PortableIdentity;
+  peers: PortablePeer[];
+  incomingSessions: PortableIncoming[];
+  outgoingSessions: PortableOutgoing[];
+  channels: PortableChannel[];
+  autotrust: PortableAutotrust[];
+}
+
+// ─── decoded (validated) form — raw bytes + typed enums ──────────────────────
+
+export interface ValidatedKeyring {
+  identity: IdentityRow;
+  peers: PeerRecord[];
+  incoming: IncomingSession[];
+  outgoing: OutgoingSession[];
+  channels: ChannelConfig[];
+  autotrust: PortableAutotrust[];
+}
+
+export interface ExportInput {
+  identity: IdentityRow;
+  peers: PeerRecord[];
+  incoming: IncomingSession[];
+  outgoing: OutgoingSession[];
+  channels: ChannelConfig[];
+  autotrust: PortableAutotrust[];
+  exportedAt: number;
+}
+
+export interface PortableCounts {
+  peers: number;
+  incoming: number;
+  outgoing: number;
+  channels: number;
+  autotrust: number;
+}
+
+const hex = (u8: Uint8Array): string => Buffer.from(u8).toString('hex');
+
+// ─── build (export) ──────────────────────────────────────────────────────────
+
+/** Serialize already-read keyring rows into the portable document. Pure (no DB,
+ *  no clock) — the caller supplies the unsealed rows and `exportedAt`. */
+export function buildPortable(input: ExportInput): Portable {
+  return {
+    version: EXPORT_VERSION,
+    exportedAt: input.exportedAt,
+    identity: {
+      pubkey: hex(input.identity.pubkey),
+      privkey: hex(input.identity.privkey),
+      fingerprint: hex(input.identity.fingerprint),
+      createdAt: input.identity.createdAt,
+    },
+    peers: input.peers.map((p) => ({
+      fingerprint: hex(p.fingerprint),
+      pubkey: hex(p.pubkey),
+      lastHandle: p.lastHandle,
+      lastNick: p.lastNick,
+      firstSeen: p.firstSeen,
+      lastSeen: p.lastSeen,
+      globalStatus: p.globalStatus,
+    })),
+    incomingSessions: input.incoming.map((s) => ({
+      handle: s.handle,
+      channel: s.channel,
+      fingerprint: hex(s.fingerprint),
+      sk: hex(s.sk),
+      status: s.status,
+      createdAt: s.createdAt,
+    })),
+    outgoingSessions: input.outgoing.map((o) => ({
+      channel: o.channel,
+      sk: hex(o.sk),
+      createdAt: o.createdAt,
+      pendingRotation: o.pendingRotation,
+    })),
+    channels: input.channels.map((c) => ({
+      channel: c.channel,
+      enabled: c.enabled,
+      mode: c.mode,
+    })),
+    autotrust: input.autotrust.map((a) => ({ scope: a.scope, handlePattern: a.handlePattern })),
+  };
+}
+
+/** Pretty-print a portable document (2-space indent, like the reference). */
+export function serializePortable(doc: Portable): string {
+  return JSON.stringify(doc, null, 2);
+}
+
+export function countsOf(doc: Portable): PortableCounts {
+  return {
+    peers: doc.peers.length,
+    incoming: doc.incomingSessions.length,
+    outgoing: doc.outgoingSessions.length,
+    channels: doc.channels.length,
+    autotrust: doc.autotrust.length,
+  };
+}
+
+// ─── parse + validate (import) ───────────────────────────────────────────────
+
+/** Parse JSON and validate the ENTIRE structure (version, hex lengths, enum
+ *  strings) before returning decoded bytes — so a malformed import is rejected
+ *  before the keyring is touched. Every failure is an `E2eError('keyring')`. */
+export function parseAndValidate(json: string): ValidatedKeyring {
+  let doc: Portable;
+  try {
+    doc = JSON.parse(json) as Portable;
+  } catch (err) {
+    throw new E2eError('keyring', `parse json: ${(err as Error).message}`);
+  }
+  if (typeof doc !== 'object' || doc === null) {
+    throw new E2eError('keyring', 'import: not a JSON object');
+  }
+  if (doc.version !== EXPORT_VERSION) {
+    throw new E2eError(
+      'keyring',
+      `unsupported export version: got ${doc.version}, expected ${EXPORT_VERSION}`,
+    );
+  }
+  if (typeof doc.identity !== 'object' || doc.identity === null) {
+    throw new E2eError('keyring', 'import: missing identity');
+  }
+  for (const [field, arr] of [
+    ['peers', doc.peers],
+    ['incomingSessions', doc.incomingSessions],
+    ['outgoingSessions', doc.outgoingSessions],
+    ['channels', doc.channels],
+    ['autotrust', doc.autotrust],
+  ] as const) {
+    if (!Array.isArray(arr)) throw new E2eError('keyring', `import: ${field} must be an array`);
+  }
+
+  const identity: IdentityRow = {
+    pubkey: parseHex('identity.pubkey', doc.identity.pubkey, 32),
+    privkey: parseHex('identity.privkey', doc.identity.privkey, 32),
+    fingerprint: parseHex('identity.fingerprint', doc.identity.fingerprint, 16),
+    createdAt: intField('identity.createdAt', doc.identity.createdAt),
+  };
+
+  const peers: PeerRecord[] = doc.peers.map((p, i) => ({
+    fingerprint: parseHex(`peers[${i}].fingerprint`, p.fingerprint, 16),
+    pubkey: parseHex(`peers[${i}].pubkey`, p.pubkey, 32),
+    lastHandle: nullableStr(p.lastHandle),
+    lastNick: nullableStr(p.lastNick),
+    firstSeen: intField(`peers[${i}].firstSeen`, p.firstSeen),
+    lastSeen: intField(`peers[${i}].lastSeen`, p.lastSeen),
+    globalStatus: parseStatus(strField(`peers[${i}].globalStatus`, p.globalStatus)),
+  }));
+
+  const incoming: IncomingSession[] = doc.incomingSessions.map((s, i) => ({
+    handle: strField(`incomingSessions[${i}].handle`, s.handle),
+    channel: strField(`incomingSessions[${i}].channel`, s.channel),
+    fingerprint: parseHex(`incomingSessions[${i}].fingerprint`, s.fingerprint, 16),
+    sk: parseHex(`incomingSessions[${i}].sk`, s.sk, 32),
+    status: parseStatus(strField(`incomingSessions[${i}].status`, s.status)),
+    createdAt: intField(`incomingSessions[${i}].createdAt`, s.createdAt),
+  }));
+
+  const outgoing: OutgoingSession[] = doc.outgoingSessions.map((o, i) => ({
+    channel: strField(`outgoingSessions[${i}].channel`, o.channel),
+    sk: parseHex(`outgoingSessions[${i}].sk`, o.sk, 32),
+    createdAt: intField(`outgoingSessions[${i}].createdAt`, o.createdAt),
+    pendingRotation: o.pendingRotation === true,
+  }));
+
+  const channels: ChannelConfig[] = doc.channels.map((c, i) => ({
+    channel: strField(`channels[${i}].channel`, c.channel),
+    enabled: c.enabled === true,
+    mode: parseMode(strField(`channels[${i}].mode`, c.mode)),
+  }));
+
+  const autotrust: PortableAutotrust[] = doc.autotrust.map((a, i) => ({
+    scope: strField(`autotrust[${i}].scope`, a.scope),
+    handlePattern: strField(`autotrust[${i}].handlePattern`, a.handlePattern),
+  }));
+
+  return { identity, peers, incoming, outgoing, channels, autotrust };
+}
+
+// ─── field helpers ───────────────────────────────────────────────────────────
+
+/** Strict hex → exactly `len` bytes. Rejects non-hex chars and wrong length
+ *  (Buffer.from is lenient, so validate the string shape first). */
+function parseHex(field: string, s: unknown, len: number): Uint8Array {
+  if (typeof s !== 'string' || !/^[0-9a-fA-F]*$/.test(s)) {
+    throw new E2eError('keyring', `${field}: invalid hex`);
+  }
+  if (s.length !== len * 2) {
+    throw new E2eError(
+      'keyring',
+      `${field}: expected ${len} bytes (hex length ${len * 2}), got ${s.length}`,
+    );
+  }
+  return new Uint8Array(Buffer.from(s, 'hex'));
+}
+
+function strField(field: string, s: unknown): string {
+  if (typeof s !== 'string') throw new E2eError('keyring', `${field}: expected a string`);
+  return s;
+}
+
+function nullableStr(s: unknown): string | null {
+  return typeof s === 'string' ? s : null;
+}
+
+function intField(field: string, n: unknown): number {
+  if (typeof n !== 'number' || !Number.isFinite(n)) {
+    throw new E2eError('keyring', `${field}: expected a number`);
+  }
+  return Math.trunc(n);
+}

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2767,6 +2767,7 @@ export class IrcConnection {
           '   forget [-all] <nick|handle> · verify <nick> · fingerprint',
           '   status · list [-all]',
           '   autotrust <list | add <scope> <pattern> | remove <pattern>>',
+          '   export (download keyring) · import (upload + replace keyring)',
         ]) {
           info(line);
         }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -12,6 +12,7 @@ import cookie from 'cookie';
 import cookieParser from 'cookie-parser';
 import ircManager from './ircManager.js';
 import { e2eManager } from './e2e/manager.js';
+import { MAX_IMPORT_BYTES } from './e2e/portable.js';
 import settingsService from './settingsService.js';
 import highlightRulesService from './highlightRulesService.js';
 import draftsService from './draftsService.js';
@@ -1525,6 +1526,12 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
             ok: false,
             reason: 'run /e2e import from a network buffer',
           });
+          break;
+        }
+        // Reject an oversized payload at the boundary, before the parse/replace
+        // work (defence-in-depth; parseAndValidate guards the same limit too).
+        if (json.length > MAX_IMPORT_BYTES) {
+          send(ws, { kind: 'e2eImport', ok: false, reason: 'import file too large' });
           break;
         }
         send(ws, {

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -11,6 +11,7 @@ import { WebSocketServer } from 'ws';
 import cookie from 'cookie';
 import cookieParser from 'cookie-parser';
 import ircManager from './ircManager.js';
+import { e2eManager } from './e2e/manager.js';
 import settingsService from './settingsService.js';
 import highlightRulesService from './highlightRulesService.js';
 import draftsService from './draftsService.js';
@@ -1493,6 +1494,44 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           } as unknown as MessageEvent;
           fanOut(userId, { ...decorateMessage(userId, evt), kind: 'irc' });
         }
+        break;
+      }
+      case 'e2e-export': {
+        // Keyring portability (#382 follow-up). DB-backed via e2eManager — no live
+        // connection needed (unlike `case 'e2e'`). Reply to THIS socket only: the
+        // requesting tab turns the JSON into a file download, so a broadcast would
+        // make every open tab download. networkId ownership is enforced at the
+        // boundary above; reject the system-buffer (null/0) case here.
+        const networkId = msg.networkId == null ? NaN : Number(msg.networkId);
+        if (!Number.isFinite(networkId) || networkId <= 0) {
+          send(ws, {
+            kind: 'e2eExport',
+            ok: false,
+            reason: 'run /e2e export from a network buffer',
+          });
+          break;
+        }
+        send(ws, { kind: 'e2eExport', networkId, ...e2eManager.exportKeyring(userId, networkId) });
+        break;
+      }
+      case 'e2e-import': {
+        // Replace this network's keyring from an uploaded export. Validated +
+        // applied atomically by importKeyring; reply to the requesting socket.
+        const networkId = msg.networkId == null ? NaN : Number(msg.networkId);
+        const json = typeof msg.json === 'string' ? msg.json : '';
+        if (!Number.isFinite(networkId) || networkId <= 0) {
+          send(ws, {
+            kind: 'e2eImport',
+            ok: false,
+            reason: 'run /e2e import from a network buffer',
+          });
+          break;
+        }
+        send(ws, {
+          kind: 'e2eImport',
+          networkId,
+          ...e2eManager.importKeyring(userId, networkId, json),
+        });
         break;
       }
       case 'join':

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1700,6 +1700,16 @@ function onE2eImportFile(e: Event): void {
   const networkId = e2eImportNetworkId.value;
   e2eImportNetworkId.value = null;
   if (!file || networkId == null) return;
+  // Reject an oversized file before reading it (the server enforces the same cap;
+  // this just fails fast without freezing the tab on a huge/wrong file).
+  if (file.size > 4 * 1024 * 1024) {
+    toasts.push({
+      kind: 'error',
+      title: 'E2E import failed',
+      body: 'that file is too large to be a keyring export',
+    });
+    return;
+  }
   const reader = new FileReader();
   reader.onload = () => {
     const json = String(reader.result ?? '');

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -57,6 +57,13 @@
       class="file-hidden"
       @change="onFileSelected"
     />
+    <input
+      ref="e2eImportInputEl"
+      type="file"
+      accept=".json,application/json"
+      class="file-hidden"
+      @change="onE2eImportFile"
+    />
     <!-- The nick / emoji suggestion strips and the mIRC colour picker render
          inside StatusBar (they overlay it visually) — see useComposerOverlay
          for the cross-component state contract. Only the desktop @-popup
@@ -239,6 +246,8 @@ function combinedHighlights(
 const inputEl = ref<HTMLTextAreaElement | null>(null);
 const formEl = ref<HTMLElement | null>(null);
 const fileInputEl = ref<HTMLInputElement | null>(null);
+const e2eImportInputEl = ref<HTMLInputElement | null>(null);
+const e2eImportNetworkId = ref<number | null>(null);
 const dragOver = ref(false);
 const pickerOpen = ref(false);
 const pickerQuery = ref('');
@@ -1681,6 +1690,33 @@ function onFileSelected(e: Event): void {
   uploads.upload(file, file.name).catch(() => {});
 }
 
+// `/e2e import` flow: read the chosen export file, confirm (it's destructive and
+// can change the account identity), then ship the JSON for the cell to validate
+// and replace the keyring. The networkId is carried from the command invocation.
+function onE2eImportFile(e: Event): void {
+  const input = e.target as HTMLInputElement;
+  const file = input.files?.[0];
+  input.value = '';
+  const networkId = e2eImportNetworkId.value;
+  e2eImportNetworkId.value = null;
+  if (!file || networkId == null) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    const json = String(reader.result ?? '');
+    const ok = window.confirm(
+      'Import E2E keyring?\n\n' +
+        'This REPLACES this network’s encryption keyring (peers, sessions, settings) ' +
+        'and resets your account identity on ALL networks. It cannot be undone.',
+    );
+    if (!ok) return;
+    sendOrToast({ type: 'e2e-import', networkId, json }, 'e2e import');
+  };
+  reader.onerror = () => {
+    toasts.push({ kind: 'error', title: 'E2E import failed', body: 'could not read the file' });
+  };
+  reader.readAsText(file);
+}
+
 function onDragOver(e: DragEvent): void {
   if (!sendable.value) return;
   if (!Array.from(e.dataTransfer?.types || []).includes('Files')) return;
@@ -2001,7 +2037,7 @@ const COMMANDS_LINES = [
   '      handshake <nick>   ·   accept <nick>   ·   decline <nick>',
   '      revoke <nick>   ·   unrevoke <nick>   ·   reverify <nick>   ·   verify <nick>',
   '      rotate [#chan]   ·   forget [-all] <nick|handle>   ·   fingerprint   ·   status   ·   list [-all]',
-  '      autotrust <list | add <scope> <pattern> | remove <pattern>>',
+  '      autotrust <list | add <scope> <pattern> | remove <pattern>>   ·   export   ·   import',
   '  /commands              — this list',
   '  //text                 — send literal "/text" as a message (escape)',
 ];
@@ -2487,11 +2523,24 @@ function handleCommand(line: string, networkId: number | null, target: string): 
   }
 
   switch (verb) {
-    case 'e2e':
-      // RPE2E (#382). Thin pass-through: the server parses the subcommand and
-      // publishes its status/results back into this buffer. We forward the raw
-      // arg line plus the issuing buffer so the server can default the channel.
+    case 'e2e': {
+      // RPE2E (#382). `export`/`import` move keyring material across the
+      // client↔cell boundary, so they're handled here rather than via the
+      // server's buffer-oriented runE2eCommand: export downloads a file (never
+      // rendered — it holds the private key), import opens a file picker. Every
+      // other subcommand is a thin pass-through; the server parses it and
+      // publishes status back into this buffer (defaulting the channel).
+      const sub = (rest[0] || '').toLowerCase();
+      if (sub === 'export') {
+        return sendOrToast({ type: 'e2e-export', networkId }, line);
+      }
+      if (sub === 'import') {
+        e2eImportNetworkId.value = networkId;
+        e2eImportInputEl.value?.click();
+        return true;
+      }
       return sendOrToast({ type: 'e2e', networkId, target, args: argLine }, line);
+    }
     case 'me':
       return ackedSend({ type: 'action', networkId, target, text: argLine }, argLine);
     case 'msg':

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -22,6 +22,7 @@ import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useDataExportStore } from '../stores/dataExport.js';
 import { useToastsStore } from '../stores/toasts.js';
+import { downloadTextFile } from '../utils/download.js';
 import { notifyForEvent, playSound } from './useHighlightNotifier.js';
 
 export interface AckResult {
@@ -529,6 +530,47 @@ function handleMessage(raw: string): void {
   if (payload.kind === 'search-result') {
     const search = useSearchStore();
     search.applyResult(payload);
+    return;
+  }
+  if (payload.kind === 'e2eExport') {
+    // Response to `/e2e export` — download the JSON as a file rather than render
+    // it (it carries the private key). Reaches only the requesting tab.
+    if (payload.ok) {
+      const stamp = new Date().toISOString().slice(0, 10);
+      downloadTextFile(`lurker-e2e-keyring-${stamp}.json`, payload.json as string);
+      const c = (payload.counts as Record<string, number>) || {};
+      useToastsStore().push({
+        kind: 'info',
+        title: 'E2E keyring exported',
+        body: `Saved ${c.peers ?? 0} peer(s), ${c.incoming ?? 0} session(s). Keep this file private — it contains your private key.`,
+      });
+    } else {
+      useToastsStore().push({
+        kind: 'error',
+        title: 'E2E export failed',
+        body: String(payload.reason ?? 'unknown error'),
+      });
+    }
+    return;
+  }
+  if (payload.kind === 'e2eImport') {
+    if (payload.ok) {
+      const c = (payload.counts as Record<string, number>) || {};
+      const idNote = payload.identityChanged
+        ? ' Your account identity changed — peers will need to reverify you.'
+        : '';
+      useToastsStore().push({
+        kind: payload.identityChanged ? 'warn' : 'info',
+        title: 'E2E keyring imported',
+        body: `Replaced with ${c.peers ?? 0} peer(s), ${c.incoming ?? 0} session(s).${idNote}`,
+      });
+    } else {
+      useToastsStore().push({
+        kind: 'error',
+        title: 'E2E import failed',
+        body: String(payload.reason ?? 'unknown error'),
+      });
+    }
     return;
   }
   if (payload.kind === 'pins-changed') {

--- a/vue_client/src/utils/download.ts
+++ b/vue_client/src/utils/download.ts
@@ -11,6 +11,10 @@ export function downloadTextFile(filename: string, text: string, mime = 'applica
   a.download = filename;
   document.body.appendChild(a);
   a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
+  // Defer cleanup to the next tick: revoking the object URL synchronously after
+  // click() can cancel an in-flight download in some browsers.
+  setTimeout(() => {
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, 0);
 }

--- a/vue_client/src/utils/download.ts
+++ b/vue_client/src/utils/download.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Trigger a browser "save as" for in-memory text (no server round-trip / HTTP
+// route). Used by the E2E keyring export so the private-key material lands in a
+// file the user controls rather than being rendered into the message view.
+export function downloadTextFile(filename: string, text: string, mime = 'application/json'): void {
+  const url = URL.createObjectURL(new Blob([text], { type: mime }));
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Adds keyring export/import so a user can back up or migrate their E2E identity + trust state — and, because the format is a byte-compatible port of repartee's `e2e/portable.rs` (schema `version: 1`, lowercase-hex fields), move a keyring losslessly between Lurker and repartee. Follows Phase 2 (#409).

## Why
The keyring (identity keypair + peer pins + sessions + channel configs + autotrust) only lived in the cell DB. A DB reset / DR rebuild regenerated the identity → every peer saw a fingerprint change (exactly the interop pain we debugged during Phase 2 QA). Export/import lets you preserve identity across that, and carry trust between installs / clients.

## Core (`portable.ts` + keyring + manager)
- **`server/services/e2e/portable.ts`** — pure serialization (no runtime storage dependency; enum parsers inlined so it stays unit-testable without a DB): `buildPortable` / `serializePortable` / `parseAndValidate`. Import validates the **entire** structure (version, hex lengths, enum strings) *before* any write, so a malformed file changes nothing.
- **`db/e2e.ts replaceKeyringForImport`** — one transaction: (re)set the account identity and full-snapshot-replace this `(user, network)`'s peers / incoming+outgoing sessions / channel configs / autotrust. Outgoing recipients (derived rotation state) are cleared — they re-record on the next handshake.
- **`E2eManager.exportKeyring` / `importKeyring`** — crash-guarded (shared singleton). Import flags `identityChanged` when the imported identity differs from the current one (it becomes the **account** identity on **all** networks) and busts the identity cache.

**Scope:** per-`(user, network)` for everything except the account-wide identity. (repartee has no network dimension; a single-network round-trip is lossless.)

**Security:** the export contains the identity private key + session keys in **plaintext hex** (Lurker stores them sealed at rest; export necessarily unseals). It's a backup/migration escape hatch — the UX keeps it out of the rendered buffer and warns the user.

## Delivery (command-triggered, over the existing WS — no new HTTP routes)
- **wsHub**: `e2e-export` / `e2e-import` message types, handled directly via `e2eManager` (DB-backed, no live connection needed). The reply goes to the **requesting socket only** (`send`, not `fanOut`) so a broadcast doesn't make every open tab download. networkId ownership enforced at the boundary; system-buffer (null) rejected with a hint.
- **client**: `utils/download.ts downloadTextFile` (Blob + anchor) so export lands in a user-controlled file. `useSocket` handles `e2eExport` (download `lurker-e2e-keyring-<date>.json` + toast) and `e2eImport` (summary toast; warn toast on `identityChanged`). `MessageInput`: `/e2e export` → request the download; `/e2e import` → hidden `.json` picker → FileReader → `window.confirm` (destructive + identity-change warning) → send. All other `/e2e` subcommands pass through unchanged. `/e2e help` + the cheatsheet list export/import.

## Testing
- `portable.test.ts`: build→serialize→parse→validate round-trip, lowercase-hex wire format, and rejection of bad version / wrong hex length / non-hex / malformed JSON / non-array fields.
- Manager: export → import (into a separate account+network) → re-export reproduces the same document (lossless through the DB seal/unseal); `identityChanged` flag; malformed-input no-op; no-identity export.
- Full server suite (1159) + client suite (264) green; tsc (server + client) + oxlint + oxfmt clean.

⚠️ **Not browser-smoke-tested** — the dev server isn't run in this environment, so the actual download / file-picker / confirm path is unverified at runtime. Worth a quick `/e2e export` then `/e2e import` of that file before merge. The import confirm is a native `window.confirm` for v1 (easy to upgrade to an `AppModal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)