### PR TITLE
Release 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.0",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Patch bump `1.1.0` → `1.1.1`. Native-app foundation + security hardening; nothing user-facing removed or changed.

## What's in it (10 commits since v1.1.0)
- **Bearer session tokens on the WS + REST (#489)** — native sessions are ordinary session rows; the bearer is returned in a body instead of a cookie so iOS/Android can auth the WS upgrade.
- **Per-IP auth rate limiting / brute-force backoff (#568)** — first rate limiting in the codebase; guards login + token-mint.
- **WS protocol versioning + compatibility policy (#569)** — version in `GET /api/config` + snapshot, a `?v=` handshake, and a written additive-only / never-fatal-on-unknown contract. Had to land before a store binary exists.
- **WS upgrade hardening (#574)** — `maxPayload`, same-origin/allowed-origin check, per-socket flood limiter.
- **Paused-account write block moved into `requireAuth` (#573)** — fixes a real gap where a paused account could still mutate settings/tokens/push/uploads/exports.
- **oidentd shared-daemon ident mode (#575)** — opt-in via `LURKER_OIDENTD_FILE`.

## Why a patch, not a minor
Everything is additive, transparent, opt-in, or a bugfix — no breaking changes and no behavior change for existing users.

## Diff
Only the self-`version` fields in `package.json` + `vue_client/package.json` and their lockfiles, bumped via `npm version patch`. Dependency entries — several of which sit at `1.1.0` — are deliberately untouched (a find-replace would corrupt them).

Version is read at runtime by `utils/userAgent.ts`, so Lurker will report `Lurker/1.1.1` in the HTTP User-Agent and CTCP VERSION reply.

After merge: tag `v1.1.1` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)