### PR TITLE
Rename the `hoarder` driver id to `dropper` (#537)

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -11,6 +11,7 @@ import {
   seedUploaderConfig,
   reconcileBuiltInUploaders,
   reconcileLegacyUploadSettings,
+  renameHoarderDriver,
   reconcileHostedUploaderFromEnv,
 } from './uploaderConfigSeed.js';
 
@@ -290,7 +291,7 @@ function migrate() {
     -- Per-user log of every successful image upload. Thumbnail is a 128² JPEG
     -- generated at upload time and served back via /api/uploads/:id/thumb,
     -- so the recent-uploads modal stays cheap even if the original lives on a
-    -- third-party host. provider is the upload destination ('hoarder', 'catbox',
+    -- third-party host. provider is the upload destination ('dropper', 'catbox',
     -- 'x0') so the modal can label rows and so we know whether to attempt any
     -- provider-side delete (none today; tracked as a follow-up).
     CREATE TABLE IF NOT EXISTS upload_history (
@@ -1574,6 +1575,16 @@ try {
   reconcileLegacyUploadSettings(db);
 } catch (err) {
   console.warn('[db] legacy upload-settings reconcile failed:', err);
+}
+
+// Rewrite the old `hoarder` driver id to `dropper` (#537). Every boot, idempotent,
+// self-terminating. MUST come after the legacy reconcile above (the last thing that
+// can still mint a row from legacy keys) and BEFORE the hosted reconcile below,
+// which finds its row by driver id.
+try {
+  renameHoarderDriver(db);
+} catch (err) {
+  console.warn('[db] hoarder→dropper driver rename failed:', err);
 }
 
 // Re-sync the hosted locked uploader from env on every boot — idempotent no-op on

--- a/server/db/uploaderConfigSeed.node.test.ts
+++ b/server/db/uploaderConfigSeed.node.test.ts
@@ -49,7 +49,7 @@ describe('seedUploaderConfig (hosted)', () => {
       .prepare(`SELECT * FROM uploader_config WHERE scope = 'instance' AND locked = 1`)
       .get() as Row | undefined;
     expect(row).toBeTruthy();
-    expect(row!.driver).toBe('hoarder');
+    expect(row!.driver).toBe('dropper');
     expect(row!.is_default).toBe(1);
     expect(row!.offered_to_users).toBe(1);
 
@@ -78,6 +78,6 @@ describe('seedUploaderConfig (hosted)', () => {
         driver: string;
       }[]
     ).map((r) => r.driver);
-    expect(drivers).toEqual(['hoarder']);
+    expect(drivers).toEqual(['dropper']);
   });
 });

--- a/server/db/uploaderConfigSeed.test.ts
+++ b/server/db/uploaderConfigSeed.test.ts
@@ -195,7 +195,7 @@ describe('reconcileLegacyUploadSettings (self-host)', () => {
 
     const rows = userRows(u.id);
     expect(rows).toHaveLength(1);
-    expect(rows[0].driver).toBe('hoarder');
+    expect(rows[0].driver).toBe('dropper');
     expect(JSON.parse(rows[0].config_json)).toEqual({ url: 'https://u.example' });
     expect(rows[0].secrets_enc).toContain('k-secret');
     expect(rows[0].config_json).not.toContain('k-secret');
@@ -219,7 +219,7 @@ describe('reconcileLegacyUploadSettings (self-host)', () => {
 
     const rows = userRows(u.id);
     expect(rows).toHaveLength(1);
-    expect(rows[0].driver).toBe('hoarder');
+    expect(rows[0].driver).toBe('dropper');
     expect(rows[0].secrets_enc).toContain('late-key');
     // Repointed off x0 and onto their own Hoarder — the bytes stop leaking public.
     expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(rows[0].id);
@@ -292,5 +292,86 @@ describe('reconcileLegacyUploadSettings (self-host)', () => {
     const local = instanceRows().find((r) => r.driver === 'local')!;
     expect(getUserSettings(u.id)['uploads.uploader_id']).toBe(local.id);
     expect(userRows(u.id)).toHaveLength(0); // zero-config: no user row needed
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #537: the driver id `hoarder` is renamed to `dropper`. It's persisted in two
+// tables and in old .lurk exports, so this is a data migration, not a rename.
+describe('renameHoarderDriver (#537)', () => {
+  let renameHoarderDriver: typeof import('./uploaderConfigSeed.js').renameHoarderDriver;
+  let getDriver: typeof import('../services/uploadProviders/index.js').getDriver;
+
+  beforeAll(async () => {
+    renameHoarderDriver = (await import('./uploaderConfigSeed.js')).renameHoarderDriver;
+    getDriver = (await import('../services/uploadProviders/index.js')).getDriver;
+  });
+
+  const uploaderDrivers = (): string[] =>
+    (
+      db.prepare(`SELECT driver FROM uploader_config ORDER BY id`).all() as { driver: string }[]
+    ).map((r) => r.driver);
+
+  it('rewrites the id in uploader_config AND in upload_history', async () => {
+    const user = createUser(`rename-${Date.now()}`);
+    db.prepare(
+      `INSERT INTO uploader_config (scope, owner_user_id, driver, label, config_json, secrets_enc,
+         enabled, offered_to_users, locked, is_default)
+       VALUES ('user', ?, 'hoarder', 'Hoarder', '{"url":"https://h.test"}', NULL, 1, 0, 0, 0)`,
+    ).run(user.id);
+    db.prepare(
+      `INSERT INTO upload_history (user_id, provider, url, mime, byte_size)
+       VALUES (?, 'hoarder', 'https://cdn.test/a.png', 'image/png', 10)`,
+    ).run(user.id);
+
+    renameHoarderDriver(db);
+
+    expect(uploaderDrivers()).toContain('dropper');
+    expect(uploaderDrivers()).not.toContain('hoarder');
+    // The history string is denormalized and display-only — but leaving it would
+    // show "hoarder" for old uploads and "dropper" for new ones in the same list.
+    const provider = (
+      db.prepare(`SELECT provider FROM upload_history WHERE user_id = ?`).get(user.id) as {
+        provider: string;
+      }
+    ).provider;
+    expect(provider).toBe('dropper');
+  });
+
+  it('is idempotent and self-terminating (it runs on every boot)', () => {
+    const before = uploaderDrivers();
+    renameHoarderDriver(db);
+    renameHoarderDriver(db);
+    expect(uploaderDrivers()).toEqual(before);
+  });
+
+  // The catastrophe this rename can cause, and the reason findHostedRow matches
+  // BOTH ids: if a hosted row still said `hoarder` and the lookup only knew
+  // `dropper`, the seed would insert a SECOND locked is_default row and trip the
+  // one-default unique index — failing the seed on every boot thereafter. The seed
+  // re-runs on any future SCHEMA_VERSION bump, so this is reachable.
+  it('a not-yet-migrated hosted row is still found, so the seed never duplicates it', async () => {
+    const { seedUploaderConfig: seed } = await import('./uploaderConfigSeed.js');
+    db.prepare(`DELETE FROM uploader_config WHERE scope = 'instance'`).run();
+    db.prepare(
+      `INSERT INTO uploader_config (scope, owner_user_id, driver, label, config_json, secrets_enc,
+         enabled, offered_to_users, locked, is_default)
+       VALUES ('instance', NULL, 'hoarder', 'Hosted uploader', '{}', NULL, 1, 1, 1, 1)`,
+    ).run();
+
+    // Re-running the seed against the old id must NOT insert a second locked row.
+    expect(() => seed(db)).not.toThrow();
+    const locked = db
+      .prepare(`SELECT COUNT(*) AS n FROM uploader_config WHERE scope = 'instance' AND locked = 1`)
+      .get() as { n: number };
+    expect(locked.n).toBe(1);
+  });
+
+  // A .lurk export taken before the rename can be imported at any time — including
+  // between boots, when the migration hasn't swept it up yet. The row still has to
+  // resolve to a driver, or that user's uploads simply stop working.
+  it('the old id still resolves to a driver, so an old export is never stranded', () => {
+    expect(getDriver('hoarder')).toBe(getDriver('dropper'));
+    expect(getDriver('dropper')?.driver).toBe('dropper');
   });
 });

--- a/server/db/uploaderConfigSeed.ts
+++ b/server/db/uploaderConfigSeed.ts
@@ -199,10 +199,23 @@ function hostedConfigFromEnv(): { config_json: string; secrets_enc: string | nul
   };
 }
 
+/**
+ * The hosted cell's one locked instance uploader.
+ *
+ * ⚠ Matches BOTH ids, and that is load-bearing rather than tidy. The driver was
+ * renamed `hoarder` → `dropper` (#537), and if this only matched the new id it
+ * would fail to recognise a row that hadn't been migrated yet — whereupon
+ * seedUploaderConfig would insert a SECOND locked row with is_default = 1 and hit
+ * the one-default partial unique index, failing the seed on every boot from then
+ * on. The seed re-runs on any future SCHEMA_VERSION bump, so "the migration
+ * already ran" is not a safe assumption to bake in here.
+ */
 function findHostedRow(db: Database.Database): number | null {
   const r = db
     .prepare(
-      `SELECT id FROM uploader_config WHERE scope = 'instance' AND locked = 1 AND driver = 'hoarder' LIMIT 1`,
+      `SELECT id FROM uploader_config
+        WHERE scope = 'instance' AND locked = 1 AND driver IN ('dropper', 'hoarder')
+        LIMIT 1`,
     )
     .get() as { id: number } | undefined;
   return r ? r.id : null;
@@ -211,7 +224,7 @@ function findHostedRow(db: Database.Database): number | null {
 // ─── the migration ────────────────────────────────────────────────────────────
 
 /**
- * Seed the uploader model. Hosted: a single locked `hoarder` instance default
+ * Seed the uploader model. Hosted: a single locked `dropper` instance default
  * from env + allow_user_defined=0. Self-host: the built-in instance rows (x0
  * default, catbox, local) + allow_user_defined=1. Fully idempotent.
  *
@@ -227,7 +240,7 @@ export function seedUploaderConfig(db: Database.Database): void {
         insertRow(db, {
           scope: 'instance',
           owner_user_id: null,
-          driver: 'hoarder',
+          driver: 'dropper',
           label: 'Hosted uploader',
           config_json,
           secrets_enc,
@@ -359,7 +372,10 @@ function migrateUserOffLegacyKeys(db: Database.Database, userId: number): void {
   const hoarderRowId =
     hoarderUrl && hoarderKey
       ? upsertUserRow(db, userId, {
-          driver: 'hoarder',
+          // The row's LABEL stays "Hoarder": a self-hoster who set these keys is
+          // pointing at an actual Hoarder instance, and that's their name for it.
+          // Only the internal adapter id changes (#537).
+          driver: 'dropper',
           label: 'Hoarder',
           config: { url: hoarderUrl },
           secrets: { api_key: hoarderKey },
@@ -448,4 +464,36 @@ export function reconcileHostedUploaderFromEnv(db: Database.Database): void {
   db.prepare(
     `UPDATE uploader_config SET config_json = ?, secrets_enc = ?, updated_at = datetime('now') WHERE id = ?`,
   ).run(config_json, secrets_enc, rowId);
+}
+
+/**
+ * Rewrite the old `hoarder` driver id to `dropper` (#537).
+ *
+ * Runs on EVERY boot, not behind a SCHEMA_VERSION gate — the one-shot gate is
+ * exactly what wedged a dev DB in #511, and this doesn't need one: it's
+ * self-terminating (once no row says `hoarder`, both statements match nothing).
+ *
+ * Two tables, because the id is persisted in two places:
+ *   • uploader_config.driver     — the rows themselves.
+ *   • upload_history.provider    — denormalized onto every historical upload, on
+ *                                  purpose, so it survives the config row being
+ *                                  deleted. It's a display string, and leaving it
+ *                                  would mean the uploads list showed "hoarder" for
+ *                                  old rows and "dropper" for new ones — more
+ *                                  confusing than either name alone.
+ *
+ * MUST run before reconcileHostedUploaderFromEnv (which looks the hosted row up by
+ * driver id) and after reconcileLegacyUploadSettings (which is the last thing that
+ * could still mint a row from legacy keys).
+ *
+ * NOTE this is a tidy-up, not a correctness dependency: getDriver() accepts
+ * `hoarder` as an alias, so a row that somehow escapes this — an old export
+ * imported between boots — still resolves.
+ */
+export function renameHoarderDriver(db: Database.Database): void {
+  const run = db.transaction(() => {
+    db.prepare(`UPDATE uploader_config SET driver = 'dropper' WHERE driver = 'hoarder'`).run();
+    db.prepare(`UPDATE upload_history SET provider = 'dropper' WHERE provider = 'hoarder'`).run();
+  });
+  run();
 }

--- a/server/routes/uploaders.test.ts
+++ b/server/routes/uploaders.test.ts
@@ -92,10 +92,10 @@ describe('GET /api/uploaders', () => {
     expect(row.editable).toBe(true);
 
     // …so a descriptor for its driver MUST be present, or the form can't render.
-    const hoarder = res.body.drivers.find((d: any) => d.driver === 'dropper');
-    expect(hoarder).toBeDefined();
-    expect(hoarder.creatable).toBe(false); // but still not offered in the add menu
-    expect(hoarder.configSchema.map((f: any) => f.key)).toEqual(['url', 'api_key']);
+    const dropper = res.body.drivers.find((d: any) => d.driver === 'dropper');
+    expect(dropper).toBeDefined();
+    expect(dropper.creatable).toBe(false); // but still not offered in the add menu
+    expect(dropper.configSchema.map((f: any) => f.key)).toEqual(['url', 'api_key']);
 
     // And editing it still works end-to-end, secret preserved on omit.
     const patched = await agent.patch(`/api/uploaders/${migrated}`).send({ label: 'My Hoarder' });

--- a/server/routes/uploaders.test.ts
+++ b/server/routes/uploaders.test.ts
@@ -82,7 +82,7 @@ describe('GET /api/uploaders', () => {
     const migrated = createUploaderConfig({
       scope: 'user',
       ownerUserId: user.id,
-      driver: 'hoarder', // what the legacy-settings migration produces
+      driver: 'dropper', // what the legacy-settings migration produces
       label: 'Hoarder',
       values: { url: 'https://hoard.example', api_key: 'k' },
     });
@@ -92,7 +92,7 @@ describe('GET /api/uploaders', () => {
     expect(row.editable).toBe(true);
 
     // …so a descriptor for its driver MUST be present, or the form can't render.
-    const hoarder = res.body.drivers.find((d: any) => d.driver === 'hoarder');
+    const hoarder = res.body.drivers.find((d: any) => d.driver === 'dropper');
     expect(hoarder).toBeDefined();
     expect(hoarder.creatable).toBe(false); // but still not offered in the add menu
     expect(hoarder.configSchema.map((f: any) => f.key)).toEqual(['url', 'api_key']);

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -27,7 +27,7 @@ const ctx = setupTestDb('routes-uploads-node');
 // per-user settings. The configSchema mirrors hoarder (url + api_key required) so
 // the resolver's "locked-but-unconfigured → 503" check has fields to test.
 const stub = {
-  driver: 'hoarder',
+  driver: 'dropper',
   label: 'Hosted uploader',
   capabilities: {
     storesRemotely: true,
@@ -147,7 +147,7 @@ describe('POST /api/uploads (node edition)', () => {
     const list = await agent.get('/api/uploads');
     const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
     // Recorded as the forced in-house provider, not the tenant's 'catbox' pick.
-    expect(row.provider).toBe('hoarder');
+    expect(row.provider).toBe('dropper');
   });
 
   it('hands the provider operator env credentials, not per-user settings', async () => {

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -24,7 +24,7 @@ const ctx = setupTestDb('routes-uploads-node');
 // Same stub pattern as uploads.test.ts: capture the config the route hands the
 // driver so we can prove the hosted uploader sources its credentials from the
 // baked instance row (seeded from the operator env), never from the tenant's
-// per-user settings. The configSchema mirrors hoarder (url + api_key required) so
+// per-user settings. The configSchema mirrors dropper (url + api_key required) so
 // the resolver's "locked-but-unconfigured → 503" check has fields to test.
 const stub = {
   driver: 'dropper',

--- a/server/services/uploadProviders/dropper.ts
+++ b/server/services/uploadProviders/dropper.ts
@@ -1,19 +1,28 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// Hoarder provider — the operator's own self-hosted file dropper at
-// ~/Coding/hoarder, deployed at upload.bradroot.me. Authenticates via
-// Authorization: Bearer <api_key> (support added in coordinated change to
-// the Hoarder repo); returns JSON `{ id, ext, url, thumb_url, ... }` where
-// `url` is already the public CDN URL.
+// The `dropper` driver — the adapter that speaks the in-house upload protocol:
+// POST /api/upload, `Authorization: Bearer <api_key>`, JSON `{ id, ext, url,
+// thumb_url, … }` where `url` is already the public CDN URL.
+//
+// It has two speakers: the HOSTED dropper (control-plane/dropper), which is what
+// every app.lurker.chat cell uploads through, and a self-hoster's own Hoarder
+// instance — the service the protocol was first written for, and where this
+// driver's old name came from.
+//
+// ⚠ The id used to be `hoarder`, which was a historical accident: decision 12
+// retired it from the self-host menu (S3 replaces it) and it survives as the
+// hosted transport. Renamed in #537. `hoarder` is still accepted as a driver id
+// (see the alias in index.ts) because it is PERSISTED — in uploader_config rows
+// and in old .lurk exports — so it can arrive from data we don't control.
 
 import { USER_AGENT } from '../../utils/userAgent.js';
 import { postMultipart, isOk, jsonBody, type StreamPart } from './multipart.js';
 import type { UploadSource } from './source.js';
 import type { ConfigField, DriverCapabilities, UploadMeta, UploadResult } from './types.js';
 
-export const driver = 'hoarder';
-export const label = 'Hoarder';
+export const driver = 'dropper';
+export const label = 'Dropper';
 export const capabilities: DriverCapabilities = {
   storesRemotely: true,
   supportsDelete: false,

--- a/server/services/uploadProviders/index.ts
+++ b/server/services/uploadProviders/index.ts
@@ -47,12 +47,19 @@ export const driverIds = Object.keys(DRIVERS);
  * resolve to a driver or the user's uploads simply break. Keeping the alias means
  * the migration is a tidy-up, not a load-bearing dependency.
  */
-const DEPRECATED_DRIVER_IDS: Record<string, string> = {
+const DEPRECATED_DRIVER_IDS: Record<string, string | undefined> = {
   hoarder: 'dropper',
 };
 
 export function getDriver(id: string): UploadDriver | null {
-  return DRIVERS[id] ?? DRIVERS[DEPRECATED_DRIVER_IDS[id]] ?? null;
+  const direct = DRIVERS[id];
+  if (direct) return direct;
+  // Spelled out rather than chained: an id with no alias yields `undefined`, and
+  // `DRIVERS[undefined]` only misses because JS coerces the key to the string
+  // "undefined". Correct by accident is not a property to rely on in a lookup that
+  // decides whether a user's uploads resolve at all.
+  const alias = DEPRECATED_DRIVER_IDS[id];
+  return alias ? (DRIVERS[alias] ?? null) : null;
 }
 
 /**

--- a/server/services/uploadProviders/index.ts
+++ b/server/services/uploadProviders/index.ts
@@ -8,7 +8,7 @@
 
 import * as x0 from './x0.js';
 import * as catbox from './catbox.js';
-import * as hoarder from './hoarder.js';
+import * as dropper from './dropper.js';
 import * as local from './local.js';
 import * as zipline from './zipline.js';
 import * as chibisafe from './chibisafe.js';
@@ -27,7 +27,7 @@ export type {
 const DRIVERS: Record<string, UploadDriver> = {
   [x0.driver]: x0,
   [catbox.driver]: catbox,
-  [hoarder.driver]: hoarder,
+  [dropper.driver]: dropper,
   [local.driver]: local,
   [zipline.driver]: zipline,
   [chibisafe.driver]: chibisafe,
@@ -36,8 +36,23 @@ const DRIVERS: Record<string, UploadDriver> = {
 
 export const driverIds = Object.keys(DRIVERS);
 
+/**
+ * Driver ids that used to be written to the database and may still arrive from
+ * data we don't control.
+ *
+ * `hoarder` → `dropper` (#537). The id is PERSISTED — in `uploader_config.driver`
+ * and inside old `.lurk` export archives — so a boot migration rewriting our own
+ * rows isn't enough on its own: an export taken before the rename can be imported
+ * at any time, and until the next boot's migration sweeps it up, that row has to
+ * resolve to a driver or the user's uploads simply break. Keeping the alias means
+ * the migration is a tidy-up, not a load-bearing dependency.
+ */
+const DEPRECATED_DRIVER_IDS: Record<string, string> = {
+  hoarder: 'dropper',
+};
+
 export function getDriver(id: string): UploadDriver | null {
-  return DRIVERS[id] ?? null;
+  return DRIVERS[id] ?? DRIVERS[DEPRECATED_DRIVER_IDS[id]] ?? null;
 }
 
 /**

--- a/server/services/uploadProviders/nodeUpload.ts
+++ b/server/services/uploadProviders/nodeUpload.ts
@@ -13,7 +13,7 @@
 import { getOption } from '../settingsRegistry.js';
 
 /** Provider id forced for every upload in node edition. */
-export const NODE_UPLOAD_PROVIDER_ID = 'hoarder';
+export const NODE_UPLOAD_PROVIDER_ID = 'dropper';
 
 /**
  * Operator-supplied in-house uploader credentials, read fresh from the

--- a/server/services/uploadProviders/uploadProviders.test.ts
+++ b/server/services/uploadProviders/uploadProviders.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as x0 from './x0.js';
 import * as catbox from './catbox.js';
-import * as hoarder from './hoarder.js';
+import * as dropper from './dropper.js';
 import * as zipline from './zipline.js';
 import * as chibisafe from './chibisafe.js';
 import * as s3 from './s3.js';
@@ -294,7 +294,7 @@ describe('catbox provider', () => {
   });
 });
 
-describe('hoarder provider', () => {
+describe('dropper provider', () => {
   it('POSTs to {base}/api/upload with Authorization: Bearer and `file` field', async () => {
     const cap = capturePost();
     postResponse = {
@@ -302,7 +302,7 @@ describe('hoarder provider', () => {
       headers: {},
       text: JSON.stringify({ id: 'aB3kZ', url: 'https://cdn.test/aB3kZ.gif' }),
     };
-    const result = await hoarder.upload(
+    const result = await dropper.upload(
       src([0xff, 0xd8]),
       { filename: 'wave.gif', mime: 'image/gif' },
       { url: 'https://upload.example.com', api_key: 'sekret' },
@@ -321,7 +321,7 @@ describe('hoarder provider', () => {
       headers: {},
       text: JSON.stringify({ url: 'https://cdn.test/x.png' }),
     };
-    await hoarder.upload(
+    await dropper.upload(
       src([1]),
       { filename: 'x.png', mime: 'image/png' },
       { url: 'https://upload.example.com/', api_key: 'k' },
@@ -331,13 +331,13 @@ describe('hoarder provider', () => {
 
   it('rejects with PROVIDER_CONFIG when url is missing', async () => {
     await expect(
-      hoarder.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { api_key: 'k' }),
+      dropper.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { api_key: 'k' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
   });
 
   it('rejects with PROVIDER_CONFIG when api_key is missing', async () => {
     await expect(
-      hoarder.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { url: 'https://u' }),
+      dropper.upload(src([1]), { filename: 'x.png', mime: 'image/png' }, { url: 'https://u' }),
     ).rejects.toMatchObject({ code: 'PROVIDER_CONFIG' });
   });
 
@@ -348,7 +348,7 @@ describe('hoarder provider', () => {
       text: 'Invalid API key',
     });
     await expect(
-      hoarder.upload(
+      dropper.upload(
         src([1]),
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', api_key: 'bad' },
@@ -363,7 +363,7 @@ describe('hoarder provider', () => {
       text: JSON.stringify({ id: 'x' }),
     });
     await expect(
-      hoarder.upload(
+      dropper.upload(
         src([1]),
         { filename: 'x.png', mime: 'image/png' },
         { url: 'https://u', api_key: 'k' },


### PR DESCRIPTION
Closes #537. The in-house adapter was called `hoarder` for historical reasons — it's the **hosted dropper**, and decision 12 retired it from the self-host menu. The id is **persisted**, so this is a data migration, not a rename.

## The migration

`renameHoarderDriver()` rewrites **both** tables the id lives in:

- `uploader_config.driver` — the rows themselves.
- `upload_history.provider` — denormalized onto every historical upload, deliberately, so it survives its config row being deleted. It's display-only, but leaving it would mean the uploads list showed **"hoarder" for old uploads and "dropper" for new ones in the same list** — more confusing than either name alone.

Runs on **every boot**, idempotent and self-terminating. Not behind a `SCHEMA_VERSION` gate — a one-shot gate is exactly what wedged a dev DB in #511. Ordered *after* the legacy reconcile (the last thing that can still mint a row from legacy keys) and *before* the hosted reconcile (which finds its row by driver id).

## ⚠ The trap, which is worse than the issue recorded

`findHostedRow()` now matches **both** ids, and that is load-bearing rather than tidy.

`seedUploaderConfig` re-runs whenever `schemaVersion < SCHEMA_VERSION` — i.e. on **any future schema bump**, not just this release. So "the migration already ran" is not a safe assumption to bake into the lookup. If it only knew `dropper` and met a row that still said `hoarder`, it would insert a **second locked `is_default = 1` row**, trip the one-default partial unique index, and fail the seed on every boot from then on. There's a test for exactly this.

## The alias

`getDriver()` keeps `hoarder` as a **permanent** alias. A `.lurk` export taken before the rename can be imported at any time — including *between boots*, when the migration hasn't swept it up yet — and that row still has to resolve to a driver or the user's uploads simply stop working.

This is what makes the migration a tidy-up rather than a correctness dependency, which is the property I wanted given the failure mode above.

## Rehearsed against real data

Fixtures only prove the code does what I told it to. So: a **copy** of the real 285 MB dev DB, with a `hoarder` config row and `hoarder` history rows injected, booted through the actual migration ordering.

- 23 ms boot — the `upload_history` UPDATE is not slow
- both tables rewritten
- the existing `s3` instance default untouched (no `is_default` collateral)
- the user's **label** preserved: a self-hoster with these keys is pointing at an actual Hoarder instance, and that's their name for it. Only the internal adapter id changes.

## ⚠ Not rollback-safe for uploads

Once the rows say `dropper`, a cell rolled back to a pre-#537 image can't resolve the driver (`getDriver('dropper')` → `null`) and hosted uploads 400 until it's rolled forward.

No data is damaged and no duplicate row is created (the seed is version-gated and this bumps nothing), but **roll-forward is the fix, not roll-back**. Worth knowing before deploying it, since it's the one property this change gives up.

`npm run check` clean; 2193 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)