### PR TITLE
Message context menu + toggleable hover action bar; gate hover styles for touch (#392, #115)

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -589,9 +589,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     default: true,
     description:
       'Show the floating action toolbar (reply, copy, bookmark, ignore) when ' +
-      'hovering a message on desktop. The same actions are always available by ' +
-      'right-clicking (or tapping on touch devices) a message. No effect on ' +
-      'touch devices, where the bar is never shown.',
+      'hovering a message on desktop. When off, click a message to open the same ' +
+      'actions as a menu instead. No effect on touch devices, where the bar is ' +
+      'never shown and tapping a message always opens the menu.',
   },
   {
     key: 'look.buffer.time_format',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -581,6 +581,19 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     description: 'Render /me action messages in italics.',
   },
   {
+    key: 'look.message.hover_actions',
+    label: 'Show hover action bar on messages',
+    category: 'appearance',
+    group: 'misc',
+    type: 'bool',
+    default: true,
+    description:
+      'Show the floating action toolbar (reply, copy, bookmark, ignore) when ' +
+      'hovering a message on desktop. The same actions are always available by ' +
+      'right-clicking (or tapping on touch devices) a message. No effect on ' +
+      'touch devices, where the bar is never shown.',
+  },
+  {
     key: 'look.buffer.time_format',
     label: 'Message timestamp format',
     category: 'appearance',

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@types/node": "^25.9.4",
         "@vitejs/plugin-vue": "^6.0.7",
+        "postcss-hover-media-feature": "^1.0.2",
         "typescript": "^6.0.3",
         "vite": "^8.0.16",
         "vite-plugin-mkcert": "^2.1.0",
@@ -847,6 +848,19 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1432,6 +1446,36 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-hover-media-feature": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-hover-media-feature/-/postcss-hover-media-feature-1.0.2.tgz",
+      "integrity": "sha512-o5xDUqCQ4xtilWOcvo5LKYxFVSLWcBN0IlTqa0IJwAwHTd4pxKmX4c0fGIpgLQCcBB/+aFizt2NVWNGJWG4Izg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -1645,6 +1689,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.16",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/node": "^25.9.4",
     "@vitejs/plugin-vue": "^6.0.7",
+    "postcss-hover-media-feature": "^1.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vite-plugin-mkcert": "^2.1.0",

--- a/vue_client/postcss.config.js
+++ b/vue_client/postcss.config.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Gate every `:hover` rule behind `@media (hover: hover)` at build time (#115).
+//
+// iOS Safari has no real hover, so for any element that carries `:hover` styles
+// it *simulates* one: the first tap applies `:hover` and only the second tap
+// fires the click, and that hover sticks until you tap elsewhere (so scrolling
+// past a row leaves it highlighted). Wrapping hover styles in `@media (hover:
+// hover)` means they simply don't exist on touch devices — every tap is a
+// single tap and nothing sticks. Doing it here, at build time, gates all
+// current AND future `:hover` rules across `assets/main.css` and every SFC
+// `<style>` block without per-rule churn or relying on contributor discipline.
+//
+// The plugin splits mixed selector lists, so non-:hover selectors sharing a rule
+// (`.active`, `:focus`, `:focus-visible`) stay ungated and keep working on
+// touch. Rules already inside a hover media query are left untouched.
+export default {
+  plugins: {
+    'postcss-hover-media-feature': {},
+  },
+};

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -423,6 +423,10 @@ const actionItalic = computed(() => !!settings.effective('look.action.italic'));
 // Hover action bar toggle (#392). Off → the bar never renders (right-click / tap
 // menu still works). Always off on touch via the CSS reveal media query too.
 const hoverActions = computed(() => !!settings.effective('look.message.hover_actions'));
+// The message whose action menu is open — gives the row a `selected` background
+// so touch users (who get no hover) can see which message the menu targets, and
+// keeps it lit on desktop after the cursor leaves for the menu (#392).
+const selectedMessageId = ref<number | null>(null);
 const selfColor = computed<string | null>(
   () => (settings.effective('look.nick.self_color') as string | undefined) ?? null,
 );
@@ -580,6 +584,7 @@ function rowClass(row: RenderRow) {
     highlight: !!row.highlight && !row.nohilight,
     'cont-author': !!row.continuationAuthor,
     'cont-time': !!row.continuationTime,
+    selected: m?.id != null && m.id === selectedMessageId.value,
   };
 }
 
@@ -652,6 +657,7 @@ function onMessageMenu(e: MouseEvent, m: ChatMessage | undefined | null): void {
   // copy link) is what's wanted there.
   if ((e.target as Element | null)?.closest('a')) return;
   e.preventDefault();
+  selectedMessageId.value = m?.id ?? null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   messageActions.openMenu(m as any, actionContext, e.clientX, e.clientY);
 }
@@ -665,6 +671,7 @@ function onMessageRowClick(e: MouseEvent, m: ChatMessage | undefined | null): vo
   // Taps on a link follow the link; taps on a nick are handled by NickRef
   // (which stops propagation), so they never reach here.
   if ((e.target as Element | null)?.closest('a')) return;
+  selectedMessageId.value = m?.id ?? null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   messageActions.openMenu(m as any, actionContext, e.clientX, e.clientY);
 }
