### PR TITLE
Join keyed (+k) channels, surface channel modes, and persist keys for auto-rejoin

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -37,6 +37,12 @@ export const ENCRYPTED_NETWORK_COLUMNS = [
   'connect_commands',
 ] as const;
 
+// Channel-scoped secrets encrypted at rest on hosted cells, same envelope as the
+// network columns above. The +k channel key is a credential of the same class
+// (it gates entry to the channel), so it gets the same treatment: ciphertext in
+// the R2-replicated SQLite, plaintext passthrough on self-host.
+export const ENCRYPTED_CHANNEL_COLUMNS = ['key'] as const;
+
 // FTS5 maintains its own shadow tables (messages_fts_data, _idx, _content,
 // _docsize, _config). Only the virtual `messages_fts` itself surfaces in
 // sqlite_master as a row the registry needs to address; the shadows are
@@ -117,7 +123,7 @@ export const EXPORT_TABLES = Object.freeze({
     pk: 'id',
     rekeyOnImport: true,
     fkRekey: { network_id: 'networks' },
-    columns: ['id', 'network_id', 'name', 'joined', 'created_at'],
+    columns: ['id', 'network_id', 'name', 'joined', 'created_at', 'key'],
   },
 
   // Friends/contacts. contacts is a rekey root (its id is referenced by

--- a/server/db/foldBufferCase.test.ts
+++ b/server/db/foldBufferCase.test.ts
@@ -19,6 +19,8 @@ let createNetwork: typeof import('./networks.js').createNetwork;
 let insertMessage: typeof import('./messages.js').insertMessage;
 let setReadState: typeof import('./bufferReads.js').setReadState;
 let foldBufferCase: typeof import('./foldBufferCase.js').foldBufferCase;
+let upsertChannel: typeof import('./networks.js').upsertChannel;
+let listChannels: typeof import('./networks.js').listChannels;
 let userId: number;
 
 const T = '2026-06-01T00:00:00.000Z';
@@ -26,7 +28,7 @@ const T = '2026-06-01T00:00:00.000Z';
 beforeAll(async () => {
   db = (await import('./index.js')).default;
   ({ createUser } = await import('./users.js'));
-  ({ createNetwork } = await import('./networks.js'));
+  ({ createNetwork, upsertChannel, listChannels } = await import('./networks.js'));
   ({ insertMessage } = await import('./messages.js'));
   ({ setReadState } = await import('./bufferReads.js'));
   ({ foldBufferCase } = await import('./foldBufferCase.js'));
@@ -81,6 +83,23 @@ describe('foldBufferCase', () => {
 
     // Channel and DM each collapse onto the majority casing; no stray rows left.
     expect(targetCounts(net)).toEqual({ '#CoolChan': 4, Bob: 3 });
+  });
+
+  it('preserves a +k channel key when folding a case-forked channel', () => {
+    const net = freshNetwork();
+    // '#Secret' is the majority casing (canon); the stray '#secret' variant is
+    // the one carrying the key — the merge must carry it onto the canon, not
+    // drop it when the stray row is deleted.
+    seed(net, '#Secret', 3);
+    seed(net, '#secret', 1);
+    upsertChannel(net, '#Secret', true); // canon row, no key
+    upsertChannel(net, '#secret', true, 'strays-key'); // stray row holds the key
+
+    foldBufferCase(db, { scope: 'all' });
+
+    const chans = listChannels(net);
+    expect(chans.map((c) => c.name)).toEqual(['#Secret']); // variant gone
+    expect(chans[0].key).toBe('strays-key'); // key survived the merge
   });
 
   it('channels-only scope leaves DM forks untouched', () => {

--- a/server/db/foldBufferCase.ts
+++ b/server/db/foldBufferCase.ts
@@ -195,16 +195,20 @@ export function foldBufferCase(
       }
 
       // channels: UNIQUE(network_id, name). Fold to canon (joined if ANY variant
-      // was joined, earliest created_at), then drop the off-case variant.
+      // was joined, earliest created_at, and any +k key from either side), then
+      // drop the off-case variant. Carrying `key` here is essential — without it
+      // the merge would strip the channel key off a case-forked keyed channel
+      // and it would fail to auto-rejoin after the next reconnect.
       db.exec(`
-        INSERT INTO channels (network_id, name, joined, created_at)
-          SELECT ch.network_id, c.canon, ch.joined, ch.created_at
+        INSERT INTO channels (network_id, name, joined, created_at, key)
+          SELECT ch.network_id, c.canon, ch.joined, ch.created_at, ch.key
           FROM channels ch JOIN _buf_canon c
             ON c.network_id = ch.network_id AND c.lkey = lower(ch.name)
           WHERE ${pred('ch.name')} AND c.canon <> ch.name
         ON CONFLICT(network_id, name) DO UPDATE SET
           joined = MAX(channels.joined, excluded.joined),
-          created_at = MIN(channels.created_at, excluded.created_at)
+          created_at = MIN(channels.created_at, excluded.created_at),
+          key = COALESCE(channels.key, excluded.key)
       `);
       db.exec(`
         DELETE FROM channels WHERE ${pred('name')} AND EXISTS (

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -807,6 +807,10 @@ ensureColumn('messages', 'extra', 'TEXT');
 ensureColumn('messages', 'userhost', 'TEXT');
 ensureColumn('networks', 'sasl_account', 'TEXT');
 ensureColumn('networks', 'sasl_password', 'TEXT');
+// The +k channel key, so a keyed channel can be auto-rejoined with its key
+// after a reconnect/restart (like soju/znc/thelounge). Stored encrypted at rest
+// on hosted cells (see secretCrypto), NULL for keyless channels.
+ensureColumn('channels', 'key', 'TEXT');
 ensureColumn('networks', 'trusted_certificates', 'INTEGER NOT NULL DEFAULT 1');
 // Newline-delimited raw IRC commands fired after RPL_WELCOME, IRCCloud-style.
 // Supports `WAIT <seconds>` lines that pause before the next command.

--- a/server/db/networks.test.ts
+++ b/server/db/networks.test.ts
@@ -20,12 +20,24 @@ let updateNetwork: typeof import('./networks.js').updateNetwork;
 let ownsNetwork: typeof import('./networks.js').ownsNetwork;
 let listNetworksForUser: typeof import('./networks.js').listNetworksForUser;
 let reorderNetworks: typeof import('./networks.js').reorderNetworks;
+let upsertChannel: typeof import('./networks.js').upsertChannel;
+let listChannels: typeof import('./networks.js').listChannels;
+let setChannelKey: typeof import('./networks.js').setChannelKey;
 
 beforeAll(async () => {
   db = (await import('./index.js')).default;
   ({ createUser } = await import('./users.js'));
-  ({ createNetwork, getNetwork, updateNetwork, ownsNetwork, listNetworksForUser, reorderNetworks } =
-    await import('./networks.js'));
+  ({
+    createNetwork,
+    getNetwork,
+    updateNetwork,
+    ownsNetwork,
+    listNetworksForUser,
+    reorderNetworks,
+    upsertChannel,
+    listChannels,
+    setChannelKey,
+  } = await import('./networks.js'));
 });
 
 afterAll(() => {
@@ -218,5 +230,57 @@ describe('network secrets without an encryption key (self-host)', () => {
       })!;
       expect(net.trusted_certificates).toBe(0);
     });
+  });
+});
+
+describe('channel key persistence', () => {
+  let seq = 0;
+  function net(): number {
+    return createNetwork(createUser(`chk-${seq++}`).id, {
+      name: 'n',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!.id;
+  }
+
+  it('stores a key on join and returns it from listChannels', () => {
+    const id = net();
+    upsertChannel(id, '#secret', true, 'hunter2');
+    const ch = listChannels(id).find((c) => c.name === '#secret');
+    expect(ch!.key).toBe('hunter2');
+    expect(ch!.joined).toBe(1);
+  });
+
+  it('preserves the stored key when a later keyless upsert re-joins the channel', () => {
+    const id = net();
+    upsertChannel(id, '#secret', true, 'hunter2');
+    // A plain re-join / NAMES / reopen passes no key — it must not wipe it.
+    upsertChannel(id, '#secret', true);
+    expect(listChannels(id).find((c) => c.name === '#secret')!.key).toBe('hunter2');
+  });
+
+  it('updates the key when a new one is supplied', () => {
+    const id = net();
+    upsertChannel(id, '#secret', true, 'old');
+    upsertChannel(id, '#secret', true, 'new');
+    expect(listChannels(id).find((c) => c.name === '#secret')!.key).toBe('new');
+  });
+
+  it('setChannelKey updates and clears (null) the key, case-insensitively', () => {
+    const id = net();
+    upsertChannel(id, '#Secret', true, 'first');
+    // MODE arrives with a different case than the joined name.
+    setChannelKey(id, '#secret', 'second');
+    expect(listChannels(id).find((c) => c.name === '#Secret')!.key).toBe('second');
+    setChannelKey(id, '#SECRET', null);
+    expect(listChannels(id).find((c) => c.name === '#Secret')!.key).toBeNull();
+  });
+
+  it('defaults to a null key for a channel joined without one', () => {
+    const id = net();
+    upsertChannel(id, '#open', true);
+    expect(listChannels(id).find((c) => c.name === '#open')!.key).toBeNull();
   });
 });

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -3,13 +3,13 @@
 
 import db from './index.js';
 import { encryptSecret, decryptSecret, isEncrypted, hasSecretKey } from '../utils/secretCrypto.js';
-import { ENCRYPTED_NETWORK_COLUMNS } from './exportSchema.js';
+import { ENCRYPTED_NETWORK_COLUMNS, ENCRYPTED_CHANNEL_COLUMNS } from './exportSchema.js';
 
 // The list of encrypted network-secret columns lives in db/exportSchema.ts (a
 // db-singleton-free module) so the worker-safe export builder can import it
 // without pulling this module's db connection into a worker. Re-exported here
 // for the callers that have always reached for it via db/networks.js.
-export { ENCRYPTED_NETWORK_COLUMNS };
+export { ENCRYPTED_NETWORK_COLUMNS, ENCRYPTED_CHANNEL_COLUMNS };
 
 // Decrypt the secret columns on a freshly-read row, in place. No-op for legacy
 // plaintext and when no key is configured (decryptSecret passes those through).
@@ -48,6 +48,8 @@ export interface Channel {
   name: string;
   joined: number;
   created_at: string;
+  // The +k channel key (decrypted on read), or null for a keyless channel.
+  key: string | null;
 }
 
 /** Fields accepted when creating or updating a network. */
@@ -220,6 +222,31 @@ export function backfillEncryptNetworkSecrets(): { scanned: number; encrypted: n
   return { scanned: rows.length, encrypted };
 }
 
+// Sibling of backfillEncryptNetworkSecrets for the channels.key column: wrap any
+// plaintext channel key once a key is configured (e.g. a plaintext key imported
+// onto a keyed cell, or one written before the key was set). No-op without a
+// key. Idempotent — isEncrypted() skips already-wrapped values.
+export function backfillEncryptChannelKeys(): { scanned: number; encrypted: number } {
+  if (!hasSecretKey()) return { scanned: 0, encrypted: 0 };
+  const rows = db.prepare(`SELECT id, key FROM channels`).all() as Array<{
+    id: number;
+    key: string | null;
+  }>;
+  const update = db.prepare(`UPDATE channels SET key = ? WHERE id = ?`);
+  let encrypted = 0;
+  const tx = db.transaction(() => {
+    for (const row of rows) {
+      const v = row.key;
+      if (typeof v === 'string' && v !== '' && !isEncrypted(v)) {
+        update.run(encryptSecret(v), row.id);
+        encrypted += 1;
+      }
+    }
+  });
+  tx();
+  return { scanned: rows.length, encrypted };
+}
+
 // Rewrite the sidebar order for one user. The caller must supply exactly the
 // user's current set of network ids (no adds, no drops); the function returns
 // null on mismatch so the caller can echo authoritative state back. On success
@@ -249,26 +276,60 @@ export function reorderNetworks(userId: number, ids: unknown[]): number[] | null
   return [...numericIds];
 }
 
+// Decrypt the channel key in place. No-op for legacy plaintext / no key.
+function decryptChannel<T extends Channel | undefined>(row: T): T {
+  if (row) row.key = decryptSecret(row.key);
+  return row;
+}
+
 export function listChannels(networkId: number): Channel[] {
-  return db
-    .prepare('SELECT * FROM channels WHERE network_id = ? ORDER BY name')
-    .all(networkId) as Channel[];
+  return (
+    db
+      .prepare('SELECT * FROM channels WHERE network_id = ? ORDER BY name')
+      .all(networkId) as Channel[]
+  ).map((row) => decryptChannel(row)!);
 }
 
 export function upsertChannel(
   networkId: number,
   name: string,
   joined: boolean | number,
+  key?: string | null,
 ): Channel | undefined {
-  db.prepare(
-    `
-    INSERT INTO channels (network_id, name, joined) VALUES (?, ?, ?)
-    ON CONFLICT (network_id, name) DO UPDATE SET joined = excluded.joined
-  `,
-  ).run(networkId, name, joined ? 1 : 0);
-  return db
-    .prepare('SELECT * FROM channels WHERE network_id = ? AND name = ?')
-    .get(networkId, name) as Channel | undefined;
+  // key === undefined means "don't touch the stored key" — most callers (NAMES,
+  // reopen, part/kick) don't know it and must not clobber a key set at join.
+  // A provided value (string or null) is written, so an explicit null clears it.
+  if (key === undefined) {
+    db.prepare(
+      `
+      INSERT INTO channels (network_id, name, joined) VALUES (?, ?, ?)
+      ON CONFLICT (network_id, name) DO UPDATE SET joined = excluded.joined
+    `,
+    ).run(networkId, name, joined ? 1 : 0);
+  } else {
+    db.prepare(
+      `
+      INSERT INTO channels (network_id, name, joined, key) VALUES (?, ?, ?, ?)
+      ON CONFLICT (network_id, name) DO UPDATE SET joined = excluded.joined, key = excluded.key
+    `,
+    ).run(networkId, name, joined ? 1 : 0, encryptSecret(key));
+  }
+  return decryptChannel(
+    db.prepare('SELECT * FROM channels WHERE network_id = ? AND name = ?').get(networkId, name) as
+      | Channel
+      | undefined,
+  );
+}
+
+// Update just the stored +k key for a channel (from a live MODE +k/-k), matched
+// case-insensitively since the MODE target case may differ from the joined name.
+// `null` clears it (on -k). No-op if the channel row doesn't exist.
+export function setChannelKey(networkId: number, name: string, key: string | null): void {
+  db.prepare('UPDATE channels SET key = ? WHERE network_id = ? AND name = ? COLLATE NOCASE').run(
+    encryptSecret(key),
+    networkId,
+    name,
+  );
 }
 
 export function deleteChannel(networkId: number, name: string): void {

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -228,17 +228,20 @@ export function backfillEncryptNetworkSecrets(): { scanned: number; encrypted: n
 // key. Idempotent — isEncrypted() skips already-wrapped values.
 export function backfillEncryptChannelKeys(): { scanned: number; encrypted: number } {
   if (!hasSecretKey()) return { scanned: 0, encrypted: 0 };
-  const rows = db.prepare(`SELECT id, key FROM channels`).all() as Array<{
+  // Only rows with an actual key can need wrapping — most channels are keyless,
+  // so filter at the SQL level rather than scanning the whole table each boot.
+  const rows = db
+    .prepare(`SELECT id, key FROM channels WHERE key IS NOT NULL AND key != ''`)
+    .all() as Array<{
     id: number;
-    key: string | null;
+    key: string;
   }>;
   const update = db.prepare(`UPDATE channels SET key = ? WHERE id = ?`);
   let encrypted = 0;
   const tx = db.transaction(() => {
     for (const row of rows) {
-      const v = row.key;
-      if (typeof v === 'string' && v !== '' && !isEncrypted(v)) {
-        update.run(encryptSecret(v), row.id);
+      if (!isEncrypted(row.key)) {
+        update.run(encryptSecret(row.key), row.id);
         encrypted += 1;
       }
     }

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -41,8 +41,8 @@ const fakeManager = {
     this.calls.push(['listContacts', userId]);
     return [];
   },
-  joinChannel(userId: number, networkId: number, channel: string) {
-    this.calls.push(['joinChannel', userId, networkId, channel]);
+  joinChannel(userId: number, networkId: number, channel: string, key?: string) {
+    this.calls.push(['joinChannel', userId, networkId, channel, key]);
     return this.joinReturn !== undefined ? this.joinReturn : true;
   },
   partChannel(userId: number, networkId: number, channel: string, reason: string) {

--- a/server/routes/networks.test.ts
+++ b/server/routes/networks.test.ts
@@ -269,6 +269,18 @@ describe('join / part', () => {
     expect((await aliceAgent.post(`/api/networks/${id}/part`).send({})).status).toBe(400);
   });
 
+  it('forwards an optional channel key to ircManager', async () => {
+    const net = await makeNet(aliceAgent, { name: 'keyed' });
+    const id = net.body.network.id;
+    fakeManager.calls = [];
+    expect(
+      (await aliceAgent.post(`/api/networks/${id}/join`).send({ channel: '#x', key: 'sekret' }))
+        .status,
+    ).toBe(200);
+    const call = fakeManager.calls.find(([m]) => m === 'joinChannel');
+    expect(call).toEqual(['joinChannel', expect.any(Number), id, '#x', 'sekret']);
+  });
+
   it('returns 409 when ircManager reports not-connected', async () => {
     const net = await makeNet(aliceAgent, { name: 'offline' });
     const id = net.body.network.id;

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -181,12 +181,12 @@ router.post('/:id/reconnect', (req: Request, res: Response) => {
 
 router.post('/:id/join', (req: Request, res: Response) => {
   const id = Number(req.params.id);
-  const { channel } = req.body || {};
+  const { channel, key } = req.body || {};
   if (!channel) {
     res.status(400).json({ error: 'channel required' });
     return;
   }
-  if (!ircManager.joinChannel(req.user!.id, id, channel)) {
+  if (!ircManager.joinChannel(req.user!.id, id, channel, key)) {
     res.status(409).json({ error: 'network not connected' });
     return;
   }

--- a/server/server.ts
+++ b/server/server.ts
@@ -12,7 +12,7 @@ import { getNodeSecret } from './middleware/nodeAuth.js';
 import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
-import { backfillEncryptNetworkSecrets } from './db/networks.js';
+import { backfillEncryptNetworkSecrets, backfillEncryptChannelKeys } from './db/networks.js';
 import { backfillEncryptE2eSecrets } from './db/e2e.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
@@ -95,6 +95,13 @@ const wrapped = backfillEncryptNetworkSecrets();
 if (wrapped.encrypted > 0) {
   console.log(`[lurker] encrypted ${wrapped.encrypted} network-secret row(s) at rest`);
   systemLog.log({ scope: 'server', text: `Encrypted ${wrapped.encrypted} network-secret row(s)` });
+}
+
+// Same re-seal for stored +k channel keys.
+const wrappedKeys = backfillEncryptChannelKeys();
+if (wrappedKeys.encrypted > 0) {
+  console.log(`[lurker] encrypted ${wrappedKeys.encrypted} channel-key row(s) at rest`);
+  systemLog.log({ scope: 'server', text: `Encrypted ${wrappedKeys.encrypted} channel-key row(s)` });
 }
 
 // Same re-seal for the RPE2E keyring's secret columns (identity privkey +

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -47,9 +47,9 @@ import { findUserByUsername, getPasswordHash } from '../db/users.js';
 import type { User } from '../db/users.js';
 import { verifyPassword, hashPassword } from './password.js';
 import { hashToken, findActiveByHash, touchLastUsed } from '../db/apiTokens.js';
-import { listNetworksForUser, upsertChannel } from '../db/networks.js';
+import { listNetworksForUser } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
-import { reopenBuffer, closedKeySetForUser } from '../db/closedBuffers.js';
+import { closedKeySetForUser } from '../db/closedBuffers.js';
 import {
   listMessages,
   listBuffersForNetwork,
@@ -1632,16 +1632,10 @@ class BouncerSession {
         const channels = first.split(',').filter(Boolean);
         const keys = (msg.params[1] || '').split(',');
         channels.forEach((channel, i) => {
+          // joinChannel now carries the optional key: it persists it (encrypted,
+          // for keyed auto-rejoin), reopens the buffer, and JOINs with the key.
           const key = (keys[i] || '').trim();
-          if (key) {
-            // ircManager.joinChannel can't carry a key; persist + reopen the
-            // buffer the same way it does, then JOIN with the key ourselves.
-            upsertChannel(this.networkId, channel, true);
-            reopenBuffer(this.userId, this.networkId, channel);
-            conn.raw(`JOIN ${channel} ${key}`);
-          } else {
-            ircManager.joinChannel(this.userId, this.networkId, channel);
-          }
+          ircManager.joinChannel(this.userId, this.networkId, channel, key || undefined);
         });
         return;
       }

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -25,6 +25,7 @@ import {
   EXPORT_TABLES,
   EXPORT_FORMAT_VERSION,
   ENCRYPTED_NETWORK_COLUMNS,
+  ENCRYPTED_CHANNEL_COLUMNS,
 } from '../db/exportSchema.js';
 import { decryptSecret } from '../utils/secretCrypto.js';
 
@@ -237,6 +238,14 @@ export async function buildExportZip(
     if (table === 'networks') {
       for (const row of rows) {
         for (const col of ENCRYPTED_NETWORK_COLUMNS) {
+          row[col] = decryptSecret(row[col] as string | null);
+        }
+      }
+    }
+    // Same portability decrypt for the +k channel key.
+    if (table === 'channels') {
+      for (const row of rows) {
+        for (const col of ENCRYPTED_CHANNEL_COLUMNS) {
           row[col] = decryptSecret(row[col] as string | null);
         }
       }

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -30,7 +30,7 @@ import { setImmediate as yieldToEventLoop } from 'node:timers/promises';
 import type { Statement, RunResult } from 'better-sqlite3';
 import db from '../db/index.js';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION, IMPORT_ORDER } from '../db/exportSchema.js';
-import { ENCRYPTED_NETWORK_COLUMNS } from '../db/networks.js';
+import { ENCRYPTED_NETWORK_COLUMNS, ENCRYPTED_CHANNEL_COLUMNS } from '../db/networks.js';
 import { encryptSecret } from '../utils/secretCrypto.js';
 import ignoreRulesService from './ignoreRulesService.js';
 import type { IgnorePatternKind } from '../db/ignoredMasks.js';
@@ -200,6 +200,12 @@ function insertTable(
       // secure behavior during import.
       if (row.trusted_certificates === undefined) row.trusted_certificates = 1;
       for (const col of ENCRYPTED_NETWORK_COLUMNS) {
+        if (typeof row[col] === 'string') row[col] = encryptSecret(row[col] as string);
+      }
+    }
+    // Same re-encrypt for the imported +k channel key.
+    if (table === 'channels') {
+      for (const col of ENCRYPTED_CHANNEL_COLUMNS) {
         if (typeof row[col] === 'string') row[col] = encryptSecret(row[col] as string);
       }
     }

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -25,6 +25,7 @@ import {
   sendRejectionTargetKind,
   sendRejectionText,
   outgoingAddr,
+  resolveKeyModeChange,
 } from './ircConnection.js';
 import { createIdentdServer, unregisterIdent } from './identd.js';
 import { getRecent } from './systemLog.js';
@@ -1786,6 +1787,31 @@ describe('channel mode display (status bar)', () => {
     expect(modes).toContain('k');
     expect(modes).not.toContain('b');
     expect(modes).not.toContain('secret');
+  });
+});
+
+describe('resolveKeyModeChange', () => {
+  it('clears the stored key on -k', () => {
+    expect(resolveKeyModeChange('-', 'ignored')).toEqual({ key: null });
+    expect(resolveKeyModeChange('-', undefined)).toEqual({ key: null });
+  });
+
+  it('sets the key on +k with a real value', () => {
+    expect(resolveKeyModeChange('+', 'hunter2')).toEqual({ key: 'hunter2' });
+  });
+
+  it('leaves the stored key untouched for a value-less +k (on-join mode burst)', () => {
+    // The dangerous case: a +k echoed without its value must NOT wipe the key
+    // we persisted from the join command, or the channel loses its key on the
+    // next reconnect.
+    expect(resolveKeyModeChange('+', undefined)).toBeNull();
+    expect(resolveKeyModeChange('+', '')).toBeNull();
+  });
+
+  it('leaves the stored key untouched for a masked +k (* placeholder)', () => {
+    // Some servers hide the key from non-ops by echoing it as `*`; persisting
+    // that would replace the real key with an unusable one.
+    expect(resolveKeyModeChange('+', '*')).toBeNull();
   });
 });
 

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1788,3 +1788,56 @@ describe('channel mode display (status bar)', () => {
     expect(modes).not.toContain('secret');
   });
 });
+
+describe('join key forwarding', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'me',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  it('forwards a string key to the underlying client', () => {
+    const conn = makeConn();
+    const join = vi.fn<(channel: string, key?: string) => void>();
+    conn.client.join = join;
+    conn.join('#secret', 'hunter2');
+    expect(join).toHaveBeenCalledWith('#secret', 'hunter2');
+  });
+
+  it('drops a non-string key rather than passing it to the raw serialiser', () => {
+    // A numeric key from an untrusted payload would otherwise throw inside
+    // irc-framework (.match on a Number) and crash the process.
+    const conn = makeConn();
+    const join = vi.fn<(channel: string, key?: string) => void>();
+    conn.client.join = join;
+    conn.join('#secret', 123 as unknown as string);
+    expect(join).toHaveBeenCalledWith('#secret', undefined);
+  });
+
+  it('omits the key for a plain join', () => {
+    const conn = makeConn();
+    const join = vi.fn<(channel: string, key?: string) => void>();
+    conn.client.join = join;
+    conn.join('#open');
+    expect(join).toHaveBeenCalledWith('#open', undefined);
+  });
+});

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1624,3 +1624,167 @@ describe('invite channel lines + dedup (#261)', () => {
     );
   });
 });
+
+describe('channel mode display (status bar)', () => {
+  function makeConn(): IrcConnection {
+    return new IrcConnection({
+      network: {
+        id: 1,
+        user_id: 1,
+        name: 'n',
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'me',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 1,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+        position: 0,
+        created_at: new Date().toISOString(),
+      },
+      onEvent: () => {},
+    });
+  }
+
+  // Grab the latest channel-modes payload (the (+...) status-bar string).
+  function latestModes(publish: ReturnType<typeof vi.fn>): string | undefined {
+    const calls = publish.mock.calls
+      .map((c) => c[0] as { type: string; modes?: string })
+      .filter((e) => e.type === 'channel-modes');
+    return calls.at(-1)?.modes;
+  }
+
+  it('surfaces +k in the mode string but never the key value (#476)', () => {
+    const conn = makeConn();
+    conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+k', param: 'hunter2' }],
+      raw_modes: '+k',
+      raw_params: ['hunter2'],
+    });
+
+    const modes = latestModes(publish);
+    expect(modes).toContain('k');
+    expect(modes).not.toContain('hunter2'); // only the letter, never the secret
+  });
+
+  it('surfaces +l (limit) as a flag', () => {
+    const conn = makeConn();
+    conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+l', param: '42' }],
+      raw_modes: '+l',
+      raw_params: ['42'],
+    });
+
+    const modes = latestModes(publish);
+    expect(modes).toContain('l');
+    expect(modes).not.toContain('42');
+  });
+
+  it('excludes list-type modes (+b bans) from the display', () => {
+    const conn = makeConn();
+    conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+n' }, { mode: '+b', param: 'troll!*@*' }],
+      raw_modes: '+nb',
+      raw_params: ['troll!*@*'],
+    });
+
+    const modes = latestModes(publish);
+    expect(modes).toContain('n');
+    expect(modes).not.toContain('b'); // the ban mask must not pollute the display
+  });
+
+  it('honours the server ISUPPORT CHANMODES when deciding what is a list mode', () => {
+    const conn = makeConn();
+    // Declare a server-specific list mode (+g) in CHANMODES group A. A hardcoded
+    // b/e/I list would miss it; reading group A excludes exactly what the server
+    // says is list-type.
+    // irc-framework stores CHANMODES as the four comma-split groups at runtime
+    // (see registration.js), though its .d.ts types it as a string.
+    (conn.client.network.options as { CHANMODES?: unknown }).CHANMODES = [
+      'beIg',
+      'k',
+      'l',
+      'imnpst',
+    ];
+    conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [
+        { mode: '+n' },
+        { mode: '+g', param: 'spam' }, // server-declared list mode → excluded
+        { mode: '+k', param: 'secret' }, // param mode, not a list mode → kept
+      ],
+      raw_modes: '+ngk',
+      raw_params: ['spam', 'secret'],
+    });
+
+    const modes = latestModes(publish);
+    expect([...(modes ?? '')].toSorted().join('')).toBe('kn');
+    expect(modes).not.toContain('g');
+    expect(modes).not.toContain('secret');
+  });
+
+  it('drops a channel mode when it is removed (-k)', () => {
+    const conn = makeConn();
+    conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+k', param: 'secret' }],
+      raw_modes: '+k',
+      raw_params: ['secret'],
+    });
+    expect(latestModes(publish)).toContain('k');
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '-k', param: 'secret' }],
+      raw_modes: '-k',
+      raw_params: ['secret'],
+    });
+    expect(latestModes(publish)).not.toContain('k');
+  });
+
+  it('RPL_CHANNELMODEIS (324) captures param modes and drops list modes', () => {
+    const conn = makeConn();
+    conn.upsertChannel('#chan');
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('channel info', {
+      channel: '#chan',
+      modes: [{ mode: '+n' }, { mode: '+k', param: 'secret' }, { mode: '+b', param: 'troll!*@*' }],
+    });
+
+    const modes = latestModes(publish);
+    expect(modes).toContain('n');
+    expect(modes).toContain('k');
+    expect(modes).not.toContain('b');
+    expect(modes).not.toContain('secret');
+  });
+});

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -10,7 +10,7 @@ import {
   listBufferTargets,
 } from '../db/messages.js';
 import type { Network } from '../db/networks.js';
-import { upsertChannel } from '../db/networks.js';
+import { upsertChannel, setChannelKey } from '../db/networks.js';
 import { isClosed as isBufferClosed } from '../db/closedBuffers.js';
 import { listTargetsForNetwork as listFriendTargetsForNetwork } from '../db/contacts.js';
 import * as chanlistDb from '../db/chanlist.js';
@@ -1794,6 +1794,14 @@ export class IrcConnection {
             } else if (sign === '-' && ch.modes.delete(letter)) {
               chanModesChanged = true;
             }
+          }
+          // Keep the persisted +k key current so a live key change survives a
+          // reconnect. Only act on -k (clear) or a +k that carries the key —
+          // a +k echoed WITHOUT the value (common in the on-join mode burst)
+          // must not wipe the key we stored from the join command.
+          if (letter === 'k') {
+            if (sign === '-') setChannelKey(this.network.id, ch.name, null);
+            else if (m.param) setChannelKey(this.network.id, ch.name, m.param);
           }
         }
       }

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1796,12 +1796,11 @@ export class IrcConnection {
             }
           }
           // Keep the persisted +k key current so a live key change survives a
-          // reconnect. Only act on -k (clear) or a +k that carries the key —
-          // a +k echoed WITHOUT the value (common in the on-join mode burst)
-          // must not wipe the key we stored from the join command.
+          // reconnect (see resolveKeyModeChange for the value-less / masked-key
+          // guards that stop an on-join mode burst from wiping the real key).
           if (letter === 'k') {
-            if (sign === '-') setChannelKey(this.network.id, ch.name, null);
-            else if (m.param) setChannelKey(this.network.id, ch.name, m.param);
+            const change = resolveKeyModeChange(sign, m.param);
+            if (change) setChannelKey(this.network.id, ch.name, change.key);
           }
         }
       }
@@ -4067,6 +4066,22 @@ export class IrcConnection {
 const PREFIX_MODES = new Set(['q', 'a', 'o', 'h', 'v']);
 function isPrefixMode(letter: string): boolean {
   return PREFIX_MODES.has(letter);
+}
+
+// Decide how a channel +k / -k MODE change should update the persisted key.
+// Returns null for "leave the stored key alone" — the two cases that must NOT
+// touch it are (a) a +k echoed WITHOUT its value (common in the on-join mode
+// burst) and (b) a masked +k where the server sends the key as `*` to hide it
+// from non-ops. Either would otherwise clobber the real key we stored at join
+// time, so the channel would fail to auto-rejoin on the next reconnect. -k
+// clears; +k with a real value sets. Pure + exported so the guard is unit-tested.
+export function resolveKeyModeChange(
+  sign: string,
+  param: string | undefined,
+): { key: string | null } | null {
+  if (sign === '-') return { key: null };
+  if (sign === '+' && param && param !== '*') return { key: param };
+  return null;
 }
 
 // Pure helper for the pre-registration nick-fallback ladder. The configured

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2485,16 +2485,18 @@ export class IrcConnection {
   }
 
   // List-type channel modes (CHANMODES group A) carry a mask param — bans,
-  // ban/invite exceptions, solanum-style +q quiets — that we don't surface in
-  // the status bar. We read the set from the server's ISUPPORT CHANMODES so
-  // it's correct per-ircd (e.g. +q is a list mode on solanum but a member
-  // prefix on UnrealIRCd, where it's handled via PREFIX instead), falling back
-  // to the RFC defaults before 005 has been parsed. This is the same
-  // categorisation weechat/irssi/gamja use. Parameter modes like +k/+l are
-  // NOT list modes, so they still land in the (+...) display.
+  // ban/invite exceptions, and quiets on ircds that model them as a list — that
+  // we don't surface in the status bar. We read the set from the server's
+  // ISUPPORT CHANMODES so it's correct per-ircd, falling back to the RFC
+  // defaults before 005 has been parsed (`??`, so a server that legitimately
+  // declares an empty group A keeps its empty set rather than the default).
+  // This is the same categorisation weechat/irssi/gamja use. Parameter modes
+  // like +k/+l are NOT list modes, so they still land in the (+...) display.
+  // Member-prefix modes (o/v/h, plus q/a where an ircd uses them as prefixes)
+  // are filtered earlier by isPrefixMode(), so they never reach this set.
   private listModes(): Set<string> {
     const chanmodes = this.client.network?.options?.CHANMODES as string[] | undefined;
-    return new Set((chanmodes?.[0] || 'beI').split(''));
+    return new Set((chanmodes?.[0] ?? 'beI').split(''));
   }
 
   publishLag(): void {
@@ -2584,7 +2586,12 @@ export class IrcConnection {
   }
 
   join(channel: string, key?: string): void {
-    this.client.join(channel, key);
+    // Only a string is a valid channel key. Guard against a non-string sneaking
+    // in from an untrusted ws/HTTP join payload — irc-framework's raw serialiser
+    // calls .match() on the last arg, so a numeric key throws a TypeError that,
+    // with no global uncaught handler (see wsHub sendSnapshot backstop), would
+    // drop the whole (shared, on hosted) process.
+    this.client.join(channel, typeof key === 'string' ? key : undefined);
   }
   part(channel: string, reason?: string): void {
     this.client.part(channel, reason);

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2568,8 +2568,8 @@ export class IrcConnection {
     });
   }
 
-  join(channel: string): void {
-    this.client.join(channel);
+  join(channel: string, key?: string): void {
+    this.client.join(channel, key);
   }
   part(channel: string, reason?: string): void {
     this.client.part(channel, reason);

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1767,6 +1767,7 @@ export class IrcConnection {
       // the snapshot keeps current modes after page reload.
       let memberModesChanged = false;
       let chanModesChanged = false;
+      const listModes = this.listModes();
       if (ch) {
         for (const m of eventModes) {
           if (!m || !m.mode) continue;
@@ -1783,11 +1784,10 @@ export class IrcConnection {
             memberModesChanged = true;
             continue;
           }
-          // Channel-level flag mode (or parameter mode like +k/+l). We track them
-          // to surface them in the status bar, but we exclude list-type modes like +b/+e/+I
-          // to prevent polluting the display.
-          const isListMode = ['b', 'e', 'I', 'q', 'a'].includes(letter);
-          if (!isListMode) {
+          // Channel-level flag mode (or parameter mode like +k/+l). We track
+          // them to surface them in the status bar, but exclude list-type modes
+          // (bans/exceptions/quiets) so their masks don't pollute the display.
+          if (!listModes.has(letter)) {
             if (sign === '+' && !ch.modes.has(letter)) {
               ch.modes.add(letter);
               chanModesChanged = true;
@@ -1824,11 +1824,12 @@ export class IrcConnection {
       if (!eventChannel || !eventModes) return;
       const ch = this.channels.get(eventChannel.toLowerCase());
       if (!ch) return;
+      const listModes = this.listModes();
       const next = new Set<string>();
       for (const m of eventModes) {
         if (!m || !m.mode) continue;
         const letter = m.mode.replace(/^[+-]/, '');
-        if (!letter || ['b', 'e', 'I', 'q', 'a'].includes(letter)) continue;
+        if (!letter || listModes.has(letter)) continue;
         next.add(letter);
       }
       const before = [...ch.modes].toSorted().join('');
@@ -2481,6 +2482,19 @@ export class IrcConnection {
       target: ch.name,
       modes: [...ch.modes].join(''),
     });
+  }
+
+  // List-type channel modes (CHANMODES group A) carry a mask param — bans,
+  // ban/invite exceptions, solanum-style +q quiets — that we don't surface in
+  // the status bar. We read the set from the server's ISUPPORT CHANMODES so
+  // it's correct per-ircd (e.g. +q is a list mode on solanum but a member
+  // prefix on UnrealIRCd, where it's handled via PREFIX instead), falling back
+  // to the RFC defaults before 005 has been parsed. This is the same
+  // categorisation weechat/irssi/gamja use. Parameter modes like +k/+l are
+  // NOT list modes, so they still land in the (+...) display.
+  private listModes(): Set<string> {
+    const chanmodes = this.client.network?.options?.CHANMODES as string[] | undefined;
+    return new Set((chanmodes?.[0] || 'beI').split(''));
   }
 
   publishLag(): void {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1783,10 +1783,11 @@ export class IrcConnection {
             memberModesChanged = true;
             continue;
           }
-          // Channel-level flag mode (no param, or list-type mode like +b that
-          // we don't surface in the status bar). We only track flag modes
-          // (no param) so +b/+e/+I bans don't pollute the (+...) display.
-          if (!m.param) {
+          // Channel-level flag mode (or parameter mode like +k/+l). We track them
+          // to surface them in the status bar, but we exclude list-type modes like +b/+e/+I
+          // to prevent polluting the display.
+          const isListMode = ['b', 'e', 'I', 'q', 'a'].includes(letter);
+          if (!isListMode) {
             if (sign === '+' && !ch.modes.has(letter)) {
               ch.modes.add(letter);
               chanModesChanged = true;
@@ -1825,9 +1826,9 @@ export class IrcConnection {
       if (!ch) return;
       const next = new Set<string>();
       for (const m of eventModes) {
-        if (!m || !m.mode || m.param) continue;
+        if (!m || !m.mode) continue;
         const letter = m.mode.replace(/^[+-]/, '');
-        if (!letter) continue;
+        if (!letter || ['b', 'e', 'I', 'q', 'a'].includes(letter)) continue;
         next.add(letter);
       }
       const before = [...ch.modes].toSorted().join('');

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -18,9 +18,11 @@ let setUserPaused: typeof import('../db/users.js').setUserPaused;
 let createNetwork: typeof import('../db/networks.js').createNetwork;
 let insertDccTransfer: typeof import('../db/dccTransfers.js').insertDccTransfer;
 let updateDccTransferState: typeof import('../db/dccTransfers.js').updateDccTransferState;
+let planChannelRejoins: typeof import('./ircManager.js').planChannelRejoins;
 
 beforeAll(async () => {
   ircManager = (await import('./ircManager.js')).default;
+  ({ planChannelRejoins } = await import('./ircManager.js'));
   connectScheduler = (await import('./connectScheduler.js')).default;
   systemLog = (await import('./systemLog.js')).default;
   ({ createUser, setUserPaused } = await import('../db/users.js'));
@@ -368,5 +370,37 @@ describe('ircManager contacts', () => {
     expect(ircManager.deleteContact(other.id, made.id)).toBe(false);
     expect(ircManager.deleteContact(user.id, made.id)).toBe(true);
     expect(ircManager.listContacts(user.id)).toEqual([]);
+  });
+});
+
+describe('planChannelRejoins', () => {
+  it('emits a keyed JOIN per keyed channel and one batched JOIN for keyless ones', () => {
+    const ops = planChannelRejoins([
+      { name: '#alsoplain', key: null },
+      { name: '#keyed', key: 'sekret' },
+      { name: '#plain', key: null },
+    ]);
+    // Keyed channels first (each with its key), then the keyless batch — and the
+    // keyed channel is never folded into the batch.
+    expect(ops).toEqual([{ channel: '#keyed', key: 'sekret' }, { channel: '#alsoplain,#plain' }]);
+  });
+
+  it('splits keyless channels into multiple JOINs under the IRC line cap', () => {
+    // 50 channels of 12 chars each (≈650 with separators) blow past the
+    // 400-char budget → more than one batch.
+    const many = Array.from({ length: 50 }, (_, i) => ({
+      name: `#channel-${String(i).padStart(3, '0')}`,
+      key: null as string | null,
+    }));
+    const ops = planChannelRejoins(many);
+    expect(ops.length).toBeGreaterThan(1);
+    // Every batch stays under the cap, and every channel appears exactly once.
+    for (const op of ops) expect(op.channel.length).toBeLessThanOrEqual(400);
+    const rejoined = ops.flatMap((o) => o.channel.split(','));
+    expect(rejoined.toSorted()).toEqual(many.map((c) => c.name).toSorted());
+  });
+
+  it('returns nothing for no joined channels', () => {
+    expect(planChannelRejoins([])).toEqual([]);
   });
 });

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { setupTestDb } from '../test-utils/testApp.js';
 
 // The startNetwork gate is the linchpin of the pause feature: a paused account
