### PR TITLE
docs: surface Developers as a top-nav dropdown

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,6 +25,13 @@ export default defineConfig({
     nav: [
       { text: 'Guide', link: '/guide/' },
       { text: 'Self-Hosting', link: '/SELF_HOSTING' },
+      {
+        text: 'Developers',
+        items: [
+          { text: 'Client Protocol & API', link: '/CLIENT_PROTOCOL' },
+          { text: 'MCP & HTTP API', link: '/MCP' },
+        ],
+      },
       { text: 'App', link: 'https://app.lurker.chat' },
     ],
     sidebar: {


### PR DESCRIPTION
Adds a **Developers** dropdown to the docs-site top nav, next to Self-Hosting, holding Client Protocol & API and MCP & HTTP API. Follow-up to #609, where these pages got a sidebar group but no nav presence.

VitePress build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)