### PR TITLE
Uploads P4a: stream to disk instead of buffering in the heap (#543)

### DIFF
--- a/server/routes/localUploads.test.ts
+++ b/server/routes/localUploads.test.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import sharp from 'sharp';
+import { bufferSource } from '../services/uploadProviders/source.js';
 import { createTestApp, createAnonAgent } from '../test-utils/testApp.js';
 import type { LurkerTestAgent } from '../test-utils/testApp.js';
 import * as local from '../services/uploadProviders/local.js';
@@ -18,7 +19,7 @@ const prevEnv = process.env.LOCAL_UPLOADS_DIR;
 
 // Write a buffer through the real driver and return the served path.
 async function put(buffer: Buffer, filename: string, mime: string): Promise<string> {
-  const res = await local.upload(buffer, { filename, mime }, {});
+  const res = await local.upload(bufferSource(buffer), { filename, mime }, {});
   return res.url; // /uploads/local/<key>
 }
 

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -12,6 +12,10 @@ import {
   createAnonAgent,
 } from '../test-utils/testApp.js';
 import type { User } from '../db/users.js';
+import type { UploadSource } from '../services/uploadProviders/source.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveDataDir } from '../utils/dataDir.js';
 
 const ctx = setupTestDb('routes-uploads');
 
@@ -36,12 +40,17 @@ const stub = {
   // exercise the storesRemotely:false (local-style relative URL) absolutization.
   nextResult: null as { url: string; ref?: string } | null,
   capturedDeleteRef: null as string | null,
+  // What the route handed us. Drivers take an UploadSource now (#543): a
+  // passthrough upload must arrive as a `file` (streamed off multer's temp file,
+  // never in the heap), while an optimized image arrives as a small `buffer`.
+  capturedSource: null as UploadSource | null,
   async upload(
-    _buffer: Buffer,
+    source: UploadSource,
     meta: { filename: string; mime: string },
     config?: Record<string, string>,
   ) {
     stub.capturedConfig = config ?? null;
+    stub.capturedSource = source;
     if (stub.shouldThrow) throw stub.shouldThrow;
     if (stub.nextResult) return stub.nextResult;
     return { url: `https://stub.example/${meta.filename}` };
@@ -447,5 +456,97 @@ describe('DELETE /api/uploads/:id', () => {
       stub.capabilities.supportsDelete = false;
       stub.nextResult = null;
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #543: uploads stream through a temp file instead of living in the heap. What
+// matters here is the shape handed to the driver and that the temp file never
+// outlives the request — an orphan per upload is a slow disk leak.
+describe('temp-file lifecycle (#543)', () => {
+  const tmpDir = (): string => path.join(resolveDataDir(), 'tmp', 'uploads');
+  const tempFiles = (): string[] => {
+    try {
+      return fs.readdirSync(tmpDir()).filter((f) => f.startsWith('up-'));
+    } catch {
+      return [];
+    }
+  };
+
+  it('hands the driver a FILE source for passthrough, a BUFFER source for images', async () => {
+    stub.shouldThrow = null;
+
+    // Text passes through untouched: it must arrive as a file the driver streams,
+    // never read into memory. This is the property the whole PR exists for.
+    await agent.post('/api/uploads').attach('image', Buffer.from('a passthrough upload'), {
+      filename: 'note.txt',
+      contentType: 'text/plain',
+    });
+    expect(stub.capturedSource!.kind).toBe('file');
+
+    // An image is re-encoded by the pipeline, so what goes out is the optimized
+    // buffer — small, bounded, and not worth a temp-file round trip.
+    await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'pic.png', contentType: 'image/png' });
+    expect(stub.capturedSource!.kind).toBe('buffer');
+  });
+
+  it('removes the temp file after a successful upload', async () => {
+    stub.shouldThrow = null;
+    const before = tempFiles().length;
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'clean.png', contentType: 'image/png' });
+    expect(res.status).toBe(200);
+    expect(tempFiles().length).toBe(before);
+  });
+
+  it('removes the temp file when the driver fails', async () => {
+    const before = tempFiles().length;
+    stub.shouldThrow = Object.assign(new Error('upstream down'), { code: 'PROVIDER_ERROR' });
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'boom.png', contentType: 'image/png' });
+    expect(res.status).toBe(502);
+    // A failed upload must not strand its bytes on disk.
+    expect(tempFiles().length).toBe(before);
+    stub.shouldThrow = null;
+  });
+
+  it('rejects an over-cap upload with 413 — mid-stream, not after ingesting it', async () => {
+    const { setUserSetting } = await import('../db/settings.js');
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 1);
+    try {
+      const before = tempFiles().length;
+      const big = Buffer.alloc(2 * 1024 * 1024, 0x7a); // 2 MB against a 1 MB cap
+      const res = await agent
+        .post('/api/uploads')
+        .attach('image', big, { filename: 'big.bin', contentType: 'text/plain' });
+      expect(res.status).toBe(413);
+      // multer aborts and unlinks its own partial file when the limit trips.
+      expect(tempFiles().length).toBe(before);
+    } finally {
+      setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
+    }
+  });
+
+  it('sweeps orphaned temp files a crash left behind, but never a live one', async () => {
+    const { sweepTempUploads } = await import('./uploads.js');
+    fs.mkdirSync(tmpDir(), { recursive: true });
+    const stale = path.join(tmpDir(), 'up-stale-orphan');
+    const fresh = path.join(tmpDir(), 'up-fresh-inflight');
+    fs.writeFileSync(stale, 'x');
+    fs.writeFileSync(fresh, 'x');
+    // Backdate the orphan past the age gate; the fresh one stands in for an
+    // upload in flight right now, which a sweep must not yank out from under.
+    const old = Date.now() - 2 * 60 * 60 * 1000;
+    fs.utimesSync(stale, new Date(old), new Date(old));
+
+    const removed = await sweepTempUploads();
+    expect(removed).toBe(1);
+    expect(fs.existsSync(stale)).toBe(false);
+    expect(fs.existsSync(fresh)).toBe(true);
+    fs.unlinkSync(fresh);
   });
 });

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -466,15 +466,19 @@ describe('DELETE /api/uploads/:id', () => {
 describe('temp-file lifecycle (#543)', () => {
   const tmpDir = (): string => path.join(resolveDataDir(), 'tmp', 'uploads');
 
-  // The handler unlinks the temp file in a `finally`, which runs AFTER the
-  // response is sent — so the client can observe the reply before the unlink has
-  // landed. Poll rather than assert on the next line: a same-tick assertion passes
-  // locally and loses the race on a slower CI runner.
-  const waitForTempCount = async (n: number, timeoutMs = 2000): Promise<void> => {
+  // The handler unlinks the temp file in a `finally`, which runs AFTER the response
+  // is sent — so the client can observe the reply before the unlink has landed.
+  // Two consequences, both of which bit this test in CI:
+  //   1. Assert by polling, not on the next line (same-tick passes locally, loses
+  //      the race on a slower runner).
+  //   2. Assert the ABSOLUTE invariant — the temp dir drains to empty — not a
+  //      delta against a `before` count, because a previous test's pending unlink
+  //      makes that baseline itself a race.
+  const waitForNoTemps = async (timeoutMs = 3000): Promise<void> => {
     const start = Date.now();
-    while (tempFiles().length !== n) {
+    while (tempFiles().length > 0) {
       if (Date.now() - start > timeoutMs) {
-        throw new Error(`temp files: expected ${n}, still ${tempFiles().length}`);
+        throw new Error(`temp files not cleaned up: ${tempFiles().join(', ')}`);
       }
       await new Promise((r) => setTimeout(r, 5));
     }
@@ -504,27 +508,26 @@ describe('temp-file lifecycle (#543)', () => {
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'pic.png', contentType: 'image/png' });
     expect(stub.capturedSource!.kind).toBe('buffer');
+    await waitForNoTemps();
   });
 
   it('removes the temp file after a successful upload', async () => {
     stub.shouldThrow = null;
-    const before = tempFiles().length;
     const res = await agent
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'clean.png', contentType: 'image/png' });
     expect(res.status).toBe(200);
-    await waitForTempCount(before);
+    await waitForNoTemps();
   });
 
   it('removes the temp file when the driver fails', async () => {
-    const before = tempFiles().length;
     stub.shouldThrow = Object.assign(new Error('upstream down'), { code: 'PROVIDER_ERROR' });
     const res = await agent
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'boom.png', contentType: 'image/png' });
     expect(res.status).toBe(502);
     // A failed upload must not strand its bytes on disk.
-    await waitForTempCount(before);
+    await waitForNoTemps();
     stub.shouldThrow = null;
   });
 
@@ -532,14 +535,13 @@ describe('temp-file lifecycle (#543)', () => {
     const { setUserSetting } = await import('../db/settings.js');
     setUserSetting(user.id, 'uploads.image.max_upload_mb', 1);
     try {
-      const before = tempFiles().length;
       const big = Buffer.alloc(2 * 1024 * 1024, 0x7a); // 2 MB against a 1 MB cap
       const res = await agent
         .post('/api/uploads')
         .attach('image', big, { filename: 'big.bin', contentType: 'text/plain' });
       expect(res.status).toBe(413);
       // multer aborts and unlinks its own partial file when the limit trips.
-      await waitForTempCount(before);
+      await waitForNoTemps();
     } finally {
       setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
     }

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -465,6 +465,20 @@ describe('DELETE /api/uploads/:id', () => {
 // outlives the request — an orphan per upload is a slow disk leak.
 describe('temp-file lifecycle (#543)', () => {
   const tmpDir = (): string => path.join(resolveDataDir(), 'tmp', 'uploads');
+
+  // The handler unlinks the temp file in a `finally`, which runs AFTER the
+  // response is sent — so the client can observe the reply before the unlink has
+  // landed. Poll rather than assert on the next line: a same-tick assertion passes
+  // locally and loses the race on a slower CI runner.
+  const waitForTempCount = async (n: number, timeoutMs = 2000): Promise<void> => {
+    const start = Date.now();
+    while (tempFiles().length !== n) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`temp files: expected ${n}, still ${tempFiles().length}`);
+      }
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  };
   const tempFiles = (): string[] => {
     try {
       return fs.readdirSync(tmpDir()).filter((f) => f.startsWith('up-'));
@@ -499,7 +513,7 @@ describe('temp-file lifecycle (#543)', () => {
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'clean.png', contentType: 'image/png' });
     expect(res.status).toBe(200);
-    expect(tempFiles().length).toBe(before);
+    await waitForTempCount(before);
   });
 
   it('removes the temp file when the driver fails', async () => {
@@ -510,7 +524,7 @@ describe('temp-file lifecycle (#543)', () => {
       .attach('image', smallPng, { filename: 'boom.png', contentType: 'image/png' });
     expect(res.status).toBe(502);
     // A failed upload must not strand its bytes on disk.
-    expect(tempFiles().length).toBe(before);
+    await waitForTempCount(before);
     stub.shouldThrow = null;
   });
 
@@ -525,7 +539,7 @@ describe('temp-file lifecycle (#543)', () => {
         .attach('image', big, { filename: 'big.bin', contentType: 'text/plain' });
       expect(res.status).toBe(413);
       // multer aborts and unlinks its own partial file when the limit trips.
-      expect(tempFiles().length).toBe(before);
+      await waitForTempCount(before);
     } finally {
       setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
     }

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -1,10 +1,15 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import fs from 'node:fs';
+import path from 'node:path';
 import { Router } from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import { requireAuth } from '../middleware/auth.js';
+import { resolveDataDir } from '../utils/dataDir.js';
+import { randomId } from '../services/uploadProviders/objectKey.js';
+import { bufferSource, fileSource, type UploadSource } from '../services/uploadProviders/source.js';
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from '../services/settingsRegistry.js';
 import * as imagePipeline from '../services/imagePipeline.js';
@@ -100,18 +105,101 @@ function providerErrorStatus(e: { code?: string }): number {
   return e.code === 'PROVIDER_CONFIG' ? 400 : 502;
 }
 
-// multer needs configuring up-front, before we know the effective per-uploader
-// cap. Use a generous hard ceiling (200 MB, the registry max) so multer never
-// rejects below the real cap; the handler enforces the resolved cap.
-const HARD_BYTE_CEILING = 200 * 1024 * 1024;
-const upload = multer({
-  storage: multer.memoryStorage(),
-  limits: { fileSize: HARD_BYTE_CEILING, files: 1 },
+// Uploads land in a temp file, never in the heap. multer's memoryStorage used to
+// hold the whole file, and the drivers then copied it again (and fetch copied it a
+// third time) — a 200 MB upload cost ~1 GB of RSS. See services/uploadProviders/
+// source.ts for the measurements. Everything downstream takes an UploadSource.
+const TMP_DIR = path.join(resolveDataDir(), 'tmp', 'uploads');
+fs.mkdirSync(TMP_DIR, { recursive: true });
+
+// The registry's own ceiling; a per-user cap can't exceed it, so neither can multer.
+const MAX_CAP_MB = 200;
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, TMP_DIR),
+  filename: (_req, _file, cb) => cb(null, `up-${randomId()}`),
 });
+
+/** The cap to hand multer, resolved BEFORE a byte is read (requireAuth already
+ *  ran, so we know who's asking). The old code gave multer a flat 200 MB and let
+ *  the handler reject afterwards — which meant a user capped at 25 MB could still
+ *  make the server ingest 200 MB before being told no. The per-upload `uploaderId`
+ *  override lives in the multipart body, which isn't parsed yet, so this resolves
+ *  the DEFAULT uploader's cap; the handler re-checks against the actually-resolved
+ *  uploader, which is what catches an override with a tighter policy cap. */
+function capMbFor(userId: number, isAdmin: boolean): number {
+  const settings = effectiveSettings(userId);
+  const userCap = Number(settings['uploads.image.max_upload_mb']) || 25;
+  let cap = userCap;
+  try {
+    cap = resolveUploader({ userId, isAdmin, requestedId: null }).policy.maxMb ?? userCap;
+  } catch {
+    // No usable uploader → the handler will produce the real error. Fall back to
+    // the user's own cap so we still bound what we're willing to read.
+  }
+  return Math.max(1, Math.min(cap, MAX_CAP_MB));
+}
+
+/** Best-effort removal of an upload's temp file. Tolerates ENOENT: the `local`
+ *  driver RENAMES the temp file into its storage dir (zero copies), so by the time
+ *  we clean up there may be nothing left to remove — which is the good case. */
+async function discardTemp(file?: Express.Multer.File): Promise<void> {
+  if (!file?.path) return;
+  await fs.promises.unlink(file.path).catch(() => {});
+}
+
+/**
+ * Delete temp uploads left behind by a crash (an in-flight upload when the process
+ * died — the one case the handler's `finally` can't cover). Called once at boot.
+ * Age-gated so it can never race a live upload in another worker: only files older
+ * than the request timeout are candidates.
+ */
+export async function sweepTempUploads(maxAgeMs = 60 * 60 * 1000): Promise<number> {
+  let removed = 0;
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(TMP_DIR);
+  } catch {
+    return 0;
+  }
+  const cutoff = Date.now() - maxAgeMs;
+  for (const name of entries) {
+    if (!name.startsWith('up-')) continue;
+    const full = path.join(TMP_DIR, name);
+    try {
+      const stat = await fs.promises.stat(full);
+      if (stat.mtimeMs < cutoff) {
+        await fs.promises.unlink(full);
+        removed++;
+      }
+    } catch {
+      // vanished under us (another sweep, or the handler finishing) — fine
+    }
+  }
+  if (removed > 0) console.log(`[lurker] swept ${removed} orphaned upload temp file(s)`);
+  return removed;
+}
+
+const uploadToDisk = (req: Request, res: Response, next: NextFunction): void => {
+  const capMb = capMbFor(req.user!.id, req.user!.role === 'admin');
+  const handler = multer({
+    storage,
+    limits: { fileSize: capMb * 1024 * 1024, files: 1 },
+  }).single('image');
+  handler(req, res, (err: unknown) => {
+    // multer aborts the stream and unlinks its partial file once the cap is hit,
+    // so an oversized upload is refused mid-flight instead of after we've eaten it.
+    if ((err as { code?: string })?.code === 'LIMIT_FILE_SIZE') {
+      res.status(413).json({ error: `file exceeds ${capMb} MB` });
+      return;
+    }
+    next(err as Error | undefined);
+  });
+};
 
 router.post(
   '/',
-  upload.single('image'),
+  uploadToDisk,
   asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.file) {
@@ -180,7 +268,7 @@ router.post(
         return;
       }
 
-      let outBuffer: Buffer;
+      let outSource: UploadSource;
       let outMime: string;
       let outExt: string;
       let outByteSize: number;
@@ -189,7 +277,9 @@ router.post(
       let thumb: Buffer | null = null;
 
       if (isText) {
-        outBuffer = req.file.buffer;
+        // Passthrough: the bytes go out of the temp file exactly as they came in.
+        // Nothing reads them into memory — the driver streams the file.
+        outSource = fileSource(req.file.path, req.file.size);
         outMime = 'text/plain';
         outExt = 'txt';
         outByteSize = req.file.size;
@@ -198,7 +288,7 @@ router.post(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let optimized: any;
         try {
-          optimized = await imagePipeline.optimize(req.file.buffer, {
+          optimized = await imagePipeline.optimize(req.file.path, {
             maxDim:
               resolved.policy.maxDim ?? (Number(settings['uploads.image.max_dimension']) || 2048),
             quality: resolved.policy.quality ?? (Number(settings['uploads.image.quality']) || 85),
@@ -215,8 +305,11 @@ router.post(
           }
           throw err;
         }
-        thumb = (await imagePipeline.thumbnail(req.file.buffer)) as Buffer | null;
-        outBuffer = optimized.buffer as Buffer;
+        thumb = (await imagePipeline.thumbnail(req.file.path)) as Buffer | null;
+        // The optimized image is small and bounded (resized + re-encoded), so it
+        // stays a buffer — round-tripping it through another temp file would be
+        // pointless I/O. The heap blowup this PR removes was the ORIGINAL bytes.
+        outSource = bufferSource(optimized.buffer as Buffer);
         outMime = optimized.mime as string;
         outExt = optimized.ext as string;
         outByteSize = optimized.byteSize as number;
@@ -233,7 +326,7 @@ router.post(
       let result: any;
       try {
         result = await resolved.driver.upload(
-          outBuffer,
+          outSource,
           { filename, mime: outMime, contentClass },
           resolved.driverConfig,
         );
@@ -256,7 +349,7 @@ router.post(
       if (resolved.policy.hostsThumbnails && thumb) {
         try {
           const tRes = await resolved.driver.upload(
-            thumb,
+            bufferSource(thumb),
             { filename: 'thumb.jpg', mime: 'image/jpeg', contentClass: 'image', kind: 'thumb' },
             resolved.driverConfig,
           );
@@ -309,6 +402,11 @@ router.post(
       });
     } catch (err) {
       next(err);
+    } finally {
+      // Every exit takes the temp file with it: success, 4xx/5xx, driver failure,
+      // or a throw. (A client abort never reaches the handler — multer unlinks its
+      // own partial file — and sweepTempUploads() catches anything a crash left.)
+      await discardTemp(req.file);
     }
   }),
 );

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -109,8 +109,11 @@ function providerErrorStatus(e: { code?: string }): number {
 // hold the whole file, and the drivers then copied it again (and fetch copied it a
 // third time) — a 200 MB upload cost ~1 GB of RSS. See services/uploadProviders/
 // source.ts for the measurements. Everything downstream takes an UploadSource.
+// 0o700: an in-flight upload is the user's private data and must not be readable
+// by other local users on a shared host. Matches routes/exports.ts's staged-import
+// posture.
 const TMP_DIR = path.join(resolveDataDir(), 'tmp', 'uploads');
-fs.mkdirSync(TMP_DIR, { recursive: true });
+fs.mkdirSync(TMP_DIR, { recursive: true, mode: 0o700 });
 
 // The registry's own ceiling; a per-user cap can't exceed it, so neither can multer.
 const MAX_CAP_MB = 200;

--- a/server/server.ts
+++ b/server/server.ts
@@ -37,6 +37,7 @@ import {
   shutdownExportJobs,
 } from './services/exportJobs.js';
 import { startIgnoreSweeper, stopIgnoreSweeper } from './services/ignoreSweeper.js';
+import { sweepTempUploads } from './routes/uploads.js';
 import { startEventLoopMonitor, stopEventLoopMonitor } from './services/eventLoopMonitor.js';
 
 const PORT = Number(process.env.PORT || 8010);
@@ -126,6 +127,12 @@ startOrchestratorClient();
 // In node edition, periodically reconcile any upload moderation records that
 // didn't reach the control plane at upload time. No-op in standalone.
 startModerationReporter();
+
+// Uploads stream through a temp file, and the request handler removes it on every
+// exit — except a crash mid-upload, which is what this cleans up (#543).
+void sweepTempUploads().catch((err: unknown) => {
+  console.warn('[lurker] upload temp sweep failed:', (err as Error).message);
+});
 
 server.listen(PORT, HOST, () => {
   console.log(`[lurker] listening on http://${HOST || '0.0.0.0'}:${PORT}`);

--- a/server/services/imagePipeline.ts
+++ b/server/services/imagePipeline.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import fs from 'node:fs';
 import sharp, { type Metadata } from 'sharp';
 import { canScrubInPlace, scrubMetadata } from './metadataScrub.js';
 
@@ -44,17 +45,27 @@ export function extensionFor(mime: string, fallback = 'bin'): string {
 // Animated images (sharp.metadata.pages > 1) bypass the resize/re-encode and
 // are returned verbatim, which is a hard requirement so reaction GIFs / animated
 // WebP / APNG don't lose animation on the way through Lurker.
+// `input` is a path (an upload's temp file) or a Buffer. sharp accepts either, so
+// the image path never has to read a file into the heap just to hand it over; the
+// scrub/passthrough branches below do read the bytes, but only after sharp has
+// confirmed it's an image, which the size cap already bounds.
 export async function optimize(
-  buffer: Buffer,
+  input: Buffer | string,
   {
     maxDim,
     quality,
     rasterOnly = false,
   }: { maxDim: number; quality: number; rasterOnly?: boolean },
 ): Promise<OptimizeResult> {
+  // Only the passthrough/scrub branches need the bytes in memory; the resize path
+  // hands the path straight to sharp. Read lazily so an ordinary image upload
+  // never materializes its original file in the heap.
+  const readInput = async (): Promise<Buffer> =>
+    typeof input === 'string' ? fs.promises.readFile(input) : input;
+
   let meta: Metadata;
   try {
-    meta = await sharp(buffer).metadata();
+    meta = await sharp(input).metadata();
   } catch (cause) {
     const err = new Error(
       `unable to read image: ${(cause as Error).message || String(cause)}`,
@@ -77,7 +88,7 @@ export async function optimize(
     // animated WebP/APNG can carry GPS EXIF. Scrub in-container (no re-encode)
     // for the formats we can do surgically.
     if (canScrubInPlace(meta.format)) {
-      const scrubbed = scrubMetadata(buffer, meta.format);
+      const scrubbed = scrubMetadata(await readInput(), meta.format);
       return {
         buffer: scrubbed,
         mime: fmt.mime,
@@ -95,7 +106,7 @@ export async function optimize(
     // through to the static single-frame encode below. Either way the metadata
     // is gone; we never pass an un-scrubbed image through.
     try {
-      const out = await sharp(buffer, { animated: true })
+      const out = await sharp(input, { animated: true })
         .toFormat(meta.format)
         .toBuffer({ resolveWithObject: true });
       return {
@@ -126,7 +137,7 @@ export async function optimize(
       throw err;
     }
     // Strip <metadata>/comments from the vector without rasterizing it.
-    const scrubbed = scrubMetadata(buffer, meta.format);
+    const scrubbed = scrubMetadata(await readInput(), meta.format);
     return {
       buffer: scrubbed,
       mime: fmt.mime,
@@ -138,7 +149,7 @@ export async function optimize(
     };
   }
 
-  const out = await sharp(buffer)
+  const out = await sharp(input)
     .rotate()
     .resize({
       width: maxDim,
@@ -160,9 +171,9 @@ export async function optimize(
   };
 }
 
-export async function thumbnail(buffer: Buffer): Promise<Buffer> {
+export async function thumbnail(input: Buffer | string): Promise<Buffer> {
   // Force first frame for animated inputs; cover-crop to a square JPEG.
-  return sharp(buffer, { animated: false })
+  return sharp(input, { animated: false })
     .rotate()
     .resize(THUMB_SIZE, THUMB_SIZE, { fit: 'cover', position: 'centre' })
     .jpeg({ quality: 80 })

--- a/server/services/uploadProviders/catbox.ts
+++ b/server/services/uploadProviders/catbox.ts
@@ -15,9 +15,10 @@
 //      while the same bytes via https.request succeed.
 // Both go away when we hand the body off to https.request directly.
 
-import { buildMultipart, postBuffer } from './multipart.js';
-import type { MultipartPart } from './multipart.js';
+import { buildMultipart, postBuffer, postMultipart } from './multipart.js';
+import type { StreamPart } from './multipart.js';
 import { USER_AGENT } from '../../utils/userAgent.js';
+import type { UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 const ENDPOINT = 'https://catbox.moe/user/api.php';
@@ -50,25 +51,27 @@ export const configSchema: ConfigField[] = [
 ];
 
 export async function upload(
-  buffer: Buffer,
+  source: UploadSource,
   { filename, mime }: UploadMeta,
   config: { userhash?: string } = {},
 ): Promise<UploadResult> {
-  const parts: MultipartPart[] = [{ name: 'reqtype', value: 'fileupload' }];
+  const parts: StreamPart[] = [{ name: 'reqtype', value: 'fileupload' }];
   if (config.userhash) parts.push({ name: 'userhash', value: config.userhash });
   parts.push({
     name: 'fileToUpload',
     filename,
     contentType: mime,
-    value: buffer,
+    source,
   });
-  const { body, contentType } = buildMultipart(parts);
 
   let resp;
   try {
-    resp = await postBuffer(ENDPOINT, body, {
+    // postMultipart streams the file and still sends an exact Content-Length,
+    // which is the property catbox's PHP backend needs (it stalls on chunked
+    // transfer-encoding) — so this keeps the reason postBuffer existed while
+    // dropping the "whole file in a Buffer" part of it.
+    resp = await postMultipart(ENDPOINT, parts, {
       headers: {
-        'Content-Type': contentType,
         'User-Agent': USER_AGENT,
         Accept: '*/*',
       },

--- a/server/services/uploadProviders/chibisafe.ts
+++ b/server/services/uploadProviders/chibisafe.ts
@@ -10,6 +10,8 @@
 // far below it. The response is `{ name, uuid, url, … }` where `url` is public.
 
 import { USER_AGENT } from '../../utils/userAgent.js';
+import { postMultipart, isOk, jsonBody } from './multipart.js';
+import type { UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 export const driver = 'chibisafe';
@@ -43,7 +45,7 @@ export const configSchema: ConfigField[] = [
 ];
 
 export async function upload(
-  buffer: Buffer,
+  source: UploadSource,
   { filename, mime }: UploadMeta,
   config: { url?: string; api_key?: string } = {},
 ): Promise<UploadResult> {
@@ -59,23 +61,20 @@ export async function upload(
   }
 
   const base = config.url.replace(/\/+$/, '');
-  const form = new FormData();
-  form.append('file[]', new Blob([new Uint8Array(buffer)], { type: mime }), filename);
+  const resp = await postMultipart(
+    `${base}/api/upload`,
+    [{ name: 'file[]', filename, contentType: mime, source }],
+    { headers: { 'x-api-key': config.api_key, 'User-Agent': USER_AGENT } },
+  );
 
-  const resp = await fetch(`${base}/api/upload`, {
-    method: 'POST',
-    headers: { 'x-api-key': config.api_key, 'User-Agent': USER_AGENT },
-    body: form,
-  });
-
-  if (!resp.ok) {
-    const text = (await resp.text()).slice(0, 200);
+  if (!isOk(resp)) {
+    const text = resp.text.slice(0, 200);
     throw Object.assign(new Error(`chibisafe upload failed: ${resp.status} ${text}`), {
       code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
     });
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const body = (await resp.json().catch(() => null)) as any;
+  const body = jsonBody(resp) as any;
   if (!body || typeof body.url !== 'string' || !body.url) {
     throw Object.assign(new Error('chibisafe returned no url'), { code: 'PROVIDER_ERROR' });
   }

--- a/server/services/uploadProviders/hoarder.ts
+++ b/server/services/uploadProviders/hoarder.ts
@@ -8,6 +8,8 @@
 // `url` is already the public CDN URL.
 
 import { USER_AGENT } from '../../utils/userAgent.js';
+import { postMultipart, isOk, jsonBody, type StreamPart } from './multipart.js';
+import type { UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 export const driver = 'hoarder';
@@ -38,7 +40,7 @@ export const configSchema: ConfigField[] = [
 ];
 
 export async function upload(
-  buffer: Buffer,
+  source: UploadSource,
   { filename, mime, kind }: UploadMeta,
   config: { url?: string; api_key?: string } = {},
 ): Promise<UploadResult> {
@@ -54,28 +56,26 @@ export async function upload(
   }
 
   const base = config.url.replace(/\/+$/, '');
-  const form = new FormData();
+  const parts: StreamPart[] = [];
   // Text fields before the file so multipart parsers populate req.body reliably.
-  if (kind) form.append('kind', kind);
-  form.append('file', new Blob([new Uint8Array(buffer)], { type: mime }), filename);
+  if (kind) parts.push({ name: 'kind', value: kind });
+  parts.push({ name: 'file', filename, contentType: mime, source });
 
-  const resp = await fetch(`${base}/api/upload`, {
-    method: 'POST',
+  const resp = await postMultipart(`${base}/api/upload`, parts, {
     headers: {
       Authorization: `Bearer ${config.api_key}`,
       'User-Agent': USER_AGENT,
     },
-    body: form,
   });
 
-  if (!resp.ok) {
-    const text = (await resp.text()).slice(0, 200);
+  if (!isOk(resp)) {
+    const text = resp.text.slice(0, 200);
     throw Object.assign(new Error(`hoarder upload failed: ${resp.status} ${text}`), {
       code: resp.status === 401 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
     });
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const body = (await resp.json().catch(() => null)) as any;
+  const body = jsonBody(resp) as any;
   if (!body || typeof body.url !== 'string') {
     throw Object.assign(new Error('hoarder returned no url'), { code: 'PROVIDER_ERROR' });
   }

--- a/server/services/uploadProviders/local.test.ts
+++ b/server/services/uploadProviders/local.test.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as local from './local.js';
+import { bufferSource } from './source.js';
 
 let dir: string;
 const prevEnv = process.env.LOCAL_UPLOADS_DIR;
@@ -31,7 +32,11 @@ describe('local driver', () => {
 
   it('writes bytes to disk and returns a relative URL + on-disk ref', async () => {
     const bytes = Buffer.from('hello local disk');
-    const res = await local.upload(bytes, { filename: 'note.txt', mime: 'text/plain' }, {});
+    const res = await local.upload(
+      bufferSource(bytes),
+      { filename: 'note.txt', mime: 'text/plain' },
+      {},
+    );
 
     expect(res.url).toMatch(/^\/uploads\/local\/[0-9a-f]{12}\.txt$/);
     expect(res.ref).toMatch(/^[0-9a-f]{12}\.txt$/);
@@ -50,7 +55,7 @@ describe('local driver', () => {
 
   it('takes the extension from the pipeline filename, not a hostile claim', async () => {
     const res = await local.upload(
-      Buffer.from('x'),
+      bufferSource(Buffer.from('x')),
       // The route always passes {basename}.{pipeline-ext}; even a traversal-y
       // basename can only affect the (re-sanitized) extension, never the path.
       { filename: '../../etc/passwd.png', mime: 'image/png' },
@@ -61,7 +66,7 @@ describe('local driver', () => {
 
   it('deletes the on-disk bytes for its ref (orphan reap)', async () => {
     const res = await local.upload(
-      Buffer.from('to-delete'),
+      bufferSource(Buffer.from('to-delete')),
       { filename: 'x.txt', mime: 'text/plain' },
       {},
     );

--- a/server/services/uploadProviders/local.ts
+++ b/server/services/uploadProviders/local.ts
@@ -22,6 +22,7 @@ import fs from 'fs';
 import path from 'path';
 import { resolveDataDir } from '../../utils/dataDir.js';
 import { buildObjectKey, randomId } from './objectKey.js';
+import { moveTo, sizeOf, type UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 export const driver = 'local';
@@ -65,7 +66,7 @@ export function resolveDiskPath(key: string, storageDir = resolveStorageDir()): 
 }
 
 export async function upload(
-  buffer: Buffer,
+  source: UploadSource,
   { filename }: UploadMeta,
   _config: Record<string, string>,
 ): Promise<UploadResult> {
@@ -75,13 +76,16 @@ export async function upload(
   const ext = filename.split('.').pop() || 'bin';
   const key = buildObjectKey({ ext });
   const full = resolveDiskPath(key, storageDir);
+  const bytes = sizeOf(source);
   await fs.promises.mkdir(path.dirname(full), { recursive: true });
-  // Write to a temp sibling then rename so a crash mid-write never leaves a
-  // half-written file at the served key. (The whole buffer is already in memory
-  // via multer.memoryStorage — there's no streaming/abort path to clean up.)
+  // Land the bytes at a temp sibling, then rename into place, so a crash mid-write
+  // never leaves a half-written file at the served key. moveTo does the right
+  // thing for either source shape: a passthrough upload is already a file on disk
+  // (multer's temp), so it's a rename — the bytes never enter the heap at all;
+  // an optimized image is a small buffer, so it's a write.
   const tmp = `${full}.tmp-${randomId()}`;
   try {
-    await fs.promises.writeFile(tmp, buffer, { mode: 0o644 });
+    await moveTo(source, tmp);
     await fs.promises.rename(tmp, full);
   } catch (err) {
     await fs.promises.unlink(tmp).catch(() => {});
@@ -89,7 +93,7 @@ export async function upload(
       code: 'PROVIDER_ERROR',
     });
   }
-  return { url: `/uploads/local/${key}`, ref: key, bytes: buffer.length };
+  return { url: `/uploads/local/${key}`, ref: key, bytes };
 }
 
 /** Orphan reap: unlink the on-disk file when its history row is deleted. Missing

--- a/server/services/uploadProviders/multipart.test.ts
+++ b/server/services/uploadProviders/multipart.test.ts
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Real sockets, real temp files. The driver tests stub multipart.postMultipart to
+// assert what each provider ASKS for; this file asserts that the asking actually
+// works — and, crucially, that it streams.
+//
+// The streaming test is the regression guard for #543. Every other test in the
+// repo passes just as happily if someone rewrites postMultipart on top of fetch —
+// and the upload path silently goes back to holding the whole file in memory
+// (5x the file size, as shipped). This one fails.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import v8 from 'node:v8';
+import vm from 'node:vm';
+import { postMultipart, putSource, isOk } from './multipart.js';
+import { bufferSource, fileSource } from './source.js';
+
+// Force a GC on demand without needing `node --expose-gc` on the test runner:
+// live `arrayBuffers` is only meaningful after collection, otherwise it counts
+// dead chunks and a streaming upload looks identical to a buffering one.
+v8.setFlagsFromString('--expose-gc');
+const forceGc = vm.runInNewContext('gc') as () => void;
+
+interface Received {
+  contentLength?: string;
+  transferEncoding?: string;
+  contentType?: string;
+  body: Buffer;
+  bytes: number;
+}
+
+let server: Server;
+let base: string;
+let last: Received;
+let throttleBytesPerTick = 0; // 0 = read as fast as possible
+let keepBody = true;
+let respondWith: { status: number; text: string } = { status: 200, text: 'ok' };
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-multipart-'));
+  server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    const record = (c: Buffer) => {
+      bytes += c.length;
+      if (keepBody) chunks.push(c);
+    };
+    if (throttleBytesPerTick > 0) {
+      let budget = throttleBytesPerTick;
+      const grant = setInterval(() => {
+        budget = throttleBytesPerTick;
+        req.resume();
+      }, 50);
+      req.on('data', (c: Buffer) => {
+        record(c);
+        budget -= c.length;
+        if (budget <= 0) req.pause();
+      });
+      req.on('end', () => clearInterval(grant));
+    } else {
+      req.on('data', record);
+    }
+    req.on('end', () => {
+      last = {
+        contentLength: req.headers['content-length'],
+        transferEncoding: req.headers['transfer-encoding'],
+        contentType: req.headers['content-type'],
+        body: Buffer.concat(chunks),
+        bytes,
+      };
+      res.writeHead(respondWith.status, { 'content-type': 'text/plain' });
+      res.end(respondWith.text);
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', () => r()));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}/`;
+});
+
+afterAll(() => {
+  server.close();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeTemp(name: string, contents: Buffer): { path: string; size: number } {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, contents);
+  return { path: p, size: contents.length };
+}
+
+describe('postMultipart', () => {
+  it('streams a file source with an exact Content-Length and no chunked encoding', async () => {
+    // Both properties matter: catbox's PHP backend stalls on chunked transfer
+    // encoding (the original reason this module exists), so streaming must NOT
+    // cost us the Content-Length.
+    const bytes = Buffer.alloc(200_000, 0xab);
+    const f = writeTemp('a.bin', bytes);
+    respondWith = { status: 200, text: 'https://example.test/a' };
+    keepBody = true;
+
+    const resp = await postMultipart(base, [
+      { name: 'reqtype', value: 'fileupload' },
+      {
+        name: 'fileToUpload',
+        filename: 'a.bin',
+        contentType: 'image/png',
+        source: fileSource(f.path, f.size),
+      },
+    ]);
+
+    expect(isOk(resp)).toBe(true);
+    expect(resp.text).toBe('https://example.test/a');
+    expect(last.transferEncoding).toBeUndefined();
+    expect(Number(last.contentLength)).toBe(last.bytes);
+    expect(last.contentType).toMatch(/^multipart\/form-data; boundary=/);
+
+    // The parts arrived intact and in order, and the file bytes round-tripped.
+    const text = last.body.toString('binary');
+    expect(text).toContain('name="reqtype"');
+    expect(text).toContain('fileupload');
+    expect(text).toContain('name="fileToUpload"; filename="a.bin"');
+    expect(text).toContain('Content-Type: image/png');
+    expect(last.body.includes(bytes)).toBe(true);
+  });
+
+  it('sends a buffer source identically (the optimized-image path)', async () => {
+    const bytes = Buffer.from('hello buffer source');
+    respondWith = { status: 200, text: 'ok' };
+    keepBody = true;
+
+    await postMultipart(base, [
+      { name: 'file', filename: 'x.txt', contentType: 'text/plain', source: bufferSource(bytes) },
+    ]);
+
+    expect(Number(last.contentLength)).toBe(last.bytes);
+    expect(last.transferEncoding).toBeUndefined();
+    expect(last.body.includes(bytes)).toBe(true);
+  });
+
+  it('surfaces a non-2xx as a status, and a dead socket as a rejection', async () => {
+    respondWith = { status: 413, text: 'too big' };
+    const resp = await postMultipart(base, [{ name: 'a', value: 'b' }]);
+    expect(isOk(resp)).toBe(false);
+    expect(resp.status).toBe(413);
+    expect(resp.text).toBe('too big');
+
+    await expect(
+      postMultipart('http://127.0.0.1:1/', [{ name: 'a', value: 'b' }]),
+    ).rejects.toMatchObject({ code: 'ECONNREFUSED' });
+  });
+
+  // ── The one that defends the PR ───────────────────────────────────────────────
+  // A 64 MB file through a throttled sink. Streaming keeps only the pipe's queue
+  // live (single-digit MB, independent of file size); anything that buffers the
+  // body — which is EVERY fetch/undici body shape, measured — holds ~1x the file
+  // (and the pre-#543 Blob path held 5x). The gap is enormous, so the threshold
+  // can be generous and still catch a regression.
+  it('holds constant memory: a large file is streamed, never buffered', async () => {
+    const FILE_MB = 96;
+    const chunk = Buffer.alloc(1024 * 1024);
+    for (let i = 0; i < chunk.length; i++) chunk[i] = i & 0xff;
+    const p = path.join(tmpDir, 'big.bin');
+    fs.writeFileSync(p, Buffer.alloc(0));
+    for (let i = 0; i < FILE_MB; i++) fs.appendFileSync(p, chunk);
+    const size = fs.statSync(p).size;
+
+    // Throttle the sink and drop the body, so what we measure is the CLIENT's
+    // retained memory while the upload is genuinely in flight.
+    throttleBytesPerTick = 8 * 1024 * 1024;
+    keepBody = false;
+    respondWith = { status: 200, text: 'ok' };
+
+    forceGc();
+    const baseline = process.memoryUsage().arrayBuffers;
+    let peakLive = baseline;
+    const sampler = setInterval(() => {
+      forceGc(); // collect first, THEN read: we want live bytes, not churn
+      const live = process.memoryUsage().arrayBuffers;
+      if (live > peakLive) peakLive = live;
+    }, 30);
+
+    try {
+      const resp = await postMultipart(base, [
+        {
+          name: 'file',
+          filename: 'big.bin',
+          contentType: 'application/octet-stream',
+          source: fileSource(p, size),
+        },
+      ]);
+      expect(isOk(resp)).toBe(true);
+    } finally {
+      clearInterval(sampler);
+      throttleBytesPerTick = 0;
+      keepBody = true;
+      fs.unlinkSync(p);
+    }
+
+    expect(last.bytes).toBeGreaterThan(size); // the whole file plus part headers
+    const liveMb = (peakLive - baseline) / 1024 / 1024;
+    // What stays live while streaming is the pipe's queue, which is bounded and
+    // does NOT grow with the file (a 300 MB upload measured 7.6 MB live). Buffering
+    // holds at least the whole file. So the bar is a constant, comfortably above
+    // the observed queue depth (~16 MB under full-suite load) and far below 96 MB.
+    expect(liveMb).toBeLessThan(32);
+  });
+});
+
+describe('putSource', () => {
+  it('PUTs a file source with an exact Content-Length (the s3 object path)', async () => {
+    const bytes = Buffer.alloc(64_000, 0x5a);
+    const f = writeTemp('obj.bin', bytes);
+    respondWith = { status: 200, text: '' };
+    keepBody = true;
+
+    const resp = await putSource(base, fileSource(f.path, f.size), {
+      headers: { 'content-type': 'image/png' },
+    });
+
+    expect(isOk(resp)).toBe(true);
+    // A raw PUT body is the object itself — no multipart framing, exact length.
+    expect(Number(last.contentLength)).toBe(size(bytes));
+    expect(last.transferEncoding).toBeUndefined();
+    expect(last.body.equals(bytes)).toBe(true);
+  });
+});
+
+function size(b: Buffer): number {
+  return b.length;
+}

--- a/server/services/uploadProviders/multipart.test.ts
+++ b/server/services/uploadProviders/multipart.test.ts
@@ -143,6 +143,49 @@ describe('postMultipart', () => {
     expect(last.body.includes(bytes)).toBe(true);
   });
 
+  // A provider rejecting an oversized upload is the most common error there is, and
+  // it arrives while we're still sending — so the response has to win over the
+  // EPIPE our own writes then take. NOTE: this passes against the old pipeline-based
+  // code too (a graceful close delivers the response before the write fails), so
+  // it's a behavior test, not a regression guard — it pins the contract that the
+  // provider's status/message is what surfaces, independent of write-error timing.
+  it('reports the provider’s answer when it rejects early and hangs up mid-upload', async () => {
+    const bytes = Buffer.alloc(24 * 1024 * 1024, 0x11); // big enough to still be sending
+    const f = writeTemp('rejected.bin', bytes);
+
+    // A server that answers 413 the moment bytes start arriving, then hangs up
+    // without draining the rest — what a provider does when you exceed its size
+    // limit. It closes GRACEFULLY (response, then FIN), so the answer is on the
+    // wire before our writes start failing; an RST would discard the response and
+    // a socket error really is all that's left, which is why this closes with
+    // socket.end() rather than destroy().
+    const rude = createServer((req, res) => {
+      req.once('data', () => {
+        res.writeHead(413, { 'content-type': 'text/plain', connection: 'close' });
+        res.end('Files larger than 200MB are not allowed.');
+        res.socket?.end();
+      });
+    });
+    await new Promise<void>((r) => rude.listen(0, '127.0.0.1', () => r()));
+    const rudeBase = `http://127.0.0.1:${(rude.address() as AddressInfo).port}/`;
+
+    try {
+      const resp = await postMultipart(rudeBase, [
+        {
+          name: 'fileToUpload',
+          filename: 'rejected.bin',
+          contentType: 'application/octet-stream',
+          source: fileSource(f.path, f.size),
+        },
+      ]);
+      // The status and the message survive — not an EPIPE rejection.
+      expect(resp.status).toBe(413);
+      expect(resp.text).toContain('Files larger than 200MB');
+    } finally {
+      rude.close();
+    }
+  });
+
   it('surfaces a non-2xx as a status, and a dead socket as a rejection', async () => {
     respondWith = { status: 413, text: 'too big' };
     const resp = await postMultipart(base, [{ name: 'a', value: 'b' }]);

--- a/server/services/uploadProviders/multipart.ts
+++ b/server/services/uploadProviders/multipart.ts
@@ -4,18 +4,37 @@
 import { randomBytes } from 'crypto';
 import https from 'https';
 import http from 'http';
+import type { IncomingHttpHeaders } from 'http';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { sizeOf, streamOf, type UploadSource } from './source.js';
 
-// Manual multipart/form-data encoder that produces a single Buffer with a
-// known Content-Length. The browser-style WHATWG FormData + native fetch
-// combination sends the body with chunked transfer encoding, which catbox's
-// PHP backend silently stalls on. Pre-serialising the body sidesteps that.
+// Multipart/form-data encoding + posting, on node's http/https rather than fetch.
+//
+// TWO reasons this doesn't use fetch, and both are load-bearing:
+//
+//   1. Chunked encoding. WHATWG FormData + native fetch sends the body with
+//      chunked transfer-encoding, which catbox's PHP backend silently stalls on.
+//      We always send an exact Content-Length instead.
+//   2. Memory. undici (fetch's engine) does NOT propagate backpressure into a
+//      request body — it drains the whole thing into memory first, whatever shape
+//      you hand it. Measured on node 22 with a 300 MB upload: fetch holds 300 MB
+//      live no matter what; node:http + pipeline holds 7 MB. See source.ts for the
+//      full table. This is why `postMultipart` streams and why fetch must never
+//      come back to an upload path.
 
 const CRLF = '\r\n';
 
-/** A text field or a binary file field in a multipart form. */
+/** A text field or a file field in a multipart form. A file field's bytes come
+ *  from an UploadSource, so the caller never has to know whether they live in a
+ *  buffer or in a temp file on disk — this module streams either one. */
 export type MultipartPart =
   | { name: string; value: string; filename?: undefined; contentType?: undefined }
   | { name: string; filename: string; contentType?: string; value: Buffer | string };
+
+export type StreamPart =
+  | { name: string; value: string; filename?: undefined; contentType?: undefined }
+  | { name: string; filename: string; contentType?: string; source: UploadSource };
 
 export interface MultipartResult {
   body: Buffer;
@@ -24,30 +43,60 @@ export interface MultipartResult {
 
 export interface PostBufferResult {
   status: number;
-  headers: http.IncomingHttpHeaders;
+  headers: IncomingHttpHeaders;
   text: string;
 }
 
+export interface RequestOptions {
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+}
+
+/** fetch's `resp.ok`, for the node:http results these helpers return. */
+export function isOk(resp: PostBufferResult): boolean {
+  return resp.status >= 200 && resp.status < 300;
+}
+
+/** fetch's `resp.json().catch(() => null)`. Providers occasionally answer a
+ *  success status with a non-JSON body; callers already treat that as an error. */
+export function jsonBody(resp: PostBufferResult): unknown {
+  try {
+    return JSON.parse(resp.text);
+  } catch {
+    return null;
+  }
+}
+
+// RFC 7578: backslashes and quotes in filenames need escaping.
+function encodeFilename(name: string): string {
+  return name.replace(/["\\]/g, (c) => `\\${c}`);
+}
+
+function partHeader(boundary: string, part: MultipartPart | StreamPart): Buffer {
+  if (part.filename !== undefined) {
+    return Buffer.from(
+      `--${boundary}${CRLF}` +
+        `Content-Disposition: form-data; name="${part.name}"; filename="${encodeFilename(part.filename)}"${CRLF}` +
+        `Content-Type: ${part.contentType || 'application/octet-stream'}${CRLF}${CRLF}`,
+    );
+  }
+  return Buffer.from(
+    `--${boundary}${CRLF}Content-Disposition: form-data; name="${part.name}"${CRLF}${CRLF}` +
+      String((part as { value: string }).value),
+  );
+}
+
+/** Serialize a whole multipart body into one Buffer. Still used for small bodies
+ *  (catbox's delete), where streaming would be pure ceremony. Never use it for an
+ *  upload — that's what postMultipart is for. */
 export function buildMultipart(parts: MultipartPart[]): MultipartResult {
   const boundary = `----LurkerBoundary${randomBytes(16).toString('hex')}`;
   const chunks: Buffer[] = [];
 
   for (const part of parts) {
-    chunks.push(Buffer.from(`--${boundary}${CRLF}`));
-    if (part.filename) {
-      chunks.push(
-        Buffer.from(
-          `Content-Disposition: form-data; name="${part.name}"; filename="${encodeFilename(part.filename)}"${CRLF}` +
-            `Content-Type: ${part.contentType || 'application/octet-stream'}${CRLF}${CRLF}`,
-        ),
-      );
+    chunks.push(partHeader(boundary, part));
+    if (part.filename !== undefined) {
       chunks.push(Buffer.isBuffer(part.value) ? part.value : Buffer.from(part.value));
-    } else {
-      chunks.push(
-        Buffer.from(
-          `Content-Disposition: form-data; name="${part.name}"${CRLF}${CRLF}` + String(part.value),
-        ),
-      );
     }
     chunks.push(Buffer.from(CRLF));
   }
@@ -59,28 +108,17 @@ export function buildMultipart(parts: MultipartPart[]): MultipartResult {
   };
 }
 
-// RFC 7578: backslashes and quotes in filenames need to be escaped. Most
-// servers also accept percent-encoded bytes, which sidesteps quirky encodings
-// when filenames contain non-ASCII.
-function encodeFilename(name: string): string {
-  return name.replace(/["\\]/g, (c) => `\\${c}`);
-}
-
-// Direct https/http POST that bypasses undici. Node's native fetch wraps
-// undici, which has historically been finicky with picky servers (catbox's
-// PHP backend in particular wedges on the combination of HTTP/1.1 keepalive
-// and the recomputed Content-Length undici emits). Using https.request keeps
-// us closer to the axios/form-data path that's known to work end-to-end.
-//
-// Returns { status, headers, text }. The body is buffered fully — every
-// provider response we care about is small (a URL or a tiny JSON object).
-export function postBuffer(
+// The one place we actually talk HTTP. `makeBody` is called once, lazily, and its
+// chunks are piped into the request — so a file part is read off disk at the rate
+// the socket drains it, and nothing accumulates. contentLength MUST be exact; it's
+// computed by the caller from part headers + byte sizes, all of which are known
+// before a single byte is read.
+function sendStreamed(
+  method: 'POST' | 'PUT',
   urlString: string,
-  body: Buffer,
-  {
-    headers = {},
-    timeoutMs = 60_000,
-  }: { headers?: Record<string, string>; timeoutMs?: number } = {},
+  contentLength: number,
+  makeBody: () => AsyncIterable<Buffer>,
+  { headers = {}, timeoutMs = 60_000 }: RequestOptions = {},
 ): Promise<PostBufferResult> {
   return new Promise((resolve, reject) => {
     let url: URL;
@@ -94,17 +132,19 @@ export function postBuffer(
 
     const req = lib.request(
       {
-        method: 'POST',
+        method,
         hostname: url.hostname,
         port: url.port || (isHttps ? 443 : 80),
         path: `${url.pathname}${url.search}`,
         headers: {
-          'Content-Length': String(body.length),
+          'Content-Length': String(contentLength),
           Connection: 'close',
           ...headers,
         },
       },
       (res) => {
+        // Provider responses are small (a URL or a little JSON), so buffering the
+        // RESPONSE is fine — it's the request body that had to stop being buffered.
         const chunks: Buffer[] = [];
         res.on('data', (c: Buffer) => chunks.push(c));
         res.on('end', () => {
@@ -123,7 +163,85 @@ export function postBuffer(
       );
     });
     req.on('error', reject);
-    req.write(body);
-    req.end();
+    // pipeline ends the request when the body is exhausted, and destroys it (so
+    // the socket doesn't leak) if reading the source fails partway.
+    pipeline(Readable.from(makeBody()), req).catch(reject);
   });
+}
+
+/** POST a pre-serialized body. For small payloads only. */
+export function postBuffer(
+  urlString: string,
+  body: Buffer,
+  opts: RequestOptions = {},
+): Promise<PostBufferResult> {
+  return sendStreamed(
+    'POST',
+    urlString,
+    body.length,
+    async function* () {
+      yield body;
+    },
+    opts,
+  );
+}
+
+/** POST a multipart form, streaming any file parts straight off disk. This is the
+ *  upload path for every HTTP-forwarding driver. */
+export function postMultipart(
+  urlString: string,
+  parts: StreamPart[],
+  opts: RequestOptions = {},
+): Promise<PostBufferResult> {
+  const boundary = `----LurkerBoundary${randomBytes(16).toString('hex')}`;
+  const closing = Buffer.from(`--${boundary}--${CRLF}`);
+  const crlf = Buffer.from(CRLF);
+
+  // Exact Content-Length up front: headers are known strings, and a file part's
+  // size is known from the temp file's stat. No need to read a byte to compute it.
+  let contentLength = closing.length;
+  const heads = parts.map((part) => {
+    const head = partHeader(boundary, part);
+    const bodyLen = 'source' in part ? sizeOf(part.source) : 0;
+    contentLength += head.length + bodyLen + crlf.length;
+    return head;
+  });
+
+  async function* body(): AsyncIterable<Buffer> {
+    for (let i = 0; i < parts.length; i++) {
+      yield heads[i];
+      const part = parts[i];
+      if ('source' in part) {
+        for await (const chunk of streamOf(part.source)) yield chunk as Buffer;
+      }
+      yield crlf;
+    }
+    yield closing;
+  }
+
+  return sendStreamed('POST', urlString, contentLength, body, {
+    ...opts,
+    headers: {
+      'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      ...opts.headers,
+    },
+  });
+}
+
+/** PUT raw bytes, streamed. Used by the s3 driver, whose body is the object
+ *  itself rather than a multipart form. */
+export function putSource(
+  urlString: string,
+  source: UploadSource,
+  opts: RequestOptions = {},
+): Promise<PostBufferResult> {
+  return sendStreamed(
+    'PUT',
+    urlString,
+    sizeOf(source),
+    async function* () {
+      for await (const chunk of streamOf(source)) yield chunk as Buffer;
+    },
+    opts,
+  );
 }

--- a/server/services/uploadProviders/multipart.ts
+++ b/server/services/uploadProviders/multipart.ts
@@ -6,7 +6,6 @@ import https from 'https';
 import http from 'http';
 import type { IncomingHttpHeaders } from 'http';
 import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import { sizeOf, streamOf, type UploadSource } from './source.js';
 
 // Multipart/form-data encoding + posting, on node's http/https rather than fetch.
@@ -24,6 +23,17 @@ import { sizeOf, streamOf, type UploadSource } from './source.js';
 //      come back to an upload path.
 
 const CRLF = '\r\n';
+
+/** Drop the named headers (case-insensitively) from a caller-supplied set, so a
+ *  header this module computes can't be shadowed by a case variant — node would
+ *  otherwise emit both and produce a malformed request. */
+function omitHeaders(headers: Record<string, string>, drop: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (!drop.includes(k.toLowerCase())) out[k] = v;
+  }
+  return out;
+}
 
 /** A text field or a file field in a multipart form. A file field's bytes come
  *  from an UploadSource, so the caller never has to know whether they live in a
@@ -130,30 +140,53 @@ function sendStreamed(
     const isHttps = url.protocol === 'https:';
     const lib = isHttps ? https : http;
 
+    let settled = false;
+    let gotResponse = false;
+    const done = (r: PostBufferResult): void => {
+      if (!settled) {
+        settled = true;
+        resolve(r);
+      }
+    };
+    const fail = (err: Error): void => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    };
+
     const req = lib.request(
       {
         method,
         hostname: url.hostname,
         port: url.port || (isHttps ? 443 : 80),
         path: `${url.pathname}${url.search}`,
+        // Content-Length and Connection are OURS: a caller that supplied either
+        // could silently corrupt the framing (a wrong Content-Length hangs the
+        // request or truncates the body). Strip any case-variant they passed so
+        // node can't emit the header twice.
         headers: {
+          ...omitHeaders(headers, ['content-length', 'connection']),
           'Content-Length': String(contentLength),
           Connection: 'close',
-          ...headers,
         },
       },
       (res) => {
+        gotResponse = true;
         // Provider responses are small (a URL or a little JSON), so buffering the
         // RESPONSE is fine — it's the request body that had to stop being buffered.
         const chunks: Buffer[] = [];
         res.on('data', (c: Buffer) => chunks.push(c));
-        res.on('end', () => {
-          resolve({
+        const finish = (): void =>
+          done({
             status: res.statusCode || 0,
             headers: res.headers,
             text: Buffer.concat(chunks).toString('utf8'),
           });
-        });
+        res.on('end', finish);
+        // A peer that answers early and hangs up may never deliver 'end'. Settle
+        // with what arrived rather than hanging until the timeout.
+        res.on('close', finish);
       },
     );
 
@@ -162,10 +195,30 @@ function sendStreamed(
         Object.assign(new Error(`request timed out after ${timeoutMs}ms`), { code: 'ETIMEDOUT' }),
       );
     });
-    req.on('error', reject);
-    // pipeline ends the request when the body is exhausted, and destroys it (so
-    // the socket doesn't leak) if reading the source fails partway.
-    pipeline(Readable.from(makeBody()), req).catch(reject);
+
+    // Deliberately NOT stream.pipeline, which rejects on a write error and destroys
+    // the request with it.
+    //
+    // A provider that rejects a big upload EARLY (catbox: "Files larger than 200MB
+    // are not allowed"; a 401 on a bad token) answers and hangs up while we are
+    // still pushing bytes, so our write then fails with EPIPE/ECONNRESET. That
+    // write error is the expected *consequence* of the rejection, not the outcome —
+    // the outcome is the status and message the server just sent. Streaming makes
+    // this window the whole upload rather than microseconds, so make the response
+    // authoritative whenever we got one, and let a write error only speak for
+    // itself when we didn't. (In practice a graceful close delivers the response
+    // first and an abortive one discards it, so this is belt-and-braces rather than
+    // a bug fix — but it removes the timing dependency either way.)
+    const body = Readable.from(makeBody());
+    body.on('error', (err: Error) => {
+      req.destroy();
+      fail(err);
+    });
+    req.on('error', (err: Error) => {
+      body.destroy();
+      if (!gotResponse) fail(err);
+    });
+    body.pipe(req);
   });
 }
 
@@ -221,9 +274,11 @@ export function postMultipart(
 
   return sendStreamed('POST', urlString, contentLength, body, {
     ...opts,
+    // Ours wins: a caller-supplied Content-Type would carry the wrong boundary (or
+    // none), and the server would fail to parse a body it can't find the parts in.
     headers: {
+      ...omitHeaders(opts.headers ?? {}, ['content-type']),
       'Content-Type': `multipart/form-data; boundary=${boundary}`,
-      ...opts.headers,
     },
   });
 }

--- a/server/services/uploadProviders/s3.ts
+++ b/server/services/uploadProviders/s3.ts
@@ -23,6 +23,8 @@
 
 import { createHash, createHmac, randomBytes } from 'node:crypto';
 import { USER_AGENT } from '../../utils/userAgent.js';
+import { putSource, isOk } from './multipart.js';
+import { hashOf, type UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 export const driver = 's3';
@@ -151,6 +153,7 @@ export function signObjectRequest(
     bucket,
     key,
     payload = Buffer.alloc(0),
+    payloadHash: precomputedHash,
     contentType,
     region,
     accessKeyId,
@@ -161,6 +164,11 @@ export function signObjectRequest(
     bucket: string;
     key: string;
     payload?: Buffer;
+    // Hex sha256 of the body, when the caller already has it. SigV4 needs the
+    // payload hash to sign, but an upload's payload may be a 200 MB temp file we
+    // refuse to read into memory — so the caller streams it through a hash first
+    // (source.hashOf) and passes the digest here instead of the bytes.
+    payloadHash?: string;
     contentType?: string;
     region: string;
     accessKeyId: string;
@@ -179,7 +187,7 @@ export function signObjectRequest(
     .replace(/\.\d{3}Z$/, 'Z');
   const dateStamp = amzDate.slice(0, 8);
   const scope = `${dateStamp}/${region}/s3/aws4_request`;
-  const payloadHash = sha256hex(payload);
+  const payloadHash = precomputedHash ?? sha256hex(payload);
 
   // Signed headers, sorted by lowercase name. Everything we send that the server
   // may validate is signed — including cache-control, so a store can't reject it
@@ -228,7 +236,7 @@ function requireField(config: Record<string, string>, field: string): string {
 }
 
 export async function upload(
-  buffer: Buffer,
+  source: UploadSource,
   { filename, mime, kind }: UploadMeta,
   config: Record<string, string> = {},
 ): Promise<UploadResult> {
@@ -241,26 +249,27 @@ export async function upload(
   const region = (config.region || '').trim() || 'auto';
 
   const key = buildObjectKey(filename, { kind, prefix: config.key_prefix });
+  // SigV4 signs the payload hash, so the bytes get read twice: once to hash
+  // (streamed, constant memory), once to send (streamed, constant memory). Two
+  // passes over a warm temp file beats holding it in the heap. UNSIGNED-PAYLOAD
+  // would avoid the first pass but changes the signing contract — not this PR.
+  const payloadHash = await hashOf(source);
   const signed = signObjectRequest({
     method: 'PUT',
     endpoint,
     bucket,
     key,
-    payload: buffer,
+    payloadHash,
     contentType: mime,
     region,
     accessKeyId,
     secretAccessKey,
   });
 
-  const resp = await fetch(signed.url, {
-    method: 'PUT',
-    headers: signed.headers,
-    body: new Uint8Array(buffer),
-  });
+  const resp = await putSource(signed.url, source, { headers: signed.headers });
 
-  if (!resp.ok) {
-    const text = (await resp.text()).slice(0, 200);
+  if (!isOk(resp)) {
+    const text = resp.text.slice(0, 200);
     throw Object.assign(new Error(`s3 upload failed: ${resp.status} ${text}`), {
       code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
     });

--- a/server/services/uploadProviders/source.ts
+++ b/server/services/uploadProviders/source.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// What a driver is handed to upload. Two shapes, one interface:
+//
+//   file   — bytes sitting in a temp file (multer's diskStorage). This is the
+//            passthrough path: text and (with #515) media, where the original
+//            bytes go out untouched and may be hundreds of megabytes.
+//   buffer — bytes we produced in memory. This is the image path: the pipeline's
+//            optimized output is small and bounded (resized + re-encoded), so
+//            round-tripping it through a temp file would be pointless I/O.
+//
+// The point of the union is that the branch lives HERE, not in seven drivers.
+// Every driver takes an UploadSource and calls streamOf/sizeOf/hashOf/moveTo; no
+// driver knows or cares which shape it got.
+//
+// ⚠ Why any of this exists — measured 2026-07-12 on the production runtime
+// (Linux, node 22), 300 MB upload, live `arrayBuffers` sampled after a forced GC:
+//
+//   node:http + pipeline .............   7.6 MB live  (0.03x)
+//   fetch, streamed multipart body ...   301 MB live  (1.0x)
+//   fetch, openAsBlob in FormData ....   301 MB live  (1.0x)
+//   fetch, Blob([Uint8Array(buf)]) ...  1501 MB live  (5.0x)   <- what we shipped
+//
+// **undici does not propagate backpressure into a request body.** It drains the
+// source into memory no matter how the body is supplied — Blob, file-backed Blob,
+// ReadableStream, or a hand-built multipart stream with an exact Content-Length.
+// Only node's own http/https + stream.pipeline holds constant memory. That is why
+// the drivers post through multipart.ts instead of fetch(), and why `fetch` must
+// not creep back into an upload path. (It's fine for small bodies: delete calls,
+// moderation reports, response reads.)
+
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+import { Readable } from 'node:stream';
+
+export type UploadSource =
+  | { kind: 'buffer'; data: Buffer }
+  | { kind: 'file'; path: string; size: number };
+
+export function bufferSource(data: Buffer): UploadSource {
+  return { kind: 'buffer', data };
+}
+
+export function fileSource(path: string, size: number): UploadSource {
+  return { kind: 'file', path, size };
+}
+
+export function sizeOf(source: UploadSource): number {
+  return source.kind === 'buffer' ? source.data.length : source.size;
+}
+
+/** A fresh Readable over the bytes. Fresh each call: a retry needs to re-read
+ *  from the start, and a consumed stream can't be rewound. */
+export function streamOf(source: UploadSource): Readable {
+  return source.kind === 'buffer' ? Readable.from([source.data]) : fs.createReadStream(source.path);
+}
+
+/** Hex sha256 of the bytes. Streamed, so hashing a 200 MB file costs one pass and
+ *  no memory — s3's SigV4 needs the payload hash before it can sign the request,
+ *  which is why the file gets read twice (hash, then send). */
+export async function hashOf(source: UploadSource): Promise<string> {
+  if (source.kind === 'buffer') {
+    return createHash('sha256').update(source.data).digest('hex');
+  }
+  const hash = createHash('sha256');
+  for await (const chunk of fs.createReadStream(source.path)) {
+    hash.update(chunk as Buffer);
+  }
+  return hash.digest('hex');
+}
+
+/** Put the bytes at `dest`, replacing whatever is there. A file source is renamed
+ *  (zero copies — the common case for `local`, where multer's temp file and the
+ *  storage dir are on the same filesystem); a buffer source is written. Falls back
+ *  to a copy when rename crosses a device boundary (EXDEV — e.g. LOCAL_UPLOADS_DIR
+ *  on a different mount than the data dir). */
+export async function moveTo(source: UploadSource, dest: string): Promise<void> {
+  if (source.kind === 'buffer') {
+    await fs.promises.writeFile(dest, source.data, { mode: 0o644 });
+    return;
+  }
+  try {
+    await fs.promises.rename(source.path, dest);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EXDEV') throw err;
+    await fs.promises.copyFile(source.path, dest);
+    await fs.promises.unlink(source.path).catch(() => {});
+  }
+  await fs.promises.chmod(dest, 0o644).catch(() => {});
+}
+
+/** The whole thing as a Buffer. For tests and for callers that genuinely need the
+ *  bytes in memory — never on the upload hot path, which is the entire point. */
+export async function readAll(source: UploadSource): Promise<Buffer> {
+  return source.kind === 'buffer' ? source.data : fs.promises.readFile(source.path);
+}

--- a/server/services/uploadProviders/source.ts
+++ b/server/services/uploadProviders/source.ts
@@ -89,9 +89,3 @@ export async function moveTo(source: UploadSource, dest: string): Promise<void> 
   }
   await fs.promises.chmod(dest, 0o644).catch(() => {});
 }
-
-/** The whole thing as a Buffer. For tests and for callers that genuinely need the
- *  bytes in memory — never on the upload hot path, which is the entire point. */
-export async function readAll(source: UploadSource): Promise<Buffer> {
-  return source.kind === 'buffer' ? source.data : fs.promises.readFile(source.path);
-}

--- a/server/services/uploadProviders/types.ts
+++ b/server/services/uploadProviders/types.ts
@@ -8,6 +8,8 @@
 // registry) and the individual driver modules can import the types without an
 // import cycle.
 
+import type { UploadSource } from './source.js';
+
 export type ContentClass = 'image' | 'text' | 'binary';
 
 /** One field a driver needs configured. `secret` fields are encrypted at rest
@@ -75,7 +77,15 @@ export interface UploadDriver {
   label: string; // default human label
   capabilities: DriverCapabilities;
   configSchema: ConfigField[];
-  upload(buffer: Buffer, meta: UploadMeta, config: Record<string, string>): Promise<UploadResult>;
+  // The bytes arrive as an UploadSource (source.ts), not a Buffer: a passthrough
+  // upload can be hundreds of megabytes and lives in a temp file, which the driver
+  // streams rather than reads. A driver must NOT readAll() it on the upload path —
+  // that reintroduces exactly the heap blowup #543 removed.
+  upload(
+    source: UploadSource,
+    meta: UploadMeta,
+    config: Record<string, string>,
+  ): Promise<UploadResult>;
   // Present iff capabilities.supportsDelete. CONTRACT: must be idempotent —
   // "already gone" resolves rather than throws, because the route drops the DB
   // row only after delete() succeeds, so a delete whose response was lost gets

--- a/server/services/uploadProviders/uploadProviders.test.ts
+++ b/server/services/uploadProviders/uploadProviders.test.ts
@@ -10,9 +10,42 @@ import * as chibisafe from './chibisafe.js';
 import * as s3 from './s3.js';
 import * as multipart from './multipart.js';
 import type { PostBufferResult } from './multipart.js';
+import { bufferSource } from './source.js';
+import { createHash } from 'node:crypto';
 
-// Helper that grabs the FormData passed to fetch() so we can assert the
-// multipart shape without reaching into providers' internals.
+// UPLOADS now go through multipart.postMultipart (node:http + pipeline), never
+// fetch — undici buffers request bodies, which is the whole point of #543. So the
+// upload path is captured by spying on that one helper, and what we assert is the
+// multipart PARTS (field name, filename, content type, source) rather than a
+// FormData object. The DELETE paths still use fetch (tiny bodies), so the fetch
+// capture below stays for them.
+interface CapturedPost {
+  url: string | null;
+  parts: multipart.StreamPart[] | null;
+  headers: Record<string, string> | null;
+}
+function capturePost(): CapturedPost {
+  const captured: CapturedPost = { url: null, parts: null, headers: null };
+  vi.spyOn(multipart, 'postMultipart').mockImplementation(
+    async (url: string, parts: multipart.StreamPart[], opts?: multipart.RequestOptions) => {
+      captured.url = url;
+      captured.parts = parts;
+      captured.headers = opts?.headers ?? {};
+      return postResponse;
+    },
+  );
+  return captured;
+}
+
+/** The file part of a captured multipart post, for shape assertions. */
+function filePart(cap: CapturedPost, name: string): multipart.StreamPart & { source: unknown } {
+  const part = cap.parts?.find((p) => p.name === name);
+  if (!part || !('source' in part)) throw new Error(`no file part named ${name}`);
+  return part as multipart.StreamPart & { source: unknown };
+}
+
+// Captures a fetch() call — used by the DELETE tests (and catbox's HEAD probe),
+// which legitimately still use fetch.
 function captureFormData(): {
   url: string | null;
   init: RequestInit | null;
@@ -34,8 +67,7 @@ function captureFormData(): {
   return captured;
 }
 
-// Catbox uses postBuffer (https.request under the hood) instead of fetch.
-// We spy on postBuffer directly to capture the body Buffer and headers.
+// Catbox's DELETE still uses postBuffer (a small hand-encoded body).
 function captureCatboxCall(): {
   url: string | null;
   body: Buffer | null;
@@ -57,12 +89,37 @@ function captureCatboxCall(): {
   return captured;
 }
 
+/** Stub the streamed PUT the s3 driver uses. */
+function capturePut(): { url: string | null; headers: Record<string, string> | null } {
+  const captured: { url: string | null; headers: Record<string, string> | null } = {
+    url: null,
+    headers: null,
+  };
+  vi.spyOn(multipart, 'putSource').mockImplementation(
+    async (url: string, _source: unknown, opts?: multipart.RequestOptions) => {
+      captured.url = url;
+      captured.headers = opts?.headers ?? {};
+      return postResponse;
+    },
+  );
+  return captured;
+}
+
 let captureResponse: Response;
 let catboxResponse: PostBufferResult;
+let postResponse: PostBufferResult;
+
+/** Every driver takes an UploadSource now; the tests' bytes are small, so a
+ *  buffer source is the natural stand-in. The streaming (file-source) path gets
+ *  its own real-HTTP coverage in multipart.test.ts. */
+function src(bytes: number[]): ReturnType<typeof bufferSource> {
+  return bufferSource(Buffer.from(bytes));
+}
 
 beforeEach(() => {
   captureResponse = new Response('https://example.test/abc.png', { status: 200 });
   catboxResponse = { status: 200, headers: {}, text: 'https://files.catbox.moe/xyz.png' };
+  postResponse = { status: 200, headers: {}, text: 'https://example.test/abc.png' };
 });
 
 afterEach(() => {
@@ -71,80 +128,91 @@ afterEach(() => {
 
 describe('x0 provider', () => {
   it('POSTs multipart `file` and returns the URL from the response body', async () => {
-    const cap = captureFormData();
-    const result = await x0.upload(Buffer.from([1, 2, 3]), {
+    const cap = capturePost();
+    const result = await x0.upload(src([1, 2, 3]), {
       filename: 'a.png',
       mime: 'image/png',
     });
     expect(cap.url).toBe('https://x0.at/');
-    expect((cap.init as RequestInit & { method: string }).method).toBe('POST');
-    expect(
-      (cap.init as RequestInit & { headers: Record<string, string> }).headers['User-Agent'],
-    ).toMatch(/^Lurker\//);
-    expect(cap.formData!.get('file')).toBeInstanceOf(Blob);
+    expect(cap.headers!['User-Agent']).toMatch(/^Lurker\//);
+    const file = filePart(cap, 'file');
+    expect(file.filename).toBe('a.png');
+    expect(file.contentType).toBe('image/png');
     expect(result.url).toBe('https://example.test/abc.png');
   });
 
   it('throws PROVIDER_ERROR on non-2xx response', async () => {
-    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('rejected', { status: 500 }));
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
+      status: 500,
+      headers: {},
+      text: 'rejected',
+    });
     await expect(
-      x0.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }),
+      x0.upload(src([1]), { filename: 'x.png', mime: 'image/png' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
   });
 
   it('throws PROVIDER_ERROR when response is not a URL', async () => {
-    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('not a url', { status: 200 }));
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
+      status: 200,
+      headers: {},
+      text: 'not a url',
+    });
     await expect(
-      x0.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }),
+      x0.upload(src([1]), { filename: 'x.png', mime: 'image/png' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
   });
 });
 
 describe('catbox provider', () => {
-  it('POSTs a hand-encoded multipart body via postBuffer with reqtype, optional userhash, and fileToUpload', async () => {
-    const cap = captureCatboxCall();
+  it('POSTs a streamed multipart body with reqtype, optional userhash, and fileToUpload', async () => {
+    const cap = capturePost();
+    postResponse = { status: 200, headers: {}, text: 'https://files.catbox.moe/xyz.png' };
     const result = await catbox.upload(
-      Buffer.from([7, 7]),
+      src([7, 7]),
       { filename: 'b.png', mime: 'image/png' },
       { userhash: 'abc123' },
     );
     expect(cap.url).toBe('https://catbox.moe/user/api.php');
-    expect(Buffer.isBuffer(cap.body)).toBe(true);
-    expect(cap.headers!['Content-Type']).toMatch(/^multipart\/form-data; boundary=/);
     expect(cap.headers!['User-Agent']).toMatch(/^Lurker\//);
-    const text = cap.body!.toString('binary');
-    expect(text).toContain('name="reqtype"');
-    expect(text).toContain('fileupload');
-    expect(text).toContain('name="userhash"');
-    expect(text).toContain('abc123');
-    expect(text).toContain('name="fileToUpload"; filename="b.png"');
-    expect(text).toContain('Content-Type: image/png');
+    // Text fields carry values; the file part carries a source postMultipart
+    // streams. Content-Length is still exact (catbox stalls on chunked encoding),
+    // which multipart.test.ts asserts against a real socket.
+    expect(cap.parts).toEqual([
+      { name: 'reqtype', value: 'fileupload' },
+      { name: 'userhash', value: 'abc123' },
+      expect.objectContaining({
+        name: 'fileToUpload',
+        filename: 'b.png',
+        contentType: 'image/png',
+      }),
+    ]);
     expect(result.url).toBe('https://files.catbox.moe/xyz.png');
   });
 
   it('omits userhash when not provided', async () => {
-    const cap = captureCatboxCall();
-    await catbox.upload(Buffer.from([1]), { filename: 'a.png', mime: 'image/png' }, {});
-    const text = cap.body!.toString('binary');
-    expect(text).not.toContain('name="userhash"');
+    const cap = capturePost();
+    postResponse = { status: 200, headers: {}, text: 'https://files.catbox.moe/xyz.png' };
+    await catbox.upload(src([1]), { filename: 'a.png', mime: 'image/png' }, {});
+    expect(cap.parts!.some((p) => p.name === 'userhash')).toBe(false);
   });
 
   it('throws PROVIDER_ERROR on non-URL response body (catbox returns 200 with error string)', async () => {
-    vi.spyOn(multipart, 'postBuffer').mockResolvedValue({
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
       status: 200,
       headers: {},
       text: 'Files larger than 200MB are not allowed.',
     });
     await expect(
-      catbox.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, {}),
+      catbox.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, {}),
     ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
   });
 
   it('surfaces the underlying socket error code on transport failure', async () => {
     const sockErr = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
-    vi.spyOn(multipart, 'postBuffer').mockRejectedValue(sockErr);
+    vi.spyOn(multipart, 'postMultipart').mockRejectedValue(sockErr);
     await expect(
-      catbox.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, {}),
+      catbox.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, {}),
     ).rejects.toMatchObject({
       code: 'PROVIDER_ERROR',
       message: expect.stringContaining('ECONNRESET'),
@@ -154,18 +222,15 @@ describe('catbox provider', () => {
   // Deletability is decided at capture time: only a userhash upload can ever be
   // deleted on catbox's side, so only it carries a ref.
   it('returns the served filename as ref for userhash uploads, no ref when anonymous', async () => {
-    captureCatboxCall();
+    capturePost();
+    postResponse = { status: 200, headers: {}, text: 'https://files.catbox.moe/xyz.png' };
     const withHash = await catbox.upload(
-      Buffer.from([1]),
+      src([1]),
       { filename: 'a.png', mime: 'image/png' },
       { userhash: 'abc123' },
     );
     expect(withHash.ref).toBe('xyz.png');
-    const anonymous = await catbox.upload(
-      Buffer.from([1]),
-      { filename: 'a.png', mime: 'image/png' },
-      {},
-    );
+    const anonymous = await catbox.upload(src([1]), { filename: 'a.png', mime: 'image/png' }, {});
     expect(anonymous.ref).toBeUndefined();
   });
 
@@ -231,38 +296,33 @@ describe('catbox provider', () => {
 
 describe('hoarder provider', () => {
   it('POSTs to {base}/api/upload with Authorization: Bearer and `file` field', async () => {
-    const cap = captureFormData();
-    captureResponse = new Response(
-      JSON.stringify({ id: 'aB3kZ', url: 'https://cdn.test/aB3kZ.gif' }),
-      {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      },
-    );
+    const cap = capturePost();
+    postResponse = {
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ id: 'aB3kZ', url: 'https://cdn.test/aB3kZ.gif' }),
+    };
     const result = await hoarder.upload(
-      Buffer.from([0xff, 0xd8]),
+      src([0xff, 0xd8]),
       { filename: 'wave.gif', mime: 'image/gif' },
       { url: 'https://upload.example.com', api_key: 'sekret' },
     );
     expect(cap.url).toBe('https://upload.example.com/api/upload');
-    expect(
-      (cap.init as RequestInit & { headers: Record<string, string> }).headers.Authorization,
-    ).toBe('Bearer sekret');
-    expect(
-      (cap.init as RequestInit & { headers: Record<string, string> }).headers['User-Agent'],
-    ).toMatch(/^Lurker\//);
-    expect(cap.formData!.get('file')).toBeInstanceOf(Blob);
+    expect(cap.headers!.Authorization).toBe('Bearer sekret');
+    expect(cap.headers!['User-Agent']).toMatch(/^Lurker\//);
+    expect(filePart(cap, 'file').filename).toBe('wave.gif');
     expect(result.url).toBe('https://cdn.test/aB3kZ.gif');
   });
 
   it('strips trailing slash from base URL', async () => {
-    const cap = captureFormData();
-    captureResponse = new Response(JSON.stringify({ url: 'https://cdn.test/x.png' }), {
+    const cap = capturePost();
+    postResponse = {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+      headers: {},
+      text: JSON.stringify({ url: 'https://cdn.test/x.png' }),
+    };
     await hoarder.upload(
-      Buffer.from([1]),
+      src([1]),
       { filename: 'x.png', mime: 'image/png' },
       { url: 'https://upload.example.com/', api_key: 'k' },
     );
@@ -271,27 +331,25 @@ describe('hoarder provider', () => {
 
   it('rejects with PROVIDER_CONFIG when url is missing', async () => {
     await expect(
-      hoarder.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, { api_key: 'k' }),
+      hoarder.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { api_key: 'k' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
   });
 
   it('rejects with PROVIDER_CONFIG when api_key is missing', async () => {
     await expect(
-      hoarder.upload(
-        Buffer.from([1]),
-        { filename: 'x.png', mime: 'image/png' },
-        { url: 'https://u' },
-      ),
+      hoarder.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { url: 'https://u' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
   });
 
   it('maps 401 to PROVIDER_AUTH', async () => {
-    globalThis.fetch = vi.fn<typeof fetch>(
-      async () => new Response('Invalid API key', { status: 401 }),
-    );
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
+      status: 401,
+      headers: {},
+      text: 'Invalid API key',
+    });
     await expect(
       hoarder.upload(
-        Buffer.from([1]),
+        src([1]),
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', api_key: 'bad' },
       ),
@@ -299,16 +357,14 @@ describe('hoarder provider', () => {
   });
 
   it('rejects PROVIDER_ERROR when JSON has no url', async () => {
-    globalThis.fetch = vi.fn<typeof fetch>(
-      async () =>
-        new Response(JSON.stringify({ id: 'x' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-    );
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ id: 'x' }),
+    });
     await expect(
       hoarder.upload(
-        Buffer.from([1]),
+        src([1]),
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', api_key: 'k' },
       ),
@@ -318,35 +374,36 @@ describe('hoarder provider', () => {
 
 describe('zipline provider', () => {
   it('POSTs to {base}/api/upload with raw authorization header and `file` field', async () => {
-    const cap = captureFormData();
-    captureResponse = new Response(
-      JSON.stringify({
+    const cap = capturePost();
+    postResponse = {
+      status: 200,
+      headers: {},
+      text: JSON.stringify({
         files: [{ id: 'a1', name: 'x.png', type: 'image/png', url: 'https://zl.test/u/x.png' }],
       }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
-    );
+    };
     const result = await zipline.upload(
-      Buffer.from([0x89, 0x50]),
+      src([0x89, 0x50]),
       { filename: 'x.png', mime: 'image/png' },
       { url: 'https://zl.test', token: 'ziptok' },
     );
     expect(cap.url).toBe('https://zl.test/api/upload');
-    const headers = (cap.init as RequestInit & { headers: Record<string, string> }).headers;
     // Raw token, NOT "Bearer …" — Zipline's middleware decrypts the header verbatim.
-    expect(headers.authorization).toBe('ziptok');
-    expect(headers['User-Agent']).toMatch(/^Lurker\//);
-    expect(cap.formData!.get('file')).toBeInstanceOf(Blob);
+    expect(cap.headers!.authorization).toBe('ziptok');
+    expect(cap.headers!['User-Agent']).toMatch(/^Lurker\//);
+    expect(filePart(cap, 'file').filename).toBe('x.png');
     expect(result.url).toBe('https://zl.test/u/x.png');
   });
 
   it('accepts the v3 response shape (files as URL strings)', async () => {
-    captureFormData();
-    captureResponse = new Response(JSON.stringify({ files: ['https://zl.test/u/y.png'] }), {
+    capturePost();
+    postResponse = {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+      headers: {},
+      text: JSON.stringify({ files: ['https://zl.test/u/y.png'] }),
+    };
     const result = await zipline.upload(
-      Buffer.from([1]),
+      src([1]),
       { filename: 'y.png', mime: 'image/png' },
       { url: 'https://zl.test/', token: 't' },
     );
@@ -355,35 +412,35 @@ describe('zipline provider', () => {
 
   it('rejects with PROVIDER_CONFIG when url or token is missing', async () => {
     await expect(
-      zipline.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, { token: 't' }),
+      zipline.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { token: 't' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
     await expect(
-      zipline.upload(
-        Buffer.from([1]),
-        { filename: 'x.png', mime: 'image/png' },
-        { url: 'https://u' },
-      ),
+      zipline.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { url: 'https://u' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
   });
 
   it('maps 401 to PROVIDER_AUTH and missing url in body to PROVIDER_ERROR', async () => {
-    globalThis.fetch = vi.fn<typeof fetch>(
-      async () => new Response('unauthorized', { status: 401 }),
-    );
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
+      status: 401,
+      headers: {},
+      text: 'unauthorized',
+    });
     await expect(
       zipline.upload(
-        Buffer.from([1]),
+        src([1]),
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', token: 'bad' },
       ),
     ).rejects.toMatchObject({ code: 'PROVIDER_AUTH' });
 
-    globalThis.fetch = vi.fn<typeof fetch>(
-      async () => new Response(JSON.stringify({ files: [] }), { status: 200 }),
-    );
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ files: [] }),
+    });
     await expect(
       zipline.upload(
-        Buffer.from([1]),
+        src([1]),
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', token: 't' },
       ),
@@ -391,24 +448,26 @@ describe('zipline provider', () => {
   });
 
   it('captures the v4 file id as ref; v3 string responses carry no ref', async () => {
-    captureFormData();
-    captureResponse = new Response(
-      JSON.stringify({ files: [{ id: 'clxyz123', url: 'https://zl.test/u/x.png' }] }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
-    );
+    capturePost();
+    postResponse = {
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ files: [{ id: 'clxyz123', url: 'https://zl.test/u/x.png' }] }),
+    };
     const v4 = await zipline.upload(
-      Buffer.from([1]),
+      src([1]),
       { filename: 'x.png', mime: 'image/png' },
       { url: 'https://zl.test', token: 't' },
     );
     expect(v4.ref).toBe('clxyz123');
 
-    captureResponse = new Response(JSON.stringify({ files: ['https://zl.test/u/y.png'] }), {
+    postResponse = {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+      headers: {},
+      text: JSON.stringify({ files: ['https://zl.test/u/y.png'] }),
+    };
     const v3 = await zipline.upload(
-      Buffer.from([1]),
+      src([1]),
       { filename: 'y.png', mime: 'image/png' },
       { url: 'https://zl.test', token: 't' },
     );
@@ -443,58 +502,56 @@ describe('zipline provider', () => {
 
 describe('chibisafe provider', () => {
   it('POSTs to {base}/api/upload with x-api-key and `file[]` field', async () => {
-    const cap = captureFormData();
-    captureResponse = new Response(
-      JSON.stringify({ name: 'x.png', uuid: 'u-u-i-d', url: 'https://cb.test/x1y2z.png' }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
-    );
+    const cap = capturePost();
+    postResponse = {
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ name: 'x.png', uuid: 'u-u-i-d', url: 'https://cb.test/x1y2z.png' }),
+    };
     const result = await chibisafe.upload(
-      Buffer.from([0x47, 0x49]),
+      src([0x47, 0x49]),
       { filename: 'x.png', mime: 'image/png' },
       { url: 'https://cb.test/', api_key: 'chibikey' },
     );
     expect(cap.url).toBe('https://cb.test/api/upload');
-    const headers = (cap.init as RequestInit & { headers: Record<string, string> }).headers;
-    expect(headers['x-api-key']).toBe('chibikey');
-    expect(headers['User-Agent']).toMatch(/^Lurker\//);
+    expect(cap.headers!['x-api-key']).toBe('chibikey');
+    expect(cap.headers!['User-Agent']).toMatch(/^Lurker\//);
     // Chibisafe's uploader expects the lolisafe-lineage field name `file[]`.
-    expect(cap.formData!.get('file[]')).toBeInstanceOf(Blob);
+    expect(filePart(cap, 'file[]').filename).toBe('x.png');
     expect(result.url).toBe('https://cb.test/x1y2z.png');
   });
 
   it('rejects with PROVIDER_CONFIG when url or api_key is missing', async () => {
     await expect(
-      chibisafe.upload(
-        Buffer.from([1]),
-        { filename: 'x.png', mime: 'image/png' },
-        { api_key: 'k' },
-      ),
+      chibisafe.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { api_key: 'k' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
     await expect(
-      chibisafe.upload(
-        Buffer.from([1]),
-        { filename: 'x.png', mime: 'image/png' },
-        { url: 'https://u' },
-      ),
+      chibisafe.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { url: 'https://u' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
   });
 
   it('maps 401 to PROVIDER_AUTH and missing url in body to PROVIDER_ERROR', async () => {
-    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('no key', { status: 401 }));
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
+      status: 401,
+      headers: {},
+      text: 'no key',
+    });
     await expect(
       chibisafe.upload(
-        Buffer.from([1]),
+        src([1]),
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', api_key: 'bad' },
       ),
     ).rejects.toMatchObject({ code: 'PROVIDER_AUTH' });
 
-    globalThis.fetch = vi.fn<typeof fetch>(
-      async () => new Response(JSON.stringify({ name: 'x' }), { status: 200 }),
-    );
+    vi.spyOn(multipart, 'postMultipart').mockResolvedValue({
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ name: 'x' }),
+    });
     await expect(
       chibisafe.upload(
-        Buffer.from([1]),
+        src([1]),
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', api_key: 'k' },
       ),
@@ -502,24 +559,26 @@ describe('chibisafe provider', () => {
   });
 
   it('captures the response uuid as ref; a uuid-less response carries no ref', async () => {
-    captureFormData();
-    captureResponse = new Response(
-      JSON.stringify({ name: 'x.png', uuid: 'u-u-i-d', url: 'https://cb.test/x.png' }),
-      { status: 200, headers: { 'Content-Type': 'application/json' } },
-    );
+    capturePost();
+    postResponse = {
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ name: 'x.png', uuid: 'u-u-i-d', url: 'https://cb.test/x.png' }),
+    };
     const withUuid = await chibisafe.upload(
-      Buffer.from([1]),
+      src([1]),
       { filename: 'x.png', mime: 'image/png' },
       { url: 'https://cb.test', api_key: 'k' },
     );
     expect(withUuid.ref).toBe('u-u-i-d');
 
-    captureResponse = new Response(JSON.stringify({ url: 'https://cb.test/y.png' }), {
+    postResponse = {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+      headers: {},
+      text: JSON.stringify({ url: 'https://cb.test/y.png' }),
+    };
     const without = await chibisafe.upload(
-      Buffer.from([1]),
+      src([1]),
       { filename: 'y.png', mime: 'image/png' },
       { url: 'https://cb.test', api_key: 'k' },
     );
@@ -597,24 +656,25 @@ describe('s3 provider', () => {
   });
 
   it('PUTs path-style to the endpoint and returns the public URL for the same key', async () => {
-    let putUrl = '';
-    let putHeaders: Record<string, string> = {};
-    globalThis.fetch = vi.fn<typeof fetch>(async (url, init) => {
-      putUrl = String(url);
-      putHeaders = (init?.headers as Record<string, string>) ?? {};
-      return new Response('', { status: 200 });
-    });
+    const cap = capturePut();
+    postResponse = { status: 200, headers: {}, text: '' };
     const result = await s3.upload(
-      Buffer.from([0x89, 0x50]),
+      src([0x89, 0x50]),
       { filename: 'x.png', mime: 'image/png' },
       SECRETS,
     );
-    expect(putUrl).toMatch(/^http:\/\/minio\.test:9000\/lurker\/[A-Za-z0-9_-]{8}\.png$/);
-    const key = putUrl.slice('http://minio.test:9000/lurker/'.length);
+    expect(cap.url).toMatch(/^http:\/\/minio\.test:9000\/lurker\/[A-Za-z0-9_-]{8}\.png$/);
+    const key = cap.url!.slice('http://minio.test:9000/lurker/'.length);
     expect(result.url).toBe(`https://cdn.test/${key}`);
-    expect(putHeaders['x-amz-content-sha256']).toMatch(/^[0-9a-f]{64}$/);
-    expect(putHeaders['content-type']).toBe('image/png');
-    expect(putHeaders.authorization).toContain('AWS4-HMAC-SHA256');
+    // The payload hash is streamed from the source (source.hashOf), not computed
+    // from a Buffer the driver holds — but it must still be the real sha256.
+    expect(cap.headers!['x-amz-content-sha256']).toBe(
+      createHash('sha256')
+        .update(Buffer.from([0x89, 0x50]))
+        .digest('hex'),
+    );
+    expect(cap.headers!['content-type']).toBe('image/png');
+    expect(cap.headers!.authorization).toContain('AWS4-HMAC-SHA256');
   });
 
   it('rejects with PROVIDER_CONFIG when any required setting is missing', async () => {
@@ -627,22 +687,24 @@ describe('s3 provider', () => {
     ] as const) {
       const partial = { ...SECRETS, [missing]: '' };
       await expect(
-        s3.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, partial),
+        s3.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, partial),
       ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
     }
   });
 
   it('maps 403 to PROVIDER_AUTH and other failures to PROVIDER_ERROR', async () => {
-    globalThis.fetch = vi.fn<typeof fetch>(
-      async () => new Response('SignatureDoesNotMatch', { status: 403 }),
-    );
+    vi.spyOn(multipart, 'putSource').mockResolvedValue({
+      status: 403,
+      headers: {},
+      text: 'SignatureDoesNotMatch',
+    });
     await expect(
-      s3.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, SECRETS),
+      s3.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, SECRETS),
     ).rejects.toMatchObject({ code: 'PROVIDER_AUTH' });
 
-    globalThis.fetch = vi.fn<typeof fetch>(async () => new Response('oops', { status: 500 }));
+    vi.spyOn(multipart, 'putSource').mockResolvedValue({ status: 500, headers: {}, text: 'oops' });
     await expect(
-      s3.upload(Buffer.from([1]), { filename: 'x.png', mime: 'image/png' }, SECRETS),
+      s3.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, SECRETS),
     ).rejects.toMatchObject({ code: 'PROVIDER_ERROR' });
   });
 

--- a/server/services/uploadProviders/x0.ts
+++ b/server/services/uploadProviders/x0.ts
@@ -5,6 +5,8 @@
 // body is the bare URL with a trailing newline.
 
 import { USER_AGENT } from '../../utils/userAgent.js';
+import { postMultipart } from './multipart.js';
+import type { UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 const ENDPOINT = 'https://x0.at/';
@@ -20,19 +22,16 @@ export const capabilities: DriverCapabilities = {
 export const configSchema: ConfigField[] = [];
 
 export async function upload(
-  buffer: Buffer,
+  source: UploadSource,
   { filename, mime }: UploadMeta,
 ): Promise<UploadResult> {
-  const form = new FormData();
-  form.append('file', new Blob([new Uint8Array(buffer)], { type: mime }), filename);
-
-  const resp = await fetch(ENDPOINT, {
-    method: 'POST',
-    headers: { 'User-Agent': USER_AGENT },
-    body: form,
-  });
-  const text = (await resp.text()).trim();
-  if (!resp.ok) {
+  const resp = await postMultipart(
+    ENDPOINT,
+    [{ name: 'file', filename, contentType: mime, source }],
+    { headers: { 'User-Agent': USER_AGENT } },
+  );
+  const text = resp.text.trim();
+  if (resp.status < 200 || resp.status >= 300) {
     throw Object.assign(new Error(`x0.at upload failed: ${resp.status} ${text.slice(0, 200)}`), {
       code: 'PROVIDER_ERROR',
     });

--- a/server/services/uploadProviders/zipline.ts
+++ b/server/services/uploadProviders/zipline.ts
@@ -10,6 +10,8 @@
 // since the difference is one line and v3 servers are still common.
 
 import { USER_AGENT } from '../../utils/userAgent.js';
+import { postMultipart, isOk, jsonBody } from './multipart.js';
+import type { UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
 export const driver = 'zipline';
@@ -43,7 +45,7 @@ export const configSchema: ConfigField[] = [
 ];
 
 export async function upload(
-  buffer: Buffer,
+  source: UploadSource,
   { filename, mime }: UploadMeta,
   config: { url?: string; token?: string } = {},
 ): Promise<UploadResult> {
@@ -57,23 +59,20 @@ export async function upload(
   }
 
   const base = config.url.replace(/\/+$/, '');
-  const form = new FormData();
-  form.append('file', new Blob([new Uint8Array(buffer)], { type: mime }), filename);
+  const resp = await postMultipart(
+    `${base}/api/upload`,
+    [{ name: 'file', filename, contentType: mime, source }],
+    { headers: { authorization: config.token, 'User-Agent': USER_AGENT } },
+  );
 
-  const resp = await fetch(`${base}/api/upload`, {
-    method: 'POST',
-    headers: { authorization: config.token, 'User-Agent': USER_AGENT },
-    body: form,
-  });
-
-  if (!resp.ok) {
-    const text = (await resp.text()).slice(0, 200);
+  if (!isOk(resp)) {
+    const text = resp.text.slice(0, 200);
     throw Object.assign(new Error(`zipline upload failed: ${resp.status} ${text}`), {
       code: resp.status === 401 || resp.status === 403 ? 'PROVIDER_AUTH' : 'PROVIDER_ERROR',
     });
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const body = (await resp.json().catch(() => null)) as any;
+  const body = jsonBody(resp) as any;
   const first = body?.files?.[0];
   // v4: files is an array of objects with `url`; v3: an array of URL strings.
   const url = typeof first === 'string' ? first : first?.url;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -51,10 +51,14 @@
     >
       <i class="fa-solid fa-circle-arrow-up"></i>
     </button>
+    <!-- Matches what the server actually accepts (image + text). It only listed
+         images, so a .txt — which the upload route has always taken, and which is
+         the passthrough path — could not be picked at all: macOS greys out
+         non-matching files, with no "All Files" escape. Widens further in #515. -->
     <input
       ref="fileInputEl"
       type="file"
-      accept="image/*"
+      :accept="ACCEPTED_FILE_TYPES"
       class="file-hidden"
       @change="onFileSelected"
     />
@@ -157,6 +161,7 @@ import { useHighlightRulesStore, type HighlightRule } from '../stores/highlightR
 import { parseIgnoreArgs } from '../../../shared/parseIgnore.js';
 import { parseHighlightArgs } from '../../../shared/parseHighlight.js';
 import { highlightRuleDetailParts } from '../utils/highlightFormat.js';
+import { ACCEPTED_FILE_TYPES, isUploadableType } from '../utils/uploaders.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChanlistStore } from '../stores/chanlist.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
@@ -1748,7 +1753,7 @@ function onDrop(e: DragEvent): void {
   dragOver.value = false;
   if (!sendable.value) return;
   const file = e.dataTransfer?.files?.[0];
-  if (!file || !file.type.startsWith('image/')) return;
+  if (!file || !isUploadableType(file.type)) return;
   uploads.upload(file, file.name).catch(() => {});
 }
 

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -95,3 +95,18 @@ export function missingRequired(
     return !String(values[f.key] ?? '').trim();
   });
 }
+
+// What the upload route accepts today: images (optimized by the sharp pipeline)
+// and text/plain (passthrough). ONE definition, so the file picker's `accept` and
+// the drag-drop gate can't drift apart — they had, and the picker was the stricter
+// of the two: it listed images only, so a .txt could not be selected at all on
+// macOS (non-matching files are greyed out, with no "All Files" escape) even
+// though the server has always taken one.
+//
+// #515 replaces this with the effective accepted set projected from the server,
+// once media lands and "what's allowed" stops being a constant.
+export const ACCEPTED_FILE_TYPES = 'image/*,text/plain,.txt';
+
+export function isUploadableType(mime: string): boolean {
+  return mime.startsWith('image/') || mime === 'text/plain';
+}


### PR DESCRIPTION
Closes #543. Behavior-identical refactor — no new user-visible behavior. It exists to make a large upload cap safe, and to make P4b (#515) small.

## The measurement that changed the plan

The issue originally assumed `openAsBlob()` + `FormData` would let undici stream a file off disk. **It doesn't.** Measured on the production runtime (Linux, node 22), 300 MB upload to a throttled sink, sampling live `arrayBuffers` after a forced GC:

| approach | live buffer bytes | peak RSS growth |
|---|---|---|
| `node:http` + `stream/promises.pipeline` | **7.6 MB** (0.03×) | 22 MB |
| `fetch` + hand-built streamed multipart (exact `Content-Length`) | 301 MB (1.0×) | 316 MB |
| `fetch` + `openAsBlob()` in `FormData` | 301 MB (1.0×) | 318 MB |
| **what we shipped** (`readFileSync` → `new Blob([new Uint8Array(buf)])`) | **1501 MB (5.0×)** | 1510 MB |

**undici does not propagate backpressure into a request body.** It drains the source into memory regardless of how the body is supplied — Blob, file-backed Blob, ReadableStream, or a hand-built multipart stream with an exact `Content-Length`. Node's own `http`/`https` + `pipeline` does, and holds constant memory independent of file size.

So a 200 MB upload really cost ~1 GB of RSS, and **switching multer to disk storage alone would not have fixed it** — the driver would have re-buffered the whole file at the `fetch` call. Hence two halves, the second being load-bearing.

## What changed

- **multer → `diskStorage`**, with `limits.fileSize` set **per request** to the caller's effective cap (`requireAuth` runs before multer, so the cap is knowable up front). An over-cap upload now dies mid-stream with a 413 instead of being ingested in full and rejected afterwards. Retires the flat 200 MB `HARD_BYTE_CEILING`.
- **New `services/uploadProviders/source.ts`.** An `UploadSource` is either a temp file (the passthrough path — text today, media in #515, potentially hundreds of MB) or a buffer (the optimized image, which is small and bounded, so a temp-file round trip would be pointless I/O). The branch lives there, not in seven drivers: every driver takes an `UploadSource` and calls `streamOf`/`sizeOf`/`hashOf`/`moveTo`.
- **`multipart.ts` gains `postMultipart`** (streams file parts, still sends an exact `Content-Length`) and `putSource`. `x0`/`hoarder`/`zipline`/`chibisafe`/`catbox` all move off `fetch` onto it; `s3` stream-hashes the file for SigV4 and then streams the PUT.
  - This **subsumes catbox's `postBuffer` workaround**: catbox's PHP backend stalls on chunked transfer-encoding, which is why it hand-built a body in the first place. Every upload now carries a real `Content-Length`, so that stops being a special case. (`postBuffer` stays for catbox's small delete body.)
- **`local` becomes a `rename()`** — zero copies.
- **Temp-file lifetime**: removed on every exit (success, 4xx/5xx, driver failure, throw), plus `sweepTempUploads()` at boot for anything a crash left behind.
- `fetch` is still fine — and still used — for small bodies: delete calls, moderation reports, response reads.

## Tests

`multipart.test.ts` drives a **real socket**: exact `Content-Length`, no chunked encoding, parts in order, bytes intact, error surfaces.

The memory guard is the one that defends this PR — every other test in the repo passes just as happily if someone rewrites `postMultipart` on top of `fetch`. It streams a 96 MB file through a throttled sink and asserts live memory stays bounded. **Verified it actually fails**: injecting the buffering regression takes it to 110 MB live against a 32 MB bar.

Route tests cover the source shape handed to drivers (a `file` for passthrough, a `buffer` for optimized images), temp cleanup on success *and* on driver failure, the early 413, and the orphan sweep (which must not eat an in-flight upload).

`npm run check` clean; 2157 tests green, stable across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)