### PR TITLE
Channel completion by recency; make repeat Tab actually cycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@types/yauzl": "^3.4.0",
         "@vitest/coverage-v8": "^4.1.10",
         "concurrently": "^10.0.3",
+        "happy-dom": "^20.10.6",
         "oxfmt": "^0.57.0",
         "oxlint": "^1.72.0",
         "supertest": "^7.2.2",
@@ -52,9 +53,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -62,9 +63,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -72,13 +73,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -88,14 +89,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2686,6 +2687,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -3416,6 +3424,19 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -3931,6 +3952,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -4518,6 +4552,25 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "license": "MIT"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7049,6 +7102,16 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which-typed-array": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/yauzl": "^3.4.0",
     "@vitest/coverage-v8": "^4.1.10",
     "concurrently": "^10.0.3",
+    "happy-dom": "^20.10.6",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",
     "supertest": "^7.2.2",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineConfig } from 'vitest/config';
+
+// `npm test` runs from the repo root and covers two npm packages: the server
+// here, and the Vue client in vue_client/ (which has its own package.json and
+// node_modules). They're split into projects so the client's suite resolves its
+// own dependencies — notably the SFC compiler, which only exists there. See
+// vue_client/vitest.config.ts.
+//
+// Before component tests existed there was no config at all: every test was
+// plain TS, vitest's defaults found them all, and nothing needed a Vue plugin.
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        test: {
+          name: 'server',
+          include: ['server/**/*.test.ts', 'shared/**/*.test.ts'],
+          environment: 'node',
+        },
+      },
+      './vue_client/vitest.config.ts',
+    ],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,13 @@ export default defineConfig({
       {
         test: {
           name: 'server',
-          include: ['server/**/*.test.ts', 'shared/**/*.test.ts'],
+          // Catch-all, minus the client — deliberately not a list of the
+          // directories that happen to hold tests today. A project that includes
+          // only known paths doesn't *skip* a test file added outside them, it
+          // never collects it, and the run still reports all-green. Everything
+          // that isn't the client's belongs to this project.
+          include: ['**/*.{test,spec}.ts'],
+          exclude: ['**/node_modules/**', 'vue_client/**'],
           environment: 'node',
         },
       },

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@types/node": "^26.0.1",
         "@vitejs/plugin-vue": "^6.0.7",
+        "@vue/test-utils": "^2.4.11",
         "postcss-hover-media-feature": "^1.0.2",
         "typescript": "^6.0.3",
         "vite": "^8.1.3",
@@ -175,6 +176,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -238,6 +257,13 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.138.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
@@ -246,6 +272,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -769,6 +806,37 @@
       "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.11.tgz",
+      "integrity": "sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -787,6 +855,32 @@
       "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
     },
     "node_modules/ast-kit": {
       "version": "2.2.0",
@@ -821,6 +915,13 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -828,6 +929,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/chokidar": {
@@ -845,11 +956,52 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/copy-anything": {
       "version": "4.0.5",
@@ -864,6 +1016,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/cssesc": {
@@ -913,6 +1080,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -954,6 +1154,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -968,11 +1185,50 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-what": {
       "version": "5.5.0",
@@ -985,6 +1241,58 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1277,6 +1585,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1299,6 +1614,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -1367,12 +1708,62 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1494,6 +1885,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -1569,6 +1967,55 @@
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sortablejs": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
@@ -1591,6 +2038,110 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/superjson": {
@@ -1839,6 +2390,13 @@
         }
       }
     },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.7.tgz",
+      "integrity": "sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue-router": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.1.0.tgz",
@@ -1955,6 +2513,120 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/node": "^26.0.1",
     "@vitejs/plugin-vue": "^6.0.7",
+    "@vue/test-utils": "^2.4.11",
     "postcss-hover-media-feature": "^1.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.1.3",

--- a/vue_client/src/components/ChannelPicker.vue
+++ b/vue_client/src/components/ChannelPicker.vue
@@ -44,12 +44,16 @@ const props = withDefaults(
     // both the match filter and the inserted result.
     query?: string;
     networkId?: number | null;
+    // The composer's current buffer target, so the channel you're in is
+    // offered first (matches the Tab-completion order in MessageInput).
+    activeTarget?: string | null;
     anchor?: HTMLElement | null;
   }>(),
   {
     open: false,
     query: '',
     networkId: null,
+    activeTarget: null,
     anchor: null,
   },
 );
@@ -66,7 +70,11 @@ const rows = computed<string[]>(() => {
   // doesn't rebuild on every buffer mutation behind a closed picker. The
   // popover hides when closed anyway, so returning [] here is behavior-neutral.
   if (!props.open || props.networkId == null) return [];
-  return buildChannelCandidates(buffers.forNetwork(props.networkId), props.query).slice(0, 50);
+  return buildChannelCandidates(
+    buffers.forNetwork(props.networkId),
+    props.query,
+    props.activeTarget,
+  ).slice(0, 50);
 });
 
 function rowKey(row: string): string {

--- a/vue_client/src/components/ChannelPicker.vue
+++ b/vue_client/src/components/ChannelPicker.vue
@@ -32,7 +32,8 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { useBuffersStore } from '../stores/buffers.js';
+import { bufferKey, useBuffersStore } from '../stores/buffers.js';
+import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { buildChannelCandidates } from '../utils/channelCompletion.js';
 import VerticalPopover from './VerticalPopover.vue';
 import type { PopoverNav } from './popoverNav.js';
@@ -44,16 +45,12 @@ const props = withDefaults(
     // both the match filter and the inserted result.
     query?: string;
     networkId?: number | null;
-    // The composer's current buffer target, so the channel you're in is
-    // offered first (matches the Tab-completion order in MessageInput).
-    activeTarget?: string | null;
     anchor?: HTMLElement | null;
   }>(),
   {
     open: false,
     query: '',
     networkId: null,
-    activeTarget: null,
     anchor: null,
   },
 );
@@ -64,16 +61,20 @@ const emit = defineEmits<{
 }>();
 
 const buffers = useBuffersStore();
