### PR TITLE
Uploads P4b: media (audio + video), each metadata-scrubbed (#515)

### DIFF
--- a/server/routes/exports.ts
+++ b/server/routes/exports.ts
@@ -129,6 +129,9 @@ const IMPORT_TMP_DIR = path.join(os.tmpdir(), 'lurker-imports');
 fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true, mode: 0o700 });
 const upload = multer({
   dest: IMPORT_TMP_DIR,
+  // See routes/uploads.ts: busboy's default param charset is latin-1, which mangles
+  // any non-ASCII filename.
+  defParamCharset: 'utf8',
   limits: { fileSize: HARD_IMPORT_LIMIT, files: 1 },
 });
 

--- a/server/routes/localUploads.ts
+++ b/server/routes/localUploads.ts
@@ -22,6 +22,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import fs from 'fs';
 import { fileTypeFromBuffer } from 'file-type';
+import { isUtf8, trimPartialUtf8 } from '../utils/utf8.js';
 import { resolveDiskPath } from '../services/uploadProviders/local.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 
@@ -50,6 +51,13 @@ const INLINE_MIME = new Set<string>([
   'video/mp4',
   'video/ogg',
   'video/webm',
+  // The media the upload route accepts (#515). quicktime/m4v/m4a weren't here
+  // because nothing could produce them; now they can, and a shared clip should play
+  // when you click it rather than land in Downloads.
+  'video/quicktime',
+  'video/x-m4v',
+  'audio/x-m4a',
+  'audio/mp4',
 ]);
 
 // file-type recommends >= 4100 bytes to recognize every supported signature.
@@ -66,30 +74,6 @@ async function sniffHead(fullPath: string): Promise<Buffer> {
     return buf.subarray(0, bytesRead);
   } finally {
     await fd.close();
-  }
-}
-
-// Drop a trailing incomplete UTF-8 multibyte sequence, so a valid text file whose
-// SNIFF_BYTES window happens to split a character isn't misjudged as binary and
-// force-downloaded. Walks back over continuation bytes (0b10xxxxxx) to the lead
-// byte; if the sequence it starts runs past the window, trim it.
-function trimPartialUtf8(buf: Buffer): Buffer {
-  for (let i = 1; i <= 3 && buf.length - i >= 0; i++) {
-    const b = buf[buf.length - i];
-    if ((b & 0xc0) === 0x80) continue; // continuation byte — keep walking back
-    const seqLen = b < 0x80 ? 1 : b >= 0xf0 ? 4 : b >= 0xe0 ? 3 : b >= 0xc0 ? 2 : 1;
-    return i < seqLen ? buf.subarray(0, buf.length - i) : buf; // incomplete → drop
-  }
-  return buf;
-}
-
-function isUtf8(buf: Buffer): boolean {
-  if (buf.length === 0) return false;
-  try {
-    new TextDecoder('utf-8', { fatal: true }).decode(buf);
-    return true;
-  } catch {
-    return false;
   }
 }
 

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../test-utils/testApp.js';
 import type { User } from '../db/users.js';
 import type { UploadSource } from '../services/uploadProviders/source.js';
+import type { ContentClass } from '../services/uploadProviders/types.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { resolveDataDir } from '../utils/dataDir.js';
@@ -31,7 +32,7 @@ const stub = {
     storesRemotely: true,
     supportsDelete: false,
     mintsKeys: false,
-    acceptsContentClasses: ['image', 'text'] as ('image' | 'text' | 'binary')[],
+    acceptsContentClasses: ['image', 'text'] as ContentClass[],
   },
   configSchema: [],
   shouldThrow: null as Error | null,
