### PR TITLE
Own the IRC reconnect policy: retry-forever with backoff

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -6,7 +6,7 @@
 // at module-load time). Without this, the IrcConnections built in these tests
 // write straight into the real data/lurker.db.
 import '../test-utils/isolateDb.js';
-import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import net from 'net';
 import { ircLineParser } from 'irc-framework';
 import type { ConnectOptions } from 'irc-framework';
@@ -28,6 +28,7 @@ import {
   resolveKeyModeChange,
 } from './ircConnection.js';
 import { createIdentdServer, unregisterIdent } from './identd.js';
+import connectScheduler from './connectScheduler.js';
 import { getRecent } from './systemLog.js';
 import { createUser } from '../db/users.js';
 import { createNetwork } from '../db/networks.js';
@@ -1284,6 +1285,176 @@ describe('disconnect-offline sweep + WHO re-light (no-MONITOR presence)', () => 
     // A later WHO with the away flag cleared must move away → back (renders online).
     conn.client.emit('wholist', { target: '#room', users: [{ nick: 'awaychan', away: false }] });
     expect(getPeerPresence(conn.network.id, 'awaychan')?.state).toBe('back');
+  });
+});
+
+// Lurker owns the reconnect policy now (irc-framework's auto_reconnect is off).
+// The controller retries any transient drop indefinitely with exponential
+// backoff, but stops for an intentional disconnect or a classified-terminal
+// reason (detected ban / hard SASL auth failure). Timers are faked; the actual
+// socket open (conn.connect) is stubbed so no real connection is attempted.
+describe('auto-reconnect controller', () => {
+  function makeConn(name: string): { conn: IrcConnection; events: Record<string, unknown>[] } {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'nick',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+    })!;
+    const events: Record<string, unknown>[] = [];
+    const conn = new IrcConnection({
+      network,
+      onEvent: (e) => events.push(e as Record<string, unknown>),
+    });
+    // Never open a real socket when the backoff fires.
+    vi.spyOn(conn, 'connect').mockImplementation(() => {});
+    return { conn, events };
+  }
+
+  // The connectScheduler is a process-wide singleton; clear its per-host gate
+  // state before each test so a prior run's timestamps can't delay this launch.
+  beforeEach(() => connectScheduler.reset());
+  afterEach(() => {
+    connectScheduler.reset();
+    vi.useRealTimers();
+  });
+
+  it('schedules a backoff reconnect after an unexpected socket close', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-basic');
+    conn.client.emit('close', false);
+    expect(conn.state).toBe('reconnecting');
+    expect(conn.connect).not.toHaveBeenCalled(); // still waiting out the backoff
+    vi.runAllTimers();
+    expect(conn.connect).toHaveBeenCalledTimes(1);
+  });
+
+  // The core gap this overhaul fixes: irc-framework only retried a connection
+  // that had been healthy for >5s, so an initial-connect failure (DNS/refused/
+  // registration timeout — never 'registered') got ZERO retries. It must now
+  // reconnect like any other transient drop.
+  it('reconnects after a never-registered initial-connect failure', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-initial');
+    conn.client.emit('socket close', { code: 'ECONNREFUSED' });
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).toHaveBeenCalledTimes(1);
+  });
+
+  // A user who hits Disconnect while the network is mid-backoff has no live
+  // socket to close, so quit() emits no 'close' — disconnect() must assert the
+  // terminal 'disconnected' state itself or the UI stays stuck on 'Reconnecting'.
+  it('settles to disconnected when the user disconnects mid-reconnect', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-mid');
+    conn.client.emit('close', false); // drop → enters reconnecting/backoff
+    expect(conn.state).toBe('reconnecting');
+    conn.disconnect(); // user stops it while the backoff is still pending
+    expect(conn.state).toBe('disconnected');
+    vi.runAllTimers();
+    expect(conn.connect).not.toHaveBeenCalled();
+  });
+
+  it('does not reconnect after an intentional disconnect', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-intentional');
+    conn.disconnect(); // records intent; quit() is a no-op with no live socket
+    conn.client.emit('close', false);
+    vi.runAllTimers();
+    expect(conn.connect).not.toHaveBeenCalled();
+    expect(conn.state).toBe('disconnected');
+  });
+
+  it('stops (no reconnect) and surfaces a notice on a detected server ban', () => {
+    vi.useFakeTimers();
+    const { conn, events } = makeConn('rc-ban');
+    conn.client.emit('irc error', { error: 'irc', reason: 'Closing Link: nick[u@h] (G-Lined)' });
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).not.toHaveBeenCalled();
+    expect(conn.state).toBe('disconnected');
+    expect(
+      events.some(
+        (e) => e.type === 'error' && /Not reconnecting automatically/i.test(String(e.text)),
+      ),
+    ).toBe(true);
+  });
+
+  it('stops (no reconnect) on a hard SASL authentication failure', () => {
+    vi.useFakeTimers();
+    const { conn, events } = makeConn('rc-sasl');
+    conn.client.emit('sasl failed', { reason: 'fail' });
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).not.toHaveBeenCalled();
+    expect(
+      events.some((e) => e.type === 'error' && /SASL authentication failed/i.test(String(e.text))),
+    ).toBe(true);
+  });
+
+  // A clean SASL abort is transient (server hiccup), not a credential problem —
+  // it must still reconnect.
+  it('still reconnects after a clean SASL abort', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-sasl-abort');
+    conn.client.emit('sasl failed', { reason: 'aborted' });
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).toHaveBeenCalledTimes(1);
+  });
+
+  // A SASL failure the server DIDN'T drop us for (we registered unauthenticated)
+  // must not leave a stale terminal flag that blocks a later transient reconnect.
+  it('clears the terminal flag when registration succeeds despite a SASL failure', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-sasl-recovered');
+    conn.client.emit('sasl failed', { reason: 'fail' });
+    (conn.client as unknown as { options: unknown }).options = {
+      ping_interval: 0,
+      ping_timeout: 0,
+    };
+    conn.client.emit('registered', { nick: 'nick' }); // server let us in anyway
+    conn.client.emit('close', false); // a later, unrelated drop
+    vi.runAllTimers();
+    expect(conn.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the backoff ladder after a successful registration', () => {
+    vi.useFakeTimers();
+    const { conn, events } = makeConn('rc-reset');
+    const attemptOf = (): number | null => {
+      for (let i = events.length - 1; i >= 0; i--) {
+        const m = /attempt (\d+)/.exec(String(events[i].text ?? ''));
+        if (m) return Number(m[1]);
+      }
+      return null;
+    };
+    // First drop → attempt 1.
+    conn.client.emit('close', false);
+    expect(attemptOf()).toBe(1);
+    vi.runAllTimers();
+    // A full registration proves the network is reachable again → ladder resets.
+    // (connect() is stubbed here, so the library's own 'registered' listener has
+    // no live connection.options; pin harmless ping settings so its
+    // startPeriodicPing early-returns instead of dereferencing null.)
+    (conn.client as unknown as { options: unknown }).options = {
+      ping_interval: 0,
+      ping_timeout: 0,
+    };
+    conn.client.emit('registered', { nick: 'nick' });
+    // Next drop starts back at attempt 1, not 2.
+    conn.client.emit('close', false);
+    expect(attemptOf()).toBe(1);
   });
 });
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -173,14 +173,21 @@ const RECONNECT_MAX_MS = reconnectEnvInt('LURKER_RECONNECT_MAX_MS', 300_000);
 // same-host launches on top of this, but the jitter de-syncs the herd first).
 const RECONNECT_JITTER_MS = reconnectEnvInt('LURKER_RECONNECT_JITTER_MS', 3000);
 
