### PR TITLE
Strip EXIF/metadata on animated &amp; SVG uploads (#516)

### DIFF
--- a/server/services/imagePipeline.test.ts
+++ b/server/services/imagePipeline.test.ts
@@ -67,6 +67,46 @@ describe('imagePipeline.optimize', () => {
     expect(Buffer.compare(out.buffer, buf)).toBe(0);
   });
 
+  it('scrubs a Comment Extension from an animated GIF while keeping frames', async () => {
+    const base = animatedGif();
+    const comment = Buffer.concat([
+      Buffer.from([0x21, 0xfe, 0x0a]),
+      Buffer.from('SECRET-GPS', 'latin1'),
+      Buffer.from([0x00]),
+    ]);
+    // Splice the comment in just before the trailer (final 0x3B byte).
+    const withComment = Buffer.concat([
+      base.subarray(0, base.length - 1),
+      comment,
+      base.subarray(base.length - 1),
+    ]);
+
+    const out = await optimize(withComment, { maxDim: 1024, quality: 80 });
+    expect(out.animated).toBe(true);
+    expect(out.byteSize).toBe(out.buffer.length);
+    expect(out.buffer.toString('latin1')).not.toContain('SECRET-GPS');
+    // Still a valid, still-animated GIF.
+    const meta = await sharp(out.buffer).metadata();
+    expect(meta.format).toBe('gif');
+    expect((meta.pages ?? 1) > 1).toBe(true);
+  });
+
+  it('scrubs <metadata> and comments from a passed-through SVG', async () => {
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">' +
+        '<!-- SECRET-GPS 40.7,-74.0 --><metadata>SECRET-META</metadata>' +
+        '<rect width="10" height="10"/></svg>',
+      'utf8',
+    );
+    const out = await optimize(svg, { maxDim: 1024, quality: 80 });
+    expect(out.mime).toBe('image/svg+xml');
+    expect(out.byteSize).toBe(out.buffer.length);
+    const text = out.buffer.toString('utf8');
+    expect(text).not.toContain('SECRET-GPS');
+    expect(text).not.toContain('SECRET-META');
+    expect(text).toContain('<rect width="10" height="10"/>');
+  });
+
   it('rejects unsupported formats with code UNSUPPORTED_FORMAT', async () => {
     const garbage = Buffer.from('this is definitely not an image');
     await expect(optimize(garbage, { maxDim: 1024, quality: 80 })).rejects.toMatchObject({

--- a/server/services/imagePipeline.ts
+++ b/server/services/imagePipeline.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import sharp, { type Metadata } from 'sharp';
+import { canScrubInPlace, scrubMetadata } from './metadataScrub.js';
 
 const THUMB_SIZE = 128;
 
@@ -72,15 +73,44 @@ export async function optimize(
 
   const animated = (meta.pages || 1) > 1;
   if (animated) {
-    return {
-      buffer,
-      mime: fmt.mime,
-      ext: fmt.ext,
-      width: meta.width || null,
-      height: meta.height || null,
-      byteSize: buffer.length,
-      animated: true,
-    };
+    // Passthrough keeps frames intact but must still honor "strip metadata":
+    // animated WebP/APNG can carry GPS EXIF. Scrub in-container (no re-encode)
+    // for the formats we can do surgically.
+    if (canScrubInPlace(meta.format)) {
+      const scrubbed = scrubMetadata(buffer, meta.format);
+      return {
+        buffer: scrubbed,
+        mime: fmt.mime,
+        ext: fmt.ext,
+        width: meta.width || null,
+        height: meta.height || null,
+        byteSize: scrubbed.length,
+        animated: true,
+      };
+    }
+
+    // No surgical scrubber for this container (multi-page TIFF, animated
+    // AVIF/HEIF). Re-encode to strip metadata rather than leak it — prefer
+    // keeping the animation, and only if the codec can't round-trip do we fall
+    // through to the static single-frame encode below. Either way the metadata
+    // is gone; we never pass an un-scrubbed image through.
+    try {
+      const out = await sharp(buffer, { animated: true })
+        .toFormat(meta.format)
+        .toBuffer({ resolveWithObject: true });
+      return {
+        buffer: out.data,
+        mime: fmt.mime,
+        ext: fmt.ext,
+        width: meta.width || null,
+        height: meta.height || null,
+        byteSize: out.data.length,
+        animated: true,
+      };
+    } catch {
+      // Codec can't re-encode animated — fall through to the static path, which
+      // flattens to a metadata-free JPEG first frame. Degraded but never leaks.
+    }
   }
 
   // SVG is a static vector — we pass it through unchanged. sharp can rasterize
@@ -95,13 +125,15 @@ export async function optimize(
       err.code = 'UNSUPPORTED_FORMAT';
       throw err;
     }
+    // Strip <metadata>/comments from the vector without rasterizing it.
+    const scrubbed = scrubMetadata(buffer, meta.format);
     return {
-      buffer,
+      buffer: scrubbed,
       mime: fmt.mime,
       ext: fmt.ext,
       width: meta.width || null,
       height: meta.height || null,
-      byteSize: buffer.length,
+      byteSize: scrubbed.length,
       animated: false,
     };
   }

--- a/server/services/metadataScrub.test.ts
+++ b/server/services/metadataScrub.test.ts
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { canScrubInPlace, scrubMetadata } from './metadataScrub.js';
+
+// ---- helpers ---------------------------------------------------------------
+
+// Build a RIFF/WebP chunk (FourCC + LE size + payload + even-pad byte).
+function webpChunk(fourcc: string, payload: Buffer): Buffer {
+  const head = Buffer.alloc(8);
+  head.write(fourcc, 0, 'latin1');
+  head.writeUInt32LE(payload.length, 4);
+  const parts = [head, payload];
+  if (payload.length % 2 === 1) parts.push(Buffer.from([0]));
+  return Buffer.concat(parts);
+}
+
+function buildWebp(chunks: Buffer[]): Buffer {
+  const body = Buffer.concat(chunks);
+  const head = Buffer.alloc(12);
+  head.write('RIFF', 0, 'latin1');
+  head.writeUInt32LE(body.length + 4, 4); // + 'WEBP'
+  head.write('WEBP', 8, 'latin1');
+  return Buffer.concat([head, body]);
+}
+
+function listWebpChunks(buf: Buffer): { fourcc: string; payload: Buffer }[] {
+  const out: { fourcc: string; payload: Buffer }[] = [];
+  let o = 12;
+  while (o + 8 <= buf.length) {
+    const fourcc = buf.toString('latin1', o, o + 4);
+    const size = buf.readUInt32LE(o + 4);
+    out.push({ fourcc, payload: buf.subarray(o + 8, o + 8 + size) });
+    o = o + 8 + size + (size % 2);
+  }
+  return out;
+}
+
+function pngChunk(type: string, payload: Buffer): Buffer {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(payload.length, 0);
+  // CRC is a fixed placeholder — the scrubber copies kept chunks verbatim and
+  // never recomputes or validates CRCs.
+  return Buffer.concat([len, Buffer.from(type, 'latin1'), payload, Buffer.from([1, 2, 3, 4])]);
+}
+
+const PNG_SIG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function listPngChunks(buf: Buffer): string[] {
+  const out: string[] = [];
+  let o = 8;
+  while (o + 8 <= buf.length) {
+    const len = buf.readUInt32BE(o);
+    const type = buf.toString('latin1', o + 4, o + 8);
+    out.push(type);
+    o = o + 12 + len;
+    if (type === 'IEND') break;
+  }
+  return out;
+}
+
+// A real 2-frame 1×1 GIF89a with a NETSCAPE looping application extension —
+// same fixture the imagePipeline tests use. Exercises the full GIF walker.
+const TWO_FRAME_GIF_B64 =
+  'R0lGODlhAQABAIAAAP///wAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQACgAAACwAAAAA' +
+  'AQABAAACAkQBACH5BAAKAAAALAAAAAABAAEAAAICRAEAOw==';
+const TWO_FRAME_GIF = Buffer.from(TWO_FRAME_GIF_B64, 'base64');
+
+// Splice `ext` in just before the GIF trailer (0x3B, the final byte).
+function insertBeforeTrailer(gif: Buffer, ext: Buffer): Buffer {
+  return Buffer.concat([gif.subarray(0, gif.length - 1), ext, gif.subarray(gif.length - 1)]);
+}
+
+// ---- WebP ------------------------------------------------------------------
+
+describe('scrubMetadata — WebP', () => {
+  it('drops EXIF and XMP chunks and clears the VP8X flag bits, keeping frames', () => {
+    // flags: EXIF(0x08) | XMP(0x04) | Animation(0x02) all set
+    const vp8xPayload = Buffer.concat([Buffer.from([0x0e]), Buffer.alloc(9)]);
+    const frame = Buffer.from('framebytes', 'latin1'); // stand-in VP8L payload
+    const input = buildWebp([
+      webpChunk('VP8X', vp8xPayload),
+      webpChunk('VP8L', frame),
+      webpChunk('EXIF', Buffer.from('gps-here', 'latin1')),
+      webpChunk('XMP ', Buffer.from('<x:xmpmeta/>', 'latin1')),
+    ]);
+
+    const out = scrubMetadata(input, 'webp');
+    const chunks = listWebpChunks(out);
+
+    expect(chunks.map((c) => c.fourcc)).toEqual(['VP8X', 'VP8L']);
+    // Only the Animation bit survives.
+    expect(chunks[0].payload[0]).toBe(0x02);
+    // Frame bytes untouched.
+    expect(Buffer.compare(chunks[1].payload, frame)).toBe(0);
+    // RIFF size header matches the new length.
+    expect(out.readUInt32LE(4)).toBe(out.length - 8);
+    expect(out.toString('latin1')).not.toContain('gps-here');
+  });
+
+  it('returns the input unchanged when there is no metadata', () => {
+    const input = buildWebp([
+      webpChunk('VP8X', Buffer.concat([Buffer.from([0x02]), Buffer.alloc(9)])),
+      webpChunk('VP8L', Buffer.from('framebytes', 'latin1')),
+    ]);
+    // Same reference back = provably a no-op.
+    expect(scrubMetadata(input, 'webp')).toBe(input);
+  });
+
+  it('bails (returns input) on a truncated chunk', () => {
+    const input = buildWebp([webpChunk('VP8L', Buffer.from('frame', 'latin1'))]);
+    input.writeUInt32LE(9999, 20); // corrupt the VP8L declared size
+    expect(scrubMetadata(input, 'webp')).toBe(input);
+  });
+});
+
+// ---- PNG / APNG ------------------------------------------------------------
+
+describe('scrubMetadata — PNG', () => {
+  it('drops text/EXIF/time chunks and keeps structural + frame chunks', () => {
+    const input = Buffer.concat([
+      PNG_SIG,
+      pngChunk('IHDR', Buffer.alloc(13)),
+      pngChunk('eXIf', Buffer.from('gps-here', 'latin1')),
+      pngChunk('tEXt', Buffer.from('Comment\0secret', 'latin1')),
+      pngChunk('acTL', Buffer.alloc(8)), // APNG animation control — must survive
+      pngChunk('IDAT', Buffer.from('pixels', 'latin1')),
+      pngChunk('IEND', Buffer.alloc(0)),
+    ]);
+
+    const out = scrubMetadata(input, 'png');
+    expect(listPngChunks(out)).toEqual(['IHDR', 'acTL', 'IDAT', 'IEND']);
+    expect(out.toString('latin1')).not.toContain('gps-here');
+    expect(out.toString('latin1')).not.toContain('secret');
+  });
+
+  it('returns the input unchanged when there is no metadata', () => {
+    const input = Buffer.concat([
+      PNG_SIG,
+      pngChunk('IHDR', Buffer.alloc(13)),
+      pngChunk('IDAT', Buffer.from('pixels', 'latin1')),
+      pngChunk('IEND', Buffer.alloc(0)),
+    ]);
+    expect(scrubMetadata(input, 'png')).toBe(input);
+  });
+});
+
+// ---- GIF -------------------------------------------------------------------
+
+describe('scrubMetadata — GIF', () => {
+  it('is a no-op on a comment-free animated GIF', () => {
+    expect(scrubMetadata(TWO_FRAME_GIF, 'gif')).toBe(TWO_FRAME_GIF);
+  });
+
+  it('removes a Comment Extension and restores the original bytes', () => {
+    const comment = Buffer.concat([
+      Buffer.from([0x21, 0xfe, 0x0a]),
+      Buffer.from('SECRET-GPS', 'latin1'),
+      Buffer.from([0x00]),
+    ]);
+    const withComment = insertBeforeTrailer(TWO_FRAME_GIF, comment);
+
+    const out = scrubMetadata(withComment, 'gif');
+    expect(out.toString('latin1')).not.toContain('SECRET-GPS');
+    // The NETSCAPE looping extension is preserved.
+    expect(out.toString('latin1')).toContain('NETSCAPE2.0');
+    // Removing exactly what we added reproduces the original.
+    expect(Buffer.compare(out, TWO_FRAME_GIF)).toBe(0);
+  });
+
+  it('removes an XMP Application Extension but keeps NETSCAPE', () => {
+    const xmp = Buffer.concat([
+      Buffer.from([0x21, 0xff, 0x0b]),
+      Buffer.from('XMP DataXMP', 'latin1'),
+      Buffer.from([0x03]),
+      Buffer.from('abc', 'latin1'),
+      Buffer.from([0x00]),
+    ]);
+    const withXmp = insertBeforeTrailer(TWO_FRAME_GIF, xmp);
+
+    const out = scrubMetadata(withXmp, 'gif');
+    expect(out.toString('latin1')).not.toContain('XMP DataXMP');
+    expect(out.toString('latin1')).toContain('NETSCAPE2.0');
+    expect(Buffer.compare(out, TWO_FRAME_GIF)).toBe(0);
+  });
+
+  it('bails on a non-GIF buffer handed in as gif', () => {
+    const garbage = Buffer.from('definitely not a gif at all here', 'latin1');
+    expect(scrubMetadata(garbage, 'gif')).toBe(garbage);
+  });
+});
+
+// ---- SVG -------------------------------------------------------------------
+
+describe('scrubMetadata — SVG', () => {
+  it('strips <metadata> elements and XML comments', () => {
+    const svg = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg">' +
+        '<!-- author: Jane, taken at 40.7,-74.0 -->' +
+        '<metadata id="m"><rdf:RDF>secret</rdf:RDF></metadata>' +
+        '<rect width="10" height="10"/></svg>',
+      'utf8',
+    );
+    const out = scrubMetadata(svg, 'svg').toString('utf8');
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('author: Jane');
+    expect(out).toContain('<rect width="10" height="10"/>');
+  });
+
+  it('returns the input unchanged when there is nothing to strip', () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>', 'utf8');
+    expect(scrubMetadata(svg, 'svg')).toBe(svg);
+  });
+});
+
+// ---- dispatch --------------------------------------------------------------
+
+describe('scrubMetadata — dispatch', () => {
+  it('returns the input unchanged for formats without a scrubber', () => {
+    const jpeg = Buffer.from('jpeg-ish bytes', 'latin1');
+    expect(scrubMetadata(jpeg, 'jpeg')).toBe(jpeg);
+    expect(scrubMetadata(jpeg, undefined)).toBe(jpeg);
+  });
+});
+
+describe('canScrubInPlace', () => {
+  it('is true only for the surgically-scrubbable containers', () => {
+    for (const f of ['webp', 'png', 'gif', 'svg']) expect(canScrubInPlace(f)).toBe(true);
+    // Formats that can be animated/multi-page but have no in-place scrubber must
+    // report false so optimize() routes them through the re-encode fallback
+    // rather than passing their EXIF through untouched.
+    for (const f of ['tiff', 'avif', 'heif', 'jpeg', undefined])
+      expect(canScrubInPlace(f)).toBe(false);
+  });
+});

--- a/server/services/metadataScrub.test.ts
+++ b/server/services/metadataScrub.test.ts
@@ -108,10 +108,19 @@ describe('scrubMetadata — WebP', () => {
     expect(scrubMetadata(input, 'webp')).toBe(input);
   });
 
-  it('bails (returns input) on a truncated chunk', () => {
-    const input = buildWebp([webpChunk('VP8L', Buffer.from('frame', 'latin1'))]);
-    input.writeUInt32LE(9999, 20); // corrupt the VP8L declared size
-    expect(scrubMetadata(input, 'webp')).toBe(input);
+  it('bails (returns input untouched) on a truncated chunk without partial scrubbing', () => {
+    // EXIF first (flagged for removal), then a chunk whose declared size overruns
+    // the buffer. Order matters: the scrubber has already marked the EXIF chunk
+    // gone, so hitting the truncated chunk must make it return the ORIGINAL bytes
+    // (EXIF intact) rather than emit a partially-scrubbed buffer. A broken bail
+    // would drop the EXIF and return a different buffer, failing both assertions.
+    const exif = webpChunk('EXIF', Buffer.from('gps-here', 'latin1'));
+    const input = buildWebp([exif, webpChunk('VP8L', Buffer.from('frame', 'latin1'))]);
+    // VP8L size field = RIFF header (12) + EXIF chunk length + FourCC (4).
+    input.writeUInt32LE(9999, 12 + exif.length + 4);
+    const out = scrubMetadata(input, 'webp');
+    expect(out).toBe(input);
+    expect(out.toString('latin1')).toContain('gps-here');
   });
 });
 

--- a/server/services/metadataScrub.ts
+++ b/server/services/metadataScrub.ts
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Frame-preserving metadata scrub for the image-pipeline passthrough paths
+// (animated raster + SVG). The static-raster path already drops EXIF/GPS as a
+// side effect of the sharp re-encode, but animated images (pages > 1) and
+// standalone SVG pass through byte-for-byte and would otherwise keep any
+// embedded EXIF/XMP/GPS. Animated WebP and APNG in particular can carry GPS
+// EXIF, so "we strip metadata to protect your privacy" must hold for them too.
+//
+// This is deliberately container surgery, NOT a decode + re-encode: we drop the
+// metadata chunks and leave every frame's pixel data untouched, so animation and
+// quality are preserved exactly. Every scrubber is fail-safe — if the bytes look
+// malformed or unexpected in any way, it returns the input unchanged rather than
+// risk corrupting a valid upload. A scrub that can't run is a privacy miss; a
+// scrub that corrupts frames is data loss, and the latter is worse.
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// PNG ancillary chunks that carry user metadata. Frame/structural chunks
+// (IHDR, PLTE, IDAT, IEND, acTL, fcTL, fdAT, tRNS) and colour-management chunks
+// (iCCP, sRGB, gAMA, cHRM) are kept so rendering and animation are unaffected.
+const PNG_METADATA_CHUNKS = new Set(['tEXt', 'zTXt', 'iTXt', 'eXIf', 'tIME']);
+
+// The formats we can scrub surgically (in-container, no re-encode). sharp
+// format names. Anything outside this set has no targeted scrubber, so a
+// passthrough of it must be metadata-stripped some other way (e.g. re-encode).
+const SURGICAL_FORMATS = new Set(['webp', 'png', 'gif', 'svg']);
+
+/** Whether scrubMetadata has an in-place scrubber for this sharp format name. */
+export function canScrubInPlace(format: string | undefined): boolean {
+  return format !== undefined && SURGICAL_FORMATS.has(format);
+}
+
+/**
+ * Strip embedded metadata from an image without recompressing or de-animating
+ * it. `format` is sharp's format name (`webp` | `png` | `gif` | `svg`, …).
+ * Formats we don't have a targeted scrubber for are returned unchanged.
+ */
+export function scrubMetadata(buffer: Buffer, format: string | undefined): Buffer {
+  try {
+    switch (format) {
+      case 'webp':
+        return scrubWebp(buffer);
+      case 'png': // also covers APNG (animated PNG shares the container)
+        return scrubPng(buffer);
+      case 'gif':
+        return scrubGif(buffer);
+      case 'svg':
+        return scrubSvg(buffer);
+      default:
+        return buffer;
+    }
+  } catch {
+    // Any unforeseen parsing error → hand back the original bytes untouched.
+    return buffer;
+  }
+}
+
+// ---- WebP (RIFF container) -------------------------------------------------
+// Structure: 'RIFF' <uint32 LE size> 'WEBP' then a sequence of chunks, each
+// 'FourCC' <uint32 LE size> <payload> plus a pad byte when size is odd. EXIF and
+// XMP live in dedicated 'EXIF' / 'XMP ' chunks; the VP8X header chunk carries
+// flag bits announcing their presence. We drop the metadata chunks and clear the
+// corresponding VP8X flags; every frame chunk (VP8/VP8L/ANIM/ANMF/ALPH) is kept.
+function scrubWebp(buffer: Buffer): Buffer {
+  if (buffer.length < 12) return buffer;
+  if (buffer.toString('latin1', 0, 4) !== 'RIFF') return buffer;
+  if (buffer.toString('latin1', 8, 12) !== 'WEBP') return buffer;
+
+  const VP8X_EXIF_FLAG = 0x08;
+  const VP8X_XMP_FLAG = 0x04;
+
+  const kept: Buffer[] = [buffer.subarray(0, 12)];
+  let changed = false;
+  let offset = 12;
+
+  while (offset + 8 <= buffer.length) {
+    const fourcc = buffer.toString('latin1', offset, offset + 4);
+    const size = buffer.readUInt32LE(offset + 4);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + size;
+    if (dataEnd > buffer.length) return buffer; // truncated chunk → bail
+    // Chunks are padded to an even boundary; the pad byte may be absent on the
+    // final chunk of some encoders, so clamp to the buffer end.
+    const next = Math.min(dataStart + size + (size % 2), buffer.length);
+
+    if (fourcc === 'EXIF' || fourcc === 'XMP ') {
+      changed = true; // drop it
+    } else if (fourcc === 'VP8X' && size >= 1) {
+      const flags = buffer[dataStart];
+      const cleared = flags & ~(VP8X_EXIF_FLAG | VP8X_XMP_FLAG);
+      if (cleared !== flags) {
+        const chunk = Buffer.from(buffer.subarray(offset, next));
+        chunk[8] = cleared; // byte 0 of the payload = offset 8 within the chunk
+        kept.push(chunk);
+        changed = true;
+      } else {
+        kept.push(buffer.subarray(offset, next));
+      }
+    } else {
+      kept.push(buffer.subarray(offset, next));
+    }
+    offset = next;
+  }
+
+  if (!changed) return buffer;
+  const out = Buffer.concat(kept);
+  out.writeUInt32LE(out.length - 8, 4); // fix the RIFF payload size
+  return out;
+}
+
+// ---- PNG / APNG ------------------------------------------------------------
+// Structure: 8-byte signature then chunks of <uint32 BE length> <4-byte type>
+// <payload> <uint32 BE CRC>. Metadata lives in ancillary text/time/EXIF chunks;
+// we drop those and keep every structural and frame chunk byte-for-byte (kept
+// chunks retain their original CRCs, so nothing needs recomputing).
+function scrubPng(buffer: Buffer): Buffer {
+  if (buffer.length < 8 || !buffer.subarray(0, 8).equals(PNG_SIGNATURE)) return buffer;
+
+  const kept: Buffer[] = [buffer.subarray(0, 8)];
+  let changed = false;
+  let offset = 8;
+
+  while (offset + 8 <= buffer.length) {
+    const len = buffer.readUInt32BE(offset);
+    const type = buffer.toString('latin1', offset + 4, offset + 8);
+    const chunkEnd = offset + 12 + len; // 4 len + 4 type + len + 4 CRC
+    if (chunkEnd > buffer.length) return buffer; // truncated chunk → bail
+
+    if (PNG_METADATA_CHUNKS.has(type)) {
+      changed = true; // drop it
+    } else {
+      kept.push(buffer.subarray(offset, chunkEnd));
+    }
+
+    offset = chunkEnd;
+    if (type === 'IEND') break; // ignore any trailing bytes past the end chunk
+  }
+
+  return changed ? Buffer.concat(kept) : buffer;
+}
+
+// ---- GIF -------------------------------------------------------------------
+// GIF carries no standard EXIF, but Comment Extensions (0x21 0xFE) hold
+// arbitrary text and an XMP payload rides in an Application Extension
+// (0x21 0xFF, app-id "XMP DataXMP"). We drop those two and keep everything else
+// — crucially the NETSCAPE looping extension, graphic-control extensions and all
+// image data — so animation and timing survive untouched.
+function scrubGif(buffer: Buffer): Buffer {
+  if (buffer.length < 13) return buffer;
+  const sig = buffer.toString('latin1', 0, 6);
+  if (sig !== 'GIF87a' && sig !== 'GIF89a') return buffer;
+
+  // Logical Screen Descriptor: the packed byte at offset 10 says whether a
+  // Global Colour Table follows and how big it is.
+  const packed = buffer[10];
+  const gctSize = (packed & 0x80) !== 0 ? 3 * (1 << ((packed & 0x07) + 1)) : 0;
+  let p = 13 + gctSize;
+  if (p > buffer.length) return buffer;
+
+  // Walk a run of size-prefixed data sub-blocks; return the offset just past the
+  // 0x00 terminator, or -1 if the bytes run out first.
+  const skipSubBlocks = (start: number): number => {
+    let q = start;
+    for (;;) {
+      if (q >= buffer.length) return -1;
+      const blockSize = buffer[q];
+      if (blockSize === 0) return q + 1;
+      q += 1 + blockSize;
+    }
+  };
+
+  const kept: Buffer[] = [buffer.subarray(0, p)]; // header + LSD + GCT
+  let changed = false;
+
+  while (p < buffer.length) {
+    const marker = buffer[p];
+
+    if (marker === 0x3b) {
+      // Trailer — copy it and stop; anything after is trailing junk.
+      kept.push(buffer.subarray(p, p + 1));
+      p += 1;
+      break;
+    }
+
+    if (marker === 0x2c) {
+      // Image Descriptor: 10-byte header, optional Local Colour Table, then an
+      // LZW-minimum-code-size byte and the image data sub-blocks.
+      if (p + 10 > buffer.length) return buffer;
+      const lpacked = buffer[p + 9];
+      const lctSize = (lpacked & 0x80) !== 0 ? 3 * (1 << ((lpacked & 0x07) + 1)) : 0;
+      const dataStart = p + 10 + lctSize + 1; // +1 skips the LZW min-code byte
+      const end = skipSubBlocks(dataStart);
+      if (end < 0) return buffer;
+      kept.push(buffer.subarray(p, end));
+      p = end;
+      continue;
+    }
+
+    if (marker === 0x21) {
+      // Extension: 0x21 <label> then data sub-blocks.
+      if (p + 2 > buffer.length) return buffer;
+      const label = buffer[p + 1];
+      const dataStart = p + 2;
+      const end = skipSubBlocks(dataStart);
+      if (end < 0) return buffer;
+
+      const isComment = label === 0xfe;
+      const isXmp =
+        label === 0xff &&
+        buffer[dataStart] === 0x0b &&
+        buffer.toString('latin1', dataStart + 1, dataStart + 12) === 'XMP DataXMP';
+
+      if (isComment || isXmp) {
+        changed = true; // drop it
+      } else {
+        kept.push(buffer.subarray(p, end));
+      }
+      p = end;
+      continue;
+    }
+
+    return buffer; // unexpected marker → bail rather than risk corruption
+  }
+
+  return changed ? Buffer.concat(kept) : buffer;
+}
+
+// ---- SVG -------------------------------------------------------------------
+// SVG is XML text. Editors (Inkscape, Illustrator) embed author, title, and RDF
+// document metadata in <metadata> elements and XML comments. Strip both; leave
+// the drawing untouched. This runs only on the standalone passthrough (hosted
+// rejects SVG outright).
+function scrubSvg(buffer: Buffer): Buffer {
+  const text = buffer.toString('utf8');
+  const scrubbed = text
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(\w+:)?metadata\b[^>]*\/>/gi, '')
+    .replace(/<(\w+:)?metadata\b[\s\S]*?<\/(\w+:)?metadata\s*>/gi, '');
+  return scrubbed === text ? buffer : Buffer.from(scrubbed, 'utf8');
+}


### PR DESCRIPTION
## What

Closes a latent privacy gap in the upload pipeline. Static raster images already lose EXIF as a side effect of the `sharp` re-encode, but the **animated** (`pages > 1`) and **standalone SVG** passthrough paths in `imagePipeline.optimize()` returned their bytes verbatim — so animated WebP/APNG kept any embedded **GPS EXIF**, and SVG kept its document metadata. The "we strip metadata to protect your privacy" guarantee must hold for *every* image class, not just the ones that happen to get re-encoded.

Part of #509 (design doc §5.1, decision 18). **Independent of the driver work** — touches only the pipeline.

## How

New `server/services/metadataScrub.ts` does **frame-preserving, in-container surgery**: it drops the metadata chunks and leaves every frame's pixel data byte-for-byte, so animation and quality are preserved exactly — no re-encode, no de-animation.

| Format | Scrub |
|---|---|
| **WebP** | drop `EXIF` / `XMP ` RIFF chunks, clear the VP8X flag bits, fix the RIFF size |
| **PNG / APNG** | drop `eXIf`/`tEXt`/`zTXt`/`iTXt`/`tIME`; keep structural + frame chunks (`acTL`/`fcTL`/`fdAT`/`IDAT`, colour chunks) |
| **GIF** | drop Comment + XMP Application extensions; keep the NETSCAPE looping extension + all frame data |
| **SVG** | strip `<metadata>` elements and XML comments |

Every scrubber is **fail-safe**: any malformed or unexpected byte returns the input untouched. A scrub that can't run is a privacy miss, but it must never corrupt a valid upload — so we never risk the latter.

`optimize()` applies the scrub on both passthrough branches. For animated containers **without** a surgical scrubber (multi-page TIFF, animated AVIF/HEIF), it falls back to a metadata-stripping `sharp` re-encode that preserves animation, degrading to a static metadata-free frame only if the codec can't round-trip — guarded so a missing encoder can never crash an upload. Either way the metadata is gone; an un-scrubbed image is never passed through.

## Design decisions

- **In-container surgery, not a re-encode** — the design (§5.1) explicitly requires the scrub to be frame-preserving; a `sharp` round-trip on animated WebP would recompress every frame. The re-encode is only a fallback for the three formats that have no cheap surgical scrubber.
- **Privacy-first fallback ordering** — for TIFF/AVIF/HEIF the priority is "never leak," then "keep animation," then "keep it as one file." We'd rather flatten an animated AVIF to a clean JPEG than pass its GPS through.

## Testing

- `npm run check` clean, `npm test` green (**2004 tests**, +15 here).
- `metadataScrub.test.ts` — per-format container assertions on real bytes: chunks removed, frames preserved byte-for-byte, VP8X flags cleared, no-op returns the same buffer, truncated/garbage input bails; plus a classification test locking TIFF/AVIF/HEIF into the re-encode fallback.
- `imagePipeline.test.ts` — end-to-end through `optimize()`: a real animated GIF stays animated (2 frames) with its comment payload gone, and an SVG loses its `<metadata>`/comments.
- Verified independently of any upload provider (x0/catbox strip EXIF server-side, which would otherwise mask whether *our* code fired): drove a genuinely animated GIF (`pages=2`) with an injected metadata payload through `optimize()` → 98→85 bytes, payload removed, still a valid 2-frame GIF. Not run against a live server per repo convention.

## Known caveat

The SVG scrub removes **all** XML comments, including any inside `<script>`/`<style>`, so it can alter a functional standalone SVG's behavior — not only its metadata. Low impact (standalone/self-host path only; interactive SVGs are rare), noting it here rather than expanding scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)