### PR TITLE
Fix pinned-channel reorder snapping back on invisible orphan pins (#405)

### DIFF
--- a/server/db/pinnedBuffers.test.ts
+++ b/server/db/pinnedBuffers.test.ts
@@ -64,9 +64,74 @@ describe('reorderPins', () => {
     expect(pinned.listPinnedForUserNetwork(user.id, net!.id)).toEqual(['#d', '#c']);
   });
 
-  it('returns null on a mismatched set', () => {
-    expect(pinned.reorderPins(user.id, net!.id, ['#d'])).toBeNull();
+  it('returns null when a requested target is not pinned', () => {
     expect(pinned.reorderPins(user.id, net!.id, ['#d', '#c', '#missing'])).toBeNull();
+  });
+
+  it('returns null on a duplicated target', () => {
+    expect(pinned.reorderPins(user.id, net!.id, ['#d', '#d'])).toBeNull();
+  });
+
+  // The client drops pins it can't render (closed/parted buffers, friend
+  // primary DMs), so a drag legitimately reorders only a subset of the pinned
+  // set. The reorder must still apply, keeping the unmentioned ("hidden") pins
+  // after the visible ones rather than snapping back (issue #405).
+  it('accepts a subset, reordering the supplied targets and keeping hidden pins after them', () => {
+    // Fresh user/network so the suite-wide ordering above stays intact.
+    const carol = createUser('pin-carol');
+    const netC = createNetwork(carol.id, {
+      name: 'c',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'c',
+    });
+    pinned.pinBuffer(carol.id, netC!.id, '#visibleA'); // pos 0
+    pinned.pinBuffer(carol.id, netC!.id, 'hiddenDM'); // pos 1 (invisible to the client)
+    pinned.pinBuffer(carol.id, netC!.id, '#visibleB'); // pos 2
+
+    // Client only sees the two channels and drags B above A.
+    const next = pinned.reorderPins(carol.id, netC!.id, ['#visibleB', '#visibleA']);
+    expect(next).toEqual(['#visibleB', '#visibleA', 'hiddenDM']);
+    expect(pinned.listPinnedForUserNetwork(carol.id, netC!.id)).toEqual([
+      '#visibleB',
+      '#visibleA',
+      'hiddenDM',
+    ]);
+  });
+});
+
+describe('unpinBufferCaseInsensitive', () => {
+  it('removes a pin whose stored casing differs from the requested target', () => {
+    const dave = createUser('pin-dave');
+    const netD = createNetwork(dave.id, {
+      name: 'd',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'd',
+    });
+    pinned.pinBuffer(dave.id, netD!.id, '#Channel'); // stored with a capital C
+    pinned.pinBuffer(dave.id, netD!.id, '#other');
+
+    // close-buffer arrives with the server's lowercased casing.
+    const next = pinned.unpinBufferCaseInsensitive(dave.id, netD!.id, '#channel');
+    expect(next).toEqual(['#other']);
+    expect(pinned.listPinnedForUserNetwork(dave.id, netD!.id)).toEqual(['#other']);
+  });
+
+  it('returns null when nothing matches so the caller can skip the broadcast', () => {
+    const erin = createUser('pin-erin');
+    const netE = createNetwork(erin.id, {
+      name: 'e',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'e',
+    });
+    pinned.pinBuffer(erin.id, netE!.id, '#kept');
+    expect(pinned.unpinBufferCaseInsensitive(erin.id, netE!.id, '#nope')).toBeNull();
+    expect(pinned.listPinnedForUserNetwork(erin.id, netE!.id)).toEqual(['#kept']);
   });
 });
 

--- a/server/db/pinnedBuffers.test.ts
+++ b/server/db/pinnedBuffers.test.ts
@@ -120,6 +120,30 @@ describe('unpinBufferCaseInsensitive', () => {
     expect(pinned.listPinnedForUserNetwork(dave.id, netD!.id)).toEqual(['#other']);
   });
 
+  it('removes every case-variant in one pass (PRIMARY KEY is case-sensitive)', () => {
+    const frank = createUser('pin-frank');
+    const netF = createNetwork(frank.id, {
+      name: 'f',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'f',
+    });
+    // The schema allows both rows since the target column has no NOCASE.
+    pinned.pinBuffer(frank.id, netF!.id, '#Channel');
+    pinned.pinBuffer(frank.id, netF!.id, '#channel');
+    pinned.pinBuffer(frank.id, netF!.id, '#kept');
+
+    const next = pinned.unpinBufferCaseInsensitive(frank.id, netF!.id, '#CHANNEL');
+    expect(next).toEqual(['#kept']);
+    expect(pinned.listPinnedForUserNetwork(frank.id, netF!.id)).toEqual(['#kept']);
+    // Positions stay dense after pulling two rows out of the middle/front.
+    const rows = db
+      .prepare(`SELECT target, position FROM pinned_buffers WHERE user_id = ? AND network_id = ?`)
+      .all(frank.id, netF!.id) as Array<{ target: string; position: number }>;
+    expect(rows).toEqual([{ target: '#kept', position: 0 }]);
+  });
+
   it('returns null when nothing matches so the caller can skip the broadcast', () => {
     const erin = createUser('pin-erin');
     const netE = createNetwork(erin.id, {

--- a/server/db/pinnedBuffers.ts
+++ b/server/db/pinnedBuffers.ts
@@ -102,23 +102,54 @@ export function unpinBuffer(userId: number, networkId: number, target: string): 
   return listPinnedForUserNetwork(userId, networkId);
 }
 
-// Rewrite the order for a (user, network). The caller must supply exactly the
-// set of currently-pinned targets (no adds, no drops); the function validates
-// and returns null on mismatch so the caller can surface a no-op. On success
-// returns the new ordered target list.
+// Unpin the buffer matching `target` case-insensitively. IRC targets are
+// case-insensitive but a pin row stores one canonical casing, so a caller that
+// only has the server's current casing (e.g. close-buffer, where the buffer may
+// have been re-cased by the server) can still find and remove the stranded pin.
+// Returns the new ordered list when a row was removed, or null when nothing
+// matched — callers use null to skip the pins-changed broadcast. Matches the
+// case-folding the snapshot already applies to closed buffers (issue #405).
+export function unpinBufferCaseInsensitive(
+  userId: number,
+  networkId: number,
+  target: string,
+): string[] | null {
+  const lower = target.toLowerCase();
+  const match = listPinnedForUserNetwork(userId, networkId).find((t) => t.toLowerCase() === lower);
+  if (match === undefined) return null;
+  return unpinBuffer(userId, networkId, match);
+}
+
+// Rewrite the order for a (user, network). Every supplied target must currently
+// be pinned (and appear at most once); an unknown or duplicated target means the
+// client is working from a stale set (e.g. a concurrent pin/unpin from another
+// tab), so we return null and let the caller echo the authoritative order.
+//
+// The supplied list may be a strict SUBSET of the pinned set. The client only
+// renders pins that resolve to a visible buffer — it drops any pin whose buffer
+// is closed/parted/case-mismatched, or that is a friend's primary DM (shown
+// under FRIENDS) — so a drag legitimately reorders only the rows the user can
+// see. We honor that order for the supplied targets and keep the unmentioned
+// ("hidden") pins after them in their existing relative order. Requiring an
+// exact set match instead made a single invisible orphan pin wedge every
+// reorder for that network (issue #405). On success returns the new full
+// ordered target list.
 export function reorderPins(userId: number, networkId: number, targets: string[]): string[] | null {
-  const current = new Set(listPinnedForUserNetwork(userId, networkId));
-  if (targets.length !== current.size) return null;
+  const currentOrdered = listPinnedForUserNetwork(userId, networkId);
+  const current = new Set(currentOrdered);
+  const seen = new Set<string>();
   for (const t of targets) {
-    if (!current.has(t)) return null;
+    if (!current.has(t) || seen.has(t)) return null;
+    seen.add(t);
   }
+  const next = [...targets, ...currentOrdered.filter((t) => !seen.has(t))];
   const tx = db.transaction(() => {
     let i = 0;
-    for (const t of targets) {
+    for (const t of next) {
       setPositionStmt.run(i, userId, networkId, t);
       i += 1;
     }
   });
   tx();
-  return [...targets];
+  return next;
 }

--- a/server/db/pinnedBuffers.ts
+++ b/server/db/pinnedBuffers.ts
@@ -102,22 +102,43 @@ export function unpinBuffer(userId: number, networkId: number, target: string): 
   return listPinnedForUserNetwork(userId, networkId);
 }
 
-// Unpin the buffer matching `target` case-insensitively. IRC targets are
+// Unpin every buffer matching `target` case-insensitively. IRC targets are
 // case-insensitive but a pin row stores one canonical casing, so a caller that
 // only has the server's current casing (e.g. close-buffer, where the buffer may
 // have been re-cased by the server) can still find and remove the stranded pin.
-// Returns the new ordered list when a row was removed, or null when nothing
-// matched — callers use null to skip the pins-changed broadcast. Matches the
-// case-folding the snapshot already applies to closed buffers (issue #405).
+// The schema's PRIMARY KEY is on the raw target (no NOCASE), so two case
+// variants of the same channel can coexist as separate rows — remove ALL of
+// them in one transaction and renumber once, or closing one would leave the
+// other as an invisible orphan. Returns the new ordered list when at least one
+// row was removed, or null when nothing matched — callers use null to skip the
+// pins-changed broadcast. Matches the case-folding the snapshot already applies
+// to closed buffers (issue #405).
 export function unpinBufferCaseInsensitive(
   userId: number,
   networkId: number,
   target: string,
 ): string[] | null {
   const lower = target.toLowerCase();
-  const match = listPinnedForUserNetwork(userId, networkId).find((t) => t.toLowerCase() === lower);
-  if (match === undefined) return null;
-  return unpinBuffer(userId, networkId, match);
+  const matches = listPinnedForUserNetwork(userId, networkId).filter(
+    (t) => t.toLowerCase() === lower,
+  );
+  if (matches.length === 0) return null;
+  const tx = db.transaction(() => {
+    for (const m of matches) deleteStmt.run(userId, networkId, m);
+    const remaining = allForUserNetworkStmt.all(userId, networkId) as Array<{
+      target: string;
+      position: number;
+    }>;
+    let i = 0;
+    for (const row of remaining) {
+      if (row.position !== i) {
+        setPositionStmt.run(i, userId, networkId, row.target);
+      }
+      i += 1;
+    }
+  });
+  tx();
+  return listPinnedForUserNetwork(userId, networkId);
 }
 
 // Rewrite the order for a (user, network). Every supplied target must currently

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -59,6 +59,7 @@ import { closeBuffer, reopenBuffer, isClosed, closedKeySetForUser } from '../db/
 import {
   pinBuffer,
   unpinBuffer,
+  unpinBufferCaseInsensitive,
   reorderPins,
   listPinnedForUserNetwork,
 } from '../db/pinnedBuffers.js';
@@ -1581,10 +1582,13 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         closeBuffer(userId, networkId, target);
         // The client renders the pinned section by intersecting pins with open
         // buffers, so a pin on a now-closed buffer is invisible — and leaving
-        // the row would diverge the client's pin set from ours, snapping the
-        // next reorder back as a mismatch (issue #112). Close implies unpin.
-        if (listPinnedForUserNetwork(userId, networkId).includes(target)) {
-          const pinned = unpinBuffer(userId, networkId, target);
+        // the row would diverge the client's pin set from ours (issue #112).
+        // Close implies unpin. Match case-insensitively: the snapshot hides
+        // closed buffers case-folded (closedKeySetForUser lowercases), so a
+        // differently-cased close would otherwise hide the buffer while leaving
+        // the exact-cased pin row stranded — an invisible orphan (issue #405).
+        const pinned = unpinBufferCaseInsensitive(userId, networkId, target);
+        if (pinned) {
           fanOut(userId, { kind: 'pins-changed', networkId, pinned });
         }
         if (target.startsWith('#')) {


### PR DESCRIPTION
Closes #405.

## Symptom

Reordering pinned channels snapped back to the original order — no console errors. It only affected the operator's account in production; other users could reorder fine.

## Root cause

Reorder is **all-or-nothing** on the server. The client builds the draggable pinned list in `syncPinned()` (`BufferList.vue`) by resolving each server pin to a *visible* buffer, **dropping** any pin that:

1. has no matching open buffer (closed / parted / case-mismatched), or
2. is a **friend's primary DM** (rendered under FRIENDS, hidden from its network via `isFriendPrimaryDm`).

It then sends `list.map(b => b.target)` — always a **subset** of the server's pin set. `reorderPins` required an exact set match (`targets.length !== current.size → return null`), so a single dropped pin made the lists differ, the reorder returned `null`, and the WS handler **echoed the authoritative order back** → the snap-back.

Two things made it look mysterious:

- **It's account-specific** — you only hit it if a pinned buffer overlaps your contacts/closed buffers. The operator pinned a DM and also has that nick friended, so its pin is filtered out of the draggable list but stays in the server set.
- **"Unpin everything + repin" didn't help** — the orphan pin is *invisible*, so the UI can't unpin it. Repinning just added to a set that still contained the hidden orphan.

A second, narrower way an orphan is created: `close-buffer`'s unpin used an **exact-case** `.includes(target)`, while the snapshot hides closed buffers **case-folded** (`closedKeySetForUser` lowercases). A differently-cased close hid the buffer while leaving the exact-cased pin row stranded.

## Fix

- **`reorderPins` tolerates a strict subset** (`server/db/pinnedBuffers.ts`): every supplied target must currently be pinned (no unknowns, no duplicates → still `null` so a genuinely stale client snaps to truth), then it reorders the supplied targets and keeps the unmentioned ("hidden") pins after them in their existing relative order. An invisible pin can no longer wedge the whole reorder. Robust to *any* future reason a pin is hidden.
- **`close-buffer` unpins case-insensitively** via new `unpinBufferCaseInsensitive`, matching the case-folding the snapshot already applies — closes one orphan-creation path.

## Tests

`server/db/pinnedBuffers.test.ts`:
- subset reorder keeps hidden pins after the visible ones
- unknown / duplicated targets still rejected
- case-folded unpin removes a pin whose stored casing differs; returns `null` (skip broadcast) when nothing matches

Server typecheck, `oxlint`, `oxfmt --check`, and the `pinnedBuffers` + `wsHub` suites all pass.

## Notes for prod

The reorder fix unblocks reordering immediately — existing orphan pins are preserved but no longer block. They're harmless (invisible), but if you'd like them cleared from your prod DB I have a targeted `DELETE` ready; no migration is bundled here since deleting pins is a data decision, not a correctness requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)