### PR TITLE
Bouncer Phase 3: soju.im/bouncer-networks (control mode, LISTNETWORKS, BIND, notify)

### DIFF
--- a/server/services/bouncer.networks.test.ts
+++ b/server/services/bouncer.networks.test.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Socket-driven tests for the soju.im/bouncer-networks control surface:
+// control (unbound) mode, BOUNCER LISTNETWORKS / BIND, BOUNCER_NETID, and the
+// -notify state-change pushes. See test-utils/bouncerHarness.ts.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('services-bouncer-networks');
+
+let harnessMod: typeof import('../test-utils/bouncerHarness.js');
+let bouncerMod: typeof import('./bouncer.js');
+let harness: import('../test-utils/bouncerHarness.js').Harness;
+
+beforeAll(async () => {
+  process.env.LURKER_BOUNCER_ENABLED = 'true';
+  harnessMod = await import('../test-utils/bouncerHarness.js');
+  bouncerMod = await import('./bouncer.js');
+  harness = await harnessMod.startHarness();
+});
+
+afterAll(() => {
+  harness.stop();
+  ctx.cleanup();
+});
+
+beforeEach(() => {
+  bouncerMod.resetAuthThrottle();
+});
+
+const NUL = String.fromCharCode(0);
+function saslPlain(authcid: string, passwd: string): string {
+  return Buffer.from(['', authcid, passwd].join(NUL), 'utf8').toString('base64');
+}
+
+// Drive CAP + SASL to the point of registration, requesting the given caps.
+// Leaves the client at CAP-END-ready (caller sends CAP END + BOUNCER as needed).
+type Client = Awaited<ReturnType<import('../test-utils/bouncerHarness.js').Harness['connect']>>;
+async function negotiate(
+  c: Client,
+  acct: { user: { username: string }; password: string },
+  caps: string,
+): Promise<void> {
+  c.send('CAP LS 302');
+  await c.waitFor((l) => l.includes('CAP') && l.includes('LS'));
+  c.send('NICK client');
+  c.send('USER client 0 * :client');
+  c.send(`CAP REQ :${caps}`);
+  await c.waitFor((l) => l.includes('ACK'));
+  c.send('AUTHENTICATE PLAIN');
+  await c.waitFor((l) => l === 'AUTHENTICATE +');
+  c.send(`AUTHENTICATE ${saslPlain(acct.user.username, acct.password)}`);
+  await c.waitForCommand('903');
+}
+
+describe('control (unbound) mode', () => {
+  it('registers a bouncer-networks client with no network as a control connection', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ctl1' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'second', nick: 'ctl1b' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('CAP END');
+    const welcome = await c.waitForCommand('005');
+    // Control connections must NOT advertise BOUNCER_NETID (that's the signal).
+    expect(welcome).not.toContain('BOUNCER_NETID');
+    expect(harnessMod.attachedFor(acct)).toBe(0); // not bound to network 1
+  });
+
+  it('refuses channel/user traffic on a control connection', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ctl2' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    c.send('PRIVMSG #chan :hi');
+    const notice = await c.waitForCommand('NOTICE');
+    expect(notice.toLowerCase()).toContain('bind a network');
+  });
+});
+
+describe('BOUNCER LISTNETWORKS', () => {
+  it('returns a batch of BOUNCER NETWORK lines, one per network', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ls1', networkName: 'alpha' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'beta', nick: 'ls1b' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    c.send('BOUNCER LISTNETWORKS');
+    const open = await c.waitForCommand('BATCH');
+    const ref = open.split('BATCH +')[1].split(' ')[0];
+    expect(open).toContain('soju.im/bouncer-networks');
+    const net1 = await c.waitFor((l) => l.includes('BOUNCER NETWORK') && l.includes('name=alpha'));
+    expect(net1).toContain(`@batch=${ref}`);
+    expect(net1).toMatch(/BOUNCER NETWORK \d+ /);
+    expect(net1).toContain('state=connected'); // fake upstream is "connected"
+    await c.waitFor((l) => l.includes('BOUNCER NETWORK') && l.includes('name=beta'));
+    await c.waitFor((l) => l.includes(`BATCH -${ref}`));
+  });
+});
+
+describe('BOUNCER BIND', () => {
+  it('binds a network by id and advertises BOUNCER_NETID', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'bind1', networkName: 'primary' });
+    const second = harnessMod.seedNetwork(acct.user, { networkName: 'secondary', nick: 'bind1b' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send(`BOUNCER BIND ${second.network.id}`);
+    c.send('CAP END');
+    const welcome = await c.waitFor((l) => l.includes('005') && l.includes('BOUNCER_NETID'));
+    expect(welcome).toContain(`BOUNCER_NETID=${second.network.id}`);
+    expect(bouncerMod.attachedSessionCount(acct.user.id, second.network.id)).toBe(1);
+  });
+
+  it('rejects a non-numeric BIND with FAIL INVALID_NETID', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'bind2' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('BOUNCER BIND notanumber');
+    const fail = await c.waitForCommand('FAIL');
+    expect(fail).toContain('INVALID_NETID');
+    c.close();
+  });
+
+  it('rejects BIND to an unknown id at CAP END with FAIL INVALID_NETID', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'bind3' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('BOUNCER BIND 999999');
+    c.send('CAP END');
+    const fail = await c.waitForCommand('FAIL');
+    expect(fail).toContain('INVALID_NETID');
+    expect(fail).toContain('999999');
+  });
+
+  it('rejects BOUNCER BIND after registration with REGISTRATION_IS_COMPLETED', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'bind4' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    c.send('BOUNCER BIND 1');
+    const fail = await c.waitForCommand('FAIL');
+    expect(fail).toContain('REGISTRATION_IS_COMPLETED');
+    c.close();
+  });
+});
+
+describe('bouncer-networks-notify', () => {
+  it('sends an initial batch dump then bare state-change pushes', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'nfy1', networkName: 'gamma' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks soju.im/bouncer-networks-notify');
+    c.send('CAP END');
+    // Initial dump is a batch (arrives during/after the welcome burst).
+    await c.waitFor((l) => l.includes('BOUNCER NETWORK') && l.includes('name=gamma'));
+
+    // A later state change is an UNbatched BOUNCER NETWORK line.
+    harnessMod.emitNetworkState(acct.user.id, acct.network.id, 'disconnected');
+    const push = await c.waitFor(
+      (l) => l.includes('BOUNCER NETWORK') && l.includes('state=disconnected'),
+    );
+    expect(push).not.toContain('@batch=');
+    expect(push).toContain(`BOUNCER NETWORK ${acct.network.id}`);
+  });
+
+  it('does not push state changes to a client without the notify cap', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'nfy2' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    harnessMod.emitNetworkState(acct.user.id, acct.network.id, 'disconnected');
+    // Give the event a tick; assert no BOUNCER NETWORK push arrived.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(c.lines.some((l) => l.includes('BOUNCER NETWORK'))).toBe(false);
+    c.close();
+  });
+});

