### PR TITLE
Update about pane to indicate that Lurker is FOSS

### DIFF
--- a/vue_client/src/components/settings-panes/AboutPane.vue
+++ b/vue_client/src/components/settings-panes/AboutPane.vue
@@ -35,7 +35,7 @@
       </li>
     </ul>
     <p class="about-warning">
-      Lurker is free and source-available — anyone can host it themselves at no cost. If you're
+      Lurker is free and open source software — anyone can host it themselves at no cost. If you're
       paying for it, be sure you know why.
     </p>
   </section>


### PR DESCRIPTION
I noticed that the About pane said that Lurker is source-available, which isn't true anymore since it was re-licensed under a true open source license (yay!). Update the about text to show that it is free and open source software, not just source-available.