### PR TITLE
[Uploads P0] Uploader data model + capability-driver refactor (#510)

### DIFF
--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -304,6 +304,9 @@ export const EXPORT_TABLES = Object.freeze({
     skippedColumns: {
       synced_to_cp: 'operational: cell↔control-plane moderation-sync bookkeeping, not portable',
       removed: 'instance/CP-owned moderation state; a fresh instance starts it at the default 0',
+      uploader_config_id:
+        'instance-local: references an uploader_config row id that does not survive import (#510)',
+      ref: 'driver-local delete handle (object/disk key), not portable (#510)',
     },
   },
 
@@ -385,6 +388,20 @@ export const EXPORT_TABLES = Object.freeze({
   },
 
   // ---- skipped ----
+
+  uploader_config: {
+    mode: 'skip',
+    reason:
+      'instance-scoped uploader infrastructure (#510): user rows hold secrets encrypted with the ' +
+      'source instance key and reference driver ids/rows that do not survive import. In P0 a user’s ' +
+      'provider config is still carried by the legacy uploads.* user_settings keys (which ARE exported); ' +
+      'revisit the export contract when those legacy keys are removed.',
+  },
+
+  instance_settings: {
+    mode: 'skip',
+    reason: 'instance-level operational settings (e.g. uploads.allow_user_defined), not user data',
+  },
 
   sessions: {
     mode: 'skip',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1531,10 +1531,15 @@ try {
 // locked hosted uploader from env + allow_user_defined=0 (hosted). Behavior is
 // byte-identical post-migration. Passed `db` (not importing it) to avoid an
 // import cycle, matching foldMutedIntoIgnoreRules above. See db/uploaderConfigSeed.ts.
+let uploaderSeedOk = true;
 if (schemaVersion < 14) {
   try {
     seedUploaderConfig(db);
   } catch (err) {
+    // Leave schema_version un-bumped (see the version write below) so this
+    // genuinely retries next boot rather than being permanently skipped. The
+    // seed is idempotent, so a retry after a partial/failed run is safe.
+    uploaderSeedOk = false;
     console.warn('[db] uploader-config seed migration failed (will retry next boot):', err);
   }
 }
@@ -1549,7 +1554,10 @@ try {
   console.warn('[db] hosted uploader env reconcile failed:', err);
 }
 
-if (schemaVersion < SCHEMA_VERSION) {
+// Gate on uploaderSeedOk: if the #510 seed threw, keep schema_version below 14 so
+// the seed retries on the next boot instead of being silently skipped forever
+// (the other <14 blocks are shape/data-gated, so re-running them is a no-op).
+if (schemaVersion < SCHEMA_VERSION && uploaderSeedOk) {
   db.prepare(
     `INSERT INTO app_meta (key, value) VALUES ('schema_version', ?)
               ON CONFLICT(key) DO UPDATE SET value = excluded.value`,

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
 import { foldBufferCase } from './foldBufferCase.js';
+import { seedUploaderConfig, reconcileHostedUploaderFromEnv } from './uploaderConfigSeed.js';
 
 // Guardrail: under vitest, refuse to fall back to the real database. A test
 // that forgets to isolate DATABASE_PATH would otherwise open data/lurker.db and
@@ -726,6 +727,48 @@ function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_e2e_recipients_handle
       ON e2e_outgoing_recipients(user_id, network_id, handle);
+
+    -- Configured uploaders (issue #510): a named instance of an upload driver
+    -- with its settings filled in. scope 'instance' rows are admin-defined
+    -- (secrets held server-side); 'user' rows are a user's own. config_json holds
+    -- the non-secret fields; secrets_enc is a secretCrypto envelope (lk1.*) of the
+    -- secret fields — plaintext no-op on self-host without LURKER_SECRET_KEY,
+    -- decrypted server-side at upload time and never sent to a client. locked
+    -- expresses the hosted "you get this default, can't touch it" case without a
+    -- separate edition fork; at most one instance row may be is_default. The
+    -- denormalized driver string on upload_history keeps display working even if
+    -- the config row is later deleted.
+    CREATE TABLE IF NOT EXISTS uploader_config (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      scope TEXT NOT NULL CHECK (scope IN ('instance','user')),
+      owner_user_id INTEGER,
+      driver TEXT NOT NULL,
+      label TEXT NOT NULL,
+      config_json TEXT NOT NULL DEFAULT '{}',
+      secrets_enc TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      offered_to_users INTEGER NOT NULL DEFAULT 0,
+      locked INTEGER NOT NULL DEFAULT 0,
+      is_default INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_uploader_config_owner
+      ON uploader_config(owner_user_id) WHERE scope = 'user';
+    -- At most one instance default (partial unique index over is_default=1).
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_uploader_config_one_default
+      ON uploader_config(is_default) WHERE scope = 'instance' AND is_default = 1;
+
+    -- Minimal instance-level key/value settings (issue #510). First (and for now
+    -- only) key is uploads.allow_user_defined ('1'|'0'): may users define their
+    -- own uploaders at all — default '1' standalone, '0' hosted. Kept
+    -- uploader-scoped for now; the generalized instance-defaults surface (#299)
+    -- comes later.
+    CREATE TABLE IF NOT EXISTS instance_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
   `);
 }
 
@@ -924,6 +967,15 @@ ensureColumn('upload_history', 'synced_to_cp', 'INTEGER NOT NULL DEFAULT 0');
 // image), but the bytes are gone from storage. Standalone never sets it.
 ensureColumn('upload_history', 'removed', 'INTEGER NOT NULL DEFAULT 0');
 
+// Issue #510: which configured uploader (uploader_config.id) produced this
+// upload — for a later delete + display — and `ref`, the driver's opaque delete
+// handle (object key / disk key), NULL for non-deletable drivers (all P0
+// drivers). The denormalized `provider` string above is kept for display even if
+// the uploader_config row is later deleted. Behavior-neutral in P0: no path yet
+// reads these back, they're the seam later phases (delete, s3/local) build on.
+ensureColumn('upload_history', 'uploader_config_id', 'INTEGER');
+ensureColumn('upload_history', 'ref', 'TEXT');
+
 // The offer's address/port, persisted so an unsolicited DCC SEND recorded as
 // pending_approval can be accepted later (the user clicks Accept seconds/minutes
 // after the bot offered). #270 phase 2.
@@ -938,7 +990,7 @@ ensureColumn('push_subscriptions', 'fail_count', 'INTEGER NOT NULL DEFAULT 0');
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
-const SCHEMA_VERSION = 13;
+const SCHEMA_VERSION = 14;
 const schemaVersionRow = db
   .prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`)
   .get() as { value: string } | undefined;
@@ -1472,6 +1524,29 @@ try {
       db.pragma(`foreign_keys = ${prevFk ? 'ON' : 'OFF'}`);
     }
   }
+}
+
+// Issue #510: seed the uploader data model once — instance x0/catbox rows +
+// per-user conversion of existing uploads.* settings (self-host), or a single
+// locked hosted uploader from env + allow_user_defined=0 (hosted). Behavior is
+// byte-identical post-migration. Passed `db` (not importing it) to avoid an
+// import cycle, matching foldMutedIntoIgnoreRules above. See db/uploaderConfigSeed.ts.
+if (schemaVersion < 14) {
+  try {
+    seedUploaderConfig(db);
+  } catch (err) {
+    console.warn('[db] uploader-config seed migration failed (will retry next boot):', err);
+  }
+}
+
+// Re-sync the hosted locked uploader from env on every boot — idempotent no-op on
+// self-host and when the hosted upload env is unset. The config now lives in the
+// DB row, so this is what lets a deploy that rotates LURKER_NODE_UPLOAD_API_KEY or
+// changes the caps still take effect.
+try {
+  reconcileHostedUploaderFromEnv(db);
+} catch (err) {
+  console.warn('[db] hosted uploader env reconcile failed:', err);
 }
 
 if (schemaVersion < SCHEMA_VERSION) {

--- a/server/db/instanceSettings.test.ts
+++ b/server/db/instanceSettings.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-instance-settings-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+let mod: typeof import('./instanceSettings.js');
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  mod = await import('./instanceSettings.js');
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+beforeEach(() => {
+  db.prepare('DELETE FROM instance_settings').run();
+});
+
+describe('instanceSettings', () => {
+  it('returns null for an unset key', () => {
+    expect(mod.getInstanceSetting('nope')).toBeNull();
+  });
+
+  it('set then get roundtrips', () => {
+    mod.setInstanceSetting('k', 'v');
+    expect(mod.getInstanceSetting('k')).toBe('v');
+    // upsert overwrites
+    mod.setInstanceSetting('k', 'v2');
+    expect(mod.getInstanceSetting('k')).toBe('v2');
+  });
+
+  it('allowUserDefinedUploaders defaults to true on self-host when unset', () => {
+    // The seed cleared by beforeEach; no LURKER_EDITION in this process → self-host.
+    expect(mod.allowUserDefinedUploaders()).toBe(true);
+  });
+
+  it('setAllowUserDefinedUploaders flips the flag', () => {
+    mod.setAllowUserDefinedUploaders(false);
+    expect(mod.allowUserDefinedUploaders()).toBe(false);
+    mod.setAllowUserDefinedUploaders(true);
+    expect(mod.allowUserDefinedUploaders()).toBe(true);
+  });
+});

--- a/server/db/instanceSettings.ts
+++ b/server/db/instanceSettings.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Instance-level key/value settings (issue #510). A tiny surface — one key today
+// (uploads.allow_user_defined) — distinct from per-user settings: these belong to
+// the whole instance, set by the admin/operator, not scoped to any account.
+
+import db from './index.js';
+import { isNodeMode } from '../utils/edition.js';
+
+export function getInstanceSetting(key: string): string | null {
+  const row = db.prepare('SELECT value FROM instance_settings WHERE key = ?').get(key) as
+    | { value: string }
+    | undefined;
+  return row ? row.value : null;
+}
+
+export function setInstanceSetting(key: string, value: string): void {
+  db.prepare(
+    `INSERT INTO instance_settings (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  ).run(key, value);
+}
+
+// Keep this literal in sync with the one the seed migration writes
+// (db/uploaderConfigSeed.ts) — the seed can't import this module (import cycle),
+// so the string lives in both places by necessity.
+export const ALLOW_USER_DEFINED_KEY = 'uploads.allow_user_defined';
+
+/**
+ * May users define their own uploaders? Default when unset: yes on self-host
+ * (trusted), no on the hosted fleet (tenants get the operator's locked default).
+ */
+export function allowUserDefinedUploaders(): boolean {
+  const v = getInstanceSetting(ALLOW_USER_DEFINED_KEY);
+  if (v === null) return !isNodeMode();
+  return v === '1';
+}
+
+export function setAllowUserDefinedUploaders(allow: boolean): void {
+  setInstanceSetting(ALLOW_USER_DEFINED_KEY, allow ? '1' : '0');
+}

--- a/server/db/uploadHistory.ts
+++ b/server/db/uploadHistory.ts
@@ -50,16 +50,22 @@ export interface InsertUploadFields {
   byte_size: number;
   width?: number | null;
   height?: number | null;
-  // Exactly one of thumbnail (inline BLOB, standalone) or thumbnail_url (remote
-  // CDN object, node edition) is set; both null for thumbnail-less uploads (txt).
+  // Exactly one of thumbnail (inline BLOB, self-host) or thumbnail_url (remote
+  // CDN object) is set; both null for thumbnail-less uploads (txt).
   thumbnail: Buffer | null;
   thumbnail_url?: string | null;
+  // The configured uploader (uploader_config.id) that produced this upload, and
+  // the driver's opaque delete handle. Both nullable in P0 (no path reads them
+  // back yet) — the seam later phases (delete, s3/local) build on.
+  uploader_config_id?: number | null;
+  ref?: string | null;
 }
 
 const insertStmt = db.prepare(`
   INSERT INTO upload_history
-    (user_id, provider, url, filename, mime, byte_size, width, height, thumbnail, thumbnail_url)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    (user_id, provider, url, filename, mime, byte_size, width, height, thumbnail,
+     thumbnail_url, uploader_config_id, ref)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
 export function insertUpload(userId: number, row: InsertUploadFields): number {
@@ -74,6 +80,8 @@ export function insertUpload(userId: number, row: InsertUploadFields): number {
     row.height ?? null,
     row.thumbnail,
     row.thumbnail_url ?? null,
+    row.uploader_config_id ?? null,
+    row.ref ?? null,
   );
   return Number(info.lastInsertRowid);
 }

--- a/server/db/uploaderConfig.test.ts
+++ b/server/db/uploaderConfig.test.ts
@@ -79,6 +79,14 @@ describe('uploaderConfig', () => {
     expect(mod.resolvedConfig(row)).toEqual({ userhash: 'topsecret' });
   });
 
+  it('degrades an undecryptable secret to {} instead of throwing (avoids a 500)', () => {
+    process.env.LURKER_SECRET_KEY = Buffer.alloc(32, 7).toString('base64');
+    resetKeyRegistryForTests();
+    // A well-formed envelope whose keyid does not match the configured key
+    // (e.g. a row wrapped under a since-rotated key). Must not throw.
+    expect(mod.decodeSecrets('lk1.00000000.AAAAAAAAAAAAAAAAAAAAAA')).toEqual({});
+  });
+
   it('client projection carries only { id, driver, label } — no secrets', () => {
     const id = mod.createUploaderConfig({
       scope: 'user',

--- a/server/db/uploaderConfig.test.ts
+++ b/server/db/uploaderConfig.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-uploader-config-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+let mod: typeof import('./uploaderConfig.js');
+let createUser: typeof import('./users.js').createUser;
+let resetKeyRegistryForTests: typeof import('../utils/secretCrypto.js').resetKeyRegistryForTests;
+let userId: number;
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  mod = await import('./uploaderConfig.js');
+  ({ createUser } = await import('./users.js'));
+  ({ resetKeyRegistryForTests } = await import('../utils/secretCrypto.js'));
+  userId = createUser('uploader-cfg-alice').id;
+});
+
+afterAll(() => {
+  delete process.env.LURKER_SECRET_KEY;
+  resetKeyRegistryForTests();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  db.prepare('DELETE FROM uploader_config').run();
+  delete process.env.LURKER_SECRET_KEY;
+  resetKeyRegistryForTests();
+});
+
+describe('uploaderConfig', () => {
+  it('splits config by schema: secrets never land in config_json', () => {
+    const id = mod.createUploaderConfig({
+      scope: 'user',
+      ownerUserId: userId,
+      driver: 'hoarder',
+      values: { url: 'https://u.example', api_key: 'sekret' },
+    });
+    const row = mod.getUploaderConfig(id)!;
+    // url is a non-secret field → config_json; api_key is secret → secrets_enc.
+    expect(JSON.parse(row.config_json)).toEqual({ url: 'https://u.example' });
+    expect(row.config_json).not.toContain('sekret');
+    expect(mod.resolvedConfig(row)).toEqual({ url: 'https://u.example', api_key: 'sekret' });
+  });
+
+  it('roundtrips secrets as plaintext on self-host (no key configured)', () => {
+    const id = mod.createUploaderConfig({
+      scope: 'user',
+      ownerUserId: userId,
+      driver: 'catbox',
+      values: { userhash: 'abc123' },
+    });
+    const row = mod.getUploaderConfig(id)!;
+    // Without a key, secretCrypto is a plaintext no-op — the value is stored as-is.
+    expect(row.secrets_enc).toContain('abc123');
+    expect(mod.resolvedConfig(row)).toEqual({ userhash: 'abc123' });
+  });
+
+  it('encrypts secrets at rest when LURKER_SECRET_KEY is configured', () => {
+    process.env.LURKER_SECRET_KEY = Buffer.alloc(32, 7).toString('base64');
+    resetKeyRegistryForTests();
+    const id = mod.createUploaderConfig({
+      scope: 'user',
+      ownerUserId: userId,
+      driver: 'catbox',
+      values: { userhash: 'topsecret' },
+    });
+    const row = mod.getUploaderConfig(id)!;
+    expect(row.secrets_enc).toMatch(/^lk1\./); // secretCrypto envelope
+    expect(row.secrets_enc).not.toContain('topsecret');
+    // Decrypts back on read.
+    expect(mod.resolvedConfig(row)).toEqual({ userhash: 'topsecret' });
+  });
+
+  it('client projection carries only { id, driver, label } — no secrets', () => {
+    const id = mod.createUploaderConfig({
+      scope: 'user',
+      ownerUserId: userId,
+      driver: 'catbox',
+      label: 'My Catbox',
+      values: { userhash: 'abc' },
+    });
+    const row = mod.getUploaderConfig(id)!;
+    expect(mod.toSummary(row)).toEqual({ id, driver: 'catbox', label: 'My Catbox' });
+  });
+
+  it('enforces at most one instance default', () => {
+    mod.createUploaderConfig({ scope: 'instance', driver: 'x0', isDefault: true });
+    expect(() =>
+      mod.createUploaderConfig({ scope: 'instance', driver: 'catbox', isDefault: true }),
+    ).toThrow(/UNIQUE constraint/);
+  });
+
+  it('lists and finds instance vs user uploaders', () => {
+    const instId = mod.createUploaderConfig({ scope: 'instance', driver: 'x0', isDefault: true });
+    const userRow = mod.createUploaderConfig({
+      scope: 'user',
+      ownerUserId: userId,
+      driver: 'catbox',
+      values: { userhash: 'x' },
+    });
+    expect(mod.listInstanceUploaders().map((r) => r.id)).toEqual([instId]);
+    expect(mod.listUserUploaders(userId).map((r) => r.id)).toEqual([userRow]);
+    expect(mod.getInstanceDefault()?.id).toBe(instId);
+  });
+
+  it('rejects an unknown driver', () => {
+    expect(() => mod.createUploaderConfig({ scope: 'instance', driver: 'nope' })).toThrow(
+      /unknown upload driver/,
+    );
+  });
+});

--- a/server/db/uploaderConfig.test.ts
+++ b/server/db/uploaderConfig.test.ts
@@ -124,4 +124,10 @@ describe('uploaderConfig', () => {
       /unknown upload driver/,
     );
   });
+
+  it('rejects a user-scoped row with no owner (would be orphaned)', () => {
+    expect(() => mod.createUploaderConfig({ scope: 'user', driver: 'catbox' })).toThrow(
+      /requires ownerUserId/,
+    );
+  });
 });

--- a/server/db/uploaderConfig.ts
+++ b/server/db/uploaderConfig.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// CRUD for `uploader_config` — the first-class "configured uploader" (issue
+// #510): a named instance of an upload driver with its settings filled in. The
+// secret fields (per the driver's configSchema) are encrypted at rest into
+// `secrets_enc` with the same secretCrypto envelope that protects network creds
+// (plaintext no-op on self-host without LURKER_SECRET_KEY); non-secret fields go
+// in `config_json`. Secrets are decrypted server-side only, at upload time, and
+// never reach a client — the client-safe projection is `{ id, driver, label }`.
+//
+// NOTE: loaded post-boot (by the resolver / route), so importing `db` is safe.
+// The seed migration (db/uploaderConfigSeed.ts) runs *during* db/index.ts
+// evaluation and therefore does NOT use this module — it writes rows via raw SQL
+// against its `db` parameter to avoid the import cycle.
+
+import db from './index.js';
+import { encryptSecret, decryptSecret } from '../utils/secretCrypto.js';
+import { getDriver, splitConfigBySchema } from '../services/uploadProviders/index.js';
+
+export interface UploaderConfigRow {
+  id: number;
+  scope: 'instance' | 'user';
+  owner_user_id: number | null;
+  driver: string;
+  label: string;
+  config_json: string;
+  secrets_enc: string | null;
+  enabled: number;
+  offered_to_users: number;
+  locked: number;
+  is_default: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Client-safe projection — never carries config values or secrets. */
+export interface UploaderConfigSummary {
+  id: number;
+  driver: string;
+  label: string;
+}
+
+// ─── secret encoding (pure; no db) ────────────────────────────────────────────
+
+/** JSON-encode the secret fields and wrap them in a secretCrypto envelope.
+ *  Returns null when there are no secrets (so the column stays NULL). */
+export function encodeSecrets(secrets: Record<string, string>): string | null {
+  if (!secrets || Object.keys(secrets).length === 0) return null;
+  return encryptSecret(JSON.stringify(secrets));
+}
+
+/** Inverse of encodeSecrets: decrypt + parse back to a flat object. */
+export function decodeSecrets(enc: string | null): Record<string, string> {
+  if (!enc) return {};
+  const json = decryptSecret(enc);
+  if (!json) return {};
+  try {
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseConfigJson(configJson: string): Record<string, string> {
+  try {
+    const parsed = JSON.parse(configJson || '{}');
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+// ─── reads ────────────────────────────────────────────────────────────────────
+
+export function getUploaderConfig(id: number): UploaderConfigRow | null {
+  return (
+    (db.prepare('SELECT * FROM uploader_config WHERE id = ?').get(id) as
+      | UploaderConfigRow
+      | undefined) ?? null
+  );
+}
+
+export function listInstanceUploaders(): UploaderConfigRow[] {
+  return db
+    .prepare(`SELECT * FROM uploader_config WHERE scope = 'instance' ORDER BY id`)
+    .all() as UploaderConfigRow[];
+}
+
+export function listUserUploaders(userId: number): UploaderConfigRow[] {
+  return db
+    .prepare(`SELECT * FROM uploader_config WHERE scope = 'user' AND owner_user_id = ? ORDER BY id`)
+    .all(userId) as UploaderConfigRow[];
+}
+
+/** The single instance default (unique partial index guarantees at most one). */
+export function getInstanceDefault(): UploaderConfigRow | null {
+  return (
+    (db
+      .prepare(`SELECT * FROM uploader_config WHERE scope = 'instance' AND is_default = 1`)
+      .get() as UploaderConfigRow | undefined) ?? null
+  );
+}
+
+/** Merge a row's non-secret config with its decrypted secrets into the flat
+ *  object a driver's upload() expects. Server-side only. */
+export function resolvedConfig(row: UploaderConfigRow): Record<string, string> {
+  return { ...parseConfigJson(row.config_json), ...decodeSecrets(row.secrets_enc) };
+}
+
+export function toSummary(row: UploaderConfigRow): UploaderConfigSummary {
+  return { id: row.id, driver: row.driver, label: row.label };
+}
+
+// ─── writes ─────────────────────────────────────────────────────────────────
+
+export interface CreateUploaderConfigParams {
+  scope: 'instance' | 'user';
+  ownerUserId?: number | null;
+  driver: string;
+  label?: string;
+  // Flat config, secrets included — split by the driver's schema before storage.
+  values?: Record<string, string>;
+  enabled?: boolean;
+  offeredToUsers?: boolean;
+  locked?: boolean;
+  isDefault?: boolean;
+}
+
+const insertStmt = db.prepare(`
+  INSERT INTO uploader_config
+    (scope, owner_user_id, driver, label, config_json, secrets_enc,
+     enabled, offered_to_users, locked, is_default)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`);
+
+export function createUploaderConfig(p: CreateUploaderConfigParams): number {
+  const drv = getDriver(p.driver);
+  if (!drv) throw new Error(`unknown upload driver: ${p.driver}`);
+  const { config, secrets } = splitConfigBySchema(drv, p.values ?? {});
+  const info = insertStmt.run(
+    p.scope,
+    p.scope === 'user' ? (p.ownerUserId ?? null) : null,
+    p.driver,
+    p.label ?? drv.label,
+    JSON.stringify(config),
+    encodeSecrets(secrets),
+    p.enabled === false ? 0 : 1,
+    p.offeredToUsers ? 1 : 0,
+    p.locked ? 1 : 0,
+    p.isDefault ? 1 : 0,
+  );
+  return Number(info.lastInsertRowid);
+}
+
+export function deleteUploaderConfig(id: number): boolean {
+  const info = db.prepare('DELETE FROM uploader_config WHERE id = ?').run(id);
+  return info.changes > 0;
+}

--- a/server/db/uploaderConfig.ts
+++ b/server/db/uploaderConfig.ts
@@ -142,6 +142,11 @@ const insertStmt = db.prepare(`
 export function createUploaderConfig(p: CreateUploaderConfigParams): number {
   const drv = getDriver(p.driver);
   if (!drv) throw new Error(`unknown upload driver: ${p.driver}`);
+  // A user-scoped row without an owner is orphaned — the resolver's allowed-set
+  // can never match it (owner_user_id NULL !== any userId). Fail fast.
+  if (p.scope === 'user' && p.ownerUserId == null) {
+    throw new Error('a user-scoped uploader requires ownerUserId');
+  }
   const { config, secrets } = splitConfigBySchema(drv, p.values ?? {});
   const info = insertStmt.run(
     p.scope,

--- a/server/db/uploaderConfig.ts
+++ b/server/db/uploaderConfig.ts
@@ -50,12 +50,16 @@ export function encodeSecrets(secrets: Record<string, string>): string | null {
   return encryptSecret(JSON.stringify(secrets));
 }
 
-/** Inverse of encodeSecrets: decrypt + parse back to a flat object. */
+/** Inverse of encodeSecrets: decrypt + parse back to a flat object. A malformed
+ *  or undecryptable envelope (e.g. after a LURKER_SECRET_KEY rotation with no
+ *  re-wrap) degrades to no-secrets rather than throwing — the caller then gets a
+ *  clean "uploader unconfigured" 4xx/503 instead of a 500, and no ciphertext is
+ *  handed to a driver. */
 export function decodeSecrets(enc: string | null): Record<string, string> {
   if (!enc) return {};
-  const json = decryptSecret(enc);
-  if (!json) return {};
   try {
+    const json = decryptSecret(enc);
+    if (!json) return {};
     const parsed = JSON.parse(json);
     return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
   } catch {

--- a/server/db/uploaderConfigSeed.node.test.ts
+++ b/server/db/uploaderConfigSeed.node.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Node edition + operator upload env, set before the DB (and its seed) load.
+process.env.LURKER_EDITION = 'node';
+process.env.LURKER_NODE_UPLOAD_URL = 'https://dropper.test';
+process.env.LURKER_NODE_UPLOAD_API_KEY = 'operator-key-123';
+process.env.LURKER_NODE_UPLOAD_MAX_MB = '1';
+process.env.LURKER_NODE_UPLOAD_MAX_DIM = '512';
+process.env.LURKER_NODE_UPLOAD_QUALITY = '40';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-uploader-seed-node-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+
+interface Row {
+  driver: string;
+  is_default: number;
+  offered_to_users: number;
+  locked: number;
+  config_json: string;
+  secrets_enc: string | null;
+}
+
+beforeAll(async () => {
+  // The seed runs at DB init (below), in the hosted branch, from the env above.
+  db = (await import('./index.js')).default;
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.LURKER_EDITION;
+  delete process.env.LURKER_NODE_UPLOAD_URL;
+  delete process.env.LURKER_NODE_UPLOAD_API_KEY;
+  delete process.env.LURKER_NODE_UPLOAD_MAX_MB;
+  delete process.env.LURKER_NODE_UPLOAD_MAX_DIM;
+  delete process.env.LURKER_NODE_UPLOAD_QUALITY;
+});
+
+describe('seedUploaderConfig (hosted)', () => {
+  it('seeds a single locked hoarder default baked from the operator env', () => {
+    const row = db
+      .prepare(`SELECT * FROM uploader_config WHERE scope = 'instance' AND locked = 1`)
+      .get() as Row | undefined;
+    expect(row).toBeTruthy();
+    expect(row!.driver).toBe('hoarder');
+    expect(row!.is_default).toBe(1);
+    expect(row!.offered_to_users).toBe(1);
+
+    const cfg = JSON.parse(row!.config_json);
+    expect(cfg.url).toBe('https://dropper.test');
+    expect(cfg['policy.hostsThumbnails']).toBe('1');
+    expect(cfg['policy.rasterOnly']).toBe('1');
+    expect(cfg['policy.maxMb']).toBe('1');
+    expect(cfg['policy.maxDim']).toBe('512');
+    expect(cfg['policy.quality']).toBe('40');
+    // api_key is a secret → secrets_enc, never config_json.
+    expect(row!.secrets_enc).toContain('operator-key-123');
+    expect(row!.config_json).not.toContain('operator-key-123');
+  });
+
+  it('locks users out of defining their own uploaders (allow_user_defined=0)', () => {
+    const v = db
+      .prepare(`SELECT value FROM instance_settings WHERE key = 'uploads.allow_user_defined'`)
+      .get() as { value: string } | undefined;
+    expect(v?.value).toBe('0');
+  });
+
+  it('is the only instance row on the hosted fleet (no x0/catbox offered)', () => {
+    const drivers = (
+      db.prepare(`SELECT driver FROM uploader_config WHERE scope = 'instance'`).all() as {
+        driver: string;
+      }[]
+    ).map((r) => r.driver);
+    expect(drivers).toEqual(['hoarder']);
+  });
+});

--- a/server/db/uploaderConfigSeed.test.ts
+++ b/server/db/uploaderConfigSeed.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-uploader-seed-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+let seedUploaderConfig: typeof import('./uploaderConfigSeed.js').seedUploaderConfig;
+let createUser: typeof import('./users.js').createUser;
+let setUserSetting: typeof import('./settings.js').setUserSetting;
+let getUserSettings: typeof import('./settings.js').getUserSettings;
+
+interface Row {
+  id: number;
+  driver: string;
+  is_default: number;
+  offered_to_users: number;
+  secrets_enc: string | null;
+  config_json: string;
+}
+
+const instanceRows = (): Row[] =>
+  db
+    .prepare(`SELECT * FROM uploader_config WHERE scope = 'instance' ORDER BY driver`)
+    .all() as Row[];
+const userRows = (uid: number): Row[] =>
+  db
+    .prepare(`SELECT * FROM uploader_config WHERE scope = 'user' AND owner_user_id = ?`)
+    .all(uid) as Row[];
+const allowUserDefined = (): string | undefined =>
+  (
+    db
+      .prepare(`SELECT value FROM instance_settings WHERE key = 'uploads.allow_user_defined'`)
+      .get() as { value: string } | undefined
+  )?.value;
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  ({ seedUploaderConfig } = await import('./uploaderConfigSeed.js'));
+  ({ createUser } = await import('./users.js'));
+  ({ setUserSetting, getUserSettings } = await import('./settings.js'));
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+beforeEach(() => {
+  // Clear everything the seed touches (users cascade to their uploader_config +
+  // user_settings) for a deterministic starting point.
+  db.prepare('DELETE FROM uploader_config').run();
+  db.prepare('DELETE FROM instance_settings').run();
+  db.prepare('DELETE FROM user_settings').run();
+  db.prepare('DELETE FROM users').run();
+});
+
+describe('seedUploaderConfig (self-host)', () => {
+  it('seeds instance x0 (default) + catbox, allow_user_defined=1', () => {
+    seedUploaderConfig(db);
+    const inst = instanceRows();
+    expect(inst.map((r) => r.driver)).toEqual(['catbox', 'x0']);
+    const x0 = inst.find((r) => r.driver === 'x0')!;
+    const catbox = inst.find((r) => r.driver === 'catbox')!;
+    expect(x0.is_default).toBe(1);
+    expect(x0.offered_to_users).toBe(1);
+    expect(catbox.is_default).toBe(0);
+    expect(catbox.offered_to_users).toBe(1);
+    expect(allowUserDefined()).toBe('1');
+  });
+
+  it('converts a configured catbox user into a user row + uploader_id', () => {
+    const u = createUser('seed-catbox');
+    setUserSetting(u.id, 'uploads.provider', 'catbox');
+    setUserSetting(u.id, 'uploads.catbox.userhash', 'hash1');
+    seedUploaderConfig(db);
+
+    const rows = userRows(u.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].driver).toBe('catbox');
+    expect(rows[0].secrets_enc).toContain('hash1'); // secret carried across
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(rows[0].id);
+  });
+
+  it('converts a configured self-host hoarder user (url public, key secret)', () => {
+    const u = createUser('seed-hoarder');
+    setUserSetting(u.id, 'uploads.provider', 'hoarder');
+    setUserSetting(u.id, 'uploads.hoarder.url', 'https://u.example');
+    setUserSetting(u.id, 'uploads.hoarder.api_key', 'k-secret');
+    seedUploaderConfig(db);
+
+    const rows = userRows(u.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].driver).toBe('hoarder');
+    expect(JSON.parse(rows[0].config_json)).toEqual({ url: 'https://u.example' });
+    expect(rows[0].secrets_enc).toContain('k-secret');
+    expect(rows[0].config_json).not.toContain('k-secret');
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(rows[0].id);
+  });
+
+  it('points an x0 / unconfigured user at the instance x0 row, no user row', () => {
+    const u = createUser('seed-x0'); // no settings at all
+    seedUploaderConfig(db);
+    expect(userRows(u.id)).toHaveLength(0);
+    const x0 = instanceRows().find((r) => r.driver === 'x0')!;
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(x0.id);
+  });
+
+  it('is idempotent — a second run adds no rows and does not clobber', () => {
+    const u = createUser('seed-idem');
+    setUserSetting(u.id, 'uploads.provider', 'catbox');
+    setUserSetting(u.id, 'uploads.catbox.userhash', 'hh');
+    seedUploaderConfig(db);
+    const firstUserRowId = userRows(u.id)[0].id;
+    const firstUploaderId = getUserSettings(u.id)['uploads.uploader_id'];
+
+    seedUploaderConfig(db);
+    expect(instanceRows()).toHaveLength(2); // still just x0 + catbox
+    expect(userRows(u.id)).toHaveLength(1);
+    expect(userRows(u.id)[0].id).toBe(firstUserRowId);
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(firstUploaderId);
+  });
+});

--- a/server/db/uploaderConfigSeed.ts
+++ b/server/db/uploaderConfigSeed.ts
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Seed-once migration for the uploader data model (issue #510). Converts the
+// pre-existing per-user `uploads.*` settings (self-host) or the env-forced hosted
+// uploader into `uploader_config` rows so the rest of the system stops branching
+// on isNodeMode(). Behavior is byte-identical post-migration.
+//
+// Takes `db` as a PARAMETER (never `import db from './index.js'`) because it runs
+// *during* db/index.ts evaluation, before its default export is assigned — the
+// same rule foldMutedIntoIgnoreRules follows. For that reason it also can't use
+// db/uploaderConfig.ts (which binds the imported db + prepares statements at load)
+// and does its own raw SQL + secret encoding here.
+
+import type Database from 'better-sqlite3';
+import { isNodeMode } from '../utils/edition.js';
+import { encryptSecret } from '../utils/secretCrypto.js';
+import { nodeUploadSecrets, nodeUploadLimits } from '../services/uploadProviders/nodeUpload.js';
+
+// Must match instanceSettings.ALLOW_USER_DEFINED_KEY (that module can't be
+// imported here — see header).
+const ALLOW_USER_DEFINED_KEY = 'uploads.allow_user_defined';
+
+// ─── low-level helpers (raw SQL against the passed db) ────────────────────────
+
+function encodeSecrets(secrets: Record<string, string>): string | null {
+  const keys = Object.keys(secrets).filter((k) => secrets[k]);
+  if (keys.length === 0) return null;
+  const compact: Record<string, string> = {};
+  for (const k of keys) compact[k] = secrets[k];
+  return encryptSecret(JSON.stringify(compact));
+}
+
+interface InsertRow {
+  scope: 'instance' | 'user';
+  owner_user_id: number | null;
+  driver: string;
+  label: string;
+  config_json: string;
+  secrets_enc: string | null;
+  enabled: number;
+  offered_to_users: number;
+  locked: number;
+  is_default: number;
+}
+
+function insertRow(db: Database.Database, row: InsertRow): number {
+  const info = db
+    .prepare(
+      `INSERT INTO uploader_config
+         (scope, owner_user_id, driver, label, config_json, secrets_enc,
+          enabled, offered_to_users, locked, is_default)
+       VALUES (@scope, @owner_user_id, @driver, @label, @config_json, @secrets_enc,
+          @enabled, @offered_to_users, @locked, @is_default)`,
+    )
+    .run(row);
+  return Number(info.lastInsertRowid);
+}
+
+function findInstanceRowByDriver(db: Database.Database, driver: string): number | null {
+  const r = db
+    .prepare(`SELECT id FROM uploader_config WHERE scope = 'instance' AND driver = ? LIMIT 1`)
+    .get(driver) as { id: number } | undefined;
+  return r ? r.id : null;
+}
+
+/** Insert an instance row for `driver` only if none exists yet; return its id. */
+function ensureInstanceRow(
+  db: Database.Database,
+  opts: { driver: string; label: string; offered: boolean; isDefault: boolean },
+): number {
+  const existing = findInstanceRowByDriver(db, opts.driver);
+  if (existing != null) return existing;
+  return insertRow(db, {
+    scope: 'instance',
+    owner_user_id: null,
+    driver: opts.driver,
+    label: opts.label,
+    config_json: '{}',
+    secrets_enc: null,
+    enabled: 1,
+    offered_to_users: opts.offered ? 1 : 0,
+    locked: 0,
+    is_default: opts.isDefault ? 1 : 0,
+  });
+}
+
+function setInstanceSettingIfAbsent(db: Database.Database, key: string, value: string): void {
+  db.prepare(
+    `INSERT INTO instance_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO NOTHING`,
+  ).run(key, value);
+}
+
+function getUserSettingsRaw(db: Database.Database, userId: number): Record<string, unknown> {
+  const rows = db
+    .prepare('SELECT key, value FROM user_settings WHERE user_id = ?')
+    .all(userId) as Array<{ key: string; value: string }>;
+  const out: Record<string, unknown> = {};
+  for (const r of rows) {
+    try {
+      out[r.key] = JSON.parse(r.value);
+    } catch {
+      // skip malformed rows
+    }
+  }
+  return out;
+}
+
+function setUserSettingRaw(
+  db: Database.Database,
+  userId: number,
+  key: string,
+  value: unknown,
+): void {
+  db.prepare(
+    `INSERT INTO user_settings (user_id, key, value, updated_at)
+     VALUES (?, ?, ?, datetime('now'))
+     ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+  ).run(userId, key, JSON.stringify(value));
+}
+
+// ─── hosted config (shared by seed + reconcile) ───────────────────────────────
+
+// The locked hosted uploader's config, derived from the operator env. `url` is a
+// non-secret driver field; `api_key` is the secret. The pipeline policy (remote
+// thumbnails, SVG rejection, operator caps) rides in config_json under `policy.*`
+// so the resolver can pick it up without it leaking into the driver's own fields.
+function hostedConfigFromEnv(): { config_json: string; secrets_enc: string | null } {
+  const { url, api_key } = nodeUploadSecrets();
+  const limits = nodeUploadLimits();
+  const config: Record<string, string> = {
+    url,
+    'policy.hostsThumbnails': '1',
+    'policy.rasterOnly': '1',
+    'policy.maxMb': String(limits.maxMb),
+    'policy.maxDim': String(limits.maxDim),
+    'policy.quality': String(limits.quality),
+  };
+  return {
+    config_json: JSON.stringify(config),
+    secrets_enc: encodeSecrets({ api_key }),
+  };
+}
+
+function findHostedRow(db: Database.Database): number | null {
+  const r = db
+    .prepare(
+      `SELECT id FROM uploader_config WHERE scope = 'instance' AND locked = 1 AND driver = 'hoarder' LIMIT 1`,
+    )
+    .get() as { id: number } | undefined;
+  return r ? r.id : null;
+}
+
+// ─── the migration ────────────────────────────────────────────────────────────
+
+/**
+ * Seed the uploader model once. Hosted: a single locked `hoarder` instance
+ * default from env + allow_user_defined=0. Self-host: instance x0 (default) +
+ * catbox rows, allow_user_defined=1, and each user's existing uploads.* settings
+ * converted into a user row with uploads.uploader_id pointed at it. Idempotent —
+ * skips rows/users already converted, so a re-run is a no-op.
+ */
+export function seedUploaderConfig(db: Database.Database): void {
+  const run = db.transaction(() => {
+    if (isNodeMode()) {
+      if (findHostedRow(db) == null) {
+        const { config_json, secrets_enc } = hostedConfigFromEnv();
+        insertRow(db, {
+          scope: 'instance',
+          owner_user_id: null,
+          driver: 'hoarder',
+          label: 'Hosted uploader',
+          config_json,
+          secrets_enc,
+          enabled: 1,
+          offered_to_users: 1,
+          locked: 1,
+          is_default: 1,
+        });
+      }
+      setInstanceSettingIfAbsent(db, ALLOW_USER_DEFINED_KEY, '0');
+      return;
+    }
+
+    // Self-host.
+    const x0Id = ensureInstanceRow(db, {
+      driver: 'x0',
+      label: 'x0.at',
+      offered: true,
+      isDefault: true,
+    });
+    const catboxId = ensureInstanceRow(db, {
+      driver: 'catbox',
+      label: 'catbox.moe',
+      offered: true,
+      isDefault: false,
+    });
+    setInstanceSettingIfAbsent(db, ALLOW_USER_DEFINED_KEY, '1');
+
+    const users = db.prepare('SELECT id FROM users').all() as Array<{ id: number }>;
+    for (const { id: userId } of users) {
+      convertUser(db, userId, x0Id, catboxId);
+    }
+  });
+  run();
+}
+
+function convertUser(db: Database.Database, userId: number, x0Id: number, catboxId: number): void {
+  const settings = getUserSettingsRaw(db, userId);
+
+  // Already converted (has a user row or an explicit uploader_id) → leave alone.
+  const hasUserRow = db
+    .prepare(`SELECT 1 FROM uploader_config WHERE scope = 'user' AND owner_user_id = ? LIMIT 1`)
+    .get(userId);
+  if (hasUserRow || settings['uploads.uploader_id'] != null) return;
+
+  const provider =
+    typeof settings['uploads.provider'] === 'string'
+      ? (settings['uploads.provider'] as string)
+      : 'x0';
+  const userhash =
+    typeof settings['uploads.catbox.userhash'] === 'string'
+      ? (settings['uploads.catbox.userhash'] as string)
+      : '';
+  const hoarderUrl =
+    typeof settings['uploads.hoarder.url'] === 'string'
+      ? (settings['uploads.hoarder.url'] as string)
+      : '';
+  const hoarderKey =
+    typeof settings['uploads.hoarder.api_key'] === 'string'
+      ? (settings['uploads.hoarder.api_key'] as string)
+      : '';
+
+  let targetId: number;
+  if (provider === 'catbox' && userhash) {
+    // Configured catbox → a user row carrying the userhash secret.
+    targetId = insertRow(db, {
+      scope: 'user',
+      owner_user_id: userId,
+      driver: 'catbox',
+      label: 'catbox.moe',
+      config_json: '{}',
+      secrets_enc: encodeSecrets({ userhash }),
+      enabled: 1,
+      offered_to_users: 0,
+      locked: 0,
+      is_default: 0,
+    });
+  } else if (provider === 'hoarder' && hoarderUrl && hoarderKey) {
+    // Configured self-host hoarder → a user row (url public, api_key secret).
+    targetId = insertRow(db, {
+      scope: 'user',
+      owner_user_id: userId,
+      driver: 'hoarder',
+      label: 'Hoarder',
+      config_json: JSON.stringify({ url: hoarderUrl }),
+      secrets_enc: encodeSecrets({ api_key: hoarderKey }),
+      enabled: 1,
+      offered_to_users: 0,
+      locked: 0,
+      is_default: 0,
+    });
+  } else {
+    // Anonymous catbox or x0 (or unconfigured) → point at the seeded instance row.
+    targetId = provider === 'catbox' ? catboxId : x0Id;
+  }
+
+  setUserSettingRaw(db, userId, 'uploads.uploader_id', targetId);
+}
+
+/**
+ * Re-sync the locked hosted uploader from env on every boot. Idempotent no-op on
+ * self-host. Since the config now lives in the DB row (not read from env at
+ * upload time), this is what makes a deploy that rotates LURKER_NODE_UPLOAD_API_KEY
+ * or changes the caps still take effect. If the seed hasn't created the row yet
+ * (a boot before the migration ran), it's a no-op — the seed will create it.
+ */
+export function reconcileHostedUploaderFromEnv(db: Database.Database): void {
+  if (!isNodeMode()) return;
+  const rowId = findHostedRow(db);
+  if (rowId == null) return;
+  const { config_json, secrets_enc } = hostedConfigFromEnv();
+  db.prepare(
+    `UPDATE uploader_config SET config_json = ?, secrets_enc = ?, updated_at = datetime('now') WHERE id = ?`,
+  ).run(config_json, secrets_enc, rowId);
+}

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -21,12 +21,24 @@ process.env.LURKER_NODE_UPLOAD_QUALITY = '40';
 
 const ctx = setupTestDb('routes-uploads-node');
 
-// Same stub pattern as uploads.test.ts: capture the secrets the route hands the
-// provider so we can prove node edition sources them from the environment
-// (nodeUploadSecrets), never from the per-user secretsForProvider below.
+// Same stub pattern as uploads.test.ts: capture the config the route hands the
+// driver so we can prove the hosted uploader sources its credentials from the
+// baked instance row (seeded from the operator env), never from the tenant's
+// per-user settings. The configSchema mirrors hoarder (url + api_key required) so
+// the resolver's "locked-but-unconfigured → 503" check has fields to test.
 const stub = {
-  id: 'stub',
-  requiresSecrets: false,
+  driver: 'hoarder',
+  label: 'Hosted uploader',
+  capabilities: {
+    storesRemotely: true,
+    supportsDelete: false,
+    mintsKeys: false,
+    acceptsContentClasses: ['image', 'text'] as ('image' | 'text' | 'binary')[],
+  },
+  configSchema: [
+    { key: 'url', label: 'URL', type: 'string' as const, required: true, description: '' },
+    { key: 'api_key', label: 'Key', type: 'secret' as const, required: true, description: '' },
+  ],
   capturedSecrets: null as Record<string, string> | null,
   // Lets a test simulate the remote thumbnail upload failing so we can assert
   // the BLOB fallback. Reset per-test by the specs that touch it.
@@ -38,9 +50,9 @@ const stub = {
   async upload(
     _buffer: Buffer,
     meta: { filename: string; mime: string; kind?: string },
-    secrets?: Record<string, string>,
+    config?: Record<string, string>,
   ) {
-    stub.capturedSecrets = secrets ?? null;
+    stub.capturedSecrets = config ?? null;
     stub.lastKinds.push(meta.kind);
     if (meta.kind === 'thumb') {
       if (stub.thumbShouldThrow) {
@@ -53,11 +65,13 @@ const stub = {
 };
 
 vi.mock('../services/uploadProviders/index.js', () => ({
-  providerIds: ['x0', 'catbox', 'hoarder'],
-  getProvider: () => stub,
-  // A distinctive sentinel: if node edition ever fell back to per-user secrets,
-  // the credential assertion below would fail loudly.
-  secretsForProvider: () => ({ from: 'user-settings' }),
+  driverIds: ['x0', 'catbox', 'hoarder'],
+  getDriver: () => stub,
+  secretFieldKeys: () => ['api_key'],
+  splitConfigBySchema: (_driver: unknown, values: Record<string, string>) => ({
+    config: values,
+    secrets: {},
+  }),
 }));
 
 // Mock the sharp pipeline so we can capture the maxDim/quality the route passes
@@ -149,10 +163,17 @@ describe('POST /api/uploads (node edition)', () => {
   });
 
   it('503s with a clear message (no per-user key names) when the operator env is unset', async () => {
+    // The hosted config now lives in the baked instance row, not read from env
+    // per-request. An operator who boots with the env unset gets an unconfigured
+    // locked uploader → the resolver's locked-but-unconfigured check → 503. We
+    // simulate that boot by reconciling the row from a cleared env.
+    const { default: db } = await import('../db/index.js');
+    const { reconcileHostedUploaderFromEnv } = await import('../db/uploaderConfigSeed.js');
     const savedUrl = process.env.LURKER_NODE_UPLOAD_URL;
     const savedKey = process.env.LURKER_NODE_UPLOAD_API_KEY;
     delete process.env.LURKER_NODE_UPLOAD_URL;
     delete process.env.LURKER_NODE_UPLOAD_API_KEY;
+    reconcileHostedUploaderFromEnv(db);
     try {
       const res = await agent
         .post('/api/uploads')
@@ -163,6 +184,7 @@ describe('POST /api/uploads (node edition)', () => {
     } finally {
       process.env.LURKER_NODE_UPLOAD_URL = savedUrl;
       process.env.LURKER_NODE_UPLOAD_API_KEY = savedKey;
+      reconcileHostedUploaderFromEnv(db);
     }
   });
 

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -67,7 +67,6 @@ const stub = {
 vi.mock('../services/uploadProviders/index.js', () => ({
   driverIds: ['x0', 'catbox', 'hoarder'],
   getDriver: () => stub,
-  secretFieldKeys: () => ['api_key'],
   splitConfigBySchema: (_driver: unknown, values: Record<string, string>) => ({
     config: values,
     secrets: {},

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -15,36 +15,45 @@ import type { User } from '../db/users.js';
 
 const ctx = setupTestDb('routes-uploads');
 
-// Stub provider — the route exercises secrets/uploads/url plumbing without
-// reaching the real network. Behavior is configurable per-test via state on
-// the module-level `stub` so we can simulate auth failures, network errors,
-// etc., on demand.
+// Stub driver — the route exercises resolve/upload/url plumbing without reaching
+// the real network. Behavior is configurable per-test via state on the
+// module-level `stub`. The seed migration creates a real `x0` instance default in
+// the test DB; the resolver falls back to it, and the mocked getDriver returns
+// this stub for whatever driver id the resolved uploader names.
 const stub = {
-  id: 'stub',
-  requiresSecrets: false,
+  driver: 'stub',
+  label: 'Stub',
+  capabilities: {
+    storesRemotely: true,
+    supportsDelete: false,
+    mintsKeys: false,
+    acceptsContentClasses: ['image', 'text'] as ('image' | 'text' | 'binary')[],
+  },
+  configSchema: [],
   shouldThrow: null as Error | null,
-  capturedSecrets: null as Record<string, string> | null,
+  capturedConfig: null as Record<string, string> | null,
   async upload(
     _buffer: Buffer,
     meta: { filename: string; mime: string },
-    secrets?: Record<string, string>,
+    config?: Record<string, string>,
   ) {
-    stub.capturedSecrets = secrets ?? null;
+    stub.capturedConfig = config ?? null;
     if (stub.shouldThrow) throw stub.shouldThrow;
     return { url: `https://stub.example/${meta.filename}` };
   },
 };
 
-// The settings registry only accepts the real provider ids in `uploads.provider`,
-// so we can't redirect via settings. Instead, the mocked getProvider returns
-// the stub for whatever id the route asks for (typically the registry default
-// 'x0'). Tests that need to assert on "unknown provider" override
-// getProvider locally inside the spec.
+// Mock the registry so getDriver returns the stub for whatever driver the
+// resolved uploader names. splitConfigBySchema is provided because
+// db/uploaderConfig.ts imports it at load; the resolver reads driver.capabilities
+// + driver.configSchema off the stub.
 vi.mock('../services/uploadProviders/index.js', () => ({
-  providerIds: ['x0', 'catbox', 'hoarder'],
-  getProvider: () => stub,
-  secretsForProvider: (_id: string, settings: Record<string, string>) => ({
-    token: settings['uploads.stub.token'] || '',
+  driverIds: ['x0', 'catbox', 'hoarder'],
+  getDriver: () => stub,
+  secretFieldKeys: () => [],
+  splitConfigBySchema: (_driver: unknown, values: Record<string, string>) => ({
+    config: values,
+    secrets: {},
   }),
 }));
 

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -172,6 +172,20 @@ describe('POST /api/uploads', () => {
     expect(res.status).toBe(502);
     stub.shouldThrow = null;
   });
+
+  it('rejects a content class the resolved driver does not accept (415)', async () => {
+    const prev = stub.capabilities.acceptsContentClasses;
+    stub.capabilities.acceptsContentClasses = ['image']; // no text
+    try {
+      const res = await agent.post('/api/uploads').attach('image', Buffer.from('hello'), {
+        filename: 'note.txt',
+        contentType: 'text/plain',
+      });
+      expect(res.status).toBe(415);
+    } finally {
+      stub.capabilities.acceptsContentClasses = prev;
+    }
+  });
 });
 
 describe('GET /api/uploads/:id/thumb', () => {

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -50,7 +50,6 @@ const stub = {
 vi.mock('../services/uploadProviders/index.js', () => ({
   driverIds: ['x0', 'catbox', 'hoarder'],
   getDriver: () => stub,
-  secretFieldKeys: () => [],
   splitConfigBySchema: (_driver: unknown, values: Record<string, string>) => ({
     config: values,
     secrets: {},

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -14,6 +14,7 @@ import {
   resolveUploader,
   UploaderUnavailableError,
   UploaderNotConfiguredError,
+  type ResolvedUploader,
 } from '../services/uploadProviders/resolve.js';
 import type { UploadListRow } from '../db/uploadHistory.js';
 import { insertUpload, listUploads, getThumbnail, deleteUpload } from '../db/uploadHistory.js';
@@ -53,7 +54,7 @@ router.post(
       // Resolve the configured uploader. Every isNodeMode() branch the old route
       // made (which provider, whose credentials, which caps, SVG policy, thumbnail
       // strategy) is now derived from the resolved uploader's driver + policy.
-      let resolved;
+      let resolved: ResolvedUploader;
       try {
         resolved = resolveUploader({
           userId: req.user!.id,
@@ -89,6 +90,15 @@ router.post(
       // straight through with a .txt extension and no thumbnail.
       const isText = req.file.mimetype === 'text/plain';
       const contentClass: ContentClass = isText ? 'text' : 'image';
+
+      // Validate stage: the resolved driver must accept this content class. In P0
+      // every driver accepts image + text, so this never rejects — but it makes
+      // acceptsContentClasses a real gate (defense-in-depth) once binary-capable
+      // drivers land, rather than a declared-but-unused capability.
+      if (!resolved.driver.capabilities.acceptsContentClasses.includes(contentClass)) {
+        res.status(415).json({ error: `this uploader does not accept ${contentClass} files` });
+        return;
+      }
 
       let outBuffer: Buffer;
       let outMime: string;

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -8,33 +8,32 @@ import { requireAuth } from '../middleware/auth.js';
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from '../services/settingsRegistry.js';
 import * as imagePipeline from '../services/imagePipeline.js';
-import { getProvider, providerIds, secretsForProvider } from '../services/uploadProviders/index.js';
+import { driverIds } from '../services/uploadProviders/index.js';
+import type { ContentClass } from '../services/uploadProviders/index.js';
 import {
-  NODE_UPLOAD_PROVIDER_ID,
-  nodeUploadSecrets,
-  nodeUploadLimits,
-  nodeUploadConfigured,
-} from '../services/uploadProviders/nodeUpload.js';
+  resolveUploader,
+  UploaderUnavailableError,
+  UploaderNotConfiguredError,
+} from '../services/uploadProviders/resolve.js';
 import type { UploadListRow } from '../db/uploadHistory.js';
 import { insertUpload, listUploads, getThumbnail, deleteUpload } from '../db/uploadHistory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
-import { isNodeMode } from '../utils/edition.js';
 import { reportUploadSoon } from '../services/moderationReport.js';
 
 const router = Router();
 router.use(requireAuth);
 
-// Resolve effective settings with registry defaults filled in. Reused across
-// the size-cap middleware and the route handler so they always agree.
-// Settings are untyped (JS module) — Record<string, unknown> is the best we can do.
+// Resolve effective settings with registry defaults filled in. The per-user
+// image-pipeline settings (size cap, max dimension, JPEG quality) are the
+// fallback used when the resolved uploader carries no operator-baked policy caps
+// — i.e. every self-host uploader. Untyped (JS module) → Record<string, unknown>.
 function effectiveSettings(userId: number): Record<string, unknown> {
   return { ...defaultsAsObject(), ...getUserSettings(userId) };
 }
 
-// multer doesn't know about per-user settings until we look up the user, but
-// it needs to be configured up-front. We use a generous hard ceiling (200 MB,
-// the registry max) so multer never rejects below the per-user cap; the route
-// handler enforces the actual per-user `uploads.image.max_upload_mb`.
+// multer needs configuring up-front, before we know the effective per-uploader
+// cap. Use a generous hard ceiling (200 MB, the registry max) so multer never
+// rejects below the real cap; the handler enforces the resolved cap.
 const HARD_BYTE_CEILING = 200 * 1024 * 1024;
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -51,43 +50,45 @@ router.post(
         return;
       }
 
-      // In node edition the operator must have configured the in-house uploader.
-      // Without it the forced provider would throw an error naming per-user
-      // settings a tenant can't see — fail fast with a clear, server-side signal
-      // instead. The boot warning already tells the operator what to set.
-      if (isNodeMode() && !nodeUploadConfigured()) {
-        res.status(503).json({ error: 'uploads are not configured on this server' });
-        return;
+      // Resolve the configured uploader. Every isNodeMode() branch the old route
+      // made (which provider, whose credentials, which caps, SVG policy, thumbnail
+      // strategy) is now derived from the resolved uploader's driver + policy.
+      let resolved;
+      try {
+        resolved = resolveUploader({
+          userId: req.user!.id,
+          isAdmin: req.user!.role === 'admin',
+        });
+      } catch (err) {
+        // A locked instance default that the operator hasn't configured →
+        // server-side 503 (was: isNodeMode() && !nodeUploadConfigured()).
+        if (err instanceof UploaderNotConfiguredError) {
+          res.status(503).json({ error: err.message });
+          return;
+        }
+        // No usable uploader for this account → ask the user to pick one.
+        if (err instanceof UploaderUnavailableError) {
+          res.status(400).json({ error: err.message });
+          return;
+        }
+        throw err;
       }
 
       const settings = effectiveSettings(req.user!.id);
-      // The image-pipeline limits (size cap, max dimension, JPEG quality) are
-      // operator-controlled in node edition — sourced from env, not the tenant's
-      // settings, so a tenant can't lift their own cap or inflate storage. A3
-      // hides the matching UI. Standalone keeps these as per-user settings.
-      const limits = isNodeMode() ? nodeUploadLimits() : null;
-      const maxMb = limits ? limits.maxMb : Number(settings['uploads.image.max_upload_mb']) || 25;
+      // Size cap: operator-baked policy (hosted locked uploader) wins; otherwise
+      // the user's own setting. A tenant can't lift a policy cap because the
+      // policy is on the instance row, not their settings.
+      const maxMb =
+        resolved.policy.maxMb ?? (Number(settings['uploads.image.max_upload_mb']) || 25);
       if (req.file.size > maxMb * 1024 * 1024) {
         res.status(413).json({ error: `file exceeds ${maxMb} MB` });
         return;
       }
 
-      // In node edition the operator forces the in-house uploader and supplies
-      // its credentials from the environment — a tenant never picks a host or
-      // sees the keys. Standalone honors the user's chosen provider as before.
-      const providerId = isNodeMode()
-        ? NODE_UPLOAD_PROVIDER_ID
-        : String(settings['uploads.provider'] ?? '');
-      const provider = getProvider(providerId);
-      if (!provider) {
-        res.status(400).json({ error: `unknown provider: ${providerId}` });
-        return;
-      }
-
-      // Long-message → .txt upload bypasses the sharp pipeline. Providers
-      // (x0.at, catbox, hoarder) are MIME-agnostic, so we hand the raw bytes
+      // Long-message → .txt upload bypasses the sharp pipeline: the bytes go
       // straight through with a .txt extension and no thumbnail.
       const isText = req.file.mimetype === 'text/plain';
+      const contentClass: ContentClass = isText ? 'text' : 'image';
 
       let outBuffer: Buffer;
       let outMime: string;
@@ -108,14 +109,13 @@ router.post(
         let optimized: any;
         try {
           optimized = await imagePipeline.optimize(req.file.buffer, {
-            maxDim: limits
-              ? limits.maxDim
-              : Number(settings['uploads.image.max_dimension']) || 2048,
-            quality: limits ? limits.quality : Number(settings['uploads.image.quality']) || 85,
-            // Hosted service is raster images + .txt only — reject SVG (the one
-            // non-raster format sharp would otherwise pass through). Standalone
-            // keeps SVG passthrough.
-            rasterOnly: isNodeMode(),
+            maxDim:
+              resolved.policy.maxDim ?? (Number(settings['uploads.image.max_dimension']) || 2048),
+            quality: resolved.policy.quality ?? (Number(settings['uploads.image.quality']) || 85),
+            // SVG is rejected only where the resolved uploader's policy says so
+            // (the hosted locked uploader serves raster + .txt). Self-host keeps
+            // the SVG passthrough. Was: rasterOnly = isNodeMode().
+            rasterOnly: resolved.policy.rasterOnly,
           });
         } catch (err) {
           const e = err as { code?: string; message?: string };
@@ -138,41 +138,35 @@ router.post(
       const baseName = originalName.replace(/\.[^.]+$/, '') || `upload-${Date.now()}`;
       const filename = `${baseName}.${outExt}`;
 
-      const secrets: Record<string, string> = isNodeMode()
-        ? nodeUploadSecrets()
-        : secretsForProvider(providerId, settings as Record<string, string>);
-      // provider.upload is from an untyped JS module
+      // provider.upload is from an untyped JS module boundary
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let result: any;
       try {
-        result = await provider.upload(
+        result = await resolved.driver.upload(
           outBuffer,
-          {
-            filename,
-            mime: outMime,
-          },
-          secrets,
+          { filename, mime: outMime, contentClass },
+          resolved.driverConfig,
         );
       } catch (err) {
         const e = err as { code?: string; message?: string };
         const status = e.code === 'PROVIDER_AUTH' ? 401 : e.code === 'PROVIDER_CONFIG' ? 400 : 502;
-        res.status(status).json({ error: e.message, provider: providerId });
+        res.status(status).json({ error: e.message, provider: resolved.driverId });
         return;
       }
 
-      // In node edition the thumbnail goes to remote storage (a `thumbs/` prefix
-      // on the in-house dropper) instead of an inline BLOB, so it doesn't bloat
-      // the cell DB / R2 backups and is served straight from the CDN. Best-effort:
-      // a thumb-upload failure falls back to storing the BLOB (standalone path),
-      // so a hiccup never blocks the user's upload.
+      // Thumbnail strategy is a resolved policy value, not isNodeMode(): a
+      // hostsThumbnails uploader (the hosted in-house one) stores the thumb as a
+      // remote object under a `thumbs/` prefix so it doesn't bloat the cell DB /
+      // R2 backups; everyone else keeps the inline BLOB. Best-effort: a thumb
+      // upload failure falls back to the BLOB so a hiccup never blocks the user.
       let thumbnailBlob: Buffer | null = thumb;
       let thumbnailUrl: string | null = null;
-      if (isNodeMode() && thumb) {
+      if (resolved.policy.hostsThumbnails && thumb) {
         try {
-          const tRes = await provider.upload(
+          const tRes = await resolved.driver.upload(
             thumb,
-            { filename: 'thumb.jpg', mime: 'image/jpeg', kind: 'thumb' },
-            secrets,
+            { filename: 'thumb.jpg', mime: 'image/jpeg', contentClass: 'image', kind: 'thumb' },
+            resolved.driverConfig,
           );
           if (tRes && typeof tRes.url === 'string') {
             thumbnailUrl = tRes.url;
@@ -184,7 +178,7 @@ router.post(
       }
 
       const id = insertUpload(req.user!.id, {
-        provider: providerId,
+        provider: resolved.driverId,
         url: result.url,
         filename: originalName || null,
         mime: outMime,
@@ -193,23 +187,23 @@ router.post(
         height: outHeight,
         thumbnail: thumbnailBlob,
         thumbnail_url: thumbnailUrl,
+        uploader_config_id: resolved.configId,
+        ref: (result.ref as string | undefined) ?? null,
       });
 
-      // Node edition: report the upload to the control plane's moderation index.
-      // Fire-and-forget — never blocks the response; the flush reconciles if the
-      // CP is unreachable. No-op in standalone.
-      if (isNodeMode()) {
-        reportUploadSoon({
-          cell_upload_id: id,
-          cell_user_id: req.user!.id,
-          url: result.url,
-          thumb_url: thumbnailUrl,
-          mime: outMime,
-          byte_size: outByteSize,
-          width: outWidth,
-          height: outHeight,
-        });
-      }
+      // Report the upload to the control plane's moderation index. Self-gates to
+      // a no-op in standalone (no control plane configured), so it's called
+      // unconditionally; fire-and-forget, never blocks the response.
+      reportUploadSoon({
+        cell_upload_id: id,
+        cell_user_id: req.user!.id,
+        url: result.url,
+        thumb_url: thumbnailUrl,
+        mime: outMime,
+        byte_size: outByteSize,
+        width: outWidth,
+        height: outHeight,
+      });
 
       res.json({ id, url: result.url, ...(thumbnailUrl ? { thumbnail_url: thumbnailUrl } : {}) });
     } catch (err) {
@@ -226,22 +220,21 @@ router.get('/', (req: Request, res: Response) => {
     items: rows.map((r) => {
       const { has_thumbnail, thumbnail_url, removed, ...rest } = r;
       // A moderated-away upload keeps its row as a tombstone, but its bytes are
-      // gone (remote object deleted, BLOB cleared) — advertise no thumbnail so
-      // the client renders the tombstone instead of chasing a dead URL.
+      // gone — advertise no thumbnail so the client renders the tombstone.
       if (removed) return { ...rest, removed: true };
-      // Prefer a remote CDN thumbnail (node edition); otherwise fall back to the
-      // local BLOB-serving route when an inline thumbnail exists.
+      // Prefer a remote CDN thumbnail; otherwise fall back to the local
+      // BLOB-serving route when an inline thumbnail exists.
       const thumb = thumbnail_url || (has_thumbnail ? `/api/uploads/${r.id}/thumb` : null);
       return thumb ? { ...rest, thumbnail_url: thumb } : rest;
     }),
-    providers: providerIds,
+    providers: driverIds,
   });
 });
 
 router.get('/:id/thumb', (req: Request, res: Response) => {
   const row = getThumbnail(req.user!.id, Number(req.params.id));
-  // No inline BLOB → nothing to serve here. Node-edition uploads keep their
-  // thumbnail as a remote CDN object (thumbnail_url) the client uses directly.
+  // No inline BLOB → nothing to serve here. Remote-thumbnail uploads keep their
+  // thumbnail as a CDN object (thumbnail_url) the client uses directly.
   if (!row || !row.thumbnail) {
     res.status(404).json({ error: 'not found' });
     return;

--- a/server/services/uploadProviders/catbox.ts
+++ b/server/services/uploadProviders/catbox.ts
@@ -18,20 +18,39 @@
 import { buildMultipart, postBuffer } from './multipart.js';
 import type { MultipartPart } from './multipart.js';
 import { USER_AGENT } from '../../utils/userAgent.js';
+import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 const ENDPOINT = 'https://catbox.moe/user/api.php';
 const TIMEOUT_MS = 60_000;
 
-export const id = 'catbox';
-export const requiresSecrets = false;
+export const driver = 'catbox';
+export const label = 'catbox.moe';
+export const capabilities: DriverCapabilities = {
+  storesRemotely: true,
+  supportsDelete: false,
+  mintsKeys: false,
+  acceptsContentClasses: ['image', 'text'],
+};
+export const configSchema: ConfigField[] = [
+  {
+    key: 'userhash',
+    label: 'Catbox userhash',
+    type: 'secret',
+    required: false,
+    default: '',
+    description:
+      'Optional catbox.moe account hash. Uploads made with a userhash can be ' +
+      'managed from your catbox account; without one they are anonymous.',
+  },
+];
 
 export async function upload(
   buffer: Buffer,
-  { filename, mime }: { filename: string; mime: string },
-  secrets: { userhash?: string } = {},
-): Promise<{ url: string }> {
+  { filename, mime }: UploadMeta,
+  config: { userhash?: string } = {},
+): Promise<UploadResult> {
   const parts: MultipartPart[] = [{ name: 'reqtype', value: 'fileupload' }];
-  if (secrets.userhash) parts.push({ name: 'userhash', value: secrets.userhash });
+  if (config.userhash) parts.push({ name: 'userhash', value: config.userhash });
   parts.push({
     name: 'fileToUpload',
     filename,

--- a/server/services/uploadProviders/hoarder.ts
+++ b/server/services/uploadProviders/hoarder.ts
@@ -8,27 +8,52 @@
 // `url` is already the public CDN URL.
 
 import { USER_AGENT } from '../../utils/userAgent.js';
+import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
-export const id = 'hoarder';
-export const requiresSecrets = true;
+export const driver = 'hoarder';
+export const label = 'Hoarder';
+export const capabilities: DriverCapabilities = {
+  storesRemotely: true,
+  supportsDelete: false,
+  mintsKeys: false,
+  acceptsContentClasses: ['image', 'text'],
+};
+export const configSchema: ConfigField[] = [
+  {
+    key: 'url',
+    label: 'Hoarder URL',
+    type: 'string',
+    required: true,
+    default: '',
+    description: 'Base URL of your Hoarder instance (e.g. https://upload.example.com).',
+  },
+  {
+    key: 'api_key',
+    label: 'Hoarder API key',
+    type: 'secret',
+    required: true,
+    default: '',
+    description: 'API key for your Hoarder instance.',
+  },
+];
 
 export async function upload(
   buffer: Buffer,
-  { filename, mime, kind }: { filename: string; mime: string; kind?: string },
-  secrets: { url?: string; api_key?: string } = {},
-): Promise<{ url: string }> {
-  if (!secrets.url) {
-    throw Object.assign(new Error('hoarder provider requires uploads.hoarder.url'), {
+  { filename, mime, kind }: UploadMeta,
+  config: { url?: string; api_key?: string } = {},
+): Promise<UploadResult> {
+  if (!config.url) {
+    throw Object.assign(new Error('hoarder uploader requires a url'), {
       code: 'PROVIDER_CONFIG',
     });
   }
-  if (!secrets.api_key) {
-    throw Object.assign(new Error('hoarder provider requires uploads.hoarder.api_key'), {
+  if (!config.api_key) {
+    throw Object.assign(new Error('hoarder uploader requires an api_key'), {
       code: 'PROVIDER_CONFIG',
     });
   }
 
-  const base = secrets.url.replace(/\/+$/, '');
+  const base = config.url.replace(/\/+$/, '');
   const form = new FormData();
   // Text fields before the file so multipart parsers populate req.body reliably.
   if (kind) form.append('kind', kind);
@@ -37,7 +62,7 @@ export async function upload(
   const resp = await fetch(`${base}/api/upload`, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${secrets.api_key}`,
+      Authorization: `Bearer ${config.api_key}`,
       'User-Agent': USER_AGENT,
     },
     body: form,

--- a/server/services/uploadProviders/index.ts
+++ b/server/services/uploadProviders/index.ts
@@ -1,52 +1,60 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+// The driver registry. Each driver is a small module conforming to UploadDriver
+// (see types.ts). The old thin `UploadProvider` + `secretsForProvider` switch is
+// gone: the secret/non-secret split now derives from each driver's configSchema,
+// so there's no three-places coupling to keep in sync.
+
 import * as x0 from './x0.js';
 import * as catbox from './catbox.js';
 import * as hoarder from './hoarder.js';
+import type { UploadDriver } from './types.js';
 
-/** Shared shape every upload provider must satisfy. */
-export interface UploadProvider {
-  id: string;
-  requiresSecrets: boolean;
-  upload(
-    buffer: Buffer,
-    // `kind` is an optional hint forwarded to the in-house dropper so a thumbnail
-    // lands under a `thumbs/` prefix. Hosts that don't understand it ignore the
-    // extra form field.
-    meta: { filename: string; mime: string; kind?: string },
-    secrets?: Record<string, string>,
-  ): Promise<{ url: string }>;
-}
+export type {
+  ContentClass,
+  ConfigField,
+  DriverCapabilities,
+  UploadMeta,
+  UploadResult,
+  UploadDriver,
+} from './types.js';
 
-const PROVIDERS: Record<string, UploadProvider> = {
-  [x0.id]: x0,
-  [catbox.id]: catbox,
-  [hoarder.id]: hoarder,
+const DRIVERS: Record<string, UploadDriver> = {
+  [x0.driver]: x0,
+  [catbox.driver]: catbox,
+  [hoarder.driver]: hoarder,
 };
 
-export const providerIds = Object.keys(PROVIDERS);
+export const driverIds = Object.keys(DRIVERS);
 
-export function getProvider(id: string): UploadProvider | null {
-  return PROVIDERS[id] ?? null;
+export function getDriver(id: string): UploadDriver | null {
+  return DRIVERS[id] ?? null;
 }
 
-// Lift the relevant per-user settings into a flat secrets object for the
-// chosen provider. The router calls this rather than passing the raw settings
-// object so each provider only sees what it needs.
-export function secretsForProvider(
-  id: string,
-  userSettings: Record<string, string>,
-): Record<string, string> {
-  switch (id) {
-    case 'catbox':
-      return { userhash: userSettings['uploads.catbox.userhash'] || '' };
-    case 'hoarder':
-      return {
-        url: userSettings['uploads.hoarder.url'] || '',
-        api_key: userSettings['uploads.hoarder.api_key'] || '',
-      };
-    default:
-      return {};
+/** The keys of a driver's `type:'secret'` config fields — the fields that get
+ *  encrypted into `secrets_enc` and never projected to the client. */
+export function secretFieldKeys(driver: UploadDriver): string[] {
+  return driver.configSchema.filter((f) => f.type === 'secret').map((f) => f.key);
+}
+
+/**
+ * Split a flat config object into its non-secret and secret halves per a
+ * driver's schema. Unknown keys are dropped (schema is the allowlist). Used on
+ * write (uploaderConfig) so `config_json` never holds a secret and `secrets_enc`
+ * never holds a non-secret.
+ */
+export function splitConfigBySchema(
+  driver: UploadDriver,
+  values: Record<string, string>,
+): { config: Record<string, string>; secrets: Record<string, string> } {
+  const config: Record<string, string> = {};
+  const secrets: Record<string, string> = {};
+  for (const field of driver.configSchema) {
+    const v = values[field.key];
+    if (v == null) continue;
+    if (field.type === 'secret') secrets[field.key] = v;
+    else config[field.key] = v;
   }
+  return { config, secrets };
 }

--- a/server/services/uploadProviders/index.ts
+++ b/server/services/uploadProviders/index.ts
@@ -32,12 +32,6 @@ export function getDriver(id: string): UploadDriver | null {
   return DRIVERS[id] ?? null;
 }
 
-/** The keys of a driver's `type:'secret'` config fields — the fields that get
- *  encrypted into `secrets_enc` and never projected to the client. */
-export function secretFieldKeys(driver: UploadDriver): string[] {
-  return driver.configSchema.filter((f) => f.type === 'secret').map((f) => f.key);
-}
-
 /**
  * Split a flat config object into its non-secret and secret halves per a
  * driver's schema. Unknown keys are dropped (schema is the allowlist). Used on

--- a/server/services/uploadProviders/objectKey.test.ts
+++ b/server/services/uploadProviders/objectKey.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { buildObjectKey, sanitizeSegment, randomId } from './objectKey.js';
+
+describe('sanitizeSegment', () => {
+  it('keeps the safe alphabet verbatim', () => {
+    expect(sanitizeSegment('Q3-report_v2.png')).toBe('Q3-report_v2.png');
+  });
+  it('replaces unsafe characters with a dash', () => {
+    expect(sanitizeSegment('a b/c*d')).toBe('a-b-c-d');
+  });
+  it('drops dot-only segments to the fallback (traversal-proof)', () => {
+    expect(sanitizeSegment('..')).toBe('file');
+    expect(sanitizeSegment('.')).toBe('file');
+  });
+  it('empty → fallback', () => {
+    expect(sanitizeSegment('')).toBe('file');
+  });
+  it('trims leading/trailing separators', () => {
+    expect(sanitizeSegment('--x--')).toBe('x');
+  });
+  it('caps length', () => {
+    expect(sanitizeSegment('a'.repeat(200)).length).toBe(96);
+  });
+  it('honors a custom fallback', () => {
+    expect(sanitizeSegment('...', 'img')).toBe('img');
+  });
+});
+
+describe('buildObjectKey', () => {
+  it('default shape is {random}.{ext}', () => {
+    expect(buildObjectKey({ ext: 'jpg' })).toMatch(/^[0-9a-f]{12}\.jpg$/);
+  });
+  it('applies a prefix', () => {
+    expect(buildObjectKey({ prefix: 'thumbs', ext: 'jpg' })).toMatch(/^thumbs\/[0-9a-f]{12}\.jpg$/);
+  });
+  it('preserve shape is {random}/{sanitized-basename}.{ext}', () => {
+    expect(buildObjectKey({ ext: 'png', originalBasename: 'Q3 Report.png' })).toMatch(
+      /^[0-9a-f]{12}\/Q3-Report\.png$/,
+    );
+  });
+  it('takes the extension from the pipeline output, never the claimed name', () => {
+    // A user's .html basename is preserved but the served extension is the
+    // validated pipeline ext — never becomes .html.
+    expect(buildObjectKey({ ext: 'jpg', originalBasename: 'evil.html' })).toMatch(/\/evil\.jpg$/);
+  });
+  it('a traversal attempt in the name cannot escape the key', () => {
+    const k = buildObjectKey({ ext: 'png', originalBasename: '../../etc/passwd' });
+    expect(k).not.toContain('..');
+    // Exactly two segments: the locating random id and one decorative name.
+    expect(k.split('/')).toHaveLength(2);
+  });
+  it('randomId is 12 hex chars (48 bits)', () => {
+    expect(randomId()).toMatch(/^[0-9a-f]{12}$/);
+  });
+});

--- a/server/services/uploadProviders/objectKey.ts
+++ b/server/services/uploadProviders/objectKey.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared storage-key builder for drivers that mint their own keys (`mintsKeys`
+// — s3, local). Ported from the JawshTheDark/lurker fork's buildObjectKey so the
+// sanitization rule lives in exactly ONE place rather than being re-derived per
+// driver. No P0 driver mints keys yet; this is the foundation the local (P1) and
+// s3 (P2) drivers + preserve-original-filename (#517) build on. Unit-tested so it
+// isn't dead code.
+//
+// Security invariants (see design §5.2):
+//   - The random segment LOCATES the file; the trailing original name is
+//     decorative. A traversal attempt in the name can never escape the key.
+//   - The extension always comes from the pipeline output, never the client's
+//     claim — callers pass a validated `ext`.
+//   - Dot-only segments ("..", ".") collapse to a fallback so a proxy can't be
+//     tricked into path traversal.
+
+import { randomBytes } from 'crypto';
+
+// 48 bits of randomness — matches the fork; ample for non-guessable, non-
+// enumerable keys at this scale.
+const RANDOM_BYTES = 6;
+const SEGMENT_MAX = 96;
+
+/** Random, URL-safe, non-guessable id used as the locating segment of a key. */
+export function randomId(): string {
+  return randomBytes(RANDOM_BYTES).toString('hex');
+}
+
+/**
+ * Sanitize an arbitrary filename basename into a single safe path segment:
+ * `[A-Za-z0-9._-]` only, length-capped, leading/trailing separators trimmed,
+ * dot-only results dropped to `fallback`.
+ */
+export function sanitizeSegment(name: string, fallback = 'file'): string {
+  let s = (name || '').replace(/[^A-Za-z0-9._-]+/g, '-');
+  s = s.replace(/^[-.]+/, '').replace(/[-.]+$/, '');
+  if (s === '' || /^\.+$/.test(s)) return fallback;
+  if (s.length > SEGMENT_MAX) s = s.slice(0, SEGMENT_MAX);
+  return s;
+}
+
+export interface BuildObjectKeyOpts {
+  // Optional leading namespace, e.g. 'thumbs'. Slashes trimmed.
+  prefix?: string;
+  // Extension from the pipeline output (no leading dot); sanitized to alnum.
+  ext: string;
+  // When set, the original basename is preserved as a cosmetic trailing segment
+  // (preserve-original-filename, #517). Omit for the default random-only key.
+  originalBasename?: string;
+}
+
+/**
+ * Build a storage key. Shapes (matching The Lounge's `<random>/<name>` trick):
+ *   default:  {prefix}/{random}.{ext}
+ *   preserve: {prefix}/{random}/{sanitized-basename}.{ext}
+ */
+export function buildObjectKey({ prefix, ext, originalBasename }: BuildObjectKeyOpts): string {
+  const rnd = randomId();
+  const cleanExt = (ext || 'bin').replace(/[^A-Za-z0-9]+/g, '').toLowerCase() || 'bin';
+  const p = prefix ? `${prefix.replace(/^\/+|\/+$/g, '')}/` : '';
+  if (originalBasename != null && originalBasename !== '') {
+    const base = sanitizeSegment(originalBasename.replace(/\.[^.]+$/, ''), 'file');
+    return `${p}${rnd}/${base}.${cleanExt}`;
+  }
+  return `${p}${rnd}.${cleanExt}`;
+}

--- a/server/services/uploadProviders/resolve.test.ts
+++ b/server/services/uploadProviders/resolve.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-resolve-uploader-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('../../db/index.js').default;
+let resolve: typeof import('./resolve.js');
+let cfg: typeof import('../../db/uploaderConfig.js');
+let createUser: typeof import('../../db/users.js').createUser;
+let setUserSetting: typeof import('../../db/settings.js').setUserSetting;
+let userId: number;
+
+beforeAll(async () => {
+  db = (await import('../../db/index.js')).default;
+  resolve = await import('./resolve.js');
+  cfg = await import('../../db/uploaderConfig.js');
+  ({ createUser } = await import('../../db/users.js'));
+  ({ setUserSetting } = await import('../../db/settings.js'));
+  userId = createUser('resolve-alice').id;
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+beforeEach(() => {
+  db.prepare('DELETE FROM uploader_config').run();
+  db.prepare('DELETE FROM user_settings WHERE user_id = ?').run(userId);
+});
+
+describe('resolveUploader', () => {
+  it('falls back to the instance default when the user has no choice', () => {
+    const id = cfg.createUploaderConfig({
+      scope: 'instance',
+      driver: 'x0',
+      offeredToUsers: true,
+      isDefault: true,
+    });
+    const r = resolve.resolveUploader({ userId });
+    expect(r.configId).toBe(id);
+    expect(r.driverId).toBe('x0');
+  });
+
+  it('prefers the user default (uploads.uploader_id) over the instance default', () => {
+    cfg.createUploaderConfig({
+      scope: 'instance',
+      driver: 'x0',
+      offeredToUsers: true,
+      isDefault: true,
+    });
+    const mine = cfg.createUploaderConfig({
+      scope: 'user',
+      ownerUserId: userId,
+      driver: 'catbox',
+      values: { userhash: 'h' },
+    });
+    setUserSetting(userId, 'uploads.uploader_id', mine);
+    const r = resolve.resolveUploader({ userId });
+    expect(r.configId).toBe(mine);
+    expect(r.driverConfig).toEqual({ userhash: 'h' });
+  });
+
+  it('throws UploaderUnavailable when nothing resolves', () => {
+    expect(() => resolve.resolveUploader({ userId })).toThrow(resolve.UploaderUnavailableError);
+  });
+
+  it('an explicit requested id that is not allowed is an error, not a silent reroute', () => {
+    cfg.createUploaderConfig({
+      scope: 'instance',
+      driver: 'x0',
+      offeredToUsers: true,
+      isDefault: true,
+    });
+    const hidden = cfg.createUploaderConfig({
+      scope: 'instance',
+      driver: 'catbox',
+      offeredToUsers: false,
+    });
+    expect(() => resolve.resolveUploader({ userId, requestedId: hidden })).toThrow(
+      resolve.UploaderUnavailableError,
+    );
+    // ...but an admin may use a non-offered instance row.
+    expect(resolve.resolveUploader({ userId, isAdmin: true, requestedId: hidden }).configId).toBe(
+      hidden,
+    );
+  });
+
+  it('surfaces policy metadata separately from driver config', () => {
+    // Simulate the hosted locked uploader: driver field + policy.* metadata.
+    const id = cfg.createUploaderConfig({
+      scope: 'instance',
+      driver: 'hoarder',
+      isDefault: true,
+      locked: true,
+      values: { url: 'https://dropper.test' },
+    });
+    // Bake the policy + secret the way the seed does (raw, bypassing the schema
+    // split which would drop the policy.* keys).
+    db.prepare('UPDATE uploader_config SET config_json = ? WHERE id = ?').run(
+      JSON.stringify({
+        url: 'https://dropper.test',
+        'policy.hostsThumbnails': '1',
+        'policy.rasterOnly': '1',
+        'policy.maxMb': '1',
+        'policy.maxDim': '512',
+        'policy.quality': '40',
+      }),
+      id,
+    );
+    db.prepare('UPDATE uploader_config SET secrets_enc = ? WHERE id = ?').run(
+      JSON.stringify({ api_key: 'k' }),
+      id,
+    );
+    const r = resolve.resolveUploader({ userId });
+    expect(r.driverConfig).toEqual({ url: 'https://dropper.test', api_key: 'k' });
+    expect(r.policy).toEqual({
+      hostsThumbnails: true,
+      rasterOnly: true,
+      maxMb: 1,
+      maxDim: 512,
+      quality: 40,
+    });
+  });
+
+  it('a locked uploader missing a required field → UploaderNotConfigured (→ 503)', () => {
+    cfg.createUploaderConfig({
+      scope: 'instance',
+      driver: 'hoarder', // url + api_key required
+      isDefault: true,
+      locked: true,
+      // no values → required fields empty
+    });
+    expect(() => resolve.resolveUploader({ userId })).toThrow(resolve.UploaderNotConfiguredError);
+  });
+});

--- a/server/services/uploadProviders/resolve.test.ts
+++ b/server/services/uploadProviders/resolve.test.ts
@@ -68,6 +68,57 @@ describe('resolveUploader', () => {
     expect(() => resolve.resolveUploader({ userId })).toThrow(resolve.UploaderUnavailableError);
   });
 
+  describe('P0 bridge: legacy uploads.provider dropdown', () => {
+    it('honors the dropdown, overriding the migration-seeded uploader_id', () => {
+      const x0 = cfg.createUploaderConfig({
+        scope: 'instance',
+        driver: 'x0',
+        offeredToUsers: true,
+        isDefault: true,
+      });
+      const catbox = cfg.createUploaderConfig({
+        scope: 'instance',
+        driver: 'catbox',
+        offeredToUsers: true,
+      });
+      // Migration pointed uploader_id at x0; the user then switched the dropdown.
+      setUserSetting(userId, 'uploads.uploader_id', x0);
+      setUserSetting(userId, 'uploads.provider', 'catbox');
+      expect(resolve.resolveUploader({ userId }).configId).toBe(catbox);
+    });
+
+    it('prefers the user’s own configured uploader for that driver (carries secrets)', () => {
+      cfg.createUploaderConfig({
+        scope: 'instance',
+        driver: 'catbox',
+        offeredToUsers: true,
+        isDefault: true,
+      });
+      const mine = cfg.createUploaderConfig({
+        scope: 'user',
+        ownerUserId: userId,
+        driver: 'catbox',
+        values: { userhash: 'h' },
+      });
+      setUserSetting(userId, 'uploads.provider', 'catbox');
+      const r = resolve.resolveUploader({ userId });
+      expect(r.configId).toBe(mine);
+      expect(r.driverConfig).toEqual({ userhash: 'h' });
+    });
+
+    it('falls through to the instance default when the enum maps to nothing usable', () => {
+      const x0 = cfg.createUploaderConfig({
+        scope: 'instance',
+        driver: 'x0',
+        offeredToUsers: true,
+        isDefault: true,
+      });
+      // No hoarder row exists for this user → unmappable → default, not an error.
+      setUserSetting(userId, 'uploads.provider', 'hoarder');
+      expect(resolve.resolveUploader({ userId }).configId).toBe(x0);
+    });
+  });
+
   it('an explicit requested id that is not allowed is an error, not a silent reroute', () => {
     cfg.createUploaderConfig({
       scope: 'instance',

--- a/server/services/uploadProviders/resolve.ts
+++ b/server/services/uploadProviders/resolve.ts
@@ -23,7 +23,7 @@ import {
   resolvedConfig,
   type UploaderConfigRow,
 } from '../../db/uploaderConfig.js';
-import { getDriver, type UploadDriver, type DriverCapabilities } from './index.js';
+import { getDriver, type UploadDriver } from './index.js';
 
 // Policy metadata lives in config_json under `policy.<key>` string values so the
 // driver config (the schema fields) stays clean. Seeded onto the hosted locked
@@ -46,10 +46,6 @@ export interface ResolvedUploader {
   configId: number;
   driverId: string;
   driver: UploadDriver;
-  label: string;
-  capabilities: DriverCapabilities;
-  scope: 'instance' | 'user';
-  locked: boolean;
   // Driver fields only (schema keys + decrypted secrets); policy stripped.
   driverConfig: Record<string, string>;
   policy: UploaderPolicy;
@@ -154,10 +150,6 @@ export function resolveUploader(input: ResolveInput): ResolvedUploader {
     configId: chosen.id,
     driverId: chosen.driver,
     driver,
-    label: chosen.label,
-    capabilities: driver.capabilities,
-    scope: chosen.scope,
-    locked: chosen.locked === 1,
     driverConfig,
     policy,
   };

--- a/server/services/uploadProviders/resolve.ts
+++ b/server/services/uploadProviders/resolve.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Resolve which configured uploader an upload should use. Replaces the old
+// `isNodeMode() ? forced-provider : user-setting` selection + secretsForProvider
+// switch in routes/uploads.ts with a single policy lookup:
+//
+//   allowed(user) = { user rows owned by user, enabled }
+//                 ∪ { instance rows enabled AND offered_to_users }
+//                 ∪ (isAdmin ? all instance rows : ∅)
+//   effective     = requested (must be allowed) ?? user default (if allowed)
+//                                               ?? instance is_default
+//
+// The returned object carries the decrypted+merged driver config plus the policy
+// metadata (thumbnail strategy, SVG rule, size/pipeline caps) that the hosted
+// locked default bakes into its config_json. Every isNodeMode() branch the route
+// used to make is now one of these fields.
+
+import { getUserSettings } from '../../db/settings.js';
+import {
+  getUploaderConfig,
+  getInstanceDefault,
+  resolvedConfig,
+  type UploaderConfigRow,
+} from '../../db/uploaderConfig.js';
+import { getDriver, type UploadDriver, type DriverCapabilities } from './index.js';
+
+// Policy metadata lives in config_json under `policy.<key>` string values so the
+// driver config (the schema fields) stays clean. Seeded onto the hosted locked
+// uploader (db/uploaderConfigSeed.ts); absent on ordinary self-host rows.
+const POLICY_PREFIX = 'policy.';
+
+export interface UploaderPolicy {
+  // true → upload a separate thumb object and store thumbnail_url; false → keep
+  // the inline BLOB thumbnail (the historical self-host behavior).
+  hostsThumbnails: boolean;
+  // true → reject SVG (hosted); false → pass SVG through (self-host).
+  rasterOnly: boolean;
+  // Operator-baked pipeline caps; undefined → fall back to the user's settings.
+  maxMb?: number;
+  maxDim?: number;
+  quality?: number;
+}
+
+export interface ResolvedUploader {
+  configId: number;
+  driverId: string;
+  driver: UploadDriver;
+  label: string;
+  capabilities: DriverCapabilities;
+  scope: 'instance' | 'user';
+  locked: boolean;
+  // Driver fields only (schema keys + decrypted secrets); policy stripped.
+  driverConfig: Record<string, string>;
+  policy: UploaderPolicy;
+}
+
+export class UploaderUnavailableError extends Error {
+  code = 'UPLOADER_UNAVAILABLE';
+  constructor(message = 'no usable uploader is configured for this account') {
+    super(message);
+  }
+}
+
+export class UploaderNotConfiguredError extends Error {
+  code = 'UPLOADER_NOT_CONFIGURED';
+  constructor(message = 'uploads are not configured on this server') {
+    super(message);
+  }
+}
+
+export interface ResolveInput {
+  userId: number;
+  isAdmin?: boolean;
+  // Per-upload override (client-supplied). Absent in P0 — the client doesn't send
+  // it yet — so resolution runs the user-default → instance-default path.
+  requestedId?: number | null;
+}
+
+function isAllowed(row: UploaderConfigRow, userId: number, isAdmin: boolean): boolean {
+  if (!row.enabled) return false;
+  if (row.scope === 'user') return row.owner_user_id === userId;
+  return row.offered_to_users === 1 || isAdmin;
+}
+
+function splitPolicy(merged: Record<string, string>): {
+  driverConfig: Record<string, string>;
+  policy: UploaderPolicy;
+} {
+  const driverConfig: Record<string, string> = {};
+  const raw: Record<string, string> = {};
+  for (const [k, v] of Object.entries(merged)) {
+    if (k.startsWith(POLICY_PREFIX)) raw[k.slice(POLICY_PREFIX.length)] = String(v);
+    else driverConfig[k] = String(v);
+  }
+  const num = (s: string | undefined): number | undefined => {
+    if (s == null || s === '') return undefined;
+    const n = Number(s);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  return {
+    driverConfig,
+    policy: {
+      hostsThumbnails: raw.hostsThumbnails === '1' || raw.hostsThumbnails === 'true',
+      rasterOnly: raw.rasterOnly === '1' || raw.rasterOnly === 'true',
+      maxMb: num(raw.maxMb),
+      maxDim: num(raw.maxDim),
+      quality: num(raw.quality),
+    },
+  };
+}
+
+/** True when a locked instance uploader is missing a required driver field —
+ *  the hosted "operator hasn't configured uploads yet" case (→ 503). */
+function lockedButUnconfigured(
+  row: UploaderConfigRow,
+  driver: UploadDriver,
+  driverConfig: Record<string, string>,
+): boolean {
+  if (row.locked !== 1) return false;
+  return driver.configSchema.some((f) => f.required && !driverConfig[f.key]);
+}
+
+export function resolveUploader(input: ResolveInput): ResolvedUploader {
+  const { userId, isAdmin = false, requestedId = null } = input;
+
+  let chosen: UploaderConfigRow | null = null;
+
+  if (requestedId != null) {
+    const r = getUploaderConfig(requestedId);
+    // An explicit choice that isn't usable is an error — never silently reroute
+    // the file to a different backend (design decision 15).
+    if (!r || !isAllowed(r, userId, isAdmin)) throw new UploaderUnavailableError();
+    chosen = r;
+  } else {
+    const settings = getUserSettings(userId);
+    const savedId = settings['uploads.uploader_id'];
+    if (typeof savedId === 'number') {
+      const r = getUploaderConfig(savedId);
+      if (r && isAllowed(r, userId, isAdmin)) chosen = r;
+    }
+    if (!chosen) chosen = getInstanceDefault();
+  }
+
+  if (!chosen) throw new UploaderUnavailableError();
+
+  const driver = getDriver(chosen.driver);
+  if (!driver) throw new UploaderUnavailableError(`unknown upload driver: ${chosen.driver}`);
+
+  const { driverConfig, policy } = splitPolicy(resolvedConfig(chosen));
+  if (lockedButUnconfigured(chosen, driver, driverConfig)) throw new UploaderNotConfiguredError();
+
+  return {
+    configId: chosen.id,
+    driverId: chosen.driver,
+    driver,
+    label: chosen.label,
+    capabilities: driver.capabilities,
+    scope: chosen.scope,
+    locked: chosen.locked === 1,
+    driverConfig,
+    policy,
+  };
+}

--- a/server/services/uploadProviders/resolve.ts
+++ b/server/services/uploadProviders/resolve.ts
@@ -20,6 +20,8 @@ import { getUserSettings } from '../../db/settings.js';
 import {
   getUploaderConfig,
   getInstanceDefault,
+  listUserUploaders,
+  listInstanceUploaders,
   resolvedConfig,
   type UploaderConfigRow,
 } from '../../db/uploaderConfig.js';
@@ -79,6 +81,25 @@ function isAllowed(row: UploaderConfigRow, userId: number, isAdmin: boolean): bo
   return row.offered_to_users === 1 || isAdmin;
 }
 
+// P0 bridge helper: resolve a legacy `uploads.provider` enum value to a concrete
+// uploader this user may use, preferring their own configured row (which carries
+// their secrets, e.g. a catbox userhash) over an offered instance row for the
+// same driver. Returns null when the enum maps to nothing usable (e.g. 'hoarder'
+// with no configured row) so the caller can fall through. Removed with the bridge
+// at P3.
+function findAllowedByDriver(
+  driver: string,
+  userId: number,
+  isAdmin: boolean,
+): UploaderConfigRow | null {
+  const userRow = listUserUploaders(userId).find((r) => r.driver === driver && r.enabled === 1);
+  if (userRow) return userRow;
+  const instRow = listInstanceUploaders().find(
+    (r) => r.driver === driver && r.enabled === 1 && (r.offered_to_users === 1 || isAdmin),
+  );
+  return instRow ?? null;
+}
+
 function splitPolicy(merged: Record<string, string>): {
   driverConfig: Record<string, string>;
   policy: UploaderPolicy;
@@ -130,10 +151,22 @@ export function resolveUploader(input: ResolveInput): ResolvedUploader {
     chosen = r;
   } else {
     const settings = getUserSettings(userId);
-    const savedId = settings['uploads.uploader_id'];
-    if (typeof savedId === 'number') {
-      const r = getUploaderConfig(savedId);
-      if (r && isAllowed(r, userId, isAdmin)) chosen = r;
+    // P0 bridge: the legacy `uploads.provider` dropdown is still the only live
+    // selection UI (the picker that writes uploads.uploader_id is P3), so honor it
+    // — map the enum to this user's matching uploader so changing the dropdown
+    // still switches hosts. Takes precedence over the migration-seeded
+    // uploads.uploader_id, which the dropdown does not update. Remove when the P3
+    // selection UI lands and writes uploads.uploader_id directly.
+    const provider = settings['uploads.provider'];
+    if (typeof provider === 'string' && provider) {
+      chosen = findAllowedByDriver(provider, userId, isAdmin);
+    }
+    if (!chosen) {
+      const savedId = settings['uploads.uploader_id'];
+      if (typeof savedId === 'number') {
+        const r = getUploaderConfig(savedId);
+        if (r && isAllowed(r, userId, isAdmin)) chosen = r;
+      }
     }
     if (!chosen) chosen = getInstanceDefault();
   }

--- a/server/services/uploadProviders/types.ts
+++ b/server/services/uploadProviders/types.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared driver contract for the uploader. A *driver* is the mechanism that
+// gets bytes to a destination (x0/catbox/hoarder today; local/s3 later); a
+// *configured uploader* (uploader_config row) is a named instance of a driver
+// with its settings filled in. Kept in its own module so both index.ts (the
+// registry) and the individual driver modules can import the types without an
+// import cycle.
+
+export type ContentClass = 'image' | 'text' | 'binary';
+
+/** One field a driver needs configured. `secret` fields are encrypted at rest
+ *  and never projected to the client. This single declaration drives the admin
+ *  form, the secret/non-secret split, and the client-safe projection. */
+export interface ConfigField {
+  key: string;
+  label: string;
+  type: 'string' | 'secret';
+  required: boolean;
+  default?: string;
+  description: string;
+}
+
+export interface DriverCapabilities {
+  // true → the driver returns a public URL on another origin (x0/catbox/hoarder/
+  // s3). false → WE serve the bytes (local) and the route builds the URL.
+  storesRemotely: boolean;
+  // Can the stored bytes be removed given a ref? All P0 drivers: false (external
+  // forwarders don't offer delete; hosted takedown stays CP/admin-key-only).
+  supportsDelete: boolean;
+  // true only where WE construct the storage key (s3, local — none in P0). The
+  // preserve-original-filename option (#517) is a no-op where the remote host
+  // names the file.
+  mintsKeys: boolean;
+  // Defense-in-depth; the effective gate is instance policy ∩ this.
+  acceptsContentClasses: ContentClass[];
+  // local, s3 — never offered on the hosted fleet.
+  selfHostOnly?: boolean;
+}
+
+export interface UploadMeta {
+  filename: string;
+  mime: string;
+  // Forward-looking classification the route always supplies; optional because no
+  // P0 driver consumes it (the local/s3 drivers will branch on it later).
+  contentClass?: ContentClass;
+  // Hint forwarded to the in-house dropper so a thumbnail lands under a
+  // `thumbs/` prefix. Hosts that don't understand it ignore the extra field.
+  kind?: 'thumb';
+}
+
+export interface UploadResult {
+  url: string;
+  // Opaque delete handle (object key / disk key); absent when not deletable.
+  ref?: string;
+  bytes?: number;
+}
+
+export interface UploadDriver {
+  driver: string; // stable id, matches uploader_config.driver
+  label: string; // default human label
+  capabilities: DriverCapabilities;
+  configSchema: ConfigField[];
+  upload(buffer: Buffer, meta: UploadMeta, config: Record<string, string>): Promise<UploadResult>;
+  // Present iff capabilities.supportsDelete.
+  delete?(ref: string, config: Record<string, string>): Promise<void>;
+}

--- a/server/services/uploadProviders/x0.ts
+++ b/server/services/uploadProviders/x0.ts
@@ -5,16 +5,24 @@
 // body is the bare URL with a trailing newline.
 
 import { USER_AGENT } from '../../utils/userAgent.js';
+import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 const ENDPOINT = 'https://x0.at/';
 
-export const id = 'x0';
-export const requiresSecrets = false;
+export const driver = 'x0';
+export const label = 'x0.at';
+export const capabilities: DriverCapabilities = {
+  storesRemotely: true,
+  supportsDelete: false,
+  mintsKeys: false,
+  acceptsContentClasses: ['image', 'text'],
+};
+export const configSchema: ConfigField[] = [];
 
 export async function upload(
   buffer: Buffer,
-  { filename, mime }: { filename: string; mime: string },
-): Promise<{ url: string }> {
+  { filename, mime }: UploadMeta,
+): Promise<UploadResult> {
   const form = new FormData();
   form.append('file', new Blob([new Uint8Array(buffer)], { type: mime }), filename);
 


### PR DESCRIPTION
Foundation for the uploader overhaul (#509). Closes #510.

**Behavior byte-identical** — no client/UI changes, the `/api/uploads` contract and inline-BLOB thumbnails are unchanged, and the legacy `uploads.provider` dropdown still switches hosts on self-host. Every `isNodeMode()` branch in the upload route becomes a driver capability or a policy lookup. Design doc §4.

## What's in it

**Data model**
- New `uploader_config` table (scope/driver/`config_json`/encrypted `secrets_enc`/`offered_to_users`/`locked`/`is_default`, partial unique index for the single default) and `instance_settings` KV (first key `uploads.allow_user_defined`).
- `upload_history` gains `uploader_config_id` + `ref` (nullable, additive).
- `SCHEMA_VERSION` 13→14 gates a **seed-once** migration; a boot reconcile keeps the hosted uploader in sync with env. The version bump is gated on the seed succeeding, so a failed migration genuinely retries next boot.

**Capability driver interface** (`uploadProviders/types.ts` + `index.ts`)
- `UploadDriver` with `capabilities` + `configSchema`, replacing the thin provider shape and the `secretsForProvider` switch — the secret/non-secret split and client projection now derive from the schema.
- x0/catbox/hoarder keep their `upload()` bodies verbatim, just declaring capabilities.
- Adds shared `objectKey.ts` (`buildObjectKey`/`sanitizeSegment` + `mintsKeys`) as the foundation for #517/local/s3 (unit-tested; no P0 driver mints keys yet).

**Resolver** (`resolve.ts`)
- One policy lookup replacing every `isNodeMode()` branch: allowed-set → effective uploader → decrypt+merge config, splitting `policy.*` metadata (thumbnail strategy, SVG rule, size caps) from driver fields.
- `UploaderUnavailable` → 400, `UploaderNotConfigured` → 503.
- **P0 bridge:** honors the legacy `uploads.provider` dropdown (mapping the enum to the user's matching uploader) so provider-switching keeps working until the P3 selection UI writes `uploads.uploader_id` directly.

**Route** (`routes/uploads.ts`)
- Formalized `ingest → resolve → validate → process → dispatch → record → report`. The remote-vs-blob thumbnail choice is now the resolved `hostsThumbnails` policy (true only for the hosted uploader). Response shape, `/thumb` route, and the client are untouched.

**Migration** (`uploaderConfigSeed.ts`, `db`-as-parameter to avoid the import cycle)
- Self-host seeds x0/catbox + converts each user's `uploads.*` settings into a user row; hosted seeds one locked `hoarder` default from env + `allow_user_defined=0`. Legacy `uploads.*` keys left in place, which keeps the export contract whole (new tables declared `skip` in `exportSchema.ts`).

## Deploy / safety notes

- **Hosted:** byte-identical — the seed creates the locked `hoarder` default from the existing env, and every upload resolves to it (provider, operator creds, env caps, remote thumbnails, moderation report all preserved; exercised end-to-end by `uploads.node.test.ts`).
- **Rollback-safe:** additive schema; the old image ignores the new tables and reverts to env-based behavior. No downgrade migration runs.
- One deliberate semantic change (owner-approved): hosted upload config is read from env at **boot** (baked + reconciled) rather than per-request. Immaterial to the fleet, which only changes that env via redeploy.

## Testing

New suites for objectKey, uploaderConfig (incl. secret encrypt-at-rest roundtrip + undecryptable-secret degradation), instanceSettings, resolve (incl. the provider bridge), and the seed (self-host + hosted). Existing route suites adapted. Full suite green (2046), `npm run check` clean. Reviewed at `/code-review high`; findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)