### PR TITLE
Bouncer: TLS by default (self-signed + hot-reload)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,15 +159,25 @@ VAPID_SUBJECT=mailto:you@example.com
 # A read-write API token (web UI -> Settings -> API tokens) is recommended over
 # your account password, since IRC client configs store the value in plaintext.
 #
-# SECURITY: plain-text IRC carries that credential on the wire. Either bind to
-# localhost / a private (VPN) interface with LURKER_BOUNCER_BIND, or provide a
-# TLS cert+key so the listener speaks TLS (point your client at "TLS" mode).
+# TLS: the listener speaks TLS by DEFAULT so that credential never crosses the
+# wire in the clear. With no cert configured, Lurker generates a self-signed
+# cert on first boot (persisted next to the DB) and prints its SHA-256
+# fingerprint at startup + to the in-app system buffer — connect in your
+# client's "TLS" mode and verify/pin that fingerprint (ZNC-style). To use a
+# real (browser-trusted) cert instead, point LURKER_BOUNCER_TLS_CERT/KEY at a
+# Let's Encrypt pair; Lurker hot-reloads it when it renews (no restart). A
+# configured cert is watched and swapped in automatically.
+#
+# Only set LURKER_BOUNCER_TLS=off to force PLAINTEXT — do that ONLY when the
+# listener is bound to localhost / a private (VPN/Tailscale) interface via
+# LURKER_BOUNCER_BIND, never on a public address.
 # ---------------------------------------------------------------------------
 # LURKER_BOUNCER_ENABLED=true
 # LURKER_BOUNCER_PORT=6667
 # LURKER_BOUNCER_BIND=127.0.0.1
-# LURKER_BOUNCER_TLS_CERT=/path/to/fullchain.pem
+# LURKER_BOUNCER_TLS_CERT=/path/to/fullchain.pem   # optional: real cert
 # LURKER_BOUNCER_TLS_KEY=/path/to/privkey.pem
+# LURKER_BOUNCER_TLS=off                            # opt out of TLS (loopback/VPN only)
 #
 # Lines of history replayed per buffer when a client attaches (0 disables
 # playback, max 1000). Joined channels always replay; the 20 most recently

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -209,9 +209,13 @@ Point your IRC client at the host/port with a **server password** of:
 
 The secret can be your Lurker account password, but a **read-write API token** (web UI → **Settings → API tokens**) is the better choice — IRC clients store the server password in plaintext config files, and a token can be revoked without changing your password.
 
-Security notes:
+#### TLS
 
-- Plain-text IRC sends that credential in the clear. Either keep the listener private — `LURKER_BOUNCER_BIND=127.0.0.1` behind an SSH tunnel, or a VPN/Tailscale interface — or give it a certificate so it speaks TLS:
+Plain-text IRC would send that credential across the wire in the clear, so **the bouncer speaks TLS by default** — you don't have to do anything to get an encrypted connection. Connect in your IRC client's **TLS/SSL** mode. There are three ways the cert is sourced:
+
+- **Self-signed (default, zero setup).** With no cert configured, Lurker generates a self-signed cert on first boot and persists it next to the database (so it survives container rebuilds). It's the ZNC model: the wire is encrypted, and to also protect against man-in-the-middle you **pin the certificate's fingerprint** in your client. Lurker prints the SHA-256 fingerprint at startup — in the container logs and in the in-app **system buffer** — e.g. `TLS certificate fingerprint (SHA-256): AB:CD:…`. Most clients (WeeChat, irssi, Textual, …) let you pin that fingerprint; do it once and any impostor cert is rejected thereafter.
+
+- **Your own Let's Encrypt cert (browser-trusted, no pinning).** If you want a cert clients trust without pinning, get one for a hostname (e.g. `irc.example.com`) with certbot and point Lurker at the PEM files — bind-mount them into the container and set:
 
   ```yaml
   environment:
@@ -219,7 +223,11 @@ Security notes:
     - LURKER_BOUNCER_TLS_KEY=/certs/privkey.pem
   ```
 
-- Repeated failed logins from an address are throttled automatically.
+  Note the bouncer is raw IRC over TCP, so your **HTTP reverse proxy (Caddy/Cloudflare) can't front it** — the bouncer terminates its own TLS. Lurker re-reads the cert files periodically and hot-swaps a renewed cert, so certbot renewals need no restart.
+
+- **Plain-text (opt-in, private networks only).** If — and only if — you keep the listener private (`LURKER_BOUNCER_BIND=127.0.0.1` behind an SSH tunnel, or a VPN/Tailscale interface), you can turn TLS off with `LURKER_BOUNCER_TLS=off`. On a non-loopback bind without TLS, Lurker logs a loud security warning. Don't do this on a public address.
+
+Repeated failed logins from an address are throttled automatically.
 
 Playback replays the last 50 lines per joined channel (plus your 20 most recently active DMs) on attach; tune with `LURKER_BOUNCER_PLAYBACK` (0 disables, max 1000). Clients that negotiate IRCv3 `server-time` get real timestamps on replayed lines.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "express": "^5.2.1",
         "irc-framework": "^4.13.1",
         "multer": "^2.2.0",
