### PR TITLE
Consolidate chghost alongside join/part/quit

### DIFF
--- a/shared/consolidate.test.ts
+++ b/shared/consolidate.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONSOLIDATABLE_TYPES,
+  consolidateMessages,
+  type ConsolidationGroup,
+  type ConsolidationRow,
+  type ConsolidatableMessage,
+  type NickEntry,
+  type RenameEntry,
+} from './consolidate.js';
+
+let seq = 0;
+function ev(type: string, nick: string, extra: Partial<ConsolidatableMessage> = {}) {
+  seq += 1;
+  return {
+    id: seq,
+    type,
+    nick,
+    time: `2026-07-19T00:00:${String(seq).padStart(2, '0')}Z`,
+    ...extra,
+  };
+}
+
+function isConsolidation(row: unknown): row is ConsolidationRow {
+  return !!row && (row as ConsolidationRow).consolidation === true;
+}
+
+/** The single consolidation row a run is expected to collapse to. */
+function onlyRow(messages: ConsolidatableMessage[], maxNames = 5): ConsolidationRow {
+  const rows = consolidateMessages(messages, { maxNames });
+  expect(rows).toHaveLength(1);
+  expect(isConsolidation(rows[0])).toBe(true);
+  return rows[0] as ConsolidationRow;
+}
+
+/** Groups as a plain `kind → nicks` map, for terse assertions. */
+function summarize(groups: ConsolidationGroup[]): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const g of groups) {
+    out[g.kind] = g.visible.map((v) =>
+      'from' in v ? `${(v as RenameEntry).from}→${(v as RenameEntry).to}` : (v as NickEntry).nick,
+    );
+  }
+  return out;
+}
+
+describe('CONSOLIDATABLE_TYPES', () => {
+  it('covers the presence-noise types and nothing else', () => {
+    expect([...CONSOLIDATABLE_TYPES].toSorted()).toEqual([
+      'chghost',
+      'join',
+      'nick',
+      'part',
+      'quit',
+    ]);
+  });
+
+  // The setter-vs-target problem (#593): a mode line's `nick` is whoever SET
+  // the mode, not who it was applied to, so it can't feed the identity map.
+  it('excludes mode', () => {
+    expect(CONSOLIDATABLE_TYPES.has('mode')).toBe(false);
+  });
+});
+
+describe('baseline join/part/quit/nick consolidation', () => {
+  it('classifies each net effect', () => {
+    const row = onlyRow([
+      ev('join', 'alice'),
+      ev('quit', 'bob'),
+      ev('join', 'carol'),
+      ev('part', 'carol'),
+      ev('quit', 'dave'),
+      ev('join', 'dave'),
+      ev('nick', 'eve', { newNick: 'eve_afk' }),
+    ]);
+    expect(summarize(row.groups)).toEqual({
+      joined: ['alice'],
+      left: ['bob'],
+      reconnected: ['dave'],
+      joinedAndLeft: ['carol'],
+      renamed: ['eve→eve_afk'],
+    });
+  });
+
+  it('passes a lone event through unchanged', () => {
+    const rows = consolidateMessages([ev('join', 'alice')]);
+    expect(rows).toHaveLength(1);
+    expect(isConsolidation(rows[0])).toBe(false);
+  });
+
+  it('breaks runs on a non-consolidatable row', () => {
+    const rows = consolidateMessages([
+      ev('join', 'alice'),
+      ev('join', 'bob'),
+      ev('message', 'carol'),
+      ev('join', 'dave'),
+      ev('join', 'eve'),
+    ]);
+    expect(rows.map(isConsolidation)).toEqual([true, false, true]);
+  });
+
+  it('follows a rename chain through to the final nick', () => {
+    const row = onlyRow([
+      ev('join', 'alice'),
+      ev('nick', 'alice', { newNick: 'alice_' }),
+      ev('nick', 'alice_', { newNick: 'alice__' }),
+      ev('join', 'bob'),
+    ]);
+    // One identity, not three: the joins bucket carries the final display nick.
+    expect(summarize(row.groups)).toEqual({ joined: ['alice__', 'bob'] });
+  });
+});
+
+describe('chghost consolidation (#593)', () => {
+  it('no longer breaks a run', () => {
+    const rows = consolidateMessages([
+      ev('join', 'alice'),
+      ev('chghost', 'alice'),
+      ev('join', 'bob'),
+    ]);
+    expect(rows).toHaveLength(1);
+  });
+
+  // The netsplit-recovery case this issue exists for: rejoins interleaved with
+  // the CHGHOST each user emits as they identify. Must read as a plain "N
+  // joined", with no separate host-change category.
+  it('is transparent when the identity also joined', () => {
+    const row = onlyRow([
+      ev('join', 'alice'),
+      ev('join', 'bob'),
+      ev('chghost', 'alice'),
+      ev('join', 'carol'),
+      ev('chghost', 'bob'),
+      ev('chghost', 'carol'),
+    ]);
+    expect(summarize(row.groups)).toEqual({ joined: ['alice', 'bob', 'carol'] });
+  });
+
+  it('is transparent for an identity that left', () => {
+    const row = onlyRow([ev('chghost', 'alice'), ev('quit', 'alice'), ev('join', 'bob')]);
+    expect(summarize(row.groups)).toEqual({ joined: ['bob'], left: ['alice'] });
+  });
+
+  it('gets its own category only when nothing else happened', () => {
+    const row = onlyRow([ev('chghost', 'alice'), ev('chghost', 'bob')]);
+    expect(summarize(row.groups)).toEqual({ rehosted: ['alice', 'bob'] });
+  });
+
+  it('collapses repeated host changes for one nick into a single entry', () => {
+    const row = onlyRow([ev('chghost', 'alice'), ev('chghost', 'alice'), ev('chghost', 'bob')]);
+    expect(summarize(row.groups)).toEqual({ rehosted: ['alice', 'bob'] });
+  });
+
+  it('prefers the rename when an identity both renamed and rehosted', () => {
+    const row = onlyRow([
+      ev('nick', 'alice', { newNick: 'alice_' }),
+      ev('chghost', 'alice_'),
+      ev('chghost', 'bob'),
+    ]);
+    expect(summarize(row.groups)).toEqual({ renamed: ['alice→alice_'], rehosted: ['bob'] });
+  });
+
+  it('still renders a lone chghost as its own row', () => {
+    const rows = consolidateMessages([ev('chghost', 'alice')]);
+    expect(rows).toHaveLength(1);
+    expect(isConsolidation(rows[0])).toBe(false);
+  });
+
+  it('folds host changes into an identity tracked across a rename', () => {
+    const row = onlyRow([
+      ev('join', 'alice'),
+      ev('nick', 'alice', { newNick: 'alice_' }),
+      ev('chghost', 'alice_'),
+      ev('join', 'bob'),
+    ]);
+    expect(summarize(row.groups)).toEqual({ joined: ['alice_', 'bob'] });
+  });
+
+  it('caps and counts rehosted nicks like any other category', () => {
+    const row = onlyRow(
+      ['a', 'b', 'c', 'd'].map((n) => ev('chghost', n)),
+      2,
+    );
+    expect(row.groups).toHaveLength(1);
+    expect(row.groups[0]).toMatchObject({ kind: 'rehosted', hidden: 2 });
+    expect(row.groups[0].visible).toHaveLength(2);
+  });
+});

