### PR TITLE
docs: bouncer is soju-parity + TLS-by-default, not just ZNC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,10 +148,12 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_DCC_ALLOW_PRIVATE_HOSTS=false
 
 # ---------------------------------------------------------------------------
-# Built-in IRC bouncer (ZNC-style). OFF by default. When enabled, ordinary IRC
-# clients (WeeChat, irssi, Textual, HexChat, ...) can attach to your always-on
-# Lurker connections: shared upstream socket and nick, history playback on
-# attach, and messages sent from the client persist and sync to the web UI.
+# Built-in IRC bouncer (ZNC- and soju-compatible). OFF by default. When enabled,
+# any IRC client (from mIRC to modern IRCv3 clients like Halloy/gamja/Goguma) can
+# attach to your always-on Lurker connections: shared upstream socket and nick,
+# history playback on attach, messages persist + sync to the web UI. Capable
+# clients also get SASL, network discovery (soju.im/bouncer-networks), and
+# on-demand scrollback (draft/chathistory). Speaks TLS by default (see below).
 #
 # Log in from your IRC client with a server password of
 #   <username>:<password-or-api-token>              (single network)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Lurker runs as an always-on server that stays connected to IRC on your behalf, k
 - **Image uploads.** Paste, drag, or pick an image; Lurker optimizes it, uploads it to [x0.at](https://x0.at) or [catbox.moe](https://catbox.moe), inserts the link into your message, and keeps a history of all your uploads.
 - **Customizable UI.** The beautiful retro terminal-style interface has 40+ settings to customize it how you want, and you can freely pin and rearrange channels and DMs.
 - **Installable.** Lurker is a PWA — install it as a native-feeling app on your phone, Mac, or PC straight from the browser.
-- **Built-in bouncer.** Opt-in ZNC-style IRC listener: attach WeeChat, irssi, Textual, or any other IRC client to your always-on connection, with history playback on attach. See the [self-hosting guide](docs/SELF_HOSTING.md#irc-bouncer-attach-from-other-irc-clients).
+- **Built-in bouncer.** Opt-in, TLS-by-default IRC listener: attach any client — from mIRC to modern IRCv3 clients like Halloy, gamja, and Goguma — to your always-on connection. Speaks SASL, network discovery (`soju.im/bouncer-networks`), and on-demand scrollback (`draft/chathistory`) for capable clients, with history playback on attach for the rest. See the [self-hosting guide](docs/SELF_HOSTING.md#irc-bouncer-attach-from-other-irc-clients).
 
 # Screenshot (as macOS PWA)
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -194,7 +194,7 @@ Unset, it falls back to the upstream project link.
 
 ### IRC bouncer (attach from other IRC clients)
 
-Lurker can act as a ZNC-style bouncer: enable the built-in IRC listener and any ordinary IRC client (WeeChat, irssi, Textual, HexChat, …) can attach to the same always-on connection your web UI uses — same nick, same channels, recent history replayed on attach, and anything you send from the client lands in your Lurker history and web tabs too. Detaching never disconnects you from IRC.
+Lurker can act as a bouncer (ZNC- and soju-compatible): enable the built-in IRC listener and any ordinary IRC client (WeeChat, irssi, Textual, HexChat, …) can attach to the same always-on connection your web UI uses — same nick, same channels, recent history replayed on attach, and anything you send from the client lands in your Lurker history and web tabs too. Detaching never disconnects you from IRC.
 
 ```yaml
 environment:
@@ -208,6 +208,14 @@ Point your IRC client at the host/port with a **server password** of:
 - `username/networkname:secret` — to pick one of several (the network's name as shown in the web UI, or its numeric id)
 
 The secret can be your Lurker account password, but a **read-write API token** (web UI → **Settings → API tokens**) is the better choice — IRC clients store the server password in plaintext config files, and a token can be revoked without changing your password.
+
+Modern IRCv3 clients (Halloy, gamja, Goguma, …) get more than the server-password floor above:
+
+- **SASL** — log in with the same credential via SASL PLAIN instead of a server password.
+- **Network discovery** (`soju.im/bouncer-networks`) — the client lists and binds your networks itself, so you don't hardcode `username/networkname`; connect as just `username` and pick from the list.
+- **On-demand scrollback** (`draft/chathistory`) — page back through history on demand instead of relying only on the fixed replay-on-attach.
+
+These are negotiated automatically; plain clients that don't support them keep working over the server-password path.
 
 #### TLS
 

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1,12 +1,14 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// Built-in IRC bouncer (ZNC-style). An opt-in TCP/TLS listener that speaks the
-// IRC *server* protocol, so any ordinary IRC client (WeeChat, irssi, Textual,
-// HexChat, …) can attach to a user's always-on Lurker connection and use it
-// like a ZNC network: shared upstream socket, shared nick, history playback on
-// attach, and everything the client sends flows through the same ircManager
-// paths the web UI uses (so messages persist and fan out to web tabs too).
+// Built-in IRC bouncer (ZNC- and soju-compatible). An opt-in TCP/TLS listener
+// that speaks the IRC *server* protocol, so any ordinary IRC client (WeeChat,
+// irssi, Textual, HexChat, …) can attach to a user's always-on Lurker connection
+// and use it like a ZNC network: shared upstream socket, shared nick, history
+// playback on attach, and everything the client sends flows through the same
+// ircManager paths the web UI uses (so messages persist and fan out to web tabs
+// too). Modern clients also negotiate SASL, soju.im/bouncer-networks (network
+// discovery/BIND), and draft/chathistory (on-demand scrollback).
 //
 // Attach protocol. Two interchangeable credential transports:
 //   1. PASS (ZNC-compatible floor — dumb clients like mIRC):


### PR DESCRIPTION
The bouncer docs never got updated as the soju-parity work landed — the README, self-hosting guide, and `.env.example` still described a plain "ZNC-style" listener whose only trick is history-playback-on-attach. Everything since (#478–#481) is on `main`, so the docs now describe it accurately.

**Updated:**
- **README** — reframed from "ZNC-style IRC listener" to a TLS-by-default bouncer that any client from mIRC to modern IRCv3 clients (Halloy/gamja/Goguma) can attach to, with SASL, network discovery, and on-demand scrollback for capable clients.
- **docs/SELF_HOSTING.md** — intro now says "ZNC- and soju-compatible"; added a short "modern IRCv3 clients get more" note covering SASL, `soju.im/bouncer-networks` (connect as just `username` and pick your network from a list instead of hardcoding `username/network`), and `draft/chathistory`.
- **.env.example** — header now mentions the IRCv3 features + TLS-by-default.
- **bouncer.ts** — the module header comment, for accuracy.

**Deliberately left alone:** the accurate ZNC-*compatibility* references in the code (the PASS-login floor, `@clientid` parsing, the NICK-swap) — those describe real behavior, not stale framing. The marketing site uses "bouncer" in the always-on/IRCCloud sense (not stale); advertising the attach-external-clients capability there is a separate marketing call.

Docs-only; `npm run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)