+const recentBuffers = useRecentBuffersStore();
 
 const rows = computed<string[]>(() => {
   // Bail before touching the buffers store while closed so the candidate list
   // doesn't rebuild on every buffer mutation behind a closed picker. The
   // popover hides when closed anyway, so returning [] here is behavior-neutral.
-  if (!props.open || props.networkId == null) return [];
-  return buildChannelCandidates(
-    buffers.forNetwork(props.networkId),
-    props.query,
-    props.activeTarget,
+  const networkId = props.networkId;
+  if (!props.open || networkId == null) return [];
+  // Recency ordering (so the channel you're in leads) is read from the store
+  // here rather than passed in as a prop: the picker and MessageInput's
+  // Tab-completion have to agree on the order, and a prop the parent can forget
+  // to bind fails silently as a plausible alphabetical list.
+  return buildChannelCandidates(buffers.forNetwork(networkId), props.query, (target) =>
+    recentBuffers.rank(bufferKey(networkId, target)),
   ).slice(0, 50);
 });
 

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// Keystroke-level coverage of the composer's Tab-completion. This is the one
+// corner of the client where the logic is genuinely intricate — three selection
+// UIs (`@` picker, `#` picker, mobile strip), an in-place cycle, and a shared
+// session that has to survive a commit — and all of it only runs in response to
+// real key events, so a pure unit test of the candidate builders can't see it.
+// Two shipped bugs hid in exactly that gap: a picker prop nothing bound, and a
+// Tab cycle that dead-ended on the first match because the commit appended a
+// space that terminated the token.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { useNetworksStore } from '../stores/networks.js';
+import { useBuffersStore } from '../stores/buffers.js';
+import { useRecentBuffersStore } from '../stores/recentBuffers.js';
+import MessageInput from './MessageInput.vue';
+
+// The composer sends typing state / drafts over the socket as you type. There's
+// no socket in a test, and none of it is what we're exercising.
+vi.mock('../composables/useSocket.js', () => ({
+  socketSend: vi.fn<() => void>(),
+  socketSendWithAck: vi.fn<() => null>(() => null),
+  onSocketOpen: vi.fn<() => () => void>(() => () => {}),
+}));
+
+const CHANNELS = ['#apple', '#mango', '#zebra'];
+const MEMBERS = ['alice', 'alexis', 'bob', 'me'];
+
+function seedStores(activeTarget = '#zebra', recent: string[] = []) {
+  const networks = useNetworksStore();
+  const buffers = useBuffersStore();
+  const recentBuffers = useRecentBuffersStore();
+
+  networks.networks = [{ id: 1, name: 'testnet' }] as never;
+  networks.states = { 1: { nick: 'me' } } as never;
+
+  for (const target of CHANNELS) {
+    buffers.buffers[`1::${target}`] = {
+      networkId: 1,
+      target,
+      members: MEMBERS.map((nick) => ({ nick, modes: [], away: false })),
+      messages: [],
+    } as never;
+  }
+  networks.activeKey = `1::${activeTarget}`;
+  // The MRU trail the real store would have built from activeKey activations:
+  // most-recent first, and the buffer you're in is always at the front.
+  recentBuffers.keys = [`1::${activeTarget}`, ...recent.map((t) => `1::${t}`)];
+  return { networks, buffers, recentBuffers };
+}
+
+async function mountComposer() {
+  const wrapper = mount(MessageInput, { attachTo: document.body });
+  await flush();
+  const textarea = wrapper.find('textarea');
+  expect(textarea.exists()).toBe(true);
+  return { wrapper, textarea, el: textarea.element as HTMLTextAreaElement };
+}
+
+// Let Vue's render flush and applyCompletion's queueMicrotask (which parks the
+// caret and records it on the session) run before the next keystroke.
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+// Type `value` into the composer: set it, put the caret at the end, and fire the
+// input event v-model listens for — the same sequence a real keystroke produces.
+async function type(el: HTMLTextAreaElement, value: string) {
+  el.value = value;
+  el.setSelectionRange(value.length, value.length);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  await flush();
+}
+
+async function tab(el: HTMLTextAreaElement, opts: { shift?: boolean } = {}) {
+  el.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'Tab', shiftKey: !!opts.shift, bubbles: true }),
+  );
+  await flush();
+}
+
+describe('MessageInput Tab-completion', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('channels', () => {
+    it('offers the channel you are in first, not the alphabetical first', async () => {
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '#');
+      await tab(el);
+
+      // Alphabetically #apple would lead; recency puts the buffer you're in first.
+      expect(el.value).toBe('#zebra ');
+    });
+
+    it('cycles through the candidates on repeat Tab', async () => {
+      // The bug this whole file exists for: the commit appends a trailing space,
+      // so a second Tab found no token under the caret and dead-ended here.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '#');
+      await tab(el);
+      expect(el.value).toBe('#zebra ');
+
+      await tab(el);
+      expect(el.value).toBe('#apple ');
+
+      await tab(el);
+      expect(el.value).toBe('#mango ');
+
+      // …and wraps.
+      await tab(el);
+      expect(el.value).toBe('#zebra ');
+    });
+
+    it('walks backwards on Shift+Tab', async () => {
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '#');
+      await tab(el);
+      await tab(el, { shift: true });
+
+      expect(el.value).toBe('#mango ');
+    });
+
+    it('orders the cycle by recency, then alphabetically', async () => {
+      // In #zebra, was just in #mango; #apple is unvisited this session.
+      seedStores('#zebra', ['#mango']);
+      const { el } = await mountComposer();
+
+      await type(el, '#');
+      await tab(el);
+      expect(el.value).toBe('#zebra ');
+      await tab(el);
+      expect(el.value).toBe('#mango ');
+      await tab(el);
+      expect(el.value).toBe('#apple ');
+    });
+
+    it('completes mid-sentence without disturbing the surrounding text', async () => {
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, 'join #a');
+      await tab(el);
+
+      expect(el.value).toBe('join #apple ');
+      // Cycling replaces only the completed token — #apple is the sole match for
+      // the "#a" prefix, so it stays put rather than walking into #mango.
+      await tab(el);
+      expect(el.value).toBe('join #apple ');
+    });
+  });
+
+  describe('nicks', () => {
+    it('cycles nicks picked through the @ picker', async () => {
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, 'hey @al');
+      await tab(el);
+      expect(el.value).toBe('hey alexis ');
+
+      await tab(el);
+      expect(el.value).toBe('hey alice ');
+    });
+
+    it('keeps the addressing colon across a cycle at line start', async () => {
+      // A nick at line start is being addressed, so it gets ': ' — and every Tab
+      // in the cycle has to keep reproducing it. The suffix rides on the session
+      // for exactly this reason; re-deriving it per cycle dropped it.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '@al');
+      await tab(el);
+      expect(el.value).toBe('alexis: ');
+
+      await tab(el);
+      expect(el.value).toBe('alice: ');
+    });
+
+    it('never offers your own nick', async () => {
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '@m');
+      await tab(el);
+
+      expect(el.value).not.toContain('me');
+    });
+  });
+
+  describe('session staleness', () => {
+    it('does not rewrite the wrong span after the caret moves', async () => {
+      // A click or tap inside the textarea moves the caret with no keydown to
+      // reset the session. Applying it then would splice the pick in at the old
+      // prefix/tail offsets, mangling the text.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '#');
+      await tab(el);
+      expect(el.value).toBe('#zebra ');
+
+      // Caret jumps to the very start, as if clicked there. There's no token
+      // under it, so Tab has nothing to complete and must leave the text alone.
+      el.setSelectionRange(0, 0);
+      await tab(el);
+
+      expect(el.value).toBe('#zebra ');
+    });
+  });
+});

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -12,8 +12,8 @@
 // Tab cycle that dead-ended on the first match because the commit appended a
 // space that terminated the token.
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
@@ -29,7 +29,10 @@ vi.mock('../composables/useSocket.js', () => ({
 }));
 
 const CHANNELS = ['#apple', '#mango', '#zebra'];
