### PR TITLE
Accept bearer session tokens on the WebSocket and REST (#489)

### DIFF
--- a/server/middleware/auth.test.ts
+++ b/server/middleware/auth.test.ts
@@ -62,3 +62,53 @@ describe('requireAuth stale-session recovery', () => {
     expect(res.headers['set-cookie']).toBeUndefined();
   });
 });
+
+// Native clients (iOS/Android) present the session token as a bearer instead of
+// a cookie. Same session row, same lookup — the only difference is where the
+// token rides on the request.
+describe('requireAuth bearer auth (native clients)', () => {
+  it('accepts a session token presented as a bearer', async () => {
+    const { createSession } = await import('../db/sessions.js');
+    const { token } = createSession(userId);
+    const res = await testRequest(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('rejects an unknown bearer token without clearing cookies', async () => {
+    const res = await testRequest(app).get('/protected').set('Authorization', 'Bearer nonsense');
+    expect(res.status).toBe(401);
+    // No cookie was sent, so there is no stale cookie to clear — a native client
+    // has no cookie jar and must not be handed Set-Cookie headers.
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('rejects a malformed Authorization header', async () => {
+    const res = await testRequest(app).get('/protected').set('Authorization', 'Basic abc123');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a bearer whose session has expired', async () => {
+    const { createSession } = await import('../db/sessions.js');
+    const db = (await import('../db/index.js')).default;
+    const { token } = createSession(userId);
+    db.prepare('UPDATE sessions SET expires_at = ? WHERE token = ?').run(
+      new Date(Date.now() - 1000).toISOString(),
+      token,
+    );
+    const res = await testRequest(app).get('/protected').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('falls through to the bearer when the cookie is stale', async () => {
+    // Not a shape a real native client produces (it sends no cookie at all), but
+    // it pins the precedence: a dead cookie must not shadow a good bearer.
+    const { createSession } = await import('../db/sessions.js');
+    const { token } = createSession(userId);
+    const res = await testRequest(app)
+      .get('/protected')
+      .set('Cookie', 'lurker_session=s%3Astale.deadbeefbadsignature')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -46,8 +46,40 @@ export function loadSession(req: Request): { session: Session; user: User } | nu
   return { session, user };
 }
 
+// Native clients (iOS/Android) authenticate with `Authorization: Bearer <token>`
+// instead of a cookie — they can set headers on a WebSocket upgrade, which
+// browsers cannot, and that is exactly why the web client stays cookie-bound.
+//
+// The bearer here IS a session token: the same opaque `sessions.token` the
+// cookie carries, just handed to the app in a response body rather than wrapped
+// in a Set-Cookie (see POST /api/auth/login/token). So this resolves through the
+// unmodified findSession path and a native session is a real session row —
+// revoking one is deleting a row, and expiry works as it always has.
+//
+// This does NOT collide with the API-token bearer (middleware/apiAuth.ts): that
+// one is mounted only on /mcp, so the two bearer namespaces never meet on the
+// same route.
+export function bearerToken(authorization: string | undefined): string | null {
+  const match = /^Bearer\s+(\S+)$/.exec(authorization ?? '');
+  return match ? match[1] : null;
+}
+
+export function loadBearerSession(
+  authorization: string | undefined,
+): { session: Session; user: User } | null {
+  const token = bearerToken(authorization);
+  if (!token) return null;
+  const session = findSession(token);
+  if (!session) return null;
+  const user = findUserById(session.user_id);
+  if (!user) return null;
+  return { session, user };
+}
+
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  const ctx = loadSession(req);
+  // Cookie first (every web request), bearer second (native only) — so the hot
+  // path is unchanged and a native request costs one extra header regex.
+  const ctx = loadSession(req) ?? loadBearerSession(req.headers.authorization);
   if (!ctx) {
     // If the request carried a lurker_session we can't honor — a stale cookie
     // whose signature no longer verifies (cell SESSION_SECRET rotated on a

--- a/server/routes/auth.test.ts
+++ b/server/routes/auth.test.ts
@@ -277,3 +277,92 @@ describe('POST /api/auth/invite/:token/password', () => {
     expect(reuse.status).toBe(404);
   });
 });
+
+// The native-app front door: password in, session token out, no browser needed.
+//
+// Owns its user rather than reusing `firstadmin`, whose password the
+// password-management suite above rotates mid-file — these tests must not care
+// what order they run in.
+describe('POST /api/auth/login/token', () => {
+  const USERNAME = 'nativeclient';
+  const PASSWORD = 'nativepassword';
+
+  beforeAll(async () => {
+    const { createUser, setPasswordHash } = await import('../db/users.js');
+    const { hashPassword } = await import('../services/password.js');
+    const user = createUser(USERNAME);
+    setPasswordHash(user.id, hashPassword(PASSWORD));
+  });
+
+  const mint = () =>
+    testRequest(app).post('/api/auth/login/token').send({ username: USERNAME, password: PASSWORD });
+
+  it('rejects a request with no credentials', async () => {
+    const res = await testRequest(app).post('/api/auth/login/token').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a wrong password', async () => {
+    const res = await testRequest(app).post('/api/auth/login/token').send({
+      username: USERNAME,
+      password: 'notthepassword',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.token).toBeUndefined();
+  });
+
+  it('rejects an unknown user', async () => {
+    const res = await testRequest(app).post('/api/auth/login/token').send({
+      username: 'ghost',
+      password: PASSWORD,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('mints a token in the body and sets no cookie', async () => {
+    const res = await mint();
+    expect(res.status).toBe(200);
+    expect(typeof res.body.token).toBe('string');
+    expect(res.body.token.length).toBeGreaterThan(20);
+    expect(new Date(res.body.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    expect(res.body.user.username).toBe(USERNAME);
+    // A native client has no cookie jar; handing it a Set-Cookie would be noise.
+    expect(res.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('mints a real session row — the token authenticates as a bearer', async () => {
+    const res = await mint();
+    const me = await testRequest(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${res.body.token}`);
+    expect(me.status).toBe(200);
+    expect(me.body.user.username).toBe(USERNAME);
+  });
+
+  it('logout revokes the bearer session, so the token stops working', async () => {
+    const token: string = (await mint()).body.token;
+
+    const out = await testRequest(app)
+      .post('/api/auth/logout')
+      .set('Authorization', `Bearer ${token}`);
+    expect(out.status).toBe(200);
+
+    const after = await testRequest(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+    expect(after.status).toBe(401);
+  });
+
+  it('revoking one device leaves the others signed in', async () => {
+    const phone: string = (await mint()).body.token;
+    const laptop: string = (await mint()).body.token;
+    expect(phone).not.toBe(laptop);
+
+    await testRequest(app).post('/api/auth/logout').set('Authorization', `Bearer ${phone}`);
+
+    const survivor = await testRequest(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${laptop}`);
+    expect(survivor.status).toBe(200);
+  });
+});

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -37,7 +37,7 @@ import {
   deleteById as deleteCredentialById,
 } from '../db/webauthnCredentials.js';
 import { createSession, deleteSession } from '../db/sessions.js';
-import { SESSION_COOKIE, getCookieOptions, requireAuth } from '../middleware/auth.js';
+import { SESSION_COOKIE, getCookieOptions, requireAuth, bearerToken } from '../middleware/auth.js';
 import { rpConfig, saveChallenge, consumeChallenge, userIdToHandle } from '../services/webauthn.js';
 import {
   hashPassword,
@@ -523,6 +523,43 @@ router.post('/login/password', (req: Request, res: Response) => {
   res.json({ user: { id: user.id, username: user.username, role: user.role } });
 });
 
+// Password → session token, for clients that have no browser to hold a cookie.
+// This is the native-app front door (iOS/Android): same credentials and same
+// `sessions` row as POST /login/password above, but the token is returned in the
+// body instead of a Set-Cookie, and the app then presents it as
+// `Authorization: Bearer <token>` on both REST calls and the /ws upgrade.
+//
+// Deliberately NOT a new kind of credential: a native session is an ordinary
+// session row, so expiry, lookup, and revocation all work exactly as they do
+// for the web client.
+//
+// SECURITY: this is a public, unauthenticated, password-in / long-lived-token-out
+// endpoint and it is NOT rate-limited — because nothing in Lurker is yet (#568).
+// It is no weaker than /login/password, which is equally public and equally
+// unthrottled, and it shares that route's constant-time miss behavior via
+// DUMMY_PASSWORD_HASH. #568 must cover both before this is advertised to users.
+router.post('/login/token', (req: Request, res: Response) => {
+  const username = (req.body?.username || '').trim();
+  const password: unknown = req.body?.password;
+  if (!isValidUsername(username) || typeof password !== 'string' || password.length === 0) {
+    res.status(400).json({ error: 'username and password required' });
+    return;
+  }
+  const user = findUserByUsername(username);
+  const stored = user ? getPasswordHash(user.id) : null;
+  const ok = verifyPassword(password, stored || DUMMY_PASSWORD_HASH);
+  if (!user || !stored || !ok) {
+    res.status(401).json({ error: 'invalid username or password' });
+    return;
+  }
+  const { token, expiresAt } = createSession(user.id);
+  res.json({
+    token,
+    expiresAt,
+    user: { id: user.id, username: user.username, role: user.role },
+  });
+});
+
 // Public probe so the login UI can decide which sign-in buttons to surface.
 // Currently just reports whether any passkey exists anywhere — discoverable
 // passkey login doesn't need a username, so a single global flag is enough.
@@ -533,7 +570,10 @@ router.get('/auth-methods', (_req: Request, res: Response) => {
 // ---------- session ----------
 
 router.post('/logout', (req: Request, res: Response) => {
-  const token = req.signedCookies?.[SESSION_COOKIE];
+  // Cookie for web, bearer for native — a native client has no cookie to clear,
+  // so without the bearer branch its "log out" would leave a live session row
+  // behind and the token on the device would keep working.
+  const token = req.signedCookies?.[SESSION_COOKIE] ?? bearerToken(req.headers.authorization);
   if (token) deleteSession(token);
   res.clearCookie(SESSION_COOKIE, { ...getCookieOptions(), maxAge: undefined });
   res.json({ ok: true });

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { setupTestDb } from '../test-utils/testApp.js';
+import { setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
+import { sign as signCookie } from 'cookie-signature';
+import type { IncomingMessage } from 'http';
 
 // setupTestDb sets DATABASE_PATH before any dynamic import touches db/index.js,
 // so it must run at module top level.
@@ -96,6 +98,11 @@ function mockWs() {
   const ws = { OPEN: 1, readyState: 1, send: (s: string) => frames.push(JSON.parse(s)) };
   return { ws: ws as unknown as Parameters<typeof handleOpenBuffer>[0], frames };
 }
+
+// authenticateUpgrade only reads headers, so a bare object stands in for a real
+// upgrade request.
+const upgrade = (headers: Record<string, string>): IncomingMessage =>
+  ({ headers }) as unknown as IncomingMessage;
 
 describe('buildBufferBacklog', () => {
   it('builds a backlog frame from a buffer’s persisted history', () => {
@@ -808,5 +815,70 @@ describe('eachUserBufferTarget / badge-vs-snapshot parity (#454)', () => {
     // The closed buffer is absent and the server pseudo-buffer is present in both.
     expect(standalone.some((s) => s.startsWith('#closed|'))).toBe(false);
     expect(standalone.some((s) => s.startsWith(`:server:${net}|`))).toBe(true);
+  });
+});
+
+// The /ws upgrade accepts two credentials: the signed session cookie (browsers)
+// and a bearer session token (native clients, which can set headers on the
+// upgrade where browsers cannot). Both must land on the same user.
+describe('authenticateUpgrade', () => {
+  let authenticateUpgrade: typeof import('./wsHub.js').authenticateUpgrade;
+  let createSession: typeof import('../db/sessions.js').createSession;
+
+  beforeAll(async () => {
+    ({ authenticateUpgrade } = await import('./wsHub.js'));
+    ({ createSession } = await import('../db/sessions.js'));
+  });
+
+  it('authenticates a browser via the signed session cookie', () => {
+    const { token } = createSession(userId);
+    const signed = encodeURIComponent('s:' + signCookie(token, TEST_SESSION_SECRET));
+    const user = authenticateUpgrade(
+      upgrade({ cookie: `lurker_session=${signed}` }),
+      TEST_SESSION_SECRET,
+    );
+    expect(user?.id).toBe(userId);
+  });
+
+  it('authenticates a native client via a bearer session token', () => {
+    const { token } = createSession(userId);
+    const user = authenticateUpgrade(
+      upgrade({ authorization: `Bearer ${token}` }),
+      TEST_SESSION_SECRET,
+    );
+    expect(user?.id).toBe(userId);
+  });
+
+  it('rejects an upgrade with no credentials at all', () => {
+    expect(authenticateUpgrade(upgrade({}), TEST_SESSION_SECRET)).toBeNull();
+  });
+
+  it('rejects an unknown bearer token', () => {
+    const user = authenticateUpgrade(
+      upgrade({ authorization: 'Bearer not-a-real-token' }),
+      TEST_SESSION_SECRET,
+    );
+    expect(user).toBeNull();
+  });
+
+  it('rejects a raw (unsigned) session token in the cookie', () => {
+    // The cookie path requires the 's:' signature prefix — a bearer token pasted
+    // into the cookie must not authenticate.
+    const { token } = createSession(userId);
+    const user = authenticateUpgrade(
+      upgrade({ cookie: `lurker_session=${token}` }),
+      TEST_SESSION_SECRET,
+    );
+    expect(user).toBeNull();
+  });
+
+  it('rejects a cookie signed with a different secret', () => {
+    const { token } = createSession(userId);
+    const signed = encodeURIComponent('s:' + signCookie(token, 'some-other-secret'));
+    const user = authenticateUpgrade(
+      upgrade({ cookie: `lurker_session=${signed}` }),
+      TEST_SESSION_SECRET,
+    );
+    expect(user).toBeNull();
   });
 });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -79,7 +79,7 @@ import { upsertChannel, ownsNetwork, listNetworksForUser } from '../db/networks.
 import * as chanlistDb from '../db/chanlist.js';
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from './settingsRegistry.js';
-import { SESSION_COOKIE } from '../middleware/auth.js';
+import { SESSION_COOKIE, loadBearerSession } from '../middleware/auth.js';
 import { callVerb } from './verbRegistry.js';
 
 // WebSocket extended with per-socket bookkeeping fields.
@@ -1031,6 +1031,38 @@ export function startChanlistRefresh(networkId: number): void {
   chanlistDb.setMeta(networkId, { inProgress: true, totalCount: 0, fetchedAt: null });
 }
 
+// Authenticate a `/ws` upgrade. Two accepted credentials, in order:
+//
+//   1. the signed `lurker_session` cookie — every browser client, unchanged;
+//   2. `Authorization: Bearer <session token>` — native clients, which unlike
+//      browsers can set arbitrary headers on the upgrade request.
+//
+// Both resolve to the same `sessions` row, so everything downstream of the
+// upgrade (and every WS verb) is identical regardless of how the client
+// authenticated. Lives at module scope rather than inside attachWsHub so it is
+// reachable from tests without standing up a real WebSocket server.
+export function authenticateUpgrade(req: IncomingMessage, sessionSecret: string): User | null {
+  const header = req.headers.cookie;
+  if (header) {
+    const cookies = cookie.parse(header);
+    const raw = cookies[SESSION_COOKIE];
+    if (raw) {
+      const token = raw.startsWith('s:') ? cookieParser.signedCookie(raw, sessionSecret) : false;
+      if (token) {
+        const session = findSession(token);
+        // A present-but-dead cookie falls through to the bearer check rather
+        // than short-circuiting to 401 — a native client sends no cookie at
+        // all, so in practice only one credential is ever on the request.
+        if (session) {
+          const user = findUserById(session.user_id);
+          if (user) return user;
+        }
+      }
+    }
+  }
+  return loadBearerSession(req.headers.authorization)?.user ?? null;
+}
+
 export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
   const wss = new WebSocketServer({ noServer: true });
   // Per-user pending auto-away timers. Set when a user goes from 1→0 sockets;
@@ -1470,22 +1502,9 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     fanOut(userId, { kind: 'account-state', paused: false });
   });
 
-  function authenticateRequest(req: IncomingMessage): User | null | undefined {
-    const header = req.headers.cookie;
-    if (!header) return null;
-    const cookies = cookie.parse(header);
-    const raw = cookies[SESSION_COOKIE];
-    if (!raw) return null;
-    const token = raw.startsWith('s:') ? cookieParser.signedCookie(raw, sessionSecret) : false;
-    if (!token) return null;
-    const session = findSession(token);
-    if (!session) return null;
-    return findUserById(session.user_id);
-  }
-
   httpServer.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
     if (!req.url || !req.url.startsWith('/ws')) return;
-    const user = authenticateRequest(req);
+    const user = authenticateUpgrade(req, sessionSecret);
     if (!user) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
       socket.destroy();

--- a/server/services/wsHub.upgrade.test.ts
+++ b/server/services/wsHub.upgrade.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// End-to-end cover for the /ws upgrade itself (#489). wsHub.test.ts exercises
+// authenticateUpgrade as a function; this drives a real `ws` client against a
+// real http server running attachWsHub, because the whole promise of native
+// bearer auth is that an actual socket opens when the ONLY credential on the
+// upgrade is an Authorization header. A function-level test cannot prove that:
+// it would still pass if the header never reached the upgrade handler.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import { WebSocket } from 'ws';
+import type { AddressInfo } from 'net';
+import { setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
+import { sign as signCookie } from 'cookie-signature';
+
+const testDb = setupTestDb('wshub-upgrade');
+
+let server: http.Server;
+let userId: number;
+let createSession: typeof import('../db/sessions.js').createSession;
+let url: string;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  ({ createSession } = await import('../db/sessions.js'));
+  const { attachWsHub } = await import('./wsHub.js');
+
+  userId = createUser('nativeuser').id;
+  server = http.createServer();
+  attachWsHub(server, TEST_SESSION_SECRET);
+  server.listen(0);
+  server.unref();
+  url = `ws://127.0.0.1:${(server.address() as AddressInfo).port}/ws`;
+});
+
+afterAll(() => {
+  server.close();
+  testDb.cleanup();
+});
+
+// Resolves to the first frame the server sends (hydration starts with
+// `snapshot`), or rejects with the HTTP status when the upgrade is refused.
+function connect(headers: Record<string, string>): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url, { headers });
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error('timed out waiting for a frame'));
+    }, 5000);
+    ws.on('message', (raw) => {
+      clearTimeout(timer);
+      ws.close();
+      resolve(JSON.parse(raw.toString()) as Record<string, unknown>);
+    });
+    ws.on('unexpected-response', (_req, res) => {
+      clearTimeout(timer);
+      reject(new Error(`upgrade refused: ${res.statusCode}`));
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+describe('/ws upgrade', () => {
+  it('opens for a native client presenting ONLY a bearer token', async () => {
+    const { token } = createSession(userId);
+    const frame = await connect({ Authorization: `Bearer ${token}` });
+    // Getting a snapshot means the socket opened AND hydration ran for the right
+    // user — the bearer resolved all the way through to a session.
+    expect(frame.kind).toBe('snapshot');
+  });
+
+  it('still opens for a browser presenting the signed session cookie', async () => {
+    const { token } = createSession(userId);
+    const signed = encodeURIComponent('s:' + signCookie(token, TEST_SESSION_SECRET));
+    const frame = await connect({ Cookie: `lurker_session=${signed}` });
+    expect(frame.kind).toBe('snapshot');
+  });
+
+  it('refuses an upgrade with no credentials', async () => {
+    await expect(connect({})).rejects.toThrow(/401/);
+  });
+
+  it('refuses an upgrade with an unknown bearer token', async () => {
+    await expect(connect({ Authorization: 'Bearer not-a-real-token' })).rejects.toThrow(/401/);
+  });
+});

--- a/server/services/wsHub.upgrade.test.ts
+++ b/server/services/wsHub.upgrade.test.ts
@@ -11,7 +11,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import http from 'http';
 import { WebSocket } from 'ws';
-import type { AddressInfo } from 'net';
 import { setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
 import { sign as signCookie } from 'cookie-signature';
 
@@ -30,9 +29,17 @@ beforeAll(async () => {
   userId = createUser('nativeuser').id;
   server = http.createServer();
   attachWsHub(server, TEST_SESSION_SECRET);
+  // listen(0) binds synchronously with no host argument, so address() is live on
+  // return (same reasoning as test-utils/testApp.ts). If it ever isn't, say so —
+  // casting the null away would build a `ws://127.0.0.1:undefined/ws` URL and
+  // surface a bind failure as an inscrutable connection error in every test below.
   server.listen(0);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test server did not bind synchronously to a TCP port');
+  }
   server.unref();
-  url = `ws://127.0.0.1:${(server.address() as AddressInfo).port}/ws`;
+  url = `ws://127.0.0.1:${address.port}/ws`;
 });
 
 afterAll(() => {


### PR DESCRIPTION
Closes #489. First foundational card in the **Mobile Apps** milestone: today the WebSocket authenticates by cookie only (`wsHub.ts` `authenticateRequest`), so a native client cannot open one at all. Everything else in that milestone is downstream of this.

## The shape

**A native session is an ordinary session.** The bearer *is* the `sessions.token` the cookie already carries — handed to the app in a response body instead of wrapped in a `Set-Cookie`. It therefore resolves through the unmodified `findSession` path, expiry works as it always has, and revoking a device is deleting a row. No new table, no parallel session system, no schema change.

- `middleware/auth.ts` — `bearerToken()` / `loadBearerSession()`. `requireAuth` tries the cookie first and the bearer second, so the web hot path is unchanged and one change covers every `requireAuth` route.
- `services/wsHub.ts` — `authenticateRequest` is lifted out of the `attachWsHub` closure into a module-level `authenticateUpgrade` (it only ever needed `sessionSecret` from that scope). Now cookie-then-bearer, and reachable from tests without standing up a WebSocket server.
- `routes/auth.ts` — `POST /api/auth/login/token`: password in, session token out, no browser in the loop. Mirrors `/login/password` including its constant-time `DUMMY_PASSWORD_HASH` miss behavior.
- `routes/auth.ts` — `POST /logout` now also accepts a bearer. Without this, a native "log out" would clear a cookie it never had and leave a live session row behind, with the token on the device still working.

**No bearer collision:** the API-token bearer (`middleware/apiAuth.ts`) is mounted only on `/mcp` (`app.ts:92`), so the two bearer namespaces never meet on the same route.

## Verification

`npm run check` and `npm test` both green (2413 passing).

Beyond the function-level tests, `wsHub.upgrade.test.ts` drives a **real `ws` client against a real http server running `attachWsHub`** — because the promise of this PR is that an actual socket opens when the only credential on the upgrade is an `Authorization` header, and a function-level test would still pass if that header never reached the upgrade handler. It asserts a bearer-only client gets a `snapshot` frame (socket opened *and* hydration ran for the right user), the cookie path still works, and both no-credential and bad-bearer upgrades are refused with 401.

I mutation-checked it: removing the bearer branch from `authenticateUpgrade` fails exactly the bearer test and nothing else.

## Deliberately not in scope

Both are pre-existing gaps that predate native and are **not** native-scoped, so they are split out rather than folded in here:

- **#567 — cell-side session revocation.** Verified against code: the cell has no `session_epoch` (it is a control-plane-only concept) and `PUT /api/auth/password` deletes no sessions. Changing your password on a cell logs nobody out, which means a lost phone cannot be remediated the way every user will try to remediate it.
- **#568 — rate limiting.** There is no rate limiting anywhere in Lurker, so the spec's "apply the same throttling as the current login routes" cannot be followed — they have none. `/login/token` is a public, unauthenticated, password-in/long-lived-token-out endpoint; it is no weaker than the equally-public and equally-unthrottled `/login/password`, but **#568 should land before this endpoint is advertised to users.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)