### PR TITLE
Fix stuck-online peers on networks without MONITOR

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -31,6 +31,7 @@ import { createIdentdServer, unregisterIdent } from './identd.js';
 import { getRecent } from './systemLog.js';
 import { createUser } from '../db/users.js';
 import { createNetwork } from '../db/networks.js';
+import { getPeerPresence } from '../db/peerPresence.js';
 import { setUserSetting, deleteUserSetting } from '../db/settings.js';
 
 // The bare IrcConnections built below carry user_id: 1, and their join/part
@@ -1177,6 +1178,105 @@ describe('away/back presence logging (#310)', () => {
     conn.markPeerEvent('stranger', 'away', 'nope');
     const texts = getRecent(1).map((l) => l.text);
     expect(texts).not.toContain('Presence: stranger away (nope)');
+  });
+});
+
+// The "stuck online" fix for networks without MONITOR: our own disconnect
+// forces every tracked peer offline, and WHO-on-join re-lights the peers we can
+// still observe on reconnect (existing channel occupants arrive via NAMES, not
+// JOIN, so the 'join' handler never fires for them).
+describe('disconnect-offline sweep + WHO re-light (no-MONITOR presence)', () => {
+  function makeConn(name: string): IrcConnection {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'nick',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+    })!;
+    return new IrcConnection({ network, onEvent: () => {} });
+  }
+
+  it('markAllPeersOffline forces every tracked peer (DM + friend) offline', () => {
+    const conn = makeConn('disco');
+    conn.trackFriend('pal', 1);
+    conn.trackDmPeer('dmpal');
+    conn.markPeerEvent('pal', 'online');
+    conn.markPeerEvent('dmpal', 'away', 'brb');
+    conn.markAllPeersOffline();
+    expect(getPeerPresence(conn.network.id, 'pal')?.state).toBe('offline');
+    expect(getPeerPresence(conn.network.id, 'dmpal')?.state).toBe('offline');
+  });
+
+  it('never writes a row for an untracked nick during the sweep', () => {
+    const conn = makeConn('disco2');
+    conn.markPeerEvent('stranger', 'online'); // untracked → gated out, no row
+    conn.markAllPeersOffline();
+    expect(getPeerPresence(conn.network.id, 'stranger')).toBeNull();
+  });
+
+  // dispose() sets disposed=true before the socket tears down; on a deletion
+  // dispose the network row (+ its peer_presence_state rows) may already be gone
+  // when the async socket-close fires, so a write here would hit a FK violation.
+  // The guard makes the sweep a no-op in that window.
+  it('is a no-op when the connection is disposed (avoids a post-delete FK write)', () => {
+    const conn = makeConn('disco-disposed');
+    conn.trackFriend('pal', 1);
+    conn.markPeerEvent('pal', 'online');
+    conn.disposed = true;
+    conn.markAllPeersOffline();
+    expect(getPeerPresence(conn.network.id, 'pal')?.state).toBe('online'); // untouched
+  });
+
+  // The sweep is wired to 'socket close' (not 'close') because irc-framework
+  // auto-reconnects a blip internally and only emits 'socket close' — 'close' is
+  // reserved for a terminal give-up/dispose, so it would miss the common case.
+  it("fires the sweep from the 'socket close' event (the auto-reconnect path)", () => {
+    const conn = makeConn('sockclose');
+    conn.publish = vi.fn<typeof conn.publish>(); // skip the disconnected-state + error publishes
+    conn.trackFriend('pal', 1);
+    conn.markPeerEvent('pal', 'online');
+    conn.client.emit('socket close', {});
+    expect(getPeerPresence(conn.network.id, 'pal')?.state).toBe('offline');
+  });
+
+  it('WHO-on-join promotes a still-present peer back to online after the sweep', () => {
+    const conn = makeConn('relight');
+    conn.publish = vi.fn<typeof conn.publish>(); // assert on presence, not history
+    conn.client.user.nick = 'me';
+    conn.trackFriend('chanpal', 9);
+    // Peer shares a channel with us…
+    conn.client.emit('join', { channel: '#room', nick: 'chanpal', ident: 'u', hostname: 'h' });
+    // …then our socket drops (peer quit unseen or not — doesn't matter):
+    conn.markAllPeersOffline();
+    expect(getPeerPresence(conn.network.id, 'chanpal')?.state).toBe('offline');
+    // Reconnect: existing occupant arrives via WHO, not JOIN, and isn't away.
+    conn.client.emit('wholist', {
+      target: '#room',
+      users: [{ nick: 'chanpal', away: false }],
+    });
+    expect(getPeerPresence(conn.network.id, 'chanpal')?.state).toBe('online');
+  });
+
+  it('WHO-on-join records an away peer as away and clears a stale away to back', () => {
+    const conn = makeConn('relight-away');
+    conn.publish = vi.fn<typeof conn.publish>();
+    conn.client.user.nick = 'me';
+    conn.trackFriend('awaychan', 10);
+    conn.client.emit('join', { channel: '#room', nick: 'awaychan' });
+    conn.client.emit('wholist', { target: '#room', users: [{ nick: 'awaychan', away: true }] });
+    expect(getPeerPresence(conn.network.id, 'awaychan')?.state).toBe('away');
+    // A later WHO with the away flag cleared must move away → back (renders online).
+    conn.client.emit('wholist', { target: '#room', users: [{ nick: 'awaychan', away: false }] });
+    expect(getPeerPresence(conn.network.id, 'awaychan')?.state).toBe('back');
   });
 });
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -891,6 +891,13 @@ export class IrcConnection {
       this.useMonitor = false;
       this.monitorLimit = 0;
       this.pendingMonitorSeed = false;
+      // Safety-net presence sweep. The primary one runs in 'socket close',
+      // which fires on every disconnect (including auto-reconnect blips), so it
+      // has almost always swept already by the time this terminal 'close'
+      // fires. This covers any clean-close path that somehow skipped it;
+      // markAllPeersOffline is idempotent and disposed-guarded, so the double
+      // call is a no-op.
+      this.markAllPeersOffline();
       this.setState('disconnected');
     });
 
