### PR TITLE
Bouncer: preserve client-only message tags on upstream relay

### DIFF
--- a/server/services/bouncer.integration.test.ts
+++ b/server/services/bouncer.integration.test.ts
@@ -227,6 +227,38 @@ describe('live relay', () => {
     expect(line).toBe(':bob!b@h PRIVMSG #chan :hello there');
   });
 
+  it('relays a client TAGMSG with its client-only typing tag to the upstream', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'typer' });
+    const c = await harness.connect();
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    await c.waitForCommand('422');
+    c.send('@+typing=active TAGMSG #chan');
+    // PING is handled locally and in-order after TAGMSG, so a PONG proves the
+    // TAGMSG was already processed and relayed.
+    c.send('PING sync');
+    await c.waitFor((l) => l.includes('PONG'));
+    expect(acct.upstream.rawSent).toContain('@+typing=active TAGMSG #chan');
+  });
+
+  it('strips client-only tags when the upstream lacks message-tags', async () => {
+    const acct = harnessMod.seedAccount({ nick: 'plainnet' });
+    acct.upstream.messageTags = false;
+    const c = await harness.connect();
+    c.send(`PASS ${acct.user.username}:${acct.password}`);
+    c.send('NICK client');
+    c.send('USER client 0 * :client');
+    await c.waitForCommand('422');
+    c.send('@+typing=active TAGMSG #chan');
+    c.send('PING sync');
+    await c.waitFor((l) => l.includes('PONG'));
+    // The bare command still forwards; the tag prefix is dropped so a non-IRCv3
+    // server doesn't parse `@+typing=active` as the command.
+    expect(acct.upstream.rawSent).toContain('TAGMSG #chan');
+    expect(acct.upstream.rawSent.some((l) => l.includes('+typing'))).toBe(false);
+  });
+
   it('never forwards a post-registration AUTHENTICATE to the upstream', async () => {
     const acct = harnessMod.seedAccount({ nick: 'noauth' });
     const c = await harness.connect();

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -81,11 +81,24 @@ describe('parseClientLine', () => {
     });
   });
 
