### PR TITLE
Hosted: let the dropper accept media (⚠ merge only after the dropper is deployed)

### DIFF
--- a/server/services/uploadProviders/hoarder.ts
+++ b/server/services/uploadProviders/hoarder.ts
@@ -18,12 +18,10 @@ export const capabilities: DriverCapabilities = {
   storesRemotely: true,
   supportsDelete: false,
   mintsKeys: false,
-  // NOT media yet: the hosted dropper hard-rejects anything but raster images +
-  // text/plain (control-plane dropper/src/app.ts, ALLOWED_MIME -> 415), so this is
-  // honest rather than conservative. Flips to media once the dropper ships
-  // (control-plane #56) — and it must ship FIRST, or a cell that thinks it can send
-  // video gets a 415 back from a dropper that can't take it.
-  acceptsContentClasses: ['image', 'text'],
+  // The hosted dropper accepts the same media set the cell scrubs (control-plane
+  // #56). ⚠ The dropper has to be DEPLOYED before a cell running this code, or the
+  // cell will happily send a video to a dropper that still 415s it.
+  acceptsContentClasses: ['image', 'text', 'media'],
 };
 export const configSchema: ConfigField[] = [
   {


### PR DESCRIPTION
One line: `hoarder` declares the `media` content class, so a hosted account can upload the same audio/video a self-hoster can.

Closes the gap the #515 merge opened — the media feature currently stops at the paywall, which is backwards (design decision 25: hosted must never be worse than the free tier).

## ⚠ Draft on purpose — this is a deploy-ordering hazard

The dropper only started accepting media in control-plane `582bc42`. **A cell running this code against an older dropper will happily send it a video and get a 415 straight back**, so every hosted media upload would fail until the dropper caught up.

Merge + deploy order:
1. Deploy the **dropper** (control-plane) — widening what it accepts is backward-compatible, so this is safe on its own.
2. Then merge this and ship the cell image.

Un-draft once step 1 is done.

## What the dropper side already covers

- mp4 / mov / m4v / m4a / mp3, matching exactly what the cell accepts and metadata-scrubs. webm stays refused (the cell can't clean it, so it must never reach the bucket).
- Cap raised 50 → 200 MB, matching the cell — safe only because the dropper now streams to disk instead of holding each upload in the heap of the box that serves the whole fleet.
- Content type is now **verified from magic bytes**, and the stored key's extension is derived from that verified type rather than from the caller's filename.
- Verified against real object storage (MinIO), not just the mocks: a real 120 MB mp4 lands at 120 MiB with `Content-Type: video/mp4`, while the process holds 5.6 MB of live buffers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)