### PR TITLE
Send a terminal backlog-complete frame at the end of the snapshot burst

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -208,8 +208,37 @@ frames**, synchronously, in this order (`wsHub.ts:1828`):
 6. One `backlog` frame per open buffer on each connected network.
 7. Per **offline** network: a real backlog for its `:server:` log, shells for
    its channels/DMs.
+8. `{kind:'backlog-complete'}` — terminal marker, nothing else in it.
 
-There is no "end of burst" marker; after frame 1 you can render progressively.
+Render progressively from frame 1; don't wait for the end.
+
+**What frame 8 is for.** Until it arrives, "I have no row for this buffer _yet_"
+and "there is no such buffer" are the same observation, and no amount of waiting
+separates them. After it arrives, **absence is proof**: a buffer key with no
+`backlog` frame does not exist on the server — for channels, DMs and `:server:`
+logs alike, on connected and disconnected networks alike. That matters if you
+navigate by **key** rather than by tapping a row that already exists (restoring
+the last-read buffer at launch, opening one from a notification tap): without it
+those screens sit on a spinner forever, because nothing ever says the row isn't
+coming (#635).
+
+Two things that look like they'd answer the same question and don't:
+
+- **`snapshot`'s per-network `channels` is not authoritative for buffer
+  existence.** It's empty outright for any network with no live connection
+  (paused account, manually disconnected, never autoconnected) even though
+  those networks still own persisted buffers, and even on a live connection
+  it's read at the `'connected'` instant — before auto-rejoin JOINs land. Judge
+  membership from it and you'll decide a user left channels they're still in.
+- **Don't probe with `open-buffer`.** For a `#channel` with no row the server
+  reads that as "join it" (§9.1), so a probe silently re-JOINs a channel the
+  user deliberately left from another client.
+
+An older server never sends frame 8 (it's additive, and `protocolVersion` does
+not move for it) — if you don't see one, keep whatever you do today rather than
+concluding anything. A truncated burst withholds it too: the server only sends
+it once the whole burst went out, so a snapshot that failed part-way through
+never claims a buffer is missing.
 
 **Shells vs. hydrated backlogs.** On a fresh connect (`since=0`) channel/DM
 buffers arrive as _shells_: `{kind:'backlog', …, events:[], hasMoreOlder:true}` —
@@ -454,6 +483,7 @@ a v1 client.
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | `snapshot`                                                                                                                                                               | `protocolVersion, networks[], globalIgnores[], cursor?`                                                                                                             | Connect burst / gap-fill                           |
 | `draft-snapshot` / `bookmark-ids-snapshot` / `contacts-snapshot`                                                                                                         | `drafts` / `ids[]` / `contacts[]`                                                                                                                                   | Connect burst                                      |
+| `backlog-complete`                                                                                                                                                       | —                                                                                                                                                                   | Last frame of the burst; absence is proof (§4.3)   |
 | `backlog`                                                                                                                                                                | `networkId, target, events[], reset?, hasMoreOlder, joined, lastReadId, unread, highlights, highlightsCapped, clearedBeforeId, clearedAt, speakers?, inputHistory?` | Burst, `open-buffer` reply, resume gap             |
 | `irc`                                                                                                                                                                    | A decorated `MessageEvent` (§5.3) with `kind` clobbered to `'irc'`                                                                                                  | Every live IRC-side event                          |
 | `history`                                                                                                                                                                | `networkId, target, mode, token, events[], speakers, hasMoreOlder, hasMoreNewer, hasMore, before/afterId/anchorId/anchorMissing` (per mode)                         | Reply to `history`                                 |
@@ -597,6 +627,11 @@ these signals:
 - NOTICEs never create or reopen a DM — a notice to a closed/absent DM arrives
   on `:server:` with `mirrored:true`. Already handled server-side; just don't
   special-case it.
+- **Navigating to a buffer by key** (launch restore, notification tap) is the
+  one case where you need to ask "does this exist?" rather than mirror a
+  signal. Wait for `backlog-complete`; if the key still has no `backlog` frame
+  after it, the buffer is gone and you can say so. Don't guess from `snapshot`
+  and don't probe with `open-buffer` — see §4.3 for why both are traps.
 
 ### 9.2 Identity & case
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -215,12 +215,21 @@ Render progressively from frame 1; don't wait for the end.
 **What frame 8 is for.** Until it arrives, "I have no row for this buffer _yet_"
 and "there is no such buffer" are the same observation, and no amount of waiting
 separates them. After it arrives, **absence is proof**: a buffer key with no
-`backlog` frame does not exist on the server — for channels, DMs and `:server:`
-logs alike, on connected and disconnected networks alike. That matters if you
+`backlog` frame is **not open** — for channels, DMs and `:server:` logs alike,
+on connected and disconnected networks alike. That matters if you
 navigate by **key** rather than by tapping a row that already exists (restoring
 the last-read buffer at launch, opening one from a notification tap): without it
 those screens sit on a spinner forever, because nothing ever says the row isn't
 coming (#635).
+
+**"Not open" is not "never existed", and the burst can't tell you which.** A
+buffer the user closed from another client ships no frame either (it's dropped
+from the enumeration — `wsHub.ts:609`), yet it keeps its full persisted history
+and one `open-buffer` reopens it with that history intact. Both cases mean the
+same thing for what you _render_ — it isn't in the buffer list — which is why
+§9.1 models closed as absent. They differ for what you **destroy**: don't purge
+local history, drafts, or a saved read position on the strength of a missing
+frame, because the server hasn't forgotten any of it.
 
 Two things that look like they'd answer the same question and don't:
 
@@ -630,8 +639,10 @@ these signals:
 - **Navigating to a buffer by key** (launch restore, notification tap) is the
   one case where you need to ask "does this exist?" rather than mirror a
   signal. Wait for `backlog-complete`; if the key still has no `backlog` frame
-  after it, the buffer is gone and you can say so. Don't guess from `snapshot`
-  and don't probe with `open-buffer` — see §4.3 for why both are traps.
+  after it, that buffer isn't open — say so instead of spinning. It may be
+  closed rather than gone, so render it as absent but don't destroy anything
+  local over it. Don't guess from `snapshot` and don't probe with `open-buffer`
+  — see §4.3 for why both are traps.
 
 ### 9.2 Identity & case
 

--- a/server/services/wsHub.burst.test.ts
+++ b/server/services/wsHub.burst.test.ts
@@ -92,11 +92,14 @@ function collectBurst(send?: Frame): Promise<Frame[]> {
     let resent = false;
     // A missing terminal frame is the failure this suite is about, so time out
     // rather than hang — and report what DID arrive, since "which frames came
-    // before it gave up" is the whole diagnostic.
+    // before it gave up" is the whole diagnostic. Deliberately under vitest's
+    // 5000ms default testTimeout (vitest.config.ts sets none): at parity the
+    // two timers race, and vitest winning replaces this frame list with a bare
+    // "Test timed out" exactly when the list is worth having.
     const timer = setTimeout(() => {
       ws.close();
       reject(new Error(`no backlog-complete; got: ${frames.map((f) => f.kind).join(', ')}`));
-    }, 5000);
+    }, 3000);
     ws.on('message', (raw) => {
       const frame = JSON.parse(raw.toString()) as Frame;
       frames.push(frame);
@@ -133,12 +136,44 @@ describe('connect burst terminator (#635)', () => {
     expect(targets).toEqual(expect.arrayContaining(['#lurker', 'bob', `:server:${networkId}`]));
 
     // The claim a by-key client leans on: a buffer with no frame by the time
-    // the terminator arrives genuinely does not exist. Nothing else in the
-    // burst supports it — note that the snapshot reports this network's
-    // channels as empty even though #lurker is right there in the frames.
+    // the terminator arrives is not open (see the closed-buffer case below for
+    // why that's the honest phrasing). Nothing else in the burst supports it —
+    // note that the snapshot reports this network's channels as empty even
+    // though #lurker is right there in the frames.
     expect(targets).not.toContain('#never-joined');
     const snapshot = frames[0] as { networks: Array<{ channels: unknown[] }> };
     expect(snapshot.networks[0].channels).toEqual([]);
+  });
+
+  it('withholds a frame for a CLOSED buffer, whose history the server still holds', async () => {
+    // The sharp edge of "absence is proof": a closed buffer is dropped from the
+    // enumeration, so it looks identical to one that never existed — while its
+    // backlog sits intact server-side, one open-buffer away. A client that
+    // purged local history on a missing frame would be destroying a copy of
+    // something the server never forgot, so the doc says render-absent but
+    // don't destroy, and this pins the behavior that claim rests on.
+    const buffers = await import('../db/buffers.js');
+    const { insertMessage, hasMessageForTarget } = await import('../db/messages.js');
+    buffers.ensureExists(userId, networkId, '#closed');
+    insertMessage({
+      networkId,
+      target: '#closed',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'bob',
+      text: 'still here',
+      self: false,
+    });
+    buffers.close(userId, networkId, '#closed');
+
+    const frames = await collectBurst();
+    expect(frames.filter((f) => f.kind === 'backlog').map((f) => f.target)).not.toContain(
+      '#closed',
+    );
+
+    // Same instant, same server: the history the burst declined to mention.
+    expect(buffers.isClosed(userId, networkId, '#closed')).toBe(true);
+    expect(hasMessageForTarget(networkId, '#closed')).toBe(true);
   });
 
   it('terminates an in-band snapshot resync too, not just the connect burst', async () => {

--- a/server/services/wsHub.burst.test.ts
+++ b/server/services/wsHub.burst.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The connect burst's SHAPE, over a real socket (#635). wsHub.test.ts covers the
+// individual frame builders as functions; none of them can prove the thing that
+// actually matters here — that `backlog-complete` arrives after every buffer
+// frame the burst is going to send. That is an ordering property of the whole
+// synchronous burst, so it needs a real client reading real frames in order: a
+// function-level test would still pass if the terminal frame were sent first,
+// which is precisely the bug it exists to rule out.
+//
+// Its own DB (and its own user) rather than a describe block in
+// wsHub.upgrade.test.ts, because seeding networks and buffers to make the burst
+// interesting would change what those upgrade tests see on connect.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import { WebSocket } from 'ws';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const testDb = setupTestDb('wshub-burst');
+
+let server: http.Server;
+let userId: number;
+let networkId: number;
+let createSession: typeof import('../db/sessions.js').createSession;
+let url: string;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { createNetwork } = await import('../db/networks.js');
+  const { insertMessage } = await import('../db/messages.js');
+  const buffers = await import('../db/buffers.js');
+  ({ createSession } = await import('../db/sessions.js'));
+  const { attachWsHub } = await import('./wsHub.js');
+
+  userId = createUser('burstuser').id;
+  const net = createNetwork(userId, {
+    name: 'libera',
+    host: 'h',
+    port: 6697,
+    tls: true,
+    nick: 'burstuser',
+  });
+  networkId = net!.id;
+
+  // No live IRC connection in tests, so this network takes the offline path —
+  // the same one a paused or disconnected account hits, and the one whose
+  // buffers `snapshot.networks[].channels` reports as empty regardless.
+  const seed = (target: string, text: string): void => {
+    if (!target.startsWith(':')) buffers.ensureExists(userId, networkId, target);
+    insertMessage({
+      networkId,
+      target,
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'bob',
+      text,
+      self: false,
+    });
+  };
+  seed('#lurker', 'hello');
+  seed('bob', 'a dm');
+  seed(`:server:${networkId}`, 'connection notice');
+
+  server = http.createServer();
+  attachWsHub(server, 'burst-test-secret');
+  server.listen(0);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test server did not bind synchronously to a TCP port');
+  }
+  server.unref();
+  url = `ws://127.0.0.1:${address.port}/ws`;
+});
+
+afterAll(() => {
+  server.close();
+  testDb.cleanup();
+});
+
+type Frame = Record<string, unknown>;
+
+// Opens a socket and collects frames until `backlog-complete` arrives, then
+// hands back everything including it. `send` runs once the burst is in, so a
+// caller can drive a second burst (the in-band resync) on the same socket.
+function collectBurst(send?: Frame): Promise<Frame[]> {
+  return new Promise((resolve, reject) => {
+    const { token } = createSession(userId);
+    const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
+    const frames: Frame[] = [];
+    let resent = false;
+    // A missing terminal frame is the failure this suite is about, so time out
+    // rather than hang — and report what DID arrive, since "which frames came
+    // before it gave up" is the whole diagnostic.
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error(`no backlog-complete; got: ${frames.map((f) => f.kind).join(', ')}`));
+    }, 5000);
+    ws.on('message', (raw) => {
+      const frame = JSON.parse(raw.toString()) as Frame;
+      frames.push(frame);
+      if (frame.kind !== 'backlog-complete') return;
+      if (send && !resent) {
+        // Second burst requested: keep collecting, and stop at ITS terminator.
+        resent = true;
+        ws.send(JSON.stringify(send));
+        return;
+      }
+      clearTimeout(timer);
+      ws.close();
+      resolve(frames);
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+describe('connect burst terminator (#635)', () => {
+  it('ends the burst with backlog-complete, after every buffer frame', async () => {
+    const frames = await collectBurst();
+
+    // Terminal means terminal: nothing the burst had to say comes after it.
+    expect(frames.at(-1)!.kind).toBe('backlog-complete');
+    expect(frames.filter((f) => f.kind === 'backlog-complete')).toHaveLength(1);
+    expect(frames[0].kind).toBe('snapshot');
+
+    // Every buffer the user owns landed BEFORE the terminator — which is what
+    // makes absence provable for anything that didn't.
+    const targets = frames.filter((f) => f.kind === 'backlog').map((f) => f.target);
+    expect(targets).toEqual(expect.arrayContaining(['#lurker', 'bob', `:server:${networkId}`]));
+
+    // The claim a by-key client leans on: a buffer with no frame by the time
+    // the terminator arrives genuinely does not exist. Nothing else in the
+    // burst supports it — note that the snapshot reports this network's
+    // channels as empty even though #lurker is right there in the frames.
+    expect(targets).not.toContain('#never-joined');
+    const snapshot = frames[0] as { networks: Array<{ channels: unknown[] }> };
+    expect(snapshot.networks[0].channels).toEqual([]);
+  });
+
+  it('terminates an in-band snapshot resync too, not just the connect burst', async () => {
+    // A visibility-return resync ships a fresh burst on a live socket. It has
+    // the same "is this buffer gone?" problem, so it gets the same terminator.
+    const frames = await collectBurst({ type: 'snapshot' });
+    expect(frames.filter((f) => f.kind === 'backlog-complete')).toHaveLength(2);
+    expect(frames.at(-1)!.kind).toBe('backlog-complete');
+  });
+});

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -2064,6 +2064,27 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // handed the client — otherwise a later re-snapshot on this socket would
     // re-gap-fill everything the shells deliberately skipped.
     ws.sinceId = Math.max(maxSentId, cursor);
+    // Terminal frame (#635). Everything above ships synchronously with nothing
+    // marking the end, so until now "no row for this buffer yet" and "no such
+    // buffer" were the same observation no matter how long a client waited.
+    // That wedges any client that navigates by KEY rather than by tapping an
+    // existing row — a native app restoring its last buffer, or opening one
+    // from a notification — on a permanent "Loading messages…".
+    //
+    // The absence has to be provable here rather than inferred: `snapshot`'s
+    // per-network `channels` is empty for every network with no live
+    // connection and is read before auto-rejoin JOINs land even for one that
+    // has it, so it is NOT authoritative for buffer existence; and probing with
+    // `open-buffer` is worse still, since handleOpenBuffer treats an unknown
+    // `#channel` as a request to JOIN it.
+    //
+    // Deliberately inside sendSnapshotInner, so a throw mid-burst suppresses
+    // it: a truncated snapshot has NOT proved anything about the buffers it
+    // never reached, and a client is better left on today's spinner than told
+    // a buffer it owns doesn't exist. Sent on every snapshot (connect, in-band
+    // resync, and the fresh-network re-emit) — it terminates whichever burst
+    // just went out, and carries no state of its own.
+    send(ws, { kind: 'backlog-complete' });
     return {
       bufferCount,
       fresh: isFreshConnect,


### PR DESCRIPTION
Closes #635.

## The problem

The connect burst ships every frame synchronously with nothing marking the end, so "no row for this buffer **yet**" and "no such buffer" are the same observation no matter how long a client waits. That wedges any client that navigates by **key** rather than by tapping a row that already exists — a native app restoring its last-read buffer at launch, or opening one from a notification tap. The screen sits on "Loading messages…" forever, nothing retries, and the only way out is navigating somewhere else.

Nothing already in the protocol answers it, and both plausible workarounds are traps:

- **`snapshot.networks[].channels` is not authoritative for buffer existence.** It's empty outright for every network with no live connection (paused, manually disconnected, never autoconnected) even though those networks still own persisted buffers — and even on a live connection it's read at the `'connected'` instant, before auto-rejoin JOINs land. Judge membership from it and you decide a user left channels they're still in.
- **Probing with `open-buffer` is worse.** For a `#channel` with no row, `handleOpenBuffer` reads that as a request to JOIN, so a probe silently re-joins a channel the user deliberately left from another client.

## The change

One frame — `{kind:'backlog-complete'}` — at the tail of `sendSnapshotInner`, which makes absence provable for every buffer kind, on connected and disconnected networks alike.

Two placement decisions worth calling out:

- **Inside `sendSnapshotInner`, not the `sendSnapshot` wrapper**, so a throw mid-burst suppresses it. A truncated snapshot has proved nothing about the buffers it never reached, and a client is better left on today's spinner than told a buffer it owns is gone.
- **On all three snapshot paths** — connect, in-band `{type:'snapshot'}` resync, and the fresh-network re-emit. It terminates whichever burst just went out and carries no state of its own.

Additive, so `PROTOCOL_VERSION` doesn't move: an older server simply never sends it, and a client that doesn't see one keeps today's behaviour. The web client already drops unrecognized `kind`s (`useSocket.ts` falls through with no default branch), so it needs no change — it doesn't hit this bug anyway, since it navigates to buffers that exist by clicking rows.

## "Not open" ≠ "never existed"

Caught in review, and the reason the docs don't say "does not exist": `eachUserBufferTarget` drops closed buffers (`wsHub.ts:609`), so a buffer the user closed from another client ships no frame either — while keeping its full persisted history, one `open-buffer` away. Both cases mean the same thing for what a client **renders** (it isn't in the buffer list, which is why §9.1 models closed as absent); they differ for what it **destroys**. The docs now say *not open*, and tell clients not to purge local history, drafts, or a read position over a missing frame.

## Testing

New `server/services/wsHub.burst.test.ts` — a real `ws` client against a real `attachWsHub`, because this is an ordering property of the whole burst and a function-level test would still pass if the terminator were sent first. It asserts the frame is last and singular, that every buffer lands before it, that an in-band resync gets its own, and that a closed buffer is withheld while `hasMessageForTarget` still reports its history. It also pins the trap directly: the snapshot reports `channels: []` for that network while `#lurker` is right there in the frames.

Verified it fails with the one line removed. `npm run check` clean; full suite 214 files / 2836 tests green.

## Follow-ups (not in this PR)

- **lurker-ios** consumes the frame and renders an honest "this buffer isn't there any more".
- A **rejected join** (`+i`, `+k`, `+b`, bad name, disconnected network) still wedges identically — the `ERR_*` numeric goes to `:server:` and no frame ever names the target the user asked for. Worth its own issue.
- No capability signal, by deliberate choice: a new client against an older server never sees the frame and falls back to today's behaviour. Revisit if a long-tail-versioned client ever appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
