### PR TITLE
Add allowScripts allowlist for native/build install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cp .env.example .env   # defaults assume the local hostname documented in the fi
 npm run dev
 ```
 
-> **Note on install scripts.** A few dependencies build native code or fetch a platform binary at install time (`better-sqlite3`, `sharp`, `esbuild`, `workerd`). These are pre-approved in each `package.json`'s `allowScripts` allowlist, so npm runs them without prompting. On npm versions older than 11.16 the `allowScripts` field is simply ignored. `core-js` is intentionally denied — its only install script prints a funding message.
+> **Note on install scripts.** A few dependencies build native code or fetch a platform binary at install time — `better-sqlite3` (root), `esbuild` (root and `docs/`), and `sharp`/`workerd` (`docs/`). Each is pre-approved in that workspace's `allowScripts` allowlist, so npm runs them without prompting; `core-js` is intentionally denied — its only install script prints a funding message. The `vue_client` workspace has no install-script dependencies, so it has no allowlist. The `allowScripts` field is ignored by npm older than 11.16.
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cp .env.example .env   # defaults assume the local hostname documented in the fi
 npm run dev
 ```
 
+> **Note on install scripts.** A few dependencies build native code or fetch a platform binary at install time (`better-sqlite3`, `sharp`, `esbuild`, `workerd`). These are pre-approved in each `package.json`'s `allowScripts` allowlist, so npm runs them without prompting. On npm versions older than 11.16 the `allowScripts` field is simply ignored. `core-js` is intentionally denied — its only install script prints a funding message.
+
 # Documentation
 
 - **[Self-hosting guide](docs/SELF_HOSTING.md)** — reverse proxy + HTTPS, passkeys, web push, updating, backups, and troubleshooting.

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,5 +16,10 @@
   "devDependencies": {
     "vitepress": "^2.0.0-alpha.17",
     "wrangler": "^4.20.0"
+  },
+  "allowScripts": {
+    "esbuild": true,
+    "sharp": true,
+    "workerd": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,5 +71,10 @@
     "supertest": "^7.2.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"
+  },
+  "allowScripts": {
+    "better-sqlite3": true,
+    "esbuild": true,
+    "core-js": false
   }
 }


### PR DESCRIPTION
## What

Adds an `allowScripts` allowlist to the root and `docs` `package.json` so the dependencies that legitimately run install/postinstall scripts are pre-approved.

| Workspace | Allowed (`true`) | Denied (`false`) | Why |
|---|---|---|---|
| root | `better-sqlite3`, `esbuild` | `core-js` | better-sqlite3 compiles the native SQLite binding (`node-gyp rebuild`); esbuild fetches its platform binary. core-js's only install script prints a funding/ads message — not needed. |
| `docs` | `esbuild`, `sharp`, `workerd` | — | VitePress build tooling + `wrangler`'s Cloudflare Workers runtime for deploy. |
| `vue_client` | — | — | No dependencies with install scripts. |

## Why

npm **11.16+** added an `allowScripts` field (managed by `npm approve-scripts` / `npm deny-scripts`) that records which dependencies may run lifecycle install scripts. It's **advisory today** — `npm run install:all` just prints a list of "packages whose install scripts are not yet covered by allowScripts" — but **npm v12 will block** unreviewed scripts. Pre-approving the known-good ones:

- silences the warning contributors are already hitting on newer npm, and
- keeps the install working unbroken once v12 (or a blocking CI policy) lands.

Doubles as supply-chain documentation: an explicit, reviewed list of which deps are allowed to execute code at install time.

## Notes

- Entries are **name-only** (no `#version` pin) so routine dependency bumps don't re-trigger the unreviewed-scripts warning. `npm approve-scripts` pins by default; we deliberately don't.
- The field is **ignored by npm < 11.16**, so this is a no-op for anyone on older npm.
- No code changes; `format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)