### PR TITLE
Fix a load-dependent race in the push presence test

### DIFF
--- a/server/services/wsHub.push.test.ts
+++ b/server/services/wsHub.push.test.ts
@@ -181,27 +181,45 @@ async function payload(): Promise<Record<string, unknown>> {
   return deliverMock.mock.calls[0][1] as Record<string, unknown>;
 }
 
-// Opens a real socket and reports presence, resolving once the server has
-// acknowledged by... nothing — the presence verb has no reply. Waiting for the
-// snapshot proves the socket is registered, and presence is sent after, so a
-// short settle covers the ordering. Returns a closer the test must call, or the
-// socket leaks into the next test's socketsByUser and silently suppresses push.
-async function connectWithPresence(visible: boolean): Promise<() => Promise<void>> {
-  const { token } = createSession(userId);
-  const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error('timed out waiting for snapshot')), 5000);
-    ws.on('message', () => {
+// Resolve on the socket's next inbound frame, or reject on error/timeout.
+function nextMessage(ws: WebSocket, what: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timed out waiting for ${what}`)), 5000);
+    ws.once('message', () => {
       clearTimeout(timer);
       resolve();
     });
-    ws.on('error', (err) => {
+    ws.once('error', (err) => {
       clearTimeout(timer);
       reject(err);
     });
   });
+}
+
+// Opens a real socket and reports presence, resolving only once the server has
+// definitely applied it.
+//
+// The presence verb sends no reply, so there is nothing to await directly. This
+// used to `await settle()` — one macrotask turn — and hope that covered a real
+// WebSocket round trip: send over loopback, server receives, parses, mutates
+// ws.presence. Under full-suite CPU contention that tick can fire first, leaving
+// presence unset, so a DM pushes and the "does not push when a client is
+// visible" test sees true. That was a rare, load-dependent flake.
+//
+// Instead, follow presence with a verb that DOES reply. The socket processes
+// inbound frames in order, so the snapshot coming back proves the presence frame
+// ahead of it was already handled — an ordering guarantee rather than a timing
+// guess, and it can't be outrun by a slow machine.
+//
+// Returns a closer the test must call, or the socket leaks into the next test's
+// socketsByUser and silently suppresses push.
+async function connectWithPresence(visible: boolean): Promise<() => Promise<void>> {
+  const { token } = createSession(userId);
+  const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
+  await nextMessage(ws, 'the connect snapshot');
   ws.send(JSON.stringify({ type: 'presence', visible }));
-  await settle();
+  ws.send(JSON.stringify({ type: 'snapshot' }));
+  await nextMessage(ws, 'the snapshot barrier after presence');
   return () =>
     new Promise<void>((resolve) => {
       ws.on('close', () => resolve());

--- a/server/services/wsHub.push.test.ts
+++ b/server/services/wsHub.push.test.ts
@@ -182,17 +182,24 @@ async function payload(): Promise<Record<string, unknown>> {
 }
 
 // Resolve on the socket's next inbound frame, or reject on error/timeout.
+// Every exit path detaches both listeners and clears the timer — a `once` that
+// never fires stays attached, so resolving via 'message' would otherwise strand
+// the 'error' handler (and a timeout would strand both).
 function nextMessage(ws: WebSocket, what: string): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`timed out waiting for ${what}`)), 5000);
-    ws.once('message', () => {
+    let timer: ReturnType<typeof setTimeout>;
+    function finish(err?: Error) {
       clearTimeout(timer);
-      resolve();
-    });
-    ws.once('error', (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+      if (err) reject(err);
+      else resolve();
+    }
+    const onMessage = () => finish();
+    const onError = (err: Error) => finish(err);
+    timer = setTimeout(() => finish(new Error(`timed out waiting for ${what}`)), 5000);
+    ws.on('message', onMessage);
+    ws.on('error', onError);
   });
 }
 
@@ -212,19 +219,29 @@ function nextMessage(ws: WebSocket, what: string): Promise<void> {
 // guess, and it can't be outrun by a slow machine.
 //
 // Returns a closer the test must call, or the socket leaks into the next test's
-// socketsByUser and silently suppresses push.
+// socketsByUser and silently suppresses push. That's also why the failure path
+// closes the socket itself: if setup throws, the caller never receives the
+// closer, so an un-closed socket would linger as a phantom VISIBLE client and
+// silently suppress push in every later test in this file — turning one real
+// failure into a cascade of misleading ones.
 async function connectWithPresence(visible: boolean): Promise<() => Promise<void>> {
   const { token } = createSession(userId);
   const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
-  await nextMessage(ws, 'the connect snapshot');
-  ws.send(JSON.stringify({ type: 'presence', visible }));
-  ws.send(JSON.stringify({ type: 'snapshot' }));
-  await nextMessage(ws, 'the snapshot barrier after presence');
-  return () =>
+  const close = () =>
     new Promise<void>((resolve) => {
       ws.on('close', () => resolve());
       ws.close();
     });
+  try {
+    await nextMessage(ws, 'the connect snapshot');
+    ws.send(JSON.stringify({ type: 'presence', visible }));
+    ws.send(JSON.stringify({ type: 'snapshot' }));
+    await nextMessage(ws, 'the snapshot barrier after presence');
+  } catch (err) {
+    await close();
+    throw err;
+  }
+  return close;
 }
 
 describe('maybePush gate chain', () => {


### PR DESCRIPTION
Split out from #592, where this flake surfaced. Touches only `wsHub.push.test.ts` — no product code.

## The race

`connectWithPresence` sent the presence frame and awaited `settle()` — a single `setTimeout(0)` — before letting the test proceed.

The presence verb has **no reply** (`wsHub.ts` `case 'presence'` mutates `ws.presence` and breaks), so that tick was standing in for a full WebSocket round trip: send over loopback → server receives → parses → mutates. The helper's own comment admitted it, resolving "once the server has acknowledged by... nothing".

One macrotask turn doesn't reliably cover that. Under full-suite CPU contention the tick fires first, presence is still unset, the DM pushes, and `does not push when a client is visible` sees `true`.

It showed up as roughly one failure in ten full-suite runs and never reproduced in isolation — which is exactly why it needed a mechanism, not a retry.

## The fix

Follow presence with a `snapshot` frame, which *does* reply, and await that instead. The socket processes inbound frames in order, so the snapshot coming back proves the presence frame ahead of it was already handled.

An ordering guarantee rather than a timing guess: nothing to tune, and a slow machine can't outrun it. No new protocol — `case 'snapshot'` already exists.

## Verification

Replacing the barrier with an immediately-resolving `await Promise.resolve()` reproduces the original failure in **exactly** the one test that flaked, and only that test:

```
× does not push when a client is visible 10ms
  Tests  1 failed | 21 passed (22)
```

That pins the diagnosis rather than inferring it. With the barrier restored: 22/22, `npm run check` clean, and three consecutive full-suite runs green (2635 tests).

Worth being straight about the limit of that evidence: at a ~10% reproduction rate, three green full runs don't *prove* the flake is gone. The argument is structural — the timing dependency the failure needed no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)