@@ -16,6 +16,7 @@ let systemLog: typeof import('./systemLog.js').default;
 let createUser: typeof import('../db/users.js').createUser;
 let setUserPaused: typeof import('../db/users.js').setUserPaused;
 let createNetwork: typeof import('../db/networks.js').createNetwork;
+let listChannels: typeof import('../db/networks.js').listChannels;
 let insertDccTransfer: typeof import('../db/dccTransfers.js').insertDccTransfer;
 let updateDccTransferState: typeof import('../db/dccTransfers.js').updateDccTransferState;
 let planChannelRejoins: typeof import('./ircManager.js').planChannelRejoins;
@@ -26,7 +27,7 @@ beforeAll(async () => {
   connectScheduler = (await import('./connectScheduler.js')).default;
   systemLog = (await import('./systemLog.js')).default;
   ({ createUser, setUserPaused } = await import('../db/users.js'));
-  ({ createNetwork } = await import('../db/networks.js'));
+  ({ createNetwork, listChannels } = await import('../db/networks.js'));
   ({ insertDccTransfer, updateDccTransferState } = await import('../db/dccTransfers.js'));
 });
 
@@ -374,15 +375,37 @@ describe('ircManager contacts', () => {
 });
 
 describe('planChannelRejoins', () => {
-  it('emits a keyed JOIN per keyed channel and one batched JOIN for keyless ones', () => {
+  it('batches keyed channels (with an aligned key list) separately from keyless ones', () => {
     const ops = planChannelRejoins([
       { name: '#alsoplain', key: null },
-      { name: '#keyed', key: 'sekret' },
+      { name: '#k1', key: 'key1' },
       { name: '#plain', key: null },
+      { name: '#k2', key: 'key2' },
     ]);
-    // Keyed channels first (each with its key), then the keyless batch — and the
-    // keyed channel is never folded into the batch.
-    expect(ops).toEqual([{ channel: '#keyed', key: 'sekret' }, { channel: '#alsoplain,#plain' }]);
+    // One keyed JOIN line with a positional key list, then the keyless batch —
+    // keyed channels are never folded into the keyless (key-less) line.
+    expect(ops).toEqual([
+      { channels: '#k1,#k2', keys: 'key1,key2' },
+      { channels: '#alsoplain,#plain' },
+    ]);
+  });
+
+  it('keeps keys aligned 1:1 with channels within each keyed batch', () => {
+    const keyed = Array.from({ length: 40 }, (_, i) => ({
+      name: `#keyed-${String(i).padStart(2, '0')}`,
+      key: `secret-${String(i).padStart(2, '0')}`,
+    }));
+    const ops = planChannelRejoins(keyed);
+    expect(ops.length).toBeGreaterThan(1); // must split under the line cap
+    const seen: Record<string, string> = {};
+    for (const op of ops) {
+      const chans = op.channels.split(',');
+      const ks = (op.keys ?? '').split(',');
+      expect(ks).toHaveLength(chans.length); // no misalignment across the split
+      expect(op.channels.length + 1 + (op.keys ?? '').length).toBeLessThanOrEqual(400);
+      chans.forEach((c, i) => (seen[c] = ks[i]));
+    }
+    for (const c of keyed) expect(seen[c.name]).toBe(c.key); // each kept its own key
   });
 
   it('splits keyless channels into multiple JOINs under the IRC line cap', () => {
@@ -395,12 +418,33 @@ describe('planChannelRejoins', () => {
     const ops = planChannelRejoins(many);
     expect(ops.length).toBeGreaterThan(1);
     // Every batch stays under the cap, and every channel appears exactly once.
-    for (const op of ops) expect(op.channel.length).toBeLessThanOrEqual(400);
-    const rejoined = ops.flatMap((o) => o.channel.split(','));
+    for (const op of ops) expect(op.channels.length).toBeLessThanOrEqual(400);
+    const rejoined = ops.flatMap((o) => o.channels.split(','));
     expect(rejoined.toSorted()).toEqual(many.map((c) => c.name).toSorted());
   });
 
   it('returns nothing for no joined channels', () => {
     expect(planChannelRejoins([])).toEqual([]);
+  });
+
+  it('joinChannel persists the key end-to-end so the rejoin plan carries it', () => {
+    const user = createUser('irc-join-e2e');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.invalid',
+      port: 6697,
+      tls: true,
+      nick: 'a',
+    })!;
+    // deferrable parks the socket launch (drained in afterEach); stub join so
+    // no bytes hit the (never-opened) socket.
+    const conn = ircManager.startNetwork(user.id, net.id, { deferrable: true })!;
+    conn.client.join = vi.fn<(channel: string, key?: string) => void>();
+
+    ircManager.joinChannel(user.id, net.id, '#secret', 'hunter2');
+
+    // The key made it to the DB and comes back out in the rejoin plan.
+    const joined = listChannels(net.id).filter((c) => c.joined);
+    expect(planChannelRejoins(joined)).toContainEqual({ channels: '#secret', keys: 'hunter2' });
   });
 });

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -447,4 +447,26 @@ describe('planChannelRejoins', () => {
     const joined = listChannels(net.id).filter((c) => c.joined);
     expect(planChannelRejoins(joined)).toContainEqual({ channels: '#secret', keys: 'hunter2' });
   });
+
+  it('joinChannel drops a non-string key from an untrusted payload without throwing', () => {
+    const user = createUser('irc-join-badkey');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.invalid',
+      port: 6697,
+      tls: true,
+      nick: 'a',
+    })!;
+    const conn = ircManager.startNetwork(user.id, net.id, { deferrable: true })!;
+    conn.client.join = vi.fn<(channel: string, key?: string) => void>();
+
+    // A number sneaks in via an unvalidated ws/HTTP join payload. It must not
+    // reach encryptSecret (which throws on a non-string and, on the unguarded
+    // ws path, would crash the process).
+    expect(() =>
+      ircManager.joinChannel(user.id, net.id, '#x', 123 as unknown as string),
+    ).not.toThrow();
+    expect(listChannels(net.id).find((c) => c.name === '#x')!.key).toBeNull(); // dropped
+    expect(conn.client.join).toHaveBeenCalledWith('#x', undefined);
+  });
 });

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -78,23 +78,50 @@ function awayStateFromRow(row: AwayStateRow | null) {
   };
 }
 
