### PR TITLE
Mute user modes in the desktop input prompt (#415)

### DIFF
--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -14,7 +14,8 @@
   >
     <span class="prompt"
       ><template v-if="!isMobile"
-        >{{ promptLabel }}<span v-if="awayLabel" class="away">&nbsp;{{ awayLabel }}</span
+        >{{ promptLabelNoModes }}<span v-if="promptModes" class="modes">{{ promptModes }}</span
+        ><span v-if="awayLabel" class="away">&nbsp;{{ awayLabel }}</span
         >&nbsp;</template
       ><span
         v-if="hasHistory"
@@ -420,12 +421,14 @@ const systemFeatures = computed(() => {
     autocapitalize: autocorrectOn ? 'sentences' : 'off',
   };
 });
-// Prompt identity (nick + channel prefix + user modes) and away marker — see
-// useSelfLabel. On mobile we don't render the prompt label inline here (the
-// template gates it on !isMobile so the input row stays just `>` + composer);
-// instead the modeless variant feeds the placeholder above, since the compact
-// status bar now shows network/channel rather than the self identity.
-const { promptLabel, promptLabelNoModes, awayLabel } = useSelfLabel();
+// Prompt identity (nick + channel prefix, then user modes) and away marker —
+// see useSelfLabel. The nick and the user-mode parens come back separately so
+// the prompt can accent-colour the nick but mute the modes (issue #415). On
+// mobile we don't render the prompt label inline here (the template gates it on
+// !isMobile so the input row stays just `>` + composer); instead the modeless
+// variant feeds the placeholder above, since the compact status bar now shows
+// network/channel rather than the self identity.
+const { promptLabelNoModes, promptModes, awayLabel } = useSelfLabel();
 const { isMobile } = useViewport();
 
 let typingState: string | null = null;
@@ -2955,6 +2958,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
   /* Matches the textarea's intrinsic single-row height so the prompt and
      the first text line baseline-align before any growth. */
   line-height: 1.4;
+}
+/* User modes ride the accent-coloured nick but stay muted, matching the status
+   bar's channel name (accent) vs mode suffix (muted) treatment (issue #415). */
+.prompt .modes {
+  color: var(--fg-muted);
 }
 .prompt .away {
   color: var(--warn);

--- a/vue_client/src/composables/useSelfLabel.ts
+++ b/vue_client/src/composables/useSelfLabel.ts
@@ -8,14 +8,18 @@ import { useBuffersStore } from '../stores/buffers.js';
 import { prefixOf } from '../utils/memberPrefix.js';
 
 export interface SelfLabelState {
-  promptLabel: ComputedRef<string>;
   promptLabelNoModes: ComputedRef<string>;
+  promptModes: ComputedRef<string>;
   awayLabel: ComputedRef<string>;
 }
 
-// Self-identity label used in the input prompt and (compact) status bar:
+// Self-identity label used in the input prompt:
 //   [channel-prefix][nick](userModes)   e.g.  @bradleyroot(i)
-// Plus a separate away label string like "(brb)" when /away is set.
+// The nick part (promptLabelNoModes) and the user-mode parens (promptModes) are
+// exposed separately so the prompt can accent-colour the nick while muting the
+// modes — mirroring the status bar, which colours the channel name but not its
+// mode suffix (issue #415). Plus a separate away label like "(brb)" when /away
+// is set.
 //
 // The channel-prefix is the user's own op/voice marker derived from the
 // active channel's member list. For DMs / server buffers it's empty.
@@ -38,7 +42,7 @@ export function useSelfLabel(): SelfLabelState {
 
   // Identity without the trailing user-mode parens. Feeds the mobile input
   // placeholder, which mirrors the compact status bar's choice to drop modes
-  // on narrow screens; the desktop prompt (promptLabel) keeps them.
+  // on narrow screens; the desktop prompt renders this plus promptModes.
   const promptLabelNoModes = computed(() => {
     const a = active.value;
     if (!a) return '—';
@@ -47,12 +51,13 @@ export function useSelfLabel(): SelfLabelState {
     return `${channelPrefix.value}${nick}`;
   });
 
-  const promptLabel = computed(() => {
-    const base = promptLabelNoModes.value;
+  // The trailing user-mode parens, kept apart from the nick so the prompt can
+  // render them in a muted colour (issue #415). Empty when no modes are set.
+  const promptModes = computed(() => {
     const a = active.value;
-    if (!a || base === '—') return base;
+    if (!a || promptLabelNoModes.value === '—') return '';
     const modes = networks.states[a.networkId]?.userModes || '';
-    return modes ? `${base}(${modes})` : base;
+    return modes ? `(${modes})` : '';
   });
 
   const awayLabel = computed(() => {
@@ -64,5 +69,5 @@ export function useSelfLabel(): SelfLabelState {
     return away?.active && away.message ? `(${away.message})` : '';
   });
 
-  return { promptLabel, promptLabelNoModes, awayLabel };
+  return { promptLabelNoModes, promptModes, awayLabel };
 }


### PR DESCRIPTION
Fixes #415.

The desktop input bar's `>` prompt accent-coloured the entire self-identity, including the trailing user-mode parens — `@bradleyroot(i)` rendered with `(i)` in the accent colour too. The status bar already colours the channel **name** but not its **mode suffix**; this makes the prompt match that treatment: accent the nick, mute the modes.

## Change
- `useSelfLabel` now exposes the nick (`promptLabelNoModes`) and the user-mode parens (`promptModes`) separately, instead of one concatenated `promptLabel`.
- The prompt renders the modes in their own `.prompt .modes` span at `var(--fg-muted)`, mirroring the status bar's `.name` (accent) / `.modes` (muted) split.
- Desktop only — the mobile placeholder already drops user modes (`promptLabelNoModes`), so nothing changes there.

Before: `@bradleyroot(i)` — nick **and** `(i)` accent-coloured.
After: `@bradleyroot` accent + `(i)` muted.

## Verification
`npm run check` clean (client typecheck via vue-tsc, lint, oxfmt). Visual-only change; I don't run the dev server (it autoconnects to a live IRC session), so this wasn't screenshotted — the markup/CSS split mirrors the existing StatusBar pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)