### PR TITLE
perf: bound listSpeakers scan to a recent window (reconnect snapshot stall)

### DIFF
--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -97,8 +97,11 @@ describe('hasConversationForTarget (#439)', () => {
 });
 
 describe('listSpeakers', () => {
+  // Deterministic unique user per network — no Math.random (reproducible, no
+  // rare collision flake).
+  let seq = 0;
   function net() {
-    const user = createUser(`spk-${Math.random().toString(36).slice(2)}`);
+    const user = createUser(`spk-${++seq}`);
     return createNetwork(user.id, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'me' })!.id;
   }
 

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -132,6 +132,19 @@ describe('listSpeakers', () => {
     // Unbounded (default window) still finds it.
     expect(listSpeakers(n, '#c').map((s) => s.nick)).toContain('oldtimer');
   });
+
+  it('window counts CHAT rows only — an event flood does not starve speakers', () => {
+    const n = net();
+    chat(n, '#c', 'speaker', 'hi'); // one chat line...
+    for (let i = 0; i < 8; i++) event(n, '#c', 'join', `joiner${i}`); // ...then a join flood
+    // Window of 2. The filters run INSIDE the window, so the 8 joins are skipped
+    // rather than filling it; the one chat row still lands in-window. If the
+    // filters ran AFTER the id-DESC LIMIT (the netsplit-starvation bug), a window
+    // of 2 would be [join7, join6] → filtered to empty → no speaker.
+    const nicks = listSpeakers(n, '#c', 20, 2).map((s) => s.nick);
+    expect(nicks).toContain('speaker');
+    expect(nicks.some((x) => x.startsWith('joiner'))).toBe(false);
+  });
 });
 
 describe('messages.alt parity', () => {

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -20,6 +20,7 @@ let countHighlightsNewer: typeof import('./messages.js').countHighlightsNewer;
 let listUserHighlights: typeof import('./messages.js').listUserHighlights;
 let maxIdForBuffer: typeof import('./messages.js').maxIdForBuffer;
 let hasConversationForTarget: typeof import('./messages.js').hasConversationForTarget;
+let listSpeakers: typeof import('./messages.js').listSpeakers;
 
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
@@ -34,6 +35,7 @@ beforeAll(async () => {
     listUserHighlights,
     maxIdForBuffer,
     hasConversationForTarget,
+    listSpeakers,
   } = await import('./messages.js'));
 });
 
@@ -91,6 +93,44 @@ describe('hasConversationForTarget (#439)', () => {
     // Case-insensitive match; unknown target is false.
     expect(hasConversationForTarget(net!.id, 'BOB')).toBe(true);
     expect(hasConversationForTarget(net!.id, 'nobody')).toBe(false);
+  });
+});
+
+describe('listSpeakers', () => {
+  function net() {
+    const user = createUser(`spk-${Math.random().toString(36).slice(2)}`);
+    return createNetwork(user.id, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'me' })!.id;
+  }
+
+  it('returns recent distinct speakers, case-folded, excluding self and non-chat', () => {
+    const n = net();
+    chat(n, '#c', 'Alice', 'hi');
+    chat(n, '#c', 'alice', 'again'); // same speaker, divergent case → one entry
+    chat(n, '#c', 'Bob', 'yo');
+    event(n, '#c', 'join', 'Carol'); // non-chat → not a speaker
+    insertMessage({
+      networkId: n,
+      target: '#c',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'me',
+      text: 'self line',
+      self: true, // our own line → excluded
+    });
+    const nicks = listSpeakers(n, '#c').map((s) => s.nick.toLowerCase());
+    expect(new Set(nicks)).toEqual(new Set(['alice', 'bob']));
+  });
+
+  it('bounds the scan to the recent window — older speakers outside it drop off', () => {
+    const n = net();
+    chat(n, '#c', 'oldtimer', 'first'); // oldest chat line
+    for (let i = 0; i < 5; i++) chat(n, '#c', `recent${i}`, 'x');
+    // With a scan window of 3, only the 3 newest rows are considered, so
+    // 'oldtimer' (6 rows back) is excluded even though it's real chat history.
+    const nicks = listSpeakers(n, '#c', 20, 3).map((s) => s.nick);
+    expect(nicks).not.toContain('oldtimer');
+    // Unbounded (default window) still finds it.
+    expect(listSpeakers(n, '#c').map((s) => s.nick)).toContain('oldtimer');
   });
 });
 

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -530,12 +530,27 @@ export function searchMessages(
   }));
 }
 
