### PR TITLE
Admin screens auto-refresh + strip mIRC codes from notifications

### DIFF
--- a/server/services/notificationContent.test.ts
+++ b/server/services/notificationContent.test.ts
@@ -79,6 +79,13 @@ describe('composeNotification', () => {
     ).toBe('A friend came online (Libera)');
   });
 
+  it('strips mIRC formatting codes from the body (#606)', () => {
+    // A native alert renders body as plain text, so \x03 colors and \x02 bold
+    // would otherwise land as literal control chars on the lock screen.
+    const out = composeNotification(payload({ text: '\x0304red\x03 and \x02bold\x02 text' }));
+    expect(out.body).toBe('red and bold text');
+  });
+
   it('tags by buffer so a burst in one channel collapses', () => {
     const a = composeNotification(payload({ kind: 'highlight', target: '#lurker', text: 'one' }));
     const b = composeNotification(payload({ kind: 'highlight', target: '#lurker', text: 'two' }));

--- a/server/services/notificationContent.ts
+++ b/server/services/notificationContent.ts
@@ -19,6 +19,8 @@
 // when the server starts sending them. Once every client has cycled, the worker's
 // copy is dead code and goes.
 
+import { stripFormatting } from './textMatch.js';
+
 export type PushPayloadKind = 'dm' | 'highlight' | 'always_notify' | 'friend_online';
 
 /**
@@ -82,7 +84,10 @@ export function composeNotification(payload: PushPayload): NotificationContent {
   return {
     title: title(payload),
     // friend_online carries no text, so its body is empty — the title says it all.
-    body: payload.text || '',
+    // Strip mIRC formatting codes (\x03 colors, \x02 bold, …): a native alert
+    // renders body as plain text, so the codes would otherwise arrive as literal
+    // control chars on the lock screen (#606).
+    body: stripFormatting(payload.text || ''),
     tag: `${payload.networkId || 0}::${payload.target || ''}`,
   };
 }

--- a/vue_client/src/components/admin-panes/InvitesPane.vue
+++ b/vue_client/src/components/admin-panes/InvitesPane.vue
@@ -71,14 +71,14 @@ const adminBusy = ref(false);
 const lastCreatedInviteUrl = ref('');
 
 onMounted(() => {
-  // Fetch once per session — the admin panel route-swaps panes, so an
-  // unconditional fetch would re-hit /api/admin/invites on every tab switch.
-  // The store keeps the list current for local mutations (create/revoke).
-  if (!adminStore.invitesLoaded) {
-    adminStore.fetchInvites().catch((e: any) => {
-      adminError.value = e.message;
-    });
-  }
+  // Refetch on every pane activation. The store cache stays correct for THIS
+  // session's own mutations (create/revoke), but an invite accepted elsewhere —
+  // or another admin's change — leaves it stale until a full browser reload. The
+  // admin panel route-swaps panes, so re-mount is the natural place to re-sync;
+  // the request is cheap and keeps the screen honest (#613).
+  adminStore.fetchInvites().catch((e: any) => {
+    adminError.value = e.message;
+  });
 });
 
 async function onCreateInvite() {

--- a/vue_client/src/components/admin-panes/UsersPane.vue
+++ b/vue_client/src/components/admin-panes/UsersPane.vue
@@ -80,14 +80,14 @@ const adminError = ref('');
 const adminBusy = ref(false);
 
 onMounted(() => {
-  // Fetch once per session — the admin panel route-swaps panes, so an
-  // unconditional fetch would re-hit /api/admin/users on every tab switch. The
-  // store keeps the list current for local mutations (delete/pause/resume).
-  if (!adminStore.usersLoaded) {
-    adminStore.fetchUsers().catch((e: any) => {
-      adminError.value = e.message;
-    });
-  }
+  // Refetch on every pane activation. The store cache stays correct for THIS
+  // session's own mutations (delete/pause/resume), but an invite accepted
+  // elsewhere — or another admin's change — leaves it stale until a full browser
+  // reload. The admin panel route-swaps panes, so re-mount is the natural place
+  // to re-sync; the request is cheap and keeps the screen honest (#613).
+  adminStore.fetchUsers().catch((e: any) => {
+    adminError.value = e.message;
+  });
 });
 
 async function onDeleteUser(user: AdminUser) {

--- a/vue_client/src/composables/useHighlightNotifier.test.ts
+++ b/vue_client/src/composables/useHighlightNotifier.test.ts
@@ -106,4 +106,13 @@ describe('notifyForEvent notify gate', () => {
     notifyForEvent(dm());
     expect(push).not.toHaveBeenCalled();
   });
+
+  it('strips mIRC formatting codes from the toast body (#606)', async () => {
+    // The toast renders body as plain text, so \x03 colors / \x02 bold would
+    // otherwise surface as literal control chars.
+    const { notifyForEvent } = await load();
+    notifyForEvent(dm({ text: '\x0304red\x03 and \x02bold\x02 text' }));
+    expect(push).toHaveBeenCalledTimes(1);
+    expect((push.mock.calls[0][0] as { body: string }).body).toBe('red and bold text');
+  });
 });

--- a/vue_client/src/composables/useHighlightNotifier.ts
+++ b/vue_client/src/composables/useHighlightNotifier.ts
@@ -20,6 +20,7 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { viewedBuffer } from './useViewedBuffer.js';
 import { META_SEPARATOR } from '../utils/metaLine.js';
+import { stripFormatting } from '../../../shared/textMatch.js';
 
 export interface NotifyEvent {
   self?: boolean;
@@ -146,7 +147,10 @@ export function notifyForEvent(event: NotifyEvent | null | undefined): void {
   toasts.push({
     kind: kindKey,
     title: `${event.nick || '?'} in ${where}`,
-    body: event.text || '',
+    // The toast renders body as plain text, so mIRC formatting codes (\x03
+    // colors, \x02 bold, …) would show up as literal control chars. Strip them
+    // — a toast is a glanceable summary, not the message view (#606).
+    body: stripFormatting(event.text || ''),
     networkId: event.networkId,
     target: event.target,
     messageId: event.id,

--- a/vue_client/src/stores/admin.test.ts
+++ b/vue_client/src/stores/admin.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The admin panes refetch on every mount (#613), so a slow users/invites GET can
+// still be in flight when a local mutation patches the list. These lock in the
+// per-resource fetch-generation guard that drops a superseded GET rather than
+// letting it resurrect a just-deleted row.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const h = vi.hoisted(() => ({
+  api: vi.fn<(url: string, opts?: { method?: string }) => Promise<unknown>>(),
+}));
+vi.mock('../api.js', () => ({ api: h.api }));
+
+import { useAdminStore, type AdminUser, type AdminInvite } from './admin.js';
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function user(id: number, username: string): AdminUser {
+  return { id, username, createdAt: '' };
+}
+
+function invite(token: string): AdminInvite {
+  return { token, url: '', status: 'pending', createdAt: '', expiresAt: null, usedAt: null };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  h.api.mockReset();
+});
+
+describe('admin store — refetch race guard (#613)', () => {
+  it('an in-flight users GET cannot resurrect a locally-deleted user', async () => {
+    const store = useAdminStore();
+    store.users = [user(1, 'a'), user(2, 'b')];
+    store.usersLoaded = true;
+
+    // The GET (mount refetch) stays in flight; DELETE resolves immediately.
+    const getDefer = deferred<{ users: AdminUser[] }>();
+    h.api.mockImplementation((_url: string, opts?: { method?: string }) =>
+      opts?.method === 'DELETE' ? Promise.resolve({}) : getDefer.promise,
+    );
+
+    const fetching = store.fetchUsers(); // seq = 1, awaiting the GET
+    await store.deleteUser(2); // bumps seq to 2, filters locally
+    expect(store.users.map((u) => u.id)).toEqual([1]);
+
+    // The stale GET resolves with the PRE-delete list.
+    getDefer.resolve({ users: [user(1, 'a'), user(2, 'b')] });
+    await fetching;
+
+    // User 2 must not be back.
+    expect(store.users.map((u) => u.id)).toEqual([1]);
+  });
+
+  it('an in-flight invites GET cannot drop a locally-created invite', async () => {
+    const store = useAdminStore();
+    store.invites = [invite('old')];
+    store.invitesLoaded = true;
+
+    const getDefer = deferred<{ invites: AdminInvite[] }>();
+    h.api.mockImplementation((_url: string, opts?: { method?: string }) =>
+      opts?.method === 'POST' ? Promise.resolve({ invite: invite('new') }) : getDefer.promise,
+    );
+
+    const fetching = store.fetchInvites(); // seq = 1, awaiting the GET
+    await store.createInvite(); // bumps seq, prepends locally
+    expect(store.invites.map((i) => i.token)).toEqual(['new', 'old']);
+
+    // The stale GET resolves without the freshly-created invite.
+    getDefer.resolve({ invites: [invite('old')] });
+    await fetching;
+
+    expect(store.invites.map((i) => i.token)).toEqual(['new', 'old']);
+  });
+
+  it('a fresh GET with no mutation racing applies normally', async () => {
+    const store = useAdminStore();
+    h.api.mockResolvedValue({ users: [user(5, 'e')] });
+    await store.fetchUsers();
+    expect(store.users.map((u) => u.id)).toEqual([5]);
+    expect(store.usersLoaded).toBe(true);
+  });
+});

--- a/vue_client/src/stores/admin.ts
+++ b/vue_client/src/stores/admin.ts
@@ -59,42 +59,62 @@ export const useAdminStore = defineStore('admin', {
     usersLoaded: false,
     invitesLoaded: false,
     uploadersLoaded: false,
+    // Monotonic per-resource fetch generation. The admin panes refetch on every
+    // mount (#613), so a slow GET can still be in flight when a local mutation
+    // (delete/pause/create/revoke) patches the list. Each fetch captures the seq
+    // and drops its payload if a newer fetch OR a mutation bumped it meanwhile —
+    // otherwise the stale GET would resurrect a just-deleted row.
+    usersFetchSeq: 0,
+    invitesFetchSeq: 0,
     loading: false,
     error: '',
   }),
   actions: {
     async fetchUsers() {
+      const seq = ++this.usersFetchSeq;
       this.error = '';
       try {
         const { users } = await api('/api/admin/users');
+        // A newer fetch or a local mutation superseded this GET while it was in
+        // flight — its payload is stale, so drop it rather than clobber the
+        // fresher state.
+        if (seq !== this.usersFetchSeq) return;
         this.users = users || [];
         this.usersLoaded = true;
       } catch (e: any) {
+        if (seq !== this.usersFetchSeq) return;
         this.error = e.message || 'failed to load users';
         throw e;
       }
     },
     async deleteUser(id: number) {
       await api(`/api/admin/users/${id}`, { method: 'DELETE' });
+      // Invalidate any in-flight GET so it can't resurrect the deleted row.
+      this.usersFetchSeq++;
       this.users = this.users.filter((u) => u.id !== id);
     },
     async pauseUser(id: number) {
       await api(`/api/admin/users/${id}/pause`, { method: 'POST' });
+      this.usersFetchSeq++;
       const u = this.users.find((x) => x.id === id);
       if (u) u.isPaused = true;
     },
     async resumeUser(id: number) {
       await api(`/api/admin/users/${id}/resume`, { method: 'POST' });
+      this.usersFetchSeq++;
       const u = this.users.find((x) => x.id === id);
       if (u) u.isPaused = false;
     },
     async fetchInvites() {
+      const seq = ++this.invitesFetchSeq;
       this.error = '';
       try {
         const { invites } = await api('/api/admin/invites');
+        if (seq !== this.invitesFetchSeq) return;
         this.invites = invites || [];
         this.invitesLoaded = true;
       } catch (e: any) {
+        if (seq !== this.invitesFetchSeq) return;
         this.error = e.message || 'failed to load invites';
         throw e;
       }
@@ -104,11 +124,13 @@ export const useAdminStore = defineStore('admin', {
         method: 'POST',
         body: expiresInDays ? { expiresInDays } : {},
       });
+      this.invitesFetchSeq++;
       this.invites = [invite, ...this.invites];
       return invite as AdminInvite;
     },
     async deleteInvite(token: string) {
       await api(`/api/admin/invites/${encodeURIComponent(token)}`, { method: 'DELETE' });
+      this.invitesFetchSeq++;
       this.invites = this.invites.filter((i) => i.token !== token);
     },
 


### PR DESCRIPTION
Two small Admin & Onboarding polish fixes, folded in ahead of v1.1.3.

Closes #613, Closes #606

## #613 — admin Users/Invites screens auto-refresh
The panes fetched once per session and gated on `usersLoaded`/`invitesLoaded`, so an invite accepted elsewhere (or another admin's change) showed stale until a full browser reload. The admin panel re-mounts panes on tab switch, so this drops the `onMounted` guard and refetches on every activation. The `*Loaded` flags stay (they still gate the "No users." / "No invites yet." empty-state copy).

**Refetch race guard.** Because the store still patches `users`/`invites` locally on delete/pause/create/revoke, an unconditional refetch introduced a clobber race: a slow GET in flight when a mutation lands could resolve afterward and resurrect the mutated-away row. Fixed with a monotonic per-resource fetch generation — each `fetchUsers`/`fetchInvites` captures the seq and drops its payload if a newer fetch or a mutation bumped it meanwhile; mutations bump the seq. Covered by a new `admin.test.ts` (delete-race + create-race).

## #606 — strip mIRC codes from toasts & push
mIRC formatting codes (`\x03` colors, `\x02` bold, …) leaked into toasts and native push bodies as literal control chars, since both render plain text. Now stripped via the shared `stripFormatting()` at the two choke points: the toast body in `useHighlightNotifier` and the push body in `composeNotification` (covers APNs/FCM/web push). Titles are nick-based and left alone. Colored-toast *rendering* is deliberately out of scope.

### Known edge (deferred)
A message consisting *only* of formatting codes strips to an empty body; `sw.js`'s `data.body || data.text` fallback then resurrects the raw text on the **web-push** transport only (APNs/FCM use the composed body directly). Degenerate input — left as a noted follow-up rather than touching `sw.js` here.

## Checks
`npm run format`, `npm run check`, `npm test` (2804 passing). Reviewed via `/code-review high` — 3 findings, 2 fixed here, 1 (the edge above) deferred by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)