### PR TITLE
Block paused-account writes centrally in requireAuth (#573)

### DIFF
--- a/server/middleware/auth.paused.test.ts
+++ b/server/middleware/auth.paused.test.ts
@@ -59,12 +59,19 @@ const WRITES: Array<[string, string]> = [
 const READS: string[] = ['/api/settings/bootstrap', '/api/api-tokens/', '/api/push/subscriptions'];
 
 describe('paused accounts are read-only across every authed router (#573)', () => {
-  it('serves reads while active and after pause', async () => {
+  it('serves reads with 200 both while active and while paused', async () => {
     const { setUserPaused } = await import('../db/users.js');
+    // Active: reads work normally.
+    setUserPaused(userId, false);
+    for (const path of READS) {
+      const res = await agent.get(path);
+      expect(res.status, `GET ${path} should be 200 while active`).toBe(200);
+    }
+    // Paused: the same reads still return 200 (only writes are blocked).
     setUserPaused(userId, true);
     for (const path of READS) {
       const res = await agent.get(path);
-      expect(res.status, `GET ${path} should read while paused`).not.toBe(403);
+      expect(res.status, `GET ${path} should still be 200 while paused`).toBe(200);
     }
     setUserPaused(userId, false);
   });
@@ -88,10 +95,15 @@ describe('paused accounts are read-only across every authed router (#573)', () =
 
   it('restores write access once un-paused', async () => {
     const { setUserPaused } = await import('../db/users.js');
+    // While paused the write is blocked...
+    setUserPaused(userId, true);
+    const blocked = await agent.patch('/api/settings').send({ changes: { 'look.font.size': 18 } });
+    expect(blocked.status).toBe(403);
+    // ...and once un-paused the same valid write actually lands (200), proving
+    // the gate released rather than merely stopped returning the pause 403.
     setUserPaused(userId, false);
-    // A valid settings write now lands instead of 403 account-paused.
-    const res = await agent.patch('/api/settings/').send({ 'appearance.theme': 'dark' });
-    expect(res.status).not.toBe(403);
-    expect(res.body?.error).not.toBe('account paused');
+    const ok = await agent.patch('/api/settings').send({ changes: { 'look.font.size': 18 } });
+    expect(ok.status).toBe(200);
+    expect(ok.body.values['look.font.size']).toBe(18);
   });
 });

--- a/server/middleware/auth.paused.test.ts
+++ b/server/middleware/auth.paused.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// #573: the paused-account write block lives centrally in requireAuth, so EVERY
+// authed router inherits it — not just networks + dcc (which used to mount it
+// explicitly). This proves the previously-unguarded routers (settings, push,
+// api-tokens, uploads, exports) now reject writes from a paused account while
+// still serving reads.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Express } from 'express';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+
+const ctx = setupTestDb('middleware-paused');
+
+let app: Express;
+let agent: LurkerTestAgent;
+let userId: number;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const settingsRouter = (await import('../routes/settings.js')).default;
+  const pushRouter = (await import('../routes/push.js')).default;
+  const apiTokensRouter = (await import('../routes/apiTokens.js')).default;
+  const uploadsRouter = (await import('../routes/uploads.js')).default;
+  const { exportsRouter } = await import('../routes/exports.js');
+
+  const user = createUser('paused-central');
+  userId = user.id;
+  app = createTestApp({
+    '/api/settings': settingsRouter,
+    '/api/push': pushRouter,
+    '/api/api-tokens': apiTokensRouter,
+    '/api/uploads': uploadsRouter,
+    '/api/exports': exportsRouter,
+  });
+  agent = await createAuthedAgent(app, user.id);
+});
+
+afterAll(() => ctx.cleanup());
+
+// Each entry is a mutating request that used to slip past the pause block
+// because its router never mounted blockWritesWhenPaused. The 403 now fires in
+// requireAuth BEFORE the route handler runs, so the request bodies are
+// irrelevant (an empty body still gets the pause 403, never a validation error).
+const WRITES: Array<[string, string]> = [
+  ['patch', '/api/settings/'],
+  ['delete', '/api/settings/some-key'],
+  ['post', '/api/push/subscriptions'],
+  ['delete', '/api/push/subscriptions'],
+  ['post', '/api/api-tokens/'],
+  ['delete', '/api/api-tokens/1'],
+  ['post', '/api/uploads'],
+  ['post', '/api/exports/'],
+];
+
+// Reads must still work for a paused account so the UI renders read-only.
+const READS: string[] = ['/api/settings/bootstrap', '/api/api-tokens/', '/api/push/subscriptions'];
+
+describe('paused accounts are read-only across every authed router (#573)', () => {
+  it('serves reads while active and after pause', async () => {
+    const { setUserPaused } = await import('../db/users.js');
+    setUserPaused(userId, true);
+    for (const path of READS) {
+      const res = await agent.get(path);
+      expect(res.status, `GET ${path} should read while paused`).not.toBe(403);
+    }
+    setUserPaused(userId, false);
+  });
+
+  it('blocks every write with a clean 403 while paused', async () => {
+    const { setUserPaused } = await import('../db/users.js');
+    setUserPaused(userId, true);
+    for (const [method, path] of WRITES) {
+      const res = await (method === 'patch'
+        ? agent.patch(path)
+        : method === 'delete'
+          ? agent.delete(path)
+          : agent.post(path));
+      expect(res.status, `${method.toUpperCase()} ${path} should be blocked while paused`).toBe(
+        403,
+      );
+      expect(res.body.error).toBe('account paused');
+    }
+    setUserPaused(userId, false);
+  });
+
+  it('restores write access once un-paused', async () => {
+    const { setUserPaused } = await import('../db/users.js');
+    setUserPaused(userId, false);
+    // A valid settings write now lands instead of 403 account-paused.
+    const res = await agent.patch('/api/settings/').send({ 'appearance.theme': 'dark' });
+    expect(res.status).not.toBe(403);
+    expect(res.body?.error).not.toBe('account paused');
+  });
+});

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -106,6 +106,19 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
   }
   req.user = ctx.user;
   req.session = ctx.session;
+  // Paused accounts are read-only, enforced HERE (centrally) rather than per
+  // router (#573): requireAuth guards every authed router, so folding the write
+  // block in means no current or future router can forget it. GET/HEAD reads
+  // fall through; any mutation gets a clean 403. Two paths deliberately bypass
+  // this because they don't use requireAuth: POST /logout (a paused user must
+  // still be able to sign out) and the CP-driven /api/node pause/resume routes
+  // (fleet-secret authed — the orchestrator must still flip the flag). Live IRC
+  // writes are separately gated in the WS layer + the ircManager startNetwork
+  // gate, so this covers only the HTTP write surface.
+  if (isPausedWrite(req)) {
+    res.status(403).json({ error: 'account paused' });
+    return;
+  }
   touchUserLastSeen(ctx.user.id);
   next();
 }
@@ -125,15 +138,12 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction): v
   next();
 }
 
