### PR TITLE
instrument: per-phase snapshot timing + slow NAMES/WHO handler logging

### DIFF
--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -115,8 +115,6 @@ const NON_PERSISTED_TYPES = new Set([
   'ctcp',
 ]);
 
-// Forget an outbound CTCP request we never got a reply to after a minute, so the
-// routing map can't grow unbounded.
 // Diagnostic: a single synchronous IRC-event handler (NAMES/WHO member-list
 // rebuild + serialize + fan-out) slower than this is logged. On a reconnect the
 // server replays NAMES/WHO for every auto-rejoined channel; on big channels each
@@ -127,6 +125,8 @@ const IRC_HANDLER_WARN_MS = (() => {
   return Number.isFinite(raw) && raw >= 0 ? raw : 50;
 })();
 
+// Forget an outbound CTCP request we never got a reply to after a minute, so the
+// routing map can't grow unbounded.
 const CTCP_OUTSTANDING_TTL_MS = 60_000;
 // Cap distinct outstanding (nick,type) keys; evict the oldest when exceeded.
 const CTCP_OUTSTANDING_MAX_KEYS = 200;

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -117,6 +117,16 @@ const NON_PERSISTED_TYPES = new Set([
 
 // Forget an outbound CTCP request we never got a reply to after a minute, so the
 // routing map can't grow unbounded.
+// Diagnostic: a single synchronous IRC-event handler (NAMES/WHO member-list
+// rebuild + serialize + fan-out) slower than this is logged. On a reconnect the
+// server replays NAMES/WHO for every auto-rejoined channel; on big channels each
+// is O(members), and the burst is what shows up as an [event-loop] stall with no
+// [wsHub] snapshot line. Console-only. Env-tunable / 0 disables.
+const IRC_HANDLER_WARN_MS = (() => {
+  const raw = Number(process.env.LURKER_IRC_HANDLER_WARN_MS);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 50;
+})();
+
 const CTCP_OUTSTANDING_TTL_MS = 60_000;
 // Cap distinct outstanding (nick,type) keys; evict the oldest when exceeded.
 const CTCP_OUTSTANDING_MAX_KEYS = 200;
@@ -1805,6 +1815,7 @@ export class IrcConnection {
     });
 
     c.on('userlist', (event: Record<string, unknown>) => {
+      const tHandler = Date.now();
       const eventChannel = event.channel as string;
       const eventUsers = (event.users as Record<string, unknown>[]) || [];
       const ch = this.upsertChannel(eventChannel);
@@ -1845,9 +1856,18 @@ export class IrcConnection {
       } catch (_) {
         /* ignore */
       }
+      const ms = Date.now() - tHandler;
+      if (IRC_HANDLER_WARN_MS > 0 && ms >= IRC_HANDLER_WARN_MS) {
+        console.warn(
+          `[irc] NAMES(userlist) for ${eventChannel} took ${ms}ms (${ch.members.size} members) ` +
+            `on network ${this.network.id} — synchronous member rebuild + fan-out; a burst of ` +
+            `these across auto-rejoined channels is the reconnect [event-loop] stall`,
+        );
+      }
     });
 
     c.on('wholist', (event: Record<string, unknown>) => {
+      const tHandler = Date.now();
       const eventTarget = event.target as string | undefined;
       const targetKey = eventTarget?.toLowerCase() ?? '';
       const users = (event.users as Record<string, unknown>[]) || [];
@@ -1904,12 +1924,21 @@ export class IrcConnection {
           changed = true;
         }
       }
-      if (!changed) return;
-      this.publish({
-        type: 'names',
-        target: ch.name,
-        members: Array.from(ch.members.values()).map(memberSnapshot),
-      });
+      if (changed) {
+        this.publish({
+          type: 'names',
+          target: ch.name,
+          members: Array.from(ch.members.values()).map(memberSnapshot),
+        });
+      }
+      const ms = Date.now() - tHandler;
+      if (IRC_HANDLER_WARN_MS > 0 && ms >= IRC_HANDLER_WARN_MS) {
+        console.warn(
+          `[irc] WHO(wholist) for ${ch.name} took ${ms}ms (${ch.members.size} members) ` +
+            `on network ${this.network.id} — synchronous away/host backfill${changed ? ' + fan-out' : ''}; ` +
+            `part of the reconnect burst`,
+        );
+      }
     });
 
     // Per-user away/back. away-notify drives the non-self events; self events

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1483,13 +1483,21 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       onlineMs: 0,
       offlineMs: 0,
     };
