### PR TITLE
Fold the ignore/mute veto into the server notify flag

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -332,11 +332,14 @@ react/reply; today it is informational only.
 **`notify` is the server's delivery decision — the one flag to gate a live
 alert (toast, sound, native buzz) on.** It is the union of the content signals
 (`matched`, `dm`, `notifyAlways`) with the user's ignore/mute verdict **already
-applied**: a hide-level or **NONOTIFY** rule — a muted channel, network, DM, or
-sender (§6 `add-ignore`) — forces `notify:false`, even though the message is
-still delivered and still counts toward unread. So a muted-channel highlight
-arrives as `matched:true, notify:false` — style it as a highlight in history,
-but do **not** raise a notification for it. **Do not re-implement ignore
+applied**. A **NONOTIFY** rule — a muted channel, network, DM, or sender (§6
+`add-ignore`) — forces `notify:false` while the message is still delivered and
+still counts toward unread; only the alert is suppressed. A hide-level ignore
+also forces `notify:false`, but that message is _additionally_ excluded from
+unread/highlight counts server-side (the `from_ignored` stamp) and hidden by
+your render filter — so don't count it. So a muted-channel highlight arrives as
+`matched:true, notify:false` — style it as a highlight in history, but do
+**not** raise a notification for it. **Do not re-implement ignore
 matching client-side for this decision** — the server owns it (it must: push
 fires when no client is attached, so the veto can't live only in a client).
 The raw signals stay on the wire beside `notify` so you can still pick the

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -329,6 +329,23 @@ own sends learn theirs via `echo-message`). Absent — not null — on rows from
 untagged networks and on optimistic self echoes. It is the future anchor for
 react/reply; today it is informational only.
 