+        "selfsigned": "^5.5.0",
         "sharp": "^0.35.2",
         "tsx": "^4.22.4",
         "uuid": "^14.0.1",
@@ -3412,6 +3413,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -5612,6 +5622,35 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5930,6 +5969,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "^5.2.1",
     "irc-framework": "^4.13.1",
     "multer": "^2.2.0",
+    "selfsigned": "^5.5.0",
     "sharp": "^0.35.2",
     "tsx": "^4.22.4",
     "uuid": "^14.0.1",

--- a/server/server.ts
+++ b/server/server.ts
@@ -112,7 +112,11 @@ ircManager.initAll();
 // clients attach to the always-on connections ircManager just established,
 // ZNC-style. Started after initAll so an attaching client finds its network.
 if (isBouncerEnabled()) {
-  startBouncer(bouncerPort(), bouncerBindHost());
+  // Async because first-boot self-signed TLS generation is; not on the web
+  // server's critical path, so start it in the background.
+  startBouncer(bouncerPort(), bouncerBindHost()).catch((err) => {
+    console.error(`[bouncer] failed to start: ${(err as Error).message}`);
+  });
 }
 
 // Fail any export job a prior crash/restart left mid-flight, drop partial

--- a/server/services/bouncer.tls-fallback.test.ts
+++ b/server/services/bouncer.tls-fallback.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// A misconfigured operator cert (here: a mismatched cert/key pair) must not
+// bring up a broken TLS listener — the bouncer falls back to a working
+// self-signed cert so the wire stays encrypted.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('services-bouncer-tls-fallback');
+
+let harnessMod: typeof import('../test-utils/bouncerHarness.js');
+let harness: import('../test-utils/bouncerHarness.js').Harness;
+
+beforeAll(async () => {
+  process.env.LURKER_BOUNCER_ENABLED = 'true';
+  const certMod = await import('../utils/bouncerCert.js');
+  harnessMod = await import('../test-utils/bouncerHarness.js');
+  // Build a deliberately mismatched pair: cert from A, key from B.
+  const a = await certMod.loadOrCreateSelfSignedCert({ dataDir: path.join(ctx.tmpDir, 'a') });
+  const b = await certMod.loadOrCreateSelfSignedCert({ dataDir: path.join(ctx.tmpDir, 'b') });
+  process.env.LURKER_BOUNCER_TLS_CERT = a.certPath;
+  process.env.LURKER_BOUNCER_TLS_KEY = b.keyPath;
+  harness = await harnessMod.startHarness({ tls: true });
+});
+
+afterAll(() => {
+  harness.stop();
+  delete process.env.LURKER_BOUNCER_TLS_CERT;
+  delete process.env.LURKER_BOUNCER_TLS_KEY;
+  ctx.cleanup();
+});
+
+describe('operator cert fallback', () => {
+  it('serves a working self-signed TLS listener when the configured pair is mismatched', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'fbuser' });
+    const c = await harness.connect(); // TLS handshake succeeds → fallback cert is valid
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    await c.waitForCommand('001');
+    expect(harnessMod.attachedFor(acct)).toBe(1);
+    // The fallback did NOT use the (unreadable-as-a-pair) configured cert.
+    const fp = fs.existsSync(process.env.LURKER_BOUNCER_TLS_CERT!);
+    expect(fp).toBe(true); // the configured cert file exists but was rejected as a pair
+  });
+});

