### PR TITLE
Add a setting to disable typing notifications

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -762,6 +762,18 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'three or more lines always require confirmation regardless of this ' +
       'setting. /me actions never split — they are blocked outright.',
   },
+  {
+    key: 'chat.send_typing_notifications',
+    label: 'Send typing notifications',
+    category: 'chat',
+    group: 'composing',
+    type: 'bool',
+    default: true,
+    description:
+      'Let other clients see when you are typing (IRCv3 +typing tag). Off stops ' +
+      'this client from sending typing/paused/done notifications while you compose ' +
+      "a message. Doesn't affect seeing other people's typing indicators.",
+  },
 
   // ─── Smart filter (join/part/quit/nick noise) ─────────────────────────
   {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -531,6 +531,7 @@ function publishComposing(raw: string): void {
 }
 
 function sendTyping(networkId: number, target: string, state: string): void {
+  if (!settings.effective('chat.send_typing_notifications')) return;
   socketSend({ type: 'typing', networkId, target, state });
 }
 


### PR DESCRIPTION
Some users don't want to broadcast that they're typing (if you're going to lurk, lurk moar). Adds a "send typing notifications" setting (in Settings -> Chat -> Composing, default to on) that stops this client from sending typing/paused/done notifications while composing. Typing notifications received from other users are unaffected.