--- a/shared/consolidate.test.ts
+++ b/shared/consolidate.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   CONSOLIDATABLE_TYPES,
@@ -13,7 +13,14 @@ import {
   type RenameEntry,
 } from './consolidate.js';
 
+// Ids and timestamps just need to be unique and ascending *within* a test —
+// nothing here asserts on their values. Reset per test so a case's fixtures
+// don't shift when one is added above it.
 let seq = 0;
+beforeEach(() => {
+  seq = 0;
+});
+
 function ev(type: string, nick: string, extra: Partial<ConsolidatableMessage> = {}) {
   seq += 1;
   return {

--- a/shared/consolidate.ts
+++ b/shared/consolidate.ts
@@ -26,7 +26,7 @@
 //      'H' is deliberately transparent to the J|L scan (#593). Post-netsplit
 //      each rejoining user emits JOIN then CHGHOST as they identify, so their
 //      sequence is [J, H]; that must read as a plain "joined" rather than
-//      splitting the summary into "N joined" plus "N changed hostname". The
+//      splitting the summary into "N joined" plus "N changed host". The
 //      host change only earns its own category when nothing else happened.
 //   4. A run of exactly one event is passed through unchanged (so a lone
 //      "Alice joined" still renders with the familiar --> styling).
@@ -129,7 +129,7 @@ const CONSOLIDATABLE_TYPES: ReadonlySet<string> = new Set([
 function classify(actions: readonly EventAction[]): ConsolidationKind {
   const jl = actions.filter((a) => a === 'J' || a === 'L');
   // No presence change: a rename outranks a rehost, since "alice → bob" says
-  // more than "alice changed hostname" for an identity that did both.
+  // more than "alice changed host" for an identity that did both.
   if (jl.length === 0) return actions.includes('R') ? 'renamed' : 'rehosted';
   const first = jl[0];
   const last = jl[jl.length - 1];

--- a/shared/consolidate.ts
+++ b/shared/consolidate.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// Consolidation of join/part/quit/nick "noise" events into a per-identity
+// Consolidation of join/part/quit/nick/chghost "noise" events into a per-identity
 // net effect, IRCCloud-style. Pure, side-effect-free, no DOM/Vue deps — safe
 // to import from the Vue renderer, the Node demo script, and tests.
 //
@@ -13,13 +13,21 @@
 //        'J' = join
 //        'L' = leave (part or quit)
 //        'R' = rename (this identity changed nick)
+//        'H' = rehost (chghost; ident and/or host changed)
 //      Renames transfer the identity to the new key so we follow the chain.
 //   3. Classify by the first/last J|L action:
 //        first=L, last=J → reconnected     (was present; left and came back)
 //        first=L, last=L → left            (was present; net result: gone)
 //        first=J, last=J → joined          (was absent; net result: present)
 //        first=J, last=L → joinedAndLeft   (was absent; net result: gone)
-//      Identities with only 'R' actions are categorized as renamed.
+//      Identities with no J|L action fall back to rename over rehost:
+//      any 'R' → renamed, else 'H' only → rehosted.
+//
+//      'H' is deliberately transparent to the J|L scan (#593). Post-netsplit
+//      each rejoining user emits JOIN then CHGHOST as they identify, so their
+//      sequence is [J, H]; that must read as a plain "joined" rather than
+//      splitting the summary into "N joined" plus "N changed hostname". The
+//      host change only earns its own category when nothing else happened.
 //   4. A run of exactly one event is passed through unchanged (so a lone
 //      "Alice joined" still renders with the familiar --> styling).
 
@@ -45,13 +53,22 @@ export interface MessageStreamRow {
   key: string | number;
 }
 
-/** Per-identity action within a run: join, leave (part/quit), or rename. */
-type EventAction = 'J' | 'L' | 'R';
+/**
+ * Per-identity action within a run: join, leave (part/quit), rename, or
+ * rehost (chghost).
+ */
+type EventAction = 'J' | 'L' | 'R' | 'H';
 
-/** The five ways a run's net effect on an identity can be classified. */
-export type ConsolidationKind = 'joined' | 'left' | 'reconnected' | 'joinedAndLeft' | 'renamed';
+/** The six ways a run's net effect on an identity can be classified. */
+export type ConsolidationKind =
+  | 'joined'
+  | 'left'
+  | 'reconnected'
+  | 'joinedAndLeft'
+  | 'renamed'
+  | 'rehosted';
 
-/** A nick that joined / left / reconnected within the run. */
+/** A nick that joined / left / reconnected / rehosted within the run. */
 export interface NickEntry {
   nick: string;
 }
@@ -69,7 +86,7 @@ export interface ConsolidationGroup {
   hidden: number;
 }
 
-/** Synthetic row that replaces a run of consolidated join/part/quit/nick rows. */
+/** Synthetic row that replaces a run of consolidated presence-noise rows. */
 export interface ConsolidationRow {
   consolidation: true;
   groups: ConsolidationGroup[];
@@ -101,11 +118,19 @@ interface RunOptions {
 
 // ─── Algorithm ─────────────────────────────────────────────────────────────
 
-const CONSOLIDATABLE_TYPES: ReadonlySet<string> = new Set(['join', 'part', 'quit', 'nick']);
+const CONSOLIDATABLE_TYPES: ReadonlySet<string> = new Set([
+  'join',
+  'part',
+  'quit',
+  'nick',
+  'chghost',
+]);
 
 function classify(actions: readonly EventAction[]): ConsolidationKind {
   const jl = actions.filter((a) => a === 'J' || a === 'L');
-  if (jl.length === 0) return 'renamed';
+  // No presence change: a rename outranks a rehost, since "alice → bob" says
+  // more than "alice changed hostname" for an identity that did both.
+  if (jl.length === 0) return actions.includes('R') ? 'renamed' : 'rehosted';
   const first = jl[0];
   const last = jl[jl.length - 1];
   const wasPresent = first === 'L';
@@ -195,6 +220,7 @@ function consolidateRun(
       }
       if (e.type === 'join') state.actions.push('J');
       else if (e.type === 'part' || e.type === 'quit') state.actions.push('L');
+      else if (e.type === 'chghost') state.actions.push('H');
     }
   }
 
@@ -206,6 +232,7 @@ function consolidateRun(
     reconnected: [],
     joinedAndLeft: [],
     renamed: [],
+    rehosted: [],
   };
   const sorted = Array.from(ids.values()).toSorted((a, b) => a.seenIndex - b.seenIndex);
   for (const id of sorted) {
@@ -225,6 +252,7 @@ function consolidateRun(
     'reconnected',
     'joinedAndLeft',
     'renamed',
+    'rehosted',
   ];
   const groups: ConsolidationGroup[] = [];
   for (const kind of groupOrder) {

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -721,8 +721,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     max: 50,
     default: 5,
     description:
-      'In each category (joined / left / reconnected / renamed / changed ' +
-      'hostname) of a summary ' +
+      'In each category (joined / left / reconnected / renamed / changed host) of a summary ' +
       'line, show at most this many nicks before collapsing the rest into ' +
       '"and N others". Recent speakers (those tracked for nick completion) ' +
       'are preferred when picking which names to show.',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -700,13 +700,13 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   // ─── Join/part consolidation (IRCCloud-style summary line) ────────────
   {
     key: 'chat.consolidate_joins',
-    label: 'Consolidate join/part/quit/nick events',
+    label: 'Consolidate join/part/quit/nick/host-change events',
     category: 'chat',
     group: 'consolidate',
     type: 'bool',
     default: true,
     description:
-      'Merge consecutive join/part/quit/nick events into a single summary line ' +
+      'Merge consecutive join/part/quit/nick/host-change events into a single summary line ' +
       'per nick (e.g. "Alice and Bob joined; Dave left; Eve → Eve_afk"). ' +
       'Off shows every event individually. Composes with smart filter — events ' +
       'the smart filter hides are excluded from the summary.',
@@ -721,7 +721,8 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     max: 50,
     default: 5,
     description:
-      'In each category (joined / left / reconnected / renamed) of a summary ' +
+      'In each category (joined / left / reconnected / renamed / changed ' +
+      'hostname) of a summary ' +
       'line, show at most this many nicks before collapsing the rest into ' +
       '"and N others". Recent speakers (those tracked for nick completion) ' +
       'are preferred when picking which names to show.',

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -81,7 +81,7 @@
             ><template v-else-if="g.kind === 'left'"> left</template
             ><template v-else-if="g.kind === 'reconnected'"> reconnected</template
             ><template v-else-if="g.kind === 'joinedAndLeft'"> joined briefly</template
-            ><template v-else-if="g.kind === 'rehosted'"> changed hostname</template></template
+            ><template v-else-if="g.kind === 'rehosted'"> changed host</template></template
           >
         </span>
       </div>

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -80,7 +80,8 @@
             ><template v-if="g.kind === 'joined'"> joined</template
             ><template v-else-if="g.kind === 'left'"> left</template
             ><template v-else-if="g.kind === 'reconnected'"> reconnected</template
-            ><template v-else-if="g.kind === 'joinedAndLeft'"> joined briefly</template></template
+            ><template v-else-if="g.kind === 'joinedAndLeft'"> joined briefly</template
+            ><template v-else-if="g.kind === 'rehosted'"> changed hostname</template></template
           >
         </span>
       </div>
@@ -1142,7 +1143,7 @@ const renderRows = computed((): RenderRow[] => {
   // the divider at the end so the user still sees an undo affordance.
   if (!clearedInserted) pushClearedDivider();
 
-  // Final pass: merge consecutive join/part/quit/nick rows into a single
+  // Final pass: merge consecutive join/part/quit/nick/chghost rows into a single
   // summary row when consolidation is enabled. Dividers break runs (we want
   // the away/back/unread markers to land between events, not get swallowed
   // by a multi-event group). Recent speakers come from the same `speakers`


### PR DESCRIPTION
Closes #593.

## The bug

An unlisted type doesn't just render standalone — it **terminates an in-progress consolidation run** via `flush()` (`shared/consolidate.ts`). So a single chghost landing between two joins split what would have been one summary row into three.

The case this matters for is netsplit recovery, where a burst of rejoins is interleaved with the CHGHOST each user emits as they identify. `ACCOUNT` is already deliberately silent (nicklist-only, `ircConnection.ts:1276-1294`), so CHGHOST was the sole remaining fragmenter — and enough on its own to turn a clean "N users joined" into a wall.

## Approach: chghost is transparent, not a headline

Post-netsplit each identity's action sequence is `[J, H]`. Rather than give chghost a bucket of its own, `'H'` is invisible to `classify()`'s J|L scan, so that run reads as a plain "N joined" — nobody wants "3 users joined · 3 users changed host" when the host change is exactly the noise consolidation exists to eat.

The `rehosted` category only appears when nothing else happened to that identity, and a rename outranks a rehost when one identity did both ("alice → alice_" says more than "alice changed host").

A lone chghost still renders as today's line via the `run.length === 1` passthrough, so #591/#592 rendering is untouched.

## Tests

This adds the module's **first test file** — `shared/consolidate.ts` had none. It covers the pre-existing join/part/quit/nick behavior as well as the new type, so the baseline is pinned going forward. Verified non-vacuous: 9 of the 15 fail against the pre-change source.

Manually QA'd on a live network: a run of `qa` joins / `qa2` joins / `qa2` chghost / `qa2` parts / `qa2` rejoins collapses to a single "amiantos|qa and amiantos|qa2 joined" row, where on `main` the chghost split it into three. Note this exercises the *transparent* path; the `rehosted` category, its "and N others" cap, and a mixed `renamed; rehosted` row are unit-tested but haven't been eyeballed.

## `mode` is deliberately excluded

There's a test pinning this. Two reasons, both in #593 at length:

- **It doesn't fit the identity model.** A mode line's `nick` is whoever *set* the mode; the affected user is in `modes[].param`. Feeding it to `consolidateRun()` as-is buckets ChanServ, not the user who got opped.
- **The prior art doesn't support it.** All six reference clients checked; 5 of 6 exclude mode (gamja, halloy, irssi, repartee, weechat). thelounge is the lone yes, and only because its summary is a nick-less integer counter ("5 modes were set") — it sidesteps the attribution problem rather than solving it.

The genuinely useful mode feature in that survey is weechat's `irc.look.smart_filter_mode` (a *string*, default `"+"` = PREFIX modes only) — a **filter**, not a collapse, which belongs near the existing `MODES` ignore level. Deferred to its own card.

## Checks

`npm run check` clean; `npm test` 2671 passed / 204 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)