### PR TITLE
Sidebar & topic-bar UX overhaul (#411)

### DIFF
--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -5,164 +5,251 @@
 
 <template>
   <div class="buffer-list-frame">
-    <nav
-      ref="scroller"
-      class="buffer-list"
-      :class="{ 'unread-bold': unreadBold }"
-      @scroll="scheduleRecompute"
-    >
-      <!-- LURKER: the system buffer (#355) as a real top-of-list row. The status
-           light tracks the Lurker connection; the collapse control sits in the
-           corner — always visible (not hover-gated), but yielding the corner to
-           the unread/highlight badge when there is one. (Settings lives in the
-           sidebar footer.) -->
-      <div class="net system-net">
-        <div
-          class="net-head"
-          :class="{ active: isSystemActive }"
-          title="Open Lurker system buffer"
-          @click="selectSystem"
+    <!-- LURKER: the system buffer (#355) as a proper fixed header — it does not
+         scroll with the list (the list scrolls beneath it), matching the pinned
+         sidebar footer. Corner controls: + adds a network, << collapses the
+         sidebar; both always visible (not hover-gated). When the row itself has
+         an unread/highlight badge the + yields the corner to it (the << stays);
+         hovering brings the + back. -->
+    <div class="net system-net">
+      <div
+        class="net-head"
+        :class="{ active: isSystemActive }"
+        title="Open Lurker system buffer"
+        @click="selectSystem"
+      >
+        <span
+          class="indicator"
+          :class="lurkerConnected ? 'good' : 'bad'"
+          :title="lurkerConnected ? 'Connected to Lurker' : 'Disconnected from Lurker'"
+        ></span>
+        <span class="name">LURKER</span>
+        <span
+          v-if="systemHighlights > 0 && showHighlightBadge"
+          class="badge highlight"
+          title="unread"
+          >●</span
         >
-          <span
-            class="indicator"
-            :class="lurkerConnected ? 'good' : 'bad'"
-            :title="lurkerConnected ? 'Connected to Lurker' : 'Disconnected from Lurker'"
-          ></span>
-          <span class="name">LURKER</span>
-          <span
-            v-if="systemHighlights > 0 && showHighlightBadge"
-            class="badge highlight"
-            title="unread"
-            >●</span
+        <span v-if="systemUnread > 0" class="badge">{{ unreadLabel(systemUnread) }}</span>
+        <div class="net-actions">
+          <button
+            type="button"
+            class="net-action net-add"
+            title="Add network"
+            aria-label="Add network"
+            @click.stop="openAddNetwork"
+            @contextmenu.stop.prevent
           >
-          <span v-if="systemUnread > 0" class="badge">{{ unreadLabel(systemUnread) }}</span>
-          <div class="net-actions">
-            <button
-              type="button"
-              class="net-action"
-              title="Hide channel list"
-              aria-label="Hide channel list"
-              @click.stop="collapseSidebar"
-              @contextmenu.stop.prevent
-            >
-              <i class="fa-solid fa-angles-left"></i>
-            </button>
-          </div>
+            <i class="fa-solid fa-plus"></i>
+          </button>
+          <button
+            type="button"
+            class="net-action net-settings"
+            title="Settings"
+            aria-label="Settings"
+            @click.stop="openSettings"
+            @contextmenu.stop.prevent
+          >
+            <i class="fa-solid fa-gear"></i>
+          </button>
+          <button
+            type="button"
+            class="net-action"
+            title="Hide channel list"
+            aria-label="Hide channel list"
+            @click.stop="collapseSidebar"
+            @contextmenu.stop.prevent
+          >
+            <i class="fa-solid fa-angles-left"></i>
+          </button>
         </div>
       </div>
+    </div>
 
-      <!-- FRIENDS pseudo-network: a cross-network gathering of DM shortcuts. The
+    <div class="buffer-list-scroll">
+      <nav
+        ref="scroller"
+        class="buffer-list"
+        :class="{ 'unread-bold': unreadBold }"
+        @scroll="scheduleRecompute"
+      >
+        <!-- FRIENDS pseudo-network: a cross-network gathering of DM shortcuts. The
            header opens the compilation feed (:friends:); each row opens that
            friend's DM on their primary network. -->
-      <div v-if="friends.contacts.length || isFriendsActive" class="net friends-net">
-        <div
-          class="net-head"
-          :class="{ active: isFriendsActive }"
-          title="Open Friends feed"
-          @click="selectFriends"
-        >
-          <span class="indicator" :class="friendsPresence" :title="friendsStatusTitle"></span>
-          <span class="name">FRIENDS</span>
-        </div>
-        <ul v-if="friends.contacts.length" class="channels">
-          <li
-            v-for="c in friends.contacts"
-            :key="c.id"
-            :class="friendRowClasses(c)"
-            :title="`Open DM with ${c.displayName}`"
-            @click="openFriendDm(c)"
-            @contextmenu.prevent="openFriendActions($event, c)"
+        <div v-if="friends.contacts.length || isFriendsActive" class="net friends-net">
+          <div
+            class="net-head"
+            :class="{ active: isFriendsActive }"
+            title="Open Friends feed"
+            @click="selectFriends"
           >
-            <span class="label">{{ c.displayName }}</span>
+            <span class="indicator" :class="friendsPresence" :title="friendsStatusTitle"></span>
+            <span class="name">FRIENDS</span>
+            <div class="net-actions">
+              <button
+                type="button"
+                class="net-action net-add"
+                title="Add friend"
+                aria-label="Add friend"
+                @click.stop="friends.openEditorNew()"
+                @contextmenu.stop.prevent
+              >
+                <i class="fa-solid fa-plus"></i>
+              </button>
+            </div>
+          </div>
+          <ul v-if="friends.contacts.length" class="channels">
+            <li
+              v-for="c in friends.contacts"
+              :key="c.id"
+              :class="friendRowClasses(c)"
+              :title="`Open DM with ${c.displayName}`"
+              @click="openFriendDm(c)"
+              @contextmenu.prevent="openFriendActions($event, c)"
+            >
+              <span class="label">{{ c.displayName }}</span>
+              <span
+                v-if="friendHighlights(c) > 0 && showHighlightBadge"
+                class="badge highlight"
+                title="unread highlight"
+                >●</span
+              >
+              <span v-if="friendUnread(c) > 0" class="badge">{{
+                unreadLabel(friendUnread(c))
+              }}</span>
+              <button
+                type="button"
+                class="row-actions"
+                title="Edit friend"
+                aria-label="Edit friend"
+                @click.stop="friends.openEditorForContact(c)"
+                @contextmenu.stop.prevent
+              >
+                <i class="fa-solid fa-user-pen"></i>
+              </button>
+            </li>
+          </ul>
+        </div>
+
+        <div v-for="net in networks.networks" :key="net.id" class="net">
+          <div
+            class="net-head"
+            :class="netHeadClasses(net.id)"
+            :title="`Open ${net.name} server buffer`"
+            @click="select(net.id, serverTarget(net.id))"
+            @contextmenu.prevent="
+              networkActions.onNetworkContextMenu(net, $event.clientX, $event.clientY)
+            "
+          >
+            <span class="indicator" :class="stateClass(net.id)"></span>
+            <span class="name">{{ net.name }}</span>
             <span
-              v-if="friendHighlights(c) > 0 && showHighlightBadge"
+              v-if="serverHighlights(net.id) > 0 && showHighlightBadge"
               class="badge highlight"
-              title="unread highlight"
+              :title="`${serverHighlights(net.id)} highlight${serverHighlights(net.id) === 1 ? '' : 's'}`"
               >●</span
             >
-            <span v-if="friendUnread(c) > 0" class="badge">{{ unreadLabel(friendUnread(c)) }}</span>
-            <button
-              type="button"
-              class="row-actions"
-              title="Friend actions"
-              aria-label="Friend actions"
-              @click.stop="openFriendActions($event, c)"
-              @contextmenu.stop.prevent
+            <span
+              v-if="countFor(serverUnread(net.id), serverHighlights(net.id)) > 0"
+              class="badge"
+              >{{ unreadLabel(countFor(serverUnread(net.id), serverHighlights(net.id))) }}</span
             >
-              <i class="fa-solid fa-ellipsis-vertical"></i>
-            </button>
-          </li>
-        </ul>
-      </div>
-
-      <div v-for="net in networks.networks" :key="net.id" class="net">
-        <div
-          class="net-head"
-          :class="netHeadClasses(net.id)"
-          :title="`Open ${net.name} server buffer`"
-          @click="select(net.id, serverTarget(net.id))"
-          @contextmenu.prevent="
-            networkActions.onNetworkContextMenu(net, $event.clientX, $event.clientY)
-          "
-        >
-          <span class="indicator" :class="stateClass(net.id)"></span>
-          <span class="name">{{ net.name }}</span>
-          <span
-            v-if="serverHighlights(net.id) > 0 && showHighlightBadge"
-            class="badge highlight"
-            :title="`${serverHighlights(net.id)} highlight${serverHighlights(net.id) === 1 ? '' : 's'}`"
-            >●</span
-          >
-          <span v-if="countFor(serverUnread(net.id), serverHighlights(net.id)) > 0" class="badge">{{
-            unreadLabel(countFor(serverUnread(net.id), serverHighlights(net.id)))
-          }}</span>
-          <div v-if="!hasUnreadIndicator(serverBuf(net.id))" class="net-actions">
-            <button
-              type="button"
-              class="net-action"
-              :disabled="!isNetworkConnected(net)"
-              title="Channel List"
-              aria-label="Channel list"
-              @click.stop="networkActions.openChannelList(net)"
-              @contextmenu.stop.prevent
-            >
-              <i class="fa-solid fa-hashtag"></i>
-            </button>
-            <button
-              type="button"
-              class="net-action"
-              title="Network options"
-              aria-label="Network options"
-              @click.stop="networkActions.openMenuFromButton(net, $event.currentTarget as Element)"
-              @contextmenu.stop.prevent
-            >
-              <i class="fa-solid fa-ellipsis-vertical"></i>
-            </button>
+            <div class="net-actions">
+              <button
+                type="button"
+                class="net-action net-add"
+                :disabled="!isNetworkConnected(net)"
+                title="Add channel"
+                aria-label="Add channel"
+                @click.stop="joinChannelModal.open(net.id)"
+                @contextmenu.stop.prevent
+              >
+                <i class="fa-solid fa-plus"></i>
+              </button>
+              <button
+                type="button"
+                class="net-action"
+                title="Network options"
+                aria-label="Network options"
+                @click.stop="
+                  networkActions.openMenuFromButton(net, $event.currentTarget as Element)
+                "
+                @contextmenu.stop.prevent
+              >
+                <i class="fa-solid fa-ellipsis-vertical"></i>
+              </button>
+            </div>
           </div>
-        </div>
 
-        <!-- Touch delay (200ms, touch-only) so a quick swipe over the pinned
+          <!-- Touch delay (200ms, touch-only) so a quick swipe over the pinned
              section scrolls the channel list instead of starting a reorder.
              Press-and-hold still initiates drag — the iOS/Discord/Slack
              reorder convention. touchStartThreshold cancels the pending drag
              if the finger moves more than 5px during the delay, so scroll
              intent is recognised early. Desktop mouse drag stays instant. -->
-        <draggable
-          v-if="(pinnedBufsByNet[net.id] || []).length"
-          :list="pinnedBufsByNet[net.id]"
-          item-key="target"
-          tag="ul"
-          class="channels pinned"
-          :animation="120"
-          ghost-class="drag-ghost"
-          :delay="200"
-          :delay-on-touch-only="true"
-          :touch-start-threshold="5"
-          @start="dragging = true"
-          @end="onPinDragEnd(net.id)"
-        >
-          <template #item="{ element: buf }">
+          <draggable
+            v-if="(pinnedBufsByNet[net.id] || []).length"
+            :list="pinnedBufsByNet[net.id]"
+            item-key="target"
+            tag="ul"
+            class="channels pinned"
+            :animation="120"
+            ghost-class="drag-ghost"
+            :delay="200"
+            :delay-on-touch-only="true"
+            :touch-start-threshold="5"
+            @start="dragging = true"
+            @end="onPinDragEnd(net.id)"
+          >
+            <template #item="{ element: buf }">
+              <li
+                :class="rowClasses(buf, net.id)"
+                :title="dmTitle(buf)"
+                @click="select(net.id, buf.target)"
+                @contextmenu.prevent="onBufferContextMenu($event, buf)"
+              >
+                <span class="label">{{ labelFor(buf) }}</span>
+                <span
+                  v-if="hasDraft(buf)"
+                  class="badge draft"
+                  title="unsent draft"
+                  aria-label="unsent draft"
+                  ><i class="fa-solid fa-pencil"></i
+                ></span>
+                <span
+                  v-if="buf.highlighted > 0 && showHighlightBadge"
+                  class="badge highlight"
+                  :title="`${buf.highlighted} highlight${buf.highlighted === 1 ? '' : 's'}`"
+                  >●</span
+                >
+                <span v-if="displayCount(buf) > 0" class="badge">{{
+                  unreadLabel(displayCount(buf))
+                }}</span>
+                <button
+                  v-if="!isServerBuffer(buf)"
+                  type="button"
+                  class="row-actions"
+                  title="Actions"
+                  aria-label="Buffer actions"
+                  @click.stop="onRowActionsClick($event, buf)"
+                  @contextmenu.stop.prevent
+                >
+                  <i class="fa-solid fa-ellipsis-vertical"></i>
+                </button>
+              </li>
+            </template>
+          </draggable>
+
+          <div
+            v-if="(pinnedBufsByNet[net.id] || []).length && unpinnedBufs(net.id).length"
+            class="pin-divider"
+            aria-hidden="true"
+          ></div>
+
+          <ul v-if="unpinnedBufs(net.id).length" class="channels">
             <li
+              v-for="buf in unpinnedBufs(net.id)"
+              :key="buf.target"
               :class="rowClasses(buf, net.id)"
               :title="dmTitle(buf)"
               @click="select(net.id, buf.target)"
@@ -186,7 +273,7 @@
                 unreadLabel(displayCount(buf))
               }}</span>
               <button
-                v-if="!isServerBuffer(buf) && !hasUnreadIndicator(buf)"
+                v-if="!isServerBuffer(buf)"
                 type="button"
                 class="row-actions"
                 title="Actions"
@@ -197,77 +284,31 @@
                 <i class="fa-solid fa-ellipsis-vertical"></i>
               </button>
             </li>
-          </template>
-        </draggable>
-
-        <div
-          v-if="(pinnedBufsByNet[net.id] || []).length && unpinnedBufs(net.id).length"
-          class="pin-divider"
-          aria-hidden="true"
-        ></div>
-
-        <ul v-if="unpinnedBufs(net.id).length" class="channels">
-          <li
-            v-for="buf in unpinnedBufs(net.id)"
-            :key="buf.target"
-            :class="rowClasses(buf, net.id)"
-            :title="dmTitle(buf)"
-            @click="select(net.id, buf.target)"
-            @contextmenu.prevent="onBufferContextMenu($event, buf)"
-          >
-            <span class="label">{{ labelFor(buf) }}</span>
-            <span
-              v-if="hasDraft(buf)"
-              class="badge draft"
-              title="unsent draft"
-              aria-label="unsent draft"
-              ><i class="fa-solid fa-pencil"></i
-            ></span>
-            <span
-              v-if="buf.highlighted > 0 && showHighlightBadge"
-              class="badge highlight"
-              :title="`${buf.highlighted} highlight${buf.highlighted === 1 ? '' : 's'}`"
-              >●</span
-            >
-            <span v-if="displayCount(buf) > 0" class="badge">{{
-              unreadLabel(displayCount(buf))
-            }}</span>
-            <button
-              v-if="!isServerBuffer(buf) && !hasUnreadIndicator(buf)"
-              type="button"
-              class="row-actions"
-              title="Actions"
-              aria-label="Buffer actions"
-              @click.stop="onRowActionsClick($event, buf)"
-              @contextmenu.stop.prevent
-            >
-              <i class="fa-solid fa-ellipsis-vertical"></i>
-            </button>
-          </li>
-        </ul>
-      </div>
-      <p v-if="!networks.networks.length" class="empty">
-        No networks yet — add one with the + button.
-      </p>
-    </nav>
-    <button
-      v-if="unreadAbove"
-      type="button"
-      class="unread-edge top"
-      :class="{ 'is-highlight': highlightAbove }"
-      title="Unread buffers above — click to scroll into view"
-      aria-label="Scroll to unread buffers above"
-      @click="scrollToUnread('up')"
-    ></button>
-    <button
-      v-if="unreadBelow"
-      type="button"
-      class="unread-edge bottom"
-      :class="{ 'is-highlight': highlightBelow }"
-      title="Unread buffers below — click to scroll into view"
-      aria-label="Scroll to unread buffers below"
-      @click="scrollToUnread('down')"
-    ></button>
+          </ul>
+        </div>
+        <p v-if="!networks.networks.length" class="empty">
+          No networks yet — add one with the + button.
+        </p>
+      </nav>
+      <button
+        v-if="unreadAbove"
+        type="button"
+        class="unread-edge top"
+        :class="{ 'is-highlight': highlightAbove }"
+        title="Unread buffers above — click to scroll into view"
+        aria-label="Scroll to unread buffers above"
+        @click="scrollToUnread('up')"
+      ></button>
+      <button
+        v-if="unreadBelow"
+        type="button"
+        class="unread-edge bottom"
+        :class="{ 'is-highlight': highlightBelow }"
+        title="Unread buffers below — click to scroll into view"
+        aria-label="Scroll to unread buffers below"
+        @click="scrollToUnread('down')"
+      ></button>
+    </div>
   </div>
 </template>
 
@@ -282,6 +323,7 @@ import {
   ref,
   watch,
 } from 'vue';
+import { useRouter } from 'vue-router';
 import draggable from 'vuedraggable';
 import { useNetworksStore, type Network, type PeerPresenceEntry } from '../stores/networks.js';
 import { useBuffersStore, type Buffer } from '../stores/buffers.js';
@@ -294,6 +336,8 @@ import { useIgnoresStore } from '../stores/ignores.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useBufferActions } from '../composables/useBufferActions.js';
 import { useNetworkActions } from '../composables/useNetworkActions.js';
+import { useNetworkEditor } from '../composables/useNetworkEditor.js';
+import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
 import { useContextMenu } from '../composables/useContextMenu.js';
 import {
   isPeerOffline as derivePeerOffline,
@@ -309,7 +353,25 @@ const ignores = useIgnoresStore();
 const settings = useSettingsStore();
 const bufferActions = useBufferActions();
 const networkActions = useNetworkActions();
+const networkEditor = useNetworkEditor();
+const joinChannelModal = useJoinChannelModal();
 const friendMenu = useContextMenu();
+const router = useRouter();
+
+// The + in the LURKER header opens the add-network editor (the button moved off
+// the sidebar footer — #411). The modal itself is rendered by the chat shell
+// (Desktop/MobileChat), which already watches networkEditor.isOpen.
+function openAddNetwork(): void {
+  networkEditor.open();
+}
+
+// The LURKER header's sliders is the app-scoped "settings" affordance — the
+// system buffer's scope is the whole app, so its settings are the global ones
+// (#411). Moved here off the sidebar footer; the collapsed rail keeps its own
+// copy since this header is unmounted while collapsed (see DesktopChat).
+function openSettings(): void {
+  router.push('/settings').catch((err) => console.error('[BufferList] open settings failed', err));
+}
 
 function isNetworkConnected(net: Network): boolean {
   return networks.states[net.id]?.state === 'connected';
@@ -365,15 +427,6 @@ function displayCount(buf: Buffer): number {
   if (mode === 'full') return buf.unread;
   if (mode === 'highlights') return buf.highlighted;
   return 0;
-}
-
-// Hover-revealed kebab lives in the same right-edge slot as the unread/
-// highlight badges. When the row has unread state, the badge wins — the
-// kebab stays hidden so it doesn't overlay the indicator the user is
-// scanning for. Right-click on the row still opens the same action menu.
-function hasUnreadIndicator(buf: Buffer | null): boolean {
-  if (!buf) return false;
-  return (buf.highlighted > 0 && showHighlightBadge.value) || displayCount(buf) > 0;
 }
 
 // Per-network local mirror of the pinned buffer list, kept as concrete buffer
@@ -504,7 +557,8 @@ function onBufferContextMenu(e: MouseEvent, buf: Buffer): void {
   bufferActions.openMenuFor(buf, e.clientX, e.clientY);
 }
 
-// Hover three-dots affordance — opens the same menu anchored to the button.
+// The per-row kebab (channel/DM rows) — opens the buffer's context menu anchored
+// to the button, the same menu a right-click on the row gives.
 function onRowActionsClick(e: MouseEvent, buf: Buffer): void {
   bufferActions.openMenuFromButton(buf, e.currentTarget as Element);
 }
@@ -793,23 +847,12 @@ function scrollActiveIntoZone(behavior: ScrollBehavior): void {
   const elRect = el.getBoundingClientRect();
   const rowH = elRect.height;
   if (rowH <= 0) return;
-  // The LURKER row (.system-net) is sticky-pinned to the top on desktop, so
-  // buffers scroll *under* it — the usable top of the viewport is below it, not
-  // at scRect.top. Without this inset, upward nav parks the active row 3 rows
-  // below scRect.top but the sticky header hides the topmost ~row, so the top
-  // stays cramped while the (unobstructed) bottom looks fine (#388). The formula
-  // also covers mobile, where .system-net is inline: it insets only by however
-  // much the row actually overlaps the top, and clamps to 0 once it scrolls off.
-  const sticky = sc.querySelector<HTMLElement>('.system-net');
-  const topInset = sticky ? Math.max(0, sticky.getBoundingClientRect().bottom - scRect.top) : 0;
-  // When the active row IS the sticky LURKER row and it's pinned at the top
-  // (topInset > 0), it's already fully visible, so selecting the system buffer
-  // must not move the list. Without this the math below treats the pinned header
-  // as sitting above the zone and yanks the list back to the top. On mobile the
-  // row is inline and can scroll off (topInset === 0), so we fall through and
-  // reveal it normally.
-  if (sticky && topInset > 0 && sticky.contains(el)) return;
-  const topEdge = scRect.top + topInset;
+  // The LURKER row now lives in a fixed header *outside* this scroller (#411), so
+  // the scroller's own top is the usable top of the viewport — no sticky-header
+  // inset to subtract anymore. The system buffer's header can never be `.active`
+  // inside `sc` (it isn't a descendant), so the query above returns null for it
+  // and we've already bailed; no special-case needed here.
+  const topEdge = scRect.top;
   const bottomEdge = scRect.bottom;
   // Never demand more room than centering would, so a viewport too short for the
   // full zone degrades to "centered" instead of fighting between the two edges.
@@ -869,10 +912,18 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-/* The frame is the component root: a non-scrolling, positioned box that holds
-   the scrollable nav plus the absolutely-pinned out-of-view unread bars. It
-   takes the flex slot the .buffer-list used to occupy in the sidebar. */
+/* The frame is the component root: a column of [fixed LURKER header] + [scroll
+   region]. The header never scrolls (#411); the scroll region holds the
+   scrollable nav plus the absolutely-pinned out-of-view unread bars. */
 .buffer-list-frame {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+/* Positioned wrapper so the out-of-view unread bars pin to the top/bottom of the
+   scroll viewport (below the fixed header), not the whole frame. */
+.buffer-list-scroll {
   flex: 1;
   min-height: 0;
   position: relative;
@@ -883,8 +934,8 @@ onBeforeUnmount(() => {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  /* No top padding: the LURKER row is always first and sits flush at the top so
-     it lines up with the topic bar across the sidebar boundary (#355). */
+  /* No top padding: the first network group sits flush under the fixed LURKER
+     header so it lines up with the topic bar across the sidebar boundary. */
   padding: 0 0 var(--space-2);
 }
 /* IRCCloud-style affordance: a thin accent bar pinned to the top or bottom
@@ -951,34 +1002,25 @@ onBeforeUnmount(() => {
   border-top: 1px solid var(--border);
   margin-top: var(--space-2);
 }
-/* The LURKER row is the sidebar's header — size it to the topic bar beside it:
+/* The LURKER row is the sidebar's header — a real fixed header now (#411): it's
+   a flex child of the frame that sits above the scroll region and never scrolls,
+   the same way the sidebar footer is pinned. Size it to the topic bar beside it:
    strip the group padding so it sits flush, give its head the topic bar's 8px
    block padding, and cap it with a 1px rule that lines up with the topic
    divider. (#355) */
 .system-net {
   padding: 0;
   border-bottom: 1px solid var(--border);
+  background: var(--bg);
 }
 .system-net .net-head {
   padding-block: var(--space-4);
-}
-/* The next group draws its own top separator via `.net + .net`; drop it here so
-   it doesn't double up with the LURKER row's bottom rule. */
-.system-net + .net {
-  border-top: none;
-  margin-top: 0;
-}
-/* Desktop only: pin the LURKER row as a fixed header so the networks/buffers
-   scroll under it. (Mobile keeps it inline — it has its own top bar.) Needs an
-   opaque background matching the sidebar (which inherits --bg) so scrolling rows
-   don't show through, and a z-index above them. */
-@media (min-width: 769px) {
-  .system-net {
-    position: sticky;
-    top: 0;
-    z-index: var(--z-base);
-    background: var(--bg);
-  }
+  /* Trim the right padding to var(--space-2) so the always-visible inline
+     + / gear / << line up with the absolutely-positioned + that the network /
+     FRIENDS headers reveal at right: var(--space-2). Without this the LURKER
+     controls, being in normal flow, end at the wider var(--space-5) content edge
+     and read ~6px too far left. (#411) */
+  padding-inline-end: var(--space-2);
 }
 .net-head {
   display: flex;
@@ -1006,15 +1048,25 @@ onBeforeUnmount(() => {
   border-left-color: var(--accent);
 }
 
-/* Hover action buttons on network rows — mirrors .channels .row-actions pattern. */
+/* Network-row header actions (+ add channel/network/friend, kebab). Hidden by
+   default and revealed only when the row is engaged — hovered, selected
+   (active), or keyboard-focused (#411) — so the corner stays quiet. At rest it
+   shows the unread/highlight badge (or nothing); when the actions appear the
+   badge steps aside so the two never stack.
+   pointer-events:none while hidden is essential, not cosmetic: the actions are
+   absolutely positioned over the badge, so an opacity:0 (but still hit-testable)
+   overlay would swallow taps meant for the row. On a touch device in desktop
+   layout (iPad, width>768) there's no hover, so without this a tap on a network
+   row's right edge could fire "add channel"/options instead of opening it. */
 .net-actions {
   position: absolute;
   right: var(--space-2);
   top: 50%;
   transform: translateY(-50%);
   display: flex;
-  background: var(--bg-soft);
+  background: none;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 80ms linear;
 }
 .net-action {
@@ -1026,9 +1078,28 @@ onBeforeUnmount(() => {
   font: inherit;
   line-height: 1;
 }
+/* Reveal triggers. Selected (active) and keyboard focus work on every device;
+   hover is desktop-only (gated below) so touch doesn't get a sticky-hover
+   reveal. Each also hides the badge so it doesn't sit under the actions. */
+.net-head.active .net-actions,
+.net-head:focus-within .net-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+/* Only the network/FRIENDS headers hide their badge when the actions reveal —
+   their actions are absolute and would overlap it. The LURKER header keeps its
+   actions inline and always-visible (below), so its count never needs to hide. */
+.net:not(.system-net) .net-head.active .badge,
+.net:not(.system-net) .net-head:focus-within .badge {
+  visibility: hidden;
+}
 @media (hover: hover) {
   .net-head:hover .net-actions {
     opacity: 1;
+    pointer-events: auto;
+  }
+  .net:not(.system-net) .net-head:hover .badge {
+    visibility: hidden;
   }
   .net-head:hover .net-action:disabled {
     opacity: 0.35;
@@ -1036,9 +1107,6 @@ onBeforeUnmount(() => {
   .net-action:hover {
     color: var(--fg);
   }
-}
-.net-actions:focus-within {
-  opacity: 1;
 }
 .net-action:disabled {
   pointer-events: none;
@@ -1049,23 +1117,48 @@ onBeforeUnmount(() => {
   }
 }
 
-/* LURKER row (#355): the settings cog is always visible, not hover-gated like
-   the other network rows. When an unread/highlight badge is present it takes
-   the corner and the cog steps aside — the badge is the more important signal,
-   and the cog returns the moment the buffer is read. */
+/* LURKER header (#411): its actions ride the normal flex flow (static, not
+   absolute) so they sit beside the unread count without overlapping it (which is
+   also why the count never has to step aside here). The container stays visible
+   because the << collapse control is a persistent affordance — but the + (add
+   network) and gear (settings) reveal only on hover / selection / focus, like
+   the other headers' actions. */
 .system-net .net-actions {
+  position: static;
+  transform: none;
   opacity: 1;
-  /* Flat (no chip): the cog is always visible here, so unlike the other rows'
-     hover-revealed actions there's no row content to mask behind it. */
-  background: none;
+  pointer-events: auto;
 }
-.system-net .net-head:has(.badge) .net-actions {
-  display: none;
+/* On pointer (hover-capable) devices, declutter the header: hide the + and gear
+   until the row is hovered, selected, or focused. Touch devices have no hover to
+   reveal them (and display:none would make them unfocusable, so :focus-within
+   couldn't help either) — so there the whole block is skipped and they stay
+   visible. The collapse << is always visible on every device regardless. */
+@media (hover: hover) {
+  .system-net .net-add,
+  .system-net .net-settings {
+    display: none;
+  }
+  .system-net .net-head:hover .net-add,
+  .system-net .net-head:hover .net-settings,
+  .system-net .net-head.active .net-add,
+  .system-net .net-head.active .net-settings,
+  .system-net .net-head:focus-within .net-add,
+  .system-net .net-head:focus-within .net-settings {
+    display: inline-flex;
+  }
 }
 
 .name {
   flex: 1;
   color: var(--fg);
+  /* Ellipsize like .label so a long network name clips instead of wrapping the
+     row to two lines or running under the revealed + / kebab glyphs. min-width:0
+     lets the flex item shrink below its content width so the ellipsis engages. */
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .indicator {
   width: 7px;
@@ -1194,13 +1287,14 @@ onBeforeUnmount(() => {
   color: var(--fg-muted);
 }
 
-/* Hover three-dots: absolute-positioned so it doesn't displace badges on
-   hover-in. Briefly overlays the rightmost badges while the cursor is on
-   the row — that's the moment the user is reaching for the menu, so the
-   badges have already done their job. Background matches the row's hover
-   shade so the overlay reads as part of the row, not floating chrome.
-   Hidden on touch breakpoints; mobile uses the topic-bar cog (channels/
-   DMs) or single-tap (members) instead. */
+/* Per-row settings affordance (the sliders on channel/DM rows, the kebab on
+   friend rows). Absolute so it overlays the badges rather than displacing them.
+   Same reveal model as the header + buttons (#411): hidden at rest, surfaced
+   when the row is hovered, selected (active), or keyboard-focused, with the
+   badge stepping aside so the two never stack. Background matches the row's
+   hover/active shade so the overlay reads as part of the row. Hidden on phones
+   (mobile uses the topic-bar cog / single-tap); on tablets the active row and
+   long-press cover it. */
 .channels .row-actions {
   position: absolute;
   right: var(--space-2);
@@ -1214,22 +1308,34 @@ onBeforeUnmount(() => {
   font: inherit;
   line-height: 1;
   opacity: 0;
+  /* pointer-events:none while hidden so the invisible overlay can't swallow taps
+     on the row's right edge — on iPad (width>768) an inactive row's control
+     never reveals, and long-press on the row opens the same menu, so it must
+     never be tappable in its own right. */
+  pointer-events: none;
   transition: opacity 80ms linear;
 }
-/* Reveal the row-actions button on hover (desktop) or keyboard focus (a11y).
-   No touch path here on purpose — long-press fires `contextmenu` on the row,
-   which already opens the same buffer-actions menu, so iPad users reach
-   identical functionality without paying the sticky-hover two-tap tax. */
+/* Reveal on select (active) or keyboard focus — works on every device. */
+.channels li.active .row-actions,
+.channels .row-actions:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.channels li.active .badge {
+  visibility: hidden;
+}
+/* Reveal on hover — desktop only, so touch doesn't get a sticky-hover reveal. */
 @media (hover: hover) {
   .channels li:hover .row-actions {
     opacity: 1;
+    pointer-events: auto;
+  }
+  .channels li:hover .badge {
+    visibility: hidden;
   }
   .channels .row-actions:hover {
     color: var(--fg);
   }
-}
-.channels .row-actions:focus-visible {
-  opacity: 1;
 }
 @media (max-width: 768px) {
   .channels .row-actions {

--- a/vue_client/src/components/JoinChannelModal.vue
+++ b/vue_client/src/components/JoinChannelModal.vue
@@ -1,0 +1,143 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  "Join Channel" modal (#411). A lightweight entry point attached to the + button
+  on each network header: type a channel name and join it directly, or fall
+  through to the full channel-list browser. Network-scoped — the network is
+  implied by the header/button the user opened it from. A future admin overhaul
+  can grow this with instance-suggested channels (see the issue).
+-->
+
+<template>
+  <AppModal word="join" :title="`join channel — ${networkLabel}`" size="sm" @close="$emit('close')">
+    <form class="modal-form" @submit.prevent="onJoin">
+      <div class="body">
+        <input
+          ref="inputEl"
+          v-model="channel"
+          class="chan-input"
+          type="text"
+          placeholder="#channel"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+        />
+        <button type="button" class="browse" @click="onBrowse">
+          <i class="fa-solid fa-hashtag" aria-hidden="true"></i>
+          Browse Channel List
+        </button>
+      </div>
+      <footer class="modal-footer">
+        <button type="button" class="btn-secondary" @click="$emit('close')">Cancel</button>
+        <button type="submit" class="btn-primary" :disabled="!normalized">Join</button>
+      </footer>
+    </form>
+  </AppModal>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import AppModal from './AppModal.vue';
+import { useNetworksStore } from '../stores/networks.js';
+import { useBuffersStore } from '../stores/buffers.js';
+import { useToastsStore } from '../stores/toasts.js';
+import { useChannelListModal } from '../composables/useChannelListModal.js';
+
+const props = defineProps<{ networkId: number }>();
+const emit = defineEmits<{ close: [] }>();
+
+const networks = useNetworksStore();
+const buffers = useBuffersStore();
+const channelListModal = useChannelListModal();
+
+const inputEl = ref<HTMLInputElement | null>(null);
+const channel = ref('');
+
+const networkLabel = computed(() => {
+  const net = networks.networks.find((n) => n.id === props.networkId);
+  return net?.name || `net:${props.networkId}`;
+});
+
+// Prepend a leading # when the user omits a channel prefix (#, &, +, !) — a
+// bare, prefix-less name is what people usually type. (This is slightly more
+// permissive than the /join command, which only auto-prefixes with #.) Returns
+// '' for anything that isn't a valid target so the Join button stays disabled:
+// channel names can't contain whitespace, and a lone prefix has no name — either
+// would otherwise send a JOIN the server just rejects.
+const normalized = computed(() => {
+  const raw = channel.value.trim();
+  if (!raw || /\s/.test(raw)) return '';
+  const withPrefix = /^[#&+!]/.test(raw) ? raw : `#${raw}`;
+  return withPrefix.length > 1 ? withPrefix : '';
+});
+
+function onJoin() {
+  const target = normalized.value;
+  if (!target) return;
+  // joinOrActivate switches to an already-open buffer or sends a JOIN; it only
+  // returns false when a JOIN had to go out but the socket is closed. Surface
+  // that so the click isn't a silent no-op (the modal still closes either way).
+  if (!buffers.joinOrActivate(props.networkId, target)) {
+    useToastsStore().push({
+      kind: 'warn',
+      title: 'Not connected',
+      body: `Can't join ${target} while disconnected.`,
+      networkId: props.networkId,
+      ttlMs: 5000,
+    });
+  }
+  emit('close');
+}
+
+// Hand off to the full channel-list browser for the same network. Close this
+// modal first; the shared channel-list toggle then renders it (both live off
+// singleton composables, so opening one and closing the other just works).
+function onBrowse() {
+  const id = props.networkId;
+  emit('close');
+  channelListModal.open(id);
+}
+
+onMounted(() => {
+  setTimeout(() => inputEl.value?.focus(), 0);
+});
+</script>
+
+<style scoped>
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+.chan-input {
+  background: var(--bg-soft);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: var(--space-4) var(--space-5);
+  font: inherit;
+}
+.chan-input:focus {
+  outline: 1px solid var(--accent);
+}
+/* Secondary path — a full-width, quiet button that reads as "or, browse" rather
+   than competing with the primary Join action in the footer. */
+.browse {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--accent);
+  font: inherit;
+  padding: var(--space-3) var(--space-5);
+  cursor: pointer;
+}
+.browse:hover {
+  border-color: var(--accent);
+  color: var(--fg);
+}
+</style>

--- a/vue_client/src/composables/useJoinChannelModal.ts
+++ b/vue_client/src/composables/useJoinChannelModal.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { ref } from 'vue';
+
+// Shared open-state for the "Join Channel" modal (#411). Mirrors
+// useChannelListModal: a singleton network-scoped toggle so any surface (a
+// network header's + button, the server-buffer topic bar, the mobile kebab)
+// opens the same modal instance.
+const isOpen = ref(false);
+const networkId = ref<number | null>(null);
+
+export function useJoinChannelModal() {
+  function open(id: number): void {
+    networkId.value = id;
+    isOpen.value = true;
+  }
+  function close(): void {
+    isOpen.value = false;
+    networkId.value = null;
+  }
+  return { isOpen, networkId, open, close };
+}

--- a/vue_client/src/composables/useNetworkActions.ts
+++ b/vue_client/src/composables/useNetworkActions.ts
@@ -4,16 +4,19 @@
 import type { ContextMenuItem } from './useContextMenu.js';
 import { useContextMenu } from './useContextMenu.js';
 import { useChannelListModal } from './useChannelListModal.js';
+import { useJoinChannelModal } from './useJoinChannelModal.js';
 import { useNetworkEditor } from './useNetworkEditor.js';
 import { useNotifyLadder } from './useNotifyLadder.js';
 import { useNetworksStore, type Network } from '../stores/networks.js';
 
 // Buffer-list action logic for network rows. Analogous to useBufferActions for
-// channel/DM rows. Opens the channel list modal or a two-item overflow menu
-// (Edit Network + Disconnect/Reconnect) anchored to a button or cursor position.
+// channel/DM rows. Builds the network context menu — Join Channel / Channel List,
+// Edit Network / Disconnect·Reconnect, and the notification ladder — anchored to
+// a button (the header kebab) or a cursor position (right-click / long-press).
 export function useNetworkActions() {
   const menu = useContextMenu();
   const channelListModal = useChannelListModal();
+  const joinChannelModal = useJoinChannelModal();
   const networkEditor = useNetworkEditor();
   const notify = useNotifyLadder();
   const networks = useNetworksStore();
@@ -28,6 +31,21 @@ export function useNetworkActions() {
   function buildItems(net: Network): ContextMenuItem[] {
     const isConnected = networks.states[net.id]?.state === 'connected';
     return [
+      // Channel actions first — the common reason to reach for a network's menu.
+      // Join needs a live connection; the channel list is still browsable from
+      // cache while disconnected, so only Join is gated.
+      {
+        label: 'Join Channel…',
+        icon: 'fa-solid fa-plus',
+        disabled: !isConnected,
+        onClick: () => joinChannelModal.open(net.id),
+      },
+      {
+        label: 'Channel List…',
+        icon: 'fa-solid fa-hashtag',
+        onClick: () => channelListModal.open(net.id),
+      },
+      { divider: true },
       {
         label: 'Edit Network',
         icon: 'fa-solid fa-gear',
@@ -56,9 +74,5 @@ export function useNetworkActions() {
     menu.open(buildItems(net), x, y);
   }
 
-  function openChannelList(net: Network): void {
-    channelListModal.open(net.id);
-  }
-
-  return { openMenuFromButton, onNetworkContextMenu, openChannelList };
+  return { openMenuFromButton, onNetworkContextMenu };
 }

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -22,20 +22,27 @@
         <i class="fa-solid fa-angles-right"></i>
       </button>
       <div ref="footEl" class="sidebar-foot" :class="{ 'foot-wrapped': footWrapped }">
-        <button class="link" @click="openSettings" title="Settings">
+        <!-- Settings and Add-network normally live in the LURKER header (#411),
+             but that header is unmounted while the sidebar is collapsed, so the
+             rail offers them here instead — collapsed-only to avoid duplicating
+             the header controls when expanded. -->
+        <button v-if="!showChannels" class="link" @click="openSettings" title="Settings">
           <i class="fa-solid fa-gear"></i>
         </button>
-        <button class="link" @click="showSearch = true" title="Search messages">
+        <button v-if="!showChannels" class="link" @click="openAddNetwork" title="Add network">
+          <i class="fa-solid fa-plus"></i>
+        </button>
+        <button class="link" @click="openSearch(false)" title="Search messages">
           <i class="fa-solid fa-magnifying-glass"></i>
         </button>
-        <button class="link" @click="showHighlights = true" title="Highlights">
-          <i class="fa-solid fa-bell"></i>
+        <button class="link" @click="openHighlights(false)" title="Highlights">
+          <i class="fa-regular fa-bell"></i>
         </button>
         <button class="link" @click="showBookmarks = true" title="Saved messages">
-          <i class="fa-solid fa-bookmark"></i>
+          <i class="fa-regular fa-bookmark"></i>
         </button>
         <button class="link" @click="showUploads = true" title="Recent uploads">
-          <i class="fa-solid fa-paperclip"></i>
+          <i class="fa-solid fa-arrow-up-from-bracket"></i>
         </button>
         <!-- Self-revealing: DCC is off for almost everyone, so the Transfers
              button only appears once a transfer exists (or the panel is open).
@@ -48,40 +55,41 @@
           @click="dcc.open()"
           :title="dccTitle"
         >
-          <i class="fa-solid fa-circle-down"></i>
-        </button>
-        <button class="link" @click="openAddNetwork" title="Add network">
-          <i class="fa-solid fa-plus"></i>
+          <i class="fa-solid fa-download"></i>
         </button>
       </div>
     </aside>
 
-    <header v-if="isVirtual" class="topic">
-      <div class="topic-meta">
-        <span class="buffer">{{ bufferLabel }}</span>
-      </div>
-      <div v-if="isFriendsBuffer" class="topic-actions">
+    <!-- Topic bar: always rendered so the back/forward history controls (#411)
+         are present in every state, even before any buffer is selected. The nav
+         cluster is anchored at the far left, left of the buffer title; the meta
+         (name + topic) and per-buffer actions render conditionally beside it. -->
+    <header class="topic">
+      <div class="topic-nav">
         <button
           type="button"
-          class="link"
-          title="Add friend"
-          aria-label="Add friend"
-          @click="friends.openEditorNew()"
+          class="link nav-btn"
+          title="Back"
+          aria-label="Back"
+          :disabled="!navHistory.canBack"
+          @click="navHistory.back()"
         >
-          <i class="fa-solid fa-person-circle-plus"></i>
+          <i class="fa-solid fa-angle-left"></i>
         </button>
-        <span
-          class="member-count"
-          :title="`${friendCount} ${friendCount === 1 ? 'friend' : 'friends'}`"
+        <button
+          type="button"
+          class="link nav-btn"
+          title="Forward"
+          aria-label="Forward"
+          :disabled="!navHistory.canForward"
+          @click="navHistory.forward()"
         >
-          <i class="fa-solid fa-users"></i> {{ friendCount }}
-        </span>
+          <i class="fa-solid fa-angle-right"></i>
+        </button>
       </div>
-    </header>
-    <header v-else-if="active" class="topic">
       <div class="topic-meta">
-        <span class="buffer">{{ bufferLabel }}</span>
-        <template v-if="topic">
+        <span v-if="isVirtual || active" class="buffer">{{ bufferLabel }}</span>
+        <template v-if="active && topic">
           <span class="sep">│</span>
           <button
             type="button"
@@ -94,68 +102,121 @@
         </template>
       </div>
       <div class="topic-actions">
-        <template v-if="isServerBuffer">
-          <button
-            type="button"
-            class="link"
-            title="Channel list"
-            aria-label="Channel list"
-            @click="active && channelListModal.open(active.networkId)"
-          >
-            <i class="fa-solid fa-hashtag"></i>
-          </button>
-          <button
-            type="button"
-            class="link"
-            :title="serverConnectActionLabel"
-            :aria-label="serverConnectActionLabel"
-            @click="toggleServerConnection"
-          >
-            <i :class="serverConnectActionIcon"></i>
-          </button>
-          <button class="link" title="Edit network" @click="editActiveNetwork">
-            <i class="fa-solid fa-gear"></i>
-          </button>
+        <template v-if="isVirtual">
+          <template v-if="isFriendsBuffer">
+            <button
+              type="button"
+              class="link"
+              title="Add friend"
+              aria-label="Add friend"
+              @click="friends.openEditorNew()"
+            >
+              <i class="fa-solid fa-person-circle-plus"></i>
+            </button>
+            <span
+              class="member-count"
+              :title="`${friendCount} ${friendCount === 1 ? 'friend' : 'friends'}`"
+            >
+              <i class="fa-solid fa-users"></i> {{ friendCount }}
+            </span>
+          </template>
         </template>
-        <template v-else-if="isDmHeader">
-          <button
-            type="button"
-            class="link"
-            title="View profile"
-            aria-label="View profile"
-            @click="openDmProfile"
-          >
-            <i class="fa-solid fa-id-card"></i>
-          </button>
-          <button
-            type="button"
-            class="link"
-            :title="dmNoteLabel"
-            :aria-label="dmNoteLabel"
-            @click="openDmNote"
-          >
-            <i class="fa-solid fa-note-sticky"></i>
-          </button>
-        </template>
-        <template v-else-if="isChannel">
-          <button
-            class="link"
-            :title="showMembers ? 'Hide members' : 'Show members'"
-            :aria-label="showMembers ? 'Hide members' : 'Show members'"
-            @click="toggleMembers"
-          >
-            <i class="fa-solid fa-users"></i>
-          </button>
-          <span
-            v-if="memberCount != null"
-            class="member-count"
-            :title="`${memberCount} ${memberCount === 1 ? 'user' : 'users'} in channel`"
-            >{{ memberCount }}</span
-          >
+        <template v-else-if="active">
+          <!-- Search & highlights scoped to this buffer (channels/DMs only) —
+               parity with the mobile topic bar. The server buffer has no
+               per-buffer scope, so it's excluded. -->
+          <template v-if="!isServerBuffer">
+            <button
+              type="button"
+              class="link"
+              title="Search this buffer"
+              aria-label="Search this buffer"
+              @click="openSearch(true)"
+            >
+              <i class="fa-solid fa-magnifying-glass"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              title="Highlights in this buffer"
+              aria-label="Highlights in this buffer"
+              @click="openHighlights(true)"
+            >
+              <i class="fa-regular fa-bell"></i>
+            </button>
+          </template>
+          <template v-if="isServerBuffer">
+            <button
+              type="button"
+              class="link"
+              title="Join channel"
+              aria-label="Join channel"
+              @click="active && joinChannelModal.open(active.networkId)"
+            >
+              <i class="fa-solid fa-plus"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              title="Channel list"
+              aria-label="Channel list"
+              @click="active && channelListModal.open(active.networkId)"
+            >
+              <i class="fa-solid fa-hashtag"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              :title="serverConnectActionLabel"
+              :aria-label="serverConnectActionLabel"
+              @click="toggleServerConnection"
+            >
+              <i :class="serverConnectActionIcon"></i>
+            </button>
+            <button class="link" title="Edit network" @click="editActiveNetwork">
+              <i class="fa-solid fa-gear"></i>
+            </button>
+          </template>
+          <template v-else-if="isDmHeader">
+            <button
+              type="button"
+              class="link"
+              title="View profile"
+              aria-label="View profile"
+              @click="openDmProfile"
+            >
+              <i class="fa-solid fa-id-card"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              :title="dmNoteLabel"
+              :aria-label="dmNoteLabel"
+              @click="openDmNote"
+            >
+              <i class="fa-solid fa-note-sticky"></i>
+            </button>
+          </template>
+          <template v-else-if="isChannel">
+            <button
+              class="link"
+              :title="showMembers ? 'Hide members' : 'Show members'"
+              :aria-label="showMembers ? 'Hide members' : 'Show members'"
+              @click="toggleMembers"
+            >
+              <i class="fa-solid fa-users"></i>
+            </button>
+            <span
+              v-if="memberCount != null"
+              class="member-count"
+              :title="`${memberCount} ${memberCount === 1 ? 'user' : 'users'} in channel`"
+              >{{ memberCount }}</span
+            >
+          </template>
         </template>
       </div>
     </header>
-    <div v-if="active || isVirtual" class="topic-divider"></div>
+    <div class="topic-divider"></div>
 
     <FriendsOverview v-if="renderMode === 'overview'" @view-activity="onViewActivity" />
     <MessageList v-else ref="messageListRef" :pending-scroll-id="pendingScrollId" />
@@ -170,6 +231,7 @@
     />
     <HighlightsModal
       v-if="showHighlights"
+      :scope="highlightScope"
       @close="showHighlights = false"
       @jump="onJumpToMessage"
     />
@@ -185,10 +247,20 @@
       :network-id="channelListModal.networkId!"
       @close="channelListModal.close()"
     />
+    <JoinChannelModal
+      v-if="joinChannelModal.isOpen && joinChannelModal.networkId !== null"
+      :network-id="joinChannelModal.networkId!"
+      @close="joinChannelModal.close()"
+    />
     <RecentUploadsModal v-if="showUploads" @close="showUploads = false" />
     <TransfersModal v-if="dcc.panelOpen" @close="dcc.close()" />
     <QuickSwitcher v-if="showSwitcher" @close="showSwitcher = false" />
-    <SearchModal v-if="showSearch" @close="showSearch = false" @jump="onJumpToMessage" />
+    <SearchModal
+      v-if="showSearch"
+      :scope="searchScope"
+      @close="showSearch = false"
+      @jump="onJumpToMessage"
+    />
     <KeyboardHelpModal v-if="showKbdHelp" @close="showKbdHelp = false" />
     <ImageViewerModal
       v-if="imageModal.isOpen && imageModal.url !== null"
@@ -235,6 +307,7 @@ import BookmarksModal from '../components/BookmarksModal.vue';
 import LinkedText from '../components/LinkedText.vue';
 import TopicModal from '../components/TopicModal.vue';
 import ChannelListModal from '../components/ChannelListModal.vue';
+import JoinChannelModal from '../components/JoinChannelModal.vue';
 import RecentUploadsModal from '../components/RecentUploadsModal.vue';
 import TransfersModal from '../components/TransfersModal.vue';
 import QuickSwitcher from '../components/QuickSwitcher.vue';
@@ -252,9 +325,11 @@ import { useDccStore } from '../stores/dcc.js';
 import { useSearchStore } from '../stores/search.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
+import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
 import { useImageModal } from '../composables/useImageModal.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
+import { useNavHistoryStore } from '../stores/navHistory.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -299,8 +374,10 @@ const dccTitle = computed(() =>
 const whois = useWhoisStore();
 
 const channelListModal = reactive(useChannelListModal());
+const joinChannelModal = reactive(useJoinChannelModal());
 const imageModal = reactive(useImageModal());
 const networkEditor = reactive(useNetworkEditor());
+const navHistory = useNavHistoryStore();
 const showHighlights = ref(false);
 const showBookmarks = ref(false);
 const showTopic = ref(false);
@@ -310,10 +387,37 @@ const showSearch = ref(false);
 const showKbdHelp = ref(false);
 const pendingScrollId = ref<number | null>(null);
 
+// Per-buffer scope for search & highlights: `in:<target> on:<network>`, mirroring
+// the mobile topic bar's scoped buttons. The `on:` token is dropped when the
+// network name has whitespace (the filter parser splits tokens on spaces, so it
+// couldn't round-trip); `in:<target>` alone still scopes by channel/nick. Null
+// for server/system buffers, which have no per-buffer scope.
+const searchScope = ref<string | null>(null);
+const highlightScope = ref<string | null>(null);
+const bufferScope = computed<string | null>(() => {
+  const a = active.value;
+  if (!a || isServerBuffer.value || isSystemBuffer.value || !a.target) return null;
+  const netName = (a.network as { name?: string } | null)?.name;
+  const onTok = netName && !/\s/.test(netName) ? ` on:${netName}` : '';
+  return `in:${a.target}${onTok}`;
+});
+// Topic-bar buttons pass scoped=true so the modal opens pre-filtered to this
+// buffer; the sidebar-foot and keyboard shortcut pass false for the global view.
+// Both share one modal instance — the scope ref differentiates the two entries.
+function openSearch(scoped: boolean) {
+  searchScope.value = scoped ? bufferScope.value : null;
+  showSearch.value = true;
+}
+function openHighlights(scoped: boolean) {
+  highlightScope.value = scoped ? bufferScope.value : null;
+  showHighlights.value = true;
+}
+
 // "View activity" from the Friends overview: open Search with the scoped query
 // (from:<nick> on:<network>) and run it immediately.
 function onViewActivity(query: string) {
   useSearchStore().runQuery(query);
+  searchScope.value = null;
   showSearch.value = true;
 }
 const messageInputRef = ref<{ focus: () => void } | null>(null);
@@ -327,6 +431,7 @@ const anyModalOpen = computed(
     showBookmarks.value ||
     showTopic.value ||
     channelListModal.isOpen ||
+    joinChannelModal.isOpen ||
     imageModal.isOpen ||
     showUploads.value ||
     dcc.panelOpen ||
@@ -343,7 +448,7 @@ useKeyboardShortcuts({
     showKbdHelp.value = true;
   },
   onOpenSearch: () => {
-    showSearch.value = true;
+    openSearch(false);
   },
   onTypeAhead: () => {
     if (anyModalOpen.value || !active.value) return;
@@ -487,6 +592,8 @@ function openSettings() {
   router.push('/settings');
 }
 
+// Collapsed-rail add-network (the expanded affordance is the LURKER header's +,
+// which is unmounted with the sidebar).
 function openAddNetwork() {
   networkEditor.open();
 }
@@ -689,9 +796,27 @@ useChatBootstrap({ onJump: onJumpToMessage });
   padding: var(--space-4) var(--space-6);
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
+  gap: var(--space-4);
   white-space: nowrap;
   overflow: hidden;
+}
+/* Back/forward history controls (#411), anchored at the far left of the bar,
+   left of the buffer title. Same accent icon buttons as the rest of the bar;
+   disabled (dimmed, non-interactive) when there's nowhere to go that way. */
+.topic-nav {
+  display: flex;
+  align-items: baseline;
+  /* Match .topic-actions' gap so the back/forward pair is spaced like every
+     other button pair in the bar, not tighter. */
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+.nav-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.nav-btn:disabled:hover {
+  color: var(--accent);
 }
 .topic-divider {
   grid-area: divider;
@@ -753,6 +878,9 @@ useChatBootstrap({ onJump: onJumpToMessage });
   display: flex;
   align-items: baseline;
   gap: 1ch;
+  /* flex:1 so the meta absorbs the free space and keeps the action cluster
+     anchored to the right edge; min-width:0 lets the topic text ellipsis. */
+  flex: 1;
   min-width: 0;
   overflow: hidden;
 }

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -151,6 +151,7 @@
               class="link"
               title="Join channel"
               aria-label="Join channel"
+              :disabled="serverConnectionState !== 'connected'"
               @click="active && joinChannelModal.open(active.networkId)"
             >
               <i class="fa-solid fa-plus"></i>
@@ -764,6 +765,15 @@ useChatBootstrap({ onJump: onJumpToMessage });
 }
 .link:hover {
   color: var(--fg);
+}
+/* Disabled topic-bar link (e.g. Join channel while the network is disconnected):
+   dimmed and non-interactive, and it must not brighten on hover. */
+.link:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.link:disabled:hover {
+  color: var(--accent);
 }
 /* Transfers button: while an unsolicited offer awaits a decision the glyph
    turns warn-colored to draw the eye (color-as-signal, no count badge). */

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -23,7 +23,7 @@
           <i class="fa-regular fa-bookmark"></i>
         </button>
         <button class="icon" title="Recent uploads" @click="showUploads = true">
-          <i class="fa-solid fa-paperclip"></i>
+          <i class="fa-solid fa-arrow-up-from-bracket"></i>
         </button>
         <!-- Self-revealing DCC transfers button — see DesktopChat for rationale.
              Warn-colored while an offer awaits a decision. -->
@@ -34,7 +34,7 @@
           :title="dccTitle"
           @click="dcc.open()"
         >
-          <i class="fa-solid fa-circle-down"></i>
+          <i class="fa-solid fa-download"></i>
         </button>
         <button class="icon" title="Add network" @click="openAddNetwork">
           <i class="fa-solid fa-plus"></i>
@@ -81,17 +81,40 @@
             <i class="fa-solid fa-users"></i> {{ friendCount }}
           </span>
         </template>
-        <button v-if="!isVirtual" class="icon" title="Search this buffer" @click="openSearch(true)">
+        <button
+          v-if="!isVirtual && !isServerBuffer"
+          class="icon"
+          title="Search this buffer"
+          @click="openSearch(true)"
+        >
           <i class="fa-solid fa-magnifying-glass"></i>
         </button>
         <button
-          v-if="!isVirtual"
+          v-if="!isVirtual && !isServerBuffer"
           class="icon"
           title="Highlights in this buffer"
           @click="openHighlights(true)"
         >
           <i class="fa-regular fa-bell"></i>
         </button>
+        <template v-if="isServerBuffer">
+          <button
+            class="icon"
+            title="Join channel"
+            aria-label="Join channel"
+            @click="active && joinChannelModal.open(active.networkId)"
+          >
+            <i class="fa-solid fa-plus"></i>
+          </button>
+          <button
+            class="icon"
+            title="Channel list"
+            aria-label="Channel list"
+            @click="active && channelListModal.open(active.networkId)"
+          >
+            <i class="fa-solid fa-hashtag"></i>
+          </button>
+        </template>
         <button
           v-if="isChannel"
           class="icon"
@@ -158,6 +181,11 @@
       :network-id="channelListModal.networkId!"
       @close="channelListModal.close()"
     />
+    <JoinChannelModal
+      v-if="joinChannelModal.isOpen && joinChannelModal.networkId !== null"
+      :network-id="joinChannelModal.networkId!"
+      @close="joinChannelModal.close()"
+    />
     <RecentUploadsModal v-if="showUploads" @close="showUploads = false" />
     <TransfersModal v-if="dcc.panelOpen" @close="dcc.close()" />
     <SearchModal
@@ -210,6 +238,7 @@ import HighlightsModal from '../components/HighlightsModal.vue';
 import BookmarksModal from '../components/BookmarksModal.vue';
 import TopicModal from '../components/TopicModal.vue';
 import ChannelListModal from '../components/ChannelListModal.vue';
+import JoinChannelModal from '../components/JoinChannelModal.vue';
 import RecentUploadsModal from '../components/RecentUploadsModal.vue';
 import TransfersModal from '../components/TransfersModal.vue';
 import SearchModal from '../components/SearchModal.vue';
@@ -223,6 +252,7 @@ import { useDccStore } from '../stores/dcc.js';
 import { useSearchStore } from '../stores/search.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
+import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
 import { useImageModal } from '../composables/useImageModal.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
@@ -275,6 +305,7 @@ function openSystemConsole() {
 // flow is short and stateful, and a URL would expose us to bookmarks that
 // land on the buffer screen with no active buffer.
 const channelListModal = reactive(useChannelListModal());
+const joinChannelModal = reactive(useJoinChannelModal());
 const imageModal = reactive(useImageModal());
 const networkEditor = reactive(useNetworkEditor());
 const screen = ref('list');
@@ -345,12 +376,9 @@ function openBufferActions() {
     });
   }
   if (isServerBuffer.value) {
+    // Join channel / Channel list now live as top-bar buttons for server buffers,
+    // so the kebab keeps just the less-frequent connect/edit actions.
     items.push(
-      {
-        label: 'Channel list',
-        icon: 'fa-solid fa-hashtag',
-        onClick: () => channelListModal.open(a.networkId),
-      },
       {
         label: serverConnectActionLabel.value,
         icon: serverConnectActionIcon.value,

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -102,6 +102,7 @@
             class="icon"
             title="Join channel"
             aria-label="Join channel"
+            :disabled="serverConnectionState !== 'connected'"
             @click="active && joinChannelModal.open(active.networkId)"
           >
             <i class="fa-solid fa-plus"></i>
@@ -569,6 +570,15 @@ useChatBootstrap({ onJump: onJumpToMessage });
 }
 .icon:hover {
   color: var(--fg);
+}
+/* Disabled top-bar icon (e.g. Join channel while the network is disconnected):
+   dimmed and non-interactive, and it must not brighten on hover. */
+.icon:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.icon:disabled:hover {
+  color: var(--accent);
 }
 /* Transfers button turns warn-colored while an offer awaits a decision
    (color-as-signal, no count badge — matches DesktopChat). */


### PR DESCRIPTION
Closes #411.

Reworks the sidebar buffer-list headers and the topic bar into one consistent affordance system, and builds the Join Channel modal that #411 asked for.

## What's here

**Add / join affordances**
- Add-network `+` moves from the sidebar footer into the **LURKER header**.
- Every network header gets an add-channel `+` that opens a new **Join Channel** modal (type a channel name, or **Browse Channel List** to fall through to the full `/list` browser). New `JoinChannelModal.vue` + `useJoinChannelModal.ts`.
- The **network context menu** (right-click / long-press / header kebab) gains **Join Channel** and **Channel List** — the only sidebar path to these on mobile.

**Reveal model**
- Header actions (`+` / settings / collapse) and row kebabs reveal on **hover / selection / focus**; at rest the corner shows the unread badge (or nothing), and the badge yields when actions appear.
- The LURKER **collapse `<<` is always visible**; its `+` and settings **gear** reveal on pointer devices and stay visible on touch (no hover to reveal them there).
- Channel/DM rows show a kebab (context menu); friend rows show an edit-friend button that opens the editor directly.

**LURKER as a real header**
- The LURKER row is now a **fixed header** above the scroll region (it used to scroll with the list). Global **settings** moves into it (with a collapsed-rail fallback, since the header is unmounted when the sidebar is collapsed).

**Topic bar**
- `<` / `>` **back-forward** history nav (same as `Cmd+[` / `]`) at the far left of every topic bar, empty state included.
- Server buffer bar: `+` / `#` / connect / edit. Channel & DM bars gain **buffer-scoped search & highlights** (`in:<target> on:<network>`), matching mobile.

**Mobile**
- Server buffers get `+` / `#` top-bar buttons (moved out of the kebab).
- Scoped search/highlights are hidden on server buffers (they had no per-buffer scope and were silently searching globally).

**Icons** — pass across the desktop footer and mobile top bar (outline bell/bookmark, folder-free uploads glyph, DCC download, nav angles, settings cog).

## Testing
- `npm run check` (typecheck + client vue-tsc + lint + oxfmt) clean; `npm test` — 1954 tests pass.
- A `/code-review high` pass ran before this PR; its findings were applied: touch/keyboard reachability of the LURKER `+`/gear, a collapsed-sidebar add-network fallback, and Join Channel input validation (rejects a bare prefix / whitespace).
- Not driven in the live app (dev server autoconnects to real IRC); verified via typecheck + tests + mirroring the proven mobile paths.

## Deferred follow-ups (quality, not bugs)
- `bufferScope` + `openSearch`/`openHighlights` are now duplicated in Desktop/MobileChat — worth a shared `useBufferSearchScope()` composable.
- `JoinChannelModal.onJoin` (join-or-toast) and channel-prefix normalization overlap with `ChannelListModal` / `MessageInput` — candidates for a shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)