### PR TITLE
Stop asking upload providers to hang up on us mid-upload

### DIFF
--- a/server/services/uploadProviders/multipart.test.ts
+++ b/server/services/uploadProviders/multipart.test.ts
@@ -154,6 +154,11 @@ describe('postMultipart', () => {
 
     // A well-behaved server: answer immediately, but keep reading the body so the
     // client's writes never fail. The response is reliably delivered.
+    //
+    // This only holds because we no longer send `Connection: close`: a server told
+    // to close destroys the socket as soon as it has written its answer, draining
+    // or not, and the 413 dies with it (~30% of the time on a body this size). So
+    // this test doubles as the guard on that — bring the header back and it flakes.
     const polite = createServer((req, res) => {
       req.once('data', () => {
         res.writeHead(413, { 'content-type': 'text/plain' });

--- a/server/services/uploadProviders/multipart.ts
+++ b/server/services/uploadProviders/multipart.ts
@@ -155,7 +155,14 @@ function sendStreamed(
     // Owning the agent (rather than letting node's global one pool sockets to
     // providers between uploads) keeps the old header's real benefit: nothing is
     // reused, the connection still goes away as soon as we're done with it.
-    const agent = new lib.Agent({ keepAlive: true });
+    //
+    // keepAlive is about what we put ON THE WIRE, not about pooling: it is what
+    // makes node send `Connection: keep-alive`. maxFreeSockets:0 then says never
+    // park an idle socket, so the connection dies the moment the exchange is done
+    // even if the destroy() below never runs. Do NOT "simplify" this to
+    // keepAlive:false — that sends `Connection: close` again and brings the bug
+    // straight back.
+    const agent = new lib.Agent({ keepAlive: true, maxFreeSockets: 0 });
 
     let settled = false;
     const done = (r: PostBufferResult): void => {

--- a/server/services/uploadProviders/multipart.ts
+++ b/server/services/uploadProviders/multipart.ts
@@ -140,6 +140,23 @@ function sendStreamed(
     const isHttps = url.protocol === 'https:';
     const lib = isHttps ? https : http;
 
+    // A keep-alive agent, private to this ONE request and destroyed when it ends.
+    //
+    // We used to send `Connection: close`. That is actively harmful on an upload:
+    // a provider that rejects early (413 too-large, 401 bad token) answers while
+    // we are still pushing bytes, and a server told `close` destroys the socket
+    // the moment it has finished writing that answer — no matter how politely it
+    // drains the rest of the body. Node's socket then takes the EPIPE and throws
+    // away the response bytes already in its receive buffer, so we lose the very
+    // status and message the provider just sent us and fall back to the generic
+    // hangup error below. Measured against a draining server: `close` lost the
+    // 413 on ~30% of 8MB uploads; keep-alive delivered it every time.
+    //
+    // Owning the agent (rather than letting node's global one pool sockets to
+    // providers between uploads) keeps the old header's real benefit: nothing is
+    // reused, the connection still goes away as soon as we're done with it.
+    const agent = new lib.Agent({ keepAlive: true });
+
     let settled = false;
     const done = (r: PostBufferResult): void => {
       if (!settled) {
@@ -163,12 +180,13 @@ function sendStreamed(
         // Content-Length and Connection are OURS: a caller that supplied either
         // could silently corrupt the framing (a wrong Content-Length hangs the
         // request or truncates the body). Strip any case-variant they passed so
-        // node can't emit the header twice.
+        // node can't emit the header twice. Connection is left to the agent,
+        // which means keep-alive — see the agent above for why that matters.
         headers: {
           ...omitHeaders(headers, ['content-length', 'connection']),
           'Content-Length': String(contentLength),
-          Connection: 'close',
         },
+        agent,
       },
       (res) => {
         // Provider responses are small (a URL or a little JSON), so buffering the
@@ -217,6 +235,10 @@ function sendStreamed(
     // "connection reset" rather than as the 413 it sent. So: surface the response
     // whenever it parsed, and otherwise fail with something that NAMES the likely
     // cause instead of a bare `write EPIPE` that tells a user nothing.
+    //
+    // What we no longer do is CAUSE that hangup ourselves — a provider that drains
+    // gets to finish talking to us now (see the keep-alive agent above), so this
+    // path is for providers that cut us off regardless, not the common case.
     let writeError: Error | null = null;
     const body = Readable.from(makeBody());
     body.on('error', (err: Error) => {
@@ -228,6 +250,9 @@ function sendStreamed(
       body.destroy();
     });
     req.on('close', () => {
+      // Nothing may outlive the request: the agent is ours alone, so drop its
+      // socket rather than leave a keep-alive connection open to the provider.
+      agent.destroy();
       // The SUCCESS path lands here too, having already resolved via done(). Bail
       // before building an error: fail() would discard it anyway, but constructing
       // one captures a V8 stack trace on every successful upload, and it reads like


### PR DESCRIPTION
Follow-up to #554. That PR fixed the flaky *route* tests and flagged one remaining flake in `multipart.test.ts` as unrelated and still open. This is that one — and it turned out to be a real product bug, not just a bad test.

## The bug

The upload client sent **`Connection: close`** on every request (`multipart.ts`). On a streaming upload that is actively harmful.

A provider that rejects **early** — catbox's `413 Files larger than 200MB are not allowed`, a `401` on a bad token — answers while we're still pushing bytes. A server told `close` destroys the socket the moment it finishes writing that answer, **no matter how politely it drains the rest of the body**. Node's socket then takes the `EPIPE` and throws away the response bytes already sitting in its receive buffer. We lose the very status and message the provider just sent us, and fall back to the generic *"the provider closed the connection… it most likely rejected the file"*.

So the hangup that `hangupError()` exists to apologize for was one **we were largely requesting ourselves**. Users were getting a vague guess a good fraction of the time when the provider had told us exactly what was wrong.

Measured against a draining server, 8 MB body, 20 uploads each:

| client header | result |
|---|---|
| `Connection: close` | **6 write errors**, 14 × 413 |
| `Connection: keep-alive` | **0 write errors, 20 × 413** |

## The fix

Let the agent decide `Connection` (i.e. keep-alive). The agent is created **per request and destroyed when the request closes**, so we keep the real benefit the header was providing — nothing is pooled or reused between uploads, the connection still goes away as soon as we're done with it — without telling the peer to cut us off the instant it answers.

`hangupError()` **stays.** A provider can still hang up regardless (an nginx `client_max_body_size` rejection typically does), and when it does the 413 is genuinely unrecoverable. That path is now for providers that cut us off, rather than the common case.

## The flaky test

`surfaces the provider's 413 when it rejects early but keeps draining` failed **4/40 runs in isolation** — independent of suite load, and unaffected by #554. Its "polite" server drains the body and the test asserts the 413 therefore always arrives; but the client had asked it to close, so ~10% of the time the socket died first. **The test's premise was false, and it was false because of the product bug.**

The premise is now true and it holds **40/40**. It doubles as the regression guard: bring the header back and it flakes again.

## Validation

- multipart test: 4/40 failures → **0/40** in isolation
- uploader suite: 76/76
- full suite: 174 files, 2198 tests, green
- `npm run check` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)