+**`notify` is the server's delivery decision — the one flag to gate a live
+alert (toast, sound, native buzz) on.** It is the union of the content signals
+(`matched`, `dm`, `notifyAlways`) with the user's ignore/mute verdict **already
+applied**: a hide-level or **NONOTIFY** rule — a muted channel, network, DM, or
+sender (§6 `add-ignore`) — forces `notify:false`, even though the message is
+still delivered and still counts toward unread. So a muted-channel highlight
+arrives as `matched:true, notify:false` — style it as a highlight in history,
+but do **not** raise a notification for it. **Do not re-implement ignore
+matching client-side for this decision** — the server owns it (it must: push
+fires when no client is attached, so the veto can't live only in a client).
+The raw signals stay on the wire beside `notify` so you can still pick the
+toast kind / sound per signal type. Note a **NOHIGHLIGHT** rule is display-only
+(it clears `matched`, not `notify`), so a de-highlighted DM still notifies —
+`notify` and the client-applied render/hide filter (from the snapshot's
+`globalIgnores` / `ignoredMasks`) are two different jobs: the server pre-resolves
+the _notify_ verdict into this flag; you apply the _hide_ verdict yourself.
+
 > ⚠ **Live-frame `kind` clobber.** When an event arrives live it is wrapped as
 > `{...event, kind:'irc'}` — the event's own `kind` field is overwritten by the
 > envelope discriminator. The raw-IRC-command `kind` (`privmsg`, `action`,

--- a/server/services/wsHub.decorate.test.ts
+++ b/server/services/wsHub.decorate.test.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Characterization cover for decorateMessage's `notify` fold (#359 follow-up).
+//
+// `notify` is the single authoritative "alert the user" gate: the content-signal
+// union (matched/dm/notifyAlways) with the ignore/mute veto folded in, so every
+// live client (web toast, native buzz) and the push path can trust one flag
+// instead of re-deriving the verdict — which is how a per-channel mute leaked
+// back through to native clients that trusted `notify`. These lock in which
+// ignore levels clear it: a hide-level or NONOTIFY rule suppresses; a NOHIGHLIGHT
+// rule does NOT (it's display-only — the message stays visible and counted).
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+import type { MessageEvent } from '../db/messages.js';
+
+const testDb = setupTestDb('wshub-decorate');
+
+let decorateMessage: typeof import('./wsHub.js').decorateMessage;
+let ignoreRulesService: typeof import('./ignoreRulesService.js').default;
+let setChannelNotifyAlways: typeof import('../db/channelNotify.js').setChannelNotifyAlways;
+
+let userId: number;
+let networkId: number;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { createNetwork } = await import('../db/networks.js');
+  ({ setChannelNotifyAlways } = await import('../db/channelNotify.js'));
+  ignoreRulesService = (await import('./ignoreRulesService.js')).default;
+  ({ decorateMessage } = await import('./wsHub.js'));
+
+  userId = createUser('decorateuser').id;
+  networkId = createNetwork(userId, {
+    name: 'libera',
+    host: 'irc.example',
+    port: 6697,
+    tls: true,
+    nick: 'decorateuser',
+  })!.id;
+});
+
+afterAll(() => {
+  testDb.cleanup();
+});
+
+beforeEach(() => {
+  for (const rule of ignoreRulesService.list(userId, networkId)) {
+    ignoreRulesService.removeById(userId, networkId, rule.id);
+  }
+  for (const rule of ignoreRulesService.listGlobal(userId)) {
+    ignoreRulesService.removeById(userId, null, rule.id);
+  }
+  setChannelNotifyAlways(userId, networkId, '#lurker', false);
+});
+
+// A base inbound message event from bob. `id`/`time` don't affect the notify
+// decision; callers override target/type/matched/nick as needed. A bare target
+// (no '#') on a 'message' makes decorateMessage derive dm → notify.
+function ev(overrides: Partial<MessageEvent> = {}): MessageEvent {
+  return {
+    id: 1,
+    networkId,
+    target: 'bob',
+    time: new Date().toISOString(),
+    type: 'message',
+    nick: 'bob',
+    text: 'ping',
+    kind: null,
+    self: false,
+    userhost: 'bob!bob@example.host',
+    alt: false,
+    matched: false,
+    matchedRuleId: null,
+    fromIgnored: false,
+    mirrored: false,
+    ...overrides,
+  };
+}
+
+// A sender-scoped rule on bob. `levels` is the only knob most tests touch.
+function addSenderRule(levels: string[]): void {
+  ignoreRulesService.add(userId, networkId, {
+    mask: 'bob!*@*',
+    channels: null,
+    pattern: null,
+    patternKind: 'substr',
+    levels,
+    isExcept: false,
+    expiresAt: null,
+  });
+}
+
+// A channel-scoped, null-mask mute — exactly what the notify ladder writes to
+// mute #lurker (mask null = anyone, scoped to the channel).
+function addChannelMute(levels: string[]): void {
+  ignoreRulesService.add(userId, networkId, {
+    mask: null,
+    channels: ['#lurker'],
+    pattern: null,
+    patternKind: 'substr',
+    levels,
+    isExcept: false,
+    expiresAt: null,
+  });
+}
+
+describe('decorateMessage notify fold', () => {
+  it('sets notify on a DM when nothing suppresses it', () => {
+    const d = decorateMessage(userId, ev());
+    expect(d.dm).toBe(true);
+    expect(d.notify).toBe(true);
+  });
+
+  it('a NONOTIFY rule clears notify while the raw signals still ride the wire', () => {
+    addSenderRule(['NONOTIFY']);
+    const d = decorateMessage(userId, ev());
+    expect(d.notify).toBe(false);
+    // The content signal is untouched — clients still learn it was a DM.
+    expect(d.dm).toBe(true);
+  });
+
+  it('a hide-level rule clears notify', () => {
+    addSenderRule(['ALL']);
+    expect(decorateMessage(userId, ev()).notify).toBe(false);
+  });
+
+  it('a NOHIGHLIGHT rule does NOT clear notify (display-only, matches push)', () => {
+    // Deliberate (#359): NOHIGHLIGHT means "don't light it up", not "don't tell
+    // me". Only hide + NONOTIFY clear notify. If this flips, the levels have
+    // been conflated and a de-highlighted DM would stop notifying.
+    addSenderRule(['NOHIGHLIGHT']);
+    expect(decorateMessage(userId, ev()).notify).toBe(true);
+  });
+
+  it('a muted channel forces notify:false on a highlight while matched stays true', () => {
+    // The headline case: a muted-channel highlight must arrive as
+    // matched:true, notify:false — styled as a highlight in history, but no
+    // toast/buzz. matched is stamped at insert time and rides in on the event.
+    addChannelMute(['NOUNREAD', 'NONOTIFY']);
+    const d = decorateMessage(
+      userId,
+      ev({
+        target: '#lurker',
+        nick: 'carol',
+        userhost: 'carol!c@h',
+        matched: true,
+        matchedRuleId: 7,
+      }),
+    );
+    expect(d.matched).toBe(true);
+    expect(d.notify).toBe(false);
+  });
+
+  it('a NONOTIFY mute wins even in a notify-always channel', () => {
+    setChannelNotifyAlways(userId, networkId, '#lurker', true);
+    addChannelMute(['NONOTIFY']);
+    const d = decorateMessage(
+      userId,
+      ev({ target: '#lurker', nick: 'carol', userhost: 'carol!c@h' }),
+    );
+    expect(d.notifyAlways).toBe(true);
+    expect(d.notify).toBe(false);
+  });
+});

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -417,16 +417,46 @@ function isDirect(event: MessageEvent): boolean {
   return isDmTarget(event.target || '');
 }
 
