### PR TITLE
Quick switcher smart sort (#393)

### DIFF
--- a/vue_client/src/components/QuickSwitcher.vue
+++ b/vue_client/src/components/QuickSwitcher.vue
@@ -24,10 +24,10 @@
       <ul v-if="rows.length" ref="listEl" class="list">
         <li
           v-for="(row, i) in rows"
-          :key="`${row.networkId}::${row.target}`"
+          :key="row.key"
           :class="{ row: true, active: i === selected }"
           @click="pick(row)"
-          @mouseenter="selected = i"
+          @mousemove="onPointerMove($event, i)"
         >
           <span class="net">{{ row.networkName }}</span>
           <span class="sep">/</span>
@@ -46,8 +46,10 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { usePinsStore } from '../stores/pins.js';
 import { useFriendsStore } from '../stores/friends.js';
+import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { useNickColors } from '../composables/useNickColors.js';
-import { flattenBufferOrder } from '../utils/bufferOrder.js';
+import { flattenBufferOrder, bufferSortKey } from '../utils/bufferOrder.js';
+import { smartSortRows } from '../utils/switcherSort.js';
 
 interface Row {
   networkId: string | number;
@@ -56,6 +58,12 @@ interface Row {
   label: string;
   unread: number;
   style: { color: string } | null;
+  // Smart-sort inputs (#393): identity/recency key, pin state, and the
+  // alphabetical tie-break key. Carried on the row so the template's :key and
+  // the sort share one source.
+  key: string;
+  pinned: boolean;
+  sortKey: string;
 }
 
 const emit = defineEmits<{
@@ -66,6 +74,7 @@ const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const pins = usePinsStore();
 const friends = useFriendsStore();
+const recent = useRecentBuffersStore();
 const nicks = useNickColors();
 
 const query = ref('');
@@ -118,18 +127,35 @@ const allRows = computed<Row[]>(() => {
       label: isServer ? '[server]' : entry.target,
       unread: buf?.unread || 0,
       style: dmStyle(entry.networkId, entry.target),
+      key: entry.key,
+      pinned: pins.isPinned(entry.networkId, entry.target),
+      sortKey: bufferSortKey(entry.target as string),
     };
   });
 });
 
 const rows = computed<Row[]>(() => {
   const q = query.value.trim().toLowerCase();
-  if (!q) return allRows.value;
+  // No query: this is the alt-tab view, so drop the buffer you're already in —
+  // switching to where you already are is a no-op, and dropping it puts your
+  // *previous* buffer at row 0 (and pre-selected), making Cmd+K→Enter a clean
+  // back toggle. With a query it's a search: keep everything matchable, since
+  // you may well be looking for the current buffer by name.
   // Match only on the channel/DM label, not the network name — a bare network
   // keyword ("libera") surfacing every buffer in that network is noise, and
   // there's no multi-keyword "libera amiantos" syntax to make it useful (#153).
-  return allRows.value.filter((r) => {
-    return r.label.toLowerCase().includes(q);
+  const filtered = q
+    ? allRows.value.filter((r) => r.label.toLowerCase().includes(q))
+    : allRows.value.filter((r) => r.key !== networks.activeKey);
+  // Tiered smart sort applied AFTER filtering (#393): recent → pinned → unread →
+  // alphabetical, so recency/favourites survive a search instead of collapsing
+  // to plain alphabetical. Reads recent.keys so this recomputes as the MRU moves.
+  const ranks = recent.keys;
+  return smartSortRows(filtered, {
+    recencyRank: (key) => {
+      const i = ranks.indexOf(key);
+      return i === -1 ? Infinity : i;
+    },
   });
 });
 
@@ -140,6 +166,20 @@ watch(rows, () => {
 function pick(row: Row) {
   buffers.activate(row.networkId, row.target);
   emit('close');
+}
+
+// Hover-to-select, but only on a *real* pointer move. `mouseenter`/hover also
+// fires when the list paints under a stationary cursor (on open) or scrolls
+// under it (arrow-key nav scrollIntoView), which would otherwise clobber the
+// keyboard selection — the classic sticky-hover trap. Gating on an actual
+// change in pointer coordinates ignores both: those synthetic events carry the
+// same clientX/clientY, since the mouse didn't move.
+const lastPointer = ref<{ x: number; y: number } | null>(null);
+function onPointerMove(e: MouseEvent, i: number) {
+  if (lastPointer.value && lastPointer.value.x === e.clientX && lastPointer.value.y === e.clientY)
+    return;
+  lastPointer.value = { x: e.clientX, y: e.clientY };
+  selected.value = i;
 }
 
 function onKeydown(e: KeyboardEvent) {
@@ -173,12 +213,10 @@ function scrollSelectedIntoView() {
 }
 
 onMounted(() => {
-  // Pre-select the first row that isn't the currently active buffer so Enter
-  // is a useful default — switching to wherever you were last vs. staying put.
-  const activeKey = networks.activeKey;
-  const list = rows.value;
-  const idx = list.findIndex((r) => `${r.networkId}::${r.target}` !== activeKey);
-  selected.value = idx >= 0 ? idx : 0;
+  // Row 0 is the right default: the default (no-query) view excludes the active
+  // buffer, so the most-recent remaining entry — your previous buffer — sits at
+  // the top, making Cmd+K→Enter a back toggle. selected starts at 0 and the
+  // rows watcher keeps it there as the query changes; just take focus here.
   setTimeout(() => inputEl.value?.focus(), 0);
 });
 </script>

--- a/vue_client/src/components/QuickSwitcher.vue
+++ b/vue_client/src/components/QuickSwitcher.vue
@@ -176,9 +176,15 @@ function pick(row: Row) {
 // same clientX/clientY, since the mouse didn't move.
 const lastPointer = ref<{ x: number; y: number } | null>(null);
 function onPointerMove(e: MouseEvent, i: number) {
+  // Coordinate gate first (and update lastPointer regardless of the row) so a
+  // later synthetic event at the cursor's true position is still recognised as
+  // "no movement" — even when the pointer just slid within the current row.
   if (lastPointer.value && lastPointer.value.x === e.clientX && lastPointer.value.y === e.clientY)
     return;
   lastPointer.value = { x: e.clientX, y: e.clientY };
+  // Only a change of hovered row is worth acting on; skip moves within the
+  // already-selected row.
+  if (selected.value === i) return;
   selected.value = i;
 }
 

--- a/vue_client/src/composables/useKeyboardShortcuts.ts
+++ b/vue_client/src/composables/useKeyboardShortcuts.ts
@@ -7,6 +7,7 @@ import { useBuffersStore } from '../stores/buffers.js';
 import { usePinsStore } from '../stores/pins.js';
 import { useFriendsStore } from '../stores/friends.js';
 import { useNavHistoryStore } from '../stores/navHistory.js';
+import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { socketSend } from './useSocket.js';
 import { flattenBufferOrder, flattenUnreadOrder } from '../utils/bufferOrder.js';
 import { FRIENDS_KEY } from '../lib/virtualBuffers.js';
@@ -54,22 +55,32 @@ export function useKeyboardShortcuts({
   const pins = usePinsStore();
   const friends = useFriendsStore();
   const navHistory = useNavHistoryStore();
+  const recentBuffers = useRecentBuffersStore();
 
-  // Feed the back/forward history (#309). networks.activeKey is the one place
-  // every navigation path converges (sidebar click, quick switcher, slash
-  // commands, deep links, the Friends pane), so recording there captures them
-  // all with one seam. `flush: 'sync'` keeps the store's re-entrancy guard exact
-  // — the echo from our own back()/forward() fires the instant activeKey mutates,
-  // before the guard clears. Seed the current buffer so the first Cmd+[ has
-  // somewhere to return from.
+  // Feed the back/forward history (#309) and the quick switcher's MRU recency
+  // list (#393) from one seam. networks.activeKey is the single place every
+  // navigation path converges (sidebar click, quick switcher, slash commands,
+  // deep links, the Friends pane), so recording there captures them all.
+  // `flush: 'sync'` keeps navHistory's re-entrancy guard exact — the echo from
+  // its own back()/forward() fires the instant activeKey mutates, before the
+  // guard clears (recentBuffers has no such guard: a back/forward hop is a
+  // genuine recent visit and should move to the front). Seed the current buffer
+  // so the first Cmd+[ has somewhere to return from and the switcher opens with
+  // recency already meaningful.
   watch(
     () => networks.activeKey,
     (key) => {
-      if (key != null) navHistory.record(key);
+      if (key != null) {
+        navHistory.record(key);
+        recentBuffers.record(key);
+      }
     },
     { flush: 'sync' },
   );
-  if (networks.activeKey != null) navHistory.record(networks.activeKey);
+  if (networks.activeKey != null) {
+    navHistory.record(networks.activeKey);
+    recentBuffers.record(networks.activeKey);
+  }
 
   // The FRIENDS group as the sidebar shows it: a feed header (only when there
   // are contacts) + each friend's primary DM, with those DMs excluded from

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -8,6 +8,7 @@ import { useHighlightsStore } from '../stores/highlights.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
 import { useNavHistoryStore } from '../stores/navHistory.js';
+import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { usePushSubscriptionsStore } from '../stores/pushSubscriptions.js';
 import { usePinsStore } from '../stores/pins.js';
@@ -31,6 +32,7 @@ export function resetSession(): void {
   useHighlightRulesStore().$reset();
   useInputHistoryStore().$reset();
   useNavHistoryStore().$reset();
+  useRecentBuffersStore().$reset();
   const drafts = useDraftStore();
   drafts.resetTimers();
   drafts.$reset();

--- a/vue_client/src/stores/recentBuffers.ts
+++ b/vue_client/src/stores/recentBuffers.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineStore } from 'pinia';
+import { createRecentBuffers, recordRecent, recencyRank } from '../utils/recentBuffers.js';
+
+// Most-recently-used buffer list powering the quick switcher's smart sort
+// (#393). Client-only and in-memory, like its cousin navHistory (#309): both are
+// fed by the single networks.activeKey watcher in useKeyboardShortcuts, but
+// where navHistory keeps a back/forward cursor stack, this keeps a move-to-front
+// recency list. Unlike navHistory it records EVERY activation, including the
+// programmatic back/forward hops navHistory itself ignores — landing on a buffer
+// via Cmd+[ still legitimately makes it recently-used.
+export const useRecentBuffersStore = defineStore('recentBuffers', {
+  state: () => createRecentBuffers(),
+  getters: {
+    // Recency rank as a bound lookup: 0 = most recent … Infinity = unvisited.
+    // Reads s.keys, so a computed calling it re-runs when the MRU changes.
+    rank: (s) => (key: string) => recencyRank(s, key),
+  },
+  actions: {
+    // The recording seam: the activeKey watcher calls this on every change.
+    record(activeKey: string) {
+      recordRecent(this, activeKey);
+    },
+  },
+});

--- a/vue_client/src/utils/bufferOrder.ts
+++ b/vue_client/src/utils/bufferOrder.ts
@@ -69,7 +69,10 @@ function isChannelTarget(target: string): boolean {
   return typeof target === 'string' && target.startsWith('#');
 }
 
-function sortKey(target: string): string {
+// Alphabetical sort key for a buffer: leading channel sigils stripped, ASCII-
+// lowercased (matching the house case-folding style). Exported so the quick
+// switcher's smart sort (#393) alphabetises identically to the sidebar.
+export function bufferSortKey(target: string): string {
   return target.replace(/^#+/, '').toLowerCase();
 }
 
@@ -137,7 +140,7 @@ export function flattenBufferOrder({
         const oa = bufferOrder(a.target);
         const ob = bufferOrder(b.target);
         if (oa !== ob) return oa - ob;
-        return sortKey(a.target).localeCompare(sortKey(b.target));
+        return bufferSortKey(a.target).localeCompare(bufferSortKey(b.target));
       });
     for (const b of unpinned)
       out.push({

--- a/vue_client/src/utils/recentBuffers.test.ts
+++ b/vue_client/src/utils/recentBuffers.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import {
+  createRecentBuffers,
+  recordRecent,
+  recencyRank,
+  MAX_RECENT,
+  type RecentBuffers,
+} from './recentBuffers.js';
+
+// Replay a sequence of visits through recordRecent, the way the activeKey
+// watcher feeds it live (left-to-right = oldest-to-newest).
+function visiting(...keys: string[]): RecentBuffers {
+  const r = createRecentBuffers();
+  for (const k of keys) recordRecent(r, k);
+  return r;
+}
+
+describe('recordRecent', () => {
+  it('puts the first visit at the front', () => {
+    const r = visiting('1::#a');
+    expect(r.keys).toEqual(['1::#a']);
+  });
+
+  it('keeps the most-recent visit at index 0 (newest first)', () => {
+    const r = visiting('1::#a', '1::#b', '1::#c');
+    expect(r.keys).toEqual(['1::#c', '1::#b', '1::#a']);
+  });
+
+  it('moves a revisited buffer to the front instead of duplicating it', () => {
+    const r = visiting('1::#a', '1::#b', '1::#c', '1::#a');
+    expect(r.keys).toEqual(['1::#a', '1::#c', '1::#b']);
+  });
+
+  it('is a no-op when re-recording the buffer already at the front', () => {
+    const r = visiting('1::#a', '1::#b');
+    expect(recordRecent(r, '1::#b')).toBe(false);
+    expect(r.keys).toEqual(['1::#b', '1::#a']);
+  });
+
+  it('reports a change when an older entry is promoted to the front', () => {
+    const r = visiting('1::#a', '1::#b');
+    expect(recordRecent(r, '1::#a')).toBe(true);
+    expect(r.keys).toEqual(['1::#a', '1::#b']);
+  });
+
+  it('evicts the oldest entries past the cap', () => {
+    const r = createRecentBuffers();
+    for (let i = 0; i < MAX_RECENT + 5; i++) recordRecent(r, `1::#c${i}`);
+    expect(r.keys.length).toBe(MAX_RECENT);
+    expect(r.keys[0]).toBe(`1::#c${MAX_RECENT + 4}`); // newest at front
+    expect(r.keys.at(-1)).toBe('1::#c5'); // first five fell off the tail
+  });
+});
+
+describe('recencyRank', () => {
+  it('ranks 0 = most recent, higher = older', () => {
+    const r = visiting('1::#a', '1::#b', '1::#c');
+    expect(recencyRank(r, '1::#c')).toBe(0);
+    expect(recencyRank(r, '1::#b')).toBe(1);
+    expect(recencyRank(r, '1::#a')).toBe(2);
+  });
+
+  it('returns Infinity for a buffer never visited this session', () => {
+    const r = visiting('1::#a');
+    expect(recencyRank(r, '1::#never')).toBe(Infinity);
+  });
+});

--- a/vue_client/src/utils/recentBuffers.ts
+++ b/vue_client/src/utils/recentBuffers.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Pure mechanics for the most-recently-used (MRU) buffer list that feeds the
+// quick switcher's tiered smart sort (#393). A cousin of the back/forward nav
+// stack (utils/navHistory, #309) — both hang off the same networks.activeKey
+// signal — but a different shape: this is a move-to-front, deduped recency list
+// (most recent at index 0), not a cursor stack with a forward branch. Kept free
+// of Vue/Pinia so the move-to-front, cap, and ranking edge cases are unit-
+// testable in isolation; the recentBuffers store wires it to networks.activeKey.
+
+// activeKey strings exactly as networks.activeKey holds them:
+// `${networkId}::${target}` for real buffers, or a bare sentinel (:system:,
+// :friends:) for the virtual panes.
+export interface RecentBuffers {
+  keys: string[]; // most-recent first
+}
+
+// Cap the retained recency trail. The switcher reads only the first few
+// (the recent tier window) plus does rank lookups for ordering the pinned tier,
+// so a long tail buys nothing; keep enough that pinned-by-recency stays
+// meaningful across a session without growing unbounded.
+export const MAX_RECENT = 50;
+
+export function createRecentBuffers(): RecentBuffers {
+  return { keys: [] };
+}
+
+// Record a visit to `key`: move it to the front (deduping any earlier mention),
+// then trim the tail to the cap. Returns true when the list changed —
+// re-visiting the key already at the front is a no-op so a flush:'sync' watcher
+// firing on an unrelated activeKey settle doesn't churn the list.
+export function recordRecent(r: RecentBuffers, key: string): boolean {
+  if (r.keys[0] === key) return false;
+  const existing = r.keys.indexOf(key);
+  if (existing !== -1) r.keys.splice(existing, 1);
+  r.keys.unshift(key);
+  if (r.keys.length > MAX_RECENT) r.keys.length = MAX_RECENT;
+  return true;
+}
+
+// Recency rank of `key`: 0 = most recent, higher = older, Infinity = unvisited
+// this session. Drives both the pinned tier's ordering and recent-tier
+// membership in the switcher's smart sort.
+export function recencyRank(r: RecentBuffers, key: string): number {
+  const i = r.keys.indexOf(key);
+  return i === -1 ? Infinity : i;
+}

--- a/vue_client/src/utils/switcherSort.test.ts
+++ b/vue_client/src/utils/switcherSort.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { smartSortRows, type SwitcherItem } from './switcherSort.js';
+
+// Build a switcher item; sortKey is derived the way QuickSwitcher does
+// (bufferSortKey: leading '#' stripped, lowercased) so alpha tie-breaks read
+// naturally from the key.
+function item(key: string, opts: Partial<SwitcherItem> = {}): SwitcherItem {
+  const target = key.slice(key.indexOf('::') + 2);
+  return {
+    key,
+    pinned: false,
+    unread: 0,
+    sortKey: target.replace(/^#+/, '').toLowerCase(),
+    ...opts,
+  };
+}
+
+// recencyRank from an ordered key list, most-recent-first (index = rank);
+// anything absent is unvisited (Infinity).
+function ranker(...mostRecentFirst: string[]) {
+  return (key: string) => {
+    const i = mostRecentFirst.indexOf(key);
+    return i === -1 ? Infinity : i;
+  };
+}
+
+const keys = (rows: SwitcherItem[]) => rows.map((r) => r.key);
+
+describe('smartSortRows tier precedence', () => {
+  it('orders recent → pinned → unread → alphabetical', () => {
+    const rows = [
+      item('1::#alp'),
+      item('1::#unr', { unread: 3 }),
+      item('1::#pin', { pinned: true }),
+      item('1::#rec'),
+    ];
+    const out = smartSortRows(rows, { recencyRank: ranker('1::#rec') });
+    expect(keys(out)).toEqual(['1::#rec', '1::#pin', '1::#unr', '1::#alp']);
+  });
+
+  it('keeps a recently-visited buffer on top even when it is pinned (recency wins)', () => {
+    const rows = [item('1::#pin', { pinned: true }), item('1::#rec')];
+    // #rec is most recent; #pin is pinned but unvisited this session.
+    const out = smartSortRows(rows, { recencyRank: ranker('1::#rec') });
+    expect(keys(out)).toEqual(['1::#rec', '1::#pin']);
+  });
+
+  it('keeps a recently-visited buffer above unread (recency wins)', () => {
+    const rows = [item('1::#unr', { unread: 9 }), item('1::#rec')];
+    const out = smartSortRows(rows, { recencyRank: ranker('1::#rec') });
+    expect(keys(out)).toEqual(['1::#rec', '1::#unr']);
+  });
+});
+
+describe('smartSortRows recent tier', () => {
+  it('sorts the recent tier most-recently-visited first', () => {
+    const rows = [item('1::#a'), item('1::#b'), item('1::#c')];
+    // Visited order (most recent first): c, a, b.
+    const out = smartSortRows(rows, { recencyRank: ranker('1::#c', '1::#a', '1::#b') });
+    expect(keys(out)).toEqual(['1::#c', '1::#a', '1::#b']);
+  });
+});
+
+describe('smartSortRows pinned tier', () => {
+  it('alphabetises unvisited pins (the favourites shelf below recents)', () => {
+    const rows = [
+      item('1::#zeta', { pinned: true }),
+      item('1::#alpha', { pinned: true }),
+      item('1::#mu', { pinned: true }),
+    ];
+    const out = smartSortRows(rows, { recencyRank: ranker() }); // none visited
+    expect(keys(out)).toEqual(['1::#alpha', '1::#mu', '1::#zeta']);
+  });
+});
+
+describe('smartSortRows unread tier', () => {
+  it('sorts by unread count descending, then alphabetically', () => {
+    const rows = [
+      item('1::#m', { unread: 5 }),
+      item('1::#k', { unread: 5 }),
+      item('1::#c', { unread: 2 }),
+    ];
+    const out = smartSortRows(rows, { recencyRank: ranker() });
+    expect(keys(out)).toEqual(['1::#k', '1::#m', '1::#c']); // 5s tie-broken alpha, then 2
+  });
+});
+
+describe('smartSortRows alphabetical tier', () => {
+  it('alphabetises by the normalised sort key (sigil-stripped, case-folded)', () => {
+    const rows = [item('1::#Beta'), item('1::alpha'), item('1::#Gamma')];
+    const out = smartSortRows(rows, { recencyRank: ranker() });
+    expect(keys(out)).toEqual(['1::alpha', '1::#Beta', '1::#Gamma']);
+  });
+});

--- a/vue_client/src/utils/switcherSort.ts
+++ b/vue_client/src/utils/switcherSort.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Tiered "smart sort" for the quick switcher (#393), applied AFTER the user's
+// query narrows the list: recent → pinned → unread → alphabetical. A switcher's
+// job is fast movement, so recency leads (the way VS Code's Ctrl+Tab / Cmd+P,
+// Slack's Cmd+K, and browser address bars all rank) — not pins. Buffers visited
+// this session sort by recency at the top; pins you *haven't* touched this
+// session form a "favourites" shelf below that; then unread; then the rest
+// alphabetically. Each buffer lands in exactly the highest tier it qualifies
+// for. Pure (no Vue/store deps) so the tier precedence and tie-breaks stay
+// unit-testable; the component supplies recency (from stores/recentBuffers) and
+// pin state, and excludes the active buffer before calling in (you never switch
+// to where you already are).
+
+export interface SwitcherItem {
+  // `${networkId}::${target}` — both the row identity and the recency lookup key.
+  key: string;
+  pinned: boolean;
+  unread: number;
+  // Pre-normalised label for the alphabetical tie-break (leading '#' stripped,
+  // lowercased) — see bufferSortKey.
+  sortKey: string;
+}
+
+export interface SmartSortOptions {
+  // recencyRank(key): 0 = most recent … Infinity = unvisited this session.
+  recencyRank: (key: string) => number;
+}
+
+const TIER_RECENT = 0;
+const TIER_PINNED = 1;
+const TIER_UNREAD = 2;
+const TIER_ALPHA = 3;
+
+export function smartSortRows<T extends SwitcherItem>(rows: T[], opts: SmartSortOptions): T[] {
+  const { recencyRank } = opts;
+
+  const tierOf = (r: T): number => {
+    if (recencyRank(r.key) !== Infinity) return TIER_RECENT;
+    if (r.pinned) return TIER_PINNED;
+    if (r.unread > 0) return TIER_UNREAD;
+    return TIER_ALPHA;
+  };
+
+  return rows.toSorted((a, b) => {
+    const ta = tierOf(a);
+    const tb = tierOf(b);
+    if (ta !== tb) return ta - tb;
+    // Recent tier: most-recently-visited first (both ranks finite here).
+    if (ta === TIER_RECENT) return recencyRank(a.key) - recencyRank(b.key);
+    // Unread tier: most unread first, then alphabetical.
+    if (ta === TIER_UNREAD && a.unread !== b.unread) return b.unread - a.unread;
+    // Pinned and alphabetical tiers (and unread ties) fall back to alphabetical.
+    return a.sortKey.localeCompare(b.sortKey);
+  });
+}


### PR DESCRIPTION
Closes #393.

Re-ranks the `Cmd/Ctrl+K` quick switcher with a tiered smart sort applied **after** filtering, so a search no longer flattens everything back to plain alphabetical.

### Tier order: Recent → Pinned → Unread → Alphabetical
Recency leads — the way VS Code's `Ctrl+Tab`/`Cmd+P`, Slack's `Cmd+K`, and browser address bars rank. The issue originally described pinned-first; we landed on recency-first after discussion, because a switcher's job is fast movement and forcing all pins above your recent working set buries your actual back-and-forth target. Pins become a "favourites you haven't touched this session" shelf below recents. Each buffer lands in the highest tier it qualifies for; recency wins ties.

### Default view is an alt-tab toggle
With no query, the **active buffer is dropped** from the list, so your *previous* buffer sits at row 0 and is pre-selected → `Cmd+K → Enter` jumps back. Typing a query switches to search mode and keeps everything matchable (you can still find the current buffer by name).

### Mouse-clobber fix
Hover-to-select now reacts only to **real pointer movement** (`@mousemove` + a coordinate-change guard). The synthetic hover events that fire when the list paints under a stationary cursor (on open) or scrolls under it (arrow-key nav) carry identical `clientX/clientY`, so they're ignored — the keyboard selection holds until you actually move the mouse. This was the bug behind "the selected default is the buffer I'm already on."

### Implementation
- **`utils/recentBuffers.ts`** (new) — pure move-to-front MRU mechanics (deduped, capped at 50), a cousin of #309's `navHistory` cursor stack. Both hang off the single `networks.activeKey` watcher in `useKeyboardShortcuts`; the MRU records *every* activation (back/forward hops included) where navHistory ignores its own.
- **`stores/recentBuffers.ts`** (new) — thin Pinia wrapper; `$reset` wired into `useSessionReset`.
- **`utils/switcherSort.ts`** (new) — the pure tiered `smartSortRows()`, decoupled from UI fields.
- **`QuickSwitcher.vue`** — consumes both; active-buffer exclusion + mouse fix.
- **`bufferOrder.ts`** — exports `bufferSortKey` so the alphabetical tier folds case identically to the sidebar.

### Tests
- `utils/recentBuffers.test.ts` + `utils/switcherSort.test.ts` cover MRU move-to-front/dedupe/cap/rank and tier precedence/tie-breaks (+15 tests).
- Full suite green (1589), client typecheck + lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)