+    let ok = false;
     try {
       b = sendSnapshotInner(ws, userId, freshNetworkId);
+      ok = true;
     } catch (err) {
-      console.error(`[wsHub] snapshot for user ${userId} failed (IRC left intact):`, err);
+      console.error(
+        `[wsHub] snapshot for user ${userId} failed after ${Date.now() - startedAt}ms ` +
+          `(IRC left intact):`,
+        err,
+      );
     }
     const ms = Date.now() - startedAt;
-    if (ms >= SNAPSHOT_SLOW_MS) {
+    // Only attribute phases on success — a throw leaves the breakdown at its
+    // zero defaults, which would mislead exactly when the log is meant to help.
+    if (ok && ms >= SNAPSHOT_SLOW_MS) {
       console.warn(
         `[wsHub] snapshot for user ${userId} took ${ms}ms across ${b.bufferCount} buffers ` +
           `(${b.fresh ? 'fresh/shells' : 'resume'}) — networks=${b.networksMs}ms seeds=${b.seedsMs}ms ` +

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -520,6 +520,18 @@ const INPUT_HISTORY_SLICE = 50;
 // the thing that starves IRC socket I/O when it gets large.
 const SNAPSHOT_SLOW_MS = 250;
 
+// Per-phase timing of one snapshot, so a slow one says WHERE the time went
+// (member-list blob vs seeds vs the per-buffer loop vs offline frames) instead
+// of just a total. See the sendSnapshot wrapper's log.
+interface SnapshotBreakdown {
+  bufferCount: number;
+  fresh: boolean; // true = fresh connect → online loop shipped shells, not resume frames
+  networksMs: number; // ircManager.snapshotForUser (serializes channel member lists)
+  seedsMs: number; // drafts/bookmarks/system/contacts + the bulk read/cleared/closed maps
+  onlineMs: number; // the live per-buffer loop (shells: unread counts; resume: +reads/speakers)
+  offlineMs: number; // buildOfflineBacklogFrames
+}
+
 // Decide the slice a resume snapshot ships for ONE buffer.
 //
 // Normal case: ship just the gap the client missed (id > sinceId). The client
@@ -1463,18 +1475,27 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     freshNetworkId: number | null = null,
   ): void {
     const startedAt = Date.now();
-    let bufferCount = 0;
+    let b: SnapshotBreakdown = {
+      bufferCount: 0,
+      fresh: false,
+      networksMs: 0,
+      seedsMs: 0,
+      onlineMs: 0,
+      offlineMs: 0,
+    };
     try {
-      bufferCount = sendSnapshotInner(ws, userId, freshNetworkId);
+      b = sendSnapshotInner(ws, userId, freshNetworkId);
     } catch (err) {
       console.error(`[wsHub] snapshot for user ${userId} failed (IRC left intact):`, err);
     }
     const ms = Date.now() - startedAt;
     if (ms >= SNAPSHOT_SLOW_MS) {
       console.warn(
-        `[wsHub] snapshot for user ${userId} took ${ms}ms across ${bufferCount} buffers — ` +
-          `it runs synchronously on the event loop; on slow storage or a large account this ` +
-          `can starve IRC socket I/O and trip ping timeouts (see [event-loop] logs)`,
+        `[wsHub] snapshot for user ${userId} took ${ms}ms across ${b.bufferCount} buffers ` +
+          `(${b.fresh ? 'fresh/shells' : 'resume'}) — networks=${b.networksMs}ms seeds=${b.seedsMs}ms ` +
+          `online=${b.onlineMs}ms offline=${b.offlineMs}ms. Runs synchronously on the event loop; ` +
+          `on slow storage or a large account this can starve IRC socket I/O and trip ping timeouts ` +
+          `(see [event-loop] logs). networks=member-list blob, online=per-buffer unread/reads.`,
       );
     }
   }
@@ -1483,8 +1504,11 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     ws: LurkerWebSocket,
     userId: number,
     freshNetworkId: number | null = null,
-  ): number {
+  ): SnapshotBreakdown {
+    const tNetworks = Date.now();
     const networks = ircManager.snapshotForUser(userId);
+    const networksMs = Date.now() - tNetworks;
+    const tSeeds = Date.now();
     // A fresh connect (no resume cursor yet) means an empty client with no
     // active buffer — Lurker auto-focuses nothing on load. So we ship channel/DM
     // buffers as lazy shells (no backlog) below. `cursor` hands the client the
@@ -1526,6 +1550,8 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     const readState = listReadStateForUser(userId);
     const clearedState = listClearedStateForUser(userId);
     const closed = closedKeySetForUser(userId);
+    const seedsMs = Date.now() - tSeeds;
+    const tOnline = Date.now();
     let maxSentId = ws.sinceId || 0;
     let bufferCount = 0;
     for (const conn of ircManager.listConnections(userId)) {
@@ -1616,6 +1642,8 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         bufferCount += 1;
       }
     }
+    const onlineMs = Date.now() - tOnline;
+    const tOffline = Date.now();
     // Offline networks (no live connection) ship their buffers as lightweight
     // SHELLS (buffer row + unread/read state, no message rows) rather than the
     // full recent slice. The client hydrates a shell's history on first open via
@@ -1630,6 +1658,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       send(ws, frame);
       bufferCount += 1;
     }
