### PR TITLE
Route notices to their natural buffer, not the server buffer (#439)

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -165,6 +165,7 @@ export const EXPORT_TABLES = Object.freeze({
       'matched_rule_id',
       'alt',
       'from_ignored',
+      'mirrored',
     ],
   },
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -853,6 +853,12 @@ ensureColumn('messages', 'alt', 'INTEGER NOT NULL DEFAULT 0');
 // they remain visible/countable, matching pre-fix behavior.
 ensureColumn('messages', 'from_ignored', 'INTEGER NOT NULL DEFAULT 0');
 
+// Marks a server-buffer copy of a closed-buffer NOTICE (#439). The real copy
+// lives in the sender's buffer; this duplicate is surfaced in the server buffer
+// so a notice to a closed buffer isn't invisible. Excluded from search so it
+// doesn't double up its real copy. Old rows default to 0 (not a mirror).
+ensureColumn('messages', 'mirrored', 'INTEGER NOT NULL DEFAULT 0');
+
 // Per-(user, buffer) /clear marker. cleared_before_message_id is the highest
 // message id hidden from the live view; messages with id > it remain visible.
 // cleared_at is the wall-clock time the user issued /clear (shown in the

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -19,6 +19,7 @@ let countNewer: typeof import('./messages.js').countNewer;
 let countHighlightsNewer: typeof import('./messages.js').countHighlightsNewer;
 let listUserHighlights: typeof import('./messages.js').listUserHighlights;
 let maxIdForBuffer: typeof import('./messages.js').maxIdForBuffer;
+let hasConversationForTarget: typeof import('./messages.js').hasConversationForTarget;
 
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
@@ -32,6 +33,7 @@ beforeAll(async () => {
     countHighlightsNewer,
     listUserHighlights,
     maxIdForBuffer,
+    hasConversationForTarget,
   } = await import('./messages.js'));
 });
 
