### PR TITLE
Add relay-bot message re-attribution (#277)

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -358,6 +358,14 @@ export const EXPORT_TABLES = Object.freeze({
     columns: ['user_id', 'network_id', 'nick', 'note', 'updated_at'],
   },
 
+  user_relay_bots: {
+    mode: 'export',
+    scope: 'user_id',
+    section: 'data',
+    fkRekey: { user_id: 'users', network_id: 'networks' },
+    columns: ['user_id', 'network_id', 'nick', 'pattern', 'created_at'],
+  },
+
   user_bookmarks: {
     mode: 'export',
     scope: 'user_id',
@@ -491,6 +499,7 @@ export const IMPORT_ORDER = Object.freeze([
   'user_settings',
   'ignored_masks',
   'user_nick_notes',
+  'user_relay_bots',
   'pinned_buffers',
   'nicklist_collapsed',
   'channel_notify_settings',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -433,6 +433,24 @@ function migrate() {
     CREATE INDEX IF NOT EXISTS idx_user_nick_notes_user_net
       ON user_nick_notes(user_id, network_id);
 
+    -- Per-(user, network, nick) relay-bot marks (#277). A marked nick is a
+    -- relay / bridge bot; the client re-attributes its messages to the speaker
+    -- embedded in the envelope, e.g. [Discord] <alice> hi. Row presence is the
+    -- mark; the pattern column is an optional custom template (empty = built-in
+    -- defaults). Same NOCASE / per-network keying as notes.
+    CREATE TABLE IF NOT EXISTS user_relay_bots (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      nick TEXT NOT NULL COLLATE NOCASE,
+      pattern TEXT NOT NULL DEFAULT '',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, network_id, nick),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_user_relay_bots_user_net
+      ON user_relay_bots(user_id, network_id);
+
     -- Friends / watch-list. A "contact" is a person, network-agnostic: it carries
     -- the display name and the per-contact "toast me when they come online" flag.
     -- contact_targets is the watch list — which (network, nick) to follow for

--- a/server/db/relayBots.ts
+++ b/server/db/relayBots.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import db from './index.js';
+
+// Per-(user, network, nick) relay-bot marks (#277). A marked nick is a relay /
+// bridge bot whose messages wrap another person's speech in an envelope like
+// `[Discord] <alice> hi`; the client re-attributes those lines to the embedded
+// speaker. A row's presence IS the mark; `pattern` is an optional custom
+// template (empty = use the built-in default formats). nick collates NOCASE so
+// case-flips don't fragment, and the same nick on different networks is its own
+// row because the bots may be unrelated.
+
+/** A row from the `user_relay_bots` table. */
+export interface UserRelayBot {
+  user_id: number;
+  network_id: number;
+  nick: string;
+  pattern: string;
+  created_at: string;
+}
+
+/** Projected mark returned to callers. */
+export interface RelayBotResult {
+  nick: string;
+  pattern: string;
+}
+
+const upsertStmt = db.prepare(`
+  INSERT INTO user_relay_bots (user_id, network_id, nick, pattern, created_at)
+  VALUES (@userId, @networkId, @nick, @pattern, datetime('now'))
+  ON CONFLICT(user_id, network_id, nick) DO UPDATE SET
+    pattern = excluded.pattern
+`);
+
+const deleteStmt = db.prepare(`
+  DELETE FROM user_relay_bots
+  WHERE user_id = @userId AND network_id = @networkId AND nick = @nick COLLATE NOCASE
+`);
+
+const getStmt = db.prepare(`
+  SELECT nick, pattern FROM user_relay_bots
+  WHERE user_id = ? AND network_id = ? AND nick = ? COLLATE NOCASE
+`);
+
+const listForUserStmt = db.prepare(`
+  SELECT network_id AS networkId, nick, pattern
+  FROM user_relay_bots
+  WHERE user_id = ?
+`);
+
+/** Mark a nick as a relay bot (upsert), optionally with a custom template. */
+export function setRelayBot({
+  userId,
+  networkId,
+  nick,
+  pattern,
+}: {
+  userId: number;
+  networkId: number;
+  nick: string;
+  pattern: string;
+}): RelayBotResult | null {
+  upsertStmt.run({ userId, networkId, nick, pattern: (pattern || '').trim() });
+  return (getStmt.get(userId, networkId, nick) as RelayBotResult | undefined) ?? null;
+}
+
+/** Clear a relay-bot mark. */
+export function removeRelayBot({
+  userId,
+  networkId,
+  nick,
+}: {
+  userId: number;
+  networkId: number;
+  nick: string;
+}): void {
+  deleteStmt.run({ userId, networkId, nick });
+}
+
+export function getRelayBot({
+  userId,
+  networkId,
+  nick,
+}: {
+  userId: number;
+  networkId: number;
+  nick: string;
+}): RelayBotResult | null {
+  return (getStmt.get(userId, networkId, nick) as RelayBotResult | undefined) ?? null;
+}
+
+// Map<networkId, [{ nick, pattern }, ...]> for snapshot seeding.
+export function listForUserGrouped(
+  userId: number,
+): Map<number, Array<{ nick: string; pattern: string }>> {
+  const out = new Map<number, Array<{ nick: string; pattern: string }>>();
+  for (const row of listForUserStmt.all(userId) as Array<{
+    networkId: number;
+    nick: string;
+    pattern: string;
+  }>) {
+    const entry = { nick: row.nick, pattern: row.pattern };
+    const list = out.get(row.networkId);
+    if (list) list.push(entry);
+    else out.set(row.networkId, [entry]);
+  }
+  return out;
+}

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -28,6 +28,12 @@ import {
 } from '../db/nickNotes.js';
 import type { NoteResult } from '../db/nickNotes.js';
 import {
+  listForUserGrouped as listRelayBotsGrouped,
+  setRelayBot as setRelayBotRow,
+  removeRelayBot as removeRelayBotRow,
+} from '../db/relayBots.js';
+import type { RelayBotResult } from '../db/relayBots.js';
+import {
   createContact,
   updateContactMeta,
   setContactTargets,
@@ -619,6 +625,7 @@ class IrcManager extends EventEmitter {
     const notifyByNetwork = listChannelNotifyForUser(userId);
     const ignoresByNetwork = ignoresGrouped(userId);
     const notesByNetwork = listNickNotesGrouped(userId);
+    const relayBotsByNetwork = listRelayBotsGrouped(userId);
     // Attach the per-network user-preference blobs to a base snapshot. Shared by
     // the live-connection and offline branches so both shapes stay identical.
     const withExtras = <T extends { networkId: number }>(snap: T) => {
@@ -630,6 +637,7 @@ class IrcManager extends EventEmitter {
         channelNotify: notifyByNetwork.get(networkId) || {},
         ignoredMasks: ignoresByNetwork.get(networkId) || [],
         nickNotes: notesByNetwork.get(networkId) || [],
+        relayBots: relayBotsByNetwork.get(networkId) || [],
       };
     };
     const live = this.listConnections(userId);
@@ -696,6 +704,22 @@ class IrcManager extends EventEmitter {
 
   getNickNote(userId: number, networkId: number, nick: string): NoteResult | null {
     return getNickNoteRow({ userId, networkId, nick });
+  }
+
+  // Mark/unmark a relay bot (#277). Returns the stored row when marked, or null
+  // after clearing the mark — the verb maps that to `marked`.
+  setRelayBot(
+    userId: number,
+    networkId: number,
+    nick: string,
+    marked: boolean,
+    pattern: string,
+  ): RelayBotResult | null {
+    if (!marked) {
+      removeRelayBotRow({ userId, networkId, nick });
+      return null;
+    }
+    return setRelayBotRow({ userId, networkId, nick, pattern });
   }
 
   listContacts(userId: number): ContactRecord[] {

--- a/server/services/mcpServer.test.ts
+++ b/server/services/mcpServer.test.ts
@@ -124,6 +124,7 @@ describe('MCP server', () => {
       'send_notice',
       'set_contact',
       'set_nick_note',
+      'set_relay_bot',
     ]);
     // Each entry carries an inputSchema usable by an MCP client.
     for (const tool of res.body.result.tools as Array<{ inputSchema: { type: string } }>) {

--- a/server/services/textMatch.test.ts
+++ b/server/services/textMatch.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { buildTextTest, stripFormatting, cleanForMatch } from './textMatch.js';
+import {
+  buildTextTest,
+  stripFormatting,
+  cleanForMatch,
+  rawIndexForVisibleOffset,
+} from './textMatch.js';
 
 describe('buildTextTest — substr', () => {
   it('matches case-insensitive substring by default', () => {
@@ -97,5 +102,27 @@ describe('stripFormatting / cleanForMatch', () => {
 
   it('cleanForMatch also strips URLs', () => {
     expect(cleanForMatch('see https://example.com/amiantos here')).not.toContain('amiantos');
+  });
+});
+
+describe('rawIndexForVisibleOffset', () => {
+  it('maps offsets straight through when there is no formatting', () => {
+    expect(rawIndexForVisibleOffset('hello world', 6)).toBe(6);
+    expect('hello world'.slice(rawIndexForVisibleOffset('hello world', 6))).toBe('world');
+  });
+
+  it('returns 0 for a non-positive offset', () => {
+    expect(rawIndexForVisibleOffset('\x02abc', 0)).toBe(0);
+  });
+
+  it('skips colour codes so the raw index lands past them', () => {
+    // 7 visible chars are "<FAST> " — the raw index should point at the message.
+    const raw = '<\x0313FAST\x03> hi';
+    expect(raw.slice(rawIndexForVisibleOffset(raw, 7))).toBe('hi');
+  });
+
+  it('clamps to the raw length when the offset exceeds the visible text', () => {
+    const raw = '\x02ab\x02';
+    expect(rawIndexForVisibleOffset(raw, 99)).toBe(raw.length);
   });
 });

--- a/server/services/verbs/index.ts
+++ b/server/services/verbs/index.ts
@@ -10,6 +10,7 @@ import './recentMessages.js';
 import './searchMessages.js';
 import './getNickNote.js';
 import './setNickNote.js';
+import './setRelayBot.js';
 import './setContact.js';
 import './deleteContact.js';
 import './sendMessage.js';

--- a/server/services/verbs/setRelayBot.ts
+++ b/server/services/verbs/setRelayBot.ts
@@ -44,7 +44,12 @@ registerVerb({
     const saved = ircManager.setRelayBot(ctx.userId, networkId, nick, marked, pattern);
     const result = {
       networkId,
-      nick,
+      // Echo the canonical stored casing when marked: the row may predate this
+      // call under a different case (the NOCASE primary key keeps the
+      // first-inserted casing), so this keeps the WS echo and /relay list in
+      // agreement with snapshot seeding. Falls back to the input nick when
+      // clearing — there's no row to read, and casing is moot once removed.
+      nick: saved ? saved.nick : nick,
       marked: !!saved,
       pattern: saved ? saved.pattern : '',
     };

--- a/server/services/verbs/setRelayBot.ts
+++ b/server/services/verbs/setRelayBot.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { registerVerb } from '../verbRegistry.js';
+import ircManager from '../ircManager.js';
+import { fanOutToUser } from '../wsHub.js';
+
+/** Authenticated caller context passed to every verb handler. */
+interface VerbContext {
+  userId: number;
+  scope: string;
+}
+
+registerVerb({
+  name: 'set_relay_bot',
+  description:
+    'Mark or unmark a nick as a relay/bridge bot on a network (#277). When marked, the client re-attributes the bot\'s messages to the speaker embedded in its envelope (e.g. "[Discord] <alice> hi" is shown as alice). Set marked=false to clear the mark. An optional pattern overrides the built-in formats with a custom template using {source}, {nick}, and {message} placeholders.',
+  scope: 'read-write',
+  input: {
+    type: 'object',
+    properties: {
+      networkId: { type: 'integer' },
+      nick: { type: 'string' },
+      marked: { type: 'boolean', description: 'true to mark as a relay bot, false to clear.' },
+      pattern: {
+        type: 'string',
+        description:
+          'Optional custom envelope template. Empty string uses the built-in defaults. Must contain {nick} and {message}; {source} is optional.',
+        maxLength: 512,
+      },
+    },
+    required: ['networkId', 'nick', 'marked'],
+    additionalProperties: false,
+  },
+  handler(ctx: VerbContext, input: Record<string, unknown>) {
+    const networkId = Number(input.networkId);
+    const nick = typeof input.nick === 'string' ? input.nick.trim() : '';
+    if (!nick) {
+      throw Object.assign(new Error('nick is empty or whitespace'), { code: 'invalid_input' });
+    }
+    const marked = input.marked === true;
+    const rawPattern = typeof input.pattern === 'string' ? input.pattern : '';
+    const pattern = rawPattern.length > 512 ? rawPattern.slice(0, 512) : rawPattern;
+    const saved = ircManager.setRelayBot(ctx.userId, networkId, nick, marked, pattern);
+    const result = {
+      networkId,
+      nick,
+      marked: !!saved,
+      pattern: saved ? saved.pattern : '',
+    };
+    // Fan out to every open WS tab of this user so the mark stays in sync across
+    // devices, mirroring nick-note / contact updates.
+    fanOutToUser(ctx.userId, { kind: 'relay-bot-updated', ...result });
+    return result;
+  },
+});

--- a/server/services/verbs/verbs.test.ts
+++ b/server/services/verbs/verbs.test.ts
@@ -695,6 +695,24 @@ describe('set_relay_bot', () => {
     );
   });
 
+  it('echoes the canonical stored casing when re-marking under a different case', () => {
+    callVerb('set_relay_bot', rwCtx(owner.id), {
+      networkId: net.id,
+      nick: 'CamelBot',
+      marked: true,
+      pattern: '',
+    });
+    // NOCASE primary key keeps the first-inserted 'CamelBot'; the response echoes
+    // that, not the 'camelbot' just passed in, so the UI shows consistent casing.
+    const out = callVerb('set_relay_bot', rwCtx(owner.id), {
+      networkId: net.id,
+      nick: 'camelbot',
+      marked: true,
+      pattern: 'x',
+    });
+    expect(out).toMatchObject({ nick: 'CamelBot', marked: true, pattern: 'x' });
+  });
+
   it('throws unknown_network for a network the caller does not own', () => {
     let code: string | undefined;
     try {

--- a/server/services/verbs/verbs.test.ts
+++ b/server/services/verbs/verbs.test.ts
@@ -649,3 +649,75 @@ describe('delete_contact', () => {
     expect((caughtErr as Error).message).toMatch(/contactId/);
   });
 });
+
+describe('set_relay_bot', () => {
+  it('marks a nick (persisting it NOCASE) and then clears it', async () => {
+    const { getRelayBot } = await import('../../db/relayBots.js');
+    const marked = callVerb('set_relay_bot', rwCtx(owner.id), {
+      networkId: net.id,
+      nick: 'RelayBot',
+      marked: true,
+      pattern: '',
+    });
+    expect(marked).toMatchObject({
+      networkId: net.id,
+      nick: 'RelayBot',
+      marked: true,
+      pattern: '',
+    });
+    // Stored, and resolvable regardless of case.
+    expect(getRelayBot({ userId: owner.id, networkId: net.id, nick: 'relaybot' })).toMatchObject({
+      nick: 'RelayBot',
+      pattern: '',
+    });
+
+    const cleared = callVerb('set_relay_bot', rwCtx(owner.id), {
+      networkId: net.id,
+      nick: 'relaybot',
+      marked: false,
+      pattern: '',
+    });
+    expect(cleared).toMatchObject({ marked: false, pattern: '' });
+    expect(getRelayBot({ userId: owner.id, networkId: net.id, nick: 'RelayBot' })).toBeNull();
+  });
+
+  it('stores and round-trips a custom envelope template', async () => {
+    const { getRelayBot } = await import('../../db/relayBots.js');
+    const saved = callVerb('set_relay_bot', rwCtx(owner.id), {
+      networkId: net.id,
+      nick: 'bridge',
+      marked: true,
+      pattern: '<{nick}> {message}',
+    });
+    expect(saved).toMatchObject({ marked: true, pattern: '<{nick}> {message}' });
+    expect(getRelayBot({ userId: owner.id, networkId: net.id, nick: 'bridge' })?.pattern).toBe(
+      '<{nick}> {message}',
+    );
+  });
+
+  it('throws unknown_network for a network the caller does not own', () => {
+    let code: string | undefined;
+    try {
+      callVerb('set_relay_bot', rwCtx(owner.id), {
+        networkId: otherNet.id,
+        nick: 'x',
+        marked: true,
+        pattern: '',
+      });
+    } catch (err) {
+      code = (err as { code?: string }).code;
+    }
+    expect(code).toBe('unknown_network');
+  });
+
+  it('is rejected for read-only scope', () => {
+    expect(() =>
+      callVerb('set_relay_bot', rCtx(owner.id), {
+        networkId: net.id,
+        nick: 'x',
+        marked: true,
+        pattern: '',
+      }),
+    ).toThrow(/scope insufficient/);
+  });
+});

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1967,6 +1967,26 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         }
         break;
       }
+      case 'set-relay-bot': {
+        // Relay-bot mark (#277). Same thin-delegator shape as set-nick-note:
+        // the verb owns validation, the mark/unmark + custom-pattern logic, and
+        // the relay-bot-updated fanOut to every open tab.
+        try {
+          callVerb(
+            'set_relay_bot',
+            { userId, scope: 'read-write', transport: 'ws' },
+            {
+              networkId: msg.networkId,
+              nick: msg.nick,
+              marked: msg.marked,
+              pattern: msg.pattern,
+            },
+          );
+        } catch (_) {
+          /* boundary already filtered bad networkId; ignore */
+        }
+        break;
+      }
       case 'set-contact': {
         // Verb owns validation, the per-(network,nick) uniqueness guard, the
         // live MONITOR diff, and the fanOut. Thin delegator, same as nick-note.

--- a/shared/parseRelay.test.ts
+++ b/shared/parseRelay.test.ts
@@ -105,6 +105,31 @@ describe('parseRelayMessage — custom templates', () => {
   });
 });
 
+describe('parseRelayMessage — reversed layout (nick before source)', () => {
+  // Real ##videogames bot that posts `<nick> [source] message` — the reverse of
+  // our default — plus a stray colour code and fancy unicode/emoji in the body.
+  const raw = '\x0303<EyeSeeYou> [Discord] Present: 𝔅𝔢𝔩𝔦𝔞𝔩 ChatGAYTB 🌈🏳️‍🌈 syrius';
+
+  it('extracts source/nick/message cleanly with a matching custom template', () => {
+    expect(parseRelayMessage(raw, '<{nick}> [{source}] {message}')).toEqual({
+      source: 'Discord',
+      nick: 'EyeSeeYou',
+      text: 'Present: 𝔅𝔢𝔩𝔦𝔞𝔩 ChatGAYTB 🌈🏳️‍🌈 syrius',
+    });
+  });
+
+  it('with defaults, still attributes the nick but leaves [source] inline', () => {
+    // The bare `<nick> message` default catches it, so re-attribution works, but
+    // the reversed [source] tag isn't recognized — it stays in the body. This is
+    // the behavior that motivates the custom template above.
+    expect(parseRelayMessage(raw)).toEqual({
+      source: null,
+      nick: 'EyeSeeYou',
+      text: '[Discord] Present: 𝔅𝔢𝔩𝔦𝔞𝔩 ChatGAYTB 🌈🏳️‍🌈 syrius',
+    });
+  });
+});
+
 describe('parseRelayMessage — mIRC formatting', () => {
   it('strips colour codes AND the +voice prefix off the nick (the ##videogames case)', () => {
     // Bot colours the nick `+FAST` (voiced on efnet) with mIRC colour 13, resets

--- a/shared/parseRelay.test.ts
+++ b/shared/parseRelay.test.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { parseRelayMessage, compileRelayTemplate, DEFAULT_RELAY_TEMPLATES } from './parseRelay.js';
+
+describe('parseRelayMessage — default formats', () => {
+  it('parses the bracketed-source form `[source] <nick> message`', () => {
+    expect(parseRelayMessage('[Discord] <alice> hello there')).toEqual({
+      source: 'Discord',
+      nick: 'alice',
+      text: 'hello there',
+    });
+  });
+
+  it('parses the bare `<nick> message` form (no source tag)', () => {
+    expect(parseRelayMessage('<bob> hey everyone')).toEqual({
+      source: null,
+      nick: 'bob',
+      text: 'hey everyone',
+    });
+  });
+
+  it('keeps angle brackets and brackets that appear inside the message body', () => {
+    expect(parseRelayMessage('[Telegram] <carol> 2 < 3 and [maybe] > nope')).toEqual({
+      source: 'Telegram',
+      nick: 'carol',
+      text: '2 < 3 and [maybe] > nope',
+    });
+  });
+
+  it('preserves an empty relayed message', () => {
+    expect(parseRelayMessage('[IRC] <dave> ')).toEqual({ source: 'IRC', nick: 'dave', text: '' });
+  });
+
+  it('does not match a plain message with no envelope', () => {
+    expect(parseRelayMessage('just a normal line from the bot')).toBeNull();
+  });
+
+  it('does not match when only a closing bracket is present', () => {
+    expect(parseRelayMessage('lunch < later')).toBeNull();
+  });
+
+  it('returns null for empty / nullish bodies', () => {
+    expect(parseRelayMessage('')).toBeNull();
+    expect(parseRelayMessage(null)).toBeNull();
+    expect(parseRelayMessage(undefined)).toBeNull();
+  });
+
+  it('handles a source tag that contains spaces', () => {
+    expect(parseRelayMessage('[Game Chat] <eve> gg')).toEqual({
+      source: 'Game Chat',
+      nick: 'eve',
+      text: 'gg',
+    });
+  });
+});
+
+describe('parseRelayMessage — membership prefixes', () => {
+  it('drops a leading +voice prefix from the nick', () => {
+    expect(parseRelayMessage('<+bob> hi')).toEqual({ source: null, nick: 'bob', text: 'hi' });
+  });
+
+  it('drops stacked prefixes (e.g. @+) but keeps the rest of the nick', () => {
+    expect(parseRelayMessage('[net] <@+carol> yo')).toEqual({
+      source: 'net',
+      nick: 'carol',
+      text: 'yo',
+    });
+  });
+
+  it('leaves a normal nick untouched', () => {
+    expect(parseRelayMessage('<dave> hey')).toEqual({ source: null, nick: 'dave', text: 'hey' });
+  });
+});
+
+describe('parseRelayMessage — custom templates', () => {
+  it('honors a custom `nick: message` template', () => {
+    expect(parseRelayMessage('frank: yo', '{nick}: {message}')).toEqual({
+      source: null,
+      nick: 'frank',
+      text: 'yo',
+    });
+  });
+
+  it('honors a custom template with a parenthesized source', () => {
+    expect(parseRelayMessage('(Matrix) grace » hi', '({source}) {nick} » {message}')).toEqual({
+      source: 'Matrix',
+      nick: 'grace',
+      text: 'hi',
+    });
+  });
+
+  it('falls back to defaults when the custom pattern is blank', () => {
+    expect(parseRelayMessage('[Slack] <heidi> ok', '   ')).toEqual({
+      source: 'Slack',
+      nick: 'heidi',
+      text: 'ok',
+    });
+  });
+
+  it('returns null when the custom template lacks required placeholders', () => {
+    expect(parseRelayMessage('whatever', 'no placeholders here')).toBeNull();
+    expect(parseRelayMessage('<x> y', '<{nick}> no-message-placeholder')).toBeNull();
+  });
+});
+
+describe('parseRelayMessage — mIRC formatting', () => {
+  it('strips colour codes AND the +voice prefix off the nick (the ##videogames case)', () => {
+    // Bot colours the nick `+FAST` (voiced on efnet) with mIRC colour 13, resets
+    // before `>`. We want a clean `FAST` so coloring/Reply/Copy target the nick.
+    const raw = '[efnet] <\x0313+FAST\x03> ultros: bet';
+    expect(parseRelayMessage(raw)).toEqual({
+      source: 'efnet',
+      nick: 'FAST',
+      text: 'ultros: bet',
+    });
+  });
+
+  it('strips colour codes wrapping the source tag too', () => {
+    const raw = '\x0304[efnet]\x03 <\x0313FAST\x03> hey there';
+    expect(parseRelayMessage(raw)).toEqual({ source: 'efnet', nick: 'FAST', text: 'hey there' });
+  });
+
+  it('strips bold/underline toggles around the envelope', () => {
+    const raw = '[\x02Discord\x02] <\x1funderlined\x1f> hello';
+    expect(parseRelayMessage(raw)).toEqual({
+      source: 'Discord',
+      nick: 'underlined',
+      text: 'hello',
+    });
+  });
+
+  it("preserves the message's OWN formatting in the displayed text", () => {
+    // Nick is coloured (stripped for matching), but the message is bold and that
+    // bold survives into the re-attributed line.
+    const raw = '[efnet] <\x0313FAST\x03> \x02bold msg\x02';
+    expect(parseRelayMessage(raw)).toEqual({
+      source: 'efnet',
+      nick: 'FAST',
+      text: '\x02bold msg\x02',
+    });
+  });
+
+  it('preserves message colour codes after the envelope', () => {
+    const raw = '<\x0307relaybot\x03> \x0304red\x03 and \x0309green\x03';
+    expect(parseRelayMessage(raw)).toEqual({
+      source: null,
+      nick: 'relaybot',
+      text: '\x0304red\x03 and \x0309green\x03',
+    });
+  });
+});
+
+describe('compileRelayTemplate', () => {
+  it('compiles the built-in defaults', () => {
+    for (const t of DEFAULT_RELAY_TEMPLATES) {
+      expect(compileRelayTemplate(t)).not.toBeNull();
+    }
+  });
+
+  it('records slot order for source/nick/message', () => {
+    const compiled = compileRelayTemplate('[{source}] <{nick}> {message}');
+    expect(compiled?.slots).toEqual(['source', 'nick', 'message']);
+  });
+
+  it('rejects a template missing {nick} or {message}', () => {
+    expect(compileRelayTemplate('<{nick}> static')).toBeNull();
+    expect(compileRelayTemplate('{message} only')).toBeNull();
+  });
+
+  it('treats regex metacharacters in the template as literals', () => {
+    // The `.` and `*` are literal here, so a real `.*` in the body must match
+    // them verbatim rather than acting as a wildcard.
+    const parsed = parseRelayMessage('a.*b ivan done', '{source}.*b {nick} {message}');
+    expect(parsed).toEqual({ source: 'a', nick: 'ivan', text: 'done' });
+    expect(parseRelayMessage('aXXb ivan done', '{source}.*b {nick} {message}')).toBeNull();
+  });
+});

--- a/shared/parseRelay.ts
+++ b/shared/parseRelay.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Relay/bridge-bot message parsing (#277). A relay bot posts other people's
+// messages on IRC — bridged in from Discord, Telegram, Matrix, another network,
+// etc. — wrapped in a fixed envelope like `[Discord] <alice> hello`. When the
+// user marks the bot's nick as a relay, the client parses that envelope and
+// attributes the line to the embedded speaker instead of the bot.
+//
+// Parsing is template-driven, not free regex: a template is literal text with
+// `{source}`, `{nick}`, and `{message}` placeholders. We escape the literals
+// and compile the placeholders to capture groups, so a user-supplied pattern
+// can't inject regex or trigger catastrophic backtracking. `{nick}` and
+// `{message}` are required; `{source}` is optional. Everything stays pure and
+// dependency-free so it runs at render time on the client and in tests from the
+// repo root.
+
+import { stripFormatting, rawIndexForVisibleOffset } from './textMatch.js';
+
+/** Which captured value a compiled group holds, in left-to-right order. */
+type Slot = 'source' | 'nick' | 'message';
+
+/** Parsed envelope: the embedded speaker plus the platform tag, when present. */
+export interface RelayParse {
+  /** The `[source]` tag (e.g. "Discord"), or null when the template omits it. */
+  source: string | null;
+  /** The embedded speaker's nick. Always non-empty on a successful parse. */
+  nick: string;
+  /** The actual message text, with the envelope stripped. */
+  text: string;
+}
+
+// Channel-membership prefix glyphs (PREFIX in ISUPPORT): owner ~, admin &, op @,
+// halfop %, voice +. A relay bot often carries the speaker's status from the
+// source channel — `<+FAST>` — but those glyphs aren't part of the nick, so we
+// drop a leading run of them. Safe because a real nick can't begin with one.
+const MEMBER_PREFIX_RE = /^[~&@%+]+/;
+
+// Built-in formats, tried in order. The bracketed-source form first because
+// it's the common bridge shape (matterbridge, the ##videogames relay on Libera,
+// most operator-run bots); the bare `<nick>` form second for relays that don't
+// prefix a platform tag. A marked bot whose format matches neither needs a
+// custom template.
+export const DEFAULT_RELAY_TEMPLATES = ['[{source}] <{nick}> {message}', '<{nick}> {message}'];
+
+const PLACEHOLDER = /\{(source|nick|message)\}/g;
+
+function escapeLiteral(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+interface Compiled {
+  re: RegExp;
+  slots: Slot[];
+}
+
+// Compiled-template cache. Templates are a tiny, stable set (two defaults plus
+// the occasional custom pattern), so an unbounded Map is fine and keeps the
+// per-row render cost to a hash lookup.
+const cache = new Map<string, Compiled | null>();
+
+/**
+ * Compile a relay template into an anchored regex plus the slot order of its
+ * capture groups. Returns null when the template lacks the required `{nick}` /
+ * `{message}` placeholders or produces an invalid regex.
+ */
+export function compileRelayTemplate(template: string): Compiled | null {
+  if (cache.has(template)) return cache.get(template) ?? null;
+  const slots: Slot[] = [];
+  let out = '';
+  let last = 0;
+  let m: RegExpExecArray | null;
+  PLACEHOLDER.lastIndex = 0;
+  while ((m = PLACEHOLDER.exec(template))) {
+    out += escapeLiteral(template.slice(last, m.index));
+    const slot = m[1] as Slot;
+    slots.push(slot);
+    // `{message}` is greedy to the end of the line; `{nick}` and `{source}` are
+    // lazy so the literals that follow them (`>`, `]`, a space) bound the match.
+    // A nick can't contain whitespace; a source tag might, so it's permissive.
+    out += slot === 'message' ? '(.*)' : slot === 'nick' ? '(\\S+?)' : '(.+?)';
+    last = m.index + m[0].length;
+  }
+  out += escapeLiteral(template.slice(last));
+  if (!slots.includes('nick') || !slots.includes('message')) {
+    cache.set(template, null);
+    return null;
+  }
+  let compiled: Compiled | null;
+  try {
+    compiled = { re: new RegExp(`^${out}$`), slots };
+  } catch {
+    compiled = null;
+  }
+  cache.set(template, compiled);
+  return compiled;
+}
+
+/**
+ * Parse a relay bot's message body into its embedded speaker and text. Pass a
+ * custom template to override the built-in formats; an empty/whitespace pattern
+ * falls back to {@link DEFAULT_RELAY_TEMPLATES}. Returns null when no template
+ * matches (the caller then renders the line unchanged, attributed to the bot).
+ */
+export function parseRelayMessage(
+  body: string | null | undefined,
+  customPattern?: string | null,
+): RelayParse | null {
+  if (!body) return null;
+  // Relay bots colour the source tag and nick (mIRC \x03 codes, bold, etc.),
+  // and those control chars sit right inside the [source]/<nick> we match — so
+  // strip formatting before matching or the envelope never lines up. The source
+  // and nick come back plain (we re-colour the nick ourselves anyway); the
+  // message keeps its own formatting, recovered by mapping the match back onto
+  // the raw body.
+  const stripped = stripFormatting(body);
+  const custom = (customPattern || '').trim();
+  const templates = custom ? [custom] : DEFAULT_RELAY_TEMPLATES;
+  for (const template of templates) {
+    const compiled = compileRelayTemplate(template);
+    if (!compiled) continue;
+    const match = compiled.re.exec(stripped);
+    if (!match) continue;
+    let source: string | null = null;
+    let nick = '';
+    let text = '';
+    compiled.slots.forEach((slot, i) => {
+      const value = match[i + 1] ?? '';
+      if (slot === 'source') source = value;
+      else if (slot === 'nick') nick = value;
+      else text = value;
+    });
+    // Drop any channel-membership prefix the bot carried into the nick, so the
+    // speaker reads as `FAST`, not `+FAST` — and so Reply/Copy target the real
+    // nick.
+    nick = nick.replace(MEMBER_PREFIX_RE, '');
+    if (!nick) continue;
+    // Recover the message's original formatting. {message} is the trailing group
+    // in every sane template, so its stripped form is a suffix of `stripped` —
+    // map that suffix's start back into the raw body and slice. (A custom
+    // template that puts {message} elsewhere falls back to the plain text.)
+    let displayText = text;
+    if (compiled.slots[compiled.slots.length - 1] === 'message') {
+      const rawStart = rawIndexForVisibleOffset(body, stripped.length - text.length);
+      displayText = body.slice(rawStart);
+    }
+    return { source, nick, text: displayText };
+  }
+  return null;
+}

--- a/shared/textMatch.ts
+++ b/shared/textMatch.ts
@@ -105,6 +105,36 @@ export function stripFormatting(text: string): string {
   return text.replace(FORMAT_RE, '');
 }
 
+// Sticky variant of FORMAT_RE for position-anchored scanning. Shares the source
+// so the two never drift.
+/* eslint-disable no-control-regex */
+const FORMAT_RE_STICKY = new RegExp(FORMAT_RE.source, 'y');
+/* eslint-enable no-control-regex */
+
+// Map a "visible" (formatting-stripped) character offset back to its index in
+// the raw, still-formatted string. When you match against stripFormatting(text)
+// but then need to slice the ORIGINAL text at the same logical point — e.g. to
+// keep a message's bold/colour after locating where it begins — this converts
+// the stripped offset to the raw one. Walks raw once, skipping whole format
+// codes (which contribute no visible characters).
+export function rawIndexForVisibleOffset(raw: string, visibleOffset: number): number {
+  if (visibleOffset <= 0) return 0;
+  let visible = 0;
+  let i = 0;
+  while (i < raw.length) {
+    if (visible >= visibleOffset) return i;
+    FORMAT_RE_STICKY.lastIndex = i;
+    const m = FORMAT_RE_STICKY.exec(raw);
+    if (m && m[0].length > 0) {
+      i += m[0].length;
+    } else {
+      visible++;
+      i++;
+    }
+  }
+  return raw.length;
+}
+
 // Normalize a message body for highlight/ignore-pattern matching: drop IRC
 // formatting codes, then blank out URLs. Both the highlight engine and the
 // ignore content matcher run this so they agree on what the "text" is.

--- a/vue_client/src/components/ContextMenu.vue
+++ b/vue_client/src/components/ContextMenu.vue
@@ -81,15 +81,11 @@ function activate(item: ContextMenuItem): void {
 function onWindowPointerDown(e: PointerEvent): void {
   if (!state.open) return;
   if (menuEl.value && menuEl.value.contains(e.target as Node)) return;
-  // Re-clicking the same trigger should close (toggle behavior). Without
-  // swallowing the event, the trigger's own @click handler runs next and
-  // immediately reopens the menu on the same gesture.
-  if (state.triggerEl && state.triggerEl.contains(e.target as Node)) {
-    e.preventDefault();
-    e.stopPropagation();
-    menu.close();
-    return;
-  }
+  // Leave a pointerdown on the opening trigger alone: its own click handler
+  // fires next and re-calls open() with the same triggerEl, which toggles the
+  // menu closed (see useContextMenu). Closing here would race that click and
+  // reopen the menu — pointerdown can't cancel the click that follows.
+  if (state.triggerEl && state.triggerEl.contains(e.target as Node)) return;
   menu.close();
 }
 function onWindowKey(e: KeyboardEvent): void {

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -129,10 +129,12 @@ function menuContext() {
 }
 function onRowClick(e: MouseEvent, m: BufferMember): void {
   if (!buffer.value) return;
-  memberActions.openMenuFor(m, menuContext(), e.clientX, e.clientY);
+  // Left-click: pass the row as the trigger so re-clicking it toggles closed.
+  memberActions.openMenuFor(m, menuContext(), e.clientX, e.clientY, e.currentTarget as Element);
 }
 function onRowContextMenu(e: MouseEvent, m: BufferMember): void {
   if (!buffer.value) return;
+  // Right-click: no trigger — a second right-click repositions, as is conventional.
   memberActions.openMenuFor(m, menuContext(), e.clientX, e.clientY);
 }
 function onActionsClick(e: MouseEvent, m: BufferMember): void {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -137,6 +137,7 @@ import { useNetworksStore, type Network } from '../stores/networks.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { parseNetworkCommand } from '../lib/commands/network.js';
 import { splitSetArgs, coerceSettingValue, formatSettingValue } from '../lib/commands/settings.js';
+import { parseRelayCommand } from '../lib/commands/relay.js';
 import { formatColumns } from '../lib/commands/output.js';
 import { REGISTRY, getOption, optionVisible, CATEGORIES } from '../utils/settingsRegistry.js';
 import type { SettingOption } from '../../../shared/settingsRegistry.js';
@@ -149,6 +150,7 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore, onInsertUrl } from '../stores/uploads.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
+import { useRelayBotsStore } from '../stores/relayBots.js';
 import { useHighlightRulesStore, type HighlightRule } from '../stores/highlightRules.js';
 import { parseIgnoreArgs } from '../../../shared/parseIgnore.js';
 import { parseHighlightArgs } from '../../../shared/parseHighlight.js';
@@ -208,6 +210,7 @@ const config = useConfigStore();
 const uploads = useUploadsStore();
 const toasts = useToastsStore();
 const ignores = useIgnoresStore();
+const relayBots = useRelayBotsStore();
 const highlightRules = useHighlightRulesStore();
 const chanlist = useChanlistStore();
 const channelListModal = useChannelListModal();
@@ -2036,6 +2039,8 @@ const COMMANDS_LINES = [
   '      opts: -network -mask -full -regexp -matchcase -channels <#a,#b>',
   '      e.g. /highlight QUACK!   ·   /highlight -mask bob!*@*   ·   /highlight -network -regexp qu+ack',
   '  /unhighlight <index|text> — remove a highlight (index from /highlight list; alias: /dehilight)',
+  '  /relay [list]          — list, mark, or unmark relay/bridge bots on this network',
+  '      e.g. /relay add relaybot   ·   /relay add bridge <{nick}> {message}   ·   /relay remove relaybot',
   '  /network [list]        — manage networks (alias: /net); runs from the system buffer',
   '      add [-host <addr>] [-port <n>] [-tls|-notls] [-nick <n>] [-user <u>] [-realname <name>]',
   '          [-sasl_username <u>] [-sasl_password <p>] [-password <serverpass>]',
@@ -2129,6 +2134,41 @@ function ackedSend(payload: Record<string, unknown>, body: string): boolean {
 // /ignore and /unignore operate on the per-user ignore list (global by default;
 // `-network` scopes to the active network), so they're network-agnostic and run
 // from the system buffer too — networkId is null there.
+// /relay (#277) — mark, unmark, or list relay/bridge bots on this network. The
+// store writes go over WS and echo back through `relay-bot-updated`, so the
+// confirmation here is optimistic-but-authoritative just like /ignore.
+function runRelay(argLine: string, networkId: number, target: string): boolean {
+  const cmd = parseRelayCommand(argLine);
+  if (cmd.kind === 'error') {
+    localInfo(networkId, target, `/relay: ${cmd.message}`);
+    return true;
+  }
+  if (cmd.kind === 'list') {
+    const list = relayBots.listForNetwork(networkId);
+    if (!list.length) {
+      localInfo(networkId, target, 'no relay bots marked on this network. /relay add <nick>');
+      return true;
+    }
+    localInfo(networkId, target, `relay bots (${list.length}):`);
+    for (const { nick, pattern } of list) {
+      localInfo(networkId, target, `  ${nick}${pattern ? `  — ${pattern}` : ''}`);
+    }
+    return true;
+  }
+  if (cmd.kind === 'add') {
+    relayBots.setRelay(networkId, cmd.nick, true, cmd.pattern);
+    localInfo(
+      networkId,
+      target,
+      `marked ${cmd.nick} as a relay bot${cmd.pattern ? ` (pattern: ${cmd.pattern})` : ''}.`,
+    );
+    return true;
+  }
+  relayBots.setRelay(networkId, cmd.nick, false);
+  localInfo(networkId, target, `unmarked ${cmd.nick} as a relay bot.`);
+  return true;
+}
+
 function runIgnore(argLine: string, networkId: number | null, target: string): boolean {
   const args = argLine.trim();
   if (!args) {
@@ -2554,6 +2594,10 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       }
       return sendOrToast({ type: 'e2e', networkId, target, args: argLine }, line);
     }
+    case 'relay':
+      // Mark/unmark/list relay bots on this network (#277). Network-scoped: a
+      // relay mark is per-(network, nick), so it needs an active network.
+      return runRelay(argLine, networkId, target);
     case 'me':
       return ackedSend({ type: 'action', networkId, target, text: argLine }, argLine);
     case 'ctcp': {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2041,6 +2041,8 @@ const COMMANDS_LINES = [
   '  /unhighlight <index|text> — remove a highlight (index from /highlight list; alias: /dehilight)',
   '  /relay [list]          — list, mark, or unmark relay/bridge bots on this network',
   '      e.g. /relay add relaybot   ·   /relay add bridge <{nick}> {message}   ·   /relay remove relaybot',
+  '      custom template mirrors the bot order with {source}/{nick}/{message} placeholders',
+  '      e.g. reversed: /relay add eyebot <{nick}> [{source}] {message}',
   '  /network [list]        — manage networks (alias: /net); runs from the system buffer',
   '      add [-host <addr>] [-port <n>] [-tls|-notls] [-nick <n>] [-user <u>] [-realname <name>]',
   '          [-sasl_username <u>] [-sasl_password <p>] [-password <serverpass>]',

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -103,7 +103,7 @@
           </div>
           <span class="body" :class="bodyClass(row.m)">
             <span
-              v-if="row.m?.relayBot && !row.continuationAuthor"
+              v-if="row.m?.relaySource && !row.continuationAuthor"
               class="relay-via"
               :title="'Relayed via ' + row.m.relayBot"
               >[{{ relayLabel(row.m) }}]</span
@@ -134,7 +134,7 @@
           >
           <span class="body" :class="bodyClass(row.m)">
             <span
-              v-if="row.m?.relayBot && !row.continuationAuthor"
+              v-if="row.m?.relaySource && !row.continuationAuthor"
               class="relay-via"
               :title="'Relayed via ' + row.m.relayBot"
               >[{{ relayLabel(row.m) }}]</span
@@ -742,11 +742,12 @@ function openRelayNickMenu(
 }
 
 // The "via" affordance shown next to a re-attributed relay line (#277): the
-// `[source]` platform tag when the envelope had one, else the bot's nick. The
-// full title always names the bot so the real origin is one hover away.
+// `[source]` platform tag. Only rendered when the envelope actually carried a
+// source (the template gates on relaySource), so a bare `<nick> message` relay
+// shows no tag and the re-attributed nick just reads as the speaker. The title
+// (set in the template) still names the bot, so provenance is one hover away.
 function relayLabel(m: ChatMessage | undefined): string {
-  if (!m?.relayBot) return '';
-  return m.relaySource || m.relayBot;
+  return m?.relaySource || '';
 }
 
 // A coloured nick mention inside message text (emitted by RenderSegments). The

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -691,11 +691,14 @@ function nickMenuContext(): MemberContext {
 // the kicked user in a kick line).
 function onNickMenu(e: MouseEvent, nick: string | undefined, m?: ChatMessage): void {
   if (!buffer.value) return;
+  // Nicks open on left-click, so pass the clicked element as the trigger:
+  // re-clicking the same name toggles its menu closed, like the kebab menus.
+  const trigger = (e.currentTarget as Element | null) ?? null;
   // Relay virtual speaker (#277): the displayed author is the embedded speaker,
   // not a real IRC user, so the full member menu (DM, ignore, kick, ban) is
   // meaningless. Give it a trimmed menu aimed at the relayed nick instead.
   if (m?.relayBot && nick && buffer.value.networkId != null) {
-    openRelayNickMenu(nick, m.relayBot, buffer.value.networkId, e.clientX, e.clientY);
+    openRelayNickMenu(nick, m.relayBot, buffer.value.networkId, e.clientX, e.clientY, trigger);
     return;
   }
   if (!nick) return;
@@ -703,7 +706,7 @@ function onNickMenu(e: MouseEvent, nick: string | undefined, m?: ChatMessage): v
   // fall back to the message's own userhost so a departed speaker stays
   // actionable.
   const member: MemberLike = nickMember(nick) ?? { nick, ...parseUserHost(m?.userhost) };
-  memberActions.openMenuFor(member, nickMenuContext(), e.clientX, e.clientY);
+  memberActions.openMenuFor(member, nickMenuContext(), e.clientX, e.clientY, trigger);
 }
 
 // Context menu for a relayed virtual speaker (#277). Only the actions that make
@@ -717,6 +720,7 @@ function openRelayNickMenu(
   networkId: number,
   x: number,
   y: number,
+  triggerEl: Element | null = null,
 ): void {
   const items: ContextMenuItem[] = [
     { label: `Reply to ${nick}`, icon: 'fa-solid fa-reply', onClick: () => addressNick(nick) },
@@ -734,7 +738,7 @@ function openRelayNickMenu(
       onClick: () => whois.openViewer(networkId, bot),
     },
   ];
-  contextMenu.open(items, x, y);
+  contextMenu.open(items, x, y, triggerEl);
 }
 
 // The "via" affordance shown next to a re-attributed relay line (#277): the

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -102,7 +102,12 @@
             /></span>
           </div>
           <span class="body" :class="bodyClass(row.m)">
-            <RenderSegments
+            <span
+              v-if="row.m?.relayBot && !row.continuationAuthor"
+              class="relay-via"
+              :title="'Relayed via ' + row.m.relayBot"
+              >[{{ relayLabel(row.m) }}]</span
+            ><RenderSegments
               :segments="textSegments(row.m)"
               :self-color="selfColor"
               :network-id="buffer?.networkId ?? null"
@@ -128,7 +133,12 @@
             ><template v-else>{{ row.continuationAuthor ? '' : prefixText(row.m) }}</template></span
           >
           <span class="body" :class="bodyClass(row.m)">
-            <RenderSegments
+            <span
+              v-if="row.m?.relayBot && !row.continuationAuthor"
+              class="relay-via"
+              :title="'Relayed via ' + row.m.relayBot"
+              >[{{ relayLabel(row.m) }}]</span
+            ><RenderSegments
               v-if="hasInlineText(row.m)"
               :segments="textSegments(row.m)"
               :self-color="selfColor"
@@ -262,6 +272,7 @@ import { useBuffersStore, type BufferMember } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
+import { useRelayBotsStore } from '../stores/relayBots.js';
 import { socketSend } from '../composables/useSocket.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useViewport } from '../composables/useViewport.js';
@@ -283,6 +294,7 @@ import {
 import { consolidateRows } from '../utils/consolidate.js';
 import type { ConsolidationGroup, NickEntry, RenameEntry } from '../../../shared/consolidate.js';
 import { collapseDisplay } from '../utils/collapseDisplay.js';
+import { parseRelayMessage } from '../../../shared/parseRelay.js';
 import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';
 import RenderSegments from './RenderSegments.vue';
@@ -295,6 +307,8 @@ import type {
 } from '../composables/useMessageActions.js';
 import { useMemberActions } from '../composables/useMemberActions.js';
 import type { MemberContext, MemberLike } from '../composables/useMemberActions.js';
+import { useContextMenu, type ContextMenuItem } from '../composables/useContextMenu.js';
+import { useWhoisStore } from '../stores/whois.js';
 import { addressNick } from '../composables/useComposerOverlay.js';
 import { setViewedBuffer } from '../composables/useViewedBuffer.js';
 
@@ -322,6 +336,13 @@ interface ChatMessage {
   e2e?: boolean;
   // Severity for `type: 'e2e'` status lines — drives the tag color.
   level?: 'info' | 'warn';
+  // Relay-bot re-attribution (#277). When set, this row was authored by a nick
+  // the user marked as a relay bot: `nick`/`text` have been swapped to the
+  // embedded speaker, `relayBot` holds the bot's real nick (the actual IRC
+  // entity), and `relaySource` is the `[source]` tag when the envelope had one.
+  // These exist only on the per-render display clone, never on the stored row.
+  relayBot?: string;
+  relaySource?: string | null;
   [key: string]: unknown;
 }
 
@@ -375,6 +396,7 @@ const buffers = useBuffersStore();
 const settings = useSettingsStore();
 const ignores = useIgnoresStore();
 const highlights = useHighlightRulesStore();
+const relayBots = useRelayBotsStore();
 const nicks = useNickColors();
 const { isMobile } = useViewport();
 
@@ -604,6 +626,8 @@ function runAction(key: MessageActionKey, m: ChatMessage | undefined | null): vo
 // Nickname, whois, DM, note, friend, ignore, and op-gated kick/ban/op/voice.
 // The menu and ignore modal are owned here, mirroring MemberList's pattern.
 const memberActions = useMemberActions();
+const contextMenu = useContextMenu();
+const whois = useWhoisStore();
 
 const showModePrefix = computed(() => !!settings.effective('look.nick.show_mode_prefix'));
 
@@ -666,12 +690,59 @@ function nickMenuContext(): MemberContext {
 // Omit it for nicks where the message's userhost belongs to someone else (e.g.
 // the kicked user in a kick line).
 function onNickMenu(e: MouseEvent, nick: string | undefined, m?: ChatMessage): void {
-  if (!nick || !buffer.value) return;
+  if (!buffer.value) return;
+  // Relay virtual speaker (#277): the displayed author is the embedded speaker,
+  // not a real IRC user, so the full member menu (DM, ignore, kick, ban) is
+  // meaningless. Give it a trimmed menu aimed at the relayed nick instead.
+  if (m?.relayBot && nick && buffer.value.networkId != null) {
+    openRelayNickMenu(nick, m.relayBot, buffer.value.networkId, e.clientX, e.clientY);
+    return;
+  }
+  if (!nick) return;
   // Prefer the live member (modes for op-gating, host for a clean ban mask);
   // fall back to the message's own userhost so a departed speaker stays
   // actionable.
   const member: MemberLike = nickMember(nick) ?? { nick, ...parseUserHost(m?.userhost) };
   memberActions.openMenuFor(member, nickMenuContext(), e.clientX, e.clientY);
+}
+
+// Context menu for a relayed virtual speaker (#277). Only the actions that make
+// sense for a name with no IRC presence: address them in a reply (the bridge
+// carries it back the other way) and copy the name — both targeting the relayed
+// nick. View Profile, by contrast, opens the relay *bot's* profile: it's the
+// only real IRC entity here, so its whois actually resolves.
+function openRelayNickMenu(
+  nick: string,
+  bot: string,
+  networkId: number,
+  x: number,
+  y: number,
+): void {
+  const items: ContextMenuItem[] = [
+    { label: `Reply to ${nick}`, icon: 'fa-solid fa-reply', onClick: () => addressNick(nick) },
+    {
+      label: 'Copy Nickname',
+      icon: 'fa-regular fa-copy',
+      onClick: () => {
+        navigator.clipboard?.writeText(nick).catch(() => {});
+      },
+    },
+    { divider: true },
+    {
+      label: 'View Profile…',
+      icon: 'fa-solid fa-id-card',
+      onClick: () => whois.openViewer(networkId, bot),
+    },
+  ];
+  contextMenu.open(items, x, y);
+}
+
+// The "via" affordance shown next to a re-attributed relay line (#277): the
+// `[source]` platform tag when the envelope had one, else the bot's nick. The
+// full title always names the bot so the real origin is one hover away.
+function relayLabel(m: ChatMessage | undefined): string {
+  if (!m?.relayBot) return '';
+  return m.relaySource || m.relayBot;
 }
 
 // A coloured nick mention inside message text (emitted by RenderSegments). The
@@ -932,8 +1003,38 @@ const renderRows = computed((): RenderRow[] => {
       out.push({ divider: 'unread', key: 'unread-divider' });
       dividerInserted = true;
     }
+    // Relay-bot re-attribution (#277). If this line's author is a nick the user
+    // marked as a relay/bridge bot, parse its `[source] <nick> message` envelope
+    // and display the embedded speaker as the author instead. Display-only: we
+    // push a shallow clone so the stored row keeps the bot's nick/text (unmark
+    // restores the raw view instantly). Coloring, author-continuation collapse,
+    // and the body all key off the clone, so a relayed user gets their own
+    // colour and consecutive lines from the same person collapse naturally.
+    // Highlights/ignores ran above on the raw line — the bot's full text is a
+    // superset of the embedded text, so a ping inside it still fires. Restricted
+    // to plain messages: relays bridge speech as PRIVMSG, and action/notice
+    // re-attribution would tangle with their special body rendering.
+    let mDisplay = m;
+    if (
+      m.type === 'message' &&
+      m.nick &&
+      !m.self &&
+      networkId &&
+      relayBots.isRelay(networkId, m.nick)
+    ) {
+      const parsed = parseRelayMessage(m.text ?? '', relayBots.patternFor(networkId, m.nick));
+      if (parsed) {
+        mDisplay = {
+          ...m,
+          nick: parsed.nick,
+          text: parsed.text,
+          relayBot: m.nick,
+          relaySource: parsed.source,
+        };
+      }
+    }
     out.push({
-      m,
+      m: mDisplay,
       alt: STRIPED_TYPES.has(m.type) && !!m.alt,
       key,
       nohilight: rowNohilight,
@@ -1828,6 +1929,15 @@ watch(
   white-space: pre-wrap;
   word-break: break-word;
   padding-left: 1ch;
+}
+/* Relay-bot origin tag (#277): the bracketed [source] before the re-attributed
+   text — mirrors how the bot framed the line, so it reads as provenance rather
+   than part of the message. Muted, no glyph; font size stays uniform per house
+   style. */
+.relay-via {
+  color: var(--fg-muted);
+  margin-right: 1ch;
+  white-space: nowrap;
 }
 /* Vertical separator between the nick and body columns. Drawn from .body
    so it stretches the full height of the body cell — including wrapped

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -123,10 +123,11 @@
     </div>
 
     <footer class="modal-footer">
-      <!-- Send DM and Ignore are meaningless on yourself and while the peer is
-           offline — DMs would bounce and there's no hostmask to build an ignore
-           rule from. Hide entirely rather than disable (matching Add Friend) so
-           the modal doesn't read as "you could do this if only…". -->
+      <!-- Primary actions only. Send DM is meaningless on yourself and while the
+           peer is offline (a DM would bounce), so it's hidden then. Add Friend
+           works regardless of presence — you can watch an offline peer — so it
+           isn't gated on isOffline. Everything else (Ignore, relay-bot toggle,
+           Refresh) lives in the More menu so the footer never crowds or wraps. -->
       <button
         v-if="!isOffline && !isSelf"
         type="button"
@@ -136,17 +137,6 @@
       >
         <i class="fa-solid fa-envelope"></i> <span class="label">Send DM</span>
       </button>
-      <button
-        v-if="!isOffline && !isSelf"
-        type="button"
-        class="btn-secondary"
-        title="Ignore…"
-        @click="onIgnore"
-      >
-        <i class="fa-solid fa-ban"></i> <span class="label">Ignore…</span>
-      </button>
-      <!-- Friending works regardless of presence — you can watch an offline
-           peer — so this isn't gated on isOffline like Send DM / Ignore. -->
       <button
         v-if="!isSelf"
         type="button"
@@ -158,8 +148,8 @@
         <span class="label">{{ isFriend ? 'Edit Friend' : 'Add Friend' }}</span>
       </button>
       <span class="spacer"></span>
-      <button type="button" class="btn-secondary" @click="onRefresh" title="Re-run whois">
-        <i class="fa-solid fa-arrows-rotate"></i> <span class="label">Refresh</span>
+      <button type="button" class="btn-secondary" title="More actions" @click="openMoreMenu">
+        <i class="fa-solid fa-ellipsis"></i> <span class="label">More</span>
       </button>
     </footer>
 
@@ -180,7 +170,9 @@ import AppModal from './AppModal.vue';
 import IgnoreModal from './IgnoreModal.vue';
 import { useWhoisStore } from '../stores/whois.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useRelayBotsStore } from '../stores/relayBots.js';
 import { useFriendsStore } from '../stores/friends.js';
+import { useContextMenu, type ContextMenuItem } from '../composables/useContextMenu.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { socketSend } from '../composables/useSocket.js';
@@ -194,12 +186,15 @@ const props = defineProps<{
 
 const whoisStore = useWhoisStore();
 const nickNotes = useNickNotesStore();
+const relayBots = useRelayBotsStore();
 const friends = useFriendsStore();
+const contextMenu = useContextMenu();
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const ignoreOpen = ref(false);
 
 const isFriend = computed(() => !!friends.contactForTarget(props.networkId, props.nick));
+const isRelay = computed(() => relayBots.isRelay(props.networkId, props.nick));
 
 const entry = computed(() => whoisStore.entryFor(props.networkId, props.nick));
 const whois = computed(() => entry.value?.data ?? null);
@@ -267,16 +262,21 @@ interface Chip {
   icon?: string;
 }
 const chips = computed<Chip[]>(() => {
-  const w = whois.value;
-  if (!w) return [];
   const out: Chip[] = [];
-  if (w.secure) out.push({ label: 'TLS', tone: 'good', icon: 'fa-solid fa-lock' });
-  if (w.bot) out.push({ label: 'Bot', tone: 'neutral', icon: 'fa-solid fa-robot' });
-  if (w.operator)
-    out.push({ label: 'IRC operator', tone: 'warn', icon: 'fa-solid fa-shield-halved' });
-  if (w.helpop) out.push({ label: 'Help', tone: 'neutral', icon: 'fa-solid fa-circle-info' });
-  if (w.registered_nick)
-    out.push({ label: 'Registered', tone: 'good', icon: 'fa-solid fa-id-badge' });
+  const w = whois.value;
+  if (w) {
+    if (w.secure) out.push({ label: 'TLS', tone: 'good', icon: 'fa-solid fa-lock' });
+    if (w.bot) out.push({ label: 'Bot', tone: 'neutral', icon: 'fa-solid fa-robot' });
+    if (w.operator)
+      out.push({ label: 'IRC operator', tone: 'warn', icon: 'fa-solid fa-shield-halved' });
+    if (w.helpop) out.push({ label: 'Help', tone: 'neutral', icon: 'fa-solid fa-circle-info' });
+    if (w.registered_nick)
+      out.push({ label: 'Registered', tone: 'good', icon: 'fa-solid fa-id-badge' });
+  }
+  // Relay-bot mark is local user state, not a whois fact, so it shows even when
+  // no whois reply is in (e.g. opening the profile of an offline bot).
+  if (isRelay.value)
+    out.push({ label: 'Relay bot', tone: 'neutral', icon: 'fa-solid fa-satellite-dish' });
   return out;
 });
 
@@ -369,6 +369,42 @@ function onAddFriend() {
   // Opens the Configure Friend modal on top of the profile (same as the note
   // editor) — a sub-edit, so we don't close the viewer here.
   friends.openEditorForNick(props.networkId, props.nick);
+}
+
+function onToggleRelay() {
+  // Mark/unmark this nick as a relay bot (#277). Marking from here uses the
+  // built-in envelope formats; a custom pattern is a power-user concern handled
+  // by `/relay add <nick> <pattern>`. The store echoes back over WS so the chip
+  // and the re-attributed messages update across every open tab.
+  if (isSelf.value) return;
+  relayBots.setRelay(props.networkId, props.nick, !isRelay.value);
+}
+
+// Secondary/contextual actions collapse into a "More" overflow menu so the
+// footer stays a clean primary-action row no matter how many actions exist.
+// Reuses the shared context-menu primitive (z-menu sits above z-modal, so it
+// floats over the modal correctly). Built fresh on open so toggle labels and
+// presence-gated entries reflect current state.
+function openMoreMenu(e: MouseEvent) {
+  const items: ContextMenuItem[] = [];
+  if (!isOffline.value && !isSelf.value) {
+    items.push({ label: 'Ignore…', icon: 'fa-solid fa-ban', onClick: onIgnore });
+  }
+  if (!isSelf.value) {
+    items.push({
+      label: isRelay.value ? 'Unmark relay bot' : 'Mark relay bot',
+      icon: 'fa-solid fa-satellite-dish',
+      onClick: onToggleRelay,
+    });
+  }
+  items.push({ label: 'Refresh', icon: 'fa-solid fa-arrows-rotate', onClick: onRefresh });
+  const btn = e.currentTarget as Element | null;
+  if (btn) {
+    const rect = btn.getBoundingClientRect();
+    contextMenu.open(items, rect.left, rect.bottom + 2, btn);
+  } else {
+    contextMenu.open(items, e.clientX, e.clientY);
+  }
 }
 
 function onChannelClick(channel: string) {

--- a/vue_client/src/composables/useContextMenu.test.ts
+++ b/vue_client/src/composables/useContextMenu.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { markRaw } from 'vue';
+import { useContextMenu, type ContextMenuItem } from './useContextMenu.js';
+
+// The store is a module-level singleton, so reset between cases. open() compares
+// triggerEl by reference (the DOM `contains` check lives in the component). Real
+// triggers are DOM elements, which Vue's reactive() leaves un-proxied — so the
+// `===` in open() sees the raw node. A plain object WOULD get proxied here and
+// break that identity, so the stand-ins are markRaw'd to mirror a DOM element.
+const items: ContextMenuItem[] = [{ label: 'A', onClick: () => {} }];
+const triggerA = markRaw({}) as unknown as Element;
+const triggerB = markRaw({}) as unknown as Element;
+
+describe('useContextMenu toggle', () => {
+  beforeEach(() => useContextMenu().close());
+
+  it('opens with a trigger', () => {
+    const menu = useContextMenu();
+    menu.open(items, 10, 20, triggerA);
+    expect(menu.state.open).toBe(true);
+    expect(menu.state.triggerEl).toBe(triggerA);
+  });
+
+  it('re-opening from the SAME trigger toggles it closed', () => {
+    const menu = useContextMenu();
+    menu.open(items, 10, 20, triggerA);
+    menu.open(items, 10, 20, triggerA);
+    expect(menu.state.open).toBe(false);
+    expect(menu.state.triggerEl).toBeNull();
+  });
+
+  it('opening from a DIFFERENT trigger switches menus, not toggles', () => {
+    const menu = useContextMenu();
+    menu.open(items, 10, 20, triggerA);
+    menu.open(items, 30, 40, triggerB);
+    expect(menu.state.open).toBe(true);
+    expect(menu.state.triggerEl).toBe(triggerB);
+  });
+
+  it('does not toggle when there is no trigger (right-click reopen repositions)', () => {
+    const menu = useContextMenu();
+    menu.open(items, 10, 20);
+    menu.open(items, 30, 40);
+    expect(menu.state.open).toBe(true);
+    expect(menu.state.x).toBe(30);
+    expect(menu.state.y).toBe(40);
+  });
+
+  it('a same-trigger re-open still toggles closed even with empty items', () => {
+    const menu = useContextMenu();
+    menu.open(items, 10, 20, triggerA);
+    menu.open([], 10, 20, triggerA);
+    expect(menu.state.open).toBe(false);
+  });
+});

--- a/vue_client/src/composables/useContextMenu.ts
+++ b/vue_client/src/composables/useContextMenu.ts
@@ -49,10 +49,26 @@ const state = reactive<ContextMenuState>({
   triggerEl: null,
 });
 
+function closeMenu(): void {
+  state.open = false;
+  state.items = [];
+  state.triggerEl = null;
+}
+
 export function useContextMenu(): ContextMenuAPI {
   return {
     state,
     open(items: ContextMenuItem[], x: number, y: number, triggerEl: Element | null = null): void {
+      // Toggle: re-invoking open() from the same trigger while its menu is up
+      // closes it. The toggle MUST live here, not in the close-on-outside
+      // listener (ContextMenu.vue) — a pointerdown there can't cancel the click
+      // that follows, so closing on the trigger's pointerdown just races the
+      // trigger's own click and reopens the menu on a single gesture. So the
+      // listener ignores the trigger and defers to this reopen path instead.
+      if (state.open && triggerEl && state.triggerEl === triggerEl) {
+        closeMenu();
+        return;
+      }
       if (!Array.isArray(items) || items.length === 0) return;
       state.items = items;
       state.x = x;
@@ -61,9 +77,7 @@ export function useContextMenu(): ContextMenuAPI {
       state.open = true;
     },
     close(): void {
-      state.open = false;
-      state.items = [];
-      state.triggerEl = null;
+      closeMenu();
     },
   };
 }

--- a/vue_client/src/composables/useMemberActions.ts
+++ b/vue_client/src/composables/useMemberActions.ts
@@ -40,6 +40,7 @@ export interface MemberActionsAPI {
     ctx: MemberContext | null | undefined,
     x: number,
     y: number,
+    triggerEl?: Element | null,
   ): void;
   openMenuFromButton(
     member: MemberLike | string | null | undefined,
@@ -226,15 +227,19 @@ export function useMemberActions(): MemberActionsAPI {
     return items;
   }
 
+  // Cursor-positioned menu (left-click a name, or right-click). Pass triggerEl
+  // for a left-click so re-clicking the same element toggles the menu closed,
+  // matching the kebab buttons; omit it for right-click, which repositions.
   function openMenuFor(
     member: MemberLike | string | null | undefined,
     ctx: MemberContext | null | undefined,
     x: number,
     y: number,
+    triggerEl: Element | null = null,
   ): void {
     const items = buildItems(member, ctx);
     if (items.length === 0) return;
-    menu.open(items, x, y);
+    menu.open(items, x, y, triggerEl);
   }
 
   // Hand buttonEl to useContextMenu so re-clicking the same trigger toggles

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -17,6 +17,7 @@ import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useChannelNotifyStore } from '../stores/channelNotify.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useRelayBotsStore } from '../stores/relayBots.js';
 import { useFriendsStore } from '../stores/friends.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
@@ -328,12 +329,14 @@ function applySnapshot(snapshot: any[], globalIgnores: any[] = []): void {
   const channelNotify = useChannelNotifyStore();
   const ignores = useIgnoresStore();
   const nickNotes = useNickNotesStore();
+  const relayBots = useRelayBotsStore();
   networks.applySnapshot(snapshot);
   pins.applySnapshot(snapshot);
   nicklistCollapse.applySnapshot(snapshot);
   channelNotify.applySnapshot(snapshot);
   ignores.applySnapshot(snapshot, globalIgnores);
   nickNotes.applySnapshot(snapshot);
+  relayBots.applySnapshot(snapshot);
   // Highlight rules aren't in the snapshot; load them now so client-side
   // render-time highlight evaluation (#349) works app-wide, not just after the
   // settings pane has been opened.
@@ -600,6 +603,11 @@ function handleMessage(raw: string): void {
   if (payload.kind === 'nick-note-updated') {
     const nickNotes = useNickNotesStore();
     nickNotes.applyUpdate(payload.networkId, payload.nick, payload.note || '', payload.updatedAt);
+    return;
+  }
+  if (payload.kind === 'relay-bot-updated') {
+    const relayBots = useRelayBotsStore();
+    relayBots.applyUpdate(payload.networkId, payload.nick, !!payload.marked, payload.pattern || '');
     return;
   }
   if (payload.kind === 'contacts-snapshot') {

--- a/vue_client/src/lib/commands/relay.test.ts
+++ b/vue_client/src/lib/commands/relay.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { parseRelayCommand } from './relay.js';
+
+describe('parseRelayCommand', () => {
+  it('treats no args as list', () => {
+    expect(parseRelayCommand('')).toEqual({ kind: 'list' });
+    expect(parseRelayCommand('   ')).toEqual({ kind: 'list' });
+  });
+
+  it('parses explicit list (and ls alias)', () => {
+    expect(parseRelayCommand('list')).toEqual({ kind: 'list' });
+    expect(parseRelayCommand('ls')).toEqual({ kind: 'list' });
+  });
+
+  it('parses add with no custom pattern', () => {
+    expect(parseRelayCommand('add relaybot')).toEqual({
+      kind: 'add',
+      nick: 'relaybot',
+      pattern: '',
+    });
+  });
+
+  it('parses add with a custom template, preserving internal spaces', () => {
+    expect(parseRelayCommand('add bridge <{nick}> {message}')).toEqual({
+      kind: 'add',
+      nick: 'bridge',
+      pattern: '<{nick}> {message}',
+    });
+  });
+
+  it('strips one pair of surrounding quotes from the pattern', () => {
+    expect(parseRelayCommand('add bridge "[{source}] <{nick}> {message}"')).toEqual({
+      kind: 'add',
+      nick: 'bridge',
+      pattern: '[{source}] <{nick}> {message}',
+    });
+  });
+
+  it('accepts mark/set as aliases for add', () => {
+    expect(parseRelayCommand('mark b')).toEqual({ kind: 'add', nick: 'b', pattern: '' });
+    expect(parseRelayCommand('set b')).toEqual({ kind: 'add', nick: 'b', pattern: '' });
+  });
+
+  it('parses remove and its aliases', () => {
+    for (const verb of ['remove', 'rm', 'del', 'delete', 'unmark']) {
+      expect(parseRelayCommand(`${verb} relaybot`)).toEqual({ kind: 'remove', nick: 'relaybot' });
+    }
+  });
+
+  it('errors on add/remove without a nick', () => {
+    expect(parseRelayCommand('add')).toMatchObject({ kind: 'error' });
+    expect(parseRelayCommand('remove')).toMatchObject({ kind: 'error' });
+  });
+
+  it('errors on an unknown subcommand', () => {
+    const out = parseRelayCommand('frobnicate bot');
+    expect(out.kind).toBe('error');
+  });
+});

--- a/vue_client/src/lib/commands/relay.ts
+++ b/vue_client/src/lib/commands/relay.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Parser for the /relay command (#277) — mark, unmark, and list relay/bridge
+// bots on the active network. A marked bot's messages get re-attributed to the
+// speaker embedded in their envelope (`[Discord] <alice> hi` → alice).
+//
+// Pure and dependency-free so it unit-tests outside the Vue SFC, like the other
+// command parsers. The custom-pattern argument is the *raw remainder* of the
+// line — a template such as `<{nick}> {message}` whose spaces are significant —
+// so we peel tokens by hand instead of tokenizeArgs, which would split and
+// de-quote it.
+
+export type RelayCommand =
+  | { kind: 'list' }
+  | { kind: 'add'; nick: string; pattern: string }
+  | { kind: 'remove'; nick: string }
+  | { kind: 'error'; message: string };
+
+const ADD = new Set(['add', 'mark', 'set']);
+const REMOVE = new Set(['remove', 'rm', 'del', 'delete', 'unmark']);
+
+const USAGE = 'usage: /relay [list] · /relay add <nick> [pattern] · /relay remove <nick>';
+
+// Split off the first whitespace-delimited token, returning [token, remainder].
+// The remainder keeps its internal spacing (only the gap after the token is
+// consumed) so a custom template survives intact.
+function peel(s: string): [string, string] {
+  const m = /^(\S+)\s*([\s\S]*)$/.exec(s.trimStart());
+  return m ? [m[1], m[2]] : ['', ''];
+}
+
+// Drop one matching pair of surrounding quotes, if present — a convenience so
+// `/relay add bot "[{s}] <{n}> {m}"` works even though quoting isn't required.
+function unquote(s: string): string {
+  if (
+    s.length >= 2 &&
+    ((s[0] === '"' && s[s.length - 1] === '"') || (s[0] === "'" && s[s.length - 1] === "'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+export function parseRelayCommand(argLine: string): RelayCommand {
+  const trimmed = (argLine || '').trim();
+  if (!trimmed) return { kind: 'list' };
+
+  const [sub, rest] = peel(trimmed);
+  const verb = sub.toLowerCase();
+
+  if (verb === 'list' || verb === 'ls') return { kind: 'list' };
+
+  if (ADD.has(verb)) {
+    const [nick, pattern] = peel(rest);
+    if (!nick) return { kind: 'error', message: 'usage: /relay add <nick> [pattern]' };
+    return { kind: 'add', nick, pattern: unquote(pattern.trim()) };
+  }
+
+  if (REMOVE.has(verb)) {
+    const [nick] = peel(rest);
+    if (!nick) return { kind: 'error', message: 'usage: /relay remove <nick>' };
+    return { kind: 'remove', nick };
+  }
+
+  return { kind: 'error', message: `unknown subcommand "${sub}". ${USAGE}` };
+}

--- a/vue_client/src/stores/relayBots.ts
+++ b/vue_client/src/stores/relayBots.ts
@@ -16,13 +16,16 @@ function key(networkId: number | string, nick: string) {
 }
 
 export interface RelayBotEntry {
+  /** Canonical nick casing (server-provided) — the key is lowercased for
+   *  case-insensitive lookup, so this preserves what to show in /relay list. */
+  nick: string;
   /** Custom envelope template; empty string means "use the built-in defaults". */
   pattern: string;
 }
 
 export const useRelayBotsStore = defineStore('relayBots', {
   state: () => ({
-    // { [networkId::nicklower]: { pattern: string } } — presence of a key IS the mark.
+    // { [networkId::nicklower]: { nick, pattern } } — presence of a key IS the mark.
     byKey: {} as Record<string, RelayBotEntry>,
   }),
   getters: {
@@ -30,13 +33,13 @@ export const useRelayBotsStore = defineStore('relayBots', {
       !!state.byKey[key(networkId, nick)],
     patternFor: (state) => (networkId: number | string, nick: string) =>
       state.byKey[key(networkId, nick)]?.pattern || '',
-    // [{ networkId, nick, pattern }] for a given network — drives `/relay list`.
+    // [{ nick, pattern }] for a given network — drives `/relay list`. Uses the
+    // stored canonical nick for display, not the lowercased key.
     listForNetwork: (state) => (networkId: number) => {
       const prefix = `${networkId}::`;
       const out: Array<{ nick: string; pattern: string }> = [];
       for (const [k, entry] of Object.entries(state.byKey)) {
-        if (k.startsWith(prefix))
-          out.push({ nick: k.slice(prefix.length), pattern: entry.pattern });
+        if (k.startsWith(prefix)) out.push({ nick: entry.nick, pattern: entry.pattern });
       }
       return out;
     },
@@ -48,7 +51,7 @@ export const useRelayBotsStore = defineStore('relayBots', {
         if (n?.networkId == null) continue;
         for (const entry of n.relayBots || []) {
           if (!entry?.nick) continue;
-          next[key(n.networkId, entry.nick)] = { pattern: entry.pattern || '' };
+          next[key(n.networkId, entry.nick)] = { nick: entry.nick, pattern: entry.pattern || '' };
         }
       }
       this.byKey = next;
@@ -57,7 +60,8 @@ export const useRelayBotsStore = defineStore('relayBots', {
       if (!networkId || !nick) return;
       const k = key(networkId, nick);
       if (marked) {
-        this.byKey[k] = { pattern: pattern || '' };
+        // `nick` here is the canonical casing echoed by the server.
+        this.byKey[k] = { nick, pattern: pattern || '' };
       } else {
         delete this.byKey[k];
       }

--- a/vue_client/src/stores/relayBots.ts
+++ b/vue_client/src/stores/relayBots.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineStore } from 'pinia';
+import { socketSend } from '../composables/useSocket.js';
+
+// Per-(network, nick) relay-bot marks (#277). A marked nick is a relay / bridge
+// bot whose messages wrap another person's speech in an envelope; MessageList
+// re-attributes those lines to the embedded speaker at render time. Server is
+// the source of truth — marks ship over WS and a `relay-bot-updated` echo fans
+// out to every session so the mark stays in sync across devices. Keying is
+// network-scoped (same nick on different networks may be unrelated bots),
+// mirroring nick notes and ignores.
+function key(networkId: number | string, nick: string) {
+  return `${networkId}::${(nick || '').toLowerCase()}`;
+}
+
+export interface RelayBotEntry {
+  /** Custom envelope template; empty string means "use the built-in defaults". */
+  pattern: string;
+}
+
+export const useRelayBotsStore = defineStore('relayBots', {
+  state: () => ({
+    // { [networkId::nicklower]: { pattern: string } } — presence of a key IS the mark.
+    byKey: {} as Record<string, RelayBotEntry>,
+  }),
+  getters: {
+    isRelay: (state) => (networkId: number | string, nick: string) =>
+      !!state.byKey[key(networkId, nick)],
+    patternFor: (state) => (networkId: number | string, nick: string) =>
+      state.byKey[key(networkId, nick)]?.pattern || '',
+    // [{ networkId, nick, pattern }] for a given network — drives `/relay list`.
+    listForNetwork: (state) => (networkId: number) => {
+      const prefix = `${networkId}::`;
+      const out: Array<{ nick: string; pattern: string }> = [];
+      for (const [k, entry] of Object.entries(state.byKey)) {
+        if (k.startsWith(prefix))
+          out.push({ nick: k.slice(prefix.length), pattern: entry.pattern });
+      }
+      return out;
+    },
+  },
+  actions: {
+    applySnapshot(networks: any[]) {
+      const next: Record<string, RelayBotEntry> = {};
+      for (const n of networks || []) {
+        if (n?.networkId == null) continue;
+        for (const entry of n.relayBots || []) {
+          if (!entry?.nick) continue;
+          next[key(n.networkId, entry.nick)] = { pattern: entry.pattern || '' };
+        }
+      }
+      this.byKey = next;
+    },
+    applyUpdate(networkId: number | string, nick: string, marked: boolean, pattern: string) {
+      if (!networkId || !nick) return;
+      const k = key(networkId, nick);
+      if (marked) {
+        this.byKey[k] = { pattern: pattern || '' };
+      } else {
+        delete this.byKey[k];
+      }
+    },
+    setRelay(networkId: number | string, nick: string, marked: boolean, pattern = '') {
+      if (!networkId || !nick) return;
+      socketSend({ type: 'set-relay-bot', networkId, nick, marked, pattern });
+    },
+  },
+});

--- a/vue_client/vite.config.ts
+++ b/vue_client/vite.config.ts
@@ -23,9 +23,15 @@ export default defineConfig(({ mode }) => {
   // doesn't need to trust a local CA. Password login still works; WebAuthn
   // and Service Worker / push features do not (they require a secure context).
   const lanHost = env.VITE_LAN_HOST;
+  // mkcert is dev-server-only HTTPS tooling — it has no business loading under
+  // vitest, and historically its native cert generation could crash the test
+  // process when the config was resolved from inside vue_client/. Vitest sets
+  // VITEST=true before resolving the config, so skip the plugin then; tests
+  // never need a cert.
+  const underTest = !!process.env.VITEST;
 
   return {
-    plugins: lanHost ? [vue()] : [vue(), mkcert()],
+    plugins: lanHost || underTest ? [vue()] : [vue(), mkcert()],
     // Build-time constant so the About panel can show the app version without
     // an API round-trip.
     define: {


### PR DESCRIPTION
Closes #277.

Mark a nick as a relay/bridge bot and Lurker re-attributes its messages to the speaker embedded in the envelope. `[efnet] <+FAST> ultros: bet` renders as **FAST** (coloured as themselves) with a muted `[efnet]` tag, instead of the bot's nick.

## How it works

- **Per-(network, nick) mark**, persisted server-side and synced across tabs/devices — clones the nick-notes subsystem: new `user_relay_bots` table, a `set_relay_bot` verb (so MCP gets it too), a WS `relay-bot-updated` echo, and snapshot seeding.
- **Re-attribution is client-side and render-time.** The stored row keeps the bot's nick/text, so unmarking restores the raw view instantly, the bot stays the real IRC entity behind menu actions, and relayed users collapse/colour by their own identity.
- **Defaults work out of the box** — `[source] <nick> message` and a bare `<nick> message` fallback — with an optional custom placeholder template (`{source}`/`{nick}`/`{message}`) per bot, compiled to a regex (no raw-regex injection).
- **mIRC-aware.** Bots colour the nick/source, and those `\x03`/`\x02` codes sit inside the envelope, so matching strips formatting first (reuses `stripFormatting`). The message's *own* colours are preserved by mapping the match back onto the raw body (new reusable `rawIndexForVisibleOffset` in `textMatch`). A leading membership prefix is dropped, so `<+FAST>` → `FAST` (and Reply/Copy target the real nick).

## Surfaces

- `/relay add <nick> [pattern]` · `/relay remove <nick>` · `/relay` (list) — in `/commands`.
- A **Mark/Unmark relay bot** toggle + a **Relay bot** chip in the profile.
- Clicking a relayed nick opens a trimmed menu: **Reply** / **Copy** target the relayed nick; **View Profile** opens the bot (the only entity whose whois resolves).
- The profile footer was crowding with the new action, so its secondary actions now collapse into a **More** overflow menu.

## Re-attribution is render-time only — by design

- Notifications and search/history results show the **raw** line (not re-attributed).
- Highlights on *message text* fire (the embedded text is a substring of the raw line); highlights on a *sender nick/mask* see the bot, not the relayed user.
- Ignoring the bot hides all its relayed traffic.
- Only `PRIVMSG` is re-attributed (not `/me` or notices).

## Drive-by fix (separate commit)

While wiring the More menu I found that **re-clicking any context-menu trigger never closed the menu** app-wide — the toggle was attempted on `pointerdown`, which can't cancel the `click` that follows, so the trigger reopened it on the same gesture. Moved the toggle into `open()` (re-invoke with the same trigger → close). Isolated in its own commit for easy cherry-pick.

## Tests

`parseRelay` (formats, custom templates, mIRC stripping, prefix stripping, colour preservation), `rawIndexForVisibleOffset`, the `/relay` command parser, the `set_relay_bot` verb (round-trip + tenant isolation + scope), the MCP surface, and the new context-menu toggle. `npm run check` (server + client typecheck, lint, format) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
