### PR TITLE
DCC/XDCC download manager — phase 2 (transfers API + Transfers UI + /dcc)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -22,6 +22,7 @@ import bookmarksRouter from './routes/bookmarks.js';
 import pushRouter from './routes/push.js';
 import adminRouter from './routes/admin.js';
 import uploadsRouter from './routes/uploads.js';
+import dccRouter from './routes/dcc.js';
 import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
@@ -60,6 +61,7 @@ export function buildApp(sessionSecret: string): Express {
   app.use('/api/push', pushRouter);
   app.use('/api/admin', adminRouter);
   app.use('/api/uploads', uploadsRouter);
+  app.use('/api/dcc', dccRouter);
   app.use('/api/drafts', draftsRouter);
   app.use('/api/exports', exportsRouter);
   app.use('/api/imports', importRouter);

--- a/server/db/dccTransfers.ts
+++ b/server/db/dccTransfers.ts
@@ -32,6 +32,19 @@ export type DccTransferState =
   | 'rejected'
   | 'cancelled';
 
+// States a transfer can still leave — i.e. NOT terminal. Used to gate the
+// cancel/reject actions so they never clobber a finished row (completed /
+// failed / rejected / cancelled): a one-shot transfer never legitimately
+// re-enters an active state, so a late action on a terminal row is a no-op.
+export const DCC_ACTIVE_STATES: ReadonlySet<DccTransferState> = new Set([
+  'requested',
+  'pending_approval',
+  'connecting',
+  'receiving',
+  'stalled',
+  'verifying',
+]);
+
 export interface DccTransferRow {
   id: number;
   user_id: number;

--- a/server/db/dccTransfers.ts
+++ b/server/db/dccTransfers.ts
@@ -45,6 +45,8 @@ export interface DccTransferRow {
   state: DccTransferState;
   passive: number;
   token: number | null;
+  peer_host: string | null;
+  peer_port: number | null;
   trigger_text: string | null;
   crc_expected: string | null;
   crc_actual: string | null;
@@ -63,6 +65,10 @@ export interface InsertDccTransferFields {
   state: DccTransferState;
   passive?: boolean;
   token?: number | null;
+  /** The offer's decoded address + port, persisted so a pending_approval offer
+   *  can be accepted (dialed) later. */
+  peer_host?: string | null;
+  peer_port?: number | null;
   /** The XDCC trigger we sent, kept so a stalled transfer can be re-requested on
    *  manual resume. Null for an unsolicited offer. */
   trigger_text?: string | null;
@@ -73,8 +79,8 @@ export interface InsertDccTransferFields {
 const insertStmt = db.prepare(`
   INSERT INTO dcc_transfers
     (user_id, network_id, peer_nick, filename, advertised_size, state,
-     passive, token, trigger_text, crc_expected)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     passive, token, peer_host, peer_port, trigger_text, crc_expected)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 export function insertDccTransfer(userId: number, f: InsertDccTransferFields): number {
@@ -87,6 +93,8 @@ export function insertDccTransfer(userId: number, f: InsertDccTransferFields): n
     f.state,
     f.passive ? 1 : 0,
     f.token ?? null,
+    f.peer_host ?? null,
+    f.peer_port ?? null,
     f.trigger_text ?? null,
     f.crc_expected ?? null,
   );

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -339,6 +339,8 @@ function migrate() {
       state TEXT NOT NULL,
       passive INTEGER NOT NULL DEFAULT 0,
       token INTEGER,
+      peer_host TEXT,
+      peer_port INTEGER,
       trigger_text TEXT,
       crc_expected TEXT,
       crc_actual TEXT,
@@ -878,6 +880,12 @@ ensureColumn('upload_history', 'synced_to_cp', 'INTEGER NOT NULL DEFAULT 0');
 // (so the owner sees a "removed by moderation" tombstone instead of a dead
 // image), but the bytes are gone from storage. Standalone never sets it.
 ensureColumn('upload_history', 'removed', 'INTEGER NOT NULL DEFAULT 0');
+
+// The offer's address/port, persisted so an unsolicited DCC SEND recorded as
+// pending_approval can be accepted later (the user clicks Accept seconds/minutes
+// after the bot offered). #270 phase 2.
+ensureColumn('dcc_transfers', 'peer_host', 'TEXT');
+ensureColumn('dcc_transfers', 'peer_port', 'INTEGER');
 
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new

--- a/server/routes/dcc.ts
+++ b/server/routes/dcc.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// DCC download-manager API (#270 phase 2). Lists the user's transfers and acts on
+// them (accept a pending offer, reject it, cancel an in-flight one). The list is
+// the Transfers view's initial load; live updates arrive over the WS as
+// `dcc-transfer` frames. All routes are user-scoped via requireAuth.
+
+import { Router, type Request, type Response } from 'express';
+
+import { requireAuth, blockWritesWhenPaused } from '../middleware/auth.js';
+import ircManager from '../services/ircManager.js';
+import { getDccTransfer, listDccTransfers } from '../db/dccTransfers.js';
+
+const router = Router();
+router.use(requireAuth);
+
+/** GET /api/dcc — the user's transfers, newest first. */
+router.get('/', (req: Request, res: Response) => {
+  const limit = req.query.limit ? Number(req.query.limit) : 100;
+  res.json({ transfers: listDccTransfers(req.user!.id, { limit }) });
+});
+
+// Acting on a transfer is a write — blocked for paused accounts (the list isn't).
+router.use(blockWritesWhenPaused);
+
+/** POST /api/dcc/:id/accept — accept a pending offer and start the download. */
+router.post('/:id/accept', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  const result = ircManager.acceptDccTransfer(req.user!.id, id);
+  if (result === 'not-found') {
+    res.status(404).json({ error: 'transfer not found' });
+    return;
+  }
+  if (result === 'not-connected') {
+    res.status(409).json({ error: 'network not connected' });
+    return;
+  }
+  res.json({ transfer: getDccTransfer(req.user!.id, id) });
+});
+
+/** POST /api/dcc/:id/reject — reject a pending offer (no download). */
+router.post('/:id/reject', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!ircManager.rejectDccTransfer(req.user!.id, id)) {
+    res.status(404).json({ error: 'transfer not found' });
+    return;
+  }
+  res.json({ transfer: getDccTransfer(req.user!.id, id) });
+});
+
+/** POST /api/dcc/:id/cancel — cancel an in-flight or still-pending transfer. */
+router.post('/:id/cancel', (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+  if (!ircManager.cancelDccTransfer(req.user!.id, id)) {
+    res.status(404).json({ error: 'transfer not found' });
+    return;
+  }
+  res.json({ transfer: getDccTransfer(req.user!.id, id) });
+});
+
+export default router;

--- a/server/routes/dcc.ts
+++ b/server/routes/dcc.ts
@@ -57,6 +57,10 @@ router.post('/:id/accept', (req: Request, res: Response) => {
     res.status(404).json({ error: 'transfer not found' });
     return;
   }
+  if (result === 'not-pending') {
+    res.status(409).json({ error: 'transfer is not awaiting approval' });
+    return;
+  }
   if (result === 'not-connected') {
     res.status(409).json({ error: 'network not connected' });
     return;

--- a/server/routes/dcc.ts
+++ b/server/routes/dcc.ts
@@ -10,10 +10,31 @@ import { Router, type Request, type Response } from 'express';
 
 import { requireAuth, blockWritesWhenPaused } from '../middleware/auth.js';
 import ircManager from '../services/ircManager.js';
+import { dccEnabledForUser } from '../services/dccConfig.js';
 import { getDccTransfer, listDccTransfers } from '../db/dccTransfers.js';
 
 const router = Router();
 router.use(requireAuth);
+
+// The two-tier DCC gate (cell master switch AND per-user capability) guards
+// every DCC entry point — the inbound-CTCP path checks it, so the API must too,
+// or a stale pending_approval row could be accepted after a grant is revoked.
+// Gating reads as well as writes keeps the whole surface dark when DCC is off
+// (and gives the /dcc command + Transfers modal a clear "not enabled" error).
+router.use((req: Request, res: Response, next) => {
+  if (!dccEnabledForUser(req.user!.id)) {
+    res.status(403).json({ error: 'DCC is not enabled for this account' });
+    return;
+  }
+  next();
+});
+
+// A transfer id is a positive integer row id; reject anything else up front so a
+// non-numeric :id can't reach better-sqlite3 as NaN (which throws → 500).
+function transferId(req: Request): number | null {
+  const id = Number(req.params.id);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
 
 /** GET /api/dcc — the user's transfers, newest first. */
 router.get('/', (req: Request, res: Response) => {
@@ -26,7 +47,11 @@ router.use(blockWritesWhenPaused);
 
 /** POST /api/dcc/:id/accept — accept a pending offer and start the download. */
 router.post('/:id/accept', (req: Request, res: Response) => {
-  const id = Number(req.params.id);
+  const id = transferId(req);
+  if (id == null) {
+    res.status(404).json({ error: 'transfer not found' });
+    return;
+  }
   const result = ircManager.acceptDccTransfer(req.user!.id, id);
   if (result === 'not-found') {
     res.status(404).json({ error: 'transfer not found' });
@@ -41,8 +66,8 @@ router.post('/:id/accept', (req: Request, res: Response) => {
 
 /** POST /api/dcc/:id/reject — reject a pending offer (no download). */
 router.post('/:id/reject', (req: Request, res: Response) => {
-  const id = Number(req.params.id);
-  if (!ircManager.rejectDccTransfer(req.user!.id, id)) {
+  const id = transferId(req);
+  if (id == null || !ircManager.rejectDccTransfer(req.user!.id, id)) {
     res.status(404).json({ error: 'transfer not found' });
     return;
   }
@@ -51,8 +76,8 @@ router.post('/:id/reject', (req: Request, res: Response) => {
 
 /** POST /api/dcc/:id/cancel — cancel an in-flight or still-pending transfer. */
 router.post('/:id/cancel', (req: Request, res: Response) => {
-  const id = Number(req.params.id);
-  if (!ircManager.cancelDccTransfer(req.user!.id, id)) {
+  const id = transferId(req);
+  if (id == null || !ircManager.cancelDccTransfer(req.user!.id, id)) {
     res.status(404).json({ error: 'transfer not found' });
     return;
   }

--- a/server/services/dccWiring.test.ts
+++ b/server/services/dccWiring.test.ts
@@ -450,3 +450,62 @@ describe('arm-on-trigger + auto-accept', () => {
     expect(row.crc_status).toBe('mismatch');
   });
 });
+
+describe('pending-offer actions (phase 2)', () => {
+  it('records an unsolicited offer with its host/port and accepts it on demand', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-dcc-accept-'));
+    process.env.LURKER_DCC_DIR = tmpDir;
+    process.env.LURKER_DCC_ALLOW_PRIVATE_HOSTS = '1';
+    enableDcc();
+    const payload = makePayload(15_000);
+    const sender = await startSender(payload);
+    activeSender = sender;
+
+    const { conn } = harness();
+    // Unsolicited (no arming) → recorded as pending_approval with its host/port.
+    conn.client.emit('ctcp request', {
+      nick: 'bot',
+      type: 'DCC',
+      message: `DCC SEND show.mkv 2130706433 ${sender.port} ${payload.length}`,
+    });
+    const pending = listDccTransfers(1)[0];
+    expect(pending.state).toBe('pending_approval');
+    expect(pending.peer_host).toBe('127.0.0.1');
+    expect(pending.peer_port).toBe(sender.port);
+
+    // Accept it later → starts the download from the stored offer.
+    conn.acceptPendingDcc(pending);
+    await waitFor(() => listDccTransfers(1)[0]?.state === 'completed', 5000);
+    const row = listDccTransfers(1)[0];
+    expect(row.received_bytes).toBe(payload.length);
+    expect(fs.readFileSync(path.join(tmpDir, 'dcc-wire-alice', 'show.mkv')).equals(payload)).toBe(
+      true,
+    );
+  });
+
+  it('rejects a pending offer', () => {
+    enableDcc();
+    const { conn } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bot',
+      type: 'DCC',
+      message: 'DCC SEND f.bin 16843009 5000 100',
+    });
+    const id = listDccTransfers(1)[0].id;
+    conn.rejectDcc(id);
+    expect(listDccTransfers(1)[0].state).toBe('rejected');
+  });
+
+  it('cancels a still-pending offer', () => {
+    enableDcc();
+    const { conn } = harness();
+    conn.client.emit('ctcp request', {
+      nick: 'bot',
+      type: 'DCC',
+      message: 'DCC SEND f.bin 16843009 5000 100',
+    });
+    const id = listDccTransfers(1)[0].id;
+    conn.cancelDcc(id);
+    expect(listDccTransfers(1)[0].state).toBe('cancelled');
+  });
+});

--- a/server/services/dccWiring.test.ts
+++ b/server/services/dccWiring.test.ts
@@ -508,4 +508,98 @@ describe('pending-offer actions (phase 2)', () => {
     conn.cancelDcc(id);
     expect(listDccTransfers(1)[0].state).toBe('cancelled');
   });
+
+  it('reject/cancel do not clobber a terminal (completed) transfer', () => {
+    enableDcc();
+    const { conn } = harness();
+    const id = insertDccTransfer(1, {
+      network_id: 1,
+      peer_nick: 'bot',
+      filename: 'done.bin',
+      advertised_size: 100,
+      state: 'requested',
+    });
+    updateDccTransferState(id, 'completed');
+    conn.rejectDcc(id);
+    expect(listDccTransfers(1)[0].state).toBe('completed');
+    conn.cancelDcc(id);
+    expect(listDccTransfers(1)[0].state).toBe('completed');
+  });
+
+  it('accepting a pending offer with no stored address fails it visibly', () => {
+    enableDcc();
+    const { conn } = harness();
+    // A pending row whose peer_host/peer_port were never decoded (e.g. predates
+    // the columns) — can't be dialed, so Accept must fail it, not silently no-op.
+    const id = insertDccTransfer(1, {
+      network_id: 1,
+      peer_nick: 'bot',
+      filename: 'noaddr.bin',
+      advertised_size: 100,
+      state: 'pending_approval',
+    });
+    const row = listDccTransfers(1)[0];
+    expect(row.peer_host).toBeNull();
+    conn.acceptPendingDcc(row);
+    const after = listDccTransfers(1)[0];
+    expect(after.state).toBe('failed');
+    expect(after.error).toMatch(/address/i);
+  });
+
+  it('cancelling during the resume wait clears the timeout (no late failure)', () => {
+    vi.useFakeTimers();
+    try {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-dcc-cancel-resume-'));
+      process.env.LURKER_DCC_DIR = tmpDir;
+      process.env.LURKER_DCC_ALLOW_PRIVATE_HOSTS = '1';
+      enableDcc();
+
+      const full = makePayload(30_000);
+      const have = 10_000;
+      // Pre-seed a partial + a tracked prior incomplete row so the offer takes the
+      // RESUME branch (which arms a 15s timer and waits for the bot's DCC ACCEPT,
+      // starting NO receiver yet).
+      const userDir = path.join(tmpDir, 'dcc-wire-alice');
+      fs.mkdirSync(userDir, { recursive: true });
+      const partialPath = path.join(userDir, 'show.mkv');
+      fs.writeFileSync(partialPath, full.subarray(0, have));
+      const priorId = insertDccTransfer(1, {
+        network_id: 1,
+        peer_nick: 'bot',
+        filename: 'show.mkv',
+        advertised_size: full.length,
+        state: 'requested',
+      });
+      markDccReceiving(priorId, {
+        filename: 'show.mkv',
+        advertised_size: full.length,
+        destination_path: partialPath,
+        received_bytes: have,
+      });
+      updateDccTransferState(priorId, 'failed', 'interrupted');
+
+      const { conn } = harness();
+      conn.client.say = vi.fn<(target: string, text: string) => void>();
+      conn.client.ctcpRequest = vi.fn<(target: string, type: string, ...p: string[]) => void>();
+
+      conn.say('bot', 'xdcc send #1'); // arm a fresh requested row
+      conn.client.emit('ctcp request', {
+        nick: 'bot',
+        type: 'DCC',
+        message: `DCC SEND show.mkv 16843009 9999 ${full.length}`, // public host, resume branch
+      });
+      const armed = listDccTransfers(1).find((r) => r.id !== priorId)!;
+      expect(armed.state).toBe('receiving'); // RESUME requested, awaiting ACCEPT
+
+      conn.cancelDcc(armed.id);
+      expect(listDccTransfers(1).find((r) => r.id === armed.id)!.state).toBe('cancelled');
+
+      // The 15s resume timeout must have been cleared by the cancel — advancing
+      // past it must NOT overwrite 'cancelled' with 'failed'.
+      vi.advanceTimersByTime(20_000);
+      expect(listDccTransfers(1).find((r) => r.id === armed.id)!.state).toBe('cancelled');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/server/services/dccWiring.test.ts
+++ b/server/services/dccWiring.test.ts
@@ -531,7 +531,7 @@ describe('pending-offer actions (phase 2)', () => {
     const { conn } = harness();
     // A pending row whose peer_host/peer_port were never decoded (e.g. predates
     // the columns) — can't be dialed, so Accept must fail it, not silently no-op.
-    const id = insertDccTransfer(1, {
+    insertDccTransfer(1, {
       network_id: 1,
       peer_nick: 'bot',
       filename: 'noaddr.bin',

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -59,8 +59,10 @@ import { dccAllowPrivateHosts, dccEnabledForUser, dccMaxFileBytes } from './dccC
 import { hasFreeSpaceFor, resolveDccDestination } from './dccPaths.js';
 import { DccReceiver } from './dccReceiver.js';
 import {
+  type DccTransferRow,
   findArmedRequest,
   findResumableTransfer,
+  getDccTransfer,
   insertDccTransfer,
   markDccCompleted,
   markDccFailed,
@@ -2640,8 +2642,9 @@ export class IrcConnection {
       this.acceptDccOffer(armed.id, nick, offer);
       return;
     }
-    // Unsolicited: nothing auto-lands. Record for the Accept/Reject UI (phase 2).
-    insertDccTransfer(this.network.user_id, {
+    // Unsolicited: nothing auto-lands. Record for the Accept/Reject UI, keeping
+    // the offer's host/port so the user can accept (dial it) later.
+    const id = insertDccTransfer(this.network.user_id, {
       network_id: this.network.id,
       peer_nick: nick,
       filename: offer.filename,
@@ -2649,8 +2652,11 @@ export class IrcConnection {
       state: 'pending_approval',
       passive: offer.passive,
       token: offer.token,
+      peer_host: offer.host,
+      peer_port: offer.port,
     });
     this.routeCtcpStatus(event, formatDccOfferLine(nick, offer));
+    this.publishDcc(id);
   }
 
   // Accept an armed offer and stream it to disk via the receive engine. Active
@@ -2735,6 +2741,7 @@ export class IrcConnection {
       crc_expected: expectedCrc,
       received_bytes: startOffset,
     });
+    this.publishDcc(transferId);
     if (startOffset > 0) {
       // A partial exists — ask the bot to resume from there and wait for its
       // DCC ACCEPT before connecting (handleDccAccept starts the receiver).
@@ -2779,6 +2786,7 @@ export class IrcConnection {
       this.dccPendingResume.delete(key);
       markDccFailed(transferId, startOffset, 'resume not accepted by sender');
       this.surfaceCtcp(nick, `DCC: "${offer.filename}" — sender did not accept resume`);
+      this.publishDcc(transferId);
     }, 15_000);
     this.dccPendingResume.set(key, { transferId, nick, offer, destPath, startOffset, timer });
     // Mirror the offer's filename quoting so the bot matches it.
@@ -2845,6 +2853,7 @@ export class IrcConnection {
         if (now - lastDbAt >= 3000) {
           lastDbAt = now;
           updateDccReceivedBytes(transferId, received);
+          this.publishDcc(transferId); // live progress to the Transfers view
         }
         if (offer.size > 0 && now - lastLineAt >= 8000) {
           lastLineAt = now;
@@ -2880,15 +2889,75 @@ export class IrcConnection {
           nick,
           `DCC: completed "${offer.filename}" (${formatBytes(received)}) → ${destPath}${badge}`,
         );
+        this.publishDcc(transferId);
       },
       onError: (err, received) => {
         this.dccReceivers.delete(transferId);
-        markDccFailed(transferId, received, err.message);
-        this.surfaceCtcp(nick, `DCC: failed "${offer.filename}" — ${err.message}`);
+        // A user-initiated cancel surfaces as a distinct 'cancelled' state, not a
+        // failure (cancel() settles with this exact message).
+        if (err.message === 'cancelled') {
+          updateDccTransferState(transferId, 'cancelled');
+          this.surfaceCtcp(nick, `DCC: cancelled "${offer.filename}"`);
+        } else {
+          markDccFailed(transferId, received, err.message);
+          this.surfaceCtcp(nick, `DCC: failed "${offer.filename}" — ${err.message}`);
+        }
+        this.publishDcc(transferId);
       },
     });
     this.dccReceivers.set(transferId, receiver);
     receiver.start();
+  }
+
+  // Push a transfer row to ALL the user's clients (user-scoped, not buffer-scoped)
+  // so the Transfers view updates live. wsHub forwards a type:'dcc-transfer' event
+  // as a { kind: 'dcc-transfer' } frame (#270 phase 2).
+  private publishDcc(transferId: number): void {
+    if (this.disposed) return;
+    const transfer = getDccTransfer(this.network.user_id, transferId);
+    if (!transfer) return;
+    this.onEvent({
+      type: 'dcc-transfer',
+      userId: this.network.user_id,
+      networkId: this.network.id,
+      time: new Date().toISOString(),
+      transfer,
+    } as unknown as EnrichedEvent);
+  }
+
+  // Accept a previously-recorded unsolicited offer (pending_approval): rebuild the
+  // offer from the stored row and run the normal accept path. The offer may be
+  // stale (the bot stopped listening) — that surfaces as a connect failure.
+  acceptPendingDcc(row: DccTransferRow): void {
+    if (this.disposed) return;
+    if (row.state !== 'pending_approval' || row.peer_host == null || row.peer_port == null) return;
+    this.acceptDccOffer(row.id, row.peer_nick, {
+      kind: 'send',
+      filename: row.filename,
+      host: row.peer_host,
+      port: row.peer_port,
+      size: row.advertised_size,
+      token: row.token,
+      passive: row.passive === 1,
+    });
+  }
+
+  // Reject a pending offer (no download). The row stays as a tombstone.
+  rejectDcc(transferId: number): void {
+    updateDccTransferState(transferId, 'rejected');
+    this.publishDcc(transferId);
+  }
+
+  // Cancel a transfer: abort the live receiver if one is running (its onError
+  // marks 'cancelled'), otherwise flip a pending/requested row to 'cancelled'.
+  cancelDcc(transferId: number): void {
+    const receiver = this.dccReceivers.get(transferId);
+    if (receiver) {
+      receiver.cancel();
+      return; // onError → 'cancelled' + publishDcc
+    }
+    updateDccTransferState(transferId, 'cancelled');
+    this.publishDcc(transferId);
   }
 
   // Surface an inbound CTCP reply (a peer answered a query we sent), routed back

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -60,6 +60,7 @@ import { hasFreeSpaceFor, resolveDccDestination } from './dccPaths.js';
 import { DccReceiver } from './dccReceiver.js';
 import {
   type DccTransferRow,
+  DCC_ACTIVE_STATES,
   findArmedRequest,
   findResumableTransfer,
   getDccTransfer,
@@ -2930,7 +2931,18 @@ export class IrcConnection {
   // stale (the bot stopped listening) — that surfaces as a connect failure.
   acceptPendingDcc(row: DccTransferRow): void {
     if (this.disposed) return;
-    if (row.state !== 'pending_approval' || row.peer_host == null || row.peer_port == null) return;
+    // Only an unsolicited offer still awaiting a decision can be accepted; a row
+    // that already moved on (receiving/terminal) is a no-op.
+    if (row.state !== 'pending_approval') return;
+    // A pending row recorded before the peer_host/peer_port columns existed (or
+    // whose address didn't decode) can't be dialed. Fail it VISIBLY rather than
+    // silently no-op — otherwise the API returns 200 and the UI shows the Accept
+    // doing nothing, with the row stuck pending forever.
+    if (row.peer_host == null || row.peer_port == null) {
+      updateDccTransferState(row.id, 'failed', 'offer is missing its address — cannot reconnect');
+      this.publishDcc(row.id);
+      return;
+    }
     this.acceptDccOffer(row.id, row.peer_nick, {
       kind: 'send',
       filename: row.filename,
@@ -2942,22 +2954,44 @@ export class IrcConnection {
     });
   }
 
-  // Reject a pending offer (no download). The row stays as a tombstone.
+  // Reject a pending offer (no download). Guarded to the offer states so a late
+  // /dcc reject can't clobber a row that already completed/failed/cancelled.
   rejectDcc(transferId: number): void {
+    const row = getDccTransfer(this.network.user_id, transferId);
+    if (!row || (row.state !== 'pending_approval' && row.state !== 'requested')) return;
     updateDccTransferState(transferId, 'rejected');
     this.publishDcc(transferId);
   }
 
   // Cancel a transfer: abort the live receiver if one is running (its onError
-  // marks 'cancelled'), otherwise flip a pending/requested row to 'cancelled'.
+  // marks 'cancelled'), otherwise flip a still-active row to 'cancelled'.
   cancelDcc(transferId: number): void {
     const receiver = this.dccReceivers.get(transferId);
     if (receiver) {
       receiver.cancel();
       return; // onError → 'cancelled' + publishDcc
     }
+    // No live receiver yet — but the transfer may be in the RESUME wait window
+    // (requestDccResume armed a timer and a pending entry, with the receiver only
+    // starting on the bot's DCC ACCEPT). Tear that down, or the timer would fire
+    // markDccFailed over our 'cancelled', or a late ACCEPT would start the
+    // download after the user cancelled it.
+    this.clearPendingResume(transferId);
+    const row = getDccTransfer(this.network.user_id, transferId);
+    if (!row || !DCC_ACTIVE_STATES.has(row.state)) return; // don't clobber a terminal row
     updateDccTransferState(transferId, 'cancelled');
     this.publishDcc(transferId);
+  }
+
+  // Drop any armed DCC RESUME wait for this transfer (clear its timeout + pending
+  // entry). The map is keyed by nick|filename, so find the entry by transferId.
+  private clearPendingResume(transferId: number): void {
+    for (const [key, pending] of this.dccPendingResume) {
+      if (pending.transferId !== transferId) continue;
+      clearTimeout(pending.timer);
+      this.dccPendingResume.delete(key);
+      return;
+    }
   }
 
   // Surface an inbound CTCP reply (a peer answered a query we sent), routed back

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -16,6 +16,8 @@ let systemLog: typeof import('./systemLog.js').default;
 let createUser: typeof import('../db/users.js').createUser;
 let setUserPaused: typeof import('../db/users.js').setUserPaused;
 let createNetwork: typeof import('../db/networks.js').createNetwork;
+let insertDccTransfer: typeof import('../db/dccTransfers.js').insertDccTransfer;
+let updateDccTransferState: typeof import('../db/dccTransfers.js').updateDccTransferState;
 
 beforeAll(async () => {
   ircManager = (await import('./ircManager.js')).default;
@@ -23,6 +25,7 @@ beforeAll(async () => {
   systemLog = (await import('./systemLog.js')).default;
   ({ createUser, setUserPaused } = await import('../db/users.js'));
   ({ createNetwork } = await import('../db/networks.js'));
+  ({ insertDccTransfer, updateDccTransferState } = await import('../db/dccTransfers.js'));
 });
 
 afterAll(() => ctx.cleanup());
@@ -60,6 +63,57 @@ describe('ircManager pause linchpin', () => {
 
     expect(ircManager.startNetwork(user.id, net.id)).toBeNull();
     expect(ircManager.getConnection(user.id, net.id)).toBeNull();
+  });
+});
+
+describe('ircManager.acceptDccTransfer result codes', () => {
+  let seq = 0;
+  function dccUserNet() {
+    const user = createUser(`dcc-accept-${(seq += 1)}`);
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.invalid',
+      port: 6697,
+      tls: true,
+      nick: 'x',
+      autoconnect: false,
+    });
+    if (!net) throw new Error('createNetwork returned undefined');
+    return { userId: user.id, networkId: net.id };
+  }
+
+  it('returns not-found for an unknown transfer id', () => {
+    const { userId } = dccUserNet();
+    expect(ircManager.acceptDccTransfer(userId, 999999)).toBe('not-found');
+  });
+
+  it('returns not-pending for a row that already left pending_approval', () => {
+    // Copilot review: accepting a non-pending row used to no-op yet report 200.
+    const { userId, networkId } = dccUserNet();
+    const id = insertDccTransfer(userId, {
+      network_id: networkId,
+      peer_nick: 'bot',
+      filename: 'done.bin',
+      advertised_size: 100,
+      state: 'pending_approval',
+    });
+    updateDccTransferState(id, 'completed');
+    expect(ircManager.acceptDccTransfer(userId, id)).toBe('not-pending');
+  });
+
+  it('returns not-connected for a genuine pending offer on a stopped network', () => {
+    const { userId, networkId } = dccUserNet();
+    const id = insertDccTransfer(userId, {
+      network_id: networkId,
+      peer_nick: 'bot',
+      filename: 'f.bin',
+      advertised_size: 100,
+      state: 'pending_approval',
+      peer_host: '203.0.113.7',
+      peer_port: 5000,
+    });
+    // No live connection registered → can't dial.
+    expect(ircManager.acceptDccTransfer(userId, id)).toBe('not-connected');
   });
 });
 

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -283,9 +283,17 @@ class IrcManager extends EventEmitter {
   // connection for its network, and routes the action there (the connection holds
   // the live receiver + the WS push). Accept needs a live connection (it dials the
   // bot); reject/cancel fall back to a DB-only state flip when disconnected.
-  acceptDccTransfer(userId: number, transferId: number): 'ok' | 'not-found' | 'not-connected' {
+  acceptDccTransfer(
+    userId: number,
+    transferId: number,
+  ): 'ok' | 'not-found' | 'not-connected' | 'not-pending' {
     const row = getDccTransfer(userId, transferId);
     if (!row) return 'not-found';
+    // Only an unsolicited offer still awaiting a decision can be accepted. A row
+    // that already moved on (receiving/completed/…) would be a silent no-op in
+    // acceptPendingDcc, so reject it here and let the route surface a 409 rather
+    // than a misleading 200 that looks successful to a stale client.
+    if (row.state !== 'pending_approval') return 'not-pending';
     const conn = this.getConnection(userId, row.network_id);
     if (!conn) return 'not-connected';
     conn.acceptPendingDcc(row);

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -13,7 +13,7 @@ import {
   deleteChannel,
 } from '../db/networks.js';
 import { reopenBuffer } from '../db/closedBuffers.js';
-import { getDccTransfer, updateDccTransferState } from '../db/dccTransfers.js';
+import { DCC_ACTIVE_STATES, getDccTransfer, updateDccTransferState } from '../db/dccTransfers.js';
 import { findUserById } from '../db/users.js';
 import { getUserAwayState, writeAwayMarker, writeBackMarker } from '../db/userAwayState.js';
 import { listPinnedForUser } from '../db/pinnedBuffers.js';
@@ -296,8 +296,11 @@ class IrcManager extends EventEmitter {
     const row = getDccTransfer(userId, transferId);
     if (!row) return false;
     const conn = this.getConnection(userId, row.network_id);
+    // The connected path applies its own state guard; the disconnected DB-only
+    // fallback must mirror it so a late reject can't clobber a terminal row.
     if (conn) conn.rejectDcc(transferId);
-    else updateDccTransferState(transferId, 'rejected');
+    else if (row.state === 'pending_approval' || row.state === 'requested')
+      updateDccTransferState(transferId, 'rejected');
     return true;
   }
 
@@ -306,7 +309,7 @@ class IrcManager extends EventEmitter {
     if (!row) return false;
     const conn = this.getConnection(userId, row.network_id);
     if (conn) conn.cancelDcc(transferId);
-    else updateDccTransferState(transferId, 'cancelled');
+    else if (DCC_ACTIVE_STATES.has(row.state)) updateDccTransferState(transferId, 'cancelled');
     return true;
   }
 

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -13,6 +13,7 @@ import {
   deleteChannel,
 } from '../db/networks.js';
 import { reopenBuffer } from '../db/closedBuffers.js';
+import { getDccTransfer, updateDccTransferState } from '../db/dccTransfers.js';
 import { findUserById } from '../db/users.js';
 import { getUserAwayState, writeAwayMarker, writeBackMarker } from '../db/userAwayState.js';
 import { listPinnedForUser } from '../db/pinnedBuffers.js';
@@ -276,6 +277,37 @@ class IrcManager extends EventEmitter {
 
   forgetChannel(userId: number, networkId: number, name: string): void {
     deleteChannel(networkId, name);
+  }
+
+  // DCC transfer actions (#270 phase 2). Each loads the user-scoped row, finds the
+  // connection for its network, and routes the action there (the connection holds
+  // the live receiver + the WS push). Accept needs a live connection (it dials the
+  // bot); reject/cancel fall back to a DB-only state flip when disconnected.
+  acceptDccTransfer(userId: number, transferId: number): 'ok' | 'not-found' | 'not-connected' {
+    const row = getDccTransfer(userId, transferId);
+    if (!row) return 'not-found';
+    const conn = this.getConnection(userId, row.network_id);
+    if (!conn) return 'not-connected';
+    conn.acceptPendingDcc(row);
+    return 'ok';
+  }
+
+  rejectDccTransfer(userId: number, transferId: number): boolean {
+    const row = getDccTransfer(userId, transferId);
+    if (!row) return false;
+    const conn = this.getConnection(userId, row.network_id);
+    if (conn) conn.rejectDcc(transferId);
+    else updateDccTransferState(transferId, 'rejected');
+    return true;
+  }
+
+  cancelDccTransfer(userId: number, transferId: number): boolean {
+    const row = getDccTransfer(userId, transferId);
+    if (!row) return false;
+    const conn = this.getConnection(userId, row.network_id);
+    if (conn) conn.cancelDcc(transferId);
+    else updateDccTransferState(transferId, 'cancelled');
+    return true;
   }
 
   // Long messages need to be split: irc-framework breaks anything past ~350

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1019,6 +1019,15 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // EnrichedEvent (from ircConnection) is a strict superset of MessageEvent.
     const event = rawEvent as MessageEvent & { userId: number; state?: string };
     const eventUserId = event.userId;
+    // DCC transfer updates (#270 phase 2) are user-scoped, not buffer messages —
+    // fan them out as their own frame, skipping message decoration/buffer logic.
+    if ((event as { type?: string }).type === 'dcc-transfer') {
+      fanOut(eventUserId, {
+        kind: 'dcc-transfer',
+        transfer: (event as unknown as { transfer: unknown }).transfer,
+      });
+      return;
+    }
     const decorated = decorateMessage(eventUserId, event);
     const target = decorated.target;
     if (

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -138,6 +138,7 @@ import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { parseNetworkCommand } from '../lib/commands/network.js';
 import { splitSetArgs, coerceSettingValue, formatSettingValue } from '../lib/commands/settings.js';
 import { parseRelayCommand } from '../lib/commands/relay.js';
+import { parseDccCommand } from '../lib/commands/dcc.js';
 import { formatColumns } from '../lib/commands/output.js';
 import { REGISTRY, getOption, optionVisible, CATEGORIES } from '../utils/settingsRegistry.js';
 import type { SettingOption } from '../../../shared/settingsRegistry.js';
@@ -148,6 +149,7 @@ import { useInputHistoryStore } from '../stores/inputHistory.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore, onInsertUrl } from '../stores/uploads.js';
+import { useDccStore, type DccTransfer } from '../stores/dcc.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
 import { useRelayBotsStore } from '../stores/relayBots.js';
@@ -208,6 +210,7 @@ const drafts = useDraftStore();
 const settings = useSettingsStore();
 const config = useConfigStore();
 const uploads = useUploadsStore();
+const dcc = useDccStore();
 const toasts = useToastsStore();
 const ignores = useIgnoresStore();
 const relayBots = useRelayBotsStore();
@@ -2049,6 +2052,8 @@ const COMMANDS_LINES = [
   "          [-autosendcmd '<cmds>'] [-channel <#chan>] [-auto|-noauto] <name>",
   '      modify <name> [-flags…]   ·   remove <name>   ·   move <name> <position>',
   '      connect <name>   ·   disconnect <name>   (Lurker folds irssi /server into these)',
+  '  /dcc [list]            — DCC downloads: list, or accept/reject/cancel <id>',
+  '      e.g. /dcc   ·   /dcc accept 3   ·   /dcc reject 3   ·   /dcc cancel 3',
   '  /set <key> <value…>    — change a setting; /set (or /set ?) lists all keys',
   '  /get <key>             — read a setting back (output in the system buffer)',
   '  /raw <line>            — send a raw IRC line (alias: /quote)',
@@ -2169,6 +2174,58 @@ function runRelay(argLine: string, networkId: number, target: string): boolean {
   relayBots.setRelay(networkId, cmd.nick, false);
   localInfo(networkId, target, `unmarked ${cmd.nick} as a relay bot.`);
   return true;
+}
+
+// /dcc (#270) — the slash-command surface over the DCC download manager. `list`
+// opens the Transfers view and echoes the current transfers into the buffer
+// (slash-command-first: the GUI is a view over the same core); accept/reject/
+// cancel act on one transfer by id and report the resulting state. User-wide, so
+// networkId may be null (running from the system buffer). The store writes go
+// over REST and the authoritative row echoes back through both the response and
+// the live `dcc-transfer` frame, so the output here is settled, not optimistic.
+async function runDcc(argLine: string, networkId: number | null, target: string): Promise<void> {
+  const cmd = parseDccCommand(argLine);
+  if (cmd.kind === 'error') {
+    localInfo(networkId, target, `/dcc: ${cmd.message}`);
+    return;
+  }
+  if (cmd.kind === 'list') {
+    dcc.panelOpen = true;
+    try {
+      const rows = await dcc.load();
+      if (!rows.length) {
+        localInfo(networkId, target, 'no DCC transfers.');
+        return;
+      }
+      localInfo(networkId, target, `transfers (${rows.length}):`);
+      for (const line of formatColumns(rows.map(dccListRow))) {
+        localInfo(networkId, target, `  ${line}`);
+      }
+    } catch (e: any) {
+      localInfo(networkId, target, `/dcc: ${e?.message || 'failed to load'}`);
+    }
+    return;
+  }
+  // accept / reject / cancel — the parser guarantees a numeric id here.
+  const verb = cmd.kind;
+  const run = verb === 'accept' ? dcc.accept : verb === 'reject' ? dcc.reject : dcc.cancel;
+  try {
+    const t = await run.call(dcc, cmd.id);
+    localInfo(
+      networkId,
+      target,
+      t ? `/dcc ${verb}: #${t.id} ${t.filename} — ${t.state}` : `/dcc ${verb}: #${cmd.id} done`,
+    );
+  } catch (e: any) {
+    localInfo(networkId, target, `/dcc ${verb}: ${e?.message || 'failed'}`);
+  }
+}
+
+// One row for the /dcc list output: "#3  movie.mkv  receiving  alice  42%".
+function dccListRow(t: DccTransfer): string[] {
+  const pct =
+    t.advertised_size > 0 ? `${Math.round((t.received_bytes / t.advertised_size) * 100)}%` : '';
+  return [`#${t.id}`, t.filename, t.state, t.peer_nick, pct];
 }
 
 function runIgnore(argLine: string, networkId: number | null, target: string): boolean {
@@ -2568,6 +2625,13 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       return true;
     case 'get':
       runGet(argLine, networkId, target);
+      return true;
+    case 'dcc':
+      // DCC download manager (#270). User-wide (transfers aren't tied to the
+      // active buffer), so it runs from anywhere including the system buffer.
+      // REST-backed + async, so fire-and-forget like /network; it reports into
+      // the buffer when it settles.
+      void runDcc(argLine, networkId, target);
       return true;
   }
 

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -149,7 +149,7 @@ import { useInputHistoryStore } from '../stores/inputHistory.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore, onInsertUrl } from '../stores/uploads.js';
-import { useDccStore, type DccTransfer } from '../stores/dcc.js';
+import { useDccStore, percentReceived, type DccTransfer } from '../stores/dcc.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
 import { useRelayBotsStore } from '../stores/relayBots.js';
@@ -2206,11 +2206,11 @@ async function runDcc(argLine: string, networkId: number | null, target: string)
     }
     return;
   }
-  // accept / reject / cancel — the parser guarantees a numeric id here.
+  // accept / reject / cancel — the parser guarantees a numeric id here. They all
+  // route through the store's shared act() path.
   const verb = cmd.kind;
-  const run = verb === 'accept' ? dcc.accept : verb === 'reject' ? dcc.reject : dcc.cancel;
   try {
-    const t = await run.call(dcc, cmd.id);
+    const t = await dcc.act(cmd.id, verb);
     localInfo(
       networkId,
       target,
@@ -2223,8 +2223,7 @@ async function runDcc(argLine: string, networkId: number | null, target: string)
 
 // One row for the /dcc list output: "#3  movie.mkv  receiving  alice  42%".
 function dccListRow(t: DccTransfer): string[] {
-  const pct =
-    t.advertised_size > 0 ? `${Math.round((t.received_bytes / t.advertised_size) * 100)}%` : '';
+  const pct = t.advertised_size > 0 ? `${percentReceived(t)}%` : '';
   return [`#${t.id}`, t.filename, t.state, t.peer_nick, pct];
 }
 

--- a/vue_client/src/components/TransfersModal.vue
+++ b/vue_client/src/components/TransfersModal.vue
@@ -27,7 +27,7 @@
             <!-- Progress bar while bytes can still arrive (or after, if partial). -->
             <div v-if="showProgress(t)" class="progress" :title="progressTitle(t)">
               <div class="bar">
-                <div class="fill" :style="{ width: progressPct(t) + '%' }"></div>
+                <div class="fill" :style="{ width: percentReceived(t) + '%' }"></div>
               </div>
               <span class="progress-text">{{ progressTitle(t) }}</span>
             </div>
@@ -70,7 +70,13 @@
 <script setup lang="ts">
 import { onMounted } from 'vue';
 import AppModal from './AppModal.vue';
-import { useDccStore, isCancellable, type DccTransfer, type DccState } from '../stores/dcc.js';
+import {
+  useDccStore,
+  isCancellable,
+  percentReceived,
+  type DccTransfer,
+  type DccState,
+} from '../stores/dcc.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { formatRelative } from '../utils/timestamp.js';
 
@@ -145,21 +151,19 @@ function subLine(t: DccTransfer): string {
     .join(' · ');
 }
 
+// Only show the progress bar once a download has actually started — a
+// pending_approval offer hasn't, so it must not render a 0% bar that implies
+// one. A stalled/failed transfer with a partial keeps its bar so the user sees
+// how far it got.
 function showProgress(t: DccTransfer): boolean {
-  // While bytes can still arrive, or for a non-completed transfer that already
-  // has partial bytes (stalled/failed mid-stream) so the user sees how far it got.
+  if (t.state === 'pending_approval' || t.state === 'requested') return false;
   return isCancellable(t) || (t.received_bytes > 0 && t.state !== 'completed');
-}
-
-function progressPct(t: DccTransfer): number {
-  if (!t.advertised_size || t.advertised_size <= 0) return 0;
-  return Math.max(0, Math.min(100, Math.round((t.received_bytes / t.advertised_size) * 100)));
 }
 
 function progressTitle(t: DccTransfer): string {
   const got = formatBytes(t.received_bytes);
   if (t.advertised_size > 0) {
-    return `${got} / ${formatBytes(t.advertised_size)} (${progressPct(t)}%)`;
+    return `${got} / ${formatBytes(t.advertised_size)} (${percentReceived(t)}%)`;
   }
   return got;
 }

--- a/vue_client/src/components/TransfersModal.vue
+++ b/vue_client/src/components/TransfersModal.vue
@@ -1,0 +1,355 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Transfers view for the DCC download manager (#270 phase 2). Lists the user's
+  inbound DCC transfers and lets them act on each: accept / reject an unsolicited
+  offer, or cancel one in flight. The list seeds from GET /api/dcc on open and
+  then updates live as `dcc-transfer` frames arrive over the WS. The same
+  operations are available headless via /dcc — this is a view over that core.
+-->
+
+<template>
+  <AppModal word="transfers" title="transfers" size="xl" fill-height @close="$emit('close')">
+    <p v-if="dcc.listError" class="error">{{ dcc.listError }}</p>
+
+    <div class="list-wrap">
+      <ul v-if="dcc.transfers.length" class="list">
+        <li v-for="t in dcc.transfers" :key="t.id" class="row">
+          <div class="icon" :class="stateClass(t.state)" :title="stateLabel(t.state)">
+            <i :class="stateIcon(t.state)"></i>
+          </div>
+          <div class="meta">
+            <div class="filename" :title="t.filename">{{ t.filename }}</div>
+            <div class="sub">{{ subLine(t) }}</div>
+            <!-- Progress bar while bytes can still arrive (or after, if partial). -->
+            <div v-if="showProgress(t)" class="progress" :title="progressTitle(t)">
+              <div class="bar">
+                <div class="fill" :style="{ width: progressPct(t) + '%' }"></div>
+              </div>
+              <span class="progress-text">{{ progressTitle(t) }}</span>
+            </div>
+            <div v-if="crcBadge(t)" class="crc" :class="crcBadge(t)!.cls">
+              <i :class="crcBadge(t)!.icon"></i> {{ crcBadge(t)!.text }}
+            </div>
+            <div v-if="t.error && isErrorState(t.state)" class="err" :title="t.error">
+              {{ t.error }}
+            </div>
+            <div v-if="dcc.actionError[t.id]" class="err">{{ dcc.actionError[t.id] }}</div>
+          </div>
+          <div class="row-actions">
+            <template v-if="t.state === 'pending_approval'">
+              <button class="link accept" :disabled="dcc.busy[t.id]" @click="onAccept(t)">
+                Accept
+              </button>
+              <button class="link reject" :disabled="dcc.busy[t.id]" @click="onReject(t)">
+                Reject
+              </button>
+            </template>
+            <button
+              v-else-if="isCancellable(t)"
+              class="link reject"
+              :disabled="dcc.busy[t.id]"
+              @click="onCancel(t)"
+            >
+              Cancel
+            </button>
+          </div>
+        </li>
+      </ul>
+      <p v-else-if="dcc.loading && !dcc.loaded" class="empty">Loading…</p>
+      <p v-else-if="dcc.loaded" class="empty">
+        No transfers. Inbound DCC downloads appear here when a bot sends you a file.
+      </p>
+    </div>
+  </AppModal>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import AppModal from './AppModal.vue';
+import { useDccStore, isCancellable, type DccTransfer, type DccState } from '../stores/dcc.js';
+import { useNetworksStore } from '../stores/networks.js';
+import { formatRelative } from '../utils/timestamp.js';
+
+defineEmits<{ close: [] }>();
+
+const dcc = useDccStore();
+const networks = useNetworksStore();
+
+onMounted(() => {
+  // Idempotent under the store's in-flight guard — safe even when `/dcc list`
+  // already kicked a load before opening the modal.
+  dcc.load().catch(() => {
+    /* surfaced via dcc.listError */
+  });
+});
+
+function networkName(id: number): string {
+  return networks.networkById(id)?.name || `net:${id}`;
+}
+
+function formatBytes(n: number): string {
+  if (!n || n < 0) return '0 B';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+const STATE_LABELS: Record<DccState, string> = {
+  requested: 'requested',
+  pending_approval: 'awaiting approval',
+  connecting: 'connecting',
+  receiving: 'receiving',
+  stalled: 'stalled',
+  verifying: 'verifying',
+  completed: 'completed',
+  failed: 'failed',
+  rejected: 'rejected',
+  cancelled: 'cancelled',
+};
+
+function stateLabel(s: DccState): string {
+  return STATE_LABELS[s] || s;
+}
+
+function stateClass(s: DccState): string {
+  if (s === 'completed') return 'good';
+  if (s === 'failed') return 'bad';
+  if (s === 'stalled') return 'warn';
+  if (s === 'rejected' || s === 'cancelled') return 'muted';
+  return 'accent'; // requested / pending / connecting / receiving / verifying
+}
+
+function stateIcon(s: DccState): string {
+  if (s === 'completed') return 'fa-solid fa-circle-check';
+  if (s === 'failed') return 'fa-solid fa-circle-exclamation';
+  if (s === 'rejected' || s === 'cancelled') return 'fa-solid fa-ban';
+  if (s === 'pending_approval') return 'fa-solid fa-circle-question';
+  if (s === 'stalled') return 'fa-solid fa-pause';
+  if (s === 'verifying') return 'fa-solid fa-shield-halved';
+  return 'fa-solid fa-down-long'; // requested / connecting / receiving
+}
+
+function isErrorState(s: DccState): boolean {
+  return s === 'failed' || s === 'stalled';
+}
+
+// "alice · libera · receiving · 2m ago"
+function subLine(t: DccTransfer): string {
+  return [t.peer_nick, networkName(t.network_id), stateLabel(t.state), formatRelative(t.updated_at)]
+    .filter(Boolean)
+    .join(' · ');
+}
+
+function showProgress(t: DccTransfer): boolean {
+  // While bytes can still arrive, or for a non-completed transfer that already
+  // has partial bytes (stalled/failed mid-stream) so the user sees how far it got.
+  return isCancellable(t) || (t.received_bytes > 0 && t.state !== 'completed');
+}
+
+function progressPct(t: DccTransfer): number {
+  if (!t.advertised_size || t.advertised_size <= 0) return 0;
+  return Math.max(0, Math.min(100, Math.round((t.received_bytes / t.advertised_size) * 100)));
+}
+
+function progressTitle(t: DccTransfer): string {
+  const got = formatBytes(t.received_bytes);
+  if (t.advertised_size > 0) {
+    return `${got} / ${formatBytes(t.advertised_size)} (${progressPct(t)}%)`;
+  }
+  return got;
+}
+
+interface CrcBadge {
+  cls: string;
+  icon: string;
+  text: string;
+}
+
+// Integrity badge — only meaningful once a transfer has completed. 'absent'
+// (the filename carried no CRC, so size match is the only signal) and a null
+// status render nothing, to avoid implying a verification that didn't happen.
+function crcBadge(t: DccTransfer): CrcBadge | null {
+  if (t.state !== 'completed') return null;
+  if (t.crc_status === 'ok') {
+    return { cls: 'good', icon: 'fa-solid fa-check', text: 'checksum verified' };
+  }
+  if (t.crc_status === 'mismatch') {
+    return { cls: 'bad', icon: 'fa-solid fa-triangle-exclamation', text: 'checksum mismatch' };
+  }
+  if (t.crc_status === 'unverified') {
+    return { cls: 'muted', icon: 'fa-solid fa-circle-info', text: 'resumed — not verified' };
+  }
+  return null;
+}
+
+function onAccept(t: DccTransfer) {
+  dcc.accept(t.id).catch(() => {
+    /* error surfaced via dcc.actionError */
+  });
+}
+function onReject(t: DccTransfer) {
+  dcc.reject(t.id).catch(() => {
+    /* error surfaced via dcc.actionError */
+  });
+}
+function onCancel(t: DccTransfer) {
+  dcc.cancel(t.id).catch(() => {
+    /* error surfaced via dcc.actionError */
+  });
+}
+</script>
+
+<style scoped>
+.link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: var(--space-2) var(--space-4);
+}
+.link:hover {
+  color: var(--fg);
+}
+.link:disabled {
+  color: var(--fg-muted);
+  cursor: default;
+}
+.link.accept {
+  color: var(--good);
+}
+.link.accept:hover:not(:disabled) {
+  color: var(--fg);
+}
+.link.reject {
+  color: var(--bad);
+}
+.link.reject:hover:not(:disabled) {
+  color: var(--fg);
+}
+
+.error {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-4) 0;
+  color: var(--bad);
+  border-bottom: 1px solid var(--border);
+}
+
+.list-wrap {
+  /* Break out of card padding so the scrollbar sits against the card border. */
+  margin: 0 calc(-1 * var(--card-pad-x));
+  padding: 0 var(--card-pad-x);
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.row {
+  display: grid;
+  grid-template-columns: max-content 1fr max-content;
+  column-gap: var(--space-4);
+  align-items: start;
+  padding: var(--space-4) 0 var(--space-6);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-4);
+}
+.icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  font-size: var(--icon-md);
+}
+.icon.good {
+  color: var(--good);
+}
+.icon.bad {
+  color: var(--bad);
+}
+.icon.warn {
+  color: var(--warn);
+}
+.icon.accent {
+  color: var(--accent);
+}
+.icon.muted {
+  color: var(--fg-muted);
+}
+.meta {
+  min-width: 0;
+}
+.filename {
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sub {
+  color: var(--fg-muted);
+  margin-top: var(--space-1);
+}
+.progress {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
+}
+.bar {
+  flex: 1;
+  min-width: 0;
+  height: 4px;
+  background: var(--bg-soft);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.fill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+.progress-text {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+.crc {
+  margin-top: var(--space-2);
+}
+.crc.good {
+  color: var(--good);
+}
+.crc.bad {
+  color: var(--bad);
+}
+.crc.muted {
+  color: var(--fg-muted);
+}
+.err {
+  color: var(--bad);
+  margin-top: var(--space-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.row-actions {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  margin-left: var(--space-4);
+}
+
+.empty {
+  padding: var(--space-9) 0;
+  color: var(--fg-muted);
+  text-align: center;
+}
+</style>

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -22,6 +22,7 @@ import { useFriendsStore } from '../stores/friends.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useDataExportStore } from '../stores/dataExport.js';
+import { useDccStore } from '../stores/dcc.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { downloadTextFile } from '../utils/download.js';
 import { notifyForEvent, playSound } from './useHighlightNotifier.js';
@@ -631,6 +632,13 @@ function handleMessage(raw: string): void {
   if (payload.kind === 'relay-bot-updated') {
     const relayBots = useRelayBotsStore();
     relayBots.applyUpdate(payload.networkId, payload.nick, !!payload.marked, payload.pattern || '');
+    return;
+  }
+  if (payload.kind === 'dcc-transfer') {
+    // Live DCC transfer state change (#270 phase 2) — user-scoped, not a buffer
+    // message. Upsert the row into the Transfers store; this also self-reveals
+    // the Transfers affordance the first time an offer lands.
+    useDccStore().applyTransfer(payload.transfer);
     return;
   }
   if (payload.kind === 'contacts-snapshot') {

--- a/vue_client/src/lib/commands/dcc.test.ts
+++ b/vue_client/src/lib/commands/dcc.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { parseDccCommand } from './dcc.js';
+
+describe('parseDccCommand', () => {
+  it('treats no args as list', () => {
+    expect(parseDccCommand('')).toEqual({ kind: 'list' });
+    expect(parseDccCommand('   ')).toEqual({ kind: 'list' });
+  });
+
+  it('parses explicit list (and ls alias)', () => {
+    expect(parseDccCommand('list')).toEqual({ kind: 'list' });
+    expect(parseDccCommand('ls')).toEqual({ kind: 'list' });
+  });
+
+  it('parses accept/reject/cancel with an id', () => {
+    expect(parseDccCommand('accept 7')).toEqual({ kind: 'accept', id: 7 });
+    expect(parseDccCommand('reject 12')).toEqual({ kind: 'reject', id: 12 });
+    expect(parseDccCommand('cancel 3')).toEqual({ kind: 'cancel', id: 3 });
+  });
+
+  it('accepts subcommand aliases', () => {
+    expect(parseDccCommand('ok 1')).toEqual({ kind: 'accept', id: 1 });
+    expect(parseDccCommand('yes 1')).toEqual({ kind: 'accept', id: 1 });
+    expect(parseDccCommand('get 1')).toEqual({ kind: 'accept', id: 1 });
+    expect(parseDccCommand('deny 1')).toEqual({ kind: 'reject', id: 1 });
+    expect(parseDccCommand('no 1')).toEqual({ kind: 'reject', id: 1 });
+    expect(parseDccCommand('abort 1')).toEqual({ kind: 'cancel', id: 1 });
+    expect(parseDccCommand('stop 1')).toEqual({ kind: 'cancel', id: 1 });
+  });
+
+  it('is case-insensitive on the verb', () => {
+    expect(parseDccCommand('ACCEPT 5')).toEqual({ kind: 'accept', id: 5 });
+  });
+
+  it('ignores trailing tokens after the id', () => {
+    expect(parseDccCommand('accept 9 please')).toEqual({ kind: 'accept', id: 9 });
+  });
+
+  it('errors when an action is missing its id', () => {
+    expect(parseDccCommand('accept')).toMatchObject({ kind: 'error' });
+    expect(parseDccCommand('cancel')).toMatchObject({ kind: 'error' });
+  });
+
+  it('errors on a non-numeric or non-positive id', () => {
+    expect(parseDccCommand('accept abc')).toMatchObject({ kind: 'error' });
+    expect(parseDccCommand('reject 0')).toMatchObject({ kind: 'error' });
+    expect(parseDccCommand('cancel -2')).toMatchObject({ kind: 'error' });
+    expect(parseDccCommand('accept 1.5')).toMatchObject({ kind: 'error' });
+  });
+
+  it('errors on an unknown subcommand', () => {
+    expect(parseDccCommand('frobnicate 1').kind).toBe('error');
+  });
+});

--- a/vue_client/src/lib/commands/dcc.ts
+++ b/vue_client/src/lib/commands/dcc.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Parser for the /dcc command (#270 phase 2) — the slash-command surface over
+// the DCC download manager. `list` opens the Transfers view; accept / reject /
+// cancel act on one transfer by its numeric id (the id shown in the list).
+//
+// Pure and dependency-free so it unit-tests outside the Vue SFC, like the other
+// command parsers. DCC is user-wide (not per-network), so the SFC routes this
+// among the network-agnostic commands.
+
+export type DccCommand =
+  | { kind: 'list' }
+  | { kind: 'accept'; id: number }
+  | { kind: 'reject'; id: number }
+  | { kind: 'cancel'; id: number }
+  | { kind: 'error'; message: string };
+
+const ACCEPT = new Set(['accept', 'ok', 'yes', 'get']);
+const REJECT = new Set(['reject', 'deny', 'no']);
+const CANCEL = new Set(['cancel', 'abort', 'stop']);
+const LIST = new Set(['list', 'ls']);
+
+const USAGE = 'usage: /dcc [list] · /dcc accept <id> · /dcc reject <id> · /dcc cancel <id>';
+
+// Parse a positive integer transfer id, or null. Rejects empty, non-numeric, and
+// non-positive values so a fat-fingered id surfaces a usage hint rather than
+// POSTing to /api/dcc/NaN/accept.
+function parseId(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export function parseDccCommand(argLine: string): DccCommand {
+  const trimmed = (argLine || '').trim();
+  if (!trimmed) return { kind: 'list' };
+
+  const parts = trimmed.split(/\s+/);
+  const verb = parts[0].toLowerCase();
+
+  if (LIST.has(verb)) return { kind: 'list' };
+
+  const isAccept = ACCEPT.has(verb);
+  const isReject = REJECT.has(verb);
+  const isCancel = CANCEL.has(verb);
+  if (isAccept || isReject || isCancel) {
+    const kind = isAccept ? 'accept' : isReject ? 'reject' : 'cancel';
+    const id = parseId(parts[1]);
+    if (id == null) return { kind: 'error', message: `usage: /dcc ${kind} <id>` };
+    return { kind, id };
+  }
+
+  return { kind: 'error', message: `unknown subcommand "${parts[0]}". ${USAGE}` };
+}

--- a/vue_client/src/stores/dcc.test.ts
+++ b/vue_client/src/stores/dcc.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useDccStore, percentReceived, type DccTransfer, type DccState } from './dcc.js';
+
+// Minimal row factory — only the fields the store logic reads.
+function row(id: number, state: DccState, over: Partial<DccTransfer> = {}): DccTransfer {
+  return {
+    id,
+    network_id: 1,
+    peer_nick: 'bot',
+    filename: `f${id}.bin`,
+    advertised_size: 1000,
+    received_bytes: 0,
+    state,
+    crc_status: null,
+    error: null,
+    created_at: '2026-06-28 00:00:00',
+    updated_at: '2026-06-28 00:00:00',
+    completed_at: null,
+    ...over,
+  };
+}
+
+describe('dcc store applyTransfer', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('inserts new rows keeping id-DESC order', () => {
+    const dcc = useDccStore();
+    dcc.applyTransfer(row(2, 'receiving'));
+    dcc.applyTransfer(row(5, 'pending_approval'));
+    dcc.applyTransfer(row(3, 'receiving'));
+    expect(dcc.transfers.map((t) => t.id)).toEqual([5, 3, 2]);
+  });
+
+  it('replaces an existing row in place', () => {
+    const dcc = useDccStore();
+    dcc.applyTransfer(row(1, 'receiving', { received_bytes: 100 }));
+    dcc.applyTransfer(row(1, 'receiving', { received_bytes: 500 }));
+    expect(dcc.transfers).toHaveLength(1);
+    expect(dcc.transfers[0].received_bytes).toBe(500);
+  });
+
+  it('does not let a terminal row regress to an active state (stale snapshot)', () => {
+    const dcc = useDccStore();
+    dcc.applyTransfer(row(1, 'completed', { received_bytes: 1000 }));
+    // A late POST-response snapshot carrying the pre-completion 'receiving' state.
+    dcc.applyTransfer(row(1, 'receiving', { received_bytes: 300 }));
+    expect(dcc.transfers[0].state).toBe('completed');
+    expect(dcc.transfers[0].received_bytes).toBe(1000);
+  });
+
+  it('still applies a terminal state over an active one', () => {
+    const dcc = useDccStore();
+    dcc.applyTransfer(row(1, 'receiving'));
+    dcc.applyTransfer(row(1, 'cancelled'));
+    expect(dcc.transfers[0].state).toBe('cancelled');
+  });
+
+  it('ignores a malformed frame', () => {
+    const dcc = useDccStore();
+    dcc.applyTransfer(undefined as unknown as DccTransfer);
+    dcc.applyTransfer({ id: 'x' } as unknown as DccTransfer);
+    expect(dcc.transfers).toHaveLength(0);
+  });
+});
+
+describe('dcc store getters', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it('pendingCount counts only pending_approval offers', () => {
+    const dcc = useDccStore();
+    dcc.applyTransfer(row(1, 'pending_approval'));
+    dcc.applyTransfer(row(2, 'pending_approval'));
+    dcc.applyTransfer(row(3, 'receiving'));
+    dcc.applyTransfer(row(4, 'completed'));
+    expect(dcc.pendingCount).toBe(2);
+    expect(dcc.hasAny).toBe(true);
+  });
+});
+
+describe('percentReceived', () => {
+  it('is a clamped 0–100 integer', () => {
+    expect(percentReceived(row(1, 'receiving', { received_bytes: 0, advertised_size: 1000 }))).toBe(
+      0,
+    );
+    expect(
+      percentReceived(row(1, 'receiving', { received_bytes: 500, advertised_size: 1000 })),
+    ).toBe(50);
+    expect(
+      percentReceived(row(1, 'completed', { received_bytes: 1000, advertised_size: 1000 })),
+    ).toBe(100);
+    // A bot that over-sends can't push the bar past 100%.
+    expect(
+      percentReceived(row(1, 'receiving', { received_bytes: 1500, advertised_size: 1000 })),
+    ).toBe(100);
+    // No advertised size → 0 (avoid divide-by-zero).
+    expect(percentReceived(row(1, 'receiving', { received_bytes: 500, advertised_size: 0 }))).toBe(
+      0,
+    );
+  });
+});

--- a/vue_client/src/stores/dcc.ts
+++ b/vue_client/src/stores/dcc.ts
@@ -64,16 +64,28 @@ export const ACTIVE_STATES: ReadonlySet<DccState> = new Set([
   'verifying',
 ]);
 
-// A pending_approval offer is awaiting the user's Accept/Reject — the only state
-// /dcc accept|reject act on, and what the affordance badge counts as "needs you".
-export function isPending(t: DccTransfer): boolean {
-  return t.state === 'pending_approval';
-}
+// Terminal states a transfer never legitimately leaves (a row id is one-shot).
+// Used to drop a stale snapshot that would rewind a finished row — see
+// applyTransfer.
+const TERMINAL_STATES: ReadonlySet<DccState> = new Set([
+  'completed',
+  'failed',
+  'rejected',
+  'cancelled',
+]);
 
 // True while bytes can still arrive, so the UI offers Cancel (and renders a
 // progress bar). A pending offer isn't cancellable-in-flight but can be rejected.
 export function isCancellable(t: DccTransfer): boolean {
   return ACTIVE_STATES.has(t.state);
+}
+
+// Download progress as a clamped 0–100 integer. Shared by the modal's progress
+// bar and the /dcc list output so the two never diverge (and a bot that
+// over-sends can't render >100%).
+export function percentReceived(t: DccTransfer): number {
+  if (!t.advertised_size || t.advertised_size <= 0) return 0;
+  return Math.max(0, Math.min(100, Math.round((t.received_bytes / t.advertised_size) * 100)));
 }
 
 type DccAction = 'accept' | 'reject' | 'cancel';
@@ -101,9 +113,8 @@ export const useDccStore = defineStore('dcc', {
   }),
   getters: {
     hasAny: (s): boolean => s.transfers.length > 0,
-    // In-flight transfers — drives the affordance's "active" indicator.
-    activeCount: (s): number => s.transfers.filter((t) => ACTIVE_STATES.has(t.state)).length,
-    // Unsolicited offers awaiting a decision — the urgent, you-must-act count.
+    // Unsolicited offers awaiting a decision — the urgent, you-must-act count
+    // that warn-colors the affordance.
     pendingCount: (s): number => s.transfers.filter((t) => t.state === 'pending_approval').length,
   },
   actions: {
@@ -132,17 +143,25 @@ export const useDccStore = defineStore('dcc', {
 
     // Upsert a single row from a live `dcc-transfer` frame or an action response.
     // The id is immutable, so an existing row is replaced in place; a new one is
-    // inserted and the list re-sorted id-DESC (a fresh offer has the largest id,
-    // so this lands it at the top).
+    // spliced in keeping the list id-DESC (a fresh offer has the largest id, so
+    // this is usually a prepend).
+    //
+    // WS frames and POST action responses are independent, unordered channels, so
+    // a stale snapshot can arrive after a newer one. Guard against the one case
+    // that matters: a terminal row must never rewind to an active state (e.g. a
+    // cancel/accept POST response carrying 'receiving' resolving after the live
+    // 'cancelled'/'completed' frame already landed). Drop such a regression.
     applyTransfer(t: DccTransfer): void {
       if (!t || typeof t.id !== 'number') return;
       const idx = this.transfers.findIndex((x) => x.id === t.id);
       if (idx >= 0) {
+        if (TERMINAL_STATES.has(this.transfers[idx].state) && !TERMINAL_STATES.has(t.state)) return;
         this.transfers[idx] = t;
-      } else {
-        this.transfers.push(t);
-        this.transfers.sort((a, b) => b.id - a.id);
+        return;
       }
+      const at = this.transfers.findIndex((x) => x.id < t.id);
+      if (at === -1) this.transfers.push(t);
+      else this.transfers.splice(at, 0, t);
     },
 
     async accept(id: number): Promise<DccTransfer> {

--- a/vue_client/src/stores/dcc.ts
+++ b/vue_client/src/stores/dcc.ts
@@ -74,8 +74,12 @@ const TERMINAL_STATES: ReadonlySet<DccState> = new Set([
   'cancelled',
 ]);
 
-// True while bytes can still arrive, so the UI offers Cancel (and renders a
-// progress bar). A pending offer isn't cancellable-in-flight but can be rejected.
+// True while a transfer is non-terminal — i.e. `/dcc cancel` (or the modal's
+// Cancel button) can still act on it. This INCLUDES a pending_approval offer:
+// cancelling one declines it, same as reject. The modal surfaces Reject rather
+// than Cancel for a pending offer (its pending_approval branch takes precedence
+// over the isCancellable branch), but the predicate itself is just "not yet in a
+// terminal state", so it's true for pending too.
 export function isCancellable(t: DccTransfer): boolean {
   return ACTIVE_STATES.has(t.state);
 }

--- a/vue_client/src/stores/dcc.ts
+++ b/vue_client/src/stores/dcc.ts
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Client store for the DCC download manager (#270 phase 2). Mirrors the server's
+// dcc_transfers rows and backs the Transfers view: the initial list comes from
+// GET /api/dcc, then live state changes arrive over the WS as `dcc-transfer`
+// frames (applyTransfer). Acting on a transfer (accept / reject / cancel) goes
+// over POST and the authoritative row echoes back — both through the action's
+// response and, redundantly, the live frame the server publishes on the change.
+//
+// DCC is OFF for almost everyone (a self-host opt-in + per-user grant; dark on
+// hosted cells), so this store stays empty and the UI affordance stays hidden
+// until a transfer actually exists. There's no boot fetch: the store loads
+// lazily when the Transfers modal opens or `/dcc list` runs, and the live frame
+// reveals the affordance the moment an offer lands.
+
+import { defineStore } from 'pinia';
+import { api } from '../api.js';
+
+// Mirror of the server DccTransferState union (db/dccTransfers.ts). Two entry
+// states (requested / pending_approval), an active receive path, and terminal
+// states. Kept in sync by hand — the wire is plain JSON.
+export type DccState =
+  | 'requested'
+  | 'pending_approval'
+  | 'connecting'
+  | 'receiving'
+  | 'stalled'
+  | 'verifying'
+  | 'completed'
+  | 'failed'
+  | 'rejected'
+  | 'cancelled';
+
+// How a completed transfer verified against the filename CRC32 (server's
+// DccCrcStatus). Only meaningful once `completed`.
+export type DccCrcStatus = 'ok' | 'mismatch' | 'absent' | 'unverified';
+
+// The subset of the server row the UI reads. The server ships the whole row;
+// extra columns (peer_host/port, token, trigger_text, …) are ignored here.
+export interface DccTransfer {
+  id: number;
+  network_id: number;
+  peer_nick: string;
+  filename: string;
+  advertised_size: number;
+  received_bytes: number;
+  state: DccState;
+  crc_status: DccCrcStatus | null;
+  error: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+// States that can still change — a transfer in one of these is "active" (drives
+// the affordance badge) and is the only thing /dcc cancel meaningfully targets.
+export const ACTIVE_STATES: ReadonlySet<DccState> = new Set([
+  'requested',
+  'pending_approval',
+  'connecting',
+  'receiving',
+  'stalled',
+  'verifying',
+]);
+
+// A pending_approval offer is awaiting the user's Accept/Reject — the only state
+// /dcc accept|reject act on, and what the affordance badge counts as "needs you".
+export function isPending(t: DccTransfer): boolean {
+  return t.state === 'pending_approval';
+}
+
+// True while bytes can still arrive, so the UI offers Cancel (and renders a
+// progress bar). A pending offer isn't cancellable-in-flight but can be rejected.
+export function isCancellable(t: DccTransfer): boolean {
+  return ACTIVE_STATES.has(t.state);
+}
+
+type DccAction = 'accept' | 'reject' | 'cancel';
+
+// Dedupe concurrent loads (the `/dcc list` command and the modal's mount both
+// fetch) so every awaiter shares one in-flight request and sees the same rows.
+// Held module-local, not in state — same rationale as the toasts store's action
+// handlers and the drafts store's timers (Pinia state stays serializable).
+let inflightLoad: Promise<DccTransfer[]> | null = null;
+
+export const useDccStore = defineStore('dcc', {
+  state: () => ({
+    transfers: [] as DccTransfer[],
+    loaded: false,
+    loading: false,
+    listError: '',
+    // Whether the Transfers modal is open. Lives in the store (not a view-local
+    // ref) so `/dcc list` can open it from MessageInput, mirroring the
+    // composable-backed opens (useImageModal, useChannelListModal).
+    panelOpen: false,
+    // Per-transfer action in flight (disables that row's buttons).
+    busy: {} as Record<number, boolean>,
+    // Per-transfer last action error (cleared on the next attempt / success).
+    actionError: {} as Record<number, string>,
+  }),
+  getters: {
+    hasAny: (s): boolean => s.transfers.length > 0,
+    // In-flight transfers — drives the affordance's "active" indicator.
+    activeCount: (s): number => s.transfers.filter((t) => ACTIVE_STATES.has(t.state)).length,
+    // Unsolicited offers awaiting a decision — the urgent, you-must-act count.
+    pendingCount: (s): number => s.transfers.filter((t) => t.state === 'pending_approval').length,
+  },
+  actions: {
+    // Fetch the user's transfers (newest first; the server already orders by id
+    // DESC). Idempotent under concurrency via the shared in-flight promise.
+    async load(): Promise<DccTransfer[]> {
+      if (inflightLoad) return inflightLoad;
+      this.loading = true;
+      this.listError = '';
+      inflightLoad = (async () => {
+        try {
+          const { transfers } = await api<{ transfers: DccTransfer[] }>('/api/dcc');
+          this.transfers = (transfers || []).toSorted((a, b) => b.id - a.id);
+          this.loaded = true;
+          return this.transfers;
+        } catch (e: any) {
+          this.listError = e?.message || 'failed to load transfers';
+          throw e;
+        } finally {
+          this.loading = false;
+          inflightLoad = null;
+        }
+      })();
+      return inflightLoad;
+    },
+
+    // Upsert a single row from a live `dcc-transfer` frame or an action response.
+    // The id is immutable, so an existing row is replaced in place; a new one is
+    // inserted and the list re-sorted id-DESC (a fresh offer has the largest id,
+    // so this lands it at the top).
+    applyTransfer(t: DccTransfer): void {
+      if (!t || typeof t.id !== 'number') return;
+      const idx = this.transfers.findIndex((x) => x.id === t.id);
+      if (idx >= 0) {
+        this.transfers[idx] = t;
+      } else {
+        this.transfers.push(t);
+        this.transfers.sort((a, b) => b.id - a.id);
+      }
+    },
+
+    async accept(id: number): Promise<DccTransfer> {
+      return this.act(id, 'accept');
+    },
+    async reject(id: number): Promise<DccTransfer> {
+      return this.act(id, 'reject');
+    },
+    async cancel(id: number): Promise<DccTransfer> {
+      return this.act(id, 'cancel');
+    },
+
+    // Shared accept/reject/cancel path: POST /api/dcc/:id/<action>, apply the
+    // returned authoritative row, and surface a per-row error on failure (a 409
+    // when accepting on a disconnected network, a 404 for an unknown id).
+    async act(id: number, action: DccAction): Promise<DccTransfer> {
+      this.busy[id] = true;
+      delete this.actionError[id];
+      try {
+        const { transfer } = await api<{ transfer: DccTransfer }>(`/api/dcc/${id}/${action}`, {
+          method: 'POST',
+        });
+        if (transfer) this.applyTransfer(transfer);
+        return transfer;
+      } catch (e: any) {
+        this.actionError[id] = e?.message || `${action} failed`;
+        throw e;
+      } finally {
+        delete this.busy[id];
+      }
+    },
+
+    // Open the Transfers modal and (re)load the list. Used by the sidebar button
+    // and `/dcc list`. Load errors surface via listError in the modal.
+    open(): void {
+      this.panelOpen = true;
+      this.load().catch(() => {
+        /* surfaced via listError */
+      });
+    },
+    close(): void {
+      this.panelOpen = false;
+    },
+  },
+});

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -37,6 +37,19 @@
         <button class="link" @click="showUploads = true" title="Recent uploads">
           <i class="fa-solid fa-paperclip"></i>
         </button>
+        <!-- Self-revealing: DCC is off for almost everyone, so the Transfers
+             button only appears once a transfer exists (or the panel is open).
+             Color-as-signal (house style, no count badge): the glyph turns
+             warn-colored while an unsolicited offer awaits a decision. -->
+        <button
+          v-if="dcc.hasAny || dcc.panelOpen"
+          class="link dcc-btn"
+          :class="{ pending: dcc.pendingCount > 0 }"
+          @click="dcc.open()"
+          :title="dccTitle"
+        >
+          <i class="fa-solid fa-circle-down"></i>
+        </button>
         <button class="link" @click="openAddNetwork" title="Add network">
           <i class="fa-solid fa-plus"></i>
         </button>
@@ -183,6 +196,7 @@
       @close="channelListModal.close()"
     />
     <RecentUploadsModal v-if="showUploads" @close="showUploads = false" />
+    <TransfersModal v-if="dcc.panelOpen" @close="dcc.close()" />
     <QuickSwitcher v-if="showSwitcher" @close="showSwitcher = false" />
     <SearchModal v-if="showSearch" @close="showSearch = false" @jump="onJumpToMessage" />
     <KeyboardHelpModal v-if="showKbdHelp" @close="showKbdHelp = false" />
@@ -232,6 +246,7 @@ import LinkedText from '../components/LinkedText.vue';
 import TopicModal from '../components/TopicModal.vue';
 import ChannelListModal from '../components/ChannelListModal.vue';
 import RecentUploadsModal from '../components/RecentUploadsModal.vue';
+import TransfersModal from '../components/TransfersModal.vue';
 import QuickSwitcher from '../components/QuickSwitcher.vue';
 import SearchModal from '../components/SearchModal.vue';
 import KeyboardHelpModal from '../components/KeyboardHelpModal.vue';
@@ -243,6 +258,7 @@ import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts.js';
 import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useFriendsStore } from '../stores/friends.js';
+import { useDccStore } from '../stores/dcc.js';
 import { useSearchStore } from '../stores/search.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChannelNotifyStore } from '../stores/channelNotify.js';
@@ -287,6 +303,10 @@ const nicklistCollapse = useNicklistCollapseStore();
 const nickNotes = useNickNotesStore();
 const friends = useFriendsStore();
 const friendCount = computed(() => friends.contacts.length);
+const dcc = useDccStore();
+const dccTitle = computed(() =>
+  dcc.pendingCount > 0 ? `DCC transfers — ${dcc.pendingCount} awaiting approval` : 'DCC transfers',
+);
 const whois = useWhoisStore();
 const channelNotify = useChannelNotifyStore();
 
@@ -321,6 +341,7 @@ const anyModalOpen = computed(
     channelListModal.isOpen ||
     imageModal.isOpen ||
     showUploads.value ||
+    dcc.panelOpen ||
     showSwitcher.value ||
     showSearch.value ||
     showKbdHelp.value,
@@ -664,6 +685,11 @@ useChatBootstrap({ onJump: onJumpToMessage });
 }
 .link:hover {
   color: var(--fg);
+}
+/* Transfers button: while an unsolicited offer awaits a decision the glyph
+   turns warn-colored to draw the eye (color-as-signal, no count badge). */
+.dcc-btn.pending {
+  color: var(--warn);
 }
 /* Expand control at the top of the collapsed rail — the in-list collapse
    button is unmounted with the channel list, so this brings it back up top.

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -25,6 +25,17 @@
         <button class="icon" title="Recent uploads" @click="showUploads = true">
           <i class="fa-solid fa-paperclip"></i>
         </button>
+        <!-- Self-revealing DCC transfers button — see DesktopChat for rationale.
+             Warn-colored while an offer awaits a decision. -->
+        <button
+          v-if="dcc.hasAny || dcc.panelOpen"
+          class="icon dcc-btn"
+          :class="{ pending: dcc.pendingCount > 0 }"
+          :title="dccTitle"
+          @click="dcc.open()"
+        >
+          <i class="fa-solid fa-circle-down"></i>
+        </button>
         <button class="icon" title="Add network" @click="openAddNetwork">
           <i class="fa-solid fa-plus"></i>
         </button>
@@ -148,6 +159,7 @@
       @close="channelListModal.close()"
     />
     <RecentUploadsModal v-if="showUploads" @close="showUploads = false" />
+    <TransfersModal v-if="dcc.panelOpen" @close="dcc.close()" />
     <SearchModal
       v-if="showSearch"
       :scope="searchScope"
@@ -199,6 +211,7 @@ import BookmarksModal from '../components/BookmarksModal.vue';
 import TopicModal from '../components/TopicModal.vue';
 import ChannelListModal from '../components/ChannelListModal.vue';
 import RecentUploadsModal from '../components/RecentUploadsModal.vue';
+import TransfersModal from '../components/TransfersModal.vue';
 import SearchModal from '../components/SearchModal.vue';
 import NickNoteModal from '../components/NickNoteModal.vue';
 import ConfigureFriendModal from '../components/ConfigureFriendModal.vue';
@@ -206,6 +219,7 @@ import UserProfileModal from '../components/UserProfileModal.vue';
 import ImageViewerModal from '../components/ImageViewerModal.vue';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useFriendsStore } from '../stores/friends.js';
+import { useDccStore } from '../stores/dcc.js';
 import { useSearchStore } from '../stores/search.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
@@ -239,6 +253,10 @@ const menu = useContextMenu();
 const nickNotes = useNickNotesStore();
 const friends = useFriendsStore();
 const friendCount = computed(() => friends.contacts.length);
+const dcc = useDccStore();
+const dccTitle = computed(() =>
+  dcc.pendingCount > 0 ? `DCC transfers — ${dcc.pendingCount} awaiting approval` : 'DCC transfers',
+);
 const whois = useWhoisStore();
 
 function openSystemConsole() {
@@ -523,6 +541,11 @@ useChatBootstrap({ onJump: onJumpToMessage });
 }
 .icon:hover {
   color: var(--fg);
+}
+/* Transfers button turns warn-colored while an offer awaits a decision
+   (color-as-signal, no count badge — matches DesktopChat). */
+.icon.dcc-btn.pending {
+  color: var(--warn);
 }
 .icon.back {
   margin-left: -4px;


### PR DESCRIPTION
Phase 2 of the server-side DCC/XDCC receive download manager (#270): the user-facing acceptance surface — a REST API + live WS push, a Transfers view, and a `/dcc` command. Builds on phases 0/1 (#443) and 3 (#446). Receive-only, self-host only, **off by default** behind `LURKER_DCC_ENABLED` (cell master switch) AND a per-user `dcc` capability.

Three commits:

### 2a — server core (`927943b`)
- Persist the offer's `peer_host`/`peer_port` so an unsolicited `pending_approval` offer can be dialed later.
- `IrcConnection`: `acceptPendingDcc` / `rejectDcc` / `cancelDcc`, and `publishDcc` — a user-scoped `dcc-transfer` push on every state change.
- `wsHub` forwards it as a `{ kind: 'dcc-transfer', transfer }` frame.
- `ircManager`: accept/reject/cancel routed by the row's network (accept needs a live connection → 409; reject/cancel fall back to a DB flip).
- `GET /api/dcc` + `POST /api/dcc/:id/{accept,reject,cancel}` (`requireAuth`; writes blocked when paused).

### 2b — client UI (`69a79b3`)
Pure frontend over the 2a contract:
- `stores/dcc.ts` — Pinia store (lazy load, `applyTransfer` upsert, accept/reject/cancel, `panelOpen`).
- `dcc-transfer` WS frame dispatched in `useSocket.ts`.
- `TransfersModal.vue` (mirrors `RecentUploadsModal`) — per-row state icon, progress bar, checksum verified/⚠ badge, Accept/Reject/Cancel.
- `lib/commands/dcc.ts` parser (+tests) wired into MessageInput's network-agnostic switch (`/dcc list|accept|reject|cancel`) + the `/commands` cheatsheet — slash-command-first; the modal is a view over the same store actions.
- A self-revealing Transfers button in Desktop + Mobile: shown only once a transfer exists, warn-colored while an offer awaits approval (color-as-signal, no count badge).

### Review hardening (`9f972d8`)
A local `/code-review high` pass (as run for the earlier phases) surfaced real bugs the tests missed:
- **Gate bypass** — the `/api/dcc` routes only required auth, so a revoked-capability user (or after the master switch flips off) could still POST `accept` on a stale pending offer and have the cell dial the bot. Added a `dccEnabledForUser` guard (403, reads + writes).
- **State clobber** — reject/cancel had no state guard (rejected a *completed* row; left a live receiver running). Added shared `DCC_ACTIVE_STATES` guards, including the disconnected DB-only fallbacks.
- **Cancel-during-resume leaked the 15s RESUME timer** (the transfer could still complete on a late ACCEPT, or get overwritten cancelled→failed). Added `clearPendingResume`.
- NaN `:id` → 500 instead of 404; `acceptPendingDcc` silent no-op on a missing address → now fails visibly; client `applyTransfer` terminal-regression guard (WS frame + POST response are unordered channels, so a stale `receiving` snapshot could rewind a `completed`/`cancelled` row).

### Deferred (noted, not in this PR)
`publishDcc` rides the IRC event-bus via a synthetic event + a wsHub special-case (could use `fanOutToUser`); the Transfers button is duplicated Desktop/Mobile (could be a shared component); `formatBytes` is a third copy (DataPane/RecentUploads/TransfersModal — extract a util); `publishDcc` does a `SELECT *` read-after-write per progress checkpoint. Phase 4 (authed in-browser `GET /api/dcc/:id/file` download) and passive/reverse DCC remain.

### Tests
Full suite green (**1704**), typecheck + oxfmt clean. New coverage: the `/dcc` parser, a client `dcc` store suite (terminal-regression guard, id-DESC ordering, `percentReceived` clamp), and server wiring tests (reject/cancel no-clobber, accept-with-no-address fails, cancel clears the resume timer).

Refs #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)