### PR TITLE
Reconcile the PWA app-icon badge on return to foreground (#463)

### DIFF
--- a/vue_client/src/composables/useAppBadge.test.ts
+++ b/vue_client/src/composables/useAppBadge.test.ts
@@ -16,6 +16,27 @@ beforeEach(() => {
 
 afterEach(() => vi.unstubAllGlobals());
 
+// A minimal EventTarget stand-in — the suite runs in a node environment (no DOM),
+// so we stub document/window like navigator. It records listeners and lets a test
+// fire an event, without pulling in a DOM impl. A fresh one per load() means a
+// listener registered in one test can never fire in another.
+function makeEventTarget() {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    addEventListener(type: string, fn: () => void) {
+      let set = listeners.get(type);
+      if (!set) listeners.set(type, (set = new Set()));
+      set.add(fn);
+    },
+    removeEventListener(type: string, fn: () => void) {
+      listeners.get(type)?.delete(fn);
+    },
+    fire(type: string) {
+      for (const fn of listeners.get(type) ?? []) fn();
+    },
+  };
+}
+
 // Load a fresh useAppBadge wired to a ref we control. `vue` is imported AFTER the
 // module reset and the ref is created from that same fresh instance, so the
 // composable's `watch` (which imports the same post-reset `vue`) tracks it — a
@@ -32,8 +53,12 @@ async function load(supported = true) {
     }),
   }));
   vi.stubGlobal('navigator', supported ? { setAppBadge, clearAppBadge } : {});
+  const doc = Object.assign(makeEventTarget(), { hidden: false });
+  const win = makeEventTarget();
+  vi.stubGlobal('document', doc);
+  vi.stubGlobal('window', win);
   const mod = await import('./useAppBadge.js');
