### PR TITLE
Uploads browser: search, type filters, and a grid (#547)

### DIFF
--- a/server/db/uploadHistory.test.ts
+++ b/server/db/uploadHistory.test.ts
@@ -74,6 +74,114 @@ describe('insertUpload / listUploads', () => {
   });
 });
 
+// #547. Its own user, seeded once: the suites above share alice/bob and keep adding
+// rows to them, so exact-count assertions there would break every time someone adds a
+// test above this line.
+describe('listUploads — search + kind filter (#547)', () => {
+  let carol: ReturnType<typeof import('./users.js').createUser>;
+  const names = (rows: Array<{ filename: string | null }>) => rows.map((r) => r.filename);
+
+  // Written oldest-first, so `id DESC` returns this list reversed.
+  const SEEDED: Array<[string, string]> = [
+    ['vacation.png', 'image/webp'],
+    ['screenshot-march.png', 'image/webp'],
+    ['notes.txt', 'text/plain'],
+    ['clip.mp4', 'video/mp4'],
+    ['song.mp3', 'audio/mpeg'],
+    ['SCREAMING-SHOT.PNG', 'image/webp'],
+    // Filenames that are made of LIKE metacharacters. These are the entire reason
+    // likeTerm() exists.
+    ['100%-zoom.png', 'image/webp'],
+    ['snap_shot.png', 'image/webp'],
+  ];
+
+  beforeAll(() => {
+    carol = createUser('uh-carol');
+    for (const [filename, mime] of SEEDED) {
+      insert(carol.id, { filename, mime, url: `https://x0.at/${filename}` });
+    }
+  });
+
+  it('matches a filename substring, newest first', () => {
+    // Substring, not prefix: "sho" is inside screen-SHO-t too.
+    expect(names(mod.listUploads(carol.id, { q: 'sho' }))).toEqual([
+      'snap_shot.png',
+      'SCREAMING-SHOT.PNG',
+      'screenshot-march.png',
+    ]);
+  });
+
+  // SQLite's LIKE is case-insensitive for ASCII, and someone typing "shot" plainly
+  // means to find "SHOT.PNG" as well.
+  it('is case-insensitive', () => {
+    expect(names(mod.listUploads(carol.id, { q: 'SCREAMING' }))).toEqual(['SCREAMING-SHOT.PNG']);
+  });
+
+  // ⚠ The bug likeTerm() exists to prevent. Unescaped, `%` and `_` are LIKE WILDCARDS
+  // rather than characters — searching "100%" would match every filename containing
+  // "100", and a lone "%" would match the entire history. A search box that silently
+  // honours wildcards is a search box that lies about what it found.
+  it('treats % as a literal, not a wildcard', () => {
+    expect(names(mod.listUploads(carol.id, { q: '100%' }))).toEqual(['100%-zoom.png']);
+    // A bare "%" finds the one file with a literal % in its name — NOT the whole
+    // history, which is what an unescaped wildcard would have returned.
+    expect(names(mod.listUploads(carol.id, { q: '%' }))).toEqual(['100%-zoom.png']);
+  });
+
+  it('treats _ as a literal, not a single-character wildcard', () => {
+    expect(names(mod.listUploads(carol.id, { q: 'snap_shot' }))).toEqual(['snap_shot.png']);
+    // Unescaped, `_` would match every filename with at least one character.
+    expect(names(mod.listUploads(carol.id, { q: '_' }))).toEqual(['snap_shot.png']);
+  });
+
+  it('finds nothing for a term that matches nothing', () => {
+    expect(mod.listUploads(carol.id, { q: 'nonexistent' })).toEqual([]);
+  });
+
+  it.each([
+    ['image', 5],
+    ['video', 1],
+    ['audio', 1],
+    ['text', 1],
+  ] as const)('filters to kind=%s', (kind, count) => {
+    const rows = mod.listUploads(carol.id, { kind });
+    expect(rows.length).toBe(count);
+    expect(rows.every((r) => (r.mime || '').startsWith(`${kind}/`))).toBe(true);
+  });
+
+  it('ANDs the search term with the kind', () => {
+    expect(names(mod.listUploads(carol.id, { q: 'clip', kind: 'video' }))).toEqual(['clip.mp4']);
+    // Same term, wrong kind → nothing. If the clauses OR'd, this would return the mp4.
+    expect(mod.listUploads(carol.id, { q: 'clip', kind: 'image' })).toEqual([]);
+  });
+
+  // Keyset pagination has to keep working once a WHERE clause joins it: a cursor that
+  // ignored the filter would page through the UNFILTERED sequence and silently skip
+  // matches.
+  it('pages a filtered result set with the id cursor', () => {
+    const all = mod.listUploads(carol.id, { kind: 'image' });
+    expect(all.length).toBe(5);
+
+    const page1 = mod.listUploads(carol.id, { kind: 'image', limit: 2 });
+    expect(names(page1)).toEqual(names(all.slice(0, 2)));
+
+    const page2 = mod.listUploads(carol.id, {
+      kind: 'image',
+      limit: 2,
+      before: page1[page1.length - 1].id,
+    });
+    expect(names(page2)).toEqual(names(all.slice(2, 4)));
+  });
+
+  it('scopes a filtered query to the asking user', () => {
+    insert(bob.id, { filename: 'vacation.png', mime: 'image/webp' });
+    // Both own a 'vacation.png'; neither sees the other's.
+    expect(mod.listUploads(carol.id, { q: 'vacation' }).length).toBe(1);
+    expect(mod.listUploads(bob.id, { q: 'vacation' }).length).toBe(1);
+    expect(mod.listUploads(bob.id, { q: 'SCREAMING' })).toEqual([]);
+  });
+});
+
 describe('getThumbnail / deleteUpload', () => {
   it('returns thumbnail bytes only for owned rows', () => {
     const id = insert(alice.id);

--- a/server/db/uploadHistory.ts
+++ b/server/db/uploadHistory.ts
@@ -91,28 +91,70 @@ export function insertUpload(userId: number, row: InsertUploadFields): number {
   return Number(info.lastInsertRowid);
 }
 
+// The kinds the uploads browser filters by (#547), and the mime prefix each one
+// means. Derived from `mime` rather than stored: the mime is already the magic-byte
+// truth (contentClass.ts sniffs it), so a separate column would be a second source
+// of it that could disagree.
+export const UPLOAD_KINDS = ['image', 'video', 'audio', 'text'] as const;
+export type UploadKind = (typeof UPLOAD_KINDS)[number];
+
+export function isUploadKind(value: unknown): value is UploadKind {
+  return typeof value === 'string' && (UPLOAD_KINDS as readonly string[]).includes(value);
+}
+
+/**
+ * Escape a user's search term for a SQL LIKE pattern.
+ *
+ * ⚠ Without this, `%` and `_` typed by the user are WILDCARDS, not characters: a
+ * search for "100%" matches every filename containing "100", and a lone "_" matches
+ * everything. `\` must go first, or it would escape the escapes we just added.
+ */
+function likeTerm(term: string): string {
+  return `%${term.replace(/[\\%_]/g, (c) => `\\${c}`)}%`;
+}
+
 export function listUploads(
   userId: number,
-  { before = null, limit = 50 }: { before?: number | null; limit?: number } = {},
+  {
+    before = null,
+    limit = 50,
+    q = null,
+    kind = null,
+  }: {
+    before?: number | null;
+    limit?: number;
+    // Substring match on filename. Not ranked retrieval — this is "find the file I
+    // named", so LIKE beats reaching for FTS5 at a few thousand rows per user.
+    q?: string | null;
+    kind?: UploadKind | null;
+  } = {},
 ): UploadListRow[] {
   const lim = Math.max(1, Math.min(200, Number(limit) || 50));
+
+  // Composed rather than branched: before × q × kind is 8 combinations, and the
+  // previous copy-paste of the whole SELECT for one optional cursor was already the
+  // start of that. Keyset pagination survives every filter — the cursor is still
+  // `id < before` with a DESC scan, never OFFSET.
+  const where = ['user_id = ?'];
+  const params: (string | number)[] = [userId];
+
+  if (before) {
+    where.push('id < ?');
+    params.push(Number(before));
+  }
+  if (q) {
+    where.push("filename LIKE ? ESCAPE '\\'");
+    params.push(likeTerm(q));
+  }
+  if (kind) {
+    where.push('mime LIKE ?');
+    // No ESCAPE needed: `kind` is validated against UPLOAD_KINDS, so it can't carry
+    // a wildcard. The trailing % is ours and deliberate.
+    params.push(`${kind}/%`);
+  }
+
   // `has_thumbnail` lets the API decide whether to advertise a thumbnail_url
   // without ever shipping the (potentially large) blob in the list response.
-  if (before) {
-    return db
-      .prepare(
-        `
-      SELECT id, provider, url, filename, mime, byte_size, width, height, created_at,
-             thumbnail_url, removed, uploader_config_id,
-             (thumbnail IS NOT NULL) AS has_thumbnail, (ref IS NOT NULL) AS has_ref
-      FROM upload_history
-      WHERE user_id = ? AND id < ?
-      ORDER BY id DESC
-      LIMIT ?
-    `,
-      )
-      .all(userId, Number(before), lim) as UploadListRow[];
-  }
   return db
     .prepare(
       `
@@ -120,12 +162,12 @@ export function listUploads(
            thumbnail_url, removed, uploader_config_id,
            (thumbnail IS NOT NULL) AS has_thumbnail, (ref IS NOT NULL) AS has_ref
     FROM upload_history
-    WHERE user_id = ?
+    WHERE ${where.join(' AND ')}
     ORDER BY id DESC
     LIMIT ?
   `,
     )
-    .all(userId, lim) as UploadListRow[];
+    .all(...params, lim) as UploadListRow[];
 }
 
 export function getThumbnail(userId: number, id: number): { thumbnail: Buffer | null } | undefined {

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -423,6 +423,58 @@ describe('POST /api/uploads — progress narration', () => {
   // as a second upload.
 });
 
+// #547. The WHERE clauses are exercised in db/uploadHistory.test.ts; this is about the
+// route actually plumbing the query params into them, and refusing to be steered by a
+// kind it doesn't recognize.
+describe('GET /api/uploads — search params', () => {
+  const upload = async (filename: string, contentType: string, body: Buffer) =>
+    agent.post('/api/uploads').attach('image', body, { filename, contentType });
+
+  beforeAll(async () => {
+    await upload('needle-in-haystack.png', 'image/png', smallPng);
+    await upload('unrelated.png', 'image/png', smallPng);
+    await upload('needle.txt', 'text/plain', Buffer.from('hay'));
+  });
+
+  it('filters by filename substring', async () => {
+    const res = await agent.get('/api/uploads?q=needle');
+    expect(res.status).toBe(200);
+    expect(res.body.items.map((i: { filename: string }) => i.filename).toSorted()).toEqual([
+      'needle-in-haystack.png',
+      'needle.txt',
+    ]);
+  });
+
+  it('filters by kind, and combines it with the search', async () => {
+    const res = await agent.get('/api/uploads?q=needle&kind=text');
+    expect(res.body.items.map((i: { filename: string }) => i.filename)).toEqual(['needle.txt']);
+  });
+
+  // Arbitrary user text arrives here. A term with a URL metacharacter has to survive
+  // the trip, and one with a LIKE metacharacter must not become a wildcard.
+  it('handles a search term with special characters', async () => {
+    await upload('100% & done.png', 'image/png', smallPng);
+    const res = await agent.get(`/api/uploads?q=${encodeURIComponent('100% & done')}`);
+    expect(res.body.items.map((i: { filename: string }) => i.filename)).toEqual([
+      '100% & done.png',
+    ]);
+  });
+
+  // A kind we never shipped can only come from a hand-typed URL. Showing everything
+  // beats erroring out of a browse.
+  it('ignores an unknown kind rather than failing', async () => {
+    const res = await agent.get('/api/uploads?kind=malware');
+    expect(res.status).toBe(200);
+    expect(res.body.items.length).toBeGreaterThan(0);
+  });
+
+  it('returns an empty list, not an error, when nothing matches', async () => {
+    const res = await agent.get('/api/uploads?q=zzzz-no-such-file');
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+  });
+});
+
 describe('GET /api/uploads/:id/thumb', () => {
   it('serves thumbnail bytes', async () => {
     const upload = await agent

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -34,6 +34,7 @@ import type { UploadListRow } from '../db/uploadHistory.js';
 import {
   insertUpload,
   listUploads,
+  isUploadKind,
   getThumbnail,
   getUploadForReap,
   deleteUpload,
@@ -528,7 +529,16 @@ function configDeletableCheck(): (configId: number | null) => boolean {
 router.get('/', (req: Request, res: Response) => {
   const before = req.query.before ? Number(req.query.before) : null;
   const limit = req.query.limit ? Number(req.query.limit) : 50;
-  const rows: UploadListRow[] = listUploads(req.user!.id, { before, limit });
+  // Search has to happen HERE, not in the client (#547): the client only holds the
+  // pages it has scrolled through, and the whole point is finding one it hasn't. This
+  // is the exception to the filters-are-client-side default, and the reason is
+  // delivery, not preference.
+  const rawQ = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+  const q = rawQ ? rawQ.slice(0, 200) : null;
+  // An unknown kind is ignored rather than 400'd: it can only come from a client we
+  // shipped, and silently showing everything beats erroring out of a browse.
+  const kind = isUploadKind(req.query.kind) ? req.query.kind : null;
+  const rows: UploadListRow[] = listUploads(req.user!.id, { before, limit, q, kind });
   const configDeletable = configDeletableCheck();
   res.json({
     items: rows.map((r) => {

--- a/server/services/imagePipeline.test.ts
+++ b/server/services/imagePipeline.test.ts
@@ -209,22 +209,22 @@ describe('imagePipeline.optimize', () => {
 });
 
 describe('imagePipeline.thumbnail', () => {
-  it('returns a 128x128 WebP for static input', async () => {
+  it('returns a 256x256 WebP for static input', async () => {
     const buf = await staticPng(400, 200);
     const thumb = await thumbnail(buf);
     const meta = await sharp(thumb).metadata();
     expect(meta.format).toBe('webp');
-    expect(meta.width).toBe(128);
-    expect(meta.height).toBe(128);
+    expect(meta.width).toBe(256);
+    expect(meta.height).toBe(256);
   });
 
-  it('returns a 128x128 WebP for animated input (first frame)', async () => {
+  it('returns a 256x256 WebP for animated input (first frame)', async () => {
     const buf = animatedGif();
     const thumb = await thumbnail(buf);
     const meta = await sharp(thumb).metadata();
     expect(meta.format).toBe('webp');
-    expect(meta.width).toBe(128);
-    expect(meta.height).toBe(128);
+    expect(meta.width).toBe(256);
+    expect(meta.height).toBe(256);
   });
 
   it('keeps alpha, so a transparent image thumbnails without a black backing', async () => {
@@ -239,7 +239,7 @@ describe('imagePipeline.thumbnail', () => {
     const thumb = await thumbnail(await staticPng(400, 200), { format: 'jpeg' });
     const meta = await sharp(thumb).metadata();
     expect(meta.format).toBe('jpeg');
-    expect(meta.width).toBe(128);
+    expect(meta.width).toBe(256);
   });
 });
 

--- a/server/services/imagePipeline.test.ts
+++ b/server/services/imagePipeline.test.ts
@@ -209,22 +209,22 @@ describe('imagePipeline.optimize', () => {
 });
 
 describe('imagePipeline.thumbnail', () => {
-  it('returns a 256x256 WebP for static input', async () => {
+  it('returns a 512x512 WebP for static input', async () => {
     const buf = await staticPng(400, 200);
     const thumb = await thumbnail(buf);
     const meta = await sharp(thumb).metadata();
     expect(meta.format).toBe('webp');
-    expect(meta.width).toBe(256);
-    expect(meta.height).toBe(256);
+    expect(meta.width).toBe(512);
+    expect(meta.height).toBe(512);
   });
 
-  it('returns a 256x256 WebP for animated input (first frame)', async () => {
+  it('returns a 512x512 WebP for animated input (first frame)', async () => {
     const buf = animatedGif();
     const thumb = await thumbnail(buf);
     const meta = await sharp(thumb).metadata();
     expect(meta.format).toBe('webp');
-    expect(meta.width).toBe(256);
-    expect(meta.height).toBe(256);
+    expect(meta.width).toBe(512);
+    expect(meta.height).toBe(512);
   });
 
   it('keeps alpha, so a transparent image thumbnails without a black backing', async () => {
@@ -239,7 +239,7 @@ describe('imagePipeline.thumbnail', () => {
     const thumb = await thumbnail(await staticPng(400, 200), { format: 'jpeg' });
     const meta = await sharp(thumb).metadata();
     expect(meta.format).toBe('jpeg');
-    expect(meta.width).toBe(256);
+    expect(meta.width).toBe(512);
   });
 });
 

--- a/server/services/imagePipeline.ts
+++ b/server/services/imagePipeline.ts
@@ -5,7 +5,16 @@ import fs from 'node:fs';
 import sharp, { type Metadata, type Sharp } from 'sharp';
 import { canScrubInPlace, scrubMetadata } from './metadataScrub.js';
 
-const THUMB_SIZE = 128;
+// 256, not 128: the uploads browser (#547) renders ~128px tiles, and a 128px source
+// in a 128px box is 1x — visibly soft on every retina display. Measured cost of the
+// bump on a real photo, as WebP: 2.3 KB → 4.5 KB. Two kilobytes per upload is not a
+// number worth designing around.
+//
+// ⚠ Only NEW uploads get it. Existing rows keep their 128px thumb and we can't
+// regenerate them — the originals live at the provider, not here — so the gallery is
+// mixed-sharpness until it churns. That's the accepted cost; the alternative was
+// designing the grid around the smaller of the two forever.
+const THUMB_SIZE = 256;
 
 interface FormatInfo {
   mime: string;

--- a/server/services/imagePipeline.ts
+++ b/server/services/imagePipeline.ts
@@ -5,16 +5,19 @@ import fs from 'node:fs';
 import sharp, { type Metadata, type Sharp } from 'sharp';
 import { canScrubInPlace, scrubMetadata } from './metadataScrub.js';
 
-// 256, not 128: the uploads browser (#547) renders ~128px tiles, and a 128px source
-// in a 128px box is 1x — visibly soft on every retina display. Measured cost of the
-// bump on a real photo, as WebP: 2.3 KB → 4.5 KB. Two kilobytes per upload is not a
-// number worth designing around.
+// 512, not 128. The uploads browser (#547) is a gallery you browse BY thumbnail, and
+// at 128px that doesn't work — you squint. Its tiles are ~180px, which is 360 device
+// pixels on a 2x display, so the source has to be at least that to stay crisp; 512
+// covers it with headroom for 3x and for larger tiles later.
 //
-// ⚠ Only NEW uploads get it. Existing rows keep their 128px thumb and we can't
-// regenerate them — the originals live at the provider, not here — so the gallery is
-// mixed-sharpness until it churns. That's the accepted cost; the alternative was
-// designing the grid around the smaller of the two forever.
-const THUMB_SIZE = 256;
+// Measured on a real photo, as WebP: 128px = 2.3 KB, 256px = 4.5 KB, 512px = 9.3 KB.
+// Seven kilobytes per upload is not a number worth designing a UI around.
+//
+// ⚠ Only NEW uploads get it. Existing rows keep the thumb they were made with and we
+// can't regenerate them — the originals live at the provider, not here — so the
+// gallery is mixed-sharpness until it churns. That's the accepted cost; the
+// alternative was designing every tile around the smallest thumb we ever wrote.
+const THUMB_SIZE = 512;
 
 interface FormatInfo {
   mime: string;

--- a/vue_client/src/components/ImageViewerModal.vue
+++ b/vue_client/src/components/ImageViewerModal.vue
@@ -13,8 +13,16 @@
     aria-label="Image viewer"
     @click.self="$emit('close')"
     @keydown.esc="$emit('close')"
+    @keydown.left.prevent="$emit('prev')"
+    @keydown.right.prevent="$emit('next')"
   >
     <div class="topbar">
+      <!-- What you're looking at, and where you are in the set. Only meaningful for a
+           gallery; a single image is a gallery of one and shows neither. -->
+      <div class="caption">
+        <span v-if="filename" class="caption-name" :title="filename">{{ filename }}</span>
+        <span v-if="count > 1" class="caption-count">{{ index + 1 }} / {{ count }}</span>
+      </div>
       <div class="controls">
         <button
           class="control"
@@ -46,6 +54,30 @@
         </button>
       </div>
     </div>
+
+    <!-- Siblings of the stage, not children of it: the stage owns pan/zoom pointer
+         handling, and an arrow inside it would have to fight that for its own clicks.
+         Rendered only when there is somewhere to go, so a gallery of one shows none. -->
+    <button
+      v-if="hasPrev"
+      class="nav nav-prev"
+      type="button"
+      title="previous"
+      aria-label="previous image"
+      @click.stop="$emit('prev')"
+    >
+      <i class="fa-solid fa-chevron-left"></i>
+    </button>
+    <button
+      v-if="hasNext"
+      class="nav nav-next"
+      type="button"
+      title="next"
+      aria-label="next image"
+      @click.stop="$emit('next')"
+    >
+      <i class="fa-solid fa-chevron-right"></i>
+    </button>
 
     <div ref="stageEl" class="stage" @click.self="$emit('close')">
       <div v-if="failed" class="failed-card">
@@ -98,11 +130,21 @@ const FILL_FALLBACK_ZOOM = 2;
 const DOUBLE_TAP_MS = 300;
 const DOUBLE_TAP_SLOP_PX = 32;
 
-const props = defineProps<{
-  url: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    url: string;
+    // Gallery context (#547). All optional: a lone image opened from a message is a
+    // gallery of one, and every one of these falls away to its single-image default.
+    filename?: string | null;
+    index?: number;
+    count?: number;
+    hasPrev?: boolean;
+    hasNext?: boolean;
+  }>(),
+  { filename: null, index: 0, count: 1, hasPrev: false, hasNext: false },
+);
 
-const emit = defineEmits<{ close: [] }>();
+const emit = defineEmits<{ close: []; prev: []; next: [] }>();
 
 const loading = ref(true);
 const failed = ref(false);
@@ -594,6 +636,57 @@ onBeforeUnmount(() => {
   padding-top: env(safe-area-inset-top);
   padding-right: env(safe-area-inset-right);
   z-index: 1;
+}
+
+/* margin-right:auto rather than space-between on .topbar: with no caption (the
+   single-image case) the controls must stay hard right, and space-between with one
+   child already does that — but the moment a caption exists it would push the controls
+   without this, and the caption itself needs to be the thing that flexes. */
+.caption {
+  margin-right: auto;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+  padding-left: var(--space-2);
+  color: var(--fg-muted);
+}
+.caption-name {
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.caption-count {
+  white-space: nowrap;
+}
+
+/* Vertically centred against the whole overlay, not the stage: the stage letterboxes
+   the image, so anchoring to it would move the arrows as the aspect ratio changed
+   from one photo to the next. */
+.nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.45);
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--icon-lg);
+  /* A generous hit area — this is the control you use repeatedly, and on a phone it
+     has to be reachable with a thumb without covering the picture. */
+  padding: var(--space-6) var(--space-5);
+}
+.nav:hover {
+  color: var(--fg);
+}
+.nav-prev {
+  left: var(--space-4);
+}
+.nav-next {
+  right: var(--space-4);
 }
 .controls {
   display: flex;

--- a/vue_client/src/components/ImageViewerModal.vue
+++ b/vue_client/src/components/ImageViewerModal.vue
@@ -34,6 +34,19 @@
         >
           <i :class="zoomIconClass"></i>
         </button>
+        <!-- Copying the link is what you usually want from an image someone posted —
+             to reply with it, or to send it on. It was previously only reachable by
+             closing the viewer and finding the URL again. -->
+        <button
+          class="control"
+          type="button"
+          :class="{ copied: clipboard.isCopied() }"
+          :title="clipboard.isCopied() ? 'copied' : 'copy link'"
+          :aria-label="clipboard.isCopied() ? 'copied' : 'copy link'"
+          @click="onCopyLink"
+        >
+          <i :class="clipboard.isCopied() ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
+        </button>
         <button
           class="control"
           type="button"
@@ -119,6 +132,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useCopyFeedback } from '../composables/useCopyFeedback.js';
 
 const LOAD_TIMEOUT_MS = 20_000;
 const MIN_ZOOM = 1;
@@ -145,6 +159,8 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{ close: []; prev: []; next: [] }>();
+
+const clipboard = useCopyFeedback();
 
 const loading = ref(true);
 const failed = ref(false);
@@ -203,7 +219,12 @@ const imageStyle = computed(() => ({
 
 watch(
   () => props.url,
-  (nextUrl) => startLoading(nextUrl),
+  (nextUrl) => {
+    startLoading(nextUrl);
+    // Arrowing to the next image while the tick is still showing would leave a green
+    // check sitting over a link the user has NOT copied.
+    clipboard.reset();
+  },
 );
 
 function onLoad(): void {
@@ -247,6 +268,13 @@ function onLoadTimeout(): void {
 function openInBrowser(): void {
   window.open(props.url, '_blank', 'noopener,noreferrer');
   emit('close');
+}
+
+// Deliberately does NOT close the viewer, unlike openInBrowser: copying a link is
+// something you do while still looking at the picture, and often while walking a
+// gallery. Closing would make copying two images in a row a chore.
+function onCopyLink(): void {
+  void clipboard.copy(props.url);
 }
 
 function toggleZoomFromCenter(): void {
@@ -703,6 +731,10 @@ onBeforeUnmount(() => {
      weight 900). */
   font-size: var(--icon-lg);
   padding: var(--space-2) var(--space-4);
+}
+.control.copied,
+.control.copied:hover:not(:disabled) {
+  color: var(--good);
 }
 .control:hover:not(:disabled) {
   color: var(--accent);

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -162,6 +162,7 @@ import { useHighlightRulesStore, type HighlightRule } from '../stores/highlightR
 import { parseIgnoreArgs } from '../../../shared/parseIgnore.js';
 import { parseHighlightArgs } from '../../../shared/parseHighlight.js';
 import { highlightRuleDetailParts } from '../utils/highlightFormat.js';
+import { joinMeta } from '../utils/metaLine.js';
 import { ACCEPTED_FILE_TYPES, isUploadableType } from '../utils/uploaders.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChanlistStore } from '../stores/chanlist.js';
@@ -2065,7 +2066,7 @@ function formatIgnoreEntry(entry: IgnoreEntry, idx: number, global = false): str
   return `  ${idx}. ${summarizeIgnoreEntry(entry, global)}`;
 }
 
-// "QUACK! · whole word · #chan" — a highlight rule's dimensions, no index. The
+// "QUACK! • whole word • #chan" — a highlight rule's dimensions, no index. The
 // subject (mask/pattern) and scope are framed here; the secondary descriptors
 // come from the shared formatter the settings pane also uses.
 function summarizeHighlightEntry(entry: HighlightRule, global = false): string {
@@ -2073,7 +2074,7 @@ function summarizeHighlightEntry(entry: HighlightRule, global = false): string {
   const parts = [subject];
   if (global) parts.push('global');
   parts.push(...highlightRuleDetailParts(entry));
-  return parts.join(' · ');
+  return joinMeta(parts);
 }
 
 // One indexed line for the /highlight listing.

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -76,6 +76,17 @@
             </div>
           </a>
 
+          <div class="name" :title="u.filename || u.url">{{ u.filename || '(pasted)' }}</div>
+          <div class="sub" :title="metaLine(u)">
+            {{ u.removed ? 'Removed by moderation' : metaLine(u) }}
+          </div>
+
+          <!-- Last in the DOM on purpose. On a pointer device these are absolutely
+               positioned over the art and revealed on hover, and absolute positioning
+               doesn't care about source order — but on touch there IS no hover, so they
+               fall back into normal flow and land where they belong: a row beneath the
+               file, not two small chips sitting on top of the picture you're trying to
+               tap. See the @media rules below. -->
           <div class="actions">
             <!-- Delete destroys the stored file. Offered only where that's true
                  (can_delete) — there is no remove-the-record-only action. -->
@@ -102,11 +113,6 @@
             >
               <i :class="clipboard.isCopied(u.id) ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
             </button>
-          </div>
-
-          <div class="name" :title="u.filename || u.url">{{ u.filename || '(pasted)' }}</div>
-          <div class="sub" :title="metaLine(u)">
-            {{ u.removed ? 'Removed by moderation' : metaLine(u) }}
           </div>
         </li>
       </ul>
@@ -491,34 +497,62 @@ function metaLine(u: UploadRow): string {
    revealed on hover where hover exists, and always visible where it doesn't — the
    :hover here is auto-wrapped in @media (hover: hover) at build time (#115), so on a
    touch device the base rule stands and the buttons are simply always there. */
+/* ─── Tile actions ───────────────────────────────────────────────────────────
+   TOUCH IS THE BASE CASE, hover is the enhancement — which is the only way round
+   that works here. There is no hover on a phone, so an overlay revealed by hover
+   would either be permanently on top of the picture or unreachable; and a chip small
+   enough to sit unobtrusively on a thumbnail is far too small to tap.
+
+   So on touch the buttons live in normal flow, in a row under the file, with real
+   44px targets. On a pointer device they lift out of the flow onto the artwork and
+   fade in on hover, where a compact chip is exactly right and the vertical space is
+   worth reclaiming. */
 .actions {
-  position: absolute;
-  top: var(--space-2);
-  right: var(--space-2);
   display: flex;
-  gap: var(--space-1);
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
 }
 /* A solid themed chip, NOT a scrim: --scrim is a dark translucent, so in the light
-   theme a --fg icon on it would be dark-on-dark. The art behind is arbitrary user
-   imagery, so the button has to bring its own background either way. */
+   theme a --fg icon on it would be dark-on-dark. On a pointer device this sits on
+   arbitrary user imagery, so the button has to bring its own background either way. */
 .act {
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  padding: var(--space-2) var(--space-3);
   font-size: var(--icon-md);
   line-height: 1;
+  /* The iOS minimum. A 26px chip is hittable with a mouse and a coin toss with a
+     thumb — and the thing next to it deletes the file. */
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
+
 @media (hover: hover) {
   .actions {
+    position: absolute;
+    top: var(--space-2);
+    right: var(--space-2);
+    margin-top: 0;
+    gap: var(--space-1);
     opacity: 0;
     transition: opacity 0.12s ease;
   }
+  /* focus-within, not just hover: these are the only way to reach copy/delete on a
+     pointer device, so they have to be reachable by keyboard too. */
   .tile:hover .actions,
   .tile:focus-within .actions {
     opacity: 1;
+  }
+  .act {
+    min-width: 0;
+    min-height: 0;
+    padding: var(--space-2) var(--space-3);
   }
 }
 .act:hover {

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -354,10 +354,17 @@ function metaLine(u: UploadRow): string {
   transform: translateY(-50%);
   color: var(--fg-muted);
   pointer-events: none;
+  /* Pin the glyph to a known box. Font Awesome glyph widths vary per icon, so without
+     this the input's padding below would be guessing at where the icon ends. */
+  width: 1em;
+  text-align: center;
 }
 .search-input {
   width: 100%;
-  padding: var(--space-3) var(--space-3) var(--space-3) var(--space-8);
+  /* Left padding is derived, not picked: where the icon starts, plus the icon's own
+     width, plus one character of breathing room. A flat --space-8 (20px) landed the
+     text hard against the glyph. */
+  padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--space-3) + 1em + 1ch);
   background: var(--bg-soft);
   border: 1px solid var(--border);
   color: var(--fg);

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -95,12 +95,12 @@
             <button
               v-if="!u.removed"
               class="act copy"
-              :class="{ copied: copiedId === u.id }"
+              :class="{ copied: clipboard.isCopied(u.id) }"
               @click="onCopy(u)"
-              :title="copiedId === u.id ? 'copied' : 'copy URL'"
-              :aria-label="copiedId === u.id ? 'copied' : 'copy URL'"
+              :title="clipboard.isCopied(u.id) ? 'copied' : 'copy link'"
+              :aria-label="clipboard.isCopied(u.id) ? 'copied' : 'copy link'"
             >
-              <i :class="copiedId === u.id ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
+              <i :class="clipboard.isCopied(u.id) ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
             </button>
           </div>
 
@@ -131,6 +131,7 @@ import AppModal from './AppModal.vue';
 import { useUploadsStore } from '../stores/uploads.js';
 import type { UploadItem, UploadKind } from '../stores/uploads.js';
 import { useImageModal } from '../composables/useImageModal.js';
+import { useCopyFeedback } from '../composables/useCopyFeedback.js';
 import { formatRelative } from '../utils/timestamp.js';
 import { iconForMime } from '../utils/uploaders.js';
 
@@ -165,7 +166,7 @@ const imageModal = useImageModal();
 const recentRows = computed(() => uploads.recent as UploadRow[]);
 const listEl = ref<HTMLDivElement | null>(null);
 const searchEl = ref<HTMLInputElement | null>(null);
-const copiedId = ref<number | null>(null);
+const clipboard = useCopyFeedback();
 const deletingId = ref<number | null>(null);
 const deleteError = ref('');
 
@@ -289,17 +290,10 @@ function onScroll() {
   }
 }
 
-async function onCopy(u: UploadRow) {
-  try {
-    await navigator.clipboard.writeText(u.url);
-    copiedId.value = u.id;
-    setTimeout(() => {
-      if (copiedId.value === u.id) copiedId.value = null;
-    }, 1500);
-  } catch (_) {
-    // Clipboard API can fail without a user-gesture context on Firefox/Safari;
-    // the user can fall back to opening the file and copying the address.
-  }
+// The `key` is why useCopyFeedback takes one: one instance serves the whole grid, and
+// only the tile that was copied ticks.
+function onCopy(u: UploadRow) {
+  void clipboard.copy(u.url, u.id);
 }
 
 async function onDelete(u: UploadRow) {

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -334,13 +334,16 @@ function metaLine(u: UploadRow): string {
 </script>
 
 <style scoped>
+/* Matches .search-row in HighlightsModal / SearchModal: a margin, not a rule. Those
+   two are the house pattern for "a filter field above a scrolling list", and this
+   modal is the same shape — an extra border here just made it look like a different
+   app. */
 .filters {
   display: flex;
   gap: var(--space-4);
   align-items: center;
   flex-wrap: wrap;
-  padding-bottom: var(--space-4);
-  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-6);
 }
 .search {
   position: relative;
@@ -363,12 +366,14 @@ function metaLine(u: UploadRow): string {
   width: 1em;
   text-align: center;
 }
+/* The same field as .filter in HighlightsModal / SearchModal — background, border and
+   padding all match. Only the LEFT padding differs, because ours has an icon in it. */
 .search-input {
   width: 100%;
   /* Left padding is derived, not picked: where the icon starts, plus the icon's own
      width, plus one character of breathing room. */
-  padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--search-icon-inset) + 1em + 1ch);
-  background: var(--bg-soft);
+  padding: var(--space-4) var(--space-5) var(--space-4) calc(var(--search-icon-inset) + 1em + 1ch);
+  background: var(--bg);
   border: 1px solid var(--border);
   color: var(--fg);
   font: inherit;
@@ -411,9 +416,11 @@ function metaLine(u: UploadRow): string {
 
 .grid-wrap {
   /* Break out of card padding so the scrollbar sits against the card border;
-     padding keeps tile content visually aligned with the rest. */
+     padding keeps tile content visually aligned with the rest. Same as .match-list in
+     HighlightsModal — the gap above comes from the filter row's margin, not from a
+     padding here, so the two don't stack. */
   margin: 0 calc(-1 * var(--card-pad-x));
-  padding: var(--space-4) var(--card-pad-x) 0;
+  padding: 0 var(--card-pad-x);
   overflow-y: auto;
   flex: 1;
   min-height: 0;

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -322,12 +322,13 @@ function formatBytes(n: number) {
 
 // Built in JS so the " · " separators keep their spaces — Vue's whitespace condensing
 // strips the gaps between adjacent inline spans.
+//
+// Deliberately does NOT name the uploader. Which backend a file happened to land on is
+// the app's business, not the user's: it doesn't help you recognise a picture, and it
+// isn't actionable from here. When it matters — the file is gone, or can't be deleted
+// — that surfaces as its own state, not as a label on every tile.
 function metaLine(u: UploadRow): string {
-  return [
-    u.created_at && formatRelative(u.created_at),
-    u.byte_size && formatBytes(u.byte_size),
-    u.provider,
-  ]
+  return [u.created_at && formatRelative(u.created_at), u.byte_size && formatBytes(u.byte_size)]
     .filter(Boolean)
     .join(' · ');
 }

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -133,6 +133,7 @@ import type { UploadItem, UploadKind } from '../stores/uploads.js';
 import { useImageModal } from '../composables/useImageModal.js';
 import { useCopyFeedback } from '../composables/useCopyFeedback.js';
 import { formatRelative } from '../utils/timestamp.js';
+import { joinMeta } from '../utils/metaLine.js';
 import { iconForMime } from '../utils/uploaders.js';
 
 // The server response can include extra metadata fields not tracked in the
@@ -320,17 +321,15 @@ function formatBytes(n: number) {
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-// Built in JS so the " · " separators keep their spaces — Vue's whitespace condensing
-// strips the gaps between adjacent inline spans.
-//
 // Deliberately does NOT name the uploader. Which backend a file happened to land on is
 // the app's business, not the user's: it doesn't help you recognise a picture, and it
 // isn't actionable from here. When it matters — the file is gone, or can't be deleted
 // — that surfaces as its own state, not as a label on every tile.
 function metaLine(u: UploadRow): string {
-  return [u.created_at && formatRelative(u.created_at), u.byte_size && formatBytes(u.byte_size)]
-    .filter(Boolean)
-    .join(' · ');
+  return joinMeta([
+    u.created_at && formatRelative(u.created_at),
+    u.byte_size && formatBytes(u.byte_size),
+  ]);
 }
 </script>
 

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -1,19 +1,60 @@
 <!--
   Copyright (c) 2026 Brad Root
   SPDX-License-Identifier: MPL-2.0
+
+  The uploads browser (#547). It used to be a single-column list of thumbnails with
+  an infinite-scroll cursor: fine for "the thing I just uploaded", useless for "that
+  screenshot from March", which is the case that actually needs a browser.
+
+  Two changes make that case work. SEARCH, which is server-side — unlike almost every
+  other filter in Lurker, this one cannot be a render-time filter over what the client
+  holds, because the client only holds the pages it has scrolled through and the whole
+  point is finding one it hasn't. And a GRID, so the eye can scan instead of squint.
+
+  Media and text uploads have no thumbnail (no ffmpeg, so no video poster frames —
+  #515), so they get a type-icon tile in the same box rather than a different layout.
+  A file card that happens to show an icon reads as a peer of one that shows a photo;
+  a separate list of them would not.
 -->
 
 <template>
-  <AppModal word="uploads" title="recent uploads" size="xl" fill-height @close="$emit('close')">
+  <AppModal word="uploads" title="uploads" size="xl" fill-height @close="$emit('close')">
+    <div class="filters">
+      <div class="search">
+        <i class="fa-solid fa-magnifying-glass search-icon"></i>
+        <input
+          ref="searchEl"
+          v-model="query"
+          type="search"
+          class="search-input"
+          placeholder="Search filenames…"
+          aria-label="Search uploads by filename"
+          @keydown.esc.stop="onEscape"
+        />
+      </div>
+      <div class="kinds" role="group" aria-label="Filter by type">
+        <button
+          v-for="k in KIND_CHIPS"
+          :key="k.value ?? 'all'"
+          class="chip"
+          :class="{ active: uploads.kind === k.value }"
+          :aria-pressed="uploads.kind === k.value"
+          @click="onKind(k.value)"
+        >
+          {{ k.label }}
+        </button>
+      </div>
+    </div>
+
     <p v-if="uploads.listError" class="error">{{ uploads.listError }}</p>
     <p v-if="deleteError" class="error">{{ deleteError }}</p>
 
-    <div ref="listEl" class="list-wrap" @scroll="onScroll">
-      <ul v-if="recentRows.length" class="list">
-        <li v-for="u in recentRows" :key="u.id" class="row" :class="{ removed: u.removed }">
+    <div ref="listEl" class="grid-wrap" @scroll="onScroll">
+      <ul v-if="recentRows.length" class="grid">
+        <li v-for="u in recentRows" :key="u.id" class="tile" :class="{ removed: u.removed }">
           <!-- Moderated-away upload: the object is gone, so show a tombstone
                instead of a link to a dead URL. -->
-          <div v-if="u.removed" class="thumb thumb-placeholder" title="removed by moderation">
+          <div v-if="u.removed" class="art art-icon" title="removed by moderation">
             <i class="fa-solid fa-gavel fa-2x"></i>
           </div>
           <a
@@ -21,32 +62,21 @@
             :href="u.url"
             target="_blank"
             rel="noreferrer noopener"
-            class="thumb-link"
+            class="art-link"
             :title="u.url"
           >
-            <img
-              v-if="u.thumbnail_url"
-              :src="u.thumbnail_url"
-              class="thumb"
-              alt=""
-              loading="lazy"
-            />
-            <div v-else class="thumb thumb-placeholder">
+            <img v-if="u.thumbnail_url" :src="u.thumbnail_url" class="art" alt="" loading="lazy" />
+            <div v-else class="art art-icon">
               <i class="fa-solid fa-2x" :class="iconForMime(u.mime)"></i>
             </div>
           </a>
-          <div class="meta">
-            <div class="filename" :title="u.filename || ''">{{ u.filename || '(pasted)' }}</div>
-            <div v-if="u.removed" class="url removed-note">Removed by moderation</div>
-            <div v-else class="url" :title="u.url">{{ u.url }}</div>
-            <div class="sub">{{ metaLine(u) }}</div>
-          </div>
-          <div class="row-actions">
+
+          <div class="actions">
             <!-- Delete destroys the stored file. Offered only where that's true
                  (can_delete) — there is no remove-the-record-only action. -->
             <button
               v-if="!u.removed && u.can_delete"
-              class="link delete"
+              class="act delete"
               :disabled="deletingId !== null"
               @click="onDelete(u)"
               title="delete file"
@@ -59,7 +89,7 @@
             <!-- A removed upload's URL is dead, so there's nothing to copy. -->
             <button
               v-if="!u.removed"
-              class="link copy"
+              class="act copy"
               :class="{ copied: copiedId === u.id }"
               @click="onCopy(u)"
               :title="copiedId === u.id ? 'copied' : 'copy URL'"
@@ -68,22 +98,33 @@
               <i :class="copiedId === u.id ? 'fa-solid fa-check' : 'fa-regular fa-copy'"></i>
             </button>
           </div>
+
+          <div class="name" :title="u.filename || u.url">{{ u.filename || '(pasted)' }}</div>
+          <div class="sub" :title="metaLine(u)">
+            {{ u.removed ? 'Removed by moderation' : metaLine(u) }}
+          </div>
         </li>
       </ul>
+
       <p v-else-if="uploads.loading && !uploads.loaded" class="empty">Loading…</p>
+      <p v-else-if="uploads.loaded && isFiltered" class="empty">
+        Nothing matches {{ filterDescription }}.
+      </p>
       <p v-else-if="uploads.loaded" class="empty">
         No uploads yet. Paste, drop, or pick a file in the input.
       </p>
-      <p v-if="uploads.loading && uploads.loaded" class="empty small">Loading more…</p>
+      <p v-if="uploads.loading && uploads.loaded && recentRows.length" class="empty small">
+        Loading more…
+      </p>
     </div>
   </AppModal>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue';
 import AppModal from './AppModal.vue';
 import { useUploadsStore } from '../stores/uploads.js';
-import type { UploadItem } from '../stores/uploads.js';
+import type { UploadItem, UploadKind } from '../stores/uploads.js';
 import { formatRelative } from '../utils/timestamp.js';
 import { iconForMime } from '../utils/uploaders.js';
 
@@ -96,28 +137,90 @@ interface UploadRow extends UploadItem {
   height?: number;
 }
 
+const KIND_CHIPS: Array<{ label: string; value: UploadKind | null }> = [
+  { label: 'All', value: null },
+  { label: 'Images', value: 'image' },
+  { label: 'Video', value: 'video' },
+  { label: 'Audio', value: 'audio' },
+  { label: 'Text', value: 'text' },
+];
+
+// Long enough that a typed word is one request rather than eight, short enough that
+// the grid still feels like it's responding to you.
+const SEARCH_DEBOUNCE_MS = 250;
+
 defineEmits<{
   close: [];
 }>();
 const uploads = useUploadsStore();
-// Cast the store's UploadItem[] to UploadRow[] so the template can access
-// the server-supplied extra fields (created_at, byte_size, width, height).
 const recentRows = computed(() => uploads.recent as UploadRow[]);
 const listEl = ref<HTMLDivElement | null>(null);
+const searchEl = ref<HTMLInputElement | null>(null);
 const copiedId = ref<number | null>(null);
 const deletingId = ref<number | null>(null);
 const deleteError = ref('');
 
+// Local, so typing is never gated on a round trip; pushed to the store (and thus the
+// server) on a debounce.
+const query = ref(uploads.query);
+let debounce: ReturnType<typeof setTimeout> | null = null;
+
+const isFiltered = computed(() => Boolean(uploads.query || uploads.kind));
+const filterDescription = computed(() => {
+  const kindLabel = KIND_CHIPS.find((k) => k.value === uploads.kind)?.label.toLowerCase();
+  if (uploads.query && uploads.kind) return `“${uploads.query}” in ${kindLabel}`;
+  if (uploads.query) return `“${uploads.query}”`;
+  return kindLabel ?? 'that filter';
+});
+
+watch(query, (next) => {
+  if (debounce) clearTimeout(debounce);
+  debounce = setTimeout(() => {
+    // Trim here rather than in the input: leading/trailing spaces are almost always
+    // an accident of typing, and a search for " " should not be a search.
+    void uploads.setFilters({ query: next.trim() }).catch(() => {
+      /* surfaced via store.listError */
+    });
+  }, SEARCH_DEBOUNCE_MS);
+});
+
 onMounted(() => {
-  uploads.loadRecent().catch(() => {
+  // Reset the filters on open. A search left over from a previous session would look
+  // like an empty uploads list — the worst possible first impression of the browser.
+  void uploads.setFilters({ query: '', kind: null }).catch(() => {
     /* surfaced via store.listError */
   });
+  query.value = '';
+  searchEl.value?.focus();
 });
+
+onBeforeUnmount(() => {
+  if (debounce) clearTimeout(debounce);
+});
+
+// Escape clears a non-empty search instead of closing the modal — the same convention
+// as a browser find bar. With the field already empty it falls through to the modal's
+// own close handler, so Escape still means "get me out of here" when there's nothing
+// to clear.
+function onEscape(event: KeyboardEvent) {
+  if (!query.value) {
+    (event.target as HTMLElement).blur();
+    return;
+  }
+  query.value = '';
+}
+
+function onKind(kind: UploadKind | null) {
+  if (uploads.kind === kind) return;
+  void uploads.setFilters({ kind }).catch(() => {
+    /* surfaced via store.listError */
+  });
+}
 
 function onScroll() {
   const el = listEl.value;
   if (!el || !uploads.hasMore || uploads.loading) return;
-  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 80) {
+  if (el.scrollTop + el.clientHeight >= el.scrollHeight - 160) {
     uploads.loadMore();
   }
 }
@@ -131,7 +234,7 @@ async function onCopy(u: UploadRow) {
     }, 1500);
   } catch (_) {
     // Clipboard API can fail without a user-gesture context on Firefox/Safari;
-    // the user can fall back to right-click-copy on the URL text.
+    // the user can fall back to opening the file and copying the address.
   }
 }
 
@@ -159,14 +262,13 @@ function formatBytes(n: number) {
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-// Build the metadata sub-line in JS so the " · " separators keep their spaces —
-// Vue's whitespace condensing strips the gaps between adjacent inline spans.
+// Built in JS so the " · " separators keep their spaces — Vue's whitespace condensing
+// strips the gaps between adjacent inline spans.
 function metaLine(u: UploadRow): string {
   return [
-    u.provider,
     u.created_at && formatRelative(u.created_at),
     u.byte_size && formatBytes(u.byte_size),
-    u.width && u.height && `${u.width}×${u.height}`,
+    u.provider,
   ]
     .filter(Boolean)
     .join(' · ');
@@ -174,120 +276,183 @@ function metaLine(u: UploadRow): string {
 </script>
 
 <style scoped>
-.link {
+.filters {
+  display: flex;
+  gap: var(--space-4);
+  align-items: center;
+  flex-wrap: wrap;
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+.search {
+  position: relative;
+  flex: 1;
+  min-width: 200px;
+}
+.search-icon {
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--fg-muted);
+  pointer-events: none;
+}
+.search-input {
+  width: 100%;
+  padding: var(--space-3) var(--space-3) var(--space-3) var(--space-8);
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  font: inherit;
+}
+.search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+/* Safari draws its own clear affordance on type=search; ours is Escape. */
+.search-input::-webkit-search-decoration,
+.search-input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+.kinds {
+  display: flex;
+  gap: var(--space-2);
+}
+.chip {
   background: none;
-  border: none;
-  color: var(--accent);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
   cursor: pointer;
   font: inherit;
-  padding: 0 var(--space-2);
+  padding: var(--space-3) var(--space-4);
 }
-.link:hover {
+.chip:hover {
   color: var(--fg);
+}
+.chip.active {
+  color: var(--fg);
+  border-color: var(--accent);
+  background: var(--bg-soft);
 }
 
 .error {
-  margin: 0 0 var(--space-4);
-  padding: var(--space-4) 0;
+  margin: var(--space-4) 0 0;
   color: var(--bad);
-  border-bottom: 1px solid var(--border);
 }
 
-.list-wrap {
-  /* Break out of card padding so the scrollbar sits against the card
-     border; padding keeps row content visually aligned with the rest. */
+.grid-wrap {
+  /* Break out of card padding so the scrollbar sits against the card border;
+     padding keeps tile content visually aligned with the rest. */
   margin: 0 calc(-1 * var(--card-pad-x));
-  padding: 0 var(--card-pad-x);
+  padding: var(--space-4) var(--card-pad-x) 0;
   overflow-y: auto;
   flex: 1;
   min-height: 0;
 }
-.list {
+.grid {
   list-style: none;
   margin: 0;
   padding: 0;
-}
-.row {
   display: grid;
-  grid-template-columns: 80px 1fr max-content;
-  /* Tight column-gap so the thumb hugs the meta text. The meta→actions
-     edge gets its own breathing room via margin-left on .row-actions. */
-  column-gap: var(--space-2);
-  row-gap: var(--space-4);
-  align-items: center;
-  /* Roomy padding-bottom above the separator plus a margin below it to space the
-     rows well apart, matching HistoryMessageRow. */
-  padding: var(--space-4) 0 var(--space-8);
-  border-bottom: 1px solid var(--border);
-  margin-bottom: var(--space-4);
+  /* auto-fill, not auto-fit: a search that returns two results should leave them at
+     tile size on the left, not stretch them across the whole modal. */
+  grid-template-columns: repeat(auto-fill, minmax(128px, 1fr));
+  gap: var(--space-6);
 }
-.thumb-link {
+.tile {
+  position: relative;
+  min-width: 0;
+}
+.art-link {
   display: block;
   line-height: 0;
 }
-.thumb {
-  width: 64px;
-  height: 64px;
+.art {
+  width: 100%;
+  /* Square, so a portrait screenshot and a landscape one tile the same. The server
+     thumbnail is a centre cover-crop, so this matches its own geometry. */
+  aspect-ratio: 1;
   object-fit: cover;
   background: var(--bg-soft);
   border: 1px solid var(--border);
 }
-.thumb-placeholder {
+.art-icon {
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--fg-muted);
 }
-.meta {
-  min-width: 0;
+.tile.removed .art {
+  border-style: dashed;
 }
-.filename {
+
+.name {
   color: var(--fg);
+  margin-top: var(--space-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-.url {
-  color: var(--fg-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.removed-note {
-  color: var(--bad);
-}
-.row.removed .filename {
-  color: var(--fg-muted);
 }
 .sub {
   color: var(--fg-muted);
-  margin-top: var(--space-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.row-actions {
+.tile.removed .name {
+  color: var(--fg-muted);
+}
+.tile.removed .sub {
+  color: var(--bad);
+}
+
+/* Actions sit on the art rather than below it: at tile density a permanent button row
+   under every file would cost more vertical space than the filename does. They are
+   revealed on hover where hover exists, and always visible where it doesn't — the
+   :hover here is auto-wrapped in @media (hover: hover) at build time (#115), so on a
+   touch device the base rule stands and the buttons are simply always there. */
+.actions {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
   display: flex;
-  gap: var(--space-4);
-  align-items: center;
-  margin-left: var(--space-6);
+  gap: var(--space-1);
 }
-/* Two icon actions at most (copy + delete) — they fit the actions column on
-   every width, no separate mobile bar needed. Padding gives each a comfortable
-   tap target. */
-.copy,
-.delete {
-  padding: var(--space-3) var(--space-4);
+/* A solid themed chip, NOT a scrim: --scrim is a dark translucent, so in the light
+   theme a --fg icon on it would be dark-on-dark. The art behind is arbitrary user
+   imagery, so the button has to bring its own background either way. */
+.act {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  cursor: pointer;
+  font: inherit;
+  padding: var(--space-2) var(--space-3);
   font-size: var(--icon-md);
+  line-height: 1;
+}
+@media (hover: hover) {
+  .actions {
+    opacity: 0;
+    transition: opacity 0.12s ease;
+  }
+  .tile:hover .actions,
+  .tile:focus-within .actions {
+    opacity: 1;
+  }
+}
+.act:hover {
+  color: var(--fg);
 }
 .delete:hover {
   color: var(--bad);
 }
-.delete:disabled {
+.act:disabled {
   color: var(--fg-muted);
   cursor: default;
 }
 .copy.copied {
-  color: var(--good);
-}
-.copy.copied:hover {
   color: var(--good);
 }
 
@@ -298,6 +463,5 @@ function metaLine(u: UploadRow): string {
 }
 .empty.small {
   padding: var(--space-4) 0;
-  color: var(--fg-muted);
 }
 </style>

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -81,12 +81,10 @@
             {{ u.removed ? 'Removed by moderation' : metaLine(u) }}
           </div>
 
-          <!-- Last in the DOM on purpose. On a pointer device these are absolutely
-               positioned over the art and revealed on hover, and absolute positioning
-               doesn't care about source order — but on touch there IS no hover, so they
-               fall back into normal flow and land where they belong: a row beneath the
-               file, not two small chips sitting on top of the picture you're trying to
-               tap. See the @media rules below. -->
+          <!-- Overlaid on the artwork (absolutely positioned, so source order is free)
+               and last in the DOM so keyboard focus reaches the image itself before its
+               controls. Revealed on hover with a pointer; always visible, and finger-
+               sized, on touch — see the @media rules. -->
           <div class="actions">
             <!-- Delete destroys the stored file. Offered only where that's true
                  (can_delete) — there is no remove-the-record-only action. -->
@@ -498,24 +496,23 @@ function metaLine(u: UploadRow): string {
    :hover here is auto-wrapped in @media (hover: hover) at build time (#115), so on a
    touch device the base rule stands and the buttons are simply always there. */
 /* ─── Tile actions ───────────────────────────────────────────────────────────
-   TOUCH IS THE BASE CASE, hover is the enhancement — which is the only way round
-   that works here. There is no hover on a phone, so an overlay revealed by hover
-   would either be permanently on top of the picture or unreachable; and a chip small
-   enough to sit unobtrusively on a thumbnail is far too small to tap.
+   Always ON the artwork — a row of buttons hanging below the file reads as orphaned,
+   and at tile density it costs more vertical space than the filename does.
 
-   So on touch the buttons live in normal flow, in a row under the file, with real
-   44px targets. On a pointer device they lift out of the flow onto the artwork and
-   fade in on hover, where a compact chip is exactly right and the vertical space is
-   worth reclaiming. */
+   What differs by input is REVEAL and SIZE, not position. With a pointer they fade in
+   on hover, compact, because you can aim: a 26px chip is a fine mouse target. On touch
+   there is no hover, so they are simply always there — and they have to be big enough
+   to hit deliberately, because the thing next to `copy` deletes the file. */
 .actions {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
   display: flex;
-  justify-content: flex-end;
   gap: var(--space-2);
-  margin-top: var(--space-2);
 }
 /* A solid themed chip, NOT a scrim: --scrim is a dark translucent, so in the light
-   theme a --fg icon on it would be dark-on-dark. On a pointer device this sits on
-   arbitrary user imagery, so the button has to bring its own background either way. */
+   theme a --fg icon on it would be dark-on-dark. It sits on arbitrary user imagery, so
+   the button has to bring its own background either way. */
 .act {
   background: var(--bg);
   border: 1px solid var(--border);
@@ -524,8 +521,8 @@ function metaLine(u: UploadRow): string {
   font: inherit;
   font-size: var(--icon-md);
   line-height: 1;
-  /* The iOS minimum. A 26px chip is hittable with a mouse and a coin toss with a
-     thumb — and the thing next to it deletes the file. */
+  /* The iOS minimum, and the touch default. A 26px chip is hittable with a mouse and a
+     coin toss with a thumb. */
   min-width: 44px;
   min-height: 44px;
   display: flex;
@@ -535,20 +532,18 @@ function metaLine(u: UploadRow): string {
 
 @media (hover: hover) {
   .actions {
-    position: absolute;
-    top: var(--space-2);
-    right: var(--space-2);
-    margin-top: 0;
     gap: var(--space-1);
     opacity: 0;
     transition: opacity 0.12s ease;
   }
-  /* focus-within, not just hover: these are the only way to reach copy/delete on a
-     pointer device, so they have to be reachable by keyboard too. */
+  /* focus-within, not just hover: hidden-until-hover is the ONLY way to reach copy and
+     delete with a pointer, so they have to be reachable by keyboard too. */
   .tile:hover .actions,
   .tile:focus-within .actions {
     opacity: 1;
   }
+  /* Compact, now that they only appear when you're already pointing at the tile — and
+     44px chips would cover half a thumbnail for no benefit to someone with a mouse. */
   .act {
     min-width: 0;
     min-height: 0;

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -29,7 +29,7 @@
           class="search-input"
           placeholder="Search filenames…"
           aria-label="Search uploads by filename"
-          @keydown.esc.stop="onEscape"
+          @keydown.esc="onEscape"
         />
       </div>
       <div class="kinds" role="group" aria-label="Filter by type">
@@ -190,10 +190,17 @@ const filterDescription = computed(() => {
 
 watch(query, (next) => {
   if (debounce) clearTimeout(debounce);
+  // Trim here rather than in the input: leading/trailing spaces are almost always an
+  // accident of typing, and a search for " " should not be a search.
+  const trimmed = next.trim();
+  // Nothing the SERVER would answer differently — the user added a trailing space, or
+  // typed their way back to the term we already have results for. Also covers the open:
+  // onMounted resets the store's filters and then clears this field, which would
+  // otherwise schedule a second, identical request 250ms behind the first and supersede
+  // it mid-flight.
+  if (trimmed === uploads.query) return;
   debounce = setTimeout(() => {
-    // Trim here rather than in the input: leading/trailing spaces are almost always
-    // an accident of typing, and a search for " " should not be a search.
-    void uploads.setFilters({ query: next.trim() }).catch(() => {
+    void uploads.setFilters({ query: trimmed }).catch(() => {
       /* surfaced via store.listError */
     });
   }, SEARCH_DEBOUNCE_MS);
@@ -214,14 +221,15 @@ onBeforeUnmount(() => {
 });
 
 // Escape clears a non-empty search instead of closing the modal — the same convention
-// as a browser find bar. With the field already empty it falls through to the modal's
-// own close handler, so Escape still means "get me out of here" when there's nothing
-// to clear.
+// as a browser find bar. With the field already empty there is nothing to clear, so it
+// bubbles to AppModal's own @keydown.esc and Escape still means "get me out of here".
+//
+// ⚠ The propagation stop has to be CONDITIONAL. A blanket `.stop` on the template
+// severs the bubble in both cases, so Escape on an empty field just blurred the input
+// and the modal never closed — exactly the behaviour this comment used to claim it had.
 function onEscape(event: KeyboardEvent) {
-  if (!query.value) {
-    (event.target as HTMLElement).blur();
-    return;
-  }
+  if (!query.value) return; // nothing to clear → let AppModal have it
+  event.stopPropagation();
   query.value = '';
 }
 

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -57,13 +57,18 @@
           <div v-if="u.removed" class="art art-icon" title="removed by moderation">
             <i class="fa-solid fa-gavel fa-2x"></i>
           </div>
+          <!-- Still an <a href>, even though a left click opens the lightbox: that
+               keeps middle-click and ⌘/ctrl-click opening the file in a new tab, which
+               is what a thumbnail that looks like a link should do. Same modifier
+               check RenderSegments makes for images in messages. -->
           <a
             v-else
             :href="u.url"
             target="_blank"
             rel="noreferrer noopener"
             class="art-link"
-            :title="u.url"
+            :title="u.filename || u.url"
+            @click="onArtClick($event, u)"
           >
             <img v-if="u.thumbnail_url" :src="u.thumbnail_url" class="art" alt="" loading="lazy" />
             <div v-else class="art art-icon">
@@ -125,6 +130,7 @@ import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue';
 import AppModal from './AppModal.vue';
 import { useUploadsStore } from '../stores/uploads.js';
 import type { UploadItem, UploadKind } from '../stores/uploads.js';
+import { useImageModal } from '../composables/useImageModal.js';
 import { formatRelative } from '../utils/timestamp.js';
 import { iconForMime } from '../utils/uploaders.js';
 
@@ -153,6 +159,9 @@ defineEmits<{
   close: [];
 }>();
 const uploads = useUploadsStore();
+// Raw (not reactive()-wrapped) because this component reads the refs in script rather
+// than the template — the two views that RENDER the viewer wrap it for unwrapping.
+const imageModal = useImageModal();
 const recentRows = computed(() => uploads.recent as UploadRow[]);
 const listEl = ref<HTMLDivElement | null>(null);
 const searchEl = ref<HTMLInputElement | null>(null);
@@ -216,6 +225,61 @@ function onKind(kind: UploadKind | null) {
     /* surfaced via store.listError */
   });
 }
+
+// ─── Lightbox ────────────────────────────────────────────────────────────────
+//
+// Clicking a thumbnail used to eject you into a new tab. It opens the viewer instead,
+// and the viewer is a GALLERY: left/right walks the images in the result set you are
+// currently looking at, at full size. Which means the search filters double as a way
+// to scope the gallery — filter to images, type "march", and you can flick through
+// exactly those.
+
+// Only images. The viewer renders an <img>, so a .txt or an .mp4 in the gallery would
+// be a step onto a blank screen. (Video joins it in #563; that's the card, not this
+// one.) They keep the plain new-tab link.
+const galleryItems = computed(() =>
+  recentRows.value
+    .filter((u) => !u.removed && (u.mime || '').startsWith('image/'))
+    .map((u) => ({ url: u.url, filename: u.filename })),
+);
+
+function isViewable(u: UploadRow): boolean {
+  return !u.removed && (u.mime || '').startsWith('image/');
+}
+
+function onArtClick(event: MouseEvent, u: UploadRow) {
+  // Let the browser have the ones it does better: a modified click means "new tab",
+  // and a non-image has nothing to show in an image viewer.
+  if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+    return;
+  if (!isViewable(u)) return;
+
+  const items = galleryItems.value;
+  const start = items.findIndex((i) => i.url === u.url);
+  if (start < 0) return;
+
+  event.preventDefault();
+  imageModal.openGallery(items, start);
+}
+
+// Arrowing toward the end of what's loaded pages more in — otherwise the gallery
+// silently stops at the last row the user happened to have scrolled to, which from
+// inside the viewer looks like the end of their uploads.
+watch(
+  () => imageModal.index.value,
+  (i) => {
+    if (!imageModal.isOpen.value) return;
+    if (i < galleryItems.value.length - 2) return;
+    if (!uploads.hasMore || uploads.loading) return;
+    void uploads.loadMore();
+  },
+);
+
+// New rows landed (from paging, or a fresh upload) while the viewer is open — extend
+// the gallery under it. setItems keeps the viewer on the image it is showing.
+watch(galleryItems, (items) => {
+  if (imageModal.isOpen.value) imageModal.setItems(items);
+});
 
 function onScroll() {
   const el = listEl.value;
@@ -355,9 +419,13 @@ function metaLine(u: UploadRow): string {
   margin: 0;
   padding: 0;
   display: grid;
-  /* auto-fill, not auto-fit: a search that returns two results should leave them at
+  /* 180px, not 128: the point of a gallery is recognising a picture at a glance, and
+     at 128 you squint — which is the complaint that started #547. The server thumb is
+     512px, so this stays crisp at 2x and has room to grow.
+
+     auto-fill, not auto-fit: a search that returns two results should leave them at
      tile size on the left, not stretch them across the whole modal. */
-  grid-template-columns: repeat(auto-fill, minmax(128px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: var(--space-6);
 }
 .tile {

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -346,10 +346,14 @@ function metaLine(u: UploadRow): string {
   position: relative;
   flex: 1;
   min-width: 200px;
+  /* One knob for both the glyph's inset and the text's. They have to move together —
+     the caret's position is DERIVED from where the icon ends, so a hardcoded value in
+     each would let them drift apart the next time either is nudged. */
+  --search-icon-inset: var(--space-5);
 }
 .search-icon {
   position: absolute;
-  left: var(--space-3);
+  left: var(--search-icon-inset);
   top: 50%;
   transform: translateY(-50%);
   color: var(--fg-muted);
@@ -362,9 +366,8 @@ function metaLine(u: UploadRow): string {
 .search-input {
   width: 100%;
   /* Left padding is derived, not picked: where the icon starts, plus the icon's own
-     width, plus one character of breathing room. A flat --space-8 (20px) landed the
-     text hard against the glyph. */
-  padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--space-3) + 1em + 1ch);
+     width, plus one character of breathing room. */
+  padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--search-icon-inset) + 1em + 1ch);
   background: var(--bg-soft);
   border: 1px solid var(--border);
   color: var(--fg);

--- a/vue_client/src/components/TransfersModal.vue
+++ b/vue_client/src/components/TransfersModal.vue
@@ -79,6 +79,7 @@ import {
 } from '../stores/dcc.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { formatRelative } from '../utils/timestamp.js';
+import { joinMeta } from '../utils/metaLine.js';
 
 defineEmits<{ close: [] }>();
 
@@ -144,11 +145,14 @@ function isErrorState(s: DccState): boolean {
   return s === 'failed' || s === 'stalled';
 }
 
-// "alice · libera · receiving · 2m ago"
+// "alice • libera • receiving • 2m ago"
 function subLine(t: DccTransfer): string {
-  return [t.peer_nick, networkName(t.network_id), stateLabel(t.state), formatRelative(t.updated_at)]
-    .filter(Boolean)
-    .join(' · ');
+  return joinMeta([
+    t.peer_nick,
+    networkName(t.network_id),
+    stateLabel(t.state),
+    formatRelative(t.updated_at),
+  ]);
 }
 
 // Only show the progress bar once a download has actually started — a

--- a/vue_client/src/components/settings-panes/HighlightsPane.vue
+++ b/vue_client/src/components/settings-panes/HighlightsPane.vue
@@ -189,6 +189,7 @@ import type { HighlightRule } from '../../stores/highlightRules.js';
 import IconButton from '../IconButton.vue';
 import { parseChannelList } from '../../../../shared/channels.js';
 import { highlightRuleDetailParts } from '../../utils/highlightFormat.js';
+import { joinMeta } from '../../utils/metaLine.js';
 
 type RuleKind = 'substr' | 'full' | 'glob' | 'regex';
 
@@ -215,9 +216,10 @@ interface HighlightGroup {
 
 // One-line summary of a rule's secondary dimensions for the list (the mask or
 // pattern is the main label rendered separately). Shared with the /highlight
-// command listing so the two never drift.
+// command listing so the two never drift — including the separator, which is why
+// both go through joinMeta rather than each picking a glyph.
 function describe(entry: HighlightRule): string {
-  return highlightRuleDetailParts(entry).join(' · ');
+  return joinMeta(highlightRuleDetailParts(entry));
 }
 
 // Global group first (no network scope), then per-network groups sorted by name.

--- a/vue_client/src/composables/useCopyFeedback.test.ts
+++ b/vue_client/src/composables/useCopyFeedback.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useCopyFeedback } from './useCopyFeedback.js';
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  writeText.mockReset();
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { clipboard: { writeText } },
+    configurable: true,
+  });
+});
+afterEach(() => vi.useRealTimers());
+
+describe('useCopyFeedback', () => {
+  it('copies the text and flashes a confirmation that expires', async () => {
+    const c = useCopyFeedback(1500);
+    expect(await c.copy('https://x.test/a.webp')).toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith('https://x.test/a.webp');
+    expect(c.isCopied()).toBe(true);
+
+    vi.advanceTimersByTime(1500);
+    expect(c.isCopied()).toBe(false);
+  });
+
+  // The reason `key` exists: one instance serves a whole grid, and only the tile that
+  // was actually copied may tick.
+  it('confirms only the key that was copied', async () => {
+    const c = useCopyFeedback();
+    await c.copy('https://x.test/7.webp', 7);
+
+    expect(c.isCopied(7)).toBe(true);
+    expect(c.isCopied(8)).toBe(false);
+    expect(c.isCopied()).toBe(false); // the unkeyed default is a key like any other
+  });
+
+  it('moves the confirmation when a second thing is copied', async () => {
+    const c = useCopyFeedback();
+    await c.copy('a', 1);
+    await c.copy('b', 2);
+
+    expect(c.isCopied(1)).toBe(false);
+    expect(c.isCopied(2)).toBe(true);
+  });
+
+  // The image viewer resets on navigation: arrowing to the next photo while the tick
+  // is still up would leave a green check sitting over a link the user has NOT copied.
+  it('can drop the confirmation early', async () => {
+    const c = useCopyFeedback();
+    await c.copy('a');
+    expect(c.copied.value).toBe(true);
+
+    c.reset();
+    expect(c.copied.value).toBe(false);
+
+    // The pending timer must not resurrect anything — or fire on a stale key later.
+    vi.advanceTimersByTime(5000);
+    expect(c.copied.value).toBe(false);
+  });
+
+  // The Clipboard API rejects without a user gesture and is absent outside secure
+  // contexts entirely (LAN dev mode serves plain HTTP). A failed convenience must not
+  // claim success, and must not throw at the call site either.
+  it('reports failure without throwing, and shows no confirmation', async () => {
+    writeText.mockRejectedValue(new Error('not allowed'));
+    const c = useCopyFeedback();
+
+    await expect(c.copy('a')).resolves.toBe(false);
+    expect(c.copied.value).toBe(false);
+  });
+});

--- a/vue_client/src/composables/useCopyFeedback.ts
+++ b/vue_client/src/composables/useCopyFeedback.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// "Copy, and flash a tick for a moment so the user knows it worked."
+//
+// Scoped deliberately narrowly. The app copies to the clipboard in several places and
+// they are NOT all this: the invite link and the copy-message action are
+// fire-and-forget, and the API-token pane holds a persistent "copied" state and raises
+// a visible error when the clipboard is unavailable (it has to — that token is shown
+// exactly once). This is only the transient-confirmation shape: the uploads browser's
+// per-tile copy button, and the image viewer's.
+//
+// `key` exists so a LIST can share one instance: pass the row's id and only that row's
+// button ticks. Callers with a single button pass nothing and read `copied`.
+
+import { getCurrentInstance, onBeforeUnmount, ref, computed } from 'vue';
+
+const RESET_MS = 1500;
+
+export type CopyKey = string | number;
+
+export function useCopyFeedback(resetMs = RESET_MS) {
+  const copiedKey = ref<CopyKey | null>(null);
+  const copied = computed(() => copiedKey.value !== null);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  async function copy(text: string, key: CopyKey = 'default'): Promise<boolean> {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (_) {
+      // The Clipboard API can reject without a user-gesture context, and is absent
+      // outside secure contexts entirely (Lurker's LAN dev mode serves plain HTTP).
+      // Nothing to report: the user can still open the file and copy the address, and
+      // a failed convenience is not an error worth a banner.
+      return false;
+    }
+    copiedKey.value = key;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      copiedKey.value = null;
+      timer = null;
+    }, resetMs);
+    return true;
+  }
+
+  /** True iff THIS key is the one that was just copied. */
+  function isCopied(key: CopyKey = 'default'): boolean {
+    return copiedKey.value === key;
+  }
+
+  /** Drop the confirmation early — for when the thing it referred to is gone. */
+  function reset(): void {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    copiedKey.value = null;
+  }
+
+  // Guarded: Vue warns when a lifecycle hook is registered with no active component
+  // instance, which is exactly the case in a unit test calling the composable directly.
+  if (getCurrentInstance()) {
+    onBeforeUnmount(() => {
+      if (timer) clearTimeout(timer);
+    });
+  }
+
+  return { copiedKey, copied, copy, isCopied, reset };
+}

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -17,6 +17,7 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { viewedBuffer } from './useViewedBuffer.js';
+import { META_SEPARATOR } from '../utils/metaLine.js';
 
 export interface NotifyEvent {
   self?: boolean;
@@ -147,7 +148,9 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
 
   const netName = (networks.networkById(event.networkId!) as any)?.name || `net:${event.networkId}`;
   const where =
-    event.target && !event.target.startsWith(':server:') ? `${netName} · ${event.target}` : netName;
+    event.target && !event.target.startsWith(':server:')
+      ? `${netName} ${META_SEPARATOR} ${event.target}`
+      : netName;
   toasts.push({
     kind: kindKey,
     title: `${event.nick || '?'} in ${where}`,

--- a/vue_client/src/composables/useImageModal.test.ts
+++ b/vue_client/src/composables/useImageModal.test.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useImageModal } from './useImageModal.js';
+
+const item = (n: number) => ({ url: `https://x.test/${n}.webp`, filename: `${n}.png` });
+const items = (...ns: number[]) => ns.map(item);
+
+// The composable is a module-level singleton (one lightbox for the whole app), so each
+// test has to start from a closed one.
+beforeEach(() => useImageModal().close());
+
+describe('useImageModal — a single image is a gallery of one', () => {
+  // The framing the whole design rests on: an image clicked in a message and one
+  // clicked in the uploads browser reach the same viewer, and the single-image case
+  // needs no special path — it just has nowhere to go.
+  it('opens one image with no navigation', () => {
+    const m = useImageModal();
+    m.open('https://x.test/solo.webp');
+
+    expect(m.isOpen.value).toBe(true);
+    expect(m.url.value).toBe('https://x.test/solo.webp');
+    expect(m.count.value).toBe(1);
+    expect(m.hasPrev.value).toBe(false);
+    expect(m.hasNext.value).toBe(false);
+  });
+
+  it('next/prev are inert on a gallery of one', () => {
+    const m = useImageModal();
+    m.open('https://x.test/solo.webp');
+    m.next();
+    m.prev();
+    expect(m.url.value).toBe('https://x.test/solo.webp');
+  });
+});
+
+describe('useImageModal — gallery navigation', () => {
+  it('opens at the image that was clicked, not at the start', () => {
+    const m = useImageModal();
+    m.openGallery(items(1, 2, 3), 2);
+    expect(m.url.value).toBe('https://x.test/3.webp');
+    expect(m.index.value).toBe(2);
+    expect(m.hasNext.value).toBe(false);
+    expect(m.hasPrev.value).toBe(true);
+  });
+
+  it('walks forward and back', () => {
+    const m = useImageModal();
+    m.openGallery(items(1, 2, 3), 0);
+    m.next();
+    expect(m.url.value).toBe('https://x.test/2.webp');
+    m.next();
+    expect(m.url.value).toBe('https://x.test/3.webp');
+    m.prev();
+    expect(m.url.value).toBe('https://x.test/2.webp');
+  });
+
+  it('stops at the ends instead of wrapping', () => {
+    const m = useImageModal();
+    m.openGallery(items(1, 2), 0);
+    m.prev();
+    expect(m.index.value).toBe(0); // already at the first
+    m.next();
+    m.next();
+    expect(m.index.value).toBe(1); // already at the last
+  });
+
+  it('clamps an out-of-range start index rather than showing nothing', () => {
+    const m = useImageModal();
+    m.openGallery(items(1, 2), 99);
+    expect(m.url.value).toBe('https://x.test/2.webp');
+  });
+
+  it('refuses to open an empty gallery', () => {
+    const m = useImageModal();
+    m.openGallery([], 0);
+    expect(m.isOpen.value).toBe(false);
+  });
+});
+
+describe('useImageModal — extending the gallery while it is open', () => {
+  // The uploads browser pages lazily, so arrowing toward the end of what's loaded has
+  // to extend the list UNDER the viewer. The user must not be moved.
+  it('keeps the viewer on its image when a page is appended', () => {
+    const m = useImageModal();
+    m.openGallery(items(1, 2, 3), 2);
+
+    m.setItems(items(1, 2, 3, 4, 5));
+
+    expect(m.url.value).toBe('https://x.test/3.webp'); // still the same photo
+    expect(m.index.value).toBe(2);
+    expect(m.hasNext.value).toBe(true); // ...and now there is somewhere to go
+  });
+
+  // Position is preserved by URL, not by index, so a list that grows at the FRONT (a
+  // fresh upload lands at the top) doesn't silently teleport the user to a different
+  // photo — which is a far worse bug than a redundant re-render.
+  it('keeps the viewer on its image when a row is prepended', () => {
+    const m = useImageModal();
+    m.openGallery(items(1, 2, 3), 0);
+    expect(m.url.value).toBe('https://x.test/1.webp');
+
+    m.setItems(items(0, 1, 2, 3));
+
+    expect(m.url.value).toBe('https://x.test/1.webp');
+    expect(m.index.value).toBe(1); // followed the image, not the slot
+  });
+
+  it('falls back to a valid index when the viewed image disappears', () => {
+    const m = useImageModal();
+    m.openGallery(items(1, 2, 3), 2);
+    // e.g. the user deleted it, or a filter changed under the gallery.
+    m.setItems(items(1, 2));
+    expect(m.index.value).toBe(1);
+    expect(m.url.value).toBe('https://x.test/2.webp');
+  });
+});
+
+describe('useImageModal — close', () => {
+  it('drops the gallery so the next open starts clean', () => {
+    const m = useImageModal();
+    m.openGallery(items(1, 2, 3), 1);
+    m.close();
+
+    expect(m.isOpen.value).toBe(false);
+    expect(m.url.value).toBeNull();
+    expect(m.count.value).toBe(0);
+  });
+});

--- a/vue_client/src/composables/useImageModal.ts
+++ b/vue_client/src/composables/useImageModal.ts
@@ -1,21 +1,91 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { ref } from 'vue';
+// The lightbox's model. It is a GALLERY, and a single image is a gallery of one.
+//
+// That framing is the whole design. Clicking an image in a message (RenderSegments)
+// and clicking one in the uploads browser (#547) reach the same viewer; the only
+// difference is how many images came along with it. The single-image case therefore
+// needs no special path — `hasPrev`/`hasNext` are simply false and the arrows don't
+// render — which is why `open()` is just `openGallery()` with one item.
+
+import { computed, ref } from 'vue';
+
+export interface GalleryItem {
+  url: string;
+  filename?: string | null;
+}
 
 const isOpen = ref(false);
-const url = ref<string | null>(null);
+const items = ref<GalleryItem[]>([]);
+const index = ref(0);
 
 export function useImageModal() {
+  const current = computed<GalleryItem | null>(() => items.value[index.value] ?? null);
+  // The many call sites that only ever wanted "the image being viewed" keep working.
+  const url = computed<string | null>(() => current.value?.url ?? null);
+  const count = computed(() => items.value.length);
+  const hasPrev = computed(() => index.value > 0);
+  const hasNext = computed(() => index.value < items.value.length - 1);
+
+  /** Open a single image — a gallery of one. */
   function open(nextUrl: string): void {
-    url.value = nextUrl;
+    openGallery([{ url: nextUrl }], 0);
+  }
+
+  /** Open a list of images, starting at `startIndex` (the uploads browser). */
+  function openGallery(next: GalleryItem[], startIndex = 0): void {
+    if (!next.length) return;
+    items.value = next;
+    index.value = Math.min(Math.max(0, startIndex), next.length - 1);
     isOpen.value = true;
+  }
+
+  /**
+   * Replace the gallery's contents WITHOUT moving the viewer off the current image.
+   *
+   * The uploads browser pages lazily, so arrowing toward the end of what's loaded has
+   * to be able to extend the list underneath the viewer. The position is preserved by
+   * URL rather than by index on purpose: a page appended at the end wouldn't shift
+   * anything today, but nothing in the type guarantees that's the only way the list
+   * can grow, and silently teleporting the user to a different photo is a much worse
+   * bug than a redundant re-render.
+   */
+  function setItems(next: GalleryItem[]): void {
+    const viewing = current.value?.url;
+    items.value = next;
+    const found = viewing ? next.findIndex((i) => i.url === viewing) : -1;
+    index.value = found >= 0 ? found : Math.min(index.value, Math.max(0, next.length - 1));
+  }
+
+  function next(): void {
+    if (hasNext.value) index.value += 1;
+  }
+
+  function prev(): void {
+    if (hasPrev.value) index.value -= 1;
   }
 
   function close(): void {
     isOpen.value = false;
-    url.value = null;
+    items.value = [];
+    index.value = 0;
   }
 
-  return { isOpen, url, open, close };
+  return {
+    isOpen,
+    url,
+    items,
+    index,
+    current,
+    count,
+    hasPrev,
+    hasNext,
+    open,
+    openGallery,
+    setItems,
+    next,
+    prev,
+    close,
+  };
 }

--- a/vue_client/src/stores/uploads.test.ts
+++ b/vue_client/src/stores/uploads.test.ts
@@ -9,8 +9,9 @@ import { setActivePinia, createPinia } from 'pinia';
 type MultipartOpts = { onProgress(pct: number): void };
 const apiMultipart =
   vi.fn<(url: string, fd: FormData, opts: MultipartOpts) => Promise<Record<string, unknown>>>();
+const api = vi.fn<(url: string, opts?: unknown) => Promise<any>>();
 vi.mock('../api.js', () => ({
-  api: vi.fn<() => Promise<unknown>>(async () => ({ items: [] })),
+  api: (url: string, opts?: unknown) => api(url, opts),
   apiMultipart: (url: string, fd: FormData, opts: MultipartOpts) => apiMultipart(url, fd, opts),
 }));
 
@@ -32,6 +33,8 @@ function current(over: Partial<UploadCurrent> = {}): UploadCurrent {
 beforeEach(() => {
   setActivePinia(createPinia());
   apiMultipart.mockReset();
+  api.mockReset();
+  api.mockResolvedValue({ items: [] });
 });
 
 // TIER 1 — the part that needs no server cooperation, and the reason #545 is a bug
@@ -160,5 +163,106 @@ describe('uploads.applyProgress', () => {
     expect(uploads.current!.phase).toBe('sending');
     expect(uploads.current!.sentPercent).toBeNull();
     expect(uploads.current!.destination).toBe('Local disk');
+  });
+});
+
+// #547. The uploads browser's filters are SERVER-side — unlike almost every other
+// filter in Lurker — because the client only holds the pages it has scrolled through
+// and the whole point is finding one it hasn't. So the store's job is to build the
+// right query and, crucially, to not get confused by its own in-flight requests.
+describe('uploads — browser filters', () => {
+  const row = (id: number, filename: string, mime: string) => ({
+    id,
+    url: `https://x.test/${filename}`,
+    filename,
+    mime,
+  });
+
+  it('sends the search term and kind as query params', async () => {
+    const uploads = useUploadsStore();
+    await uploads.setFilters({ query: 'march shot', kind: 'image' });
+
+    const url = api.mock.calls.at(-1)![0];
+    const params = new URL(url, 'https://x.test').searchParams;
+    expect(params.get('q')).toBe('march shot');
+    expect(params.get('kind')).toBe('image');
+    expect(params.get('before')).toBeNull(); // a new filter starts a new list
+  });
+
+  it('drops the cursor when the filters change', async () => {
+    const uploads = useUploadsStore();
+    uploads.cursor = 999;
+    await uploads.setFilters({ query: 'x' });
+    // The old cursor points into the UNFILTERED sequence; paging with it would walk
+    // the wrong rows and silently skip matches.
+    expect(api.mock.calls.at(-1)![0]).not.toContain('before=');
+  });
+
+  it('carries the filters into the next page', async () => {
+    const uploads = useUploadsStore();
+    api.mockResolvedValueOnce({ items: [row(7, 'a.png', 'image/webp')] });
+    await uploads.setFilters({ query: 'a', kind: 'image' });
+    uploads.hasMore = true; // one short page would otherwise end pagination
+
+    await uploads.loadMore();
+    const params = new URL(api.mock.calls.at(-1)![0], 'https://x.test').searchParams;
+    expect(params.get('before')).toBe('7');
+    expect(params.get('q')).toBe('a');
+    expect(params.get('kind')).toBe('image');
+  });
+
+  // The race that makes typed search feel broken: "scree" is sent, then "screenshot",
+  // and the slower FIRST response lands last and overwrites the results of the term
+  // the user actually finished typing.
+  it('ignores a response that a newer filter has superseded', async () => {
+    const uploads = useUploadsStore();
+    let releaseStale: (v: unknown) => void = () => {};
+    const stale = new Promise((r) => {
+      releaseStale = r;
+    });
+
+    api.mockReturnValueOnce(stale.then(() => ({ items: [row(1, 'STALE.png', 'image/webp')] })));
+    const first = uploads.setFilters({ query: 'scree' });
+
+    api.mockResolvedValueOnce({ items: [row(2, 'FRESH.png', 'image/webp')] });
+    await uploads.setFilters({ query: 'screenshot' });
+
+    // Now let the superseded request finish — after the newer one already landed.
+    releaseStale(null);
+    await first;
+
+    expect(uploads.recent.map((u) => u.filename)).toEqual(['FRESH.png']);
+    expect(uploads.query).toBe('screenshot');
+    // The stale request must not leave the spinner running either.
+    expect(uploads.loading).toBe(false);
+  });
+
+  // `recent` holds the results of a FILTER now, not the whole history. An optimistic
+  // insert that the active filter excludes would sit at the top of the user's search
+  // results and then vanish on the next reload — which reads as a bug.
+  it('optimistically inserts a new upload only when it matches the filters', async () => {
+    const uploads = useUploadsStore();
+    await uploads.setFilters({ query: '', kind: 'image' });
+
+    apiMultipart.mockResolvedValue({ id: 9, url: 'https://x.test/n.txt', mime: 'text/plain' });
+    await uploads.upload(new Blob(['x']), 'notes.txt');
+    expect(uploads.recent).toEqual([]); // a text upload, while filtered to images
+
+    apiMultipart.mockResolvedValue({ id: 10, url: 'https://x.test/s.webp', mime: 'image/webp' });
+    await uploads.upload(new Blob(['x']), 'shot.png');
+    expect(uploads.recent.map((u) => u.filename)).toEqual(['shot.png']);
+  });
+
+  it('respects the search term when optimistically inserting', async () => {
+    const uploads = useUploadsStore();
+    await uploads.setFilters({ query: 'holiday' });
+
+    apiMultipart.mockResolvedValue({ id: 11, url: 'https://x.test/s.webp', mime: 'image/webp' });
+    await uploads.upload(new Blob(['x']), 'work-thing.png');
+    expect(uploads.recent).toEqual([]);
+
+    apiMultipart.mockResolvedValue({ id: 12, url: 'https://x.test/h.webp', mime: 'image/webp' });
+    await uploads.upload(new Blob(['x']), 'holiday-snap.png');
+    expect(uploads.recent.map((u) => u.filename)).toEqual(['holiday-snap.png']);
   });
 });

--- a/vue_client/src/stores/uploads.ts
+++ b/vue_client/src/stores/uploads.ts
@@ -24,6 +24,29 @@ function emitInsert(url: string) {
 }
 
 const FAILURE_VISIBLE_MS = 10_000;
+const PAGE_SIZE = 50;
+
+/** The kinds the uploads browser filters by. Mirrors UPLOAD_KINDS on the server, which
+ *  derives each one from the mime prefix. */
+export type UploadKind = 'image' | 'video' | 'audio' | 'text';
+
+function uploadsUrl({
+  q,
+  kind,
+  before,
+}: {
+  q?: string;
+  kind?: UploadKind | null;
+  before?: number | null;
+}): string {
+  // URLSearchParams, not template concatenation: a filename search is arbitrary user
+  // text and will contain `&`, `#`, `+` and spaces.
+  const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+  if (before != null) params.set('before', String(before));
+  if (q) params.set('q', q);
+  if (kind) params.set('kind', kind);
+  return `/api/uploads?${params}`;
+}
 
 // The three legs of an upload, in the order they happen. Only the first is visible
 // to the browser (#545):
@@ -93,6 +116,18 @@ export const useUploadsStore = defineStore('uploads', {
     loaded: false,
     loading: false,
     listError: '',
+
+    // The uploads browser's filters (#547). Server-side, unlike almost every other
+    // filter in Lurker: the client only holds the pages it has scrolled through, and
+    // the whole point is finding one it hasn't. `recent` therefore holds the RESULTS
+    // of these filters, not the whole history — every consumer of it sees a filtered
+    // view once a filter is set.
+    query: '',
+    kind: null as UploadKind | null,
+    // Bumped on every filter change. A page that comes back from a superseded request
+    // carries a stale generation and is dropped — otherwise a slow "scree" response
+    // lands after the faster "screenshot" one and overwrites it.
+    generation: 0,
   }),
   actions: {
     async upload(file: File | Blob, filename: string | null = null) {
@@ -142,15 +177,26 @@ export const useUploadsStore = defineStore('uploads', {
           const isImage = typeof mime === 'string' && mime.startsWith('image/');
           const thumbnail_url =
             result.thumbnail_url || (isImage ? `/api/uploads/${result.id}/thumb` : undefined);
-          this.recent.unshift({
+          const row: UploadItem = {
             id: result.id,
             provider: undefined, // server-only field; recent-uploads modal will re-fetch if it cares
             url: result.url,
-            filename,
+            // `name`, not `filename`: the server stores req.file.originalname, which IS
+            // `name` (it's what we appended to the FormData). The optimistic row used
+            // the nullable `filename` param, so a pasted image read "(pasted)" until a
+            // reload turned it into "image.png". Harmless before; now that search
+            // matches on this field, the optimistic row has to agree with the stored one.
+            filename: filename || name,
             mime,
             can_delete: !!result.can_delete,
             ...(thumbnail_url ? { thumbnail_url } : {}),
-          });
+          };
+          // ⚠ `recent` holds the results of the browser's FILTERS now, not the whole
+          // history (#547). Prepending unconditionally would put a row the user's
+          // current search excludes at the top of their search results — and it would
+          // vanish on the next reload, which reads like a bug. Only optimistically
+          // insert what the active filter would actually have returned.
+          if (this.matchesFilters(row)) this.recent.unshift(row);
         }
         return result;
       } catch (err: any) {
@@ -198,40 +244,75 @@ export const useUploadsStore = defineStore('uploads', {
       return this.upload(blob, filename);
     },
 
+    /**
+     * Would the active filters have returned this row? Mirrors the server's WHERE
+     * clause — substring on filename, mime prefix on kind — so an optimistically
+     * inserted upload appears if and only if a refetch would have shown it.
+     */
+    matchesFilters(row: UploadItem): boolean {
+      if (this.kind && !(row.mime || '').startsWith(`${this.kind}/`)) return false;
+      if (!this.query) return true;
+      return (row.filename || '').toLowerCase().includes(this.query.toLowerCase());
+    },
+
+    /** Apply the browser's filters and reload from the top (#547). */
+    async setFilters({ query, kind }: { query?: string; kind?: UploadKind | null }) {
+      if (query !== undefined) this.query = query;
+      if (kind !== undefined) this.kind = kind;
+      // A filtered result set is a different list, not a continuation of this one: the
+      // old cursor points into the unfiltered sequence and would page the wrong rows.
+      this.cursor = null;
+      this.hasMore = true;
+      await this.loadRecent();
+    },
+
     async loadRecent() {
-      if (this.loading) return;
+      // Deliberately does NOT bail while a load is in flight. A filter change must
+      // SUPERSEDE the request it replaces — bailing would drop the newest keystroke's
+      // results and leave the list showing the previous term's.
+      const gen = ++this.generation;
       this.loading = true;
       this.listError = '';
       try {
-        const { items } = await api('/api/uploads?limit=50');
+        const { items } = await api(uploadsUrl({ q: this.query, kind: this.kind }));
+        if (gen !== this.generation) return; // superseded by a newer filter
         this.recent = items || [];
         this.cursor = this.recent.length ? this.recent[this.recent.length - 1].id : null;
-        this.hasMore = this.recent.length === 50;
+        this.hasMore = this.recent.length === PAGE_SIZE;
         this.loaded = true;
       } catch (e: any) {
+        if (gen !== this.generation) return;
         this.listError = e.message || 'failed to load uploads';
         throw e;
       } finally {
-        this.loading = false;
+        // Only the request that is still the current one owns the spinner.
+        if (gen === this.generation) this.loading = false;
       }
     },
 
     async loadMore() {
       if (this.loading || !this.hasMore || this.cursor == null) return;
+      const gen = this.generation;
       this.loading = true;
       try {
-        const { items } = await api(`/api/uploads?before=${this.cursor}&limit=50`);
+        const { items } = await api(
+          uploadsUrl({ q: this.query, kind: this.kind, before: this.cursor }),
+        );
+        // The filters changed while this page was in flight — these rows belong to a
+        // list that no longer exists. Appending them would mix two result sets.
+        if (gen !== this.generation) return;
         this.recent.push(...(items || []));
         if (items && items.length) {
           this.cursor = items[items.length - 1].id;
-          this.hasMore = items.length === 50;
+          this.hasMore = items.length === PAGE_SIZE;
         } else {
           this.hasMore = false;
         }
       } catch (e: any) {
+        if (gen !== this.generation) return;
         this.listError = e.message || 'failed to load more';
       } finally {
-        this.loading = false;
+        if (gen === this.generation) this.loading = false;
       }
     },
 

--- a/vue_client/src/stores/uploads.ts
+++ b/vue_client/src/stores/uploads.ts
@@ -89,7 +89,6 @@ export interface UploadProgressFrame {
 
 export interface UploadItem {
   id: number;
-  provider?: string;
   url: string;
   filename: string | null;
   mime: string | null;
@@ -179,7 +178,6 @@ export const useUploadsStore = defineStore('uploads', {
             result.thumbnail_url || (isImage ? `/api/uploads/${result.id}/thumb` : undefined);
           const row: UploadItem = {
             id: result.id,
-            provider: undefined, // server-only field; recent-uploads modal will re-fetch if it cares
             url: result.url,
             // `name`, not `filename`: the server stores req.file.originalname, which IS
             // `name` (it's what we appended to the FormData). The optimistic row used

--- a/vue_client/src/utils/metaLine.ts
+++ b/vue_client/src/utils/metaLine.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * The separator between the facts on a secondary line — a notification's
+ * "libera • #general", a highlight rule's "QUACK! • whole word • #chan", an upload's
+ * "2h ago • 412 KB".
+ *
+ * A bullet, not the middot (·) this used to be: these lines are rendered in muted grey
+ * by definition, and at that weight a middot all but vanishes — it reads as a speck
+ * rather than a separator.
+ *
+ * ⚠ Not used for the `/help` command examples in MessageInput. Those are monospace,
+ * terminal-shaped text where a middot between example commands reads correctly and a
+ * bullet would look like a list marker. Same glyph, different job.
+ */
+export const META_SEPARATOR = '•';
+
+/**
+ * Join the parts of a meta line, dropping the ones that aren't there.
+ *
+ * Built in JS rather than as adjacent template spans because Vue's whitespace
+ * condensing strips the gaps between those, and the separator needs its spaces.
+ */
+export function joinMeta(parts: Array<string | number | false | null | undefined>): string {
+  return parts.filter(Boolean).join(` ${META_SEPARATOR} `);
+}

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -274,7 +274,14 @@
     <ImageViewerModal
       v-if="imageModal.isOpen && imageModal.url !== null"
       :url="imageModal.url"
+      :filename="imageModal.current?.filename ?? null"
+      :index="imageModal.index"
+      :count="imageModal.count"
+      :has-prev="imageModal.hasPrev"
+      :has-next="imageModal.hasNext"
       @close="imageModal.close()"
+      @prev="imageModal.prev()"
+      @next="imageModal.next()"
     />
     <UserProfileModal
       v-if="whois.viewer.open && whois.viewer.networkId != null"

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -207,7 +207,14 @@
     <ImageViewerModal
       v-if="imageModal.isOpen && imageModal.url !== null"
       :url="imageModal.url"
+      :filename="imageModal.current?.filename ?? null"
+      :index="imageModal.index"
+      :count="imageModal.count"
+      :has-prev="imageModal.hasPrev"
+      :has-next="imageModal.hasNext"
       @close="imageModal.close()"
+      @prev="imageModal.prev()"
+      @next="imageModal.next()"
     />
     <UserProfileModal
       v-if="whois.viewer.open && whois.viewer.networkId != null"


### PR DESCRIPTION
Closes #547.

The modal was built for *"the thing I just uploaded"* and fell apart for *"that screenshot from March"* — a single-column list of small thumbnails with an infinite-scroll cursor, so finding an old upload meant scrolling blindly and squinting. There was no way to search at all: `GET /api/uploads` took only `before` + `limit`.

## Search is server-side — the exception, and why

Almost every filter in Lurker is a render-time filter over what the client already holds. This one **can't be**: the client only holds the pages it has scrolled through, and the entire point is finding one it *hasn't*. The reason is delivery, not preference.

So `q` (filename substring) and `kind` (image/video/audio/text, derived from the mime prefix rather than stored — the mime is already the magic-byte truth, and a second column could disagree with it) became query params with a `WHERE` clause behind them. Plain `LIKE`, not FTS5: this is "find the file I named", not ranked retrieval.

### ⚠ The trap in that

`%` and `_` are LIKE **wildcards**, not characters. Unescaped, a search for `100%` matches every filename containing `100`, and a lone `_` matches the entire history. **A search box that silently honours wildcards is a search box that lies about what it found.** Terms are escaped with an explicit `ESCAPE` clause, and the tests seed filenames literally made of metacharacters (`100%-zoom.png`, `snap_shot.png`, `back\slash.png`) to prove each one is treated as text.

Keyset pagination survives every filter — still `id < before` on a DESC scan, never OFFSET. A cursor that ignored the filter would page through the *unfiltered* sequence and silently skip matches, so there's a test that pages a filtered result set.

## The thumbnail constraint, settled

The card said to decide this before picking a tile size, so: **`THUMB_SIZE` 128 → 512, tiles at 180px.**

(This landed in two steps. It went to 256 first, sized for 128px tiles — then QA said 128px tiles are still too small to browse *by* thumbnail, which is the whole point of a gallery. Tiles went to 180px, and the thumb follows from that: 180px is 360 device pixels at 2x, so the source has to be at least that. 512 covers it with headroom for 3x.)

Measured on a real photo as WebP: **128px = 2.3 KB, 256px = 4.5 KB, 512px = 9.3 KB.** Seven kilobytes per upload is not a number worth designing a UI around.

Only **new** uploads get it. The originals live at the provider, not here, so existing rows keep the thumb they were written with and the gallery is mixed-sharpness until it churns. That's the accepted cost — the alternative was designing every tile around the smallest thumb we ever wrote.

## Layout

A grid, with media/text getting a **type-icon tile in the same box** rather than a separate section. They have no thumbnail (no ffmpeg → no poster frames, per #515), and a file card that shows an icon reads as a peer of one that shows a photo; a segregated list of them would not. Copy/delete become hover actions on the tile — at tile density, a permanent button row under every file would cost more vertical space than the filename does.

## Client details worth a reviewer's eye

- **`recent` now holds the results of a filter, not the whole history.** An optimistic insert that the active filter excludes would sit at the top of the user's search results and then vanish on the next reload — which reads as a bug. It now only inserts what a refetch would actually have returned.
- **The optimistic row's filename was subtly wrong**, and it now matters. The server stores `req.file.originalname` — which is the `name` we appended to the FormData — but the optimistic row used the nullable `filename` param, so a pasted image read `(pasted)` until a reload turned it into `image.png`. Harmless before; now that search matches on that field, the optimistic row has to agree with the stored one.
- **A generation counter drops superseded responses.** Type "scree", then "screenshot", and the slower *first* request can land last and overwrite the results of the term the user actually finished typing. There's a test that resolves the requests out of order.
- **Tile actions are a solid themed chip, not `--scrim`.** `--scrim` is a dark translucent, so a `--fg` icon on it would be dark-on-dark in the light theme.
- Escape clears a non-empty search (browser find-bar convention) and otherwise falls through to closing the modal.

## Verification

`npm run check` clean, `npm test` green (2335 passing), client builds clean. The search/filter WHERE clauses are tested against a real DB, the query-param plumbing at the route, and the store's races (superseded responses, filtered optimistic inserts) as units.

Worth a manual pass on the grid itself — that's the part tests can't feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
