### PR TITLE
Derive the identd ident from the Lurker account, admin-assignable (#643)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,11 @@ VAPID_SUBJECT=mailto:you@example.com
 # default (binding :113 is privileged; single-user self-hosts don't need it).
 # Node-edition cells should enable it. Port 113 must be reachable by the IRC
 # server; to avoid root, set a high port and have the host's oidentd forward.
+#
+# The ident answered for a user is their LURKER ACCOUNT NAME — not the nick or
+# per-network username they type, both of which they can change at will (an
+# ident a user picks can't attribute anything). An admin can assign a different
+# one per account in the admin panel → users; nobody can set their own.
 # ---------------------------------------------------------------------------
 # LURKER_IDENTD_ENABLED=true
 # LURKER_IDENTD_PORT=113

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -53,6 +53,7 @@ const USERS_SKIPPED_COLUMNS: Record<string, string> = Object.freeze({
   last_seen_at: 'tracked locally by each instance',
   created_at: 'tracked locally by each instance',
   is_paused: 'account access state, owned by the local instance / control plane',
+  ident: 'admin-assigned identd name; the importing instance’s admin owns who is called what',
 });
 
 // scope values control how the exporter filters rows for a given userId.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -911,7 +911,7 @@ ensureColumn('users', 'last_seen_at', 'TEXT');
 ensureColumn('users', 'is_paused', 'INTEGER NOT NULL DEFAULT 0');
 
 // Admin-set ident override for the built-in identd (#643). NULL — the norm —
-// means "derive it from the account username"; see utils/ident.ts. Deliberately
+// means "derive it from the account username"; see shared/ident.ts. Deliberately
 // not user-writable: the ident is how a network operator tells one member of a
 // shared IP from another, so letting members pick it defeats the identd.
 ensureColumn('users', 'ident', 'TEXT');

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -910,6 +910,12 @@ ensureColumn('users', 'last_seen_at', 'TEXT');
 // canceled; the cell stays billing-blind and only mirrors this one verdict.
 ensureColumn('users', 'is_paused', 'INTEGER NOT NULL DEFAULT 0');
 
+// Admin-set ident override for the built-in identd (#643). NULL — the norm —
+// means "derive it from the account username"; see utils/ident.ts. Deliberately
+// not user-writable: the ident is how a network operator tells one member of a
+// shared IP from another, so letting members pick it defeats the identd.
+ensureColumn('users', 'ident', 'TEXT');
+
 // Roles: 'admin' can manage invites and other users; 'user' is everyone else.
 // On a fresh install the first user (created via /api/auth/setup) is promoted
 // to admin by routes/auth.js. On an existing single-user install pre-dating

--- a/server/db/users.ts
+++ b/server/db/users.ts
@@ -16,30 +16,26 @@ export interface User {
   // 0 | 1. Paused accounts are disconnected from IRC and barred from
   // reconnecting/sending, but retain read-only access to their history.
   is_paused: number;
+  // Admin-set identd override (#643), NULL for "derive from the username".
+  // Never writable by the account it belongs to — see utils/ident.ts.
+  ident: string | null;
 }
 
+// One list, so a column added to `User` can't reach one lookup and miss another.
+const USER_COLUMNS = 'id, username, role, created_at, last_seen_at, is_paused, ident';
+
 export function findUserByUsername(username: string): User | undefined {
-  return db
-    .prepare(
-      'SELECT id, username, role, created_at, last_seen_at, is_paused FROM users WHERE username = ?',
-    )
-    .get(username) as User | undefined;
+  return db.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE username = ?`).get(username) as
+    | User
+    | undefined;
 }
 
 export function findUserById(id: number | bigint): User | undefined {
-  return db
-    .prepare(
-      'SELECT id, username, role, created_at, last_seen_at, is_paused FROM users WHERE id = ?',
-    )
-    .get(id) as User | undefined;
+  return db.prepare(`SELECT ${USER_COLUMNS} FROM users WHERE id = ?`).get(id) as User | undefined;
 }
 
 export function listUsers(): User[] {
-  return db
-    .prepare(
-      'SELECT id, username, role, created_at, last_seen_at, is_paused FROM users ORDER BY id',
-    )
-    .all() as User[];
+  return db.prepare(`SELECT ${USER_COLUMNS} FROM users ORDER BY id`).all() as User[];
 }
 
 // Throttled to once per minute via the WHERE clause so a busy client (many
@@ -96,6 +92,15 @@ export function setUserPaused(userId: number, paused: boolean): boolean {
   const info = db
     .prepare('UPDATE users SET is_paused = ? WHERE id = ?')
     .run(paused ? 1 : 0, userId);
+  return info.changes > 0;
+}
+
+// Set (or clear, with null) the admin-assigned identd override. Takes effect on
+// the account's next IRC connect: the ident is answered once, during the ircd's
+// registration handshake, so rewriting the live identd map would change nothing
+// the servers have already recorded. Returns false only when no row matched.
+export function setUserIdent(userId: number, ident: string | null): boolean {
+  const info = db.prepare('UPDATE users SET ident = ? WHERE id = ?').run(ident, userId);
   return info.changes > 0;
 }
 

--- a/server/db/users.ts
+++ b/server/db/users.ts
@@ -17,7 +17,7 @@ export interface User {
   // reconnecting/sending, but retain read-only access to their history.
   is_paused: number;
   // Admin-set identd override (#643), NULL for "derive from the username".
-  // Never writable by the account it belongs to — see utils/ident.ts.
+  // Never writable by the account it belongs to — see shared/ident.ts.
   ident: string | null;
 }
 

--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -145,6 +145,62 @@ describe('PUT /api/admin/users/:id/ident', () => {
     expect(res.body.error).toMatch(/already in use by admin-regular/);
   });
 
+  it('always allows clearing back to the default, even once the default collides', async () => {
+    // Reaching the trap takes three steps, and the API allows every one of them:
+    // move `target` off its default, let another account TAKE that default (now
+    // free), then clear. The cleared value is the account's own username-derived
+    // ident — never chosen by the admin and not editable — so refusing it would
+    // strand the override permanently. The duplicate that results is reported by
+    // identConflict rather than made unfixable here.
+    const { createUser } = await import('../db/users.js');
+    const squatter = createUser('squatter');
+    await adminAgent.put(`/api/admin/users/${target.id}/ident`).send({ ident: 'tgtx' });
+    expect(
+      (
+        await adminAgent
+          .put(`/api/admin/users/${squatter.id}/ident`)
+          .send({ ident: 'ident-target' })
+      ).status,
+    ).toBe(200);
+
+    const res = await adminAgent.put(`/api/admin/users/${target.id}/ident`).send({ ident: '' });
+    expect(res.status).toBe(200);
+    expect(await identOf(target.id)).toMatchObject({
+      ident: null,
+      effectiveIdent: 'ident-target',
+    });
+    // ...and the collision it creates is visible rather than silent.
+    const rows = (await adminAgent.get('/api/admin/users')).body.users;
+    for (const id of [target.id, squatter.id]) {
+      expect(rows.find((u: { id: number }) => u.id === id).identConflict).toBe(true);
+    }
+    await adminAgent.delete(`/api/admin/users/${squatter.id}`);
+  });
+
+  it('flags accounts that answer the same ident (usernames are looser than idents)', async () => {
+    // 'bob smith' and 'bobsmith' are two legal, distinct usernames that derive
+    // ONE ident. No signup path consults idents, so the panel has to surface it.
+    const { createUser } = await import('../db/users.js');
+    const a = createUser('bob smith');
+    const b = createUser('bobsmith');
+    const rows = (await adminAgent.get('/api/admin/users')).body.users;
+    const row = (id: number) => rows.find((u: { id: number }) => u.id === id);
+    expect(row(a.id).effectiveIdent).toBe('bobsmith');
+    expect(row(b.id).effectiveIdent).toBe('bobsmith');
+    expect(row(a.id).identConflict).toBe(true);
+    expect(row(b.id).identConflict).toBe(true);
+    // An unrelated account isn't dragged into it.
+    expect(row(target.id).identConflict).toBe(false);
+
+    // Giving one of them its own ident settles it for BOTH rows.
+    await adminAgent.put(`/api/admin/users/${a.id}/ident`).send({ ident: 'bobs' });
+    const after = (await adminAgent.get('/api/admin/users')).body.users;
+    expect(after.find((u: { id: number }) => u.id === a.id).identConflict).toBe(false);
+    expect(after.find((u: { id: number }) => u.id === b.id).identConflict).toBe(false);
+    await adminAgent.delete(`/api/admin/users/${a.id}`);
+    await adminAgent.delete(`/api/admin/users/${b.id}`);
+  });
+
   it('404 for an unknown id, 400 for a non-integer id', async () => {
     expect(
       (await adminAgent.put('/api/admin/users/999999/ident').send({ ident: 'x' })).status,

--- a/server/routes/admin.test.ts
+++ b/server/routes/admin.test.ts
@@ -78,6 +78,81 @@ describe('GET /api/admin/users', () => {
     expect(usernames).toContain('admin-root');
     expect(usernames).toContain('admin-regular');
   });
+
+  it('reports each account’s ident, derived from the username by default (#643)', async () => {
+    const res = await adminAgent.get('/api/admin/users');
+    const row = res.body.users.find((u: User) => u.username === 'admin-regular');
+    expect(row.ident).toBeNull();
+    expect(row.effectiveIdent).toBe('admin-regular');
+    // Whether an ident daemon is actually running, so the pane can say the
+    // idents are inert rather than implying networks see them.
+    expect(res.body.identdEnabled).toBe(false);
+  });
+});
+
+// The ident is an attribution handle for a shared IP, so it's assigned by the
+// admin and never chosen by the account it belongs to (#643).
+describe('PUT /api/admin/users/:id/ident', () => {
+  let target: User;
+
+  beforeAll(async () => {
+    target = (await import('../db/users.js')).createUser('ident-target');
+  });
+
+  async function identOf(id: number): Promise<{ ident: string | null; effectiveIdent: string }> {
+    const res = await adminAgent.get('/api/admin/users');
+    return res.body.users.find((u: { id: number }) => u.id === id);
+  }
+
+  it('403 for a non-admin — a user cannot set their own ident', async () => {
+    const res = await userAgent.put(`/api/admin/users/${user.id}/ident`).send({ ident: 'chosen' });
+    expect(res.status).toBe(403);
+    expect((await identOf(user.id)).effectiveIdent).toBe('admin-regular');
+  });
+
+  it('assigns an ident', async () => {
+    const res = await adminAgent.put(`/api/admin/users/${target.id}/ident`).send({ ident: 'itgt' });
+    expect(res.status).toBe(200);
+    expect(res.body.effectiveIdent).toBe('itgt');
+    expect(await identOf(target.id)).toMatchObject({ ident: 'itgt', effectiveIdent: 'itgt' });
+  });
+
+  it('clears back to the account-derived default on a blank value', async () => {
+    await adminAgent.put(`/api/admin/users/${target.id}/ident`).send({ ident: 'itgt' });
+    const res = await adminAgent.put(`/api/admin/users/${target.id}/ident`).send({ ident: '' });
+    expect(res.status).toBe(200);
+    expect(await identOf(target.id)).toMatchObject({
+      ident: null,
+      effectiveIdent: 'ident-target',
+    });
+  });
+
+  it('rejects an ident an ircd would choke on, rather than reshaping it', async () => {
+    for (const ident of ['bob smith', 'bob@host', '-bob', 'a'.repeat(17)]) {
+      const res = await adminAgent.put(`/api/admin/users/${target.id}/ident`).send({ ident });
+      expect(res.status).toBe(400);
+    }
+    expect((await identOf(target.id)).ident).toBeNull();
+  });
+
+  it('409 on a collision with another account — two members must not share one ident', async () => {
+    // 'admin-regular' is another account's DERIVED ident, not a stored override:
+    // the check has to compare effective idents or most collisions slip through.
+    const res = await adminAgent
+      .put(`/api/admin/users/${target.id}/ident`)
+      .send({ ident: 'admin-regular' });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already in use by admin-regular/);
+  });
+
+  it('404 for an unknown id, 400 for a non-integer id', async () => {
+    expect(
+      (await adminAgent.put('/api/admin/users/999999/ident').send({ ident: 'x' })).status,
+    ).toBe(404);
+    expect((await adminAgent.put('/api/admin/users/abc/ident').send({ ident: 'x' })).status).toBe(
+      400,
+    );
+  });
 });
 
 describe('GET /api/admin/presence', () => {

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -4,11 +4,21 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
-import { listUsers, findUserById, deleteUser, countAdmins, setUserPaused } from '../db/users.js';
+import {
+  listUsers,
+  findUserById,
+  deleteUser,
+  countAdmins,
+  setUserPaused,
+  setUserIdent,
+} from '../db/users.js';
+import type { User } from '../db/users.js';
 import { createInvite, listInvites, deleteInvite, getInvite } from '../db/invites.js';
 import ircManager from '../services/ircManager.js';
 import { presenceDiagnostics } from '../services/wsHub.js';
+import { isIdentdEnabled, isOidentdFileEnabled } from '../services/identd.js';
 import { isNodeMode } from '../utils/edition.js';
+import { deriveIdent, isValidIdentOverride, MAX_IDENT_LENGTH } from '../utils/ident.js';
 import adminUploadersRouter from './adminUploaders.js';
 import adminNetworksRouter from './adminNetworks.js';
 
@@ -57,6 +67,14 @@ function originFromRequest(req: Request): string {
   return `${req.protocol}://${req.get('host')}`;
 }
 
+function effectiveIdent(u: User): string {
+  return deriveIdent({
+    nodeMode: isNodeMode(),
+    accountUsername: u.username,
+    accountIdent: u.ident,
+  });
+}
+
 router.get('/users', (_req: Request, res: Response) => {
   res.json({
     users: listUsers().map((u) => ({
@@ -66,7 +84,82 @@ router.get('/users', (_req: Request, res: Response) => {
       createdAt: u.created_at,
       lastSeenAt: u.last_seen_at,
       isPaused: !!u.is_paused,
+      // The stored override (null = derived from the username) alongside what
+      // the identd would actually answer, so the admin can see both without
+      // re-deriving the rule in the client.
+      ident: u.ident,
+      effectiveIdent: effectiveIdent(u),
     })),
+    // Whether either ident mode is running. When neither is, the idents above
+    // are inert — the UI says so rather than implying networks see them. (The
+    // other half of the story, "may these be edited at all", is node edition,
+    // which the client already knows from /api/config.)
+    identdEnabled: isIdentdEnabled() || isOidentdFileEnabled(),
+  });
+});
+
+// Assign (or clear, with null/'') an account's ident — the name a network sees
+// in nick!ident@host for that member (#643). Admin-only on purpose: on a
+// multi-user instance the ident is what lets an operator ban or blame ONE
+// member of a shared IP, so a member who could pick their own could wear a
+// neighbour's identity or churn away from a ban.
+router.put('/users/:id/ident', (req: Request, res: Response) => {
+  if (isNodeMode()) {
+    // Hosted idents are `lu<controlPlaneAccountId>` — fleet-unique and stable
+    // across cell moves. A cell-local override would break both.
+    res.status(409).json({ error: 'the ident is managed by the control plane in node edition' });
+    return;
+  }
+  const id = Number(req.params.id);
+  if (!Number.isInteger(id)) {
+    res.status(400).json({ error: 'invalid id' });
+    return;
+  }
+  const target = findUserById(id);
+  if (!target) {
+    res.status(404).json({ error: 'not found' });
+    return;
+  }
+  const raw = req.body?.ident;
+  if (raw != null && typeof raw !== 'string') {
+    res.status(400).json({ error: 'ident must be a string' });
+    return;
+  }
+  const value = (raw ?? '').trim();
+  if (value && !isValidIdentOverride(value)) {
+    res.status(400).json({
+      error: `ident must start with a letter or number and use only letters, numbers, . _ - (max ${MAX_IDENT_LENGTH})`,
+    });
+    return;
+  }
+  const next = value || null;
+  // Two members answering the same ident is the exact ambiguity the identd
+  // exists to remove, so refuse the collision. Compared case-insensitively
+  // (an operator reading a ban list won't distinguish Bob from bob) and
+  // against every other account's EFFECTIVE ident, not just the stored
+  // overrides — most accounts derive theirs from the username.
+  const candidate = deriveIdent({
+    nodeMode: false,
+    accountUsername: target.username,
+    accountIdent: next,
+  }).toLowerCase();
+  const clash = listUsers().find(
+    (u) => u.id !== id && effectiveIdent(u).toLowerCase() === candidate,
+  );
+  if (clash) {
+    res.status(409).json({ error: `that ident is already in use by ${clash.username}` });
+    return;
+  }
+  setUserIdent(id, next);
+  const updated = findUserById(id)!;
+  // Deliberately no reconnect: the ircd asks for the ident once, during
+  // registration, so live connections keep the one they registered with until
+  // they next connect. Saying so beats silently doing nothing.
+  res.json({
+    ok: true,
+    ident: updated.ident,
+    effectiveIdent: effectiveIdent(updated),
+    appliesOnNextConnect: true,
   });
 });
 

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -18,7 +18,7 @@ import ircManager from '../services/ircManager.js';
 import { presenceDiagnostics } from '../services/wsHub.js';
 import { isIdentdEnabled, isOidentdFileEnabled } from '../services/identd.js';
 import { isNodeMode } from '../utils/edition.js';
-import { deriveIdent, isValidIdentOverride, MAX_IDENT_LENGTH } from '../utils/ident.js';
+import { deriveIdent, isValidIdentOverride, MAX_IDENT_LENGTH } from '../../shared/ident.js';
 import adminUploadersRouter from './adminUploaders.js';
 import adminNetworksRouter from './adminNetworks.js';
 
@@ -76,8 +76,20 @@ function effectiveIdent(u: User): string {
 }
 
 router.get('/users', (_req: Request, res: Response) => {
+  const all = listUsers();
+  // Accounts are only unique as USERNAMES, which are looser than idents (spaces,
+  // case, 64 chars) — so two of them can legitimately derive one ident, and no
+  // signup path consults idents. The PUT below refuses to CREATE a collision,
+  // but it can't prevent one arriving with a new account, and a silent duplicate
+  // is precisely the ambiguity this feature exists to remove. Count them here so
+  // the panel can show the operator which rows to settle with an override.
+  const identCounts = new Map<string, number>();
+  for (const u of all) {
+    const key = effectiveIdent(u).toLowerCase();
+    identCounts.set(key, (identCounts.get(key) ?? 0) + 1);
+  }
   res.json({
-    users: listUsers().map((u) => ({
+    users: all.map((u) => ({
       id: u.id,
       username: u.username,
       role: u.role,
@@ -89,6 +101,9 @@ router.get('/users', (_req: Request, res: Response) => {
       // re-deriving the rule in the client.
       ident: u.ident,
       effectiveIdent: effectiveIdent(u),
+      // Another account answers this same ident — neither is attributable until
+      // the operator assigns one of them something else.
+      identConflict: (identCounts.get(effectiveIdent(u).toLowerCase()) ?? 0) > 1,
     })),
     // Whether either ident mode is running. When neither is, the idents above
     // are inert — the UI says so rather than implying networks see them. (The
@@ -134,21 +149,29 @@ router.put('/users/:id/ident', (req: Request, res: Response) => {
   }
   const next = value || null;
   // Two members answering the same ident is the exact ambiguity the identd
-  // exists to remove, so refuse the collision. Compared case-insensitively
-  // (an operator reading a ban list won't distinguish Bob from bob) and
-  // against every other account's EFFECTIVE ident, not just the stored
-  // overrides — most accounts derive theirs from the username.
-  const candidate = deriveIdent({
-    nodeMode: false,
-    accountUsername: target.username,
-    accountIdent: next,
-  }).toLowerCase();
-  const clash = listUsers().find(
-    (u) => u.id !== id && effectiveIdent(u).toLowerCase() === candidate,
-  );
-  if (clash) {
-    res.status(409).json({ error: `that ident is already in use by ${clash.username}` });
-    return;
+  // exists to remove, so refuse to CREATE one. Compared case-insensitively (an
+  // operator reading a ban list won't distinguish Bob from bob) and against
+  // every other account's EFFECTIVE ident, not just the stored overrides —
+  // most accounts derive theirs from the username.
+  //
+  // Clearing is exempt. The cleared value is the account's own default, which
+  // the admin never chose and can't edit, so refusing it would trap the
+  // override permanently — there'd be no way back to the default once some
+  // other account's ident happened to match it. A duplicate that arises this
+  // way is reported by identConflict above rather than made unfixable here.
+  if (next) {
+    const candidate = deriveIdent({
+      nodeMode: false,
+      accountUsername: target.username,
+      accountIdent: next,
+    }).toLowerCase();
+    const clash = listUsers().find(
+      (u) => u.id !== id && effectiveIdent(u).toLowerCase() === candidate,
+    );
+    if (clash) {
+      res.status(409).json({ error: `that ident is already in use by ${clash.username}` });
+      return;
+    }
   }
   setUserIdent(id, next);
   const updated = findUserById(id)!;

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -32,7 +32,7 @@ import { effectiveSetting, effectiveSettings } from './settingsService.js';
 import { APP_NAME, APP_VERSION } from '../utils/userAgent.js';
 import { findUserById } from '../db/users.js';
 import { isNodeMode } from '../utils/edition.js';
-import { deriveIdent } from '../utils/ident.js';
+import { deriveIdent } from '../../shared/ident.js';
 import { registerIdent, unregisterIdent, isIdentdEnabled, isOidentdFileEnabled } from './identd.js';
 import { MESSAGE_MAX_BYTES, partitionMultiline, reassembleMultiline } from './messageSplit.js';
 import type { MultilineLimits } from './messageSplit.js';
@@ -1380,7 +1380,7 @@ export class IrcConnection {
         if (!localPort || !remotePort) return;
         // The ident comes from the ACCOUNT, not from this network's username or
         // nick — those are the user's to retype at will, and an ident a user can
-        // choose can't attribute anything (#643). See utils/ident.ts.
+        // choose can't attribute anything (#643). See shared/ident.ts.
         const account = findUserById(this.network.user_id);
         this.identdId = registerIdent({
           localAddress: socket.localAddress || '',

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1378,6 +1378,10 @@ export class IrcConnection {
         const localPort = socket?.localPort;
         const remotePort = socket?.remotePort;
         if (!localPort || !remotePort) return;
+        // The ident comes from the ACCOUNT, not from this network's username or
+        // nick — those are the user's to retype at will, and an ident a user can
+        // choose can't attribute anything (#643). See utils/ident.ts.
+        const account = findUserById(this.network.user_id);
         this.identdId = registerIdent({
           localAddress: socket.localAddress || '',
           localPort,
@@ -1385,9 +1389,8 @@ export class IrcConnection {
           remotePort,
           ident: deriveIdent({
             nodeMode: isNodeMode(),
-            accountUsername: findUserById(this.network.user_id)?.username || '',
-            networkUsername: this.network.username,
-            nick: this.network.nick,
+            accountUsername: account?.username || '',
+            accountIdent: account?.ident || null,
           }),
         });
       },

--- a/server/utils/ident.test.ts
+++ b/server/utils/ident.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { deriveIdent } from './ident.js';
+import { deriveIdent, isValidIdentOverride } from './ident.js';
 
 describe('deriveIdent', () => {
   it('node edition surfaces the global account id from the acct-<id> username', () => {
@@ -10,64 +10,72 @@ describe('deriveIdent', () => {
       deriveIdent({
         nodeMode: true,
         accountUsername: 'acct-42',
-        networkUsername: 'whatever',
-        nick: 'alice',
       }),
     ).toBe('lu42');
   });
 
-  it('node edition ignores the per-network username (uniqueness is forced)', () => {
-    // Two users who both picked the network username "bob" still get distinct
-    // idents, because node edition keys off the account, not their choice.
-    expect(
-      deriveIdent({
-        nodeMode: true,
-        accountUsername: 'acct-7',
-        networkUsername: 'bob',
-        nick: 'bob',
-      }),
-    ).toBe('lu7');
-    expect(
-      deriveIdent({
-        nodeMode: true,
-        accountUsername: 'acct-8',
-        networkUsername: 'bob',
-        nick: 'bob',
-      }),
-    ).toBe('lu8');
+  it('node edition ignores an admin ident override (the control plane owns it)', () => {
+    // A cell-local override would break the fleet-wide uniqueness the hosted
+    // ident guarantees, so node edition never honours one.
+    expect(deriveIdent({ nodeMode: true, accountUsername: 'acct-42', accountIdent: 'alice' })).toBe(
+      'lu42',
+    );
+  });
+
+  it('node edition gives two accounts distinct idents (uniqueness is forced)', () => {
+    expect(deriveIdent({ nodeMode: true, accountUsername: 'acct-7' })).toBe('lu7');
+    expect(deriveIdent({ nodeMode: true, accountUsername: 'acct-8' })).toBe('lu8');
   });
 
   it('node edition falls back safely for a non-acct username (e.g. the operator)', () => {
-    expect(
-      deriveIdent({ nodeMode: true, accountUsername: 'brad', networkUsername: null, nick: 'brad' }),
-    ).toBe('brad');
+    expect(deriveIdent({ nodeMode: true, accountUsername: 'brad' })).toBe('brad');
   });
 
-  it('standalone uses the configured network username', () => {
-    expect(
-      deriveIdent({
-        nodeMode: false,
-        accountUsername: 'acct-42',
-        networkUsername: 'alice',
-        nick: 'al',
-      }),
-    ).toBe('alice');
+  it('standalone uses the lurker account name', () => {
+    expect(deriveIdent({ nodeMode: false, accountUsername: 'alice' })).toBe('alice');
   });
 
-  it('standalone falls back to the nick when no username is set', () => {
-    expect(
-      deriveIdent({
-        nodeMode: false,
-        accountUsername: 'acct-42',
-        networkUsername: null,
-        nick: 'al',
-      }),
-    ).toBe('al');
+  it('standalone prefers an admin-assigned override', () => {
+    expect(deriveIdent({ nodeMode: false, accountUsername: 'alice', accountIdent: 'ali' })).toBe(
+      'ali',
+    );
+  });
+
+  it('standalone ignores a blank/whitespace override', () => {
+    expect(deriveIdent({ nodeMode: false, accountUsername: 'alice', accountIdent: '  ' })).toBe(
+      'alice',
+    );
+    expect(deriveIdent({ nodeMode: false, accountUsername: 'alice', accountIdent: null })).toBe(
+      'alice',
+    );
   });
 
   it('strips ident-invalid characters', () => {
-    expect(
-      deriveIdent({ nodeMode: false, accountUsername: '', networkUsername: 'a b@c!', nick: 'x' }),
-    ).toBe('abc');
+    expect(deriveIdent({ nodeMode: false, accountUsername: 'a b@c!' })).toBe('abc');
+  });
+
+  it('truncates to 16 characters', () => {
+    expect(deriveIdent({ nodeMode: false, accountUsername: 'a'.repeat(30) })).toBe('a'.repeat(16));
+  });
+
+  it('never returns empty — an unusable name still identifies as "user"', () => {
+    expect(deriveIdent({ nodeMode: false, accountUsername: '!!!' })).toBe('user');
+    expect(deriveIdent({ nodeMode: false, accountUsername: '' })).toBe('user');
+  });
+});
+
+describe('isValidIdentOverride', () => {
+  it('accepts ident-legal values', () => {
+    for (const v of ['alice', 'a', 'a.b_c-d', 'x9', 'A'.repeat(16)]) {
+      expect(isValidIdentOverride(v)).toBe(true);
+    }
+  });
+
+  it('rejects values an ircd (or the operator reading it) would choke on', () => {
+    // Rejected rather than silently sanitized: quietly reshaping "bob smith"
+    // into "bobsmith" would hand the admin an identity they didn't type.
+    for (const v of ['', ' ', 'bob smith', 'bob@host', '-bob', '.bob', 'a'.repeat(17), 'héllo']) {
+      expect(isValidIdentOverride(v)).toBe(false);
+    }
   });
 });

--- a/server/utils/ident.ts
+++ b/server/utils/ident.ts
@@ -4,26 +4,50 @@
 // Derives the IRC ident (the user part of nick!ident@host) that the built-in
 // identd reports for a connection.
 //
+// The ident is an ATTRIBUTION handle, not a preference. On a multi-user instance
+// every member shares one IP, so `nick!ident@shared.host` is the only thing a
+// network operator can use to tell them apart — to ban one member without
+// banning everyone, or to tell the instance's admin WHO did something. That only
+// works if the ident is assigned rather than chosen: a self-service ident lets
+// one member wear another member's ident, or churn it to slip a ban, which
+// defeats the point of running an identd at all (#643). So it comes from the
+// LURKER ACCOUNT, never from the per-network username or nick the user types.
+//
 //   node edition — the ident must identify the GLOBAL account, so it's stable
 //     across cell moves and unique fleet-wide. Cells are provisioned with the
 //     account username `acct-<controlPlaneAccountId>`, so we surface
 //     `lu<controlPlaneAccountId>` ("lu" = Lurker user, so a network operator can
 //     tell at a glance it's one of ours). Using the cell-local user id would
-//     change if an account were ever migrated to another cell.
-//   standalone — the operator's per-network choice wins (the configured
-//     username, else the nick), matching how a single-user bouncer behaves.
+//     change if an account were ever migrated to another cell. The per-user
+//     override is IGNORED here — the control plane owns hosted identity, and a
+//     cell-side override would break fleet-wide uniqueness.
+//   standalone — the Lurker account username, unless an admin has set an
+//     explicit override for that account (users.ident, admin panel → users).
+//     Admin-only by design: it's the operator's call who is called what.
+
+/** Max ident length. Longer values are truncated by most ircds anyway. */
+export const MAX_IDENT_LENGTH = 16;
 
 const NON_IDENT_CHARS = /[^A-Za-z0-9._-]/g;
 
-function sanitizeIdent(value: string): string {
-  return value.replace(NON_IDENT_CHARS, '').slice(0, 16);
+export function sanitizeIdent(value: string): string {
+  return value.replace(NON_IDENT_CHARS, '').slice(0, MAX_IDENT_LENGTH);
+}
+
+// What an admin may type as a per-user override. Stricter than sanitizeIdent
+// (which silently drops whatever it can't use): the admin should be told their
+// value is unusable rather than have it quietly reshaped into a different
+// identity. Must start alphanumeric — a leading '-' reads as a flag to
+// downstream tooling and some ircds reject it outright.
+export function isValidIdentOverride(value: string): boolean {
+  return new RegExp(`^[A-Za-z0-9][A-Za-z0-9._-]{0,${MAX_IDENT_LENGTH - 1}}$`).test(value);
 }
 
 export function deriveIdent(opts: {
   nodeMode: boolean;
   accountUsername: string;
-  networkUsername: string | null;
-  nick: string;
+  /** Admin-set per-account override (users.ident). Standalone only. */
+  accountIdent?: string | null;
 }): string {
   if (opts.nodeMode) {
     const m = /^acct-(\d+)$/.exec(opts.accountUsername.trim());
@@ -32,5 +56,7 @@ export function deriveIdent(opts: {
     // ident-safe rather than inventing an id.
     return sanitizeIdent(opts.accountUsername) || 'user';
   }
-  return sanitizeIdent(opts.networkUsername || opts.nick) || 'user';
+  return (
+    sanitizeIdent((opts.accountIdent || '').trim()) || sanitizeIdent(opts.accountUsername) || 'user'
+  );
 }

--- a/shared/ident.test.ts
+++ b/shared/ident.test.ts
@@ -54,6 +54,17 @@ describe('deriveIdent', () => {
     expect(deriveIdent({ nodeMode: false, accountUsername: 'a b@c!' })).toBe('abc');
   });
 
+  it('strips a leading -, . or _ so the derived path can only emit typeable idents', () => {
+    // Usernames may legally start with these (server/utils/username.ts); idents
+    // may not, and an admin is blocked from typing one — the two paths have to
+    // agree about what an ident is.
+    expect(deriveIdent({ nodeMode: false, accountUsername: '-bob' })).toBe('bob');
+    expect(deriveIdent({ nodeMode: false, accountUsername: '._x' })).toBe('x');
+    expect(isValidIdentOverride(deriveIdent({ nodeMode: false, accountUsername: '-bob' }))).toBe(
+      true,
+    );
+  });
+
   it('truncates to 16 characters', () => {
     expect(deriveIdent({ nodeMode: false, accountUsername: 'a'.repeat(30) })).toBe('a'.repeat(16));
   });
@@ -61,6 +72,28 @@ describe('deriveIdent', () => {
   it('never returns empty — an unusable name still identifies as "user"', () => {
     expect(deriveIdent({ nodeMode: false, accountUsername: '!!!' })).toBe('user');
     expect(deriveIdent({ nodeMode: false, accountUsername: '' })).toBe('user');
+  });
+});
+
+// The one property that ties the two halves together: whatever we ANSWER on the
+// wire is something an admin could also have typed.
+describe('deriveIdent output is always a legal override', () => {
+  it('holds for the usernames the account rules allow', () => {
+    for (const username of [
+      'alice',
+      '-bob',
+      '.hidden',
+      '_x',
+      'bob smith',
+      'a'.repeat(30),
+      '!!!',
+      '',
+      'Mixed.Case-99',
+    ]) {
+      expect(
+        isValidIdentOverride(deriveIdent({ nodeMode: false, accountUsername: username })),
+      ).toBe(true);
+    }
   });
 });
 

--- a/shared/ident.ts
+++ b/shared/ident.ts
@@ -24,14 +24,35 @@
 //   standalone — the Lurker account username, unless an admin has set an
 //     explicit override for that account (users.ident, admin panel → users).
 //     Admin-only by design: it's the operator's call who is called what.
+//
+// UNIQUENESS IS NOT GUARANTEED on the standalone derived path, and deliberately
+// isn't faked. Usernames are unique but far looser than idents (spaces allowed,
+// case-sensitive, up to 64 chars — server/utils/username.ts), so "bob smith" and
+// "bobsmith" both derive `bobsmith`, as do "Bob"/"bob" and any two usernames
+// sharing their first 16 characters. Resolving that HERE would mean mixing in
+// something like the row id when a clash appears, which makes an account's ident
+// change when an unrelated account signs up — and an ident that moves is worse
+// than one that's ambiguous, because bans and ACLs are keyed on it. So the
+// derivation stays stable and pure, the admin API refuses to CREATE a collision,
+// and the admin panel flags any that exist for the operator to settle with an
+// override (routes/admin.ts).
 
 /** Max ident length. Longer values are truncated by most ircds anyway. */
 export const MAX_IDENT_LENGTH = 16;
 
 const NON_IDENT_CHARS = /[^A-Za-z0-9._-]/g;
+// Usernames may legally start with '-', '.' or '_' (see server/utils/username.ts),
+// so the derived path has to trim them too — a leading '-' reads as a flag to
+// downstream tooling and some ircds reject it. Without this, an account named
+// '-bob' would be ANSWERED an ident that isValidIdentOverride refuses to let an
+// admin type, and the two paths would disagree about what an ident is.
+const LEADING_NON_ALNUM = /^[._-]+/;
 
 export function sanitizeIdent(value: string): string {
-  return value.replace(NON_IDENT_CHARS, '').slice(0, MAX_IDENT_LENGTH);
+  return value
+    .replace(NON_IDENT_CHARS, '')
+    .replace(LEADING_NON_ALNUM, '')
+    .slice(0, MAX_IDENT_LENGTH);
 }
 
 // What an admin may type as a per-user override. Stricter than sanitizeIdent
@@ -39,6 +60,9 @@ export function sanitizeIdent(value: string): string {
 // value is unusable rather than have it quietly reshaped into a different
 // identity. Must start alphanumeric — a leading '-' reads as a flag to
 // downstream tooling and some ircds reject it outright.
+//
+// Invariant worth keeping: every deriveIdent() result also satisfies this, so
+// an ident nobody could type is never one we answer.
 export function isValidIdentOverride(value: string): boolean {
   return new RegExp(`^[A-Za-z0-9][A-Za-z0-9._-]{0,${MAX_IDENT_LENGTH - 1}}$`).test(value);
 }

--- a/shared/ident.ts
+++ b/shared/ident.ts
@@ -36,6 +36,22 @@
 // derivation stays stable and pure, the admin API refuses to CREATE a collision,
 // and the admin panel flags any that exist for the operator to settle with an
 // override (routes/admin.ts).
+//
+// SCOPE OF THE GUARANTEE — it covers the ident an identd ANSWERS, and nothing
+// else. The `USER` command still carries the account holder's own per-network
+// username (ircConnection.ts, `username: this.network.username || nick`), and on
+// a network that never completes an ident lookup — port 113 filtered, the query
+// timed out, or no ident mode enabled — the ircd falls back to that value with a
+// tilde: `~whatever-they-typed`. So a member CAN put a neighbour's ident in their
+// network username and appear as `alice!~bob@shared.host` there. The leading
+// tilde is IRC's standard "unverified, the client just claimed this" marker and
+// makes the two distinct both to an operator reading a mask and to any ban keyed
+// on one, which is why this is left as-is (operator's call, 2026-07-25): every
+// IRC client in existence sends a user-chosen USER value, and constraining it
+// would diverge from that for a string the network already labels untrusted. The
+// honest summary is narrower than "a member can't wear a neighbour's identity":
+// when an identd answers, the ident is assigned and trustworthy; when none does,
+// nothing on that connection is verified anyway.
 
 /** Max ident length. Longer values are truncated by most ircds anyway. */
 export const MAX_IDENT_LENGTH = 16;

--- a/vue_client/src/components/admin-panes/UsersPane.vue
+++ b/vue_client/src/components/admin-panes/UsersPane.vue
@@ -65,7 +65,14 @@
         </span>
 
         <!-- Inline ident editor for this row. Empty input = clear the override
-             and go back to deriving it from the account name. -->
+             and go back to deriving it from the account name.
+
+             The placeholder is the DERIVED ident, not the username: the two
+             differ whenever the username isn't ident-legal ("bob smith" →
+             "bobsmith", a 20-char name → 16), so showing the username would
+             both misstate what clearing produces and hand the admin a string
+             that 400s if they retype it. effectiveIdent equals the derived
+             default whenever no override is set — exactly when it's visible. -->
         <form
           v-if="canAssignIdents && editingIdentFor === u.id"
           class="ident-edit"
@@ -75,7 +82,7 @@
             <span>ident</span>
             <input
               v-model="identDraft"
-              :placeholder="u.username"
+              :placeholder="u.effectiveIdent"
               :maxlength="MAX_IDENT_LENGTH"
               spellcheck="false"
               autocapitalize="off"

--- a/vue_client/src/components/admin-panes/UsersPane.vue
+++ b/vue_client/src/components/admin-panes/UsersPane.vue
@@ -15,45 +15,100 @@
       Everyone with an account on this instance. The last admin and your own account can't be
       deleted.
     </p>
+    <p v-if="!config.isNode" class="section-desc">
+      Each account's <strong>ident</strong> is the name networks see in
+      <code>nick!ident@host</code>. Everyone here shares this server's IP, so it's what lets an
+      operator tell your members apart — assigned by you, not chosen by them. It defaults to the
+      account name.
+    </p>
+    <p v-if="adminStore.usersLoaded && !adminStore.identdEnabled" class="muted small">
+      No ident daemon is running on this server, so networks can't ask for these idents yet — set
+      <code>LURKER_IDENTD_ENABLED</code> (or <code>LURKER_OIDENTD_FILE</code>) to turn one on.
+    </p>
     <p v-if="adminError" class="error inline">{{ adminError }}</p>
 
     <ul v-if="users.length" class="device-list">
-      <li v-for="u in users" :key="u.id" class="device user-row">
+      <li v-for="u in users" :key="u.id" class="device stacked user-row">
         <span class="ua">
           {{ u.username }}
           <span v-if="u.role === 'admin'" class="role-tag">admin</span>
           <span v-if="u.isPaused" class="paused-tag">paused</span>
+          <span
+            v-if="u.effectiveIdent"
+            class="ident-tag"
+            :title="
+              u.ident
+                ? 'ident assigned by an admin'
+                : 'ident derived from the account name — networks see this in nick!ident@host'
+            "
+          >
+            ident {{ u.effectiveIdent }}
+          </span>
+          <span
+            class="last-seen"
+            :title="`joined ${u.createdAt}${u.lastSeenAt ? ` · last seen ${u.lastSeenAt}` : ''}`"
+          >
+            <template v-if="u.lastSeenAt">last seen {{ formatRelative(u.lastSeenAt) }}</template>
+            <template v-else>joined {{ formatRelative(u.createdAt) }}</template>
+          </span>
         </span>
-        <span
-          class="last-seen"
-          :title="`joined ${u.createdAt}${u.lastSeenAt ? ` · last seen ${u.lastSeenAt}` : ''}`"
-        >
-          <template v-if="u.lastSeenAt">last seen {{ formatRelative(u.lastSeenAt) }}</template>
-          <template v-else>joined {{ formatRelative(u.createdAt) }}</template>
-        </span>
-        <button
-          v-if="!config.isNode"
-          class="link"
-          :disabled="u.id === auth.user?.id || adminBusy"
-          :title="
-            u.id === auth.user?.id
-              ? 'cannot pause yourself'
-              : u.isPaused
-                ? 'resume — reconnect to IRC'
-                : 'pause — disconnect from IRC and make read-only'
-          "
-          @click="u.isPaused ? onResumeUser(u) : onPauseUser(u)"
-        >
-          {{ u.isPaused ? 'resume' : 'pause' }}
-        </button>
-        <button
-          class="link danger"
-          :disabled="u.id === auth.user?.id || adminBusy"
-          :title="u.id === auth.user?.id ? 'cannot delete yourself' : 'delete user'"
-          @click="onDeleteUser(u)"
-        >
-          delete
-        </button>
+
+        <!-- Inline ident editor for this row. Empty input = clear the override
+             and go back to deriving it from the account name. -->
+        <form v-if="editingIdentFor === u.id" class="ident-edit" @submit.prevent="onSaveIdent(u)">
+          <label>
+            <span>ident</span>
+            <input
+              v-model="identDraft"
+              :placeholder="u.username"
+              maxlength="16"
+              spellcheck="false"
+              autocapitalize="off"
+            />
+          </label>
+          <button type="submit" class="link" :disabled="adminBusy">save</button>
+          <button type="button" class="link" :disabled="adminBusy" @click="editingIdentFor = null">
+            cancel
+          </button>
+          <small class="muted">
+            Leave blank to use the account name. Applies the next time they connect.
+          </small>
+        </form>
+
+        <div class="row-actions">
+          <button
+            v-if="!config.isNode"
+            class="link"
+            :disabled="adminBusy"
+            title="set the ident networks see for this account"
+            @click="onEditIdent(u)"
+          >
+            ident
+          </button>
+          <button
+            v-if="!config.isNode"
+            class="link"
+            :disabled="u.id === auth.user?.id || adminBusy"
+            :title="
+              u.id === auth.user?.id
+                ? 'cannot pause yourself'
+                : u.isPaused
+                  ? 'resume — reconnect to IRC'
+                  : 'pause — disconnect from IRC and make read-only'
+            "
+            @click="u.isPaused ? onResumeUser(u) : onPauseUser(u)"
+          >
+            {{ u.isPaused ? 'resume' : 'pause' }}
+          </button>
+          <button
+            class="link danger"
+            :disabled="u.id === auth.user?.id || adminBusy"
+            :title="u.id === auth.user?.id ? 'cannot delete yourself' : 'delete user'"
+            @click="onDeleteUser(u)"
+          >
+            delete
+          </button>
+        </div>
       </li>
     </ul>
     <p v-else-if="adminStore.usersLoaded" class="muted small">No users.</p>
@@ -70,14 +125,40 @@ import { formatRelative } from '../../utils/timestamp.js';
 
 const auth = useAuthStore();
 const adminStore = useAdminStore();
-// Pause/resume is a self-hosted control only — in node edition the control plane
-// owns account state, so the buttons are hidden.
+// Pause/resume and the ident are self-hosted controls only — in node edition the
+// control plane owns account state and derives idents from the hosted account id,
+// so those buttons are hidden (their routes 409 there anyway).
 const config = useConfigStore();
 
 const users = computed(() => adminStore.users);
 
 const adminError = ref('');
 const adminBusy = ref(false);
+
+// id of the row whose ident is being edited (one at a time), plus its draft.
+const editingIdentFor = ref<number | null>(null);
+const identDraft = ref('');
+
+function onEditIdent(user: AdminUser) {
+  adminError.value = '';
+  // Seed with the override only — showing the derived value would make "save"
+  // silently pin an ident that's currently just tracking the account name.
+  identDraft.value = user.ident || '';
+  editingIdentFor.value = editingIdentFor.value === user.id ? null : user.id;
+}
+
+async function onSaveIdent(user: AdminUser) {
+  adminError.value = '';
+  adminBusy.value = true;
+  try {
+    await adminStore.setUserIdent(user.id, identDraft.value.trim() || null);
+    editingIdentFor.value = null;
+  } catch (e: any) {
+    adminError.value = e.message || 'failed to set ident';
+  } finally {
+    adminBusy.value = false;
+  }
+}
 
 onMounted(() => {
   // Refetch on every pane activation. The store cache stays correct for THIS
@@ -136,18 +217,44 @@ async function onResumeUser(user: AdminUser) {
 
 <style src="../settings-panes/panes.css"></style>
 <style scoped>
+/* Vue's whitespace: 'condense' drops the whitespace-only text nodes between
+   these spans, so the gap has to come from flex — same workaround as
+   ApiTokensPane's .ua. */
+.user-row .ua {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+.user-row .ident-tag {
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  padding: 0 var(--space-2);
+}
+.user-row .ident-edit {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+.user-row .ident-edit label {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+.user-row .ident-edit input {
+  width: 12ch;
+}
 .user-row .role-tag {
   color: var(--accent);
   border: 1px solid var(--accent);
   padding: 0 var(--space-2);
-  margin-left: var(--space-3);
   text-transform: uppercase;
 }
 .user-row .paused-tag {
   color: var(--warn);
   border: 1px solid var(--warn);
   padding: 0 var(--space-2);
-  margin-left: var(--space-3);
   text-transform: uppercase;
 }
 </style>

--- a/vue_client/src/components/admin-panes/UsersPane.vue
+++ b/vue_client/src/components/admin-panes/UsersPane.vue
@@ -15,15 +15,19 @@
       Everyone with an account on this instance. The last admin and your own account can't be
       deleted.
     </p>
-    <p v-if="!config.isNode" class="section-desc">
+    <p v-if="canAssignIdents" class="section-desc">
       Each account's <strong>ident</strong> is the name networks see in
       <code>nick!ident@host</code>. Everyone here shares this server's IP, so it's what lets an
       operator tell your members apart — assigned by you, not chosen by them. It defaults to the
       account name.
     </p>
-    <p v-if="adminStore.usersLoaded && !adminStore.identdEnabled" class="muted small">
-      No ident daemon is running on this server, so networks can't ask for these idents yet — set
-      <code>LURKER_IDENTD_ENABLED</code> (or <code>LURKER_OIDENTD_FILE</code>) to turn one on.
+    <!-- Nothing on this server answers ident lookups, so the idents would be
+         inert: one line saying how to turn one on, and the rest of the ident
+         surface stays out of the way (most self-hosts never enable it). -->
+    <p v-else-if="adminStore.usersLoaded && !config.isNode" class="muted small">
+      Networks can't ask this server who its users are — set
+      <code>LURKER_IDENTD_ENABLED</code> (or <code>LURKER_OIDENTD_FILE</code>) to run an ident
+      daemon, and each account gets an ident you can assign here.
     </p>
     <p v-if="adminError" class="error inline">{{ adminError }}</p>
 
@@ -34,7 +38,7 @@
           <span v-if="u.role === 'admin'" class="role-tag">admin</span>
           <span v-if="u.isPaused" class="paused-tag">paused</span>
           <span
-            v-if="u.effectiveIdent"
+            v-if="adminStore.identdEnabled && u.effectiveIdent"
             class="ident-tag"
             :title="
               u.ident
@@ -55,7 +59,11 @@
 
         <!-- Inline ident editor for this row. Empty input = clear the override
              and go back to deriving it from the account name. -->
-        <form v-if="editingIdentFor === u.id" class="ident-edit" @submit.prevent="onSaveIdent(u)">
+        <form
+          v-if="canAssignIdents && editingIdentFor === u.id"
+          class="ident-edit"
+          @submit.prevent="onSaveIdent(u)"
+        >
           <label>
             <span>ident</span>
             <input
@@ -77,7 +85,7 @@
 
         <div class="row-actions">
           <button
-            v-if="!config.isNode"
+            v-if="canAssignIdents"
             class="link"
             :disabled="adminBusy"
             title="set the ident networks see for this account"
@@ -131,6 +139,14 @@ const adminStore = useAdminStore();
 const config = useConfigStore();
 
 const users = computed(() => adminStore.users);
+
+// Two separate questions, deliberately not collapsed into one flag:
+//   • does anything answer ident lookups? — if not, the idents are inert and the
+//     whole surface (per-row tag included) stays hidden.
+//   • may they be ASSIGNED here? — standalone only; a hosted cell answers with
+//     `lu<accountId>` from the control plane, so the tag is worth showing there
+//     but the editor isn't (its route 409s).
+const canAssignIdents = computed(() => adminStore.identdEnabled && !config.isNode);
 
 const adminError = ref('');
 const adminBusy = ref(false);

--- a/vue_client/src/components/admin-panes/UsersPane.vue
+++ b/vue_client/src/components/admin-panes/UsersPane.vue
@@ -49,6 +49,13 @@
             ident {{ u.effectiveIdent }}
           </span>
           <span
+            v-if="adminStore.identdEnabled && u.identConflict"
+            class="conflict-tag"
+            title="another account answers this same ident — until one of them is given its own, a network can't tell these two apart"
+          >
+            duplicate
+          </span>
+          <span
             class="last-seen"
             :title="`joined ${u.createdAt}${u.lastSeenAt ? ` · last seen ${u.lastSeenAt}` : ''}`"
           >
@@ -69,7 +76,7 @@
             <input
               v-model="identDraft"
               :placeholder="u.username"
-              maxlength="16"
+              :maxlength="MAX_IDENT_LENGTH"
               spellcheck="false"
               autocapitalize="off"
             />
@@ -130,6 +137,9 @@ import { useAdminStore } from '../../stores/admin.js';
 import { useConfigStore } from '../../stores/config.js';
 import type { AdminUser } from '../../stores/admin.js';
 import { formatRelative } from '../../utils/timestamp.js';
+// Same module the server derives and validates idents with, so the input's cap
+// can't drift from what the route accepts.
+import { MAX_IDENT_LENGTH } from '../../../../shared/ident.js';
 
 const auth = useAuthStore();
 const adminStore = useAdminStore();
@@ -233,15 +243,6 @@ async function onResumeUser(user: AdminUser) {
 
 <style src="../settings-panes/panes.css"></style>
 <style scoped>
-/* Vue's whitespace: 'condense' drops the whitespace-only text nodes between
-   these spans, so the gap has to come from flex — same workaround as
-   ApiTokensPane's .ua. */
-.user-row .ua {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-3);
-}
 .user-row .ident-tag {
   color: var(--fg-muted);
   border: 1px solid var(--border);
@@ -264,6 +265,12 @@ async function onResumeUser(user: AdminUser) {
 .user-row .role-tag {
   color: var(--accent);
   border: 1px solid var(--accent);
+  padding: 0 var(--space-2);
+  text-transform: uppercase;
+}
+.user-row .conflict-tag {
+  color: var(--bad);
+  border: 1px solid currentcolor;
   padding: 0 var(--space-2);
   text-transform: uppercase;
 }

--- a/vue_client/src/stores/admin.test.ts
+++ b/vue_client/src/stores/admin.test.ts
@@ -90,3 +90,56 @@ describe('admin store — refetch race guard (#613)', () => {
     expect(store.usersLoaded).toBe(true);
   });
 });
+
+// The ident write reports on the WRITE, not on the bookkeeping refetch that
+// follows it (#643). Getting this backwards tells an admin their save failed
+// when it landed, and invites them to retry a write that already applied.
+describe('admin store — setUserIdent', () => {
+  it('resolves when the write succeeds even if the follow-up refetch fails', async () => {
+    const store = useAdminStore();
+    store.users = [user(1, 'alice')];
+    h.api.mockImplementation((_url: string, opts?: { method?: string }) =>
+      opts?.method === 'PUT'
+        ? Promise.resolve({ ok: true, ident: 'ali', effectiveIdent: 'ali' })
+        : Promise.reject(new Error('network down')),
+    );
+
+    await expect(store.setUserIdent(1, 'ali')).resolves.toMatchObject({ effectiveIdent: 'ali' });
+    // The row still shows the value the write returned...
+    expect(store.users[0]).toMatchObject({ ident: 'ali', effectiveIdent: 'ali' });
+    // ...and no error is left on the SHARED store field for the next pane to
+    // render as its own failure.
+    expect(store.error).toBe('');
+  });
+
+  it('still rejects when the write itself fails', async () => {
+    const store = useAdminStore();
+    store.users = [user(1, 'alice')];
+    h.api.mockRejectedValue(new Error('that ident is already in use by bob'));
+    await expect(store.setUserIdent(1, 'bob')).rejects.toThrow(/already in use/);
+    expect(store.users[0].ident).toBeUndefined();
+  });
+
+  it('refreshes conflict flags from the server after a successful write', async () => {
+    // Assigning an override can clear the duplicate badge on the OTHER side of a
+    // clash, which only a refetch can know.
+    const store = useAdminStore();
+    store.users = [
+      { ...user(1, 'bob smith'), effectiveIdent: 'bobsmith', identConflict: true },
+      { ...user(2, 'bobsmith'), effectiveIdent: 'bobsmith', identConflict: true },
+    ];
+    h.api.mockImplementation((_url: string, opts?: { method?: string }) =>
+      opts?.method === 'PUT'
+        ? Promise.resolve({ ok: true, ident: 'bobs', effectiveIdent: 'bobs' })
+        : Promise.resolve({
+            users: [
+              { ...user(1, 'bob smith'), effectiveIdent: 'bobs', identConflict: false },
+              { ...user(2, 'bobsmith'), effectiveIdent: 'bobsmith', identConflict: false },
+            ],
+          }),
+    );
+
+    await store.setUserIdent(1, 'bobs');
+    expect(store.users.map((u) => u.identConflict)).toEqual([false, false]);
+  });
+});

--- a/vue_client/src/stores/admin.ts
+++ b/vue_client/src/stores/admin.ts
@@ -12,6 +12,10 @@ export interface AdminUser {
   createdAt: string;
   lastSeenAt?: string | null;
   isPaused?: boolean;
+  /** Admin-assigned identd override; null means "derived from the username". */
+  ident?: string | null;
+  /** What the identd actually answers for this account (#643). */
+  effectiveIdent?: string;
 }
 
 export interface AdminInvite {
@@ -43,6 +47,9 @@ export type AdminNetworkPresetInput = Omit<AdminNetworkPreset, 'id' | 'position'
 export const useAdminStore = defineStore('admin', {
   state: () => ({
     users: [] as AdminUser[],
+    // Whether an ident daemon is actually running (built-in identd or the
+    // oidentd file). False makes the per-user idents inert — the pane says so.
+    identdEnabled: false,
     invites: [] as AdminInvite[],
     uploaders: [] as AdminUploader[],
     uploaderDrivers: [] as UploaderDriver[],
@@ -74,12 +81,13 @@ export const useAdminStore = defineStore('admin', {
       const seq = ++this.usersFetchSeq;
       this.error = '';
       try {
-        const { users } = await api('/api/admin/users');
+        const { users, identdEnabled } = await api('/api/admin/users');
         // A newer fetch or a local mutation superseded this GET while it was in
         // flight — its payload is stale, so drop it rather than clobber the
         // fresher state.
         if (seq !== this.usersFetchSeq) return;
         this.users = users || [];
+        this.identdEnabled = !!identdEnabled;
         this.usersLoaded = true;
       } catch (e: any) {
         if (seq !== this.usersFetchSeq) return;
@@ -104,6 +112,19 @@ export const useAdminStore = defineStore('admin', {
       this.usersFetchSeq++;
       const u = this.users.find((x) => x.id === id);
       if (u) u.isPaused = false;
+    },
+    // Pass null (or '') to fall back to deriving the ident from the username.
+    // Patched locally rather than refetched: the response carries the resolved
+    // pair, and a refetch here would race the pane's own mount fetch.
+    async setUserIdent(id: number, ident: string | null) {
+      const res = await api(`/api/admin/users/${id}/ident`, { method: 'PUT', body: { ident } });
+      this.usersFetchSeq++;
+      const u = this.users.find((x) => x.id === id);
+      if (u) {
+        u.ident = res.ident ?? null;
+        u.effectiveIdent = res.effectiveIdent;
+      }
+      return res as { ident: string | null; effectiveIdent: string };
     },
     async fetchInvites() {
       const seq = ++this.invitesFetchSeq;

--- a/vue_client/src/stores/admin.ts
+++ b/vue_client/src/stores/admin.ts
@@ -128,8 +128,17 @@ export const useAdminStore = defineStore('admin', {
       }
       // identConflict is a property of the whole SET of accounts, not of the one
       // that changed: assigning an override can resolve a duplicate for the other
-      // side of the clash too. Only a refetch can know, so ask for one.
-      await this.fetchUsers();
+      // side of the clash too. Only a refetch can know, so ask for one — but
+      // SWALLOW its failure. The write already landed; letting a transient GET
+      // error propagate would report a successful save as a failed one and
+      // invite the admin to retry. The only casualty is a stale conflict badge
+      // until the next fetch, and the pane refetches on every mount.
+      await this.fetchUsers().catch(() => {
+        // fetchUsers sets the SHARED store error before throwing, and the other
+        // admin panes render that field — so leaving it set would surface
+        // "failed to load users" over whichever pane the admin opens next.
+        this.error = '';
+      });
       return res as { ident: string | null; effectiveIdent: string };
     },
     async fetchInvites() {

--- a/vue_client/src/stores/admin.ts
+++ b/vue_client/src/stores/admin.ts
@@ -16,6 +16,8 @@ export interface AdminUser {
   ident?: string | null;
   /** What the identd actually answers for this account (#643). */
   effectiveIdent?: string;
+  /** Another account answers this same ident — neither one attributes anything. */
+  identConflict?: boolean;
 }
 
 export interface AdminInvite {
@@ -114,8 +116,8 @@ export const useAdminStore = defineStore('admin', {
       if (u) u.isPaused = false;
     },
     // Pass null (or '') to fall back to deriving the ident from the username.
-    // Patched locally rather than refetched: the response carries the resolved
-    // pair, and a refetch here would race the pane's own mount fetch.
+    // Patches the changed row from the response so the edit lands immediately,
+    // then refetches for the conflict flags (see below).
     async setUserIdent(id: number, ident: string | null) {
       const res = await api(`/api/admin/users/${id}/ident`, { method: 'PUT', body: { ident } });
       this.usersFetchSeq++;
@@ -124,6 +126,10 @@ export const useAdminStore = defineStore('admin', {
         u.ident = res.ident ?? null;
         u.effectiveIdent = res.effectiveIdent;
       }
+      // identConflict is a property of the whole SET of accounts, not of the one
+      // that changed: assigning an override can resolve a duplicate for the other
+      // side of the clash too. Only a refetch can know, so ask for one.
+      await this.fetchUsers();
       return res as { ident: string | null; effectiveIdent: string };
     },
     async fetchInvites() {


### PR DESCRIPTION
Closes #643.

## The bug

Standalone derived the identd answer from `network.username || network.nick` — both values the account holder can retype at will. On a multi-user instance that defeats the identd: a member could answer as another member's ident, or churn it to walk away from a ban. Node/hosted was already correct (`lu<accountId>`), which is why the issue reads as "not sure how this happened" — only the standalone branch was wrong.

## What changed

- **Standalone ident = the Lurker account name.** The per-network username and nick no longer feed it at all.
- **Admin-assignable per account** — nullable `users.ident`, `PUT /api/admin/users/:id/ident`, inline editor in admin → users. Members have no route to their own; the whole surface is behind `requireAdmin`.
- **Node edition unchanged** and the override route 409s there: the control plane owns hosted identity, and a cell-local override would break fleet-wide uniqueness.
- **Collisions refused** on assignment, compared against every other account's *effective* ident (most accounts derive theirs from the username, so checking stored overrides alone would miss nearly every real collision). Ident-illegal input is rejected rather than silently reshaped into an identity the admin didn't type.
- **Duplicates surfaced, not faked away.** Usernames are looser than idents (spaces, case, 64 chars), so `bob smith` and `bobsmith` both derive `bobsmith`, and no signup path consults idents. Making the derivation collision-aware would mean mixing in the row id on a clash — which makes an account's ident *move* when an unrelated account signs up, and an ident that moves is worse than one that's ambiguous because bans are keyed on it. So the derivation stays stable and the panel flags duplicates for the operator to settle with an override.
- **UI gated on whether anything answers ident lookups.** identd is opt-in and most self-hosts never enable it; when nothing answers, the whole surface collapses to one line naming the env var.

## Behavior change

A self-host **already running identd** (opt-in, mostly multi-user) will see idents change from the network username/nick to the account name on each connection's next connect. Not backfilled from the old value — a multi-network account has no single value to backfill from, and preserving it would preserve the bug. Operator's call, made deliberately.

## Scope of the guarantee

`network.username` still rides the USER command, so on a network that never completes an ident lookup a member can still appear as `alice!~bob@host`. The leading tilde is IRC's standard "unverified" marker and every IRC client sends a user-chosen USER value, so this is left alone. `shared/ident.ts` documents the real scope: when an identd answers, the ident is assigned and trustworthy; when none does, nothing on that connection is verified anyway.

## Testing

`npm run check` clean, 2856 tests pass. New coverage: ident derivation + the invariant that every derived ident is also a legal admin-typed one; route tests for assign / clear / reject / 409-collision / duplicate-flagging; store tests for the write-vs-refetch reporting.

Two review passes (`/code-review high`) found six defects between them — derived idents that the code's own validator rejected (`-bob`), a clear-the-override path that could be refused forever, a placeholder that misstated what clearing produces, and a successful save that could report as failed. All fixed in the follow-up commits, each with a test that fails without the fix.

**Not QA'd against a live network** — the operator doesn't run identd personally and the hosted cells use their own path, so this rests on the test suite and review rather than manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
