### PR TITLE
Make nicks open menus on click/tap only so selection stays copyable (#426)

### DIFF
--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -62,20 +62,17 @@
                 ><NickRef
                   :nick="asRename(item).from"
                   interactive
-                  @click.stop.prevent="onNickMenu($event, asRename(item).from)"
-                  @contextmenu.stop.prevent="onNickMenu($event, asRename(item).from)" />
+                  @click.stop.prevent="onNickMenu($event, asRename(item).from)" />
                 →
                 <NickRef
                   :nick="asRename(item).to"
                   interactive
-                  @click.stop.prevent="onNickMenu($event, asRename(item).to)"
-                  @contextmenu.stop.prevent="onNickMenu($event, asRename(item).to)" /></template
+                  @click.stop.prevent="onNickMenu($event, asRename(item).to)" /></template
               ><template v-else
                 ><NickRef
                   :nick="asNick(item).nick"
                   interactive
-                  @click.stop.prevent="onNickMenu($event, asNick(item).nick)"
-                  @contextmenu.stop.prevent="
+                  @click.stop.prevent="
                     onNickMenu($event, asNick(item).nick)
                   " /></template></template
             ><template v-if="g.hidden > 0"
@@ -102,7 +99,6 @@
                 :show-prefix="showModePrefix"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
             /></span>
           </div>
           <span class="body" :class="bodyClass(row.m)">
@@ -128,8 +124,7 @@
                 :modes="authorModes(row.m)"
                 :show-prefix="showModePrefix"
                 interactive
-                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /></template
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /></template
             ><template v-else>{{ row.continuationAuthor ? '' : prefixText(row.m) }}</template></span
           >
           <span class="body" :class="bodyClass(row.m)">
@@ -146,7 +141,6 @@
                 :nick="row.m.nick ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               />{{ eventHostSuffix(row.m) }} joined</template
             >
             <template v-else-if="row.m?.type === 'part'"
@@ -154,7 +148,6 @@
                 :nick="row.m.nick ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               />{{ eventHostSuffix(row.m) }} left<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
@@ -164,7 +157,6 @@
                 :nick="row.m.nick ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               />{{ eventHostSuffix(row.m) }} quit<template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
@@ -174,14 +166,12 @@
                 :nick="row.m.kicked ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.kicked)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.kicked)"
               />
               kicked by
               <NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               /><template v-if="row.m.text">
                 (<LinkedText :text="row.m.text" />)</template
               ></template
@@ -191,14 +181,12 @@
                 :nick="row.m.nick ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
               />
               is now
               <NickRef
                 :nick="row.m.newNick ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.newNick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.newNick, row.m)"
               />{{ eventHostSuffix(row.m) }}</template
             >
             <template v-else-if="row.m?.type === 'mode'"
@@ -206,8 +194,7 @@
               <NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
                 v-if="row.m.text"
                 >: <LinkedText :text="row.m.text" /></template
             ></template>
@@ -216,8 +203,7 @@
               <NickRef
                 :nick="row.m.nick ?? ''"
                 interactive
-                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-                @contextmenu.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" /><template
                 v-if="row.m.text"
                 >: <LinkedText :text="row.m.text" /></template
             ></template>

--- a/vue_client/src/components/NickRef.vue
+++ b/vue_client/src/components/NickRef.vue
@@ -23,9 +23,11 @@ const props = defineProps<{
   // render; callers that aren't a channel speaker just omit them.
   modes?: string[];
   showPrefix?: boolean;
-  // Pointer affordance for clickable nicks (#238). The click/contextmenu
-  // handlers are attached by the consumer and reach the root span via Vue's
-  // attribute fallthrough — this prop only drives the cursor styling.
+  // Pointer affordance for clickable nicks (#238). The click handler is
+  // attached by the consumer and reaches the root span via Vue's attribute
+  // fallthrough — this prop only drives the cursor styling. Nicks open their
+  // menu on left-click/tap only; right-click is left to the browser so the
+  // text stays selectable for copy/paste (#426).
   interactive?: boolean;
 }>();
 
@@ -62,11 +64,6 @@ const style = computed(() => {
 }
 .nick-ref.interactive {
   cursor: pointer;
-  /* Right-clicking to open the menu otherwise selects the word under the
-     cursor (the selection happens on pointer-down, before @contextmenu.prevent
-     can fire), which reads as a glitch. Matches the member list, where rows are
-     likewise unselectable. */
-  user-select: none;
 }
 /* The mode glyph reuses the nicklist's per-mode colors so it reads as a status
    marker rather than part of the (separately-colored) nick. */

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -46,7 +46,6 @@
       class="msg-nick"
       :style="styleFor(seg)"
       @click.stop="$emit('nickClick', seg.text, $event)"
-      @contextmenu.stop.prevent="$emit('nickClick', seg.text, $event)"
       >{{ seg.text }}</span
     >
     <span v-else-if="hasStyle(seg)" :style="styleFor(seg)">{{ seg.text }}</span>


### PR DESCRIPTION
Fixes #426.

## Problem

Drag-selecting a channel buffer for copy/paste **skipped every nick**, pasting blank gaps where the names should be:

```text
13:18:35
testing
13:18:40
[mansion]  cool
```

## Cause

The clickable-nick work (#238) put `user-select: none` on interactive nicks in `NickRef.vue`. That existed to stop a right-click from selecting the word under the cursor before the context menu opened (the selection fires on pointer-down, before `@contextmenu.prevent` can run). The side effect: nicks were excluded from any drag-selection, so copying the buffer dropped them all.

## Fix

Per discussion, nicks now open their member menu on **left-click / tap only** — the right-click (`@contextmenu`) handlers are removed, which makes the `user-select: none` workaround unnecessary, so it's gone too. Right-click falls back to normal browser behavior and nicks are selectable again.

- **`NickRef.vue`** — drop `user-select: none`, update the prop comment.
- **`MessageList.vue`** — remove the 14 `@contextmenu` nick handlers (author + join/part/quit/kick/rename/nick/mode/topic), keep `@click`. The bare `@contextmenu.stop.prevent` on the hover row-action buttons is unrelated and left alone.
- **`RenderSegments.vue`** — same for in-body @mention nicks.

## Verification

- `typecheck:client` ✅
- `lint` ✅ (only pre-existing test-file warnings)
- `format:check` ✅

Selection behavior is hard to assert in a unit test; worth a quick manual check (select across a few lines including nicks → paste).

🤖 Generated with [Claude Code](https://claude.com/claude-code)