### PR TITLE
Add inbound IRC channel INVITE handling with actionable Join toast (#261)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1380,3 +1380,96 @@ describe('IRCv3 draft/multiline (#381)', () => {
     });
   });
 });
+
+// Inbound channel INVITE (#261): surface "you've been invited" as an actionable
+// ephemeral + a durable system-buffer line; ignore invite-notify echoes for
+// other people. publishEphemeral/logNet are stubbed to assert routing without a
+// DB or live socket.
+describe('inbound INVITE handler (#261)', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'me',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  it('publishes an actionable invite event + system line when WE are invited', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'me';
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    const logNet = vi.fn<(text: string, level?: string) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    conn.logNet = logNet;
+
+    conn.client.emit('invite', { nick: 'alice', invited: 'me', channel: '#secret' });
+
+    expect(publishEphemeral).toHaveBeenCalledTimes(1);
+    expect(publishEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'invite',
+        // Routed via the server pseudo-buffer so the wsHub closed-buffer guard
+        // can't drop an invite to a channel we'd previously closed.
+        target: ':server:1',
+        channel: '#secret',
+        from: 'alice',
+      }),
+    );
+    expect(logNet).toHaveBeenCalledWith('alice invited you to #secret');
+  });
+
+  it('ignores invite-notify echoes for someone else (not us)', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'me';
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    const logNet = vi.fn<(text: string, level?: string) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    conn.logNet = logNet;
+
+    conn.client.emit('invite', { nick: 'alice', invited: 'bob', channel: '#secret' });
+
+    expect(publishEphemeral).not.toHaveBeenCalled();
+    expect(logNet).not.toHaveBeenCalled();
+  });
+
+  it('matches the invited nick case-insensitively', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'Me';
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    conn.logNet = vi.fn<(text: string, level?: string) => void>();
+
+    conn.client.emit('invite', { nick: 'alice', invited: 'mE', channel: '#secret' });
+
+    expect(publishEphemeral).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a malformed invite missing the channel', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'me';
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    conn.logNet = vi.fn<(text: string, level?: string) => void>();
+
+    conn.client.emit('invite', { nick: 'alice', invited: 'me' });
+
+    expect(publishEphemeral).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1378,6 +1378,37 @@ export class IrcConnection {
       }
     });
 
