### PR TITLE
Bump version to v1.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Bumps the app version `1.0.5` → `1.0.6` across the root and client `package.json` + lockfile self-references (same 4-file shape as the previous bump, #8ebff3f).

Cuts a release carrying to production:
- **#405** — pinned-channel reorder no longer snaps back on invisible orphan pins (subset-tolerant `reorderPins` + case-folded close-buffer unpin).
- **#388** — buffer-list keyboard nav keeps a 3-buffer scrolloff zone (accounting for the sticky LURKER header).

No code changes beyond the version strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)