### PR TITLE
Small UI/UX tweaks: topic bar, typing indicator, NAMES noise

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -73,9 +73,9 @@ describe('computeFallbackNick', () => {
 
 describe('isServerBufferDeniedNumeric (#342)', () => {
   it('denies numerics another handler already renders or that would flood', () => {
-    // MOTD block, /LIST (cached off-wire), auto-WHO replies, MONITOR presence,
-    // and nick-collision errors are surfaced elsewhere — the raw handler skips
-    // them so they aren't duplicated in the server buffer.
+    // MOTD block, /LIST (cached off-wire), auto-WHO replies, NAMES (nicklist),
+    // MONITOR presence, and nick-collision errors are surfaced elsewhere — the
+    // raw handler skips them so they aren't duplicated in the server buffer.
     for (const n of [
       '372',
       '375',
@@ -87,6 +87,8 @@ describe('isServerBufferDeniedNumeric (#342)', () => {
       '352',
       '315',
       '354', // WHO
+      '353',
+      '366', // NAMES
       '730',
       '731',
       '732',
@@ -99,8 +101,8 @@ describe('isServerBufferDeniedNumeric (#342)', () => {
   });
 
   it('shows everything else by default — there is no curated allowlist', () => {
-    // The whole point of #342: greeting, whois, oper, time, names, topic and
-    // even ISUPPORT all fall through to the raw renderer instead of vanishing.
+    // The whole point of #342: greeting, whois, oper, time, topic and even
+    // ISUPPORT all fall through to the raw renderer instead of vanishing.
     for (const n of [
       '001',
       '002',
@@ -113,7 +115,6 @@ describe('isServerBufferDeniedNumeric (#342)', () => {
       '319',
       '381',
       '391',
-      '353',
       '332',
       '364',
     ]) {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -4219,6 +4219,11 @@ const SERVER_BUFFER_DENIED_NUMERICS = new Set<string>([
   '352',
   '315',
   '354',
+  // RPL_NAMREPLY/RPL_ENDOFNAMES — the server sends NAMES on every join; the
+  // nicklist is the pretty surface (rebuilt from the parsed 'userlist' event),
+  // so the raw per-batch lines are a redundant flood in the server buffer.
+  '353',
+  '366',
   // RPL_MON* — MONITOR presence, surfaced by the presence rail, not the buffer.
   '730',
   '731',

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -534,10 +534,11 @@ function onToggleColorPicker() {
 .seg.split.bad {
   color: var(--bad);
 }
-/* Keyboard glyph standing in for the old "Typing:" label — nudge it off the
-   first nick (a bare inline space sits too tight against the icon). */
+/* Keyboard glyph standing in for the old "Typing:" label — one character of
+   space off the first nick, matching the 1ch gap/pipe spacing used across the
+   bar. */
 .seg.typing i {
-  margin-right: 0.5ch;
+  margin-right: 1ch;
 }
 .seg.jump-unread,
 .seg.return-present {

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -534,11 +534,13 @@ function onToggleColorPicker() {
 .seg.split.bad {
   color: var(--bad);
 }
-/* Keyboard glyph standing in for the old "Typing:" label — one character of
-   space off the first nick, matching the 1ch gap/pipe spacing used across the
-   bar. */
-.seg.typing i {
-  margin-right: 1ch;
+/* Keyboard glyph standing in for the old "Typing:" label. The 1ch space off the
+   first nick lives on the nick span, NOT the icon: `ch` is measured against the
+   element's own font, and the FontAwesome `<i>` has no '0' glyph, so its `ch`
+   falls back to ~0.5em — half the intended gap. The nick span inherits the mono
+   text font, where 1ch is a true character, matching the bar's gap/pipe spacing. */
+.seg.typing > span:first-of-type {
+  margin-left: 1ch;
 }
 .seg.jump-unread,
 .seg.return-present {

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -852,15 +852,16 @@ useChatBootstrap({ onJump: onJumpToMessage });
 }
 
 /* Two-group layout for the topic bar: .topic-meta (name + topic text, spaced
-   by the 1ch gap) sits left, .topic-actions (buffer/network/channel buttons)
-   sits right.
+   by the 2ch gap — wider than the 1ch bar convention to give the name and
+   topic breathing room now that the │ divider is gone) sits left,
+   .topic-actions (buffer/network/channel buttons) sits right.
    .topic uses justify-content:space-between to split them. .topic-meta
    shrinks first via min-width:0 + topic-text ellipsis, so the action
    cluster stays anchored to the right edge. */
 .topic-meta {
   display: flex;
   align-items: baseline;
-  gap: 1ch;
+  gap: 2ch;
   /* flex:1 so the meta absorbs the free space and keeps the action cluster
      anchored to the right edge; min-width:0 lets the topic text ellipsis. */
   flex: 1;

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -90,7 +90,6 @@
       <div class="topic-meta">
         <span v-if="isVirtual || active" class="buffer">{{ bufferLabel }}</span>
         <template v-if="active && topic">
-          <span class="sep">│</span>
           <button
             type="button"
             class="topic-text"
@@ -812,9 +811,6 @@ useChatBootstrap({ onJump: onJumpToMessage });
 .topic .buffer {
   color: var(--accent);
 }
-.topic .sep {
-  color: var(--border);
-}
 .topic .topic-text {
   color: var(--fg-muted);
   text-overflow: ellipsis;
@@ -855,8 +851,9 @@ useChatBootstrap({ onJump: onJumpToMessage });
   grid-area: input;
 }
 
-/* Two-group layout for the topic bar: .topic-meta (name + │ + topic text)
-   sits left, .topic-actions (buffer/network/channel buttons) sits right.
+/* Two-group layout for the topic bar: .topic-meta (name + topic text, spaced
+   by the 1ch gap) sits left, .topic-actions (buffer/network/channel buttons)
+   sits right.
    .topic uses justify-content:space-between to split them. .topic-meta
    shrinks first via min-width:0 + topic-text ellipsis, so the action
    cluster stays anchored to the right edge. */


### PR DESCRIPTION
A catch-all of small, independent tweaks.

## Changes

- **Topic bar: drop the `│` name/topic separator** (`DesktopChat.vue`) and widen the name↔topic gap to `2ch` so they read cleanly without a divider. Drops the now-unused `.topic .sep` rule.
- **Typing indicator spacing** (`StatusBar.vue`): put the `1ch` gap between the keyboard icon and the nick(s) on the nick span rather than the icon. The app font is monospace, so `1ch` on a normal element is a full character — but the FontAwesome `<i>` has no `0` glyph, so `ch` on *it* falls back to ~`0.5em` (half). Moving the margin to the mono-font nick span makes it a true character, matching the bar's `1ch` gap/pipe spacing.
- **Suppress NAMES from the server buffer on join** (`ircConnection.ts`): the server sends `RPL_NAMREPLY`/`RPL_ENDOFNAMES` (353/366) on every channel join, which the default-show `raw` handler was echoing as a per-batch flood. The nicklist already renders the parsed `userlist` event, so the raw lines are redundant. Denied in `SERVER_BUFFER_DENIED_NUMERICS`, mirroring the existing WHO (352/315/354) and /LIST (321/322/323) precedent.

Style/noise only; the NAMES change is a denylist addition with no logic edits. `npm run check` clean, full suite green (1981), test updated for the 353/366 denylist entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)