+// The user's ignore verdict for an event, off the cached compiled rule set (no
+// DB scan per event). Shared by decorateMessage's notify fold, the push gate,
+// and the closed-buffer reopen guard. Evaluates even for a nick-less event so a
+// scope mute (mask null — a muted channel/network) still vetoes it; a
+// sender-specific rule simply won't match a null nick.
+function ignoreVerdictForEvent(
+  userId: number,
+  networkId: number,
+  ev: {
+    nick?: string | null;
+    userhost?: string | null;
+    target: string;
+    text?: string | null;
+    type: string;
+    isDm: boolean;
+  },
+): IgnoreVerdict {
+  const compiled = ignoreRulesService.getCompiled(userId, networkId);
+  if (!compiled.length) return { hide: false, nohilight: false, nonotify: false };
+  return evaluateIgnores(compiled, {
+    nick: ev.nick ?? null,
+    userhost: ev.userhost ?? null,
+    target: ev.target,
+    text: ev.text ?? '',
+    type: ev.type,
+    isDm: ev.isDm,
+  });
+}
+
 // Match state is persisted on each message at insert time (see
 // ircConnection.publish), so events already arrive with matched/matchedRuleId
 // populated — either from the live IRC pipeline or from rowToEvent for
 // backlog reads. This decoration adds the per-broadcast `dm` and
 // `notifyAlways` content signals and the derived `notify` delivery decision,
 // and normalizes the match fields so non-persisted events (typing, names,
