### PR TITLE
Unify mute / always-notify into the /ignore engine (#359)

### DIFF
--- a/server/db/channelNotify.test.ts
+++ b/server/db/channelNotify.test.ts
@@ -12,21 +12,14 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 let createUser: typeof import('./users.js').createUser;
 let createNetwork: typeof import('./networks.js').createNetwork;
 let getChannelNotifyAlways: typeof import('./channelNotify.js').getChannelNotifyAlways;
-let getChannelMuted: typeof import('./channelNotify.js').getChannelMuted;
 let listChannelNotifyForUser: typeof import('./channelNotify.js').listChannelNotifyForUser;
 let setChannelNotifyAlways: typeof import('./channelNotify.js').setChannelNotifyAlways;
-let setChannelMuted: typeof import('./channelNotify.js').setChannelMuted;
 
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
-  ({
-    getChannelNotifyAlways,
-    getChannelMuted,
-    listChannelNotifyForUser,
-    setChannelNotifyAlways,
-    setChannelMuted,
-  } = await import('./channelNotify.js'));
+  ({ getChannelNotifyAlways, listChannelNotifyForUser, setChannelNotifyAlways } =
+    await import('./channelNotify.js'));
 });
 
 afterAll(() => {
@@ -66,42 +59,14 @@ describe('channelNotify', () => {
     expect(listChannelNotifyForUser(u.id).size).toBe(0);
   });
 
-  it('groups settings by network for the whole user', () => {
+  it('groups notify_always settings by network for the whole user', () => {
     const u = createUser('cn-dave');
     const a = mkNetwork(u.id, 'liberaA');
     const b = mkNetwork(u.id, 'liberaB');
     setChannelNotifyAlways(u.id, a!.id, '#one', true);
     setChannelNotifyAlways(u.id, b!.id, '#two', true);
     const byNetwork = listChannelNotifyForUser(u.id);
-    expect(byNetwork.get(a!.id)).toEqual({ '#one': { notifyAlways: true, muted: false } });
-    expect(byNetwork.get(b!.id)).toEqual({ '#two': { notifyAlways: true, muted: false } });
-  });
-
-  it('records and reads back a per-channel muted flag', () => {
-    const u = createUser('cn-erin');
-    const net = mkNetwork(u.id, 'libera');
-    setChannelMuted(u.id, net!.id, '#radio', true);
-    expect(getChannelMuted(u.id, net!.id, '#radio')).toBe(true);
-    expect(getChannelNotifyAlways(u.id, net!.id, '#radio')).toBe(false);
-  });
-
-  it('keeps the row alive while either flag is set, deletes only when both clear', () => {
-    const u = createUser('cn-frank');
-    const net = mkNetwork(u.id, 'libera');
-    // Both flags on the same channel — orthogonal, so both must persist.
-    setChannelNotifyAlways(u.id, net!.id, '#mix', true);
-    setChannelMuted(u.id, net!.id, '#mix', true);
-    expect(listChannelNotifyForUser(u.id).get(net!.id)).toEqual({
-      '#mix': { notifyAlways: true, muted: true },
-    });
-    // Clearing one leaves the row (the other flag still holds it).
-    setChannelNotifyAlways(u.id, net!.id, '#mix', false);
-    expect(getChannelMuted(u.id, net!.id, '#mix')).toBe(true);
-    expect(listChannelNotifyForUser(u.id).get(net!.id)).toEqual({
-      '#mix': { notifyAlways: false, muted: true },
-    });
-    // Clearing the last flag drops the row entirely.
-    setChannelMuted(u.id, net!.id, '#mix', false);
-    expect(listChannelNotifyForUser(u.id).size).toBe(0);
+    expect(byNetwork.get(a!.id)).toEqual({ '#one': { notifyAlways: true } });
+    expect(byNetwork.get(b!.id)).toEqual({ '#two': { notifyAlways: true } });
   });
 });

--- a/server/db/channelNotify.ts
+++ b/server/db/channelNotify.ts
@@ -3,50 +3,36 @@
 
 import db from './index.js';
 
-/** A row from `channel_notify_settings`. */
-export interface ChannelNotifySetting {
-  user_id: number;
-  network_id: number;
-  target: string;
-  notify_always: number;
-  muted: number;
-  updated_at: string;
-}
-
 /** Per-target settings shape returned to callers. */
 export interface ChannelNotifyShape {
   notifyAlways: boolean;
-  muted: boolean;
 }
 
-// Per-(user, network, channel) overrides. Two independent flags live here:
+// Per-(user, network, channel) override. One flag lives here now:
 //   notify_always — treat every message in the channel like a notification
-//                   trigger for push/toast purposes (no visual highlight).
-//   muted         — buffer-list display only: suppress the plain-unread signal
-//                   (count + row color + off-screen unread arrow). Highlights
-//                   and notifications are untouched.
-// The flags are orthogonal, so a row persists as long as EITHER is set; the
-// row is deleted only when both fall back to 0 (absent row = all flags off).
+//                   trigger for push/toast (no visual highlight).
+// The old display-only `muted` flag was folded into the ignore engine as a
+// NOUNREAD/NONOTIFY rule (issue #359, so mute now also silences notifications).
+// The `muted` column remains in the table (always written 0) for backward-compat
+// with older images, but is no longer read or written meaningfully — the boot
+// migration in index.ts converts any lingering muted=1 rows into ignore rules.
 
 const getStmt = db.prepare(`
-  SELECT notify_always, muted FROM channel_notify_settings
+  SELECT notify_always FROM channel_notify_settings
   WHERE user_id = ? AND network_id = ? AND target = ?
 `);
 
 const listForUserStmt = db.prepare(`
-  SELECT network_id AS networkId, target,
-         notify_always AS notifyAlways, muted AS muted
+  SELECT network_id AS networkId, target, notify_always AS notifyAlways
   FROM channel_notify_settings
-  WHERE user_id = ?
+  WHERE user_id = ? AND notify_always = 1
 `);
 
 const upsertStmt = db.prepare(`
   INSERT INTO channel_notify_settings (user_id, network_id, target, notify_always, muted, updated_at)
-  VALUES (?, ?, ?, ?, ?, datetime('now'))
+  VALUES (?, ?, ?, 1, 0, datetime('now'))
   ON CONFLICT(user_id, network_id, target)
-  DO UPDATE SET notify_always = excluded.notify_always,
-                muted = excluded.muted,
-                updated_at = excluded.updated_at
+  DO UPDATE SET notify_always = 1, updated_at = excluded.updated_at
 `);
 
 const deleteStmt = db.prepare(`
@@ -54,57 +40,22 @@ const deleteStmt = db.prepare(`
   WHERE user_id = ? AND network_id = ? AND target = ?
 `);
 
-/** Current flags for a channel as 0/1 ints (both 0 when no row exists). */
-function currentFlags(
-  userId: number,
-  networkId: number,
-  target: string,
-): { notifyAlways: number; muted: number } {
-  const row = getStmt.get(userId, networkId, target) as
-    | { notify_always: number; muted: number }
-    | undefined;
-  return {
-    notifyAlways: row && row.notify_always ? 1 : 0,
-    muted: row && row.muted ? 1 : 0,
-  };
-}
-
-// Write the resulting flag pair: upsert while either flag is set, delete the
-// row outright once both are 0 so we never leave all-default rows behind.
-function write(
-  userId: number,
-  networkId: number,
-  target: string,
-  notifyAlways: number,
-  muted: number,
-): void {
-  if (notifyAlways || muted) {
-    upsertStmt.run(userId, networkId, target, notifyAlways, muted);
-  } else {
-    deleteStmt.run(userId, networkId, target);
-  }
-}
-
 export function getChannelNotifyAlways(userId: number, networkId: number, target: string): boolean {
-  return !!currentFlags(userId, networkId, target).notifyAlways;
+  const row = getStmt.get(userId, networkId, target) as { notify_always: number } | undefined;
+  return !!(row && row.notify_always);
 }
 
-export function getChannelMuted(userId: number, networkId: number, target: string): boolean {
-  return !!currentFlags(userId, networkId, target).muted;
-}
-
-/** Both flags for a channel — used by the WS layer to broadcast full state. */
+/** Flags for a channel — used by the WS layer to broadcast state. */
 export function getChannelFlags(
   userId: number,
   networkId: number,
   target: string,
 ): ChannelNotifyShape {
-  const f = currentFlags(userId, networkId, target);
-  return { notifyAlways: !!f.notifyAlways, muted: !!f.muted };
+  return { notifyAlways: getChannelNotifyAlways(userId, networkId, target) };
 }
 
-// Map<networkId, { [target]: { notifyAlways, muted } }> snapshot for the whole
-// user, shaped to drop straight into the client's channelNotify store.
+// Map<networkId, { [target]: { notifyAlways } }> snapshot for the whole user,
+// shaped to drop straight into the client's channelNotify store.
 export function listChannelNotifyForUser(
   userId: number,
 ): Map<number, Record<string, ChannelNotifyShape>> {
@@ -113,34 +64,25 @@ export function listChannelNotifyForUser(
     networkId: number;
     target: string;
     notifyAlways: number;
-    muted: number;
   }>) {
     if (!byNetwork.has(row.networkId)) byNetwork.set(row.networkId, {});
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    byNetwork.get(row.networkId)![row.target] = {
-      notifyAlways: !!row.notifyAlways,
-      muted: !!row.muted,
-    };
+    byNetwork.get(row.networkId)![row.target] = { notifyAlways: !!row.notifyAlways };
   }
   return byNetwork;
 }
 
+// Upsert while notify-always is on; delete the row once it's off so we never
+// leave an all-default row behind.
 export function setChannelNotifyAlways(
   userId: number,
   networkId: number,
   target: string,
   notifyAlways: boolean,
 ): void {
-  const cur = currentFlags(userId, networkId, target);
-  write(userId, networkId, target, notifyAlways ? 1 : 0, cur.muted);
-}
-
-export function setChannelMuted(
-  userId: number,
-  networkId: number,
-  target: string,
-  muted: boolean,
-): void {
-  const cur = currentFlags(userId, networkId, target);
-  write(userId, networkId, target, cur.notifyAlways, muted ? 1 : 0);
+  if (notifyAlways) {
+    upsertStmt.run(userId, networkId, target);
+  } else {
+    deleteStmt.run(userId, networkId, target);
+  }
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import Database from 'better-sqlite3';
+import { foldMutedIntoIgnoreRules } from './migrateMutedFold.js';
 import path from 'path';
 import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
@@ -792,11 +793,11 @@ if (columnExists('peer_presence_state', 'offline_datetime')) {
 // marker. Nullable; only meaningful when state='away'.
 ensureColumn('peer_presence_state', 'away_message', 'TEXT');
 
-// Per-channel "mute" for the buffer list: suppresses the plain-unread signal
-// (count + row color + off-screen unread arrow) for this channel without
-// touching highlights or notifications. Display-only — the server stores and
-// syncs it but never acts on it. Sits in channel_notify_settings alongside
-// notify_always; a row now persists if EITHER flag is set (see channelNotify.ts).
+// DEPRECATED (issue #359): the per-channel display-only `muted` flag was folded
+// into the ignore engine as a NOUNREAD+NONOTIFY rule (mute now silences
+// notifications too). The column is retained (always written 0) so older images
+// still satisfy the schema; the boot migration below converts any lingering
+// muted=1 rows into ignore rules. No new code reads or sets it.
 ensureColumn('channel_notify_settings', 'muted', 'INTEGER NOT NULL DEFAULT 0');
 
 ensureColumn('messages', 'extra', 'TEXT');
@@ -1313,6 +1314,18 @@ if (schemaVersion < 11) {
       db.pragma(`foreign_keys = ${prevFk ? 'ON' : 'OFF'}`);
     }
   }
+}
+
+// Issue #359: fold the old display-only per-channel `muted` flag into the ignore
+// engine (see migrateMutedFold.ts). Runs after the ignored_masks rebuild above so
+// the table is in its final shape. Best-effort — a failure leaves muted=1 rows to
+// retry on the next boot.
+try {
+  foldMutedIntoIgnoreRules(db);
+} catch (err) {
+  // Log rather than swallow: the self-gating retry masks a deterministic bug as
+  // a transient failure, so surface it or a broken fold vanishes silently.
+  console.warn('[db] muted→ignore fold migration failed (will retry next boot):', err);
 }
 
 // Issue #355: buffer_reads.network_id must be nullable so the app-scoped system

--- a/server/db/migrateMutedFold.test.ts
+++ b/server/db/migrateMutedFold.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type BetterSqlite3 from 'better-sqlite3';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: BetterSqlite3.Database;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+let listRules: typeof import('./ignoredMasks.js').listRules;
+let foldMutedIntoIgnoreRules: typeof import('./migrateMutedFold.js').foldMutedIntoIgnoreRules;
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  ({ createUser } = await import('./users.js'));
+  ({ createNetwork } = await import('./networks.js'));
+  ({ listRules } = await import('./ignoredMasks.js'));
+  ({ foldMutedIntoIgnoreRules } = await import('./migrateMutedFold.js'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function mkNetwork(userId: number, name: string) {
+  return createNetwork(userId, {
+    name,
+    host: 'irc.libera.chat',
+    port: 6697,
+    tls: true,
+    nick: name,
+  });
+}
+
+function setRawMuted(userId: number, networkId: number, target: string, notifyAlways: number) {
+  db.prepare(
+    `INSERT INTO channel_notify_settings (user_id, network_id, target, notify_always, muted, updated_at)
+     VALUES (?, ?, ?, ?, 1, datetime('now'))`,
+  ).run(userId, networkId, target, notifyAlways);
+}
+
+function mutedFlag(userId: number, networkId: number, target: string): number | undefined {
+  return (
+    db
+      .prepare(
+        `SELECT muted FROM channel_notify_settings WHERE user_id=? AND network_id=? AND target=?`,
+      )
+      .get(userId, networkId, target) as { muted: number } | undefined
+  )?.muted;
+}
+
+describe('foldMutedIntoIgnoreRules (issue #359 migration)', () => {
+  it('converts a muted channel into a NOUNREAD+NONOTIFY ignore rule and drops the row', () => {
+    const u = createUser('mig-alice');
+    const net = mkNetwork(u.id, 'libera')!;
+    setRawMuted(u.id, net.id, '#Radio', 0); // mixed case, notify_always off
+
+    const converted = foldMutedIntoIgnoreRules(db);
+    expect(converted).toBeGreaterThanOrEqual(1);
+
+    const rules = listRules({ userId: u.id, networkId: net.id });
+    const muteRule = rules.find((r) => r.channels?.[0] === '#radio');
+    expect(muteRule).toBeTruthy();
+    expect(muteRule!.mask).toBeNull();
+    expect(muteRule!.isExcept).toBe(false);
+    expect([...muteRule!.levels].sort()).toEqual(['NONOTIFY', 'NOUNREAD']);
+    // notify_always was off, so the now-empty settings row is gone entirely.
+    expect(mutedFlag(u.id, net.id, '#Radio')).toBeUndefined();
+  });
+
+  it('preserves notify_always: clears muted, keeps the row, creates NO suppressor rule', () => {
+    const u = createUser('mig-bob');
+    const net = mkNetwork(u.id, 'libera')!;
+    setRawMuted(u.id, net.id, '#keep', 1); // notify_always on
+
+    foldMutedIntoIgnoreRules(db);
+    expect(mutedFlag(u.id, net.id, '#keep')).toBe(0); // row kept, muted cleared
+    // notify_always is the explicit opt-in to push; muting it would contradict it,
+    // so no NONOTIFY/NOUNREAD rule is created for this channel.
+    const muteRule = listRules({ userId: u.id, networkId: net.id }).find(
+      (r) => r.channels?.[0] === '#keep',
+    );
+    expect(muteRule).toBeUndefined();
+  });
+
+  it('is idempotent — a second run finds nothing and adds no duplicate rule', () => {
+    const u = createUser('mig-carol');
+    const net = mkNetwork(u.id, 'libera')!;
+    setRawMuted(u.id, net.id, '#once', 0);
+
+    expect(foldMutedIntoIgnoreRules(db)).toBeGreaterThanOrEqual(1);
+    expect(foldMutedIntoIgnoreRules(db)).toBe(0); // nothing left to convert
+    const ruleCount = listRules({ userId: u.id, networkId: net.id }).filter(
+      (r) => r.channels?.[0] === '#once',
+    ).length;
+    expect(ruleCount).toBe(1);
+  });
+});

--- a/server/db/migrateMutedFold.ts
+++ b/server/db/migrateMutedFold.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type Database from 'better-sqlite3';
+import { canonicalizeLevels } from '../../shared/ignoreLevels.js';
+
+// The mute rung's levels, serialized in canonical order — derived (not a literal)
+// so it can't drift from what the GUI/parser store, keeping the dedupe guard and
+// the two write paths byte-identical.
+const MUTE_CSV = canonicalizeLevels(['NOUNREAD', 'NONOTIFY']).join(',');
+
+// Issue #359: fold the deprecated per-channel display-only `muted` flag into the
+// ignore engine. A muted channel becomes a network-scoped NOUNREAD+NONOTIFY rule
+// (mute now also silences notifications, matching Discord/The Lounge). Called at
+// DB init, after the ignored_masks table is in its final shape.
+//
+// A row that ALSO had notify_always=1 is a pre-#359 contradiction ("push every
+// message" + a display-only badge hide). notify_always is the explicit opt-in to
+// notifications, so we preserve it and do NOT create a suppressor rule for those
+// rows — only drop the deprecated muted bit. A silent NONOTIFY there would freeze
+// the push the user explicitly asked for.
+//
+// Idempotent and self-gating: converting a row clears/deletes it, so a re-run
+// finds nothing — no schema_version needed, and it self-heals a half-migrated DB.
+// Returns the number of muted rows processed.
+export function foldMutedIntoIgnoreRules(db: Database.Database): number {
+  const mutedRows = db
+    .prepare(
+      `SELECT user_id AS userId, network_id AS networkId, target, notify_always AS notifyAlways
+       FROM channel_notify_settings WHERE muted = 1`,
+    )
+    .all() as Array<{ userId: number; networkId: number; target: string; notifyAlways: number }>;
+  if (!mutedRows.length) return 0;
+
+  const findRule = db.prepare(
+    `SELECT id FROM ignored_masks
+     WHERE user_id = @userId AND network_id = @networkId AND mask IS NULL
+       AND channels = @channels AND pattern IS NULL AND is_except = 0
+       AND levels = @levels`,
+  );
+  const insertRule = db.prepare(
+    `INSERT INTO ignored_masks (user_id, network_id, mask, channels, pattern, pattern_kind, levels, is_except)
+     VALUES (@userId, @networkId, NULL, @channels, NULL, 'substr', @levels, 0)`,
+  );
+  const clearMuted = db.prepare(
+    `UPDATE channel_notify_settings SET muted = 0
+     WHERE user_id = @userId AND network_id = @networkId AND target = @target`,
+  );
+  const dropRow = db.prepare(
+    `DELETE FROM channel_notify_settings
+     WHERE user_id = @userId AND network_id = @networkId AND target = @target`,
+  );
+
+  const migrate = db.transaction(
+    (rows: Array<{ userId: number; networkId: number; target: string; notifyAlways: number }>) => {
+      for (const row of rows) {
+        const rowKey = { userId: row.userId, networkId: row.networkId, target: row.target };
+        if (row.notifyAlways) {
+          // Preserve the explicit always-notify choice; just drop the deprecated
+          // muted bit, keeping the row.
+          clearMuted.run(rowKey);
+          continue;
+        }
+        // Pure mute → a network-scoped NOUNREAD+NONOTIFY rule, then drop the now-
+        // empty settings row. Ignore channels are stored lowercased; match the
+        // GUI/parser so a later GUI toggle dedupes onto the same rule.
+        const ruleParams = {
+          userId: row.userId,
+          networkId: row.networkId,
+          channels: row.target.toLowerCase(),
+          levels: MUTE_CSV,
+        };
+        if (!findRule.get(ruleParams)) insertRule.run(ruleParams);
+        dropRow.run(rowKey);
+      }
+    },
+  );
+  migrate(mutedRows);
+  return mutedRows.length;
+}

--- a/server/services/ignoreMatch.test.ts
+++ b/server/services/ignoreMatch.test.ts
@@ -4,7 +4,12 @@
 import { describe, it, expect } from 'vitest';
 import type { IgnoreRuleRow } from '../db/ignoredMasks.js';
 import type { IgnoreInput } from './ignoreMatch.js';
-import { compileIgnoreRules, evaluateIgnores, canonicalizeLevels } from './ignoreMatch.js';
+import {
+  compileIgnoreRules,
+  evaluateIgnores,
+  canonicalizeLevels,
+  channelMutesUnread,
+} from './ignoreMatch.js';
 
 function r(overrides: Partial<IgnoreRuleRow> = {}): IgnoreRuleRow {
   return {
@@ -43,6 +48,7 @@ describe('must-have #1 — NOHIGHLIGHT', () => {
     expect(evalRules(rules, { nick: 'bob', type: 'message' })).toEqual({
       hide: false,
       nohilight: true,
+      nonotify: false,
     });
   });
 
@@ -51,6 +57,7 @@ describe('must-have #1 — NOHIGHLIGHT', () => {
     expect(evalRules(rules, { nick: 'alice', type: 'message' })).toEqual({
       hide: false,
       nohilight: false,
+      nonotify: false,
     });
   });
 
@@ -192,5 +199,113 @@ describe('canonicalizeLevels', () => {
     expect(canonicalizeLevels(['publics', 'join'])).toEqual(['PUBLIC', 'JOINS']);
     expect(canonicalizeLevels(['bogus', 'ALL'])).toEqual(['ALL']);
     expect(canonicalizeLevels(['nohilite'])).toEqual(['NOHIGHLIGHT']);
+  });
+
+  it('canonicalizes the mute modifier aliases (issue #359)', () => {
+    expect(canonicalizeLevels(['no_act'])).toEqual(['NOUNREAD']);
+    expect(canonicalizeLevels(['noact'])).toEqual(['NOUNREAD']);
+    expect(canonicalizeLevels(['nonotify'])).toEqual(['NONOTIFY']);
+    expect(canonicalizeLevels(['NONOTIFY', 'NOUNREAD'])).toEqual(['NOUNREAD', 'NONOTIFY']);
+  });
+});
+
+describe('NOUNREAD / NONOTIFY modifier levels (issue #359)', () => {
+  it('a NONOTIFY rule mutes notifications but keeps the message visible', () => {
+    const v = evalRules([r({ channels: ['#chan'], levels: ['NOUNREAD', 'NONOTIFY'] })], {
+      target: '#chan',
+    });
+    expect(v).toEqual({ hide: false, nohilight: false, nonotify: true });
+  });
+
+  it('NOUNREAD alone produces no per-message verdict (badge-only, via channelMutesUnread)', () => {
+    // NOUNREAD is not a per-message verdict field — its only effect is the
+    // whole-buffer badge downgrade tested in the channelMutesUnread block below.
+    expect(
+      evalRules([r({ channels: ['#chan'], levels: ['NOUNREAD'] })], { target: '#chan' }),
+    ).toEqual({ hide: false, nohilight: false, nonotify: false });
+  });
+
+  it('NONOTIFY vetoes NON-highlightable types too (notices/joins) — quietest wins', () => {
+    // A muted channel/network must silence a notify_always notice/join, not just
+    // messages — so nonotify is NOT bounded to highlightable types.
+    const rules = [r({ channels: ['#chan'], levels: ['NONOTIFY'] })];
+    expect(evalRules(rules, { target: '#chan', type: 'notice', text: 'hi' }).nonotify).toBe(true);
+    expect(evalRules(rules, { target: '#chan', type: 'join', text: '' }).nonotify).toBe(true);
+    expect(evalRules(rules, { target: '#chan', type: 'action', text: 'waves' }).nonotify).toBe(
+      true,
+    );
+  });
+
+  it('respects channel scope — a different channel is unaffected', () => {
+    const rules = [r({ channels: ['#chan'], levels: ['NONOTIFY'] })];
+    expect(evalRules(rules, { target: '#other' }).nonotify).toBe(false);
+  });
+
+  it('is sender-scopable via a mask (that person everywhere)', () => {
+    const rules = [r({ mask: 'bob', levels: ['NONOTIFY'] })];
+    expect(evalRules(rules, { nick: 'bob' }).nonotify).toBe(true);
+    expect(evalRules(rules, { nick: 'alice' }).nonotify).toBe(false);
+  });
+
+  it('honors -except (a longer except mask un-mutes)', () => {
+    const rules = [
+      r({ id: 1, mask: null, channels: ['#chan'], levels: ['NONOTIFY'] }),
+      r({ id: 2, mask: 'boss', channels: ['#chan'], levels: ['NONOTIFY'], isExcept: true }),
+    ];
+    expect(evalRules(rules, { nick: 'rando', target: '#chan' }).nonotify).toBe(true);
+    expect(evalRules(rules, { nick: 'boss', target: '#chan' }).nonotify).toBe(false);
+  });
+});
+
+describe('channelMutesUnread (issue #359)', () => {
+  it('is true for a whole-channel NOUNREAD rule', () => {
+    expect(
+      channelMutesUnread(
+        compileIgnoreRules([r({ channels: ['#chan'], levels: ['NOUNREAD'] })]),
+        '#chan',
+      ),
+    ).toBe(true);
+  });
+
+  it('is true for a network-wide rule (channels null) on any buffer', () => {
+    const compiled = compileIgnoreRules([r({ channels: null, mask: null, levels: ['NOUNREAD'] })]);
+    expect(channelMutesUnread(compiled, '#anything')).toBe(true);
+    expect(channelMutesUnread(compiled, 'somenick')).toBe(true); // DM buffer too
+  });
+
+  it('is false in an unrelated channel', () => {
+    expect(
+      channelMutesUnread(
+        compileIgnoreRules([r({ channels: ['#chan'], levels: ['NOUNREAD'] })]),
+        '#other',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not fire for a masked (per-sender) NOUNREAD rule', () => {
+    expect(
+      channelMutesUnread(
+        compileIgnoreRules([r({ mask: 'bob', channels: ['#chan'], levels: ['NOUNREAD'] })]),
+        '#chan',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not fire for a NONOTIFY-only rule', () => {
+    expect(
+      channelMutesUnread(
+        compileIgnoreRules([r({ channels: ['#chan'], levels: ['NONOTIFY'] })]),
+        '#chan',
+      ),
+    ).toBe(false);
+  });
+
+  it('ignores except rules', () => {
+    expect(
+      channelMutesUnread(
+        compileIgnoreRules([r({ channels: ['#chan'], levels: ['NOUNREAD'], isExcept: true })]),
+        '#chan',
+      ),
+    ).toBe(false);
   });
 });

--- a/server/services/ignoreMatch.test.ts
+++ b/server/services/ignoreMatch.test.ts
@@ -247,6 +247,24 @@ describe('NOUNREAD / NONOTIFY modifier levels (issue #359)', () => {
     expect(evalRules(rules, { nick: 'alice' }).nonotify).toBe(false);
   });
 
+  it('a scope mute (mask null) vetoes a nick-less event; a sender mute does not', () => {
+    // A nick-less notifying line (e.g. a server notice in a notify_always
+    // channel) must still be silenced by a muted channel/network.
+    expect(
+      evalRules([r({ mask: null, channels: ['#chan'], levels: ['NONOTIFY'] })], {
+        nick: null,
+        userhost: null,
+        target: '#chan',
+        type: 'notice',
+      }).nonotify,
+    ).toBe(true);
+    // …but a sender-specific mute can't match a null nick.
+    expect(
+      evalRules([r({ mask: 'bob', levels: ['NONOTIFY'] })], { nick: null, userhost: null })
+        .nonotify,
+    ).toBe(false);
+  });
+
   it('honors -except (a longer except mask un-mutes)', () => {
     const rules = [
       r({ id: 1, mask: null, channels: ['#chan'], levels: ['NONOTIFY'] }),

--- a/server/services/ignoreParity.test.ts
+++ b/server/services/ignoreParity.test.ts
@@ -109,10 +109,17 @@ describe('deliberate divergences (asserted, not silently dropped)', () => {
     expect(parseIgnoreArgs('-replies *!*@*.irssi.org ALL', NOW).error).toMatch(/replies/);
   });
 
-  it('NO_ACT / HIDDEN after a mask error out (not special levels)', () => {
-    expect(parseIgnoreArgs('mike NO_ACT -MSGS', NOW).error).toMatch(/unexpected/);
+  it('HIDDEN is not a supported level (irssi divergence)', () => {
     expect(parseIgnoreArgs('mike HIDDEN PUBLIC JOINS PARTS QUITS', NOW).error).toMatch(
       /unexpected/,
     );
+  });
+
+  it('NO_ACT is now supported as NOUNREAD (issue #359 — parity, no longer a divergence)', () => {
+    // irssi's NO_ACT ("don't trigger channel activity") maps to Lurker's
+    // NOUNREAD mute modifier; it used to error as an unknown token.
+    const parsed = parseIgnoreArgs('mike NO_ACT', NOW);
+    expect(parsed.error).toBeUndefined();
+    expect(parsed).toMatchObject({ mask: 'mike', levels: ['NOUNREAD'] });
   });
 });

--- a/server/services/parseIgnore.test.ts
+++ b/server/services/parseIgnore.test.ts
@@ -32,6 +32,35 @@ describe('parseIgnoreArgs — masks & levels', () => {
     expect(p('bob publics').levels).toEqual(['PUBLIC']);
     expect(p('bob join part').levels).toEqual(['JOINS', 'PARTS']);
   });
+
+  it('NOUNREAD / NONOTIFY mute modifiers (issue #359) + irssi NO_ACT alias', () => {
+    // Channel-scoped mute rules carry no mask — the whole channel is muted.
+    expect(p('#idlerpg NOUNREAD')).toMatchObject({
+      mask: null,
+      channels: ['#idlerpg'],
+      levels: ['NOUNREAD'],
+    });
+    expect(p('#idlerpg NONOTIFY NOUNREAD').levels).toEqual(['NOUNREAD', 'NONOTIFY']); // canonical order
+    expect(p('#idlerpg no_act').levels).toEqual(['NOUNREAD']);
+    expect(p('#idlerpg noact').levels).toEqual(['NOUNREAD']);
+  });
+
+  it('a bare token stays a sender mask, not a channel (that person everywhere)', () => {
+    expect(p('spambot NONOTIFY')).toMatchObject({
+      mask: 'spambot',
+      channels: null,
+      levels: ['NONOTIFY'],
+    });
+  });
+
+  it('ALL does not expand to include the modifier levels', () => {
+    // Modifiers are not in LEVEL_DEFS, so a bare "ALL" (or default) never pulls
+    // NOUNREAD/NONOTIFY/NOHIGHLIGHT into the concrete set.
+    const levels = p('bob ALL -PUBLIC').levels;
+    expect(levels).not.toContain('NOUNREAD');
+    expect(levels).not.toContain('NONOTIFY');
+    expect(levels).not.toContain('NOHIGHLIGHT');
+  });
 });
 
 describe('parseIgnoreArgs — content + channel (must-have #2)', () => {

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -18,7 +18,7 @@ import highlightRulesService from './highlightRulesService.js';
 import draftsService from './draftsService.js';
 import * as systemLog from './systemLog.js';
 import * as pushService from './pushService.js';
-import { evaluateIgnores } from './ignoreMatch.js';
+import { evaluateIgnores, type IgnoreVerdict } from './ignoreMatch.js';
 import ignoreRulesService from './ignoreRulesService.js';
 import { parseIgnoreInput, maskToRuleInput } from './ignoreRuleInput.js';
 import { findSession } from '../db/sessions.js';
@@ -68,7 +68,6 @@ import { addBookmark, removeBookmark, listBookmarkIdsForUser } from '../db/bookm
 import {
   getChannelNotifyAlways,
   setChannelNotifyAlways,
-  setChannelMuted,
   getChannelFlags,
 } from '../db/channelNotify.js';
 import { getUserAwayState } from '../db/userAwayState.js';
@@ -985,21 +984,32 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     return false;
   }
 
+  // The user's ignore verdict for an event, off the cached compiled rule set (no
+  // DB scan per event). senderHidden reads .hide for the render/reopen path;
+  // maybePush additionally honors .nonotify (issue #359 — a NONOTIFY mute rule
+  // freezes push without hiding the message).
+  function ignoreVerdictFor(userId: number, decorated: DecoratedEvent): IgnoreVerdict {
+    if (decorated.nick) {
+      const compiled = ignoreRulesService.getCompiled(userId, decorated.networkId);
+      if (compiled.length) {
+        return evaluateIgnores(compiled, {
+          nick: decorated.nick,
+          userhost: decorated.userhost ?? null,
+          target: decorated.target,
+          text: decorated.text ?? '',
+          type: decorated.type,
+          isDm: !!decorated.dm,
+        });
+      }
+    }
+    return { hide: false, nohilight: false, nonotify: false };
+  }
+
   // True when the user's ignore rules would hide this event (a hide-level match,
-  // not a NOHIGHLIGHT-only one). Shared by the push gate and the closed-DM reopen
-  // guard. Runs off the cached compiled rule set — no DB scan per event.
+  // not a modifier-only one). Shared by the push gate and the closed-DM reopen
+  // guard.
   function senderHidden(userId: number, decorated: DecoratedEvent): boolean {
-    if (!decorated.nick) return false;
-    const compiled = ignoreRulesService.getCompiled(userId, decorated.networkId);
-    if (!compiled.length) return false;
-    return evaluateIgnores(compiled, {
-      nick: decorated.nick,
-      userhost: decorated.userhost ?? null,
-      target: decorated.target,
-      text: decorated.text ?? '',
-      type: decorated.type,
-      isDm: !!decorated.dm,
-    }).hide;
+    return ignoreVerdictFor(userId, decorated).hide;
   }
 
   function maybePush(userId: number, decorated: DecoratedEvent): void {
@@ -1010,13 +1020,15 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // the badge total below (it's an O(buffers) scan). deliver() would no-op on
     // an empty subscription set anyway — bail before the work (#451 review).
     if (!pushService.hasSubscriptions(userId)) return;
-    // Suppress push for events the user's ignore rules would hide. This is the
-    // one piece of the ignore feature that has to live server-side: push fires
+    // Suppress push for events the user's ignore rules would hide OR mute
+    // (NONOTIFY, e.g. a muted channel/network — issue #359). This is the one
+    // piece of the ignore/mute feature that has to live server-side: push fires
     // while no client is open, so a client-side filter can't intercept. The
     // unread badge and render filter stay reactive client-side, so /unignore
     // still reveals; only push delivery is frozen here. A NOHIGHLIGHT rule does
     // NOT freeze push — the message is still visible, it just doesn't highlight.
-    if (senderHidden(userId, decorated)) return;
+    const pushVerdict = ignoreVerdictFor(userId, decorated);
+    if (pushVerdict.hide || pushVerdict.nonotify) return;
     // Signal kind in priority order: DM beats matched beats always_notify.
     // The `kind` doubles as the settings-key namespace, so picking a single
     // priority winner here means a DM that also matched a rule still
@@ -1992,23 +2004,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // by notifications.dm.enabled; server pseudo-buffers can't carry it.
         if (!networkId || !target.startsWith('#')) break;
         setChannelNotifyAlways(userId, networkId, target, !!msg.notifyAlways);
-        // Broadcast the full flag pair (notifyAlways + muted) so the muted flag
-        // isn't clobbered when only notify_always changed, and vice versa.
-        fanOut(userId, {
-          kind: 'channel-notify-changed',
-          networkId,
-          target,
-          ...getChannelFlags(userId, networkId, target),
-        });
-        break;
-      }
-      case 'set-channel-muted': {
-        const networkId = Number(msg.networkId);
-        const target = typeof msg.target === 'string' ? msg.target : '';
-        // Mute is a buffer-list display concern and channel-only — DMs always
-        // want their unread shown, server pseudo-buffers can't carry it.
-        if (!networkId || !target.startsWith('#')) break;
-        setChannelMuted(userId, networkId, target, !!msg.muted);
         fanOut(userId, {
           kind: 'channel-notify-changed',
           networkId,

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -989,20 +989,20 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
   // maybePush additionally honors .nonotify (issue #359 — a NONOTIFY mute rule
   // freezes push without hiding the message).
   function ignoreVerdictFor(userId: number, decorated: DecoratedEvent): IgnoreVerdict {
-    if (decorated.nick) {
-      const compiled = ignoreRulesService.getCompiled(userId, decorated.networkId);
-      if (compiled.length) {
-        return evaluateIgnores(compiled, {
-          nick: decorated.nick,
-          userhost: decorated.userhost ?? null,
-          target: decorated.target,
-          text: decorated.text ?? '',
-          type: decorated.type,
-          isDm: !!decorated.dm,
-        });
-      }
-    }
-    return { hide: false, nohilight: false, nonotify: false };
+    const compiled = ignoreRulesService.getCompiled(userId, decorated.networkId);
+    if (!compiled.length) return { hide: false, nohilight: false, nonotify: false };
+    // Evaluate even for a nick-less event: a scope mute (mask null — a muted
+    // channel/network) must still veto its notification, so a nick-less line
+    // (e.g. a server notice in a notify_always channel) doesn't slip past. A
+    // sender-specific rule simply won't match a null nick.
+    return evaluateIgnores(compiled, {
+      nick: decorated.nick ?? null,
+      userhost: decorated.userhost ?? null,
+      target: decorated.target,
+      text: decorated.text ?? '',
+      type: decorated.type,
+      isDm: !!decorated.dm,
+    });
   }
 
   // True when the user's ignore rules would hide this event (a hide-level match,

--- a/shared/ignoreLevels.ts
+++ b/shared/ignoreLevels.ts
@@ -6,8 +6,9 @@
 // which level tokens exist, their aliases, or how they map to event types.
 
 // Each level token maps to the persisted event `type`s it covers. PUBLIC vs MSGS
-// split a 'message' by channel-vs-DM (`dm`). ALL and NOHIGHLIGHT are special
-// (handled by the matcher); CTCPS is accepted but maps to nothing — Lurker never
+// split a 'message' by channel-vs-DM (`dm`). ALL and the modifier levels
+// (NOHIGHLIGHT / NOUNREAD / NONOTIFY) are special (handled by the matcher, not
+// event-type tokens); CTCPS is accepted but maps to nothing — Lurker never
 // surfaces CTCP as a persisted type, a documented no-op.
 export const LEVEL_DEFS: Record<string, { types: string[]; dm?: boolean }> = {
   PUBLIC: { types: ['message'], dm: false },
@@ -74,6 +75,19 @@ export const LEVEL_ALIASES: Record<string, string> = {
   NOHIGHLIGHTS: 'NOHIGHLIGHT',
   NOHILIGHT: 'NOHIGHLIGHT',
   NOHILITE: 'NOHIGHLIGHT',
+  // Modifier levels for muting (issue #359). NOUNREAD suppresses the plain-unread
+  // signal (≙ irssi's NO_ACT, "don't trigger channel activity"); NONOTIFY
+  // suppresses toast/push/sound. Both keep the message visible + counted, like
+  // NOHIGHLIGHT. irssi's NO_ACT spellings are accepted as NOUNREAD aliases.
+  NOUNREAD: 'NOUNREAD',
+  NOUNREADS: 'NOUNREAD',
+  NO_ACT: 'NOUNREAD',
+  NOACT: 'NOUNREAD',
+  NOACTIVITY: 'NOUNREAD',
+  NONOTIFY: 'NONOTIFY',
+  NONOTIFYS: 'NONOTIFY',
+  NONOTIFICATION: 'NONOTIFY',
+  NONOTIFICATIONS: 'NONOTIFY',
 };
 
 // Deterministic order so the stored levels CSV is stable (the DB dedupe compares
@@ -93,6 +107,8 @@ export const CANONICAL_ORDER = [
   'TOPICS',
   'CTCPS',
   'NOHIGHLIGHT',
+  'NOUNREAD',
+  'NONOTIFY',
 ];
 
 export const KNOWN_LEVELS = new Set(Object.keys(LEVEL_ALIASES));

--- a/shared/ignoreMatch.ts
+++ b/shared/ignoreMatch.ts
@@ -10,6 +10,12 @@
 import { buildTextTest, cleanForMatch, type TextKind } from './textMatch.js';
 import { LEVEL_DEFS, ALL_TYPES, HIGHLIGHTABLE } from './ignoreLevels.js';
 
+// The special "modifier" levels: they don't name an event-type to hide, they
+// change how a still-visible message is treated (never highlight / don't bump
+// unread / don't notify). Filtered out of the hide-level set so a modifier-only
+// rule keeps `hides` false. See issues #301 (NOHIGHLIGHT) and #359.
+const MODIFIER_LEVELS = new Set(['NOHIGHLIGHT', 'NOUNREAD', 'NONOTIFY']);
+
 // Re-export the level helpers the store / parser / service pull from here.
 export { KNOWN_LEVELS, canonicalLevel, canonicalizeLevels } from './ignoreLevels.js';
 
@@ -105,6 +111,12 @@ export interface IgnoreInput {
 export interface IgnoreVerdict {
   hide: boolean;
   nohilight: boolean;
+  // Modifier verdict (issue #359): the message stays visible + counted, but
+  // nonotify suppresses toast/push/sound (honors longest-mask-wins + -except).
+  // NOUNREAD is deliberately NOT a per-message verdict — muting the buffer-list
+  // unread badge is a whole-buffer concern computed by channelMutesUnread off the
+  // compiled `nounread` flag; per-sender unread accounting is deferred (#359).
+  nonotify: boolean;
 }
 
 export interface CompiledIgnoreRule {
@@ -113,8 +125,11 @@ export interface CompiledIgnoreRule {
   expiresAt: number | null;
   hides: boolean;
   nohilight: boolean;
+  nounread: boolean;
+  nonotify: boolean;
   pattern: boolean; // has a content pattern (used by member-list gating)
   channels: boolean; // is channel-scoped
+  anyNick: boolean; // mask matches everyone (null/*) — used by channelMutesUnread
   hasAll: boolean;
   matchesNick: (nick: string | null, userhost: string | null) => boolean;
   matchesChannel: (target: string) => boolean;
@@ -136,7 +151,9 @@ export function compileIgnoreRules(rules: IgnoreRule[]): CompiledIgnoreRule[] {
   const out: CompiledIgnoreRule[] = [];
   for (const rule of rules) {
     const hasNohilight = rule.levels.includes('NOHIGHLIGHT');
-    const hideLevels = rule.levels.filter((l) => l !== 'NOHIGHLIGHT');
+    const hasNounread = rule.levels.includes('NOUNREAD');
+    const hasNonotify = rule.levels.includes('NONOTIFY');
+    const hideLevels = rule.levels.filter((l) => !MODIFIER_LEVELS.has(l));
     const hasAll = hideLevels.includes('ALL');
     const hides = hideLevels.length > 0;
 
@@ -167,8 +184,11 @@ export function compileIgnoreRules(rules: IgnoreRule[]): CompiledIgnoreRule[] {
       expiresAt: rule.expiresAt ? Date.parse(rule.expiresAt) : null,
       hides,
       nohilight: hasNohilight,
+      nounread: hasNounread,
+      nonotify: hasNonotify,
       pattern: !!rule.pattern,
       channels: !!(rule.channels && rule.channels.length),
+      anyNick: !rule.mask || rule.mask === '*',
       hasAll,
       matchesNick,
       matchesChannel,
@@ -191,7 +211,7 @@ export function evaluateIgnores(
   input: IgnoreInput,
   now: number = Date.now(),
 ): IgnoreVerdict {
-  if (compiled.length === 0) return { hide: false, nohilight: false };
+  if (compiled.length === 0) return { hide: false, nohilight: false, nonotify: false };
   const { nick, userhost, target, type, isDm } = input;
   // Only pay for the URL/formatting strip when a rule actually matches text.
   const text = input.text && anyHasPattern(compiled) ? cleanForMatch(input.text) : '';
@@ -200,13 +220,23 @@ export function evaluateIgnores(
   let bestHideExcept = -1;
   let bestNo = -1;
   let bestNoExcept = -1;
+  let bestNotify = -1;
+  let bestNotifyExcept = -1;
 
   for (const r of compiled) {
     if (r.expiresAt !== null && r.expiresAt <= now) continue;
     const hideApplies = r.hides && r.hideLevel(type, isDm);
+    // nohilight only sensibly applies to highlightable (message/action) events;
+    // when the rule also carries hide levels it's bounded to those.
     const noApplies =
       r.nohilight && HIGHLIGHTABLE.has(type) && (r.hides ? r.hideLevel(type, isDm) : true);
-    if (!hideApplies && !noApplies) continue;
+    // nonotify gates notifications, which — via a channel's notify_always — can
+    // fire for ANY event type (notices, joins, …), so it is NOT bounded to
+    // highlightable types (issue #359 "quietest wins": a network/channel mute
+    // must veto those too). Bounded only by the rule's own hide levels if it has
+    // any; a modifier-only NONOTIFY rule applies to every type its target matches.
+    const notifyApplies = r.nonotify && (r.hides ? r.hideLevel(type, isDm) : true);
+    if (!hideApplies && !noApplies && !notifyApplies) continue;
     if (!r.matchesNick(nick, userhost)) continue;
     if (!r.matchesChannel(target)) continue;
     if (!r.matchesText(text)) continue;
@@ -225,11 +255,19 @@ export function evaluateIgnores(
         bestNo = r.maskLen;
       }
     }
+    if (notifyApplies) {
+      if (r.isExcept) {
+        if (r.maskLen > bestNotifyExcept) bestNotifyExcept = r.maskLen;
+      } else if (r.maskLen > bestNotify) {
+        bestNotify = r.maskLen;
+      }
+    }
   }
 
   return {
     hide: bestHide >= 0 && bestHideExcept < bestHide,
     nohilight: bestNo >= 0 && bestNoExcept < bestNo,
+    nonotify: bestNotify >= 0 && bestNotifyExcept < bestNotify,
   };
 }
 
@@ -250,6 +288,26 @@ export function isMemberHidden(
     if (r.expiresAt !== null && r.expiresAt <= now) continue;
     if (!r.matchesChannel(channel)) continue;
     if (r.matchesNick(nick, userhost)) return true;
+  }
+  return false;
+}
+
+// Whether a whole buffer's plain-unread signal is muted (issue #359) — used by
+// the buffer list to downgrade the unread badge, mirroring the old per-channel
+// `muted` flag. True when a non-except, no-pattern, everyone-mask (null/*) rule
+// carrying NOUNREAD covers this buffer. A network-wide rule (channels null)
+// matches every buffer, so muting a network downgrades all its children here.
+// Per-sender NOUNREAD (a masked rule) deliberately does NOT mute the whole
+// buffer's badge — that would need insert-time unread accounting (deferred).
+export function channelMutesUnread(
+  compiled: CompiledIgnoreRule[],
+  channel: string,
+  now: number = Date.now(),
+): boolean {
+  for (const r of compiled) {
+    if (r.isExcept || r.pattern || !r.nounread || !r.anyNick) continue;
+    if (r.expiresAt !== null && r.expiresAt <= now) continue;
+    if (r.matchesChannel(channel)) return true;
   }
   return false;
 }

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -290,7 +290,7 @@ import { FRIENDS_KEY, SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { connected as lurkerConnected } from '../composables/useSocket.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { usePinsStore } from '../stores/pins.js';
-import { useChannelNotifyStore } from '../stores/channelNotify.js';
+import { useIgnoresStore } from '../stores/ignores.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useBufferActions } from '../composables/useBufferActions.js';
 import { useNetworkActions } from '../composables/useNetworkActions.js';
@@ -305,7 +305,7 @@ const buffers = useBuffersStore();
 const friends = useFriendsStore();
 const drafts = useDraftStore();
 const pins = usePinsStore();
-const channelNotify = useChannelNotifyStore();
+const ignores = useIgnoresStore();
 const settings = useSettingsStore();
 const bufferActions = useBufferActions();
 const networkActions = useNetworkActions();
@@ -349,19 +349,15 @@ function countFor(unread: number, highlights: number): number {
   return 0;
 }
 
-// A muted channel drops the plain-unread signal from the buffer list: a "full"
+// A muted buffer drops the plain-unread signal from the buffer list: a "full"
 // count downgrades to highlights-only so ordinary traffic stops incrementing
 // the badge, and the `unread` row class (color + bold + off-screen arrow) is
 // withheld below. Highlights pass through untouched — they still color the row
 // and show the ● per the global display mode, which is the whole point of
-// muting a busy-but-followed room. Mute is channel-only; DMs/server never muted.
+// muting a busy-but-followed room. Mute is now an ignore rule carrying NOUNREAD
+// (issue #359): channel, DM, or a network-wide rule that covers every child.
 function isChannelMuted(buf: Buffer | null): boolean {
-  return (
-    !!buf &&
-    buf.networkId != null &&
-    buf.target.startsWith('#') &&
-    channelNotify.muted(buf.networkId, buf.target)
-  );
+  return !!buf && buf.networkId != null && ignores.bufferMutesUnread(buf.networkId, buf.target);
 }
 function displayCount(buf: Buffer): number {
   const mode =

--- a/vue_client/src/components/ContextMenu.vue
+++ b/vue_client/src/components/ContextMenu.vue
@@ -16,6 +16,7 @@
     >
       <template v-for="(item, i) in state.items" :key="i">
         <div v-if="item.divider" class="divider" role="separator"></div>
+        <div v-else-if="item.heading" class="heading" role="presentation">{{ item.heading }}</div>
         <button
           v-else
           type="button"
@@ -91,6 +92,18 @@ function onWindowPointerDown(e: PointerEvent): void {
 function onWindowKey(e: KeyboardEvent): void {
   if (state.open && e.key === 'Escape') menu.close();
 }
+// Close on a user-driven scroll gesture (wheel / touch drag) — the menu is
+// pinned to fixed cursor/anchor coords, so once the user scrolls the content
+// underneath it, it would float detached. We deliberately listen for the
+// *gesture* (wheel/touchmove), NOT the 'scroll' event: a busy channel's
+// auto-scroll on each new message fires 'scroll' programmatically and would
+// otherwise slam the menu shut mid-interaction. A gesture that starts inside the
+// menu itself (e.g. scrolling a long menu) is ignored.
+function onWindowUserScroll(e: Event): void {
+  if (!state.open) return;
+  if (menuEl.value && menuEl.value.contains(e.target as Node)) return;
+  menu.close();
+}
 function onWindowResize(): void {
   if (state.open) menu.close();
 }
@@ -110,12 +123,14 @@ watch(
       window.addEventListener('pointerdown', onWindowPointerDown, true);
       window.addEventListener('keydown', onWindowKey);
       window.addEventListener('resize', onWindowResize);
-      window.addEventListener('scroll', onWindowResize, true);
+      window.addEventListener('wheel', onWindowUserScroll, { capture: true, passive: true });
+      window.addEventListener('touchmove', onWindowUserScroll, { capture: true, passive: true });
     } else {
       window.removeEventListener('pointerdown', onWindowPointerDown, true);
       window.removeEventListener('keydown', onWindowKey);
       window.removeEventListener('resize', onWindowResize);
-      window.removeEventListener('scroll', onWindowResize, true);
+      window.removeEventListener('wheel', onWindowUserScroll, true);
+      window.removeEventListener('touchmove', onWindowUserScroll, true);
     }
   },
 );
@@ -124,7 +139,8 @@ onBeforeUnmount(() => {
   window.removeEventListener('pointerdown', onWindowPointerDown, true);
   window.removeEventListener('keydown', onWindowKey);
   window.removeEventListener('resize', onWindowResize);
-  window.removeEventListener('scroll', onWindowResize, true);
+  window.removeEventListener('wheel', onWindowUserScroll, true);
+  window.removeEventListener('touchmove', onWindowUserScroll, true);
 });
 </script>
 
@@ -199,6 +215,17 @@ onBeforeUnmount(() => {
   flex-shrink: 0;
   color: var(--fg-muted);
   transform: translateY(1px);
+}
+.heading {
+  /* A muted group label above a radio group (e.g. "Notifications"). Uppercased
+     with letter-spacing so it reads as a header without changing font-size (the
+     app keeps a single type size — hierarchy comes from color/weight/spacing). */
+  padding: var(--space-3) var(--space-7) var(--space-2);
+  color: var(--fg-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  user-select: none;
 }
 .divider {
   height: 1px;

--- a/vue_client/src/components/ContextMenu.vue
+++ b/vue_client/src/components/ContextMenu.vue
@@ -101,7 +101,11 @@ function onWindowKey(e: KeyboardEvent): void {
 // menu itself (e.g. scrolling a long menu) is ignored.
 function onWindowUserScroll(e: Event): void {
   if (!state.open) return;
-  if (menuEl.value && menuEl.value.contains(e.target as Node)) return;
+  // e.target on a captured wheel/touchmove is normally the element under the
+  // pointer, but guard the non-Node case (window/document) so contains() can't
+  // throw. A non-Node target is never inside the menu, so fall through to close.
+  const t = e.target;
+  if (t instanceof Node && menuEl.value?.contains(t)) return;
   menu.close();
 }
 function onWindowResize(): void {

--- a/vue_client/src/composables/useBufferActions.ts
+++ b/vue_client/src/composables/useBufferActions.ts
@@ -3,11 +3,11 @@
 
 import type { ContextMenuItem } from './useContextMenu.js';
 import { usePinsStore } from '../stores/pins.js';
-import { useChannelNotifyStore } from '../stores/channelNotify.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useFriendsStore } from '../stores/friends.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useContextMenu } from './useContextMenu.js';
+import { useNotifyLadder } from './useNotifyLadder.js';
 import { socketSend } from './useSocket.js';
 
 export interface BufferLike {
@@ -29,11 +29,11 @@ export interface BufferActionsAPI {
 // network, browse channels) and aren't handled here.
 export function useBufferActions(): BufferActionsAPI {
   const pins = usePinsStore();
-  const channelNotify = useChannelNotifyStore();
   const nickNotes = useNickNotesStore();
   const friends = useFriendsStore();
   const whois = useWhoisStore();
   const menu = useContextMenu();
+  const notify = useNotifyLadder();
 
   function buildItems(buf: BufferLike | null | undefined): ContextMenuItem[] {
     // Capture networkId as a const after the null guard so the narrowing to
@@ -58,68 +58,45 @@ export function useBufferActions(): BufferActionsAPI {
             onClick: () => pins.pin(networkId, buf.target),
           },
     ];
-    if (isChannel) {
-      const isAlwaysNotify = channelNotify.notifyAlways(networkId, buf.target);
-      items.push(
-        // Icon reflects current state (solid = always-notifying, regular = not)
-        // to match the topic-bar toggle; the label states the action.
-        isAlwaysNotify
-          ? {
-              label: 'Stop Always Notifying',
-              icon: 'fa-solid fa-bell',
-              onClick: () => channelNotify.setNotifyAlways(networkId, buf.target, false),
-            }
-          : {
-              label: 'Always Notify',
-              icon: 'fa-regular fa-bell',
-              onClick: () => channelNotify.setNotifyAlways(networkId, buf.target, true),
-            },
-      );
-      // Mute hides the unread count + row color for ordinary traffic, leaving
-      // highlights (and notifications) intact — for busy rooms you want to stay
-      // in but not have nagging at you. Icon mirrors the always-notify pattern:
-      // solid bell-slash = muted, regular bell-slash = not.
-      const isMuted = channelNotify.muted(networkId, buf.target);
-      items.push(
-        isMuted
-          ? {
-              label: 'Unmute Channel',
-              icon: 'fa-solid fa-bell-slash',
-              onClick: () => channelNotify.setMuted(networkId, buf.target, false),
-            }
-          : {
-              label: 'Mute Channel',
-              icon: 'fa-regular fa-bell-slash',
-              onClick: () => channelNotify.setMuted(networkId, buf.target, true),
-            },
-      );
-    } else {
+    // Notification "quietness" ladder (issue #359): channels get the full 4-rung
+    // ladder (All / Highlights / Nothing / Muted), DMs the 3-rung one (no
+    // "Highlights only" — every DM is already the signal).
+    items.push(
+      { divider: true },
+      ...(isChannel
+        ? notify.channelItems(networkId, buf.target)
+        : notify.dmItems(networkId, buf.target)),
+    );
+    if (!isChannel) {
       // DM target is the peer's nick — open the profile/note actions directly.
       // Channels can't carry a per-nick action from this menu (which nick?),
       // so these are DM-only; in-channel equivalents flow through the member
       // list menu.
       const hasNote = nickNotes.hasNote(networkId, buf.target);
       const isFriend = !!friends.contactForTarget(networkId, buf.target);
-      items.push({
-        label: 'View Profile…',
-        icon: 'fa-solid fa-id-card',
-        onClick: () => whois.openViewer(networkId, buf.target),
-      });
-      items.push({
-        label: hasNote ? 'Edit Note…' : 'Add Note…',
-        icon: 'fa-solid fa-note-sticky',
-        onClick: () => nickNotes.openEditor(networkId, buf.target),
-      });
-      items.push({
-        label: isFriend ? 'Edit Friend…' : 'Add Friend…',
-        icon: 'fa-solid fa-user-group',
-        onClick: () => friends.openEditorForNick(networkId, buf.target),
-      });
+      items.push(
+        { divider: true },
+        {
+          label: 'View Profile…',
+          icon: 'fa-solid fa-id-card',
+          onClick: () => whois.openViewer(networkId, buf.target),
+        },
+        {
+          label: hasNote ? 'Edit Note…' : 'Add Note…',
+          icon: 'fa-solid fa-note-sticky',
+          onClick: () => nickNotes.openEditor(networkId, buf.target),
+        },
+        {
+          label: isFriend ? 'Edit Friend…' : 'Add Friend…',
+          icon: 'fa-solid fa-user-group',
+          onClick: () => friends.openEditorForNick(networkId, buf.target),
+        },
+      );
     }
     // Close drops the buffer entirely — for a channel that also PARTs it, for
     // a DM it just stops tracking the peer. Both are reversible (rejoin /
     // reopen), so no confirmation; the divider sets it apart from the
-    // non-destructive pin/notify/note actions above.
+    // non-destructive actions above.
     items.push(
       { divider: true },
       {

--- a/vue_client/src/composables/useContextMenu.ts
+++ b/vue_client/src/composables/useContextMenu.ts
@@ -20,6 +20,9 @@ export interface ContextMenuItem {
   icon?: string;
   disabled?: boolean;
   divider?: boolean;
+  // A non-interactive small-caps group label (e.g. "Notifications" above a radio
+  // group). Rendered as a muted heading row; other fields ignored.
+  heading?: string;
 }
 
 export interface ContextMenuState {

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -117,9 +117,10 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
 
   // Ignored sender → no toast, no sound. Full-context evaluate so a scoped rule
   // (/ignore x PUBLIC, a #chan or -pattern rule) suppresses the toast for a
-  // message it also hides, and a NOHIGHLIGHT rule suppresses the highlight
-  // toast/sound while leaving the message visible. Push is gated server-side in
-  // wsHub.maybePush (push fires while no client is open).
+  // message it also hides; a NOHIGHLIGHT rule suppresses the highlight
+  // toast/sound while leaving the message visible; and a NONOTIFY rule (a muted
+  // channel/network/DM — issue #359) suppresses the toast/sound outright. Push
+  // is gated server-side in wsHub.maybePush (push fires while no client is open).
   const ignores = useIgnoresStore();
   if (event.nick && event.networkId && event.target) {
     const verdict = ignores.evaluate(event.networkId, {
@@ -130,7 +131,7 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
       type: event.type ?? 'message',
       isDm: !!event.dm,
     });
-    if (verdict.hide || verdict.nohilight) return;
+    if (verdict.hide || verdict.nohilight || verdict.nonotify) return;
   }
 
   const settings = useSettingsStore();

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -119,12 +119,14 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   // (/ignore x PUBLIC, a #chan or -pattern rule) suppresses the toast for a
   // message it also hides; a NOHIGHLIGHT rule suppresses the highlight
   // toast/sound while leaving the message visible; and a NONOTIFY rule (a muted
-  // channel/network/DM — issue #359) suppresses the toast/sound outright. Push
-  // is gated server-side in wsHub.maybePush (push fires while no client is open).
+  // channel/network/DM — issue #359) suppresses the toast/sound outright. We
+  // evaluate even for a nick-less event so a scope mute (mask null) still vetoes
+  // it; a sender-specific rule just won't match a null nick. Push is gated
+  // server-side in wsHub.maybePush (push fires while no client is open).
   const ignores = useIgnoresStore();
-  if (event.nick && event.networkId && event.target) {
+  if (event.networkId && event.target) {
     const verdict = ignores.evaluate(event.networkId, {
-      nick: event.nick,
+      nick: event.nick ?? null,
       userhost: event.userhost ?? null,
       target: event.target,
       text: event.text ?? '',

--- a/vue_client/src/composables/useNetworkActions.ts
+++ b/vue_client/src/composables/useNetworkActions.ts
@@ -5,6 +5,7 @@ import type { ContextMenuItem } from './useContextMenu.js';
 import { useContextMenu } from './useContextMenu.js';
 import { useChannelListModal } from './useChannelListModal.js';
 import { useNetworkEditor } from './useNetworkEditor.js';
+import { useNotifyLadder } from './useNotifyLadder.js';
 import { useNetworksStore, type Network } from '../stores/networks.js';
 
 // Buffer-list action logic for network rows. Analogous to useBufferActions for
@@ -14,6 +15,7 @@ export function useNetworkActions() {
   const menu = useContextMenu();
   const channelListModal = useChannelListModal();
   const networkEditor = useNetworkEditor();
+  const notify = useNotifyLadder();
   const networks = useNetworksStore();
 
   function toggleConnection(networkId: number): void {
@@ -36,6 +38,11 @@ export function useNetworkActions() {
         icon: isConnected ? 'fa-solid fa-plug-circle-xmark' : 'fa-solid fa-plug',
         onClick: () => toggleConnection(net.id),
       },
+      // Network-wide notification ladder (issue #359): Highlights only (default)
+      // / Nothing / Muted — a -network-scoped NONOTIFY(+NOUNREAD) rule covering
+      // every buffer on the network.
+      { divider: true },
+      ...notify.networkItems(net.id),
     ];
   }
 

--- a/vue_client/src/composables/useNotifyLadder.ts
+++ b/vue_client/src/composables/useNotifyLadder.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The notification "quietness" ladder (issue #359), shared by the channel/DM
+// buffer menu (useBufferActions) and the network menu (useNetworkActions). A
+// single monotonically-quieter radio group per buffer/network:
+//
+//   Channel:  All messages · Highlights only (default) · Nothing · Muted
+//   DM:       All messages (default) · Nothing · Muted     (no "Highlights only"
+//             — every DM is already the signal)
+//   Network:  Highlights only (default) · Nothing · Muted  (no "All" — a network
+//             firehose makes no sense)
+//
+// Under the hood the suppressor rungs are ignore rules: "Nothing" = a NONOTIFY
+// rule, "Muted" = NONOTIFY + NOUNREAD, both scoped to the buffer (channel/DM
+// target) or the whole network. "All messages" is the channel-only notify_always
+// flag. The rungs are mutually exclusive, so no conflicting state can be created
+// from the menu; if a hand-typed /ignore contradicts, the ignore veto wins.
+
+import type { ContextMenuItem } from './useContextMenu.js';
+import { useIgnoresStore } from '../stores/ignores.js';
+import { useChannelNotifyStore } from '../stores/channelNotify.js';
+import { canonicalizeLevels, type IgnoreRule } from '../utils/ignoreMatch.js';
+
+type Rung = 'all' | 'highlights' | 'nothing' | 'muted';
+
+// Levels for the suppressor rungs; 'all'/'highlights' carry no ignore rule.
+function levelsForRung(rung: Rung): string[] | null {
+  if (rung === 'nothing') return canonicalizeLevels(['NONOTIFY']);
+  if (rung === 'muted') return canonicalizeLevels(['NOUNREAD', 'NONOTIFY']);
+  return null;
+}
+
+function sameLevels(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((l) => set.has(l));
+}
+
+// Which rung a mute rule's levels represent. Keyed on NONOTIFY (the notify
+// dimension): NONOTIFY+NOUNREAD = Muted, NONOTIFY alone = Nothing. A NOUNREAD-only
+// rule (badge hidden but notifications still fire — only reachable by hand-typed
+// /ignore) falls through to `base`, since it is neither "Nothing" nor "Muted".
+function rungFromLevels(levels: string[], base: Rung): Rung {
+  if (levels.includes('NONOTIFY')) return levels.includes('NOUNREAD') ? 'muted' : 'nothing';
+  return base;
+}
+
+export function useNotifyLadder() {
+  const ignores = useIgnoresStore();
+  const channelNotify = useChannelNotifyStore();
+
+  function rungItem(label: string, active: boolean, onClick: () => void): ContextMenuItem {
+    return { label, icon: active ? 'fa-solid fa-circle-dot' : 'fa-regular fa-circle', onClick };
+  }
+
+  // Reconcile the per-buffer (or, when channels is null, per-network) mute rule
+  // to the desired rung: remove a stale rule and add the wanted one. Idempotent
+  // when the current rule already matches. A new rule is added at `addNetworkId`
+  // (network scope), but a stale rule is removed from ITS OWN scope
+  // (existing.networkId, null = global) so a hand-typed global mute is cleared
+  // from the right bucket rather than orphaned.
+  function reconcileRule(
+    addNetworkId: number,
+    existing: { id: number; levels: string[]; networkId: number | null } | null,
+    want: string[] | null,
+    channels: string[] | null,
+  ): void {
+    if (existing && want && sameLevels(existing.levels, want)) return;
+    if (existing) ignores.removeRule(existing.networkId, { id: existing.id });
+    if (want) {
+      const rule: IgnoreRule = {
+        mask: null,
+        channels,
+        pattern: null,
+        patternKind: 'substr',
+        levels: want,
+        isExcept: false,
+        expiresAt: null,
+      };
+      ignores.addRule(addNetworkId, rule);
+    }
+  }
+
+  // ---- Channel: 4 rungs (notify_always + buffer mute rule) ------------------
+  function channelItems(networkId: number, target: string): ContextMenuItem[] {
+    const notifyAlways = channelNotify.notifyAlways(networkId, target);
+    const levels = ignores.bufferMuteRule(networkId, target)?.levels ?? [];
+    const current: Rung = notifyAlways ? 'all' : rungFromLevels(levels, 'highlights');
+    const set = (rung: Rung) => {
+      if ((rung === 'all') !== notifyAlways) {
+        channelNotify.setNotifyAlways(networkId, target, rung === 'all');
+      }
+      reconcileRule(networkId, ignores.bufferMuteRule(networkId, target), levelsForRung(rung), [
+        target.toLowerCase(),
+      ]);
+    };
+    return [
+      { heading: 'Notifications' },
+      rungItem('All messages', current === 'all', () => set('all')),
+      rungItem('Highlights only', current === 'highlights', () => set('highlights')),
+      rungItem('Nothing', current === 'nothing', () => set('nothing')),
+      rungItem('Muted', current === 'muted', () => set('muted')),
+    ];
+  }
+
+  // ---- DM: 3 rungs (buffer mute rule only, no notify_always) ----------------
+  function dmItems(networkId: number, target: string): ContextMenuItem[] {
+    const levels = ignores.bufferMuteRule(networkId, target)?.levels ?? [];
+    const current: Rung = rungFromLevels(levels, 'all');
+    const set = (rung: Rung) =>
+      reconcileRule(networkId, ignores.bufferMuteRule(networkId, target), levelsForRung(rung), [
+        target.toLowerCase(),
+      ]);
+    return [
+      { heading: 'Notifications' },
+      rungItem('All messages', current === 'all', () => set('all')),
+      rungItem('Nothing', current === 'nothing', () => set('nothing')),
+      rungItem('Muted', current === 'muted', () => set('muted')),
+    ];
+  }
+
+  // ---- Network: 3 rungs (network-wide mute rule) ----------------------------
+  function networkItems(networkId: number): ContextMenuItem[] {
+    const levels = ignores.networkMuteRule(networkId)?.levels ?? [];
+    const current: Rung = rungFromLevels(levels, 'highlights');
+    const set = (rung: Rung) =>
+      reconcileRule(networkId, ignores.networkMuteRule(networkId), levelsForRung(rung), null);
+    return [
+      { heading: 'Notifications' },
+      rungItem('Highlights only', current === 'highlights', () => set('highlights')),
+      rungItem('Nothing', current === 'nothing', () => set('nothing')),
+      rungItem('Muted', current === 'muted', () => set('muted')),
+    ];
+  }
+
+  return { channelItems, dmItems, networkItems };
+}

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -615,7 +615,6 @@ function handleMessage(raw: string): void {
     const channelNotify = useChannelNotifyStore();
     channelNotify.applyChange(payload.networkId, payload.target, {
       notifyAlways: !!payload.notifyAlways,
-      muted: !!payload.muted,
     });
     return;
   }

--- a/vue_client/src/stores/channelNotify.ts
+++ b/vue_client/src/stores/channelNotify.ts
@@ -4,19 +4,17 @@
 import { defineStore } from 'pinia';
 import { socketSend } from '../composables/useSocket.js';
 
-// Per-channel overrides. Two independent flags are tracked:
+// Per-channel override. One flag is tracked here:
 //   notifyAlways — every message in the channel is a notification trigger for
 //                  push/toast (without lighting the channel up as a highlight).
-//   muted        — buffer-list display only: suppress the plain-unread signal
-//                  (count + row color + off-screen unread arrow); highlights
-//                  and notifications are untouched.
-// The server is the source of truth — toggles send a WS message, and the
-// `channel-notify-changed` echo (carrying both flags) updates state on all the
-// user's tabs.
+// The old display-only `muted` flag was folded into the ignore engine as a
+// NOUNREAD/NONOTIFY rule (issue #359) — see the ignores store's bufferMuteRule/
+// networkMuteRule and the notification-menu ladders. The server is the source of
+// truth: toggles send a WS message and the `channel-notify-changed` echo updates
+// state on all the user's tabs.
 
 export interface ChannelNotifyFlags {
   notifyAlways: boolean;
-  muted: boolean;
 }
 
 export interface ChannelNotifyEntry {
@@ -26,15 +24,13 @@ export interface ChannelNotifyEntry {
 
 export const useChannelNotifyStore = defineStore('channelNotify', {
   state: () => ({
-    // { [networkId]: { [target]: { notifyAlways, muted } } } — only channels
-    // with any flag set live here; absent entries default to all-off.
+    // { [networkId]: { [target]: { notifyAlways } } } — only channels with the
+    // flag set live here; absent entries default to off.
     byNetwork: {} as Record<number | string, Record<string, ChannelNotifyFlags>>,
   }),
   getters: {
     notifyAlways: (state) => (networkId: number | string, target: string) =>
       !!state.byNetwork[networkId]?.[target]?.notifyAlways,
-    muted: (state) => (networkId: number | string, target: string) =>
-      !!state.byNetwork[networkId]?.[target]?.muted,
     // List of { networkId, target } for all channels that currently have
     // always-notify enabled — used by the Settings panel's "always-notify
     // channels" audit list.
@@ -58,21 +54,15 @@ export const useChannelNotifyStore = defineStore('channelNotify', {
     },
     applyChange(networkId: number | string, target: string, flags: ChannelNotifyFlags) {
       if (!this.byNetwork[networkId]) this.byNetwork[networkId] = {};
-      if (flags.notifyAlways || flags.muted) {
-        this.byNetwork[networkId][target] = {
-          notifyAlways: !!flags.notifyAlways,
-          muted: !!flags.muted,
-        };
+      if (flags.notifyAlways) {
+        this.byNetwork[networkId][target] = { notifyAlways: true };
       } else {
-        // Both flags off — drop the entry so it mirrors the server's row delete.
+        // Flag off — drop the entry so it mirrors the server's row delete.
         delete this.byNetwork[networkId][target];
       }
     },
     setNotifyAlways(networkId: number | string, target: string, notifyAlways: boolean) {
       socketSend({ type: 'set-channel-notify-always', networkId, target, notifyAlways });
-    },
-    setMuted(networkId: number | string, target: string, muted: boolean) {
-      socketSend({ type: 'set-channel-muted', networkId, target, muted });
     },
   },
 });

--- a/vue_client/src/stores/ignores.test.ts
+++ b/vue_client/src/stores/ignores.test.ts
@@ -137,3 +137,69 @@ describe('ignores store — matcher getters union global + network', () => {
     );
   });
 });
+
+describe('ignores store — mute-rule getters (#359)', () => {
+  const mute = (over: Partial<IgnoreEntry> = {}) =>
+    entry({ mask: null, levels: ['NOUNREAD', 'NONOTIFY'], ...over });
+
+  it('bufferMuteRule finds a network-scoped per-channel mute and reports its scope', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot([{ networkId: 1, ignoredMasks: [mute({ id: 5, channels: ['#chan'] })] }], []);
+    const rule = s.bufferMuteRule(1, '#Chan'); // case-insensitive
+    expect(rule).toMatchObject({ id: 5, networkId: 1 });
+  });
+
+  it('bufferMuteRule also finds a GLOBAL per-channel mute (default /ignore scope) with networkId null', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot([{ networkId: 1, ignoredMasks: [] }], [mute({ id: 7, channels: ['#chan'] })]);
+    expect(s.bufferMuteRule(1, '#chan')).toMatchObject({ id: 7, networkId: null });
+    // …and the badge path agrees the buffer is muted.
+    expect(s.bufferMutesUnread(1, '#chan')).toBe(true);
+  });
+
+  it('bufferMuteRule ignores masked / patterned / except / non-mute rules', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot(
+      [
+        {
+          networkId: 1,
+          ignoredMasks: [
+            mute({ id: 1, channels: ['#chan'], mask: 'bob' }), // masked → not a whole-buffer mute
+            mute({ id: 2, channels: ['#chan'], isExcept: true }), // except
+            entry({ id: 3, mask: null, channels: ['#chan'], levels: ['PUBLIC'] }), // hide, not mute
+          ],
+        },
+      ],
+      [],
+    );
+    expect(s.bufferMuteRule(1, '#chan')).toBeNull();
+  });
+
+  it('networkMuteRule finds a network-wide (channel-less) mute; a per-channel rule is not it', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot(
+      [
+        {
+          networkId: 1,
+          ignoredMasks: [mute({ id: 8, channels: null }), mute({ id: 9, channels: ['#chan'] })],
+        },
+      ],
+      [],
+    );
+    expect(s.networkMuteRule(1)).toMatchObject({ id: 8, networkId: 1 });
+  });
+
+  it('a network-wide mute downgrades unread for every buffer incl. DMs', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot([{ networkId: 1, ignoredMasks: [mute({ id: 8, channels: null })] }], []);
+    expect(s.bufferMutesUnread(1, '#anything')).toBe(true);
+    expect(s.bufferMutesUnread(1, 'somenick')).toBe(true); // DM buffer
+  });
+
+  it('a per-channel mute does not leak to sibling buffers', () => {
+    const s = useIgnoresStore();
+    s.applySnapshot([{ networkId: 2, ignoredMasks: [mute({ id: 9, channels: ['#only'] })] }], []);
+    expect(s.bufferMutesUnread(2, '#only')).toBe(true);
+    expect(s.bufferMutesUnread(2, '#other')).toBe(false);
+  });
+});

--- a/vue_client/src/stores/ignores.ts
+++ b/vue_client/src/stores/ignores.ts
@@ -7,10 +7,37 @@ import {
   compileIgnoreRules,
   evaluateIgnores,
   isMemberHidden,
+  channelMutesUnread,
   type IgnoreRule,
   type IgnoreInput,
   type IgnoreVerdict,
 } from '../utils/ignoreMatch.js';
+
+// The two "mute" modifier levels (issue #359). A per-buffer or per-network mute
+// rung is a canonical rule carrying only these (no hide levels, no mask/pattern/
+// except), so the notification menus can find, read, and toggle it.
+const MUTE_LEVELS = new Set(['NOUNREAD', 'NONOTIFY']);
+function isMuteOnlyLevels(levels: string[]): boolean {
+  return levels.length > 0 && levels.every((l) => MUTE_LEVELS.has(l));
+}
+
+// Find the canonical mute rule (unmasked, unpatterned, non-except, mute-only
+// levels) matching a scope predicate, searching the network bucket then globals.
+// Returns it annotated with its scope (networkId null = global) so the caller
+// removes it from the right bucket. Shared by bufferMuteRule/networkMuteRule.
+function findMuteRule(
+  netList: IgnoreEntry[],
+  globalList: IgnoreEntry[],
+  networkId: number,
+  scopeMatches: (e: IgnoreEntry) => boolean,
+): IgnoreEntryWithNetwork | null {
+  const ok = (e: IgnoreEntry) =>
+    !e.mask && !e.pattern && !e.isExcept && scopeMatches(e) && isMuteOnlyLevels(e.levels);
+  const net = netList.find(ok);
+  if (net) return { ...net, networkId };
+  const g = globalList.find(ok);
+  return g ? { ...g, networkId: null } : null;
+}
 
 // Ignore rules (issue #301; global-vs-network scoping #350). Server is the
 // source of truth — adds/removes ship over WS and the server fans an
@@ -88,8 +115,60 @@ export const useIgnoresStore = defineStore('ignores', {
         const nid = Number(networkId);
         const net = state.byNetwork[nid] || EMPTY;
         const g = state.global;
-        if (g.length === 0 && net.length === 0) return { hide: false, nohilight: false };
+        if (g.length === 0 && net.length === 0)
+          return { hide: false, nohilight: false, nonotify: false };
         return evaluateIgnores(mergedCompiled(g, net, nid), ctx);
+      },
+
+    // Buffer-list mute check (issue #359): does a whole-buffer NOUNREAD rule
+    // cover this target? Includes network-wide rules (channels null) and globals,
+    // so muting a network downgrades every child buffer's unread here. Serves
+    // channels (#chan) and DMs (peer nick) alike.
+    bufferMutesUnread:
+      (state) =>
+      (networkId: number | string, target: string): boolean => {
+        const nid = Number(networkId);
+        const net = state.byNetwork[nid] || EMPTY;
+        const g = state.global;
+        if (g.length === 0 && net.length === 0) return false;
+        return channelMutesUnread(mergedCompiled(g, net, nid), target);
+      },
+
+    // The canonical per-buffer notification rule for the given target — an
+    // unmasked, unpatterned, non-except rule carrying only mute levels, whose
+    // channel scope is exactly [target]. Searches the network bucket then globals
+    // (so a hand-typed global `/ignore #chan NOUNREAD NONOTIFY` — global is the
+    // default scope — is still recognized, matching bufferMutesUnread). The
+    // returned `networkId` (null = global) tells the menu which bucket to remove
+    // from. Serves channels (#chan) and DMs (peer nick) alike.
+    bufferMuteRule:
+      (state) =>
+      (networkId: number | string, target: string): IgnoreEntryWithNetwork | null => {
+        const nid = Number(networkId);
+        const t = target.toLowerCase();
+        return findMuteRule(
+          state.byNetwork[nid] || EMPTY,
+          state.global,
+          nid,
+          (e) => e.channels?.length === 1 && e.channels[0].toLowerCase() === t,
+        );
+      },
+
+    // The canonical network-wide notification rule — like bufferMuteRule but
+    // scoped to the whole network (no channel scope). Used by the network menu.
+    // A global no-channel mute rule is "mute everything, every network"; toggling
+    // it from a single network's menu removes it globally, which is the honest
+    // consequence of having created a global rule.
+    networkMuteRule:
+      (state) =>
+      (networkId: number | string): IgnoreEntryWithNetwork | null => {
+        const nid = Number(networkId);
+        return findMuteRule(
+          state.byNetwork[nid] || EMPTY,
+          state.global,
+          nid,
+          (e) => !e.channels || e.channels.length === 0,
+        );
       },
 
     isHidden:

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -139,16 +139,6 @@
         </template>
         <template v-else-if="isChannel">
           <button
-            type="button"
-            class="link notify"
-            :class="{ on: channelNotifyAlways }"
-            :title="channelNotifyLabel"
-            :aria-label="channelNotifyLabel"
-            @click="toggleChannelNotify"
-          >
-            <i :class="channelNotifyAlways ? 'fa-solid fa-bell' : 'fa-regular fa-bell'"></i>
-          </button>
-          <button
             class="link"
             :title="showMembers ? 'Hide members' : 'Show members'"
             :aria-label="showMembers ? 'Hide members' : 'Show members'"
@@ -261,7 +251,6 @@ import { useFriendsStore } from '../stores/friends.js';
 import { useDccStore } from '../stores/dcc.js';
 import { useSearchStore } from '../stores/search.js';
 import { useWhoisStore } from '../stores/whois.js';
-import { useChannelNotifyStore } from '../stores/channelNotify.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { useImageModal } from '../composables/useImageModal.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
@@ -308,7 +297,6 @@ const dccTitle = computed(() =>
   dcc.pendingCount > 0 ? `DCC transfers — ${dcc.pendingCount} awaiting approval` : 'DCC transfers',
 );
 const whois = useWhoisStore();
-const channelNotify = useChannelNotifyStore();
 
 const channelListModal = reactive(useChannelListModal());
 const imageModal = reactive(useImageModal());
@@ -438,25 +426,9 @@ function openDmNote() {
   nickNotes.openEditor(active.value.networkId, active.value.target);
 }
 
-// Channel "always notify" toggle — the one non-pin, non-close action from the
-// buffer menu, promoted to an inline button (pin/close stay buffer-list
-// concerns, reachable by right-clicking the sidebar row). The bell fills and
-// goes accent when the override is on.
-const channelNotifyAlways = computed(() => {
-  if (!isChannel.value || !active.value) return false;
-  return channelNotify.notifyAlways(active.value.networkId, active.value.target);
-});
-const channelNotifyLabel = computed(() =>
-  channelNotifyAlways.value ? 'Stop always notifying' : 'Always notify',
-);
-function toggleChannelNotify() {
-  if (!isChannel.value || !active.value) return;
-  channelNotify.setNotifyAlways(
-    active.value.networkId,
-    active.value.target,
-    !channelNotifyAlways.value,
-  );
-}
+// Channel notification level (always/highlights/nothing/muted) now lives in the
+// buffer context-menu ladder (right-click the sidebar row, or the topic-bar cog),
+// so there is no dedicated topic-bar bell anymore (issue #359).
 
 // User count for the active channel buffer. Sits in the topic bar (next to
 // the members-toggle button) rather than the status bar — the count is a
@@ -789,15 +761,6 @@ useChatBootstrap({ onJump: onJumpToMessage });
   align-items: baseline;
   gap: var(--space-4);
   flex-shrink: 0;
-}
-/* The always-notify bell reads as off (muted) until the override is on, when
-   it fills and switches to accent — distinct from the always-accent toggle
-   buttons beside it. */
-.topic-actions .notify {
-  color: var(--fg-muted);
-}
-.topic-actions .notify.on {
-  color: var(--accent);
 }
 .topic .member-count {
   color: var(--fg-muted);


### PR DESCRIPTION
## What & why

Closes the overlap called out in #359: Lurker had **two** systems for "how loud is this channel" — the display-only per-channel `muted` flag and `notify_always` — implemented separately from the rich irssi-style `/ignore` engine. This folds the *suppressors* into the ignore engine as two composable modifier levels (siblings of `NOHIGHLIGHT`):

| Level | Effect | Keeps message visible + counted? |
|---|---|---|
| `NOUNREAD` (≙ irssi `NO_ACT`) | suppress the buffer-list unread badge | ✅ |
| `NONOTIFY` | suppress toast / push / sound | ✅ |

## UX: one "quietness" ladder

Notification control is now a single monotonic radio ladder in the buffer + network context menus (right-click the sidebar row, or the topic-bar cog):

- **Channel** — All messages · Highlights only *(default)* · Nothing · Muted
- **DM** — All messages *(default)* · Nothing · Muted  *(no "Highlights only" — every DM is already the signal)*
- **Network** — Highlights only *(default)* · Nothing · Muted  *(no "All" — a network firehose makes no sense)*

Suppressor rungs are ignore rules scoped to the buffer (`channels=[target]`) or the whole network (`-network`, `channels=null`). "All messages" stays the separate `notify_always` amplifier. Rungs are mutually exclusive at the menu; a hand-typed conflicting `/ignore` is resolved by the **ignore veto winning** — "quietest wins", so a network mute silences a channel set louder.

## Notable consequences

- **Mute now also silences notifications** (was display-only) — matches Discord / The Lounge, and what users expect the word to mean.
- **"Mute network" comes for free** from the engine's existing `-network` scope (the thing floated in #359's comments).
- A **boot migration** folds existing `muted=1` rows into `NOUNREAD,NONOTIFY` rules. Rows that also had `notify_always` keep it and get **no** suppressor rule (the flag is the explicit opt-in to pings — silencing it would be a surprise). The deprecated `muted` column is retired (kept, unused).
- Command parity: `/ignore #chan NOUNREAD`, `/ignore -network NONOTIFY`, and `/ignore nick NONOTIFY` (person-everywhere) all work and round-trip into the menus.

## Also in this branch

- **Context menu no longer closes on programmatic scroll** — a busy channel's auto-scroll on each new message was dismissing it (and would have dismissed the new radio menus). It now closes on the user *gesture* (`wheel`/`touchmove`), not the `scroll` event.
- A lightweight `heading` item type for the context menu (the "Notifications" group label).
- Removed the topic-bar always-notify bell (superseded by the ladder; it could otherwise create a "says All / actually silenced" contradiction).

## Testing

- `npm run check` (typecheck + client typecheck + lint + oxfmt) clean.
- `npm test` → **1789 passing**. New coverage: the two modifier levels (scope / `-except` / non-highlightable veto), `channelMutesUnread`, the migration (conversion, `notify_always` preservation, idempotency), and the mute-rule store getters across network/global/DM scope.
- Not runtime-verified against a live IRC connection (dev server autoconnects to a real network) — QA notes below.

## Deferred (own follow-ups)

- Per-**sender** NOUNREAD in unread *counting* (needs insert-time accounting).
- Per-channel *punch-through* of a network mute ("mute network except #important", via `-except`).
- A channel-settings modal as a richer home for the same radio component.

## Reviewer notes

This was self-reviewed with a multi-angle pass before opening; 9 findings were fixed (topic-bell contradiction, migration `notify_always` edge, `NONOTIFY` veto covering non-highlightable types, global-scope mute lookup, rung-label edge, silent migration catch, dead verdict field, and two dedups). One pre-existing efficiency nit (double ignore-evaluate on the closed-DM reopen path) was left as-is.

Closes #359 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