-// Read-only gate for paused accounts. Stack on top of requireAuth. GET/HEAD
-// reads fall through so a paused user can still browse their history; any
-// mutating method gets a clean 403. The authoritative block on IRC traffic is
-// the startNetwork gate in ircManager — this just turns what would be a silent
-// no-op into a clear error and stops a paused user from mutating network config.
-export function blockWritesWhenPaused(req: Request, res: Response, next: NextFunction): void {
-  if (req.user?.is_paused && req.method !== 'GET' && req.method !== 'HEAD') {
-    res.status(403).json({ error: 'account paused' });
-    return;
-  }
-  next();
+// Read-only gate for paused accounts: a paused account may read but not mutate.
+// GET/HEAD reads fall through so a paused user can still browse their history;
+// any mutating method is a write. Enforced centrally in requireAuth above (#573)
+// rather than mounted per router. The authoritative block on IRC traffic is the
+// startNetwork gate in ircManager — this just turns what would be a silent no-op
+// into a clear error on the HTTP surface.
+function isPausedWrite(req: Request): boolean {
+  return !!req.user?.is_paused && req.method !== 'GET' && req.method !== 'HEAD';
 }

--- a/server/routes/dcc.ts
+++ b/server/routes/dcc.ts
@@ -8,7 +8,7 @@
 
 import { Router, type Request, type Response } from 'express';
 
-import { requireAuth, blockWritesWhenPaused } from '../middleware/auth.js';
+import { requireAuth } from '../middleware/auth.js';
 import ircManager from '../services/ircManager.js';
 import { dccEnabledForUser } from '../services/dccConfig.js';
 import { getDccTransfer, listDccTransfers } from '../db/dccTransfers.js';
@@ -42,8 +42,8 @@ router.get('/', (req: Request, res: Response) => {
   res.json({ transfers: listDccTransfers(req.user!.id, { limit }) });
 });
 
-// Acting on a transfer is a write — blocked for paused accounts (the list isn't).
-router.use(blockWritesWhenPaused);
+// Acting on a transfer is a write — blocked for paused accounts (the list isn't)
+// by the central requireAuth gate (#573); the GET list above stays available.
 
 /** POST /api/dcc/:id/accept — accept a pending offer and start the download. */
 router.post('/:id/accept', (req: Request, res: Response) => {

--- a/server/routes/networks.ts
+++ b/server/routes/networks.ts
@@ -3,7 +3,7 @@
 
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-import { requireAuth, blockWritesWhenPaused } from '../middleware/auth.js';
+import { requireAuth } from '../middleware/auth.js';
 import type { Network } from '../db/networks.js';
 import {
   listNetworksForUser,
@@ -21,10 +21,9 @@ import { fanOutToUser } from '../services/wsHub.js';
 
 const router = Router();
 router.use(requireAuth);
-// Paused accounts are read-only: every connect/reconnect/join/part and all
-// network-config mutation here is blocked, while GET listing still works so the
-// sidebar renders. See blockWritesWhenPaused.
-router.use(blockWritesWhenPaused);
+// Paused accounts are read-only (every connect/reconnect/join/part and all
+// network-config mutation here is blocked while GET listing still renders the
+// sidebar). The write block lives centrally in requireAuth — see #573.
 
 // `default_channel` is a comma-separated channel list, matching IRC's own JOIN
 // syntax ("JOIN #a,#b") — the onboarding flow and `/network add -channel` both


### PR DESCRIPTION
## What

`blockWritesWhenPaused` was mounted on only the **networks** and **dcc** routers, so a paused account (or a native Bearer holding a paused user's session) could still mutate **settings, push subscriptions, API tokens, uploads, and exports**. This contradicts the paused-account design (read-only banner + write block).

Fold the read-only write block into `requireAuth` itself — which already guards every authed router — so no current or future router can forget it. GET/HEAD reads still fall through.

## Why it's safe (doesn't over-block)

Two mutating paths deliberately bypass this because they don't use `requireAuth`:
- `POST /logout` (resolves the session itself) — a paused user must still be able to sign out.
- The CP-driven `/api/node/users/:id/pause|resume` routes (fleet-secret authed) — the orchestrator must still flip the flag.

Live IRC writes stay gated by the WS layer (`PAUSED_BLOCKED_TYPES`) + the `ircManager` startNetwork gate, so this covers only the HTTP write surface.

## Changes
- `middleware/auth.ts`: paused-write block moved into `requireAuth`; `blockWritesWhenPaused` collapsed to the shared `isPausedWrite` predicate.
- Removed the now-redundant `router.use(blockWritesWhenPaused)` from `networks.ts` + `dcc.ts`.
- New `middleware/auth.paused.test.ts`: asserts the previously-unguarded routers reject writes with 403 `account paused` while still serving reads, and that access is restored on un-pause.

`npm run check` + full `npm test` (2443 tests) green.

Closes #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)