### PR TITLE
Fix two uploader URL-shape bugs (#582, #589)

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -216,8 +216,10 @@ If you expose Lurker through Cloudflare (including a [Cloudflare Tunnel](#exposi
 
 Fix it in the Cloudflare dashboard under **Scrape Shield → Hotlink Protection → Off**. If you want to keep it on for the rest of your site, leave it enabled and add a **Configuration Rule** that turns it off just for your uploads:
 
-- **When incoming requests match:** `URI Path` `starts with` `/uploads/local/`
+- **When incoming requests match:** `URI Path` `starts with` `/uploads/`
 - **Then the settings are:** `Hotlink Protection` → `Off`
+
+If you set this rule up before Lurker 1.0 it will say `/uploads/local/`. Uploads now live directly under `/uploads/`, so widen it — the shorter prefix still matches the old links, which keep working.
 
 See [Uploaded images are broken for other people](#uploaded-images-are-broken-for-other-people-403) if you've already hit this.
 :::
@@ -366,14 +368,14 @@ Confirm it with two `curl`s against the same URL, where the _only_ difference is
 ```bash
 # 1. No referer → 200, and Lurker serves the image
 curl -sS -o /dev/null -D - \
-  https://lurker.example.com/uploads/local/<key>.<ext> \
+  https://lurker.example.com/uploads/<key>.<ext> \
   | grep -iE '^HTTP/|^content-type:'
 #   HTTP/2 200
 #   content-type: image/webp     ← or image/jpeg, depending on the upload
 
 # 2. Cross-domain referer → 403, and your image never gets served
 curl -sS -o /dev/null -D - -H 'Referer: https://example.org/' \
-  https://lurker.example.com/uploads/local/<key>.<ext> \
+  https://lurker.example.com/uploads/<key>.<ext> \
   | grep -iE '^HTTP/|^content-type:|^vary:'
 #   HTTP/2 403
 #   content-type: text/plain; charset=UTF-8
@@ -384,7 +386,7 @@ If adding a `Referer` is all it takes to flip a `200` into a `403`, that's Hotli
 
 > Don't try to tell the two apart by looking for `server: cloudflare` — Cloudflare proxies the _successful_ response too, so that header is on both. The status flip is the signal.
 
-Turn Hotlink Protection off (or scope it around `/uploads/local/`) — see [File uploads on your own disk](#file-uploads-on-your-own-disk).
+Turn Hotlink Protection off (or scope it around `/uploads/`) — see [File uploads on your own disk](#file-uploads-on-your-own-disk).
 
 ### Container logs
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -84,7 +84,14 @@ export function buildApp(sessionSecret: string): Express {
   // Self-host only — the `local` driver isn't offered on the (ephemeral) hosted
   // fleet, so the route would only ever 404 there; don't expose it at all.
   if (!isNodeMode()) {
+    // /uploads/local was the original mount (#582 dropped the redundant segment).
+    // It stays mounted forever as an alias: upload_history.url stores the fully
+    // absolutized link and nothing reparses it, so every link already pasted into
+    // IRC — including ones read by other clients we can't rewrite — still resolves.
+    // The two-segment path can't match the new mount's single-segment '/:key', so
+    // order between them doesn't matter.
     app.use('/uploads/local', localUploadsRouter);
+    app.use('/uploads', localUploadsRouter);
   }
   app.use('/api/dcc', dccRouter);
   app.use('/api/drafts', draftsRouter);

--- a/server/routes/localUploads.integration.test.ts
+++ b/server/routes/localUploads.integration.test.ts
@@ -45,7 +45,7 @@ beforeAll(async () => {
   if (!localRow) throw new Error('expected the seeded self-host local uploader row');
   setUserSetting(user.id, 'uploads.uploader_id', localRow.id);
 
-  app = createTestApp({ '/api/uploads': uploadsRouter, '/uploads/local': localRouter });
+  app = createTestApp({ '/api/uploads': uploadsRouter, '/uploads': localRouter });
   agent = await createAuthedAgent(app, user.id);
 
   smallPng = await sharp({
@@ -73,12 +73,12 @@ describe('local uploader — full round trip', () => {
     expect(up.status).toBe(200);
     // Absolutized against the forwarded origin, pointing at our serve route.
     expect(up.body.url).toMatch(
-      /^https:\/\/irc\.example\.com\/uploads\/local\/[0-9a-f]{12}\.(png|jpe?g|webp)$/,
+      /^https:\/\/irc\.example\.com\/uploads\/[0-9a-f]{12}\.(png|jpe?g|webp)$/,
     );
 
     // The image was optimized to JPEG by the pipeline and written to disk (under
     // its shard subdir).
-    const servePath = new URL(up.body.url).pathname; // /uploads/local/<key>
+    const servePath = new URL(up.body.url).pathname; // /uploads/<key>
     const key = servePath.split('/').pop()!;
     expect(fs.existsSync(local.resolveDiskPath(key))).toBe(true);
 

--- a/server/routes/localUploads.test.ts
+++ b/server/routes/localUploads.test.ts
@@ -20,14 +20,16 @@ const prevEnv = process.env.LOCAL_UPLOADS_DIR;
 // Write a buffer through the real driver and return the served path.
 async function put(buffer: Buffer, filename: string, mime: string): Promise<string> {
   const res = await local.upload(bufferSource(buffer), { filename, mime }, {});
-  return res.url; // /uploads/local/<key>
+  return res.url; // /uploads/<key>
 }
 
 beforeAll(async () => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-localserve-'));
   process.env.LOCAL_UPLOADS_DIR = dir;
   const router = (await import('./localUploads.js')).default;
-  app = createTestApp({ '/uploads/local': router });
+  // Both mounts, mirroring app.ts: the current path plus the legacy alias that
+  // keeps pre-#582 links alive.
+  app = createTestApp({ '/uploads': router, '/uploads/local': router });
   agent = createAnonAgent(app);
 });
 
@@ -37,7 +39,7 @@ afterAll(() => {
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
-describe('GET /uploads/local/:key', () => {
+describe('GET /uploads/:key', () => {
   it('serves a recognized image inline with hardened headers', async () => {
     const png = await sharp({
       create: { width: 8, height: 8, channels: 3, background: { r: 0, g: 128, b: 255 } },
@@ -121,13 +123,32 @@ describe('GET /uploads/local/:key', () => {
   it('404s an invalid key without touching the filesystem', async () => {
     const bad = ['../../etc/passwd', 'not-a-key', 'a1b2c3d4e5f6', 'ABCDEF012345.png'];
     for (const k of bad) {
-      const res = await agent.get(`/uploads/local/${encodeURIComponent(k)}`);
+      const res = await agent.get(`/uploads/${encodeURIComponent(k)}`);
       expect(res.status).toBe(404);
     }
   });
 
   it('404s a well-formed key with no file on disk', async () => {
-    const res = await agent.get('/uploads/local/0123456789ab.png');
+    const res = await agent.get('/uploads/0123456789ab.png');
     expect(res.status).toBe(404);
+  });
+
+  // #582 shortened the minted path, but upload_history stores absolutized URLs
+  // that nothing rewrites — so every link shared before the change must still
+  // resolve, including ones pasted into IRC and read by other clients.
+  it('still serves the same file through the legacy /uploads/local alias', async () => {
+    const png = await sharp({
+      create: { width: 8, height: 8, channels: 3, background: { r: 9, g: 9, b: 9 } },
+    })
+      .png()
+      .toBuffer();
+    const url = await put(png, 'legacy.png', 'image/png');
+    expect(url.startsWith('/uploads/')).toBe(true);
+    expect(url.startsWith('/uploads/local/')).toBe(false);
+
+    const key = url.slice('/uploads/'.length);
+    const res = await agent.get(`/uploads/local/${key}`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/png');
   });
 });

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -237,7 +237,7 @@ describe('POST /api/uploads', () => {
 describe('local-style (storesRemotely:false) uploads', () => {
   it('absolutizes a relative driver URL against the request origin', async () => {
     stub.capabilities.storesRemotely = false;
-    stub.nextResult = { url: '/uploads/local/abcdef012345.png', ref: 'abcdef012345.png' };
+    stub.nextResult = { url: '/uploads/abcdef012345.png', ref: 'abcdef012345.png' };
     try {
       const res = await agent
         .post('/api/uploads')
@@ -245,12 +245,12 @@ describe('local-style (storesRemotely:false) uploads', () => {
         .set('X-Forwarded-Host', 'irc.example.com')
         .attach('image', smallPng, { filename: 'local.png', contentType: 'image/png' });
       expect(res.status).toBe(200);
-      expect(res.body.url).toBe('https://irc.example.com/uploads/local/abcdef012345.png');
+      expect(res.body.url).toBe('https://irc.example.com/uploads/abcdef012345.png');
 
       // The absolutized URL — not the relative one — is what gets persisted.
       const list = await agent.get('/api/uploads');
       const row = list.body.items.find((r: { id: number }) => r.id === res.body.id);
-      expect(row.url).toBe('https://irc.example.com/uploads/local/abcdef012345.png');
+      expect(row.url).toBe('https://irc.example.com/uploads/abcdef012345.png');
     } finally {
       stub.capabilities.storesRemotely = true;
       stub.nextResult = null;
@@ -259,7 +259,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
 
   it('ignores a spoofed non-http(s) X-Forwarded-Proto', async () => {
     stub.capabilities.storesRemotely = false;
-    stub.nextResult = { url: '/uploads/local/ccddeeff0011.png', ref: 'ccddeeff0011.png' };
+    stub.nextResult = { url: '/uploads/ccddeeff0011.png', ref: 'ccddeeff0011.png' };
     try {
       const res = await agent
         .post('/api/uploads')
@@ -268,7 +268,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
         .attach('image', smallPng, { filename: 'x.png', contentType: 'image/png' });
       expect(res.status).toBe(200);
       // The bogus scheme is dropped; never javascript://.
-      expect(res.body.url).toBe('https://irc.example.com/uploads/local/ccddeeff0011.png');
+      expect(res.body.url).toBe('https://irc.example.com/uploads/ccddeeff0011.png');
     } finally {
       stub.capabilities.storesRemotely = true;
       stub.nextResult = null;
@@ -277,7 +277,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
 
   it('leaves the URL relative when the forwarded host is malformed', async () => {
     stub.capabilities.storesRemotely = false;
-    stub.nextResult = { url: '/uploads/local/223344556677.png', ref: '223344556677.png' };
+    stub.nextResult = { url: '/uploads/223344556677.png', ref: '223344556677.png' };
     try {
       const res = await agent
         .post('/api/uploads')
@@ -285,7 +285,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
         .attach('image', smallPng, { filename: 'x.png', contentType: 'image/png' });
       expect(res.status).toBe(200);
       // A host with authority-breaking chars is rejected → no base is prefixed.
-      expect(res.body.url).toBe('/uploads/local/223344556677.png');
+      expect(res.body.url).toBe('/uploads/223344556677.png');
     } finally {
       stub.capabilities.storesRemotely = true;
       stub.nextResult = null;
@@ -294,7 +294,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
 
   it('prefers PUBLIC_BASE_URL over the request origin when set', async () => {
     stub.capabilities.storesRemotely = false;
-    stub.nextResult = { url: '/uploads/local/aabbccddeeff.png', ref: 'aabbccddeeff.png' };
+    stub.nextResult = { url: '/uploads/aabbccddeeff.png', ref: 'aabbccddeeff.png' };
     process.env.PUBLIC_BASE_URL = 'https://cdn.example.org/';
     try {
       const res = await agent
@@ -303,7 +303,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
         .attach('image', smallPng, { filename: 'local2.png', contentType: 'image/png' });
       expect(res.status).toBe(200);
       // Trailing slash on the base is trimmed; the request host is ignored.
-      expect(res.body.url).toBe('https://cdn.example.org/uploads/local/aabbccddeeff.png');
+      expect(res.body.url).toBe('https://cdn.example.org/uploads/aabbccddeeff.png');
     } finally {
       delete process.env.PUBLIC_BASE_URL;
       stub.capabilities.storesRemotely = true;
@@ -314,7 +314,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
   it('destroys the bytes via driver.delete before removing a deletable upload', async () => {
     stub.capabilities.storesRemotely = false;
     stub.capabilities.supportsDelete = true;
-    stub.nextResult = { url: '/uploads/local/112233445566.png', ref: '112233445566.png' };
+    stub.nextResult = { url: '/uploads/112233445566.png', ref: '112233445566.png' };
     stub.capturedDeleteRef = null;
     try {
       const up = await agent
@@ -340,7 +340,7 @@ describe('local-style (storesRemotely:false) uploads', () => {
     // A ref is present, but supportsDelete is false → there is no "remove the
     // record but leave the file up" path; the request is refused and the row stays.
     stub.capabilities.storesRemotely = false;
-    stub.nextResult = { url: '/uploads/local/778899aabbcc.png', ref: '778899aabbcc.png' };
+    stub.nextResult = { url: '/uploads/778899aabbcc.png', ref: '778899aabbcc.png' };
     stub.capturedDeleteRef = null;
     try {
       const up = await agent

--- a/server/services/uploadProviders/local.test.ts
+++ b/server/services/uploadProviders/local.test.ts
@@ -38,7 +38,7 @@ describe('local driver', () => {
       {},
     );
 
-    expect(res.url).toMatch(/^\/uploads\/local\/[0-9a-f]{12}\.txt$/);
+    expect(res.url).toMatch(/^\/uploads\/[0-9a-f]{12}\.txt$/);
     expect(res.ref).toMatch(/^[0-9a-f]{12}\.txt$/);
     expect(res.bytes).toBe(bytes.length);
 

--- a/server/services/uploadProviders/local.ts
+++ b/server/services/uploadProviders/local.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // The `local` driver — writes upload bytes to the server's own disk and serves
-// them back over the public GET /uploads/local/:key route (routes/localUploads.ts).
+// them back over the public GET /uploads/:key route (routes/localUploads.ts).
 // Self-host only: hosted cells are ephemeral (Litestream'd SQLite, no durable
 // blob disk), so this driver is never offered on the fleet.
 //
 // This is the one driver where `storesRemotely` is false: upload() returns a
-// RELATIVE url (/uploads/local/<key>) plus the on-disk `ref`; the upload route
+// RELATIVE url (/uploads/<key>) plus the on-disk `ref`; the upload route
 // absolutizes it against PUBLIC_BASE_URL (or the request origin) so the link is
 // clickable from IRC. The real security boundary is SERVE-time, not here — see
 // routes/localUploads.ts for the sniff / disposition / header recipe.
@@ -93,7 +93,7 @@ export async function upload(
       code: 'PROVIDER_ERROR',
     });
   }
-  return { url: `/uploads/local/${key}`, ref: key, bytes };
+  return { url: `/uploads/${key}`, ref: key, bytes };
 }
 
 /** Orphan reap: unlink the on-disk file when its history row is deleted. Missing

--- a/server/services/uploadProviders/uploadProviders.test.ts
+++ b/server/services/uploadProviders/uploadProviders.test.ts
@@ -392,7 +392,8 @@ describe('zipline provider', () => {
     expect(cap.headers!.authorization).toBe('ziptok');
     expect(cap.headers!['User-Agent']).toMatch(/^Lurker\//);
     expect(filePart(cap, 'file').filename).toBe('x.png');
-    expect(result.url).toBe('https://zl.test/u/x.png');
+    // The upstream /u/ view path is rewritten to /raw/ on the way out (#589).
+    expect(result.url).toBe('https://zl.test/raw/x.png');
   });
 
   it('accepts the v3 response shape (files as URL strings)', async () => {
@@ -407,7 +408,7 @@ describe('zipline provider', () => {
       { filename: 'y.png', mime: 'image/png' },
       { url: 'https://zl.test/', token: 't' },
     );
-    expect(result.url).toBe('https://zl.test/u/y.png');
+    expect(result.url).toBe('https://zl.test/raw/y.png');
   });
 
   it('rejects with PROVIDER_CONFIG when url or token is missing', async () => {
@@ -472,6 +473,47 @@ describe('zipline provider', () => {
       { url: 'https://zl.test', token: 't' },
     );
     expect(v3.ref).toBeUndefined();
+  });
+
+  // #589: /u/ serves an HTML viewer page wrapping the file. Lurker's media
+  // viewer classifies by extension, so a /u/*.txt link fetched into the text
+  // pane renders Zipline's HTML at the reader; /raw/ serves the bytes.
+  it('rewrites the /u/ view path to /raw/ on both response shapes', async () => {
+    capturePost();
+    postResponse = {
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ files: [{ id: 'clxyz123', url: 'https://zl.test/u/notes.txt' }] }),
+    };
+    const v4 = await zipline.upload(
+      src([1]),
+      { filename: 'notes.txt', mime: 'text/plain' },
+      { url: 'https://zl.test', token: 't' },
+    );
+    expect(v4.url).toBe('https://zl.test/raw/notes.txt');
+
+    postResponse = {
+      status: 200,
+      headers: {},
+      text: JSON.stringify({ files: ['https://zl.test/u/pic.png'] }),
+    };
+    const v3 = await zipline.upload(
+      src([1]),
+      { filename: 'pic.png', mime: 'image/png' },
+      { url: 'https://zl.test', token: 't' },
+    );
+    expect(v3.url).toBe('https://zl.test/raw/pic.png');
+  });
+
+  it('only rewrites the leading path segment, and leaves other shapes alone', async () => {
+    // A substring replace would corrupt each of these.
+    expect(zipline.toRawUrl('https://zl.test/u/u/x.txt')).toBe('https://zl.test/raw/u/x.txt');
+    expect(zipline.toRawUrl('https://u.test/u/x.txt')).toBe('https://u.test/raw/x.txt');
+    expect(zipline.toRawUrl('https://zl.test/files/u/x.txt')).toBe('https://zl.test/files/u/x.txt');
+    // Already raw, an unrecognized route, and an unparseable value all pass through.
+    expect(zipline.toRawUrl('https://zl.test/raw/x.txt')).toBe('https://zl.test/raw/x.txt');
+    expect(zipline.toRawUrl('https://zl.test/view/x.txt')).toBe('https://zl.test/view/x.txt');
+    expect(zipline.toRawUrl('not a url')).toBe('not a url');
   });
 
   it('delete DELETEs /api/user/files/{ref} with the raw token; 404 = already gone', async () => {

--- a/server/services/uploadProviders/zipline.ts
+++ b/server/services/uploadProviders/zipline.ts
@@ -44,6 +44,34 @@ export const configSchema: ConfigField[] = [
   },
 ];
 
+/** Rewrite Zipline's `/u/<name>` view URL to the `/raw/<name>` byte URL (#589).
+ *
+ *  `/u/` serves an HTML viewer page wrapping the file, which is wrong wherever
+ *  the link is treated as the file itself: Lurker's media viewer classifies by
+ *  extension, so a `/u/notes.txt` link opens the text pane and renders Zipline's
+ *  HTML at the reader. `/raw/` serves the bytes for every content type, so the
+ *  rewrite is unconditional rather than text-only — images and video resolve
+ *  identically either way.
+ *
+ *  Anchored to the first path segment: a blind replace would mangle a Zipline
+ *  hosted under a `/u/` subdirectory, or any hostname containing `/u/`. A URL
+ *  that doesn't have the expected shape (custom route, unparseable) is returned
+ *  untouched — a working view link beats a broken raw one. */
+export function toRawUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  const segments = parsed.pathname.split('/');
+  // ['', 'u', 'name'] — leading empty from the root slash.
+  if (segments[1] !== 'u') return url;
+  segments[1] = 'raw';
+  parsed.pathname = segments.join('/');
+  return parsed.toString();
+}
+
 export async function upload(
   source: UploadSource,
   { filename, mime, onProgress }: UploadMeta,
@@ -82,7 +110,7 @@ export async function upload(
   // v4 responses carry the file id — the delete handle. v3 responses are bare
   // URL strings with no id, so a v3 upload is simply not deletable (no ref).
   const ref = typeof first === 'object' && typeof first?.id === 'string' ? first.id : undefined;
-  return { url, ...(ref ? { ref } : {}) };
+  return { url: toRawUrl(url), ...(ref ? { ref } : {}) };
 }
 
 /** Delete a file by the id upload() captured. Zipline v4's delete route accepts

--- a/vue_client/vite.config.ts
+++ b/vue_client/vite.config.ts
@@ -52,7 +52,8 @@ export default defineConfig(({ mode }) => {
           target: apiBase,
           changeOrigin: true,
         },
-        // The local-disk uploader serves files from the backend at /uploads/local.
+        // The local-disk uploader serves files from the backend at /uploads
+        // (and the legacy /uploads/local alias, which this prefix also covers).
         // Proxy it so a PUBLIC_BASE_URL pointed at the dev origin (5173) resolves
         // pasted upload links through here instead of hitting the SPA fallback.
         '/uploads': {


### PR DESCRIPTION
Two small uploader bugs that are both "the URL we hand back is the wrong shape." They touch adjacent files with no overlap, so they're batched here.

## #582 — local uploads drop `/local/`

The `local` driver now mints `/uploads/<key>` instead of `/uploads/local/<key>`.

**The old mount stays as a permanent alias.** `upload_history.url` stores the fully absolutized link (`https://host/uploads/local/<key>`) and nothing in the codebase reparses it, so changing the mount alone would 404 every link already pasted into IRC — including ones sitting in other people's clients that we have no way to rewrite. `app.ts` mounts the same router at both paths. The two-segment legacy path can't match the new mount's single-segment `/:key`, so ordering between them is irrelevant.

The Vite dev proxy already matched on the `/uploads` prefix, so it covers both without change. `docs/SELF_HOSTING.md` had a Cloudflare Hotlink Protection rule keyed on `URI Path starts with /uploads/local/` — widened to `/uploads/`, which still matches the legacy links, with a note for operators who set the rule up already.

## #589 — Zipline links use `/raw/`, not `/u/`

Zipline's `/u/` route serves an HTML viewer page wrapping the file rather than the bytes. Lurker's media viewer classifies by extension (`uploadHostMatch.ts`, no HEAD request, no mime), so a `/u/notes.txt` link was classified as text, `fetch`ed into the text pane, and rendered Zipline's HTML at the reader.

The rewrite is **unconditional** rather than text-only: `/raw/` serves the bytes for every content type, so images and video resolve identically either way and there's no `contentClass` branch to maintain.

It's anchored to the first path segment rather than a substring replace, which would mangle a Zipline hosted under a `/u/` subdirectory or a hostname containing `/u/`. Unrecognized routes and unparseable values pass through untouched — a working view link beats a broken raw one. Delete is unaffected (keyed on the file `id`, not the URL).

One thing worth flagging: `loadText` in `MediaViewerModal.vue` is the only CORS-subject path in the viewer, so a Zipline instance that doesn't send permissive CORS on `/raw/` will still fall through to the "open in browser" card. That's pre-existing and not something this PR can fix from our side.

## Testing

`npm run check` clean, `npm test` green (2678 passing). Added coverage for the legacy `/uploads/local` alias still serving a file minted at the new path, and for the segment-anchoring edge cases (`/u/u/`, a `u.test` hostname, `/files/u/`, already-raw, unknown route, unparseable).

Not device-verified against a live Zipline instance — the rewrite is asserted against both the v3 and v4 response shapes at the driver boundary.

Closes #582
Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
