### PR TITLE
Add built-in ZNC-style IRC bouncer (opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,3 +146,30 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_DCC_DIR=/data/downloads
 # LURKER_DCC_MAX_FILE_MB=0
 # LURKER_DCC_ALLOW_PRIVATE_HOSTS=false
+
+# ---------------------------------------------------------------------------
+# Built-in IRC bouncer (ZNC-style). OFF by default. When enabled, ordinary IRC
+# clients (WeeChat, irssi, Textual, HexChat, ...) can attach to your always-on
+# Lurker connections: shared upstream socket and nick, history playback on
+# attach, and messages sent from the client persist and sync to the web UI.
+#
+# Log in from your IRC client with a server password of
+#   <username>:<password-or-api-token>              (single network)
+#   <username>/<network-name>:<password-or-token>   (pick one of several)
+# A read-write API token (web UI -> Settings -> API tokens) is recommended over
+# your account password, since IRC client configs store the value in plaintext.
+#
+# SECURITY: plain-text IRC carries that credential on the wire. Either bind to
+# localhost / a private (VPN) interface with LURKER_BOUNCER_BIND, or provide a
+# TLS cert+key so the listener speaks TLS (point your client at "TLS" mode).
+# ---------------------------------------------------------------------------
+# LURKER_BOUNCER_ENABLED=true
+# LURKER_BOUNCER_PORT=6667
+# LURKER_BOUNCER_BIND=127.0.0.1
+# LURKER_BOUNCER_TLS_CERT=/path/to/fullchain.pem
+# LURKER_BOUNCER_TLS_KEY=/path/to/privkey.pem
+#
+# Lines of history replayed per buffer when a client attaches (0 disables
+# playback, max 1000). Joined channels always replay; the 20 most recently
+# active open DMs replay too.
+# LURKER_BOUNCER_PLAYBACK=50

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Lurker runs as an always-on server that stays connected to IRC on your behalf, k
 - **Image uploads.** Paste, drag, or pick an image; Lurker optimizes it, uploads it to [x0.at](https://x0.at) or [catbox.moe](https://catbox.moe), inserts the link into your message, and keeps a history of all your uploads.
 - **Customizable UI.** The beautiful retro terminal-style interface has 40+ settings to customize it how you want, and you can freely pin and rearrange channels and DMs.
 - **Installable.** Lurker is a PWA — install it as a native-feeling app on your phone, Mac, or PC straight from the browser.
+- **Built-in bouncer.** Opt-in ZNC-style IRC listener: attach WeeChat, irssi, Textual, or any other IRC client to your always-on connection, with history playback on attach. See the [self-hosting guide](docs/SELF_HOSTING.md#irc-bouncer-attach-from-other-irc-clients).
 
 # Screenshot (as macOS PWA)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,14 @@ services:
       # to supply your own (e.g. from a secrets manager).
       # - SESSION_SECRET=replace-me-with-a-long-random-string
       #
+      # ───── Optional: built-in IRC bouncer (ZNC-style) ────────────────────
+      # Attach ordinary IRC clients (WeeChat, irssi, Textual, ...) to your
+      # always-on Lurker connection. Also publish the port above, e.g.
+      #   - '6667:6667'
+      # and see docs/SELF_HOSTING.md for login format + TLS options.
+      # - LURKER_BOUNCER_ENABLED=true
+      # - LURKER_BOUNCER_PORT=6667
+      #
       # ───── Optional: Secure cookie flag ──────────────────────────────────
       # Off by default so cookies work over plain HTTP (localhost / LAN) and
       # behind TLS-terminating proxies (Cloudflare Tunnel, Caddy, etc.)

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -192,6 +192,39 @@ environment:
 
 Unset, it falls back to the upstream project link.
 
+### IRC bouncer (attach from other IRC clients)
+
+Lurker can act as a ZNC-style bouncer: enable the built-in IRC listener and any ordinary IRC client (WeeChat, irssi, Textual, HexChat, …) can attach to the same always-on connection your web UI uses — same nick, same channels, recent history replayed on attach, and anything you send from the client lands in your Lurker history and web tabs too. Detaching never disconnects you from IRC.
+
+```yaml
+environment:
+  - LURKER_BOUNCER_ENABLED=true
+  - LURKER_BOUNCER_PORT=6667 # remember to publish this port in docker-compose
+```
+
+Point your IRC client at the host/port with a **server password** of:
+
+- `username:secret` — when you have one network configured
+- `username/networkname:secret` — to pick one of several (the network's name as shown in the web UI, or its numeric id)
+
+The secret can be your Lurker account password, but a **read-write API token** (web UI → **Settings → API tokens**) is the better choice — IRC clients store the server password in plaintext config files, and a token can be revoked without changing your password.
+
+Security notes:
+
+- Plain-text IRC sends that credential in the clear. Either keep the listener private — `LURKER_BOUNCER_BIND=127.0.0.1` behind an SSH tunnel, or a VPN/Tailscale interface — or give it a certificate so it speaks TLS:
+
+  ```yaml
+  environment:
+    - LURKER_BOUNCER_TLS_CERT=/certs/fullchain.pem
+    - LURKER_BOUNCER_TLS_KEY=/certs/privkey.pem
+  ```
+
+- Repeated failed logins from an address are throttled automatically.
+
+Playback replays the last 50 lines per joined channel (plus your 20 most recently active DMs) on attach; tune with `LURKER_BOUNCER_PLAYBACK` (0 disables, max 1000). Clients that negotiate IRCv3 `server-time` get real timestamps on replayed lines.
+
+Known limitations (shared-connection bouncer semantics): replies to one attached client's WHOIS/LIST are visible to all attached clients on that network; Lurker-side ignore rules don't filter the live relay; and on end-to-end encrypted channels an attached client sees the wire ciphertext for incoming messages.
+
 ---
 
 ## Troubleshooting

--- a/server/server.ts
+++ b/server/server.ts
@@ -26,6 +26,13 @@ import {
   identdBindHost,
 } from './services/identd.js';
 import {
+  startBouncer,
+  stopBouncer,
+  isBouncerEnabled,
+  bouncerPort,
+  bouncerBindHost,
+} from './services/bouncer.js';
+import {
   recoverInterruptedExports,
   startExportSweeper,
   shutdownExportJobs,
@@ -101,6 +108,13 @@ if (wrappedE2e.encrypted > 0) {
 
 ircManager.initAll();
 
+// Built-in IRC bouncer (opt-in via LURKER_BOUNCER_ENABLED): lets ordinary IRC
+// clients attach to the always-on connections ircManager just established,
+// ZNC-style. Started after initAll so an attaching client finds its network.
+if (isBouncerEnabled()) {
+  startBouncer(bouncerPort(), bouncerBindHost());
+}
+
 // Fail any export job a prior crash/restart left mid-flight, drop partial
 // artifacts + expired ones, then sweep finished exports on an interval.
 recoverInterruptedExports();
@@ -128,6 +142,7 @@ function shutdown(signal: string): void {
   stopOrchestratorClient();
   stopModerationReporter();
   stopIdentd();
+  stopBouncer();
   shutdownExportJobs();
   stopIgnoreSweeper();
   stopEventLoopMonitor();

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -15,6 +15,7 @@ let rewriteNumericTarget: typeof import('./bouncer.js').rewriteNumericTarget;
 let filterRelayLine: typeof import('./bouncer.js').filterRelayLine;
 let memberPrefixSymbol: typeof import('./bouncer.js').memberPrefixSymbol;
 let buildNamesLines: typeof import('./bouncer.js').buildNamesLines;
+let isServicesNick: typeof import('./bouncer.js').isServicesNick;
 
 beforeAll(async () => {
   const mod = await import('./bouncer.js');
@@ -25,6 +26,7 @@ beforeAll(async () => {
   filterRelayLine = mod.filterRelayLine;
   memberPrefixSymbol = mod.memberPrefixSymbol;
   buildNamesLines = mod.buildNamesLines;
+  isServicesNick = mod.isServicesNick;
 });
 
 afterAll(() => ctx.cleanup());
@@ -236,6 +238,28 @@ describe('filterRelayLine', () => {
     expect(filterRelayLine('@+typing=active :n!u@h TAGMSG #c', caps)).toBe(
       '@+typing=active :n!u@h TAGMSG #c',
     );
+  });
+});
+
+describe('isServicesNick', () => {
+  it('matches network-services pseudo-users regardless of case', () => {
+    for (const n of [
+      'NickServ',
+      'chanserv',
+      'MemoServ',
+      'HostServ',
+      'OperServ',
+      'SaslServ',
+      'Global',
+    ]) {
+      expect(isServicesNick(n)).toBe(true);
+    }
+  });
+
+  it('leaves ordinary nicks alone', () => {
+    for (const n of ['bob', 'serv', 'nickservv', 'server1', 'preserve1']) {
+      expect(isServicesNick(n)).toBe(false);
+    }
   });
 });
 

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+// bouncer.js transitively imports ircManager → db/index.js, so the test DB
+// path must be pinned before the dynamic import below touches it.
+const ctx = setupTestDb('services-bouncer');
+
+let parseClientLine: typeof import('./bouncer.js').parseClientLine;
+let rebuildLine: typeof import('./bouncer.js').rebuildLine;
+let parseBouncerCredentials: typeof import('./bouncer.js').parseBouncerCredentials;
+let rewriteNumericTarget: typeof import('./bouncer.js').rewriteNumericTarget;
+let filterRelayLine: typeof import('./bouncer.js').filterRelayLine;
+let memberPrefixSymbol: typeof import('./bouncer.js').memberPrefixSymbol;
+let buildNamesLines: typeof import('./bouncer.js').buildNamesLines;
+
+beforeAll(async () => {
+  const mod = await import('./bouncer.js');
+  parseClientLine = mod.parseClientLine;
+  rebuildLine = mod.rebuildLine;
+  parseBouncerCredentials = mod.parseBouncerCredentials;
+  rewriteNumericTarget = mod.rewriteNumericTarget;
+  filterRelayLine = mod.filterRelayLine;
+  memberPrefixSymbol = mod.memberPrefixSymbol;
+  buildNamesLines = mod.buildNamesLines;
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('parseClientLine', () => {
+  it('parses a simple command with params and trailing', () => {
+    expect(parseClientLine('PRIVMSG #chan :hello world')).toEqual({
+      command: 'PRIVMSG',
+      params: ['#chan', 'hello world'],
+    });
+  });
+
+  it('uppercases the command', () => {
+    expect(parseClientLine('privmsg #chan :hi')?.command).toBe('PRIVMSG');
+  });
+
+  it('handles commands with no params', () => {
+    expect(parseClientLine('QUIT')).toEqual({ command: 'QUIT', params: [] });
+  });
+
+  it('keeps an empty trailing param', () => {
+    expect(parseClientLine('TOPIC #chan :')).toEqual({ command: 'TOPIC', params: ['#chan', ''] });
+  });
+
+  it('preserves colons inside the trailing param', () => {
+    expect(parseClientLine('PRIVMSG #c :see: this')).toEqual({
+      command: 'PRIVMSG',
+      params: ['#c', 'see: this'],
+    });
+  });
+
+  it('strips a client-supplied prefix', () => {
+    expect(parseClientLine(':me!u@h PRIVMSG #c :hi')).toEqual({
+      command: 'PRIVMSG',
+      params: ['#c', 'hi'],
+    });
+  });
+
+  it('strips client message tags', () => {
+    expect(parseClientLine('@label=x;time=y PRIVMSG #c :hi')).toEqual({
+      command: 'PRIVMSG',
+      params: ['#c', 'hi'],
+    });
+  });
+
+  it('strips CR/LF/NUL and rejects empty lines', () => {
+    expect(parseClientLine('\r\n')).toBeNull();
+    expect(parseClientLine('')).toBeNull();
+    expect(parseClientLine('PING\r')).toEqual({ command: 'PING', params: [] });
+  });
+
+  it('handles PASS whose value contains a colon (not treated as trailing)', () => {
+    expect(parseClientLine('PASS alice:hunter2')).toEqual({
+      command: 'PASS',
+      params: ['alice:hunter2'],
+    });
+  });
+});
+
+describe('rebuildLine', () => {
+  it('round-trips a parsed line', () => {
+    const parsed = parseClientLine('MODE #chan +o somebody')!;
+    expect(rebuildLine(parsed)).toBe('MODE #chan +o somebody');
+  });
+
+  it('re-adds the trailing colon when the last param has spaces', () => {
+    const parsed = parseClientLine('TOPIC #chan :new topic here')!;
+    expect(rebuildLine(parsed)).toBe('TOPIC #chan :new topic here');
+  });
+
+  it('re-adds the trailing colon for an empty last param', () => {
+    expect(rebuildLine({ command: 'TOPIC', params: ['#chan', ''] })).toBe('TOPIC #chan :');
+  });
+
+  it('handles a bare command', () => {
+    expect(rebuildLine({ command: 'LUSERS', params: [] })).toBe('LUSERS');
+  });
+});
+
+describe('parseBouncerCredentials', () => {
+  it('parses user:secret', () => {
+    expect(parseBouncerCredentials('alice:hunter2', null)).toEqual({
+      username: 'alice',
+      secret: 'hunter2',
+      network: null,
+    });
+  });
+
+  it('parses user/network:secret', () => {
+    expect(parseBouncerCredentials('alice/libera:hunter2', null)).toEqual({
+      username: 'alice',
+      secret: 'hunter2',
+      network: 'libera',
+    });
+  });
+
+  it('keeps colons inside the secret (API tokens can contain none, passwords may)', () => {
+    expect(parseBouncerCredentials('alice:pa:ss:word', null)?.secret).toBe('pa:ss:word');
+  });
+
+  it('falls back to the USER field for the login when PASS is only the secret', () => {
+    expect(parseBouncerCredentials('hunter2', 'alice/libera')).toEqual({
+      username: 'alice',
+      secret: 'hunter2',
+      network: 'libera',
+    });
+  });
+
+  it('picks the network from USER when PASS carried only user:secret', () => {
+    expect(parseBouncerCredentials('alice:hunter2', 'alice/libera')?.network).toBe('libera');
+  });
+
+  it('discards a ZNC-style @clientid', () => {
+    expect(parseBouncerCredentials('alice@phone/libera:hunter2', null)).toEqual({
+      username: 'alice',
+      secret: 'hunter2',
+      network: 'libera',
+    });
+  });
+
+  it('rejects a missing login or secret', () => {
+    expect(parseBouncerCredentials('', null)).toBeNull();
+    expect(parseBouncerCredentials('secretonly', null)).toBeNull();
+    expect(parseBouncerCredentials(':nouser', null)).toBeNull();
+    expect(parseBouncerCredentials('alice:', null)).toBeNull();
+  });
+});
+
+describe('rewriteNumericTarget', () => {
+  it('replaces the target nick of a numeric', () => {
+    expect(rewriteNumericTarget(':irc.libera.chat 001 oldnick :Welcome to Libera', 'newnick')).toBe(
+      ':irc.libera.chat 001 newnick :Welcome to Libera',
+    );
+  });
+
+  it('preserves ISUPPORT tokens after the nick', () => {
+    expect(
+      rewriteNumericTarget(
+        ':server 005 old CHANTYPES=# PREFIX=(ov)@+ :are supported by this server',
+        'me',
+      ),
+    ).toBe(':server 005 me CHANTYPES=# PREFIX=(ov)@+ :are supported by this server');
+  });
+
+  it('returns unprefixed lines unchanged', () => {
+    expect(rewriteNumericTarget('PING :x', 'me')).toBe('PING :x');
+  });
+
+  it('still rewrites when the line carries a stray trailing CR', () => {
+    expect(rewriteNumericTarget(':server 001 old :Welcome\r', 'me')).toBe(
+      ':server 001 me :Welcome\r',
+    );
+  });
+});
+
+describe('filterRelayLine', () => {
+  const noCaps = new Set<string>();
+
+  it('passes ordinary conversation through untouched', () => {
+    const line = ':nick!u@h PRIVMSG #chan :hello';
+    expect(filterRelayLine(line, noCaps)).toBe(line);
+  });
+
+  it('strips the trailing CR irc-framework leaves on raw lines', () => {
+    expect(filterRelayLine(':nick!u@h PRIVMSG #chan :hello\r', noCaps)).toBe(
+      ':nick!u@h PRIVMSG #chan :hello',
+    );
+  });
+
+  it('drops connection plumbing', () => {
+    expect(filterRelayLine('PING :irc.libera.chat', noCaps)).toBeNull();
+    expect(filterRelayLine(':irc.libera.chat PONG server :token', noCaps)).toBeNull();
+    expect(filterRelayLine(':irc.libera.chat CAP * LS :sasl', noCaps)).toBeNull();
+    expect(filterRelayLine('AUTHENTICATE +', noCaps)).toBeNull();
+    expect(filterRelayLine('ERROR :Closing Link', noCaps)).toBeNull();
+    expect(filterRelayLine(':server 001 me :Welcome', noCaps)).toBeNull();
+    expect(filterRelayLine(':server 005 me CHANTYPES=# :are supported', noCaps)).toBeNull();
+    expect(filterRelayLine(':server 903 me :SASL successful', noCaps)).toBeNull();
+  });
+
+  it('relays MOTD and other numerics', () => {
+    const line = ':server 372 me :- welcome to the network';
+    expect(filterRelayLine(line, noCaps)).toBe(line);
+  });
+
+  it('strips all tags for a capless client', () => {
+    expect(filterRelayLine('@time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :hi', noCaps)).toBe(
+      ':n!u@h PRIVMSG #c :hi',
+    );
+  });
+
+  it('keeps only the time tag for a server-time client', () => {
+    const caps = new Set(['server-time']);
+    expect(
+      filterRelayLine('@msgid=abc;time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :hi', caps),
+    ).toBe('@time=2026-01-01T00:00:00.000Z :n!u@h PRIVMSG #c :hi');
+  });
+
+  it('keeps every tag for a message-tags client', () => {
+    const caps = new Set(['message-tags']);
+    const line = '@msgid=abc;time=x :n!u@h PRIVMSG #c :hi';
+    expect(filterRelayLine(line, caps)).toBe(line);
+  });
+
+  it('drops TAGMSG and BATCH unless the client negotiated message-tags', () => {
+    expect(filterRelayLine('@+typing=active :n!u@h TAGMSG #c', noCaps)).toBeNull();
+    expect(filterRelayLine(':server BATCH +ref draft/multiline #c', noCaps)).toBeNull();
+    const caps = new Set(['message-tags']);
+    expect(filterRelayLine('@+typing=active :n!u@h TAGMSG #c', caps)).toBe(
+      '@+typing=active :n!u@h TAGMSG #c',
+    );
+  });
+});
+
+describe('memberPrefixSymbol', () => {
+  it('maps the highest-ranked mode to its symbol', () => {
+    expect(memberPrefixSymbol(['v', 'o'])).toBe('@');
+    expect(memberPrefixSymbol(['v'])).toBe('+');
+    expect(memberPrefixSymbol([])).toBe('');
+  });
+
+  it('honors a network-supplied prefix table', () => {
+    const prefixes = [
+      { mode: 'y', symbol: '!' },
+      { mode: 'o', symbol: '@' },
+    ];
+    expect(memberPrefixSymbol(['y'], prefixes)).toBe('!');
+    expect(memberPrefixSymbol(['q'], prefixes)).toBe('');
+  });
+});
+
+describe('buildNamesLines', () => {
+  it('emits a 353 with members and a 366 terminator', () => {
+    const lines = buildNamesLines('me', '#chan', ['@op', '+voice', 'plain']);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe(':lurker.bouncer 353 me = #chan :@op +voice plain');
+    expect(lines[1]).toBe(':lurker.bouncer 366 me #chan :End of /NAMES list.');
+  });
+
+  it('emits only the terminator for an empty channel', () => {
+    const lines = buildNamesLines('me', '#chan', []);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('366');
+  });
+
+  it('chunks large member lists under the wire cap', () => {
+    const names = Array.from({ length: 200 }, (_, i) => `member${i}`);
+    const lines = buildNamesLines('me', '#chan', names);
+    expect(lines.length).toBeGreaterThan(2);
+    for (const line of lines.slice(0, -1)) {
+      expect(line.length).toBeLessThanOrEqual(510);
+      expect(line).toContain('353');
+    }
+    // Every member appears exactly once across the chunks.
+    const all = lines
+      .slice(0, -1)
+      .map((l) => l.split(' :')[1])
+      .join(' ')
+      .split(' ');
+    expect(all).toHaveLength(200);
+    expect(new Set(all).size).toBe(200);
+  });
+});

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -314,6 +314,16 @@ function isChannelName(target: string): boolean {
   return target.startsWith('#') || target.startsWith('&');
 }
 
+// Network-services pseudo-users whose DM buffers must never replay on attach:
+// they're registration plumbing, not conversation, and the self side routinely
+// contains credentials (`msg NickServ IDENTIFY <password>` from a client's
+// perform/on-connect) that would otherwise land in every attached client's
+// logs on every reconnect.
+export function isServicesNick(nick: string): boolean {
+  const lower = nick.toLowerCase();
+  return /^[a-z]+serv$/.test(lower) || lower === 'global' || lower === 'services';
+}
+
 // ---------------------------------------------------------------------------
 // Session registry
 // ---------------------------------------------------------------------------
@@ -737,6 +747,7 @@ class BouncerSession {
     const joined = new Set(Array.from(conn.channels.keys()));
     const dms = listBuffersForNetwork(this.networkId)
       .filter((b) => !isChannelName(b.target) && !b.target.startsWith(':server:'))
+      .filter((b) => !isServicesNick(b.target))
       .filter((b) => !joined.has(b.target.toLowerCase()))
       .filter((b) => !isBufferClosed(this.userId, this.networkId, b.target))
       .toSorted((a, b) => (a.lastMessageAt < b.lastMessageAt ? 1 : -1))
@@ -755,6 +766,12 @@ class BouncerSession {
     for (const row of rows) {
       if (row.type !== 'message' && row.type !== 'action' && row.type !== 'notice') continue;
       if (row.fromIgnored || row.mirrored || !row.text) continue;
+      // A self-message in a DM is `:you PRIVMSG peer` — a shape only clients
+      // that negotiated znc.in/self-message (or echo-message) can attribute
+      // correctly. Anything else (e.g. mIRC) misreads it as an INCOMING PM
+      // "from you", which confuses query windows and trips auto-responders.
+      // ZNC gates on the same caps. Channel self-lines are safe for everyone.
+      if (row.self && !isChannel && !this.wantsSelfMessages()) continue;
       const nick = row.nick || 'unknown';
       const prefix =
         row.userhost && row.userhost.includes('!')
@@ -925,6 +942,11 @@ class BouncerSession {
     }
   }
 
+  // Whether this client can render `:you PRIVMSG peer` self-messages in DMs.
+  private wantsSelfMessages(): boolean {
+    return this.caps.has('znc.in/self-message') || this.caps.has('echo-message');
+  }
+
   // --- events from ircManager -------------------------------------------------
 
   deliverSelfEcho(type: string, target: string, text: string, time: string | null): void {
@@ -938,6 +960,11 @@ class BouncerSession {
       // echo-message want it back.
       if (!this.caps.has('echo-message')) return;
     }
+    // Cross-client DM sync is only intelligible to clients that negotiated
+    // znc.in/self-message / echo-message — anyone else would render it as an
+    // incoming PM from yourself (and auto-responders reply to it). Channel
+    // self-lines render fine everywhere, so they always sync.
+    if (!isChannelName(target) && !this.wantsSelfMessages()) return;
     const cmd = type === 'notice' ? 'NOTICE' : 'PRIVMSG';
     // Web-composed multiline messages arrive as one event with embedded
     // newlines; a raw newline inside a wire line would split into a bogus

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1,0 +1,1171 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Built-in IRC bouncer (ZNC-style). An opt-in TCP/TLS listener that speaks the
+// IRC *server* protocol, so any ordinary IRC client (WeeChat, irssi, Textual,
+// HexChat, …) can attach to a user's always-on Lurker connection and use it
+// like a ZNC network: shared upstream socket, shared nick, history playback on
+// attach, and everything the client sends flows through the same ircManager
+// paths the web UI uses (so messages persist and fan out to web tabs too).
+//
+// Attach protocol (ZNC-compatible credential shapes):
+//   PASS <username>:<password-or-api-token>            single network
+//   PASS <username>/<network>:<password-or-api-token>  pick a network by name/id
+//   …or put `username/network` in the USER field and only the secret in PASS.
+// The secret may be the account password or an active read-write API token
+// (Settings → API tokens) — tokens are recommended since client configs store
+// the value in plaintext.
+//
+// Design notes / v1 limitations, all deliberate:
+// - Upstream→client traffic is relayed as the RAW wire lines the network sent
+//   (minus registration/PING plumbing), so semantics stay exact. That means
+//   Lurker-level ignore rules and RPE2E decryption do NOT apply to live relay:
+//   an ignored sender is still visible in an attached client, and E2E channel
+//   traffic shows as ciphertext there (your own sends echo as plaintext).
+// - Numeric replies to one attached client's query (WHOIS, LIST, …) are
+//   broadcast to every client attached to that network — the classic
+//   shared-connection bouncer quirk.
+// - Detaching (client QUIT / socket drop) never touches the upstream
+//   connection; Lurker stays online exactly like ZNC.
+
+import net from 'net';
+import tls from 'tls';
+import fs from 'fs';
+import ircManager from './ircManager.js';
+import type { IrcConnection } from './ircConnection.js';
+import * as systemLog from './systemLog.js';
+import { findUserByUsername, getPasswordHash } from '../db/users.js';
+import type { User } from '../db/users.js';
+import { verifyPassword } from './password.js';
+import { hashToken, findActiveByHash, touchLastUsed } from '../db/apiTokens.js';
+import { listNetworksForUser, upsertChannel } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import { reopenBuffer, isClosed as isBufferClosed } from '../db/closedBuffers.js';
+import { listMessages, listBuffersForNetwork } from '../db/messages.js';
+import type { MessageEvent } from '../db/messages.js';
+import { splitSay, splitAction } from './messageSplit.js';
+import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
+
+const SERVER_NAME = 'lurker.bouncer';
+
+// Caps we can honestly offer an attaching client. server-time stamps playback
+// and relayed lines; message-tags passes upstream tags through verbatim;
+// echo-message opts the client into receiving its own sends back (otherwise we
+// suppress the echo, since the client already rendered the message locally);
+// znc.in/self-message is a marker cap — clients that know it render
+// `:you PRIVMSG peer` playback/sync lines as *your* outgoing DMs.
+const SUPPORTED_CAPS = ['server-time', 'message-tags', 'echo-message', 'znc.in/self-message'];
+
+// Upstream wire commands never relayed to attached clients: connection
+// plumbing that belongs to Lurker's own registration/keepalive (we answer the
+// client's PINGs ourselves and replay our own welcome burst at attach), plus
+// SASL/STARTTLS numerics from an upstream re-registration that would confuse a
+// client that never negotiated them.
+const RELAY_DROP = new Set([
+  'PING',
+  'PONG',
+  'CAP',
+  'AUTHENTICATE',
+  'ERROR',
+  '001',
+  '002',
+  '003',
+  '004',
+  '005',
+  '670',
+  '691',
+  '900',
+  '901',
+  '902',
+  '903',
+  '904',
+  '905',
+  '906',
+  '907',
+  '908',
+]);
+
+const REGISTRATION_TIMEOUT_MS = 60_000;
+// Heartbeat: PING an idle client after this much silence, and reap it when the
+// silence outlives the reap threshold (any inbound line counts as activity).
+const HEARTBEAT_INTERVAL_MS = 45_000;
+const HEARTBEAT_PING_AFTER_MS = 90_000;
+const HEARTBEAT_REAP_AFTER_MS = 240_000;
+const MAX_INPUT_BUFFER = 64 * 1024;
+// Cap DM buffers replayed on attach so a years-old account doesn't spew every
+// conversation it ever had; joined channels are always replayed.
+const PLAYBACK_MAX_DM_BUFFERS = 20;
+
+// Per-IP failed-auth throttle: after MAX failures inside the window, further
+// attempts from that address are refused before touching scrypt.
+const AUTH_FAIL_WINDOW_MS = 15 * 60 * 1000;
+const AUTH_FAIL_MAX = 10;
+const authFailures = new Map<string, { count: number; resetAt: number }>();
+
+function authThrottled(ip: string): boolean {
+  const entry = authFailures.get(ip);
+  if (!entry) return false;
+  if (Date.now() > entry.resetAt) {
+    authFailures.delete(ip);
+    return false;
+  }
+  return entry.count >= AUTH_FAIL_MAX;
+}
+
+function noteAuthFailure(ip: string): void {
+  const now = Date.now();
+  const entry = authFailures.get(ip);
+  if (!entry || now > entry.resetAt) {
+    authFailures.set(ip, { count: 1, resetAt: now + AUTH_FAIL_WINDOW_MS });
+  } else {
+    entry.count += 1;
+  }
+}
+
+// Tests reset between cases; production never calls this.
+export function resetAuthThrottle(): void {
+  authFailures.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Pure protocol helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+export interface ParsedClientLine {
+  command: string;
+  params: string[];
+}
+
+/** Parse one client→server IRC line: optional @tags and :prefix are ignored. */
+export function parseClientLine(raw: string): ParsedClientLine | null {
+  // eslint-disable-next-line no-control-regex
+  let line = raw.replace(/[\r\n\u0000]/g, '');
+  if (line.startsWith('@')) {
+    const sp = line.indexOf(' ');
+    if (sp === -1) return null;
+    line = line.slice(sp + 1);
+  }
+  line = line.replace(/^ +/, '');
+  if (line.startsWith(':')) {
+    const sp = line.indexOf(' ');
+    if (sp === -1) return null;
+    line = line.slice(sp + 1).replace(/^ +/, '');
+  }
+  if (!line) return null;
+  let trailing: string | null = null;
+  let head = line;
+  if (line.startsWith(':')) return null;
+  const ti = line.indexOf(' :');
+  if (ti !== -1) {
+    trailing = line.slice(ti + 2);
+    head = line.slice(0, ti);
+  }
+  const parts = head.split(' ').filter(Boolean);
+  if (parts.length === 0) return null;
+  const command = parts.shift()!.toUpperCase();
+  const params = parts;
+  if (trailing !== null) params.push(trailing);
+  return { command, params };
+}
+
+/** Rebuild a parsed client line for verbatim upstream forwarding. */
+export function rebuildLine({ command, params }: ParsedClientLine): string {
+  if (params.length === 0) return command;
+  const head = params.slice(0, -1);
+  const last = params[params.length - 1];
+  const needsTrailing = last === '' || last.includes(' ') || last.startsWith(':');
+  return [command, ...head, needsTrailing ? `:${last}` : last].join(' ');
+}
+
+export interface BouncerCredentials {
+  username: string;
+  secret: string;
+  network: string | null;
+}
+
+// PASS carries `user[/network]:secret` (ZNC shape); when PASS is just the
+// secret, the login (and optional `/network`) rides the USER field instead. A
+// ZNC-style `@clientid` in the login part is accepted and discarded.
+export function parseBouncerCredentials(
+  pass: string,
+  userField: string | null,
+): BouncerCredentials | null {
+  let loginPart = '';
+  let secret = pass;
+  const colon = pass.indexOf(':');
+  if (colon !== -1) {
+    loginPart = pass.slice(0, colon);
+    secret = pass.slice(colon + 1);
+  }
+  if (!loginPart) loginPart = userField || '';
+  let network: string | null = null;
+  const slash = loginPart.indexOf('/');
+  if (slash !== -1) {
+    network = loginPart.slice(slash + 1) || null;
+    loginPart = loginPart.slice(0, slash);
+  }
+  // The network selector may also ride the USER field while the login came
+  // from PASS (`PASS user:secret` + `USER user/libera …`).
+  if (!network && userField) {
+    const uSlash = userField.indexOf('/');
+    if (uSlash !== -1) network = userField.slice(uSlash + 1) || null;
+  }
+  const at = loginPart.indexOf('@');
+  if (at !== -1) loginPart = loginPart.slice(0, at);
+  if (!loginPart || !secret) return null;
+  return { username: loginPart, secret, network };
+}
+
+// Rewrite the target-nick param of a server numeric (`:prefix NNN nick …`).
+// Used to point the replayed registration burst at whatever nick the attaching
+// client asked for, ZNC-style, before we NICK it over to the live one.
+export function rewriteNumericTarget(line: string, nick: string): string {
+  // [\s\S] instead of `.` so a stray trailing CR can't stop the tail group
+  // short of `$` and silently skip the rewrite.
+  const m = /^(:\S+ \S+ )\S+([\s\S]*)$/.exec(line);
+  if (!m) return line;
+  return `${m[1]}${nick}${m[2]}`;
+}
+
+/**
+ * Filter one raw upstream line for an attached client: drop connection
+ * plumbing, drop tag-only commands the client can't parse, and strip message
+ * tags down to what the client negotiated (everything for message-tags, just
+ * `time` for server-time, nothing otherwise). Returns null to drop the line.
+ */
+export function filterRelayLine(line: string, caps: ReadonlySet<string>): string | null {
+  // irc-framework's raw event line keeps its trailing CR — strip it so the
+  // relayed copy doesn't carry a stray control char into our own CRLF framing.
+  line = line.replace(/[\r\n]+$/, '');
+  let tags = '';
+  let rest = line;
+  if (rest.startsWith('@')) {
+    const sp = rest.indexOf(' ');
+    if (sp === -1) return null;
+    tags = rest.slice(1, sp);
+    rest = rest.slice(sp + 1);
+  }
+  let afterPrefix = rest;
+  if (afterPrefix.startsWith(':')) {
+    const sp = afterPrefix.indexOf(' ');
+    if (sp === -1) return null;
+    afterPrefix = afterPrefix.slice(sp + 1);
+  }
+  const command = (afterPrefix.split(' ', 1)[0] || '').toUpperCase();
+  if (RELAY_DROP.has(command)) return null;
+  if ((command === 'TAGMSG' || command === 'BATCH') && !caps.has('message-tags')) return null;
+  if (!tags) return line;
+  if (caps.has('message-tags')) return line;
+  if (caps.has('server-time')) {
+    const time = tags.split(';').find((t) => t === 'time' || t.startsWith('time='));
+    if (time) return `@${time} ${rest}`;
+  }
+  return rest;
+}
+
+// Default IRC prefix ladder, used when the network's ISUPPORT PREFIX isn't
+// available (attached while upstream is still registering).
+const DEFAULT_PREFIXES: Array<{ mode: string; symbol: string }> = [
+  { mode: 'q', symbol: '~' },
+  { mode: 'a', symbol: '&' },
+  { mode: 'o', symbol: '@' },
+  { mode: 'h', symbol: '%' },
+  { mode: 'v', symbol: '+' },
+];
+
+export function memberPrefixSymbol(
+  memberModes: string[],
+  prefixes: Array<{ mode: string; symbol: string }> = DEFAULT_PREFIXES,
+): string {
+  for (const p of prefixes) {
+    if (memberModes.includes(p.mode)) return p.symbol;
+  }
+  return '';
+}
+
+/** Chunk a NAMES membership list into 353 lines under the 512-byte wire cap. */
+export function buildNamesLines(nick: string, channel: string, names: string[]): string[] {
+  const base = `:${SERVER_NAME} 353 ${nick} = ${channel} :`;
+  const budget = Math.max(64, 480 - base.length);
+  const lines: string[] = [];
+  let chunk: string[] = [];
+  let len = 0;
+  for (const name of names) {
+    const add = chunk.length === 0 ? name.length : name.length + 1;
+    if (len + add > budget && chunk.length > 0) {
+      lines.push(base + chunk.join(' '));
+      chunk = [];
+      len = 0;
+    }
+    chunk.push(name);
+    len += chunk.length === 1 ? name.length : add;
+  }
+  if (chunk.length > 0) lines.push(base + chunk.join(' '));
+  lines.push(`:${SERVER_NAME} 366 ${nick} ${channel} :End of /NAMES list.`);
+  return lines;
+}
+
+function toIrcTime(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
+}
+
+function isChannelName(target: string): boolean {
+  return target.startsWith('#') || target.startsWith('&');
+}
+
+// ---------------------------------------------------------------------------
+// Session registry
+// ---------------------------------------------------------------------------
+
+const sessions = new Set<BouncerSession>();
+const registry = new Map<string, Set<BouncerSession>>();
+
+function registryKey(userId: number, networkId: number): string {
+  return `${userId}:${networkId}`;
+}
+
+function attachToRegistry(session: BouncerSession): void {
+  const key = registryKey(session.userId, session.networkId);
+  let set = registry.get(key);
+  if (!set) {
+    set = new Set();
+    registry.set(key, set);
+  }
+  set.add(session);
+}
+
+function detachFromRegistry(session: BouncerSession): void {
+  const key = registryKey(session.userId, session.networkId);
+  const set = registry.get(key);
+  if (!set) return;
+  set.delete(session);
+  if (set.size === 0) registry.delete(key);
+}
+
+export function attachedSessionCount(userId?: number, networkId?: number): number {
+  if (userId == null) return sessions.size;
+  if (networkId == null) {
+    let n = 0;
+    for (const s of sessions) if (s.userId === userId && s.isRegistered()) n += 1;
+    return n;
+  }
+  return registry.get(registryKey(userId, networkId))?.size ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+class BouncerSession {
+  readonly caps = new Set<string>();
+  userId = 0;
+  networkId = 0;
+  lastActivityAt = Date.now();
+
+  private readonly socket: net.Socket;
+  private readonly remoteIp: string;
+  private buf = '';
+  private capNegotiating = false;
+  private passRaw: string | null = null;
+  private clientNick: string | null = null;
+  private clientUser: string | null = null;
+  private registered = false;
+  private closed = false;
+  private conn: IrcConnection | null = null;
+  private network: Network | null = null;
+  // Outbound sends awaiting their self-echo event from ircManager, so a
+  // client that didn't negotiate echo-message doesn't get its own message
+  // back (it already rendered it locally). Other attached clients and web
+  // tabs still receive the echo. Keys are per wire chunk, and entries expire
+  // after a short window so an unconsumed key (from the rare chunking-
+  // mismatch cases) can't suppress an identical message sent much later.
+  private pendingEcho: Array<{ key: string; at: number }> = [];
+  private onRawUpstream: ((event: { from_server: boolean; line: string }) => void) | null = null;
+  private regTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(socket: net.Socket) {
+    this.socket = socket;
+    this.remoteIp = socket.remoteAddress || 'unknown';
+    socket.setNoDelay(true);
+    socket.on('data', (chunk) => this.onData(chunk));
+    socket.on('error', () => this.destroy());
+    socket.on('close', () => this.destroy());
+    this.regTimer = setTimeout(() => {
+      this.closeWithError('Registration timeout');
+    }, REGISTRATION_TIMEOUT_MS);
+    this.regTimer.unref?.();
+  }
+
+  isRegistered(): boolean {
+    return this.registered;
+  }
+
+  private write(line: string): void {
+    if (this.closed) return;
+    try {
+      // No generated line legitimately contains CR/LF/NUL; scrub rather than
+      // let an embedded newline in interpolated text split into a second
+      // injected command. Matching control chars is the point of the regex.
+      // eslint-disable-next-line no-control-regex
+      this.socket.write(line.replace(/[\r\n\u0000]/g, ' ') + '\r\n');
+    } catch {
+      this.destroy();
+    }
+  }
+
+  private numeric(code: string, params: string): void {
+    const nick = this.currentNick() || this.clientNick || '*';
+    this.write(`:${SERVER_NAME} ${code} ${nick} ${params}`);
+  }
+
+  private notice(text: string): void {
+    const nick = this.currentNick() || this.clientNick || '*';
+    this.write(`:${SERVER_NAME} NOTICE ${nick} :${text}`);
+  }
+
+  private currentNick(): string | null {
+    return this.conn?.currentNick || null;
+  }
+
+  private selfPrefix(): string {
+    const nick = this.currentNick() || this.clientNick || '*';
+    const user = this.conn?.client.user?.username || 'lurker';
+    const host = this.conn?.client.user?.host || SERVER_NAME;
+    return `${nick}!${user}@${host}`;
+  }
+
+  private onData(chunk: Buffer | string): void {
+    this.lastActivityAt = Date.now();
+    this.buf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    if (this.buf.length > MAX_INPUT_BUFFER) {
+      this.closeWithError('Input buffer exceeded');
+      return;
+    }
+    let idx: number;
+    while (!this.closed && (idx = this.buf.indexOf('\n')) !== -1) {
+      const raw = this.buf.slice(0, idx).replace(/\r$/, '');
+      this.buf = this.buf.slice(idx + 1);
+      if (!raw) continue;
+      try {
+        this.onLine(raw);
+      } catch (e) {
+        console.warn('[bouncer] error handling line:', (e as Error)?.message || e);
+      }
+    }
+  }
+
+  private onLine(raw: string): void {
+    const parsed = parseClientLine(raw);
+    if (!parsed) return;
+    if (!this.registered) this.handlePreRegistration(parsed);
+    else this.handleCommand(parsed);
+  }
+
+  // --- registration ---------------------------------------------------------
+
+  private handlePreRegistration(msg: ParsedClientLine): void {
+    switch (msg.command) {
+      case 'CAP':
+        this.handleCap(msg);
+        break;
+      case 'PASS':
+        this.passRaw = msg.params[0] ?? '';
+        break;
+      case 'NICK':
+        if (msg.params[0]) this.clientNick = msg.params[0];
+        break;
+      case 'USER':
+        if (msg.params[0]) this.clientUser = msg.params[0];
+        break;
+      case 'AUTHENTICATE':
+        this.write(`:${SERVER_NAME} 904 * :SASL authentication failed (not supported — use PASS)`);
+        break;
+      case 'QUIT':
+        this.destroy();
+        return;
+      default:
+        this.write(`:${SERVER_NAME} 451 * :You have not registered`);
+        break;
+    }
+    this.maybeFinishRegistration();
+  }
+
+  private handleCap(msg: ParsedClientLine): void {
+    const sub = (msg.params[0] || '').toUpperCase();
+    const nick = this.currentNick() || this.clientNick || '*';
+    switch (sub) {
+      case 'LS':
+        if (!this.registered) this.capNegotiating = true;
+        this.write(`:${SERVER_NAME} CAP ${nick} LS :${SUPPORTED_CAPS.join(' ')}`);
+        break;
+      case 'LIST':
+        this.write(`:${SERVER_NAME} CAP ${nick} LIST :${[...this.caps].join(' ')}`);
+        break;
+      case 'REQ': {
+        if (!this.registered) this.capNegotiating = true;
+        const requested = (msg.params[1] || '')
+          .split(' ')
+          .map((c) => c.trim())
+          .filter(Boolean);
+        const supported = requested.every((c) => SUPPORTED_CAPS.includes(c.replace(/^-/, '')));
+        if (!supported || requested.length === 0) {
+          this.write(`:${SERVER_NAME} CAP ${nick} NAK :${requested.join(' ')}`);
+          break;
+        }
+        for (const cap of requested) {
+          if (cap.startsWith('-')) this.caps.delete(cap.slice(1));
+          else this.caps.add(cap);
+        }
+        this.write(`:${SERVER_NAME} CAP ${nick} ACK :${requested.join(' ')}`);
+        break;
+      }
+      case 'END':
+        this.capNegotiating = false;
+        break;
+      default:
+        this.write(`:${SERVER_NAME} 410 ${nick} ${sub || '*'} :Invalid CAP command`);
+        break;
+    }
+  }
+
+  private maybeFinishRegistration(): void {
+    if (this.registered || this.closed) return;
+    if (!this.clientNick || !this.clientUser || this.capNegotiating) return;
+    this.authenticate();
+  }
+
+  private failRegistration(text: string): void {
+    // Console too (not just the wire): a misconfigured client often hides the
+    // 464/ERROR lines, so the operator needs a server-side trace of why.
+    console.warn(`[bouncer] registration failed from ${this.remoteIp}: ${text}`);
+    this.write(`:${SERVER_NAME} 464 ${this.clientNick || '*'} :${text}`);
+    this.closeWithError(text);
+  }
+
+  private authenticate(): void {
+    if (authThrottled(this.remoteIp)) {
+      this.closeWithError('Too many failed logins — try again later');
+      return;
+    }
+    if (!this.passRaw) {
+      this.failRegistration('Password required: PASS <username>[/<network>]:<password-or-token>');
+      return;
+    }
+    const creds = parseBouncerCredentials(this.passRaw, this.clientUser);
+    if (!creds) {
+      this.failRegistration('Invalid credentials format: PASS <username>[/<network>]:<secret>');
+      return;
+    }
+    const user = this.verifyUser(creds.username, creds.secret);
+    if (!user) {
+      noteAuthFailure(this.remoteIp);
+      this.failRegistration('Invalid username or password/token');
+      return;
+    }
+    if (user.is_paused) {
+      this.failRegistration('Account is paused');
+      return;
+    }
+    const networks = listNetworksForUser(user.id);
+    if (networks.length === 0) {
+      this.failRegistration('No IRC networks configured — add one in the web UI first');
+      return;
+    }
+    let network: Network | undefined;
+    if (creds.network) {
+      const sel = creds.network.toLowerCase();
+      network = networks.find((n) => n.name.toLowerCase() === sel || String(n.id) === sel);
+      if (!network) {
+        this.failRegistration(
+          `Unknown network '${creds.network}' — available: ${networks.map((n) => n.name).join(', ')}`,
+        );
+        return;
+      }
+    } else if (networks.length === 1) {
+      network = networks[0];
+    } else {
+      this.failRegistration(
+        `Multiple networks — log in as ${creds.username}/<network>. Available: ${networks
+          .map((n) => n.name)
+          .join(', ')}`,
+      );
+      return;
+    }
+    // Attach to the live upstream connection; attaching to a stopped or dead
+    // network (re)connects it, mirroring how ZNC brings a network up when a
+    // client attaches. A conn object stuck in 'disconnected' (e.g. its boot-
+    // time connect was refused and retries ran out) is restarted — safe here
+    // because this session hasn't attached any listeners to it yet.
+    let conn = ircManager.getConnection(user.id, network.id);
+    if (!conn) {
+      conn = ircManager.startNetwork(user.id, network.id);
+    } else if (conn.state === 'disconnected') {
+      conn = ircManager.restartNetwork(user.id, network.id, 'bouncer client attached');
+    }
+    if (!conn) {
+      this.failRegistration('Network is unavailable');
+      return;
+    }
+
+    this.userId = user.id;
+    this.networkId = network.id;
+    this.network = network;
+    this.conn = conn;
+    this.registered = true;
+    if (this.regTimer) {
+      clearTimeout(this.regTimer);
+      this.regTimer = null;
+    }
+    attachToRegistry(this);
+    this.sendAttachBurst();
+    systemLog.log({
+      userId: this.userId,
+      scope: 'bouncer',
+      fields: { networkId: this.networkId },
+      text: `IRC client attached from ${this.remoteIp} (${attachedSessionCount(this.userId, this.networkId)} attached to ${network.name})`,
+    });
+  }
+
+  private verifyUser(username: string, secret: string): User | null {
+    const user = findUserByUsername(username) ?? findUserByUsername(username.toLowerCase());
+    if (!user) {
+      // Burn comparable time so a missing username isn't distinguishable from
+      // a wrong password by response latency.
+      verifyPassword(secret, null);
+      return null;
+    }
+    if (verifyPassword(secret, getPasswordHash(user.id))) return user;
+    const token = findActiveByHash(hashToken(secret));
+    if (token && token.userId === user.id && token.scope === 'read-write') {
+      touchLastUsed(token.id);
+      return user;
+    }
+    return null;
+  }
+
+  // --- attach burst ----------------------------------------------------------
+
+  private sendAttachBurst(): void {
+    const conn = this.conn!;
+    const requested = this.clientNick || conn.currentNick || 'user';
+    const liveNick = conn.currentNick || requested;
+
+    // ZNC's welcome shape: numerics target the nick the client asked for, then
+    // an explicit NICK line moves it onto the connection's real nick. Replay
+    // the network's own 001–005 when we have them so the client sees the real
+    // ISUPPORT tokens (CHANTYPES/PREFIX/NETWORK drive its parsing).
+    if (conn.state === 'connected' && conn.registrationLines.length > 0) {
+      for (const line of conn.registrationLines) {
+        this.write(rewriteNumericTarget(line, requested));
+      }
+    } else {
+      this.write(
+        `:${SERVER_NAME} 001 ${requested} :Welcome to the ${APP_NAME} bouncer, ${requested}`,
+      );
+      this.write(
+        `:${SERVER_NAME} 002 ${requested} :Your host is ${SERVER_NAME}, running ${APP_NAME} ${APP_VERSION}`,
+      );
+      this.write(`:${SERVER_NAME} 003 ${requested} :This server was created for you`);
+      this.write(`:${SERVER_NAME} 004 ${requested} ${SERVER_NAME} ${APP_NAME}-${APP_VERSION} o o`);
+    }
+    if (requested !== liveNick) {
+      this.write(
+        `:${requested}!${conn.client.user?.username || 'lurker'}@${SERVER_NAME} NICK :${liveNick}`,
+      );
+    }
+    this.write(`:${SERVER_NAME} 422 ${liveNick} :MOTD File is missing`);
+
+    if (conn.state !== 'connected') {
+      this.notice(
+        `Network '${this.network?.name}' is ${conn.state}; channels will appear once it registers.`,
+      );
+    } else {
+      this.sendJoinBurst();
+      this.sendPlayback();
+    }
+
+    // Live relay attaches AFTER playback so replayed history and the live
+    // stream don't interleave out of order.
+    this.onRawUpstream = (event) => {
+      if (this.closed || !event?.from_server || typeof event.line !== 'string') return;
+      const out = filterRelayLine(event.line, this.caps);
+      if (out) this.write(out);
+    };
+    // irc-framework's Client is an eventemitter3, which has no listener-count
+    // cap — several attached clients can listen on one upstream client freely.
+    conn.client.on('raw', this.onRawUpstream);
+  }
+
+  private isupportPrefixes(): Array<{ mode: string; symbol: string }> {
+    const raw = this.conn?.client.network?.options?.PREFIX as unknown;
+    if (
+      Array.isArray(raw) &&
+      raw.length > 0 &&
+      raw.every(
+        (p) =>
+          p &&
+          typeof (p as { mode?: unknown }).mode === 'string' &&
+          typeof (p as { symbol?: unknown }).symbol === 'string',
+      )
+    ) {
+      return raw as Array<{ mode: string; symbol: string }>;
+    }
+    return DEFAULT_PREFIXES;
+  }
+
+  private sendJoinBurst(): void {
+    const conn = this.conn!;
+    const nick = this.currentNick() || '*';
+    const prefixes = this.isupportPrefixes();
+    for (const ch of conn.channels.values()) {
+      this.write(`:${this.selfPrefix()} JOIN ${ch.name}`);
+      if (ch.topic) this.write(`:${SERVER_NAME} 332 ${nick} ${ch.name} :${ch.topic}`);
+      const names = Array.from(ch.members.values()).map(
+        (m) => memberPrefixSymbol(m.modes || [], prefixes) + m.nick,
+      );
+      for (const line of buildNamesLines(nick, ch.name, names)) this.write(line);
+    }
+  }
+
+  private sendPlayback(): void {
+    const limit = playbackLimit();
+    if (limit <= 0) return;
+    const conn = this.conn!;
+    const targets: Array<{ target: string; isChannel: boolean }> = [];
+    for (const ch of conn.channels.values()) targets.push({ target: ch.name, isChannel: true });
+    const joined = new Set(Array.from(conn.channels.keys()));
+    const dms = listBuffersForNetwork(this.networkId)
+      .filter((b) => !isChannelName(b.target) && !b.target.startsWith(':server:'))
+      .filter((b) => !joined.has(b.target.toLowerCase()))
+      .filter((b) => !isBufferClosed(this.userId, this.networkId, b.target))
+      .toSorted((a, b) => (a.lastMessageAt < b.lastMessageAt ? 1 : -1))
+      .slice(0, PLAYBACK_MAX_DM_BUFFERS);
+    for (const b of dms) targets.push({ target: b.target, isChannel: false });
+
+    for (const { target, isChannel } of targets) {
+      const rows = listMessages(this.networkId, target, { limit });
+      for (const line of this.playbackLines(rows, target, isChannel)) this.write(line);
+    }
+  }
+
+  private playbackLines(rows: MessageEvent[], bufferTarget: string, isChannel: boolean): string[] {
+    const out: string[] = [];
+    const selfNick = this.currentNick() || this.clientNick || '*';
+    for (const row of rows) {
+      if (row.type !== 'message' && row.type !== 'action' && row.type !== 'notice') continue;
+      if (row.fromIgnored || row.mirrored || !row.text) continue;
+      const nick = row.nick || 'unknown';
+      const prefix =
+        row.userhost && row.userhost.includes('!')
+          ? row.userhost
+          : `${nick}!${nick}@${SERVER_NAME}`;
+      // Channel rows keep the channel as the target; DM rows address inbound
+      // lines to us and outbound (self) lines to the peer, ZNC-style.
+      const target = isChannel ? bufferTarget : row.self ? bufferTarget : selfNick;
+      const cmd = row.type === 'notice' ? 'NOTICE' : 'PRIVMSG';
+      // Persisted multiline bodies (IRCv3 draft/multiline) become one playback
+      // line per row line; ACTION collapses to a single line.
+      const bodies =
+        row.type === 'action'
+          ? [`\u0001ACTION ${row.text.replace(/\n/g, ' ')}\u0001`]
+          : row.text.split('\n');
+      for (const body of bodies) {
+        let line = `:${prefix} ${cmd} ${target} :${body}`;
+        if (this.caps.has('server-time')) line = `@time=${toIrcTime(row.time)} ${line}`;
+        out.push(line);
+      }
+    }
+    return out;
+  }
+
+  // --- post-registration commands --------------------------------------------
+
+  private liveConn(): IrcConnection | null {
+    const live = ircManager.getConnection(this.userId, this.networkId);
+    if (live && this.conn && live !== this.conn) {
+      // The IrcConnection object was replaced (network edit / explicit
+      // reconnect). Our relay listeners point at the dead client; drop the
+      // session and let the IRC client's auto-reconnect reattach cleanly.
+      this.closeWithError('Upstream connection was reset — reconnect to reattach');
+      return null;
+    }
+    return live;
+  }
+
+  private handleCommand(msg: ParsedClientLine): void {
+    switch (msg.command) {
+      case 'PING':
+        this.write(`:${SERVER_NAME} PONG ${SERVER_NAME} :${msg.params[0] ?? SERVER_NAME}`);
+        return;
+      case 'PONG':
+        return;
+      case 'QUIT':
+        // Detach only — the upstream connection stays up. That's the point.
+        this.destroy();
+        return;
+      case 'CAP':
+        this.handleCap(msg);
+        return;
+      case 'USER':
+        this.numeric('462', ':You may not reregister');
+        return;
+    }
+
+    const conn = this.liveConn();
+    if (this.closed) return;
+    if (!conn) {
+      this.notice(`Not connected to '${this.network?.name}' — connect it from the web UI.`);
+      return;
+    }
+    this.conn = conn;
+
+    switch (msg.command) {
+      case 'PRIVMSG':
+      case 'NOTICE':
+        this.handleClientMessage(msg);
+        return;
+      case 'JOIN': {
+        const first = msg.params[0] || '';
+        if (!first) return;
+        if (first === '0') {
+          conn.raw('JOIN 0');
+          return;
+        }
+        const channels = first.split(',').filter(Boolean);
+        const keys = (msg.params[1] || '').split(',');
+        channels.forEach((channel, i) => {
+          const key = (keys[i] || '').trim();
+          if (key) {
+            // ircManager.joinChannel can't carry a key; persist + reopen the
+            // buffer the same way it does, then JOIN with the key ourselves.
+            upsertChannel(this.networkId, channel, true);
+            reopenBuffer(this.userId, this.networkId, channel);
+            conn.raw(`JOIN ${channel} ${key}`);
+          } else {
+            ircManager.joinChannel(this.userId, this.networkId, channel);
+          }
+        });
+        return;
+      }
+      case 'PART': {
+        const channels = (msg.params[0] || '').split(',').filter(Boolean);
+        const reason = msg.params[1];
+        for (const channel of channels) {
+          ircManager.partChannel(this.userId, this.networkId, channel, reason);
+        }
+        return;
+      }
+      case 'AWAY': {
+        const message = (msg.params[0] || '').trim();
+        // Route through the canonical user-level away writers so the web UI
+        // and every other network connection stay in sync.
+        if (message) ircManager.setAwayAll(this.userId, message);
+        else ircManager.clearAwayAll(this.userId);
+        return;
+      }
+      default:
+        // Everything else (MODE, TOPIC, WHOIS, WHO, NAMES, LIST, KICK, INVITE,
+        // NICK, …) forwards verbatim; replies come back via the raw relay.
+        conn.raw(rebuildLine(msg));
+        return;
+    }
+  }
+
+  private handleClientMessage(msg: ParsedClientLine): void {
+    const conn = this.conn!;
+    const targets = (msg.params[0] || '').split(',').filter(Boolean);
+    const text = msg.params[1] ?? '';
+    if (targets.length === 0) {
+      this.numeric('411', `:No recipient given (${msg.command})`);
+      return;
+    }
+    if (!text) {
+      this.numeric('412', ':No text to send');
+      return;
+    }
+    for (const target of targets) {
+      const isAction = text.startsWith('\u0001ACTION ') || text.startsWith('\u0001ACTION\u0001');
+      if (text.startsWith('\u0001') && !isAction) {
+        // Non-ACTION CTCP (VERSION, PING, replies…): forward on the wire
+        // untouched; these aren't conversation and don't persist.
+        conn.raw(rebuildLine({ command: msg.command, params: [target, text] }));
+        continue;
+      }
+      if (isAction) {
+        // eslint-disable-next-line no-control-regex
+        const body = text.replace(/^\u0001ACTION ?/, '').replace(/\u0001$/, '');
+        for (const chunk of splitAction(body)) this.registerEcho('action', target, chunk);
+        ircManager.action(this.userId, this.networkId, target, body);
+      } else if (msg.command === 'PRIVMSG') {
+        const chunks = splitSay(text);
+        for (const chunk of chunks) this.registerEcho('message', target, chunk);
+        // On an E2E channel the self event carries the full body as ONE event
+        // (not per wire chunk), so register the whole text too when it split.
+        // The unmatched leftover key expires harmlessly (see pendingEcho).
+        if (chunks.length > 1) this.registerEcho('message', target, text);
+        ircManager.send(this.userId, this.networkId, target, text);
+      } else {
+        for (const chunk of splitSay(text)) this.registerEcho('notice', target, chunk);
+        ircManager.notice(this.userId, this.networkId, target, text);
+      }
+    }
+  }
+
+  private registerEcho(type: string, target: string, text: string): void {
+    this.prunePendingEcho();
+    this.pendingEcho.push({ key: echoKey(type, target, text), at: Date.now() });
+    if (this.pendingEcho.length > 500) this.pendingEcho.splice(0, this.pendingEcho.length - 500);
+  }
+
+  private prunePendingEcho(): void {
+    const cutoff = Date.now() - 30_000;
+    if (this.pendingEcho.length && this.pendingEcho[0].at < cutoff) {
+      this.pendingEcho = this.pendingEcho.filter((e) => e.at >= cutoff);
+    }
+  }
+
+  // --- events from ircManager -------------------------------------------------
+
+  deliverSelfEcho(type: string, target: string, text: string, time: string | null): void {
+    if (this.closed) return;
+    this.prunePendingEcho();
+    const key = echoKey(type, target, text);
+    const idx = this.pendingEcho.findIndex((e) => e.key === key);
+    if (idx !== -1) {
+      this.pendingEcho.splice(idx, 1);
+      // This session originated the message; only clients that asked for
+      // echo-message want it back.
+      if (!this.caps.has('echo-message')) return;
+    }
+    const cmd = type === 'notice' ? 'NOTICE' : 'PRIVMSG';
+    // Web-composed multiline messages arrive as one event with embedded
+    // newlines; a raw newline inside a wire line would split into a bogus
+    // second command, so emit one client line per body line.
+    const bodies =
+      type === 'action' ? [`\u0001ACTION ${text.replace(/\n/g, ' ')}\u0001`] : text.split('\n');
+    for (const body of bodies) {
+      let line = `:${this.selfPrefix()} ${cmd} ${target} :${body}`;
+      if (this.caps.has('server-time') && time) line = `@time=${toIrcTime(time)} ${line}`;
+      this.write(line);
+    }
+  }
+
+  onUpstreamState(state: string): void {
+    if (this.closed) return;
+    // liveConn() closes us if the connection object was swapped out.
+    if (!this.liveConn() || this.closed) return;
+    if (state === 'connected') this.notice(`Upstream reconnected to '${this.network?.name}'.`);
+    else if (state === 'reconnecting' || state === 'disconnected') {
+      this.notice(`Upstream ${state} ('${this.network?.name}') — Lurker will keep retrying.`);
+    }
+  }
+
+  heartbeat(now: number): void {
+    if (this.closed) return;
+    const idle = now - this.lastActivityAt;
+    if (idle > HEARTBEAT_REAP_AFTER_MS) {
+      this.closeWithError('Ping timeout');
+    } else if (idle > HEARTBEAT_PING_AFTER_MS) {
+      this.write(`PING :${SERVER_NAME}`);
+    }
+  }
+
+  // --- teardown ---------------------------------------------------------------
+
+  closeWithError(reason: string): void {
+    this.write(`ERROR :${reason}`);
+    // Graceful teardown: socket.destroy() would discard the not-yet-flushed
+    // 464/ERROR bytes (especially over TLS), leaving the client a reasonless
+    // "host disconnected". end() flushes and FINs; the timer backstops a peer
+    // that never closes its half.
+    this.destroy(reason, { graceful: true });
+  }
+
+  destroy(reason?: string, opts: { graceful?: boolean } = {}): void {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.regTimer) {
+      clearTimeout(this.regTimer);
+      this.regTimer = null;
+    }
+    if (this.onRawUpstream && this.conn) {
+      try {
+        this.conn.client.off('raw', this.onRawUpstream);
+      } catch {
+        /* ignore */
+      }
+    }
+    this.onRawUpstream = null;
+    sessions.delete(this);
+    if (this.registered) {
+      detachFromRegistry(this);
+      systemLog.log({
+        userId: this.userId,
+        scope: 'bouncer',
+        fields: { networkId: this.networkId },
+        text: `IRC client detached${reason ? ` (${reason})` : ''} (${attachedSessionCount(this.userId, this.networkId)} still attached)`,
+      });
+    }
+    try {
+      if (opts.graceful) {
+        this.socket.end();
+        const backstop = setTimeout(() => {
+          try {
+            this.socket.destroy();
+          } catch {
+            /* ignore */
+          }
+        }, 3000);
+        backstop.unref?.();
+      } else {
+        this.socket.destroy();
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function echoKey(type: string, target: string, text: string): string {
+  return `${type}\u0000${target.toLowerCase()}\u0000${text}`;
+}
+
+// ---------------------------------------------------------------------------
+// ircManager event fan-in
+// ---------------------------------------------------------------------------
+
+function dispatchIrcEvent(event: Record<string, unknown>): void {
+  const userId = Number(event.userId);
+  const networkId = Number(event.networkId);
+  if (!userId || !networkId) return;
+  const set = registry.get(registryKey(userId, networkId));
+  if (!set || set.size === 0) return;
+  const type = String(event.type || '');
+  if (type === 'state') {
+    const state = String(event.state || '');
+    // Deleting from a Set mid-iteration is safe; handlers only ever remove.
+    for (const session of set) session.onUpstreamState(state);
+    return;
+  }
+  // Self-originated conversation (sent from the web UI, MCP, or another
+  // attached IRC client) — the upstream never echoes it, so synthesize it.
+  if (!event.self) return;
+  if (type !== 'message' && type !== 'action' && type !== 'notice') return;
+  const target = typeof event.target === 'string' ? event.target : '';
+  if (!target || target.startsWith(':server:')) return;
+  const text = typeof event.text === 'string' ? event.text : '';
+  if (!text) return;
+  const time = typeof event.time === 'string' ? event.time : null;
+  for (const session of set) session.deliverSelfEcho(type, target, text, time);
+}
+
+function dropSessionsForUser(userId: number, reason: string): void {
+  for (const session of sessions) {
+    if (session.userId === userId && session.isRegistered()) session.closeWithError(reason);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server lifecycle + env config
+// ---------------------------------------------------------------------------
+
+let server: net.Server | tls.Server | null = null;
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let onIrcEvent: ((event: Record<string, unknown>) => void) | null = null;
+let onUserDisposed: ((payload: { userId: number }) => void) | null = null;
+let onUserSuspended: ((payload: { userId: number }) => void) | null = null;
+
+export function isBouncerEnabled(): boolean {
+  return /^(1|true|yes|on)$/i.test((process.env.LURKER_BOUNCER_ENABLED || '').trim());
+}
+
+export function bouncerPort(): number {
+  const p = Number(process.env.LURKER_BOUNCER_PORT);
+  return Number.isInteger(p) && p > 0 ? p : 6667;
+}
+
+// Optional bind address (LURKER_BOUNCER_BIND). Unset binds every interface —
+// pair the default with TLS or a private network; plain-text IRC carries the
+// login credential.
+export function bouncerBindHost(): string | undefined {
+  const host = (process.env.LURKER_BOUNCER_BIND || '').trim();
+  return host || undefined;
+}
+
+function playbackLimit(): number {
+  const n = Number(process.env.LURKER_BOUNCER_PLAYBACK);
+  if (!Number.isFinite(n) || n < 0) return 50;
+  return Math.min(1000, Math.floor(n));
+}
+
+// TLS when both cert and key paths are set (LURKER_BOUNCER_TLS_CERT/KEY).
+// Read once at startup; a reload requires a restart, same as the web server.
+function tlsOptions(): { cert: Buffer; key: Buffer } | null {
+  const certPath = (process.env.LURKER_BOUNCER_TLS_CERT || '').trim();
+  const keyPath = (process.env.LURKER_BOUNCER_TLS_KEY || '').trim();
+  if (!certPath || !keyPath) return null;
+  return { cert: fs.readFileSync(certPath), key: fs.readFileSync(keyPath) };
+}
+
+export function startBouncer(port: number = bouncerPort(), host?: string): void {
+  if (server) return;
+  const tlsOpts = tlsOptions();
+  const onConnection = (socket: net.Socket) => {
+    sessions.add(new BouncerSession(socket));
+  };
+  server = tlsOpts ? tls.createServer(tlsOpts, onConnection) : net.createServer(onConnection);
+  server.on('error', (err) => {
+    console.warn(`[bouncer] listener error: ${(err as Error).message}`);
+  });
+  server.listen(port, host, () => {
+    console.log(
+      `[bouncer] IRC bouncer listening on ${host || '0.0.0.0'}:${port}${tlsOpts ? ' (TLS)' : ''}`,
+    );
+    systemLog.log({
+      scope: 'bouncer',
+      text: `IRC bouncer listening on port ${port}${tlsOpts ? ' (TLS)' : ''}`,
+    });
+  });
+
+  onIrcEvent = (event) => dispatchIrcEvent(event as Record<string, unknown>);
+  ircManager.on('event', onIrcEvent);
+  onUserDisposed = ({ userId }) => dropSessionsForUser(userId, 'Account removed');
+  onUserSuspended = ({ userId }) => dropSessionsForUser(userId, 'Account paused');
+  ircManager.on('user-disposed', onUserDisposed);
+  ircManager.on('user-suspended', onUserSuspended);
+
+  heartbeatTimer = setInterval(() => {
+    const now = Date.now();
+    for (const session of sessions) session.heartbeat(now);
+  }, HEARTBEAT_INTERVAL_MS);
+  heartbeatTimer.unref?.();
+}
+
+export function stopBouncer(): void {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+  if (onIrcEvent) {
+    ircManager.off('event', onIrcEvent);
+    onIrcEvent = null;
+  }
+  if (onUserDisposed) {
+    ircManager.off('user-disposed', onUserDisposed);
+    onUserDisposed = null;
+  }
+  if (onUserSuspended) {
+    ircManager.off('user-suspended', onUserSuspended);
+    onUserSuspended = null;
+  }
+  for (const session of sessions) session.destroy('Server shutting down');
+  if (server) {
+    try {
+      server.close();
+    } catch {
+      /* ignore */
+    }
+    server = null;
+  }
+}

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -314,11 +314,11 @@ function isChannelName(target: string): boolean {
   return target.startsWith('#') || target.startsWith('&');
 }
 
-// Network-services pseudo-users whose DM buffers must never replay on attach:
-// they're registration plumbing, not conversation, and the self side routinely
-// contains credentials (`msg NickServ IDENTIFY <password>` from a client's
-// perform/on-connect) that would otherwise land in every attached client's
-// logs on every reconnect.
+// Network-services pseudo-users (NickServ/ChanServ/…). Playback replays their
+// buffers like any DM, but never the user's OWN lines to them — the self side
+// routinely contains credentials (`msg NickServ IDENTIFY <password>` from a
+// client's perform/on-connect) that would otherwise land in every attached
+// client's logs on every reconnect.
 export function isServicesNick(nick: string): boolean {
   const lower = nick.toLowerCase();
   return /^[a-z]+serv$/.test(lower) || lower === 'global' || lower === 'services';
@@ -747,7 +747,6 @@ class BouncerSession {
     const joined = new Set(Array.from(conn.channels.keys()));
     const dms = listBuffersForNetwork(this.networkId)
       .filter((b) => !isChannelName(b.target) && !b.target.startsWith(':server:'))
-      .filter((b) => !isServicesNick(b.target))
       .filter((b) => !joined.has(b.target.toLowerCase()))
       .filter((b) => !isBufferClosed(this.userId, this.networkId, b.target))
       .toSorted((a, b) => (a.lastMessageAt < b.lastMessageAt ? 1 : -1))
@@ -772,6 +771,11 @@ class BouncerSession {
       // "from you", which confuses query windows and trips auto-responders.
       // ZNC gates on the same caps. Channel self-lines are safe for everyone.
       if (row.self && !isChannel && !this.wantsSelfMessages()) continue;
+      // Never replay your OWN lines to services (NickServ/ChanServ/…) even to
+      // capable clients: that's where credentials live (IDENTIFY from a
+      // client's perform), and each reconnect would replay them into that
+      // client's logs. The services' replies still play back normally.
+      if (row.self && !isChannel && isServicesNick(bufferTarget)) continue;
       const nick = row.nick || 'unknown';
       const prefix =
         row.userhost && row.userhost.includes('!')

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -382,6 +382,11 @@ export class IrcConnection {
   // of issuing buffers, so two concurrent same-type queries to one nick route
   // their replies back in order. Bounded + TTL-pruned on access.
   ctcpOutstanding: Map<string, Array<{ issuingTarget: string; sentAt: number }>>;
+  // The raw 001–005 registration burst as the server sent it, captured by the
+  // 'raw' handler (reset on each 001). The bouncer replays these verbatim
+  // (nick-rewritten) to IRC clients that attach mid-session, so they see the
+  // network's real ISUPPORT tokens instead of a synthesized approximation.
+  registrationLines: string[];
 
   constructor({ network, onEvent }: { network: Network; onEvent: (event: EnrichedEvent) => void }) {
     this.network = network;
@@ -461,6 +466,7 @@ export class IrcConnection {
     this.multilineBatches = new Map();
     this.ctcpLimiter = new RateLimiter();
     this.ctcpOutstanding = new Map();
+    this.registrationLines = [];
     this.bind();
   }
 
@@ -661,7 +667,25 @@ export class IrcConnection {
       } catch (_) {
         return;
       }
-      if (isServerBufferDeniedNumeric((msg?.command || '').toString())) return;
+      const rawCommand = (msg?.command || '').toString();
+      // Capture the registration burst for bouncer attach-time replay. 001
+      // starts a fresh burst (each (re)registration replaces the last), and
+      // the follow-on 002–005 lines are only appended once a burst has begun
+      // so a stray mid-session numeric can't graft onto a stale burst. The
+      // raw line keeps its trailing CR; strip it so replay consumers get a
+      // clean single-line payload.
+      const burstLine = event.line.replace(/[\r\n]+$/, '');
+      if (rawCommand === '001') this.registrationLines = [burstLine];
+      else if (
+        this.registrationLines.length > 0 &&
+        (rawCommand === '002' ||
+          rawCommand === '003' ||
+          rawCommand === '004' ||
+          rawCommand === '005')
+      ) {
+        this.registrationLines.push(burstLine);
+      }
+      if (isServerBufferDeniedNumeric(rawCommand)) return;
       // formatUnknownNumeric only renders 3-digit numerics (it strips the
       // leading recipient-nick param), so PRIVMSG/JOIN/NOTICE/etc. naturally
       // fall through and never pollute the server buffer.


### PR DESCRIPTION
An opt-in TCP/TLS listener (LURKER_BOUNCER_ENABLED) that speaks the IRC server protocol, so ordinary IRC clients (WeeChat, irssi, Textual, HexChat, ...) can attach to a user's always-on Lurker connection like a ZNC network: shared upstream socket and nick, the network's real 001-005 registration burst replayed on attach, live channel state (JOIN + TOPIC
+ NAMES), and history playback with IRCv3 server-time stamps.

Clients authenticate with PASS <username>[/<network>]:<secret>, where the secret is the account password or a read-write API token. Failed logins are throttled per IP.

Everything a client sends routes through the same ircManager paths the web UI uses, so messages persist and fan out to web tabs; upstream traffic is relayed as raw wire lines with per-client tag filtering keyed to negotiated caps (server-time, message-tags, echo-message, znc.in/self-message). Detaching never touches the upstream connection.

Documented v1 limitations: replies to one attached client's WHOIS/LIST broadcast to all attached clients on that network, ignore rules don't filter the raw relay, and E2E channels relay incoming ciphertext.