### PR TITLE
Native push notifications: transport seam, APNs + FCM (#490)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,7 +78,7 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_APNS_KEY=
 # LURKER_APNS_KEY_ID=
 # LURKER_APNS_TEAM_ID=
-# LURKER_APNS_BUNDLE_ID=chat.lurker.app
+# LURKER_APNS_BUNDLE_ID=net.amiantos.Lurker
 # LURKER_APNS_SANDBOX=
 #
 # LURKER_FCM_SERVICE_ACCOUNT — a Google service-account JSON, raw or base64.

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,40 @@ VITE_DEV_HOST=irc.local.bradroot.me
 # APNs (Safari/iOS) rejects single-label domains like localhost.
 VAPID_SUBJECT=mailto:you@example.com
 
+# --- Native push (APNs / FCM) — almost certainly NOT for you ------------------
+#
+# These push to the FIRST-PARTY Lurker mobile apps, and only their publisher can
+# use them: an APNs key signs only for the bundle id Apple issued it to, and an
+# FCM token is scoped to the Firebase project baked into the APK (a mismatch is
+# rejected with MismatchSenderId). So setting these with your own Apple/Google
+# credentials does NOT let your server push to the App Store / Play build.
+#
+# Self-hosting and want push? You already have it: Web Push above works on
+# desktop browsers and, via an installed home-screen PWA, on iOS 16.4+ and
+# Android. That path needs no developer account and no keys here.
+#
+# Leaving these unset is normal and correct. Set is only for the publisher of the
+# apps, or for someone running their own build of them signed with their own
+# credentials. Partially set fails loud at boot rather than silently disabling
+# push for every phone.
+#
+# LURKER_APNS_KEY — the .p8 signing key, PEM or base64 of the PEM (base64 is what
+#   survives an env var; a PEM is multi-line).
+# LURKER_APNS_KEY_ID — Apple's key id for that .p8.
+# LURKER_APNS_TEAM_ID — your Apple developer team id.
+# LURKER_APNS_BUNDLE_ID — the app's bundle id.
+# LURKER_APNS_SANDBOX — 1 to route to Apple's development gateway (debug builds
+#   installed from Xcode). Leave unset for TestFlight and the App Store.
+#
+# LURKER_APNS_KEY=
+# LURKER_APNS_KEY_ID=
+# LURKER_APNS_TEAM_ID=
+# LURKER_APNS_BUNDLE_ID=chat.lurker.app
+# LURKER_APNS_SANDBOX=
+#
+# LURKER_FCM_SERVICE_ACCOUNT — a Google service-account JSON, raw or base64.
+# LURKER_FCM_SERVICE_ACCOUNT=
+
 # Contact info embedded in our outbound User-Agent (and CTCP VERSION reply)
 # so external service operators can reach you if Lurker misbehaves. May be a
 # URL or mailto:. Leave unset to fall back to the upstream project link.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -180,6 +180,19 @@ Lurker supports background push notifications for highlights and DMs, delivered 
 
 If you change `VAPID_SUBJECT` later, existing subscriptions continue to work — the subject only affects new push JWTs, not the keypair.
 
+### Push and the mobile apps
+
+**Short version: install Lurker as a home-screen PWA and use Web Push above. That is the supported path for a self-hosted server, and it works on iOS 16.4+ and Android with no developer account and no extra configuration.**
+
+The first-party Lurker mobile apps use native push (APNs on iOS, FCM on Android), and a self-hosted server **cannot** deliver to them. This isn't a missing feature — it's how the platforms work:
+
+- An APNs signing key only signs for the bundle id Apple issued it to.
+- An FCM token is scoped to the Firebase project compiled into the APK; a token from a different project is rejected outright (`MismatchSenderId`).
+
+So only the publisher of a build can push to that build. Supplying your own Apple or Google credentials to `LURKER_APNS_*` / `LURKER_FCM_SERVICE_ACCOUNT` will not make your server able to push to the App Store or Play Store app — those variables exist for whoever publishes the app, and for anyone running **their own build** of it signed with their own credentials.
+
+You can check what a given server can actually deliver on: `GET /api/push/config` returns a `transports` list. A self-hosted server reports `["webpush"]`, and the apps use that to tell you push isn't available rather than asking for notification permission and then silently never delivering.
+
 ### File uploads on your own disk
 
 By default, images you paste or drop into the message box are uploaded to a third-party host (x0.at). If you'd rather keep them on your own server, pick **local** in **Settings → Uploads**. Lurker then writes the file to disk and serves it back from your own instance, and the link it pastes into IRC points at you — no third party involved.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1016,6 +1016,12 @@ ensureColumn('dcc_transfers', 'peer_port', 'INTEGER');
 // so it stops erroring on every notification.
 ensureColumn('push_subscriptions', 'fail_count', 'INTEGER NOT NULL DEFAULT 0');
 
+// #490: native push. A row now says which transport it speaks, because APNs and
+// FCM deliver to an opaque device token rather than a Web Push service URL and
+// carry no ECDH keypair. Every pre-existing row is Web Push by definition, which
+// is also why the default is safe to rely on rather than backfill.
+ensureColumn('push_subscriptions', 'transport', "TEXT NOT NULL DEFAULT 'webpush'");
+
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
@@ -1502,6 +1508,62 @@ try {
   }
 }
 
+// Issue #490 native push: p256dh/auth must be nullable. They are Web Push ECDH
+// crypto (RFC 8291) and an APNs/FCM device token has no equivalent — a native row
+// has nothing truthful to put there, and '' would be a lie the type system would
+// then have to believe. SQLite can't drop a NOT NULL in place, so rebuild.
+// Shape-gated on p256dh's notnull flag — idempotent, self-heals a half-migrated
+// DB, and won't touch a DB already on the new shape. Placed after the
+// ensureColumn block above so `transport` and `fail_count` exist to copy.
+//
+// `endpoint` keeps its global UNIQUE rather than moving to UNIQUE(transport,
+// endpoint): a device token and a push-service URL cannot collide in practice, so
+// the composite would buy nothing while forcing `transport` through every
+// endpoint-keyed call site (get/delete/heartbeat) and the routes above them.
+{
+  const p256Col = (
+    db.prepare(`PRAGMA table_info(push_subscriptions)`).all() as TableInfoRow[]
+  ).find((c) => c.name === 'p256dh');
+  if (p256Col && p256Col.notnull === 1) {
+    const rebuild = db.transaction(() => {
+      db.exec(`DROP INDEX IF EXISTS idx_push_subs_user`);
+      db.exec(`
+        CREATE TABLE push_subscriptions_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          user_id INTEGER NOT NULL,
+          endpoint TEXT NOT NULL UNIQUE,
+          transport TEXT NOT NULL DEFAULT 'webpush',
+          p256dh TEXT,
+          auth TEXT,
+          user_agent TEXT,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+          fail_count INTEGER NOT NULL DEFAULT 0,
+          FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+      `);
+      db.exec(`
+        INSERT INTO push_subscriptions_new
+          (id, user_id, endpoint, transport, p256dh, auth, user_agent, enabled,
+           created_at, last_seen_at, fail_count)
+        SELECT id, user_id, endpoint, transport, p256dh, auth, user_agent, enabled,
+           created_at, last_seen_at, fail_count
+        FROM push_subscriptions
+      `);
+      db.exec(`DROP TABLE push_subscriptions`);
+      db.exec(`ALTER TABLE push_subscriptions_new RENAME TO push_subscriptions`);
+    });
+    const prevFk = db.pragma('foreign_keys', { simple: true });
+    db.pragma('foreign_keys = OFF');
+    try {
+      rebuild();
+    } finally {
+      db.pragma(`foreign_keys = ${prevFk ? 'ON' : 'OFF'}`);
+    }
+  }
+}
+
 // Issue #349 highlight overhaul: `pattern` must be nullable so a pure -mask
 // rule (highlight everyone matching a nick!user@host) can carry no keyword, and
 // the table gains `mask` + `channels` scope columns. SQLite can't drop a NOT
@@ -1650,5 +1712,10 @@ db.exec(`CREATE INDEX IF NOT EXISTS idx_ignored_masks_user_net
 db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_buffer_reads_key
          ON buffer_reads(user_id, IFNULL(network_id, 0), target)`);
 db.exec(`CREATE INDEX IF NOT EXISTS idx_buffer_reads_user ON buffer_reads(user_id)`);
+
+// #490: the push_subscriptions rebuild drops this with the table, and migrate()'s
+// CREATE already ran before it — so recreate here for both fresh and rebuilt
+// paths. hasEnabledForUser hits it on the push hot path.
+db.exec(`CREATE INDEX IF NOT EXISTS idx_push_subs_user ON push_subscriptions(user_id)`);
 
 export default db;

--- a/server/db/pushSubscriptions.test.ts
+++ b/server/db/pushSubscriptions.test.ts
@@ -109,6 +109,65 @@ describe('listEnabledForUser', () => {
   });
 });
 