-// Plan the JOINs for auto-rejoin on (re)registration. Keyed channels each get
-// their own keyed JOIN — a comma JOIN uses a positional key list
-// (JOIN #a,#b k_a,k_b) that's easy to get wrong, and keyed channels are rare.
-// Keyless channels coalesce into comma-separated batches per IRC line: a tight
-// loop of single JOINs trips Libera's per-connection flood limit ("Closing
-// Link: ... (Excess Flood)"), so we chunk well under the 512-byte line cap.
-// Pure and export-only so the batching/keying is unit-testable without a socket.
+// Plan the JOINs for auto-rejoin on (re)registration. A tight loop of single
+// JOINs trips Libera's per-connection flood limit ("Closing Link: ... (Excess
+// Flood)"), so channels coalesce into comma-separated JOIN lines chunked well
+// under the 512-byte cap. Keyed and keyless channels go in SEPARATE lines:
+// keyed lines carry a positional key list (JOIN #a,#b k_a,k_b), so keeping each
+// keyed line all-keyed means every key lines up 1:1 with its channel — no
+// cross-type alignment to get wrong. Pure + export-only so it's unit-testable
+// without a socket; the caller maps each op to client.join(channels, keys).
 export function planChannelRejoins(
   channels: Array<{ name: string; key: string | null }>,
-): Array<{ channel: string; key?: string }> {
-  const ops: Array<{ channel: string; key?: string }> = [];
-  for (const c of channels) if (c.key) ops.push({ channel: c.name, key: c.key });
+): Array<{ channels: string; keys?: string }> {
   const MAX = 400;
+  const ops: Array<{ channels: string; keys?: string }> = [];
+
+  // Keyed channels: batch with an aligned key list. Budget both the channel and
+  // key lists plus the single space that joins them on the wire.
+  let names: string[] = [];
+  let keys: string[] = [];
+  let namesLen = 0;
+  let keysLen = 0;
+  const flushKeyed = () => {
+    if (names.length > 0) ops.push({ channels: names.join(','), keys: keys.join(',') });
+    names = [];
+    keys = [];
+    namesLen = 0;
+    keysLen = 0;
+  };
+  for (const c of channels) {
+    if (!c.key) continue;
+    const addName = names.length === 0 ? c.name.length : c.name.length + 1;
+    const addKey = keys.length === 0 ? c.key.length : c.key.length + 1;
+    if (namesLen + addName + 1 + keysLen + addKey > MAX && names.length > 0) flushKeyed();
+    names.push(c.name);
+    keys.push(c.key);
+    namesLen += names.length === 1 ? c.name.length : c.name.length + 1;
+    keysLen += keys.length === 1 ? c.key.length : c.key.length + 1;
+  }
+  flushKeyed();
+
+  // Keyless channels: names only.
   let chunk: string[] = [];
   let len = 0;
   const flush = () => {
-    if (chunk.length > 0) ops.push({ channel: chunk.join(',') });
+    if (chunk.length > 0) ops.push({ channels: chunk.join(',') });
     chunk = [];
     len = 0;
   };
@@ -106,6 +133,7 @@ export function planChannelRejoins(
     len += add;
   }
   flush();
+
   return ops;
 }
 
