### PR TITLE
Bouncer Phase 4: draft/chathistory (on-demand scrollback)

### DIFF
--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -22,6 +22,10 @@ let maxIdForBuffer: typeof import('./messages.js').maxIdForBuffer;
 let hasConversationForTarget: typeof import('./messages.js').hasConversationForTarget;
 let listSpeakers: typeof import('./messages.js').listSpeakers;
 let listBufferTargets: typeof import('./messages.js').listBufferTargets;
+let listMessagesBetween: typeof import('./messages.js').listMessagesBetween;
+let firstIdAtOrAfterTime: typeof import('./messages.js').firstIdAtOrAfterTime;
+let lastIdAtOrBeforeTime: typeof import('./messages.js').lastIdAtOrBeforeTime;
+let listActiveTargetsInWindow: typeof import('./messages.js').listActiveTargetsInWindow;
 
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
@@ -38,6 +42,10 @@ beforeAll(async () => {
     hasConversationForTarget,
     listSpeakers,
     listBufferTargets,
+    listMessagesBetween,
+    firstIdAtOrAfterTime,
+    lastIdAtOrBeforeTime,
+    listActiveTargetsInWindow,
   } = await import('./messages.js'));
 });
 
@@ -876,5 +884,80 @@ describe('maxIdForBuffer', () => {
     chat(net1.id, '#b', 'bob', 'b1');
     chat(net2.id, '#a', 'eve', 'e1');
     expect(maxIdForBuffer(net1.id, '#a')).toBe(a2.id);
+  });
+});
+
+describe('chathistory window queries', () => {
+  // Insert a message at a controlled ISO time so the timestamp resolvers are
+  // deterministic; ids stay monotonic in insertion order.
+  function at(networkId: number, target: string, iso: string, text: string) {
+    return Number(
+      insertMessage({ networkId, target, time: iso, type: 'message', nick: 'n', text, self: false })
+        .id,
+    );
+  }
+
+  it('listMessagesBetween returns ids strictly inside the window, oldest-first', () => {
+    const user = createUser(`cw_${Math.random().toString(36).slice(2)}`);
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    const ids = [1, 2, 3, 4, 5].map((n) =>
+      at(net.id, '#w', `2023-05-23T06:00:0${n}.000Z`, `m${n}`),
+    );
+    // Exclusive both ends: between ids[0] and ids[4] → the three middle rows.
+    const mid = listMessagesBetween(net.id, '#w', ids[0], ids[4], 100);
+    expect(mid.map((m) => m.id)).toEqual([ids[1], ids[2], ids[3]]);
+    // newestFirst caps from the top but still returns oldest-first.
+    const top2 = listMessagesBetween(net.id, '#w', ids[0], ids[4], 2, { newestFirst: true });
+    expect(top2.map((m) => m.id)).toEqual([ids[2], ids[3]]);
+  });
+
+  it('resolves timestamp boundaries to ids', () => {
+    const user = createUser(`cw_${Math.random().toString(36).slice(2)}`);
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    const a = at(net.id, '#t', '2023-05-23T06:00:00.000Z', 'a');
+    const b = at(net.id, '#t', '2023-05-23T06:00:02.000Z', 'b');
+    // A timestamp between the two rows: first-at-or-after is b, last-at-or-before is a.
+    expect(firstIdAtOrAfterTime(net.id, '#t', '2023-05-23T06:00:01.000Z')).toBe(b);
+    expect(lastIdAtOrBeforeTime(net.id, '#t', '2023-05-23T06:00:01.000Z')).toBe(a);
+    // Exact matches are inclusive on both sides.
+    expect(firstIdAtOrAfterTime(net.id, '#t', '2023-05-23T06:00:00.000Z')).toBe(a);
+    expect(lastIdAtOrBeforeTime(net.id, '#t', '2023-05-23T06:00:02.000Z')).toBe(b);
+    // Out of range → null.
+    expect(firstIdAtOrAfterTime(net.id, '#t', '2024-01-01T00:00:00.000Z')).toBeNull();
+    expect(lastIdAtOrBeforeTime(net.id, '#t', '2020-01-01T00:00:00.000Z')).toBeNull();
+  });
+
+  it('listActiveTargetsInWindow returns buffers active in the window, newest first', () => {
+    const user = createUser(`cw_${Math.random().toString(36).slice(2)}`);
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    at(net.id, '#old', '2023-05-20T00:00:00.000Z', 'old');
+    at(net.id, '#a', '2023-05-23T06:00:00.000Z', 'a');
+    at(net.id, '#b', '2023-05-23T07:00:00.000Z', 'b');
+    at(net.id, ':server:x', '2023-05-23T06:30:00.000Z', 'srv'); // excluded
+    const targets = listActiveTargetsInWindow(
+      net.id,
+      '2023-05-23T00:00:00.000Z',
+      '2023-05-24T00:00:00.000Z',
+      100,
+    );
+    expect(targets.map((t) => t.target)).toEqual(['#b', '#a']); // #old outside window, :server: excluded
   });
 });

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -922,6 +922,29 @@ describe('chathistory window queries', () => {
     expect(latest2.map((m) => m.id)).toEqual([ids[3], ids[4]]);
   });
 
