### PR TITLE
Add CTCP support: /ctcp + /ping, auto-replies, reply display (#263)

### DIFF
--- a/server/services/ctcp.test.ts
+++ b/server/services/ctcp.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCtcpReply,
+  CTCP_SOURCE,
+  CTCP_SUPPORTED,
+  formatCtcpReplyLine,
+  formatCtcpRequestLine,
+  formatLatency,
+  parseCtcp,
+  pingReplyLatencyMs,
+} from './ctcp.js';
+import { IRC_VERSION } from '../utils/userAgent.js';
+
+describe('parseCtcp', () => {
+  it('splits type and args, uppercasing the type', () => {
+    expect(parseCtcp('VERSION')).toEqual({ type: 'VERSION', args: '' });
+    expect(parseCtcp('version')).toEqual({ type: 'VERSION', args: '' });
+    expect(parseCtcp('PING 1719500000000')).toEqual({ type: 'PING', args: '1719500000000' });
+  });
+
+  it('keeps spaces inside the args', () => {
+    expect(parseCtcp('PING 123 456')).toEqual({ type: 'PING', args: '123 456' });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseCtcp('  TIME  ')).toEqual({ type: 'TIME', args: '' });
+  });
+});
+
+describe('buildCtcpReply', () => {
+  const now = new Date('2026-06-27T14:03:11Z');
+
+  it('answers VERSION with the Lurker user-agent', () => {
+    expect(buildCtcpReply('VERSION', '', now)).toBe(IRC_VERSION);
+  });
+
+  it('answers SOURCE with the repo URL', () => {
+    expect(buildCtcpReply('SOURCE', '', now)).toBe(CTCP_SOURCE);
+  });
+
+  it('answers CLIENTINFO with the supported set', () => {
+    expect(buildCtcpReply('CLIENTINFO', '', now)).toBe(CTCP_SUPPORTED.join(' '));
+  });
+
+  it('answers TIME with a UTC string', () => {
+    expect(buildCtcpReply('TIME', '', now)).toBe(now.toUTCString());
+  });
+
+  it('echoes a PING payload verbatim', () => {
+    expect(buildCtcpReply('PING', '1719500000000', now)).toBe('1719500000000');
+  });
+
+  it('refuses an oversized PING payload (flood-amp guard)', () => {
+    expect(buildCtcpReply('PING', 'x'.repeat(101), now)).toBeNull();
+  });
+
+  it('is case-insensitive on the type', () => {
+    expect(buildCtcpReply('version', '', now)).toBe(IRC_VERSION);
+  });
+
+  it('returns null for an unsupported type (e.g. USERINFO/FINGER)', () => {
+    expect(buildCtcpReply('USERINFO', '', now)).toBeNull();
+    expect(buildCtcpReply('FINGER', '', now)).toBeNull();
+    expect(buildCtcpReply('DCC', 'SEND foo', now)).toBeNull();
+  });
+
+  it('advertises exactly the types it can answer (CLIENTINFO ⊇ answerable)', () => {
+    // ACTION is in the set for completeness (we send/receive it) but isn't a
+    // query; every OTHER advertised type must produce a non-null reply.
+    for (const t of CTCP_SUPPORTED) {
+      if (t === 'ACTION') continue;
+      expect(buildCtcpReply(t, '', now), `expected a reply for ${t}`).not.toBeNull();
+    }
+  });
+});
+
+describe('pingReplyLatencyMs', () => {
+  it('computes the delta from an echoed epoch-ms timestamp', () => {
+    expect(pingReplyLatencyMs('1000', 1123)).toBe(123);
+  });
+
+  it('uses only the first token (sec/usec style degrades to raw)', () => {
+    // "1 0" → first token 1, now 1234 → 1233ms, still within plausible window
+    expect(pingReplyLatencyMs('1000 500', 1500)).toBe(500);
+  });
+
+  it('rejects a non-numeric payload', () => {
+    expect(pingReplyLatencyMs('hello', 1000)).toBeNull();
+    expect(pingReplyLatencyMs('', 1000)).toBeNull();
+  });
+
+  it('rejects an implausible delta (future / >1h)', () => {
+    expect(pingReplyLatencyMs('2000', 1000)).toBeNull(); // negative
+    expect(pingReplyLatencyMs('0', 3_600_001)).toBeNull(); // > 1h
+  });
+});
+
+describe('formatLatency', () => {
+  it('renders seconds with 3 decimals', () => {
+    expect(formatLatency(123)).toBe('0.123s');
+    expect(formatLatency(1500)).toBe('1.500s');
+  });
+});
+
+describe('formatCtcpReplyLine', () => {
+  it('renders a generic reply with the data', () => {
+    expect(formatCtcpReplyLine('bob', 'VERSION', 'WeeChat 4.0', 0)).toBe(
+      'CTCP VERSION reply from bob: WeeChat 4.0',
+    );
+  });
+
+  it('renders a PING reply as a latency', () => {
+    expect(formatCtcpReplyLine('bob', 'PING', '1000', 1123)).toBe(
+      'CTCP PING reply from bob: 0.123s',
+    );
+  });
+
+  it('falls back to the raw PING payload when it is not our timestamp', () => {
+    expect(formatCtcpReplyLine('bob', 'PING', 'garbage', 1123)).toBe(
+      'CTCP PING reply from bob: garbage',
+    );
+  });
+
+  it('omits the colon when there is no data', () => {
+    expect(formatCtcpReplyLine('bob', 'CLIENTINFO', '', 0)).toBe('CTCP CLIENTINFO reply from bob');
+  });
+});
+
+describe('formatCtcpRequestLine', () => {
+  it('notes an answered probe', () => {
+    expect(formatCtcpRequestLine('bob', 'version', true)).toBe('bob requested CTCP VERSION');
+  });
+
+  it('flags an unanswered probe', () => {
+    expect(formatCtcpRequestLine('bob', 'finger', false)).toBe(
+      'bob requested CTCP FINGER (no reply)',
+    );
+  });
+});

