### PR TITLE
Fix blank message lists (hydration reconciler) and the vanishing mobile-Chrome input bar

### DIFF
--- a/vue_client/index.html
+++ b/vue_client/index.html
@@ -13,9 +13,20 @@
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <meta name="theme-color" content="#0b0b0b" />
+    <!-- interactive-widget=resizes-content (#581): Chrome Android 108+ defaults
+         to resizes-visual — the soft keyboard OVERLAYS the page, 100dvh stays
+         full-height, and Chrome reveals the focused composer by scrolling the
+         document. Our shell forbids document scrolling (html/body
+         overflow:hidden + touch-action:none), so when that scroll isn't undone
+         on keyboard dismiss the layout is left shifted with the input bar
+         permanently off-screen (unrecoverable by touch or pinch — full refresh
+         only). resizes-content restores the model the 100dvh shell was built
+         for: the keyboard shrinks the layout viewport, the composer rides up
+         above it, and no document scroll ever happens. Safari doesn't support
+         the property and ignores it, so iOS behavior is unchanged. -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <title>Lurker</title>
   </head>

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -16,7 +16,15 @@
          throwing off the prepend anchor math or (with browser anchoring)
          leaving scrollTop near the top so maybeRequestHistory cascades. -->
     <div v-if="!buffer?.hasMoreOlder && messages.length" class="notice">— start of history —</div>
-    <p v-if="!messages.length" class="notice empty">No messages yet.</p>
+    <!-- Exactly one of these renders when there are no message rows, so the
+         pane is never silently blank: a fetch in flight (or pending — an
+         unhydrated shell awaiting the reconciler) says so, a hydrated-but-
+         empty buffer says so, and the degenerate every-row-filtered-out case
+         (e.g. an inconsistent /clear marker) gets a fallback instead of an
+         empty scroller that looks broken. -->
+    <p v-if="initialLoading" class="notice empty">Loading messages…</p>
+    <p v-else-if="!messages.length" class="notice empty">No messages yet.</p>
+    <p v-else-if="!renderRows.length" class="notice empty">No messages to show.</p>
     <template v-for="row in renderRows" :key="row.key">
       <div v-if="row.divider === 'unread'" :ref="setUnreadDividerEl" class="notice unread-divider">
         <span class="notice-label">unread</span>
@@ -553,6 +561,19 @@ function setUnreadDividerEl(el: Element | ComponentPublicInstance | null): void 
 
 const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
 const messages = computed(() => buffer.value?.messages || []);
+
+// "Loading messages…" vs "No messages yet.": an empty list whose buffer is
+// unhydrated (fresh-connect shell / wiped detach slice) or mid-fetch is
+// LOADING — content exists server-side and a fetch is in flight or will fire
+// as soon as the socket allows (useBufferHydration). Only a hydrated empty
+// buffer is genuinely "no messages". Empty-list-only on purpose: loadingHistory
+// is also true during scrollback paging, where injecting a notice above the
+// viewport would shift scrollTop (see the comment atop the template).
+const initialLoading = computed(() => {
+  const b = buffer.value;
+  if (!b || b.networkId == null || messages.value.length) return false;
+  return b.loadingHistory || b.unseeded || b.pendingRefetch;
+});
 
 const selfLower = computed(() => {
   const b = buffer.value;

--- a/vue_client/src/composables/useBufferHydration.ts
+++ b/vue_client/src/composables/useBufferHydration.ts
@@ -24,21 +24,25 @@
 // preconditions come back.
 //
 // Module-level singleton (like the socket itself): started once from
-// useChatBootstrap and never stopped — the Desktop<->Mobile shell swap
-// remounts that composable, and a component-scoped watcher would either die
-// with the old shell or double-register with the new one.
+// useChatBootstrap and never stopped. The watchers live in a DETACHED
+// effectScope (mirroring useAppBadge) so their lifetime is structural, not
+// positional — created inside a component's scope they'd be disposed on the
+// Desktop<->Mobile shell swap while `started` stayed true, silently killing
+// the reconciler for the rest of the session.
 
-import { computed, watch } from 'vue';
+import { computed, effectScope, watch } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore, bufferNeedsHydration } from '../stores/buffers.js';
 import { connected } from './useSocket.js';
 
-// Floor between automatic attempts for the SAME buffer. Normal operation never
-// hits it (the first attempt per buffer/reconnect fires immediately, and
-// loadingHistory suppresses `needs` while a fetch is in flight). It exists to
-// bound the pathological loop where a fetch "succeeds" yet leaves the buffer
-// still-needy — e.g. a latest reply whose rows all filter out client-side —
-// turning what would be a tight refetch spin into a slow, self-limiting retry.
+// Same-buffer floor between automatic attempts, as a BACKSTOP only. No known
+// completed-fetch path leaves a buffer still-needy (applyLatestReplace clamps
+// hasMoreOlder on an all-filtered empty slice precisely so hydration is
+// terminal), so in normal operation the throttle never engages: the first
+// attempt per buffer/reconnect fires immediately, and loadingHistory
+// suppresses `needs` while a fetch is in flight. If a future regression
+// reintroduces a fetch-completes-but-still-needy state, this bounds it to one
+// round-trip per window instead of a tight network-speed spin.
 const RETRY_THROTTLE_MS = 5000;
 
 let started = false;
@@ -46,53 +50,75 @@ let lastAttemptKey: string | null = null;
 let lastAttemptAt = 0;
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
+function clearThrottle(): void {
+  lastAttemptKey = null;
+  lastAttemptAt = 0;
+  if (retryTimer) {
+    clearTimeout(retryTimer);
+    retryTimer = null;
+  }
+}
+
 export function startBufferHydration(): void {
   if (started) return;
   started = true;
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
 
-  const needs = computed(() => {
-    if (!connected.value) return false;
-    const key = networks.activeKey;
-    if (!key) return false;
-    // Virtual buffers without a store entry (the FRIENDS overview) resolve to
-    // null; the system buffer is excluded inside bufferNeedsHydration.
-    const buf = buffers.byKey(key);
-    return !!buf && bufferNeedsHydration(buf);
+  // Detached scope: never disposed, regardless of where the starting call
+  // sits relative to a component lifecycle. See header.
+  effectScope(true).run(() => {
+    const needs = computed(() => {
+      if (!connected.value) return false;
+      const key = networks.activeKey;
+      if (!key) return false;
+      // Virtual buffers without a store entry (the FRIENDS overview) resolve to
+      // null; the system buffer is excluded inside bufferNeedsHydration.
+      const buf = buffers.byKey(key);
+      return !!buf && bufferNeedsHydration(buf);
+    });
+
+    const attempt = (): void => {
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      // Re-check on entry: state may have moved while a retry timer was pending
+      // (fetch landed, buffer switched, socket dropped).
+      if (!needs.value) return;
+      const key = networks.activeKey;
+      if (!key) return;
+      const now = Date.now();
+      if (key === lastAttemptKey && now - lastAttemptAt < RETRY_THROTTLE_MS) {
+        // Too soon for the same buffer — re-arm rather than drop, so a throttled
+        // attempt still happens once the window opens (there may be no further
+        // reactive transition to re-trigger us).
+        retryTimer = setTimeout(attempt, RETRY_THROTTLE_MS - (now - lastAttemptAt));
+        return;
+      }
+      lastAttemptKey = key;
+      lastAttemptAt = now;
+      const buf = buffers.byKey(key);
+      if (buf) buffers.ensureHydrated(buf.networkId, buf.target);
+    };
+
+    // The throttle is keyed on wall clock; without this reset a connection
+    // that flaps within the window would have its post-reconnect rehydration
+    // deferred by up to RETRY_THROTTLE_MS — the opposite of "re-asserts as
+    // soon as preconditions come back". A connection edge is a new generation:
+    // whatever the last attempt was, it belonged to the old socket. (This also
+    // keeps a logout→login within the window from inheriting a stale floor —
+    // the module globals outlive the session.)
+    watch(connected, clearThrottle);
+
+    // immediate: the app can start with a persisted activeKey pointing at a
+    // shell (cold PWA launch) — reconcile the initial state, not just changes.
+    watch(
+      needs,
+      (n) => {
+        if (n) attempt();
+      },
+      { immediate: true },
+    );
   });
-
-  const attempt = (): void => {
-    if (retryTimer) {
-      clearTimeout(retryTimer);
-      retryTimer = null;
-    }
-    // Re-check on entry: state may have moved while a retry timer was pending
-    // (fetch landed, buffer switched, socket dropped).
-    if (!needs.value) return;
-    const key = networks.activeKey;
-    if (!key) return;
-    const now = Date.now();
-    if (key === lastAttemptKey && now - lastAttemptAt < RETRY_THROTTLE_MS) {
-      // Too soon for the same buffer — re-arm rather than drop, so a throttled
-      // attempt still happens once the window opens (there may be no further
-      // reactive transition to re-trigger us).
-      retryTimer = setTimeout(attempt, RETRY_THROTTLE_MS - (now - lastAttemptAt));
-      return;
-    }
-    lastAttemptKey = key;
-    lastAttemptAt = now;
-    const buf = buffers.byKey(key);
-    if (buf) buffers.ensureHydrated(buf.networkId, buf.target);
-  };
-
-  // immediate: the app can start with a persisted activeKey pointing at a
-  // shell (cold PWA launch) — reconcile the initial state, not just changes.
-  watch(
-    needs,
-    (n) => {
-      if (n) attempt();
-    },
-    { immediate: true },
-  );
 }

--- a/vue_client/src/composables/useBufferHydration.ts
+++ b/vue_client/src/composables/useBufferHydration.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Declarative hydration reconciler for the active buffer's message list.
+//
+// Fresh-connect snapshots ship channel/DM buffers as empty SHELLS; the actual
+// messages load lazily via a `history latest` fetch. Historically that fetch
+// fired from exactly one place — activate(), at the instant of the click — so
+// any bad instant produced a persistently blank buffer with no recovery:
+//   - click while the socket is closed (mobile foregrounding races the 2s
+//     reconnect timer) → send fails silently, nothing retries;
+//   - reply lost to a socket drop mid-flight → loadingHistory wedged forever;
+//   - reconnect wipes a detached buffer (pendingRefetch) but the flag was only
+//     consumed by activate(), which never re-runs for the buffer you're
+//     already in;
+//   - a resume snapshot re-shells a never-hydrated buffer (empty gap frame).
+//
+// This watcher inverts that: hydration is an INVARIANT, not an event. Whenever
+// the active buffer needs hydration (bufferNeedsHydration) AND the socket is
+// connected, fire the fetch — on activate-while-offline followed by reconnect,
+// on socket-close flag cleanup (failInFlightHistory makes the wedged buffer
+// eligible again), on a resume re-shell flipping `unseeded` back on. The bad
+// instant no longer matters; the invariant re-asserts itself as soon as its
+// preconditions come back.
+//
+// Module-level singleton (like the socket itself): started once from
+// useChatBootstrap and never stopped — the Desktop<->Mobile shell swap
+// remounts that composable, and a component-scoped watcher would either die
+// with the old shell or double-register with the new one.
+
+import { computed, watch } from 'vue';
+import { useNetworksStore } from '../stores/networks.js';
+import { useBuffersStore, bufferNeedsHydration } from '../stores/buffers.js';
+import { connected } from './useSocket.js';
+
+// Floor between automatic attempts for the SAME buffer. Normal operation never
+// hits it (the first attempt per buffer/reconnect fires immediately, and
+// loadingHistory suppresses `needs` while a fetch is in flight). It exists to
+// bound the pathological loop where a fetch "succeeds" yet leaves the buffer
+// still-needy — e.g. a latest reply whose rows all filter out client-side —
+// turning what would be a tight refetch spin into a slow, self-limiting retry.
+const RETRY_THROTTLE_MS = 5000;
+
+let started = false;
+let lastAttemptKey: string | null = null;
+let lastAttemptAt = 0;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function startBufferHydration(): void {
+  if (started) return;
+  started = true;
+  const networks = useNetworksStore();
+  const buffers = useBuffersStore();
+
+  const needs = computed(() => {
+    if (!connected.value) return false;
+    const key = networks.activeKey;
+    if (!key) return false;
+    // Virtual buffers without a store entry (the FRIENDS overview) resolve to
+    // null; the system buffer is excluded inside bufferNeedsHydration.
+    const buf = buffers.byKey(key);
+    return !!buf && bufferNeedsHydration(buf);
+  });
+
+  const attempt = (): void => {
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+    // Re-check on entry: state may have moved while a retry timer was pending
+    // (fetch landed, buffer switched, socket dropped).
+    if (!needs.value) return;
+    const key = networks.activeKey;
+    if (!key) return;
+    const now = Date.now();
+    if (key === lastAttemptKey && now - lastAttemptAt < RETRY_THROTTLE_MS) {
+      // Too soon for the same buffer — re-arm rather than drop, so a throttled
+      // attempt still happens once the window opens (there may be no further
+      // reactive transition to re-trigger us).
+      retryTimer = setTimeout(attempt, RETRY_THROTTLE_MS - (now - lastAttemptAt));
+      return;
+    }
+    lastAttemptKey = key;
+    lastAttemptAt = now;
+    const buf = buffers.byKey(key);
+    if (buf) buffers.ensureHydrated(buf.networkId, buf.target);
+  };
+
+  // immediate: the app can start with a persisted activeKey pointing at a
+  // shell (cold PWA launch) — reconcile the initial state, not just changes.
+  watch(
+    needs,
+    (n) => {
+      if (n) attempt();
+    },
+    { immediate: true },
+  );
+}

--- a/vue_client/src/composables/useChatBootstrap.ts
+++ b/vue_client/src/composables/useChatBootstrap.ts
@@ -12,6 +12,7 @@ import { registerSW, onSWPushMessage } from './usePush.js';
 import { onJumpIntent } from './useJumpIntent.js';
 import { connected } from './useSocket.js';
 import { startAppBadge } from './useAppBadge.js';
+import { startBufferHydration } from './useBufferHydration.js';
 import type { JumpTarget } from './useJumpToMessage.js';
 
 // How long to wait for the app to become able to honor a cold-start deep link
@@ -150,6 +151,10 @@ export function useChatBootstrap({ onJump }: ChatBootstrapOptions = {}): void {
     void settingsReady.then(() => onboarding.evaluate());
     startPresenceReporter();
     reportNow();
+    // Keep the active buffer's message list hydrated across reconnects and
+    // send failures (idempotent module singleton, like the presence reporter —
+    // survives the Desktop<->Mobile shell swap without double-registering).
+    startBufferHydration();
     // Mirror the unread-highlight total onto the PWA app icon (#451). Idempotent
     // and feature-detected — a no-op where the Badging API is unavailable.
     startAppBadge();

--- a/vue_client/src/composables/useJumpToMessage.ts
+++ b/vue_client/src/composables/useJumpToMessage.ts
@@ -131,9 +131,23 @@ export function useJumpToMessage({ pendingScrollId, afterActivate }: JumpToMessa
       (pending) => {
         if (pending === token) return; // our request still in flight
         stop();
-        if (pending == null && buf?.messages?.some((m: any) => m.id === messageId)) {
+        if (pending != null) return; // superseded by a newer jump — it owns the UI now
+        if (buf?.messages?.some((m: any) => m.id === messageId)) {
           armScroll(pendingScrollId, messageId);
+          return;
         }
+        // Token nulled but our row never arrived. Two ways here: the socket
+        // dropped mid-flight and the close sweep (failInFlightHistory) failed
+        // the request, or the slice landed without the anchor row (message no
+        // longer exists server-side). Either way the user's jump silently
+        // evaporates onto the live tail — mirror the feedback the
+        // socket-already-closed branch above gives.
+        toasts.push({
+          kind: 'warn',
+          title: 'Couldn’t load that message',
+          body: 'The connection dropped, or the message is no longer available.',
+          ttlMs: 5000,
+        });
       },
     );
   };

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -77,17 +77,47 @@ const HIDDEN_RESNAPSHOT_MS = 30_000;
 let hiddenSince: number | null = null;
 let visibilityWired = false;
 
-// Zombie-socket detection for the resume path. iOS routinely kills a
-// backgrounded WebSocket's TCP connection without telling the page — on
-// return, readyState still claims OPEN, so refreshSnapshot()'s send goes into
-// the void and the user sits on stale (or shell-blank) buffers until the OS
-// gets around to erroring the socket, if it ever does. The snapshot request IS
-// a liveness probe: a live server always replies, so if nothing at all arrives
-// within the window, the link is dead — force-close it, which trips the normal
-// 'close' arm (fail pending ACKs + in-flight history, schedule reconnect).
-const SNAPSHOT_PROBE_TIMEOUT_MS = 5000;
-let snapshotProbeTimer: ReturnType<typeof setTimeout> | null = null;
+// Zombie-socket liveness probe. Mobile OSes routinely kill a backgrounded (or
+// flaky-network) WebSocket's TCP connection without telling the page —
+// readyState still claims OPEN, so sends go into the void and the user sits on
+// stale or wedged-loading buffers until the OS TCP timeout errors the socket,
+// minutes later. Any request with a guaranteed reply (the resume snapshot,
+// every 'history' fetch) doubles as a probe: a live server always produces
+// SOME inbound traffic after it, so total silence for the whole window means
+// the link is dead — force-close it, which trips the normal 'close' arm (fail
+// pending ACKs + in-flight history, schedule reconnect, and the hydration
+// reconciler refetches on the reconnect edge).
+//
+// 10s, not lower: the probe fires only on TOTAL inbound silence since the
+// send (any frame counts), so the window's only job is to out-wait worst-case
+// link latency on a quiet connection. A false positive costs one spurious
+// reconnect cycle (self-healing — the reconnect path arms no probe and the
+// server re-sends a snapshot on connect), but there's no reason to shave
+// seconds off a detector whose true-positive alternative is a minutes-long
+// TCP timeout.
+const LIVENESS_PROBE_TIMEOUT_MS = 10_000;
+let livenessProbeTimer: ReturnType<typeof setTimeout> | null = null;
 let lastMessageAt = 0;
+
+// Arm (or re-arm) the probe against the CURRENT socket. The callback captures
+// the socket instance it measured and re-checks identity before acting: a
+// probe armed against socket A must never close A's healthy replacement B
+// when A dies mid-window and the 2s reconnect brings B up before the timer
+// fires (B can be OPEN with its first snapshot frame still in flight). The
+// close handler also clears the timer outright, so identity is a second
+// fence, not the only one.
+function armLivenessProbe(): void {
+  if (!socket || socket.readyState !== WebSocket.OPEN) return;
+  const probed = socket;
+  const sentAt = Date.now();
+  if (livenessProbeTimer) clearTimeout(livenessProbeTimer);
+  livenessProbeTimer = setTimeout(() => {
+    livenessProbeTimer = null;
+    if (socket === probed && socket.readyState === WebSocket.OPEN && lastMessageAt < sentAt) {
+      socket.close();
+    }
+  }, LIVENESS_PROBE_TIMEOUT_MS);
+}
 
 function wsUrl(): string {
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
@@ -801,6 +831,13 @@ function open() {
     () => {
       connected.value = false;
       socket = null;
+      // A probe armed against the socket that just died must not survive into
+      // the replacement's lifetime (its identity check would make firing a
+      // no-op, but a dead timer serves nobody).
+      if (livenessProbeTimer) {
+        clearTimeout(livenessProbeTimer);
+        livenessProbeTimer = null;
+      }
       // Anything we were waiting on is gone with the socket. Settle every
       // pending ACK as a disconnect so callers can surface the failure now
       // instead of waiting out the timeout.
@@ -889,9 +926,9 @@ export function resetSocket(): void {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;
   }
-  if (snapshotProbeTimer) {
-    clearTimeout(snapshotProbeTimer);
-    snapshotProbeTimer = null;
+  if (livenessProbeTimer) {
+    clearTimeout(livenessProbeTimer);
+    livenessProbeTimer = null;
   }
   if (socket) {
     // Detach every listener at once so the 'close' reconnect arm can't fire.
@@ -912,19 +949,10 @@ export function resetSocket(): void {
 
 function refreshSnapshot() {
   if (socket && socket.readyState === WebSocket.OPEN) {
-    const sentAt = Date.now();
     send({ type: 'snapshot' });
-    // The socket may be a zombie (see SNAPSHOT_PROBE_TIMEOUT_MS). Any inbound
-    // message counts as liveness — the snapshot reply is guaranteed traffic,
-    // so silence for the whole window means the link is dead. close() trips
-    // the 'close' arm, which cleans up and schedules the reconnect.
-    if (snapshotProbeTimer) clearTimeout(snapshotProbeTimer);
-    snapshotProbeTimer = setTimeout(() => {
-      snapshotProbeTimer = null;
-      if (socket && socket.readyState === WebSocket.OPEN && lastMessageAt < sentAt) {
-        socket.close();
-      }
-    }, SNAPSHOT_PROBE_TIMEOUT_MS);
+    // The socket may be a zombie after a long background stint — the snapshot
+    // reply is guaranteed traffic, so treat the request as a liveness probe.
+    armLivenessProbe();
     return;
   }
   // Socket isn't open — pull the reconnect forward instead of waiting on the
@@ -963,5 +991,15 @@ export function useSocket(): SocketAPI {
 }
 
 export function socketSend(payload: Record<string, unknown>): boolean {
-  return send(payload);
+  const sent = send(payload);
+  // Every 'history' request has a guaranteed reply, so each successful send is
+  // also a liveness expectation. Without this, a fetch swallowed by a
+  // half-open socket while the tab stays FOREGROUNDED wedges that buffer's
+  // loadingHistory until the OS TCP timeout finally fires 'close' (minutes):
+  // the close-handler sweep can't run without a close, and the resume-path
+  // probe only arms after a ≥30s-hidden visibilitychange. Arming here closes
+  // that gap — silence for the probe window forces the close, the sweep
+  // clears the flags, and the hydration reconciler refetches on reconnect.
+  if (sent && payload.type === 'history') armLivenessProbe();
+  return sent;
 }

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -77,6 +77,18 @@ const HIDDEN_RESNAPSHOT_MS = 30_000;
 let hiddenSince: number | null = null;
 let visibilityWired = false;
 
+// Zombie-socket detection for the resume path. iOS routinely kills a
+// backgrounded WebSocket's TCP connection without telling the page — on
+// return, readyState still claims OPEN, so refreshSnapshot()'s send goes into
+// the void and the user sits on stale (or shell-blank) buffers until the OS
+// gets around to erroring the socket, if it ever does. The snapshot request IS
+// a liveness probe: a live server always replies, so if nothing at all arrives
+// within the window, the link is dead — force-close it, which trips the normal
+// 'close' arm (fail pending ACKs + in-flight history, schedule reconnect).
+const SNAPSHOT_PROBE_TIMEOUT_MS = 5000;
+let snapshotProbeTimer: ReturnType<typeof setTimeout> | null = null;
+let lastMessageAt = 0;
+
 function wsUrl(): string {
   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
   const base = `${proto}://${window.location.host}/ws`;
@@ -776,7 +788,14 @@ function open() {
     },
     opts,
   );
-  socket.addEventListener('message', (ev) => handleMessage(ev.data), opts);
+  socket.addEventListener(
+    'message',
+    (ev) => {
+      lastMessageAt = Date.now();
+      handleMessage(ev.data);
+    },
+    opts,
+  );
   socket.addEventListener(
     'close',
     () => {
@@ -786,6 +805,16 @@ function open() {
       // pending ACK as a disconnect so callers can surface the failure now
       // instead of waiting out the timeout.
       failAllPendingAcks('disconnected');
+      // Same for in-flight history fetches: their responses died with the
+      // socket, and the per-buffer loadingHistory guards would otherwise wedge
+      // every future fetch for those buffers (a permanently blank,
+      // un-refetchable message list). Clearing here also makes the buffers
+      // eligible again for the hydration reconciler's reconnect refetch.
+      try {
+        useBuffersStore().failInFlightHistory();
+      } catch (_) {
+        /* store not yet initialized; nothing in flight */
+      }
       const auth = useAuthStore();
       if (auth.user) {
         reconnectTimer = setTimeout(open, 2000);
@@ -860,6 +889,10 @@ export function resetSocket(): void {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;
   }
+  if (snapshotProbeTimer) {
+    clearTimeout(snapshotProbeTimer);
+    snapshotProbeTimer = null;
+  }
   if (socket) {
     // Detach every listener at once so the 'close' reconnect arm can't fire.
     socketListeners?.abort();
@@ -879,7 +912,19 @@ export function resetSocket(): void {
 
 function refreshSnapshot() {
   if (socket && socket.readyState === WebSocket.OPEN) {
+    const sentAt = Date.now();
     send({ type: 'snapshot' });
+    // The socket may be a zombie (see SNAPSHOT_PROBE_TIMEOUT_MS). Any inbound
+    // message counts as liveness — the snapshot reply is guaranteed traffic,
+    // so silence for the whole window means the link is dead. close() trips
+    // the 'close' arm, which cleans up and schedules the reconnect.
+    if (snapshotProbeTimer) clearTimeout(snapshotProbeTimer);
+    snapshotProbeTimer = setTimeout(() => {
+      snapshotProbeTimer = null;
+      if (socket && socket.readyState === WebSocket.OPEN && lastMessageAt < sentAt) {
+        socket.close();
+      }
+    }, SNAPSHOT_PROBE_TIMEOUT_MS);
     return;
   }
   // Socket isn't open — pull the reconnect forward instead of waiting on the

--- a/vue_client/src/composables/useVisualViewport.ts
+++ b/vue_client/src/composables/useVisualViewport.ts
@@ -84,6 +84,21 @@ export function installVisualViewport(): void {
     keyboardOpen.value = open;
     if (open) root.setAttribute('data-keyboard-open', 'true');
     else root.removeAttribute('data-keyboard-open');
+    // Document-scroll watchdog (#581). The shell never scrolls the document
+    // (html/body are overflow:hidden), but a browser's keyboard-reveal logic
+    // can scroll it anyway — Chrome Android under resizes-visual scrolled the
+    // layout viewport to expose the focused composer and sometimes never
+    // scrolled back after dismiss, leaving the input bar off-screen until a
+    // full refresh (touch-action:none + user-scalable=no block manual
+    // recovery). The resizes-content viewport meta removes the cause; this
+    // heals any residue: with the keyboard down, a scrolled document is
+    // always a bug state, so snap it home. Runs on every update() — vv
+    // resize/scroll, focusout, orientationchange — so a stuck offset
+    // self-corrects on the next signal.
+    if (!open) {
+      const se = document.scrollingElement;
+      if (se && se.scrollTop > 0) se.scrollTop = 0;
+    }
   };
 
   update();

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -574,6 +574,32 @@ describe('hydration lifecycle (blank-buffer fix)', () => {
       expect(bufferNeedsHydration(buf)).toBe(false);
     });
 
+    it('treats an all-filtered latest reply as terminal (no refetch loop)', () => {
+      const store = useBuffersStore();
+      shellFrame(store, '#a');
+      const buf = store.byKey('1::#a')!;
+      vi.mocked(socketSend).mockReturnValue(true);
+      store.reattachToLive(1, '#a');
+
+      // Legacy away/back rows at the tail: the server ships them (it doesn't
+      // filter by type) with hasMoreOlder=true, the client filters them ALL
+      // out. Without the terminal clamp this left messages empty +
+      // hasMoreOlder true — permanently "needy", spinning the reconciler on a
+      // refetch every throttle window while the pane claimed settled-empty.
+      store.applyLatestReplace(1, '#a', {
+        token: buf.pendingHistoryToken,
+        events: [
+          { networkId: 1, target: '#a', id: 4001, type: 'away', nick: 'bob' },
+          { networkId: 1, target: '#a', id: 4002, type: 'back', nick: 'bob' },
+        ],
+        hasMoreOlder: true,
+      });
+
+      expect(buf.messages.length).toBe(0);
+      expect(buf.hasMoreOlder).toBe(false); // clamped: hydration is terminal
+      expect(bufferNeedsHydration(buf)).toBe(false);
+    });
+
     it('is true when the slice was wiped on switch-away-from-detached (pendingRefetch)', () => {
       const store = useBuffersStore();
       shellFrame(store, '#a');

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -25,9 +25,11 @@ vi.mock('./networks.js', () => ({
   }),
 }));
 vi.mock('./toasts.js', () => ({ useToastsStore: () => ({ push: vi.fn<() => void>() }) }));
-vi.mock('../composables/useSocket.js', () => ({ socketSend: vi.fn<(payload: unknown) => void>() }));
+vi.mock('../composables/useSocket.js', () => ({
+  socketSend: vi.fn<(payload: unknown) => boolean>(),
+}));
 
-import { useBuffersStore } from './buffers.js';
+import { useBuffersStore, bufferNeedsHydration } from './buffers.js';
 import { socketSend } from '../composables/useSocket.js';
 
 // The store always seeds the app-scoped system buffer (#355). These tests assert
@@ -521,5 +523,162 @@ describe('member attribute patching (#591, #508)', () => {
 
     expect(store.accountFor(1, 'bob')).toBeNull(); // server said logged out
     expect(store.accountFor(1, 'carol')).toBeUndefined(); // we never learned
+  });
+});
+
+describe('hydration lifecycle (blank-buffer fix)', () => {
+  const shellFrame = (store: ReturnType<typeof useBuffersStore>, target: string) =>
+    store.replaceBacklog(
+      1,
+      target,
+      [],
+      undefined,
+      { lastReadId: 1000, unread: 5, highlights: 0 },
+      true,
+      { hasMoreOlder: true },
+    );
+
+  describe('bufferNeedsHydration', () => {
+    it('is true for a fresh-connect shell and false once hydrated', () => {
+      const store = useBuffersStore();
+      shellFrame(store, '#a');
+      const buf = store.byKey('1::#a')!;
+      expect(bufferNeedsHydration(buf)).toBe(true);
+
+      vi.mocked(socketSend).mockReturnValue(true);
+      store.reattachToLive(1, '#a');
+      // In flight: not "in need" — the pending fetch will resolve or be failed.
+      expect(bufferNeedsHydration(buf)).toBe(false);
+      store.applyLatestReplace(1, '#a', {
+        token: buf.pendingHistoryToken,
+        events: [{ networkId: 1, target: '#a', id: 5000, type: 'message', nick: 'bob', body: 'x' }],
+        hasMoreOlder: true,
+      });
+      expect(bufferNeedsHydration(buf)).toBe(false);
+    });
+
+    it('is false for a genuinely-empty buffer (empty latest reply cleared hasMoreOlder)', () => {
+      const store = useBuffersStore();
+      store.ensure(1, 'newnick'); // brand-new DM, no history server-side
+      const buf = store.byKey('1::newnick')!;
+      expect(bufferNeedsHydration(buf)).toBe(true); // empty + default hasMoreOlder
+
+      vi.mocked(socketSend).mockReturnValue(true);
+      store.reattachToLive(1, 'newnick');
+      store.applyLatestReplace(1, 'newnick', {
+        token: buf.pendingHistoryToken,
+        events: [],
+        hasMoreOlder: false,
+      });
+      // No refetch loop: hydrated-and-empty is a terminal state.
+      expect(bufferNeedsHydration(buf)).toBe(false);
+    });
+
+    it('is true when the slice was wiped on switch-away-from-detached (pendingRefetch)', () => {
+      const store = useBuffersStore();
+      shellFrame(store, '#a');
+      const buf = store.byKey('1::#a')!;
+      buf.detached = true;
+      store.clearDetached(1, '#a', { wipeMessages: true });
+      expect(buf.pendingRefetch).toBe(true);
+      expect(bufferNeedsHydration(buf)).toBe(true);
+    });
+
+    it('excludes the system buffer and detached buffers', () => {
+      const store = useBuffersStore();
+      expect(bufferNeedsHydration(store.byKey(':system:')!)).toBe(false);
+      shellFrame(store, '#a');
+      const buf = store.byKey('1::#a')!;
+      buf.detached = true;
+      expect(bufferNeedsHydration(buf)).toBe(false);
+    });
+  });
+
+  describe('ensureHydrated', () => {
+    it('fires a latest fetch for an unhydrated shell', () => {
+      const store = useBuffersStore();
+      shellFrame(store, '#a');
+      vi.mocked(socketSend).mockClear().mockReturnValue(true);
+
+      store.ensureHydrated(1, '#a');
+
+      expect(socketSend).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'history', mode: 'latest', networkId: 1, target: '#a' }),
+      );
+    });
+
+    it('preserves pendingRefetch when the send fails, consumes it when the send succeeds', () => {
+      const store = useBuffersStore();
+      shellFrame(store, '#a');
+      const buf = store.byKey('1::#a')!;
+      buf.detached = true;
+      store.clearDetached(1, '#a', { wipeMessages: true });
+      expect(buf.pendingRefetch).toBe(true);
+
+      // Socket closed: socketSend reports false. The intent flag must survive
+      // so the reconciler's reconnect attempt still knows to refetch.
+      vi.mocked(socketSend).mockReturnValue(false);
+      store.ensureHydrated(1, '#a');
+      expect(buf.pendingRefetch).toBe(true);
+      expect(buf.loadingHistory).toBe(false); // rolled back, not wedged
+
+      vi.mocked(socketSend).mockReturnValue(true);
+      store.ensureHydrated(1, '#a');
+      expect(buf.pendingRefetch).toBe(false);
+      expect(buf.loadingHistory).toBe(true); // fetch in flight
+    });
+
+    it('no-ops while a fetch is already in flight', () => {
+      const store = useBuffersStore();
+      shellFrame(store, '#a');
+      vi.mocked(socketSend).mockReturnValue(true);
+      store.ensureHydrated(1, '#a');
+      vi.mocked(socketSend).mockClear();
+
+      store.ensureHydrated(1, '#a');
+
+      expect(socketSend).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failInFlightHistory', () => {
+    it('clears loadingHistory and pendingHistoryToken on every buffer', () => {
+      const store = useBuffersStore();
+      shellFrame(store, '#a');
+      shellFrame(store, '#b');
+      vi.mocked(socketSend).mockReturnValue(true);
+      store.reattachToLive(1, '#a');
+      store.reattachToLive(1, '#b');
+      expect(store.byKey('1::#a')!.loadingHistory).toBe(true);
+      expect(store.byKey('1::#b')!.loadingHistory).toBe(true);
+
+      store.failInFlightHistory();
+
+      for (const key of ['1::#a', '1::#b']) {
+        expect(store.byKey(key)!.loadingHistory).toBe(false);
+        expect(store.byKey(key)!.pendingHistoryToken).toBe(null);
+      }
+    });
+
+    it('unwedges a buffer whose reply was lost, so the next hydration attempt can fetch', () => {
+      const store = useBuffersStore();
+      shellFrame(store, '#a');
+      vi.mocked(socketSend).mockReturnValue(true);
+      store.reattachToLive(1, '#a');
+      const buf = store.byKey('1::#a')!;
+
+      // Socket died mid-flight: the reply never arrives. Historically this
+      // wedged the buffer forever (every fetch guard early-returns on
+      // loadingHistory). The close handler now sweeps the flags…
+      store.failInFlightHistory();
+      expect(bufferNeedsHydration(buf)).toBe(true);
+
+      // …so the reconciler's post-reconnect attempt goes through.
+      vi.mocked(socketSend).mockClear().mockReturnValue(true);
+      store.ensureHydrated(1, '#a');
+      expect(socketSend).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'history', mode: 'latest', target: '#a' }),
+      );
+    });
   });
 });

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -253,6 +253,24 @@ function makeBuffer(networkId: number | string | null, target: string): Buffer {
   };
 }
 
+// Does this buffer need a `history latest` fetch before it can render real
+// content? One predicate shared by activate() (the click path) and the
+// hydration reconciler (useBufferHydration — the reconnect/retry path) so the
+// two can never disagree about what "unhydrated" means. True for: a buffer
+// whose slice was wiped on switch-away-from-detached (pendingRefetch), a
+// fresh-connect SHELL (unseeded), and a locally-materialized empty buffer
+// (brand-new DM, channel-joined pre-backlog). `hasMoreOlder` gates the empty
+// case so a genuinely-empty buffer (empty latest reply flipped it false)
+// doesn't refetch forever. Detached and in-flight buffers are never "in need"
+// — the jump slice is deliberate, and a pending fetch will resolve or be
+// failed by failInFlightHistory on socket close.
+export function bufferNeedsHydration(buf: Buffer): boolean {
+  if (buf.networkId == null) return false;
+  if (buf.detached || buf.loadingHistory) return false;
+  if (buf.pendingRefetch) return true;
+  return (buf.messages.length === 0 || buf.unseeded) && buf.hasMoreOlder;
+}
+
 function ensureBuffer(
   state: { buffers: Record<string, Buffer> },
   networkId: number | string | null,
@@ -653,13 +671,17 @@ export const useBuffersStore = defineStore('buffers', {
     // button. Same token discipline as loadAround — detached stays true
     // until the response lands, so any fanOut between request and response
     // continues to be dropped by pushMessage.
-    reattachToLive(networkId: number | string, target: string, limit = 200) {
+    // Returns true when the request actually went out over the socket, so
+    // callers (ensureHydrated) can decide whether to consume one-shot intent
+    // flags like pendingRefetch — a failed send must leave them armed for the
+    // next attempt.
+    reattachToLive(networkId: number | string, target: string, limit = 200): boolean {
       const buf = ensureBuffer(this, networkId, target);
       // No detached guard: this is also called by activate() to refetch
       // the live tail after a switch-away from a detached buffer wiped
       // the slice. In that case detached is already false. The applyLatestReplace
       // handler is idempotent (re-clearing already-clear flags is a no-op).
-      if (buf.loadingHistory) return;
+      if (buf.loadingHistory) return false;
       const token = nextHistoryToken();
       buf.pendingHistoryToken = token;
       buf.loadingHistory = true;
@@ -672,15 +694,44 @@ export const useBuffersStore = defineStore('buffers', {
         limit,
       });
       // socketSend returns false when the socket isn't open. No response will
-      // arrive to clear loadingHistory, and there's no reconnect handler that
-      // resets it per-buffer — so without this rollback the buffer would be
-      // permanently stranded "loading" and every subsequent fetch guard
-      // (this function's early-return, MessageList's requestMoreHistory) would
-      // block forever. Relevant when activate fires before the socket has
-      // (re)connected, e.g. push-notification deep-link into a cold PWA.
+      // arrive to clear loadingHistory — so without this rollback the buffer
+      // would be stranded "loading" until the socket-close sweep
+      // (failInFlightHistory) ran, and every fetch guard (this function's
+      // early-return, MessageList's requestMoreHistory) would block until then.
+      // Relevant when activate fires before the socket has (re)connected, e.g.
+      // push-notification deep-link into a cold PWA.
       if (!sent) {
         buf.loadingHistory = false;
         buf.pendingHistoryToken = null;
+        return false;
+      }
+      return true;
+    },
+    // Fire the initial `latest` fetch for the active-path buffer if (and only
+    // if) it still needs one — see bufferNeedsHydration. Safe to call
+    // repeatedly: it no-ops once a fetch is in flight or the buffer is
+    // hydrated. pendingRefetch is consumed only when the request really went
+    // out; a send into a closed socket leaves it armed so the hydration
+    // reconciler retries on reconnect instead of silently downgrading the
+    // wiped-slice case to "maybe the empty-arm catches it".
+    ensureHydrated(networkId: number | string | null, target: string) {
+      const buf = this.findByTarget(networkId, target);
+      if (!buf || buf.networkId == null || !bufferNeedsHydration(buf)) return;
+      const sent = this.reattachToLive(buf.networkId, buf.target);
+      if (sent && buf.pendingRefetch) buf.pendingRefetch = false;
+    },
+    // Socket died. Any in-flight history request (latest/around/before/after)
+    // will never get a response, and every fetch path early-returns while
+    // loadingHistory is set — historically a permanently wedged, blank,
+    // un-refetchable buffer. Called from the socket 'close' handler (the same
+    // seam that fails pending ACKs) so the flags are clean before the
+    // reconnect's snapshot and the hydration reconciler's refetch arrive.
+    failInFlightHistory() {
+      for (const buf of Object.values(this.buffers)) {
+        if (buf.loadingHistory || buf.pendingHistoryToken != null) {
+          buf.loadingHistory = false;
+          buf.pendingHistoryToken = null;
+        }
       }
     },
     applyLatestReplace(networkId: number | string, target: string, payload: any) {
@@ -1119,42 +1170,16 @@ export const useBuffersStore = defineStore('buffers', {
           });
         }
       }
-      // Re-entry after the slice was wiped on switch-away-from-detached.
-      // Fire a fresh latest fetch so the user lands on live tail content
-      // instead of an empty buffer. The applyLatestReplace response will
-      // do its own mark-read against the new tail.
-      // Network-buffer only: the system buffer is seeded by its connect backlog
-      // and never detaches (its lines aren't searchable/jumpable), so it doesn't
-      // need the activate-refetch; the guard also excludes the FRIENDS overview.
-      if (networkId != null && buf.pendingRefetch) {
-        buf.pendingRefetch = false;
-        this.reattachToLive(networkId, canonTarget);
-      } else if (
-        networkId != null &&
-        (buf.messages.length === 0 || buf.unseeded) &&
-        buf.hasMoreOlder &&
-        !buf.detached &&
-        !buf.loadingHistory
-      ) {
-        // First-load fetch. The buffer shell exists but has no messages —
-        // either it's brand new (profile-modal "Send DM" to a nick we've
-        // never DM'd before) or it was pre-created by a side channel
-        // (the channel-joined handler calls ensure() before any backlog
-        // arrives) and the initial backlog snapshot only covers
-        // buffers that were already open at socket-connect. Push-notification
-        // deep-links land here too, since isOpen() is satisfied by any shell
-        // in the store regardless of message contents. Kick a latest fetch
-        // here so every entry path is uniformly seeded — the MessageList
-        // lifecycle's ensureViewportFilled() goes back to being a safety
-        // net rather than the load-bearing initial-fetch trigger.
-        //
-        // hasMoreOlder gates against the truly-empty case: a brand-new
-        // DM/channel with no server history returns an empty latest slice
-        // that leaves messages.length=0 but flips hasMoreOlder to false —
-        // without this guard we'd refire the same empty fetch on every
-        // re-activate.
-        this.reattachToLive(networkId, canonTarget);
-      }
+      // Fire the initial fetch if the buffer still needs one: a slice wiped on
+      // switch-away-from-detached (pendingRefetch), a fresh-connect SHELL
+      // (unseeded), or a locally-materialized empty buffer — profile-modal
+      // "Send DM" to a never-DM'd nick, the channel-joined handler's ensure()
+      // racing its backlog, a push-notification deep-link onto a shell. The
+      // decision (and its guards) lives in bufferNeedsHydration so this click
+      // path and the hydration reconciler (useBufferHydration — which retries
+      // when THIS send loses the race with a closed/half-dead socket) can
+      // never disagree about what "needs a fetch" means.
+      this.ensureHydrated(networkId, canonTarget);
       // For DMs, ask the server to WHOIS-probe the peer so the banner/sidebar
       // dim reflect current state rather than a possibly-stale cached value.
       // The probe is silent (no /whois reply in the server buffer); only the

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -743,7 +743,16 @@ export const useBuffersStore = defineStore('buffers', {
       buf.messages = filtered.slice(-MAX_PER_BUFFER);
       buf.oldestId = buf.messages[0]?.id ?? null;
       buf.newestId = buf.messages[buf.messages.length - 1]?.id ?? null;
-      buf.hasMoreOlder = !!payload.hasMoreOlder;
+      // A token-matched latest reply is TERMINAL hydration even when every row
+      // filtered out client-side (a legacy away/back tail can blank the whole
+      // slice). Honoring the server's hasMoreOlder on an empty slice would
+      // leave `messages.length === 0 && hasMoreOlder` standing forever —
+      // bufferNeedsHydration true, the reconciler refetching the same empty
+      // slice every throttle window, and the pane claiming a settled "No
+      // messages yet." between attempts. Clamping to false costs nothing: an
+      // empty buffer has no anchor row, so the upward pager can't page it
+      // anyway.
+      buf.hasMoreOlder = filtered.length > 0 ? !!payload.hasMoreOlder : false;
       buf.hasMoreNewer = false;
       buf.detached = false;
       buf.liveDuringDetach = 0;

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -488,10 +488,16 @@ useChatBootstrap({ onJump: onJumpToMessage });
 /* Single-column flex stack sized to 100dvh. On current iOS Safari the
    dynamic-viewport unit shrinks with the soft keyboard, so the shell
    contracts and the input bar (last flex child) rides up flush against
-   the keyboard with no extra plumbing. We deliberately do NOT use
-   position: fixed or a JS-tracked --kb-bottom here — those approaches
-   fight iOS auto-scroll, env() shifts, and a known iOS 26 visualViewport
-   regression (returns phantom positive values after keyboard dismiss).
+   the keyboard with no extra plumbing. Chrome Android needs one assist
+   to follow the same model: interactive-widget=resizes-content in the
+   viewport meta (index.html, #581) — without it Chrome overlays the
+   keyboard instead of shrinking the layout viewport, and its focused-
+   input reveal scrolls the document our shell forbids from scrolling,
+   stranding the input bar off-screen after dismiss. We deliberately do
+   NOT use position: fixed or a JS-tracked --kb-bottom here — those
+   approaches fight iOS auto-scroll, env() shifts, and a known iOS 26
+   visualViewport regression (returns phantom positive values after
+   keyboard dismiss).
    The body-level `touch-action: none` (see main.css) is what stops iOS
    from drag-scrolling the document despite overflow:hidden. Safe-area
    home-indicator clearance lives on .composer-host (below) — wrapping


### PR DESCRIPTION
## What this fixes

Two long-standing, overlapping bugs that shared one symptom — "clicking into a buffer shows a blank view":

1. **Empty-data blanks (all platforms).** Fresh-connect snapshots ship buffers as empty shells, and exactly one code path ever hydrated a shell: `activate()`'s fetch at the instant of the click. A click while the socket was closed, a reply lost mid-flight (permanently wedging `loadingHistory`), a reconnect wiping a detached buffer, or a resume re-shelling a buffer all produced a blank list with no recovery.
2. **Shifted-viewport blanks + the vanishing input bar on Chrome Android (#581).** The `100dvh` shell assumes the soft keyboard shrinks the layout viewport — true on iOS Safari, false on Chrome Android 108+ (`resizes-visual` overlays the keyboard and scrolls a document our shell forbids from scrolling). A stuck shift left the input bar (and sometimes the whole pane) off-screen until a full refresh.

## How

- **Hydration is now an invariant, not an event**: `bufferNeedsHydration()` is a single shared predicate; the `useBufferHydration` reconciler (module singleton in a detached `effectScope`) refires the fetch whenever the active buffer needs one and the socket allows.
- **Socket close fails in-flight history** (`failInFlightHistory`), exactly like pending ACKs — no more permanently wedged `loadingHistory`.
- **A socket-scoped liveness probe** arms on the resume snapshot and every history send: total inbound silence for 10s force-closes the zombie socket, so recovery is seconds, not OS-TCP-timeout minutes. The probe is identity-checked and cleared on close so it can never kill a healthy replacement socket.
- **Terminal hydration**: an empty token-matched `latest` reply clamps `hasMoreOlder` so legacy away/back tails can't spin a refetch loop.
- **MessageList always renders an explicit state** — "Loading messages…" / "No messages yet." / "No messages to show." — so the pane can no longer be silently blank.
- **`interactive-widget=resizes-content`** in the viewport meta restores the keyboard model the shell was built for on Chrome (Safari ignores it), plus a watchdog that snaps a stuck document scroll home. Closes #581.

## Review

`/code-review high` ran on the branch: 8 findings survived adversarial verification, 7 fixed in the follow-up commit (generalized liveness probe, probe socket-scoping, refetch-loop clamp, `effectScope`, throttle generation reset, wider probe window, jump-abandon toast); 1 negligible-efficiency finding deliberately skipped.

## Testing

- `npm run check` (both typechecks, lint, format) and the full suite pass — 2,799 tests, including 10 new hydration-lifecycle regression tests.
- QA focus: mobile PWA foreground/background cycles (blank-list recovery), Chrome Android keyboard open/dismiss (input bar stays), and jump-to-message during flaky connectivity.

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)