### PR TITLE
Handle chghost and extended-join for other users

### DIFF
--- a/server/services/chghostWiring.test.ts
+++ b/server/services/chghostWiring.test.ts
@@ -170,6 +170,21 @@ describe('extended-join / account-notify (#508)', () => {
     expect(memberIn('#one', 'bob')?.account).toBe('bobaccount');
   });
 
+  it('puts the account on the join event so the join line can show it', () => {
+    const { of, join } = harness();
+    join('#one', 'bob', { account: 'bobaccount' });
+    expect(of('join')[0]).toMatchObject({ nick: 'bob', account: 'bobaccount' });
+  });
+
+  it('omits account from the join event when there is nothing to show', () => {
+    const { of, join } = harness();
+    join('#one', 'bob', { account: false }); // logged out
+    join('#two', 'carol'); // cap not enabled
+    // Renders as nothing either way, so keep it off the persisted `extra` JSON
+    // rather than writing a null onto every join row.
+    for (const e of of('join')) expect(e).not.toHaveProperty('account');
+  });
+
   it('distinguishes logged-out from never-learned', () => {
     const { memberIn, join } = harness();
     // irc-framework hands us `false` for the `*` sentinel...

--- a/server/services/chghostWiring.test.ts
+++ b/server/services/chghostWiring.test.ts
@@ -153,6 +153,21 @@ describe('chghost fan-out (#591)', () => {
     expect(of('chghost').map((e) => e.target)).toEqual(['#one']);
   });
 
+  it('keeps the old half of the mask rather than publishing an empty one', () => {
+    const { conn, of, memberIn } = harness();
+    // A member whose ident we never learned (NAMES-derived, no JOIN observed),
+    // then a host-only CHGHOST. Neither side should end up with a bare '@host'.
+    conn.client.emit('userlist', { channel: '#one', users: [{ nick: 'bob', modes: [] }] });
+    conn.client.emit('user updated', {
+      nick: 'bob',
+      hostname: '',
+      new_hostname: 'user/bob',
+    });
+    expect(of('chghost')[0]).toMatchObject({ newIdent: '', newHost: 'user/bob' });
+    // The stored mask keeps whatever it had rather than being blanked.
+    expect(memberIn('#one', 'bob')?.host).toBe('user/bob');
+  });
+
   it('ignores SETNAME, which rides the same event', () => {
     const { conn, of, join } = harness();
     join('#one', 'bob');
@@ -220,6 +235,16 @@ describe('extended-join / account-notify (#508)', () => {
     join('#one', 'bob', { account: 'bobaccount' });
     conn.client.emit('account', { nick: 'bob', account: false });
     expect(memberIn('#one', 'bob')?.account).toBeNull();
+  });
+
+  it('preserves a known account across a nick change', () => {
+    const { conn, memberIn, join } = harness();
+    join('#one', 'bob', { account: 'bobaccount' });
+    // A nick change doesn't log you out, and nothing would re-teach us the
+    // account afterwards — account-notify only fires when the account itself
+    // changes, which it hasn't.
+    conn.client.emit('nick', { nick: 'bob', new_nick: 'bob_' });
+    expect(memberIn('#one', 'bob_')?.account).toBe('bobaccount');
   });
 
   it('preserves a known account across a NAMES rebuild', () => {

--- a/server/services/chghostWiring.test.ts
+++ b/server/services/chghostWiring.test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// chghost (#591) + extended-join/account-notify (#508) wiring: the glue between
+// live IRC traffic and channel-member state on IrcConnection.
+//
+// The regression these pin down is subtle. Requesting the `chghost` cap makes
+// the server STOP sending the fake QUIT/rejoin pair it uses to describe a host
+// change to clients that lack it. Lurker requested the cap but only handled the
+// event for ITSELF, so a third party's host change rendered as nothing at all —
+// strictly less than a client with no IRCv3 support. These tests assert the
+// fan-out (one line per shared channel), the nicklist mutation that goes with
+// it (thelounge prints the line but has no host field, so its nicklist stays
+// stale — the exact complaint in #591), and that ACCOUNT stays silent.
+
+// MUST be first — redirect DATABASE_PATH before the static imports below open
+// the real data/lurker.db.
+import '../test-utils/isolateDb.js';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { IrcConnection } from './ircConnection.js';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+
+beforeAll(() => {
+  createUser('chghost-alice'); // id 1
+  createNetwork(1, { name: 'n', host: 'h', port: 6697, tls: true, nick: 'alice' }); // network id 1
+});
+
+function makeConn(): IrcConnection {
+  return new IrcConnection({
+    network: {
+      id: 1,
+      user_id: 1,
+      name: 'n',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'alice',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 1,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+      position: 0,
+      created_at: new Date().toISOString(),
+    },
+    onEvent: () => {},
+  });
+}
+
+type Ev = Record<string, unknown>;
+
+function harness() {
+  const conn = makeConn();
+  const publish = vi.fn<(event: Ev) => void>();
+  // The real publish persists and fans out; we only care about what it's handed.
+  conn.publish = publish as unknown as IrcConnection['publish'];
+  conn.client.user.nick = 'alice';
+  const of = (type: string) => publish.mock.calls.map((c) => c[0]).filter((e) => e.type === type);
+  const memberIn = (channel: string, nick: string) =>
+    conn.channels.get(channel.toLowerCase())?.members.get(nick.toLowerCase());
+  // Drive a real JOIN so member state is built the way production builds it.
+  const join = (channel: string, nick: string, extra: Ev = {}) =>
+    conn.client.emit('join', {
+      channel,
+      nick,
+      ident: 'ident',
+      hostname: 'old.host',
+      ...extra,
+    });
+  return { conn, publish, of, memberIn, join };
+}
+
+describe('chghost fan-out (#591)', () => {
+  it('publishes one line per shared channel and updates the stored mask', () => {
+    const { conn, of, memberIn, join } = harness();
+    join('#one', 'bob');
+    join('#two', 'bob');
+    join('#three', 'carol'); // bob absent — must not receive a line
+
+    conn.client.emit('user updated', {
+      nick: 'bob',
+      ident: 'ident',
+      hostname: 'old.host',
+      new_ident: 'newident',
+      new_hostname: 'user/bob',
+    });
+
+    const lines = of('chghost');
+    expect(lines.map((l) => l.target).sort()).toEqual(['#one', '#two']);
+    expect(lines[0]).toMatchObject({
+      nick: 'bob',
+      newIdent: 'newident',
+      newHost: 'user/bob',
+      // The OLD mask — the new one is the body of the line, matching weechat's
+      // "nick (old) has changed host to new" shape.
+      userhost: 'bob!ident@old.host',
+    });
+
+    // The nicklist must actually move, not just the rendered line.
+    expect(memberIn('#one', 'bob')).toMatchObject({ user: 'newident', host: 'user/bob' });
+    expect(memberIn('#two', 'bob')).toMatchObject({ user: 'newident', host: 'user/bob' });
+    expect(memberIn('#three', 'carol')).toMatchObject({ host: 'old.host' });
+  });
+
+  it('emits a member-update alongside each line so the nicklist patches live', () => {
+    const { conn, of, join } = harness();
+    join('#one', 'bob');
+    conn.client.emit('user updated', {
+      nick: 'bob',
+      ident: 'ident',
+      hostname: 'old.host',
+      new_hostname: 'user/bob',
+    });
+    const patches = of('member-update');
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toMatchObject({
+      target: '#one',
+      member: { nick: 'bob', host: 'user/bob' },
+    });
+  });
+
+  it('carries the unchanged half forward when CHGHOST only moves one', () => {
+    const { conn, of, memberIn, join } = harness();
+    join('#one', 'bob');
+    // Host-only change: no new_ident on the wire.
+    conn.client.emit('user updated', {
+      nick: 'bob',
+      ident: 'ident',
+      hostname: 'old.host',
+      new_hostname: 'user/bob',
+    });
+    expect(of('chghost')[0]).toMatchObject({ newIdent: 'ident', newHost: 'user/bob' });
+    expect(memberIn('#one', 'bob')).toMatchObject({ user: 'ident', host: 'user/bob' });
+  });
+
+  it('keeps the server-buffer line for your own host change, and still fans out', () => {
+    const { conn, of, join } = harness();
+    join('#one', 'alice');
+    conn.client.emit('user updated', {
+      nick: 'alice',
+      ident: 'ident',
+      hostname: 'old.host',
+      new_ident: 'newident',
+      new_hostname: 'user/alice',
+    });
+    // The SASL-cloak confirmation belongs where you'll see it even with no
+    // channels open — but it must not REPLACE the in-channel line.
+    expect(of('motd').map((e) => e.text)).toContain('Your hostmask: newident@user/alice');
+    expect(of('chghost').map((e) => e.target)).toEqual(['#one']);
+  });
+
+  it('ignores SETNAME, which rides the same event', () => {
+    const { conn, of, join } = harness();
+    join('#one', 'bob');
+    // A realname change carries neither new_ident nor new_hostname.
+    conn.client.emit('user updated', { nick: 'bob', ident: 'ident', hostname: 'old.host' });
+    expect(of('chghost')).toHaveLength(0);
+    expect(of('member-update')).toHaveLength(0);
+  });
+});
+
+describe('extended-join / account-notify (#508)', () => {
+  it('records the account from an extended JOIN', () => {
+    const { memberIn, join } = harness();
+    join('#one', 'bob', { account: 'bobaccount' });
+    expect(memberIn('#one', 'bob')?.account).toBe('bobaccount');
+  });
+
+  it('distinguishes logged-out from never-learned', () => {
+    const { memberIn, join } = harness();
+    // irc-framework hands us `false` for the `*` sentinel...
+    join('#one', 'bob', { account: false });
+    expect(memberIn('#one', 'bob')?.account).toBeNull();
+    // ...and omits the key entirely when the cap isn't enabled. That's the
+    // state a future WHOX backfill is allowed to fill in; `null` is not.
+    join('#one', 'carol');
+    expect(memberIn('#one', 'carol')?.account).toBeUndefined();
+  });
+
+  it('updates the account on ACCOUNT without rendering a line', () => {
+    const { conn, of, memberIn, join } = harness();
+    join('#one', 'bob');
+    join('#two', 'bob');
+    conn.client.emit('account', { nick: 'bob', account: 'bobaccount' });
+
+    expect(memberIn('#one', 'bob')?.account).toBe('bobaccount');
+    expect(memberIn('#two', 'bob')?.account).toBe('bobaccount');
+    // Silent by design: on Libera an identify fires ACCOUNT *and* CHGHOST back
+    // to back, so a visible line here would double every identify.
+    expect(of('account')).toHaveLength(0);
+    expect(of('chghost')).toHaveLength(0);
+    expect(
+      of('member-update')
+        .map((e) => e.target)
+        .sort(),
+    ).toEqual(['#one', '#two']);
+  });
+
+  it('records a logout', () => {
+    const { conn, memberIn, join } = harness();
+    join('#one', 'bob', { account: 'bobaccount' });
+    conn.client.emit('account', { nick: 'bob', account: false });
+    expect(memberIn('#one', 'bob')?.account).toBeNull();
+  });
+
+  it('preserves a known account across a NAMES rebuild', () => {
+    const { conn, memberIn, join } = harness();
+    join('#one', 'bob', { account: 'bobaccount' });
+    // NAMES never carries an account, so a rebuild must not wipe what we know.
+    conn.client.emit('userlist', {
+      channel: '#one',
+      users: [{ nick: 'bob', modes: [] }],
+    });
+    expect(memberIn('#one', 'bob')?.account).toBe('bobaccount');
+  });
+});

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1578,17 +1578,17 @@ export class IrcConnection {
       const eventChannel = event.channel as string;
       const eventNick = event.nick as string;
       const ch = this.upsertChannel(eventChannel);
+      // extended-join: irc-framework parses the account param when the cap is
+      // enabled, and omits the key when it isn't (#508).
+      const joinAccount = normalizeAccount(event.account);
       ch.members.set(eventNick.toLowerCase(), {
         nick: eventNick,
         modes: [],
         away: false,
         user: (event.ident as string) || null,
         host: (event.hostname as string) || null,
-        // extended-join: irc-framework parses the account param when the cap is
-        // enabled, and omits the key when it isn't (#508).
-        account: normalizeAccount(event.account),
+        account: joinAccount,
       });
-      const joinAccount = normalizeAccount(event.account);
       this.publish({
         type: 'join',
         target: eventChannel,
@@ -1822,6 +1822,10 @@ export class IrcConnection {
             away: !!member.away,
             user: (event.ident as string) || member.user || null,
             host: (event.hostname as string) || member.host || null,
+            // A nick change doesn't log you out — carry the account across, or
+            // it's lost for good (account-notify only fires when the account
+            // itself changes, which it hasn't) (#508).
+            account: member.account,
           });
           this.publish({
             type: 'nick',

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -238,6 +238,11 @@ function extractExtras(event: IrcEvent): Record<string, unknown> | null {
       // backlog, so the line reads "X changed host to @" after a reload.
       extras = { newIdent: event.newIdent, newHost: event.newHost };
       break;
+    case 'join':
+      // extended-join account, so the join line still shows it after a reload
+      // (#508). Absent on networks without the cap and for logged-out users.
+      if (event.account) extras = { account: event.account };
+      break;
   }
   // RPE2E: persist the lock flag for message/action/notice so the indicator
   // survives a reload and reaches late-attaching clients (round-trips through the
@@ -1583,11 +1588,16 @@ export class IrcConnection {
         // enabled, and omits the key when it isn't (#508).
         account: normalizeAccount(event.account),
       });
+      const joinAccount = normalizeAccount(event.account);
       this.publish({
         type: 'join',
         target: eventChannel,
         nick: eventNick,
         userhost: buildUserhost(event),
+        // Only when we actually know an account — a logged-out `null` renders
+        // as nothing anyway, and omitting it keeps the persisted `extra` JSON
+        // off every join row on networks without the cap.
+        ...(joinAccount ? { account: joinAccount } : {}),
       });
       if (eventNick !== c.user.nick) {
         // JOIN means they're online. If they were marked away and JOIN fires,

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -113,6 +113,9 @@ const NON_PERSISTED_TYPES = new Set([
   // CTCP request/reply notices are transient status, surfaced via
   // publishEphemeral — never persisted (#263).
   'ctcp',
+  // Incremental nicklist patch (host/account). Like 'names' it describes
+  // current membership state, not history — a replayed one would be wrong.
+  'member-update',
 ]);
 
 // Diagnostic: a single synchronous IRC-event handler (NAMES/WHO member-list
@@ -147,6 +150,14 @@ interface ChannelMember {
   away: boolean;
   user: string | null;
   host: string | null;
+  // Services account, from extended-join / account-notify. Three states:
+  // a string = logged in as that account; null = server told us they're logged
+  // out (the `*` sentinel); undefined = we never learned (no cap, or they were
+  // already here when we joined — NAMES carries no account). Unknown and
+  // logged-out both render as nothing today, but keeping them distinct is what
+  // lets a future WHOX backfill (#508 follow-up) write a correct merge rule
+  // instead of clobbering fresher data — see irssi's nickrec->account guard.
+  account?: string | null;
 }
 
 interface ChannelState {
@@ -222,6 +233,11 @@ function extractExtras(event: IrcEvent): Record<string, unknown> | null {
     case 'mode':
       extras = { modes: event.modes };
       break;
+    case 'chghost':
+      // Without this the new mask survives the live fan-out but vanishes from
+      // backlog, so the line reads "X changed host to @" after a reload.
+      extras = { newIdent: event.newIdent, newHost: event.newHost };
+      break;
   }
   // RPE2E: persist the lock flag for message/action/notice so the indicator
   // survives a reload and reaches late-attaching clients (round-trips through the
@@ -275,7 +291,21 @@ function memberSnapshot(m: ChannelMember): ChannelMember {
     away: !!m.away,
     user: m.user || null,
     host: m.host || null,
+    account: m.account,
   };
+}
+
+// Normalize a services account off the wire into ChannelMember.account's
+// tristate. There are TWO logged-out sentinels: `*` on JOIN/ACCOUNT, and `0` on
+// a WHOX 354 reply — normalize both here, at the parse boundary, so exactly one
+// representation reaches the member map. irc-framework hands us `false` for `*`
+// on the events it parses, and omits the key entirely when the cap is off.
+function normalizeAccount(raw: unknown): string | null | undefined {
+  if (raw === undefined) return undefined; // cap not enabled — we know nothing
+  if (raw === false || raw === null) return null; // framework's `*` sentinel
+  const s = String(raw).trim();
+  if (!s || s === '*' || s === '0') return null;
+  return s;
 }
 
 // Why a nick is on the presence watch list: an active DM peer, a friend/contact
@@ -516,6 +546,15 @@ export class IrcConnection {
     const target = canonicalChannelTarget(event.target, this.channels);
     if (target === event.target) return event;
     return { ...event, target };
+  }
+
+  // Patch one member's attributes on the client's nicklist. The pre-existing
+  // way to push a member change was to republish the whole `names` array (see
+  // the WHO ident/host backfill), which is O(members) for a one-nick edit —
+  // fine once per join, wasteful for a chghost storm after a netsplit, and no
+  // use at all for the silent account-notify path.
+  private publishMemberUpdate(target: string, member: ChannelMember): void {
+    this.publish({ type: 'member-update', target, member: memberSnapshot(member) });
   }
 
   // Returns the enriched, persisted event so callers can read server-stamped
@@ -1175,26 +1214,79 @@ export class IrcConnection {
     // irc-framework fires 'user updated' for both CHGHOST (ident/host change)
     // and SETNAME (realname change). The cloaked-vhost case after SASL on
     // Libera arrives as a CHGHOST, but only when we've requested the chghost
-    // cap (see the client constructor). Surface self changes in the server
-    // buffer so users see "your host became X" the way other clients do.
+    // cap (see the client constructor).
+    //
+    // Requesting that cap makes the server STOP sending the fake QUIT/rejoin
+    // pair it uses to describe a host change to clients that lack it. So until
+    // #591 this handler's self-only guard meant third-party host changes
+    // rendered as literally nothing — strictly less than a client with no
+    // IRCv3 support at all. CHGHOST arrives once, globally; every reference
+    // client (weechat irc-protocol.c, irssi massjoin.c, halloy, thelounge)
+    // fans it out to each channel the user shares with you, updates the
+    // nicklist host there, and renders ONE native line. No client synthesizes
+    // the fake QUIT/rejoin — that's a server/bouncer compat shim (znc does it
+    // only when relaying to a downstream that didn't negotiate the cap).
     c.on('user updated', (event: Record<string, unknown>) => {
-      if (
-        !event ||
-        !c.user.nick ||
-        (event.nick as string | undefined)?.toLowerCase() !== c.user.nick.toLowerCase()
-      )
-        return;
-      if (event.new_hostname || event.new_ident) {
-        const ident = (event.new_ident as string) || (event.ident as string) || '';
-        const host = (event.new_hostname as string) || (event.hostname as string) || '';
-        const mask = ident ? `${ident}@${host}` : host;
-        if (mask) {
-          this.publish({
-            type: 'motd',
-            target: this.serverTarget(),
-            text: `Your hostmask: ${mask}`,
-          });
-        }
+      if (!event || !event.nick) return;
+      if (!event.new_hostname && !event.new_ident) return; // SETNAME — not ours
+      const eventNick = event.nick as string;
+      const lower = eventNick.toLowerCase();
+      const isSelf = !!c.user.nick && c.user.nick.toLowerCase() === lower;
+      // CHGHOST only carries the half that changed on some ircds; fall back to
+      // the previous value so the mask we store and show is always complete.
+      const newIdent = (event.new_ident as string) || (event.ident as string) || '';
+      const newHost = (event.new_hostname as string) || (event.hostname as string) || '';
+      const mask = newIdent ? `${newIdent}@${newHost}` : newHost;
+      if (!mask) return;
+
+      if (isSelf) {
+        // Keep the long-standing server-buffer line for your own host change —
+        // it's the SASL-cloak confirmation, and it belongs where you'll see it
+        // even when you share no channels yet.
+        this.publish({
+          type: 'motd',
+          target: this.serverTarget(),
+          text: `Your hostmask: ${mask}`,
+        });
+      }
+
+      const oldUserhost = buildUserhost(event);
+      for (const ch of this.channels.values()) {
+        const member = ch.members.get(lower);
+        if (!member) continue;
+        // Update the stored mask, not just the rendered line. thelounge is the
+        // cautionary case here: it prints the line but has no host field on its
+        // user model, so its nicklist stays stale — the exact complaint in #591.
+        member.user = newIdent || member.user;
+        member.host = newHost || member.host;
+        this.publish({
+          type: 'chghost',
+          target: ch.name,
+          nick: eventNick,
+          userhost: oldUserhost,
+          newIdent,
+          newHost,
+        });
+        this.publishMemberUpdate(ch.name, member);
+      }
+    });
+
+    // account-notify. Deliberately silent: no channel line, nicklist/hover
+    // only. On Libera (and most Atheme networks) identifying to services fires
+    // ACCOUNT and CHGHOST back to back, so rendering both would mean two lines
+    // per identify in every shared channel. chghost earns its line because it
+    // regressed against the no-cap baseline (#591); this never showed anything.
+    // halloy and gamja both treat ACCOUNT as a pure state update too.
+    c.on('account', (event: Record<string, unknown>) => {
+      if (!event || !event.nick) return;
+      const eventNick = event.nick as string;
+      const lower = eventNick.toLowerCase();
+      const account = normalizeAccount(event.account);
+      for (const ch of this.channels.values()) {
+        const member = ch.members.get(lower);
+        if (!member) continue;
+        member.account = account;
+        this.publishMemberUpdate(ch.name, member);
       }
     });
 
@@ -1487,6 +1579,9 @@ export class IrcConnection {
         away: false,
         user: (event.ident as string) || null,
         host: (event.hostname as string) || null,
+        // extended-join: irc-framework parses the account param when the cap is
+        // enabled, and omits the key when it isn't (#508).
+        account: normalizeAccount(event.account),
       });
       this.publish({
         type: 'join',
@@ -1889,9 +1984,17 @@ export class IrcConnection {
       // (e.g. on /NAMES or a fresh join). NAMES doesn't carry ident/host on
       // most ircds — the JOIN event and WHO reply do — so we hold onto
       // whatever we already learned.
-      const prev = new Map<string, { away: boolean; user: string | null; host: string | null }>();
+      const prev = new Map<
+        string,
+        { away: boolean; user: string | null; host: string | null; account?: string | null }
+      >();
       for (const [k, v] of ch.members)
-        prev.set(k, { away: !!v.away, user: v.user || null, host: v.host || null });
+        prev.set(k, {
+          away: !!v.away,
+          user: v.user || null,
+          host: v.host || null,
+          account: v.account,
+        });
       ch.members.clear();
       for (const u of eventUsers) {
         const nick = u.nick as string;
@@ -1903,6 +2006,9 @@ export class IrcConnection {
           away: carry.away || false,
           user: (u.ident as string) || carry.user || null,
           host: (u.hostname as string) || carry.host || null,
+          // NAMES never carries an account, so this is carry-forward only —
+          // same reasoning as user/host above (#508).
+          account: carry.account,
         });
       }
       this.publish({

--- a/shared/ignoreLevels.ts
+++ b/shared/ignoreLevels.ts
@@ -17,7 +17,11 @@ export const LEVEL_DEFS: Record<string, { types: string[]; dm?: boolean }> = {
   ACTIONS: { types: ['action'] },
   JOINS: { types: ['join'] },
   PARTS: { types: ['part'] },
-  QUITS: { types: ['quit'] },
+  // Host changes ride with QUITS rather than getting their own level: a
+  // chghost IS what a client without the cap would have shown you as a
+  // quit/rejoin pair, so someone who silenced a nick's quits already expects
+  // these gone too (#591).
+  QUITS: { types: ['quit', 'chghost'] },
   NICKS: { types: ['nick'] },
   KICKS: { types: ['kick'] },
   MODES: { types: ['mode'] },
@@ -38,6 +42,7 @@ export const ALL_TYPES = new Set([
   'kick',
   'mode',
   'topic',
+  'chghost',
 ]);
 
 export const HIGHLIGHTABLE = new Set(['message', 'action']);

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -740,6 +740,21 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'individual lines only; events that collapse into the consolidation ' +
       'summary above stay host-less. Regular chat messages are unaffected.',
   },
+  {
+    key: 'chat.show_join_account',
+    label: 'Show services account on join lines',
+    category: 'chat',
+    group: 'consolidate',
+    type: 'bool',
+    default: false,
+    description:
+      'Show the joining user’s services (NickServ) account next to their nick ' +
+      'on JOIN lines (e.g. "alice [aliceacct] joined") — useful for channel ops ' +
+      'confirming who is identified. Requires the network to support the ' +
+      'extended-join extension; nothing is shown for users who are not logged ' +
+      'in, or on networks without it. Applies to individual lines only; events ' +
+      'that collapse into the consolidation summary above stay account-less.',
+  },
 
   // ─── Composing (outgoing message guardrails) ─────────────────────────
   // irc-framework splits anything past ~350 bytes into multiple PRIVMSGs on

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -182,9 +182,7 @@
                 :nick="row.m.nick ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-              />{{ eventHostSuffix(row.m) }} changed host to {{ row.m.newIdent }}@{{
-                row.m.newHost
-              }}</template
+              />{{ eventHostSuffix(row.m) }} changed host to {{ chghostMask(row.m) }}</template
             >
             <template v-else-if="row.m?.type === 'kick'"
               ><NickRef
@@ -1042,7 +1040,12 @@ const renderRows = computed((): RenderRow[] => {
     if (filterOn && m.nick && !m.self) {
       const filterable =
         (m.type === 'join' && fJoin) ||
-        ((m.type === 'part' || m.type === 'quit') && fQuit) ||
+        // chghost rides the quit toggle rather than adding a fourth setting:
+        // it's the same churn from the same silent lurkers (identifying to
+        // services after a netsplit fires one per shared channel), which is
+        // exactly what smart filtering exists to absorb. weechat ships a
+        // dedicated smart_filter_chghost for the same reason (#591).
+        ((m.type === 'part' || m.type === 'quit' || m.type === 'chghost') && fQuit) ||
         (m.type === 'nick' && fNick);
       if (filterable && m.nick.toLowerCase() !== ownNickLc) {
         const lastSpoke = buf?.speakers[m.nick.toLowerCase()]?.lastTime;
@@ -1256,6 +1259,16 @@ function eventHostSuffix(m: ChatMessage | undefined): string {
   const { user, host } = parseUserHost(m?.userhost);
   if (!user || !host) return '';
   return ` (${user}@${host})`;
+}
+
+// The post-change mask on a chghost line (#591). Same rule eventHostSuffix
+// applies above: a half-mask like `@host` reads worse than the host alone, so
+// only join the two with an `@` when we actually have both halves. Mirrors the
+// server's own mask construction in the CHGHOST handler.
+function chghostMask(m: ChatMessage | undefined): string {
+  const ident = m?.newIdent || '';
+  const host = m?.newHost || '';
+  return ident && host ? `${ident}@${host}` : host || ident;
 }
 
 // The joining user's services account, from extended-join (#508). Rendered

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -177,6 +177,15 @@
                 (<LinkedText :text="row.m.text" />)</template
               ></template
             >
+            <template v-else-if="row.m?.type === 'chghost'"
+              ><NickRef
+                :nick="row.m.nick ?? ''"
+                interactive
+                @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
+              />{{ eventHostSuffix(row.m) }} changed host to {{ row.m.newIdent }}@{{
+                row.m.newHost
+              }}</template
+            >
             <template v-else-if="row.m?.type === 'kick'"
               ><NickRef
                 :nick="row.m.kicked ?? ''"
@@ -1199,6 +1208,7 @@ function prefixText(m: ChatMessage | undefined): string {
     case 'topic':
     case 'motd':
     case 'invite':
+    case 'chghost':
       return '--';
     case 'system':
       // System-buffer log lines (#355). Tied to a network → that network's
@@ -1227,10 +1237,12 @@ function prefixText(m: ChatMessage | undefined): string {
 // absent — the server stores an empty ident/host when it lacks one
 // (`nick!@host` / `nick!ident@`), and a half-mask like `(@host)` reads worse
 // than nothing, so we only render when both pieces are present. The full
-// formatting (leading space + parens) lives here so the four presence-line
-// templates share one source of truth and each call it once (only the matching
-// branch renders per row); reuses parseUserHost so parsing matches the ignore
-// flow exactly.
+// formatting (leading space + parens) lives here so the presence-line templates
+// share one source of truth and each call it once (only the matching branch
+// renders per row); reuses parseUserHost so parsing matches the ignore flow
+// exactly. On a chghost line this renders the OLD mask — the new one is the
+// body of the message — which matches weechat's "nick (old) has changed host
+// to new" shape.
 function eventHostSuffix(m: ChatMessage | undefined): string {
   if (!showEventHost.value) return '';
   const { user, host } = parseUserHost(m?.userhost);

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -157,7 +157,7 @@
                 :nick="row.m.nick ?? ''"
                 interactive
                 @click.stop.prevent="onNickMenu($event, row.m?.nick, row.m)"
-              />{{ eventHostSuffix(row.m) }} joined</template
+              />{{ joinAccountSuffix(row.m) }}{{ eventHostSuffix(row.m) }} joined</template
             >
             <template v-else-if="row.m?.type === 'part'"
               ><NickRef
@@ -355,6 +355,13 @@ interface ChatMessage {
   kicked?: string;
   invited?: string;
   userhost?: string;
+  // chghost (#591): the mask AFTER the change. `userhost` holds the old one,
+  // so a line can show both.
+  newIdent?: string;
+  newHost?: string;
+  // extended-join (#508): the joining user's services account, when the
+  // network supports the cap and they're identified.
+  account?: string | null;
   // System-buffer lines (#355): the network this line is about, when any. The
   // prefix column resolves the network's current name from it.
   originNetworkId?: number | null;
@@ -850,6 +857,7 @@ const consolidateMaxNames = computed(
 );
 
 const showEventHost = computed(() => !!settings.effective('chat.show_event_host'));
+const showJoinAccount = computed(() => !!settings.effective('chat.show_join_account'));
 
 const collapseAuthorsEnabled = computed(
   () => !!settings.effective('look.message.collapse_authors'),
@@ -1248,6 +1256,19 @@ function eventHostSuffix(m: ChatMessage | undefined): string {
   const { user, host } = parseUserHost(m?.userhost);
   if (!user || !host) return '';
   return ` (${user}@${host})`;
+}
+
+// The joining user's services account, from extended-join (#508). Rendered
+// between the nick and the host suffix, matching weechat's `[account]` shape
+// (irssi and thelounge put it in the same slot). Unlike the nicklist, this
+// surface needs no WHOX backfill to be consistent: a join line only exists for
+// a join event, and extended-join always carries the account for exactly that
+// event — so the value is either present or the network lacks the cap, never
+// silently stale. Only a known account renders; a logged-out user (the `*`
+// sentinel, stored as null) shows nothing, same as no data.
+function joinAccountSuffix(m: ChatMessage | undefined): string {
+  if (!showJoinAccount.value) return '';
+  return m?.account ? ` [${m.account}]` : '';
 }
 
 function prefixClass(m: ChatMessage | undefined) {

--- a/vue_client/src/components/UserProfileModal.vue
+++ b/vue_client/src/components/UserProfileModal.vue
@@ -54,9 +54,9 @@
               <code>{{ actualHost }}</code>
             </dd>
           </template>
-          <template v-if="whois?.account">
+          <template v-if="account">
             <dt>Account</dt>
-            <dd>{{ whois.account }}</dd>
+            <dd>{{ account }}</dd>
           </template>
           <template v-if="whois?.server">
             <dt>Server</dt>
@@ -212,6 +212,18 @@ const awayMessage = computed(() => {
   const fromPresence = peer.value?.awayMessage || '';
   if (fromPresence) return fromPresence;
   return (whois.value?.away as string) || '';
+});
+
+// Prefer the WHOIS reply, fall back to what extended-join / account-notify
+// taught the nicklist (#508) — same precedence as awayMessage above, and for
+// the same reason: WHOIS is the richer, freshly-requested source, but it only
+// exists once the round-trip lands. The fallback means the row is populated the
+// instant the modal opens for anyone who joined while we were watching, and
+// account-notify keeps it honest afterwards.
+const account = computed(() => {
+  const fromWhois = (whois.value?.account as string) || '';
+  if (fromWhois) return fromWhois;
+  return buffers.accountFor(props.networkId, props.nick) || '';
 });
 
 const presenceClass = computed(() => {

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -170,12 +170,12 @@ function applyEvent(event: any): void {
     case 'away-state':
       networks.applyAwayState(event);
       break;
+    // Render only. The nicklist patch rides the `member-update` the server
+    // sends alongside this — patching here too would double the work and, since
+    // the raw event carries '' for a half the server chose to keep unchanged,
+    // would briefly write the wrong value before member-update corrected it.
     case 'chghost':
-      if (!buffers.pushMessage(event)) break;
-      buffers.updateMember(event.networkId, event.target, event.nick, {
-        user: event.newIdent,
-        host: event.newHost,
-      });
+      buffers.pushMessage(event);
       break;
     case 'names':
       buffers.setMembers(event.networkId, event.target, event.members);

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -170,8 +170,19 @@ function applyEvent(event: any): void {
     case 'away-state':
       networks.applyAwayState(event);
       break;
+    case 'chghost':
+      if (!buffers.pushMessage(event)) break;
+      buffers.updateMember(event.networkId, event.target, event.nick, {
+        user: event.newIdent,
+        host: event.newHost,
+      });
+      break;
     case 'names':
       buffers.setMembers(event.networkId, event.target, event.members);
+      break;
+    // Incremental nicklist patch — not persisted, so no pushMessage/dedupe.
+    case 'member-update':
+      buffers.updateMember(event.networkId, event.target, event.member?.nick, event.member);
       break;
     case 'channel-joined':
       buffers.ensure(event.networkId, event.target);

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -444,3 +444,82 @@ describe('joinOrActivate channel key', () => {
     });
   });
 });
+
+describe('member attribute patching (#591, #508)', () => {
+  const member = (nick: string, extra: Record<string, unknown> = {}) => ({
+    nick,
+    modes: [],
+    away: false,
+    ...extra,
+  });
+
+  it('patches a member in place, leaving unmentioned fields alone', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#chan', [member('bob', { user: 'ident', host: 'old.host' })]);
+
+    store.updateMember(1, '#chan', 'bob', { host: 'user/bob' });
+
+    const m = store.byKey('1::#chan')!.members[0];
+    expect(m.host).toBe('user/bob');
+    expect(m.user).toBe('ident'); // untouched
+  });
+
+  it('matches the nick case-insensitively', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#chan', [member('Bob', { host: 'old.host' })]);
+
+    // A CHGHOST/ACCOUNT echoes the nick as the server holds it, which needn't
+    // match the case NAMES gave us.
+    store.updateMember(1, '#chan', 'bob', { host: 'user/bob' });
+
+    expect(store.byKey('1::#chan')!.members[0].host).toBe('user/bob');
+    expect(store.byKey('1::#chan')!.members[0].nick).toBe('Bob'); // case preserved
+  });
+
+  it('never lets a patch overwrite the nick', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#chan', [member('bob')]);
+
+    store.updateMember(1, '#chan', 'bob', { nick: 'evil', host: 'user/bob' });
+
+    expect(store.byKey('1::#chan')!.members[0].nick).toBe('bob');
+  });
+
+  it('does not materialize a buffer for an unopened target', () => {
+    const store = useBuffersStore();
+    const before = netBuffers(store).length;
+
+    store.updateMember(1, '#never-opened', 'bob', { host: 'user/bob' });
+
+    // A pure attribute patch has no business creating a buffer — doing so
+    // would leave an empty one in the sidebar.
+    expect(netBuffers(store)).toHaveLength(before);
+    expect(store.isOpen(1, '#never-opened')).toBe(false);
+  });
+
+  it('finds an account from any shared channel on the network', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#one', [member('bob')]); // joined before us — no data
+    store.setMembers(1, '#two', [member('bob', { account: 'bobaccount' })]);
+
+    expect(store.accountFor(1, 'bob')).toBe('bobaccount');
+  });
+
+  it('tolerates a string network id', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#one', [member('bob', { account: 'bobaccount' })]);
+
+    // Buffers store networkId as a number; `'1' !== 1` would silently match
+    // nothing rather than fail loudly.
+    expect(store.accountFor('1', 'bob')).toBe('bobaccount');
+  });
+
+  it('distinguishes logged-out from never-learned', () => {
+    const store = useBuffersStore();
+    store.setMembers(1, '#one', [member('bob', { account: null })]);
+    store.setMembers(1, '#two', [member('carol')]);
+
+    expect(store.accountFor(1, 'bob')).toBeNull(); // server said logged out
+    expect(store.accountFor(1, 'carol')).toBeUndefined(); // we never learned
+  });
+});

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -782,7 +782,13 @@ export const useBuffersStore = defineStore('buffers', {
       patch: Partial<BufferMember> | undefined,
     ) {
       if (!nick || !patch) return;
-      const buf = ensureBuffer(this, networkId, target);
+      // Resolve, never create. Unlike addMember/removeMember — which ride a
+      // join/part that legitimately implies the buffer should exist — a pure
+      // attribute patch has no business materializing a buffer, and doing so
+      // would leave an empty one in the sidebar when the target isn't open.
+      const bufKey = resolveExistingKey(this.buffers, networkId, target);
+      if (!bufKey) return;
+      const buf = this.buffers[bufKey];
       const lc = nick.toLowerCase();
       const m = buf.members.find(
         (x) => typeof x === 'object' && (x.nick || '').toLowerCase() === lc,

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -94,6 +94,11 @@ export interface BufferMember {
   // because pre-upgrade backlog and bare JOIN-derived members may lack them.
   user?: string | null;
   host?: string | null;
+  // Services account (extended-join / account-notify, #508). A string means
+  // logged in; null means the server told us they're logged out; undefined
+  // means we never learned. Both falsy states render as nothing today — the
+  // distinction is kept so a later WHOX backfill can merge without clobbering.
+  account?: string | null;
 }
 
 export interface TypingEntry {
@@ -296,6 +301,26 @@ export const useBuffersStore = defineStore('buffers', {
       resolveExistingKey(state.buffers, networkId, target) !== null,
     forNetwork: (state) => (networkId: number | string) =>
       Object.values(state.buffers).filter((b) => b.networkId === networkId),
+    // The services account we've learned for a nick anywhere on this network,
+    // from extended-join / account-notify (#508). Account is per-network, not
+    // per-channel, so any channel we share is an equally good source — take the
+    // first that actually knows. Returns undefined when no shared channel has
+    // data (we joined after them, or the network lacks the caps), which is
+    // distinct from null ("server told us they're logged out").
+    accountFor:
+      (state) =>
+      (networkId: number | string, nick: string): string | null | undefined => {
+        if (!nick) return undefined;
+        const lc = nick.toLowerCase();
+        for (const b of Object.values(state.buffers)) {
+          if (b.networkId !== networkId) continue;
+          const m = b.members?.find(
+            (x) => typeof x === 'object' && (x.nick || '').toLowerCase() === lc,
+          );
+          if (m && m.account !== undefined) return m.account;
+        }
+        return undefined;
+      },
     // The open DM buffer for a (network, nick), matched case-insensitively so we
     // resolve to whatever case is already open rather than forking a second
     // buffer that differs only by nick case. Channels and the flat virtual
@@ -746,6 +771,29 @@ export const useBuffersStore = defineStore('buffers', {
       const buf = ensureBuffer(this, networkId, target);
       const existing = buf.members.find((m) => (m.nick || m) === nick);
       if (!existing) buf.members.push({ nick, modes: [], away: false });
+    },
+    // Patch attributes on one member in place, leaving fields the caller didn't
+    // mention alone. Matched case-insensitively: a CHGHOST/ACCOUNT echoes the
+    // nick as the server holds it, which needn't match the case NAMES gave us.
+    updateMember(
+      networkId: number | string,
+      target: string,
+      nick: string | undefined,
+      patch: Partial<BufferMember> | undefined,
+    ) {
+      if (!nick || !patch) return;
+      const buf = ensureBuffer(this, networkId, target);
+      const lc = nick.toLowerCase();
+      const m = buf.members.find(
+        (x) => typeof x === 'object' && (x.nick || '').toLowerCase() === lc,
+      );
+      if (!m) return;
+      // Never let a patch blank out a nick, and skip keys the sender omitted so
+      // a chghost carrying only the changed half can't wipe the other one.
+      for (const [k, v] of Object.entries(patch)) {
+        if (k === 'nick' || v === undefined) continue;
+        (m as unknown as Record<string, unknown>)[k] = v;
+      }
     },
     renameMember(networkId: number | string, target: string, oldNick: string, newNick: string) {
       const buf = ensureBuffer(this, networkId, target);

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -312,8 +312,12 @@ export const useBuffersStore = defineStore('buffers', {
       (networkId: number | string, nick: string): string | null | undefined => {
         if (!nick) return undefined;
         const lc = nick.toLowerCase();
+        // Coerce before comparing: buffers store networkId as a number, but the
+        // signature accepts a string, and `'3' !== 3` would silently match
+        // nothing rather than fail loudly. Same guard resolveExistingKey uses.
+        const nid = Number(networkId);
         for (const b of Object.values(state.buffers)) {
-          if (b.networkId !== networkId) continue;
+          if (b.networkId !== nid) continue;
           const m = b.members?.find(
             (x) => typeof x === 'object' && (x.nick || '').toLowerCase() === lc,
           );


### PR DESCRIPTION
Closes #591, closes #508.

## The bug is worse than "cap not supported"

Lurker already requested the `chghost` cap — `enable_chghost: true` has been set on the `connect()` call for a while — but the handler only acted when the event was about **you**. Everyone else's host change was received and dropped.

That combination is a strict regression against having no IRCv3 support at all. Advertising the cap makes the server **stop** sending the fake QUIT/rejoin pair it uses to describe a host change to clients that lack it. So we turned off the fallback and put nothing in its place, which is why #591 reports "Lurker does not even show this" rather than "Lurker shows this badly."

## What changed

`CHGHOST` arrives once, globally. It now fans out to every channel the user shares with us, updates the stored ident/host there, and renders one native line:

```
-- bob (ident@old.host) changed host to ~bob@user/bob
```

This matches every reference client — weechat (`irc-protocol.c`), irssi (`massjoin.c`), halloy, thelounge all do one-line-per-shared-channel. **No client synthesizes the fake QUIT/rejoin**; that's a server/bouncer compat shim (znc does it only when relaying to a downstream that didn't negotiate the cap). One real line carries the same information without putting a quit that never happened into the transcript, and it drops into the existing presence-event machinery for free.

thelounge is the cautionary case worth *not* copying: it renders the line but has no host field on its user model, so its nicklist stays stale — which is the actual operator-facing complaint in #591. We update the stored mask, like weechat's `irc_nick_set_host` and irssi's `nicklist_set_host`.

### extended-join / account-notify (#508)

Same root cause: `ChannelMember` was written once at JOIN and never updated, so there was nowhere for a services account to live. Both caps were already in irc-framework's default want-list — the data was arriving and being discarded. Now `account` is populated from the extended JOIN and kept current via account-notify.

**account-notify is deliberately silent** — nicklist and profile modal only, no channel line. On Libera an identify fires `ACCOUNT` *and* `CHGHOST` back to back, so rendering both would mean two lines per identify in every shared channel. chghost earns its line because it regressed against the no-cap baseline; this never showed anything. halloy and gamja treat ACCOUNT as a pure state update too.

### Where the account shows up

Most clients put it **on the join line**, and that's the surface added here (behind `chat.show_join_account`, default off):

```
-- bob [bobaccount] (~bob@user/bob) joined
```

Prior art: weechat renders ` [account]` in that exact slot under `irc.look.display_extended_join` (default on); irssi has a three-way join format dispatch under `show_extended_join` (default off); thelounge renders it unconditionally in `join.vue`. halloy and gamja are the dissenters, using a hover/header surface instead.

It's also **the one surface where skipping WHOX costs nothing.** The objection to a nicklist badge is that without a backfill most members' accounts are unknown, so it'd be present for some people and absent for others with no way to distinguish "logged out" from "never asked". That doesn't apply to a join line: it exists only for a join event, and extended-join always carries the account for exactly that event. Every join line either has the data or the network lacks the cap — no holes, nothing silently stale.

The setting sits next to `chat.show_event_host` — same audience and same axis, which is how irssi groups them too. Default off so nobody's join lines change without opting in.

Note the profile modal **already** had an Account row fed by WHOIS. The stored account now prefills it, so it's populated the moment the modal opens for anyone who joined while we were watching, instead of waiting on the round trip — same precedence as the existing `awayMessage` fallback.

## Design notes

- **`account` is a tristate**: string (logged in), `null` (server said logged out), `undefined` (never learned). Both falsy states render as nothing today, so this buys nothing on its own — it's kept so a future WHOX backfill can write a correct merge rule instead of clobbering fresher data, the way irssi's `nickrec->account == NULL` guard does. There are **two** wire sentinels (`*` on JOIN/ACCOUNT, `0` on WHOX 354); both normalize at the parse boundary.
- **No WHOX backfill**, by design. extended-join only tells you about people who join while you're watching, so this is event-driven only — nothing is retroactively filled in for members who were already there.
- **New `member-update` frame** patches a single member rather than republishing the whole `names` array (what the existing WHO backfill does). Non-persisted: it describes current state, not history.
- **chghost joins the `QUITS` ignore level and `ALL_TYPES`.** Without the latter, `/ignore nick ALL` would silently fail to hide host-change lines — an ignore leak, since `ALL_TYPES` is a real allowlist.
- **`extractExtras` carries `newIdent`/`newHost`** so the line survives a reload instead of reading "X changed host to @".

## Not in scope

`chghost` is **not** in `CONSOLIDATABLE_TYPES` yet. Worth knowing that's not neutral: an unlisted type *breaks* an in-progress consolidation run, so a chghost between two joins splits one summary line into two — most visible during a netsplit-recovery identify storm. Filed as a follow-up together with mode changes, which aren't consolidated either. halloy and thelounge both include chghost in their condense sets, so this is the known-good end state.

## Testing

New `server/services/chghostWiring.test.ts` — 10 integration tests driving a real `IrcConnection` with emitted wire events: fan-out across shared channels, nicklist mutation, half-mask carry-forward, self-change keeping its server-buffer line while still fanning out, SETNAME correctly ignored (it rides the same event), the account tristate, ACCOUNT staying silent, and account surviving a NAMES rebuild.

Verified these fail against the old handler — 9 of 10 go red when the change is reverted (the tenth is the SETNAME guard, which passed trivially before because the self-guard suppressed everything).

`npm run check` and `npm test` (2645 tests) green.

⚠️ One thing to flag: `server/services/wsHub.push.test.ts` "does not push when a client is visible" failed **once** in an early full-suite run and passed in 7 subsequent runs (4 baseline, plus repeats with this change). The mechanism is a pre-existing race in the test harness — `connectWithPresence` sends the presence frame and waits `setTimeout(0)`, which doesn't reliably cover a real WebSocket round trip under full-suite CPU contention, so the DM can push before presence registers. This diff touches nothing in the push path, but I couldn't prove it innocent statistically and didn't want to bury it. Worth its own fix (await an ack rather than a tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)