--- a/server/services/ctcp.ts
+++ b/server/services/ctcp.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// CTCP (Client-To-Client Protocol) helpers — pure wire-format + display logic,
+// kept out of ircConnection so the parsing/reply rules are unit-testable on
+// their own. CTCP is the `\x01TYPE args\x01`-framed sub-protocol that rides
+// PRIVMSG (requests) and NOTICE (replies); ACTION (/me) is the one CTCP type
+// Lurker already handled as a normal message, the rest land here.
+//
+// References cloned for parity (see ~/Coding/irc-clients): irssi
+// (src/irc/core/ctcp.c — the auto-reply set + PING flood guard), WeeChat
+// (src/plugins/irc/irc-ctcp.c — CLIENTINFO/SOURCE/TIME templates), and The
+// Lounge (server/plugins/irc-events/ctcp.ts — the same irc-framework
+// `version:false` + manual-reply approach we use).
+
+import { IRC_VERSION } from '../utils/userAgent.js';
+
+/** Where Lurker's source lives — the CTCP SOURCE reply. */
+export const CTCP_SOURCE = 'https://github.com/amiantos/lurker';
+
+// The CTCP request types we auto-answer. CLIENTINFO advertises exactly this set
+// (ACTION included — we send/receive it as messages even though it isn't a
+// query). Keep in sync with buildCtcpReply's switch.
+export const CTCP_SUPPORTED = [
+  'ACTION',
+  'CLIENTINFO',
+  'PING',
+  'SOURCE',
+  'TIME',
+  'VERSION',
+] as const;
+
+// irssi parity (ctcp.c): refuse to echo back an oversized PING payload so a peer
+// can't turn our auto-reply into a reflection/flood amplifier.
+const PING_MAX_PAYLOAD = 100;
+
+// A sane CTCP PING round trip is well under an hour; anything outside [0, 1h] is
+// clock skew or a payload that wasn't our timestamp, so we show the raw reply
+// instead of a nonsense latency.
+const PING_MAX_PLAUSIBLE_MS = 3_600_000;
+
+/** Split a CTCP inner body (`"VERSION"` / `"PING 1719500000000"`) into an
+ *  upper-cased type and the remaining argument string. */
+export function parseCtcp(message: string): { type: string; args: string } {
+  const trimmed = message.trim();
+  const sp = trimmed.indexOf(' ');
+  if (sp === -1) return { type: trimmed.toUpperCase(), args: '' };
+  return { type: trimmed.slice(0, sp).toUpperCase(), args: trimmed.slice(sp + 1) };
+}
+
+/**
+ * Build the auto-reply argument string for an inbound CTCP request, or null when
+ * we don't answer this type. The returned value is the params AFTER the type;
+ * the caller frames it as `ctcpResponse(nick, type, reply)`.
+ */
+export function buildCtcpReply(type: string, args: string, now: Date): string | null {
+  switch (type.toUpperCase()) {
+    case 'VERSION':
+      return IRC_VERSION;
+    case 'SOURCE':
+      return CTCP_SOURCE;
+    case 'CLIENTINFO':
+      return CTCP_SUPPORTED.join(' ');
+    case 'TIME':
+      return formatCtcpTime(now);
+    case 'PING':
+      // Echo the payload verbatim (that's what makes round-trip timing work for
+      // the requester), but drop an abusive one.
+      if (args.length > PING_MAX_PAYLOAD) return null;
+      return args;
+    default:
+      return null;
+  }
+}
+
+/** Locale-free local-ish timestamp for a CTCP TIME reply (RFC-1123 / UTC). */
+export function formatCtcpTime(now: Date): string {
+  return now.toUTCString();
+}
+
+/**
+ * Latency in ms for an inbound CTCP PING *reply*, derived from the echoed
+ * payload (we send `PING <epoch-ms>`; a well-behaved peer echoes it back), or
+ * null if the payload isn't our timestamp / the delta is implausible. The first
+ * whitespace-token is used so a `sec usec` style payload degrades to "show raw"
+ * rather than misreporting.
+ */
+export function pingReplyLatencyMs(payload: string, nowMs: number): number | null {
+  const first = payload.trim().split(/\s+/)[0];
+  const t = Number(first);
+  if (!Number.isFinite(t) || first === '') return null;
+  const ms = nowMs - t;
+  if (ms < 0 || ms > PING_MAX_PLAUSIBLE_MS) return null;
+  return ms;
+}
+
+/** Render a latency as seconds with 3 decimals ("0.123s"), like irssi/WeeChat. */
+export function formatLatency(ms: number): string {
+  return `${(ms / 1000).toFixed(3)}s`;
+}
+
+/** Display line for an inbound CTCP *reply* (someone answered our query).
+ *  `nowMs` lets PING report a round-trip latency from the echoed timestamp. */
+export function formatCtcpReplyLine(
+  nick: string,
+  type: string,
+  args: string,
+  nowMs: number,
+): string {
+  const t = type.toUpperCase();
+  if (t === 'PING') {
+    const ms = pingReplyLatencyMs(args, nowMs);
+    if (ms != null) return `CTCP PING reply from ${nick}: ${formatLatency(ms)}`;
+  }
+  const tail = args ? `: ${args}` : '';
+  return `CTCP ${t} reply from ${nick}${tail}`;
+}
+
+/** Display line for an inbound CTCP *request* (someone probed us). */
+export function formatCtcpRequestLine(nick: string, type: string, answered: boolean): string {
+  const suffix = answered ? '' : ' (no reply)';
+  return `${nick} requested CTCP ${type.toUpperCase()}${suffix}`;
+}

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -122,6 +122,19 @@ describe('inbound CTCP request (auto-reply + surface)', () => {
     // CTCP_REPLY_BURST = 5; all fire within the same ms so no token refills.
     expect(ctcpResponse).toHaveBeenCalledTimes(5);
   });
+
+  it('a malformed (empty) CTCP does not drain the reply budget', () => {
+    const { conn, ctcpResponse } = harness();
+    // Empty-body CTCPs (\x01\x01) parse to no type — they must be rejected
+    // BEFORE a token is taken, or a peer could starve real replies.
+    for (let i = 0; i < 20; i++) {
+      conn.client.emit('ctcp request', { nick: 'bob', type: '', message: '' });
+    }
+    expect(ctcpResponse).not.toHaveBeenCalled();
+    // A real VERSION afterward is still answered — the budget is intact.
+    conn.client.emit('ctcp request', { nick: 'bob', type: 'VERSION', message: 'VERSION' });
+    expect(ctcpResponse).toHaveBeenCalledWith('bob', 'VERSION', IRC_VERSION);
+  });
 });
 
 describe('outbound CTCP request (/ctcp, /ping)', () => {

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// CTCP wiring (#263): the glue between live IRC traffic and our CTCP handling on
+// IrcConnection. The wire-format + reply rules are unit-pinned in ctcp.test.ts;
+// these exercise the PLUMBING — does an inbound request auto-reply over NOTICE
+// and surface a status line; does an inbound reply route back to the issuing
+// buffer with a PING latency; does an outbound /ctcp frame + echo; do the flood
+// guard and self-echo / RPEE2E guards hold.
+
+// MUST be first — redirect DATABASE_PATH before the static imports below open
+// the real data/lurker.db.
+import '../test-utils/isolateDb.js';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { IrcConnection } from './ircConnection.js';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import { IRC_VERSION } from '../utils/userAgent.js';
+
+beforeAll(() => {
+  createUser('ctcp-alice'); // id 1
+  createNetwork(1, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'alice' }); // network id 1
+});
+
+function makeConn(): IrcConnection {
+  return new IrcConnection({
+    network: {
+      id: 1,
+      user_id: 1,
+      name: 'n',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'alice',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 1,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+      position: 0,
+      created_at: new Date().toISOString(),
+    },
+    onEvent: () => {},
+  });
+}
+
+// Spy the wire + publish seams on a freshly-built connection.
+function harness() {
+  const conn = makeConn();
+  const ctcpRequest = vi.fn<(target: string, type: string, ...p: string[]) => void>();
+  const ctcpResponse = vi.fn<(target: string, type: string, ...p: string[]) => void>();
+  const publishEphemeral = vi.fn<(event: Record<string, unknown>) => void>();
+  conn.client.ctcpRequest = ctcpRequest;
+  conn.client.ctcpResponse = ctcpResponse;
+  conn.publishEphemeral = publishEphemeral;
+  const ctcpLines = () =>
+    publishEphemeral.mock.calls.map((c) => c[0]).filter((e) => e.type === 'ctcp') as Array<{
+      target: string;
+      text: string;
+    }>;
+  return { conn, ctcpRequest, ctcpResponse, publishEphemeral, ctcpLines };
+}
+
+describe('inbound CTCP request (auto-reply + surface)', () => {
+  it('answers VERSION with the Lurker user-agent and notes the probe', () => {
+    const { conn, ctcpResponse, ctcpLines } = harness();
+
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      type: 'VERSION',
+      message: 'VERSION',
+    });
+
+    expect(ctcpResponse).toHaveBeenCalledWith('bob', 'VERSION', IRC_VERSION);
+    const lines = ctcpLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].target).toBe(':server:1'); // probes land in the server buffer
+    expect(lines[0].text).toBe('bob requested CTCP VERSION');
+  });
+
+  it('echoes a PING payload back verbatim', () => {
+    const { conn, ctcpResponse } = harness();
+    conn.client.emit('ctcp request', { nick: 'bob', type: 'PING', message: 'PING 1719500000000' });
+    expect(ctcpResponse).toHaveBeenCalledWith('bob', 'PING', '1719500000000');
+  });
+
+  it('does not reply to an unsupported type but still shows the probe', () => {
+    const { conn, ctcpResponse, ctcpLines } = harness();
+    conn.client.emit('ctcp request', { nick: 'bob', type: 'USERINFO', message: 'USERINFO' });
+    expect(ctcpResponse).not.toHaveBeenCalled();
+    expect(ctcpLines()[0].text).toBe('bob requested CTCP USERINFO (no reply)');
+  });
+
+  it('ignores our own request echoed back by an echo-message server', () => {
+    const { conn, ctcpResponse, publishEphemeral } = harness();
+    conn.client.emit('ctcp request', { nick: 'alice', type: 'VERSION', message: 'VERSION' });
+    expect(ctcpResponse).not.toHaveBeenCalled();
+    expect(publishEphemeral).not.toHaveBeenCalled();
+  });
+
+  it('never treats an RPEE2E PRIVMSG as a standard CTCP query', () => {
+    const { conn, ctcpResponse, publishEphemeral } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      type: 'RPEE2E',
+      message: 'RPEE2E KEYREQ v=1 c=#x',
+    });
+    expect(ctcpResponse).not.toHaveBeenCalled();
+    expect(publishEphemeral).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits a flood of requests to the burst budget', () => {
+    const { conn, ctcpResponse } = harness();
+    for (let i = 0; i < 10; i++) {
+      conn.client.emit('ctcp request', { nick: 'bob', type: 'VERSION', message: 'VERSION' });
+    }
+    // CTCP_REPLY_BURST = 5; all fire within the same ms so no token refills.
+    expect(ctcpResponse).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe('outbound CTCP request (/ctcp, /ping)', () => {
+  it('frames a /ctcp VERSION and echoes it to the issuing buffer', () => {
+    const { conn, ctcpRequest, ctcpLines } = harness();
+    conn.sendCtcpRequest('#chan', 'bob', 'VERSION', '');
+    expect(ctcpRequest).toHaveBeenCalledWith('bob', 'VERSION');
+    const lines = ctcpLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ target: '#chan', text: '→ CTCP VERSION to bob' });
+  });
+
+  it('auto-fills a bare PING with an epoch-ms timestamp payload', () => {
+    const { conn, ctcpRequest } = harness();
+    conn.sendCtcpRequest('bob', 'bob', 'PING', '');
+    expect(ctcpRequest).toHaveBeenCalledTimes(1);
+    const [target, type, payload] = ctcpRequest.mock.calls[0];
+    expect(target).toBe('bob');
+    expect(type).toBe('PING');
+    expect(Number.isFinite(Number(payload))).toBe(true);
+  });
+
+  it('uppercases an arbitrary lowercase type', () => {
+    const { conn, ctcpRequest } = harness();
+    conn.sendCtcpRequest('#chan', 'bob', 'time', '');
+    expect(ctcpRequest).toHaveBeenCalledWith('bob', 'TIME');
+  });
+});
+
+describe('inbound CTCP reply (route + latency)', () => {
+  it('routes a reply back to the buffer the request was issued from', () => {
+    const { conn, ctcpResponse, ctcpLines } = harness();
+    conn.sendCtcpRequest('#chan', 'bob', 'VERSION', '');
+    conn.client.emit('ctcp response', {
+      nick: 'bob',
+      type: 'VERSION',
+      message: 'VERSION WeeChat 4.0',
+    });
+    expect(ctcpResponse).not.toHaveBeenCalled(); // we never reply to a reply
+    const reply = ctcpLines().find((l) => l.text.includes('reply'));
+    expect(reply?.target).toBe('#chan');
+    expect(reply?.text).toBe('CTCP VERSION reply from bob: WeeChat 4.0');
+  });
+
+  it('reports PING round-trip latency from the echoed timestamp', () => {
+    const { conn, ctcpRequest, ctcpLines } = harness();
+    conn.sendCtcpRequest('#chan', 'bob', 'PING', '');
+    const ts = ctcpRequest.mock.calls[0][2] as string; // the auto-filled epoch-ms payload
+    conn.client.emit('ctcp response', { nick: 'bob', type: 'PING', message: `PING ${ts}` });
+    const reply = ctcpLines().find((l) => l.text.includes('PING reply'));
+    expect(reply?.target).toBe('#chan');
+    expect(reply?.text).toMatch(/^CTCP PING reply from bob: \d+\.\d{3}s$/);
+  });
+
+  it('falls back to the server buffer for an unsolicited reply', () => {
+    const { conn, ctcpLines } = harness();
+    conn.client.emit('ctcp response', {
+      nick: 'bob',
+      type: 'VERSION',
+      message: 'VERSION Unsolicited',
+    });
+    const reply = ctcpLines().find((l) => l.text.includes('reply'));
+    expect(reply?.target).toBe(':server:1');
+  });
+});

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -114,25 +114,65 @@ describe('inbound CTCP request (auto-reply + surface)', () => {
     expect(publishEphemeral).not.toHaveBeenCalled();
   });
 