--- a/server/services/bouncer.tls.test.ts
+++ b/server/services/bouncer.tls.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// TLS behaviour of the bouncer: the self-signed default speaks TLS end-to-end,
+// and reloadBouncerTls() hot-swaps a renewed cert without a restart.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import tls from 'tls';
+import fs from 'fs';
+import path from 'path';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('services-bouncer-tls');
+
+let harnessMod: typeof import('../test-utils/bouncerHarness.js');
+let bouncerMod: typeof import('./bouncer.js');
+let certMod: typeof import('../utils/bouncerCert.js');
+let harness: import('../test-utils/bouncerHarness.js').Harness;
+
+beforeAll(async () => {
+  process.env.LURKER_BOUNCER_ENABLED = 'true';
+  harnessMod = await import('../test-utils/bouncerHarness.js');
+  bouncerMod = await import('./bouncer.js');
+  certMod = await import('../utils/bouncerCert.js');
+  harness = await harnessMod.startHarness({ tls: true });
+});
+
+afterAll(() => {
+  harness.stop();
+  delete process.env.LURKER_BOUNCER_TLS;
+  ctx.cleanup();
+});
+
+describe('self-signed TLS default', () => {
+  it('accepts a PASS login over a TLS handshake', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'tlsuser' });
+    const c = await harness.connect();
+    // The handshake already completed (harness awaited secureConnect) against a
+    // self-signed cert — the presence of a peer cert proves TLS is live.
+    const cert = (c.socket as tls.TLSSocket).getPeerCertificate();
+    expect(cert.fingerprint256).toBeTruthy();
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    await c.waitForCommand('001');
+    expect(harnessMod.attachedFor(acct)).toBe(1);
+  });
+});
+
+describe('reloadBouncerTls', () => {
+  it('is a no-op when the cert file is unchanged', () => {
+    expect(bouncerMod.reloadBouncerTls()).toBe('unchanged');
+  });
+
+  it('hot-swaps a renewed cert so new connections get it', async () => {
+    const before = (await handshakeFingerprint(harness.port)).toString();
+
+    // Mint a fresh self-signed cert and drop it over the live files (an LE
+    // renewal / wildcard rotation looks the same on disk).
+    const fresh = await certMod.loadOrCreateSelfSignedCert({
+      dataDir: path.join(ctx.tmpDir, 'renewed'),
+    });
+    const dataDir = path.dirname(ctx.dbPath);
+    fs.copyFileSync(fresh.certPath, path.join(dataDir, 'bouncer-cert.pem'));
+    fs.copyFileSync(fresh.keyPath, path.join(dataDir, 'bouncer-key.pem'));
+
+    expect(bouncerMod.reloadBouncerTls()).toBe('reloaded');
+
+    const after = (await handshakeFingerprint(harness.port)).toString();
+    expect(after).not.toBe(before); // the new connection presents the renewed cert
+  });
+
+  it('does NOT install a cert whose key has not landed yet (partial renewal)', async () => {
+    const before = await handshakeFingerprint(harness.port);
+    const dataDir = path.dirname(ctx.dbPath);
+    // Mint a fresh pair but copy ONLY the cert over — the on-disk key still
+    // belongs to the current cert, so the pair is momentarily mismatched.
+    const fresh = await certMod.loadOrCreateSelfSignedCert({
+      dataDir: path.join(ctx.tmpDir, 'partial'),
+    });
+    fs.copyFileSync(fresh.certPath, path.join(dataDir, 'bouncer-cert.pem'));
+    expect(bouncerMod.reloadBouncerTls()).toBe('error');
+    expect(await handshakeFingerprint(harness.port)).toBe(before); // kept the working cert
+
+    // Once the matching key lands, the next poll swaps cleanly.
+    fs.copyFileSync(fresh.keyPath, path.join(dataDir, 'bouncer-key.pem'));
+    expect(bouncerMod.reloadBouncerTls()).toBe('reloaded');
+  });
+});
+
+// Open a bare TLS connection and return the server cert's SHA-256 fingerprint.
+function handshakeFingerprint(port: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = tls.connect({ port, host: '127.0.0.1', rejectUnauthorized: false }, () => {
+      const fp = socket.getPeerCertificate().fingerprint256;
+      socket.destroy();
+      resolve(fp);
+    });
+    socket.on('error', reject);
+  });
+}

--- a/server/services/bouncer.tls.test.ts
+++ b/server/services/bouncer.tls.test.ts
@@ -26,8 +26,7 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  harness.stop();
-  delete process.env.LURKER_BOUNCER_TLS;
+  harness.stop(); // also clears LURKER_BOUNCER_TLS
   ctx.cleanup();
 });
 

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -59,6 +59,11 @@ import { splitSay, splitAction } from './messageSplit.js';
 import { e2eManager } from './e2e/manager.js';
 import { contextKey, isChannelContext } from './e2e/context.js';
 import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
+import {
+  loadOrCreateSelfSignedCert,
+  certFingerprint,
+  keyMatchesCert,
+} from '../utils/bouncerCert.js';
 
 const SERVER_NAME = 'lurker.bouncer';
 
@@ -152,6 +157,10 @@ const HEARTBEAT_INTERVAL_MS = 45_000;
 const HEARTBEAT_PING_AFTER_MS = 90_000;
 const HEARTBEAT_REAP_AFTER_MS = 240_000;
 const MAX_INPUT_BUFFER = 64 * 1024;
+// How often to check the TLS cert file for a renewal and hot-swap it. Renewal
+// is never time-critical (certs renew well before expiry), so a slow poll is
+// fine and far simpler/robuster than fs.watch across symlink renames.
+const CERT_RELOAD_INTERVAL_MS = 6 * 60 * 60 * 1000;
 // Ceiling on an accumulated multi-chunk SASL response. A PLAIN payload is tiny
 // (username + network + token); this only exists to stop an endless stream of
 // 400-char AUTHENTICATE chunks from growing the heap without bound.
