### PR TITLE
Uploads settings: don't render a picker when there's nothing to pick

### DIFF
--- a/vue_client/src/components/settings-panes/UploadsPane.vue
+++ b/vue_client/src/components/settings-panes/UploadsPane.vue
@@ -18,54 +18,84 @@
 <template>
   <section id="uploads" class="settings-pane">
     <h2>Uploads</h2>
-    <p class="section-desc">
+    <!-- Three variants, because `allowUserDefined` defaults to true before the fetch
+         lands: without the `loaded` gate a hosted user is briefly told they can
+         choose an uploader, which isn't true. -->
+    <p v-if="!loaded" class="section-desc">
+      Where pasted and picked files are uploaded. Lurker pastes a link into the message — the file
+      itself is hosted by an uploader, not by Lurker.
+    </p>
+    <p v-else-if="canChoose" class="section-desc">
       Where pasted and picked files are uploaded. Lurker pastes a link into the message — the file
       itself is hosted by whichever uploader you choose here.
     </p>
+    <p v-else class="section-desc">
+      Where pasted and picked files are uploaded. Lurker pastes a link into the message — the file
+      itself is hosted by
+      <strong>{{ soleUploaderLabel }}</strong
+      >, which this server provides.
+    </p>
     <p v-if="error" class="error inline">{{ error }}</p>
 
-    <h3 class="subhead">destination</h3>
-    <p v-if="loading && !loaded" class="muted small">Loading…</p>
-    <ul v-else class="device-list">
-      <li v-for="u in uploaders" :key="u.id" class="device stacked">
-        <span class="ua">
-          <span class="name">{{ u.label }}</span>
-          <span class="driver">{{ u.driver }}</span>
-          <span v-if="u.scope === 'user'" class="badge">yours</span>
-          <span v-if="u.id === selectedId" class="badge in-use">in use</span>
-        </span>
-        <div class="row-actions">
-          <button v-if="u.id !== selectedId" class="link" :disabled="busy" @click="onSelect(u.id)">
-            use this one
-          </button>
-          <!-- Editable AND describable: a row whose driver we have no schema for
+    <!-- The destination picker only exists to make a CHOICE. On the hosted service
+         there is exactly one uploader and personal ones are off, so it rendered the
+         same destination twice — once as itself and once as "Server default" — and
+         asked you to pick between them. Nothing to choose → no chooser; the line
+         above says where the files go instead. -->
+    <template v-if="canChoose">
+      <h3 class="subhead">destination</h3>
+      <p v-if="loading && !loaded" class="muted small">Loading…</p>
+      <ul v-else class="device-list">
+        <li v-for="u in uploaders" :key="u.id" class="device stacked">
+          <span class="ua">
+            <span class="name">{{ u.label }}</span>
+            <span class="driver">{{ u.driver }}</span>
+            <span v-if="u.scope === 'user'" class="badge">yours</span>
+            <span v-if="u.id === selectedId" class="badge in-use">in use</span>
+          </span>
+          <div class="row-actions">
+            <button
+              v-if="u.id !== selectedId"
+              class="link"
+              :disabled="busy"
+              @click="onSelect(u.id)"
+            >
+              use this one
+            </button>
+            <!-- Editable AND describable: a row whose driver we have no schema for
                can't be rendered as a form, so offer removal but not editing. -->
-          <button
-            v-if="u.editable && driverFor(u.driver)"
-            class="link"
-            :disabled="busy"
-            @click="onEdit(u)"
-          >
-            edit
-          </button>
-          <button v-if="u.editable" class="link danger" :disabled="busy" @click="onDelete(u)">
-            remove
-          </button>
-        </div>
-      </li>
-      <li class="device stacked">
-        <span class="ua">
-          <span class="name">Server default</span>
-          <span class="driver">follow whatever the admin has set</span>
-          <span v-if="selectedId === null" class="badge in-use">in use</span>
-        </span>
-        <div class="row-actions">
-          <button v-if="selectedId !== null" class="link" :disabled="busy" @click="onSelect(null)">
-            use this one
-          </button>
-        </div>
-      </li>
-    </ul>
+            <button
+              v-if="u.editable && driverFor(u.driver)"
+              class="link"
+              :disabled="busy"
+              @click="onEdit(u)"
+            >
+              edit
+            </button>
+            <button v-if="u.editable" class="link danger" :disabled="busy" @click="onDelete(u)">
+              remove
+            </button>
+          </div>
+        </li>
+        <li class="device stacked">
+          <span class="ua">
+            <span class="name">Server default</span>
+            <span class="driver">follow whatever the admin has set</span>
+            <span v-if="selectedId === null" class="badge in-use">in use</span>
+          </span>
+          <div class="row-actions">
+            <button
+              v-if="selectedId !== null"
+              class="link"
+              :disabled="busy"
+              @click="onSelect(null)"
+            >
+              use this one
+            </button>
+          </div>
+        </li>
+      </ul>
+    </template>
 
     <template v-if="editing && editingDriver">
       <h3 class="subhead">edit {{ editing.label }}</h3>
@@ -110,7 +140,7 @@
         </button>
       </p>
     </template>
-    <p v-else-if="!allowUserDefined" class="muted small">
+    <p v-else-if="!allowUserDefined && canChoose" class="muted small">
       This server doesn’t allow personal uploaders — you can pick from the ones above.
     </p>
 
@@ -124,12 +154,18 @@ import { ref, computed, onMounted } from 'vue';
 import { api } from '../../api.js';
 import RegistryPane from './RegistryPane.vue';
 import UploaderConfigForm from '../UploaderConfigForm.vue';
