### PR TITLE
Server buffer: only mark notable lines unread (#470)

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -172,6 +172,7 @@ export const EXPORT_TABLES = Object.freeze({
       'alt',
       'from_ignored',
       'mirrored',
+      'notable',
     ],
   },
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -864,6 +864,37 @@ ensureColumn('messages', 'from_ignored', 'INTEGER NOT NULL DEFAULT 0');
 // doesn't double up its real copy. Old rows default to 0 (not a mirror).
 ensureColumn('messages', 'mirrored', 'INTEGER NOT NULL DEFAULT 0');
 
+// Server-buffer notability (#470). Lurker's own connection-status notices —
+// connecting/reconnecting, nick fallback/in-use/reclaimed, MONITOR-limit (all
+// published with nick:'lurker') — are stamped notable=0 so they still render in
+// the server buffer but never mark it unread. Genuine inbound notices/messages,
+// server errors (killed/banned/etc.), and closed-buffer NOTICE mirrors stay
+// notable=1 (the default). Only the :server: unread count consults this column
+// (countServerBufferUnread); channel/DM counts never filter on it, so they're
+// unaffected. Old rows default to 1 — no behavior change for existing history.
+const hadNotableColumn = columnExists('messages', 'notable');
+ensureColumn('messages', 'notable', 'INTEGER NOT NULL DEFAULT 1');
+// One-time backfill on the migration that introduces the column: existing rows
+// all defaulted to notable=1, so historical Lurker status notices ("Connecting…",
+// "Reconnecting…" etc. — published with nick:'lurker' into a :server: buffer)
+// would keep marking the server buffer unread until read. Demote them so the new
+// behavior applies to existing history too. Gated on the column having been
+// absent, so it runs exactly once — never a repeated full scan on later boots.
+if (!hadNotableColumn) demoteLegacyServerStatusNotices();
+
+// #470 backfill body, split out so it can be unit-tested against seeded rows
+// (a hoisted declaration, so the gated call above reaches it). Demotes only
+// Lurker's own status notices — nick:'lurker' NOTICEs in a :server: buffer — so
+// genuine inbound content in channels/DMs is never touched. The nick heuristic is
+// used only here for historical rows; going forward the notable flag is stamped
+// explicitly at publish, never inferred from nick.
+export function demoteLegacyServerStatusNotices(): void {
+  db.exec(
+    `UPDATE messages SET notable = 0
+       WHERE type = 'notice' AND nick = 'lurker' AND target LIKE ':server:%'`,
+  );
+}
+
 // Per-(user, buffer) /clear marker. cleared_before_message_id is the highest
 // message id hidden from the live view; messages with id > it remain visible.
 // cleared_at is the wall-clock time the user issued /clear (shown in the

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -869,8 +869,9 @@ ensureColumn('messages', 'mirrored', 'INTEGER NOT NULL DEFAULT 0');
 // published with nick:'lurker') — are stamped notable=0 so they still render in
 // the server buffer but never mark it unread. Genuine inbound notices/messages,
 // server errors (killed/banned/etc.), and closed-buffer NOTICE mirrors stay
-// notable=1 (the default). Only the :server: unread count consults this column
-// (countServerBufferUnread); channel/DM counts never filter on it, so they're
+// notable=1 (the default). The column is consulted by countServerBufferUnread
+// (the :server: unread count) and countHighlightsNewer (highlight counts); the
+// generic channel/DM unread count never filters on it, so channels/DMs are
 // unaffected. Old rows default to 1 — no behavior change for existing history.
 const hadNotableColumn = columnExists('messages', 'notable');
 ensureColumn('messages', 'notable', 'INTEGER NOT NULL DEFAULT 1');

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -16,6 +16,7 @@ let listMessages: typeof import('./messages.js').listMessages;
 let listMessagesAround: typeof import('./messages.js').listMessagesAround;
 let searchMessages: typeof import('./messages.js').searchMessages;
 let countNewer: typeof import('./messages.js').countNewer;
+let countServerBufferUnread: typeof import('./messages.js').countServerBufferUnread;
 let countHighlightsNewer: typeof import('./messages.js').countHighlightsNewer;
 let listUserHighlights: typeof import('./messages.js').listUserHighlights;
 let maxIdForBuffer: typeof import('./messages.js').maxIdForBuffer;
@@ -24,16 +25,19 @@ let listSpeakers: typeof import('./messages.js').listSpeakers;
 let listBufferTargets: typeof import('./messages.js').listBufferTargets;
 let loadHistoryWindow: typeof import('./messages.js').loadHistoryWindow;
 let listActiveTargetsInWindow: typeof import('./messages.js').listActiveTargetsInWindow;
+let demoteLegacyServerStatusNotices: typeof import('./index.js').demoteLegacyServerStatusNotices;
 
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
+  ({ demoteLegacyServerStatusNotices } = await import('./index.js'));
   ({
     insertMessage,
     listMessages,
     listMessagesAround,
     searchMessages,
     countNewer,
+    countServerBufferUnread,
     countHighlightsNewer,
     listUserHighlights,
     maxIdForBuffer,
@@ -77,6 +81,89 @@ function event(networkId: number, target: string, type: string, nick: string | n
 function altsFor(networkId: number, target: string) {
   return listMessages(networkId, target, { limit: 1000 }).map((m) => m.alt);
 }
+
+describe('countServerBufferUnread (#470)', () => {
+  let seq = 0;
+  const net = () => {
+    const user = createUser(`sbu-${++seq}`);
+    return createNetwork(user.id, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'me' })!.id;
+  };
+  const put = (
+    networkId: number,
+    target: string,
+    type: string,
+    opts: { nick?: string; notable?: boolean; fromIgnored?: boolean; mirrored?: boolean } = {},
+  ) =>
+    Number(
+      insertMessage({
+        networkId,
+        target,
+        time: new Date().toISOString(),
+        type,
+        nick: opts.nick ?? 'someone',
+        text: 'x',
+        self: false,
+        notable: opts.notable,
+        fromIgnored: opts.fromIgnored,
+        mirrored: opts.mirrored,
+      }).id,
+    );
+
+  it('counts errors, inbound notices/messages, and mirrors; skips Lurker status notices', () => {
+    const n = net();
+    const target = `:server:${n}`;
+    put(n, target, 'error'); // killed/banned/etc. — countNewer would NOT count this
+    put(n, target, 'notice', { nick: 'NickServ' }); // inbound notice
+    put(n, target, 'message', { nick: 'irc.server' }); // server message
+    put(n, target, 'notice', { nick: 'ChanServ', mirrored: true }); // closed-buffer mirror → still counts
+    put(n, target, 'notice', { nick: 'lurker', notable: false }); // "Connecting…" — must NOT count
+    put(n, target, 'notice', { nick: 'lurker', notable: false }); // "Reconnecting…" — must NOT count
+
+    expect(countServerBufferUnread(n, target, 0)).toBe(4);
+    // The generic channel count disagrees on BOTH axes: it drops the 'error' but
+    // counts the two notable=0 Lurker status notices (it ignores the flag) — so it
+    // sees the 5 notice/message rows and misses the error. Exactly why :server:
+    // needs its own count.
+    expect(countNewer(n, target, 0)).toBe(5);
+  });
+
+  it('honors the read pointer and excludes ignored senders', () => {
+    const n = net();
+    const target = `:server:${n}`;
+    const a = put(n, target, 'notice', { nick: 'a' });
+    put(n, target, 'notice', { nick: 'b' });
+    put(n, target, 'notice', { nick: 'spammer', fromIgnored: true }); // ignored → not counted
+    expect(countServerBufferUnread(n, target, 0)).toBe(2);
+    expect(countServerBufferUnread(n, target, a)).toBe(1); // only lines after `a`
+  });
+
+  it('returns 0 when every server line is a non-notable Lurker status notice', () => {
+    const n = net();
+    const target = `:server:${n}`;
+    put(n, target, 'notice', { nick: 'lurker', notable: false });
+    put(n, target, 'notice', { nick: 'lurker', notable: false });
+    expect(countServerBufferUnread(n, target, 0)).toBe(0);
+  });
+
+  it('backfill demotes historical Lurker :server: status notices, sparing inbound and channel rows', () => {
+    const n = net();
+    const server = `:server:${n}`;
+    // Simulate PRE-migration rows: all notable=1 (the column default), including
+    // Lurker's own status notices, which were only tagged notable=false going
+    // forward. A real inbound :server: notice and a #channel notice from a
+    // (coincidentally) 'lurker'-nicked sender must survive the backfill.
+    put(n, server, 'notice', { nick: 'lurker' }); // status notice → should be demoted
+    put(n, server, 'notice', { nick: 'NickServ' }); // inbound → keep
+    put(n, '#room', 'notice', { nick: 'lurker' }); // wrong buffer → keep (LIKE ':server:%' scope)
+    expect(countServerBufferUnread(n, server, 0)).toBe(2);
+    expect(countServerBufferUnread(n, '#room', 0)).toBe(1);
+
+    demoteLegacyServerStatusNotices();
+
+    expect(countServerBufferUnread(n, server, 0)).toBe(1); // only the status notice dropped
+    expect(countServerBufferUnread(n, '#room', 0)).toBe(1); // channel row untouched
+  });
+});
 
 describe('hasConversationForTarget (#439)', () => {
   it('is true only when a non-notice message exists for the target', () => {

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -17,6 +17,7 @@ let listMessagesAround: typeof import('./messages.js').listMessagesAround;
 let searchMessages: typeof import('./messages.js').searchMessages;
 let countNewer: typeof import('./messages.js').countNewer;
 let countServerBufferUnread: typeof import('./messages.js').countServerBufferUnread;
+let typeCountsForUnread: typeof import('./messages.js').typeCountsForUnread;
 let countHighlightsNewer: typeof import('./messages.js').countHighlightsNewer;
 let listUserHighlights: typeof import('./messages.js').listUserHighlights;
 let maxIdForBuffer: typeof import('./messages.js').maxIdForBuffer;
@@ -38,6 +39,7 @@ beforeAll(async () => {
     searchMessages,
     countNewer,
     countServerBufferUnread,
+    typeCountsForUnread,
     countHighlightsNewer,
     listUserHighlights,
     maxIdForBuffer,
@@ -143,6 +145,21 @@ describe('countServerBufferUnread (#470)', () => {
     put(n, target, 'notice', { nick: 'lurker', notable: false });
     put(n, target, 'notice', { nick: 'lurker', notable: false });
     expect(countServerBufferUnread(n, target, 0)).toBe(0);
+  });
+
+  it('typeCountsForUnread: :server: counts errors, other buffers do not — matches the count queries', () => {
+    // This is the rule the live read-state-broadcast trigger uses (wsHub). A
+    // :server: 'error' (a disconnect/quit echo, a kill/ban) must count here, or
+    // its badge wouldn't refresh until the next ordinary countable event — the
+    // delayed-badge bug. Everything countNewer counts still counts everywhere.
+    expect(typeCountsForUnread(':server:1', 'error')).toBe(true);
+    expect(typeCountsForUnread(':server:1', 'notice')).toBe(true);
+    expect(typeCountsForUnread(':server:1', 'message')).toBe(true);
+    expect(typeCountsForUnread(':server:1', 'motd')).toBe(false); // motd never counts
+    // Channels/DMs keep the narrower set: an error there doesn't badge.
+    expect(typeCountsForUnread('#chan', 'error')).toBe(false);
+    expect(typeCountsForUnread('#chan', 'message')).toBe(true);
+    expect(typeCountsForUnread('bob', 'notice')).toBe(true);
   });
 
   it('backfill demotes historical Lurker :server: status notices, sparing inbound and channel rows', () => {

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -70,6 +70,10 @@ export interface MessageInput {
   userhost?: string | null;
   fromIgnored?: boolean;
   mirrored?: boolean;
+  // Server-buffer notability (#470). Defaults to notable (true); pass false for
+  // Lurker's own connection-status notices so they render in the server buffer
+  // but don't mark it unread. Only countServerBufferUnread reads this.
+  notable?: boolean;
 }
 
 /** Buffer summary row for MCP list_buffers. */
@@ -90,9 +94,9 @@ export interface MaxIdByBufferRow {
 // Non-striped types pass through with alt=0; the value is meaningless for them
 // and the client never reads it.
 const insertStmt = db.prepare(`
-  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, mirrored, alt)
+  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, mirrored, notable, alt)
   VALUES (
-    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored, @mirrored,
+    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored, @mirrored, @notable,
     CASE WHEN @type IN ('message', 'action', 'notice')
          THEN 1 - COALESCE(
            (SELECT alt FROM messages
@@ -122,6 +126,8 @@ export function insertMessage(row: MessageInput): { id: number | bigint; alt: bo
     userhost: row.userhost ?? null,
     fromIgnored: row.fromIgnored ? 1 : 0,
     mirrored: row.mirrored ? 1 : 0,
+    // Default notable=1; only an explicit `false` (Lurker's status notices) is 0.
+    notable: row.notable === false ? 0 : 1,
   });
   const id = result.lastInsertRowid;
   const altRow = altByIdStmt.get(id) as { alt: number } | undefined;
@@ -467,15 +473,25 @@ const COUNTABLE_TYPES_SQL = `('${[...COUNTABLE_TYPES].join("','")}')`;
 // past ~999 anyway, and keeping DM highlights exact would mean reintroducing the
 // unbounded scan for DMs. Channel highlights are exact (their own indexed count).
 export const UNREAD_COUNT_CAP = 1000;
-export function countNewer(
+
+// The server pseudo-buffer also counts `error` lines (killed/banned/connection
+// failures SHOULD badge it), which countNewer's type set omits. Derived from
+// COUNTABLE_TYPES so the two SQL paths can't drift (see the note on that const).
+const SERVER_COUNTABLE_TYPES_SQL = `('${[...COUNTABLE_TYPES, 'error'].join("','")}')`;
+
+// Shared unread-count core for countNewer and countServerBufferUnread. Both need
+// the same cap guard and the same ORDER BY id DESC LIMIT index walk; they differ
+// only in the countable type set and whether the notability filter applies. Kept
+// as one body so the LIMIT-guard invariant (a bad cap must not become SQLite's
+// unbounded `LIMIT -1`) lives in exactly one place.
+function countUnreadRows(
   networkId: number,
   target: string,
   afterId: number,
-  cap = UNREAD_COUNT_CAP,
+  typesSql: string,
+  notableOnly: boolean,
+  cap: number,
 ): number {
-  // Guard: a non-positive / non-integer cap would become SQLite's `LIMIT -1`
-  // (= no limit) and silently reintroduce the unbounded scan — fall back to the
-  // default instead.
   const lim = Number.isInteger(cap) && cap > 0 ? cap : UNREAD_COUNT_CAP;
   return (
     db
@@ -483,7 +499,8 @@ export function countNewer(
         `SELECT COUNT(*) AS n FROM (
            SELECT 1 FROM messages
            WHERE network_id = ? AND target = ? AND id > ?
-             AND type IN ${COUNTABLE_TYPES_SQL}
+             AND type IN ${typesSql}
+             ${notableOnly ? 'AND notable = 1' : ''}
              AND from_ignored = 0
            ORDER BY id DESC
            LIMIT ?
@@ -493,10 +510,38 @@ export function countNewer(
   ).n;
 }
 
+export function countNewer(
+  networkId: number,
+  target: string,
+  afterId: number,
+  cap = UNREAD_COUNT_CAP,
+): number {
+  return countUnreadRows(networkId, target, afterId, COUNTABLE_TYPES_SQL, false, cap);
+}
+
+// Unread count for a `:server:` pseudo-buffer (#470). Differs from countNewer in
+// two ways: it also counts `error` rows (a killed/banned/connection-failed line
+// SHOULD mark the server buffer unread — those are type 'error', which countNewer
+// excludes), and it counts only `notable = 1` rows so Lurker's own routine
+// connection-status notices (connecting/reconnecting/nick-status/monitor-limit,
+// stamped notable=0 at publish) don't. Genuine inbound notices/messages and
+// closed-buffer NOTICE mirrors are notable by default, so they still badge.
+export function countServerBufferUnread(
+  networkId: number,
+  target: string,
+  afterId: number,
+  cap = UNREAD_COUNT_CAP,
+): number {
+  return countUnreadRows(networkId, target, afterId, SERVER_COUNTABLE_TYPES_SQL, true, cap);
+}
+
 // Cheap indexed count of unread highlights since `afterId`. Uses the partial
 // idx_messages_matched index — the old scan+decorate approach was replaced
 // once match state moved to insert time. Ignored senders are excluded so the
-// red highlight pip doesn't fire for someone the user can't see.
+// red highlight pip doesn't fire for someone the user can't see. notable=0 lines
+// are excluded too (#470): a Lurker status notice that happens to match a self-
+// nick rule ("Reclaimed nick <you>.") must not highlight the server buffer when
+// it's deliberately not even counted as unread.
 export function countHighlightsNewer(networkId: number, target: string, afterId: number): number {
   return (
     db
@@ -504,7 +549,8 @@ export function countHighlightsNewer(networkId: number, target: string, afterId:
         `SELECT COUNT(*) AS n FROM messages
      WHERE network_id = ? AND target = ? AND id > ?
        AND matched_rule_id IS NOT NULL
-       AND from_ignored = 0`,
+       AND from_ignored = 0
+       AND notable = 1`,
       )
       .get(networkId, target, afterId || 0) as { n: number }
   ).n;

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -449,12 +449,14 @@ export function countOlder(networkId: number, target: string, beforeId: number):
   ).n;
 }
 
-// Types that count as "real content" for the unread badge. Membership churn
-// (join/part/quit/kick/nick/mode/topic), MOTD, away markers, and server
-// errors are all persisted for the buffer log but shouldn't bump the badge —
-// the live unread path in useSocket.applyEvent uses the same allowlist, and
-// we need the SQL paths to match so backlog/read-state recomputes don't snap
-// the count to an inflated number.
+// Types that count as "real content" for the unread badge in a channel or DM.
+// Membership churn (join/part/quit/kick/nick/mode/topic), MOTD, and away markers
+// are persisted for the buffer log but don't bump the badge. `error` is excluded
+// HERE but the `:server:` buffer does count it (see SERVER_COUNTABLE_TYPES /
+// typeCountsForUnread below) — a killed/banned/disconnect line should badge the
+// server tab. The client no longer mirrors any allowlist: unread is driven purely
+// by the server's read-state broadcast (whose trigger uses typeCountsForUnread),
+// so this set only has to stay in sync with the count queries in this file.
 export const COUNTABLE_TYPES = new Set(['message', 'action', 'notice']);
 const COUNTABLE_TYPES_SQL = `('${[...COUNTABLE_TYPES].join("','")}')`;
 

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -476,9 +476,23 @@ const COUNTABLE_TYPES_SQL = `('${[...COUNTABLE_TYPES].join("','")}')`;
 export const UNREAD_COUNT_CAP = 1000;
 
 // The server pseudo-buffer also counts `error` lines (killed/banned/connection
-// failures SHOULD badge it), which countNewer's type set omits. Derived from
-// COUNTABLE_TYPES so the two SQL paths can't drift (see the note on that const).
-const SERVER_COUNTABLE_TYPES_SQL = `('${[...COUNTABLE_TYPES, 'error'].join("','")}')`;
+// failures, and the QUIT-echo disconnect line — all SHOULD badge it), which
+// countNewer's type set omits. Derived from COUNTABLE_TYPES so the paths can't
+// drift.
+const SERVER_COUNTABLE_TYPES = new Set([...COUNTABLE_TYPES, 'error']);
+const SERVER_COUNTABLE_TYPES_SQL = `('${[...SERVER_COUNTABLE_TYPES].join("','")}')`;
+
+// Does an event of `type` count toward `target`'s unread badge? This is the same
+// rule countNewer / countServerBufferUnread apply, exposed so the live read-state
+// broadcast trigger (wsHub) can tell whether an event changed the count without
+// re-implementing it. Crucially a `:server:` 'error' counts here — otherwise its
+// badge wouldn't refresh until the next ordinary countable event landed (a
+// reconnect's "Connecting…" notice), which is the delayed-badge bug (#470).
+export function typeCountsForUnread(target: string, type: string): boolean {
+  return target.startsWith(':server:')
+    ? SERVER_COUNTABLE_TYPES.has(type)
+    : COUNTABLE_TYPES.has(type);
+}
 
 // Shared unread-count core for countNewer and countServerBufferUnread. Both need
 // the same cap guard and the same ORDER BY id DESC LIMIT index walk; they differ

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -72,7 +72,8 @@ export interface MessageInput {
   mirrored?: boolean;
   // Server-buffer notability (#470). Defaults to notable (true); pass false for
   // Lurker's own connection-status notices so they render in the server buffer
-  // but don't mark it unread. Only countServerBufferUnread reads this.
+  // but don't mark it unread. Read by countServerBufferUnread (the :server: unread
+  // count) and countHighlightsNewer (which excludes notable=0 lines from highlights).
   notable?: boolean;
 }
 

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -576,12 +576,12 @@ describe('importFromZipBuffer — roundtrip', () => {
     expect(msg).toBeDefined();
   });
 
-  it('imports a pre-#439 archive whose messages omit the mirrored column', async () => {
-    // A backup taken before messages.mirrored existed has no `mirrored` key in
-    // messages.ndjson. mirrored is NOT NULL DEFAULT 0, but a column default does
-    // NOT apply when the importer binds an explicit NULL for a missing key — so
-    // without the import-side fallback the insert fails with a NOT NULL
-    // constraint and aborts the entire restore.
+  it('imports an older archive whose messages omit late-added NOT NULL columns (mirrored #439, notable #470)', async () => {
+    // A backup taken before messages.mirrored / messages.notable existed has no
+    // such key in messages.ndjson. Both are NOT NULL DEFAULT-ed, but a column
+    // default does NOT apply when the importer binds an explicit NULL for a
+    // missing key — so without the import-side fallback the insert fails with a
+    // NOT NULL constraint and aborts the entire restore.
     const { alice } = seedAlice();
     const buf = await exportToBuffer(alice.id, { includeMessages: true });
     const yauzl = await import('yauzl');
@@ -613,7 +613,7 @@ describe('importFromZipBuffer — roundtrip', () => {
       });
     });
 
-    // Strip `mirrored` from every messages row to mimic a pre-#439 archive.
+    // Strip `mirrored` and `notable` from every messages row to mimic an older archive.
     const msgsKey = [...entries.keys()].find((k) => k.endsWith('messages.ndjson'));
     expect(msgsKey).toBeDefined();
     const stripped = entries
@@ -624,6 +624,7 @@ describe('importFromZipBuffer — roundtrip', () => {
       .map((l) => {
         const row = JSON.parse(l);
         delete row.mirrored;
+        delete row.notable;
         return JSON.stringify(row);
       })
       .join('\n');
@@ -641,14 +642,16 @@ describe('importFromZipBuffer — roundtrip', () => {
     );
     await importFromZipBuffer(olive.id, rebuilt);
 
-    // Restore succeeds and the messages land with mirrored defaulted to 0.
+    // Restore succeeds and the messages land with mirrored defaulted to 0 and
+    // notable defaulted to 1 (old history predates the notability model → counts).
     const rows = db
       .prepare(
-        'SELECT m.mirrored FROM messages m JOIN networks n ON n.id = m.network_id WHERE n.user_id = ?',
+        'SELECT m.mirrored, m.notable FROM messages m JOIN networks n ON n.id = m.network_id WHERE n.user_id = ?',
       )
-      .all(olive.id) as Array<{ mirrored: number }>;
+      .all(olive.id) as Array<{ mirrored: number; notable: number }>;
     expect(rows.length).toBeGreaterThan(0);
     expect(rows.every((r) => r.mirrored === 0)).toBe(true);
+    expect(rows.every((r) => r.notable === 1)).toBe(true);
   });
 
   it('rejects an archive without a manifest', async () => {

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -291,6 +291,10 @@ async function streamMessagesInBatches(
       // mirrored (#439) was added later too — same NOT NULL fallback so a
       // pre-#439 archive (no `mirrored` key) doesn't fail the insert.
       if (row.mirrored === undefined) row.mirrored = 0;
+      // notable (#470) was added later — pre-#470 archives omit it and the column
+      // is NOT NULL. Default to 1 (notable), matching the column default: old
+      // history predates the server-buffer notability model, so it all counts.
+      if (row.notable === undefined) row.notable = 1;
       const result = insertOne(stmt, cols, row);
       messagesMap.set(original.id, result.lastInsertRowid);
       inserted += 1;

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Brad Root
+//Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
 import IRC, { ircLineParser } from 'irc-framework';
@@ -175,6 +175,9 @@ interface AwayState {
 interface IrcEvent {
   type: string;
   target?: string;
+  // Server-buffer notability (#470). Pass false on Lurker's own status notices
+  // so they render but don't mark the server buffer unread; omitted = notable.
+  notable?: boolean;
   [key: string]: unknown;
 }
 
@@ -573,6 +576,7 @@ export class IrcConnection {
         userhost: (event.userhost as string | null | undefined) ?? null,
         fromIgnored,
         mirrored: event.mirrored as boolean | undefined,
+        notable: event.notable as boolean | undefined,
       });
       enriched.id = id;
       enriched.alt = alt;
@@ -805,6 +809,7 @@ export class IrcConnection {
           type: 'notice',
           target: this.serverTarget(),
           nick: 'lurker',
+          notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
           text: `Connected as ${registeredNick} (configured nick ${this.network.nick} was unavailable).`,
         });
         // Defer the MONITOR + handshake until ISUPPORT tells us the server
@@ -900,6 +905,7 @@ export class IrcConnection {
           type: 'notice',
           target: this.serverTarget(),
           nick: 'lurker',
+          notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
           text: `Nick ${requested} is already in use.`,
         });
         return;
@@ -1058,6 +1064,7 @@ export class IrcConnection {
         type: 'notice',
         target: this.serverTarget(),
         nick: 'lurker',
+        notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
         text,
       });
     });
@@ -1664,6 +1671,7 @@ export class IrcConnection {
               type: 'notice',
               target: this.serverTarget(),
               nick: 'lurker',
+              notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
               text: `Reclaimed nick ${this.regainNick}.`,
             });
           }
@@ -2268,6 +2276,7 @@ export class IrcConnection {
         type: 'notice',
         target: this.serverTarget(),
         nick: 'lurker',
+        notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
         text: `MONITOR limit (${this.monitorLimit}) reached; live presence skipped for ${overflow} nick${overflow === 1 ? '' : 's'}.`,
       });
     }
@@ -2364,6 +2373,7 @@ export class IrcConnection {
         type: 'notice',
         target: this.serverTarget(),
         nick: 'lurker',
+        notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
         text: `MONITOR limit (${this.monitorLimit}) reached; live presence skipped for ${nick}.`,
       });
       return true;
@@ -2560,6 +2570,7 @@ export class IrcConnection {
       type: 'notice',
       target: this.serverTarget(),
       nick: 'lurker',
+      notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
       text: `Connecting to ${this.network.host}:${this.network.port}${proto}…`,
     });
     this.client.connect({

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1,4 +1,4 @@
-//Copyright (c) 2026 Brad Root
+// Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
 import IRC, { ircLineParser } from 'irc-framework';

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -118,6 +118,31 @@ describe('buildBufferBacklog', () => {
     expect(buildBufferBacklog(userId, networkId, 'carol').joined).toBe(true);
   });
 
+  it('server buffer unread counts notable lines only, and includes errors (#470)', () => {
+    const target = `:server:${networkId}`;
+    const putServer = (type: string, opts: { nick?: string; notable?: boolean } = {}) =>
+      insertMessage({
+        networkId,
+        target,
+        time: new Date().toISOString(),
+        type,
+        nick: opts.nick ?? 'server',
+        text: 'x',
+        self: false,
+        notable: opts.notable,
+      });
+    putServer('notice', { nick: 'lurker', notable: false }); // "Connecting…" — not unread
+    putServer('notice', { nick: 'lurker', notable: false }); // "Reconnecting…" — not unread
+    putServer('notice', { nick: 'NickServ' }); // inbound notice → unread
+    putServer('error'); // killed/banned → unread (countNewer would drop this)
+
+    const frame = buildBufferBacklog(userId, networkId, target);
+    // All 4 lines render in the buffer...
+    expect((frame.events as unknown[]).length).toBe(4);
+    // ...but only the inbound notice + the error mark it unread.
+    expect(frame.unread).toBe(2);
+  });
+
   it('counts every unread DM line as a highlight (yellow row treatment, like the system buffer)', () => {
     seed('erin', 'one');
     seed('erin', 'two');

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -32,6 +32,7 @@ import {
   listBufferTargets,
   listSpeakers,
   countNewer,
+  countServerBufferUnread,
   countHighlightsNewer,
   maxIdByBuffer,
   maxIdForBuffer,
@@ -326,7 +327,12 @@ function computeUnreadFor(
     return { lastReadId: lastReadId || 0, unread, highlights: unread, highlightsCapped: false };
   }
   const nid = networkId as number;
-  const unread = countNewer(nid, target, lastReadId);
+  // The server pseudo-buffer applies a notability filter (#470): routine
+  // Lurker-generated connection-status notices don't mark it unread, but errors,
+  // inbound notices, and closed-buffer mirrors do. Channels/DMs count normally.
+  const unread = target.startsWith(':server:')
+    ? countServerBufferUnread(nid, target, lastReadId)
+    : countNewer(nid, target, lastReadId);
   // A DM is inherently a mention of you, so — like the system buffer — every
   // unread line counts as a highlight. This lights the buffer-list row up in
   // the highlight color and shows the ● badge, surfacing unread DMs above

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -37,7 +37,7 @@ import {
   maxIdByBuffer,
   maxIdForBuffer,
   maxMessageId,
-  COUNTABLE_TYPES,
+  typeCountsForUnread,
 } from '../db/messages.js';
 import {
   listReadStateForUser,
@@ -1324,8 +1324,15 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // Countable persisted events change the buffer's unread/highlight counts
     // for this user. Broadcast the recomputed read-state so every tab —
     // including inactive ones — reflects the new badge without the client
-    // having to mirror the server's counting logic.
-    if (decorated.id != null && decorated.target && COUNTABLE_TYPES.has(decorated.type)) {
+    // having to mirror the server's counting logic. The `:server:` buffer also
+    // counts 'error' lines (a disconnect/quit echo, a kill/ban); without matching
+    // that here the badge wouldn't refresh until the NEXT countable event landed
+    // (e.g. a reconnect's "Connecting…" notice) — the delayed-badge bug (#470).
+    if (
+      decorated.id != null &&
+      decorated.target &&
+      typeCountsForUnread(decorated.target, decorated.type)
+    ) {
       const lastReadId = getReadState(eventUserId, decorated.networkId, decorated.target);
       broadcastReadState(eventUserId, decorated.networkId, decorated.target, lastReadId);
     }


### PR DESCRIPTION
Closes #470.

## Audit finding

The `:server:` pseudo-buffer marked itself unread on **every** countable line, so the signal was inverted:

- **Badged on noise** — routine Lurker-generated connection chatter: *Connecting…*, *Reconnecting…*, nick fallback/in-use/reclaimed, MONITOR-limit (all published with `nick:'lurker'`).
- **Silent on signal** — being killed / banned / G-lined / a failed connection are all `type:'error'`, which `countNewer` (message/action/notice) never counted, so they never badged.

(MOTD, welcome/LUSERS/numerics were already excluded — they're `type:'motd'`.)

## Change

A persisted `notable` flag on `messages` (default 1), mirroring the `:system:` buffer's notability model:

- Lurker's own status notices are stamped `notable=0` at publish — they still **render** in the buffer, they just no longer mark it unread.
- `countServerBufferUnread` counts `type ∈ {message, action, notice, error} AND notable=1`, so **errors** and **inbound notices/messages (including closed-buffer NOTICE mirrors)** badge, while routine status chatter doesn't. `computeUnreadFor` routes `:server:` targets through it; channels/DMs are unchanged (they never read the flag).
- `countHighlightsNewer` also filters `notable=1`, so a status notice matching a self-nick rule (*"Reclaimed nick &lt;you&gt;."*) can't highlight the buffer it isn't even counting.
- `countNewer`/`countServerBufferUnread` share one `countUnreadRows` core (LIMIT-guard invariant + countable-type set can't drift).

## Migration / compatibility

- Adds the column; a one-time gated backfill (`demoteLegacyServerStatusNotices`) demotes historical `nick:'lurker'` `:server:` notices so the behavior applies to existing history.
- The importer defaults a missing `notable` to 1, so a pre-#470 archive still restores (the column is NOT NULL and the raw insert binds NULL for a missing key).

## Tests

`countServerBufferUnread` (errors/inbound/mirror count; status notices + ignored senders don't; read-pointer honored; channel count still differs), the backfill demotion + `:server:` scoping, a wsHub backlog-frame wiring test, and the old-archive import defaulting `mirrored=0`/`notable=1`.

## Notes for review
- All 7 `nick:'lurker'` status notices are `notable:false`. The two borderline ones — **nick-fallback-used** and **nick-in-use** — are identity events; easy to promote back to notable if we decide they should badge.
- The backfill's `nick='lurker'` heuristic is historical-rows-only; going forward notability is stamped explicitly at publish, never inferred from nick.

Reviewed with `/code-review high` before opening — the import-restore break (HIGH), the highlight-path `notable` gap, and the count-dedup were all found and fixed in-branch. Full suite green (1974).

🤖 Generated with [Claude Code](https://claude.com/claude-code)