@@ -1032,6 +1039,21 @@ export class IrcConnection {
     // log line.
     c.on('socket close', (err: Record<string, unknown>) => {
       this.setState('disconnected');
+      // Our socket to this network just dropped — from our vantage point every
+      // peer we track here is now unreachable, so mark them all offline. This is
+      // the fix for the "stuck online" gap on networks without MONITOR: if a
+      // peer quit while we were disconnected we never saw their QUIT, but our own
+      // disconnect is a discontinuity we DO observe, so we stop asserting a stale
+      // 'online'. 'socket close' (not 'close') is the hook: irc-framework
+      // auto-reconnects a blip internally and emits only 'socket close' +
+      // 'reconnecting' — it reserves 'close' for a terminal give-up/dispose
+      // (connection.js:111 always fires 'socket close'; :141 fires 'close' only
+      // when it won't retry), so sweeping in 'close' alone would miss the common
+      // reconnect. On reconnect the peers we can still observe are re-lit
+      // (MONITOR re-seed + WHO-on-join); the rest stay honestly offline. No
+      // came-online suppression — a reconnect re-firing "came online" for peers
+      // still around is the honest signal, and toasts are already rate-limited.
+      this.markAllPeersOffline();
       // Release this socket's identd mapping (a reconnect re-registers via the
       // 'raw socket connected' handler above and gets a fresh handle).
       unregisterIdent(this.identdId);
@@ -1941,13 +1963,23 @@ export class IrcConnection {
         const m = ch.members.get((u.nick as string).toLowerCase());
         if (!m) continue;
         const next = !!u.away;
-        // Bridge the WHO away flag to the DM/friend presence rail for tracked
-        // peers. away-notify keeps presence live, but it doesn't fire on join —
-        // so without this a friend who's away when we (re)connect and share a
-        // channel would read as online. The transition gates in markPeerEvent
-        // make this idempotent: 'away' sets away; 'back' only clears a stale
-        // away and otherwise no-ops, so it never disturbs online/offline.
-        this.markPeerEvent(u.nick as string, next ? 'away' : 'back');
+        // Bridge the WHO snapshot to the DM/friend presence rail for tracked
+        // peers. away-notify doesn't fire on join, so this is where a peer we
+        // share a channel with gets (re-)established — critically on reconnect,
+        // where markAllPeersOffline has just forced every tracked peer offline
+        // and a friend still sitting in a channel we rejoin must be promoted
+        // back to online here (the server sends existing occupants via NAMES,
+        // not JOIN, so the 'join' handler never fires for them). 'away' sets
+        // away; for a present, non-away member 'online' promotes an
+        // offline/unknown row while 'back' clears a stale away. Each call is
+        // gated to its valid prior state, so at most one writes and an
+        // already-online peer is left untouched.
+        if (next) {
+          this.markPeerEvent(u.nick as string, 'away');
+        } else {
+          this.markPeerEvent(u.nick as string, 'online');
+          this.markPeerEvent(u.nick as string, 'back');
+        }
         if (m.away !== next) {
           m.away = next;
           changed = true;
@@ -2248,6 +2280,26 @@ export class IrcConnection {
     // push when no client is visible — mirrors the client-side toast gate.
     const cameOnline = state === 'online' && prevState === 'offline';
     this.publishPeerPresence(canonical, next, cameOnline);
+  }
+
+  // Mark every tracked peer on this network offline — called when our own
+  // socket drops (see the 'socket close' handler). trackedPeers is still
+  // populated at close time (it's only cleared/re-hydrated on the next
+  // 'registered'), so we can walk it directly. markPeerEvent's per-state gate
+  // keeps this a no-op for peers already offline, so a flap doesn't churn
+  // timestamps.
+  markAllPeersOffline(): void {
+    // Skip during dispose. dispose() sets disposed=true right before tearing the
+    // socket down, and on a *deletion* dispose the network row — and its
+    // peer_presence_state rows, via ON DELETE CASCADE — can already be gone by
+    // the time the async socket close fires. A writePeerState here would then
+    // hit a foreign-key violation and throw inside the close listener. This is
+    // the same reason publish()/publishEphemeral() gate on disposed; see
+    // ircManager.disposeNetwork/disposeUser (and the note at ircManager.ts:679).
+    if (this.disposed) return;
+    for (const nick of this.trackedPeers.keys()) {
+      this.markPeerEvent(nick, 'offline');
+    }
   }
 
   // Bulk-seed the MONITOR watch list from the tracked DM peers set. Called


### PR DESCRIPTION
## Problem

Peer/friend presence on networks without MONITOR (e.g. DALnet/Bahamut, which also lacks `away-notify`) relies entirely on shared-channel events (`quit`/`nick`/WHO-on-join). That leaves a hole: a peer who goes offline while we can't see them — they parted our last common channel, or **quit while our own socket was down** — stays pinned `online` forever. There's no MONITOR push to correct it, and polling was explicitly ruled out.

Concretely: you and a friend both drop, you reconnect, they don't. You never saw their QUIT (it happened during your downtime), and they never rejoin a shared channel or DM you, so they're stuck showing online.

## Fix

Our *own* disconnect is a visibility discontinuity we **can** observe, even when the peer's isn't. So:

- **Mark every tracked peer offline when our socket drops.** Hooked to `'socket close'`, which fires on every disconnect — including irc-framework's internal auto-reconnect blips. `'close'` only fires on a terminal give-up/dispose (`connection.js:111` always emits `socket close`; `:141` emits `close` only when it won't retry), so a sweep there alone would miss the common reconnect. Left an idempotent safety-net call in `'close'`.
- **`disposed`-guard the sweep.** On a *deletion* dispose the network row and its `peer_presence_state` rows can already be cascade-deleted by the time the async close fires; an unguarded `writePeerState` would then hit a foreign-key violation and throw in the socket-close listener. Mirrors the guard `publish`/`publishEphemeral` already rely on (see `ircManager.ts:679`).
- **WHO-on-join now promotes a present, non-away member to `online`** (was `back`, which only fires from `away` and so could never re-light a peer the sweep just forced offline). Existing channel occupants arrive via NAMES, not JOIN, so the `join` handler never covers them.

On reconnect, peers we can still observe are re-lit (MONITOR re-seed + WHO-on-join); the rest stay honestly offline. No polling. No came-online suppression window — a reconnect re-firing "came online" for peers still around is the honest signal, and toasts are already rate-limited.

## Tests

6 new cases in `ircConnection.test.ts`: the sweep forces DM + friend peers offline, skips untracked nicks, is a no-op when disposed (the FK-write guard), fires from `'socket close'`, and WHO-on-join re-lights a still-present peer / records away / clears stale-away to back. Full suite green (1981).

🤖 Generated with [Claude Code](https://claude.com/claude-code)