@@ -67,6 +69,30 @@ function event(networkId: number, target: string, type: string, nick: string | n
 function altsFor(networkId: number, target: string) {
   return listMessages(networkId, target, { limit: 1000 }).map((m) => m.alt);
 }
+
+describe('hasConversationForTarget (#439)', () => {
+  it('is true only when a non-notice message exists for the target', () => {
+    const user = createUser('conv-target');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'conv-target',
+    });
+    // Notice-only buffer (a service) → not a conversation.
+    chat(net!.id, 'NickServ', 'NickServ', 'you are now identified', 'notice');
+    expect(hasConversationForTarget(net!.id, 'NickServ')).toBe(false);
+    // A real PRIVMSG promotes it to a conversation; an ACTION counts too.
+    chat(net!.id, 'bob', 'bob', 'hey there');
+    expect(hasConversationForTarget(net!.id, 'bob')).toBe(true);
+    chat(net!.id, 'carol', 'carol', 'waves', 'action');
+    expect(hasConversationForTarget(net!.id, 'carol')).toBe(true);
+    // Case-insensitive match; unknown target is false.
+    expect(hasConversationForTarget(net!.id, 'BOB')).toBe(true);
+    expect(hasConversationForTarget(net!.id, 'nobody')).toBe(false);
+  });
+});
 
 describe('messages.alt parity', () => {
   it('alternates alt for chat-shaped types within a buffer', () => {
@@ -148,6 +174,41 @@ describe('messages.alt parity', () => {
 });
 
 describe('searchMessages', () => {
+  it('excludes mirrored server-buffer copies but keeps the real copy (#439)', () => {
+    const user = createUser('search-mirror');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'search-mirror',
+    });
+    // The real copy in the sender's (closed) buffer, plus the mirrored duplicate
+    // in the server buffer — same text. Search must return only the real one.
+    insertMessage({
+      networkId: net!.id,
+      target: 'NickServ',
+      time: new Date().toISOString(),
+      type: 'notice',
+      nick: 'NickServ',
+      text: 'your unique-cloak-token is set',
+      self: false,
+    });
+    insertMessage({
+      networkId: net!.id,
+      target: `:server:${net!.id}`,
+      time: new Date().toISOString(),
+      type: 'notice',
+      nick: 'NickServ',
+      text: 'your unique-cloak-token is set',
+      self: false,
+      mirrored: true,
+    });
+    const hits = searchMessages(user.id, { query: 'unique-cloak-token' });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].target).toBe('NickServ');
+  });
+
   it('matches free text against message bodies', () => {
     const user = createUser('search-text');
     const net = createNetwork(user.id, {

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -19,6 +19,7 @@ interface MessageRow {
   alt: number;
   matched_rule_id: number | null;
   from_ignored: number;
+  mirrored: number;
 }
 
 /** A raw message row joined with network_name. */
@@ -42,6 +43,9 @@ export interface MessageEvent {
   matched: boolean;
   matchedRuleId: number | null;
   fromIgnored: boolean;
+  // A duplicate of a closed-buffer NOTICE surfaced in the server buffer (#439).
+  // Excluded from search/highlights so it doesn't double up its real copy.
+  mirrored: boolean;
   [key: string]: unknown;
 }
 
@@ -65,6 +69,7 @@ export interface MessageInput {
   matchedRuleId?: number | null;
   userhost?: string | null;
   fromIgnored?: boolean;
+  mirrored?: boolean;
 }
 
 /** Buffer summary row for MCP list_buffers. */
@@ -85,9 +90,9 @@ export interface MaxIdByBufferRow {
 // Non-striped types pass through with alt=0; the value is meaningless for them
 // and the client never reads it.
 const insertStmt = db.prepare(`
-  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, alt)
+  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, mirrored, alt)
   VALUES (
-    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored,
+    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored, @mirrored,
     CASE WHEN @type IN ('message', 'action', 'notice')
          THEN 1 - COALESCE(
            (SELECT alt FROM messages
@@ -116,6 +121,7 @@ export function insertMessage(row: MessageInput): { id: number | bigint; alt: bo
     matchedRuleId: row.matchedRuleId ?? null,
     userhost: row.userhost ?? null,
     fromIgnored: row.fromIgnored ? 1 : 0,
+    mirrored: row.mirrored ? 1 : 0,
   });
   const id = result.lastInsertRowid;
   const altRow = altByIdStmt.get(id) as { alt: number } | undefined;
@@ -138,6 +144,7 @@ function rowToEvent(row: MessageRow): MessageEvent {
     matched: row.matched_rule_id != null,
     matchedRuleId: row.matched_rule_id,
     fromIgnored: row.from_ignored === 1,
+    mirrored: row.mirrored === 1,
   };
   if (row.extra) {
     try {
@@ -297,6 +304,20 @@ export function hasMessageForTarget(networkId: number, target: string): boolean 
   return !!row;
 }
 
+// Whether a target has a real (non-notice) conversation — at least one PRIVMSG or
+// ACTION. NOTICE-only buffers (services like NickServ/ChanServ, which now get a
+// buffer of their own, #439) are NOT conversations: presence-tracking keys off
+// this so services don't consume MONITOR slots or show a presence dot.
+export function hasConversationForTarget(networkId: number, target: string): boolean {
+  if (!networkId || !target) return false;
+  const row = db
+    .prepare(
+      "SELECT 1 FROM messages WHERE network_id = ? AND target = ? COLLATE NOCASE AND type IN ('message', 'action') LIMIT 1",
+    )
+    .get(networkId, target);
+  return !!row;
+}
+
 export function countOlder(networkId: number, target: string, beforeId: number): number {
   return (
     db
@@ -438,6 +459,11 @@ export function searchMessages(
     'n.user_id = ?',
     `m.type IN ${COUNTABLE_TYPES_SQL}`,
     'm.from_ignored = 0',
+    // Skip server-buffer mirror duplicates of closed-buffer NOTICEs (#439) so a
+    // mirrored notice doesn't surface twice — its real copy in the sender's
+    // buffer is the searchable one. Genuine server-buffer notices (mirrored = 0)
+    // stay searchable.
+    'm.mirrored = 0',
   ];
   const params: (string | number)[] = [userId];
 

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -576,6 +576,81 @@ describe('importFromZipBuffer — roundtrip', () => {
     expect(msg).toBeDefined();
   });
 
+  it('imports a pre-#439 archive whose messages omit the mirrored column', async () => {
+    // A backup taken before messages.mirrored existed has no `mirrored` key in
+    // messages.ndjson. mirrored is NOT NULL DEFAULT 0, but a column default does
+    // NOT apply when the importer binds an explicit NULL for a missing key — so
+    // without the import-side fallback the insert fails with a NOT NULL
+    // constraint and aborts the entire restore.
+    const { alice } = seedAlice();
+    const buf = await exportToBuffer(alice.id, { includeMessages: true });
+    const yauzl = await import('yauzl');
+    const { ZipArchive } = await import('archiver');
+
+    const entries = await new Promise<Map<string, Buffer>>((resolve, reject) => {
+      yauzl.fromBuffer(buf, { lazyEntries: true }, (err, zip) => {
+        if (err) return reject(err);
+        const out = new Map<string, Buffer>();
+        zip.readEntry();
+        zip.on('entry', (entry) => {
+          if (entry.fileName.endsWith('/')) {
+            zip.readEntry();
+            return;
+          }
+          zip.openReadStream(entry, (e2, stream) => {
+            if (e2) return reject(e2);
+            const chunks: Buffer[] = [];
+            stream.on('data', (c: Buffer) => chunks.push(c));
+            stream.on('end', () => {
+              out.set(entry.fileName, Buffer.concat(chunks));
+              zip.readEntry();
+            });
+            stream.on('error', reject);
+          });
+        });
+        zip.on('end', () => resolve(out));
+        zip.on('error', reject);
+      });
+    });
+
+    // Strip `mirrored` from every messages row to mimic a pre-#439 archive.
+    const msgsKey = [...entries.keys()].find((k) => k.endsWith('messages.ndjson'));
+    expect(msgsKey).toBeDefined();
+    const stripped = entries
+      .get(msgsKey!)!
+      .toString('utf8')
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => {
+        const row = JSON.parse(l);
+        delete row.mirrored;
+        return JSON.stringify(row);
+      })
+      .join('\n');
+    entries.set(msgsKey!, Buffer.from(stripped + '\n'));
+
+    const archive = new ZipArchive();
+    const rebuiltChunks: Buffer[] = [];
+    archive.on('data', (c: Buffer) => rebuiltChunks.push(c));
+    for (const [name, content] of entries) archive.append(content, { name });
+    await archive.finalize();
+    const rebuilt = Buffer.concat(rebuiltChunks);
+
+    const olive = createUser(
+      `olive_mirror_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    );
+    await importFromZipBuffer(olive.id, rebuilt);
+
+    // Restore succeeds and the messages land with mirrored defaulted to 0.
+    const rows = db
+      .prepare(
+        'SELECT m.mirrored FROM messages m JOIN networks n ON n.id = m.network_id WHERE n.user_id = ?',
+      )
+      .all(olive.id) as Array<{ mirrored: number }>;
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((r) => r.mirrored === 0)).toBe(true);
+  });
+
   it('rejects an archive without a manifest', async () => {
     createUser(`eve_${Date.now()}`);
     // A zip with only an unrelated file.

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -282,6 +282,9 @@ async function streamMessagesInBatches(
       // from_ignored was added later; older archives omit it and the column is
       // NOT NULL, so a missing key would fail the insert.
       if (row.from_ignored === undefined) row.from_ignored = 0;
+      // mirrored (#439) was added later too — same NOT NULL fallback so a
+      // pre-#439 archive (no `mirrored` key) doesn't fail the insert.
+      if (row.mirrored === undefined) row.mirrored = 0;
       const result = insertOne(stmt, cols, row);
       messagesMap.set(original.id, result.lastInsertRowid);
       inserted += 1;

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -21,6 +21,7 @@ import {
   isServerBufferDeniedNumeric,
   joinRejectionMessage,
   joinRejectionMessageByTag,
+  resolveChannelContext,
   sendRejectionTargetKind,
   sendRejectionText,
   outgoingAddr,
@@ -296,6 +297,61 @@ describe('canonicalChannelTarget (#268)', () => {
     expect(canonicalChannelTarget('SomeNick', channels)).toBe('SomeNick');
     expect(canonicalChannelTarget(':server:7', channels)).toBe(':server:7');
     expect(canonicalChannelTarget(undefined, channels)).toBeUndefined();
+  });
+});
+
+describe('resolveChannelContext (#439)', () => {
+  // Joined set: keyed lowercase, .name holds the case we joined with.
+  const channels = new Map([['#christian', { name: '#Christian' }]]);
+
+  it('redirects via the +draft/channel-context tag to the joined channel (canonical case)', () => {
+    expect(
+      resolveChannelContext({ '+draft/channel-context': '#CHRISTIAN' }, 'hello', channels),
+    ).toBe('#Christian');
+  });
+
+  it('redirects via a leading [#chan] body prefix, tolerating (), <>, {}', () => {
+    expect(resolveChannelContext(undefined, '[#christian] welcome', channels)).toBe('#Christian');
+    expect(resolveChannelContext(undefined, '(#christian) hi', channels)).toBe('#Christian');
+    expect(resolveChannelContext(undefined, '<#christian> hi', channels)).toBe('#Christian');
+    expect(resolveChannelContext(undefined, '{#christian} hi', channels)).toBe('#Christian');
+  });
+
+  it('prefers the tag over a conflicting body prefix', () => {
+    // Body names a channel we are NOT in; the tag names one we are — tag wins.
+    expect(
+      resolveChannelContext({ '+draft/channel-context': '#christian' }, '[#elsewhere] x', channels),
+    ).toBe('#Christian');
+  });
+
+  it('returns null when the referenced channel is not joined (no buffer fabrication)', () => {
+    expect(resolveChannelContext({ '+draft/channel-context': '#elsewhere' }, 'x', channels)).toBe(
+      null,
+    );
+    expect(resolveChannelContext(undefined, '[#elsewhere] x', channels)).toBe(null);
+  });
+
+  it('returns null when there is no usable context', () => {
+    expect(resolveChannelContext(undefined, 'just a normal notice', channels)).toBe(null);
+    expect(resolveChannelContext(undefined, 'a [#christian] mid-line mention', channels)).toBe(
+      null,
+    );
+    expect(resolveChannelContext({}, undefined, channels)).toBe(null);
+    // A bracketed token without a channel sigil is not a context prefix.
+    expect(resolveChannelContext(undefined, '[info] something', channels)).toBe(null);
+  });
+
+  it('only resolves `#` channels, not `&`/`!`/`+` (matches Lurker routing)', () => {
+    // Even when "joined" to a non-# channel, channel-context must not redirect to
+    // it — Lurker routes `&`/`!`/`+` targets as non-channels.
+    const withLocal = new Map([
+      ['#christian', { name: '#Christian' }],
+      ['&local', { name: '&local' }],
+    ]);
+    expect(resolveChannelContext({ '+draft/channel-context': '&local' }, 'x', withLocal)).toBe(
+      null,
+    );
+    expect(resolveChannelContext(undefined, '[&local] hi', withLocal)).toBe(null);
   });
 });
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3,7 +3,12 @@
 
 import IRC, { ircLineParser } from 'irc-framework';
 import type { Client as IrcClient } from 'irc-framework';
-import { insertMessage, hasMessageForTarget, listBufferTargets } from '../db/messages.js';
+import {
+  insertMessage,
+  hasMessageForTarget,
+  hasConversationForTarget,
+  listBufferTargets,
+} from '../db/messages.js';
 import type { Network } from '../db/networks.js';
 import { upsertChannel } from '../db/networks.js';
 import { isClosed as isBufferClosed } from '../db/closedBuffers.js';
@@ -172,6 +177,10 @@ interface EnrichedEvent extends IrcEvent {
   alt?: boolean;
   matched?: boolean;
   matchedRuleId?: number | null;
+  // Hide-level ignore verdict, stamped at persist time. Callers that surface a
+  // secondary copy of the event (e.g. the closed-buffer NOTICE mirror) read this
+  // so they don't leak an ignored sender's text past the ignore filter (#439).
+  fromIgnored?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -490,7 +499,11 @@ export class IrcConnection {
     return { ...event, target };
   }
 
-  publish(event: IrcEvent): void {
+  // Returns the enriched, persisted event so callers can read server-stamped
+  // fields (e.g. the `fromIgnored` verdict the closed-buffer NOTICE mirror needs).
+  // Typed `| void` rather than `| undefined` so the many `() => void` test spies
+  // that stand in for publish stay assignable.
+  publish(event: IrcEvent): EnrichedEvent | void {
     if (this.disposed) return;
     event = this.normalizeChannelTarget(event);
     const time = (event.time as string | undefined) || new Date().toISOString();
@@ -543,14 +556,17 @@ export class IrcConnection {
         matchedRuleId,
         userhost: (event.userhost as string | null | undefined) ?? null,
         fromIgnored,
+        mirrored: event.mirrored as boolean | undefined,
       });
       enriched.id = id;
       enriched.alt = alt;
       enriched.matched = matchedRuleId != null;
       enriched.matchedRuleId = matchedRuleId;
+      enriched.fromIgnored = fromIgnored;
     }
 
     this.onEvent(enriched);
+    return enriched;
   }
 
   publishEphemeral(event: IrcEvent): void {
@@ -723,6 +739,10 @@ export class IrcConnection {
         for (const target of listBufferTargets(this.network.id)) {
           if (!isDmTargetName(target)) continue;
           if (isBufferClosed(this.network.user_id, this.network.id, target)) continue;
+          // A notice-only buffer (NickServ/ChanServ, #439) is not a real DM —
+          // don't seed it into MONITOR or it consumes presence slots and shows a
+          // bogus presence dot for a service. Track only actual conversations.
+          if (!hasConversationForTarget(this.network.id, target)) continue;
           this.addPeerReason(target.toLowerCase(), 'dm', null);
         }
       } catch (e) {
@@ -1145,25 +1165,41 @@ export class IrcConnection {
       if (isServer) target = `:server:${this.network.id}`;
       else if (targetIsChannel) target = eventTarget;
       else if (isNotice) {
-        // NOTICE routing: keep replies inside an active conversation if the
-        // user has one open (e.g. they /msg'd ChanServ and ChanServ is
-        // NOTICE'ing back — those belong in the ChanServ buffer), but route
-        // unsolicited NOTICEs (NickServ cloak alert on connect, server-wide
-        // wallops, oper notices) to the server buffer the way IRCCloud and
-        // most modern clients do. "Active" = there's history for that
-        // target on this network AND the user hasn't explicitly closed it.
-        // IRC nicks are case-insensitive at the protocol layer but the DB
-        // stores whatever case the buffer was created with, so match
-        // case-insensitively and use the persisted casing as the routing
-        // target so we don't accidentally split history across "ChanServ"
-        // and "chanserv".
-        const dmLower = (eventNick as string).toLowerCase();
-        const existingTarget = listBufferTargets(this.network.id).find(
-          (t) => t.toLowerCase() === dmLower,
+        // A NOTICE addressed to us persists to the sender's buffer (its natural
+        // home), like a PRIVMSG — so the buffer surfaces on first notice and the
+        // history lives in the right place. Open/closed is a client display
+        // concern: the wsHub fan-out drops live delivery to a buffer the user has
+        // closed (closed stays closed — a notice never reopens it, see
+        // DM_ELIGIBLE_TYPES), and the closed-buffer mirror below persists a
+        // durable copy in the server buffer so the notice isn't lost.
+        //   - EXCEPTION 1: a channel-context hint (the IRCv3 +draft/channel-context
+        //     tag, or a leading "[#chan]" body prefix) for a channel we're in
+        //     routes the notice to that channel.
+        //   - EXCEPTION 2: a notice NOT addressed to our nick (e.g. to an `&`/`!`/`+`
+        //     local channel, which Lurker routes as a non-channel, or a STATUSMSG
+        //     target) has no DM home — surface it in the server buffer rather than
+        //     fabricating a bogus DM with the sender.
+        const ctx = resolveChannelContext(
+          event.tags as Record<string, string> | undefined,
+          eventMessage,
+          this.channels,
         );
-        const hasOpenDm =
-          existingTarget && !isBufferClosed(this.network.user_id, this.network.id, existingTarget);
-        target = hasOpenDm ? existingTarget : `:server:${this.network.id}`;
+        if (ctx) {
+          target = ctx;
+        } else if (
+          eventTarget &&
+          this.currentNick &&
+          eventTarget.toLowerCase() === this.currentNick.toLowerCase()
+        ) {
+          // Fold to an existing buffer's casing so a reply sourced as "ChanServ"
+          // doesn't fork history from a "chanserv" buffer the user started (#289).
+          const nickLower = (eventNick as string).toLowerCase();
+          target =
+            listBufferTargets(this.network.id).find((t) => t.toLowerCase() === nickLower) ??
+            (eventNick as string);
+        } else {
+          target = `:server:${this.network.id}`;
+        }
       } else target = eventNick as string;
 
       const type =
@@ -1234,7 +1270,7 @@ export class IrcConnection {
         }
       }
 
-      this.publish({
+      const published = this.publish({
         type,
         target,
         nick,
@@ -1243,12 +1279,42 @@ export class IrcConnection {
         self: false,
         userhost: buildUserhost(event),
         ...(e2eFlag ? { e2e: true } : {}),
-      });
+      }) as EnrichedEvent | undefined;
+      // If a notice's home buffer is one the user has closed, the wsHub fan-out
+      // drops its live delivery — so without this the notice would be invisible
+      // until the buffer is reopened. Persist a SECOND copy in the server buffer
+      // (a durable mirror, not a transient emit) so it's visible there for every
+      // client, including one that was offline when it arrived — an ephemeral copy
+      // would never reach a reconnecting or mobile client. The real copy still
+      // lives in the closed home buffer for when it's reopened; `:server:` targets
+      // bypass the closed-buffer fan-out guard and are excluded from search, so the
+      // duplicate doesn't double up search results. Skip ignored senders
+      // (`fromIgnored`): the home copy is ignore-flagged and client-filtered, so
+      // mirroring the raw text would bypass the ignore list (a harassment vector).
+      if (
+        isNotice &&
+        !isServer &&
+        target !== this.serverTarget() &&
+        !published?.fromIgnored &&
+        isBufferClosed(this.network.user_id, this.network.id, target)
+      ) {
+        this.publish({
+          type: 'notice',
+          target: this.serverTarget(),
+          nick,
+          text: bodyText,
+          kind: eventType,
+          self: false,
+          mirrored: true,
+        });
+      }
       // An incoming PRIVMSG (not NOTICE) is the moment this nick becomes a
       // tracked DM peer — add them via trackDmPeer so MONITOR + fires too.
-      // NOTICEs go to the server buffer above, so there's no DM peer to
-      // track for them. Channel chatter still flips presence only for peers
-      // we already track.
+      // A NOTICE now opens a buffer under the sender's nick too, but we
+      // deliberately don't start presence-tracking for notice senders: they're
+      // overwhelmingly services/bots (NickServ, ChanServ, oper notices) that
+      // shouldn't consume MONITOR slots or show a presence dot. Channel chatter
+      // still flips presence only for peers we already track.
       if (eventNick && !isServer && !targetIsChannel && !isNotice) {
         this.trackDmPeer(eventNick);
       }
@@ -2297,6 +2363,10 @@ export class IrcConnection {
   // RPL_MONOFFLINE from the server — no separate WHOIS probe needed.
   probePresence(nick: string | undefined | null): void {
     if (!nick || !isDmTargetName(nick)) return;
+    // Opening a notice-only buffer (a service like NickServ, #439) must not start
+    // MONITOR tracking — only probe presence for targets we have a real
+    // conversation with. Friends are tracked separately at hydrate time.
+    if (!hasConversationForTarget(this.network.id, nick)) return;
     this.trackDmPeer(nick);
   }
 
@@ -4040,6 +4110,37 @@ export function canonicalChannelTarget(
   if (typeof target !== 'string' || !target.startsWith('#')) return target;
   const known = channels.get(target.toLowerCase());
   return known ? known.name : target;
+}
+
+// Matches a conventional "[#chan] …" channel-context body prefix, also tolerating
+// (#chan), <#chan>, {#chan}. Restricted to `#` to match Lurker's routing, which
+// treats only `#` as a channel (`&`/`!`/`+` are routed as non-channels); the
+// captured name is validated against the joined set before use, and brackets
+// aren't required to pair since the joined-channel check is the real gate.
+const CHANNEL_CONTEXT_PREFIX = /^\s*[[(<{]\s*(#[^\])>}\s]+)\s*[\])>}]/;
+
+// A nick-addressed NOTICE sometimes belongs in a channel rather than a DM with
+// the sender: services announce per-channel info to your nick (Atheme ENTRYMSG,
+// ChanServ welcome) either via the IRCv3 +draft/channel-context client tag or a
+// conventional "[#chan] …" body prefix. Mirrors weechat's notice_welcome_redirect
+// and irssi's notice_channel_context: redirect to the referenced channel, but ONLY
+// when it's a `#` channel we're currently joined to (so a stray tag/prefix can't
+// fabricate a buffer), returning its canonical (joined) casing. The tag wins over
+// the body prefix. Returns null when there's no usable, joined `#`-channel context.
+export function resolveChannelContext(
+  tags: Record<string, string> | undefined,
+  body: string | undefined,
+  channels: Map<string, { name: string }>,
+): string | null {
+  const joinedChannel = (name: string | undefined): string | null => {
+    if (!name || !name.startsWith('#')) return null;
+    const known = channels.get(name.toLowerCase());
+    return known ? known.name : null;
+  };
+  const tagged = joinedChannel(tags?.['+draft/channel-context']);
+  if (tagged) return tagged;
+  const match = typeof body === 'string' ? body.match(CHANNEL_CONTEXT_PREFIX) : null;
+  return match ? joinedChannel(match[1]) : null;
 }
 
 export function joinRejectionMessage(numeric: string): string | null {

--- a/server/services/noticeRouting.test.ts
+++ b/server/services/noticeRouting.test.ts
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// NOTICE routing (#439): a notice persists to its natural home — the sender's
+// buffer for a nick notice, the channel for a channel notice, the server buffer
+// for a server-sourced one — like a PRIVMSG, so the buffer surfaces on first
+// notice and history lands in the right place. Open/closed is a client display
+// concern; the one server-side exception is the closed-buffer mirror, which
+// persists a second (search-excluded, `mirrored`-flagged) copy in the server
+// buffer so a notice to a buffer you've closed isn't silently lost — including
+// for a client that was offline when it arrived. These exercise that PLUMBING via
+// inbound `message` event. The channel-context helper is unit-pinned in
+// ircConnection.test.ts.
+
+// MUST be first — redirect DATABASE_PATH before the static imports below open
+// the real data/lurker.db.
+import '../test-utils/isolateDb.js';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { IrcConnection } from './ircConnection.js';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import { closeBuffer, reopenBuffer } from '../db/closedBuffers.js';
+import { insertMessage } from '../db/messages.js';
+
+beforeAll(() => {
+  createUser('notice-alice'); // id 1
+  createNetwork(1, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'alice' }); // network id 1
+});
+
+afterEach(() => {
+  // closed_buffers persists across tests in this file — reset what we close.
+  reopenBuffer(1, 1, 'NickServ');
+  vi.restoreAllMocks();
+});
+
+function makeConn(): IrcConnection {
+  return new IrcConnection({
+    network: {
+      id: 1,
+      user_id: 1,
+      name: 'n',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'alice',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 1,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+      position: 0,
+      created_at: new Date().toISOString(),
+    },
+    onEvent: () => {},
+  });
+}
+
+// Spy the persist + ephemeral seams on a fresh connection. publish returns the
+// enriched event (with the ignore verdict); the spy defaults to undefined, which
+// the mirror treats as "not ignored".
+function harness() {
+  const conn = makeConn();
+  const publish = vi.fn<(event: Record<string, unknown>) => unknown>();
+  const publishEphemeral = vi.fn<(event: Record<string, unknown>) => unknown>();
+  conn.publish = publish as unknown as typeof conn.publish;
+  conn.publishEphemeral = publishEphemeral as unknown as typeof conn.publishEphemeral;
+  return { conn, publish, publishEphemeral };
+}
+
+// Seed a real persisted message so DB-backed routing (casing fold, presence
+// gate) sees history. Returns nothing — callers query via the connection.
+function seed(target: string, nick: string, text: string, type = 'message'): void {
+  insertMessage({
+    networkId: 1,
+    target,
+    time: new Date().toISOString(),
+    type,
+    nick,
+    text,
+    self: false,
+  });
+}
+
+// Mark a channel as currently joined (this.channels is keyed lowercase; .name
+// holds the case we joined with).
+function join(conn: IrcConnection, name: string): void {
+  conn.channels.set(name.toLowerCase(), {
+    name,
+    topic: null,
+    members: new Map(),
+    modes: new Set(),
+  });
+}
+
+function emitNotice(conn: IrcConnection, fields: Record<string, unknown>): void {
+  conn.client.emit('message', {
+    ident: 'svc',
+    hostname: 'services.',
+    type: 'notice',
+    ...fields,
+  });
+}
+
+describe('NOTICE routing (#439)', () => {
+  it('persists a nick notice to the sender buffer (no mirror when not closed)', () => {
+    const { conn, publish, publishEphemeral } = harness();
+    emitNotice(conn, { nick: 'ChanServ', target: 'alice', message: 'hi there' });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'ChanServ', type: 'notice', nick: 'ChanServ' }),
+    );
+    expect(publishEphemeral).not.toHaveBeenCalled();
+  });
+
+  it('persists a channel notice to the channel buffer', () => {
+    const { conn, publish } = harness();
+    emitNotice(conn, { nick: 'bob', target: '#general', message: 'heads up' });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: '#general', type: 'notice' }),
+    );
+  });
+
+  it('persists a server-sourced notice (no nick) to the server buffer', () => {
+    const { conn, publish } = harness();
+    emitNotice(conn, {
+      nick: undefined,
+      target: 'alice',
+      hostname: 'irc.example.test',
+      message: '*** Looking up your hostname',
+    });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: ':server:1', type: 'notice' }),
+    );
+  });
+
+  it('redirects a nick notice to a joined channel via +draft/channel-context', () => {
+    const { conn, publish } = harness();
+    join(conn, '#Christian');
+    emitNotice(conn, {
+      nick: 'ChanServ',
+      target: 'alice',
+      message: 'welcome',
+      tags: { '+draft/channel-context': '#christian' },
+    });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: '#Christian', type: 'notice' }),
+    );
+  });
+
+  it('redirects a nick notice to a joined channel via a [#chan] body prefix', () => {
+    const { conn, publish } = harness();
+    join(conn, '#Christian');
+    emitNotice(conn, { nick: 'ChanServ', target: 'alice', message: '[#christian] welcome!' });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: '#Christian', type: 'notice' }),
+    );
+  });
+
+  it('does not redirect when the referenced channel is not joined', () => {
+    const { conn, publish } = harness();
+    emitNotice(conn, { nick: 'ChanServ', target: 'alice', message: '[#elsewhere] welcome!' });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: 'ChanServ', type: 'notice' }),
+    );
+  });
+
+  it('mirrors a closed-buffer notice as a durable, flagged copy in the server buffer', () => {
+    const { conn, publish } = harness();
+    closeBuffer(1, 1, 'NickServ');
+    emitNotice(conn, { nick: 'NickServ', target: 'alice', message: 'your cloak is set' });
+    // Real copy persisted under the (closed) home buffer.
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: 'NickServ' }));
+    // A second, durable copy persisted in the server buffer, flagged `mirrored`
+    // so it's excluded from search (no duplicate hit). Persisted (publish), not
+    // ephemeral, so a reconnecting/mobile client sees it too.
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: ':server:1',
+        type: 'notice',
+        nick: 'NickServ',
+        text: 'your cloak is set',
+        mirrored: true,
+      }),
+    );
+  });
+
+  it('does not mirror an ignored sender into the server buffer', () => {
+    const { conn, publish } = harness();
+    closeBuffer(1, 1, 'IgnTroll');
+    // publish reports the message was ignore-filtered (from_ignored), so the
+    // mirror must not re-surface the raw text past the ignore list.
+    publish.mockReturnValue({ fromIgnored: true });
+    emitNotice(conn, { nick: 'IgnTroll', target: 'alice', message: 'rude thing' });
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: 'IgnTroll' }));
+    expect(publish).not.toHaveBeenCalledWith(expect.objectContaining({ target: ':server:1' }));
+    reopenBuffer(1, 1, 'IgnTroll');
+  });
+
+  it('folds the sender nick to an existing buffer casing (no ChanServ/chanserv split)', () => {
+    const { conn, publish } = harness();
+    seed('caseserv', 'caseserv', 'earlier reply'); // history exists as lowercase
+    emitNotice(conn, { nick: 'CaseServ', target: 'alice', message: 'later reply' });
+    expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: 'caseserv' }));
+  });
+
+  it('routes a notice not addressed to our nick to the server buffer (no bogus DM)', () => {
+    const { conn, publish } = harness();
+    // A NOTICE to an `&` local channel Lurker does not route as a channel, and
+    // not addressed to us → server buffer, not a fabricated DM with the sender.
+    emitNotice(conn, { nick: 'LogBot', target: '&admin', message: 'audit log line' });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: ':server:1', type: 'notice' }),
+    );
+  });
+
+  it('probePresence tracks a real conversation but not a notice-only service buffer', () => {
+    const { conn } = harness();
+    seed('SvcOnly', 'SvcOnly', 'a notice', 'notice'); // notice-only → not a peer
+    seed('RealPal', 'RealPal', 'hello'); // real conversation → a peer
+    const track = vi.spyOn(conn, 'trackDmPeer').mockReturnValue(true);
+    conn.probePresence('SvcOnly');
+    expect(track).not.toHaveBeenCalled();
+    conn.probePresence('RealPal');
+    expect(track).toHaveBeenCalledWith('RealPal');
+  });
+});

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -23,6 +23,7 @@ let buildSystemBacklog: typeof import('./wsHub.js').buildSystemBacklog;
 let systemLineToEvent: typeof import('./wsHub.js').systemLineToEvent;
 let buildSystemHistoryReply: typeof import('./wsHub.js').buildSystemHistoryReply;
 let startChanlistRefresh: typeof import('./wsHub.js').startChanlistRefresh;
