### PR TITLE
Tell the truth about upload progress (#545)

### DIFF
--- a/server/routes/uploads.node.test.ts
+++ b/server/routes/uploads.node.test.ts
@@ -52,13 +52,23 @@ const stub = {
   // silent BLOB fallback — so the claim has to be asserted here or a wrong one
   // is invisible until it's bloating the cell DB in production.
   lastThumbMeta: null as { filename: string; mime: string } | null,
+  // Whether each upload call in a request was handed a progress callback (#545). The
+  // thumbnail is its own driver.upload; if it inherited the callback, a 128px thumb
+  // would yank the bar back to 0 and re-fill it right after the real file landed.
+  lastHadProgress: [] as boolean[],
   async upload(
     _buffer: Buffer,
-    meta: { filename: string; mime: string; kind?: string },
+    meta: {
+      filename: string;
+      mime: string;
+      kind?: string;
+      onProgress?: (s: number, t: number) => void;
+    },
     config?: Record<string, string>,
   ) {
     stub.capturedSecrets = config ?? null;
     stub.lastKinds.push(meta.kind);
+    stub.lastHadProgress.push(typeof meta.onProgress === 'function');
     if (meta.kind === 'thumb') stub.lastThumbMeta = { filename: meta.filename, mime: meta.mime };
     if (meta.kind === 'thumb') {
       if (stub.thumbShouldThrow) {
@@ -248,6 +258,25 @@ describe('POST /api/uploads (node edition)', () => {
     } finally {
       setUserSetting(user.id, 'uploads.image.format', 'webp');
     }
+  });
+
+  // Node edition is the only place this can be tested: hostsThumbnails sends the thumb
+  // through the driver as a SECOND upload, where standalone keeps it as an inline BLOB
+  // and never calls the driver twice at all.
+  it('gives the progress callback to the file, never to the thumbnail (#545)', async () => {
+    stub.thumbShouldThrow = false;
+    stub.lastKinds = [];
+    stub.lastHadProgress = [];
+    const res = await agent
+      .post('/api/uploads')
+      .field('progressToken', 'tok-node')
+      .attach('image', smallPng, { filename: 'prog.png', contentType: 'image/png' });
+    expect(res.status).toBe(200);
+
+    // Two uploads went out: the image, then its thumb.
+    expect(stub.lastKinds).toEqual([undefined, 'thumb']);
+    // Only the first was allowed to move the bar.
+    expect(stub.lastHadProgress).toEqual([true, false]);
   });
 
   it('stores the thumbnail as a remote thumbs/ object, not an inline BLOB', async () => {

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -49,9 +49,14 @@ const stub = {
   // leaves the building is scrubbed, since the temp file is unlinked afterwards.
   capturedBytes: null as Buffer | null,
   capturedMeta: null as { filename: string; mime: string } | null,
+  // Set to simulate a driver that streams its body, so the route's progress wiring
+  // (#545) can be driven end to end: the real byte counting lives in multipart.ts and
+  // is tested against a real socket there, but ONLY a driver call proves the route
+  // actually handed its callback down.
+  emitBytes: null as { total: number } | null,
   async upload(
     source: UploadSource,
-    meta: { filename: string; mime: string },
+    meta: { filename: string; mime: string; onProgress?: (s: number, t: number) => void },
     config?: Record<string, string>,
   ) {
     stub.capturedConfig = config ?? null;
@@ -59,6 +64,11 @@ const stub = {
     stub.capturedMeta = meta;
     stub.capturedBytes =
       source.kind === 'file' ? fs.readFileSync(source.path) : Buffer.from(source.data);
+    if (stub.emitBytes && meta.onProgress) {
+      const { total } = stub.emitBytes;
+      meta.onProgress(Math.floor(total / 2), total);
+      meta.onProgress(total, total);
+    }
     if (stub.shouldThrow) throw stub.shouldThrow;
     if (stub.nextResult) return stub.nextResult;
     return { url: `https://stub.example/${meta.filename}` };
@@ -67,6 +77,15 @@ const stub = {
     stub.capturedDeleteRef = ref;
   },
 };
+
+// Capture the WS frames the upload route fans out (#545) while leaving the rest of
+// wsHub real — createTestApp wires the actual hub, so replacing the whole module
+// would take attachWsHub with it.
+const fanOutSpy = vi.fn<(userId: number, payload: unknown) => void>();
+vi.mock('../services/wsHub.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/wsHub.js')>()),
+  fanOutToUser: (userId: number, payload: unknown) => fanOutSpy(userId, payload),
+}));
 
 // Mock the registry so getDriver returns the stub for whatever driver the
 // resolved uploader names. splitConfigBySchema is provided because
@@ -338,6 +357,68 @@ describe('local-style (storesRemotely:false) uploads', () => {
       stub.nextResult = null;
     }
   });
+});
+
+// #545. The pieces are unit-tested (multipart.ts counts real socket bytes;
+// uploadProgress.ts throttles), but only the route proves they were wired together:
+// that it announces the phases the browser can't see, and that it actually hands its
+// byte callback DOWN to the driver.
+describe('POST /api/uploads — progress narration', () => {
+  const frames = () =>
+    fanOutSpy.mock.calls
+      .map((c) => c[1] as { kind: string; phase: string; percent: number | null; token: string })
+      .filter((f) => f.kind === 'upload-progress');
+
+  it('narrates processing → sending, with the provider byte count', async () => {
+    fanOutSpy.mockClear();
+    stub.emitBytes = { total: 1000 };
+    try {
+      const res = await agent
+        .post('/api/uploads')
+        .field('progressToken', 'tok-abc')
+        .attach('image', smallPng, { filename: 'p.png', contentType: 'image/png' });
+      expect(res.status).toBe(200);
+
+      // The driver really was given the callback — the wiring this test exists for.
+      expect(typeof (stub.capturedMeta as any).onProgress).toBe('function');
+
+      const seen = frames();
+      expect(seen.every((f) => f.token === 'tok-abc')).toBe(true);
+      expect(seen.map((f) => `${f.phase}:${f.percent}`)).toEqual([
+        'processing:null',
+        'sending:0',
+        // The 50% frame is swallowed by the throttle (both callbacks land in the same
+        // millisecond here); 100 always survives it, because a bar stranded at 99%
+        // would be the same lie in a new outfit.
+        'sending:100',
+      ]);
+    } finally {
+      stub.emitBytes = null;
+    }
+  });
+
+  // Progress is a courtesy, never a precondition. An older client that sends no token
+  // must upload exactly as before — and cost the server nothing.
+  it('stays silent when the client sends no token', async () => {
+    fanOutSpy.mockClear();
+    stub.emitBytes = { total: 1000 };
+    try {
+      const res = await agent
+        .post('/api/uploads')
+        .attach('image', smallPng, { filename: 'q.png', contentType: 'image/png' });
+      expect(res.status).toBe(200);
+      expect(res.body.url).toBeTruthy();
+      expect(frames()).toEqual([]);
+    } finally {
+      stub.emitBytes = null;
+    }
+  });
+
+  // NOTE: "the thumbnail upload must not drive the bar" is asserted in
+  // uploads.node.test.ts, not here. Standalone keeps the thumb as an inline BLOB, so
+  // the driver is only ever called once and the test would pass without proving
+  // anything. It only bites where hostsThumbnails sends the thumb through the driver
+  // as a second upload.
 });
 
 describe('GET /api/uploads/:id/thumb', () => {

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -386,7 +386,9 @@ describe('POST /api/uploads — progress narration', () => {
       expect(seen.every((f) => f.token === 'tok-abc')).toBe(true);
       expect(seen.map((f) => `${f.phase}:${f.percent}`)).toEqual([
         'processing:null',
-        'sending:0',
+        // Indeterminate until a byte is actually counted — a driver that reports none
+        // (local) must not sit at a frozen "0%".
+        'sending:null',
         // The 50% frame is swallowed by the throttle (both callbacks land in the same
         // millisecond here); 100 always survives it, because a bar stranded at 99%
         // would be the same lie in a new outfit.

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -14,6 +14,7 @@ import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from '../services/settingsRegistry.js';
 import * as imagePipeline from '../services/imagePipeline.js';
 import { thumbnailFormat } from '../services/thumbnailFormat.js';
+import { makeUploadProgress } from '../services/uploadProgress.js';
 import { driverIds } from '../services/uploadProviders/index.js';
 import {
   classifyUpload,
@@ -265,6 +266,17 @@ router.post(
         throw err;
       }
 
+      // Correlation token for the progress events (#545). The client's own random
+      // string, arriving as a multipart text field like uploaderId does. Absent →
+      // makeUploadProgress returns a no-op and the client falls back to an
+      // indeterminate label; progress must never be a precondition for uploading.
+      const tokenRaw = (req.body as { progressToken?: unknown } | undefined)?.progressToken;
+      const progress = makeUploadProgress(
+        req.user!.id,
+        typeof tokenRaw === 'string' && tokenRaw ? tokenRaw.slice(0, 64) : null,
+        resolved.driver.label,
+      );
+
       const settings = effectiveSettings(req.user!.id);
       // Size cap: operator-baked policy (hosted locked uploader) wins; otherwise
       // the user's own setting. A tenant can't lift a policy cap because the
@@ -309,6 +321,11 @@ router.post(
       let outWidth: number | null = null;
       let outHeight: number | null = null;
       let thumb: Buffer | null = null;
+
+      // Everything from here to the driver call is the pipeline: the sharp re-encode
+      // for images, the in-place metadata scrub for media. Both are native one-shots
+      // with no seam to count, so this phase is announced but not measured.
+      progress.processing();
 
       if (contentClass === 'text' || contentClass === 'media') {
         // Passthrough: the bytes go out of the temp file exactly as they came in.
@@ -382,13 +399,18 @@ router.post(
       const baseName = originalName.replace(/\.[^.]+$/, '') || `upload-${Date.now()}`;
       const filename = `${baseName}.${outExt}`;
 
+      // The slow half on a home uplink, and the half the browser is blind to. Announce
+      // it before the first byte so the user learns which leg they're waiting on even
+      // for a driver that reports none (`local` renames the file — no wire to count).
+      progress.sending();
+
       // provider.upload is from an untyped JS module boundary
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let result: any;
       try {
         result = await resolved.driver.upload(
           outSource,
-          { filename, mime: outMime, contentClass },
+          { filename, mime: outMime, contentClass, onProgress: progress.onBytes },
           resolved.driverConfig,
         );
       } catch (err) {

--- a/server/services/uploadProgress.test.ts
+++ b/server/services/uploadProgress.test.ts
@@ -48,7 +48,10 @@ describe('makeUploadProgress', () => {
         token: 'tok-1',
         phase: 'sending',
         destination: 'Catbox',
-        percent: 0,
+        // Indeterminate, NOT 0. `local` never reports a byte (it renames the temp
+        // file), so a 0 here would freeze at "Sending to Local disk… 0%" for the
+        // entire send — a number we cannot back is worse than no number.
+        percent: null,
       },
     ]);
   });
@@ -124,14 +127,44 @@ describe('makeUploadProgress', () => {
     expect(framesFor(7).map((f) => f.percent)).toEqual([50]);
   });
 
-  it('reports 0% rather than NaN for an empty body', () => {
+  // ⚠ The bug this module exists to kill, sneaking back in one layer down.
+  // Math.round(0.996 * 100) is 100 — so with most of a megabyte of a 200 MB file
+  // still on the wire, the client would read "Sending… 100%". And it would STAY
+  // there: lastPercent would already be 100, so the real 100% arriving with the final
+  // chunk gets dropped as a duplicate. A false 100 that then goes quiet is precisely
+  // "Uploading: 100%" wearing a different hat.
+  it('never says 100% until the last byte is actually gone', () => {
+    const p = makeUploadProgress(7, 'tok-1', 'Catbox');
+    p.sending();
+    fanOutToUser.mockClear();
+
+    vi.advanceTimersByTime(200);
+    p.onBytes(99_600, 100_000); // 99.6% — rounds to 100, floors to 99
+    expect(framesFor(7).at(-1)!.percent).toBe(99);
+
+    // And the genuine 100 still gets through afterwards; it was not eaten as a dupe.
+    p.onBytes(100_000, 100_000);
+    expect(framesFor(7).at(-1)!.percent).toBe(100);
+  });
+
+  it('never flatters the number on the way up', () => {
+    const p = makeUploadProgress(7, 'tok-1', 'Catbox');
+    p.sending();
+    fanOutToUser.mockClear();
+
+    vi.advanceTimersByTime(200);
+    p.onBytes(1990, 10_000); // 19.9% — round() would call this 20
+    expect(framesFor(7).at(-1)!.percent).toBe(19);
+  });
+
+  it('reports a finite percent for an empty body', () => {
     const p = makeUploadProgress(7, 'tok-1', 'Local disk');
     p.sending();
     fanOutToUser.mockClear();
     vi.advanceTimersByTime(200);
+    // 0/0 would be NaN, which renders as "Sending… NaN%". Nothing to send is sent.
     p.onBytes(0, 0);
-    // 0/0 would be NaN, which renders as "Sending… NaN%".
-    expect(framesFor(7).every((f) => f.percent === null || Number.isFinite(f.percent))).toBe(true);
+    expect(framesFor(7).at(-1)!.percent).toBe(100);
   });
 
   it('scopes frames to the uploading user', () => {

--- a/server/services/uploadProgress.test.ts
+++ b/server/services/uploadProgress.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const fanOutToUser = vi.fn<(userId: number, payload: unknown) => void>();
+vi.mock('./wsHub.js', () => ({
+  fanOutToUser: (userId: number, payload: unknown) => fanOutToUser(userId, payload),
+}));
+
+const { makeUploadProgress } = await import('./uploadProgress.js');
+
+interface Frame {
+  kind: string;
+  token: string;
+  phase: string;
+  destination: string;
+  percent: number | null;
+}
+
+const framesFor = (userId: number): Frame[] =>
+  fanOutToUser.mock.calls.filter((c) => c[0] === userId).map((c) => c[1] as Frame);
+
+beforeEach(() => {
+  fanOutToUser.mockClear();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('makeUploadProgress', () => {
+  it('announces the phases the browser cannot see', () => {
+    const p = makeUploadProgress(7, 'tok-1', 'Catbox');
+    p.processing();
+    p.sending();
+
+    expect(framesFor(7)).toEqual([
+      {
+        kind: 'upload-progress',
+        token: 'tok-1',
+        phase: 'processing',
+        destination: 'Catbox',
+        percent: null,
+      },
+      {
+        kind: 'upload-progress',
+        token: 'tok-1',
+        phase: 'sending',
+        destination: 'Catbox',
+        percent: 0,
+      },
+    ]);
+  });
+
+  // The escape hatch that keeps progress a courtesy: a client that doesn't ask (or an
+  // older one that doesn't know to) must cost nothing and break nothing.
+  it('emits nothing at all without a token', () => {
+    const p = makeUploadProgress(7, null, 'Catbox');
+    p.processing();
+    p.sending();
+    p.onBytes(500, 1000);
+    expect(fanOutToUser).not.toHaveBeenCalled();
+  });
+
+  it('throttles the byte stream instead of spraying a frame per chunk', () => {
+    const p = makeUploadProgress(7, 'tok-1', 'Catbox');
+    p.sending();
+    fanOutToUser.mockClear();
+
+    // 50 chunks arriving back-to-back, as they would off a fast local socket.
+    for (let i = 1; i <= 50; i++) p.onBytes(i * 1000, 100_000);
+
+    // All inside one throttle window → at most one frame, not fifty.
+    expect(framesFor(7).length).toBeLessThanOrEqual(1);
+  });
+
+  it('lets progress through once the throttle window passes', () => {
+    const p = makeUploadProgress(7, 'tok-1', 'Catbox');
+    // sending() emits its own 0% frame and primes the throttle clock, so a byte frame
+    // landing in the same instant is (correctly) suppressed — advance past it first.
+    p.sending();
+    fanOutToUser.mockClear();
+
+    vi.advanceTimersByTime(200);
+    p.onBytes(10_000, 100_000);
+    vi.advanceTimersByTime(200);
+    p.onBytes(20_000, 100_000);
+    vi.advanceTimersByTime(200);
+    p.onBytes(30_000, 100_000);
+
+    expect(framesFor(7).map((f) => f.percent)).toEqual([10, 20, 30]);
+  });
+
+  // The frame that ends the phase. Dropping it because it landed inside the throttle
+  // window would strand the bar just short of done — the same class of lie as
+  // "Uploading: 100%", which is the entire point of #545.
+  it('always emits 100% even when it lands inside the throttle window', () => {
+    const p = makeUploadProgress(7, 'tok-1', 'Catbox');
+    p.sending();
+    fanOutToUser.mockClear();
+
+    // Two chunks back-to-back with no time between them: the first is throttled, the
+    // last completes the upload and must NOT be.
+    p.onBytes(99_000, 100_000);
+    p.onBytes(100_000, 100_000);
+
+    expect(framesFor(7).at(-1)!.percent).toBe(100);
+  });
+
+  // A 200 MB file yields thousands of chunks, and a run of them all round to the same
+  // percent. Without this guard the throttle alone would still let one through every
+  // 150ms, repainting the same number forever.
+  it('never repeats a percent it has already sent', () => {
+    const p = makeUploadProgress(7, 'tok-1', 'Catbox');
+    p.sending();
+    fanOutToUser.mockClear();
+
+    for (let i = 0; i < 20; i++) {
+      vi.advanceTimersByTime(200); // throttle is wide open every time
+      p.onBytes(50_000 + i, 100_000); // ...but every one of these is still 50%
+    }
+
+    expect(framesFor(7).map((f) => f.percent)).toEqual([50]);
+  });
+
+  it('reports 0% rather than NaN for an empty body', () => {
+    const p = makeUploadProgress(7, 'tok-1', 'Local disk');
+    p.sending();
+    fanOutToUser.mockClear();
+    vi.advanceTimersByTime(200);
+    p.onBytes(0, 0);
+    // 0/0 would be NaN, which renders as "Sending… NaN%".
+    expect(framesFor(7).every((f) => f.percent === null || Number.isFinite(f.percent))).toBe(true);
+  });
+
+  it('scopes frames to the uploading user', () => {
+    makeUploadProgress(42, 'tok-a', 'Catbox').processing();
+    expect(framesFor(42).length).toBe(1);
+    expect(framesFor(7).length).toBe(0);
+  });
+});

--- a/server/services/uploadProgress.ts
+++ b/server/services/uploadProgress.ts
@@ -25,6 +25,26 @@ const THROTTLE_MS = 150;
 
 export type UploadPhase = 'processing' | 'sending';
 
+/**
+ * Percent sent, where **100 means sent** — not "rounds to sent".
+ *
+ * ⚠ The obvious `Math.round(sent / total * 100)` reports 100% at 99.6%, which on a
+ * 200 MB file is most of a megabyte still on the wire. Worse, it poisons the
+ * de-dupe: `lastPercent` becomes 100, so the REAL 100% that arrives with the final
+ * chunk is dropped as a duplicate, and the bar sits at a false 100 for the whole
+ * tail of the upload. That is exactly the "Uploading: 100% and then dead air" bug
+ * this module exists to kill, one layer down.
+ *
+ * So: floor (never flatter the number), clamp below 100, and let only `sent >= total`
+ * — which the streamed body guarantees on its last chunk — actually say 100.
+ */
+function percentSent(sentBytes: number, totalBytes: number): number {
+  // Nothing to send is, trivially, sent. (A multipart body always has boundaries, so
+  // this is the empty-PUT case, not a normal upload.)
+  if (totalBytes <= 0 || sentBytes >= totalBytes) return 100;
+  return Math.min(99, Math.max(0, Math.floor((sentBytes / totalBytes) * 100)));
+}
+
 export interface UploadProgress {
   /** The pipeline is working (sharp re-encode, or the in-place media scrub). No
    *  percentage: it's a one-shot native call with no seam to count. */
@@ -72,13 +92,19 @@ export function makeUploadProgress(
       emit('processing', null);
     },
     sending() {
-      emit('sending', 0);
+      // No number, not a zero. A percentage here would be a claim we cannot back:
+      // `local` never calls onBytes at all (it renames the temp file — no wire), so
+      // an initial 0% would freeze at "Sending to Local disk… 0%" for the whole send.
+      // An indeterminate label is honest about an unmeasurable phase; a stuck 0% is
+      // the same species of lie as the "Uploading: 100%" this all exists to kill.
+      // A real percentage appears iff onBytes actually reports one.
+      emit('sending', null);
+      // Prime the throttle clock (so the first byte frame doesn't land on top of this
+      // one) but NOT lastPercent: 0% is still a number worth sending if it's true.
       lastEmitAt = Date.now();
-      lastPercent = 0;
     },
     onBytes(sentBytes, totalBytes) {
-      const percent =
-        totalBytes > 0 ? Math.min(100, Math.round((sentBytes / totalBytes) * 100)) : 0;
+      const percent = percentSent(sentBytes, totalBytes);
       // Nothing new to say, or too soon to say it again. 100 always goes out
       // regardless of the throttle: it's the frame that ends the "sending" phase, and
       // dropping it would strand the bar just short of done — the same class of lie

--- a/server/services/uploadProgress.ts
+++ b/server/services/uploadProgress.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Server→client progress for an upload, over the WS the user already has open.
+//
+// WHY THIS EXISTS (#545): the browser's own upload progress (`xhr.upload`) only
+// measures browser→server. When it reaches 100% the file has merely ARRIVED here —
+// and then the two slowest things happen: the sharp/scrub pipeline, and the
+// server→provider send, which on a home uplink is by far the longest phase. The bar
+// used to read "Uploading: 100%" and sit there for all of it, looking hung. It was
+// honest about the wrong thing.
+//
+// Only the server knows about those phases, so only the server can narrate them.
+//
+// The events are a COURTESY, not part of the upload's contract: the HTTP response is
+// still what completes the upload. A client that sends no token (or an old one that
+// doesn't know about this) gets no events and falls back to an indeterminate
+// "Processing…" label — strictly better than the lie, and nothing breaks.
+
+import { fanOutToUser } from './wsHub.js';
+
+// Slow enough that a 200 MB upload on a fast link doesn't spray hundreds of frames
+// at a client that can only repaint 60 times a second; fast enough to feel live.
+const THROTTLE_MS = 150;
+
+export type UploadPhase = 'processing' | 'sending';
+
+export interface UploadProgress {
+  /** The pipeline is working (sharp re-encode, or the in-place media scrub). No
+   *  percentage: it's a one-shot native call with no seam to count. */
+  processing(): void;
+  /** The send to the provider has begun. Emitted even for drivers that will never
+   *  report a byte (`local` renames the temp file — no wire to count), so the user
+   *  always learns WHICH half they're waiting on even when we can't say how far. */
+  sending(): void;
+  /** Handed to the driver as UploadMeta.onProgress. Throttled, and only ever moves
+   *  forward. */
+  onBytes(sentBytes: number, totalBytes: number): void;
+}
+
+const NOOP: UploadProgress = {
+  processing() {},
+  sending() {},
+  onBytes() {},
+};
+
+/**
+ * `token` correlates the events with the one upload the client is watching. It is
+ * the client's own random string, echoed back untouched — two tabs (or two devices)
+ * of the same user each fan out to BOTH sockets, so without it a second upload's
+ * progress would drive the first one's bar. No token → no events (NOOP).
+ *
+ * `destination` is the resolved uploader's human label, so the client can say
+ * "Sending to Catbox…" rather than "Sending…".
+ */
+export function makeUploadProgress(
+  userId: number,
+  token: string | null,
+  destination: string,
+): UploadProgress {
+  if (!token) return NOOP;
+
+  const emit = (phase: UploadPhase, percent: number | null): void => {
+    fanOutToUser(userId, { kind: 'upload-progress', token, phase, destination, percent });
+  };
+
+  let lastEmitAt = 0;
+  let lastPercent = -1;
+
+  return {
+    processing() {
+      emit('processing', null);
+    },
+    sending() {
+      emit('sending', 0);
+      lastEmitAt = Date.now();
+      lastPercent = 0;
+    },
+    onBytes(sentBytes, totalBytes) {
+      const percent =
+        totalBytes > 0 ? Math.min(100, Math.round((sentBytes / totalBytes) * 100)) : 0;
+      // Nothing new to say, or too soon to say it again. 100 always goes out
+      // regardless of the throttle: it's the frame that ends the "sending" phase, and
+      // dropping it would strand the bar just short of done — the same class of lie
+      // this whole thing exists to kill.
+      if (percent === lastPercent) return;
+      const now = Date.now();
+      if (percent < 100 && now - lastEmitAt < THROTTLE_MS) return;
+      lastEmitAt = now;
+      lastPercent = percent;
+      emit('sending', percent);
+    },
+  };
+}

--- a/server/services/uploadProviders/catbox.ts
+++ b/server/services/uploadProviders/catbox.ts
@@ -52,7 +52,7 @@ export const configSchema: ConfigField[] = [
 
 export async function upload(
   source: UploadSource,
-  { filename, mime }: UploadMeta,
+  { filename, mime, onProgress }: UploadMeta,
   config: { userhash?: string } = {},
 ): Promise<UploadResult> {
   const parts: StreamPart[] = [{ name: 'reqtype', value: 'fileupload' }];
@@ -76,6 +76,7 @@ export async function upload(
         Accept: '*/*',
       },
       timeoutMs: TIMEOUT_MS,
+      onProgress,
     });
   } catch (cause) {
     const c = cause as NodeJS.ErrnoException; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/server/services/uploadProviders/chibisafe.ts
+++ b/server/services/uploadProviders/chibisafe.ts
@@ -46,7 +46,7 @@ export const configSchema: ConfigField[] = [
 
 export async function upload(
   source: UploadSource,
-  { filename, mime }: UploadMeta,
+  { filename, mime, onProgress }: UploadMeta,
   config: { url?: string; api_key?: string } = {},
 ): Promise<UploadResult> {
   if (!config.url) {
@@ -64,7 +64,7 @@ export async function upload(
   const resp = await postMultipart(
     `${base}/api/upload`,
     [{ name: 'file[]', filename, contentType: mime, source }],
-    { headers: { 'x-api-key': config.api_key, 'User-Agent': USER_AGENT } },
+    { headers: { 'x-api-key': config.api_key, 'User-Agent': USER_AGENT }, onProgress },
   );
 
   if (!isOk(resp)) {

--- a/server/services/uploadProviders/dropper.ts
+++ b/server/services/uploadProviders/dropper.ts
@@ -53,7 +53,7 @@ export const configSchema: ConfigField[] = [
 
 export async function upload(
   source: UploadSource,
-  { filename, mime, kind }: UploadMeta,
+  { filename, mime, kind, onProgress }: UploadMeta,
   config: { url?: string; api_key?: string } = {},
 ): Promise<UploadResult> {
   if (!config.url) {
@@ -78,6 +78,7 @@ export async function upload(
       Authorization: `Bearer ${config.api_key}`,
       'User-Agent': USER_AGENT,
     },
+    onProgress,
   });
 
   if (!isOk(resp)) {

--- a/server/services/uploadProviders/multipart.test.ts
+++ b/server/services/uploadProviders/multipart.test.ts
@@ -129,6 +129,46 @@ describe('postMultipart', () => {
     expect(last.body.includes(bytes)).toBe(true);
   });
 
+  // #545: the byte count that drives the client's "Sending… NN%" for the slow half of
+  // an upload. Asserted against a REAL socket (this suite's http server), because the
+  // whole claim is that a yielded-and-resumed chunk is a chunk the socket took — that
+  // is a property of the transport, not of the generator, and a fake would assume it.
+  it('reports send progress that ends at exactly Content-Length', async () => {
+    const bytes = Buffer.alloc(300_000, 0xcd);
+    const f = writeTemp('prog.bin', bytes);
+    respondWith = { status: 200, text: 'ok' };
+
+    const seen: Array<{ sent: number; total: number }> = [];
+    const resp = await postMultipart(
+      base,
+      [
+        {
+          name: 'file',
+          filename: 'prog.bin',
+          contentType: 'image/png',
+          source: fileSource(f.path, f.size),
+        },
+      ],
+      { onProgress: (sent, total) => seen.push({ sent, total }) },
+    );
+    expect(isOk(resp)).toBe(true);
+
+    // It actually streamed — a single 0→100 jump would mean the body was buffered
+    // whole, which is the memory blowup #543 removed.
+    expect(seen.length).toBeGreaterThan(1);
+    // Monotonic, and it lands on the exact total the server received. A count that
+    // overshoots or stops short is a bar that ends at 103% or stalls at 98%.
+    for (let i = 1; i < seen.length; i++) {
+      expect(seen[i].sent).toBeGreaterThan(seen[i - 1].sent);
+    }
+    const total = seen[0].total;
+    expect(seen.at(-1)!.sent).toBe(total);
+    expect(total).toBe(Number(last.contentLength));
+    // Every part of the body counts, not just the file: Content-Length covers the
+    // headers and boundaries too, so counting only file bytes would never reach 100%.
+    expect(total).toBeGreaterThan(bytes.length);
+  });
+
   it('sends a buffer source identically (the optimized-image path)', async () => {
     const bytes = Buffer.from('hello buffer source');
     respondWith = { status: 200, text: 'ok' };

--- a/server/services/uploadProviders/multipart.ts
+++ b/server/services/uploadProviders/multipart.ts
@@ -60,6 +60,18 @@ export interface PostBufferResult {
 export interface RequestOptions {
   headers?: Record<string, string>;
   timeoutMs?: number;
+  // Called as the body drains, with the running byte count and the exact total.
+  //
+  // This is the ONLY place a driver-agnostic count of "bytes on the wire" exists —
+  // every remote driver's send funnels through sendStreamed — and it is meaningful
+  // only because the body is a generator the socket pulls from: it advances at the
+  // rate the socket drains, so a chunk that has been yielded and resumed is a chunk
+  // the socket has taken. Counting anywhere upstream would count bytes we merely
+  // intended to send, which is exactly the lie #545 is about.
+  //
+  // Called after each chunk lands, so it can fire often on a big file — throttle in
+  // the caller, not here (the caller knows what it's driving).
+  onProgress?: (sentBytes: number, totalBytes: number) => void;
 }
 
 /** fetch's `resp.ok`, for the node:http results these helpers return. */
@@ -128,8 +140,23 @@ function sendStreamed(
   urlString: string,
   contentLength: number,
   makeBody: () => AsyncIterable<Buffer>,
-  { headers = {}, timeoutMs = 60_000 }: RequestOptions = {},
+  { headers = {}, timeoutMs = 60_000, onProgress }: RequestOptions = {},
 ): Promise<PostBufferResult> {
+  // Count bytes as the socket takes them. The count happens AFTER `yield` resumes,
+  // not before it: resumption is the signal the consumer has accepted the chunk and
+  // backpressure has been honoured. Counting before the yield would report bytes
+  // that are still sitting in this generator.
+  const countedBody: () => AsyncIterable<Buffer> = onProgress
+    ? async function* () {
+        let sent = 0;
+        for await (const chunk of makeBody()) {
+          yield chunk;
+          sent += chunk.length;
+          onProgress(sent, contentLength);
+        }
+      }
+    : makeBody;
+
   return new Promise((resolve, reject) => {
     let url: URL;
     try {
@@ -247,7 +274,7 @@ function sendStreamed(
     // gets to finish talking to us now (see the keep-alive agent above), so this
     // path is for providers that cut us off regardless, not the common case.
     let writeError: Error | null = null;
-    const body = Readable.from(makeBody());
+    const body = Readable.from(countedBody());
     body.on('error', (err: Error) => {
       writeError = err;
       req.destroy();

--- a/server/services/uploadProviders/s3.ts
+++ b/server/services/uploadProviders/s3.ts
@@ -237,7 +237,7 @@ function requireField(config: Record<string, string>, field: string): string {
 
 export async function upload(
   source: UploadSource,
-  { filename, mime, kind }: UploadMeta,
+  { filename, mime, kind, onProgress }: UploadMeta,
   config: Record<string, string> = {},
 ): Promise<UploadResult> {
   const endpoint = requireField(config, 'endpoint');
@@ -266,7 +266,9 @@ export async function upload(
     secretAccessKey,
   });
 
-  const resp = await putSource(signed.url, source, { headers: signed.headers });
+  // onProgress goes on the SEND pass only. The hash pass above reads the same bytes
+  // end to end, so counting both would run the bar 0→100 twice on every s3 upload.
+  const resp = await putSource(signed.url, source, { headers: signed.headers, onProgress });
 
   if (!isOk(resp)) {
     const text = resp.text.slice(0, 200);

--- a/server/services/uploadProviders/types.ts
+++ b/server/services/uploadProviders/types.ts
@@ -68,6 +68,16 @@ export interface UploadMeta {
   // Hint forwarded to the in-house dropper so a thumbnail lands under a
   // `thumbs/` prefix. Hosts that don't understand it ignore the extra field.
   kind?: 'thumb';
+  // Byte-level progress for the server→provider leg — the slow half of a big
+  // upload, and the half the client is blind to (#545). A driver forwards this
+  // straight into its RequestOptions; multipart.ts does the counting.
+  //
+  // OPTIONAL ON PURPOSE, in both directions. A driver that doesn't forward it, or
+  // one with no wire to count (`local` renames the temp file — zero copies, so
+  // there is nothing to stream), simply reports no percentage and the client falls
+  // back to the indeterminate phase label. Progress is a courtesy, never a
+  // precondition: an upload must not fail because nobody was watching.
+  onProgress?: (sentBytes: number, totalBytes: number) => void;
 }
 
 export interface UploadResult {

--- a/server/services/uploadProviders/x0.ts
+++ b/server/services/uploadProviders/x0.ts
@@ -23,12 +23,12 @@ export const configSchema: ConfigField[] = [];
 
 export async function upload(
   source: UploadSource,
-  { filename, mime }: UploadMeta,
+  { filename, mime, onProgress }: UploadMeta,
 ): Promise<UploadResult> {
   const resp = await postMultipart(
     ENDPOINT,
     [{ name: 'file', filename, contentType: mime, source }],
-    { headers: { 'User-Agent': USER_AGENT } },
+    { headers: { 'User-Agent': USER_AGENT }, onProgress },
   );
   const text = resp.text.trim();
   if (resp.status < 200 || resp.status >= 300) {

--- a/server/services/uploadProviders/zipline.ts
+++ b/server/services/uploadProviders/zipline.ts
@@ -46,7 +46,7 @@ export const configSchema: ConfigField[] = [
 
 export async function upload(
   source: UploadSource,
-  { filename, mime }: UploadMeta,
+  { filename, mime, onProgress }: UploadMeta,
   config: { url?: string; token?: string } = {},
 ): Promise<UploadResult> {
   if (!config.url) {
@@ -62,7 +62,7 @@ export async function upload(
   const resp = await postMultipart(
     `${base}/api/upload`,
     [{ name: 'file', filename, contentType: mime, source }],
-    { headers: { authorization: config.token, 'User-Agent': USER_AGENT } },
+    { headers: { authorization: config.token, 'User-Agent': USER_AGENT }, onProgress },
   );
 
   if (!isOk(resp)) {

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -213,8 +213,20 @@ const splitClass = computed(() => {
   return 'warn';
 });
 
+// Narrate the leg the upload is ACTUALLY on (#545). A percentage appears only where
+// one is real — the browser leg, and the provider send when the driver can count
+// bytes. Everywhere else the label is indeterminate on purpose: "Processing…" tells
+// the truth about an unmeasurable phase, where "100%" told a comfortable lie.
 const uploadLabel = computed(() => {
-  if (uploads.current) return `Uploading: ${uploads.current.progress}%`;
+  const cur = uploads.current;
+  if (cur) {
+    if (cur.phase === 'uploading') return `Uploading: ${cur.progress}%`;
+    if (cur.phase === 'sending') {
+      const where = cur.destination ? `Sending to ${cur.destination}` : 'Sending';
+      return cur.sentPercent == null ? `${where}…` : `${where}… ${cur.sentPercent}%`;
+    }
+    return 'Processing…';
+  }
   if (uploads.failedAt) {
     return uploads.failedMessage ? `Upload failed — ${uploads.failedMessage}` : 'Upload failed';
   }

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -23,6 +23,8 @@ import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useDataExportStore } from '../stores/dataExport.js';
 import { useDccStore } from '../stores/dcc.js';
+import { useUploadsStore } from '../stores/uploads.js';
+import { makeClientId } from '../utils/clientId.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { downloadTextFile } from '../utils/download.js';
 import { notifyForEvent, playSound } from './useHighlightNotifier.js';
@@ -701,6 +703,14 @@ function handleMessage(raw: string): void {
     useDataExportStore().apply(payload.job);
     return;
   }
+  if (payload.kind === 'upload-progress') {
+    // The server narrating the half of an upload the browser can't see: the
+    // pipeline, then the server→provider send (#545). The store drops frames whose
+    // token isn't the upload THIS tab is running — these fan out to every socket the
+    // user has open, so a second tab's upload must not drive this one's bar.
+    useUploadsStore().applyProgress(payload);
+    return;
+  }
 }
 
 function open() {
@@ -782,16 +792,6 @@ function failAllPendingAcks(error: string): void {
   const entries = Array.from(pendingAcks.values());
   pendingAcks.clear();
   for (const resolver of entries) resolver({ ok: false, error });
-}
-
-// Generate a clientId for an ACK-tracked send. Uses crypto.randomUUID where
-// available and falls back to a random-base36 string otherwise (older Safari
-// in non-secure contexts won't expose randomUUID).
-function makeClientId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `c-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 // Send a payload that expects a `send-result` ACK from the server. Returns

--- a/vue_client/src/stores/uploads.test.ts
+++ b/vue_client/src/stores/uploads.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+// Lets a test drive the real upload() action and watch the store react to the
+// browser-leg progress events the way an XHR would deliver them.
+type MultipartOpts = { onProgress(pct: number): void };
+const apiMultipart =
+  vi.fn<(url: string, fd: FormData, opts: MultipartOpts) => Promise<Record<string, unknown>>>();
+vi.mock('../api.js', () => ({
+  api: vi.fn<() => Promise<unknown>>(async () => ({ items: [] })),
+  apiMultipart: (url: string, fd: FormData, opts: MultipartOpts) => apiMultipart(url, fd, opts),
+}));
+
+const { useUploadsStore } = await import('./uploads.js');
+type UploadCurrent = NonNullable<ReturnType<typeof useUploadsStore>['current']>;
+
+function current(over: Partial<UploadCurrent> = {}): UploadCurrent {
+  return {
+    token: 'tok-mine',
+    phase: 'uploading',
+    progress: 0,
+    sentPercent: null,
+    destination: null,
+    filename: 'photo.png',
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  apiMultipart.mockReset();
+});
+
+// TIER 1 — the part that needs no server cooperation, and the reason #545 is a bug
+// rather than a missing feature. xhr.upload only measures browser→server; when it
+// hits 100% the file has merely ARRIVED, and the slow half (pipeline + provider send)
+// hasn't started. The bar used to read "Uploading: 100%" and sit there looking hung.
+describe('uploads.upload — browser-leg progress', () => {
+  it('stops claiming to upload the moment the browser leg finishes', async () => {
+    const uploads = useUploadsStore();
+    const seen: Array<{ phase: string; progress: number }> = [];
+
+    apiMultipart.mockImplementation(
+      async (_url: string, _fd: FormData, { onProgress }: { onProgress(p: number): void }) => {
+        for (const pct of [25, 75, 100]) {
+          onProgress(pct);
+          seen.push({ phase: uploads.current!.phase, progress: uploads.current!.progress });
+        }
+        return { id: 1, url: 'https://x.test/a.webp', mime: 'image/webp' };
+      },
+    );
+
+    await uploads.upload(new Blob(['x']), 'a.png');
+
+    expect(seen).toEqual([
+      { phase: 'uploading', progress: 25 },
+      { phase: 'uploading', progress: 75 },
+      // NOT 'uploading' at 100 — that was the lie.
+      { phase: 'processing', progress: 100 },
+    ]);
+  });
+
+  // Correlation for the server's frames rides the multipart body, and it has to be
+  // appended BEFORE the file: multer fills req.body as fields stream past, so a token
+  // sitting behind 200 MB of image would not exist yet when the route reads it.
+  it('sends a progress token ahead of the file', async () => {
+    const uploads = useUploadsStore();
+    apiMultipart.mockResolvedValue({ id: 1, url: 'https://x.test/a.webp' });
+
+    await uploads.upload(new Blob(['x']), 'a.png');
+
+    const fd = apiMultipart.mock.calls[0][1] as FormData;
+    const keys = [...fd.keys()];
+    expect(keys).toEqual(['progressToken', 'image']);
+    expect(fd.get('progressToken')).toBeTruthy();
+  });
+});
+
+describe('uploads.applyProgress', () => {
+  it('advances through the phases the browser cannot see', () => {
+    const uploads = useUploadsStore();
+    uploads.current = current({ phase: 'processing', progress: 100 });
+
+    uploads.applyProgress({
+      token: 'tok-mine',
+      phase: 'sending',
+      percent: 42,
+      destination: 'Catbox',
+    });
+
+    expect(uploads.current!.phase).toBe('sending');
+    expect(uploads.current!.sentPercent).toBe(42);
+    expect(uploads.current!.destination).toBe('Catbox');
+  });
+
+  // The frames fan out to EVERY socket the user has open. Two tabs (or a phone and a
+  // laptop) uploading at once would otherwise drive each other's bars.
+  it("ignores another upload's frames", () => {
+    const uploads = useUploadsStore();
+    uploads.current = current({ phase: 'processing' });
+
+    uploads.applyProgress({
+      token: 'tok-other-tab',
+      phase: 'sending',
+      percent: 90,
+      destination: 'Catbox',
+    });
+
+    expect(uploads.current!.phase).toBe('processing');
+    expect(uploads.current!.sentPercent).toBeNull();
+  });
+
+  it('ignores a frame that arrives with no upload in flight', () => {
+    const uploads = useUploadsStore();
+    uploads.current = null;
+    expect(() =>
+      uploads.applyProgress({
+        token: 'tok-mine',
+        phase: 'sending',
+        percent: 50,
+        destination: 'Catbox',
+      }),
+    ).not.toThrow();
+    expect(uploads.current).toBeNull();
+  });
+
+  // A late 'processing' frame landing after 'sending' has begun would rewind a live
+  // percentage back to an indeterminate label — a visibly jumping bar.
+  it('never rewinds from sending back to processing', () => {
+    const uploads = useUploadsStore();
+    uploads.current = current({ phase: 'sending', sentPercent: 60, destination: 'Catbox' });
+
+    uploads.applyProgress({
+      token: 'tok-mine',
+      phase: 'processing',
+      percent: null,
+      destination: 'Catbox',
+    });
+
+    expect(uploads.current!.phase).toBe('sending');
+    expect(uploads.current!.sentPercent).toBe(60);
+  });
+
+  // `local` renames the temp file — zero copies, so there is no wire to count. The
+  // user still learns which leg they are on; they just get no number.
+  it('accepts a sending phase with no percentage', () => {
+    const uploads = useUploadsStore();
+    uploads.current = current({ phase: 'processing' });
+
+    uploads.applyProgress({
+      token: 'tok-mine',
+      phase: 'sending',
+      percent: null,
+      destination: 'Local disk',
+    });
+
+    expect(uploads.current!.phase).toBe('sending');
+    expect(uploads.current!.sentPercent).toBeNull();
+    expect(uploads.current!.destination).toBe('Local disk');
+  });
+});

--- a/vue_client/src/stores/uploads.ts
+++ b/vue_client/src/stores/uploads.ts
@@ -3,6 +3,7 @@
 
 import { defineStore } from 'pinia';
 import { api, apiMultipart } from '../api.js';
+import { makeClientId } from '../utils/clientId.js';
 
 // "Insert URL into MessageInput" needs to reach across the component tree.
 // A tiny event bus pattern (Set of callbacks) keeps the modal independent of
@@ -24,9 +25,43 @@ function emitInsert(url: string) {
 
 const FAILURE_VISIBLE_MS = 10_000;
 
+// The three legs of an upload, in the order they happen. Only the first is visible
+// to the browser (#545):
+//
+//   uploading  — browser → server. Measured by xhr.upload; the ONLY thing the old
+//                bar ever showed, which is why it read 100% and then sat there.
+//   processing — the server's pipeline (sharp re-encode / metadata scrub). A native
+//                one-shot with no seam to count, so it has no percentage.
+//   sending    — server → provider. The long one on a home uplink. Has a percentage
+//                when the driver can report bytes, and none when it can't (`local`
+//                renames the temp file; there is no wire).
+//
+// `processing` is also the FALLBACK state: the store enters it the moment the
+// browser leg finishes, without waiting for the server to say so. That alone kills
+// the "Uploading: 100%" lie even if no WS frame ever arrives (an old server, a
+// dropped socket) — the server's frames then refine it rather than enable it.
+export type UploadPhase = 'uploading' | 'processing' | 'sending';
+
 export interface UploadCurrent {
+  // Correlates the server's progress frames with THIS upload. They fan out to every
+  // socket the user has open, so a frame for anything else gets dropped.
+  token: string;
+  phase: UploadPhase;
+  // 0-100, the browser→server leg.
   progress: number;
+  // 0-100 for the server→provider leg, or null when the driver can't report bytes.
+  sentPercent: number | null;
+  // Human label of the uploader the server resolved ("Catbox", "Local disk"), so the
+  // status bar can name where the file is going. Null until the server says.
+  destination: string | null;
   filename: string | null;
+}
+
+export interface UploadProgressFrame {
+  token: string;
+  phase: 'processing' | 'sending';
+  percent: number | null;
+  destination: string | null;
 }
 
 export interface UploadItem {
@@ -62,11 +97,20 @@ export const useUploadsStore = defineStore('uploads', {
   actions: {
     async upload(file: File | Blob, filename: string | null = null) {
       if (this.current) return; // Single concurrent upload — keeps the status bar coherent.
+      const token = makeClientId();
       const fd = new FormData();
       const name = filename || (file instanceof File ? file.name : null) || 'upload';
+      // Before the file, not after: multer populates req.body as fields stream past,
+      // so a token appended behind a 200 MB file would not exist yet when the route
+      // reads it.
+      fd.append('progressToken', token);
       fd.append('image', file, name);
       this.current = {
+        token,
+        phase: 'uploading',
         progress: 0,
+        sentPercent: null,
+        destination: null,
         filename: filename || (file instanceof File ? file.name : null) || null,
       };
       this.failedAt = null;
@@ -74,7 +118,14 @@ export const useUploadsStore = defineStore('uploads', {
       try {
         const result = await apiMultipart('/api/uploads', fd, {
           onProgress: (pct) => {
-            if (this.current) this.current.progress = pct;
+            if (!this.current) return;
+            this.current.progress = pct;
+            // The moment the browser leg is done, stop claiming to be uploading. This
+            // is the whole of "tier 1": it needs no server cooperation, so the bar
+            // stops lying even when the WS frames never come.
+            if (pct >= 100 && this.current.phase === 'uploading') {
+              this.current.phase = 'processing';
+            }
           },
         });
         emitInsert(result.url);
@@ -115,6 +166,28 @@ export const useUploadsStore = defineStore('uploads', {
       } finally {
         this.current = null;
       }
+    },
+
+    /**
+     * A server progress frame (#545). Fans out to every socket the user has open, so
+     * most of the guarding here is about frames that aren't ours:
+     *
+     *  - no active upload → another tab's, or one that already finished. Drop it.
+     *  - token mismatch → another tab/device is uploading too. Drop it, or its bytes
+     *    would drive this tab's bar.
+     *  - phase went backwards → a delayed 'processing' frame arriving after 'sending'
+     *    has begun would rewind the bar to indeterminate. WS ordering makes this
+     *    unlikely, not impossible, and the cost of being wrong is a visibly jumping
+     *    UI, so it's cheaper to enforce monotonicity than to trust the wire.
+     */
+    applyProgress(frame: UploadProgressFrame) {
+      const cur = this.current;
+      if (!cur || !frame?.token || frame.token !== cur.token) return;
+      if (cur.phase === 'sending' && frame.phase === 'processing') return;
+
+      cur.phase = frame.phase;
+      if (frame.destination) cur.destination = frame.destination;
+      cur.sentPercent = frame.phase === 'sending' ? (frame.percent ?? null) : null;
     },
 
     async uploadText(content: string, filename = 'message.txt') {

--- a/vue_client/src/utils/clientId.ts
+++ b/vue_client/src/utils/clientId.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * A random id the client mints to correlate one of its own requests with the
+ * server's asynchronous answers about it — an ACK for a sent message, the progress
+ * frames for an upload (#545).
+ *
+ * Not a security token: it never authorizes anything, and the server echoes it back
+ * untouched. It only has to be unique among one user's own in-flight work.
+ *
+ * ⚠ The fallback is load-bearing, not defensive clutter: `crypto.randomUUID` is only
+ * exposed in SECURE contexts, and Lurker's LAN dev mode (VITE_LAN_HOST) deliberately
+ * serves plain HTTP so a phone can reach it without a trusted cert. Calling
+ * randomUUID unguarded there is a TypeError, not a degraded id.
+ */
+export function makeClientId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `c-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}


### PR DESCRIPTION
Closes #545.

## The bug

`xhr.upload` only measures **browser → server**. When it reaches 100% the file has merely *arrived* — and then the two slowest things happen: the sharp/scrub pipeline, and the server→provider send, which on a home uplink is by far the longest phase. The bar read `Uploading: 100%` and then sat there for all of it, looking hung.

It was honest about the wrong thing.

## Three legs, each narrated by whoever can see it

```
Uploading: 64%            browser → server    (xhr, as before)
Optimizing…               the pipeline        (server)
Sending to Catbox… 38%    server → provider   (server)
```

**Tier 1 is the fallback, not throwaway work.** The store enters `processing` the moment the browser leg ends, *without waiting to be told* — so the lie dies even if no WS frame ever arrives (an old server, a dropped socket). The server's frames **refine** that state rather than enable it.

**Tier 2 only just became possible.** Before #543 the provider send was a single atomic `fetch()` with an opaque body — there was no seam to count at. Now every driver funnels through one streamed generator, so the count lives in `sendStreamed()` and rides the WS the user already has open (`fanOutToUser`, same shape as the existing background-export progress).

The count happens **after `yield` resumes**, not before it: resumption is the moment the socket has actually taken the chunk. Counting before the yield would count bytes we merely *intended* to send — the same class of lie, one layer down.

## Design notes

- **Progress is a courtesy, never a precondition.** No token (or a client that predates this) → no frames, and the upload behaves exactly as it did. A driver that doesn't forward the callback simply reports no percentage.
- **`local` has no wire to count** — `moveTo()` renames the temp file, zero copies — so it announces the phase without a number. **s3 reads the source twice** (SigV4 must sign the payload hash before it can sign the request), so only the *send* pass is counted, or the bar would run 0→100 twice on every s3 upload.
- **The thumbnail is its own `driver.upload`** and deliberately gets no callback — a 128px thumb would yank the bar back to 0 and re-fill it right after the real file landed. Asserted in node edition, the only place `hostsThumbnails` actually sends it through the driver.
- **The token is appended to the FormData *before* the file.** multer fills `req.body` as fields stream past, so a token sitting behind 200 MB of image would not exist yet when the route read it.
- Frames fan out to **every socket the user has open**, so the store drops any that aren't its own upload's — otherwise a second tab's bytes drive this tab's bar.
- **100% always defeats the throttle.** A bar stranded at 99% is the same lie in a new outfit.
- `makeClientId()` lifted out of `useSocket` into `utils/clientId.ts` rather than re-derived: its `crypto.randomUUID` fallback is load-bearing, because LAN dev mode (`VITE_LAN_HOST`) serves plain HTTP, where `randomUUID` is a `TypeError` rather than a degraded id.

## Verification

The byte count is asserted **against a real socket** (the suite's http server), not a fake — the claim is a property of the transport, and a fake would just assume it. The test also proves it *streamed* (many frames, not one 0→100 jump, which would mean the body was buffered whole — the memory blowup #543 removed) and that it lands on exactly `Content-Length`, headers and boundaries included.

Route-level tests prove the wiring the unit tests can't: that the route announces the phases *and* actually hands its callback down to the driver.

`npm run check` clean, `npm test` green (2310 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)