### PR TITLE
Require a 2-char query before opening the emoji suggester (#402)

### DIFF
--- a/vue_client/src/components/EmojiPicker.vue
+++ b/vue_client/src/components/EmojiPicker.vue
@@ -10,10 +10,10 @@
   it owns only the candidate list + row look; the shared popover owns
   positioning, dismissal, the iOS focus contract, and keyboard nav.
 
-  Opens as soon as `:` is typed: with no query yet it shows a static
-  frequently-used set (see frequentEmoji), then filters as the user types.
-  `reverse` puts the best match at the bottom, nearest the input, matching the
-  other pickers.
+  Opens once a 2+ character `:shortcode` query is typed (issue #402) and
+  filters as the user types — a lone `:` or a one-char emoticon like `:D`
+  never pops it. `reverse` puts the best match at the bottom, nearest the
+  input, matching the other pickers.
 -->
 
 <template>
@@ -39,7 +39,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { searchEmojiSync, frequentEmoji } from '../utils/emojiShortcodes.js';
+import { searchEmojiSync } from '../utils/emojiShortcodes.js';
 import { emojiFn } from '../composables/useEmoji.js';
 import VerticalPopover from './VerticalPopover.vue';
 import type { PopoverNav } from './popoverNav.js';
@@ -48,7 +48,7 @@ import type { EmojiMatch } from '../utils/emojiData.js';
 const props = withDefaults(
   defineProps<{
     open?: boolean;
-    // The shortcode body under the caret (no colons); '' for a bare `:`.
+    // The shortcode body under the caret (no colons); 2+ chars (issue #402).
     query?: string;
     anchor?: HTMLElement | null;
   }>(),
@@ -69,8 +69,7 @@ const rows = computed<EmojiMatch[]>(() => {
   // lazily-loaded table lands), so rows recompute once it's available. The
   // table is preloaded at app start, so it's normally ready by the first `:`.
   if (!props.open || !emojiFn()) return [];
-  const q = props.query.trim();
-  return q ? searchEmojiSync(q, 30) : frequentEmoji(24);
+  return searchEmojiSync(props.query.trim(), 30);
 });
 
 function rowKey(row: EmojiMatch): string {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1189,9 +1189,7 @@ function onEmojiSelect(item: EmojiMatch): void {
   // re-sync the span via refreshPicker, but the async strip refresh leaves a
   // brief window). Mirrors the re-check maybeConvertShortcode already does;
   // on a mismatch, no-op rather than splice blind into the wrong span.
-  // allowEmpty: a desktop pick from the bare-`:` frequently-used set has an
-  // empty query, so the captured span is just the `:` — still valid.
-  const sc = emojiTokenStart >= 0 ? findActiveShortcode(value, emojiTokenEnd, true) : null;
+  const sc = emojiTokenStart >= 0 ? findActiveShortcode(value, emojiTokenEnd) : null;
   if (!sc || sc.start !== emojiTokenStart) {
     closeEmojiStrip();
     closeEmojiPicker();
@@ -1260,13 +1258,13 @@ function refreshPicker() {
 
   // An in-progress `:shortcode:` owns the suggester slot — it isn't a nick
   // token, and both emoji UIs and the nick picker/strip share one slot over the
-  // StatusBar. Desktop opens the vertical EmojiPicker (issue #348) the moment
-  // `:` is typed (empty query → a frequently-used set); mobile keeps the
-  // horizontal strip, gated at 2+ chars so a lone `:` — or an emoticon like
-  // `:)` — doesn't flash it.
+  // StatusBar. Both the desktop EmojiPicker (issue #348) and the mobile strip
+  // wait for a 2+ character query before opening, so a lone `:` or a one-char
+  // emoticon like `:D` / `:P` never pops the suggester — and Enter never
+  // silently swaps it for an emoji (issue #402).
   const emojiOnStrip = isMobile.value;
-  const shortcode = findActiveShortcode(value, cursor, !emojiOnStrip);
-  if (shortcode && (!emojiOnStrip || shortcode.name.length >= 2)) {
+  const shortcode = findActiveShortcode(value, cursor);
+  if (shortcode && shortcode.name.length >= 2) {
     closePicker();
     closeStrip();
     closeChannelPicker();

--- a/vue_client/src/utils/emojiShortcodes.test.ts
+++ b/vue_client/src/utils/emojiShortcodes.test.ts
@@ -6,7 +6,6 @@ import {
   emojiGlyph,
   findActiveShortcode,
   findCompletedShortcode,
-  frequentEmoji,
   loadEmoji,
   onEmojiLoaded,
   rankShortcodes,
@@ -29,24 +28,22 @@ describe('findActiveShortcode', () => {
     expect(findActiveShortcode(':BoNe', 5)?.name).toBe('bone');
   });
 
-  it('returns null when the caret is not in a shortcode', () => {
+  it('returns null when the caret is not in a shortcode, including a lone `:`', () => {
     expect(findActiveShortcode('hello world', 11)).toBeNull();
     expect(findActiveShortcode('', 0)).toBeNull();
+    // A bare `:` no longer opens anything (issue #402) — the suggester only ever
+    // sees a non-empty body, and the composer further gates it at 2+ chars.
     expect(findActiveShortcode(':', 1)).toBeNull();
+    expect(findActiveShortcode('hi :', 4)).toBeNull();
   });
 
-  it('matches a bare `:` with an empty name when allowEmpty (issue #348)', () => {
-    expect(findActiveShortcode(':', 1, true)).toEqual({ name: '', start: 0, end: 1 });
-    expect(findActiveShortcode('hi :', 4, true)).toEqual({ name: '', start: 3, end: 4 });
-  });
-
-  it('still captures a partial query under allowEmpty', () => {
-    expect(findActiveShortcode(':sm', 3, true)).toEqual({ name: 'sm', start: 0, end: 3 });
-  });
-
-  it('does not match a `:` glued to a word or number even under allowEmpty', () => {
-    expect(findActiveShortcode('word:', 5, true)).toBeNull();
-    expect(findActiveShortcode('12:', 3, true)).toBeNull();
+  it('reports a single-char body for one-letter emoticons the composer gates out (issue #402)', () => {
+    // `:D` / `:P` capture a length-1 name; MessageInput requires name.length >= 2
+    // before opening the suggester, so these emoticons never trigger it (and Enter
+    // never silently swaps `:D` for an emoji). A 2-letter query is what opens it.
+    expect(findActiveShortcode(':D', 2)).toEqual({ name: 'd', start: 0, end: 2 });
+    expect(findActiveShortcode(':P', 2)?.name.length).toBe(1);
+    expect(findActiveShortcode(':bo', 3)?.name.length).toBe(2);
   });
 
   it('does not trigger mid-word or after a digit', () => {
@@ -204,21 +201,6 @@ describe('searchEmojiSync', () => {
   it('returns nothing for a non-matching query', async () => {
     await loadEmoji();
     expect(searchEmojiSync('definitely_not_an_emoji')).toEqual([]);
-  });
-});
-
-describe('frequentEmoji', () => {
-  it('returns a non-empty static set, every entry resolving to a real glyph', async () => {
-    await loadEmoji();
-    const f = frequentEmoji();
-    expect(f.length).toBeGreaterThan(0);
-    expect(f.every((m) => typeof m.emoji === 'string' && m.emoji.length > 0)).toBe(true);
-    expect(f.some((m) => m.name === 'tada')).toBe(true);
-  });
-
-  it('respects the limit', async () => {
-    await loadEmoji();
-    expect(frequentEmoji(5).length).toBeLessThanOrEqual(5);
   });
 });
 

--- a/vue_client/src/utils/emojiShortcodes.ts
+++ b/vue_client/src/utils/emojiShortcodes.ts
@@ -26,10 +26,6 @@ const NAME = `${NAME_CHARS}+`;
 // `(?<!${NAME_CHARS})` keeps the opening colon off the back of a word or number.
 const OPEN_RE = new RegExp(`(?<!${NAME_CHARS}):(${NAME})$`, 'i');
 const CLOSE_RE = new RegExp(`(?<!${NAME_CHARS}):(${NAME}):$`, 'i');
-// Like OPEN_RE but the body may be empty — matches a bare `:` just opened (the
-// desktop emoji picker uses this to pop a frequently-used set before any query
-// is typed). Same opening-boundary rule, so `word:` / `12:` still don't match.
-const OPEN_EMPTY_RE = new RegExp(`(?<!${NAME_CHARS}):(${NAME_CHARS}*)$`, 'i');
 
 // A *global* matcher for every completed `:name:` in a string, used by the
 // render-time emoji pass (`splitTextByEmoji` in nickColor). It shares NAME and
@@ -52,14 +48,12 @@ export interface ShortcodeToken {
 }
 
 // An *in-progress* shortcode ending at the caret: `:bo|` → { name: 'bo' }.
-// Returns null when the caret isn't sitting in a shortcode body. Drives the
-// suggester strip; the caller decides the minimum query length to act on.
-export function findActiveShortcode(
-  text: string,
-  caret: number,
-  allowEmpty = false,
-): ShortcodeToken | null {
-  const m = (allowEmpty ? OPEN_EMPTY_RE : OPEN_RE).exec(text.slice(0, caret));
+// Returns null when the caret isn't sitting in a non-empty shortcode body — a
+// lone `:` never matches. Drives the suggester; the caller decides the minimum
+// query length to act on (the composer gates at 2+ chars so a one-char emoticon
+// like `:D` doesn't open the picker — issue #402).
+export function findActiveShortcode(text: string, caret: number): ShortcodeToken | null {
+  const m = OPEN_RE.exec(text.slice(0, caret));
   if (!m) return null;
   return { name: m[1].toLowerCase(), start: caret - m[1].length - 1, end: caret };
 }
@@ -167,42 +161,6 @@ export function searchEmojiSync(query: string, limit = 30): EmojiMatch[] {
   if (!loadedTable) return [];
   const table = loadedTable;
   return rankShortcodes(loadedNames, query)
-    .slice(0, limit)
-    .map((name) => ({ name, emoji: table[name] }));
-}
-
-// A small static "frequently used" set shown when the picker opens on a bare
-// `:` (no query yet). Deliberately not usage-tracked — a fixed common set keeps
-// it simple; frecency can come later. Only entries present in the loaded table
-// are returned, so a future gemoji revision can't surface a dangling shortcode.
-const FREQUENT_SHORTCODES = [
-  'joy',
-  'sob',
-  'heart',
-  'smile',
-  '+1',
-  'pray',
-  'fire',
-  'tada',
-  'rofl',
-  'sweat_smile',
-  'heart_eyes',
-  'thinking',
-  'eyes',
-  'pleading_face',
-  'ok_hand',
-  'raised_hands',
-  'sparkles',
-  'wave',
-  '100',
-  'clap',
-  'rocket',
-  'thumbsdown',
-];
-export function frequentEmoji(limit = 30): EmojiMatch[] {
-  if (!loadedTable) return [];
-  const table = loadedTable;
-  return FREQUENT_SHORTCODES.filter((name) => table[name] != null)
     .slice(0, limit)
     .map((name) => ({ name, emoji: table[name] }));
 }


### PR DESCRIPTION
Fixes #402.

## The bug
Typing `:D` at the end of a sentence and pressing Enter swapped it for an emoji (the German flag 🇩🇪). The desktop `:` emoji picker opened on a **1-character** query, and Enter accepts the highlighted match — so a one-char emoticon like `:D` / `:P` / `:o` got silently converted on send.

The picker also auto-opened on a **bare `:`** (the #348 frequently-used browse), which has the same Enter-misfire: `:` + Enter inserted the top frequent emoji.

## The fix
Gate the suggester at a **2+ character query** on every platform — matching Slack ("`:bo`…") and the mobile strip, which already required `>= 2`. A lone `:` or a one-char emoticon no longer opens the picker, so Enter just sends the message.

Per the maintainer decision on the issue, this **drops the bare-`:` frequently-used browse** added in #348 (it shared the same Enter-misfire). The now-dead path is removed end to end:
- `OPEN_EMPTY_RE` + the `allowEmpty` arg of `findActiveShortcode`
- `frequentEmoji` / `FREQUENT_SHORTCODES`
- `EmojiPicker.vue`'s empty-query fallback

| Input | Before | After |
|-------|--------|-------|
| `:` | frequently-used picker opens | nothing |
| `:D` `:P` `:o` | picker opens, Enter → emoji | nothing |
| `:bo` | picker opens | picker opens (unchanged) |

## Tests
`emojiShortcodes.test.ts` updated: a bare `:` now returns null, and a new case documents that one-letter emoticons capture a length-1 body the composer gates out, while a 2-letter query opens it. The removed `allowEmpty` / `frequentEmoji` tests went with the dead code.

Verified: `npm run check` (server + client typecheck, lint, format) clean; `emojiShortcodes.test.ts` 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)