### PR TITLE
Unify per-user buffer enumeration so the PWA badge total can't drift (#454)

### DIFF
--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -760,4 +760,31 @@ describe('eachUserBufferTarget / badge-vs-snapshot parity (#454)', () => {
     // so this isn't a vacuous 0 === 0.
     expect(computeTotalHighlights(u)).toBe(3 + (Number(systemFrame.highlights) || 0));
   });
+
+  it('buildOfflineBacklogFrames reuses a pre-walked enumeration identically to walking itself', () => {
+    // The connect snapshot materializes eachUserBufferTarget once and hands it to
+    // buildOfflineBacklogFrames so the per-network listBufferTargets/listNetworksForUser
+    // DB reads run 1× per snapshot, not once here and once in the live loop. This
+    // locks that the reuse path yields the exact same frames as the standalone walk.
+    const u = createUser('reuse').id;
+    const net = netFor(u, 'reusenet');
+    ins(net, '#a', 'one');
+    ins(net, 'dee', 'dm');
+    ins(net, '#closed', 'gone');
+    closeBuffer(u, net, '#closed');
+    ins(net, `:server:${net}`, 'notice');
+
+    const shape = (frames: ReturnType<typeof buildOfflineBacklogFrames>) =>
+      frames
+        .filter((f) => f.networkId === net)
+        .map((f) => `${f.target}|${f.kind}|${(f as { unread?: number }).unread ?? ''}`)
+        .sort();
+
+    const standalone = shape(buildOfflineBacklogFrames(u));
+    const reused = shape(buildOfflineBacklogFrames(u, undefined, [...eachUserBufferTarget(u)]));
+    expect(reused).toEqual(standalone);
+    // The closed buffer is absent and the server pseudo-buffer is present in both.
+    expect(standalone.some((s) => s.startsWith('#closed|'))).toBe(false);
+    expect(standalone.some((s) => s.startsWith(`:server:${net}|`))).toBe(true);
+  });
 });

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -781,7 +781,7 @@ describe('eachUserBufferTarget / badge-vs-snapshot parity (#454)', () => {
         .sort();
 
     const standalone = shape(buildOfflineBacklogFrames(u));
-    const reused = shape(buildOfflineBacklogFrames(u, undefined, [...eachUserBufferTarget(u)]));
+    const reused = shape(buildOfflineBacklogFrames(u, [...eachUserBufferTarget(u)]));
     expect(reused).toEqual(standalone);
     // The closed buffer is absent and the server pseudo-buffer is present in both.
     expect(standalone.some((s) => s.startsWith('#closed|'))).toBe(false);

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -644,15 +644,12 @@ describe('eachUserBufferTarget / badge-vs-snapshot parity (#454)', () => {
     return { network: { id: netId }, channels } as unknown as LiveConn;
   }
   function setLiveConn(uid: number, conn: LiveConn) {
-    let m = ircManager.byUser.get(uid);
-    if (!m) {
-      m = new Map();
-      ircManager.byUser.set(uid, m);
-    }
-    m.set(conn.network.id, conn);
+    // connectionsForUser creates the inner map if absent — same seam the bouncer
+    // test harness uses to inject upstream connections.
+    ircManager.connectionsForUser(uid).set(conn.network.id, conn);
   }
   function clearLiveConns(uid: number) {
-    ircManager.byUser.delete(uid);
+    ircManager.connectionsForUser(uid).clear();
   }
 
   const netFor = (uid: number, name: string) =>

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -17,6 +17,8 @@ let isClosed: typeof import('../db/closedBuffers.js').isClosed;
 let setClearedState: typeof import('../db/bufferReads.js').setClearedState;
 let setReadState: typeof import('../db/bufferReads.js').setReadState;
 let computeTotalHighlights: typeof import('./wsHub.js').computeTotalHighlights;
+let eachUserBufferTarget: typeof import('./wsHub.js').eachUserBufferTarget;
+let ircManager: typeof import('./ircManager.js').default;
 let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
 let buildBufferShell: typeof import('./wsHub.js').buildBufferShell;
 let buildResumeSlice: typeof import('./wsHub.js').buildResumeSlice;
@@ -41,8 +43,10 @@ beforeAll(async () => {
   ({ insertMessage, maxMessageId } = await import('../db/messages.js'));
   ({ closeBuffer, reopenBuffer, isClosed } = await import('../db/closedBuffers.js'));
   ({ setClearedState, setReadState } = await import('../db/bufferReads.js'));
+  ircManager = (await import('./ircManager.js')).default;
   ({
     computeTotalHighlights,
+    eachUserBufferTarget,
     buildBufferBacklog,
     buildBufferShell,
     buildResumeSlice,
@@ -619,5 +623,141 @@ describe('computeTotalHighlights', () => {
     // Reading dave up to its newest line clears its contribution.
     setReadState(u, net, 'dave', d3);
     expect(computeTotalHighlights(u)).toBe(base + 2);
+  });
+});
+
+// #454: the connect snapshot's live loop, buildOfflineBacklogFrames, and the
+// push-badge total (computeTotalHighlights) all walk the same set of buffers via
+// eachUserBufferTarget, so the app-icon badge can't drift from the in-app count.
+// These lock the two invariants that used to diverge: the closed-vs-joined
+// precedence on a live network (finding #3), and per-buffer highlight parity
+// between the frames the client receives and the total the badge shows.
+describe('eachUserBufferTarget / badge-vs-snapshot parity (#454)', () => {
+  // A minimal live-connection stand-in: the enumerator only reads network.id and
+  // the lowercased-keyed channels map (has() for join-precedence, values().name to
+  // surface joined-but-history-less channels). Injected straight into the shared
+  // ircManager singleton — remember to clear it so sibling "offline" tests aren't
+  // poisoned by a lingering live connection.
+  type LiveConn = ReturnType<typeof ircManager.listConnections>[number];
+  function stubLiveConn(netId: number, joinedChannels: string[]): LiveConn {
+    const channels = new Map(joinedChannels.map((c) => [c.toLowerCase(), { name: c }]));
+    return { network: { id: netId }, channels } as unknown as LiveConn;
+  }
+  function setLiveConn(uid: number, conn: LiveConn) {
+    let m = ircManager.byUser.get(uid);
+    if (!m) {
+      m = new Map();
+      ircManager.byUser.set(uid, m);
+    }
+    m.set(conn.network.id, conn);
+  }
+  function clearLiveConns(uid: number) {
+    ircManager.byUser.delete(uid);
+  }
+
+  const netFor = (uid: number, name: string) =>
+    createNetwork(uid, { name, host: 'h', port: 6697, tls: true, nick: 'x' })!.id;
+  const ins = (net: number, target: string, text: string, matchedRuleId: number | null = null) =>
+    Number(
+      insertMessage({
+        networkId: net,
+        target,
+        time: new Date().toISOString(),
+        type: 'message',
+        nick: 'bob',
+        text,
+        self: false,
+        matchedRuleId,
+      }).id,
+    );
+
+  it('counts a closed-but-currently-joined channel — a live join beats a stale closed flag (finding #3)', () => {
+    const u = createUser('racer').id;
+    const net = netFor(u, 'race');
+    const base = computeTotalHighlights(u);
+
+    // Two real channel highlights (matched_rule_id set → countHighlightsNewer).
+    ins(net, '#joined', 'ping alice', 1);
+    ins(net, '#joined', 'alice again', 1);
+    // Open + offline: enumerated with history → both highlights count.
+    expect(computeTotalHighlights(u)).toBe(base + 2);
+
+    // Closing it while offline hides it from the store, so the badge drops it too.
+    closeBuffer(u, net, '#joined');
+    expect(computeTotalHighlights(u)).toBe(base);
+
+    // The autorejoin/reconnect race: the buffer still carries a stale closed flag
+    // but the live connection reports it currently joined. The snapshot ships it
+    // (isHiddenClosedBuffer join-precedence), so the badge total must count it too
+    // — the exact undercount that used to make the app-icon badge read low.
+    setLiveConn(u, stubLiveConn(net, ['#joined']));
+    try {
+      expect(computeTotalHighlights(u)).toBe(base + 2);
+    } finally {
+      clearLiveConns(u);
+    }
+    // ...and once the connection drops, the closed flag wins again.
+    expect(computeTotalHighlights(u)).toBe(base);
+  });
+
+  it('eachUserBufferTarget honors closed offline but yields a closed channel that is live-joined', () => {
+    const u = createUser('enum').id;
+    const net = netFor(u, 'enumnet');
+    ins(net, '#c', 'hi');
+    closeBuffer(u, net, '#c');
+
+    const targetsFor = () =>
+      [...eachUserBufferTarget(u)].filter((t) => t.networkId === net).map((t) => t.target);
+
+    // Offline: nothing is joined, so the closed flag hides #c.
+    expect(targetsFor()).not.toContain('#c');
+    // The :server: pseudo-buffer is always present and never filtered.
+    expect(targetsFor()).toContain(`:server:${net}`);
+
+    setLiveConn(u, stubLiveConn(net, ['#c']));
+    try {
+      const live = [...eachUserBufferTarget(u)].filter((t) => t.networkId === net);
+      expect(live.map((t) => t.target)).toContain('#c');
+      // A live yield carries the connection so callers can pick shell-vs-backlog.
+      expect(live.find((t) => t.target === '#c')?.conn).not.toBeNull();
+    } finally {
+      clearLiveConns(u);
+    }
+  });
+
+  it('badge total equals the summed highlights of the frames the client actually receives', () => {
+    // The client's totalHighlights getter sums buf.highlighted, and each buffer's
+    // highlighted is set from its snapshot frame's `highlights`. For an all-offline
+    // user the client's frames are the system-buffer frame + buildOfflineBacklogFrames,
+    // so their highlight sum must equal computeTotalHighlights for the same DB state —
+    // the cross-check that fails if the frame path and the badge path ever drift.
+    const u = createUser('parity').id;
+    const net = netFor(u, 'paritynet');
+
+    // Never-opened DM: every unread line is a highlight (DMs are inherently mentions).
+    ins(net, 'zed', 'yo');
+    ins(net, 'zed', 'you there?');
+    // Channel with one genuine mention among plain chatter → contributes 1.
+    ins(net, '#chan', 'idle talk');
+    ins(net, '#chan', 'hey alice', 1);
+    // Plain channel, no mention → contributes 0 (still enumerated).
+    ins(net, '#quiet', 'nothing to see');
+    // Closed buffer with a mention → excluded from both paths.
+    ins(net, '#gone', 'alice?', 1);
+    closeBuffer(u, net, '#gone');
+    // Server pseudo-buffer notice → not a DM, no mention rule → 0 highlights.
+    ins(net, `:server:${net}`, 'connection notice');
+
+    const systemFrame = buildSystemBacklog(u) as { highlights?: number };
+    const offlineHighlights = buildOfflineBacklogFrames(u).reduce(
+      (sum, f) => sum + (Number((f as { highlights?: number }).highlights) || 0),
+      0,
+    );
+    const clientTotal = (Number(systemFrame.highlights) || 0) + offlineHighlights;
+
+    expect(clientTotal).toBe(computeTotalHighlights(u));
+    // Sanity: the mix actually exercised highlights (DM 2 + channel mention 1),
+    // so this isn't a vacuous 0 === 0.
+    expect(computeTotalHighlights(u)).toBe(3 + (Number(systemFrame.highlights) || 0));
   });
 });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -807,15 +807,14 @@ function buildOfflineFrame(userId: number, networkId: number, target: string): W
     : buildBufferShell(userId, networkId, target, channelJoined(target));
 }
 
-// `closed` defaults to a fresh query so standalone callers (tests) stay simple.
 // `targets` lets the snapshot hand in the enumeration it already materialized for
 // the live loop, so a connect snapshot walks eachUserBufferTarget — and its
 // per-network listBufferTargets/listNetworksForUser DB reads — exactly ONCE
-// instead of once here and once in the live loop.
+// instead of once here and once in the live loop. Standalone callers (tests) omit
+// it and get a fresh walk (which computes its own closed set).
 export function buildOfflineBacklogFrames(
   userId: number,
-  closed: Set<string> = closedKeySetForUser(userId),
-  targets: Iterable<UserBufferTarget> = eachUserBufferTarget(userId, closed),
+  targets: Iterable<UserBufferTarget> = eachUserBufferTarget(userId),
 ): WsPayload[] {
   const frames: WsPayload[] = [];
   for (const { networkId, target, conn } of targets) {
@@ -1619,7 +1618,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     const readState = listReadStateForUser(userId);
     const clearedState = listClearedStateForUser(userId);
     const closed = closedKeySetForUser(userId);
-    const seedsMs = Date.now() - tSeeds;
     // Walk the shared enumerator ONCE per snapshot and reuse it for both the live
     // loop and the offline backlog. Each walk runs a listBufferTargets DB query
     // (recursive CTE) per network plus listNetworksForUser (SELECT * + decryptRow),
@@ -1629,7 +1627,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // buffer references (incl. live conns), which stay valid for the rest of this
     // synchronous snapshot. The system buffer / :server: / closed-joined precedence
     // and joined-channel-even-without-history rules all live in the enumerator.
+    // Counted in seedsMs (it's a bulk pre-loop read like readState/clearedState),
+    // so onlineMs/offlineMs stay pure per-buffer frame-build time.
     const allTargets = [...eachUserBufferTarget(userId, closed)];
+    const seedsMs = Date.now() - tSeeds;
     const tOnline = Date.now();
     let maxSentId = ws.sinceId || 0;
     let bufferCount = 0;
@@ -1737,7 +1738,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // from reading recent backlog for every historical/offline buffer — the bulk
     // of the synchronous read burst on a long-lived account. Reuses the enumeration
     // materialized above so this doesn't re-run the per-network DB reads.
-    for (const frame of buildOfflineBacklogFrames(userId, closed, allTargets)) {
+    for (const frame of buildOfflineBacklogFrames(userId, allTargets)) {
       for (const e of frame.events as Array<{ id?: number | null }>) {
         if (e.id != null && e.id > maxSentId) maxSentId = e.id;
       }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -794,31 +794,37 @@ export function buildSystemHistoryReply(userId: number, msg: WsPayload): WsPaylo
 // connection exists — which a paused user can never establish. Reuses
 // buildBufferBacklog, which reads purely from the DB and reports joined:false
 // when no connection is tracking the channel.
-// `closed` defaults to a fresh query so standalone callers (tests) stay simple;
-// sendSnapshot passes the Set it already computed for the live loop to avoid a
-// redundant DB read per snapshot.
+// The frame for one offline buffer. The server pseudo-buffer ships its real
+// recent slice (one cheap read per network, and it's where the disconnect reason
+// the user wants lives); channel/DM buffers ship as lazy-load shells — that's
+// where the read cost and buffer count actually pile up on a long-lived account.
+// No live conn, so channelJoined folds #channels to parted and DMs to joined
+// (they never dim). Shared by buildOfflineBacklogFrames and the snapshot's single
+// enumeration pass so the offline carve-out lives in exactly one place.
+function buildOfflineFrame(userId: number, networkId: number, target: string): WsPayload {
+  return target.startsWith(':server:')
+    ? buildBufferBacklog(userId, networkId, target)
+    : buildBufferShell(userId, networkId, target, channelJoined(target));
+}
+
+// `closed` defaults to a fresh query so standalone callers (tests) stay simple.
+// `targets` lets the snapshot hand in the enumeration it already materialized for
+// the live loop, so a connect snapshot walks eachUserBufferTarget — and its
+// per-network listBufferTargets/listNetworksForUser DB reads — exactly ONCE
+// instead of once here and once in the live loop.
 export function buildOfflineBacklogFrames(
   userId: number,
   closed: Set<string> = closedKeySetForUser(userId),
+  targets: Iterable<UserBufferTarget> = eachUserBufferTarget(userId, closed),
 ): WsPayload[] {
   const frames: WsPayload[] = [];
-  for (const { networkId, target, conn } of eachUserBufferTarget(userId, closed)) {
+  for (const { networkId, target, conn } of targets) {
     // Offline backlog only: the app-scoped system buffer ships via its own frame,
     // and live networks are handled by the snapshot's live loop. eachUserBufferTarget
     // has already applied the closed-flag carve-out (nothing is joined offline, so
     // there's no autorejoin race to defend against here — unlike the live loop).
     if (networkId == null || conn) continue;
-    // The server pseudo-buffer ships its real recent slice (one cheap read per
-    // network, and it's where the disconnect reason the user wants lives).
-    // Channel/DM buffers ship as lazy-load shells — that's where the read cost
-    // and buffer count actually pile up on a long-lived account.
-    frames.push(
-      target.startsWith(':server:')
-        ? buildBufferBacklog(userId, networkId, target)
-        : // Offline: no live conn, so channelJoined folds #channels to parted
-          // and DMs to joined (they never dim).
-          buildBufferShell(userId, networkId, target, channelJoined(target)),
-    );
+    frames.push(buildOfflineFrame(userId, networkId, target));
   }
   return frames;
 }
@@ -1614,18 +1620,25 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     const clearedState = listClearedStateForUser(userId);
     const closed = closedKeySetForUser(userId);
     const seedsMs = Date.now() - tSeeds;
+    // Walk the shared enumerator ONCE per snapshot and reuse it for both the live
+    // loop and the offline backlog. Each walk runs a listBufferTargets DB query
+    // (recursive CTE) per network plus listNetworksForUser (SELECT * + decryptRow),
+    // so materializing here — rather than iterating the generator separately in the
+    // live loop and again in buildOfflineBacklogFrames — keeps those per-network
+    // reads at 1× on this ping-timeout-sensitive path (#454/#460). The array holds
+    // buffer references (incl. live conns), which stay valid for the rest of this
+    // synchronous snapshot. The system buffer / :server: / closed-joined precedence
+    // and joined-channel-even-without-history rules all live in the enumerator.
+    const allTargets = [...eachUserBufferTarget(userId, closed)];
     const tOnline = Date.now();
     let maxSentId = ws.sinceId || 0;
     let bufferCount = 0;
     let unreadMs = 0;
     let sliceMs = 0;
-    // Live buffers come from the shared enumerator so this loop, the offline
-    // backlog, and the push-badge total can't disagree on the set (#454). It
-    // yields the system buffer and offline networks too — skip both here: the
-    // system buffer ships via its own frame above, and offline networks are
-    // handled by buildOfflineBacklogFrames below. Closed/joined precedence and
-    // the joined-channel-even-without-history rule already live in the enumerator.
-    for (const { networkId: nid, target, conn } of eachUserBufferTarget(userId, closed)) {
+    // Live loop: the enumerator yields the system buffer and offline networks too —
+    // skip both here. The system buffer ships via its own frame above, and offline
+    // networks are handled by buildOfflineBacklogFrames below (same materialized set).
+    for (const { networkId: nid, target, conn } of allTargets) {
       if (nid == null || !conn) continue;
       // Fresh-network branch: this connection just came online, so the client
       // has never received a backlog frame for any of its buffers this
@@ -1722,8 +1735,9 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // reattachToLive (buffers.ts activate() → 'history' mode:'latest'), the same
     // lazy path brand-new buffers already use. This keeps the connect snapshot
     // from reading recent backlog for every historical/offline buffer — the bulk
-    // of the synchronous read burst on a long-lived account.
-    for (const frame of buildOfflineBacklogFrames(userId, closed)) {
+    // of the synchronous read burst on a long-lived account. Reuses the enumeration
+    // materialized above so this doesn't re-run the per-network DB reads.
+    for (const frame of buildOfflineBacklogFrames(userId, closed, allTargets)) {
       for (const e of frame.events as Array<{ id?: number | null }>) {
         if (e.id != null && e.id > maxSentId) maxSentId = e.id;
       }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -11,6 +11,7 @@ import { WebSocketServer } from 'ws';
 import cookie from 'cookie';
 import cookieParser from 'cookie-parser';
 import ircManager from './ircManager.js';
+import type { IrcConnection } from './ircConnection.js';
 import { e2eManager } from './e2e/manager.js';
 import { MAX_IMPORT_BYTES } from './e2e/portable.js';
 import settingsService from './settingsService.js';
@@ -344,43 +345,86 @@ function computeUnreadFor(
   };
 }
 
-// App-wide unread-highlight total for a user — the number the PWA app-icon
-// badge shows while no client is open (#451). Must equal the client's
-// `totalHighlights` getter (sum of every store buffer's `highlighted`), so it
-// enumerates the SAME buffer set the snapshot ships: every network the user
-// owns and every target with history under it, plus the app-scoped system
-// buffer. Crucially it keys off buffer history, NOT buffer_reads rows — a
-// buffer the user has never opened has no read pointer, but the client still
-// counts it (the snapshot computes its highlights from lastReadId 0), so this
-// uses getReadState (which defaults to 0) the same way. Closed buffers are
-// excluded to mirror the client dropping them from its store. :server: pseudo-
-// buffers ARE enumerated by listBufferTargets (it doesn't filter them), but
-// isDmTarget excludes them, so they get no DM=unread shortcut — their only
-// highlights are genuine mention-rule matches against server-notice text
-// (normally none), which the client's snapshot counts identically, so the
-// totals still agree. Only called on push delivery (no visible client), so the
-// per-buffer indexed counts are cheap; computeUnreadFor skips the highlight
-// query entirely when a buffer has no unread.
-export function computeTotalHighlights(userId: number): number {
-  const closed = closedKeySetForUser(userId);
+// A joined-set stand-in for buffers with no join concept (offline networks, the
+// system buffer): nothing is ever "currently joined", so isHiddenClosedBuffer
+// falls back to a plain closed-flag check. Shared so we don't allocate one per
+// network in the enumerator.
+const NONE_JOINED: { has(name: string): boolean } = { has: () => false };
+
+// One yield per buffer.
+export interface UserBufferTarget {
+  networkId: number | null; // null == the app-scoped system buffer
+  target: string;
+  conn: IrcConnection | null; // the live connection, or null (offline / system)
+}
+
+// THE single source of "which buffers belong in this user's client store". Every
+// site that has to walk a user's whole buffer set — the connect snapshot's live
+// loop, buildOfflineBacklogFrames, and the push-badge total — used to hand-roll
+// this walk and re-derive the system / :server: / closed-vs-joined carve-outs
+// slightly differently, which let the PWA app-icon badge total drift from the
+// in-app count (#454). Now they all iterate this generator, so the set can't
+// diverge. It yields, in order:
+//   1. the app-scoped system buffer (networkId null, uncloseable);
+//   2. for every network the user owns (live OR offline): its :server: pseudo-
+//      buffer (uncloseable), every target with persisted history
+//      (listBufferTargets), and — for a live connection — its currently-joined
+//      channels even before they have history (matching what the snapshot ships).
+// Closed buffers are dropped with the SAME join-precedence the snapshot uses
+// (isHiddenClosedBuffer): a closed flag hides a buffer only when it isn't
+// currently joined, so an autorejoin/reconnect race where a channel is both
+// closed and joined can't make the badge total omit highlights the snapshot
+// actually shipped (finding #3). `conn` is the live connection or null so callers
+// can choose shell-vs-backlog and thread per-connection state without re-deriving
+// liveness. Keys off buffer history, not buffer_reads rows, so a never-opened
+// buffer (no read pointer) is still enumerated — the client counts it from
+// lastReadId 0, and callers use getReadState (defaults to 0) the same way.
+export function* eachUserBufferTarget(
+  userId: number,
+  closed: Set<string> = closedKeySetForUser(userId),
+): Generator<UserBufferTarget> {
   // System buffer first — app-scoped (networkId null), uncloseable.
-  let total = computeUnreadFor(
-    userId,
-    null,
-    SYSTEM_TARGET,
-    getReadState(userId, null, SYSTEM_TARGET),
-  ).highlights;
+  yield { networkId: null, target: SYSTEM_TARGET, conn: null };
+  const liveById = new Map<number, IrcConnection>(
+    ircManager.listConnections(userId).map((c) => [c.network.id, c]),
+  );
   for (const net of listNetworksForUser(userId)) {
-    for (const target of listBufferTargets(net.id)) {
-      // closedKeySetForUser keys are `${networkId}::${lowercased target}`.
-      if (closed.has(`${net.id}::${target.toLowerCase()}`)) continue;
-      total += computeUnreadFor(
-        userId,
-        net.id,
-        target,
-        getReadState(userId, net.id, target),
-      ).highlights;
+    const conn = liveById.get(net.id) ?? null;
+    const targets = new Set(listBufferTargets(net.id));
+    targets.add(`:server:${net.id}`);
+    // Live: currently-joined channels are shown even before they have history,
+    // and take precedence over a stale closed flag.
+    if (conn) for (const ch of conn.channels.values()) targets.add(ch.name);
+    const joined = conn?.channels ?? NONE_JOINED;
+    for (const target of targets) {
+      // :server: is uncloseable; every other target honors the closed flag, but
+      // a currently-joined channel beats a stale closed flag (join-precedence).
+      if (!target.startsWith(':server:') && isHiddenClosedBuffer(closed, joined, net.id, target))
+        continue;
+      yield { networkId: net.id, target, conn };
     }
+  }
+}
+
+// App-wide unread-highlight total for a user — the number the PWA app-icon badge
+// shows while no client is open (#451). Must equal the client's `totalHighlights`
+// getter (sum of every store buffer's `highlighted`), so it counts highlights
+// over exactly the buffer set eachUserBufferTarget enumerates — the same set the
+// snapshot ships. :server: pseudo-buffers are enumerated but isDmTarget excludes
+// them, so they get no DM=unread shortcut — their only highlights are genuine
+// mention-rule matches against server-notice text (normally none), which the
+// client's snapshot counts identically, so the totals still agree. Only called on
+// push delivery (no visible client), so the per-buffer indexed counts are cheap;
+// computeUnreadFor skips the highlight query entirely when a buffer has no unread.
+export function computeTotalHighlights(userId: number): number {
+  let total = 0;
+  for (const { networkId, target } of eachUserBufferTarget(userId)) {
+    total += computeUnreadFor(
+      userId,
+      networkId,
+      target,
+      getReadState(userId, networkId, target),
+    ).highlights;
   }
   return total;
 }
@@ -757,31 +801,24 @@ export function buildOfflineBacklogFrames(
   userId: number,
   closed: Set<string> = closedKeySetForUser(userId),
 ): WsPayload[] {
-  const liveIds = new Set(ircManager.listConnections(userId).map((c) => c.network.id));
   const frames: WsPayload[] = [];
-  for (const net of listNetworksForUser(userId)) {
-    if (liveIds.has(net.id)) continue;
-    const targets = new Set(listBufferTargets(net.id));
-    targets.add(`:server:${net.id}`);
-    for (const target of targets) {
-      // Server pseudo-buffer is uncloseable; otherwise honor a closed flag.
-      // Nothing is joined on an offline network, so there's no autorejoin race
-      // to defend against here (unlike the live loop in sendSnapshot). The
-      // closed set is case-folded, so fold the target on lookup too.
-      if (!target.startsWith(':server:') && closed.has(`${net.id}::${target.toLowerCase()}`))
-        continue;
-      // The server pseudo-buffer ships its real recent slice (one cheap read per
-      // network, and it's where the disconnect reason the user wants lives).
-      // Channel/DM buffers ship as lazy-load shells — that's where the read cost
-      // and buffer count actually pile up on a long-lived account.
-      frames.push(
-        target.startsWith(':server:')
-          ? buildBufferBacklog(userId, net.id, target)
-          : // Offline: no live conn, so channelJoined folds #channels to parted
-            // and DMs to joined (they never dim).
-            buildBufferShell(userId, net.id, target, channelJoined(target)),
-      );
-    }
+  for (const { networkId, target, conn } of eachUserBufferTarget(userId, closed)) {
+    // Offline backlog only: the app-scoped system buffer ships via its own frame,
+    // and live networks are handled by the snapshot's live loop. eachUserBufferTarget
+    // has already applied the closed-flag carve-out (nothing is joined offline, so
+    // there's no autorejoin race to defend against here — unlike the live loop).
+    if (networkId == null || conn) continue;
+    // The server pseudo-buffer ships its real recent slice (one cheap read per
+    // network, and it's where the disconnect reason the user wants lives).
+    // Channel/DM buffers ship as lazy-load shells — that's where the read cost
+    // and buffer count actually pile up on a long-lived account.
+    frames.push(
+      target.startsWith(':server:')
+        ? buildBufferBacklog(userId, networkId, target)
+        : // Offline: no live conn, so channelJoined folds #channels to parted
+          // and DMs to joined (they never dim).
+          buildBufferShell(userId, networkId, target, channelJoined(target)),
+    );
   }
   return frames;
 }
@@ -1582,106 +1619,100 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     let bufferCount = 0;
     let unreadMs = 0;
     let sliceMs = 0;
-    for (const conn of ircManager.listConnections(userId)) {
-      const targets = new Set(listBufferTargets(conn.network.id));
-      targets.add(`:server:${conn.network.id}`);
-      // Currently-joined channels are always shown — they take precedence over
-      // a stale closed flag (shouldn't normally exist since joining clears it,
-      // but defensive against autorejoin/state races).
-      for (const ch of conn.channels.values()) targets.add(ch.name);
+    // Live buffers come from the shared enumerator so this loop, the offline
+    // backlog, and the push-badge total can't disagree on the set (#454). It
+    // yields the system buffer and offline networks too — skip both here: the
+    // system buffer ships via its own frame above, and offline networks are
+    // handled by buildOfflineBacklogFrames below. Closed/joined precedence and
+    // the joined-channel-even-without-history rule already live in the enumerator.
+    for (const { networkId: nid, target, conn } of eachUserBufferTarget(userId, closed)) {
+      if (nid == null || !conn) continue;
       // Fresh-network branch: this connection just came online, so the client
       // has never received a backlog frame for any of its buffers this
       // session. ws.sinceId has been advanced by live events on other
       // networks, so a cursor read would return nothing — ship the full
       // recent slice instead.
       const isFreshNetwork = freshNetworkId != null && conn.network.id === freshNetworkId;
-      for (const target of targets) {
-        if (target.startsWith(':server:')) {
-          // Server pseudo-buffer is uncloseable — never filter.
-        } else if (isHiddenClosedBuffer(closed, conn.channels, conn.network.id, target)) {
-          continue;
-        }
-        // Fresh connect (empty client, nothing focused) or a just-connected
-        // network: ship a lazy SHELL for channel/DM buffers instead of reading
-        // their backlog. Lurker auto-focuses nothing on load, so no messages are
-        // needed up front — the client hydrates whatever the user actually opens
-        // (activate() → reattachToLive). The :server: pseudo-buffer stays real
-        // (one cheap read per network; it holds connection notices worth seeing
-        // without a click). isFreshNetwork routes here too: its buffers' history
-        // all predates the advanced cursor, so a gap read would be empty — a
-        // shell is both correct and cheaper than the old forced-latest slice.
-        // Read/cleared state comes from the bulk maps this loop already built
-        // (listReadStateForUser/listClearedStateForUser) — thread them through so
-        // neither the shell nor the resume frame re-issues a per-buffer point
-        // query (the O(buffers) synchronous work the shell optimization exists to
-        // cut).
-        const key = `${conn.network.id}::${target}`;
-        const precomputed = {
-          lastReadId: readState[key] || 0,
-          cleared: clearedState[key] ?? { clearedBeforeId: 0, clearedAt: null },
-        };
-        if ((isFreshConnect || isFreshNetwork) && !target.startsWith(':server:')) {
-          // Shell path: the only per-buffer work is buildBufferShell's unread
-          // count (bufferStateFields → computeUnreadFor), so it goes to unreadMs.
-          const tShell = Date.now();
-          const shell = buildBufferShell(
-            userId,
-            conn.network.id,
-            target,
-            channelJoined(target, conn),
-            precomputed,
-          );
-          unreadMs += Date.now() - tShell;
-          send(ws, shell);
-          bufferCount += 1;
-          continue;
-        }
-        // Resume cursor: ship the gap the client missed (id > sinceId), or a
-        // fresh latest slice + reset flag when that gap exceeds the cap (see
-        // buildResumeSlice for the gap/reset rationale).
-        const tSlice = Date.now();
-        const slice = buildResumeSlice(userId, conn.network.id, target, ws.sinceId || 0);
-        sliceMs += Date.now() - tSlice;
-        const events = slice.events;
-        for (const e of events) {
-          if (e.id != null && e.id > maxSentId) maxSentId = e.id;
-        }
-        // Per-buffer input history for up-arrow recall — a recent slice
-        // (INPUT_HISTORY_SLICE); older entries stay in the DB (no pagination
-        // request exists, so this slice is the recall depth). The 'history' latest
-        // reply re-seeds it when a shell is opened.
-        const inputHistory = listRecentInputHistory(
+      // Fresh connect (empty client, nothing focused) or a just-connected
+      // network: ship a lazy SHELL for channel/DM buffers instead of reading
+      // their backlog. Lurker auto-focuses nothing on load, so no messages are
+      // needed up front — the client hydrates whatever the user actually opens
+      // (activate() → reattachToLive). The :server: pseudo-buffer stays real
+      // (one cheap read per network; it holds connection notices worth seeing
+      // without a click). isFreshNetwork routes here too: its buffers' history
+      // all predates the advanced cursor, so a gap read would be empty — a
+      // shell is both correct and cheaper than the old forced-latest slice.
+      // Read/cleared state comes from the bulk maps this loop already built
+      // (listReadStateForUser/listClearedStateForUser) — thread them through so
+      // neither the shell nor the resume frame re-issues a per-buffer point
+      // query (the O(buffers) synchronous work the shell optimization exists to
+      // cut).
+      const key = `${conn.network.id}::${target}`;
+      const precomputed = {
+        lastReadId: readState[key] || 0,
+        cleared: clearedState[key] ?? { clearedBeforeId: 0, clearedAt: null },
+      };
+      if ((isFreshConnect || isFreshNetwork) && !target.startsWith(':server:')) {
+        // Shell path: the only per-buffer work is buildBufferShell's unread
+        // count (bufferStateFields → computeUnreadFor), so it goes to unreadMs.
+        const tShell = Date.now();
+        const shell = buildBufferShell(
           userId,
           conn.network.id,
           target,
-          INPUT_HISTORY_SLICE,
+          channelJoined(target, conn),
+          precomputed,
         );
-        // Speakers are deliberately NOT shipped on connect. The sidebar doesn't
-        // use them, and computing them per buffer here (listSpeakers scanning
-        // history × every buffer) was the snapshot's dominant cost once the other
-        // scans were fixed. Nick autocomplete seeds them when you actually OPEN a
-        // buffer (the 'history' latest reply carries them — see applyLatestReplace)
-        // and live via recordSpeaker; omitting the key here leaves the client's
-        // existing map untouched.
-        const tUnread = Date.now();
-        const stateFields = bufferStateFields(userId, conn.network.id, target, precomputed);
-        unreadMs += Date.now() - tUnread;
-        send(ws, {
-          kind: 'backlog',
-          networkId: conn.network.id,
-          target,
-          events,
-          // reset=true means the resume gap overflowed the cap and `events` is
-          // a fresh latest slice — the client must replace its buffer, not
-          // append, or it splices a permanent hole (issue #205).
-          reset: slice.reset,
-          hasMoreOlder: slice.hasMoreOlder,
-          joined: channelJoined(target, conn),
-          ...stateFields,
-          inputHistory,
-        });
+        unreadMs += Date.now() - tShell;
+        send(ws, shell);
         bufferCount += 1;
+        continue;
       }
+      // Resume cursor: ship the gap the client missed (id > sinceId), or a
+      // fresh latest slice + reset flag when that gap exceeds the cap (see
+      // buildResumeSlice for the gap/reset rationale).
+      const tSlice = Date.now();
+      const slice = buildResumeSlice(userId, conn.network.id, target, ws.sinceId || 0);
+      sliceMs += Date.now() - tSlice;
+      const events = slice.events;
+      for (const e of events) {
+        if (e.id != null && e.id > maxSentId) maxSentId = e.id;
+      }
+      // Per-buffer input history for up-arrow recall — a recent slice
+      // (INPUT_HISTORY_SLICE); older entries stay in the DB (no pagination
+      // request exists, so this slice is the recall depth). The 'history' latest
+      // reply re-seeds it when a shell is opened.
+      const inputHistory = listRecentInputHistory(
+        userId,
+        conn.network.id,
+        target,
+        INPUT_HISTORY_SLICE,
+      );
+      // Speakers are deliberately NOT shipped on connect. The sidebar doesn't
+      // use them, and computing them per buffer here (listSpeakers scanning
+      // history × every buffer) was the snapshot's dominant cost once the other
+      // scans were fixed. Nick autocomplete seeds them when you actually OPEN a
+      // buffer (the 'history' latest reply carries them — see applyLatestReplace)
+      // and live via recordSpeaker; omitting the key here leaves the client's
+      // existing map untouched.
+      const tUnread = Date.now();
+      const stateFields = bufferStateFields(userId, conn.network.id, target, precomputed);
+      unreadMs += Date.now() - tUnread;
+      send(ws, {
+        kind: 'backlog',
+        networkId: conn.network.id,
+        target,
+        events,
+        // reset=true means the resume gap overflowed the cap and `events` is
+        // a fresh latest slice — the client must replace its buffer, not
+        // append, or it splices a permanent hole (issue #205).
+        reset: slice.reset,
+        hasMoreOlder: slice.hasMoreOlder,
+        joined: channelJoined(target, conn),
+        ...stateFields,
+        inputHistory,
+      });
+      bufferCount += 1;
     }
     const onlineMs = Date.now() - tOnline;
     const tOffline = Date.now();

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -364,12 +364,13 @@ export interface UserBufferTarget {
 // this walk and re-derive the system / :server: / closed-vs-joined carve-outs
 // slightly differently, which let the PWA app-icon badge total drift from the
 // in-app count (#454). Now they all iterate this generator, so the set can't
-// diverge. It yields, in order:
-//   1. the app-scoped system buffer (networkId null, uncloseable);
-//   2. for every network the user owns (live OR offline): its :server: pseudo-
-//      buffer (uncloseable), every target with persisted history
-//      (listBufferTargets), and — for a live connection — its currently-joined
-//      channels even before they have history (matching what the snapshot ships).
+// diverge. The app-scoped system buffer (networkId null, uncloseable) is yielded
+// first; then, for every network the user owns (live OR offline), the buffers
+// under it — in no particular order — its :server: pseudo-buffer (uncloseable),
+// every target with persisted history (listBufferTargets), and, for a live
+// connection, its currently-joined channels even before they have history
+// (matching what the snapshot ships). Consumers key frames by network+target and
+// sum per buffer, so intra-network yield order doesn't matter.
 // Closed buffers are dropped with the SAME join-precedence the snapshot uses
 // (isHiddenClosedBuffer): a closed flag hides a buffer only when it isn't
 // currently joined, so an autorejoin/reconnect race where a channel is both


### PR DESCRIPTION
Closes #454.

## Problem

The connect snapshot's live loop, `buildOfflineBacklogFrames`, and the push-badge total (`computeTotalHighlights`) each hand-rolled a "walk every buffer for a user" loop and re-derived the system / `:server:` / closed-vs-joined carve-outs slightly differently. That let the PWA app-icon badge total drift from the in-app count.

Concretely (review finding #3 from #453): `computeTotalHighlights` dropped closed buffers with a bare `closed.has()`, losing the join-precedence the snapshot encodes (a closed buffer is hidden only when closed **and not currently joined**). During an autorejoin/reconnect race where a channel is both flagged closed and currently joined, the snapshot ships it and the client counts its mentions, but the badge total omitted them — so the app-icon badge read lower than the in-app count.

## Change

**One shared generator** — `eachUserBufferTarget(userId, closed)` — is now the single source of "which buffers are in a user's client store." It yields the system buffer, then each owned network's `:server:` pseudo-buffer, persisted targets, and (for a live connection) joined-but-history-less channels, dropping closed buffers via the shared `isHiddenClosedBuffer` join-precedence. All three consumers iterate it, so the set can't diverge — which also fixes finding #3.

**Snapshot walks it once.** The live loop and `buildOfflineBacklogFrames` both consume the enumeration, so the snapshot materializes it a single time and hands it to both. That keeps the per-network `listBufferTargets` (recursive-CTE) and `listNetworksForUser` (`SELECT *` + `decryptRow`) reads at 1× per snapshot — a small perf win on the ping-timeout-sensitive path #460/#469 already work to shrink. The offline per-target frame builder is extracted to `buildOfflineFrame` so the carve-out lives in one place.

## Tests

- Live-connection regression for the closed-**and**-joined channel (finding #3): the badge total now counts it, and drops it again once the connection ends.
- `eachUserBufferTarget` closed/joined-precedence contract (offline honors closed; live join overrides it).
- Cross-path parity: `computeTotalHighlights` equals the summed `highlights` of the frames the client actually receives (system frame + offline frames) — the guard that fails if the frame path and the badge path ever drift again.
- `buildOfflineBacklogFrames` yields identical frames whether it walks the enumeration itself or reuses a pre-materialized one.

Full suite green (1965 tests). Reviewed with two `/code-review high` passes; the double-walk regression the first pass flagged and the two cleanups the second pass flagged are all fixed in-branch. Badges verified working in local QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)