### PR TITLE
Improve message jump-to reliability across all entry points

### DIFF
--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -1789,19 +1789,34 @@ function scrollByPage(direction: number) {
 
 defineExpose({ scrollByPage });
 
+// Budget (in animation frames, ~1s at 60fps) for the target row to mount before
+// we give up. On a cold-start deep link or a large around-slice the row often
+// isn't painted on the first tick; a single querySelector would silently abandon
+// the jump, which is the main reason a *delivered* jump fails to scroll on mobile.
+const SCROLL_RETRY_FRAMES = 60;
+
 watch(
   () => props.pendingScrollId,
   async (id) => {
     if (id == null) return;
     await nextTick();
-    const el = scroller.value;
-    if (!el) return;
-    const target = el.querySelector(`[data-msg-id="${id}"]`);
-    if (!target) return;
-    stickToBottom.value = false;
-    target.scrollIntoView({ block: 'center', behavior: 'smooth' });
-    target.classList.add('scroll-target');
-    setTimeout(() => target.classList.remove('scroll-target'), 1500);
+    let attempts = 0;
+    const tryScroll = () => {
+      // A newer jump superseded this one — abandon the stale retry loop.
+      if (props.pendingScrollId !== id) return;
+      const el = scroller.value;
+      if (!el) return;
+      const target = el.querySelector(`[data-msg-id="${id}"]`);
+      if (!target) {
+        if (attempts++ < SCROLL_RETRY_FRAMES) requestAnimationFrame(tryScroll);
+        return;
+      }
+      stickToBottom.value = false;
+      target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      target.classList.add('scroll-target');
+      setTimeout(() => target.classList.remove('scroll-target'), 1500);
+    };
+    tryScroll();
   },
 );
 </script>

--- a/vue_client/src/components/ToastContainer.vue
+++ b/vue_client/src/components/ToastContainer.vue
@@ -10,7 +10,7 @@
         v-for="t in toasts.items"
         :key="t.id"
         class="toast"
-        :class="[`kind-${t.kind}`, { clickable: !!t.networkId }]"
+        :class="[`kind-${t.kind}`, { clickable: !!t.networkId && !!t.target }]"
         @click="onClick(t)"
       >
         <div class="row">
@@ -32,21 +32,31 @@
 import { useToastsStore } from '../stores/toasts.js';
 import type { Toast } from '../stores/toasts.js';
 import { useBuffersStore } from '../stores/buffers.js';
+import { emitJumpIntent } from '../composables/useJumpIntent.js';
 
 const toasts = useToastsStore();
 const buffers = useBuffersStore();
 
 function onClick(t: Toast) {
   if (!t.networkId || !t.target) return;
-  // The buffer can be closed between the toast firing and the user clicking
-  // it; activating would recreate an empty shell. Replace the toast with a
-  // "closed" notice instead.
-  if (!buffers.isOpen(t.networkId, t.target)) {
-    toasts.dismiss(t.id);
+  if (t.messageId != null) {
+    // A specific message → scroll to it via the shared jump pipeline (#444). The
+    // active chat shell subscribes through useChatBootstrap and runs the jump.
+    emitJumpIntent({
+      kind: 'jump',
+      networkId: t.networkId,
+      target: t.target,
+      messageId: t.messageId,
+    });
+  } else if (!buffers.isOpen(t.networkId, t.target)) {
+    // A message-less toast (join failure, unknown command, info) whose buffer has
+    // since closed: activating would recreate an empty shell, so show a notice
+    // instead — the pre-#444 behavior. The jump pipeline's guards don't fit here;
+    // they'd reject a :server: target or recreate a parted channel.
     toasts.push({ kind: 'info', title: 'Buffer is closed', body: '', ttlMs: 4000 });
-    return;
+  } else {
+    buffers.activate(t.networkId, t.target);
   }
-  buffers.activate(t.networkId, t.target);
   toasts.dismiss(t.id);
 }
 

--- a/vue_client/src/composables/useChatBootstrap.test.ts
+++ b/vue_client/src/composables/useChatBootstrap.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// consumeColdStartJump only consults the socket-`connected` flag and the buffers
+// store passed to it. Stub useSocket so we control readiness; everything else in
+// the bootstrap module is import-safe. The suite has no DOM environment, so we
+// install a minimal window (location + history) rather than pull in jsdom.
+const h = vi.hoisted(() => ({ connected: { value: false } as { value: boolean } }));
+vi.mock('./useSocket.js', () => ({ connected: h.connected }));
+
+import { consumeColdStartJump } from './useChatBootstrap.js';
+
+function installWindow(search: string): void {
+  const loc = { pathname: '/', search, hash: '' };
+  (globalThis as any).window = {
+    location: loc,
+    history: {
+      replaceState: (_state: unknown, _title: string, url: string) => {
+        const u = new URL(url, 'http://localhost');
+        loc.pathname = u.pathname;
+        loc.search = u.search;
+        loc.hash = u.hash;
+      },
+    },
+  };
+}
+
+const currentSearch = (): string => (globalThis as any).window.location.search;
+const openBuffers = { isOpen: () => true } as any;
+
+beforeEach(() => {
+  h.connected.value = false;
+  installWindow('');
+});
+afterEach(() => {
+  delete (globalThis as any).window;
+});
+
+describe('consumeColdStartJump', () => {
+  it('fires the jump and strips the params when the app is already ready', () => {
+    h.connected.value = true;
+    installWindow('?net=1&buf=%23chan&msg=42');
+    const onJump = vi.fn<(payload: unknown) => void>();
+
+    consumeColdStartJump(openBuffers, onJump);
+
+    expect(onJump).toHaveBeenCalledWith({
+      kind: 'jump',
+      networkId: 1,
+      target: '#chan',
+      messageId: 42,
+    });
+    // Deep-link params are consumed so a refresh doesn't re-jump.
+    expect(currentSearch()).toBe('');
+  });
+
+  it('passes messageId null for an "open conversation" deep link with no msg', () => {
+    h.connected.value = true;
+    installWindow('?net=2&buf=alice');
+    const onJump = vi.fn<(payload: unknown) => void>();
+
+    consumeColdStartJump(openBuffers, onJump);
+
+    expect(onJump).toHaveBeenCalledWith({
+      kind: 'jump',
+      networkId: 2,
+      target: 'alice',
+      messageId: null,
+    });
+  });
+
+  it('treats a non-numeric msg as a null messageId, not NaN', () => {
+    h.connected.value = true;
+    installWindow('?net=1&buf=%23x&msg=foo');
+    const onJump = vi.fn<(payload: unknown) => void>();
+
+    consumeColdStartJump(openBuffers, onJump);
+
+    expect(onJump).toHaveBeenCalledWith({
+      kind: 'jump',
+      networkId: 1,
+      target: '#x',
+      messageId: null,
+    });
+  });
+
+  it('does nothing and leaves unrelated params when there is no deep link', () => {
+    h.connected.value = true;
+    installWindow('?foo=bar');
+    const onJump = vi.fn<(payload: unknown) => void>();
+
+    consumeColdStartJump(openBuffers, onJump);
+
+    expect(onJump).not.toHaveBeenCalled();
+    expect(currentSearch()).toBe('?foo=bar');
+  });
+
+  it('captures (strips) the intent but defers the jump until ready', () => {
+    vi.useFakeTimers();
+    try {
+      h.connected.value = false; // socket not up yet
+      installWindow('?net=1&buf=%23chan&msg=42');
+      const onJump = vi.fn<(payload: unknown) => void>();
+
+      consumeColdStartJump(openBuffers, onJump);
+
+      // Not fired yet, but the URL is already cleaned so a refresh can't double it.
+      expect(onJump).not.toHaveBeenCalled();
+      expect(currentSearch()).toBe('');
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/vue_client/src/composables/useChatBootstrap.test.ts
+++ b/vue_client/src/composables/useChatBootstrap.test.ts
@@ -99,17 +99,20 @@ describe('consumeColdStartJump', () => {
 
   it('captures (strips) the intent but defers the jump until ready', () => {
     vi.useFakeTimers();
+    let dispose: (() => void) | undefined;
     try {
       h.connected.value = false; // socket not up yet
       installWindow('?net=1&buf=%23chan&msg=42');
       const onJump = vi.fn<(payload: unknown) => void>();
 
-      consumeColdStartJump(openBuffers, onJump);
+      dispose = consumeColdStartJump(openBuffers, onJump);
 
       // Not fired yet, but the URL is already cleaned so a refresh can't double it.
       expect(onJump).not.toHaveBeenCalled();
       expect(currentSearch()).toBe('');
     } finally {
+      // Tear down the deferred watch/timer so it can't leak into other tests.
+      dispose?.();
       vi.clearAllTimers();
       vi.useRealTimers();
     }

--- a/vue_client/src/composables/useChatBootstrap.ts
+++ b/vue_client/src/composables/useChatBootstrap.ts
@@ -1,32 +1,135 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { onMounted } from 'vue';
+import { onBeforeUnmount, onMounted, watch } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useSettingsStore } from '../stores/settings.js';
+import { useBuffersStore } from '../stores/buffers.js';
+import { useToastsStore } from '../stores/toasts.js';
 import { startPresenceReporter, reportNow } from './usePresence.js';
 import { registerSW, onSWPushMessage } from './usePush.js';
+import { onJumpIntent } from './useJumpIntent.js';
+import { connected } from './useSocket.js';
 import { startAppBadge } from './useAppBadge.js';
+import type { JumpTarget } from './useJumpToMessage.js';
 
-export interface JumpPayload {
+// How long to wait for the app to become able to honor a cold-start deep link
+// before giving up. networks.fetchAll() (REST) has resolved by the time we look,
+// but buffers + the socket come up asynchronously over the WS — and loadAround()
+// no-ops while the socket is closed — so we hold the jump until both land.
+const COLD_START_JUMP_TIMEOUT_MS = 10000;
+
+// The bus/notification payload is a jump target plus a `kind` discriminator
+// shared with the service-worker message channel; it IS what jump() consumes.
+export interface JumpPayload extends JumpTarget {
   kind: string;
-  networkId: number;
-  target: string;
-  // Absent for an "open this conversation" tap (e.g. a friend-online push).
-  messageId?: number | null;
 }
 
 export interface ChatBootstrapOptions {
   onJump?: (data: JumpPayload) => void;
 }
 
+// The service worker can only hand a launched-from-closed PWA its jump target
+// through the URL (a postMessage would race the not-yet-registered listener and
+// be dropped), so the notificationclick handler writes /?net&buf&msg. Nothing
+// read it back before — the user just landed on the default screen. Recover it
+// here, strip it so a refresh doesn't re-jump, and fire it through the same
+// onJump the warm push path uses once the app can actually honor it. Returns a
+// disposer for the deferred-readiness watch/timer.
+export function consumeColdStartJump(
+  buffers: ReturnType<typeof useBuffersStore>,
+  onJump: (data: JumpPayload) => void,
+): () => void {
+  const noop = (): void => {};
+  // new URLSearchParams(string) never throws, so no guard is needed.
+  const params = new URLSearchParams(window.location.search);
+  const net = params.get('net');
+  const buf = params.get('buf');
+  if (!net || !buf) return noop;
+  const networkId = Number(net);
+  if (!Number.isFinite(networkId)) return noop;
+
+  const msg = params.get('msg');
+  // Strip the deep-link params immediately so a manual refresh doesn't re-jump.
+  params.delete('net');
+  params.delete('buf');
+  params.delete('msg');
+  const qs = params.toString();
+  window.history.replaceState(
+    null,
+    '',
+    window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash,
+  );
+
+  // Validate msg the same way as networkId: a malformed ?msg=foo must become a
+  // null "open the conversation" intent, not NaN — NaN slips past the
+  // `messageId == null` check downstream and anchors loadAround on NaN.
+  const parsed = msg != null && msg !== '' ? Number(msg) : null;
+  const messageId = parsed != null && Number.isFinite(parsed) ? parsed : null;
+
+  const payload: JumpPayload = { kind: 'jump', networkId, target: buf, messageId };
+  const ready = (): boolean => connected.value && buffers.isOpen(networkId, buf);
+  if (ready()) {
+    onJump(payload);
+    return noop;
+  }
+
+  let done = false;
+  // Watch the boolean directly (not a fresh [a, b] array, which compares
+  // unequal every tick) so the callback runs only when readiness actually flips.
+  const stop = watch(ready, (ok) => {
+    if (!ok) return;
+    cleanup();
+    onJump(payload);
+  });
+  const timer = setTimeout(() => {
+    cleanup();
+    // The buffer never re-opened (e.g. a channel/DM closed before the app was
+    // killed). The URL is already stripped, so without this the intent would
+    // vanish silently. Surface it instead of leaving the user on the default
+    // screen wondering why the notification did nothing.
+    useToastsStore().push({
+      kind: 'info',
+      title: messageId != null ? 'Couldn’t open that message' : 'Couldn’t open that conversation',
+      body: '',
+      ttlMs: 5000,
+    });
+  }, COLD_START_JUMP_TIMEOUT_MS);
+  function cleanup(): void {
+    if (done) return;
+    done = true;
+    stop();
+    clearTimeout(timer);
+  }
+  return cleanup;
+}
+
 // Shared post-login bootstrap for the chat shells (Desktop + Mobile).
-// onJump receives { networkId, target, messageId } when a push notification
-// is clicked; each shell wires up its own handler since the mobile shell
-// also needs to advance its screen state.
+// onJump receives { networkId, target, messageId } from any of the three jump
+// entry points — a clicked push notification (warm via postMessage, cold via the
+// launch URL) or an in-app toast click (#444). Each shell wires up its own handler
+// since the mobile shell also needs to advance its screen state.
 export function useChatBootstrap({ onJump }: ChatBootstrapOptions = {}): void {
   const networks = useNetworksStore();
   const settings = useSettingsStore();
+  const buffers = useBuffersStore();
+  const disposers: Array<() => void> = [];
+
+  // Wire all three jump entry points synchronously in setup so onBeforeUnmount
+  // can always dispose them. Registering after the onMounted await would race a
+  // fast shell unmount (Desktop<->Mobile viewport swap): cleanup would run with
+  // an empty disposer list, then the awaited continuation would add listeners
+  // that never get torn down — leaking them and double-firing every later jump.
+  if (onJump) {
+    disposers.push(
+      onSWPushMessage((data) => {
+        const d = data as any;
+        if (d?.kind === 'jump') onJump(d as JumpPayload);
+      }),
+    );
+    disposers.push(onJumpIntent(onJump));
+    disposers.push(consumeColdStartJump(buffers, onJump));
+  }
 
   onMounted(async () => {
     if (!settings.loaded) settings.fetchAll().catch(() => {});
@@ -42,11 +145,12 @@ export function useChatBootstrap({ onJump }: ChatBootstrapOptions = {}): void {
     registerSW().catch(() => {
       /* ignore */
     });
-    if (onJump) {
-      onSWPushMessage((data) => {
-        const d = data as any;
-        if (d?.kind === 'jump') onJump(d as JumpPayload);
-      });
-    }
+  });
+
+  // The viewport-driven shell swap (Desktop <-> Mobile) remounts this composable;
+  // without cleanup the old listeners would linger and double-fire every jump.
+  onBeforeUnmount(() => {
+    for (const dispose of disposers) dispose();
+    disposers.length = 0;
   });
 }

--- a/vue_client/src/composables/useJumpIntent.test.ts
+++ b/vue_client/src/composables/useJumpIntent.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { emitJumpIntent, onJumpIntent } from './useJumpIntent.js';
+
+describe('useJumpIntent', () => {
+  it('delivers an emitted payload to a subscriber', () => {
+    const seen: unknown[] = [];
+    const off = onJumpIntent((p) => seen.push(p));
+    emitJumpIntent({ kind: 'jump', networkId: 1, target: '#x', messageId: 42 });
+    off();
+    expect(seen).toEqual([{ kind: 'jump', networkId: 1, target: '#x', messageId: 42 }]);
+  });
+
+  it('stops delivering after the disposer runs', () => {
+    const fn = vi.fn<() => void>();
+    const off = onJumpIntent(fn);
+    off();
+    emitJumpIntent({ kind: 'jump', networkId: 1, target: '#x', messageId: 1 });
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('emitting with no listeners is a no-op', () => {
+    expect(() => emitJumpIntent({ kind: 'jump', networkId: 1, target: '#x' })).not.toThrow();
+  });
+
+  it('a throwing listener does not block the others', () => {
+    const good = vi.fn<() => void>();
+    const offBad = onJumpIntent(() => {
+      throw new Error('boom');
+    });
+    const offGood = onJumpIntent(good);
+    emitJumpIntent({ kind: 'jump', networkId: 2, target: '#y', messageId: 7 });
+    offBad();
+    offGood();
+    expect(good).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vue_client/src/composables/useJumpIntent.ts
+++ b/vue_client/src/composables/useJumpIntent.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type { JumpPayload } from './useChatBootstrap.js';
+
+// In-app "jump to this message" intent bus. The push-notification path has its
+// own delivery channel (onSWPushMessage); this is the parallel channel for jump
+// intents that originate inside the already-running app — today, a click on a
+// highlight/DM toast (#444). ToastContainer is mounted at the App level, outside
+// the chat shells that own the jump machinery (pendingScrollId / useJumpToMessage),
+// so it can't run the jump itself; it emits here and the active shell — which
+// subscribed via useChatBootstrap — performs it. One jump implementation, three
+// entry points (warm push, cold push, in-app toast).
+type JumpIntentListener = (payload: JumpPayload) => void;
+
+const listeners = new Set<JumpIntentListener>();
+
+export function emitJumpIntent(payload: JumpPayload): void {
+  for (const listener of listeners) {
+    try {
+      listener(payload);
+    } catch (_) {
+      // A misbehaving listener must not strand the originating click.
+    }
+  }
+}
+
+export function onJumpIntent(listener: JumpIntentListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/vue_client/src/composables/useJumpToMessage.test.ts
+++ b/vue_client/src/composables/useJumpToMessage.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { ref, nextTick } from 'vue';
+
+// Mirror buffers.test.ts: the store reaches into networks/toasts/socket. Keep a
+// stable toast spy so the closed-buffer notice is assertable, and make socketSend
+// report success so loadAround mints a token instead of bailing.
+const h = vi.hoisted(() => ({ activeKey: null as string | null, push: vi.fn<() => void>() }));
+
+vi.mock('../stores/networks.js', () => ({
+  useNetworksStore: () => ({
+    get activeKey() {
+      return h.activeKey;
+    },
+    set activeKey(v: string | null) {
+      h.activeKey = v;
+    },
+    setActive(networkId: number | string, target: string) {
+      h.activeKey = `${networkId}::${target}`;
+    },
+  }),
+}));
+vi.mock('../stores/toasts.js', () => ({ useToastsStore: () => ({ push: h.push }) }));
+vi.mock('./useSocket.js', () => ({ socketSend: vi.fn<() => boolean>(() => true) }));
+
+import { useBuffersStore } from '../stores/buffers.js';
+import { useJumpToMessage } from './useJumpToMessage.js';
+
+const NET = 1;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  h.activeKey = null;
+  h.push.mockClear();
+});
+
+describe('useJumpToMessage', () => {
+  it('arms pendingScrollId immediately when the message is already in memory', () => {
+    const store = useBuffersStore();
+    const buf = store.ensure(NET, '#chan');
+    buf.messages.push({ id: 5, networkId: NET, target: '#chan', type: 'message' } as any);
+
+    const pendingScrollId = ref<number | null>(null);
+    const jump = useJumpToMessage({ pendingScrollId });
+    jump({ networkId: NET, target: '#chan', messageId: 5 });
+
+    expect(pendingScrollId.value).toBe(5);
+  });
+
+  it('re-arms for a repeat jump to the same id by bouncing through null', async () => {
+    const store = useBuffersStore();
+    const buf = store.ensure(NET, '#chan');
+    buf.messages.push({ id: 5, networkId: NET, target: '#chan', type: 'message' } as any);
+
+    const pendingScrollId = ref<number | null>(null);
+    const jump = useJumpToMessage({ pendingScrollId });
+    jump({ networkId: NET, target: '#chan', messageId: 5 });
+    expect(pendingScrollId.value).toBe(5);
+
+    // Same id again would be a no-op for MessageList's watcher without the bounce.
+    jump({ networkId: NET, target: '#chan', messageId: 5 });
+    expect(pendingScrollId.value).toBe(null);
+    await nextTick();
+    expect(pendingScrollId.value).toBe(5);
+  });
+
+  it('arms after the around-slice lands when the message is off-screen (not by length)', async () => {
+    const store = useBuffersStore();
+    store.ensure(NET, '#chan'); // open but empty — target message is not in memory
+
+    const pendingScrollId = ref<number | null>(null);
+    const jump = useJumpToMessage({ pendingScrollId });
+    jump({ networkId: NET, target: '#chan', messageId: 100 });
+
+    // Not armed yet — we're waiting on the history fetch to settle.
+    expect(pendingScrollId.value).toBe(null);
+    const buf = store.findByTarget(NET, '#chan')!;
+    expect(buf.loadingHistory).toBe(true);
+
+    // Land the slice via the real token the store minted.
+    store.applyAroundSlice(NET, '#chan', {
+      token: buf.pendingHistoryToken,
+      events: [{ id: 100, networkId: NET, target: '#chan', type: 'message' }],
+      hasMoreOlder: false,
+      hasMoreNewer: false,
+    });
+    await nextTick();
+
+    expect(pendingScrollId.value).toBe(100);
+  });
+
+  it('is not disarmed by a concurrent older-history pager (token-keyed, not loadingHistory)', async () => {
+    const store = useBuffersStore();
+    store.ensure(NET, '#chan');
+
+    const pendingScrollId = ref<number | null>(null);
+    const jump = useJumpToMessage({ pendingScrollId });
+    jump({ networkId: NET, target: '#chan', messageId: 100 });
+
+    const buf = store.findByTarget(NET, '#chan')!;
+    const token = buf.pendingHistoryToken;
+
+    // An in-flight loadOlder response lands first: prependHistory clears
+    // loadingHistory with NO token guard, but leaves pendingHistoryToken alone.
+    // A loadingHistory watch would have stopped here and lost the jump.
+    store.prependHistory(
+      NET,
+      '#chan',
+      [{ id: 5, networkId: NET, target: '#chan', type: 'message' } as any],
+      false,
+      undefined,
+    );
+    await nextTick();
+    expect(pendingScrollId.value).toBe(null);
+
+    // Our around-slice finally lands (token match) and arms.
+    store.applyAroundSlice(NET, '#chan', {
+      token,
+      events: [{ id: 100, networkId: NET, target: '#chan', type: 'message' }],
+      hasMoreOlder: false,
+      hasMoreNewer: false,
+    });
+    await nextTick();
+    expect(pendingScrollId.value).toBe(100);
+  });
+
+  it('does not arm a same-length slice that omits the target (superseded jump)', async () => {
+    const store = useBuffersStore();
+    store.ensure(NET, '#chan');
+
+    const pendingScrollId = ref<number | null>(null);
+    const jump = useJumpToMessage({ pendingScrollId });
+    jump({ networkId: NET, target: '#chan', messageId: 100 });
+
+    const buf = store.findByTarget(NET, '#chan')!;
+    // A slice that settles loadingHistory but lacks message 100 must not scroll.
+    store.applyAroundSlice(NET, '#chan', {
+      token: buf.pendingHistoryToken,
+      events: [{ id: 7, networkId: NET, target: '#chan', type: 'message' }],
+      hasMoreOlder: false,
+      hasMoreNewer: false,
+    });
+    await nextTick();
+
+    expect(pendingScrollId.value).toBe(null);
+  });
+
+  it('shows a "Buffer is closed" notice instead of jumping into a closed buffer', () => {
+    const pendingScrollId = ref<number | null>(null);
+    const jump = useJumpToMessage({ pendingScrollId });
+    jump({ networkId: NET, target: '#never-opened', messageId: 9 });
+
+    expect(pendingScrollId.value).toBe(null);
+    expect(h.push).toHaveBeenCalledWith(expect.objectContaining({ title: 'Buffer is closed' }));
+  });
+});

--- a/vue_client/src/composables/useJumpToMessage.test.ts
+++ b/vue_client/src/composables/useJumpToMessage.test.ts
@@ -27,6 +27,7 @@ vi.mock('../stores/toasts.js', () => ({ useToastsStore: () => ({ push: h.push })
 vi.mock('./useSocket.js', () => ({ socketSend: vi.fn<() => boolean>(() => true) }));
 
 import { useBuffersStore } from '../stores/buffers.js';
+import { socketSend } from './useSocket.js';
 import { useJumpToMessage } from './useJumpToMessage.js';
 
 const NET = 1;
@@ -155,5 +156,23 @@ describe('useJumpToMessage', () => {
 
     expect(pendingScrollId.value).toBe(null);
     expect(h.push).toHaveBeenCalledWith(expect.objectContaining({ title: 'Buffer is closed' }));
+  });
+
+  it('warns "Not connected" instead of silently failing when the slice can\'t be sent', () => {
+    const store = useBuffersStore();
+    store.ensure(NET, '#chan'); // open, but target message is off-screen
+    // Socket closed: every send fails, so loadAround returns null. (Force it for
+    // the whole call — activate() also sends, which would eat a one-shot mock.)
+    (socketSend as any).mockReturnValue(false);
+    try {
+      const pendingScrollId = ref<number | null>(null);
+      const jump = useJumpToMessage({ pendingScrollId });
+      jump({ networkId: NET, target: '#chan', messageId: 100 });
+
+      expect(pendingScrollId.value).toBe(null);
+      expect(h.push).toHaveBeenCalledWith(expect.objectContaining({ title: 'Not connected' }));
+    } finally {
+      (socketSend as any).mockReturnValue(true);
+    }
   });
 });

--- a/vue_client/src/composables/useJumpToMessage.ts
+++ b/vue_client/src/composables/useJumpToMessage.ts
@@ -2,9 +2,26 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type { Ref } from 'vue';
-import { watch } from 'vue';
+import { watch, nextTick } from 'vue';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useToastsStore } from '../stores/toasts.js';
+
+// Drive MessageList's pendingScrollId watcher. Arming the same id twice in a row
+// would be a no-op (the value doesn't change), so a second tap on the same
+// notification — or a retry after a first attempt that landed before the row
+// mounted — would silently do nothing. Bounce through null on a repeat so the
+// watcher always re-fires.
+function armScroll(pendingScrollId: Ref<number | null> | undefined, messageId: number): void {
+  if (!pendingScrollId) return;
+  if (pendingScrollId.value === messageId) {
+    pendingScrollId.value = null;
+    nextTick(() => {
+      pendingScrollId.value = messageId;
+    });
+    return;
+  }
+  pendingScrollId.value = messageId;
+}
 
 export interface JumpTarget {
   networkId: number;
@@ -82,22 +99,28 @@ export function useJumpToMessage({ pendingScrollId, afterActivate }: JumpToMessa
       messageId <= buf.clearedBeforeId;
     if (hasMessage) {
       if (hiddenByClear) buffers.detachForJump(networkId, target);
-      if (pendingScrollId) pendingScrollId.value = messageId;
+      armScroll(pendingScrollId, messageId);
       return;
     }
-    // Detached fetch path. loadAround sets detached=true synchronously, so
-    // any live fanOut between here and the response is dropped. We arm
-    // pendingScrollId once the slice replaces buf.messages — the MessageList
-    // watcher then handles the scroll/pulse.
-    buffers.loadAround(networkId, target, messageId);
+    // Detached fetch path. loadAround sets detached=true synchronously (any live
+    // fanOut between here and the response is dropped) and returns OUR request
+    // token, or null if the socket was closed so no slice will ever arrive.
+    const token = buffers.loadAround(networkId, target, messageId);
+    if (token == null) return;
+    // Arm off the token, not loadingHistory: an in-flight older/newer pager
+    // (prependHistory/appendHistory) clears loadingHistory with no token guard,
+    // which would trip a loadingHistory watch, fail the membership check, and
+    // stop() us before our slice ever lands. Only the token-matched
+    // applyAroundSlice nulls pendingHistoryToken, so watching it ignores the
+    // pagers; a newer jump supersedes us by setting it to a different token.
     const stop = watch(
-      () => buf?.messages?.length,
-      (len) => {
-        if (!len) return;
-        // The around response replaces messages wholesale, so the first
-        // non-empty change after dispatch is the slice landing.
+      () => buf?.pendingHistoryToken,
+      (pending) => {
+        if (pending === token) return; // our request still in flight
         stop();
-        if (pendingScrollId) pendingScrollId.value = messageId;
+        if (pending == null && buf?.messages?.some((m: any) => m.id === messageId)) {
+          armScroll(pendingScrollId, messageId);
+        }
       },
     );
   };

--- a/vue_client/src/composables/useJumpToMessage.ts
+++ b/vue_client/src/composables/useJumpToMessage.ts
@@ -16,7 +16,9 @@ function armScroll(pendingScrollId: Ref<number | null> | undefined, messageId: n
   if (pendingScrollId.value === messageId) {
     pendingScrollId.value = null;
     nextTick(() => {
-      pendingScrollId.value = messageId;
+      // Only re-arm if nothing claimed the slot during the tick — a different
+      // jump firing before this microtask must not be clobbered back to our id.
+      if (pendingScrollId.value === null) pendingScrollId.value = messageId;
     });
     return;
   }
@@ -106,7 +108,18 @@ export function useJumpToMessage({ pendingScrollId, afterActivate }: JumpToMessa
     // fanOut between here and the response is dropped) and returns OUR request
     // token, or null if the socket was closed so no slice will ever arrive.
     const token = buffers.loadAround(networkId, target, messageId);
-    if (token == null) return;
+    if (token == null) {
+      // Socket was closed, so the history slice can't be sent and will never
+      // arrive — the buffer is activated but we can't scroll. Say so rather than
+      // failing as a silent no-op (mirrors ChannelListModal's join feedback).
+      toasts.push({
+        kind: 'warn',
+        title: 'Not connected',
+        body: "Can't load that message while disconnected.",
+        ttlMs: 5000,
+      });
+      return;
+    }
     // Arm off the token, not loadingHistory: an in-flight older/newer pager
     // (prependHistory/appendHistory) clears loadingHistory with no token guard,
     // which would trip a loadingHistory watch, fail the membership check, and

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -536,7 +536,15 @@ export const useBuffersStore = defineStore('buffers', {
     // by applyAroundSlice — a second loadAround (or a reattach) before the
     // first response lands mints a new token, so the stale response is
     // discarded on arrival.
-    loadAround(networkId: number | string, target: string, anchorId: number, halfLimit = 100) {
+    // Returns the request token so a caller (useJumpToMessage) can correlate the
+    // eventual applyAroundSlice, or null if the socket was closed and nothing was
+    // sent — in which case no response will ever arrive to scroll to.
+    loadAround(
+      networkId: number | string,
+      target: string,
+      anchorId: number,
+      halfLimit = 100,
+    ): number | null {
       const buf = ensureBuffer(this, networkId, target);
       const token = nextHistoryToken();
       const wasDetached = buf.detached;
@@ -560,7 +568,9 @@ export const useBuffersStore = defineStore('buffers', {
         buf.loadingHistory = false;
         buf.pendingHistoryToken = null;
         buf.detached = wasDetached;
+        return null;
       }
+      return token;
     },
     // Token-guarded replace for the 'around' response. A mismatched token
     // means a fresher request superseded this one — drop the stale slice


### PR DESCRIPTION
Closes #444.

## Why

"Jump to a message" had three entry points — a clicked push notification, and (newly, #444) a clicked highlight/DM toast — but they were unreliable in different ways. The standout reports: clicking a toast didn't scroll to the message, and a push notification on a **cold-started** PWA stranded you on the buffer list instead of jumping.

Root cause was structural: three delivery mechanisms feeding one under-built pipeline. This funnels all of them through a single path (`useJumpToMessage` → `pendingScrollId` → MessageList scroll watcher) and hardens that path.

## What changed

**Entry points**
- **Cold-start push** — the service worker already wrote the jump target into the launch URL (`?net&buf&msg`), but nothing read it back. Now `consumeColdStartJump` reads it, strips it (so a refresh doesn't re-jump), and fires the jump once the socket + target buffer are actually ready (with a 10s fallback that surfaces a toast rather than vanishing).
- **Toast click (#444)** — message toasts now scroll to the message; message-less toasts (join failures, "Unknown command", `:server:` targets) keep their pre-existing focus/closed-buffer behavior instead of being routed through the jump guards.
- New in-app jump-intent bus connects the app-level `ToastContainer` to the active chat shell.

**Pipeline hardening**
- Off-screen jumps arm on the `loadAround` **token** (`pendingHistoryToken`), not the unguarded `loadingHistory` flag — a concurrent older/newer history pager can no longer silently disarm a jump.
- The MessageList scroll watcher retries across animation frames until the target row mounts, instead of giving up after a single lookup (the main reason a *delivered* jump failed to scroll on a freshly-mounted/cold list).
- `pendingScrollId` is re-armable so a repeat/same-id jump fires again.

**Lifecycle**
- Jump listeners register synchronously and are disposed on unmount, so a Desktop↔Mobile shell swap can't leak them or double-fire jumps.

## Tests
New coverage for the intent bus, the token-keyed arm (including the pager-race regression), the cold-start URL parse + readiness gate, and `msg` validation. Full suite green (`npm run check` + `npm test`).

## Deferred follow-ups
- Warm-path service-worker hardening (narrow the client match, await focus, retain-last replay).
- A durable `scrollTarget` owned by MessageList, which would replace both the re-arm bounce and the frame-budget retry with a single re-attempt-each-render mechanism.

## QA
Manually verified by the operator: cold-start push deep-link, warm push, toast click, and the search/bookmarks/highlights jump paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)