--- a/server/services/bouncer.networks.test.ts
+++ b/server/services/bouncer.networks.test.ts
@@ -166,6 +166,34 @@ describe('bouncer-networks-notify', () => {
     expect(push).toContain(`BOUNCER NETWORK ${acct.network.id}`);
   });
 
+  it('pushes live state changes to a BOUND -notify client too', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'nfy3', networkName: 'delta' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks soju.im/bouncer-networks-notify');
+    c.send(`BOUNCER BIND ${acct.network.id}`);
+    c.send('CAP END');
+    await c.waitFor((l) => l.includes('BOUNCER_NETID'));
+    harnessMod.emitNetworkState(acct.user.id, acct.network.id, 'disconnected');
+    const push = await c.waitFor(
+      (l) => l.includes('BOUNCER NETWORK') && l.includes('state=disconnected'),
+    );
+    expect(push).not.toContain('@batch=');
+  });
+
+  it('reports a mid-connect network as state=connecting, not disconnected', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'nfy4', networkName: 'epsilon' });
+    acct.upstream.state = 'connecting';
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    c.send('BOUNCER LISTNETWORKS');
+    const line = await c.waitFor(
+      (l) => l.includes('BOUNCER NETWORK') && l.includes('name=epsilon'),
+    );
+    expect(line).toContain('state=connecting');
+  });
+
   it('does not push state changes to a client without the notify cap', async () => {
     const acct = harnessMod.seedAccount({ nick: 'nfy2' });
     const c = await harness.connect();

--- a/server/services/bouncer.networks.test.ts
+++ b/server/services/bouncer.networks.test.ts
@@ -81,11 +81,11 @@ describe('control (unbound) mode', () => {
 });
 
 describe('BOUNCER LISTNETWORKS', () => {
-  it('returns a batch of BOUNCER NETWORK lines, one per network', async () => {
+  it('returns a batch of BOUNCER NETWORK lines when the client negotiated batch', async () => {
     const acct = harnessMod.seedAccount({ nick: 'ls1', networkName: 'alpha' });
     harnessMod.seedNetwork(acct.user, { networkName: 'beta', nick: 'ls1b' });
     const c = await harness.connect();
-    await negotiate(c, acct, 'sasl soju.im/bouncer-networks');
+    await negotiate(c, acct, 'sasl batch soju.im/bouncer-networks');
     c.send('CAP END');
     await c.waitForCommand('422');
     c.send('BOUNCER LISTNETWORKS');
@@ -98,6 +98,33 @@ describe('BOUNCER LISTNETWORKS', () => {
     expect(net1).toContain('state=connected'); // fake upstream is "connected"
     await c.waitFor((l) => l.includes('BOUNCER NETWORK') && l.includes('name=beta'));
     await c.waitFor((l) => l.includes(`BATCH -${ref}`));
+  });
+
+  it('sends unwrapped, untagged BOUNCER NETWORK lines without the batch cap', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ls2', networkName: 'solo' });
+    const c = await harness.connect();
+    await negotiate(c, acct, 'sasl soju.im/bouncer-networks'); // no batch cap
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    c.send('BOUNCER LISTNETWORKS');
+    const line = await c.waitFor((l) => l.includes('BOUNCER NETWORK') && l.includes('name=solo'));
+    // No message tag, and no surrounding BATCH command.
+    expect(line).not.toContain('@batch=');
+    expect(line.startsWith(':')).toBe(true);
+    expect(c.lines.some((l) => harnessMod.commandOf(l) === 'BATCH')).toBe(false);
+  });
+
+  it('refuses BOUNCER without the bouncer-networks cap', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ls3', networkName: 'onlynet' });
+    const c = await harness.connect();
+    // Single network + no cap → auto-binds; then BOUNCER should be refused.
+    await negotiate(c, acct, 'sasl');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    c.send('BOUNCER LISTNETWORKS');
+    const fail = await c.waitForCommand('FAIL');
+    expect(fail).toContain('UNKNOWN_COMMAND');
+    c.close();
   });
 });
 

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -19,6 +19,7 @@ let buildNamesLines: typeof import('./bouncer.js').buildNamesLines;
 let isServicesNick: typeof import('./bouncer.js').isServicesNick;
 let escapeTagValue: typeof import('./bouncer.js').escapeTagValue;
 let buildNetworkAttrs: typeof import('./bouncer.js').buildNetworkAttrs;
+let bouncerNetworkState: typeof import('./bouncer.js').bouncerNetworkState;
 let maxSessionsPerUser: typeof import('./bouncer.js').maxSessionsPerUser;
 let maxSessionsTotal: typeof import('./bouncer.js').maxSessionsTotal;
 let maxTotalPlaybackLines: typeof import('./bouncer.js').maxTotalPlaybackLines;
@@ -36,6 +37,7 @@ beforeAll(async () => {
   isServicesNick = mod.isServicesNick;
   escapeTagValue = mod.escapeTagValue;
   buildNetworkAttrs = mod.buildNetworkAttrs;
+  bouncerNetworkState = mod.bouncerNetworkState;
   maxSessionsPerUser = mod.maxSessionsPerUser;
   maxSessionsTotal = mod.maxSessionsTotal;
   maxTotalPlaybackLines = mod.maxTotalPlaybackLines;
@@ -333,15 +335,25 @@ describe('buildNetworkAttrs', () => {
   const network = { name: 'Libera Chat', host: 'irc.libera.chat', port: 6697, tls: 1, nick: 'me' };
 
   it('encodes the network as a tag-escaped attribute list', () => {
-    expect(buildNetworkAttrs(network, { connected: true })).toBe(
+    expect(buildNetworkAttrs(network, { state: 'connected' })).toBe(
       'name=Libera\\sChat;state=connected;host=irc.libera.chat;port=6697;tls=1;nickname=me',
     );
   });
 
-  it('reports disconnected state and honors a live nickname override', () => {
-    const attrs = buildNetworkAttrs(network, { connected: false, nickname: 'me_' });
+  it('reports the given state and honors a live nickname override', () => {
+    const attrs = buildNetworkAttrs(network, { state: 'disconnected', nickname: 'me_' });
     expect(attrs).toContain('state=disconnected');
     expect(attrs).toContain('nickname=me_');
+  });
+});
+
+describe('bouncerNetworkState', () => {
+  it('maps upstream states to spec values (connecting/reconnecting → connecting)', () => {
+    expect(bouncerNetworkState('connected')).toBe('connected');
+    expect(bouncerNetworkState('connecting')).toBe('connecting');
+    expect(bouncerNetworkState('reconnecting')).toBe('connecting');
+    expect(bouncerNetworkState('disconnected')).toBe('disconnected');
+    expect(bouncerNetworkState(undefined)).toBe('disconnected');
   });
 });
 

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -17,6 +17,8 @@ let filterRelayLine: typeof import('./bouncer.js').filterRelayLine;
 let memberPrefixSymbol: typeof import('./bouncer.js').memberPrefixSymbol;
 let buildNamesLines: typeof import('./bouncer.js').buildNamesLines;
 let isServicesNick: typeof import('./bouncer.js').isServicesNick;
+let escapeTagValue: typeof import('./bouncer.js').escapeTagValue;
+let buildNetworkAttrs: typeof import('./bouncer.js').buildNetworkAttrs;
 let maxSessionsPerUser: typeof import('./bouncer.js').maxSessionsPerUser;
 let maxSessionsTotal: typeof import('./bouncer.js').maxSessionsTotal;
 let maxTotalPlaybackLines: typeof import('./bouncer.js').maxTotalPlaybackLines;
@@ -32,6 +34,8 @@ beforeAll(async () => {
   memberPrefixSymbol = mod.memberPrefixSymbol;
   buildNamesLines = mod.buildNamesLines;
   isServicesNick = mod.isServicesNick;
+  escapeTagValue = mod.escapeTagValue;
+  buildNetworkAttrs = mod.buildNetworkAttrs;
   maxSessionsPerUser = mod.maxSessionsPerUser;
   maxSessionsTotal = mod.maxSessionsTotal;
   maxTotalPlaybackLines = mod.maxTotalPlaybackLines;
@@ -309,6 +313,35 @@ describe('isServicesNick', () => {
     for (const n of ['bob', 'serv', 'nickservv', 'server1', 'preserve1', 'quinn', 'xavier']) {
       expect(isServicesNick(n)).toBe(false);
     }
+  });
+});
+
+describe('escapeTagValue (IRCv3 message-tag escaping)', () => {
+  it('escapes space, semicolon, backslash, CR and LF', () => {
+    expect(escapeTagValue('My Awesome Network')).toBe('My\\sAwesome\\sNetwork');
+    expect(escapeTagValue('a;b')).toBe('a\\:b');
+    expect(escapeTagValue('a\\b')).toBe('a\\\\b');
+    expect(escapeTagValue('a\r\nb')).toBe('a\\r\\nb');
+  });
+
+  it('leaves ordinary text untouched', () => {
+    expect(escapeTagValue('libera.chat')).toBe('libera.chat');
+  });
+});
+
+describe('buildNetworkAttrs', () => {
+  const network = { name: 'Libera Chat', host: 'irc.libera.chat', port: 6697, tls: 1, nick: 'me' };
+
+  it('encodes the network as a tag-escaped attribute list', () => {
+    expect(buildNetworkAttrs(network, { connected: true })).toBe(
+      'name=Libera\\sChat;state=connected;host=irc.libera.chat;port=6697;tls=1;nickname=me',
+    );
+  });
+
+  it('reports disconnected state and honors a live nickname override', () => {
+    const attrs = buildNetworkAttrs(network, { connected: false, nickname: 'me_' });
+    expect(attrs).toContain('state=disconnected');
+    expect(attrs).toContain('nickname=me_');
   });
 });
 

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -420,16 +420,27 @@ export function escapeTagValue(value: string): string {
     .replace(/\n/g, '\\n');
 }
 
+// Map an IrcConnection state to a bouncer-networks `state` attribute value.
+// soju itself only ever emits connected/disconnected, but the spec defines
+// `connecting` and requires clients to accept it, so we surface the extra
+// fidelity of the connecting/reconnecting phase (a deliberate divergence — a
+// mid-connect network must not be advertised as `disconnected`).
+export function bouncerNetworkState(connState: string | undefined): string {
+  if (connState === 'connected') return 'connected';
+  if (connState === 'connecting' || connState === 'reconnecting') return 'connecting';
+  return 'disconnected';
+}
+
 // Build the tag-encoded attribute list for one network's BOUNCER NETWORK line.
-// `state` is derived from whether the upstream is live; soju only ever emits
-// connected/disconnected (never `connecting`), so we match that.
+// (v1 omits soju's `error`/`username`/`realname` — LISTNETWORKS is read-only and
+// we don't yet plumb a per-network last-error string here.)
 export function buildNetworkAttrs(
   network: { name: string; host: string; port: number; tls: number | boolean; nick: string },
-  opts: { connected: boolean; nickname?: string },
+  opts: { state: string; nickname?: string },
 ): string {
   const attrs: Array<[string, string]> = [
     ['name', network.name],
-    ['state', opts.connected ? 'connected' : 'disconnected'],
+    ['state', opts.state],
     ['host', network.host],
     ['port', String(network.port)],
     ['tls', network.tls ? '1' : '0'],
@@ -444,11 +455,6 @@ export function buildNetworkAttrs(
 
 const sessions = new Set<BouncerSession>();
 const registry = new Map<string, Set<BouncerSession>>();
-// Control (unbound) sessions: a `soju.im/bouncer-networks` client that
-// registered without binding a network. Keyed by userId (not networkId — a
-// control connection spans all of the user's networks) so state-change
-// notifications can fan out to every control client the user has open.
-const controlSessions = new Map<number, Set<BouncerSession>>();
 
 function registryKey(userId: number, networkId: number): string {
   return `${userId}:${networkId}`;
@@ -470,22 +476,6 @@ function detachFromRegistry(session: BouncerSession): void {
   if (!set) return;
   set.delete(session);
   if (set.size === 0) registry.delete(key);
-}
-
-function attachToControlRegistry(session: BouncerSession): void {
-  let set = controlSessions.get(session.userId);
-  if (!set) {
-    set = new Set();
-    controlSessions.set(session.userId, set);
-  }
-  set.add(session);
-}
-
-function detachFromControlRegistry(session: BouncerSession): void {
-  const set = controlSessions.get(session.userId);
-  if (!set) return;
-  set.delete(session);
-  if (set.size === 0) controlSessions.delete(session.userId);
 }
 
 export function attachedSessionCount(userId?: number, networkId?: number): number {
@@ -978,12 +968,13 @@ class BouncerSession {
   }
 
   // Register a control (unbound) connection: authenticated, bound to no network.
+  // It lives only in the global `sessions` set (no per-network registry); state
+  // notifications reach it via the user-scoped fan-out in dispatchIrcEvent.
   private registerControl(user: User): void {
     this.userId = user.id;
     this.isControl = true;
     this.registered = true;
     this.clearRegTimer();
-    attachToControlRegistry(this);
     this.sendControlBurst();
     systemLog.log({
       userId: this.userId,
@@ -1025,14 +1016,7 @@ class BouncerSession {
         this.write(rewriteNumericTarget(line, requested));
       }
     } else {
-      this.write(
-        `:${SERVER_NAME} 001 ${requested} :Welcome to the ${APP_NAME} bouncer, ${requested}`,
-      );
-      this.write(
-        `:${SERVER_NAME} 002 ${requested} :Your host is ${SERVER_NAME}, running ${APP_NAME} ${APP_VERSION}`,
-      );
-      this.write(`:${SERVER_NAME} 003 ${requested} :This server was created for you`);
-      this.write(`:${SERVER_NAME} 004 ${requested} ${SERVER_NAME} ${APP_NAME}-${APP_VERSION} o o`);
+      this.writeWelcomeNumerics(requested);
     }
     if (requested !== liveNick) {
       this.write(
@@ -1079,17 +1063,23 @@ class BouncerSession {
 
   // --- control (unbound) connection ------------------------------------------
 
-  // Minimal welcome for a control connection: it binds no network, so no
-  // registrationLines / JOIN / playback / relay. The bouncer-scoped ISUPPORT
-  // omits BOUNCER_NETID (its absence is how a client detects control mode).
-  private sendControlBurst(): void {
-    const nick = this.clientNick || 'user';
+  // The 001–004 welcome numerics, shared by the control burst and the
+  // no-registrationLines fallback of the bound attach burst.
+  private writeWelcomeNumerics(nick: string): void {
     this.write(`:${SERVER_NAME} 001 ${nick} :Welcome to the ${APP_NAME} bouncer, ${nick}`);
     this.write(
       `:${SERVER_NAME} 002 ${nick} :Your host is ${SERVER_NAME}, running ${APP_NAME} ${APP_VERSION}`,
     );
     this.write(`:${SERVER_NAME} 003 ${nick} :This server was created for you`);
     this.write(`:${SERVER_NAME} 004 ${nick} ${SERVER_NAME} ${APP_NAME}-${APP_VERSION} o o`);
+  }
+
+  // Minimal welcome for a control connection: it binds no network, so no
+  // registrationLines / JOIN / playback / relay. The bouncer-scoped ISUPPORT
+  // omits BOUNCER_NETID (its absence is how a client detects control mode).
+  private sendControlBurst(): void {
+    const nick = this.clientNick || 'user';
+    this.writeWelcomeNumerics(nick);
     this.write(
       `:${SERVER_NAME} 005 ${nick} NETWORK=${APP_NAME} CASEMAPPING=ascii :are supported by this server`,
     );
@@ -1162,7 +1152,7 @@ class BouncerSession {
     for (const network of listNetworksForUser(this.userId)) {
       const conn = ircManager.getConnection(this.userId, network.id);
       const attrs = buildNetworkAttrs(network, {
-        connected: conn?.state === 'connected',
+        state: bouncerNetworkState(conn?.state),
         nickname: conn?.currentNick || network.nick,
       });
       this.write(`@batch=${ref} :${SERVER_NAME} BOUNCER NETWORK ${network.id} ${attrs}`);
@@ -1510,14 +1500,13 @@ class BouncerSession {
     }
   }
 
-  // A control connection's view of ANY of the user's networks changing state.
-  // Emits only the changed attributes, soju-style (connect also clears error).
-  onNetworkNotify(networkId: number, state: string): void {
-    if (this.closed || !this.isControl) return;
-    let attrs: string;
-    if (state === 'connected') attrs = 'state=connected;error=';
-    else if (state === 'reconnecting') attrs = 'state=connecting';
-    else attrs = 'state=disconnected';
+  // A -notify client's view of ANY of the user's networks changing state (both
+  // control and bound connections receive these). Emits only the changed
+  // attributes, soju-style (a connect also clears any prior error).
+  onNetworkNotify(networkId: number, connState: string): void {
+    if (this.closed) return;
+    const state = bouncerNetworkState(connState);
+    const attrs = state === 'connected' ? 'state=connected;error=' : `state=${state}`;
     this.notifyNetworkState(networkId, attrs);
   }
 
@@ -1559,7 +1548,6 @@ class BouncerSession {
     this.onRawUpstream = null;
     sessions.delete(this);
     if (this.registered && this.isControl) {
-      detachFromControlRegistry(this);
       systemLog.log({
         userId: this.userId,
         scope: 'bouncer',
@@ -1607,14 +1595,16 @@ function dispatchIrcEvent(event: Record<string, unknown>): void {
   const networkId = Number(event.networkId);
   if (!userId || !networkId) return;
   const type = String(event.type || '');
-  // Control connections track state for ALL the user's networks — including
-  // ones no bound session is attached to — so fan state events to them before
-  // the bound-session early-return below.
+  // A -notify client (bound OR control) tracks state for ALL of the user's
+  // networks — including ones no bound session is attached to — so fan state
+  // events across every one of the user's sessions, before the per-network
+  // early-return below. State transitions are infrequent, so the scan is cheap.
   if (type === 'state') {
-    const controls = controlSessions.get(userId);
-    if (controls) {
-      const state = String(event.state || '');
-      for (const session of controls) session.onNetworkNotify(networkId, state);
+    const state = String(event.state || '');
+    for (const session of sessions) {
+      if (session.userId === userId && session.isRegistered()) {
+        session.onNetworkNotify(networkId, state);
+      }
     }
   }
   const set = registry.get(registryKey(userId, networkId));

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -79,7 +79,14 @@ const SUPPORTED_CAPS = [
   'message-tags',
   'echo-message',
   'znc.in/self-message',
+  // soju's bouncer-networks: a control connection can enumerate/bind the user's
+  // networks; -notify opts into unsolicited BOUNCER NETWORK state pushes.
+  'soju.im/bouncer-networks',
+  'soju.im/bouncer-networks-notify',
 ];
+
+const CAP_BOUNCER_NETWORKS = 'soju.im/bouncer-networks';
+const CAP_BOUNCER_NETWORKS_NOTIFY = 'soju.im/bouncer-networks-notify';
 
 // The SASL mechanisms we implement. Advertised as a `sasl=…` value only under
 // CAP 302 (bare `sasl` otherwise, since pre-302 CAP LS carries no cap values).
@@ -402,12 +409,46 @@ export function isServicesNick(nick: string): boolean {
   );
 }
 
+// IRCv3 message-tag value escaping (space→\s, ;→\:, \→\\, CR→\r, LF→\n). Used
+// to encode a network's `key=value;…` attribute list for BOUNCER NETWORK.
+export function escapeTagValue(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\:')
+    .replace(/ /g, '\\s')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n');
+}
+
+// Build the tag-encoded attribute list for one network's BOUNCER NETWORK line.
+// `state` is derived from whether the upstream is live; soju only ever emits
+// connected/disconnected (never `connecting`), so we match that.
+export function buildNetworkAttrs(
+  network: { name: string; host: string; port: number; tls: number | boolean; nick: string },
+  opts: { connected: boolean; nickname?: string },
+): string {
+  const attrs: Array<[string, string]> = [
+    ['name', network.name],
+    ['state', opts.connected ? 'connected' : 'disconnected'],
+    ['host', network.host],
+    ['port', String(network.port)],
+    ['tls', network.tls ? '1' : '0'],
+    ['nickname', opts.nickname || network.nick],
+  ];
+  return attrs.map(([k, v]) => `${k}=${escapeTagValue(v)}`).join(';');
+}
+
 // ---------------------------------------------------------------------------
 // Session registry
 // ---------------------------------------------------------------------------
 
 const sessions = new Set<BouncerSession>();
 const registry = new Map<string, Set<BouncerSession>>();
+// Control (unbound) sessions: a `soju.im/bouncer-networks` client that
+// registered without binding a network. Keyed by userId (not networkId — a
+// control connection spans all of the user's networks) so state-change
+// notifications can fan out to every control client the user has open.
+const controlSessions = new Map<number, Set<BouncerSession>>();
 
 function registryKey(userId: number, networkId: number): string {
   return `${userId}:${networkId}`;
@@ -429,6 +470,22 @@ function detachFromRegistry(session: BouncerSession): void {
   if (!set) return;
   set.delete(session);
   if (set.size === 0) registry.delete(key);
+}
+
+function attachToControlRegistry(session: BouncerSession): void {
+  let set = controlSessions.get(session.userId);
+  if (!set) {
+    set = new Set();
+    controlSessions.set(session.userId, set);
+  }
+  set.add(session);
+}
+
+function detachFromControlRegistry(session: BouncerSession): void {
+  const set = controlSessions.get(session.userId);
+  if (!set) return;
+  set.delete(session);
+  if (set.size === 0) controlSessions.delete(session.userId);
 }
 
 export function attachedSessionCount(userId?: number, networkId?: number): number {
@@ -472,6 +529,15 @@ class BouncerSession {
   private closed = false;
   private conn: IrcConnection | null = null;
   private network: Network | null = null;
+  // Control (unbound) mode: a `soju.im/bouncer-networks` client that registered
+  // without binding a network (no conn/networkId). It can only enumerate and
+  // manage networks via BOUNCER, never send channel/user traffic.
+  private isControl = false;
+  // A pre-registration `BOUNCER BIND <id>` selector, consumed at completeAttach
+  // (takes precedence over a username-embedded network name).
+  private boundNetId: number | null = null;
+  // A per-session counter for BATCH reference tags (LISTNETWORKS / initial dump).
+  private batchSeq = 0;
   // Outbound sends awaiting their self-echo event from ircManager, so a
   // client that didn't negotiate echo-message doesn't get its own message
   // back (it already rendered it locally). Other attached clients and web
@@ -601,6 +667,9 @@ class BouncerSession {
         break;
       case 'AUTHENTICATE':
         this.handleSasl(msg);
+        break;
+      case 'BOUNCER':
+        this.handleBouncerPreReg(msg);
         break;
       case 'PING':
         // Answer keepalive PINGs during CAP/registration so strict clients
@@ -794,8 +863,16 @@ class BouncerSession {
     this.completeAttach(user, creds.network);
   }
 
-  // Shared tail for both auth paths: pick the network, enforce caps, attach to
-  // the live upstream, and replay the welcome burst.
+  private clearRegTimer(): void {
+    if (this.regTimer) {
+      clearTimeout(this.regTimer);
+      this.regTimer = null;
+    }
+  }
+
+  // Called at CAP END / registration completion. Resolves the target network
+  // (BIND id > username selector > single-network default), or drops into
+  // control mode for a bouncer-networks client that named no network.
   private completeAttach(user: User, networkSel: string | null): void {
     if (user.is_paused) {
       this.failRegistration('Account is paused');
@@ -809,13 +886,41 @@ class BouncerSession {
       );
       return;
     }
+    // A valid login can otherwise open unbounded connections; cap how many a
+    // single account may hold at once (bound and control connections both count).
+    if (attachedSessionCount(user.id) >= maxSessionsPerUser()) {
+      this.failRegistration(
+        `Too many bouncer connections for this account (max ${maxSessionsPerUser()})`,
+      );
+      return;
+    }
+
+    // Control (unbound) mode: a bouncer-networks-aware client that named no
+    // network manages its networks via BOUNCER instead of attaching to one.
+    const hasSelector = this.boundNetId !== null || !!networkSel;
+    if (!hasSelector && this.caps.has(CAP_BOUNCER_NETWORKS)) {
+      this.registerControl(user);
+      return;
+    }
+
     const networks = listNetworksForUser(user.id);
     if (networks.length === 0) {
       this.failRegistration('No IRC networks configured — add one in the web UI first');
       return;
     }
     let network: Network | undefined;
-    if (networkSel) {
+    if (this.boundNetId !== null) {
+      // A `BOUNCER BIND <id>` selector resolves by numeric id and reports
+      // failures with the bouncer-networks FAIL vocabulary, not a 464.
+      network = networks.find((n) => n.id === this.boundNetId);
+      if (!network) {
+        this.write(
+          `:${SERVER_NAME} FAIL BOUNCER INVALID_NETID ${this.boundNetId} :Unknown network ID`,
+        );
+        this.closeWithError('Unknown network ID');
+        return;
+      }
+    } else if (networkSel) {
       const sel = networkSel.toLowerCase();
       network = networks.find((n) => n.name.toLowerCase() === sel || String(n.id) === sel);
       if (!network) {
@@ -834,14 +939,12 @@ class BouncerSession {
       );
       return;
     }
-    // A valid login can otherwise open unbounded attach connections; cap how
-    // many a single account may hold at once (across all its networks).
-    if (attachedSessionCount(user.id) >= maxSessionsPerUser()) {
-      this.failRegistration(
-        `Too many bouncer connections for this account (max ${maxSessionsPerUser()})`,
-      );
-      return;
-    }
+    this.bindNetwork(user, network);
+  }
+
+  // Attach the session to one network's live upstream and replay its welcome
+  // burst. Shared by every bound-registration path.
+  private bindNetwork(user: User, network: Network): void {
     // Attach to the live upstream connection; attaching to a stopped or dead
     // network (re)connects it, mirroring how ZNC brings a network up when a
     // client attaches. A conn object stuck in 'disconnected' (e.g. its boot-
@@ -863,10 +966,7 @@ class BouncerSession {
     this.network = network;
     this.conn = conn;
     this.registered = true;
-    if (this.regTimer) {
-      clearTimeout(this.regTimer);
-      this.regTimer = null;
-    }
+    this.clearRegTimer();
     attachToRegistry(this);
     this.sendAttachBurst();
     systemLog.log({
@@ -874,6 +974,21 @@ class BouncerSession {
       scope: 'bouncer',
       fields: { networkId: this.networkId },
       text: `IRC client attached from ${this.remoteIp} (${attachedSessionCount(this.userId, this.networkId)} attached to ${network.name})`,
+    });
+  }
+
+  // Register a control (unbound) connection: authenticated, bound to no network.
+  private registerControl(user: User): void {
+    this.userId = user.id;
+    this.isControl = true;
+    this.registered = true;
+    this.clearRegTimer();
+    attachToControlRegistry(this);
+    this.sendControlBurst();
+    systemLog.log({
+      userId: this.userId,
+      scope: 'bouncer',
+      text: `Bouncer control connection from ${this.remoteIp}`,
     });
   }
 
@@ -924,6 +1039,13 @@ class BouncerSession {
         `:${requested}!${conn.client.user?.username || 'lurker'}@${SERVER_NAME} NICK :${liveNick}`,
       );
     }
+    // Tell a bouncer-networks-aware client which network it bound to. The
+    // upstream's own 005 can't carry this, so append our own ISUPPORT line.
+    if (this.caps.has(CAP_BOUNCER_NETWORKS)) {
+      this.write(
+        `:${SERVER_NAME} 005 ${liveNick} BOUNCER_NETID=${this.networkId} :are supported by this server`,
+      );
+    }
     this.write(`:${SERVER_NAME} 422 ${liveNick} :MOTD File is missing`);
 
     if (conn.state !== 'connected') {
@@ -934,6 +1056,10 @@ class BouncerSession {
       this.sendJoinBurst();
       this.sendPlayback();
     }
+
+    // A -notify client gets the full network list up-front (soju sends this at
+    // registration completion for bound and control connections alike).
+    if (this.caps.has(CAP_BOUNCER_NETWORKS_NOTIFY)) this.sendNetworkList();
 
     // Live relay attaches AFTER playback so replayed history and the live
     // stream don't interleave out of order.
@@ -949,6 +1075,105 @@ class BouncerSession {
     // irc-framework's Client is an eventemitter3, which has no listener-count
     // cap — several attached clients can listen on one upstream client freely.
     conn.client.on('raw', this.onRawUpstream);
+  }
+
+  // --- control (unbound) connection ------------------------------------------
+
+  // Minimal welcome for a control connection: it binds no network, so no
+  // registrationLines / JOIN / playback / relay. The bouncer-scoped ISUPPORT
+  // omits BOUNCER_NETID (its absence is how a client detects control mode).
+  private sendControlBurst(): void {
+    const nick = this.clientNick || 'user';
+    this.write(`:${SERVER_NAME} 001 ${nick} :Welcome to the ${APP_NAME} bouncer, ${nick}`);
+    this.write(
+      `:${SERVER_NAME} 002 ${nick} :Your host is ${SERVER_NAME}, running ${APP_NAME} ${APP_VERSION}`,
+    );
+    this.write(`:${SERVER_NAME} 003 ${nick} :This server was created for you`);
+    this.write(`:${SERVER_NAME} 004 ${nick} ${SERVER_NAME} ${APP_NAME}-${APP_VERSION} o o`);
+    this.write(
+      `:${SERVER_NAME} 005 ${nick} NETWORK=${APP_NAME} CASEMAPPING=ascii :are supported by this server`,
+    );
+    this.write(`:${SERVER_NAME} 422 ${nick} :MOTD File is missing`);
+    // A -notify client gets the full network list up-front as a batch.
+    if (this.caps.has(CAP_BOUNCER_NETWORKS_NOTIFY)) this.sendNetworkList();
+  }
+
+  // --- BOUNCER command -------------------------------------------------------
+
+  // Pre-registration BOUNCER: only BIND is legal here (soju parity). BIND
+  // stashes the netid to resolve at completeAttach; everything else is refused.
+  private handleBouncerPreReg(msg: ParsedClientLine): void {
+    const sub = (msg.params[0] || '').toUpperCase();
+    if (sub !== 'BIND') {
+      this.write(`:${SERVER_NAME} FAIL BOUNCER UNKNOWN_COMMAND ${sub || '*'} :Unknown subcommand`);
+      return;
+    }
+    // Binding needs an authenticated account. In our flow that means either SASL
+    // already succeeded or a PASS is present to verify at CAP END.
+    if (!this.saslUser && !this.passRaw) {
+      this.write(
+        `:${SERVER_NAME} FAIL BOUNCER ACCOUNT_REQUIRED BIND :Authentication needed to bind to bouncer network`,
+      );
+      return;
+    }
+    const raw = msg.params[1] || '';
+    const id = Number(raw);
+    if (!raw || !Number.isInteger(id) || id <= 0) {
+      this.write(`:${SERVER_NAME} FAIL BOUNCER INVALID_NETID BIND ${raw} :Invalid network ID`);
+      return;
+    }
+    this.boundNetId = id;
+  }
+
+  // Post-registration BOUNCER: LISTNETWORKS (+ BIND is now too late; CRUD is
+  // deferred to the web UI).
+  private handleBouncer(msg: ParsedClientLine): void {
+    const sub = (msg.params[0] || '').toUpperCase();
+    switch (sub) {
+      case 'LISTNETWORKS':
+        this.sendNetworkList();
+        return;
+      case 'BIND':
+        this.write(
+          `:${SERVER_NAME} FAIL BOUNCER REGISTRATION_IS_COMPLETED BIND :Cannot bind to a network after registration`,
+        );
+        return;
+      case 'ADDNETWORK':
+      case 'CHANGENETWORK':
+      case 'DELNETWORK':
+        // CRUD is managed in the web UI; keep soju's error vocabulary.
+        this.write(
+          `:${SERVER_NAME} FAIL BOUNCER UNKNOWN_COMMAND ${sub} :Manage networks in the ${APP_NAME} web UI`,
+        );
+        return;
+      default:
+        this.write(
+          `:${SERVER_NAME} FAIL BOUNCER UNKNOWN_COMMAND ${sub || '*'} :Unknown subcommand`,
+        );
+        return;
+    }
+  }
+
+  // Reply to LISTNETWORKS (and the initial -notify dump) with a
+  // soju.im/bouncer-networks batch of BOUNCER NETWORK lines, one per network.
+  private sendNetworkList(): void {
+    const ref = `lbnc${++this.batchSeq}`;
+    this.write(`:${SERVER_NAME} BATCH +${ref} soju.im/bouncer-networks`);
+    for (const network of listNetworksForUser(this.userId)) {
+      const conn = ircManager.getConnection(this.userId, network.id);
+      const attrs = buildNetworkAttrs(network, {
+        connected: conn?.state === 'connected',
+        nickname: conn?.currentNick || network.nick,
+      });
+      this.write(`@batch=${ref} :${SERVER_NAME} BOUNCER NETWORK ${network.id} ${attrs}`);
+    }
+    this.write(`:${SERVER_NAME} BATCH -${ref}`);
+  }
+
+  // Push an unsolicited (unbatched) network state change to a -notify client.
+  private notifyNetworkState(networkId: number, attrs: string): void {
+    if (this.closed || !this.caps.has(CAP_BOUNCER_NETWORKS_NOTIFY)) return;
+    this.write(`:${SERVER_NAME} BOUNCER NETWORK ${networkId} ${attrs}`);
   }
 
   private isupportPrefixes(): Array<{ mode: string; symbol: string }> {
@@ -1096,6 +1321,20 @@ class BouncerSession {
         // unexpected upstream re-auth — swallow it.
         this.write(`:${SERVER_NAME} 904 ${this.currentNick() || '*'} :Already authenticated`);
         return;
+      case 'BOUNCER':
+        // Network enumeration/management works from any registered connection,
+        // bound or control (it doesn't touch a specific upstream).
+        this.handleBouncer(msg);
+        return;
+    }
+
+    // A control connection has no upstream: it can only speak BOUNCER (handled
+    // above). Anything network-facing is refused, soju-style.
+    if (this.isControl) {
+      this.notice(
+        'Cannot interact with channels and users on the bouncer connection — bind a network.',
+      );
+      return;
     }
 
     const conn = this.liveConn();
@@ -1271,6 +1510,17 @@ class BouncerSession {
     }
   }
 
+  // A control connection's view of ANY of the user's networks changing state.
+  // Emits only the changed attributes, soju-style (connect also clears error).
+  onNetworkNotify(networkId: number, state: string): void {
+    if (this.closed || !this.isControl) return;
+    let attrs: string;
+    if (state === 'connected') attrs = 'state=connected;error=';
+    else if (state === 'reconnecting') attrs = 'state=connecting';
+    else attrs = 'state=disconnected';
+    this.notifyNetworkState(networkId, attrs);
+  }
+
   heartbeat(now: number): void {
     if (this.closed) return;
     const idle = now - this.lastActivityAt;
@@ -1308,7 +1558,14 @@ class BouncerSession {
     }
     this.onRawUpstream = null;
     sessions.delete(this);
-    if (this.registered) {
+    if (this.registered && this.isControl) {
+      detachFromControlRegistry(this);
+      systemLog.log({
+        userId: this.userId,
+        scope: 'bouncer',
+        text: `Bouncer control connection closed${reason ? ` (${reason})` : ''}`,
+      });
+    } else if (this.registered) {
       detachFromRegistry(this);
       systemLog.log({
         userId: this.userId,
@@ -1349,9 +1606,19 @@ function dispatchIrcEvent(event: Record<string, unknown>): void {
   const userId = Number(event.userId);
   const networkId = Number(event.networkId);
   if (!userId || !networkId) return;
+  const type = String(event.type || '');
+  // Control connections track state for ALL the user's networks — including
+  // ones no bound session is attached to — so fan state events to them before
+  // the bound-session early-return below.
+  if (type === 'state') {
+    const controls = controlSessions.get(userId);
+    if (controls) {
+      const state = String(event.state || '');
+      for (const session of controls) session.onNetworkNotify(networkId, state);
+    }
+  }
   const set = registry.get(registryKey(userId, networkId));
   if (!set || set.size === 0) return;
-  const type = String(event.type || '');
   if (type === 'state') {
     const state = String(event.state || '');
     // Deleting from a Set mid-iteration is safe; handlers only ever remove.

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -79,6 +79,10 @@ const SUPPORTED_CAPS = [
   'message-tags',
   'echo-message',
   'znc.in/self-message',
+  // batch groups the BOUNCER NETWORK burst (LISTNETWORKS / initial -notify dump)
+  // — advertised so a client can opt into the batched form; without it we send
+  // the same lines unwrapped.
+  'batch',
   // soju's bouncer-networks: a control connection can enumerate/bind the user's
   // networks; -notify opts into unsolicited BOUNCER NETWORK state pushes.
   'soju.im/bouncer-networks',
@@ -1093,6 +1097,12 @@ class BouncerSession {
   // Pre-registration BOUNCER: only BIND is legal here (soju parity). BIND
   // stashes the netid to resolve at completeAttach; everything else is refused.
   private handleBouncerPreReg(msg: ParsedClientLine): void {
+    if (!this.caps.has(CAP_BOUNCER_NETWORKS)) {
+      this.write(
+        `:${SERVER_NAME} FAIL BOUNCER UNKNOWN_COMMAND :Negotiate the soju.im/bouncer-networks capability first`,
+      );
+      return;
+    }
     const sub = (msg.params[0] || '').toUpperCase();
     if (sub !== 'BIND') {
       this.write(`:${SERVER_NAME} FAIL BOUNCER UNKNOWN_COMMAND ${sub || '*'} :Unknown subcommand`);
@@ -1118,6 +1128,12 @@ class BouncerSession {
   // Post-registration BOUNCER: LISTNETWORKS (+ BIND is now too late; CRUD is
   // deferred to the web UI).
   private handleBouncer(msg: ParsedClientLine): void {
+    if (!this.caps.has(CAP_BOUNCER_NETWORKS)) {
+      this.write(
+        `:${SERVER_NAME} FAIL BOUNCER UNKNOWN_COMMAND :Negotiate the soju.im/bouncer-networks capability first`,
+      );
+      return;
+    }
     const sub = (msg.params[0] || '').toUpperCase();
     switch (sub) {
       case 'LISTNETWORKS':
@@ -1144,20 +1160,24 @@ class BouncerSession {
     }
   }
 
-  // Reply to LISTNETWORKS (and the initial -notify dump) with a
-  // soju.im/bouncer-networks batch of BOUNCER NETWORK lines, one per network.
+  // Reply to LISTNETWORKS (and the initial -notify dump) with a BOUNCER NETWORK
+  // line per network. The soju.im/bouncer-networks batch wrapper (and its
+  // `@batch=` message tag) is only used when the client negotiated `batch` —
+  // otherwise we must not emit tags, so send the same lines unwrapped.
   private sendNetworkList(): void {
+    const batched = this.caps.has('batch');
     const ref = `lbnc${++this.batchSeq}`;
-    this.write(`:${SERVER_NAME} BATCH +${ref} soju.im/bouncer-networks`);
+    if (batched) this.write(`:${SERVER_NAME} BATCH +${ref} soju.im/bouncer-networks`);
+    const tag = batched ? `@batch=${ref} ` : '';
     for (const network of listNetworksForUser(this.userId)) {
       const conn = ircManager.getConnection(this.userId, network.id);
       const attrs = buildNetworkAttrs(network, {
         state: bouncerNetworkState(conn?.state),
         nickname: conn?.currentNick || network.nick,
       });
-      this.write(`@batch=${ref} :${SERVER_NAME} BOUNCER NETWORK ${network.id} ${attrs}`);
+      this.write(`${tag}:${SERVER_NAME} BOUNCER NETWORK ${network.id} ${attrs}`);
     }
-    this.write(`:${SERVER_NAME} BATCH -${ref}`);
+    if (batched) this.write(`:${SERVER_NAME} BATCH -${ref}`);
   }
 
   // Push an unsolicited (unbatched) network state change to a -notify client.

--- a/server/test-utils/bouncerHarness.ts
+++ b/server/test-utils/bouncerHarness.ts
@@ -153,6 +153,11 @@ export function attachedFor(acct: HarnessAccount): number {
   return attachedSessionCount(acct.user.id, acct.network.id);
 }
 
+/** Simulate an upstream network state change flowing through ircManager. */
+export function emitNetworkState(userId: number, networkId: number, state: string): void {
+  ircManager.emit('event', { userId, networkId, type: 'state', state });
+}
+
 /** Add a second network + upstream to an already-seeded user. */
 export function seedNetwork(
   user: User,


### PR DESCRIPTION
Phase 3 of the built-in IRC bouncer: soju's `bouncer-networks` extension, so a capable client (gamja/Goguma/Halloy) can **enumerate and pick networks** instead of hardcoding `user/network` in its login. This is the discovery/management win over ZNC — and directly resolves the "Multiple networks — log in as user/&lt;network&gt;" friction a bare-username attach hits today. Builds on #478.

Everything is gated behind CAP negotiation: the `PASS` floor, SASL, and single-network auto-attach are all unchanged, so plain clients never see any of this.

## What's in it

**Two session modes.** The bouncer was premised on one session = one `(userId, networkId)`; this adds a **control (unbound)** mode alongside the existing **bound** mode.
- **Caps:** `soju.im/bouncer-networks` + `soju.im/bouncer-networks-notify` (valueless tokens).
- **Control mode:** a bouncer-networks-aware client that names no network registers bound to *nothing* — it manages networks via `BOUNCER` and is refused channel/user traffic. The **absence of `BOUNCER_NETID`** in its `005` is how a client detects the mode; bound sessions advertise `BOUNCER_NETID=<id>`.

**`BOUNCER` command:**
- `BOUNCER LISTNETWORKS` → a `soju.im/bouncer-networks` batch of `BOUNCER NETWORK <id> name=…;state=…;host=…;port=…;tls=…;nickname=…` lines (IRCv3 tag-escaped).
- `BOUNCER BIND <id>` — registration-phase only (post-reg → `FAIL BOUNCER REGISTRATION_IS_COMPLETED`); binds by numeric id, precedence over a username selector; bad/unknown id → `FAIL BOUNCER INVALID_NETID`. Per soju, a control connection never *transitions* — clients open one TCP connection per network.
- `ADDNETWORK`/`CHANGENETWORK`/`DELNETWORK` → `FAIL BOUNCER UNKNOWN_COMMAND` (network CRUD stays in the web UI).

**`-notify`:** initial batched network dump at registration, then bare `BOUNCER NETWORK <id> state=…` pushes on upstream connect/disconnect, fanned out to every `-notify` connection the user has open (bound and control). `connecting`/`reconnecting` surface as `state=connecting` (spec-legal; more accurate than soju, which only ever emits connected/disconnected).

## Notes / deliberate divergences

- **`state=connecting`** is emitted for mid-connect networks. soju never sends it, but the spec defines it and requires clients to accept it — surfacing it avoids advertising a connecting network as `disconnected`.
- **CRUD deferred** to the web UI (soju's own error vocabulary for the refusal).
- **Attribute set is minimal** for v1 (`name/state/host/port/tls/nickname`); soju's `error`/`username`/`realname` aren't plumbed yet.
- Multi-upstream `*` remains rejected.

## Testing

- `server/services/bouncer.networks.test.ts` — 11 socket-driven cases: control-mode registration + traffic refusal, LISTNETWORKS batch, BIND (success / non-numeric / unknown-id / post-reg), `-notify` initial-dump + live push (control *and* bound), `state=connecting`, and no-push-without-the-cap.
- `escapeTagValue` / `buildNetworkAttrs` / `bouncerNetworkState` unit tables.
- Full `npm run check` green; suite **1891 passing**.
- Ran a high multi-agent review on the diff and fixed every real finding (the `connecting` mislabel, the bound-`-notify` gap — which let the `controlSessions` registry be removed entirely — plus welcome-burst dedup).

## Refactor

Extracted `bindNetwork()` / `registerControl()` from `completeAttach` so the bound and control registration paths share the attach tail; notify fan-out is now user-scoped over the `sessions` set (no separate control registry).

## Fast-follow

The one-listener-per-upstream relay consolidation (deferred review item #9) is intentionally **not** here — it'll be a small separate PR now that the harness makes it safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)