### PR TITLE
WS protocol versioning + upgrade hardening (#569, #574)

### DIFF
--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// WebSocket + REST protocol version and the compatibility contract every client
+// — the web app and the native iOS/Android apps — relies on.
+//
+// Why this exists: the Vue client and the server ship from one repo in lockstep,
+// so an unversioned protocol has cost nothing. A native binary in an App Store
+// breaks that permanently — old clients hit new servers (the user hasn't
+// updated), and new clients hit old servers (a self-hosted instance the operator
+// hasn't upgraded). Both become normal operating conditions, so both sides need
+// a version they can negotiate on. Adding this is cheap now and impossible to
+// add cleanly once a binary is in someone's hands (see #569).
+//
+// The compatibility policy — a guarantee, not a nicety:
+//   1. Additive-only. New verbs, new frame `kind`s, and new fields on existing
+//      frames may be added freely. An existing field's meaning or type is NEVER
+//      repurposed; to change a shape, add a new field/kind and deprecate the old.
+//   2. Unknown is never fatal. Neither side may crash or mis-parse on something
+//      it doesn't recognize, and both tolerate unknown fields. Concretely: the
+//      client DROPS an unrecognized frame `kind` (already its behavior — this
+//      makes it a promise, not an accident), and the server answers an
+//      unrecognized verb with a non-fatal `error` frame rather than closing the
+//      socket (see handleClientMessage's default case). Either way an old client
+//      can talk to a newer server and vice-versa.
+//   3. PROTOCOL_VERSION only bumps on a change rule (1) cannot express — i.e.
+//      effectively never. MIN_PROTOCOL_VERSION is the oldest client this server
+//      still serves; a client that announces an older version on the upgrade is
+//      told to update (HTTP 426) instead of being handed a snapshot it would
+//      mis-render.
+//
+// The server advertises PROTOCOL_VERSION in GET /api/config (so a client can
+// check before opening the socket) and in the `snapshot` frame. A client
+// announces the version it speaks with `?v=<n>` on the /ws upgrade.
+
+export const PROTOCOL_VERSION = 1;
+
+// Oldest client protocol version this server will accept on the WS upgrade.
+// Equal to PROTOCOL_VERSION today (nothing to deprecate yet); raise it only when
+// an old client genuinely can no longer be served correctly.
+export const MIN_PROTOCOL_VERSION = 1;

--- a/server/routes/config.test.ts
+++ b/server/routes/config.test.ts
@@ -29,4 +29,14 @@ describe('GET /api/config', () => {
     expect(res.status).toBe(200);
     expect(res.body.edition).toBe('node');
   });
+
+  // #569: a native client reads these to check compatibility before opening the
+  // WebSocket, so they must be present and unauthenticated.
+  it('advertises the protocol version and minimum supported version', async () => {
+    const { PROTOCOL_VERSION, MIN_PROTOCOL_VERSION } = await import('../protocol.js');
+    const res = await createAnonAgent(app).get('/api/config');
+    expect(res.status).toBe(200);
+    expect(res.body.protocolVersion).toBe(PROTOCOL_VERSION);
+    expect(res.body.minProtocolVersion).toBe(MIN_PROTOCOL_VERSION);
+  });
 });

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -4,6 +4,7 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { getEdition } from '../utils/edition.js';
+import { PROTOCOL_VERSION, MIN_PROTOCOL_VERSION } from '../protocol.js';
 
 const router = Router();
 
@@ -11,8 +12,17 @@ const router = Router();
 // the UI can branch on deployment edition (self-hosted vs hosted node) and other
 // instance-level feature flags. Keep this lean and strictly non-sensitive — it is
 // served to anyone who hits the origin.
+//
+// protocolVersion / minProtocolVersion let a native client check compatibility
+// BEFORE it opens the WebSocket and render a real "update required" error instead
+// of a failed connect (#569). minProtocolVersion is the oldest CLIENT this server
+// serves; protocolVersion is what the server itself speaks.
 router.get('/', (_req: Request, res: Response) => {
-  res.json({ edition: getEdition() });
+  res.json({
+    edition: getEdition(),
+    protocolVersion: PROTOCOL_VERSION,
+    minProtocolVersion: MIN_PROTOCOL_VERSION,
+  });
 });
 
 export default router;

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -882,3 +882,100 @@ describe('authenticateUpgrade', () => {
     expect(user).toBeNull();
   });
 });