-// etc.) don't surface as undefined. Content signals stay separate on the
-// wire so clients can route toast/sound per signal type; `notify` is the
-// union and is the single gate consulted by push delivery and the in-client
-// notifier.
+// etc.) don't surface as undefined. The raw content signals stay separate on
+// the wire so clients can route toast/sound per signal type; `notify` is the
+// authoritative delivery gate — the union of those signals WITH the ignore/mute
+// veto folded in (see below), consulted by push delivery and by every live
+// client (web toast, native buzz).
 export function decorateMessage(userId: number, event: MessageEvent): DecoratedEvent {
   const matched = !!event.matched;
   const matchedRuleId = event.matchedRuleId ?? null;
@@ -442,7 +472,32 @@ export function decorateMessage(userId: number, event: MessageEvent): DecoratedE
     isChannel &&
     !event.self &&
     getChannelNotifyAlways(userId, event.networkId, target);
-  const notify = !isStatus && (matched || dm || notifyAlways);
+  // Content says this line is notification-worthy: a highlight, a DM, or a
+  // notify-always channel.
+  const contentNotify = !isStatus && (matched || dm || notifyAlways);
+  // Fold the ignore/mute veto into `notify` so it is the single authoritative
+  // "alert the user" gate every consumer can trust — push, the web toast, and
+  // native clients all read this one flag instead of each re-deriving the
+  // verdict (a per-channel mute leaked through to native clients that trusted
+  // `notify`; issue #359). The predicate mirrors the push path exactly: a
+  // hide-level or NONOTIFY rule suppresses; a NOHIGHLIGHT rule does NOT — it's
+  // display-only (decideStamp already nulled `matched`, and the message stays
+  // visible and counted). Recomputed per serve off the cached compiled rules,
+  // so /unignore reveals reactively. Only pay for the verdict when the content
+  // is otherwise notify-worthy — most backlog rows aren't, so history serves
+  // stay cheap.
+  let notify = contentNotify;
+  if (contentNotify) {
+    const verdict = ignoreVerdictForEvent(userId, event.networkId, {
+      nick: event.nick,
+      userhost: event.userhost,
+      target,
+      text: event.text,
+      type: event.type,
+      isDm: dm,
+    });
+    if (verdict.hide || verdict.nonotify) notify = false;
+  }
   return {
     ...event,
     matched,
@@ -1386,22 +1441,16 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     return false;
   }
 
-  // The user's ignore verdict for an event, off the cached compiled rule set (no
-  // DB scan per event). senderHidden reads .hide for the render/reopen path;
-  // maybePush additionally honors .nonotify (issue #359 — a NONOTIFY mute rule
-  // freezes push without hiding the message).
+  // The user's ignore verdict for a decorated event. Thin wrapper over the
+  // module-level ignoreVerdictForEvent; senderHidden reads .hide for the
+  // render/reopen path (the .nonotify veto is already folded into `notify` by
+  // decorateMessage, so the push gate no longer needs this).
   function ignoreVerdictFor(userId: number, decorated: DecoratedEvent): IgnoreVerdict {
-    const compiled = ignoreRulesService.getCompiled(userId, decorated.networkId);
-    if (!compiled.length) return { hide: false, nohilight: false, nonotify: false };
-    // Evaluate even for a nick-less event: a scope mute (mask null — a muted
-    // channel/network) must still veto its notification, so a nick-less line
-    // (e.g. a server notice in a notify_always channel) doesn't slip past. A
-    // sender-specific rule simply won't match a null nick.
-    return evaluateIgnores(compiled, {
-      nick: decorated.nick ?? null,
-      userhost: decorated.userhost ?? null,
+    return ignoreVerdictForEvent(userId, decorated.networkId, {
+      nick: decorated.nick,
+      userhost: decorated.userhost,
       target: decorated.target,
-      text: decorated.text ?? '',
+      text: decorated.text,
       type: decorated.type,
       isDm: !!decorated.dm,
     });
@@ -1422,15 +1471,16 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // the badge total below (it's an O(buffers) scan). deliver() would no-op on
     // an empty subscription set anyway — bail before the work (#451 review).
     if (!pushService.hasSubscriptions(userId)) return;
-    // Suppress push for events the user's ignore rules would hide OR mute
-    // (NONOTIFY, e.g. a muted channel/network — issue #359). This is the one
-    // piece of the ignore/mute feature that has to live server-side: push fires
-    // while no client is open, so a client-side filter can't intercept. The
-    // unread badge and render filter stay reactive client-side, so /unignore
-    // still reveals; only push delivery is frozen here. A NOHIGHLIGHT rule does
-    // NOT freeze push — the message is still visible, it just doesn't highlight.
-    const pushVerdict = ignoreVerdictFor(userId, decorated);
-    if (pushVerdict.hide || pushVerdict.nonotify) return;
+    // The ignore/mute veto — a hide-level or NONOTIFY rule (a muted
+    // channel/network/sender — issue #359) — is already folded into
+    // `decorated.notify` by decorateMessage, so the `notify` gate above has
+    // suppressed those before we reach here; no separate verdict check needed.
+    // This decision must live server-side (push fires while no client is open,
+    // so a client-side filter can't intercept), and folding it into `notify` is
+    // what lets every live client trust the one flag too. The unread badge and
+    // render filter stay reactive client-side, so /unignore still reveals. A
+    // NOHIGHLIGHT rule deliberately does NOT freeze push — the message is still
+    // visible, it just doesn't highlight.
     // Signal kind in priority order: DM beats matched beats always_notify.
     // The `kind` doubles as the settings-key namespace, so picking a single
     // priority winner here means a DM that also matched a rule still

--- a/vue_client/src/composables/useHighlightNotifier.test.ts
+++ b/vue_client/src/composables/useHighlightNotifier.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Cover for notifyForEvent's gate on the server `notify` flag (#359 follow-up).
+//
+// The client no longer re-derives the ignore verdict — it trusts the server's
+// `notify` (the content-signal union with hide + NONOTIFY already folded in). A
+// muted buffer arrives as notify:false and must not toast; a de-highlighted DM
+// arrives as notify:true and still toasts (NOHIGHLIGHT is display-only). These
+// lock that in so a future edit can't silently re-introduce a client-side veto
+// or invert the gate.
+
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+
+let push: Mock<(t: unknown) => void>;
+let effective: Mock<(key: string) => unknown>;
+
+// Load a fresh notifyForEvent with the stores it reads mocked. `viewed` is the
+// buffer key currently on screen (default '' so the event's buffer is never the
+// viewed one); `hidden` models a background tab; `enabled` toggles the per-kind
+// master switch. Sound is forced off so no Audio is constructed.
+async function load(opts: { viewed?: string; hidden?: boolean; enabled?: boolean } = {}) {
+  vi.resetModules();
+  push = vi.fn<(t: unknown) => void>();
+  effective = vi.fn<(key: string) => unknown>((key: string) => {
+    if (key.includes('.sound.')) return false; // no sound / no Audio
+    if (key.endsWith('.enabled')) return opts.enabled ?? true;
+    return undefined;
+  });
+  vi.doMock('../stores/toasts.js', () => ({ useToastsStore: () => ({ push }) }));
+  vi.doMock('../stores/settings.js', () => ({ useSettingsStore: () => ({ effective }) }));
+  vi.doMock('../stores/networks.js', () => ({
+    useNetworksStore: () => ({ networkById: () => ({ name: 'libera' }) }),
+  }));
+  vi.doMock('./useViewedBuffer.js', () => ({ viewedBuffer: () => opts.viewed ?? '' }));
+  vi.stubGlobal('document', { hidden: opts.hidden ?? false });
+  return import('./useHighlightNotifier.js');
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+// A DM from bob that the server flagged notify-worthy. Callers override `notify`
+// (and other signals) per case.
+function dm(overrides: Record<string, unknown> = {}) {
+  return {
+    networkId: 1,
+    target: 'bob',
+    nick: 'bob',
+    text: 'ping',
+    type: 'message',
+    id: 1,
+    self: false,
+    dm: true,
+    matched: false,
+    notifyAlways: false,
+    notify: true,
+    ...overrides,
+  };
+}
+
+describe('notifyForEvent notify gate', () => {
+  beforeEach(() => vi.resetModules());
+
+  it('toasts a notify:true event when the tab is visible and its buffer is off-screen', async () => {
+    const { notifyForEvent } = await load();
+    notifyForEvent(dm());
+    expect(push).toHaveBeenCalledTimes(1);
+    expect((push.mock.calls[0][0] as { kind: string }).kind).toBe('dm');
+  });
+
+  it('does not toast when notify is false — the server already applied the mute veto', async () => {
+    const { notifyForEvent } = await load();
+    notifyForEvent(dm({ notify: false }));
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('does not toast an event with no notify flag (never re-derives the verdict client-side)', async () => {
+    const { notifyForEvent } = await load();
+    notifyForEvent(dm({ notify: undefined }));
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('still toasts a de-highlighted DM (NOHIGHLIGHT is display-only, so notify stays true)', async () => {
+    // The server sends matched:false (decideStamp nulled it) but notify:true —
+    // the client must NOT suppress it the way the old client-side NOHIGHLIGHT
+    // check did. Kind falls through to dm.
+    const { notifyForEvent } = await load();
+    notifyForEvent(dm({ matched: false, notify: true }));
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not toast when the tab is hidden (that is the push path’s job)', async () => {
+    const { notifyForEvent } = await load({ hidden: true });
+    notifyForEvent(dm());
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('does not toast when viewing the event’s own buffer', async () => {
+    const { notifyForEvent } = await load({ viewed: '1::bob' });
+    notifyForEvent(dm());
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('respects the per-kind enabled toggle even when notify is true', async () => {
+    const { notifyForEvent } = await load({ enabled: false });
+    notifyForEvent(dm());
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Drives in-client notifications: a toast in the corner and an optional sound.
-// Called from useSocket whenever an IRC message arrives. The event carries
-// independent content signals (matched, dm, notifyAlways) set by the server;
-// each signal type has its own master `enabled` toggle and sound sub-toggle in
-// settings, so toast/sound delivery is fully decoupled from how the signal
-// was generated. Settings are read live so quick-toggles take effect at once.
+// Called from useSocket whenever an IRC message arrives. The server sets the
+// authoritative `notify` flag — the highlight/DM/notify-always union with the
+// ignore/mute veto already folded in (wsHub.decorateMessage) — so we gate on
+// that one flag rather than re-deriving the ignore verdict here. The raw
+// content signals (matched, dm, notifyAlways) still ride alongside it and pick
+// the toast kind: each kind has its own master `enabled` toggle and sound
+// sub-toggle, so toast/sound delivery is decoupled from how the signal was
+// generated. Settings are read live so quick-toggles take effect at once.
 //
 // The in-app toast + sound fire only for a visible tab when the event's
 // buffer isn't the one on screen — see shouldNotifyInApp for the three cases
@@ -15,12 +18,15 @@
 import { useToastsStore, type ToastKind } from '../stores/toasts.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useNetworksStore } from '../stores/networks.js';
-import { useIgnoresStore } from '../stores/ignores.js';
 import { viewedBuffer } from './useViewedBuffer.js';
 import { META_SEPARATOR } from '../utils/metaLine.js';
 
 export interface NotifyEvent {
   self?: boolean;
+  // Server's authoritative "alert the user" verdict: the content-signal union
+  // (matched/dm/notifyAlways) with the ignore/mute veto (hide + NONOTIFY)
+  // already applied. A NOHIGHLIGHT rule is display-only and does NOT clear it.
+  notify?: boolean;
   dm?: boolean;
   matched?: boolean;
   notifyAlways?: boolean;
@@ -108,6 +114,13 @@ function shouldNotifyInApp(event: NotifyEvent): boolean {
 
 export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   if (!event || event.self) return;
+  // Trust the server's `notify` verdict — the ignore/mute veto (a hidden
+  // sender or a NONOTIFY-muted channel/network/DM — issue #359) is already
+  // folded in, so a muted buffer never toasts, and we don't re-run ignore
+  // matching here. A NOHIGHLIGHT rule is display-only and does NOT clear
+  // `notify`, so it still toasts — matching the server push path. Push is
+  // gated the same way server-side (it fires while no client is open).
+  if (!event.notify) return;
   const kindKey = pickKindKey(event);
   if (!kindKey) return;
 
@@ -115,27 +128,6 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   // the one on screen — a hidden tab is the push path's job, and the viewed
   // buffer is already in plain view. See shouldNotifyInApp.
   if (!shouldNotifyInApp(event)) return;
-
-  // Ignored sender → no toast, no sound. Full-context evaluate so a scoped rule
-  // (/ignore x PUBLIC, a #chan or -pattern rule) suppresses the toast for a
-  // message it also hides; a NOHIGHLIGHT rule suppresses the highlight
-  // toast/sound while leaving the message visible; and a NONOTIFY rule (a muted
-  // channel/network/DM — issue #359) suppresses the toast/sound outright. We
-  // evaluate even for a nick-less event so a scope mute (mask null) still vetoes
-  // it; a sender-specific rule just won't match a null nick. Push is gated
-  // server-side in wsHub.maybePush (push fires while no client is open).
-  const ignores = useIgnoresStore();
-  if (event.networkId && event.target) {
-    const verdict = ignores.evaluate(event.networkId, {
-      nick: event.nick ?? null,
-      userhost: event.userhost ?? null,
-      target: event.target,
-      text: event.text ?? '',
-      type: event.type ?? 'message',
-      isDm: !!event.dm,
-    });
-    if (verdict.hide || verdict.nohilight || verdict.nonotify) return;
-  }
 
   const settings = useSettingsStore();
   if (!settings.effective(`notifications.${kindKey}.enabled`)) return;


### PR DESCRIPTION
## Problem

`decorateMessage`'s `notify` flag was a pure **content** signal — `matched || dm || notifyAlways` — and never applied the ignore verdict. So a per-channel/network **NONOTIFY** mute leaked through to any live client that trusts `notify`. (Surfaced by the Android app: a relayed line highlight-matched the user's nick and buzzed through a muted channel.)

The mute veto was applied *separately at each delivery site*:
- `maybePush` suppressed it **server-side** for web-push.
- The web toast (`useHighlightNotifier`) re-derived the verdict **client-side**.
- Native live notifications had **neither** — the gap.

## Fix

Make `notify` the single authoritative "alert the user" gate. `decorateMessage` now folds the push path's exact predicate (`hide || nonotify`) into `notify`, so push, the web toast, and native clients all read one flag instead of each re-deriving the verdict.

- **`NOHIGHLIGHT` stays out of the fold** — it's display-only (`decideStamp` already nulls `matched`), matching the push path's documented behavior. A de-highlighted DM still notifies.
- The verdict is recomputed per serve off the **cached** compiled rules, so `/unignore` reveals reactively. It's only computed when the content is otherwise notify-worthy, so backlog serves stay cheap.

## Changes

- **server** — fold `hide || nonotify` into `decorateMessage`'s `notify`; extract a module-level `ignoreVerdictForEvent`; drop `maybePush`'s now-redundant verdict check (the `notify` gate front-runs it).
- **vue_client** — `useHighlightNotifier` trusts `notify` instead of re-running the ignore verdict. This drops its extra `NOHIGHLIGHT` suppression, aligning the web toast with the push path.
- **docs** — document `notify` semantics in `CLIENT_PROTOCOL.md` (§5.3): gate live alerts on it, don't re-implement ignore matching; a muted-channel highlight arrives as `matched:true, notify:false`.
- **test** — `wsHub.decorate.test.ts` characterizes the fold: `hide`/`NONOTIFY` clear `notify`, `NOHIGHLIGHT` does not, and a muted-channel highlight arrives as `matched:true, notify:false`.

## Behavior change to flag

The web toast previously suppressed on `NOHIGHLIGHT`; the push path never did. This unifies them on the push path's stance (nohilight = display-only, still notifies). If we'd rather `NOHIGHLIGHT` suppress notifications everywhere, that's the opposite reconciliation — say the word.

## Verification

`npm run check` ✅ · `npm test` ✅ (208 files, 2770 tests) — includes the existing `wsHub.push.test.ts` NONOTIFY/NOHIGHLIGHT guards, which still pass after `maybePush` was simplified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)