+let DM_ELIGIBLE_TYPES: typeof import('./wsHub.js').DM_ELIGIBLE_TYPES;
 let chanlist: typeof import('../db/chanlist.js');
 let systemMessages: typeof import('../db/systemMessages.js').default;
 
@@ -45,6 +46,7 @@ beforeAll(async () => {
     systemLineToEvent,
     buildSystemHistoryReply,
     startChanlistRefresh,
+    DM_ELIGIBLE_TYPES,
   } = await import('./wsHub.js'));
   chanlist = await import('../db/chanlist.js');
   systemMessages = (await import('../db/systemMessages.js')).default;
@@ -248,6 +250,17 @@ describe('buildOfflineBacklogFrames', () => {
       .map((f) => f.target);
     expect(targets).not.toContain('#hidden');
     expect(targets).toContain(`:server:${offId}`);
+  });
+});
+
+describe('DM_ELIGIBLE_TYPES (#439)', () => {
+  it('excludes notice so a notice never reopens a closed buffer', () => {
+    // The fan-out guard reopens a closed buffer on a DM-eligible event. NOTICE
+    // must not be in this set: a notice to a buffer the user closed has to stay
+    // closed (it's surfaced transiently in the server buffer instead).
+    expect(DM_ELIGIBLE_TYPES.has('message')).toBe(true);
+    expect(DM_ELIGIBLE_TYPES.has('action')).toBe(true);
+    expect(DM_ELIGIBLE_TYPES.has('notice')).toBe(false);
   });
 });
 

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -237,7 +237,14 @@ function isInQuietWindow(currentMin: number, startMin: number, endMin: number): 
   return currentMin >= startMin || currentMin < endMin;
 }
 