-  return { ...mod, total, nextTick };
+  return { ...mod, total, nextTick, doc, win };
 }
 
 describe('useAppBadge', () => {
@@ -71,6 +96,70 @@ describe('useAppBadge', () => {
     clearAppBadgeNow();
     expect(clearAppBadge).toHaveBeenCalledTimes(1);
     expect(setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('re-clears the badge on return to visibility even when the total did not change (#463)', async () => {
+    // The bug: the service worker sets the badge from a push while hidden, then
+    // the app returns to the foreground with total still 0. The change-only
+    // watcher never re-fires, so the stale SW-set count lingers. The visibility
+    // reconcile must re-assert the store total (0 → clear) regardless of change.
+    const { startAppBadge, nextTick, doc } = await load(); // total defaults to 0
+    startAppBadge();
+    await nextTick();
+    clearAppBadge.mockClear();
+    setAppBadge.mockClear();
+
+    doc.fire('visibilitychange');
+    expect(clearAppBadge).toHaveBeenCalledTimes(1);
+    expect(setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it('re-asserts a non-zero total on return to visibility', async () => {
+    const { startAppBadge, total, nextTick, doc } = await load();
+    total.value = 2;
+    startAppBadge();
+    await nextTick();
+    setAppBadge.mockClear();
+    clearAppBadge.mockClear();
+
+    doc.fire('visibilitychange');
+    expect(setAppBadge).toHaveBeenCalledTimes(1);
+    expect(setAppBadge).toHaveBeenLastCalledWith(2);
+  });
+
+  it('re-asserts the total on window focus (desktop PWA that never went hidden)', async () => {
+    // A desktop window can regain the foreground via `focus` without ever having
+    // been document.hidden (e.g. across OS sleep with the socket dropped), so
+    // visibilitychange alone would miss it — the platform in the #463 report.
+    const { startAppBadge, total, nextTick, win } = await load();
+    total.value = 3;
+    startAppBadge();
+    await nextTick();
+    setAppBadge.mockClear();
+
+    win.fire('focus');
+    expect(setAppBadge).toHaveBeenCalledTimes(1);
+    expect(setAppBadge).toHaveBeenLastCalledWith(3);
+  });
+
+  it('reconciles when visible but not while the page is hidden', async () => {
+    const { startAppBadge, total, nextTick, doc } = await load();
+    total.value = 4;
+    startAppBadge();
+    await nextTick();
+    setAppBadge.mockClear();
+
+    // Visible → the reconcile listener fires (proves it's actually wired).
+    doc.fire('visibilitychange');
+    expect(setAppBadge).toHaveBeenCalledTimes(1);
+    expect(setAppBadge).toHaveBeenLastCalledWith(4);
+
+    // Hidden → the same event must NOT reconcile.
+    setAppBadge.mockClear();
+    doc.hidden = true;
+    doc.fire('visibilitychange');
+    expect(setAppBadge).not.toHaveBeenCalled();
+    expect(clearAppBadge).not.toHaveBeenCalled();
   });
 
   it('no-ops when the Badging API is unavailable', async () => {

--- a/vue_client/src/composables/useAppBadge.ts
+++ b/vue_client/src/composables/useAppBadge.ts
@@ -55,7 +55,10 @@ export function startAppBadge(): void {
         if (!document.hidden) applyBadge(buffers.totalHighlights);
       };
       document.addEventListener('visibilitychange', reconcile);
-      window.addEventListener('focus', reconcile);
+      // Guarded independently of document: a partial DOM shim could expose one
+      // without the other, and losing focus reconciliation shouldn't cost us the
+      // visibilitychange one.
+      if (typeof window !== 'undefined') window.addEventListener('focus', reconcile);
     }
   });
 }

--- a/vue_client/src/composables/useAppBadge.ts
+++ b/vue_client/src/composables/useAppBadge.ts
@@ -33,7 +33,30 @@ export function startAppBadge(): void {
   scope = effectScope(true);
   scope.run(() => {
     const buffers = useBuffersStore();
+    // The change-only watcher below is one of TWO writers of the app-icon badge:
+    // the service worker also writes it from push payloads (syncAppBadge in
+    // public/sw.js) while the app is hidden/closed — the exact window this
+    // in-page watcher can't reach. So the badge can be left showing a count the
+    // store never matches once the app returns to the foreground with an
+    // unchanged total (the watcher only fires on a CHANGE, so it never re-clears
+    // it). Re-assert the current store total whenever the page returns to the
+    // foreground, so the page always wins over a stale service-worker write (#463).
     watch(() => buffers.totalHighlights, applyBadge, { immediate: true });
+    // Two return-to-foreground signals, mirroring usePresence's listener set:
+    // visibilitychange covers a tab/PWA that was document.hidden (mobile,
+    // minimized, tab-discarded); window focus covers a desktop PWA window that
+    // stayed visibilityState='visible' but lost focus — e.g. across an OS sleep
+    // where the socket dropped — which fires no visibilitychange on return. The
+    // !document.hidden guard keeps focus-while-hidden a no-op. These live for the
+    // whole session (the detached scope is never stopped — see above), which is
+    // correct: they must survive logout→login and keep reconciling.
+    if (typeof document !== 'undefined') {
+      const reconcile = () => {
+        if (!document.hidden) applyBadge(buffers.totalHighlights);
+      };
+      document.addEventListener('visibilitychange', reconcile);
+      window.addEventListener('focus', reconcile);
+    }
   });
 }
 


### PR DESCRIPTION
Closes #463.

## Symptom

macOS PWA shows a stuck unread badge (e.g. `1`) when there are no unread highlights, and it doesn't clear until a new highlight comes in and then goes away.

## Root cause — two writers, one badge

The app-icon badge has two independent writers:

1. **In-page** (`useAppBadge.ts`) — a watcher on `buffers.totalHighlights`, but it only fires on a **change**.
2. **Service worker** (`public/sw.js` `syncAppBadge`) — sets the badge from `data.badge` on push payloads, while the app is hidden/closed (the window the page watcher can't reach).

Pushes (and thus the SW's badge write) fire only when no client reports visible. So: app hidden → highlight arrives → push sets the icon to `1` → the highlight is read (on another device, or the read-state arrives over the still-open WS) so the true total returns to `0` → user foregrounds the PWA. The store total is already `0` and **doesn't change**, so the change-only watcher never re-fires to clear the SW's stale `1`. It only clears later when a *new* highlight arrives and then clears — exactly the reported behavior.

## Fix

Re-assert the current store total onto the badge whenever the page returns to the foreground, so the page always wins over a stale SW write. Listen on **both** signals, mirroring `usePresence`:

- `visibilitychange` — a tab/PWA that was `document.hidden` (mobile, minimized, tab-discarded).
- `window` `focus` — a desktop PWA window that stayed `visibilityState='visible'` but lost focus (e.g. across an OS sleep where the socket dropped), which fires **no** `visibilitychange` on return. This is the macOS desktop case in the report.

Both guarded on `!document.hidden`. Cold-start (app fully closed → reopened) was already covered by the watcher's `immediate: true`; this closes the return-to-foreground gap. The listeners live for the session, matching the existing never-stopped effect scope.

## Tests

Stub a minimal fake `document`/`window` (the suite runs node-only, no DOM): the zero-total reconcile that reproduces #463, a non-zero re-assert, the window-focus path, and a combined visible-reconciles / hidden-does-not guard. Full suite green (1969).

Reviewed with `/code-review high`: the review surfaced the desktop `focus` gap (added), and flagged an earlier `stopAppBadge`/teardown as unnecessary cruft (removed — a fresh fake document per test means no cross-test listener leak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)