-  it('strips client message tags', () => {
+  it('strips server-authoritative message tags but keeps client-only ones', () => {
     expect(parseClientLine('@label=x;time=y PRIVMSG #c :hi')).toEqual({
       command: 'PRIVMSG',
       params: ['#c', 'hi'],
     });
+    expect(parseClientLine('@+typing=active TAGMSG #c')).toEqual({
+      command: 'TAGMSG',
+      params: ['#c'],
+      clientTags: '+typing=active',
+    });
+    // Mixed: drop the server tags (msgid/time), keep the `+`-prefixed ones.
+    expect(parseClientLine('@time=y;+typing=paused;msgid=z TAGMSG #c')).toEqual({
+      command: 'TAGMSG',
+      params: ['#c'],
+      clientTags: '+typing=paused',
+    });
+    // A lone `+` with no key is not a valid client tag.
+    expect(parseClientLine('@+ TAGMSG #c')?.clientTags).toBeUndefined();
   });
 
   it('strips CR/LF/NUL and rejects empty lines', () => {
@@ -119,6 +132,15 @@ describe('rebuildLine', () => {
 
   it('handles a bare command', () => {
     expect(rebuildLine({ command: 'LUSERS', params: [] })).toBe('LUSERS');
+  });
+
+  it('re-attaches preserved client-only tags for upstream relay', () => {
+    // Round-trips typing so halloy → bouncer → network keeps its payload.
+    const parsed = parseClientLine('@+typing=active TAGMSG #chan')!;
+    expect(rebuildLine(parsed)).toBe('@+typing=active TAGMSG #chan');
+    expect(rebuildLine({ command: 'TAGMSG', params: ['#c'], clientTags: '+draft/react=👍' })).toBe(
+      '@+draft/react=👍 TAGMSG #c',
+    );
   });
 });
 

--- a/server/services/bouncer.test.ts
+++ b/server/services/bouncer.test.ts
@@ -101,6 +101,16 @@ describe('parseClientLine', () => {
     expect(parseClientLine('@+ TAGMSG #c')?.clientTags).toBeUndefined();
   });
 
+  it('drops the whole tag set when it exceeds the client-tag byte cap', () => {
+    // A client could otherwise pad the tag section up to the input-buffer limit
+    // and have the bouncer relay an oversized line that drops the shared socket.
+    const huge = Array.from({ length: 1200 }, (_, i) => `+t${i}=x`).join(';');
+    const parsed = parseClientLine(`@${huge} TAGMSG #c`)!;
+    expect(parsed.command).toBe('TAGMSG'); // command still parses
+    expect(parsed.params).toEqual(['#c']);
+    expect(parsed.clientTags).toBeUndefined(); // tags dropped, not truncated
+  });
+
   it('strips CR/LF/NUL and rejects empty lines', () => {
     expect(parseClientLine('\r\n')).toBeNull();
     expect(parseClientLine('')).toBeNull();

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -159,6 +159,9 @@ const HEARTBEAT_INTERVAL_MS = 45_000;
 const HEARTBEAT_PING_AFTER_MS = 90_000;
 const HEARTBEAT_REAP_AFTER_MS = 240_000;
 const MAX_INPUT_BUFFER = 64 * 1024;
+// IRCv3 caps the client-only tag section at 4096 bytes including the leading
+// `@` and the trailing space; 4094 is the room left for the tag content we relay.
+const MAX_CLIENT_TAG_BYTES = 4094;
 // How often to check the TLS cert file for a renewal and hot-swap it. Renewal
 // is never time-critical (certs renew well before expiry), so a slow poll is
 // fine and far simpler and more robust than fs.watch across symlink renames.
@@ -218,9 +221,12 @@ export interface ParsedClientLine {
   params: string[];
   // Client-only message tags (the `+`-prefixed ones, e.g. `+typing`,
   // `+draft/react`) exactly as the client sent them, joined by `;` with no
-  // leading `@`. Preserved so TAGMSG/PRIVMSG relayed upstream keep their
-  // typing/reaction payload; server-authoritative tags (time, account, msgid,
-  // label, batch) are dropped here — mirrors soju's copyClientTags.
+  // leading `@`. Preserved so a relayed TAGMSG (and other commands routed
+  // through the verbatim `default:` relay) keeps its typing/reaction payload.
+  // NOTE: PRIVMSG/NOTICE route through ircManager.send, which carries no tags,
+  // so tags on a message body are NOT forwarded yet (tracked separately).
+  // Server-authoritative tags (time, account, msgid, label, batch) are dropped
+  // here — mirrors soju's copyClientTags.
   clientTags?: string;
 }
 
@@ -243,7 +249,13 @@ export function parseClientLine(raw: string): ParsedClientLine | null {
       .slice(1, sp)
       .split(';')
       .filter((t) => t.startsWith('+') && t.length > 1);
-    if (kept.length > 0) clientTags = kept.join(';');
+    // Bound what we'll relay upstream. The IRCv3 client-tag section is capped
+    // at 4096 bytes (`@` + tags + space); a client could otherwise pad a line
+    // up to MAX_INPUT_BUFFER with `+`-tags and have us forward an oversized
+    // line that the network drops — killing the upstream socket shared by
+    // every other session on this account. Over the limit → forward tagless.
+    const joined = kept.join(';');
+    if (kept.length > 0 && joined.length <= MAX_CLIENT_TAG_BYTES) clientTags = joined;
     line = line.slice(sp + 1);
   }
   line = line.replace(/^ +/, '');
@@ -1652,9 +1664,20 @@ class BouncerSession {
       default:
         // Everything else (MODE, TOPIC, WHOIS, WHO, NAMES, LIST, KICK, INVITE,
         // NICK, …) forwards verbatim; replies come back via the raw relay.
-        conn.raw(rebuildLine(msg));
+        this.relayRaw(conn, msg);
         return;
     }
+  }
+
+  // Forward a parsed client line to the upstream, re-attaching its client-only
+  // tags only when the network speaks message-tags. On a non-IRCv3 server a
+  // leading `@+tag …` prefix is parsed as the command, mangling the real
+  // command into ERR_UNKNOWNCOMMAND — the same hazard IrcConnection.sendTyping
+  // guards against — so drop the tags and forward the bare command there.
+  private relayRaw(conn: IrcConnection, msg: ParsedClientLine): void {
+    const forward =
+      msg.clientTags && !conn.supportsMessageTags() ? { ...msg, clientTags: undefined } : msg;
+    conn.raw(rebuildLine(forward));
   }
 
   private handleClientMessage(msg: ParsedClientLine): void {
@@ -1673,8 +1696,9 @@ class BouncerSession {
       const isAction = text.startsWith('\u0001ACTION ') || text.startsWith('\u0001ACTION\u0001');
       if (text.startsWith('\u0001') && !isAction) {
         // Non-ACTION CTCP (VERSION, PING, replies…): forward on the wire
-        // untouched; these aren't conversation and don't persist.
-        conn.raw(rebuildLine({ command: msg.command, params: [target, text] }));
+        // untouched; these aren't conversation and don't persist. Spread msg so
+        // any client-only tags ride along (gated on upstream message-tags).
+        this.relayRaw(conn, { ...msg, params: [target, text] });
         continue;
       }
       // /me actions and NOTICEs aren't encrypted yet, so ircManager refuses

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -216,15 +216,34 @@ export function resetAuthThrottle(): void {
 export interface ParsedClientLine {
   command: string;
   params: string[];
+  // Client-only message tags (the `+`-prefixed ones, e.g. `+typing`,
+  // `+draft/react`) exactly as the client sent them, joined by `;` with no
+  // leading `@`. Preserved so TAGMSG/PRIVMSG relayed upstream keep their
+  // typing/reaction payload; server-authoritative tags (time, account, msgid,
+  // label, batch) are dropped here — mirrors soju's copyClientTags.
+  clientTags?: string;
 }
 
-/** Parse one client→server IRC line: optional @tags and :prefix are ignored. */
+/**
+ * Parse one client→server IRC line. The `:prefix` is ignored; message tags are
+ * dropped EXCEPT client-only (`+`-prefixed) tags, which are retained on
+ * `clientTags` so they can be relayed upstream (typing, reactions, …).
+ */
 export function parseClientLine(raw: string): ParsedClientLine | null {
   // eslint-disable-next-line no-control-regex
   let line = raw.replace(/[\r\n\u0000]/g, '');
+  let clientTags: string | undefined;
   if (line.startsWith('@')) {
     const sp = line.indexOf(' ');
     if (sp === -1) return null;
+    // Keep only client-only tags (IRCv3 `+`-prefixed); server-authoritative
+    // tags a client must not set (time, account, msgid, label, batch, …) are
+    // discarded. Matches soju's copyClientTags.
+    const kept = line
+      .slice(1, sp)
+      .split(';')
+      .filter((t) => t.startsWith('+') && t.length > 1);
+    if (kept.length > 0) clientTags = kept.join(';');
     line = line.slice(sp + 1);
   }
   line = line.replace(/^ +/, '');
@@ -247,16 +266,21 @@ export function parseClientLine(raw: string): ParsedClientLine | null {
   const command = parts.shift()!.toUpperCase();
   const params = parts;
   if (trailing !== null) params.push(trailing);
-  return { command, params };
+  return { command, params, clientTags };
 }
 
-/** Rebuild a parsed client line for verbatim upstream forwarding. */
-export function rebuildLine({ command, params }: ParsedClientLine): string {
-  if (params.length === 0) return command;
+/**
+ * Rebuild a parsed client line for verbatim upstream forwarding, re-attaching
+ * any preserved client-only tags as an `@tag;tag ` prefix so typing/reaction
+ * payloads survive the round-trip to the network.
+ */
+export function rebuildLine({ command, params, clientTags }: ParsedClientLine): string {
+  const prefix = clientTags ? `@${clientTags} ` : '';
+  if (params.length === 0) return prefix + command;
   const head = params.slice(0, -1);
   const last = params[params.length - 1];
   const needsTrailing = last === '' || last.includes(' ') || last.startsWith(':');
-  return [command, ...head, needsTrailing ? `:${last}` : last].join(' ');
+  return prefix + [command, ...head, needsTrailing ? `:${last}` : last].join(' ');
 }
 
 export interface ParsedLogin {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3841,6 +3841,12 @@ export class IrcConnection {
     // eslint-disable-next-line no-control-regex
     this.client.raw(line.replace(/[\u000d\u000a\u0000]/g, ''));
   }
+  // Whether the network negotiated IRCv3 message-tags. Client-only tags
+  // (+typing, +draft/react, …) and TAGMSG only mean anything to a server that
+  // speaks it; forwarding them to one that doesn't yields ERR_UNKNOWNCOMMAND.
+  supportsMessageTags(): boolean {
+    return (this.client.network?.cap?.enabled || []).includes('message-tags');
+  }
   sendTyping(target: string, state: string): void {
     // +typing is a client-only tag carried over TAGMSG, which only exists when
     // the server negotiated the message-tags capability. Networks that don't
@@ -3848,7 +3854,7 @@ export class IrcConnection {
     // ERR_UNKNOWNCOMMAND, which our 'irc error' handler surfaces as a toast —
     // so an ungated send spams an error on each keystroke. Typing indicators
     // are a best-effort nicety; no cap, no send.
-    if (!(this.client.network?.cap?.enabled || []).includes('message-tags')) return;
+    if (!this.supportsMessageTags()) return;
     // Suppress typing TAGMSGs to a target the server has refused our messages to
     // (a +R/+M channel needing a registered nick to speak, a +R user, ...).
     // Every typing TAGMSG to it bounces as another send rejection; we learned it

--- a/server/test-utils/bouncerHarness.ts
+++ b/server/test-utils/bouncerHarness.ts
@@ -46,6 +46,10 @@ export class FakeUpstream {
   channels = new Map<string, FakeChannel>();
   // Lines the bouncer forwarded to the upstream network via conn.raw().
   rawSent: string[] = [];
+  // Whether this fake network negotiated IRCv3 message-tags. The bouncer gates
+  // client-only tag relay on it (mirrors IrcConnection.supportsMessageTags);
+  // flip to false in a test to exercise the non-IRCv3 strip path.
+  messageTags = true;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   client: any;
 
@@ -71,6 +75,10 @@ export class FakeUpstream {
 
   raw(line: string): void {
     this.rawSent.push(line);
+  }
+
+  supportsMessageTags(): boolean {
+    return this.messageTags;
   }
 
   // Simulate the upstream network sending a raw line down to attached clients.


### PR DESCRIPTION
## Problem

When attached to the built-in bouncer, an IRC client (e.g. halloy) **receives** typing notifications but its own outbound typing never reaches the network. Same for standalone reactions.

Root cause: `parseClientLine` skipped past the entire `@tags` segment, dropping every message tag before the line was forwarded upstream. Inbound worked because the raw relay passes upstream tags through verbatim once `message-tags` is negotiated — so only the **outbound** direction was broken.

## Fix

Match soju's `copyClientTags`: keep **client-only** (`+`-prefixed) tags — `+typing`, `+draft/react`, … — and drop the server-authoritative ones a client must not assert (`time`, `account`, `msgid`, `label`, `batch`).

- `parseClientLine` retains the kept tags on a new `ParsedClientLine.clientTags` field.
- `rebuildLine` re-attaches them as an `@…` prefix, so the `default:` forward path (where `TAGMSG` lands) relays `@+typing=active TAGMSG #chan` verbatim.

Inbound typing already proves the upstream connection has `message-tags` negotiated, so the forwarded `TAGMSG` is accepted.

## Tests

- `parseClientLine`: drops server tags, keeps `+`-prefixed ones, handles mixed sets and a bare `+`.
- `rebuildLine`: round-trips a preserved-tag line for upstream relay.

Full suite: 1921 passing; `npm run check` clean.

## Follow-up

Client-only tags on **PRIVMSG** (e.g. `+draft/reply`) still drop, because PRIVMSG routes through `ircManager.send` rather than the raw relay — tracked in #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)