### PR TITLE
Media viewer: play video, play audio, read text (#563)

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -843,17 +843,23 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'the JOIN line is revealed. 0 disables unmasking.',
   },
 
-  // ─── Inline image viewer ──────────────────────────────────────────────
+  // ─── Inline media viewer ──────────────────────────────────────────────
   {
+    // ⚠ The key still says `image_modal` even though the viewer now plays video and
+    // audio and reads text (#563). Renaming it is a MIGRATION, not a rename: the stored
+    // row lives under the old key, so a new key would orphan it — silently switching
+    // the viewer back on for exactly the people who went out of their way to turn it
+    // off. The label is what users read; the key is an id, and ids age.
     key: 'chat.image_modal.enabled',
-    label: 'Image viewer',
+    label: 'Media viewer',
     category: 'chat',
     group: 'viewing',
     type: 'bool',
     default: true,
     description:
-      'When enabled, clicking a URL to an image opens it in an in-app viewer instead ' +
-      'of a new browser tab. Cmd/Ctrl-click always opens in a new tab.',
+      'When enabled, clicking a link to an image, video, audio file, or .txt opens it ' +
+      'in an in-app viewer instead of a new browser tab. Cmd/Ctrl-click always opens ' +
+      'in a new tab.',
   },
 
   // ─── Connection ───────────────────────────────────────────────────────

