### PR TITLE
RPE2E channel parity: fix failed-revoke on outgoing-only recipients + reverify/TOFU edges

### DIFF
--- a/server/db/e2e.ts
+++ b/server/db/e2e.ts
@@ -334,6 +334,10 @@ const incomingChannelsForHandleStmt = db.prepare(
   `SELECT DISTINCT channel FROM e2e_incoming_sessions
    WHERE user_id = ? AND network_id = ? AND handle = ?`,
 );
+const outgoingChannelsForHandleStmt = db.prepare(
+  `SELECT DISTINCT channel FROM e2e_outgoing_recipients
+   WHERE user_id = ? AND network_id = ? AND handle = ?`,
+);
 const listTrustedForChannelStmt = db.prepare(
   `SELECT * FROM e2e_incoming_sessions
    WHERE user_id = ? AND network_id = ? AND channel = ? AND status = 'trusted'`,
@@ -476,6 +480,20 @@ export function listIncomingChannelsForHandle(
 ): string[] {
   return (
     incomingChannelsForHandleStmt.all(userId, networkId, handle) as Array<{ channel: string }>
+  ).map((r) => r.channel);
+}
+
+/** Channels where `handle` is one of OUR outgoing-key recipients (i.e. they can
+ *  decrypt our messages there). This is the authoritative "who can read us" set
+ *  and is recorded at KEYRSP-build time, before/independent of any reciprocal
+ *  incoming session — so revoke must consult it, not just incoming sessions. */
+export function listOutgoingChannelsForHandle(
+  userId: number,
+  networkId: number,
+  handle: string,
+): string[] {
+  return (
+    outgoingChannelsForHandleStmt.all(userId, networkId, handle) as Array<{ channel: string }>
   ).map((r) => r.channel);
 }
 

--- a/server/services/e2e/encoding.ts
+++ b/server/services/e2e/encoding.ts
@@ -34,8 +34,10 @@ export function tryDecodeUrlBase64(s: string): Uint8Array | null {
 /**
  * Parse a canonical unsigned decimal integer. Returns `null` for non-canonical
  * forms that `Number()` would otherwise accept (hex `0xa`, exponent `1e0`,
- * decimal `1.0`, leading sign) or values beyond the safe-integer range. This
- * matches Rust's typed integer parse, which rejects all of the above.
+ * decimal `1.0`, any leading sign) or values beyond the safe-integer range.
+ * This is slightly STRICTER than repartee's `str::parse::<u8>()`, which accepts
+ * a leading `+` (e.g. "+5") — harmless, since neither side ever serializes a
+ * sign, so the difference is only reachable on hand-crafted/malformed input.
  */
 export function parseUintStrict(s: string): number | null {
   if (!/^\d+$/.test(s)) return null;

--- a/server/services/e2e/manager.test.ts
+++ b/server/services/e2e/manager.test.ts
@@ -210,6 +210,44 @@ describe('E2eManager TOFU + replay + window', () => {
     mgr.forgetPeer(alice, aliceNet, BOB_H); // restore the shared keyring for later tests
   });
 
+  it('treats a pinned peer with a null stored handle as handle-changed (matches repartee)', async () => {
+    // The null-last_handle state is reachable via an imported repartee keyring.
+    // repartee's `last_handle != Some(new)` flags this as a change; Lurker must
+    // not silently swallow it as 'known'.
+    const keyring = await import('../../db/e2e.js');
+    fullHandshake('#nullh'); // pin Bob's fp under BOB_H, trusted
+    const peer = keyring.getPeerByHandle(alice, aliceNet, BOB_H)!;
+    keyring.upsertPeer(alice, aliceNet, {
+      fingerprint: peer.fingerprint,
+      pubkey: peer.pubkey,
+      lastHandle: null, // simulate an imported peer carrying no handle
+      lastNick: null,
+      firstSeen: peer.firstSeen,
+      lastSeen: peer.lastSeen,
+      globalStatus: 'trusted', // ignored on conflict; the row stays trusted
+    });
+
+    // Bob re-handshakes under BOB_H. A null stored handle must surface a
+    // handle-changed warning (refused), not a silent re-handshake.
+    mgr.setChannelConfig(bob, bobNet, '#nullh', true, 'auto-accept');
+    const out = mgr.handleHandshakeBody(
+      alice,
+      aliceNet,
+      BOB_H,
+      'bob',
+      mgr.buildKeyReq(bob, bobNet, '#nullh')!,
+    )!;
+    expect(out.replies).toHaveLength(0);
+    expect(out.notice?.level).toBe('warn');
+    expect(out.notice?.text).toMatch(/new handle/);
+
+    // Restore the shared keyring: the row now has a NULL handle, so the
+    // handle-keyed forgetPeer can't reach it — delete by fingerprint.
+    keyring.deletePeerByFingerprint(alice, aliceNet, peer.fingerprint);
+    mgr.forgetPeer(alice, aliceNet, BOB_H); // sessions/recipients/pending
+    mgr.forgetPeer(bob, bobNet, ALICE_H);
+  });
+
   it('flags a replayed chunk', () => {
     fullHandshake('#rp');
     const line = encLines(alice, aliceNet, '#rp', 'once')[0];
@@ -460,6 +498,52 @@ describe('E2eManager key rotation (Phase 2)', () => {
   it('rotateChannel is a no-op (false) when there is no outgoing session yet', () => {
     expect(mgr.rotateChannel(alice, aliceNet, '#rot-never')).toBe(false);
     expect(mgr.takePendingRekeySends(alice, aliceNet)).toEqual([]);
+  });
+
+  it('revoke cuts off an outgoing-only recipient (incomplete reciprocal handshake)', () => {
+    // Regression: a peer who completed only HALF the handshake — they got our
+    // channel key (so they can read us) but never answered our reciprocal KEYREQ,
+    // so we hold NO incoming session for them. Revoke once enumerated rotation
+    // channels from incoming sessions alone and silently missed this peer.
+    const ch = '#rv-outgoing-only';
+    mgr.forgetPeer(alice, aliceNet, BOB_H);
+    mgr.forgetPeer(bob, bobNet, ALICE_H);
+    mgr.setChannelConfig(alice, aliceNet, ch, true, 'auto-accept');
+    mgr.setChannelConfig(bob, bobNet, ch, true, 'auto-accept');
+
+    // Bob → KEYREQ; Alice auto-accepts → KEYRSP (records Bob as an outgoing
+    // recipient) + a reciprocal KEYREQ. Bob applies the KEYRSP but never answers
+    // the reciprocal, so Alice has the recipient row but no incoming session.
+    const aOut = mgr.handleHandshakeBody(
+      alice,
+      aliceNet,
+      BOB_H,
+      'bob',
+      mgr.buildKeyReq(bob, bobNet, ch)!,
+    )!;
+    expect(aOut.replies).toHaveLength(2); // KEYRSP + reciprocal KEYREQ
+    mgr.handleHandshakeBody(bob, bobNet, ALICE_H, 'alice', aOut.replies[0]); // Bob installs Alice's key
+    // aOut.replies[1] (Alice's reciprocal KEYREQ) is intentionally dropped.
+
+    // Precondition: Bob can read Alice (he has her current channel key).
+    const pre = encLines(alice, aliceNet, ch, 'pre-revoke');
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, ch, pre[0])).toMatchObject({
+      kind: 'plaintext',
+    });
+
+    // Revoke Bob → the next send must rotate the key away from him even though
+    // there was never an incoming session on this channel.
+    expect(mgr.revokePeer(alice, aliceNet, BOB_H)).toBe(true);
+    const post = encLines(alice, aliceNet, ch, 'post-revoke');
+    // Bob was the only recipient and was dropped, so nothing is re-keyed to him.
+    expect(mgr.takePendingRekeySends(alice, aliceNet)).toEqual([]);
+    // And he can no longer decrypt Alice's post-revoke traffic.
+    expect(mgr.decryptIncoming(bob, bobNet, ALICE_H, ch, post[0]).kind).not.toBe('plaintext');
+
+    // Clean up the shared DB: leaving Bob revoked would block a later
+    // re-handshake in another test (the keyring is shared across this file).
+    mgr.forgetPeer(alice, aliceNet, BOB_H);
+    mgr.forgetPeer(bob, bobNet, ALICE_H);
   });
 
   it('rejects a replayed REKEY (nonce-LRU) so a superseded key cannot be reinstalled', () => {

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -622,8 +622,10 @@ export class E2eManager {
     // A REKEY from a peer we've never handshaked with is illegitimate.
     if (change === 'new') return { replies: [] };
     if (isTofuBlock(change)) {
-      // Remember the change (as the KEYREQ/KEYRSP handlers do) so a later
-      // `/e2e reverify` can re-pin in place instead of falling back to a forget.
+      // Remember a fingerprint/handle change (as the KEYREQ/KEYRSP handlers do)
+      // so a later `/e2e reverify` can re-pin in place instead of falling back to
+      // a forget. A 'revoked' block is intentionally a no-op here (stashKeyChange
+      // only stashes fingerprint/handle changes).
       this.stashKeyChange(userId, networkId, senderHandle, change, rekey.pubkey, rekey.channel);
       return {
         replies: [],

--- a/server/services/e2e/manager.ts
+++ b/server/services/e2e/manager.ts
@@ -557,6 +557,17 @@ export class E2eManager {
     keyring.setPeerStatus(userId, networkId, fp, 'trusted');
 
     if (!this.installIncoming(userId, networkId, senderHandle, rsp.channel, fp, sk, now)) {
+      // Install-time second line of defense: the session row for this (handle,
+      // channel) is pinned to a different fingerprint. Stash the new (already
+      // sig-verified) pubkey so `/e2e reverify` can re-pin it in place.
+      this.stashKeyChange(
+        userId,
+        networkId,
+        senderHandle,
+        'fingerprint-changed',
+        rsp.pubkey,
+        rsp.channel,
+      );
       return {
         replies: [],
         notice: this.tofuWarning(senderHandle, 'fingerprint-changed', fp),
@@ -610,12 +621,16 @@ export class E2eManager {
     const change = this.classifyPeerChange(userId, networkId, fp, senderHandle);
     // A REKEY from a peer we've never handshaked with is illegitimate.
     if (change === 'new') return { replies: [] };
-    if (isTofuBlock(change))
+    if (isTofuBlock(change)) {
+      // Remember the change (as the KEYREQ/KEYRSP handlers do) so a later
+      // `/e2e reverify` can re-pin in place instead of falling back to a forget.
+      this.stashKeyChange(userId, networkId, senderHandle, change, rekey.pubkey, rekey.channel);
       return {
         replies: [],
         notice: this.tofuWarning(senderHandle, change, fp),
         channel: rekey.channel,
       };
+    }
 
     // ECDH from OUR Ed25519 identity (converted to X25519) with their fresh
     // ephemeral, HKDF under the REKEY domain separator.
@@ -633,6 +648,16 @@ export class E2eManager {
     if (
       !this.installIncoming(userId, networkId, senderHandle, rekey.channel, fp, sk, this.nowUnix())
     ) {
+      // Install-time second line of defense (see handleKeyRsp): stash the new
+      // pubkey so `/e2e reverify` can re-pin it in place.
+      this.stashKeyChange(
+        userId,
+        networkId,
+        senderHandle,
+        'fingerprint-changed',
+        rekey.pubkey,
+        rekey.channel,
+      );
       return {
         replies: [],
         notice: this.tofuWarning(senderHandle, 'fingerprint-changed', fp),
@@ -916,7 +941,17 @@ export class E2eManager {
     try {
       const peer = keyring.getPeerByHandle(userId, networkId, handle);
       if (peer) keyring.setPeerStatus(userId, networkId, peer.fingerprint, 'revoked');
-      const channels = keyring.listIncomingChannelsForHandle(userId, networkId, handle);
+      // Rotate every channel where the peer can read us. That's the UNION of the
+      // channels we hold an incoming session on AND the channels they're an
+      // outgoing recipient of — the latter is recorded at KEYRSP-build, before any
+      // reciprocal incoming session exists, so a peer who never completed the
+      // reciprocal handshake is an outgoing recipient with NO incoming session.
+      // Enumerating from incoming sessions alone left such a peer able to decrypt
+      // our future messages (and still queued for the next REKEY) after a revoke.
+      const channels = new Set([
+        ...keyring.listIncomingChannelsForHandle(userId, networkId, handle),
+        ...keyring.listOutgoingChannelsForHandle(userId, networkId, handle),
+      ]);
       const revoked = keyring.revokeIncomingSessionsForHandle(userId, networkId, handle);
       for (const channel of channels) {
         keyring.markOutgoingPendingRotation(userId, networkId, channel);
@@ -996,8 +1031,13 @@ export class E2eManager {
   /** Accept a TOFU-blocked key/handle change for `handle` after the user verified
    *  it out-of-band. If we remembered the change (it appeared since the last
    *  handshake), re-pin the new key/handle as trusted IN PLACE — no re-handshake,
-   *  no re-prompt — matching repartee. If there's nothing remembered, fall back to
-   *  a clean forget so the next handshake re-pins from scratch. Never throws. */
+   *  no re-prompt. If there's nothing remembered, fall back to a clean forget so
+   *  the next handshake re-pins from scratch. Never throws.
+   *
+   *  Parity note: repartee applies in place for a fingerprint change but forgets
+   *  for a handle change; Lurker deliberately re-pins in place for BOTH (a
+   *  handle change is the same already-trusted key under a new ident@host, so an
+   *  in-place re-pin is safe and avoids a needless re-handshake). */
   reverifyPeer(userId: number, networkId: number, handle: string): ReverifyOutcome {
     try {
       const stashKey = this.keyChangeKey(userId, networkId, handle);
@@ -1488,7 +1528,10 @@ export class E2eManager {
     const byFp = keyring.getPeerByFingerprint(userId, networkId, fp);
     if (byFp) {
       if (byFp.globalStatus === 'revoked') return 'revoked';
-      if (byFp.lastHandle && !eqLower(byFp.lastHandle, handle)) return 'handle-changed';
+      // A missing/empty stored handle counts as a change (matching repartee's
+      // `last_handle != Some(new)`, where None != Some(h) is true) — otherwise an
+      // imported peer with a null handle would suppress the handle-changed warning.
+      if (!byFp.lastHandle || !eqLower(byFp.lastHandle, handle)) return 'handle-changed';
       return 'known';
     }
     const byHandle = keyring.getPeerByHandle(userId, networkId, handle);


### PR DESCRIPTION
A channel-only parity audit of Lurker's RPE2E channel E2E vs the reference implementation (**repartee**) found Lurker to be a faithful clone on every interop-load-bearing surface (wire / AEAD-AAD / crypto primitives / handshake encode-parse / REKEY crypto / rate-limit constants / ts-window — all byte-for-byte; crypto KATs reproduce repartee's exact bytes). The audit surfaced **one real bug** and a few benign divergences. This PR addresses all the actionable ones.

## 🔴 RANK 1 — failed-revoke on outgoing-only recipients (confidentiality)

`revokePeer` enumerated the channels to rotate from the **incoming-session** set only (`listIncomingChannelsForHandle`). But a peer is recorded as an **outgoing recipient** at KEYRSP-build time (`recordOutgoingRecipient`), *before and independent of* any reciprocal incoming session. A peer who received our channel key but never completed the reciprocal handshake (offline / declined / rate-limited) was therefore **missed by revoke** — they kept decrypting our future messages on that channel and stayed queued for the next REKEY, with no signal to the user that the revoke was incomplete.

**Fix:** `revokePeer` now rotates the **union** of incoming-session channels and outgoing-recipient channels, via a new `listOutgoingChannelsForHandle` query (mirroring the by-handle outgoing primitive `forgetPeer` already uses). Regression test included — verified to fail without the fix (revoked peer still decrypts post-revoke traffic) and pass with it.

## 🟡 RANK 2 — `/e2e reverify` stash coverage

`stashKeyChange` was called on the KEYREQ/KEYRSP classifier-block paths but **omitted** on `handleRekey`'s TOFU-block and on both install-strict `HandleMismatch` fallbacks, so a later `/e2e reverify` destructively forgot the peer instead of re-pinning the (already sig-verified) key in place. Added the missing stash calls for consistency with the sibling handlers.

Also corrected the `reverifyPeer` doc comment that claimed full parity with repartee: Lurker re-pins a **handle change** in place where repartee forgets — a deliberate, safe divergence (same already-trusted key under a new ident@host), now documented as such rather than overstated as parity.

## 🟡 RANK 3 — TOFU null-handle classification

A pinned peer with a `NULL` stored `last_handle` was classified `known`, suppressing a handle-changed warning that repartee surfaces. Now classified `handle-changed`, matching repartee's `last_handle != Some(new)`. Reachable via an imported repartee keyring carrying a null-handle peer. Lock-in test included.

## 🟢 Comment fix

`encoding.ts`'s `parseUintStrict` comment claimed it "matches Rust's typed integer parse, which rejects a leading sign" — false for unsigned `parse`, which accepts `+`. Lurker is in fact slightly *stricter* (harmless, malformed-input-only). Comment corrected.

## Validation

- Full server suite green: **1164 tests / 101 files**.
- `tsc -p tsconfig.json` clean; `oxfmt` clean.
- Both behavior-change tests independently verified red → green.

Diff is small and mostly additive: `manager.ts` (revoke union + 3 stash calls + 2 comments), `e2e.ts` (+1 query/export), `encoding.ts` (comment), and 2 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)