### PR TITLE
Re-encode static images to WebP by default, with a jpeg escape hatch

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -314,14 +314,14 @@ Confirm it with two `curl`s against the same URL, where the _only_ difference is
 ```bash
 # 1. No referer → 200, and Lurker serves the image
 curl -sS -o /dev/null -D - \
-  https://lurker.example.com/uploads/local/<key>.jpg \
+  https://lurker.example.com/uploads/local/<key>.webp \
   | grep -iE '^HTTP/|^content-type:'
 #   HTTP/2 200
-#   content-type: image/jpeg
+#   content-type: image/webp
 
 # 2. Cross-domain referer → 403, and your image never gets served
 curl -sS -o /dev/null -D - -H 'Referer: https://example.org/' \
-  https://lurker.example.com/uploads/local/<key>.jpg \
+  https://lurker.example.com/uploads/local/<key>.webp \
   | grep -iE '^HTTP/|^content-type:|^vary:'
 #   HTTP/2 403
 #   content-type: text/plain; charset=UTF-8

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -314,14 +314,14 @@ Confirm it with two `curl`s against the same URL, where the _only_ difference is
 ```bash
 # 1. No referer → 200, and Lurker serves the image
 curl -sS -o /dev/null -D - \
-  https://lurker.example.com/uploads/local/<key>.webp \
+  https://lurker.example.com/uploads/local/<key>.<ext> \
   | grep -iE '^HTTP/|^content-type:'
 #   HTTP/2 200
-#   content-type: image/webp
+#   content-type: image/webp     ← or image/jpeg, depending on the upload
 
 # 2. Cross-domain referer → 403, and your image never gets served
 curl -sS -o /dev/null -D - -H 'Referer: https://example.org/' \