--- a/vue_client/src/components/MediaViewerModal.test.ts
+++ b/vue_client/src/components/MediaViewerModal.test.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// The viewer's mode switch and its load lifecycle (#563).
+//
+// This file exists because of a bug it would have caught. Removing `autoplay` from the
+// <video>/<audio> broke them completely: the load handler was bound to `loadeddata`,
+// which only fires once a FRAME has been buffered — something `preload="metadata"`
+// deliberately never does. Autoplay had been forcing that load and hiding the mistake.
+// Take it away and the event never comes, `loading` never clears, and `v-show` leaves
+// the player hidden behind a spinner that spins forever.
+//
+// No unit test could see that: the bug lived entirely in which DOM event was bound to
+// which handler. So the test mounts the real component and fires the real events.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import MediaViewerModal from './MediaViewerModal.vue';
+
+// Text is the one mode that FETCHES (see the CORS block below), so it must never be
+// allowed to reach the network from a test.
+const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+function open(url: string) {
+  return mount(MediaViewerModal, { props: { url } });
+}
+
+describe('MediaViewerModal — mode', () => {
+  it('renders an <img> for an image', () => {
+    const w = open('https://x.test/a.webp');
+    expect(w.find('img.image').exists()).toBe(true);
+    expect(w.find('video').exists()).toBe(false);
+  });
+
+  it('renders a <video> for a video', () => {
+    const w = open('https://x.test/clip.mp4');
+    expect(w.find('video.video').exists()).toBe(true);
+    expect(w.find('img.image').exists()).toBe(false);
+  });
+
+  it('renders an <audio> for audio', () => {
+    const w = open('https://x.test/song.mp3');
+    expect(w.find('audio.audio').exists()).toBe(true);
+  });
+
+  it('renders a <pre> for text', () => {
+    const w = open('https://x.test/notes.txt');
+    expect(w.find('pre.text').exists()).toBe(true);
+  });
+
+  // playsinline is not optional: without it iOS Safari yanks the video into its own
+  // native fullscreen player and the viewer — gallery arrows, copy link, all of it —
+  // is gone. It is one attribute and it is invisible until you test on a phone.
+  it('keeps video inline on iOS', () => {
+    const w = open('https://x.test/clip.mp4');
+    const video = w.find('video').element as HTMLVideoElement;
+    expect(video.hasAttribute('playsinline')).toBe(true);
+  });
+
+  // Opening a file to look at it is not asking it to start making noise — and with the
+  // gallery arrows, autoplay would fire off a new track on every keypress.
+  it.each(['clip.mp4', 'song.mp3'])('does not autoplay %s', (file) => {
+    const w = open(`https://x.test/${file}`);
+    const el = w.find('video, audio').element as HTMLMediaElement;
+    expect(el.autoplay).toBe(false);
+  });
+
+  // The zoom control is meaningless on a player and dead on a <pre>. A dead button on
+  // three modes out of four is worse than no button.
+  it('offers zoom for images only', () => {
+    expect(open('https://x.test/a.webp').find('[aria-label="zoom in"]').exists()).toBe(true);
+    expect(open('https://x.test/clip.mp4').find('[aria-label="zoom in"]').exists()).toBe(false);
+    expect(open('https://x.test/song.mp3').find('[aria-label="zoom in"]').exists()).toBe(false);
+  });
+});
+
+// ⚠ THE REGRESSION. Each of these fails if the handler is bound to `loadeddata` again.
+describe('MediaViewerModal — load lifecycle', () => {
+  it('shows a spinner until the media reports in', () => {
+    const w = open('https://x.test/clip.mp4');
+    expect(w.find('.loading').exists()).toBe(true);
+  });
+
+  it.each([
+    ['video', 'https://x.test/clip.mp4'],
+    ['audio', 'https://x.test/song.mp3'],
+  ])('clears the spinner when %s metadata arrives', async (tag, url) => {
+    const w = open(url);
+    expect(w.find('.loading').exists()).toBe(true);
+
+    // The event a browser ACTUALLY fires under preload="metadata". `loadeddata` would
+    // not come until a frame was buffered, which without autoplay never happens.
+    await w.find(tag).trigger('loadedmetadata');
+
+    expect(w.find('.loading').exists()).toBe(false);
+    expect(w.find('.failed-card').exists()).toBe(false);
+  });
+
+  it('clears the spinner when an image loads', async () => {
+    const w = open('https://x.test/a.webp');
+    await w.find('img').trigger('load');
+    expect(w.find('.loading').exists()).toBe(false);
+  });
+
+  it.each([
+    ['video', 'https://x.test/clip.mp4'],
+    ['audio', 'https://x.test/song.mp3'],
+    ['img', 'https://x.test/a.webp'],
+  ])('falls back to the open-in-browser card when %s fails', async (tag, url) => {
+    const w = open(url);
+    await w.find(tag).trigger('error');
+    expect(w.find('.failed-card').exists()).toBe(true);
+  });
+});
+
+// Text is the only mode subject to CORS: an <img> or <video> RENDERS a cross-origin
+// file without the host's permission, but READING one requires it. So .txt works on the
+// `local` driver (same origin) and is at the mercy of the provider anywhere else.
+describe('MediaViewerModal — text', () => {
+  const ok = (body: string) =>
+    ({ ok: true, status: 200, text: async () => body }) as unknown as Response;
+
+  it('shows the file when the host allows the read', async () => {
+    fetchMock.mockResolvedValue(ok('the long message someone pasted'));
+    const w = open('https://x.test/notes.txt');
+    await flushPromises();
+
+    expect(w.find('pre.text').text()).toBe('the long message someone pasted');
+    expect(w.find('.loading').exists()).toBe(false);
+  });
+
+  // The whole reason this is best-effort rather than a feature we can promise. A
+  // refused read must land on the same "open in browser" card a dead image already did
+  // — which is exactly the behaviour a .txt link had before the viewer knew about text,
+  // so nothing is lost by trying.
+  it('falls back to open-in-browser when the host refuses (CORS)', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    const w = open('https://x.test/notes.txt');
+    await flushPromises();
+
+    expect(w.find('.failed-card').exists()).toBe(true);
+    expect(w.text()).toContain('the host may not allow it');
+  });
+
+  it('falls back on a non-2xx too', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403 } as unknown as Response);
+    const w = open('https://x.test/notes.txt');
+    await flushPromises();
+    expect(w.find('.failed-card').exists()).toBe(true);
+  });
+
+  // A .txt upload is a pasted chat message, but nothing stops someone linking a 200 MB
+  // log, and a <pre> with that in it locks the tab.
+  it('truncates a file too big to render', async () => {
+    fetchMock.mockResolvedValue(ok('x'.repeat(500_000)));
+    const w = open('https://x.test/huge.txt');
+    await flushPromises();
+
+    const shown = w.find('pre.text').text();
+    expect(shown.length).toBeLessThan(500_000);
+    expect(shown).toContain('truncated');
+  });
+
+  // The other three kinds hand their URL to an element and never read the bytes.
+  it.each(['a.webp', 'clip.mp4', 'song.mp3'])('does not fetch %s', (file) => {
+    open(`https://x.test/${file}`);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/vue_client/src/components/MediaViewerModal.vue
+++ b/vue_client/src/components/MediaViewerModal.vue
@@ -142,6 +142,12 @@
            NO autoplay, here or on audio. Opening a file to look at it is not the same
            as asking it to start making noise, and walking a gallery with the arrow keys
            would fire off a new track on every keypress. Press play. -->
+      <!-- ⚠ loadedmetadata, NOT loadeddata. `loadeddata` fires when the first FRAME is
+           buffered, which `preload="metadata"` deliberately never does — it was only
+           firing before because autoplay forced the data load. Take autoplay away and
+           the event never comes: the spinner spins forever and v-show keeps the player
+           hidden behind it. `loadedmetadata` is the one that fires when duration and
+           dimensions are known, which is exactly when there is a player worth showing. -->
       <video
         v-else-if="kind === 'video'"
         v-show="!loading && !failed"
@@ -150,7 +156,7 @@
         controls
         playsinline
         preload="metadata"
-        @loadeddata="onLoad"
+        @loadedmetadata="onLoad"
         @error="onError"
       ></video>
 
@@ -163,7 +169,7 @@
           :src="displayUrl"
           controls
           preload="metadata"
-          @loadeddata="onLoad"
+          @loadedmetadata="onLoad"
           @error="onError"
         ></audio>
       </div>

--- a/vue_client/src/components/MediaViewerModal.vue
+++ b/vue_client/src/components/MediaViewerModal.vue
@@ -13,8 +13,8 @@
     aria-label="Image viewer"
     @click.self="$emit('close')"
     @keydown.esc="$emit('close')"
-    @keydown.left.prevent="$emit('prev')"
-    @keydown.right.prevent="$emit('next')"
+    @keydown.left="onArrowKey($event, 'prev')"
+    @keydown.right="onArrowKey($event, 'next')"
   >
     <div class="topbar">
       <!-- What you're looking at, and where you are in the set. Only meaningful for a
@@ -24,7 +24,11 @@
         <span v-if="count > 1" class="caption-count">{{ index + 1 }} / {{ count }}</span>
       </div>
       <div class="controls">
+        <!-- Images only. There is nothing to zoom into on an audio player, and a video
+             has its own controls; offering a dead button on three modes out of four
+             would be worse than offering none. -->
         <button
+          v-if="kind === 'image'"
           class="control"
           type="button"
           :title="zoomControlLabel"
@@ -34,7 +38,7 @@
         >
           <i :class="zoomIconClass"></i>
         </button>
-        <!-- Copying the link is what you usually want from an image someone posted —
+        <!-- Copying the link is what you usually want from something someone posted —
              to reply with it, or to send it on. It was previously only reachable by
              closing the viewer and finding the URL again. -->
         <button
@@ -95,14 +99,18 @@
     <div ref="stageEl" class="stage" @click.self="$emit('close')">
       <div v-if="failed" class="failed-card">
         <p class="empty">
-          Failed to load image.
+          {{ failureMessage }}
           <button class="link" type="button" @click="openInBrowser">Open in browser.</button>
         </p>
       </div>
-      <p v-else-if="loading" class="loading" aria-label="Loading image">
+      <p v-else-if="loading" class="loading" aria-label="Loading">
         <i class="fa-solid fa-circle-notch fa-spin"></i>
       </p>
+
+      <!-- IMAGE — the only mode with pan/zoom. A photo is the one thing here you want
+           to inspect closer than it fits. -->
       <img
+        v-if="kind === 'image'"
         ref="imageEl"
         v-show="!loading && !failed"
         class="image"
@@ -126,6 +134,49 @@
         @pointercancel="onImagePointerEnd"
         @lostpointercapture="onImagePointerEnd"
       />
+
+      <!-- VIDEO. `playsinline` is not optional: without it iOS Safari yanks the video
+           into its own native fullscreen player and our viewer — gallery arrows, copy
+           link, the lot — is gone. `autoplay` is a request, not a promise: if the
+           browser's autoplay policy refuses it, the controls are right there. -->
+      <video
+        v-else-if="kind === 'video'"
+        v-show="!loading && !failed"
+        class="video"
+        :src="displayUrl"
+        controls
+        autoplay
+        playsinline
+        preload="metadata"
+        @loadeddata="onLoad"
+        @error="onError"
+      ></video>
+
+      <!-- AUDIO has nothing to show, so give it something to be: the filename and a
+           player, framed as a card rather than a bare <audio> element floating in a
+           black void. -->
+      <div v-else-if="kind === 'audio'" v-show="!loading && !failed" class="audio-card">
+        <i class="fa-solid fa-music audio-art" aria-hidden="true"></i>
+        <p v-if="filename" class="audio-name">{{ filename }}</p>
+        <audio
+          class="audio"
+          :src="displayUrl"
+          controls
+          autoplay
+          preload="metadata"
+          @loadeddata="onLoad"
+          @error="onError"
+        ></audio>
+      </div>
+
+      <!-- TEXT is the one kind we have to FETCH rather than hand to an element, which
+           makes it the only one subject to CORS. Lurker's own long-message paste turns
+           into a .txt upload, so this is the mode that lets you read one without
+           leaving the app. When the provider won't allow the read, onError puts up the
+           same "open in browser" card as a dead image — see loadText(). -->
+      <pre v-else-if="kind === 'text'" v-show="!loading && !failed" class="text">{{
+        textContent
+      }}</pre>
     </div>
   </div>
 </template>
@@ -133,8 +184,13 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useCopyFeedback } from '../composables/useCopyFeedback.js';
+import { mediaKindForUrl, type MediaKind } from '../utils/uploadHostMatch.js';
 
 const LOAD_TIMEOUT_MS = 20_000;
+// A .txt upload is a pasted chat message, not a novel — but nothing stops someone
+// linking a 200 MB log, and a <pre> with 200 MB in it locks the tab. Show the head of
+// it and say so.
+const MAX_TEXT_CHARS = 200_000;
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 4;
 const MOVE_SLOP_PX = 6;
@@ -165,6 +221,7 @@ const clipboard = useCopyFeedback();
 const loading = ref(true);
 const failed = ref(false);
 const displayUrl = ref(props.url);
+const textContent = ref('');
 const overlayEl = ref<HTMLElement | null>(null);
 const imageEl = ref<HTMLImageElement | null>(null);
 const stageEl = ref<HTMLElement | null>(null);
@@ -207,6 +264,23 @@ let pinchStart: PinchStart | null = null;
 let pinchOccurred = false;
 let lastTap: { time: number; x: number; y: number } | null = null;
 
+// What we're showing. Derived from the URL rather than passed in, so a link clicked in
+// a message and one clicked in the uploads grid classify identically — one rule, not
+// two that can disagree. An unrecognised URL falls back to `image`, which fails into
+// the "open in browser" card exactly as it did before this component knew about video.
+const kind = computed<MediaKind>(() => mediaKindForUrl(props.url) ?? 'image');
+
+const FAILURE_MESSAGES: Record<MediaKind, string> = {
+  image: 'Failed to load image.',
+  video: 'Failed to play video.',
+  audio: 'Failed to play audio.',
+  // The likeliest cause by far, and the one the user can do something about. Reading a
+  // .txt means fetching its bytes, which the host has to permit (CORS) — playing a
+  // video or showing an image never does.
+  text: 'Could not read this file — the host may not allow it.',
+};
+const failureMessage = computed(() => FAILURE_MESSAGES[kind.value]);
+
 const isZoomed = computed(() => scale.value > MIN_ZOOM);
 const zoomControlLabel = computed(() => (isZoomed.value ? 'zoom out' : 'zoom in'));
 const zoomIconClass = computed(() => [
@@ -246,8 +320,45 @@ function startLoading(nextUrl: string): void {
   displayUrl.value = nextUrl;
   loading.value = true;
   failed.value = false;
+  textContent.value = '';
   resetZoom();
   loadTimer.value = window.setTimeout(onLoadTimeout, LOAD_TIMEOUT_MS);
+  // <img>, <video> and <audio> fetch their own bytes and tell us via @load / @error.
+  // Text has no element that does that, so we do it by hand.
+  if (mediaKindForUrl(nextUrl) === 'text') void loadText(nextUrl);
+}
+
+/**
+ * Read a .txt so it can be shown in-app.
+ *
+ * ⚠ THE ONLY MODE SUBJECT TO CORS. An <img> or <video> renders a cross-origin file
+ * without the host's permission; READING one requires it. So this works on the `local`
+ * driver (same origin) and is at the mercy of the provider anywhere else — catbox, x0,
+ * a CDN. There is no way around that from the client: a proxy on our server would be an
+ * SSRF surface and would put every viewed file through our bandwidth.
+ *
+ * When it's refused, we land on the same "open in browser" card as a dead image, which
+ * is exactly today's behaviour. Nothing is lost by trying; a lot is gained when it
+ * works, because Lurker's own long-message paste becomes a .txt upload and this is what
+ * lets you read one without leaving the app.
+ */
+async function loadText(url: string): Promise<void> {
+  try {
+    const res = await fetch(url, { credentials: 'omit', referrerPolicy: 'no-referrer' });
+    if (!res.ok) throw new Error(String(res.status));
+    const body = await res.text();
+    // The URL is still the one we started on — the user may have arrowed to the next
+    // item while this was in flight, and a stale body must not overwrite it.
+    if (displayUrl.value !== url) return;
+    textContent.value =
+      body.length > MAX_TEXT_CHARS
+        ? `${body.slice(0, MAX_TEXT_CHARS)}\n\n… truncated — open in browser for the rest.`
+        : body;
+    onLoad();
+  } catch {
+    if (displayUrl.value !== url) return;
+    onError();
+  }
 }
 
 function clearLoadTimer(): void {
@@ -263,6 +374,19 @@ function onLoadTimeout(): void {
   loading.value = false;
   failed.value = true;
   resetZoom();
+}
+
+// Left/right walks the gallery — EXCEPT when a media element has focus, where the
+// browser already gives those keys a better meaning: seek. Stealing them would make a
+// video impossible to scrub with the keyboard, and the user who has clicked into the
+// player is plainly not asking for the next file.
+function onArrowKey(event: KeyboardEvent, direction: 'prev' | 'next'): void {
+  const tag = (event.target as HTMLElement | null)?.tagName;
+  if (tag === 'VIDEO' || tag === 'AUDIO') return;
+  event.preventDefault();
+  // Branched rather than emit(direction): defineEmits' overloads don't narrow a union.
+  if (direction === 'prev') emit('prev');
+  else emit('next');
 }
 
 function openInBrowser(): void {
@@ -615,6 +739,10 @@ function releasePointer(pointerId: number): void {
 }
 
 function preventNativeTouchGesture(event: TouchEvent): void {
+  // Only the image mode pans and pinches. Swallowing touches in the others would fight
+  // the native <video>/<audio> controls for their own scrubbing gestures, and would
+  // stop a long <pre> from being scrolled with a finger.
+  if (kind.value !== 'image') return;
   if (event.touches.length > 1 || (isZoomed.value && event.touches.length > 0))
     event.preventDefault();
 }
@@ -773,6 +901,61 @@ onBeforeUnmount(() => {
   -webkit-touch-callout: none;
   -webkit-user-drag: none;
 }
+/* Letterboxed like the image, but without the transform machinery — a video sizes to
+   the stage and its own controls do the rest. */
+.video {
+  display: block;
+  max-width: 92vw;
+  max-height: 100%;
+  /* A portrait phone clip in a landscape stage would otherwise be a sliver. */
+  min-width: min(320px, 92vw);
+  background: #000;
+}
+
+/* Audio has nothing to look at, so the card IS the presentation. */
+.audio-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-9);
+  width: min(480px, 92vw);
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.audio-art {
+  font-size: 4em;
+  color: var(--fg-muted);
+}
+.audio-name {
+  margin: 0;
+  color: var(--fg);
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  text-align: center;
+}
+.audio {
+  width: 100%;
+}
+
+/* A .txt is usually a pasted chat message, so it wants to read like one: themed,
+   selectable, wrapped rather than scrolled sideways. */
+.text {
+  margin: 0;
+  padding: var(--space-7);
+  width: min(900px, 92vw);
+  max-height: 100%;
+  overflow: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  font-family: var(--font-mono, monospace);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  user-select: text;
+  text-align: left;
+}
+
 .image--zoomed {
   cursor: zoom-out;
 }

--- a/vue_client/src/components/MediaViewerModal.vue
+++ b/vue_client/src/components/MediaViewerModal.vue
@@ -137,32 +137,31 @@
 
       <!-- VIDEO. `playsinline` is not optional: without it iOS Safari yanks the video
            into its own native fullscreen player and our viewer — gallery arrows, copy
-           link, the lot — is gone. `autoplay` is a request, not a promise: if the
-           browser's autoplay policy refuses it, the controls are right there. -->
+           link, the lot — is gone.
+
+           NO autoplay, here or on audio. Opening a file to look at it is not the same
+           as asking it to start making noise, and walking a gallery with the arrow keys
+           would fire off a new track on every keypress. Press play. -->
       <video
         v-else-if="kind === 'video'"
         v-show="!loading && !failed"
         class="video"
         :src="displayUrl"
         controls
-        autoplay
         playsinline
         preload="metadata"
         @loadeddata="onLoad"
         @error="onError"
       ></video>
 
-      <!-- AUDIO has nothing to show, so give it something to be: the filename and a
-           player, framed as a card rather than a bare <audio> element floating in a
-           black void. -->
+      <!-- AUDIO is just the player, in a box. There is nothing to look at, and dressing
+           the nothing up with a big music glyph was decoration standing in for content.
+           The filename lives in the caption above, same as every other kind. -->
       <div v-else-if="kind === 'audio'" v-show="!loading && !failed" class="audio-card">
-        <i class="fa-solid fa-music audio-art" aria-hidden="true"></i>
-        <p v-if="filename" class="audio-name">{{ filename }}</p>
         <audio
           class="audio"
           :src="displayUrl"
           controls
-          autoplay
           preload="metadata"
           @loadeddata="onLoad"
           @error="onError"
@@ -912,29 +911,16 @@ onBeforeUnmount(() => {
   background: #000;
 }
 
-/* Audio has nothing to look at, so the card IS the presentation. */
+/* Just the player, in a box — the box exists only to give the native control strip a
+   surface to sit on instead of floating in the black. */
 .audio-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-6);
-  padding: var(--space-9);
+  padding: var(--space-6);
   width: min(480px, 92vw);
   background: var(--bg);
   border: 1px solid var(--border);
 }
-.audio-art {
-  font-size: 4em;
-  color: var(--fg-muted);
-}
-.audio-name {
-  margin: 0;
-  color: var(--fg);
-  max-width: 100%;
-  overflow-wrap: anywhere;
-  text-align: center;
-}
 .audio {
+  display: block;
   width: 100%;
 }
 

--- a/vue_client/src/components/RecentUploadsModal.vue
+++ b/vue_client/src/components/RecentUploadsModal.vue
@@ -134,11 +134,12 @@ import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue';
 import AppModal from './AppModal.vue';
 import { useUploadsStore } from '../stores/uploads.js';
 import type { UploadItem, UploadKind } from '../stores/uploads.js';
-import { useImageModal } from '../composables/useImageModal.js';
+import { useMediaViewer } from '../composables/useMediaViewer.js';
 import { useCopyFeedback } from '../composables/useCopyFeedback.js';
 import { formatRelative } from '../utils/timestamp.js';
 import { joinMeta } from '../utils/metaLine.js';
 import { iconForMime } from '../utils/uploaders.js';
+import { mediaKindForUrl } from '../utils/uploadHostMatch.js';
 
 // The server response can include extra metadata fields not tracked in the
 // store's base UploadItem shape (they come from the GET /api/uploads list).
@@ -167,7 +168,7 @@ defineEmits<{
 const uploads = useUploadsStore();
 // Raw (not reactive()-wrapped) because this component reads the refs in script rather
 // than the template — the two views that RENDER the viewer wrap it for unwrapping.
-const imageModal = useImageModal();
+const viewer = useMediaViewer();
 const recentRows = computed(() => uploads.recent as UploadRow[]);
 const listEl = ref<HTMLDivElement | null>(null);
 const searchEl = ref<HTMLInputElement | null>(null);
@@ -248,22 +249,23 @@ function onKind(kind: UploadKind | null) {
 // to scope the gallery — filter to images, type "march", and you can flick through
 // exactly those.
 
-// Only images. The viewer renders an <img>, so a .txt or an .mp4 in the gallery would
-// be a step onto a blank screen. (Video joins it in #563; that's the card, not this
-// one.) They keep the plain new-tab link.
+// EVERY kind the viewer can show, which since #563 is every kind we accept: images,
+// video, audio, and text. The gallery used to be images-only because the viewer was an
+// <img> and anything else was a step onto a blank screen. Now left/right walks the
+// whole result set — so the filters double as a way to scope it, and "Audio" + arrow
+// keys is a playlist.
+//
+// A moderated-away upload stays out: its bytes are gone, so there is nothing to view.
 const galleryItems = computed(() =>
-  recentRows.value
-    .filter((u) => !u.removed && (u.mime || '').startsWith('image/'))
-    .map((u) => ({ url: u.url, filename: u.filename })),
+  recentRows.value.filter(isViewable).map((u) => ({ url: u.url, filename: u.filename })),
 );
 
 function isViewable(u: UploadRow): boolean {
-  return !u.removed && (u.mime || '').startsWith('image/');
+  return !u.removed && mediaKindForUrl(u.url) !== null;
 }
 
 function onArtClick(event: MouseEvent, u: UploadRow) {
-  // Let the browser have the ones it does better: a modified click means "new tab",
-  // and a non-image has nothing to show in an image viewer.
+  // A modified click still means "new tab" — the browser does that better than we do.
   if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
     return;
   if (!isViewable(u)) return;
@@ -273,16 +275,16 @@ function onArtClick(event: MouseEvent, u: UploadRow) {
   if (start < 0) return;
 
   event.preventDefault();
-  imageModal.openGallery(items, start);
+  viewer.openGallery(items, start);
 }
 
 // Arrowing toward the end of what's loaded pages more in — otherwise the gallery
 // silently stops at the last row the user happened to have scrolled to, which from
 // inside the viewer looks like the end of their uploads.
 watch(
-  () => imageModal.index.value,
+  () => viewer.index.value,
   (i) => {
-    if (!imageModal.isOpen.value) return;
+    if (!viewer.isOpen.value) return;
     if (i < galleryItems.value.length - 2) return;
     if (!uploads.hasMore || uploads.loading) return;
     void uploads.loadMore();
@@ -292,7 +294,7 @@ watch(
 // New rows landed (from paging, or a fresh upload) while the viewer is open — extend
 // the gallery under it. setItems keeps the viewer on the image it is showing.
 watch(galleryItems, (items) => {
-  if (imageModal.isOpen.value) imageModal.setItems(items);
+  if (viewer.isOpen.value) viewer.setItems(items);
 });
 
 function onScroll() {

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -60,9 +60,9 @@ import { segmentInlineStyle, segmentHasStyle } from '../utils/nickColor.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useMircPalette } from '../composables/useNickColors.js';
-import { useImageModal } from '../composables/useImageModal.js';
+import { useMediaViewer } from '../composables/useMediaViewer.js';
 import { socketSend } from '../composables/useSocket.js';
-import { isImageUrl } from '../utils/uploadHostMatch.js';
+import { mediaKindForUrl } from '../utils/uploadHostMatch.js';
 import SpoilerText from './SpoilerText.vue';
 
 // The single renderer for an array of RenderSegments (the output of
@@ -97,7 +97,7 @@ defineEmits<{
 
 const buffers = useBuffersStore();
 const settings = useSettingsStore();
-const imageModal = useImageModal();
+const viewer = useMediaViewer();
 const mircPalette = useMircPalette();
 
 function styleFor(seg: RenderSegment): CSSProperties {
@@ -107,10 +107,17 @@ function hasStyle(seg: RenderSegment): boolean {
   return segmentHasStyle(seg);
 }
 
-function isModalImageUrl(url: string): boolean {
+// Any kind the viewer can show, not just images (#563): a video, an audio file, or a
+// .txt now open in-app too, rather than throwing the user out to a new tab.
+//
+// The setting KEY still says `image_modal` — deliberately. Renaming it would orphan the
+// stored row of every user who has turned the viewer off, silently switching it back on
+// for exactly the people who said they didn't want it. The label they read says "Media
+// viewer"; the key is just an id.
+function isViewableUrl(url: string): boolean {
   if (settings.effective('chat.image_modal.enabled') !== true) return false;
 
-  return isImageUrl(url);
+  return mediaKindForUrl(url) !== null;
 }
 
 function onLinkClick(event: MouseEvent, url: string): void {
@@ -118,10 +125,10 @@ function onLinkClick(event: MouseEvent, url: string): void {
 
   if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
     return;
-  if (!isModalImageUrl(url)) return;
+  if (!isViewableUrl(url)) return;
 
   event.preventDefault();
-  imageModal.open(url);
+  viewer.open(url);
 }
 
 // Clicking a channel name mirrors IRCCloud. IRC channel names are

--- a/vue_client/src/composables/useMediaViewer.test.ts
+++ b/vue_client/src/composables/useMediaViewer.test.ts
@@ -2,21 +2,20 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useImageModal } from './useImageModal.js';
+import { useMediaViewer } from './useMediaViewer.js';
 
 const item = (n: number) => ({ url: `https://x.test/${n}.webp`, filename: `${n}.png` });
 const items = (...ns: number[]) => ns.map(item);
 
 // The composable is a module-level singleton (one lightbox for the whole app), so each
 // test has to start from a closed one.
-beforeEach(() => useImageModal().close());
+beforeEach(() => useMediaViewer().close());
 
-describe('useImageModal — a single image is a gallery of one', () => {
-  // The framing the whole design rests on: an image clicked in a message and one
-  // clicked in the uploads browser reach the same viewer, and the single-image case
+describe('useMediaViewer — a single file is a gallery of one', () => {
+  // The framing the whole design rests on: a file clicked in a message and one  // clicked in the uploads browser reach the same viewer, and the single-image case
   // needs no special path — it just has nowhere to go.
   it('opens one image with no navigation', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.open('https://x.test/solo.webp');
 
     expect(m.isOpen.value).toBe(true);
@@ -27,7 +26,7 @@ describe('useImageModal — a single image is a gallery of one', () => {
   });
 
   it('next/prev are inert on a gallery of one', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.open('https://x.test/solo.webp');
     m.next();
     m.prev();
@@ -35,9 +34,9 @@ describe('useImageModal — a single image is a gallery of one', () => {
   });
 });
 
-describe('useImageModal — gallery navigation', () => {
+describe('useMediaViewer — gallery navigation', () => {
   it('opens at the image that was clicked, not at the start', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery(items(1, 2, 3), 2);
     expect(m.url.value).toBe('https://x.test/3.webp');
     expect(m.index.value).toBe(2);
@@ -46,7 +45,7 @@ describe('useImageModal — gallery navigation', () => {
   });
 
   it('walks forward and back', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery(items(1, 2, 3), 0);
     m.next();
     expect(m.url.value).toBe('https://x.test/2.webp');
@@ -57,7 +56,7 @@ describe('useImageModal — gallery navigation', () => {
   });
 
   it('stops at the ends instead of wrapping', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery(items(1, 2), 0);
     m.prev();
     expect(m.index.value).toBe(0); // already at the first
@@ -67,23 +66,23 @@ describe('useImageModal — gallery navigation', () => {
   });
 
   it('clamps an out-of-range start index rather than showing nothing', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery(items(1, 2), 99);
     expect(m.url.value).toBe('https://x.test/2.webp');
   });
 
   it('refuses to open an empty gallery', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery([], 0);
     expect(m.isOpen.value).toBe(false);
   });
 });
 
-describe('useImageModal — extending the gallery while it is open', () => {
+describe('useMediaViewer — extending the gallery while it is open', () => {
   // The uploads browser pages lazily, so arrowing toward the end of what's loaded has
   // to extend the list UNDER the viewer. The user must not be moved.
   it('keeps the viewer on its image when a page is appended', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery(items(1, 2, 3), 2);
 
     m.setItems(items(1, 2, 3, 4, 5));
@@ -97,7 +96,7 @@ describe('useImageModal — extending the gallery while it is open', () => {
   // fresh upload lands at the top) doesn't silently teleport the user to a different
   // photo — which is a far worse bug than a redundant re-render.
   it('keeps the viewer on its image when a row is prepended', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery(items(1, 2, 3), 0);
     expect(m.url.value).toBe('https://x.test/1.webp');
 
@@ -108,7 +107,7 @@ describe('useImageModal — extending the gallery while it is open', () => {
   });
 
   it('falls back to a valid index when the viewed image disappears', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery(items(1, 2, 3), 2);
     // e.g. the user deleted it, or a filter changed under the gallery.
     m.setItems(items(1, 2));
@@ -117,9 +116,9 @@ describe('useImageModal — extending the gallery while it is open', () => {
   });
 });
 
-describe('useImageModal — close', () => {
+describe('useMediaViewer — close', () => {
   it('drops the gallery so the next open starts clean', () => {
-    const m = useImageModal();
+    const m = useMediaViewer();
     m.openGallery(items(1, 2, 3), 1);
     m.close();
 

--- a/vue_client/src/composables/useMediaViewer.ts
+++ b/vue_client/src/composables/useMediaViewer.ts
@@ -32,12 +32,12 @@ export function useMediaViewer() {
   const hasPrev = computed(() => index.value > 0);
   const hasNext = computed(() => index.value < items.value.length - 1);
 
-  /** Open a single image — a gallery of one. */
+  /** Open a single file — a gallery of one. */
   function open(nextUrl: string): void {
     openGallery([{ url: nextUrl }], 0);
   }
 
-  /** Open a list of images, starting at `startIndex` (the uploads browser). */
+  /** Open a list of files, starting at `startIndex` (the uploads browser). */
   function openGallery(next: GalleryItem[], startIndex = 0): void {
     if (!next.length) return;
     items.value = next;

--- a/vue_client/src/composables/useMediaViewer.ts
+++ b/vue_client/src/composables/useMediaViewer.ts
@@ -1,13 +1,17 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// The lightbox's model. It is a GALLERY, and a single image is a gallery of one.
+// The media viewer's model. It is a GALLERY, and a single file is a gallery of one.
 //
-// That framing is the whole design. Clicking an image in a message (RenderSegments)
-// and clicking one in the uploads browser (#547) reach the same viewer; the only
-// difference is how many images came along with it. The single-image case therefore
-// needs no special path — `hasPrev`/`hasNext` are simply false and the arrows don't
-// render — which is why `open()` is just `openGallery()` with one item.
+// That framing is the whole design. Clicking a link in a message (RenderSegments) and
+// clicking a tile in the uploads browser (#547) reach the same viewer; the only
+// difference is how many files came along with it. The single-file case therefore needs
+// no special path — `hasPrev`/`hasNext` are simply false and the arrows don't render —
+// which is why `open()` is just `openGallery()` with one item.
+//
+// The model is deliberately blind to what KIND each item is (#563). The viewer derives
+// that from the URL when it renders, so this stays a list of things to look at, and
+// there is no second place that could disagree about what a `.mp4` is.
 
 import { computed, ref } from 'vue';
 
@@ -20,7 +24,7 @@ const isOpen = ref(false);
 const items = ref<GalleryItem[]>([]);
 const index = ref(0);
 
-export function useImageModal() {
+export function useMediaViewer() {
   const current = computed<GalleryItem | null>(() => items.value[index.value] ?? null);
   // The many call sites that only ever wanted "the image being viewed" keep working.
   const url = computed<string | null>(() => current.value?.url ?? null);

--- a/vue_client/src/stores/dcc.ts
+++ b/vue_client/src/stores/dcc.ts
@@ -108,7 +108,7 @@ export const useDccStore = defineStore('dcc', {
     listError: '',
     // Whether the Transfers modal is open. Lives in the store (not a view-local
     // ref) so `/dcc list` can open it from MessageInput, mirroring the
-    // composable-backed opens (useImageModal, useChannelListModal).
+    // composable-backed opens (useMediaViewer, useChannelListModal).
     panelOpen: false,
     // Per-transfer action in flight (disables that row's buttons).
     busy: {} as Record<number, boolean>,

--- a/vue_client/src/utils/uploadHostMatch.test.ts
+++ b/vue_client/src/utils/uploadHostMatch.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, expect, it } from 'vitest';
-import { isImageUrl } from './uploadHostMatch.js';
+import { isImageUrl, mediaKindForUrl } from './uploadHostMatch.js';
 
 describe('isImageUrl', () => {
   it('matches image URLs on any host', () => {
@@ -45,5 +45,56 @@ describe('isImageUrl', () => {
 
   it('rejects malformed URLs', () => {
     expect(isImageUrl('not a url')).toBe(false);
+  });
+});
+
+// #563. The viewer shows four kinds now, and this is the one rule that decides which —
+// a link clicked in a message and a tile clicked in the uploads grid both come here, so
+// they cannot disagree about what a URL is.
+describe('mediaKindForUrl', () => {
+  it.each([
+    ['https://x.test/a.png', 'image'],
+    ['https://x.test/a.webp', 'image'],
+    ['https://x.test/a.mp4', 'video'],
+    ['https://x.test/a.mov', 'video'],
+    ['https://x.test/a.m4v', 'video'],
+    ['https://x.test/a.mp3', 'audio'],
+    ['https://x.test/a.m4a', 'audio'],
+    ['https://x.test/a.txt', 'text'],
+  ] as const)('classifies %s as %s', (url, kind) => {
+    expect(mediaKindForUrl(url)).toBe(kind);
+  });
+
+  // Deliberately WIDER than what the uploader accepts. The viewer renders links; it is
+  // not a gate on uploads. Refusing to play someone's .webm because *we* can't yet
+  // scrub its metadata (#553) would be enforcing our upload policy on their link.
+  it.each([
+    ['https://x.test/a.webm', 'video'],
+    ['https://x.test/a.flac', 'audio'],
+    ['https://x.test/a.ogg', 'audio'],
+    ['https://x.test/a.wav', 'audio'],
+  ] as const)('plays %s even though we would not accept it as an upload', (url, kind) => {
+    expect(mediaKindForUrl(url)).toBe(kind);
+  });
+
+  it('is case-insensitive and survives a query string', () => {
+    expect(mediaKindForUrl('https://x.test/CLIP.MP4?v=2')).toBe('video');
+  });
+
+  // Anything we can't name stays an ordinary link that opens in a new tab — the
+  // behaviour every URL had before the viewer existed.
+  it.each([
+    'https://x.test/page.html',
+    'https://x.test/archive.zip',
+    'https://x.test/',
+    'not-a-url',
+  ])('leaves %s unclassified', (url) => {
+    expect(mediaKindForUrl(url)).toBeNull();
+  });
+
+  it('keeps isImageUrl in agreement with itself', () => {
+    expect(isImageUrl('https://x.test/a.png')).toBe(true);
+    // An image-only caller must not start treating videos as images.
+    expect(isImageUrl('https://x.test/a.mp4')).toBe(false);
   });
 });

--- a/vue_client/src/utils/uploadHostMatch.ts
+++ b/vue_client/src/utils/uploadHostMatch.ts
@@ -1,16 +1,51 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.bmp'] as const;
+/**
+ * What kind of thing a URL points at, judged by its extension.
+ *
+ * This is the media viewer's gate (#563): it decides whether clicking a link in a
+ * message opens the in-app viewer instead of ejecting you to a new tab, and which
+ * element the viewer renders.
+ *
+ * ⚠ The extension is all we have. These are arbitrary URLs from a chat message — no
+ * HEAD request, no mime — so a `.mp4` served as something else will simply fail to
+ * play and land on the viewer's "open in browser" card. That's the right failure: the
+ * cost of guessing wrong is one dead lightbox, and the cost of NOT guessing is that
+ * every image in every channel goes back to opening in a new tab.
+ */
+export type MediaKind = 'image' | 'video' | 'audio' | 'text';
 
-export function isImageUrl(rawUrl: string): boolean {
+// Deliberately WIDER than what the uploader accepts. The viewer is a renderer of
+// links, not a gate on uploads: a .webm or .flac someone pastes from elsewhere plays
+// perfectly well in a browser, and refusing to show it because *we* can't yet scrub its
+// metadata (#553) would be enforcing our upload policy on other people's links.
+const EXTENSIONS: Record<MediaKind, readonly string[]> = {
+  image: ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.bmp'],
+  video: ['.mp4', '.mov', '.m4v', '.webm'],
+  audio: ['.mp3', '.m4a', '.ogg', '.oga', '.wav', '.flac'],
+  text: ['.txt'],
+};
+
+export function mediaKindForUrl(rawUrl: string): MediaKind | null {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
   } catch {
-    return false;
+    return null;
   }
 
   const path = parsed.pathname.toLowerCase();
-  return IMAGE_EXTS.some((ext) => path.endsWith(ext) || path.includes(`${ext}/`));
+  for (const [kind, exts] of Object.entries(EXTENSIONS)) {
+    // `${ext}/` as well as endsWith: some hosts hang a transform path off the file
+    // (…/photo.jpg/large), and that's still a photo.
+    if (exts.some((ext) => path.endsWith(ext) || path.includes(`${ext}/`))) {
+      return kind as MediaKind;
+    }
+  }
+  return null;
+}
+
+export function isImageUrl(rawUrl: string): boolean {
+  return mediaKindForUrl(rawUrl) === 'image';
 }

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -271,17 +271,17 @@
       @jump="onJumpToMessage"
     />
     <KeyboardHelpModal v-if="showKbdHelp" @close="showKbdHelp = false" />
-    <ImageViewerModal
-      v-if="imageModal.isOpen && imageModal.url !== null"
-      :url="imageModal.url"
-      :filename="imageModal.current?.filename ?? null"
-      :index="imageModal.index"
-      :count="imageModal.count"
-      :has-prev="imageModal.hasPrev"
-      :has-next="imageModal.hasNext"
-      @close="imageModal.close()"
-      @prev="imageModal.prev()"
-      @next="imageModal.next()"
+    <MediaViewerModal
+      v-if="viewer.isOpen && viewer.url !== null"
+      :url="viewer.url"
+      :filename="viewer.current?.filename ?? null"
+      :index="viewer.index"
+      :count="viewer.count"
+      :has-prev="viewer.hasPrev"
+      :has-next="viewer.hasNext"
+      @close="viewer.close()"
+      @prev="viewer.prev()"
+      @next="viewer.next()"
     />
     <UserProfileModal
       v-if="whois.viewer.open && whois.viewer.networkId != null"
@@ -334,7 +334,7 @@ import KeyboardHelpModal from '../components/KeyboardHelpModal.vue';
 import NickNoteModal from '../components/NickNoteModal.vue';
 import ConfigureFriendModal from '../components/ConfigureFriendModal.vue';
 import UserProfileModal from '../components/UserProfileModal.vue';
-import ImageViewerModal from '../components/ImageViewerModal.vue';
+import MediaViewerModal from '../components/MediaViewerModal.vue';
 import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts.js';
 import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
@@ -343,7 +343,7 @@ import { useDccStore } from '../stores/dcc.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
-import { useImageModal } from '../composables/useImageModal.js';
+import { useMediaViewer } from '../composables/useMediaViewer.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
 import { useNavHistoryStore } from '../stores/navHistory.js';
@@ -393,7 +393,7 @@ const whois = useWhoisStore();
 
 const channelListModal = reactive(useChannelListModal());
 const joinChannelModal = reactive(useJoinChannelModal());
-const imageModal = reactive(useImageModal());
+const viewer = reactive(useMediaViewer());
 const networkEditor = reactive(useNetworkEditor());
 const navHistory = useNavHistoryStore();
 const showBookmarks = ref(false);
@@ -426,7 +426,7 @@ const anyModalOpen = computed(
     showTopic.value ||
     channelListModal.isOpen ||
     joinChannelModal.isOpen ||
-    imageModal.isOpen ||
+    viewer.isOpen ||
     showUploads.value ||
     dcc.panelOpen ||
     showSwitcher.value ||

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -204,17 +204,17 @@
       @close="showSearch = false"
       @jump="onJumpToMessage"
     />
-    <ImageViewerModal
-      v-if="imageModal.isOpen && imageModal.url !== null"
-      :url="imageModal.url"
-      :filename="imageModal.current?.filename ?? null"
-      :index="imageModal.index"
-      :count="imageModal.count"
-      :has-prev="imageModal.hasPrev"
-      :has-next="imageModal.hasNext"
-      @close="imageModal.close()"
-      @prev="imageModal.prev()"
-      @next="imageModal.next()"
+    <MediaViewerModal
+      v-if="viewer.isOpen && viewer.url !== null"
+      :url="viewer.url"
+      :filename="viewer.current?.filename ?? null"
+      :index="viewer.index"
+      :count="viewer.count"
+      :has-prev="viewer.hasPrev"
+      :has-next="viewer.hasNext"
+      @close="viewer.close()"
+      @prev="viewer.prev()"
+      @next="viewer.next()"
     />
     <UserProfileModal
       v-if="whois.viewer.open && whois.viewer.networkId != null"
@@ -263,14 +263,14 @@ import SearchModal from '../components/SearchModal.vue';
 import NickNoteModal from '../components/NickNoteModal.vue';
 import ConfigureFriendModal from '../components/ConfigureFriendModal.vue';
 import UserProfileModal from '../components/UserProfileModal.vue';
-import ImageViewerModal from '../components/ImageViewerModal.vue';
+import MediaViewerModal from '../components/MediaViewerModal.vue';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useFriendsStore } from '../stores/friends.js';
 import { useDccStore } from '../stores/dcc.js';
 import { useWhoisStore } from '../stores/whois.js';
 import { useChannelListModal } from '../composables/useChannelListModal.js';
 import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
-import { useImageModal } from '../composables/useImageModal.js';
+import { useMediaViewer } from '../composables/useMediaViewer.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
 import { useVisualViewport } from '../composables/useVisualViewport.js';
@@ -328,7 +328,7 @@ function openSystemConsole() {
 // land on the buffer screen with no active buffer.
 const channelListModal = reactive(useChannelListModal());
 const joinChannelModal = reactive(useJoinChannelModal());
-const imageModal = reactive(useImageModal());
+const viewer = reactive(useMediaViewer());
 const networkEditor = reactive(useNetworkEditor());
 const screen = ref('list');
 const showBookmarks = ref(false);


### PR DESCRIPTION
Closes #563. Scope grew, at your suggestion, from "mp4/mov" to **every type the uploader accepts**.

#515 made media a first-class upload — the cell takes mp4/mov/m4v/m4a/mp3, scrubs their metadata, serves them inline. Then you clicked one and Lurker threw you out into a new tab, while an image opened the lightbox.

## The four modes

| kind | element | notes |
|---|---|---|
| image | `<img>` | pan/zoom, as before — the one thing you want to inspect closer than it fits |
| video | `<video controls playsinline autoplay>` | mp4, mov, m4v (+ webm) |
| audio | `<audio controls autoplay>` in a card | mp3, m4a (+ ogg, wav, flac) |
| text | fetched, themed `<pre>` | .txt |

Renamed `ImageViewerModal` → `MediaViewerModal` and `useImageModal` → `useMediaViewer`. A file called `ImageViewerModal` that plays mp3s is a name that lies, and the next person to read it pays for that.

## ⚠ Text is the only mode subject to CORS

This is the fact that shaped the design, and it's worth understanding before reviewing.

An `<img>` or `<video>` **renders** a cross-origin file without the host's permission. **Reading** one requires it. Text is the only kind we have to `fetch()`, so it works on the `local` driver (same origin) and is at the mercy of the provider anywhere else — catbox, x0, a CDN.

There is no client-side way around that. A proxy on our own server would be an SSRF surface *and* would put every viewed file through our bandwidth. So when it's refused, it lands on the same "open in browser" card a dead image already did — **exactly today's behaviour, nothing lost by trying.**

Worth doing anyway: Lurker's own long-message paste becomes a `.txt` upload, so this is the mode that lets you read one without leaving the app. And we control our own CDN, so the hosted side can be fixed later with an `Access-Control-Allow-Origin` header (a control-plane change, not this repo).

## One classifier, deliberately wider than the uploader

`mediaKindForUrl()` is the single rule for what a URL is. A link clicked in a message and a tile clicked in the uploads grid both go through it, so there is no second rule that could disagree about what a `.mp4` is.

It accepts **more** than we'd take as an upload — `.webm`, `.flac`, `.ogg`, `.wav`. The viewer renders links; it is not a gate on uploads. Refusing to play someone's `.webm` because *we* can't yet scrub that container (#553) would be enforcing our upload policy on their file.

## Things that would have bitten

- **`playsinline` is not optional.** Without it iOS Safari yanks the video into its own native fullscreen player and our viewer — gallery arrows, copy link, all of it — is gone.
- **Arrow keys stop stealing left/right when a `<video>`/`<audio>` has focus.** The browser already gives those keys a better meaning there (seek), and someone who has clicked into the player is plainly not asking for the next file.
- **The pinch/pan touch guard only arms in image mode.** Swallowing touches in the others would fight the native media controls for their own scrubbing gestures, and would stop a long `<pre>` being scrolled with a finger.
- **`autoplay` is a request, not a promise.** If the browser's policy refuses it, the controls are right there.
- **Text is capped at 200k chars.** A `.txt` upload is a pasted chat message, but nothing stops someone linking a 200 MB log, and a `<pre>` with that in it locks the tab.
- **The uploads gallery no longer filters to images** — left/right walks the whole result set, so "Audio" + arrow keys is a playlist.

## ⚠ The setting key stays `chat.image_modal.enabled`

Renaming it is a **migration**, not a rename. The stored row lives under the old key, so a new key would orphan it — silently switching the viewer back **on** for exactly the people who went out of their way to turn it off. The label they read is now "Media viewer". The key is an id, and ids age.

## Verification

`npm run check` clean, `npm test` green (2369 passing), client builds. The classifier has its own suite, including the wider-than-uploads cases and the unclassifiable ones that must stay ordinary links.

The four modes themselves want real QA — especially video on iOS (the `playsinline` case) and a `.txt` on a remote provider (the CORS fallback), which are the two I can't drive from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)