### PR TITLE
Store IRCv3 server-time + msgid; adopt echo-message for own sends

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -305,17 +305,29 @@ Common fields on every **persisted** event (`db/messages.ts:31` +
 `decorateMessage`, `wsHub.ts:430`):
 
 ```
-{ id, networkId, target, time,        // ISO 8601
+{ id, networkId, target, time,        // ISO 8601 — see the note below
   type,                               // see §7.2
   nick, text, kind,                   // kind = raw IRC command; see the ⚠ below
   self,                               // you sent it (any of your clients)
   userhost, alt, mirrored, dm,
   matched, matchedRuleId,             // highlight decoration
-  fromIgnored, notifyAlways, notify }
+  fromIgnored, notifyAlways, notify,
+  msgid? }                            // IRCv3 server message id, when supplied
 ```
 
 plus type-specific extras (`newNick`, `kicked`, `modes`, `members`, …).
 **Ephemeral** event types (§7.2) carry no `id`.
+
+**`time` is IRCv3 server-time** where the network offers it (the `@time=` tag),
+receive time otherwise. Far-future stamps (> ~2 min ahead) fall back to receive
+time. Rows persisted before this existed carry receive time. Because a bouncer
+upstream can replay old messages live, `time` is **not** guaranteed monotonic
+with respect to `id` — order and dedupe by `id`, always (§9.3).
+
+**`msgid`** is the server-assigned IRCv3 message id (`message-tags` networks;
+own sends learn theirs via `echo-message`). Absent — not null — on rows from
+untagged networks and on optimistic self echoes. It is the future anchor for
+react/reply; today it is informational only.
 
 > ⚠ **Live-frame `kind` clobber.** When an event arrives live it is wrapped as
 > `{...event, kind:'irc'}` — the event's own `kind` field is overwritten by the
@@ -353,7 +365,10 @@ paused. Dispatch: `handleClientMessage`, `wsHub.ts:2031`.
 `notice` and the server replies `{kind:'send-result', clientId, ok, error?}`.
 This confirms acceptance only — the message itself comes back as a normal `irc`
 echo with `self:true` and its real id (§9.3). The web client times acks out
-after 8 s (client policy).
+after 8 s (client policy). On networks that ACK `echo-message` upstream, that
+`self:true` frame arrives only after the IRC server reflects the send back (one
+upstream round trip, carrying the real `msgid` + server `time`); elsewhere it
+is emitted immediately from the server's optimistic local copy.
 
 ### Channels & buffers ⏸
 

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -193,6 +193,7 @@ export const EXPORT_TABLES = Object.freeze({
       'from_ignored',
       'mirrored',
       'notable',
+      'msgid',
     ],
   },
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -931,6 +931,17 @@ db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_matched
 // styled with .line.alt. See schemaVersion < 2 backfill below.
 ensureColumn('messages', 'alt', 'INTEGER NOT NULL DEFAULT 0');
 
+// IRCv3 server-assigned message id (#450), captured from the msgid tag on
+// message-tags networks (own sends learn theirs via echo-message). Foundation
+// for react/reply, which reference a target message by msgid. Deliberately
+// NON-unique: the closed-buffer NOTICE mirror and a replaying upstream may
+// legitimately produce duplicates, and a constraint failure inside publish()
+// would drop the message. Partial index — untagged rows stay out of it.
+ensureColumn('messages', 'msgid', 'TEXT');
+db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_msgid
+         ON messages(network_id, msgid)
+         WHERE msgid IS NOT NULL`);
+
 // Sender matched the network owner's ignore list at insert time. Stamped on
 // the row so countNewer/countHighlightsNewer can exclude ignored senders
 // without doing a JS-side mask scan over every unread row — the client's

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -881,6 +881,28 @@ describe('messages.msgid (#450)', () => {
     // Absent, not null — untagged backlogs must not grow a msgid field.
     expect(untagged).not.toHaveProperty('msgid');
   });
+
+  it('coerces an empty-string msgid to NULL so it is never stored or indexed', () => {
+    const user = createUser('msgid-empty');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'msgid-empty',
+    });
+    insertMessage({
+      networkId: net!.id,
+      target: '#m',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'alice',
+      text: 'empty tag',
+      self: false,
+      msgid: '',
+    });
+    expect(listMessages(net!.id, '#m')[0]).not.toHaveProperty('msgid');
+  });
 });
 
 describe('from_ignored excludes ignored senders from unread/highlight counts', () => {

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -847,6 +847,42 @@ describe('messages.alt parity (insert result)', () => {
   });
 });
 
+describe('messages.msgid (#450)', () => {
+  it('round-trips through insertMessage → listMessages; absent when the row has none', () => {
+    const user = createUser('msgid-roundtrip');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'msgid-roundtrip',
+    });
+    insertMessage({
+      networkId: net!.id,
+      target: '#m',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'alice',
+      text: 'tagged',
+      self: false,
+      msgid: 'abc-123',
+    });
+    insertMessage({
+      networkId: net!.id,
+      target: '#m',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'bob',
+      text: 'untagged',
+      self: false,
+    });
+    const [tagged, untagged] = listMessages(net!.id, '#m');
+    expect(tagged.msgid).toBe('abc-123');
+    // Absent, not null — untagged backlogs must not grow a msgid field.
+    expect(untagged).not.toHaveProperty('msgid');
+  });
+});
+
 describe('from_ignored excludes ignored senders from unread/highlight counts', () => {
   function chatWith(
     networkId: number,

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -134,7 +134,9 @@ export function insertMessage(row: MessageInput): { id: number | bigint; alt: bo
     mirrored: row.mirrored ? 1 : 0,
     // Default notable=1; only an explicit `false` (Lurker's status notices) is 0.
     notable: row.notable === false ? 0 : 1,
-    msgid: row.msgid ?? null,
+    // `||` not `??`: an empty-string msgid would be stored and indexed
+    // (msgid IS NOT NULL) yet never surfaced — rowToEvent reads truthily.
+    msgid: row.msgid || null,
   });
   const id = result.lastInsertRowid;
   const altRow = altByIdStmt.get(id) as { alt: number } | undefined;

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -20,6 +20,7 @@ interface MessageRow {
   matched_rule_id: number | null;
   from_ignored: number;
   mirrored: number;
+  msgid: string | null;
 }
 
 /** A raw message row joined with network_name. */
@@ -46,6 +47,9 @@ export interface MessageEvent {
   // A duplicate of a closed-buffer NOTICE surfaced in the server buffer (#439).
   // Excluded from search/highlights so it doesn't double up its real copy.
   mirrored: boolean;
+  // IRCv3 server-assigned message id (#450). Only set when the network supplied
+  // one — absent (not null) otherwise, so untagged backlogs don't grow a field.
+  msgid?: string;
   [key: string]: unknown;
 }
 
@@ -70,6 +74,7 @@ export interface MessageInput {
   userhost?: string | null;
   fromIgnored?: boolean;
   mirrored?: boolean;
+  msgid?: string | null;
   // Server-buffer notability (#470). Defaults to notable (true); pass false for
   // Lurker's own connection-status notices so they render in the server buffer
   // but don't mark it unread. Read by countServerBufferUnread (the :server: unread
@@ -95,9 +100,9 @@ export interface MaxIdByBufferRow {
 // Non-striped types pass through with alt=0; the value is meaningless for them
 // and the client never reads it.
 const insertStmt = db.prepare(`