-  it('rate-limits a flood of requests to the burst budget', () => {
+  it('rate-limits a flood of requests from one peer (per-peer limiter)', () => {
     const { conn, ctcpResponse } = harness();
     for (let i = 0; i < 10; i++) {
-      conn.client.emit('ctcp request', { nick: 'bob', type: 'VERSION', message: 'VERSION' });
+      conn.client.emit('ctcp request', {
+        nick: 'bob',
+        ident: 'b',
+        hostname: 'h',
+        type: 'VERSION',
+        message: 'VERSION',
+      });
     }
-    // CTCP_REPLY_BURST = 5; all fire within the same ms so no token refills.
-    expect(ctcpResponse).toHaveBeenCalledTimes(5);
+    // The shared e2e RateLimiter allows 3 per peer per 60s window, then backoff.
+    expect(ctcpResponse).toHaveBeenCalledTimes(3);
   });
 
-  it('a malformed (empty) CTCP does not drain the reply budget', () => {
+  it('one peer flooding does not suppress replies to a different peer', () => {
     const { conn, ctcpResponse } = harness();
-    // Empty-body CTCPs (\x01\x01) parse to no type — they must be rejected
-    // BEFORE a token is taken, or a peer could starve real replies.
+    for (let i = 0; i < 10; i++) {
+      conn.client.emit('ctcp request', {
+        nick: 'flood',
+        ident: 'f',
+        hostname: 'h',
+        type: 'VERSION',
+        message: 'VERSION',
+      });
+    }
+    conn.client.emit('ctcp request', {
+      nick: 'carol',
+      ident: 'c',
+      hostname: 'h',
+      type: 'VERSION',
+      message: 'VERSION',
+    });
+    // carol's bucket is independent of flood's — she still gets answered.
+    expect(ctcpResponse).toHaveBeenCalledWith('carol', 'VERSION', IRC_VERSION);
+  });
+
+  it('a malformed (empty) CTCP does not consume a peer rate-limit slot', () => {
+    const { conn, ctcpResponse } = harness();
+    // Empty-body CTCPs (\x01\x01) parse to no type — rejected BEFORE the limiter
+    // records the peer, so they can't burn the budget and starve real probes.
     for (let i = 0; i < 20; i++) {
-      conn.client.emit('ctcp request', { nick: 'bob', type: '', message: '' });
+      conn.client.emit('ctcp request', {
+        nick: 'bob',
+        ident: 'b',
+        hostname: 'h',
+        type: '',
+        message: '',
+      });
     }
     expect(ctcpResponse).not.toHaveBeenCalled();
     // A real VERSION afterward is still answered — the budget is intact.
-    conn.client.emit('ctcp request', { nick: 'bob', type: 'VERSION', message: 'VERSION' });
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      type: 'VERSION',
+      message: 'VERSION',
+    });
     expect(ctcpResponse).toHaveBeenCalledWith('bob', 'VERSION', IRC_VERSION);
   });
 });
@@ -198,5 +238,61 @@ describe('inbound CTCP reply (route + latency)', () => {
     });
     const reply = ctcpLines().find((l) => l.text.includes('reply'));
     expect(reply?.target).toBe(':server:1');