+
+// #574: the /ws upgrade only accepts a same-origin or allowlisted browser
+// upgrade; a native client (no Origin header) always passes.
+describe('isAllowedUpgradeOrigin', () => {
+  let isAllowedUpgradeOrigin: typeof import('./wsHub.js').isAllowedUpgradeOrigin;
+  const savedCors = process.env.CORS_ORIGIN;
+
+  beforeAll(async () => {
+    ({ isAllowedUpgradeOrigin } = await import('./wsHub.js'));
+  });
+  afterAll(() => {
+    if (savedCors === undefined) delete process.env.CORS_ORIGIN;
+    else process.env.CORS_ORIGIN = savedCors;
+  });
+
+  it('allows an upgrade with no Origin header (native client)', () => {
+    expect(isAllowedUpgradeOrigin(upgrade({ host: 'app.lurker.chat' }))).toBe(true);
+  });
+
+  it('allows a same-origin browser upgrade regardless of CORS_ORIGIN', () => {
+    process.env.CORS_ORIGIN = 'https://something-else.example';
+    expect(
+      isAllowedUpgradeOrigin(
+        upgrade({ host: 'app.lurker.chat', origin: 'https://app.lurker.chat' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('allows a cross-origin upgrade that is on the CORS allowlist', () => {
+    process.env.CORS_ORIGIN = 'https://client.example, https://other.example';
+    expect(
+      isAllowedUpgradeOrigin(upgrade({ host: 'api.internal', origin: 'https://client.example' })),
+    ).toBe(true);
+  });
+
+  it('rejects a cross-site browser upgrade that is neither same-origin nor allowlisted', () => {
+    process.env.CORS_ORIGIN = 'https://app.lurker.chat';
+    expect(
+      isAllowedUpgradeOrigin(upgrade({ host: 'app.lurker.chat', origin: 'https://evil.example' })),
+    ).toBe(false);
+  });
+
+  it('rejects a malformed Origin header from a browser', () => {
+    expect(isAllowedUpgradeOrigin(upgrade({ host: 'app.lurker.chat', origin: 'not-a-url' }))).toBe(
+      false,
+    );
+  });
+});
+
+// #569: the client announces its protocol version via ?v= on the upgrade URL.
+describe('parseProtocolParam', () => {
+  let parseProtocolParam: typeof import('./wsHub.js').parseProtocolParam;
+  beforeAll(async () => {
+    ({ parseProtocolParam } = await import('./wsHub.js'));
+  });
+
+  it('returns null when ?v is absent', () => {
+    expect(parseProtocolParam('/ws')).toBeNull();
+    expect(parseProtocolParam('/ws?since=5')).toBeNull();
+  });
+
+  it('parses a positive integer version', () => {
+    expect(parseProtocolParam('/ws?v=1')).toBe(1);
+    expect(parseProtocolParam('/ws?v=3&since=5')).toBe(3);
+  });
+
+  it('returns null for a non-positive or non-numeric version', () => {
+    expect(parseProtocolParam('/ws?v=0')).toBeNull();
+    expect(parseProtocolParam('/ws?v=-2')).toBeNull();
+    expect(parseProtocolParam('/ws?v=abc')).toBeNull();
+  });
+});
+
+// #574: per-socket inbound flood control. The bucket starts full, drains one
+// token per message, and refills over time.
+describe('allowInboundMessage', () => {
+  let allowInboundMessage: typeof import('./wsHub.js').allowInboundMessage;
+  beforeAll(async () => {
+    ({ allowInboundMessage } = await import('./wsHub.js'));
+  });
+
+  it('passes a normal message rate and eventually throttles a sustained flood', () => {
+    const ws = {} as Parameters<typeof allowInboundMessage>[0];
+    // A full bucket admits a burst; a tight loop with no time to refill must hit
+    // the floor and start rejecting.
+    let allowed = 0;
+    let rejected = 0;
+    for (let i = 0; i < 10_000; i++) {
+      if (allowInboundMessage(ws)) allowed++;
+      else rejected++;
+    }
+    expect(allowed).toBeGreaterThan(0); // the initial burst got through
+    expect(rejected).toBeGreaterThan(0); // the flood was throttled
+    // Nowhere near all 10k were admitted — the cap held.
+    expect(allowed).toBeLessThan(1_000);
+  });
+});

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -910,8 +910,9 @@ describe('isAllowedUpgradeOrigin', () => {
     ).toBe(true);
   });
 
-  it('allows a cross-origin upgrade that is on the CORS allowlist', () => {
-    process.env.CORS_ORIGIN = 'https://client.example, https://other.example';
+  it('allows a cross-origin upgrade that matches the configured CORS_ORIGIN', () => {
+    // Matches app.ts's single-string CORS semantics exactly (not a comma list).
+    process.env.CORS_ORIGIN = 'https://client.example';
     expect(
       isAllowedUpgradeOrigin(upgrade({ host: 'api.internal', origin: 'https://client.example' })),
     ).toBe(true);

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -145,25 +145,21 @@ export function allowInboundMessage(ws: LurkerWebSocket): boolean {
   return true;
 }
 
-// The origins allowed to open a WebSocket, mirroring the same CORS_ORIGIN the
-// HTTP API already trusts for credentialed requests (app.ts). Comma-separated so
-// an operator can list several; defaults to the dev origin, matching app.ts.
-function corsAllowlist(): Set<string> {
-  const raw = process.env.CORS_ORIGIN || 'https://irc.local.bradroot.me:5173';
-  return new Set(
-    raw
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean),
-  );
+// The single browser origin the HTTP CORS layer trusts. app.ts passes CORS_ORIGIN
+// straight to cors({ origin }), which matches it as one exact string — so we do
+// the same here (NOT a comma-split allowlist) to keep the WS and HTTP layers in
+// exact agreement about what's allowed. Defaults to the dev origin, matching
+// app.ts.
+function allowedBrowserOrigin(): string {
+  return process.env.CORS_ORIGIN || 'https://irc.local.bradroot.me:5173';
 }
 
-// #574: same-origin / allowlisted Origin check for the WS upgrade. Browsers
-// always send Origin on a WS handshake; native clients send none. We reject only
-// a *browser* upgrade whose Origin is neither same-origin as the request Host nor
-// on the CORS allowlist — i.e. a cross-site attempt. Absent Origin (native) and
-// same-origin (the normal web case, hosted or self-host, independent of whether
-// CORS_ORIGIN was configured) always pass, so this can't wedge a working
+// #574: same-origin / allowed-origin check for the WS upgrade. Browsers always
+// send Origin on a WS handshake; native clients send none. We reject only a
+// *browser* upgrade whose Origin is neither same-origin as the request Host nor
+// the CORS-configured origin — i.e. a cross-site attempt. Absent Origin (native)
+// and same-origin (the normal web case, hosted or self-host, independent of
+// whether CORS_ORIGIN was configured) always pass, so this can't wedge a working
 // deployment. On the hosted proxy the browser's Origin and Host both arrive as
 // the public app origin (http-proxy forwards them unchanged), so they match here.
 export function isAllowedUpgradeOrigin(req: IncomingMessage): boolean {
@@ -176,11 +172,19 @@ export function isAllowedUpgradeOrigin(req: IncomingMessage): boolean {
     return false;
   }
   if (req.headers.host && originHost === req.headers.host) return true;
-  return corsAllowlist().has(origin);
+  return origin === allowedBrowserOrigin();
 }
 
-// The protocol version a client announces via `?v=<n>` on the /ws upgrade (#569),
-// or null when absent. Mirrors parseSinceParam.
+// The protocol version a client announces via `?v=<n>` on the /ws upgrade (#569).
+// Returns null when the param is absent OR present-but-unparseable, and the
+// caller treats null as "current" (no version gate). Conflating the two is
+// deliberate and consistent: a client that omits `?v` and one that sends garbage
+// have both failed to announce a valid version, so both are treated identically.
+// This is not a security bypass of MIN_PROTOCOL_VERSION — omitting `?v` is itself
+// the sanctioned "treat me as current" path, so there is nothing a malformed
+// value could bypass that an absent one couldn't. The gate is a compatibility
+// courtesy (tell a well-behaved old client to update), not an auth control.
+// Mirrors parseSinceParam.
 export function parseProtocolParam(rawUrl: string): number | null {
   try {
     const raw = new URL(rawUrl, 'http://localhost').searchParams.get('v');

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -80,6 +80,7 @@ import * as chanlistDb from '../db/chanlist.js';
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from './settingsRegistry.js';
 import { SESSION_COOKIE, loadBearerSession } from '../middleware/auth.js';
+import { PROTOCOL_VERSION, MIN_PROTOCOL_VERSION } from '../protocol.js';
 import { callVerb } from './verbRegistry.js';
 
 // WebSocket extended with per-socket bookkeeping fields.
@@ -101,6 +102,94 @@ interface LurkerWebSocket extends WebSocket {
   // needs a per-message DB read. (Named accountPaused, not isPaused, to avoid
   // colliding with the ws library's own WebSocket.isPaused.)
   accountPaused?: boolean;
+  // Protocol version the client announced via `?v=` on the upgrade (#569), or
+  // PROTOCOL_VERSION when it announced none (web client / legacy native build).
+  protocolVersion?: number;
+  // Per-socket inbound flood-control token bucket (#574). Lazily initialized on
+  // the first message; see allowInboundMessage.
+  floodTokens?: number;
+  floodRefilledAt?: number;
+}
+
+// #574: cap a single inbound WS frame. The library default is 100 MB; client→
+// server frames are IRC-shaped (a line of text plus a little JSON), so a low cap
+// is safe and stops one frame from allocating a huge buffer. Uploads and imports
+// go over REST, never the socket.
+const MAX_WS_MESSAGE_BYTES = 256 * 1024;
+
+// #574: per-socket inbound message-rate limiter. A token bucket sized well above
+// any legitimate client — a human, plus the burst of open-buffer verbs a client
+// fires right after connect, never approaches this — that caps an authenticated
+// client trying to flood verbs. Checked BEFORE JSON.parse so a flood can't even
+// pay parse cost.
+const WS_MSG_BUCKET_CAPACITY = 120;
+const WS_MSG_BUCKET_REFILL_PER_SEC = 40;
+
+// Refill by elapsed time, spend one token. Returns false when the bucket is dry
+// — the caller then closes the socket, since a client hitting this rate is
+// misbehaving, not racing.
+export function allowInboundMessage(ws: LurkerWebSocket): boolean {
+  const now = Date.now();
+  const last = ws.floodRefilledAt ?? now;
+  const refilled = Math.min(
+    WS_MSG_BUCKET_CAPACITY,
+    (ws.floodTokens ?? WS_MSG_BUCKET_CAPACITY) +
+      ((now - last) / 1000) * WS_MSG_BUCKET_REFILL_PER_SEC,
+  );
+  ws.floodRefilledAt = now;
+  if (refilled < 1) {
+    ws.floodTokens = refilled;
+    return false;
+  }
+  ws.floodTokens = refilled - 1;
+  return true;
+}
+
+// The origins allowed to open a WebSocket, mirroring the same CORS_ORIGIN the
+// HTTP API already trusts for credentialed requests (app.ts). Comma-separated so
+// an operator can list several; defaults to the dev origin, matching app.ts.
+function corsAllowlist(): Set<string> {
+  const raw = process.env.CORS_ORIGIN || 'https://irc.local.bradroot.me:5173';
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+}
+
+// #574: same-origin / allowlisted Origin check for the WS upgrade. Browsers
+// always send Origin on a WS handshake; native clients send none. We reject only
+// a *browser* upgrade whose Origin is neither same-origin as the request Host nor
+// on the CORS allowlist — i.e. a cross-site attempt. Absent Origin (native) and
+// same-origin (the normal web case, hosted or self-host, independent of whether
+// CORS_ORIGIN was configured) always pass, so this can't wedge a working
+// deployment. On the hosted proxy the browser's Origin and Host both arrive as
+// the public app origin (http-proxy forwards them unchanged), so they match here.
+export function isAllowedUpgradeOrigin(req: IncomingMessage): boolean {
+  const origin = req.headers.origin;
+  if (!origin) return true;
+  let originHost: string;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return false;
+  }
+  if (req.headers.host && originHost === req.headers.host) return true;
+  return corsAllowlist().has(origin);
+}
+
+// The protocol version a client announces via `?v=<n>` on the /ws upgrade (#569),
+// or null when absent. Mirrors parseSinceParam.
+export function parseProtocolParam(rawUrl: string): number | null {
+  try {
+    const raw = new URL(rawUrl, 'http://localhost').searchParams.get('v');
+    if (!raw) return null;
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch (_) {
+    return null;
+  }
 }
 
 // Generic payload for outgoing WS messages.
@@ -1064,7 +1153,7 @@ export function authenticateUpgrade(req: IncomingMessage, sessionSecret: string)
 }
 
 export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_WS_MESSAGE_BYTES });
   // Per-user pending auto-away timers. Set when a user goes from 1→0 sockets;
   // cleared on 0→1 or when the timer fires.
   const autoAwayTimers = new Map();
@@ -1504,6 +1593,23 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
 
   httpServer.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
     if (!req.url || !req.url.startsWith('/ws')) return;
+    // #574: reject a cross-site browser upgrade before we touch auth or the DB.
+    // Native clients send no Origin and pass; same-origin/allowlisted pass.
+    if (!isAllowedUpgradeOrigin(req)) {
+      socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+    // #569: a client too old for this server is told to update (426) rather than
+    // handed a snapshot it would mis-render. A client that announces no version
+    // (?v absent) is treated as current — the web client ships in lockstep and
+    // any native build predating the handshake speaks today's protocol.
+    const clientVersion = parseProtocolParam(req.url);
+    if (clientVersion !== null && clientVersion < MIN_PROTOCOL_VERSION) {
+      socket.write('HTTP/1.1 426 Upgrade Required\r\n\r\n');
+      socket.destroy();
+      return;
+    }
     const user = authenticateUpgrade(req, sessionSecret);
     if (!user) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
@@ -1521,6 +1627,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       const lurkerWs = ws as LurkerWebSocket;
       lurkerWs.userId = user.id;
       lurkerWs.sinceId = initialSinceId;
+      lurkerWs.protocolVersion = clientVersion ?? PROTOCOL_VERSION;
       lurkerWs.presence = { visible: false };
       lurkerWs.isAlive = true;
       lurkerWs.accountPaused = user.is_paused === 1;
@@ -1533,6 +1640,20 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     sendSnapshot(ws, user.id);
 
     ws.on('message', (raw) => {
+      // #574: per-socket flood control, checked before JSON.parse so a flood
+      // pays no parse cost. Exhausting the bucket closes the socket (1008 policy
+      // violation) rather than dropping silently — a client at this rate is
+      // misbehaving, and closing makes it stop.
+      if (!allowInboundMessage(ws)) {
+        console.warn(`[wsHub] user ${user.id} exceeded WS message rate; closing socket`);
+        try {
+          send(ws, { kind: 'error', text: 'message rate exceeded' });
+        } catch (_err) {
+          /* socket may already be unwritable */
+        }
+        ws.close(1008, 'message rate exceeded');
+        return;
+      }
       let msg: WsPayload;
       try {
         msg = JSON.parse(raw.toString()) as WsPayload;
@@ -1623,6 +1744,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // so they ride alongside the per-network snapshot as their own field (#350).
     send(ws, {
       kind: 'snapshot',
+      // #569: the server's protocol version rides the snapshot so a client that
+      // connected without pre-checking GET /api/config still learns what the
+      // server speaks and can degrade knowingly.
+      protocolVersion: PROTOCOL_VERSION,
       networks,
       globalIgnores: ircManager.listGlobalIgnoresFor(userId),
       ...(isFreshConnect ? { cursor } : {}),


### PR DESCRIPTION
Two native-client foundation pieces on the WebSocket, both cheap now and expensive-or-impossible once a store binary ships. Grouped because they touch the same upgrade path and ship together in 1.1.1.

## #569 — protocol versioning + compatibility policy

- **New `server/protocol.ts`** holds `PROTOCOL_VERSION` + `MIN_PROTOCOL_VERSION` and writes down the compatibility contract: additive-only; unknown verbs/kinds are never fatal (client drops unknown `kind`s, server answers an unknown verb with a non-fatal `error` frame — its existing `default` case).
- **`GET /api/config`** now advertises `protocolVersion` + `minProtocolVersion` so a client can check compatibility *before* opening the socket and render a real "update required" error instead of a failed connect.
- The **`snapshot` frame** carries `protocolVersion` for a client that connected without pre-checking.
- The **upgrade** reads the client's announced version from `?v=` and rejects a too-old client with **HTTP 426** rather than a snapshot it would mis-render. An absent `?v` is treated as current (the web client ships in lockstep; legacy native builds predate the handshake).

> This is the time-critical one: the protocol has no version negotiation today, which is fine only because client+server ship in lockstep. Once a store binary exists it can't be added without a flag day.

## #574 — upgrade hardening

- **`maxPayload`** caps a single inbound frame at 256 KB (library default is 100 MB); client→server frames are IRC-shaped, uploads go over REST.
- **Same-origin / CORS-allowlisted Origin check** on the upgrade. Rejects only a *cross-site browser* upgrade; native clients (no `Origin`) and same-origin requests (hosted **or** self-host, independent of whether `CORS_ORIGIN` is set) always pass, so it can't wedge a working deployment. Safe because the CP proxy uses `http-proxy` without `changeOrigin`, so cells receive the original browser `Origin`/`Host` (both the public app origin on hosted).
- **Per-socket token-bucket flood limiter** on the message loop, checked *before* `JSON.parse`; exhausting it closes the socket (1008).

## Tests
Unit tests for the origin check, version parsing, and the flood bucket (exported the three helpers, mirroring the existing `authenticateUpgrade` test pattern); `config.test.ts` asserts the advertised versions. `npm run check` + full `npm test` (2450 tests) green.

Closes #569, closes #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)