### PR TITLE
Prototype: Windowed buffers (mIRC-style) behind look.layout.windowed

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -697,6 +697,18 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'desktop layout. The members toggle in each channel’s topic bar ' +
       'overrides this per channel and is remembered. Has no effect on mobile.',
   },
+  {
+    key: 'look.layout.windowed',
+    label: 'Windowed buffers (desktop, experimental)',
+    category: 'appearance',
+    group: 'layout',
+    type: 'bool',
+    default: false,
+    description:
+      'Show buffers as mIRC-style windows you can move, resize, and minimize ' +
+      'inside the area right of the channel list, instead of one buffer filling ' +
+      'it. Experimental. Has no effect on mobile.',
+  },
 
   // ─── Join/part consolidation (IRCCloud-style summary line) ────────────
   {

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -67,12 +67,16 @@
      inventing bare numbers in components.
        base    in-flow lift (sticky headers, bg layers)
        raised  lifts above sibling content within a component
+       window  floating buffer windows on the mIRC-style canvas. Each frame
+               adds its stacking order on top of this base, so the whole
+               window layer stays below modals no matter how many are open.
        modal   modal/overlay shells (AppModal, QuickSwitcher)
        toast   toast stack — sits above modals so notifications stay visible
        menu    context menus
        popover input autocomplete (NickPicker) — top of the stack */
   --z-base: 1;
   --z-raised: 5;
+  --z-window: 10;
   --z-modal: 100;
   --z-toast: 200;
   --z-menu: 300;

--- a/vue_client/src/components/BufferPane.vue
+++ b/vue_client/src/components/BufferPane.vue
@@ -1,0 +1,554 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  One buffer, whole: topic bar, message list, member list, status bar, input.
+
+  These five used to be direct grid children of DesktopChat's frame, each
+  independently reading networks.activeKey to decide what to render. Bundling
+  them here — and provide()ing the buffer key over the subtree — makes "a buffer
+  on screen" a thing the app can have more than one of. DesktopChat renders a
+  single maximized pane; the windowed canvas renders N.
+
+  App-scoped concerns stay in the shell: modals, the sidebar, the WS lifecycle.
+  The pane reaches global stores directly for the modals it summons (profile,
+  note, network editor, channel list), and emits for the two the shell owns
+  local open-state for (search, highlights) plus the topic modal.
+-->
+
+<template>
+  <div
+    class="buffer-pane"
+    :class="{ 'members-collapsed': !showMembers, 'system-pane': isSystemBuffer }"
+  >
+    <!-- Topic bar: always rendered so the header is present even before any
+         buffer is selected. The nav cluster is anchored at the far left, left of
+         the buffer title; the meta (name + topic) and per-buffer actions render
+         conditionally beside it. -->
+    <header class="topic">
+      <!-- Back/forward is app-scoped navigation over the single active buffer,
+           so it only belongs on a pane that *is* the app's one view. A windowed
+           pane is one of several and has no history of its own. -->
+      <div v-if="showNav" class="topic-nav">
+        <button
+          type="button"
+          class="link nav-btn"
+          title="Back"
+          aria-label="Back"
+          :disabled="!navHistory.canBack"
+          @click="navHistory.back()"
+        >
+          <i class="fa-solid fa-angle-left"></i>
+        </button>
+        <button
+          type="button"
+          class="link nav-btn"
+          title="Forward"
+          aria-label="Forward"
+          :disabled="!navHistory.canForward"
+          @click="navHistory.forward()"
+        >
+          <i class="fa-solid fa-angle-right"></i>
+        </button>
+      </div>
+      <div class="topic-meta">
+        <span v-if="isVirtual || active" class="buffer">{{ bufferLabel }}</span>
+        <template v-if="active && topic">
+          <button
+            type="button"
+            class="topic-text"
+            title="View full topic"
+            @click="emit('show-topic')"
+          >
+            <LinkedText :text="topic" />
+          </button>
+        </template>
+      </div>
+      <div class="topic-actions">
+        <template v-if="isVirtual">
+          <template v-if="isFriendsBuffer">
+            <button
+              type="button"
+              class="link"
+              title="Add friend"
+              aria-label="Add friend"
+              @click="friends.openEditorNew()"
+            >
+              <i class="fa-solid fa-person-circle-plus"></i>
+            </button>
+            <span
+              class="member-count"
+              :title="`${friendCount} ${friendCount === 1 ? 'friend' : 'friends'}`"
+            >
+              <i class="fa-solid fa-users"></i> {{ friendCount }}
+            </span>
+          </template>
+        </template>
+        <template v-else-if="active">
+          <!-- Search & highlights scoped to this buffer (channels/DMs only) —
+               parity with the mobile topic bar. The server buffer has no
+               per-buffer scope, so it's excluded. -->
+          <template v-if="!isServerBuffer">
+            <button
+              type="button"
+              class="link"
+              title="Search this buffer"
+              aria-label="Search this buffer"
+              @click="emit('open-search', true)"
+            >
+              <i class="fa-solid fa-magnifying-glass"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              title="Highlights in this buffer"
+              aria-label="Highlights in this buffer"
+              @click="emit('open-highlights', true)"
+            >
+              <i class="fa-regular fa-bell"></i>
+            </button>
+          </template>
+          <template v-if="isServerBuffer">
+            <button
+              type="button"
+              class="link"
+              title="Join channel"
+              aria-label="Join channel"
+              :disabled="serverConnectionState !== 'connected'"
+              @click="active && joinChannelModal.open(active.networkId)"
+            >
+              <i class="fa-solid fa-plus"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              title="Channel list"
+              aria-label="Channel list"
+              @click="active && channelListModal.open(active.networkId)"
+            >
+              <i class="fa-solid fa-hashtag"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              :title="serverConnectActionLabel"
+              :aria-label="serverConnectActionLabel"
+              @click="toggleServerConnection"
+            >
+              <i :class="serverConnectActionIcon"></i>
+            </button>
+            <button class="link" title="Edit network" @click="editActiveNetwork">
+              <i class="fa-solid fa-gear"></i>
+            </button>
+          </template>
+          <template v-else-if="isDmHeader">
+            <button
+              type="button"
+              class="link"
+              title="View profile"
+              aria-label="View profile"
+              @click="openDmProfile"
+            >
+              <i class="fa-solid fa-id-card"></i>
+            </button>
+            <button
+              type="button"
+              class="link"
+              :title="dmNoteLabel"
+              :aria-label="dmNoteLabel"
+              @click="openDmNote"
+            >
+              <i class="fa-solid fa-note-sticky"></i>
+            </button>
+          </template>
+          <template v-else-if="isChannel">
+            <button
+              class="link"
+              :title="showMembers ? 'Hide members' : 'Show members'"
+              :aria-label="showMembers ? 'Hide members' : 'Show members'"
+              @click="toggleMembers"
+            >
+              <i class="fa-solid fa-users"></i>
+            </button>
+            <span
+              v-if="memberCount != null"
+              class="member-count"
+              :title="`${memberCount} ${memberCount === 1 ? 'user' : 'users'} in channel`"
+              >{{ memberCount }}</span
+            >
+          </template>
+        </template>
+      </div>
+    </header>
+    <div class="topic-divider"></div>
+
+    <FriendsOverview
+      v-if="renderMode === 'overview'"
+      @view-activity="(q: string) => emit('view-activity', q)"
+    />
+    <MessageList v-else ref="messageListRef" :pending-scroll-id="pendingScrollId" />
+    <MemberList v-if="showMembers && hasNicklist" />
+    <StatusBar />
+    <MessageInput v-if="hasInput" ref="messageInputRef" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive, ref, toRef } from 'vue';
+import type { Network } from '../stores/networks.js';
+import { useNetworksStore } from '../stores/networks.js';
+import type { Buffer } from '../stores/buffers.js';
+import { provideBufferKey, useActiveBuffer } from '../composables/useActiveBuffer.js';
+import { registerPane, unregisterPane, type PaneApi } from '../composables/usePaneRegistry.js';
+import { useSettingsStore } from '../stores/settings.js';
+import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
+import { useNickNotesStore } from '../stores/nickNotes.js';
+import { useFriendsStore } from '../stores/friends.js';
+import { useWhoisStore } from '../stores/whois.js';
+import { useNavHistoryStore } from '../stores/navHistory.js';
+import { useChannelListModal } from '../composables/useChannelListModal.js';
+import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
+import { useNetworkEditor } from '../composables/useNetworkEditor.js';
+import MessageList from './MessageList.vue';
+import FriendsOverview from './FriendsOverview.vue';
+import MessageInput from './MessageInput.vue';
+import MemberList from './MemberList.vue';
+import StatusBar from './StatusBar.vue';
+import LinkedText from './LinkedText.vue';
+
+const props = withDefaults(
+  defineProps<{
+    // The buffer this pane renders. Null renders the empty header + "no
+    // messages" body, which is what the shell shows before anything is active.
+    bufferKey: string | null;
+    // Jump-to-message target, forwarded to this pane's message list. The shell
+    // only hands it to the pane that owns the jump's buffer.
+    pendingScrollId?: number | null;
+    // Back/forward controls. On in the single-pane shell, off in a window.
+    showNav?: boolean;
+  }>(),
+  { pendingScrollId: null, showNav: true },
+);
+
+const emit = defineEmits<{
+  (e: 'open-search', scoped: boolean): void;
+  (e: 'open-highlights', scoped: boolean): void;
+  (e: 'show-topic'): void;
+  (e: 'view-activity', query: string): void;
+}>();
+
+const bufferKey = toRef(props, 'bufferKey');
+// Everything below this component resolves "my buffer" from here rather than
+// from networks.activeKey.
+provideBufferKey(bufferKey);
+
+const networks = useNetworksStore();
+const settings = useSettingsStore();
+const nicklistCollapse = useNicklistCollapseStore();
+const nickNotes = useNickNotesStore();
+const friends = useFriendsStore();
+const whois = useWhoisStore();
+const navHistory = useNavHistoryStore();
+const channelListModal = reactive(useChannelListModal());
+const joinChannelModal = reactive(useJoinChannelModal());
+const networkEditor = reactive(useNetworkEditor());
+
+// Explicit key, not the injected one: inject() resolves against the *parent's*
+// provides, so asking for our own would hand back the global activeKey.
+const {
+  active,
+  activeBuf,
+  topic,
+  isServerBuffer,
+  isChannel,
+  bufferLabel,
+  isSystemBuffer,
+  isVirtual,
+  isFriendsBuffer,
+  renderMode,
+  hasInput,
+  hasNicklist,
+} = useActiveBuffer(bufferKey);
+
+const friendCount = computed(() => friends.contacts.length);
+
+const messageInputRef = ref<{ focus: () => void } | null>(null);
+const messageListRef = ref<{ scrollByPage: (dir: number) => void } | null>(null);
+
+const api: PaneApi = {
+  focusInput: () => messageInputRef.value?.focus(),
+  scrollByPage: (dir: number) => messageListRef.value?.scrollByPage(dir),
+};
+onMounted(() => registerPane(bufferKey.value, api));
+onBeforeUnmount(() => unregisterPane(bufferKey.value, api));
+
+// True when this buffer is a DM (not a channel, not the network's server
+// buffer). Drives the clickable DM header that opens the user profile modal —
+// channel headers stay non-interactive.
+const isDmHeader = computed(() => {
+  if (!active.value) return false;
+  if (isChannel.value || isServerBuffer.value) return false;
+  return true;
+});
+function openDmProfile() {
+  if (!active.value) return;
+  whois.openViewer(active.value.networkId, active.value.target);
+}
+// DM note button — mirrors the old context-menu entry, surfaced inline so the
+// per-peer note is one click from the conversation. Label flips once a note
+// exists so the button doubles as a "has a note" tell.
+const dmNoteLabel = computed(() =>
+  active.value && nickNotes.hasNote(active.value.networkId, active.value.target)
+    ? 'Edit note'
+    : 'Add note',
+);
+function openDmNote() {
+  if (!active.value) return;
+  nickNotes.openEditor(active.value.networkId, active.value.target);
+}
+
+// User count for a channel buffer. Sits in the topic bar (next to the
+// members-toggle button) rather than the status bar — the count is a property
+// of the channel, so the channel header is the natural home.
+const memberCount = computed(() => {
+  if (!isChannel.value) return null;
+  return (activeBuf.value as Buffer | null)?.members?.length ?? null;
+});
+
+// Per-channel nicklist visibility. A channel the user has explicitly toggled
+// carries an override (true = collapsed); otherwise the global
+// look.layout.show_member_list default applies. DMs and server buffers have no
+// member list at all, so the toggle and panel are hidden for them entirely.
+const showMembers = computed(() => {
+  if (!isChannel.value || !active.value) return false;
+  const { networkId, target } = active.value;
+  const override = nicklistCollapse.override(networkId, target);
+  if (override !== undefined) return !override;
+  return settings.effective('look.layout.show_member_list');
+});
+
+function toggleMembers() {
+  if (!isChannel.value || !active.value) return;
+  const { networkId, target } = active.value;
+  // Pass the current visibility through as the new collapsed flag — it flips.
+  nicklistCollapse.setCollapsed(networkId, target, !!showMembers.value);
+}
+
+function editActiveNetwork() {
+  const net = active.value?.network as Network | undefined;
+  if (net) networkEditor.open(net);
+}
+
+// State-aware connect/disconnect for the server buffer header. We label the
+// button "Disconnect" only while we're confidently connected; every other
+// state (idle, connecting, reconnecting, disconnected, unknown) reads as
+// "Reconnect" because the action — fire a fresh connect — is the same in
+// each case, and "Reconnect" is what the user reaches for when something
+// looks stuck.
+const serverConnectionState = computed(() => {
+  if (!active.value || !isServerBuffer.value) return null;
+  return networks.states[active.value.networkId]?.state ?? null;
+});
+const serverConnectActionLabel = computed(() =>
+  serverConnectionState.value === 'connected' ? 'Disconnect' : 'Reconnect',
+);
+const serverConnectActionIcon = computed(() =>
+  serverConnectionState.value === 'connected'
+    ? 'fa-solid fa-plug-circle-xmark'
+    : 'fa-solid fa-plug',
+);
+function toggleServerConnection() {
+  if (!active.value) return;
+  const id = active.value.networkId;
+  // Fire-and-forget — the button's label is driven by networks.states so
+  // success reflects itself. A failed call stays observable via the state
+  // (label doesn't flip), so we just log and let the user retry rather
+  // than wiring a toast through the topic bar for this case.
+  const p =
+    serverConnectionState.value === 'connected' ? networks.disconnect(id) : networks.reconnect(id);
+  p.catch((err) => console.error('[BufferPane] toggle server connection failed', err));
+}
+
+defineExpose<PaneApi>(api);
+</script>
+
+<style scoped>
+/* The pane's own frame: topic and status/input bars span the full width; the
+   message list and nicklist sit between them.
+
+   The member-list column is sized via a custom property so the
+   .members-collapsed modifier can zero it without touching the rest of the
+   grid. */
+.buffer-pane {
+  --members-w: 180px;
+  display: grid;
+  grid-template-columns: 1fr var(--members-w);
+  /* The 1px row owns the topic/messages divider as its own grid track,
+     outside the scroll container. Putting the line inside .message-list
+     (border-top, inset box-shadow) lets row backgrounds and hover states
+     paint over it as content scrolls past — the line appears to be eaten
+     by the scrolling rows. A dedicated row sits between the two children
+     and nothing can paint on top of it. */
+  grid-template-rows: auto auto 1fr auto auto;
+  grid-template-areas:
+    'topic    topic'
+    'divider  divider'
+    'messages members'
+    'status   status'
+    'input    input';
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+/* Members column fully collapses — no rail. The reopen toggle lives in the
+   topic bar on the right, so there's nothing to leave behind. */
+.buffer-pane.members-collapsed {
+  --members-w: 0px;
+}
+/* System console has no member list — collapse the rail so the log pane
+   spans the full content width instead of leaving an empty column. */
+.buffer-pane.system-pane {
+  --members-w: 0px;
+}
+/* The status bar carries the separator border above the input, but it's hidden
+   in the system buffer (no network state to show). Give the input its own top
+   border there so it stays visually divided from the message list. */
+.buffer-pane.system-pane .input {
+  border-top: 1px solid var(--border);
+}
+/* min-height/min-width 0 lets flex/scrolling children stay inside their row. */
+.buffer-pane > * {
+  min-width: 0;
+  min-height: 0;
+}
+
+.link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  padding: 0 var(--space-2);
+  cursor: pointer;
+  font: inherit;
+  text-decoration: none;
+}
+.link:hover {
+  color: var(--fg);
+}
+/* Disabled topic-bar link (e.g. Join channel while the network is disconnected):
+   dimmed and non-interactive, and it must not brighten on hover. */
+.link:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.link:disabled:hover {
+  color: var(--accent);
+}
+
+.topic {
+  grid-area: topic;
+  padding: var(--space-4) var(--space-6);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  white-space: nowrap;
+  overflow: hidden;
+}
+/* Back/forward history controls (#411), anchored at the far left of the bar,
+   left of the buffer title. Same accent icon buttons as the rest of the bar;
+   disabled (dimmed, non-interactive) when there's nowhere to go that way. */
+.topic-nav {
+  display: flex;
+  align-items: baseline;
+  /* Match .topic-actions' gap so the back/forward pair is spaced like every
+     other button pair in the bar, not tighter. */
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+.nav-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.nav-btn:disabled:hover {
+  color: var(--accent);
+}
+.topic-divider {
+  grid-area: divider;
+  background: var(--border);
+  height: 1px;
+}
+.topic .buffer {
+  color: var(--accent);
+}
+.topic .topic-text {
+  color: var(--fg-muted);
+  text-overflow: ellipsis;
+  overflow: hidden;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  min-width: 0;
+}
+.topic .topic-text:hover {
+  color: var(--fg);
+}
+.topic .topic-text:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* These selectors target the root elements of the imported components.
+   Vue 3 scoped CSS attaches the parent's data-v attribute to a child
+   component's root element, so .message-list / .members / .input here
+   match the rendered roots of MessageList / MemberList / MessageInput.
+   .friends-overview is placed explicitly rather than left to grid
+   auto-placement, which happened to land it in `messages` anyway. */
+.message-list,
+.friends-overview {
+  grid-area: messages;
+}
+.members {
+  grid-area: members;
+  border-left: 1px solid var(--border);
+}
+.status-bar {
+  grid-area: status;
+}
+.input {
+  grid-area: input;
+}
+
+/* Two-group layout for the topic bar: .topic-meta (name + topic text, spaced
+   by the 2ch gap — wider than the 1ch bar convention to give the name and
+   topic breathing room now that the │ divider is gone) sits left,
+   .topic-actions (buffer/network/channel buttons) sits right.
+   .topic uses justify-content:space-between to split them. .topic-meta
+   shrinks first via min-width:0 + topic-text ellipsis, so the action
+   cluster stays anchored to the right edge. */
+.topic-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 2ch;
+  /* flex:1 so the meta absorbs the free space and keeps the action cluster
+     anchored to the right edge; min-width:0 lets the topic text ellipsis. */
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+.topic-actions {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+.topic .member-count {
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/vue_client/src/components/BufferPane.vue
+++ b/vue_client/src/components/BufferPane.vue
@@ -196,7 +196,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref, toRef } from 'vue';
+import { computed, onBeforeUnmount, reactive, ref, toRef, watch } from 'vue';
 import type { Network } from '../stores/networks.js';
 import { useNetworksStore } from '../stores/networks.js';
 import type { Buffer } from '../stores/buffers.js';
@@ -281,7 +281,19 @@ const api: PaneApi = {
   focusInput: () => messageInputRef.value?.focus(),
   scrollByPage: (dir: number) => messageListRef.value?.scrollByPage(dir),
 };
-onMounted(() => registerPane(bufferKey.value, api));
+// Registration follows the key, not the mount. The single-pane shell keeps one
+// BufferPane alive across every buffer switch (its key prop changes), and it
+// first mounts while activeKey is still null — so registering once at mount
+// would leave the registry empty forever and quietly break type-ahead focus,
+// PageUp/PageDown, and click-anywhere-to-focus-the-input.
+watch(
+  bufferKey,
+  (key, prev) => {
+    if (prev) unregisterPane(prev, api);
+    registerPane(key, api);
+  },
+  { immediate: true },
+);
 onBeforeUnmount(() => unregisterPane(bufferKey.value, api));
 
 // True when this buffer is a DM (not a channel, not the network's server

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -51,6 +51,7 @@ import {
   prefixClass as modePrefixClass,
 } from '../utils/memberPrefix.js';
 import IgnoreModal from './IgnoreModal.vue';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -60,7 +61,8 @@ const ignores = useIgnoresStore();
 const modalMember = ref<BufferMember | null>(null);
 const listEl = ref<HTMLElement | null>(null);
 
-const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
+const bufferKey = useBufferKey();
+const buffer = computed(() => (bufferKey.value ? buffers.byKey(bufferKey.value) : null));
 const members = computed((): BufferMember[] => buffer.value?.members || []);
 const selfNick = computed(() => {
   const b = buffer.value;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -161,7 +161,8 @@ import { useWhoisStore } from '../stores/whois.js';
 import { useChanlistStore } from '../stores/chanlist.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
-import { requestScrollToBottom } from '../composables/useScrollState.js';
+import { useScrollState } from '../composables/useScrollState.js';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 import { setComposingState } from '../composables/useComposing.js';
 import {
   chunkCountForSay,
@@ -300,13 +301,16 @@ const emojiPickerOpen = ref(false);
 const emojiPickerQuery = ref('');
 const emojiPickerEl = ref<InstanceType<typeof EmojiPicker> | null>(null);
 
-const active = computed(() => networks.activeBuffer);
+const bufferKey = useBufferKey();
+const active = computed(() => networks.bufferFor(bufferKey.value));
+// Sending a line snaps this pane's message list back to the live tail.
+const { requestScrollToBottom } = useScrollState();
 
 // The app-scoped system buffer (issue #355) has no network, so networks
-// .activeBuffer reports null for it. It accepts slash commands, not chat, so it
+// .bufferFor reports null for it. It accepts slash commands, not chat, so it
 // gets a local-only input ref rather than a server-synced per-buffer draft (no
 // network to key a draft row to, and command typing needn't sync cross-device).
-const isSystemBuffer = computed(() => networks.activeKey === SYSTEM_KEY);
+const isSystemBuffer = computed(() => bufferKey.value === SYSTEM_KEY);
 const systemText = ref('');
 
 // Input contents are server-side per-buffer drafts — switching channels swaps

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -293,13 +293,8 @@ import { useRelayBotsStore } from '../stores/relayBots.js';
 import { socketSend } from '../composables/useSocket.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useViewport } from '../composables/useViewport.js';
-import {
-  setStuckToBottom,
-  bumpNewBelow,
-  resetScrollState,
-  setUnreadAnchor,
-  useScrollState,
-} from '../composables/useScrollState.js';
+import { useScrollState } from '../composables/useScrollState.js';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 import type { RenderSegment } from '../utils/nickColor.js';
 import {
   formatTimestamp,
@@ -327,7 +322,7 @@ import type { MemberContext, MemberLike } from '../composables/useMemberActions.
 import { useContextMenu, type ContextMenuItem } from '../composables/useContextMenu.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { addressNick } from '../composables/useComposerOverlay.js';
-import { setViewedBuffer } from '../composables/useViewedBuffer.js';
+import { retainViewedBuffer, releaseViewedBuffer } from '../composables/useViewedBuffer.js';
 
 // Extended BufferMessage fields accessed in the template and script
 // (beyond the core BufferMessage definition which uses [key: string]: unknown).
@@ -444,7 +439,18 @@ const tsFormat = computed(() =>
 
 const scroller = ref<HTMLElement | null>(null);
 const stickToBottom = ref(true);
-const { scrollToBottomToken, scrollToUnreadToken } = useScrollState();
+// Which buffer this list renders: the pane's, or the global active buffer when
+// this list isn't inside a pane. Everything below keys off `bufferKey`, never
+// networks.activeKey directly, so N lists can be alive at once.
+const bufferKey = useBufferKey();
+const {
+  scrollToBottomToken,
+  scrollToUnreadToken,
+  setStuckToBottom,
+  bumpNewBelow,
+  reset: resetScrollState,
+  setUnreadAnchor,
+} = useScrollState();
 
 // Unread-divider visibility tracking. The divider is pinned for the whole
 // visit (dividerAfterId snapshot). The "Jump to unread" button exists to catch
@@ -536,7 +542,7 @@ function setUnreadDividerEl(el: Element | ComponentPublicInstance | null): void 
   else if (!next) setUnreadAnchor(null);
 }
 
-const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
+const buffer = computed(() => (bufferKey.value ? buffers.byKey(bufferKey.value) : null));
 const messages = computed(() => buffer.value?.messages || []);
 
 const selfLower = computed(() => {
@@ -1631,12 +1637,14 @@ watch(
 );
 
 // immediate: true handles the mobile case where MessageList is v-if'd out
-// until the user taps a buffer — by the time we mount, activeKey is already
-// set, so a plain (lazy) watcher would never see it change. The first
+// until the user taps a buffer — by the time we mount, the buffer key is
+// already set, so a plain (lazy) watcher would never see it change. The first
 // nextTick after setup resolves after the initial render, so scroller.value
-// is populated by the time scrollToBottom runs.
+// is populated by the time scrollToBottom runs. Inside a windowed pane the key
+// never changes, so this fires once at mount and the resets are the pane's
+// entry scroll.
 watch(
-  () => networks.activeKey,
+  bufferKey,
   async () => {
     stickToBottom.value = true;
     unreadSeen = false;
@@ -1704,7 +1712,7 @@ watch(scrollToUnreadToken, async () => {
   if (dividerPinnedToTop && buf.networkId != null && buf.hasMoreOlder && !buf.loadingHistory) {
     stickToBottom.value = false;
     setStuckToBottom(false);
-    const wantKey = networks.activeKey;
+    const wantKey = bufferKey.value;
     buffers.loadAround(buf.networkId, buf.target, dividerAfterId);
     // loadAround rolls loadingHistory back to false synchronously if the send
     // failed (offline) — nothing will land to drive the scroll, and there's no
@@ -1725,7 +1733,7 @@ watch(scrollToUnreadToken, async () => {
         stop();
         // Bail if the user switched buffers while the slice was in flight —
         // the scroller now belongs to a different buffer.
-        if (networks.activeKey !== wantKey) return;
+        if (bufferKey.value !== wantKey) return;
         await nextTick();
         scrollDividerIntoView();
       },
@@ -1757,11 +1765,18 @@ function onScrollerResize() {
 // "looking at this buffer" apart from networks.activeKey's looser "last-opened
 // buffer" (see useHighlightNotifier.shouldNotifyInApp). This component mounts
 // only while a buffer's messages are actually rendered, so its lifecycle is
-// the signal: follow activeKey while mounted, clear on unmount (Settings
-// route, mobile list/members screen, system console).
+// the signal: retain our buffer while mounted, release on unmount (Settings
+// route, mobile list/members screen, system console, closed window).
+//
+// Refcounted rather than a single "the viewed buffer" slot, because with
+// windowed panes several message lists are mounted at once and each is looking
+// at a buffer of its own.
 watch(
-  () => networks.activeKey,
-  (key) => setViewedBuffer(key),
+  bufferKey,
+  (key, prev) => {
+    if (prev) releaseViewedBuffer(prev);
+    retainViewedBuffer(key);
+  },
   { immediate: true },
 );
 
@@ -1794,7 +1809,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  setViewedBuffer(null);
+  releaseViewedBuffer(bufferKey.value);
   if (scrollerObserver) {
     scrollerObserver.disconnect();
     scrollerObserver = null;

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -141,11 +141,8 @@ import { useUploadsStore } from '../stores/uploads.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useNickColors } from '../composables/useNickColors.js';
-import {
-  useScrollState,
-  requestScrollToBottom,
-  requestScrollToUnread,
-} from '../composables/useScrollState.js';
+import { useScrollState } from '../composables/useScrollState.js';
+import { useBufferKey } from '../composables/useActiveBuffer.js';
 import { useComposing } from '../composables/useComposing.js';
 import { formatTimestamp } from '../utils/timestamp.js';
 import { isPeerOffline, isPeerAway } from '../utils/peerPresence.js';
@@ -220,10 +217,12 @@ const uploadLabel = computed(() => {
   }
   return '';
 });
-const { newBelow, stuckToBottom, unreadAnchor } = useScrollState();
+const { newBelow, stuckToBottom, unreadAnchor, requestScrollToBottom, requestScrollToUnread } =
+  useScrollState();
 
-const active = computed(() => networks.activeBuffer);
-const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
+const bufferKey = useBufferKey();
+const active = computed(() => networks.bufferFor(bufferKey.value));
+const buffer = computed(() => (bufferKey.value ? buffers.byKey(bufferKey.value) : null));
 const isServerBuffer = computed(() => !!active.value?.target?.startsWith(':server:'));
 const sendable = computed(() => !!active.value && !isServerBuffer.value && !auth.isPaused);
 const showFormatButton = computed(() => settings.effective('input.show_format_button') === true);

--- a/vue_client/src/components/WindowCanvas.vue
+++ b/vue_client/src/components/WindowCanvas.vue
@@ -25,33 +25,43 @@
 -->
 
 <template>
-  <div ref="canvasEl" class="window-canvas">
-    <WindowFrame
-      v-for="win in windows.visible"
-      :key="win.key"
-      :win="win"
-      :label="labelFor(win.key)"
-      :unread="unreadFor(win.key)"
-      :highlighted="highlightedFor(win.key)"
-      :is-focused="win.key === windows.focusedKey"
-      :canvas-width="canvasWidth"
-      :canvas-height="canvasHeight"
-      @close="onClose(win.key)"
-      @minimize="onMinimize(win.key)"
-    >
-      <BufferPane
-        :buffer-key="win.key"
-        :show-nav="false"
-        :pending-scroll-id="win.key === networks.activeKey ? (props.pendingScrollId ?? null) : null"
-        @open-search="(scoped: boolean) => emit('open-search', scoped)"
-        @open-highlights="(scoped: boolean) => emit('open-highlights', scoped)"
-        @show-topic="emit('show-topic')"
-        @view-activity="(q: string) => emit('view-activity', q)"
-      />
-    </WindowFrame>
+  <div class="window-canvas">
+    <!-- The stage is the positioning context and the maximize bounds, so a
+         maximized window fills it without sliding under the taskbar. -->
+    <div ref="stageEl" class="stage">
+      <WindowFrame
+        v-for="win in windows.visible"
+        :key="win.key"
+        :win="win"
+        :label="labelFor(win.key)"
+        :unread="unreadFor(win.key)"
+        :highlighted="highlightedFor(win.key)"
+        :is-focused="win.key === windows.focusedKey"
+        :canvas-width="stageWidth"
+        :canvas-height="stageHeight"
+        @close="onClose(win.key)"
+        @minimize="onMinimize(win.key)"
+      >
+        <BufferPane
+          :buffer-key="win.key"
+          :show-nav="false"
+          :pending-scroll-id="
+            win.key === networks.activeKey ? (props.pendingScrollId ?? null) : null
+          "
+          @open-search="(scoped: boolean) => emit('open-search', scoped)"
+          @open-highlights="(scoped: boolean) => emit('open-highlights', scoped)"
+          @show-topic="emit('show-topic')"
+          @view-activity="(q: string) => emit('view-activity', q)"
+        />
+      </WindowFrame>
 
-    <div v-if="windows.windows.length === 0" class="empty">
-      Pick a buffer from the list to open a window.
+      <div v-if="windows.visible.length === 0" class="empty">
+        {{
+          windows.minimized.length > 0
+            ? 'Every window is minimized.'
+            : 'Pick a buffer from the list to open a window.'
+        }}
+      </div>
     </div>
 
     <!-- Taskbar: minimized windows keep their geometry but drop their pane, so
@@ -97,9 +107,9 @@ const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const friends = useFriendsStore();
 
-const canvasEl = ref<HTMLElement | null>(null);
-const canvasWidth = ref(0);
-const canvasHeight = ref(0);
+const stageEl = ref<HTMLElement | null>(null);
+const stageWidth = ref(0);
+const stageHeight = ref(0);
 
 // Titles and badges come from the buffer, so a minimized window's taskbar entry
 // keeps counting while it's hidden.
@@ -175,20 +185,22 @@ function onRestore(key: string): void {
   windows.restore(key);
 }
 
+// The taskbar appearing shrinks the stage, so this also re-clamps when the last
+// window is minimized — a window pinned to the old bottom edge stays grabbable.
 let observer: ResizeObserver | null = null;
 function measure(): void {
-  const el = canvasEl.value;
+  const el = stageEl.value;
   if (!el) return;
-  canvasWidth.value = el.clientWidth;
-  canvasHeight.value = el.clientHeight;
-  windows.clampTo(canvasWidth.value, canvasHeight.value);
+  stageWidth.value = el.clientWidth;
+  stageHeight.value = el.clientHeight;
+  windows.clampTo(stageWidth.value, stageHeight.value);
 }
 
 onMounted(() => {
   measure();
-  if (typeof ResizeObserver !== 'undefined' && canvasEl.value) {
+  if (typeof ResizeObserver !== 'undefined' && stageEl.value) {
     observer = new ResizeObserver(measure);
-    observer.observe(canvasEl.value);
+    observer.observe(stageEl.value);
   }
 });
 onBeforeUnmount(() => {
@@ -199,13 +211,21 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .window-canvas {
-  position: relative;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
   min-width: 0;
   min-height: 0;
-  /* A hair darker than the window bodies so the frames read as floating on a
-     desktop rather than as panels welded to the shell. */
-  background: var(--bg-alt, var(--bg));
+  overflow: hidden;
+}
+/* Lighter than the window bodies so the frames read as floating on a desktop
+   rather than as panels welded to the shell. */
+.stage {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg-soft);
 }
 
 .empty {
@@ -218,11 +238,7 @@ onBeforeUnmount(() => {
 }
 
 .taskbar {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: calc(var(--z-window) + 1000);
+  flex-shrink: 0;
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);

--- a/vue_client/src/components/WindowCanvas.vue
+++ b/vue_client/src/components/WindowCanvas.vue
@@ -1,0 +1,260 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  The mIRC-style desktop: the whole area right of the sidebar, holding N buffer
+  windows plus a taskbar of the minimized ones.
+
+  This component owns the two-way reconciliation between the windows store and
+  the app's single-active-buffer model:
+
+    sidebar click -> networks.activeKey changes -> open (or un-minimize) a window
+    window focus  -> networks.activeKey follows it
+
+  Focus is the join between the two. Everything else in the app still asks
+  "what's the active buffer" and gets the focused window's, so the buffer list
+  highlight, the scoped search/highlight modals and the keyboard shortcuts all
+  keep working without knowing windows exist.
+
+  Focusing away from a window does NOT mark its buffer as left — it's still on
+  screen and still being read. Closing or minimizing does. That's why the
+  activate() calls here pass retainPrevious and the close/minimize handlers call
+  buffers.leaveBuffer() explicitly.
+-->
+
+<template>
+  <div ref="canvasEl" class="window-canvas">
+    <WindowFrame
+      v-for="win in windows.visible"
+      :key="win.key"
+      :win="win"
+      :label="labelFor(win.key)"
+      :unread="unreadFor(win.key)"
+      :highlighted="highlightedFor(win.key)"
+      :is-focused="win.key === windows.focusedKey"
+      :canvas-width="canvasWidth"
+      :canvas-height="canvasHeight"
+      @close="onClose(win.key)"
+      @minimize="onMinimize(win.key)"
+    >
+      <BufferPane
+        :buffer-key="win.key"
+        :show-nav="false"
+        :pending-scroll-id="win.key === networks.activeKey ? (props.pendingScrollId ?? null) : null"
+        @open-search="(scoped: boolean) => emit('open-search', scoped)"
+        @open-highlights="(scoped: boolean) => emit('open-highlights', scoped)"
+        @show-topic="emit('show-topic')"
+        @view-activity="(q: string) => emit('view-activity', q)"
+      />
+    </WindowFrame>
+
+    <div v-if="windows.windows.length === 0" class="empty">
+      Pick a buffer from the list to open a window.
+    </div>
+
+    <!-- Taskbar: minimized windows keep their geometry but drop their pane, so
+         this is the only way back to them. -->
+    <footer v-if="windows.minimized.length > 0" class="taskbar">
+      <button
+        v-for="win in windows.minimized"
+        :key="win.key"
+        type="button"
+        class="task"
+        :class="{ highlight: highlightedFor(win.key) > 0 }"
+        :title="`Restore ${labelFor(win.key)}`"
+        @click="onRestore(win.key)"
+      >
+        <span class="task-label">{{ labelFor(win.key) }}</span>
+        <span v-if="unreadFor(win.key) > 0" class="task-unread">{{ unreadFor(win.key) }}</span>
+      </button>
+    </footer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useWindowsStore } from '../stores/windows.js';
+import { useNetworksStore } from '../stores/networks.js';
+import { useBuffersStore } from '../stores/buffers.js';
+import { useFriendsStore } from '../stores/friends.js';
+import { FRIENDS_KEY, virtualConfig } from '../lib/virtualBuffers.js';
+import WindowFrame from './WindowFrame.vue';
+import BufferPane from './BufferPane.vue';
+
+const props = defineProps<{ pendingScrollId?: number | null }>();
+
+const emit = defineEmits<{
+  (e: 'open-search', scoped: boolean): void;
+  (e: 'open-highlights', scoped: boolean): void;
+  (e: 'show-topic'): void;
+  (e: 'view-activity', query: string): void;
+}>();
+
+const windows = useWindowsStore();
+const networks = useNetworksStore();
+const buffers = useBuffersStore();
+const friends = useFriendsStore();
+
+const canvasEl = ref<HTMLElement | null>(null);
+const canvasWidth = ref(0);
+const canvasHeight = ref(0);
+
+// Titles and badges come from the buffer, so a minimized window's taskbar entry
+// keeps counting while it's hidden.
+function labelFor(key: string): string {
+  const cfg = virtualConfig(key);
+  if (cfg) return cfg.label;
+  const parsed = networks.bufferFor(key);
+  if (!parsed) return key;
+  if (parsed.target.startsWith(':server:')) return parsed.network?.name ?? 'server';
+  return parsed.target;
+}
+function unreadFor(key: string): number {
+  return buffers.byKey(key)?.unread ?? 0;
+}
+function highlightedFor(key: string): number {
+  return buffers.byKey(key)?.highlighted ?? 0;
+}
+
+// Point the app's active buffer at `key`, going through the same entry paths
+// the sidebar uses so read-state, history seeding and presence probes all run.
+// retainPrevious: the buffer we're focusing away from still has a window on
+// screen, so it hasn't been left.
+function activateKey(key: string): void {
+  if (networks.activeKey === key) return;
+  if (key === FRIENDS_KEY) {
+    friends.open();
+    return;
+  }
+  const cfg = virtualConfig(key);
+  if (cfg) {
+    buffers.activate(null, key, { retainPrevious: true });
+    return;
+  }
+  const parsed = networks.bufferFor(key);
+  if (parsed) buffers.activate(parsed.networkId, parsed.target, { retainPrevious: true });
+}
+
+// Sidebar (or /query, or a push deep-link) made a buffer active: give it a
+// window, or raise and un-minimize the one it has.
+watch(
+  () => networks.activeKey,
+  (key) => {
+    if (key) windows.open(key);
+  },
+  { immediate: true },
+);
+
+// The focused window is the active buffer. When the last window goes away
+// (closed, or all minimized) there is no active buffer — which is also what
+// makes re-picking the same buffer in the sidebar a change, and so re-opens it.
+// Guarded by the equality check in activateKey, so this and the watcher above
+// settle rather than ping-pong.
+watch(
+  () => windows.focusedKey,
+  (key) => {
+    if (key) activateKey(key);
+    else networks.clearActive();
+  },
+);
+
+// Closing and minimizing are the two gestures that mean "I'm done looking at
+// this for now", so they're where the unread divider and any detached history
+// slice get dropped — not on focus change, where the window is still on screen.
+function onClose(key: string): void {
+  buffers.leaveBuffer(key);
+  windows.close(key);
+}
+function onMinimize(key: string): void {
+  buffers.leaveBuffer(key);
+  windows.minimize(key);
+}
+function onRestore(key: string): void {
+  windows.restore(key);
+}
+
+let observer: ResizeObserver | null = null;
+function measure(): void {
+  const el = canvasEl.value;
+  if (!el) return;
+  canvasWidth.value = el.clientWidth;
+  canvasHeight.value = el.clientHeight;
+  windows.clampTo(canvasWidth.value, canvasHeight.value);
+}
+
+onMounted(() => {
+  measure();
+  if (typeof ResizeObserver !== 'undefined' && canvasEl.value) {
+    observer = new ResizeObserver(measure);
+    observer.observe(canvasEl.value);
+  }
+});
+onBeforeUnmount(() => {
+  observer?.disconnect();
+  observer = null;
+});
+</script>
+
+<style scoped>
+.window-canvas {
+  position: relative;
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+  /* A hair darker than the window bodies so the frames read as floating on a
+     desktop rather than as panels welded to the shell. */
+  background: var(--bg-alt, var(--bg));
+}
+
+.empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-muted);
+}
+
+.taskbar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: calc(var(--z-window) + 1000);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+}
+.task {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+  font: inherit;
+  max-width: 220px;
+}
+.task:hover {
+  color: var(--fg);
+}
+.task.highlight {
+  color: var(--warn);
+}
+.task-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.task-unread {
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+</style>

--- a/vue_client/src/components/WindowFrame.vue
+++ b/vue_client/src/components/WindowFrame.vue
@@ -188,10 +188,12 @@ function onPointerMove(e: PointerEvent): void {
 
   if (!gesture.grip) {
     // Move. Clamp so the titlebar can't be dragged off the canvas entirely:
-    // the top edge stays on-canvas, and enough of the frame's width remains to
-    // grab it again.
+    // enough of the frame stays inside to grab it again. The lower bounds are 0
+    // rather than something negative, matching windows.clampTo() — if a drag
+    // could park a window at a negative origin, the next canvas resize would
+    // clamp it back to 0 and the window would jump on its own.
     const GRAB = 80;
-    const x = Math.max(-(o.w - GRAB), Math.min(o.x + dx, props.canvasWidth - GRAB));
+    const x = Math.max(0, Math.min(o.x + dx, Math.max(0, props.canvasWidth - GRAB)));
     const y = Math.max(0, Math.min(o.y + dy, Math.max(0, props.canvasHeight - 24)));
     windows.move(key, x, y);
     return;

--- a/vue_client/src/components/WindowFrame.vue
+++ b/vue_client/src/components/WindowFrame.vue
@@ -26,11 +26,7 @@
     :style="frameStyle"
     @pointerdown="windows.focus(win.key)"
   >
-    <header
-      class="titlebar"
-      @pointerdown="onTitlePointerDown"
-      @dblclick="windows.toggleMaximize(win.key)"
-    >
+    <header class="titlebar" @pointerdown="onTitlePointerDown" @dblclick="onTitleDoubleClick">
       <span class="title">{{ label }}</span>
       <span v-if="unread > 0" class="unread" :class="{ highlight: highlighted > 0 }">{{
         unread
@@ -171,6 +167,13 @@ function onTitlePointerDown(e: PointerEvent): void {
   beginGesture(e, null);
 }
 
+// Double-click the bar to maximize — but not when the double-click landed on a
+// control, where two fast clicks on Minimize would otherwise also maximize.
+function onTitleDoubleClick(e: MouseEvent): void {
+  if ((e.target as Element).closest('button')) return;
+  windows.toggleMaximize(props.win.key);
+}
+
 function onGripPointerDown(e: PointerEvent, grip: Grip): void {
   windows.focus(props.win.key);
   beginGesture(e, grip);
@@ -251,7 +254,7 @@ function endGesture(e: PointerEvent): void {
   gap: var(--space-4);
   padding: var(--space-2) var(--space-4);
   border-bottom: 1px solid var(--border);
-  background: var(--bg-alt, var(--bg));
+  background: var(--bg-soft);
   cursor: move;
   user-select: none;
   touch-action: none;
@@ -297,7 +300,7 @@ function endGesture(e: PointerEvent): void {
   color: var(--fg);
 }
 .ctl.close:hover {
-  color: var(--err, var(--warn));
+  color: var(--bad);
 }
 
 .body {

--- a/vue_client/src/components/WindowFrame.vue
+++ b/vue_client/src/components/WindowFrame.vue
@@ -1,0 +1,377 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Window chrome for one buffer on the mIRC-style canvas: a titlebar you drag,
+  eight edges/corners you resize from, and the minimize/maximize/close cluster.
+
+  Geometry lives in the windows store, not here — this component turns pointer
+  gestures into store calls and renders the result. That keeps the frame free of
+  its own truth, so the store can clamp, cascade, or restore geometry without
+  the frame knowing.
+
+  Pointer capture (not window-level listeners) means a fast drag that outruns
+  the cursor still delivers its moves here, and the gesture ends cleanly if the
+  pointer is lost. Focus happens on pointerdown rather than click so a button
+  inside a background window acts on an already-focused window — which is what
+  makes the topic bar's "search this buffer" scope to the right buffer.
+-->
+
+<template>
+  <div
+    class="window"
+    :class="{ focused: isFocused, maximized: win.state === 'maximized' }"
+    :style="frameStyle"
+    @pointerdown="windows.focus(win.key)"
+  >
+    <header
+      class="titlebar"
+      @pointerdown="onTitlePointerDown"
+      @dblclick="windows.toggleMaximize(win.key)"
+    >
+      <span class="title">{{ label }}</span>
+      <span v-if="unread > 0" class="unread" :class="{ highlight: highlighted > 0 }">{{
+        unread
+      }}</span>
+      <span class="spacer"></span>
+      <div class="controls">
+        <button
+          type="button"
+          class="ctl"
+          title="Minimize"
+          aria-label="Minimize"
+          @click="emit('minimize')"
+        >
+          <i class="fa-solid fa-minus"></i>
+        </button>
+        <button
+          type="button"
+          class="ctl"
+          :title="win.state === 'maximized' ? 'Restore' : 'Maximize'"
+          :aria-label="win.state === 'maximized' ? 'Restore' : 'Maximize'"
+          @click="windows.toggleMaximize(win.key)"
+        >
+          <i
+            :class="
+              win.state === 'maximized' ? 'fa-regular fa-window-restore' : 'fa-regular fa-square'
+            "
+          ></i>
+        </button>
+        <button
+          type="button"
+          class="ctl close"
+          title="Close"
+          aria-label="Close"
+          @click="emit('close')"
+        >
+          <i class="fa-solid fa-xmark"></i>
+        </button>
+      </div>
+    </header>
+
+    <div class="body">
+      <slot />
+    </div>
+
+    <!-- Resize grips. Hidden while maximized, where the frame owns the canvas. -->
+    <template v-if="win.state !== 'maximized'">
+      <div
+        v-for="dir in GRIPS"
+        :key="dir"
+        class="grip"
+        :class="`grip-${dir}`"
+        @pointerdown.stop="onGripPointerDown($event, dir)"
+      ></div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { CSSProperties } from 'vue';
+import {
+  useWindowsStore,
+  WINDOW_MIN_H,
+  WINDOW_MIN_W,
+  type BufferWindow,
+} from '../stores/windows.js';
+
+const props = defineProps<{
+  win: BufferWindow;
+  label: string;
+  unread: number;
+  highlighted: number;
+  isFocused: boolean;
+  // Canvas size, so a drag can't strand a window past the right/bottom edge.
+  canvasWidth: number;
+  canvasHeight: number;
+}>();
+
+// Close and minimize are the two gestures that take a buffer off screen, which
+// the canvas has to reconcile with the buffer's read state. Move/resize/focus/
+// maximize are pure chrome, so they go straight to the store.
+const emit = defineEmits<{ (e: 'close'): void; (e: 'minimize'): void }>();
+
+const windows = useWindowsStore();
+
+const GRIPS = ['n', 's', 'e', 'w', 'ne', 'nw', 'se', 'sw'] as const;
+type Grip = (typeof GRIPS)[number];
+
+const frameStyle = computed<CSSProperties>(() => {
+  const w = props.win;
+  if (w.state === 'maximized') {
+    return { inset: '0', zIndex: `calc(var(--z-window) + ${w.z})` };
+  }
+  return {
+    left: `${w.x}px`,
+    top: `${w.y}px`,
+    width: `${w.w}px`,
+    height: `${w.h}px`,
+    zIndex: `calc(var(--z-window) + ${w.z})`,
+  };
+});
+
+// A drag is: remember where the window and the pointer were when it started,
+// then on every move apply the pointer's delta to the remembered origin. Taking
+// deltas against the *start* rather than the previous move means a dropped
+// frame can't accumulate drift.
+interface Gesture {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  origin: { x: number; y: number; w: number; h: number };
+  grip: Grip | null; // null = titlebar move
+}
+let gesture: Gesture | null = null;
+
+function beginGesture(e: PointerEvent, grip: Grip | null): void {
+  const w = props.win;
+  if (w.state === 'maximized') return;
+  gesture = {
+    pointerId: e.pointerId,
+    startX: e.clientX,
+    startY: e.clientY,
+    origin: { x: w.x, y: w.y, w: w.w, h: w.h },
+    grip,
+  };
+  const el = e.currentTarget as HTMLElement;
+  el.setPointerCapture(e.pointerId);
+  el.addEventListener('pointermove', onPointerMove);
+  el.addEventListener('pointerup', endGesture);
+  el.addEventListener('pointercancel', endGesture);
+  e.preventDefault();
+}
+
+function onTitlePointerDown(e: PointerEvent): void {
+  // Let the control buttons have their clicks.
+  if ((e.target as Element).closest('button')) return;
+  windows.focus(props.win.key);
+  beginGesture(e, null);
+}
+
+function onGripPointerDown(e: PointerEvent, grip: Grip): void {
+  windows.focus(props.win.key);
+  beginGesture(e, grip);
+}
+
+function onPointerMove(e: PointerEvent): void {
+  if (!gesture || e.pointerId !== gesture.pointerId) return;
+  const dx = e.clientX - gesture.startX;
+  const dy = e.clientY - gesture.startY;
+  const o = gesture.origin;
+  const key = props.win.key;
+
+  if (!gesture.grip) {
+    // Move. Clamp so the titlebar can't be dragged off the canvas entirely:
+    // the top edge stays on-canvas, and enough of the frame's width remains to
+    // grab it again.
+    const GRAB = 80;
+    const x = Math.max(-(o.w - GRAB), Math.min(o.x + dx, props.canvasWidth - GRAB));
+    const y = Math.max(0, Math.min(o.y + dy, Math.max(0, props.canvasHeight - 24)));
+    windows.move(key, x, y);
+    return;
+  }
+
+  // Resize. Dragging a north/west edge moves the origin as well as the size, so
+  // the opposite edge stays put. Clamping the origin against the min size keeps
+  // a shrinking window from walking its far edge backwards once it bottoms out.
+  let { x, y, w, h } = o;
+  if (gesture.grip.includes('e')) w = o.w + dx;
+  if (gesture.grip.includes('s')) h = o.h + dy;
+  if (gesture.grip.includes('w')) {
+    w = o.w - dx;
+    x = o.x + Math.min(dx, o.w - WINDOW_MIN_W);
+  }
+  if (gesture.grip.includes('n')) {
+    h = o.h - dy;
+    y = o.y + Math.min(dy, o.h - WINDOW_MIN_H);
+  }
+  windows.move(key, Math.max(0, x), Math.max(0, y));
+  windows.resize(key, w, h);
+}
+
+function endGesture(e: PointerEvent): void {
+  if (!gesture || e.pointerId !== gesture.pointerId) return;
+  const el = e.currentTarget as HTMLElement;
+  el.releasePointerCapture?.(gesture.pointerId);
+  el.removeEventListener('pointermove', onPointerMove);
+  el.removeEventListener('pointerup', endGesture);
+  el.removeEventListener('pointercancel', endGesture);
+  gesture = null;
+}
+</script>
+
+<style scoped>
+.window {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-popover);
+  overflow: hidden;
+}
+/* The focused window gets an accent frame — the only "which one am I typing
+   into" signal on a canvas where every window looks alike. */
+.window.focused {
+  border-color: var(--accent);
+}
+.window.maximized {
+  border-width: 0;
+  box-shadow: none;
+}
+
+.titlebar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-alt, var(--bg));
+  cursor: move;
+  user-select: none;
+  touch-action: none;
+  white-space: nowrap;
+}
+.window.maximized .titlebar {
+  cursor: default;
+}
+.title {
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.window.focused .title {
+  color: var(--accent);
+}
+.unread {
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.unread.highlight {
+  color: var(--warn);
+}
+.spacer {
+  flex: 1;
+  min-width: 0;
+}
+.controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+.ctl {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  padding: 0 var(--space-2);
+  cursor: pointer;
+  font: inherit;
+}
+.ctl:hover {
+  color: var(--fg);
+}
+.ctl.close:hover {
+  color: var(--err, var(--warn));
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  overflow: hidden;
+}
+.body > * {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Grips sit just outside the content, overlapping the border. 6px is a
+   comfortable pointer target without eating into the frame's padding; corners
+   are 12px squares layered above the edges. */
+.grip {
+  position: absolute;
+  touch-action: none;
+}
+.grip-n,
+.grip-s {
+  left: 0;
+  right: 0;
+  height: 6px;
+  cursor: ns-resize;
+}
+.grip-n {
+  top: -3px;
+}
+.grip-s {
+  bottom: -3px;
+}
+.grip-e,
+.grip-w {
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  cursor: ew-resize;
+}
+.grip-e {
+  right: -3px;
+}
+.grip-w {
+  left: -3px;
+}
+.grip-ne,
+.grip-nw,
+.grip-se,
+.grip-sw {
+  width: 12px;
+  height: 12px;
+  z-index: 1;
+}
+.grip-ne {
+  top: -3px;
+  right: -3px;
+  cursor: nesw-resize;
+}
+.grip-nw {
+  top: -3px;
+  left: -3px;
+  cursor: nwse-resize;
+}
+.grip-se {
+  bottom: -3px;
+  right: -3px;
+  cursor: nwse-resize;
+}
+.grip-sw {
+  bottom: -3px;
+  left: -3px;
+  cursor: nesw-resize;
+}
+</style>

--- a/vue_client/src/composables/useActiveBuffer.ts
+++ b/vue_client/src/composables/useActiveBuffer.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import type { ComputedRef, Ref } from 'vue';
-import { computed } from 'vue';
+import type { ComputedRef, InjectionKey, Ref } from 'vue';
+import { computed, inject, provide } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
@@ -13,7 +13,34 @@ import {
   type VirtualRenderMode,
 } from '../lib/virtualBuffers.js';
 
+// Which buffer the surrounding subtree is rendering.
+//
+// The app has always had exactly one buffer on screen, so MessageList,
+// MemberList, StatusBar and MessageInput each reached up and read
+// `networks.activeKey` directly. That coupling is what makes them singletons.
+// A BufferPane provides its own key here instead, and those components resolve
+// "my buffer" through `useBufferKey()` — which falls back to the global
+// activeKey when nothing is provided. So an un-provided subtree behaves exactly
+// as it did before, and a windowed one renders whatever its pane says.
+export const BUFFER_KEY: InjectionKey<Ref<string | null>> = Symbol('lurker:buffer-key');
+
+// Call from a component that owns a buffer's subtree (BufferPane). Pass a ref
+// so the pane can repoint at another buffer without remounting the subtree.
+export function provideBufferKey(key: Ref<string | null>): void {
+  provide(BUFFER_KEY, key);
+}
+
+// The buffer key for this subtree: the provided one, or the global active
+// buffer when this component isn't inside a pane. Must be called from setup().
+export function useBufferKey(): Ref<string | null> {
+  const provided = inject(BUFFER_KEY, null);
+  if (provided) return provided;
+  return storeToRefs(useNetworksStore()).activeKey;
+}
+
 export interface ActiveBufferState {
+  // Named `activeKey` for historical reasons — inside a BufferPane this is the
+  // pane's buffer, which is only *the* active buffer when the pane is focused.
   activeKey: Ref<string | null>;
   active: ComputedRef<{ networkId: number; target: string; network: unknown } | null>;
   activeBuf: ComputedRef<unknown>;
@@ -35,9 +62,9 @@ export interface ActiveBufferState {
 export function useActiveBuffer(): ActiveBufferState {
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
-  const { activeKey } = storeToRefs(networks);
+  const activeKey = useBufferKey();
 
-  const active = computed(() => networks.activeBuffer);
+  const active = computed(() => networks.bufferFor(activeKey.value));
   const virtualCfg = computed(() => virtualConfig(activeKey.value));
   const isVirtual = computed(() => virtualCfg.value != null);
   const isSystemBuffer = computed(() => activeKey.value === SYSTEM_KEY);

--- a/vue_client/src/composables/useActiveBuffer.ts
+++ b/vue_client/src/composables/useActiveBuffer.ts
@@ -30,9 +30,15 @@ export function provideBufferKey(key: Ref<string | null>): void {
   provide(BUFFER_KEY, key);
 }
 
-// The buffer key for this subtree: the provided one, or the global active
-// buffer when this component isn't inside a pane. Must be called from setup().
-export function useBufferKey(): Ref<string | null> {
+// The buffer key for this subtree, in precedence order: an explicitly passed
+// key, the injected one, then the global active buffer. Must be called from
+// setup().
+//
+// The explicit form exists for the component that *provides* the key: Vue
+// resolves inject() against the parent's provides, so a pane asking for its own
+// key would get the global activeKey it just shadowed.
+export function useBufferKey(explicit?: Ref<string | null>): Ref<string | null> {
+  if (explicit) return explicit;
   const provided = inject(BUFFER_KEY, null);
   if (provided) return provided;
   return storeToRefs(useNetworksStore()).activeKey;
@@ -59,10 +65,10 @@ export interface ActiveBufferState {
   hasNicklist: ComputedRef<boolean>;
 }
 
-export function useActiveBuffer(): ActiveBufferState {
+export function useActiveBuffer(explicitKey?: Ref<string | null>): ActiveBufferState {
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
-  const activeKey = useBufferKey();
+  const activeKey = useBufferKey(explicitKey);
 
   const active = computed(() => networks.bufferFor(activeKey.value));
   const virtualCfg = computed(() => virtualConfig(activeKey.value));

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -16,7 +16,7 @@ import { useToastsStore, type ToastKind } from '../stores/toasts.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useIgnoresStore } from '../stores/ignores.js';
-import { viewedBuffer } from './useViewedBuffer.js';
+import { isBufferViewed } from './useViewedBuffer.js';
 
 export interface NotifyEvent {
   self?: boolean;
@@ -95,14 +95,16 @@ function throttled(event: NotifyEvent, kind: ToastKind): boolean {
 //     and a toast would be redundant (issue #50) — Discord and Slack mute the
 //     focused channel the same way.
 //
-// "Viewed buffer" is viewedBuffer(), owned by MessageList — NOT networks
-// .activeKey. activeKey only tracks the last-opened buffer and lingers across
-// route / mobile-screen changes, so keying off it would wrongly suppress a
-// toast while the user sits on the Settings route or the mobile buffer list,
-// where no message list is mounted.
+// "Viewed buffer" is the isBufferViewed() set, owned by MessageList — NOT
+// networks.activeKey. activeKey only tracks the last-opened buffer and lingers
+// across route / mobile-screen changes, so keying off it would wrongly suppress
+// a toast while the user sits on the Settings route or the mobile buffer list,
+// where no message list is mounted. With windowed panes the set holds every
+// buffer on screen, so a highlight in any visible window is suppressed — not
+// just the focused one.
 function shouldNotifyInApp(event: NotifyEvent): boolean {
   if (typeof document === 'undefined' || document.hidden) return false;
-  return viewedBuffer() !== `${event.networkId}::${event.target}`;
+  return !isBufferViewed(`${event.networkId}::${event.target}`);
 }
 
 export function notifyForEvent(event: NotifyEvent | null | undefined): void {

--- a/vue_client/src/composables/usePaneRegistry.test.ts
+++ b/vue_client/src/composables/usePaneRegistry.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  paneFor,
+  registerPane,
+  resetPanes,
+  unregisterPane,
+  type PaneApi,
+} from './usePaneRegistry.js';
+
+const makeApi = (): PaneApi => ({
+  focusInput: vi.fn<() => void>(),
+  scrollByPage: vi.fn<(dir: number) => void>(),
+});
+
+beforeEach(() => {
+  resetPanes();
+});
+
+describe('pane registry', () => {
+  it('resolves a registered pane by buffer key', () => {
+    const api = makeApi();
+    registerPane('1::#a', api);
+    expect(paneFor('1::#a')).toBe(api);
+    expect(paneFor('1::#b')).toBeNull();
+    expect(paneFor(null)).toBeNull();
+  });
+
+  it('ignores a null key rather than registering an unreachable pane', () => {
+    registerPane(null, makeApi());
+    expect(paneFor(null)).toBeNull();
+  });
+
+  // The single-pane shell keeps one BufferPane across buffer switches, so its
+  // registration has to move with the key. Regression: registering once at
+  // mount left the registry empty (activeKey is null at that point) and broke
+  // type-ahead focus and PageUp/PageDown.
+  it('follows a pane across a key change', () => {
+    const api = makeApi();
+    registerPane(null, api);
+    expect(paneFor(':system:')).toBeNull();
+
+    registerPane(':system:', api);
+    expect(paneFor(':system:')).toBe(api);
+
+    unregisterPane(':system:', api);
+    registerPane('1::#a', api);
+    expect(paneFor(':system:')).toBeNull();
+    expect(paneFor('1::#a')).toBe(api);
+  });
+
+  // A remount can register the new pane before the old one tears down; the old
+  // unmount must not delete the newcomer's registration.
+  it('unregister is identity-checked', () => {
+    const oldApi = makeApi();
+    const newApi = makeApi();
+    registerPane('1::#a', oldApi);
+    registerPane('1::#a', newApi);
+
+    unregisterPane('1::#a', oldApi);
+    expect(paneFor('1::#a')).toBe(newApi);
+
+    unregisterPane('1::#a', newApi);
+    expect(paneFor('1::#a')).toBeNull();
+  });
+
+  it('resetPanes drops everything (logout)', () => {
+    registerPane('1::#a', makeApi());
+    resetPanes();
+    expect(paneFor('1::#a')).toBeNull();
+  });
+});

--- a/vue_client/src/composables/usePaneRegistry.ts
+++ b/vue_client/src/composables/usePaneRegistry.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Imperative handles onto the mounted BufferPanes, keyed by buffer.
+//
+// The keyboard shortcuts (type-ahead focus, PageUp/PageDown) and the
+// click-anywhere-to-focus-the-input behavior have to reach *a* pane's input and
+// message list. With one pane that was a template ref in DesktopChat. With
+// several, "which pane" is a question with an answer — the focused one — so the
+// shell looks the pane up by the active buffer key instead of holding a ref.
+//
+// A pane registers on mount and unregisters on unmount. Panes showing the same
+// buffer would collide; the last mount wins, which is the same buffer's UI
+// either way, so nothing observable turns on it.
+export interface PaneApi {
+  focusInput: () => void;
+  scrollByPage: (dir: number) => void;
+}
+
+const panes = new Map<string, PaneApi>();
+
+export function registerPane(key: string | null, api: PaneApi): void {
+  if (key) panes.set(key, api);
+}
+
+export function unregisterPane(key: string | null, api: PaneApi): void {
+  // Identity-checked so a remount that registered the new pane before the old
+  // one tore down doesn't have its registration deleted by the old unmount.
+  if (key && panes.get(key) === api) panes.delete(key);
+}
+
+export function paneFor(key: string | null): PaneApi | null {
+  return key ? (panes.get(key) ?? null) : null;
+}
+
+export function resetPanes(): void {
+  panes.clear();
+}

--- a/vue_client/src/composables/useScrollState.ts
+++ b/vue_client/src/composables/useScrollState.ts
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import type { Ref } from 'vue';
-import { ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { computed, ref } from 'vue';
+import { useBufferKey } from './useActiveBuffer.js';
 
 // Direction from the viewport to the pinned unread divider when it's off
 // screen and not yet seen this visit: 'up' = above the viewport, 'down' =
@@ -10,15 +11,13 @@ import { ref } from 'vue';
 // screen, or the user already scrolled it into view this visit.
 export type UnreadAnchor = 'up' | 'down' | null;
 
-// Bridges MessageList's scroll position into the StatusBar without a prop drill.
-// MessageList writes via the setters; StatusBar reads the refs.
-const stuckToBottom = ref(true);
-const newBelow = ref(0);
-const scrollToBottomToken = ref(0);
-const unreadAnchor = ref<UnreadAnchor>(null);
-const scrollToUnreadToken = ref(0);
-
-export interface ScrollState {
+// Bridges a MessageList's scroll position into the StatusBar sitting beneath
+// it, without a prop drill: MessageList writes via the setters, StatusBar reads
+// the refs. Both live inside the same BufferPane, so the bridge is keyed by
+// buffer — with several panes on screen each one's "N new ↓" and stick-to-bottom
+// belong to its own buffer, and a scrolled-up window must not tell a pinned
+// window's status bar that it's scrolled up.
+interface Entry {
   stuckToBottom: Ref<boolean>;
   newBelow: Ref<number>;
   scrollToBottomToken: Ref<number>;
@@ -26,33 +25,85 @@ export interface ScrollState {
   scrollToUnreadToken: Ref<number>;
 }
 
+// Keyed by buffer key. The empty string stands in for "no buffer" so callers
+// never have to null-check an entry. Entries are a handful of refs each and are
+// bounded by the number of buffers ever opened this session; the whole map is
+// dropped on session reset (logout).
+const entries = new Map<string, Entry>();
+const NO_BUFFER = '';
+
+function entryFor(key: string | null): Entry {
+  const k = key ?? NO_BUFFER;
+  let entry = entries.get(k);
+  if (!entry) {
+    entry = {
+      stuckToBottom: ref(true),
+      newBelow: ref(0),
+      scrollToBottomToken: ref(0),
+      unreadAnchor: ref<UnreadAnchor>(null),
+      scrollToUnreadToken: ref(0),
+    };
+    entries.set(k, entry);
+  }
+  return entry;
+}
+
+export interface ScrollState {
+  stuckToBottom: ComputedRef<boolean>;
+  newBelow: ComputedRef<number>;
+  scrollToBottomToken: ComputedRef<number>;
+  unreadAnchor: ComputedRef<UnreadAnchor>;
+  scrollToUnreadToken: ComputedRef<number>;
+  setStuckToBottom: (v: boolean) => void;
+  bumpNewBelow: () => void;
+  reset: () => void;
+  requestScrollToBottom: () => void;
+  setUnreadAnchor: (dir: UnreadAnchor) => void;
+  requestScrollToUnread: () => void;
+}
+
+// Scroll state for this subtree's buffer. Must be called from setup(): it reads
+// the injected buffer key, falling back to the global active buffer.
 export function useScrollState(): ScrollState {
-  return { stuckToBottom, newBelow, scrollToBottomToken, unreadAnchor, scrollToUnreadToken };
+  const bufferKey = useBufferKey();
+  const entry = () => entryFor(bufferKey.value);
+
+  return {
+    stuckToBottom: computed(() => entry().stuckToBottom.value),
+    newBelow: computed(() => entry().newBelow.value),
+    scrollToBottomToken: computed(() => entry().scrollToBottomToken.value),
+    unreadAnchor: computed(() => entry().unreadAnchor.value),
+    scrollToUnreadToken: computed(() => entry().scrollToUnreadToken.value),
+
+    setStuckToBottom(v: boolean) {
+      const e = entry();
+      e.stuckToBottom.value = !!v;
+      if (v) e.newBelow.value = 0;
+    },
+    bumpNewBelow() {
+      const e = entry();
+      if (!e.stuckToBottom.value) e.newBelow.value += 1;
+    },
+    reset() {
+      const e = entry();
+      e.stuckToBottom.value = true;
+      e.newBelow.value = 0;
+      e.unreadAnchor.value = null;
+    },
+    requestScrollToBottom() {
+      entry().scrollToBottomToken.value += 1;
+    },
+    setUnreadAnchor(dir: UnreadAnchor) {
+      entry().unreadAnchor.value = dir;
+    },
+    requestScrollToUnread() {
+      entry().scrollToUnreadToken.value += 1;
+    },
+  };
 }
 
-export function setStuckToBottom(v: boolean): void {
-  stuckToBottom.value = !!v;
-  if (v) newBelow.value = 0;
-}
-
-export function bumpNewBelow(): void {
-  if (!stuckToBottom.value) newBelow.value += 1;
-}
-
-export function resetScrollState(): void {
-  stuckToBottom.value = true;
-  newBelow.value = 0;
-  unreadAnchor.value = null;
-}
-
-export function requestScrollToBottom(): void {
-  scrollToBottomToken.value += 1;
-}
-
-export function setUnreadAnchor(dir: UnreadAnchor): void {
-  unreadAnchor.value = dir;
-}
-
-export function requestScrollToUnread(): void {
-  scrollToUnreadToken.value += 1;
+// Drop every buffer's scroll state. Called on session reset (logout), where the
+// buffers themselves are also going away.
+export function resetAllScrollState(): void {
+  entries.clear();
 }

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -12,10 +12,12 @@ import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { usePushSubscriptionsStore } from '../stores/pushSubscriptions.js';
 import { usePinsStore } from '../stores/pins.js';
+import { useWindowsStore } from '../stores/windows.js';
 import { resetSocket } from './useSocket.js';
 import { resetPresence } from './usePresence.js';
 import { resetAllScrollState } from './useScrollState.js';
 import { resetViewedBuffers } from './useViewedBuffer.js';
+import { resetPanes } from './usePaneRegistry.js';
 import { clearAppBadgeNow } from './useAppBadge.js';
 
 // Wipe every session-scoped piece of client state so the next user (after
@@ -40,9 +42,13 @@ export function resetSession(): void {
   drafts.$reset();
   usePushSubscriptionsStore().$reset();
   usePinsStore().$reset();
+  // Windows are keyed by buffer, so leaving them up would render the previous
+  // user's channel names in the next user's canvas and taskbar.
+  useWindowsStore().$reset();
   resetPresence();
   resetAllScrollState();
   resetViewedBuffers();
+  resetPanes();
   // Drop the PWA app-icon badge so a stale highlight count doesn't outlive the
   // session. buffers.$reset() above already zeroes the total, but clear
   // explicitly in case the Badging watcher isn't wired in this context.

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -14,7 +14,8 @@ import { usePushSubscriptionsStore } from '../stores/pushSubscriptions.js';
 import { usePinsStore } from '../stores/pins.js';
 import { resetSocket } from './useSocket.js';
 import { resetPresence } from './usePresence.js';
-import { resetScrollState } from './useScrollState.js';
+import { resetAllScrollState } from './useScrollState.js';
+import { resetViewedBuffers } from './useViewedBuffer.js';
 import { clearAppBadgeNow } from './useAppBadge.js';
 
 // Wipe every session-scoped piece of client state so the next user (after
@@ -40,7 +41,8 @@ export function resetSession(): void {
   usePushSubscriptionsStore().$reset();
   usePinsStore().$reset();
   resetPresence();
-  resetScrollState();
+  resetAllScrollState();
+  resetViewedBuffers();
   // Drop the PWA app-icon badge so a stale highlight count doesn't outlive the
   // session. buffers.$reset() above already zeroes the total, but clear
   // explicitly in case the Badging watcher isn't wired in this context.

--- a/vue_client/src/composables/useViewedBuffer.test.ts
+++ b/vue_client/src/composables/useViewedBuffer.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isBufferViewed,
+  releaseViewedBuffer,
+  resetViewedBuffers,
+  retainViewedBuffer,
+} from './useViewedBuffer.js';
+
+beforeEach(() => {
+  resetViewedBuffers();
+});
+
+describe('viewed buffers', () => {
+  it('reports a retained buffer as viewed and a released one as not', () => {
+    expect(isBufferViewed('1::#a')).toBe(false);
+    retainViewedBuffer('1::#a');
+    expect(isBufferViewed('1::#a')).toBe(true);
+    releaseViewedBuffer('1::#a');
+    expect(isBufferViewed('1::#a')).toBe(false);
+  });
+
+  it('tracks several buffers at once — the windowed case', () => {
+    retainViewedBuffer('1::#a');
+    retainViewedBuffer('1::#b');
+    expect(isBufferViewed('1::#a')).toBe(true);
+    expect(isBufferViewed('1::#b')).toBe(true);
+
+    releaseViewedBuffer('1::#a');
+    expect(isBufferViewed('1::#a')).toBe(false);
+    expect(isBufferViewed('1::#b')).toBe(true);
+  });
+
+  // Two panes on the same buffer, or a remount that registers the new message
+  // list before the old one tears down. The first release must not blind the
+  // survivor — this is why it's a refcount and not a Set.
+  it('stays viewed until the last viewer releases', () => {
+    retainViewedBuffer('1::#a');
+    retainViewedBuffer('1::#a');
+    releaseViewedBuffer('1::#a');
+    expect(isBufferViewed('1::#a')).toBe(true);
+    releaseViewedBuffer('1::#a');
+    expect(isBufferViewed('1::#a')).toBe(false);
+  });
+
+  it('ignores null keys and over-releasing', () => {
+    retainViewedBuffer(null);
+    releaseViewedBuffer(null);
+    releaseViewedBuffer('1::#never');
+    expect(isBufferViewed('1::#never')).toBe(false);
+
+    retainViewedBuffer('1::#a');
+    releaseViewedBuffer('1::#a');
+    releaseViewedBuffer('1::#a');
+    retainViewedBuffer('1::#a');
+    expect(isBufferViewed('1::#a')).toBe(true);
+  });
+
+  it('resetViewedBuffers drops everything (logout)', () => {
+    retainViewedBuffer('1::#a');
+    retainViewedBuffer('1::#b');
+    resetViewedBuffers();
+    expect(isBufferViewed('1::#a')).toBe(false);
+    expect(isBufferViewed('1::#b')).toBe(false);
+  });
+});

--- a/vue_client/src/composables/useViewedBuffer.ts
+++ b/vue_client/src/composables/useViewedBuffer.ts
@@ -1,27 +1,47 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// The buffer key (`networkId::target`) whose message list is actually
-// rendered on screen right now, or null when none is. MessageList owns it:
-// it reports its buffer while mounted and clears it on unmount — so this is
-// null whenever MessageList isn't mounted, which covers the Settings route,
-// the mobile buffer-list / members screens, and the system console.
+// The set of buffer keys (`networkId::target`) whose message lists are actually
+// rendered on screen right now. Empty when none are — which covers the Settings
+// route, the mobile buffer-list / members screens, and the system console.
+//
+// MessageList owns the registration: it retains its buffer while mounted and
+// releases on unmount. With one message list on screen this is a set of at most
+// one; with several windowed panes open it holds every buffer the user can
+// currently see, which is exactly the question toast suppression is asking.
 //
 // Deliberately NOT networks.activeKey. activeKey only tracks the last-opened
-// buffer and lingers across route and mobile-screen changes, so it still
-// reads as "in view" while the user sits on Settings or the buffer list.
-// Toast suppression keys off this instead (useHighlightNotifier
-// .shouldNotifyInApp) so a highlight in the last-opened buffer still toasts
-// while that buffer's messages aren't actually on screen.
+// buffer and lingers across route and mobile-screen changes, so it still reads
+// as "in view" while the user sits on Settings or the buffer list. Toast
+// suppression keys off this instead (useHighlightNotifier.shouldNotifyInApp) so
+// a highlight in the last-opened buffer still toasts while that buffer's
+// messages aren't actually on screen.
 //
-// A plain module variable (not a ref): the only reader, shouldNotifyInApp,
-// polls it imperatively when an event arrives — there's nothing to react to.
-let viewedBufferKey: string | null = null;
+// Refcounted rather than a plain Set: two panes may show the same buffer (or a
+// pane may remount across a key change while the old one is still tearing
+// down), and the first release must not blind the survivor. Plain module state,
+// not a ref — the only reader, shouldNotifyInApp, polls it imperatively when an
+// event arrives, so there's nothing to react to.
+const viewers = new Map<string, number>();
 
-export function setViewedBuffer(key: string | null): void {
-  viewedBufferKey = key;
+export function retainViewedBuffer(key: string | null): void {
+  if (!key) return;
+  viewers.set(key, (viewers.get(key) ?? 0) + 1);
 }
 
-export function viewedBuffer(): string | null {
-  return viewedBufferKey;
+export function releaseViewedBuffer(key: string | null): void {
+  if (!key) return;
+  const next = (viewers.get(key) ?? 0) - 1;
+  if (next > 0) viewers.set(key, next);
+  else viewers.delete(key);
+}
+
+export function isBufferViewed(key: string): boolean {
+  return viewers.has(key);
+}
+
+// Session reset (logout) tears every message list down anyway; drop the map so
+// a stale key can't suppress a toast for the next user.
+export function resetViewedBuffers(): void {
+  viewers.clear();
 }

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -444,3 +444,78 @@ describe('joinOrActivate channel key', () => {
     });
   });
 });
+
+// Focus and visibility are the same thing in the single-pane shell and
+// different things on the windowed canvas, so the "user stopped looking at this
+// buffer" teardown is separable from activate().
+describe('leaveBuffer / retainPrevious', () => {
+  const seed = (store: ReturnType<typeof useBuffersStore>, target: string) => {
+    store.replaceBacklog(
+      1,
+      target,
+      [{ networkId: 1, target, id: 10, type: 'message', nick: 'bob', body: 'x' }],
+      undefined,
+      { lastReadId: 0, unread: 3, highlights: 2 },
+      true,
+      { hasMoreOlder: false },
+    );
+    return store.byKey(`1::${target}`)!;
+  };
+
+  it('activate() tears down the buffer it switched away from', () => {
+    const store = useBuffersStore();
+    seed(store, '#a');
+    store.activate(1, '#a');
+    seed(store, '#b');
+
+    const a = store.byKey('1::#a')!;
+    a.unread = 3;
+    a.highlighted = 2;
+    a.dividerAfterId = 7;
+
+    store.activate(1, '#b');
+
+    expect(a.unread).toBe(0);
+    expect(a.highlighted).toBe(0);
+    expect(a.dividerAfterId).toBeNull();
+  });
+
+  it('retainPrevious leaves the outgoing buffer alone — its window is still open', () => {
+    const store = useBuffersStore();
+    seed(store, '#a');
+    store.activate(1, '#a');
+    seed(store, '#b');
+
+    const a = store.byKey('1::#a')!;
+    a.unread = 3;
+    a.highlighted = 2;
+    a.dividerAfterId = 7;
+
+    store.activate(1, '#b', { retainPrevious: true });
+
+    expect(a.unread).toBe(3);
+    expect(a.highlighted).toBe(2);
+    expect(a.dividerAfterId).toBe(7);
+    // ...and the buffer we entered still got the normal focus-in treatment.
+    expect(h.activeKey).toBe('1::#b');
+  });
+
+  it('leaveBuffer() applies that teardown on demand (window close / minimize)', () => {
+    const store = useBuffersStore();
+    const a = seed(store, '#a');
+    a.unread = 3;
+    a.highlighted = 2;
+    a.dividerAfterId = 7;
+
+    store.leaveBuffer('1::#a');
+
+    expect(a.unread).toBe(0);
+    expect(a.highlighted).toBe(0);
+    expect(a.dividerAfterId).toBeNull();
+  });
+
+  it('leaveBuffer() on an unknown key is a no-op', () => {
+    const store = useBuffersStore();
+    expect(() => store.leaveBuffer('1::#nope')).not.toThrow();
+  });
+});

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -978,13 +978,46 @@ export const useBuffersStore = defineStore('buffers', {
     unclearBuffer(networkId: number | string, target: string) {
       socketSend({ type: 'unclear-buffer', networkId, target });
     },
+    // "The user stopped looking at this buffer." Drops the visit-scoped local
+    // state: the pinned unread divider, the unread/highlight counters, and any
+    // detached history slice.
+    //
+    // Split out of activate() because focus and visibility are the same thing in
+    // the single-pane shell and different things on the windowed canvas. With
+    // one pane, switching away IS stopping looking, so activate() calls this for
+    // the previous buffer. With windows, a buffer you focused away from is still
+    // on screen and still being read — what means "stopped looking" there is
+    // closing or minimizing its window, so the canvas calls this itself.
+    leaveBuffer(bufKey: string) {
+      const prev = this.buffers[bufKey];
+      if (!prev) return;
+      prev.dividerAfterId = null;
+      prev.unread = 0;
+      prev.highlighted = 0;
+      prev.highlightsCapped = false;
+      // Carrying a detached slice across buffer switches gets weird fast
+      // (the user can't see the detach status on a buffer they aren't
+      // viewing, the live counter ticks invisibly, the next entry has
+      // to remember whether to render the slice or live). Drop it and
+      // wipe the slice on switch-away — re-entry then reseeds from
+      // snapshot or the next history fetch as if it were fresh.
+      if (prev.detached) this.clearDetached(prev.networkId, prev.target, { wipeMessages: true });
+    },
     // Switch to a buffer. We mark the entered buffer read on focus-IN (not
     // on focus-OUT of the previous one) so that a tab close / reload / lost
     // socket before switch-away still leaves the buffer marked read — no
     // phantom divider on the next session. The previous buffer's pointer
     // is already current because pushMessage keeps it synced live while
     // focused (see pushMessage), so leaving it just drops local state.
-    activate(networkId: number | string | null, target: string) {
+    //
+    // `retainPrevious` suppresses the leave-teardown of the outgoing buffer, for
+    // callers where focusing elsewhere doesn't mean the old buffer left the
+    // screen — i.e. the windowed canvas, which owns that lifecycle itself.
+    activate(
+      networkId: number | string | null,
+      target: string,
+      opts: { retainPrevious?: boolean } = {},
+    ) {
       const networks = useNetworksStore();
       // Resolve to the canonical open buffer first (case-insensitive): a DM
       // activated from a member-list nick, /query, the profile modal, or a
@@ -1000,23 +1033,7 @@ export const useBuffersStore = defineStore('buffers', {
       // (networkId null) and the usual `${networkId}::${target}` otherwise.
       const newKey = key(networkId, canonTarget);
       const prevKey = networks.activeKey;
-      if (prevKey && prevKey !== newKey) {
-        const prev = this.buffers[prevKey];
-        if (prev) {
-          prev.dividerAfterId = null;
-          prev.unread = 0;
-          prev.highlighted = 0;
-          prev.highlightsCapped = false;
-          // Carrying a detached slice across buffer switches gets weird fast
-          // (the user can't see the detach status on a buffer they aren't
-          // viewing, the live counter ticks invisibly, the next entry has
-          // to remember whether to render the slice or live). Drop it and
-          // wipe the slice on switch-away — re-entry then reseeds from
-          // snapshot or the next history fetch as if it were fresh.
-          if (prev.detached)
-            this.clearDetached(prev.networkId, prev.target, { wipeMessages: true });
-        }
-      }
+      if (!opts.retainPrevious && prevKey && prevKey !== newKey) this.leaveBuffer(prevKey);
       networks.setActive(networkId, canonTarget);
       const buf = ensureBuffer(this, networkId, canonTarget);
       // Snapshot the divider from the CURRENT lastReadId before we advance

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -77,17 +77,26 @@ export const useNetworksStore = defineStore('networks', {
           return { nick, state: 'offline', stateAt: null, awayMessage: null };
         return netState?.peerPresence?.[nick.toLowerCase()] ?? null;
       },
-    activeBuffer(state): ActiveBuffer | null {
-      if (!state.activeKey) return null;
-      // Virtual buffers (:system:, :friends:) use a flat sentinel key (no `::`).
-      // They have no IRC send target, so report "no IRC buffer active" — the
-      // views drive their own header/rendering. Friends still renders messages
-      // via buffers.byKey(activeKey) directly, not through this getter.
-      if (isVirtualKey(state.activeKey)) return null;
-      if (!state.activeKey.includes('::')) return null;
-      const [networkId, name] = state.activeKey.split('::');
-      const id = Number(networkId);
-      return { networkId: id, target: name, network: state.networks.find((n) => n.id === id) };
+    // Parse any buffer key into its (network, target) pair. Split out from
+    // activeBuffer so a view rendering a buffer OTHER than the active one (a
+    // windowed BufferPane) can resolve its own key through the same rules
+    // rather than re-implementing the `${networkId}::${target}` split.
+    bufferFor(state) {
+      return (key: string | null): ActiveBuffer | null => {
+        if (!key) return null;
+        // Virtual buffers (:system:, :friends:) use a flat sentinel key (no
+        // `::`). They have no IRC send target, so report "no IRC buffer" — the
+        // views drive their own header/rendering. Friends still renders
+        // messages via buffers.byKey(key) directly, not through this getter.
+        if (isVirtualKey(key)) return null;
+        if (!key.includes('::')) return null;
+        const [networkId, name] = key.split('::');
+        const id = Number(networkId);
+        return { networkId: id, target: name, network: state.networks.find((n) => n.id === id) };
+      };
+    },
+    activeBuffer(): ActiveBuffer | null {
+      return this.bufferFor(this.activeKey);
     },
   },
   actions: {

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -169,6 +169,12 @@ export const useNetworksStore = defineStore('networks', {
     activateVirtual(key: string) {
       this.activeKey = key;
     },
+    // No buffer on screen — the state a fresh load starts in. The windowed
+    // canvas returns here when the last window is closed or minimized, so that
+    // re-picking the same buffer in the sidebar is a change and re-opens it.
+    clearActive() {
+      this.activeKey = null;
+    },
     applySnapshot(networks: NetworkState[]) {
       const map: Record<number | string, NetworkState> = {};
       for (const snap of networks) map[snap.networkId] = snap;

--- a/vue_client/src/stores/windows.test.ts
+++ b/vue_client/src/stores/windows.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+import { useWindowsStore } from './windows.js';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe('open', () => {
+  it('cascades new windows so a fresh one never lands exactly on the last', () => {
+    const store = useWindowsStore();
+    const a = store.open('1::#a');
+    const b = store.open('1::#b');
+    expect([b.x, b.y]).not.toEqual([a.x, a.y]);
+  });
+
+  it('focuses an existing window rather than opening a second for the same buffer', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.open('1::#b');
+    expect(store.focusedKey).toBe('1::#b');
+
+    store.open('1::#a');
+    expect(store.windows).toHaveLength(2);
+    expect(store.focusedKey).toBe('1::#a');
+  });
+
+  it('un-minimizes a minimized window', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.minimize('1::#a');
+    expect(store.byKey('1::#a')?.state).toBe('minimized');
+
+    store.open('1::#a');
+    expect(store.byKey('1::#a')?.state).toBe('normal');
+    expect(store.focusedKey).toBe('1::#a');
+  });
+});
+
+describe('focusedKey', () => {
+  it('is the highest-z window that is not minimized', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.open('1::#b');
+    expect(store.focusedKey).toBe('1::#b');
+
+    store.focus('1::#a');
+    expect(store.focusedKey).toBe('1::#a');
+  });
+
+  it('skips minimized windows, so minimizing the top one hands focus down', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.open('1::#b');
+    store.minimize('1::#b');
+    expect(store.focusedKey).toBe('1::#a');
+  });
+
+  // The canvas keys "no active buffer" off this, which is what lets a sidebar
+  // click on the same buffer re-open its window.
+  it('is null when every window is minimized or closed', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.minimize('1::#a');
+    expect(store.focusedKey).toBeNull();
+
+    store.restore('1::#a');
+    store.close('1::#a');
+    expect(store.focusedKey).toBeNull();
+  });
+});
+
+// The frames render at `calc(var(--z-window) + z)`. A monotonically increasing
+// z would eventually cross --z-modal and paint windows over modals, so z must
+// stay dense in 1..N no matter how much the user clicks around.
+describe('z stays bounded by the window count', () => {
+  it('does not grow with focus churn', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.open('1::#b');
+    for (let i = 0; i < 50; i++) {
+      store.focus(i % 2 === 0 ? '1::#a' : '1::#b');
+    }
+    expect(store.windows.map((w) => w.z).sort()).toEqual([1, 2]);
+  });
+
+  it('stays dense after a close', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.open('1::#b');
+    store.open('1::#c');
+    store.close('1::#b');
+    expect(store.windows.map((w) => w.z)).toEqual([1, 2]);
+  });
+
+  it('orders z so the focused window is on top', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.open('1::#b');
+    store.focus('1::#a');
+    const a = store.byKey('1::#a')!;
+    const b = store.byKey('1::#b')!;
+    expect(a.z).toBeGreaterThan(b.z);
+  });
+});
+
+describe('resize', () => {
+  it('clamps to the minimum size rather than inverting the frame', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.resize('1::#a', 10, 10);
+    const win = store.byKey('1::#a')!;
+    expect(win.w).toBeGreaterThan(10);
+    expect(win.h).toBeGreaterThan(10);
+  });
+
+  it('is a no-op on a maximized window, which owns the canvas', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.toggleMaximize('1::#a');
+    const before = { ...store.byKey('1::#a')! };
+    store.resize('1::#a', 300, 300);
+    store.move('1::#a', 50, 50);
+    const after = store.byKey('1::#a')!;
+    expect([after.w, after.h, after.x, after.y]).toEqual([before.w, before.h, before.x, before.y]);
+  });
+});
+
+describe('toggleMaximize', () => {
+  it('restores the pre-maximize geometry', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.move('1::#a', 40, 60);
+    store.resize('1::#a', 500, 300);
+
+    store.toggleMaximize('1::#a');
+    expect(store.byKey('1::#a')?.state).toBe('maximized');
+
+    store.toggleMaximize('1::#a');
+    const win = store.byKey('1::#a')!;
+    expect(win.state).toBe('normal');
+    expect([win.x, win.y, win.w, win.h]).toEqual([40, 60, 500, 300]);
+  });
+
+  // Maximize is a state flag, not a geometry rewrite — the frame's inset comes
+  // from CSS. So a round trip through any starting state leaves x/y/w/h intact.
+  it('leaves geometry intact across a maximize round trip from minimized', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.move('1::#a', 40, 60);
+    store.resize('1::#a', 500, 300);
+    store.minimize('1::#a');
+
+    store.toggleMaximize('1::#a');
+    store.toggleMaximize('1::#a');
+    const win = store.byKey('1::#a')!;
+    expect([win.x, win.y, win.w, win.h]).toEqual([40, 60, 500, 300]);
+  });
+});
+
+describe('clampTo', () => {
+  it('keeps a grabbable strip of every window inside a shrunken canvas', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.move('1::#a', 900, 700);
+
+    store.clampTo(400, 300);
+    const win = store.byKey('1::#a')!;
+    expect(win.x).toBeLessThanOrEqual(400);
+    expect(win.y).toBeLessThanOrEqual(300);
+    expect(win.x).toBeGreaterThanOrEqual(0);
+    expect(win.y).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/vue_client/src/stores/windows.test.ts
+++ b/vue_client/src/stores/windows.test.ts
@@ -106,6 +106,25 @@ describe('z stays bounded by the window count', () => {
     const b = store.byKey('1::#b')!;
     expect(a.z).toBeGreaterThan(b.z);
   });
+
+  // The canvas renders a keyed v-for over `windows`. If focusing reordered the
+  // array, Vue would move the frame's DOM node, and moving a node releases its
+  // pointer capture — killing the drag that raised the window in the first
+  // place. Stacking must live in z alone.
+  it('never reorders the array, so the frame DOM node is not moved', () => {
+    const store = useWindowsStore();
+    store.open('1::#a');
+    store.open('1::#b');
+    store.open('1::#c');
+    const order = store.windows.map((w) => w.key);
+
+    store.focus('1::#a');
+    store.focus('1::#c');
+    store.focus('1::#b');
+
+    expect(store.windows.map((w) => w.key)).toEqual(order);
+    expect(store.visible.map((w) => w.key)).toEqual(order);
+  });
 });
 
 describe('resize', () => {

--- a/vue_client/src/stores/windows.ts
+++ b/vue_client/src/stores/windows.ts
@@ -38,10 +38,12 @@ const CASCADE_WRAP = 8;
 
 export const useWindowsStore = defineStore('windows', {
   state: () => ({
+    // Array order IS stacking order: last element is on top. Focusing moves a
+    // window to the end and renumbers, which keeps z dense (1..N) rather than
+    // monotonically increasing. That matters because the frames render at
+    // `calc(var(--z-window) + z)` — a counter that climbed with every click
+    // would eventually cross --z-modal and paint windows over modals.
     windows: [] as BufferWindow[],
-    // Monotonic. The focused window is simply the one with the highest z, so
-    // focusing is a single assignment rather than a re-index of the stack.
-    topZ: 0,
     // How many windows have been opened, for cascade placement.
     opened: 0,
   }),
@@ -53,14 +55,13 @@ export const useWindowsStore = defineStore('windows', {
     // hidden pane mounted would cost a full DOM tree per minimized buffer.
     visible: (state) => state.windows.filter((w) => w.state !== 'minimized'),
     minimized: (state) => state.windows.filter((w) => w.state === 'minimized'),
-    // Highest-z visible window: the one the shortcuts and stray clicks act on.
+    // Topmost visible window: the one the shortcuts and stray clicks act on.
     focusedKey(state): string | null {
-      let best: BufferWindow | null = null;
-      for (const w of state.windows) {
-        if (w.state === 'minimized') continue;
-        if (!best || w.z > best.z) best = w;
+      for (let i = state.windows.length - 1; i >= 0; i--) {
+        const w = state.windows[i];
+        if (w.state !== 'minimized') return w.key;
       }
-      return best?.key ?? null;
+      return null;
     },
   },
   actions: {
@@ -79,7 +80,7 @@ export const useWindowsStore = defineStore('windows', {
         y: CASCADE_STEP * step,
         w: DEFAULT_W,
         h: DEFAULT_H,
-        z: ++this.topZ,
+        z: this.windows.length + 1,
         state: 'normal',
         restore: null,
       };
@@ -90,13 +91,20 @@ export const useWindowsStore = defineStore('windows', {
     close(key: string): void {
       const idx = this.windows.findIndex((w) => w.key === key);
       if (idx >= 0) this.windows.splice(idx, 1);
+      this.renumber();
     },
     focus(key: string): void {
-      const win = this.byKey(key);
-      if (!win) return;
-      // Already on top — don't burn a z or dirty the store on every click.
-      if (win.z === this.topZ) return;
-      win.z = ++this.topZ;
+      const idx = this.windows.findIndex((w) => w.key === key);
+      // Already on top — don't dirty the store on every click.
+      if (idx < 0 || idx === this.windows.length - 1) return;
+      const [win] = this.windows.splice(idx, 1);
+      this.windows.push(win);
+      this.renumber();
+    },
+    renumber(): void {
+      this.windows.forEach((w, i) => {
+        w.z = i + 1;
+      });
     },
     move(key: string, x: number, y: number): void {
       const win = this.byKey(key);

--- a/vue_client/src/stores/windows.ts
+++ b/vue_client/src/stores/windows.ts
@@ -38,9 +38,13 @@ const CASCADE_WRAP = 8;
 
 export const useWindowsStore = defineStore('windows', {
   state: () => ({
-    // Array order IS stacking order: last element is on top. Focusing moves a
-    // window to the end and renumbers, which keeps z dense (1..N) rather than
-    // monotonically increasing. That matters because the frames render at
+    // Insertion order, and it must STAY insertion order: the canvas renders a
+    // keyed v-for over this array, and reordering it makes Vue move the frame's
+    // DOM node. Moving a node implicitly releases its pointer capture, which
+    // would kill the very drag that raised the window.
+    //
+    // Stacking therefore lives in `z`, kept dense in 1..N (1 = bottom). Dense
+    // rather than a monotonic counter because the frames render at
     // `calc(var(--z-window) + z)` — a counter that climbed with every click
     // would eventually cross --z-modal and paint windows over modals.
     windows: [] as BufferWindow[],
@@ -55,13 +59,14 @@ export const useWindowsStore = defineStore('windows', {
     // hidden pane mounted would cost a full DOM tree per minimized buffer.
     visible: (state) => state.windows.filter((w) => w.state !== 'minimized'),
     minimized: (state) => state.windows.filter((w) => w.state === 'minimized'),
-    // Topmost visible window: the one the shortcuts and stray clicks act on.
+    // Highest-z visible window: the one the shortcuts and stray clicks act on.
     focusedKey(state): string | null {
-      for (let i = state.windows.length - 1; i >= 0; i--) {
-        const w = state.windows[i];
-        if (w.state !== 'minimized') return w.key;
+      let best: BufferWindow | null = null;
+      for (const w of state.windows) {
+        if (w.state === 'minimized') continue;
+        if (!best || w.z > best.z) best = w;
       }
-      return null;
+      return best?.key ?? null;
     },
   },
   actions: {
@@ -90,21 +95,24 @@ export const useWindowsStore = defineStore('windows', {
     },
     close(key: string): void {
       const idx = this.windows.findIndex((w) => w.key === key);
-      if (idx >= 0) this.windows.splice(idx, 1);
-      this.renumber();
+      if (idx < 0) return;
+      const gone = this.windows[idx].z;
+      this.windows.splice(idx, 1);
+      // Close the hole so z stays dense.
+      for (const w of this.windows) if (w.z > gone) w.z -= 1;
     },
+    // Raise to the top of the stack by rewriting z, never by reordering the
+    // array (see the `windows` state comment). Everything that was above the
+    // window drops one rung; it takes the top rung.
     focus(key: string): void {
-      const idx = this.windows.findIndex((w) => w.key === key);
+      const win = this.byKey(key);
+      if (!win) return;
+      const top = this.windows.length;
       // Already on top — don't dirty the store on every click.
-      if (idx < 0 || idx === this.windows.length - 1) return;
-      const [win] = this.windows.splice(idx, 1);
-      this.windows.push(win);
-      this.renumber();
-    },
-    renumber(): void {
-      this.windows.forEach((w, i) => {
-        w.z = i + 1;
-      });
+      if (win.z === top) return;
+      const from = win.z;
+      for (const w of this.windows) if (w.z > from) w.z -= 1;
+      win.z = top;
     },
     move(key: string, x: number, y: number): void {
       const win = this.byKey(key);

--- a/vue_client/src/stores/windows.ts
+++ b/vue_client/src/stores/windows.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineStore } from 'pinia';
+
+// Windowed-buffer geometry and stacking, for the mIRC-style canvas
+// (look.layout.windowed). One entry per open window, keyed by buffer.
+//
+// Deliberately client-only and un-persisted for now: this is a prototype, and
+// where a window sits is a property of a screen, not of an account. Persisting
+// it means deciding what happens when the same account opens a second browser
+// at a different size, which is a real design question and not this layer's.
+//
+// Coordinates are pixels relative to the canvas's top-left, not the viewport,
+// so the canvas can be positioned however the shell likes.
+export type WindowState = 'normal' | 'minimized' | 'maximized';
+
+export interface BufferWindow {
+  key: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  z: number;
+  state: WindowState;
+  // Geometry to restore to when un-maximizing. Captured at maximize time.
+  restore: { x: number; y: number; w: number; h: number } | null;
+}
+
+const DEFAULT_W = 640;
+const DEFAULT_H = 420;
+const MIN_W = 260;
+const MIN_H = 160;
+// New windows step down-right from the origin so a fresh one never lands
+// exactly on the last, then wrap before they march off the canvas.
+const CASCADE_STEP = 28;
+const CASCADE_WRAP = 8;
+
+export const useWindowsStore = defineStore('windows', {
+  state: () => ({
+    windows: [] as BufferWindow[],
+    // Monotonic. The focused window is simply the one with the highest z, so
+    // focusing is a single assignment rather than a re-index of the stack.
+    topZ: 0,
+    // How many windows have been opened, for cascade placement.
+    opened: 0,
+  }),
+  getters: {
+    byKey: (state) => (key: string) => state.windows.find((w) => w.key === key) ?? null,
+    isOpen: (state) => (key: string) => state.windows.some((w) => w.key === key),
+    // Windows that should render a pane. A minimized window keeps its geometry
+    // but unmounts its BufferPane — with no virtualized message list, keeping a
+    // hidden pane mounted would cost a full DOM tree per minimized buffer.
+    visible: (state) => state.windows.filter((w) => w.state !== 'minimized'),
+    minimized: (state) => state.windows.filter((w) => w.state === 'minimized'),
+    // Highest-z visible window: the one the shortcuts and stray clicks act on.
+    focusedKey(state): string | null {
+      let best: BufferWindow | null = null;
+      for (const w of state.windows) {
+        if (w.state === 'minimized') continue;
+        if (!best || w.z > best.z) best = w;
+      }
+      return best?.key ?? null;
+    },
+  },
+  actions: {
+    // Open (or focus, if already open) a window for a buffer. Returns it.
+    open(key: string): BufferWindow {
+      const existing = this.byKey(key);
+      if (existing) {
+        if (existing.state === 'minimized') existing.state = 'normal';
+        this.focus(key);
+        return existing;
+      }
+      const step = this.opened % CASCADE_WRAP;
+      const win: BufferWindow = {
+        key,
+        x: CASCADE_STEP * step,
+        y: CASCADE_STEP * step,
+        w: DEFAULT_W,
+        h: DEFAULT_H,
+        z: ++this.topZ,
+        state: 'normal',
+        restore: null,
+      };
+      this.opened += 1;
+      this.windows.push(win);
+      return win;
+    },
+    close(key: string): void {
+      const idx = this.windows.findIndex((w) => w.key === key);
+      if (idx >= 0) this.windows.splice(idx, 1);
+    },
+    focus(key: string): void {
+      const win = this.byKey(key);
+      if (!win) return;
+      // Already on top — don't burn a z or dirty the store on every click.
+      if (win.z === this.topZ) return;
+      win.z = ++this.topZ;
+    },
+    move(key: string, x: number, y: number): void {
+      const win = this.byKey(key);
+      if (!win || win.state === 'maximized') return;
+      win.x = x;
+      win.y = y;
+    },
+    resize(key: string, w: number, h: number): void {
+      const win = this.byKey(key);
+      if (!win || win.state === 'maximized') return;
+      win.w = Math.max(MIN_W, w);
+      win.h = Math.max(MIN_H, h);
+    },
+    minimize(key: string): void {
+      const win = this.byKey(key);
+      if (win) win.state = 'minimized';
+    },
+    // Toggle: maximized -> normal, anything else -> maximized. Stashes the
+    // pre-maximize geometry so restore puts it back where the user left it.
+    toggleMaximize(key: string): void {
+      const win = this.byKey(key);
+      if (!win) return;
+      if (win.state === 'maximized') {
+        if (win.restore) Object.assign(win, win.restore);
+        win.restore = null;
+        win.state = 'normal';
+      } else {
+        if (win.state === 'normal') win.restore = { x: win.x, y: win.y, w: win.w, h: win.h };
+        win.state = 'maximized';
+      }
+      this.focus(key);
+    },
+    restore(key: string): void {
+      const win = this.byKey(key);
+      if (!win) return;
+      if (win.state === 'maximized' && win.restore) {
+        Object.assign(win, win.restore);
+        win.restore = null;
+      }
+      win.state = 'normal';
+      this.focus(key);
+    },
+    // Keep windows reachable when the canvas shrinks: clamp origins so at least
+    // a strip of titlebar stays grabbable inside the new bounds. Not a re-tile —
+    // a window the user placed deliberately should stay where they put it.
+    clampTo(width: number, height: number): void {
+      const GRAB = 80;
+      for (const win of this.windows) {
+        win.x = Math.max(0, Math.min(win.x, Math.max(0, width - GRAB)));
+        win.y = Math.max(0, Math.min(win.y, Math.max(0, height - GRAB)));
+      }
+    },
+  },
+});
+
+export const WINDOW_MIN_W = MIN_W;
+export const WINDOW_MIN_H = MIN_H;

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -147,8 +147,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
-import type { Network } from '../stores/networks.js';
-import { useBuffersStore, type Buffer } from '../stores/buffers.js';
+import { useBuffersStore } from '../stores/buffers.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { useSocket } from '../composables/useSocket.js';
 import { useNetworksStore } from '../stores/networks.js';
@@ -400,6 +399,9 @@ useChatBootstrap({ onJump: onJumpToMessage });
   --sidebar-w: 220px;
   display: grid;
   grid-template-columns: var(--sidebar-w) 1fr;
+  /* Explicit 1fr rather than an implicit auto row: the pane and canvas both
+     need a definite height to size their own scrollers against. */
+  grid-template-rows: 1fr;
   grid-template-areas: 'sidebar content';
   /* Height sized to the dynamic viewport. iOS scrolls the page
      naturally when the keyboard opens; the input row at the bottom

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -4,15 +4,7 @@
 -->
 
 <template>
-  <div
-    class="chat"
-    :class="{
-      'sidebar-collapsed': !showChannels,
-      'members-collapsed': !showMembers,
-      'system-active': isSystemBuffer,
-    }"
-    @click="onChatClick"
-  >
+  <div class="chat" :class="{ 'sidebar-collapsed': !showChannels }" @click="onChatClick">
     <aside class="sidebar" :class="{ collapsed: !showChannels }">
       <!-- The "lurker" header + connection dot live in BufferList's LURKER row
            (#355); the collapse control lives there too. When collapsed the list
@@ -69,169 +61,28 @@
       </div>
     </aside>
 
-    <!-- Topic bar: always rendered so the back/forward history controls (#411)
-         are present in every state, even before any buffer is selected. The nav
-         cluster is anchored at the far left, left of the buffer title; the meta
-         (name + topic) and per-buffer actions render conditionally beside it. -->
-    <header class="topic">
-      <div class="topic-nav">
-        <button
-          type="button"
-          class="link nav-btn"
-          title="Back"
-          aria-label="Back"
-          :disabled="!navHistory.canBack"
-          @click="navHistory.back()"
-        >
-          <i class="fa-solid fa-angle-left"></i>
-        </button>
-        <button
-          type="button"
-          class="link nav-btn"
-          title="Forward"
-          aria-label="Forward"
-          :disabled="!navHistory.canForward"
-          @click="navHistory.forward()"
-        >
-          <i class="fa-solid fa-angle-right"></i>
-        </button>
-      </div>
-      <div class="topic-meta">
-        <span v-if="isVirtual || active" class="buffer">{{ bufferLabel }}</span>
-        <template v-if="active && topic">
-          <button
-            type="button"
-            class="topic-text"
-            title="View full topic"
-            @click="showTopic = true"
-          >
-            <LinkedText :text="topic" />
-          </button>
-        </template>
-      </div>
-      <div class="topic-actions">
-        <template v-if="isVirtual">
-          <template v-if="isFriendsBuffer">
-            <button
-              type="button"
-              class="link"
-              title="Add friend"
-              aria-label="Add friend"
-              @click="friends.openEditorNew()"
-            >
-              <i class="fa-solid fa-person-circle-plus"></i>
-            </button>
-            <span
-              class="member-count"
-              :title="`${friendCount} ${friendCount === 1 ? 'friend' : 'friends'}`"
-            >
-              <i class="fa-solid fa-users"></i> {{ friendCount }}
-            </span>
-          </template>
-        </template>
-        <template v-else-if="active">
-          <!-- Search & highlights scoped to this buffer (channels/DMs only) —
-               parity with the mobile topic bar. The server buffer has no
-               per-buffer scope, so it's excluded. -->
-          <template v-if="!isServerBuffer">
-            <button
-              type="button"
-              class="link"
-              title="Search this buffer"
-              aria-label="Search this buffer"
-              @click="openSearch(true)"
-            >
-              <i class="fa-solid fa-magnifying-glass"></i>
-            </button>
-            <button
-              type="button"
-              class="link"
-              title="Highlights in this buffer"
-              aria-label="Highlights in this buffer"
-              @click="openHighlights(true)"
-            >
-              <i class="fa-regular fa-bell"></i>
-            </button>
-          </template>
-          <template v-if="isServerBuffer">
-            <button
-              type="button"
-              class="link"
-              title="Join channel"
-              aria-label="Join channel"
-              :disabled="serverConnectionState !== 'connected'"
-              @click="active && joinChannelModal.open(active.networkId)"
-            >
-              <i class="fa-solid fa-plus"></i>
-            </button>
-            <button
-              type="button"
-              class="link"
-              title="Channel list"
-              aria-label="Channel list"
-              @click="active && channelListModal.open(active.networkId)"
-            >
-              <i class="fa-solid fa-hashtag"></i>
-            </button>
-            <button
-              type="button"
-              class="link"
-              :title="serverConnectActionLabel"
-              :aria-label="serverConnectActionLabel"
-              @click="toggleServerConnection"
-            >
-              <i :class="serverConnectActionIcon"></i>
-            </button>
-            <button class="link" title="Edit network" @click="editActiveNetwork">
-              <i class="fa-solid fa-gear"></i>
-            </button>
-          </template>
-          <template v-else-if="isDmHeader">
-            <button
-              type="button"
-              class="link"
-              title="View profile"
-              aria-label="View profile"
-              @click="openDmProfile"
-            >
-              <i class="fa-solid fa-id-card"></i>
-            </button>
-            <button
-              type="button"
-              class="link"
-              :title="dmNoteLabel"
-              :aria-label="dmNoteLabel"
-              @click="openDmNote"
-            >
-              <i class="fa-solid fa-note-sticky"></i>
-            </button>
-          </template>
-          <template v-else-if="isChannel">
-            <button
-              class="link"
-              :title="showMembers ? 'Hide members' : 'Show members'"
-              :aria-label="showMembers ? 'Hide members' : 'Show members'"
-              @click="toggleMembers"
-            >
-              <i class="fa-solid fa-users"></i>
-            </button>
-            <span
-              v-if="memberCount != null"
-              class="member-count"
-              :title="`${memberCount} ${memberCount === 1 ? 'user' : 'users'} in channel`"
-              >{{ memberCount }}</span
-            >
-          </template>
-        </template>
-      </div>
-    </header>
-    <div class="topic-divider"></div>
-
-    <FriendsOverview v-if="renderMode === 'overview'" @view-activity="onViewActivity" />
-    <MessageList v-else ref="messageListRef" :pending-scroll-id="pendingScrollId" />
-    <MemberList v-if="showMembers && hasNicklist" />
-    <StatusBar />
-    <MessageInput v-if="hasInput" ref="messageInputRef" />
+    <!-- The whole content area right of the sidebar. In classic mode that's one
+         maximized pane; the windowed canvas (behind look.layout.windowed) puts
+         several in draggable frames instead. -->
+    <WindowCanvas
+      v-if="windowed"
+      class="canvas"
+      :pending-scroll-id="pendingScrollId"
+      @open-search="openSearch"
+      @open-highlights="openHighlights"
+      @show-topic="showTopic = true"
+      @view-activity="onViewActivity"
+    />
+    <BufferPane
+      v-else
+      class="pane"
+      :buffer-key="networks.activeKey"
+      :pending-scroll-id="pendingScrollId"
+      @open-search="openSearch"
+      @open-highlights="openHighlights"
+      @show-topic="showTopic = true"
+      @view-activity="onViewActivity"
+    />
 
     <NetworkForm
       v-if="networkEditor.isOpen"
@@ -308,15 +159,11 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useConfigStore } from '../stores/config.js';
 import BufferList from '../components/BufferList.vue';
-import MessageList from '../components/MessageList.vue';
-import FriendsOverview from '../components/FriendsOverview.vue';
-import MessageInput from '../components/MessageInput.vue';
-import MemberList from '../components/MemberList.vue';
-import StatusBar from '../components/StatusBar.vue';
+import BufferPane from '../components/BufferPane.vue';
+import WindowCanvas from '../components/WindowCanvas.vue';
 import NetworkForm from '../components/NetworkForm.vue';
 import HighlightsModal from '../components/HighlightsModal.vue';
 import BookmarksModal from '../components/BookmarksModal.vue';
-import LinkedText from '../components/LinkedText.vue';
 import TopicModal from '../components/TopicModal.vue';
 import ChannelListModal from '../components/ChannelListModal.vue';
 import JoinChannelModal from '../components/JoinChannelModal.vue';
@@ -330,7 +177,6 @@ import ConfigureFriendModal from '../components/ConfigureFriendModal.vue';
 import UserProfileModal from '../components/UserProfileModal.vue';
 import ImageViewerModal from '../components/ImageViewerModal.vue';
 import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts.js';
-import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useFriendsStore } from '../stores/friends.js';
 import { useDccStore } from '../stores/dcc.js';
@@ -340,7 +186,7 @@ import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
 import { useImageModal } from '../composables/useImageModal.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
-import { useNavHistoryStore } from '../stores/navHistory.js';
+import { paneFor } from '../composables/usePaneRegistry.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -358,28 +204,16 @@ useSocket();
 onMounted(() => {
   if (networks.activeKey == null) buffers.activate(null, SYSTEM_KEY);
 });
-const {
-  active,
-  activeBuf,
-  topic,
-  isServerBuffer,
-  isChannel,
-  bufferLabel,
-  isSystemBuffer,
-  isVirtual,
-  isFriendsBuffer,
-  renderMode,
-  hasInput,
-  hasNicklist,
-} = useActiveBuffer();
+// The shell still tracks the active buffer for the modals it owns (topic,
+// scoped search) and for the keyboard shortcuts, which target whichever pane
+// has focus. The pane itself resolves its buffer from its own prop.
+const { active, topic, bufferLabel } = useActiveBuffer();
 
 const settings = useSettingsStore();
 const auth = useAuthStore();
 const config = useConfigStore();
-const nicklistCollapse = useNicklistCollapseStore();
 const nickNotes = useNickNotesStore();
 const friends = useFriendsStore();
-const friendCount = computed(() => friends.contacts.length);
 const dcc = useDccStore();
 const dccTitle = computed(() =>
   dcc.pendingCount > 0 ? `DCC transfers — ${dcc.pendingCount} awaiting approval` : 'DCC transfers',
@@ -390,7 +224,6 @@ const channelListModal = reactive(useChannelListModal());
 const joinChannelModal = reactive(useJoinChannelModal());
 const imageModal = reactive(useImageModal());
 const networkEditor = reactive(useNetworkEditor());
-const navHistory = useNavHistoryStore();
 const showBookmarks = ref(false);
 const showTopic = ref(false);
 const showUploads = ref(false);
@@ -409,8 +242,11 @@ const {
   openHighlights,
   onViewActivity,
 } = useBufferSearchScope();
-const messageInputRef = ref<{ focus: () => void } | null>(null);
-const messageListRef = ref<{ scrollByPage: (dir: number) => void } | null>(null);
+// The pane the keyboard and stray-click handlers act on: whichever one is
+// showing the active buffer. With a single maximized pane that's the only one;
+// with windows it's the focused window, since focusing a window is what makes
+// its buffer active.
+const focusedPane = () => paneFor(networks.activeKey);
 
 // Any modal open? Type-ahead must not steal focus from a modal's own fields.
 const anyModalOpen = computed(
@@ -441,11 +277,11 @@ useKeyboardShortcuts({
   },
   onTypeAhead: () => {
     if (anyModalOpen.value || !active.value) return;
-    messageInputRef.value?.focus();
+    focusedPane()?.focusInput();
   },
   onScrollMessages: (dir) => {
     if (anyModalOpen.value) return;
-    messageListRef.value?.scrollByPage(dir);
+    focusedPane()?.scrollByPage(dir);
   },
 });
 
@@ -495,70 +331,23 @@ watch(showChannels, async (open) => {
 });
 onMounted(measureFootWrap);
 
-// True when the active buffer is a DM (not a channel, not the network's
-// server buffer). Drives the clickable DM header that opens the user
-// profile modal — channel headers stay non-interactive.
-const isDmHeader = computed(() => {
-  if (!active.value) return false;
-  if (isChannel.value || isServerBuffer.value) return false;
-  return true;
-});
-function openDmProfile() {
-  if (!active.value) return;
-  whois.openViewer(active.value.networkId, active.value.target);
-}
-// DM note button — mirrors the old context-menu entry, surfaced inline so the
-// per-peer note is one click from the conversation. Label flips once a note
-// exists so the button doubles as a "has a note" tell.
-const dmNoteLabel = computed(() =>
-  active.value && nickNotes.hasNote(active.value.networkId, active.value.target)
-    ? 'Edit note'
-    : 'Add note',
-);
-function openDmNote() {
-  if (!active.value) return;
-  nickNotes.openEditor(active.value.networkId, active.value.target);
-}
-
 // Channel notification level (always/highlights/nothing/muted) now lives in the
 // buffer context-menu ladder (right-click the sidebar row, or the topic-bar cog),
 // so there is no dedicated topic-bar bell anymore (issue #359).
 
-// User count for the active channel buffer. Sits in the topic bar (next to
-// the members-toggle button) rather than the status bar — the count is a
-// property of the channel, so the channel header is the natural home.
-const memberCount = computed(() => {
-  if (!isChannel.value) return null;
-  return (activeBuf.value as Buffer | null)?.members?.length ?? null;
-});
-
-// Per-channel nicklist visibility. A channel the user has explicitly toggled
-// carries an override (true = collapsed); otherwise the global
-// look.layout.show_member_list default applies. DMs and server buffers have no
-// member list at all, so the toggle and panel are hidden for them entirely.
-const showMembers = computed(() => {
-  if (!isChannel.value || !active.value) return false;
-  const { networkId, target } = active.value;
-  const override = nicklistCollapse.override(networkId, target);
-  if (override !== undefined) return !override;
-  return settings.effective('look.layout.show_member_list');
-});
+// mIRC-style windowed buffers on the canvas right of the sidebar, instead of one
+// maximized pane. Opt-in and experimental.
+const windowed = computed(() => settings.effective('look.layout.windowed') === true);
 
 function toggleChannels() {
   settings.setValue('look.layout.show_channel_list', !showChannels.value);
 }
-function toggleMembers() {
-  if (!isChannel.value || !active.value) return;
-  const { networkId, target } = active.value;
-  // Pass the current visibility through as the new collapsed flag — it flips.
-  nicklistCollapse.setCollapsed(networkId, target, !!showMembers.value);
-}
 
 // Forward stray clicks anywhere in the chat frame (topic bar, message list,
-// member list, sidebar gutter, etc.) into the message input. The selector
-// excludes anything genuinely interactive — buttons, links, form controls,
-// and modal contents — and we bail if the user is in the middle of selecting
-// text so we don't kill their selection.
+// member list, sidebar gutter, etc.) into the focused pane's message input. The
+// selector excludes anything genuinely interactive — buttons, links, form
+// controls, and modal contents — and we bail if the user is in the middle of
+// selecting text so we don't kill their selection.
 function onChatClick(e: MouseEvent) {
   if (
     (e.target as Element).closest(
@@ -568,7 +357,7 @@ function onChatClick(e: MouseEvent) {
     return;
   const sel = window.getSelection();
   if (sel && sel.toString().length > 0) return;
-  messageInputRef.value?.focus();
+  focusedPane()?.focusInput();
 }
 
 const onJumpToMessage = useJumpToMessage({ pendingScrollId });
@@ -597,70 +386,21 @@ function closeNetworkForm() {
   networkEditor.close();
 }
 
-function editActiveNetwork() {
-  const net = active.value?.network as Network | undefined;
-  if (net) networkEditor.open(net);
-}
-
-// State-aware connect/disconnect for the server buffer header. We label the
-// button "Disconnect" only while we're confidently connected; every other
-// state (idle, connecting, reconnecting, disconnected, unknown) reads as
-// "Reconnect" because the action — fire a fresh connect — is the same in
-// each case, and "Reconnect" is what the user reaches for when something
-// looks stuck.
-const serverConnectionState = computed(() => {
-  if (!active.value || !isServerBuffer.value) return null;
-  return networks.states[active.value.networkId]?.state ?? null;
-});
-const serverConnectActionLabel = computed(() =>
-  serverConnectionState.value === 'connected' ? 'Disconnect' : 'Reconnect',
-);
-const serverConnectActionIcon = computed(() =>
-  serverConnectionState.value === 'connected'
-    ? 'fa-solid fa-plug-circle-xmark'
-    : 'fa-solid fa-plug',
-);
-function toggleServerConnection() {
-  if (!active.value) return;
-  const id = active.value.networkId;
-  // Fire-and-forget — the button's label is driven by networks.states so
-  // success reflects itself. A failed call stays observable via the state
-  // (label doesn't flip), so we just log and let the user retry rather
-  // than wiring a toast through the topic bar for this case.
-  const p =
-    serverConnectionState.value === 'connected' ? networks.disconnect(id) : networks.reconnect(id);
-  p.catch((err) => console.error('[DesktopChat] toggle server connection failed', err));
-}
-
 useChatBootstrap({ onJump: onJumpToMessage });
 </script>
 
 <style scoped>
-/* WeeChat-style frame: the sidebar runs full height on the left; the topic
-   and input bars span the full width to the right of it; and the message
-   list + nicklist sit between them.
+/* WeeChat-style frame: the sidebar runs full height on the left, and everything
+   right of it is the content area — either one maximized BufferPane (which owns
+   its own topic/messages/members/status/input grid) or the windowed canvas.
 
-   The sidebar and member-list columns are sized via CSS custom properties
-   so the .sidebar-collapsed / .members-collapsed modifier classes can shrink
-   either side to a 36px rail without touching the rest of the grid. */
+   The sidebar column is sized via a CSS custom property so .sidebar-collapsed
+   can shrink it to a 36px rail without touching the rest of the grid. */
 .chat {
   --sidebar-w: 220px;
-  --members-w: 180px;
   display: grid;
-  grid-template-columns: var(--sidebar-w) 1fr var(--members-w);
-  /* The 1px row owns the topic/messages divider as its own grid track,
-     outside the scroll container. Putting the line inside .message-list
-     (border-top, inset box-shadow) lets row backgrounds and hover states
-     paint over it as content scrolls past — the line appears to be eaten
-     by the scrolling rows. A dedicated row sits between the two children
-     and nothing can paint on top of it. */
-  grid-template-rows: auto auto 1fr auto auto;
-  grid-template-areas:
-    'sidebar topic    topic'
-    'sidebar divider  divider'
-    'sidebar messages members'
-    'sidebar status   status'
-    'sidebar input    input';
+  grid-template-columns: var(--sidebar-w) 1fr;
+  grid-template-areas: 'sidebar content';
   /* Height sized to the dynamic viewport. iOS scrolls the page
      naturally when the keyboard opens; the input row at the bottom
      stays visible above the keyboard, and the upper portion (sidebar,
@@ -672,26 +412,14 @@ useChatBootstrap({ onJump: onJumpToMessage });
 .chat.sidebar-collapsed {
   --sidebar-w: 36px;
 }
-/* Members column fully collapses — no rail. The reopen toggle lives in the
-   topic bar on the right, so there's nothing to leave behind. */
-.chat.members-collapsed {
-  --members-w: 0px;
-}
-/* System console has no member list — collapse the rail so the log pane
-   spans the full content width instead of leaving an empty column. */
-.chat.system-active {
-  --members-w: 0px;
-}
-/* The status bar carries the separator border above the input, but it's hidden
-   in the system buffer (no network state to show). Give the input its own top
-   border there so it stays visually divided from the message list. */
-.chat.system-active .input {
-  border-top: 1px solid var(--border);
-}
 /* min-height/min-width 0 lets flex/scrolling children stay inside their row. */
 .chat > * {
   min-width: 0;
   min-height: 0;
+}
+.pane,
+.canvas {
+  grid-area: content;
 }
 
 .sidebar {
@@ -794,108 +522,5 @@ useChatBootstrap({ onJump: onJumpToMessage });
    (0,3,0) beats the global `button:hover:not(:disabled)` (0,2,1). */
 .rail-toggle:hover:not(:disabled) {
   border-color: var(--border);
-}
-
-.topic {
-  grid-area: topic;
-  padding: var(--space-4) var(--space-6);
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-4);
-  white-space: nowrap;
-  overflow: hidden;
-}
-/* Back/forward history controls (#411), anchored at the far left of the bar,
-   left of the buffer title. Same accent icon buttons as the rest of the bar;
-   disabled (dimmed, non-interactive) when there's nowhere to go that way. */
-.topic-nav {
-  display: flex;
-  align-items: baseline;
-  /* Match .topic-actions' gap so the back/forward pair is spaced like every
-     other button pair in the bar, not tighter. */
-  gap: var(--space-4);
-  flex-shrink: 0;
-}
-.nav-btn:disabled {
-  opacity: 0.35;
-  cursor: default;
-}
-.nav-btn:disabled:hover {
-  color: var(--accent);
-}
-.topic-divider {
-  grid-area: divider;
-  background: var(--border);
-  height: 1px;
-}
-.topic .buffer {
-  color: var(--accent);
-}
-.topic .topic-text {
-  color: var(--fg-muted);
-  text-overflow: ellipsis;
-  overflow: hidden;
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-  white-space: nowrap;
-  min-width: 0;
-}
-.topic .topic-text:hover {
-  color: var(--fg);
-}
-.topic .topic-text:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
-}
-
-/* These selectors target the root elements of the imported components.
-   Vue 3 scoped CSS attaches the parent's data-v attribute to a child
-   component's root element, so .message-list / .members / .input here
-   match the rendered roots of MessageList / MemberList / MessageInput. */
-.message-list {
-  grid-area: messages;
-}
-.members {
-  grid-area: members;
-  border-left: 1px solid var(--border);
-}
-.status-bar {
-  grid-area: status;
-}
-.input {
-  grid-area: input;
-}
-
-/* Two-group layout for the topic bar: .topic-meta (name + topic text, spaced
-   by the 2ch gap — wider than the 1ch bar convention to give the name and
-   topic breathing room now that the │ divider is gone) sits left,
-   .topic-actions (buffer/network/channel buttons) sits right.
-   .topic uses justify-content:space-between to split them. .topic-meta
-   shrinks first via min-width:0 + topic-text ellipsis, so the action
-   cluster stays anchored to the right edge. */
-.topic-meta {
-  display: flex;
-  align-items: baseline;
-  gap: 2ch;
-  /* flex:1 so the meta absorbs the free space and keeps the action cluster
-     anchored to the right edge; min-width:0 lets the topic text ellipsis. */
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-}
-.topic-actions {
-  display: flex;
-  align-items: baseline;
-  gap: var(--space-4);
-  flex-shrink: 0;
-}
-.topic .member-count {
-  color: var(--fg-muted);
-  font-variant-numeric: tabular-nums;
 }
 </style>


### PR DESCRIPTION
Experimental mIRC-style windowed buffers on a desktop canvas, opt-in via `look.layout.windowed` (Settings → Appearance → Layout, or `/set look.layout.windowed on`). Off by default; desktop only (MobileChat is untouched — `Chat.vue` already forks on viewport). Draft — parked for future work, not for imminent merge.

## What you get

Draggable / resizable / minimizable / maximizable buffer windows right of the sidebar, several at once, click-to-raise, minimize-to-taskbar, double-click titlebar to maximize.

<img width="1921" height="1161" alt="image" src="https://github.com/user-attachments/assets/7a97c51a-fba8-49a6-9937-c187fdf0eeb9" />

## The part that matters beyond the feature

The windows are the easy half. Two changes underneath are the real value, and both are worth keeping even if the windowing itself never ships:

**1. Buffer views no longer read the global active buffer.** `MessageList`, `MemberList`, `StatusBar`, and `MessageInput` each independently read `networks.activeKey` — that coupling, not the layout, is what made them singletons. They now resolve their buffer through a provide/inject'd key (`useBufferKey()`), falling back to `activeKey` when nothing provides one. So an un-provided subtree behaves exactly as before, and `BufferPane.vue` (topic + messages + members + status + input, extracted from `DesktopChat`) provides the key. This is the foundation split-view would build on.

**2. Focus and visibility are now separate.** `activate()` used to tear down the previous buffer's unread divider and detached history slice on every switch — correct when switching away *is* stopping looking, wrong when a focused-away window is still on screen. That teardown is now `buffers.leaveBuffer(key)`; `activate()` still calls it for the single-pane case (or skips via `{retainPrevious:true}`), and the canvas calls it on window close/minimize.

Supporting: `useScrollState` and `useViewedBuffer` were module-level singletons assuming one view; both are now keyed by buffer (viewed-buffer is a refcounted set). New files: `WindowCanvas.vue`, `WindowFrame.vue`, `stores/windows.ts`, `usePaneRegistry.ts`.

## Testing

`npm run check` + `npm test` green (2018 tests, incl. new coverage for the windows store, the `leaveBuffer`/`retainPrevious` split, the viewed-buffer refcount, and the pane registry). Note: no jsdom/@vue/test-utils/playwright in the repo, so the components themselves are only exercised by manual QA — validated locally by @amiantos.

## Known rough edges (intentional, for a prototype)

- A visible-but-unfocused window still accrues unread + shows a divider (taste call, left open).
- Window geometry is un-persisted by design (it's a property of a screen, not an account).
- Toggling the setting off while every window is minimized leaves `activeKey` null → blank pane until a buffer is clicked.
- No message-list virtualization: N panes × up to `MAX_PER_BUFFER` (500) rows + N `MessageInput`s is the perf ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)