### PR TITLE
Fix the infinite login redirect loop that ends in a 429

### DIFF
--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -29,7 +29,10 @@ const config = useConfigStore();
 useTheme();
 
 onMounted(() => {
-  auth.fetchMe();
+  // The router guard already fetches this on the first navigation; match the
+  // sibling boot fetches below so a mount after it resolved doesn't spend a
+  // second /api/auth/me against the auth-surface rate limiter.
+  if (!auth.checked) auth.fetchMe();
   if (!config.checked) config.fetch().catch(() => {});
   if (!settings.loaded) settings.fetchAll().catch(() => {});
 });

--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -28,12 +28,19 @@ const config = useConfigStore();
 
 useTheme();
 
-onMounted(() => {
-  // The router guard already fetches this on the first navigation; match the
-  // sibling boot fetches below so a mount after it resolved doesn't spend a
-  // second /api/auth/me against the auth-surface rate limiter.
-  if (!auth.checked) auth.fetchMe();
+onMounted(async () => {
+  // /api/config is public, so it can go out immediately.
   if (!config.checked) config.fetch().catch(() => {});
-  if (!settings.loaded) settings.fetchAll().catch(() => {});
+  // The router guard resolves the session on the first navigation and fetchMe
+  // coalesces, so awaiting it here costs no extra request.
+  const user = auth.checked ? auth.user : await auth.fetchMe();
+  // /api/settings/bootstrap is requireAuth. Firing it before the session is
+  // known 401s on every logged-out load of `/` — and because this mount races
+  // the guard's redirect, `window.location.pathname` is often still `/` when
+  // that 401 lands, which trips api.ts's stale-session bounce and costs a
+  // gratuitous full-page reload. Chat (useChatBootstrap) and Settings both
+  // fetch settings themselves, so waiting here delays nothing that matters:
+  // useTheme watches the store and repaints when the values land.
+  if (user && !settings.loaded) settings.fetchAll().catch(() => {});
 });
 </script>

--- a/vue_client/src/api.test.ts
+++ b/vue_client/src/api.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect } from 'vitest';
-import { shouldBounceToLogin } from './api.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { api, clearAuthRecoveryGuard, shouldBounceToLogin } from './api.js';
 
 describe('shouldBounceToLogin', () => {
   it('bounces to sign-in on a 401 from a normal authed call', () => {
@@ -33,5 +33,86 @@ describe('shouldBounceToLogin', () => {
       false,
     );
     expect(shouldBounceToLogin('/api/settings/bootstrap', 401, false, '/login')).toBe(false);
+  });
+});
+
+// The pure predicate above can't express the bug that actually shipped: the
+// one-shot guard was armed correctly and then silently DISARMED by the next
+// successful response, so `alreadyTried` was false again on every reload and the
+// tab ping-ponged between `/` and `/login?next=/` until the auth rate limiter
+// answered 429. That lifecycle only shows up through `api()` itself.
+function respond(status: number) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: '',
+    text: () => Promise.resolve('{}'),
+  });
+}
+
+// One logged-out page load of `/`, in App.vue's boot order: the public config
+// endpoint answers 200 while the authed settings bootstrap answers 401.
+async function bootLoggedOutAtRoot() {
+  await api('/api/config').catch(() => {});
+  await api('/api/settings/bootstrap').catch(() => {});
+}
+
+describe('stale-session bounce guard lifecycle', () => {
+  let stored: Map<string, string>;
+  let assigned: string[];
+  let routes: Map<string, number>;
+
+  beforeEach(() => {
+    stored = new Map();
+    assigned = [];
+    routes = new Map([
+      ['/api/config', 200],
+      ['/api/settings/bootstrap', 401],
+      ['/api/networks', 401],
+    ]);
+    vi.stubGlobal('sessionStorage', {
+      getItem: (k: string) => stored.get(k) ?? null,
+      setItem: (k: string, v: string) => void stored.set(k, String(v)),
+      removeItem: (k: string) => void stored.delete(k),
+    });
+    vi.stubGlobal('window', {
+      location: { pathname: '/', assign: (url: string) => void assigned.push(url) },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) => respond(routes.get(url) ?? 200)),
+    );
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('bounces once, then stays put across the reload it triggered', async () => {
+    await bootLoggedOutAtRoot();
+    expect(assigned).toEqual(['/']);
+
+    // The reload that bounce caused. Nothing about being logged out has changed,
+    // so a second bounce here is the loop the user hit.
+    await bootLoggedOutAtRoot();
+    expect(assigned).toEqual(['/']);
+  });
+
+  it('does not re-arm on an unauthenticated 200 (the public /api/config hole)', async () => {
+    await api('/api/networks').catch(() => {});
+    expect(assigned).toEqual(['/']);
+
+    await api('/api/config');
+    await api('/api/networks').catch(() => {});
+    expect(assigned).toEqual(['/']);
+  });
+
+  it('re-arms once a live session is proven, so a later loss still recovers', async () => {
+    await bootLoggedOutAtRoot();
+    expect(assigned).toEqual(['/']);
+
+    // What the auth store does when /api/auth/me comes back with a user.
+    clearAuthRecoveryGuard();
+
+    await api('/api/networks').catch(() => {});
+    expect(assigned).toEqual(['/', '/']);
   });
 });

--- a/vue_client/src/api.ts
+++ b/vue_client/src/api.ts
@@ -60,9 +60,15 @@ function bounceToLoginOnAuthFailure(url: string, status: number): void {
   window.location.assign('/');
 }
 
-function clearAuthRecoveryGuard(): void {
-  // A request succeeded → the session works; clear the marker so a later session
-  // loss can recover again.
+// Clear the one-shot marker so a LATER session loss can recover again. Only
+// `/api/auth/me` returning a user may call this — see the store. Clearing it on
+// any 2xx (which this used to do) silently disarmed the guard and turned the
+// bounce into an infinite full-page reload loop: on a logged-out load of `/`,
+// App.vue fires /api/config (public, 200 — cleared the flag) alongside
+// /api/settings/bootstrap (requireAuth, 401 — set it and bounced). config's 200
+// almost always won the race, so every reload re-armed the bounce and the tab
+// ping-ponged until the auth rate limiter answered 429.
+export function clearAuthRecoveryGuard(): void {
   try {
     sessionStorage.removeItem(AUTH_RECOVERY_FLAG);
   } catch {
@@ -103,7 +109,6 @@ export async function api<T = any>(
     err.data = data;
     throw err;
   }
-  clearAuthRecoveryGuard();
   return data as T;
 }
 
@@ -139,7 +144,6 @@ export function apiMultipart<T = any>(
         }
       }
       if (xhr.status >= 200 && xhr.status < 300) {
-        clearAuthRecoveryGuard();
         resolve(data as T);
       } else {
         bounceToLoginOnAuthFailure(url, xhr.status);

--- a/vue_client/src/api.ts
+++ b/vue_client/src/api.ts
@@ -60,10 +60,12 @@ function bounceToLoginOnAuthFailure(url: string, status: number): void {
   window.location.assign('/');
 }
 
-// Clear the one-shot marker so a LATER session loss can recover again. Only
-// `/api/auth/me` returning a user may call this — see the store. Clearing it on
-// any 2xx (which this used to do) silently disarmed the guard and turned the
-// bounce into an infinite full-page reload loop: on a logged-out load of `/`,
+// Clear the one-shot marker so a LATER session loss can recover again. The bar
+// is proof that a session exists, and only the auth store can supply it: either
+// `/api/auth/me` came back with a user (fetchMe) or one was just established by
+// a sign-in / setup / invite (adoptSession). Nothing else may call this.
+// Clearing it on any 2xx (which this used to do) silently disarmed the guard and
+// turned the bounce into an infinite full-page reload loop: on a logged-out `/`,
 // App.vue fires /api/config (public, 200 — cleared the flag) alongside
 // /api/settings/bootstrap (requireAuth, 401 — set it and bounced). config's 200
 // almost always won the race, so every reload re-armed the bounce and the tab

--- a/vue_client/src/stores/auth.test.ts
+++ b/vue_client/src/stores/auth.test.ts
@@ -10,16 +10,19 @@ import { setActivePinia, createPinia } from 'pinia';
 const h = vi.hoisted(() => ({
   api: vi.fn<(url: string, opts?: unknown) => Promise<any>>(),
   clearAuthRecoveryGuard: vi.fn<() => void>(),
+  resetSession: vi.fn<() => void>(),
+  startRegistration: vi.fn<() => Promise<unknown>>(),
+  startAuthentication: vi.fn<() => Promise<unknown>>(),
 }));
 
 vi.mock('../api.js', () => ({
   api: h.api,
   clearAuthRecoveryGuard: h.clearAuthRecoveryGuard,
 }));
-vi.mock('../composables/useSessionReset.js', () => ({ resetSession: vi.fn<() => void>() }));
+vi.mock('../composables/useSessionReset.js', () => ({ resetSession: h.resetSession }));
 vi.mock('@simplewebauthn/browser', () => ({
-  startRegistration: vi.fn<() => Promise<unknown>>(),
-  startAuthentication: vi.fn<() => Promise<unknown>>(),
+  startRegistration: h.startRegistration,
+  startAuthentication: h.startAuthentication,
 }));
 
 const { useAuthStore } = await import('./auth.js');
@@ -31,6 +34,9 @@ describe('auth store — stale-session guard', () => {
     setActivePinia(createPinia());
     h.api.mockReset();
     h.clearAuthRecoveryGuard.mockReset();
+    h.resetSession.mockReset();
+    h.startRegistration.mockReset().mockResolvedValue({ id: 'cred' });
+    h.startAuthentication.mockReset().mockResolvedValue({ id: 'cred' });
   });
 
   it('re-arms the bounce only when /api/auth/me returns a user', async () => {
@@ -112,5 +118,77 @@ describe('auth store — stale-session guard', () => {
     await auth.fetchMe();
     await auth.fetchMe();
     expect(h.api).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Every path that establishes a session routes through adoptSession(), so each
+// one has to re-arm the bounce. A path that forgot would leave a user who
+// bounced once unable to recover from any LATER session loss in that tab —
+// silent, and invisible until the next stale session.
+describe('auth store — every session-establishing path re-arms', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    h.api.mockReset().mockResolvedValue({ user: USER, options: {} });
+    h.clearAuthRecoveryGuard.mockReset();
+    h.resetSession.mockReset();
+    h.startRegistration.mockReset().mockResolvedValue({ id: 'cred' });
+    h.startAuthentication.mockReset().mockResolvedValue({ id: 'cred' });
+  });
+
+  it.each([
+    ['loginWithPasskey', (a: any) => a.loginWithPasskey()],
+    ['loginWithPassword', (a: any) => a.loginWithPassword({ username: 'brad', password: 'pw' })],
+    ['setupFirstPasskey', (a: any) => a.setupFirstPasskey({ username: 'brad' })],
+    [
+      'setupFirstPassword',
+      (a: any) => a.setupFirstPassword({ username: 'brad', password: 'hunter22' }),
+    ],
+    ['acceptInvite', (a: any) => a.acceptInvite({ token: 't', username: 'brad' })],
+    [
+      'acceptInviteWithPassword',
+      (a: any) => a.acceptInviteWithPassword({ token: 't', username: 'brad', password: 'pw' }),
+    ],
+  ])('%s adopts the session and re-arms the bounce', async (_name, run) => {
+    const auth = useAuthStore();
+    await run(auth);
+    expect(auth.user).toEqual(USER);
+    expect(auth.checked).toBe(true);
+    expect(h.clearAuthRecoveryGuard).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['setupFirstPasskey', (a: any) => a.setupFirstPasskey({ username: 'brad' })],
+    [
+      'setupFirstPassword',
+      (a: any) => a.setupFirstPassword({ username: 'brad', password: 'hunter22' }),
+    ],
+  ])('%s clears the first-run prompt', async (_name, run) => {
+    const auth = useAuthStore();
+    await run(auth);
+    expect(auth.setupStatus).toEqual({ needsSetup: false });
+  });
+
+  it.each([
+    ['acceptInvite', (a: any) => a.acceptInvite({ token: 't', username: 'brad' })],
+    [
+      'acceptInviteWithPassword',
+      (a: any) => a.acceptInviteWithPassword({ token: 't', username: 'brad', password: 'pw' }),
+    ],
+  ])('%s wipes the prior user BEFORE adopting the new session', async (_name, run) => {
+    // Ordering is load-bearing: resetSession() must see a null user so the WS
+    // onclose handler skips its reconnect arm. adoptSession() moved the
+    // assignment, so pin the order down rather than trust the read.
+    const auth = useAuthStore();
+    auth.user = { id: 9, username: 'previous', role: 'user' };
+    let userAtReset: unknown = 'not called';
+    h.resetSession.mockImplementation(() => {
+      userAtReset = auth.user;
+    });
+
+    await run(auth);
+
+    expect(h.resetSession).toHaveBeenCalledTimes(1);
+    expect(userAtReset).toBeNull();
+    expect(auth.user).toEqual(USER);
   });
 });

--- a/vue_client/src/stores/auth.test.ts
+++ b/vue_client/src/stores/auth.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+// The store's half of the login-loop fix: it owns the one and only signal that
+// re-arms api.ts's stale-session bounce — a session that demonstrably exists.
+// Mock the api module so this exercises that decision without a network.
+const h = vi.hoisted(() => ({
+  api: vi.fn<(url: string, opts?: unknown) => Promise<any>>(),
+  clearAuthRecoveryGuard: vi.fn<() => void>(),
+}));
+
+vi.mock('../api.js', () => ({
+  api: h.api,
+  clearAuthRecoveryGuard: h.clearAuthRecoveryGuard,
+}));
+vi.mock('../composables/useSessionReset.js', () => ({ resetSession: vi.fn<() => void>() }));
+vi.mock('@simplewebauthn/browser', () => ({
+  startRegistration: vi.fn<() => Promise<unknown>>(),
+  startAuthentication: vi.fn<() => Promise<unknown>>(),
+}));
+
+const { useAuthStore } = await import('./auth.js');
+
+const USER = { id: 1, username: 'brad', role: 'user' as const };
+
+describe('auth store — stale-session guard', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    h.api.mockReset();
+    h.clearAuthRecoveryGuard.mockReset();
+  });
+
+  it('re-arms the bounce only when /api/auth/me returns a user', async () => {
+    h.api.mockResolvedValue({ user: USER });
+    await useAuthStore().fetchMe();
+    expect(h.clearAuthRecoveryGuard).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the bounce disarmed when the session is dead', async () => {
+    // The loop case: a logged-out load must not re-arm, or the next 401 bounces
+    // again and the tab reloads forever.
+    h.api.mockRejectedValue(Object.assign(new Error('unauthorized'), { status: 401 }));
+    const auth = useAuthStore();
+    await auth.fetchMe();
+    expect(auth.user).toBeNull();
+    expect(auth.checked).toBe(true);
+    expect(h.clearAuthRecoveryGuard).not.toHaveBeenCalled();
+  });
+
+  it('re-arms on a fresh sign-in, so a later session loss still recovers', async () => {
+    h.api.mockResolvedValue({ user: USER });
+    await useAuthStore().loginWithPassword({ username: 'brad', password: 'hunter22' });
+    expect(h.clearAuthRecoveryGuard).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent fetchMe callers into one request', async () => {
+    // The router guard and App.vue's boot both fire on a fresh load; two
+    // /api/auth/me calls double this tab's spend against the auth rate limiter.
+    h.api.mockResolvedValue({ user: USER });
+    const auth = useAuthStore();
+    const [a, b] = await Promise.all([auth.fetchMe(), auth.fetchMe()]);
+    expect(h.api).toHaveBeenCalledTimes(1);
+    expect(a).toEqual(USER);
+    expect(b).toEqual(USER);
+  });
+
+  it('does not latch the in-flight promise after it settles', async () => {
+    h.api.mockResolvedValue({ user: USER });
+    const auth = useAuthStore();
+    await auth.fetchMe();
+    await auth.fetchMe();
+    expect(h.api).toHaveBeenCalledTimes(2);
+  });
+});

--- a/vue_client/src/stores/auth.test.ts
+++ b/vue_client/src/stores/auth.test.ts
@@ -67,6 +67,45 @@ describe('auth store — stale-session guard', () => {
     expect(b).toEqual(USER);
   });
 
+  it('latches "logged out" only on a 401', async () => {
+    h.api.mockRejectedValue(Object.assign(new Error('unauthorized'), { status: 401 }));
+    const auth = useAuthStore();
+    await auth.fetchMe();
+    expect(auth.checked).toBe(true);
+  });
+
+  it.each([
+    ['a network blip', undefined],
+    ['a 500', 500],
+    ['a 429 from the auth limiter', 429],
+  ])(
+    'leaves the session unresolved on %s so a later navigation retries',
+    async (_label, status) => {
+      // This page load now gets exactly one /api/auth/me (guard + App.vue are
+      // coalesced), so latching here would strand a signed-in user at
+      // /login?next=/ for the whole document off a single blip.
+      h.api.mockRejectedValue(Object.assign(new Error('failed'), status ? { status } : {}));
+      const auth = useAuthStore();
+      await auth.fetchMe();
+      expect(auth.checked).toBe(false);
+
+      h.api.mockResolvedValue({ user: USER });
+      await auth.fetchMe();
+      expect(auth.user).toEqual(USER);
+      expect(auth.checked).toBe(true);
+    },
+  );
+
+  it('keeps a signed-in user signed in across a transient failure', async () => {
+    h.api.mockResolvedValue({ user: USER });
+    const auth = useAuthStore();
+    await auth.fetchMe();
+
+    h.api.mockRejectedValue(Object.assign(new Error('network error'), { status: 503 }));
+    await auth.fetchMe();
+    expect(auth.user).toEqual(USER);
+  });
+
   it('does not latch the in-flight promise after it settles', async () => {
     h.api.mockResolvedValue({ user: USER });
     const auth = useAuthStore();

--- a/vue_client/src/stores/auth.ts
+++ b/vue_client/src/stores/auth.ts
@@ -71,14 +71,23 @@ export const useAuthStore = defineStore('auth', {
         try {
           const { user } = await api('/api/auth/me');
           this.user = user;
+          this.checked = true;
           // A live session is the ONLY thing that re-arms api.ts's one-shot
           // stale-session bounce. Anything weaker (any 2xx) disarms it on a
           // logged-out page and loops the tab — see clearAuthRecoveryGuard.
           if (user) clearAuthRecoveryGuard();
-        } catch (_err) {
-          this.user = null;
-        } finally {
-          this.checked = true;
+        } catch (err: any) {
+          // Only a 401 proves "not signed in". A network blip, a 5xx, or a 429
+          // from the auth-surface limiter says nothing about the session — and
+          // since the guard and App.vue now share one coalesced call, a page
+          // load gets exactly one attempt. Latching `checked` on those would
+          // strand a signed-in user at /login?next=/ for the whole document off
+          // a single blip. Leave it false so a later navigation retries, the
+          // same self-heal the config store uses.
+          if (err?.status === 401) {
+            this.user = null;
+            this.checked = true;
+          }
         }
         return this.user;
       })();

--- a/vue_client/src/stores/auth.ts
+++ b/vue_client/src/stores/auth.ts
@@ -29,11 +29,16 @@ export interface Passkey {
   createdAt: string;
 }
 
+// Shared in-flight fetch so concurrent callers — the router guard and App.vue's
+// boot — coalesce onto one GET /api/auth/me instead of each spending a request
+// against the auth-surface rate limiter. Module-scoped (not store state) so it
+// stays non-reactive, matching the config store.
+let inflight: Promise<AuthUser | null> | null = null;
+
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     user: null as AuthUser | null,
     checked: false,
-    inflight: null as Promise<AuthUser | null> | null,
     error: null as string | null,
     setupStatus: null as SetupStatus | null, // { needsSetup, mode?, username? }
   }),
@@ -63,11 +68,8 @@ export const useAuthStore = defineStore('auth', {
       if (this.user) this.user.is_paused = paused;
     },
     async fetchMe() {
-      // Coalesce concurrent callers. The router guard and App.vue's boot both
-      // call this on every fresh load, and a duplicate /api/auth/me doubles this
-      // tab's spend against the auth-surface rate limiter for nothing.
-      if (this.inflight) return this.inflight;
-      this.inflight = (async () => {
+      if (inflight) return inflight; // a fetch is in flight — share its result
+      inflight = (async () => {
         try {
           const { user } = await api('/api/auth/me');
           this.user = user;
@@ -92,9 +94,9 @@ export const useAuthStore = defineStore('auth', {
         return this.user;
       })();
       try {
-        return await this.inflight;
+        return await inflight;
       } finally {
-        this.inflight = null;
+        inflight = null;
       }
     },
     // On a hosted cell the account's real identity — its email — lives on the

--- a/vue_client/src/stores/auth.ts
+++ b/vue_client/src/stores/auth.ts
@@ -3,7 +3,7 @@
 
 import { defineStore } from 'pinia';
 import { startRegistration, startAuthentication } from '@simplewebauthn/browser';
-import { api } from '../api.js';
+import { api, clearAuthRecoveryGuard } from '../api.js';
 import { resetSession } from '../composables/useSessionReset.js';
 import { useConfigStore } from './config.js';
 
@@ -33,6 +33,7 @@ export const useAuthStore = defineStore('auth', {
   state: () => ({
     user: null as AuthUser | null,
     checked: false,
+    inflight: null as Promise<AuthUser | null> | null,
     error: null as string | null,
     setupStatus: null as SetupStatus | null, // { needsSetup, mode?, username? }
   }),
@@ -46,21 +47,46 @@ export const useAuthStore = defineStore('auth', {
     isAdmin: (s): boolean => s.user?.role === 'admin',
   },
   actions: {
+    // Adopt a freshly-established session. Every sign-in / setup / invite path
+    // lands here rather than assigning `user` itself, so none of them can forget
+    // to re-arm api.ts's one-shot stale-session bounce: without the clear, a tab
+    // that bounced once and then signed in would never recover from a LATER
+    // session loss.
+    adoptSession(user: AuthUser) {
+      this.user = user;
+      this.checked = true;
+      clearAuthRecoveryGuard();
+    },
     // Live flip from the server's 'account-state' WS event, so an open tab
     // enters/leaves read-only without a reload.
     setPaused(paused: boolean) {
       if (this.user) this.user.is_paused = paused;
     },
     async fetchMe() {
+      // Coalesce concurrent callers. The router guard and App.vue's boot both
+      // call this on every fresh load, and a duplicate /api/auth/me doubles this
+      // tab's spend against the auth-surface rate limiter for nothing.
+      if (this.inflight) return this.inflight;
+      this.inflight = (async () => {
+        try {
+          const { user } = await api('/api/auth/me');
+          this.user = user;
+          // A live session is the ONLY thing that re-arms api.ts's one-shot
+          // stale-session bounce. Anything weaker (any 2xx) disarms it on a
+          // logged-out page and loops the tab — see clearAuthRecoveryGuard.
+          if (user) clearAuthRecoveryGuard();
+        } catch (_err) {
+          this.user = null;
+        } finally {
+          this.checked = true;
+        }
+        return this.user;
+      })();
       try {
-        const { user } = await api('/api/auth/me');
-        this.user = user;
-      } catch (_err) {
-        this.user = null;
+        return await this.inflight;
       } finally {
-        this.checked = true;
+        this.inflight = null;
       }
-      return this.user;
     },
     // On a hosted cell the account's real identity — its email — lives on the
     // control plane; the cell only knows a synthetic `acct-N` username. This
@@ -99,8 +125,7 @@ export const useAuthStore = defineStore('auth', {
           method: 'POST',
           body: { response },
         });
-        this.user = user;
-        this.checked = true;
+        this.adoptSession(user);
         return user as AuthUser;
       } catch (err: any) {
         this.error = friendlyError(err, 'login failed');
@@ -119,8 +144,7 @@ export const useAuthStore = defineStore('auth', {
           method: 'POST',
           body: { response },
         });
-        this.user = user;
-        this.checked = true;
+        this.adoptSession(user);
         this.setupStatus = { needsSetup: false };
         return user as AuthUser;
       } catch (err: any) {
@@ -138,8 +162,7 @@ export const useAuthStore = defineStore('auth', {
           method: 'POST',
           body: { username, password },
         });
-        this.user = user;
-        this.checked = true;
+        this.adoptSession(user);
         this.setupStatus = { needsSetup: false };
         return user as AuthUser;
       } catch (err: any) {
@@ -154,8 +177,7 @@ export const useAuthStore = defineStore('auth', {
           method: 'POST',
           body: { username, password },
         });
-        this.user = user;
-        this.checked = true;
+        this.adoptSession(user);
         return user as AuthUser;
       } catch (err: any) {
         this.error = friendlyError(err, 'login failed');
@@ -189,8 +211,7 @@ export const useAuthStore = defineStore('auth', {
         // onclose reconnect arm sees no user (matches the logout pattern).
         this.user = null;
         resetSession();
-        this.user = user;
-        this.checked = true;
+        this.adoptSession(user);
         return user as AuthUser;
       } catch (err: any) {
         this.error = friendlyError(err, 'invite redemption failed');
@@ -210,8 +231,7 @@ export const useAuthStore = defineStore('auth', {
         });
         this.user = null;
         resetSession();
-        this.user = user;
-        this.checked = true;
+        this.adoptSession(user);
         return user as AuthUser;
       } catch (err: any) {
         this.error = friendlyError(err, 'invite redemption failed');


### PR DESCRIPTION
Some users hit an infinite redirect loop on the sign-in screen, and enough reloads to trip the auth rate limiter into `Too many requests`. It cleared on its own for some people and not others. The reported workaround — going straight to `/login?next=/` — turned out to be the key clue.

## The bug

`api.ts` bounces a stale session back to `/` on a 401 from an authed call, guarded by a one-shot `sessionStorage` flag so it can't loop. The guard was cleared by **any** successful response, which on a logged-out page meant it was cleared every single time.

On a logged-out load of `/`, `App.vue` fired three fetches in one tick:

| call | logged out | effect |
|---|---|---|
| `/api/auth/me` | 401 | ignored — `/api/auth/` is skipped by design |
| `/api/config` | **200** (unauthenticated route) | **cleared the guard** |
| `/api/settings/bootstrap` | **401** (`requireAuth`) | armed the guard, `location.assign('/')` |

`/api/config` is the cheaper endpoint and almost always won the race, so it disarmed the guard just before the bootstrap 401 armed it and reloaded the page. Every reload re-armed the bounce. The tab ping-ponged between `/` and `/login?next=/` until `authRequestThrottle` (60/min/IP) answered 429.

**Why it was intermittent:** it's a race, twice over. If the bootstrap 401 lands first, the flag survives the reload. If the router guard's redirect lands first, `window.location.pathname` is `/login`, and `isPublicPath()` suppresses the bounce. **Why `/login?next=/` dodged it:** you start on a public path, so the bounce never arms. The `next` value was irrelevant — any URL starting at `/login` broke the cycle.

Regression window: `a4c00fa` added the bounce; `8c78a31` added the public-path check, which fixed the `/invite` case but not `/`, which is exactly where a logged-out visitor lands.

## The fix

**Only a proven-live session re-arms the bounce.** `clearAuthRecoveryGuard()` is out of `api()`'s generic success path and is now called from `fetchMe()` when `/api/auth/me` returns a user, plus a shared `adoptSession()` that all six sign-in / setup / invite paths route through — so none of them can forget, and a tab that bounced once and then signed in can still recover from a *later* session loss.

**Authed boot fetches wait for a known session.** `App.vue` no longer fires `settings.fetchAll()` before the session resolves. Safe to defer: `useChatBootstrap` and `Settings.vue` both fetch settings themselves, and `useTheme` watches the store reactively.

**`fetchMe()` coalesces, and only a 401 means logged out.** The router guard and `App.vue` both fired one on every load, doubling the tab's spend against the same limiter that produced the 429. With them coalesced, a page load gets exactly one attempt — so the old blanket `catch` would have stranded a signed-in user at `/login?next=/` off a single blip. A 5xx, a network error, or a 429 now leaves `checked` false so a later navigation retries, mirroring the config store's self-heal.

## Testing

`npm run check` clean, `npm test` 213 files / 2823 tests passing.

New lifecycle suite in `api.test.ts` drives real `api()` calls against a stubbed `fetch`/`sessionStorage`/`window`, replaying the exact boot sequence and asserting one bounce then none across the reload it triggered. Mutation-checked: restoring the old `clearAuthRecoveryGuard()` call fails 2 of the 3 new tests. New `stores/auth.test.ts` covers the store half — re-arm rules, coalescing, and the 401-vs-transient classification.

**Not covered by a test:** the `App.vue` boot-ordering change is verified by inspection. A component test would need router + pinia + four child stubs to assert three lines, and the race it protects against (mount vs. the guard's redirect) is the part an isolated mount wouldn't reproduce faithfully. The store and `api()` invariants underneath it are both covered. Worth one manual check on a logged-out load to confirm zero reloads.

## Out of scope

The hosted CP proxy 302s `/login` → `/` for signed-in users (`proxy.ts:175`) on pathname alone, ignoring `?next=`. Not part of this loop, but if a hosted user lands with a valid `cp_session` against a cell that 401s, that's a separate server-side cycle worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)