-const DM_ELIGIBLE_TYPES = new Set(['message', 'action', 'notice']);
+// Message types that mark a target as a real DM conversation — used both to
+// reopen a closed buffer on fresh activity (the fan-out guard) and to flag an
+// event as a personal DM for notifications (isDirect). NOTICE is deliberately
+// excluded (#439): a notice persists to the sender's buffer like a message, but
+// it must NOT reopen a buffer the user explicitly closed (closed stays closed —
+// the closed-buffer NOTICE is persisted as a durable copy in the server buffer
+// instead) and a service notice (NickServ/ChanServ) must not fire a DM notification.
+export const DM_ELIGIBLE_TYPES = new Set(['message', 'action']);
 
 // Structural DM detection from a target string: ircConnection routes any direct
 // message into a buffer keyed by the *other* person's nick, so a target that's


### PR DESCRIPTION
Closes #439

## Problem

A prior fix to stop NickServ/ChanServ notices from auto-spawning buffers went too far: every unsolicited notice landed in the **server buffer** instead of its natural home. Routing used "does this nick have message history and isn't closed?" as a proxy for "is this buffer open" — which is wrong, and the open/closed decision shouldn't be a server-side routing concern at all.

## Approach

A notice now persists to its **natural home** like a PRIVMSG — the sender's buffer for a nick notice, the channel for a channel notice, the server buffer for a server-sourced one — so the buffer surfaces on first notice (irssi-style) and history lands in the right place. Open/closed becomes a client display concern.