-  https://lurker.example.com/uploads/local/<key>.webp \
+  https://lurker.example.com/uploads/local/<key>.<ext> \
   | grep -iE '^HTTP/|^content-type:|^vary:'
 #   HTTP/2 403
 #   content-type: text/plain; charset=UTF-8

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -293,8 +293,10 @@ export const EXPORT_TABLES = Object.freeze({
     // them) have no map entry by design. Nulling the column keeps the upload in
     // the user's history, just without a link to an uploader that isn't theirs.
     fkRekeyNullable: ['uploader_config_id'],
-    // thumbnail BLOB is written to thumbnails/<id>.jpg in the zip rather than
-    // base64-inlined; the row carries a hasThumbnail boolean in data.json.
+    // thumbnail BLOB is written to thumbnails/<id>.<ext> in the zip rather than
+    // base64-inlined; the row carries a hasThumbnail boolean in data.json. The ext
+    // is sniffed from the bytes (services/thumbnailFormat.ts) — webp since #560,
+    // jpg for everything stored before it, and one archive can hold both.
     // thumbnail_url (node edition) is a plain string column carried as-is.
     blobColumns: ['thumbnail'],
     columns: [

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -47,6 +47,11 @@ const stub = {
   // full image, 'thumb' for the thumbnail) so we can prove the thumb is sent
   // as its own object flagged kind=thumb.
   lastKinds: [] as (string | undefined)[],
+  // The meta of the thumb call. The real dropper 415s when the claimed mime
+  // disagrees with the magic bytes, and the route's catch swallows that into a
+  // silent BLOB fallback — so the claim has to be asserted here or a wrong one
+  // is invisible until it's bloating the cell DB in production.
+  lastThumbMeta: null as { filename: string; mime: string } | null,
   async upload(
     _buffer: Buffer,
     meta: { filename: string; mime: string; kind?: string },
@@ -54,6 +59,7 @@ const stub = {
   ) {
     stub.capturedSecrets = config ?? null;
     stub.lastKinds.push(meta.kind);
+    if (meta.kind === 'thumb') stub.lastThumbMeta = { filename: meta.filename, mime: meta.mime };
     if (meta.kind === 'thumb') {
       if (stub.thumbShouldThrow) {
         throw Object.assign(new Error('thumb store down'), { code: 'PROVIDER_ERROR' });
@@ -94,19 +100,20 @@ vi.mock('../services/imagePipeline.js', () => ({
       height: 10,
     };
   },
-  // A non-empty buffer so the route exercises the (node-edition) remote thumb
-  // upload + BLOB-fallback paths.
-  thumbnail: async () => Buffer.from('fake-jpeg-thumb-bytes'),
-  // Not stubs: the route derives the thumb's Content-Type and filename from the
-  // bytes, so mocking these away would hide a mismatch the dropper would 415 on.
-  thumbnailMime: (blob: Buffer) =>
-    blob.length >= 12 &&
-    blob.toString('latin1', 0, 4) === 'RIFF' &&
-    blob.toString('latin1', 8, 12) === 'WEBP'
-      ? 'image/webp'
-      : 'image/jpeg',
-  extensionFor: (mime: string, fallback = 'bin') =>
-    ({ 'image/webp': 'webp', 'image/jpeg': 'jpg' })[mime] || fallback,
+  // REAL WebP bytes, not a placeholder string: the hosted dropper magic-byte
+  // verifies the mime we claim against the bytes we send and 415s a mismatch, so
+  // a thumb fixture that isn't actually a WebP would leave the one path that can
+  // 415 in production (thumbs are WebP since #560) untested. thumbnailFormat() is
+  // NOT mocked, so the route sniffs these for real. sharp is imported inside the
+  // factory rather than closed over — vi.mock is hoisted above the imports.
+  thumbnail: async () => {
+    const { default: sharpFn } = await import('sharp');
+    return sharpFn({
+      create: { width: 8, height: 8, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0 } },
+    })
+      .webp()
+      .toBuffer();
+  },
 }));
 
 let app: Express;
@@ -246,6 +253,7 @@ describe('POST /api/uploads (node edition)', () => {
   it('stores the thumbnail as a remote thumbs/ object, not an inline BLOB', async () => {
     stub.thumbShouldThrow = false;
     stub.lastKinds = [];
+    stub.lastThumbMeta = null;
     const res = await agent
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'thumbed.png', contentType: 'image/png' });
@@ -255,6 +263,10 @@ describe('POST /api/uploads (node edition)', () => {
     expect(res.body.thumbnail_url).toMatch(/^https:\/\/stub\.example\/thumbs\//);
     // The thumb went up as its own object flagged kind=thumb.
     expect(stub.lastKinds).toContain('thumb');
+    // …and it was ANNOUNCED as what it actually is. The real dropper sniffs the
+    // bytes and 415s a WebP claiming to be image/jpeg; the route swallows that
+    // into a silent inline-BLOB fallback, so nothing else would catch it.
+    expect(stub.lastThumbMeta).toEqual({ filename: 'thumb.webp', mime: 'image/webp' });
 
     const list = await agent.get('/api/uploads');
     const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
@@ -282,6 +294,9 @@ describe('POST /api/uploads (node edition)', () => {
     expect(row.thumbnail_url).toBe(`/api/uploads/${res.body.id}/thumb`);
     const thumbRes = await agent.get(`/api/uploads/${res.body.id}/thumb`);
     expect(thumbRes.status).toBe(200);
-    expect(thumbRes.headers['content-type']).toBe('image/jpeg');
+    // The fallback BLOB is served as what it is. This read image/jpeg while the
+    // fixture was a placeholder string that happened to sniff as JPEG — the stale
+    // assertion was itself the proof that this path had never seen a real WebP.
+    expect(thumbRes.headers['content-type']).toBe('image/webp');
   });
 });

--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -77,18 +77,18 @@ vi.mock('../services/uploadProviders/index.js', () => ({
 // it (the real pipeline runs in uploads.test.ts). Lets us assert those come
 // from the operator env, not the tenant's settings.
 const pipelineCapture = {
-  opts: null as { maxDim: number; quality: number; rasterOnly?: boolean } | null,
+  opts: null as { maxDim: number; quality: number; format?: string; rasterOnly?: boolean } | null,
 };
 vi.mock('../services/imagePipeline.js', () => ({
   optimize: async (
     _buf: Buffer,
-    opts: { maxDim: number; quality: number; rasterOnly?: boolean },
+    opts: { maxDim: number; quality: number; format?: string; rasterOnly?: boolean },
   ) => {
     pipelineCapture.opts = opts;
     return {
       buffer: Buffer.from('x'),
-      mime: 'image/jpeg',
-      ext: 'jpg',
+      mime: 'image/webp',
+      ext: 'webp',
       byteSize: 1,
       width: 10,
       height: 10,
@@ -97,6 +97,16 @@ vi.mock('../services/imagePipeline.js', () => ({
   // A non-empty buffer so the route exercises the (node-edition) remote thumb
   // upload + BLOB-fallback paths.
   thumbnail: async () => Buffer.from('fake-jpeg-thumb-bytes'),
+  // Not stubs: the route derives the thumb's Content-Type and filename from the
+  // bytes, so mocking these away would hide a mismatch the dropper would 415 on.
+  thumbnailMime: (blob: Buffer) =>
+    blob.length >= 12 &&
+    blob.toString('latin1', 0, 4) === 'RIFF' &&
+    blob.toString('latin1', 8, 12) === 'WEBP'
+      ? 'image/webp'
+      : 'image/jpeg',
+  extensionFor: (mime: string, fallback = 'bin') =>
+    ({ 'image/webp': 'webp', 'image/jpeg': 'jpg' })[mime] || fallback,
 }));
 
 let app: Express;
@@ -204,7 +214,33 @@ describe('POST /api/uploads (node edition)', () => {
     expect(res.status).toBe(200);
     // Operator env (512 / 40), not the tenant's 8192 / 100. rasterOnly is on in
     // node edition (raster + .txt only; SVG rejected).
-    expect(pipelineCapture.opts).toEqual({ maxDim: 512, quality: 40, rasterOnly: true });
+    //
+    // `format` is the exception that proves the rule: the other three are cost/
+    // abuse levers the operator has to own in hosted, but the output format is a
+    // compatibility preference and stays the TENANT's even here (#560).
+    expect(pipelineCapture.opts).toEqual({
+      maxDim: 512,
+      quality: 40,
+      format: 'webp',
+      rasterOnly: true,
+    });
+  });
+
+  it('honors a tenant who forces jpeg, even in node edition', async () => {
+    // Imported here, not at module scope: db/settings.js has to load against the
+    // test DB beforeAll installs (same reason beforeAll does it).
+    const { setUserSetting } = await import('../db/settings.js');
+    setUserSetting(user.id, 'uploads.image.format', 'jpeg');
+    try {
+      pipelineCapture.opts = null;
+      const res = await agent
+        .post('/api/uploads')
+        .attach('image', smallPng, { filename: 'compat.png', contentType: 'image/png' });
+      expect(res.status).toBe(200);
+      expect(pipelineCapture.opts).toMatchObject({ format: 'jpeg' });
+    } finally {
+      setUserSetting(user.id, 'uploads.image.format', 'webp');
+    }
   });
 
   it('stores the thumbnail as a remote thumbs/ object, not an inline BLOB', async () => {

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -347,7 +347,7 @@ describe('GET /api/uploads/:id/thumb', () => {
       .attach('image', smallPng, { filename: 'thumby.png', contentType: 'image/png' });
     const res = await agent.get(`/api/uploads/${upload.body.id}/thumb`);
     expect(res.status).toBe(200);
-    expect(res.headers['content-type']).toBe('image/jpeg');
+    expect(res.headers['content-type']).toBe('image/webp');
     expect(res.body.length).toBeGreaterThan(0);
   });
 
@@ -720,7 +720,7 @@ describe('media uploads (#515)', () => {
       .post('/api/uploads')
       .attach('image', smallPng, { filename: 'liar.mp4', contentType: 'video/mp4' });
     expect(res.status).toBe(200);
-    expect(res.body.mime).toBe('image/jpeg'); // ran through the pipeline regardless
+    expect(res.body.mime).toBe('image/webp'); // ran through the pipeline regardless
     expect(stub.capturedSource!.kind).toBe('buffer');
     await waitForNoTemps();
   });

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -13,6 +13,7 @@ import { bufferSource, fileSource, type UploadSource } from '../services/uploadP
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from '../services/settingsRegistry.js';
 import * as imagePipeline from '../services/imagePipeline.js';
+import { thumbnailFormat } from '../services/thumbnailFormat.js';
 import { driverIds } from '../services/uploadProviders/index.js';
 import {
   classifyUpload,
@@ -345,9 +346,7 @@ router.post(
           settings['uploads.image.format'] === 'jpeg' ? 'jpeg' : 'webp';
         const quality =
           resolved.policy.quality ?? (Number(settings['uploads.image.quality']) || 85);
-        // imagePipeline is an untyped JS module — any is unavoidable here
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let optimized: any;
+        let optimized: imagePipeline.OptimizeResult;
         try {
           optimized = await imagePipeline.optimize(req.file.path, {
             maxDim:
@@ -367,16 +366,16 @@ router.post(
           }
           throw err;
         }
-        thumb = (await imagePipeline.thumbnail(req.file.path, { format })) as Buffer | null;
+        thumb = await imagePipeline.thumbnail(req.file.path, { format });
         // The optimized image is small and bounded (resized + re-encoded), so it
         // stays a buffer — round-tripping it through another temp file would be
         // pointless I/O. The heap blowup this PR removes was the ORIGINAL bytes.
-        outSource = bufferSource(optimized.buffer as Buffer);
-        outMime = optimized.mime as string;
-        outExt = optimized.ext as string;
-        outByteSize = optimized.byteSize as number;
-        outWidth = optimized.width as number | null;
-        outHeight = optimized.height as number | null;
+        outSource = bufferSource(optimized.buffer);
+        outMime = optimized.mime;
+        outExt = optimized.ext;
+        outByteSize = optimized.byteSize;
+        outWidth = optimized.width;
+        outHeight = optimized.height;
       }
 
       const originalName = req.file.originalname || '';
@@ -413,12 +412,12 @@ router.post(
           // Describe the bytes we actually produced, not the format thumbnails
           // used to be: the dropper verifies the claimed mime against the magic
           // bytes and 415s a webp announced as image/jpeg.
-          const thumbMime = imagePipeline.thumbnailMime(thumb);
+          const thumbFmt = thumbnailFormat(thumb);
           const tRes = await resolved.driver.upload(
             bufferSource(thumb),
             {
-              filename: `thumb.${imagePipeline.extensionFor(thumbMime, 'jpg')}`,
-              mime: thumbMime,
+              filename: `thumb.${thumbFmt.ext}`,
+              mime: thumbFmt.mime,
               contentClass: 'image',
               kind: 'thumb',
             },
@@ -539,7 +538,7 @@ router.get('/:id/thumb', (req: Request, res: Response) => {
   }
   // Sniffed, not named: thumbnails stored before #560 are jpeg and those rows
   // outlive the format setting, so this route serves a mix forever.
-  res.setHeader('Content-Type', imagePipeline.thumbnailMime(row.thumbnail));
+  res.setHeader('Content-Type', thumbnailFormat(row.thumbnail).mime);
   res.setHeader('Cache-Control', 'private, max-age=31536000, immutable');
   res.send(row.thumbnail);
 });

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -338,6 +338,13 @@ router.post(
         outExt = classified.ext;
         outByteSize = bytesOnDisk;
       } else {
+        // The output format is the user's, with no policy override: unlike maxDim/
+        // quality/maxMb it isn't a cost lever the operator needs to bake, and the
+        // hosted dropper accepts both webp and jpeg (#560).
+        const format: imagePipeline.OutputFormat =
+          settings['uploads.image.format'] === 'jpeg' ? 'jpeg' : 'webp';
+        const quality =
+          resolved.policy.quality ?? (Number(settings['uploads.image.quality']) || 85);
         // imagePipeline is an untyped JS module — any is unavoidable here
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let optimized: any;
@@ -345,7 +352,8 @@ router.post(
           optimized = await imagePipeline.optimize(req.file.path, {
             maxDim:
               resolved.policy.maxDim ?? (Number(settings['uploads.image.max_dimension']) || 2048),
-            quality: resolved.policy.quality ?? (Number(settings['uploads.image.quality']) || 85),
+            quality,
+            format,
             // SVG is rejected only where the resolved uploader's policy says so
             // (the hosted locked uploader serves raster + .txt). Self-host keeps
             // the SVG passthrough. Was: rasterOnly = isNodeMode().
@@ -359,7 +367,7 @@ router.post(
           }
           throw err;
         }
-        thumb = (await imagePipeline.thumbnail(req.file.path)) as Buffer | null;
+        thumb = (await imagePipeline.thumbnail(req.file.path, { format })) as Buffer | null;
         // The optimized image is small and bounded (resized + re-encoded), so it
         // stays a buffer — round-tripping it through another temp file would be
         // pointless I/O. The heap blowup this PR removes was the ORIGINAL bytes.
@@ -402,9 +410,18 @@ router.post(
       let thumbnailUrl: string | null = null;
       if (resolved.policy.hostsThumbnails && thumb) {
         try {
+          // Describe the bytes we actually produced, not the format thumbnails
+          // used to be: the dropper verifies the claimed mime against the magic
+          // bytes and 415s a webp announced as image/jpeg.
+          const thumbMime = imagePipeline.thumbnailMime(thumb);
           const tRes = await resolved.driver.upload(
             bufferSource(thumb),
-            { filename: 'thumb.jpg', mime: 'image/jpeg', contentClass: 'image', kind: 'thumb' },
+            {
+              filename: `thumb.${imagePipeline.extensionFor(thumbMime, 'jpg')}`,
+              mime: thumbMime,
+              contentClass: 'image',
+              kind: 'thumb',
+            },
             resolved.driverConfig,
           );
           if (tRes && typeof tRes.url === 'string') {
@@ -520,7 +537,9 @@ router.get('/:id/thumb', (req: Request, res: Response) => {
     res.status(404).json({ error: 'not found' });
     return;
   }
-  res.setHeader('Content-Type', 'image/jpeg');
+  // Sniffed, not named: thumbnails stored before #560 are jpeg and those rows
+  // outlive the format setting, so this route serves a mix forever.
+  res.setHeader('Content-Type', imagePipeline.thumbnailMime(row.thumbnail));
   res.setHeader('Cache-Control', 'private, max-age=31536000, immutable');
   res.send(row.thumbnail);
 });

--- a/server/services/exportService.test.ts
+++ b/server/services/exportService.test.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { PassThrough } from 'stream';
+import sharp from 'sharp';
 import yauzl from 'yauzl';
 import type { User } from '../db/users.js';
 import type { Network } from '../db/networks.js';
@@ -232,6 +233,31 @@ describe('buildExportZip', () => {
     expect(upload.hasThumbnail).toBe(true);
     expect(entries.has(`thumbnails/${upload.id}.jpg`)).toBe(true);
     expect(entries.get(`thumbnails/${upload.id}.jpg`)!.length).toBeGreaterThan(0);
+  });
+
+  // Thumbnails are WebP since #560, but rows predating it are JPEG and both can
+  // sit in one account — so the entry name is sniffed per blob, not assumed.
+  it('names a WebP thumbnail .webp while a legacy JPEG one stays .jpg', async () => {
+    const webpThumb = await sharp({
+      create: { width: 8, height: 8, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0 } },
+    })
+      .webp()
+      .toBuffer();
+    const webpUpload = insertUpload(alice.id, {
+      provider: 'hoarder',
+      url: 'https://example.com/new.webp',
+      filename: 'new.webp',
+      mime: 'image/webp',
+      byte_size: 99,
+      width: 8,
+      height: 8,
+      thumbnail: webpThumb,
+    });
+
+    const entries = await readZipToMap(await runExport(alice.id, { includeMessages: false }));
+    expect(entries.has(`thumbnails/${webpUpload}.webp`)).toBe(true);
+    // The JPEG row seeded in beforeAll is untouched by the new default.
+    expect([...entries.keys()].some((k) => k.endsWith('.jpg'))).toBe(true);
   });
 
   it('scopes data per-user (bob does not see alice)', async () => {

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -22,6 +22,7 @@ import { Readable } from 'stream';
 import type { Database } from 'better-sqlite3';
 import { ZipArchive } from 'archiver';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION } from '../db/exportSchema.js';
+import { extensionFor, thumbnailMime } from './imagePipeline.js';
 import { decryptSecret } from '../utils/secretCrypto.js';
 
 interface ExportTableDefWithScope {
@@ -249,11 +250,16 @@ export async function buildExportZip(
     data[table] = rows.map((row) => projectRow(row, d));
     counts[table] = rows.length;
 
-    // Thumbnails — emit each blob as a separate zip entry.
+    // Thumbnails — emit each blob as a separate zip entry. The extension is
+    // sniffed from the bytes, not assumed: thumbnails are WebP since #560 but a
+    // long-lived account still has JPEG ones from before, so a single archive can
+    // legitimately hold both.
     if (d.blobColumns?.includes('thumbnail')) {
       for (const row of rows) {
         if (row.thumbnail != null) {
-          archive.append(row.thumbnail as Buffer, { name: `thumbnails/${row.id as number}.jpg` });
+          const blob = row.thumbnail as Buffer;
+          const ext = extensionFor(thumbnailMime(blob), 'jpg');
+          archive.append(blob, { name: `thumbnails/${row.id as number}.${ext}` });
         }
       }
     }

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -22,7 +22,7 @@ import { Readable } from 'stream';
 import type { Database } from 'better-sqlite3';
 import { ZipArchive } from 'archiver';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION } from '../db/exportSchema.js';
-import { extensionFor, thumbnailMime } from './imagePipeline.js';
+import { thumbnailFormat } from './thumbnailFormat.js';
 import { decryptSecret } from '../utils/secretCrypto.js';
 
 interface ExportTableDefWithScope {
@@ -258,7 +258,7 @@ export async function buildExportZip(
       for (const row of rows) {
         if (row.thumbnail != null) {
           const blob = row.thumbnail as Buffer;
-          const ext = extensionFor(thumbnailMime(blob), 'jpg');
+          const { ext } = thumbnailFormat(blob);
           archive.append(blob, { name: `thumbnails/${row.id as number}.${ext}` });
         }
       }

--- a/server/services/imagePipeline.test.ts
+++ b/server/services/imagePipeline.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect } from 'vitest';
 import sharp from 'sharp';
-import { optimize, thumbnail, thumbnailMime } from './imagePipeline.js';
+import { optimize, thumbnail } from './imagePipeline.js';
 
 // All fixtures are synthesised on the fly so the test stays self-contained
 // and doesn't need committed binary blobs.
@@ -83,6 +83,30 @@ describe('imagePipeline.optimize', () => {
     // The corner was transparent going in; it must still be transparent, not black.
     const px = await sharp(out.buffer).ensureAlpha().raw().toBuffer();
     expect(px[3]).toBe(0);
+  });
+
+  // The reason optimize() re-encodes static images at all (#516): the re-encode is
+  // what drops EXIF, and a phone photo's EXIF carries GPS. That guarantee is a
+  // property of the ENCODER, and #560 swapped it — so assert it for both, or the
+  // next format change (AVIF) can silently reopen the leak with a green suite.
+  it.each(['webp', 'jpeg'] as const)('strips EXIF/GPS when re-encoding to %s', async (format) => {
+    const withExif = await sharp({
+      create: { width: 800, height: 600, channels: 3, background: { r: 10, g: 120, b: 200 } },
+    })
+      .withExif({
+        IFD0: { Make: 'SECRET-CAMERA', Model: 'SECRET-MODEL' },
+        IFD3: { GPSLatitude: '40/1 44/1 5595/100', GPSLongitude: '73/1 59/1 5100/100' },
+      })
+      .jpeg()
+      .toBuffer();
+    // The fixture really does carry it, or the assertions below prove nothing.
+    expect((await sharp(withExif).metadata()).exif).toBeTruthy();
+
+    const out = await optimize(withExif, { maxDim: 2048, quality: 85, format });
+    expect((await sharp(out.buffer).metadata()).exif).toBeFalsy();
+    const raw = out.buffer.toString('latin1');
+    expect(raw).not.toContain('SECRET-CAMERA');
+    expect(raw).not.toContain('SECRET-MODEL');
   });
 
   it('flattens alpha when the user opts into the jpeg escape hatch', async () => {
@@ -219,20 +243,6 @@ describe('imagePipeline.thumbnail', () => {
   });
 });
 
-describe('imagePipeline.thumbnailMime', () => {
-  // The serving route has to keep telling the truth about thumbnails stored
-  // BEFORE #560, which are jpeg and will outlive the setting change.
-  it('recognizes a WebP thumbnail', async () => {
-    expect(thumbnailMime(await thumbnail(await staticPng(400, 200)))).toBe('image/webp');
-  });
-
-  it('still reports a legacy JPEG thumbnail as image/jpeg', async () => {
-    const legacy = await thumbnail(await staticPng(400, 200), { format: 'jpeg' });
-    expect(thumbnailMime(legacy)).toBe('image/jpeg');
-  });
-
-  it("doesn't read past the end of a short buffer", () => {
-    expect(thumbnailMime(Buffer.from('RIFF'))).toBe('image/jpeg');
-    expect(thumbnailMime(Buffer.alloc(0))).toBe('image/jpeg');
-  });
-});
+// thumbnailFormat() has its own suite (thumbnailFormat.test.ts). Its fixtures come
+// from thumbnail() here, so the two stay honest about each other: the sniff is
+// tested against bytes this pipeline really produces, not a hand-rolled header.

--- a/server/services/imagePipeline.test.ts
+++ b/server/services/imagePipeline.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect } from 'vitest';
 import sharp from 'sharp';
-import { optimize, thumbnail } from './imagePipeline.js';
+import { optimize, thumbnail, thumbnailMime } from './imagePipeline.js';
 
 // All fixtures are synthesised on the fly so the test stays self-contained
 // and doesn't need committed binary blobs.
@@ -16,6 +16,28 @@ async function staticPng(
   return sharp({
     create: { width, height, channels: 3, background: color },
   })
+    .png()
+    .toBuffer();
+}
+
+// A PNG with a real alpha channel: opaque red square centred on a fully
+// transparent field — a logo/sticker/screenshot-with-rounded-corners in
+// miniature. The transparent border is what JPEG destroys.
+async function transparentPng(size = 64): Promise<Buffer> {
+  const square = await sharp({
+    create: {
+      width: size / 2,
+      height: size / 2,
+      channels: 4,
+      background: { r: 255, g: 0, b: 0, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+  return sharp({
+    create: { width: size, height: size, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0 } },
+  })
+    .composite([{ input: square, left: size / 4, top: size / 4 }])
     .png()
     .toBuffer();
 }
@@ -33,18 +55,46 @@ function animatedGif(): Buffer {
 }
 
 describe('imagePipeline.optimize', () => {
-  it('resizes and re-encodes a static PNG to JPEG with the longest edge clamped', async () => {
+  it('resizes and re-encodes a static PNG to WebP with the longest edge clamped', async () => {
     const buf = await staticPng(4000, 2000);
     const out = await optimize(buf, { maxDim: 1024, quality: 80 });
-    expect(out.mime).toBe('image/jpeg');
-    expect(out.ext).toBe('jpg');
+    expect(out.mime).toBe('image/webp');
+    expect(out.ext).toBe('webp');
     expect(out.animated).toBe(false);
     expect(Math.max(out.width ?? 0, out.height ?? 0)).toBeLessThanOrEqual(1024);
     expect(out.byteSize).toBe(out.buffer.length);
-    // Re-encoded JPEG is smaller than the original raw PNG
+    // Re-encoded is smaller than the original raw PNG
     expect(out.byteSize).toBeLessThan(buf.length);
     const meta = await sharp(out.buffer).metadata();
+    expect(meta.format).toBe('webp');
+  });
+
+  // The bug #560 exists to fix. JPEG has no alpha channel, so the old
+  // unconditional .jpeg() composited every transparent pixel onto BLACK (verified
+  // against sharp — not white, black) and shipped that as the file the channel saw.
+  it('preserves the alpha channel of a transparent PNG', async () => {
+    const buf = await transparentPng(64);
+    const out = await optimize(buf, { maxDim: 1024, quality: 80 });
+
+    const meta = await sharp(out.buffer).metadata();
+    expect(meta.format).toBe('webp');
+    expect(meta.hasAlpha).toBe(true);
+
+    // The corner was transparent going in; it must still be transparent, not black.
+    const px = await sharp(out.buffer).ensureAlpha().raw().toBuffer();
+    expect(px[3]).toBe(0);
+  });
+
+  it('flattens alpha when the user opts into the jpeg escape hatch', async () => {
+    const buf = await transparentPng(64);
+    const out = await optimize(buf, { maxDim: 1024, quality: 80, format: 'jpeg' });
+    expect(out.mime).toBe('image/jpeg');
+    expect(out.ext).toBe('jpg');
+    const meta = await sharp(out.buffer).metadata();
     expect(meta.format).toBe('jpeg');
+    // Documenting the cost of the escape hatch, not endorsing it: JPEG cannot
+    // carry alpha, so choosing it is choosing this.
+    expect(meta.hasAlpha).toBe(false);
   });
 
   it("doesn't upscale smaller-than-maxDim images", async () => {
@@ -135,21 +185,54 @@ describe('imagePipeline.optimize', () => {
 });
 
 describe('imagePipeline.thumbnail', () => {
-  it('returns a 128x128 JPEG for static input', async () => {
+  it('returns a 128x128 WebP for static input', async () => {
     const buf = await staticPng(400, 200);
     const thumb = await thumbnail(buf);
     const meta = await sharp(thumb).metadata();
-    expect(meta.format).toBe('jpeg');
+    expect(meta.format).toBe('webp');
     expect(meta.width).toBe(128);
     expect(meta.height).toBe(128);
   });
 
-  it('returns a 128x128 JPEG for animated input (first frame)', async () => {
+  it('returns a 128x128 WebP for animated input (first frame)', async () => {
     const buf = animatedGif();
     const thumb = await thumbnail(buf);
     const meta = await sharp(thumb).metadata();
-    expect(meta.format).toBe('jpeg');
+    expect(meta.format).toBe('webp');
     expect(meta.width).toBe(128);
     expect(meta.height).toBe(128);
+  });
+
+  it('keeps alpha, so a transparent image thumbnails without a black backing', async () => {
+    const thumb = await thumbnail(await transparentPng(64));
+    const meta = await sharp(thumb).metadata();
+    expect(meta.hasAlpha).toBe(true);
+    const px = await sharp(thumb).ensureAlpha().raw().toBuffer();
+    expect(px[3]).toBe(0);
+  });
+
+  it('follows the jpeg escape hatch', async () => {
+    const thumb = await thumbnail(await staticPng(400, 200), { format: 'jpeg' });
+    const meta = await sharp(thumb).metadata();
+    expect(meta.format).toBe('jpeg');
+    expect(meta.width).toBe(128);
+  });
+});
+
+describe('imagePipeline.thumbnailMime', () => {
+  // The serving route has to keep telling the truth about thumbnails stored
+  // BEFORE #560, which are jpeg and will outlive the setting change.
+  it('recognizes a WebP thumbnail', async () => {
+    expect(thumbnailMime(await thumbnail(await staticPng(400, 200)))).toBe('image/webp');
+  });
+
+  it('still reports a legacy JPEG thumbnail as image/jpeg', async () => {
+    const legacy = await thumbnail(await staticPng(400, 200), { format: 'jpeg' });
+    expect(thumbnailMime(legacy)).toBe('image/jpeg');
+  });
+
+  it("doesn't read past the end of a short buffer", () => {
+    expect(thumbnailMime(Buffer.from('RIFF'))).toBe('image/jpeg');
+    expect(thumbnailMime(Buffer.alloc(0))).toBe('image/jpeg');
   });
 });

--- a/server/services/imagePipeline.ts
+++ b/server/services/imagePipeline.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import fs from 'node:fs';
-import sharp, { type Metadata } from 'sharp';
+import sharp, { type Metadata, type Sharp } from 'sharp';
 import { canScrubInPlace, scrubMetadata } from './metadataScrub.js';
 
 const THUMB_SIZE = 128;
@@ -26,6 +26,11 @@ const FORMAT_INFO: Record<string, FormatInfo> = {
   svg: { mime: 'image/svg+xml', ext: 'svg' },
 };
 
+// The formats the static path will ENCODE to (a subset of the formats it can
+// read). webp is the default; jpeg is the escape hatch for an ancient client or
+// an upload host that mangles webp (`uploads.image.format`, #560).
+export type OutputFormat = 'webp' | 'jpeg';
+
 export interface OptimizeResult {
   buffer: Buffer;
   mime: string;
@@ -41,7 +46,15 @@ export function extensionFor(mime: string, fallback = 'bin'): string {
   return entry?.ext || fallback;
 }
 
-// Optimize a static image (resize longest edge to maxDim, re-encode JPEG).
+// `quality` is a single 0–100 perceptual scale handed to whichever encoder the
+// format selects. The two scales are NOT identical — libwebp's 85 is not
+// mozjpeg's 85 — but both mean "higher = better and bigger", which is what the
+// setting promises, and one slider beats two knobs nobody touches.
+function encode(pipeline: Sharp, format: OutputFormat, quality: number): Sharp {
+  return format === 'jpeg' ? pipeline.jpeg({ quality, mozjpeg: true }) : pipeline.webp({ quality });
+}
+
+// Optimize a static image (resize longest edge to maxDim, re-encode to `format`).
 // Animated images (sharp.metadata.pages > 1) bypass the resize/re-encode and
 // are returned verbatim, which is a hard requirement so reaction GIFs / animated
 // WebP / APNG don't lose animation on the way through Lurker.
@@ -54,8 +67,9 @@ export async function optimize(
   {
     maxDim,
     quality,
+    format = 'webp',
     rasterOnly = false,
-  }: { maxDim: number; quality: number; rasterOnly?: boolean },
+  }: { maxDim: number; quality: number; format?: OutputFormat; rasterOnly?: boolean },
 ): Promise<OptimizeResult> {
   // Only the passthrough/scrub branches need the bytes in memory; the resize path
   // hands the path straight to sharp. Read lazily so an ordinary image upload
@@ -120,7 +134,7 @@ export async function optimize(
       };
     } catch {
       // Codec can't re-encode animated — fall through to the static path, which
-      // flattens to a metadata-free JPEG first frame. Degraded but never leaks.
+      // flattens to a metadata-free first frame. Degraded but never leaks.
     }
   }
 
@@ -149,21 +163,25 @@ export async function optimize(
     };
   }
 
-  const out = await sharp(input)
-    .rotate()
-    .resize({
+  // ⚠ The output format, mime and ext MUST agree — they used to be three
+  // hardcoded jpeg constants that could drift. Pick the format once and derive
+  // the other two from FORMAT_INFO.
+  const outFmt = FORMAT_INFO[format];
+  const out = await encode(
+    sharp(input).rotate().resize({
       width: maxDim,
       height: maxDim,
       fit: 'inside',
       withoutEnlargement: true,
-    })
-    .jpeg({ quality, mozjpeg: true })
-    .toBuffer({ resolveWithObject: true });
+    }),
+    format,
+    quality,
+  ).toBuffer({ resolveWithObject: true });
 
   return {
     buffer: out.data,
-    mime: 'image/jpeg',
-    ext: 'jpg',
+    mime: outFmt.mime,
+    ext: outFmt.ext,
     width: out.info.width,
     height: out.info.height,
     byteSize: out.data.length,
@@ -171,11 +189,33 @@ export async function optimize(
   };
 }
 
-export async function thumbnail(input: Buffer | string): Promise<Buffer> {
-  // Force first frame for animated inputs; cover-crop to a square JPEG.
-  return sharp(input, { animated: false })
-    .rotate()
-    .resize(THUMB_SIZE, THUMB_SIZE, { fit: 'cover', position: 'centre' })
-    .jpeg({ quality: 80 })
-    .toBuffer();
+export async function thumbnail(
+  input: Buffer | string,
+  { format = 'webp', quality = 80 }: { format?: OutputFormat; quality?: number } = {},
+): Promise<Buffer> {
+  // Force first frame for animated inputs; cover-crop to a square. Follows the
+  // same format as the full image: a jpeg thumbnail of a transparent PNG is
+  // black-backgrounded, which is the most visible face of the alpha bug.
+  return encode(
+    sharp(input, { animated: false })
+      .rotate()
+      .resize(THUMB_SIZE, THUMB_SIZE, { fit: 'cover', position: 'centre' }),
+    format,
+    quality,
+  ).toBuffer();
+}
+
+/**
+ * Content-Type for a stored thumbnail BLOB, sniffed from its magic bytes.
+ *
+ * The thumb-serving route can't just name the CURRENT format: every thumbnail
+ * stored before #560 is a jpeg, and those rows outlive the setting change. WebP
+ * is a RIFF container — `RIFF....WEBP` — which is enough to tell the two apart.
+ */
+export function thumbnailMime(blob: Buffer): string {
+  const isWebp =
+    blob.length >= 12 &&
+    blob.toString('latin1', 0, 4) === 'RIFF' &&
+    blob.toString('latin1', 8, 12) === 'WEBP';
+  return isWebp ? 'image/webp' : 'image/jpeg';
 }

--- a/server/services/imagePipeline.ts
+++ b/server/services/imagePipeline.ts
@@ -204,18 +204,3 @@ export async function thumbnail(
     quality,
   ).toBuffer();
 }
-
-/**
- * Content-Type for a stored thumbnail BLOB, sniffed from its magic bytes.
- *
- * The thumb-serving route can't just name the CURRENT format: every thumbnail
- * stored before #560 is a jpeg, and those rows outlive the setting change. WebP
- * is a RIFF container — `RIFF....WEBP` — which is enough to tell the two apart.
- */
-export function thumbnailMime(blob: Buffer): string {
-  const isWebp =
-    blob.length >= 12 &&
-    blob.toString('latin1', 0, 4) === 'RIFF' &&
-    blob.toString('latin1', 8, 12) === 'WEBP';
-  return isWebp ? 'image/webp' : 'image/jpeg';
-}

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { PassThrough } from 'stream';
+import sharp from 'sharp';
 import type { User } from '../db/users.js';
 import type { Network } from '../db/networks.js';
 
@@ -231,6 +232,42 @@ describe('importFromZipBuffer — roundtrip', () => {
     // that would fail the NOT NULL constraint (the old-archive import hazard).
     expect(bobUploads[0].synced_to_cp).toBe(0);
     expect(bobUploads[0].removed).toBe(0);
+  });
+
+  // The export names thumbnail entries from the blob's magic bytes and the import
+  // matches them by extension — two places that have to agree. Since #560 the
+  // bytes are WebP, so a jpg-only regex on either side silently drops thumbnails
+  // on restore. Round-trip a real WebP thumb to keep them honest.
+  it('round-trips a WebP thumbnail, not just a legacy JPEG one', async () => {
+    const { alice } = seedAlice();
+    const webpThumb = await sharp({
+      create: { width: 8, height: 8, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 0 } },
+    })
+      .webp()
+      .toBuffer();
+    insertUpload(alice.id, {
+      provider: 'hoarder',
+      url: 'https://example.com/new.webp',
+      filename: 'new.webp',
+      mime: 'image/webp',
+      byte_size: 99,
+      width: 8,
+      height: 8,
+      thumbnail: webpThumb,
+    });
+
+    const bob = createUser(`bob_webp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+    const result = await importFromZipBuffer(
+      bob.id,
+      await exportToBuffer(alice.id, { includeMessages: false }),
+    );
+
+    // Both thumbnails came back: the seeded JPEG and the WebP one.
+    expect(result.thumbnailsAttached).toBe(2);
+    const restored = db
+      .prepare('SELECT thumbnail FROM upload_history WHERE user_id = ? AND mime = ?')
+      .get(bob.id, 'image/webp') as { thumbnail: Buffer };
+    expect(Buffer.compare(Buffer.from(restored.thumbnail), webpThumb)).toBe(0);
   });
 
   it('refuses to import into a non-empty account', async () => {

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -426,11 +426,14 @@ export async function importFromZipFile(
         )
       : null;
 
-    // ---- thumbnails (small JPEGs) — read up front so phase C can apply them
-    // inside a synchronous transaction. ----
+    // ---- thumbnails — read up front so phase C can apply them inside a
+    // synchronous transaction. Accepts .webp (since #560) and .jpg (everything
+    // exported before it, which must keep importing). The extension only locates
+    // the entry; the bytes go into the BLOB as-is and the serving route sniffs
+    // their type, so a mismatch here can't corrupt anything. ----
     const thumbs = new Map<number, Buffer>();
     for (const [name, entry] of entries) {
-      const m = name.match(/^thumbnails\/(\d+)\.jpg$/);
+      const m = name.match(/^thumbnails\/(\d+)\.(?:jpg|webp)$/);
       if (m) thumbs.set(parseInt(m[1], 10), await readEntryBuffer(zip, entry));
     }
 

--- a/server/services/thumbnailFormat.test.ts
+++ b/server/services/thumbnailFormat.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import sharp from 'sharp';
+import { thumbnail } from './imagePipeline.js';
+import { thumbnailFormat } from './thumbnailFormat.js';
+
+// Fixtures come from thumbnail() rather than hand-rolled headers: the sniff exists
+// to read the bytes the pipeline ACTUALLY writes, so testing it against a
+// hand-made RIFF header would only prove the header matches itself.
+async function square(): Promise<Buffer> {
+  return sharp({
+    create: { width: 400, height: 200, channels: 3, background: { r: 255, g: 128, b: 64 } },
+  })
+    .png()
+    .toBuffer();
+}
+
+describe('thumbnailFormat', () => {
+  it('recognizes a WebP thumbnail (the default since #560)', async () => {
+    expect(thumbnailFormat(await thumbnail(await square()))).toEqual({
+      mime: 'image/webp',
+      ext: 'webp',
+    });
+  });
+
+  // The rows that make the sniff necessary: every thumbnail stored before #560 is
+  // a JPEG, and they outlive the setting change.
+  it('still reports a legacy JPEG thumbnail as image/jpeg', async () => {
+    const legacy = await thumbnail(await square(), { format: 'jpeg' });
+    expect(thumbnailFormat(legacy)).toEqual({ mime: 'image/jpeg', ext: 'jpg' });
+  });
+
+  it("doesn't read past the end of a short or empty buffer", () => {
+    // 'RIFF' alone is a prefix of the WebP magic but not the whole of it — the
+    // length guard is what stops a truncated BLOB from reading as WebP.
+    expect(thumbnailFormat(Buffer.from('RIFF')).mime).toBe('image/jpeg');
+    expect(thumbnailFormat(Buffer.alloc(0)).mime).toBe('image/jpeg');
+  });
+
+  // RIFF is a container family, not WebP specifically (a .wav is RIFF too), so the
+  // second half of the magic is load-bearing.
+  it('does not mistake another RIFF container for WebP', () => {
+    const wavish = Buffer.concat([
+      Buffer.from('RIFF', 'latin1'),
+      Buffer.alloc(4),
+      Buffer.from('WAVE', 'latin1'),
+    ]);
+    expect(thumbnailFormat(wavish).mime).toBe('image/jpeg');
+  });
+});

--- a/server/services/thumbnailFormat.ts
+++ b/server/services/thumbnailFormat.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Which format a STORED thumbnail BLOB is in, read from its magic bytes.
+//
+// Thumbnails are WebP since #560, but every one written before it is a JPEG and
+// those rows outlive the setting change — so a single account holds both, and the
+// current default is never a safe thing to name. Every place that has to DECLARE a
+// thumbnail's type sniffs it instead: the serving route's Content-Type, the mime
+// claimed to the dropper (which verifies the claim against the bytes and 415s a
+// mismatch), and the `.lurk` export entry name.
+//
+// Deliberately sharp-free. It's a 12-byte check, and the export path — a DB/zip
+// module with no other reason to know what an image is — needs it without dragging
+// the native image pipeline into its module graph.
+
+export interface ThumbnailFormat {
+  mime: string;
+  ext: string;
+}
+
+const WEBP: ThumbnailFormat = { mime: 'image/webp', ext: 'webp' };
+const JPEG: ThumbnailFormat = { mime: 'image/jpeg', ext: 'jpg' };
+
+// WebP is a RIFF container — `RIFF` <4-byte length> `WEBP`. A JPEG never is, so
+// the two thumbnail formats we can hold are distinguishable on 12 bytes. Anything
+// else (a truncated or empty BLOB) reads as JPEG, which is what the pre-#560 rows
+// are and the only thing an unrecognizable legacy blob could be.
+export function thumbnailFormat(blob: Buffer): ThumbnailFormat {
+  const isWebp =
+    blob.length >= 12 &&
+    blob.toString('latin1', 0, 4) === 'RIFF' &&
+    blob.toString('latin1', 8, 12) === 'WEBP';
+  return isWebp ? WEBP : JPEG;
+}

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1006,6 +1006,25 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   // db/uploaderConfigSeed.ts#reconcileLegacyUploadSettings. What remains here is
   // the part that genuinely is a per-user preference: the processing pipeline.
   {
+    key: 'uploads.image.format',
+    label: 'Static image format',
+    category: 'uploads',
+    group: 'pipeline',
+    type: 'enum',
+    choices: ['webp', 'jpeg'],
+    default: 'webp',
+    // Deliberately NOT selfHostedOnly, unlike every other key in this group.
+    // Those are cost/abuse levers the operator owns in hosted edition; this is a
+    // compatibility preference the user owns, and the hosted dropper accepts
+    // both formats, so there is nothing for the operator to protect.
+    description:
+      'Format static images are re-encoded to. "webp" (default) is smaller and — ' +
+      'unlike JPEG — has an alpha channel, so transparent PNGs survive the ' +
+      're-encode instead of being flattened onto black. "jpeg" is the escape ' +
+      'hatch for a client or upload host that mangles WebP. Animated GIF/WebP/' +
+      'APNG bypass this entirely and are uploaded verbatim.',
+  },
+  {
     key: 'uploads.image.max_dimension',
     label: 'Max image dimension (longest edge)',
     category: 'uploads',
@@ -1018,12 +1037,12 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     // server-side in A8), not a tenant knob.
     selfHostedOnly: true,
     description:
-      'Longest-edge limit for static images before they are re-encoded as JPEG. ' +
+      'Longest-edge limit for static images before they are re-encoded. ' +
       'Animated GIF/WebP/APNG bypass this and are uploaded verbatim.',
   },
   {
     key: 'uploads.image.quality',
-    label: 'JPEG re-encode quality',
+    label: 'Image re-encode quality',
     category: 'uploads',
     group: 'pipeline',
     type: 'int',
@@ -1031,7 +1050,11 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     max: 100,
     default: 85,
     selfHostedOnly: true,
-    description: 'JPEG quality for the re-encode pass on static images (30–100).',
+    description:
+      'Quality (30–100) for the re-encode pass on static images, handed to ' +
+      'whichever encoder uploads.image.format selects. Higher is better-looking ' +
+      'and bigger in both, but the scales are not identical — WebP at 85 is not ' +
+      'the same picture as JPEG at 85.',
   },
   {
     key: 'uploads.image.max_upload_mb',


### PR DESCRIPTION
Closes #560.

## The bug this actually fixes

The static image path ended in an unconditional `.jpeg({ quality, mozjpeg: true })`. **JPEG has no alpha channel**, so every transparent PNG that anyone uploads — a screenshot with rounded corners, a logo, a sticker — was silently composited onto a background and shipped as the file the channel sees.

Confirmed against sharp rather than assumed, since the issue asked what it composites onto: **black**, not white.

```
source: png channels 4 hasAlpha true
jpeg out: channels 3 hasAlpha false   corner pixel (was transparent) -> 0 0 0
webp out: channels 4 hasAlpha true    corner pixel alpha -> 0
```

WebP has alpha, so the transparency survives. `optimize()` and `thumbnail()` both grow an alpha-preservation test.

## And it's smaller

Measured through the real pipeline at quality 85, on real content:

| input | webp | mozjpeg | |
|---|---|---|---|
| photograph | 6 KB | 12 KB | **54% smaller** |
| flat-UI screenshot | 7 KB | 19 KB | **64% smaller** |

(A synthetic-noise fixture shows WebP *losing* by 31%. Noise is pathological for it and isn't what anyone uploads — noting it so nobody re-derives it and panics.)

## The three decisions the issue left open

1. **Enum, not a bool.** `uploads.image.format` ∈ {`webp`, `jpeg`}, default `webp`. Extends to AVIF later, and lowercase raw values match every other enum in the registry.
2. **Not `selfHostedOnly`** — deliberately unlike the three keys next to it. `max_dimension` / `quality` / `max_upload_mb` are cost/abuse levers the operator has to own in hosted edition; an output format is a *compatibility preference* the user owns. The hosted dropper already accepts and magic-byte-sniffs `image/webp`, so there is nothing for the operator to protect. A node-edition test asserts a tenant who forces `jpeg` gets it.
3. **One `quality` key, honest copy.** Both encoders take a 0–100 scale where higher means better and bigger, so one slider can drive both — but the copy no longer says "JPEG" and now states outright that WebP at 85 is not the same picture as JPEG at 85. A second `quality_webp` would double the surface on a knob nobody touches.

Also: format/mime/ext were three hardcoded constants that had to agree. Now the format is picked once and the other two are derived from `FORMAT_INFO`.

## Thumbnails, and the legacy rows

Thumbnails switch too — the alpha argument applies, and a black-backed thumbnail is the most *visible* face of the bug.

But thumbnails stored before this are JPEG and those rows outlive the setting change, so anywhere their type is declared, the bytes are now **sniffed rather than named**:

- the `/api/uploads/:id/thumb` `Content-Type`,
- the mime handed to the dropper — which verifies the claim against the magic bytes and would `415` a WebP announced as `image/jpeg`,
- the `.lurk` export entry name, which was hardcoded `.jpg`.

The importer matches `thumbnails/<id>.{jpg,webp}` so old archives keep restoring, and a round-trip test covers a real WebP thumb so the export's naming and the import's regex can't drift apart.

## Not touched (confirmed)

Animated GIF/WebP/APNG never reach this path — still scrubbed in-container and passed through verbatim. SVG is still a passthrough (rejected in node edition). Media never enters the image pipeline. No control-plane change is needed. The client's `isImageUrl` already lists `.webp`.

## Verification

`npm run check` clean, `npm test` green (2288 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)