+  });
+
+  it('FIFO-routes concurrent same-type replies to the buffers in order (#11)', () => {
+    const { conn, ctcpLines } = harness();
+    conn.sendCtcpRequest('#chan1', 'bob', 'VERSION', '');
+    conn.sendCtcpRequest('#chan2', 'bob', 'VERSION', '');
+    conn.client.emit('ctcp response', { nick: 'bob', type: 'VERSION', message: 'VERSION first' });
+    conn.client.emit('ctcp response', { nick: 'bob', type: 'VERSION', message: 'VERSION second' });
+    const replies = ctcpLines().filter((l) => l.text.includes('reply'));
+    expect(replies.map((r) => r.target)).toEqual(['#chan1', '#chan2']);
+  });
+
+  it('rate-limits an UNSOLICITED reply flood but never a solicited reply', () => {
+    const { conn, ctcpLines } = harness();
+    // Unsolicited (no outstanding request): per-peer limiter caps at 3/window.
+    for (let i = 0; i < 10; i++) {
+      conn.client.emit('ctcp response', {
+        nick: 'mal',
+        ident: 'm',
+        hostname: 'h',
+        type: 'VERSION',
+        message: 'VERSION x',
+      });
+    }
+    expect(ctcpLines().filter((l) => l.text.includes('reply'))).toHaveLength(3);
+
+    // Solicited replies (matching outstanding /ctcp) bypass the limiter entirely,
+    // so a burst of our own queries to one peer all surface.
+    const { conn: conn2, ctcpLines: lines2 } = harness();
+    for (let i = 0; i < 6; i++) conn2.sendCtcpRequest('#chan', 'bob', 'VERSION', '');
+    for (let i = 0; i < 6; i++) {
+      conn2.client.emit('ctcp response', { nick: 'bob', type: 'VERSION', message: 'VERSION ok' });
+    }
+    expect(lines2().filter((l) => l.text.includes('reply'))).toHaveLength(6);
+  });
+
+  it('does not surface a lowercase rpee2e NOTICE as a CTCP reply (#13)', () => {
+    const { conn, ctcpLines } = harness();
+    // Response types are raw-case; a lowercase rpee2e must route to the E2E path
+    // (which won't parse it), not surface a bogus "CTCP rpee2e reply" line.
+    conn.client.emit('ctcp response', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      type: 'rpee2e',
+      message: 'rpee2e KEYREQ v=1 c=#x',
+    });
+    expect(ctcpLines()).toHaveLength(0);
+  });
+
+  it('clears CTCP routing/limit state on socket close (#8)', () => {
+    const { conn } = harness();
+    conn.sendCtcpRequest('#chan', 'bob', 'VERSION', '');
+    expect(conn.ctcpOutstanding.size).toBe(1);
+    conn.client.emit('close');
+    expect(conn.ctcpOutstanding.size).toBe(0);
   });
 });

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -305,7 +305,7 @@ export class IrcConnection {
   ctcpReplyTokens: number;
   ctcpReplyRefillAt: number;
   // Outstanding outbound CTCP requests we sent, so a reply routes back to the
-  // buffer the /ctcp was issued from. Key = `${nick-lc} ${TYPE}` → the
+  // buffer the /ctcp was issued from. Key = `${nick-lc} ${TYPE}` → the
   // issuing buffer + send time. Bounded + TTL-pruned on access.
   ctcpOutstanding: Map<string, { issuingTarget: string; sentAt: number }>;
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2372,12 +2372,13 @@ export class IrcConnection {
     const nick = event.nick as string | undefined;
     // Our own outbound CTCP echoed back by an echo-message server — not a probe.
     if (!nick || this.isSelfNick(nick)) return;
-    const now = Date.now();
-    // Flood guard gates the whole handler (reply AND display), so a CTCP flood
-    // can neither make us spew NOTICEs nor spam the buffer.
-    if (!this.takeCtcpToken(now)) return;
     const { type, args } = parseCtcp(String(event.message ?? ''));
     if (!type) return;
+    const now = Date.now();
+    // Flood guard gates the whole handler (reply AND display), so a CTCP flood
+    // can neither make us spew NOTICEs nor spam the buffer. Checked AFTER parsing
+    // so a malformed/empty CTCP can't drain the bucket and starve real replies.
+    if (!this.takeCtcpToken(now)) return;
     const reply = buildCtcpReply(type, args, new Date(now));
     if (reply !== null) this.client.ctcpResponse(nick, type, reply);
     this.surfaceCtcp(this.serverTarget(), formatCtcpRequestLine(nick, type, reply !== null));

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -33,6 +33,7 @@ import type { UserNotice } from './e2e/manager.js';
 import { contextKey, isChannelContext } from './e2e/context.js';
 import { CTCP_TAG, WIRE_PREFIX } from './e2e/constants.js';
 import { e2eDbg } from './e2e/debug.js';
+import { RateLimiter } from './e2e/rateLimiter.js';
 import { buildCtcpReply, formatCtcpReplyLine, formatCtcpRequestLine, parseCtcp } from './ctcp.js';
 import { getChannelConfig as getE2eChannelConfig } from '../db/e2e.js';
 import type { ChannelMode } from '../db/e2e.js';
@@ -73,15 +74,11 @@ const NON_PERSISTED_TYPES = new Set([
   'ctcp',
 ]);
 
-// CTCP auto-reply rate limit (anti-flood). Burst of 5, refilling one token every
-// 2s — generous for honest probes, but a sustained flood drains it and gets
-// dropped (The Lounge throttles the whole handler to ~1/s; this is a kinder
-// burst-tolerant equivalent).
-const CTCP_REPLY_BURST = 5;
-const CTCP_REPLY_REFILL_MS = 2000;
 // Forget an outbound CTCP request we never got a reply to after a minute, so the
 // routing map can't grow unbounded.
 const CTCP_OUTSTANDING_TTL_MS = 60_000;
+// Cap distinct outstanding (nick,type) keys; evict the oldest when exceeded.
+const CTCP_OUTSTANDING_MAX_KEYS = 200;
 
 // How recently the user must have sent a real message to a target for a send
 // rejection (404/477/531) to be attributed to that message and surfaced inline.
@@ -298,26 +295,29 @@ export class IrcConnection {
   // so far; flushed as one reassembled message on 'batch end draft/multiline'
   // and cleared on socket close so a never-closed batch can't leak. (#381)
   multilineBatches: Map<string, { event: Record<string, unknown>; text: string }>;
-  // Token bucket gating CTCP auto-replies so a peer flooding us with CTCP
-  // requests can't make the cell spew NOTICEs (and get the user flood-killed).
-  // Refills one token every CTCP_REPLY_REFILL_MS up to CTCP_REPLY_BURST; an
-  // over-budget request is dropped silently (no reply, no display).
-  ctcpReplyTokens: number;
-  ctcpReplyRefillAt: number;
+  // Per-peer rate limiter for inbound CTCP (requests AND replies). Being
+  // per-peer, one flooding peer can't make the cell spew NOTICEs, spam the
+  // buffer, OR suppress CTCP from everyone else — it only exhausts its own
+  // bucket. Reuses the same limiter the E2E handshake path uses for the
+  // identical inbound-flood threat.
+  ctcpLimiter: RateLimiter;
   // Outstanding outbound CTCP requests we sent, so a reply routes back to the
-  // buffer the /ctcp was issued from. Key = `${nick-lc} ${TYPE}` → the
-  // issuing buffer + send time. Bounded + TTL-pruned on access.
-  ctcpOutstanding: Map<string, { issuingTarget: string; sentAt: number }>;
+  // buffer the /ctcp was issued from. Key = `${nick-lc} ${TYPE}` → a FIFO queue
+  // of issuing buffers, so two concurrent same-type queries to one nick route
+  // their replies back in order. Bounded + TTL-pruned on access.
+  ctcpOutstanding: Map<string, Array<{ issuingTarget: string; sentAt: number }>>;
 
   constructor({ network, onEvent }: { network: Network; onEvent: (event: EnrichedEvent) => void }) {
     this.network = network;
     this.onEvent = onEvent;
-    // `version: false` disables irc-framework's built-in CTCP VERSION
-    // auto-reply so ALL CTCP handling lives in one place — our 'ctcp request'
-    // handler (which answers VERSION with IRC_VERSION, plus PING/TIME/SOURCE/
-    // CLIENTINFO), rate-limited and surfaced to the user. This mirrors The
-    // Lounge, which uses the same library the same way. See services/ctcp.ts.
-    this.client = new IRC.Client({ version: false });
+    // ALL CTCP handling lives in our 'ctcp request' handler (VERSION/PING/TIME/
+    // SOURCE/CLIENTINFO, rate-limited + surfaced), so irc-framework's built-in
+    // VERSION auto-reply is disabled with `version: false`. That MUST go in the
+    // connect() dict, NOT here: connect() overwrites client.options with its dict
+    // (client.js:202), so a constructor `version` doesn't survive — exactly the
+    // pitfall the enable_chghost note on the connect() call documents. Mirrors
+    // The Lounge, which uses the same library the same way. See services/ctcp.ts.
+    this.client = new IRC.Client();
     this.client.requestCap('message-tags');
     // extended-monitor (IRCv3): asks the server to relay away-notify (and the
     // other notify caps irc-framework already negotiates) for nicks on our
@@ -383,8 +383,7 @@ export class IrcConnection {
     this.lastUserSendAt = new Map();
     this.autoWhoTargets = new Set();
     this.multilineBatches = new Map();
-    this.ctcpReplyTokens = CTCP_REPLY_BURST;
-    this.ctcpReplyRefillAt = 0;
+    this.ctcpLimiter = new RateLimiter();
     this.ctcpOutstanding = new Map();
     this.bind();
   }
@@ -753,6 +752,11 @@ export class IrcConnection {
       this.userModes.clear();
       this.autoWhoTargets.clear();
       this.multilineBatches.clear();
+      // CTCP routing/limit state is per-socket: a stale outstanding entry would
+      // mis-route a same-type reply on the new socket, and a drained limiter
+      // would drop the new socket's first probes. Reset both (#263).
+      this.ctcpOutstanding.clear();
+      this.ctcpLimiter = new RateLimiter();
       this.stopLagPinger();
       this.cancelPendingConnectCommands();
       this.lagMs = null;
@@ -1212,7 +1216,11 @@ export class IrcConnection {
         () =>
           `ctcp-response from ${event.nick}!${event.ident}@${event.hostname} type=${event.type} body=${String(event.message).slice(0, 140)}`,
       );
-      if (event.type !== CTCP_TAG) {
+      // Response `event.type` is raw-case (the library uppercases request types
+      // but not response types), so compare case-insensitively — otherwise a
+      // lowercase `rpee2e` NOTICE would slip past and surface as a bogus CTCP
+      // reply line instead of routing to the E2E path.
+      if (String(event.type).toUpperCase() !== CTCP_TAG) {
         // A standard CTCP reply (VERSION/PING/TIME/…) — someone answered a query
         // we sent. Surface it; RPE2E claims only the RPEE2E tag.
         this.handleInboundCtcpReply(event);
@@ -2289,6 +2297,12 @@ export class IrcConnection {
       account,
       auto_reconnect: true,
       auto_reconnect_max_retries: 0,
+      // Disable irc-framework's built-in CTCP VERSION auto-reply so our own
+      // handler owns VERSION (#263). Like enable_chghost below, this MUST ride
+      // the connect() dict — connect() overwrites client.options, so a
+      // constructor value is lost and `version` falls back to the truthy default
+      // 'node.js irc-framework'. See client.js:202 + _applyDefaultOptions.
+      version: false,
       // Request the `chghost` cap so SASL-cloaked vhost changes (Libera et al.)
       // arrive as CHGHOST events instead of silently. Must go through connect()
       // — irc-framework overwrites client.options with this dict, so passing
@@ -2337,26 +2351,29 @@ export class IrcConnection {
     return !!nick && !!this.currentNick && nick.toLowerCase() === this.currentNick.toLowerCase();
   }
 
-  // Token bucket for CTCP auto-replies (anti-flood). Returns false when over
-  // budget — the caller then drops the request entirely (no reply, no display).
-  private takeCtcpToken(now: number): boolean {
-    if (this.ctcpReplyRefillAt === 0) this.ctcpReplyRefillAt = now;
-    const refill = Math.floor((now - this.ctcpReplyRefillAt) / CTCP_REPLY_REFILL_MS);
-    if (refill > 0) {
-      this.ctcpReplyTokens = Math.min(CTCP_REPLY_BURST, this.ctcpReplyTokens + refill);
-      this.ctcpReplyRefillAt += refill * CTCP_REPLY_REFILL_MS;
-    }
-    if (this.ctcpReplyTokens <= 0) return false;
-    this.ctcpReplyTokens -= 1;
-    return true;
+  // A stable per-peer key for rate limiting inbound CTCP: the sender's
+  // ident@host when known, else the nick (lowercased). Mirrors how the E2E path
+  // keys peers, so a nick-churning flooder still maps to bounded state.
+  private ctcpPeerKey(event: Record<string, unknown>): string {
+    const ident = (event.ident as string) || '';
+    const host = (event.hostname as string) || '';
+    const nick = (event.nick as string) || '';
+    return (ident && host ? `${ident}@${host}` : nick).toLowerCase();
   }
 
   private pruneCtcpOutstanding(now: number): void {
-    for (const [k, v] of this.ctcpOutstanding) {
-      if (now - v.sentAt > CTCP_OUTSTANDING_TTL_MS) this.ctcpOutstanding.delete(k);
+    for (const [k, queue] of this.ctcpOutstanding) {
+      const live = queue.filter((e) => now - e.sentAt <= CTCP_OUTSTANDING_TTL_MS);
+      if (live.length === 0) this.ctcpOutstanding.delete(k);
+      else if (live.length !== queue.length) this.ctcpOutstanding.set(k, live);
     }
-    // Backstop: a flood of un-replied requests shouldn't grow the map forever.
-    if (this.ctcpOutstanding.size > 200) this.ctcpOutstanding.clear();
+    // Backstop: evict the OLDEST keys (Map preserves insertion order) rather than
+    // flushing everything, so a burst past the cap doesn't lose ALL routing.
+    while (this.ctcpOutstanding.size > CTCP_OUTSTANDING_MAX_KEYS) {
+      const oldest = this.ctcpOutstanding.keys().next().value;
+      if (oldest === undefined) break;
+      this.ctcpOutstanding.delete(oldest);
+    }
   }
 
   // A CTCP status line (request probe, reply, or outbound echo). Transient
@@ -2366,38 +2383,51 @@ export class IrcConnection {
   }
 
   // Auto-answer an inbound CTCP request (VERSION/PING/TIME/CLIENTINFO/SOURCE)
-  // and show the user they were probed. Rate-limited; self-echoes ignored.
+  // and show the user they were probed. Self-echoes ignored; rate-limited
+  // per-peer so a flood from one nick can't spew NOTICEs, spam the buffer, or
+  // starve replies to other peers.
   handleInboundCtcpRequest(event: Record<string, unknown>): void {
     if (this.disposed) return;
     const nick = event.nick as string | undefined;
     // Our own outbound CTCP echoed back by an echo-message server — not a probe.
     if (!nick || this.isSelfNick(nick)) return;
     const { type, args } = parseCtcp(String(event.message ?? ''));
+    // Parse + validate BEFORE the rate-limit check so a malformed/empty CTCP
+    // can't burn a peer's budget and suppress its legitimate probes.
     if (!type) return;
-    const now = Date.now();
-    // Flood guard gates the whole handler (reply AND display), so a CTCP flood
-    // can neither make us spew NOTICEs nor spam the buffer. Checked AFTER parsing
-    // so a malformed/empty CTCP can't drain the bucket and starve real replies.
-    if (!this.takeCtcpToken(now)) return;
-    const reply = buildCtcpReply(type, args, new Date(now));
+    if (!this.ctcpLimiter.allowIncoming(this.ctcpPeerKey(event))) return;
+    const reply = buildCtcpReply(type, args, new Date());
     if (reply !== null) this.client.ctcpResponse(nick, type, reply);
     this.surfaceCtcp(this.serverTarget(), formatCtcpRequestLine(nick, type, reply !== null));
   }
 
   // Surface an inbound CTCP reply (a peer answered a query we sent), routed back
-  // to the buffer the /ctcp was issued from when we still remember it.
+  // to the buffer the /ctcp was issued from. A SOLICITED reply (matches an
+  // outstanding request) always shows; an UNSOLICITED one is rate-limited
+  // per-peer so a NOTICE flood can't spam the buffer.
   handleInboundCtcpReply(event: Record<string, unknown>): void {
     if (this.disposed) return;
     const nick = event.nick as string | undefined;
     if (!nick || this.isSelfNick(nick)) return;
-    const now = Date.now();
     const { type, args } = parseCtcp(String(event.message ?? ''));
     if (!type) return;
+    const now = Date.now();
     this.pruneCtcpOutstanding(now);
     const key = this.ctcpKey(nick, type);
-    const pending = this.ctcpOutstanding.get(key);
-    if (pending) this.ctcpOutstanding.delete(key);
-    const target = pending?.issuingTarget ?? this.serverTarget();
+    const queue = this.ctcpOutstanding.get(key);
+    const pending = queue?.shift(); // FIFO: the oldest matching query
+    if (queue && queue.length === 0) this.ctcpOutstanding.delete(key);
+    if (!pending && !this.ctcpLimiter.allowIncoming(this.ctcpPeerKey(event))) return;
+    let target = pending?.issuingTarget ?? this.serverTarget();
+    // The issuing buffer may have been closed while the reply was in flight — a
+    // wsHub guard discards ephemeral events to a closed buffer, so don't lose the
+    // answer: fall back to the server buffer.
+    if (
+      target !== this.serverTarget() &&
+      isBufferClosed(this.network.user_id, this.network.id, target)
+    ) {
+      target = this.serverTarget();
+    }
     this.surfaceCtcp(target, formatCtcpReplyLine(nick, type, args, now));
   }
 
@@ -2416,7 +2446,10 @@ export class IrcConnection {
     if (payload) this.client.ctcpRequest(target, t, payload);
     else this.client.ctcpRequest(target, t);
     this.pruneCtcpOutstanding(now);
-    this.ctcpOutstanding.set(this.ctcpKey(target, t), { issuingTarget: issuing, sentAt: now });
+    const key = this.ctcpKey(target, t);
+    const queue = this.ctcpOutstanding.get(key) ?? [];
+    queue.push({ issuingTarget: issuing, sentAt: now });
+    this.ctcpOutstanding.set(key, queue);
     this.surfaceCtcp(issuing, `→ CTCP ${t} to ${target}`);
   }
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -21,7 +21,7 @@ import ignoreRulesService from './ignoreRulesService.js';
 import { decideStamp } from './insertDecisions.js';
 import * as systemLog from './systemLog.js';
 import { effectiveSetting } from './settingsService.js';
-import { IRC_VERSION, APP_VERSION } from '../utils/userAgent.js';
+import { APP_VERSION } from '../utils/userAgent.js';
 import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent } from '../utils/ident.js';
@@ -33,6 +33,7 @@ import type { UserNotice } from './e2e/manager.js';
 import { contextKey, isChannelContext } from './e2e/context.js';
 import { CTCP_TAG, WIRE_PREFIX } from './e2e/constants.js';
 import { e2eDbg } from './e2e/debug.js';
+import { buildCtcpReply, formatCtcpReplyLine, formatCtcpRequestLine, parseCtcp } from './ctcp.js';
 import { getChannelConfig as getE2eChannelConfig } from '../db/e2e.js';
 import type { ChannelMode } from '../db/e2e.js';
 import { randomBytes } from 'node:crypto';
@@ -67,7 +68,20 @@ const NON_PERSISTED_TYPES = new Set([
   // RPE2E status lines are transient echoes (like /help output), surfaced via
   // publishEphemeral — never write them to history (#382).
   'e2e',
+  // CTCP request/reply notices are transient status, surfaced via
+  // publishEphemeral — never persisted (#263).
+  'ctcp',
 ]);
+
+// CTCP auto-reply rate limit (anti-flood). Burst of 5, refilling one token every
+// 2s — generous for honest probes, but a sustained flood drains it and gets
+// dropped (The Lounge throttles the whole handler to ~1/s; this is a kinder
+// burst-tolerant equivalent).
+const CTCP_REPLY_BURST = 5;
+const CTCP_REPLY_REFILL_MS = 2000;
+// Forget an outbound CTCP request we never got a reply to after a minute, so the
+// routing map can't grow unbounded.
+const CTCP_OUTSTANDING_TTL_MS = 60_000;
 
 // How recently the user must have sent a real message to a target for a send
 // rejection (404/477/531) to be attributed to that message and surfaced inline.
@@ -284,15 +298,26 @@ export class IrcConnection {
   // so far; flushed as one reassembled message on 'batch end draft/multiline'
   // and cleared on socket close so a never-closed batch can't leak. (#381)
   multilineBatches: Map<string, { event: Record<string, unknown>; text: string }>;
+  // Token bucket gating CTCP auto-replies so a peer flooding us with CTCP
+  // requests can't make the cell spew NOTICEs (and get the user flood-killed).
+  // Refills one token every CTCP_REPLY_REFILL_MS up to CTCP_REPLY_BURST; an
+  // over-budget request is dropped silently (no reply, no display).
+  ctcpReplyTokens: number;
+  ctcpReplyRefillAt: number;
+  // Outstanding outbound CTCP requests we sent, so a reply routes back to the
+  // buffer the /ctcp was issued from. Key = `${nick-lc} ${TYPE}` → the
+  // issuing buffer + send time. Bounded + TTL-pruned on access.
+  ctcpOutstanding: Map<string, { issuingTarget: string; sentAt: number }>;
 
   constructor({ network, onEvent }: { network: Network; onEvent: (event: EnrichedEvent) => void }) {
     this.network = network;
     this.onEvent = onEvent;
-    // `version` is the string irc-framework returns in response to CTCP
-    // VERSION queries — without this, peers see the library's default
-    // "node.js irc-framework". Identifying as Lurker lets server operators
-    // tell our traffic apart from generic library bots.
-    this.client = new IRC.Client({ version: IRC_VERSION });
+    // `version: false` disables irc-framework's built-in CTCP VERSION
+    // auto-reply so ALL CTCP handling lives in one place — our 'ctcp request'
+    // handler (which answers VERSION with IRC_VERSION, plus PING/TIME/SOURCE/
+    // CLIENTINFO), rate-limited and surfaced to the user. This mirrors The
+    // Lounge, which uses the same library the same way. See services/ctcp.ts.
+    this.client = new IRC.Client({ version: false });
     this.client.requestCap('message-tags');
     // extended-monitor (IRCv3): asks the server to relay away-notify (and the
     // other notify caps irc-framework already negotiates) for nicks on our
@@ -358,6 +383,9 @@ export class IrcConnection {
     this.lastUserSendAt = new Map();
     this.autoWhoTargets = new Set();
     this.multilineBatches = new Map();
+    this.ctcpReplyTokens = CTCP_REPLY_BURST;
+    this.ctcpReplyRefillAt = 0;
+    this.ctcpOutstanding = new Map();
     this.bind();
   }
 
@@ -1184,7 +1212,12 @@ export class IrcConnection {
         () =>
           `ctcp-response from ${event.nick}!${event.ident}@${event.hostname} type=${event.type} body=${String(event.message).slice(0, 140)}`,
       );
-      if (event.type !== CTCP_TAG) return;
+      if (event.type !== CTCP_TAG) {
+        // A standard CTCP reply (VERSION/PING/TIME/…) — someone answered a query
+        // we sent. Surface it; RPE2E claims only the RPEE2E tag.
+        this.handleInboundCtcpReply(event);
+        return;
+      }
       const senderNick = (event.nick as string) || null;
       const senderHandle = buildE2eHandle(event);
       const body = event.message as string | undefined;
@@ -1211,17 +1244,19 @@ export class IrcConnection {
       if (outcome.notice) this.surfaceE2eNotice(outcome.notice, outcome.channel);
     });
 
-    // Diagnostic only: some clients send CTCP over PRIVMSG (→ 'ctcp request')
-    // instead of NOTICE. The RPE2E spec uses NOTICE, but if a peer's handshake
-    // arrives here we'd otherwise never see it — log it under LURKER_E2E_DEBUG so
-    // an interop mismatch is visible rather than silent.
+    // Inbound CTCP request (a peer probed us over PRIVMSG, e.g. VERSION/PING).
+    // ACTION never reaches here — irc-framework emits it as an 'action' message.
     c.on('ctcp request', (event: Record<string, unknown>) => {
       if (event.type === CTCP_TAG) {
+        // RPE2E rides NOTICE; an RPEE2E PRIVMSG is a misconfigured peer, not a
+        // real CTCP query. Log it for interop debugging and don't auto-answer.
         e2eDbg(
           () =>
             `ctcp-REQUEST (PRIVMSG, not NOTICE!) from ${event.nick}!${event.ident}@${event.hostname} body=${String(event.message).slice(0, 140)}`,
         );
+        return;
       }
+      this.handleInboundCtcpRequest(event);
     });
 
     c.on('join', (event: Record<string, unknown>) => {
@@ -2288,6 +2323,100 @@ export class IrcConnection {
     // service or bot doesn't spin up presence tracking for it.
     this.noteUserSend(target);
     this.client.notice(target, text);
+  }
+
+  // --- CTCP (#263) -----------------------------------------------------------
+
+  // Map key for an outstanding outbound CTCP request, so its reply routes back
+  // to the buffer it was issued from.
+  private ctcpKey(nick: string, type: string): string {
+    return `${nick.toLowerCase()} ${type.toUpperCase()}`;
+  }
+
+  private isSelfNick(nick: string | undefined): boolean {
+    return !!nick && !!this.currentNick && nick.toLowerCase() === this.currentNick.toLowerCase();
+  }
+
+  // Token bucket for CTCP auto-replies (anti-flood). Returns false when over
+  // budget — the caller then drops the request entirely (no reply, no display).
+  private takeCtcpToken(now: number): boolean {
+    if (this.ctcpReplyRefillAt === 0) this.ctcpReplyRefillAt = now;
+    const refill = Math.floor((now - this.ctcpReplyRefillAt) / CTCP_REPLY_REFILL_MS);
+    if (refill > 0) {
+      this.ctcpReplyTokens = Math.min(CTCP_REPLY_BURST, this.ctcpReplyTokens + refill);
+      this.ctcpReplyRefillAt += refill * CTCP_REPLY_REFILL_MS;
+    }
+    if (this.ctcpReplyTokens <= 0) return false;
+    this.ctcpReplyTokens -= 1;
+    return true;
+  }
+
+  private pruneCtcpOutstanding(now: number): void {
+    for (const [k, v] of this.ctcpOutstanding) {
+      if (now - v.sentAt > CTCP_OUTSTANDING_TTL_MS) this.ctcpOutstanding.delete(k);
+    }
+    // Backstop: a flood of un-replied requests shouldn't grow the map forever.
+    if (this.ctcpOutstanding.size > 200) this.ctcpOutstanding.clear();
+  }
+
+  // A CTCP status line (request probe, reply, or outbound echo). Transient
+  // status like /help output — never persisted (NON_PERSISTED_TYPES).
+  surfaceCtcp(target: string, text: string): void {
+    this.publishEphemeral({ type: 'ctcp', level: 'info', target, text });
+  }
+
+  // Auto-answer an inbound CTCP request (VERSION/PING/TIME/CLIENTINFO/SOURCE)
+  // and show the user they were probed. Rate-limited; self-echoes ignored.
+  handleInboundCtcpRequest(event: Record<string, unknown>): void {
+    if (this.disposed) return;
+    const nick = event.nick as string | undefined;
+    // Our own outbound CTCP echoed back by an echo-message server — not a probe.
+    if (!nick || this.isSelfNick(nick)) return;
+    const now = Date.now();
+    // Flood guard gates the whole handler (reply AND display), so a CTCP flood
+    // can neither make us spew NOTICEs nor spam the buffer.
+    if (!this.takeCtcpToken(now)) return;
+    const { type, args } = parseCtcp(String(event.message ?? ''));
+    if (!type) return;
+    const reply = buildCtcpReply(type, args, new Date(now));
+    if (reply !== null) this.client.ctcpResponse(nick, type, reply);
+    this.surfaceCtcp(this.serverTarget(), formatCtcpRequestLine(nick, type, reply !== null));
+  }
+
+  // Surface an inbound CTCP reply (a peer answered a query we sent), routed back
+  // to the buffer the /ctcp was issued from when we still remember it.
+  handleInboundCtcpReply(event: Record<string, unknown>): void {
+    if (this.disposed) return;
+    const nick = event.nick as string | undefined;
+    if (!nick || this.isSelfNick(nick)) return;
+    const now = Date.now();
+    const { type, args } = parseCtcp(String(event.message ?? ''));
+    if (!type) return;
+    this.pruneCtcpOutstanding(now);
+    const key = this.ctcpKey(nick, type);
+    const pending = this.ctcpOutstanding.get(key);
+    if (pending) this.ctcpOutstanding.delete(key);
+    const target = pending?.issuingTarget ?? this.serverTarget();
+    this.surfaceCtcp(target, formatCtcpReplyLine(nick, type, args, now));
+  }
+
+  // Send an outbound CTCP request (/ctcp, /ping). `issuingTarget` is the buffer
+  // the command was typed in: the local echo lands there and the reply routes
+  // back to it. A bare PING gets an epoch-ms payload so the reply yields a
+  // round-trip latency.
+  sendCtcpRequest(issuingTarget: string, target: string, type: string, args: string): void {
+    if (this.disposed) return;
+    const issuing = issuingTarget || this.serverTarget();
+    const t = type.toUpperCase();
+    const now = Date.now();
+    let payload = args.trim();
+    if (t === 'PING' && !payload) payload = String(now);
+    this.noteUserSend(target);
+    if (payload) this.client.ctcpRequest(target, t, payload);
+    else this.client.ctcpRequest(target, t);
+    this.pruneCtcpOutstanding(now);
+    this.ctcpOutstanding.set(this.ctcpKey(target, t), { issuingTarget: issuing, sentAt: now });
+    this.surfaceCtcp(issuing, `→ CTCP ${t} to ${target}`);
   }
 
   // --- RPE2E (#382) ----------------------------------------------------------

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -449,6 +449,23 @@ class IrcManager extends EventEmitter {
     return true;
   }
 
+  // Send an outbound CTCP request (/ctcp, /ping). `issuingTarget` is the buffer
+  // the command came from so the reply routes back there. Returns false when the
+  // network isn't connected (no wire to send on).
+  ctcpRequest(
+    userId: number,
+    networkId: number,
+    issuingTarget: string,
+    target: string,
+    type: string,
+    args: string,
+  ): boolean {
+    const conn = this.getConnection(userId, networkId);
+    if (!conn) return false;
+    conn.sendCtcpRequest(issuingTarget, target, type, args);
+    return true;
+  }
+
   // Canonical /away writer. Persists the user-level state in user_away_state,
   // then fans the new state out to every IrcConnection so each one issues
   // AWAY on its IRC server and publishes an away-state event. Auto-away

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1531,12 +1531,14 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           ctcpArgs,
         );
         if (!ok) {
+          // Name the command the user actually typed (/ping rides this same path).
+          const cmdName = ctcpType.toUpperCase() === 'PING' ? '/ping' : '/ctcp';
           const evt = {
             type: 'ctcp',
             level: 'warn',
             networkId,
             target: issuingTarget,
-            text: '/ctcp: this network isn’t connected',
+            text: `${cmdName}: this network isn’t connected`,
             time: new Date().toISOString(),
             self: false,
           } as unknown as MessageEvent;

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -127,6 +127,7 @@ const PAUSED_BLOCKED_TYPES = new Set([
   'back',
   'typing',
   'e2e',
+  'ctcp',
 ]);
 
 // Options bag for fanOut.
@@ -1503,6 +1504,39 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
             networkId,
             target,
             text: '/e2e: this network isn’t connected',
+            time: new Date().toISOString(),
+            self: false,
+          } as unknown as MessageEvent;
+          fanOut(userId, { ...decorateMessage(userId, evt), kind: 'irc' });
+        }
+        break;
+      }
+      case 'ctcp': {
+        // Outbound CTCP request (/ctcp <nick> <type> [args], /ping <nick>, #263).
+        // The cell frames + sends it, echoes locally, and routes the reply back
+        // to `issuingTarget`. Like /e2e it needs a live connection, so on a
+        // disconnected network we surface that to the issuing buffer.
+        const networkId = msg.networkId == null ? NaN : Number(msg.networkId);
+        const ctcpTarget = typeof msg.target === 'string' ? msg.target.trim() : '';
+        const ctcpType = typeof msg.ctcpType === 'string' ? msg.ctcpType.trim() : '';
+        const ctcpArgs = typeof msg.args === 'string' ? msg.args : '';
+        const issuingTarget = typeof msg.issuingTarget === 'string' ? msg.issuingTarget : '';
+        if (!Number.isFinite(networkId) || networkId <= 0 || !ctcpTarget || !ctcpType) break;
+        const ok = ircManager.ctcpRequest(
+          userId,
+          networkId,
+          issuingTarget,
+          ctcpTarget,
+          ctcpType,
+          ctcpArgs,
+        );
+        if (!ok) {
+          const evt = {
+            type: 'ctcp',
+            level: 'warn',
+            networkId,
+            target: issuingTarget,
+            text: '/ctcp: this network isn’t connected',
             time: new Date().toISOString(),
             self: false,
           } as unknown as MessageEvent;

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -270,9 +270,16 @@ export function decorateMessage(userId: number, event: MessageEvent): DecoratedE
   const dm = isDirect(event) && !event.self;
   const target = event.target || '';
   const isChannel = target.startsWith('#');
+  // CTCP request/reply/echo lines are status, not conversation — never notify,
+  // even when routed to a notify-always channel (otherwise running /ctcp from
+  // such a channel would self-notify on your own echo). (#263)
+  const isStatus = event.type === 'ctcp';
   const notifyAlways =
-    isChannel && !event.self && getChannelNotifyAlways(userId, event.networkId, target);
-  const notify = matched || dm || notifyAlways;
+    !isStatus &&
+    isChannel &&
+    !event.self &&
+    getChannelNotifyAlways(userId, event.networkId, target);
+  const notify = !isStatus && (matched || dm || notifyAlways);
   return {
     ...event,
     matched,

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -26,7 +26,10 @@ declare module 'irc-framework' {
     enable_chghost?: boolean;
     enable_setname?: boolean;
     enable_echomessage?: boolean;
-    version?: string;
+    /** CTCP VERSION auto-reply string, or `false` to disable the built-in reply
+     *  so the host can answer CTCP itself. This is the interface that actually
+     *  governs runtime VERSION behavior (connect() overwrites client.options). */
+    version?: string | false;
     /**
      * Local source address to bind the outgoing socket to. irc-framework's net
      * transport forwards this as the socket's `localAddress` (and derives the
@@ -38,9 +41,7 @@ declare module 'irc-framework' {
 
   /** Options passed to the Client constructor. */
   export interface ClientOptions {
-    /** CTCP VERSION auto-reply string, or `false` to disable the built-in
-     *  reply so the host can handle CTCP itself. */
-    version?: string | false;
+    version?: string;
     nick?: string;
     username?: string;
     gecos?: string;

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -38,7 +38,9 @@ declare module 'irc-framework' {
 
   /** Options passed to the Client constructor. */
   export interface ClientOptions {
-    version?: string;
+    /** CTCP VERSION auto-reply string, or `false` to disable the built-in
+     *  reply so the host can handle CTCP itself. */
+    version?: string | false;
     nick?: string;
     username?: string;
     gecos?: string;
@@ -114,6 +116,12 @@ declare module 'irc-framework' {
 
     /** Send a CTCP ACTION (/me). */
     action(target: string, message: string): void;
+
+    /** Send a CTCP request (PRIVMSG `\x01TYPE params\x01`); type is uppercased. */
+    ctcpRequest(target: string, type: string, ...params: string[]): void;
+
+    /** Send a CTCP reply (NOTICE `\x01TYPE params\x01`); type is uppercased. */
+    ctcpResponse(target: string, type: string, ...params: string[]): void;
 
     /** Send a NOTICE. */
     notice(target: string, message: string, tags?: Record<string, string>): void;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2584,7 +2584,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       const who =
         rest[0] || (target && !target.startsWith('#') && !target.startsWith(':') ? target : '');
       if (!who) {
-        localInfo(networkId, target, 'usage: /ping <nick>');
+        localInfo(networkId, target, 'usage: /ping <nick> (a nick is only optional inside a DM)');
         return true;
       }
       return sendOrToast(

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2011,6 +2011,8 @@ const COMMANDS_LINES = [
   '  /away [message]        — set away across every network (no arg clears)',
   '  /back                  — clear away',
   '  /whois <nick>          — query user info (renders in server buffer)',
+  '  /ctcp <nick> <type>    — CTCP query (VERSION/PING/TIME/CLIENTINFO/SOURCE)',
+  '  /ping [nick]           — CTCP ping a user for round-trip latency',
   '  /kick <nick> [reason]  — kick from current channel',
   '  /kickban <nick> [msg]  — kick and ban in one step',
   '  /op <nick…>            — give op (also /deop /voice /devoice /halfop /dehalfop)',
@@ -2554,6 +2556,42 @@ function handleCommand(line: string, networkId: number | null, target: string): 
     }
     case 'me':
       return ackedSend({ type: 'action', networkId, target, text: argLine }, argLine);
+    case 'ctcp': {
+      // /ctcp <nick> <type> [args] — send a CTCP query (#263). The cell frames
+      // and sends it, echoes locally, and routes the reply back to this buffer.
+      const who = rest[0];
+      const type = rest[1];
+      if (!who || !type) {
+        localInfo(networkId, target, 'usage: /ctcp <nick> <type> [args] — e.g. /ctcp bob VERSION');
+        return true;
+      }
+      const ctcpArgs = rest.slice(2).join(' ');
+      return sendOrToast(
+        {
+          type: 'ctcp',
+          networkId,
+          target: who,
+          issuingTarget: target,
+          ctcpType: type,
+          args: ctcpArgs,
+        },
+        line,
+      );
+    }
+    case 'ping': {
+      // /ping [nick] — CTCP PING for round-trip latency (#263). Defaults to the
+      // current DM peer when no nick is given.
+      const who =
+        rest[0] || (target && !target.startsWith('#') && !target.startsWith(':') ? target : '');
+      if (!who) {
+        localInfo(networkId, target, 'usage: /ping <nick>');
+        return true;
+      }
+      return sendOrToast(
+        { type: 'ctcp', networkId, target: who, issuingTarget: target, ctcpType: 'PING', args: '' },
+        line,
+      );
+    }
     case 'msg':
     case 'query': {
       const [who, ...msgParts] = rest;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2580,9 +2580,11 @@ function handleCommand(line: string, networkId: number | null, target: string): 
     }
     case 'ping': {
       // /ping [nick] — CTCP PING for round-trip latency (#263). Defaults to the
-      // current DM peer when no nick is given.
-      const who =
-        rest[0] || (target && !target.startsWith('#') && !target.startsWith(':') ? target : '');
+      // current DM peer when no nick is given — i.e. the active buffer is not a
+      // channel (any prefix #&!+, matching the server's isChannelContext) and not
+      // a pseudo-buffer (`:server:`/system), so /ping in an `&local` channel
+      // doesn't ping the whole channel.
+      const who = rest[0] || (target && !/^[#&!+:]/.test(target) ? target : '');
       if (!who) {
         localInfo(networkId, target, 'usage: /ping <nick> (a nick is only optional inside a DM)');
         return true;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -209,7 +209,10 @@
             ></template>
             <template
               v-else-if="
-                row.m?.type === 'motd' || row.m?.type === 'system' || row.m?.type === 'e2e'
+                row.m?.type === 'motd' ||
+                row.m?.type === 'system' ||
+                row.m?.type === 'e2e' ||
+                row.m?.type === 'ctcp'
               "
               ><LinkedText :text="row.m.text ?? ''"
             /></template>
@@ -1033,6 +1036,9 @@ function prefixText(m: ChatMessage | undefined): string {
       // RPE2E status echoes get their own tag (not the generic "System") so the
       // user can tell encryption lines apart at a glance (#382).
       return 'E2E';
+    case 'ctcp':
+      // CTCP request/reply/echo status lines get their own tag (#263).
+      return 'CTCP';
     case 'error':
       return '!!';
     default:
@@ -1797,6 +1803,8 @@ watch(
 .prefix.p-motd,
 .prefix.p-away,
 .prefix.p-back,
+/* CTCP request/reply/echo status (#263): informational, so muted like motd. */
+.prefix.p-ctcp,
 .prefix.p-cons {
   color: var(--fg-muted);
 }

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1074,6 +1074,9 @@ function prefixClass(m: ChatMessage | undefined) {
     // A warn-level E2E line (TOFU warning, refused send) colors its tag like an
     // error; info-level stays the calm E2E color.
     'e2e-warn': m?.type === 'e2e' && m?.level === 'warn',
+    // A warn-level CTCP line (e.g. "/ctcp: this network isn't connected") reads
+    // as an error too; info-level stays muted (#263).
+    'ctcp-warn': m?.type === 'ctcp' && m?.level === 'warn',
     [`p-${m?.type}`]: true,
   };
 }
@@ -1807,6 +1810,10 @@ watch(
 .prefix.p-ctcp,
 .prefix.p-cons {
   color: var(--fg-muted);
+}
+/* …except a warn-level CTCP line (failed send) colors its tag like an error. */
+.prefix.p-ctcp.ctcp-warn {
+  color: var(--bad);
 }
 /* "System" lines (#355) read as the full-strength foreground, not muted — the
    app speaking in its own voice. A network-tied system line overrides this with

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -271,6 +271,7 @@ function applyEvent(event: any): void {
       break;
     }
     case 'e2e': // RPE2E status line (#382) — same routing as a server notice.
+    case 'ctcp': // CTCP request/reply/echo status line (#263) — same routing.
     case 'motd':
     case 'error': {
       const decorated = { ...event, target: event.target || `:server:${event.networkId}` };


### PR DESCRIPTION
## Why

#263 ("flesh out slash-command coverage") was closed as completed, but the CTCP items it listed under *Messaging* — `/ctcp <nick> <type>`, `/ping` (CTCP latency) — were never actually built, and inbound CTCP replies were silently dropped. Today `/ctcp nick version` falls through the raw passthrough to a server "unknown command", and only VERSION is auto-answered (by irc-framework's built-in). This PR adds a full CTCP layer.

Modeled on the reference clients under `~/Coding/irc-clients`: **irssi** (`src/irc/core/ctcp.c` — the auto-reply set + PING flood guard), **WeeChat** (`src/plugins/irc/irc-ctcp.c` — CLIENTINFO/SOURCE/TIME), and **The Lounge** (`server/plugins/irc-events/ctcp.ts` — same `irc-framework`, used the same way: `version:false` + manual replies).

## What

**Outbound** (`MessageInput.vue` → `wsHub` → `ircManager` → `ircConnection`)
- `/ctcp <nick> <type> [args]` and `/ping [nick]` (defaults to the current DM peer). The cell frames + sends via `irc-framework`, echoes locally to the issuing buffer, and routes the reply back there. A bare PING is auto-stamped with an epoch-ms payload so the echoed reply yields a round-trip latency (single-clock, stateless).

**Inbound auto-replies** (cell-side, so they answer even with no tab open)
- VERSION / PING / TIME / CLIENTINFO / SOURCE. The `irc-framework` client is switched to `version: false` so **all** CTCP handling lives in one place — our `ctcp request` handler — instead of being split between the library and us.
- **Flood protection:** PING payloads over 100 bytes are refused (irssi parity); a token bucket (burst 5, 1 token / 2s) rate-limits replies so a CTCP flood can't make the cell spew NOTICEs (and get the user flood-killed).
- Self-echoes (echo-message) and RPEE2E-over-PRIVMSG are ignored — no loops, no mis-classification.

**Display**
- Inbound requests, replies, and outbound echoes surface as transient `type: 'ctcp'` status lines (never persisted, like `/help` output): probes + unsolicited replies → server buffer, solicited replies → the issuing buffer, PING as a latency. New muted **"CTCP"** prefix tag; client routes it alongside `e2e`/`motd`.

## Tests
- Pure wire/format/display logic isolated in `server/services/ctcp.ts` — **23 unit tests** (`ctcp.test.ts`).
- IrcConnection plumbing — **12 integration tests** (`ctcpWiring.test.ts`), modeled on the e2e wiring suite (auto-reply, PING echo, unsupported-type, self-echo guard, RPEE2E guard, rate limit, outbound framing, reply routing + latency).
- Full server suite **1205 green**, client **260 green**, `npm run check` (tsc ×2 + oxlint + oxfmt) exit 0.

## Scoped out
- USERINFO/FINGER auto-replies (USERINFO leaks realname; both rarely used). CLIENTINFO advertises exactly what we answer.
- `/wallops` (also in #263) — an oper broadcast, not CTCP; already works via the raw passthrough.

## Note for the RPE2E DM work
This flips the `irc-framework` client to `version: false`, so inbound CTCP VERSION now routes through our `ctcp request` handler rather than the library's built-in reply. The RPE2E handshake path (RPEE2E over NOTICE → `ctcp response`) is untouched, and an RPEE2E-over-PRIVMSG is explicitly skipped in the new request handler.

Closes #263 (CTCP portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)