### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version bump for the buffers-registry release (#601): first-class buffer rows replace derived existence, `closed_buffers`, and `channels`, with the schemaVersion 16 migration (fold + backfill + legacy-table drop), bouncer closed-set unification, legacy-archive import conversion, and the forwarded-join client fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)