+// Floor for the computed backoff. reconnectEnvInt accepts 0 (a legit "disable
+// jitter" value), so a misconfigured base of 0 with jitter off would otherwise
+// yield a 0ms delay — a tight reconnect loop that hammers the server and spins
+// the event loop. 1s is also the smallest interval the "Reconnecting in Ns"
+// notice can honestly display (it rounds to whole seconds, min 1).
+const RECONNECT_MIN_MS = 1000;
+
 // Exponential backoff for the Nth reconnect attempt (0-indexed): base·2^n,
-// capped, plus jitter. attempt is clamped so 2^n can't overflow on a very long
-// outage — past the cap the doubling is moot anyway.
+// capped, plus jitter, then floored. attempt is clamped so 2^n can't overflow on
+// a very long outage — past the cap the doubling is moot anyway.
 function reconnectBackoffMs(attempt: number): number {
   const capped = Math.min(attempt, 20);
   const grown = RECONNECT_BASE_MS * Math.pow(2, capped);
   const jitter = RECONNECT_JITTER_MS > 0 ? Math.floor(Math.random() * RECONNECT_JITTER_MS) : 0;
-  return Math.min(grown, RECONNECT_MAX_MS) + jitter;
+  return Math.max(RECONNECT_MIN_MS, Math.min(grown, RECONNECT_MAX_MS) + jitter);
 }
 
 // Conservative, high-confidence match for a server disconnect that won't heal on

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -25,6 +25,7 @@ import {
 } from '../db/peerPresence.js';
 import highlightRulesService from './highlightRulesService.js';
 import ignoreRulesService from './ignoreRulesService.js';
