### PR TITLE
Bump version to 1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version bump to **1.1.3** — root + `vue_client` `package.json`/`package-lock.json`.

## What's in this release
- **Own the IRC reconnect policy: retry-forever with backoff** (#618)
- **Fix blank message lists** (hydration reconciler) and the vanishing mobile-Chrome input bar (#619)
- **Store IRCv3 server-time + msgid; adopt echo-message for own sends** (#611)
- **Fold the ignore/mute veto into the server notify flag** (#614)
- **Admin screens auto-refresh + strip mIRC codes from toasts/push** (#613, #606)
- **/part: leave the current channel with a reason** (#615)
- **Run the v16 buffers cutover as BEGIN IMMEDIATE** (#603)
- **docs: Client Protocol & API spec for third-party client authors** (#609), surfaced as a top-nav Developers dropdown (#610)
- **Label native push devices by transport instead of user agent** (#604)

Version-strings only — no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)