+describe('cross-user collision is decided by the STORED row (#490 review)', () => {
+  it('refuses to let a native registration claim another user webpush endpoint', () => {
+    // The bug: the guard tested the INCOMING transport, so declaring 'apns'
+    // walked straight past the webpush refusal and rebound Alice's browser
+    // subscription to Bob — nulling her keys and silently ending her push, with
+    // no UI anywhere showing why. What a caller CLAIMS to be cannot be what
+    // decides whether it may take someone else's row.
+    mod.upsertSubscription(alice.id, {
+      transport: 'webpush',
+      endpoint: 'https://push.test/alice-owned',
+      p256dh: 'k',
+      auth: 'a',
+    });
+    const out = mod.upsertSubscription(bob.id, {
+      transport: 'apns',
+      endpoint: 'https://push.test/alice-owned',
+    });
+    expect(out).toEqual({ ok: false, error: 'endpoint_owned_by_other_user' });
+    const sub = mod.getByEndpoint('https://push.test/alice-owned');
+    expect(sub).toMatchObject({ user_id: alice.id, transport: 'webpush', p256dh: 'k' });
+  });
+
+  it('refuses to let a webpush registration claim another user device token', () => {
+    mod.upsertSubscription(alice.id, { transport: 'apns', endpoint: 'alice-device-token' });
+    const out = mod.upsertSubscription(bob.id, {
+      transport: 'webpush',
+      endpoint: 'alice-device-token',
+      p256dh: 'k',
+      auth: 'a',
+    });
+    expect(out).toEqual({ ok: false, error: 'endpoint_owned_by_other_user' });
+    expect(mod.getByEndpoint('alice-device-token')?.user_id).toBe(alice.id);
+  });
+
+  it('still rebinds native→native, which is a phone changing hands', () => {
+    mod.upsertSubscription(alice.id, { transport: 'apns', endpoint: 'shared-phone-token' });
+    const out = mod.upsertSubscription(bob.id, {
+      transport: 'apns',
+      endpoint: 'shared-phone-token',
+    });
+    expect(out.ok).toBe(true);
+    expect(mod.getByEndpoint('shared-phone-token')?.user_id).toBe(bob.id);
+  });
+
+  it('lets the SAME user change a subscription transport on their own row', () => {
+    // Not a collision at all — no ownership question to answer.
+    mod.upsertSubscription(alice.id, { transport: 'apns', endpoint: 'alice-retransport' });
+    const out = mod.upsertSubscription(alice.id, {
+      transport: 'fcm',
+      endpoint: 'alice-retransport',
+    });
+    expect(out.ok).toBe(true);
+    expect(mod.getByEndpoint('alice-retransport')).toMatchObject({
+      user_id: alice.id,
+      transport: 'fcm',
+    });
+  });
+});
+
 describe('failure tracking (#441)', () => {
   function freshSub(endpoint: string) {
     const out = mod.upsertSubscription(alice.id, {

--- a/server/db/pushSubscriptions.test.ts
+++ b/server/db/pushSubscriptions.test.ts
@@ -26,6 +26,7 @@ afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 describe('upsertSubscription', () => {
   it('inserts a new subscription and surfaces it via listAllForUser', () => {
     const out = mod.upsertSubscription(alice.id, {
+      transport: 'webpush',
       endpoint: 'https://example.test/a',
       p256dh: 'k1',
       auth: 'a1',
@@ -38,6 +39,7 @@ describe('upsertSubscription', () => {
 
   it('refuses to rebind a foreign-owned endpoint', () => {
     const conflict = mod.upsertSubscription(bob.id, {
+      transport: 'webpush',
       endpoint: 'https://example.test/a',
       p256dh: 'k2',
       auth: 'a2',
@@ -50,6 +52,7 @@ describe('upsertSubscription', () => {
 
   it('updates p256dh/auth for the same owner', () => {
     const out = mod.upsertSubscription(alice.id, {
+      transport: 'webpush',
       endpoint: 'https://example.test/a',
       p256dh: 'k1-new',
       auth: 'a1-new',
@@ -86,11 +89,13 @@ describe('listEnabledForUser', () => {
   it('filters by enabled=1', async () => {
     const db = (await import('./index.js')).default;
     mod.upsertSubscription(alice.id, {
+      transport: 'webpush',
       endpoint: 'https://example.test/on',
       p256dh: 'k',
       auth: 'a',
     });
     const off = mod.upsertSubscription(alice.id, {
+      transport: 'webpush',
       endpoint: 'https://example.test/off',
       p256dh: 'k',
       auth: 'a',
@@ -106,7 +111,12 @@ describe('listEnabledForUser', () => {
 
 describe('failure tracking (#441)', () => {
   function freshSub(endpoint: string) {
-    const out = mod.upsertSubscription(alice.id, { endpoint, p256dh: 'k', auth: 'a' });
+    const out = mod.upsertSubscription(alice.id, {
+      transport: 'webpush',
+      endpoint,
+      p256dh: 'k',
+      auth: 'a',
+    });
     return (out as Extract<typeof out, { ok: true }>).sub!;
   }
 

--- a/server/db/pushSubscriptions.ts
+++ b/server/db/pushSubscriptions.ts
@@ -10,16 +10,27 @@ import db from './index.js';
  * `fcm` are opaque per-install device tokens with no keypair at all — which is
  * why the crypto columns are nullable and why this discriminator exists rather
  * than the code sniffing at the endpoint's shape.
+ *
+ * These arrays are the ONE list of transports; the type is derived from them and
+ * every consumer reads them rather than restating the members. Adding a fourth
+ * transport should be a compile error at each place that must handle it (the
+ * sender registry is a Record over this type), not a silent omission — the
+ * previous shape spelled the list out in six places, only one of which the
+ * compiler checked.
  */
-export type PushTransport = 'webpush' | 'apns' | 'fcm';
+export const PUSH_TRANSPORTS = ['webpush', 'apns', 'fcm'] as const;
+export type PushTransport = (typeof PUSH_TRANSPORTS)[number];
 
-export const NATIVE_TRANSPORTS: ReadonlySet<PushTransport> = new Set<PushTransport>([
-  'apns',
-  'fcm',
-]);
+/** The transports that deliver to an app install rather than a browser. */
+export const NATIVE_TRANSPORTS = ['apns', 'fcm'] as const satisfies readonly PushTransport[];
+export type NativeTransport = (typeof NATIVE_TRANSPORTS)[number];
 
 export function isPushTransport(value: unknown): value is PushTransport {
-  return value === 'webpush' || value === 'apns' || value === 'fcm';
+  return PUSH_TRANSPORTS.includes(value as PushTransport);
+}
+
+export function isNativeTransport(value: unknown): value is NativeTransport {
+  return NATIVE_TRANSPORTS.includes(value as NativeTransport);
 }
 
 /** A row from the `push_subscriptions` table. */
@@ -160,6 +171,13 @@ export type SubscriptionInput =
 //   the token owned by the old account and the new user permanently unpushable,
 //   with no UI anywhere to release it.
 //
+// Which means the rebind is only safe when BOTH sides are native, and the test
+// has to be on the STORED row — never on what the caller declares itself to be,
+// or claiming `transport: 'apns'` while presenting someone else's push URL walks
+// straight past the refusal and takes their subscription (review of #490). A
+// native token and a push-service URL can't legitimately be equal anyway, so the
+// mixed cases are refused rather than reasoned about.
+//
 // Returns { ok, sub } on success or { ok: false, error } on a refused collision.
 export function upsertSubscription(
   userId: number,
@@ -170,8 +188,9 @@ export function upsertSubscription(
   const auth = transport === 'webpush' ? input.auth : null;
 
   const existing = getByEndpoint(endpoint);
-  if (existing && existing.user_id !== userId && transport === 'webpush') {
-    return { ok: false, error: 'endpoint_owned_by_other_user' };
+  if (existing && existing.user_id !== userId) {
+    const bothNative = existing.transport !== 'webpush' && transport !== 'webpush';
+    if (!bothNative) return { ok: false, error: 'endpoint_owned_by_other_user' };
   }
   if (existing) {
     // user_id is reassigned on a native rebind; for webpush it's a no-op write of

--- a/server/db/pushSubscriptions.ts
+++ b/server/db/pushSubscriptions.ts
@@ -3,13 +3,33 @@
 
 import db from './index.js';
 
+/**
+ * How a subscription is delivered to (#490).
+ *
+ * `webpush` is a push-service URL plus an ECDH keypair (RFC 8291). `apns` and
+ * `fcm` are opaque per-install device tokens with no keypair at all — which is
+ * why the crypto columns are nullable and why this discriminator exists rather
+ * than the code sniffing at the endpoint's shape.
+ */
+export type PushTransport = 'webpush' | 'apns' | 'fcm';
+
+export const NATIVE_TRANSPORTS: ReadonlySet<PushTransport> = new Set<PushTransport>([
+  'apns',
+  'fcm',
+]);
+
+export function isPushTransport(value: unknown): value is PushTransport {
+  return value === 'webpush' || value === 'apns' || value === 'fcm';
+}
+
 /** A row from the `push_subscriptions` table. */
 export interface PushSubscriptionRow {
   id: number;
   user_id: number;
   endpoint: string;
-  p256dh: string;
-  auth: string;
+  transport: string;
+  p256dh: string | null;
+  auth: string | null;
   user_agent: string | null;
   enabled: number;
   created_at: string;
@@ -17,13 +37,10 @@ export interface PushSubscriptionRow {
   fail_count: number;
 }
 
-/** Projected push subscription with boolean `enabled`. */
-export interface PushSubscription {
+interface PushSubscriptionBase {
   id: number;
   user_id: number;
   endpoint: string;
-  p256dh: string;
-  auth: string;
   user_agent: string | null;
   enabled: boolean;
   created_at: string;
@@ -31,20 +48,48 @@ export interface PushSubscription {
   fail_count: number;
 }
 
+/**
+ * Projected push subscription, discriminated on transport so the credential
+ * shape follows from it. A `webpush` sub always has its keys and a native one
+ * never does — the union is what lets deliver() narrow to a transport and reach
+ * for `p256dh` without a non-null assertion, and what makes "native sub with
+ * Web Push keys" unrepresentable rather than merely unlikely.
+ */
+export type PushSubscription =
+  | (PushSubscriptionBase & { transport: 'webpush'; p256dh: string; auth: string })
+  | (PushSubscriptionBase & { transport: 'apns' | 'fcm'; p256dh: null; auth: null });
+
 function rowToSub(row: PushSubscriptionRow | undefined): PushSubscription | null {
   if (!row) return null;
-  return {
+  const base: PushSubscriptionBase = {
     id: row.id,
     user_id: row.user_id,
     endpoint: row.endpoint,
-    p256dh: row.p256dh,
-    auth: row.auth,
     user_agent: row.user_agent,
     enabled: !!row.enabled,
     created_at: row.created_at,
     last_seen_at: row.last_seen_at,
     fail_count: row.fail_count ?? 0,
   };
+  if (!isPushTransport(row.transport)) {
+    // A transport this build doesn't know — e.g. a row written by a NEWER server
+    // after a downgrade. Skipping it is the safe read: we cannot deliver to a
+    // transport we can't speak, and guessing would mean handing an opaque token
+    // to the Web Push sender. The row survives for the newer build to use again.
+    console.warn(`[push] ignoring subscription ${row.id}: unknown transport ${row.transport}`);
+    return null;
+  }
+  if (row.transport === 'webpush') {
+    if (row.p256dh == null || row.auth == null) {
+      // Web Push without a keypair can't be encrypted, so it can't be sent. Only
+      // reachable via direct DB surgery, but skip rather than crash the fan-out
+      // for every other device the user owns.
+      console.warn(`[push] ignoring webpush subscription ${row.id}: missing keys`);
+      return null;
+    }
+    return { ...base, transport: 'webpush', p256dh: row.p256dh, auth: row.auth };
+  }
+  return { ...base, transport: row.transport, p256dh: null, auth: null };
 }
 
 export function listEnabledForUser(userId: number): PushSubscription[] {
@@ -85,47 +130,73 @@ export function getByEndpoint(endpoint: string): PushSubscription | null {
   );
 }
 
-// Push endpoint URLs persist per browser/PushManager — when two users log
-// into the same browser, the same endpoint comes back from subscribe(). A
-// blind UPDATE would silently rebind it to whichever user enabled most
-// recently, stealing the other user's notifications. Refuse instead; the
-// previous owner must disable push on their session before a new user can
-// claim it. Returns { ok, sub? } on success or { ok: false, error } on a
-// cross-user collision.
+/**
+ * What to register. The union means a Web Push subscription cannot be filed
+ * without its keypair, and a native one cannot smuggle keys it doesn't have.
+ */
+export type SubscriptionInput =
+  | {
+      transport: 'webpush';
+      endpoint: string;
+      p256dh: string;
+      auth: string;
+      userAgent?: string | null;
+    }
+  | { transport: 'apns' | 'fcm'; endpoint: string; userAgent?: string | null };
+
+// Ownership on a cross-user collision is decided by transport, because the two
+// cases mean opposite things (#490):
+//
+// - webpush: endpoint URLs persist per browser/PushManager, so when two users
+//   log into the same browser, subscribe() hands back the SAME endpoint for
+//   both — concurrently. A blind rebind would silently steal the other user's
+//   notifications, so refuse; the previous owner disables push first.
+//
+// - apns/fcm: the token identifies an app INSTALL, and an install has exactly
+//   one signed-in user at a time. The same token coming back under a different
+//   user means the phone changed hands (sign out → sign in), so rebind — that
+//   is the truth, not a collision. Refusing here would be an outright bug: a
+//   sign-out that failed to deregister (crash, offline, force-quit) would leave
+//   the token owned by the old account and the new user permanently unpushable,
+//   with no UI anywhere to release it.
+//
+// Returns { ok, sub } on success or { ok: false, error } on a refused collision.
 export function upsertSubscription(
   userId: number,
-  {
-    endpoint,
-    p256dh,
-    auth,
-    userAgent,
-  }: { endpoint: string; p256dh: string; auth: string; userAgent?: string | null },
+  input: SubscriptionInput,
 ): { ok: true; sub: PushSubscription | null } | { ok: false; error: string } {
+  const { transport, endpoint, userAgent } = input;
+  const p256dh = transport === 'webpush' ? input.p256dh : null;
+  const auth = transport === 'webpush' ? input.auth : null;
+
   const existing = getByEndpoint(endpoint);
-  if (existing && existing.user_id !== userId) {
+  if (existing && existing.user_id !== userId && transport === 'webpush') {
     return { ok: false, error: 'endpoint_owned_by_other_user' };
   }
   if (existing) {
+    // user_id is reassigned on a native rebind; for webpush it's a no-op write of
+    // the value it already held, since a cross-user webpush row returned above.
     db.prepare(
       `
       UPDATE push_subscriptions
-      SET p256dh = ?, auth = ?, user_agent = COALESCE(?, user_agent),
+      SET user_id = ?, transport = ?, p256dh = ?, auth = ?,
+          user_agent = COALESCE(?, user_agent),
           enabled = 1, fail_count = 0,
           last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
       WHERE endpoint = ?
     `,
-    ).run(p256dh, auth, userAgent || null, endpoint);
+    ).run(userId, transport, p256dh, auth, userAgent || null, endpoint);
     return { ok: true, sub: getByEndpoint(endpoint) };
   }
   db.prepare(
     `
     INSERT INTO push_subscriptions
-      (user_id, endpoint, p256dh, auth, user_agent, created_at, last_seen_at)
-    VALUES (?, ?, ?, ?, ?,
+      (user_id, endpoint, transport, p256dh, auth, user_agent, created_at, last_seen_at)
+    VALUES (?, ?, ?, ?, ?, ?,
       strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
       strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
   `,
-  ).run(userId, endpoint, p256dh, auth, userAgent || null);
+  ).run(userId, endpoint, transport, p256dh, auth, userAgent || null);
   return { ok: true, sub: getByEndpoint(endpoint) };
 }
 

--- a/server/db/pushSubscriptionsMigration.test.ts
+++ b/server/db/pushSubscriptionsMigration.test.ts
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Proves the #490 push_subscriptions rebuild upgrades a REAL pre-existing DB
+// without losing anything.
+//
+// Every other test in the suite gets its DB from setupTestDb, which runs the
+// rebuild against a table that was created empty microseconds earlier. That
+// exercises the SQL but proves nothing about the case a deploy actually hits: an
+// installed database with live subscriptions in the old Web-Push-only shape. A
+// rebuild is create-new → copy → DROP the original → rename, so a wrong column
+// list in the copy silently drops user data and every other test stays green.
+//
+// So this seeds a database in the genuine pre-migration shape — the CREATE TABLE
+// as it stood before #490, NOT NULL crypto columns and all — inserts rows, and
+// only then imports db/index.js to run the migration for real.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+import type BetterSqlite3 from 'better-sqlite3';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-pushmig-'));
+const dbPath = path.join(tmpDir, 'test.db');
+
+// Seed BEFORE db/index.js is imported: the migration runs at import time, so the
+// old-shape database has to be on disk first.
+{
+  const seed = new Database(dbPath);
+  // Verbatim copies of the shapes as they were before #490 — deliberately not
+  // imported from anywhere, because the point is to reproduce the schema a
+  // deployed server is actually sitting on, not whatever the code says today.
+  seed.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE push_subscriptions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      endpoint TEXT NOT NULL UNIQUE,
+      p256dh TEXT NOT NULL,
+      auth TEXT NOT NULL,
+      user_agent TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    CREATE INDEX idx_push_subs_user ON push_subscriptions(user_id);
+  `);
+  seed.prepare(`INSERT INTO users (id, username) VALUES (1, 'alice'), (2, 'bob')`).run();
+  seed
+    .prepare(
+      `INSERT INTO push_subscriptions
+         (id, user_id, endpoint, p256dh, auth, user_agent, enabled, created_at, last_seen_at)
+       VALUES
+         (10, 1, 'https://push.test/alice', 'kA', 'aA', 'Firefox', 1, '2026-01-01T00:00:00.000Z', '2026-02-02T00:00:00.000Z'),
+         (11, 1, 'https://push.test/alice2', 'kA2', 'aA2', NULL, 0, '2026-01-03T00:00:00.000Z', '2026-02-04T00:00:00.000Z'),
+         (12, 2, 'https://push.test/bob', 'kB', 'aB', 'Chrome', 1, '2026-01-05T00:00:00.000Z', '2026-02-06T00:00:00.000Z')`,
+    )
+    .run();
+  seed.close();
+}
+
+process.env.DATABASE_PATH = dbPath;
+
+let db: BetterSqlite3.Database;
+let mod: typeof import('./pushSubscriptions.js');
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  mod = await import('./pushSubscriptions.js');
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+interface ColumnInfo {
+  name: string;
+  notnull: number;
+}
+
+const columns = (): ColumnInfo[] =>
+  db.prepare(`PRAGMA table_info(push_subscriptions)`).all() as ColumnInfo[];
+
+describe('push_subscriptions rebuild (#490)', () => {
+  it('preserves every existing row, with ids and metadata intact', () => {
+    const rows = db.prepare(`SELECT * FROM push_subscriptions ORDER BY id`).all() as Array<
+      Record<string, unknown>
+    >;
+    expect(rows).toHaveLength(3);
+    // Ids matter: a re-INSERT that renumbered them would orphan nothing visibly
+    // today but would break any future row this table is joined from.
+    expect(rows.map((r) => r.id)).toEqual([10, 11, 12]);
+    expect(rows[0]).toMatchObject({
+      user_id: 1,
+      endpoint: 'https://push.test/alice',
+      p256dh: 'kA',
+      auth: 'aA',
+      user_agent: 'Firefox',
+      enabled: 1,
+      created_at: '2026-01-01T00:00:00.000Z',
+      last_seen_at: '2026-02-02T00:00:00.000Z',
+    });
+    // The disabled row stays disabled — a copy that defaulted enabled would
+    // silently resurrect a subscription the user turned off.
+    expect(rows[1]).toMatchObject({ id: 11, enabled: 0, user_agent: null });
+    expect(rows[2]).toMatchObject({ id: 12, user_id: 2, endpoint: 'https://push.test/bob' });
+  });
+
+  it('backfills existing rows as webpush', () => {
+    const rows = db.prepare(`SELECT transport FROM push_subscriptions`).all() as Array<{
+      transport: string;
+    }>;
+    expect(rows.every((r) => r.transport === 'webpush')).toBe(true);
+  });
+
+  it('backfills fail_count rather than leaving it null', () => {
+    // fail_count arrived via ensureColumn (#441) and the rebuild copies it, so a
+    // DB that predates BOTH migrations has to come out with a usable 0 — NULL
+    // would make `fail_count + 1` in recordFailure evaluate to NULL forever and
+    // the disable threshold would never trigger.
+    const rows = db.prepare(`SELECT fail_count FROM push_subscriptions`).all() as Array<{
+      fail_count: number;
+    }>;
+    expect(rows.every((r) => r.fail_count === 0)).toBe(true);
+  });
+
+  it('drops NOT NULL from the Web Push crypto columns', () => {
+    const cols = columns();
+    expect(cols.find((c) => c.name === 'p256dh')?.notnull).toBe(0);
+    expect(cols.find((c) => c.name === 'auth')?.notnull).toBe(0);
+    // ...while the columns that must stay required, stay required.
+    expect(cols.find((c) => c.name === 'user_id')?.notnull).toBe(1);
+    expect(cols.find((c) => c.name === 'endpoint')?.notnull).toBe(1);
+    expect(cols.find((c) => c.name === 'transport')?.notnull).toBe(1);
+  });
+
+  it('recreates the user index the rebuild dropped with the table', () => {
+    const idx = db.prepare(`PRAGMA index_list(push_subscriptions)`).all() as Array<{
+      name: string;
+    }>;
+    expect(idx.some((i) => i.name === 'idx_push_subs_user')).toBe(true);
+  });
+
+  it('keeps endpoint unique', () => {
+    expect(() =>
+      db
+        .prepare(`INSERT INTO push_subscriptions (user_id, endpoint, transport) VALUES (1, ?, ?)`)
+        .run('https://push.test/alice', 'webpush'),
+    ).toThrow(/UNIQUE/);
+  });
+
+  it('accepts a native subscription with no keys — the point of the rebuild', () => {
+    const out = mod.upsertSubscription(1, {
+      transport: 'apns',
+      endpoint: 'apns-device-token-abc',
+      userAgent: 'Lurker/1.0 (iPhone)',
+    });
+    expect(out.ok).toBe(true);
+    const sub = mod.getByEndpoint('apns-device-token-abc');
+    expect(sub).toMatchObject({ transport: 'apns', p256dh: null, auth: null, user_id: 1 });
+  });
+
+  it('still refuses to hand a webpush endpoint to another user', () => {
+    // The pre-existing rule, unchanged by the transport work.
+    const out = mod.upsertSubscription(2, {
+      transport: 'webpush',
+      endpoint: 'https://push.test/alice',
+      p256dh: 'stolen',
+      auth: 'stolen',
+    });
+    expect(out).toEqual({ ok: false, error: 'endpoint_owned_by_other_user' });
+    expect(mod.getByEndpoint('https://push.test/alice')?.user_id).toBe(1);
+  });
+
+  it('rebinds a native device token to whoever signed in last', () => {
+    // The deliberate inversion: one app install has one signed-in user, so the
+    // same token under a new user means the phone changed hands. Refusing would
+    // strand the new user with no way to release the token.
+    mod.upsertSubscription(1, { transport: 'apns', endpoint: 'apns-shared-phone' });
+    const out = mod.upsertSubscription(2, { transport: 'apns', endpoint: 'apns-shared-phone' });
+    expect(out.ok).toBe(true);
+    expect(mod.getByEndpoint('apns-shared-phone')?.user_id).toBe(2);
+    // And alice no longer gets pushes for it.
+    expect(mod.listEnabledForUser(1).some((s) => s.endpoint === 'apns-shared-phone')).toBe(false);
+    expect(mod.listEnabledForUser(2).some((s) => s.endpoint === 'apns-shared-phone')).toBe(true);
+  });
+
+  it('re-enables and clears the failure streak when a device re-registers', () => {
+    mod.upsertSubscription(1, { transport: 'fcm', endpoint: 'fcm-token-1' });
+    const sub = mod.getByEndpoint('fcm-token-1')!;
+    mod.recordFailure(sub.id);
+    mod.recordFailure(sub.id);
+    mod.disableSubscription(sub.id);
+    expect(mod.getByEndpoint('fcm-token-1')?.enabled).toBe(false);
+
+    mod.upsertSubscription(1, { transport: 'fcm', endpoint: 'fcm-token-1' });
+    expect(mod.getByEndpoint('fcm-token-1')).toMatchObject({ enabled: true, fail_count: 0 });
+  });
+});

--- a/server/routes/push.ts
+++ b/server/routes/push.ts
@@ -5,18 +5,99 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { getPublicKey } from '../services/pushService.js';
+import { senderFor } from '../services/push/index.js';
 import {
   upsertSubscription,
   deleteByEndpoint,
   listAllForUser,
   heartbeatByEndpoint,
+  type PushTransport,
 } from '../db/pushSubscriptions.js';
 
 const router = Router();
 router.use(requireAuth);
 
+// A device token is opaque and provider-issued; anything much longer than APNs'
+// 64 hex chars or an FCM registration token is not one. A bound at all matters
+// because the value goes straight into a URL path (APNs) and a JSON body.
+const MAX_DEVICE_TOKEN_LENGTH = 4096;
+
+const NATIVE_TRANSPORTS = ['apns', 'fcm'] as const;
+type NativeTransport = (typeof NATIVE_TRANSPORTS)[number];
+
+function isNativeTransport(value: unknown): value is NativeTransport {
+  return NATIVE_TRANSPORTS.includes(value as NativeTransport);
+}
+
 router.get('/config', (_req: Request, res: Response) => {
-  res.json({ publicKey: getPublicKey() });
+  // `transports` tells a client what this server can ACTUALLY deliver on, which
+  // is not knowable from the app's own build (#490). A self-hosted server holds
+  // no Apple key and reports ['webpush'] — so the iOS app can say so plainly
+  // instead of asking for notification permission and then silently never
+  // delivering. publicKey stays for Web Push and is meaningless to native.
+  const transports: PushTransport[] = (['webpush', 'apns', 'fcm'] as const).filter((t) =>
+    senderFor(t).isConfigured(),
+  );
+  res.json({ publicKey: getPublicKey(), transports });
+});
+
+// Native device registration (#490 phase 4). Separate from /subscriptions rather
+// than an overload of it: there are no `keys` here, and the cross-user collision
+// rule is the opposite — see upsertSubscription.
+router.post('/devices', (req: Request, res: Response) => {
+  const { token, transport } = req.body || {};
+  if (!token || typeof token !== 'string') {
+    res.status(400).json({ error: 'token is required' });
+    return;
+  }
+  if (token.length > MAX_DEVICE_TOKEN_LENGTH) {
+    res.status(400).json({ error: 'token is not a device token' });
+    return;
+  }
+  // 'webpush' is deliberately not accepted here. It would file a Web Push row
+  // with no keypair, which is undeliverable AND unrepresentable — every later
+  // read would skip it, so push would silently never arrive.
+  if (!isNativeTransport(transport)) {
+    res.status(400).json({ error: `transport must be one of: ${NATIVE_TRANSPORTS.join(', ')}` });
+    return;
+  }
+  // Registering against a server that can't deliver is a real case, not an edge
+  // one: a self-hoster's user running the App Store build. Say so rather than
+  // accepting a row that will never push.
+  if (!senderFor(transport).isConfigured()) {
+    res.status(503).json({
+      error: `this server is not configured for ${transport} push`,
+      transport,
+    });
+    return;
+  }
+  const result = upsertSubscription(req.user!.id, {
+    transport,
+    endpoint: token,
+    userAgent: req.headers['user-agent'] || null,
+  });
+  if (!result.ok || !result.sub) {
+    // upsertSubscription rebinds rather than refusing for native, so !ok here is
+    // not the cross-user case — it's a genuine storage failure.
+    res.status(500).json({ error: 'device could not be registered' });
+    return;
+  }
+  res.status(201).json({ device: { id: result.sub.id, transport: result.sub.transport } });
+});
+
+// Deregister on sign-out. The app is expected to call this BEFORE /auth/logout,
+// while it still has a session to authenticate with. When that fails — a crash,
+// a force-quit, no network — the token stays filed against the old account, and
+// the native rebind rule in upsertSubscription is what stops that from stranding
+// the next user who signs in on the phone.
+router.delete('/devices', (req: Request, res: Response) => {
+  const { token } = req.body || {};
+  if (!token || typeof token !== 'string') {
+    res.status(400).json({ error: 'token is required' });
+    return;
+  }
+  deleteByEndpoint(req.user!.id, token);
+  res.json({ ok: true });
 });
 
 router.get('/subscriptions', (req: Request, res: Response) => {

--- a/server/routes/push.ts
+++ b/server/routes/push.ts
@@ -11,23 +11,31 @@ import {
   deleteByEndpoint,
   listAllForUser,
   heartbeatByEndpoint,
-  type PushTransport,
+  isNativeTransport,
+  NATIVE_TRANSPORTS,
+  PUSH_TRANSPORTS,
+  type NativeTransport,
 } from '../db/pushSubscriptions.js';
 
 const router = Router();
 router.use(requireAuth);
 
-// A device token is opaque and provider-issued; anything much longer than APNs'
-// 64 hex chars or an FCM registration token is not one. A bound at all matters
-// because the value goes straight into a URL path (APNs) and a JSON body.
-const MAX_DEVICE_TOKEN_LENGTH = 4096;
-
-const NATIVE_TRANSPORTS = ['apns', 'fcm'] as const;
-type NativeTransport = (typeof NATIVE_TRANSPORTS)[number];
-
-function isNativeTransport(value: unknown): value is NativeTransport {
-  return NATIVE_TRANSPORTS.includes(value as NativeTransport);
-}
+// A device token is provider-issued and has a known shape, so validate it as one
+// rather than accepting any bounded string. It is untrusted input that reaches
+// the APNs request path (`/3/device/${token}`), and Node's http2 neither
+// validates nor encodes `:path` — an unchecked token is a request-path injection
+// against Apple's gateway carrying our own provider JWT (review of #490).
+//
+// Deliberately a little loose on length: an APNs token is 32 bytes / 64 hex
+// today, but Apple has said it may grow, and rejecting a longer one would break
+// push on a future iOS with no way for an operator to tell why.
+const TOKEN_SHAPES: Record<NativeTransport, RegExp> = {
+  // Hex, and only hex.
+  apns: /^[0-9a-fA-F]{64,200}$/,
+  // An FCM registration token is `<instance-id>:<APA91b…>` — base64url plus the
+  // colon separator and dots seen in older tokens.
+  fcm: /^[A-Za-z0-9_:.-]{64,4096}$/,
+};
 
 router.get('/config', (_req: Request, res: Response) => {
   // `transports` tells a client what this server can ACTUALLY deliver on, which
@@ -35,9 +43,7 @@ router.get('/config', (_req: Request, res: Response) => {
   // no Apple key and reports ['webpush'] — so the iOS app can say so plainly
   // instead of asking for notification permission and then silently never
   // delivering. publicKey stays for Web Push and is meaningless to native.
-  const transports: PushTransport[] = (['webpush', 'apns', 'fcm'] as const).filter((t) =>
-    senderFor(t).isConfigured(),
-  );
+  const transports = PUSH_TRANSPORTS.filter((t) => senderFor(t).isConfigured());
   res.json({ publicKey: getPublicKey(), transports });
 });
 
@@ -50,15 +56,15 @@ router.post('/devices', (req: Request, res: Response) => {
     res.status(400).json({ error: 'token is required' });
     return;
   }
-  if (token.length > MAX_DEVICE_TOKEN_LENGTH) {
-    res.status(400).json({ error: 'token is not a device token' });
-    return;
-  }
   // 'webpush' is deliberately not accepted here. It would file a Web Push row
   // with no keypair, which is undeliverable AND unrepresentable — every later
   // read would skip it, so push would silently never arrive.
   if (!isNativeTransport(transport)) {
     res.status(400).json({ error: `transport must be one of: ${NATIVE_TRANSPORTS.join(', ')}` });
+    return;
+  }
+  if (!TOKEN_SHAPES[transport].test(token)) {
+    res.status(400).json({ error: `token is not a valid ${transport} device token` });
     return;
   }
   // Registering against a server that can't deliver is a real case, not an edge

--- a/server/routes/push.ts
+++ b/server/routes/push.ts
@@ -20,10 +20,12 @@ router.get('/config', (_req: Request, res: Response) => {
 });
 
 router.get('/subscriptions', (req: Request, res: Response) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const subs = listAllForUser(req.user!.id).map((s: any) => ({
+  // Keys are deliberately never projected. `transport` is, so a client can tell
+  // a browser subscription from a phone when listing devices.
+  const subs = listAllForUser(req.user!.id).map((s) => ({
     id: s.id,
     endpoint: s.endpoint,
+    transport: s.transport,
     user_agent: s.user_agent,
     enabled: s.enabled,
     created_at: s.created_at,
@@ -32,6 +34,9 @@ router.get('/subscriptions', (req: Request, res: Response) => {
   res.json({ subscriptions: subs });
 });
 
+// Web Push registration. Native (APNs/FCM) device registration is its own route
+// (#490 phase 4) rather than an overload of this one: it has no `keys`, and its
+// cross-user collision rule is the opposite of this one's.
 router.post('/subscriptions', (req: Request, res: Response) => {
   const { endpoint, keys, userAgent } = req.body || {};
   if (!endpoint || !keys?.p256dh || !keys?.auth) {
@@ -39,6 +44,7 @@ router.post('/subscriptions', (req: Request, res: Response) => {
     return;
   }
   const result = upsertSubscription(req.user!.id, {
+    transport: 'webpush',
     endpoint,
     p256dh: keys.p256dh,
     auth: keys.auth,
@@ -51,9 +57,13 @@ router.post('/subscriptions', (req: Request, res: Response) => {
     });
     return;
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sub = (result as any).sub;
-  res.status(201).json({ subscription: { id: sub.id, endpoint: sub.endpoint } });
+  if (!result.sub) {
+    // The row was written and immediately failed to read back — corrupt enough
+    // that reporting success would be a lie.
+    res.status(500).json({ error: 'subscription could not be stored' });
+    return;
+  }
+  res.status(201).json({ subscription: { id: result.sub.id, endpoint: result.sub.endpoint } });
 });
 
 router.delete('/subscriptions', (req: Request, res: Response) => {

--- a/server/routes/pushDevices.test.ts
+++ b/server/routes/pushDevices.test.ts
@@ -40,6 +40,18 @@ let alice: User;
 let bob: User;
 let pushDb: typeof import('../db/pushSubscriptions.js');
 
+// Real-shaped tokens. The route validates shape now, because an unvalidated
+// token reaches the APNs request path. So a made-up fixture is not merely ugly:
+// it is a token the route correctly refuses, and a test built on one proves
+// nothing about the path a real device takes.
+const apnsToken = (seed: string): string =>
+  seed
+    .padEnd(64, '0')
+    .slice(0, 64)
+    .replace(/[^0-9a-f]/g, 'a');
+const fcmToken = (seed: string): string =>
+  `${seed.replace(/[^A-Za-z0-9_-]/g, '_')}:APA91b${'Ab_-9'.repeat(20)}`;
+
 beforeAll(async () => {
   const { createUser } = await import('../db/users.js');
   pushDb = await import('../db/pushSubscriptions.js');
@@ -74,10 +86,10 @@ describe('POST /api/push/devices', () => {
   it('registers an APNs device', async () => {
     const res = await aliceAgent
       .post('/api/push/devices')
-      .send({ token: 'apns-token-1', transport: 'apns' });
+      .send({ token: apnsToken('a1'), transport: 'apns' });
     expect(res.status).toBe(201);
     expect(res.body.device).toMatchObject({ transport: 'apns' });
-    expect(pushDb.getByEndpoint('apns-token-1')).toMatchObject({
+    expect(pushDb.getByEndpoint(apnsToken('a1'))).toMatchObject({
       user_id: alice.id,
       transport: 'apns',
       p256dh: null,
@@ -88,17 +100,17 @@ describe('POST /api/push/devices', () => {
   it('registers an FCM device', async () => {
     const res = await aliceAgent
       .post('/api/push/devices')
-      .send({ token: 'fcm-token-1', transport: 'fcm' });
+      .send({ token: fcmToken('fcm1'), transport: 'fcm' });
     expect(res.status).toBe(201);
-    expect(pushDb.getByEndpoint('fcm-token-1')?.transport).toBe('fcm');
+    expect(pushDb.getByEndpoint(fcmToken('fcm1'))?.transport).toBe('fcm');
   });
 
   it('records the user agent so a device list can name the phone', async () => {
     await aliceAgent
       .post('/api/push/devices')
       .set('user-agent', 'Lurker/1.0 (iPhone; iOS 26.0)')
-      .send({ token: 'apns-token-ua', transport: 'apns' });
-    expect(pushDb.getByEndpoint('apns-token-ua')?.user_agent).toBe('Lurker/1.0 (iPhone; iOS 26.0)');
+      .send({ token: apnsToken('ua'), transport: 'apns' });
+    expect(pushDb.getByEndpoint(apnsToken('ua'))?.user_agent).toBe('Lurker/1.0 (iPhone; iOS 26.0)');
   });
 
   it('rejects a missing token', async () => {
@@ -111,6 +123,55 @@ describe('POST /api/push/devices', () => {
       .post('/api/push/devices')
       .send({ token: 'x'.repeat(5000), transport: 'apns' });
     expect(res.status).toBe(400);
+  });
+
+  it('rejects a token that is not the shape APNs issues', async () => {
+    // A token was previously anything under 4096 chars, and it goes STRAIGHT
+    // into the APNs request path as `/3/device/${token}`. Node's http2 does not
+    // validate or encode :path — verified: '/3/device/../../1/apps/other?x=1' is
+    // transmitted verbatim — so an authenticated user could steer our requests,
+    // carrying our valid provider JWT, at arbitrary paths on Apple's gateway.
+    for (const bad of [
+      '../../1/apps/other?x=1',
+      'abc/def',
+      'token with spaces',
+      'tok\r\nX-Injected: 1',
+      'zzzz', // right charset-ish, far too short
+      '#{}',
+    ]) {
+      const res = await aliceAgent
+        .post('/api/push/devices')
+        .send({ token: bad, transport: 'apns' });
+      expect(res.status, `should reject APNs token ${JSON.stringify(bad)}`).toBe(400);
+    }
+  });
+
+  it('accepts a real-shaped APNs token', async () => {
+    const real = 'a'.repeat(64);
+    const res = await aliceAgent.post('/api/push/devices').send({ token: real, transport: 'apns' });
+    expect(res.status).toBe(201);
+  });
+
+  it('accepts a longer APNs token, since Apple has room to grow them', async () => {
+    const res = await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: 'b'.repeat(160), transport: 'apns' });
+    expect(res.status).toBe(201);
+  });
+
+  it('rejects an FCM token outside the registration-token charset', async () => {
+    for (const bad of ['../../evil', 'has spaces', 'x'.repeat(10)]) {
+      const res = await aliceAgent.post('/api/push/devices').send({ token: bad, transport: 'fcm' });
+      expect(res.status, `should reject FCM token ${JSON.stringify(bad)}`).toBe(400);
+    }
+  });
+
+  it('accepts a real-shaped FCM registration token', async () => {
+    // FCM tokens look like `<instance-id>:<APA91b…>` — colons, hyphens and
+    // underscores are all legitimate.
+    const real = `cXY-Z_1234567890:APA91b${'A_-x'.repeat(30)}`;
+    const res = await aliceAgent.post('/api/push/devices').send({ token: real, transport: 'fcm' });
+    expect(res.status).toBe(201);
   });
 
   it('rejects an unknown transport', async () => {
@@ -137,16 +198,20 @@ describe('POST /api/push/devices', () => {
     configured.apns = false;
     const res = await aliceAgent
       .post('/api/push/devices')
-      .send({ token: 'apns-token-2', transport: 'apns' });
+      .send({ token: apnsToken('a2'), transport: 'apns' });
     expect(res.status).toBe(503);
     expect(res.body.transport).toBe('apns');
-    expect(pushDb.getByEndpoint('apns-token-2')).toBeNull();
+    expect(pushDb.getByEndpoint(apnsToken('a2'))).toBeNull();
   });
 
   it('is idempotent — re-registering the same token does not duplicate it', async () => {
     // iOS hands back the same token on every launch.
-    await aliceAgent.post('/api/push/devices').send({ token: 'apns-same', transport: 'apns' });
-    await aliceAgent.post('/api/push/devices').send({ token: 'apns-same', transport: 'apns' });
+    await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: apnsToken('5a3e'), transport: 'apns' });
+    await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: apnsToken('5a3e'), transport: 'apns' });
     expect(pushDb.listAllForUser(alice.id)).toHaveLength(1);
   });
 
@@ -154,12 +219,14 @@ describe('POST /api/push/devices', () => {
     // Alice signs out (without deregistering — crash, no network), Bob signs in
     // on the same phone and APNs hands back the same token. Refusing would leave
     // Bob permanently unpushable with no UI anywhere to release it.
-    await aliceAgent.post('/api/push/devices').send({ token: 'apns-phone', transport: 'apns' });
+    await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: apnsToken('9b0e'), transport: 'apns' });
     const res = await bobAgent
       .post('/api/push/devices')
-      .send({ token: 'apns-phone', transport: 'apns' });
+      .send({ token: apnsToken('9b0e'), transport: 'apns' });
     expect(res.status).toBe(201);
-    expect(pushDb.getByEndpoint('apns-phone')?.user_id).toBe(bob.id);
+    expect(pushDb.getByEndpoint(apnsToken('9b0e'))?.user_id).toBe(bob.id);
     expect(pushDb.listAllForUser(alice.id)).toHaveLength(0);
   });
 
@@ -181,20 +248,22 @@ describe('POST /api/push/devices', () => {
 
 describe('DELETE /api/push/devices', () => {
   it('deregisters on sign-out', async () => {
-    await aliceAgent.post('/api/push/devices').send({ token: 'apns-bye', transport: 'apns' });
-    const res = await aliceAgent.delete('/api/push/devices').send({ token: 'apns-bye' });
+    await aliceAgent.post('/api/push/devices').send({ token: apnsToken('bbe'), transport: 'apns' });
+    const res = await aliceAgent.delete('/api/push/devices').send({ token: apnsToken('bbe') });
     expect(res.status).toBe(200);
-    expect(pushDb.getByEndpoint('apns-bye')).toBeNull();
+    expect(pushDb.getByEndpoint(apnsToken('bbe'))).toBeNull();
   });
 
   it('cannot deregister another user device', async () => {
-    await aliceAgent.post('/api/push/devices').send({ token: 'apns-alice', transport: 'apns' });
-    const res = await bobAgent.delete('/api/push/devices').send({ token: 'apns-alice' });
+    await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: apnsToken('a11ce'), transport: 'apns' });
+    const res = await bobAgent.delete('/api/push/devices').send({ token: apnsToken('a11ce') });
     // Reports ok — there is nothing of Bob's by that token — but Alice's device
     // survives. A 404 here would confirm the token exists to someone who
     // shouldn't know.
     expect(res.status).toBe(200);
-    expect(pushDb.getByEndpoint('apns-alice')?.user_id).toBe(alice.id);
+    expect(pushDb.getByEndpoint(apnsToken('a11ce'))?.user_id).toBe(alice.id);
   });
 
   it('rejects a missing token', async () => {
@@ -233,7 +302,9 @@ describe('GET /api/push/config', () => {
 
 describe('GET /api/push/subscriptions', () => {
   it('lists a phone and a browser together, without leaking keys', async () => {
-    await aliceAgent.post('/api/push/devices').send({ token: 'apns-list', transport: 'apns' });
+    await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: apnsToken('115d'), transport: 'apns' });
     await aliceAgent
       .post('/api/push/subscriptions')
       .send({ endpoint: 'https://push.test/list', keys: { p256dh: 'k', auth: 'a' } });

--- a/server/routes/pushDevices.test.ts
+++ b/server/routes/pushDevices.test.ts
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Native device registration routes (#490 phase 4).
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import type { Express } from 'express';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  createAnonAgent,
+} from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+
+const ctx = setupTestDb('routes-push-devices');
+
+// Credentials are the thing under test in half of these, so the sender registry
+// is stubbed rather than the env poked — what matters here is the route's
+// behavior on either answer.
+const configured: Record<string, boolean> = { webpush: true, apns: true, fcm: true };
+
+vi.mock('../services/push/index.js', () => ({
+  senderFor: (transport: string) => ({
+    transport,
+    isConfigured: () => configured[transport],
+    configHint: () => 'hint',
+    send: async () => {},
+    classify: () => 'strike',
+    describe: () => '',
+  }),
+  warnUnconfiguredOnce: () => {},
+}));
+
+let app: Express;
+let aliceAgent: LurkerTestAgent;
+let bobAgent: LurkerTestAgent;
+let alice: User;
+let bob: User;
+let pushDb: typeof import('../db/pushSubscriptions.js');
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  pushDb = await import('../db/pushSubscriptions.js');
+  const router = (await import('./push.js')).default;
+
+  alice = createUser('devices-alice');
+  bob = createUser('devices-bob');
+  app = createTestApp({ '/api/push': router });
+  aliceAgent = await createAuthedAgent(app, alice.id);
+  bobAgent = await createAuthedAgent(app, bob.id);
+});
+
+beforeEach(() => {
+  configured.webpush = true;
+  configured.apns = true;
+  configured.fcm = true;
+  for (const u of [alice, bob]) {
+    for (const s of pushDb.listAllForUser(u.id)) pushDb.deleteById(s.id, u.id);
+  }
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('POST /api/push/devices', () => {
+  it('requires auth', async () => {
+    const res = await createAnonAgent(app)
+      .post('/api/push/devices')
+      .send({ token: 't', transport: 'apns' });
+    expect(res.status).toBe(401);
+  });
+
+  it('registers an APNs device', async () => {
+    const res = await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: 'apns-token-1', transport: 'apns' });
+    expect(res.status).toBe(201);
+    expect(res.body.device).toMatchObject({ transport: 'apns' });
+    expect(pushDb.getByEndpoint('apns-token-1')).toMatchObject({
+      user_id: alice.id,
+      transport: 'apns',
+      p256dh: null,
+      auth: null,
+    });
+  });
+
+  it('registers an FCM device', async () => {
+    const res = await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: 'fcm-token-1', transport: 'fcm' });
+    expect(res.status).toBe(201);
+    expect(pushDb.getByEndpoint('fcm-token-1')?.transport).toBe('fcm');
+  });
+
+  it('records the user agent so a device list can name the phone', async () => {
+    await aliceAgent
+      .post('/api/push/devices')
+      .set('user-agent', 'Lurker/1.0 (iPhone; iOS 26.0)')
+      .send({ token: 'apns-token-ua', transport: 'apns' });
+    expect(pushDb.getByEndpoint('apns-token-ua')?.user_agent).toBe('Lurker/1.0 (iPhone; iOS 26.0)');
+  });
+
+  it('rejects a missing token', async () => {
+    const res = await aliceAgent.post('/api/push/devices').send({ transport: 'apns' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an absurdly long token', async () => {
+    const res = await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: 'x'.repeat(5000), transport: 'apns' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an unknown transport', async () => {
+    const res = await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: 't', transport: 'carrier-pigeon' });
+    expect(res.status).toBe(400);
+  });
+
+  it('refuses to register webpush here', async () => {
+    // It would file a Web Push row with no keypair — undeliverable, and skipped
+    // by every later read, so push would silently never arrive.
+    const res = await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: 'https://push.test/x', transport: 'webpush' });
+    expect(res.status).toBe(400);
+    expect(pushDb.getByEndpoint('https://push.test/x')).toBeNull();
+  });
+
+  it('says so when the server cannot deliver on that transport', async () => {
+    // The self-hosted case: a user running the App Store build against their own
+    // server, which holds no Apple key. Accepting the row would mean a phone
+    // that thinks it has push and never gets any.
+    configured.apns = false;
+    const res = await aliceAgent
+      .post('/api/push/devices')
+      .send({ token: 'apns-token-2', transport: 'apns' });
+    expect(res.status).toBe(503);
+    expect(res.body.transport).toBe('apns');
+    expect(pushDb.getByEndpoint('apns-token-2')).toBeNull();
+  });
+
+  it('is idempotent — re-registering the same token does not duplicate it', async () => {
+    // iOS hands back the same token on every launch.
+    await aliceAgent.post('/api/push/devices').send({ token: 'apns-same', transport: 'apns' });
+    await aliceAgent.post('/api/push/devices').send({ token: 'apns-same', transport: 'apns' });
+    expect(pushDb.listAllForUser(alice.id)).toHaveLength(1);
+  });
+
+  it('rebinds a token to the user who signed in on that phone', async () => {
+    // Alice signs out (without deregistering — crash, no network), Bob signs in
+    // on the same phone and APNs hands back the same token. Refusing would leave
+    // Bob permanently unpushable with no UI anywhere to release it.
+    await aliceAgent.post('/api/push/devices').send({ token: 'apns-phone', transport: 'apns' });
+    const res = await bobAgent
+      .post('/api/push/devices')
+      .send({ token: 'apns-phone', transport: 'apns' });
+    expect(res.status).toBe(201);
+    expect(pushDb.getByEndpoint('apns-phone')?.user_id).toBe(bob.id);
+    expect(pushDb.listAllForUser(alice.id)).toHaveLength(0);
+  });
+
+  it('still refuses to hand a webpush endpoint to another user', async () => {
+    // The opposite rule, on the route that owns it — two users share a browser
+    // concurrently, so rebinding there would steal notifications.
+    await aliceAgent.post('/api/push/subscriptions').send({
+      endpoint: 'https://push.test/shared',
+      keys: { p256dh: 'k', auth: 'a' },
+    });
+    const res = await bobAgent.post('/api/push/subscriptions').send({
+      endpoint: 'https://push.test/shared',
+      keys: { p256dh: 'k2', auth: 'a2' },
+    });
+    expect(res.status).toBe(409);
+    expect(pushDb.getByEndpoint('https://push.test/shared')?.user_id).toBe(alice.id);
+  });
+});
+
+describe('DELETE /api/push/devices', () => {
+  it('deregisters on sign-out', async () => {
+    await aliceAgent.post('/api/push/devices').send({ token: 'apns-bye', transport: 'apns' });
+    const res = await aliceAgent.delete('/api/push/devices').send({ token: 'apns-bye' });
+    expect(res.status).toBe(200);
+    expect(pushDb.getByEndpoint('apns-bye')).toBeNull();
+  });
+
+  it('cannot deregister another user device', async () => {
+    await aliceAgent.post('/api/push/devices').send({ token: 'apns-alice', transport: 'apns' });
+    const res = await bobAgent.delete('/api/push/devices').send({ token: 'apns-alice' });
+    // Reports ok — there is nothing of Bob's by that token — but Alice's device
+    // survives. A 404 here would confirm the token exists to someone who
+    // shouldn't know.
+    expect(res.status).toBe(200);
+    expect(pushDb.getByEndpoint('apns-alice')?.user_id).toBe(alice.id);
+  });
+
+  it('rejects a missing token', async () => {
+    const res = await aliceAgent.delete('/api/push/devices').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('is idempotent', async () => {
+    const res = await aliceAgent.delete('/api/push/devices').send({ token: 'never-existed' });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /api/push/config', () => {
+  it('advertises which transports this server can actually deliver on', async () => {
+    const res = await aliceAgent.get('/api/push/config');
+    expect(res.status).toBe(200);
+    expect(res.body.transports).toEqual(['webpush', 'apns', 'fcm']);
+  });
+
+  it('reports webpush only on a server with no native credentials', async () => {
+    // What a self-hosted server looks like — and what lets the iOS app say
+    // "this server does not support push" instead of asking for notification
+    // permission and then silently never delivering.
+    configured.apns = false;
+    configured.fcm = false;
+    const res = await aliceAgent.get('/api/push/config');
+    expect(res.body.transports).toEqual(['webpush']);
+  });
+
+  it('still carries the VAPID key for Web Push', async () => {
+    const res = await aliceAgent.get('/api/push/config');
+    expect(typeof res.body.publicKey).toBe('string');
+  });
+});
+
+describe('GET /api/push/subscriptions', () => {
+  it('lists a phone and a browser together, without leaking keys', async () => {
+    await aliceAgent.post('/api/push/devices').send({ token: 'apns-list', transport: 'apns' });
+    await aliceAgent
+      .post('/api/push/subscriptions')
+      .send({ endpoint: 'https://push.test/list', keys: { p256dh: 'k', auth: 'a' } });
+
+    const res = await aliceAgent.get('/api/push/subscriptions');
+    expect(res.status).toBe(200);
+    expect(res.body.subscriptions).toHaveLength(2);
+    expect(res.body.subscriptions.map((s: { transport: string }) => s.transport).sort()).toEqual([
+      'apns',
+      'webpush',
+    ]);
+    for (const sub of res.body.subscriptions) {
+      expect(sub.p256dh).toBeUndefined();
+      expect(sub.auth).toBeUndefined();
+    }
+  });
+});

--- a/server/server.ts
+++ b/server/server.ts
@@ -13,6 +13,7 @@ import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { backfillEncryptColumns } from './db/secretBackfill.js';
+import { assertPushCredentials } from './services/push/credentials.js';
 import { resolveSessionSecret } from './utils/sessionSecret.js';
 import { getEdition, isNodeMode } from './utils/edition.js';
 import { startOrchestratorClient, stopOrchestratorClient } from './services/orchestratorClient.js';
@@ -104,6 +105,13 @@ if (isOidentdFileEnabled()) {
   }
   initOidentdFile();
 }
+
+// Parse any native push credentials now, so a misconfiguration is a failed boot
+// with a name attached rather than a silent non-delivery. Unset is normal and
+// passes: a self-hosted server holds no Apple/Google key and uses Web Push.
+// Deliberately loud — at delivery time the same error is swallowed as a failed
+// push and nobody ever sees it (#490).
+assertPushCredentials();
 
 // Wrap any plaintext secret columns at rest now that the DB schema is ready and
 // before IRC connects — network secrets, +k channel keys, and the RPE2E keyring

--- a/server/services/notificationContent.test.ts
+++ b/server/services/notificationContent.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'url';
+import { composeNotification, type PushPayload } from './notificationContent.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SW_PATH = path.resolve(here, '../../vue_client/public/sw.js');
+
+function payload(over: Partial<PushPayload> = {}): PushPayload {
+  return {
+    kind: 'dm',
+    networkId: 7,
+    networkName: 'Libera',
+    target: 'bob',
+    nick: 'bob',
+    text: 'hey there',
+    ...over,
+  };
+}
+
+describe('composeNotification', () => {
+  it('titles a DM with the sender and network', () => {
+    // The target would only repeat the nick, so it's left out.
+    expect(composeNotification(payload())).toEqual({
+      title: 'bob (Libera)',
+      body: 'hey there',
+      tag: '7::bob',
+    });
+  });
+
+  it('titles a channel highlight with the sender and where it happened', () => {
+    expect(composeNotification(payload({ kind: 'highlight', target: '#lurker' }))).toMatchObject({
+      title: 'bob in #lurker',
+      tag: '7::#lurker',
+    });
+  });
+
+  it('titles a notify_always line the same as a highlight', () => {
+    expect(composeNotification(payload({ kind: 'always_notify', target: '#lurker' })).title).toBe(
+      'bob in #lurker',
+    );
+  });
+
+  it('names the identity a friend signed on as when it differs', () => {
+    expect(
+      composeNotification(
+        payload({ kind: 'friend_online', target: 'nostimo', displayName: 'Amiantos', text: null }),
+      ),
+    ).toMatchObject({
+      title: 'Amiantos came online (as nostimo · Libera)',
+      // No text on a presence transition — the title carries it.
+      body: '',
+    });
+  });
+
+  it('omits the nick when a friend signed on under their display name', () => {
+    // Case-insensitively: 'Amiantos' vs 'amiantos' is the same identity, and
+    // saying "Amiantos came online (as amiantos)" would be noise.
+    expect(
+      composeNotification(
+        payload({ kind: 'friend_online', target: 'amiantos', displayName: 'Amiantos' }),
+      ).title,
+    ).toBe('Amiantos came online (Libera)');
+  });
+
+  it('falls back when a nick or display name is missing', () => {
+    expect(composeNotification(payload({ nick: null })).title).toBe('someone (Libera)');
+    // The same fallback on the channel branch, which is a separate expression.
+    expect(
+      composeNotification(payload({ kind: 'highlight', target: '#lurker', nick: null })).title,
+    ).toBe('someone in #lurker');
+    expect(
+      composeNotification(payload({ kind: 'friend_online', displayName: null, target: '' })).title,
+    ).toBe('A friend came online (Libera)');
+  });
+
+  it('tags by buffer so a burst in one channel collapses', () => {
+    const a = composeNotification(payload({ kind: 'highlight', target: '#lurker', text: 'one' }));
+    const b = composeNotification(payload({ kind: 'highlight', target: '#lurker', text: 'two' }));
+    expect(a.tag).toBe(b.tag);
+    // ...but a different buffer on the same network does not collapse into it.
+    expect(composeNotification(payload({ kind: 'highlight', target: '#other' })).tag).not.toBe(
+      a.tag,
+    );
+  });
+});
+
+// The comments in notificationContent.ts and sw.js both claim the two
+// compositions are byte-for-byte twins, and the phase-2 rollout depends on it: a
+// service worker cached before the server started composing falls back to its own
+// copy, so if the two disagree, the same push renders differently depending on
+// how stale the user's worker is — invisible in every other test.
+//
+// So rather than trust the claim, run the real sw.js. It's plain browser JS with
+// no exports, so it loads in a vm context with a stub `self`; its top-level
+// function declarations land on the context's global.
+describe('parity with the service worker fallback', () => {
+  const sandbox: Record<string, unknown> = {
+    self: {
+      addEventListener: () => {},
+      navigator: {},
+      registration: {},
+      clients: {},
+    },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(SW_PATH, 'utf8'), sandbox);
+  const legacyTitle = sandbox.legacyTitle as (data: unknown) => string;
+
+  it('loaded the worker (guards against a silent no-op if sw.js moves)', () => {
+    expect(typeof legacyTitle).toBe('function');
+  });
+
+  const cases: Array<[string, PushPayload]> = [
+    ['dm', payload()],
+    ['dm with no network name', payload({ networkName: '' })],
+    ['dm with no nick', payload({ nick: null })],
+    ['highlight', payload({ kind: 'highlight', target: '#lurker' })],
+    ['always_notify', payload({ kind: 'always_notify', target: '#lurker' })],
+    ['highlight with no target', payload({ kind: 'highlight', target: '' })],
+    // The nick fallback lives in a different expression per branch, so a null
+    // nick has to be paired with EACH kind or one of them drifts untested.
+    ['highlight with no nick', payload({ kind: 'highlight', target: '#lurker', nick: null })],
+    [
+      'always_notify with no nick',
+      payload({ kind: 'always_notify', target: '#lurker', nick: null }),
+    ],
+    [
+      'friend_online under a different nick',
+      payload({ kind: 'friend_online', target: 'nostimo', displayName: 'Amiantos' }),
+    ],
+    [
+      'friend_online under the same nick',
+      payload({ kind: 'friend_online', target: 'amiantos', displayName: 'Amiantos' }),
+    ],
+    [
+      'friend_online with no display name',
+      payload({ kind: 'friend_online', target: 'nostimo', displayName: null }),
+    ],
+    [
+      'friend_online with no network',
+      payload({
+        kind: 'friend_online',
+        target: 'nostimo',
+        displayName: 'Amiantos',
+        networkName: '',
+      }),
+    ],
+  ];
+
+  it.each(cases)('server and worker compose the same title: %s', (_label, p) => {
+    expect(composeNotification(p).title).toBe(legacyTitle(p));
+  });
+});

--- a/server/services/notificationContent.ts
+++ b/server/services/notificationContent.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// What a push notification actually SAYS (#490).
+//
+// This used to live in vue_client/public/sw.js, which was fine while Web Push
+// was the only transport: the payload could stay semantic (nick, target, text)
+// and the service worker turned it into a title and a body. APNs and FCM have no
+// service worker — they want a composed alert on the wire — so the copy has to be
+// written here instead.
+//
+// Note this is composition, not decision. Whether to push at all is maybePush's
+// job in wsHub and is genuinely transport-neutral; this is the part that wasn't,
+// because it wasn't on the server at all.
+//
+// The strings below are a deliberate byte-for-byte port of the service worker's,
+// so the move is invisible to anyone already running Lurker. sw.js keeps its copy
+// for now and prefers these when present — an old cached worker must not break
+// when the server starts sending them. Once every client has cycled, the worker's
+// copy is dead code and goes.
+
+export type PushPayloadKind = 'dm' | 'highlight' | 'always_notify' | 'friend_online';
+
+/**
+ * The semantic push payload wsHub hands to pushService. Deliberately typed (it
+ * was `unknown`, which was only tenable while every consumer just re-stringified
+ * it): a native transport has to READ these fields to build an alert, so a field
+ * quietly dropped here is a notification that renders wrong on a device with
+ * nothing else failing.
+ */
+export interface PushPayload {
+  kind: PushPayloadKind;
+  networkId: number;
+  networkName: string;
+  target: string;
+  nick?: string | null;
+  text?: string | null;
+  time?: string;
+  messageId?: number | null;
+  /** friend_online only. */
+  displayName?: string | null;
+  /** Unread-highlight total for the app icon; absent when it can't have changed. */
+  badge?: number;
+}
+
+export interface NotificationContent {
+  title: string;
+  body: string;
+  /**
+   * Collapse key: later notifications for the same buffer replace earlier ones
+   * rather than stacking. Maps to the Notification API's `tag` on Web Push,
+   * `aps.thread-id` on APNs, and `android.collapse_key`/`tag` on FCM.
+   */
+  tag: string;
+}
+
+// "Amiantos came online (as nostimo · Libera)". The nick (target) is shown only
+// when it differs from the display name — for a friend watched under several
+// nicks it says which identity signed on; the network disambiguates a friend
+// watched across networks.
+function friendOnlineTitle(payload: PushPayload): string {
+  const name = payload.displayName || 'A friend';
+  const parts: string[] = [];
+  if (payload.target && String(payload.target).toLowerCase() !== name.toLowerCase()) {
+    parts.push(`as ${payload.target}`);
+  }
+  if (payload.networkName) parts.push(payload.networkName);
+  return `${name} came online${parts.length ? ` (${parts.join(' · ')})` : ''}`;
+}
+
+function title(payload: PushPayload): string {
+  // A DM is already identified by its sender, so the target would just repeat the
+  // nick; a channel highlight needs to say where it happened.
+  if (payload.kind === 'dm') {
+    return `${payload.nick || 'someone'}${payload.networkName ? ' (' + payload.networkName + ')' : ''}`;
+  }
+  if (payload.kind === 'friend_online') return friendOnlineTitle(payload);
+  return `${payload.nick || 'someone'} in ${payload.target || ''}`;
+}
+
+export function composeNotification(payload: PushPayload): NotificationContent {
+  return {
+    title: title(payload),
+    // friend_online carries no text, so its body is empty — the title says it all.
+    body: payload.text || '',
+    tag: `${payload.networkId || 0}::${payload.target || ''}`,
+  };
+}

--- a/server/services/push/apnsSender.ts
+++ b/server/services/push/apnsSender.ts
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// APNs (#490 phase 3).
+//
+// The one place the providers genuinely diverge in plumbing rather than payload:
+// **APNs requires HTTP/2**, and Node's fetch/undici does not speak it. So this
+// talks node:http2 directly rather than going through the fetch-shaped path FCM
+// uses. That asymmetry is the reason APNs and FCM were built together — an
+// abstraction designed around FCM alone would have baked in fetch and had to be
+// unpicked here.
+//
+// No dependency: the provider bearer is an ES256 JWT we sign ourselves (see
+// jwt.ts), and http2 is stdlib. `apns2`/`node-apn` would mostly be buying a
+// connection pool, which the session cache below covers for our fan-out sizes.
+
+import http2 from 'node:http2';
+import crypto from 'node:crypto';
+import type { PushSubscription } from '../../db/pushSubscriptions.js';
+import type { NotificationContent, PushPayload } from '../notificationContent.js';
+import type { FailureClass, PushSender } from './types.js';
+import { apnsCredentials, type ApnsCredentials } from './credentials.js';
+import { signJwt, TokenCache } from './jwt.js';
+
+const PROD_HOST = 'https://api.push.apple.com';
+const SANDBOX_HOST = 'https://api.sandbox.push.apple.com';
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** An APNs rejection, carrying the bits classify() and describe() need. */
+export class ApnsError extends Error {
+  constructor(
+    readonly status: number | null,
+    /** Apple's machine-readable `reason`, e.g. 'Unregistered', 'BadDeviceToken'. */
+    readonly reason: string | null,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApnsError';
+  }
+}
+
+// Apple caps provider-token refresh at once per 20 minutes (more earns
+// TooManyProviderTokenUpdates) and expires them at 60. An hour lifetime with the
+// default 5-minute skew lands comfortably inside both.
+const TOKEN_LIFETIME_SECONDS = 3600;
+
+const providerToken = new TokenCache(async () => {
+  const creds = apnsCredentials();
+  if (!creds) throw new Error('APNs is not configured');
+  const token = signJwt(
+    'ES256',
+    { kid: creds.keyId },
+    { iss: creds.teamId, iat: Math.floor(Date.now() / 1000) },
+    creds.keyPem,
+  );
+  return { token, lifetimeSeconds: TOKEN_LIFETIME_SECONDS };
+});
+
+// One HTTP/2 session, reused. A push fans out to every device at once and APNs
+// multiplexes them over a single connection — opening one per notification would
+// pay a TLS handshake per device and is what Apple explicitly asks providers not
+// to do. Lazily (re)created: a session that errored or was closed by Apple is
+// discarded and the next send opens a fresh one.
+let session: http2.ClientHttp2Session | null = null;
+
+function getSession(host: string): http2.ClientHttp2Session {
+  if (session && !session.closed && !session.destroyed) return session;
+  const next = http2.connect(host);
+  // Without a handler, an async session error (Apple closing an idle connection,
+  // a network drop) is an unhandled 'error' event and takes the process down.
+  next.on('error', () => {
+    if (session === next) session = null;
+  });
+  next.on('close', () => {
+    if (session === next) session = null;
+  });
+  next.unref();
+  session = next;
+  return next;
+}
+
+/** Test-only: drop the cached session and provider token. */
+export function resetApnsState(): void {
+  if (session && !session.destroyed) session.destroy();
+  session = null;
+  providerToken.reset();
+}
+
+/**
+ * The APNs wire format, as pure data.
+ *
+ * Split out from send() so it's testable without a gateway: the `aps` dict is
+ * what decides whether a real phone renders the notification correctly, and it's
+ * the part we cannot check against Apple until there's a signed build. Getting it
+ * checkable here is the difference between "unverified" and "unverifiable".
+ */
+export function buildApnsRequest(
+  sub: PushSubscription,
+  payload: PushPayload,
+  content: NotificationContent,
+  creds: ApnsCredentials,
+  jwt: string,
+): { headers: Record<string, string>; body: string } {
+  return {
+    headers: {
+      ':method': 'POST',
+      ':path': `/3/device/${sub.endpoint}`,
+      authorization: `bearer ${jwt}`,
+      'apns-topic': creds.bundleId,
+      'apns-push-type': 'alert',
+      // 10 is "deliver immediately"; a chat notification is the case this is
+      // for. (5 asks APNs to conserve power, which delays it.)
+      'apns-priority': '10',
+      // Collapses a buffer's notifications on the device — the same role `tag`
+      // plays for the Notification API. Distinct from thread-id, which only
+      // GROUPS them in the notification centre.
+      'apns-collapse-id': collapseId(content.tag),
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      aps: {
+        alert: { title: content.title, body: content.body },
+        // Only stamped when the payload carries one: a friend-online push
+        // deliberately omits it (#451), and sending 0 there would CLEAR the
+        // user's badge rather than leave it alone.
+        ...(typeof payload.badge === 'number' ? { badge: payload.badge } : {}),
+        sound: 'default',
+        'thread-id': content.tag,
+      },
+      // Custom keys live beside `aps`, and are what tap-to-open reads to know
+      // which buffer to jump to.
+      networkId: payload.networkId,
+      target: payload.target,
+      messageId: payload.messageId,
+      kind: payload.kind,
+    }),
+  };
+}
+
+// APNs rejects an apns-collapse-id over 64 BYTES with BadCollapseId. A channel
+// name is UTF-8 and can carry multibyte characters, so measure bytes, not
+// characters, and hash anything too long rather than truncating — a truncated id
+// could collide two buffers whose names share a prefix, silently replacing one
+// buffer's notification with another's.
+function collapseId(tag: string): string {
+  const bytes = Buffer.from(tag, 'utf8');
+  if (bytes.length <= 64) return tag;
+  return crypto.createHash('sha256').update(bytes).digest('base64url').slice(0, 43);
+}
+
+export const apnsSender: PushSender = {
+  transport: 'apns',
+
+  isConfigured(): boolean {
+    return apnsCredentials() !== null;
+  },
+
+  configHint(): string {
+    return 'set LURKER_APNS_KEY, LURKER_APNS_KEY_ID, LURKER_APNS_TEAM_ID and LURKER_APNS_BUNDLE_ID';
+  },
+
+  async send(
+    sub: PushSubscription,
+    payload: PushPayload,
+    content: NotificationContent,
+  ): Promise<void> {
+    const creds = apnsCredentials();
+    if (!creds) throw new Error('APNs is not configured');
+    const jwt = await providerToken.get();
+    const { headers, body } = buildApnsRequest(sub, payload, content, creds, jwt);
+
+    const client = getSession(creds.sandbox ? SANDBOX_HOST : PROD_HOST);
+    await new Promise<void>((resolve, reject) => {
+      const req = client.request(headers);
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        req.close(http2.constants.NGHTTP2_CANCEL);
+        // No status: classify() reads that as transient, which a timeout is.
+        reject(new ApnsError(null, null, 'APNs request timed out'));
+      });
+
+      let status: number | null = null;
+      let responseBody = '';
+      req.on('response', (headers) => {
+        status = Number(headers[':status']) || null;
+      });
+      req.on('data', (chunk: Buffer) => {
+        responseBody += chunk.toString();
+      });
+      req.on('error', (err) => reject(new ApnsError(null, null, err.message)));
+      req.on('end', () => {
+        if (status === 200) {
+          resolve();
+          return;
+        }
+        // Apple returns {"reason":"Unregistered"} — the reason, not the status,
+        // is what distinguishes a dead device from a bad key.
+        let reason: string | null = null;
+        try {
+          reason = (JSON.parse(responseBody) as { reason?: string }).reason ?? null;
+        } catch {
+          /* a non-JSON body just means no reason to read */
+        }
+        reject(new ApnsError(status, reason, `APNs rejected: ${status} ${reason ?? responseBody}`));
+      });
+      req.end(body);
+    });
+  },
+
+  classify(err: unknown): FailureClass {
+    const e = err as Partial<ApnsError>;
+    const reason = e?.reason ?? null;
+    const status = e?.status ?? null;
+
+    // The device is gone: uninstalled, or the token was never ours to use.
+    // BadDeviceToken also covers the classic environment mix-up — a sandbox
+    // token sent to production — which no amount of retrying fixes.
+    if (reason === 'Unregistered' || reason === 'BadDeviceToken') return 'permanent';
+    if (reason === 'DeviceTokenNotForTopic') return 'permanent';
+    if (status === 410) return 'permanent';
+
+    // OUR credentials are broken, not this device. Every device fails
+    // identically, so a strike would march the user's whole fleet to disabled
+    // after five pushes and force each to re-register once the key was fixed.
+    // Transient keeps them alive; the operator fixes the key and delivery
+    // resumes on its own.
+    if (
+      reason === 'InvalidProviderToken' ||
+      reason === 'ExpiredProviderToken' ||
+      reason === 'MissingProviderToken' ||
+      status === 403
+    ) {
+      // The cached token may simply have aged out against a clock skew; drop it
+      // so the next attempt mints a fresh one rather than replaying a dead one.
+      providerToken.reset();
+      return 'transient';
+    }
+
+    // Apple throttling us, Apple being down, or no response at all.
+    if (status == null || status === 429 || status >= 500) return 'transient';
+    return 'strike';
+  },
+
+  describe(err: unknown): string {
+    const e = err as Partial<ApnsError>;
+    return `status=${e?.status ?? '?'} reason=${e?.reason ?? '?'} message=${e?.message || String(err)}`;
+  },
+};

--- a/server/services/push/apnsSender.ts
+++ b/server/services/push/apnsSender.ts
@@ -19,7 +19,7 @@ import crypto from 'node:crypto';
 import type { PushSubscription } from '../../db/pushSubscriptions.js';
 import type { NotificationContent, PushPayload } from '../notificationContent.js';
 import type { FailureClass, PushSender } from './types.js';
-import { apnsCredentials, type ApnsCredentials } from './credentials.js';
+import { configuredApns, type ApnsCredentials } from './credentials.js';
 import { signJwt, TokenCache } from './jwt.js';
 
 const PROD_HOST = 'https://api.push.apple.com';
@@ -45,7 +45,7 @@ export class ApnsError extends Error {
 const TOKEN_LIFETIME_SECONDS = 3600;
 
 const providerToken = new TokenCache(async () => {
-  const creds = apnsCredentials();
+  const creds = configuredApns();
   if (!creds) throw new Error('APNs is not configured');
   const token = signJwt(
     'ES256',
@@ -62,9 +62,16 @@ const providerToken = new TokenCache(async () => {
 // to do. Lazily (re)created: a session that errored or was closed by Apple is
 // discarded and the next send opens a fresh one.
 let session: http2.ClientHttp2Session | null = null;
+let sessionHost: string | null = null;
 
 function getSession(host: string): http2.ClientHttp2Session {
-  if (session && !session.closed && !session.destroyed) return session;
+  // The host is part of the cache key, not just an argument to the first call
+  // that happens to open the session. Ignoring it would hand back a production
+  // session for a sandbox request, where every token is invalid and classify()
+  // reads BadDeviceToken as permanent — silently DELETING every real device
+  // (review of #490).
+  if (session && sessionHost === host && !session.closed && !session.destroyed) return session;
+  if (session && !session.destroyed) session.destroy();
   const next = http2.connect(host);
   // Without a handler, an async session error (Apple closing an idle connection,
   // a network drop) is an unhandled 'error' event and takes the process down.
@@ -76,14 +83,8 @@ function getSession(host: string): http2.ClientHttp2Session {
   });
   next.unref();
   session = next;
+  sessionHost = host;
   return next;
-}
-
-/** Test-only: drop the cached session and provider token. */
-export function resetApnsState(): void {
-  if (session && !session.destroyed) session.destroy();
-  session = null;
-  providerToken.reset();
 }
 
 /**
@@ -104,7 +105,11 @@ export function buildApnsRequest(
   return {
     headers: {
       ':method': 'POST',
-      ':path': `/3/device/${sub.endpoint}`,
+      // Encoded even though the route already validates the token as hex: Node's
+      // http2 neither validates nor encodes `:path`, so this is the last line
+      // between an untrusted string and a request carrying our provider JWT. A
+      // no-op for a real token, which is the point (review of #490).
+      ':path': `/3/device/${encodeURIComponent(sub.endpoint)}`,
       authorization: `bearer ${jwt}`,
       'apns-topic': creds.bundleId,
       'apns-push-type': 'alert',
@@ -148,11 +153,23 @@ function collapseId(tag: string): string {
   return crypto.createHash('sha256').update(bytes).digest('base64url').slice(0, 43);
 }
 
+// Apple rejecting OUR provider token rather than the device. Shared by classify()
+// and onFailure() so the verdict and the reaction can never disagree about which
+// failures are the credential's fault.
+function isProviderTokenRejection(status: number | null, reason: string | null): boolean {
+  return (
+    reason === 'InvalidProviderToken' ||
+    reason === 'ExpiredProviderToken' ||
+    reason === 'MissingProviderToken' ||
+    status === 403
+  );
+}
+
 export const apnsSender: PushSender = {
   transport: 'apns',
 
   isConfigured(): boolean {
-    return apnsCredentials() !== null;
+    return configuredApns() !== null;
   },
 
   configHint(): string {
@@ -164,7 +181,7 @@ export const apnsSender: PushSender = {
     payload: PushPayload,
     content: NotificationContent,
   ): Promise<void> {
-    const creds = apnsCredentials();
+    const creds = configuredApns();
     if (!creds) throw new Error('APNs is not configured');
     const jwt = await providerToken.get();
     const { headers, body } = buildApnsRequest(sub, payload, content, creds, jwt);
@@ -223,21 +240,22 @@ export const apnsSender: PushSender = {
     // after five pushes and force each to re-register once the key was fixed.
     // Transient keeps them alive; the operator fixes the key and delivery
     // resumes on its own.
-    if (
-      reason === 'InvalidProviderToken' ||
-      reason === 'ExpiredProviderToken' ||
-      reason === 'MissingProviderToken' ||
-      status === 403
-    ) {
-      // The cached token may simply have aged out against a clock skew; drop it
-      // so the next attempt mints a fresh one rather than replaying a dead one.
-      providerToken.reset();
-      return 'transient';
-    }
+    if (isProviderTokenRejection(status, reason)) return 'transient';
 
     // Apple throttling us, Apple being down, or no response at all.
     if (status == null || status === 429 || status >= 500) return 'transient';
     return 'strike';
+  },
+
+  onFailure(err: unknown): void {
+    const e = err as Partial<ApnsError>;
+    // The cached token may simply have aged out against a clock skew, so drop it
+    // and let the next attempt mint a fresh one rather than replay a dead one.
+    //
+    // Deliberately NOT on a bare 429: TooManyProviderTokenUpdates is Apple
+    // telling us we are minting too often, and re-minting in response is the one
+    // move guaranteed to keep it true.
+    if (isProviderTokenRejection(e?.status ?? null, e?.reason ?? null)) providerToken.reset();
   },
 
   describe(err: unknown): string {

--- a/server/services/push/classify.test.ts
+++ b/server/services/push/classify.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Error classification for all three transports (#490 phase 3).
+//
+// This is the fiddly part of adding a provider and the part that needs no real
+// credentials to test: each provider has its own vocabulary for "this device is
+// gone" vs "try again later", and all of it has to land on the same three
+// outcomes pushService acts on. Getting it wrong is quiet and expensive — a
+// permanent misread as a strike keeps a dead device for five more pushes; a
+// transient misread as permanent deletes a live device during a rate limit.
+
+import { describe, it, expect } from 'vitest';
+import { webpushSender } from './webpushSender.js';
+import { apnsSender, ApnsError } from './apnsSender.js';
+import { fcmSender, FcmError } from './fcmSender.js';
+
+describe('webpush classify', () => {
+  const c = (statusCode?: number) => webpushSender.classify({ statusCode });
+
+  it('drops an endpoint the push service says is gone', () => {
+    expect(c(404)).toBe('permanent');
+    expect(c(410)).toBe('permanent');
+  });
+
+  it('keeps the subscription through a bad moment', () => {
+    expect(c(429)).toBe('transient');
+    expect(c(500)).toBe('transient');
+    expect(c(503)).toBe('transient');
+    // No statusCode at all: a DNS/connect blip or timeout, not a dead endpoint.
+    expect(c(undefined)).toBe('transient');
+    expect(webpushSender.classify(new Error('socket hang up'))).toBe('transient');
+  });
+
+  it('strikes a concrete 4xx', () => {
+    expect(c(400)).toBe('strike');
+    expect(c(403)).toBe('strike');
+    expect(c(413)).toBe('strike');
+  });
+});
+
+describe('apns classify', () => {
+  const c = (status: number | null, reason: string | null = null) =>
+    apnsSender.classify(new ApnsError(status, reason, 'test'));
+
+  it('drops a device Apple says is gone', () => {
+    expect(c(410, 'Unregistered')).toBe('permanent');
+    expect(c(400, 'BadDeviceToken')).toBe('permanent');
+    // The classic environment mix-up: a sandbox token sent to production. No
+    // amount of retrying fixes it, and it is not our credentials' fault.
+    expect(c(400, 'DeviceTokenNotForTopic')).toBe('permanent');
+    expect(c(410, null)).toBe('permanent');
+  });
+
+  it('never strikes a device for OUR broken credentials', () => {
+    // The distinction native has and Web Push didn't. A bad .p8 fails
+    // identically for EVERY device, so striking would march the user's whole
+    // fleet to disabled after five pushes and force each to re-register once the
+    // operator fixed the key.
+    expect(c(403, 'InvalidProviderToken')).toBe('transient');
+    expect(c(403, 'ExpiredProviderToken')).toBe('transient');
+    expect(c(403, 'MissingProviderToken')).toBe('transient');
+    expect(c(403, null)).toBe('transient');
+  });
+
+  it('keeps the device through Apple throttling or an outage', () => {
+    expect(c(429, 'TooManyRequests')).toBe('transient');
+    expect(c(500, 'InternalServerError')).toBe('transient');
+    expect(c(503, 'ServiceUnavailable')).toBe('transient');
+    // A timeout: no status, no reason.
+    expect(c(null, null)).toBe('transient');
+  });
+
+  it('strikes a rejection that is specific to this request', () => {
+    expect(c(400, 'PayloadTooLarge')).toBe('strike');
+    expect(c(400, 'BadTopic')).toBe('strike');
+  });
+});
+
+describe('fcm classify', () => {
+  const c = (status: number | null, reason: string | null = null) =>
+    fcmSender.classify(new FcmError(status, reason, 'test'));
+
+  it('drops a device Google says is gone', () => {
+    expect(c(404, 'UNREGISTERED')).toBe('permanent');
+    expect(c(404, 'NOT_FOUND')).toBe('permanent');
+    expect(c(404, null)).toBe('permanent');
+  });
+
+  it('drops a token that can never work for this project', () => {
+    // SENDER_ID_MISMATCH is the token/Firebase-project binding: a token minted
+    // against a different project is not ours to push to, ever. It's also the
+    // exact failure a self-hoster would hit trying to push to our build, which
+    // is why self-hosted native push isn't a goal (see #490).
+    expect(c(403, 'SENDER_ID_MISMATCH')).toBe('permanent');
+    expect(c(400, 'INVALID_ARGUMENT')).toBe('permanent');
+  });
+
+  it('never strikes a device for OUR broken service account', () => {
+    expect(c(401, null)).toBe('transient');
+    expect(c(403, null)).toBe('transient');
+    expect(c(400, 'OAUTH_FAILED')).toBe('transient');
+  });
+
+  it('keeps the device through Google throttling or an outage', () => {
+    expect(c(429, 'QUOTA_EXCEEDED')).toBe('transient');
+    expect(c(500, 'INTERNAL')).toBe('transient');
+    expect(c(503, 'UNAVAILABLE')).toBe('transient');
+    expect(c(null, null)).toBe('transient');
+  });
+
+  it('strikes an otherwise-unexplained 4xx', () => {
+    expect(c(413, 'PAYLOAD_TOO_LARGE')).toBe('strike');
+  });
+});
+
+describe('classification ordering', () => {
+  it('reads SENDER_ID_MISMATCH as permanent even though it arrives as a 403', () => {
+    // 403 is also the "our credentials are broken" signal, so the reason has to
+    // be consulted BEFORE the status. If the status check ran first this would
+    // come back transient and a token that can never work would be retried on
+    // every push, forever.
+    expect(fcmSender.classify(new FcmError(403, 'SENDER_ID_MISMATCH', 't'))).toBe('permanent');
+  });
+
+  it('reads BadDeviceToken as permanent even though it arrives as a 400', () => {
+    expect(apnsSender.classify(new ApnsError(400, 'BadDeviceToken', 't'))).toBe('permanent');
+  });
+});

--- a/server/services/push/classify.test.ts
+++ b/server/services/push/classify.test.ts
@@ -114,6 +114,51 @@ describe('fcm classify', () => {
   });
 });
 
+// classify() must be a pure verdict — deliver() calls it for control flow, and a
+// caller may reasonably call it again to log. The reset that used to live inside
+// it now lives in onFailure(), which fires exactly once per failed delivery.
+describe('classify is pure', () => {
+  it('returns the same verdict however many times it is asked', () => {
+    const err = new ApnsError(403, 'ExpiredProviderToken', 'test');
+    expect(apnsSender.classify(err)).toBe('transient');
+    expect(apnsSender.classify(err)).toBe('transient');
+    expect(apnsSender.classify(err)).toBe('transient');
+  });
+
+  it('exposes the credential reaction as an explicit hook, not a hidden effect', () => {
+    expect(typeof apnsSender.onFailure).toBe('function');
+    expect(typeof fcmSender.onFailure).toBe('function');
+    // Web Push has no cached credential to invalidate, so it declines the hook
+    // rather than implementing an empty one.
+    expect(webpushSender.onFailure).toBeUndefined();
+  });
+});
+
+describe('onFailure', () => {
+  it('does not re-mint on TooManyProviderTokenUpdates', () => {
+    // Apple returns this (429) when we mint too often. Re-minting in response is
+    // the one move guaranteed to keep it true — a self-reinforcing failure that
+    // never recovers. The reaction must be to back off, i.e. do nothing.
+    const err = new ApnsError(429, 'TooManyProviderTokenUpdates', 'test');
+    expect(apnsSender.classify(err)).toBe('transient');
+    expect(() => apnsSender.onFailure?.(err, 'transient')).not.toThrow();
+  });
+
+  it('is safe to call for a failure with no credential involvement', () => {
+    // deliver() calls onFailure for EVERY failure, not just credential ones.
+    for (const err of [
+      new ApnsError(410, 'Unregistered', 'gone'),
+      new ApnsError(null, null, 'timeout'),
+      new ApnsError(500, 'InternalServerError', 'apple down'),
+    ]) {
+      expect(() => apnsSender.onFailure?.(err, apnsSender.classify(err))).not.toThrow();
+    }
+    for (const err of [new FcmError(404, 'UNREGISTERED', 'gone'), new FcmError(null, null, 't')]) {
+      expect(() => fcmSender.onFailure?.(err, fcmSender.classify(err))).not.toThrow();
+    }
+  });
+});
+
 describe('classification ordering', () => {
   it('reads SENDER_ID_MISMATCH as permanent even though it arrives as a 403', () => {
     // 403 is also the "our credentials are broken" signal, so the reason has to

--- a/server/services/push/credentialFailure.test.ts
+++ b/server/services/push/credentialFailure.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Regressions from the #490 review.
+//
+// A misconfigured native credential is an operator mistake, and the two ways it
+// can go wrong pull in opposite directions: it must be LOUD (say what's missing,
+// at boot, before anyone relies on push) and it must be CONTAINED (one broken
+// transport cannot take down the transports that are fine). The original code
+// managed neither — it threw lazily, from inside a filter, on the first push.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'crypto';
+import { apnsSender } from './apnsSender.js';
+import { fcmSender } from './fcmSender.js';
+import { assertPushCredentials, resetCredentialCache } from './credentials.js';
+
+const ec = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+const P8_PEM = ec.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+const ENV = [
+  'LURKER_APNS_KEY',
+  'LURKER_APNS_KEY_ID',
+  'LURKER_APNS_TEAM_ID',
+  'LURKER_APNS_BUNDLE_ID',
+  'LURKER_APNS_SANDBOX',
+  'LURKER_FCM_SERVICE_ACCOUNT',
+];
+
+function clearEnv(): void {
+  for (const k of ENV) delete process.env[k];
+  resetCredentialCache();
+}
+
+beforeEach(clearEnv);
+afterEach(clearEnv);
+
+describe('isConfigured never throws', () => {
+  it('reports false for a partially-configured APNs rather than throwing', () => {
+    // The bug this replaces: apnsCredentials() throws on a partial config and
+    // isConfigured() let it escape. deliver() calls isConfigured() inside a
+    // filter, and a throwing predicate aborts Array.filter outright — so the
+    // user's healthy Web Push browser was never even attempted. One operator
+    // typo silenced push entirely, for every transport.
+    process.env.LURKER_APNS_KEY = P8_PEM;
+    process.env.LURKER_APNS_KEY_ID = 'KEYID';
+    // ...TEAM_ID and BUNDLE_ID missing.
+    resetCredentialCache();
+    expect(() => apnsSender.isConfigured()).not.toThrow();
+    expect(apnsSender.isConfigured()).toBe(false);
+  });
+
+  it('reports false for a malformed APNs key rather than throwing', () => {
+    process.env.LURKER_APNS_KEY = 'not-a-key';
+    process.env.LURKER_APNS_KEY_ID = 'KEYID';
+    process.env.LURKER_APNS_TEAM_ID = 'TEAM';
+    process.env.LURKER_APNS_BUNDLE_ID = 'chat.lurker.app';
+    resetCredentialCache();
+    expect(() => apnsSender.isConfigured()).not.toThrow();
+    expect(apnsSender.isConfigured()).toBe(false);
+  });
+
+  it('reports false for a malformed FCM service account rather than throwing', () => {
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = '{not json';
+    resetCredentialCache();
+    expect(() => fcmSender.isConfigured()).not.toThrow();
+    expect(fcmSender.isConfigured()).toBe(false);
+  });
+
+  it('reports false when nothing is configured at all', () => {
+    expect(apnsSender.isConfigured()).toBe(false);
+    expect(fcmSender.isConfigured()).toBe(false);
+  });
+});
+
+describe('assertPushCredentials', () => {
+  it('passes when nothing is configured — self-hosting is not a misconfiguration', () => {
+    expect(() => assertPushCredentials()).not.toThrow();
+  });
+
+  it('passes on a complete APNs config', () => {
+    process.env.LURKER_APNS_KEY = P8_PEM;
+    process.env.LURKER_APNS_KEY_ID = 'KEYID';
+    process.env.LURKER_APNS_TEAM_ID = 'TEAM';
+    process.env.LURKER_APNS_BUNDLE_ID = 'chat.lurker.app';
+    resetCredentialCache();
+    expect(() => assertPushCredentials()).not.toThrow();
+  });
+
+  it('throws at boot naming the missing APNs pieces', () => {
+    // This is what makes "fails loud at boot" true. Nothing used to call the
+    // credential parsers at boot at all, so the claim in the comments was simply
+    // false: a misconfigured server started clean and failed on the first push,
+    // where the throw was swallowed as a transient failure and never surfaced.
+    process.env.LURKER_APNS_KEY = P8_PEM;
+    process.env.LURKER_APNS_KEY_ID = 'KEYID';
+    resetCredentialCache();
+    expect(() => assertPushCredentials()).toThrow(/LURKER_APNS_TEAM_ID, LURKER_APNS_BUNDLE_ID/);
+  });
+
+  it('throws at boot on a malformed FCM service account', () => {
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = '{not json';
+    resetCredentialCache();
+    expect(() => assertPushCredentials()).toThrow(/LURKER_FCM_SERVICE_ACCOUNT/);
+  });
+});

--- a/server/services/push/credentialFailure.test.ts
+++ b/server/services/push/credentialFailure.test.ts
@@ -78,6 +78,33 @@ describe('assertPushCredentials', () => {
     expect(() => assertPushCredentials()).not.toThrow();
   });
 
+  it('treats EMPTY vars as unconfigured, not as a partial config', () => {
+    // The shape a hosted cell actually boots with. cell-cloud-init.sh renders every var
+    // unconditionally, so a fleet without push keys gets `LURKER_APNS_KEY=` — present but
+    // empty — rather than the var being absent. If empty read as "set", every cell on a
+    // push-less fleet would see a partial config and crash-loop on boot.
+    process.env.LURKER_APNS_KEY = '';
+    process.env.LURKER_APNS_KEY_ID = '';
+    process.env.LURKER_APNS_TEAM_ID = '';
+    process.env.LURKER_APNS_BUNDLE_ID = '';
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = '';
+    resetCredentialCache();
+    expect(() => assertPushCredentials()).not.toThrow();
+    expect(apnsSender.isConfigured()).toBe(false);
+    expect(fcmSender.isConfigured()).toBe(false);
+  });
+
+  it('still catches a partial config when the OTHER vars are empty rather than absent', () => {
+    // The counterpart: one var filled in on a cell whose others render empty is exactly
+    // the typo this is meant to catch, and it must not be mistaken for "unconfigured".
+    process.env.LURKER_APNS_KEY = P8_PEM;
+    process.env.LURKER_APNS_KEY_ID = '';
+    process.env.LURKER_APNS_TEAM_ID = '';
+    process.env.LURKER_APNS_BUNDLE_ID = '';
+    resetCredentialCache();
+    expect(() => assertPushCredentials()).toThrow(/LURKER_APNS_KEY_ID/);
+  });
+
   it('passes on a complete APNs config', () => {
     process.env.LURKER_APNS_KEY = P8_PEM;
     process.env.LURKER_APNS_KEY_ID = 'KEYID';

--- a/server/services/push/credentials.test.ts
+++ b/server/services/push/credentials.test.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import crypto from 'crypto';
+import { apnsCredentials, fcmCredentials, resetCredentialCache } from './credentials.js';
+
+const ec = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+const P8_PEM = ec.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+const APNS_ENV = [
+  'LURKER_APNS_KEY',
+  'LURKER_APNS_KEY_ID',
+  'LURKER_APNS_TEAM_ID',
+  'LURKER_APNS_BUNDLE_ID',
+  'LURKER_APNS_SANDBOX',
+  'LURKER_FCM_SERVICE_ACCOUNT',
+];
+
+function clearEnv(): void {
+  for (const k of APNS_ENV) delete process.env[k];
+  resetCredentialCache();
+}
+
+beforeEach(clearEnv);
+afterEach(clearEnv);
+
+function setApns(over: Record<string, string> = {}): void {
+  process.env.LURKER_APNS_KEY = P8_PEM;
+  process.env.LURKER_APNS_KEY_ID = 'KEYID123';
+  process.env.LURKER_APNS_TEAM_ID = 'TEAM456';
+  process.env.LURKER_APNS_BUNDLE_ID = 'chat.lurker.app';
+  Object.assign(process.env, over);
+  resetCredentialCache();
+}
+
+const serviceAccount = (over: Record<string, unknown> = {}): string =>
+  JSON.stringify({
+    type: 'service_account',
+    project_id: 'lurker-prod',
+    client_email: 'push@lurker-prod.iam.gserviceaccount.com',
+    private_key: '-----BEGIN PRIVATE KEY-----\\nMIIkey\\n-----END PRIVATE KEY-----\\n',
+    ...over,
+  });
+
+describe('apnsCredentials', () => {
+  it('is null when nothing is set — a self-hosted server holds no Apple key', () => {
+    // Unset is normal operation, not an error. Web Push still works.
+    expect(apnsCredentials()).toBeNull();
+  });
+
+  it('reads a raw PEM', () => {
+    setApns();
+    expect(apnsCredentials()).toMatchObject({
+      keyPem: P8_PEM.trim(),
+      keyId: 'KEYID123',
+      teamId: 'TEAM456',
+      bundleId: 'chat.lurker.app',
+      sandbox: false,
+    });
+  });
+
+  it('reads a base64-encoded PEM', () => {
+    // The form an env var can actually carry: `docker run -e` will not preserve
+    // a multi-line PEM.
+    setApns({ LURKER_APNS_KEY: Buffer.from(P8_PEM).toString('base64') });
+    expect(apnsCredentials()?.keyPem).toBe(P8_PEM.trim());
+  });
+
+  it('trims stray whitespace around the ids', () => {
+    setApns({ LURKER_APNS_KEY_ID: '  KEYID123\n' });
+    expect(apnsCredentials()?.keyId).toBe('KEYID123');
+  });
+
+  it('opts into the sandbox gateway explicitly', () => {
+    for (const v of ['1', 'true', 'yes', 'sandbox', 'TRUE']) {
+      setApns({ LURKER_APNS_SANDBOX: v });
+      expect(apnsCredentials()?.sandbox).toBe(true);
+    }
+    for (const v of ['0', 'false', '', 'no']) {
+      setApns({ LURKER_APNS_SANDBOX: v });
+      expect(apnsCredentials()?.sandbox).toBe(false);
+    }
+  });
+
+  it('names the missing piece when only partly configured', () => {
+    // Partially set is a mistake, not a choice. Silently disabling push for
+    // every iOS device would be the wrong read of it.
+    setApns();
+    delete process.env.LURKER_APNS_TEAM_ID;
+    delete process.env.LURKER_APNS_BUNDLE_ID;
+    resetCredentialCache();
+    expect(() => apnsCredentials()).toThrow(/LURKER_APNS_TEAM_ID, LURKER_APNS_BUNDLE_ID/);
+  });
+
+  it('rejects a key that is neither a PEM nor base64 of one', () => {
+    // Fails loud at boot rather than as a mystery 403 on the first push six
+    // hours later.
+    setApns({ LURKER_APNS_KEY: 'not-a-key' });
+    expect(() => apnsCredentials()).toThrow(/LURKER_APNS_KEY/);
+  });
+
+  it('caches, so a later env change is not picked up mid-process', () => {
+    setApns();
+    expect(apnsCredentials()?.keyId).toBe('KEYID123');
+    process.env.LURKER_APNS_KEY_ID = 'CHANGED';
+    expect(apnsCredentials()?.keyId).toBe('KEYID123');
+  });
+});
+
+describe('fcmCredentials', () => {
+  it('is null when unset', () => {
+    expect(fcmCredentials()).toBeNull();
+  });
+
+  it('reads a raw service-account JSON', () => {
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = serviceAccount();
+    resetCredentialCache();
+    expect(fcmCredentials()).toMatchObject({
+      projectId: 'lurker-prod',
+      clientEmail: 'push@lurker-prod.iam.gserviceaccount.com',
+    });
+  });
+
+  it('reads a base64-encoded service-account JSON', () => {
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = Buffer.from(serviceAccount()).toString('base64');
+    resetCredentialCache();
+    expect(fcmCredentials()?.projectId).toBe('lurker-prod');
+  });
+
+  it('unescapes the literal \\n Google ships in private_key', () => {
+    // Google's JSON carries the PEM with escaped newlines, and anything that has
+    // round-tripped through an env var or YAML may too. Hand that to crypto
+    // as-is and it rejects the key as malformed.
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = serviceAccount();
+    resetCredentialCache();
+    const pem = fcmCredentials()!.privateKeyPem;
+    expect(pem).toContain('\n');
+    expect(pem).not.toContain('\\n');
+    expect(pem.startsWith('-----BEGIN PRIVATE KEY-----\n')).toBe(true);
+  });
+
+  it('rejects JSON that is not a service account', () => {
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = JSON.stringify({ hello: 'world' });
+    resetCredentialCache();
+    expect(() => fcmCredentials()).toThrow(/project_id, client_email and private_key/);
+  });
+
+  it('rejects a service account missing only the private key', () => {
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = serviceAccount({ private_key: undefined });
+    resetCredentialCache();
+    expect(() => fcmCredentials()).toThrow(/project_id, client_email and private_key/);
+  });
+
+  it('rejects malformed JSON, quoting the parse error', () => {
+    process.env.LURKER_FCM_SERVICE_ACCOUNT = '{not json';
+    resetCredentialCache();
+    expect(() => fcmCredentials()).toThrow(/LURKER_FCM_SERVICE_ACCOUNT/);
+  });
+});

--- a/server/services/push/credentials.ts
+++ b/server/services/push/credentials.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Native push credentials (#490).
+//
+// These follow the LURKER_SECRET_KEY precedent, not the VAPID one. VAPID's model
+// — auto-generate on first use, store plaintext in app_meta — is wrong here: an
+// APNs .p8 and an FCM service account are issued by Apple and Google, cannot be
+// generated, and are per-APP-BUNDLE rather than per-user. On hosted they're a
+// fleet-wide secret injected by the orchestrator, exactly like LURKER_SECRET_KEY.
+//
+// Unset is NORMAL, not an error: a self-hosted server has no reason to hold the
+// first-party app's signing key, and Web Push still works for it. Set-but-broken
+// is an error, and fails loud at boot rather than as a mystery 403 on the first
+// push six hours later.
+//
+// Why a self-hoster cannot simply supply their own: an APNs key only signs for
+// the bundle ID it was issued to, and an FCM token is scoped to the Firebase
+// project baked into the APK (a mismatch returns MismatchSenderId). So these
+// credentials only ever push to OUR builds. See the #490 discussion.
+
+/**
+ * Accept either base64 or the raw value. Base64 is what an env var can carry
+ * without newline mangling (a PEM is multi-line, and `docker run -e` will not
+ * preserve it); the raw form is what a human pastes into a compose file with a
+ * heredoc. The discriminator is the value's own syntax, so neither is guessed.
+ */
+function decodeMaybeBase64(raw: string, rawPrefix: string, envName: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith(rawPrefix)) return trimmed;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(trimmed, 'base64').toString('utf8');
+  } catch {
+    throw new Error(`${envName} is neither valid base64 nor a value starting with ${rawPrefix}`);
+  }
+  if (!decoded.trim().startsWith(rawPrefix)) {
+    throw new Error(
+      `${envName} must be a value starting with ${rawPrefix}, or that value base64-encoded ` +
+        `(decoded to something starting with ${JSON.stringify(decoded.slice(0, 12))})`,
+    );
+  }
+  return decoded.trim();
+}
+
+export interface ApnsCredentials {
+  /** The .p8 private key, PEM-encoded. */
+  keyPem: string;
+  /** Apple's key identifier for that .p8 (the `kid` claim). */
+  keyId: string;
+  /** The Apple developer team id (the `iss` claim). */
+  teamId: string;
+  /** The app's bundle id — APNs' `apns-topic`. */
+  bundleId: string;
+  /** Sandbox routes to Apple's development gateway; TestFlight/dev builds need it. */
+  sandbox: boolean;
+}
+
+export interface FcmCredentials {
+  projectId: string;
+  clientEmail: string;
+  privateKeyPem: string;
+}
+
+let apnsCache: ApnsCredentials | null | undefined;
+let fcmCache: FcmCredentials | null | undefined;
+
+/** Test-only: forget parsed credentials so a test can re-read a changed env. */
+export function resetCredentialCache(): void {
+  apnsCache = undefined;
+  fcmCache = undefined;
+}
+
+/** Parsed APNs credentials, or null when unconfigured. Throws when misconfigured. */
+export function apnsCredentials(): ApnsCredentials | null {
+  if (apnsCache !== undefined) return apnsCache;
+  const key = process.env.LURKER_APNS_KEY;
+  const keyId = process.env.LURKER_APNS_KEY_ID;
+  const teamId = process.env.LURKER_APNS_TEAM_ID;
+  const bundleId = process.env.LURKER_APNS_BUNDLE_ID;
+  if (!key && !keyId && !teamId && !bundleId) {
+    apnsCache = null;
+    return null;
+  }
+  // Partially set is a mistake, not a choice — say which piece is missing rather
+  // than silently disabling push for every iOS device.
+  const missing = [
+    !key && 'LURKER_APNS_KEY',
+    !keyId && 'LURKER_APNS_KEY_ID',
+    !teamId && 'LURKER_APNS_TEAM_ID',
+    !bundleId && 'LURKER_APNS_BUNDLE_ID',
+  ].filter(Boolean);
+  if (missing.length) {
+    throw new Error(`APNs push is partially configured; missing: ${missing.join(', ')}`);
+  }
+  apnsCache = {
+    keyPem: decodeMaybeBase64(key as string, '-----BEGIN', 'LURKER_APNS_KEY'),
+    keyId: (keyId as string).trim(),
+    teamId: (teamId as string).trim(),
+    bundleId: (bundleId as string).trim(),
+    sandbox: /^(1|true|yes|sandbox)$/i.test(process.env.LURKER_APNS_SANDBOX || ''),
+  };
+  return apnsCache;
+}
+
+/** Parsed FCM credentials, or null when unconfigured. Throws when misconfigured. */
+export function fcmCredentials(): FcmCredentials | null {
+  if (fcmCache !== undefined) return fcmCache;
+  const raw = process.env.LURKER_FCM_SERVICE_ACCOUNT;
+  if (!raw) {
+    fcmCache = null;
+    return null;
+  }
+  const json = decodeMaybeBase64(raw, '{', 'LURKER_FCM_SERVICE_ACCOUNT');
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(json) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(`LURKER_FCM_SERVICE_ACCOUNT is not valid JSON: ${(err as Error).message}`, {
+      cause: err,
+    });
+  }
+  const projectId = parsed.project_id;
+  const clientEmail = parsed.client_email;
+  const privateKey = parsed.private_key;
+  if (
+    typeof projectId !== 'string' ||
+    typeof clientEmail !== 'string' ||
+    typeof privateKey !== 'string'
+  ) {
+    throw new Error(
+      'LURKER_FCM_SERVICE_ACCOUNT must be a Google service-account JSON with ' +
+        'project_id, client_email and private_key',
+    );
+  }
+  fcmCache = {
+    projectId,
+    clientEmail,
+    // Google's JSON carries the PEM with literal \n escapes. Anything that has
+    // round-tripped through an env var or a YAML string may too, so unescape
+    // rather than hand crypto a key it will reject as malformed.
+    privateKeyPem: privateKey.replace(/\\n/g, '\n'),
+  };
+  return fcmCache;
+}

--- a/server/services/push/credentials.ts
+++ b/server/services/push/credentials.ts
@@ -11,8 +11,16 @@
 //
 // Unset is NORMAL, not an error: a self-hosted server has no reason to hold the
 // first-party app's signing key, and Web Push still works for it. Set-but-broken
-// is an error, and fails loud at boot rather than as a mystery 403 on the first
-// push six hours later.
+// IS an error, and the two demands it makes pull in opposite directions:
+//
+//  - Loud. assertPushCredentials() runs at boot (server.ts) and throws, naming
+//    the missing piece. Without it a misconfigured server starts clean and the
+//    error surfaces on the first push, where it is swallowed as a delivery
+//    failure and nobody ever sees it.
+//  - Contained. configuredApns()/configuredFcm() NEVER throw, so one broken
+//    transport can't take down the transports that are fine. deliver() consults
+//    them inside a filter, and a throwing predicate aborts Array.filter outright
+//    — which is how a half-typed APNs config silenced a user's browser too.
 //
 // Why a self-hoster cannot simply supply their own: an APNs key only signs for
 // the bundle ID it was issued to, and an FCM token is scoped to the Firebase
@@ -28,19 +36,16 @@
 function decodeMaybeBase64(raw: string, rawPrefix: string, envName: string): string {
   const trimmed = raw.trim();
   if (trimmed.startsWith(rawPrefix)) return trimmed;
-  let decoded: string;
-  try {
-    decoded = Buffer.from(trimmed, 'base64').toString('utf8');
-  } catch {
-    throw new Error(`${envName} is neither valid base64 nor a value starting with ${rawPrefix}`);
-  }
-  if (!decoded.trim().startsWith(rawPrefix)) {
+  // No try/catch around this: Buffer.from is LENIENT about base64 and never
+  // throws — it returns garbage bytes for garbage input. So the only usable
+  // check is whether the decoded value looks like what we asked for.
+  const decoded = Buffer.from(trimmed, 'base64').toString('utf8').trim();
+  if (!decoded.startsWith(rawPrefix)) {
     throw new Error(
-      `${envName} must be a value starting with ${rawPrefix}, or that value base64-encoded ` +
-        `(decoded to something starting with ${JSON.stringify(decoded.slice(0, 12))})`,
+      `${envName} must be a value starting with ${rawPrefix}, or that value base64-encoded`,
     );
   }
-  return decoded.trim();
+  return decoded;
 }
 
 export interface ApnsCredentials {
@@ -69,6 +74,7 @@ let fcmCache: FcmCredentials | null | undefined;
 export function resetCredentialCache(): void {
   apnsCache = undefined;
   fcmCache = undefined;
+  warnedBroken.clear();
 }
 
 /** Parsed APNs credentials, or null when unconfigured. Throws when misconfigured. */
@@ -142,4 +148,52 @@ export function fcmCredentials(): FcmCredentials | null {
     privateKeyPem: privateKey.replace(/\\n/g, '\n'),
   };
   return fcmCache;
+}
+
+// The non-throwing accessors the delivery path uses. A misconfiguration is
+// reported as "not configured" here rather than raised, because by the time a
+// push is being delivered it is far too late to be useful and the throw would
+// take healthy transports down with it. assertPushCredentials() below is what
+// makes sure an operator hears about it, at boot, when they can act on it.
+//
+// The warn-once is a backstop for the case boot validation can't cover (a cell
+// whose env changed under it, or a caller that skipped the boot check): without
+// it, a misconfigured transport would be silently indistinguishable from an
+// unconfigured one.
+const warnedBroken = new Set<string>();
+
+function configuredOrNull<T>(name: string, read: () => T | null): T | null {
+  try {
+    return read();
+  } catch (err) {
+    if (!warnedBroken.has(name)) {
+      warnedBroken.add(name);
+      console.error(
+        `[push] ${name} push is configured but unusable, so it is disabled: ${(err as Error).message}`,
+      );
+    }
+    return null;
+  }
+}
+
+export function configuredApns(): ApnsCredentials | null {
+  return configuredOrNull('apns', apnsCredentials);
+}
+
+export function configuredFcm(): FcmCredentials | null {
+  return configuredOrNull('fcm', fcmCredentials);
+}
+
+/**
+ * Boot-time validation. Parses every native credential that is set, letting a
+ * misconfiguration throw so the server refuses to start with a name for what's
+ * wrong — the same bargain LURKER_SECRET_KEY makes in secretCrypto, and for the
+ * same reason: a silent downgrade is worse than a failed boot.
+ *
+ * Unset stays unset: a self-hosted server holding no Apple key is the normal
+ * case and must boot cleanly.
+ */
+export function assertPushCredentials(): void {
+  apnsCredentials();
+  fcmCredentials();
 }

--- a/server/services/push/fcmSender.ts
+++ b/server/services/push/fcmSender.ts
@@ -19,7 +19,7 @@
 import type { PushSubscription } from '../../db/pushSubscriptions.js';
 import type { NotificationContent, PushPayload } from '../notificationContent.js';
 import type { FailureClass, PushSender } from './types.js';
-import { fcmCredentials } from './credentials.js';
+import { configuredFcm } from './credentials.js';
 import { signJwt, TokenCache } from './jwt.js';
 
 const OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
@@ -41,7 +41,7 @@ export class FcmError extends Error {
 }
 
 const accessToken = new TokenCache(async () => {
-  const creds = fcmCredentials();
+  const creds = configuredFcm();
   if (!creds) throw new Error('FCM is not configured');
   const now = Math.floor(Date.now() / 1000);
   const assertion = signJwt(
@@ -80,9 +80,10 @@ const accessToken = new TokenCache(async () => {
   return { token: json.access_token, lifetimeSeconds: json.expires_in ?? 3600 };
 });
 
-/** Test-only: drop the cached access token. */
-export function resetFcmState(): void {
-  accessToken.reset();
+// Google rejecting OUR service account rather than the device. Shared by
+// classify() and onFailure() so the verdict and the reaction agree.
+function isCredentialRejection(status: number | null, reason: string | null): boolean {
+  return status === 401 || status === 403 || reason === 'OAUTH_FAILED';
 }
 
 /**
@@ -123,7 +124,7 @@ export const fcmSender: PushSender = {
   transport: 'fcm',
 
   isConfigured(): boolean {
-    return fcmCredentials() !== null;
+    return configuredFcm() !== null;
   },
 
   configHint(): string {
@@ -135,7 +136,7 @@ export const fcmSender: PushSender = {
     payload: PushPayload,
     content: NotificationContent,
   ): Promise<void> {
-    const creds = fcmCredentials();
+    const creds = configuredFcm();
     if (!creds) throw new Error('FCM is not configured');
     const token = await accessToken.get();
 
@@ -181,14 +182,18 @@ export const fcmSender: PushSender = {
     // OUR service account is broken, not this device — same reasoning as APNs'
     // 403: it fails identically for every device, so a strike would disable the
     // whole fleet for an operator's misconfiguration.
-    if (status === 401 || status === 403 || reason === 'OAUTH_FAILED') {
-      accessToken.reset();
-      return 'transient';
-    }
+    if (isCredentialRejection(status, reason)) return 'transient';
 
     // Google throttling us (QUOTA_EXCEEDED/429), or FCM being down.
     if (status == null || status === 429 || status >= 500) return 'transient';
     return 'strike';
+  },
+
+  onFailure(err: unknown): void {
+    // Drop the access token so the next push re-runs the OAuth2 exchange rather
+    // than replaying one Google has already rejected.
+    const e = err as Partial<FcmError>;
+    if (isCredentialRejection(e?.status ?? null, e?.reason ?? null)) accessToken.reset();
   },
 
   describe(err: unknown): string {

--- a/server/services/push/fcmSender.ts
+++ b/server/services/push/fcmSender.ts
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// FCM (#490 phase 3).
+//
+// The mirror image of apnsSender, and the reason the seam is shaped the way it
+// is. Same job, but: HTTP/1.1 so plain fetch works, and OAuth2 rather than a
+// self-signed bearer — we sign an RS256 assertion with the service-account key
+// and trade it with Google for an access token, instead of signing the bearer
+// APNs accepts directly.
+//
+// ⚠ Android is paused (see APP_1.0_SCOPE.md), so nothing here has ever pushed to
+// a real device. Auth, token minting/refresh, request shape and error mapping are
+// all exercised — FCM answers a bogus token with a well-formed UNREGISTERED — but
+// "a phone rendered this correctly" is NOT proven and won't be until Android
+// unpauses. Built now anyway because designing the seam against one provider is a
+// guess about where the variation lives; against two it's a measurement.
+
+import type { PushSubscription } from '../../db/pushSubscriptions.js';
+import type { NotificationContent, PushPayload } from '../notificationContent.js';
+import type { FailureClass, PushSender } from './types.js';
+import { fcmCredentials } from './credentials.js';
+import { signJwt, TokenCache } from './jwt.js';
+
+const OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const FCM_SCOPE = 'https://www.googleapis.com/auth/firebase.messaging';
+const ASSERTION_LIFETIME_SECONDS = 3600;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** An FCM rejection, carrying the bits classify() and describe() need. */
+export class FcmError extends Error {
+  constructor(
+    readonly status: number | null,
+    /** Google's machine-readable error status, e.g. 'UNREGISTERED'. */
+    readonly reason: string | null,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'FcmError';
+  }
+}
+
+const accessToken = new TokenCache(async () => {
+  const creds = fcmCredentials();
+  if (!creds) throw new Error('FCM is not configured');
+  const now = Math.floor(Date.now() / 1000);
+  const assertion = signJwt(
+    'RS256',
+    {},
+    {
+      iss: creds.clientEmail,
+      scope: FCM_SCOPE,
+      aud: OAUTH_TOKEN_URL,
+      iat: now,
+      exp: now + ASSERTION_LIFETIME_SECONDS,
+    },
+    creds.privateKeyPem,
+  );
+  const res = await fetch(OAUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new FcmError(
+      res.status,
+      'OAUTH_FAILED',
+      `FCM token exchange failed: ${text.slice(0, 300)}`,
+    );
+  }
+  const json = JSON.parse(text) as { access_token?: string; expires_in?: number };
+  if (!json.access_token) {
+    throw new FcmError(res.status, 'OAUTH_FAILED', 'FCM token exchange returned no access_token');
+  }
+  return { token: json.access_token, lifetimeSeconds: json.expires_in ?? 3600 };
+});
+
+/** Test-only: drop the cached access token. */
+export function resetFcmState(): void {
+  accessToken.reset();
+}
+
+/**
+ * The FCM v1 message body, as pure data. Split out from send() for the same
+ * reason as buildApnsRequest — and more urgently here, since Android is paused
+ * and this is the only check on the shape until it isn't.
+ */
+export function buildFcmMessage(
+  sub: PushSubscription,
+  payload: PushPayload,
+  content: NotificationContent,
+): Record<string, unknown> {
+  return {
+    message: {
+      token: sub.endpoint,
+      notification: { title: content.title, body: content.body },
+      android: {
+        priority: 'HIGH',
+        // Same role as the Notification API's tag / APNs' thread-id: a later
+        // notification for a buffer replaces the earlier one.
+        collapse_key: content.tag,
+        notification: { tag: content.tag },
+      },
+      // FCM requires every data value to be a string — a number here is rejected
+      // outright, so this is not the place to be clever about types.
+      data: {
+        kind: payload.kind,
+        networkId: String(payload.networkId),
+        target: payload.target,
+        ...(payload.messageId != null ? { messageId: String(payload.messageId) } : {}),
+        ...(typeof payload.badge === 'number' ? { badge: String(payload.badge) } : {}),
+      },
+    },
+  };
+}
+
+export const fcmSender: PushSender = {
+  transport: 'fcm',
+
+  isConfigured(): boolean {
+    return fcmCredentials() !== null;
+  },
+
+  configHint(): string {
+    return 'set LURKER_FCM_SERVICE_ACCOUNT to a Google service-account JSON';
+  },
+
+  async send(
+    sub: PushSubscription,
+    payload: PushPayload,
+    content: NotificationContent,
+  ): Promise<void> {
+    const creds = fcmCredentials();
+    if (!creds) throw new Error('FCM is not configured');
+    const token = await accessToken.get();
+
+    const res = await fetch(
+      `https://fcm.googleapis.com/v1/projects/${creds.projectId}/messages:send`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(buildFcmMessage(sub, payload, content)),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+    );
+    if (res.ok) return;
+    const text = await res.text();
+    let reason: string | null = null;
+    try {
+      reason = (JSON.parse(text) as { error?: { status?: string } }).error?.status ?? null;
+    } catch {
+      /* a non-JSON body just means no reason to read */
+    }
+    throw new FcmError(
+      res.status,
+      reason,
+      `FCM rejected: ${res.status} ${reason ?? text.slice(0, 300)}`,
+    );
+  },
+
+  classify(err: unknown): FailureClass {
+    const e = err as Partial<FcmError>;
+    const reason = e?.reason ?? null;
+    const status = e?.status ?? null;
+
+    // The app was uninstalled or the token was replaced.
+    if (reason === 'UNREGISTERED' || reason === 'NOT_FOUND') return 'permanent';
+    // A token that isn't a token — or, notably, one minted for a DIFFERENT
+    // Firebase project (MismatchSenderId). Retrying never fixes either.
+    if (reason === 'INVALID_ARGUMENT' || reason === 'SENDER_ID_MISMATCH') return 'permanent';
+    if (status === 404) return 'permanent';
+
+    // OUR service account is broken, not this device — same reasoning as APNs'
+    // 403: it fails identically for every device, so a strike would disable the
+    // whole fleet for an operator's misconfiguration.
+    if (status === 401 || status === 403 || reason === 'OAUTH_FAILED') {
+      accessToken.reset();
+      return 'transient';
+    }
+
+    // Google throttling us (QUOTA_EXCEEDED/429), or FCM being down.
+    if (status == null || status === 429 || status >= 500) return 'transient';
+    return 'strike';
+  },
+
+  describe(err: unknown): string {
+    const e = err as Partial<FcmError>;
+    return `status=${e?.status ?? '?'} reason=${e?.reason ?? '?'} message=${e?.message || String(err)}`;
+  },
+};

--- a/server/services/push/index.ts
+++ b/server/services/push/index.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type { PushTransport } from '../../db/pushSubscriptions.js';
+import type { PushSender } from './types.js';
+import { webpushSender } from './webpushSender.js';
+import { apnsSender } from './apnsSender.js';
+import { fcmSender } from './fcmSender.js';
+
+export type { FailureClass, PushSender } from './types.js';
+
+const SENDERS: Record<PushTransport, PushSender> = {
+  webpush: webpushSender,
+  apns: apnsSender,
+  fcm: fcmSender,
+};
+
+export function senderFor(transport: PushTransport): PushSender {
+  return SENDERS[transport];
+}
+
+// Transports whose credentials are missing are logged once, not once per push:
+// a self-hosted server holds no APNs key and that is normal operation, so the
+// line is a one-time explanation rather than a recurring error.
+const warned = new Set<PushTransport>();
+
+export function warnUnconfiguredOnce(sender: PushSender): void {
+  if (warned.has(sender.transport)) return;
+  warned.add(sender.transport);
+  console.warn(
+    `[push] ${sender.transport} device registered but the transport is not configured — ` +
+      `${sender.configHint()}`,
+  );
+}
+
+/** Test-only: forget which transports have already been warned about. */
+export function resetUnconfiguredWarnings(): void {
+  warned.clear();
+}

--- a/server/services/push/index.ts
+++ b/server/services/push/index.ts
@@ -32,8 +32,3 @@ export function warnUnconfiguredOnce(sender: PushSender): void {
       `${sender.configHint()}`,
   );
 }
-
-/** Test-only: forget which transports have already been warned about. */
-export function resetUnconfiguredWarnings(): void {
-  warned.clear();
-}

--- a/server/services/push/jwt.test.ts
+++ b/server/services/push/jwt.test.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// No real Apple/Google credentials are needed to prove this: a .p8 is just an EC
+// P-256 private key and a service-account key is just an RSA one, so the tests
+// generate their own and VERIFY the signature rather than asserting on shape.
+// That's the difference between "we emitted three dot-separated base64 blobs" and
+// "a provider would accept this".
+
+import { describe, it, expect, vi } from 'vitest';
+import crypto from 'crypto';
+import { signJwt, TokenCache } from './jwt.js';
+
+type MintFn = () => Promise<{ token: string; lifetimeSeconds: number }>;
+
+const ec = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+const rsa = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+
+const pem = (key: crypto.KeyObject): string =>
+  key.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+function decodeSegment(segment: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(segment, 'base64url').toString()) as Record<string, unknown>;
+}
+
+describe('signJwt', () => {
+  it('produces an ES256 token Apple could verify', () => {
+    const token = signJwt(
+      'ES256',
+      { kid: 'KEY123' },
+      { iss: 'TEAM456', iat: 1 },
+      pem(ec.privateKey),
+    );
+    const [h, c, s] = token.split('.');
+    expect(decodeSegment(h)).toEqual({ alg: 'ES256', typ: 'JWT', kid: 'KEY123' });
+    expect(decodeSegment(c)).toEqual({ iss: 'TEAM456', iat: 1 });
+
+    // The actual check: verify with the public half, in the encoding APNs uses.
+    const ok = crypto
+      .createVerify('SHA256')
+      .update(`${h}.${c}`)
+      .verify({ key: ec.publicKey, dsaEncoding: 'ieee-p1363' }, Buffer.from(s, 'base64url'));
+    expect(ok).toBe(true);
+  });
+
+  it('emits the raw 64-byte r||s signature, not DER', () => {
+    // The detail that usually forces a JWT dependency. Node defaults to DER for
+    // EC keys, which is ~70 bytes, variable-length, and rejected by APNs as a
+    // malformed token — a failure that only shows up against the real service.
+    const token = signJwt('ES256', { kid: 'k' }, { iss: 't', iat: 1 }, pem(ec.privateKey));
+    const sig = Buffer.from(token.split('.')[2], 'base64url');
+    expect(sig.length).toBe(64);
+    // DER signatures start with the SEQUENCE tag 0x30. A raw one starting with
+    // 0x30 by chance is possible, so this is a hint, not the assertion above.
+    expect(sig.length).not.toBe(70);
+  });
+
+  it('produces an RS256 token Google could verify', () => {
+    const token = signJwt(
+      'RS256',
+      {},
+      { iss: 'svc@project.iam.gserviceaccount.com', scope: 'scope', aud: 'aud', iat: 1, exp: 2 },
+      pem(rsa.privateKey),
+    );
+    const [h, c, s] = token.split('.');
+    expect(decodeSegment(h)).toEqual({ alg: 'RS256', typ: 'JWT' });
+    const ok = crypto
+      .createVerify('SHA256')
+      .update(`${h}.${c}`)
+      .verify(rsa.publicKey, Buffer.from(s, 'base64url'));
+    expect(ok).toBe(true);
+  });
+
+  it('base64url-encodes, so a token is URL/header safe', () => {
+    // A '+' or '/' in a header value is a wire-level bug that only bites on the
+    // fraction of tokens whose bytes happen to produce one.
+    for (let i = 0; i < 20; i++) {
+      const token = signJwt('ES256', { kid: `k${i}` }, { iss: 't', iat: i }, pem(ec.privateKey));
+      expect(token).not.toMatch(/[+/=]/);
+    }
+  });
+});
+
+describe('TokenCache', () => {
+  it('mints once and reuses until near expiry', async () => {
+    const mint = vi.fn<MintFn>(async () => ({ token: 'tok-1', lifetimeSeconds: 3600 }));
+    const cache = new TokenCache(mint);
+    expect(await cache.get(0)).toBe('tok-1');
+    expect(await cache.get(1000)).toBe('tok-1');
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes early, so a token cannot expire in flight', async () => {
+    let n = 0;
+    const mint = vi.fn<MintFn>(async () => ({ token: `tok-${++n}`, lifetimeSeconds: 3600 }));
+    const cache = new TokenCache(mint, 300);
+    await cache.get(0);
+    // 3600 - 300 skew = usable until t=3300s.
+    expect(await cache.get(3_299_000)).toBe('tok-1');
+    expect(await cache.get(3_300_000)).toBe('tok-2');
+    expect(mint).toHaveBeenCalledTimes(2);
+  });
+
+  it('collapses concurrent mints into one', async () => {
+    // A push fans out to every device at once, so the first push after expiry
+    // would otherwise mint one token per device — which is exactly what APNs
+    // punishes with TooManyProviderTokenUpdates.
+    let resolve!: (v: { token: string; lifetimeSeconds: number }) => void;
+    const mint = vi.fn<MintFn>(
+      () => new Promise<{ token: string; lifetimeSeconds: number }>((r) => (resolve = r)),
+    );
+    const cache = new TokenCache(mint);
+    const all = Promise.all([cache.get(0), cache.get(0), cache.get(0), cache.get(0)]);
+    resolve({ token: 'tok-1', lifetimeSeconds: 3600 });
+    expect(await all).toEqual(['tok-1', 'tok-1', 'tok-1', 'tok-1']);
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after a failed mint instead of caching the failure', async () => {
+    let attempt = 0;
+    const mint = vi.fn<MintFn>(async () => {
+      if (++attempt === 1) throw new Error('network down');
+      return { token: 'tok-ok', lifetimeSeconds: 3600 };
+    });
+    const cache = new TokenCache(mint);
+    await expect(cache.get(0)).rejects.toThrow('network down');
+    // The in-flight promise must be cleared on rejection too, or every later
+    // call would await a promise that already rejected and push would be dead
+    // until restart.
+    expect(await cache.get(0)).toBe('tok-ok');
+  });
+
+  it('re-mints after reset', async () => {
+    let n = 0;
+    const mint = vi.fn<MintFn>(async () => ({ token: `tok-${++n}`, lifetimeSeconds: 3600 }));
+    const cache = new TokenCache(mint);
+    expect(await cache.get(0)).toBe('tok-1');
+    cache.reset();
+    expect(await cache.get(0)).toBe('tok-2');
+  });
+});

--- a/server/services/push/jwt.ts
+++ b/server/services/push/jwt.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// JWT minting for the native push providers (#490).
+//
+// Both APNs and FCM boil down to the same move: hold a long-lived secret, mint a
+// short-lived signed token from it, cache the token, refresh before it expires.
+// Only the algorithm and the claims differ — APNs signs its own bearer with an
+// ES256 .p8 key, FCM signs an RS256 assertion it then trades with Google for an
+// OAuth2 access token.
+//
+// No dependency for this. Node's crypto signs both, and the one detail that
+// usually pushes people to a JWT library — that ES256 wants the raw r||s
+// signature while Node defaults to DER for EC keys — is just
+// `dsaEncoding: 'ieee-p1363'`.
+
+import crypto from 'crypto';
+
+function b64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url');
+}
+
+/**
+ * Sign a JWT. `alg` picks both the header and the signature encoding: ES256 for
+ * an EC P-256 key (APNs), RS256 for an RSA key (FCM service accounts).
+ */
+export function signJwt(
+  alg: 'ES256' | 'RS256',
+  header: Record<string, unknown>,
+  claims: Record<string, unknown>,
+  privateKeyPem: string,
+): string {
+  const encodedHeader = b64url(JSON.stringify({ alg, typ: 'JWT', ...header }));
+  const encodedClaims = b64url(JSON.stringify(claims));
+  const signingInput = `${encodedHeader}.${encodedClaims}`;
+  const signature = crypto.createSign('SHA256').update(signingInput).sign({
+    key: privateKeyPem,
+    // ES256 requires the raw 64-byte r||s pair (RFC 7518). Node emits DER for EC
+    // keys by default, which APNs rejects as a malformed token. Ignored for RSA.
+    dsaEncoding: 'ieee-p1363',
+  });
+  return `${signingInput}.${b64url(signature)}`;
+}
+
+/**
+ * A short-lived token with a refresh-before-expiry cache.
+ *
+ * Both providers punish over-minting — APNs rejects a provider token refreshed
+ * more than once every 20 minutes with TooManyProviderTokenUpdates, and Google
+ * rate-limits the OAuth2 endpoint — so the cache isn't just an optimization.
+ * `mint` is only called when the cached token is missing or close enough to
+ * expiry to be worth replacing.
+ */
+export class TokenCache {
+  private token: string | null = null;
+  private expiresAtMs = 0;
+  private inFlight: Promise<string> | null = null;
+
+  constructor(
+    private readonly mint: () => Promise<{ token: string; lifetimeSeconds: number }>,
+    /** Refresh this long before actual expiry, so a token can't die in flight. */
+    private readonly skewSeconds = 300,
+  ) {}
+
+  async get(nowMs: number = Date.now()): Promise<string> {
+    if (this.token && nowMs < this.expiresAtMs) return this.token;
+    // A push fans out to every device at once, so without this a user with five
+    // phones would mint five tokens concurrently on the first push after expiry —
+    // which is exactly what APNs' TooManyProviderTokenUpdates punishes.
+    if (this.inFlight) return this.inFlight;
+    this.inFlight = (async () => {
+      try {
+        const { token, lifetimeSeconds } = await this.mint();
+        this.token = token;
+        this.expiresAtMs = nowMs + Math.max(0, lifetimeSeconds - this.skewSeconds) * 1000;
+        return token;
+      } finally {
+        this.inFlight = null;
+      }
+    })();
+    return this.inFlight;
+  }
+
+  /** Drop the cached token — e.g. after the provider rejects it as invalid. */
+  reset(): void {
+    this.token = null;
+    this.expiresAtMs = 0;
+  }
+}

--- a/server/services/push/types.ts
+++ b/server/services/push/types.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The transport seam (#490 phase 3).
+//
+// Web Push, APNs and FCM differ in more than payload: each has its own
+// credential model (VAPID keypair / .p8 signing key / service-account JSON), its
+// own wire format, and — the fiddly part — its own vocabulary for "this device is
+// gone" versus "try again later". What they have in common is the shape below,
+// which is the only thing pushService needs to fan out.
+//
+// The seam is deliberately narrow. Everything upstream of it (the maybePush gate
+// chain) is transport-neutral already, and everything downstream is per-provider.
+
+import type { PushSubscription, PushTransport } from '../../db/pushSubscriptions.js';
+import type { NotificationContent, PushPayload } from '../notificationContent.js';
+
+/**
+ * What a failure MEANS for the subscription that produced it. This vocabulary is
+ * the pre-existing Web Push behavior generalized, and pushService applies it
+ * identically to every transport:
+ *
+ * - `permanent` — the provider says this device is gone for good (Web Push
+ *   404/410, APNs 410 Unregistered, FCM 404 UNREGISTERED). Delete the row.
+ * - `transient` — the network or the provider is having a bad moment (429, 5xx,
+ *   a connect blip with no status). The subscription is fine, we just didn't
+ *   deliver. Never counts toward the disable threshold: a short outage during a
+ *   burst would otherwise disable perfectly healthy devices.
+ * - `strike` — the provider rejected THIS subscription specifically with a
+ *   concrete 4xx. Enough consecutive strikes disables it, so a broken endpoint
+ *   stops erroring on every push (#441); any success resets the streak.
+ *
+ * The distinction that matters for native and didn't exist for Web Push: a
+ * CREDENTIAL failure (a bad .p8, an expired service account — APNs 403, FCM
+ * 401/403) must classify as `transient`, never `strike`. It isn't the device's
+ * fault, and it fails identically for every device the fleet owns, so striking
+ * would march the user's entire set of phones to disabled after five pushes and
+ * require each to re-register once the operator fixed the key.
+ */
+export type FailureClass = 'permanent' | 'transient' | 'strike';
+
+export interface PushSender {
+  readonly transport: PushTransport;
+
+  /**
+   * Whether this transport has usable credentials. Unconfigured transports are
+   * skipped rather than attempted — a self-hosted server has no APNs key and
+   * that is normal operation, not an error.
+   */
+  isConfigured(): boolean;
+
+  /** Human-readable reason a transport is unconfigured, for a one-time log. */
+  configHint(): string;
+
+  /** Deliver, or throw. Throwing is what feeds classify(). */
+  send(sub: PushSubscription, payload: PushPayload, content: NotificationContent): Promise<void>;
+
+  classify(err: unknown): FailureClass;
+
+  /** One-line diagnostic for the disable/failure logs. */
+  describe(err: unknown): string;
+}

--- a/server/services/push/types.ts
+++ b/server/services/push/types.ts
@@ -55,7 +55,25 @@ export interface PushSender {
   /** Deliver, or throw. Throwing is what feeds classify(). */
   send(sub: PushSubscription, payload: PushPayload, content: NotificationContent): Promise<void>;
 
+  /**
+   * Read-only verdict on a failure. Pure: callers may classify the same error
+   * more than once (to log it and to act on it), and must get the same answer
+   * with no side effects. Anything a failure should CHANGE belongs in
+   * onFailure() below.
+   */
   classify(err: unknown): FailureClass;
+
+  /**
+   * React to a failure — invalidate a cached credential, drop a poisoned
+   * connection. Called once per failed delivery, after classify(). Optional:
+   * Web Push has nothing to react to.
+   *
+   * Separate from classify() because a predicate that mutates module state is a
+   * trap: the reset was invisible to anyone reading the seam, fired once per
+   * failing device instead of once per failure, and vanished entirely in any
+   * test that stubbed the sender (review of #490).
+   */
+  onFailure?(err: unknown, verdict: FailureClass): void;
 
   /** One-line diagnostic for the disable/failure logs. */
   describe(err: unknown): string;

--- a/server/services/push/webpushSender.ts
+++ b/server/services/push/webpushSender.ts
@@ -20,6 +20,26 @@ interface WebPushErrorish {
   body?: string;
 }
 
+// The body is identical for every one of a user's browsers, but send() is called
+// once per subscription — so serializing inside it would rebuild the same string
+// per device, where the pre-seam code hoisted one `const json` above the fan-out.
+//
+// deliver() composes `content` exactly once per push and hands that same object
+// to every subscription, so keying on its identity collapses the work back to
+// one serialization. A WeakMap because the entry should die with the push, not
+// accumulate one string per notification ever sent.
+const bodyCache = new WeakMap<NotificationContent, string>();
+
+function webpushBody(payload: PushPayload, content: NotificationContent): string {
+  const cached = bodyCache.get(content);
+  if (cached !== undefined) return cached;
+  // Composed fields ride ALONGSIDE the semantic ones so a service worker cached
+  // before #490 phase 2 can still compose locally. See sw.js.
+  const body = JSON.stringify({ ...payload, ...content });
+  bodyCache.set(content, body);
+  return body;
+}
+
 export const webpushSender: PushSender = {
   transport: 'webpush',
 
@@ -39,11 +59,9 @@ export const webpushSender: PushSender = {
       // so p256dh/auth are known present, and states the invariant out loud.
       throw new Error(`webpushSender received a ${sub.transport} subscription`);
     }
-    // Composed fields ride ALONGSIDE the semantic ones so a service worker
-    // cached before #490 phase 2 can still compose locally. See sw.js.
     await webpush.sendNotification(
       { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-      JSON.stringify({ ...payload, ...content }),
+      webpushBody(payload, content),
     );
   },
 

--- a/server/services/push/webpushSender.ts
+++ b/server/services/push/webpushSender.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Web Push over the seam (#490 phase 3).
+//
+// This is the pre-existing behavior moved, not rewritten — the classify() rules
+// below are the exact status checks deliver() used to make inline, and their
+// reasoning is preserved with them. It's also the transport the other two are
+// measured against: it went first through the seam precisely to check the seam
+// could hold something real.
+
+import webpush from 'web-push';
+import type { PushSubscription } from '../../db/pushSubscriptions.js';
+import type { NotificationContent, PushPayload } from '../notificationContent.js';
+import type { FailureClass, PushSender } from './types.js';
+
+interface WebPushErrorish {
+  statusCode?: number;
+  message?: string;
+  body?: string;
+}
+
+export const webpushSender: PushSender = {
+  transport: 'webpush',
+
+  // VAPID keys are generated on demand and stored in app_meta, so Web Push is
+  // always configured — unlike the native transports, it needs nothing from the
+  // operator.
+  isConfigured: () => true,
+  configHint: () => '',
+
+  async send(
+    sub: PushSubscription,
+    payload: PushPayload,
+    content: NotificationContent,
+  ): Promise<void> {
+    if (sub.transport !== 'webpush') {
+      // Unreachable: pushService dispatches by sub.transport. Narrows the union
+      // so p256dh/auth are known present, and states the invariant out loud.
+      throw new Error(`webpushSender received a ${sub.transport} subscription`);
+    }
+    // Composed fields ride ALONGSIDE the semantic ones so a service worker
+    // cached before #490 phase 2 can still compose locally. See sw.js.
+    await webpush.sendNotification(
+      { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+      JSON.stringify({ ...payload, ...content }),
+    );
+  },
+
+  classify(err: unknown): FailureClass {
+    const status = (err as WebPushErrorish)?.statusCode;
+    // The push service says this endpoint is gone for good.
+    if (status === 404 || status === 410) return 'permanent';
+    // Rate limits (429), server errors (5xx), and transport-level errors with no
+    // statusCode (DNS/connect blips, timeouts) are the network or the service
+    // having a bad moment — not a dead subscription. Otherwise a short outage
+    // during a burst of notifications could disable a healthy endpoint.
+    if (status == null || status === 429 || status >= 500) return 'transient';
+    // A concrete 4xx (auth rejects, malformed requests, gone-but-not-404/410).
+    return 'strike';
+  },
+
+  describe(err: unknown): string {
+    const e = err as WebPushErrorish;
+    const body = typeof e?.body === 'string' ? e.body.slice(0, 500) : '';
+    return `status=${e?.statusCode ?? '?'} message=${e?.message || String(err)} body=${body}`;
+  },
+};

--- a/server/services/push/wireFormat.test.ts
+++ b/server/services/push/wireFormat.test.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The APNs/FCM wire formats (#490 phase 3).
+//
+// What this is and isn't: it proves we build the request Apple and Google
+// document. It does NOT prove a phone renders it — there's no signed iOS build
+// yet and Android is paused. That last mile stays open until there's a device to
+// check against, and is called out on #490 rather than papered over.
+//
+// Still worth pinning here, because these dicts are the part with no other
+// feedback loop: a wrong key in `aps` doesn't fail a typecheck, doesn't fail a
+// request, and shows up as a notification that silently renders wrong.
+
+import { describe, it, expect } from 'vitest';
+import { buildApnsRequest } from './apnsSender.js';
+import { buildFcmMessage } from './fcmSender.js';
+import type { ApnsCredentials } from './credentials.js';
+import type { PushSubscription } from '../../db/pushSubscriptions.js';
+import { composeNotification, type PushPayload } from '../notificationContent.js';
+
+const creds: ApnsCredentials = {
+  keyPem: '-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----',
+  keyId: 'KEYID',
+  teamId: 'TEAM',
+  bundleId: 'chat.lurker.app',
+  sandbox: false,
+};
+
+const sub = (endpoint = 'devicetoken123'): PushSubscription => ({
+  id: 1,
+  user_id: 1,
+  endpoint,
+  transport: 'apns',
+  p256dh: null,
+  auth: null,
+  user_agent: null,
+  enabled: true,
+  created_at: '',
+  last_seen_at: '',
+  fail_count: 0,
+});
+
+const payload = (over: Partial<PushPayload> = {}): PushPayload => ({
+  kind: 'dm',
+  networkId: 7,
+  networkName: 'Libera',
+  target: 'bob',
+  nick: 'bob',
+  text: 'hey there',
+  messageId: 42,
+  badge: 3,
+  ...over,
+});
+
+describe('buildApnsRequest', () => {
+  const build = (p: PushPayload = payload(), s = sub()) =>
+    buildApnsRequest(s, p, composeNotification(p), creds, 'JWT');
+
+  it('addresses the device and identifies the app', () => {
+    const { headers } = build();
+    expect(headers[':method']).toBe('POST');
+    expect(headers[':path']).toBe('/3/device/devicetoken123');
+    expect(headers['apns-topic']).toBe('chat.lurker.app');
+    expect(headers.authorization).toBe('bearer JWT');
+  });
+
+  it('asks for immediate delivery of an alert', () => {
+    const { headers } = build();
+    // apns-push-type is REQUIRED since iOS 13 — omit it and Apple rejects the
+    // request outright. Priority 5 would let APNs delay for power, which is
+    // wrong for a chat message.
+    expect(headers['apns-push-type']).toBe('alert');
+    expect(headers['apns-priority']).toBe('10');
+  });
+
+  it('builds an aps dict with the composed copy', () => {
+    const body = JSON.parse(build().body);
+    expect(body.aps).toMatchObject({
+      alert: { title: 'bob (Libera)', body: 'hey there' },
+      badge: 3,
+      sound: 'default',
+      'thread-id': '7::bob',
+    });
+  });
+
+  it('carries the routing keys tap-to-open needs, beside aps not inside it', () => {
+    // Apple reserves `aps`; custom keys go at the top level. Nesting them inside
+    // would silently strand tap-to-open with no buffer to jump to.
+    const body = JSON.parse(build().body);
+    expect(body).toMatchObject({ networkId: 7, target: 'bob', messageId: 42, kind: 'dm' });
+    expect(body.aps.networkId).toBeUndefined();
+  });
+
+  it('omits the badge rather than sending 0 when there is none', () => {
+    // A friend-online push carries no badge on purpose (#451): the total can't
+    // have changed. Sending `badge: 0` would CLEAR the user's app icon instead
+    // of leaving it alone — worse than not sending it.
+    const p = payload({ kind: 'friend_online', displayName: 'Amiantos', badge: undefined });
+    const body = JSON.parse(build(p).body);
+    expect('badge' in body.aps).toBe(false);
+  });
+
+  it('sends a zero badge when the total genuinely is zero', () => {
+    const body = JSON.parse(build(payload({ badge: 0 })).body);
+    expect(body.aps.badge).toBe(0);
+  });
+
+  it('collapses per buffer', () => {
+    expect(build(payload({ text: 'one' })).headers['apns-collapse-id']).toBe(
+      build(payload({ text: 'two' })).headers['apns-collapse-id'],
+    );
+    expect(build(payload({ target: '#other' })).headers['apns-collapse-id']).not.toBe(
+      build().headers['apns-collapse-id'],
+    );
+  });
+
+  it('hashes a collapse id that would exceed Apple 64-byte cap', () => {
+    // APNs rejects a longer one with BadCollapseId. Channel names are UTF-8, so
+    // the cap is on BYTES — a name of 40 emoji is under 64 characters and well
+    // over 64 bytes.
+    const longTarget = '#' + '🎉'.repeat(40);
+    const p = payload({ target: longTarget });
+    const id = build(p).headers['apns-collapse-id'];
+    expect(Buffer.byteLength(id, 'utf8')).toBeLessThanOrEqual(64);
+    // Hashed, not truncated: two buffers sharing a long prefix must not collide
+    // into one collapse id and replace each other's notifications.
+    const other = build(payload({ target: longTarget + 'x' })).headers['apns-collapse-id'];
+    expect(id).not.toBe(other);
+  });
+
+  it('leaves a short collapse id readable', () => {
+    expect(build().headers['apns-collapse-id']).toBe('7::bob');
+  });
+});
+
+describe('buildFcmMessage', () => {
+  const build = (p: PushPayload = payload()) =>
+    buildFcmMessage(sub('fcmtoken456'), p, composeNotification(p)) as {
+      message: Record<string, any>;
+    };
+
+  it('addresses the device and carries the composed copy', () => {
+    const { message } = build();
+    expect(message.token).toBe('fcmtoken456');
+    expect(message.notification).toEqual({ title: 'bob (Libera)', body: 'hey there' });
+  });
+
+  it('asks for high priority and collapses per buffer', () => {
+    const { message } = build();
+    expect(message.android.priority).toBe('HIGH');
+    expect(message.android.collapse_key).toBe('7::bob');
+    expect(message.android.notification.tag).toBe('7::bob');
+  });
+
+  it('stringifies every data value', () => {
+    // FCM rejects a non-string data value outright — and it would arrive as a
+    // 400 INVALID_ARGUMENT, which classify() reads as permanent and DELETES the
+    // device over. A number here costs a real subscription.
+    const { message } = build();
+    for (const [key, value] of Object.entries(message.data)) {
+      expect(typeof value, `data.${key} must be a string`).toBe('string');
+    }
+    expect(message.data).toEqual({
+      kind: 'dm',
+      networkId: '7',
+      target: 'bob',
+      messageId: '42',
+      badge: '3',
+    });
+  });
+
+  it('omits optional data keys rather than sending "undefined"', () => {
+    // String(undefined) is the string "undefined" — which FCM would happily
+    // accept and the client would happily parse into nonsense.
+    const { message } = build(payload({ messageId: null, badge: undefined }));
+    expect('messageId' in message.data).toBe(false);
+    expect('badge' in message.data).toBe(false);
+  });
+});

--- a/server/services/pushContainment.test.ts
+++ b/server/services/pushContainment.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Regression from the #490 review: one broken transport must not take down the
+// others.
+//
+// Unlike pushDispatch.test.ts, this does NOT stub the sender registry — the bug
+// lived in the real senders' isConfigured(), so stubbing it away is exactly how
+// the original tests missed it. Only the credentials' env is controlled here;
+// everything from senderFor() down is real.
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { PushPayload } from './notificationContent.js';
+import type { User } from '../db/users.js';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-containment-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+const sendNotification = vi.fn<(...args: unknown[]) => Promise<{ statusCode: number }>>(
+  async () => ({ statusCode: 201 }),
+);
+vi.mock('web-push', () => ({
+  default: {
+    generateVAPIDKeys: () => ({ publicKey: 'pub', privateKey: 'priv' }),
+    setVapidDetails: () => {},
+    sendNotification: (...args: unknown[]) => sendNotification(...(args as [])),
+  },
+}));
+
+let pushService: typeof import('./pushService.js');
+let pushDb: typeof import('../db/pushSubscriptions.js');
+let resetCredentialCache: typeof import('./push/credentials.js').resetCredentialCache;
+let createUser: typeof import('../db/users.js').createUser;
+let user: User;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  pushDb = await import('../db/pushSubscriptions.js');
+  pushService = await import('./pushService.js');
+  ({ resetCredentialCache } = await import('./push/credentials.js'));
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+beforeEach(() => {
+  sendNotification.mockClear();
+  for (const k of [
+    'LURKER_APNS_KEY',
+    'LURKER_APNS_KEY_ID',
+    'LURKER_APNS_TEAM_ID',
+    'LURKER_APNS_BUNDLE_ID',
+  ]) {
+    delete process.env[k];
+  }
+  resetCredentialCache();
+  user = createUser(`u-${Math.random().toString(36).slice(2)}`);
+});
+
+const payload: PushPayload = {
+  kind: 'dm',
+  networkId: 1,
+  networkName: 'Libera',
+  target: 'bob',
+  nick: 'bob',
+  text: 'hi',
+};
+
+describe('a broken APNs config cannot silence Web Push', () => {
+  it('still delivers to the browser when APNs is half-configured', async () => {
+    // The exact operator mistake: LURKER_APNS_KEY and _KEY_ID set, _TEAM_ID and
+    // _BUNDLE_ID forgotten. Previously apnsCredentials() threw, isConfigured()
+    // let it escape, and the throw aborted deliver()'s filter — so this user's
+    // browser silently got nothing, forever, with the only clue a single
+    // "[push] deliver failed" line.
+    process.env.LURKER_APNS_KEY = '-----BEGIN PRIVATE KEY-----\nnope\n-----END PRIVATE KEY-----';
+    process.env.LURKER_APNS_KEY_ID = 'KEYID';
+    resetCredentialCache();
+
+    pushDb.upsertSubscription(user.id, {
+      transport: 'webpush',
+      endpoint: `https://push.test/${user.id}`,
+      p256dh: 'k',
+      auth: 'a',
+    });
+    pushDb.upsertSubscription(user.id, { transport: 'apns', endpoint: `apnstoken${user.id}` });
+
+    const result = await pushService.deliver(user.id, payload);
+
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    expect(result.sent).toBe(1);
+    // The iOS device is skipped, not deleted and not struck — it starts working
+    // the moment the operator fixes the config, with no re-registration.
+    const apns = pushDb.listAllForUser(user.id).find((s) => s.transport === 'apns');
+    expect(apns).toMatchObject({ enabled: true, fail_count: 0 });
+  });
+
+  it('does not throw out of deliver() when a transport is misconfigured', async () => {
+    process.env.LURKER_APNS_KEY = 'garbage';
+    process.env.LURKER_APNS_KEY_ID = 'KEYID';
+    process.env.LURKER_APNS_TEAM_ID = 'TEAM';
+    process.env.LURKER_APNS_BUNDLE_ID = 'chat.lurker.app';
+    resetCredentialCache();
+    pushDb.upsertSubscription(user.id, { transport: 'apns', endpoint: `apnstoken${user.id}` });
+    await expect(pushService.deliver(user.id, payload)).resolves.toEqual({ sent: 0, dropped: 0 });
+  });
+});

--- a/server/services/pushDispatch.test.ts
+++ b/server/services/pushDispatch.test.ts
@@ -24,9 +24,11 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 // so each test can rewire behavior without re-importing.
 type SendFn = (sub: unknown, payload: unknown, content: unknown) => Promise<void>;
 type ClassifyFn = (err: unknown) => string;
+type OnFailureFn = (err: unknown, verdict: string) => void;
 type Stub = {
   send: Mock<SendFn>;
   classify: Mock<ClassifyFn>;
+  onFailure: Mock<OnFailureFn>;
   configured: boolean;
 };
 const stubs: Record<string, Stub> = {};
@@ -35,6 +37,7 @@ function freshStub(): Stub {
   return {
     send: vi.fn<SendFn>(async () => {}),
     classify: vi.fn<ClassifyFn>(() => 'strike'),
+    onFailure: vi.fn<OnFailureFn>(() => {}),
     configured: true,
   };
 }
@@ -48,6 +51,7 @@ vi.mock('./push/index.js', () => ({
       send: (sub: unknown, payload: unknown, content: unknown) =>
         stubs[transport].send(sub, payload, content),
       classify: (err: unknown) => stubs[transport].classify(err),
+      onFailure: (err: unknown, verdict: string) => stubs[transport].onFailure(err, verdict),
       describe: () => 'described',
     }) as unknown as PushSender,
   warnUnconfiguredOnce: () => {},
@@ -160,6 +164,43 @@ describe('deliver skips unconfigured transports', () => {
     const result = await pushService.deliver(user.id, payload);
     expect(stubs.webpush.send).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ sent: 1, dropped: 0 });
+  });
+});
+
+describe('deliver drives the sender failure hook', () => {
+  it('calls onFailure once per failed delivery, with the verdict', async () => {
+    // The hook exists because the credential reset used to hide inside
+    // classify() — invisible at the seam, fired per failing device, and gone in
+    // any test that stubbed the sender. Which is to say: exactly here.
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    const boom = new Error('nope');
+    stubs.apns.send = vi.fn<SendFn>(async () => {
+      throw boom;
+    });
+    stubs.apns.classify = vi.fn<ClassifyFn>(() => 'transient');
+
+    await pushService.deliver(user.id, payload);
+    expect(stubs.apns.onFailure).toHaveBeenCalledTimes(1);
+    expect(stubs.apns.onFailure).toHaveBeenCalledWith(boom, 'transient');
+  });
+
+  it('does not call onFailure for a delivery that succeeded', async () => {
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    await pushService.deliver(user.id, payload);
+    expect(stubs.apns.onFailure).not.toHaveBeenCalled();
+  });
+
+  it('calls only the failing transport hook', async () => {
+    addWebpush(user.id, `https://push.test/${user.id}`);
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    stubs.apns.send = vi.fn<SendFn>(async () => {
+      throw new Error('nope');
+    });
+    stubs.apns.classify = vi.fn<ClassifyFn>(() => 'transient');
+
+    await pushService.deliver(user.id, payload);
+    expect(stubs.apns.onFailure).toHaveBeenCalledTimes(1);
+    expect(stubs.webpush.onFailure).not.toHaveBeenCalled();
   });
 });
 

--- a/server/services/pushDispatch.test.ts
+++ b/server/services/pushDispatch.test.ts
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// deliver()'s orchestration across transports (#490 phase 3).
+//
+// The senders are mocked at the seam on purpose: what's under test is the part
+// that is NOT per-provider — dispatching each subscription to its own transport,
+// skipping transports with no credentials, and turning a FailureClass into the
+// right thing happening to the row. Each provider's own classify() is covered in
+// push/classify.test.ts, and the wire formats in push/wireFormat.test.ts.
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi, type Mock } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { PushSender } from './push/types.js';
+import type { PushPayload } from './notificationContent.js';
+import type { User } from '../db/users.js';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-dispatch-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+// A controllable stand-in per transport. The factory reads these at call time,
+// so each test can rewire behavior without re-importing.
+type SendFn = (sub: unknown, payload: unknown, content: unknown) => Promise<void>;
+type ClassifyFn = (err: unknown) => string;
+type Stub = {
+  send: Mock<SendFn>;
+  classify: Mock<ClassifyFn>;
+  configured: boolean;
+};
+const stubs: Record<string, Stub> = {};
+
+function freshStub(): Stub {
+  return {
+    send: vi.fn<SendFn>(async () => {}),
+    classify: vi.fn<ClassifyFn>(() => 'strike'),
+    configured: true,
+  };
+}
+
+vi.mock('./push/index.js', () => ({
+  senderFor: (transport: string): PushSender =>
+    ({
+      transport,
+      isConfigured: () => stubs[transport].configured,
+      configHint: () => 'hint',
+      send: (sub: unknown, payload: unknown, content: unknown) =>
+        stubs[transport].send(sub, payload, content),
+      classify: (err: unknown) => stubs[transport].classify(err),
+      describe: () => 'described',
+    }) as unknown as PushSender,
+  warnUnconfiguredOnce: () => {},
+}));
+
+vi.mock('web-push', () => ({
+  default: {
+    generateVAPIDKeys: () => ({ publicKey: 'pub', privateKey: 'priv' }),
+    setVapidDetails: () => {},
+    sendNotification: async () => {},
+  },
+}));
+
+let pushService: typeof import('./pushService.js');
+let pushDb: typeof import('../db/pushSubscriptions.js');
+let createUser: typeof import('../db/users.js').createUser;
+let user: User;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  pushDb = await import('../db/pushSubscriptions.js');
+  pushService = await import('./pushService.js');
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+beforeEach(() => {
+  for (const t of ['webpush', 'apns', 'fcm']) stubs[t] = freshStub();
+  user = createUser(`u-${Math.random().toString(36).slice(2)}`);
+});
+
+const payload: PushPayload = {
+  kind: 'dm',
+  networkId: 1,
+  networkName: 'Libera',
+  target: 'bob',
+  nick: 'bob',
+  text: 'hi',
+};
+
+function addWebpush(u: number, endpoint: string): void {
+  pushDb.upsertSubscription(u, { transport: 'webpush', endpoint, p256dh: 'k', auth: 'a' });
+}
+function addNative(u: number, transport: 'apns' | 'fcm', endpoint: string): void {
+  pushDb.upsertSubscription(u, { transport, endpoint });
+}
+
+describe('deliver dispatches by transport', () => {
+  it('sends each subscription through its own sender', async () => {
+    addWebpush(user.id, `https://push.test/${user.id}`);
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    addNative(user.id, 'fcm', `fcm-${user.id}`);
+
+    const result = await pushService.deliver(user.id, payload);
+
+    expect(stubs.webpush.send).toHaveBeenCalledTimes(1);
+    expect(stubs.apns.send).toHaveBeenCalledTimes(1);
+    expect(stubs.fcm.send).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ sent: 3, dropped: 0 });
+    // The sender receives its OWN subscription — a crossed wire here would hand
+    // an APNs device token to the Web Push sender.
+    expect(stubs.apns.send.mock.calls[0][0]).toMatchObject({ endpoint: `apns-${user.id}` });
+  });
+
+  it('composes once and hands every transport the same content', async () => {
+    addWebpush(user.id, `https://push.test/${user.id}`);
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    await pushService.deliver(user.id, payload);
+    const webContent = stubs.webpush.send.mock.calls[0][2];
+    const apnsContent = stubs.apns.send.mock.calls[0][2];
+    expect(webContent).toEqual({ title: 'bob (Libera)', body: 'hi', tag: '1::bob' });
+    expect(apnsContent).toEqual(webContent);
+  });
+
+  it('one transport failing does not stop the others', async () => {
+    addWebpush(user.id, `https://push.test/${user.id}`);
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    stubs.apns.send = vi.fn<SendFn>(async () => {
+      throw new Error('apns down');
+    });
+    stubs.apns.classify = vi.fn<ClassifyFn>(() => 'transient');
+
+    const result = await pushService.deliver(user.id, payload);
+    expect(stubs.webpush.send).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ sent: 1, dropped: 1 });
+  });
+});
+
+describe('deliver skips unconfigured transports', () => {
+  it('does not attempt a transport with no credentials', async () => {
+    // The self-hosted case: an iOS device registered, but the server holds no
+    // Apple key. Attempting would throw, count as a failure, and eventually
+    // disable a device for a reason that isn't the device's fault.
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    stubs.apns.configured = false;
+
+    const result = await pushService.deliver(user.id, payload);
+    expect(stubs.apns.send).not.toHaveBeenCalled();
+    expect(result).toEqual({ sent: 0, dropped: 0 });
+    // Crucially the subscription SURVIVES — it starts working the moment the
+    // operator configures the key, with no re-registration.
+    expect(pushDb.listEnabledForUser(user.id)).toHaveLength(1);
+  });
+
+  it('still delivers to configured transports alongside an unconfigured one', async () => {
+    addWebpush(user.id, `https://push.test/${user.id}`);
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    stubs.apns.configured = false;
+
+    const result = await pushService.deliver(user.id, payload);
+    expect(stubs.webpush.send).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ sent: 1, dropped: 0 });
+  });
+});
+
+describe('deliver acts on the failure class', () => {
+  async function failWith(verdict: string, transport: 'webpush' | 'apns' = 'apns') {
+    if (transport === 'apns') addNative(user.id, 'apns', `apns-${user.id}`);
+    else addWebpush(user.id, `https://push.test/${user.id}`);
+    stubs[transport].send = vi.fn<SendFn>(async () => {
+      throw new Error('nope');
+    });
+    stubs[transport].classify = vi.fn<ClassifyFn>(() => verdict);
+    return pushService.deliver(user.id, payload);
+  }
+
+  it('permanent deletes the subscription', async () => {
+    const result = await failWith('permanent');
+    expect(result).toEqual({ sent: 0, dropped: 1 });
+    expect(pushDb.listAllForUser(user.id)).toHaveLength(0);
+  });
+
+  it('transient keeps the subscription and does not strike it', async () => {
+    // A rate limit or an outage during a burst must not march a healthy device
+    // toward disabled — and for native, a credential fault fails identically for
+    // EVERY device, so charging it to one would take the whole fleet down.
+    const result = await failWith('transient');
+    expect(result).toEqual({ sent: 0, dropped: 1 });
+    const [sub] = pushDb.listAllForUser(user.id);
+    expect(sub).toMatchObject({ enabled: true, fail_count: 0 });
+  });
+
+  it('strike increments the streak but keeps the subscription enabled', async () => {
+    const result = await failWith('strike');
+    expect(result).toEqual({ sent: 0, dropped: 1 });
+    expect(pushDb.listAllForUser(user.id)[0]).toMatchObject({ enabled: true, fail_count: 1 });
+  });
+
+  it('disables a subscription after enough consecutive strikes', async () => {
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    stubs.apns.send = vi.fn<SendFn>(async () => {
+      throw new Error('nope');
+    });
+    stubs.apns.classify = vi.fn<ClassifyFn>(() => 'strike');
+    for (let i = 0; i < 5; i++) await pushService.deliver(user.id, payload);
+    expect(pushDb.listAllForUser(user.id)[0]).toMatchObject({ enabled: false, fail_count: 5 });
+    // Disabled means it stops being attempted at all (#441).
+    stubs.apns.send.mockClear();
+    await pushService.deliver(user.id, payload);
+    expect(stubs.apns.send).not.toHaveBeenCalled();
+  });
+
+  it('a success resets the failure streak', async () => {
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    stubs.apns.send = vi.fn<SendFn>(async () => {
+      throw new Error('nope');
+    });
+    stubs.apns.classify = vi.fn<ClassifyFn>(() => 'strike');
+    await pushService.deliver(user.id, payload);
+    await pushService.deliver(user.id, payload);
+    expect(pushDb.listAllForUser(user.id)[0].fail_count).toBe(2);
+
+    stubs.apns.send = vi.fn<SendFn>(async () => {});
+    await pushService.deliver(user.id, payload);
+    expect(pushDb.listAllForUser(user.id)[0].fail_count).toBe(0);
+  });
+
+  it('deletes only the failing subscription, not the user other devices', async () => {
+    addWebpush(user.id, `https://push.test/${user.id}`);
+    addNative(user.id, 'apns', `apns-${user.id}`);
+    stubs.apns.send = vi.fn<SendFn>(async () => {
+      throw new Error('gone');
+    });
+    stubs.apns.classify = vi.fn<ClassifyFn>(() => 'permanent');
+
+    await pushService.deliver(user.id, payload);
+    const left = pushDb.listAllForUser(user.id);
+    expect(left).toHaveLength(1);
+    expect(left[0].transport).toBe('webpush');
+  });
+});

--- a/server/services/pushService.test.ts
+++ b/server/services/pushService.test.ts
@@ -34,11 +34,13 @@ beforeAll(async () => {
   alice = createUser('push-alice');
   bob = createUser('push-bob');
   pushDb.upsertSubscription(alice.id, {
+    transport: 'webpush',
     endpoint: 'https://example.test/alice',
     p256dh: 'k',
     auth: 'a',
   });
   pushDb.upsertSubscription(alice.id, {
+    transport: 'webpush',
     endpoint: 'https://example.test/alice2',
     p256dh: 'k',
     auth: 'a',
@@ -60,6 +62,7 @@ describe('hasSubscriptions', () => {
     const u = createUser('push-has-sub');
     expect(pushService.hasSubscriptions(u.id)).toBe(false);
     pushDb.upsertSubscription(u.id, {
+      transport: 'webpush',
       endpoint: 'https://example.test/hassub',
       p256dh: 'k',
       auth: 'a',

--- a/server/services/pushService.test.ts
+++ b/server/services/pushService.test.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import type { User } from '../db/users.js';
+import type { PushPayload } from './notificationContent.js';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-push-service-'));
 process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
@@ -71,19 +72,41 @@ describe('hasSubscriptions', () => {
   });
 });
 
+const samplePayload = (): PushPayload => ({
+  kind: 'dm',
+  networkId: 3,
+  networkName: 'Libera',
+  target: 'bob',
+  nick: 'bob',
+  text: 'hi',
+});
+
 describe('deliver', () => {
   it('returns {sent:0, dropped:0} when the user has no subscriptions', async () => {
-    const result = await pushService.deliver(bob.id, { title: 'hi' });
+    const result = await pushService.deliver(bob.id, samplePayload());
     expect(result).toEqual({ sent: 0, dropped: 0 });
     expect(sendNotification).not.toHaveBeenCalled();
   });
 
   it('fans out to every enabled subscription and counts successes', async () => {
     sendNotification.mockResolvedValue({ statusCode: 201 });
-    const result = await pushService.deliver(alice.id, { title: 'hi' });
+    const result = await pushService.deliver(alice.id, samplePayload());
     expect(sendNotification).toHaveBeenCalledTimes(2);
     expect(result.sent).toBe(2);
     expect(result.dropped).toBe(0);
+  });
+
+  it('sends composed title/body/tag alongside the semantic fields (#490 phase 2)', async () => {
+    sendNotification.mockResolvedValue({ statusCode: 201 });
+    await pushService.deliver(alice.id, samplePayload());
+    const body = JSON.parse(sendNotification.mock.calls[0][1] as string);
+    // Composed here rather than in the service worker, because APNs/FCM have no
+    // worker to compose for them.
+    expect(body).toMatchObject({ title: 'bob (Libera)', body: 'hi', tag: '3::bob' });
+    // ...and the semantic fields still ride along, which is what lets a service
+    // worker cached before this change keep composing locally instead of
+    // rendering an empty notification.
+    expect(body).toMatchObject({ kind: 'dm', nick: 'bob', text: 'hi', networkId: 3 });
   });
 
   // 410/transient/strike rejection paths exist in pushService but vitest's

--- a/server/services/pushService.ts
+++ b/server/services/pushService.ts
@@ -3,6 +3,9 @@
 
 import webpush from 'web-push';
 import type { PushSubscription } from '../db/pushSubscriptions.js';
+
+/** The Web Push arm of the union — the only one this sender can speak. */
+type WebPushSubscription = Extract<PushSubscription, { transport: 'webpush' }>;
 import {
   listEnabledForUser,
   hasEnabledForUser,
@@ -59,7 +62,13 @@ export async function deliver(
   payload: unknown,
 ): Promise<{ sent: number; dropped: number }> {
   ensureVapid();
-  const subs: PushSubscription[] = listEnabledForUser(userId);
+  // Native transports (APNs/FCM) get their own senders behind a transport seam
+  // in #490 phase 3. Until then no route can create a native row, so this
+  // partition can't silently drop a real device — it exists to prove to the type
+  // system that every sub below carries the ECDH keypair sendNotification needs.
+  const subs: WebPushSubscription[] = listEnabledForUser(userId).filter(
+    (s): s is WebPushSubscription => s.transport === 'webpush',
+  );
   if (!subs.length) return { sent: 0, dropped: 0 };
   const json = JSON.stringify(payload);
   const results = await Promise.allSettled(

--- a/server/services/pushService.ts
+++ b/server/services/pushService.ts
@@ -4,9 +4,7 @@
 import webpush from 'web-push';
 import type { PushSubscription } from '../db/pushSubscriptions.js';
 import { composeNotification, type PushPayload } from './notificationContent.js';
-
-/** The Web Push arm of the union — the only one this sender can speak. */
-type WebPushSubscription = Extract<PushSubscription, { transport: 'webpush' }>;
+import { senderFor, warnUnconfiguredOnce } from './push/index.js';
 import {
   listEnabledForUser,
   hasEnabledForUser,
@@ -58,37 +56,55 @@ export function hasSubscriptions(userId: number): boolean {
   return hasEnabledForUser(userId);
 }
 
+// Identify a subscription in a log line without printing the endpoint whole. For
+// Web Push the host is the useful part — it says WHICH push service is failing.
+// A device token has no structure to extract, and is enough of a credential that
+// a log file is the wrong place for it, so it gets a prefix.
+function describeSub(sub: PushSubscription): string {
+  if (sub.transport === 'webpush') {
+    try {
+      return new URL(sub.endpoint).host;
+    } catch {
+      return 'invalid-endpoint';
+    }
+  }
+  return `${sub.endpoint.slice(0, 8)}…`;
+}
+
 export async function deliver(
   userId: number,
   payload: PushPayload,
 ): Promise<{ sent: number; dropped: number }> {
+  // VAPID is Web Push's business, but it's cheap and idempotent, and hoisting it
+  // here keeps the "which transports does this user have?" question out of it.
   ensureVapid();
-  // Native transports (APNs/FCM) get their own senders behind a transport seam
-  // in #490 phase 3. Until then no route can create a native row, so this
-  // partition can't silently drop a real device — it exists to prove to the type
-  // system that every sub below carries the ECDH keypair sendNotification needs.
-  const subs: WebPushSubscription[] = listEnabledForUser(userId).filter(
-    (s): s is WebPushSubscription => s.transport === 'webpush',
-  );
+  const subs = listEnabledForUser(userId);
   if (!subs.length) return { sent: 0, dropped: 0 };
-  // Composed title/body/tag ride ALONGSIDE the semantic fields rather than
-  // replacing them (#490 phase 2). A service worker cached before this change
-  // ignores the new keys and composes the same strings locally, so it can't
-  // break; a current one prefers what's here. Once every client has cycled, the
-  // worker's copy is dead and the semantic fields can stop being sent.
-  const json = JSON.stringify({ ...payload, ...composeNotification(payload) });
+
+  // Composition is transport-neutral and identical for every device, so it
+  // happens once rather than per sub. Each sender renders it its own way — JSON
+  // for a service worker, an `aps` dict for APNs, a `notification` for FCM.
+  const content = composeNotification(payload);
+
+  // Skip transports with no credentials rather than attempting them. A
+  // self-hosted server holds no APNs key and that's normal operation; without
+  // this, every push to a native device would throw and count as a failure,
+  // eventually disabling the device for a reason that isn't the device's fault.
+  const deliverable = subs.filter((sub) => {
+    const sender = senderFor(sub.transport);
+    if (sender.isConfigured()) return true;
+    warnUnconfiguredOnce(sender);
+    return false;
+  });
+  if (!deliverable.length) return { sent: 0, dropped: 0 };
+
   const results = await Promise.allSettled(
-    subs.map((sub) =>
-      webpush.sendNotification(
-        { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-        json,
-      ),
-    ),
+    deliverable.map((sub) => senderFor(sub.transport).send(sub, payload, content)),
   );
   let sent = 0;
   let dropped = 0;
   results.forEach((r, i) => {
-    const sub = subs[i];
+    const sub = deliverable[i];
     if (r.status === 'fulfilled') {
       sent += 1;
       try {
@@ -98,51 +114,38 @@ export async function deliver(
       }
       return;
     }
-    const err = r.reason as webpush.WebPushError & { statusCode?: number };
-    const status = err?.statusCode;
-    if (status === 404 || status === 410) {
-      // The push service says this endpoint is gone for good — drop it.
+    dropped += 1;
+    const sender = senderFor(sub.transport);
+    const verdict = sender.classify(r.reason);
+    if (verdict === 'permanent') {
+      // The provider says this device is gone for good — drop it.
       deleteById(sub.id, sub.user_id);
-      dropped += 1;
       return;
     }
-    let host = '';
-    try {
-      host = new URL(sub.endpoint).host;
-    } catch (_) {
-      /* ignore */
-    }
-    // Don't count a failure toward the disable threshold unless the push
-    // service actually rejected the subscription with an HTTP status. Rate
-    // limits (429), server errors (5xx), and transport-level errors with no
-    // statusCode (DNS/connect blips, timeouts) are the network or the service
-    // having a bad moment — not a dead subscription. The subscription lives and
-    // we simply didn't deliver this time; otherwise a short outage during a
-    // burst of notifications could disable a perfectly healthy endpoint.
-    if (status == null || status === 429 || status >= 500) {
-      dropped += 1;
+    if (verdict === 'transient') {
+      // The network or the provider is having a bad moment (or, for native, OUR
+      // credentials are broken — which fails identically for every device and so
+      // must never be charged to one). The subscription lives; we simply didn't
+      // deliver this time. Silent by design: a rate limit or a 5xx during a
+      // burst would otherwise write a line per device per push.
       return;
     }
-    // A concrete 4xx rejection (auth rejects, malformed requests, gone-but-not-
-    // 404/410) is a strike against this subscription. After enough consecutive
-    // strikes we disable it so it stops erroring on every notification; a
-    // re-subscribe re-enables it. This also bounds the console noise to a
-    // handful of lines per broken endpoint instead of one on every push (#441).
+    // A concrete rejection of THIS subscription. After enough consecutive
+    // strikes, disable it so it stops erroring on every notification; a
+    // re-subscribe re-enables it. Bounds console noise to a handful of lines per
+    // broken endpoint instead of one on every push (#441).
     const failures = recordFailure(sub.id);
-    const body = typeof err?.body === 'string' ? err.body.slice(0, 500) : '';
     if (failures >= MAX_CONSECUTIVE_FAILURES) {
       disableSubscription(sub.id);
-      dropped += 1;
       console.warn(
-        `[push] disabled sub ${sub.id} (${host}) after ${failures} consecutive failures: ` +
-          `status=${status ?? '?'} message=${err?.message || String(err)} body=${body}`,
+        `[push] disabled ${sub.transport} sub ${sub.id} (${describeSub(sub)}) after ` +
+          `${failures} consecutive failures: ${sender.describe(r.reason)}`,
       );
       return;
     }
-    dropped += 1;
     console.warn(
-      `[push] delivery failed for sub ${sub.id} (${host}) [${failures}/${MAX_CONSECUTIVE_FAILURES}]: ` +
-        `status=${status ?? '?'} message=${err?.message || String(err)} body=${body}`,
+      `[push] delivery failed for ${sub.transport} sub ${sub.id} (${describeSub(sub)}) ` +
+        `[${failures}/${MAX_CONSECUTIVE_FAILURES}]: ${sender.describe(r.reason)}`,
     );
   });
   return { sent, dropped };

--- a/server/services/pushService.ts
+++ b/server/services/pushService.ts
@@ -117,6 +117,10 @@ export async function deliver(
     dropped += 1;
     const sender = senderFor(sub.transport);
     const verdict = sender.classify(r.reason);
+    // Anything the failure should CHANGE (invalidate a cached provider token,
+    // drop a poisoned connection) happens here, not inside classify() — which is
+    // a pure verdict and is called for logging as well as for control flow.
+    sender.onFailure?.(r.reason, verdict);
     if (verdict === 'permanent') {
       // The provider says this device is gone for good — drop it.
       deleteById(sub.id, sub.user_id);

--- a/server/services/pushService.ts
+++ b/server/services/pushService.ts
@@ -3,6 +3,7 @@
 
 import webpush from 'web-push';
 import type { PushSubscription } from '../db/pushSubscriptions.js';
+import { composeNotification, type PushPayload } from './notificationContent.js';
 
 /** The Web Push arm of the union — the only one this sender can speak. */
 type WebPushSubscription = Extract<PushSubscription, { transport: 'webpush' }>;
@@ -59,7 +60,7 @@ export function hasSubscriptions(userId: number): boolean {
 
 export async function deliver(
   userId: number,
-  payload: unknown,
+  payload: PushPayload,
 ): Promise<{ sent: number; dropped: number }> {
   ensureVapid();
   // Native transports (APNs/FCM) get their own senders behind a transport seam
@@ -70,7 +71,12 @@ export async function deliver(
     (s): s is WebPushSubscription => s.transport === 'webpush',
   );
   if (!subs.length) return { sent: 0, dropped: 0 };
-  const json = JSON.stringify(payload);
+  // Composed title/body/tag ride ALONGSIDE the semantic fields rather than
+  // replacing them (#490 phase 2). A service worker cached before this change
+  // ignores the new keys and composes the same strings locally, so it can't
+  // break; a current one prefers what's here. Once every client has cycled, the
+  // worker's copy is dead and the semantic fields can stop being sent.
+  const json = JSON.stringify({ ...payload, ...composeNotification(payload) });
   const results = await Promise.allSettled(
     subs.map((sub) =>
       webpush.sendNotification(

--- a/server/services/wsHub.push.test.ts
+++ b/server/services/wsHub.push.test.ts
@@ -1,0 +1,444 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Characterization cover for maybePush's gate chain (#490).
+//
+// The native-push work (APNs + FCM) replaces the delivery transport underneath
+// pushService while leaving the *decision* to push untouched. That decision had
+// no end-to-end test: wsHub.test.ts covers the pieces around it (the badge
+// total, the heartbeat sweep) but nothing drove an IRC event all the way to a
+// push. Every assertion here is a statement about behavior as it exists TODAY —
+// if one fails after the transport refactor, the refactor changed something it
+// was supposed to leave alone.
+//
+// maybePush is a closure inside attachWsHub and can't be called directly.
+// Extracting it first would mean refactoring the very thing this file exists to
+// protect, so instead this drives the real path — ircManager.emit('event') →
+// decorateMessage → maybePush → pushService.deliver — and mocks pushService,
+// which is exactly the seam the transport work replaces. What's asserted is
+// therefore the gate decision and the payload handed across that seam, not how
+// (or whether) a notification ultimately reaches a device.
+//
+// The presence gate needs a genuinely visible client, and visibility is only
+// reachable over a live socket (the `presence` verb), so these tests run a real
+// http server + `ws` client rather than a mock socket.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi, type Mock } from 'vitest';
+import http from 'http';
+import { WebSocket } from 'ws';
+import { setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
+
+const testDb = setupTestDb('wshub-push');
+
+// Reassigned per test; the factory below closes over the binding and reads it at
+// call time, so each test gets a fresh spy. (Same lazy-factory trick as
+// pushService.test.ts's web-push mock — the factory body doesn't run until the
+// first dynamic import inside beforeAll, by which point these are initialized.)
+let deliverMock: Mock<(userId: number, payload: unknown) => Promise<unknown>>;
+let hasSubsMock: Mock<(userId: number) => boolean>;
+
+vi.mock('./pushService.js', () => ({
+  hasSubscriptions: (userId: number) => hasSubsMock(userId),
+  deliver: (userId: number, body: unknown) => deliverMock(userId, body),
+  getPublicKey: () => 'test-vapid-key',
+}));
+
+// A deliver spy that resolves like the real one. Tests that assert "no push
+// after a state change" re-arm with this to drop earlier calls.
+const freshDeliver = (): typeof deliverMock =>
+  vi.fn<(userId: number, payload: unknown) => Promise<unknown>>(async () => ({
+    sent: 1,
+    dropped: 0,
+  }));
+
+// Minutes-since-midnight → 'HH:MM', wrapping across the day boundary so a
+// window built around "now" is still valid near midnight.
+function hhmm(min: number): string {
+  const m = ((min % 1440) + 1440) % 1440;
+  return `${String(Math.floor(m / 60)).padStart(2, '0')}:${String(m % 60).padStart(2, '0')}`;
+}
+
+// Minutes-since-midnight of "now" in UTC, to pair with a pinned system.timezone.
+const nowUtcMinutes = (): number => new Date().getUTCHours() * 60 + new Date().getUTCMinutes();
+
+let ircManager: typeof import('./ircManager.js').default;
+let ignoreRulesService: typeof import('./ignoreRulesService.js').default;
+let setUserSetting: typeof import('../db/settings.js').setUserSetting;
+let deleteUserSetting: typeof import('../db/settings.js').deleteUserSetting;
+let writeAwayMarker: typeof import('../db/userAwayState.js').writeAwayMarker;
+let writeBackMarker: typeof import('../db/userAwayState.js').writeBackMarker;
+let setChannelNotifyAlways: typeof import('../db/channelNotify.js').setChannelNotifyAlways;
+let createSession: typeof import('../db/sessions.js').createSession;
+let insertMessage: typeof import('../db/messages.js').insertMessage;
+
+let server: http.Server;
+let url: string;
+let userId: number;
+let networkId: number;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { createNetwork } = await import('../db/networks.js');
+  ({ setUserSetting, deleteUserSetting } = await import('../db/settings.js'));
+  ({ writeAwayMarker, writeBackMarker } = await import('../db/userAwayState.js'));
+  ({ setChannelNotifyAlways } = await import('../db/channelNotify.js'));
+  ({ createSession } = await import('../db/sessions.js'));
+  ({ insertMessage } = await import('../db/messages.js'));
+  ircManager = (await import('./ircManager.js')).default;
+  ignoreRulesService = (await import('./ignoreRulesService.js')).default;
+  const { attachWsHub } = await import('./wsHub.js');
+
+  userId = createUser('pushuser').id;
+  networkId = createNetwork(userId, {
+    name: 'libera',
+    host: 'irc.example',
+    port: 6697,
+    tls: true,
+    nick: 'pushuser',
+  })!.id;
+
+  server = http.createServer();
+  attachWsHub(server, TEST_SESSION_SECRET);
+  server.listen(0);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test server did not bind synchronously to a TCP port');
+  }
+  server.unref();
+  url = `ws://127.0.0.1:${address.port}/ws`;
+});
+
+afterAll(() => {
+  server.close();
+  testDb.cleanup();
+});
+
+beforeEach(() => {
+  deliverMock = freshDeliver();
+  hasSubsMock = vi.fn<(userId: number) => boolean>(() => true);
+  // Each test starts from registry defaults and no rules/away state. Settings
+  // are cleared via the db layer rather than settingsService, which deletes rows
+  // that equal the default and would make "explicitly set to the default" and
+  // "unset" indistinguishable here.
+  for (const key of [
+    'notifications.dm.enabled',
+    'notifications.highlight.enabled',
+    'notifications.always_notify.enabled',
+    'notifications.friend_online.enabled',
+    'notifications.push.mute_when_away',
+    'notifications.push.quiet_hours.enabled',
+    'notifications.push.quiet_hours.start',
+    'notifications.push.quiet_hours.end',
+    'system.timezone',
+  ]) {
+    deleteUserSetting(userId, key);
+  }
+  for (const rule of ignoreRulesService.list(userId, networkId)) {
+    ignoreRulesService.removeById(userId, networkId, rule.id);
+  }
+  for (const rule of ignoreRulesService.listGlobal(userId)) {
+    ignoreRulesService.removeById(userId, null, rule.id);
+  }
+  writeBackMarker(userId, new Date().toISOString());
+});
+
+// A DM from bob. `notify` is derived, not passed: a non-channel, non-server
+// target on a 'message' makes decorateMessage set dm → notify, which is the
+// cheapest way into the gate chain.
+function emitDm(overrides: Record<string, unknown> = {}): void {
+  ircManager.emit('event', {
+    userId,
+    networkId,
+    type: 'message',
+    target: 'bob',
+    nick: 'bob',
+    userhost: 'bob!bob@example.host',
+    text: 'ping',
+    time: new Date().toISOString(),
+    id: 1,
+    self: false,
+    ...overrides,
+  });
+}
+
+function emitChannel(overrides: Record<string, unknown> = {}): void {
+  emitDm({ target: '#lurker', ...overrides });
+}
+
+// maybePush's deliver() is fire-and-forget (.catch()'d, never awaited), so the
+// emit returns before the mock is called. One macrotask turn is enough to let
+// the promise chain settle.
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+async function pushed(): Promise<boolean> {
+  await settle();
+  return deliverMock.mock.calls.length > 0;
+}
+
+async function payload(): Promise<Record<string, unknown>> {
+  await settle();
+  expect(deliverMock).toHaveBeenCalled();
+  return deliverMock.mock.calls[0][1] as Record<string, unknown>;
+}
+
+// Opens a real socket and reports presence, resolving once the server has
+// acknowledged by... nothing — the presence verb has no reply. Waiting for the
+// snapshot proves the socket is registered, and presence is sent after, so a
+// short settle covers the ordering. Returns a closer the test must call, or the
+// socket leaks into the next test's socketsByUser and silently suppresses push.
+async function connectWithPresence(visible: boolean): Promise<() => Promise<void>> {
+  const { token } = createSession(userId);
+  const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timed out waiting for snapshot')), 5000);
+    ws.on('message', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+  ws.send(JSON.stringify({ type: 'presence', visible }));
+  await settle();
+  return () =>
+    new Promise<void>((resolve) => {
+      ws.on('close', () => resolve());
+      ws.close();
+    });
+}
+
+describe('maybePush gate chain', () => {
+  it('pushes a DM when nothing suppresses it', async () => {
+    emitDm();
+    expect(await pushed()).toBe(true);
+  });
+
+  it('does not push an event that does not notify', async () => {
+    // A plain channel message: not a DM, not matched, no notify_always.
+    emitChannel();
+    expect(await pushed()).toBe(false);
+  });
+
+  it('does not push your own message', async () => {
+    emitDm({ self: true });
+    expect(await pushed()).toBe(false);
+  });
+
+  it('does not push a CTCP line even in a notify_always channel', async () => {
+    setChannelNotifyAlways(userId, networkId, '#lurker', true);
+    try {
+      emitChannel({ type: 'ctcp' });
+      expect(await pushed()).toBe(false);
+    } finally {
+      setChannelNotifyAlways(userId, networkId, '#lurker', false);
+    }
+  });
+
+  it('does not push when a client is visible', async () => {
+    const close = await connectWithPresence(true);
+    try {
+      emitDm();
+      expect(await pushed()).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+
+  it('pushes when a client is connected but not visible', async () => {
+    // The distinction that matters on mobile: an open socket is not presence.
+    // A backgrounded app holds its socket and must still receive push.
+    const close = await connectWithPresence(false);
+    try {
+      emitDm();
+      expect(await pushed()).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it('does not push when the user has no subscriptions', async () => {
+    hasSubsMock = vi.fn<(userId: number) => boolean>(() => false);
+    emitDm();
+    expect(await pushed()).toBe(false);
+  });
+
+  it('does not push a sender an ignore rule hides', async () => {
+    ignoreRulesService.add(userId, networkId, {
+      mask: 'bob!*@*',
+      channels: null,
+      pattern: null,
+      patternKind: 'substr',
+      levels: ['ALL'],
+      isExcept: false,
+      expiresAt: null,
+    });
+    emitDm();
+    expect(await pushed()).toBe(false);
+  });
+
+  it('does not push when a NONOTIFY rule matches', async () => {
+    ignoreRulesService.add(userId, networkId, {
+      mask: 'bob!*@*',
+      channels: null,
+      pattern: null,
+      patternKind: 'substr',
+      levels: ['NONOTIFY'],
+      isExcept: false,
+      expiresAt: null,
+    });
+    emitDm();
+    expect(await pushed()).toBe(false);
+  });
+
+  it('DOES push when only a NOHIGHLIGHT rule matches', async () => {
+    // Deliberate (#359): NOHIGHLIGHT means "don't light it up", not "don't tell
+    // me". Only NONOTIFY freezes push. If this flips, the two levels have been
+    // conflated.
+    ignoreRulesService.add(userId, networkId, {
+      mask: 'bob!*@*',
+      channels: null,
+      pattern: null,
+      patternKind: 'substr',
+      levels: ['NOHIGHLIGHT'],
+      isExcept: false,
+      expiresAt: null,
+    });
+    emitDm();
+    expect(await pushed()).toBe(true);
+  });
+
+  it('does not push a DM when the DM toggle is off', async () => {
+    setUserSetting(userId, 'notifications.dm.enabled', false);
+    emitDm();
+    expect(await pushed()).toBe(false);
+  });
+
+  it('does not push a highlight when the highlight toggle is off', async () => {
+    setUserSetting(userId, 'notifications.highlight.enabled', false);
+    emitChannel({ matched: true });
+    expect(await pushed()).toBe(false);
+  });
+
+  it('gates a matched DM on the DM toggle, not the highlight toggle', async () => {
+    // Kind priority: dm > matched > always_notify. A DM that also matched a rule
+    // delivers as one 'dm' notification, so the highlight toggle must not
+    // silence it and the DM toggle must.
+    setUserSetting(userId, 'notifications.highlight.enabled', false);
+    emitDm({ matched: true });
+    expect(await pushed()).toBe(true);
+    expect((await payload()).kind).toBe('dm');
+
+    deliverMock = freshDeliver();
+    setUserSetting(userId, 'notifications.dm.enabled', false);
+    emitDm({ matched: true });
+    expect(await pushed()).toBe(false);
+  });
+
+  it('does not push during a manual /away when mute_when_away is on', async () => {
+    setUserSetting(userId, 'notifications.push.mute_when_away', true);
+    writeAwayMarker(userId, { awayDatetime: new Date().toISOString(), autoSet: false });
+    emitDm();
+    expect(await pushed()).toBe(false);
+  });
+
+  it('DOES push during an AUTO away even when mute_when_away is on', async () => {
+    // Deliberate: auto-away means the user walked off, which is precisely when
+    // push matters most. Only a manual /away means "leave me alone".
+    setUserSetting(userId, 'notifications.push.mute_when_away', true);
+    writeAwayMarker(userId, { awayDatetime: new Date().toISOString(), autoSet: true });
+    emitDm();
+    expect(await pushed()).toBe(true);
+  });
+
+  it('pushes during a manual /away when mute_when_away is off', async () => {
+    writeAwayMarker(userId, { awayDatetime: new Date().toISOString(), autoSet: false });
+    emitDm();
+    expect(await pushed()).toBe(true);
+  });
+
+  it('does not push inside the quiet-hours window', async () => {
+    // Anchored to the user's timezone, so pin one and build a window that
+    // brackets "now" in it rather than in the test runner's zone.
+    setUserSetting(userId, 'system.timezone', 'UTC');
+    const nowUtcMin = nowUtcMinutes();
+    setUserSetting(userId, 'notifications.push.quiet_hours.enabled', true);
+    setUserSetting(userId, 'notifications.push.quiet_hours.start', hhmm(nowUtcMin - 60));
+    setUserSetting(userId, 'notifications.push.quiet_hours.end', hhmm(nowUtcMin + 60));
+    emitDm();
+    expect(await pushed()).toBe(false);
+  });
+
+  it('pushes outside the quiet-hours window', async () => {
+    setUserSetting(userId, 'system.timezone', 'UTC');
+    const nowUtcMin = nowUtcMinutes();
+    setUserSetting(userId, 'notifications.push.quiet_hours.enabled', true);
+    setUserSetting(userId, 'notifications.push.quiet_hours.start', hhmm(nowUtcMin + 120));
+    setUserSetting(userId, 'notifications.push.quiet_hours.end', hhmm(nowUtcMin + 240));
+    emitDm();
+    expect(await pushed()).toBe(true);
+  });
+
+  it('pushes a notify_always channel message, gated by its own toggle', async () => {
+    setChannelNotifyAlways(userId, networkId, '#lurker', true);
+    try {
+      emitChannel();
+      expect(await pushed()).toBe(true);
+      expect((await payload()).kind).toBe('always_notify');
+
+      deliverMock = freshDeliver();
+      setUserSetting(userId, 'notifications.always_notify.enabled', false);
+      emitChannel();
+      expect(await pushed()).toBe(false);
+    } finally {
+      setChannelNotifyAlways(userId, networkId, '#lurker', false);
+    }
+  });
+});
+
+// The payload is the contract across the pushService seam. Native transports
+// must compose an APNs/FCM notification from exactly these fields, so pin the
+// shape: a field silently dropped here is a notification that renders wrong on
+// a device, with nothing else failing.
+describe('maybePush payload', () => {
+  it('carries the fields a notification is built from', async () => {
+    const time = new Date().toISOString();
+    emitDm({ text: 'hey there', time, id: 4242 });
+    const p = await payload();
+    expect(p).toMatchObject({
+      kind: 'dm',
+      networkId,
+      target: 'bob',
+      nick: 'bob',
+      text: 'hey there',
+      time,
+      messageId: 4242,
+    });
+  });
+
+  it('falls back to a synthetic network name when the connection is offline', async () => {
+    // No live IrcConnection in tests, so this is the fallback branch. Worth
+    // pinning: it's what a native notification title would show.
+    emitDm();
+    expect((await payload()).networkName).toBe(`net:${networkId}`);
+  });
+
+  it('stamps the unread-highlight total as the app-icon badge', async () => {
+    // The badge is the running total, not this message's count (#451), and it
+    // includes the triggering message because it is persisted before the push.
+    insertMessage({
+      networkId,
+      target: 'carol',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'carol',
+      text: 'unread dm',
+      self: false,
+    });
+    emitDm();
+    // A DM's every unread line counts as a highlight, so the badge is non-zero
+    // and reflects a DB scan rather than anything on the event.
+    expect((await payload()).badge).toBeGreaterThan(0);
+  });
+});

--- a/server/tenantIsolation.test.ts
+++ b/server/tenantIsolation.test.ts
@@ -185,7 +185,12 @@ beforeAll(async () => {
   drafts.upsertDraft(userAId, netAId, SECRET_TARGET, 'A-draft');
 
   // A push subscription owned by A — B must not be able to delete or hijack it.
-  push.upsertSubscription(userAId, { endpoint: PUSH_ENDPOINT_A, p256dh: 'pA', auth: 'aA' });
+  push.upsertSubscription(userAId, {
+    transport: 'webpush',
+    endpoint: PUSH_ENDPOINT_A,
+    p256dh: 'pA',
+    auth: 'aA',
+  });
 
   // A pending export job — the enumerable :id/download is the classic
   // "fetch-by-job-id-without-owner-check" IDOR surface.

--- a/vue_client/public/sw.js
+++ b/vue_client/public/sw.js
@@ -30,10 +30,18 @@ function syncAppBadge(data) {
   return op.catch(() => {});
 }
 
-// "Amiantos came online (as nostimo · Libera)". The nick (data.target) is
-// shown only when it differs from the display name — for a friend watched under
-// several nicks it says which identity signed on; the network disambiguates a
-// friend watched across networks.
+// LEGACY composition, kept only as a fallback (#490 phase 2).
+//
+// The server composes title/body/tag itself now — it has to, because APNs and FCM
+// have no service worker to do it for them — and sends them on the payload. This
+// worker prefers those. But a worker cached before that change is still out there
+// receiving pushes from a server that already composes, and a server mid-rollback
+// may still send a payload without them, so both directions have to keep working.
+//
+// These functions are a byte-for-byte twin of server/services/notificationContent.ts.
+// They become dead code once every client has cycled onto a worker that reads the
+// server's fields, at which point both these and the semantic fields on the wire
+// can go. Until then: change one, change the other.
 function friendOnlineTitle(data) {
   const name = data.displayName || 'A friend';
   const parts = [];
@@ -44,6 +52,14 @@ function friendOnlineTitle(data) {
   return `${name} came online${parts.length ? ` (${parts.join(' · ')})` : ''}`;
 }
 
+function legacyTitle(data) {
+  return data.kind === 'dm'
+    ? `${data.nick || 'someone'}${data.networkName ? ' (' + data.networkName + ')' : ''}`
+    : data.kind === 'friend_online'
+      ? friendOnlineTitle(data)
+      : `${data.nick || 'someone'} in ${data.target || ''}`;
+}
+
 self.addEventListener('push', (event) => {
   if (!event.data) return;
   let data;
@@ -52,17 +68,17 @@ self.addEventListener('push', (event) => {
   } catch {
     data = { kind: 'unknown', text: event.data.text() };
   }
-  const title =
-    data.kind === 'dm'
-      ? `${data.nick || 'someone'}${data.networkName ? ' (' + data.networkName + ')' : ''}`
-      : data.kind === 'friend_online'
-        ? friendOnlineTitle(data)
-        : `${data.nick || 'someone'} in ${data.target || ''}`;
+  // `||` not `??`: an empty title from the server is as useless as a missing one,
+  // so fall back on both. Body genuinely may be '' (friend_online has no text),
+  // but the legacy expression yields '' there too, so the two agree either way.
+  const title = data.title || legacyTitle(data);
+  const body = data.body || data.text || '';
+  const tag = data.tag || `${data.networkId || 0}::${data.target || ''}`;
   event.waitUntil(
     Promise.all([
       self.registration.showNotification(title, {
-        body: data.text || '',
-        tag: `${data.networkId || 0}::${data.target || ''}`,
+        body,
+        tag,
         data,
         icon: '/lurker-icon-192.png',
         badge: '/lurker-icon-192.png',


### PR DESCRIPTION
Server side of #490. **Verified end to end on a real iPhone** — a notification composed by this code, signed with a real `.p8`, rendered on a device. The client is amiantos/lurker-ios#31.

`deliver()` no longer knows what a push service is: it composes once, dispatches each subscription to its transport's sender, and turns the returned failure class into the right thing happening to the row.

### The three-way failure vocabulary

`permanent` / `transient` / `strike` is the pre-existing Web Push behavior **generalized, not invented** — `webpushSender.classify()` is the exact status checks `deliver()` used to make inline, moved with their reasoning intact.

The distinction native has and Web Push didn't: a **credential** failure (APNs 403 `InvalidProviderToken`, FCM 401/403) is `transient`, never `strike`. It isn't the device's fault and it fails identically for every device the fleet owns — striking would march a user's entire set of phones to disabled after five pushes and force each to re-register once the operator fixed the key. Same reason an unconfigured transport is skipped rather than attempted: a self-hosted server holds no Apple key, and its users' iOS devices must survive that untouched.

### Both providers at once

Building them together paid for itself immediately: **APNs requires HTTP/2 and Node's fetch/undici doesn't speak it**, while FCM v1 is fine over plain `fetch`. An abstraction shaped around either one alone would have baked that in wrong. The other asymmetry is auth — APNs signs its own ES256 bearer from a `.p8`, FCM signs an RS256 assertion and trades it with Google for an OAuth2 token — which is what the shared `TokenCache` absorbs.

**No new dependency.** The detail that usually forces a JWT library is that ES256 wants the raw `r||s` signature while Node emits DER for EC keys, which APNs rejects as malformed. That's `dsaEncoding: 'ieee-p1363'`.

### Self-hosted push (decided)

APNs keys are per-app-bundle and FCM tokens are scoped to the Firebase project baked into the APK, so **only the publisher of a build can push to it**. FCM's documented cross-project workaround requires letting a foreign service account push to any of our users — non-starter.

Self-hosters are **not regressed**: Apple bridges Web Push for home-screen PWAs with no developer account, which is what they use today. Documented loudly in `SELF_HOSTING.md` and `.env.example`, because it will be asked.

### Phases

| | |
|---|---|
| **0** | Characterization net for the `maybePush` gate chain — it had *no* end-to-end test, so the logic we most needed to preserve was the least protected. Stayed green across every later phase. |
| **1** | Schema rebuild + `transport` discriminator. Shape-gated, not `SCHEMA_VERSION`-gated, per the `buffer_reads` precedent. |
| **2** | Notification copy moves server-side. The payload was a **service-worker contract** — `sw.js` composed the title — and APNs has no service worker. Additive: composed fields ride alongside the semantic ones, so a stale worker can't break. |
| **3** | Transport seam + all three providers. |
| **4** | Native registration routes + credential config. |

### What is NOT proven

FCM has never pushed to a real device — Android is paused per `APP_1.0_SCOPE.md`. Auth, request shape and error mapping are exercised (FCM answers a bogus token with a well-formed `UNREGISTERED`), but the last mile waits for Android to unpause. Called out in the code rather than papered over.

### Review

A high-effort self-review found three real bugs, all fixed in `c71bbab` (test-first, each re-verified by reverting the fix):

1. **A half-typed APNs config silenced Web Push too** — `isConfigured()` threw from inside a `filter`, and a throwing predicate aborts `Array.filter` outright, so a user with an iPhone got no push *at all*. Also made the "fails loud at boot" claim true: nothing called the parsers at boot, so a misconfig surfaced on the first push where it was swallowed.
2. **The cross-user guard trusted the caller's claim** — `transport: 'apns'` plus someone else's Web Push URL walked past the refusal and took their subscription.
3. **Device tokens reached the APNs `:path` unvalidated** — Node's http2 doesn't encode `:path` (verified).

Plus: `classify()` is pure again (its hidden reset moved to an explicit `onFailure` hook — and must *not* re-mint on `TooManyProviderTokenUpdates`), `getSession()` honors its host argument, the transport list is derived from one const instead of six places, and Web Push serializes once per push again.

**2,633 tests green**, `npm run check` clean.

### Deploy note

`LURKER_APNS_*` / `LURKER_FCM_SERVICE_ACCOUNT` are fleet-wide secrets and unset is normal — a self-hosted server should never hold them. Partially set now **fails the boot** with the missing variable named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)