### PR TITLE
Uploads: user delete reaps real bytes on every driver that can (#541)

### DIFF
--- a/server/db/uploadHistory.ts
+++ b/server/db/uploadHistory.ts
@@ -39,6 +39,11 @@ export interface UploadListRow {
   // 1 once the control plane has moderated the upload away. The row stays so the
   // owner sees a tombstone, but its bytes are gone from storage.
   removed: number;
+  // Which configured uploader produced the row, and whether the driver handed
+  // back a delete handle — the API derives the row's `can_delete` from these
+  // (never shipping the ref itself to the client).
+  uploader_config_id: number | null;
+  has_ref: number;
 }
 
 /** Fields passed to insertUpload. */
@@ -98,7 +103,8 @@ export function listUploads(
       .prepare(
         `
       SELECT id, provider, url, filename, mime, byte_size, width, height, created_at,
-             thumbnail_url, removed, (thumbnail IS NOT NULL) AS has_thumbnail
+             thumbnail_url, removed, uploader_config_id,
+             (thumbnail IS NOT NULL) AS has_thumbnail, (ref IS NOT NULL) AS has_ref
       FROM upload_history
       WHERE user_id = ? AND id < ?
       ORDER BY id DESC
@@ -111,7 +117,8 @@ export function listUploads(
     .prepare(
       `
     SELECT id, provider, url, filename, mime, byte_size, width, height, created_at,
-           thumbnail_url, removed, (thumbnail IS NOT NULL) AS has_thumbnail
+           thumbnail_url, removed, uploader_config_id,
+           (thumbnail IS NOT NULL) AS has_thumbnail, (ref IS NOT NULL) AS has_ref
     FROM upload_history
     WHERE user_id = ?
     ORDER BY id DESC
@@ -140,12 +147,13 @@ export interface UploadReapRow {
   uploader_config_id: number | null;
   ref: string | null;
   provider: string;
+  removed: number;
 }
 
 export function getUploadForReap(userId: number, id: number): UploadReapRow | undefined {
   return db
     .prepare(
-      'SELECT uploader_config_id, ref, provider FROM upload_history WHERE user_id = ? AND id = ?',
+      'SELECT uploader_config_id, ref, provider, removed FROM upload_history WHERE user_id = ? AND id = ?',
     )
     .get(userId, Number(id)) as UploadReapRow | undefined;
 }

--- a/server/routes/localUploads.integration.test.ts
+++ b/server/routes/localUploads.integration.test.ts
@@ -62,16 +62,6 @@ afterAll(() => {
   ctx.cleanup();
 });
 
-// The byte reap is fire-and-forget (the DELETE responds before the async unlink
-// finishes), so poll for its effect rather than assume a single tick.
-async function waitUntil(fn: () => boolean, timeoutMs = 2000): Promise<void> {
-  const start = Date.now();
-  while (!fn()) {
-    if (Date.now() - start > timeoutMs) throw new Error('condition not met in time');
-    await new Promise((r) => setTimeout(r, 10));
-  }
-}
-
 describe('local uploader — full round trip', () => {
   it('uploads to disk, serves it back, and reaps bytes on delete', async () => {
     const up = await agent
@@ -99,10 +89,10 @@ describe('local uploader — full round trip', () => {
     expect(served.headers['x-content-type-options']).toBe('nosniff');
     expect(served.headers['content-type']).toMatch(/^image\//);
 
-    // Deleting the history row reaps the on-disk file (orphan reap).
+    // Delete destroys the bytes BEFORE dropping the row (decision 8), so by the
+    // time the response lands the file is gone from disk.
     const del = await agent.delete(`/api/uploads/${up.body.id}`);
     expect(del.status).toBe(200);
-    await waitUntil(() => !fs.existsSync(local.resolveDiskPath(key)));
     expect(fs.existsSync(local.resolveDiskPath(key))).toBe(false);
   });
 });

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -64,16 +64,6 @@ vi.mock('../services/uploadProviders/index.js', () => ({
   }),
 }));
 
-// The byte reap is fire-and-forget (DELETE responds before the async unlink), so
-// poll for its effect rather than assume a single tick has run it.
-async function waitUntil(fn: () => boolean, timeoutMs = 2000): Promise<void> {
-  const start = Date.now();
-  while (!fn()) {
-    if (Date.now() - start > timeoutMs) throw new Error('condition not met in time');
-    await new Promise((r) => setTimeout(r, 10));
-  }
-}
-
 let app: Express;
 let agent: LurkerTestAgent;
 let user: User;
@@ -283,7 +273,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
     }
   });
 
-  it('reaps the on-disk bytes via driver.delete when a deletable upload is removed', async () => {
+  it('destroys the bytes via driver.delete before removing a deletable upload', async () => {
     stub.capabilities.storesRemotely = false;
     stub.capabilities.supportsDelete = true;
     stub.nextResult = { url: '/uploads/local/112233445566.png', ref: '112233445566.png' };
@@ -293,12 +283,14 @@ describe('local-style (storesRemotely:false) uploads', () => {
         .post('/api/uploads')
         .attach('image', smallPng, { filename: 'reap.png', contentType: 'image/png' });
       expect(up.status).toBe(200);
+      expect(up.body.can_delete).toBe(true);
 
       const del = await agent.delete(`/api/uploads/${up.body.id}`);
       expect(del.status).toBe(200);
-      // The reap is fire-and-forget; poll until it runs rather than assume a tick.
-      await waitUntil(() => stub.capturedDeleteRef === '112233445566.png');
+      // Bytes-first: by the time the response lands, the driver has run.
       expect(stub.capturedDeleteRef).toBe('112233445566.png');
+      const list = await agent.get('/api/uploads');
+      expect(list.body.items.find((r: { id: number }) => r.id === up.body.id)).toBeFalsy();
     } finally {
       stub.capabilities.storesRemotely = true;
       stub.capabilities.supportsDelete = false;
@@ -306,9 +298,9 @@ describe('local-style (storesRemotely:false) uploads', () => {
     }
   });
 
-  it('does not call driver.delete for a non-deletable driver (even with a ref)', async () => {
-    // A ref is present, but supportsDelete is false → the reap must short-circuit
-    // and never unlink (external forwarders offer list-only removal).
+  it('refuses to delete when the driver cannot destroy the bytes (no fake delete)', async () => {
+    // A ref is present, but supportsDelete is false → there is no "remove the
+    // record but leave the file up" path; the request is refused and the row stays.
     stub.capabilities.storesRemotely = false;
     stub.nextResult = { url: '/uploads/local/778899aabbcc.png', ref: '778899aabbcc.png' };
     stub.capturedDeleteRef = null;
@@ -316,10 +308,12 @@ describe('local-style (storesRemotely:false) uploads', () => {
       const up = await agent
         .post('/api/uploads')
         .attach('image', smallPng, { filename: 'keep.png', contentType: 'image/png' });
+      expect(up.body.can_delete).toBe(false);
       const del = await agent.delete(`/api/uploads/${up.body.id}`);
-      expect(del.status).toBe(200);
-      await new Promise((r) => setImmediate(r));
+      expect(del.status).toBe(409);
       expect(stub.capturedDeleteRef).toBeNull();
+      const list = await agent.get('/api/uploads');
+      expect(list.body.items.find((r: { id: number }) => r.id === up.body.id)).toBeTruthy();
     } finally {
       stub.capabilities.storesRemotely = true;
       stub.nextResult = null;
@@ -345,18 +339,80 @@ describe('GET /api/uploads/:id/thumb', () => {
 });
 
 describe('DELETE /api/uploads/:id', () => {
-  it('removes an owned row', async () => {
+  it('409 for a row without a delete handle (no ref → never deletable)', async () => {
+    // The stub's default upload result carries no ref — like x0 or an anonymous
+    // catbox upload. Its row must refuse deletion and stay put.
     const upload = await agent
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'delete-me.png', contentType: 'image/png' });
+    expect(upload.body.can_delete).toBe(false);
     const del = await agent.delete(`/api/uploads/${upload.body.id}`);
-    expect(del.status).toBe(200);
+    expect(del.status).toBe(409);
     const list = await agent.get('/api/uploads');
-    expect(list.body.items.find((r: { id: number }) => r.id === upload.body.id)).toBeFalsy();
+    const row = list.body.items.find((r: { id: number }) => r.id === upload.body.id);
+    expect(row).toBeTruthy();
+    expect(row.can_delete).toBe(false);
   });
 
   it("404 for a row that doesn't exist", async () => {
     const res = await agent.delete('/api/uploads/999999');
     expect(res.status).toBe(404);
+  });
+
+  it('keeps the row and surfaces the failure when the driver delete throws', async () => {
+    stub.capabilities.supportsDelete = true;
+    stub.nextResult = { url: 'https://stub.example/fail.png', ref: 'fail.png' };
+    try {
+      const up = await agent
+        .post('/api/uploads')
+        .attach('image', smallPng, { filename: 'fail.png', contentType: 'image/png' });
+      expect(up.body.can_delete).toBe(true);
+
+      const origDelete = stub.delete;
+      stub.delete = async () => {
+        throw Object.assign(new Error('upstream down'), { code: 'PROVIDER_ERROR' });
+      };
+      try {
+        const del = await agent.delete(`/api/uploads/${up.body.id}`);
+        expect(del.status).toBe(502);
+      } finally {
+        stub.delete = origDelete;
+      }
+      // The bytes weren't destroyed, so the record must survive for a retry.
+      const list = await agent.get('/api/uploads');
+      const row = list.body.items.find((r: { id: number }) => r.id === up.body.id);
+      expect(row).toBeTruthy();
+      expect(row.can_delete).toBe(true);
+
+      // And the retry succeeds once the driver recovers.
+      const retry = await agent.delete(`/api/uploads/${up.body.id}`);
+      expect(retry.status).toBe(200);
+    } finally {
+      stub.capabilities.supportsDelete = false;
+      stub.nextResult = null;
+    }
+  });
+
+  it('maps a PROVIDER_AUTH delete failure to 401', async () => {
+    stub.capabilities.supportsDelete = true;
+    stub.nextResult = { url: 'https://stub.example/auth.png', ref: 'auth.png' };
+    try {
+      const up = await agent
+        .post('/api/uploads')
+        .attach('image', smallPng, { filename: 'auth.png', contentType: 'image/png' });
+      const origDelete = stub.delete;
+      stub.delete = async () => {
+        throw Object.assign(new Error('bad creds'), { code: 'PROVIDER_AUTH' });
+      };
+      try {
+        const del = await agent.delete(`/api/uploads/${up.body.id}`);
+        expect(del.status).toBe(401);
+      } finally {
+        stub.delete = origDelete;
+      }
+    } finally {
+      stub.capabilities.supportsDelete = false;
+      stub.nextResult = null;
+    }
   });
 });

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -151,13 +151,15 @@ describe('POST /api/uploads', () => {
     expect(res.status).toBe(200);
   });
 
-  it('maps PROVIDER_AUTH into 401', async () => {
+  it('maps PROVIDER_AUTH into 502 — provider auth is not session auth', async () => {
+    // A 401 here would trip the client's bounce-to-login handler and hard-reload
+    // the app over a bad *provider* credential while the Lurker session is fine.
     const err = Object.assign(new Error('bad creds'), { code: 'PROVIDER_AUTH' });
     stub.shouldThrow = err;
     const res = await agent
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'auth.png', contentType: 'image/png' });
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(502);
     stub.shouldThrow = null;
   });
 
@@ -393,7 +395,9 @@ describe('DELETE /api/uploads/:id', () => {
     }
   });
 
-  it('maps a PROVIDER_AUTH delete failure to 401', async () => {
+  it('maps a PROVIDER_AUTH delete failure to 502, never 401', async () => {
+    // 401 would make the client treat a revoked provider token as a dead Lurker
+    // session and reload to the login page mid-click.
     stub.capabilities.supportsDelete = true;
     stub.nextResult = { url: 'https://stub.example/auth.png', ref: 'auth.png' };
     try {
@@ -406,9 +410,38 @@ describe('DELETE /api/uploads/:id', () => {
       };
       try {
         const del = await agent.delete(`/api/uploads/${up.body.id}`);
-        expect(del.status).toBe(401);
+        expect(del.status).toBe(502);
       } finally {
         stub.delete = origDelete;
+      }
+    } finally {
+      stub.capabilities.supportsDelete = false;
+      stub.nextResult = null;
+    }
+  });
+
+  it('409s (and hides the button) when the config no longer satisfies canDeleteWith', async () => {
+    // catbox-shaped case: the row captured a ref while a userhash existed, but
+    // the config has since lost it. The row must not advertise can_delete and
+    // the route must refuse — a button that always errors is not offered.
+    stub.capabilities.supportsDelete = true;
+    stub.nextResult = { url: 'https://stub.example/hash.png', ref: 'hash.png' };
+    try {
+      const up = await agent
+        .post('/api/uploads')
+        .attach('image', smallPng, { filename: 'hash.png', contentType: 'image/png' });
+      expect(up.body.can_delete).toBe(true);
+
+      (stub as { canDeleteWith?: (c: Record<string, string>) => boolean }).canDeleteWith = () =>
+        false;
+      try {
+        const list = await agent.get('/api/uploads');
+        const row = list.body.items.find((r: { id: number }) => r.id === up.body.id);
+        expect(row.can_delete).toBe(false);
+        const del = await agent.delete(`/api/uploads/${up.body.id}`);
+        expect(del.status).toBe(409);
+      } finally {
+        delete (stub as { canDeleteWith?: unknown }).canDeleteWith;
       }
     } finally {
       stub.capabilities.supportsDelete = false;

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -8,8 +8,9 @@ import { requireAuth } from '../middleware/auth.js';
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from '../services/settingsRegistry.js';
 import * as imagePipeline from '../services/imagePipeline.js';
-import { driverIds } from '../services/uploadProviders/index.js';
+import { driverIds, getDriver } from '../services/uploadProviders/index.js';
 import type { ContentClass } from '../services/uploadProviders/index.js';
+import { getUploaderConfig } from '../db/uploaderConfig.js';
 import {
   resolveUploader,
   loadDriverForRef,
@@ -288,27 +289,60 @@ router.post(
         height: outHeight,
       });
 
-      res.json({ id, url: mainUrl, ...(thumbnailUrl ? { thumbnail_url: thumbnailUrl } : {}) });
+      // Deletability is decided at capture time (decision 8): the driver returned
+      // a ref only if this specific upload's bytes can be destroyed later.
+      const canDelete = Boolean(
+        result.ref && resolved.driver.capabilities.supportsDelete && resolved.driver.delete,
+      );
+      res.json({
+        id,
+        url: mainUrl,
+        can_delete: canDelete,
+        ...(thumbnailUrl ? { thumbnail_url: thumbnailUrl } : {}),
+      });
     } catch (err) {
       next(err);
     }
   }),
 );
 
+// Can rows produced by this configured uploader have their bytes destroyed?
+// Memoized per request — a page of history rows references very few configs.
+function configDeletableCheck(): (configId: number | null) => boolean {
+  const memo = new Map<number, boolean>();
+  return (configId) => {
+    if (configId == null) return false;
+    let known = memo.get(configId);
+    if (known === undefined) {
+      const row = getUploaderConfig(configId);
+      const driver = row ? getDriver(row.driver) : null;
+      known = Boolean(driver && driver.capabilities.supportsDelete && driver.delete);
+      memo.set(configId, known);
+    }
+    return known;
+  };
+}
+
 router.get('/', (req: Request, res: Response) => {
   const before = req.query.before ? Number(req.query.before) : null;
   const limit = req.query.limit ? Number(req.query.limit) : 50;
   const rows: UploadListRow[] = listUploads(req.user!.id, { before, limit });
+  const configDeletable = configDeletableCheck();
   res.json({
     items: rows.map((r) => {
-      const { has_thumbnail, thumbnail_url, removed, ...rest } = r;
+      const { has_thumbnail, thumbnail_url, removed, uploader_config_id, has_ref, ...rest } = r;
       // A moderated-away upload keeps its row as a tombstone, but its bytes are
       // gone — advertise no thumbnail so the client renders the tombstone.
       if (removed) return { ...rest, removed: true };
+      // A row is deletable only when its bytes can actually be destroyed: the
+      // driver captured a delete handle at upload time AND its configured
+      // uploader still exists with a delete-capable driver. No ref (x0, anonymous
+      // catbox, pre-#541 rows) → the client never shows a delete button.
+      const can_delete = Boolean(has_ref) && configDeletable(uploader_config_id);
       // Prefer a remote CDN thumbnail; otherwise fall back to the local
       // BLOB-serving route when an inline thumbnail exists.
       const thumb = thumbnail_url || (has_thumbnail ? `/api/uploads/${r.id}/thumb` : null);
-      return thumb ? { ...rest, thumbnail_url: thumb } : rest;
+      return { ...rest, can_delete, ...(thumb ? { thumbnail_url: thumb } : {}) };
     }),
     providers: driverIds,
   });
@@ -327,34 +361,42 @@ router.get('/:id/thumb', (req: Request, res: Response) => {
   res.send(row.thumbnail);
 });
 
-router.delete('/:id', (req: Request, res: Response) => {
-  const id = Number(req.params.id);
-  // Capture the delete handle before dropping the row so we can reap the bytes
-  // for drivers that own their storage (local disk). Ownership is enforced by the
-  // user-scoped lookup — a caller can only reap their own upload.
-  const reap = getUploadForReap(req.user!.id, id);
-  const ok = deleteUpload(req.user!.id, id);
-  if (!ok) {
-    res.status(404).json({ error: 'not found' });
-    return;
-  }
-  // Best-effort, fire-and-forget: a failed unlink leaves an orphan file but must
-  // never fail the user's delete or block the response. Non-owning drivers
-  // (x0/catbox/hoarder) don't advertise delete, so this is a no-op for them.
-  if (reap && reap.ref && reap.uploader_config_id != null) {
-    void reapUploadBytes(reap.uploader_config_id, reap.ref);
-  }
-  res.json({ ok: true });
-});
-
-async function reapUploadBytes(configId: number, ref: string): Promise<void> {
-  try {
-    const loaded = loadDriverForRef(configId);
-    if (!loaded || !loaded.driver.capabilities.supportsDelete || !loaded.driver.delete) return;
-    await loaded.driver.delete(ref, loaded.driverConfig);
-  } catch (err) {
-    console.error('[lurker] upload byte reap failed:', err);
-  }
-}
+// Delete = destroy the bytes, then drop the row (decision 8, revised). There is
+// deliberately NO "remove the record but leave the file up" path: rows whose
+// bytes can't be destroyed (no ref, driver can't delete, config gone, moderation
+// tombstone) are refused — the client never offered a button for them, so a
+// request for one is forged or stale. Bytes go first so a driver failure keeps
+// the row and the user can retry; drivers treat "already gone" as success.
+router.delete(
+  '/:id',
+  asyncHandler(async (req: Request, res: Response) => {
+    const id = Number(req.params.id);
+    // Ownership is enforced by the user-scoped lookup — a caller can only
+    // delete their own upload.
+    const row = getUploadForReap(req.user!.id, id);
+    if (!row) {
+      res.status(404).json({ error: 'not found' });
+      return;
+    }
+    const loaded =
+      row.ref && !row.removed && row.uploader_config_id != null
+        ? loadDriverForRef(row.uploader_config_id)
+        : null;
+    if (!loaded || !loaded.driver.capabilities.supportsDelete || !loaded.driver.delete) {
+      res.status(409).json({ error: 'this upload cannot be deleted' });
+      return;
+    }
+    try {
+      await loaded.driver.delete(row.ref!, loaded.driverConfig);
+    } catch (err) {
+      const e = err as { code?: string; message?: string };
+      const status = e.code === 'PROVIDER_AUTH' ? 401 : e.code === 'PROVIDER_CONFIG' ? 400 : 502;
+      res.status(status).json({ error: e.message || 'delete failed', provider: row.provider });
+      return;
+    }
+    deleteUpload(req.user!.id, id);
+    res.json({ ok: true });
+  }),
+);
 
 export default router;

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -8,12 +8,12 @@ import { requireAuth } from '../middleware/auth.js';
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from '../services/settingsRegistry.js';
 import * as imagePipeline from '../services/imagePipeline.js';
-import { driverIds, getDriver } from '../services/uploadProviders/index.js';
+import { driverIds } from '../services/uploadProviders/index.js';
 import type { ContentClass } from '../services/uploadProviders/index.js';
-import { getUploaderConfig } from '../db/uploaderConfig.js';
 import {
   resolveUploader,
   loadDriverForRef,
+  deletableWith,
   UploaderUnavailableError,
   UploaderNotConfiguredError,
   type ResolvedUploader,
@@ -89,6 +89,15 @@ function absolutizeUrl(url: string, storesRemotely: boolean, req: Request): stri
   }
   const base = (configured || requestOrigin(req)).replace(/\/+$/, '');
   return base ? base + url : url;
+}
+
+// Map a driver error onto an HTTP status. PROVIDER_AUTH deliberately does NOT
+// become 401: that's the provider rejecting the uploader's stored credential,
+// not the caller's Lurker session — and the client's api() treats any 401 as a
+// dead session and hard-reloads to the login page. Upstream failures of every
+// kind are 502; only a config the user can fix themselves is a 400.
+function providerErrorStatus(e: { code?: string }): number {
+  return e.code === 'PROVIDER_CONFIG' ? 400 : 502;
 }
 
 // multer needs configuring up-front, before we know the effective per-uploader
@@ -230,8 +239,7 @@ router.post(
         );
       } catch (err) {
         const e = err as { code?: string; message?: string };
-        const status = e.code === 'PROVIDER_AUTH' ? 401 : e.code === 'PROVIDER_CONFIG' ? 400 : 502;
-        res.status(status).json({ error: e.message, provider: resolved.driverId });
+        res.status(providerErrorStatus(e)).json({ error: e.message, provider: resolved.driverId });
         return;
       }
 
@@ -291,9 +299,8 @@ router.post(
 
       // Deletability is decided at capture time (decision 8): the driver returned
       // a ref only if this specific upload's bytes can be destroyed later.
-      const canDelete = Boolean(
-        result.ref && resolved.driver.capabilities.supportsDelete && resolved.driver.delete,
-      );
+      const canDelete =
+        Boolean(result.ref) && deletableWith(resolved.driver, resolved.driverConfig);
       res.json({
         id,
         url: mainUrl,
@@ -307,16 +314,17 @@ router.post(
 );
 
 // Can rows produced by this configured uploader have their bytes destroyed?
-// Memoized per request — a page of history rows references very few configs.
+// Same resolution the DELETE gate uses (loadDriverForRef → deletableWith), so
+// the list can never advertise a button the route would refuse. Memoized per
+// request — a page of history rows references very few configs.
 function configDeletableCheck(): (configId: number | null) => boolean {
   const memo = new Map<number, boolean>();
   return (configId) => {
     if (configId == null) return false;
     let known = memo.get(configId);
     if (known === undefined) {
-      const row = getUploaderConfig(configId);
-      const driver = row ? getDriver(row.driver) : null;
-      known = Boolean(driver && driver.capabilities.supportsDelete && driver.delete);
+      const loaded = loadDriverForRef(configId);
+      known = loaded != null && deletableWith(loaded.driver, loaded.driverConfig);
       memo.set(configId, known);
     }
     return known;
@@ -382,16 +390,17 @@ router.delete(
       row.ref && !row.removed && row.uploader_config_id != null
         ? loadDriverForRef(row.uploader_config_id)
         : null;
-    if (!loaded || !loaded.driver.capabilities.supportsDelete || !loaded.driver.delete) {
+    if (!loaded || !deletableWith(loaded.driver, loaded.driverConfig)) {
       res.status(409).json({ error: 'this upload cannot be deleted' });
       return;
     }
     try {
-      await loaded.driver.delete(row.ref!, loaded.driverConfig);
+      await loaded.driver.delete!(row.ref!, loaded.driverConfig);
     } catch (err) {
       const e = err as { code?: string; message?: string };
-      const status = e.code === 'PROVIDER_AUTH' ? 401 : e.code === 'PROVIDER_CONFIG' ? 400 : 502;
-      res.status(status).json({ error: e.message || 'delete failed', provider: row.provider });
+      res
+        .status(providerErrorStatus(e))
+        .json({ error: e.message || 'delete failed', provider: row.provider });
       return;
     }
     deleteUpload(req.user!.id, id);

--- a/server/services/uploadProviders/catbox.ts
+++ b/server/services/uploadProviders/catbox.ts
@@ -28,7 +28,11 @@ export const label = 'catbox.moe';
 export const capabilities: DriverCapabilities = {
   creatable: true,
   storesRemotely: true,
-  supportsDelete: false,
+  // Deletable only for uploads made with a userhash — upload() signals that per
+  // upload by returning a ref only when one was used. Anonymous uploads are
+  // permanently undeletable on catbox's side, so they carry no ref and the row
+  // never offers delete.
+  supportsDelete: true,
   mintsKeys: false,
   acceptsContentClasses: ['image', 'text'],
 };
@@ -91,5 +95,57 @@ export async function upload(
       code: 'PROVIDER_ERROR',
     });
   }
-  return { url: text };
+  // The delete handle is the served filename (the deletefiles API addresses
+  // files by name) — but only a userhash upload can ever be deleted, so an
+  // anonymous upload gets no ref and its row never offers delete.
+  const name = config.userhash ? text.split('/').pop() : undefined;
+  return { url: text, ...(name ? { ref: name } : {}) };
 }
+
+/** Delete a file by the served filename upload() captured. Catbox answers 200
+ *  with a plain-text body for both outcomes, so success is sniffed from the
+ *  text; "doesn't exist" counts as already-gone. Requires the userhash the
+ *  upload was made with — if the config no longer has one, the delete fails
+ *  loudly rather than pretending. */
+async function deleteFile(ref: string, config: { userhash?: string } = {}): Promise<void> {
+  if (!config.userhash) {
+    throw Object.assign(new Error('catbox delete requires the uploader’s userhash'), {
+      code: 'PROVIDER_CONFIG',
+    });
+  }
+  const { body, contentType } = buildMultipart([
+    { name: 'reqtype', value: 'deletefiles' },
+    { name: 'userhash', value: config.userhash },
+    { name: 'files', value: ref },
+  ]);
+
+  let resp;
+  try {
+    resp = await postBuffer(ENDPOINT, body, {
+      headers: {
+        'Content-Type': contentType,
+        'User-Agent': USER_AGENT,
+        Accept: '*/*',
+      },
+      timeoutMs: TIMEOUT_MS,
+    });
+  } catch (cause) {
+    const c = cause as NodeJS.ErrnoException;
+    const detail = c.code || c.message || 'unknown error';
+    throw Object.assign(new Error(`catbox delete failed: ${detail}`), {
+      code: 'PROVIDER_ERROR',
+      cause,
+    });
+  }
+
+  const text = (resp.text || '').trim();
+  // Already gone is the outcome the caller wanted.
+  if (/doesn'?t exist/i.test(text)) return;
+  if (resp.status < 200 || resp.status >= 300 || !/successful/i.test(text)) {
+    throw Object.assign(new Error(`catbox delete failed: ${text.slice(0, 200) || resp.status}`), {
+      code: 'PROVIDER_ERROR',
+    });
+  }
+}
+
+export { deleteFile as delete };

--- a/server/services/uploadProviders/catbox.ts
+++ b/server/services/uploadProviders/catbox.ts
@@ -102,11 +102,23 @@ export async function upload(
   return { url: text, ...(name ? { ref: name } : {}) };
 }
 
+// A row is only deletable while the config still holds a userhash — declared
+// here so the shared deletability predicate (and thus the client's trash
+// button) tracks the config instead of offering a button that must fail.
+export function canDeleteWith(config: Record<string, string>): boolean {
+  return Boolean(config.userhash);
+}
+
+const FILE_BASE = 'https://files.catbox.moe';
+
 /** Delete a file by the served filename upload() captured. Catbox answers 200
  *  with a plain-text body for both outcomes, so success is sniffed from the
- *  text; "doesn't exist" counts as already-gone. Requires the userhash the
- *  upload was made with — if the config no longer has one, the delete fails
- *  loudly rather than pretending. */
+ *  text. A "doesn't exist" reply is AMBIGUOUS: catbox says the same thing for a
+ *  genuinely-deleted file and for one the current userhash doesn't own (e.g.
+ *  the user swapped accounts since uploading) — and the second case must NOT
+ *  count as success, or we'd drop the record while the file stays live. So the
+ *  ambiguity is resolved by probing the public URL: gone → already deleted;
+ *  still served → refuse. */
 async function deleteFile(ref: string, config: { userhash?: string } = {}): Promise<void> {
   if (!config.userhash) {
     throw Object.assign(new Error('catbox delete requires the uploader’s userhash'), {
@@ -139,13 +151,25 @@ async function deleteFile(ref: string, config: { userhash?: string } = {}): Prom
   }
 
   const text = (resp.text || '').trim();
-  // Already gone is the outcome the caller wanted.
-  if (/doesn'?t exist/i.test(text)) return;
-  if (resp.status < 200 || resp.status >= 300 || !/successful/i.test(text)) {
-    throw Object.assign(new Error(`catbox delete failed: ${text.slice(0, 200) || resp.status}`), {
-      code: 'PROVIDER_ERROR',
+  if (resp.status >= 200 && resp.status < 300 && /successful/i.test(text)) return;
+
+  // Not a clean success — check whether the file is actually gone before
+  // failing. If the public URL 404s the delete already happened (out of band or
+  // on a lost prior attempt) and the caller may safely drop the record; any
+  // other outcome keeps the record.
+  try {
+    const probe = await fetch(`${FILE_BASE}/${encodeURIComponent(ref)}`, {
+      method: 'HEAD',
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(15_000),
     });
+    if (probe.status === 404 || probe.status === 410) return;
+  } catch {
+    // Probe failed → we can't prove the file is gone; fall through to the error.
   }
+  throw Object.assign(new Error(`catbox delete failed: ${text.slice(0, 200) || resp.status}`), {
+    code: 'PROVIDER_ERROR',
+  });
 }
 
 export { deleteFile as delete };

--- a/server/services/uploadProviders/chibisafe.ts
+++ b/server/services/uploadProviders/chibisafe.ts
@@ -17,7 +17,7 @@ export const label = 'Chibisafe';
 export const capabilities: DriverCapabilities = {
   creatable: true,
   storesRemotely: true,
-  supportsDelete: false,
+  supportsDelete: true,
   mintsKeys: false,
   acceptsContentClasses: ['image', 'text'],
   selfHostOnly: true,
@@ -79,5 +79,33 @@ export async function upload(
   if (!body || typeof body.url !== 'string' || !body.url) {
     throw Object.assign(new Error('chibisafe returned no url'), { code: 'PROVIDER_ERROR' });
   }
-  return { url: body.url as string };
+  // The uuid is the delete handle; an older server that omits it just makes the
+  // upload non-deletable (no ref).
+  const ref = typeof body.uuid === 'string' && body.uuid ? (body.uuid as string) : undefined;
+  return { url: body.url as string, ...(ref ? { ref } : {}) };
 }
+
+/** Delete a file by the uuid upload() captured. 404 = already gone = success. */
+async function deleteFile(
+  ref: string,
+  config: { url?: string; api_key?: string } = {},
+): Promise<void> {
+  if (!config.url || !config.api_key) {
+    throw Object.assign(new Error('chibisafe uploader is missing its url or api_key'), {
+      code: 'PROVIDER_CONFIG',
+    });
+  }
+  const base = config.url.replace(/\/+$/, '');
+  const resp = await fetch(`${base}/api/file/${encodeURIComponent(ref)}`, {
+    method: 'DELETE',
+    headers: { 'x-api-key': config.api_key, 'User-Agent': USER_AGENT },
+  });
+  if (!resp.ok && resp.status !== 404) {
+    const text = (await resp.text()).slice(0, 200);
+    throw Object.assign(new Error(`chibisafe delete failed: ${resp.status} ${text}`), {
+      code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
+    });
+  }
+}
+
+export { deleteFile as delete };

--- a/server/services/uploadProviders/chibisafe.ts
+++ b/server/services/uploadProviders/chibisafe.ts
@@ -99,6 +99,7 @@ async function deleteFile(
   const resp = await fetch(`${base}/api/file/${encodeURIComponent(ref)}`, {
     method: 'DELETE',
     headers: { 'x-api-key': config.api_key, 'User-Agent': USER_AGENT },
+    signal: AbortSignal.timeout(60_000),
   });
   if (!resp.ok && resp.status !== 404) {
     const text = (await resp.text()).slice(0, 200);

--- a/server/services/uploadProviders/resolve.ts
+++ b/server/services/uploadProviders/resolve.ts
@@ -131,10 +131,10 @@ function lockedButUnconfigured(
 
 /**
  * Load a driver + its decrypted, policy-stripped config by uploader_config id,
- * skipping the user/policy allow-set checks. Used by the delete path to reap the
- * stored bytes of an upload the user already owns (ownership was checked when the
- * history row was fetched). Returns null when the config row or its driver is
- * gone — the caller then just drops the history row without a byte reap.
+ * skipping the user/policy allow-set checks. Used by the delete path to destroy
+ * the stored bytes of an upload the user already owns (ownership was checked
+ * when the history row was fetched). Returns null when the config row or its
+ * driver is gone — such rows are simply not deletable.
  */
 export function loadDriverForRef(
   configId: number,
@@ -145,6 +145,20 @@ export function loadDriverForRef(
   if (!driver) return null;
   const { driverConfig } = splitPolicy(resolvedConfig(row));
   return { driver, driverConfig };
+}
+
+/**
+ * THE deletability predicate: can this driver, with this config, destroy stored
+ * bytes? Row-level deletability is this ∧ a captured ref. Every projection of
+ * "deletable" (POST response, GET list, the DELETE gate) goes through here so
+ * the client's trash button and the route's refusal can never disagree.
+ */
+export function deletableWith(driver: UploadDriver, driverConfig: Record<string, string>): boolean {
+  return (
+    driver.capabilities.supportsDelete &&
+    typeof driver.delete === 'function' &&
+    (driver.canDeleteWith ? driver.canDeleteWith(driverConfig) : true)
+  );
 }
 
 export function resolveUploader(input: ResolveInput): ResolvedUploader {

--- a/server/services/uploadProviders/s3.ts
+++ b/server/services/uploadProviders/s3.ts
@@ -30,7 +30,7 @@ export const label = 'S3 / R2';
 export const capabilities: DriverCapabilities = {
   creatable: true,
   storesRemotely: true,
-  supportsDelete: false,
+  supportsDelete: true,
   // WE construct the object key (unlike a remote host that names the file).
   mintsKeys: true,
   acceptsContentClasses: ['image', 'text', 'binary'],
@@ -135,35 +135,39 @@ export function buildObjectKey(
   return segments.join('/');
 }
 
-export interface SignedPut {
+export interface SignedRequest {
   url: string;
   headers: Record<string, string>;
 }
 
-/** Build a SigV4-signed PUT for one object. Pure given `now`, so tests can pin
- *  the clock and assert determinism. */
-export function signPutObject(
+/** Build a SigV4-signed request for one object. Pure given `now`, so tests can
+ *  pin the clock and assert determinism. PUT carries the payload plus the
+ *  cache/content headers a store may validate; DELETE signs an empty payload
+ *  and only the mandatory host/x-amz headers. */
+export function signObjectRequest(
   {
+    method,
     endpoint,
     bucket,
     key,
-    payload,
+    payload = Buffer.alloc(0),
     contentType,
     region,
     accessKeyId,
     secretAccessKey,
   }: {
+    method: 'PUT' | 'DELETE';
     endpoint: string;
     bucket: string;
     key: string;
-    payload: Buffer;
-    contentType: string;
+    payload?: Buffer;
+    contentType?: string;
     region: string;
     accessKeyId: string;
     secretAccessKey: string;
   },
   now: Date = new Date(),
-): SignedPut {
+): SignedRequest {
   const base = endpoint.replace(/\/+$/, '');
   const url = new URL(`${base}/${bucket}/${key}`);
   const host = url.host;
@@ -181,17 +185,19 @@ export function signPutObject(
   // may validate is signed — including cache-control, so a store can't reject it
   // as an unsigned x-amz-adjacent header surprise.
   const headers: Record<string, string> = {
-    'cache-control': 'public, max-age=31536000, immutable',
-    'content-type': contentType,
     host,
     'x-amz-content-sha256': payloadHash,
     'x-amz-date': amzDate,
   };
+  if (method === 'PUT') {
+    headers['cache-control'] = 'public, max-age=31536000, immutable';
+    headers['content-type'] = contentType || 'application/octet-stream';
+  }
   const signedHeaderNames = Object.keys(headers).sort();
   const canonicalHeaders = signedHeaderNames.map((h) => `${h}:${headers[h].trim()}\n`).join('');
   const signedHeaders = signedHeaderNames.join(';');
 
-  const canonicalRequest = ['PUT', path, '', canonicalHeaders, signedHeaders, payloadHash].join(
+  const canonicalRequest = [method, path, '', canonicalHeaders, signedHeaders, payloadHash].join(
     '\n',
   );
 
@@ -211,6 +217,23 @@ export function signPutObject(
     url: url.toString(),
     headers: { ...headers, authorization, 'User-Agent': USER_AGENT },
   };
+}
+
+/** Backwards-compatible PUT wrapper around signObjectRequest. */
+export function signPutObject(
+  params: {
+    endpoint: string;
+    bucket: string;
+    key: string;
+    payload: Buffer;
+    contentType: string;
+    region: string;
+    accessKeyId: string;
+    secretAccessKey: string;
+  },
+  now: Date = new Date(),
+): SignedRequest {
+  return signObjectRequest({ method: 'PUT', ...params }, now);
 }
 
 function requireField(config: Record<string, string>, field: string): string {
@@ -258,6 +281,37 @@ export async function upload(
       code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
     });
   }
-  // key is the delete handle if delete is ever added; harmless to surface now.
+  // key is the delete handle consumed by delete() below.
   return { url: `${publicBase.replace(/\/+$/, '')}/${key}`, ref: key };
 }
+
+/** Remove one object by its key (the ref upload() returned). S3 DeleteObject is
+ *  idempotent — deleting a key that's already gone returns 204 — so the
+ *  "already deleted counts as success" contract needs no special-casing here. */
+async function deleteObject(ref: string, config: Record<string, string> = {}): Promise<void> {
+  const endpoint = requireField(config, 'endpoint');
+  const bucket = requireField(config, 'bucket');
+  const accessKeyId = requireField(config, 'access_key_id');
+  const secretAccessKey = requireField(config, 'secret_access_key');
+  const region = (config.region || '').trim() || 'auto';
+
+  const signed = signObjectRequest({
+    method: 'DELETE',
+    endpoint,
+    bucket,
+    key: ref,
+    region,
+    accessKeyId,
+    secretAccessKey,
+  });
+
+  const resp = await fetch(signed.url, { method: 'DELETE', headers: signed.headers });
+  if (!resp.ok && resp.status !== 404) {
+    const text = (await resp.text()).slice(0, 200);
+    throw Object.assign(new Error(`s3 delete failed: ${resp.status} ${text}`), {
+      code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
+    });
+  }
+}
+
+export { deleteObject as delete };

--- a/server/services/uploadProviders/s3.ts
+++ b/server/services/uploadProviders/s3.ts
@@ -219,23 +219,6 @@ export function signObjectRequest(
   };
 }
 
-/** Backwards-compatible PUT wrapper around signObjectRequest. */
-export function signPutObject(
-  params: {
-    endpoint: string;
-    bucket: string;
-    key: string;
-    payload: Buffer;
-    contentType: string;
-    region: string;
-    accessKeyId: string;
-    secretAccessKey: string;
-  },
-  now: Date = new Date(),
-): SignedRequest {
-  return signObjectRequest({ method: 'PUT', ...params }, now);
-}
-
 function requireField(config: Record<string, string>, field: string): string {
   const value = (config[field] || '').trim();
   if (!value) {
@@ -258,7 +241,8 @@ export async function upload(
   const region = (config.region || '').trim() || 'auto';
 
   const key = buildObjectKey(filename, { kind, prefix: config.key_prefix });
-  const signed = signPutObject({
+  const signed = signObjectRequest({
+    method: 'PUT',
     endpoint,
     bucket,
     key,
@@ -286,8 +270,11 @@ export async function upload(
 }
 
 /** Remove one object by its key (the ref upload() returned). S3 DeleteObject is
- *  idempotent — deleting a key that's already gone returns 204 — so the
- *  "already deleted counts as success" contract needs no special-casing here. */
+ *  idempotent by protocol — deleting a key that's already gone returns 204 — so
+ *  the "already deleted counts as success" contract holds with NO 404
+ *  carve-out. Deliberately so: a 404 here means the request never reached a
+ *  real DeleteObject handler (repointed endpoint, wrong bucket), and swallowing
+ *  it would drop the record while the original object lives on. */
 async function deleteObject(ref: string, config: Record<string, string> = {}): Promise<void> {
   const endpoint = requireField(config, 'endpoint');
   const bucket = requireField(config, 'bucket');
@@ -305,8 +292,12 @@ async function deleteObject(ref: string, config: Record<string, string> = {}): P
     secretAccessKey,
   });
 
-  const resp = await fetch(signed.url, { method: 'DELETE', headers: signed.headers });
-  if (!resp.ok && resp.status !== 404) {
+  const resp = await fetch(signed.url, {
+    method: 'DELETE',
+    headers: signed.headers,
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!resp.ok) {
     const text = (await resp.text()).slice(0, 200);
     throw Object.assign(new Error(`s3 delete failed: ${resp.status} ${text}`), {
       code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',

--- a/server/services/uploadProviders/types.ts
+++ b/server/services/uploadProviders/types.ts
@@ -26,8 +26,11 @@ export interface DriverCapabilities {
   // true → the driver returns a public URL on another origin (x0/catbox/hoarder/
   // s3). false → WE serve the bytes (local) and the route builds the URL.
   storesRemotely: boolean;
-  // Can the stored bytes be removed given a ref? All P0 drivers: false (external
-  // forwarders don't offer delete; hosted takedown stays CP/admin-key-only).
+  // Can the driver remove stored bytes given a ref? Deletability of a specific
+  // upload is decided at capture time: upload() returns a ref only when that
+  // upload can actually be deleted later (e.g. catbox omits it for anonymous
+  // uploads), so "deletable row" = supportsDelete AND ref present. x0 has no
+  // delete API at all; hosted dropper deletion stays CP-mediated (CP #55).
   supportsDelete: boolean;
   // true only where WE construct the storage key (s3, local — none in P0). The
   // preserve-original-filename option (#517) is a no-op where the remote host

--- a/server/services/uploadProviders/types.ts
+++ b/server/services/uploadProviders/types.ts
@@ -29,7 +29,9 @@ export interface DriverCapabilities {
   // Can the driver remove stored bytes given a ref? Deletability of a specific
   // upload is decided at capture time: upload() returns a ref only when that
   // upload can actually be deleted later (e.g. catbox omits it for anonymous
-  // uploads), so "deletable row" = supportsDelete AND ref present. x0 has no
+  // uploads). The full row predicate is deletableWith() in resolve.ts —
+  // supportsDelete AND canDeleteWith(config) AND ref present — since a config
+  // can lose the credential delete() needs after refs were captured. x0 has no
   // delete API at all; hosted dropper deletion stays CP-mediated (CP #55).
   supportsDelete: boolean;
   // true only where WE construct the storage key (s3, local — none in P0). The

--- a/server/services/uploadProviders/types.ts
+++ b/server/services/uploadProviders/types.ts
@@ -74,6 +74,17 @@ export interface UploadDriver {
   capabilities: DriverCapabilities;
   configSchema: ConfigField[];
   upload(buffer: Buffer, meta: UploadMeta, config: Record<string, string>): Promise<UploadResult>;
-  // Present iff capabilities.supportsDelete.
+  // Present iff capabilities.supportsDelete. CONTRACT: must be idempotent —
+  // "already gone" resolves rather than throws, because the route drops the DB
+  // row only after delete() succeeds, so a delete whose response was lost gets
+  // retried against bytes that are already destroyed. Failures throw with the
+  // PROVIDER_CONFIG / PROVIDER_AUTH / PROVIDER_ERROR code taxonomy; never
+  // resolve on an ambiguous outcome (a resolved delete() is the route's license
+  // to destroy the only record of the file).
   delete?(ref: string, config: Record<string, string>): Promise<void>;
+  // Optional per-config refinement of supportsDelete: can delete() work with
+  // THIS config right now? (catbox: only with a userhash.) Absent → yes.
+  // Deletability of a row = supportsDelete ∧ canDeleteWith(config) ∧ ref
+  // present — see deletableWith() in resolve.ts, the one shared predicate.
+  canDeleteWith?(config: Record<string, string>): boolean;
 }

--- a/server/services/uploadProviders/uploadProviders.test.ts
+++ b/server/services/uploadProviders/uploadProviders.test.ts
@@ -183,14 +183,30 @@ describe('catbox provider', () => {
     expect(text).toContain('xyz.png');
   });
 
-  it('delete treats "doesn\'t exist" as already gone, other text as failure', async () => {
+  it('delete resolves a non-success reply only when the public URL proves the file is gone', async () => {
+    // Catbox says "doesn't exist" both for a genuinely-deleted file and for one
+    // the current userhash doesn't own. The driver probes the public URL to
+    // disambiguate: 404 → really gone (success)…
     vi.spyOn(multipart, 'postBuffer').mockResolvedValue({
       status: 200,
       headers: {},
       text: "File doesn't exist?",
     });
+    globalThis.fetch = vi.fn<typeof fetch>(async (url, init) => {
+      expect(String(url)).toBe('https://files.catbox.moe/gone.png');
+      expect(init?.method).toBe('HEAD');
+      return new Response(null, { status: 404 });
+    });
     await expect(catbox.delete('gone.png', { userhash: 'h' })).resolves.toBeUndefined();
 
+    // …but a file that's still being served must NOT count as deleted — that's
+    // the userhash-mismatch case, and dropping the record would strand the file.
+    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response(null, { status: 200 }));
+    await expect(catbox.delete('gone.png', { userhash: 'h' })).rejects.toMatchObject({
+      code: 'PROVIDER_ERROR',
+    });
+
+    // An unrecognized error reply with a live file also fails.
     vi.spyOn(multipart, 'postBuffer').mockResolvedValue({
       status: 200,
       headers: {},
@@ -205,6 +221,11 @@ describe('catbox provider', () => {
     await expect(catbox.delete('xyz.png', {})).rejects.toMatchObject({
       code: 'PROVIDER_CONFIG',
     });
+  });
+
+  it('canDeleteWith tracks the presence of a userhash', () => {
+    expect(catbox.canDeleteWith({ userhash: 'abc' })).toBe(true);
+    expect(catbox.canDeleteWith({})).toBe(false);
   });
 });
 
@@ -549,9 +570,10 @@ describe('s3 provider', () => {
     expect(s3.buildObjectKey('evil.<scr>', {})).toMatch(/\.bin$/);
   });
 
-  it('signPutObject is deterministic for a pinned clock and shaped like SigV4', () => {
+  it('signObjectRequest is deterministic for a pinned clock and shaped like SigV4', () => {
     const now = new Date('2026-01-02T03:04:05.000Z');
     const args = {
+      method: 'PUT' as const,
       endpoint: SECRETS.endpoint,
       bucket: SECRETS.bucket,
       key: 'abc123.png',
@@ -561,8 +583,8 @@ describe('s3 provider', () => {
       accessKeyId: SECRETS.access_key_id,
       secretAccessKey: SECRETS.secret_access_key,
     };
-    const a = s3.signPutObject(args, now);
-    const b = s3.signPutObject(args, now);
+    const a = s3.signObjectRequest(args, now);
+    const b = s3.signObjectRequest(args, now);
     expect(a).toEqual(b);
     expect(a.url).toBe('http://minio.test:9000/lurker/abc123.png');
     expect(a.headers['x-amz-date']).toBe('20260102T030405Z');
@@ -570,7 +592,7 @@ describe('s3 provider', () => {
       /^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\/20260102\/auto\/s3\/aws4_request, SignedHeaders=cache-control;content-type;host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$/,
     );
     // A different secret must change the signature.
-    const c = s3.signPutObject({ ...args, secretAccessKey: 'other' }, now);
+    const c = s3.signObjectRequest({ ...args, secretAccessKey: 'other' }, now);
     expect(c.headers.authorization).not.toBe(a.headers.authorization);
   });
 
@@ -649,7 +671,7 @@ describe('s3 provider', () => {
     );
   });
 
-  it('delete sends a signed DELETE for the ref; 204 and 404 both succeed', async () => {
+  it('delete sends a signed DELETE for the ref; 204 succeeds (S3 delete is idempotent)', async () => {
     let delUrl = '';
     let delMethod = '';
     globalThis.fetch = vi.fn<typeof fetch>(async (url, init) => {
@@ -660,9 +682,16 @@ describe('s3 provider', () => {
     await s3.delete('abc123.png', SECRETS);
     expect(delMethod).toBe('DELETE');
     expect(delUrl).toBe('http://minio.test:9000/lurker/abc123.png');
+  });
 
+  it('delete rejects on 404 — a real DeleteObject never 404s, so the target was wrong', async () => {
+    // S3 answers 204 even for a missing key; a 404 means the config points
+    // somewhere that isn't the object's home (repointed endpoint/bucket) and
+    // must NOT count as "already gone".
     globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('NoSuchKey', { status: 404 }));
-    await expect(s3.delete('abc123.png', SECRETS)).resolves.toBeUndefined();
+    await expect(s3.delete('abc123.png', SECRETS)).rejects.toMatchObject({
+      code: 'PROVIDER_ERROR',
+    });
   });
 
   it('delete maps 403 to PROVIDER_AUTH and missing config to PROVIDER_CONFIG', async () => {

--- a/server/services/uploadProviders/uploadProviders.test.ts
+++ b/server/services/uploadProviders/uploadProviders.test.ts
@@ -150,6 +150,62 @@ describe('catbox provider', () => {
       message: expect.stringContaining('ECONNRESET'),
     });
   });
+
+  // Deletability is decided at capture time: only a userhash upload can ever be
+  // deleted on catbox's side, so only it carries a ref.
+  it('returns the served filename as ref for userhash uploads, no ref when anonymous', async () => {
+    captureCatboxCall();
+    const withHash = await catbox.upload(
+      Buffer.from([1]),
+      { filename: 'a.png', mime: 'image/png' },
+      { userhash: 'abc123' },
+    );
+    expect(withHash.ref).toBe('xyz.png');
+    const anonymous = await catbox.upload(
+      Buffer.from([1]),
+      { filename: 'a.png', mime: 'image/png' },
+      {},
+    );
+    expect(anonymous.ref).toBeUndefined();
+  });
+
+  it('delete POSTs reqtype=deletefiles with the userhash and filename', async () => {
+    const cap = captureCatboxCall();
+    catboxResponse = { status: 200, headers: {}, text: 'Files successfully deleted.' };
+    await catbox.delete('xyz.png', { userhash: 'abc123' });
+    expect(cap.url).toBe('https://catbox.moe/user/api.php');
+    const text = cap.body!.toString('binary');
+    expect(text).toContain('name="reqtype"');
+    expect(text).toContain('deletefiles');
+    expect(text).toContain('name="userhash"');
+    expect(text).toContain('abc123');
+    expect(text).toContain('name="files"');
+    expect(text).toContain('xyz.png');
+  });
+
+  it('delete treats "doesn\'t exist" as already gone, other text as failure', async () => {
+    vi.spyOn(multipart, 'postBuffer').mockResolvedValue({
+      status: 200,
+      headers: {},
+      text: "File doesn't exist?",
+    });
+    await expect(catbox.delete('gone.png', { userhash: 'h' })).resolves.toBeUndefined();
+
+    vi.spyOn(multipart, 'postBuffer').mockResolvedValue({
+      status: 200,
+      headers: {},
+      text: 'Invalid userhash.',
+    });
+    await expect(catbox.delete('xyz.png', { userhash: 'bad' })).rejects.toMatchObject({
+      code: 'PROVIDER_ERROR',
+    });
+  });
+
+  it('delete rejects with PROVIDER_CONFIG when the config has no userhash', async () => {
+    await expect(catbox.delete('xyz.png', {})).rejects.toMatchObject({
+      code: 'PROVIDER_CONFIG',
+    });
+  });
 });
 
 describe('hoarder provider', () => {
@@ -312,6 +368,56 @@ describe('zipline provider', () => {
       ),
     ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
   });
+
+  it('captures the v4 file id as ref; v3 string responses carry no ref', async () => {
+    captureFormData();
+    captureResponse = new Response(
+      JSON.stringify({ files: [{ id: 'clxyz123', url: 'https://zl.test/u/x.png' }] }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+    const v4 = await zipline.upload(
+      Buffer.from([1]),
+      { filename: 'x.png', mime: 'image/png' },
+      { url: 'https://zl.test', token: 't' },
+    );
+    expect(v4.ref).toBe('clxyz123');
+
+    captureResponse = new Response(JSON.stringify({ files: ['https://zl.test/u/y.png'] }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const v3 = await zipline.upload(
+      Buffer.from([1]),
+      { filename: 'y.png', mime: 'image/png' },
+      { url: 'https://zl.test', token: 't' },
+    );
+    expect(v3.ref).toBeUndefined();
+  });
+
+  it('delete DELETEs /api/user/files/{ref} with the raw token; 404 = already gone', async () => {
+    const cap = captureFormData();
+    captureResponse = new Response(JSON.stringify({ id: 'clxyz123' }), { status: 200 });
+    await zipline.delete('clxyz123', { url: 'https://zl.test/', token: 'ziptok' });
+    expect(cap.url).toBe('https://zl.test/api/user/files/clxyz123');
+    const init = cap.init as RequestInit & { method: string; headers: Record<string, string> };
+    expect(init.method).toBe('DELETE');
+    expect(init.headers.authorization).toBe('ziptok');
+
+    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('gone', { status: 404 }));
+    await expect(
+      zipline.delete('clxyz123', { url: 'https://zl.test', token: 't' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('delete maps 401 to PROVIDER_AUTH and missing config to PROVIDER_CONFIG', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('nope', { status: 401 }));
+    await expect(
+      zipline.delete('clxyz123', { url: 'https://zl.test', token: 'bad' }),
+    ).rejects.toMatchObject({ code: 'PROVIDER_AUTH' });
+    await expect(zipline.delete('clxyz123', { url: 'https://zl.test' })).rejects.toMatchObject({
+      code: 'PROVIDER_CONFIG',
+    });
+  });
 });
 
 describe('chibisafe provider', () => {
@@ -372,6 +478,56 @@ describe('chibisafe provider', () => {
         { url: 'https://u', api_key: 'k' },
       ),
     ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
+  });
+
+  it('captures the response uuid as ref; a uuid-less response carries no ref', async () => {
+    captureFormData();
+    captureResponse = new Response(
+      JSON.stringify({ name: 'x.png', uuid: 'u-u-i-d', url: 'https://cb.test/x.png' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+    const withUuid = await chibisafe.upload(
+      Buffer.from([1]),
+      { filename: 'x.png', mime: 'image/png' },
+      { url: 'https://cb.test', api_key: 'k' },
+    );
+    expect(withUuid.ref).toBe('u-u-i-d');
+
+    captureResponse = new Response(JSON.stringify({ url: 'https://cb.test/y.png' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const without = await chibisafe.upload(
+      Buffer.from([1]),
+      { filename: 'y.png', mime: 'image/png' },
+      { url: 'https://cb.test', api_key: 'k' },
+    );
+    expect(without.ref).toBeUndefined();
+  });
+
+  it('delete DELETEs /api/file/{uuid} with x-api-key; 404 = already gone', async () => {
+    const cap = captureFormData();
+    captureResponse = new Response('{}', { status: 200 });
+    await chibisafe.delete('u-u-i-d', { url: 'https://cb.test/', api_key: 'chibikey' });
+    expect(cap.url).toBe('https://cb.test/api/file/u-u-i-d');
+    const init = cap.init as RequestInit & { method: string; headers: Record<string, string> };
+    expect(init.method).toBe('DELETE');
+    expect(init.headers['x-api-key']).toBe('chibikey');
+
+    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('gone', { status: 404 }));
+    await expect(
+      chibisafe.delete('u-u-i-d', { url: 'https://cb.test', api_key: 'k' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('delete maps 401 to PROVIDER_AUTH and missing config to PROVIDER_CONFIG', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('nope', { status: 401 }));
+    await expect(
+      chibisafe.delete('u-u-i-d', { url: 'https://cb.test', api_key: 'bad' }),
+    ).rejects.toMatchObject({ code: 'PROVIDER_AUTH' });
+    await expect(chibisafe.delete('u-u-i-d', { url: 'https://cb.test' })).rejects.toMatchObject({
+      code: 'PROVIDER_CONFIG',
+    });
   });
 });
 
@@ -466,5 +622,58 @@ describe('s3 provider', () => {
     await expect(
       s3.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, SECRETS),
     ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
+  });
+
+  it('signObjectRequest DELETE signs an empty payload without content headers', () => {
+    const now = new Date('2026-01-02T03:04:05.000Z');
+    const signed = s3.signObjectRequest(
+      {
+        method: 'DELETE',
+        endpoint: SECRETS.endpoint,
+        bucket: SECRETS.bucket,
+        key: 'abc123.png',
+        region: 'auto',
+        accessKeyId: SECRETS.access_key_id,
+        secretAccessKey: SECRETS.secret_access_key,
+      },
+      now,
+    );
+    expect(signed.url).toBe('http://minio.test:9000/lurker/abc123.png');
+    // Empty payload hash (sha256 of zero bytes), no content-type/cache-control.
+    expect(signed.headers['x-amz-content-sha256']).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    );
+    expect(signed.headers['content-type']).toBeUndefined();
+    expect(signed.headers.authorization).toMatch(
+      /SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=[0-9a-f]{64}$/,
+    );
+  });
+
+  it('delete sends a signed DELETE for the ref; 204 and 404 both succeed', async () => {
+    let delUrl = '';
+    let delMethod = '';
+    globalThis.fetch = vi.fn<typeof fetch>(async (url, init) => {
+      delUrl = String(url);
+      delMethod = init?.method ?? '';
+      return new Response(null, { status: 204 });
+    });
+    await s3.delete('abc123.png', SECRETS);
+    expect(delMethod).toBe('DELETE');
+    expect(delUrl).toBe('http://minio.test:9000/lurker/abc123.png');
+
+    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('NoSuchKey', { status: 404 }));
+    await expect(s3.delete('abc123.png', SECRETS)).resolves.toBeUndefined();
+  });
+
+  it('delete maps 403 to PROVIDER_AUTH and missing config to PROVIDER_CONFIG', async () => {
+    globalThis.fetch = vi.fn<typeof fetch>(
+      async () => new Response('SignatureDoesNotMatch', { status: 403 }),
+    );
+    await expect(s3.delete('abc123.png', SECRETS)).rejects.toMatchObject({
+      code: 'PROVIDER_AUTH',
+    });
+    await expect(s3.delete('abc123.png', { ...SECRETS, bucket: '' })).rejects.toMatchObject({
+      code: 'PROVIDER_CONFIG',
+    });
   });
 });

--- a/server/services/uploadProviders/zipline.ts
+++ b/server/services/uploadProviders/zipline.ts
@@ -102,6 +102,7 @@ async function deleteFile(
   const resp = await fetch(`${base}/api/user/files/${encodeURIComponent(ref)}`, {
     method: 'DELETE',
     headers: { authorization: config.token, 'User-Agent': USER_AGENT },
+    signal: AbortSignal.timeout(60_000),
   });
   if (!resp.ok && resp.status !== 404) {
     const text = (await resp.text()).slice(0, 200);

--- a/server/services/uploadProviders/zipline.ts
+++ b/server/services/uploadProviders/zipline.ts
@@ -17,7 +17,7 @@ export const label = 'Zipline';
 export const capabilities: DriverCapabilities = {
   creatable: true,
   storesRemotely: true,
-  supportsDelete: false,
+  supportsDelete: true,
   mintsKeys: false,
   acceptsContentClasses: ['image', 'text'],
   selfHostOnly: true,
@@ -80,5 +80,35 @@ export async function upload(
   if (typeof url !== 'string' || !url) {
     throw Object.assign(new Error('zipline returned no url'), { code: 'PROVIDER_ERROR' });
   }
-  return { url };
+  // v4 responses carry the file id — the delete handle. v3 responses are bare
+  // URL strings with no id, so a v3 upload is simply not deletable (no ref).
+  const ref = typeof first === 'object' && typeof first?.id === 'string' ? first.id : undefined;
+  return { url, ...(ref ? { ref } : {}) };
 }
+
+/** Delete a file by the id upload() captured. Zipline v4's delete route accepts
+ *  the file id (or name) in the path; a 404 means it's already gone, which is
+ *  the outcome the caller wanted. */
+async function deleteFile(
+  ref: string,
+  config: { url?: string; token?: string } = {},
+): Promise<void> {
+  if (!config.url || !config.token) {
+    throw Object.assign(new Error('zipline uploader is missing its url or token'), {
+      code: 'PROVIDER_CONFIG',
+    });
+  }
+  const base = config.url.replace(/\/+$/, '');
+  const resp = await fetch(`${base}/api/user/files/${encodeURIComponent(ref)}`, {
+    method: 'DELETE',
+    headers: { authorization: config.token, 'User-Agent': USER_AGENT },
+  });
+  if (!resp.ok && resp.status !== 404) {
+    const text = (await resp.text()).slice(0, 200);
+    throw Object.assign(new Error(`zipline delete failed: ${resp.status} ${text}`), {
+      code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
+    });
+  }
+}
+
+export { deleteFile as delete };

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -42,17 +42,6 @@
             <div class="sub">{{ metaLine(u) }}</div>
           </div>
           <div class="row-actions">
-            <!-- A removed upload's URL is dead, so there's nothing to copy. -->
-            <button
-              v-if="!u.removed"
-              class="link copy"
-              :class="{ copied: copiedId === u.id }"
-              @click="onCopy(u)"
-              :title="copiedId === u.id ? 'copied' : 'copy URL'"
-              :aria-label="copiedId === u.id ? 'copied' : 'copy URL'"
-            >
-              <i :class="copiedId === u.id ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
-            </button>
             <!-- Delete destroys the stored file. Offered only where that's true
                  (can_delete) — there is no remove-the-record-only action. -->
             <button
@@ -66,6 +55,17 @@
               <i
                 :class="deletingId === u.id ? 'fa-solid fa-spinner fa-spin' : 'fa-solid fa-trash'"
               ></i>
+            </button>
+            <!-- A removed upload's URL is dead, so there's nothing to copy. -->
+            <button
+              v-if="!u.removed"
+              class="link copy"
+              :class="{ copied: copiedId === u.id }"
+              @click="onCopy(u)"
+              :title="copiedId === u.id ? 'copied' : 'copy URL'"
+              :aria-label="copiedId === u.id ? 'copied' : 'copy URL'"
+            >
+              <i :class="copiedId === u.id ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
             </button>
           </div>
         </li>

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -47,7 +47,7 @@
             <button
               v-if="!u.removed && u.can_delete"
               class="link delete"
-              :disabled="deletingId === u.id"
+              :disabled="deletingId !== null"
               @click="onDelete(u)"
               title="delete file"
               aria-label="delete file"
@@ -135,6 +135,10 @@ async function onCopy(u: UploadRow) {
 }
 
 async function onDelete(u: UploadRow) {
+  // One delete at a time: a second in-flight delete would fight over the single
+  // deletingId ref (spinner/disabled state desync). All delete buttons are
+  // disabled while one runs; this guard covers the pre-render window.
+  if (deletingId.value !== null) return;
   if (!confirm(`Delete "${u.filename || u.url}"? The file is removed from storage.`)) return;
   deletingId.value = u.id;
   deleteError.value = '';

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -6,6 +6,7 @@
 <template>
   <AppModal word="uploads" title="recent uploads" size="xl" fill-height @close="$emit('close')">
     <p v-if="uploads.listError" class="error">{{ uploads.listError }}</p>
+    <p v-if="deleteError" class="error">{{ deleteError }}</p>
 
     <div ref="listEl" class="list-wrap" @scroll="onScroll">
       <ul v-if="recentRows.length" class="list">
@@ -52,6 +53,20 @@
             >
               <i :class="copiedId === u.id ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
             </button>
+            <!-- Delete destroys the stored file. Offered only where that's true
+                 (can_delete) — there is no remove-the-record-only action. -->
+            <button
+              v-if="!u.removed && u.can_delete"
+              class="link delete"
+              :disabled="deletingId === u.id"
+              @click="onDelete(u)"
+              title="delete file"
+              aria-label="delete file"
+            >
+              <i
+                :class="deletingId === u.id ? 'fa-solid fa-spinner fa-spin' : 'fa-solid fa-trash'"
+              ></i>
+            </button>
           </div>
         </li>
       </ul>
@@ -89,6 +104,8 @@ const uploads = useUploadsStore();
 const recentRows = computed(() => uploads.recent as UploadRow[]);
 const listEl = ref<HTMLDivElement | null>(null);
 const copiedId = ref<number | null>(null);
+const deletingId = ref<number | null>(null);
+const deleteError = ref('');
 
 onMounted(() => {
   uploads.loadRecent().catch(() => {
@@ -114,6 +131,20 @@ async function onCopy(u: UploadRow) {
   } catch (_) {
     // Clipboard API can fail without a user-gesture context on Firefox/Safari;
     // the user can fall back to right-click-copy on the URL text.
+  }
+}
+
+async function onDelete(u: UploadRow) {
+  if (!confirm(`Delete "${u.filename || u.url}"? The file is removed from storage.`)) return;
+  deletingId.value = u.id;
+  deleteError.value = '';
+  try {
+    await uploads.remove(u.id);
+  } catch (e: any) {
+    // The bytes weren't destroyed, so the row stays and the reason surfaces.
+    deleteError.value = e.message || 'delete failed';
+  } finally {
+    deletingId.value = null;
   }
 }
 
@@ -233,12 +264,20 @@ function metaLine(u: UploadRow): string {
   align-items: center;
   margin-left: var(--space-6);
 }
-/* Copy is the lone row action now, so it stays in its own column on every
-   width — a single icon needs no separate mobile bar. Padding gives it a
-   comfortable tap target. */
-.copy {
+/* Two icon actions at most (copy + delete) — they fit the actions column on
+   every width, no separate mobile bar needed. Padding gives each a comfortable
+   tap target. */
+.copy,
+.delete {
   padding: var(--space-3) var(--space-4);
   font-size: var(--icon-md);
+}
+.delete:hover {
+  color: var(--bad);
+}
+.delete:disabled {
+  color: var(--fg-muted);
+  cursor: default;
 }
 .copy.copied {
   color: var(--good);

--- a/vue_client/src/stores/uploads.ts
+++ b/vue_client/src/stores/uploads.ts
@@ -39,6 +39,10 @@ export interface UploadItem {
   // True when the hosted operator has moderated the upload away. The row stays
   // as a tombstone; its bytes are gone from storage.
   removed?: boolean;
+  // True when deleting this row destroys the stored bytes. Rows without it get
+  // no delete affordance at all — there is no "remove the record but leave the
+  // file up" path (design decision 8).
+  can_delete?: boolean;
 }
 
 export const useUploadsStore = defineStore('uploads', {
@@ -89,6 +93,7 @@ export const useUploadsStore = defineStore('uploads', {
             url: result.url,
             filename,
             mime: file.type || null,
+            can_delete: !!result.can_delete,
             ...(thumbnail_url ? { thumbnail_url } : {}),
           });
         }


### PR DESCRIPTION
Closes #541. Revised design decision 8: delete means **destroy the stored file**, on every driver whose service allows it — and never fake it. There is no remove-the-record-but-leave-the-file path.

## The mechanism: capture-time deletability

`upload()` returns a `ref` only when that specific upload's bytes can be destroyed later. A deletable row is exactly `deletableWith(driver, config) ∧ ref present` — one shared predicate (`resolve.ts`) behind all three projections (POST response, GET list, DELETE gate), so the client's trash button and the route's refusal can never disagree.

That's what makes catbox work without config branching: a userhash upload captures the served filename as its ref; an anonymous one captures nothing and is permanently undeletable (catbox offers no anonymous delete) — indistinguishable from an x0 row, which is correct.

## Per driver

| Driver | Delete | Ref |
|---|---|---|
| `local` | already shipped (P1) | on-disk key |
| `s3` | SigV4 DeleteObject (signer generalized to `signObjectRequest`) | object key — **recorded since P2, so existing R2 uploads light up retroactively** |
| `zipline` | `DELETE /api/user/files/{id}`, raw auth token | v4 file id; v3 string responses have no id → not deletable |
| `chibisafe` | `DELETE /api/file/{uuid}`, x-api-key | response uuid |
| `catbox` | `reqtype=deletefiles` via the same postBuffer path uploads use | URL basename, **userhash uploads only** |
| `x0` | no delete API exists (retention-expiry only) | never |
| `hoarder`/dropper | stays CP-mediated — amiantos/lurker-control-plane#55 | — |

## Route semantics

`DELETE /api/uploads/:id`: **409** when the row isn't byte-deletable (no ref, driver/config can't delete, config gone, moderation tombstone). Otherwise bytes die **first** (awaited, 60s timeout), then the row drops. Drivers treat already-gone as success (idempotency is now a documented contract on the driver interface); other failures keep the row and surface so the user can retry.

## Client

Trash button in the recent-uploads modal, shown only for `can_delete` rows; confirm-before-delete; failure keeps the row and shows the reason.

## Self-review pass (`/code-review high`) — 4 findings, all fixed in the second commit

1. **PROVIDER_AUTH no longer maps to HTTP 401.** The client treats any non-auth 401 as a dead session and hard-reloads to login — so a revoked Zipline token + trash click would have rebooted the app (the pre-existing POST mapping had the same latent bug). Both handlers now share `providerErrorStatus()` → 502.
2. **catbox "doesn't exist" was ambiguous** — same reply for genuinely-deleted and not-owned-by-current-userhash, and swallowing the second is a fake delete. Now disambiguated by HEAD-probing the public URL (404 → gone; still served → refuse). New `canDeleteWith` driver hook also hides the button when a config loses its userhash, instead of offering a forever-erroring one.
3. **s3's 404-as-success carve-out removed** — DeleteObject is idempotent by protocol (204 for missing keys), so retry-safety never needed it; a real 404 means a repointed endpoint/bucket and must not count as deleted.
4. **60s AbortSignal timeouts** on the awaited delete fetches so a hung provider can't pin the request for undici's 5-minute default.

Known residual (documented, accepted on the trusted-self-host threat model): if a user repoints their own zipline/chibisafe config at a *different server or account* after uploading, a foreign 404 on delete reads as already-gone. Catbox — the likely case — is covered by the URL probe; the others have no reliable verification target (user-editable base URLs).

Verified: `npm run check` clean, 2147 tests green (+22 new: per-driver delete units incl. the catbox probe disambiguation, route 409/bytes-first/failure-keeps-row/canDeleteWith semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)