+    const offlineMs = Date.now() - tOffline;
     // Advance the resume cursor past everything we just shipped, so the next
     // sendSnapshot (in-band 'snapshot' request, or another IRC-state trigger)
     // resumes from where this snapshot left off. On a fresh (shell) connect we
@@ -1637,7 +1666,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // handed the client — otherwise a later re-snapshot on this socket would
     // re-gap-fill everything the shells deliberately skipped.
     ws.sinceId = Math.max(maxSentId, cursor);
-    return bufferCount;
+    return { bufferCount, fresh: isFreshConnect, networksMs, seedsMs, onlineMs, offlineMs };
   }
 
   function handleClientMessage(ws: LurkerWebSocket, user: User, msg: WsPayload): void {


### PR DESCRIPTION
## Why

The `#460`/`#462` instrumentation caught two remaining sub-500ms stalls on a self-hosted instance but couldn't localize them:

- **Reload** → `[wsHub] snapshot … took 462ms across 9 buffers` (a fresh/shell snapshot). Could be the member-list blob, per-buffer unread counts, or offline frames.
- **Reconnect** → `[event-loop] stalled ~513ms` with **no** `[wsHub]` line — so *not* the snapshot (that's now <250ms, confirming `#462` worked). It's the reconnect IRC burst: NAMES/WHO member processing.

Both are ~200× under the 120s timeout on a fast box, but they scale up 10–50× on the slow NAS, so it's worth knowing exactly which sub-part owns them before optimizing. This adds the attribution (no behavior change, console-only).

## Changes

**Snapshot per-phase breakdown** — when a snapshot exceeds `SNAPSHOT_SLOW_MS`, the log now reads:
```
[wsHub] snapshot for user 1 took 462ms across 9 buffers (fresh/shells) — networks=…ms seeds=…ms online=…ms offline=…ms.
```
- `networks` = `snapshotForUser` (serializes channel member lists — big on Libera)
- `online` = the per-buffer loop (shells: unread counts; resume: +reads/speakers)
- `offline` = `buildOfflineBacklogFrames`

**Slow IRC-handler logging** — `ircConnection` times the `userlist` (NAMES) and `wholist` (WHO) handlers; any single one over `IRC_HANDLER_WARN_MS` (default 50ms, `LURKER_IRC_HANDLER_WARN_MS` env-tunable, 0 disables) logs the channel + member count:
```
[irc] NAMES(userlist) for #python took 180ms (2400 members) on network 3 — synchronous member rebuild + fan-out; a burst … is the reconnect stall
```
`wholist`'s `if (!changed) return` became `if (changed) { publish }` so the tail timing always runs — behavior identical.

## Testing
- `npm run check` clean; full server suite green (1803). Instrumentation-only.

Once this is deployed, a reload + a reconnect will print exactly where the 462ms and 513ms go, and we fix the real culprit instead of the plausible one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)