### PR TITLE
Back/forward buffer navigation (#309)

### DIFF
--- a/vue_client/src/components/KeyboardHelpModal.vue
+++ b/vue_client/src/components/KeyboardHelpModal.vue
@@ -46,6 +46,8 @@ const shortcuts = computed<ShortcutRow[]>(() => [
   { keys: [ALT, '↓'], label: 'Next channel' },
   { keys: [ALT, 'Shift', '↑'], label: 'Previous unread channel' },
   { keys: [ALT, 'Shift', '↓'], label: 'Next unread channel' },
+  { keys: [MOD, '['], label: 'Back (previously viewed channel)' },
+  { keys: [MOD, ']'], label: 'Forward' },
   { keys: ['Shift', 'Esc'], label: 'Mark all channels read' },
   { keys: ['PgUp'], label: 'Scroll messages up one page' },
   { keys: ['PgDn'], label: 'Scroll messages down one page' },

--- a/vue_client/src/composables/useKeyboardShortcuts.ts
+++ b/vue_client/src/composables/useKeyboardShortcuts.ts
@@ -1,11 +1,12 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { onBeforeUnmount, onMounted } from 'vue';
+import { onBeforeUnmount, onMounted, watch } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { usePinsStore } from '../stores/pins.js';
 import { useFriendsStore } from '../stores/friends.js';
+import { useNavHistoryStore } from '../stores/navHistory.js';
 import { socketSend } from './useSocket.js';
 import { flattenBufferOrder, flattenUnreadOrder } from '../utils/bufferOrder.js';
 import { FRIENDS_KEY } from '../lib/virtualBuffers.js';
@@ -52,6 +53,23 @@ export function useKeyboardShortcuts({
   const buffers = useBuffersStore();
   const pins = usePinsStore();
   const friends = useFriendsStore();
+  const navHistory = useNavHistoryStore();
+
+  // Feed the back/forward history (#309). networks.activeKey is the one place
+  // every navigation path converges (sidebar click, quick switcher, slash
+  // commands, deep links, the Friends pane), so recording there captures them
+  // all with one seam. `flush: 'sync'` keeps the store's re-entrancy guard exact
+  // — the echo from our own back()/forward() fires the instant activeKey mutates,
+  // before the guard clears. Seed the current buffer so the first Cmd+[ has
+  // somewhere to return from.
+  watch(
+    () => networks.activeKey,
+    (key) => {
+      if (key != null) navHistory.record(key);
+    },
+    { flush: 'sync' },
+  );
+  if (networks.activeKey != null) navHistory.record(networks.activeKey);
 
   // The FRIENDS group as the sidebar shows it: a feed header (only when there
   // are contacts) + each friend's primary DM, with those DMs excluded from
@@ -165,6 +183,17 @@ export function useKeyboardShortcuts({
       // these buffer-nav combos don't double-trigger.
       e.preventDefault();
       step(delta, scope);
+      return;
+    }
+    // Cmd/Ctrl + [ / ] — back/forward through recently-visited buffers (#309).
+    // Slack's history shortcut. Chosen over Cmd/Alt+Arrow because both of those
+    // collide with text-cursor movement (line ends / word jumps) when focus is
+    // in the message input. preventDefault also suppresses the browser's own
+    // Cmd+[ / Cmd+] history navigation, which would otherwise leave the app.
+    if (isCmd(e) && !e.altKey && !e.shiftKey && (e.key === '[' || e.key === ']')) {
+      e.preventDefault();
+      if (e.key === '[') navHistory.back();
+      else navHistory.forward();
       return;
     }
     // Type-ahead: a bare printable character pressed while focus is on some

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -7,6 +7,7 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useHighlightsStore } from '../stores/highlights.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
+import { useNavHistoryStore } from '../stores/navHistory.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { usePushSubscriptionsStore } from '../stores/pushSubscriptions.js';
 import { usePinsStore } from '../stores/pins.js';
@@ -29,6 +30,7 @@ export function resetSession(): void {
   useHighlightsStore().$reset();
   useHighlightRulesStore().$reset();
   useInputHistoryStore().$reset();
+  useNavHistoryStore().$reset();
   const drafts = useDraftStore();
   drafts.resetTimers();
   drafts.$reset();

--- a/vue_client/src/stores/navHistory.test.ts
+++ b/vue_client/src/stores/navHistory.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+// navHistory dispatches hops through the buffers/friends stores. Stub both: byKey
+// reports liveness from a Set, activate echoes its key back through record() the
+// way the real activeKey watcher does (so the re-entrancy guard is exercised),
+// and friends.open() echoes the :friends: sentinel. ':friends:' is inlined here
+// because vi.hoisted runs before the virtualBuffers import binding exists.
+const h = vi.hoisted(() => ({
+  live: new Set<string>(),
+  record: null as null | ((key: string) => void),
+  activate: vi.fn((networkId: number | null, target: string) => {
+    h.record?.(networkId == null ? target : `${networkId}::${target}`);
+  }),
+  friendsOpen: vi.fn(() => h.record?.(':friends:')),
+}));
+
+vi.mock('./buffers.js', () => ({
+  useBuffersStore: () => ({
+    byKey: (k: string) => (h.live.has(k) ? { key: k } : null),
+    activate: h.activate,
+  }),
+}));
+vi.mock('./friends.js', () => ({
+  useFriendsStore: () => ({ open: h.friendsOpen }),
+}));
+
+import { useNavHistoryStore } from './navHistory.js';
+import { FRIENDS_KEY, SYSTEM_KEY } from '../lib/virtualBuffers.js';
+
+// Create the store and wire the simulated activeKey watcher (activate/open echo
+// back into record), matching how useKeyboardShortcuts hooks it up live.
+function mkStore() {
+  const nav = useNavHistoryStore();
+  h.record = (k) => nav.record(k);
+  return nav;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  h.live.clear();
+  h.record = null;
+  h.activate.mockReset();
+  h.activate.mockImplementation((networkId: number | null, target: string) => {
+    h.record?.(networkId == null ? target : `${networkId}::${target}`);
+  });
+  h.friendsOpen.mockReset();
+  h.friendsOpen.mockImplementation(() => h.record?.(':friends:'));
+});
+
+describe('record', () => {
+  it('builds the stack and tracks back/forward reachability', () => {
+    const nav = mkStore();
+    nav.record('1::#a');
+    expect(nav.canBack).toBe(false);
+    nav.record('1::#b');
+    expect(nav.stack).toEqual(['1::#a', '1::#b']);
+    expect(nav.index).toBe(1);
+    expect(nav.canBack).toBe(true);
+    expect(nav.canForward).toBe(false);
+  });
+});
+
+describe('back / forward dispatch', () => {
+  it('back re-activates the previous network buffer with parsed network + target', () => {
+    const nav = mkStore();
+    h.live.add('1::#a').add('1::#b');
+    nav.record('1::#a');
+    nav.record('1::#b');
+    h.activate.mockClear();
+
+    nav.back();
+
+    expect(h.activate).toHaveBeenCalledWith(1, '#a');
+    expect(nav.index).toBe(0);
+    expect(nav.canForward).toBe(true);
+  });
+
+  it('forward returns to the buffer we backed away from', () => {
+    const nav = mkStore();
+    h.live.add('1::#a').add('1::#b');
+    nav.record('1::#a');
+    nav.record('1::#b');
+    nav.back();
+    h.activate.mockClear();
+
+    nav.forward();
+
+    expect(h.activate).toHaveBeenCalledWith(1, '#b');
+    expect(nav.index).toBe(1);
+  });
+
+  it('routes the system sentinel to the networkId-less system buffer', () => {
+    const nav = mkStore();
+    h.live.add('1::#a');
+    nav.record(SYSTEM_KEY);
+    nav.record('1::#a');
+    h.activate.mockClear();
+
+    nav.back();
+
+    expect(h.activate).toHaveBeenCalledWith(null, SYSTEM_KEY);
+  });
+
+  it('routes the friends sentinel through the friends store', () => {
+    const nav = mkStore();
+    h.live.add('1::#a');
+    nav.record(FRIENDS_KEY);
+    nav.record('1::#a');
+
+    nav.back();
+
+    expect(h.friendsOpen).toHaveBeenCalledOnce();
+    expect(h.activate).not.toHaveBeenCalled();
+  });
+
+  it('skips a buffer that was closed since it was visited', () => {
+    const nav = mkStore();
+    h.live.add('1::#a').add('1::#c'); // #dead is gone from the store
+    nav.record('1::#a');
+    nav.record('1::#dead');
+    nav.record('1::#c');
+    h.activate.mockClear();
+
+    nav.back(); // over #dead, onto #a
+
+    expect(h.activate).toHaveBeenCalledOnce();
+    expect(h.activate).toHaveBeenCalledWith(1, '#a');
+    expect(nav.index).toBe(0);
+  });
+
+  it('no-ops at the back boundary without activating anything', () => {
+    const nav = mkStore();
+    h.live.add('1::#a');
+    nav.record('1::#a');
+    h.activate.mockClear();
+
+    nav.back();
+
+    expect(h.activate).not.toHaveBeenCalled();
+    expect(nav.index).toBe(0);
+  });
+});
+
+describe('re-entrancy guard', () => {
+  it('ignores the activation echo so a back hop cannot corrupt the stack', () => {
+    const nav = mkStore();
+    h.live.add('1::#a').add('1::#b');
+    nav.record('1::#a');
+    nav.record('1::#b');
+    // Simulate the activeKey watcher echoing a *canonicalized* (differently
+    // cased) key back into record() mid-hop. The dedupe check wouldn't catch a
+    // different string — only the navigating guard keeps the stack intact.
+    h.activate.mockImplementation(() => nav.record('1::#CANON'));
+
+    nav.back();
+
+    expect(nav.stack).toEqual(['1::#a', '1::#b']);
+    expect(nav.index).toBe(0);
+  });
+});

--- a/vue_client/src/stores/navHistory.test.ts
+++ b/vue_client/src/stores/navHistory.test.ts
@@ -12,10 +12,10 @@ import { setActivePinia, createPinia } from 'pinia';
 const h = vi.hoisted(() => ({
   live: new Set<string>(),
   record: null as null | ((key: string) => void),
-  activate: vi.fn((networkId: number | null, target: string) => {
+  activate: vi.fn<(networkId: number | null, target: string) => void>((networkId, target) => {
     h.record?.(networkId == null ? target : `${networkId}::${target}`);
   }),
-  friendsOpen: vi.fn(() => h.record?.(':friends:')),
+  friendsOpen: vi.fn<() => void>(() => h.record?.(':friends:')),
 }));
 
 vi.mock('./buffers.js', () => ({

--- a/vue_client/src/stores/navHistory.ts
+++ b/vue_client/src/stores/navHistory.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineStore } from 'pinia';
+import { useBuffersStore } from './buffers.js';
+import { useFriendsStore } from './friends.js';
+import { FRIENDS_KEY, isVirtualKey } from '../lib/virtualBuffers.js';
+import { createNavHistory, recordVisit, stepIndex } from '../utils/navHistory.js';
+
+// True only for the synchronous span of a back()/forward() activation, so the
+// networks.activeKey watcher (wired in useKeyboardShortcuts) doesn't re-record
+// the programmatic hop as a fresh visit and corrupt the cursor. Module-level
+// because the store is a singleton and this never needs to be reactive; it's
+// always false between operations, so $reset() needn't touch it.
+let navigating = false;
+
+// Slack-style back/forward across recently-visited buffers (#309). Client-only
+// and in-memory by design: no server round-trip, no persistence across reloads.
+// The cursor mechanics live in utils/navHistory; this store owns the live
+// wiring — recording activations (via record(), fed by the activeKey watcher)
+// and dispatching a hop back through the same activation path a click takes.
+export const useNavHistoryStore = defineStore('navHistory', {
+  state: () => createNavHistory(),
+  getters: {
+    // Reachability is gated only by the boundaries here; back()/forward() may
+    // still no-op if everything in that direction turns out to be a dead buffer.
+    canBack: (s) => s.index > 0,
+    canForward: (s) => s.index < s.stack.length - 1,
+  },
+  actions: {
+    // The single recording seam: the activeKey watcher calls this on every
+    // change. The guard drops the echo from our own back/forward navigation.
+    record(activeKey: string) {
+      if (navigating) return;
+      recordVisit(this, activeKey);
+    },
+    back() {
+      this.move(-1);
+    },
+    forward() {
+      this.move(1);
+    },
+    move(delta: number) {
+      const target = stepIndex(this, delta, (k) => this.exists(k));
+      if (target === -1) return; // nothing live that way — keypress is a no-op
+      this.index = target;
+      navigating = true;
+      try {
+        this.go(this.stack[target]);
+      } finally {
+        navigating = false;
+      }
+    },
+    // A virtual pane (:friends:, :system:) is always reachable; a real buffer is
+    // gone once parted/closed (the buffers store deletes its entry).
+    exists(activeKey: string): boolean {
+      return isVirtualKey(activeKey) || !!useBuffersStore().byKey(activeKey);
+    },
+    // Re-activate a recorded key through the same path the original click took,
+    // so the hop runs all the usual activation side effects (read pointer,
+    // refetch, presence probe).
+    go(activeKey: string) {
+      if (activeKey === FRIENDS_KEY) {
+        useFriendsStore().open();
+        return;
+      }
+      // `${networkId}::${target}`, or a bare sentinel (:system:) with no `::`,
+      // which activates as the networkId-less system buffer.
+      const sep = activeKey.indexOf('::');
+      if (sep === -1) useBuffersStore().activate(null, activeKey);
+      else useBuffersStore().activate(Number(activeKey.slice(0, sep)), activeKey.slice(sep + 2));
+    },
+  },
+});

--- a/vue_client/src/utils/navHistory.test.ts
+++ b/vue_client/src/utils/navHistory.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import {
+  createNavHistory,
+  recordVisit,
+  stepIndex,
+  MAX_HISTORY,
+  type NavHistory,
+} from './navHistory.js';
+
+// Build a history and replay a sequence of visits through recordVisit, the way
+// the activeKey watcher feeds it live.
+function visiting(...keys: string[]): NavHistory {
+  const h = createNavHistory();
+  for (const k of keys) recordVisit(h, k);
+  return h;
+}
+
+describe('recordVisit', () => {
+  it('pushes the first visit and parks the cursor on it', () => {
+    const h = visiting('1::#a');
+    expect(h.stack).toEqual(['1::#a']);
+    expect(h.index).toBe(0);
+  });
+
+  it('appends distinct visits and tracks the cursor at the tail', () => {
+    const h = visiting('1::#a', '1::#b', '1::#c');
+    expect(h.stack).toEqual(['1::#a', '1::#b', '1::#c']);
+    expect(h.index).toBe(2);
+  });
+
+  it('collapses re-entering the buffer already at the cursor', () => {
+    const h = visiting('1::#a', '1::#a');
+    expect(h.stack).toEqual(['1::#a']);
+    expect(h.index).toBe(0);
+    expect(recordVisit(h, '1::#a')).toBe(false);
+  });
+
+  it('keeps non-consecutive repeats (A, B, A is a real path)', () => {
+    const h = visiting('1::#a', '1::#b', '1::#a');
+    expect(h.stack).toEqual(['1::#a', '1::#b', '1::#a']);
+    expect(h.index).toBe(2);
+  });
+
+  it('truncates the forward branch when navigating somewhere new after going back', () => {
+    const h = visiting('1::#a', '1::#b', '1::#c');
+    h.index = 0; // pretend the user pressed back twice to land on #a
+    recordVisit(h, '1::#z');
+    expect(h.stack).toEqual(['1::#a', '1::#z']);
+    expect(h.index).toBe(1);
+  });
+
+  it('is a no-op when re-recording the cursor entry mid-history (back then click-same)', () => {
+    const h = visiting('1::#a', '1::#b', '1::#c');
+    h.index = 1;
+    expect(recordVisit(h, '1::#b')).toBe(false);
+    expect(h.stack).toEqual(['1::#a', '1::#b', '1::#c']);
+    expect(h.index).toBe(1);
+  });
+
+  it('evicts the oldest entries past the cap and shifts the cursor with them', () => {
+    const h = createNavHistory();
+    for (let i = 0; i < MAX_HISTORY + 5; i++) recordVisit(h, `1::#c${i}`);
+    expect(h.stack.length).toBe(MAX_HISTORY);
+    expect(h.stack[0]).toBe('1::#c5'); // first five dropped
+    expect(h.stack[h.stack.length - 1]).toBe(`1::#c${MAX_HISTORY + 4}`);
+    expect(h.index).toBe(MAX_HISTORY - 1);
+  });
+});
+
+describe('stepIndex', () => {
+  const allLive = () => true;
+
+  it('walks back and forward one live entry at a time', () => {
+    const h = visiting('1::#a', '1::#b', '1::#c'); // index 2
+    expect(stepIndex(h, -1, allLive)).toBe(1);
+    h.index = 1;
+    expect(stepIndex(h, -1, allLive)).toBe(0);
+    expect(stepIndex(h, 1, allLive)).toBe(2);
+  });
+
+  it('returns -1 at the back and forward boundaries', () => {
+    const h = visiting('1::#a', '1::#b'); // index 1 (tail)
+    expect(stepIndex(h, 1, allLive)).toBe(-1); // already at the front
+    h.index = 0;
+    expect(stepIndex(h, -1, allLive)).toBe(-1); // already at the back
+  });
+
+  it('returns -1 for an empty history', () => {
+    expect(stepIndex(createNavHistory(), -1, allLive)).toBe(-1);
+  });
+
+  it('skips dead entries and lands on the nearest live one', () => {
+    const h = visiting('1::#a', '1::#dead', '1::#c'); // index 2
+    const exists = (k: string) => k !== '1::#dead';
+    expect(stepIndex(h, -1, exists)).toBe(0); // hop over #dead
+  });
+
+  it('returns -1 when every entry in the requested direction is dead', () => {
+    const h = visiting('1::#x', '1::#y', '1::#z'); // index 2
+    const exists = (k: string) => k === '1::#z'; // only the current is live
+    expect(stepIndex(h, -1, exists)).toBe(-1);
+  });
+});

--- a/vue_client/src/utils/navHistory.ts
+++ b/vue_client/src/utils/navHistory.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Pure mechanics for the back/forward buffer-navigation stack (#309). Browser
+// history semantics: visiting a buffer pushes onto the stack and discards any
+// forward branch; back/forward just walk a cursor without mutating the stack.
+// Kept free of Vue/Pinia/store deps so the cursor edge cases (consecutive-dupe
+// collapse, forward-branch truncation, cap eviction, dead-target skipping) are
+// unit-testable in isolation — the navHistory store wires this to
+// networks.activeKey and to buffer activation.
+
+// Stack entries are activeKey strings exactly as networks.activeKey holds them:
+// `${networkId}::${target}` for real buffers, or a bare sentinel (:system:,
+// :friends:) for the virtual panes.
+export interface NavHistory {
+  stack: string[];
+  index: number; // cursor into stack; -1 when empty
+}
+
+// Cap the retained trail. Back/forward is a convenience for recent hops, not an
+// audit log — an unbounded stack would pin every buffer key the session ever
+// touched in memory for no user benefit.
+export const MAX_HISTORY = 100;
+
+export function createNavHistory(): NavHistory {
+  return { stack: [], index: -1 };
+}
+
+// Record a user-initiated visit to `key`. Returns true when the stack changed.
+// Re-entering the buffer already at the cursor is a no-op (no consecutive
+// dupes); navigating somewhere new from a back position drops the forward branch.
+export function recordVisit(h: NavHistory, key: string): boolean {
+  if (h.stack[h.index] === key) return false;
+  if (h.index < h.stack.length - 1) h.stack.splice(h.index + 1);
+  h.stack.push(key);
+  h.index = h.stack.length - 1;
+  if (h.stack.length > MAX_HISTORY) {
+    const drop = h.stack.length - MAX_HISTORY;
+    h.stack.splice(0, drop);
+    h.index -= drop;
+  }
+  return true;
+}
+
+// Resolve where a back (delta -1) or forward (delta +1) step should land,
+// skipping entries whose buffer no longer exists (parted channel, closed DM).
+// Returns the destination index, or -1 when there's no live target that way —
+// the caller leaves the cursor put and the keypress is a no-op.
+export function stepIndex(h: NavHistory, delta: number, exists: (key: string) => boolean): number {
+  let i = h.index;
+  for (;;) {
+    const next = i + delta;
+    if (next < 0 || next >= h.stack.length) return -1;
+    i = next;
+    if (exists(h.stack[i])) return i;
+  }
+}


### PR DESCRIPTION
Closes #309.

Slack-style back/forward across recently-visited buffers, bound to **`Cmd/Ctrl+[`** (back) and **`Cmd/Ctrl+]`** (forward). Fully client-side and in-memory — no server round-trip, no persistence across reloads, as the issue scoped.

### Why these keys
Both `Cmd/Ctrl+←/→` and `Alt+←/→` collide with text-cursor movement (line ends / word jumps) when focus is in the message input, so they'd only be safe to fire when the input is unfocused — fragile and bad for discoverability. `Cmd/Ctrl+[` / `]` is Slack's history shortcut and has no such conflict. `preventDefault` also suppresses the browser's own `Cmd+[` / `]` history navigation, which would otherwise leave the app.

### Approach
`networks.activeKey` is the one place every navigation path converges (sidebar click, quick switcher, slash commands, deep links, the Friends pane), so a single `flush:'sync'` watcher records all of them with one seam — no changes to `buffers.ts` or `friends.ts`.

- **`utils/navHistory.ts`** — pure cursor mechanics (collapse consecutive dupes, truncate the forward branch on new navigation, cap at 100, skip dead targets). No Vue/store deps, so the tricky edges are unit-testable in isolation.
- **`stores/navHistory.ts`** — Pinia store wrapping it; `back()`/`forward()` re-dispatch through the real activation paths (network buffer, `:system:`, Friends pane) and skip buffers parted/closed since they were visited. A re-entrancy guard drops the activation echo so our own hops can't corrupt the cursor.
- **`useKeyboardShortcuts.ts`** — the recording watcher + the two bindings.
- **`useSessionReset.ts`** — `$reset` on logout so history doesn't bleed across users.
- **`KeyboardHelpModal.vue`** — both shortcuts listed; the discoverability path now that the feature is keyboard-only.

### Notes / deliberate choices
- **Dead buffers are skipped, not resurrected** — backing into a since-parted channel hops to the next live buffer rather than re-creating an empty shell.
- **No new "switch buffer" shortcuts** — the issue's "& More" musing about global `Cmd+↑/↓` is already covered by the existing `Alt+↑/↓` (all buffers) and `Shift+Alt+↑/↓` (unread).
- **Related issue #393** (quick-switcher smart sort) is a cousin, not coupled — it needs an MRU list rather than a cursor stack, but can reuse this same `activate`/`activeKey` recording seam. Left untouched here.

### Testing
- 20 new tests (11 pure-mechanics + 9 store routing/guard/skip/boundary).
- Full suite green (1574 passed); typecheck + format clean.
- Verified working in local QA (keyboard-only feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)