### PR TITLE
Uploads P1: local disk uploader driver (#511)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,16 @@ VAPID_SUBJECT=mailto:you@example.com
 # URL or mailto:. Leave unset to fall back to the upstream project link.
 # USER_AGENT_CONTACT=https://lurker.example.com
 
+# Public base URL of this instance (scheme + host, no trailing path). Only the
+# "local disk" uploader needs it: files it stores are served back from this
+# server, and the link pasted into IRC must be absolute so it resolves for
+# everyone. Set it to the public origin your reverse proxy serves Lurker on —
+# the same one that routes /uploads/local to this backend. Leave unset to derive
+# the origin from each upload request (works behind a proxy that sets
+# X-Forwarded-Host); set it explicitly when that guess is wrong (e.g. the vite
+# dev server, which rewrites the Host to localhost:8010).
+# PUBLIC_BASE_URL=https://irc.example.com
+
 # ---------------------------------------------------------------------------
 # Node mode (hosted lurker.chat service) — leave ALL of this unset for normal
 # self-hosting. A standalone instance ignores it entirely.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "file-type": "^19.6.0",
         "irc-framework": "^4.13.1",
         "multer": "^2.2.0",
         "selfsigned": "^5.5.0",
@@ -108,6 +109,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2415,6 +2426,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@simplewebauthn/server": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.2.tgz",
@@ -2439,6 +2456,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -4245,6 +4268,24 @@
         }
       }
     },