-  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, mirrored, notable, alt)
+  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, mirrored, notable, msgid, alt)
   VALUES (
-    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored, @mirrored, @notable,
+    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored, @mirrored, @notable, @msgid,
     CASE WHEN @type IN ('message', 'action', 'notice')
          THEN 1 - COALESCE(
            (SELECT alt FROM messages
@@ -129,6 +134,7 @@ export function insertMessage(row: MessageInput): { id: number | bigint; alt: bo
     mirrored: row.mirrored ? 1 : 0,
     // Default notable=1; only an explicit `false` (Lurker's status notices) is 0.
     notable: row.notable === false ? 0 : 1,
+    msgid: row.msgid ?? null,
   });
   const id = result.lastInsertRowid;
   const altRow = altByIdStmt.get(id) as { alt: number } | undefined;
@@ -153,6 +159,7 @@ function rowToEvent(row: MessageRow): MessageEvent {
     fromIgnored: row.from_ignored === 1,
     mirrored: row.mirrored === 1,
   };
+  if (row.msgid) event.msgid = row.msgid;
   if (row.extra) {
     try {
       Object.assign(event, JSON.parse(row.extra));

--- a/server/services/bouncer.chathistory.test.ts
+++ b/server/services/bouncer.chathistory.test.ts
@@ -117,6 +117,33 @@ describe('CHATHISTORY LATEST', () => {
     await c.waitFor((l) => l.includes('msg3') && l.includes(`msgid=${ids[2]}`));
     await c.waitFor((l) => l.includes(`BATCH -${ref}`));
   });
+
+  it('still emits the INTERNAL row id as msgid for a row that stored an upstream msgid', async () => {
+    // The stored IRCv3 msgid (#450) and the bouncer's playback msgid are
+    // different namespaces (MSGREFTYPES=timestamp, see SUPPORTED_CAPS notes) —
+    // storing the upstream tag must not leak it into chathistory playback.
+    const acct = harnessMod.seedAccount({ nick: 'ch2b' });
+    const rowId = Number(
+      insertMessage({
+        networkId: acct.network.id,
+        target: '#tagged',
+        time: '2023-05-23T06:00:01.000Z',
+        type: 'message',
+        nick: 'bob',
+        userhost: 'bob!u@h',
+        text: 'tagged msg',
+        self: false,
+        msgid: 'upstream-uuid-1',
+      }).id,
+    );
+    const c = await harness.connect();
+    await attachBound(c, acct);
+    c.send('CHATHISTORY LATEST #tagged * 100');
+    const line = await c.waitFor((l) => l.includes('PRIVMSG #tagged :tagged msg'));
+    expect(line).toContain(`msgid=${rowId}`);
+    expect(line).not.toContain('upstream-uuid-1');
+    c.close();
+  });
 });
 
 describe('CHATHISTORY BEFORE / AFTER (timestamp, exclusive)', () => {

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -111,6 +111,7 @@ function seedAlice(): { alice: User; net: Network; ruleId: number } {
     nick: 'alice',
     text: 'hello',
     self: true,
+    msgid: 'seed-msgid-1',
   });
   insertMessage({
     networkId: net.id,
@@ -167,9 +168,11 @@ describe('importFromZipBuffer — roundtrip', () => {
 
     const bobMessages = db
       .prepare('SELECT * FROM messages WHERE network_id = ? ORDER BY id ASC')
-      .all(bobNets[0].id) as Array<{ text: string }>;
+      .all(bobNets[0].id) as Array<{ text: string; msgid: string | null }>;
     expect(bobMessages.length).toBe(2);
     expect(bobMessages.map((m) => m.text)).toEqual(['hello', 'hi alice']);
+    // The IRCv3 msgid column (#450) round-trips losslessly.
+    expect(bobMessages.map((m) => m.msgid)).toEqual(['seed-msgid-1', null]);
 
     const bobBookmarks = db
       .prepare('SELECT * FROM user_bookmarks WHERE user_id = ?')

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -218,6 +218,31 @@ function isDmTargetName(target: string | undefined | null): boolean {
   return !target.startsWith('#') && !target.startsWith(':server:');
 }
 
+// Persisted timestamps prefer IRCv3 server-time (#450): irc-framework parses
+// the @time= tag into an epoch-ms NUMBER on the raw event; handlers thread it
+// through as `time` and this normalizes to canonical ISO-Z. Only that form may
+// ever be stored — loadHistoryWindow / listBuffersForNetwork compare the TEXT
+// column lexicographically, so a raw number (or an offset-timezone string)
+// would corrupt window selection and buffer ordering. Missing/unparseable
+// falls back to receive time. Far-FUTURE stamps also fall back (a skewed
+// server must not pin MAX(time) buffer ordering); far-past stamps are kept —
+// that's legitimate bouncer/ZNC replay. References mostly trust the tag
+// as-is; the clamp is a deliberate Lurker deviation and degrades gracefully
+// (a wholly-skewed server just gets receive time, i.e. pre-#450 behavior).
+const MAX_FUTURE_TIME_SKEW_MS = 2 * 60_000;
+function normalizeEventTime(t: unknown): string {
+  let ms: number | undefined;
+  if (typeof t === 'number' && Number.isFinite(t)) ms = t;
+  else if (typeof t === 'string' && t) {
+    const parsed = Date.parse(t);
+    if (Number.isFinite(parsed)) ms = parsed;
+  }
+  if (ms === undefined || ms - Date.now() > MAX_FUTURE_TIME_SKEW_MS) {
+    return new Date().toISOString();
+  }
+  return new Date(ms).toISOString();
+}
+
 function extractExtras(event: IrcEvent): Record<string, unknown> | null {
   let extras: Record<string, unknown> | null = null;
   switch (event.type) {
@@ -576,7 +601,7 @@ export class IrcConnection {
   publish(event: IrcEvent): EnrichedEvent | void {
     if (this.disposed) return;
     event = this.normalizeChannelTarget(event);
-    const time = (event.time as string | undefined) || new Date().toISOString();
+    const time = normalizeEventTime(event.time);
     const enriched: EnrichedEvent = {
       ...event,
       userId: this.network.user_id,
@@ -628,6 +653,7 @@ export class IrcConnection {
         fromIgnored,
         mirrored: event.mirrored as boolean | undefined,
         notable: event.notable as boolean | undefined,
+        msgid: event.msgid as string | undefined,
       });
       enriched.id = id;
       enriched.alt = alt;
@@ -647,7 +673,7 @@ export class IrcConnection {
       ...event,
       userId: this.network.user_id,
       networkId: this.network.id,
-      time: (event.time as string | undefined) || new Date().toISOString(),
+      time: normalizeEventTime(event.time),
     });
   }
 
@@ -1274,6 +1300,7 @@ export class IrcConnection {
           userhost: oldUserhost,
           newIdent,
           newHost,
+          time: event.time,
         });
         this.publishMemberUpdate(ch.name, member);
       }
@@ -1337,15 +1364,63 @@ export class IrcConnection {
       const eventHostname = event.hostname as string | undefined;
       const eventMessage = event.message as string | undefined;
       const eventType = event.type as string | undefined;
-      // Skip self-echoes. ircManager.send/.action already publishes a local
-      // copy of every outgoing PRIVMSG/ACTION, so when the IRC server reflects
-      // it back to us (echo-message cap, ergo's always-on relay, some
-      // bouncers) the second copy would land in the database with a fresh id
-      // and surface as a duplicate in the buffer. The local publish is the
-      // source of truth for anything this backend sent.
-      if (eventNick && me && eventNick.toLowerCase() === me.toLowerCase()) return;
-      const isServer = !eventNick;
+      const tags = event.tags as Record<string, string> | undefined;
+      // IRCv3 server message id (#450) — the future react/reply anchor. Tag
+      // keys arrive lowercased; draft/msgid covers pre-ratification servers.
+      const msgid = tags?.msgid || tags?.['draft/msgid'] || undefined;
       const targetIsChannel = eventTarget && eventTarget.startsWith('#');
+      const type =
+        eventType === 'action' ? 'action' : eventType === 'notice' ? 'notice' : 'message';
+
+      // Self-echoes. Without echo-message, ircManager.send/.action already
+      // published the local copy, so a reflection (ergo's always-on relay, some
+      // bouncers) would land as a duplicate — drop it, as ever. With the cap
+      // ACKed the roles flip: the send path SKIPPED its optimistic publish and
+      // this echo IS the message — adopt it as the persisted self row, carrying
+      // the server's msgid + @time (the only way our own sends learn their
+      // msgid, #450).
+      if (eventNick && me && eventNick.toLowerCase() === me.toLowerCase()) {
+        if (!this.echoActive()) return;
+        // Our own E2E ciphertext coming back: the optimistic PLAINTEXT row
+        // (self, e2e) was already published at send time. Mirror the inbound
+        // decrypt gate below exactly, so a literal "+RPE2E01…" typed on a
+        // non-E2E channel still adopts as ordinary cleartext.
+        if (
+          typeof eventMessage === 'string' &&
+          eventMessage.startsWith(WIRE_PREFIX) &&
+          isChannelContext(eventTarget ?? '') &&
+          e2eManager.isChannelEnabled(
+            this.network.user_id,
+            this.network.id,
+            contextKey(eventTarget as string, ''),
+          )
+        ) {
+          return;
+        }
+        if (!eventTarget || typeof eventMessage !== 'string') return;
+        // Route by RECIPIENT (event.target), never nick — the echo's nick is
+        // us, and keying off it would file every DM under our own nick. DMs
+        // fold to the existing buffer row's casing (#289); channel case is
+        // normalized inside publish().
+        const selfTarget = targetIsChannel
+          ? eventTarget
+          : (getBuffer(this.network.user_id, this.network.id, eventTarget)?.target ?? eventTarget);
+        this.publish({
+          type,
+          target: selfTarget,
+          nick: eventNick,
+          text: eventMessage,
+          kind: eventType,
+          self: true,
+          userhost: buildUserhost(event),
+          time: event.time,
+          ...(msgid ? { msgid } : {}),
+        });
+        // Parity with the optimistic path it replaces: no closed-buffer notice
+        // mirror, no trackDmPeer/markPeerEvent for ourselves.
+        return;
+      }
+      const isServer = !eventNick;
       const isNotice = eventType === 'notice';
 
       let target: string;
@@ -1389,8 +1464,6 @@ export class IrcConnection {
         }
       } else target = eventNick as string;
 
-      const type =
-        eventType === 'action' ? 'action' : eventType === 'notice' ? 'notice' : 'message';
       const nick = eventNick || eventHostname || 'server';
 
       // RPE2E: a `+RPE2E01` chunk on an encryption channel is decrypted to its
@@ -1465,6 +1538,8 @@ export class IrcConnection {
         kind: eventType,
         self: false,
         userhost: buildUserhost(event),
+        time: event.time,
+        ...(msgid ? { msgid } : {}),
         ...(e2eFlag ? { e2e: true } : {}),
       }) as EnrichedEvent | undefined;
       // If a notice's home buffer is one the user has closed, the wsHub fan-out
@@ -1493,6 +1568,9 @@ export class IrcConnection {
           kind: eventType,
           self: false,
           mirrored: true,
+          // Server time yes, msgid no — the msgid names the REAL copy in the
+          // home buffer; a react/reply lookup must never resolve to the mirror.
+          time: event.time,
         });
       }
       // An incoming PRIVMSG (not NOTICE) is the moment this nick becomes a
@@ -1522,6 +1600,12 @@ export class IrcConnection {
     // RPEE2E and hand the body to the manager, which returns the bodies to NOTICE
     // straight back to the sender's nick (re-framed) plus an optional user notice.
     c.on('ctcp response', (event: Record<string, unknown>) => {
+      // Under echo-message the server reflects our own CTCP-framed NOTICEs
+      // (RPE2E handshake replies, standard CTCP answers) back to us — without
+      // this guard our own KEYREQ/KEYRSP would re-enter handleHandshakeBody
+      // under our own handle. handleInboundCtcpReply has its own self guard,
+      // but the RPE2E branch below ran unguarded.
+      if (this.isSelfNick(event.nick as string | undefined)) return;
       e2eDbg(
         () =>
           `ctcp-response from ${event.nick}!${event.ident}@${event.hostname} type=${event.type} body=${String(event.message).slice(0, 140)}`,
@@ -1597,6 +1681,7 @@ export class IrcConnection {
         target: eventChannel,
         nick: eventNick,
         userhost: buildUserhost(event),
+        time: event.time,
         // Only when we actually know an account — a logged-out `null` renders
         // as nothing anyway, and omitting it keeps the persisted `extra` JSON
         // off every join row on networks without the cap.
@@ -1690,6 +1775,7 @@ export class IrcConnection {
         nick: eventNick,
         text: event.message as string | undefined,
         userhost: buildUserhost(event),
+        time: event.time,
       });
       if (eventNick === c.user.nick) {
         this.channels.delete(eventChannel.toLowerCase());
@@ -1718,6 +1804,7 @@ export class IrcConnection {
         kicked: eventKicked,
         text: event.message as string | undefined,
         userhost: buildUserhost(event),
+        time: event.time,
       });
       // Mirror the self-PART path when we ourselves are the one kicked, so
       // the buffer dims in the sidebar instead of staying styled as joined.
@@ -1769,7 +1856,7 @@ export class IrcConnection {
 
       // (3) invite-notify op-visibility: a third party invited someone to a
       // channel we're in → persisted channel line "inviter invited invited".
-      this.publish({ type: 'invite', target: channel, nick: inviter, invited });
+      this.publish({ type: 'invite', target: channel, nick: inviter, invited, time: event.time });
     });
 
     c.on('invited', (event: Record<string, unknown>) => {
@@ -1783,13 +1870,14 @@ export class IrcConnection {
       const me = c.user?.nick;
       if (!invited || !rawChannel || !me) return;
       const channel = canonicalChannelTarget(rawChannel, this.channels) ?? rawChannel;
-      this.publish({ type: 'invite', target: channel, nick: me, invited });
+      this.publish({ type: 'invite', target: channel, nick: me, invited, time: event.time });
     });
 
     c.on('quit', (event: Record<string, unknown>) => {
       const eventNick = event.nick as string;
       const lower = eventNick.toLowerCase();
       const userhost = buildUserhost(event);
+      const time = event.time;
       for (const ch of this.channels.values()) {
         if (ch.members.delete(lower)) {
           this.publish({
@@ -1798,6 +1886,7 @@ export class IrcConnection {
             nick: eventNick,
             text: event.message as string | undefined,
             userhost,
+            time,
           });
         }
       }
@@ -1883,6 +1972,7 @@ export class IrcConnection {
             nick: eventNick,
             newNick: eventNewNick,
             userhost,
+            time: event.time,
           });
         }
       }
@@ -1907,6 +1997,7 @@ export class IrcConnection {
           target: eventChannel,
           nick: event.nick as string,
           text: eventTopic,
+          time: event.time,
         });
       } else {
         // RPL_TOPIC on join — sync the topic bar without printing a row, so
@@ -2005,6 +2096,7 @@ export class IrcConnection {
         nick: eventNick,
         text,
         modes: eventModes,
+        time: event.time,
       });
       if (memberModesChanged && ch) {
         this.publish({
@@ -2363,7 +2455,10 @@ export class IrcConnection {
     c.on('tagmsg', (event: Record<string, unknown>) => {
       const me = c.user?.nick;
       const eventNick = event.nick as string | undefined;
-      const isSelf = !!eventNick && eventNick === me;
+      // Case-folded, matching the message handler's self check — under
+      // echo-message our own TAGMSGs reflect back, and a server relaying a
+      // case-variant nick must not show us our own typing indicator.
+      const isSelf = !!eventNick && !!me && eventNick.toLowerCase() === me.toLowerCase();
       if (isSelf) return;
       const tags = event.tags as Record<string, string> | undefined;
       const typing = tags && tags['+typing'];
@@ -2884,6 +2979,13 @@ export class IrcConnection {
       // — irc-framework overwrites client.options with this dict, so passing
       // it to the constructor doesn't survive. See client.js:202.
       enable_chghost: true,
+      // Request echo-message (#450): the server reflects our own sends back
+      // with their msgid + @time, and the message handler adopts that echo as
+      // the persisted self row (see echoActive). Same connect()-dict rule as
+      // enable_chghost. Harmless where unsupported — irc-framework only CAP
+      // REQs caps the server advertises, and the send path keeps the
+      // optimistic publish until the cap is actually ACKed.
+      enable_echomessage: true,
       // Source-bind outbound IRC when LURKER_OUTGOING_ADDR is set, so the
       // network's RFC 1413 callback lands on the built-in identd rather than the
       // host's (outgoingAddr → irc-framework outgoing_addr → socket localAddress).
@@ -4054,6 +4156,16 @@ export class IrcConnection {
   // raw splitting, they just span multiple batches (see sendMultiline).
   supportsMultiline(): boolean {
     return this.multilineLimits() != null;
+  }
+
+  // echo-message ACKed: the server reflects our own PRIVMSG/NOTICE/TAGMSG back,
+  // the send path skips its optimistic publish, and the message handler adopts
+  // the reflection as the persisted self row (real msgid + server time, #450).
+  // When false, ircManager keeps the optimistic local publish and reflections
+  // stay deduped — the pre-echo-message behavior.
+  echoActive(): boolean {
+    const cap = this.client.network?.cap as { enabled?: string[] } | undefined;
+    return !!cap?.enabled?.includes('echo-message');
   }
 
   // Send `text` as one-or-more draft/multiline batches: each is BATCH +ref …

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -230,6 +230,12 @@ function isDmTargetName(target: string | undefined | null): boolean {
 // as-is; the clamp is a deliberate Lurker deviation and degrades gracefully
 // (a wholly-skewed server just gets receive time, i.e. pre-#450 behavior).
 const MAX_FUTURE_TIME_SKEW_MS = 2 * 60_000;
+
+// Echo-correlation bounds for sentCiphertext (see noteSentCiphertext): 30s
+// mirrors the bouncer's pendingEcho prune window — an echo slower than that
+// is pathological — and the cap bounds a hostile/broken flood.
+const SENT_CIPHERTEXT_TTL_MS = 30_000;
+const SENT_CIPHERTEXT_MAX = 500;
 function normalizeEventTime(t: unknown): string {
   let ms: number | undefined;
   if (typeof t === 'number' && Number.isFinite(t)) ms = t;
@@ -441,6 +447,24 @@ export class IrcConnection {
   // so far; flushed as one reassembled message on 'batch end draft/multiline'
   // and cleared on socket close so a never-closed batch can't leak. (#381)
   multilineBatches: Map<string, { event: Record<string, unknown>; text: string }>;
+  // Tags from a `draft/multiline` BATCH *start* line, keyed by batch reference.
+  // The spec puts the logical message's msgid/@time on the BATCH +ref line, but
+  // irc-framework reduces the batch to {id,type,params} and DISCARDS the start
+  // line's tags — so the raw handler stashes them here and accumulateMultiline
+  // grafts them onto the first fragment. Consumed on first fragment; cleared on
+  // socket close with multilineBatches so an unopened batch can't leak.
+  multilineBatchTags: Map<string, { time?: string; msgid?: string }>;
+  // Exact ciphertext lines we recently put on the wire for E2E sends, so the
+  // echo-message reflection of our OWN ciphertext is recognized by content —
+  // not by re-checking channel E2E state at echo time, which races /e2e off
+  // (state can flip in the send→echo RTT window and the optimistic plaintext
+  // row already exists either way). TTL-pruned; consumed on match.
+  sentCiphertext: Array<{ line: string; at: number }>;
+  // Consecutive-adoption dedupe for our own msgid: a PRIVMSG to your OWN nick
+  // arrives twice under echo-message (delivery copy + echo copy — ergo and
+  // solanum both send both, with the same msgid), and both pass the self
+  // check. The msgid index is deliberately non-unique, so dedupe here.
+  lastAdoptedSelfMsgid: string | null;
   // Per-peer rate limiter for inbound CTCP (requests AND replies). Being
   // per-peer, one flooding peer can't make the cell spew NOTICEs, spam the
   // buffer, OR suppress CTCP from everyone else — it only exhausts its own
@@ -534,6 +558,9 @@ export class IrcConnection {
     this.lastUserSendAt = new Map();
     this.autoWhoTargets = new Set();
     this.multilineBatches = new Map();
+    this.multilineBatchTags = new Map();
+    this.sentCiphertext = [];
+    this.lastAdoptedSelfMsgid = null;
     this.ctcpLimiter = new RateLimiter();
     this.ctcpOutstanding = new Map();
     this.registrationLines = [];
@@ -749,6 +776,22 @@ export class IrcConnection {
         return;
       }
       const rawCommand = (msg?.command || '').toString();
+      // draft/multiline BATCH start: the logical message's msgid/@time ride
+      // THIS line per the spec, and irc-framework drops them when it reduces
+      // the batch to {id,type,params} — stash them for accumulateMultiline.
+      // Bounded: consumed by the first fragment, cleared on socket close, and
+      // capped so a server opening batches it never populates can't grow it.
+      if (rawCommand === 'BATCH' && msg?.params?.[0]?.startsWith('+')) {
+        if (msg.params[1] === 'draft/multiline') {
+          const tags = (msg.tags ?? {}) as Record<string, string>;
+          const time = tags.time || undefined;
+          const msgid = tags.msgid || tags['draft/msgid'] || undefined;
+          if (time || msgid) {
+            if (this.multilineBatchTags.size >= 100) this.multilineBatchTags.clear();
+            this.multilineBatchTags.set(msg.params[0].slice(1), { time, msgid });
+          }
+        }
+      }
       // Capture the registration burst for bouncer attach-time replay. 001
       // starts a fresh burst (each (re)registration replaces the last), and
       // the follow-on 002–005 lines are only appended once a burst has begun
@@ -941,6 +984,11 @@ export class IrcConnection {
       this.userModes.clear();
       this.autoWhoTargets.clear();
       this.multilineBatches.clear();
+      this.multilineBatchTags.clear();
+      // Echo-correlation state is per-socket: no echo can arrive for a line
+      // sent on the dead socket.
+      this.sentCiphertext.length = 0;
+      this.lastAdoptedSelfMsgid = null;
       // CTCP routing/limit state is per-socket: a stale outstanding entry would
       // mis-route a same-type reply on the new socket, and a drained limiter
       // would drop the new socket's first probes. Reset both (#263).
@@ -1381,30 +1429,27 @@ export class IrcConnection {
       // msgid, #450).
       if (eventNick && me && eventNick.toLowerCase() === me.toLowerCase()) {
         if (!this.echoActive()) return;
+        if (!eventTarget || typeof eventMessage !== 'string') return;
         // Our own E2E ciphertext coming back: the optimistic PLAINTEXT row
-        // (self, e2e) was already published at send time. Mirror the inbound
-        // decrypt gate below exactly, so a literal "+RPE2E01…" typed on a
-        // non-E2E channel still adopts as ordinary cleartext.
-        if (
-          typeof eventMessage === 'string' &&
-          eventMessage.startsWith(WIRE_PREFIX) &&
-          isChannelContext(eventTarget ?? '') &&
-          e2eManager.isChannelEnabled(
-            this.network.user_id,
-            this.network.id,
-            contextKey(eventTarget as string, ''),
-          )
-        ) {
+        // (self, e2e) was already published at send time. Recognized by
+        // CONTENT (the exact lines ircManager's E2E branch registered when it
+        // wired them), not by re-checking channel E2E state — which races
+        // /e2e off inside the send→echo RTT window. A literal "+RPE2E01…" the
+        // user actually typed was never registered, so it still adopts as
+        // ordinary cleartext.
+        if (eventMessage.startsWith(WIRE_PREFIX) && this.consumeSentCiphertext(eventMessage)) {
           return;
         }
-        if (!eventTarget || typeof eventMessage !== 'string') return;
+        // A PRIVMSG to your OWN nick arrives twice under echo-message (the
+        // delivery copy AND the echo — ergo and solanum both send both, same
+        // msgid). Adopt the first copy, drop the twin.
+        if (msgid && msgid === this.lastAdoptedSelfMsgid) return;
+        if (msgid) this.lastAdoptedSelfMsgid = msgid;
         // Route by RECIPIENT (event.target), never nick — the echo's nick is
         // us, and keying off it would file every DM under our own nick. DMs
         // fold to the existing buffer row's casing (#289); channel case is
         // normalized inside publish().
-        const selfTarget = targetIsChannel
-          ? eventTarget
-          : (getBuffer(this.network.user_id, this.network.id, eventTarget)?.target ?? eventTarget);
+        const selfTarget = targetIsChannel ? eventTarget : this.canonicalDmTarget(eventTarget);
         this.publish({
           type,
           target: selfTarget,
@@ -1414,7 +1459,7 @@ export class IrcConnection {
           self: true,
           userhost: buildUserhost(event),
           time: event.time,
-          ...(msgid ? { msgid } : {}),
+          msgid,
         });
         // Parity with the optimistic path it replaces: no closed-buffer notice
         // mirror, no trackDmPeer/markPeerEvent for ourselves.
@@ -1453,12 +1498,7 @@ export class IrcConnection {
           this.currentNick &&
           eventTarget.toLowerCase() === this.currentNick.toLowerCase()
         ) {
-          // Fold to the existing buffer row's casing so a reply sourced as
-          // "ChanServ" doesn't fork history from a "chanserv" buffer the user
-          // started (#289).
-          target =
-            getBuffer(this.network.user_id, this.network.id, eventNick as string)?.target ??
-            (eventNick as string);
+          target = this.canonicalDmTarget(eventNick as string);
         } else {
           target = `:server:${this.network.id}`;
         }
@@ -1539,7 +1579,7 @@ export class IrcConnection {
         self: false,
         userhost: buildUserhost(event),
         time: event.time,
-        ...(msgid ? { msgid } : {}),
+        msgid,
         ...(e2eFlag ? { e2e: true } : {}),
       }) as EnrichedEvent | undefined;
       // If a notice's home buffer is one the user has closed, the wsHub fan-out
@@ -4163,9 +4203,49 @@ export class IrcConnection {
   // the reflection as the persisted self row (real msgid + server time, #450).
   // When false, ircManager keeps the optimistic local publish and reflections
   // stay deduped — the pre-echo-message behavior.
+  //
+  // The socket-liveness check is load-bearing: irc-framework clears cap.enabled
+  // only on the NEXT 'connecting' event, not on socket close, and its write()
+  // silently discards lines on a dead socket. Without the check, a send during
+  // the disconnect/backoff window would skip the optimistic publish AND never
+  // get an echo — silently lost while send() returns true. Disconnected falls
+  // back to the optimistic publish, matching pre-echo behavior.
   echoActive(): boolean {
+    if (!this.client.connected) return false;
     const cap = this.client.network?.cap as { enabled?: string[] } | undefined;
     return !!cap?.enabled?.includes('echo-message');
+  }
+
+  // Register an E2E ciphertext line just written to the wire, so the message
+  // handler can recognize its echo BY CONTENT. Matching on content instead of
+  // re-checking channel E2E state at echo time closes the /e2e-off race: state
+  // can flip inside the send→echo RTT window, but the set of lines we sent
+  // cannot. TTL matches the bouncer's pendingEcho window; cap is a flood
+  // backstop (oldest dropped — worst case a stale echo is adopted as text,
+  // never lost).
+  noteSentCiphertext(line: string): void {
+    const now = Date.now();
+    const keep = this.sentCiphertext.filter((e) => now - e.at <= SENT_CIPHERTEXT_TTL_MS);
+    keep.push({ line, at: now });
+    if (keep.length > SENT_CIPHERTEXT_MAX) keep.splice(0, keep.length - SENT_CIPHERTEXT_MAX);
+    this.sentCiphertext = keep;
+  }
+
+  // True (and consumes the entry) iff `line` is a ciphertext line we recently
+  // sent. Consuming keeps a repeated identical ciphertext (can't happen — the
+  // wire format nonces every chunk — but cheap insurance) from matching twice.
+  consumeSentCiphertext(line: string): boolean {
+    const idx = this.sentCiphertext.findIndex((e) => e.line === line);
+    if (idx === -1) return false;
+    this.sentCiphertext.splice(idx, 1);
+    return true;
+  }
+
+  // Fold a DM name to the existing buffer row's casing so an echo/notice
+  // sourced as "ChanServ" doesn't fork history from a "chanserv" buffer the
+  // user started (#289). Falls back to the given casing for first contact.
+  canonicalDmTarget(name: string): string {
+    return getBuffer(this.network.user_id, this.network.id, name)?.target ?? name;
   }
 
   // Send `text` as one-or-more draft/multiline batches: each is BATCH +ref …
@@ -4208,6 +4288,24 @@ export class IrcConnection {
     const line = (event.message as string | undefined) ?? '';
     const existing = this.multilineBatches.get(id);
     if (!existing) {
+      // Graft the BATCH start line's msgid/@time (stashed by the raw handler)
+      // onto the retained first fragment: inner fragments carry only the batch
+      // ref, so without this every multiline row loses its msgid and falls
+      // back to receive time. Fragment-level tags win if a server sets both.
+      const batchTags = this.multilineBatchTags.get(id);
+      if (batchTags) {
+        this.multilineBatchTags.delete(id);
+        const tags = event.tags as Record<string, string> | undefined;
+        event = {
+          ...event,
+          // normalizeEventTime accepts the raw ISO tag string.
+          time: event.time ?? batchTags.time,
+          tags:
+            batchTags.msgid && !tags?.msgid && !tags?.['draft/msgid']
+              ? { ...tags, msgid: batchTags.msgid }
+              : tags,
+        };
+      }
       this.multilineBatches.set(id, { event, text: line });
       return;
     }

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -69,6 +69,7 @@ describe('outbound encrypt (ircManager.send)', () => {
       publish,
       client: { user: { nick: 'alice' } },
       supportsMultiline: () => false,
+      echoActive: () => false,
       flushE2eRekeys: () => {},
     } as unknown as IrcConnection;
     vi.spyOn(ircManager, 'getConnection').mockReturnValue(fakeConn);
@@ -106,6 +107,7 @@ describe('outbound encrypt (ircManager.send)', () => {
       publish,
       client: { user: { nick: 'alice' } },
       supportsMultiline: () => false,
+      echoActive: () => false,
       flushE2eRekeys: () => {},
     } as unknown as IrcConnection;
     vi.spyOn(ircManager, 'getConnection').mockReturnValue(fakeConn);
@@ -306,6 +308,7 @@ describe('egress refuses cleartext actions/notices on an E2E channel (#2)', () =
       notice,
       publish,
       publishEphemeral,
+      echoActive: () => false,
       client: { user: { nick: 'alice' } },
     } as unknown as IrcConnection;
     return { conn, action, notice, publishEphemeral };

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -70,6 +70,7 @@ describe('outbound encrypt (ircManager.send)', () => {
       client: { user: { nick: 'alice' } },
       supportsMultiline: () => false,
       echoActive: () => false,
+      noteSentCiphertext: () => {},
       flushE2eRekeys: () => {},
     } as unknown as IrcConnection;
     vi.spyOn(ircManager, 'getConnection').mockReturnValue(fakeConn);
@@ -108,6 +109,7 @@ describe('outbound encrypt (ircManager.send)', () => {
       client: { user: { nick: 'alice' } },
       supportsMultiline: () => false,
       echoActive: () => false,
+      noteSentCiphertext: () => {},
       flushE2eRekeys: () => {},
     } as unknown as IrcConnection;
     vi.spyOn(ircManager, 'getConnection').mockReturnValue(fakeConn);

--- a/server/services/ircEchoMessage.test.ts
+++ b/server/services/ircEchoMessage.test.ts
@@ -67,13 +67,23 @@ function makeConn(onEvent: (event: unknown) => void = () => {}): IrcConnection {
   return conn;
 }
 
-// Flip the negotiated cap set the way a registered server would.
+// Flip the negotiated cap set the way a registered server would, and mark the
+// socket live — echoActive() requires BOTH (a stale ACKed cap on a dead socket
+// must fall back to the optimistic publish).
 function enableEcho(conn: IrcConnection): void {
   (
     conn.client as unknown as {
       network: { cap: { enabled: string[]; available: Map<string, string> } };
+      connection: { connected: boolean };
     }
   ).network = { cap: { enabled: ['echo-message'], available: new Map() } };
+  (conn.client as unknown as { connection: { connected: boolean } }).connection = {
+    connected: true,
+  };
+}
+
+function setSocketConnected(conn: IrcConnection, connected: boolean): void {
+  (conn.client as unknown as { connection: { connected: boolean } }).connection = { connected };
 }
 
 function makeReceiver(): { conn: IrcConnection; publish: ReturnType<typeof vi.fn> } {
@@ -89,6 +99,17 @@ describe('echoActive()', () => {
     expect(conn.echoActive()).toBe(false);
     enableEcho(conn);
     expect(conn.echoActive()).toBe(true);
+  });
+
+  it('goes false when the socket drops, even though the ACKed cap survives', () => {
+    // irc-framework clears cap.enabled only on the NEXT 'connecting', and its
+    // write() silently discards lines on a dead socket — without this gate, a
+    // send in the disconnect/backoff window would skip the optimistic publish
+    // AND never get an echo: silently lost while send() returns true.
+    const conn = makeConn();
+    enableEcho(conn);
+    setSocketConnected(conn, false);
+    expect(conn.echoActive()).toBe(false);
   });
 });
 
@@ -153,10 +174,10 @@ describe('self-echo adoption in the message handler', () => {
     expect(publish.mock.calls[1][0]).toMatchObject({ type: 'action', kind: 'action', self: true });
   });
 
-  it('drops our own E2E ciphertext echo (the plaintext row was published at send time)', () => {
-    e2eManager.setChannelConfig(userId, networkId, '#enc', true, 'normal');
+  it('drops the echo of ciphertext we sent (the plaintext row was published at send time)', () => {
     const { conn, publish } = makeReceiver();
     enableEcho(conn);
+    conn.noteSentCiphertext('+RPE2E01 deadbeef');
     conn.client.emit('message', {
       nick: 'me',
       target: '#enc',
@@ -166,7 +187,25 @@ describe('self-echo adoption in the message handler', () => {
     expect(publish).not.toHaveBeenCalled();
   });
 
-  it('adopts a literal +RPE2E01 body on a NON-E2E channel as ordinary cleartext', () => {
+  it('drops sent ciphertext even after E2E was disabled in the send→echo window', () => {
+    // The gate matches by CONTENT, not channel state — /e2e off between the
+    // wire write and the echo must not turn our own ciphertext into an
+    // adopted cleartext row.
+    e2eManager.setChannelConfig(userId, networkId, '#racechan', true, 'normal');
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    conn.noteSentCiphertext('+RPE2E01 racebytes');
+    e2eManager.setChannelConfig(userId, networkId, '#racechan', false, 'normal');
+    conn.client.emit('message', {
+      nick: 'me',
+      target: '#racechan',
+      type: 'privmsg',
+      message: '+RPE2E01 racebytes',
+    });
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('adopts a literal +RPE2E01 body we never sent as ciphertext (any channel)', () => {
     const { conn, publish } = makeReceiver();
     enableEcho(conn);
     conn.client.emit('message', {
@@ -179,6 +218,20 @@ describe('self-echo adoption in the message handler', () => {
       text: '+RPE2E01 not actually ciphertext',
       self: true,
     });
+  });
+
+  it('adopts a self-DM exactly once — the delivery copy and echo copy share a msgid', () => {
+    // /msg <own nick>: ergo and solanum both send the delivery line AND the
+    // echo line, same msgid, both prefixed with our nick.
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    const selfDm = { nick: 'me', target: 'me', type: 'privmsg', message: 'note to self' };
+    conn.client.emit('message', { ...selfDm, tags: { msgid: 'twin-1' } });
+    conn.client.emit('message', { ...selfDm, tags: { msgid: 'twin-1' } });
+    expect(publish).toHaveBeenCalledTimes(1);
+    // A genuinely new message (fresh msgid) still adopts.
+    conn.client.emit('message', { ...selfDm, message: 'second note', tags: { msgid: 'twin-2' } });
+    expect(publish).toHaveBeenCalledTimes(2);
   });
 
   it('adopts a multiline echo as ONE row with the first fragment tags/time', () => {
@@ -205,6 +258,36 @@ describe('self-echo adoption in the message handler', () => {
       self: true,
       time: 1750000000000,
       msgid: 'mm',
+    });
+  });
+
+  it('grafts msgid/@time from the BATCH start line onto a multiline message', () => {
+    // Per the draft/multiline spec the logical message's tags ride the
+    // `BATCH +ref` line — which irc-framework reduces to {id,type,params},
+    // discarding the tags. The raw-line stash must recover them; inner
+    // fragments carry only the batch ref.
+    const { conn, publish } = makeReceiver();
+    conn.client.emit('raw', {
+      from_server: true,
+      line: '@msgid=batch-mm;time=2025-01-01T00:00:00.000Z :alice!u@h BATCH +bt1 draft/multiline #chan',
+    });
+    const fragment = (message: string) => ({
+      nick: 'alice',
+      target: '#chan',
+      type: 'privmsg',
+      message,
+      batch: { id: 'bt1', type: 'draft/multiline' },
+    });
+    conn.client.emit('message', fragment('part one'));
+    conn.client.emit('message', fragment('part two'));
+    conn.client.emit('batch end draft/multiline', { id: 'bt1' });
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toMatchObject({
+      text: 'part one\npart two',
+      msgid: 'batch-mm',
+      // The raw tag value is an ISO string; normalizeEventTime canonicalizes
+      // strings, so the graft passes it through untouched.
+      time: '2025-01-01T00:00:00.000Z',
     });
   });
 
@@ -347,6 +430,7 @@ describe('ircManager optimistic-publish gating', () => {
       client: { user: { nick: 'me' } },
       supportsMultiline: () => false,
       echoActive: () => true,
+      noteSentCiphertext: () => {},
       flushE2eRekeys: () => {},
       ...overrides,
     } as unknown as IrcConnection;

--- a/server/services/ircEchoMessage.test.ts
+++ b/server/services/ircEchoMessage.test.ts
@@ -1,0 +1,413 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// echo-message adoption + server-time/msgid capture (#450). With the upstream
+// cap ACKed, ircManager skips its optimistic self publish and the message
+// handler adopts the server's reflection as the persisted self row (real msgid
+// + server @time). Without the cap, reflections stay deduped and the
+// optimistic publish remains the source of truth.
+
+// MUST be first: isolate the DB before ircConnection pulls in db/index.js.
+import '../test-utils/isolateDb.js';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { IrcConnection } from './ircConnection.js';
+import ircManager from './ircManager.js';
+import { e2eManager } from './e2e/manager.js';
+import { createUser } from '../db/users.js';
+import { createNetwork } from '../db/networks.js';
+import { listMessages } from '../db/messages.js';
+import { ensureOpen } from '../db/buffers.js';
+
+let userId: number;
+let networkId: number;
+
+beforeAll(() => {
+  userId = createUser('echo-test').id;
+  const net = createNetwork(userId, {
+    name: 'echonet',
+    host: 'irc.example.test',
+    port: 6697,
+    tls: true,
+    nick: 'me',
+  });
+  networkId = net!.id;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeConn(onEvent: (event: unknown) => void = () => {}): IrcConnection {
+  const conn = new IrcConnection({
+    network: {
+      id: networkId,
+      user_id: userId,
+      name: 'echonet',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'me',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 1,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+      position: 0,
+      created_at: new Date().toISOString(),
+    },
+    onEvent,
+  });
+  conn.client.user.nick = 'me';
+  // Presence writes would trip FKs for nicks with no seeded state — not under test.
+  conn.markPeerEvent = vi.fn<typeof conn.markPeerEvent>();
+  conn.trackDmPeer = vi.fn<typeof conn.trackDmPeer>();
+  return conn;
+}
+
+// Flip the negotiated cap set the way a registered server would.
+function enableEcho(conn: IrcConnection): void {
+  (
+    conn.client as unknown as {
+      network: { cap: { enabled: string[]; available: Map<string, string> } };
+    }
+  ).network = { cap: { enabled: ['echo-message'], available: new Map() } };
+}
+
+function makeReceiver(): { conn: IrcConnection; publish: ReturnType<typeof vi.fn> } {
+  const conn = makeConn();
+  const publish = vi.fn<(event: unknown) => void>();
+  conn.publish = publish;
+  return { conn, publish };
+}
+
+describe('echoActive()', () => {
+  it('is false on a bare connection and true once the cap is ACKed', () => {
+    const conn = makeConn();
+    expect(conn.echoActive()).toBe(false);
+    enableEcho(conn);
+    expect(conn.echoActive()).toBe(true);
+  });
+});
+
+describe('self-echo adoption in the message handler', () => {
+  it('still drops a reflected self message when the cap is NOT ACKed', () => {
+    const { conn, publish } = makeReceiver();
+    conn.client.emit('message', { nick: 'me', target: '#chan', type: 'privmsg', message: 'hi' });
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('adopts a channel echo as the self row, carrying msgid + server time', () => {
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    conn.client.emit('message', {
+      // Case-variant nick: the self check must fold.
+      nick: 'ME',
+      ident: 'u',
+      hostname: 'h',
+      target: '#chan',
+      type: 'privmsg',
+      message: 'hello there',
+      time: 1750000000000,
+      tags: { msgid: 'm1' },
+    });
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toMatchObject({
+      type: 'message',
+      target: '#chan',
+      nick: 'ME',
+      text: 'hello there',
+      kind: 'privmsg',
+      self: true,
+      time: 1750000000000,
+      msgid: 'm1',
+    });
+  });
+
+  it('routes a DM echo by RECIPIENT, never by our own nick', () => {
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    conn.client.emit('message', { nick: 'me', target: 'Bob', type: 'privmsg', message: 'yo' });
+    expect(publish.mock.calls[0][0]).toMatchObject({ target: 'Bob', self: true });
+  });
+
+  it('folds a DM echo to the existing buffer row casing (#289)', () => {
+    ensureOpen(userId, networkId, 'bob');
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    conn.client.emit('message', { nick: 'me', target: 'BOB', type: 'privmsg', message: 'yo' });
+    expect(publish.mock.calls[0][0]).toMatchObject({ target: 'bob' });
+  });
+
+  it('adopts NOTICE and ACTION echoes with their own type — and never mirrors', () => {
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    conn.client.emit('message', { nick: 'me', target: '#chan', type: 'notice', message: 'n' });
+    conn.client.emit('message', { nick: 'me', target: '#chan', type: 'action', message: 'waves' });
+    // Exactly one publish per echo: the closed-buffer :server: mirror path is
+    // skipped for adopted self notices, same as the optimistic path it replaces.
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'notice', kind: 'notice', self: true });
+    expect(publish.mock.calls[1][0]).toMatchObject({ type: 'action', kind: 'action', self: true });
+  });
+
+  it('drops our own E2E ciphertext echo (the plaintext row was published at send time)', () => {
+    e2eManager.setChannelConfig(userId, networkId, '#enc', true, 'normal');
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    conn.client.emit('message', {
+      nick: 'me',
+      target: '#enc',
+      type: 'privmsg',
+      message: '+RPE2E01 deadbeef',
+    });
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('adopts a literal +RPE2E01 body on a NON-E2E channel as ordinary cleartext', () => {
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    conn.client.emit('message', {
+      nick: 'me',
+      target: '#plain',
+      type: 'privmsg',
+      message: '+RPE2E01 not actually ciphertext',
+    });
+    expect(publish.mock.calls[0][0]).toMatchObject({
+      text: '+RPE2E01 not actually ciphertext',
+      self: true,
+    });
+  });
+
+  it('adopts a multiline echo as ONE row with the first fragment tags/time', () => {
+    const { conn, publish } = makeReceiver();
+    enableEcho(conn);
+    const fragment = (message: string, extra: Record<string, unknown> = {}) => ({
+      nick: 'me',
+      target: '#chan',
+      type: 'privmsg',
+      message,
+      batch: { id: 'b1', type: 'draft/multiline' },
+      ...extra,
+    });
+    conn.client.emit(
+      'message',
+      fragment('line one', { time: 1750000000000, tags: { msgid: 'mm' } }),
+    );
+    conn.client.emit('message', fragment('line two'));
+    expect(publish).not.toHaveBeenCalled();
+    conn.client.emit('batch end draft/multiline', { id: 'b1' });
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toMatchObject({
+      text: 'line one\nline two',
+      self: true,
+      time: 1750000000000,
+      msgid: 'mm',
+    });
+  });
+
+  it('a case-variant self TAGMSG echo never surfaces a typing indicator', () => {
+    const conn = makeConn();
+    enableEcho(conn);
+    const publishEphemeral = vi.fn<(event: unknown) => void>();
+    conn.publishEphemeral = publishEphemeral;
+    conn.client.emit('tagmsg', { nick: 'ME', target: '#chan', tags: { '+typing': 'active' } });
+    expect(publishEphemeral).not.toHaveBeenCalled();
+  });
+
+  it('a self CTCP response echo never re-enters the E2E handshake', () => {
+    const conn = makeConn();
+    enableEcho(conn);
+    const handshake = vi.spyOn(e2eManager, 'handleHandshakeBody');
+    conn.client.emit('ctcp response', {
+      nick: 'ME',
+      ident: 'u',
+      hostname: 'h',
+      target: '#hs',
+      type: 'RPEE2E',
+      message: 'RPEE2E whatever',
+    });
+    expect(handshake).not.toHaveBeenCalled();
+  });
+});
+
+describe('server-time + msgid persistence (real publish)', () => {
+  it('persists an adopted echo with the ISO of the @time tag and its msgid', () => {
+    const conn = makeConn();
+    enableEcho(conn);
+    conn.client.emit('message', {
+      nick: 'me',
+      target: '#persist1',
+      type: 'privmsg',
+      message: 'stamped',
+      time: 1750000000000,
+      tags: { msgid: 'echo-1' },
+    });
+    const rows = listMessages(networkId, '#persist1');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      self: true,
+      text: 'stamped',
+      msgid: 'echo-1',
+      time: new Date(1750000000000).toISOString(),
+    });
+  });
+
+  it('persists a peer message with tag time as ISO and honors the draft/msgid alias', () => {
+    const conn = makeConn();
+    conn.client.emit('message', {
+      nick: 'alice',
+      ident: 'a',
+      hostname: 'h',
+      target: '#persist2',
+      type: 'privmsg',
+      message: 'tagged',
+      time: 1750000000000,
+      tags: { 'draft/msgid': 'draft-1' },
+    });
+    const rows = listMessages(networkId, '#persist2');
+    expect(rows[0]).toMatchObject({
+      self: false,
+      msgid: 'draft-1',
+      time: new Date(1750000000000).toISOString(),
+    });
+  });
+
+  it('falls back to receive time when the tag is absent, and omits msgid entirely', () => {
+    const conn = makeConn();
+    const before = Date.now();
+    conn.client.emit('message', {
+      nick: 'alice',
+      target: '#persist3',
+      type: 'privmsg',
+      message: 'untagged',
+    });
+    const row = listMessages(networkId, '#persist3')[0];
+    const stored = Date.parse(row.time);
+    expect(stored).toBeGreaterThanOrEqual(before - 1000);
+    expect(stored).toBeLessThanOrEqual(Date.now() + 1000);
+    expect(row).not.toHaveProperty('msgid');
+  });
+
+  it('clamps a far-future tag time to receive time (buffer MAX(time) pinning guard)', () => {
+    const conn = makeConn();
+    const before = Date.now();
+    conn.client.emit('message', {
+      nick: 'alice',
+      target: '#persist4',
+      type: 'privmsg',
+      message: 'from the future',
+      time: Date.now() + 10 * 60_000,
+    });
+    const stored = Date.parse(listMessages(networkId, '#persist4')[0].time);
+    expect(stored).toBeGreaterThanOrEqual(before - 1000);
+    expect(stored).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it('keeps a PAST tag time verbatim — bouncer replay must not be rewritten', () => {
+    const conn = makeConn();
+    const past = Date.now() - 3 * 24 * 60 * 60_000;
+    conn.client.emit('message', {
+      nick: 'alice',
+      target: '#persist5',
+      type: 'privmsg',
+      message: 'replayed',
+      time: past,
+    });
+    expect(listMessages(networkId, '#persist5')[0].time).toBe(new Date(past).toISOString());
+  });
+
+  it('threads @time through a metadata handler too (join)', () => {
+    const conn = makeConn();
+    conn.client.emit('join', {
+      nick: 'alice',
+      ident: 'a',
+      hostname: 'h',
+      channel: '#persist6',
+      time: 1750000000000,
+    });
+    const rows = listMessages(networkId, '#persist6');
+    expect(rows[0]).toMatchObject({ type: 'join', time: new Date(1750000000000).toISOString() });
+  });
+});
+
+describe('ircManager optimistic-publish gating', () => {
+  function fakeConn(overrides: Record<string, unknown> = {}) {
+    const say = vi.fn<(target: string, text: string) => void>();
+    const action = vi.fn<(target: string, text: string) => void>();
+    const notice = vi.fn<(target: string, text: string) => void>();
+    const publish = vi.fn<(event: unknown) => void>();
+    const conn = {
+      say,
+      action,
+      notice,
+      publish,
+      client: { user: { nick: 'me' } },
+      supportsMultiline: () => false,
+      echoActive: () => true,
+      flushE2eRekeys: () => {},
+      ...overrides,
+    } as unknown as IrcConnection;
+    return { conn, say, action, notice, publish };
+  }
+
+  it('send/action/notice write the wire but skip the optimistic publish when echo is active', () => {
+    const { conn, say, action, notice, publish } = fakeConn();
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
+    ircManager.send(userId, networkId, '#gate', 'hi');
+    ircManager.action(userId, networkId, '#gate', 'waves');
+    ircManager.notice(userId, networkId, '#gate', 'psst');
+    expect(say).toHaveBeenCalledWith('#gate', 'hi');
+    expect(action).toHaveBeenCalledWith('#gate', 'waves');
+    expect(notice).toHaveBeenCalledWith('#gate', 'psst');
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('keeps the optimistic publish when the cap is absent', () => {
+    const { conn, publish } = fakeConn({ echoActive: () => false });
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
+    ircManager.send(userId, networkId, '#gate', 'hi');
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toMatchObject({ type: 'message', text: 'hi', self: true });
+  });
+
+  it('multiline sends still hit the wire, publish only without the cap', () => {
+    const sendMultiline = vi.fn<(target: string, text: string) => string[]>(() => ['a\nb']);
+    const withEcho = fakeConn({ supportsMultiline: () => true, sendMultiline });
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(withEcho.conn);
+    ircManager.send(userId, networkId, '#gate', 'a\nb');
+    expect(sendMultiline).toHaveBeenCalledWith('#gate', 'a\nb');
+    expect(withEcho.publish).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+
+    const noEcho = fakeConn({
+      supportsMultiline: () => true,
+      sendMultiline,
+      echoActive: () => false,
+    });
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(noEcho.conn);
+    ircManager.send(userId, networkId, '#gate', 'a\nb');
+    expect(noEcho.publish).toHaveBeenCalledTimes(1);
+    expect(noEcho.publish.mock.calls[0][0]).toMatchObject({ text: 'a\nb', self: true });
+  });
+
+  it('the E2E branch keeps its optimistic plaintext publish even with echo active', () => {
+    e2eManager.setChannelConfig(userId, networkId, '#e2egate', true, 'normal');
+    const { conn, say, publish } = fakeConn();
+    vi.spyOn(ircManager, 'getConnection').mockReturnValue(conn);
+    ircManager.send(userId, networkId, '#e2egate', 'secret hello');
+    // Ciphertext on the wire, exactly one readable self bubble locally.
+    expect(say).toHaveBeenCalled();
+    for (const [, line] of say.mock.calls) {
+      expect(line.startsWith('+RPE2E01')).toBe(true);
+    }
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toMatchObject({
+      text: 'secret hello',
+      self: true,
+      e2e: true,
+    });
+  });
+});

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -453,7 +453,14 @@ class IrcManager extends EventEmitter {
         return false;
       }
       if (outcome.kind === 'encrypted') {
-        for (const line of outcome.lines) conn.say(target, line);
+        for (const line of outcome.lines) {
+          conn.say(target, line);
+          // Registered so the message handler can recognize (and drop) the
+          // echo-message reflection of our own ciphertext by content — see
+          // consumeSentCiphertext. Unconditional: echoActive() can flip
+          // between here and the echo's arrival.
+          conn.noteSentCiphertext(line);
+        }
         conn.publish({
           type: 'message',
           target,
@@ -548,6 +555,8 @@ class IrcManager extends EventEmitter {
         target,
         nick: conn.client.user?.nick,
         text: chunk,
+        // Shape parity with the adopted echo, which stamps kind:'action'.
+        kind: 'action',
         self: true,
       });
     }

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -476,16 +476,28 @@ class IrcManager extends EventEmitter {
     // (not a bare newline) so "hello\n" stays a single-line send — splitMultiline
     // trims edge blanks, and the client's multilineMessageCount gates the same
     // way, so the two stay in sync. (#381)
+    // With upstream echo-message ACKed, the server reflects our sends back and
+    // the ircConnection message handler adopts that echo as the persisted self
+    // row (real msgid + server time, #450) — so the optimistic publish below is
+    // skipped or it would duplicate. Wire writes still happen unconditionally
+    // (say/sendMultiline own the noteUserSend/trackDmPeer side effects). The
+    // E2E branch above is exempt: its echo is ciphertext, so the plaintext self
+    // row can only come from here.
+    const adoptEcho = conn.echoActive();
     if (hasInteriorNewline(text) && conn.supportsMultiline()) {
       const nick = conn.client.user?.nick;
-      for (const echo of conn.sendMultiline(target, text)) {
-        conn.publish({ type: 'message', target, nick, text: echo, kind: 'privmsg', self: true });
+      const echoes = conn.sendMultiline(target, text);
+      if (!adoptEcho) {
+        for (const echo of echoes) {
+          conn.publish({ type: 'message', target, nick, text: echo, kind: 'privmsg', self: true });
+        }
       }
       return true;
     }
     const chunks = splitSay(text);
     for (const chunk of chunks) {
       conn.say(target, chunk);
+      if (adoptEcho) continue;
       conn.publish({
         type: 'message',
         target,
@@ -525,9 +537,12 @@ class IrcManager extends EventEmitter {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
     if (this.refuseCleartextOnE2eChannel(conn, userId, networkId, target, 'action')) return true;
+    // Same echo-adoption gating as send() — see the comment there.
+    const adoptEcho = conn.echoActive();
     const chunks = splitAction(text);
     for (const chunk of chunks) {
       conn.action(target, chunk);
+      if (adoptEcho) continue;
       conn.publish({
         type: 'action',
         target,
@@ -539,17 +554,20 @@ class IrcManager extends EventEmitter {
     return true;
   }
 
-  // IRC servers don't echo your own NOTICE back (and Lurker doesn't request the
-  // echo-message cap), so — exactly like send/action — we publish a self copy
-  // locally per wire chunk. splitSay applies because NOTICE shares PRIVMSG's
-  // length budget.
+  // NOTICE shares send()'s echo model: echo-message servers DO reflect your
+  // own NOTICEs (the cap covers PRIVMSG/NOTICE/TAGMSG alike), so the local
+  // self copy is published only where the cap is absent — exactly like
+  // send/action. splitSay applies because NOTICE shares PRIVMSG's length
+  // budget.
   notice(userId: number, networkId: number, target: string, text: string): boolean {
     const conn = this.getConnection(userId, networkId);
     if (!conn) return false;
     if (this.refuseCleartextOnE2eChannel(conn, userId, networkId, target, 'notice')) return true;
+    const adoptEcho = conn.echoActive();
     const chunks = splitSay(text);
     for (const chunk of chunks) {
       conn.notice(target, chunk);
+      if (adoptEcho) continue;
       conn.publish({
         type: 'notice',
         target,

--- a/server/types/irc-framework.d.ts
+++ b/server/types/irc-framework.d.ts
@@ -94,6 +94,13 @@ declare module 'irc-framework' {
     /** The local user's state (nick, username, etc.). */
     user: UserInfo;
 
+    /**
+     * True while the TCP/TLS socket is up (client.js proxies
+     * connection.connected). NOT reset caps/registration state — cap.enabled
+     * survives a socket drop until the next 'connecting' event.
+     */
+    readonly connected: boolean;
+
     /** Request an IRCv3 capability during CAP negotiation. */
     requestCap(cap: string): void;
 

--- a/vue_client/src/utils/collapseDisplay.test.ts
+++ b/vue_client/src/utils/collapseDisplay.test.ts
@@ -95,6 +95,22 @@ describe('collapseDisplay — author collapsing', () => {
     expect(rows[1].continuationAuthor).toBeUndefined();
   });
 
+  it('breaks the run when time goes BACKWARD (bouncer replay of an old line)', () => {
+    // Rows carry server-time: a chained-bouncer replay can append a row whose
+    // time is older than the previous row's. A negative delta must not read
+    // as "within the window" and collapse the replayed line under the fresh
+    // message.
+    const rows = [
+      msg({ id: 1, nick: 'alice', time: '2026-05-16T10:00:00Z' }),
+      msg({ id: 2, nick: 'alice', time: '2026-05-16T08:00:00Z' }),
+    ];
+    collapseDisplay(rows, {
+      collapseAuthors: true,
+      authorWindowMs: 5 * 60_000,
+    });
+    expect(rows[1].continuationAuthor).toBeUndefined();
+  });
+
   it('does not collapse action / notice rows even from the same nick', () => {
     const rows = [
       msg({ id: 1, nick: 'alice', time: '2026-05-16T10:00:00Z', type: 'action' }),

--- a/vue_client/src/utils/collapseDisplay.ts
+++ b/vue_client/src/utils/collapseDisplay.ts
@@ -82,11 +82,12 @@ export function collapseDisplay(rows: DisplayRow[], options: CollapseOptions = {
       // so a self message after a non-self message from the same nick must
       // not collapse — even though that's a deeply unusual case.
       const key = `${row.m.self ? '1' : '0'}:${row.m.nick || ''}`;
-      if (
-        prevAuthorKey === key &&
-        prevAuthorTimeMs != null &&
-        timeMs - prevAuthorTimeMs <= authorWindowMs
-      ) {
+      // The delta must be non-negative: rows carry server-time, which a
+      // bouncer replay can stamp OLDER than the preceding row's. A negative
+      // delta would trivially pass the window check and collapse a replayed
+      // old line under a fresh message it doesn't belong to.
+      const deltaMs = prevAuthorTimeMs != null ? timeMs - prevAuthorTimeMs : -1;
+      if (prevAuthorKey === key && deltaMs >= 0 && deltaMs <= authorWindowMs) {
         row.continuationAuthor = true;
       }
       prevAuthorKey = key;


### PR DESCRIPTION
## Summary

Two long-standing gaps, one plumbing pass (closes #450):

1. **Timestamps are now IRCv3 server-time** where the network offers it. Previously every persisted row got cell receive time — `publish()` had an `event.time` fallback, but no call site ever passed one, even though irc-framework parses the `@time=` tag onto every event (the `loadHistoryWindow` comment already *assumed* replayed server-time was stored; now it actually is). `normalizeEventTime()` converts irc-framework's epoch-ms numbers to canonical ISO-Z — the only form the `time` TEXT column's lexicographic comparisons tolerate — with receive-time fallback, and every persisting handler (message/action/notice, join, part, kick, quit, nick, topic, mode, invite, chghost) threads the tag through.
2. **`msgid` capture + `echo-message`** (#450): new indexed `messages.msgid` column stores the server's message id (`draft/msgid` alias honored), surfaced on the ws frame (additive — no client changes) and in export/import. We now request `echo-message` upstream; when ACKed, the optimistic self publish in `ircManager` is skipped and the message handler **adopts the server's reflection** as the persisted self row — so our own sends get their real msgid + server time. Without the cap, behavior is byte-for-byte today's (optimistic publish + reflection dedupe).

## Design notes

- **Reference-validated**: The Lounge (`enable_echomessage: true`, cap-gated suppression, persists `tags.msgid`, `new Date(data.time)`) and soju (persists the upstream time tag, skips the local insert when upstream echo-message is ACKed) both do exactly this. halloy's optimistic-insert-then-content-reconcile approach was considered and rejected (more machinery; irc-framework lacks labeled-response).
- **Future-time clamp (+2 min → receive time)** is deliberately *stricter* than every reference (only znc guards int64 overflow): `listBuffersForNetwork` orders by `MAX(time)`, so one bad future row would pin a buffer's sort forever. Past stamps are kept verbatim — that's legitimate bouncer replay. A wholly-skewed server degrades gracefully to receive time (= previous behavior).
- **Echo routing is by recipient** (`event.target`), never nick — a DM echo's nick is *us*; DM targets fold to the existing buffer row's casing (#289 pattern).
- **E2E**: encrypted sends keep the optimistic plaintext row; our own ciphertext echoes are dropped (gate mirrors the inbound decrypt gate, so a literal `+RPE2E01` typed on a non-E2E channel still adopts). New self-guards: `ctcp response` (echoed RPE2E handshake replies must not re-enter the key exchange) and case-folded `tagmsg` (no self typing indicators).
- **Bouncer unchanged**: `deliverSelfEcho`/`pendingEcho` key off `event.self`, which adopted echoes still set. CHATHISTORY keeps emitting internal row ids as `msgid` (MSGREFTYPES stays `timestamp`-only) — a new test locks that in; serving stored upstream msgids there is future work.

## Behavior changes

- On echo-message networks, your own message renders after one upstream RTT (the `self:true` frame now comes from the wire); `send-result` acks are still immediate. Non-echo networks unchanged.
- A send the server never echoes (netsplit mid-send) is no longer persisted — more truthful than the old optimistic row.
- `time` may be non-monotonic vs `id` (bouncer replays); all message-list ordering remains id-based. Old rows keep receive time — no migration, no version bump (single `ensureColumn` ALTER, Litestream-safe).
- Small additive deltas on adopted self rows: `kind:'action'` now set, `userhost` = our own mask, `msgid` present.

## Testing

- New `server/services/ircEchoMessage.test.ts` (21 tests): cap-off dedupe preserved; channel/DM/notice/action adoption; DM recipient routing + case-fold; E2E ciphertext echo dropped with plaintext intact; multiline echo = one row with first-fragment tags; self TAGMSG/CTCP-response guards; end-to-end persistence (epoch-ms → ISO, msgid column, draft/msgid alias, receive-time fallback, future clamp, past kept, join threading); ircManager gating incl. the E2E exemption.
- Extended: msgid round-trip in `messages.test.ts` (absent-not-null), export→import round-trip in `importService.test.ts`, bouncer CHATHISTORY namespace guard in `bouncer.chathistory.test.ts`.
- `npm run check` exit 0; `npm test` exit 0 (207 files, 2758 tests).

Follow-up candidates: push-notification suppression for old-server-time replays (The Lounge does 15 min), serving real msgids downstream in the bouncer, react/reply themselves (#450's original motivation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)