### PR TITLE
Add /invite command + in-channel invite lines (#261)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1435,16 +1435,21 @@ describe('inbound INVITE handler (#261)', () => {
     expect(logNet).toHaveBeenCalledWith('alice invited you to #secret');
   });
 
-  it('ignores invite-notify echoes for someone else (not us)', () => {
+  it('does not toast for an invite-notify echo about someone else (channel line only)', () => {
     const conn = makeConn();
     conn.client.user.nick = 'me';
+    const publish = vi.fn<(event: unknown) => void>();
     const publishEphemeral = vi.fn<(event: unknown) => void>();
     const logNet = vi.fn<(text: string, level?: string) => void>();
+    conn.publish = publish;
     conn.publishEphemeral = publishEphemeral;
     conn.logNet = logNet;
 
     conn.client.emit('invite', { nick: 'alice', invited: 'bob', channel: '#secret' });
 
+    // Surfaced as a channel line (covered in detail elsewhere), never as a toast
+    // or a "you've been invited" system line — that's only for invites to us.
+    expect(publish).toHaveBeenCalledTimes(1);
     expect(publishEphemeral).not.toHaveBeenCalled();
     expect(logNet).not.toHaveBeenCalled();
   });
@@ -1471,5 +1476,95 @@ describe('inbound INVITE handler (#261)', () => {
     conn.client.emit('invite', { nick: 'alice', invited: 'me' });
 
     expect(publishEphemeral).not.toHaveBeenCalled();
+  });
+});
+
+// Outbound /invite confirmation (RPL_INVITING 341 -> 'invited') and op-visibility
+// invite-notify lines (#261). Both render a persisted "X invited Y" channel line
+// via publish(); the self-echo is deduped against the 341 line.
+describe('invite channel lines + dedup (#261)', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'me',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  it('renders our own /invite as a channel line from RPL_INVITING (341)', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'me';
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    // irc-framework emits 'invited' for 341 with { nick: invited, channel }.
+    conn.client.emit('invited', { nick: 'bob', channel: '#secret' });
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'invite', target: '#secret', nick: 'me', invited: 'bob' }),
+    );
+  });
+
+  it('renders a third party invite-notify as a channel line', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'me';
+    conn.upsertChannel('#secret');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('invite', { nick: 'alice', invited: 'bob', channel: '#secret' });
+
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'invite', target: '#secret', nick: 'alice', invited: 'bob' }),
+    );
+  });
+
+  it('suppresses the invite-notify echo of our OWN invite (deduped against 341)', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'me';
+    const publish = vi.fn<(event: unknown) => void>();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.publishEphemeral = publishEphemeral;
+
+    // Our own INVITE, echoed back via invite-notify (inviter === us).
+    conn.client.emit('invite', { nick: 'me', invited: 'bob', channel: '#secret' });
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(publishEphemeral).not.toHaveBeenCalled();
+  });
+
+  it('still routes an invite TO us as the actionable toast, not a channel line', () => {
+    const conn = makeConn();
+    conn.client.user.nick = 'me';
+    const publish = vi.fn<(event: unknown) => void>();
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+    conn.publishEphemeral = publishEphemeral;
+    conn.logNet = vi.fn<(text: string, level?: string) => void>();
+
+    conn.client.emit('invite', { nick: 'alice', invited: 'me', channel: '#secret' });
+
+    expect(publish).not.toHaveBeenCalled(); // not a channel line
+    expect(publishEphemeral).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'invite', target: ':server:1', channel: '#secret' }),
+    );
   });
 });

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -162,6 +162,11 @@ function extractExtras(event: IrcEvent): Record<string, unknown> | null {
     case 'kick':
       extras = { kicked: event.kicked };
       break;
+    case 'invite':
+      // The invited nick — `nick` (the standard actor column) holds the
+      // inviter. Persisted so the "X invited Y" channel line round-trips (#261).
+      extras = { invited: event.invited };
+      break;
     case 'nick':
       extras = { newNick: event.newNick };
       break;
@@ -1380,33 +1385,54 @@ export class IrcConnection {
 
     c.on('invite', (event: Record<string, unknown>) => {
       // irc-framework parses an inbound INVITE as { nick: inviter, invited:
-      // target nick, channel }. With invite-notify we also see invites sent to
-      // *other* people in channels we're in — only the "you've been invited"
-      // case is actionable, so ignore any invite whose target isn't us. (A
-      // future enhancement could surface op-visibility invites as a quiet
-      // channel line; #261.)
+      // target nick, channel }. Three cases land here (#261):
       const inviter = event.nick as string | undefined;
       const invited = event.invited as string | undefined;
-      const channel = event.channel as string | undefined;
-      if (!inviter || !channel || !invited) return;
+      const rawChannel = event.channel as string | undefined;
+      if (!inviter || !rawChannel || !invited) return;
       const me = c.user?.nick;
-      if (!me || invited.toLowerCase() !== me.toLowerCase()) return;
-      // Route through the server pseudo-buffer, not the channel: we're not in
-      // the channel (that's the whole point of an invite), and if we'd
-      // previously closed its buffer the wsHub closed-buffer guard would drop
-      // an ephemeral targeted at it. The channel rides in its own field; the
-      // client toast reads `channel`/`from`, never `target`.
-      this.publishEphemeral({
-        type: 'invite',
-        target: this.serverTarget(),
-        channel,
-        from: inviter,
-        userhost: buildUserhost(event),
-      });
-      // Durable fallback: the toast is transient, so log the invite to the
-      // system buffer too — a missed or expired toast still leaves a record the
-      // user can act on later (#261, #355).
-      this.logNet(`${inviter} invited you to ${channel}`);
+      const meLower = me?.toLowerCase();
+      const channel = canonicalChannelTarget(rawChannel, this.channels) ?? rawChannel;
+
+      // (1) Someone invited US → actionable toast + durable system line. Routed
+      // through the server pseudo-buffer, not the channel: we're not in the
+      // channel (that's the point of an invite), and if we'd previously closed
+      // its buffer the wsHub closed-buffer guard would drop an ephemeral
+      // targeted at it. The client toast reads `channel`/`from`, never `target`.
+      if (meLower && invited.toLowerCase() === meLower) {
+        this.publishEphemeral({
+          type: 'invite',
+          target: this.serverTarget(),
+          channel,
+          from: inviter,
+          userhost: buildUserhost(event),
+        });
+        this.logNet(`${inviter} invited you to ${channel}`);
+        return;
+      }
+
+      // (2) Our OWN invite, echoed back to us via the invite-notify cap. The
+      // RPL_INVITING (341) 'invited' handler already renders the channel line,
+      // so drop the echo to avoid a duplicate.
+      if (meLower && inviter.toLowerCase() === meLower) return;
+
+      // (3) invite-notify op-visibility: a third party invited someone to a
+      // channel we're in → persisted channel line "inviter invited invited".
+      this.publish({ type: 'invite', target: channel, nick: inviter, invited });
+    });
+
+    c.on('invited', (event: Record<string, unknown>) => {
+      // RPL_INVITING (341): the server confirms OUR /invite was relayed.
+      // irc-framework gives { nick: the invited nick, channel }. Render the same
+      // persisted channel line as the op-visibility path, attributed to us — so
+      // the confirmation shows up in the channel rather than the server buffer,
+      // and the invite-notify self-echo above is deduped against it (#261).
+      const invited = event.nick as string | undefined;
+      const rawChannel = event.channel as string | undefined;
+      const me = c.user?.nick;
+      if (!invited || !rawChannel || !me) return;
+      const channel = canonicalChannelTarget(rawChannel, this.channels) ?? rawChannel;
+      this.publish({ type: 'invite', target: channel, nick: me, invited });
     });
 
     c.on('quit', (event: Record<string, unknown>) => {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2742,6 +2742,32 @@ function handleCommand(line: string, networkId: number | null, target: string): 
         line,
       );
     }
+    case 'invite': {
+      // /invite <nick>             (in a channel buffer → invite to it)
+      // /invite <nick> <#chan>     (anywhere)
+      // /invite <#chan> <nick>     (channel-first, mirroring /kick)
+      let channel;
+      let nick;
+      if (rest[0] && rest[0].startsWith('#')) {
+        channel = rest[0];
+        nick = rest[1];
+      } else {
+        nick = rest[0];
+        channel =
+          rest[1] && rest[1].startsWith('#') ? rest[1] : isChannelTarget(target) ? target : null;
+      }
+      if (!nick) {
+        localInfo(networkId, target, 'usage: /invite <nick> [#channel]');
+        return true;
+      }
+      if (!channel) {
+        localInfo(networkId, target, 'usage: /invite <nick> [#channel] — no channel context');
+        return true;
+      }
+      // Wire order is INVITE <nick> <channel> (note: irc-framework's own
+      // .invite() flips the args — we build the raw line directly so it can't).
+      return sendOrToast({ type: 'raw', networkId, line: `INVITE ${nick} ${channel}` }, line);
+    }
     case 'topic': {
       // /topic                        — request current topic (server buffer)
       // /topic <text>                 — set on current channel

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -186,6 +186,17 @@
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
+            <template v-else-if="row.m?.type === 'invite'"
+              ><NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)" />
+              invited
+              <NickRef
+                :nick="row.m.invited ?? ''"
+                interactive
+                @click.stop.prevent="onNickMenu($event, row.m?.invited)"
+            /></template>
             <template v-else-if="row.m?.type === 'nick'"
               ><NickRef
                 :nick="row.m.nick ?? ''"
@@ -327,6 +338,7 @@ interface ChatMessage {
   matched?: unknown;
   newNick?: string;
   kicked?: string;
+  invited?: string;
   userhost?: string;
   // System-buffer lines (#355): the network this line is about, when any. The
   // prefix column resolves the network's current name from it.
@@ -1132,6 +1144,7 @@ function prefixText(m: ChatMessage | undefined): string {
     case 'mode':
     case 'topic':
     case 'motd':
+    case 'invite':
       return '--';
     case 'system':
       // System-buffer log lines (#355). Tied to a network → that network's

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -193,10 +193,17 @@ function applyEvent(event: any): void {
       });
       break;
     case 'invite': {
-      // Someone invited us to a channel we're not in. Surface it as an
-      // actionable toast with a one-click Join — the durable record lives in the
-      // system buffer (logged server-side), so a longer TTL here is just a
-      // convenience window, not the only chance to act (#261).
+      // Two shapes share this type (#261). A persisted channel line ("X invited
+      // Y", target = the channel) renders inline like a join/kick. The inbound
+      // "you've been invited" event is ephemeral, targets the server
+      // pseudo-buffer, and carries channel/from — surface it as an actionable
+      // toast with a one-click Join. The durable record for the latter lives in
+      // the system buffer (logged server-side), so the long TTL is just a
+      // convenience window, not the only chance to act.
+      if (typeof event.target === 'string' && event.target.startsWith('#')) {
+        buffers.pushMessage(event);
+        break;
+      }
       const channel = event.channel as string;
       const from = event.from as string;
       useToastsStore().push({


### PR DESCRIPTION
Outbound half of channel invite support (#261), building on the inbound toast from #433.

## What this adds
- **`/invite <nick> [#channel]`** (`MessageInput.vue`) — mirrors `/kick`: works as `/invite nick` in a channel buffer, `/invite nick #other` anywhere, or channel-first `/invite #chan nick`; prints usage hints on missing args. Builds the raw line in **`INVITE <nick> <channel>`** wire order directly — irc-framework's own `.invite()` flips the args, so we don't use it.
- **"X invited Y" channel lines**, persisted like join/kick:
  - `c.on('invited')` (`RPL_INVITING 341`) renders *your own* successful invites, attributed to you.
  - `c.on('invite')` else-branch renders *others'* invites seen via the `invite-notify` cap.
  - The invite-notify **echo of your own invite is suppressed** (deduped against the 341 line) — robust whether or not the server echoes self-invites.
- `extractExtras` persists the `invited` nick so the line round-trips through the DB; `MessageList` renders it with clickable `NickRef`s and a `--` gutter; `useSocket` discriminates the persisted channel line (`target` = `#chan`) from the inbound toast (`target` = `:server:`) by target.

## QA (verified on a live network)
- Own invite → single "X invited Y" line in the channel (no duplicate — self-dedup works).
- Line **persists across reload** (the new `extractExtras` round-trip).
- Inbound "you've been invited" toast + system line **still fire** (the `c.on('invite')` refactor didn't regress #433).
- Command variants + usage hints behave; inviter/invited nicks are clickable.
- A failed invite (not-an-op in `+i`) surfaces in the server buffer — visible, see deferred below.

## Checks
- `npm run check` (typecheck ×2 + lint + format) — clean
- `npm test` — **1554 passing**, incl. 4 new server tests (341→line, third-party→line, self-echo deduped, invite-to-us still toasts) + an updated prior test

## Deferred (tracked)
- **Invite-failure numerics** (482/443/401) routing to the originating buffer — a *shared* command-error limitation across kick/mode/topic/invite, tracked in #434. Failures are visible in the server buffer today, so this PR is usable without it.
- **Member context-menu "Invite to…"** — left as an open design question on #261 (the useful case needs a channel picker, since inviting someone to the channel you're both in is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)