### PR TITLE
Fix stale channels lingering in /list cache on refresh (#396)

### DIFF
--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -22,6 +22,8 @@ let sweepWsHeartbeat: typeof import('./wsHub.js').sweepWsHeartbeat;
 let buildSystemBacklog: typeof import('./wsHub.js').buildSystemBacklog;
 let systemLineToEvent: typeof import('./wsHub.js').systemLineToEvent;
 let buildSystemHistoryReply: typeof import('./wsHub.js').buildSystemHistoryReply;
+let startChanlistRefresh: typeof import('./wsHub.js').startChanlistRefresh;
+let chanlist: typeof import('../db/chanlist.js');
 let systemMessages: typeof import('../db/systemMessages.js').default;
 
 let userId: number;
@@ -42,7 +44,9 @@ beforeAll(async () => {
     buildSystemBacklog,
     systemLineToEvent,
     buildSystemHistoryReply,
+    startChanlistRefresh,
   } = await import('./wsHub.js'));
+  chanlist = await import('../db/chanlist.js');
   systemMessages = (await import('../db/systemMessages.js')).default;
 
   userId = createUser('alice').id;
@@ -424,5 +428,48 @@ describe('system buffer delivery (#355)', () => {
     expect(buildSystemHistoryReply(u, { mode: 'after', afterId: -1 })).toMatchObject({
       kind: 'error',
     });
+  });
+});
+
+describe('startChanlistRefresh (issue #396)', () => {
+  it('wipes the prior cache so a refresh drops departed channels', () => {
+    const net = createNetwork(userId, {
+      name: 'chanlist-refresh',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'alice',
+    });
+    const nid = net!.id;
+
+    // First /LIST: three channels land in the cache.
+    chanlist.upsertChannels(nid, [
+      { channel: '#a', topic: 'a', num_users: 5 },
+      { channel: '#b', topic: 'b', num_users: 4 },
+      { channel: '#gone', topic: 'gone', num_users: 1 },
+    ]);
+    expect(chanlist.countChannels(nid)).toBe(3);
+
+    // Refresh: this is the send-time reset that no longer relies on the server
+    // echoing RPL_LISTSTART (321). The cache is emptied and marked in-progress.
+    startChanlistRefresh(nid);
+    expect(chanlist.countChannels(nid)).toBe(0);
+    expect(chanlist.getMeta(nid)).toMatchObject({
+      inProgress: true,
+      totalCount: 0,
+      fetchedAt: null,
+    });
+
+    // The second /LIST returns a smaller set — #gone has been removed server-side.
+    // Without the reset above it would survive via the additive upsert (#396).
+    chanlist.upsertChannels(nid, [
+      { channel: '#a', topic: 'a', num_users: 6 },
+      { channel: '#b', topic: 'b', num_users: 4 },
+    ]);
+    const names = chanlist
+      .searchChannels(nid, { sortBy: 'name', sortDir: 'asc' })
+      .rows.map((r) => r.channel);
+    expect(names).toEqual(['#a', '#b']);
+    expect(names).not.toContain('#gone');
   });
 });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -775,6 +775,18 @@ function parseSinceParam(rawUrl: string): number {
   }
 }
 
+// Reset the channel-list cache the moment we send `/LIST`, rather than waiting
+// for the server's RPL_LISTSTART (321). Many ircds omit 321 entirely, and
+// irc-framework only emits 'channel list start' (the sole other caller of
+// clearChannels) when it arrives. Without an unconditional reset here, a refresh
+// upserts the fresh rows on top of the stale cache and never drops channels that
+// have since disappeared — they reappear forever (issue #396). Mirrors The
+// Lounge's inputs/list.ts, which empties chanCache when the user sends /list.
+export function startChanlistRefresh(networkId: number): void {
+  chanlistDb.clearChannels(networkId);
+  chanlistDb.setMeta(networkId, { inProgress: true, totalCount: 0, fetchedAt: null });
+}
+
 export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
   const wss = new WebSocketServer({ noServer: true });
   // Per-user pending auto-away timers. Set when a user goes from 1→0 sockets;
@@ -1643,6 +1655,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         }
         chanlistInFlight.add(networkId);
         try {
+          startChanlistRefresh(networkId);
           conn.raw('LIST');
         } catch (_) {
           chanlistInFlight.delete(networkId);


### PR DESCRIPTION
Fixes #396.

## Root cause

Lurker's `/list` cache is only ever cleared when the IRC server sends **`RPL_LISTSTART` (numeric 321)** — and many ircds don't send it (RFC 2812 treats 321 as an effectively-obsolete optional preamble).

- `clearChannels()` had exactly one caller: the `'channel list start'` handler in `ircConnection.ts`, and irc-framework only emits that event on 321 (`misc.js` `RPL_LISTSTART`).
- Channel rows still arrive without 321 — `RPL_LIST` (322) self-initializes the framework cache (`getChanListCache`, comment: *"fix some IRC networks"*), so `'channel list'` fires and we upsert.
- The upsert is `INSERT … ON CONFLICT DO UPDATE` — **purely additive**. It updates topics/counts but never removes a channel absent from the new LIST.

So on a server that omits 321, every refresh merged new rows onto the old cache and **never dropped departed channels** — they reappeared forever. This matched the report exactly: correct right after deleting the DB (cache starts empty), stale channels creeping back over time, and **only on Lurker** (The Lounge and weechat don't depend on 321).

## Fix

Clear the cache at the moment we **send** `LIST`, instead of relying on the server echoing 321. This mirrors The Lounge — which uses the same `irc-framework` — whose `inputs/list.ts` does `network.chanCache = []` when the user sends `/list`, treating 321 as merely a "nice to have" reset.

The existing 321 handler in `ircConnection.ts` stays as harmless redundancy: 321 always precedes any 322, so a double-clear is safe.

### Behavior change
A refresh now briefly empties the cached list until new rows stream in (the modal shows its in-progress state) — strictly better than showing stale data, and identical to The Lounge.

## Test
Adds a `wsHub.test.ts` regression: seed a 3-channel cache, run `startChanlistRefresh`, assert the cache is wiped + marked in-progress, then upsert a smaller second LIST and assert the departed channel is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)