### PR TITLE
perf+fix: load speakers on buffer-open, not connect (fixes empty @ autocomplete)

### DIFF
--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -584,22 +584,20 @@ export function searchMessages(
   }));
 }
 
-// Autocomplete speakers, derived from message history. Grouping over a buffer's
-// ENTIRE history is O(stored messages) per buffer — the dominant cost of a
-// resume/reconnect snapshot on a deep buffer (a fresh connect ships shells that
-// omit speakers, which is why reload stays cheap). So bound the work to the most
-// recent SPEAKER_SCAN_WINDOW *chat* rows, THEN group. The filters live INSIDE the
-// windowed subquery (not outside it) on purpose: SQLite walks the tail of
-// idx_messages_buffer(network_id, target, id DESC) applying them, so a burst of
-// non-chat rows (a netsplit's join/quit flood) is skipped rather than eating the
-// window and starving the speaker set. Steady-state cost is fixed regardless of
-// history depth; only a channel that is currently almost all events walks
-// further, and that's still far cheaper than the old whole-history group. Output
-// is (near-)equivalent to the old query for autocomplete's purposes — it already
-// returned only the most-recent speakers by last-spoken time, which is what nick
-// completion wants. (Backfilled CHATHISTORY isn't a concern: those batches are
-// dropped, not inserted, so id order tracks time order — see ircConnection.ts.)
-const SPEAKER_SCAN_WINDOW = 2000;
+// Autocomplete speakers, derived from message history. This is now called when
+// the user OPENS a buffer (the 'history' latest reply seeds nick completion) — the
+// connect snapshot no longer ships speakers — so it's one buffer at a time, not
+// every buffer at once. Still, bound the work to the most recent
+// SPEAKER_SCAN_WINDOW *chat* rows, THEN group, so it's O(window) regardless of how
+// deep the buffer is. The window is small: autocomplete only cares about the last
+// handful of speakers, and the client keeps building the list live via
+// recordSpeaker as the conversation continues. The filters live INSIDE the
+// windowed subquery on purpose: SQLite walks the tail of idx_messages_buffer(
+// network_id, target, id DESC) applying them, so a burst of non-chat rows (a
+// netsplit's join/quit flood) is skipped rather than eating the window and
+// starving the speaker set. (Backfilled CHATHISTORY isn't a concern: those batches
+// are dropped, not inserted, so id order tracks time order — see ircConnection.ts.)
+const SPEAKER_SCAN_WINDOW = 300;
 const listSpeakersStmt = db.prepare(`
   -- Exactly one MAX() aggregate, so SQLite takes the bare (non-grouped) \`nick\`
   -- from the same row that supplied MAX(time) — i.e. the most-recent casing,

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -543,7 +543,6 @@ interface SnapshotBreakdown {
   // lookups are NOT included (the loop passes precomputed values).
   unreadMs: number; // shell: buildBufferShell; resume: bufferStateFields
   sliceMs: number; // buildResumeSlice — message reads + decorate (resume path only)
-  speakersMs: number; // listSpeakers (resume path only)
 }
 
 // Decide the slice a resume snapshot ships for ONE buffer.
@@ -1498,7 +1497,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       offlineMs: 0,
       unreadMs: 0,
       sliceMs: 0,
-      speakersMs: 0,
     };
     let ok = false;
     try {
@@ -1519,11 +1517,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         `[wsHub] snapshot for user ${userId} took ${ms}ms across ${b.bufferCount} buffers ` +
           `(${b.fresh ? 'fresh/shells' : 'resume'}) — networks=${b.networksMs}ms seeds=${b.seedsMs}ms ` +
           `online=${b.onlineMs}ms offline=${b.offlineMs}ms [online split: unread=${b.unreadMs}ms ` +
-          `slice=${b.sliceMs}ms speakers=${b.speakersMs}ms ` +
-          `rest=${Math.max(0, b.onlineMs - b.unreadMs - b.sliceMs - b.speakersMs)}ms]. ` +
+          `slice=${b.sliceMs}ms rest=${Math.max(0, b.onlineMs - b.unreadMs - b.sliceMs)}ms]. ` +
           `Runs synchronously on the event loop; on slow storage or a large account this can starve ` +
           `IRC socket I/O and trip ping timeouts (see [event-loop] logs). networks=member-list blob; ` +
-          `unread≈computeUnreadFor(+frame assembly), slice=buildResumeSlice reads, speakers=listSpeakers, ` +
+          `unread≈computeUnreadFor(+frame assembly), slice=buildResumeSlice reads, ` +
           `rest=sends/input-history/overhead.`,
       );
     }
@@ -1585,7 +1582,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     let bufferCount = 0;
     let unreadMs = 0;
     let sliceMs = 0;
-    let speakersMs = 0;
     for (const conn of ircManager.listConnections(userId)) {
       const targets = new Set(listBufferTargets(conn.network.id));
       targets.add(`:server:${conn.network.id}`);
@@ -1660,9 +1656,13 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           target,
           INPUT_HISTORY_SLICE,
         );
-        const tSpeakers = Date.now();
-        const speakers = listSpeakers(conn.network.id, target);
-        speakersMs += Date.now() - tSpeakers;
+        // Speakers are deliberately NOT shipped on connect. The sidebar doesn't
+        // use them, and computing them per buffer here (listSpeakers scanning
+        // history × every buffer) was the snapshot's dominant cost once the other
+        // scans were fixed. Nick autocomplete seeds them when you actually OPEN a
+        // buffer (the 'history' latest reply carries them — see applyLatestReplace)
+        // and live via recordSpeaker; omitting the key here leaves the client's
+        // existing map untouched.
         const tUnread = Date.now();
         const stateFields = bufferStateFields(userId, conn.network.id, target, precomputed);
         unreadMs += Date.now() - tUnread;
@@ -1676,7 +1676,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           // append, or it splices a permanent hole (issue #205).
           reset: slice.reset,
           hasMoreOlder: slice.hasMoreOlder,
-          speakers,
           joined: channelJoined(target, conn),
           ...stateFields,
           inputHistory,
@@ -1717,7 +1716,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       offlineMs,
       unreadMs,
       sliceMs,
-      speakersMs,
     };
   }
 

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -384,4 +384,24 @@ describe('shell unseeded lifecycle', () => {
     });
     expect(store.byKey('1::#a')!.unseeded).toBe(false);
   });
+
+  it('seeds speakers from the history reply so autocomplete works on open, not just after live messages', () => {
+    const store = useBuffersStore();
+    shellFrame(store, '#a');
+    store.activate(1, '#a');
+    const token = store.byKey('1::#a')!.pendingHistoryToken;
+    // The connect snapshot no longer ships speakers, so opening the buffer (this
+    // reply) is where they must load — otherwise nick autocomplete is empty until
+    // someone talks. applyLatestReplace previously dropped payload.speakers.
+    store.applyLatestReplace(1, '#a', {
+      token,
+      events: [live('#a', 5000)],
+      hasMoreOlder: true,
+      speakers: [
+        { nick: 'Alice', lastTime: 1000 },
+        { nick: 'Bob', lastTime: 2000 },
+      ],
+    });
+    expect(Object.keys(store.byKey('1::#a')!.speakers).sort()).toEqual(['alice', 'bob']);
+  });
 });

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -666,6 +666,11 @@ export const useBuffersStore = defineStore('buffers', {
       // Fully hydrated now (this reply is the shell's real backlog) — clear the
       // shell flag so activate() stops trying to refetch it.
       buf.unseeded = false;
+      // Seed the recent-speaker map from the reply so nick autocomplete works the
+      // moment you open a channel — not only after someone speaks. This is the
+      // primary place speakers load now (the connect snapshot no longer ships
+      // them); seedSpeakers merges, so it composes with recordSpeaker's live map.
+      if (payload.speakers !== undefined) this.seedSpeakers(networkId, target, payload.speakers);
       // We're back on live: advance the read pointer to the new tail in the
       // same way activate() does on focus-in. Server clamps with MAX(), so
       // sending mark-read against the latest known id is idempotent.


### PR DESCRIPTION
## Two birds

The op-split instrumentation showed `listSpeakers` was the last big snapshot cost — **`speakers=234ms`** on the Mac Mini, computing a per-buffer speaker list for *every* buffer on connect. But the sidebar doesn't use speakers at all; only the in-buffer **@ / Tab nick autocomplete** does. So it was pure waste on connect.

And it was doubly broken: **`applyLatestReplace`** (the handler for the buffer-open `history` reply) **ignored the `speakers` the server already sends.** So on a shell load the recent-speaker map stayed empty until a live message arrived (`recordSpeaker`) — which is the *"@ list is just channel members in alphabetical order"* bug the reporter hit. It "works in channels that get messages after loading but not before."

## Fix — move speaker-loading to where it's actually used (buffer-open)

- **Client:** `applyLatestReplace` now seeds speakers from the `history` `latest` reply → autocomplete has recent-speaker-first completion the moment you open a channel, not only after someone talks.
- **Server:** stop shipping `speakers` in the connect snapshot (resume path; fresh already omitted them via shells). Omitting the key leaves the client's existing map intact; it seeds on open + live via `recordSpeaker`. **Kills the 234ms.**
- **Trim `SPEAKER_SCAN_WINDOW` 2000 → 300:** the query now runs one-buffer-at-a-time on open, and autocomplete only needs the last handful of recent speakers.
- Drop the now-dead `speakersMs` from the snapshot breakdown log.

Net: connect gets ~234ms cheaper on the NAS *and* autocomplete finally works before you've chatted — because speakers now load for the one buffer you open instead of eagerly for all of them.

## Testing
- New client test: `applyLatestReplace` seeds speakers from the reply.
- `npm run check` clean; full suites green (**server 1807, client 378**).

Expected on the Mac Mini: the `online=…ms` figure drops again (no more `speakers=`), and opening a channel shows recent speakers first in @ completion immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)