### PR TITLE
Bump version to v1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Cuts **v1.0.7**, carrying everything merged to `main` since the v1.0.6 tag (2026-06-26). Pure metadata bump — updates `version` in the root and `vue_client` `package.json` + `package-lock.json` (4 files, 6 lines), matching the v1.0.6 bump exactly.

## What's shipped since v1.0.6

**Features**
- XDCC download manager — receive → accept → verify path, off by default behind a two-tier gate (#443, #446, #447)
- CTCP support with configurable replies (#429, #431)
- Inbound & outbound channel invites (#433, #435)
- Relay-bot message routing (#432)
- VitePress docs-site scaffold (#425, #428, #436)

**Navigation & UX**
- Buffer back/forward navigation — Cmd/Ctrl+[ / ] (#437)
- Quick-switcher smart-sort (recency-first) (#438)
- Message context menu (#449)
- More reliable message jump-to across entry points (#455)
- PWA app-icon unread badge (#453)

**Notifications**
- Unified notify / mute into the `/ignore` engine (#457)
- Notice-routing rework (#452)

**Security / hardening**
- `allowscripts` allowlist (#440)
- Docs deps security bump to VitePress 2 (#436)

**Fixes**
- Capped-buffer scroll-anchor upward-drift fix (#448 / #456)
- Nick copy-paste selection fix (#426 / #427)
- Dependabot minor/patch + GitHub Actions bumps (#398, #399, #400, #401)

## Verification
- All four JSON files parse and report `1.0.7`
- Diff is limited to the version fields; no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)