+import { hasUploaderChoice } from '../../utils/uploaders.js';
 import type { Uploader, UploaderDriver } from '../../utils/uploaders.js';
 
 const uploaders = ref<Uploader[]>([]);
 const drivers = ref<UploaderDriver[]>([]);
 const selectedId = ref<number | null>(null);
 const allowUserDefined = ref(true);
+
+const canChoose = computed(() => hasUploaderChoice(uploaders.value.length, allowUserDefined.value));
+
+/** Where files actually go when there's nothing to choose. */
+const soleUploaderLabel = computed(() => uploaders.value[0]?.label ?? 'this server’s uploader');
 
 const loading = ref(false);
 const loaded = ref(false);

--- a/vue_client/src/utils/uploaders.test.ts
+++ b/vue_client/src/utils/uploaders.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { hasUploaderChoice, iconForMime, isUploadableType } from './uploaders.js';
+
+describe('hasUploaderChoice', () => {
+  // The bug this exists to prevent: on app.lurker.chat there is exactly ONE
+  // uploader (the locked dropper) and personal uploaders are off, so the settings
+  // pane rendered the same destination twice — once by name, once as the "Server
+  // default" pseudo-row that resolves to it — and asked the user to choose.
+  it('is false on a hosted cell: one uploader, and you cannot add another', () => {
+    expect(hasUploaderChoice(1, false)).toBe(false);
+  });
+
+  it('is true when you may add your own, even with a single uploader today', () => {
+    // The picker still has a job — the list is about to grow.
+    expect(hasUploaderChoice(1, true)).toBe(true);
+    expect(hasUploaderChoice(0, true)).toBe(true);
+  });
+
+  it('is true on a locked-down instance that offers several to pick between', () => {
+    expect(hasUploaderChoice(3, false)).toBe(true);
+  });
+});
+
+describe('iconForMime', () => {
+  it('distinguishes the types a thumbnail-less row can be', () => {
+    expect(iconForMime('video/mp4')).toBe('fa-file-video');
+    expect(iconForMime('audio/mpeg')).toBe('fa-file-audio');
+    expect(iconForMime('text/plain')).toBe('fa-file-lines');
+    expect(iconForMime('image/png')).toBe('fa-file-image');
+    expect(iconForMime(null)).toBe('fa-file');
+  });
+});
+
+describe('isUploadableType', () => {
+  // Deliberately looser than the server's accepted set: these gates exist to ignore
+  // things that obviously aren't uploads, not to enforce policy. The server's 415
+  // names the real reason, which beats a drop that silently does nothing.
+  it('lets media through for the server to judge', () => {
+    expect(isUploadableType('video/webm')).toBe(true); // server will 415 it, with a reason
+    expect(isUploadableType('image/png')).toBe(true);
+    expect(isUploadableType('text/plain')).toBe(true);
+    expect(isUploadableType('application/pdf')).toBe(false);
+  });
+});

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -145,3 +145,21 @@ export function iconForMime(mime: string | null | undefined): string {
   if (m.startsWith('text/')) return 'fa-file-lines';
   return 'fa-file';
 }
+
+/**
+ * Is there an actual choice of upload destination to make?
+ *
+ * A picker with one option isn't a picker. On the hosted service there is exactly
+ * one uploader (the locked dropper) and personal ones are disabled, so the settings
+ * pane offered the SAME destination twice — once by name, and once as the "Server
+ * default" pseudo-row that resolves to it — and asked the user to choose between
+ * them.
+ *
+ * ⚠ `allowUserDefined` counts even when there's only one uploader: you can add a
+ * second, so the picker has a job to do. And a locked-down self-host that offers
+ * several instance uploaders also has one. The ONLY case with no choice is "a single
+ * destination that you cannot add to" — which is exactly the hosted cell.
+ */
+export function hasUploaderChoice(uploaderCount: number, allowUserDefined: boolean): boolean {
+  return allowUserDefined || uploaderCount > 1;
+}


### PR DESCRIPTION
On app.lurker.chat the destination list showed the **same destination twice** — once as "Hosted uploader / dropper", and once as the "Server default" pseudo-row that *resolves to it* — and invited you to choose between them.

<img width="500" alt="before" src="https://github.com/user-attachments/assets/placeholder" />

A hosted cell has exactly one uploader (the locked dropper) and personal uploaders are disabled, so there is no choice to make. **A picker with one option isn't a picker.**

## What changed

The destination section is gated on there actually being a choice. When there isn't, it's replaced by a plain statement of where files go — hiding the section outright would have left that question unanswered, which is worse than the duplicate rows.

The rule is `hasUploaderChoice(count, allowUserDefined)`, pulled into `utils/uploaders.ts` so it can be tested and, more importantly, so its intent is written down:

- **allowing personal uploaders counts as a choice even at one uploader today** — you can add a second, so the picker has a job;
- **a locked-down self-host offering several instance uploaders** also has a real choice;
- the only case with none is *"a single destination you cannot add to"* — which is exactly the hosted cell.

`count > 1` alone looks like the whole rule and isn't, which is why it's a named function with a comment rather than an inline condition someone later "simplifies".

## Two smaller things it dragged out

- The *"This server doesn't allow personal uploaders — you can pick from the ones above"* note is nonsense when there's nothing to pick between. Now gated too.
- The intro copy is gated on `loaded`: `allowUserDefined` defaults to `true` before the fetch lands, so a hosted user was briefly told they could choose an uploader. Small, but it's a sentence that's false.

## Tests

No SFC test infrastructure in the repo (only composables and utils are tested), so this is a pure function plus a table test over the three real configurations — hosted, self-host, and locked-down-multi — rather than a component test. Also backfilled coverage for `iconForMime` and `isUploadableType` while I was in that file.

`npm run check` clean; 2198 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)