@@ -217,7 +245,7 @@ class IrcManager extends EventEmitter {
           text: `Auto-joining ${names.length} ${names.length === 1 ? 'channel' : 'channels'}: ${names.join(', ')}`,
         });
       }
-      for (const op of planChannelRejoins(joined)) connRef.join(op.channel, op.key);
+      for (const op of planChannelRejoins(joined)) connRef.join(op.channels, op.keys);
     });
 
     return conn;
@@ -267,11 +295,12 @@ class IrcManager extends EventEmitter {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
     // Persist the key (encrypted at rest) so the channel auto-rejoins keyed
-    // after a reconnect/restart. Only pass it through when supplied — a keyless
-    // re-join (clicking an already-keyed channel, /join with no key) must
-    // preserve the stored key, not wipe it (soju does the same). A key that no
-    // longer applies is cleared by the MODE -k handler, not here.
-    upsertChannel(networkId, name, true, key);
+    // after a reconnect/restart. Normalize an empty/absent key to undefined so a
+    // keyless re-join (clicking an already-keyed channel, /join with no key, or
+    // an API call passing key:"") preserves the stored key rather than wiping it
+    // — soju does the same. A key that no longer applies is cleared by the
+    // MODE -k handler, not here.
+    upsertChannel(networkId, name, true, key || undefined);
     // Joining is an explicit "I want this buffer back" — clear any stale
     // closed flag from a prior close. The matching channel-joined event will
     // recreate the buffer in clients via the normal flow.

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -78,6 +78,37 @@ function awayStateFromRow(row: AwayStateRow | null) {
   };
 }
 
