### PR TITLE
Label native push devices by transport instead of user agent

### DIFF
--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -32,7 +32,7 @@
 
     <ul v-if="otherSubscriptions.length" class="device-list">
       <li v-for="sub in otherSubscriptions" :key="sub.id" class="device">
-        <span class="ua">{{ formatUA(sub.user_agent) }}</span>
+        <span class="ua">{{ deviceLabel(sub) }}</span>
         <span class="last-seen" :title="sub.last_seen_at"
           >last seen {{ formatRelative(sub.last_seen_at) }}</span
         >
@@ -259,6 +259,7 @@ import {
 // the template can display them without colliding with the browser API type.
 interface StoredPushSub extends PushSubscription {
   id: string;
+  transport: string;
   user_agent: string | null;
   last_seen_at: string;
 }
@@ -422,6 +423,15 @@ async function onRemoveOther(sub: StoredPushSub) {
   } finally {
     pushBusy.value = false;
   }
+}
+
+// A native app's UA is CFNetwork/OkHttp noise, but its transport says exactly
+// what it is — the server projects `transport` for precisely this. UA parsing
+// is the fallback for webpush rows, where the browser genuinely is the client.
+function deviceLabel(sub: StoredPushSub): string {
+  if (sub.transport === 'apns') return 'Lurker for iOS';
+  if (sub.transport === 'fcm') return 'Lurker for Android';
+  return formatUA(sub.user_agent);
 }
 
 function formatUA(ua: string | null | undefined): string {


### PR DESCRIPTION
## Summary

The device list in **settings → notifications** names every registered push client by parsing its stored User-Agent string. Native apps register through URLSession/OkHttp, whose default UAs (`Lurker/1 CFNetwork/… Darwin/…`) match none of the parser's browser/OS patterns — so an iPhone running the Lurker app shows up as the bare fallback label **"browser"**.

The server has projected `transport` on `GET /api/push/subscriptions` since #490, with a comment saying it exists "so a client can tell a browser subscription from a phone when listing devices" — the pane just never consumed it.

## Change

- `NotificationsPane.vue`: declare `transport` on `StoredPushSub` and label rows by transport first — `apns` → **Lurker for iOS**, `fcm` → **Lurker for Android** — falling back to the existing UA parser for `webpush` rows, where the browser genuinely is the client.

Client-side only. Retroactively fixes rows already registered (transport is stored per row), so no re-registration and no app update needed.

## Testing

- `npm run check` — clean
- `npm test` — 206 files, 2735 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)