### PR TITLE
Add per-IP auth rate limiting / brute-force backoff (#568)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,16 @@ DATABASE_PATH=./data/lurker.db
 # true end-to-end HTTPS.
 # COOKIE_SECURE=true
 
+# Auth rate limiting keys per client IP. By default Lurker uses the socket peer
+# address, which is correct when it faces the internet directly. If you run it
+# behind a reverse proxy or tunnel (Caddy/nginx/Cloudflare), the socket peer is
+# the proxy — so every client shares one key. Set this to true ONLY when a proxy
+# you control sets X-Forwarded-For, so Lurker keys on the real client instead.
+# Never set it on a directly-exposed instance: the header is then attacker-
+# spoofable and defeats the limit. (Hosted 'node' cells ignore this — the control
+# plane injects a trusted client IP.)
+# LURKER_TRUST_PROXY=true
+
 # CORS / dev origin for the Vite dev server.
 CORS_ORIGIN=https://irc.local.bradroot.me:5173
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -199,6 +199,19 @@ environment:
   - COOKIE_SECURE=true
 ```
 
+### Auth rate limiting behind a proxy
+
+Lurker throttles repeated failed logins per client IP (a per-IP backoff on the login, token, and password-change endpoints, plus a coarse request cap on the auth surface). By default it uses the connection's socket address, which is correct when Lurker faces the internet directly.
+
+If you run Lurker behind a reverse proxy or tunnel (Caddy, nginx, Cloudflare), the socket address is the _proxy_, so every visitor would share one bucket. Set this **only** when a proxy you control populates `X-Forwarded-For`, so Lurker keys on the real client:
+
+```yaml
+environment:
+  - LURKER_TRUST_PROXY=true
+```
+
+Do **not** set it on a directly-exposed instance — `X-Forwarded-For` is then attacker-spoofable and an attacker can dodge the limit by rotating a fake value.
+
 ### Custom session secret
 
 By default Lurker generates a random 64-byte secret on first boot and writes it to `data/session-secret.key` (mode `0600`). All session cookies are signed with it. If you'd rather supply your own (e.g. pulled from a secrets manager), set:

--- a/server/middleware/rateLimit.test.ts
+++ b/server/middleware/rateLimit.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Express } from 'express';
+import { setupTestDb, createTestApp, testRequest } from '../test-utils/testApp.js';
+import {
+  FailureThrottle,
+  RequestThrottle,
+  LOGIN_FAILURE_MAX,
+  resetAuthRateLimits,
+} from './rateLimit.js';
+
+// --- Unit: the throttle classes with an injected clock (the tricky edges) -----
+
+describe('FailureThrottle', () => {
+  const cfg = { windowMs: 1000, maxFailures: 3, backoffMs: 5000 };
+
+  it('allows until the threshold, then blocks with a Retry-After', () => {
+    let now = 0;
+    const t = new FailureThrottle(cfg, () => now);
+    expect(t.retryAfter('ip')).toBeNull();
+    t.recordFailure('ip'); // 1
+    t.recordFailure('ip'); // 2
+    expect(t.retryAfter('ip')).toBeNull();
+    t.recordFailure('ip'); // 3 -> trips
+    const retry = t.retryAfter('ip');
+    expect(retry).toBe(5); // 5000ms backoff -> 5s
+  });
+
+  it('auto-clears once the backoff elapses', () => {
+    let now = 0;
+    const t = new FailureThrottle(cfg, () => now);
+    for (let i = 0; i < cfg.maxFailures; i++) t.recordFailure('ip');
+    expect(t.retryAfter('ip')).not.toBeNull();
+    now += cfg.backoffMs; // block horizon reached
+    expect(t.retryAfter('ip')).toBeNull();
+  });
+
+  it('ages out failures older than the window (never trips on slow drips)', () => {
+    let now = 0;
+    const t = new FailureThrottle(cfg, () => now);
+    t.recordFailure('ip'); // t=0
+    now += 600;
+    t.recordFailure('ip'); // t=600
+    now += 600; // t=1200 — the first failure is now >windowMs old
+    t.recordFailure('ip'); // only 2 live failures -> no trip
+    expect(t.retryAfter('ip')).toBeNull();
+  });
+
+  it('a success (reset) wipes the slate', () => {
+    let now = 0;
+    const t = new FailureThrottle(cfg, () => now);
+    t.recordFailure('ip');
+    t.recordFailure('ip');
+    t.reset('ip');
+    t.recordFailure('ip'); // back to 1, not 3
+    expect(t.retryAfter('ip')).toBeNull();
+  });
+
+  it('keys are independent', () => {
+    let now = 0;
+    const t = new FailureThrottle(cfg, () => now);
+    for (let i = 0; i < cfg.maxFailures; i++) t.recordFailure('a');
+    expect(t.retryAfter('a')).not.toBeNull();
+    expect(t.retryAfter('b')).toBeNull();
+  });
+});
+
+describe('RequestThrottle', () => {
+  it('caps requests per window and reports Retry-After', () => {
+    let now = 0;
+    const t = new RequestThrottle({ windowMs: 1000, maxRequests: 2 }, () => now);
+    expect(t.allow('ip').ok).toBe(true);
+    expect(t.allow('ip').ok).toBe(true);
+    const blocked = t.allow('ip') as { ok: false; retryAfter: number };
+    expect(blocked.ok).toBe(false);
+    expect(blocked.retryAfter).toBe(1);
+    now += 1000; // window frees
+    expect(t.allow('ip').ok).toBe(true);
+  });
+});
+
+// --- Integration: the wired auth endpoints -----------------------------------
+
+const ctx = setupTestDb('middleware-ratelimit');
+
+let app: Express;
+
+beforeAll(async () => {
+  const router = (await import('../routes/auth.js')).default;
+  app = createTestApp({ '/api/auth': router });
+  // First admin with a known password, so we can drive real failed logins.
+  await testRequest(app)
+    .post('/api/auth/setup/password')
+    .send({ username: 'admin', password: 'correct-horse' });
+});
+
+afterAll(() => ctx.cleanup());
+
+beforeEach(() => resetAuthRateLimits());
+
+describe('POST /api/auth/login/password rate limiting', () => {
+  it('backs off with 429 + Retry-After after repeated failures', async () => {
+    for (let i = 0; i < LOGIN_FAILURE_MAX; i++) {
+      const r = await testRequest(app)
+        .post('/api/auth/login/password')
+        .send({ username: 'admin', password: 'wrong' });
+      expect(r.status).toBe(401);
+    }
+    const blocked = await testRequest(app)
+      .post('/api/auth/login/password')
+      .send({ username: 'admin', password: 'wrong' });
+    expect(blocked.status).toBe(429);
+    expect(Number(blocked.headers['retry-after'])).toBeGreaterThan(0);
+  });
+
+  it('does not throttle a correct login, and a success clears the slate', async () => {
+    // A few failures, then a success — which resets the counter...
+    for (let i = 0; i < LOGIN_FAILURE_MAX - 1; i++) {
+      await testRequest(app)
+        .post('/api/auth/login/password')
+        .send({ username: 'admin', password: 'wrong' });
+    }
+    const ok = await testRequest(app)
+      .post('/api/auth/login/password')
+      .send({ username: 'admin', password: 'correct-horse' });
+    expect(ok.status).toBe(200);
+    // ...so the next failure starts from zero rather than immediately tripping.
+    const after = await testRequest(app)
+      .post('/api/auth/login/password')
+      .send({ username: 'admin', password: 'wrong' });
+    expect(after.status).toBe(401);
+  });
+
+  it('keys per client IP so one attacker cannot lock out another user', async () => {
+    // Standalone honors X-Forwarded-For only under LURKER_TRUST_PROXY — opt in so
+    // the two simulated clients get distinct keys instead of sharing 127.0.0.1.
+    process.env.LURKER_TRUST_PROXY = 'true';
+    try {
+      for (let i = 0; i < LOGIN_FAILURE_MAX; i++) {
+        await testRequest(app)
+          .post('/api/auth/login/password')
+          .set('X-Forwarded-For', '10.0.0.1')
+          .send({ username: 'admin', password: 'wrong' });
+      }
+      const attacker = await testRequest(app)
+        .post('/api/auth/login/password')
+        .set('X-Forwarded-For', '10.0.0.1')
+        .send({ username: 'admin', password: 'wrong' });
+      expect(attacker.status).toBe(429);
+      // A different IP is unaffected.
+      const other = await testRequest(app)
+        .post('/api/auth/login/password')
+        .set('X-Forwarded-For', '10.0.0.2')
+        .send({ username: 'admin', password: 'wrong' });
+      expect(other.status).toBe(401);
+    } finally {
+      delete process.env.LURKER_TRUST_PROXY;
+    }
+  });
+});

--- a/server/middleware/rateLimit.test.ts
+++ b/server/middleware/rateLimit.test.ts
@@ -136,6 +136,7 @@ describe('POST /api/auth/login/password rate limiting', () => {
   it('keys per client IP so one attacker cannot lock out another user', async () => {
     // Standalone honors X-Forwarded-For only under LURKER_TRUST_PROXY — opt in so
     // the two simulated clients get distinct keys instead of sharing 127.0.0.1.
+    const prevTrustProxy = process.env.LURKER_TRUST_PROXY;
     process.env.LURKER_TRUST_PROXY = 'true';
     try {
       for (let i = 0; i < LOGIN_FAILURE_MAX; i++) {
@@ -156,7 +157,8 @@ describe('POST /api/auth/login/password rate limiting', () => {
         .send({ username: 'admin', password: 'wrong' });
       expect(other.status).toBe(401);
     } finally {
-      delete process.env.LURKER_TRUST_PROXY;
+      if (prevTrustProxy === undefined) delete process.env.LURKER_TRUST_PROXY;
+      else process.env.LURKER_TRUST_PROXY = prevTrustProxy;
     }
   });
 });

--- a/server/middleware/rateLimit.ts
+++ b/server/middleware/rateLimit.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Rate limiting for the public auth surface (#568). Until this landed, Lurker had
+// no HTTP throttling anywhere — the login endpoints (and the public, unauthenticated
+// password->long-lived-token mint at POST /api/auth/login/token) accepted password
+// guesses as fast as an attacker could open sockets. Two cooperating limiters, both
+// keyed per client IP, in-memory, single-process:
+//
+//   - FailureThrottle — counts *failed* credential attempts. After N failures in a
+//     window, further attempts are refused with 429 + Retry-After for a backoff
+//     window, BEFORE any scrypt work runs. A successful auth clears the slate, so a
+//     legitimate user who fat-fingers a password a few times is never locked out for
+//     long, and a correct login is never throttled. This is the brute-force guard;
+//     it generalizes the IRC bouncer's per-IP `authFailures` throttle
+//     (services/bouncer.ts) — the one auth path that was already protected — to the
+//     HTTP login path serving the same credentials.
+//   - RequestThrottle — a coarse per-IP request cap across the whole auth surface
+//     (options, invite probing, setup, auth-methods, ...), so the cheaper probe
+//     endpoints can't be hammered for enumeration or flood.
+//
+// Behavior on trip is backoff, not lockout: a 429 with Retry-After that auto-clears
+// once the window frees. A hard lockout is a self-DoS vector (an attacker can lock a
+// real user out by failing on their behalf); backoff avoids that while still making
+// online brute force impractical.
+//
+// Storage is in-memory per process — fine for a single-process cell and the
+// single-process control-plane. A restart resets it, which is acceptable: an attacker
+// who can force restarts has bigger levers. Both maps are capped so a spray of
+// one-off failures from many distinct addresses can't grow them without bound.
+
+import type { NextFunction, Request, Response } from 'express';
+import { isNodeMode } from '../utils/edition.js';
+
+// The header the control-plane injects carrying the true client IP. On hosted, every
+// request reaches the cell through the CP proxy, which derives the real client IP
+// from Cloudflare's CF-Connecting-IP at the edge and forwards exactly one trusted
+// value here. We read it ONLY in node mode; in standalone an inbound copy would be
+// caller-spoofable, so we never trust it there.
+export const CLIENT_IP_HEADER = 'x-lurker-client-ip';
+
+let warnedMissingClientIp = false;
+
+function firstHeaderValue(v: string | string[] | undefined): string {
+  const raw = Array.isArray(v) ? v[0] : v;
+  return (raw ?? '').split(',')[0].trim();
+}
+
+// Resolve the per-client key for rate limiting, or null when we can't determine a
+// trustworthy one. Returning null makes every caller fail OPEN — we NEVER collapse
+// all clients onto one shared key, which would let a handful of bad attempts lock out
+// the whole instance at once. That "bans everyone or nobody" footgun is exactly what
+// #568 warns about behind a proxy.
+export function clientIp(req: Request): string | null {
+  if (isNodeMode()) {
+    const fwd = firstHeaderValue(req.headers[CLIENT_IP_HEADER]);
+    if (fwd) return fwd;
+    // Missing in node mode means a CP/edge misconfiguration, not a direct client.
+    // Warn once and fail open rather than throttle every tenant on one shared key.
+    if (!warnedMissingClientIp) {
+      warnedMissingClientIp = true;
+      console.warn(
+        `[lurker] node mode but no ${CLIENT_IP_HEADER} header on auth requests — ` +
+          `auth rate limiting is disabled until the proxy sets it`,
+      );
+    }
+    return null;
+  }
+  // Standalone: the socket peer is the client (or the operator's own reverse proxy).
+  // Honor X-Forwarded-For's first hop only when the operator explicitly opts in via
+  // LURKER_TRUST_PROXY — an internet-exposed instance must not trust a spoofable
+  // header by default, or an attacker just rotates a fake XFF to dodge the limit.
+  if (process.env.LURKER_TRUST_PROXY === 'true') {
+    const xff = firstHeaderValue(req.headers['x-forwarded-for']);
+    if (xff) return xff;
+  }
+  return req.socket.remoteAddress ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Failure throttle — counts failed credential attempts per key.
+// ---------------------------------------------------------------------------
+
+export interface FailureThrottleConfig {
+  /** Sliding window over which failures accumulate toward the trip threshold. */
+  windowMs: number;
+  /** Failures within the window that trip the backoff. */
+  maxFailures: number;
+  /** How long a tripped key stays blocked (the Retry-After horizon). */
+  backoffMs: number;
+  /** Cap on tracked keys so distinct-IP sprays can't grow the map unbounded. */
+  maxKeys?: number;
+}
+
+interface FailureEntry {
+  /** Epoch-ms of recent failures inside the sliding window. */
+  fails: number[];
+  /** Epoch-ms until which the key is blocked; 0 when not blocked. */
+  blockedUntil: number;
+}
+
+export class FailureThrottle {
+  private entries = new Map<string, FailureEntry>();
+  private readonly now: () => number;
+  private readonly maxKeys: number;
+
+  // `now` is injectable so tests can drive the clock without sleeping (mirrors
+  // services/e2e/rateLimiter.ts).
+  constructor(
+    private readonly cfg: FailureThrottleConfig,
+    now: () => number = Date.now,
+  ) {
+    this.now = now;
+    this.maxKeys = cfg.maxKeys ?? 10_000;
+  }
+
+  /**
+   * Seconds the caller must wait if `key` is currently blocked, else null (allowed).
+   * A key whose block has elapsed is cleared here, so the next attempt starts fresh.
+   */
+  retryAfter(key: string): number | null {
+    const entry = this.entries.get(key);
+    if (!entry || entry.blockedUntil === 0) return null;
+    const now = this.now();
+    if (now >= entry.blockedUntil) {
+      this.entries.delete(key);
+      return null;
+    }
+    return Math.ceil((entry.blockedUntil - now) / 1000);
+  }
+
+  /** Record a failed attempt; trips the backoff once the threshold is reached. */
+  recordFailure(key: string): void {
+    const now = this.now();
+    let entry = this.entries.get(key);
+    if (!entry) {
+      entry = { fails: [], blockedUntil: 0 };
+      this.entries.set(key, entry);
+      this.cap();
+    }
+    entry.fails = entry.fails.filter((t) => now - t < this.cfg.windowMs);
+    entry.fails.push(now);
+    if (entry.fails.length >= this.cfg.maxFailures) {
+      entry.blockedUntil = now + this.cfg.backoffMs;
+      entry.fails = [];
+    }
+  }
+
+  /** A successful auth clears the key's failure history entirely. */
+  reset(key: string): void {
+    this.entries.delete(key);
+  }
+
+  private cap(): void {
+    if (this.entries.size <= this.maxKeys) return;
+    // First sweep entries that are neither blocked nor holding live failures.
+    const now = this.now();
+    for (const [k, e] of this.entries) {
+      const stale = e.fails.length === 0 || now - e.fails[e.fails.length - 1] >= this.cfg.windowMs;
+      if (e.blockedUntil === 0 && stale) this.entries.delete(k);
+    }
+    // If still over (an all-active flood), evict oldest — Maps keep insertion order.
+    while (this.entries.size > this.maxKeys) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+
+  /** Test hook. Production never calls this. */
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request throttle — coarse per-key request cap (sliding window).
+// ---------------------------------------------------------------------------
+
+export interface RequestThrottleConfig {
+  windowMs: number;
+  maxRequests: number;
+  maxKeys?: number;
+}
+
+export class RequestThrottle {
+  private hits = new Map<string, number[]>();
+  private readonly now: () => number;
+  private readonly maxKeys: number;
+
+  constructor(
+    private readonly cfg: RequestThrottleConfig,
+    now: () => number = Date.now,
+  ) {
+    this.now = now;
+    this.maxKeys = cfg.maxKeys ?? 10_000;
+  }
+
+  /** True if a request from `key` is allowed now; records it. Retry-After in `retry`. */
+  allow(key: string): { ok: true } | { ok: false; retryAfter: number } {
+    const now = this.now();
+    let recent = this.hits.get(key);
+    if (!recent) {
+      recent = [];
+      this.hits.set(key, recent);
+      this.cap();
+    }
+    const cutoff = now - this.cfg.windowMs;
+    recent = recent.filter((t) => t > cutoff);
+    this.hits.set(key, recent);
+    if (recent.length >= this.cfg.maxRequests) {
+      // Retry-After = time until the oldest in-window hit ages out.
+      const retryAfter = Math.max(1, Math.ceil((recent[0] + this.cfg.windowMs - now) / 1000));
+      return { ok: false, retryAfter };
+    }
+    recent.push(now);
+    return { ok: true };
+  }
+
+  private cap(): void {
+    if (this.hits.size <= this.maxKeys) return;
+    const cutoff = this.now() - this.cfg.windowMs;
+    for (const [k, ts] of this.hits) {
+      if (ts.length === 0 || ts[ts.length - 1] <= cutoff) this.hits.delete(k);
+    }
+    while (this.hits.size > this.maxKeys) {
+      const oldest = this.hits.keys().next().value;
+      if (oldest === undefined) break;
+      this.hits.delete(oldest);
+    }
+  }
+
+  clear(): void {
+    this.hits.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Express middleware.
+// ---------------------------------------------------------------------------
+
+/**
+ * Guard a credential-verifying route (password / passkey / token login, password
+ * change). Pre-checks the failure throttle and, if the key is in backoff, returns
+ * 429 + Retry-After BEFORE the handler runs any scrypt work. Otherwise it hooks the
+ * response: a 401 counts as a failed attempt, a 2xx clears the slate. Counting off
+ * the final status means we never have to instrument every failure branch inside the
+ * handler, and 400s (malformed input, not a credential guess) correctly don't count.
+ *
+ * Fails open when the client key can't be trusted (see clientIp).
+ */
+export function guardCredentialAttempt(throttle: FailureThrottle) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = clientIp(req);
+    if (key === null) {
+      next();
+      return;
+    }
+    const retry = throttle.retryAfter(key);
+    if (retry !== null) {
+      res.set('Retry-After', String(retry));
+      res.status(429).json({ error: 'too many attempts — try again later' });
+      return;
+    }
+    res.on('finish', () => {
+      if (res.statusCode === 401) throttle.recordFailure(key);
+      else if (res.statusCode >= 200 && res.statusCode < 300) throttle.reset(key);
+    });
+    next();
+  };
+}
+
+/** Coarse per-IP request cap for a whole router. Fails open on an untrusted key. */
+export function limitRequests(throttle: RequestThrottle) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const key = clientIp(req);
+    if (key === null) {
+      next();
+      return;
+    }
+    const verdict = throttle.allow(key);
+    if (!verdict.ok) {
+      res.set('Retry-After', String(verdict.retryAfter));
+      res.status(429).json({ error: 'too many requests — slow down' });
+      return;
+    }
+    next();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The wired-up limiters for the auth surface.
+// ---------------------------------------------------------------------------
+
+// Mirror the IRC bouncer's tuning (10 failures / 15 min) for the credential guard,
+// with a 15-minute backoff once tripped.
+export const LOGIN_FAILURE_MAX = 10;
+
+export const loginFailureThrottle = new FailureThrottle({
+  windowMs: 15 * 60_000,
+  maxFailures: LOGIN_FAILURE_MAX,
+  backoffMs: 15 * 60_000,
+});
+
+// A generous blanket over the whole auth router — real UI flows fire only a handful
+// of requests, so 60/min/IP is invisible to users but caps enumeration/flood.
+export const authRequestThrottle = new RequestThrottle({
+  windowMs: 60_000,
+  maxRequests: 60,
+});
+
+/** Reset all auth-surface limiters. Test hook (integration tests reuse one process). */
+export function resetAuthRateLimits(): void {
+  loginFailureThrottle.clear();
+  authRequestThrottle.clear();
+}

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -46,6 +46,12 @@ import {
   passwordRequirementsMessage,
 } from '../services/password.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
+import {
+  guardCredentialAttempt,
+  limitRequests,
+  loginFailureThrottle,
+  authRequestThrottle,
+} from '../middleware/rateLimit.js';
 
 const CHALLENGE_COOKIE = 'lurker_webauthn_challenge';
 
@@ -79,6 +85,12 @@ function publicCredential(c: any): Record<string, unknown> {
 }
 
 const router = Router();
+
+// Coarse per-IP request cap across the entire auth surface (options, invite probing,
+// setup, auth-methods, ...) — a blanket flood/enumeration backstop. The credential
+// endpoints below stack a much tighter failure throttle on top. Both are no-ops on an
+// untrusted client key (fail open); see middleware/rateLimit.ts (#568).
+router.use(limitRequests(authRequestThrottle));
 
 // ---------- setup status ----------
 
@@ -435,6 +447,7 @@ router.post(
 
 router.post(
   '/login/verify',
+  guardCredentialAttempt(loginFailureThrottle),
   asyncHandler(async (req: Request, res: Response) => {
     const token = req.signedCookies?.[CHALLENGE_COOKIE];
     const entry = consumeChallenge(token);
@@ -504,24 +517,28 @@ router.post(
 // fixed zero bytes — no secret value.
 const DUMMY_PASSWORD_HASH = `scrypt$32768$8$1$${Buffer.alloc(16).toString('base64')}$${Buffer.alloc(64).toString('base64')}`;
 
-router.post('/login/password', (req: Request, res: Response) => {
-  const username = (req.body?.username || '').trim();
-  const password: unknown = req.body?.password;
-  if (!isValidUsername(username) || typeof password !== 'string' || password.length === 0) {
-    res.status(400).json({ error: 'username and password required' });
-    return;
-  }
-  const user = findUserByUsername(username);
-  const stored = user ? getPasswordHash(user.id) : null;
-  const ok = verifyPassword(password, stored || DUMMY_PASSWORD_HASH);
-  if (!user || !stored || !ok) {
-    res.status(401).json({ error: 'invalid username or password' });
-    return;
-  }
-  const { token: sessionToken } = createSession(user.id);
-  res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
-  res.json({ user: { id: user.id, username: user.username, role: user.role } });
-});
+router.post(
+  '/login/password',
+  guardCredentialAttempt(loginFailureThrottle),
+  (req: Request, res: Response) => {
+    const username = (req.body?.username || '').trim();
+    const password: unknown = req.body?.password;
+    if (!isValidUsername(username) || typeof password !== 'string' || password.length === 0) {
+      res.status(400).json({ error: 'username and password required' });
+      return;
+    }
+    const user = findUserByUsername(username);
+    const stored = user ? getPasswordHash(user.id) : null;
+    const ok = verifyPassword(password, stored || DUMMY_PASSWORD_HASH);
+    if (!user || !stored || !ok) {
+      res.status(401).json({ error: 'invalid username or password' });
+      return;
+    }
+    const { token: sessionToken } = createSession(user.id);
+    res.cookie(SESSION_COOKIE, sessionToken, getCookieOptions());
+    res.json({ user: { id: user.id, username: user.username, role: user.role } });
+  },
+);
 
 // Password → session token, for clients that have no browser to hold a cookie.
 // This is the native-app front door (iOS/Android): same credentials and same
@@ -534,31 +551,35 @@ router.post('/login/password', (req: Request, res: Response) => {
 // for the web client.
 //
 // SECURITY: this is a public, unauthenticated, password-in / long-lived-token-out
-// endpoint and it is NOT rate-limited — because nothing in Lurker is yet (#568).
-// It is no weaker than /login/password, which is equally public and equally
-// unthrottled, and it shares that route's constant-time miss behavior via
-// DUMMY_PASSWORD_HASH. #568 must cover both before this is advertised to users.
-router.post('/login/token', (req: Request, res: Response) => {
-  const username = (req.body?.username || '').trim();
-  const password: unknown = req.body?.password;
-  if (!isValidUsername(username) || typeof password !== 'string' || password.length === 0) {
-    res.status(400).json({ error: 'username and password required' });
-    return;
-  }
-  const user = findUserByUsername(username);
-  const stored = user ? getPasswordHash(user.id) : null;
-  const ok = verifyPassword(password, stored || DUMMY_PASSWORD_HASH);
-  if (!user || !stored || !ok) {
-    res.status(401).json({ error: 'invalid username or password' });
-    return;
-  }
-  const { token, expiresAt } = createSession(user.id);
-  res.json({
-    token,
-    expiresAt,
-    user: { id: user.id, username: user.username, role: user.role },
-  });
-});
+// endpoint — the most attractive credential-stuffing target on the cell. It shares
+// /login/password's constant-time miss behavior via DUMMY_PASSWORD_HASH and, as of
+// #568, the same per-IP failure throttle (guardCredentialAttempt above): repeated
+// failures from an IP back off with 429 before scrypt runs.
+router.post(
+  '/login/token',
+  guardCredentialAttempt(loginFailureThrottle),
+  (req: Request, res: Response) => {
+    const username = (req.body?.username || '').trim();
+    const password: unknown = req.body?.password;
+    if (!isValidUsername(username) || typeof password !== 'string' || password.length === 0) {
+      res.status(400).json({ error: 'username and password required' });
+      return;
+    }
+    const user = findUserByUsername(username);
+    const stored = user ? getPasswordHash(user.id) : null;
+    const ok = verifyPassword(password, stored || DUMMY_PASSWORD_HASH);
+    if (!user || !stored || !ok) {
+      res.status(401).json({ error: 'invalid username or password' });
+      return;
+    }
+    const { token, expiresAt } = createSession(user.id);
+    res.json({
+      token,
+      expiresAt,
+      user: { id: user.id, username: user.username, role: user.role },
+    });
+  },
+);
 
 // Public probe so the login UI can decide which sign-in buttons to surface.
 // Currently just reports whether any passkey exists anywhere — discoverable
@@ -719,25 +740,30 @@ router.get('/password', requireAuth, (req: Request, res: Response) => {
   res.json({ hasPassword: userHasPassword(req.user!.id) });
 });
 
-router.put('/password', requireAuth, (req: Request, res: Response) => {
-  const password: unknown = req.body?.password;
-  const currentPassword: unknown = req.body?.currentPassword;
-  if (!isValidPassword(password)) {
-    res.status(400).json({ error: passwordRequirementsMessage() });
-    return;
-  }
-  // Require the current password when one already exists, so a stolen session
-  // cookie can't lock the real owner out by silently rotating it.
-  if (userHasPassword(req.user!.id)) {
-    const stored = getPasswordHash(req.user!.id);
-    if (typeof currentPassword !== 'string' || !verifyPassword(currentPassword, stored)) {
-      res.status(401).json({ error: 'current password is incorrect' });
+router.put(
+  '/password',
+  requireAuth,
+  guardCredentialAttempt(loginFailureThrottle),
+  (req: Request, res: Response) => {
+    const password: unknown = req.body?.password;
+    const currentPassword: unknown = req.body?.currentPassword;
+    if (!isValidPassword(password)) {
+      res.status(400).json({ error: passwordRequirementsMessage() });
       return;
     }
-  }
-  setPasswordHash(req.user!.id, hashPassword(password as string));
-  res.json({ ok: true, hasPassword: true });
-});
+    // Require the current password when one already exists, so a stolen session
+    // cookie can't lock the real owner out by silently rotating it.
+    if (userHasPassword(req.user!.id)) {
+      const stored = getPasswordHash(req.user!.id);
+      if (typeof currentPassword !== 'string' || !verifyPassword(currentPassword, stored)) {
+        res.status(401).json({ error: 'current password is incorrect' });
+        return;
+      }
+    }
+    setPasswordHash(req.user!.id, hashPassword(password as string));
+    res.json({ ok: true, hasPassword: true });
+  },
+);
 
 router.delete('/password', requireAuth, (req: Request, res: Response) => {
   // Can't drop the last sign-in method.


### PR DESCRIPTION
Closes #568.

Lurker had **no HTTP rate limiting anywhere** — the login endpoints, and the public unauthenticated password→long-lived-token mint at `POST /api/auth/login/token`, accepted password guesses as fast as sockets could be opened. This is the ship-blocker for advertising the native mint endpoint.

## What this adds

`server/middleware/rateLimit.ts`:
- **`FailureThrottle`** — per-IP failed-attempt counter (10 fails / 15 min → 15-minute backoff, `429 + Retry-After` returned *before* scrypt runs; a successful auth clears the slate). Generalizes the IRC bouncer's `authFailures` pattern (`services/bouncer.ts`) — the one auth path that was already protected — to the HTTP login path serving the same credentials. **Backoff, not lockout**, so an attacker can't self-DoS a real user by failing on their behalf.
- **`RequestThrottle`** — coarse per-IP request cap (60/min) as a blanket over the whole auth router for flood/enumeration.

Outcome is counted off `res.on('finish')` status (401 → failure, 2xx → clear), so no per-branch instrumentation is needed and malformed-input 400s correctly don't count.

## Client-IP derivation (the part that's catastrophic to get wrong)

Edition-aware, and **fails open** on an untrusted/missing key so a misconfig never collapses every client onto one shared bucket:
- **standalone:** socket address; honors `X-Forwarded-For` only under an explicit `LURKER_TRUST_PROXY=true` opt-in (documented in `.env.example` + `docs/SELF_HOSTING.md`), since XFF is spoofable on a directly-exposed instance.
- **node cell:** trusts `X-Lurker-Client-IP`, injected by the control plane (paired control-plane change stamps it from Cloudflare's `CF-Connecting-IP`).

## Wiring

Failure throttle on `/login/password`, `/login/token`, `/login/verify`, and `PUT /password`. Coarse cap covers the rest of the auth surface. On by default in both editions.

## Deliberately out of scope

WebAuthn `/login/options`, invite redemption, and password reset get the coarse blanket only (not the failure counter) — they aren't password-brute-force targets. WS connection-flood control is left for the separate WS-hardening work (the WS token isn't brute-forceable; that's a DoS concern, not credential stuffing).

## Tests

New `server/middleware/rateLimit.test.ts` — unit (throttle edges with an injected clock: window expiry, backoff auto-clear, key independence) + integration (429 after N fails with `Retry-After`, correct login never throttled and clears the slate, per-IP isolation). Full suite green (2422 tests); `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)