### PR TITLE
Highlight-count chip on the buffer-list reveal controls

### DIFF
--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -351,6 +351,7 @@ import { useNetworkActions } from '../composables/useNetworkActions.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJoinChannelModal } from '../composables/useJoinChannelModal.js';
 import { useContextMenu } from '../composables/useContextMenu.js';
+import { unreadLabel } from '../utils/unreadLabel.js';
 import {
   isPeerOffline as derivePeerOffline,
   isPeerAway as derivePeerAway,
@@ -478,12 +479,6 @@ function serverUnread(networkId: number): number {
 
 function serverHighlights(networkId: number): number {
   return serverBuf(networkId)?.highlighted || 0;
-}
-
-// Keep the unread chip narrow — a four-figure count would stretch the row
-// and isn't more actionable than "a lot".
-function unreadLabel(count: number): string {
-  return count > 999 ? '>999' : String(count);
 }
 
 function hasDraft(buf: Buffer): boolean {

--- a/vue_client/src/composables/useHighlightChip.test.ts
+++ b/vue_client/src/composables/useHighlightChip.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+beforeEach(() => vi.resetModules());
+
+// Load a fresh useHighlightChip over refs we control, following useAppBadge's
+// pattern: `vue` is imported AFTER the module reset so the refs come from the
+// same reactivity instance the composable's `computed` will track.
+async function load(total = 0, unreadDisplay = 'full') {
+  const { ref } = await import('vue');
+  const totalRef = ref(total);
+  const displayRef = ref(unreadDisplay);
+  vi.doMock('../stores/buffers.js', () => ({
+    useBuffersStore: () => ({
+      get totalHighlights() {
+        return totalRef.value;
+      },
+    }),
+  }));
+  vi.doMock('../stores/settings.js', () => ({
+    useSettingsStore: () => ({
+      effective: (key: string) =>
+        key === 'look.buffer_list.unread_display' ? displayRef.value : undefined,
+    }),
+  }));
+  const mod = await import('./useHighlightChip.js');
+  return { ...mod, totalRef, displayRef };
+}
+
+describe('useHighlightChip', () => {
+  it('reports the store total verbatim, so the chip and the app-icon badge agree', async () => {
+    const { useHighlightChip, totalRef } = await load(3);
+    const chip = useHighlightChip();
+    expect(chip.count.value).toBe(3);
+    expect(chip.label.value).toBe('3');
+
+    totalRef.value = 12;
+    expect(chip.count.value).toBe(12);
+    expect(chip.label.value).toBe('12');
+  });
+
+  it('hides at zero — nothing waiting means no chip', async () => {
+    const { useHighlightChip, totalRef } = await load(0);
+    const chip = useHighlightChip();
+    expect(chip.show.value).toBe(false);
+
+    totalRef.value = 1;
+    expect(chip.show.value).toBe(true);
+  });
+
+  it('shows in every unread_display mode except off', async () => {
+    const { useHighlightChip, displayRef } = await load(4);
+    const chip = useHighlightChip();
+    for (const mode of ['full', 'highlights', 'badge']) {
+      displayRef.value = mode;
+      expect(chip.show.value).toBe(true);
+    }
+    // "off" means row color/weight is the only cue — the chip is exactly the
+    // numeric cue that mode turns down.
+    displayRef.value = 'off';
+    expect(chip.show.value).toBe(false);
+  });
+
+  it('stays hidden at zero even when unread_display would allow it', async () => {
+    const { useHighlightChip, displayRef } = await load(0);
+    const chip = useHighlightChip();
+    displayRef.value = 'highlights';
+    expect(chip.show.value).toBe(false);
+  });
+
+  it('caps a four-figure total so the chip cannot stretch its host control', async () => {
+    const { useHighlightChip } = await load(1500);
+    const chip = useHighlightChip();
+    expect(chip.label.value).toBe('>999');
+    expect(chip.show.value).toBe(true);
+  });
+});

--- a/vue_client/src/composables/useHighlightChip.ts
+++ b/vue_client/src/composables/useHighlightChip.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { computed, type ComputedRef } from 'vue';
+import { useBuffersStore } from '../stores/buffers.js';
+import { useSettingsStore } from '../stores/settings.js';
+import { unreadLabel } from '../utils/unreadLabel.js';
+
+export interface HighlightChip {
+  count: ComputedRef<number>;
+  label: ComputedRef<string>;
+  show: ComputedRef<boolean>;
+}
+
+// The highlight-count chip for the controls that reveal a hidden buffer list:
+// the desktop rail's expand button and the mobile buffer screen's back button
+// (#636). Both hosts exist ONLY while the list is hidden, so the chip stands in
+// for the highlighted rows the collapse took off-screen rather than adding a
+// new app-wide indicator — nothing to surface when the list is up.
+//
+// Highlights only, deliberately. The count is `totalHighlights` verbatim — the
+// same getter behind the PWA app-icon badge (useAppBadge) — so the chip and the
+// badge can never report different NUMBERS. It is NOT the per-row unread total
+// that `full` mode draws on each row: a collapsed rail with unread-but-
+// unhighlighted traffic shows no chip, which is correct precisely because it
+// matches the app badge (also highlights-only). The active buffer always
+// contributes 0 (the store forces it), so the number means "highlights waiting
+// somewhere I can't see" without any subtraction.
+//
+// The one thing the chip does NOT share with the app badge is the `off` gate
+// below: that's an in-app buffer-list display preference the OS badge has no
+// business reading. So the value stays in lockstep with the badge; only
+// visibility can differ, and only for that one setting.
+export function useHighlightChip(): HighlightChip {
+  const buffers = useBuffersStore();
+  const settings = useSettingsStore();
+
+  const count = computed(() => buffers.totalHighlights);
+  // `off` means "row color/weight is the only cue" — a chip is exactly the
+  // numeric cue that mode turns down, so it goes too. The other three modes all
+  // show it: the chip is highlights-only, which makes `full`, `highlights` and
+  // `badge` equivalent here (they differ only in how per-row counts are drawn).
+  const show = computed(
+    () => count.value > 0 && settings.effective('look.buffer_list.unread_display') !== 'off',
+  );
+
+  return { count, label: computed(() => unreadLabel(count.value)), show };
+}

--- a/vue_client/src/utils/unreadLabel.test.ts
+++ b/vue_client/src/utils/unreadLabel.test.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { unreadLabel } from './unreadLabel.js';
+
+describe('unreadLabel', () => {
+  it('renders the count as-is up to 999 and caps above it', () => {
+    expect(unreadLabel(0)).toBe('0');
+    expect(unreadLabel(1)).toBe('1');
+    expect(unreadLabel(999)).toBe('999');
+    expect(unreadLabel(1000)).toBe('>999');
+    expect(unreadLabel(1500)).toBe('>999');
+  });
+});

--- a/vue_client/src/utils/unreadLabel.ts
+++ b/vue_client/src/utils/unreadLabel.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Keep an unread/highlight count narrow wherever it's shown — a four-figure
+// number would stretch the row or control it sits on and isn't more actionable
+// than "a lot". Shared by BufferList's per-row badges and the collapsed-list
+// highlight chip (useHighlightChip) so both cap by one rule, not two copies.
+export function unreadLabel(count: number): string {
+  return count > 999 ? '>999' : String(count);
+}

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -18,8 +18,21 @@
            (#355); the collapse control lives there too. When collapsed the list
            is unmounted, so the expand control returns to the top of the rail. -->
       <BufferList v-if="showChannels" />
-      <button v-else class="link rail-toggle" title="Show channel list" @click="toggleChannels">
+      <!-- Collapsing the list takes its per-row highlight badges with it, so the
+           control that brings it back carries their total (#636). Unlike the
+           Transfers button below this one IS a count badge: the number is the
+           information here, not a state the glyph could stand in for. -->
+      <button
+        v-else
+        class="link rail-toggle"
+        :title="railToggleTitle"
+        :aria-label="railToggleTitle"
+        @click="toggleChannels"
+      >
         <i class="fa-solid fa-angles-right"></i>
+        <span v-if="hlChip.show.value" class="hl-chip" aria-hidden="true">{{
+          hlChip.label.value
+        }}</span>
       </button>
       <div ref="footEl" class="sidebar-foot" :class="{ 'foot-wrapped': footWrapped }">
         <!-- Settings and Add-network normally live in the LURKER header (#411),
@@ -311,6 +324,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useChatBootstrap } from '../composables/useChatBootstrap.js';
 import { useActiveBuffer } from '../composables/useActiveBuffer.js';
 import { useBufferSearchScope } from '../composables/useBufferSearchScope.js';
+import { useHighlightChip } from '../composables/useHighlightChip.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useAuthStore } from '../stores/auth.js';
 import BufferList from '../components/BufferList.vue';
@@ -390,6 +404,17 @@ const dccTitle = computed(() =>
   dcc.pendingCount > 0 ? `DCC transfers — ${dcc.pendingCount} awaiting approval` : 'DCC transfers',
 );
 const whois = useWhoisStore();
+
+// Not reactive()-wrapped: the chip's fields stay refs so the template can read
+// them as `hlChip.show.value`, which keeps this identical to MobileChat's use.
+const hlChip = useHighlightChip();
+// The count is aria-hidden in the markup — screen readers get it here instead,
+// as words rather than a bare number floating beside "Show channel list".
+const railToggleTitle = computed(() =>
+  hlChip.show.value
+    ? `Show channel list — ${hlChip.label.value} highlight${hlChip.count.value === 1 ? '' : 's'}`
+    : 'Show channel list',
+);
 
 const channelListModal = reactive(useChannelListModal());
 const joinChannelModal = reactive(useJoinChannelModal());
@@ -793,6 +818,30 @@ useChatBootstrap({ onJump: onJumpToMessage });
   text-align: center;
   padding: var(--space-4) 0;
   border-bottom: 1px solid var(--border);
+  /* Anchors .hl-chip only — the chip is positioned so it stays OUT of the line
+     box, which is what keeps the rule below aligned with the topic divider. */
+  position: relative;
+}
+/* Highlight total for the list this button reveals. Colored text on a tint of
+   the same var rather than a solid fill: --buffer-highlight is user-themeable
+   (look.color.buffer.highlight), so any fixed label color could land on an
+   unreadable pairing. The tint tracks whatever they picked and the text keeps
+   its own contrast against it.
+
+   Mixed against --bg, not transparent: the chip sits over the chevron, and a
+   see-through wash let the glyph ghost through the pill where they overlap at
+   larger font sizes. An opaque tint covers it cleanly while staying light
+   enough to keep the colored text legible. */
+.rail-toggle .hl-chip {
+  position: absolute;
+  top: var(--space-1);
+  right: var(--space-1);
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: 0.75em;
+  line-height: 1.5;
+  color: var(--buffer-highlight);
+  background: color-mix(in srgb, var(--buffer-highlight) 24%, var(--bg));
 }
 /* The global `button:hover` repaints border-color to --accent, which would
    recolor the bottom rule on hover. Pin it back to --border — and keep it a

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -60,8 +60,16 @@
     <!-- Screen: buffer -->
     <section v-else-if="screen === 'buffer'" class="screen buffer">
       <header class="bar">
-        <button class="icon back" title="Back" @click="goList">
+        <!-- Leaving this screen is the only way back to the buffer list, so its
+             per-row highlight badges collapse onto this button while it's the
+             only thing standing in for them (#636). Inline rather than a corner
+             badge: .icon is already a flex row and the bar has the width, so
+             "← 3" stays legible where an overlay on a 36px target would not. -->
+        <button class="icon back" :title="backTitle" :aria-label="backTitle" @click="goList">
           <i class="fa-solid fa-arrow-left"></i>
+          <span v-if="hlChip.show.value" class="hl-chip" aria-hidden="true">{{
+            hlChip.label.value
+          }}</span>
         </button>
         <!-- Channels and DMs drop the name here — the compact status bar
              carries net/#chan on mobile, so a header copy is just redundant
@@ -274,6 +282,7 @@ import { useMediaViewer } from '../composables/useMediaViewer.js';
 import { useNetworkEditor } from '../composables/useNetworkEditor.js';
 import { useJumpToMessage } from '../composables/useJumpToMessage.js';
 import { useVisualViewport } from '../composables/useVisualViewport.js';
+import { useHighlightChip } from '../composables/useHighlightChip.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useAuthStore } from '../stores/auth.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
@@ -284,6 +293,15 @@ const auth = useAuthStore();
 
 // Admin panel entry in the mobile top bar.
 const showAdminEntry = computed(() => auth.isAdmin);
+
+const hlChip = useHighlightChip();
+// The chip is aria-hidden in the markup — screen readers get the count here as
+// words instead, so "Back" doesn't turn into "Back 3".
+const backTitle = computed(() =>
+  hlChip.show.value
+    ? `Back — ${hlChip.label.value} highlight${hlChip.count.value === 1 ? '' : 's'}`
+    : 'Back',
+);
 const { connected } = useSocket();
 const { keyboardOpen } = useVisualViewport();
 const {
@@ -588,6 +606,21 @@ useChatBootstrap({ onJump: onJumpToMessage });
 }
 .icon.back {
   margin-left: -4px;
+  gap: var(--space-2);
+}
+/* Highlight total for the buffer list this button returns to. Colored text on a
+   tint of the same var rather than a solid fill: --buffer-highlight is
+   user-themeable (look.color.buffer.highlight), so a fixed label color could
+   land on an unreadable pairing — the tint tracks their choice and the text
+   keeps its contrast against it. Mixed against --bg (not transparent) so the
+   pill is opaque: a see-through wash let the back arrow ghost through where the
+   two overlap at larger font sizes. Matches DesktopChat's rail chip. */
+.icon.back .hl-chip {
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: 0.85em;
+  color: var(--buffer-highlight);
+  background: color-mix(in srgb, var(--buffer-highlight) 24%, var(--bg));
 }
 /* The buffer screen's MessageList + StatusBar + MessageInput chain mirrors
    the desktop rows but in a vertical flex. min-height: 0 on the screen +


### PR DESCRIPTION
Closes #636.

When the buffer list is hidden its per-row highlight badges go with it, leaving no in-app signal that something is waiting elsewhere. This puts the total on the two controls that bring the list back:

- **Desktop** — the collapsed rail's expand button (`DesktopChat.vue`, `.rail-toggle`), as a corner badge.
- **Mobile PWA** — the buffer screen's back button (`MobileChat.vue`, `.icon.back`), inline as `← 3`.

Both hosts exist *only* while the list is hidden, so this is those row badges collapsing into their own toggle rather than a new app-wide indicator — nothing to suppress or coordinate when the list is up.

### Design

- **The chip is the app-icon badge, inlined.** The count is `buffers.totalHighlights` verbatim — the same getter behind the PWA app-icon badge (`useAppBadge`) — so the two can never report different numbers. Highlights-only by design; the active buffer already contributes 0, so it means "highlights waiting somewhere I can't see".
- **Respects `look.buffer_list.unread_display`:** the `off` mode ("row color is the only cue") suppresses the chip; every other mode shows it. This is the one gate the OS app-icon badge intentionally doesn't share — an in-app display preference the OS badge has no business reading.
- **Cap** reuses the existing `unreadLabel` rule (`>999`), moved out of `BufferList.vue` into the new composable so the chip and the rows it stands in for cap by one rule rather than two copies.
- **Color:** colored text on an opaque 24% tint of `--buffer-highlight` (themeable via `look.color.buffer.highlight`) mixed against `--bg` — so it tracks whatever color the user picked and the text stays legible against it, with no fixed color that could clash. Mixed against `--bg` rather than `transparent` so the arrow can't ghost through the pill where they overlap at larger font sizes.

### Logic lives in one composable

`useHighlightChip.ts` owns all three decisions (count, `off` suppression, cap). Both host views just read `hlChip.show/.label`, and `MobileChat` didn't previously import the settings store — encapsulating the `off` check paid for itself.

### iOS

The iOS half of the original issue (amiantos/lurker-ios#48) was dropped: UIKit has no badge API for `UIBarButtonItem`, and routing the count to the "…"/Highlights screen has the wrong denominator (`totalHighlights` also counts unread DMs and system lines, which the Highlights feed can't show). iOS keeps relying on its app-icon badge and per-row buffer-list badges.

### Testing

- New `useHighlightChip.test.ts` — 6 tests covering the verbatim-total invariant, zero-hiding, every `unread_display` mode, and the cap.
- `npm run check` (typecheck ×2, lint, format) ✅
- `client:build` ✅
- Full `npm test` suite ✅ (see #637 for an unrelated, pre-existing `adminNetworks` load flake surfaced during this work — not reachable from this Vue-only diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)