+import connectScheduler from './connectScheduler.js';
 import { decideStamp } from './insertDecisions.js';
 import * as systemLog from './systemLog.js';
 import { effectiveSetting, effectiveSettings } from './settingsService.js';
@@ -141,6 +142,71 @@ const CTCP_OUTSTANDING_MAX_KEYS = 200;
 // Beyond this window the bounce is treated as an automated TAGMSG/typing reply
 // and swallowed. Generous — IRC error numerics come back in well under a second.
 const SEND_REJECTION_ATTRIBUTION_MS = 15000;
+
+// ---------------------------------------------------------------------------
+// Auto-reconnect policy (see IrcConnection.scheduleReconnectIfWarranted)
+// ---------------------------------------------------------------------------
+// We own the reconnect policy rather than irc-framework's built-in, which only
+// retries a connection that was healthy for >5s AND died cleanly, ~3 times —
+// so an initial-connect failure, a registration timeout, or a sustained outage
+// each got zero or near-zero retries and left the user silently offline until a
+// manual reconnect (#236's connectScheduler comment flagged exactly this gap).
+// The policy here: retry indefinitely with exponential backoff for ANY drop,
+// EXCEPT a confidently-classified terminal reason (a detected ban or a hard SASL
+// auth failure), where retrying can't help and hammering an actively-rejecting
+// server is antisocial — those stop and require a manual reconnect.
+
+function reconnectEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+// First-retry delay; each subsequent attempt doubles up to the cap.
+const RECONNECT_BASE_MS = reconnectEnvInt('LURKER_RECONNECT_BASE_MS', 2000);
+// Ceiling on the backoff interval — a long outage keeps retrying at this cadence
+// forever rather than giving up (5 min mirrors irc-framework's own max_wait).
+const RECONNECT_MAX_MS = reconnectEnvInt('LURKER_RECONNECT_MAX_MS', 300_000);
+// Random extra wait added to each backoff so a fleet-wide outage recovery doesn't
+// reconverge every connection on the same instant (the connectScheduler spaces
+// same-host launches on top of this, but the jitter de-syncs the herd first).
+const RECONNECT_JITTER_MS = reconnectEnvInt('LURKER_RECONNECT_JITTER_MS', 3000);
+
+// Exponential backoff for the Nth reconnect attempt (0-indexed): base·2^n,
+// capped, plus jitter. attempt is clamped so 2^n can't overflow on a very long
+// outage — past the cap the doubling is moot anyway.
+function reconnectBackoffMs(attempt: number): number {
+  const capped = Math.min(attempt, 20);
+  const grown = RECONNECT_BASE_MS * Math.pow(2, capped);
+  const jitter = RECONNECT_JITTER_MS > 0 ? Math.floor(Math.random() * RECONNECT_JITTER_MS) : 0;
+  return Math.min(grown, RECONNECT_MAX_MS) + jitter;
+}
+
+// Conservative, high-confidence match for a server disconnect that won't heal on
+// retry: an oper/server ban (K/G/Z/D-line) or an explicit "you are banned". Kept
+// narrow on purpose — anything NOT matched here (timeouts, refused, TLS blips,
+// netsplits, generic drops) is treated as transient and retried forever. The
+// text is the trailing param of a server ERROR / "Closing Link" line. Channel-
+// scoped bans (474 ERR_BANNEDFROMCHAN) never reach this — they carry a channel
+// and are routed inline, not treated as a connection-terminal event.
+function classifyServerBan(reason: string | undefined): string | null {
+  if (!reason) return null;
+  if (/\b[kgzd][-\s]?lined?\b/i.test(reason)) return reason;
+  if (/\byou(?:'re| are)\s+banned\b/i.test(reason)) return reason;
+  if (/\bbanned\s+from\s+(?:this\s+)?(?:server|network)\b/i.test(reason)) return reason;
+  return null;
+}
+
+// SASL failure reasons that mean the credentials themselves are wrong or the
+// account is locked — a retry with the same stored password is pointless. Other
+// SASL reasons (unsupported_mechanism, capability_missing) are server/config
+// mismatches that also won't self-heal, so they're terminal too; only a clean
+// abort is left to the normal transient path. irc-framework's reasons:
+// fail | nick_locked | unsupported_mechanism | capability_missing | too_long | aborted.
+function isTerminalSaslFailure(reason: string | undefined): boolean {
+  return reason != null && reason !== 'aborted';
+}
 
 // ---------------------------------------------------------------------------
 // Internal shapes
@@ -481,6 +547,21 @@ export class IrcConnection {
   // (nick-rewritten) to IRC clients that attach mid-session, so they see the
   // network's real ISUPPORT tokens instead of a synthesized approximation.
   registrationLines: string[];
+  // Auto-reconnect controller (we own the policy; irc-framework's auto_reconnect
+  // is disabled in connect()). See scheduleReconnectIfWarranted.
+  //
+  // reconnectTimer: pending backoff timer, cleared on connect/dispose/intentional
+  //   stop so we never re-open a socket the caller just tore down.
+  // reconnectAttempt: monotonic backoff counter, reset to 0 on 'registered'.
+  // intentionalDisconnect: the user/system asked us to disconnect (stopNetwork,
+  //   dispose, pause) — the 'close' handler must NOT reconnect over their intent.
+  // terminalDisconnect: a classified give-up reason (detected ban / hard SASL
+  //   auth failure). Non-null = stop retrying and require a manual reconnect; the
+  //   string is the human-readable cause shown in the "not reconnecting" notice.
+  private reconnectTimer: ReturnType<typeof setTimeout> | null;
+  private reconnectAttempt: number;
+  private intentionalDisconnect: boolean;
+  private terminalDisconnect: string | null;
 
   constructor({ network, onEvent }: { network: Network; onEvent: (event: EnrichedEvent) => void }) {
     this.network = network;
@@ -564,6 +645,10 @@ export class IrcConnection {
     this.ctcpLimiter = new RateLimiter();
     this.ctcpOutstanding = new Map();
     this.registrationLines = [];
+    this.reconnectTimer = null;
+    this.reconnectAttempt = 0;
+    this.intentionalDisconnect = false;
+    this.terminalDisconnect = null;
     this.bind();
   }
 
@@ -864,9 +949,35 @@ export class IrcConnection {
       this.unsendableTargets.clear();
     });
 
+    // SASL authentication failed (ERR_SASLFAIL 904 / 905, or a mechanism/account
+    // problem). The stored credentials won't start working on their own, and a
+    // network that requires SASL then drops the connection — so classify this as
+    // terminal (unless it's a clean abort). The flag is CONSUMED at 'close':
+    // whether it actually causes a disconnect is up to the server, but if the
+    // socket does die we must not reconnect-loop into the same rejection (which
+    // on a server that requires auth is a fast failed-login hammer). We don't
+    // publish here — the server's own error/ERROR line surfaces the cause.
+    c.on('sasl failed', (event: Record<string, unknown>) => {
+      const reason = (event?.reason as string | undefined) || undefined;
+      if (isTerminalSaslFailure(reason)) {
+        this.terminalDisconnect = `SASL authentication failed${
+          reason && reason !== 'fail' ? ` (${reason})` : ''
+        } — check the network's account credentials`;
+      }
+    });
+
     c.on('registered', (event: Record<string, unknown>) => {
       this.userModes.clear();
       this.lagMs = null;
+      // A full, registered connection is the only signal that the network is
+      // genuinely reachable again — reset the backoff so a later drop starts a
+      // fresh, fast retry ladder instead of inheriting a long prior interval.
+      this.reconnectAttempt = 0;
+      // Clear any terminal classification too: if a SASL failure or a ban-looking
+      // error was flagged but we registered anyway (e.g. the server didn't drop
+      // us for it), it clearly wasn't fatal — a later transient drop must still
+      // auto-reconnect rather than inherit a stale give-up flag.
+      this.terminalDisconnect = null;
       // Fresh registration means a new socket — forget per-connection send
       // state so speak permission is re-probed and stale attribution can't leak
       // across the reconnect (#283).
@@ -1020,6 +1131,11 @@ export class IrcConnection {
       // call is a no-op.
       this.markAllPeersOffline();
       this.setState('disconnected');
+      // 'close' is now the single terminal socket-death event (irc-framework's
+      // auto_reconnect is disabled, so it no longer retries internally): decide
+      // here whether to schedule our own backoff retry. Runs after the state/
+      // presence cleanup above so a reconnect starts from a swept slate.
+      this.scheduleReconnectIfWarranted();
     });
 
     // ERR_NICKNAMEINUSE while we're still racing to register. Climb the
@@ -1165,15 +1281,15 @@ export class IrcConnection {
       // the fix for the "stuck online" gap on networks without MONITOR: if a
       // peer quit while we were disconnected we never saw their QUIT, but our own
       // disconnect is a discontinuity we DO observe, so we stop asserting a stale
-      // 'online'. 'socket close' (not 'close') is the hook: irc-framework
-      // auto-reconnects a blip internally and emits only 'socket close' +
-      // 'reconnecting' — it reserves 'close' for a terminal give-up/dispose
-      // (connection.js:111 always fires 'socket close'; :141 fires 'close' only
-      // when it won't retry), so sweeping in 'close' alone would miss the common
-      // reconnect. On reconnect the peers we can still observe are re-lit
-      // (MONITOR re-seed + WHO-on-join); the rest stay honestly offline. No
-      // came-online suppression — a reconnect re-firing "came online" for peers
-      // still around is the honest signal, and toasts are already rate-limited.
+      // 'online'. 'socket close' is the hook because it fires first and carries
+      // the socket-level error. (Historically it also mattered that 'socket
+      // close' fired on auto-reconnect blips while 'close' was terminal; now that
+      // Lurker owns reconnect and irc-framework's auto_reconnect is off, BOTH
+      // fire on every drop — but 'socket close' remains the right sweep point.)
+      // On reconnect the peers we can still observe are re-lit (MONITOR re-seed +
+      // WHO-on-join); the rest stay honestly offline. No came-online suppression
+      // — a reconnect re-firing "came online" for peers still around is the honest
+      // signal, and toasts are already rate-limited.
       this.markAllPeersOffline();
       // Release this socket's identd mapping (a reconnect re-registers via the
       // 'raw socket connected' handler above and gets a fresh handle).
@@ -1194,29 +1310,16 @@ export class IrcConnection {
         this.logNet(text, 'error');
       }
     });
-    c.on('reconnecting', (event: Record<string, unknown>) => {
-      this.setState('reconnecting');
-      const wait =
-        event && event.wait ? Math.max(1, Math.round((event.wait as number) / 1000)) : null;
-      const attempt = event && event.attempt;
-      const text =
-        wait != null && attempt
-          ? `Reconnecting in ${wait}s (attempt ${attempt})…`
-          : 'Reconnecting…';
-      this.publish({
-        type: 'notice',
-        target: this.serverTarget(),
-        nick: 'lurker',
-        notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
-        text,
-      });
-    });
+    // The 'reconnecting' state + notice are now emitted by our own controller
+    // (scheduleReconnectIfWarranted), not the library: irc-framework's
+    // auto_reconnect is disabled, so it never fires a 'reconnecting' event.
     c.on('connecting', () => this.setState('connecting'));
 
     // Diagnostic: irc-framework fires 'ping timeout' when it hasn't seen data
     // from the server for `ping_timeout` seconds (120s default) — then it QUITs
-    // and auto-reconnects with NO socket error, so the disconnect otherwise
-    // surfaces as a bare "Disconnected" with no cause. A ping timeout on a
+    // (ending the socket with NO socket error, so the disconnect otherwise
+    // surfaces as a bare "Disconnected" with no cause) and our controller
+    // schedules the reconnect from 'close'. A ping timeout on a
     // healthy network usually means WE stopped reading the socket, i.e. the
     // event loop was starved by synchronous work (see eventLoopMonitor); when
     // every network times out together on a client connect, that's the tell.
@@ -2406,6 +2509,16 @@ export class IrcConnection {
       const tag = (event?.error as string) || 'irc error';
       const reason = event?.reason as string | undefined;
       const eventNick = event?.nick as string | undefined;
+      // Classify an oper/server ban (K/G/Z/D-line) so the auto-reconnect
+      // controller stops instead of hammering a server that's actively refusing
+      // us. Only server-scoped bans qualify: a channel-scoped ban (474) carries a
+      // channel param and is routed inline below, so gate on its absence. The flag
+      // is consumed at 'close'; setting it here is harmless if the socket lives.
+      const banChannel = event?.channel as string | undefined;
+      if (!banChannel) {
+        const banned = classifyServerBan(reason);
+        if (banned) this.terminalDisconnect = `banned by the server (${banned})`;
+      }
       const isDmMiss = tag === 'no_such_nick' && eventNick && isDmTargetName(eventNick);
       // For ERR_NOSUCHNICK against a nick the user has any DM history with,
       // route the error into that DM buffer so the failure surfaces where
@@ -2984,18 +3097,32 @@ export class IrcConnection {
   }
 
   connect(): void {
+    // A deliberate (re)connect: cancel any pending backoff and clear the flags
+    // that would suppress a future auto-reconnect. This runs for both the initial
+    // connect and each backoff-driven retry, so a socket that opens starts from a
+    // clean slate; the attempt counter is NOT reset here (only a successful
+    // 'registered' resets it) so backoff keeps growing across failed retries.
+    this.clearReconnectTimer();
+    this.intentionalDisconnect = false;
+    this.terminalDisconnect = null;
     const { sasl_password, sasl_account, nick } = this.network;
     const account = sasl_password
       ? { account: sasl_account || nick, password: sasl_password }
       : undefined;
     const proto = this.network.tls ? ' (TLS)' : '';
-    this.publish({
+    const connectingNotice: IrcEvent = {
       type: 'notice',
       target: this.serverTarget(),
       nick: 'lurker',
       notable: false, // #470: status line — not counted as unread (see MessageInput.notable)
       text: `Connecting to ${this.network.host}:${this.network.port}${proto}…`,
-    });
+    };
+    // On an auto-reconnect attempt (reconnectAttempt has advanced past 0), don't
+    // persist this per-attempt status line — a long outage would otherwise write
+    // one row per retry forever (see scheduleReconnectIfWarranted). The initial
+    // and manual connects (attempt 0) still persist their one "Connecting…" line.
+    if (this.reconnectAttempt > 0) this.publishEphemeral(connectingNotice);
+    else this.publish(connectingNotice);
     this.client.connect({
       host: this.network.host,
       port: this.network.port,
@@ -3006,8 +3133,15 @@ export class IrcConnection {
       gecos: this.network.realname || nick,
       password: this.network.server_password || undefined,
       account,
-      auto_reconnect: true,
-      auto_reconnect_max_retries: 0,
+      // Lurker owns the reconnect policy (scheduleReconnectIfWarranted), so
+      // irc-framework's built-in is disabled outright. Its heuristic only retries
+      // a connection that was healthy for >5s and died cleanly, ~3 times — which
+      // never retries an initial-connect failure or a registration timeout and
+      // gives up on a sustained outage. (Note its default is auto_reconnect:true /
+      // max_retries:3; passing 0 for max_retries is a no-op — `options.x || 3`
+      // coerces 0 back to 3 — which is the bug this replaces.) With this off,
+      // every socket death funnels to our 'close' handler, which decides.
+      auto_reconnect: false,
       // Disable irc-framework's built-in CTCP VERSION auto-reply so our own
       // handler owns VERSION (#263). Like enable_chghost below, this MUST ride
       // the connect() dict — connect() overwrites client.options, so a
@@ -4444,7 +4578,81 @@ export class IrcConnection {
   }
 
   disconnect(reason?: string): void {
+    // The user/system asked to disconnect — record intent BEFORE quit() so the
+    // 'close' handler doesn't fight them by auto-reconnecting, and drop any
+    // pending backoff so an earlier drop's retry can't resurrect the connection.
+    this.intentionalDisconnect = true;
+    // If we're mid-reconnect (waiting out the backoff, or with a launch already
+    // queued in connectScheduler) there is NO live socket, so quit() won't emit a
+    // 'close' event and nothing else would move us off 'reconnecting'. Capture
+    // that before clearing the timer.
+    const noLiveSocketToClose = this.reconnectTimer != null || this.state === 'reconnecting';
+    this.clearReconnectTimer();
     this.client.quit(reason ?? this.defaultQuitMessage());
+    // Assert the terminal state directly in that case. When a live socket IS
+    // closed, its 'close' handler sets 'disconnected' too — setState is
+    // change-guarded, so the double-call is a harmless no-op.
+    if (noLiveSocketToClose) this.setState('disconnected');
+  }
+
+  // Cancel a pending backoff retry. Idempotent.
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer != null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  // Called from the terminal 'close' handler. Decides whether this socket death
+  // warrants an auto-reconnect and, if so, schedules one with exponential
+  // backoff (routed through connectScheduler so a fleet-wide outage recovery
+  // doesn't flood one host). Retries indefinitely for any transient drop; stops
+  // only for a disposed connection, a user/system-requested disconnect, or a
+  // classified-terminal reason (detected ban / hard SASL auth failure).
+  private scheduleReconnectIfWarranted(): void {
+    if (this.disposed || this.intentionalDisconnect) return;
+    if (this.reconnectTimer != null) return; // a retry is already pending
+    if (this.terminalDisconnect) {
+      // Won't self-heal — surface why and stop. A manual reconnect (which
+      // rebuilds the connection from scratch) clears this and tries again.
+      this.publish({
+        type: 'error',
+        target: this.serverTarget(),
+        text: `Not reconnecting automatically: ${this.terminalDisconnect}. Fix the issue and reconnect manually.`,
+      });
+      this.logNet(`Auto-reconnect stopped: ${this.terminalDisconnect}`, 'error');
+      return;
+    }
+    const attempt = this.reconnectAttempt;
+    const delay = reconnectBackoffMs(attempt);
+    this.reconnectAttempt = attempt + 1;
+    const seconds = Math.max(1, Math.round(delay / 1000));
+    this.setState('reconnecting');
+    const reconnectNotice: IrcEvent = {
+      type: 'notice',
+      target: this.serverTarget(),
+      nick: 'lurker',
+      notable: false, // #470: status line — not counted as unread
+      text: `Reconnecting in ${seconds}s (attempt ${attempt + 1})…`,
+    };
+    // Persist only the FIRST status line of an outage; a network down for hours
+    // would otherwise write a row every backoff tick forever — the same write
+    // amplification the 'ping timeout' handler avoids. Later ticks are live-only:
+    // the 'state' dot and that first persisted line already anchor history.
+    if (attempt === 0) this.publish(reconnectNotice);
+    else this.publishEphemeral(reconnectNotice);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      // Re-check intent/disposal: the user may have stopped the network, or it
+      // may have been disposed, during the backoff wait.
+      if (this.disposed || this.intentionalDisconnect) return;
+      // Stagger the actual launch per destination host (issue #236) so many
+      // connections whose backoffs elapse together don't flood one IRC server.
+      connectScheduler.schedule(this.network.host, () => {
+        if (this.disposed || this.intentionalDisconnect) return;
+        this.connect();
+      });
+    }, delay);
   }
 
   // The QUIT reason for a clean disconnect when the caller gave none (the bare
@@ -4460,6 +4668,7 @@ export class IrcConnection {
 
   dispose(reason: string = 'network removed'): void {
     this.disposed = true;
+    this.clearReconnectTimer();
     this.stopLagPinger();
     this.cancelPendingConnectCommands();
     // Abort any in-flight DCC downloads (their sockets are independent of the IRC


### PR DESCRIPTION
## Why

The "Reconnect automatically" behavior was fragile. irc-framework's built-in `auto_reconnect` only retries a connection that was healthy for >5s **and** died cleanly, ~3 times. So:

- an **initial-connect failure** (DNS / refused / TLS) got **zero** retries;
- a **registration timeout** got **zero** retries;
- a **sustained outage** exhausted ~3 attempts and then gave up **forever** until a manual reconnect or process restart.

On top of that, the `auto_reconnect_max_retries: 0` we passed was a silent no-op — irc-framework does `options.x || 3`, coercing `0` back to the library default of `3`.

## What

Lurker now owns the reconnect policy:

- **`auto_reconnect: false`** — every socket death funnels to our terminal `close` handler.
- **Retry ANY drop indefinitely** with exponential backoff (base 2s, ×2, 5-min cap, jittered; env-tunable via `LURKER_RECONNECT_BASE_MS` / `_MAX_MS` / `_JITTER_MS`), routed through the existing `connectScheduler` so a fleet-wide recovery doesn't flood one host. Backoff resets on `registered`.
- **Stop only** for an intentional disconnect (stop / pause / lockdown) or a confidently-classified terminal reason — a detected server ban (K/G/Z/D-line, "you are banned") or a hard SASL auth failure — which surface a *"Not reconnecting automatically…"* notice and require a manual reconnect. Classification is deliberately narrow: anything else (timeouts, refused, TLS blips, netsplits, generic drops) retries forever.

## Robustness details (from the code review)

- **No unbounded DB growth:** only the first status line of an outage is persisted; later backoff ticks go ephemeral (the `state` dot anchors history), avoiding the write amplification the `ping timeout` path already guards against.
- **No stuck state:** a user-initiated disconnect *mid-backoff* asserts the terminal `disconnected` state directly, since there's no live socket to emit `close`.

## Tests

New `auto-reconnect controller` suite covers the initial-failure gap fix, ban / SASL stops, the clean-SASL-abort and SASL-recovered cases, the intentional-disconnect and mid-reconnect-disconnect paths, and the backoff reset. Full check clean; `npm test` = 2789 passing.

## Follow-ups (filed)

- #616 — reconnect calls `connect()` directly, bypassing the `startNetwork` pause/lockdown gate (currently masked by `suspendUser` calling `disconnect()`).
- #617 — SASL-fail terminal flag can permanently stop reconnect on an unrelated transient drop in a narrow window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)