### PR TITLE
Release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.1.0",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Bumps `1.0.9` → `1.1.0`.

## Why 1.1.0 and not something else

**Too big for a patch.** 102 commits since `v1.0.9`:

- **The uploader overhaul (#509, now closed)** — pluggable storage drivers (local disk, S3/R2, Zipline, Chibisafe, the in-house dropper), admin-managed uploader configs with policy, expanded file types (media), EXIF/metadata scrubbing on upload, and user-initiated deletes that reap the real bytes.
- **Admin panel** (#507) and its graduation out of the feature flag.
- **First-run onboarding** (#300/#308) with admin-defined instance networks and network lockdown.
- **Uploads, finished properly** — WebP by default (which fixed a live alpha-destruction bug), honest upload progress (the bar used to read "100%" through the entire server→provider leg), a searchable uploads browser, and a media viewer that plays video/audio and reads text instead of ejecting you to a new tab.
- **Channel tab-completion**, contributed by @JawshTheDark (#539).
- Plus the usual run of fixes and Dependabot.

**Not a major, because nothing breaks.** I checked the three changes that looked like they might:

| Looked breaking | Actually |
|---|---|
| `hoarder` → `dropper` driver rename (#537) | **Alias kept.** The id is PERSISTED — in `uploader_config.driver` rows and in old `.lurk` exports — so it can arrive from data we don't control. |
| `uploads.provider` + flat credential settings removed (#514) | **Auto-migrated on every boot** by `reconcileLegacyUploadSettings`. |
| `LURKER_NEW_ADMIN_PANEL` deleted | **No longer read at all.** A stale env var is ignored, not an error. |

Backwards-compatible feature additions → minor bump.

## The diff

Four files, six lines. `package.json` + `vue_client/package.json`, and both lockfiles **regenerated with `npm install --package-lock-only` rather than hand-edited** — `package-lock.json` also carries *dependency* versions that happen to be `1.0.9` (`@types/estree`, among others), and a find-and-replace would have quietly corrupted them. `docs/package-lock.json` is deliberately untouched for the same reason: its `1.0.9` is `@types/estree`, not us.

## Worth knowing

The version is read at runtime by `server/utils/userAgent.ts`, so this isn't only cosmetic — it's what Lurker now tells the outside world:

```
APP_VERSION = 1.1.0
USER_AGENT  = Lurker/1.1.0 (+https://github.com/amiantos/lurker)
```

That string goes out in the HTTP User-Agent to upload hosts and in the **CTCP VERSION reply** to IRC peers.

`npm run check` clean, `npm test` green (2391 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)