+  it('loadHistoryWindow orders/selects by time even when id order diverges', () => {
+    const user = createUser(`cw_${Math.random().toString(36).slice(2)}`);
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    // Insert out of chronological order (a chained/ZNC upstream replaying old
+    // buffered messages as live lines): the OLD-time row gets the highest id.
+    at(net.id, '#o', '2023-05-23T06:00:02.000Z', 'newer');
+    const oldId = at(net.id, '#o', '2023-05-23T06:00:01.000Z', 'older'); // higher id, older time
+    // LATEST must return them oldest-first BY TIME, not by id.
+    const latest = loadHistoryWindow(net.id, '#o', null, null, 10, { newestFirst: true });
+    expect(latest.map((m) => m.text)).toEqual(['older', 'newer']);
+    // BEFORE :02 selects the older-time row (id-ordering would have missed it).
+    const before = loadHistoryWindow(net.id, '#o', null, '2023-05-23T06:00:02.000Z', 10, {
+      newestFirst: true,
+    });
+    expect(before.map((m) => m.id)).toEqual([oldId]);
+  });
+
   it('loadHistoryWindow excludes non-message rows so limit counts real messages', () => {
     const user = createUser(`cw_${Math.random().toString(36).slice(2)}`);
     const net = createNetwork(user.id, {

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -22,9 +22,7 @@ let maxIdForBuffer: typeof import('./messages.js').maxIdForBuffer;
 let hasConversationForTarget: typeof import('./messages.js').hasConversationForTarget;
 let listSpeakers: typeof import('./messages.js').listSpeakers;
 let listBufferTargets: typeof import('./messages.js').listBufferTargets;
-let listMessagesBetween: typeof import('./messages.js').listMessagesBetween;
-let firstIdAtOrAfterTime: typeof import('./messages.js').firstIdAtOrAfterTime;
-let lastIdAtOrBeforeTime: typeof import('./messages.js').lastIdAtOrBeforeTime;
+let loadHistoryWindow: typeof import('./messages.js').loadHistoryWindow;
 let listActiveTargetsInWindow: typeof import('./messages.js').listActiveTargetsInWindow;
 
 beforeAll(async () => {
@@ -42,9 +40,7 @@ beforeAll(async () => {
     hasConversationForTarget,
     listSpeakers,
     listBufferTargets,
-    listMessagesBetween,
-    firstIdAtOrAfterTime,
-    lastIdAtOrBeforeTime,
+    loadHistoryWindow,
     listActiveTargetsInWindow,
   } = await import('./messages.js'));
 });
@@ -897,7 +893,11 @@ describe('chathistory window queries', () => {
     );
   }
 
-  it('listMessagesBetween returns ids strictly inside the window, oldest-first', () => {
+  function evt(networkId: number, target: string, iso: string, type: string) {
+    return Number(insertMessage({ networkId, target, time: iso, type, nick: 'x', self: false }).id);
+  }
+
+  it('loadHistoryWindow applies exclusive time bounds and returns oldest-first', () => {
     const user = createUser(`cw_${Math.random().toString(36).slice(2)}`);
     const net = createNetwork(user.id, {
       name: 'n',
@@ -909,15 +909,20 @@ describe('chathistory window queries', () => {
     const ids = [1, 2, 3, 4, 5].map((n) =>
       at(net.id, '#w', `2023-05-23T06:00:0${n}.000Z`, `m${n}`),
     );
-    // Exclusive both ends: between ids[0] and ids[4] → the three middle rows.
-    const mid = listMessagesBetween(net.id, '#w', ids[0], ids[4], 100);
-    expect(mid.map((m) => m.id)).toEqual([ids[1], ids[2], ids[3]]);
-    // newestFirst caps from the top but still returns oldest-first.
-    const top2 = listMessagesBetween(net.id, '#w', ids[0], ids[4], 2, { newestFirst: true });
-    expect(top2.map((m) => m.id)).toEqual([ids[2], ids[3]]);
+    // upper bound (BEFORE): strictly earlier than :03, newest-first cap → oldest-first out.
+    const before = loadHistoryWindow(net.id, '#w', null, '2023-05-23T06:00:03.000Z', 100, {
+      newestFirst: true,
+    });
+    expect(before.map((m) => m.id)).toEqual([ids[0], ids[1]]);
+    // lower bound (AFTER): strictly later than :02, earliest-first.
+    const after = loadHistoryWindow(net.id, '#w', '2023-05-23T06:00:02.000Z', null, 100);
+    expect(after.map((m) => m.id)).toEqual([ids[2], ids[3], ids[4]]);
+    // newestFirst caps from the recent end but still returns oldest-first.
+    const latest2 = loadHistoryWindow(net.id, '#w', null, null, 2, { newestFirst: true });
+    expect(latest2.map((m) => m.id)).toEqual([ids[3], ids[4]]);
   });
 
-  it('resolves timestamp boundaries to ids', () => {
+  it('loadHistoryWindow excludes non-message rows so limit counts real messages', () => {
     const user = createUser(`cw_${Math.random().toString(36).slice(2)}`);
     const net = createNetwork(user.id, {
       name: 'n',
@@ -926,17 +931,11 @@ describe('chathistory window queries', () => {
       tls: true,
       nick: 'me',
     })!;
-    const a = at(net.id, '#t', '2023-05-23T06:00:00.000Z', 'a');
-    const b = at(net.id, '#t', '2023-05-23T06:00:02.000Z', 'b');
-    // A timestamp between the two rows: first-at-or-after is b, last-at-or-before is a.
-    expect(firstIdAtOrAfterTime(net.id, '#t', '2023-05-23T06:00:01.000Z')).toBe(b);
-    expect(lastIdAtOrBeforeTime(net.id, '#t', '2023-05-23T06:00:01.000Z')).toBe(a);
-    // Exact matches are inclusive on both sides.
-    expect(firstIdAtOrAfterTime(net.id, '#t', '2023-05-23T06:00:00.000Z')).toBe(a);
-    expect(lastIdAtOrBeforeTime(net.id, '#t', '2023-05-23T06:00:02.000Z')).toBe(b);
-    // Out of range → null.
-    expect(firstIdAtOrAfterTime(net.id, '#t', '2024-01-01T00:00:00.000Z')).toBeNull();
-    expect(lastIdAtOrBeforeTime(net.id, '#t', '2020-01-01T00:00:00.000Z')).toBeNull();
+    const m1 = at(net.id, '#n', '2023-05-23T06:00:01.000Z', 'hello');
+    // A flood of joins/quits after the message must not fill the window.
+    for (let i = 2; i <= 9; i++) evt(net.id, '#n', `2023-05-23T06:00:0${i}.000Z`, 'join');
+    const rows = loadHistoryWindow(net.id, '#n', null, null, 3, { newestFirst: true });
+    expect(rows.map((r) => r.id)).toEqual([m1]); // the joins are skipped, not counted
   });
 
   it('listActiveTargetsInWindow returns buffers active in the window, newest first', () => {
@@ -951,13 +950,14 @@ describe('chathistory window queries', () => {
     at(net.id, '#old', '2023-05-20T00:00:00.000Z', 'old');
     at(net.id, '#a', '2023-05-23T06:00:00.000Z', 'a');
     at(net.id, '#b', '2023-05-23T07:00:00.000Z', 'b');
-    at(net.id, ':server:x', '2023-05-23T06:30:00.000Z', 'srv'); // excluded
+    at(net.id, ':server:x', '2023-05-23T06:30:00.000Z', 'srv'); // excluded (pseudo-buffer)
+    evt(net.id, '#joinonly', '2023-05-23T06:45:00.000Z', 'join'); // excluded (no real message)
     const targets = listActiveTargetsInWindow(
       net.id,
       '2023-05-23T00:00:00.000Z',
       '2023-05-24T00:00:00.000Z',
       100,
     );
-    expect(targets.map((t) => t.target)).toEqual(['#b', '#a']); // #old outside window, :server: excluded
+    expect(targets.map((t) => t.target)).toEqual(['#b', '#a']); // #old outside window; :server:/#joinonly excluded
   });
 });

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -251,9 +251,14 @@ const CHATHISTORY_MSG_FILTER = `type IN ('message', 'action', 'notice') AND mirr
 // bounds (null = unbounded on that side). `newestFirst` takes the `limit` from
 // the recent end of the window (BEFORE/LATEST) vs the old end (AFTER); the
 // result is ALWAYS returned oldest-first (the batch must be chronological).
-// Filtering by time is unindexed, but ORDER BY id + LIMIT lets SQLite stop after
-// `limit` matches, and this is correct regardless of whether time is monotonic
-// in id (unlike an id-boundary seek).
+//
+// Ordered by `time` (id as a stable tie-breaker for same-millisecond rows), NOT
+// by id: chathistory is a timestamp-semantic API and a client pages by the
+// returned lines' @time, so window selection and ordering must follow time.
+// These usually coincide (id is assigned in receive order), but a chained/ZNC
+// upstream that replays its buffer as live PRIVMSGs with old server-time tags
+// (stored as event.time) breaks that — old-time rows get fresh, high ids. The
+// time sort is unindexed, but this is an on-demand path with a bounded LIMIT.
 export function loadHistoryWindow(
   networkId: number,
   target: string,
@@ -273,10 +278,11 @@ export function loadHistoryWindow(
     params.push(upper);
   }
   params.push(limit);
+  const dir = newestFirst ? 'DESC' : 'ASC';
   const rows = db
     .prepare(
       `SELECT * FROM messages WHERE ${conds.join(' AND ')}
-       ORDER BY id ${newestFirst ? 'DESC' : 'ASC'} LIMIT ?`,
+       ORDER BY time ${dir}, id ${dir} LIMIT ?`,
     )
     .all(...params) as MessageRow[];
   const events = rows.map(rowToEvent);

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -237,6 +237,90 @@ export function hasNewerRow(networkId: number, target: string, id: number): bool
   return hasNewerThan(networkId, target, id);
 }
 
+// --- IRCv3 draft/chathistory window queries --------------------------------
+
+// Messages strictly between two ids (both bounds exclusive), for CHATHISTORY
+// BETWEEN. `newestFirst` selects which end the `limit` is taken from — the most
+// recent `limit` in the window vs the earliest — but results are ALWAYS
+// returned oldest-first (the chathistory batch must be chronological).
+export function listMessagesBetween(
+  networkId: number,
+  target: string,
+  loId: number,
+  hiId: number,
+  limit: number,
+  { newestFirst = false }: { newestFirst?: boolean } = {},
+): MessageEvent[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM messages WHERE network_id = ? AND target = ? AND id > ? AND id < ?
+       ORDER BY id ${newestFirst ? 'DESC' : 'ASC'} LIMIT ?`,
+    )
+    .all(networkId, target, loId, hiId, limit) as MessageRow[];
+  const events = rows.map(rowToEvent);
+  return newestFirst ? events.toReversed() : events;
+}
+
+// Resolve an ISO-8601 timestamp to a message-id boundary within a buffer, so
+// CHATHISTORY's `timestamp=` selectors can page on the fast (network,target,id)
+// index. id order tracks insert (time) order, so scanning that index and taking
+// the first row past the timestamp finds the boundary without a time index.
+// firstIdAtOrAfterTime → smallest id with time >= iso: `id < result` is exactly
+// "everything strictly before the timestamp" (the BEFORE boundary).
+export function firstIdAtOrAfterTime(
+  networkId: number,
+  target: string,
+  iso: string,
+): number | null {
+  const row = db
+    .prepare(
+      `SELECT id FROM messages WHERE network_id = ? AND target = ? AND time >= ?
+       ORDER BY id ASC LIMIT 1`,
+    )
+    .get(networkId, target, iso) as { id: number } | undefined;
+  return row?.id ?? null;
+}
+
+// lastIdAtOrBeforeTime → largest id with time <= iso: `id > result` is exactly
+// "everything strictly after the timestamp" (the AFTER boundary).
+export function lastIdAtOrBeforeTime(
+  networkId: number,
+  target: string,
+  iso: string,
+): number | null {
+  const row = db
+    .prepare(
+      `SELECT id FROM messages WHERE network_id = ? AND target = ? AND time <= ?
+       ORDER BY id DESC LIMIT 1`,
+    )
+    .get(networkId, target, iso) as { id: number } | undefined;
+  return row?.id ?? null;
+}
+
+// Buffers with activity inside a time window (exclusive), newest-activity first,
+// for CHATHISTORY TARGETS. Excludes :server: pseudo-buffers. The two bounds may
+// arrive in either order; we normalize.
+export function listActiveTargetsInWindow(
+  networkId: number,
+  isoA: string,
+  isoB: string,
+  limit: number,
+): BufferSummary[] {
+  const [lo, hi] = isoA <= isoB ? [isoA, isoB] : [isoB, isoA];
+  return db
+    .prepare(
+      `SELECT target, MAX(time) AS lastMessageAt
+         FROM messages
+        WHERE network_id = ?
+          AND target NOT LIKE ':server:%'
+          AND time > ? AND time < ?
+        GROUP BY target
+        ORDER BY lastMessageAt DESC
+        LIMIT ?`,
+    )
+    .all(networkId, lo, hi, limit) as BufferSummary[];
+}
+
 export function listRecentForBuffers(
   networkId: number,
   targets: string[],

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -239,67 +239,54 @@ export function hasNewerRow(networkId: number, target: string, id: number): bool
 
 // --- IRCv3 draft/chathistory window queries --------------------------------
 
-// Messages strictly between two ids (both bounds exclusive), for CHATHISTORY
-// BETWEEN. `newestFirst` selects which end the `limit` is taken from — the most
-// recent `limit` in the window vs the earliest — but results are ALWAYS
-// returned oldest-first (the chathistory batch must be chronological).
-export function listMessagesBetween(
+// Only replayable conversation rows count toward a chathistory window/limit:
+// joins/parts/quits/nick/mode/topic events and mirrored server-buffer dupes are
+// excluded, so a `limit` of N yields up to N real messages (a window full of a
+// netsplit's QUITs must not come back as an empty batch — that would make a
+// client think it reached the start of history and stop paging). Matches what
+// playbackLines will actually emit onto the wire.
+const CHATHISTORY_MSG_FILTER = `type IN ('message', 'action', 'notice') AND mirrored = 0 AND text IS NOT NULL AND text != ''`;
+
+// Windowed history fetch for CHATHISTORY. `lower`/`upper` are exclusive ISO time
+// bounds (null = unbounded on that side). `newestFirst` takes the `limit` from
+// the recent end of the window (BEFORE/LATEST) vs the old end (AFTER); the
+// result is ALWAYS returned oldest-first (the batch must be chronological).
+// Filtering by time is unindexed, but ORDER BY id + LIMIT lets SQLite stop after
+// `limit` matches, and this is correct regardless of whether time is monotonic
+// in id (unlike an id-boundary seek).
+export function loadHistoryWindow(
   networkId: number,
   target: string,
-  loId: number,
-  hiId: number,
+  lower: string | null,
+  upper: string | null,
   limit: number,
   { newestFirst = false }: { newestFirst?: boolean } = {},
 ): MessageEvent[] {
+  const conds = ['network_id = ?', 'target = ?', CHATHISTORY_MSG_FILTER];
+  const params: (string | number)[] = [networkId, target];
+  if (lower !== null) {
+    conds.push('time > ?');
+    params.push(lower);
+  }
+  if (upper !== null) {
+    conds.push('time < ?');
+    params.push(upper);
+  }
+  params.push(limit);
   const rows = db
     .prepare(
-      `SELECT * FROM messages WHERE network_id = ? AND target = ? AND id > ? AND id < ?
+      `SELECT * FROM messages WHERE ${conds.join(' AND ')}
        ORDER BY id ${newestFirst ? 'DESC' : 'ASC'} LIMIT ?`,
     )
-    .all(networkId, target, loId, hiId, limit) as MessageRow[];
+    .all(...params) as MessageRow[];
   const events = rows.map(rowToEvent);
   return newestFirst ? events.toReversed() : events;
 }
 
-// Resolve an ISO-8601 timestamp to a message-id boundary within a buffer, so
-// CHATHISTORY's `timestamp=` selectors can page on the fast (network,target,id)
-// index. id order tracks insert (time) order, so scanning that index and taking
-// the first row past the timestamp finds the boundary without a time index.
-// firstIdAtOrAfterTime → smallest id with time >= iso: `id < result` is exactly
-// "everything strictly before the timestamp" (the BEFORE boundary).
-export function firstIdAtOrAfterTime(
-  networkId: number,
-  target: string,
-  iso: string,
-): number | null {
-  const row = db
-    .prepare(
-      `SELECT id FROM messages WHERE network_id = ? AND target = ? AND time >= ?
-       ORDER BY id ASC LIMIT 1`,
-    )
-    .get(networkId, target, iso) as { id: number } | undefined;
-  return row?.id ?? null;
-}
-
-// lastIdAtOrBeforeTime → largest id with time <= iso: `id > result` is exactly
-// "everything strictly after the timestamp" (the AFTER boundary).
-export function lastIdAtOrBeforeTime(
-  networkId: number,
-  target: string,
-  iso: string,
-): number | null {
-  const row = db
-    .prepare(
-      `SELECT id FROM messages WHERE network_id = ? AND target = ? AND time <= ?
-       ORDER BY id DESC LIMIT 1`,
-    )
-    .get(networkId, target, iso) as { id: number } | undefined;
-  return row?.id ?? null;
-}
-
-// Buffers with activity inside a time window (exclusive), newest-activity first,
-// for CHATHISTORY TARGETS. Excludes :server: pseudo-buffers. The two bounds may
-// arrive in either order; we normalize.
+// Buffers with real message activity inside a time window (exclusive), newest
+// first, for CHATHISTORY TARGETS. Excludes :server: pseudo-buffers and applies
+// the same message filter (a buffer whose only in-window rows are JOINs isn't
+// "active"). The two bounds may arrive in either order; we normalize.
 export function listActiveTargetsInWindow(
   networkId: number,
   isoA: string,
@@ -313,6 +300,7 @@ export function listActiveTargetsInWindow(
          FROM messages
         WHERE network_id = ?
           AND target NOT LIKE ':server:%'
+          AND ${CHATHISTORY_MSG_FILTER}
           AND time > ? AND time < ?
         GROUP BY target
         ORDER BY lastMessageAt DESC

--- a/server/services/bouncer.chathistory.test.ts
+++ b/server/services/bouncer.chathistory.test.ts
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Socket-driven tests for IRCv3 draft/chathistory: CHATHISTORY BEFORE/AFTER/
+// LATEST/BETWEEN/AROUND/TARGETS over the message store. See bouncerHarness.ts.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('services-bouncer-chathistory');
+
+let harnessMod: typeof import('../test-utils/bouncerHarness.js');
+let bouncerMod: typeof import('./bouncer.js');
+let insertMessage: typeof import('../db/messages.js').insertMessage;
+let harness: import('../test-utils/bouncerHarness.js').Harness;
+
+beforeAll(async () => {
+  process.env.LURKER_BOUNCER_ENABLED = 'true';
+  harnessMod = await import('../test-utils/bouncerHarness.js');
+  bouncerMod = await import('./bouncer.js');
+  ({ insertMessage } = await import('../db/messages.js'));
+  harness = await harnessMod.startHarness();
+});
+
+afterAll(() => {
+  harness.stop();
+  ctx.cleanup();
+});
+
+beforeEach(() => {
+  bouncerMod.resetAuthThrottle();
+});
+
+const NUL = String.fromCharCode(0);
+function saslPlain(authcid: string, passwd: string): string {
+  return Buffer.from(['', authcid, passwd].join(NUL), 'utf8').toString('base64');
+}
+
+type Client = Awaited<ReturnType<import('../test-utils/bouncerHarness.js').Harness['connect']>>;
+
+const HISTORY_CAPS = 'sasl batch server-time message-tags draft/chathistory';
+
+// Bind a single-network account (auto-binds without bouncer-networks) with the
+// history-relevant caps negotiated.
+async function attachBound(
+  c: Client,
+  acct: { user: { username: string }; password: string },
+  caps = HISTORY_CAPS,
+): Promise<void> {
+  c.send('CAP LS 302');
+  await c.waitFor((l) => l.includes('CAP') && l.includes('LS'));
+  c.send('NICK client');
+  c.send('USER client 0 * :client');
+  c.send(`CAP REQ :${caps}`);
+  await c.waitFor((l) => l.includes('ACK'));
+  c.send('AUTHENTICATE PLAIN');
+  await c.waitFor((l) => l === 'AUTHENTICATE +');
+  c.send(`AUTHENTICATE ${saslPlain(acct.user.username, acct.password)}`);
+  await c.waitForCommand('903');
+  c.send('CAP END');
+  await c.waitForCommand('422');
+}
+
+function seedMessages(networkId: number, target: string, n: number): number[] {
+  const ids: number[] = [];
+  for (let i = 1; i <= n; i++) {
+    ids.push(
+      Number(
+        insertMessage({
+          networkId,
+          target,
+          time: `2023-05-23T06:00:0${i}.000Z`,
+          type: 'message',
+          nick: 'bob',
+          userhost: 'bob!u@h',
+          text: `msg${i}`,
+          self: false,
+        }).id,
+      ),
+    );
+  }
+  return ids;
+}
+
+// Collect the BOUNCER... err, chathistory batch lines between BATCH +/- for a ref.
+function batchBodies(lines: string[], ref: string): string[] {
+  return lines.filter((l) => l.includes(`@batch=${ref}`) || l.includes(`;batch=${ref}`));
+}
+
+describe('CHATHISTORY advertisement', () => {
+  it('advertises CHATHISTORY + MSGREFTYPES in ISUPPORT when the cap is negotiated', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch1' });
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    const isupport = c.lines.find((l) => l.includes('CHATHISTORY='));
+    expect(isupport).toBeTruthy();
+    expect(isupport).toContain('MSGREFTYPES=msgid,timestamp');
+    c.close();
+  });
+});
+
+describe('CHATHISTORY LATEST', () => {
+  it('returns the newest messages oldest-first, in a chathistory batch with msgid+time', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch2' });
+    const ids = seedMessages(acct.network.id, '#room', 3);
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send('CHATHISTORY LATEST #room * 100');
+    const open = await c.waitFor((l) => l.includes('BATCH +') && l.includes('chathistory'));
+    const ref = open.split('BATCH +')[1].split(' ')[0];
+    expect(open).toContain('chathistory #room');
+    const m1 = await c.waitFor((l) => l.includes('PRIVMSG #room :msg1'));
+    expect(m1).toContain(`msgid=${ids[0]}`);
+    expect(m1).toContain('time=2023-05-23T06:00:01.000Z');
+    expect(m1).toContain(`batch=${ref}`);
+    await c.waitFor((l) => l.includes('msg3') && l.includes(`msgid=${ids[2]}`));
+    await c.waitFor((l) => l.includes(`BATCH -${ref}`));
+  });
+});
+
+describe('CHATHISTORY BEFORE / AFTER (msgid, exclusive)', () => {
+  it('BEFORE returns only messages with a smaller id', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch3' });
+    const ids = seedMessages(acct.network.id, '#r', 4);
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send(`CHATHISTORY BEFORE #r msgid=${ids[2]} 100`);
+    await c.waitFor((l) => l.includes('BATCH +') && l.includes('chathistory'));
+    await c.waitFor((l) => l.includes('msg1'));
+    await c.waitFor((l) => l.includes('msg2'));
+    await c.waitFor((l) => l.includes('BATCH -'));
+    // msg3 (the bound) and msg4 must NOT appear.
+    expect(c.lines.some((l) => l.includes('PRIVMSG #r :msg3'))).toBe(false);
+    expect(c.lines.some((l) => l.includes('PRIVMSG #r :msg4'))).toBe(false);
+  });
+
+  it('AFTER returns only messages with a larger id', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch4' });
+    const ids = seedMessages(acct.network.id, '#r', 4);
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send(`CHATHISTORY AFTER #r msgid=${ids[1]} 100`);
+    await c.waitFor((l) => l.includes('BATCH +'));
+    await c.waitFor((l) => l.includes('msg3'));
+    await c.waitFor((l) => l.includes('msg4'));
+    await c.waitFor((l) => l.includes('BATCH -'));
+    expect(c.lines.some((l) => l.includes('PRIVMSG #r :msg1'))).toBe(false);
+    expect(c.lines.some((l) => l.includes('PRIVMSG #r :msg2'))).toBe(false);
+  });
+});
+
+describe('CHATHISTORY timestamp selector', () => {
+  it('BEFORE timestamp= excludes messages at or after the timestamp', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch5' });
+    seedMessages(acct.network.id, '#ts', 3); // at :01, :02, :03
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send('CHATHISTORY BEFORE #ts timestamp=2023-05-23T06:00:03.000Z 100');
+    await c.waitFor((l) => l.includes('BATCH +'));
+    await c.waitFor((l) => l.includes('msg2'));
+    await c.waitFor((l) => l.includes('BATCH -'));
+    expect(c.lines.some((l) => l.includes('PRIVMSG #ts :msg3'))).toBe(false);
+  });
+});
+
+describe('CHATHISTORY TARGETS', () => {
+  it('lists active buffers with their last-activity time', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch6' });
+    seedMessages(acct.network.id, '#alpha', 2);
+    seedMessages(acct.network.id, '#beta', 1);
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send(
+      'CHATHISTORY TARGETS timestamp=2023-05-23T00:00:00.000Z timestamp=2023-05-24T00:00:00.000Z 100',
+    );
+    const open = await c.waitFor((l) => l.includes('draft/chathistory-targets'));
+    const ref = open.split('BATCH +')[1].split(' ')[0];
+    const alpha = await c.waitFor((l) => l.includes('CHATHISTORY TARGETS #alpha'));
+    // The target line carries the buffer's last-activity server-time.
+    expect(alpha).toContain('2023-05-23T06:00:02.000Z');
+    expect(alpha).toContain(`@batch=${ref}`);
+    await c.waitFor((l) => l.includes('CHATHISTORY TARGETS #beta'));
+    await c.waitFor((l) => l.includes(`BATCH -${ref}`));
+  });
+});
+
+describe('CHATHISTORY errors', () => {
+  it('rejects a limit over the advertised maximum', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch7' });
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send('CHATHISTORY LATEST #r * 99999');
+    const fail = await c.waitForCommand('FAIL');
+    expect(fail).toContain('INVALID_PARAMS');
+    expect(fail).toContain('Invalid limit');
+    c.close();
+  });
+
+  it('rejects a malformed bound', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch8' });
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send('CHATHISTORY BEFORE #r msgid=notanumber 100');
+    const fail = await c.waitForCommand('FAIL');
+    expect(fail).toContain('INVALID_PARAMS');
+    expect(fail).toContain('Invalid first bound');
+    c.close();
+  });
+
+  it('refuses CHATHISTORY on a control (unbound) connection', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch9' });
+    harnessMod.seedNetwork(acct.user, { networkName: 'second', nick: 'ch9b' });
+    const c = await harness.connect();
+    // Control mode: bouncer-networks cap, no network selector.
+    c.send('CAP LS 302');
+    await c.waitFor((l) => l.includes('CAP') && l.includes('LS'));
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    c.send('CAP REQ :sasl draft/chathistory soju.im/bouncer-networks');
+    await c.waitFor((l) => l.includes('ACK'));
+    c.send('AUTHENTICATE PLAIN');
+    await c.waitFor((l) => l === 'AUTHENTICATE +');
+    c.send(`AUTHENTICATE ${saslPlain(acct.user.username, acct.password)}`);
+    await c.waitForCommand('903');
+    c.send('CAP END');
+    await c.waitForCommand('422');
+    c.send('CHATHISTORY LATEST #r * 100');
+    const fail = await c.waitForCommand('FAIL');
+    expect(fail).toContain('INVALID_TARGET');
+    c.close();
+  });
+
+  it('returns an empty batch (not a FAIL) when there is no history', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'ch10' });
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send('CHATHISTORY LATEST #empty * 100');
+    const open = await c.waitFor((l) => l.includes('BATCH +') && l.includes('chathistory'));
+    const ref = open.split('BATCH +')[1].split(' ')[0];
+    const close = await c.waitFor((l) => l.includes(`BATCH -${ref}`));
+    expect(close).toBeTruthy();
+    expect(batchBodies(c.lines, ref)).toHaveLength(0);
+  });
+});

--- a/server/services/bouncer.chathistory.test.ts
+++ b/server/services/bouncer.chathistory.test.ts
@@ -94,7 +94,8 @@ describe('CHATHISTORY advertisement', () => {
     await attachBound(c, acct);
     const isupport = c.lines.find((l) => l.includes('CHATHISTORY='));
     expect(isupport).toBeTruthy();
-    expect(isupport).toContain('MSGREFTYPES=msgid,timestamp');
+    expect(isupport).toContain('CHATHISTORY=1000');
+    expect(isupport).toContain('MSGREFTYPES=timestamp');
     c.close();
   });
 });