+    c.on('invite', (event: Record<string, unknown>) => {
+      // irc-framework parses an inbound INVITE as { nick: inviter, invited:
+      // target nick, channel }. With invite-notify we also see invites sent to
+      // *other* people in channels we're in — only the "you've been invited"
+      // case is actionable, so ignore any invite whose target isn't us. (A
+      // future enhancement could surface op-visibility invites as a quiet
+      // channel line; #261.)
+      const inviter = event.nick as string | undefined;
+      const invited = event.invited as string | undefined;
+      const channel = event.channel as string | undefined;
+      if (!inviter || !channel || !invited) return;
+      const me = c.user?.nick;
+      if (!me || invited.toLowerCase() !== me.toLowerCase()) return;
+      // Route through the server pseudo-buffer, not the channel: we're not in
+      // the channel (that's the whole point of an invite), and if we'd
+      // previously closed its buffer the wsHub closed-buffer guard would drop
+      // an ephemeral targeted at it. The channel rides in its own field; the
+      // client toast reads `channel`/`from`, never `target`.
+      this.publishEphemeral({
+        type: 'invite',
+        target: this.serverTarget(),
+        channel,
+        from: inviter,
+        userhost: buildUserhost(event),
+      });
+      // Durable fallback: the toast is transient, so log the invite to the
+      // system buffer too — a missed or expired toast still leaves a record the
+      // user can act on later (#261, #355).
+      this.logNet(`${inviter} invited you to ${channel}`);
+    });
+
     c.on('quit', (event: Record<string, unknown>) => {
       const eventNick = event.nick as string;
       const lower = eventNick.toLowerCase();

--- a/vue_client/src/components/ToastContainer.vue
+++ b/vue_client/src/components/ToastContainer.vue
@@ -51,7 +51,7 @@ function onClick(t: Toast) {
 }
 
 function onAction(t: Toast) {
-  t.action?.onClick();
+  toasts.runAction(t.id);
   toasts.dismiss(t.id);
 }
 </script>

--- a/vue_client/src/components/ToastContainer.vue
+++ b/vue_client/src/components/ToastContainer.vue
@@ -20,6 +20,9 @@
           </button>
         </div>
         <div v-if="t.body" class="body">{{ t.body }}</div>
+        <div v-if="t.action" class="actions">
+          <button class="action" @click.stop="onAction(t)">{{ t.action.label }}</button>
+        </div>
       </div>
     </div>
   </Teleport>
@@ -44,6 +47,11 @@ function onClick(t: Toast) {
     return;
   }
   buffers.activate(t.networkId, t.target);
+  toasts.dismiss(t.id);
+}
+
+function onAction(t: Toast) {
+  t.action?.onClick();
   toasts.dismiss(t.id);
 }
 </script>
@@ -135,6 +143,24 @@ function onClick(t: Toast) {
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+.actions {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+.action {
+  background: var(--toast-accent, var(--accent));
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--bg);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  padding: var(--space-2) var(--space-5);
+}
+.action:hover {
+  filter: brightness(1.08);
 }
 @keyframes toast-in {
   from {

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -192,6 +192,22 @@ function applyEvent(event: any): void {
         ttlMs: 6000,
       });
       break;
+    case 'invite': {
+      // Someone invited us to a channel we're not in. Surface it as an
+      // actionable toast with a one-click Join — the durable record lives in the
+      // system buffer (logged server-side), so a longer TTL here is just a
+      // convenience window, not the only chance to act (#261).
+      const channel = event.channel as string;
+      const from = event.from as string;
+      useToastsStore().push({
+        kind: 'notify',
+        title: `Invitation to ${channel}`,
+        body: `${from} invited you`,
+        ttlMs: 15000,
+        action: { label: 'Join', onClick: () => buffers.joinOrActivate(event.networkId, channel) },
+      });
+      break;
+    }
     case 'channel-parted':
       // Keep the buffer around so the user can still scroll history; just
       // mark it un-joined so it renders dimmed in the buffer list. /close

--- a/vue_client/src/stores/toasts.test.ts
+++ b/vue_client/src/stores/toasts.test.ts
@@ -14,10 +14,10 @@ describe('toasts store', () => {
     vi.useRealTimers();
   });
 
-  it('threads an action callback through push so the toast can offer a CTA', () => {
+  it('stores only the serializable label in state and runs the handler via runAction', () => {
     const toasts = useToastsStore();
     const onClick = vi.fn<() => void>();
-    toasts.push({
+    const id = toasts.push({
       title: 'Invitation to #secret',
       body: 'alice invited you',
       kind: 'notify',
@@ -25,9 +25,19 @@ describe('toasts store', () => {
       ttlMs: 0,
     });
     const t = toasts.items[0];
-    expect(t.action?.label).toBe('Join');
-    t.action?.onClick();
+    // Pinia state holds only { label } — no function leaks into the store.
+    expect(t.action).toEqual({ label: 'Join' });
+    toasts.runAction(id);
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the action handler on dismiss so it cannot run afterward', () => {
+    const toasts = useToastsStore();
+    const onClick = vi.fn<() => void>();
+    const id = toasts.push({ title: 'x', body: '', action: { label: 'Go', onClick }, ttlMs: 0 });
+    toasts.dismiss(id);
+    toasts.runAction(id); // no-op — handler was cleaned up
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it('omits action when none is given (plain toast)', () => {

--- a/vue_client/src/stores/toasts.test.ts
+++ b/vue_client/src/stores/toasts.test.ts
@@ -16,7 +16,7 @@ describe('toasts store', () => {
 
   it('threads an action callback through push so the toast can offer a CTA', () => {
     const toasts = useToastsStore();
-    const onClick = vi.fn();
+    const onClick = vi.fn<() => void>();
     toasts.push({
       title: 'Invitation to #secret',
       body: 'alice invited you',

--- a/vue_client/src/stores/toasts.test.ts
+++ b/vue_client/src/stores/toasts.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useToastsStore } from './toasts.js';
+
+describe('toasts store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('threads an action callback through push so the toast can offer a CTA', () => {
+    const toasts = useToastsStore();
+    const onClick = vi.fn();
+    toasts.push({
+      title: 'Invitation to #secret',
+      body: 'alice invited you',
+      kind: 'notify',
+      action: { label: 'Join', onClick },
+      ttlMs: 0,
+    });
+    const t = toasts.items[0];
+    expect(t.action?.label).toBe('Join');
+    t.action?.onClick();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits action when none is given (plain toast)', () => {
+    const toasts = useToastsStore();
+    toasts.push({ title: 'hi', body: '', ttlMs: 0 });
+    expect(toasts.items[0].action).toBeUndefined();
+  });
+
+  it('auto-dismisses after the ttl', () => {
+    const toasts = useToastsStore();
+    toasts.push({ title: 'hi', body: '', ttlMs: 5000 });
+    expect(toasts.items.length).toBe(1);
+    vi.advanceTimersByTime(5000);
+    expect(toasts.items.length).toBe(0);
+  });
+});

--- a/vue_client/src/stores/toasts.ts
+++ b/vue_client/src/stores/toasts.ts
@@ -5,12 +5,20 @@ import { defineStore } from 'pinia';
 
 let nextId = 1;
 
+// Action callbacks live module-local, keyed by toast id — never in Pinia state.
+// The store keeps only the serializable `{ label }` so $reset / devtools /
+// persistence never have to deal with a function (same rationale as the
+// drafts store's module-local timers). Registered in push(), cleared in
+// dismiss()/clear() so the map can't outlive its toast.
+const actionHandlers = new Map<number, () => void>();
+
 export type ToastKind = 'highlight' | 'dm' | 'always_notify' | 'notify' | 'info' | 'warn' | 'error';
 
 // An explicit call-to-action button rendered inside the toast (e.g. the "Join"
 // on a channel-invite toast). Distinct from the whole-toast click, which only
 // activates an existing buffer — an action can run any handler, so it's the
-// primitive for toasts that offer to *do* something rather than navigate.
+// primitive for toasts that offer to *do* something rather than navigate. The
+// handler is split off into the module-local map above; only `label` is stored.
 export interface ToastAction {
   label: string;
   onClick: () => void;
@@ -24,7 +32,8 @@ export interface Toast {
   target?: string;
   messageId?: number;
   kind: ToastKind;
-  action?: ToastAction;
+  // Serializable subset of ToastAction — the onClick is held in actionHandlers.
+  action?: { label: string };
 }
 
 export interface ToastOptions {
@@ -54,17 +63,33 @@ export const useToastsStore = defineStore('toasts', {
       action,
     }: ToastOptions) {
       const id = nextId++;
-      this.items.push({ id, title, body, networkId, target, messageId, kind, action });
+      if (action) actionHandlers.set(id, action.onClick);
+      this.items.push({
+        id,
+        title,
+        body,
+        networkId,
+        target,
+        messageId,
+        kind,
+        action: action ? { label: action.label } : undefined,
+      });
       if (ttlMs > 0) {
         setTimeout(() => this.dismiss(id), ttlMs);
       }
       return id;
     },
+    // Run a toast's action handler (looked up module-local, not from state).
+    runAction(id: number) {
+      actionHandlers.get(id)?.();
+    },
     dismiss(id: number) {
+      actionHandlers.delete(id);
       const idx = this.items.findIndex((t) => t.id === id);
       if (idx >= 0) this.items.splice(idx, 1);
     },
     clear() {
+      actionHandlers.clear();
       this.items = [];
     },
   },

--- a/vue_client/src/stores/toasts.ts
+++ b/vue_client/src/stores/toasts.ts
@@ -7,6 +7,15 @@ let nextId = 1;
 
 export type ToastKind = 'highlight' | 'dm' | 'always_notify' | 'notify' | 'info' | 'warn' | 'error';
 
+// An explicit call-to-action button rendered inside the toast (e.g. the "Join"
+// on a channel-invite toast). Distinct from the whole-toast click, which only
+// activates an existing buffer — an action can run any handler, so it's the
+// primitive for toasts that offer to *do* something rather than navigate.
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface Toast {
   id: number;
   title: string;
@@ -15,6 +24,7 @@ export interface Toast {
   target?: string;
   messageId?: number;
   kind: ToastKind;
+  action?: ToastAction;
 }
 
 export interface ToastOptions {
@@ -25,6 +35,7 @@ export interface ToastOptions {
   messageId?: number;
   kind?: ToastKind;
   ttlMs?: number;
+  action?: ToastAction;
 }
 
 export const useToastsStore = defineStore('toasts', {
@@ -40,9 +51,10 @@ export const useToastsStore = defineStore('toasts', {
       messageId,
       kind = 'highlight',
       ttlMs = 5000,
+      action,
     }: ToastOptions) {
       const id = nextId++;
-      this.items.push({ id, title, body, networkId, target, messageId, kind });
+      this.items.push({ id, title, body, networkId, target, messageId, kind, action });
       if (ttlMs > 0) {
         setTimeout(() => this.dismiss(id), ttlMs);
       }


### PR DESCRIPTION
Implements the **inbound half** of #261 — surfacing a channel invite sent _to us_ as an actionable notification with a one-click join. Inbound `INVITE` was previously dropped entirely.

## What this does
- **Server (`ircConnection.ts`)** — new `c.on('invite')` handler:
  - **Filters to us:** only acts when the invited nick is our own (case-folded). `invite-notify` echoes for other people are ignored for now (the early-return is the seam where the "alice invited bob" channel line will go in the outbound phase — see #261 notes).
  - **Routes via the server pseudo-buffer**, not the channel: we're not in the channel (that's the point of an invite), and an ephemeral targeted at a previously-**closed** channel buffer would be silently dropped by the wsHub closed-buffer guard. The channel rides in its own field.
  - **Durable fallback:** logs `"alice invited you to #channel"` to the system buffer, so a missed/expired toast still leaves a record.
- **Client — reusable actionable-toast primitive:** `ToastAction { label, onClick }` threaded through the toast store + `ToastContainer` (consistent with how `useContextMenu` already stores `onClick` callbacks). This is the one new bit of UI infra; it's generic, not invite-specific.
- **Client (`useSocket.ts`)** — the `invite` event pushes a `notify` toast ("`alice` invited you") with a **Join** action wired to `buffers.joinOrActivate`, 15s TTL.

## QA (manually verified on a live network)
- Toast + system-buffer line appear when invited; **Join** opens & activates the channel (incl. through `+i`).
- **Closed-buffer routing:** invite to a previously-closed channel buffer still surfaces (confirms the `:server:` routing).
- **Self-filter:** an invite-notify echo for someone else produces nothing.

## Checks
- `typecheck` (server + client), `oxfmt --check` — clean
- `npm test` — **1549 passing**, incl. 4 new server tests (self/not-self filter, case-insensitive match, malformed-drop, `:server:` routing) + 3 toast-store tests

## Deferred to the outbound phase (#261)
- `/invite` command, `RPL_INVITING (341)` confirmation + error numerics (401/443/482), member-context-menu item
- op-visibility `invite-notify` channel line ("alice invited bob") + self-invite dedup against 341 — notes captured on the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)