### PR TITLE
Release 1.0.8: shared join helpers (#496) + web-push failure recovery (#441)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -898,6 +898,11 @@ ensureColumn('upload_history', 'removed', 'INTEGER NOT NULL DEFAULT 0');
 ensureColumn('dcc_transfers', 'peer_host', 'TEXT');
 ensureColumn('dcc_transfers', 'peer_port', 'INTEGER');
 
+// Consecutive push-delivery failures (#441): reset to 0 on any success, bumped
+// on a non-permanent error, and used to disable a chronically-failing endpoint
+// so it stops erroring on every notification.
+ensureColumn('push_subscriptions', 'fail_count', 'INTEGER NOT NULL DEFAULT 0');
+
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.

--- a/server/db/pushSubscriptions.test.ts
+++ b/server/db/pushSubscriptions.test.ts
@@ -104,6 +104,47 @@ describe('listEnabledForUser', () => {
   });
 });
 
+describe('failure tracking (#441)', () => {
+  function freshSub(endpoint: string) {
+    const out = mod.upsertSubscription(alice.id, { endpoint, p256dh: 'k', auth: 'a' });
+    return (out as Extract<typeof out, { ok: true }>).sub!;
+  }
+
+  it('recordFailure increments and returns the running count', () => {
+    const sub = freshSub('https://example.test/fail-count');
+    expect(sub.fail_count).toBe(0);
+    expect(mod.recordFailure(sub.id)).toBe(1);
+    expect(mod.recordFailure(sub.id)).toBe(2);
+    expect(mod.getByEndpoint(sub.endpoint)!.fail_count).toBe(2);
+  });
+
+  it('touchSubscription clears the failure streak on success', () => {
+    const sub = freshSub('https://example.test/fail-reset');
+    mod.recordFailure(sub.id);
+    mod.recordFailure(sub.id);
+    mod.touchSubscription(sub.id);
+    expect(mod.getByEndpoint(sub.endpoint)!.fail_count).toBe(0);
+  });
+
+  it('disableSubscription drops the row out of listEnabledForUser without deleting it', () => {
+    const sub = freshSub('https://example.test/fail-disable');
+    mod.disableSubscription(sub.id);
+    expect(mod.getByEndpoint(sub.endpoint)).not.toBeNull();
+    expect(mod.getByEndpoint(sub.endpoint)!.enabled).toBe(false);
+    expect(mod.listEnabledForUser(alice.id).find((s) => s.id === sub.id)).toBeFalsy();
+  });
+
+  it('re-subscribing re-enables and resets the streak', () => {
+    const sub = freshSub('https://example.test/fail-resub');
+    mod.recordFailure(sub.id);
+    mod.disableSubscription(sub.id);
+    freshSub('https://example.test/fail-resub'); // same endpoint → upsert UPDATE path
+    const after = mod.getByEndpoint('https://example.test/fail-resub')!;
+    expect(after.enabled).toBe(true);
+    expect(after.fail_count).toBe(0);
+  });
+});
+
 describe('app_meta', () => {
   it('getMeta / setMeta round-trip', () => {
     expect(mod.getMeta('vapid_public')).toBeNull();

--- a/server/db/pushSubscriptions.ts
+++ b/server/db/pushSubscriptions.ts
@@ -14,6 +14,7 @@ export interface PushSubscriptionRow {
   enabled: number;
   created_at: string;
   last_seen_at: string;
+  fail_count: number;
 }
 
 /** Projected push subscription with boolean `enabled`. */
@@ -27,6 +28,7 @@ export interface PushSubscription {
   enabled: boolean;
   created_at: string;
   last_seen_at: string;
+  fail_count: number;
 }
 
 function rowToSub(row: PushSubscriptionRow | undefined): PushSubscription | null {
@@ -41,6 +43,7 @@ function rowToSub(row: PushSubscriptionRow | undefined): PushSubscription | null
     enabled: !!row.enabled,
     created_at: row.created_at,
     last_seen_at: row.last_seen_at,
+    fail_count: row.fail_count ?? 0,
   };
 }
 
@@ -107,7 +110,8 @@ export function upsertSubscription(
       `
       UPDATE push_subscriptions
       SET p256dh = ?, auth = ?, user_agent = COALESCE(?, user_agent),
-          enabled = 1, last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+          enabled = 1, fail_count = 0,
+          last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
       WHERE endpoint = ?
     `,
     ).run(p256dh, auth, userAgent || null, endpoint);
@@ -156,10 +160,30 @@ export function deleteById(id: number, userId: number): void {
 export function touchSubscription(id: number): void {
   // strftime with Z suffix so the value parses back as UTC on the client.
   // SQLite's bare datetime('now') returns 'YYYY-MM-DD HH:MM:SS' with no TZ
-  // marker, which Date.parse() then treats as local time.
+  // marker, which Date.parse() then treats as local time. A successful
+  // delivery also clears the failure streak (#441).
   db.prepare(
-    "UPDATE push_subscriptions SET last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE id = ?",
+    "UPDATE push_subscriptions SET last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), fail_count = 0 WHERE id = ?",
   ).run(id);
+}
+
+// Record a non-permanent delivery failure and return the new consecutive-failure
+// count (#441). The caller disables the subscription once this crosses a
+// threshold so a chronically-broken endpoint stops erroring on every push; any
+// success (touchSubscription) or re-subscribe (upsertSubscription) resets it.
+export function recordFailure(id: number): number {
+  db.prepare('UPDATE push_subscriptions SET fail_count = fail_count + 1 WHERE id = ?').run(id);
+  const row = db.prepare('SELECT fail_count FROM push_subscriptions WHERE id = ?').get(id) as
+    | { fail_count: number }
+    | undefined;
+  return row?.fail_count ?? 0;
+}
+
+// Stop delivering to a subscription without deleting it, so the row (and its
+// history) survives and a later re-subscribe re-enables it. Used when an
+// endpoint has failed too many times in a row (#441).
+export function disableSubscription(id: number): void {
+  db.prepare('UPDATE push_subscriptions SET enabled = 0 WHERE id = ?').run(id);
 }
 
 // app_meta single-key store for VAPID config

--- a/server/services/pushService.test.ts
+++ b/server/services/pushService.test.ts
@@ -83,9 +83,11 @@ describe('deliver', () => {
     expect(result.dropped).toBe(0);
   });
 
-  // 410/transient rejection paths exist in pushService but vitest's
+  // 410/transient/strike rejection paths exist in pushService but vitest's
   // unhandled-rejection guard flags the rejected promise even when
   // Promise.allSettled internally handles it. Skipping these paths here keeps
-  // the suite green; the route layer's push.test.js covers the happy path
-  // end-to-end via the API.
+  // the suite green; the failure-tracking DB helpers (recordFailure /
+  // disableSubscription / touchSubscription reset) are covered directly in
+  // db/pushSubscriptions.test.ts (#441), and the route layer's push.test.js
+  // covers the happy path end-to-end via the API.
 });

--- a/server/services/pushService.ts
+++ b/server/services/pushService.ts
@@ -7,12 +7,20 @@ import {
   listEnabledForUser,
   hasEnabledForUser,
   deleteById,
+  disableSubscription,
+  recordFailure,
   touchSubscription,
   getMeta,
   setMeta,
 } from '../db/pushSubscriptions.js';
 
 const VAPID_SUBJECT = process.env.VAPID_SUBJECT || 'mailto:lurker@localhost';
+
+// A subscription that draws this many concrete 4xx rejections in a row — i.e.
+// not an outright 404/410 (handled immediately) and not a transient 429/5xx or
+// transport-level error (never counted) — is disabled so it stops erroring on
+// every push (#441). Any success resets the streak.
+const MAX_CONSECUTIVE_FAILURES = 5;
 
 let vapidConfigured = false;
 let publicKey: string | null = null;
@@ -78,6 +86,7 @@ export async function deliver(
     const err = r.reason as webpush.WebPushError & { statusCode?: number };
     const status = err?.statusCode;
     if (status === 404 || status === 410) {
+      // The push service says this endpoint is gone for good — drop it.
       deleteById(sub.id, sub.user_id);
       dropped += 1;
       return;
@@ -88,9 +97,36 @@ export async function deliver(
     } catch (_) {
       /* ignore */
     }
+    // Don't count a failure toward the disable threshold unless the push
+    // service actually rejected the subscription with an HTTP status. Rate
+    // limits (429), server errors (5xx), and transport-level errors with no
+    // statusCode (DNS/connect blips, timeouts) are the network or the service
+    // having a bad moment — not a dead subscription. The subscription lives and
+    // we simply didn't deliver this time; otherwise a short outage during a
+    // burst of notifications could disable a perfectly healthy endpoint.
+    if (status == null || status === 429 || status >= 500) {
+      dropped += 1;
+      return;
+    }
+    // A concrete 4xx rejection (auth rejects, malformed requests, gone-but-not-
+    // 404/410) is a strike against this subscription. After enough consecutive
+    // strikes we disable it so it stops erroring on every notification; a
+    // re-subscribe re-enables it. This also bounds the console noise to a
+    // handful of lines per broken endpoint instead of one on every push (#441).
+    const failures = recordFailure(sub.id);
     const body = typeof err?.body === 'string' ? err.body.slice(0, 500) : '';
+    if (failures >= MAX_CONSECUTIVE_FAILURES) {
+      disableSubscription(sub.id);
+      dropped += 1;
+      console.warn(
+        `[push] disabled sub ${sub.id} (${host}) after ${failures} consecutive failures: ` +
+          `status=${status ?? '?'} message=${err?.message || String(err)} body=${body}`,
+      );
+      return;
+    }
+    dropped += 1;
     console.warn(
-      `[push] delivery failed for sub ${sub.id} (${host}): ` +
+      `[push] delivery failed for sub ${sub.id} (${host}) [${failures}/${MAX_CONSECUTIVE_FAILURES}]: ` +
         `status=${status ?? '?'} message=${err?.message || String(err)} body=${body}`,
     );
   });

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {

--- a/vue_client/src/components/ChannelListModal.vue
+++ b/vue_client/src/components/ChannelListModal.vue
@@ -73,7 +73,6 @@ import AppModal from './AppModal.vue';
 import { useChanlistStore, resultKey, type ChanlistRow } from '../stores/chanlist.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
-import { useToastsStore } from '../stores/toasts.js';
 import { socketSend } from '../composables/useSocket.js';
 import { formatRelative } from '../utils/timestamp.js';
 
@@ -180,18 +179,9 @@ function onJoin(ch: ChanlistRow): void {
   // If we're already in the channel (or have its buffer parted), just switch to
   // it; otherwise join and wait for the channel-joined confirmation before
   // focusing, so a refused join doesn't strand the user in a blank buffer
-  // (#260). joinOrActivate handles both, plus rejection toasts. It returns false
-  // only when a JOIN had to be sent but the socket is closed — surface that so
-  // the click isn't a silent no-op (the modal still closes).
-  if (!buffers.joinOrActivate(props.networkId, ch.channel)) {
-    useToastsStore().push({
-      kind: 'warn',
-      title: 'Not connected',
-      body: `Can't join ${ch.channel} while disconnected.`,
-      networkId: props.networkId,
-      ttlMs: 5000,
-    });
-  }
+  // (#260). joinOrToast handles both, plus rejection toasts, and warns if the
+  // socket is closed so the click isn't a silent no-op (the modal still closes).
+  buffers.joinOrToast(props.networkId, ch.channel);
   emit('close');
 }
 

--- a/vue_client/src/components/JoinChannelModal.vue
+++ b/vue_client/src/components/JoinChannelModal.vue
@@ -43,8 +43,8 @@ import { computed, onMounted, ref } from 'vue';
 import AppModal from './AppModal.vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
-import { useToastsStore } from '../stores/toasts.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
+import { ensureChannelPrefix } from '../utils/channelTarget.js';
 
 const props = defineProps<{ networkId: number }>();
 const emit = defineEmits<{ close: [] }>();
@@ -61,34 +61,24 @@ const networkLabel = computed(() => {
   return net?.name || `net:${props.networkId}`;
 });
 
-// Prepend a leading # when the user omits a channel prefix (#, &, +, !) — a
-// bare, prefix-less name is what people usually type. (This is slightly more
-// permissive than the /join command, which only auto-prefixes with #.) Returns
-// '' for anything that isn't a valid target so the Join button stays disabled:
-// channel names can't contain whitespace, and a lone prefix has no name — either
-// would otherwise send a JOIN the server just rejects.
+// Settle the channel prefix (ensureChannelPrefix: bare names get a leading #),
+// then reject anything that isn't a valid target so the Join button stays
+// disabled: channel names can't contain whitespace, and a lone prefix has no
+// name — either would otherwise send a JOIN the server just rejects.
 const normalized = computed(() => {
   const raw = channel.value.trim();
   if (!raw || /\s/.test(raw)) return '';
-  const withPrefix = /^[#&+!]/.test(raw) ? raw : `#${raw}`;
+  const withPrefix = ensureChannelPrefix(raw);
   return withPrefix.length > 1 ? withPrefix : '';
 });
 
 function onJoin() {
   const target = normalized.value;
   if (!target) return;
-  // joinOrActivate switches to an already-open buffer or sends a JOIN; it only
-  // returns false when a JOIN had to go out but the socket is closed. Surface
-  // that so the click isn't a silent no-op (the modal still closes either way).
-  if (!buffers.joinOrActivate(props.networkId, target)) {
-    useToastsStore().push({
-      kind: 'warn',
-      title: 'Not connected',
-      body: `Can't join ${target} while disconnected.`,
-      networkId: props.networkId,
-      ttlMs: 5000,
-    });
-  }
+  // joinOrToast switches to an already-open buffer or sends a JOIN, and warns
+  // if the socket is closed so the click isn't a silent no-op. The modal still
+  // closes either way.
+  buffers.joinOrToast(props.networkId, target);
   emit('close');
 }
 

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -172,6 +172,7 @@ import {
 import { applySpoilerMarkup } from '../utils/spoilerMarkup.js';
 import { buildNickCandidates } from '../utils/nickCompletion.js';
 import { buildChannelCandidates } from '../utils/channelCompletion.js';
+import { ensureChannelPrefix } from '../utils/channelTarget.js';
 import {
   findActiveShortcode,
   findCompletedShortcode,
@@ -2730,7 +2731,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
     }
     case 'join':
       if (rest[0]) {
-        const ch = rest[0].startsWith('#') ? rest[0] : `#${rest[0]}`;
+        const ch = ensureChannelPrefix(rest[0]);
         // A channel key is a single whitespace-free token — take just the next
         // arg, not the rest joined (which would fold trailing words into an
         // invalid, space-bearing key).

--- a/vue_client/src/composables/useBufferSearchScope.ts
+++ b/vue_client/src/composables/useBufferSearchScope.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { computed, ref } from 'vue';
+import { useActiveBuffer } from './useActiveBuffer.js';
+import { useSearchStore } from '../stores/search.js';
+
+// Shared open-state and per-buffer scoping for the Search & Highlights modals,
+// used by both the desktop and mobile chat shells (#496). Each shell owns one
+// instance (the refs are per-call, not module-level) so the two layouts don't
+// share modal visibility. The filter grammar (`in:<target> on:<network>`) lives
+// here so it can't drift between the shells.
+export function useBufferSearchScope() {
+  const { active, isServerBuffer, isSystemBuffer } = useActiveBuffer();
+
+  const showSearch = ref(false);
+  const showHighlights = ref(false);
+  const searchScope = ref<string | null>(null);
+  const highlightScope = ref<string | null>(null);
+
+  // Per-buffer scope for search & highlights: `in:<target> on:<network>`,
+  // mirroring the topic bar's scoped buttons. The `on:` token is dropped when
+  // the network name has whitespace (the filter parser splits tokens on spaces,
+  // so it couldn't round-trip); `in:<target>` alone still scopes by
+  // channel/nick. Null for server/system buffers, which have no per-buffer
+  // scope.
+  const bufferScope = computed<string | null>(() => {
+    const a = active.value;
+    if (!a || isServerBuffer.value || isSystemBuffer.value || !a.target) return null;
+    const netName = (a.network as { name?: string } | null)?.name;
+    const onTok = netName && !/\s/.test(netName) ? ` on:${netName}` : '';
+    return `in:${a.target}${onTok}`;
+  });
+
+  // Topic-bar buttons pass scoped=true so the modal opens pre-filtered to this
+  // buffer; the global entry points (sidebar foot / buffer-list top bar /
+  // keyboard shortcut) pass false. Both share one modal instance — the scope
+  // ref is what differentiates the two entries.
+  function openSearch(scoped: boolean): void {
+    searchScope.value = scoped ? bufferScope.value : null;
+    showSearch.value = true;
+  }
+  function openHighlights(scoped: boolean): void {
+    highlightScope.value = scoped ? bufferScope.value : null;
+    showHighlights.value = true;
+  }
+
+  // "View activity" from the Friends overview: open Search with the scoped query
+  // (from:<nick> on:<network>) and run it immediately.
+  function onViewActivity(query: string): void {
+    useSearchStore().runQuery(query);
+    searchScope.value = null;
+    showSearch.value = true;
+  }
+
+  return {
+    showSearch,
+    showHighlights,
+    searchScope,
+    highlightScope,
+    openSearch,
+    openHighlights,
+    onViewActivity,
+  };
+}

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -885,6 +885,23 @@ export const useBuffersStore = defineStore('buffers', {
       if (ok) this.requestJoin(nid, channel);
       return ok;
     },
+    // "Join a channel from a button" — the shared path behind JoinChannelModal
+    // and the channel-list browser. joinOrActivate returns false only when a
+    // JOIN had to go out over a closed socket; surface that as an offline toast
+    // so the click isn't a silent no-op. Returns joinOrActivate's result.
+    joinOrToast(networkId: number | string, target: string): boolean {
+      const ok = this.joinOrActivate(networkId, target);
+      if (!ok) {
+        useToastsStore().push({
+          kind: 'warn',
+          title: 'Not connected',
+          body: `Can't join ${target} while disconnected.`,
+          networkId: typeof networkId === 'string' ? Number(networkId) : networkId,
+          ttlMs: 5000,
+        });
+      }
+      return ok;
+    },
     setJoined(networkId: number | string, target: string, joined: boolean) {
       // Resolve case-insensitively (#327): channel-joined/-parted already arrive
       // canonical from the server (canonicalChannelTarget), but fold here too so

--- a/vue_client/src/utils/channelTarget.test.ts
+++ b/vue_client/src/utils/channelTarget.test.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { ensureChannelPrefix } from './channelTarget.js';
+
+describe('ensureChannelPrefix', () => {
+  it('prepends # to a bare name', () => {
+    expect(ensureChannelPrefix('lurker')).toBe('#lurker');
+  });
+
+  it('leaves any RFC 2811 channel prefix untouched', () => {
+    expect(ensureChannelPrefix('#chan')).toBe('#chan');
+    expect(ensureChannelPrefix('&local')).toBe('&local');
+    expect(ensureChannelPrefix('+modeless')).toBe('+modeless');
+    expect(ensureChannelPrefix('!12345chan')).toBe('!12345chan');
+  });
+
+  it('does not validate — a lone prefix or empty string passes through / gets prefixed', () => {
+    // Prefix-only concern: input validation (empty, whitespace, lone prefix)
+    // stays with the caller, so these are intentionally not rejected here.
+    expect(ensureChannelPrefix('#')).toBe('#');
+    expect(ensureChannelPrefix('')).toBe('#');
+  });
+});

--- a/vue_client/src/utils/channelTarget.ts
+++ b/vue_client/src/utils/channelTarget.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The single notion of "what is a channel prefix" for the client's join paths.
+// IRC channels start with one of #, &, +, ! (RFC 2811); a bare, prefix-less
+// name is what people usually type, so prepend the common `#`. Callers own
+// their own input validation (whitespace, empty, lone-prefix) — this only
+// settles the prefix. Shared by the Join Channel modal, the channel-list
+// browser, and the `/join` command so all three normalize identically (#496).
+export function ensureChannelPrefix(name: string): string {
+  return /^[#&+!]/.test(name) ? name : `#${name}`;
+}

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -295,6 +295,7 @@ import { useSocket } from '../composables/useSocket.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useChatBootstrap } from '../composables/useChatBootstrap.js';
 import { useActiveBuffer } from '../composables/useActiveBuffer.js';
+import { useBufferSearchScope } from '../composables/useBufferSearchScope.js';
 import { useSettingsStore } from '../stores/settings.js';
 import BufferList from '../components/BufferList.vue';
 import MessageList from '../components/MessageList.vue';
@@ -323,7 +324,6 @@ import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useFriendsStore } from '../stores/friends.js';
 import { useDccStore } from '../stores/dcc.js';
-import { useSearchStore } from '../stores/search.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
@@ -379,48 +379,24 @@ const joinChannelModal = reactive(useJoinChannelModal());
 const imageModal = reactive(useImageModal());
 const networkEditor = reactive(useNetworkEditor());
 const navHistory = useNavHistoryStore();
-const showHighlights = ref(false);
 const showBookmarks = ref(false);
 const showTopic = ref(false);
 const showUploads = ref(false);
 const showSwitcher = ref(false);
-const showSearch = ref(false);
 const showKbdHelp = ref(false);
 const pendingScrollId = ref<number | null>(null);
 
-// Per-buffer scope for search & highlights: `in:<target> on:<network>`, mirroring
-// the mobile topic bar's scoped buttons. The `on:` token is dropped when the
-// network name has whitespace (the filter parser splits tokens on spaces, so it
-// couldn't round-trip); `in:<target>` alone still scopes by channel/nick. Null
-// for server/system buffers, which have no per-buffer scope.
-const searchScope = ref<string | null>(null);
-const highlightScope = ref<string | null>(null);
-const bufferScope = computed<string | null>(() => {
-  const a = active.value;
-  if (!a || isServerBuffer.value || isSystemBuffer.value || !a.target) return null;
-  const netName = (a.network as { name?: string } | null)?.name;
-  const onTok = netName && !/\s/.test(netName) ? ` on:${netName}` : '';
-  return `in:${a.target}${onTok}`;
-});
-// Topic-bar buttons pass scoped=true so the modal opens pre-filtered to this
-// buffer; the sidebar-foot and keyboard shortcut pass false for the global view.
-// Both share one modal instance — the scope ref differentiates the two entries.
-function openSearch(scoped: boolean) {
-  searchScope.value = scoped ? bufferScope.value : null;
-  showSearch.value = true;
-}
-function openHighlights(scoped: boolean) {
-  highlightScope.value = scoped ? bufferScope.value : null;
-  showHighlights.value = true;
-}
-
-// "View activity" from the Friends overview: open Search with the scoped query
-// (from:<nick> on:<network>) and run it immediately.
-function onViewActivity(query: string) {
-  useSearchStore().runQuery(query);
-  searchScope.value = null;
-  showSearch.value = true;
-}
+// Search & Highlights modal state + per-buffer `in:/on:` scoping, shared with
+// MobileChat (#496).
+const {
+  showSearch,
+  showHighlights,
+  searchScope,
+  highlightScope,
+  openSearch,
+  openHighlights,
+  onViewActivity,
+} = useBufferSearchScope();
 const messageInputRef = ref<{ focus: () => void } | null>(null);
 const messageListRef = ref<{ scrollByPage: (dir: number) => void } | null>(null);
 

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -225,6 +225,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useSocket } from '../composables/useSocket.js';
 import { useChatBootstrap } from '../composables/useChatBootstrap.js';
 import { useActiveBuffer } from '../composables/useActiveBuffer.js';
+import { useBufferSearchScope } from '../composables/useBufferSearchScope.js';
 import { useBufferActions } from '../composables/useBufferActions.js';
 import { useContextMenu } from '../composables/useContextMenu.js';
 import type { ContextMenuItem } from '../composables/useContextMenu.js';
@@ -250,7 +251,6 @@ import ImageViewerModal from '../components/ImageViewerModal.vue';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useFriendsStore } from '../stores/friends.js';
 import { useDccStore } from '../stores/dcc.js';
-import { useSearchStore } from '../stores/search.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
@@ -310,50 +310,24 @@ const joinChannelModal = reactive(useJoinChannelModal());
 const imageModal = reactive(useImageModal());
 const networkEditor = reactive(useNetworkEditor());
 const screen = ref('list');
-const showHighlights = ref(false);
 const showBookmarks = ref(false);
 const showTopic = ref(false);
 const showUploads = ref(false);
-const showSearch = ref(false);
-const searchScope = ref<string | null>(null);
-const highlightScope = ref<string | null>(null);
 const pendingScrollId = ref<number | null>(null);
 const messageInputRef = ref<{ focus: () => void } | null>(null);
 const bufferCogBtn = ref<HTMLElement | null>(null);
 
-// in:/on: filter that scopes search & highlights to the current buffer when
-// they're opened from the topic bar. Null for the server buffer / system
-// console (no per-buffer scope there). The network name is omitted when it
-// contains whitespace — the filter parser splits tokens on spaces, so
-// `on:<name>` couldn't round-trip; `in:<target>` alone still scopes by
-// channel/nick in that case.
-const bufferScope = computed<string | null>(() => {
-  const a = active.value;
-  if (!a || isServerBuffer.value || isSystemBuffer.value || !a.target) return null;
-  const netName = (a.network as { name?: string } | null)?.name;
-  const onTok = netName && !/\s/.test(netName) ? ` on:${netName}` : '';
-  return `in:${a.target}${onTok}`;
-});
-
-// Topic-bar buttons pass scoped=true so the modal opens pre-filtered to this
-// buffer; the buffer-list top bar passes false for the global view. Both share
-// one modal instance — the scope ref is what differentiates the two entries.
-function openSearch(scoped: boolean) {
-  searchScope.value = scoped ? bufferScope.value : null;
-  showSearch.value = true;
-}
-
-// "View activity" from the Friends overview: open Search with the scoped query
-// (from:<nick> on:<network>) and run it immediately.
-function onViewActivity(query: string) {
-  useSearchStore().runQuery(query);
-  searchScope.value = null;
-  showSearch.value = true;
-}
-function openHighlights(scoped: boolean) {
-  highlightScope.value = scoped ? bufferScope.value : null;
-  showHighlights.value = true;
-}
+// Search & Highlights modal state + per-buffer `in:/on:` scoping, shared with
+// DesktopChat (#496).
+const {
+  showSearch,
+  showHighlights,
+  searchScope,
+  highlightScope,
+  openSearch,
+  openHighlights,
+  onViewActivity,
+} = useBufferSearchScope();
 
 // Mobile folds the remaining buffer/topic/server actions behind one kebab menu
 // to keep the header uncluttered (Members is an inline header button — see


### PR DESCRIPTION
Bundles two small 1.1.0-milestone cards plus the patch-release version bump. The two changes touch disjoint surfaces (client Vue vs. server push), kept as separate commits.

## #496 — share buffer-search scope + join-channel helpers (quality-only)
Two DRY follow-ups deferred out of #495:
- **`useBufferSearchScope()` composable** — the Search/Highlights modal state and the per-buffer `in:<target> on:<network>` scope grammar were duplicated near-verbatim in `DesktopChat.vue` and `MobileChat.vue`. Now one composable owns the grammar so it can't drift.
- **`buffers.joinOrToast()`** — folds the `joinOrActivate` + "Not connected" warn-toast pattern (duplicated in `JoinChannelModal` and `ChannelListModal`) into a store action.
- **`ensureChannelPrefix()` util** — the single notion of "what is a channel prefix" (`#&+!`), shared by both modals and the `/join` command.

⚠️ **Behavior note:** `/join` now recognizes the full RFC 2811 prefix set (`#&+!`) instead of only `#`, matching the modals — so `/join &local` no longer becomes `#&local`. This unifies the previously-third notion of a channel prefix and is the point of the card.

## #441 — disable chronically-failing web-push subscriptions
`deliver()` already dropped a subscription on 404/410, but every *other* failure was re-logged on **every** notification with no recovery — endless console spam for a permanently-broken endpoint.

- New `fail_count` column tracks **consecutive** delivery failures; any success (`touchSubscription`) or re-subscribe (`upsertSubscription`) resets it.
- A concrete 4xx rejection bumps the streak; crossing a threshold (5) **disables** the subscription (kept in the table so a re-subscribe re-enables it) so it stops erroring on every push.
- Transient failures — 429, 5xx, **and transport-level errors with no HTTP status** (DNS/connect blips, timeouts) — are excluded from the streak so a brief outage can't disable a healthy endpoint. *(This transport-error exclusion was surfaced by a `/code-review high` pass on the branch and folded into the #441 commit.)*

## Testing
- `npm run check` (typecheck + lint + oxfmt) clean
- `npm test` — 1961 passed
- New unit tests: `ensureChannelPrefix` (client) and the failure-tracking DB helpers `recordFailure`/`disableSubscription`/reset-on-touch/reset-on-resubscribe (server). Service-layer rejection paths intentionally left to the DB-helper + route e2e coverage per the existing note in `pushService.test.ts` (vitest unhandled-rejection guard).

Closes #496
Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)