### PR TITLE
Fix flaky route tests: reuse one listener instead of a port per request

### DIFF
--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -3,8 +3,7 @@
 
 import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
 import type { Express } from 'express';
-import request from 'supertest';
-import { setupTestDb, TEST_SESSION_SECRET } from './test-utils/testApp.js';
+import { setupTestDb, testRequest, TEST_SESSION_SECRET } from './test-utils/testApp.js';
 
 // buildApp gates routes on the cached edition, resolved once per module
 // instance. vi.resetModules() between builds hands each call a fresh edition
@@ -30,13 +29,13 @@ describe('buildApp route gating by edition', () => {
     it('does not mount /api/api-tokens', async () => {
       const app = await buildFor('node');
       // 404 (no route), distinct from the 401 a mounted-but-authless route gives.
-      const res = await request(app).get('/api/api-tokens');
+      const res = await testRequest(app).get('/api/api-tokens');
       expect(res.status).toBe(404);
     });
 
     it('does not mount the MCP server at /mcp', async () => {
       const app = await buildFor('node');
-      const res = await request(app)
+      const res = await testRequest(app)
         .post('/mcp')
         .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
       expect(res.status).toBe(404);
@@ -46,7 +45,7 @@ describe('buildApp route gating by edition', () => {
       const app = await buildFor('node');
       // `mcp` is excluded from the SPA catch-all, so a disabled /mcp is
       // consistently absent rather than served index.html.
-      const res = await request(app).get('/mcp');
+      const res = await testRequest(app).get('/mcp');
       expect(res.status).toBe(404);
     });
 
@@ -54,7 +53,7 @@ describe('buildApp route gating by edition', () => {
       const app = await buildFor('node');
       // requireNodeAuth rejects (503 with no secret configured), but the router
       // IS mounted — the point is it does not 404.
-      const res = await request(app).get('/api/node/status');
+      const res = await testRequest(app).get('/api/node/status');
       expect(res.status).not.toBe(404);
     });
   });
@@ -62,13 +61,13 @@ describe('buildApp route gating by edition', () => {
   describe('standalone edition', () => {
     it('mounts /api/api-tokens (requireAuth → 401, not 404)', async () => {
       const app = await buildFor('standalone');
-      const res = await request(app).get('/api/api-tokens');
+      const res = await testRequest(app).get('/api/api-tokens');
       expect(res.status).toBe(401);
     });
 
     it('mounts the MCP server (requireApiAuth → 401 without a bearer token)', async () => {
       const app = await buildFor('standalone');
-      const res = await request(app)
+      const res = await testRequest(app)
         .post('/mcp')
         .send({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
       expect(res.status).toBe(401);
@@ -76,7 +75,7 @@ describe('buildApp route gating by edition', () => {
 
     it('does not mount the orchestrator control surface /api/node', async () => {
       const app = await buildFor('standalone');
-      const res = await request(app).get('/api/node/status');
+      const res = await testRequest(app).get('/api/node/status');
       expect(res.status).toBe(404);
     });
   });

--- a/server/middleware/apiAuth.test.ts
+++ b/server/middleware/apiAuth.test.ts
@@ -4,8 +4,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import express from 'express';
 import type { Express } from 'express';
-import request from 'supertest';
-import { setupTestDb } from '../test-utils/testApp.js';
+import { setupTestDb, testRequest } from '../test-utils/testApp.js';
 import type { User } from '../db/users.js';
 import type { CreateTokenResult } from '../db/apiTokens.js';
 
@@ -37,24 +36,26 @@ afterAll(() => ctx.cleanup());
 
 describe('requireApiAuth', () => {
   it('401 when Authorization header is missing', async () => {
-    const res = await request(app).get('/protected');
+    const res = await testRequest(app).get('/protected');
     expect(res.status).toBe(401);
   });
 
   it('401 when header is not Bearer-shaped', async () => {
-    const res = await request(app).get('/protected').set('Authorization', 'Basic foo');
+    const res = await testRequest(app).get('/protected').set('Authorization', 'Basic foo');
     expect(res.status).toBe(401);
   });
 
   it('401 when token is bogus (no DB row)', async () => {
-    const res = await request(app).get('/protected').set('Authorization', 'Bearer notarealtoken');
+    const res = await testRequest(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer notarealtoken');
     expect(res.status).toBe(401);
   });
 
   it('authenticates a valid token and populates req.user without req.session', async () => {
     const u: User = createUser('mw-alice');
     const t: CreateTokenResult = createToken({ userId: u.id, name: 'mw', scope: 'read-write' });
-    const res = await request(app).get('/protected').set('Authorization', `Bearer ${t.token}`);
+    const res = await testRequest(app).get('/protected').set('Authorization', `Bearer ${t.token}`);
     expect(res.status).toBe(200);
     expect(res.body.userId).toBe(u.id);
     expect(res.body.username).toBe('mw-alice');
@@ -66,7 +67,7 @@ describe('requireApiAuth', () => {
     const u: User = createUser('mw-bob');
     const t: CreateTokenResult = createToken({ userId: u.id, name: 'rev', scope: 'read' });
     revoke(t.id, u.id);
-    const res = await request(app).get('/protected').set('Authorization', `Bearer ${t.token}`);
+    const res = await testRequest(app).get('/protected').set('Authorization', `Bearer ${t.token}`);
     expect(res.status).toBe(401);
   });
 
@@ -74,7 +75,7 @@ describe('requireApiAuth', () => {
     const u: User = createUser('mw-carol');
     const t: CreateTokenResult = createToken({ userId: u.id, name: 'orphan', scope: 'read' });
     deleteUser(u.id);
-    const res = await request(app).get('/protected').set('Authorization', `Bearer ${t.token}`);
+    const res = await testRequest(app).get('/protected').set('Authorization', `Bearer ${t.token}`);
     expect(res.status).toBe(401);
   });
 
@@ -82,8 +83,10 @@ describe('requireApiAuth', () => {
     const u: User = createUser('mw-dave');
     const tRead: CreateTokenResult = createToken({ userId: u.id, name: 'r', scope: 'read' });
     const tRW: CreateTokenResult = createToken({ userId: u.id, name: 'rw', scope: 'read-write' });
-    const r1 = await request(app).get('/protected').set('Authorization', `Bearer ${tRead.token}`);
-    const r2 = await request(app).get('/protected').set('Authorization', `Bearer ${tRW.token}`);
+    const r1 = await testRequest(app)
+      .get('/protected')
+      .set('Authorization', `Bearer ${tRead.token}`);
+    const r2 = await testRequest(app).get('/protected').set('Authorization', `Bearer ${tRW.token}`);
     expect(r1.body.tokenScope).toBe('read');
     expect(r2.body.tokenScope).toBe('read-write');
   });

--- a/server/middleware/auth.test.ts
+++ b/server/middleware/auth.test.ts
@@ -3,12 +3,12 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Router } from 'express';
-import request from 'supertest';
 import type { Express } from 'express';
 import {
   setupTestDb,
   createTestApp,
   createAuthedAgent,
+  testRequest,
   type TestDbContext,
 } from '../test-utils/testApp.js';
 
@@ -47,7 +47,7 @@ describe('requireAuth stale-session recovery', () => {
   it('clears BOTH lurker_session and cp_session on a stale (bad-signature) cookie', async () => {
     // A cookie signed with a different secret — what a rebuilt cell with a fresh
     // SESSION_SECRET sees from a browser holding the old lurker_session.
-    const res = await request(app)
+    const res = await testRequest(app)
       .get('/protected')
       .set('Cookie', 'lurker_session=s%3Astale.deadbeefbadsignature');
     expect(res.status).toBe(401);
@@ -57,7 +57,7 @@ describe('requireAuth stale-session recovery', () => {
   });
 
   it('does not clear cookies when no session cookie was sent', async () => {
-    const res = await request(app).get('/protected');
+    const res = await testRequest(app).get('/protected');
     expect(res.status).toBe(401);
     expect(res.headers['set-cookie']).toBeUndefined();
   });

--- a/server/routes/apiTokens.test.ts
+++ b/server/routes/apiTokens.test.ts
@@ -3,9 +3,13 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import type { LurkerTestAgent } from '../test-utils/testApp.js';
-import request from 'supertest';
 import type { Express } from 'express';
-import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  testRequest,
+} from '../test-utils/testApp.js';
 import type { User } from '../db/users.js';
 
 const ctx = setupTestDb('routes-api-tokens');
@@ -31,7 +35,7 @@ afterAll(() => ctx.cleanup());
 
 describe('GET /api/api-tokens (auth)', () => {
   it('401 when no session cookie', async () => {
-    const res = await request(app).get('/api/api-tokens');
+    const res = await testRequest(app).get('/api/api-tokens');
     expect(res.status).toBe(401);
   });
 

--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -3,8 +3,12 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import type { Express } from 'express';
-import request from 'supertest';
-import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  testRequest,
+} from '../test-utils/testApp.js';
 
 const ctx = setupTestDb('routes-auth');
 
@@ -19,7 +23,7 @@ afterAll(() => ctx.cleanup());
 
 describe('GET /api/auth/setup-status', () => {
   it('reports needsSetup=true on a fresh install (no users)', async () => {
-    const res = await request(app).get('/api/auth/setup-status');
+    const res = await testRequest(app).get('/api/auth/setup-status');
     expect(res.status).toBe(200);
     expect(res.body.needsSetup).toBe(true);
   });
@@ -27,7 +31,7 @@ describe('GET /api/auth/setup-status', () => {
 
 describe('GET /api/auth/auth-methods (pre-setup)', () => {
   it('reports passkey=false when no credentials exist', async () => {
-    const res = await request(app).get('/api/auth/auth-methods');
+    const res = await testRequest(app).get('/api/auth/auth-methods');
     expect(res.status).toBe(200);
     expect(res.body.passkey).toBe(false);
   });
@@ -35,7 +39,7 @@ describe('GET /api/auth/auth-methods (pre-setup)', () => {
 
 describe('POST /api/auth/setup/password', () => {
   it('rejects an invalid username', async () => {
-    const res = await request(app).post('/api/auth/setup/password').send({
+    const res = await testRequest(app).post('/api/auth/setup/password').send({
       username: '!!bad!!',
       password: 'longenoughpw',
     });
@@ -43,7 +47,7 @@ describe('POST /api/auth/setup/password', () => {
   });
 
   it('rejects too-short passwords', async () => {
-    const res = await request(app).post('/api/auth/setup/password').send({
+    const res = await testRequest(app).post('/api/auth/setup/password').send({
       username: 'firstadmin',
       password: 'short',
     });
@@ -51,7 +55,7 @@ describe('POST /api/auth/setup/password', () => {
   });
 
   it('creates the first admin and signs them in', async () => {
-    const res = await request(app).post('/api/auth/setup/password').send({
+    const res = await testRequest(app).post('/api/auth/setup/password').send({
       username: 'firstadmin',
       password: 'longenoughpw',
     });
@@ -66,7 +70,7 @@ describe('POST /api/auth/setup/password', () => {
   });
 
   it('subsequent setup attempts return 409', async () => {
-    const res = await request(app).post('/api/auth/setup/password').send({
+    const res = await testRequest(app).post('/api/auth/setup/password').send({
       username: 'second',
       password: 'longenoughpw',
     });
@@ -74,19 +78,19 @@ describe('POST /api/auth/setup/password', () => {
   });
 
   it('setup-status switches to false after the first user', async () => {
-    const res = await request(app).get('/api/auth/setup-status');
+    const res = await testRequest(app).get('/api/auth/setup-status');
     expect(res.body.needsSetup).toBe(false);
   });
 });
 
 describe('login / logout / me', () => {
   it('rejects unknown user + wrong password identically', async () => {
-    const ghost = await request(app).post('/api/auth/login/password').send({
+    const ghost = await testRequest(app).post('/api/auth/login/password').send({
       username: 'ghost',
       password: 'doesnotmatter',
     });
     expect(ghost.status).toBe(401);
-    const wrong = await request(app).post('/api/auth/login/password').send({
+    const wrong = await testRequest(app).post('/api/auth/login/password').send({
       username: 'firstadmin',
       password: 'wrong-password',
     });
@@ -95,8 +99,8 @@ describe('login / logout / me', () => {
   });
 
   it('rejects login when fields are missing or empty', async () => {
-    const r1 = await request(app).post('/api/auth/login/password').send({});
-    const r2 = await request(app)
+    const r1 = await testRequest(app).post('/api/auth/login/password').send({});
+    const r2 = await testRequest(app)
       .post('/api/auth/login/password')
       .send({ username: 'firstadmin', password: '' });
     expect(r1.status).toBe(400);
@@ -104,7 +108,7 @@ describe('login / logout / me', () => {
   });
 
   it('valid password login issues a session cookie', async () => {
-    const res = await request(app).post('/api/auth/login/password').send({
+    const res = await testRequest(app).post('/api/auth/login/password').send({
       username: 'firstadmin',
       password: 'longenoughpw',
     });
@@ -118,7 +122,7 @@ describe('login / logout / me', () => {
   });
 
   it('/me requires auth', async () => {
-    const res = await request(app).get('/api/auth/me');
+    const res = await testRequest(app).get('/api/auth/me');
     expect(res.status).toBe(401);
   });
 
@@ -132,7 +136,7 @@ describe('login / logout / me', () => {
   });
 
   it('/logout clears the cookie', async () => {
-    const res = await request(app).post('/api/auth/logout');
+    const res = await testRequest(app).post('/api/auth/logout');
     expect(res.status).toBe(200);
     // Should set the clearCookie header even when no token was present.
     expect(
@@ -145,7 +149,7 @@ describe('login / logout / me', () => {
 
 describe('password management', () => {
   it('GET /api/auth/password requires auth', async () => {
-    const res = await request(app).get('/api/auth/password');
+    const res = await testRequest(app).get('/api/auth/password');
     expect(res.status).toBe(401);
   });
 
@@ -173,13 +177,13 @@ describe('password management', () => {
     expect(res.status).toBe(200);
 
     // Old password no longer works.
-    const fail = await request(app).post('/api/auth/login/password').send({
+    const fail = await testRequest(app).post('/api/auth/login/password').send({
       username: 'firstadmin',
       password: 'longenoughpw',
     });
     expect(fail.status).toBe(401);
     // New one does.
-    const ok = await request(app).post('/api/auth/login/password').send({
+    const ok = await testRequest(app).post('/api/auth/login/password').send({
       username: 'firstadmin',
       password: 'newerpassword',
     });
@@ -206,7 +210,7 @@ describe('password management', () => {
 
 describe('GET /api/auth/passkeys', () => {
   it('requires auth', async () => {
-    const res = await request(app).get('/api/auth/passkeys');
+    const res = await testRequest(app).get('/api/auth/passkeys');
     expect(res.status).toBe(401);
   });
 
@@ -221,21 +225,21 @@ describe('GET /api/auth/passkeys', () => {
 
 describe('GET /api/auth/invite/:token', () => {
   it('valid:false for an unknown token', async () => {
-    const res = await request(app).get('/api/auth/invite/no-such-token');
+    const res = await testRequest(app).get('/api/auth/invite/no-such-token');
     expect(res.body).toEqual({ valid: false });
   });
 });
 
 describe('POST /api/auth/login/options', () => {
   it('409 when no passkeys exist', async () => {
-    const res = await request(app).post('/api/auth/login/options');
+    const res = await testRequest(app).post('/api/auth/login/options');
     expect(res.status).toBe(409);
   });
 });
 
 describe('POST /api/auth/invite/:token/password', () => {
   it('404 for an invalid token', async () => {
-    const res = await request(app).post('/api/auth/invite/bogus/password').send({
+    const res = await testRequest(app).post('/api/auth/invite/bogus/password').send({
       username: 'someone',
       password: 'longenoughpw',
     });
@@ -247,7 +251,7 @@ describe('POST /api/auth/invite/:token/password', () => {
     const { createInvite } = await import('../db/invites.js');
     const admin = findUserByUsername('firstadmin')!;
     const invite = createInvite(admin.id, { expiresInDays: 1 })!;
-    const res = await request(app).post(`/api/auth/invite/${invite.token}/password`).send({
+    const res = await testRequest(app).post(`/api/auth/invite/${invite.token}/password`).send({
       username: 'invitee',
       password: 'longenoughpw',
     });
@@ -261,12 +265,12 @@ describe('POST /api/auth/invite/:token/password', () => {
     const { createInvite } = await import('../db/invites.js');
     const admin = findUserByUsername('firstadmin')!;
     const invite = createInvite(admin.id, { expiresInDays: 1 })!;
-    const ok = await request(app).post(`/api/auth/invite/${invite.token}/password`).send({
+    const ok = await testRequest(app).post(`/api/auth/invite/${invite.token}/password`).send({
       username: 'one-shot',
       password: 'longenoughpw',
     });
     expect(ok.status).toBe(200);
-    const reuse = await request(app).post(`/api/auth/invite/${invite.token}/password`).send({
+    const reuse = await testRequest(app).post(`/api/auth/invite/${invite.token}/password`).send({
       username: 'two-shot',
       password: 'longenoughpw',
     });

--- a/server/routes/uploaders.test.ts
+++ b/server/routes/uploaders.test.ts
@@ -6,10 +6,14 @@
 // projection assertion here is really asserting that.
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import request from 'supertest';
 import type { Express } from 'express';
 import type { LurkerTestAgent } from '../test-utils/testApp.js';
-import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  testRequest,
+} from '../test-utils/testApp.js';
 import type { User } from '../db/users.js';
 
 const ctx = setupTestDb('routes-uploaders');
@@ -52,7 +56,7 @@ async function createCatbox(hash = 'my-userhash') {
 
 describe('GET /api/uploaders', () => {
   it('401 without a session', async () => {
-    expect((await request(app).get('/api/uploaders')).status).toBe(401);
+    expect((await testRequest(app).get('/api/uploaders')).status).toBe(401);
   });
 
   it('lists the seeded instance uploaders, and flags which drivers may be ADDED', async () => {

--- a/server/services/mcpServer.test.ts
+++ b/server/services/mcpServer.test.ts
@@ -4,8 +4,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import express from 'express';
 import type { Express } from 'express';
-import request from 'supertest';
-import { setupTestDb } from '../test-utils/testApp.js';
+import { setupTestDb, testRequest } from '../test-utils/testApp.js';
 import type { User } from '../db/users.js';
 import type { Network } from '../db/networks.js';
 import type { CreateTokenResult } from '../db/apiTokens.js';
@@ -56,7 +55,7 @@ beforeAll(async () => {
 afterAll(() => ctx.cleanup());
 
 function rpc(token: string, body: object) {
-  return request(app)
+  return testRequest(app)
     .post('/mcp')
     .set('Authorization', `Bearer ${token}`)
     .set('Content-Type', 'application/json')
@@ -65,7 +64,7 @@ function rpc(token: string, body: object) {
 
 describe('MCP server', () => {
   it('401 without a bearer token', async () => {
-    const res = await request(app)
+    const res = await testRequest(app)
       .post('/mcp')
       .send({ jsonrpc: '2.0', id: 1, method: 'initialize' });
     expect(res.status).toBe(401);

--- a/server/test-utils/testApp.ts
+++ b/server/test-utils/testApp.ts
@@ -23,10 +23,49 @@ import cookieParser from 'cookie-parser';
 import { sign as signCookie } from 'cookie-signature';
 import request from 'supertest';
 import fs from 'fs';
+import http from 'http';
 import os from 'os';
 import path from 'path';
 
 export const TEST_SESSION_SECRET = 'test-session-secret';
+
+// One listening server per app, reused by every agent and every request.
+//
+// Handed a bare Express app, supertest binds a fresh ephemeral port with
+// listen(0) for EACH request and close()s it once the response lands. Across a
+// full suite run that churns thousands of short-lived listeners, and a small
+// fraction of those connections get reset by the kernel — surfacing as a
+// "socket hang up" that fails whichever route test happened to be running.
+// It's rare, load-dependent, and lands on an arbitrary test, which is exactly
+// what makes it read as a flaky assertion rather than a transport fault.
+//
+// Handing supertest an ALREADY-LISTENING server instead makes it skip both the
+// listen and the close (see supertest's Test#serverAddress / Test#end), so the
+// whole file shares one stable port. listen() binds synchronously, so
+// address() is live by the time an agent issues its first request.
+const servers = new WeakMap<Express, http.Server>();
+let openServers: http.Server[] = [];
+
+function listeningServer(app: Express): http.Server {
+  const existing = servers.get(app);
+  if (existing) return existing;
+  const server = http.createServer(app);
+  // No host argument: listen(0) binds synchronously, so address() is live on
+  // return. Passing a host defers the bind to a DNS/next-tick path, address()
+  // stays null, and supertest would silently go right back to listening per
+  // request.
+  server.listen(0);
+  // If address() is ever null here, supertest quietly falls back to listening
+  // per request and the flake comes back unnoticed — fail loudly instead.
+  if (!server.address()) {
+    throw new Error('test server did not bind synchronously; supertest would listen per request');
+  }
+  // Never let a stray listener hold the vitest worker open.
+  server.unref();
+  servers.set(app, server);
+  openServers.push(server);
+  return server;
+}
 
 export interface TestDbContext {
   tmpDir: string;
@@ -49,6 +88,8 @@ export function setupTestDb(suffix = ''): TestDbContext {
     tmpDir,
     dbPath: process.env.DATABASE_PATH,
     cleanup() {
+      for (const server of openServers) server.close();
+      openServers = [];
       fs.rmSync(tmpDir, { recursive: true, force: true });
     },
   };
@@ -75,6 +116,13 @@ export function createTestApp(routerMounts: Record<string, Router>): Express {
   return app;
 }
 
+// One-off (agent-less) requests. Use this instead of supertest's `request(app)`
+// so the request goes through the file's shared listener rather than binding
+// and tearing down a port of its own — see listeningServer above.
+export function testRequest(app: Express): request.Agent {
+  return request(listeningServer(app));
+}
+
 // Returns a supertest agent pre-loaded with a signed lurker_session cookie for
 // the given user. Creates a real session row via db/sessions.js — the route
 // handlers then go through the unmodified loadSession path.
@@ -84,7 +132,7 @@ export async function createAuthedAgent(app: Express, userId: number): Promise<L
   const { createSession } = await import('../db/sessions.js');
   const { token } = createSession(userId);
   const signed = 's:' + signCookie(token, TEST_SESSION_SECRET);
-  const agent = request.agent(app);
+  const agent = request.agent(listeningServer(app));
   // request.agent stores cookies by jar, but the simplest reliable approach is
   // to set the Cookie header on every request. Supertest's .set('Cookie',...)
   // sticks for the agent's lifetime.
@@ -94,5 +142,5 @@ export async function createAuthedAgent(app: Express, userId: number): Promise<L
 
 // Convenience: build an unauthenticated supertest agent against the app.
 export function createAnonAgent(app: Express): LurkerTestAgent {
-  return request.agent(app);
+  return request.agent(listeningServer(app));
 }


### PR DESCRIPTION
## What this is

`server/routes/highlights.test.ts` → *"filters by free text (q) over the FTS index"* failed once in a full run but passes 10/10 in isolation. **It is not an FTS bug, and the assertion was correct** — the request never reached a response, it died at the TCP layer. The test is unchanged.

## Root cause

Handed a bare Express app, supertest calls `app.listen(0)` for **every request** and `close()`s it once the response lands (`supertest/lib/test.js`, `serverAddress` + `end`). A full suite run churns thousands of short-lived ephemeral listeners, and a small fraction of those connections get reset — surfacing as `socket hang up` on whichever route test happened to be running.

At ~4×10⁻⁵ per request it never reproduces on one file in isolation, which is exactly what makes it read as a flaky assertion rather than a transport fault.

## Evidence

- **53 full-suite runs**: 4 failures, roaming across three unrelated files — including `push.test.ts > requires auth`, a bare 401 check that touches no messages, no writes, and no FTS at all.
- **The exact FTS scenario hammered 80,000× under load**: 3 failures, *all* `socket hang up`, and **0 data failures**. The index returned the correct single row 80,000/80,000.
- **FTS5 external-content drift ruled out separately**: 400 interleaved inserts, searches, NULL-text rows and cascading network deletes on the shared connection, with FTS5 `integrity-check` throughout and results diffed against a ground-truth base-table scan — clean. (Single-connection write/search ordering is a non-issue too: better-sqlite3 is synchronous, so the insert commits before the search is prepared.)

## The fix

Bind **one listener per app** and hand supertest the already-listening server, so it skips both the `listen` and the `close`. The seven files that called `request(app)` directly now go through a `testRequest()` helper, so nothing bypasses the shared listener.

⚠️ `listen(0)` must be called **without a host argument**. Passing one defers the bind, `address()` stays null, and supertest *silently* reverts to listening per request — the flake persists at an unchanged rate and the fix looks like a dud. (This caught me; only a probe counting distinct ports — 25 requests → 25 ports — revealed it.) A guard now throws if the bind is ever not synchronous, so that regression can't return quietly.

## Validation

Same load, same everything else:

| | before | after |
|---|---|---|
| 80k-request FTS hammer | 3 × `socket hang up` | **0** |
| 60 full-suite runs | 2 × `socket hang up` (in 53) | **0** |
| distinct ports / 25 requests | 25 | **1** |

Suite green (174 files, 2198 tests); `npm run check` exits 0.

## Still open, and unrelated

`multipart.test.ts > surfaces the provider's 413 when it rejects early but keeps draining` flakes at an **unchanged** rate (2/53 before, 2/60 after), with a real `write EPIPE` surfacing through `hangupError` in `server/services/uploadProviders/multipart.ts:252`. It's exercising product code, not the harness — likely a genuine race in the upload path. Deliberately left out of this PR; wants its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)