+// Plan the JOINs for auto-rejoin on (re)registration. Keyed channels each get
+// their own keyed JOIN — a comma JOIN uses a positional key list
+// (JOIN #a,#b k_a,k_b) that's easy to get wrong, and keyed channels are rare.
+// Keyless channels coalesce into comma-separated batches per IRC line: a tight
+// loop of single JOINs trips Libera's per-connection flood limit ("Closing
+// Link: ... (Excess Flood)"), so we chunk well under the 512-byte line cap.
+// Pure and export-only so the batching/keying is unit-testable without a socket.
+export function planChannelRejoins(
+  channels: Array<{ name: string; key: string | null }>,
+): Array<{ channel: string; key?: string }> {
+  const ops: Array<{ channel: string; key?: string }> = [];
+  for (const c of channels) if (c.key) ops.push({ channel: c.name, key: c.key });
+  const MAX = 400;
+  let chunk: string[] = [];
+  let len = 0;
+  const flush = () => {
+    if (chunk.length > 0) ops.push({ channel: chunk.join(',') });
+    chunk = [];
+    len = 0;
+  };
+  for (const c of channels) {
+    if (c.key) continue;
+    const add = chunk.length === 0 ? c.name.length : c.name.length + 1;
+    if (len + add > MAX && chunk.length > 0) flush();
+    chunk.push(c.name);
+    len += add;
+  }
+  flush();
+  return ops;
+}
+
 class IrcManager extends EventEmitter {
   byUser: Map<number, Map<number, IrcConnection>>;
 
@@ -176,9 +207,8 @@ class IrcManager extends EventEmitter {
       launch();
     }
     conn.client.on('registered', () => {
-      const names = listChannels(networkId)
-        .filter((c) => c.joined)
-        .map((c) => c.name);
+      const joined = listChannels(networkId).filter((c) => c.joined);
+      const names = joined.map((c) => c.name);
       if (names.length > 0) {
         systemLog.log({
           userId,
@@ -187,24 +217,7 @@ class IrcManager extends EventEmitter {
           text: `Auto-joining ${names.length} ${names.length === 1 ? 'channel' : 'channels'}: ${names.join(', ')}`,
         });
       }
-      // Send JOINs as comma-separated batches per IRC line. A tight loop of
-      // single JOINs trips Libera's per-connection flood limit ("Closing Link:
-      // ... (Excess Flood)"), so we coalesce into one line and chunk well under
-      // the 512-byte IRC line cap.
-      const MAX = 400;
-      let chunk: string[] = [];
-      let len = 0;
-      for (const name of names) {
-        const add = chunk.length === 0 ? name.length : name.length + 1;
-        if (len + add > MAX && chunk.length > 0) {
-          connRef.join(chunk.join(','));
-          chunk = [];
-          len = 0;
-        }
-        chunk.push(name);
-        len += add;
-      }
-      if (chunk.length > 0) connRef.join(chunk.join(','));
+      for (const op of planChannelRejoins(joined)) connRef.join(op.channel, op.key);
     });
 
     return conn;
@@ -253,7 +266,12 @@ class IrcManager extends EventEmitter {
   joinChannel(userId: number, networkId: number, name: string, key?: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
-    upsertChannel(networkId, name, true);
+    // Persist the key (encrypted at rest) so the channel auto-rejoins keyed
+    // after a reconnect/restart. Only pass it through when supplied — a keyless
+    // re-join (clicking an already-keyed channel, /join with no key) must
+    // preserve the stored key, not wipe it (soju does the same). A key that no
+    // longer applies is cleared by the MODE -k handler, not here.
+    upsertChannel(networkId, name, true, key);
     // Joining is an explicit "I want this buffer back" — clear any stale
     // closed flag from a prior close. The matching channel-joined event will
     // recreate the buffer in clients via the normal flow.

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -250,7 +250,7 @@ class IrcManager extends EventEmitter {
     return this.startNetwork(userId, networkId);
   }
 
-  joinChannel(userId: number, networkId: number, name: string): boolean {
+  joinChannel(userId: number, networkId: number, name: string, key?: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
     upsertChannel(networkId, name, true);
@@ -258,7 +258,7 @@ class IrcManager extends EventEmitter {
     // closed flag from a prior close. The matching channel-joined event will
     // recreate the buffer in clients via the normal flow.
     reopenBuffer(userId, networkId, name);
-    conn.join(name);
+    conn.join(name, key);
     return true;
   }
 

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -294,18 +294,22 @@ class IrcManager extends EventEmitter {
   joinChannel(userId: number, networkId: number, name: string, key?: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
+    // Coerce the key to a safe string-or-undefined once, up front. The ws/HTTP
+    // join payloads are unvalidated, so a non-string (e.g. a number) can reach
+    // here — it must not flow into upsertChannel → encryptSecret (which throws
+    // on a non-string and, on the unguarded ws path, would take down the shared
+    // cell process). An empty string coerces to undefined too, so a keyless
+    // re-join preserves a stored key instead of wiping it (soju does the same);
+    // a key that no longer applies is cleared by the MODE -k handler, not here.
+    const safeKey = typeof key === 'string' && key !== '' ? key : undefined;
     // Persist the key (encrypted at rest) so the channel auto-rejoins keyed
-    // after a reconnect/restart. Normalize an empty/absent key to undefined so a
-    // keyless re-join (clicking an already-keyed channel, /join with no key, or
-    // an API call passing key:"") preserves the stored key rather than wiping it
-    // — soju does the same. A key that no longer applies is cleared by the
-    // MODE -k handler, not here.
-    upsertChannel(networkId, name, true, key || undefined);
+    // after a reconnect/restart.
+    upsertChannel(networkId, name, true, safeKey);
     // Joining is an explicit "I want this buffer back" — clear any stale
     // closed flag from a prior close. The matching channel-joined event will
     // recreate the buffer in clients via the normal flow.
     reopenBuffer(userId, networkId, name);
-    conn.join(name, key);
+    conn.join(name, safeKey);
     return true;
   }
 

--- a/server/services/networkSecretsRoundtrip.test.ts
+++ b/server/services/networkSecretsRoundtrip.test.ts
@@ -20,6 +20,8 @@ let db: typeof import('../db/index.js').default;
 let createUser: typeof import('../db/users.js').createUser;
 let createNetwork: typeof import('../db/networks.js').createNetwork;
 let getNetwork: typeof import('../db/networks.js').getNetwork;
+let upsertChannel: typeof import('../db/networks.js').upsertChannel;
+let listChannels: typeof import('../db/networks.js').listChannels;
 let isEncrypted: typeof import('../utils/secretCrypto.js').isEncrypted;
 let buildExportZip: typeof import('./exportService.js').buildExportZip;
 let importFromZipBuffer: typeof import('./importService.js').importFromZipBuffer;
@@ -35,7 +37,7 @@ const SECRET_COLS = Object.keys(SECRETS) as (keyof typeof SECRETS)[];
 beforeAll(async () => {
   db = (await import('../db/index.js')).default;
   ({ createUser } = await import('../db/users.js'));
-  ({ createNetwork, getNetwork } = await import('../db/networks.js'));
+  ({ createNetwork, getNetwork, upsertChannel, listChannels } = await import('../db/networks.js'));
   ({ isEncrypted } = await import('../utils/secretCrypto.js'));
   ({ buildExportZip } = await import('./exportService.js'));
   ({ importFromZipBuffer } = await import('./importService.js'));
@@ -116,5 +118,43 @@ describe('network secret export/import round-trip (key configured)', () => {
     for (const col of SECRET_COLS) {
       expect(bobFetched[col]).toBe(SECRETS[col]);
     }
+  });
+
+  it('channel keys are encrypted at rest, exported plaintext, and re-encrypted on import', async () => {
+    const carol = createUser('carol');
+    const net = createNetwork(carol.id, {
+      name: 'libera',
+      host: 'irc.libera.chat',
+      port: 6697,
+      tls: true,
+      nick: 'carol',
+    })!;
+    upsertChannel(net.id, '#secret', true, 'chankey');
+
+    // Stored encrypted at rest; decrypted on read.
+    const raw = db
+      .prepare('SELECT key FROM channels WHERE network_id = ? AND name = ?')
+      .get(net.id, '#secret') as { key: string | null };
+    expect(isEncrypted(raw.key)).toBe(true);
+    expect(listChannels(net.id).find((c) => c.name === '#secret')!.key).toBe('chankey');
+
+    // Export carries the key as portable plaintext.
+    const buf = await exportToBuffer(carol.id);
+    const data = JSON.parse(await readZipEntry(buf, 'data.json')) as {
+      channels: Record<string, string>[];
+    };
+    expect(data.channels.find((c) => c.name === '#secret')!.key).toBe('chankey');
+
+    // Import onto a fresh keyed account re-encrypts at rest and reads back plain.
+    const dave = createUser('dave');
+    await importFromZipBuffer(dave.id, buf);
+    const daveNet = db.prepare('SELECT id FROM networks WHERE user_id = ?').get(dave.id) as {
+      id: number;
+    };
+    const daveRaw = db
+      .prepare('SELECT key FROM channels WHERE network_id = ? AND name = ?')
+      .get(daveNet.id, '#secret') as { key: string | null };
+    expect(isEncrypted(daveRaw.key)).toBe(true);
+    expect(listChannels(daveNet.id).find((c) => c.name === '#secret')!.key).toBe('chankey');
   });
 });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1938,7 +1938,12 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         break;
       }
       case 'join':
-        ircManager.joinChannel(userId, msg.networkId as number, msg.channel as string);
+        ircManager.joinChannel(
+          userId,
+          msg.networkId as number,
+          msg.channel as string,
+          msg.key as string | undefined,
+        );
         break;
       case 'open-buffer':
         // A clicked channel name — handleOpenBuffer resolves reopen-vs-join.

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2731,9 +2731,10 @@ function handleCommand(line: string, networkId: number | null, target: string): 
     case 'join':
       if (rest[0]) {
         const ch = rest[0].startsWith('#') ? rest[0] : `#${rest[0]}`;
+        const key = rest.slice(1).join(' ') || undefined;
         // Switch to the channel if we're already in it; otherwise join. Returns
         // false only when a JOIN had to be sent but the socket was closed.
-        if (buffers.joinOrActivate(networkId, ch)) return true;
+        if (buffers.joinOrActivate(networkId, ch, key)) return true;
         toastSendFailure('disconnected', line);
         return false;
       }

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2731,7 +2731,10 @@ function handleCommand(line: string, networkId: number | null, target: string): 
     case 'join':
       if (rest[0]) {
         const ch = rest[0].startsWith('#') ? rest[0] : `#${rest[0]}`;
-        const key = rest.slice(1).join(' ') || undefined;
+        // A channel key is a single whitespace-free token — take just the next
+        // arg, not the rest joined (which would fold trailing words into an
+        // invalid, space-bearing key).
+        const key = rest[1] || undefined;
         // Switch to the channel if we're already in it; otherwise join. Returns
         // false only when a JOIN had to be sent but the socket was closed.
         if (buffers.joinOrActivate(networkId, ch, key)) return true;

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -405,3 +405,42 @@ describe('shell unseeded lifecycle', () => {
     expect(Object.keys(store.byKey('1::#a')!.speakers).sort()).toEqual(['alice', 'bob']);
   });
 });
+
+describe('joinOrActivate channel key', () => {
+  // /join #chan <key> must forward the key so keyed (+k) channels are joinable.
+  it('includes the key in the JOIN payload for a brand-new channel', () => {
+    const store = useBuffersStore();
+    store.joinOrActivate(1, '#secret', 'sekret');
+    expect(socketSend).toHaveBeenCalledWith({
+      type: 'join',
+      networkId: 1,
+      channel: '#secret',
+      key: 'sekret',
+    });
+  });
+
+  it('re-sends JOIN with the key when the buffer exists but we are not in it', () => {
+    const store = useBuffersStore();
+    // Open the buffer but leave it un-joined (e.g. after a part/kick).
+    store.replaceBacklog(1, '#secret', [], undefined, undefined, undefined);
+    store.byKey('1::#secret')!.joined = false;
+    vi.mocked(socketSend).mockClear();
+
+    store.joinOrActivate(1, '#secret', 'sekret');
+
+    expect(socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'join', channel: '#secret', key: 'sekret' }),
+    );
+  });
+
+  it('omits the key when none is given (plain /join)', () => {
+    const store = useBuffersStore();
+    store.joinOrActivate(1, '#open');
+    expect(socketSend).toHaveBeenCalledWith({
+      type: 'join',
+      networkId: 1,
+      channel: '#open',
+      key: undefined,
+    });
+  });
+});

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -863,7 +863,7 @@ export const useBuffersStore = defineStore('buffers', {
     // a second buffer for a different-cased name. Returns false only when a
     // JOIN had to be sent but the socket was closed, so the caller can surface
     // an offline toast.
-    joinOrActivate(networkId: number | string, channel: string): boolean {
+    joinOrActivate(networkId: number | string, channel: string, key?: string): boolean {
       // forNetwork compares networkId with === against the numeric
       // Buffer.networkId, so coerce a numeric-string id first — otherwise an
       // existing buffer wouldn't match and we'd send a duplicate JOIN.
@@ -876,12 +876,12 @@ export const useBuffersStore = defineStore('buffers', {
         // it immediately. Re-send JOIN if we're not currently in it.
         this.activate(nid, existing.target);
         if (existing.joined) return true;
-        return socketSend({ type: 'join', networkId: nid, channel: existing.target });
+        return socketSend({ type: 'join', networkId: nid, channel: existing.target, key });
       }
       // Brand-new channel: don't open optimistically (#260). Join and wait for
       // the channel-joined confirmation; requestJoin focuses on success and
       // toasts on rejection.
-      const ok = socketSend({ type: 'join', networkId: nid, channel });
+      const ok = socketSend({ type: 'join', networkId: nid, channel, key });
       if (ok) this.requestJoin(nid, channel);
       return ok;
     },


### PR DESCRIPTION
Builds on @Fastidious's #476 (cherry-picked here with authorship preserved, so their commits keep contributor credit) and carries it the rest of the way to a complete, tested feature.

## What this does
- **`/join #channel key`** now works — the key threads MessageInput → buffers store → ws hub → ircManager → ircConnection → irc-framework's `join(channel, key)`.
- **Channel modes (`+k`/`+l`, etc.) surface in the status bar**, with list modes (bans/exceptions/quiets) excluded — matching how weechat/irssi/gamja/halloy do it.
- **Channel keys persist**, so a keyed channel auto-rejoins with its key after any reconnect or cell restart — the behaviour every always-on client ships (soju/znc/The Lounge all do this; The Lounge, same irc-framework, does literally `irc.join(name, key)` on reconnect).

## Notable changes on top of #476
1. **List-mode exclusion is ISUPPORT `CHANMODES`-driven** (group A), not a hardcoded `['b','e','I','q','a']` — correct per-ircd, matching every reference client. irc-framework already parses `CHANMODES`, so it's free.
2. **Robustness/security:** a non-string channel key from an untrusted ws/HTTP payload no longer reaches irc-framework's serialiser (a numeric key would `.match()` on a Number and throw uncaught — with no global handler, that drops the shared hosted-cell process).
3. **`channels.key` column, encrypted at rest** with the same envelope as network secrets (plaintext passthrough on self-host; ciphertext in the R2-replicated SQLite on hosted). Wired through export (portable plaintext), import (re-encrypt), and a boot backfill.
4. **Key lifecycle handled carefully:** a keyless re-join preserves a stored key (never wipes it, à la soju); MODE `-k` clears; a value-less `+k` (on-join burst) or a masked `+k *` (servers hiding the key from non-ops) leaves the stored key untouched.
5. **`foldBufferCase` carries the key** through case-fork merges — without it, a case-folded keyed channel silently lost its key on the next migration.
6. **Keyed auto-rejoin batches** with aligned positional key lists (`JOIN #a,#b k_a,k_b`) so a user with many keyed channels doesn't trip flood protection.

## Tests
DB round-trip (store/preserve/update/clear, case-insensitive), at-rest encryption + export/import round-trip, fold key-survival, `resolveKeyModeChange` guards, keyed-batch key alignment across the line-cap split, `/join` key forwarding at every layer, mode display, and a `joinChannel`→rejoin-plan end-to-end assertion. `npm run check` clean; full suite green (+33 tests).

## Follow-ups (deliberately out of scope)
- #485 — make export/import at-rest encryption schema-driven (per-table `encryptedColumns`), collapsing the per-table special-cases and the three boot backfills.
- #486 — derive `isPrefixMode` from ISUPPORT `PREFIX` (pre-existing hardcode this work surfaces).

Original PR: #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)