@@ -118,28 +119,28 @@ describe('CHATHISTORY LATEST', () => {
   });
 });
 
-describe('CHATHISTORY BEFORE / AFTER (msgid, exclusive)', () => {
-  it('BEFORE returns only messages with a smaller id', async () => {
+describe('CHATHISTORY BEFORE / AFTER (timestamp, exclusive)', () => {
+  it('BEFORE excludes messages at or after the timestamp', async () => {
     const acct = harnessMod.seedAccount({ nick: 'ch3' });
-    const ids = seedMessages(acct.network.id, '#r', 4);
+    seedMessages(acct.network.id, '#r', 4); // at :01 :02 :03 :04
     const c = await harness.connect();
     await attachBound(c, acct);
-    c.send(`CHATHISTORY BEFORE #r msgid=${ids[2]} 100`);
+    c.send('CHATHISTORY BEFORE #r timestamp=2023-05-23T06:00:03.000Z 100');
     await c.waitFor((l) => l.includes('BATCH +') && l.includes('chathistory'));
     await c.waitFor((l) => l.includes('msg1'));
     await c.waitFor((l) => l.includes('msg2'));
     await c.waitFor((l) => l.includes('BATCH -'));
-    // msg3 (the bound) and msg4 must NOT appear.
+    // msg3 (at the bound) and msg4 must NOT appear.
     expect(c.lines.some((l) => l.includes('PRIVMSG #r :msg3'))).toBe(false);
     expect(c.lines.some((l) => l.includes('PRIVMSG #r :msg4'))).toBe(false);
   });
 
-  it('AFTER returns only messages with a larger id', async () => {
+  it('AFTER excludes messages at or before the timestamp', async () => {
     const acct = harnessMod.seedAccount({ nick: 'ch4' });
-    const ids = seedMessages(acct.network.id, '#r', 4);
+    seedMessages(acct.network.id, '#r', 4);
     const c = await harness.connect();
     await attachBound(c, acct);
-    c.send(`CHATHISTORY AFTER #r msgid=${ids[1]} 100`);
+    c.send('CHATHISTORY AFTER #r timestamp=2023-05-23T06:00:02.000Z 100');
     await c.waitFor((l) => l.includes('BATCH +'));
     await c.waitFor((l) => l.includes('msg3'));
     await c.waitFor((l) => l.includes('msg4'));
@@ -147,19 +148,44 @@ describe('CHATHISTORY BEFORE / AFTER (msgid, exclusive)', () => {
     expect(c.lines.some((l) => l.includes('PRIVMSG #r :msg1'))).toBe(false);
     expect(c.lines.some((l) => l.includes('PRIVMSG #r :msg2'))).toBe(false);
   });
-});
 
-describe('CHATHISTORY timestamp selector', () => {
-  it('BEFORE timestamp= excludes messages at or after the timestamp', async () => {
-    const acct = harnessMod.seedAccount({ nick: 'ch5' });
-    seedMessages(acct.network.id, '#ts', 3); // at :01, :02, :03
+  it('a netsplit of joins does not truncate the batch (limit counts real messages)', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'chns' });
+    seedMessages(acct.network.id, '#split', 1); // one real message at :01
+    // Then a flood of joins (non-replayable) at :02..:09.
+    for (let i = 2; i <= 9; i++) {
+      insertMessage({
+        networkId: acct.network.id,
+        target: '#split',
+        time: `2023-05-23T06:00:0${i}.000Z`,
+        type: 'join',
+        nick: `joiner${i}`,
+        self: false,
+      });
+    }
     const c = await harness.connect();
     await attachBound(c, acct);
-    c.send('CHATHISTORY BEFORE #ts timestamp=2023-05-23T06:00:03.000Z 100');
+    c.send('CHATHISTORY LATEST #split * 3');
     await c.waitFor((l) => l.includes('BATCH +'));
-    await c.waitFor((l) => l.includes('msg2'));
+    // The real message is returned even though the newest rows are all joins.
+    const line = await c.waitFor((l) => l.includes('PRIVMSG #split :msg1'));
+    expect(line).toContain('PRIVMSG #split :msg1');
     await c.waitFor((l) => l.includes('BATCH -'));
-    expect(c.lines.some((l) => l.includes('PRIVMSG #ts :msg3'))).toBe(false);
+  });
+});
+
+describe('CHATHISTORY msgid rejected', () => {
+  it('rejects a msgid selector (timestamp-only, MSGREFTYPES=timestamp)', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'chm' });
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    const isupport = c.lines.find((l) => l.includes('MSGREFTYPES'));
+    expect(isupport).toContain('MSGREFTYPES=timestamp');
+    expect(isupport).not.toContain('msgid');
+    c.send('CHATHISTORY BEFORE #r msgid=5 100');
+    const fail = await c.waitForCommand('FAIL');
+    expect(fail).toContain('Invalid first bound');
+    c.close();
   });
 });
 

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -20,6 +20,7 @@ let isServicesNick: typeof import('./bouncer.js').isServicesNick;
 let escapeTagValue: typeof import('./bouncer.js').escapeTagValue;
 let buildNetworkAttrs: typeof import('./bouncer.js').buildNetworkAttrs;
 let bouncerNetworkState: typeof import('./bouncer.js').bouncerNetworkState;
+let isValidServerTime: typeof import('./bouncer.js').isValidServerTime;
 let maxSessionsPerUser: typeof import('./bouncer.js').maxSessionsPerUser;
 let maxSessionsTotal: typeof import('./bouncer.js').maxSessionsTotal;
 let maxTotalPlaybackLines: typeof import('./bouncer.js').maxTotalPlaybackLines;
@@ -38,6 +39,7 @@ beforeAll(async () => {
   escapeTagValue = mod.escapeTagValue;
   buildNetworkAttrs = mod.buildNetworkAttrs;
   bouncerNetworkState = mod.bouncerNetworkState;
+  isValidServerTime = mod.isValidServerTime;
   maxSessionsPerUser = mod.maxSessionsPerUser;
   maxSessionsTotal = mod.maxSessionsTotal;
   maxTotalPlaybackLines = mod.maxTotalPlaybackLines;
@@ -344,6 +346,19 @@ describe('buildNetworkAttrs', () => {
     const attrs = buildNetworkAttrs(network, { state: 'disconnected', nickname: 'me_' });
     expect(attrs).toContain('state=disconnected');
     expect(attrs).toContain('nickname=me_');
+  });
+});
+
+describe('isValidServerTime', () => {
+  it('accepts exactly the millisecond-precision UTC layout', () => {
+    expect(isValidServerTime('2023-05-23T06:00:00.000Z')).toBe(true);
+  });
+  it('rejects other formats', () => {
+    expect(isValidServerTime('2023-05-23T06:00:00Z')).toBe(false); // no millis
+    expect(isValidServerTime('2023-05-23 06:00:00.000Z')).toBe(false); // space
+    expect(isValidServerTime('2023-05-23T06:00:00.000+00:00')).toBe(false); // offset
+    expect(isValidServerTime('not-a-time')).toBe(false);
+    expect(isValidServerTime('2023-13-45T99:99:99.000Z')).toBe(false); // impossible
   });
 });
 

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -48,7 +48,14 @@ import { hashToken, findActiveByHash, touchLastUsed } from '../db/apiTokens.js';
 import { listNetworksForUser, upsertChannel } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
 import { reopenBuffer, closedKeySetForUser } from '../db/closedBuffers.js';
-import { listMessages, listBuffersForNetwork } from '../db/messages.js';
+import {
+  listMessages,
+  listBuffersForNetwork,
+  listMessagesBetween,
+  firstIdAtOrAfterTime,
+  lastIdAtOrBeforeTime,
+  listActiveTargetsInWindow,
+} from '../db/messages.js';
 import type { MessageEvent } from '../db/messages.js';
 import { splitSay, splitAction } from './messageSplit.js';
 import { e2eManager } from './e2e/manager.js';
@@ -87,10 +94,18 @@ const SUPPORTED_CAPS = [
   // networks; -notify opts into unsolicited BOUNCER NETWORK state pushes.
   'soju.im/bouncer-networks',
   'soju.im/bouncer-networks-notify',
+  // draft/chathistory: on-demand scrollback fetch (CHATHISTORY BEFORE/AFTER/…).
+  'draft/chathistory',
 ];
 
 const CAP_BOUNCER_NETWORKS = 'soju.im/bouncer-networks';
 const CAP_BOUNCER_NETWORKS_NOTIFY = 'soju.im/bouncer-networks-notify';
+const CAP_CHATHISTORY = 'draft/chathistory';
+
+// Max messages a single CHATHISTORY request may return (advertised as the
+// CHATHISTORY ISUPPORT token). Requests over this are rejected, not clamped —
+// matching soju, whose clients read the token and stay under it.
+const MAX_CHATHISTORY = 1000;
 
 // The SASL mechanisms we implement. Advertised as a `sasl=…` value only under
 // CAP 302 (bare `sasl` otherwise, since pre-302 CAP LS carries no cap values).
@@ -386,6 +401,18 @@ function toIrcTime(iso: string): string {
   const d = new Date(iso);
   return Number.isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
 }
+
+// IRCv3 server-time layout used by CHATHISTORY `timestamp=` selectors:
+// exactly `YYYY-MM-DDThh:mm:ss.sssZ` (millisecond precision, literal Z).
+export function isValidServerTime(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(s) && !Number.isNaN(Date.parse(s));
+}
+
+// A CHATHISTORY selector: `*` (LATEST only), `msgid=<id>` (our msgid is the
+// numeric messages.id), or `timestamp=<iso>`.
+type ChatBound = { star: true } | { msgid: number } | { iso: string };
+// id sentinel for an unbounded window edge (larger than any real message id).
+const CHATHISTORY_MAX_ID = Number.MAX_SAFE_INTEGER;
 
 function isChannelName(target: string): boolean {
   return target.startsWith('#') || target.startsWith('&');
@@ -1027,11 +1054,17 @@ class BouncerSession {
         `:${requested}!${conn.client.user?.username || 'lurker'}@${SERVER_NAME} NICK :${liveNick}`,
       );
     }
-    // Tell a bouncer-networks-aware client which network it bound to. The
-    // upstream's own 005 can't carry this, so append our own ISUPPORT line.
-    if (this.caps.has(CAP_BOUNCER_NETWORKS)) {
+    // Append our own ISUPPORT for tokens the upstream's 005 can't carry:
+    // BOUNCER_NETID (which network this connection bound) and the chathistory
+    // limits. Bundled into one 005 line, gated on the relevant caps.
+    const extraIsupport: string[] = [];
+    if (this.caps.has(CAP_BOUNCER_NETWORKS)) extraIsupport.push(`BOUNCER_NETID=${this.networkId}`);
+    if (this.caps.has(CAP_CHATHISTORY)) {
+      extraIsupport.push(`CHATHISTORY=${MAX_CHATHISTORY}`, 'MSGREFTYPES=msgid,timestamp');
+    }
+    if (extraIsupport.length > 0) {
       this.write(
-        `:${SERVER_NAME} 005 ${liveNick} BOUNCER_NETID=${this.networkId} :are supported by this server`,
+        `:${SERVER_NAME} 005 ${liveNick} ${extraIsupport.join(' ')} :are supported by this server`,
       );
     }
     this.write(`:${SERVER_NAME} 422 ${liveNick} :MOTD File is missing`);
@@ -1186,6 +1219,178 @@ class BouncerSession {
     this.write(`:${SERVER_NAME} BOUNCER NETWORK ${networkId} ${attrs}`);
   }
 
+  // --- CHATHISTORY (draft/chathistory) ---------------------------------------
+
+  private handleChatHistory(msg: ParsedClientLine): void {
+    const sub = (msg.params[0] || '').toUpperCase();
+    // History is per-network; a control connection has no bound buffers.
+    if (this.isControl || !this.networkId) {
+      this.write(
+        `:${SERVER_NAME} FAIL CHATHISTORY INVALID_TARGET ${sub || '*'} :Cannot fetch chat history on the bouncer connection`,
+      );
+      return;
+    }
+    if (sub === 'TARGETS') {
+      this.handleChatHistoryTargets(msg);
+      return;
+    }
+    if (!['BEFORE', 'AFTER', 'LATEST', 'AROUND', 'BETWEEN'].includes(sub)) {
+      this.write(`:${SERVER_NAME} FAIL CHATHISTORY INVALID_PARAMS ${sub || '*'} :Unknown command`);
+      return;
+    }
+    const target = msg.params[1] || '';
+    if (!target) {
+      this.numeric('461', 'CHATHISTORY :Not enough parameters');
+      return;
+    }
+    const isBetween = sub === 'BETWEEN';
+    const limit = this.parseChatHistoryLimit(sub, msg.params[isBetween ? 4 : 3] || '');
+    if (limit === null) return;
+    const bound0 = this.parseChatHistoryBound(sub, msg.params[2] || '', sub === 'LATEST', 'first');
+    if (!bound0) return;
+    let bound1: ChatBound | null = null;
+    if (isBetween) {
+      bound1 = this.parseChatHistoryBound(sub, msg.params[3] || '', false, 'second');
+      if (!bound1) return;
+    }
+    const rows = this.loadChatHistory(sub, target, bound0, bound1, limit);
+    this.sendChatHistoryBatch(target, rows);
+  }
+
+  private handleChatHistoryTargets(msg: ParsedClientLine): void {
+    // TARGETS has no <target>; two timestamp bounds + limit. soju (and we) only
+    // accept timestamp selectors here, not msgid.
+    const isoA = this.parseTimestampBound(msg.params[1] || '', 'first');
+    if (isoA === null) return;
+    const isoB = this.parseTimestampBound(msg.params[2] || '', 'second');
+    if (isoB === null) return;
+    const limit = this.parseChatHistoryLimit('TARGETS', msg.params[3] || '');
+    if (limit === null) return;
+    const targets = listActiveTargetsInWindow(this.networkId, isoA, isoB, limit);
+    const batched = this.caps.has('batch');
+    const ref = `lct${++this.batchSeq}`;
+    if (batched) this.write(`:${SERVER_NAME} BATCH +${ref} draft/chathistory-targets`);
+    const tag = batched ? `@batch=${ref} ` : '';
+    for (const t of targets) {
+      this.write(
+        `${tag}:${SERVER_NAME} CHATHISTORY TARGETS ${t.target} ${toIrcTime(t.lastMessageAt)}`,
+      );
+    }
+    if (batched) this.write(`:${SERVER_NAME} BATCH -${ref}`);
+  }
+
+  // Map a subcommand + bound(s) + limit onto the message store. Every mode is
+  // expressed as a single id-window fetch (exclusive bounds), so the wire
+  // contract — chronological, oldest-first — always holds.
+  private loadChatHistory(
+    sub: string,
+    target: string,
+    bound0: ChatBound,
+    bound1: ChatBound | null,
+    limit: number,
+  ): MessageEvent[] {
+    const nid = this.networkId;
+    const lower = (b: ChatBound): number =>
+      'msgid' in b ? b.msgid : 'iso' in b ? (lastIdAtOrBeforeTime(nid, target, b.iso) ?? 0) : 0;
+    const upper = (b: ChatBound): number =>
+      'msgid' in b
+        ? b.msgid
+        : 'iso' in b
+          ? (firstIdAtOrAfterTime(nid, target, b.iso) ?? CHATHISTORY_MAX_ID)
+          : CHATHISTORY_MAX_ID;
+    const before = (b: ChatBound, n: number) =>
+      listMessagesBetween(nid, target, 0, upper(b), n, { newestFirst: true });
+    const after = (b: ChatBound, n: number) =>
+      listMessagesBetween(nid, target, lower(b), CHATHISTORY_MAX_ID, n);
+
+    switch (sub) {
+      case 'BEFORE':
+        return before(bound0, limit);
+      case 'AFTER':
+        return after(bound0, limit);
+      case 'LATEST': {
+        const lo = 'star' in bound0 ? 0 : lower(bound0);
+        return listMessagesBetween(nid, target, lo, CHATHISTORY_MAX_ID, limit, {
+          newestFirst: true,
+        });
+      }
+      case 'AROUND': {
+        const beforeLimit = Math.ceil(limit / 2);
+        return [...before(bound0, beforeLimit), ...after(bound0, limit - beforeLimit)];
+      }
+      case 'BETWEEN': {
+        const b1 = bound1!;
+        // Order the two bounds; take the earliest `limit` when ascending, the
+        // most recent when descending (soju semantics), always emit oldest-first.
+        const ascending = lower(bound0) <= lower(b1);
+        const loB = ascending ? bound0 : b1;
+        const hiB = ascending ? b1 : bound0;
+        return listMessagesBetween(nid, target, lower(loB), upper(hiB), limit, {
+          newestFirst: !ascending,
+        });
+      }
+    }
+    return [];
+  }
+
+  private sendChatHistoryBatch(target: string, rows: MessageEvent[]): void {
+    const batched = this.caps.has('batch');
+    const ref = `lch${++this.batchSeq}`;
+    if (batched) this.write(`:${SERVER_NAME} BATCH +${ref} chathistory ${target}`);
+    const lines = this.playbackLines(rows, target, isChannelName(target), {
+      batchRef: batched ? ref : undefined,
+      withMsgid: true,
+    });
+    for (const line of lines) this.write(line);
+    if (batched) this.write(`:${SERVER_NAME} BATCH -${ref}`);
+  }
+
+  // Parse a CHATHISTORY selector; on error writes a FAIL and returns null.
+  private parseChatHistoryBound(
+    sub: string,
+    boundStr: string,
+    allowStar: boolean,
+    which: 'first' | 'second',
+  ): ChatBound | null {
+    if (allowStar && boundStr === '*') return { star: true };
+    const eq = boundStr.indexOf('=');
+    const key = eq === -1 ? '' : boundStr.slice(0, eq);
+    const val = eq === -1 ? '' : boundStr.slice(eq + 1);
+    if (key === 'msgid') {
+      const id = Number(val);
+      if (Number.isInteger(id) && id > 0) return { msgid: id };
+    } else if (key === 'timestamp' && isValidServerTime(val)) {
+      return { iso: val };
+    }
+    this.write(
+      `:${SERVER_NAME} FAIL CHATHISTORY INVALID_PARAMS ${sub} ${boundStr} :Invalid ${which} bound`,
+    );
+    return null;
+  }
+
+  private parseTimestampBound(boundStr: string, which: 'first' | 'second'): string | null {
+    const eq = boundStr.indexOf('=');
+    if (eq !== -1 && boundStr.slice(0, eq) === 'timestamp') {
+      const val = boundStr.slice(eq + 1);
+      if (isValidServerTime(val)) return val;
+    }
+    this.write(
+      `:${SERVER_NAME} FAIL CHATHISTORY INVALID_PARAMS TARGETS ${boundStr} :Invalid ${which} bound`,
+    );
+    return null;
+  }
+
+  private parseChatHistoryLimit(sub: string, limitStr: string): number | null {
+    const n = Number(limitStr);
+    if (!Number.isInteger(n) || n < 0 || n > MAX_CHATHISTORY) {
+      this.write(
+        `:${SERVER_NAME} FAIL CHATHISTORY INVALID_PARAMS ${sub} ${limitStr} :Invalid limit`,
+      );
+      return null;
+    }
+    return n;
+  }
+
   private isupportPrefixes(): Array<{ mode: string; symbol: string }> {
     const raw = this.conn?.client.network?.options?.PREFIX as unknown;
     if (
@@ -1248,7 +1453,23 @@ class BouncerSession {
     }
   }
 
-  private playbackLines(rows: MessageEvent[], bufferTarget: string, isChannel: boolean): string[] {
+  // Assemble the leading IRCv3 tag block for a replayed line, honoring the
+  // client's negotiated caps. `batch` ties a line to an open BATCH; `time`
+  // needs server-time; `msgid` needs message-tags.
+  private formatTags(opts: { time?: string; msgid?: number; batchRef?: string }): string {
+    const tags: string[] = [];
+    if (opts.batchRef) tags.push(`batch=${opts.batchRef}`);
+    if (opts.time && this.caps.has('server-time')) tags.push(`time=${toIrcTime(opts.time)}`);
+    if (opts.msgid != null && this.caps.has('message-tags')) tags.push(`msgid=${opts.msgid}`);
+    return tags.length > 0 ? `@${tags.join(';')} ` : '';
+  }
+
+  private playbackLines(
+    rows: MessageEvent[],
+    bufferTarget: string,
+    isChannel: boolean,
+    opts: { batchRef?: string; withMsgid?: boolean } = {},
+  ): string[] {
     const out: string[] = [];
     const selfNick = this.currentNick() || this.clientNick || '*';
     for (const row of rows) {
@@ -1285,9 +1506,12 @@ class BouncerSession {
           ? [`\u0001ACTION ${row.text.replace(/\n/g, ' ')}\u0001`]
           : row.text.split('\n');
       for (const body of bodies) {
-        let line = `:${prefix} ${cmd} ${target} :${body}`;
-        if (this.caps.has('server-time')) line = `@time=${toIrcTime(row.time)} ${line}`;
-        out.push(line);
+        const tags = this.formatTags({
+          time: row.time,
+          msgid: opts.withMsgid ? (row.id as number) : undefined,
+          batchRef: opts.batchRef,
+        });
+        out.push(`${tags}:${prefix} ${cmd} ${target} :${body}`);
       }
     }
     return out;
@@ -1335,6 +1559,12 @@ class BouncerSession {
         // Network enumeration/management works from any registered connection,
         // bound or control (it doesn't touch a specific upstream).
         this.handleBouncer(msg);
+        return;
+      case 'CHATHISTORY':
+        // Answered locally from the message store — placed here so it works even
+        // when the upstream is disconnected (a bouncer's whole point), bypassing
+        // the liveConn() gate below.
+        this.handleChatHistory(msg);
         return;
     }
 

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -51,9 +51,7 @@ import { reopenBuffer, closedKeySetForUser } from '../db/closedBuffers.js';
 import {
   listMessages,
   listBuffersForNetwork,
-  listMessagesBetween,
-  firstIdAtOrAfterTime,
-  lastIdAtOrBeforeTime,
+  loadHistoryWindow,
   listActiveTargetsInWindow,
 } from '../db/messages.js';
 import type { MessageEvent } from '../db/messages.js';
@@ -408,11 +406,12 @@ export function isValidServerTime(s: string): boolean {
   return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(s) && !Number.isNaN(Date.parse(s));
 }
 
-// A CHATHISTORY selector: `*` (LATEST only), `msgid=<id>` (our msgid is the
-// numeric messages.id), or `timestamp=<iso>`.
-type ChatBound = { star: true } | { msgid: number } | { iso: string };
-// id sentinel for an unbounded window edge (larger than any real message id).
-const CHATHISTORY_MAX_ID = Number.MAX_SAFE_INTEGER;
+// A CHATHISTORY selector: `*` (LATEST only) or `timestamp=<iso>`. We advertise
+// MSGREFTYPES=timestamp only — deliberately NOT msgid: our persisted history id
+// (messages.id) and the upstream's opaque msgid on live-relayed lines are
+// different namespaces, so honoring `msgid=` would break for a client paging
+// from a live-captured id. Timestamp works off any line's @time. (Matches soju.)
+type ChatBound = { star: true } | { iso: string };
 
 function isChannelName(target: string): boolean {
   return target.startsWith('#') || target.startsWith('&');
@@ -1060,7 +1059,7 @@ class BouncerSession {
     const extraIsupport: string[] = [];
     if (this.caps.has(CAP_BOUNCER_NETWORKS)) extraIsupport.push(`BOUNCER_NETID=${this.networkId}`);
     if (this.caps.has(CAP_CHATHISTORY)) {
-      extraIsupport.push(`CHATHISTORY=${MAX_CHATHISTORY}`, 'MSGREFTYPES=msgid,timestamp');
+      extraIsupport.push(`CHATHISTORY=${MAX_CHATHISTORY}`, 'MSGREFTYPES=timestamp');
     }
     if (extraIsupport.length > 0) {
       this.write(
@@ -1197,20 +1196,28 @@ class BouncerSession {
   // line per network. The soju.im/bouncer-networks batch wrapper (and its
   // `@batch=` message tag) is only used when the client negotiated `batch` —
   // otherwise we must not emit tags, so send the same lines unwrapped.
+  // Run `fn(ref)` wrapped in a BATCH of the given type + params when the client
+  // negotiated the `batch` cap (`ref` is the batch reference, or null unbatched
+  // — IRCv3: no tags to clients that didn't ask). Mirrors soju's SendBatch.
+  private withBatch(type: string, params: string[], fn: (ref: string | null) => void): void {
+    const ref = this.caps.has('batch') ? `lb${++this.batchSeq}` : null;
+    if (ref) this.write(`:${SERVER_NAME} BATCH +${ref} ${[type, ...params].join(' ')}`);
+    fn(ref);
+    if (ref) this.write(`:${SERVER_NAME} BATCH -${ref}`);
+  }
+
   private sendNetworkList(): void {
-    const batched = this.caps.has('batch');
-    const ref = `lbnc${++this.batchSeq}`;
-    if (batched) this.write(`:${SERVER_NAME} BATCH +${ref} soju.im/bouncer-networks`);
-    const tag = batched ? `@batch=${ref} ` : '';
-    for (const network of listNetworksForUser(this.userId)) {
-      const conn = ircManager.getConnection(this.userId, network.id);
-      const attrs = buildNetworkAttrs(network, {
-        state: bouncerNetworkState(conn?.state),
-        nickname: conn?.currentNick || network.nick,
-      });
-      this.write(`${tag}:${SERVER_NAME} BOUNCER NETWORK ${network.id} ${attrs}`);
-    }
-    if (batched) this.write(`:${SERVER_NAME} BATCH -${ref}`);
+    this.withBatch('soju.im/bouncer-networks', [], (ref) => {
+      const tag = ref ? `@batch=${ref} ` : '';
+      for (const network of listNetworksForUser(this.userId)) {
+        const conn = ircManager.getConnection(this.userId, network.id);
+        const attrs = buildNetworkAttrs(network, {
+          state: bouncerNetworkState(conn?.state),
+          nickname: conn?.currentNick || network.nick,
+        });
+        this.write(`${tag}:${SERVER_NAME} BOUNCER NETWORK ${network.id} ${attrs}`);
+      }
+    });
   }
 
   // Push an unsolicited (unbatched) network state change to a -notify client.
@@ -1226,7 +1233,7 @@ class BouncerSession {
     // History is per-network; a control connection has no bound buffers.
     if (this.isControl || !this.networkId) {
       this.write(
-        `:${SERVER_NAME} FAIL CHATHISTORY INVALID_TARGET ${sub || '*'} :Cannot fetch chat history on the bouncer connection`,
+        `:${SERVER_NAME} FAIL CHATHISTORY INVALID_TARGET ${sub || '*'} ${msg.params[1] || '*'} :Cannot fetch chat history on the bouncer connection`,
       );
       return;
     }
@@ -1244,7 +1251,7 @@ class BouncerSession {
       return;
     }
     const isBetween = sub === 'BETWEEN';
-    const limit = this.parseChatHistoryLimit(sub, msg.params[isBetween ? 4 : 3] || '');
+    const limit = this.parseChatHistoryLimit(sub, msg.params[isBetween ? 4 : 3] ?? '');
     if (limit === null) return;
     const bound0 = this.parseChatHistoryBound(sub, msg.params[2] || '', sub === 'LATEST', 'first');
     if (!bound0) return;
@@ -1258,30 +1265,27 @@ class BouncerSession {
   }
 
   private handleChatHistoryTargets(msg: ParsedClientLine): void {
-    // TARGETS has no <target>; two timestamp bounds + limit. soju (and we) only
-    // accept timestamp selectors here, not msgid.
+    // TARGETS has no <target>; two timestamp bounds + limit (timestamp-only).
     const isoA = this.parseTimestampBound(msg.params[1] || '', 'first');
     if (isoA === null) return;
     const isoB = this.parseTimestampBound(msg.params[2] || '', 'second');
     if (isoB === null) return;
-    const limit = this.parseChatHistoryLimit('TARGETS', msg.params[3] || '');
+    const limit = this.parseChatHistoryLimit('TARGETS', msg.params[3] ?? '');
     if (limit === null) return;
     const targets = listActiveTargetsInWindow(this.networkId, isoA, isoB, limit);
-    const batched = this.caps.has('batch');
-    const ref = `lct${++this.batchSeq}`;
-    if (batched) this.write(`:${SERVER_NAME} BATCH +${ref} draft/chathistory-targets`);
-    const tag = batched ? `@batch=${ref} ` : '';
-    for (const t of targets) {
-      this.write(
-        `${tag}:${SERVER_NAME} CHATHISTORY TARGETS ${t.target} ${toIrcTime(t.lastMessageAt)}`,
-      );
-    }
-    if (batched) this.write(`:${SERVER_NAME} BATCH -${ref}`);
+    this.withBatch('draft/chathistory-targets', [], (ref) => {
+      const tag = ref ? `@batch=${ref} ` : '';
+      for (const t of targets) {
+        this.write(
+          `${tag}:${SERVER_NAME} CHATHISTORY TARGETS ${t.target} ${toIrcTime(t.lastMessageAt)}`,
+        );
+      }
+    });
   }
 
-  // Map a subcommand + bound(s) + limit onto the message store. Every mode is
-  // expressed as a single id-window fetch (exclusive bounds), so the wire
-  // contract — chronological, oldest-first — always holds.
+  // Map a subcommand + timestamp bound(s) + limit onto a message-store window
+  // fetch (exclusive time bounds), mirroring soju's LoadBeforeTime/LoadAfterTime.
+  // Results are always chronological, oldest-first.
   private loadChatHistory(
     sub: string,
     target: string,
@@ -1290,42 +1294,32 @@ class BouncerSession {
     limit: number,
   ): MessageEvent[] {
     const nid = this.networkId;
-    const lower = (b: ChatBound): number =>
-      'msgid' in b ? b.msgid : 'iso' in b ? (lastIdAtOrBeforeTime(nid, target, b.iso) ?? 0) : 0;
-    const upper = (b: ChatBound): number =>
-      'msgid' in b
-        ? b.msgid
-        : 'iso' in b
-          ? (firstIdAtOrAfterTime(nid, target, b.iso) ?? CHATHISTORY_MAX_ID)
-          : CHATHISTORY_MAX_ID;
-    const before = (b: ChatBound, n: number) =>
-      listMessagesBetween(nid, target, 0, upper(b), n, { newestFirst: true });
-    const after = (b: ChatBound, n: number) =>
-      listMessagesBetween(nid, target, lower(b), CHATHISTORY_MAX_ID, n);
-
+    // Only LATEST's bound can be `*` (unbounded); every other bound is a
+    // timestamp by the time we get here (the parser rejects `*` elsewhere).
+    const iso = (b: ChatBound): string | null => ('iso' in b ? b.iso : null);
     switch (sub) {
       case 'BEFORE':
-        return before(bound0, limit);
+        return loadHistoryWindow(nid, target, null, iso(bound0), limit, { newestFirst: true });
       case 'AFTER':
-        return after(bound0, limit);
-      case 'LATEST': {
-        const lo = 'star' in bound0 ? 0 : lower(bound0);
-        return listMessagesBetween(nid, target, lo, CHATHISTORY_MAX_ID, limit, {
+        return loadHistoryWindow(nid, target, iso(bound0), null, limit);
+      case 'LATEST':
+        return loadHistoryWindow(nid, target, iso(bound0), null, limit, { newestFirst: true });
+      case 'AROUND': {
+        // Split the limit around the point: newest half before, earliest after.
+        const afterLimit = Math.floor(limit / 2);
+        const older = loadHistoryWindow(nid, target, null, iso(bound0), limit - afterLimit, {
           newestFirst: true,
         });
-      }
-      case 'AROUND': {
-        const beforeLimit = Math.ceil(limit / 2);
-        return [...before(bound0, beforeLimit), ...after(bound0, limit - beforeLimit)];
+        const newer = loadHistoryWindow(nid, target, iso(bound0), null, afterLimit);
+        return [...older, ...newer];
       }
       case 'BETWEEN': {
-        const b1 = bound1!;
-        // Order the two bounds; take the earliest `limit` when ascending, the
-        // most recent when descending (soju semantics), always emit oldest-first.
-        const ascending = lower(bound0) <= lower(b1);
-        const loB = ascending ? bound0 : b1;
-        const hiB = ascending ? b1 : bound0;
-        return listMessagesBetween(nid, target, lower(loB), upper(hiB), limit, {
+        // Order the two time bounds; ascending → earliest `limit` in the window,
+        // descending → most recent (soju semantics); always emit oldest-first.
+        const a = iso(bound0);
+        const b = iso(bound1!);
+        const ascending = (a ?? '') <= (b ?? '');
+        return loadHistoryWindow(nid, target, ascending ? a : b, ascending ? b : a, limit, {
           newestFirst: !ascending,
         });
       }
@@ -1334,18 +1328,18 @@ class BouncerSession {
   }
 
   private sendChatHistoryBatch(target: string, rows: MessageEvent[]): void {
-    const batched = this.caps.has('batch');
-    const ref = `lch${++this.batchSeq}`;
-    if (batched) this.write(`:${SERVER_NAME} BATCH +${ref} chathistory ${target}`);
-    const lines = this.playbackLines(rows, target, isChannelName(target), {
-      batchRef: batched ? ref : undefined,
-      withMsgid: true,
+    this.withBatch('chathistory', [target], (ref) => {
+      const lines = this.playbackLines(rows, target, isChannelName(target), {
+        batchRef: ref ?? undefined,
+        withMsgid: true,
+      });
+      for (const line of lines) this.write(line);
     });
-    for (const line of lines) this.write(line);
-    if (batched) this.write(`:${SERVER_NAME} BATCH -${ref}`);
   }
 
-  // Parse a CHATHISTORY selector; on error writes a FAIL and returns null.
+  // Parse a CHATHISTORY selector — `*` (LATEST only) or `timestamp=<iso>`. msgid
+  // selectors are deliberately rejected (see the ChatBound type). Writes a FAIL
+  // and returns null on error.
   private parseChatHistoryBound(
     sub: string,
     boundStr: string,
@@ -1354,13 +1348,9 @@ class BouncerSession {
   ): ChatBound | null {
     if (allowStar && boundStr === '*') return { star: true };
     const eq = boundStr.indexOf('=');
-    const key = eq === -1 ? '' : boundStr.slice(0, eq);
-    const val = eq === -1 ? '' : boundStr.slice(eq + 1);
-    if (key === 'msgid') {
-      const id = Number(val);
-      if (Number.isInteger(id) && id > 0) return { msgid: id };
-    } else if (key === 'timestamp' && isValidServerTime(val)) {
-      return { iso: val };
+    if (eq !== -1 && boundStr.slice(0, eq) === 'timestamp') {
+      const val = boundStr.slice(eq + 1);
+      if (isValidServerTime(val)) return { iso: val };
     }
     this.write(
       `:${SERVER_NAME} FAIL CHATHISTORY INVALID_PARAMS ${sub} ${boundStr} :Invalid ${which} bound`,
@@ -1369,20 +1359,15 @@ class BouncerSession {
   }
 
   private parseTimestampBound(boundStr: string, which: 'first' | 'second'): string | null {
-    const eq = boundStr.indexOf('=');
-    if (eq !== -1 && boundStr.slice(0, eq) === 'timestamp') {
-      const val = boundStr.slice(eq + 1);
-      if (isValidServerTime(val)) return val;
-    }
-    this.write(
-      `:${SERVER_NAME} FAIL CHATHISTORY INVALID_PARAMS TARGETS ${boundStr} :Invalid ${which} bound`,
-    );
-    return null;
+    const bound = this.parseChatHistoryBound('TARGETS', boundStr, false, which);
+    return bound && 'iso' in bound ? bound.iso : null;
   }
 
   private parseChatHistoryLimit(sub: string, limitStr: string): number | null {
+    // A missing/empty limit is a param error (Number('') === 0 would otherwise
+    // silently become an empty-batch request); an explicit 0 is valid.
     const n = Number(limitStr);
-    if (!Number.isInteger(n) || n < 0 || n > MAX_CHATHISTORY) {
+    if (limitStr.trim() === '' || !Number.isInteger(n) || n < 0 || n > MAX_CHATHISTORY) {
       this.write(
         `:${SERVER_NAME} FAIL CHATHISTORY INVALID_PARAMS ${sub} ${limitStr} :Invalid limit`,
       );


### PR DESCRIPTION
Phase 4 of the built-in IRC bouncer: IRCv3 `draft/chathistory`, so modern clients (gamja/Goguma/Halloy) can page real scrollback on demand instead of relying on the fixed attach-burst. Answered locally from the message store, so it works even while the upstream is disconnected. Builds on #479.

Gated behind CAP; the PASS floor and existing playback are unchanged.

## What's in it

- **`CHATHISTORY BEFORE / AFTER / LATEST / AROUND / BETWEEN <target> <selector> <limit>`** + **`CHATHISTORY TARGETS <ts> <ts> <limit>`**. Results come back in a `chathistory` BATCH (bare type, target as sole param — soju parity), chronological oldest-first, each line tagged `@time`/`@msgid`/`@batch`. TARGETS returns a `draft/chathistory-targets` batch of `CHATHISTORY TARGETS <name> <time>` lines.
- **Selectors: `timestamp=<iso>` and `*`** (LATEST). Advertised as `MSGREFTYPES=timestamp` — **deliberately not msgid**: our persisted history id (`messages.id`) and the *upstream's* opaque msgid on live-relayed lines are different namespaces, so honoring `msgid=` would break for a client paging from a live-captured id. Matches soju. (`@msgid` is still emitted on replay lines for local dedup, just not accepted as a selector.)
- **Bounds exclusive; limit `0..1000`** rejected (not clamped) out of range; a **missing** limit is a param error; empty result = empty batch, never FAIL. `FAIL CHATHISTORY INVALID_PARAMS/INVALID_TARGET`.
- **Refused on a control (unbound) connection.** Advertises the `draft/chathistory` cap + `CHATHISTORY=1000` ISUPPORT on bound sessions.

## Store

New `loadHistoryWindow` (exclusive ISO time bounds, mirroring soju's `LoadBeforeTime`/`LoadAfterTime`) + `listActiveTargetsInWindow`. Both filter to **replayable messages in SQL** (`type IN (message,action,notice) AND NOT mirrored AND text present`) so `LIMIT` counts real messages — a window full of a netsplit's JOIN/QUIT must not come back empty (which would make a client think it reached the start of history and stop paging). `playbackLines` refactored to a shared tag builder so history lines carry `@msgid`.

## Testing

- `server/services/bouncer.chathistory.test.ts` — 11 socket cases: LATEST/BEFORE/AFTER/TARGETS, msgid-rejection, the netsplit non-truncation guarantee, limit/bound errors, control-connection refusal, empty-batch-not-FAIL.
- `messages.test.ts` — `loadHistoryWindow` (bounds, message-filter) + `listActiveTargetsInWindow` + `isValidServerTime` units.
- Full `npm run check` green; suite **1909 passing**.
- Ran a high multi-agent review; the two material findings (paging truncation, msgid namespace footgun) drove the windowed-query + timestamp-only rework in the second commit, plus the smaller fixes (empty-limit, INVALID_TARGET param, shared batch helper, TARGETS activity filter).

## Deferred

`draft/event-playback` (replaying JOIN/PART/etc. in history) — soju gates it too; PRIVMSG/NOTICE only for now. The one-listener-per-upstream relay consolidation (#9) remains a separate fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)