@@ -44,6 +45,10 @@ const stub = {
   // passthrough upload must arrive as a `file` (streamed off multer's temp file,
   // never in the heap), while an optimized image arrives as a small `buffer`.
   capturedSource: null as UploadSource | null,
+  // The bytes the driver was actually given — the only place to prove that what
+  // leaves the building is scrubbed, since the temp file is unlinked afterwards.
+  capturedBytes: null as Buffer | null,
+  capturedMeta: null as { filename: string; mime: string } | null,
   async upload(
     source: UploadSource,
     meta: { filename: string; mime: string },
@@ -51,6 +56,9 @@ const stub = {
   ) {
     stub.capturedConfig = config ?? null;
     stub.capturedSource = source;
+    stub.capturedMeta = meta;
+    stub.capturedBytes =
+      source.kind === 'file' ? fs.readFileSync(source.path) : Buffer.from(source.data);
     if (stub.shouldThrow) throw stub.shouldThrow;
     if (stub.nextResult) return stub.nextResult;
     return { url: `https://stub.example/${meta.filename}` };
@@ -463,9 +471,29 @@ describe('DELETE /api/uploads/:id', () => {
 // #543: uploads stream through a temp file instead of living in the heap. What
 // matters here is the shape handed to the driver and that the temp file never
 // outlives the request — an orphan per upload is a slow disk leak.
-describe('temp-file lifecycle (#543)', () => {
-  const tmpDir = (): string => path.join(resolveDataDir(), 'tmp', 'uploads');
+const tmpDir = (): string => path.join(resolveDataDir(), 'tmp', 'uploads');
+const tempFiles = (): string[] => {
+  try {
+    return fs.readdirSync(tmpDir()).filter((f) => f.startsWith('up-'));
+  } catch {
+    return [];
+  }
+};
+// The handler unlinks the temp file in a `finally`, which runs AFTER the response
+// is sent, so poll — and poll for the ABSOLUTE invariant (the dir drains to empty),
+// not a delta against a `before` count, which is itself racy against a preceding
+// test's pending unlink.
+const waitForNoTemps = async (timeoutMs = 3000): Promise<void> => {
+  const start = Date.now();
+  while (tempFiles().length > 0) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`temp files not cleaned up: ${tempFiles().join(', ')}`);
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+};
 
+describe('temp-file lifecycle (#543)', () => {
   // The handler unlinks the temp file in a `finally`, which runs AFTER the response
   // is sent — so the client can observe the reply before the unlink has landed.
   // Two consequences, both of which bit this test in CI:
@@ -564,5 +592,116 @@ describe('temp-file lifecycle (#543)', () => {
     expect(fs.existsSync(stale)).toBe(false);
     expect(fs.existsSync(fresh)).toBe(true);
     fs.unlinkSync(fresh);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #515: media uploads. The route classifies from magic bytes and scrubs metadata
+// before dispatch — the two things that make "we accept video" safe to say.
+describe('media uploads (#515)', () => {
+  /** An mp4 carrying GPS in moov/udta/©xyz, exactly where a phone puts it. */
+  const GPS = '+37.7749-122.4194/';
+  function box(type: string, payload: Buffer): Buffer {
+    const size = Buffer.alloc(4);
+    size.writeUInt32BE(8 + payload.length);
+    return Buffer.concat([size, Buffer.from(type, 'latin1'), payload]);
+  }
+  function mp4WithGps(): Buffer {
+    const ftyp = box(
+      'ftyp',
+      Buffer.concat([Buffer.from('isom'), Buffer.alloc(4), Buffer.from('mp42')]),
+    );
+    const mvhd = Buffer.alloc(100);
+    mvhd.writeUInt32BE(0xe679e672, 4);
+    const udta = box(
+      'udta',
+      box('©xyz', Buffer.concat([Buffer.from([0, 0x12, 0x15, 0xc7]), Buffer.from(GPS)])),
+    );
+    const moov = box('moov', Buffer.concat([box('mvhd', mvhd), udta]));
+    return Buffer.concat([ftyp, moov, box('mdat', Buffer.alloc(1024, 0xab))]);
+  }
+
+  beforeAll(() => {
+    stub.capabilities.acceptsContentClasses = ['image', 'text', 'media'];
+  });
+  afterAll(() => {
+    stub.capabilities.acceptsContentClasses = ['image', 'text'];
+  });
+
+  it('accepts an mp4, passes it through unoptimized, and gives it no thumbnail', async () => {
+    stub.shouldThrow = null;
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', mp4WithGps(), { filename: 'clip.mp4', contentType: 'video/mp4' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.mime).toBe('video/mp4');
+    // Passthrough: the driver gets the temp FILE, streamed, not a buffer.
+    expect(stub.capturedSource!.kind).toBe('file');
+    expect(stub.capturedMeta!.filename).toMatch(/\.mp4$/);
+
+    const list = await agent.get('/api/uploads');
+    const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
+    expect(row.thumbnail_url).toBeUndefined(); // no ffmpeg, no poster frame
+    await waitForNoTemps();
+  });
+
+  // The whole reason video needs anything more than "pass the bytes through".
+  it('strips the GPS out of a video BEFORE it leaves the server', async () => {
+    stub.shouldThrow = null;
+    const original = mp4WithGps();
+    expect(original.includes(Buffer.from(GPS))).toBe(true);
+
+    await agent
+      .post('/api/uploads')
+      .attach('image', original, { filename: 'vacation.mp4', contentType: 'video/mp4' });
+
+    const sent = stub.capturedBytes!;
+    expect(sent.includes(Buffer.from(GPS))).toBe(false);
+    expect(sent.includes(Buffer.from('udta'))).toBe(false);
+    // Size-preserving, so the recorded byte_size is still right.
+    expect(sent.length).toBe(original.length);
+    await waitForNoTemps();
+  });
+
+  it('415s a type we cannot clean, naming what is allowed', async () => {
+    const webm = Buffer.from([
+      0x1a, 0x45, 0xdf, 0xa3, 0x9f, 0x42, 0x86, 0x81, 0x01, 0x42, 0xf7, 0x81, 0x01, 0x42, 0xf2,
+      0x81, 0x04, 0x42, 0xf3, 0x81, 0x08, 0x42, 0x82, 0x84, 0x77, 0x65, 0x62, 0x6d, 0x42, 0x87,
+      0x81, 0x02, 0x42, 0x85, 0x81, 0x02, 0x18, 0x53, 0x80, 0x67, 0x01, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00,
+    ]);
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', webm, { filename: 'rec.webm', contentType: 'video/webm' });
+    expect(res.status).toBe(415);
+    expect(res.body.error).toMatch(/not accepted/);
+    await waitForNoTemps();
+  });
+
+  it('415s media when the resolved uploader does not accept it (the hosted dropper)', async () => {
+    stub.capabilities.acceptsContentClasses = ['image', 'text'];
+    try {
+      const res = await agent
+        .post('/api/uploads')
+        .attach('image', mp4WithGps(), { filename: 'clip.mp4', contentType: 'video/mp4' });
+      expect(res.status).toBe(415);
+      expect(res.body.error).toMatch(/does not accept media/);
+    } finally {
+      stub.capabilities.acceptsContentClasses = ['image', 'text', 'media'];
+    }
+    await waitForNoTemps();
+  });
+
+  // The claim cannot pick the class — otherwise it's a route around the EXIF scrub.
+  it('optimizes an image even when the client swears it is a video', async () => {
+    stub.shouldThrow = null;
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: 'liar.mp4', contentType: 'video/mp4' });
+    expect(res.status).toBe(200);
+    expect(res.body.mime).toBe('image/jpeg'); // ran through the pipeline regardless
+    expect(stub.capturedSource!.kind).toBe('buffer');
+    await waitForNoTemps();
   });
 });

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -598,6 +598,26 @@ describe('temp-file lifecycle (#543)', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // #515: media uploads. The route classifies from magic bytes and scrubs metadata
 // before dispatch — the two things that make "we accept video" safe to say.
+describe('filenames are UTF-8', () => {
+  it('round-trips a non-ASCII filename intact', async () => {
+    stub.shouldThrow = null;
+    // macOS puts a NARROW NO-BREAK SPACE (U+202F) between the time and AM/PM in
+    // screen-recording names. Its UTF-8 bytes are E2 80 AF, and busboy's DEFAULT is
+    // to decode multipart params as latin1 — which renders them as "â¯".
+    const name = 'Screen Recording 2026-07-12 at 8.10.56\u202fPM.mov';
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', smallPng, { filename: name, contentType: 'image/png' });
+    expect(res.status).toBe(200);
+
+    const list = await agent.get('/api/uploads');
+    const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
+    expect(row.filename).toBe(name);
+    expect(row.filename).not.toContain('â');
+    await waitForNoTemps();
+  });
+});
+
 describe('media uploads (#515)', () => {
   /** An mp4 carrying GPS in moov/udta/©xyz, exactly where a phone puts it. */
   const GPS = '+37.7749-122.4194/';

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -14,7 +14,12 @@ import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from '../services/settingsRegistry.js';
 import * as imagePipeline from '../services/imagePipeline.js';
 import { driverIds } from '../services/uploadProviders/index.js';
-import type { ContentClass } from '../services/uploadProviders/index.js';
+import {
+  classifyUpload,
+  UnsupportedTypeError,
+  type Classification,
+} from '../services/contentClass.js';
+import { scrubMediaFile, MediaScrubError } from '../services/mediaScrub.js';
 import {
   resolveUploader,
   loadDriverForRef,
@@ -257,17 +262,30 @@ router.post(
         return;
       }
 
-      // Long-message → .txt upload bypasses the sharp pipeline: the bytes go
-      // straight through with a .txt extension and no thumbnail.
-      const isText = req.file.mimetype === 'text/plain';
-      const contentClass: ContentClass = isText ? 'text' : 'image';
+      // Classify from the MAGIC BYTES, never the client's claimed MIME (#515). The
+      // claim used to decide this, which was survivable only while the alternative
+      // branch was the image pipeline — the moment a class means "passthrough", a
+      // claimed MIME is a route around imagePipeline.optimize(), and that's where
+      // the EXIF scrub lives. See services/contentClass.ts.
+      let classified: Classification;
+      try {
+        classified = await classifyUpload(req.file.path, req.file.mimetype);
+      } catch (err) {
+        if (err instanceof UnsupportedTypeError) {
+          res.status(415).json({ error: err.message });
+          return;
+        }
+        throw err;
+      }
+      const contentClass = classified.contentClass;
 
-      // Validate stage: the resolved driver must accept this content class. In P0
-      // every driver accepts image + text, so this never rejects — but it makes
-      // acceptsContentClasses a real gate (defense-in-depth) once binary-capable
-      // drivers land, rather than a declared-but-unused capability.
+      // Validate stage: the resolved driver must accept this class. This is what
+      // makes hosted (whose dropper takes images + text only) refuse media, without
+      // a policy flag anywhere.
       if (!resolved.driver.capabilities.acceptsContentClasses.includes(contentClass)) {
-        res.status(415).json({ error: `this uploader does not accept ${contentClass} files` });
+        res.status(415).json({
+          error: `${resolved.driver.label} does not accept ${contentClass} files`,
+        });
         return;
       }
 
@@ -279,12 +297,27 @@ router.post(
       let outHeight: number | null = null;
       let thumb: Buffer | null = null;
 
-      if (isText) {
+      if (contentClass === 'text' || contentClass === 'media') {
         // Passthrough: the bytes go out of the temp file exactly as they came in.
-        // Nothing reads them into memory — the driver streams the file.
+        // Nothing reads them into memory — the driver streams the file (#543).
+        if (contentClass === 'media') {
+          // …except the metadata, which is stripped in place first. A phone's MP4
+          // carries GPS in moov/udta; passing it through untouched would re-open
+          // exactly the leak #516 closed for photos. The scrub is size-preserving,
+          // so req.file.size stays correct.
+          try {
+            await scrubMediaFile(req.file.path, classified.mime);
+          } catch (err) {
+            if (err instanceof MediaScrubError) {
+              res.status(415).json({ error: err.message });
+              return;
+            }
+            throw err;
+          }
+        }
         outSource = fileSource(req.file.path, req.file.size);
-        outMime = 'text/plain';
-        outExt = 'txt';
+        outMime = classified.mime;
+        outExt = classified.ext;
         outByteSize = req.file.size;
       } else {
         // imagePipeline is an untyped JS module — any is unavoidable here
@@ -400,6 +433,10 @@ router.post(
       res.json({
         id,
         url: mainUrl,
+        // The REAL mime, derived from the bytes — the client builds its optimistic
+        // history row from this rather than from what the browser guessed, so the
+        // row's type icon isn't a lie until the next refetch.
+        mime: outMime,
         can_delete: canDelete,
         ...(thumbnailUrl ? { thumbnail_url: thumbnailUrl } : {}),
       });

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -123,6 +123,14 @@ fs.mkdirSync(TMP_DIR, { recursive: true, mode: 0o700 });
 // The registry's own ceiling; a per-user cap can't exceed it, so neither can multer.
 const MAX_CAP_MB = 200;
 
+/** The user's size cap. effectiveSettings() has already merged the registry default
+ *  in, so this reads it from ONE place — a second hardcoded default here would be a
+ *  duplicate that quietly disagrees the next time the registry's changes. */
+function userCapMb(settings: Record<string, unknown>): number {
+  const n = Number(settings['uploads.image.max_upload_mb']);
+  return Number.isFinite(n) && n > 0 ? n : MAX_CAP_MB;
+}
+
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, TMP_DIR),
   filename: (_req, _file, cb) => cb(null, `up-${randomId()}`),
@@ -137,7 +145,7 @@ const storage = multer.diskStorage({
  *  uploader, which is what catches an override with a tighter policy cap. */
 function capMbFor(userId: number, isAdmin: boolean): number {
   const settings = effectiveSettings(userId);
-  const userCap = Number(settings['uploads.image.max_upload_mb']) || 25;
+  const userCap = userCapMb(settings);
   let cap = userCap;
   try {
     cap = resolveUploader({ userId, isAdmin, requestedId: null }).policy.maxMb ?? userCap;
@@ -255,8 +263,7 @@ router.post(
       // Size cap: operator-baked policy (hosted locked uploader) wins; otherwise
       // the user's own setting. A tenant can't lift a policy cap because the
       // policy is on the instance row, not their settings.
-      const maxMb =
-        resolved.policy.maxMb ?? (Number(settings['uploads.image.max_upload_mb']) || 25);
+      const maxMb = resolved.policy.maxMb ?? userCapMb(settings);
       if (req.file.size > maxMb * 1024 * 1024) {
         res.status(413).json({ error: `file exceeds ${maxMb} MB` });
         return;
@@ -315,10 +322,16 @@ router.post(
             throw err;
           }
         }
-        outSource = fileSource(req.file.path, req.file.size);
+        // Re-stat rather than reuse req.file.size. The scrub is size-preserving by
+        // construction — that's the whole reason boxes are retyped to `free` instead
+        // of removed — but this size becomes the upload's Content-Length, and a
+        // wrong one truncates the body or hangs the request. Don't make a network
+        // framing invariant depend on a promise made in another module's comment.
+        const { size: bytesOnDisk } = await fs.promises.stat(req.file.path);
+        outSource = fileSource(req.file.path, bytesOnDisk);
         outMime = classified.mime;
         outExt = classified.ext;
-        outByteSize = req.file.size;
+        outByteSize = bytesOnDisk;
       } else {
         // imagePipeline is an untyped JS module — any is unavoidable here
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -201,6 +201,11 @@ const uploadToDisk = (req: Request, res: Response, next: NextFunction): void => 
   const handler = multer({
     storage,
     limits: { fileSize: capMb * 1024 * 1024, files: 1 },
+    // busboy decodes multipart params as LATIN-1 unless told otherwise, so any
+    // non-ASCII filename arrives mangled — a macOS screen recording is named with a
+    // narrow no-break space (U+202F) before AM/PM, whose UTF-8 bytes (E2 80 AF) then
+    // show up in the uploads list as "â¯". Browsers send the header in UTF-8.
+    defParamCharset: 'utf8',
   }).single('image');
   handler(req, res, (err: unknown) => {
     // multer aborts the stream and unlinks its partial file once the cap is hit,

--- a/server/services/contentClass.test.ts
+++ b/server/services/contentClass.test.ts
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import sharp from 'sharp';
+import { classifyUpload, UnsupportedTypeError } from './contentClass.js';
+
+let dir: string;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-classify-'));
+});
+afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+function write(name: string, bytes: Buffer): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, bytes);
+  return p;
+}
+
+/** A minimal ISO-BMFF file: an ftyp box with the given brand, plus a moov. This is
+ *  exactly what file-type keys off, so it's a faithful fixture. */
+function bmff(brand: string, compat: string[] = ['isom', 'mp42']): Buffer {
+  const brands = [brand, ...compat].map((b) => Buffer.from(b.padEnd(4, ' ')));
+  const payload = Buffer.concat([Buffer.from(brand.padEnd(4, ' ')), Buffer.alloc(4), ...brands]);
+  const size = Buffer.alloc(4);
+  size.writeUInt32BE(8 + payload.length);
+  const moovBody = Buffer.alloc(16);
+  const moovSize = Buffer.alloc(4);
+  moovSize.writeUInt32BE(8 + moovBody.length);
+  return Buffer.concat([
+    size,
+    Buffer.from('ftyp'),
+    payload,
+    moovSize,
+    Buffer.from('moov'),
+    moovBody,
+  ]);
+}
+
+const mp3Frame = Buffer.concat([Buffer.from([0xff, 0xfb, 0x90, 0x00]), Buffer.alloc(400, 0x55)]);
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let n = 0; n < buf.length; n++) {
+    let c = (crc ^ buf[n]) & 0xff;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    crc = (crc >>> 8) ^ c;
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** PNG + an acTL chunk = APNG, which file-type reports as `image/apng`. */
+async function apngBytes(): Promise<Buffer> {
+  const png = await sharp({ create: { width: 4, height: 4, channels: 3, background: '#f00' } })
+    .png()
+    .toBuffer();
+  const idatAt = png.indexOf(Buffer.from('IDAT')) - 4;
+  const data = Buffer.alloc(8);
+  data.writeUInt32BE(2, 0);
+  const body = Buffer.concat([Buffer.from('acTL'), data]);
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(8);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(body));
+  return Buffer.concat([png.subarray(0, idatAt), len, body, crc, png.subarray(idatAt)]);
+}
+
+describe('classifyUpload — images', () => {
+  it('classifies the formats the pipeline can optimize', async () => {
+    const png = await sharp({ create: { width: 4, height: 4, channels: 3, background: '#0f0' } })
+      .png()
+      .toBuffer();
+    const jpg = await sharp({ create: { width: 4, height: 4, channels: 3, background: '#0f0' } })
+      .jpeg()
+      .toBuffer();
+
+    for (const [name, bytes] of [
+      ['a.png', png],
+      ['a.jpg', jpg],
+    ] as const) {
+      const c = await classifyUpload(write(name, bytes), 'image/png');
+      expect(c.contentClass).toBe('image');
+    }
+  });
+
+  // ⚠ THE trap. file-type reports APNG as `image/apng`, which is NOT a key in
+  // imagePipeline's FORMAT_INFO — so a naive FORMAT_INFO-derived alias set drops
+  // APNG out of the image class entirely, into passthrough, silently un-doing
+  // #516's frame-preserving metadata scrub for exactly the animated format it was
+  // written for.
+  it('routes APNG to the image pipeline (image/apng is not a sharp format name)', async () => {
+    const c = await classifyUpload(write('anim.png', await apngBytes()), 'image/png');
+    expect(c.contentClass).toBe('image');
+  });
+
+  // Same shape of trap: an iPhone photo sniffs as image/heic; sharp calls it heif.
+  it('routes HEIC to the image pipeline (image/heic is not a sharp format name)', async () => {
+    const c = await classifyUpload(write('photo.heic', bmff('heic', ['mif1'])), 'image/heic');
+    expect(c.contentClass).toBe('image');
+  });
+
+  it('detects SVG, which has no magic bytes at all', async () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>');
+    const c = await classifyUpload(write('bare.svg', svg), 'image/svg+xml');
+    expect(c.contentClass).toBe('image');
+    expect(c.mime).toBe('image/svg+xml');
+  });
+
+  // ⚠ A REAL SVG — what Illustrator and Inkscape write — opens with an XML
+  // declaration, and file-type reports THAT as `application/xml`. Treating every
+  // recognized-but-unaccepted type as a refusal would have 415'd every real SVG
+  // file, breaking an upload that works today.
+  it('detects an SVG with an XML prolog (file-type calls it application/xml)', async () => {
+    const svg = Buffer.from(
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+        '<!-- Generator: Adobe Illustrator -->\n' +
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect/></svg>',
+    );
+    const c = await classifyUpload(write('real.svg', svg), 'image/svg+xml');
+    expect(c.contentClass).toBe('image');
+    expect(c.mime).toBe('image/svg+xml');
+  });
+
+  // …and the same bytes claimed as text/plain (the long-message flow) stay text.
+  it('an XML document that is not an SVG is text', async () => {
+    const xml = Buffer.from('<?xml version="1.0"?>\n<note><to>you</to></note>');
+    const c = await classifyUpload(write('doc.xml', xml), 'application/xml');
+    expect(c.contentClass).toBe('text');
+    expect(c.ext).toBe('txt');
+  });
+});
+
+describe('classifyUpload — media', () => {
+  it('accepts exactly the containers we can scrub', async () => {
+    const cases: [string, Buffer, string, string][] = [
+      ['v.mp4', bmff('isom'), 'video/mp4', 'mp4'],
+      ['v.mov', bmff('qt  ', []), 'video/quicktime', 'mov'],
+      ['v.m4v', bmff('M4V '), 'video/x-m4v', 'm4v'],
+      ['a.m4a', bmff('M4A '), 'audio/x-m4a', 'm4a'],
+      ['a.mp3', mp3Frame, 'audio/mpeg', 'mp3'],
+    ];
+    for (const [name, bytes, mime, ext] of cases) {
+      const c = await classifyUpload(write(name, bytes), 'application/octet-stream');
+      expect({ name, ...c }).toEqual({ name, contentClass: 'media', mime, ext });
+    }
+  });
+
+  it('rejects media we have no scrubber for, rather than leaking its metadata', async () => {
+    // WebM: harmless in practice (a browser recorder writes a muxer name and a
+    // date, not a location), but "everything we accept, we clean" is the rule, and
+    // we have no EBML scrubber yet. A real EBML header, not a stub — file-type needs
+    // to read as far as the DocType to call it webm.
+    const webm = Buffer.from([
+      0x1a, 0x45, 0xdf, 0xa3, 0x9f, 0x42, 0x86, 0x81, 0x01, 0x42, 0xf7, 0x81, 0x01, 0x42, 0xf2,
+      0x81, 0x04, 0x42, 0xf3, 0x81, 0x08, 0x42, 0x82, 0x84, 0x77, 0x65, 0x62, 0x6d, 0x42, 0x87,
+      0x81, 0x02, 0x42, 0x85, 0x81, 0x02, 0x18, 0x53, 0x80, 0x67, 0x01, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00,
+    ]);
+    await expect(classifyUpload(write('v.webm', webm), 'video/webm')).rejects.toBeInstanceOf(
+      UnsupportedTypeError,
+    );
+  });
+});
+
+describe('classifyUpload — the client cannot talk us out of the truth', () => {
+  // The whole reason this module exists. If a claimed MIME could pick the class, it
+  // would be a route around imagePipeline.optimize() — i.e. around the EXIF scrub.
+  it('sends an image through the image pipeline however it is announced', async () => {
+    const jpg = await sharp({ create: { width: 8, height: 8, channels: 3, background: '#00f' } })
+      .jpeg()
+      .toBuffer();
+    const p = write('liar.mp4', jpg);
+    for (const claim of ['video/mp4', 'application/octet-stream', 'text/plain', '']) {
+      const c = await classifyUpload(p, claim);
+      expect(c.contentClass).toBe('image');
+    }
+  });
+
+  it('will not let a claimed text/plain smuggle arbitrary bytes through as .txt', async () => {
+    // Invalid UTF-8, no signature. The old route trusted the claim and passed it
+    // through with a .txt extension; now the whole file has to actually be text.
+    const junk = Buffer.from([0xc3, 0x28, 0xa0, 0xa1, 0xff, 0xfe, 0x00, 0x01]);
+    await expect(classifyUpload(write('junk.txt', junk), 'text/plain')).rejects.toBeInstanceOf(
+      UnsupportedTypeError,
+    );
+  });
+
+  // The long-message → .txt flow ALWAYS claims text/plain. Someone pasting raw SVG
+  // markup into the composer must not have it reclassified as an image (which on
+  // hosted, where SVG is refused, would turn a working upload into a 415).
+  it('keeps SVG markup pasted into the composer as text', async () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>');
+    const c = await classifyUpload(write('pasted.txt', svg), 'text/plain');
+    expect(c.contentClass).toBe('text');
+    expect(c.ext).toBe('txt');
+  });
+});
+
+describe('classifyUpload — text and refusals', () => {
+  it('classifies plain UTF-8 as text', async () => {
+    const c = await classifyUpload(write('n.txt', Buffer.from('hello — ünïcodé\n')), 'text/plain');
+    expect(c).toEqual({ contentClass: 'text', mime: 'text/plain', ext: 'txt' });
+  });
+
+  it('handles a multibyte char straddling the streaming read boundary', async () => {
+    // 64 KB is the chunk size; land a 3-byte '€' across the seam. A naive
+    // per-chunk UTF-8 check would call this binary and refuse a perfectly good file.
+    const head = Buffer.from('a'.repeat(64 * 1024 - 1));
+    const c = await classifyUpload(
+      write('big.txt', Buffer.concat([head, Buffer.from('€ trailing text')])),
+      'text/plain',
+    );
+    expect(c.contentClass).toBe('text');
+  });
+
+  it('refuses recognized types outside the accepted set, naming what is allowed', async () => {
+    const pdf = Buffer.concat([Buffer.from('%PDF-1.4\n'), Buffer.alloc(64, 0x20)]);
+    const zip = Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.alloc(64)]);
+    for (const [name, bytes] of [
+      ['d.pdf', pdf],
+      ['a.zip', zip],
+    ] as const) {
+      await expect(classifyUpload(write(name, bytes), 'application/pdf')).rejects.toThrow(
+        /not accepted/,
+      );
+    }
+  });
+
+  it('refuses an empty file', async () => {
+    await expect(
+      classifyUpload(write('empty.txt', Buffer.alloc(0)), 'text/plain'),
+    ).rejects.toBeInstanceOf(UnsupportedTypeError);
+  });
+});

--- a/server/services/contentClass.ts
+++ b/server/services/contentClass.ts
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// What IS this file? Decided from its magic bytes, on the server, every time.
+//
+// THE RULE: the bytes have absolute authority over the class. The client's claimed
+// MIME is consulted for exactly one thing — telling text apart from SVG among
+// signature-less UTF-8 content — where it cannot cause a bypass, because a real
+// image would have been caught by the sniff regardless of what it was called.
+//
+// Why it has to be this way: the route used to take the client's word for it
+// (`req.file.mimetype === 'text/plain'`). That was survivable while the only two
+// outcomes were "image pipeline" or "text passthrough" — nobody gains by lying. The
+// moment a class means "your bytes go out untouched", a claimed MIME becomes a
+// route AROUND imagePipeline.optimize(), and that is where the EXIF scrub lives
+// (#516). Announce your geotagged JPEG as video/mp4 and the GPS rides along.
+//
+// The accepted set is a GUARANTEE, not a preference: we accept exactly the formats
+// we can strip metadata from (design decision 21). Adding a format here without a
+// scrubber for it silently breaks the promise the uploader makes about metadata.
+// Arbitrary binary is deliberately NOT a thing — DCC is the file-transfer path
+// (decision 20).
+
+import { fileTypeFromFile } from 'file-type';
+import fs from 'node:fs';
+import { isFileUtf8 } from '../utils/utf8.js';
+import type { ContentClass } from './uploadProviders/types.js';
+
+export interface Classification {
+  contentClass: ContentClass;
+  /** Canonical MIME for the bytes. For `image` the pipeline re-derives it from the
+   *  decoded image, so this is provisional; for `text`/`media` it is final. */
+  mime: string;
+  /** Canonical extension. NEVER the client's claim — a user's `.html` must never
+   *  become the served extension. */
+  ext: string;
+}
+
+export class UnsupportedTypeError extends Error {
+  code = 'UNSUPPORTED_TYPE';
+}
+
+/**
+ * Sniffed MIME → sharp format name.
+ *
+ * ⚠ This is an ALIAS MAP, not imagePipeline's FORMAT_INFO keyed by mime, and the
+ * difference is load-bearing. Verified against file-type 19 with real bytes:
+ *   • APNG sniffs as `image/apng` — sharp calls it `png`.
+ *   • iPhone photos sniff as `image/heic` — sharp calls it `heif`.
+ * A FORMAT_INFO-derived set therefore misses both: APNG would fall out of the image
+ * class entirely (regressing #516's frame-preserving scrub for exactly the animated
+ * format it was written for) and HEIC would stop being optimized.
+ */
+const IMAGE_SNIFF_MIMES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/apng',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+  'image/heic',
+  'image/heif',
+  'image/tiff',
+]);
+
+/**
+ * The media we accept — i.e. the media we can clean (decision 21).
+ *
+ * All ISO-BMFF except mp3, which is why one box-walking scrubber covers four of the
+ * five. Deliberately ABSENT: WebM/Ogg/FLAC/WAV. Not because they're dangerous — a
+ * WebM comes from a browser recorder and carries a muxer name and a date, not a
+ * location — but because we have no scrubber for them yet, and "everything we
+ * accept, we clean" is a better rule than "everything we accept, we clean, except
+ * these four". They're each a small follow-up (EBML has a `Void` element that plays
+ * the same role `free` does in MP4, so the trick transfers).
+ *
+ * MIMEs verified against file-type 19 with real/synthesized containers — note m4a
+ * is `audio/x-m4a`, NOT `audio/mp4`.
+ */
+const MEDIA_MIMES = new Map<string, string>([
+  ['video/mp4', 'mp4'],
+  ['video/quicktime', 'mov'],
+  ['video/x-m4v', 'm4v'],
+  ['audio/x-m4a', 'm4a'],
+  ['audio/mpeg', 'mp3'],
+]);
+
+export function isAcceptedMediaMime(mime: string): boolean {
+  return MEDIA_MIMES.has(mime);
+}
+
+/** Human list for the 415 — the error message is how a user discovers the policy. */
+export const ACCEPTED_SUMMARY = 'images, text, and audio/video (mp4, mov, m4v, m4a, mp3)';
+
+/**
+ * Sniffed types that mean "this is text, I just recognized its dialect" — NOT a
+ * container we should refuse.
+ *
+ * ⚠ Found the hard way: a bare `<svg>` sniffs as nothing, but a REAL SVG (what
+ * Illustrator and Inkscape write) opens with `<?xml version="1.0"?>` and file-type
+ * reports that as `application/xml`. Lumping it in with pdf/zip would have turned
+ * every real SVG upload — which works today — into a 415. These fall through to the
+ * text/SVG logic below and get decided there.
+ */
+const TEXTISH_SNIFF = new Set(['application/xml', 'text/xml']);
+
+/** file-type THROWS (End-Of-Stream) on a file too short to finish parsing a
+ *  signature it started to recognize — it doesn't just return undefined. A
+ *  truncated upload must not become a 500; "couldn't identify it" is the same
+ *  answer as "no signature", and the UTF-8 check below decides what to do next. */
+async function sniffType(path: string): Promise<{ mime: string; ext: string } | undefined> {
+  try {
+    return await fileTypeFromFile(path);
+  } catch {
+    return undefined;
+  }
+}
+
+// SVG is invisible to file-type (it's XML, not magic bytes), so it has to be
+// probed for. Without this an SVG would silently reclassify image → text, which
+// changes self-host's SVG passthrough and turns hosted's deliberate SVG rejection
+// into a silent .txt accept.
+const SVG_PROBE_BYTES = 1024;
+
+async function looksLikeSvg(path: string): Promise<boolean> {
+  const fh = await fs.promises.open(path, 'r');
+  try {
+    const buf = Buffer.alloc(SVG_PROBE_BYTES);
+    const { bytesRead } = await fh.read(buf, 0, SVG_PROBE_BYTES, 0);
+    const head = buf.subarray(0, bytesRead).toString('utf8');
+    return /<svg[\s>]/i.test(head);
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * Classify an uploaded file. Throws UnsupportedTypeError (→ 415) for anything
+ * outside the accepted set.
+ *
+ * `claimedMime` is the client's multipart Content-Type. It is untrusted, and it is
+ * used for exactly one decision — see looksLikeSvg's caller below.
+ */
+export async function classifyUpload(path: string, claimedMime: string): Promise<Classification> {
+  const sniff = await sniffType(path);
+
+  if (sniff) {
+    if (IMAGE_SNIFF_MIMES.has(sniff.mime)) {
+      // The pipeline re-derives the real mime/ext from the decoded image (and will
+      // 415 it itself if sharp can't read it), so these are provisional.
+      return { contentClass: 'image', mime: sniff.mime, ext: sniff.ext };
+    }
+
+    const mediaExt = MEDIA_MIMES.get(sniff.mime);
+    if (mediaExt) {
+      return { contentClass: 'media', mime: sniff.mime, ext: mediaExt };
+    }
+
+    // A recognized container we don't accept: pdf, zip, exe, webm, an image sharp
+    // can't read (bmp/ico)… all one answer. TEXTISH_SNIFF is the exception — it
+    // falls through to the text/SVG logic below.
+    if (!TEXTISH_SNIFF.has(sniff.mime)) {
+      throw new UnsupportedTypeError(
+        `${sniff.mime} files are not accepted — Lurker takes ${ACCEPTED_SUMMARY}`,
+      );
+    }
+  }
+
+  // No binary signature: text-ish, or unknown. Requiring the WHOLE file to be valid
+  // UTF-8 (not just a window) is what stops "claim text/plain" from smuggling
+  // arbitrary bytes through as a .txt.
+  if (await isFileUtf8(path)) {
+    // The ONE place the client's claim is consulted. An SVG picked from a file
+    // dialog arrives as image/svg+xml; the long-message → .txt flow ALWAYS claims
+    // text/plain, so this guard keeps it from being hijacked into the image path
+    // when someone pastes raw SVG markup into the composer. Neither direction is a
+    // bypass: a real image would have sniffed above, and a text file misrouted to
+    // sharp simply fails to decode and 415s.
+    if (claimedMime !== 'text/plain' && (await looksLikeSvg(path))) {
+      return { contentClass: 'image', mime: 'image/svg+xml', ext: 'svg' };
+    }
+    return { contentClass: 'text', mime: 'text/plain', ext: 'txt' };
+  }
+
+  throw new UnsupportedTypeError(
+    `this file type is not accepted — Lurker takes ${ACCEPTED_SUMMARY}`,
+  );
+}

--- a/server/services/contentClass.ts
+++ b/server/services/contentClass.ts
@@ -85,10 +85,6 @@ const MEDIA_MIMES = new Map<string, string>([
   ['audio/mpeg', 'mp3'],
 ]);
 
-export function isAcceptedMediaMime(mime: string): boolean {
-  return MEDIA_MIMES.has(mime);
-}
-
 /** Human list for the 415 — the error message is how a user discovers the policy. */
 export const ACCEPTED_SUMMARY = 'images, text, and audio/video (mp4, mov, m4v, m4a, mp3)';
 

--- a/server/services/mediaScrub.test.ts
+++ b/server/services/mediaScrub.test.ts
@@ -196,3 +196,46 @@ describe('scrubMediaFile — MP3', () => {
     expect(fs.readFileSync(p).equals(original)).toBe(true);
   });
 });
+
+describe('scrubMediaFile — pathological nesting', () => {
+  function box(type: string, payload: Buffer): Buffer {
+    const size = Buffer.alloc(4);
+    size.writeUInt32BE(8 + payload.length);
+    return Buffer.concat([size, Buffer.from(type, 'latin1'), payload]);
+  }
+
+  // Copilot's find: the depth guard used to `return` silently, so a udta hidden
+  // below it survived un-scrubbed — neither scrubbed nor refused, which is the one
+  // outcome this module promises never to produce. (Not an exploit: nesting moov in
+  // moov hides only the uploader's OWN metadata from us.)
+  it('refuses a file that nests metadata below the depth guard, rather than passing it through', async () => {
+    let inner = box('udta', Buffer.from('+37.7749-122.4194/'));
+    for (let i = 0; i < 10; i++) inner = box('moov', inner); // absurd nesting
+    const ftyp = box(
+      'ftyp',
+      Buffer.concat([Buffer.from('isom'), Buffer.alloc(4), Buffer.from('mp42')]),
+    );
+    const p = write('nested.mp4', Buffer.concat([ftyp, inner]));
+
+    await expect(scrubMediaFile(p, 'video/mp4')).rejects.toBeInstanceOf(MediaScrubError);
+    // And it stays untouched on disk, so nothing half-scrubbed can be dispatched:
+    // the route turns the throw into a 415 and the temp file is discarded.
+    expect(fs.readFileSync(p).includes(Buffer.from('+37.7749'))).toBe(true);
+  });
+
+  it('still handles the deepest nesting a real muxer produces (moov → trak → mdia)', async () => {
+    const mdia = box('mdia', box('udta', Buffer.from('device: iPhone')));
+    const trak = box('trak', Buffer.concat([mdia, box('udta', Buffer.from('+37.7749/'))]));
+    const moov = box('moov', trak);
+    const ftyp = box(
+      'ftyp',
+      Buffer.concat([Buffer.from('isom'), Buffer.alloc(4), Buffer.from('mp42')]),
+    );
+    const p = write('deep-ok.mp4', Buffer.concat([ftyp, moov]));
+
+    await scrubMediaFile(p, 'video/mp4');
+    const after = fs.readFileSync(p);
+    expect(after.includes(Buffer.from('+37.7749'))).toBe(false);
+    expect(after.includes(Buffer.from('iPhone'))).toBe(false); // nested one level deeper
+  });
+});

--- a/server/services/mediaScrub.test.ts
+++ b/server/services/mediaScrub.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { scrubMediaFile, MediaScrubError } from './mediaScrub.js';
+
+let dir: string;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-mediascrub-'));
+});
+afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+function write(name: string, bytes: Buffer): string {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, bytes);
+  return p;
+}
+
+/** An ISO-BMFF box: [size][type][payload]. */
+function box(type: string, payload: Buffer): Buffer {
+  const size = Buffer.alloc(4);
+  size.writeUInt32BE(8 + payload.length);
+  return Buffer.concat([size, Buffer.from(type, 'latin1'), payload]);
+}
+
+/** An mvhd (version 0) whose creation/modification times are set — a real muxer
+ *  writes these, and "when was this recorded" is metadata too. */
+function mvhd(creation: number): Buffer {
+  const p = Buffer.alloc(100);
+  p.writeUInt8(0, 0); // version 0
+  p.writeUInt32BE(creation, 4); // creation_time
+  p.writeUInt32BE(creation, 8); // modification_time
+  p.writeUInt32BE(1000, 12); // timescale — must survive
+  p.writeUInt32BE(5000, 16); // duration  — must survive
+  return box('mvhd', p);
+}
+
+/** GPS, the thing we actually care about: QuickTime stores it in moov/udta/©xyz. */
+const GPS = '+37.7749-122.4194/';
+function udtaWithGps(): Buffer {
+  const xyz = box('©xyz', Buffer.concat([Buffer.from([0x00, 0x12, 0x15, 0xc7]), Buffer.from(GPS)]));
+  const make = box('©mak', Buffer.from('Apple'));
+  return box('udta', Buffer.concat([xyz, make]));
+}
+
+function mp4WithGps(creation = 0xe679e672): Buffer {
+  const ftyp = box(
+    'ftyp',
+    Buffer.concat([Buffer.from('isom'), Buffer.alloc(4), Buffer.from('mp42')]),
+  );
+  const moov = box('moov', Buffer.concat([mvhd(creation), udtaWithGps()]));
+  const mdat = box('mdat', Buffer.alloc(2048, 0xab)); // the payload we must not touch
+  return Buffer.concat([ftyp, moov, mdat]);
+}
+
+describe('scrubMediaFile — ISO-BMFF', () => {
+  it('destroys GPS and device metadata, and never changes the file length', async () => {
+    const original = mp4WithGps();
+    const p = write('gps.mp4', original);
+    expect(fs.readFileSync(p).includes(Buffer.from(GPS))).toBe(true);
+
+    await scrubMediaFile(p, 'video/mp4');
+    const after = fs.readFileSync(p);
+
+    // The coordinates are gone…
+    expect(after.includes(Buffer.from(GPS))).toBe(false);
+    expect(after.includes(Buffer.from('Apple'))).toBe(false);
+    // …the udta box is now `free` padding…
+    expect(after.includes(Buffer.from('udta'))).toBe(false);
+    expect(after.includes(Buffer.from('free'))).toBe(true);
+    // …and the length is IDENTICAL, which is what makes this safe: nothing shifts,
+    // so stco/co64 chunk offsets into mdat stay valid and the file can't be
+    // corrupted by an arithmetic slip.
+    expect(after.length).toBe(original.length);
+  });
+
+  it('zeroes recording timestamps but leaves the structural fields alone', async () => {
+    const p = write('times.mp4', mp4WithGps(0xe679e672));
+    await scrubMediaFile(p, 'video/mp4');
+    const after = fs.readFileSync(p);
+
+    const at = after.indexOf(Buffer.from('mvhd')) + 4;
+    expect(after.readUInt8(at)).toBe(0); // version untouched
+    expect(after.readUInt32BE(at + 4)).toBe(0); // creation_time wiped
+    expect(after.readUInt32BE(at + 8)).toBe(0); // modification_time wiped
+    expect(after.readUInt32BE(at + 12)).toBe(1000); // timescale SURVIVES
+    expect(after.readUInt32BE(at + 16)).toBe(5000); // duration SURVIVES
+  });
+
+  it('leaves the media payload (mdat) byte-for-byte intact', async () => {
+    const original = mp4WithGps();
+    const p = write('payload.mp4', original);
+    await scrubMediaFile(p, 'video/mp4');
+    const after = fs.readFileSync(p);
+
+    const start = original.indexOf(Buffer.from('mdat')) + 4;
+    expect(after.subarray(start).equals(original.subarray(start))).toBe(true);
+  });
+
+  it('walks a REAL file written by a real muxer (macOS `say` → m4a)', async () => {
+    // A synthesized fixture only proves the walker handles boxes I wrote myself.
+    // `say` produces a genuine ISO-BMFF file (AAC in an MP4 container, ftyp M4A ),
+    // which is the same container an iPhone voice memo lands in — and those can
+    // carry location.
+    const p = path.join(dir, 'real.m4a');
+    try {
+      execFileSync('say', ['-o', p, 'lurker media scrub test'], { stdio: 'ignore' });
+    } catch {
+      return; // not on macOS — the synthesized fixtures still cover the logic
+    }
+    const before = fs.readFileSync(p);
+    expect(before.subarray(4, 8).toString()).toBe('ftyp');
+
+    await scrubMediaFile(p, 'audio/x-m4a');
+    const after = fs.readFileSync(p);
+
+    expect(after.length).toBe(before.length);
+    expect(after.subarray(0, 8).equals(before.subarray(0, 8))).toBe(true); // ftyp intact
+    // The mvhd timestamps a real muxer wrote are now zero.
+    const at = after.indexOf(Buffer.from('mvhd')) + 4;
+    expect(before.readUInt32BE(at + 4)).toBeGreaterThan(0); // it really did carry one
+    expect(after.readUInt32BE(at + 4)).toBe(0);
+    // And it's still a playable-looking file: the audio payload is untouched.
+    const mdatAt = before.indexOf(Buffer.from('mdat'));
+    expect(after.subarray(mdatAt).equals(before.subarray(mdatAt))).toBe(true);
+  });
+
+  it('refuses a malformed container rather than passing the metadata through', async () => {
+    // A box claiming to be bigger than the file. The image scrubbers fall back to
+    // the original bytes when they get confused; here that would mean shipping
+    // someone's GPS, so we refuse instead.
+    const bad = Buffer.concat([Buffer.from([0xff, 0xff, 0xff, 0xff]), Buffer.from('moov')]);
+    await expect(scrubMediaFile(write('bad.mp4', bad), 'video/mp4')).rejects.toBeInstanceOf(
+      MediaScrubError,
+    );
+  });
+});
+
+describe('scrubMediaFile — MP3', () => {
+  function mp3(withId3v2: boolean, withId3v1: boolean): Buffer {
+    const frames = Buffer.concat([Buffer.from([0xff, 0xfb, 0x90, 0x00]), Buffer.alloc(512, 0x55)]);
+    const parts: Buffer[] = [];
+    if (withId3v2) {
+      const body = Buffer.alloc(200);
+      Buffer.from('TPE1').copy(body, 0);
+      Buffer.from('Secret Artist Name').copy(body, 10);
+      const size = Buffer.from([0x00, 0x00, 0x01, 0x48]); // synchsafe 200
+      parts.push(Buffer.concat([Buffer.from('ID3'), Buffer.from([0x03, 0x00, 0x00]), size, body]));
+    }
+    parts.push(frames);
+    if (withId3v1) {
+      const v1 = Buffer.alloc(128);
+      Buffer.from('TAG').copy(v1, 0);
+      Buffer.from('Private Title').copy(v1, 3);
+      parts.push(v1);
+    }
+    return Buffer.concat(parts);
+  }
+
+  it('blanks ID3v2 frames and ID3v1 fields, keeping the file length', async () => {
+    const original = mp3(true, true);
+    const p = write('tagged.mp3', original);
+    await scrubMediaFile(p, 'audio/mpeg');
+    const after = fs.readFileSync(p);
+
+    expect(after.includes(Buffer.from('Secret Artist Name'))).toBe(false);
+    expect(after.includes(Buffer.from('Private Title'))).toBe(false);
+    // The tag headers survive, so both tags stay well-formed (an ID3v2 body of
+    // zeros is legal padding; a `TAG` with blank fields is an empty ID3v1) — and
+    // every byte offset in the file is unchanged.
+    expect(after.subarray(0, 3).toString()).toBe('ID3');
+    expect(after.subarray(after.length - 128, after.length - 125).toString()).toBe('TAG');
+    expect(after.length).toBe(original.length);
+    // The audio frames themselves are untouched.
+    expect(after.readUInt16BE(210) === original.readUInt16BE(210)).toBe(true);
+  });
+
+  it('is a no-op on an untagged mp3', async () => {
+    const original = mp3(false, false);
+    const p = write('plain.mp3', original);
+    await scrubMediaFile(p, 'audio/mpeg');
+    expect(fs.readFileSync(p).equals(original)).toBe(true);
+  });
+});

--- a/server/services/mediaScrub.test.ts
+++ b/server/services/mediaScrub.test.ts
@@ -128,6 +128,15 @@ describe('scrubMediaFile — ISO-BMFF', () => {
     // And it's still a playable-looking file: the audio payload is untouched.
     const mdatAt = before.indexOf(Buffer.from('mdat'));
     expect(after.subarray(mdatAt).equals(before.subarray(mdatAt))).toBe(true);
+
+    // The assertions above only prove the BYTES changed the way we intended. They
+    // cannot prove the file still parses. Hand it to an independent implementation —
+    // macOS CoreAudio — and make it tell us: same track, same format, same duration.
+    // Without this, a scrubber that quietly corrupts every video would pass its own
+    // test suite.
+    const info = execFileSync('afinfo', [p], { encoding: 'utf8' });
+    expect(info).toMatch(/Num Tracks:\s*1/);
+    expect(info).toMatch(/estimated duration:\s*[1-9]/); // non-zero, i.e. decodable
   });
 
   it('refuses a malformed container rather than passing the metadata through', async () => {

--- a/server/services/mediaScrub.ts
+++ b/server/services/mediaScrub.ts
@@ -56,6 +56,10 @@ const CONTAINERS = new Set(['moov', 'trak', 'mdia']);
 // shift anything; 0 is the spec's "unset".
 const TIMESTAMPED = new Set(['mvhd', 'tkhd', 'mdhd']);
 
+// Real files bottom out at moov → trak → mdia (depth 3). The headroom is generous;
+// exceeding it means the tree isn't one a muxer produced.
+const MAX_BOX_DEPTH = 8;
+
 const FREE = Buffer.from('free');
 const ZERO_CHUNK = Buffer.alloc(64 * 1024);
 
@@ -80,7 +84,15 @@ async function walkBoxes(
   end: number,
   depth: number,
 ): Promise<void> {
-  if (depth > 8) return; // no legitimate metadata nests this deep
+  // A real file bottoms out at depth 3 (moov → trak → mdia), so this is unreachable
+  // for anything a muxer wrote. REFUSE rather than return: giving up quietly would
+  // leave a `udta` below the guard un-scrubbed, which is neither scrubbing nor
+  // refusing — the exact middle ground this module promises not to occupy. (Nesting
+  // `moov` inside `moov` to hide metadata only hides the uploader's OWN metadata
+  // from us, so this is a contract fix, not an exploit fix.)
+  if (depth > MAX_BOX_DEPTH) {
+    throw new MediaScrubError(`box nesting deeper than ${MAX_BOX_DEPTH} — refusing to guess`);
+  }
   let pos = start;
   const header = Buffer.alloc(16);
 

--- a/server/services/mediaScrub.ts
+++ b/server/services/mediaScrub.ts
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Strip metadata from audio/video, IN PLACE, without decoding a frame.
+//
+// This is NOT a media pipeline and must never become one. We do not transcode
+// (decision 22): video is never rendered inline, so there's no shrink-for-chat
+// imperative, and a minutes-long CPU peg would starve the event loop on a shared
+// box. This is a header edit — we walk the container's box tree, skip straight over
+// the payload (`mdat`) by its declared length, and zero the handful of ranges that
+// hold metadata.
+//
+// WHY IT EXISTS: a video straight off a phone carries GPS in `moov/udta` — the same
+// leak #516 closed for photos, in the format people are most likely to share from a
+// camera roll. Passing video through untouched would quietly re-open it. And the
+// scrub has to be OURS: chibisafe has an optional strip-EXIF flag and Zipline v4
+// removes GPS itself, but by the time a driver strips anything the bytes have
+// already left this machine with the coordinates in them (decision 23).
+//
+// EVERY EDIT IS SIZE-PRESERVING, which is what makes this safe:
+//   • Boxes are neutralized by RETYPING them to `free` — the ISO spec's own "ignore
+//     this padding" box — and zeroing the payload. The byte length never changes,
+//     so no chunk offsets shift (`stco`/`co64` point into `mdat`) and there is no
+//     way to corrupt the file by getting the arithmetic wrong.
+//   • ID3v2's frame area is zeroed but its declared size is kept: trailing zeros are
+//     legal ID3v2 padding. ID3v1's `TAG` magic is kept and its fields blanked.
+// So the scrub is a few pwrite() calls against the upload's temp file, costs no
+// memory, and leaves req.file.size still correct.
+//
+// Companion to services/metadataScrub.ts, which does the same job for image
+// containers (WebP/PNG/GIF/SVG) but on a Buffer — images are small and bounded, so
+// they can afford it. Media can't.
+
+import fs from 'node:fs';
+
+/** A container we could not make sense of. The route turns this into a 415.
+ *  Deliberately NOT a passthrough fallback (which is what the image scrubbers do):
+ *  there is no sharp re-encode behind us to catch what we miss, and the failure mode
+ *  is someone's home address in a public channel. Refusing the upload is the
+ *  conservative answer. */
+export class MediaScrubError extends Error {
+  code = 'MEDIA_SCRUB_FAILED';
+}
+
+// Boxes whose entire contents are metadata. `udta` (user data — this is where
+// ©xyz GPS, ©mak/©mod device info and com.apple.quicktime.* live), `meta`
+// (iTunes-style ilst metadata), and `uuid` (where XMP hides).
+const NEUTRALIZE = new Set(['udta', 'meta', 'uuid']);
+
+// Boxes we descend into looking for the above. `udta` hangs off `moov` and off each
+// `trak`; `meta` off `moov` (and, in some writers, the top level).
+const CONTAINERS = new Set(['moov', 'trak', 'mdia']);
+
+// Header boxes carrying creation/modification timestamps — "when was this recorded"
+// is metadata too, and a phone writes it. Fixed-size fields, so zeroing them can't
+// shift anything; 0 is the spec's "unset".
+const TIMESTAMPED = new Set(['mvhd', 'tkhd', 'mdhd']);
+
+const FREE = Buffer.from('free');
+const ZERO_CHUNK = Buffer.alloc(64 * 1024);
+
+/** Overwrite a byte range with zeros, chunked so a huge box can't blow up memory. */
+async function zeroRange(fh: fs.promises.FileHandle, start: number, end: number): Promise<void> {
+  let pos = start;
+  while (pos < end) {
+    const n = Math.min(ZERO_CHUNK.length, end - pos);
+    await fh.write(ZERO_CHUNK, 0, n, pos);
+    pos += n;
+  }
+}
+
+/**
+ * Walk an ISO-BMFF box tree between [start, end), neutralizing metadata boxes.
+ * Recursion is bounded by the box sizes themselves; `mdat` is never read, only
+ * stepped over.
+ */
+async function walkBoxes(
+  fh: fs.promises.FileHandle,
+  start: number,
+  end: number,
+  depth: number,
+): Promise<void> {
+  if (depth > 8) return; // no legitimate metadata nests this deep
+  let pos = start;
+  const header = Buffer.alloc(16);
+
+  while (pos + 8 <= end) {
+    const { bytesRead } = await fh.read(header, 0, 16, pos);
+    if (bytesRead < 8) return;
+
+    let size = header.readUInt32BE(0);
+    const type = header.toString('latin1', 4, 8);
+    let headerSize = 8;
+
+    if (size === 1) {
+      // 64-bit largesize follows the type.
+      if (bytesRead < 16) throw new MediaScrubError('truncated 64-bit box header');
+      const large = header.readBigUInt64BE(8);
+      if (large > BigInt(Number.MAX_SAFE_INTEGER)) throw new MediaScrubError('box too large');
+      size = Number(large);
+      headerSize = 16;
+    } else if (size === 0) {
+      // "extends to end of file"
+      size = end - pos;
+    }
+
+    if (size < headerSize || pos + size > end) {
+      throw new MediaScrubError(`malformed box "${type}" at offset ${pos}`);
+    }
+
+    if (NEUTRALIZE.has(type)) {
+      // Retype to `free` and wipe the payload. Length is untouched, so every offset
+      // elsewhere in the file stays valid.
+      await fh.write(FREE, 0, 4, pos + 4);
+      await zeroRange(fh, pos + headerSize, pos + size);
+    } else if (TIMESTAMPED.has(type)) {
+      await zeroTimestamps(fh, pos + headerSize, pos + size, type);
+    } else if (CONTAINERS.has(type)) {
+      await walkBoxes(fh, pos + headerSize, pos + size, depth + 1);
+    }
+    // Anything else (ftyp, mdat, free, moof, …) is stepped over untouched.
+
+    pos += size;
+  }
+}
+
+/** Zero creation_time + modification_time in an mvhd/tkhd/mdhd. Both are 4 bytes in
+ *  a version-0 box and 8 bytes in a version-1 box, and both sit immediately after
+ *  the version/flags word in all three box types. */
+async function zeroTimestamps(
+  fh: fs.promises.FileHandle,
+  payloadStart: number,
+  payloadEnd: number,
+  type: string,
+): Promise<void> {
+  const vf = Buffer.alloc(1);
+  const { bytesRead } = await fh.read(vf, 0, 1, payloadStart);
+  if (bytesRead < 1) throw new MediaScrubError(`truncated ${type}`);
+  const version = vf[0];
+  const width = version === 1 ? 8 : 4;
+  const from = payloadStart + 4; // skip version(1) + flags(3)
+  const to = from + width * 2; // creation_time + modification_time
+  if (to > payloadEnd) throw new MediaScrubError(`truncated ${type} timestamps`);
+  await zeroRange(fh, from, to);
+}
+
+/** ID3 tags on an MP3. Both edits keep the file length identical. */
+async function scrubId3(fh: fs.promises.FileHandle, size: number): Promise<void> {
+  // ID3v2 prefix: "ID3" ver(2) flags(1) size(4, synchsafe — 7 bits per byte).
+  const head = Buffer.alloc(10);
+  const { bytesRead } = await fh.read(head, 0, 10, 0);
+  if (bytesRead === 10 && head.toString('latin1', 0, 3) === 'ID3') {
+    const tagSize =
+      ((head[6] & 0x7f) << 21) |
+      ((head[7] & 0x7f) << 14) |
+      ((head[8] & 0x7f) << 7) |
+      (head[9] & 0x7f);
+    const end = Math.min(10 + tagSize, size);
+    // Keep the header and its declared size; blank the frames. Zeros inside an
+    // ID3v2 tag are padding, which the spec allows, so the tag stays well-formed
+    // and every byte offset after it is unchanged.
+    if (end > 10) await zeroRange(fh, 10, end);
+  }
+
+  // ID3v1 trailer: the last 128 bytes, starting "TAG". Keep the magic (so it stays a
+  // valid, empty tag rather than 128 bytes of garbage a decoder might try to play)
+  // and blank the fields.
+  if (size >= 128) {
+    const tail = Buffer.alloc(3);
+    await fh.read(tail, 0, 3, size - 128);
+    if (tail.toString('latin1') === 'TAG') {
+      await zeroRange(fh, size - 128 + 3, size);
+    }
+  }
+}
+
+/**
+ * Strip metadata from a media file in place. The file's length is unchanged, so a
+ * caller's recorded size stays correct.
+ *
+ * Throws MediaScrubError if the container doesn't parse — see the class comment for
+ * why that's a refusal rather than a passthrough.
+ */
+export async function scrubMediaFile(path: string, mime: string): Promise<void> {
+  const fh = await fs.promises.open(path, 'r+');
+  try {
+    const { size } = await fh.stat();
+    if (mime === 'audio/mpeg') {
+      await scrubId3(fh, size);
+      return;
+    }
+    // Everything else we accept is ISO-BMFF: mp4, mov, m4v, m4a.
+    await walkBoxes(fh, 0, size, 0);
+  } catch (err) {
+    if (err instanceof MediaScrubError) throw err;
+    throw new MediaScrubError(`could not process this media file: ${(err as Error).message}`);
+  } finally {
+    await fh.close();
+  }
+}

--- a/server/services/uploadProviders/catbox.ts
+++ b/server/services/uploadProviders/catbox.ts
@@ -35,7 +35,7 @@ export const capabilities: DriverCapabilities = {
   // never offers delete.
   supportsDelete: true,
   mintsKeys: false,
-  acceptsContentClasses: ['image', 'text'],
+  acceptsContentClasses: ['image', 'text', 'media'],
 };
 export const configSchema: ConfigField[] = [
   {

--- a/server/services/uploadProviders/chibisafe.ts
+++ b/server/services/uploadProviders/chibisafe.ts
@@ -21,7 +21,7 @@ export const capabilities: DriverCapabilities = {
   storesRemotely: true,
   supportsDelete: true,
   mintsKeys: false,
-  acceptsContentClasses: ['image', 'text'],
+  acceptsContentClasses: ['image', 'text', 'media'],
   selfHostOnly: true,
 };
 export const configSchema: ConfigField[] = [

--- a/server/services/uploadProviders/hoarder.ts
+++ b/server/services/uploadProviders/hoarder.ts
@@ -18,6 +18,11 @@ export const capabilities: DriverCapabilities = {
   storesRemotely: true,
   supportsDelete: false,
   mintsKeys: false,
+  // NOT media yet: the hosted dropper hard-rejects anything but raster images +
+  // text/plain (control-plane dropper/src/app.ts, ALLOWED_MIME -> 415), so this is
+  // honest rather than conservative. Flips to media once the dropper ships
+  // (control-plane #56) — and it must ship FIRST, or a cell that thinks it can send
+  // video gets a 415 back from a dropper that can't take it.
   acceptsContentClasses: ['image', 'text'],
 };
 export const configSchema: ConfigField[] = [

--- a/server/services/uploadProviders/local.ts
+++ b/server/services/uploadProviders/local.ts
@@ -33,7 +33,7 @@ export const capabilities: DriverCapabilities = {
   storesRemotely: false,
   supportsDelete: true,
   mintsKeys: true,
-  acceptsContentClasses: ['image', 'text'],
+  acceptsContentClasses: ['image', 'text', 'media'],
   selfHostOnly: true,
 };
 

--- a/server/services/uploadProviders/s3.ts
+++ b/server/services/uploadProviders/s3.ts
@@ -35,7 +35,7 @@ export const capabilities: DriverCapabilities = {
   supportsDelete: true,
   // WE construct the object key (unlike a remote host that names the file).
   mintsKeys: true,
-  acceptsContentClasses: ['image', 'text', 'binary'],
+  acceptsContentClasses: ['image', 'text', 'media'],
   selfHostOnly: true,
 };
 export const configSchema: ConfigField[] = [

--- a/server/services/uploadProviders/types.ts
+++ b/server/services/uploadProviders/types.ts
@@ -10,7 +10,12 @@
 
 import type { UploadSource } from './source.js';
 
-export type ContentClass = 'image' | 'text' | 'binary';
+// image  — decoded + re-encoded by the sharp pipeline (optimize + metadata strip)
+// text    — passthrough, .txt
+// media   — passthrough, metadata scrubbed in place (services/mediaScrub.ts)
+// binary  — RESERVED and deliberately unused: arbitrary binary is not a feature,
+//           DCC is the file-transfer path (design decision 20). No driver declares it.
+export type ContentClass = 'image' | 'text' | 'media' | 'binary';
 
 /** One field a driver needs configured. `secret` fields are encrypted at rest
  *  and never projected to the client. This single declaration drives the admin

--- a/server/services/uploadProviders/x0.ts
+++ b/server/services/uploadProviders/x0.ts
@@ -17,7 +17,7 @@ export const capabilities: DriverCapabilities = {
   storesRemotely: true,
   supportsDelete: false,
   mintsKeys: false,
-  acceptsContentClasses: ['image', 'text'],
+  acceptsContentClasses: ['image', 'text', 'media'],
 };
 export const configSchema: ConfigField[] = [];
 

--- a/server/services/uploadProviders/zipline.ts
+++ b/server/services/uploadProviders/zipline.ts
@@ -21,7 +21,7 @@ export const capabilities: DriverCapabilities = {
   storesRemotely: true,
   supportsDelete: true,
   mintsKeys: false,
-  acceptsContentClasses: ['image', 'text'],
+  acceptsContentClasses: ['image', 'text', 'media'],
   selfHostOnly: true,
 };
 export const configSchema: ConfigField[] = [

--- a/server/utils/utf8.ts
+++ b/server/utils/utf8.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// "Is this text?" — the one definition, shared by the two places that ask.
+//
+//   SERVE time (routes/localUploads.ts): a magic-byte sniff came back empty, so
+//     decide whether to serve the bytes as text/plain (inline) or force a
+//     download. It only ever sees the first ~4 KB.
+//   UPLOAD time (services/contentClass.ts): decide whether a file with no binary
+//     signature is the `text` class. That answer must hold for the WHOLE file, not
+//     a window — otherwise "claim text/plain" is a way to smuggle arbitrary bytes
+//     past the accepted-type policy as a .txt.
+//
+// They used to be separate copies inside localUploads.ts, which is exactly how the
+// two drift apart.
+
+import fs from 'node:fs';
+
+/** Drop a trailing incomplete UTF-8 multibyte sequence, so a valid text file whose
+ *  read window happens to split a character isn't misjudged as binary. Walks back
+ *  over continuation bytes (0b10xxxxxx) to the lead byte; if the sequence it starts
+ *  runs past the window, trim it. */
+export function trimPartialUtf8(buf: Buffer): Buffer {
+  for (let i = 1; i <= 3 && buf.length - i >= 0; i++) {
+    const b = buf[buf.length - i];
+    if ((b & 0xc0) === 0x80) continue; // continuation byte — keep walking back
+    const seqLen = b < 0x80 ? 1 : b >= 0xf0 ? 4 : b >= 0xe0 ? 3 : b >= 0xc0 ? 2 : 1;
+    return i < seqLen ? buf.subarray(0, buf.length - i) : buf; // incomplete → drop
+  }
+  return buf;
+}
+
+export function isUtf8(buf: Buffer): boolean {
+  if (buf.length === 0) return false;
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(buf);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Is the ENTIRE file valid UTF-8? Streamed in chunks, carrying the partial
+ * multibyte sequence across the boundary — reading the file into a Buffer to check
+ * would put a 150 MB .txt straight back on the heap, which is the thing #543 spent
+ * a whole PR removing.
+ *
+ * An empty file is not text (nothing to decode, and it's a degenerate upload).
+ */
+export async function isFileUtf8(path: string): Promise<boolean> {
+  let carry = Buffer.alloc(0);
+  let sawAnything = false;
+
+  for await (const chunk of fs.createReadStream(path, { highWaterMark: 64 * 1024 })) {
+    sawAnything = true;
+    const buf: Buffer =
+      carry.length > 0 ? Buffer.concat([carry, chunk as Buffer]) : (chunk as Buffer);
+    const complete = trimPartialUtf8(buf);
+    if (complete.length > 0 && !isUtf8(complete)) return false;
+    carry = Buffer.from(buf.subarray(complete.length));
+    // A lead byte promises at most 4 bytes, so a legitimate carry is 1-3 bytes.
+    // Anything longer means trimPartialUtf8 found no lead byte to sync on.
+    if (carry.length > 3) return false;
+  }
+
+  if (!sawAnything) return false;
+  // A file that ends mid-sequence is truncated, i.e. not valid UTF-8.
+  return carry.length === 0;
+}

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1042,7 +1042,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'int',
     min: 1,
     max: 200,
-    default: 25,
+    // 100, not 25: a 30-second phone video clears 25 MB instantly, and media
+    // uploads (#515) make that the common case rather than the exotic one.
+    default: 100,
     selfHostedOnly: true,
     description:
       'Hard cap on the raw upload size in megabytes. Anything larger is ' +
@@ -1050,7 +1052,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
   {
     key: 'uploads.paste.enabled',
-    label: 'Upload pasted images',
+    label: 'Upload pasted files',
     category: 'uploads',
     group: 'pipeline',
     type: 'bool',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -997,7 +997,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       '"afk since 2026-05-09 15:30:00-0500".',
   },
 
-  // ─── Image uploads ────────────────────────────────────────────────────
+  // ─── Uploads ────────────────────────────────────────────────────
   //
   // WHERE a file goes is no longer a setting. The destination is a configured
   // uploader (a `uploader_config` row: driver + its own credentials), managed in

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -1670,7 +1670,10 @@ onMounted(() => {
 });
 
 function blobFromClipboardItem(item: DataTransferItem): File | null {
-  if (!item || !item.type || !item.type.startsWith('image/')) return null;
+  // Same gate as drop, from the same definition — pasting a video file from Finder
+  // used to silently do nothing. `kind === 'file'` keeps pasted rich text from being
+  // hijacked into an upload; the server has the final say on the type.
+  if (!item || item.kind !== 'file' || !isUploadableType(item.type)) return null;
   const file = item.getAsFile();
   return file || null;
 }

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -32,7 +32,7 @@
               loading="lazy"
             />
             <div v-else class="thumb thumb-placeholder">
-              <i class="fa-solid fa-file-lines fa-2x"></i>
+              <i class="fa-solid fa-2x" :class="iconForMime(u.mime)"></i>
             </div>
           </a>
           <div class="meta">
@@ -72,7 +72,7 @@
       </ul>
       <p v-else-if="uploads.loading && !uploads.loaded" class="empty">Loading…</p>
       <p v-else-if="uploads.loaded" class="empty">
-        No uploads yet. Paste, drop, or pick an image in the input.
+        No uploads yet. Paste, drop, or pick a file in the input.
       </p>
       <p v-if="uploads.loading && uploads.loaded" class="empty small">Loading more…</p>
     </div>
@@ -85,6 +85,7 @@ import AppModal from './AppModal.vue';
 import { useUploadsStore } from '../stores/uploads.js';
 import type { UploadItem } from '../stores/uploads.js';
 import { formatRelative } from '../utils/timestamp.js';
+import { iconForMime } from '../utils/uploaders.js';
 
 // The server response can include extra metadata fields not tracked in the
 // store's base UploadItem shape (they come from the GET /api/uploads list).

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -68,8 +68,8 @@
           type="button"
           class="tool-btn"
           :disabled="!sendable"
-          title="upload image"
-          aria-label="upload image"
+          title="upload file"
+          aria-label="upload file"
           @click="onPickFile"
         >
           <i class="fa-solid fa-paperclip"></i>

--- a/vue_client/src/stores/uploads.ts
+++ b/vue_client/src/stores/uploads.ts
@@ -84,7 +84,11 @@ export const useUploadsStore = defineStore('uploads', {
         // — the same gate the server's GET response applies. Text uploads have
         // no thumbnail.
         if (this.loaded) {
-          const isImage = typeof file.type === 'string' && file.type.startsWith('image/');
+          // Trust the server's mime — it's derived from the magic bytes, whereas
+          // file.type is the browser's guess and can be wrong or absent. It decides
+          // which type icon the row shows, so a lie here is visible.
+          const mime: string | null = result.mime ?? (file.type || null);
+          const isImage = typeof mime === 'string' && mime.startsWith('image/');
           const thumbnail_url =
             result.thumbnail_url || (isImage ? `/api/uploads/${result.id}/thumb` : undefined);
           this.recent.unshift({
@@ -92,7 +96,7 @@ export const useUploadsStore = defineStore('uploads', {
             provider: undefined, // server-only field; recent-uploads modal will re-fetch if it cares
             url: result.url,
             filename,
-            mime: file.type || null,
+            mime,
             can_delete: !!result.can_delete,
             ...(thumbnail_url ? { thumbnail_url } : {}),
           });

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -96,17 +96,52 @@ export function missingRequired(
   });
 }
 
-// What the upload route accepts today: images (optimized by the sharp pipeline)
-// and text/plain (passthrough). ONE definition, so the file picker's `accept` and
-// the drag-drop gate can't drift apart — they had, and the picker was the stricter
-// of the two: it listed images only, so a .txt could not be selected at all on
-// macOS (non-matching files are greyed out, with no "All Files" escape) even
-// though the server has always taken one.
+// What the upload route accepts: images, text, and the media we can strip metadata
+// from (mp4/mov/m4v/m4a/mp3 — see server/services/contentClass.ts). ONE definition,
+// so the file picker's `accept` and the drag-drop gate can't drift apart.
 //
-// #515 replaces this with the effective accepted set projected from the server,
-// once media lands and "what's allowed" stops being a constant.
-export const ACCEPTED_FILE_TYPES = 'image/*,text/plain,.txt';
+// Extensions are listed alongside the MIME types because browsers disagree about
+// what they call an .m4a (audio/x-m4a vs audio/mp4) and macOS greys out anything
+// the attribute doesn't match, with no "All Files" escape.
+export const ACCEPTED_FILE_TYPES = [
+  'image/*',
+  'text/plain',
+  '.txt',
+  'video/mp4',
+  'video/quicktime',
+  'video/x-m4v',
+  'audio/mpeg',
+  'audio/mp4',
+  'audio/x-m4a',
+  '.mp4',
+  '.mov',
+  '.m4v',
+  '.m4a',
+  '.mp3',
+].join(',');
 
+// Deliberately LOOSER than the accepted set: the drop/paste gates exist to ignore
+// things that obviously aren't uploads, not to enforce policy. The server is the
+// gate, and its 415 names the problem ("webm files are not accepted — Lurker takes
+// …"), which is far more useful than a drop that silently does nothing — the bug
+// this replaces.
 export function isUploadableType(mime: string): boolean {
-  return mime.startsWith('image/') || mime === 'text/plain';
+  return (
+    mime.startsWith('image/') ||
+    mime.startsWith('audio/') ||
+    mime.startsWith('video/') ||
+    mime === 'text/plain'
+  );
+}
+
+/** A Font Awesome icon for an upload with no thumbnail, from its MIME. The recent-
+ *  uploads browser used one generic page glyph for everything, so a PDF, a song and
+ *  a video were indistinguishable. */
+export function iconForMime(mime: string | null | undefined): string {
+  const m = mime || '';
+  if (m.startsWith('video/')) return 'fa-file-video';
+  if (m.startsWith('audio/')) return 'fa-file-audio';
+  if (m.startsWith('image/')) return 'fa-file-image';
+  if (m.startsWith('text/')) return 'fa-file-lines';
+  return 'fa-file';
 }


### PR DESCRIPTION
Closes #515. Depends on #543 (merged).

Rescoped from "arbitrary binary opt-in" after design review. **Binary is dropped as a feature** — the uploader shares *content*, DCC is the file-transfer path — which deletes the entire policy layer the original plan needed: no `allow_binary` column, no schema bump, no admin checkbox, no capability×policy matrix. **Zero configuration surface.**

It also dissolves the per-driver-denylist problem: catbox bans `.exe`/`.scr`/`.cpl`/`.doc*`/`.jar`, and cross-referencing that against an admin's chosen types is genuinely nasty — but with an images+text+media set, **every extension catbox bans is already outside our set.** The intersection is empty by construction.

## We accept exactly the formats we can clean

A guarantee, not a preference: `video/mp4`, `video/quicktime`, `video/x-m4v`, `audio/x-m4a`, `audio/mpeg`.

WebM/Ogg/FLAC/WAV are **out** — not because they're dangerous (a WebM comes from a browser recorder and carries a muxer name and a date, not a location) but because we have no scrubber for them, and *"everything we accept, we clean"* is a better rule than *"everything we accept, we clean, except these four"*. Each is a small follow-up (EBML has a `Void` element that plays the same role `free` does in MP4).

No transcoding, ever. Video is never rendered inline, so there's no shrink-for-chat imperative, and a minutes-long CPU peg would starve a shared box. For reference, The Lounge accepts *everything* and processes *nothing* — no sharp, no ffmpeg, no metadata stripping. Supporting video ≠ building a video pipeline.

## The two pieces

**`services/contentClass.ts` — classify from magic bytes, never the client's claim.** The route used to take the browser's word for it (`req.file.mimetype === 'text/plain'`). That was survivable while the only alternative was the image pipeline; the moment a class means "your bytes go out untouched", a claimed MIME is a **route around `imagePipeline.optimize()`** — i.e. around #516's EXIF scrub. Announce your geotagged JPEG as `video/mp4` and the GPS rides along. The claim now decides exactly one thing: text vs SVG among signature-less UTF-8, where it can't cause a bypass.

**`services/mediaScrub.ts` — strip metadata in place, no frame decoded.** A phone's MP4 carries GPS in `moov/udta`; passing video through untouched would re-open the leak #516 closed for photos, in the format people are most likely to share from a camera roll. And the scrub has to be *ours*: chibisafe has an optional strip-EXIF flag and Zipline v4 removes GPS itself, but by then the bytes have already left this machine with the coordinates in them.

Boxes are **retyped to `free`** — the ISO spec's own "ignore this padding" box — and zeroed. The byte length never changes, so no chunk offsets shift (`stco`/`co64` point into `mdat`) and there's no way to corrupt the file by getting the arithmetic wrong. `mvhd`/`tkhd`/`mdhd` recording timestamps zeroed; ID3v2 frames and ID3v1 fields blanked in place. A container that doesn't parse is a **415, not a passthrough** — unlike the image scrubbers there's no sharp re-encode behind us, and the failure mode is someone's home address in a public channel.

## Verified with real bytes, which caught three things the design doc had wrong

- **APNG sniffs as `image/apng` and HEIC as `image/heic`** — neither is a sharp format name, so a `FORMAT_INFO`-derived alias map drops APNG into passthrough and **silently un-does #516's scrub for exactly the animated format it was written for**.
- **m4a is `audio/x-m4a`**, not `audio/mp4` as the doc said.
- **A real SVG** (Illustrator/Inkscape) opens with an XML prolog, which file-type reports as `application/xml` — refusing every unaccepted sniff would have **415'd every real SVG file**, an upload that works today.

And `file-type` *throws* (End-Of-Stream) on a too-short file rather than returning undefined, which would have been a 500.

## Does it still play?

The byte-level tests prove the bytes changed the way I intended; they can't prove the file still parses. So the scrubber is also run against a real muxer's output (macOS `say` → m4a) and the result handed to an **independent implementation** — CoreAudio via `afinfo` — which reads it back with the same track, same format, and a preserved 2.79s duration, at an identical byte length. Without that, a scrubber that quietly corrupted every video would sail through its own test suite. (Skipped off macOS; the synthesized fixtures still cover the logic.)

## Rest of it

- Drivers declare `media`. **`hoarder` does not**: the hosted dropper still 415s anything but image/text, so that's honest rather than conservative. It flips when the dropper ships (control-plane #56) — and **the dropper must ship first**, or a cell that thinks it can send video gets a 415 back from one that can't take it.
- `utils/utf8.ts` — one definition of "is this text", shared by upload-time and serve-time (they were separate copies). Streams the file: a 150 MB `.txt` must not come back onto the heap, which is what #543 spent a PR removing.
- Client: picker and drop accept media; **paste too** (it was still image-only, so pasting a video from Finder silently did nothing). Recent-uploads shows a per-type icon — the row already carried `mime` and never read it. POST returns the real mime so the optimistic row isn't built from the browser's guess.
- Default cap 25 → **100 MB**: a 30-second phone video clears 25 instantly.

`/code-review high` run and its findings fixed. `npm run check` clean; 2185 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)