### PR TITLE
Make CTCP auto-replies fully customizable (WeeChat-style templates)

### DIFF
--- a/server/services/ctcp.test.ts
+++ b/server/services/ctcp.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildCtcpReply,
+  CTCP_DEFAULT_CONFIG,
   CTCP_SOURCE,
   CTCP_SUPPORTED,
+  type CtcpReplyConfig,
   formatCtcpReplyLine,
   formatCtcpRequestLine,
   formatLatency,
@@ -14,6 +16,11 @@ import {
   pingReplyLatencyMs,
 } from './ctcp.js';
 import { IRC_VERSION } from '../utils/userAgent.js';
+
+const cfg = (over: Partial<CtcpReplyConfig> = {}): CtcpReplyConfig => ({
+  ...CTCP_DEFAULT_CONFIG,
+  ...over,
+});
 
 describe('parseCtcp', () => {
   it('splits type and args, uppercasing the type', () => {
@@ -75,6 +82,40 @@ describe('buildCtcpReply', () => {
       if (t === 'ACTION') continue;
       expect(buildCtcpReply(t, '', now), `expected a reply for ${t}`).not.toBeNull();
     }
+  });
+});
+
+describe('buildCtcpReply — config gating', () => {
+  const now = new Date('2026-06-27T14:03:11Z');
+
+  it('master replies:false silences everything, including PING', () => {
+    const off = cfg({ replies: false });
+    expect(buildCtcpReply('VERSION', '', now, off)).toBeNull();
+    expect(buildCtcpReply('TIME', '', now, off)).toBeNull();
+    expect(buildCtcpReply('SOURCE', '', now, off)).toBeNull();
+    expect(buildCtcpReply('CLIENTINFO', '', now, off)).toBeNull();
+    expect(buildCtcpReply('PING', '123', now, off)).toBeNull();
+  });
+
+  it('a disabled per-type reply returns null while others still answer', () => {
+    const noVersion = cfg({ version: false });
+    expect(buildCtcpReply('VERSION', '', now, noVersion)).toBeNull();
+    expect(buildCtcpReply('TIME', '', now, noVersion)).toBe(now.toUTCString());
+    expect(buildCtcpReply('PING', '123', now, noVersion)).toBe('123'); // PING has no toggle
+  });
+
+  it('CLIENTINFO advertises only the enabled types (+ ACTION/PING)', () => {
+    expect(buildCtcpReply('CLIENTINFO', '', now, cfg({ time: false, source: false }))).toBe(
+      'ACTION CLIENTINFO PING VERSION',
+    );
+    expect(
+      buildCtcpReply('CLIENTINFO', '', now, cfg({ version: false, time: false, source: false })),
+    ).toBe('ACTION CLIENTINFO PING');
+  });
+
+  it('defaults to all-on (current behavior) when no config is passed', () => {
+    expect(buildCtcpReply('VERSION', '', now)).toBe(IRC_VERSION);
+    expect(buildCtcpReply('CLIENTINFO', '', now)).toBe(CTCP_SUPPORTED.join(' '));
   });
 });
 

--- a/server/services/ctcp.test.ts
+++ b/server/services/ctcp.test.ts
@@ -6,17 +6,25 @@ import { describe, expect, it } from 'vitest';
 import {
   buildCtcpReply,
   CTCP_DEFAULT_CONFIG,
-  CTCP_SOURCE,
-  CTCP_SUPPORTED,
   type CtcpReplyConfig,
+  enabledCtcpTypes,
+  expandCtcpTemplate,
   formatCtcpReplyLine,
   formatCtcpRequestLine,
   formatLatency,
   parseCtcp,
   pingReplyLatencyMs,
 } from './ctcp.js';
-import { IRC_VERSION } from '../utils/userAgent.js';
 
+// Representative ${...} values, as ircConnection.ctcpTemplateVars would supply.
+const VARS: Record<string, string> = {
+  name: 'Lurker',
+  version: '1.2.3',
+  source: 'https://example.test/src',
+  clientinfo: 'ACTION CLIENTINFO PING SOURCE TIME VERSION',
+  time: 'Sat, 27 Jun 2026 14:03:11 GMT',
+  nick: 'me',
+};
 const cfg = (over: Partial<CtcpReplyConfig> = {}): CtcpReplyConfig => ({
   ...CTCP_DEFAULT_CONFIG,
   ...over,
@@ -38,84 +46,98 @@ describe('parseCtcp', () => {
   });
 });
 
-describe('buildCtcpReply', () => {
-  const now = new Date('2026-06-27T14:03:11Z');
-
-  it('answers VERSION with the Lurker user-agent', () => {
-    expect(buildCtcpReply('VERSION', '', now)).toBe(IRC_VERSION);
+describe('expandCtcpTemplate', () => {
+  it('expands known ${...} placeholders', () => {
+    expect(expandCtcpTemplate('${name} ${version}', VARS)).toBe('Lurker 1.2.3');
   });
 
-  it('answers SOURCE with the repo URL', () => {
-    expect(buildCtcpReply('SOURCE', '', now)).toBe(CTCP_SOURCE);
+  it('leaves unknown placeholders literal (so a typo is visible)', () => {
+    expect(expandCtcpTemplate('${bogus} ${name}', VARS)).toBe('${bogus} Lurker');
   });
 
-  it('answers CLIENTINFO with the supported set', () => {
-    expect(buildCtcpReply('CLIENTINFO', '', now)).toBe(CTCP_SUPPORTED.join(' '));
-  });
-
-  it('answers TIME with a UTC string', () => {
-    expect(buildCtcpReply('TIME', '', now)).toBe(now.toUTCString());
-  });
-
-  it('echoes a PING payload verbatim', () => {
-    expect(buildCtcpReply('PING', '1719500000000', now)).toBe('1719500000000');
-  });
-
-  it('refuses an oversized PING payload (flood-amp guard)', () => {
-    expect(buildCtcpReply('PING', 'x'.repeat(101), now)).toBeNull();
-  });
-
-  it('is case-insensitive on the type', () => {
-    expect(buildCtcpReply('version', '', now)).toBe(IRC_VERSION);
-  });
-
-  it('returns null for an unsupported type (e.g. USERINFO/FINGER)', () => {
-    expect(buildCtcpReply('USERINFO', '', now)).toBeNull();
-    expect(buildCtcpReply('FINGER', '', now)).toBeNull();
-    expect(buildCtcpReply('DCC', 'SEND foo', now)).toBeNull();
-  });
-
-  it('advertises exactly the types it can answer (CLIENTINFO ⊇ answerable)', () => {
-    // ACTION is in the set for completeness (we send/receive it) but isn't a
-    // query; every OTHER advertised type must produce a non-null reply.
-    for (const t of CTCP_SUPPORTED) {
-      if (t === 'ACTION') continue;
-      expect(buildCtcpReply(t, '', now), `expected a reply for ${t}`).not.toBeNull();
-    }
+  it('returns a plain template unchanged', () => {
+    expect(expandCtcpTemplate('hello there', VARS)).toBe('hello there');
   });
 });
 
-describe('buildCtcpReply — config gating', () => {
-  const now = new Date('2026-06-27T14:03:11Z');
-
-  it('master replies:false silences everything, including PING', () => {
-    const off = cfg({ replies: false });
-    expect(buildCtcpReply('VERSION', '', now, off)).toBeNull();
-    expect(buildCtcpReply('TIME', '', now, off)).toBeNull();
-    expect(buildCtcpReply('SOURCE', '', now, off)).toBeNull();
-    expect(buildCtcpReply('CLIENTINFO', '', now, off)).toBeNull();
-    expect(buildCtcpReply('PING', '123', now, off)).toBeNull();
+describe('buildCtcpReply', () => {
+  it('expands the default templates against the supplied vars', () => {
+    expect(buildCtcpReply('VERSION', '', CTCP_DEFAULT_CONFIG, VARS)).toBe('Lurker 1.2.3');
+    expect(buildCtcpReply('TIME', '', CTCP_DEFAULT_CONFIG, VARS)).toBe(VARS.time);
+    expect(buildCtcpReply('SOURCE', '', CTCP_DEFAULT_CONFIG, VARS)).toBe(VARS.source);
+    expect(buildCtcpReply('CLIENTINFO', '', CTCP_DEFAULT_CONFIG, VARS)).toBe(VARS.clientinfo);
   });
 
-  it('a disabled per-type reply returns null while others still answer', () => {
-    const noVersion = cfg({ version: false });
-    expect(buildCtcpReply('VERSION', '', now, noVersion)).toBeNull();
-    expect(buildCtcpReply('TIME', '', now, noVersion)).toBe(now.toUTCString());
-    expect(buildCtcpReply('PING', '123', now, noVersion)).toBe('123'); // PING has no toggle
-  });
-
-  it('CLIENTINFO advertises only the enabled types (+ ACTION/PING)', () => {
-    expect(buildCtcpReply('CLIENTINFO', '', now, cfg({ time: false, source: false }))).toBe(
-      'ACTION CLIENTINFO PING VERSION',
+  it('echoes a PING payload verbatim', () => {
+    expect(buildCtcpReply('PING', '1719500000000', CTCP_DEFAULT_CONFIG, VARS)).toBe(
+      '1719500000000',
     );
-    expect(
-      buildCtcpReply('CLIENTINFO', '', now, cfg({ version: false, time: false, source: false })),
-    ).toBe('ACTION CLIENTINFO PING');
   });
 
-  it('defaults to all-on (current behavior) when no config is passed', () => {
-    expect(buildCtcpReply('VERSION', '', now)).toBe(IRC_VERSION);
-    expect(buildCtcpReply('CLIENTINFO', '', now)).toBe(CTCP_SUPPORTED.join(' '));
+  it('refuses an oversized PING payload (flood-amp guard)', () => {
+    expect(buildCtcpReply('PING', 'x'.repeat(101), CTCP_DEFAULT_CONFIG, VARS)).toBeNull();
+  });
+
+  it('is case-insensitive on the type', () => {
+    expect(buildCtcpReply('version', '', CTCP_DEFAULT_CONFIG, VARS)).toBe('Lurker 1.2.3');
+  });
+
+  it('returns null for an unsupported type (e.g. USERINFO/FINGER)', () => {
+    expect(buildCtcpReply('USERINFO', '', CTCP_DEFAULT_CONFIG, VARS)).toBeNull();
+    expect(buildCtcpReply('FINGER', '', CTCP_DEFAULT_CONFIG, VARS)).toBeNull();
+    expect(buildCtcpReply('DCC', 'SEND foo', CTCP_DEFAULT_CONFIG, VARS)).toBeNull();
+  });
+
+  it('honors a fully custom template', () => {
+    expect(
+      buildCtcpReply('VERSION', '', cfg({ version: 'hi from ${nick} on ${name}' }), VARS),
+    ).toBe('hi from me on Lurker');
+  });
+
+  it('strips CR/LF so a template cannot inject a second wire line', () => {
+    expect(buildCtcpReply('VERSION', '', cfg({ version: 'a\r\nQUIT b' }), VARS)).toBe('aQUIT b');
+  });
+});
+
+describe('buildCtcpReply — disabling', () => {
+  it('master enabled:false silences everything, including PING', () => {
+    const off = cfg({ enabled: false });
+    expect(buildCtcpReply('VERSION', '', off, VARS)).toBeNull();
+    expect(buildCtcpReply('TIME', '', off, VARS)).toBeNull();
+    expect(buildCtcpReply('PING', '123', off, VARS)).toBeNull();
+  });
+
+  it('an empty template disables that type while others still answer', () => {
+    const noVersion = cfg({ version: '' });
+    expect(buildCtcpReply('VERSION', '', noVersion, VARS)).toBeNull();
+    expect(buildCtcpReply('TIME', '', noVersion, VARS)).toBe(VARS.time);
+    expect(buildCtcpReply('PING', '123', noVersion, VARS)).toBe('123'); // PING isn't templated
+  });
+
+  it('a whitespace-only template counts as disabled', () => {
+    expect(buildCtcpReply('SOURCE', '', cfg({ source: '   ' }), VARS)).toBeNull();
+  });
+});
+
+describe('enabledCtcpTypes', () => {
+  it('lists ACTION/PING plus each non-empty template, sorted', () => {
+    expect(enabledCtcpTypes(CTCP_DEFAULT_CONFIG)).toEqual([
+      'ACTION',
+      'CLIENTINFO',
+      'PING',
+      'SOURCE',
+      'TIME',
+      'VERSION',
+    ]);
+  });
+
+  it('omits a type whose template is empty', () => {
+    expect(enabledCtcpTypes(cfg({ time: '', source: '' }))).toEqual([
+      'ACTION',
+      'CLIENTINFO',
+      'PING',
+      'VERSION',
+    ]);
   });
 });
 

--- a/server/services/ctcp.test.ts
+++ b/server/services/ctcp.test.ts
@@ -194,12 +194,14 @@ describe('formatCtcpReplyLine', () => {
 });
 
 describe('formatCtcpRequestLine', () => {
-  it('notes an answered probe', () => {
-    expect(formatCtcpRequestLine('bob', 'version', true)).toBe('bob requested CTCP VERSION');
+  it('shows what we disclosed back on an answered probe', () => {
+    expect(formatCtcpRequestLine('bob', 'version', 'Lurker 1.2.3')).toBe(
+      'bob requested CTCP VERSION (replied: Lurker 1.2.3)',
+    );
   });
 
-  it('flags an unanswered probe', () => {
-    expect(formatCtcpRequestLine('bob', 'finger', false)).toBe(
+  it('flags an unanswered probe (null reply)', () => {
+    expect(formatCtcpRequestLine('bob', 'finger', null)).toBe(
       'bob requested CTCP FINGER (no reply)',
     );
   });

--- a/server/services/ctcp.test.ts
+++ b/server/services/ctcp.test.ts
@@ -94,8 +94,12 @@ describe('buildCtcpReply', () => {
     ).toBe('hi from me on Lurker');
   });
 
-  it('strips CR/LF so a template cannot inject a second wire line', () => {
+  it('strips CR/LF/NUL and the 0x01 CTCP frame byte so a template cannot inject', () => {
+    // CR/LF would split the IRC line; \x01 would split the reply into extra CTCP
+    // segments for the peer.
     expect(buildCtcpReply('VERSION', '', cfg({ version: 'a\r\nQUIT b' }), VARS)).toBe('aQUIT b');
+    const dirty = `a${String.fromCharCode(1)}b${String.fromCharCode(0)}c`;
+    expect(buildCtcpReply('VERSION', '', cfg({ version: dirty }), VARS)).toBe('abc');
   });
 });
 

--- a/server/services/ctcp.ts
+++ b/server/services/ctcp.ts
@@ -18,9 +18,10 @@ import { IRC_VERSION } from '../utils/userAgent.js';
 /** Where Lurker's source lives — the CTCP SOURCE reply. */
 export const CTCP_SOURCE = 'https://github.com/amiantos/lurker';
 
-// The CTCP request types we auto-answer. CLIENTINFO advertises exactly this set
-// (ACTION included — we send/receive it as messages even though it isn't a
-// query). Keep in sync with buildCtcpReply's switch.
+// The CTCP request types we can auto-answer when everything is enabled.
+// CLIENTINFO advertises the currently-ENABLED subset of this (see
+// supportedCtcp); ACTION + PING are always handled (ACTION as a message, PING
+// as a harmless echo) so they're always advertised.
 export const CTCP_SUPPORTED = [
   'ACTION',
   'CLIENTINFO',
@@ -29,6 +30,37 @@ export const CTCP_SUPPORTED = [
   'TIME',
   'VERSION',
 ] as const;
+
+/** Which CTCP auto-replies are enabled (per-user, read from the settings
+ *  registry cell-side). `replies` is the master switch — when false we answer
+ *  nothing at all, including PING. */
+export interface CtcpReplyConfig {
+  replies: boolean;
+  version: boolean;
+  time: boolean;
+  source: boolean;
+  clientinfo: boolean;
+}
+
+/** All-on — current behavior, and the default when no config is supplied. */
+export const CTCP_DEFAULT_CONFIG: CtcpReplyConfig = {
+  replies: true,
+  version: true,
+  time: true,
+  source: true,
+  clientinfo: true,
+};
+
+/** The CTCP types CLIENTINFO advertises given the active config: ACTION + PING
+ *  always, plus each enabled answerable type. Sorted for a stable wire string. */
+function supportedCtcp(config: CtcpReplyConfig): string {
+  const types = ['ACTION', 'PING'];
+  if (config.version) types.push('VERSION');
+  if (config.time) types.push('TIME');
+  if (config.source) types.push('SOURCE');
+  if (config.clientinfo) types.push('CLIENTINFO');
+  return types.sort().join(' ');
+}
 
 // irssi parity (ctcp.c): refuse to echo back an oversized PING payload so a peer
 // can't turn our auto-reply into a reflection/flood amplifier.
@@ -50,19 +82,28 @@ export function parseCtcp(message: string): { type: string; args: string } {
 
 /**
  * Build the auto-reply argument string for an inbound CTCP request, or null when
- * we don't answer this type. The returned value is the params AFTER the type;
- * the caller frames it as `ctcpResponse(nick, type, reply)`.
+ * we don't answer this type (unsupported, or disabled by `config`). The returned
+ * value is the params AFTER the type; the caller frames it as
+ * `ctcpResponse(nick, type, reply)`. `config` gates each disclosure per the
+ * user's privacy settings; omit it for the all-on default.
  */
-export function buildCtcpReply(type: string, args: string, now: Date): string | null {
+export function buildCtcpReply(
+  type: string,
+  args: string,
+  now: Date,
+  config: CtcpReplyConfig = CTCP_DEFAULT_CONFIG,
+): string | null {
+  // Master switch off → publish nothing, not even a PING echo.
+  if (!config.replies) return null;
   switch (type.toUpperCase()) {
     case 'VERSION':
-      return IRC_VERSION;
+      return config.version ? IRC_VERSION : null;
     case 'SOURCE':
-      return CTCP_SOURCE;
+      return config.source ? CTCP_SOURCE : null;
     case 'CLIENTINFO':
-      return CTCP_SUPPORTED.join(' ');
+      return config.clientinfo ? supportedCtcp(config) : null;
     case 'TIME':
-      return formatCtcpTime(now);
+      return config.time ? formatCtcpTime(now) : null;
     case 'PING':
       // Echo the payload verbatim (that's what makes round-trip timing work for
       // the requester), but drop an abusive one.

--- a/server/services/ctcp.ts
+++ b/server/services/ctcp.ts
@@ -13,15 +13,13 @@
 // Lounge (server/plugins/irc-events/ctcp.ts — the same irc-framework
 // `version:false` + manual-reply approach we use).
 
-import { IRC_VERSION } from '../utils/userAgent.js';
-
-/** Where Lurker's source lives — the CTCP SOURCE reply. */
+/** Where Lurker's source lives — the default CTCP SOURCE reply. */
 export const CTCP_SOURCE = 'https://github.com/amiantos/lurker';
 
-// The CTCP request types we can auto-answer when everything is enabled.
-// CLIENTINFO advertises the currently-ENABLED subset of this (see
-// supportedCtcp); ACTION + PING are always handled (ACTION as a message, PING
-// as a harmless echo) so they're always advertised.
+// The CTCP request types we can answer. CLIENTINFO advertises the currently
+// ENABLED subset (a per-type template that's non-empty); ACTION + PING are
+// always handled (ACTION as a message, PING as a harmless echo) so they're
+// always advertised.
 export const CTCP_SUPPORTED = [
   'ACTION',
   'CLIENTINFO',
@@ -31,35 +29,60 @@ export const CTCP_SUPPORTED = [
   'VERSION',
 ] as const;
 
-/** Which CTCP auto-replies are enabled (per-user, read from the settings
- *  registry cell-side). `replies` is the master switch — when false we answer
- *  nothing at all, including PING. */
+/**
+ * Per-user CTCP auto-reply config (read from the settings registry cell-side).
+ * `enabled` is the master switch — off answers nothing, including PING. The rest
+ * are WeeChat-style reply TEMPLATES: a non-empty string is the reply (with
+ * `${...}` placeholders expanded — see expandCtcpTemplate), an empty string
+ * disables that type.
+ */
 export interface CtcpReplyConfig {
-  replies: boolean;
-  version: boolean;
-  time: boolean;
-  source: boolean;
-  clientinfo: boolean;
+  enabled: boolean;
+  version: string;
+  time: string;
+  source: string;
+  clientinfo: string;
 }
 
-/** All-on — current behavior, and the default when no config is supplied. */
+/** Defaults — the all-on, WeeChat-flavored templates. */
 export const CTCP_DEFAULT_CONFIG: CtcpReplyConfig = {
-  replies: true,
-  version: true,
-  time: true,
-  source: true,
-  clientinfo: true,
+  enabled: true,
+  version: '${name} ${version}',
+  time: '${time}',
+  source: '${source}',
+  clientinfo: '${clientinfo}',
 };
 
+/** Placeholders a reply template may use, with what each expands to. The caller
+ *  (ircConnection) supplies the live values; documented here so /set and the
+ *  Settings UI can describe them. */
+export const CTCP_TEMPLATE_VARS: Readonly<Record<string, string>> = Object.freeze({
+  name: 'the client name ("Lurker")',
+  version: 'Lurker version (e.g. 1.0.6)',
+  source: 'Lurker project URL',
+  clientinfo: 'space-separated list of CTCP types currently answered',
+  time: 'current server time',
+  nick: 'your current nick on this network',
+});
+
+/** Expand `${key}` placeholders in a template from `vars`. Unknown keys are left
+ *  literal so a typo is visible rather than silently blank. */
+export function expandCtcpTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\$\{(\w+)\}/g, (m, key) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : m,
+  );
+}
+
 /** The CTCP types CLIENTINFO advertises given the active config: ACTION + PING
- *  always, plus each enabled answerable type. Sorted for a stable wire string. */
-function supportedCtcp(config: CtcpReplyConfig): string {
+ *  always, plus each type whose template is non-empty. Sorted for a stable
+ *  wire string. */
+export function enabledCtcpTypes(config: CtcpReplyConfig): string[] {
   const types = ['ACTION', 'PING'];
-  if (config.version) types.push('VERSION');
-  if (config.time) types.push('TIME');
-  if (config.source) types.push('SOURCE');
-  if (config.clientinfo) types.push('CLIENTINFO');
-  return types.sort().join(' ');
+  if (config.version.trim()) types.push('VERSION');
+  if (config.time.trim()) types.push('TIME');
+  if (config.source.trim()) types.push('SOURCE');
+  if (config.clientinfo.trim()) types.push('CLIENTINFO');
+  return types.toSorted();
 }
 
 // irssi parity (ctcp.c): refuse to echo back an oversized PING payload so a peer
@@ -71,6 +94,18 @@ const PING_MAX_PAYLOAD = 100;
 // instead of a nonsense latency.
 const PING_MAX_PLAUSIBLE_MS = 3_600_000;
 
+// A CTCP reply is a single IRC line — strip anything that could split it (CR/LF)
+// or NUL, so a crafted template can't smuggle a second wire command. Done by
+// char code (no control chars in source, which keeps the linter + grep happy).
+function stripCtcpControlChars(s: string): string {
+  let out = '';
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c !== 0x00 && c !== 0x0a && c !== 0x0d) out += s[i];
+  }
+  return out;
+}
+
 /** Split a CTCP inner body (`"VERSION"` / `"PING 1719500000000"`) into an
  *  upper-cased type and the remaining argument string. */
 export function parseCtcp(message: string): { type: string; args: string } {
@@ -80,38 +115,49 @@ export function parseCtcp(message: string): { type: string; args: string } {
   return { type: trimmed.slice(0, sp).toUpperCase(), args: trimmed.slice(sp + 1) };
 }
 
+function ctcpTemplateFor(type: string, config: CtcpReplyConfig): string | undefined {
+  switch (type) {
+    case 'VERSION':
+      return config.version;
+    case 'TIME':
+      return config.time;
+    case 'SOURCE':
+      return config.source;
+    case 'CLIENTINFO':
+      return config.clientinfo;
+    default:
+      return undefined;
+  }
+}
+
 /**
- * Build the auto-reply argument string for an inbound CTCP request, or null when
- * we don't answer this type (unsupported, or disabled by `config`). The returned
+ * Build the auto-reply for an inbound CTCP request, or null when we don't answer
+ * it (master off, unsupported type, or an empty/disabled template). The returned
  * value is the params AFTER the type; the caller frames it as
- * `ctcpResponse(nick, type, reply)`. `config` gates each disclosure per the
- * user's privacy settings; omit it for the all-on default.
+ * `ctcpResponse(nick, type, reply)`. `vars` supplies the `${...}` values for
+ * template expansion; omit `config`/`vars` for the all-on defaults.
  */
 export function buildCtcpReply(
   type: string,
   args: string,
-  now: Date,
   config: CtcpReplyConfig = CTCP_DEFAULT_CONFIG,
+  vars: Record<string, string> = {},
 ): string | null {
   // Master switch off → publish nothing, not even a PING echo.
-  if (!config.replies) return null;
-  switch (type.toUpperCase()) {
-    case 'VERSION':
-      return config.version ? IRC_VERSION : null;
-    case 'SOURCE':
-      return config.source ? CTCP_SOURCE : null;
-    case 'CLIENTINFO':
-      return config.clientinfo ? supportedCtcp(config) : null;
-    case 'TIME':
-      return config.time ? formatCtcpTime(now) : null;
-    case 'PING':
-      // Echo the payload verbatim (that's what makes round-trip timing work for
-      // the requester), but drop an abusive one.
-      if (args.length > PING_MAX_PAYLOAD) return null;
-      return args;
-    default:
-      return null;
+  if (!config.enabled) return null;
+  const t = type.toUpperCase();
+  if (t === 'PING') {
+    // Echo the payload verbatim (that's what makes round-trip timing work for
+    // the requester), but drop an abusive one. PING can't be templated — it has
+    // to mirror the asker's token — but the master switch still silences it.
+    if (args.length > PING_MAX_PAYLOAD) return null;
+    return args;
   }
+  const template = ctcpTemplateFor(t, config);
+  if (template === undefined) return null; // unsupported type
+  if (!template.trim()) return null; // empty template = disabled
+  const reply = stripCtcpControlChars(expandCtcpTemplate(template, vars)).trim();
+  return reply || null;
 }
 
 /** Locale-free local-ish timestamp for a CTCP TIME reply (RFC-1123 / UTC). */

--- a/server/services/ctcp.ts
+++ b/server/services/ctcp.ts
@@ -94,16 +94,19 @@ const PING_MAX_PAYLOAD = 100;
 // instead of a nonsense latency.
 const PING_MAX_PLAUSIBLE_MS = 3_600_000;
 
-// A CTCP reply is a single IRC line — strip anything that could split it (CR/LF)
-// or NUL, so a crafted template can't smuggle a second wire command. Done by
-// char code (no control chars in source, which keeps the linter + grep happy).
+// A CTCP reply is a single IRC line framed by 0x01 — strip anything that would
+// break that: CR/LF/NUL (split the IRC line) and 0x01 itself (an embedded one
+// would split the reply into extra CTCP segments for the peer). A crafted/
+// rebranded template therefore can't smuggle a second wire command. Filtered by
+// char code (no control chars in source, keeping the linter + grep happy) and
+// in one pass (no O(n²) concat on long templates).
 function stripCtcpControlChars(s: string): string {
-  let out = '';
-  for (let i = 0; i < s.length; i++) {
-    const c = s.charCodeAt(i);
-    if (c !== 0x00 && c !== 0x0a && c !== 0x0d) out += s[i];
-  }
-  return out;
+  return [...s]
+    .filter((ch) => {
+      const c = ch.charCodeAt(0);
+      return c !== 0x00 && c !== 0x01 && c !== 0x0a && c !== 0x0d;
+    })
+    .join('');
 }
 
 /** Split a CTCP inner body (`"VERSION"` / `"PING 1719500000000"`) into an
@@ -134,14 +137,17 @@ function ctcpTemplateFor(type: string, config: CtcpReplyConfig): string | undefi
  * Build the auto-reply for an inbound CTCP request, or null when we don't answer
  * it (master off, unsupported type, or an empty/disabled template). The returned
  * value is the params AFTER the type; the caller frames it as
- * `ctcpResponse(nick, type, reply)`. `vars` supplies the `${...}` values for
- * template expansion; omit `config`/`vars` for the all-on defaults.
+ * `ctcpResponse(nick, type, reply)`. `config` is the user's reply config and
+ * `vars` supplies the live `${...}` values for template expansion — both
+ * required (the templates are inert without their values; see
+ * CTCP_DEFAULT_CONFIG for the default templates and CTCP_TEMPLATE_VARS for the
+ * placeholder set the caller must populate).
  */
 export function buildCtcpReply(
   type: string,
   args: string,
-  config: CtcpReplyConfig = CTCP_DEFAULT_CONFIG,
-  vars: Record<string, string> = {},
+  config: CtcpReplyConfig,
+  vars: Record<string, string>,
 ): string | null {
   // Master switch off → publish nothing, not even a PING echo.
   if (!config.enabled) return null;

--- a/server/services/ctcp.ts
+++ b/server/services/ctcp.ts
@@ -203,8 +203,12 @@ export function formatCtcpReplyLine(
   return `CTCP ${t} reply from ${nick}${tail}`;
 }
 
-/** Display line for an inbound CTCP *request* (someone probed us). */
-export function formatCtcpRequestLine(nick: string, type: string, answered: boolean): string {
-  const suffix = answered ? '' : ' (no reply)';
-  return `${nick} requested CTCP ${type.toUpperCase()}${suffix}`;
+/** Display line for an inbound CTCP *request* (someone probed us), showing what
+ *  we disclosed back: `reply` is the answer we sent, or null when we declined
+ *  (unsupported type / disabled). WeeChat shows the sent reply on its own line
+ *  (irc.look.display_ctcp_reply); we fold it into the one probe line to keep the
+ *  buffer quiet while still surfacing exactly what was disclosed. */
+export function formatCtcpRequestLine(nick: string, type: string, reply: string | null): string {
+  const base = `${nick} requested CTCP ${type.toUpperCase()}`;
+  return reply === null ? `${base} (no reply)` : `${base} (replied: ${reply})`;
 }

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -11,11 +11,12 @@
 // MUST be first — redirect DATABASE_PATH before the static imports below open
 // the real data/lurker.db.
 import '../test-utils/isolateDb.js';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { IrcConnection } from './ircConnection.js';
 import { createUser } from '../db/users.js';
 import { createNetwork } from '../db/networks.js';
 import { IRC_VERSION } from '../utils/userAgent.js';
+import settingsService from './settingsService.js';
 
 beforeAll(() => {
   createUser('ctcp-alice'); // id 1
@@ -294,5 +295,63 @@ describe('inbound CTCP reply (route + latency)', () => {
     expect(conn.ctcpOutstanding.size).toBe(1);
     conn.client.emit('close');
     expect(conn.ctcpOutstanding.size).toBe(0);
+  });
+});
+
+describe('inbound CTCP request — settings gating', () => {
+  // Settings persist in the shared isolated DB, so reset every ctcp.* key after
+  // each test or the override leaks into the default-on tests above.
+  afterEach(() => {
+    for (const k of ['replies', 'version', 'time', 'source', 'clientinfo']) {
+      settingsService.reset(1, `ctcp.${k}`);
+    }
+  });
+
+  it('a disabled type (ctcp.version off) suppresses the reply but still shows the probe', () => {
+    settingsService.update(1, { 'ctcp.version': false });
+    const { conn, ctcpResponse, ctcpLines } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      type: 'VERSION',
+      message: 'VERSION',
+    });
+    expect(ctcpResponse).not.toHaveBeenCalled();
+    expect(ctcpLines()[0].text).toBe('bob requested CTCP VERSION (no reply)');
+  });
+
+  it('a still-enabled type keeps answering when a sibling is disabled', () => {
+    settingsService.update(1, { 'ctcp.version': false });
+    const { conn, ctcpResponse } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      type: 'TIME',
+      message: 'TIME',
+    });
+    expect(ctcpResponse).toHaveBeenCalledTimes(1);
+    expect(ctcpResponse.mock.calls[0][1]).toBe('TIME');
+  });
+
+  it('the master switch (ctcp.replies off) silences all auto-replies', () => {
+    settingsService.update(1, { 'ctcp.replies': false });
+    const { conn, ctcpResponse } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      type: 'TIME',
+      message: 'TIME',
+    });
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      type: 'PING',
+      message: 'PING 1',
+    });
+    expect(ctcpResponse).not.toHaveBeenCalled();
   });
 });

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -15,8 +15,11 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { IrcConnection } from './ircConnection.js';
 import { createUser } from '../db/users.js';
 import { createNetwork } from '../db/networks.js';
-import { IRC_VERSION } from '../utils/userAgent.js';
+import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
 import settingsService from './settingsService.js';
+
+// The default ctcp.version template (`${name} ${version}`) expands to this.
+const DEFAULT_VERSION_REPLY = `${APP_NAME} ${APP_VERSION}`;
 
 beforeAll(() => {
   createUser('ctcp-alice'); // id 1
@@ -77,7 +80,7 @@ describe('inbound CTCP request (auto-reply + surface)', () => {
       message: 'VERSION',
     });
 
-    expect(ctcpResponse).toHaveBeenCalledWith('bob', 'VERSION', IRC_VERSION);
+    expect(ctcpResponse).toHaveBeenCalledWith('bob', 'VERSION', DEFAULT_VERSION_REPLY);
     const lines = ctcpLines();
     expect(lines).toHaveLength(1);
     expect(lines[0].target).toBe(':server:1'); // probes land in the server buffer
@@ -149,7 +152,7 @@ describe('inbound CTCP request (auto-reply + surface)', () => {
       message: 'VERSION',
     });
     // carol's bucket is independent of flood's — she still gets answered.
-    expect(ctcpResponse).toHaveBeenCalledWith('carol', 'VERSION', IRC_VERSION);
+    expect(ctcpResponse).toHaveBeenCalledWith('carol', 'VERSION', DEFAULT_VERSION_REPLY);
   });
 
   it('a malformed (empty) CTCP does not consume a peer rate-limit slot', () => {
@@ -174,7 +177,7 @@ describe('inbound CTCP request (auto-reply + surface)', () => {
       type: 'VERSION',
       message: 'VERSION',
     });
-    expect(ctcpResponse).toHaveBeenCalledWith('bob', 'VERSION', IRC_VERSION);
+    expect(ctcpResponse).toHaveBeenCalledWith('bob', 'VERSION', DEFAULT_VERSION_REPLY);
   });
 });
 
@@ -308,7 +311,7 @@ describe('inbound CTCP request — settings gating', () => {
   });
 
   it('a disabled type (ctcp.version off) suppresses the reply but still shows the probe', () => {
-    settingsService.update(1, { 'ctcp.version': false });
+    settingsService.update(1, { 'ctcp.version': '' });
     const { conn, ctcpResponse, ctcpLines } = harness();
     conn.client.emit('ctcp request', {
       nick: 'bob',
@@ -322,7 +325,7 @@ describe('inbound CTCP request — settings gating', () => {
   });
 
   it('a still-enabled type keeps answering when a sibling is disabled', () => {
-    settingsService.update(1, { 'ctcp.version': false });
+    settingsService.update(1, { 'ctcp.version': '' });
     const { conn, ctcpResponse } = harness();
     conn.client.emit('ctcp request', {
       nick: 'bob',

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -84,7 +84,7 @@ describe('inbound CTCP request (auto-reply + surface)', () => {
     const lines = ctcpLines();
     expect(lines).toHaveLength(1);
     expect(lines[0].target).toBe(':server:1'); // probes land in the server buffer
-    expect(lines[0].text).toBe('bob requested CTCP VERSION');
+    expect(lines[0].text).toBe(`bob requested CTCP VERSION (replied: ${DEFAULT_VERSION_REPLY})`);
   });
 
   it('echoes a PING payload back verbatim', () => {
@@ -415,7 +415,9 @@ describe('inbound CTCP request — msgbuffer routing (ctcp.msgbuffer)', () => {
       type: 'VERSION',
       message: 'VERSION',
     });
-    expect(logNet).toHaveBeenCalledWith('bob requested CTCP VERSION');
+    expect(logNet).toHaveBeenCalledWith(
+      `bob requested CTCP VERSION (replied: ${DEFAULT_VERSION_REPLY})`,
+    );
     expect(ctcpLines()).toHaveLength(0); // no ephemeral ctcp line in system mode
     expect(publishEphemeral).not.toHaveBeenCalled();
     logNet.mockRestore();

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -358,3 +358,66 @@ describe('inbound CTCP request — settings gating', () => {
     expect(ctcpResponse).not.toHaveBeenCalled();
   });
 });
+
+describe('inbound CTCP request — msgbuffer routing (ctcp.msgbuffer)', () => {
+  afterEach(() => settingsService.reset(1, 'ctcp.msgbuffer'));
+
+  it('defaults to the server buffer', () => {
+    const { conn, ctcpLines } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: 'alice',
+      type: 'VERSION',
+      message: 'VERSION',
+    });
+    expect(ctcpLines()[0].target).toBe(':server:1');
+  });
+
+  it('private: a direct CTCP routes to a DM with the sender', () => {
+    settingsService.update(1, { 'ctcp.msgbuffer': 'private' });
+    const { conn, ctcpLines } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: 'alice', // sent to our nick → private
+      type: 'VERSION',
+      message: 'VERSION',
+    });
+    expect(ctcpLines()[0].target).toBe('bob');
+  });
+
+  it('private: a channel-targeted CTCP routes to that channel', () => {
+    settingsService.update(1, { 'ctcp.msgbuffer': 'private' });
+    const { conn, ctcpLines } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: '#chan',
+      type: 'VERSION',
+      message: 'VERSION',
+    });
+    expect(ctcpLines()[0].target).toBe('#chan');
+  });
+
+  it('system: routes to the durable system buffer, not an ephemeral ctcp line', () => {
+    settingsService.update(1, { 'ctcp.msgbuffer': 'system' });
+    const { conn, publishEphemeral, ctcpLines } = harness();
+    const logNet = vi.spyOn(conn, 'logNet').mockImplementation(() => {});
+    conn.client.emit('ctcp request', {
+      nick: 'bob',
+      ident: 'b',
+      hostname: 'h',
+      target: 'alice',
+      type: 'VERSION',
+      message: 'VERSION',
+    });
+    expect(logNet).toHaveBeenCalledWith('bob requested CTCP VERSION');
+    expect(ctcpLines()).toHaveLength(0); // no ephemeral ctcp line in system mode
+    expect(publishEphemeral).not.toHaveBeenCalled();
+    logNet.mockRestore();
+  });
+});

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -34,7 +34,13 @@ import { contextKey, isChannelContext } from './e2e/context.js';
 import { CTCP_TAG, WIRE_PREFIX } from './e2e/constants.js';
 import { e2eDbg } from './e2e/debug.js';
 import { RateLimiter } from './e2e/rateLimiter.js';
-import { buildCtcpReply, formatCtcpReplyLine, formatCtcpRequestLine, parseCtcp } from './ctcp.js';
+import {
+  buildCtcpReply,
+  formatCtcpReplyLine,
+  formatCtcpRequestLine,
+  parseCtcp,
+  type CtcpReplyConfig,
+} from './ctcp.js';
 import { getChannelConfig as getE2eChannelConfig } from '../db/e2e.js';
 import type { ChannelMode } from '../db/e2e.js';
 import { randomBytes } from 'node:crypto';
@@ -2361,6 +2367,21 @@ export class IrcConnection {
     return (ident && host ? `${ident}@${host}` : nick).toLowerCase();
   }
 
+  // The user's CTCP auto-reply preferences (settings registry, per-user). Read
+  // fresh per inbound request — they're rare + rate-limited, so a /set takes
+  // effect immediately with no cache to invalidate. A missing key resolves to
+  // the registry default (all on), so out of the box behavior is unchanged.
+  private ctcpReplyConfig(): CtcpReplyConfig {
+    const uid = this.network.user_id;
+    return {
+      replies: effectiveSetting(uid, 'ctcp.replies') !== false,
+      version: effectiveSetting(uid, 'ctcp.version') !== false,
+      time: effectiveSetting(uid, 'ctcp.time') !== false,
+      source: effectiveSetting(uid, 'ctcp.source') !== false,
+      clientinfo: effectiveSetting(uid, 'ctcp.clientinfo') !== false,
+    };
+  }
+
   private pruneCtcpOutstanding(now: number): void {
     for (const [k, queue] of this.ctcpOutstanding) {
       const live = queue.filter((e) => now - e.sentAt <= CTCP_OUTSTANDING_TTL_MS);
@@ -2396,7 +2417,7 @@ export class IrcConnection {
     // can't burn a peer's budget and suppress its legitimate probes.
     if (!type) return;
     if (!this.ctcpLimiter.allowIncoming(this.ctcpPeerKey(event))) return;
-    const reply = buildCtcpReply(type, args, new Date());
+    const reply = buildCtcpReply(type, args, new Date(), this.ctcpReplyConfig());
     if (reply !== null) this.client.ctcpResponse(nick, type, reply);
     this.surfaceCtcp(this.serverTarget(), formatCtcpRequestLine(nick, type, reply !== null));
   }

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -21,7 +21,7 @@ import ignoreRulesService from './ignoreRulesService.js';
 import { decideStamp } from './insertDecisions.js';
 import * as systemLog from './systemLog.js';
 import { effectiveSetting } from './settingsService.js';
-import { APP_VERSION } from '../utils/userAgent.js';
+import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
 import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
 import { deriveIdent } from '../utils/ident.js';
@@ -36,8 +36,11 @@ import { e2eDbg } from './e2e/debug.js';
 import { RateLimiter } from './e2e/rateLimiter.js';
 import {
   buildCtcpReply,
+  CTCP_SOURCE,
+  enabledCtcpTypes,
   formatCtcpReplyLine,
   formatCtcpRequestLine,
+  formatCtcpTime,
   parseCtcp,
   type CtcpReplyConfig,
 } from './ctcp.js';
@@ -2373,12 +2376,28 @@ export class IrcConnection {
   // the registry default (all on), so out of the box behavior is unchanged.
   private ctcpReplyConfig(): CtcpReplyConfig {
     const uid = this.network.user_id;
+    const tmpl = (key: string): string => {
+      const v = effectiveSetting(uid, key);
+      return typeof v === 'string' ? v : '';
+    };
     return {
-      replies: effectiveSetting(uid, 'ctcp.replies') !== false,
-      version: effectiveSetting(uid, 'ctcp.version') !== false,
-      time: effectiveSetting(uid, 'ctcp.time') !== false,
-      source: effectiveSetting(uid, 'ctcp.source') !== false,
-      clientinfo: effectiveSetting(uid, 'ctcp.clientinfo') !== false,
+      enabled: effectiveSetting(uid, 'ctcp.replies') !== false,
+      version: tmpl('ctcp.version'),
+      time: tmpl('ctcp.time'),
+      source: tmpl('ctcp.source'),
+      clientinfo: tmpl('ctcp.clientinfo'),
+    };
+  }
+
+  // Live values for the `${...}` placeholders a CTCP reply template can use.
+  private ctcpTemplateVars(config: CtcpReplyConfig): Record<string, string> {
+    return {
+      name: APP_NAME,
+      version: APP_VERSION,
+      source: CTCP_SOURCE,
+      clientinfo: enabledCtcpTypes(config).join(' '),
+      time: formatCtcpTime(new Date()),
+      nick: this.currentNick,
     };
   }
 
@@ -2417,7 +2436,8 @@ export class IrcConnection {
     // can't burn a peer's budget and suppress its legitimate probes.
     if (!type) return;
     if (!this.ctcpLimiter.allowIncoming(this.ctcpPeerKey(event))) return;
-    const reply = buildCtcpReply(type, args, new Date(), this.ctcpReplyConfig());
+    const config = this.ctcpReplyConfig();
+    const reply = buildCtcpReply(type, args, config, this.ctcpTemplateVars(config));
     if (reply !== null) this.client.ctcpResponse(nick, type, reply);
     this.surfaceCtcp(this.serverTarget(), formatCtcpRequestLine(nick, type, reply !== null));
   }

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2465,7 +2465,7 @@ export class IrcConnection {
     const config = this.ctcpReplyConfig();
     const reply = buildCtcpReply(type, args, config, this.ctcpTemplateVars(config));
     if (reply !== null) this.client.ctcpResponse(nick, type, reply);
-    this.routeCtcpStatus(event, formatCtcpRequestLine(nick, type, reply !== null));
+    this.routeCtcpStatus(event, formatCtcpRequestLine(nick, type, reply));
   }
 
   // Surface an inbound CTCP reply (a peer answered a query we sent), routed back

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2422,6 +2422,32 @@ export class IrcConnection {
     this.publishEphemeral({ type: 'ctcp', level: 'info', target, text });
   }
 
+  // Route an INCOMING CTCP status line (a probe, or an unsolicited reply) per
+  // the user's ctcp.msgbuffer setting — WeeChat's irc.msgbuffer.ctcp:
+  //   server  → this network's server buffer (default)
+  //   system  → the durable app-wide system buffer (persists, like other logs)
+  //   private → the DM with the sender, or the channel for a channel CTCP
+  // (A reply to a /ctcp the USER sent is routed to its issuing buffer by the
+  // caller, not here — this governs unsolicited CTCP only.)
+  private routeCtcpStatus(event: Record<string, unknown>, text: string): void {
+    const mode = effectiveSetting(this.network.user_id, 'ctcp.msgbuffer');
+    if (mode === 'system') {
+      this.logNet(text);
+      return;
+    }
+    if (mode === 'private') {
+      const evTarget = (event.target as string) || '';
+      if (isChannelContext(evTarget)) {
+        this.surfaceCtcp(evTarget, text);
+        return;
+      }
+      const nick = (event.nick as string) || '';
+      this.surfaceCtcp(nick || this.serverTarget(), text);
+      return;
+    }
+    this.surfaceCtcp(this.serverTarget(), text); // 'server' (default)
+  }
+
   // Auto-answer an inbound CTCP request (VERSION/PING/TIME/CLIENTINFO/SOURCE)
   // and show the user they were probed. Self-echoes ignored; rate-limited
   // per-peer so a flood from one nick can't spew NOTICEs, spam the buffer, or
@@ -2439,7 +2465,7 @@ export class IrcConnection {
     const config = this.ctcpReplyConfig();
     const reply = buildCtcpReply(type, args, config, this.ctcpTemplateVars(config));
     if (reply !== null) this.client.ctcpResponse(nick, type, reply);
-    this.surfaceCtcp(this.serverTarget(), formatCtcpRequestLine(nick, type, reply !== null));
+    this.routeCtcpStatus(event, formatCtcpRequestLine(nick, type, reply !== null));
   }
 
   // Surface an inbound CTCP reply (a peer answered a query we sent), routed back
@@ -2458,18 +2484,21 @@ export class IrcConnection {
     const queue = this.ctcpOutstanding.get(key);
     const pending = queue?.shift(); // FIFO: the oldest matching query
     if (queue && queue.length === 0) this.ctcpOutstanding.delete(key);
-    if (!pending && !this.ctcpLimiter.allowIncoming(this.ctcpPeerKey(event))) return;
-    let target = pending?.issuingTarget ?? this.serverTarget();
-    // The issuing buffer may have been closed while the reply was in flight — a
-    // wsHub guard discards ephemeral events to a closed buffer, so don't lose the
-    // answer: fall back to the server buffer.
-    if (
-      target !== this.serverTarget() &&
-      isBufferClosed(this.network.user_id, this.network.id, target)
-    ) {
-      target = this.serverTarget();
+    const line = formatCtcpReplyLine(nick, type, args, now);
+    if (pending) {
+      // Solicited: route back to the buffer the /ctcp was issued from (server
+      // buffer if it has since been closed — a wsHub guard would otherwise drop
+      // an ephemeral event to a closed buffer). ctcp.msgbuffer governs only
+      // UNSOLICITED CTCP, never a reply the user explicitly asked for.
+      const target = isBufferClosed(this.network.user_id, this.network.id, pending.issuingTarget)
+        ? this.serverTarget()
+        : pending.issuingTarget;
+      this.surfaceCtcp(target, line);
+      return;
     }
-    this.surfaceCtcp(target, formatCtcpReplyLine(nick, type, args, now));
+    // Unsolicited reply: rate-limit per-peer, then route per ctcp.msgbuffer.
+    if (!this.ctcpLimiter.allowIncoming(this.ctcpPeerKey(event))) return;
+    this.routeCtcpStatus(event, line);
   }
 
   // Send an outbound CTCP request (/ctcp, /ping). `issuingTarget` is the buffer

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -20,7 +20,7 @@ import highlightRulesService from './highlightRulesService.js';
 import ignoreRulesService from './ignoreRulesService.js';
 import { decideStamp } from './insertDecisions.js';
 import * as systemLog from './systemLog.js';
-import { effectiveSetting } from './settingsService.js';
+import { effectiveSetting, effectiveSettings } from './settingsService.js';
 import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
 import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
@@ -2375,13 +2375,18 @@ export class IrcConnection {
   // effect immediately with no cache to invalidate. A missing key resolves to
   // the registry default (all on), so out of the box behavior is unchanged.
   private ctcpReplyConfig(): CtcpReplyConfig {
-    const uid = this.network.user_id;
-    const tmpl = (key: string): string => {
-      const v = effectiveSetting(uid, key);
-      return typeof v === 'string' ? v : '';
-    };
+    // One settings read for the whole cluster (not one per key) — this runs on
+    // every inbound probe.
+    const s = effectiveSettings(this.network.user_id, [
+      'ctcp.replies',
+      'ctcp.version',
+      'ctcp.time',
+      'ctcp.source',
+      'ctcp.clientinfo',
+    ]);
+    const tmpl = (key: string): string => (typeof s[key] === 'string' ? (s[key] as string) : '');
     return {
-      enabled: effectiveSetting(uid, 'ctcp.replies') !== false,
+      enabled: s['ctcp.replies'] !== false,
       version: tmpl('ctcp.version'),
       time: tmpl('ctcp.time'),
       source: tmpl('ctcp.source'),

--- a/server/services/settingsService.test.ts
+++ b/server/services/settingsService.test.ts
@@ -12,6 +12,7 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 
 let settingsService: typeof SettingsServiceModule.default;
 let effectiveSetting: typeof SettingsServiceModule.effectiveSetting;
+let effectiveSettings: typeof SettingsServiceModule.effectiveSettings;
 let createUser: typeof import('../db/users.js').createUser;
 let user: ReturnType<typeof createUser>;
 
@@ -20,6 +21,7 @@ beforeAll(async () => {
   const mod = await import('./settingsService.js');
   settingsService = mod.default;
   effectiveSetting = mod.effectiveSetting;
+  effectiveSettings = mod.effectiveSettings;
   user = createUser('ss-alice');
 });
 
@@ -85,5 +87,22 @@ describe('effectiveSetting', () => {
   it('returns undefined for an unknown key', () => {
     const u = createUser('ss-effective-2');
     expect(effectiveSetting(u.id, 'no.such.key')).toBeUndefined();
+  });
+});
+
+describe('effectiveSettings (bulk)', () => {
+  it('resolves several keys at once: defaults when unset, overrides when set', () => {
+    const u = createUser('ss-bulk');
+    settingsService.update(u.id, { 'ctcp.version': '', 'ctcp.replies': false });
+    const s = effectiveSettings(u.id, [
+      'ctcp.replies', // overridden → false
+      'ctcp.version', // overridden → ''
+      'ctcp.time', // unset → registry default
+      'no.such.key', // unknown → undefined
+    ]);
+    expect(s['ctcp.replies']).toBe(false);
+    expect(s['ctcp.version']).toBe('');
+    expect(s['ctcp.time']).toBe('${time}');
+    expect(s['no.such.key']).toBeUndefined();
   });
 });

--- a/server/services/settingsService.ts
+++ b/server/services/settingsService.ts
@@ -19,6 +19,29 @@ export function effectiveSetting(userId: number, key: string): SettingValue | un
   return opt.default;
 }
 
+// Resolve several settings in ONE getUserSettings() read, for hot paths that
+// need a cluster of related settings (e.g. the CTCP auto-reply config) without
+// firing a full-table load per key. Same stored-override-or-registry-default
+// rule as effectiveSetting; unknown keys map to undefined.
+export function effectiveSettings(
+  userId: number,
+  keys: string[],
+): Record<string, SettingValue | undefined> {
+  const stored = getUserSettings(userId);
+  const out: Record<string, SettingValue | undefined> = {};
+  for (const key of keys) {
+    const opt = getOption(key);
+    if (!opt) {
+      out[key] = undefined;
+    } else if (Object.prototype.hasOwnProperty.call(stored, key)) {
+      out[key] = stored[key] as SettingValue;
+    } else {
+      out[key] = opt.default;
+    }
+  }
+  return out;
+}
+
 function valuesEqual(a: SettingValue, b: SettingValue): boolean {
   if (a === b) return true;
   if (Array.isArray(a) && Array.isArray(b)) {

--- a/server/utils/userAgent.ts
+++ b/server/utils/userAgent.ts
@@ -32,8 +32,6 @@ export const USER_AGENT: string = contact
   ? `${APP_NAME}/${APP_VERSION} (+${contact})`
   : `${APP_NAME}/${APP_VERSION}`;
 
-// Used as the CTCP VERSION reply on IRC. Same idea, but IRC clients typically
-// don't show the contact, so keep it terse.
-export const IRC_VERSION: string = contact
-  ? `${APP_NAME} ${APP_VERSION} - ${contact}`
-  : `${APP_NAME} ${APP_VERSION}`;
+// (The CTCP VERSION reply is no longer built here — it's a user-configurable
+// template, `ctcp.version` in the settings registry, defaulting to
+// `${name} ${version}`. See server/services/ctcp.ts.)

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -846,6 +846,68 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       '(the version and project URL).',
   },
 
+  // ─── CTCP auto-replies (what we disclose to the network on a CTCP query) ──
+  // Lurker answers a few standard CTCP queries cell-side (so they work even
+  // with no tab open). These let a privacy-conscious user trim or fully silence
+  // what gets published. Defaults preserve current behavior (all on). PING has
+  // no toggle — it only echoes back what the asker sent (no info disclosed) —
+  // but the master switch silences it too.
+  {
+    key: 'ctcp.replies',
+    label: 'Answer CTCP queries',
+    category: 'chat',
+    group: 'ctcp',
+    type: 'bool',
+    default: true,
+    description:
+      'Master switch for replying to CTCP queries from other users (VERSION, ' +
+      'TIME, SOURCE, CLIENTINFO, PING). Turn off to publish nothing — Lurker ' +
+      'stays completely silent to CTCP, like a client with CTCP disabled. The ' +
+      'per-type toggles below apply only while this is on.',
+  },
+  {
+    key: 'ctcp.version',
+    label: 'Reply to CTCP VERSION',
+    category: 'chat',
+    group: 'ctcp',
+    type: 'bool',
+    default: true,
+    description:
+      'Answer CTCP VERSION with the Lurker name and version. Disclosing your ' +
+      'exact client/version aids fingerprinting; turn off to stay quiet.',
+  },
+  {
+    key: 'ctcp.time',
+    label: 'Reply to CTCP TIME',
+    category: 'chat',
+    group: 'ctcp',
+    type: 'bool',
+    default: true,
+    description:
+      'Answer CTCP TIME with the current server time. This reveals your ' +
+      'timezone and that you are connected; turn off to withhold it.',
+  },
+  {
+    key: 'ctcp.source',
+    label: 'Reply to CTCP SOURCE',
+    category: 'chat',
+    group: 'ctcp',
+    type: 'bool',
+    default: true,
+    description: 'Answer CTCP SOURCE with the Lurker project URL.',
+  },
+  {
+    key: 'ctcp.clientinfo',
+    label: 'Reply to CTCP CLIENTINFO',
+    category: 'chat',
+    group: 'ctcp',
+    type: 'bool',
+    default: true,
+    description:
+      'Answer CTCP CLIENTINFO with the list of CTCP types Lurker responds to. ' +
+      'The list reflects whichever of the toggles above are enabled.',
+  },
+
   // ─── Auto-away (sets you AWAY when no client is connected) ────────────
   {
     key: 'away.auto.enabled',
@@ -1395,6 +1457,7 @@ export const GROUPS: Readonly<Record<string, string>> = Object.freeze({
   composing: 'Composing',
   'smart-filter': 'Smart filter',
   connection: 'Connection',
+  ctcp: 'CTCP replies',
   'auto-away': 'Auto-away',
   provider: 'Provider',
   pipeline: 'Image pipeline',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -905,9 +905,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'string',
     default: '${time}',
     description:
-      'Reply sent for a CTCP TIME query (default is the current server time). ' +
-      'Same placeholders as the VERSION reply. Leave EMPTY to withhold it — ' +
-      'answering reveals your timezone and that you are connected.',
+      'Reply sent for a CTCP TIME query (default is the current server time, ' +
+      'sent as UTC). Same placeholders as the VERSION reply. Leave EMPTY to ' +
+      'withhold it — answering tells the asker you are connected.',
   },
   {
     key: 'ctcp.source',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -847,11 +847,14 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
 
   // ─── CTCP auto-replies (what we disclose to the network on a CTCP query) ──
-  // Lurker answers a few standard CTCP queries cell-side (so they work even
-  // with no tab open). These let a privacy-conscious user trim or fully silence
-  // what gets published. Defaults preserve current behavior (all on). PING has
-  // no toggle — it only echoes back what the asker sent (no info disclosed) —
-  // but the master switch silences it too.
+  // Lurker answers a few standard CTCP queries cell-side (so they work even with
+  // no tab open). The per-type values are WeeChat-style reply TEMPLATES: the
+  // text sent back, with ${...} placeholders expanded. An EMPTY template
+  // disables that reply. Placeholders: ${name} (Lurker), ${version}, ${source}
+  // (project URL), ${time} (server time), ${clientinfo} (the types still
+  // answered), ${nick} (your nick). Defaults reproduce the standard replies.
+  // PING isn't templated — it only echoes the asker's token — but the master
+  // switch silences it too.
   {
     key: 'ctcp.replies',
     label: 'Answer CTCP queries',
@@ -863,49 +866,54 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'Master switch for replying to CTCP queries from other users (VERSION, ' +
       'TIME, SOURCE, CLIENTINFO, PING). Turn off to publish nothing — Lurker ' +
       'stays completely silent to CTCP, like a client with CTCP disabled. The ' +
-      'per-type toggles below apply only while this is on.',
+      'per-type reply templates below apply only while this is on.',
   },
   {
     key: 'ctcp.version',
-    label: 'Reply to CTCP VERSION',
+    label: 'CTCP VERSION reply',
     category: 'chat',
     group: 'ctcp',
-    type: 'bool',
-    default: true,
+    type: 'string',
+    default: '${name} ${version}',
     description:
-      'Answer CTCP VERSION with the Lurker name and version. Disclosing your ' +
-      'exact client/version aids fingerprinting; turn off to stay quiet.',
+      'Reply sent for a CTCP VERSION query. Placeholders: ${name}, ${version}, ' +
+      '${source}, ${time}, ${clientinfo}, ${nick}. Leave EMPTY to not answer ' +
+      'VERSION at all — disclosing your exact client/version aids fingerprinting.',
   },
   {
     key: 'ctcp.time',
-    label: 'Reply to CTCP TIME',
+    label: 'CTCP TIME reply',
     category: 'chat',
     group: 'ctcp',
-    type: 'bool',
-    default: true,
+    type: 'string',
+    default: '${time}',
     description:
-      'Answer CTCP TIME with the current server time. This reveals your ' +
-      'timezone and that you are connected; turn off to withhold it.',
+      'Reply sent for a CTCP TIME query (default is the current server time). ' +
+      'Same placeholders as the VERSION reply. Leave EMPTY to withhold it — ' +
+      'answering reveals your timezone and that you are connected.',
   },
   {
     key: 'ctcp.source',
-    label: 'Reply to CTCP SOURCE',
+    label: 'CTCP SOURCE reply',
     category: 'chat',
     group: 'ctcp',
-    type: 'bool',
-    default: true,
-    description: 'Answer CTCP SOURCE with the Lurker project URL.',
+    type: 'string',
+    default: '${source}',
+    description:
+      'Reply sent for a CTCP SOURCE query (default is the Lurker project URL). ' +
+      'Same placeholders as the VERSION reply. Leave EMPTY to not answer.',
   },
   {
     key: 'ctcp.clientinfo',
-    label: 'Reply to CTCP CLIENTINFO',
+    label: 'CTCP CLIENTINFO reply',
     category: 'chat',
     group: 'ctcp',
-    type: 'bool',
-    default: true,
+    type: 'string',
+    default: '${clientinfo}',
     description:
-      'Answer CTCP CLIENTINFO with the list of CTCP types Lurker responds to. ' +
-      'The list reflects whichever of the toggles above are enabled.',
+      'Reply sent for a CTCP CLIENTINFO query. The default ${clientinfo} ' +
+      'expands to the list of CTCP types you currently answer. Same ' +
+      'placeholders as the VERSION reply. Leave EMPTY to not answer.',
   },
 
   // ─── Auto-away (sets you AWAY when no client is connected) ────────────

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -869,6 +869,23 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'per-type reply templates below apply only while this is on.',
   },
   {
+    key: 'ctcp.msgbuffer',
+    label: 'Where CTCP notices appear',
+    category: 'chat',
+    group: 'ctcp',
+    type: 'enum',
+    choices: ['server', 'system', 'private'],
+    default: 'server',
+    description:
+      'Which buffer shows incoming CTCP notices — a "X requested CTCP …" probe, ' +
+      'or an unsolicited CTCP reply. Modeled on WeeChat irc.msgbuffer.ctcp. ' +
+      '"server" (default) = the network\'s server buffer; "system" = the ' +
+      'app-wide system buffer (these lines persist there, like other log ' +
+      'lines); "private" = a DM with the sender (or the channel, for a ' +
+      'channel-targeted CTCP). A reply to a /ctcp YOU sent always returns to ' +
+      'the buffer you ran it from, regardless of this.',
+  },
+  {
     key: 'ctcp.version',
     label: 'CTCP VERSION reply',
     category: 'chat',


### PR DESCRIPTION
## Why

After the CTCP feature merged, a user asked whether they could control what Lurker **publishes via CTCP** (client version, `TIME` leaks timezone, etc.). The replies were hardcoded. This went **full WeeChat**: each reply is an editable **template** (empty = disabled), plus a buffer-routing knob for incoming CTCP notices.

## Settings (Chat → "CTCP replies")

Defaults reproduce the standard replies / current placement, so existing behavior is preserved.

| Setting | Type | Default | Notes |
|---|---|---|---|
| `ctcp.replies` | bool | `true` | **Master switch**; off = publish nothing, not even a PING echo |
| `ctcp.version` | string | `${name} ${version}` | reply template (empty = disabled) |
| `ctcp.time` | string | `${time}` | "" |
| `ctcp.source` | string | `${source}` | "" |
| `ctcp.clientinfo` | string | `${clientinfo}` | "" |
| `ctcp.msgbuffer` | enum | `server` | where incoming CTCP notices land — `server` \| `system` \| `private` |

### Templates
An **empty template disables that reply** (WeeChat semantics). Placeholders (`${...}` — WeeChat's syntax, *not* mustache):
- `${name}` → "Lurker" · `${version}` → version · `${source}` → project URL
- `${time}` → server time · `${nick}` → your nick · `${clientinfo}` → the CTCP types you currently answer

Unknown placeholders are left literal so a typo is visible. CR/LF/NUL are stripped from the expanded reply so a crafted template can't smuggle a second wire command.

### `ctcp.msgbuffer` (mirrors WeeChat `irc.msgbuffer.ctcp`)
Controls which buffer shows an incoming CTCP notice (a `X requested CTCP …` probe, or an *unsolicited* reply):
- **`server`** (default) — the network's server buffer
- **`system`** — the durable app-wide system buffer (these lines persist, like other log lines)
- **`private`** — a DM with the sender (or the channel, for a channel-targeted CTCP)

WeeChat's `current` (active buffer) is intentionally omitted — it's a client concept, and Lurker generates these lines cell-side and fans them to every tab, so there's no single "current buffer" server-side. A reply to a `/ctcp` **you** sent always returns to the buffer you ran it from, regardless of this setting.

## How it fits
- Registry-backed, so every setting gets a **Settings UI pane and `/set`** for free — no client code.
- Server-consumed (auto-replies fire cell-side with no tab open), read per request via `effectiveSetting()` — same pattern as `chat.quit_message`.
- **PING** stays a verbatim echo (must mirror the asker's token), but the master switch silences it.
- **CLIENTINFO is dynamic** — `${clientinfo}` lists only types whose templates are non-empty.
- Default VERSION reply is now `Lurker <version>` (dropped the old trailing contact URL — less disclosure, still available via `${source}`). Removed the now-unused `IRC_VERSION`.

## Tests
- Unit: `expandCtcpTemplate`, default/custom templates, empty/whitespace disables, CR/LF strip, `enabledCtcpTypes`.
- Wiring: disabled template suppresses the reply; master silences all; `ctcp.msgbuffer` routing (server / private direct / private channel / system→durable).
- Server **1224** green, client **260** green, `npm run check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)