@@ -677,6 +684,15 @@ function onMessageRowClick(e: MouseEvent, m: ChatMessage | undefined | null): vo
 const memberActions = useMemberActions();
 const contextMenu = useContextMenu();
 const whois = useWhoisStore();
+
+// Clear the selected-message highlight (declared up top) whenever the shared
+// context menu closes — tap an item, tap outside, or Escape (#392).
+watch(
+  () => contextMenu.state.open,
+  (open) => {
+    if (!open) selectedMessageId.value = null;
+  },
+);
 
 const showModePrefix = computed(() => !!settings.effective('look.nick.show_mode_prefix'));
 
@@ -1839,11 +1855,20 @@ watch(
 .line:hover {
   background: var(--bg-soft);
 }
-/* Override only the alt-row background on hover — not its text color. The
-   `.line.alt` selector outweighs `.line:hover`, so the hover background needs
-   restating here, but the alt foreground (--alt-fg) stays put: hover is a
-   background-only cue and shouldn't shift the text color under the cursor. */
-.message-list:not(.compact) .line.alt:hover {
+/* The row whose action menu is open. Same background as hover, but authored
+   without `:hover` so it survives the build's hover gating (#115) and shows on
+   touch — where there's no hover, this is the only cue for which message the
+   menu targets (#392). On desktop it also keeps the row lit once the cursor
+   moves off it onto the menu. */
+.line.selected {
+  background: var(--bg-soft);
+}
+/* Override only the alt-row background on hover/selected — not its text color.
+   The `.line.alt` selector outweighs `.line:hover` / `.line.selected`, so the
+   background needs restating here, but the alt foreground (--alt-fg) stays put:
+   it's a background-only cue and shouldn't shift the text color. */
+.message-list:not(.compact) .line.alt:hover,
+.message-list:not(.compact) .line.alt.selected {
   background: var(--bg-soft);
 }
 

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -89,7 +89,6 @@
         class="line"
         :class="rowClass(row)"
         :data-msg-id="row.m?.id ?? null"
-        @contextmenu="onMessageMenu($event, row.m)"
         @click="onMessageRowClick($event, row.m)"
       >
         <template v-if="compactMode && row.m?.type === 'message'">
@@ -423,9 +422,10 @@ const actionItalic = computed(() => !!settings.effective('look.action.italic'));
 // Hover action bar toggle (#392). Off → the bar never renders (right-click / tap
 // menu still works). Always off on touch via the CSS reveal media query too.
 const hoverActions = computed(() => !!settings.effective('look.message.hover_actions'));
-// The message whose action menu is open — gives the row a `selected` background
-// so touch users (who get no hover) can see which message the menu targets, and
-// keeps it lit on desktop after the cursor leaves for the menu (#392).
+// The message whose tap-opened action menu is open (touch only — desktop uses
+// the hover bar + native right-click menu, never ours). Gives the row a
+// `selected` background so touch users, who get no hover, can see which message
+// the menu targets (#392). Cleared when the menu closes.
 const selectedMessageId = ref<number | null>(null);
 const selfColor = computed<string | null>(
   () => (settings.effective('look.nick.self_color') as string | undefined) ?? null,
@@ -647,24 +647,10 @@ function runAction(key: MessageActionKey, m: ChatMessage | undefined | null): vo
   messageActions.run(key, m as any, actionContext);
 }
 
-// Right-click → message action menu (#392). Desktop only: on touch we leave the
-// `contextmenu` long-press to the browser's native text-callout so message text
-// stays selectable, and reach the menu via tap instead (onMessageRowClick).
-function onMessageMenu(e: MouseEvent, m: ChatMessage | undefined | null): void {
-  if (!canHover.value) return;
-  if (!eligibleForActions(m)) return;
-  // Don't hijack right-click over a link — the native menu (open in new tab,
-  // copy link) is what's wanted there.
-  if ((e.target as Element | null)?.closest('a')) return;
-  e.preventDefault();
-  selectedMessageId.value = m?.id ?? null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  messageActions.openMenu(m as any, actionContext, e.clientX, e.clientY);
-}
-
 // Tap → message action menu on touch devices (#392), replacing the old
-// sticky-:hover two-tap. No-op on desktop, where a left-click shouldn't summon a
-// context menu (right-click does) — and where a tap is a real text click.
+// sticky-:hover two-tap. No-op on desktop, where the hover action bar is the
+// entry point and right-click is deliberately left to the browser's native menu
+// (desktop users expect that); a tap there is just a real text click.
 function onMessageRowClick(e: MouseEvent, m: ChatMessage | undefined | null): void {
   if (canHover.value) return;
   if (!eligibleForActions(m)) return;
@@ -1863,11 +1849,10 @@ watch(
 .line:hover {
   background: var(--bg-soft);
 }
-/* The row whose action menu is open. Same background as hover, but authored
-   without `:hover` so it survives the build's hover gating (#115) and shows on
-   touch — where there's no hover, this is the only cue for which message the
-   menu targets (#392). On desktop it also keeps the row lit once the cursor
-   moves off it onto the menu. */
+/* The row whose tap-opened action menu is open (touch). Same background as
+   hover, but authored without `:hover` so it survives the build's hover gating
+   (#115) and shows on touch — where there's no hover, this is the only cue for
+   which message the menu targets (#392). */
 .line.selected {
   background: var(--bg-soft);
 }

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -419,8 +419,9 @@ const nicks = useNickColors();
 const { isMobile, canHover } = useViewport();
 
 const actionItalic = computed(() => !!settings.effective('look.action.italic'));
-// Hover action bar toggle (#392). Off → the bar never renders (right-click / tap
-// menu still works). Always off on touch via the CSS reveal media query too.
+// Hover action bar toggle (#392). Off → the bar never renders and a left-click
+// on a message opens the action menu instead (onMessageRowClick). Always off on
+// touch via the CSS reveal media query, where tap opens the menu regardless.
 const hoverActions = computed(() => !!settings.effective('look.message.hover_actions'));
 // The message whose tap-opened action menu is open (touch only — desktop uses
 // the hover bar + native right-click menu, never ours). Gives the row a
@@ -647,16 +648,22 @@ function runAction(key: MessageActionKey, m: ChatMessage | undefined | null): vo
   messageActions.run(key, m as any, actionContext);
 }
 
-// Tap → message action menu on touch devices (#392), replacing the old
-// sticky-:hover two-tap. No-op on desktop, where the hover action bar is the
-// entry point and right-click is deliberately left to the browser's native menu
-// (desktop users expect that); a tap there is just a real text click.
+// Click/tap → message action menu (#392). The entry point whenever the hover
+// action bar isn't doing the job: always on touch (no hover), and on desktop
+// when the bar is toggled off — otherwise there'd be no way to reach the actions
+// there. When the bar IS on (desktop default), a left-click stays a plain text
+// click and the bar is the affordance. Right-click is always left to the
+// browser's native menu (desktop users expect that).
 function onMessageRowClick(e: MouseEvent, m: ChatMessage | undefined | null): void {
-  if (canHover.value) return;
+  if (canHover.value && hoverActions.value) return;
   if (!eligibleForActions(m)) return;
-  // Taps on a link follow the link; taps on a nick are handled by NickRef
+  // Clicks on a link follow the link; clicks on a nick are handled by NickRef
   // (which stops propagation), so they never reach here.
   if ((e.target as Element | null)?.closest('a')) return;
+  // Don't pop the menu out from under a text selection (drag-select on desktop,
+  // long-press select on touch) — let the user keep/copy their selection.
+  const sel = window.getSelection();
+  if (sel && !sel.isCollapsed) return;
   selectedMessageId.value = m?.id ?? null;
   // Pass the row as the trigger so a second tap on the same message toggles its
   // menu closed (matches the nick menu), instead of just reopening it.

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -84,7 +84,14 @@
           >
         </span>
       </div>
-      <div v-else class="line" :class="rowClass(row)" :data-msg-id="row.m?.id ?? null">
+      <div
+        v-else
+        class="line"
+        :class="rowClass(row)"
+        :data-msg-id="row.m?.id ?? null"
+        @contextmenu="onMessageMenu($event, row.m)"
+        @click="onMessageRowClick($event, row.m)"
+      >
         <template v-if="compactMode && row.m?.type === 'message'">
           <!-- Compact-mode message rows (IRCCloud-style): nick on its own
              head line above the body; body row carries the body and a
@@ -243,7 +250,7 @@
           </span>
         </template>
         <div
-          v-if="eligibleForActions(row.m)"
+          v-if="hoverActions && eligibleForActions(row.m)"
           class="row-actions"
           role="group"
           aria-label="Message actions"
@@ -410,9 +417,12 @@ const ignores = useIgnoresStore();
 const highlights = useHighlightRulesStore();
 const relayBots = useRelayBotsStore();
 const nicks = useNickColors();
-const { isMobile } = useViewport();
+const { isMobile, canHover } = useViewport();
 
 const actionItalic = computed(() => !!settings.effective('look.action.italic'));
+// Hover action bar toggle (#392). Off → the bar never renders (right-click / tap
+// menu still works). Always off on touch via the CSS reveal media query too.
+const hoverActions = computed(() => !!settings.effective('look.message.hover_actions'));
 const selfColor = computed<string | null>(
   () => (settings.effective('look.nick.self_color') as string | undefined) ?? null,
 );
@@ -630,6 +640,33 @@ function runAction(key: MessageActionKey, m: ChatMessage | undefined | null): vo
   if (!m) return;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   messageActions.run(key, m as any, actionContext);
+}
+
+// Right-click → message action menu (#392). Desktop only: on touch we leave the
+// `contextmenu` long-press to the browser's native text-callout so message text
+// stays selectable, and reach the menu via tap instead (onMessageRowClick).
+function onMessageMenu(e: MouseEvent, m: ChatMessage | undefined | null): void {
+  if (!canHover.value) return;
+  if (!eligibleForActions(m)) return;
+  // Don't hijack right-click over a link — the native menu (open in new tab,
+  // copy link) is what's wanted there.
+  if ((e.target as Element | null)?.closest('a')) return;
+  e.preventDefault();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  messageActions.openMenu(m as any, actionContext, e.clientX, e.clientY);
+}
+
+// Tap → message action menu on touch devices (#392), replacing the old
+// sticky-:hover two-tap. No-op on desktop, where a left-click shouldn't summon a
+// context menu (right-click does) — and where a tap is a real text click.
+function onMessageRowClick(e: MouseEvent, m: ChatMessage | undefined | null): void {
+  if (canHover.value) return;
+  if (!eligibleForActions(m)) return;
+  // Taps on a link follow the link; taps on a nick are handled by NickRef
+  // (which stops propagation), so they never reach here.
+  if ((e.target as Element | null)?.closest('a')) return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  messageActions.openMenu(m as any, actionContext, e.clientX, e.clientY);
 }
 
 // ─── Nick interactivity (#238) + mode-prefix glyph (#376) ──────────────────
@@ -1814,10 +1851,11 @@ watch(
    toolbar — same card treatment as the toast stack (bg + border + drop
    shadow) — anchored to the top-right of the line, floating just above it so
    the bar barely overlaps the top edge instead of covering the message text.
-   Mobile reaches it via the same sticky-:hover path the old kebab used: iOS
-   Safari's sticky :hover makes the first tap on a row reveal the bar, and a
-   second tap hits an action. Long-press is left to the browser's native
-   text-callout so users can still select message text. */
+   Desktop only: the reveal rule lives behind `(hover: hover) and (pointer:
+   fine)` (#392), so touch devices never show the bar nor trigger the old
+   sticky-:hover two-tap. Touch reaches the same actions by tapping a message
+   (and desktop by right-clicking) — see onMessageMenu/onMessageRowClick. The
+   bar itself can also be turned off entirely via look.message.hover_actions. */
 .row-actions {
   position: absolute;
   /* Sit the bar fully above the row, then nudge down a few px so its bottom
@@ -1838,10 +1876,18 @@ watch(
   pointer-events: none;
   z-index: var(--z-base);
 }
-.line:hover .row-actions,
+/* Keyboard a11y reveal stays unconditional so focus-within works everywhere. */
 .row-actions:focus-within {
   opacity: 1;
   pointer-events: auto;
+}
+/* Pointer reveal is desktop-only: no hover on touch, and gating it here keeps
+   the sticky-:hover two-tap from ever firing on phones/tablets (#392). */
+@media (hover: hover) and (pointer: fine) {
+  .line:hover .row-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 .row-action {
   background: none;

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -672,8 +672,16 @@ function onMessageRowClick(e: MouseEvent, m: ChatMessage | undefined | null): vo
   // (which stops propagation), so they never reach here.
   if ((e.target as Element | null)?.closest('a')) return;
   selectedMessageId.value = m?.id ?? null;
+  // Pass the row as the trigger so a second tap on the same message toggles its
+  // menu closed (matches the nick menu), instead of just reopening it.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  messageActions.openMenu(m as any, actionContext, e.clientX, e.clientY);
+  messageActions.openMenu(
+    m as any,
+    actionContext,
+    e.clientX,
+    e.clientY,
+    e.currentTarget as Element,
+  );
 }
 
 // ─── Nick interactivity (#238) + mode-prefix glyph (#376) ──────────────────

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -423,9 +423,9 @@ const actionItalic = computed(() => !!settings.effective('look.action.italic'));
 // on a message opens the action menu instead (onMessageRowClick). Always off on
 // touch via the CSS reveal media query, where tap opens the menu regardless.
 const hoverActions = computed(() => !!settings.effective('look.message.hover_actions'));
-// The message whose tap-opened action menu is open (touch only — desktop uses
-// the hover bar + native right-click menu, never ours). Gives the row a
-// `selected` background so touch users, who get no hover, can see which message
+// The message whose action menu is open — set when a tap (touch) or, with the
+// hover bar toggled off, a click (desktop) opens it (onMessageRowClick). Gives
+// the row a `selected` background so users with no hover can see which message
 // the menu targets (#392). Cleared when the menu closes.
 const selectedMessageId = ref<number | null>(null);
 const selfColor = computed<string | null>(
@@ -1878,9 +1878,10 @@ watch(
    the bar barely overlaps the top edge instead of covering the message text.
    Desktop only: the build wraps every `:hover` rule in `@media (hover: hover)`
    (#115), so on touch this reveal simply doesn't exist — the bar never shows
-   and the old sticky-:hover two-tap never fires. Touch reaches the same actions
-   by tapping a message (and desktop by right-clicking) — see onMessageMenu /
-   onMessageRowClick. The bar can also be turned off via look.message.hover_actions. */
+   and the old sticky-:hover two-tap never fires. When the bar is hidden (touch,
+   or toggled off on desktop), the same actions are reached by clicking/tapping a
+   message — see onMessageRowClick; right-click stays the native browser menu.
+   The bar can also be turned off via look.message.hover_actions. */
 .row-actions {
   position: absolute;
   /* Sit the bar fully above the row, then nudge down a few px so its bottom

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1851,11 +1851,11 @@ watch(
    toolbar — same card treatment as the toast stack (bg + border + drop
    shadow) — anchored to the top-right of the line, floating just above it so
    the bar barely overlaps the top edge instead of covering the message text.
-   Desktop only: the reveal rule lives behind `(hover: hover) and (pointer:
-   fine)` (#392), so touch devices never show the bar nor trigger the old
-   sticky-:hover two-tap. Touch reaches the same actions by tapping a message
-   (and desktop by right-clicking) — see onMessageMenu/onMessageRowClick. The
-   bar itself can also be turned off entirely via look.message.hover_actions. */
+   Desktop only: the build wraps every `:hover` rule in `@media (hover: hover)`
+   (#115), so on touch this reveal simply doesn't exist — the bar never shows
+   and the old sticky-:hover two-tap never fires. Touch reaches the same actions
+   by tapping a message (and desktop by right-clicking) — see onMessageMenu /
+   onMessageRowClick. The bar can also be turned off via look.message.hover_actions. */
 .row-actions {
   position: absolute;
   /* Sit the bar fully above the row, then nudge down a few px so its bottom
@@ -1876,18 +1876,16 @@ watch(
   pointer-events: none;
   z-index: var(--z-base);
 }
-/* Keyboard a11y reveal stays unconditional so focus-within works everywhere. */
+/* Keyboard a11y reveal stays unconditional so focus-within works everywhere.
+   The hover reveal below is authored plain; the build gates it behind
+   `@media (hover: hover)` (#115) so it never fires on touch. */
 .row-actions:focus-within {
   opacity: 1;
   pointer-events: auto;
 }
-/* Pointer reveal is desktop-only: no hover on touch, and gating it here keeps
-   the sticky-:hover two-tap from ever firing on phones/tablets (#392). */
-@media (hover: hover) and (pointer: fine) {
-  .line:hover .row-actions {
-    opacity: 1;
-    pointer-events: auto;
-  }
+.line:hover .row-actions {
+  opacity: 1;
+  pointer-events: auto;
 }
 .row-action {
   background: none;

--- a/vue_client/src/composables/useMessageActions.test.ts
+++ b/vue_client/src/composables/useMessageActions.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useMessageActions, type MessageContext, type MessageLike } from './useMessageActions.js';
+import { useContextMenu } from './useContextMenu.js';
+import { useBookmarksStore } from '../stores/bookmarks.js';
+
+function makeCtx(): MessageContext {
+  return {
+    networkId: 1,
+    onReply: vi.fn<(message: MessageLike) => void>(),
+    onIgnore: vi.fn<(message: MessageLike) => void>(),
+  };
+}
+
+// A message from someone else, with text and a stable id — the case that yields
+// the full action set. Override individual fields per case.
+function other(over: Partial<MessageLike> = {}): MessageLike {
+  return { id: 42, nick: 'bob', text: 'hi', self: false, ...over };
+}
+
+describe('useMessageActions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    // The context menu is a module-level singleton — reset between cases.
+    useContextMenu().close();
+  });
+
+  describe('buildActions', () => {
+    it('returns reply, copy, save, ignore for another user with text + id', () => {
+      const actions = useMessageActions().buildActions(other());
+      expect(actions.map((a) => a.key)).toEqual(['reply', 'copy', 'save', 'ignore']);
+    });
+
+    it('drops reply + ignore on your own line', () => {
+      const actions = useMessageActions().buildActions(other({ self: true }));
+      expect(actions.map((a) => a.key)).toEqual(['copy', 'save']);
+    });
+
+    it('drops copy when there is no text', () => {
+      const actions = useMessageActions().buildActions(other({ text: '' }));
+      expect(actions.map((a) => a.key)).toEqual(['reply', 'save', 'ignore']);
+    });
+
+    it('drops save when there is no stable id', () => {
+      const actions = useMessageActions().buildActions(other({ id: null }));
+      expect(actions.map((a) => a.key)).toEqual(['reply', 'copy', 'ignore']);
+    });
+
+    it('reflects a saved bookmark in the save label, icon, and active flag', () => {
+      useBookmarksStore().applySnapshot([42]);
+      const save = useMessageActions()
+        .buildActions(other())
+        .find((a) => a.key === 'save');
+      expect(save?.label).toBe('Remove bookmark');
+      expect(save?.icon).toBe('fa-solid fa-bookmark');
+      expect(save?.active).toBe(true);
+    });
+
+    it('returns nothing for a null message', () => {
+      expect(useMessageActions().buildActions(null)).toEqual([]);
+    });
+  });
+
+  describe('buildItems parity', () => {
+    it('matches buildActions label + icon, in the same order', () => {
+      const api = useMessageActions();
+      const m = other();
+      const actions = api.buildActions(m);
+      const items = api.buildItems(m, makeCtx());
+      expect(items.map((i) => i.label)).toEqual(actions.map((a) => a.label));
+      expect(items.map((i) => i.icon)).toEqual(actions.map((a) => a.icon));
+    });
+
+    it('reply item dispatches onReply through run()', () => {
+      const api = useMessageActions();
+      const ctx = makeCtx();
+      const m = other();
+      const reply = api.buildItems(m, ctx).find((i) => i.icon?.includes('fa-reply'));
+      reply?.onClick?.();
+      expect(ctx.onReply).toHaveBeenCalledWith(m);
+    });
+
+    it('ignore item dispatches onIgnore through run()', () => {
+      const api = useMessageActions();
+      const ctx = makeCtx();
+      const m = other();
+      const ignore = api.buildItems(m, ctx).find((i) => i.icon?.includes('fa-ban'));
+      ignore?.onClick?.();
+      expect(ctx.onIgnore).toHaveBeenCalledWith(m);
+    });
+
+    it('save item toggles the bookmark store through run()', () => {
+      const api = useMessageActions();
+      const toggle = vi.spyOn(useBookmarksStore(), 'toggle');
+      const m = other();
+      const save = api.buildItems(m, makeCtx()).find((i) => i.icon?.includes('fa-bookmark'));
+      save?.onClick?.();
+      expect(toggle).toHaveBeenCalledWith(m);
+    });
+  });
+
+  describe('openMenu', () => {
+    it('opens the shared context menu with the items at the given point', () => {
+      const api = useMessageActions();
+      const menu = useContextMenu();
+      api.openMenu(other(), makeCtx(), 12, 34);
+      expect(menu.state.open).toBe(true);
+      expect(menu.state.x).toBe(12);
+      expect(menu.state.y).toBe(34);
+      expect(menu.state.items.length).toBe(4);
+    });
+
+    it('no-ops for a null message', () => {
+      const api = useMessageActions();
+      const menu = useContextMenu();
+      api.openMenu(null, makeCtx(), 1, 2);
+      expect(menu.state.open).toBe(false);
+    });
+  });
+});

--- a/vue_client/src/composables/useMessageActions.ts
+++ b/vue_client/src/composables/useMessageActions.ts
@@ -1,7 +1,9 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import type { ContextMenuItem } from './useContextMenu.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
+import { useContextMenu } from './useContextMenu.js';
 
 export interface MessageLike {
   id?: number | null;
@@ -34,6 +36,17 @@ export interface MessageAction {
 export interface MessageActionsAPI {
   buildActions(message: MessageLike | null | undefined): MessageAction[];
   run(key: MessageActionKey, message: MessageLike, ctx: MessageContext): void;
+  // The same actions rendered as ContextMenuItem[] for the right-click / tap
+  // menu (#392). Derived from buildActions so the bar and the menu can't drift.
+  buildItems(message: MessageLike | null | undefined, ctx: MessageContext): ContextMenuItem[];
+  // Open the shared context menu at a viewport point for this message.
+  openMenu(
+    message: MessageLike | null | undefined,
+    ctx: MessageContext,
+    x: number,
+    y: number,
+    triggerEl?: Element | null,
+  ): void;
 }
 
 // Single source of truth for the per-message actions rendered as the hover
@@ -50,6 +63,7 @@ export interface MessageActionsAPI {
 // `context` shape: { networkId, onReply(message), onIgnore(message) }
 export function useMessageActions(): MessageActionsAPI {
   const bookmarks = useBookmarksStore();
+  const menu = useContextMenu();
 
   function buildActions(message: MessageLike | null | undefined): MessageAction[] {
     if (!message) return [];
@@ -104,5 +118,33 @@ export function useMessageActions(): MessageActionsAPI {
     }
   }
 
-  return { buildActions, run };
+  // Map the descriptor list to context-menu items. Each item dispatches back
+  // through run() with the caller's context, so the menu shares the bar's exact
+  // side effects (reply hand-off, clipboard, bookmark toggle, ignore modal).
+  function buildItems(
+    message: MessageLike | null | undefined,
+    ctx: MessageContext,
+  ): ContextMenuItem[] {
+    if (!message) return [];
+    return buildActions(message).map((a) => ({
+      label: a.label,
+      icon: a.icon,
+      onClick: () => run(a.key, message, ctx),
+    }));
+  }
+
+  function openMenu(
+    message: MessageLike | null | undefined,
+    ctx: MessageContext,
+    x: number,
+    y: number,
+    triggerEl: Element | null = null,
+  ): void {
+    if (!message) return;
+    const items = buildItems(message, ctx);
+    if (items.length === 0) return;
+    menu.open(items, x, y, triggerEl);
+  }
+
+  return { buildActions, run, buildItems, openMenu };
 }

--- a/vue_client/src/composables/useViewport.ts
+++ b/vue_client/src/composables/useViewport.ts
@@ -8,16 +8,25 @@ import { ref } from 'vue';
 // grid, so anything below ~720px gets squeezed beyond repair. 768px is a
 // conventional tablet-portrait threshold and gives a comfortable margin.
 const MOBILE_QUERY = '(max-width: 768px)';
+// Input-capability query: a device whose primary pointer can hover and is fine
+// (a mouse/trackpad), i.e. desktop. Touch devices report `hover: none` /
+// `pointer: coarse` and fail this — including iPad in landscape, which is wider
+// than the mobile breakpoint but still has no hover. Drives the desktop-vs-touch
+// split for hover affordances and the message context menu (#392).
+const HOVER_QUERY = '(hover: hover) and (pointer: fine)';
 
-// One shared MediaQueryList — cheaper than per-component listeners and means
-// every consumer flips at the exact same moment when the viewport crosses
+// One shared MediaQueryList per query — cheaper than per-component listeners and
+// means every consumer flips at the exact same moment when the viewport crosses
 // the breakpoint.
 let mql: MediaQueryList | null = null;
+let hoverMql: MediaQueryList | null = null;
 const isMobile = ref(false);
+const canHover = ref(false);
 let initialized = false;
 
 export interface ViewportState {
   isMobile: Ref<boolean>;
+  canHover: Ref<boolean>;
 }
 
 function ensureInit(): void {
@@ -25,16 +34,24 @@ function ensureInit(): void {
   initialized = true;
   mql = window.matchMedia(MOBILE_QUERY);
   isMobile.value = mql.matches;
+  hoverMql = window.matchMedia(HOVER_QUERY);
+  canHover.value = hoverMql.matches;
   // addEventListener is the modern path; older Safari needs addListener.
   if (mql.addEventListener) mql.addEventListener('change', onChange);
   else (mql as any).addListener(onChange);
+  if (hoverMql.addEventListener) hoverMql.addEventListener('change', onHoverChange);
+  else (hoverMql as any).addListener(onHoverChange);
 }
 
 function onChange(e: MediaQueryListEvent): void {
   isMobile.value = e.matches;
 }
 
+function onHoverChange(e: MediaQueryListEvent): void {
+  canHover.value = e.matches;
+}
+
 export function useViewport(): ViewportState {
   ensureInit();
-  return { isMobile };
+  return { isMobile, canHover };
 }

--- a/vue_client/src/composables/useViewport.ts
+++ b/vue_client/src/composables/useViewport.ts
@@ -8,12 +8,13 @@ import { ref } from 'vue';
 // grid, so anything below ~720px gets squeezed beyond repair. 768px is a
 // conventional tablet-portrait threshold and gives a comfortable margin.
 const MOBILE_QUERY = '(max-width: 768px)';
-// Input-capability query: a device whose primary pointer can hover and is fine
-// (a mouse/trackpad), i.e. desktop. Touch devices report `hover: none` /
-// `pointer: coarse` and fail this — including iPad in landscape, which is wider
-// than the mobile breakpoint but still has no hover. Drives the desktop-vs-touch
-// split for hover affordances and the message context menu (#392).
-const HOVER_QUERY = '(hover: hover) and (pointer: fine)';
+// Input-capability query: the primary pointer can hover, i.e. a desktop
+// mouse/trackpad. Touch devices report `hover: none` and fail this — including
+// iPad in landscape, which is wider than the mobile breakpoint but still has no
+// hover. Drives the desktop-vs-touch split for the message context menu (#392),
+// and is kept identical to the `@media (hover: hover)` the build wraps every
+// hover rule in (#115) so CSS hover-visibility and JS interaction routing agree.
+const HOVER_QUERY = '(hover: hover)';
 
 // One shared MediaQueryList per query — cheaper than per-component listeners and
 // means every consumer flips at the exact same moment when the viewport crosses


### PR DESCRIPTION
Closes #392. Closes #115.

## What & why

Replaces the message-list hover action bar as the *sole* way to act on a message, and fixes the app-wide iOS sticky-hover problem that made it (and much else) feel broken on touch.

### #392 — message context menu + toggleable bar
- The four actions (Reply, Copy, Save/bookmark, Ignore) are now reachable as a **context menu**, not just the hover bar. Single source of truth: the menu is *derived* from the same descriptors as the bar (`useMessageActions.buildItems`/`openMenu`), so they can't drift.
- The hover bar is now **toggleable** via a new setting `look.message.hover_actions` (default **on**), surfaced in Settings → Appearance and `/set`.

**Interaction model:**

| | Bar **on** (default) | Bar **off** |
|---|---|---|
| **Desktop** | hover → action bar; right-click = **native** browser menu | **left-click → action menu**; right-click = native menu |
| **Touch** | (bar hidden) tap → action menu | tap → action menu |

- Right-click is **deliberately left to the browser's native menu** over message text — hijacking it is a common desktop annoyance.
- The tapped/clicked message gets a `selected` highlight while its menu is open (the only "which message?" cue on touch, where there's no hover). Cleared on close.
- Second tap/click on the same message toggles the menu closed (matches the nick menu).
- An active text selection is never clobbered by the click-to-open path.

### #115 — gate hover styles app-wide for touch
iOS Safari simulates `:hover` on first tap (two-tap-to-click) and leaves it stuck after a scroll. Buttons, links, and message rows all had this.

- Added `postcss-hover-media-feature` (`vue_client/postcss.config.js`) to wrap **every** `:hover` rule in `@media (hover: hover)` at build time — `assets/main.css` + every SFC `<style>`, **84 hover selectors, all gated**, with zero per-rule churn and future hovers gated automatically.
- The plugin splits mixed selector lists, so `.active` / `:focus` / `:focus-visible` sharing a rule stay ungated and keep working on touch (verified in the built CSS).
- `useViewport().canHover` uses the same `(hover: hover)` query so CSS hover-visibility and JS interaction routing share one breakpoint.

## Test plan
- `npm run check` ✅ · `npm test` ✅ (1719 tests, incl. new `useMessageActions.test.ts`)
- Built CSS audited: 84 hover selectors / 0 ungated / 0 non-hover mis-gated.
- Manual (desktop): hover bar + actions; toggle off → click a message opens the menu; right-click → native menu; right-click a link → native link menu.
- Manual (mobile/iOS): no stuck hover on scroll; single-tap a message → menu; second tap closes it; long-press still selects text; selected row highlights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)