This is grounded in a survey of six reference clients (gamja, halloy, irssi, repartee, The Lounge, weechat): all agree on channel→channel, server-sourced→server, nick→sender's buffer; they differ only on auto-creating a buffer for an unseen sender, and we chose the irssi model (the buffer appears, but closing it keeps it closed).

## What's in here

- **Closed stays closed.** Drop `notice` from `DM_ELIGIBLE_TYPES` so a notice never reopens a buffer the user closed (and a service notice no longer fires a DM-style notification). History still accrues for reopen.
- **Closed-buffer mirror (durable).** A notice to a closed buffer would otherwise be invisible until reopened. We persist a **second, durable copy** in the server buffer (new `messages.mirrored` flag) so every client sees it — including one that was offline when it arrived (an ephemeral copy would never reach a reconnecting or mobile client). The real copy stays in the home buffer. The mirror is flagged `mirrored` and excluded from search/highlights so it doesn't double up its real copy; genuine server-buffer notices stay searchable. `publish()` returns the enriched event so the mirror can skip ignored senders (re-surfacing their text would bypass the ignore list).
- **Services stay out of MONITOR.** Presence tracking (reconnect hydration + `probePresence`) is gated on `hasConversationForTarget` (a real non-notice message), so notice-only buffers don't consume MONITOR slots or show a presence dot. Friends remain tracked via their own ungated path.
- **Casing.** Fold the sender nick to an existing buffer's casing so a reply from `ChanServ` doesn't fork a `chanserv` buffer (#289).
- **Addressed-to-us guard.** Only route to the sender when the notice is addressed to our nick; a notice to an `&`/`!`/`+` local channel (which Lurker routes as a non-channel) or a STATUSMSG target goes to the server buffer instead of fabricating a bogus DM.
- **Channel-context redirect.** A nick-addressed notice describing a channel is routed to that channel via the IRCv3 `+draft/channel-context` tag (gamja/halloy) or a leading `[#chan]` body prefix (weechat `notice_welcome_redirect` / irssi `notice_channel_context`), restricted to a `#` channel we're currently in.

## Schema

Adds one column, `messages.mirrored`, via the existing `ensureColumn` migration (`ALTER ADD COLUMN`, metadata-only) + the export schema. The message importer defaults it to `0` for pre-#439 archives that omit the key, so restores of older backups don't fail the NOT NULL column. No client changes.

## Testing

`npm run check` clean; full suite green (**1740 tests**). New coverage: notice-routing wiring cases, `resolveChannelContext` (`#`-only), `hasConversationForTarget`, a `DM_ELIGIBLE_TYPES` regression guard, the mirror-excluded-from-search case, and a pre-#439 archive import.

This went through two multi-agent code-review + adversarial-verify passes; the first caught the closed-buffer reopen / ignore-leak / MONITOR-pollution issues, the second caught the import-compat bug — all fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)