-const MEMBERS = ['alice', 'alexis', 'bob', 'me'];
+// `mallory` exists so the self-exclusion test has a positive control: without a
+// second m-nick, "your own nick isn't offered" and "completion did nothing at
+// all" produce identical text and the assertion can't tell them apart.
+const MEMBERS = ['alice', 'alexis', 'bob', 'mallory', 'me'];
 
 function seedStores(activeTarget = '#zebra', recent: string[] = []) {
   const networks = useNetworksStore();
@@ -54,8 +57,15 @@ function seedStores(activeTarget = '#zebra', recent: string[] = []) {
   return { networks, buffers, recentBuffers };
 }
 
+// Mounted composers are torn down in afterEach: MessageInput's onMounted adds a
+// window listener and registers itself with setComposerOverlayHandlers — module
+// singletons — so a leaked mount would leave the *previous* test's composer
+// wired to the overlay handlers.
+let mounted: VueWrapper[] = [];
+
 async function mountComposer() {
   const wrapper = mount(MessageInput, { attachTo: document.body });
+  mounted.push(wrapper);
   await flush();
   const textarea = wrapper.find('textarea');
   expect(textarea.exists()).toBe(true);
@@ -87,6 +97,11 @@ async function tab(el: HTMLTextAreaElement, opts: { shift?: boolean } = {}) {
 describe('MessageInput Tab-completion', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    for (const wrapper of mounted) wrapper.unmount();
+    mounted = [];
   });
 
   describe('channels', () => {
@@ -191,13 +206,33 @@ describe('MessageInput Tab-completion', () => {
     });
 
     it('never offers your own nick', async () => {
+      // Both m-nicks match "@m"; only mallory may be offered. The positive half
+      // of this assertion matters as much as the negative one — with `me` as the
+      // sole m-nick, "self was correctly skipped" and "completion did nothing"
+      // would leave identical text.
       seedStores('#zebra');
       const { el } = await mountComposer();
 
       await type(el, '@m');
       await tab(el);
 
-      expect(el.value).not.toContain('me');
+      expect(el.value).toBe('mallory: ');
+    });
+
+    it('completes an @-token in place once the picker is dismissed', async () => {
+      // The picker owns Tab only while it's open. Escape closes it, and Tab then
+      // falls through to in-place completion — which used to match nothing,
+      // because it stripped the '#' sigil off channels but left the '@' on
+      // nicks, then asked for nicks beginning with '@'.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, 'hey @al');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      await flush();
+
+      await tab(el);
+      expect(el.value).toBe('hey alexis');
     });
   });
 

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -570,7 +570,6 @@ function endTypingTo(target: { networkId: number; target: string } | null | unde
 interface CompletionState {
   prefix: string;
   tail: string;
-  token: string;
   // What follows the pick: ': ' for a nick being addressed at line start, ' '
   // for a channel committed out of the ChannelPicker, '' otherwise. Stored on
   // the session rather than re-derived on each cycle so every Tab reproduces
@@ -744,19 +743,24 @@ function applyCompletion() {
 // the walk continues through exactly the list the user was just looking at —
 // and without that UI's display cap (50 rows in the popovers, 30 in the strip),
 // so a cycle can reach a candidate the list truncated.
-function commitCompletion(
-  start: number,
-  end: number,
-  pick: string,
-  suffix: string,
-  matches: string[],
-): void {
+// Named rather than positional: `start`/`end` and `pick`/`suffix` are adjacent
+// same-typed arguments, so a transposition would typecheck cleanly and only
+// show up as a garbled insertion at runtime.
+function commitCompletion(opts: {
+  // The span of `text` the pick replaces — the token under the cursor, sigil
+  // included ('@ali', '#ap').
+  start: number;
+  end: number;
+  pick: string;
+  suffix: string;
+  matches: string[];
+}): void {
+  const { start, end, pick, suffix, matches } = opts;
   const value = text.value;
   const found = matches.indexOf(pick);
   completion = {
     prefix: value.slice(0, start),
     tail: value.slice(end),
-    token: value.slice(start, end),
     suffix,
     // Fall back to the pick alone when it isn't in the rebuilt list (no network,
     // a member parting mid-keystroke): the insertion still lands, there's just
@@ -1179,7 +1183,12 @@ function onKeydown(e: KeyboardEvent): void {
   const networkId = active.value.networkId;
 
   const isChannel = token.startsWith('#');
-  const stripped = isChannel ? token.slice(1) : token;
+  // Strip the sigil off both forms. '#' is part of a channel name so it stays in
+  // the *result*, but neither sigil belongs in the *prefix* we match on: asking
+  // buildNickCandidates for nicks starting with '@' matches nothing, which is
+  // how `@ali`+Tab used to silently do nothing once the picker had been
+  // dismissed with Escape (the picker owns Tab only while it's open).
+  const stripped = isChannel || token.startsWith('@') ? token.slice(1) : token;
   const matches = isChannel
     ? buildChannelMatches(networkId, token)
     : buildNickMatches(buf, networkId, stripped);
@@ -1191,7 +1200,7 @@ function onKeydown(e: KeyboardEvent): void {
   // Channels never take one — the '#' is already part of the name.
   const suffix = !isChannel && isAtLineStart(prefix) ? ': ' : '';
 
-  completion = { prefix, tail, token, suffix, matches, index: 0, caret: 0 };
+  completion = { prefix, tail, suffix, matches, index: 0, caret: 0 };
   applyCompletion();
 }
 
@@ -1459,13 +1468,13 @@ function onPickerSelect(nick: string): void {
   const suffix = isAtLineStart(text.value.slice(0, pickerTokenStart)) ? ': ' : ' ';
   // pickerQuery is the token minus its '@' — the bare prefix buildNickMatches
   // expects. Read before commitCompletion, which closes the picker and clears it.
-  commitCompletion(
-    pickerTokenStart,
-    pickerTokenEnd,
-    nick,
+  commitCompletion({
+    start: pickerTokenStart,
+    end: pickerTokenEnd,
+    pick: nick,
     suffix,
-    buf && networkId != null ? buildNickMatches(buf, networkId, pickerQuery.value) : [],
-  );
+    matches: buf && networkId != null ? buildNickMatches(buf, networkId, pickerQuery.value) : [],
+  });
 }
 
 function onChannelPickerSelect(channel: string): void {
@@ -1479,13 +1488,13 @@ function onChannelPickerSelect(channel: string): void {
   // nicks' ': ', and the '#' is already part of the inserted name. The sent
   // `#channel` renders as a clickable join link for the recipient
   // (RenderSegments → openChannel), which is the whole point (issue #154).
-  commitCompletion(
-    channelPickerTokenStart,
-    channelPickerTokenEnd,
-    channel,
-    ' ',
-    networkId == null ? [] : buildChannelMatches(networkId, token),
-  );
+  commitCompletion({
+    start: channelPickerTokenStart,
+    end: channelPickerTokenEnd,
+    pick: channel,
+    suffix: ' ',
+    matches: networkId == null ? [] : buildChannelMatches(networkId, token),
+  });
 }
 
 function onStripSelect(nick: string): void {
@@ -1502,13 +1511,13 @@ function onStripSelect(nick: string): void {
   // The strip is prefix-less: its token is the bare word under the cursor, which
   // is already the prefix buildNickMatches wants (no '@' to strip).
   const token = text.value.slice(stripTokenStart, stripTokenEnd);
-  commitCompletion(
-    stripTokenStart,
-    stripTokenEnd,
-    nick,
+  commitCompletion({
+    start: stripTokenStart,
+    end: stripTokenEnd,
+    pick: nick,
     suffix,
-    buf && networkId != null ? buildNickMatches(buf, networkId, token) : [],
-  );
+    matches: buf && networkId != null ? buildNickMatches(buf, networkId, token) : [],
+  });
 }
 
 // Reply action from the message list's action bar: prepend `nick: ` to the

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -566,10 +566,19 @@ interface CompletionState {
   prefix: string;
   tail: string;
   token: string;
-  isChannel: boolean;
-  atLineStart: boolean;
+  // What follows the pick: ': ' for a nick being addressed at line start, ' '
+  // for a channel committed out of the ChannelPicker, '' otherwise. Stored on
+  // the session rather than re-derived on each cycle so every Tab reproduces
+  // the same shape of insertion the first one made — the picker commits with a
+  // trailing space, in-place completion doesn't, and a cycle seeded from the
+  // picker has to keep the space it already put there.
+  suffix: string;
   matches: string[];
   index: number;
+  // Caret position after the last insertion, used to detect a session the user
+  // has since abandoned: if the caret has moved somewhere we didn't put it
+  // (a click, a tap), the prefix/tail offsets no longer describe the text and
+  // the session must not be applied.
   caret: number;
 }
 let completion: CompletionState | null = null;
@@ -696,7 +705,7 @@ function buildChannelMatches(networkId: number, prefix: string): string[] {
 function applyCompletion() {
   if (!completion || !completion.matches.length) return;
   const pick = completion.matches[completion.index];
-  const suffix = completion.atLineStart && !completion.isChannel ? ': ' : '';
+  const suffix = completion.suffix;
   // Tab-completion owns the input now; any open @-picker or mobile suggestion
   // strip would be stale (cycling suppresses onInput → refreshPicker doesn't
   // fire, so they wouldn't close on their own).
@@ -1097,6 +1106,14 @@ function onKeydown(e: KeyboardEvent): void {
   const el = inputEl.value;
   if (!el) return;
 
+  // A live session cycles — but only if the caret is still where the last
+  // insertion left it. A click or tap inside the textarea moves the caret
+  // without any keydown we'd see, which would leave prefix/tail pointing at
+  // offsets that no longer describe the text; applying the session then would
+  // rewrite the wrong span. Drop it and start a fresh completion from whatever
+  // token is under the cursor now.
+  if (completion && (el.selectionStart ?? -1) !== completion.caret) resetCompletion();
+
   if (completion) {
     const dir = e.shiftKey ? -1 : 1;
     const n = completion.matches.length;
@@ -1124,9 +1141,11 @@ function onKeydown(e: KeyboardEvent): void {
 
   const prefix = value.slice(0, start);
   const tail = value.slice(end);
-  const atLineStart = isAtLineStart(prefix);
+  // A nick at line start is being *addressed* and wants an opening ': '.
+  // Channels never take one — the '#' is already part of the name.
+  const suffix = !isChannel && isAtLineStart(prefix) ? ': ' : '';
 
-  completion = { prefix, tail, token, isChannel, atLineStart, matches, index: 0, caret: 0 };
+  completion = { prefix, tail, token, suffix, matches, index: 0, caret: 0 };
   applyCompletion();
 }
 
@@ -1410,23 +1429,41 @@ function onChannelPickerSelect(channel: string): void {
     closeChannelPicker();
     return;
   }
-  const before = value.slice(0, channelPickerTokenStart);
-  const after = value.slice(channelPickerTokenEnd);
-  // Channels just get a trailing space — there's no "addressing" form like
-  // nicks' ': ', and the '#' is already part of the inserted name. The sent
-  // `#channel` renders as a clickable join link for the recipient
-  // (RenderSegments → openChannel), which is the whole point (issue #154).
-  cycling = true;
-  text.value = before + channel + ' ' + after;
-  cycling = false;
-  closeChannelPicker();
-  queueMicrotask(() => {
-    const el = inputEl.value;
-    if (!el) return;
-    const caret = before.length + channel.length + 1;
-    el.focus();
-    el.setSelectionRange(caret, caret);
-  });
+  const token = value.slice(channelPickerTokenStart, channelPickerTokenEnd);
+  const networkId = active.value?.networkId;
+  // Commit through a Tab-completion session rather than a one-shot insert, so a
+  // repeat Tab keeps cycling. Confirming closes the picker and the insertion
+  // ends in a space, so the next Tab would find no token under the caret
+  // (tokenAtCursor stops at whitespace) and dead-end on the first match — `#`+Tab
+  // could never walk past it. The session carries the candidate list forward,
+  // so the walk continues through the very list the user was just looking at.
+  //
+  // Rebuilding the matches here rather than plumbing the picker's rows out is
+  // deliberate: same builder, same store, same order — but without the picker's
+  // 50-row display cap, so a cycle can reach a channel the popover truncated.
+  const matches = networkId == null ? [] : buildChannelMatches(networkId, token);
+  const index = matches.indexOf(channel);
+  completion = {
+    prefix: value.slice(0, channelPickerTokenStart),
+    tail: value.slice(channelPickerTokenEnd),
+    token,
+    // Channels just get a trailing space — there's no "addressing" form like
+    // nicks' ': ', and the '#' is already part of the inserted name. The sent
+    // `#channel` renders as a clickable join link for the recipient
+    // (RenderSegments → openChannel), which is the whole point (issue #154).
+    suffix: ' ',
+    // Fall back to the confirmed channel alone if it somehow isn't in the
+    // rebuilt list (an empty networkId, a buffer parted mid-keystroke): the
+    // insertion still lands, there's just nothing to cycle through.
+    matches: index === -1 ? [channel] : matches,
+    index: index === -1 ? 0 : index,
+    caret: 0,
+  };
+  // A pointer-selected row leaves focus on the popover; applyCompletion only
+  // sets the caret, so take focus back first or setSelectionRange lands on a
+  // textarea the user isn't in.
+  inputEl.value?.focus();
+  applyCompletion(); // inserts, closes the picker, and parks the caret
 }
 
 function onStripSelect(nick: string): void {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -726,6 +726,47 @@ function applyCompletion() {
   });
 }
 
+// Commit a pick from one of the composer's selection UIs — the `@` nick picker,
+// the `#` channel picker, the mobile nick strip — as a Tab-completion session
+// rather than a one-shot insert, so a repeat Tab keeps cycling.
+//
+// Without the session a pick is a dead end: all three UIs close on select and
+// their insertion ends in a space, so the next Tab finds no token under the
+// caret (tokenAtCursor stops at whitespace) and returns early — Tab could never
+// walk past the first match.
+//
+// The caller rebuilds `matches` from the same builder its own list came from, so
+// the walk continues through exactly the list the user was just looking at —
+// and without that UI's display cap (50 rows in the popovers, 30 in the strip),
+// so a cycle can reach a candidate the list truncated.
+function commitCompletion(
+  start: number,
+  end: number,
+  pick: string,
+  suffix: string,
+  matches: string[],
+): void {
+  const value = text.value;
+  const found = matches.indexOf(pick);
+  completion = {
+    prefix: value.slice(0, start),
+    tail: value.slice(end),
+    token: value.slice(start, end),
+    suffix,
+    // Fall back to the pick alone when it isn't in the rebuilt list (no network,
+    // a member parting mid-keystroke): the insertion still lands, there's just
+    // nothing to cycle through.
+    matches: found === -1 ? [pick] : matches,
+    index: found === -1 ? 0 : found,
+    caret: 0,
+  };
+  // A pointer-selected row leaves focus on the popover/strip. applyCompletion
+  // only sets the caret, so take focus back first or setSelectionRange lands on
+  // a textarea the user isn't in.
+  inputEl.value?.focus();
+  applyCompletion(); // inserts, closes the open UIs, parks the caret
+}
+
 function resetCompletion() {
   completion = null;
 }
@@ -1398,97 +1439,71 @@ function refreshPicker() {
 }
 
 function onPickerSelect(nick: string): void {
-  const value = text.value;
   if (pickerTokenStart < 0) {
     closePicker();
     return;
   }
-  const before = value.slice(0, pickerTokenStart);
-  const after = value.slice(pickerTokenEnd);
-  // A nick at the start of a line is being addressed → ': '; mid-sentence
-  // gets a bare space. Identical to the mobile strip (onStripSelect). Tab-
+  const buf = buffer.value;
+  const networkId = active.value?.networkId;
+  // A nick at the start of a line is being addressed → ': '; mid-sentence gets
+  // a bare space. Identical to the mobile strip (onStripSelect). In-place Tab-
   // completion shares the isAtLineStart() check but appends nothing
-  // mid-sentence, since it cycles the completion in place.
-  const suffix = isAtLineStart(before) ? ': ' : ' ';
-  cycling = true;
-  text.value = before + nick + suffix + after;
-  cycling = false;
-  closePicker();
-  queueMicrotask(() => {
-    const el = inputEl.value;
-    if (!el) return;
-    const caret = before.length + nick.length + suffix.length;
-    el.focus();
-    el.setSelectionRange(caret, caret);
-  });
+  // mid-sentence — which is exactly why the suffix rides on the session instead
+  // of being re-derived on each cycle: a walk seeded from here has to keep
+  // reproducing the space the picker already inserted.
+  const suffix = isAtLineStart(text.value.slice(0, pickerTokenStart)) ? ': ' : ' ';
+  // pickerQuery is the token minus its '@' — the bare prefix buildNickMatches
+  // expects. Read before commitCompletion, which closes the picker and clears it.
+  commitCompletion(
+    pickerTokenStart,
+    pickerTokenEnd,
+    nick,
+    suffix,
+    buf && networkId != null ? buildNickMatches(buf, networkId, pickerQuery.value) : [],
+  );
 }
 
 function onChannelPickerSelect(channel: string): void {
-  const value = text.value;
   if (channelPickerTokenStart < 0) {
     closeChannelPicker();
     return;
   }
-  const token = value.slice(channelPickerTokenStart, channelPickerTokenEnd);
   const networkId = active.value?.networkId;
-  // Commit through a Tab-completion session rather than a one-shot insert, so a
-  // repeat Tab keeps cycling. Confirming closes the picker and the insertion
-  // ends in a space, so the next Tab would find no token under the caret
-  // (tokenAtCursor stops at whitespace) and dead-end on the first match — `#`+Tab
-  // could never walk past it. The session carries the candidate list forward,
-  // so the walk continues through the very list the user was just looking at.
-  //
-  // Rebuilding the matches here rather than plumbing the picker's rows out is
-  // deliberate: same builder, same store, same order — but without the picker's
-  // 50-row display cap, so a cycle can reach a channel the popover truncated.
-  const matches = networkId == null ? [] : buildChannelMatches(networkId, token);
-  const index = matches.indexOf(channel);
-  completion = {
-    prefix: value.slice(0, channelPickerTokenStart),
-    tail: value.slice(channelPickerTokenEnd),
-    token,
-    // Channels just get a trailing space — there's no "addressing" form like
-    // nicks' ': ', and the '#' is already part of the inserted name. The sent
-    // `#channel` renders as a clickable join link for the recipient
-    // (RenderSegments → openChannel), which is the whole point (issue #154).
-    suffix: ' ',
-    // Fall back to the confirmed channel alone if it somehow isn't in the
-    // rebuilt list (an empty networkId, a buffer parted mid-keystroke): the
-    // insertion still lands, there's just nothing to cycle through.
-    matches: index === -1 ? [channel] : matches,
-    index: index === -1 ? 0 : index,
-    caret: 0,
-  };
-  // A pointer-selected row leaves focus on the popover; applyCompletion only
-  // sets the caret, so take focus back first or setSelectionRange lands on a
-  // textarea the user isn't in.
-  inputEl.value?.focus();
-  applyCompletion(); // inserts, closes the picker, and parks the caret
+  const token = text.value.slice(channelPickerTokenStart, channelPickerTokenEnd);
+  // Channels just get a trailing space — there's no "addressing" form like
+  // nicks' ': ', and the '#' is already part of the inserted name. The sent
+  // `#channel` renders as a clickable join link for the recipient
+  // (RenderSegments → openChannel), which is the whole point (issue #154).
+  commitCompletion(
+    channelPickerTokenStart,
+    channelPickerTokenEnd,
+    channel,
+    ' ',
+    networkId == null ? [] : buildChannelMatches(networkId, token),
+  );
 }
 
 function onStripSelect(nick: string): void {
-  const value = text.value;
   if (stripTokenStart < 0) {
     closeStrip();
     return;
   }
-  const before = value.slice(0, stripTokenStart);
-  const after = value.slice(stripTokenEnd);
+  const buf = buffer.value;
+  const networkId = active.value?.networkId;
   // A nick at the start of a line is being addressed → ': '; mid-sentence
   // gets a bare space (what the old @-menu was missing — task #198). Shares
   // isAtLineStart() with Tab-completion and the desktop picker.
-  const suffix = isAtLineStart(before) ? ': ' : ' ';
-  cycling = true;
-  text.value = before + nick + suffix + after;
-  cycling = false;
-  closeStrip();
-  queueMicrotask(() => {
-    const el = inputEl.value;
-    if (!el) return;
-    const caret = before.length + nick.length + suffix.length;
-    el.focus();
-    el.setSelectionRange(caret, caret);
-  });
+  const suffix = isAtLineStart(text.value.slice(0, stripTokenStart)) ? ': ' : ' ';
+  // The strip is prefix-less: its token is the bare word under the cursor, which
+  // is already the prefix buildNickMatches wants (no '@' to strip).
+  const token = text.value.slice(stripTokenStart, stripTokenEnd);
+  commitCompletion(
+    stripTokenStart,
+    stripTokenEnd,
+    nick,
+    suffix,
+    buf && networkId != null ? buildNickMatches(buf, networkId, token) : [],
+  );
 }
 
 // Reply action from the message list's action bar: prepend `nick: ` to the

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -682,7 +682,10 @@ function buildNickStripItems(buf: Buffer, networkId: number, prefix: string): Ni
 }
 
 function buildChannelMatches(networkId: number, prefix: string): string[] {
-  return buildChannelCandidates(buffers.forNetwork(networkId), prefix);
+  // Pass the active buffer's target so the channel you're currently in sorts
+  // first (standard IRC `#`+Tab behavior); a DM target is ignored by the
+  // builder, leaving the list alphabetical.
+  return buildChannelCandidates(buffers.forNetwork(networkId), prefix, active.value?.target);
 }
 
 function applyCompletion() {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -143,7 +143,8 @@ import { formatColumns } from '../lib/commands/output.js';
 import { REGISTRY, getOption, optionVisible, CATEGORIES } from '../utils/settingsRegistry.js';
 import type { SettingOption } from '../../../shared/settingsRegistry.js';
 import { useConfigStore } from '../stores/config.js';
-import { useBuffersStore } from '../stores/buffers.js';
+import { bufferKey, useBuffersStore } from '../stores/buffers.js';
+import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
 import { useDraftStore } from '../stores/drafts.js';
@@ -205,6 +206,7 @@ import type { Buffer } from '../stores/buffers.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
+const recentBuffers = useRecentBuffersStore();
 const auth = useAuthStore();
 const inputHistory = useInputHistoryStore();
 const drafts = useDraftStore();
@@ -681,11 +683,14 @@ function buildNickStripItems(buf: Buffer, networkId: number, prefix: string): Ni
     .map((c) => ({ nick: c.nick, color: nickColors.color(c.nick) }));
 }
 
+// Same recency ordering the ChannelPicker uses, so in-place Tab-completion and
+// the popover can't disagree about which channel leads. The buffer you're in is
+// rank 0, so `#`+Tab offers the current channel first (standard IRC behavior)
+// and repeat-Tab walks back through recently-visited channels.
 function buildChannelMatches(networkId: number, prefix: string): string[] {
-  // Pass the active buffer's target so the channel you're currently in sorts
-  // first (standard IRC `#`+Tab behavior); a DM target is ignored by the
-  // builder, leaving the list alphabetical.
-  return buildChannelCandidates(buffers.forNetwork(networkId), prefix, active.value?.target);
+  return buildChannelCandidates(buffers.forNetwork(networkId), prefix, (target) =>
+    recentBuffers.rank(bufferKey(networkId, target)),
+  );
 }
 
 function applyCompletion() {

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -40,7 +40,13 @@ function nextHistoryToken() {
 // (forNetwork, the sidebar) — skip them. Network buffers keep the
 // `${networkId}::${target}` form. networkId == null is what makes a buffer
 // app-scoped; there is no magic network value.
-function key(networkId: number | string | null, target: string) {
+// Exported because it is also the format networks.activeKey holds, and so the
+// format the navHistory/recentBuffers stores key their trails by: anything
+// ranking a buffer against those trails has to derive the same string from a
+// (networkId, target) pair. activate() canonicalizes casing before setActive(),
+// so a key built from a stored buffer's `target` always matches the activeKey
+// recorded for it.
+export function bufferKey(networkId: number | string | null, target: string) {
   return networkId == null ? target : `${networkId}::${target}`;
 }
 
@@ -56,7 +62,7 @@ function resolveExistingKey(
   networkId: number | string | null,
   target: string,
 ): string | null {
-  const exact = key(networkId, target);
+  const exact = bufferKey(networkId, target);
   if (buffers[exact]) return exact;
   if (target.startsWith(':')) return null;
   const nid = Number(networkId);
@@ -253,7 +259,7 @@ function ensureBuffer(
   // then under the target's own casing, so the first writer's case is canonical.
   const existing = resolveExistingKey(state.buffers, networkId, target);
   if (existing) return state.buffers[existing];
-  const k = key(networkId, target);
+  const k = bufferKey(networkId, target);
   state.buffers[k] = makeBuffer(networkId, target);
   return state.buffers[k];
 }
@@ -353,7 +359,7 @@ export const useBuffersStore = defineStore('buffers', {
       // Active-divider tracking + live mark-read. Applies to the system buffer
       // too (#355): it's now a normal buffer with a server-owned read pointer
       // (buffer_reads, null networkId), so a live line marks read the same way —
-      // key() folds the null networkId to the bare :system: key, and the
+      // bufferKey() folds the null networkId to the bare :system: key, and the
       // mark-read below rides through with networkId null.
       if (event.id != null) {
         const networks = useNetworksStore();
@@ -362,7 +368,7 @@ export const useBuffersStore = defineStore('buffers', {
         // `bob` while the user sits in the `Bob` buffer reads as inactive and
         // the divider/read-sync below silently skips (#327). Mirrors the same
         // resolve-then-compare applyReadState does.
-        const isActive = networks.activeKey === key(buf.networkId, buf.target);
+        const isActive = networks.activeKey === bufferKey(buf.networkId, buf.target);
         if (isActive) {
           // While the user is sitting in this buffer, keep the divider
           // tracking the bottom UNLESS there's already an unread boundary
@@ -696,7 +702,7 @@ export const useBuffersStore = defineStore('buffers', {
       target: string,
       { wipeMessages = false } = {},
     ) {
-      const buf = this.buffers[key(networkId, target)];
+      const buf = this.buffers[bufferKey(networkId, target)];
       if (!buf || !buf.detached) return;
       buf.detached = false;
       buf.liveDuringDetach = 0;
@@ -932,9 +938,9 @@ export const useBuffersStore = defineStore('buffers', {
       const networks = useNetworksStore();
       // Compare against the resolved buffer's canonical key, not the (possibly
       // differently-cased) broadcast target, so badge suppression tracks the
-      // buffer the user is actually sitting in. key() also yields the bare
+      // buffer the user is actually sitting in. bufferKey() also yields the bare
       // sentinel for the app-scoped system buffer (networkId null).
-      const isActive = networks.activeKey === key(buf.networkId, buf.target);
+      const isActive = networks.activeKey === bufferKey(buf.networkId, buf.target);
       // Suppress the unread badge for the buffer the user is sitting in.
       // A read-state broadcast can briefly carry a non-zero unread for the
       // active buffer when an IRC event lands before the mark-read echo;
@@ -996,9 +1002,9 @@ export const useBuffersStore = defineStore('buffers', {
       // target when none is open yet (first writer's case becomes canonical).
       const existing = this.findByTarget(networkId, target);
       const canonTarget = existing ? existing.target : target;
-      // key() yields the bare sentinel for the app-scoped system buffer
+      // bufferKey() yields the bare sentinel for the app-scoped system buffer
       // (networkId null) and the usual `${networkId}::${target}` otherwise.
-      const newKey = key(networkId, canonTarget);
+      const newKey = bufferKey(networkId, canonTarget);
       const prevKey = networks.activeKey;
       if (prevKey && prevKey !== newKey) {
         const prev = this.buffers[prevKey];
@@ -1147,7 +1153,7 @@ export const useBuffersStore = defineStore('buffers', {
       buf.typing[canon] = { nick, state, expiresAt: Date.now() + duration, userhost };
 
       const timer = setTimeout(() => {
-        const b = this.buffers[key(networkId, tkTarget)];
+        const b = this.buffers[bufferKey(networkId, tkTarget)];
         if (b && b.typing[canon]) {
           delete b.typing[canon];
         }

--- a/vue_client/src/utils/channelCompletion.test.ts
+++ b/vue_client/src/utils/channelCompletion.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { buildChannelCandidates } from './channelCompletion.js';
+
+const bufs = (...targets: string[]) => targets.map((target) => ({ target }));
+
+describe('buildChannelCandidates', () => {
+  it('returns joined channels matching the prefix, alphabetically', () => {
+    expect(buildChannelCandidates(bufs('#zebra', '#apple', '#mango'), '#')).toEqual([
+      '#apple',
+      '#mango',
+      '#zebra',
+    ]);
+  });
+
+  it('filters case-insensitively on the prefix (# included)', () => {
+    expect(buildChannelCandidates(bufs('#Test', '#testing', '#other'), '#te')).toEqual([
+      '#Test',
+      '#testing',
+    ]);
+  });
+
+  it('excludes DM buffers and non-matching channels', () => {
+    expect(buildChannelCandidates(bufs('#chan', 'alice', ':server:1', '#chat'), '#cha')).toEqual([
+      '#chan',
+      '#chat',
+    ]);
+  });
+
+  it('hoists the active channel to the front when it matches', () => {
+    expect(buildChannelCandidates(bufs('#apple', '#mango', '#zebra'), '#', '#zebra')).toEqual([
+      '#zebra',
+      '#apple',
+      '#mango',
+    ]);
+  });
+
+  it('hoists case-insensitively', () => {
+    expect(buildChannelCandidates(bufs('#Apple', '#Mango'), '#', '#mango')).toEqual([
+      '#Mango',
+      '#Apple',
+    ]);
+  });
+
+  it('leaves ordering alphabetical when the active channel does not match the prefix', () => {
+    // Active is #zebra but the user is completing "#a" — #zebra isn't a
+    // candidate, so nothing to hoist.
+    expect(buildChannelCandidates(bufs('#apple', '#anchor'), '#a', '#zebra')).toEqual([
+      '#anchor',
+      '#apple',
+    ]);
+  });
+
+  it('ignores a DM (non-#) active target', () => {
+    expect(buildChannelCandidates(bufs('#apple', '#mango'), '#', 'alice')).toEqual([
+      '#apple',
+      '#mango',
+    ]);
+  });
+
+  it('is a no-op when the active channel is already first', () => {
+    expect(buildChannelCandidates(bufs('#apple', '#mango'), '#', '#apple')).toEqual([
+      '#apple',
+      '#mango',
+    ]);
+  });
+});

--- a/vue_client/src/utils/channelCompletion.test.ts
+++ b/vue_client/src/utils/channelCompletion.test.ts
@@ -6,9 +6,21 @@ import { buildChannelCandidates } from './channelCompletion.js';
 
 const bufs = (...targets: string[]) => targets.map((target) => ({ target }));
 
+// Stands in for the recentBuffers store's `rank` getter composed with
+// bufferKey(). Mirrors recencyRank's contract: 0 = most recent … Infinity =
+// unvisited this session.
+const rank =
+  (...recent: string[]) =>
+  (target: string) => {
+    const i = recent.indexOf(target);
+    return i === -1 ? Infinity : i;
+  };
+
+const unvisited = rank();
+
 describe('buildChannelCandidates', () => {
-  it('returns joined channels matching the prefix, alphabetically', () => {
-    expect(buildChannelCandidates(bufs('#zebra', '#apple', '#mango'), '#')).toEqual([
+  it('returns joined channels matching the prefix', () => {
+    expect(buildChannelCandidates(bufs('#zebra', '#apple', '#mango'), '#', unvisited)).toEqual([
       '#apple',
       '#mango',
       '#zebra',
@@ -16,53 +28,74 @@ describe('buildChannelCandidates', () => {
   });
 
   it('filters case-insensitively on the prefix (# included)', () => {
-    expect(buildChannelCandidates(bufs('#Test', '#testing', '#other'), '#te')).toEqual([
+    expect(buildChannelCandidates(bufs('#Test', '#testing', '#other'), '#te', unvisited)).toEqual([
       '#Test',
       '#testing',
     ]);
   });
 
   it('excludes DM buffers and non-matching channels', () => {
-    expect(buildChannelCandidates(bufs('#chan', 'alice', ':server:1', '#chat'), '#cha')).toEqual([
-      '#chan',
-      '#chat',
-    ]);
+    expect(
+      buildChannelCandidates(bufs('#chan', 'alice', ':server:1', '#chat'), '#cha', unvisited),
+    ).toEqual(['#chan', '#chat']);
   });
 
-  it('hoists the active channel to the front when it matches', () => {
-    expect(buildChannelCandidates(bufs('#apple', '#mango', '#zebra'), '#', '#zebra')).toEqual([
-      '#zebra',
-      '#apple',
-      '#mango',
-    ]);
+  it('offers the channel you are in first — it is always rank 0', () => {
+    // recentBuffers move-to-fronts on every activation, so the buffer you're in
+    // is the most recent one. This is the `#`+Tab headline behavior, and it
+    // beats the alphabetical order it displaces (#zebra sorts last).
+    expect(buildChannelCandidates(bufs('#apple', '#mango', '#zebra'), '#', rank('#zebra'))).toEqual(
+      ['#zebra', '#apple', '#mango'],
+    );
   });
 
-  it('hoists case-insensitively', () => {
-    expect(buildChannelCandidates(bufs('#Apple', '#Mango'), '#', '#mango')).toEqual([
-      '#Mango',
-      '#Apple',
-    ]);
+  it('orders by recency, then alphabetically for never-visited channels', () => {
+    // #zebra is where you are, #mango where you just were; #anchor and #apple
+    // are unvisited this session and fall to the alphabetical tail. Repeat-Tab
+    // therefore walks your recent channels before anything else.
+    expect(
+      buildChannelCandidates(
+        bufs('#apple', '#anchor', '#mango', '#zebra'),
+        '#',
+        rank('#zebra', '#mango'),
+      ),
+    ).toEqual(['#zebra', '#mango', '#anchor', '#apple']);
   });
 
-  it('leaves ordering alphabetical when the active channel does not match the prefix', () => {
-    // Active is #zebra but the user is completing "#a" — #zebra isn't a
-    // candidate, so nothing to hoist.
-    expect(buildChannelCandidates(bufs('#apple', '#anchor'), '#a', '#zebra')).toEqual([
+  it('sorts an all-unvisited list alphabetically without NaN-corrupting', () => {
+    // Every rank here is Infinity, and Infinity - Infinity is NaN — a comparator
+    // that subtracted blindly would return a garbage, engine-defined order.
+    expect(
+      buildChannelCandidates(bufs('#delta', '#bravo', '#charlie', '#alpha'), '#', unvisited),
+    ).toEqual(['#alpha', '#bravo', '#charlie', '#delta']);
+  });
+
+  it('ignores recency for channels that do not match the prefix', () => {
+    // You're in #zebra but completing "#a" — #zebra isn't a candidate at all, so
+    // the matches stay alphabetical.
+    expect(buildChannelCandidates(bufs('#apple', '#anchor'), '#a', rank('#zebra'))).toEqual([
       '#anchor',
       '#apple',
     ]);
   });
 
-  it('ignores a DM (non-#) active target', () => {
-    expect(buildChannelCandidates(bufs('#apple', '#mango'), '#', 'alice')).toEqual([
+  it('is unaffected by a recently-visited DM', () => {
+    // Composing from a DM must not perturb channel order: a DM is never a
+    // candidate, so its rank is never consulted.
+    expect(buildChannelCandidates(bufs('#apple', '#mango'), '#', rank('alice'))).toEqual([
       '#apple',
       '#mango',
     ]);
   });
 
-  it('is a no-op when the active channel is already first', () => {
-    expect(buildChannelCandidates(bufs('#apple', '#mango'), '#', '#apple')).toEqual([
-      '#apple',
+  it('ranks the target verbatim, as stored on the buffer', () => {
+    // The caller composes rank with bufferKey() over the stored target, and
+    // activate() canonicalizes casing to that same stored target before
+    // recording it as activeKey — so both sides agree without folding. Guards a
+    // future caller against folding case on one side only, which would silently
+    // rank the active channel Infinity and lose the whole feature.
+    expect(buildChannelCandidates(bufs('#Apple', '#mango'), '#', rank('#Apple'))).toEqual([
+      '#Apple',
       '#mango',
     ]);
   });

--- a/vue_client/src/utils/channelCompletion.ts
+++ b/vue_client/src/utils/channelCompletion.ts
@@ -3,7 +3,9 @@
 
 // Shared candidate builder for channel completion — used by both Tab-completion
 // in MessageInput and the `#`-triggered ChannelPicker. Returns the targets of
-// joined channels matching `prefix` (case-insensitive), sorted alphabetically.
+// joined channels matching `prefix` (case-insensitive), sorted alphabetically,
+// except the channel you're currently in is hoisted to the front when it
+// matches (see `activeTarget`).
 //
 // `prefix` includes the leading '#' (it's the raw token under the cursor), and
 // the '#' stays in every result — unlike nicks' '@' sugar, '#' is part of the
@@ -20,10 +22,28 @@ interface ChannelBuffer {
   target?: string;
 }
 
-export function buildChannelCandidates(buffers: ChannelBuffer[], prefix: string): string[] {
+// `activeTarget` is the buffer the composer is in. When it's a channel that
+// also matches `prefix`, it's moved to the front so `#`+Tab offers the channel
+// you're currently in FIRST — the standard IRC-client behavior. The rest keep
+// their alphabetical order behind it. A nick target (a DM) or an unset value
+// leaves the list purely alphabetical.
+export function buildChannelCandidates(
+  buffers: ChannelBuffer[],
+  prefix: string,
+  activeTarget?: string | null,
+): string[] {
   const lower = prefix.toLowerCase();
-  return buffers
+  const matches = buffers
     .map((b) => b.target ?? '')
     .filter((t) => t.startsWith('#') && t.toLowerCase().startsWith(lower))
     .toSorted((a, b) => a.localeCompare(b));
+  if (activeTarget && activeTarget.startsWith('#')) {
+    const activeLower = activeTarget.toLowerCase();
+    const idx = matches.findIndex((t) => t.toLowerCase() === activeLower);
+    if (idx > 0) {
+      const [current] = matches.splice(idx, 1);
+      matches.unshift(current);
+    }
+  }
+  return matches;
 }

--- a/vue_client/src/utils/channelCompletion.ts
+++ b/vue_client/src/utils/channelCompletion.ts
@@ -47,14 +47,20 @@ export function buildChannelCandidates(
   rank: (target: string) => number,
 ): string[] {
   const lower = prefix.toLowerCase();
-  return buffers
-    .map((b) => b.target ?? '')
-    .filter((t) => t.startsWith('#') && t.toLowerCase().startsWith(lower))
-    .toSorted((a, b) => {
-      const ra = rank(a);
-      const rb = rank(b);
-      // Equality first: two unvisited channels are both Infinity, and
-      // Infinity - Infinity is NaN — which would silently corrupt the sort.
-      return ra === rb ? a.localeCompare(b) : ra - rb;
-    });
+  return (
+    buffers
+      .map((b) => b.target ?? '')
+      .filter((t) => t.startsWith('#') && t.toLowerCase().startsWith(lower))
+      // Rank each candidate once up front rather than inside the comparator: a
+      // rank lookup is a linear scan of the MRU trail, and a comparator would
+      // repeat it twice per comparison — on every keystroke, since the picker's
+      // row list is a computed that rebuilds as you type.
+      .map((target) => ({ target, rank: rank(target) }))
+      .toSorted((a, b) =>
+        // Equality first: two unvisited channels both rank Infinity, and
+        // Infinity - Infinity is NaN — which would silently corrupt the sort.
+        a.rank === b.rank ? a.target.localeCompare(b.target) : a.rank - b.rank,
+      )
+      .map((c) => c.target)
+  );
 }

--- a/vue_client/src/utils/channelCompletion.ts
+++ b/vue_client/src/utils/channelCompletion.ts
@@ -3,9 +3,8 @@
 
 // Shared candidate builder for channel completion — used by both Tab-completion
 // in MessageInput and the `#`-triggered ChannelPicker. Returns the targets of
-// joined channels matching `prefix` (case-insensitive), sorted alphabetically,
-// except the channel you're currently in is hoisted to the front when it
-// matches (see `activeTarget`).
+// joined channels matching `prefix` (case-insensitive), most-recently-visited
+// first, with never-visited channels alphabetical behind them.
 //
 // `prefix` includes the leading '#' (it's the raw token under the cursor), and
 // the '#' stays in every result — unlike nicks' '@' sugar, '#' is part of the
@@ -22,28 +21,40 @@ interface ChannelBuffer {
   target?: string;
 }
 
-// `activeTarget` is the buffer the composer is in. When it's a channel that
-// also matches `prefix`, it's moved to the front so `#`+Tab offers the channel
-// you're currently in FIRST — the standard IRC-client behavior. The rest keep
-// their alphabetical order behind it. A nick target (a DM) or an unset value
-// leaves the list purely alphabetical.
+// `rank` is recency: 0 = most recent … Infinity = unvisited this session — i.e.
+// the recentBuffers store's `rank` getter (#393), composed with bufferKey() by
+// the caller. Injected rather than imported so this stays Pinia-free and the
+// ordering edge cases are unit-testable in isolation.
+//
+// Ordering by recency gets the standard IRC `#`+Tab behavior for free:
+// recentBuffers move-to-fronts on every activation, so the channel you're
+// currently in is always rank 0 and therefore always offered first. Repeat-Tab
+// then walks back through the channels you were just in before reaching the
+// alphabetical tail — better than hoisting only the active channel and
+// alphabetizing the rest, where the second Tab hands you whatever sorts first
+// rather than where you actually were.
+//
+// The recency trail is in-memory and per-session, so on a cold load everything
+// except the buffer you land on is unvisited and this degrades to exactly
+// current-channel-first, then alphabetical.
+//
+// `rank` is required, not optional: a caller that forgets to pass an ordering
+// source produces a plausible-looking alphabetical list rather than any visible
+// failure, so it's worth a type error at the call site instead.
 export function buildChannelCandidates(
   buffers: ChannelBuffer[],
   prefix: string,
-  activeTarget?: string | null,
+  rank: (target: string) => number,
 ): string[] {
   const lower = prefix.toLowerCase();
-  const matches = buffers
+  return buffers
     .map((b) => b.target ?? '')
     .filter((t) => t.startsWith('#') && t.toLowerCase().startsWith(lower))
-    .toSorted((a, b) => a.localeCompare(b));
-  if (activeTarget && activeTarget.startsWith('#')) {
-    const activeLower = activeTarget.toLowerCase();
-    const idx = matches.findIndex((t) => t.toLowerCase() === activeLower);
-    if (idx > 0) {
-      const [current] = matches.splice(idx, 1);
-      matches.unshift(current);
-    }
-  }
-  return matches;
+    .toSorted((a, b) => {
+      const ra = rank(a);
+      const rb = rank(b);
+      // Equality first: two unvisited channels are both Infinity, and
+      // Infinity - Infinity is NaN — which would silently corrupt the sort.
+      return ra === rb ? a.localeCompare(b) : ra - rb;
+    });
 }

--- a/vue_client/vitest.config.ts
+++ b/vue_client/vitest.config.ts
@@ -22,7 +22,10 @@ export default defineConfig({
   plugins: [vue()],
   test: {
     name: 'client',
-    include: ['src/**/*.test.ts'],
+    // Catch-all under src/, not a list of the directories that hold tests today:
+    // a file outside the pattern isn't skipped, it's never collected, and the
+    // run still passes.
+    include: ['src/**/*.{test,spec}.ts'],
     // Node stays the default — the store and pure-util suites are the bulk of
     // this project and don't want a DOM. Component tests opt in per-file with a
     // `// @vitest-environment happy-dom` docblock.

--- a/vue_client/vitest.config.ts
+++ b/vue_client/vitest.config.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { defineConfig } from 'vitest/config';
+import vue from '@vitejs/plugin-vue';
+
+// The client's test project. Separate from vite.config.ts (the dev-server/build
+// config, which carries mkcert and proxy settings tests have no use for) and
+// from the root config, which owns the server suite.
+//
+// It has to live here, not at the root: vue_client is its own npm package with
+// its own node_modules, so `vue` and @vitejs/plugin-vue only resolve from inside
+// it. Running the client suite as a root-level project would either fail to
+// resolve the SFC compiler or load a second copy of Vue.
+//
+// This is what was missing. Until component tests existed every client test was
+// plain TS — stores, pure utils — so nothing imported a .vue file and nobody
+// noticed the SFC compiler was never wired into the test run. That's the gap two
+// Tab-completion bugs shipped through: neither was reachable from a unit test of
+// the candidate builders, because both only manifested in response to a key event.
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    name: 'client',
+    include: ['src/**/*.test.ts'],
+    // Node stays the default — the store and pure-util suites are the bulk of
+    // this project and don't want a DOM. Component tests opt in per-file with a
+    // `// @vitest-environment happy-dom` docblock.
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Two things, both in the composer's completion machinery. Taken over from @JawshTheDark's original PR with his OK — his commit is preserved underneath.

## 1. Channel completion is ordered by recency

`#`+Tab and the `#` picker now offer the channel **you're currently in** first, then the channels you were recently in, then everything else alphabetically.

The original added an `activeTarget` prop to `ChannelPicker.vue` but nothing passed it, so it always defaulted to `null`. That's worse than a normal dead prop: `refreshPicker` opens the channel picker as soon as a `#` token is typed, and while that picker is open with candidates, `MessageInput`'s keydown handler defers Tab to its `confirmActive()`. So the exact `#`+Tab path the feature targets went through the one call site that never received the ordering. The unit tests passed and nothing changed on screen.

Rather than bind the missing prop, this removes it. Both call sites read the ordering from the store directly, and `buildChannelCandidates` takes `rank` as a **required** argument — a call site that forgets it is now a compile error (`TS2554`), not a plausible-looking alphabetical list. Verified by removing it: `vue-tsc` fails.

Ordering comes from the `recentBuffers` MRU rank (#393). That store move-to-fronts on every activation, so the buffer you're in is always rank 0 — "current channel first" falls out for free, and repeat-Tab walks back through the channels you were just in. The trail is per-session, so a cold load degrades to exactly current-channel-first, then alphabetical.

`bufferKey()` is now exported from the buffers store — it's the format `networks.activeKey` (and so the recentBuffers trail) is keyed by. `activate()` canonicalizes target casing before recording, so a key built from a stored buffer's `target` always matches the recorded `activeKey`; no folding needed on the lookup, and a test pins that.

## 2. Repeat Tab now actually cycles

It never did — not on this branch, not on `main`. Every one of the three completion UIs (`@` nick picker, `#` channel picker, mobile nick strip) closes on select and inserts a **trailing space**. The next Tab falls through to in-place completion, where `tokenAtCursor` walks back from the caret, stops at that space, and returns an empty token — so the handler returns early. The first Tab committed and terminated the token; there was nothing left to cycle. (Nicks partly hid this: completing a bare prefix skips the picker and cycles in place. A pick made *through* the `@` popup could never be walked past.)

All three select handlers were the same one-shot-insert shape, so they now share a `commitCompletion()` seam: it builds a Tab-completion session from the replaced span, the pick, its suffix, and the rebuilt candidate list, then delegates the insertion to `applyCompletion`. A repeat Tab advances through the same list the UI was just showing; Shift+Tab walks back. Each handler rebuilds matches from the same builder its own list came from, so the walk order matches what the user saw — and without the display caps (50 rows in the popovers, 30 in the strip), so a cycle can reach a candidate the list truncated.

The insertion suffix now rides on the session (`': '` for a nick addressed at line start, `' '` for a picker/strip commit, `''` for in-place mid-sentence) instead of being re-derived per cycle, so every Tab reproduces the shape of insertion the first one made rather than dropping the trailing space on the second press.

## 3. `CompletionState.caret` is wired up

It was written and never read — a staleness check that was scaffolded but never finished. A click or tap inside the textarea moves the caret with no keydown to reset the session, leaving `prefix`/`tail` describing offsets that no longer match the text; applying the session then rewrites the wrong span. That hole predates this branch on the Tab path, but seeding sessions from *pointer*-selected picker rows would have widened it. A session is now only applied if the caret is still where the last insertion left it.

## Notes

- Not addressed, pre-existing: the channel candidate filter only recognizes `#`, not `&`/`+`/`!` prefixes. Affects the picker and Tab-completion equally; separate issue if we care.
- The repo has no component-test harness (no `@vue/test-utils`/jsdom), so none of the composer's keystroke behavior is covered by tests — which is why both bugs here were invisible to CI and only turned up in manual QA. Worth its own issue.

`npm run check` and `npm test` (2138 tests) green.
