### PR TITLE
Document IRCv3 support by what each capability delivers

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -30,6 +30,7 @@ export default defineConfig({
         items: [
           { text: 'Client Protocol & API', link: '/CLIENT_PROTOCOL' },
           { text: 'MCP & HTTP API', link: '/MCP' },
+          { text: 'IRCv3 Support', link: '/IRCV3' },
         ],
       },
       { text: 'App', link: 'https://app.lurker.chat' },
@@ -61,6 +62,7 @@ export default defineConfig({
           items: [
             { text: 'Client Protocol & API', link: '/CLIENT_PROTOCOL' },
             { text: 'MCP & HTTP API', link: '/MCP' },
+            { text: 'IRCv3 Support', link: '/IRCV3' },
           ],
         },
       ],

--- a/docs/IRCV3.md
+++ b/docs/IRCV3.md
@@ -1,0 +1,279 @@
+# IRCv3 Support — what we use, and why it matters to you
+
+> **Audience:** anyone evaluating Lurker's protocol support, plus contributors
+> deciding what to build next. Last verified against `main` @ `9df7bb9`.
+> The server source is authoritative; `file:line` references point into this
+> repository.
+
+Most clients publish a bare list of IRCv3 capability names. That tells you almost
+nothing — "we support `multi-prefix`" is not a feature, it's an implementation
+detail. A capability only matters if it changes what the software can actually do
+for you.
+
+So this page is organised the other way around: **by the thing you get**, with the
+capabilities that make it possible listed underneath. There's a plain reference
+table at the end if that's what you came for, an honest accounting of what we
+negotiate but don't yet use, and a list of what we _don't_ support and what
+adopting it would buy you.
+
+One structural note that explains several entries: Lurker's upstream IRC
+connection is built on [irc-framework](https://github.com/kiwiirc/irc-framework),
+which negotiates a baseline capability set of its own. Some capabilities below are
+consumed inside that library and reach Lurker only as better-shaped events. That's
+still real support, but we mark which is which rather than taking credit for it.
+
+---
+
+## What you get
+
+### Your nicklist is correct, and it stays correct
+
+Open a channel and the member list is right immediately — ranks, away state, and
+hostmasks — and it updates live instead of drifting until something forces a
+refresh.
+
+- **`multi-prefix`** — a member's _full_ set of ranks arrives, not just the highest
+  one. Lurker shows the highest glyph (`~ & @ % +`) but tests the whole set when
+  deciding which moderation actions to offer you, so someone who is both `+o` and
+  `+v` is understood correctly.
+  <br>`vue_client/src/utils/memberPrefix.ts:19`, `vue_client/src/composables/useMemberActions.ts:167`
+- **`userhost-in-names`** — full `nick!ident@host` masks arrive with the member
+  list, so hostmasks are known the moment you join rather than after a round-trip.
+  <br>`irc-framework/src/commands/handlers/channel.js:71`
+- **`away-notify`** — away state updates live, with no polling.
+  <br>`server/services/ircConnection.ts:1845`
+- **`whox`** — on joining, Lurker issues a single extended `WHO` to learn away state
+  for the whole channel at once, instead of one query per member. `away-notify` keeps
+  it current from then on.
+  <br>`server/services/ircConnection.ts:2326`
+- **`chghost`** — when someone's hostmask changes (typically a cloak applied after
+  they identify), you see one clean line and the nicklist updates in place, rather
+  than a fake disconnect-and-rejoin.
+  <br>`server/services/ircConnection.ts:1405`
+- **`extended-join`**, **`account-notify`** — a member's registered account is known
+  on join and stays current if they identify or log out later, without Lurker having
+  to run `WHOIS` at you. Account changes update the nicklist **silently**: on
+  networks like Libera, identifying fires an account change and a cloak change
+  back-to-back, and rendering both would print two lines per identify in every
+  channel you share.
+  <br>`server/services/ircConnection.ts:1467`
+
+### Your history is in the right order, on every device
+
+Lurker stores everything and replays it to any browser or client you attach. That
+only works if timestamps are trustworthy.
+
+- **`server-time`** — messages are stored with the time _the server_ stamped them,
+  not the time Lurker happened to receive them. Lines that arrive late or out of
+  order still land in the right place, and every device you attach sees the same
+  ordering. Lurker normalises these to a canonical UTC form on the way in, and falls
+  back to receive time for implausibly far-future stamps so one clock-skewed server
+  can't reorder your buffer list.
+  <br>`server/services/ircConnection.ts:294`
+- **`echo-message`** — your own sent messages come back from the server, and _that_
+  copy is the one Lurker stores. It's the only way your own messages learn their
+  server-assigned ID and authoritative timestamp, which is what keeps them ordered
+  identically across every device you're signed in on.
+  <br>`server/services/ircConnection.ts:1533`
+- **`msgid`** — every message gets the server's stable identifier, stored and
+  indexed. Nothing user-facing depends on it today: it's deliberate groundwork, since
+  reactions and threaded replies are both anchored on a message ID and can't be built
+  without one.
+  <br>`server/services/ircConnection.ts:1528`
+
+### Multi-line messages stay one message
+
+Paste several lines and they travel as a single logical message where the network
+supports it, instead of being torn into separate messages that can interleave with
+other people's chatter. Incoming multi-line messages are reassembled the same way.
+
+- **`batch`**, **`draft/multiline`**, **`message-tags`**
+  <br>`server/services/ircConnection.ts:518`
+
+### You can see when someone is typing
+
+Typing indicators in channels and DMs, both directions — Lurker sends yours and
+displays other people's. Currently a web-client feature; the iOS app doesn't render
+them yet.
+
+- **`+typing`** (carried over `TAGMSG`), which requires **`message-tags`** — so it's
+  automatically off on networks that don't speak IRCv3, because those answer every
+  `TAGMSG` with an error and an ungated send would toast you on each keystroke.
+  Lurker also suppresses typing notifications to a target the server has already
+  refused your messages to (a `+R`/`+M` channel you can't speak in), and to peers it
+  knows are offline — otherwise every keystroke earns another error reply in your DM
+  buffer.
+  <br>`server/services/ircConnection.ts:4529` (send), `:2615` (receive)
+
+### You can see when friends are around
+
+Presence dots on DMs and the friends list, without Lurker hammering the network
+with `WHOIS` polls.
+
+- **`monitor`** — the presence transport. Lurker asks the server to tell it when
+  specific people connect or disconnect. Networks without it get no presence
+  tracking at all; we deliberately don't fall back to polling, because polling at
+  the scale of a friends list is abusive to the network.
+  <br>`server/services/ircConnection.ts:611`
+- **`extended-monitor`** — extends that to away/back state for people you share no
+  channel with, which is what makes presence useful for DM peers rather than just
+  channel regulars.
+  <br>`server/services/ircConnection.ts:586`
+
+### End-to-end encryption can identify who it's talking to
+
+Lurker's optional E2E encryption keys off a stable `ident@host` identity rather than
+a nickname, since nicknames are trivially reassigned.
+
+- **`userhost-in-names`** — supplies that identity for everyone in a channel from
+  the moment you join. Without it there's nothing stable to pin a key to.
+  <br>`server/services/ircConnection.ts:3866`
+
+### Connecting works, and failure is legible
+
+- **`sasl`** (3.1 / 3.2, PLAIN) — proper account authentication rather than
+  `/msg NickServ`. Under 3.2, Lurker reads the server's advertised mechanism list
+  and fails fast with a clear reason if PLAIN isn't offered, instead of hanging. A
+  genuine authentication failure is treated as _terminal_ — Lurker stops retrying
+  and tells you, rather than looping against a password that will never work.
+  <br>`server/services/ircConnection.ts:3115`, `:959`
+- **`cap-3.1` / `cap-3.2`** — versioned capability negotiation, which is how the
+  SASL mechanism list is readable at all.
+- **`cap-notify`** — if a network enables a capability mid-session (common right
+  after a services upgrade), it's picked up without you reconnecting.
+- **`invite-notify`** — invites are recorded as a real "X invited Y" line that
+  survives in your history.
+  <br>`server/services/ircConnection.ts:1974`
+
+---
+
+## Attaching your own IRC client
+
+Lurker can also act as a bouncer, so WeeChat, irssi, Textual or HexChat can attach
+to the same always-on connection your browser uses (see
+[Self-Hosting](/SELF_HOSTING#irc-bouncer-attach-from-other-irc-clients)). The
+capabilities Lurker offers _downstream_ are a deliberately short, honest list —
+we advertise only what we actually implement.
+
+| You get                                                                                         | Powered by                                                    |
+| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Log in with SASL instead of a server password                                                   | `sasl` (PLAIN)                                                |
+| Backlog replays at its original timestamps, not at attach time                                  | `server-time`                                                 |
+| Scrollback on demand — page back through Lurker's full stored history from your terminal client | `draft/chathistory`                                           |
+| Your own sent messages echoed back, if your client wants them                                   | `echo-message`                                                |
+| Your outgoing DMs attributed to you correctly in replay                                         | `znc.in/self-message`                                         |
+| Pick your network from a list instead of hardcoding `username/networkname`                      | `soju.im/bouncer-networks`, `soju.im/bouncer-networks-notify` |
+| Message metadata passed through from upstream                                                   | `message-tags`                                                |
+| Network list delivered as one grouped burst                                                     | `batch`                                                       |
+
+Two implementation notes worth knowing if you're writing against it:
+
+- Scrollback is capped at 1000 messages per request, advertised via the
+  `CHATHISTORY` ISUPPORT token. Over-limit requests are **rejected, not silently
+  truncated** — matching soju, whose clients read the token and stay under it.
+  Message references are `timestamp` only, deliberately not `msgid`, because
+  Lurker's stored history IDs and an upstream network's message IDs are different
+  namespaces and mixing them would break paging across the boundary.
+  <br>`server/services/bouncer.ts:110`, `:457`
+- Tags that only a server may set — `time`, `account`, `msgid`, `label`, `batch` —
+  are stripped from anything an attached client sends, so a downstream client can't
+  forge them.
+  <br>`server/services/bouncer.ts:246`
+
+---
+
+## Reference table
+
+Capability names as they appear on [ircv3.net](https://ircv3.net/software/clients).
+"Client" is Lurker connecting out to a network; "Bouncer" is your IRC client
+attaching to Lurker.
+
+| Capability                              | Client | Bouncer |
+| --------------------------------------- | :----: | :-----: |
+| `cap-3.1`, `cap-3.2`                    |   ✅   |   ✅    |
+| `cap-notify`                            |   ✅   |    —    |
+| `sasl-3.1`, `sasl-3.2` (PLAIN)          |   ✅   |   ✅    |
+| `server-time`                           |   ✅   |   ✅    |
+| `message-tags`                          |   ✅   |   ✅    |
+| `msgid`                                 |   ✅   |   ✅    |
+| `echo-message`                          |   ✅   |   ✅    |
+| `batch`                                 |   ✅   |   ✅    |
+| `draft/multiline`                       |   ✅   |    —    |
+| `+typing`                               |   ✅   |    —    |
+| `draft/chathistory`                     |   —    |   ✅    |
+| `multi-prefix`                          |   ✅   |    —    |
+| `userhost-in-names`                     |   ✅   |    —    |
+| `away-notify`                           |   ✅   |    —    |
+| `extended-join`                         |   ✅   |    —    |
+| `account-notify`                        |   ✅   |    —    |
+| `chghost`                               |   ✅   |    —    |
+| `invite-notify`                         |   ✅   |    —    |
+| `monitor`                               |   ✅   |    —    |
+| `extended-monitor`                      |   ✅   |    —    |
+| `whox`                                  |   ✅   |    —    |
+| `znc.in/self-message`                   |   —    |   ✅    |
+| `soju.im/bouncer-networks` (+`-notify`) |   —    |   ✅    |
+
+### Negotiated but not yet used
+
+In the interest of not padding the list: these are requested and acknowledged, but
+nothing in Lurker reads them yet. We'd rather say so than count them.
+
+| Capability                                                               | Status                                                                                                                                    |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `account-tag`                                                            | Acknowledged, but nothing reads the per-message account tag. Account information comes from `extended-join` and `account-notify` instead. |
+| `draft/message-tags-0.2`, `znc.in/server-time-iso`, `znc.in/server-time` | Pre-standardisation aliases requested by irc-framework for older servers. Superseded by `message-tags` and `server-time`.                 |
+
+---
+
+## Not supported yet
+
+Kept deliberately, as a roadmap. Ordered by what we think it would actually buy
+you, not by spec number.
+
+### High value — natural fits for features Lurker already has
+
+| Capability                      | What it would give you                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `+draft/react`                  | Emoji reactions on messages. Lurker already stores the `msgid` that reactions anchor to, so the hard part is done.                                                                                                                                                                                                                                                                 |
+| `+draft/reply`                  | Threaded replies, anchored on the same stored `msgid`.                                                                                                                                                                                                                                                                                                                             |
+| `draft/read-marker`             | Read state shared with an attached IRC client. Lurker already tracks read position server-side per user and pushes it to every first-party client, so web and mobile agree — but that state is invisible over the bouncer, which replays a fixed-size burst per buffer rather than resuming from where you left off. This is the cap that would close that gap in both directions. |
+| `draft/chathistory` (as client) | Backfill missed history from an upstream bouncer or a network that stores it. Note the asymmetry: Lurker _serves_ chathistory downstream but doesn't consume it upstream, so gaps from a Lurker outage can't currently be filled in.                                                                                                                                               |
+| `standard-replies`              | Machine-readable `FAIL`/`WARN`/`NOTE` errors, so command failures render as real explanations instead of raw numerics.                                                                                                                                                                                                                                                             |
+| `draft/message-redaction`       | When someone deletes a message, it disappears from your view too, rather than persisting forever in Lurker's history.                                                                                                                                                                                                                                                              |
+
+### Moderate value
+
+| Capability                   | What it would give you                                                                                                                                                           |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `labeled-response`           | Reliable correlation of a command with its reply, which makes command results attributable even when several are in flight.                                                      |
+| `setname`                    | Change your realname without reconnecting. Lurker doesn't request this today.                                                                                                    |
+| `bot-mode`                   | Visually distinguish bots from people in the nicklist and message list.                                                                                                          |
+| `draft/metadata`             | Server-side profile data — avatars being the obvious use.                                                                                                                        |
+| `draft/account-registration` | Register a network account during onboarding, instead of sending someone off to `/msg NickServ`.                                                                                 |
+| `draft/pre-away`             | Set away state before registration finishes, closing the brief window on reconnect where you appear present but aren't.                                                          |
+| `utf8only`                   | Skip encoding guesswork on networks that guarantee UTF-8.                                                                                                                        |
+| `draft/channel-rename`       | Follow a channel rename without a part/join cycle.                                                                                                                               |
+| `sts`                        | Automatic upgrade to TLS and downgrade protection. Lower priority than it sounds — Lurker connects with TLS directly — but it would harden a misconfigured plaintext connection. |
+
+### Low value or not applicable
+
+| Capability                                                                                                                    | Why it's not a priority                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `starttls`                                                                                                                    | Superseded in practice by connecting with TLS directly, which Lurker does.                                             |
+| `websockets`                                                                                                                  | Lurker connects to networks over TCP from the server; browser WebSocket transport isn't relevant to that path.         |
+| `webirc`                                                                                                                      | Designed for gateways relaying many users, and requires per-network operator trust. Lurker's connections are per-user. |
+| `no-implicit-names`                                                                                                           | A join-time optimisation for very large channels; little benefit at Lurker's scale.                                    |
+| `account-extban`, `draft/oper-tag`, `draft/network-icon`, `draft/extended-isupport`, `client-batch`, `+draft/channel-context` | Narrow or largely server-side; no user-visible feature blocked on them today.                                          |
+
+---
+
+## Related
+
+- [Self-Hosting → IRC bouncer](/SELF_HOSTING#irc-bouncer-attach-from-other-irc-clients)
+  — how to attach a terminal client.
+- [Client Protocol & API](/CLIENT_PROTOCOL) — Lurker's own WebSocket protocol, which
+  is what first-party clients speak. It is not IRC.
+- Lurker's entries in the IRCv3 support tables:
+  [Web Clients](https://ircv3.net/software/clients) and Bouncers, as
+  _Lurker_ and _Lurker (as Server)_.

--- a/docs/IRCV3.md
+++ b/docs/IRCV3.md
@@ -3,7 +3,7 @@
 > **Audience:** anyone evaluating Lurker's protocol support, plus contributors
 > deciding what to build next. Last verified against `main` @ `9df7bb9`.
 > The server source is authoritative; `file:line` references point into this
-> repository.
+> repository unless otherwise noted (e.g. upstream deps like irc-framework).
 
 Most clients publish a bare list of IRCv3 capability names. That tells you almost
 nothing — "we support `multi-prefix`" is not a feature, it's an implementation

--- a/server/services/bouncer.chathistory.test.ts
+++ b/server/services/bouncer.chathistory.test.ts
@@ -211,7 +211,16 @@ describe('CHATHISTORY msgid rejected', () => {
     expect(isupport).not.toContain('msgid');
     c.send('CHATHISTORY BEFORE #r msgid=5 100');
     const fail = await c.waitForCommand('FAIL');
-    expect(fail).toContain('Invalid first bound');
+    // A well-formed selector of a type we don't implement gets the spec's
+    // dedicated code, NOT INVALID_PARAMS — the client's syntax was fine, the
+    // reftype isn't offered, and only INVALID_MSGREFTYPE says so.
+    //
+    // Asserted as a full param sequence, not substrings: the spec layout is
+    // `<command> <target> [context]`, and a substring check would happily pass
+    // while the target was missing and the client mistook `msgid=5` for a
+    // buffer name.
+    expect(fail).toContain('FAIL CHATHISTORY INVALID_MSGREFTYPE BEFORE #r msgid=5 :');
+    expect(fail).toContain('Unsupported message reference type');
     c.close();
   });
 });
@@ -253,7 +262,10 @@ describe('CHATHISTORY errors', () => {
     const acct = harnessMod.seedAccount({ nick: 'ch8' });
     const c = await harness.connect();
     await attachBound(c, acct);
-    c.send('CHATHISTORY BEFORE #r msgid=notanumber 100');
+    // A SUPPORTED reftype carrying an unparseable value — that's a syntax error
+    // the client can fix, so it stays INVALID_PARAMS. (Deliberately not a
+    // `msgid=` selector: that's an unsupported reftype, covered above.)
+    c.send('CHATHISTORY BEFORE #r timestamp=notatimestamp 100');
     const fail = await c.waitForCommand('FAIL');
     expect(fail).toContain('INVALID_PARAMS');
     expect(fail).toContain('Invalid first bound');

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -1300,11 +1300,17 @@ class BouncerSession {
     const isBetween = sub === 'BETWEEN';
     const limit = this.parseChatHistoryLimit(sub, msg.params[isBetween ? 4 : 3] ?? '');
     if (limit === null) return;
-    const bound0 = this.parseChatHistoryBound(sub, msg.params[2] || '', sub === 'LATEST', 'first');
+    const bound0 = this.parseChatHistoryBound(
+      sub,
+      target,
+      msg.params[2] || '',
+      sub === 'LATEST',
+      'first',
+    );
     if (!bound0) return;
     let bound1: ChatBound | null = null;
     if (isBetween) {
-      bound1 = this.parseChatHistoryBound(sub, msg.params[3] || '', false, 'second');
+      bound1 = this.parseChatHistoryBound(sub, target, msg.params[3] || '', false, 'second');
       if (!bound1) return;
     }
     const rows = this.loadChatHistory(sub, target, bound0, bound1, limit);
@@ -1393,17 +1399,42 @@ class BouncerSession {
   // Parse a CHATHISTORY selector — `*` (LATEST only) or `timestamp=<iso>`. msgid
   // selectors are deliberately rejected (see the ChatBound type). Writes a FAIL
   // and returns null on error.
+  //
+  // The spec separates two failure modes and we honor the distinction, because a
+  // client probing for msgid support reads the code to decide what to do next:
+  //   INVALID_MSGREFTYPE — a well-formed `<reftype>=<value>` we don't implement.
+  //     Retrying with different syntax will never help; use timestamp instead.
+  //   INVALID_PARAMS — the selector is malformed (unparseable timestamp value, or
+  //     not a `key=value` selector at all). A syntax error the client can fix.
+  // Reporting the first as the second is a lie that hides the real reason, and
+  // it's the kind of thing a conformance-minded onlooker checks.
+  //
+  // The two codes also take DIFFERENT parameter layouts, which is easy to get
+  // wrong: INVALID_MSGREFTYPE is `<command> <target> [context]` while
+  // INVALID_PARAMS is `<command> [timestamp]` with NO target. So `target` is
+  // only ever emitted on the msgreftype path. TARGETS has no target argument at
+  // all and passes '*', keeping the parameter count stable so a client reading
+  // positionally can't mistake the bound for a buffer name.
   private parseChatHistoryBound(
     sub: string,
+    target: string,
     boundStr: string,
     allowStar: boolean,
     which: 'first' | 'second',
   ): ChatBound | null {
     if (allowStar && boundStr === '*') return { star: true };
     const eq = boundStr.indexOf('=');
-    if (eq !== -1 && boundStr.slice(0, eq) === 'timestamp') {
-      const val = boundStr.slice(eq + 1);
-      if (isValidServerTime(val)) return { iso: val };
+    const reftype = eq === -1 ? '' : boundStr.slice(0, eq);
+    if (reftype && reftype !== 'timestamp') {
+      // Known-shaped selector, unsupported type — `msgid=` today. We advertise
+      // MSGREFTYPES=timestamp; see the ChatBound notes for why msgid isn't there.
+      this.write(
+        `:${SERVER_NAME} FAIL CHATHISTORY INVALID_MSGREFTYPE ${sub} ${target || '*'} ${boundStr} :Unsupported message reference type`,
+      );
+      return null;
+    }
+    if (reftype === 'timestamp' && isValidServerTime(boundStr.slice(eq + 1))) {
+      return { iso: boundStr.slice(eq + 1) };
     }
     this.write(
       `:${SERVER_NAME} FAIL CHATHISTORY INVALID_PARAMS ${sub} ${boundStr} :Invalid ${which} bound`,
@@ -1412,7 +1443,8 @@ class BouncerSession {
   }
 
   private parseTimestampBound(boundStr: string, which: 'first' | 'second'): string | null {
-    const bound = this.parseChatHistoryBound('TARGETS', boundStr, false, which);
+    // TARGETS takes no target argument — '*' holds the slot (see parseChatHistoryBound).
+    const bound = this.parseChatHistoryBound('TARGETS', '*', boundStr, false, which);
     return bound && 'iso' in bound ? bound.iso : null;
   }
 


### PR DESCRIPTION
Adds a public IRCv3 support page at `docs/IRCV3.md`, surfaced under **Developers** in the docs nav and sidebar, plus one conformance fix found while writing it.

## Why

A bare list of capability names tells a reader nothing — "we support `multi-prefix`" is an implementation detail, not a feature. Plenty of clients publish exactly that list and leave you asking *what does that do for me?*

So the page is organised by **the thing you get**, with the capabilities that make it possible listed underneath, and every claim anchored to a `file:line` so it can be checked rather than trusted. There's still a plain reference table for people who did just want the list.

## Keeping it honest

Three sections exist specifically so the page can't drift into over-claiming:

- **Negotiated but not consumed** — `account-tag` and the legacy `znc.in/*` aliases are ACKed but nothing reads them. Listed as such instead of padding the support list.
- **Consumed inside irc-framework** — marked where the library does the work rather than our own code. Still real support, but not ours to take credit for.
- **Not supported yet** — enumerated with what adopting each would buy a user, which doubles as a roadmap.

Two that are easy to over-claim by copying a client on the same library: `setname` is never requested (we don't pass `enable_setname`) and irc-framework 4.14 has no STS implementation at all, so neither is listed.

## Conformance fix

Writing the page turned up a real deviation. We advertise `MSGREFTYPES=timestamp` and reject `msgid=` selectors, but the rejection came back as `INVALID_PARAMS` — telling a client its syntax was malformed when the syntax was fine and the reference type simply isn't offered. The spec has a dedicated `INVALID_MSGREFTYPE` code for exactly this.

The two codes take different parameter layouts, which is the easy part to get wrong: `INVALID_MSGREFTYPE` is `<command> <target> [context]` while `INVALID_PARAMS` is `<command> [timestamp]` with no target. The existing `INVALID_PARAMS` emissions were already correct; only the new path needed the target threaded through.

Follow-up for real `msgid` reference support, where the blocker is that live relay and CHATHISTORY currently put two different msgid namespaces on one connection: #641

## Verification

- `npm test` — 2833 passing
- `npm run check` — clean
- `npm run build` in `docs/` — clean, dead-link checking on

🤖 Generated with [Claude Code](https://claude.com/claude-code)