### PR TITLE
test: de-flake import round-trip on ignored_masks created_at

### DIFF
--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -710,12 +710,26 @@ type AnyTableDef = {
   blobColumns?: string[];
 };
 
+// Columns re-derived on the target instance rather than round-tripped verbatim,
+// so they legitimately differ from the source and must be excluded from the
+// payload comparison. `ignored_masks` is the only table re-inserted through a
+// service on import (ignoreRulesService.add, for regex/expiry validation — see
+// importService), and that path lets the DB stamp `created_at` at import time
+// instead of preserving the original. Every other table round-trips created_at
+// via the positional insert, so this exclusion is deliberately table-scoped —
+// widening it would mask a real regression elsewhere. (Comparing created_at
+// here is also what made this test flaky: alice's seed time and bob's import
+// time differ whenever the clock ticks a second mid-run.)
+const VOLATILE_COLUMNS: Record<string, string[]> = {
+  ignored_masks: ['created_at'],
+};
+
 // Columns that legitimately differ between the source and target accounts.
 // Per-table FK-rekey columns are taken from the registry; PKs of
 // autoincrement tables also differ; matched_rule_id can legitimately turn
 // to NULL on import if its rule wasn't carried over (it shouldn't here).
-function projectionFor(_table: string, def: AnyTableDef): string[] {
-  const skip = new Set<string>();
+function projectionFor(table: string, def: AnyTableDef): string[] {
+  const skip = new Set<string>(VOLATILE_COLUMNS[table] ?? []);
   if (def.pk) skip.add(def.pk);
   if (def.fkRekey) for (const col of Object.keys(def.fkRekey)) skip.add(col);
   const blobColumns = def.blobColumns ?? [];
@@ -930,6 +944,15 @@ describe('importFromZipBuffer — end-to-end equivalence', () => {
 
     // BLOBs aren't in the column projection — verify separately.
     expect(blobsFor(bob.id)).toEqual(blobsFor(alice.id));
+
+    // created_at for ignored_masks is excluded from the payload diff above
+    // (VOLATILE_COLUMNS) because import re-stamps it. Assert it's still
+    // populated on the imported side rather than dropped/null.
+    const bobMaskTimes = db
+      .prepare('SELECT created_at FROM ignored_masks WHERE user_id = ?')
+      .all(bob.id) as Array<{ created_at: string | null }>;
+    expect(bobMaskTimes.length).toBeGreaterThan(0);
+    expect(bobMaskTimes.every((r) => !!r.created_at)).toBe(true);
 
     // Structural FK sanity: every per-network row in bob's tables must
     // point at one of bob's networks, not alice's.

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -720,9 +720,13 @@ type AnyTableDef = {
 // widening it would mask a real regression elsewhere. (Comparing created_at
 // here is also what made this test flaky: alice's seed time and bob's import
 // time differ whenever the clock ticks a second mid-run.)
+// `satisfies` keeps the keys checked against the real table registry — a
+// mistyped table name is a compile error rather than a silently-ineffective
+// exclusion (which would let the flake back in) — while the `Record<string, …>`
+// annotation keeps it indexable by the arbitrary `table` string below.
 const VOLATILE_COLUMNS: Record<string, string[]> = {
   ignored_masks: ['created_at'],
-};
+} satisfies Partial<Record<keyof typeof EXPORT_TABLES, string[]>>;
 
 // Columns that legitimately differ between the source and target accounts.
 // Per-table FK-rekey columns are taken from the registry; PKs of


### PR DESCRIPTION
## Problem
The `importFromZipBuffer` end-to-end equivalence test (`importService.test.ts`) intermittently fails in CI with:

```
AssertionError: payload mismatch for ignored_masks
-  "created_at": "2026-07-02 21:06:52"
+  "created_at": "2026-07-02 21:06:53"
```

(Seen on the #473 Actions-bump PR, whose YAML-only change can't touch app behavior — confirming it was a pre-existing flake.)

## Root cause
The round-trip test compares every projected column verbatim, including `created_at`. Nearly every table round-trips `created_at` through a positional insert — but `ignored_masks` is special: on import it's re-inserted through `ignoreRulesService.add()` (deliberately, so a crafted/legacy archive can't plant an unvalidated regex or non-ISO expiry — see `importService.ts`). That service lets the DB stamp `created_at` fresh at import time rather than preserving the source value. So alice's seed time and bob's import time differ by however long the export/import took — and the string comparison fails whenever the clock ticks a second mid-run.

## Fix
Exclude `created_at` from the payload comparison **for `ignored_masks` only**, via a `VOLATILE_COLUMNS` map so the exclusion stays table-scoped and can't mask a real regression in a table that *should* round-trip `created_at`. Added an assertion that import still populates `created_at` on the imported side (so we don't lose all coverage of the column for this table).

Not fixed in the importer on purpose: preserving the original `created_at` would mean threading a timestamp override through the security-sensitive `ignoreRulesService.add` path (which intentionally assigns id/created_at itself) — not worth widening that API for a cosmetic field.

## Testing
- Ran the affected test file 5× locally — stable (the compared value is no longer clock-dependent).
- `npm run check` clean; `npm test` → 1961 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)