+    "node_modules/file-type": {
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
+      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-stream": "^9.0.1",
+        "strtok3": "^9.0.1",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -4436,6 +4477,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/github-from-package": {
@@ -5596,6 +5653,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/peek-readable": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
+      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -6412,6 +6482,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strtok3": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
+      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^5.3.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -6593,6 +6680,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -6688,6 +6793,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "file-type": "^19.6.0",
     "irc-framework": "^4.13.1",
     "multer": "^2.2.0",
     "selfsigned": "^5.5.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -22,6 +22,7 @@ import bookmarksRouter from './routes/bookmarks.js';
 import pushRouter from './routes/push.js';
 import adminRouter from './routes/admin.js';
 import uploadsRouter from './routes/uploads.js';
+import localUploadsRouter from './routes/localUploads.js';
 import dccRouter from './routes/dcc.js';
 import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
@@ -61,6 +62,14 @@ export function buildApp(sessionSecret: string): Express {
   app.use('/api/push', pushRouter);
   app.use('/api/admin', adminRouter);
   app.use('/api/uploads', uploadsRouter);
+  // Public (no-auth) serving of local-driver files. Off /api by design: the URL
+  // is opened by anyone the uploader shares it with, protected only by its
+  // non-guessable key. Mounted before the SPA fallback so it wins the route.
+  // Self-host only — the `local` driver isn't offered on the (ephemeral) hosted
+  // fleet, so the route would only ever 404 there; don't expose it at all.
+  if (!isNodeMode()) {
+    app.use('/uploads/local', localUploadsRouter);
+  }
   app.use('/api/dcc', dccRouter);
   app.use('/api/drafts', draftsRouter);
   app.use('/api/exports', exportsRouter);

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -7,7 +7,11 @@ import path from 'path';
 import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
 import { foldBufferCase } from './foldBufferCase.js';
-import { seedUploaderConfig, reconcileHostedUploaderFromEnv } from './uploaderConfigSeed.js';
+import {
+  seedUploaderConfig,
+  reconcileBuiltInUploaders,
+  reconcileHostedUploaderFromEnv,
+} from './uploaderConfigSeed.js';
 
 // Guardrail: under vitest, refuse to fall back to the real database. A test
 // that forgets to isolate DATABASE_PATH would otherwise open data/lurker.db and
@@ -990,7 +994,7 @@ ensureColumn('push_subscriptions', 'fail_count', 'INTEGER NOT NULL DEFAULT 0');
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
-const SCHEMA_VERSION = 14;
+const SCHEMA_VERSION = 15;
 const schemaVersionRow = db
   .prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`)
   .get() as { value: string } | undefined;
@@ -1526,13 +1530,20 @@ try {
   }
 }
 
-// Issue #510: seed the uploader data model once — instance x0/catbox rows +
+// Issue #510: seed the uploader data model — instance x0/catbox rows +
 // per-user conversion of existing uploads.* settings (self-host), or a single
 // locked hosted uploader from env + allow_user_defined=0 (hosted). Behavior is
 // byte-identical post-migration. Passed `db` (not importing it) to avoid an
 // import cycle, matching foldMutedIntoIgnoreRules above. See db/uploaderConfigSeed.ts.
+//
+// The gate is the current SCHEMA_VERSION (not a fixed 14) because the seed is
+// fully idempotent: bumping the version re-runs it to introduce a newly-added
+// built-in instance row on already-migrated installs without a bespoke block.
+// v15 (#511) adds the self-host `local` disk uploader this way — a DB seeded at
+// v14 by P0 has no `local` row, so the dropdown would resolve to nothing and
+// fall back to x0 until this re-seed creates it.
 let uploaderSeedOk = true;
-if (schemaVersion < 14) {
+if (schemaVersion < SCHEMA_VERSION) {
   try {
     seedUploaderConfig(db);
   } catch (err) {
@@ -1542,6 +1553,16 @@ if (schemaVersion < 14) {
     uploaderSeedOk = false;
     console.warn('[db] uploader-config seed migration failed (will retry next boot):', err);
   }
+}
+
+// Ensure the self-host built-in instance uploaders exist on every boot
+// (idempotent). Independent of the version-gated seed above so a newly-added
+// built-in (the #511 local disk driver) reaches an already-migrated DB even
+// though its schema_version won't re-trigger the one-shot seed.
+try {
+  reconcileBuiltInUploaders(db);
+} catch (err) {
+  console.warn('[db] built-in uploader reconcile failed:', err);
 }
 
 // Re-sync the hosted locked uploader from env on every boot — idempotent no-op on
@@ -1554,9 +1575,10 @@ try {
   console.warn('[db] hosted uploader env reconcile failed:', err);
 }
 
-// Gate on uploaderSeedOk: if the #510 seed threw, keep schema_version below 14 so
-// the seed retries on the next boot instead of being silently skipped forever
-// (the other <14 blocks are shape/data-gated, so re-running them is a no-op).
+// Gate on uploaderSeedOk: if the uploader seed threw, leave schema_version
+// un-bumped so the seed retries on the next boot instead of being silently
+// skipped forever (the other version blocks are shape/data-gated, so re-running
+// them is a no-op).
 if (schemaVersion < SCHEMA_VERSION && uploaderSeedOk) {
   db.prepare(
     `INSERT INTO app_meta (key, value) VALUES ('schema_version', ?)

--- a/server/db/uploadHistory.ts
+++ b/server/db/uploadHistory.ts
@@ -132,6 +132,24 @@ export function getThumbnail(userId: number, id: number): { thumbnail: Buffer | 
     .get(userId, Number(id)) as { thumbnail: Buffer | null } | undefined;
 }
 
+/** The delete-reap view of a row: which configured uploader produced it and the
+ *  driver's opaque on-storage handle, so the caller can unlink the bytes for
+ *  drivers that own their storage (local, s3). User-scoped, so a caller can only
+ *  reap their own uploads. */
+export interface UploadReapRow {
+  uploader_config_id: number | null;
+  ref: string | null;
+  provider: string;
+}
+
+export function getUploadForReap(userId: number, id: number): UploadReapRow | undefined {
+  return db
+    .prepare(
+      'SELECT uploader_config_id, ref, provider FROM upload_history WHERE user_id = ? AND id = ?',
+    )
+    .get(userId, Number(id)) as UploadReapRow | undefined;
+}
+
 export function deleteUpload(userId: number, id: number): boolean {
   const info = db
     .prepare(

--- a/server/db/uploaderConfigSeed.test.ts
+++ b/server/db/uploaderConfigSeed.test.ts
@@ -11,6 +11,7 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 
 let db: typeof import('./index.js').default;
 let seedUploaderConfig: typeof import('./uploaderConfigSeed.js').seedUploaderConfig;
+let reconcileBuiltInUploaders: typeof import('./uploaderConfigSeed.js').reconcileBuiltInUploaders;
 let createUser: typeof import('./users.js').createUser;
 let setUserSetting: typeof import('./settings.js').setUserSetting;
 let getUserSettings: typeof import('./settings.js').getUserSettings;
@@ -32,6 +33,16 @@ const userRows = (uid: number): Row[] =>
   db
     .prepare(`SELECT * FROM uploader_config WHERE scope = 'user' AND owner_user_id = ?`)
     .all(uid) as Row[];
+// Insert an instance row directly (bypassing the seed) to model a pre-existing
+// DB state — e.g. a P0-era DB that has x0/catbox but no local.
+const ensureInstance = (driver: string, opts: { isDefault?: number }): void => {
+  db.prepare(
+    `INSERT INTO uploader_config
+       (scope, owner_user_id, driver, label, config_json, secrets_enc,
+        enabled, offered_to_users, locked, is_default)
+     VALUES ('instance', NULL, ?, ?, '{}', NULL, 1, 1, 0, ?)`,
+  ).run(driver, driver, opts.isDefault ?? 0);
+};
 const allowUserDefined = (): string | undefined =>
   (
     db
@@ -41,7 +52,7 @@ const allowUserDefined = (): string | undefined =>
 
 beforeAll(async () => {
   db = (await import('./index.js')).default;
-  ({ seedUploaderConfig } = await import('./uploaderConfigSeed.js'));
+  ({ seedUploaderConfig, reconcileBuiltInUploaders } = await import('./uploaderConfigSeed.js'));
   ({ createUser } = await import('./users.js'));
   ({ setUserSetting, getUserSettings } = await import('./settings.js'));
 });
@@ -58,16 +69,20 @@ beforeEach(() => {
 });
 
 describe('seedUploaderConfig (self-host)', () => {
-  it('seeds instance x0 (default) + catbox, allow_user_defined=1', () => {
+  it('seeds instance x0 (default) + catbox + local, allow_user_defined=1', () => {
     seedUploaderConfig(db);
     const inst = instanceRows();
-    expect(inst.map((r) => r.driver)).toEqual(['catbox', 'x0']);
+    expect(inst.map((r) => r.driver).toSorted()).toEqual(['catbox', 'local', 'x0']);
     const x0 = inst.find((r) => r.driver === 'x0')!;
     const catbox = inst.find((r) => r.driver === 'catbox')!;
+    const local = inst.find((r) => r.driver === 'local')!;
     expect(x0.is_default).toBe(1);
     expect(x0.offered_to_users).toBe(1);
     expect(catbox.is_default).toBe(0);
     expect(catbox.offered_to_users).toBe(1);
+    // Local disk is offered but never the default — a self-hoster opts in.
+    expect(local.is_default).toBe(0);
+    expect(local.offered_to_users).toBe(1);
     expect(allowUserDefined()).toBe('1');
   });
 
@@ -108,6 +123,47 @@ describe('seedUploaderConfig (self-host)', () => {
     expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(x0.id);
   });
 
+  it('re-seed adds a newly-introduced built-in row (local) to a P0-era DB', () => {
+    // Model a DB seeded by P0 (v14): x0 + catbox instance rows, no local. The
+    // schema-version bump re-runs the idempotent seed, which must introduce the
+    // local row rather than leave the dropdown resolving to nothing.
+    seedUploaderConfig(db);
+    db.prepare(`DELETE FROM uploader_config WHERE driver = 'local'`).run();
+    expect(instanceRows().some((r) => r.driver === 'local')).toBe(false);
+
+    seedUploaderConfig(db);
+    const local = instanceRows().find((r) => r.driver === 'local');
+    expect(local).toBeTruthy();
+    expect(local!.offered_to_users).toBe(1);
+    expect(local!.is_default).toBe(0);
+  });
+
+  it('reconcile self-heals a wedged DB (x0+catbox, no local) on boot', () => {
+    // Model the exact wedge: a DB whose schema_version was bumped past the
+    // one-shot seed without the local row ever being created, so the seed will
+    // never re-run. The every-boot reconcile must add local anyway.
+    ensureInstance('x0', { isDefault: 1 });
+    ensureInstance('catbox', {});
+    expect(instanceRows().some((r) => r.driver === 'local')).toBe(false);
+
+    reconcileBuiltInUploaders(db);
+
+    const local = instanceRows().find((r) => r.driver === 'local')!;
+    expect(local).toBeTruthy();
+    expect(local.offered_to_users).toBe(1);
+    // The pre-existing x0 default is untouched — reconcile never re-asserts it.
+    const x0 = instanceRows().find((r) => r.driver === 'x0')!;
+    expect(x0.is_default).toBe(1);
+    expect(instanceRows().filter((r) => r.is_default === 1)).toHaveLength(1);
+  });
+
+  it('reconcile is a no-op when the built-ins already exist', () => {
+    seedUploaderConfig(db);
+    const before = instanceRows().length;
+    reconcileBuiltInUploaders(db);
+    expect(instanceRows()).toHaveLength(before);
+  });
+
   it('is idempotent — a second run adds no rows and does not clobber', () => {
     const u = createUser('seed-idem');
     setUserSetting(u.id, 'uploads.provider', 'catbox');
@@ -117,7 +173,7 @@ describe('seedUploaderConfig (self-host)', () => {
     const firstUploaderId = getUserSettings(u.id)['uploads.uploader_id'];
 
     seedUploaderConfig(db);
-    expect(instanceRows()).toHaveLength(2); // still just x0 + catbox
+    expect(instanceRows()).toHaveLength(3); // still just x0 + catbox + local
     expect(userRows(u.id)).toHaveLength(1);
     expect(userRows(u.id)[0].id).toBe(firstUserRowId);
     expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(firstUploaderId);

--- a/server/db/uploaderConfigSeed.ts
+++ b/server/db/uploaderConfigSeed.ts
@@ -91,6 +91,47 @@ function setInstanceSettingIfAbsent(db: Database.Database, key: string, value: s
   ).run(key, value);
 }
 
+function hasInstanceDefault(db: Database.Database): boolean {
+  return !!db
+    .prepare(`SELECT 1 FROM uploader_config WHERE scope = 'instance' AND is_default = 1 LIMIT 1`)
+    .get();
+}
+
+/**
+ * Ensure the self-host built-in instance uploaders (x0 default, catbox, local
+ * disk) and the allow_user_defined policy exist. Purely additive and idempotent:
+ * ensureInstanceRow only inserts when a driver's row is absent, so an existing
+ * row's default/label/config is never clobbered. x0 is claimed as the default
+ * only when no instance default exists yet, so re-running this never conflicts
+ * with the one-default unique index (and never overrides a self-hoster's chosen
+ * default). Returns the x0/catbox ids the per-user conversion points at.
+ */
+function ensureSelfHostInstanceRows(db: Database.Database): { x0Id: number; catboxId: number } {
+  const defaultExists = hasInstanceDefault(db);
+  const x0Id = ensureInstanceRow(db, {
+    driver: 'x0',
+    label: 'x0.at',
+    offered: true,
+    isDefault: !defaultExists,
+  });
+  const catboxId = ensureInstanceRow(db, {
+    driver: 'catbox',
+    label: 'catbox.moe',
+    offered: true,
+    isDefault: false,
+  });
+  // The zero-dependency self-host option (#511): files written to our own disk
+  // and served back. Offered but not the default — a self-hoster opts in.
+  ensureInstanceRow(db, {
+    driver: 'local',
+    label: 'Local disk',
+    offered: true,
+    isDefault: false,
+  });
+  setInstanceSettingIfAbsent(db, ALLOW_USER_DEFINED_KEY, '1');
+  return { x0Id, catboxId };
+}
+
 function getUserSettingsRaw(db: Database.Database, userId: number): Record<string, unknown> {
   const rows = db
     .prepare('SELECT key, value FROM user_settings WHERE user_id = ?')
@@ -182,20 +223,9 @@ export function seedUploaderConfig(db: Database.Database): void {
       return;
     }
 
-    // Self-host.
-    const x0Id = ensureInstanceRow(db, {
-      driver: 'x0',
-      label: 'x0.at',
-      offered: true,
-      isDefault: true,
-    });
-    const catboxId = ensureInstanceRow(db, {
-      driver: 'catbox',
-      label: 'catbox.moe',
-      offered: true,
-      isDefault: false,
-    });
-    setInstanceSettingIfAbsent(db, ALLOW_USER_DEFINED_KEY, '1');
+    // Self-host: ensure the built-in instance rows, then run the one-time
+    // per-user conversion of existing uploads.* settings.
+    const { x0Id, catboxId } = ensureSelfHostInstanceRows(db);
 
     const users = db.prepare('SELECT id FROM users').all() as Array<{ id: number }>;
     for (const { id: userId } of users) {
@@ -203,6 +233,22 @@ export function seedUploaderConfig(db: Database.Database): void {
     }
   });
   run();
+}
+
+/**
+ * Ensure the built-in instance uploaders exist on every boot (idempotent),
+ * independent of the version-gated one-time seed. This is what lets a
+ * newly-added built-in (e.g. the #511 local disk driver) reach an already-
+ * migrated DB: bumping SCHEMA_VERSION to re-run the one-shot seed is fragile —
+ * an interleaved boot can bump the version without the row — so the built-ins
+ * self-heal here instead. Self-host only; the hosted locked uploader is
+ * reconciled from env by reconcileHostedUploaderFromEnv.
+ */
+export function reconcileBuiltInUploaders(db: Database.Database): void {
+  if (isNodeMode()) return;
+  db.transaction(() => {
+    ensureSelfHostInstanceRows(db);
+  })();
 }
 
 function convertUser(db: Database.Database, userId: number, x0Id: number, catboxId: number): void {

--- a/server/routes/localUploads.integration.test.ts
+++ b/server/routes/localUploads.integration.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// End-to-end proof of the local uploader with NO registry mocking: the seeded
+// self-host `local` instance row is selected via the legacy provider dropdown,
+// the real driver writes to disk, the upload route absolutizes the URL, the
+// public serve route streams it back, and deleting the history row reaps the
+// on-disk bytes.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Express } from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import sharp from 'sharp';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+import * as local from '../services/uploadProviders/local.js';
+
+const ctx = setupTestDb('routes-localuploads-int');
+
+let storageDir: string;
+const prevEnv = process.env.LOCAL_UPLOADS_DIR;
+let app: Express;
+let agent: LurkerTestAgent;
+let user: User;
+let smallPng: Buffer;
+
+beforeAll(async () => {
+  storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-localint-'));
+  process.env.LOCAL_UPLOADS_DIR = storageDir;
+
+  const { createUser } = await import('../db/users.js');
+  const { setUserSetting } = await import('../db/settings.js');
+  const uploadsRouter = (await import('./uploads.js')).default;
+  const localRouter = (await import('./localUploads.js')).default;
+
+  user = createUser('localint-alice');
+  // Select the seeded self-host `local` instance uploader via the P0 dropdown.
+  setUserSetting(user.id, 'uploads.provider', 'local');
+
+  app = createTestApp({ '/api/uploads': uploadsRouter, '/uploads/local': localRouter });
+  agent = await createAuthedAgent(app, user.id);
+
+  smallPng = await sharp({
+    create: { width: 16, height: 16, channels: 3, background: { r: 10, g: 200, b: 90 } },
+  })
+    .png()
+    .toBuffer();
+});
+
+afterAll(() => {
+  if (prevEnv == null) delete process.env.LOCAL_UPLOADS_DIR;
+  else process.env.LOCAL_UPLOADS_DIR = prevEnv;
+  fs.rmSync(storageDir, { recursive: true, force: true });
+  ctx.cleanup();
+});
+
+// The byte reap is fire-and-forget (the DELETE responds before the async unlink
+// finishes), so poll for its effect rather than assume a single tick.
+async function waitUntil(fn: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) throw new Error('condition not met in time');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe('local uploader — full round trip', () => {
+  it('uploads to disk, serves it back, and reaps bytes on delete', async () => {
+    const up = await agent
+      .post('/api/uploads')
+      .set('X-Forwarded-Proto', 'https')
+      .set('X-Forwarded-Host', 'irc.example.com')
+      .attach('image', smallPng, { filename: 'photo.png', contentType: 'image/png' });
+
+    expect(up.status).toBe(200);
+    // Absolutized against the forwarded origin, pointing at our serve route.
+    expect(up.body.url).toMatch(
+      /^https:\/\/irc\.example\.com\/uploads\/local\/[0-9a-f]{12}\.(png|jpe?g|webp)$/,
+    );
+
+    // The image was optimized to JPEG by the pipeline and written to disk (under
+    // its shard subdir).
+    const servePath = new URL(up.body.url).pathname; // /uploads/local/<key>
+    const key = servePath.split('/').pop()!;
+    expect(fs.existsSync(local.resolveDiskPath(key))).toBe(true);
+
+    // Serve it back through the public route with hardened headers.
+    const served = await agent.get(servePath);
+    expect(served.status).toBe(200);
+    expect(served.headers['content-disposition']).toBe('inline');
+    expect(served.headers['x-content-type-options']).toBe('nosniff');
+    expect(served.headers['content-type']).toMatch(/^image\//);
+
+    // Deleting the history row reaps the on-disk file (orphan reap).
+    const del = await agent.delete(`/api/uploads/${up.body.id}`);
+    expect(del.status).toBe(200);
+    await waitUntil(() => !fs.existsSync(local.resolveDiskPath(key)));
+    expect(fs.existsSync(local.resolveDiskPath(key))).toBe(false);
+  });
+});

--- a/server/routes/localUploads.test.ts
+++ b/server/routes/localUploads.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Express } from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import sharp from 'sharp';
+import { createTestApp, createAnonAgent } from '../test-utils/testApp.js';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import * as local from '../services/uploadProviders/local.js';
+
+let dir: string;
+let app: Express;
+let agent: LurkerTestAgent;
+const prevEnv = process.env.LOCAL_UPLOADS_DIR;
+
+// Write a buffer through the real driver and return the served path.
+async function put(buffer: Buffer, filename: string, mime: string): Promise<string> {
+  const res = await local.upload(buffer, { filename, mime }, {});
+  return res.url; // /uploads/local/<key>
+}
+
+beforeAll(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-localserve-'));
+  process.env.LOCAL_UPLOADS_DIR = dir;
+  const router = (await import('./localUploads.js')).default;
+  app = createTestApp({ '/uploads/local': router });
+  agent = createAnonAgent(app);
+});
+
+afterAll(() => {
+  if (prevEnv == null) delete process.env.LOCAL_UPLOADS_DIR;
+  else process.env.LOCAL_UPLOADS_DIR = prevEnv;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('GET /uploads/local/:key', () => {
+  it('serves a recognized image inline with hardened headers', async () => {
+    const png = await sharp({
+      create: { width: 8, height: 8, channels: 3, background: { r: 0, g: 128, b: 255 } },
+    })
+      .png()
+      .toBuffer();
+    const url = await put(png, 'pic.png', 'image/png');
+
+    const res = await agent.get(url);
+    expect(res.status).toBe(200);
+    // Content-Type comes from the sniffed magic bytes, not any stored claim.
+    expect(res.headers['content-type']).toBe('image/png');
+    expect(res.headers['content-disposition']).toBe('inline');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['content-security-policy']).toContain("default-src 'none'");
+    expect(res.headers['cache-control']).toContain('immutable');
+  });
+
+  it('honors a Range request with 206 partial content (via res.sendFile)', async () => {
+    const png = await sharp({
+      create: { width: 8, height: 8, channels: 3, background: { r: 1, g: 2, b: 3 } },
+    })
+      .png()
+      .toBuffer();
+    const url = await put(png, 'range.png', 'image/png');
+
+    const res = await agent.get(url).set('Range', 'bytes=0-3');
+    expect(res.status).toBe(206);
+    expect(res.headers['content-range']).toMatch(/^bytes 0-3\//);
+    expect(res.headers['accept-ranges']).toBe('bytes');
+    // The sniffed type still wins over sendFile's extension guess.
+    expect(res.headers['content-type']).toBe('image/png');
+  });
+
+  it('serves plain text inline as text/plain', async () => {
+    const url = await put(Buffer.from('just some notes\nsecond line'), 'note.txt', 'text/plain');
+    const res = await agent.get(url);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
+    expect(res.headers['content-disposition']).toBe('inline');
+  });
+
+  it('forces download for a recognized non-inline type (pdf)', async () => {
+    // Minimal PDF header — file-type recognizes application/pdf, which is not on
+    // the inline allowlist, so it must be served as an attachment.
+    const pdf = Buffer.concat([Buffer.from('%PDF-1.4\n'), Buffer.alloc(64, 0x20)]);
+    const url = await put(pdf, 'doc.pdf', 'application/pdf');
+    const res = await agent.get(url);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('application/pdf');
+    expect(res.headers['content-disposition']).toMatch(/^attachment/);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('serves HTML as inert text/plain source, never executable', async () => {
+    // HTML is valid UTF-8 → sniffs to text/plain (never text/html), and nosniff
+    // stops the browser from re-sniffing it into an executable document.
+    const html = Buffer.from('<html><script>alert(1)</script></html>');
+    const url = await put(html, 'evil.html', 'text/html');
+    const res = await agent.get(url);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('serves text inline even when a multibyte char straddles the sniff window', async () => {
+    // 4099 ASCII bytes + a 3-byte '€' (E2 82 AC): byte 4100 (the sniff cutoff)
+    // lands mid-character. Without trimming the partial sequence, the UTF-8 check
+    // would throw and the file would be force-downloaded as octet-stream.
+    const content = Buffer.concat([
+      Buffer.from('a'.repeat(4099)),
+      Buffer.from('€ and then some more text to run past the window'),
+    ]);
+    const url = await put(content, 'long.txt', 'text/plain');
+    const res = await agent.get(url);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('text/plain; charset=utf-8');
+    expect(res.headers['content-disposition']).toBe('inline');
+  });
+
+  it('404s an invalid key without touching the filesystem', async () => {
+    const bad = ['../../etc/passwd', 'not-a-key', 'a1b2c3d4e5f6', 'ABCDEF012345.png'];
+    for (const k of bad) {
+      const res = await agent.get(`/uploads/local/${encodeURIComponent(k)}`);
+      expect(res.status).toBe(404);
+    }
+  });
+
+  it('404s a well-formed key with no file on disk', async () => {
+    const res = await agent.get('/uploads/local/0123456789ab.png');
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/routes/localUploads.ts
+++ b/server/routes/localUploads.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Public, UNAUTHENTICATED route that serves files written by the `local` upload
+// driver. The URL is pasted into IRC and opened by anyone — possibly with no
+// Lurker account — exactly like an x0/catbox link, so it must not require auth;
+// files are protected only by their non-guessable key.
+//
+// This handler is the real security boundary for local hosting (design §6). We
+// copy The Lounge's serve-time recipe but set EVERY header in this handler (not
+// via middleware ordering, which a wiring change could silently drop):
+//   - sniff the MIME from magic bytes; NEVER trust a stored/claimed content-type
+//   - positive INLINE allowlist (images/audio/video/text-plain) → everything
+//     else is forced to download, which auto-neutralizes SVG/HTML/JS
+//   - X-Content-Type-Options: nosniff backstops the text/plain fallback so a
+//     browser won't sniff-and-execute
+//   - Content-Security-Policy: default-src 'none'; sandbox on every response
+//   - the key is regex-validated and the resolved path asserted to stay inside
+//     the storage root → path traversal is impossible by construction
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import fs from 'fs';
+import { fileTypeFromBuffer } from 'file-type';
+import { resolveDiskPath } from '../services/uploadProviders/local.js';
+import { asyncHandler } from '../utils/asyncHandler.js';
+
+const router = Router();
+
+// The only key shape the `local` driver mints in P1: {12 hex}.{ext}. (The
+// preserve-original-filename shape {random}/{name}.{ext} arrives with #517 and
+// will extend this.) Anything else is rejected before touching the filesystem.
+const KEY_RE = /^[0-9a-f]{12}\.[a-z0-9]{1,16}$/;
+
+// MIME types safe to render inline. Deliberately excludes SVG/HTML/XML — those
+// fall through to forced download. Includes an audio/video set that's harmless
+// now (P1 only produces images + text) and ready when binary types land (P4).
+const INLINE_MIME = new Set<string>([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+  'image/bmp',
+  'audio/mpeg',
+  'audio/ogg',
+  'audio/wav',
+  'audio/webm',
+  'audio/flac',
+  'video/mp4',
+  'video/ogg',
+  'video/webm',
+]);
+
+// file-type recommends >= 4100 bytes to recognize every supported signature.
+const SNIFF_BYTES = 4100;
+
+// Read the first SNIFF_BYTES of a file for magic-byte detection. subarray to the
+// bytes actually read so a short file's zero-padding never reaches the sniff (a
+// subtlety The Lounge's equivalent misses — it isUtf8-checks the padded buffer).
+async function sniffHead(fullPath: string): Promise<Buffer> {
+  const fd = await fs.promises.open(fullPath, 'r');
+  try {
+    const buf = Buffer.alloc(SNIFF_BYTES);
+    const { bytesRead } = await fd.read(buf, 0, SNIFF_BYTES, 0);
+    return buf.subarray(0, bytesRead);
+  } finally {
+    await fd.close();
+  }
+}
+
+// Drop a trailing incomplete UTF-8 multibyte sequence, so a valid text file whose
+// SNIFF_BYTES window happens to split a character isn't misjudged as binary and
+// force-downloaded. Walks back over continuation bytes (0b10xxxxxx) to the lead
+// byte; if the sequence it starts runs past the window, trim it.
+function trimPartialUtf8(buf: Buffer): Buffer {
+  for (let i = 1; i <= 3 && buf.length - i >= 0; i++) {
+    const b = buf[buf.length - i];
+    if ((b & 0xc0) === 0x80) continue; // continuation byte — keep walking back
+    const seqLen = b < 0x80 ? 1 : b >= 0xf0 ? 4 : b >= 0xe0 ? 3 : b >= 0xc0 ? 2 : 1;
+    return i < seqLen ? buf.subarray(0, buf.length - i) : buf; // incomplete → drop
+  }
+  return buf;
+}
+
+function isUtf8(buf: Buffer): boolean {
+  if (buf.length === 0) return false;
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(buf);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+router.get(
+  '/:key',
+  asyncHandler(async (req: Request, res: Response) => {
+    const key = String(req.params.key);
+    if (!KEY_RE.test(key)) {
+      res.status(404).json({ error: 'not found' });
+      return;
+    }
+
+    let fullPath: string;
+    try {
+      fullPath = resolveDiskPath(key);
+    } catch {
+      res.status(404).json({ error: 'not found' });
+      return;
+    }
+
+    // Sniff the served type from the file's own bytes — never a stored or claimed
+    // content-type. A missing file (raced delete, bad key) throws here → 404.
+    let head: Buffer;
+    try {
+      head = await sniffHead(fullPath);
+    } catch {
+      res.status(404).json({ error: 'not found' });
+      return;
+    }
+
+    // Recognized-and-inline → inline; recognized-but-not-inline (pdf/zip/svg/...)
+    // → download; unrecognized-but-textual → text/plain; else opaque → download.
+    const ft = await fileTypeFromBuffer(head);
+    let mime: string;
+    let inline: boolean;
+    if (ft && INLINE_MIME.has(ft.mime)) {
+      mime = ft.mime;
+      inline = true;
+    } else if (ft) {
+      mime = ft.mime;
+      inline = false;
+    } else if (isUtf8(trimPartialUtf8(head))) {
+      mime = 'text/plain; charset=utf-8';
+      inline = true;
+    } else {
+      mime = 'application/octet-stream';
+      inline = false;
+    }
+
+    // Security headers are set HERE, in the handler (not via middleware ordering
+    // that a wiring change could silently drop). Byte delivery then goes to
+    // res.sendFile, which adds Range/ETag/Last-Modified + conditional 304s and
+    // honors our pre-set Content-Type (send skips its extension guess when a
+    // Content-Type is already present — so the sniffed type always wins).
+    res.setHeader('Content-Type', mime);
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
+    // The random key already carries a safe extension; use it as the download name.
+    res.setHeader('Content-Disposition', inline ? 'inline' : `attachment; filename="${key}"`);
+
+    res.sendFile(fullPath, { maxAge: '365d', immutable: true }, (err) => {
+      // A read error before the response is flushed → 404; after, nothing to do.
+      if (err && !res.headersSent) res.status(404).json({ error: 'not found' });
+    });
+  }),
+);
+
+export default router;

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -229,6 +229,41 @@ describe('local-style (storesRemotely:false) uploads', () => {
     }
   });
 
+  it('ignores a spoofed non-http(s) X-Forwarded-Proto', async () => {
+    stub.capabilities.storesRemotely = false;
+    stub.nextResult = { url: '/uploads/local/ccddeeff0011.png', ref: 'ccddeeff0011.png' };
+    try {
+      const res = await agent
+        .post('/api/uploads')
+        .set('X-Forwarded-Proto', 'javascript')
+        .set('X-Forwarded-Host', 'irc.example.com')
+        .attach('image', smallPng, { filename: 'x.png', contentType: 'image/png' });
+      expect(res.status).toBe(200);
+      // The bogus scheme is dropped; never javascript://.
+      expect(res.body.url).toBe('https://irc.example.com/uploads/local/ccddeeff0011.png');
+    } finally {
+      stub.capabilities.storesRemotely = true;
+      stub.nextResult = null;
+    }
+  });
+
+  it('leaves the URL relative when the forwarded host is malformed', async () => {
+    stub.capabilities.storesRemotely = false;
+    stub.nextResult = { url: '/uploads/local/223344556677.png', ref: '223344556677.png' };
+    try {
+      const res = await agent
+        .post('/api/uploads')
+        .set('X-Forwarded-Host', 'evil.example.com/@attacker')
+        .attach('image', smallPng, { filename: 'x.png', contentType: 'image/png' });
+      expect(res.status).toBe(200);
+      // A host with authority-breaking chars is rejected → no base is prefixed.
+      expect(res.body.url).toBe('/uploads/local/223344556677.png');
+    } finally {
+      stub.capabilities.storesRemotely = true;
+      stub.nextResult = null;
+    }
+  });
+
   it('prefers PUBLIC_BASE_URL over the request origin when set', async () => {
     stub.capabilities.storesRemotely = false;
     stub.nextResult = { url: '/uploads/local/aabbccddeeff.png', ref: 'aabbccddeeff.png' };

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -32,6 +32,10 @@ const stub = {
   configSchema: [],
   shouldThrow: null as Error | null,
   capturedConfig: null as Record<string, string> | null,
+  // When set, upload() returns this instead of the default remote URL — used to
+  // exercise the storesRemotely:false (local-style relative URL) absolutization.
+  nextResult: null as { url: string; ref?: string } | null,
+  capturedDeleteRef: null as string | null,
   async upload(
     _buffer: Buffer,
     meta: { filename: string; mime: string },
@@ -39,7 +43,11 @@ const stub = {
   ) {
     stub.capturedConfig = config ?? null;
     if (stub.shouldThrow) throw stub.shouldThrow;
+    if (stub.nextResult) return stub.nextResult;
     return { url: `https://stub.example/${meta.filename}` };
+  },
+  async delete(ref: string) {
+    stub.capturedDeleteRef = ref;
   },
 };
 
@@ -55,6 +63,16 @@ vi.mock('../services/uploadProviders/index.js', () => ({
     secrets: {},
   }),
 }));
+
+// The byte reap is fire-and-forget (DELETE responds before the async unlink), so
+// poll for its effect rather than assume a single tick has run it.
+async function waitUntil(fn: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) throw new Error('condition not met in time');
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
 
 let app: Express;
 let agent: LurkerTestAgent;
@@ -184,6 +202,92 @@ describe('POST /api/uploads', () => {
       expect(res.status).toBe(415);
     } finally {
       stub.capabilities.acceptsContentClasses = prev;
+    }
+  });
+});
+
+describe('local-style (storesRemotely:false) uploads', () => {
+  it('absolutizes a relative driver URL against the request origin', async () => {
+    stub.capabilities.storesRemotely = false;
+    stub.nextResult = { url: '/uploads/local/abcdef012345.png', ref: 'abcdef012345.png' };
+    try {
+      const res = await agent
+        .post('/api/uploads')
+        .set('X-Forwarded-Proto', 'https')
+        .set('X-Forwarded-Host', 'irc.example.com')
+        .attach('image', smallPng, { filename: 'local.png', contentType: 'image/png' });
+      expect(res.status).toBe(200);
+      expect(res.body.url).toBe('https://irc.example.com/uploads/local/abcdef012345.png');
+
+      // The absolutized URL — not the relative one — is what gets persisted.
+      const list = await agent.get('/api/uploads');
+      const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
+      expect(row.url).toBe('https://irc.example.com/uploads/local/abcdef012345.png');
+    } finally {
+      stub.capabilities.storesRemotely = true;
+      stub.nextResult = null;
+    }
+  });
+
+  it('prefers PUBLIC_BASE_URL over the request origin when set', async () => {
+    stub.capabilities.storesRemotely = false;
+    stub.nextResult = { url: '/uploads/local/aabbccddeeff.png', ref: 'aabbccddeeff.png' };
+    process.env.PUBLIC_BASE_URL = 'https://cdn.example.org/';
+    try {
+      const res = await agent
+        .post('/api/uploads')
+        .set('X-Forwarded-Host', 'ignored.example.com')
+        .attach('image', smallPng, { filename: 'local2.png', contentType: 'image/png' });
+      expect(res.status).toBe(200);
+      // Trailing slash on the base is trimmed; the request host is ignored.
+      expect(res.body.url).toBe('https://cdn.example.org/uploads/local/aabbccddeeff.png');
+    } finally {
+      delete process.env.PUBLIC_BASE_URL;
+      stub.capabilities.storesRemotely = true;
+      stub.nextResult = null;
+    }
+  });
+
+  it('reaps the on-disk bytes via driver.delete when a deletable upload is removed', async () => {
+    stub.capabilities.storesRemotely = false;
+    stub.capabilities.supportsDelete = true;
+    stub.nextResult = { url: '/uploads/local/112233445566.png', ref: '112233445566.png' };
+    stub.capturedDeleteRef = null;
+    try {
+      const up = await agent
+        .post('/api/uploads')
+        .attach('image', smallPng, { filename: 'reap.png', contentType: 'image/png' });
+      expect(up.status).toBe(200);
+
+      const del = await agent.delete(`/api/uploads/${up.body.id}`);
+      expect(del.status).toBe(200);
+      // The reap is fire-and-forget; poll until it runs rather than assume a tick.
+      await waitUntil(() => stub.capturedDeleteRef === '112233445566.png');
+      expect(stub.capturedDeleteRef).toBe('112233445566.png');
+    } finally {
+      stub.capabilities.storesRemotely = true;
+      stub.capabilities.supportsDelete = false;
+      stub.nextResult = null;
+    }
+  });
+
+  it('does not call driver.delete for a non-deletable driver (even with a ref)', async () => {
+    // A ref is present, but supportsDelete is false → the reap must short-circuit
+    // and never unlink (external forwarders offer list-only removal).
+    stub.capabilities.storesRemotely = false;
+    stub.nextResult = { url: '/uploads/local/778899aabbcc.png', ref: '778899aabbcc.png' };
+    stub.capturedDeleteRef = null;
+    try {
+      const up = await agent
+        .post('/api/uploads')
+        .attach('image', smallPng, { filename: 'keep.png', contentType: 'image/png' });
+      const del = await agent.delete(`/api/uploads/${up.body.id}`);
+      expect(del.status).toBe(200);
+      await new Promise((r) => setImmediate(r));
+      expect(stub.capturedDeleteRef).toBeNull();
+    } finally {
+      stub.capabilities.storesRemotely = true;
+      stub.nextResult = null;
     }
   });
 });

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -51,9 +51,18 @@ function firstHeaderValue(v: unknown): string {
     .trim();
 }
 
+// A host is hostname[:port] or [ipv6][:port] — reject anything with characters
+// that could break out of the authority (slash, space, userinfo '@', etc.), so a
+// spoofed header can never inject path/scheme into the URL we construct + persist.
+const HOST_RE = /^[A-Za-z0-9.\-:[\]]+$/;
+
 function requestOrigin(req: Request): string {
-  const proto = firstHeaderValue(req.headers['x-forwarded-proto']) || req.protocol || 'https';
-  const host = firstHeaderValue(req.headers['x-forwarded-host']) || req.get('host') || '';
+  // Only http/https are valid schemes; anything else (a spoofed "javascript" or
+  // garbage X-Forwarded-Proto) is ignored so it can never reach the built URL.
+  const rawProto = firstHeaderValue(req.headers['x-forwarded-proto']) || req.protocol;
+  const proto = rawProto === 'http' || rawProto === 'https' ? rawProto : 'https';
+  const rawHost = firstHeaderValue(req.headers['x-forwarded-host']) || req.get('host') || '';
+  const host = HOST_RE.test(rawHost) ? rawHost : '';
   return host ? `${proto}://${host}` : '';
 }
 

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -12,12 +12,19 @@ import { driverIds } from '../services/uploadProviders/index.js';
 import type { ContentClass } from '../services/uploadProviders/index.js';
 import {
   resolveUploader,
+  loadDriverForRef,
   UploaderUnavailableError,
   UploaderNotConfiguredError,
   type ResolvedUploader,
 } from '../services/uploadProviders/resolve.js';
 import type { UploadListRow } from '../db/uploadHistory.js';
-import { insertUpload, listUploads, getThumbnail, deleteUpload } from '../db/uploadHistory.js';
+import {
+  insertUpload,
+  listUploads,
+  getThumbnail,
+  getUploadForReap,
+  deleteUpload,
+} from '../db/uploadHistory.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { reportUploadSoon } from '../services/moderationReport.js';
 
@@ -30,6 +37,48 @@ router.use(requireAuth);
 // — i.e. every self-host uploader. Untyped (JS module) → Record<string, unknown>.
 function effectiveSettings(userId: number): Record<string, unknown> {
   return { ...defaultsAsObject(), ...getUserSettings(userId) };
+}
+
+// The absolute origin (scheme + host) a `local` upload's relative URL is prefixed
+// with so the pasted link works from IRC. PUBLIC_BASE_URL wins (explicit,
+// proxy-safe); otherwise derive from the request, honoring the reverse-proxy
+// forwarding headers a self-hoster's Caddy/nginx sets. Read here rather than via
+// a global `trust proxy` so the rest of the app's request handling is unchanged.
+// A forwarding header may be a list ("proto1, proto2"); take the first hop.
+function firstHeaderValue(v: unknown): string {
+  return String(v ?? '')
+    .split(',')[0]
+    .trim();
+}
+
+function requestOrigin(req: Request): string {
+  const proto = firstHeaderValue(req.headers['x-forwarded-proto']) || req.protocol || 'https';
+  const host = firstHeaderValue(req.headers['x-forwarded-host']) || req.get('host') || '';
+  return host ? `${proto}://${host}` : '';
+}
+
+// Warn once (per process) the first time a local-upload link is built from
+// request headers because PUBLIC_BASE_URL isn't set. That fallback is the only
+// path where a client-supplied Host/X-Forwarded-Host reaches the minted URL, so
+// an operator who wants stable, un-spoofable links should set PUBLIC_BASE_URL.
+let warnedRequestOriginFallback = false;
+
+/** Absolutize a driver result URL. Drivers that store remotely already return an
+ *  absolute URL; the local driver returns a root-relative path we prefix with the
+ *  instance's public base (PUBLIC_BASE_URL, else the request origin). */
+function absolutizeUrl(url: string, storesRemotely: boolean, req: Request): string {
+  if (storesRemotely || !url.startsWith('/')) return url;
+  const configured = process.env.PUBLIC_BASE_URL;
+  if (!configured && !warnedRequestOriginFallback) {
+    warnedRequestOriginFallback = true;
+    console.warn(
+      '[lurker] PUBLIC_BASE_URL is not set; local-upload links are derived from ' +
+        'the request Host/X-Forwarded-Host header, which a client can spoof. Set ' +
+        'PUBLIC_BASE_URL to this instance’s public origin for stable links.',
+    );
+  }
+  const base = (configured || requestOrigin(req)).replace(/\/+$/, '');
+  return base ? base + url : url;
 }
 
 // multer needs configuring up-front, before we know the effective per-uploader
@@ -164,6 +213,9 @@ router.post(
         return;
       }
 
+      const storesRemotely = resolved.driver.capabilities.storesRemotely;
+      const mainUrl = absolutizeUrl(result.url as string, storesRemotely, req);
+
       // Thumbnail strategy is a resolved policy value, not isNodeMode(): a
       // hostsThumbnails uploader (the hosted in-house one) stores the thumb as a
       // remote object under a `thumbs/` prefix so it doesn't bloat the cell DB /
@@ -179,7 +231,7 @@ router.post(
             resolved.driverConfig,
           );
           if (tRes && typeof tRes.url === 'string') {
-            thumbnailUrl = tRes.url;
+            thumbnailUrl = absolutizeUrl(tRes.url, storesRemotely, req);
             thumbnailBlob = null;
           }
         } catch {
@@ -189,7 +241,7 @@ router.post(
 
       const id = insertUpload(req.user!.id, {
         provider: resolved.driverId,
-        url: result.url,
+        url: mainUrl,
         filename: originalName || null,
         mime: outMime,
         byte_size: outByteSize,
@@ -207,7 +259,7 @@ router.post(
       reportUploadSoon({
         cell_upload_id: id,
         cell_user_id: req.user!.id,
-        url: result.url,
+        url: mainUrl,
         thumb_url: thumbnailUrl,
         mime: outMime,
         byte_size: outByteSize,
@@ -215,7 +267,7 @@ router.post(
         height: outHeight,
       });
 
-      res.json({ id, url: result.url, ...(thumbnailUrl ? { thumbnail_url: thumbnailUrl } : {}) });
+      res.json({ id, url: mainUrl, ...(thumbnailUrl ? { thumbnail_url: thumbnailUrl } : {}) });
     } catch (err) {
       next(err);
     }
@@ -255,12 +307,33 @@ router.get('/:id/thumb', (req: Request, res: Response) => {
 });
 
 router.delete('/:id', (req: Request, res: Response) => {
-  const ok = deleteUpload(req.user!.id, Number(req.params.id));
+  const id = Number(req.params.id);
+  // Capture the delete handle before dropping the row so we can reap the bytes
+  // for drivers that own their storage (local disk). Ownership is enforced by the
+  // user-scoped lookup — a caller can only reap their own upload.
+  const reap = getUploadForReap(req.user!.id, id);
+  const ok = deleteUpload(req.user!.id, id);
   if (!ok) {
     res.status(404).json({ error: 'not found' });
     return;
   }
+  // Best-effort, fire-and-forget: a failed unlink leaves an orphan file but must
+  // never fail the user's delete or block the response. Non-owning drivers
+  // (x0/catbox/hoarder) don't advertise delete, so this is a no-op for them.
+  if (reap && reap.ref && reap.uploader_config_id != null) {
+    void reapUploadBytes(reap.uploader_config_id, reap.ref);
+  }
   res.json({ ok: true });
 });
+
+async function reapUploadBytes(configId: number, ref: string): Promise<void> {
+  try {
+    const loaded = loadDriverForRef(configId);
+    if (!loaded || !loaded.driver.capabilities.supportsDelete || !loaded.driver.delete) return;
+    await loaded.driver.delete(ref, loaded.driverConfig);
+  } catch (err) {
+    console.error('[lurker] upload byte reap failed:', err);
+  }
+}
 
 export default router;

--- a/server/services/uploadProviders/index.ts
+++ b/server/services/uploadProviders/index.ts
@@ -9,6 +9,7 @@
 import * as x0 from './x0.js';
 import * as catbox from './catbox.js';
 import * as hoarder from './hoarder.js';
+import * as local from './local.js';
 import type { UploadDriver } from './types.js';
 
 export type {
@@ -24,6 +25,7 @@ const DRIVERS: Record<string, UploadDriver> = {
   [x0.driver]: x0,
   [catbox.driver]: catbox,
   [hoarder.driver]: hoarder,
+  [local.driver]: local,
 };
 
 export const driverIds = Object.keys(DRIVERS);

--- a/server/services/uploadProviders/local.test.ts
+++ b/server/services/uploadProviders/local.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as local from './local.js';
+
+let dir: string;
+const prevEnv = process.env.LOCAL_UPLOADS_DIR;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-local-'));
+  process.env.LOCAL_UPLOADS_DIR = dir;
+});
+
+afterAll(() => {
+  if (prevEnv == null) delete process.env.LOCAL_UPLOADS_DIR;
+  else process.env.LOCAL_UPLOADS_DIR = prevEnv;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('local driver', () => {
+  it('declares self-host, deletable, key-minting capabilities', () => {
+    expect(local.capabilities.storesRemotely).toBe(false);
+    expect(local.capabilities.supportsDelete).toBe(true);
+    expect(local.capabilities.mintsKeys).toBe(true);
+    expect(local.capabilities.selfHostOnly).toBe(true);
+  });
+
+  it('writes bytes to disk and returns a relative URL + on-disk ref', async () => {
+    const bytes = Buffer.from('hello local disk');
+    const res = await local.upload(bytes, { filename: 'note.txt', mime: 'text/plain' }, {});
+
+    expect(res.url).toMatch(/^\/uploads\/local\/[0-9a-f]{12}\.txt$/);
+    expect(res.ref).toMatch(/^[0-9a-f]{12}\.txt$/);
+    expect(res.bytes).toBe(bytes.length);
+
+    // The ref locates the file on disk (under its shard subdir) and it round-trips
+    // byte-for-byte.
+    const onDisk = fs.readFileSync(local.resolveDiskPath(res.ref!));
+    expect(onDisk.equals(bytes)).toBe(true);
+    // The file lives in a 2-char shard dir, not flat in the root.
+    expect(local.resolveDiskPath(res.ref!)).toBe(path.join(dir, res.ref!.slice(0, 2), res.ref!));
+    // No stray temp file was left behind in that shard dir.
+    const shardDir = path.dirname(local.resolveDiskPath(res.ref!));
+    expect(fs.readdirSync(shardDir).some((f) => f.includes('.tmp'))).toBe(false);
+  });
+
+  it('takes the extension from the pipeline filename, not a hostile claim', async () => {
+    const res = await local.upload(
+      Buffer.from('x'),
+      // The route always passes {basename}.{pipeline-ext}; even a traversal-y
+      // basename can only affect the (re-sanitized) extension, never the path.
+      { filename: '../../etc/passwd.png', mime: 'image/png' },
+      {},
+    );
+    expect(res.ref).toMatch(/^[0-9a-f]{12}\.png$/);
+  });
+
+  it('deletes the on-disk bytes for its ref (orphan reap)', async () => {
+    const res = await local.upload(
+      Buffer.from('to-delete'),
+      { filename: 'x.txt', mime: 'text/plain' },
+      {},
+    );
+    const full = local.resolveDiskPath(res.ref!);
+    expect(fs.existsSync(full)).toBe(true);
+    await local.delete(res.ref!, {});
+    expect(fs.existsSync(full)).toBe(false);
+  });
+
+  it('delete of an already-missing ref is a no-op', async () => {
+    await expect(local.delete('deadbeef0000.png', {})).resolves.toBeUndefined();
+  });
+
+  it('resolveDiskPath refuses traversal outside the storage root', () => {
+    expect(() => local.resolveDiskPath('../escape.png')).toThrow(/unsafe/);
+    expect(() => local.resolveDiskPath('../../etc/passwd')).toThrow(/unsafe/);
+    // A legitimate key resolves inside a 2-char shard dir under the root.
+    expect(local.resolveDiskPath('a1b2c3d4e5f6.png')).toBe(
+      path.join(dir, 'a1', 'a1b2c3d4e5f6.png'),
+    );
+  });
+});

--- a/server/services/uploadProviders/local.ts
+++ b/server/services/uploadProviders/local.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The `local` driver — writes upload bytes to the server's own disk and serves
+// them back over the public GET /uploads/local/:key route (routes/localUploads.ts).
+// Self-host only: hosted cells are ephemeral (Litestream'd SQLite, no durable
+// blob disk), so this driver is never offered on the fleet.
+//
+// This is the one driver where `storesRemotely` is false: upload() returns a
+// RELATIVE url (/uploads/local/<key>) plus the on-disk `ref`; the upload route
+// absolutizes it against PUBLIC_BASE_URL (or the request origin) so the link is
+// clickable from IRC. The real security boundary is SERVE-time, not here — see
+// routes/localUploads.ts for the sniff / disposition / header recipe.
+//
+// Storage location is instance-wide (LOCAL_UPLOADS_DIR env, else <data-dir>/
+// uploads), resolved identically by this driver and the serving route so the key
+// alone locates the file — no per-config lookup on the hot serve path. Per-
+// uploader storage dirs can come later (P3 admin UI) via a configSchema field;
+// keeping the P1 schema empty means the seeded row works zero-config.
+
+import fs from 'fs';
+import path from 'path';
+import { resolveDataDir } from '../../utils/dataDir.js';
+import { buildObjectKey, randomId } from './objectKey.js';
+import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
+
+export const driver = 'local';
+export const label = 'Local disk';
+
+export const capabilities: DriverCapabilities = {
+  // We serve the bytes ourselves; the upload route builds the absolute URL.
+  storesRemotely: false,
+  supportsDelete: true,
+  mintsKeys: true,
+  acceptsContentClasses: ['image', 'text'],
+  selfHostOnly: true,
+};
+
+// Empty in P1 (zero-config, like x0). Storage dir + public base URL come from env
+// / request derivation; per-uploader fields arrive with the P3 admin UI.
+export const configSchema: ConfigField[] = [];
+
+/** The single instance-wide storage root. Both the driver and the serving route
+ *  call this, so the stored key is all that's needed to locate a file. Defaults
+ *  to <data-dir>/uploads (beside the SQLite DB) so it survives container rebuilds
+ *  on a mounted volume; LOCAL_UPLOADS_DIR overrides it. */
+export function resolveStorageDir(): string {
+  const fromEnv = (process.env.LOCAL_UPLOADS_DIR || '').trim();
+  return fromEnv ? path.resolve(fromEnv) : path.join(resolveDataDir(), 'uploads');
+}
+
+/** Map a storage key to its on-disk path, refusing anything that would escape the
+ *  storage root. Files are sharded into 256 subdirs by the first two chars of the
+ *  key so no single directory accumulates every upload (filesystems + tooling —
+ *  ls/tar/backups — degrade on huge flat dirs; The Lounge shards the same way).
+ *  The key is regex-validated by callers, so slice(0, 2) is a safe hex pair; the
+ *  containment assert is defense in depth on top of that. */
+export function resolveDiskPath(key: string, storageDir = resolveStorageDir()): string {
+  const root = path.resolve(storageDir);
+  const full = path.resolve(root, key.slice(0, 2), key);
+  if (!full.startsWith(root + path.sep)) {
+    throw Object.assign(new Error('unsafe upload key'), { code: 'PROVIDER_ERROR' });
+  }
+  return full;
+}
+
+export async function upload(
+  buffer: Buffer,
+  { filename }: UploadMeta,
+  _config: Record<string, string>,
+): Promise<UploadResult> {
+  const storageDir = resolveStorageDir();
+  // Extension from the (pipeline-produced) filename; buildObjectKey re-sanitizes
+  // it, so a hostile value can't escape the key.
+  const ext = filename.split('.').pop() || 'bin';
+  const key = buildObjectKey({ ext });
+  const full = resolveDiskPath(key, storageDir);
+  await fs.promises.mkdir(path.dirname(full), { recursive: true });
+  // Write to a temp sibling then rename so a crash mid-write never leaves a
+  // half-written file at the served key. (The whole buffer is already in memory
+  // via multer.memoryStorage — there's no streaming/abort path to clean up.)
+  const tmp = `${full}.tmp-${randomId()}`;
+  try {
+    await fs.promises.writeFile(tmp, buffer, { mode: 0o644 });
+    await fs.promises.rename(tmp, full);
+  } catch (err) {
+    await fs.promises.unlink(tmp).catch(() => {});
+    throw Object.assign(new Error(`local write failed: ${(err as Error).message}`), {
+      code: 'PROVIDER_ERROR',
+    });
+  }
+  return { url: `/uploads/local/${key}`, ref: key, bytes: buffer.length };
+}
+
+/** Orphan reap: unlink the on-disk file when its history row is deleted. Missing
+ *  file is not an error (already gone / never written). */
+async function del(ref: string, _config: Record<string, string>): Promise<void> {
+  const full = resolveDiskPath(ref);
+  try {
+    await fs.promises.unlink(full);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+
+export { del as delete };

--- a/server/services/uploadProviders/objectKey.test.ts
+++ b/server/services/uploadProviders/objectKey.test.ts
@@ -55,4 +55,9 @@ describe('buildObjectKey', () => {
   it('randomId is 12 hex chars (48 bits)', () => {
     expect(randomId()).toMatch(/^[0-9a-f]{12}$/);
   });
+  it('caps an over-long extension so the key stays servable', () => {
+    // The local serve route's key regex accepts at most 16 ext chars; a key we
+    // mint must never exceed that or the file we wrote becomes un-servable.
+    expect(buildObjectKey({ ext: 'x'.repeat(40) })).toMatch(/^[0-9a-f]{12}\.x{16}$/);
+  });
 });

--- a/server/services/uploadProviders/objectKey.ts
+++ b/server/services/uploadProviders/objectKey.ts
@@ -22,6 +22,11 @@ import { randomBytes } from 'crypto';
 // enumerable keys at this scale.
 const RANDOM_BYTES = 6;
 const SEGMENT_MAX = 96;
+// Extension length cap. Keeps a minted key within what the local serving route's
+// key regex accepts (routes/localUploads.ts `KEY_RE`, [a-z0-9]{1,16}) so a file
+// we wrote can never be un-servable; also a sane bound for the s3 driver. Real
+// extensions are a few chars — this only ever trims a pathological input.
+const EXT_MAX = 16;
 
 /** Random, URL-safe, non-guessable id used as the locating segment of a key. */
 export function randomId(): string {
@@ -58,7 +63,11 @@ export interface BuildObjectKeyOpts {
  */
 export function buildObjectKey({ prefix, ext, originalBasename }: BuildObjectKeyOpts): string {
   const rnd = randomId();
-  const cleanExt = (ext || 'bin').replace(/[^A-Za-z0-9]+/g, '').toLowerCase() || 'bin';
+  const cleanExt =
+    (ext || 'bin')
+      .replace(/[^A-Za-z0-9]+/g, '')
+      .toLowerCase()
+      .slice(0, EXT_MAX) || 'bin';
   const p = prefix ? `${prefix.replace(/^\/+|\/+$/g, '')}/` : '';
   if (originalBasename != null && originalBasename !== '') {
     const base = sanitizeSegment(originalBasename.replace(/\.[^.]+$/, ''), 'file');

--- a/server/services/uploadProviders/resolve.ts
+++ b/server/services/uploadProviders/resolve.ts
@@ -138,6 +138,24 @@ function lockedButUnconfigured(
   return driver.configSchema.some((f) => f.required && !driverConfig[f.key]);
 }
 
+/**
+ * Load a driver + its decrypted, policy-stripped config by uploader_config id,
+ * skipping the user/policy allow-set checks. Used by the delete path to reap the
+ * stored bytes of an upload the user already owns (ownership was checked when the
+ * history row was fetched). Returns null when the config row or its driver is
+ * gone — the caller then just drops the history row without a byte reap.
+ */
+export function loadDriverForRef(
+  configId: number,
+): { driver: UploadDriver; driverConfig: Record<string, string> } | null {
+  const row = getUploaderConfig(configId);
+  if (!row) return null;
+  const driver = getDriver(row.driver);
+  if (!driver) return null;
+  const { driverConfig } = splitPolicy(resolvedConfig(row));
+  return { driver, driverConfig };
+}
+
 export function resolveUploader(input: ResolveInput): ResolvedUploader {
   const { userId, isAdmin = false, requestedId = null } = input;
 

--- a/server/utils/bouncerCert.ts
+++ b/server/utils/bouncerCert.ts
@@ -13,14 +13,10 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { generate as generateSelfSigned } from 'selfsigned';
+import { resolveDataDir } from './dataDir.js';
 
 const CERT_FILE = 'bouncer-cert.pem';
 const KEY_FILE = 'bouncer-key.pem';
-
-function defaultDataDir(): string {
-  if (process.env.DATABASE_PATH) return path.dirname(process.env.DATABASE_PATH);
-  return path.join(import.meta.dirname, '../../data');
-}
 
 export interface BouncerCertFiles {
   certPath: string;
@@ -34,7 +30,7 @@ export interface BouncerCertFiles {
 // expiry. Returns the file paths (the caller reads + watches them, sharing the
 // hot-reload path with operator-supplied certs).
 export async function loadOrCreateSelfSignedCert({
-  dataDir = defaultDataDir(),
+  dataDir = resolveDataDir(),
 }: { dataDir?: string } = {}): Promise<BouncerCertFiles> {
   fs.mkdirSync(dataDir, { recursive: true });
   const certPath = path.join(dataDir, CERT_FILE);

--- a/server/utils/dataDir.ts
+++ b/server/utils/dataDir.ts
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The single source of truth for Lurker's data directory — the persistent volume
+// that holds the SQLite DB and the files that live beside it (session secret,
+// bouncer cert, local uploads). Resolved from DATABASE_PATH when set (the
+// production/Docker path), else a repo-relative ./data for local dev. Computed
+// from THIS module's location so every caller agrees regardless of where it sits
+// in the tree — previously each site re-derived it with its own `..` depth.
+
+import path from 'path';
+
+export function resolveDataDir(): string {
+  if (process.env.DATABASE_PATH) return path.dirname(process.env.DATABASE_PATH);
+  return path.join(import.meta.dirname, '../../data');
+}

--- a/server/utils/sessionSecret.ts
+++ b/server/utils/sessionSecret.ts
@@ -13,15 +13,11 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
+import { resolveDataDir } from './dataDir.js';
 
 const SECRET_FILENAME = 'session-secret.key';
 
-function defaultDataDir(): string {
-  if (process.env.DATABASE_PATH) return path.dirname(process.env.DATABASE_PATH);
-  return path.join(import.meta.dirname, '../../data');
-}
-
-export function resolveSessionSecret({ dataDir = defaultDataDir() }: { dataDir?: string } = {}): {
+export function resolveSessionSecret({ dataDir = resolveDataDir() }: { dataDir?: string } = {}): {
   secret: string;
   source: 'env' | 'file' | 'generated';
   path?: string;

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1004,7 +1004,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     category: 'uploads',
     group: 'provider',
     type: 'enum',
-    choices: ['x0', 'catbox', 'hoarder'],
+    choices: ['x0', 'catbox', 'hoarder', 'local'],
     default: 'x0',
     // Node edition forces the operator's in-house uploader (A8); a tenant never
     // picks a host, so this and the provider-credential settings below are
@@ -1013,7 +1013,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     description:
       'Where pasted/picked images are uploaded. x0.at and catbox.moe are ' +
       'anonymous public hosts. hoarder uploads to your own self-hosted ' +
-      'Hoarder instance using the URL + API key configured below.',
+      'Hoarder instance using the URL + API key configured below. local stores ' +
+      'files on this server’s own disk and serves them back (set ' +
+      'PUBLIC_BASE_URL so the links resolve from other clients).',
   },
   {
     key: 'uploads.image.max_dimension',

--- a/vue_client/vite.config.ts
+++ b/vue_client/vite.config.ts
@@ -52,6 +52,13 @@ export default defineConfig(({ mode }) => {
           target: apiBase,
           changeOrigin: true,
         },
+        // The local-disk uploader serves files from the backend at /uploads/local.
+        // Proxy it so a PUBLIC_BASE_URL pointed at the dev origin (5173) resolves
+        // pasted upload links through here instead of hitting the SPA fallback.
+        '/uploads': {
+          target: apiBase,
+          changeOrigin: true,
+        },
         '/ws': {
           target: apiBase.replace(/^http/, 'ws'),
           ws: true,


### PR DESCRIPTION
Closes #511. Part of the uploader overhaul (#509); builds directly on the P0 capability-driver model (#510).

The zero-dependency self-host uploader: write bytes to our own disk and serve them back.

## What's here

**`local` driver** (`services/uploadProviders/local.ts`) — writes to an instance-wide storage dir (`LOCAL_UPLOADS_DIR`, else `<data-dir>/uploads`), sharded into 256 subdirs by the first 2 chars of the key so no directory ever accumulates every upload. Returns a relative `/uploads/local/<key>` URL + an on-disk `ref`; `delete()` unlinks for orphan reap. `storesRemotely:false`, `supportsDelete`/`mintsKeys`/`selfHostOnly:true`; temp-write+rename so a crash never leaves a half-file at the served key.

**Public serve route** (`routes/localUploads.ts`) — mounted off `/api` at `/uploads/local/:key`, **no auth** (files are protected only by their non-guessable key, exactly like an x0/catbox link), **self-host only**. This is the real security boundary, copying The Lounge's serve-time recipe but setting every header **in the handler** (not via middleware ordering a wiring change could silently drop):
- sniff MIME from magic bytes — never trust a stored/claimed content-type
- positive inline allowlist → force-download everything else (auto-neutralizes SVG/HTML/JS)
- `X-Content-Type-Options: nosniff` + `Content-Security-Policy: default-src 'none'; sandbox`
- regex-validated key + resolved-path containment assert → path traversal impossible by construction
- byte delivery via `res.sendFile` → Range/ETag/conditional-304 for free, honoring the pre-set sniffed `Content-Type`

**Upload route** — absolutizes the relative URL for `storesRemotely:false` drivers against `PUBLIC_BASE_URL` (else the request origin, honoring `X-Forwarded-*` without a global `trust proxy`; warns once when that fallback is used); reaps on-disk bytes via `driver.delete` when a deletable upload's history row is removed.

**Selectable now** — `local` is added to the `uploads.provider` dropdown so it rides the P0 bridge before the P3 picker UI lands. Built-in instance rows (x0/catbox/local) are ensured on **every boot** via `reconcileBuiltInUploaders`, not just the version-gated one-shot seed — a newly-added built-in must reach already-migrated DBs, and bumping the schema version to re-run the seed is fragile (an interleaved boot can bump the version without the row). Additive + idempotent; never clobbers a chosen default; never runs on the hosted fleet.

## Decisions

- **`PUBLIC_BASE_URL` stays optional.** Audited against The Lounge: their `fileUpload.baseUrl` also defaults to null, and when unset they fall back to a *relative* URL that only works because their web client resolves it — useless for our IRC-paste model. So the request-origin fallback is justified; documented in `.env.example` + a one-time runtime warn nudges operators to set it for stable links.
- **Thumbnails** stay inline-blob (the `hostsThumbnails` policy is absent on the seeded local row).

## Harvested from / compared against The Lounge
- `res.sendFile` for byte delivery (Range/ETag/304).
- Subdir sharding.
- We already improve on them: `nosniff`+CSP set in the handler (theirs is global middleware), and a stricter sniff (they `isUtf8`-check the zero-padded buffer; we subarray to `bytesRead` + trim a partial trailing UTF-8 sequence).

## Review notes (self-reviewed at `/code-review high`)
- Shared `utils/dataDir.ts` collapses the data-dir resolution that `sessionSecret`/`bouncerCert`/`local` each re-derived.
- `buildObjectKey` caps the extension to the serve route's key-regex bound so a minted key is always servable.

## Testing
Adds `file-type`. Full end-to-end coverage (seed → resolve → disk → serve → reap) with no mocks, plus unit, serve-time security, Range, UTF-8-boundary, ext-cap, and reconcile-self-heal tests. `npm run check` clean; full suite green (2071 tests), stable across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)