### PR TITLE
Honor chat.allow_split_messages at every message count

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -772,9 +772,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'Allow long messages to send as multiple consecutive IRC lines without ' +
       'confirmation. When off (the default), trying to send a message that ' +
       "would split shows a SPLIT warning in the status bar and won't submit " +
-      'until you press Send a second time. Messages that would split into ' +
-      'three or more lines always require confirmation regardless of this ' +
-      'setting. /me actions never split — they are blocked outright.',
+      'until you press Send a second time; one that would split into three or ' +
+      'more offers to upload the text as a file instead. /me actions never ' +
+      'split — they are blocked outright regardless of this setting.',
   },
   {
     key: 'chat.send_typing_notifications',

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -174,6 +174,7 @@ import {
   chunkCountForSay,
   chunkCountForAction,
   multilineMessageCount,
+  splitGateFor,
   type MultilineLimits,
 } from '../utils/messageSplit.js';
 import { applySpoilerMarkup } from '../utils/spoilerMarkup.js';
@@ -1579,6 +1580,21 @@ function onHistorySelect(entry: string): void {
 }
 
 function onInput() {
+  // These two run AHEAD of the `cycling` guard: they're facts about the text
+  // itself, not about who wrote it, so they have to hold for programmatic
+  // rewrites (history recall, completion, emoji/URL insert) too.
+  //
+  // Any change to the body invalidates the "second press confirms" override —
+  // otherwise the user could be holding a flood-confirm token from an entirely
+  // different draft. That was live: setInputAndCaretEnd holds `cycling` across
+  // a microtask, so recalling a long line from history after a confirm-armed
+  // Send used to send it with no gate at all. Cheap to clear unconditionally.
+  pendingSplitConfirm = false;
+  // Republish composing state on every change so StatusBar's SPLIT/FLOOD
+  // indicator stays live — a recalled line has to re-estimate too. We do this
+  // even on :server: buffers and slash commands (computeChunks handles both —
+  // most return 0 chunks).
+  publishComposing(text.value);
   if (cycling) return;
   // User edited the recalled line — exit walk mode but keep what they typed.
   // Done before the sendable gate so this still fires on :server: buffers
@@ -1588,14 +1604,6 @@ function onInput() {
   // must fire before the sendable gate so it also closes on :server: buffers
   // (editable but not "sendable"), where the menu can be open over /raw history.
   closeHistoryPicker();
-  // Any edit invalidates the "second press confirms" override — otherwise the
-  // user could be holding a flood-confirm token from an entirely different
-  // draft. Cheap to clear unconditionally.
-  pendingSplitConfirm = false;
-  // Republish composing state on every keystroke so StatusBar's SPLIT/FLOOD
-  // indicator stays live. We do this even on :server: buffers and slash
-  // commands (computeChunks handles both — most return 0 chunks).
-  publishComposing(text.value);
   if (!sendable.value || !active.value) return;
   if (completion) resetCompletion();
   // Inline-convert a just-completed `:shortcode:`, then refresh the suggester
@@ -1934,12 +1942,11 @@ async function submit() {
     return;
   }
   if (count > 1) {
-    const flood = count >= 3;
     const allowSplit = !!settings.effective('chat.allow_split_messages');
-    const blocked = flood || !allowSplit;
-    if (blocked && !pendingSplitConfirm) {
+    const gate = splitGateFor({ count, allowSplit, confirmed: pendingSplitConfirm });
+    if (gate !== 'send') {
       pendingSplitConfirm = true;
-      if (flood) {
+      if (gate === 'upload') {
         // 3+ messages: offer the upload-as-.txt modal. If they cancel, the
         // already-set pendingSplitConfirm makes the next Send press the
         // override (matching the prior send-again-to-confirm behavior).
@@ -1948,14 +1955,13 @@ async function submit() {
         longMessageMultiline.value = multiline;
         longMessageModalOpen.value = true;
       } else {
-        // 2 messages with chat.allow_split_messages=off: keep the existing
-        // toast confirmation — uploading would be overkill for a two-message
-        // send.
+        // 2 messages: the cheap toast confirmation — uploading would be
+        // overkill for a two-message send.
         toasts.push({
           title: multiline
             ? `Will send as ${count} messages — Send again to confirm`
             : `Will split into ${count} lines — Send again to confirm`,
-          body: 'Enable "Allow auto-split messages" in Settings to send splits without confirming.',
+          body: 'Enable "Allow long messages to split" in Settings to send splits without confirming.',
           kind: 'warn',
           ttlMs: 7000,
         });

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -189,12 +189,12 @@ const auth = useAuthStore();
 const nickColors = useNickColors();
 const composing = useComposing();
 
-// SPLIT (warn) at 2 chunks, FLOOD (bad) at 3+. Lives just before the typing
-// indicator so heavy composers can see it without taking their eyes off the
-// input. Empty / single-chunk drafts render nothing. On a multiline network
-// `composing.chunks` is the batch (message) count: 1 → a neutral MULTILINE
-// chip (lands as one logical message), 2 → MULTILINE ×2 (warn), 3+ →
-// MULTILINE ×N (bad, where the upload-as-.txt gate kicks in). (#381)
+// SPLIT at 2 chunks, FLOOD (n) at 3+. Lives just before the typing indicator so
+// heavy composers can see it without taking their eyes off the input. Empty /
+// single-chunk drafts render nothing. On a multiline network `composing.chunks`
+// is the batch (message) count: 1 → MULTILINE (lands as one logical message),
+// 2+ → MULTILINE ×N. (#381) The label always states what will happen; see
+// splitClass below for when that's coloured as a warning.
 const splitLabel = computed(() => {
   if (composing.multiline) {
     return composing.chunks <= 1 ? 'MULTILINE' : `MULTILINE ×${composing.chunks}`;
@@ -203,14 +203,20 @@ const splitLabel = computed(() => {
   if (composing.isAction) return 'ACTION TOO LONG';
   return composing.chunks >= 3 ? `FLOOD (${composing.chunks})` : 'SPLIT';
 });
+// Severity is about whether the send will be INTERRUPTED, not about length. With
+// chat.allow_split_messages on, a split just goes out — so the chip stays as a
+// neutral count rather than crying wolf in warn/bad on every long message
+// (#578). An overlong /me is still bad: actions never split, they're refused.
 const splitClass = computed(() => {
   if (composing.multiline) {
-    if (composing.chunks >= 3) return 'bad';
-    return composing.chunks === 2 ? 'warn' : '';
+    if (composing.chunks <= 1) return '';
+    if (settings.effective('chat.allow_split_messages')) return '';
+    return composing.chunks >= 3 ? 'bad' : 'warn';
   }
   if (composing.chunks <= 1) return '';
-  if (composing.isAction || composing.chunks >= 3) return 'bad';
-  return 'warn';
+  if (composing.isAction) return 'bad';
+  if (settings.effective('chat.allow_split_messages')) return '';
+  return composing.chunks >= 3 ? 'bad' : 'warn';
 });
 
 // Narrate the leg the upload is ACTUALLY on (#545). A percentage appears only where

--- a/vue_client/src/utils/messageSplit.test.ts
+++ b/vue_client/src/utils/messageSplit.test.ts
@@ -6,6 +6,7 @@ import {
   chunkCountForSay,
   chunkCountForAction,
   multilineMessageCount,
+  splitGateFor,
   MESSAGE_MAX_BYTES,
   ACTION_MAX_BYTES,
 } from './messageSplit.js';
@@ -82,6 +83,37 @@ describe('chunkCountForAction', () => {
 
   it('returns 0 for empty', () => {
     expect(chunkCountForAction('')).toBe(0);
+  });
+});
+
+describe('splitGateFor', () => {
+  const gate = (count: number, allowSplit: boolean, confirmed = false) =>
+    splitGateFor({ count, allowSplit, confirmed });
+
+  it('sends anything that fits one message', () => {
+    for (const count of [0, 1]) {
+      expect(gate(count, false)).toBe('send');
+      expect(gate(count, true)).toBe('send');
+    }
+  });
+
+  it('confirms 2 and offers upload at 3+ when splitting is off', () => {
+    expect(gate(2, false)).toBe('confirm');
+    expect(gate(3, false)).toBe('upload');
+    expect(gate(50, false)).toBe('upload');
+  });
+
+  // The #578 regression: `flood || !allowSplit` short-circuited, so the modal
+  // opened at 3+ no matter what the user had set.
+  it('sends at every size when splitting is allowed', () => {
+    expect(gate(2, true)).toBe('send');
+    expect(gate(3, true)).toBe('send');
+    expect(gate(50, true)).toBe('send');
+  });
+
+  it('lets a prior confirmation override the gate', () => {
+    expect(gate(2, false, true)).toBe('send');
+    expect(gate(50, false, true)).toBe('send');
   });
 });
 

--- a/vue_client/src/utils/messageSplit.ts
+++ b/vue_client/src/utils/messageSplit.ts
@@ -99,6 +99,27 @@ export function chunkCountForAction(text: string | null | undefined): number {
   return chunksForLine(text, ACTION_MAX_BYTES);
 }
 
+// What the composer should do with a draft that spans more than one message.
+// 'send' goes straight out; 'confirm' shows the send-again toast; 'upload'
+// offers the upload-as-.txt modal. `confirmed` carries the second-press
+// override from a previous Send on the same draft.
+//
+// chat.allow_split_messages is honoured at EVERY size: a user who turned it on
+// asked for splits to go out silently, so gating the 3+ tier anyway made the
+// setting look broken (#578). With it off, 2 messages get the cheap toast and
+// 3+ get the modal, since uploading is only worth offering for a real flood.
+export type SplitGate = 'send' | 'confirm' | 'upload';
+
+export function splitGateFor(opts: {
+  count: number;
+  allowSplit: boolean;
+  confirmed: boolean;
+}): SplitGate {
+  const { count, allowSplit, confirmed } = opts;
+  if (count <= 1 || allowSplit || confirmed) return 'send';
+  return count >= 3 ? 'upload' : 'confirm';
+}
+
 export interface MultilineLimits {
   maxBytes: number;
   maxLines: number;


### PR DESCRIPTION
Fixes #578.

## The bug

`MessageInput.vue` computed the send gate as:

```ts
const flood = count >= 3;
const blocked = flood || !allowSplit;
```

`flood ||` short-circuits, so any draft splitting into 3+ messages opened the upload-as-.txt modal regardless of the setting. That's exactly the tier you hit when trying to send a flood, so `/set chat.allow_split_messages on` looked completely dead — it only ever suppressed the 2-message toast.

The registry description did document the carve-out ("Messages that would split into three or more lines always require confirmation regardless of this setting"), so this was intentional-as-written. But the label promises the opposite, and a client that second-guesses a setting literally named "Allow long messages to split" is just wrong. Now it's honored at every size.

Behavior with the setting **off** is unchanged: 2 messages → send-again toast, 3+ → upload modal.

## Also in here

- **Toast named a setting that doesn't exist.** It said to enable *"Allow auto-split messages"*; the real label is *"Allow long messages to split"*, so searching settings for the quoted string found nothing.
- **Registry description** drops the stale 3+ carve-out sentence.
- **Status chip** keeps SPLIT / FLOOD (n) / MULTILINE ×N when splitting is allowed, but renders neutral instead of warn/bad — the send won't be interrupted, so colouring it cried wolf on every long message. An overlong `/me` stays `bad`: actions never split, they're refused outright.
- **`pendingSplitConfirm` stale-token bug.** `onInput` bails early on the `cycling` guard, and `setInputAndCaretEnd` deliberately holds that flag across a microtask — so recalling a long line from history after a confirm-armed Send fired it with no gate at all. That's precisely the "flood-confirm token from an entirely different draft" the existing comment claimed to prevent. Clearing the token and republishing the composing estimate now run *ahead* of the guard: they're facts about the text, not about who wrote it. Fixes the status chip going stale after a history recall too.

## Notes

The gate decision moved into a pure `splitGateFor()` in `utils/messageSplit.ts` so it's testable — the logic previously lived inline in `submit()`, which is why nothing covered it. New unit tests pin all four tiers plus the confirm override.

Nothing about actual wire splitting changed; that's server-side and was never gated by this setting.

## Testing

`npm run check` and `npm test` both pass (204 files, 2675 tests). The gate itself is covered by new tests; the history-recall path and the chip colour are UI behavior I have not driven in a browser — worth a manual pass when you next dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)