### PR TITLE
Uploads P3: configured uploaders, admin policy, and the self-hosted drivers (Zipline/Chibisafe/S3)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -22,6 +22,7 @@ import bookmarksRouter from './routes/bookmarks.js';
 import pushRouter from './routes/push.js';
 import adminRouter from './routes/admin.js';
 import uploadsRouter from './routes/uploads.js';
+import uploadersRouter from './routes/uploaders.js';
 import localUploadsRouter from './routes/localUploads.js';
 import dccRouter from './routes/dcc.js';
 import draftsRouter from './routes/drafts.js';
@@ -62,6 +63,7 @@ export function buildApp(sessionSecret: string): Express {
   app.use('/api/push', pushRouter);
   app.use('/api/admin', adminRouter);
   app.use('/api/uploads', uploadsRouter);
+  app.use('/api/uploaders', uploadersRouter);
   // Public (no-auth) serving of local-driver files. Off /api by design: the URL
   // is opened by anyone the uploader shares it with, protected only by its
   // non-guessable key. Mounted before the SPA fallback so it wins the route.

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -282,7 +282,17 @@ export const EXPORT_TABLES = Object.freeze({
     section: 'data',
     pk: 'id',
     rekeyOnImport: true,
-    fkRekey: { user_id: 'users' },
+    // uploader_config_id now rides the uploader_config id map (#514): user
+    // uploaders survive the trip, so the history row can still say which of them
+    // produced a file. It lands NULL when it pointed at an INSTANCE uploader
+    // (those aren't exported and the map has no entry) — correct: on the target
+    // that upload came from a host the importing user doesn't own.
+    fkRekey: { user_id: 'users', uploader_config_id: 'uploader_config' },
+    // MUST be nullable: an unmapped FK otherwise makes the importer DROP the row,
+    // and rows uploaded through an instance uploader (x0/catbox/local — most of
+    // them) have no map entry by design. Nulling the column keeps the upload in
+    // the user's history, just without a link to an uploader that isn't theirs.
+    fkRekeyNullable: ['uploader_config_id'],
     // thumbnail BLOB is written to thumbnails/<id>.jpg in the zip rather than
     // base64-inlined; the row carries a hasThumbnail boolean in data.json.
     // thumbnail_url (node edition) is a plain string column carried as-is.
@@ -299,14 +309,16 @@ export const EXPORT_TABLES = Object.freeze({
       'height',
       'thumbnail',
       'thumbnail_url',
+      'uploader_config_id',
       'created_at',
     ],
     skippedColumns: {
       synced_to_cp: 'operational: cell↔control-plane moderation-sync bookkeeping, not portable',
       removed: 'instance/CP-owned moderation state; a fresh instance starts it at the default 0',
-      uploader_config_id:
-        'instance-local: references an uploader_config row id that does not survive import (#510)',
-      ref: 'driver-local delete handle (object/disk key), not portable (#510)',
+      ref:
+        'driver-local delete handle (object/disk key). Deliberately NOT carried: the bytes it names ' +
+        'live on the SOURCE instance’s disk/bucket, so a reap driven by it on the target would be ' +
+        'either a no-op or, worse, aimed at someone else’s object with the same key (#514)',
     },
   },
 
@@ -387,16 +399,53 @@ export const EXPORT_TABLES = Object.freeze({
     columns: ['user_id', 'message_id', 'created_at'],
   },
 
-  // ---- skipped ----
-
+  // A user's OWN configured uploaders (#514). This became exportable the moment
+  // the legacy uploads.* user_settings keys were deleted: those keys used to be
+  // what carried a user's provider config across an export, and with them gone
+  // these rows are the only record of "I upload to my own Zipline".
+  //
+  // 'partial' because most of the row is deliberately left behind:
+  //   - secrets_enc is NOT exported. It's sealed with the SOURCE instance's
+  //     LURKER_SECRET_KEY, so on a keyed cell it would be undecryptable garbage on
+  //     the target (decryptSecret throws on an unknown key id) — and on a keyless
+  //     self-host the envelope is plaintext passthrough, so exporting it would put
+  //     the user's catbox userhash / S3 secret key in the clear inside a zip. A
+  //     restored uploader therefore arrives credential-less and must be re-entered;
+  //     the Uploads pane says so. (Deliberately NOT declared in encryptedColumns:
+  //     that would make the exporter decrypt it into data.json, which is the whole
+  //     thing we're avoiding.)
+  //   - the instance-policy flags are omitted so the DDL defaults apply on insert
+  //     (offered_to_users/locked/is_default → 0), which is exactly right for a
+  //     personal uploader — an imported row can't smuggle itself in as an offered
+  //     instance default. Same trick upload_history uses above.
+  // `scope` IS carried (NOT NULL with a CHECK and no default, so omitting it would
+  // fail the insert); the exporter only ever selects scope='user' rows, so its
+  // value is always the literal 'user'.
   uploader_config: {
-    mode: 'skip',
-    reason:
-      'instance-scoped uploader infrastructure (#510): user rows hold secrets encrypted with the ' +
-      'source instance key and reference driver ids/rows that do not survive import. In P0 a user’s ' +
-      'provider config is still carried by the legacy uploads.* user_settings keys (which ARE exported); ' +
-      'revisit the export contract when those legacy keys are removed.',
+    mode: 'partial',
+    scope: 'owned_uploaders',
+    section: 'data',
+    pk: 'id',
+    // upload_history.uploader_config_id and the uploads.uploader_id user setting
+    // are both rewritten through this map on import.
+    rekeyOnImport: true,
+    fkRekey: { owner_user_id: 'users' },
+    columns: ['id', 'scope', 'owner_user_id', 'driver', 'label', 'config_json', 'created_at'],
+    skippedColumns: {
+      secrets_enc:
+        'credentials sealed with the source instance key: undecryptable on the target when keyed, ' +
+        'and plaintext-in-the-zip when not. Re-entered by the user after import (#514)',
+      enabled: 'local state; a restored uploader starts enabled (DDL default 1)',
+      offered_to_users:
+        'instance policy, not user data; DDL default 0 keeps an imported row personal',
+      locked: 'instance policy (the hosted operator-managed row); DDL default 0',
+      is_default:
+        'instance policy; DDL default 0 so an import can never seize the instance default',
+      updated_at: 'tracked locally by each instance',
+    },
   },
+
+  // ---- skipped ----
 
   instance_settings: {
     mode: 'skip',
@@ -565,6 +614,9 @@ export const IMPORT_ORDER = Object.freeze([
   'channels',
   'highlight_rules',
   'highlight_rule_networks',
+  // Before user_settings (whose `uploads.uploader_id` value is rewritten through
+  // this table's id map) and before upload_history (which FK-rekeys against it).
+  'uploader_config',
   'user_settings',
   'ignored_masks',
   'user_nick_notes',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -10,6 +10,7 @@ import { foldBufferCase } from './foldBufferCase.js';
 import {
   seedUploaderConfig,
   reconcileBuiltInUploaders,
+  reconcileLegacyUploadSettings,
   reconcileHostedUploaderFromEnv,
 } from './uploaderConfigSeed.js';
 
@@ -1563,6 +1564,16 @@ try {
   reconcileBuiltInUploaders(db);
 } catch (err) {
   console.warn('[db] built-in uploader reconcile failed:', err);
+}
+
+// Fold the legacy per-user `uploads.*` credential/selection keys into real
+// uploader_config rows and delete them (#514). MUST run after the built-in
+// reconcile above, which is what guarantees the instance rows this points users
+// at actually exist. Self-terminating: once the keys are gone it's a no-op.
+try {
+  reconcileLegacyUploadSettings(db);
+} catch (err) {
+  console.warn('[db] legacy upload-settings reconcile failed:', err);
 }
 
 // Re-sync the hosted locked uploader from env on every boot — idempotent no-op on

--- a/server/db/uploaderConfig.ts
+++ b/server/db/uploaderConfig.ts
@@ -41,6 +41,27 @@ export interface UploaderConfigSummary {
   label: string;
 }
 
+/**
+ * The projection for someone entitled to *edit* a row (its owner, or an admin on
+ * an instance row). Carries the non-secret config values so a form can be
+ * populated, plus `secretsSet` — which secret fields currently hold a value —
+ * so the form can render "•••••• (set)" without the value ever leaving the
+ * server. `secrets_enc` itself is never projected under any circumstances.
+ *
+ * A `locked` row (the hosted default) is deliberately still summarizable but not
+ * detailable: routes refuse to hand out its config at all, secret or not, since
+ * the operator's endpoint is not the tenant's business.
+ */
+export interface UploaderConfigDetail extends UploaderConfigSummary {
+  scope: 'instance' | 'user';
+  config: Record<string, string>;
+  secretsSet: Record<string, boolean>;
+  enabled: boolean;
+  offeredToUsers: boolean;
+  locked: boolean;
+  isDefault: boolean;
+}
+
 // ─── secret encoding (pure; no db) ────────────────────────────────────────────
 
 /** JSON-encode the secret fields and wrap them in a secretCrypto envelope.
@@ -117,6 +138,34 @@ export function toSummary(row: UploaderConfigRow): UploaderConfigSummary {
   return { id: row.id, driver: row.driver, label: row.label };
 }
 
+/** Editor projection (see UploaderConfigDetail). Unknown driver → config fields
+ *  can't be classified, so nothing is projected: an orphaned row is summarizable
+ *  but not editable. */
+export function toDetail(row: UploaderConfigRow): UploaderConfigDetail {
+  const drv = getDriver(row.driver);
+  const stored = parseConfigJson(row.config_json);
+  const secrets = decodeSecrets(row.secrets_enc);
+  const config: Record<string, string> = {};
+  const secretsSet: Record<string, boolean> = {};
+  for (const field of drv?.configSchema ?? []) {
+    // The schema is the allowlist in both directions: a `secret` field only ever
+    // yields a boolean, and a stale non-secret key left in config_json by an
+    // older schema is dropped rather than surfaced.
+    if (field.type === 'secret') secretsSet[field.key] = Boolean(secrets[field.key]);
+    else config[field.key] = stored[field.key] ?? '';
+  }
+  return {
+    ...toSummary(row),
+    scope: row.scope,
+    config,
+    secretsSet,
+    enabled: row.enabled === 1,
+    offeredToUsers: row.offered_to_users === 1,
+    locked: row.locked === 1,
+    isDefault: row.is_default === 1,
+  };
+}
+
 // ─── writes ─────────────────────────────────────────────────────────────────
 
 export interface CreateUploaderConfigParams {
@@ -161,6 +210,79 @@ export function createUploaderConfig(p: CreateUploaderConfigParams): number {
     p.isDefault ? 1 : 0,
   );
   return Number(info.lastInsertRowid);
+}
+
+export interface UpdateUploaderConfigParams {
+  label?: string;
+  // Partial flat config. A key that is absent is left alone (this is a PATCH, not
+  // a PUT) — which is what lets a client edit an S3 bucket name without holding,
+  // or retyping, the secret key.
+  values?: Record<string, string>;
+  enabled?: boolean;
+  offeredToUsers?: boolean;
+}
+
+/**
+ * Patch a row's label / config / enabled / offered flags. Returns false when the
+ * row is gone.
+ *
+ * SECRET SEMANTICS — the whole reason this isn't a plain UPDATE: the client never
+ * receives a secret, so it cannot send one back on an edit. An omitted secret
+ * field, or one sent as the empty string, therefore means "keep what's stored",
+ * never "clear it". (Clearing a secret means deleting the uploader; every secret
+ * in every driver's schema today is `required`, so a cleared one would be a
+ * broken row anyway.) Non-secret fields follow ordinary PATCH rules: present →
+ * written (empty string clears), absent → untouched.
+ */
+export function updateUploaderConfig(id: number, p: UpdateUploaderConfigParams): boolean {
+  const row = getUploaderConfig(id);
+  if (!row) return false;
+  const drv = getDriver(row.driver);
+  if (!drv) throw new Error(`unknown upload driver: ${row.driver}`);
+
+  const { config, secrets } = splitConfigBySchema(drv, p.values ?? {});
+  const mergedConfig = { ...parseConfigJson(row.config_json), ...config };
+  const mergedSecrets = { ...decodeSecrets(row.secrets_enc) };
+  for (const [k, v] of Object.entries(secrets)) {
+    if (v !== '') mergedSecrets[k] = v;
+  }
+
+  db.prepare(
+    `UPDATE uploader_config
+        SET label = ?, config_json = ?, secrets_enc = ?, enabled = ?, offered_to_users = ?,
+            updated_at = datetime('now')
+      WHERE id = ?`,
+  ).run(
+    p.label ?? row.label,
+    JSON.stringify(mergedConfig),
+    encodeSecrets(mergedSecrets),
+    p.enabled === undefined ? row.enabled : p.enabled ? 1 : 0,
+    p.offeredToUsers === undefined ? row.offered_to_users : p.offeredToUsers ? 1 : 0,
+    id,
+  );
+  return true;
+}
+
+/**
+ * Make one instance row THE instance default, clearing any incumbent. Done in a
+ * transaction because `idx_uploader_config_one_default` is a unique partial index
+ * — setting the new flag before clearing the old one would trip it. Returns false
+ * if the row is missing or user-scoped (a user's default is their
+ * `uploads.uploader_id` setting, not a column).
+ */
+export function setInstanceDefault(id: number): boolean {
+  const row = getUploaderConfig(id);
+  if (!row || row.scope !== 'instance') return false;
+  db.transaction(() => {
+    db.prepare(
+      `UPDATE uploader_config SET is_default = 0, updated_at = datetime('now')
+        WHERE scope = 'instance' AND is_default = 1 AND id != ?`,
+    ).run(id);
+    db.prepare(
+      `UPDATE uploader_config SET is_default = 1, updated_at = datetime('now') WHERE id = ?`,
+    ).run(id);
+  })();
+  return true;
 }
 
 export function deleteUploaderConfig(id: number): boolean {

--- a/server/db/uploaderConfig.ts
+++ b/server/db/uploaderConfig.ts
@@ -119,11 +119,23 @@ export function listUserUploaders(userId: number): UploaderConfigRow[] {
     .all(userId) as UploaderConfigRow[];
 }
 
-/** The single instance default (unique partial index guarantees at most one). */
+/**
+ * The single instance default (unique partial index guarantees at most one).
+ *
+ * `enabled = 1` is part of the query, not an afterthought: this row is the
+ * fallback for every account that hasn't chosen an uploader, and it's reached in
+ * resolveUploader WITHOUT going through isAllowed() (it's the default — being
+ * offered to you is the whole point). Without this clause, an admin who disables
+ * the default keeps every one of those accounts silently uploading through it.
+ * Returning null instead surfaces as "no usable uploader" (decision 15), which is
+ * the honest answer.
+ */
 export function getInstanceDefault(): UploaderConfigRow | null {
   return (
     (db
-      .prepare(`SELECT * FROM uploader_config WHERE scope = 'instance' AND is_default = 1`)
+      .prepare(
+        `SELECT * FROM uploader_config WHERE scope = 'instance' AND is_default = 1 AND enabled = 1`,
+      )
       .get() as UploaderConfigRow | undefined) ?? null
   );
 }

--- a/server/db/uploaderConfigSeed.test.ts
+++ b/server/db/uploaderConfigSeed.test.ts
@@ -12,6 +12,7 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 let db: typeof import('./index.js').default;
 let seedUploaderConfig: typeof import('./uploaderConfigSeed.js').seedUploaderConfig;
 let reconcileBuiltInUploaders: typeof import('./uploaderConfigSeed.js').reconcileBuiltInUploaders;
+let reconcileLegacyUploadSettings: typeof import('./uploaderConfigSeed.js').reconcileLegacyUploadSettings;
 let createUser: typeof import('./users.js').createUser;
 let setUserSetting: typeof import('./settings.js').setUserSetting;
 let getUserSettings: typeof import('./settings.js').getUserSettings;
@@ -52,7 +53,8 @@ const allowUserDefined = (): string | undefined =>
 
 beforeAll(async () => {
   db = (await import('./index.js')).default;
-  ({ seedUploaderConfig, reconcileBuiltInUploaders } = await import('./uploaderConfigSeed.js'));
+  ({ seedUploaderConfig, reconcileBuiltInUploaders, reconcileLegacyUploadSettings } =
+    await import('./uploaderConfigSeed.js'));
   ({ createUser } = await import('./users.js'));
   ({ setUserSetting, getUserSettings } = await import('./settings.js'));
 });
@@ -86,41 +88,15 @@ describe('seedUploaderConfig (self-host)', () => {
     expect(allowUserDefined()).toBe('1');
   });
 
-  it('converts a configured catbox user into a user row + uploader_id', () => {
-    const u = createUser('seed-catbox');
-    setUserSetting(u.id, 'uploads.provider', 'catbox');
-    setUserSetting(u.id, 'uploads.catbox.userhash', 'hash1');
-    seedUploaderConfig(db);
-
-    const rows = userRows(u.id);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].driver).toBe('catbox');
-    expect(rows[0].secrets_enc).toContain('hash1'); // secret carried across
-    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(rows[0].id);
-  });
-
-  it('converts a configured self-host hoarder user (url public, key secret)', () => {
-    const u = createUser('seed-hoarder');
-    setUserSetting(u.id, 'uploads.provider', 'hoarder');
-    setUserSetting(u.id, 'uploads.hoarder.url', 'https://u.example');
-    setUserSetting(u.id, 'uploads.hoarder.api_key', 'k-secret');
-    seedUploaderConfig(db);
-
-    const rows = userRows(u.id);
-    expect(rows).toHaveLength(1);
-    expect(rows[0].driver).toBe('hoarder');
-    expect(JSON.parse(rows[0].config_json)).toEqual({ url: 'https://u.example' });
-    expect(rows[0].secrets_enc).toContain('k-secret');
-    expect(rows[0].config_json).not.toContain('k-secret');
-    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(rows[0].id);
-  });
-
-  it('points an x0 / unconfigured user at the instance x0 row, no user row', () => {
+  it('leaves a user with no legacy settings entirely alone (they follow the instance default)', () => {
     const u = createUser('seed-x0'); // no settings at all
     seedUploaderConfig(db);
+    reconcileLegacyUploadSettings(db);
+    // No row and no pointer — deliberately. An absent uploads.uploader_id means
+    // "use the instance default", so a new account silently inherits whatever the
+    // admin has set (#299) instead of being frozen onto x0 by the migration.
     expect(userRows(u.id)).toHaveLength(0);
-    const x0 = instanceRows().find((r) => r.driver === 'x0')!;
-    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(x0.id);
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBeUndefined();
   });
 
   it('re-seed adds a newly-introduced built-in row (local) to a P0-era DB', () => {
@@ -169,13 +145,152 @@ describe('seedUploaderConfig (self-host)', () => {
     setUserSetting(u.id, 'uploads.provider', 'catbox');
     setUserSetting(u.id, 'uploads.catbox.userhash', 'hh');
     seedUploaderConfig(db);
+    reconcileLegacyUploadSettings(db);
     const firstUserRowId = userRows(u.id)[0].id;
     const firstUploaderId = getUserSettings(u.id)['uploads.uploader_id'];
 
     seedUploaderConfig(db);
+    reconcileLegacyUploadSettings(db);
     expect(instanceRows()).toHaveLength(3); // still just x0 + catbox + local
     expect(userRows(u.id)).toHaveLength(1);
     expect(userRows(u.id)[0].id).toBe(firstUserRowId);
     expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(firstUploaderId);
+  });
+});
+
+// The migration that retires the legacy `uploads.*` keys (#514) — and, in doing
+// so, fixes the P0 hole where those keys were converted ONCE and then ignored, so
+// anything configured or changed afterwards was silently dropped.
+describe('reconcileLegacyUploadSettings (self-host)', () => {
+  const legacyKeys = (uid: number): string[] =>
+    (
+      db
+        .prepare(`SELECT key FROM user_settings WHERE user_id = ? AND key LIKE 'uploads.%'`)
+        .all(uid) as Array<{ key: string }>
+    ).map((r) => r.key);
+
+  beforeEach(() => seedUploaderConfig(db));
+
+  it('materializes a configured catbox user into a user row + pointer', () => {
+    const u = createUser('rec-catbox');
+    setUserSetting(u.id, 'uploads.provider', 'catbox');
+    setUserSetting(u.id, 'uploads.catbox.userhash', 'hash1');
+
+    reconcileLegacyUploadSettings(db);
+
+    const rows = userRows(u.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].driver).toBe('catbox');
+    expect(rows[0].secrets_enc).toContain('hash1');
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(rows[0].id);
+  });
+
+  it('materializes a configured hoarder user (url public, key secret)', () => {
+    const u = createUser('rec-hoarder');
+    setUserSetting(u.id, 'uploads.provider', 'hoarder');
+    setUserSetting(u.id, 'uploads.hoarder.url', 'https://u.example');
+    setUserSetting(u.id, 'uploads.hoarder.api_key', 'k-secret');
+
+    reconcileLegacyUploadSettings(db);
+
+    const rows = userRows(u.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].driver).toBe('hoarder');
+    expect(JSON.parse(rows[0].config_json)).toEqual({ url: 'https://u.example' });
+    expect(rows[0].secrets_enc).toContain('k-secret');
+    expect(rows[0].config_json).not.toContain('k-secret');
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(rows[0].id);
+  });
+
+  // ── THE REGRESSION (see the module header) ─────────────────────────────────
+  // A user P0 already converted (pointer at the instance x0 row, no user row) who
+  // then configures Hoarder through the only UI that existed. P0's one-shot seed
+  // never looked again, findAllowedByDriver('hoarder') found nothing, and their
+  // upload silently went to x0 — a PUBLIC host — instead of their private one.
+  it('rescues a user who configured Hoarder AFTER the P0 migration', () => {
+    const u = createUser('rec-late-hoarder');
+    const x0 = instanceRows().find((r) => r.driver === 'x0')!;
+    setUserSetting(u.id, 'uploads.uploader_id', x0.id); // what P0 left them with
+    setUserSetting(u.id, 'uploads.provider', 'hoarder');
+    setUserSetting(u.id, 'uploads.hoarder.url', 'https://private.example');
+    setUserSetting(u.id, 'uploads.hoarder.api_key', 'late-key');
+
+    reconcileLegacyUploadSettings(db);
+
+    const rows = userRows(u.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].driver).toBe('hoarder');
+    expect(rows[0].secrets_enc).toContain('late-key');
+    // Repointed off x0 and onto their own Hoarder — the bytes stop leaking public.
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(rows[0].id);
+    expect(getUserSettings(u.id)['uploads.uploader_id']).not.toBe(x0.id);
+  });
+
+  // The other half of the same hole: the row exists, but the credential in it is
+  // stale because the user edited the setting afterwards and nothing re-read it.
+  it('refreshes a credential the user changed after the P0 migration', () => {
+    const u = createUser('rec-stale');
+    setUserSetting(u.id, 'uploads.provider', 'catbox');
+    setUserSetting(u.id, 'uploads.catbox.userhash', 'old-hash');
+    reconcileLegacyUploadSettings(db); // stands in for the P0 conversion
+    const rowId = userRows(u.id)[0].id;
+
+    // User later changes their userhash through the settings UI.
+    setUserSetting(u.id, 'uploads.catbox.userhash', 'new-hash');
+    reconcileLegacyUploadSettings(db);
+
+    const rows = userRows(u.id);
+    expect(rows).toHaveLength(1); // refreshed in place, not duplicated
+    expect(rows[0].id).toBe(rowId);
+    expect(rows[0].secrets_enc).toContain('new-hash');
+    expect(rows[0].secrets_enc).not.toContain('old-hash');
+  });
+
+  it('keeps a credential the user saved but is not currently using', () => {
+    const u = createUser('rec-unused');
+    setUserSetting(u.id, 'uploads.provider', 'x0'); // uploading to x0 today…
+    setUserSetting(u.id, 'uploads.catbox.userhash', 'kept'); // …but this is theirs
+    reconcileLegacyUploadSettings(db);
+
+    // We're deleting the only copy of that userhash, so it has to survive as a
+    // row they can switch to — not evaporate because it wasn't selected.
+    const rows = userRows(u.id);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].driver).toBe('catbox');
+    expect(rows[0].secrets_enc).toContain('kept');
+    // …while their actual selection stays x0.
+    const x0 = instanceRows().find((r) => r.driver === 'x0')!;
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(x0.id);
+  });
+
+  it('deletes the legacy keys and then no-ops forever', () => {
+    const u = createUser('rec-prune');
+    setUserSetting(u.id, 'uploads.provider', 'catbox');
+    setUserSetting(u.id, 'uploads.catbox.userhash', 'h');
+    setUserSetting(u.id, 'uploads.paste.enabled', false); // a SURVIVING uploads.* key
+
+    reconcileLegacyUploadSettings(db);
+
+    const remaining = legacyKeys(u.id);
+    expect(remaining).not.toContain('uploads.provider');
+    expect(remaining).not.toContain('uploads.catbox.userhash');
+    // The pipeline/paste keys are not part of this migration and must be intact.
+    expect(remaining).toContain('uploads.paste.enabled');
+    expect(remaining).toContain('uploads.uploader_id');
+
+    // Second run: guard SELECT finds nothing, so nothing changes.
+    const before = userRows(u.id);
+    reconcileLegacyUploadSettings(db);
+    expect(userRows(u.id)).toEqual(before);
+  });
+
+  it('points a local-disk user at the instance local row', () => {
+    const u = createUser('rec-local');
+    setUserSetting(u.id, 'uploads.provider', 'local');
+    reconcileLegacyUploadSettings(db);
+
+    const local = instanceRows().find((r) => r.driver === 'local')!;
+    expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(local.id);
+    expect(userRows(u.id)).toHaveLength(0); // zero-config: no user row needed
   });
 });

--- a/server/db/uploaderConfigSeed.ts
+++ b/server/db/uploaderConfigSeed.ts
@@ -21,6 +21,23 @@ import { nodeUploadSecrets, nodeUploadLimits } from '../services/uploadProviders
 // imported here — see header).
 const ALLOW_USER_DEFINED_KEY = 'uploads.allow_user_defined';
 
+/**
+ * The instance uploaders ensureSelfHostInstanceRows guarantees on every boot.
+ * Exported because "is this row a built-in?" has exactly one correct answer —
+ * "will the reconcile put it back if I delete it?" — and the admin route needs
+ * it to refuse a delete that would be pure theatre (and, for `local`, would
+ * strand the files already on disk with nothing left that can reap them).
+ *
+ * Note this is NOT the same question as the driver's `creatable` capability:
+ * `catbox` is both a seeded built-in AND a driver a user may instantiate with
+ * their own userhash.
+ */
+export const BUILT_IN_INSTANCE_DRIVERS: readonly string[] = Object.freeze([
+  'x0',
+  'catbox',
+  'local',
+]);
+
 // ─── low-level helpers (raw SQL against the passed db) ────────────────────────
 
 function encodeSecrets(secrets: Record<string, string>): string | null {
@@ -104,17 +121,17 @@ function hasInstanceDefault(db: Database.Database): boolean {
  * row's default/label/config is never clobbered. x0 is claimed as the default
  * only when no instance default exists yet, so re-running this never conflicts
  * with the one-default unique index (and never overrides a self-hoster's chosen
- * default). Returns the x0/catbox ids the per-user conversion points at.
+ * default).
  */
-function ensureSelfHostInstanceRows(db: Database.Database): { x0Id: number; catboxId: number } {
+function ensureSelfHostInstanceRows(db: Database.Database): void {
   const defaultExists = hasInstanceDefault(db);
-  const x0Id = ensureInstanceRow(db, {
+  ensureInstanceRow(db, {
     driver: 'x0',
     label: 'x0.at',
     offered: true,
     isDefault: !defaultExists,
   });
-  const catboxId = ensureInstanceRow(db, {
+  ensureInstanceRow(db, {
     driver: 'catbox',
     label: 'catbox.moe',
     offered: true,
@@ -129,7 +146,6 @@ function ensureSelfHostInstanceRows(db: Database.Database): { x0Id: number; catb
     isDefault: false,
   });
   setInstanceSettingIfAbsent(db, ALLOW_USER_DEFINED_KEY, '1');
-  return { x0Id, catboxId };
 }
 
 function getUserSettingsRaw(db: Database.Database, userId: number): Record<string, unknown> {
@@ -195,11 +211,13 @@ function findHostedRow(db: Database.Database): number | null {
 // ─── the migration ────────────────────────────────────────────────────────────
 
 /**
- * Seed the uploader model once. Hosted: a single locked `hoarder` instance
- * default from env + allow_user_defined=0. Self-host: instance x0 (default) +
- * catbox rows, allow_user_defined=1, and each user's existing uploads.* settings
- * converted into a user row with uploads.uploader_id pointed at it. Idempotent —
- * skips rows/users already converted, so a re-run is a no-op.
+ * Seed the uploader model. Hosted: a single locked `hoarder` instance default
+ * from env + allow_user_defined=0. Self-host: the built-in instance rows (x0
+ * default, catbox, local) + allow_user_defined=1. Fully idempotent.
+ *
+ * The per-user conversion off the legacy `uploads.*` settings is NOT here — it
+ * lives in reconcileLegacyUploadSettings, which runs every boot instead of behind
+ * this version gate. See that function's header.
  */
 export function seedUploaderConfig(db: Database.Database): void {
   const run = db.transaction(() => {
@@ -223,14 +241,10 @@ export function seedUploaderConfig(db: Database.Database): void {
       return;
     }
 
-    // Self-host: ensure the built-in instance rows, then run the one-time
-    // per-user conversion of existing uploads.* settings.
-    const { x0Id, catboxId } = ensureSelfHostInstanceRows(db);
-
-    const users = db.prepare('SELECT id FROM users').all() as Array<{ id: number }>;
-    for (const { id: userId } of users) {
-      convertUser(db, userId, x0Id, catboxId);
-    }
+    // Self-host: ensure the built-in instance rows. The per-user conversion of
+    // the legacy uploads.* settings is NOT done here — reconcileLegacyUploadSettings
+    // owns it and runs every boot (see its header for why a one-shot is wrong).
+    ensureSelfHostInstanceRows(db);
   });
   run();
 }
@@ -251,67 +265,172 @@ export function reconcileBuiltInUploaders(db: Database.Database): void {
   })();
 }
 
-function convertUser(db: Database.Database, userId: number, x0Id: number, catboxId: number): void {
-  const settings = getUserSettingsRaw(db, userId);
+// ─── legacy `uploads.*` keys → uploader_config rows (P3, #514) ────────────────
 
-  // Already converted (has a user row or an explicit uploader_id) → leave alone.
-  const hasUserRow = db
-    .prepare(`SELECT 1 FROM uploader_config WHERE scope = 'user' AND owner_user_id = ? LIMIT 1`)
-    .get(userId);
-  if (hasUserRow || settings['uploads.uploader_id'] != null) return;
+// The four per-user settings keys the pre-#510 uploader was configured through.
+// P3 deletes them from the registry, so this module owns the last leg of their
+// life: materialize whatever they still hold into real rows, then drop them.
+const LEGACY_KEYS = [
+  'uploads.provider',
+  'uploads.catbox.userhash',
+  'uploads.hoarder.url',
+  'uploads.hoarder.api_key',
+] as const;
 
-  const provider =
-    typeof settings['uploads.provider'] === 'string'
-      ? (settings['uploads.provider'] as string)
-      : 'x0';
-  const userhash =
-    typeof settings['uploads.catbox.userhash'] === 'string'
-      ? (settings['uploads.catbox.userhash'] as string)
-      : '';
-  const hoarderUrl =
-    typeof settings['uploads.hoarder.url'] === 'string'
-      ? (settings['uploads.hoarder.url'] as string)
-      : '';
-  const hoarderKey =
-    typeof settings['uploads.hoarder.api_key'] === 'string'
-      ? (settings['uploads.hoarder.api_key'] as string)
-      : '';
+const LEGACY_KEY_PLACEHOLDERS = LEGACY_KEYS.map(() => '?').join(',');
 
-  let targetId: number;
-  if (provider === 'catbox' && userhash) {
-    // Configured catbox → a user row carrying the userhash secret.
-    targetId = insertRow(db, {
-      scope: 'user',
-      owner_user_id: userId,
-      driver: 'catbox',
-      label: 'catbox.moe',
-      config_json: '{}',
-      secrets_enc: encodeSecrets({ userhash }),
-      enabled: 1,
-      offered_to_users: 0,
-      locked: 0,
-      is_default: 0,
-    });
-  } else if (provider === 'hoarder' && hoarderUrl && hoarderKey) {
-    // Configured self-host hoarder → a user row (url public, api_key secret).
-    targetId = insertRow(db, {
-      scope: 'user',
-      owner_user_id: userId,
-      driver: 'hoarder',
-      label: 'Hoarder',
-      config_json: JSON.stringify({ url: hoarderUrl }),
-      secrets_enc: encodeSecrets({ api_key: hoarderKey }),
-      enabled: 1,
-      offered_to_users: 0,
-      locked: 0,
-      is_default: 0,
-    });
-  } else {
-    // Anonymous catbox or x0 (or unconfigured) → point at the seeded instance row.
-    targetId = provider === 'catbox' ? catboxId : x0Id;
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function findUserRowByDriver(db: Database.Database, userId: number, driver: string): number | null {
+  const r = db
+    .prepare(
+      `SELECT id FROM uploader_config
+        WHERE scope = 'user' AND owner_user_id = ? AND driver = ? LIMIT 1`,
+    )
+    .get(userId, driver) as { id: number } | undefined;
+  return r ? r.id : null;
+}
+
+/**
+ * Create — or refresh — the user's row for a driver from their legacy settings.
+ *
+ * Refresh (rather than "never clobber", the P0 seed's rule) is deliberate and is
+ * the fix for the regression this migration exists to close: the settings keys
+ * were the ONLY UI that could edit these credentials, so a value sitting in
+ * user_settings is by definition at least as fresh as the one P0's one-shot seed
+ * copied into the row. If they're identical this is a no-op; if they differ, the
+ * settings value is the user's later intent and the row's is stale.
+ */
+function upsertUserRow(
+  db: Database.Database,
+  userId: number,
+  spec: {
+    driver: string;
+    label: string;
+    config: Record<string, string>;
+    secrets: Record<string, string>;
+  },
+): number {
+  const existing = findUserRowByDriver(db, userId, spec.driver);
+  if (existing != null) {
+    db.prepare(
+      `UPDATE uploader_config
+          SET config_json = ?, secrets_enc = ?, enabled = 1, updated_at = datetime('now')
+        WHERE id = ?`,
+    ).run(JSON.stringify(spec.config), encodeSecrets(spec.secrets), existing);
+    return existing;
+  }
+  return insertRow(db, {
+    scope: 'user',
+    owner_user_id: userId,
+    driver: spec.driver,
+    label: spec.label,
+    config_json: JSON.stringify(spec.config),
+    secrets_enc: encodeSecrets(spec.secrets),
+    enabled: 1,
+    offered_to_users: 0,
+    locked: 0,
+    is_default: 0,
+  });
+}
+
+function migrateUserOffLegacyKeys(db: Database.Database, userId: number): void {
+  const s = getUserSettingsRaw(db, userId);
+  const provider = str(s['uploads.provider']);
+  const userhash = str(s['uploads.catbox.userhash']);
+  const hoarderUrl = str(s['uploads.hoarder.url']);
+  const hoarderKey = str(s['uploads.hoarder.api_key']);
+
+  // Materialize every credential we find, REGARDLESS of which provider is
+  // selected. We are about to delete the only copy of these values, and a user
+  // who has a catbox userhash saved but is currently on x0 still owns that
+  // userhash — it should show up as a configured uploader they can switch to,
+  // not evaporate.
+  const catboxRowId = userhash
+    ? upsertUserRow(db, userId, {
+        driver: 'catbox',
+        label: 'catbox.moe',
+        config: {},
+        secrets: { userhash },
+      })
+    : null;
+  const hoarderRowId =
+    hoarderUrl && hoarderKey
+      ? upsertUserRow(db, userId, {
+          driver: 'hoarder',
+          label: 'Hoarder',
+          config: { url: hoarderUrl },
+          secrets: { api_key: hoarderKey },
+        })
+      : null;
+
+  // Then point their default at whatever the dropdown last said, because the
+  // dropdown — not uploads.uploader_id — is what the P0 bridge actually honored.
+  let targetId: number | null = null;
+  switch (provider) {
+    case 'catbox':
+      // Their own row if they have a userhash, else the anonymous instance row.
+      targetId = catboxRowId ?? findInstanceRowByDriver(db, 'catbox');
+      break;
+    case 'hoarder':
+      // There is no instance hoarder row on self-host: if they picked hoarder
+      // without complete credentials, the bridge was already silently sending
+      // their uploads to x0. Falling through to the x0 default below preserves
+      // that (broken) behavior rather than inventing a half-configured row.
+      targetId = hoarderRowId;
+      break;
+    case 'x0':
+    case 'local':
+      targetId = findInstanceRowByDriver(db, provider);
+      break;
+    default:
+      targetId = null;
   }
 
-  setUserSettingRaw(db, userId, 'uploads.uploader_id', targetId);
+  if (targetId == null) {
+    // No usable provider selection. Keep an existing pointer if they have one
+    // (the P0 seed set it); otherwise fall back to the instance x0 row, which is
+    // exactly where the old default-'x0' enum sent them.
+    if (typeof s['uploads.uploader_id'] === 'number') return;
+    targetId = findInstanceRowByDriver(db, 'x0');
+  }
+  if (targetId != null) setUserSettingRaw(db, userId, 'uploads.uploader_id', targetId);
+}
+
+/**
+ * Fold the legacy `uploads.*` credential/selection keys into real uploader_config
+ * rows and then delete them (issue #514). Runs on EVERY boot, not behind a
+ * SCHEMA_VERSION gate: the version-gated one-shot is exactly the pattern that
+ * wedged a dev DB during #511 (an interleaved restart bumped the version without
+ * running the seed), and this migration is naturally self-terminating anyway —
+ * once the keys are gone the guard SELECT returns nothing and it is a permanent
+ * no-op. That also makes it self-healing against an import that reintroduces the
+ * old keys from an archive predating this release.
+ *
+ * This is what closes the P0 hole where the keys were converted once and then
+ * ignored: a user who configured Hoarder (or changed their catbox userhash)
+ * *after* the P0 migration had their credential silently dropped and their
+ * uploads rerouted to the x0 public host.
+ *
+ * Hosted never honored these keys (node mode forced the operator's uploader), so
+ * there is nothing to materialize there — the keys are simply pruned.
+ */
+export function reconcileLegacyUploadSettings(db: Database.Database): void {
+  const holders = db
+    .prepare(`SELECT DISTINCT user_id FROM user_settings WHERE key IN (${LEGACY_KEY_PLACEHOLDERS})`)
+    .all(...LEGACY_KEYS) as Array<{ user_id: number }>;
+  if (holders.length === 0) return;
+
+  db.transaction(() => {
+    if (!isNodeMode()) {
+      for (const { user_id } of holders) migrateUserOffLegacyKeys(db, user_id);
+    }
+    db.prepare(`DELETE FROM user_settings WHERE key IN (${LEGACY_KEY_PLACEHOLDERS})`).run(
+      ...LEGACY_KEYS,
+    );
+  })();
 }
 
 /**

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -9,9 +9,14 @@ import { createInvite, listInvites, deleteInvite, getInvite } from '../db/invite
 import ircManager from '../services/ircManager.js';
 import { presenceDiagnostics } from '../services/wsHub.js';
 import { isNodeMode } from '../utils/edition.js';
+import adminUploadersRouter from './adminUploaders.js';
 
 const router = Router();
 router.use(requireAuth, requireAdmin);
+
+// Instance uploaders + upload policy (#514). Its own module — it inherits the
+// requireAuth + requireAdmin above.
+router.use('/uploaders', adminUploadersRouter);
 
 // invites.ts is still untyped — row shape inferred as any from the JS module
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/server/routes/adminUploaders.test.ts
+++ b/server/routes/adminUploaders.test.ts
@@ -77,6 +77,28 @@ describe('GET /api/admin/uploaders', () => {
     expect(res.body.allowUserDefined).toBe(true);
   });
 
+  it('never projects a LOCKED row’s config (the hosted operator’s endpoint)', async () => {
+    // The hosted default is seeded from the operator env and re-derived every
+    // boot. A cell tenant holding the admin role has no business reading its
+    // endpoint, and nothing can edit it anyway (PATCH 409s).
+    const { createUploaderConfig } = await import('../db/uploaderConfig.js');
+    createUploaderConfig({
+      scope: 'instance',
+      driver: 'hoarder',
+      label: 'Hosted uploader',
+      values: { url: 'https://internal-dropper.lurker.chat', api_key: 'operator-key' },
+      locked: true,
+    });
+
+    const res = await adminAgent.get('/api/admin/uploaders');
+    const locked = res.body.uploaders.find((u: any) => u.locked);
+    expect(locked.label).toBe('Hosted uploader'); // still nameable…
+    expect(locked.config).toEqual({}); // …but opaque
+    expect(locked.secretsSet).toEqual({});
+    expect(JSON.stringify(res.body)).not.toContain('internal-dropper');
+    expect(JSON.stringify(res.body)).not.toContain('operator-key');
+  });
+
   it('marks the seeded rows built-in — including catbox, which is ALSO user-creatable', async () => {
     const res = await adminAgent.get('/api/admin/uploaders');
     const byDriver = Object.fromEntries(res.body.uploaders.map((u: any) => [u.driver, u]));
@@ -159,6 +181,31 @@ describe('the instance default (#299)', () => {
     expect(res.status).toBe(409);
 
     await adminAgent.patch(`/api/admin/uploaders/${catbox.id}`).send({ enabled: true });
+  });
+
+  // The default is reached WITHOUT going through the allowed-set check (being
+  // offered to you is the whole point of a default), so a disabled one would
+  // otherwise keep quietly serving every account that never picked an uploader.
+  it('refuses to DISABLE the current default', async () => {
+    const x0 = instanceRow('x0');
+    const res = await adminAgent.patch(`/api/admin/uploaders/${x0.id}`).send({ enabled: false });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/another default/);
+    expect(getUploaderConfig(x0.id)!.enabled).toBe(1);
+  });
+
+  it('a default that somehow ends up disabled resolves to nothing, not to itself', async () => {
+    // Belt and braces: the route above blocks the obvious path, but the resolver
+    // must not trust the flag either — a disabled row is not a usable uploader,
+    // and "no usable uploader" is the honest answer (decision 15).
+    const { updateUploaderConfig } = await import('../db/uploaderConfig.js');
+    const x0 = instanceRow('x0');
+    updateUploaderConfig(x0.id, { enabled: false }); // bypass the route guard
+
+    const { UploaderUnavailableError } = await import('../services/uploadProviders/resolve.js');
+    expect(() => resolveUploader({ userId: plainUser.id })).toThrow(UploaderUnavailableError);
+
+    updateUploaderConfig(x0.id, { enabled: true });
   });
 });
 

--- a/server/routes/adminUploaders.test.ts
+++ b/server/routes/adminUploaders.test.ts
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The admin half of uploader management (#514 / #299): instance uploaders, the
+// default a new account inherits, and the lockdown switch.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+
+const ctx = setupTestDb('routes-admin-uploaders');
+
+let app: Express;
+let adminAgent: LurkerTestAgent;
+let userAgent: LurkerTestAgent;
+let admin: User;
+let plainUser: User;
+let listInstanceUploaders: typeof import('../db/uploaderConfig.js').listInstanceUploaders;
+let getUploaderConfig: typeof import('../db/uploaderConfig.js').getUploaderConfig;
+let allowUserDefinedUploaders: typeof import('../db/instanceSettings.js').allowUserDefinedUploaders;
+let setAllowUserDefinedUploaders: typeof import('../db/instanceSettings.js').setAllowUserDefinedUploaders;
+let resolveUploader: typeof import('../services/uploadProviders/resolve.js').resolveUploader;
+
+const instanceRow = (driver: string) => listInstanceUploaders().find((r) => r.driver === driver)!;
+
+let db: typeof import('../db/index.js').default;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const router = (await import('./admin.js')).default;
+  db = (await import('../db/index.js')).default;
+  ({ listInstanceUploaders, getUploaderConfig } = await import('../db/uploaderConfig.js'));
+  ({ allowUserDefinedUploaders, setAllowUserDefinedUploaders } =
+    await import('../db/instanceSettings.js'));
+  ({ resolveUploader } = await import('../services/uploadProviders/resolve.js'));
+
+  admin = createUser('adminup-root', { role: 'admin' });
+  plainUser = createUser('adminup-nobody');
+
+  app = createTestApp({ '/api/admin': router });
+  adminAgent = await createAuthedAgent(app, admin.id);
+  userAgent = await createAuthedAgent(app, plainUser.id);
+});
+
+afterAll(() => ctx.cleanup());
+
+beforeEach(() => {
+  // Drop anything a previous test stood up; the seeded built-ins stay.
+  db.prepare(
+    `DELETE FROM uploader_config
+      WHERE scope = 'instance' AND driver NOT IN ('x0','catbox','local')`,
+  ).run();
+  db.prepare(`DELETE FROM uploader_config WHERE scope = 'user'`).run();
+  setAllowUserDefinedUploaders(true);
+});
+
+describe('auth', () => {
+  it('403s a non-admin', async () => {
+    expect((await userAgent.get('/api/admin/uploaders')).status).toBe(403);
+    expect(
+      (await userAgent.put('/api/admin/uploaders/policy').send({ allowUserDefined: false })).status,
+    ).toBe(403);
+  });
+});
+
+describe('GET /api/admin/uploaders', () => {
+  it('lists the instance uploaders with their policy flags', async () => {
+    const res = await adminAgent.get('/api/admin/uploaders');
+    expect(res.status).toBe(200);
+
+    const x0 = res.body.uploaders.find((u: any) => u.driver === 'x0');
+    expect(x0.isDefault).toBe(true);
+    expect(x0.offeredToUsers).toBe(true);
+    expect(x0.builtIn).toBe(true);
+    expect(res.body.allowUserDefined).toBe(true);
+  });
+
+  it('marks the seeded rows built-in — including catbox, which is ALSO user-creatable', async () => {
+    const res = await adminAgent.get('/api/admin/uploaders');
+    const byDriver = Object.fromEntries(res.body.uploaders.map((u: any) => [u.driver, u]));
+    // The distinction that matters: "may a user instantiate this driver" and "is
+    // this row one the boot reconcile will put back" are different questions.
+    expect(byDriver.catbox.builtIn).toBe(true);
+    expect(res.body.drivers.map((d: any) => d.driver)).toContain('catbox');
+  });
+});
+
+describe('creating and configuring an instance uploader', () => {
+  it('creates one, keeps the secret server-side, and offers it to users', async () => {
+    const res = await adminAgent.post('/api/admin/uploaders').send({
+      driver: 's3',
+      label: 'Company R2',
+      values: {
+        endpoint: 'https://acct.r2.cloudflarestorage.com',
+        bucket: 'uploads',
+        access_key_id: 'AKIA',
+        secret_access_key: 'super-secret',
+        public_base_url: 'https://cdn.example.com',
+      },
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.label).toBe('Company R2');
+    expect(res.body.offeredToUsers).toBe(true);
+    expect(res.body.config.bucket).toBe('uploads');
+    expect(res.body.secretsSet).toEqual({ secret_access_key: true });
+    expect(JSON.stringify(res.body)).not.toContain('super-secret');
+
+    const { resolvedConfig } = await import('../db/uploaderConfig.js');
+    expect(resolvedConfig(getUploaderConfig(res.body.id)!).secret_access_key).toBe('super-secret');
+  });
+
+  it('rejects an incomplete config', async () => {
+    const res = await adminAgent
+      .post('/api/admin/uploaders')
+      .send({ driver: 's3', values: { bucket: 'only-this' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('toggles offered_to_users, which adds/removes it from a user’s allowed set', async () => {
+    const created = (
+      await adminAgent
+        .post('/api/admin/uploaders')
+        .send({ driver: 'zipline', values: { url: 'https://z.example', token: 't' } })
+    ).body;
+
+    const { listAllowedUploaders } = await import('../services/uploadProviders/resolve.js');
+    expect(listAllowedUploaders(plainUser.id).map((r) => r.id)).toContain(created.id);
+
+    await adminAgent.patch(`/api/admin/uploaders/${created.id}`).send({ offeredToUsers: false });
+    expect(listAllowedUploaders(plainUser.id).map((r) => r.id)).not.toContain(created.id);
+    // …but an admin still sees it.
+    expect(listAllowedUploaders(admin.id, true).map((r) => r.id)).toContain(created.id);
+  });
+});
+
+describe('the instance default (#299)', () => {
+  it('moves the default, and a user who has not chosen follows it', async () => {
+    // A brand-new account has no selection, so it resolves to the instance default.
+    expect(resolveUploader({ userId: plainUser.id }).driverId).toBe('x0');
+
+    const local = instanceRow('local');
+    const res = await adminAgent.put(`/api/admin/uploaders/${local.id}/default`);
+    expect(res.status).toBe(200);
+
+    expect(resolveUploader({ userId: plainUser.id }).driverId).toBe('local');
+    // Exactly one default survives the swap (the unique partial index depends on it).
+    expect(listInstanceUploaders().filter((r) => r.is_default === 1)).toHaveLength(1);
+
+    await adminAgent.put(`/api/admin/uploaders/${instanceRow('x0').id}/default`); // restore
+  });
+
+  it('refuses to make a disabled uploader the default', async () => {
+    const catbox = instanceRow('catbox');
+    await adminAgent.patch(`/api/admin/uploaders/${catbox.id}`).send({ enabled: false });
+
+    const res = await adminAgent.put(`/api/admin/uploaders/${catbox.id}/default`);
+    expect(res.status).toBe(409);
+
+    await adminAgent.patch(`/api/admin/uploaders/${catbox.id}`).send({ enabled: true });
+  });
+});
+
+describe('DELETE /api/admin/uploaders/:id', () => {
+  it('refuses to delete a built-in (it would just come back on the next boot)', async () => {
+    for (const driver of ['x0', 'catbox', 'local']) {
+      const res = await adminAgent.delete(`/api/admin/uploaders/${instanceRow(driver).id}`);
+      expect(res.status).toBe(409);
+      expect(res.body.error).toMatch(/built-in/);
+    }
+    expect(listInstanceUploaders()).toHaveLength(3);
+  });
+
+  it('refuses to delete the current default', async () => {
+    const created = (
+      await adminAgent
+        .post('/api/admin/uploaders')
+        .send({ driver: 'zipline', values: { url: 'https://z.example', token: 't' } })
+    ).body;
+    await adminAgent.put(`/api/admin/uploaders/${created.id}/default`);
+
+    const res = await adminAgent.delete(`/api/admin/uploaders/${created.id}`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/another default/);
+
+    await adminAgent.put(`/api/admin/uploaders/${instanceRow('x0').id}/default`);
+  });
+
+  it('deletes one the admin created', async () => {
+    const created = (
+      await adminAgent
+        .post('/api/admin/uploaders')
+        .send({ driver: 'chibisafe', values: { url: 'https://c.example', api_key: 'k' } })
+    ).body;
+
+    expect((await adminAgent.delete(`/api/admin/uploaders/${created.id}`)).status).toBe(200);
+    expect(getUploaderConfig(created.id)).toBeNull();
+  });
+});
+
+describe('PUT /api/admin/uploaders/policy', () => {
+  it('flips the lockdown switch', async () => {
+    const res = await adminAgent
+      .put('/api/admin/uploaders/policy')
+      .send({ allowUserDefined: false });
+    expect(res.status).toBe(200);
+    expect(allowUserDefinedUploaders()).toBe(false);
+  });
+
+  it('locking down does NOT disable the uploaders people already have', async () => {
+    // §10's open decision, resolved: don't strand a self-hoster who flips the
+    // switch — they just can't add NEW ones.
+    const { createUploaderConfig } = await import('../db/uploaderConfig.js');
+    const mine = createUploaderConfig({
+      scope: 'user',
+      ownerUserId: plainUser.id,
+      driver: 'catbox',
+      values: { userhash: 'h' },
+    });
+
+    await adminAgent.put('/api/admin/uploaders/policy').send({ allowUserDefined: false });
+
+    const { listAllowedUploaders } = await import('../services/uploadProviders/resolve.js');
+    expect(listAllowedUploaders(plainUser.id).map((r) => r.id)).toContain(mine);
+    expect(getUploaderConfig(mine)!.enabled).toBe(1);
+  });
+
+  it('rejects a non-boolean', async () => {
+    expect(
+      (await adminAgent.put('/api/admin/uploaders/policy').send({ allowUserDefined: 'yes' }))
+        .status,
+    ).toBe(400);
+  });
+});

--- a/server/routes/adminUploaders.ts
+++ b/server/routes/adminUploaders.ts
@@ -50,11 +50,20 @@ function refuseOnNode(res: Response): boolean {
   return true;
 }
 
-function creatableDrivers() {
+/** Every driver, with `creatable` saying which may be stood up as a NEW uploader.
+ *  Same reasoning as routes/uploaders.ts#visibleDrivers: describing a row you
+ *  already have and adding a new one are different questions, and an instance row
+ *  can exist for a non-creatable driver (the seeded x0/local, or a locked hosted
+ *  dropper). A schema is field metadata, never a value. */
+function visibleDrivers() {
   return driverIds
     .map((id) => getDriver(id)!)
-    .filter((d) => d.capabilities.creatable)
-    .map((d) => ({ driver: d.driver, label: d.label, configSchema: d.configSchema }));
+    .map((d) => ({
+      driver: d.driver,
+      label: d.label,
+      configSchema: d.configSchema,
+      creatable: Boolean(d.capabilities.creatable),
+    }));
 }
 
 function validateValues(
@@ -116,7 +125,7 @@ router.get('/', (_req: Request, res: Response) => {
       return detail;
     }),
     allowUserDefined: allowUserDefinedUploaders(),
-    drivers: creatableDrivers(),
+    drivers: visibleDrivers(),
     // The client hides the whole management surface on a hosted cell rather than
     // offering buttons that will 409.
     managed: isNodeMode(),

--- a/server/routes/adminUploaders.ts
+++ b/server/routes/adminUploaders.ts
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The admin half of uploader management (#514, absorbing #299): instance-scoped
+// uploaders — the ones the operator stands up for everybody — plus the two policy
+// levers that decide what users get.
+//
+//   • is_default        the uploader a new account silently inherits (#299's whole
+//                       point: uploads work from first use, no onboarding step).
+//   • offered_to_users  whether an instance uploader shows up in a user's picker
+//                       at all, or is admin-only.
+//   • allow_user_defined  the lockdown switch: may users stand up their OWN
+//                       uploaders? Flipping it off blocks NEW personal uploaders
+//                       and hides the add button; it deliberately does NOT disable
+//                       the ones people already have (§10 open decision, resolved
+//                       here as "don't strand a self-hoster who flips the switch").
+//
+// Mounted under the admin router, so requireAuth + requireAdmin already apply.
+//
+// Node edition refuses the lot: a hosted cell's uploader is the locked row that
+// reconcileHostedUploaderFromEnv re-derives from the operator env on every boot,
+// so anything written here would be silently reverted on the next deploy. Same
+// reasoning (and same 409) as the pause routes in admin.ts.
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import {
+  getUploaderConfig,
+  listInstanceUploaders,
+  createUploaderConfig,
+  updateUploaderConfig,
+  deleteUploaderConfig,
+  setInstanceDefault,
+  toDetail,
+} from '../db/uploaderConfig.js';
+import { allowUserDefinedUploaders, setAllowUserDefinedUploaders } from '../db/instanceSettings.js';
+import { BUILT_IN_INSTANCE_DRIVERS } from '../db/uploaderConfigSeed.js';
+import { getDriver, driverIds } from '../services/uploadProviders/index.js';
+import { isNodeMode } from '../utils/edition.js';
+
+const router = Router();
+
+const MAX_LABEL_LEN = 64;
+const MAX_VALUE_LEN = 2048;
+
+/** Every instance uploader route is refused on a hosted cell — see header. */
+function refuseOnNode(res: Response): boolean {
+  if (!isNodeMode()) return false;
+  res.status(409).json({ error: 'the uploader is managed by the control plane in node edition' });
+  return true;
+}
+
+function creatableDrivers() {
+  return driverIds
+    .map((id) => getDriver(id)!)
+    .filter((d) => d.capabilities.creatable)
+    .map((d) => ({ driver: d.driver, label: d.label, configSchema: d.configSchema }));
+}
+
+function validateValues(
+  driverId: string,
+  values: Record<string, unknown>,
+  { partial }: { partial: boolean },
+): string | null {
+  const driver = getDriver(driverId);
+  if (!driver) return `unknown upload driver: ${driverId}`;
+  for (const [k, v] of Object.entries(values)) {
+    if (!driver.configSchema.some((f) => f.key === k)) return `unknown config field: ${k}`;
+    if (typeof v !== 'string') return `config field must be a string: ${k}`;
+    if (v.length > MAX_VALUE_LEN) return `config field is too long: ${k}`;
+  }
+  if (partial) return null;
+  for (const f of driver.configSchema) {
+    if (f.required && !String(values[f.key] ?? '').trim()) return `${f.label} is required`;
+  }
+  return null;
+}
+
+function readValues(body: unknown): Record<string, string> | null {
+  const raw = (body as { values?: unknown } | null)?.values;
+  if (raw == null) return {};
+  if (typeof raw !== 'object' || Array.isArray(raw)) return null;
+  return raw as Record<string, string>;
+}
+
+function readLabel(body: unknown): string | undefined {
+  const raw = (body as { label?: unknown } | null)?.label;
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  return trimmed ? trimmed.slice(0, MAX_LABEL_LEN) : undefined;
+}
+
+function bool(body: unknown, key: string): boolean | undefined {
+  const v = (body as Record<string, unknown> | null)?.[key];
+  return typeof v === 'boolean' ? v : undefined;
+}
+
+/** Built-ins are re-created by reconcileBuiltInUploaders on the next boot anyway,
+ *  so deleting one is theatre — and deleting `local` would strand the bytes
+ *  already on disk with nothing left that knows how to reap them. Disable-only.
+ *  Deliberately NOT keyed off the driver's `creatable` capability: catbox is both
+ *  a seeded built-in and a driver users may instantiate with their own userhash. */
+function isBuiltIn(driverId: string): boolean {
+  return BUILT_IN_INSTANCE_DRIVERS.includes(driverId);
+}
+
+router.get('/', (_req: Request, res: Response) => {
+  res.json({
+    uploaders: listInstanceUploaders().map((row) => ({
+      ...toDetail(row),
+      builtIn: isBuiltIn(row.driver),
+    })),
+    allowUserDefined: allowUserDefinedUploaders(),
+    drivers: creatableDrivers(),
+    // The client hides the whole management surface on a hosted cell rather than
+    // offering buttons that will 409.
+    managed: isNodeMode(),
+  });
+});
+
+router.post('/', (req: Request, res: Response) => {
+  if (refuseOnNode(res)) return;
+  const driverId = (req.body as { driver?: unknown } | null)?.driver;
+  if (typeof driverId !== 'string' || !driverId) {
+    res.status(400).json({ error: 'driver is required' });
+    return;
+  }
+  const driver = getDriver(driverId);
+  if (!driver || !driver.capabilities.creatable) {
+    res.status(400).json({ error: `unknown upload driver: ${driverId}` });
+    return;
+  }
+  const values = readValues(req.body);
+  if (!values) {
+    res.status(400).json({ error: 'values must be an object' });
+    return;
+  }
+  const invalid = validateValues(driverId, values, { partial: false });
+  if (invalid) {
+    res.status(400).json({ error: invalid });
+    return;
+  }
+  const id = createUploaderConfig({
+    scope: 'instance',
+    driver: driverId,
+    label: readLabel(req.body),
+    values,
+    offeredToUsers: bool(req.body, 'offeredToUsers') ?? true,
+  });
+  res.status(201).json(toDetail(getUploaderConfig(id)!));
+});
+
+router.patch('/:id', (req: Request, res: Response) => {
+  if (refuseOnNode(res)) return;
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const row = getUploaderConfig(id);
+  if (!row || row.scope !== 'instance') {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  if (row.locked === 1) {
+    res
+      .status(409)
+      .json({ error: 'this uploader is managed by the operator and cannot be edited' });
+    return;
+  }
+  const values = readValues(req.body);
+  if (!values) {
+    res.status(400).json({ error: 'values must be an object' });
+    return;
+  }
+  const invalid = validateValues(row.driver, values, { partial: true });
+  if (invalid) {
+    res.status(400).json({ error: invalid });
+    return;
+  }
+  updateUploaderConfig(id, {
+    label: readLabel(req.body),
+    values,
+    enabled: bool(req.body, 'enabled'),
+    offeredToUsers: bool(req.body, 'offeredToUsers'),
+  });
+  res.json(toDetail(getUploaderConfig(id)!));
+});
+
+/** Make this the instance default — what a brand-new account uploads through
+ *  without ever visiting settings (#299). */
+router.put('/:id/default', (req: Request, res: Response) => {
+  if (refuseOnNode(res)) return;
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const row = getUploaderConfig(id);
+  if (!row || row.scope !== 'instance') {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  // A disabled default resolves to nothing, which would break uploads for every
+  // account that hasn't picked an uploader — the exact silent breakage this
+  // whole milestone exists to remove.
+  if (row.enabled !== 1) {
+    res.status(409).json({ error: 'enable this uploader before making it the default' });
+    return;
+  }
+  setInstanceDefault(id);
+  res.json({ ok: true });
+});
+
+router.delete('/:id', (req: Request, res: Response) => {
+  if (refuseOnNode(res)) return;
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const row = getUploaderConfig(id);
+  if (!row || row.scope !== 'instance') {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  if (isBuiltIn(row.driver)) {
+    res.status(409).json({ error: 'built-in uploaders can be disabled, but not deleted' });
+    return;
+  }
+  if (row.is_default === 1) {
+    res.status(409).json({ error: 'choose another default before deleting this uploader' });
+    return;
+  }
+  deleteUploaderConfig(id);
+  res.json({ ok: true });
+});
+
+/** The lockdown switch (design decision 2). */
+router.put('/policy', (req: Request, res: Response) => {
+  if (refuseOnNode(res)) return;
+  const allow = bool(req.body, 'allowUserDefined');
+  if (allow === undefined) {
+    res.status(400).json({ error: 'allowUserDefined must be a boolean' });
+    return;
+  }
+  setAllowUserDefinedUploaders(allow);
+  res.json({ ok: true, allowUserDefined: allow });
+});
+
+export default router;

--- a/server/routes/adminUploaders.ts
+++ b/server/routes/adminUploaders.ts
@@ -106,10 +106,15 @@ function isBuiltIn(driverId: string): boolean {
 
 router.get('/', (_req: Request, res: Response) => {
   res.json({
-    uploaders: listInstanceUploaders().map((row) => ({
-      ...toDetail(row),
-      builtIn: isBuiltIn(row.driver),
-    })),
+    uploaders: listInstanceUploaders().map((row) => {
+      const detail = { ...toDetail(row), builtIn: isBuiltIn(row.driver) };
+      // A LOCKED row is the hosted operator's, configured from their environment
+      // and re-derived on every boot. Its endpoint isn't a cell tenant's business
+      // even when that tenant happens to hold the admin role on their cell — and
+      // nothing can edit it anyway (PATCH 409s). Name and flags only.
+      if (row.locked === 1) return { ...detail, config: {}, secretsSet: {} };
+      return detail;
+    }),
     allowUserDefined: allowUserDefinedUploaders(),
     drivers: creatableDrivers(),
     // The client hides the whole management surface on a hosted cell rather than
@@ -176,6 +181,14 @@ router.patch('/:id', (req: Request, res: Response) => {
   const invalid = validateValues(row.driver, values, { partial: true });
   if (invalid) {
     res.status(400).json({ error: invalid });
+    return;
+  }
+  // Disabling the default would leave every account that hasn't picked an
+  // uploader with nothing to resolve to — uploads would start failing across the
+  // instance. Same reasoning (and same 409) as refusing to delete it: reassign the
+  // default first.
+  if (row.is_default === 1 && bool(req.body, 'enabled') === false) {
+    res.status(409).json({ error: 'choose another default before disabling this uploader' });
     return;
   }
   updateUploaderConfig(id, {

--- a/server/routes/localUploads.integration.test.ts
+++ b/server/routes/localUploads.integration.test.ts
@@ -33,12 +33,17 @@ beforeAll(async () => {
 
   const { createUser } = await import('../db/users.js');
   const { setUserSetting } = await import('../db/settings.js');
+  const { listInstanceUploaders } = await import('../db/uploaderConfig.js');
   const uploadsRouter = (await import('./uploads.js')).default;
   const localRouter = (await import('./localUploads.js')).default;
 
   user = createUser('localint-alice');
-  // Select the seeded self-host `local` instance uploader via the P0 dropdown.
-  setUserSetting(user.id, 'uploads.provider', 'local');
+  // Select the seeded self-host `local` instance uploader the way the picker does
+  // (#514): by uploader_config id. The legacy `uploads.provider` dropdown this
+  // used to go through no longer exists.
+  const localRow = listInstanceUploaders().find((r) => r.driver === 'local');
+  if (!localRow) throw new Error('expected the seeded self-host local uploader row');
+  setUserSetting(user.id, 'uploads.uploader_id', localRow.id);
 
   app = createTestApp({ '/api/uploads': uploadsRouter, '/uploads/local': localRouter });
   agent = await createAuthedAgent(app, user.id);

--- a/server/routes/uploaders.test.ts
+++ b/server/routes/uploaders.test.ts
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The user-facing uploader API (#514). The load-bearing property under test —
+// the one the whole design hangs on — is that a SECRET NEVER COMES BACK. Every
+// projection assertion here is really asserting that.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import type { Express } from 'express';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+
+const ctx = setupTestDb('routes-uploaders');
+
+let app: Express;
+let agent: LurkerTestAgent;
+let intruderAgent: LurkerTestAgent;
+let user: User;
+let intruder: User;
+let setAllowUserDefinedUploaders: typeof import('../db/instanceSettings.js').setAllowUserDefinedUploaders;
+let getUploaderConfig: typeof import('../db/uploaderConfig.js').getUploaderConfig;
+let listInstanceUploaders: typeof import('../db/uploaderConfig.js').listInstanceUploaders;
+let resolveUploader: typeof import('../services/uploadProviders/resolve.js').resolveUploader;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const router = (await import('./uploaders.js')).default;
+  ({ setAllowUserDefinedUploaders } = await import('../db/instanceSettings.js'));
+  ({ getUploaderConfig, listInstanceUploaders } = await import('../db/uploaderConfig.js'));
+  ({ resolveUploader } = await import('../services/uploadProviders/resolve.js'));
+
+  user = createUser('uploaders-alice');
+  intruder = createUser('uploaders-mallory');
+  app = createTestApp({ '/api/uploaders': router });
+  agent = await createAuthedAgent(app, user.id);
+  intruderAgent = await createAuthedAgent(app, intruder.id);
+});
+
+afterAll(() => ctx.cleanup());
+
+async function createCatbox(hash = 'my-userhash') {
+  const res = await agent.post('/api/uploaders').send({
+    driver: 'catbox',
+    label: 'My catbox',
+    values: { userhash: hash },
+  });
+  expect(res.status).toBe(201);
+  return res.body;
+}
+
+describe('GET /api/uploaders', () => {
+  it('401 without a session', async () => {
+    expect((await request(app).get('/api/uploaders')).status).toBe(401);
+  });
+
+  it('lists the seeded instance uploaders and the creatable drivers', async () => {
+    const res = await agent.get('/api/uploaders');
+    expect(res.status).toBe(200);
+    expect(res.body.uploaders.map((u: any) => u.driver)).toEqual(
+      expect.arrayContaining(['x0', 'catbox', 'local']),
+    );
+    // The "add an uploader" menu: drivers with config that a human may stand up.
+    // x0 and local are zero-config singletons; hoarder is the seed-managed dropper.
+    const offered = res.body.drivers.map((d: any) => d.driver);
+    expect(offered).toEqual(expect.arrayContaining(['catbox', 'zipline', 'chibisafe', 's3']));
+    expect(offered).not.toContain('x0');
+    expect(offered).not.toContain('local');
+    expect(offered).not.toContain('hoarder');
+    expect(res.body.selectedId).toBeNull();
+  });
+
+  it('serves each driver’s own configSchema (the form is the driver’s, not the client’s)', async () => {
+    const res = await agent.get('/api/uploaders');
+    const s3 = res.body.drivers.find((d: any) => d.driver === 's3');
+    expect(s3.configSchema.map((f: any) => f.key)).toContain('secret_access_key');
+    const secret = s3.configSchema.find((f: any) => f.key === 'secret_access_key');
+    expect(secret.type).toBe('secret');
+    expect(secret.required).toBe(true);
+  });
+
+  it('an instance uploader is a name to pick, not a config to read', async () => {
+    const res = await agent.get('/api/uploaders');
+    const x0 = res.body.uploaders.find((u: any) => u.driver === 'x0');
+    expect(x0.editable).toBe(false);
+    // No config/secretsSet projected for rows the caller doesn't own.
+    expect(x0.config).toBeUndefined();
+    expect(x0.secretsSet).toBeUndefined();
+  });
+});
+
+describe('POST /api/uploaders', () => {
+  it('creates a personal uploader and NEVER echoes the secret back', async () => {
+    const body = await createCatbox('sekrit-hash');
+
+    expect(body.driver).toBe('catbox');
+    expect(body.label).toBe('My catbox');
+    expect(body.scope).toBe('user');
+    expect(body.editable).toBe(true);
+    // The whole contract in two lines: we're told a secret is SET, never what it is.
+    expect(body.secretsSet).toEqual({ userhash: true });
+    expect(JSON.stringify(body)).not.toContain('sekrit-hash');
+
+    // …but the server still has it, and hands it to the driver at upload time.
+    const row = getUploaderConfig(body.id)!;
+    expect(row.config_json).not.toContain('sekrit-hash'); // secrets never in config_json
+    const { resolvedConfig } = await import('../db/uploaderConfig.js');
+    expect(resolvedConfig(row).userhash).toBe('sekrit-hash');
+  });
+
+  it('rejects a missing required field', async () => {
+    const res = await agent
+      .post('/api/uploaders')
+      .send({ driver: 'zipline', values: { url: 'https://z.example' } }); // no token
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/token/i);
+  });
+
+  it('rejects an unknown config field (the schema is the allowlist)', async () => {
+    const res = await agent
+      .post('/api/uploaders')
+      .send({ driver: 'catbox', values: { userhash: 'h', evil: 'x' } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/unknown config field/);
+  });
+
+  it('refuses drivers a user may not instantiate', async () => {
+    for (const driver of ['x0', 'local', 'hoarder', 'nonsense']) {
+      const res = await agent.post('/api/uploaders').send({ driver, values: {} });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it('is blocked by the admin lockdown switch', async () => {
+    setAllowUserDefinedUploaders(false);
+    try {
+      const res = await agent
+        .post('/api/uploaders')
+        .send({ driver: 'catbox', values: { userhash: 'h' } });
+      expect(res.status).toBe(403);
+    } finally {
+      setAllowUserDefinedUploaders(true);
+    }
+  });
+});
+
+describe('PATCH /api/uploaders/:id', () => {
+  it('keeps the stored secret when the field is omitted', async () => {
+    const created = await createCatbox('keep-me');
+
+    const res = await agent.patch(`/api/uploaders/${created.id}`).send({ label: 'Renamed' });
+    expect(res.status).toBe(200);
+    expect(res.body.label).toBe('Renamed');
+    expect(res.body.secretsSet).toEqual({ userhash: true });
+
+    const { resolvedConfig } = await import('../db/uploaderConfig.js');
+    expect(resolvedConfig(getUploaderConfig(created.id)!).userhash).toBe('keep-me');
+  });
+
+  it('an empty secret means "keep", not "clear"', async () => {
+    const created = await createCatbox('still-here');
+    await agent.patch(`/api/uploaders/${created.id}`).send({ values: { userhash: '' } });
+
+    const { resolvedConfig } = await import('../db/uploaderConfig.js');
+    expect(resolvedConfig(getUploaderConfig(created.id)!).userhash).toBe('still-here');
+  });
+
+  it('replaces the secret when a new one is sent', async () => {
+    const created = await createCatbox('old');
+    await agent.patch(`/api/uploaders/${created.id}`).send({ values: { userhash: 'new' } });
+
+    const { resolvedConfig } = await import('../db/uploaderConfig.js');
+    expect(resolvedConfig(getUploaderConfig(created.id)!).userhash).toBe('new');
+  });
+
+  it('someone else’s uploader is a 404, not a 403 (no probing)', async () => {
+    const created = await createCatbox();
+    const res = await intruderAgent.patch(`/api/uploaders/${created.id}`).send({ label: 'pwned' });
+    expect(res.status).toBe(404);
+    expect(getUploaderConfig(created.id)!.label).toBe('My catbox');
+  });
+
+  it('an instance uploader is not editable here even by its owner-less self', async () => {
+    const x0 = listInstanceUploaders().find((r) => r.driver === 'x0')!;
+    const res = await agent.patch(`/api/uploaders/${x0.id}`).send({ label: 'mine now' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PUT /api/uploaders/selection', () => {
+  it('selects an allowed uploader, and the resolver agrees', async () => {
+    const created = await createCatbox();
+    const res = await agent.put('/api/uploaders/selection').send({ id: created.id });
+    expect(res.status).toBe(200);
+    expect(res.body.selectedId).toBe(created.id);
+
+    // The picker and the upload path must never disagree about what's usable.
+    expect(resolveUploader({ userId: user.id }).configId).toBe(created.id);
+  });
+
+  it('null falls back to the instance default', async () => {
+    const res = await agent.put('/api/uploaders/selection').send({ id: null });
+    expect(res.status).toBe(200);
+    expect(res.body.selectedId).toBeNull();
+
+    const x0 = listInstanceUploaders().find((r) => r.driver === 'x0')!;
+    expect(resolveUploader({ userId: user.id }).configId).toBe(x0.id);
+  });
+
+  it('refuses an uploader that is not yours', async () => {
+    const mine = await createCatbox();
+    const res = await intruderAgent.put('/api/uploaders/selection').send({ id: mine.id });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/uploaders/:id', () => {
+  it('removes it and clears the selection that pointed at it', async () => {
+    const created = await createCatbox();
+    await agent.put('/api/uploaders/selection').send({ id: created.id });
+
+    expect((await agent.delete(`/api/uploaders/${created.id}`)).status).toBe(200);
+    expect(getUploaderConfig(created.id)).toBeNull();
+
+    // Not left dangling: the pane shows "server default", and the resolver uses it.
+    const res = await agent.get('/api/uploaders');
+    expect(res.body.selectedId).toBeNull();
+  });
+
+  it('someone else cannot delete yours', async () => {
+    const created = await createCatbox();
+    expect((await intruderAgent.delete(`/api/uploaders/${created.id}`)).status).toBe(404);
+    expect(getUploaderConfig(created.id)).not.toBeNull();
+  });
+});

--- a/server/routes/uploaders.test.ts
+++ b/server/routes/uploaders.test.ts
@@ -55,20 +55,53 @@ describe('GET /api/uploaders', () => {
     expect((await request(app).get('/api/uploaders')).status).toBe(401);
   });
 
-  it('lists the seeded instance uploaders and the creatable drivers', async () => {
+  it('lists the seeded instance uploaders, and flags which drivers may be ADDED', async () => {
     const res = await agent.get('/api/uploaders');
     expect(res.status).toBe(200);
     expect(res.body.uploaders.map((u: any) => u.driver)).toEqual(
       expect.arrayContaining(['x0', 'catbox', 'local']),
     );
-    // The "add an uploader" menu: drivers with config that a human may stand up.
+    // The "add an uploader" menu is the `creatable` subset — NOT the whole list
+    // (see the migrated-hoarder case below for why the list is the whole set).
     // x0 and local are zero-config singletons; hoarder is the seed-managed dropper.
-    const offered = res.body.drivers.map((d: any) => d.driver);
-    expect(offered).toEqual(expect.arrayContaining(['catbox', 'zipline', 'chibisafe', 's3']));
-    expect(offered).not.toContain('x0');
-    expect(offered).not.toContain('local');
-    expect(offered).not.toContain('hoarder');
+    const creatable = res.body.drivers.filter((d: any) => d.creatable).map((d: any) => d.driver);
+    expect(creatable).toEqual(expect.arrayContaining(['catbox', 'zipline', 'chibisafe', 's3']));
+    expect(creatable).not.toContain('x0');
+    expect(creatable).not.toContain('local');
+    expect(creatable).not.toContain('hoarder');
     expect(res.body.selectedId).toBeNull();
+  });
+
+  // The user reconcileLegacyUploadSettings rescues owns a `hoarder` row: editable,
+  // but NOT creatable. If the driver list only carried creatable drivers, the
+  // client would have no schema to render their edit form from — and the pane blew
+  // up on it. The people this release exists to rescue are exactly the people who
+  // must not hit a wall here.
+  it('describes EVERY driver an owned row can reference, not just the creatable ones', async () => {
+    const { createUploaderConfig } = await import('../db/uploaderConfig.js');
+    const migrated = createUploaderConfig({
+      scope: 'user',
+      ownerUserId: user.id,
+      driver: 'hoarder', // what the legacy-settings migration produces
+      label: 'Hoarder',
+      values: { url: 'https://hoard.example', api_key: 'k' },
+    });
+
+    const res = await agent.get('/api/uploaders');
+    const row = res.body.uploaders.find((u: any) => u.id === migrated);
+    expect(row.editable).toBe(true);
+
+    // …so a descriptor for its driver MUST be present, or the form can't render.
+    const hoarder = res.body.drivers.find((d: any) => d.driver === 'hoarder');
+    expect(hoarder).toBeDefined();
+    expect(hoarder.creatable).toBe(false); // but still not offered in the add menu
+    expect(hoarder.configSchema.map((f: any) => f.key)).toEqual(['url', 'api_key']);
+
+    // And editing it still works end-to-end, secret preserved on omit.
+    const patched = await agent.patch(`/api/uploaders/${migrated}`).send({ label: 'My Hoarder' });
+    expect(patched.status).toBe(200);
+    const { resolvedConfig } = await import('../db/uploaderConfig.js');
+    expect(resolvedConfig(getUploaderConfig(migrated)!).api_key).toBe('k');
   });
 
   it('serves each driver’s own configSchema (the form is the driver’s, not the client’s)', async () => {

--- a/server/routes/uploaders.ts
+++ b/server/routes/uploaders.ts
@@ -47,18 +47,37 @@ interface DriverDescriptor {
   driver: string;
   label: string;
   configSchema: UploadDriver['configSchema'];
+  // Whether a human may stand up a NEW one. The client filters the "add an
+  // uploader" menu by this.
+  creatable: boolean;
 }
 
-/** Drivers a human may instantiate here: declared `creatable` (so not a
- *  zero-config singleton like x0/local, nor the seed-managed hosted dropper), and
- *  not self-host-only when we're a hosted cell. */
-function creatableDrivers(): DriverDescriptor[] {
+/**
+ * Every driver the client might need to describe — NOT just the creatable ones.
+ *
+ * These are two different questions and conflating them was a bug: "what may I
+ * add?" is `creatable`, but "what schema describes this row I already own?" is
+ * any driver at all. A self-hoster migrated off the legacy Hoarder settings owns a
+ * `hoarder` row — editable, and NOT creatable — so a creatable-only list left the
+ * client with no schema to render their edit form from. They are precisely the
+ * people this release exists to rescue, so they are precisely the people who must
+ * not hit a wall on this pane.
+ *
+ * Config VALUES still only ever ship for rows the caller owns (projectForUser);
+ * a schema is just field metadata — labels and types, never a secret.
+ */
+function visibleDrivers(): DriverDescriptor[] {
   const out: DriverDescriptor[] = [];
   for (const id of driverIds) {
     const d = getDriver(id);
-    if (!d || !d.capabilities.creatable) continue;
+    if (!d) continue;
     if (d.capabilities.selfHostOnly && isNodeMode()) continue;
-    out.push({ driver: d.driver, label: d.label, configSchema: d.configSchema });
+    out.push({
+      driver: d.driver,
+      label: d.label,
+      configSchema: d.configSchema,
+      creatable: Boolean(d.capabilities.creatable),
+    });
   }
   return out;
 }
@@ -137,7 +156,7 @@ router.get('/', (req: Request, res: Response) => {
     uploaders: allowed.map((r) => projectForUser(r, userId)),
     selectedId,
     allowUserDefined: allowUserDefinedUploaders(),
-    drivers: creatableDrivers(),
+    drivers: visibleDrivers(),
   });
 });
 

--- a/server/routes/uploaders.ts
+++ b/server/routes/uploaders.ts
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The user-facing half of uploader management (#514): list the uploaders you may
+// send a file to, stand up your own (a catbox account, your Zipline, your S3
+// bucket), and choose which one is yours by default. The admin half — instance
+// uploaders and the policy switches — lives in routes/admin.ts.
+//
+// This router replaces the old `uploads.provider` enum + flat `uploads.*.api_key`
+// settings keys. Two things that were implicit there are explicit here:
+//
+//   1. SECRETS ARE WRITE-ONLY. A response never carries a secret value, only
+//      `secretsSet[field] = true/false`. An edit that omits a secret keeps the
+//      stored one (see db/uploaderConfig.ts#updateUploaderConfig), so changing a
+//      bucket name doesn't require re-typing the key you can't read back.
+//   2. THE FORM IS THE DRIVER'S. `drivers[].configSchema` is served straight from
+//      each driver module, so a new driver is a form with no client change.
+
+import express, { type Request, type Response } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { getUserSettings, setUserSetting, deleteUserSetting } from '../db/settings.js';
+import {
+  getUploaderConfig,
+  createUploaderConfig,
+  updateUploaderConfig,
+  deleteUploaderConfig,
+  toDetail,
+  toSummary,
+  type UploaderConfigRow,
+} from '../db/uploaderConfig.js';
+import { allowUserDefinedUploaders } from '../db/instanceSettings.js';
+import { listAllowedUploaders } from '../services/uploadProviders/resolve.js';
+import { getDriver, driverIds, type UploadDriver } from '../services/uploadProviders/index.js';
+import { isNodeMode } from '../utils/edition.js';
+
+const router = express.Router();
+router.use(requireAuth);
+
+/** The user's chosen uploader id (settings key, not a registry setting — it's a
+ *  row id, not a preference). Undefined → "use the instance default". */
+const SELECTION_KEY = 'uploads.uploader_id';
+
+const MAX_LABEL_LEN = 64;
+const MAX_VALUE_LEN = 2048;
+
+interface DriverDescriptor {
+  driver: string;
+  label: string;
+  configSchema: UploadDriver['configSchema'];
+}
+
+/** Drivers a human may instantiate here: declared `creatable` (so not a
+ *  zero-config singleton like x0/local, nor the seed-managed hosted dropper), and
+ *  not self-host-only when we're a hosted cell. */
+function creatableDrivers(): DriverDescriptor[] {
+  const out: DriverDescriptor[] = [];
+  for (const id of driverIds) {
+    const d = getDriver(id);
+    if (!d || !d.capabilities.creatable) continue;
+    if (d.capabilities.selfHostOnly && isNodeMode()) continue;
+    out.push({ driver: d.driver, label: d.label, configSchema: d.configSchema });
+  }
+  return out;
+}
+
+/** A row is editable by its owner, and only its owner: an instance row is the
+ *  admin surface's business even when the caller happens to be an admin, so the
+ *  two APIs never disagree about who owns a write. */
+function isOwnedBy(row: UploaderConfigRow, userId: number): boolean {
+  return row.scope === 'user' && row.owner_user_id === userId;
+}
+
+function projectForUser(row: UploaderConfigRow, userId: number) {
+  const base = {
+    ...toSummary(row),
+    scope: row.scope,
+    enabled: row.enabled === 1,
+    editable: isOwnedBy(row, userId),
+  };
+  // Config values (non-secret) only for rows the caller owns. An instance row's
+  // endpoint/bucket is the operator's business, not the tenant's — they get a
+  // name to pick, nothing more.
+  if (!isOwnedBy(row, userId)) return base;
+  const detail = toDetail(row);
+  return { ...base, config: detail.config, secretsSet: detail.secretsSet };
+}
+
+/** Validate a flat values object against a driver's schema. Returns an error
+ *  string, or null when it's good. `partial` (a PATCH) skips the required check:
+ *  an omitted secret means "keep the stored one", which is only knowable here. */
+function validateValues(
+  driver: UploadDriver,
+  values: Record<string, unknown>,
+  { partial }: { partial: boolean },
+): string | null {
+  for (const [k, v] of Object.entries(values)) {
+    if (!driver.configSchema.some((f) => f.key === k)) return `unknown config field: ${k}`;
+    if (typeof v !== 'string') return `config field must be a string: ${k}`;
+    if (v.length > MAX_VALUE_LEN) return `config field is too long: ${k}`;
+  }
+  if (partial) return null;
+  for (const f of driver.configSchema) {
+    if (f.required && !String(values[f.key] ?? '').trim()) return `${f.label} is required`;
+  }
+  return null;
+}
+
+function readValues(body: unknown): Record<string, string> | null {
+  const raw = (body as { values?: unknown } | null)?.values;
+  if (raw == null) return {};
+  if (typeof raw !== 'object' || Array.isArray(raw)) return null;
+  return raw as Record<string, string>;
+}
+
+function readLabel(body: unknown): string | undefined {
+  const raw = (body as { label?: unknown } | null)?.label;
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  return trimmed ? trimmed.slice(0, MAX_LABEL_LEN) : undefined;
+}
+
+// ─── routes ──────────────────────────────────────────────────────────────────
+
+/** Everything the Uploads pane needs in one shot: what you may use, what you've
+ *  picked, whether you're allowed to add your own, and the driver forms. */
+router.get('/', (req: Request, res: Response) => {
+  const userId = req.user!.id;
+  const isAdmin = req.user!.role === 'admin';
+  const allowed = listAllowedUploaders(userId, isAdmin);
+
+  const settings = getUserSettings(userId);
+  const savedId = settings[SELECTION_KEY];
+  const selectedId =
+    typeof savedId === 'number' && allowed.some((r) => r.id === savedId) ? savedId : null;
+
+  res.json({
+    uploaders: allowed.map((r) => projectForUser(r, userId)),
+    selectedId,
+    allowUserDefined: allowUserDefinedUploaders(),
+    drivers: creatableDrivers(),
+  });
+});
+
+/** Choose your default uploader. `id: null` → fall back to the instance default. */
+router.put('/selection', (req: Request, res: Response) => {
+  const userId = req.user!.id;
+  const id = (req.body as { id?: unknown } | null)?.id ?? null;
+
+  if (id === null) {
+    deleteUserSetting(userId, SELECTION_KEY);
+    res.json({ ok: true, selectedId: null });
+    return;
+  }
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'id must be an integer or null' });
+    return;
+  }
+  // Must be in the allowed set — the same set resolveUploader() will consult at
+  // upload time, so a selection the picker accepts can never fail to resolve.
+  const allowed = listAllowedUploaders(userId, req.user!.role === 'admin');
+  if (!allowed.some((r) => r.id === id)) {
+    res.status(400).json({ error: 'that uploader is not available to you' });
+    return;
+  }
+  setUserSetting(userId, SELECTION_KEY, id);
+  res.json({ ok: true, selectedId: id });
+});
+
+router.post('/', (req: Request, res: Response) => {
+  const userId = req.user!.id;
+
+  if (!allowUserDefinedUploaders()) {
+    res.status(403).json({ error: 'this server does not allow personal uploaders' });
+    return;
+  }
+  const driverId = (req.body as { driver?: unknown } | null)?.driver;
+  if (typeof driverId !== 'string' || !driverId) {
+    res.status(400).json({ error: 'driver is required' });
+    return;
+  }
+  const driver = getDriver(driverId);
+  if (!driver || !driver.capabilities.creatable) {
+    res.status(400).json({ error: `unknown upload driver: ${driverId}` });
+    return;
+  }
+  if (driver.capabilities.selfHostOnly && isNodeMode()) {
+    res.status(400).json({ error: `${driver.label} is not available on this server` });
+    return;
+  }
+  const values = readValues(req.body);
+  if (!values) {
+    res.status(400).json({ error: 'values must be an object' });
+    return;
+  }
+  const invalid = validateValues(driver, values, { partial: false });
+  if (invalid) {
+    res.status(400).json({ error: invalid });
+    return;
+  }
+
+  const id = createUploaderConfig({
+    scope: 'user',
+    ownerUserId: userId,
+    driver: driverId,
+    label: readLabel(req.body),
+    values,
+  });
+  res.status(201).json(projectForUser(getUploaderConfig(id)!, userId));
+});
+
+router.patch('/:id', (req: Request, res: Response) => {
+  const userId = req.user!.id;
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const row = getUploaderConfig(id);
+  // Ownership is the 404: a row you don't own is a row that doesn't exist, so
+  // this can't be used to probe for other people's uploaders.
+  if (!row || !isOwnedBy(row, userId)) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  const driver = getDriver(row.driver);
+  if (!driver) {
+    res.status(400).json({ error: `unknown upload driver: ${row.driver}` });
+    return;
+  }
+  const values = readValues(req.body);
+  if (!values) {
+    res.status(400).json({ error: 'values must be an object' });
+    return;
+  }
+  const invalid = validateValues(driver, values, { partial: true });
+  if (invalid) {
+    res.status(400).json({ error: invalid });
+    return;
+  }
+  const enabled = (req.body as { enabled?: unknown } | null)?.enabled;
+
+  updateUploaderConfig(id, {
+    label: readLabel(req.body),
+    values,
+    enabled: typeof enabled === 'boolean' ? enabled : undefined,
+  });
+  res.json(projectForUser(getUploaderConfig(id)!, userId));
+});
+
+router.delete('/:id', (req: Request, res: Response) => {
+  const userId = req.user!.id;
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const row = getUploaderConfig(id);
+  if (!row || !isOwnedBy(row, userId)) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  deleteUploaderConfig(id);
+  // Don't leave the user pointed at a row that's gone: resolveUploader() would
+  // quietly fall back to the instance default, which is a different host than the
+  // one they picked. Clearing it makes the fallback explicit in the UI instead.
+  if (getUserSettings(userId)[SELECTION_KEY] === id) deleteUserSetting(userId, SELECTION_KEY);
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -112,11 +112,23 @@ router.post(
       // Resolve the configured uploader. Every isNodeMode() branch the old route
       // made (which provider, whose credentials, which caps, SVG policy, thumbnail
       // strategy) is now derived from the resolved uploader's driver + policy.
+      // Per-upload override (design decision 9): send this one file somewhere
+      // other than your default. Multipart, so it arrives as a string field. An
+      // override that isn't in the caller's allowed set is a 400, never a silent
+      // reroute to their default (decision 15).
+      const requestedRaw = (req.body as { uploaderId?: unknown } | undefined)?.uploaderId;
+      const requestedId = requestedRaw == null || requestedRaw === '' ? null : Number(requestedRaw);
+      if (requestedId != null && !Number.isInteger(requestedId)) {
+        res.status(400).json({ error: 'uploaderId must be an integer' });
+        return;
+      }
+
       let resolved: ResolvedUploader;
       try {
         resolved = resolveUploader({
           userId: req.user!.id,
           isAdmin: req.user!.role === 'admin',
+          requestedId,
         });
       } catch (err) {
         // A locked instance default that the operator hasn't configured →

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -57,6 +57,13 @@ function scopeFilter(scope: string, userId: number): { where: string; params: nu
         where: 'WHERE rule_id IN (SELECT id FROM highlight_rules WHERE user_id = ?)',
         params: [userId],
       };
+    // uploader_config (#514): a user's OWN uploaders only. The scope='user' half
+    // is load-bearing, not decoration — without it an export would rake in the
+    // instance's x0/catbox/local rows (owner_user_id IS NULL, so they'd slip a
+    // `WHERE owner_user_id = ?` only by luck) and hand the operator's
+    // configuration to whoever asked for their data.
+    case 'owned_uploaders':
+      return { where: "WHERE scope = 'user' AND owner_user_id = ?", params: [userId] };
     default:
       throw new Error(`exportService: unknown scope "${scope}"`);
   }

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -886,6 +886,9 @@ describe('importFromZipBuffer — end-to-end equivalence', () => {
         sql = `SELECT * FROM ${table}
                WHERE rule_id IN (SELECT id FROM highlight_rules WHERE user_id = ?)`;
         break;
+      case 'owned_uploaders':
+        sql = `SELECT * FROM ${table} WHERE scope = 'user' AND owner_user_id = ?`;
+        break;
       default:
         throw new Error(`unknown scope ${def.scope}`);
     }
@@ -1005,5 +1008,88 @@ describe('importFromZipBuffer — end-to-end equivalence', () => {
         .get(bob.id, bob.id) as { n: number }
     ).n;
     expect(junctionStray).toBe(0);
+  });
+});
+
+// A user's own configured uploaders (#514). They became exportable when the
+// legacy uploads.* settings keys — which used to carry this across an export —
+// were deleted, so without this they'd vanish from a user's data export entirely.
+describe('uploader_config — export/import', () => {
+  it('carries a personal uploader across, WITHOUT its secret', async () => {
+    const alice = createUser(`up_alice_${Date.now()}`);
+    const bob = createUser(`up_bob_${Date.now()}`);
+    const { createUploaderConfig } = await import('../db/uploaderConfig.js');
+    const { setUserSetting, getUserSettings } = await import('../db/settings.js');
+
+    const mine = createUploaderConfig({
+      scope: 'user',
+      ownerUserId: alice.id,
+      driver: 'zipline',
+      label: 'My Zipline',
+      values: { url: 'https://zip.example', token: 'TOP-SECRET-TOKEN' },
+    });
+    setUserSetting(alice.id, 'uploads.uploader_id', mine);
+
+    const buf = await exportToBuffer(alice.id, { includeMessages: false });
+    // The secret must not be anywhere in the archive: on a keyless self-host the
+    // at-rest envelope is a plaintext passthrough, so a naive export would put the
+    // token in the clear inside a zip the user hands around.
+    expect(buf.toString('binary')).not.toContain('TOP-SECRET-TOKEN');
+
+    await importFromZipBuffer(bob.id, buf);
+
+    const bobRows = db
+      .prepare(`SELECT * FROM uploader_config WHERE scope = 'user' AND owner_user_id = ?`)
+      .all(bob.id) as Array<{
+      id: number;
+      driver: string;
+      label: string;
+      config_json: string;
+      secrets_enc: string | null;
+      is_default: number;
+      offered_to_users: number;
+      locked: number;
+    }>;
+    expect(bobRows).toHaveLength(1);
+    expect(bobRows[0].driver).toBe('zipline');
+    expect(bobRows[0].label).toBe('My Zipline');
+    expect(JSON.parse(bobRows[0].config_json).url).toBe('https://zip.example');
+    // Arrives credential-less by design — Bob re-enters the token.
+    expect(bobRows[0].secrets_enc).toBeNull();
+    // An imported row can never smuggle itself in as an offered instance default.
+    expect(bobRows[0].is_default).toBe(0);
+    expect(bobRows[0].offered_to_users).toBe(0);
+    expect(bobRows[0].locked).toBe(0);
+
+    // The selection pointer is an id living inside a user_settings VALUE — the one
+    // id in the archive the column-based rekey machinery can't see. It must be
+    // rewritten to Bob's new row, not left pointing at Alice's.
+    expect(getUserSettings(bob.id)['uploads.uploader_id']).toBe(bobRows[0].id);
+    expect(getUserSettings(bob.id)['uploads.uploader_id']).not.toBe(mine);
+  });
+
+  it('does not export the INSTANCE uploaders, and drops a pointer at one', async () => {
+    const alice = createUser(`up_inst_alice_${Date.now()}`);
+    const bob = createUser(`up_inst_bob_${Date.now()}`);
+    const { listInstanceUploaders } = await import('../db/uploaderConfig.js');
+    const { setUserSetting, getUserSettings } = await import('../db/settings.js');
+
+    const x0 = listInstanceUploaders().find((r) => r.driver === 'x0')!;
+    setUserSetting(alice.id, 'uploads.uploader_id', x0.id);
+
+    const buf = await exportToBuffer(alice.id, { includeMessages: false });
+    await importFromZipBuffer(bob.id, buf);
+
+    // The operator's rows are not Alice's data and must not ride along.
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM uploader_config WHERE scope = 'user' AND owner_user_id = ?`,
+        )
+        .get(bob.id),
+    ).toEqual({ n: 0 });
+    // An instance id means nothing on the target, so the pointer is dropped and
+    // Bob lands on the target's own default rather than a dangling id.
+    expect(getUserSettings(bob.id)['uploads.uploader_id']).toBeUndefined();
   });
 });

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -223,6 +223,24 @@ function insertTable(
     }
     if (drop) continue;
 
+    // `uploads.uploader_id` is an uploader_config row id that lives inside a
+    // user_settings VALUE, so the column-based FK-rekey machinery above can't see
+    // it — this is the one id in the archive that has to be rewritten by hand
+    // (#514). Unmapped means it pointed at an INSTANCE uploader (never exported),
+    // so drop the setting entirely and let the user land on the target instance's
+    // default rather than on a dangling id.
+    if (table === 'user_settings' && row.key === 'uploads.uploader_id') {
+      let oldId: unknown;
+      try {
+        oldId = JSON.parse(String(row.value));
+      } catch {
+        continue; // malformed archive value — drop the setting, fall back to default
+      }
+      const mapped = idMaps.uploader_config?.get(oldId);
+      if (mapped === undefined) continue;
+      row.value = JSON.stringify(mapped);
+    }
+
     // Route ignore rules through the service rather than a raw INSERT, so a
     // crafted/legacy archive can't plant an unvalidated regex (ReDoS surface), a
     // non-ISO expires_at that never lapses and never sweeps, or a duplicate —
@@ -336,6 +354,13 @@ function resetImportedData(userId: number): void {
     // re-inserts every contact (accountIsEmpty only counts networks), leaving
     // duplicated, target-less friends.
     db.prepare('DELETE FROM contacts WHERE user_id = ?').run(userId);
+    // Same class of problem as contacts: uploader_config only cascades on user
+    // delete, so without this a failed-then-retried import would leave the user
+    // with two copies of every personal uploader. Scoped to 'user' — the
+    // instance's own rows are not this user's to wipe.
+    db.prepare("DELETE FROM uploader_config WHERE scope = 'user' AND owner_user_id = ?").run(
+      userId,
+    );
   });
   wipe();
 }

--- a/server/services/uploadProviders/catbox.ts
+++ b/server/services/uploadProviders/catbox.ts
@@ -26,6 +26,7 @@ const TIMEOUT_MS = 60_000;
 export const driver = 'catbox';
 export const label = 'catbox.moe';
 export const capabilities: DriverCapabilities = {
+  creatable: true,
   storesRemotely: true,
   supportsDelete: false,
   mintsKeys: false,

--- a/server/services/uploadProviders/chibisafe.ts
+++ b/server/services/uploadProviders/chibisafe.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Chibisafe driver — self-hosted file host
+// (https://github.com/chibisafe/chibisafe). Authenticates with the user's API
+// key in the `x-api-key` header (generated under Credentials in the Chibisafe
+// dashboard). A plain single multipart POST with field `file[]` is the same
+// shape Chibisafe's own generated ShareX config uses; the chunked-upload
+// protocol only matters past the server's chunk size and Lurker's uploads sit
+// far below it. The response is `{ name, uuid, url, … }` where `url` is public.
+
+import { USER_AGENT } from '../../utils/userAgent.js';
+import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
+
+export const driver = 'chibisafe';
+export const label = 'Chibisafe';
+export const capabilities: DriverCapabilities = {
+  storesRemotely: true,
+  supportsDelete: false,
+  mintsKeys: false,
+  acceptsContentClasses: ['image', 'text'],
+  selfHostOnly: true,
+};
+export const configSchema: ConfigField[] = [
+  {
+    key: 'url',
+    label: 'Chibisafe URL',
+    type: 'string',
+    required: true,
+    default: '',
+    description: 'Base URL of your Chibisafe instance (e.g. https://chibi.example.com).',
+  },
+  {
+    key: 'api_key',
+    label: 'Chibisafe API key',
+    type: 'secret',
+    required: true,
+    default: '',
+    description:
+      'API key for your Chibisafe instance — generate it under Credentials. Sent as x-api-key.',
+  },
+];
+
+export async function upload(
+  buffer: Buffer,
+  { filename, mime }: UploadMeta,
+  config: { url?: string; api_key?: string } = {},
+): Promise<UploadResult> {
+  if (!config.url) {
+    throw Object.assign(new Error('chibisafe uploader requires a url'), {
+      code: 'PROVIDER_CONFIG',
+    });
+  }
+  if (!config.api_key) {
+    throw Object.assign(new Error('chibisafe uploader requires an api_key'), {
+      code: 'PROVIDER_CONFIG',
+    });
+  }
+
+  const base = config.url.replace(/\/+$/, '');
+  const form = new FormData();
+  form.append('file[]', new Blob([new Uint8Array(buffer)], { type: mime }), filename);
+
+  const resp = await fetch(`${base}/api/upload`, {
+    method: 'POST',
+    headers: { 'x-api-key': config.api_key, 'User-Agent': USER_AGENT },
+    body: form,
+  });
+
+  if (!resp.ok) {
+    const text = (await resp.text()).slice(0, 200);
+    throw Object.assign(new Error(`chibisafe upload failed: ${resp.status} ${text}`), {
+      code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
+    });
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const body = (await resp.json().catch(() => null)) as any;
+  if (!body || typeof body.url !== 'string' || !body.url) {
+    throw Object.assign(new Error('chibisafe returned no url'), { code: 'PROVIDER_ERROR' });
+  }
+  return { url: body.url as string };
+}

--- a/server/services/uploadProviders/chibisafe.ts
+++ b/server/services/uploadProviders/chibisafe.ts
@@ -15,6 +15,7 @@ import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from '
 export const driver = 'chibisafe';
 export const label = 'Chibisafe';
 export const capabilities: DriverCapabilities = {
+  creatable: true,
   storesRemotely: true,
   supportsDelete: false,
   mintsKeys: false,

--- a/server/services/uploadProviders/index.ts
+++ b/server/services/uploadProviders/index.ts
@@ -10,6 +10,9 @@ import * as x0 from './x0.js';
 import * as catbox from './catbox.js';
 import * as hoarder from './hoarder.js';
 import * as local from './local.js';
+import * as zipline from './zipline.js';
+import * as chibisafe from './chibisafe.js';
+import * as s3 from './s3.js';
 import type { UploadDriver } from './types.js';
 
 export type {
@@ -26,6 +29,9 @@ const DRIVERS: Record<string, UploadDriver> = {
   [catbox.driver]: catbox,
   [hoarder.driver]: hoarder,
   [local.driver]: local,
+  [zipline.driver]: zipline,
+  [chibisafe.driver]: chibisafe,
+  [s3.driver]: s3,
 };
 
 export const driverIds = Object.keys(DRIVERS);

--- a/server/services/uploadProviders/resolve.test.ts
+++ b/server/services/uploadProviders/resolve.test.ts
@@ -68,31 +68,40 @@ describe('resolveUploader', () => {
     expect(() => resolve.resolveUploader({ userId })).toThrow(resolve.UploaderUnavailableError);
   });
 
-  describe('P0 bridge: legacy uploads.provider dropdown', () => {
-    it('honors the dropdown, overriding the migration-seeded uploader_id', () => {
-      const x0 = cfg.createUploaderConfig({
+  // The legacy `uploads.provider` dropdown (and the P0 bridge that read it) is
+  // gone: selection is `uploads.uploader_id`, an id, written by the picker in
+  // routes/uploaders.ts. The key is dead, so it must not steer anything.
+  it('ignores the removed uploads.provider key entirely', () => {
+    const x0 = cfg.createUploaderConfig({
+      scope: 'instance',
+      driver: 'x0',
+      offeredToUsers: true,
+      isDefault: true,
+    });
+    const catbox = cfg.createUploaderConfig({
+      scope: 'instance',
+      driver: 'catbox',
+      offeredToUsers: true,
+    });
+    setUserSetting(userId, 'uploads.uploader_id', catbox);
+    // A stale row left behind by an old archive import must not override the id.
+    setUserSetting(userId, 'uploads.provider', 'x0');
+    expect(resolve.resolveUploader({ userId }).configId).toBe(catbox);
+    expect(x0).not.toBe(catbox);
+  });
+
+  describe('listAllowedUploaders', () => {
+    it('is the set the picker offers: own rows + offered instance rows', () => {
+      const offered = cfg.createUploaderConfig({
         scope: 'instance',
         driver: 'x0',
         offeredToUsers: true,
         isDefault: true,
       });
-      const catbox = cfg.createUploaderConfig({
+      const adminOnly = cfg.createUploaderConfig({
         scope: 'instance',
         driver: 'catbox',
-        offeredToUsers: true,
-      });
-      // Migration pointed uploader_id at x0; the user then switched the dropdown.
-      setUserSetting(userId, 'uploads.uploader_id', x0);
-      setUserSetting(userId, 'uploads.provider', 'catbox');
-      expect(resolve.resolveUploader({ userId }).configId).toBe(catbox);
-    });
-
-    it('prefers the user’s own configured uploader for that driver (carries secrets)', () => {
-      cfg.createUploaderConfig({
-        scope: 'instance',
-        driver: 'catbox',
-        offeredToUsers: true,
-        isDefault: true,
+        offeredToUsers: false,
       });
       const mine = cfg.createUploaderConfig({
         scope: 'user',
@@ -100,22 +109,32 @@ describe('resolveUploader', () => {
         driver: 'catbox',
         values: { userhash: 'h' },
       });
-      setUserSetting(userId, 'uploads.provider', 'catbox');
-      const r = resolve.resolveUploader({ userId });
-      expect(r.configId).toBe(mine);
-      expect(r.driverConfig).toEqual({ userhash: 'h' });
+      const theirs = cfg.createUploaderConfig({
+        scope: 'user',
+        ownerUserId: createUser('resolve-bob').id,
+        driver: 'catbox',
+        values: { userhash: 'nope' },
+      });
+
+      const ids = resolve.listAllowedUploaders(userId).map((r) => r.id);
+      expect(ids).toContain(offered);
+      expect(ids).toContain(mine);
+      expect(ids).not.toContain(adminOnly);
+      expect(ids).not.toContain(theirs);
+
+      // An admin additionally sees instance rows that aren't offered to users.
+      expect(resolve.listAllowedUploaders(userId, true).map((r) => r.id)).toContain(adminOnly);
     });
 
-    it('falls through to the instance default when the enum maps to nothing usable', () => {
-      const x0 = cfg.createUploaderConfig({
-        scope: 'instance',
-        driver: 'x0',
-        offeredToUsers: true,
-        isDefault: true,
+    it('excludes disabled rows', () => {
+      const off = cfg.createUploaderConfig({
+        scope: 'user',
+        ownerUserId: userId,
+        driver: 'catbox',
+        values: { userhash: 'h' },
+        enabled: false,
       });
-      // No hoarder row exists for this user → unmappable → default, not an error.
-      setUserSetting(userId, 'uploads.provider', 'hoarder');
-      expect(resolve.resolveUploader({ userId }).configId).toBe(x0);
+      expect(resolve.listAllowedUploaders(userId).map((r) => r.id)).not.toContain(off);
     });
   });
 

--- a/server/services/uploadProviders/resolve.ts
+++ b/server/services/uploadProviders/resolve.ts
@@ -81,23 +81,14 @@ function isAllowed(row: UploaderConfigRow, userId: number, isAdmin: boolean): bo
   return row.offered_to_users === 1 || isAdmin;
 }
 
-// P0 bridge helper: resolve a legacy `uploads.provider` enum value to a concrete
-// uploader this user may use, preferring their own configured row (which carries
-// their secrets, e.g. a catbox userhash) over an offered instance row for the
-// same driver. Returns null when the enum maps to nothing usable (e.g. 'hoarder'
-// with no configured row) so the caller can fall through. Removed with the bridge
-// at P3.
-function findAllowedByDriver(
-  driver: string,
-  userId: number,
-  isAdmin: boolean,
-): UploaderConfigRow | null {
-  const userRow = listUserUploaders(userId).find((r) => r.driver === driver && r.enabled === 1);
-  if (userRow) return userRow;
-  const instRow = listInstanceUploaders().find(
-    (r) => r.driver === driver && r.enabled === 1 && (r.offered_to_users === 1 || isAdmin),
-  );
-  return instRow ?? null;
+/**
+ * Every uploader this user is allowed to send a file to — the allowed-set from
+ * the header, materialized. The uploader picker in settings lists exactly this,
+ * so the UI can never offer something `resolveUploader` would then reject.
+ */
+export function listAllowedUploaders(userId: number, isAdmin = false): UploaderConfigRow[] {
+  const rows = [...listUserUploaders(userId), ...listInstanceUploaders()];
+  return rows.filter((r) => isAllowed(r, userId, isAdmin));
 }
 
 function splitPolicy(merged: Record<string, string>): {
@@ -168,23 +159,16 @@ export function resolveUploader(input: ResolveInput): ResolvedUploader {
     if (!r || !isAllowed(r, userId, isAdmin)) throw new UploaderUnavailableError();
     chosen = r;
   } else {
-    const settings = getUserSettings(userId);
-    // P0 bridge: the legacy `uploads.provider` dropdown is still the only live
-    // selection UI (the picker that writes uploads.uploader_id is P3), so honor it
-    // — map the enum to this user's matching uploader so changing the dropdown
-    // still switches hosts. Takes precedence over the migration-seeded
-    // uploads.uploader_id, which the dropdown does not update. Remove when the P3
-    // selection UI lands and writes uploads.uploader_id directly.
-    const provider = settings['uploads.provider'];
-    if (typeof provider === 'string' && provider) {
-      chosen = findAllowedByDriver(provider, userId, isAdmin);
-    }
-    if (!chosen) {
-      const savedId = settings['uploads.uploader_id'];
-      if (typeof savedId === 'number') {
-        const r = getUploaderConfig(savedId);
-        if (r && isAllowed(r, userId, isAdmin)) chosen = r;
-      }
+    // The user's chosen uploader (settings key `uploads.uploader_id`, written by
+    // the picker in routes/uploaders.ts — deliberately not a settingsRegistry key,
+    // since it's an id into a table rather than a preference). A pointer at an
+    // uploader they may no longer use (deleted, un-offered, disabled) falls back
+    // to the instance default rather than erroring: they didn't ask for this
+    // upload to go anywhere specific, so there's nothing to make them re-pick.
+    const savedId = getUserSettings(userId)['uploads.uploader_id'];
+    if (typeof savedId === 'number') {
+      const r = getUploaderConfig(savedId);
+      if (r && isAllowed(r, userId, isAdmin)) chosen = r;
     }
     if (!chosen) chosen = getInstanceDefault();
   }

--- a/server/services/uploadProviders/s3.ts
+++ b/server/services/uploadProviders/s3.ts
@@ -1,0 +1,262 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// S3-compatible driver — uploads straight to an object-storage bucket
+// (Cloudflare R2, MinIO, Garage, AWS S3, …) and returns a link under the
+// bucket's public base URL. AWS Signature V4 is implemented here with node
+// crypto rather than pulling in @aws-sdk/client-s3: one signed PUT is ~70
+// lines, and the SDK is a heavyweight dependency for exactly that.
+//
+// Requests are always PATH-STYLE ({endpoint}/{bucket}/{key}). Virtual-host
+// style needs wildcard DNS that self-hosted MinIO setups rarely have, and every
+// S3-compatible store — including R2 and AWS — still accepts path-style, so it's
+// the lowest-friction default. The uploading endpoint and the PUBLIC base URL
+// are separate config fields because they usually differ (R2's storage endpoint
+// is never public; serving objects is the bucket/proxy's job, not Lurker's).
+//
+// SECURITY: the access key + secret are `secret` config fields (encrypted at
+// rest, never projected to the client). Give the instance a credential scoped to
+// the one upload bucket, not an account/root key. Object keys are 48 bits of
+// randomness over a safe alphabet with dot-only segments dropped, so a proxy
+// serving the bucket can't be walked with `..`; the secret is used only in the
+// HMAC ladder — never a URL, header, log, or error string.
+
+import { createHash, createHmac, randomBytes } from 'node:crypto';
+import { USER_AGENT } from '../../utils/userAgent.js';
+import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
+
+export const driver = 's3';
+export const label = 'S3 / R2';
+export const capabilities: DriverCapabilities = {
+  storesRemotely: true,
+  supportsDelete: false,
+  // WE construct the object key (unlike a remote host that names the file).
+  mintsKeys: true,
+  acceptsContentClasses: ['image', 'text', 'binary'],
+  selfHostOnly: true,
+};
+export const configSchema: ConfigField[] = [
+  {
+    key: 'endpoint',
+    label: 'S3 endpoint',
+    type: 'string',
+    required: true,
+    default: '',
+    description:
+      'Bucket API endpoint: https://<account-id>.r2.cloudflarestorage.com for R2, or your MinIO/Garage URL. Path-style, so no wildcard DNS needed.',
+  },
+  {
+    key: 'region',
+    label: 'S3 region',
+    type: 'string',
+    required: false,
+    default: '',
+    description: 'Signing region. Blank = "auto" (R2, MinIO); AWS needs the real bucket region.',
+  },
+  {
+    key: 'bucket',
+    label: 'S3 bucket',
+    type: 'string',
+    required: true,
+    default: '',
+    description: 'Bucket name uploads are written into.',
+  },
+  {
+    key: 'access_key_id',
+    label: 'S3 access key ID',
+    type: 'string',
+    required: true,
+    default: '',
+    description: 'Access key ID for a credential with write access to the bucket.',
+  },
+  {
+    key: 'secret_access_key',
+    label: 'S3 secret access key',
+    type: 'secret',
+    required: true,
+    default: '',
+    description: 'Secret access key paired with the access key ID.',
+  },
+  {
+    key: 'public_base_url',
+    label: 'S3 public base URL',
+    type: 'string',
+    required: true,
+    default: '',
+    description:
+      'Public URL prefix the object is reachable under — an R2 public bucket domain, a CDN, or a reverse-proxied MinIO bucket. The key is appended to this.',
+  },
+  {
+    key: 'key_prefix',
+    label: 'S3 key prefix',
+    type: 'string',
+    required: false,
+    default: '',
+    description:
+      'Optional folder prefix for objects (e.g. lurker). Unsafe characters are stripped.',
+  },
+];
+
+function sha256hex(data: Buffer | string): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+function hmac(key: Buffer | string, data: string): Buffer {
+  return createHmac('sha256', key).update(data).digest();
+}
+
+// Keys are built strictly from URL-unreserved characters ([A-Za-z0-9._-] plus
+// '/' separators), so neither the canonical request nor the public URL ever
+// needs percent-encoding — that sidesteps the classic SigV4 encoding-mismatch
+// bugs. User-supplied prefixes are sanitized to the same alphabet.
+function sanitizeSegment(s: string): string {
+  return s.replace(/[^A-Za-z0-9._-]/g, '').slice(0, 64);
+}
+
+export function buildObjectKey(
+  filename: string,
+  { kind, prefix }: { kind?: string; prefix?: string } = {},
+): string {
+  const dotIdx = filename.lastIndexOf('.');
+  const rawExt = dotIdx > 0 ? filename.slice(dotIdx + 1).toLowerCase() : '';
+  const ext = /^[a-z0-9]{1,8}$/.test(rawExt) ? rawExt : 'bin';
+  const idPart = randomBytes(6).toString('base64url');
+  const segments: string[] = [];
+  // Dot-only segments ('.', '..') are dropped: a proxy serving the bucket may
+  // normalize '..' — a traversal risk no object key needs to carry.
+  const pushClean = (part: string) => {
+    const clean = sanitizeSegment(part);
+    if (clean && !/^\.+$/.test(clean)) segments.push(clean);
+  };
+  if (prefix) for (const part of prefix.split('/')) pushClean(part);
+  if (kind) pushClean(kind);
+  segments.push(`${idPart}.${ext}`);
+  return segments.join('/');
+}
+
+export interface SignedPut {
+  url: string;
+  headers: Record<string, string>;
+}
+
+/** Build a SigV4-signed PUT for one object. Pure given `now`, so tests can pin
+ *  the clock and assert determinism. */
+export function signPutObject(
+  {
+    endpoint,
+    bucket,
+    key,
+    payload,
+    contentType,
+    region,
+    accessKeyId,
+    secretAccessKey,
+  }: {
+    endpoint: string;
+    bucket: string;
+    key: string;
+    payload: Buffer;
+    contentType: string;
+    region: string;
+    accessKeyId: string;
+    secretAccessKey: string;
+  },
+  now: Date = new Date(),
+): SignedPut {
+  const base = endpoint.replace(/\/+$/, '');
+  const url = new URL(`${base}/${bucket}/${key}`);
+  const host = url.host;
+  const path = url.pathname;
+
+  const amzDate = now
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace(/\.\d{3}Z$/, 'Z');
+  const dateStamp = amzDate.slice(0, 8);
+  const scope = `${dateStamp}/${region}/s3/aws4_request`;
+  const payloadHash = sha256hex(payload);
+
+  // Signed headers, sorted by lowercase name. Everything we send that the server
+  // may validate is signed — including cache-control, so a store can't reject it
+  // as an unsigned x-amz-adjacent header surprise.
+  const headers: Record<string, string> = {
+    'cache-control': 'public, max-age=31536000, immutable',
+    'content-type': contentType,
+    host,
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': amzDate,
+  };
+  const signedHeaderNames = Object.keys(headers).sort();
+  const canonicalHeaders = signedHeaderNames.map((h) => `${h}:${headers[h].trim()}\n`).join('');
+  const signedHeaders = signedHeaderNames.join(';');
+
+  const canonicalRequest = ['PUT', path, '', canonicalHeaders, signedHeaders, payloadHash].join(
+    '\n',
+  );
+
+  const stringToSign = ['AWS4-HMAC-SHA256', amzDate, scope, sha256hex(canonicalRequest)].join('\n');
+
+  const kDate = hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, 's3');
+  const kSigning = hmac(kService, 'aws4_request');
+  const signature = createHmac('sha256', kSigning).update(stringToSign).digest('hex');
+
+  const authorization =
+    `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${scope}, ` +
+    `SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+  return {
+    url: url.toString(),
+    headers: { ...headers, authorization, 'User-Agent': USER_AGENT },
+  };
+}
+
+function requireField(config: Record<string, string>, field: string): string {
+  const value = (config[field] || '').trim();
+  if (!value) {
+    throw Object.assign(new Error(`s3 uploader requires ${field}`), { code: 'PROVIDER_CONFIG' });
+  }
+  return value;
+}
+
+export async function upload(
+  buffer: Buffer,
+  { filename, mime, kind }: UploadMeta,
+  config: Record<string, string> = {},
+): Promise<UploadResult> {
+  const endpoint = requireField(config, 'endpoint');
+  const bucket = requireField(config, 'bucket');
+  const accessKeyId = requireField(config, 'access_key_id');
+  const secretAccessKey = requireField(config, 'secret_access_key');
+  const publicBase = requireField(config, 'public_base_url');
+  // R2 wants literally "auto"; MinIO accepts any region. Default keeps it optional.
+  const region = (config.region || '').trim() || 'auto';
+
+  const key = buildObjectKey(filename, { kind, prefix: config.key_prefix });
+  const signed = signPutObject({
+    endpoint,
+    bucket,
+    key,
+    payload: buffer,
+    contentType: mime,
+    region,
+    accessKeyId,
+    secretAccessKey,
+  });
+
+  const resp = await fetch(signed.url, {
+    method: 'PUT',
+    headers: signed.headers,
+    body: new Uint8Array(buffer),
+  });
+
+  if (!resp.ok) {
+    const text = (await resp.text()).slice(0, 200);
+    throw Object.assign(new Error(`s3 upload failed: ${resp.status} ${text}`), {
+      code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
+    });
+  }
+  // key is the delete handle if delete is ever added; harmless to surface now.
+  return { url: `${publicBase.replace(/\/+$/, '')}/${key}`, ref: key };
+}

--- a/server/services/uploadProviders/s3.ts
+++ b/server/services/uploadProviders/s3.ts
@@ -28,6 +28,7 @@ import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from '
 export const driver = 's3';
 export const label = 'S3 / R2';
 export const capabilities: DriverCapabilities = {
+  creatable: true,
   storesRemotely: true,
   supportsDelete: false,
   // WE construct the object key (unlike a remote host that names the file).

--- a/server/services/uploadProviders/types.ts
+++ b/server/services/uploadProviders/types.ts
@@ -37,6 +37,14 @@ export interface DriverCapabilities {
   acceptsContentClasses: ContentClass[];
   // local, s3 — never offered on the hosted fleet.
   selfHostOnly?: boolean;
+  // May a human stand up a new instance of this driver in the management UI
+  // (#514)? Not derivable, so it's declared: `x0` and `local` are zero-config
+  // singletons whose seeded instance row IS the driver (a second row would be
+  // byte-identical), and `hoarder` is the operator/seed-managed hosted dropper
+  // that decision 12 retired from the self-host menu. Existing rows of a
+  // non-creatable driver keep working — this gates the "add an uploader" list
+  // only. Defaults to false so a new driver has to opt in deliberately.
+  creatable?: boolean;
 }
 
 export interface UploadMeta {

--- a/server/services/uploadProviders/uploadProviders.test.ts
+++ b/server/services/uploadProviders/uploadProviders.test.ts
@@ -5,6 +5,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as x0 from './x0.js';
 import * as catbox from './catbox.js';
 import * as hoarder from './hoarder.js';
+import * as zipline from './zipline.js';
+import * as chibisafe from './chibisafe.js';
+import * as s3 from './s3.js';
 import * as multipart from './multipart.js';
 import type { PostBufferResult } from './multipart.js';
 
@@ -232,6 +235,236 @@ describe('hoarder provider', () => {
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', api_key: 'k' },
       ),
+    ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
+  });
+});
+
+describe('zipline provider', () => {
+  it('POSTs to {base}/api/upload with raw authorization header and `file` field', async () => {
+    const cap = captureFormData();
+    captureResponse = new Response(
+      JSON.stringify({
+        files: [{ id: 'a1', name: 'x.png', type: 'image/png', url: 'https://zl.test/u/x.png' }],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+    const result = await zipline.upload(
+      Buffer.from([0x89, 0x50]),
+      { filename: 'x.png', mime: 'image/png' },
+      { url: 'https://zl.test', token: 'ziptok' },
+    );
+    expect(cap.url).toBe('https://zl.test/api/upload');
+    const headers = (cap.init as RequestInit & { headers: Record<string, string> }).headers;
+    // Raw token, NOT "Bearer …" — Zipline's middleware decrypts the header verbatim.
+    expect(headers.authorization).toBe('ziptok');
+    expect(headers['User-Agent']).toMatch(/^Lurker\//);
+    expect(cap.formData!.get('file')).toBeInstanceOf(Blob);
+    expect(result.url).toBe('https://zl.test/u/x.png');
+  });
+
+  it('accepts the v3 response shape (files as URL strings)', async () => {
+    captureFormData();
+    captureResponse = new Response(JSON.stringify({ files: ['https://zl.test/u/y.png'] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const result = await zipline.upload(
+      Buffer.from([1]),
+      { filename: 'y.png', mime: 'image/png' },
+      { url: 'https://zl.test/', token: 't' },
+    );
+    expect(result.url).toBe('https://zl.test/u/y.png');
+  });
+
+  it('rejects with PROVIDER_CONFIG when url or token is missing', async () => {
+    await expect(
+      zipline.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, { token: 't' }),
+    ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
+    await expect(
+      zipline.upload(
+        Buffer.from([1]),
+        { filename: 'x.png', mime: 'image/png' },
+        { url: 'https://u' },
+      ),
+    ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
+  });
+
+  it('maps 401 to PROVIDER_AUTH and missing url in body to PROVIDER_ERROR', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(
+      async () => new Response('unauthorized', { status: 401 }),
+    );
+    await expect(
+      zipline.upload(
+        Buffer.from([1]),
+        { filename: 'x.png', mime: 'image/png' },
+        { url: 'https://u', token: 'bad' },
+      ),
+    ).rejects.toMatchObject({ code: 'PROVIDER_AUTH' });
+
+    globalThis.fetch = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ files: [] }), { status: 200 }),
+    );
+    await expect(
+      zipline.upload(
+        Buffer.from([1]),
+        { filename: 'x.png', mime: 'image/png' },
+        { url: 'https://u', token: 't' },
+      ),
+    ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
+  });
+});
+
+describe('chibisafe provider', () => {
+  it('POSTs to {base}/api/upload with x-api-key and `file[]` field', async () => {
+    const cap = captureFormData();
+    captureResponse = new Response(
+      JSON.stringify({ name: 'x.png', uuid: 'u-u-i-d', url: 'https://cb.test/x1y2z.png' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+    const result = await chibisafe.upload(
+      Buffer.from([0x47, 0x49]),
+      { filename: 'x.png', mime: 'image/png' },
+      { url: 'https://cb.test/', api_key: 'chibikey' },
+    );
+    expect(cap.url).toBe('https://cb.test/api/upload');
+    const headers = (cap.init as RequestInit & { headers: Record<string, string> }).headers;
+    expect(headers['x-api-key']).toBe('chibikey');
+    expect(headers['User-Agent']).toMatch(/^Lurker\//);
+    // Chibisafe's uploader expects the lolisafe-lineage field name `file[]`.
+    expect(cap.formData!.get('file[]')).toBeInstanceOf(Blob);
+    expect(result.url).toBe('https://cb.test/x1y2z.png');
+  });
+
+  it('rejects with PROVIDER_CONFIG when url or api_key is missing', async () => {
+    await expect(
+      chibisafe.upload(
+        Buffer.from([1]),
+        { filename: 'x.png', mime: 'image/png' },
+        { api_key: 'k' },
+      ),
+    ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
+    await expect(
+      chibisafe.upload(
+        Buffer.from([1]),
+        { filename: 'x.png', mime: 'image/png' },
+        { url: 'https://u' },
+      ),
+    ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
+  });
+
+  it('maps 401 to PROVIDER_AUTH and missing url in body to PROVIDER_ERROR', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('no key', { status: 401 }));
+    await expect(
+      chibisafe.upload(
+        Buffer.from([1]),
+        { filename: 'x.png', mime: 'image/png' },
+        { url: 'https://u', api_key: 'bad' },
+      ),
+    ).rejects.toMatchObject({ code: 'PROVIDER_AUTH' });
+
+    globalThis.fetch = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ name: 'x' }), { status: 200 }),
+    );
+    await expect(
+      chibisafe.upload(
+        Buffer.from([1]),
+        { filename: 'x.png', mime: 'image/png' },
+        { url: 'https://u', api_key: 'k' },
+      ),
+    ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
+  });
+});
+
+describe('s3 provider', () => {
+  const SECRETS = {
+    endpoint: 'http://minio.test:9000',
+    bucket: 'lurker',
+    access_key_id: 'AKIDEXAMPLE',
+    secret_access_key: 'sekrit',
+    public_base_url: 'https://cdn.test',
+  };
+
+  it('buildObjectKey sanitizes prefix/kind and keeps a safe extension', () => {
+    const key = s3.buildObjectKey('photo.PNG', { prefix: 'lurker/../etc', kind: 'thumb' });
+    // '..' segments are dropped entirely — a proxy serving the bucket could
+    // normalize them.
+    expect(key).toMatch(/^lurker\/etc\/thumb\/[A-Za-z0-9_-]{8}\.png$/);
+    expect(s3.buildObjectKey('noext', {})).toMatch(/^[A-Za-z0-9_-]{8}\.bin$/);
+    expect(s3.buildObjectKey('evil.<scr>', {})).toMatch(/\.bin$/);
+  });
+
+  it('signPutObject is deterministic for a pinned clock and shaped like SigV4', () => {
+    const now = new Date('2026-01-02T03:04:05.000Z');
+    const args = {
+      endpoint: SECRETS.endpoint,
+      bucket: SECRETS.bucket,
+      key: 'abc123.png',
+      payload: Buffer.from([1, 2, 3]),
+      contentType: 'image/png',
+      region: 'auto',
+      accessKeyId: SECRETS.access_key_id,
+      secretAccessKey: SECRETS.secret_access_key,
+    };
+    const a = s3.signPutObject(args, now);
+    const b = s3.signPutObject(args, now);
+    expect(a).toEqual(b);
+    expect(a.url).toBe('http://minio.test:9000/lurker/abc123.png');
+    expect(a.headers['x-amz-date']).toBe('20260102T030405Z');
+    expect(a.headers.authorization).toMatch(
+      /^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\/20260102\/auto\/s3\/aws4_request, SignedHeaders=cache-control;content-type;host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$/,
+    );
+    // A different secret must change the signature.
+    const c = s3.signPutObject({ ...args, secretAccessKey: 'other' }, now);
+    expect(c.headers.authorization).not.toBe(a.headers.authorization);
+  });
+
+  it('PUTs path-style to the endpoint and returns the public URL for the same key', async () => {
+    let putUrl = '';
+    let putHeaders: Record<string, string> = {};
+    globalThis.fetch = vi.fn<typeof fetch>(async (url, init) => {
+      putUrl = String(url);
+      putHeaders = (init?.headers as Record<string, string>) ?? {};
+      return new Response('', { status: 200 });
+    });
+    const result = await s3.upload(
+      Buffer.from([0x89, 0x50]),
+      { filename: 'x.png', mime: 'image/png' },
+      SECRETS,
+    );
+    expect(putUrl).toMatch(/^http:\/\/minio\.test:9000\/lurker\/[A-Za-z0-9_-]{8}\.png$/);
+    const key = putUrl.slice('http://minio.test:9000/lurker/'.length);
+    expect(result.url).toBe(`https://cdn.test/${key}`);
+    expect(putHeaders['x-amz-content-sha256']).toMatch(/^[0-9a-f]{64}$/);
+    expect(putHeaders['content-type']).toBe('image/png');
+    expect(putHeaders.authorization).toContain('AWS4-HMAC-SHA256');
+  });
+
+  it('rejects with PROVIDER_CONFIG when any required setting is missing', async () => {
+    for (const missing of [
+      'endpoint',
+      'bucket',
+      'access_key_id',
+      'secret_access_key',
+      'public_base_url',
+    ] as const) {
+      const partial = { ...SECRETS, [missing]: '' };
+      await expect(
+        s3.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, partial),
+      ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
+    }
+  });
+
+  it('maps 403 to PROVIDER_AUTH and other failures to PROVIDER_ERROR', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(
+      async () => new Response('SignatureDoesNotMatch', { status: 403 }),
+    );
+    await expect(
+      s3.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, SECRETS),
+    ).rejects.toMatchObject({ code: 'PROVIDER_AUTH' });
+
+    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('oops', { status: 500 }));
+    await expect(
+      s3.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, SECRETS),
     ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
   });
 });

--- a/server/services/uploadProviders/zipline.ts
+++ b/server/services/uploadProviders/zipline.ts
@@ -15,6 +15,7 @@ import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from '
 export const driver = 'zipline';
 export const label = 'Zipline';
 export const capabilities: DriverCapabilities = {
+  creatable: true,
   storesRemotely: true,
   supportsDelete: false,
   mintsKeys: false,

--- a/server/services/uploadProviders/zipline.ts
+++ b/server/services/uploadProviders/zipline.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Zipline driver — self-hosted ShareX-style file host
+// (https://github.com/diced/zipline). Authenticates with the user's Zipline
+// token sent RAW in the `authorization` header (no "Bearer" prefix — Zipline's
+// userMiddleware passes the header value straight to its token decryptor).
+// The v4 upload route responds `{ files: [{ id, name, type, url, … }] }`;
+// v3 instances respond `{ files: ["https://…"] }` — both shapes are accepted
+// since the difference is one line and v3 servers are still common.
+
+import { USER_AGENT } from '../../utils/userAgent.js';
+import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
+
+export const driver = 'zipline';
+export const label = 'Zipline';
+export const capabilities: DriverCapabilities = {
+  storesRemotely: true,
+  supportsDelete: false,
+  mintsKeys: false,
+  acceptsContentClasses: ['image', 'text'],
+  selfHostOnly: true,
+};
+export const configSchema: ConfigField[] = [
+  {
+    key: 'url',
+    label: 'Zipline URL',
+    type: 'string',
+    required: true,
+    default: '',
+    description: 'Base URL of your Zipline instance (e.g. https://zipline.example.com).',
+  },
+  {
+    key: 'token',
+    label: 'Zipline token',
+    type: 'secret',
+    required: true,
+    default: '',
+    description:
+      'Your Zipline user token — copy it from the Zipline dashboard. Sent as the authorization header.',
+  },
+];
+
+export async function upload(
+  buffer: Buffer,
+  { filename, mime }: UploadMeta,
+  config: { url?: string; token?: string } = {},
+): Promise<UploadResult> {
+  if (!config.url) {
+    throw Object.assign(new Error('zipline uploader requires a url'), { code: 'PROVIDER_CONFIG' });
+  }
+  if (!config.token) {
+    throw Object.assign(new Error('zipline uploader requires a token'), {
+      code: 'PROVIDER_CONFIG',
+    });
+  }
+
+  const base = config.url.replace(/\/+$/, '');
+  const form = new FormData();
+  form.append('file', new Blob([new Uint8Array(buffer)], { type: mime }), filename);
+
+  const resp = await fetch(`${base}/api/upload`, {
+    method: 'POST',
+    headers: { authorization: config.token, 'User-Agent': USER_AGENT },
+    body: form,
+  });
+
+  if (!resp.ok) {
+    const text = (await resp.text()).slice(0, 200);
+    throw Object.assign(new Error(`zipline upload failed: ${resp.status} ${text}`), {
+      code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
+    });
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const body = (await resp.json().catch(() => null)) as any;
+  const first = body?.files?.[0];
+  // v4: files is an array of objects with `url`; v3: an array of URL strings.
+  const url = typeof first === 'string' ? first : first?.url;
+  if (typeof url !== 'string' || !url) {
+    throw Object.assign(new Error('zipline returned no url'), { code: 'PROVIDER_ERROR' });
+  }
+  return { url };
+}

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -998,25 +998,14 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
 
   // ─── Image uploads ────────────────────────────────────────────────────
-  {
-    key: 'uploads.provider',
-    label: 'Upload provider',
-    category: 'uploads',
-    group: 'provider',
-    type: 'enum',
-    choices: ['x0', 'catbox', 'hoarder', 'local'],
-    default: 'x0',
-    // Node edition forces the operator's in-house uploader (A8); a tenant never
-    // picks a host, so this and the provider-credential settings below are
-    // hidden in the hosted edition.
-    selfHostedOnly: true,
-    description:
-      'Where pasted/picked images are uploaded. x0.at and catbox.moe are ' +
-      'anonymous public hosts. hoarder uploads to your own self-hosted ' +
-      'Hoarder instance using the URL + API key configured below. local stores ' +
-      'files on this server’s own disk and serves them back (set ' +
-      'PUBLIC_BASE_URL so the links resolve from other clients).',
-  },
+  //
+  // WHERE a file goes is no longer a setting. The destination is a configured
+  // uploader (a `uploader_config` row: driver + its own credentials), managed in
+  // the bespoke half of the Uploads pane and selected via /api/uploaders. The old
+  // `uploads.provider` enum + the flat `uploads.catbox.*`/`uploads.hoarder.*`
+  // credential keys were removed in #514 and folded into rows by
+  // db/uploaderConfigSeed.ts#reconcileLegacyUploadSettings. What remains here is
+  // the part that genuinely is a per-user preference: the processing pipeline.
   {
     key: 'uploads.image.max_dimension',
     label: 'Max image dimension (longest edge)',
@@ -1069,43 +1058,6 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     description:
       'When enabled, pasting an image into the input area uploads it and ' +
       'inserts the resulting URL. Disable to fall back to plain text paste.',
-  },
-  {
-    key: 'uploads.catbox.userhash',
-    label: 'Catbox userhash',
-    category: 'uploads',
-    group: 'catbox',
-    type: 'secret',
-    default: '',
-    selfHostedOnly: true,
-    description:
-      'Optional catbox.moe account hash. Uploads made with a userhash can ' +
-      'be managed from your catbox account; without one they are anonymous.',
-  },
-  {
-    key: 'uploads.hoarder.url',
-    label: 'Hoarder URL',
-    category: 'uploads',
-    group: 'hoarder',
-    type: 'string',
-    default: '',
-    selfHostedOnly: true,
-    description:
-      'Base URL of your Hoarder instance (e.g. https://upload.example.com). ' +
-      'Only used when the upload provider is set to hoarder.',
-  },
-  {
-    key: 'uploads.hoarder.api_key',
-    label: 'Hoarder API key',
-    category: 'uploads',
-    group: 'hoarder',
-    type: 'secret',
-    default: '',
-    selfHostedOnly: true,
-    description:
-      'API key for your Hoarder instance. Generate one on the Hoarder server ' +
-      'with `node scripts/gen-api-key.js` and add it to ' +
-      'web.auth.api_keys in its config.json.',
   },
 
   // ─── Notifications (unified intent, per signal type) ──────────────────
@@ -1478,7 +1430,10 @@ export const CATEGORIES: readonly SettingCategory[] = Object.freeze([
   { id: 'appearance', label: 'Appearance', kind: 'registry' },
   { id: 'chat', label: 'Chat', kind: 'registry' },
   { id: 'input', label: 'Input bar', kind: 'registry' },
-  { id: 'uploads', label: 'Uploads', kind: 'registry' },
+  // Bespoke: the pane leads with the configured-uploader list + picker (which is
+  // table-backed, not registry-backed) and renders the surviving registry rows
+  // for the image pipeline underneath it.
+  { id: 'uploads', label: 'Uploads', kind: 'bespoke' },
   { id: 'notifications', label: 'Notifications', kind: 'bespoke' },
   { id: 'highlights', label: 'Highlights', kind: 'bespoke' },
   { id: 'ignores', label: 'Ignores', kind: 'bespoke' },
@@ -1511,11 +1466,8 @@ export const GROUPS: Readonly<Record<string, string>> = Object.freeze({
   connection: 'Connection',
   ctcp: 'CTCP replies',
   'auto-away': 'Auto-away',
-  provider: 'Provider',
   pipeline: 'Image pipeline',
   viewing: 'Viewing',
-  catbox: 'catbox.moe',
-  hoarder: 'Hoarder',
   alerts: 'Alerts',
   push_filters: 'Push filters',
   system_features: 'System text features',

--- a/vue_client/src/components/UploaderConfigForm.vue
+++ b/vue_client/src/components/UploaderConfigForm.vue
@@ -1,0 +1,150 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  The uploader config form (#514). Renders itself from a driver's `configSchema`,
+  which is why there is no per-driver markup anywhere in the client: an S3 form
+  (7 fields, required + optional, string + secret) and a Zipline form (2) are the
+  same component with different input.
+
+  Shared by the user pane (settings) and the admin pane (instance uploaders) —
+  the two differ in policy, not in how a driver is configured.
+
+  Secrets: an existing secret is shown as a "stored" placeholder, never a value.
+  Leaving it blank on save keeps what's stored; typing replaces it.
+-->
+
+<template>
+  <form class="uploader-form" @submit.prevent="onSubmit">
+    <label>
+      <span>Name</span>
+      <input
+        v-model="label"
+        type="text"
+        maxlength="64"
+        :placeholder="driver.label"
+        :disabled="busy"
+      />
+    </label>
+
+    <label v-for="field in driver.configSchema" :key="field.key">
+      <span>
+        {{ field.label }}
+        <em v-if="!field.required" class="optional">optional</em>
+      </span>
+      <input
+        v-model="values[field.key]"
+        :type="field.type === 'secret' ? 'password' : 'text'"
+        :placeholder="placeholderFor(field)"
+        :autocomplete="field.type === 'secret' ? 'new-password' : 'off'"
+        :disabled="busy"
+      />
+      <span class="field-desc">{{ field.description }}</span>
+    </label>
+
+    <p v-if="error" class="error inline">{{ error }}</p>
+
+    <div class="form-actions">
+      <button class="link" type="submit" :disabled="busy || incomplete">
+        {{ existing ? 'save' : 'add uploader' }}
+      </button>
+      <button class="link" type="button" :disabled="busy" @click="emit('cancel')">cancel</button>
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import {
+  type UploaderDriver,
+  type UploaderConfigField,
+  emptyValues,
+  valuesFrom,
+  missingRequired,
+} from '../utils/uploaders.js';
+
+const props = defineProps<{
+  driver: UploaderDriver;
+  /** Editing an existing uploader: its non-secret config + which secrets are set. */
+  existing?: { label: string; config: Record<string, string>; secretsSet: Record<string, boolean> };
+  busy?: boolean;
+  error?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'save', payload: { label: string; values: Record<string, string> }): void;
+  (e: 'cancel'): void;
+}>();
+
+const label = ref('');
+const values = ref<Record<string, string>>({});
+
+// Re-seed whenever the driver changes (the add-form's driver picker) or a
+// different uploader is opened for editing.
+watch(
+  () => [props.driver, props.existing] as const,
+  () => {
+    label.value = props.existing?.label ?? '';
+    values.value = props.existing
+      ? valuesFrom(props.driver, props.existing.config)
+      : emptyValues(props.driver);
+  },
+  { immediate: true },
+);
+
+const incomplete = computed(() =>
+  missingRequired(props.driver, values.value, props.existing?.secretsSet ?? {}),
+);
+
+function placeholderFor(field: UploaderConfigField): string {
+  if (field.type !== 'secret') return '';
+  // Distinguishes "there's a key here, I just can't show it to you" from "empty".
+  return props.existing?.secretsSet[field.key] ? '•••••••• (stored — leave blank to keep)' : '';
+}
+
+function onSubmit() {
+  // Blank fields are dropped rather than sent as '': for a secret that's what
+  // means "keep the stored one", and for an optional string it's the difference
+  // between "unset" and "explicitly empty".
+  const payload: Record<string, string> = {};
+  for (const field of props.driver.configSchema) {
+    const v = String(values.value[field.key] ?? '').trim();
+    if (v) payload[field.key] = v;
+  }
+  emit('save', { label: label.value.trim() || props.driver.label, values: payload });
+}
+</script>
+
+<style scoped>
+.uploader-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.uploader-form label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* Hierarchy by color/weight only — no font-size anywhere (one-font-size rule). */
+.uploader-form label > span:first-child {
+  color: var(--fg);
+}
+
+.optional {
+  color: var(--fg-muted);
+  font-style: normal;
+}
+
+.field-desc {
+  color: var(--fg-muted);
+}
+
+.form-actions {
+  display: flex;
+  gap: var(--space-3);
+}
+</style>

--- a/vue_client/src/components/UploaderConfigForm.vue
+++ b/vue_client/src/components/UploaderConfigForm.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue';
+import { ref, computed } from 'vue';
 import {
   type UploaderDriver,
   type UploaderConfigField,
@@ -76,20 +76,18 @@ const emit = defineEmits<{
   (e: 'cancel'): void;
 }>();
 
-const label = ref('');
-const values = ref<Record<string, string>>({});
-
-// Re-seed whenever the driver changes (the add-form's driver picker) or a
-// different uploader is opened for editing.
-watch(
-  () => [props.driver, props.existing] as const,
-  () => {
-    label.value = props.existing?.label ?? '';
-    values.value = props.existing
-      ? valuesFrom(props.driver, props.existing.config)
-      : emptyValues(props.driver);
-  },
-  { immediate: true },
+// Seeded ONCE, at setup. Callers must `:key` this component on the thing it's
+// editing (the driver id when adding, the uploader id when editing) so switching
+// target remounts it with fresh state.
+//
+// Deliberately NOT a watcher on `props.existing`: parents pass that as an inline
+// object literal, so its identity changes on EVERY parent re-render — and a
+// re-render is exactly what happens when a save fails and the parent sets an
+// error. A watcher would re-seed the form at that moment and silently wipe what
+// the user typed, right as we tell them to fix it.
+const label = ref(props.existing?.label ?? '');
+const values = ref<Record<string, string>>(
+  props.existing ? valuesFrom(props.driver, props.existing.config) : emptyValues(props.driver),
 );
 
 const incomplete = computed(() =>

--- a/vue_client/src/components/admin-panes/UploadersPane.vue
+++ b/vue_client/src/components/admin-panes/UploadersPane.vue
@@ -49,7 +49,7 @@
     <h3 class="subhead">instance uploaders</h3>
     <p v-if="!store.uploadersLoaded" class="muted small">Loading…</p>
     <ul v-else class="device-list">
-      <li v-for="u in store.uploaders" :key="u.id" class="device">
+      <li v-for="u in store.uploaders" :key="u.id" class="device stacked">
         <span class="ua">
           <span class="name">{{ u.label }}</span>
           <span class="driver">{{ u.driver }}</span>
@@ -58,7 +58,9 @@
           <span v-else-if="!u.offeredToUsers" class="badge off">admin only</span>
           <span v-if="u.locked" class="badge off">managed</span>
         </span>
-        <template v-if="!store.uploadersManaged && !u.locked">
+        <!-- Five actions is more than the default .device grid holds — hence the
+             `stacked` row + the shared .row-actions cluster underneath. -->
+        <div v-if="!store.uploadersManaged && !u.locked" class="row-actions">
           <button
             v-if="!u.isDefault"
             class="link"
@@ -80,7 +82,7 @@
           <button v-if="isDeletable(u)" class="link danger" :disabled="busy" @click="onDelete(u)">
             delete
           </button>
-        </template>
+        </div>
       </li>
     </ul>
 

--- a/vue_client/src/components/admin-panes/UploadersPane.vue
+++ b/vue_client/src/components/admin-panes/UploadersPane.vue
@@ -88,6 +88,7 @@
       <template v-if="editing">
         <h3 class="subhead">edit {{ editing.label }}</h3>
         <UploaderConfigForm
+          :key="`edit-${editing.id}`"
           :driver="driverFor(editing.driver)!"
           :existing="{
             label: editing.label,
@@ -113,6 +114,7 @@
             </select>
           </label>
           <UploaderConfigForm
+            :key="`add-${adding}`"
             :driver="driverFor(adding)!"
             :busy="busy"
             :error="formError"

--- a/vue_client/src/components/admin-panes/UploadersPane.vue
+++ b/vue_client/src/components/admin-panes/UploadersPane.vue
@@ -85,11 +85,11 @@
     </ul>
 
     <template v-if="!store.uploadersManaged">
-      <template v-if="editing">
+      <template v-if="editing && editingDriver">
         <h3 class="subhead">edit {{ editing.label }}</h3>
         <UploaderConfigForm
           :key="`edit-${editing.id}`"
-          :driver="driverFor(editing.driver)!"
+          :driver="editingDriver"
           :existing="{
             label: editing.label,
             config: editing.config,
@@ -102,20 +102,20 @@
         />
       </template>
 
-      <template v-else-if="store.uploaderDrivers.length">
+      <template v-else-if="addableDrivers.length">
         <h3 class="subhead">add an uploader</h3>
-        <template v-if="adding">
+        <template v-if="addingDriver">
           <label class="driver-pick">
             <span>Type</span>
             <select v-model="adding" :disabled="busy">
-              <option v-for="d in store.uploaderDrivers" :key="d.driver" :value="d.driver">
+              <option v-for="d in addableDrivers" :key="d.driver" :value="d.driver">
                 {{ d.label }}
               </option>
             </select>
           </label>
           <UploaderConfigForm
-            :key="`add-${adding}`"
-            :driver="driverFor(adding)!"
+            :key="`add-${addingDriver.driver}`"
+            :driver="addingDriver"
             :busy="busy"
             :error="formError"
             @save="onSaveNew"
@@ -123,7 +123,7 @@
           />
         </template>
         <p v-else class="add-row">
-          <button class="link" :disabled="busy" @click="adding = store.uploaderDrivers[0].driver">
+          <button class="link" :disabled="busy" @click="adding = addableDrivers[0].driver">
             add an uploader
           </button>
         </p>
@@ -133,7 +133,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useAdminStore } from '../../stores/admin.js';
 import UploaderConfigForm from '../UploaderConfigForm.vue';
 import type { AdminUploader, UploaderDriver } from '../../utils/uploaders.js';
@@ -149,6 +149,13 @@ const editing = ref<AdminUploader | null>(null);
 function driverFor(id: string): UploaderDriver | undefined {
   return store.uploaderDrivers.find((d) => d.driver === id);
 }
+
+// `uploaderDrivers` carries EVERY driver (a schema is needed to describe rows
+// that already exist, not just ones you may add); the add menu is the creatable
+// subset.
+const addableDrivers = computed(() => store.uploaderDrivers.filter((d) => d.creatable));
+const addingDriver = computed(() => (adding.value ? driverFor(adding.value) : undefined));
+const editingDriver = computed(() => (editing.value ? driverFor(editing.value.driver) : undefined));
 
 /** Zero-config drivers (x0, local disk) have nothing to edit. */
 function hasFields(u: AdminUploader): boolean {

--- a/vue_client/src/components/admin-panes/UploadersPane.vue
+++ b/vue_client/src/components/admin-panes/UploadersPane.vue
@@ -1,0 +1,285 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  Admin → Uploaders (#514, absorbing #299). The instance's own upload
+  destinations, plus the two levers that decide what users get:
+
+    • which uploader is the DEFAULT — what a brand-new account uploads through
+      without ever opening settings, and what anyone who hasn't chosen falls back
+      to. This is #299's whole point: uploads work from first use.
+    • whether an uploader is OFFERED to users at all, or admin-only.
+    • the lockdown switch: may users define their own uploaders?
+
+  Built-ins (x0, catbox, local disk) can be disabled but not deleted — they're
+  re-created on the next boot regardless, and deleting the local-disk one would
+  strand the files already on disk.
+-->
+
+<template>
+  <section id="uploaders" class="settings-pane">
+    <h2>Uploaders</h2>
+    <p class="section-desc">
+      Where files uploaded on this server are sent. The default is what new accounts use, and what
+      anyone who hasn’t picked their own uploader falls back to.
+    </p>
+    <p v-if="error" class="error inline">{{ error }}</p>
+
+    <p v-if="store.uploadersManaged" class="muted small">
+      This server’s uploader is managed by the control plane and configured from the operator
+      environment — it can’t be changed here.
+    </p>
+
+    <template v-else>
+      <label class="policy check">
+        <input
+          type="checkbox"
+          :checked="store.allowUserDefined"
+          :disabled="busy"
+          @change="onTogglePolicy"
+        />
+        <span>
+          Let users set up their own uploaders (their own catbox account, Zipline, S3 bucket…).
+          Turning this off hides the “add an uploader” button; uploaders people already created keep
+          working.
+        </span>
+      </label>
+    </template>
+
+    <h3 class="subhead">instance uploaders</h3>
+    <p v-if="!store.uploadersLoaded" class="muted small">Loading…</p>
+    <ul v-else class="device-list">
+      <li v-for="u in store.uploaders" :key="u.id" class="device">
+        <span class="ua">
+          <span class="name">{{ u.label }}</span>
+          <span class="driver">{{ u.driver }}</span>
+          <span v-if="u.isDefault" class="badge default">default</span>
+          <span v-if="!u.enabled" class="badge off">disabled</span>
+          <span v-else-if="!u.offeredToUsers" class="badge off">admin only</span>
+          <span v-if="u.locked" class="badge off">managed</span>
+        </span>
+        <template v-if="!store.uploadersManaged && !u.locked">
+          <button
+            v-if="!u.isDefault"
+            class="link"
+            :disabled="busy || !u.enabled"
+            :title="u.enabled ? '' : 'enable this uploader first'"
+            @click="onSetDefault(u)"
+          >
+            make default
+          </button>
+          <button class="link" :disabled="busy" @click="onToggleEnabled(u)">
+            {{ u.enabled ? 'disable' : 'enable' }}
+          </button>
+          <button class="link" :disabled="busy" @click="onToggleOffered(u)">
+            {{ u.offeredToUsers ? 'hide from users' : 'offer to users' }}
+          </button>
+          <button v-if="u.config && hasFields(u)" class="link" :disabled="busy" @click="onEdit(u)">
+            edit
+          </button>
+          <button v-if="isDeletable(u)" class="link danger" :disabled="busy" @click="onDelete(u)">
+            delete
+          </button>
+        </template>
+      </li>
+    </ul>
+
+    <template v-if="!store.uploadersManaged">
+      <template v-if="editing">
+        <h3 class="subhead">edit {{ editing.label }}</h3>
+        <UploaderConfigForm
+          :driver="driverFor(editing.driver)!"
+          :existing="{
+            label: editing.label,
+            config: editing.config,
+            secretsSet: editing.secretsSet,
+          }"
+          :busy="busy"
+          :error="formError"
+          @save="onSaveEdit"
+          @cancel="closeForms"
+        />
+      </template>
+
+      <template v-else-if="store.uploaderDrivers.length">
+        <h3 class="subhead">add an uploader</h3>
+        <template v-if="adding">
+          <label class="driver-pick">
+            <span>Type</span>
+            <select v-model="adding" :disabled="busy">
+              <option v-for="d in store.uploaderDrivers" :key="d.driver" :value="d.driver">
+                {{ d.label }}
+              </option>
+            </select>
+          </label>
+          <UploaderConfigForm
+            :driver="driverFor(adding)!"
+            :busy="busy"
+            :error="formError"
+            @save="onSaveNew"
+            @cancel="closeForms"
+          />
+        </template>
+        <p v-else class="add-row">
+          <button class="link" :disabled="busy" @click="adding = store.uploaderDrivers[0].driver">
+            add an uploader
+          </button>
+        </p>
+      </template>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useAdminStore } from '../../stores/admin.js';
+import UploaderConfigForm from '../UploaderConfigForm.vue';
+import type { AdminUploader, UploaderDriver } from '../../utils/uploaders.js';
+
+const store = useAdminStore();
+
+const busy = ref(false);
+const error = ref('');
+const formError = ref('');
+const adding = ref<string | null>(null);
+const editing = ref<AdminUploader | null>(null);
+
+function driverFor(id: string): UploaderDriver | undefined {
+  return store.uploaderDrivers.find((d) => d.driver === id);
+}
+
+/** Zero-config drivers (x0, local disk) have nothing to edit. */
+function hasFields(u: AdminUploader): boolean {
+  return (driverFor(u.driver)?.configSchema.length ?? 0) > 0;
+}
+
+/** Only uploaders an admin actually created can be deleted: the built-ins come
+ *  back on the next boot regardless, and the default has to be reassigned first.
+ *  The server enforces both — this just keeps the button from appearing. */
+function isDeletable(u: AdminUploader): boolean {
+  return !u.builtIn && !u.isDefault;
+}
+
+function closeForms() {
+  adding.value = null;
+  editing.value = null;
+  formError.value = '';
+}
+
+async function run(fn: () => Promise<unknown>, fallback: string) {
+  error.value = '';
+  busy.value = true;
+  try {
+    await fn();
+  } catch (e: any) {
+    error.value = e.message || fallback;
+  } finally {
+    busy.value = false;
+  }
+}
+
+function onEdit(u: AdminUploader) {
+  closeForms();
+  editing.value = u;
+}
+
+const onSetDefault = (u: AdminUploader) =>
+  run(() => store.setDefaultUploader(u.id), 'failed to set the default uploader');
+
+const onToggleEnabled = (u: AdminUploader) =>
+  run(() => store.updateUploader(u.id, { enabled: !u.enabled }), 'failed to update the uploader');
+
+const onToggleOffered = (u: AdminUploader) =>
+  run(
+    () => store.updateUploader(u.id, { offeredToUsers: !u.offeredToUsers }),
+    'failed to update the uploader',
+  );
+
+const onTogglePolicy = (e: Event) =>
+  run(
+    () => store.setAllowUserDefined((e.target as HTMLInputElement).checked),
+    'failed to update the policy',
+  );
+
+async function onSaveNew({ label, values }: { label: string; values: Record<string, string> }) {
+  if (!adding.value) return;
+  formError.value = '';
+  busy.value = true;
+  try {
+    await store.createUploader({ driver: adding.value, label, values });
+    closeForms();
+  } catch (e: any) {
+    formError.value = e.message || 'failed to add the uploader';
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function onSaveEdit({ label, values }: { label: string; values: Record<string, string> }) {
+  if (!editing.value) return;
+  formError.value = '';
+  busy.value = true;
+  try {
+    await store.updateUploader(editing.value.id, { label, values });
+    closeForms();
+  } catch (e: any) {
+    formError.value = e.message || 'failed to save the uploader';
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function onDelete(u: AdminUploader) {
+  if (
+    !confirm(
+      `Delete ${u.label}? Anyone using it will fall back to the default uploader. Files already ` +
+        `uploaded through it stay where they are, but Lurker will no longer be able to delete them.`,
+    )
+  ) {
+    return;
+  }
+  await run(() => store.deleteUploader(u.id), 'failed to delete the uploader');
+}
+
+onMounted(() => {
+  if (!store.uploadersLoaded) {
+    store.fetchUploaders().catch((e) => {
+      error.value = e.message || 'failed to load uploaders';
+    });
+  }
+});
+</script>
+
+<style src="../settings-panes/panes.css"></style>
+<style scoped>
+.device .name {
+  color: var(--fg);
+}
+
+.device .driver,
+.badge {
+  color: var(--fg-muted);
+}
+
+.badge.default {
+  color: var(--accent);
+}
+
+.policy {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin: var(--space-3) 0;
+}
+
+.driver-pick {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+}
+
+.add-row {
+  margin: var(--space-2) 0;
+}
+</style>

--- a/vue_client/src/components/settings-panes/RegistryPane.vue
+++ b/vue_client/src/components/settings-panes/RegistryPane.vue
@@ -6,15 +6,30 @@
   groups items by their `group` field, and renders one SettingsRow per item.
   Used for any category whose `kind: 'registry'` entry in CATEGORIES — i.e.
   the categories that are just a list of options with no contextual UI.
+
+  It's also embeddable: a BESPOKE pane whose category still has ordinary registry
+  options can render them here rather than hand-rolling SettingsRows. Pass
+  `embedded` (drops the <h2> and the category id, so the host pane keeps a single
+  DOM id) and optionally `only` to restrict it to certain groups. UploadsPane uses
+  both: its destination/uploader UI is table-backed and bespoke, but the image
+  pipeline underneath it is still just registry options.
 -->
 
 <template>
-  <section :id="categoryId" class="settings-pane">
-    <h2>{{ categoryLabel }}</h2>
+  <section
+    :id="embedded ? undefined : categoryId"
+    :class="embedded ? 'registry-embed' : 'settings-pane'"
+  >
+    <h2 v-if="!embedded">{{ categoryLabel }}</h2>
     <p v-if="error" class="error inline">{{ error }}</p>
 
     <template v-for="grp in groups" :key="grp.id">
-      <h3 v-if="groups.length > 1" :id="grp.id" class="subhead" :data-setting-group="grp.id">
+      <h3
+        v-if="embedded || groups.length > 1"
+        :id="grp.id"
+        class="subhead"
+        :data-setting-group="grp.id"
+      >
         {{ grp.title }}
       </h3>
       <ul class="rows">
@@ -30,7 +45,7 @@
       </ul>
     </template>
 
-    <p v-if="!groups.length" class="muted small">No settings in this category.</p>
+    <p v-if="!groups.length && !embedded" class="muted small">No settings in this category.</p>
   </section>
 </template>
 
@@ -42,7 +57,13 @@ import { CATEGORIES, GROUPS, optionVisible } from '../../utils/settingsRegistry.
 import type { SettingOption, SettingValue } from '../../../../shared/settingsRegistry.js';
 import SettingsRow from '../SettingsRow.vue';
 
-const props = defineProps<{ categoryId: string }>();
+const props = defineProps<{
+  categoryId: string;
+  /** Render for embedding in a bespoke pane: no <h2>, no category id. */
+  embedded?: boolean;
+  /** Restrict to these group ids (in this order). Omit for every group. */
+  only?: string[];
+}>();
 
 const settings = useSettingsStore();
 const config = useConfigStore();
@@ -55,7 +76,10 @@ const categoryLabel = computed(() => {
 
 const groups = computed(() => {
   const items = settings.registry.filter(
-    (opt) => opt.category === props.categoryId && optionVisible(opt, { isNode: config.isNode }),
+    (opt) =>
+      opt.category === props.categoryId &&
+      (!props.only || props.only.includes(opt.group || '_')) &&
+      optionVisible(opt, { isNode: config.isNode }),
   );
   if (!items.length) return [];
   const groupsMap = new Map<string, SettingOption[]>();
@@ -64,11 +88,15 @@ const groups = computed(() => {
     if (!groupsMap.has(gid)) groupsMap.set(gid, []);
     groupsMap.get(gid)!.push(opt);
   }
-  return Array.from(groupsMap, ([gid, gItems]) => ({
+  const built = Array.from(groupsMap, ([gid, gItems]) => ({
     id: gid,
     title: GROUPS[gid] || gid,
     items: gItems,
   }));
+  // `only` is an explicit ordering, not just a filter.
+  if (!props.only) return built;
+  const order = props.only;
+  return built.toSorted((a, b) => order.indexOf(a.id) - order.indexOf(b.id));
 });
 
 async function onCommit(key: string, value: SettingValue) {

--- a/vue_client/src/components/settings-panes/UploadsPane.vue
+++ b/vue_client/src/components/settings-panes/UploadsPane.vue
@@ -62,6 +62,7 @@
     <template v-if="editing">
       <h3 class="subhead">edit {{ editing.label }}</h3>
       <UploaderConfigForm
+        :key="`edit-${editing.id}`"
         :driver="driverFor(editing.driver)!"
         :existing="{
           label: editing.label,
@@ -85,6 +86,7 @@
           </select>
         </label>
         <UploaderConfigForm
+          :key="`add-${adding}`"
           :driver="driverFor(adding)!"
           :busy="busy"
           :error="formError"

--- a/vue_client/src/components/settings-panes/UploadsPane.vue
+++ b/vue_client/src/components/settings-panes/UploadsPane.vue
@@ -27,44 +27,43 @@
     <h3 class="subhead">destination</h3>
     <p v-if="loading && !loaded" class="muted small">Loading…</p>
     <ul v-else class="device-list">
-      <li
-        v-for="u in uploaders"
-        :key="u.id"
-        class="device"
-        :class="{ selected: u.id === selectedId }"
-      >
+      <li v-for="u in uploaders" :key="u.id" class="device stacked">
         <span class="ua">
           <span class="name">{{ u.label }}</span>
           <span class="driver">{{ u.driver }}</span>
           <span v-if="u.scope === 'user'" class="badge">yours</span>
+          <span v-if="u.id === selectedId" class="badge in-use">in use</span>
         </span>
-        <button v-if="u.id !== selectedId" class="link" :disabled="busy" @click="onSelect(u.id)">
-          use
-        </button>
-        <span v-else class="muted small">selected</span>
-        <!-- Editable AND describable: a row whose driver we have no schema for
-             can't be rendered as a form, so offer removal but not editing. -->
-        <button
-          v-if="u.editable && driverFor(u.driver)"
-          class="link"
-          :disabled="busy"
-          @click="onEdit(u)"
-        >
-          edit
-        </button>
-        <button v-if="u.editable" class="link danger" :disabled="busy" @click="onDelete(u)">
-          remove
-        </button>
+        <div class="row-actions">
+          <button v-if="u.id !== selectedId" class="link" :disabled="busy" @click="onSelect(u.id)">
+            use this one
+          </button>
+          <!-- Editable AND describable: a row whose driver we have no schema for
+               can't be rendered as a form, so offer removal but not editing. -->
+          <button
+            v-if="u.editable && driverFor(u.driver)"
+            class="link"
+            :disabled="busy"
+            @click="onEdit(u)"
+          >
+            edit
+          </button>
+          <button v-if="u.editable" class="link danger" :disabled="busy" @click="onDelete(u)">
+            remove
+          </button>
+        </div>
       </li>
-      <li class="device" :class="{ selected: selectedId === null }">
+      <li class="device stacked">
         <span class="ua">
           <span class="name">Server default</span>
           <span class="driver">follow whatever the admin has set</span>
+          <span v-if="selectedId === null" class="badge in-use">in use</span>
         </span>
-        <button v-if="selectedId !== null" class="link" :disabled="busy" @click="onSelect(null)">
-          use
-        </button>
-        <span v-else class="muted small">selected</span>
+        <div class="row-actions">
+          <button v-if="selectedId !== null" class="link" :disabled="busy" @click="onSelect(null)">
+            use this one
+          </button>
+        </div>
       </li>
     </ul>
 
@@ -256,10 +255,9 @@ onMounted(refresh);
 
 <style src="./panes.css"></style>
 <style scoped>
-.device.selected {
-  border-color: var(--accent);
-}
-
+/* Which uploader is live is carried by the "in use" badge on the identity line,
+   not by tinting the row: .device only has a border-TOP, so an accent border on
+   the selected row reads as a stray rule above it rather than as selection. */
 .device .name {
   color: var(--fg);
 }
@@ -270,6 +268,10 @@ onMounted(refresh);
 
 .badge {
   color: var(--fg-muted);
+}
+
+.badge.in-use {
+  color: var(--accent);
 }
 
 .driver-pick {

--- a/vue_client/src/components/settings-panes/UploadsPane.vue
+++ b/vue_client/src/components/settings-panes/UploadsPane.vue
@@ -1,0 +1,262 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  Uploads (#514). Two halves in one pane, deliberately:
+
+    • DESTINATION — which configured uploader your files go to, and the personal
+      uploaders you've set up (your catbox account, your Zipline, your S3 bucket).
+      This is table-backed (uploader_config rows), so it's bespoke.
+    • IMAGE PIPELINE — still ordinary registry settings, embedded below via
+      RegistryPane rather than re-implemented here.
+
+  This replaces the old `uploads.provider` dropdown + the flat per-provider
+  credential fields. Those keys are gone; anything they held was folded into real
+  uploaders by the boot migration.
+-->
+
+<template>
+  <section id="uploads" class="settings-pane">
+    <h2>Uploads</h2>
+    <p class="section-desc">
+      Where pasted and picked files are uploaded. Lurker pastes a link into the message — the file
+      itself is hosted by whichever uploader you choose here.
+    </p>
+    <p v-if="error" class="error inline">{{ error }}</p>
+
+    <h3 class="subhead">destination</h3>
+    <p v-if="loading && !loaded" class="muted small">Loading…</p>
+    <ul v-else class="device-list">
+      <li
+        v-for="u in uploaders"
+        :key="u.id"
+        class="device"
+        :class="{ selected: u.id === selectedId }"
+      >
+        <span class="ua">
+          <span class="name">{{ u.label }}</span>
+          <span class="driver">{{ u.driver }}</span>
+          <span v-if="u.scope === 'user'" class="badge">yours</span>
+        </span>
+        <button v-if="u.id !== selectedId" class="link" :disabled="busy" @click="onSelect(u.id)">
+          use
+        </button>
+        <span v-else class="muted small">selected</span>
+        <button v-if="u.editable" class="link" :disabled="busy" @click="onEdit(u)">edit</button>
+        <button v-if="u.editable" class="link danger" :disabled="busy" @click="onDelete(u)">
+          remove
+        </button>
+      </li>
+      <li class="device" :class="{ selected: selectedId === null }">
+        <span class="ua">
+          <span class="name">Server default</span>
+          <span class="driver">follow whatever the admin has set</span>
+        </span>
+        <button v-if="selectedId !== null" class="link" :disabled="busy" @click="onSelect(null)">
+          use
+        </button>
+        <span v-else class="muted small">selected</span>
+      </li>
+    </ul>
+
+    <template v-if="editing">
+      <h3 class="subhead">edit {{ editing.label }}</h3>
+      <UploaderConfigForm
+        :driver="driverFor(editing.driver)!"
+        :existing="{
+          label: editing.label,
+          config: editing.config ?? {},
+          secretsSet: editing.secretsSet ?? {},
+        }"
+        :busy="busy"
+        :error="formError"
+        @save="onSaveEdit"
+        @cancel="closeForms"
+      />
+    </template>
+
+    <template v-else-if="allowUserDefined && drivers.length">
+      <h3 class="subhead">add your own uploader</h3>
+      <template v-if="adding">
+        <label class="driver-pick">
+          <span>Type</span>
+          <select v-model="adding" :disabled="busy">
+            <option v-for="d in drivers" :key="d.driver" :value="d.driver">{{ d.label }}</option>
+          </select>
+        </label>
+        <UploaderConfigForm
+          :driver="driverFor(adding)!"
+          :busy="busy"
+          :error="formError"
+          @save="onSaveNew"
+          @cancel="closeForms"
+        />
+      </template>
+      <p v-else class="add-row">
+        <button class="link" :disabled="busy" @click="adding = drivers[0].driver">
+          add an uploader
+        </button>
+      </p>
+    </template>
+    <p v-else-if="!allowUserDefined" class="muted small">
+      This server doesn’t allow personal uploaders — you can pick from the ones above.
+    </p>
+
+    <!-- The rest of the category is still plain registry settings. -->
+    <RegistryPane category-id="uploads" embedded :only="['pipeline']" />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { api } from '../../api.js';
+import RegistryPane from './RegistryPane.vue';
+import UploaderConfigForm from '../UploaderConfigForm.vue';
+import type { Uploader, UploaderDriver } from '../../utils/uploaders.js';
+
+const uploaders = ref<Uploader[]>([]);
+const drivers = ref<UploaderDriver[]>([]);
+const selectedId = ref<number | null>(null);
+const allowUserDefined = ref(true);
+
+const loading = ref(false);
+const loaded = ref(false);
+const busy = ref(false);
+const error = ref('');
+const formError = ref('');
+
+/** Driver id currently being added (null = the add form is closed). */
+const adding = ref<string | null>(null);
+const editing = ref<Uploader | null>(null);
+
+function driverFor(id: string): UploaderDriver | undefined {
+  return drivers.value.find((d) => d.driver === id);
+}
+
+async function refresh() {
+  loading.value = true;
+  try {
+    const data = await api('/api/uploaders');
+    uploaders.value = data.uploaders || [];
+    drivers.value = data.drivers || [];
+    selectedId.value = data.selectedId ?? null;
+    allowUserDefined.value = data.allowUserDefined !== false;
+    loaded.value = true;
+  } catch (e: any) {
+    error.value = e.message || 'failed to load uploaders';
+  } finally {
+    loading.value = false;
+  }
+}
+
+function closeForms() {
+  adding.value = null;
+  editing.value = null;
+  formError.value = '';
+}
+
+async function onSelect(id: number | null) {
+  error.value = '';
+  busy.value = true;
+  try {
+    await api('/api/uploaders/selection', { method: 'PUT', body: { id } });
+    selectedId.value = id;
+  } catch (e: any) {
+    error.value = e.message || 'failed to select uploader';
+  } finally {
+    busy.value = false;
+  }
+}
+
+function onEdit(u: Uploader) {
+  closeForms();
+  editing.value = u;
+}
+
+async function onSaveNew({ label, values }: { label: string; values: Record<string, string> }) {
+  if (!adding.value) return;
+  formError.value = '';
+  busy.value = true;
+  try {
+    await api('/api/uploaders', {
+      method: 'POST',
+      body: { driver: adding.value, label, values },
+    });
+    closeForms();
+    await refresh();
+  } catch (e: any) {
+    formError.value = e.message || 'failed to add uploader';
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function onSaveEdit({ label, values }: { label: string; values: Record<string, string> }) {
+  if (!editing.value) return;
+  formError.value = '';
+  busy.value = true;
+  try {
+    await api(`/api/uploaders/${editing.value.id}`, { method: 'PATCH', body: { label, values } });
+    closeForms();
+    await refresh();
+  } catch (e: any) {
+    formError.value = e.message || 'failed to save uploader';
+  } finally {
+    busy.value = false;
+  }
+}
+
+async function onDelete(u: Uploader) {
+  if (
+    !confirm(
+      `Remove ${u.label}? Files you already uploaded through it stay where they are, but Lurker ` +
+        `will no longer be able to delete them from the host.`,
+    )
+  ) {
+    return;
+  }
+  error.value = '';
+  busy.value = true;
+  try {
+    await api(`/api/uploaders/${u.id}`, { method: 'DELETE' });
+    closeForms();
+    await refresh();
+  } catch (e: any) {
+    error.value = e.message || 'failed to remove uploader';
+  } finally {
+    busy.value = false;
+  }
+}
+
+onMounted(refresh);
+</script>
+
+<style src="./panes.css"></style>
+<style scoped>
+.device.selected {
+  border-color: var(--accent);
+}
+
+.device .name {
+  color: var(--fg);
+}
+
+.device .driver {
+  color: var(--fg-muted);
+}
+
+.badge {
+  color: var(--fg-muted);
+}
+
+.driver-pick {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+}
+
+.add-row {
+  margin: var(--space-2) 0;
+}
+</style>

--- a/vue_client/src/components/settings-panes/UploadsPane.vue
+++ b/vue_client/src/components/settings-panes/UploadsPane.vue
@@ -42,7 +42,16 @@
           use
         </button>
         <span v-else class="muted small">selected</span>
-        <button v-if="u.editable" class="link" :disabled="busy" @click="onEdit(u)">edit</button>
+        <!-- Editable AND describable: a row whose driver we have no schema for
+             can't be rendered as a form, so offer removal but not editing. -->
+        <button
+          v-if="u.editable && driverFor(u.driver)"
+          class="link"
+          :disabled="busy"
+          @click="onEdit(u)"
+        >
+          edit
+        </button>
         <button v-if="u.editable" class="link danger" :disabled="busy" @click="onDelete(u)">
           remove
         </button>
@@ -59,11 +68,11 @@
       </li>
     </ul>
 
-    <template v-if="editing">
+    <template v-if="editing && editingDriver">
       <h3 class="subhead">edit {{ editing.label }}</h3>
       <UploaderConfigForm
         :key="`edit-${editing.id}`"
-        :driver="driverFor(editing.driver)!"
+        :driver="editingDriver"
         :existing="{
           label: editing.label,
           config: editing.config ?? {},
@@ -76,18 +85,20 @@
       />
     </template>
 
-    <template v-else-if="allowUserDefined && drivers.length">
+    <template v-else-if="allowUserDefined && addableDrivers.length">
       <h3 class="subhead">add your own uploader</h3>
-      <template v-if="adding">
+      <template v-if="addingDriver">
         <label class="driver-pick">
           <span>Type</span>
           <select v-model="adding" :disabled="busy">
-            <option v-for="d in drivers" :key="d.driver" :value="d.driver">{{ d.label }}</option>
+            <option v-for="d in addableDrivers" :key="d.driver" :value="d.driver">
+              {{ d.label }}
+            </option>
           </select>
         </label>
         <UploaderConfigForm
-          :key="`add-${adding}`"
-          :driver="driverFor(adding)!"
+          :key="`add-${addingDriver.driver}`"
+          :driver="addingDriver"
           :busy="busy"
           :error="formError"
           @save="onSaveNew"
@@ -95,7 +106,7 @@
         />
       </template>
       <p v-else class="add-row">
-        <button class="link" :disabled="busy" @click="adding = drivers[0].driver">
+        <button class="link" :disabled="busy" @click="adding = addableDrivers[0].driver">
           add an uploader
         </button>
       </p>
@@ -110,7 +121,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { api } from '../../api.js';
 import RegistryPane from './RegistryPane.vue';
 import UploaderConfigForm from '../UploaderConfigForm.vue';
@@ -134,6 +145,16 @@ const editing = ref<Uploader | null>(null);
 function driverFor(id: string): UploaderDriver | undefined {
   return drivers.value.find((d) => d.driver === id);
 }
+
+// The "add" menu is the CREATABLE subset — `drivers` also carries the drivers we
+// only need in order to describe rows the user already owns (a `hoarder` row
+// migrated off the legacy settings is editable but not creatable).
+const addableDrivers = computed(() => drivers.value.filter((d) => d.creatable));
+
+// Resolved driver objects, so the template never hands the form an undefined
+// driver (which would blow up on `.configSchema`).
+const addingDriver = computed(() => (adding.value ? driverFor(adding.value) : undefined));
+const editingDriver = computed(() => (editing.value ? driverFor(editing.value.driver) : undefined));
 
 async function refresh() {
   loading.value = true;

--- a/vue_client/src/components/settings-panes/panes.css
+++ b/vue_client/src/components/settings-panes/panes.css
@@ -108,6 +108,40 @@
   justify-self: end;
 }
 
+/* STACKED rows: identity on the first line, actions on the second.
+
+   The default .device is a three-column grid sized for [identity][meta][one
+   action]. Some rows carry an action cluster that simply doesn't fit that —
+   the uploader rows have five (make default / enable / offer / edit / delete) —
+   and cramming them into the right-hand columns squeezes the identity down to a
+   sliver, then wraps the overflow into ragged implicit grid rows. Opt into this
+   instead of inventing a per-pane layout: one column, actions underneath and
+   left-aligned so they read as a toolbar for the row above them. */
+.settings-pane .device.stacked {
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+}
+.settings-pane .device.stacked .row-actions {
+  grid-column: 1 / -1;
+  justify-self: start;
+  flex-wrap: wrap;
+}
+/* Adjacent spans inside .ua (name + driver + badges) otherwise render with NO gap
+   at all: Vue's default whitespace: 'condense' strips whitespace-only text nodes
+   that contain a newline, so `x0.at` and `x0` collide into "x0.atx0". ApiTokensPane
+   already works around this with the same flex+gap in its own scoped styles.
+
+   Scoped to .stacked rather than hoisted onto every .device on purpose: AccountPane's
+   .ua wraps a full-width <input>, which a flex container would reflow, and that's not
+   something this change can verify. Hoisting it (and de-duplicating ApiTokensPane)
+   wants eyes on all three panes — see #538. */
+.settings-pane .device.stacked .ua {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 1ch;
+}
+
 .settings-pane .hl-sep {
   border: none;
   border-top: 1px solid var(--border);

--- a/vue_client/src/stores/admin.ts
+++ b/vue_client/src/stores/admin.ts
@@ -3,6 +3,7 @@
 
 import { defineStore } from 'pinia';
 import { api } from '../api.js';
+import type { AdminUploader, UploaderDriver } from '../utils/uploaders.js';
 
 export interface AdminUser {
   id: number;
@@ -27,8 +28,15 @@ export const useAdminStore = defineStore('admin', {
   state: () => ({
     users: [] as AdminUser[],
     invites: [] as AdminInvite[],
+    uploaders: [] as AdminUploader[],
+    uploaderDrivers: [] as UploaderDriver[],
+    allowUserDefined: true,
+    // Hosted: the uploader is env-managed by the control plane, so the whole
+    // management surface is read-only (the routes 409 anyway).
+    uploadersManaged: false,
     usersLoaded: false,
     invitesLoaded: false,
+    uploadersLoaded: false,
     loading: false,
     error: '',
   }),
@@ -80,6 +88,56 @@ export const useAdminStore = defineStore('admin', {
     async deleteInvite(token: string) {
       await api(`/api/admin/invites/${encodeURIComponent(token)}`, { method: 'DELETE' });
       this.invites = this.invites.filter((i) => i.token !== token);
+    },
+
+    // ─── instance uploaders (#514) ───────────────────────────────────────────
+    // Every mutation refetches rather than patching locally: the policy flags are
+    // interdependent server-side (setting one default clears the incumbent), so a
+    // local patch would drift from the truth on the very first default swap.
+    async fetchUploaders() {
+      this.error = '';
+      try {
+        const data = await api('/api/admin/uploaders');
+        this.uploaders = data.uploaders || [];
+        this.uploaderDrivers = data.drivers || [];
+        this.allowUserDefined = data.allowUserDefined !== false;
+        this.uploadersManaged = !!data.managed;
+        this.uploadersLoaded = true;
+      } catch (e: any) {
+        this.error = e.message || 'failed to load uploaders';
+        throw e;
+      }
+    },
+    async createUploader(body: { driver: string; label: string; values: Record<string, string> }) {
+      await api('/api/admin/uploaders', { method: 'POST', body });
+      await this.fetchUploaders();
+    },
+    async updateUploader(
+      id: number,
+      body: {
+        label?: string;
+        values?: Record<string, string>;
+        enabled?: boolean;
+        offeredToUsers?: boolean;
+      },
+    ) {
+      await api(`/api/admin/uploaders/${id}`, { method: 'PATCH', body });
+      await this.fetchUploaders();
+    },
+    async setDefaultUploader(id: number) {
+      await api(`/api/admin/uploaders/${id}/default`, { method: 'PUT' });
+      await this.fetchUploaders();
+    },
+    async deleteUploader(id: number) {
+      await api(`/api/admin/uploaders/${id}`, { method: 'DELETE' });
+      await this.fetchUploaders();
+    },
+    async setAllowUserDefined(allowUserDefined: boolean) {
+      await api('/api/admin/uploaders/policy', {
+        method: 'PUT',
+        body: { allowUserDefined },
+      });
+      this.allowUserDefined = allowUserDefined;
     },
   },
 });

--- a/vue_client/src/utils/adminRegistry.ts
+++ b/vue_client/src/utils/adminRegistry.ts
@@ -11,10 +11,12 @@
 // Settings today, relocated here. The commented entries below are the known
 // incoming domains; each becomes a live tab by adding its ADMIN_TABS row and a
 // pane in views/Admin.vue's component map, no other wiring:
-//   - instance-defaults — instance-level default uploader + other new-account
-//                          seed settings (#299)
 //   - capabilities      — per-user feature grants the admin toggles (e.g. DCC)
 //   - moderation        — upload takedowns / abuse review
+//
+// `uploaders` is the tab #299 penciled in as "instance defaults": the instance's
+// configured uploaders, which one new accounts inherit, and whether users may
+// define their own (#514).
 
 export interface AdminTab {
   /** URL slug (/admin/:id) and the key into the pane component map. */
@@ -26,7 +28,7 @@ export interface AdminTab {
 export const ADMIN_TABS: readonly AdminTab[] = Object.freeze([
   { id: 'users', label: 'Users' },
   { id: 'invites', label: 'Invites' },
-  // { id: 'instance-defaults', label: 'Instance defaults' }, // #299
+  { id: 'uploaders', label: 'Uploaders' },
   // { id: 'capabilities', label: 'Capabilities' },
   // { id: 'moderation', label: 'Moderation' },
 ]);

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -46,9 +46,9 @@ describe('categoryVisible', () => {
 
 describe('optionVisible', () => {
   it('hides selfHostedOnly settings in node edition, shows them standalone', () => {
-    expect(optionVisible(opt('uploads.provider'), { isNode: false })).toBe(true);
-    expect(optionVisible(opt('uploads.provider'), { isNode: true })).toBe(false);
-    expect(optionVisible(opt('uploads.hoarder.api_key'), { isNode: true })).toBe(false);
+    expect(optionVisible(opt('uploads.image.max_upload_mb'), { isNode: false })).toBe(true);
+    expect(optionVisible(opt('uploads.image.max_upload_mb'), { isNode: true })).toBe(false);
+    expect(optionVisible(opt('uploads.image.quality'), { isNode: true })).toBe(false);
   });
 
   it('hides the cost/abuse pipeline knobs in node edition (operator-controlled)', () => {

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -24,6 +24,12 @@ export interface UploaderDriver {
   driver: string;
   label: string;
   configSchema: UploaderConfigField[];
+  // May a NEW uploader of this driver be stood up? The server sends every driver
+  // (you need a schema to render an edit form for a row you already own — e.g. a
+  // `hoarder` row migrated off the legacy settings, which is editable but not
+  // creatable), so the "add an uploader" menu filters on this rather than on
+  // whatever happens to be in the list.
+  creatable: boolean;
 }
 
 /** One configured uploader, as the user-facing API projects it. */

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Shared shapes for the uploader-management UI (#514). The server projects these
+// from each driver's own `configSchema`, so the client renders a form for a
+// driver it has never heard of — adding a driver is a server-only change.
+//
+// The one invariant worth restating here, because it shapes every component that
+// touches these types: A SECRET VALUE NEVER TRAVELS TO THE CLIENT. A secret field
+// is described by the schema and reported as set-or-not via `secretsSet`; its
+// value is only ever write-only. Anything that renders a `secret` field must
+// therefore treat "empty" as "leave what's stored alone", not "clear it".
+
+export interface UploaderConfigField {
+  key: string;
+  label: string;
+  type: 'string' | 'secret';
+  required: boolean;
+  default?: string;
+  description: string;
+}
+
+export interface UploaderDriver {
+  driver: string;
+  label: string;
+  configSchema: UploaderConfigField[];
+}
+
+/** One configured uploader, as the user-facing API projects it. */
+export interface Uploader {
+  id: number;
+  driver: string;
+  label: string;
+  scope: 'user' | 'instance';
+  enabled: boolean;
+  editable: boolean;
+  // Present only on rows the caller may edit (their own).
+  config?: Record<string, string>;
+  secretsSet?: Record<string, boolean>;
+}
+
+/** An instance uploader as the ADMIN API projects it (adds the policy flags). */
+export interface AdminUploader extends Omit<Uploader, 'editable'> {
+  config: Record<string, string>;
+  secretsSet: Record<string, boolean>;
+  offeredToUsers: boolean;
+  locked: boolean;
+  isDefault: boolean;
+  // Seeded by the boot reconcile (x0 / catbox / local disk): can be disabled, but
+  // not deleted — it would just come back. The server refuses either way; this is
+  // so the UI doesn't offer a button that 409s.
+  builtIn: boolean;
+}
+
+/** Blank form values for a driver, honoring each field's declared default. */
+export function emptyValues(driver: UploaderDriver): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const f of driver.configSchema) out[f.key] = f.default ?? '';
+  return out;
+}
+
+/**
+ * Form values seeded from an existing uploader. Secrets come back EMPTY on
+ * purpose — the server never sent us the value, and an empty secret on submit
+ * means "keep the stored one" (see updateUploaderConfig). So an edit that doesn't
+ * touch the secret field round-trips it untouched.
+ */
+export function valuesFrom(
+  driver: UploaderDriver,
+  config: Record<string, string> = {},
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const f of driver.configSchema) {
+    out[f.key] = f.type === 'secret' ? '' : (config[f.key] ?? f.default ?? '');
+  }
+  return out;
+}
+
+/** Required fields still blank — used to disable the submit button. `existing`
+ *  relaxes the check for secrets that are already stored. */
+export function missingRequired(
+  driver: UploaderDriver,
+  values: Record<string, string>,
+  secretsSet: Record<string, boolean> = {},
+): boolean {
+  return driver.configSchema.some((f) => {
+    if (!f.required) return false;
+    if (f.type === 'secret' && secretsSet[f.key]) return false; // already stored
+    return !String(values[f.key] ?? '').trim();
+  });
+}

--- a/vue_client/src/views/Admin.vue
+++ b/vue_client/src/views/Admin.vue
@@ -39,6 +39,7 @@ import { DEFAULT_ADMIN_TAB, isAdminTab } from '../utils/adminRegistry.js';
 import AdminSidebar from '../components/AdminSidebar.vue';
 import UsersPane from '../components/admin-panes/UsersPane.vue';
 import InvitesPane from '../components/admin-panes/InvitesPane.vue';
+import UploadersPane from '../components/admin-panes/UploadersPane.vue';
 
 useSocket();
 
@@ -49,6 +50,7 @@ const router = useRouter();
 const PANES: Record<string, Component> = {
   users: UsersPane,
   invites: InvitesPane,
+  uploaders: UploadersPane,
 };
 
 const activeTabId = computed((): string => {

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -60,6 +60,7 @@ import UsersPane from '../components/settings-panes/UsersPane.vue';
 import NetworksPane from '../components/settings-panes/NetworksPane.vue';
 import AccountPane from '../components/settings-panes/AccountPane.vue';
 import ApiTokensPane from '../components/settings-panes/ApiTokensPane.vue';
+import UploadsPane from '../components/settings-panes/UploadsPane.vue';
 import DataPane from '../components/settings-panes/DataPane.vue';
 import AboutPane from '../components/settings-panes/AboutPane.vue';
 
@@ -84,6 +85,7 @@ const BESPOKE_PANES: Record<string, Component> = {
   networks: NetworksPane,
   account: AccountPane,
   'api-tokens': ApiTokensPane,
+  uploads: UploadsPane,
   data: DataPane,
   about: AboutPane,
 };


### PR DESCRIPTION
Builds on **@JawshTheDark**'s upload-driver work from #528 — his commit is cherry-picked here unchanged (first commit on the branch, authored by him), so **#528 can drop its third commit** and stay focused on DCC + tab-completion.

That commit gives us **P2 (#512)** and **P2.5 (#513)** essentially for free: `zipline`, `chibisafe`, and `s3` (hand-rolled SigV4, no `@aws-sdk`), all built against the `UploadDriver` contract from #526. Verified against real instances on his side.

The rest of this PR is **P3 (#514)**, which those drivers turn out to *require*: they were unreachable, because nothing in the app could hold a driver's credentials.

## The regression this fixes

While wiring the drivers up I found that P0 (#526) shipped a live bug, and proved it against a fresh self-host DB. The legacy `uploads.*` settings keys were folded into `uploader_config` rows **once**, at migration, and never read again — so anything configured or changed *afterwards* was silently dropped:

- **Configuring Hoarder after upgrading resolved to `x0`.** Files a user meant for their own private host went to a **public** one, with no error. On a fresh install, Hoarder could not be configured at all.
- **Changing a catbox userhash** kept uploading with the old one, or anonymously.

Both violate locked decision 15 (*never silently reroute a file to a different backend*). Existing users converted at migration time were fine, which is why it hadn't bitten anyone yet; the broken cases were fresh installs and anyone who changed their uploader after upgrading. Hosted is unaffected (locked row, reconciled from env).

`reconcileLegacyUploadSettings` now runs on **every boot**: materializes whatever those keys still hold into real rows — including credentials a user saved but isn't currently using, since we're deleting the only copy — repoints `uploads.uploader_id`, then deletes the keys. No `SCHEMA_VERSION` gate: the version-gated one-shot is the exact pattern that wedged a dev DB in #511, and this migration is self-terminating anyway. Then the keys and the P0 bridge come out entirely.

## What's here

**Server** — `updateUploaderConfig` (secrets are **preserve-on-omit**: the client never receives a secret, so it can't send one back on an edit), transactional `setInstanceDefault`, `/api/uploaders` (allowed set, personal CRUD, picker), `/api/admin/uploaders` (instance uploaders, `offered_to_users` / `is_default` / `enabled`, and the `allow_user_defined` lockdown switch — that's #299). Built-ins are disable-only: deleting one is theatre (the boot reconcile puts it back) and deleting `local` would strand files on disk. The admin surface 409s wholesale in node edition, where the uploader is env-managed by the CP.

**A secret never appears in a response** — only `secretsSet[field]: true`. There are tests that assert exactly this.

**Export/import** — `uploader_config` flips from `skip` to `partial`. It *had* to: deleting the legacy keys removed the only thing carrying a user's uploaders across an export. Personal rows travel; `secrets_enc` deliberately does **not** (sealed with the source instance's key — undecryptable on the target when keyed, and *plaintext in the zip* when not), so a restored uploader arrives credential-less by design. Policy flags are omitted so the DDL defaults apply and an imported row can't seize the instance default. One sharp edge worth flagging for review: `upload_history.uploader_config_id` is declared `fkRekeyNullable`, because an unmapped FK makes the importer **drop the whole row** — without it, every upload made through an instance uploader (x0/catbox/local — i.e. most of them) would silently vanish on import.

**Client** — the Uploads pane goes bespoke: uploader list + picker + a config form **generated from each driver's own `configSchema`**, so adding a driver is a server-only change. The surviving image-pipeline settings render underneath via an embeddable `RegistryPane` rather than being re-implemented. New admin **Uploaders** tab.

## Deferred (not snuck in)

- The per-upload override **picker UI** on the message input. The server accepts `uploaderId` on the upload POST and the resolver honors it; only the UI is deferred.
- Retiring the `hoarder` driver id in favor of `dropper` (cosmetic, P2 leftover).

## Testing

`npm run check` + `npm test` green — **2,125 tests**, +40 over main. New coverage: the two regression cases above (as explicit tests), route CRUD, secret-never-projected, preserve-on-omit, the built-in delete refusal, lockdown-doesn't-strand-existing-uploaders, and an export/import round-trip asserting the secret is absent from the archive and the selection pointer is rekeyed.

## QA checklist

- [ ] Existing uploader still works after boot (check the boot log for the reconcile).
- [ ] Settings → Uploads: pick an uploader, add a personal one (catbox userhash / your Zipline), edit it **without** retyping the secret, remove it.
- [ ] Admin → Uploaders: stand up an S3/R2 uploader, make it the default, confirm a fresh account inherits it; toggle "offer to users"; flip the lockdown switch.
- [ ] Upload a file end-to-end through a newly-configured driver.
- [ ] Data export → import into a fresh account: uploaders come across, secrets don't.

Closes #512, closes #513, closes #514, closes #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)