+// Autocomplete speakers, derived from message history. Grouping over a buffer's
+// ENTIRE history is O(stored messages) per buffer — the dominant cost of a
+// resume/reconnect snapshot on a deep buffer (a fresh connect ships shells that
+// omit speakers, which is why reload stays cheap). So bound the scan to the most
+// recent SPEAKER_SCAN_WINDOW rows first, THEN group: the query already returns
+// only the 128 most-recent speakers by last-spoken time, and recent speakers are
+// exactly what autocomplete wants, so the output is (near-)equivalent at a fixed
+// cost independent of history depth. The recent window is contiguous at the tail
+// of idx_messages_buffer(network_id, target, id DESC), so it's an index-ordered
+// read of the newest rows, not a full-buffer scan.
+const SPEAKER_SCAN_WINDOW = 2000;
 const listSpeakersStmt = db.prepare(`
   SELECT nick, MAX(time) AS last_time
-  FROM messages
-  WHERE network_id = ?
-    AND target = ?
-    AND type IN ('message', 'action')
+  FROM (
+    SELECT nick, time, type, self
+    FROM messages
+    WHERE network_id = ? AND target = ?
+    ORDER BY id DESC
+    LIMIT ?
+  )
+  WHERE type IN ('message', 'action')
     AND self = 0
     AND nick IS NOT NULL
     AND nick <> ''
@@ -547,10 +562,17 @@ const listSpeakersStmt = db.prepare(`
 export function listSpeakers(
   networkId: number,
   target: string,
-  limit = 128,
+  // Recent distinct speakers for nick autocomplete. Currently-present users
+  // already come from the channel member list (NAMES); this only adds people who
+  // spoke recently and have since left, so a small count is plenty.
+  limit = 20,
+  scanWindow = SPEAKER_SCAN_WINDOW,
 ): Array<{ nick: string; lastTime: number }> {
   return (
-    listSpeakersStmt.all(networkId, target, limit) as Array<{ nick: string; last_time: string }>
+    listSpeakersStmt.all(networkId, target, scanWindow, limit) as Array<{
+      nick: string;
+      last_time: string;
+    }>
   )
     .map((r) => ({ nick: r.nick, lastTime: Date.parse(r.last_time) || 0 }))
     .filter((s) => s.lastTime > 0);

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -533,27 +533,32 @@ export function searchMessages(
 // Autocomplete speakers, derived from message history. Grouping over a buffer's
 // ENTIRE history is O(stored messages) per buffer — the dominant cost of a
 // resume/reconnect snapshot on a deep buffer (a fresh connect ships shells that
-// omit speakers, which is why reload stays cheap). So bound the scan to the most
-// recent SPEAKER_SCAN_WINDOW rows first, THEN group: the query already returns
-// only the 128 most-recent speakers by last-spoken time, and recent speakers are
-// exactly what autocomplete wants, so the output is (near-)equivalent at a fixed
-// cost independent of history depth. The recent window is contiguous at the tail
-// of idx_messages_buffer(network_id, target, id DESC), so it's an index-ordered
-// read of the newest rows, not a full-buffer scan.
+// omit speakers, which is why reload stays cheap). So bound the work to the most
+// recent SPEAKER_SCAN_WINDOW *chat* rows, THEN group. The filters live INSIDE the
+// windowed subquery (not outside it) on purpose: SQLite walks the tail of
+// idx_messages_buffer(network_id, target, id DESC) applying them, so a burst of
+// non-chat rows (a netsplit's join/quit flood) is skipped rather than eating the
+// window and starving the speaker set. Steady-state cost is fixed regardless of
+// history depth; only a channel that is currently almost all events walks
+// further, and that's still far cheaper than the old whole-history group. Output
+// is (near-)equivalent to the old query for autocomplete's purposes — it already
+// returned only the most-recent speakers by last-spoken time, which is what nick
+// completion wants. (Backfilled CHATHISTORY isn't a concern: those batches are
+// dropped, not inserted, so id order tracks time order — see ircConnection.ts.)
 const SPEAKER_SCAN_WINDOW = 2000;
 const listSpeakersStmt = db.prepare(`
   SELECT nick, MAX(time) AS last_time
   FROM (
-    SELECT nick, time, type, self
+    SELECT nick, time
     FROM messages
     WHERE network_id = ? AND target = ?
+      AND type IN ('message', 'action')
+      AND self = 0
+      AND nick IS NOT NULL
+      AND nick <> ''
     ORDER BY id DESC
     LIMIT ?
   )
-  WHERE type IN ('message', 'action')
-    AND self = 0
-    AND nick IS NOT NULL
-    AND nick <> ''
   GROUP BY LOWER(nick)
   ORDER BY last_time DESC
   LIMIT ?

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -547,6 +547,9 @@ export function searchMessages(
 // dropped, not inserted, so id order tracks time order — see ircConnection.ts.)
 const SPEAKER_SCAN_WINDOW = 2000;
 const listSpeakersStmt = db.prepare(`
+  -- Exactly one MAX() aggregate, so SQLite takes the bare (non-grouped) \`nick\`
+  -- from the same row that supplied MAX(time) — i.e. the most-recent casing,
+  -- consistent with last_time. (SQLite's documented min/max bare-column rule.)
   SELECT nick, MAX(time) AS last_time
   FROM (
     SELECT nick, time


### PR DESCRIPTION
## Context

Follow-up to #460 (the connect-snapshot work). #460's new instrumentation surfaced a **pre-existing** bottleneck: a page reload (a *fresh* connect → shells) was cheap, but **reconnecting to an IRC network** stalled the event loop:

```
[wsHub] snapshot for user 1 took 823ms across 10 buffers — ...
[event-loop] stalled ~834ms — ...
```

The fresh-vs-reconnect A/B isolates it: shells omit `speakers`, so the cost lives in something the **resume path** runs that the shell path skips — `listSpeakers`.

## Root cause

`listSpeakers` did `GROUP BY LOWER(nick)` over a buffer's **entire** message history (the `LIMIT` applies *after* grouping), so its cost scaled with total stored messages per buffer, not recency. On the resume/reconnect snapshot that runs per buffer → hundreds of ms on deep buffers. Pre-existing on `main`; the instrumentation just made it visible.

## Fix

- Bound the scan to the most recent `SPEAKER_SCAN_WINDOW` (2000) rows *before* grouping. `idx_messages_buffer(network_id, target, id DESC)` makes that an index-ordered read of the newest rows, so cost is fixed regardless of history depth. Output is (near-)equivalent — the query already returned only the most-recent speakers by last-spoken time, and recent speakers are what autocomplete needs.
- Drop the returned-speaker default **128 → 20**: currently-present users already come from the NAMES member list; `listSpeakers` only supplements with recently-departed speakers, so a small count is plenty.

## Testing
- New `listSpeakers` tests: correctness (case-folded distinct speakers, excludes self/non-chat) + window bounding (older speakers outside the window drop off; unbounded still finds them).
- `npm run check` clean; full server suite green (1802).

Note: reconnect re-runs the *full* snapshot for every buffer (even unchanged ones) — a broader "skip unchanged buffers on resume" optimization + the deferred connect-queue remain possible follow-ups, but this removes the actual per-buffer cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)