@@ -1874,6 +1883,11 @@ function dropSessionsForUser(userId: number, reason: string): void {
 
 let server: net.Server | tls.Server | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let certReloadTimer: ReturnType<typeof setInterval> | null = null;
+// Paths + current fingerprint of the live TLS cert, so the reload poll can
+// detect a renewed cert on disk and swap it in without a restart. null =
+// plaintext listener.
+let bouncerTlsState: { certPath: string; keyPath: string; fingerprint: string } | null = null;
 let onIrcEvent: ((event: Record<string, unknown>) => void) | null = null;
 let onUserDisposed: ((payload: { userId: number }) => void) | null = null;
 let onUserSuspended: ((payload: { userId: number }) => void) | null = null;
@@ -1925,24 +1939,110 @@ export function maxSessionsTotal(): number {
   return Math.floor(n);
 }
 
-// TLS when both cert and key paths are set (LURKER_BOUNCER_TLS_CERT/KEY).
-// Read once at startup; a reload requires a restart, same as the web server.
-function tlsOptions(): { cert: Buffer; key: Buffer } | null {
-  const certPath = (process.env.LURKER_BOUNCER_TLS_CERT || '').trim();
-  const keyPath = (process.env.LURKER_BOUNCER_TLS_KEY || '').trim();
-  if (!certPath || !keyPath) return null;
-  return { cert: fs.readFileSync(certPath), key: fs.readFileSync(keyPath) };
+// Plaintext IRC ships the login credential in the clear, so TLS is the default.
+// Only an explicit LURKER_BOUNCER_TLS=off (0/false/no/off) turns it off.
+function bouncerTlsDisabled(): boolean {
+  return /^(0|false|no|off)$/i.test((process.env.LURKER_BOUNCER_TLS || '').trim());
 }
 
-export function startBouncer(
+function isLoopbackBind(host: string | undefined): boolean {
+  const h = (host ?? bouncerBindHost() ?? '').trim();
+  return h === '127.0.0.1' || h === '::1' || h === 'localhost';
+}
+
+interface ResolvedTls {
+  cert: Buffer;
+  key: Buffer;
+  certPath: string;
+  keyPath: string;
+  source: 'configured' | 'self-signed';
+  fingerprint: string;
+}
+
+// Resolve the bouncer's TLS material: an operator-supplied cert
+// (LURKER_BOUNCER_TLS_CERT/KEY) if provided, otherwise an auto-generated
+// self-signed cert persisted in the data dir. Returns null only when TLS is
+// explicitly disabled. Async because first-boot self-signed generation is.
+async function resolveBouncerTls(): Promise<ResolvedTls | null> {
+  if (bouncerTlsDisabled()) return null;
+  const envCert = (process.env.LURKER_BOUNCER_TLS_CERT || '').trim();
+  const envKey = (process.env.LURKER_BOUNCER_TLS_KEY || '').trim();
+  // Half a config (one of the pair set) is almost certainly a typo. Don't
+  // silently self-sign under it — a client that trusted the intended real cert
+  // would then get an unexpected self-signed one. Warn, then fall back.
+  if (Boolean(envCert) !== Boolean(envKey)) {
+    const msg =
+      'LURKER_BOUNCER_TLS_CERT and LURKER_BOUNCER_TLS_KEY must BOTH be set to use your own certificate — only one is set, falling back to a self-signed cert.';
+    console.warn(`[bouncer] ${msg}`);
+    systemLog.log({ scope: 'bouncer', text: msg });
+  }
+  let certPath: string;
+  let keyPath: string;
+  let source: ResolvedTls['source'];
+  if (envCert && envKey) {
+    certPath = envCert;
+    keyPath = envKey;
+    source = 'configured';
+  } else {
+    ({ certPath, keyPath } = await loadOrCreateSelfSignedCert());
+    source = 'self-signed';
+  }
+  const cert = fs.readFileSync(certPath);
+  const key = fs.readFileSync(keyPath);
+  return { cert, key, certPath, keyPath, source, fingerprint: certFingerprint(cert) };
+}
+
+// Re-read the cert from disk and hot-swap it into the running TLS server if it
+// changed (an operator's LE renewal, or a control-plane wildcard rotation).
+// Called on a poll and exported for tests. No fs.watch — a periodic
+// fingerprint check is robust across certbot's atomic symlink renames, and cert
+// renewal is never time-critical (certs renew well before expiry).
+export function reloadBouncerTls(): 'reloaded' | 'unchanged' | 'skipped' | 'error' {
+  if (!server || !bouncerTlsState || !('setSecureContext' in server)) return 'skipped';
+  try {
+    const cert = fs.readFileSync(bouncerTlsState.certPath);
+    const fingerprint = certFingerprint(cert);
+    if (fingerprint === bouncerTlsState.fingerprint) return 'unchanged';
+    const key = fs.readFileSync(bouncerTlsState.keyPath);
+    // Guard the renewal race: a poll can land after the cert file was replaced
+    // but before the key. setSecureContext wouldn't catch the mismatch (it never
+    // validates the pair) — so verify here, and if they don't match yet, keep
+    // the current context and retry next poll (don't advance the fingerprint).
+    if (!keyMatchesCert(cert, key)) {
+      console.warn(
+        '[bouncer] new TLS cert does not match the key on disk yet — keeping current cert',
+      );
+      return 'error';
+    }
+    (server as tls.Server).setSecureContext({ cert, key });
+    bouncerTlsState.fingerprint = fingerprint;
+    console.log(`[bouncer] reloaded TLS certificate (SHA-256 ${fingerprint})`);
+    systemLog.log({
+      scope: 'bouncer',
+      text: `Reloaded TLS certificate — new fingerprint: ${fingerprint}`,
+    });
+    return 'reloaded';
+  } catch (e) {
+    // A partial write mid-renewal, etc. — keep the current context and retry next poll.
+    console.warn(
+      `[bouncer] TLS cert reload check failed (keeping current): ${(e as Error).message}`,
+    );
+    return 'error';
+  }
+}
+
+export async function startBouncer(
   port: number = bouncerPort(),
   host?: string,
-): net.Server | tls.Server | null {
+): Promise<net.Server | tls.Server | null> {
   // Already running → signal a no-op with null rather than handing back a server
   // that's already past its 'listening' event (a caller awaiting that event on
   // the returned handle would otherwise wait forever).
   if (server) return null;
-  const tlsOpts = tlsOptions();
+  const tlsInfo = await resolveBouncerTls();
+  // Between the await and here another call could have started the server; if so,
+  // yield to it (drop the cert we just resolved).
+  if (server) return null;
   const onConnection = (socket: net.Socket) => {
     // Global backstop: refuse new sockets once the process-wide ceiling is hit.
     // An unauthenticated flood is otherwise bounded only by the registration
@@ -1953,18 +2053,42 @@ export function startBouncer(
     }
     sessions.add(new BouncerSession(socket));
   };
-  server = tlsOpts ? tls.createServer(tlsOpts, onConnection) : net.createServer(onConnection);
+  if (tlsInfo) {
+    server = tls.createServer({ cert: tlsInfo.cert, key: tlsInfo.key }, onConnection);
+    bouncerTlsState = {
+      certPath: tlsInfo.certPath,
+      keyPath: tlsInfo.keyPath,
+      fingerprint: tlsInfo.fingerprint,
+    };
+    certReloadTimer = setInterval(() => reloadBouncerTls(), CERT_RELOAD_INTERVAL_MS);
+    certReloadTimer.unref?.();
+  } else {
+    server = net.createServer(onConnection);
+    bouncerTlsState = null;
+  }
   server.on('error', (err) => {
     console.warn(`[bouncer] listener error: ${(err as Error).message}`);
   });
   server.listen(port, host, () => {
-    console.log(
-      `[bouncer] IRC bouncer listening on ${host || '0.0.0.0'}:${port}${tlsOpts ? ' (TLS)' : ''}`,
-    );
-    systemLog.log({
-      scope: 'bouncer',
-      text: `IRC bouncer listening on port ${port}${tlsOpts ? ' (TLS)' : ''}`,
-    });
+    const mode = tlsInfo ? `TLS (${tlsInfo.source})` : 'PLAINTEXT';
+    console.log(`[bouncer] IRC bouncer listening on ${host || '0.0.0.0'}:${port} — ${mode}`);
+    systemLog.log({ scope: 'bouncer', text: `IRC bouncer listening on port ${port} — ${mode}` });
+    if (tlsInfo) {
+      const pin =
+        tlsInfo.source === 'self-signed'
+          ? ' (self-signed — verify/pin this fingerprint in your IRC client)'
+          : '';
+      console.log(`[bouncer] TLS certificate SHA-256: ${tlsInfo.fingerprint}${pin}`);
+      systemLog.log({
+        scope: 'bouncer',
+        text: `TLS certificate fingerprint (SHA-256): ${tlsInfo.fingerprint}${pin}`,
+      });
+    } else if (!isLoopbackBind(host)) {
+      const warning =
+        'SECURITY: bouncer is running WITHOUT TLS on a non-loopback address — login credentials travel in the clear. Remove LURKER_BOUNCER_TLS=off, or bind to 127.0.0.1 behind a tunnel/VPN.';
+      console.warn(`[bouncer] ${warning}`);
+      systemLog.log({ scope: 'bouncer', text: warning });
+    }
   });
 
   onIrcEvent = (event) => dispatchIrcEvent(event as Record<string, unknown>);
@@ -1987,6 +2111,11 @@ export function stopBouncer(): void {
     clearInterval(heartbeatTimer);
     heartbeatTimer = null;
   }
+  if (certReloadTimer) {
+    clearInterval(certReloadTimer);
+    certReloadTimer = null;
+  }
+  bouncerTlsState = null;
   if (onIrcEvent) {
     ircManager.off('event', onIrcEvent);
     onIrcEvent = null;

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -159,7 +159,7 @@ const HEARTBEAT_REAP_AFTER_MS = 240_000;
 const MAX_INPUT_BUFFER = 64 * 1024;
 // How often to check the TLS cert file for a renewal and hot-swap it. Renewal
 // is never time-critical (certs renew well before expiry), so a slow poll is
-// fine and far simpler/robuster than fs.watch across symlink renames.
+// fine and far simpler and more robust than fs.watch across symlink renames.
 const CERT_RELOAD_INTERVAL_MS = 6 * 60 * 60 * 1000;
 // Ceiling on an accumulated multi-chunk SASL response. A PLAIN payload is tiny
 // (username + network + token); this only exists to stop an endless stream of
@@ -1971,25 +1971,50 @@ async function resolveBouncerTls(): Promise<ResolvedTls | null> {
   // silently self-sign under it — a client that trusted the intended real cert
   // would then get an unexpected self-signed one. Warn, then fall back.
   if (Boolean(envCert) !== Boolean(envKey)) {
-    const msg =
-      'LURKER_BOUNCER_TLS_CERT and LURKER_BOUNCER_TLS_KEY must BOTH be set to use your own certificate — only one is set, falling back to a self-signed cert.';
-    console.warn(`[bouncer] ${msg}`);
-    systemLog.log({ scope: 'bouncer', text: msg });
+    fallbackWarn(
+      'LURKER_BOUNCER_TLS_CERT and LURKER_BOUNCER_TLS_KEY must BOTH be set to use your own certificate — only one is set',
+    );
+  } else if (envCert && envKey) {
+    // Validate the operator's pair up front (as reload does): an unreadable or
+    // mismatched cert/key would otherwise start a TLS listener whose every
+    // handshake fails. Fall back to a working self-signed cert instead.
+    try {
+      const cert = fs.readFileSync(envCert);
+      const key = fs.readFileSync(envKey);
+      if (keyMatchesCert(cert, key)) {
+        return {
+          cert,
+          key,
+          certPath: envCert,
+          keyPath: envKey,
+          source: 'configured',
+          fingerprint: certFingerprint(cert),
+        };
+      }
+      fallbackWarn('the configured TLS certificate and key do not match');
+    } catch (e) {
+      fallbackWarn(`could not read the configured TLS certificate/key (${(e as Error).message})`);
+    }
   }
-  let certPath: string;
-  let keyPath: string;
-  let source: ResolvedTls['source'];
-  if (envCert && envKey) {
-    certPath = envCert;
-    keyPath = envKey;
-    source = 'configured';
-  } else {
-    ({ certPath, keyPath } = await loadOrCreateSelfSignedCert());
-    source = 'self-signed';
-  }
+  const { certPath, keyPath } = await loadOrCreateSelfSignedCert();
   const cert = fs.readFileSync(certPath);
   const key = fs.readFileSync(keyPath);
-  return { cert, key, certPath, keyPath, source, fingerprint: certFingerprint(cert) };
+  return {
+    cert,
+    key,
+    certPath,
+    keyPath,
+    source: 'self-signed',
+    fingerprint: certFingerprint(cert),
+  };
+}
+
+// Warn (console + system buffer) that a configured-cert problem forced the
+// self-signed fallback, so the operator can see why TLS isn't using their cert.
+function fallbackWarn(reason: string): void {
+  const msg = `${reason} — falling back to a self-signed certificate.`;
+  console.warn(`[bouncer] ${msg}`);
+  systemLog.log({ scope: 'bouncer', text: msg });
 }
 
 // Re-read the cert from disk and hot-swap it into the running TLS server if it

--- a/server/test-utils/bouncerHarness.ts
+++ b/server/test-utils/bouncerHarness.ts
@@ -14,6 +14,7 @@
 // bouncer forwards back upstream (client → network).
 
 import net from 'net';
+import tls from 'tls';
 import { EventEmitter, once } from 'node:events';
 import ircManager from '../services/ircManager.js';
 import {
@@ -254,9 +255,19 @@ export interface Harness {
   stop(): void;
 }
 
-/** Start the real bouncer on an ephemeral port. Call stop() in afterAll. */
-export async function startHarness(): Promise<Harness> {
-  const srv = startBouncer(0, '127.0.0.1');
+/**
+ * Start the real bouncer on an ephemeral port. Call stop() in afterAll.
+ * TLS is a hard default in production, but the protocol tests speak plain IRC,
+ * so this forces plaintext (LURKER_BOUNCER_TLS=off) unless `tls: true` is passed
+ * — in which case the listener speaks TLS (self-signed) and connect() does a
+ * TLS handshake with cert validation off.
+ */
+export async function startHarness({
+  tls: useTls = false,
+}: { tls?: boolean } = {}): Promise<Harness> {
+  if (useTls) delete process.env.LURKER_BOUNCER_TLS;
+  else process.env.LURKER_BOUNCER_TLS = 'off';
+  const srv = await startBouncer(0, '127.0.0.1');
   if (!srv) throw new Error('bouncer already started');
   // Guard the await: if the server somehow already bound, its 'listening' event
   // has fired and once() would hang.
@@ -268,8 +279,10 @@ export async function startHarness(): Promise<Harness> {
   return {
     port,
     async connect(): Promise<BouncerClient> {
-      const socket = net.connect({ port, host: '127.0.0.1' });
-      await once(socket, 'connect');
+      const socket = useTls
+        ? tls.connect({ port, host: '127.0.0.1', rejectUnauthorized: false })
+        : net.connect({ port, host: '127.0.0.1' });
+      await once(socket, useTls ? 'secureConnect' : 'connect');
       const client = new BouncerClient(socket);
       clients.push(client);
       return client;

--- a/server/test-utils/bouncerHarness.ts
+++ b/server/test-utils/bouncerHarness.ts
@@ -291,6 +291,8 @@ export async function startHarness({
       for (const c of clients) c.close();
       resetAuthThrottle();
       stopBouncer();
+      // Don't leak the TLS override into later tests sharing this worker's env.
+      delete process.env.LURKER_BOUNCER_TLS;
     },
   };
 }

--- a/server/utils/bouncerCert.test.ts
+++ b/server/utils/bouncerCert.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+import { loadOrCreateSelfSignedCert, certFingerprint, keyMatchesCert } from './bouncerCert.js';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-bnccert-'));
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('loadOrCreateSelfSignedCert', () => {
+  it('generates and persists a usable cert on first call, reuses it after', async () => {
+    const dataDir = path.join(tmpDir, 'a');
+    const first = await loadOrCreateSelfSignedCert({ dataDir });
+    expect(first.created).toBe(true);
+    expect(fs.existsSync(first.certPath)).toBe(true);
+    expect(fs.existsSync(first.keyPath)).toBe(true);
+
+    // The PEM parses as a real X.509 cert with a >5-year validity.
+    const cert = new crypto.X509Certificate(fs.readFileSync(first.certPath));
+    const years =
+      (new Date(cert.validTo).getTime() - new Date(cert.validFrom).getTime()) /
+      (365 * 24 * 3600 * 1000);
+    expect(years).toBeGreaterThan(5);
+
+    // A second call reuses the persisted pair (same paths, not regenerated).
+    const second = await loadOrCreateSelfSignedCert({ dataDir });
+    expect(second.created).toBe(false);
+    expect(second.certPath).toBe(first.certPath);
+    expect(fs.readFileSync(first.certPath, 'utf8')).toBe(fs.readFileSync(second.certPath, 'utf8'));
+  });
+
+  it('writes the private key with owner-only permissions', async () => {
+    const dataDir = path.join(tmpDir, 'b');
+    const { keyPath } = await loadOrCreateSelfSignedCert({ dataDir });
+    // 0600 — group/other bits must be clear.
+    expect(fs.statSync(keyPath).mode & 0o077).toBe(0);
+  });
+});
+
+describe('keyMatchesCert', () => {
+  it('accepts a matching pair and rejects a mismatched one', async () => {
+    const a = await loadOrCreateSelfSignedCert({ dataDir: path.join(tmpDir, 'm1') });
+    const b = await loadOrCreateSelfSignedCert({ dataDir: path.join(tmpDir, 'm2') });
+    const certA = fs.readFileSync(a.certPath);
+    const keyA = fs.readFileSync(a.keyPath);
+    const keyB = fs.readFileSync(b.keyPath);
+    expect(keyMatchesCert(certA, keyA)).toBe(true);
+    expect(keyMatchesCert(certA, keyB)).toBe(false); // A's cert, B's key
+    expect(keyMatchesCert(certA, 'not a key')).toBe(false); // garbage → false, no throw
+  });
+
+  it('regenerates a persisted pair that has become mismatched', async () => {
+    const dataDir = path.join(tmpDir, 'heal');
+    const first = await loadOrCreateSelfSignedCert({ dataDir });
+    // Corrupt the on-disk pair (drop in a foreign key), then reload.
+    const foreign = await loadOrCreateSelfSignedCert({ dataDir: path.join(tmpDir, 'foreign') });
+    fs.copyFileSync(foreign.keyPath, first.keyPath);
+    const healed = await loadOrCreateSelfSignedCert({ dataDir });
+    expect(healed.created).toBe(true); // detected the mismatch and regenerated
+    expect(keyMatchesCert(fs.readFileSync(healed.certPath), fs.readFileSync(healed.keyPath))).toBe(
+      true,
+    );
+  });
+});
+
+describe('certFingerprint', () => {
+  it('returns the SHA-256 fingerprint as uppercase colon-hex', async () => {
+    const { certPath } = await loadOrCreateSelfSignedCert({ dataDir: path.join(tmpDir, 'c') });
+    const fp = certFingerprint(fs.readFileSync(certPath));
+    expect(fp).toMatch(/^([0-9A-F]{2}:){31}[0-9A-F]{2}$/);
+  });
+});

--- a/server/utils/bouncerCert.ts
+++ b/server/utils/bouncerCert.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Self-signed TLS certificate for the built-in IRC bouncer. When an operator
+// hasn't supplied their own cert (LURKER_BOUNCER_TLS_CERT/KEY), the bouncer
+// still speaks TLS by default using a self-signed cert generated on first boot
+// and persisted alongside the SQLite DB — the same zero-config, survives-a-
+// rebuild pattern as resolveSessionSecret. This is the ZNC convention: the wire
+// is encrypted out of the box; for MITM protection the user pins the cert's
+// fingerprint (printed at startup) in their IRC client.
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { generate as generateSelfSigned } from 'selfsigned';
+
+const CERT_FILE = 'bouncer-cert.pem';
+const KEY_FILE = 'bouncer-key.pem';
+
+function defaultDataDir(): string {
+  if (process.env.DATABASE_PATH) return path.dirname(process.env.DATABASE_PATH);
+  return path.join(import.meta.dirname, '../../data');
+}
+
+export interface BouncerCertFiles {
+  certPath: string;
+  keyPath: string;
+  created: boolean;
+}
+
+// Load the persisted self-signed bouncer cert, generating + persisting one on
+// first use. 10-year validity: self-signed certs aren't renewed — clients pin
+// the fingerprint rather than trust a chain, so a long life avoids a surprise
+// expiry. Returns the file paths (the caller reads + watches them, sharing the
+// hot-reload path with operator-supplied certs).
+export async function loadOrCreateSelfSignedCert({
+  dataDir = defaultDataDir(),
+}: { dataDir?: string } = {}): Promise<BouncerCertFiles> {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const certPath = path.join(dataDir, CERT_FILE);
+  const keyPath = path.join(dataDir, KEY_FILE);
+  // Reuse an existing pair only if it's internally consistent — a hand-edited
+  // file or an interleaved concurrent first-boot could leave a cert that doesn't
+  // match the key, which would fail every handshake; regenerate a fresh pair.
+  if (
+    fs.existsSync(certPath) &&
+    fs.existsSync(keyPath) &&
+    keyMatchesCert(fs.readFileSync(certPath), fs.readFileSync(keyPath))
+  ) {
+    return { certPath, keyPath, created: false };
+  }
+  const notBeforeDate = new Date();
+  const notAfterDate = new Date(notBeforeDate.getTime() + 3650 * 24 * 60 * 60 * 1000);
+  const pems = await generateSelfSigned([{ name: 'commonName', value: 'Lurker IRC Bouncer' }], {
+    notBeforeDate,
+    notAfterDate,
+    keySize: 2048,
+    algorithm: 'sha256',
+    extensions: [
+      { name: 'basicConstraints', cA: false },
+      { name: 'keyUsage', digitalSignature: true, keyEncipherment: true },
+      { name: 'extKeyUsage', serverAuth: true },
+      {
+        name: 'subjectAltName',
+        altNames: [
+          { type: 2, value: 'localhost' },
+          { type: 7, ip: '127.0.0.1' },
+          { type: 7, ip: '::1' },
+        ],
+      },
+    ],
+  });
+  // Key first (0600) and cert (0644) — never leave a half-written pair readable.
+  fs.writeFileSync(keyPath, pems.private, { mode: 0o600 });
+  fs.writeFileSync(certPath, pems.cert, { mode: 0o644 });
+  return { certPath, keyPath, created: true };
+}
+
+// SHA-256 fingerprint of a PEM cert as uppercase colon-hex ("AB:CD:…") — the
+// exact form IRC clients show for pinning/verification.
+export function certFingerprint(certPem: string | Buffer): string {
+  return new crypto.X509Certificate(certPem).fingerprint256;
+}
+
+// Does this private key correspond to this certificate? Node's setSecureContext
+// does NOT check, so a mismatched {cert, key} (e.g. a renewal that wrote the
+// cert file a moment before the key) would install silently and break every
+// handshake — callers verify with this before installing.
+export function keyMatchesCert(certPem: string | Buffer, keyPem: string | Buffer): boolean {
+  try {
+    return new crypto.X509Certificate(certPem).checkPrivateKey(crypto.createPrivateKey(keyPem));
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Plaintext IRC ships the bouncer login credential (account password or API token) in the clear on every attach, so **the bouncer now speaks TLS by default** — zero config required. This is the safe-by-default posture; the previous behavior (plaintext unless you supplied a cert) is gone.

> ⚠️ **Breaking change:** existing plaintext bouncer setups must switch their IRC client to **TLS mode**. Only an explicit `LURKER_BOUNCER_TLS=off` keeps plaintext, and that's intended solely for a listener bound to loopback / a VPN interface.

## Cert sources

All three share one load + hot-reload path — they differ only in *where the PEM comes from*, which keeps the cell module mode-agnostic (Phase 5's hosted ingress reuses this exact path with a control-plane wildcard):

- **Self-signed (default, zero setup).** Generated on first boot, persisted next to the SQLite DB (survives container rebuilds), 10-year validity. The SHA-256 fingerprint is printed at startup — in container logs and the in-app **system buffer** — so users **pin it** in their client (the ZNC model: encrypted out of the box; pin for MITM protection).
- **Operator LE cert** via `LURKER_BOUNCER_TLS_CERT/KEY` (unchanged) — browser-trusted, no pinning.
- **Plaintext** only via explicit `LURKER_BOUNCER_TLS=off`; a non-loopback plaintext bind logs a loud security warning.

## Hot-reload

A 6h poll re-reads the cert and `setSecureContext()`s a renewed one, so Let's Encrypt renewals need **no restart**. A periodic fingerprint check (not `fs.watch`) is robust across certbot's atomic symlink renames and is never time-critical. `reloadBouncerTls()` is exported for tests.

## Security-review hardening

Ran a focused correctness/security review; fixed the real findings:
- **Verify the key matches the cert before installing.** `setSecureContext` doesn't validate the pair, so a renewal that wrote the cert file a moment before the key would silently install a mismatched pair and break *every* handshake until the next renewal. Now the reload verifies with `X509Certificate.checkPrivateKey` and, on a mismatch, keeps the working cert and retries the next poll. The same check self-heals a mismatched persisted pair on load (covers a concurrent-first-boot race).
- **Warn instead of silently self-signing** when only one of `TLS_CERT`/`KEY` is set (a typo would otherwise quietly downgrade a client that trusted the intended real cert).
- Confirmed the self-signed key is *not* shipped to R2 — Litestream replicates only the SQLite DB, not arbitrary data-dir files.

## Notes

- `startBouncer` is now async (first-boot cert generation); `server.ts` starts it in the background. `node:slim` has no `openssl` CLI, so cert generation uses the pure-JS `selfsigned` dep.
- Tests: `bouncerCert.test.ts` (generation/persistence/permissions/match-verify/self-heal) + `bouncer.tls.test.ts` (TLS handshake, login over TLS, hot-swap on the wire, partial-renewal rejection). Full `npm run check` green; suite **1919 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)