### PR TITLE
Advertise the effective upload cap so clients stop guessing (#627)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,12 +112,15 @@ VAPID_SUBJECT=mailto:you@example.com
 # instance imposes a limit — the per-user cap (Settings → Uploads) then applies
 # on its own. Clamped to 200 MB, the hard ceiling.
 #
-# A bare whole number of megabytes; anything else is ignored with a warning at
-# startup ("100MB" and "100m" do NOT work). Read as decimal MB (10^6) and reduced
-# by a small multipart allowance, so the cap clients are given is a FILE size that
-# still fits inside a request body at your limit. Both roundings are deliberately
-# conservative: proxies disagree on the unit, and a cap that overshoots yours puts
-# the unreadable edge reset right back.
+# A bare whole number of megabytes ("100MB" and "100m" do NOT work). A value that
+# won't parse is ignored with a warning logged the first time the cap is needed —
+# the first client connect or upload, NOT at boot — so check the logs after
+# connecting rather than expecting it on the startup banner.
+#
+# Read as decimal MB (10^6) and reduced by a small multipart allowance, so the cap
+# clients are given is a FILE size that still fits inside a request body at your
+# limit. Both roundings are deliberately conservative: proxies disagree on the
+# unit, and a cap that overshoots yours puts the unreadable edge reset right back.
 # LURKER_MAX_UPLOAD_MB=100
 
 # ---------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,20 @@ VAPID_SUBJECT=mailto:you@example.com
 # dev server, which rewrites the Host to localhost:8010).
 # PUBLIC_BASE_URL=https://irc.example.com
 
+# Largest request body that can actually REACH this instance, in MB. This is not
+# a preference — it describes whatever sits in front of Lurker. A CDN or reverse
+# proxy with its own request-body limit rejects a bigger upload at the edge, and
+# the client sees a connection reset rather than a useful error, because Lurker
+# never got the request. Cloudflare's limit is 100 MB on every non-Enterprise
+# plan; nginx defaults to 1 MB (client_max_body_size) but is usually raised.
+#
+# Setting it does two things: uploads over the limit are refused with a real 413
+# instead of dying at the edge, and clients are told the number so they can
+# compress media to fit before uploading. Leave unset if nothing in front of this
+# instance imposes a limit — the per-user cap (Settings → Uploads) then applies
+# on its own. Clamped to 200 MB, the hard ceiling.
+# LURKER_MAX_UPLOAD_MB=100
+
 # ---------------------------------------------------------------------------
 # Node mode (hosted lurker.chat service) — leave ALL of this unset for normal
 # self-hosting. A standalone instance ignores it entirely.

--- a/.env.example
+++ b/.env.example
@@ -99,18 +99,25 @@ VAPID_SUBJECT=mailto:you@example.com
 # dev server, which rewrites the Host to localhost:8010).
 # PUBLIC_BASE_URL=https://irc.example.com
 
-# Largest request body that can actually REACH this instance, in MB. This is not
+# Largest request BODY that can actually reach this instance, in MB. This is not
 # a preference — it describes whatever sits in front of Lurker. A CDN or reverse
 # proxy with its own request-body limit rejects a bigger upload at the edge, and
 # the client sees a connection reset rather than a useful error, because Lurker
-# never got the request. Cloudflare's limit is 100 MB on every non-Enterprise
-# plan; nginx defaults to 1 MB (client_max_body_size) but is usually raised.
+# never got the request. Cloudflare's limit is 100 MB on Free/Pro (200 MB on
+# Business); nginx defaults to 1 MB (client_max_body_size) but is usually raised.
 #
 # Setting it does two things: uploads over the limit are refused with a real 413
 # instead of dying at the edge, and clients are told the number so they can
 # compress media to fit before uploading. Leave unset if nothing in front of this
 # instance imposes a limit — the per-user cap (Settings → Uploads) then applies
 # on its own. Clamped to 200 MB, the hard ceiling.
+#
+# A bare whole number of megabytes; anything else is ignored with a warning at
+# startup ("100MB" and "100m" do NOT work). Read as decimal MB (10^6) and reduced
+# by a small multipart allowance, so the cap clients are given is a FILE size that
+# still fits inside a request body at your limit. Both roundings are deliberately
+# conservative: proxies disagree on the unit, and a cap that overshoots yours puts
+# the unreadable edge reset right back.
 # LURKER_MAX_UPLOAD_MB=100
 
 # ---------------------------------------------------------------------------

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -193,7 +193,7 @@ Authorization: Bearer <token>        (native; browsers ride the cookie)
 ### 4.3 Connect: the snapshot burst
 
 On every successful connect the server immediately sends a **burst of separate
-frames**, synchronously, in this order (`wsHub.ts:1828`):
+frames**, synchronously, in this order (`wsHub.ts` `sendSnapshotInner`, 1893):
 
 1. `{kind:'snapshot', protocolVersion, maxUploadBytes, networks, globalIgnores, cursor?}`
    — full live state for every network (see §5.1). `cursor` (present only on a

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -504,7 +504,7 @@ a v1 client.
 | `pins-changed`                                                                                                                                                           | `networkId, pinned[]`                                                                                                                                               | Authoritative pin order                            |
 | `nicklist-collapsed-changed` / `channel-notify-changed`                                                                                                                  | `networkId, target, …`                                                                                                                                              | View-state sync                                    |
 | `draft-updated` / `input-history-added` / `bookmark-updated` / `nick-note-updated` / `relay-bot-updated` / `contact-updated` / `contact-deleted` / `ignore-list-updated` | various                                                                                                                                                             | Multi-device view-state fan-out                    |
-| `settings`                                                                                                                                                               | `changes`                                                                                                                                                           | Server-side settings changed                       |
+| `settings`                                                                                                                                                               | `changes`, `maxUploadBytes?` (only when the upload cap was touched)                                                                                                 | Server-side settings changed                       |
 | `highlight-rules-changed`                                                                                                                                                | —                                                                                                                                                                   | Re-fetch highlight rules                           |
 | `account-state`                                                                                                                                                          | `paused: bool`                                                                                                                                                      | Hosted pause/resume                                |
 | `chanlist-state` / `chanlist-result`                                                                                                                                     | `/LIST` cache meta / result page                                                                                                                                    | Channel browser                                    |
@@ -744,17 +744,24 @@ secrets write-only). Standalone serves local files publicly at
 message — the server does the rest.
 
 **Size cap.** `maxUploadBytes` — on the `snapshot` frame and on `GET /api/uploads`
-— is the largest body this account may send, and the number to compress media
+— is the largest **file** this account may send, and the number to compress media
 against. **Do not hardcode a cap.** It is the smallest of three ceilings: the
 200 MB hard limit, the instance's declared transport limit (`LURKER_MAX_UPLOAD_MB`
 — what a CDN or reverse proxy in front of Lurker will pass), and the per-user or
 operator-baked uploader cap. Only the first is universal, so a self-hosted
 instance and a CDN-fronted one legitimately differ by a lot.
 
+It already has the multipart envelope subtracted, so a file at exactly
+`maxUploadBytes` still fits inside the request body once the boundaries, part
+headers, and `uploaderId` / `progressToken` fields are added. Size the **file**
+to it; don't budget for the envelope yourself.
+
 Treat it as advisory, not a contract: it is resolved for the account's **default**
-uploader at connect time, so a per-upload `uploaderId` override with a tighter
-policy cap, or an operator changing the limit mid-session, is still settled by a
-`413` carrying the real number. Reconnecting re-reads it.
+uploader, so a per-upload `uploaderId` override with a tighter policy cap, or an
+operator changing the limit mid-session, is still settled by a `413` carrying the
+real number. It is refreshed on reconnect, and re-sent on the `settings` frame
+whenever the user changes their own cap — so a client that reads it from both
+frames never compresses against a stale number.
 
 ### DCC — `/api/dcc` (403 unless enabled for the account)
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -195,11 +195,12 @@ Authorization: Bearer <token>        (native; browsers ride the cookie)
 On every successful connect the server immediately sends a **burst of separate
 frames**, synchronously, in this order (`wsHub.ts:1828`):
 
-1. `{kind:'snapshot', protocolVersion, networks:[…], globalIgnores:[…], cursor?}`
+1. `{kind:'snapshot', protocolVersion, maxUploadBytes, networks, globalIgnores, cursor?}`
    — full live state for every network (see §5.1). `cursor` (present only on a
    fresh connect) is the current global max message id: **seed your resume
    cursor from it**, because the shell backlogs that follow carry no rows and
-   would otherwise leave your cursor at 0.
+   would otherwise leave your cursor at 0. `maxUploadBytes` is the largest
+   upload this account may send right now — see §Uploads.
 2. `{kind:'draft-snapshot', drafts}` — saved per-buffer input drafts.
 3. `{kind:'bookmark-ids-snapshot', ids:[…]}` — bookmarked message ids.
 4. A `backlog` frame for the app-scoped **system buffer** (`networkId:null`,
@@ -490,7 +491,7 @@ a v1 client.
 
 | `kind`                                                                                                                                                                   | Payload                                                                                                                                                             | When                                               |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `snapshot`                                                                                                                                                               | `protocolVersion, networks[], globalIgnores[], cursor?`                                                                                                             | Connect burst / gap-fill                           |
+| `snapshot`                                                                                                                                                               | `protocolVersion, maxUploadBytes, networks[], globalIgnores[], cursor?`                                                                                             | Connect burst / gap-fill                           |
 | `draft-snapshot` / `bookmark-ids-snapshot` / `contacts-snapshot`                                                                                                         | `drafts` / `ids[]` / `contacts[]`                                                                                                                                   | Connect burst                                      |
 | `backlog-complete`                                                                                                                                                       | —                                                                                                                                                                   | Last frame of the burst; absence is proof (§4.3)   |
 | `backlog`                                                                                                                                                                | `networkId, target, events[], reset?, hasMoreOlder, joined, lastReadId, unread, highlights, highlightsCapped, clearedBeforeId, clearedAt, speakers?, inputHistory?` | Burst, `open-buffer` reply, resume gap             |
@@ -733,7 +734,7 @@ form.
 | Endpoint         | Notes                                                                                                                                                                                                                                                                       |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `POST /`         | `multipart/form-data`, file field **`image`**; optional `uploaderId`, `progressToken` (≤64 chars — progress arrives as `upload-progress` WS frames). → `{id, url, mime, can_delete, thumbnail_url?}`. `413` over cap, `415` rejected type, `502` provider error (never 401) |
-| `GET /`          | `?before, limit, q, kind` → `{items, providers}`                                                                                                                                                                                                                            |
+| `GET /`          | `?before, limit, q, kind` → `{items, providers, maxUploadBytes}`                                                                                                                                                                                                            |
 | `GET /:id/thumb` | Binary thumbnail                                                                                                                                                                                                                                                            |
 | `DELETE /:id`    | `409` if not deletable                                                                                                                                                                                                                                                      |
 
@@ -741,6 +742,19 @@ form.
 secrets write-only). Standalone serves local files publicly at
 `GET /uploads/:key` (no auth, sandboxed CSP). Paste the returned `url` into a
 message — the server does the rest.
+
+**Size cap.** `maxUploadBytes` — on the `snapshot` frame and on `GET /api/uploads`
+— is the largest body this account may send, and the number to compress media
+against. **Do not hardcode a cap.** It is the smallest of three ceilings: the
+200 MB hard limit, the instance's declared transport limit (`LURKER_MAX_UPLOAD_MB`
+— what a CDN or reverse proxy in front of Lurker will pass), and the per-user or
+operator-baked uploader cap. Only the first is universal, so a self-hosted
+instance and a CDN-fronted one legitimately differ by a lot.
+
+Treat it as advisory, not a contract: it is resolved for the account's **default**
+uploader at connect time, so a per-upload `uploaderId` override with a tighter
+policy cap, or an operator changing the limit mid-session, is still settled by a
+`413` carrying the real number. Reconnecting re-reads it.
 
 ### DCC — `/api/dcc` (403 unless enabled for the account)
 

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -478,10 +478,13 @@ describe('GET /api/uploads — search params', () => {
 // #627: clients hardcoded a cap because nothing advertised one — lurker-ios shipped
 // a Cloudflare-safe 90 MiB guess that is simply wrong for a self-hoster.
 describe('GET /api/uploads — advertised size cap', () => {
+  // DELETE rather than restore-to-a-number: this user had no row for the key
+  // before, so the registry default applied for the rest of the file. Writing a
+  // value here would silently re-cap every later test in the file.
   afterEach(async () => {
     delete process.env.LURKER_MAX_UPLOAD_MB;
-    const { setUserSetting } = await import('../db/settings.js');
-    setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
+    const { deleteUserSetting } = await import('../db/settings.js');
+    deleteUserSetting(user.id, 'uploads.image.max_upload_mb');
   });
 
   it("advertises the user's effective cap in bytes", async () => {
@@ -493,21 +496,25 @@ describe('GET /api/uploads — advertised size cap', () => {
   });
 
   // The whole point of the feature: what the client is told has to account for the
-  // proxy in front of us, not just the cap this process knows how to enforce.
+  // proxy in front of us, not just the cap this process knows how to enforce. Note
+  // the number is NOT 100 MiB — decimal MB, minus the multipart envelope, because
+  // the proxy's limit is on the whole body while this describes the file part.
   it('reports the transport ceiling when it is lower than the user cap', async () => {
     const { setUserSetting } = await import('../db/settings.js');
     setUserSetting(user.id, 'uploads.image.max_upload_mb', 200);
     process.env.LURKER_MAX_UPLOAD_MB = '100';
     const res = await agent.get('/api/uploads');
-    expect(res.body.maxUploadBytes).toBe(100 * 1024 * 1024);
+    expect(res.body.maxUploadBytes).toBe(100 * 1_000_000 - 64 * 1024);
+    // A client that compressed to exactly this and added an envelope still fits.
+    expect(res.body.maxUploadBytes).toBeLessThan(100 * 1_000_000);
   });
 });
 
 describe('POST /api/uploads — transport ceiling (#627)', () => {
   afterEach(async () => {
     delete process.env.LURKER_MAX_UPLOAD_MB;
-    const { setUserSetting } = await import('../db/settings.js');
-    setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
+    const { deleteUserSetting } = await import('../db/settings.js');
+    deleteUserSetting(user.id, 'uploads.image.max_upload_mb');
   });
 
   // An over-ceiling body would be killed at the edge with a connection reset the
@@ -516,13 +523,15 @@ describe('POST /api/uploads — transport ceiling (#627)', () => {
   it('refuses a body over the declared proxy limit with a 413, even under the user cap', async () => {
     const { setUserSetting } = await import('../db/settings.js');
     setUserSetting(user.id, 'uploads.image.max_upload_mb', 200);
-    process.env.LURKER_MAX_UPLOAD_MB = '1';
-    const big = Buffer.alloc(2 * 1024 * 1024, 0x7a);
+    process.env.LURKER_MAX_UPLOAD_MB = '5';
+    const big = Buffer.alloc(6 * 1024 * 1024, 0x7a);
     const res = await agent
       .post('/api/uploads')
       .attach('image', big, { filename: 'big.bin', contentType: 'text/plain' });
     expect(res.status).toBe(413);
-    expect(res.body.error).toContain('1 MB');
+    // 4.7, not 5: the 413 has to name the number the user can actually hit, or
+    // they come back with another file that fails the same way.
+    expect(res.body.error).toBe('file exceeds 4.7 MB');
   });
 });
 

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import type { LurkerTestAgent } from '../test-utils/testApp.js';
 import type { Express } from 'express';
 import sharp from 'sharp';
@@ -472,6 +472,57 @@ describe('GET /api/uploads — search params', () => {
     const res = await agent.get('/api/uploads?q=zzzz-no-such-file');
     expect(res.status).toBe(200);
     expect(res.body.items).toEqual([]);
+  });
+});
+
+// #627: clients hardcoded a cap because nothing advertised one — lurker-ios shipped
+// a Cloudflare-safe 90 MiB guess that is simply wrong for a self-hoster.
+describe('GET /api/uploads — advertised size cap', () => {
+  afterEach(async () => {
+    delete process.env.LURKER_MAX_UPLOAD_MB;
+    const { setUserSetting } = await import('../db/settings.js');
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
+  });
+
+  it("advertises the user's effective cap in bytes", async () => {
+    const { setUserSetting } = await import('../db/settings.js');
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
+    const res = await agent.get('/api/uploads');
+    expect(res.status).toBe(200);
+    expect(res.body.maxUploadBytes).toBe(25 * 1024 * 1024);
+  });
+
+  // The whole point of the feature: what the client is told has to account for the
+  // proxy in front of us, not just the cap this process knows how to enforce.
+  it('reports the transport ceiling when it is lower than the user cap', async () => {
+    const { setUserSetting } = await import('../db/settings.js');
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 200);
+    process.env.LURKER_MAX_UPLOAD_MB = '100';
+    const res = await agent.get('/api/uploads');
+    expect(res.body.maxUploadBytes).toBe(100 * 1024 * 1024);
+  });
+});
+
+describe('POST /api/uploads — transport ceiling (#627)', () => {
+  afterEach(async () => {
+    delete process.env.LURKER_MAX_UPLOAD_MB;
+    const { setUserSetting } = await import('../db/settings.js');
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
+  });
+
+  // An over-ceiling body would be killed at the edge with a connection reset the
+  // client can't interpret. Enforcing the operator's declared limit here turns that
+  // into a 413 naming the real number.
+  it('refuses a body over the declared proxy limit with a 413, even under the user cap', async () => {
+    const { setUserSetting } = await import('../db/settings.js');
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 200);
+    process.env.LURKER_MAX_UPLOAD_MB = '1';
+    const big = Buffer.alloc(2 * 1024 * 1024, 0x7a);
+    const res = await agent
+      .post('/api/uploads')
+      .attach('image', big, { filename: 'big.bin', contentType: 'text/plain' });
+    expect(res.status).toBe(413);
+    expect(res.body.error).toContain('1 MB');
   });
 });
 

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -10,8 +10,13 @@ import { requireAuth } from '../middleware/auth.js';
 import { resolveDataDir } from '../utils/dataDir.js';
 import { randomId } from '../services/uploadProviders/objectKey.js';
 import { bufferSource, fileSource, type UploadSource } from '../services/uploadProviders/source.js';
-import { getUserSettings } from '../db/settings.js';
-import { defaultsAsObject } from '../services/settingsRegistry.js';
+import {
+  effectiveSettings,
+  userCapMb,
+  clampUploadCapMb,
+  effectiveUploadCapMb,
+  effectiveUploadCapBytes,
+} from '../services/uploadLimits.js';
 import * as imagePipeline from '../services/imagePipeline.js';
 import { thumbnailFormat } from '../services/thumbnailFormat.js';
 import { makeUploadProgress } from '../services/uploadProgress.js';
@@ -44,14 +49,6 @@ import { reportUploadSoon } from '../services/moderationReport.js';
 
 const router = Router();
 router.use(requireAuth);
-
-// Resolve effective settings with registry defaults filled in. The per-user
-// image-pipeline settings (size cap, max dimension, JPEG quality) are the
-// fallback used when the resolved uploader carries no operator-baked policy caps
-// — i.e. every self-host uploader. Untyped (JS module) → Record<string, unknown>.
-function effectiveSettings(userId: number): Record<string, unknown> {
-  return { ...defaultsAsObject(), ...getUserSettings(userId) };
-}
 
 // The absolute origin (scheme + host) a `local` upload's relative URL is prefixed
 // with so the pasted link works from IRC. PUBLIC_BASE_URL wins (explicit,
@@ -123,41 +120,10 @@ function providerErrorStatus(e: { code?: string }): number {
 const TMP_DIR = path.join(resolveDataDir(), 'tmp', 'uploads');
 fs.mkdirSync(TMP_DIR, { recursive: true, mode: 0o700 });
 
-// The registry's own ceiling; a per-user cap can't exceed it, so neither can multer.
-const MAX_CAP_MB = 200;
-
-/** The user's size cap. effectiveSettings() has already merged the registry default
- *  in, so this reads it from ONE place — a second hardcoded default here would be a
- *  duplicate that quietly disagrees the next time the registry's changes. */
-function userCapMb(settings: Record<string, unknown>): number {
-  const n = Number(settings['uploads.image.max_upload_mb']);
-  return Number.isFinite(n) && n > 0 ? n : MAX_CAP_MB;
-}
-
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, TMP_DIR),
   filename: (_req, _file, cb) => cb(null, `up-${randomId()}`),
 });
-
-/** The cap to hand multer, resolved BEFORE a byte is read (requireAuth already
- *  ran, so we know who's asking). The old code gave multer a flat 200 MB and let
- *  the handler reject afterwards — which meant a user capped at 25 MB could still
- *  make the server ingest 200 MB before being told no. The per-upload `uploaderId`
- *  override lives in the multipart body, which isn't parsed yet, so this resolves
- *  the DEFAULT uploader's cap; the handler re-checks against the actually-resolved
- *  uploader, which is what catches an override with a tighter policy cap. */
-function capMbFor(userId: number, isAdmin: boolean): number {
-  const settings = effectiveSettings(userId);
-  const userCap = userCapMb(settings);
-  let cap = userCap;
-  try {
-    cap = resolveUploader({ userId, isAdmin, requestedId: null }).policy.maxMb ?? userCap;
-  } catch {
-    // No usable uploader → the handler will produce the real error. Fall back to
-    // the user's own cap so we still bound what we're willing to read.
-  }
-  return Math.max(1, Math.min(cap, MAX_CAP_MB));
-}
 
 /** Best-effort removal of an upload's temp file. Tolerates ENOENT: the `local`
  *  driver RENAMES the temp file into its storage dir (zero copies), so by the time
@@ -199,8 +165,15 @@ export async function sweepTempUploads(maxAgeMs = 60 * 60 * 1000): Promise<numbe
   return removed;
 }
 
+// The cap handed to multer is resolved BEFORE a byte is read (requireAuth already
+// ran, so we know who's asking). The old code gave multer a flat 200 MB and let the
+// handler reject afterwards — which meant a user capped at 25 MB could still make
+// the server ingest 200 MB before being told no. The per-upload `uploaderId`
+// override lives in the multipart body, which isn't parsed yet, so this resolves the
+// DEFAULT uploader's cap; the handler re-checks against the actually-resolved
+// uploader, which is what catches an override with a tighter policy cap.
 const uploadToDisk = (req: Request, res: Response, next: NextFunction): void => {
-  const capMb = capMbFor(req.user!.id, req.user!.role === 'admin');
+  const capMb = effectiveUploadCapMb(req.user!.id, req.user!.role === 'admin');
   const handler = multer({
     storage,
     limits: { fileSize: capMb * 1024 * 1024, files: 1 },
@@ -281,8 +254,11 @@ router.post(
       const settings = effectiveSettings(req.user!.id);
       // Size cap: operator-baked policy (hosted locked uploader) wins; otherwise
       // the user's own setting. A tenant can't lift a policy cap because the
-      // policy is on the instance row, not their settings.
-      const maxMb = resolved.policy.maxMb ?? userCapMb(settings);
+      // policy is on the instance row, not their settings. Clamped to the
+      // instance's transport ceiling last (#627), so a body the proxy in front of
+      // us would have rejected anyway is refused with a real 413 rather than an
+      // edge-level connection reset.
+      const maxMb = clampUploadCapMb(resolved.policy.maxMb ?? userCapMb(settings));
       if (req.file.size > maxMb * 1024 * 1024) {
         res.status(413).json({ error: `file exceeds ${maxMb} MB` });
         return;
@@ -557,6 +533,10 @@ router.get('/', (req: Request, res: Response) => {
       return { ...rest, can_delete, ...(thumb ? { thumbnail_url: thumb } : {}) };
     }),
     providers: driverIds,
+    // The same number the snapshot advertises (#627), repeated here so a
+    // REST-only client browsing its uploads doesn't need the WebSocket to learn
+    // what it may send. Single source of truth, so the two can't drift.
+    maxUploadBytes: effectiveUploadCapBytes(req.user!.id, req.user!.role === 'admin'),
   });
 });
 

--- a/server/routes/uploads.ts
+++ b/server/routes/uploads.ts
@@ -12,10 +12,10 @@ import { randomId } from '../services/uploadProviders/objectKey.js';
 import { bufferSource, fileSource, type UploadSource } from '../services/uploadProviders/source.js';
 import {
   effectiveSettings,
-  userCapMb,
-  clampUploadCapMb,
-  effectiveUploadCapMb,
+  userCapBytes,
+  clampUploadCapBytes,
   effectiveUploadCapBytes,
+  formatCapMb,
 } from '../services/uploadLimits.js';
 import * as imagePipeline from '../services/imagePipeline.js';
 import { thumbnailFormat } from '../services/thumbnailFormat.js';
@@ -173,10 +173,10 @@ export async function sweepTempUploads(maxAgeMs = 60 * 60 * 1000): Promise<numbe
 // DEFAULT uploader's cap; the handler re-checks against the actually-resolved
 // uploader, which is what catches an override with a tighter policy cap.
 const uploadToDisk = (req: Request, res: Response, next: NextFunction): void => {
-  const capMb = effectiveUploadCapMb(req.user!.id, req.user!.role === 'admin');
+  const capBytes = effectiveUploadCapBytes(req.user!.id, req.user!.role === 'admin');
   const handler = multer({
     storage,
-    limits: { fileSize: capMb * 1024 * 1024, files: 1 },
+    limits: { fileSize: capBytes, files: 1 },
     // busboy decodes multipart params as LATIN-1 unless told otherwise, so any
     // non-ASCII filename arrives mangled — a macOS screen recording is named with a
     // narrow no-break space (U+202F) before AM/PM, whose UTF-8 bytes (E2 80 AF) then
@@ -187,7 +187,7 @@ const uploadToDisk = (req: Request, res: Response, next: NextFunction): void => 
     // multer aborts the stream and unlinks its partial file once the cap is hit,
     // so an oversized upload is refused mid-flight instead of after we've eaten it.
     if ((err as { code?: string })?.code === 'LIMIT_FILE_SIZE') {
-      res.status(413).json({ error: `file exceeds ${capMb} MB` });
+      res.status(413).json({ error: `file exceeds ${formatCapMb(capBytes)} MB` });
       return;
     }
     next(err as Error | undefined);
@@ -258,9 +258,12 @@ router.post(
       // instance's transport ceiling last (#627), so a body the proxy in front of
       // us would have rejected anyway is refused with a real 413 rather than an
       // edge-level connection reset.
-      const maxMb = clampUploadCapMb(resolved.policy.maxMb ?? userCapMb(settings));
-      if (req.file.size > maxMb * 1024 * 1024) {
-        res.status(413).json({ error: `file exceeds ${maxMb} MB` });
+      const policyMb = resolved.policy.maxMb;
+      const maxBytes = clampUploadCapBytes(
+        policyMb == null ? userCapBytes(settings) : policyMb * 1024 * 1024,
+      );
+      if (req.file.size > maxBytes) {
+        res.status(413).json({ error: `file exceeds ${formatCapMb(maxBytes)} MB` });
         return;
       }
 

--- a/server/services/uploadLimits.test.ts
+++ b/server/services/uploadLimits.test.ts
@@ -1,14 +1,17 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
 import { setupTestDb } from '../test-utils/testApp.js';
 import type { User } from '../db/users.js';
 
 setupTestDb('services-upload-limits');
 
+const MIB = 1024 * 1024;
+const ENVELOPE = 64 * 1024;
+
 let user: User;
-let admin: User;
+let fresh: User;
 let setUserSetting: (userId: number, key: string, value: unknown) => void;
 let limits: typeof import('./uploadLimits.js');
 
@@ -17,82 +20,121 @@ beforeAll(async () => {
   ({ setUserSetting } = await import('../db/settings.js'));
   limits = await import('./uploadLimits.js');
   user = createUser('alice');
-  admin = createUser('root');
+  fresh = createUser('root');
 });
 
 afterEach(() => {
   delete process.env.LURKER_MAX_UPLOAD_MB;
+  vi.restoreAllMocks();
 });
 
-describe('transportCapMb', () => {
+describe('transportCapBytes', () => {
   it('is the hard ceiling when unset — a self-hoster with nothing in front of them', () => {
-    expect(limits.transportCapMb()).toBe(limits.MAX_CAP_MB);
+    expect(limits.transportCapBytes()).toBe(limits.MAX_CAP_BYTES);
   });
 
-  it('honors the operator-declared proxy/CDN limit', () => {
+  // The bug this feature exists to kill: a proxy limit applies to the whole
+  // request body, so advertising it as a FILE size sends the client back with a
+  // body just over the line. The envelope has to come off the top.
+  it('reserves multipart headroom, so a file at the cap still fits in the body', () => {
     process.env.LURKER_MAX_UPLOAD_MB = '100';
-    expect(limits.transportCapMb()).toBe(100);
+    const cap = limits.transportCapBytes();
+    expect(cap).toBe(100 * 1_000_000 - ENVELOPE);
+    expect(cap).toBeLessThan(100 * 1_000_000);
+  });
+
+  // Cloudflare documents decimal MB; nginx's client_max_body_size 100m is MiB.
+  // Decimal is the smaller reading, so it's the safe one when the proxy is unknown.
+  it('reads the declared MB as decimal, never as the larger MiB', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '100';
+    expect(limits.transportCapBytes()).toBeLessThan(100 * MIB);
   });
 
   it('can never RAISE the hard ceiling', () => {
     process.env.LURKER_MAX_UPLOAD_MB = '5000';
-    expect(limits.transportCapMb()).toBe(limits.MAX_CAP_MB);
+    expect(limits.transportCapBytes()).toBe(limits.MAX_CAP_BYTES);
+  });
+
+  // Silently ignoring "100MB" — the natural typo, given the var is named _MB —
+  // leaves the operator staring at a setting that never took while uploads keep
+  // dying at the edge. The fallback is right; the silence isn't.
+  //
+  // FIRST in this describe on purpose: the warning is latched once per process,
+  // so any earlier test that trips an unparseable value consumes it.
+  it('warns about an unparseable value instead of ignoring it silently', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.LURKER_MAX_UPLOAD_MB = '100MB';
+    expect(limits.transportCapBytes()).toBe(limits.MAX_CAP_BYTES);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('LURKER_MAX_UPLOAD_MB'));
+    // Once per process, not once per upload — this runs on every snapshot.
+    limits.transportCapBytes();
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it('treats garbage and non-positive values as unset, never as "refuse everything"', () => {
-    // A typo here would otherwise take every upload on the instance down, which
-    // is a much worse failure than ignoring the value.
+    // A typo would otherwise take every upload on the instance down, which is a
+    // much worse failure than ignoring the value.
     for (const raw of ['', '  ', 'lots', '0', '-10', 'NaN']) {
       process.env.LURKER_MAX_UPLOAD_MB = raw;
-      expect(limits.transportCapMb()).toBe(limits.MAX_CAP_MB);
+      expect(limits.transportCapBytes()).toBe(limits.MAX_CAP_BYTES);
     }
   });
 
   it('floors a fractional value rather than rounding up past the proxy limit', () => {
     process.env.LURKER_MAX_UPLOAD_MB = '99.9';
-    expect(limits.transportCapMb()).toBe(99);
+    expect(limits.transportCapBytes()).toBe(99 * 1_000_000 - ENVELOPE);
   });
 });
 
-describe('effectiveUploadCapMb', () => {
-  it("defaults to the user's own setting", () => {
+describe('effectiveUploadCapBytes', () => {
+  it("defaults to the user's own setting, in MiB", () => {
     setUserSetting(user.id, 'uploads.image.max_upload_mb', 150);
-    expect(limits.effectiveUploadCapMb(user.id, false)).toBe(150);
+    expect(limits.effectiveUploadCapBytes(user.id, false)).toBe(150 * MIB);
   });
 
   it('is the SMALLEST of the ceilings — the transport limit wins when it is lower', () => {
     setUserSetting(user.id, 'uploads.image.max_upload_mb', 150);
     process.env.LURKER_MAX_UPLOAD_MB = '100';
-    expect(limits.effectiveUploadCapMb(user.id, false)).toBe(100);
+    expect(limits.effectiveUploadCapBytes(user.id, false)).toBe(100 * 1_000_000 - ENVELOPE);
   });
 
   it("does not inflate a user's lower cap up to the transport limit", () => {
     setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
     process.env.LURKER_MAX_UPLOAD_MB = '100';
-    expect(limits.effectiveUploadCapMb(user.id, false)).toBe(25);
+    expect(limits.effectiveUploadCapBytes(user.id, false)).toBe(25 * MIB);
   });
 
   it('answers for a user with no settings row at all (registry default applies)', () => {
     // "How big may I upload" must have an answer before the user has touched a
     // single setting — this is the value a fresh client is told on connect.
-    expect(limits.effectiveUploadCapMb(admin.id, true)).toBeGreaterThan(0);
-    expect(limits.effectiveUploadCapMb(admin.id, true)).toBeLessThanOrEqual(limits.MAX_CAP_MB);
-  });
-
-  it('reports bytes as MB × 1024²', () => {
-    setUserSetting(user.id, 'uploads.image.max_upload_mb', 42);
-    expect(limits.effectiveUploadCapBytes(user.id, false)).toBe(42 * 1024 * 1024);
+    const cap = limits.effectiveUploadCapBytes(fresh.id, true);
+    expect(cap).toBeGreaterThan(0);
+    expect(cap).toBeLessThanOrEqual(limits.MAX_CAP_BYTES);
   });
 });
 
-describe('clampUploadCapMb', () => {
-  it('floors at 1 MB so no configuration can resolve to "refuse everything"', () => {
-    expect(limits.clampUploadCapMb(0)).toBe(1);
-    expect(limits.clampUploadCapMb(-5)).toBe(1);
+describe('clampUploadCapBytes', () => {
+  it('never resolves to a zero or negative cap', () => {
+    expect(limits.clampUploadCapBytes(0)).toBe(1);
+    expect(limits.clampUploadCapBytes(-5)).toBe(1);
   });
 
   it('applies the transport ceiling to a policy cap the operator baked higher', () => {
     process.env.LURKER_MAX_UPLOAD_MB = '100';
-    expect(limits.clampUploadCapMb(200)).toBe(100);
+    expect(limits.clampUploadCapBytes(200 * MIB)).toBe(100 * 1_000_000 - ENVELOPE);
+  });
+});
+
+describe('formatCapMb', () => {
+  // A whole number would be a lie once the envelope headroom is subtracted:
+  // "exceeds 5 MB" when the real limit is 4.7 sends the user back with another
+  // file that fails exactly the same way.
+  it('keeps a decimal when the cap is not a whole MB, and rounds DOWN', () => {
+    expect(limits.formatCapMb(5 * 1_000_000 - ENVELOPE)).toBe('4.7');
+    expect(limits.formatCapMb(25 * MIB)).toBe('25');
+  });
+
+  it('drops the decimal on larger caps, where it is noise', () => {
+    expect(limits.formatCapMb(100 * 1_000_000 - ENVELOPE)).toBe('95');
   });
 });

--- a/server/services/uploadLimits.test.ts
+++ b/server/services/uploadLimits.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+
+setupTestDb('services-upload-limits');
+
+let user: User;
+let admin: User;
+let setUserSetting: (userId: number, key: string, value: unknown) => void;
+let limits: typeof import('./uploadLimits.js');
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  ({ setUserSetting } = await import('../db/settings.js'));
+  limits = await import('./uploadLimits.js');
+  user = createUser('alice');
+  admin = createUser('root');
+});
+
+afterEach(() => {
+  delete process.env.LURKER_MAX_UPLOAD_MB;
+});
+
+describe('transportCapMb', () => {
+  it('is the hard ceiling when unset — a self-hoster with nothing in front of them', () => {
+    expect(limits.transportCapMb()).toBe(limits.MAX_CAP_MB);
+  });
+
+  it('honors the operator-declared proxy/CDN limit', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '100';
+    expect(limits.transportCapMb()).toBe(100);
+  });
+
+  it('can never RAISE the hard ceiling', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '5000';
+    expect(limits.transportCapMb()).toBe(limits.MAX_CAP_MB);
+  });
+
+  it('treats garbage and non-positive values as unset, never as "refuse everything"', () => {
+    // A typo here would otherwise take every upload on the instance down, which
+    // is a much worse failure than ignoring the value.
+    for (const raw of ['', '  ', 'lots', '0', '-10', 'NaN']) {
+      process.env.LURKER_MAX_UPLOAD_MB = raw;
+      expect(limits.transportCapMb()).toBe(limits.MAX_CAP_MB);
+    }
+  });
+
+  it('floors a fractional value rather than rounding up past the proxy limit', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '99.9';
+    expect(limits.transportCapMb()).toBe(99);
+  });
+});
+
+describe('effectiveUploadCapMb', () => {
+  it("defaults to the user's own setting", () => {
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 150);
+    expect(limits.effectiveUploadCapMb(user.id, false)).toBe(150);
+  });
+
+  it('is the SMALLEST of the ceilings — the transport limit wins when it is lower', () => {
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 150);
+    process.env.LURKER_MAX_UPLOAD_MB = '100';
+    expect(limits.effectiveUploadCapMb(user.id, false)).toBe(100);
+  });
+
+  it("does not inflate a user's lower cap up to the transport limit", () => {
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 25);
+    process.env.LURKER_MAX_UPLOAD_MB = '100';
+    expect(limits.effectiveUploadCapMb(user.id, false)).toBe(25);
+  });
+
+  it('answers for a user with no settings row at all (registry default applies)', () => {
+    // "How big may I upload" must have an answer before the user has touched a
+    // single setting — this is the value a fresh client is told on connect.
+    expect(limits.effectiveUploadCapMb(admin.id, true)).toBeGreaterThan(0);
+    expect(limits.effectiveUploadCapMb(admin.id, true)).toBeLessThanOrEqual(limits.MAX_CAP_MB);
+  });
+
+  it('reports bytes as MB × 1024²', () => {
+    setUserSetting(user.id, 'uploads.image.max_upload_mb', 42);
+    expect(limits.effectiveUploadCapBytes(user.id, false)).toBe(42 * 1024 * 1024);
+  });
+});
+
+describe('clampUploadCapMb', () => {
+  it('floors at 1 MB so no configuration can resolve to "refuse everything"', () => {
+    expect(limits.clampUploadCapMb(0)).toBe(1);
+    expect(limits.clampUploadCapMb(-5)).toBe(1);
+  });
+
+  it('applies the transport ceiling to a policy cap the operator baked higher', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '100';
+    expect(limits.clampUploadCapMb(200)).toBe(100);
+  });
+});

--- a/server/services/uploadLimits.ts
+++ b/server/services/uploadLimits.ts
@@ -6,19 +6,25 @@
 // Three ceilings stack, and a client that wants to size media to fit needs the
 // smallest of them — not any single one:
 //
-//   1. MAX_CAP_MB       the registry's own hard ceiling; nothing may exceed it.
-//   2. transportCapMb() the request-body limit of whatever sits IN FRONT of this
-//                       instance. app.lurker.chat is behind Cloudflare, whose
-//                       non-Enterprise limit is 100 MB — a larger body dies at
-//                       the edge with a connection reset the client sees as an
-//                       unparseable response, before Express is ever reached.
-//                       The server cannot detect this, so the operator declares
-//                       it via LURKER_MAX_UPLOAD_MB.
-//   3. the per-user cap the operator-baked uploader policy (hosted locked row),
-//                       else the user's own `uploads.image.max_upload_mb`.
+//   1. MAX_CAP_BYTES     the registry's own hard ceiling; nothing may exceed it.
+//   2. transportCapBytes the request-body limit of whatever sits IN FRONT of this
+//                        instance. app.lurker.chat is behind Cloudflare, whose
+//                        limit is 100 MB on Free/Pro (200 MB on Business); a
+//                        larger body dies at the edge with a connection reset the
+//                        client sees as an unparseable response, before Express is
+//                        ever reached. The server cannot detect this, so the
+//                        operator declares it via LURKER_MAX_UPLOAD_MB.
+//   3. the per-user cap  the operator-baked uploader policy (hosted locked row),
+//                        else the user's own `uploads.image.max_upload_mb`.
 //
-// Everything that enforces or advertises a cap goes through here, so multer's
-// limit, the handler's 413, and the number we hand clients can never disagree.
+// Every upload path that enforces or advertises a cap goes through here, so
+// multer's limit, the handler's 413, and the number we hand clients can never
+// disagree. (`POST /api/imports` has its own, much larger, body limit and is
+// deliberately not covered — it isn't something a client sizes media against.)
+//
+// Bytes, not MB, is the canonical unit: it's what multer takes, what a client
+// compares a file size against, and the only unit in which the transport
+// ceiling's headroom below can be expressed honestly.
 
 import { getUserSettings } from '../db/settings.js';
 import { defaultsAsObject } from './settingsRegistry.js';
@@ -26,6 +32,18 @@ import { resolveUploader } from './uploadProviders/resolve.js';
 
 /** The registry's own ceiling; a per-user cap can't exceed it, so neither can multer. */
 export const MAX_CAP_MB = 200;
+export const MAX_CAP_BYTES = MAX_CAP_MB * 1024 * 1024;
+
+// What the multipart envelope costs on top of the file itself: the boundary
+// lines, each part's Content-Disposition/Content-Type headers, and the
+// `uploaderId` / `progressToken` text fields. A proxy limit applies to the whole
+// REQUEST BODY, but multer's fileSize limit — and the number we advertise —
+// describe the FILE part alone, so the difference has to come off the top.
+// Without it a client that does exactly what the docs tell it (compress to
+// maxUploadBytes) ships a body just over the proxy's limit and gets the edge
+// reset this whole feature exists to prevent. 64 KiB is far more than the few
+// hundred bytes actually needed; the slack is free and covers future fields.
+const ENVELOPE_HEADROOM_BYTES = 64 * 1024;
 
 /** Resolve effective settings with registry defaults filled in. The per-user
  *  image-pipeline settings (size cap, max dimension, JPEG quality) are the
@@ -35,60 +53,94 @@ export function effectiveSettings(userId: number): Record<string, unknown> {
   return { ...defaultsAsObject(), ...getUserSettings(userId) };
 }
 
-/** The user's size cap. effectiveSettings() has already merged the registry default
- *  in, so this reads it from ONE place — a second hardcoded default here would be a
- *  duplicate that quietly disagrees the next time the registry changes. */
-export function userCapMb(settings: Record<string, unknown>): number {
+/** The user's size cap, in bytes. effectiveSettings() has already merged the
+ *  registry default in, so this reads it from ONE place — a second hardcoded
+ *  default here would be a duplicate that quietly disagrees the next time the
+ *  registry changes. MiB, matching the registry setting's own units. */
+export function userCapBytes(settings: Record<string, unknown>): number {
   const n = Number(settings['uploads.image.max_upload_mb']);
-  return Number.isFinite(n) && n > 0 ? n : MAX_CAP_MB;
+  return Number.isFinite(n) && n > 0 ? n * 1024 * 1024 : MAX_CAP_BYTES;
 }
 
+// Warn once per process, not per upload: transportCapBytes() runs on every
+// snapshot and every upload, and a misconfiguration that repeats a thousand
+// times a minute is noise rather than a signal.
+let warnedBadTransportCap = false;
+
 /**
- * The instance's transport ceiling: the largest request body that can actually
- * reach this process, as declared by the operator. Unset (the self-hoster with
- * nothing in front of them) → MAX_CAP_MB, i.e. no extra ceiling.
+ * The instance's transport ceiling in bytes: the largest request body that can
+ * actually reach this process, as declared by the operator. Unset (the
+ * self-hoster with nothing in front of them) → MAX_CAP_BYTES, i.e. no extra
+ * ceiling.
  *
  * Deliberately an env var rather than a tenant setting, for the same reason the
  * node-edition pipeline knobs are: it describes the deployment, not a preference,
- * and a tenant must not be able to raise it. Garbage parses to "unset" rather
- * than 0 — a typo here would otherwise refuse every upload on the instance.
+ * and a tenant must not be able to raise it.
+ *
+ * The declared MB is read as DECIMAL (10⁶), unlike the per-user setting's MiB.
+ * Proxies disagree — Cloudflare documents decimal MB, nginx's `client_max_body_size
+ * 100m` is 100 MiB — and the decimal reading is the smaller of the two, so it is
+ * the safe one when the proxy's own unit is unknown. Erring 4.8% low costs a
+ * self-hoster nothing; erring high is the edge reset again.
  */
-export function transportCapMb(): number {
+export function transportCapBytes(): number {
   const raw = (process.env.LURKER_MAX_UPLOAD_MB || '').trim();
-  if (!raw) return MAX_CAP_MB;
-  const n = Math.floor(Number(raw));
-  if (!Number.isFinite(n) || n <= 0) return MAX_CAP_MB;
-  return Math.min(n, MAX_CAP_MB);
+  if (!raw) return MAX_CAP_BYTES;
+  const mb = Math.floor(Number(raw));
+  if (!Number.isFinite(mb) || mb <= 0) {
+    // "100MB" / "100m" — the natural typo, given the var is named _MB — parses to
+    // NaN. Falling back to no-ceiling is the right direction (a typo must never
+    // refuse every upload on the instance), but silently doing so would leave the
+    // operator looking at a setting that never took effect while uploads keep
+    // dying at the edge. Say so.
+    if (!warnedBadTransportCap) {
+      warnedBadTransportCap = true;
+      console.warn(
+        `[lurker] LURKER_MAX_UPLOAD_MB="${raw}" is not a positive whole number of ` +
+          'megabytes; ignoring it. Uploads are NOT bounded by a transport ceiling. ' +
+          'Use a bare integer, e.g. LURKER_MAX_UPLOAD_MB=100.',
+      );
+    }
+    return MAX_CAP_BYTES;
+  }
+  return Math.min(mb * 1_000_000 - ENVELOPE_HEADROOM_BYTES, MAX_CAP_BYTES);
 }
 
-/** Clamp a candidate cap to the instance-wide ceilings. Floors at 1 MB so a
- *  hostile or fat-fingered value can never resolve to "refuse everything". */
-export function clampUploadCapMb(mb: number): number {
-  return Math.max(1, Math.min(mb, transportCapMb(), MAX_CAP_MB));
+/** Clamp a candidate cap to the instance-wide ceilings. Floors at 1 byte so no
+ *  configuration can resolve to a negative or zero cap; a genuinely tiny value is
+ *  the operator's own declaration and is reported honestly rather than rounded up
+ *  past the limit they set. */
+export function clampUploadCapBytes(bytes: number): number {
+  return Math.max(1, Math.min(bytes, transportCapBytes(), MAX_CAP_BYTES));
 }
 
 /**
- * The effective cap for this user, in MB — what a client should size media to fit
- * and what the server will actually accept. Resolves the user's DEFAULT uploader:
- * a per-upload `uploaderId` override with a tighter policy cap is caught by the
- * handler's own re-check, which is the number that ends up in the 413.
+ * The effective cap for this user, in bytes — what a client should size media to
+ * fit and what the server will actually accept. Resolves the user's DEFAULT
+ * uploader: a per-upload `uploaderId` override with a tighter policy cap is caught
+ * by the handler's own re-check, which is the number that ends up in the 413.
  *
  * An unusable uploader is not an error here. "How big may I upload" has an answer
  * even when the answer to "where does it go" is currently 400/503 — reporting the
  * user's own clamped cap keeps this from being a second failure surface.
  */
-export function effectiveUploadCapMb(userId: number, isAdmin: boolean): number {
-  const fallback = userCapMb(effectiveSettings(userId));
+export function effectiveUploadCapBytes(userId: number, isAdmin: boolean): number {
+  const fallback = userCapBytes(effectiveSettings(userId));
   let cap = fallback;
   try {
-    cap = resolveUploader({ userId, isAdmin, requestedId: null }).policy.maxMb ?? fallback;
+    const policyMb = resolveUploader({ userId, isAdmin, requestedId: null }).policy.maxMb;
+    cap = policyMb == null ? fallback : policyMb * 1024 * 1024;
   } catch {
     // No usable uploader configured — fall through to the user's own cap.
   }
-  return clampUploadCapMb(cap);
+  return clampUploadCapBytes(cap);
 }
 
-/** Same value in bytes, which is the unit clients compare a file size against. */
-export function effectiveUploadCapBytes(userId: number, isAdmin: boolean): number {
-  return effectiveUploadCapMb(userId, isAdmin) * 1024 * 1024;
+/** The cap as a human-readable MB string for the 413 body. At most one decimal,
+ *  because the transport ceiling's headroom makes a whole number a lie: telling a
+ *  user their file "exceeds 1 MB" when the real limit is 0.9 MB sends them back
+ *  with another file that fails. */
+export function formatCapMb(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  return (mb >= 10 ? Math.floor(mb) : Math.floor(mb * 10) / 10).toString();
 }

--- a/server/services/uploadLimits.ts
+++ b/server/services/uploadLimits.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// THE upload size cap, in one place (#627).
+//
+// Three ceilings stack, and a client that wants to size media to fit needs the
+// smallest of them — not any single one:
+//
+//   1. MAX_CAP_MB       the registry's own hard ceiling; nothing may exceed it.
+//   2. transportCapMb() the request-body limit of whatever sits IN FRONT of this
+//                       instance. app.lurker.chat is behind Cloudflare, whose
+//                       non-Enterprise limit is 100 MB — a larger body dies at
+//                       the edge with a connection reset the client sees as an
+//                       unparseable response, before Express is ever reached.
+//                       The server cannot detect this, so the operator declares
+//                       it via LURKER_MAX_UPLOAD_MB.
+//   3. the per-user cap the operator-baked uploader policy (hosted locked row),
+//                       else the user's own `uploads.image.max_upload_mb`.
+//
+// Everything that enforces or advertises a cap goes through here, so multer's
+// limit, the handler's 413, and the number we hand clients can never disagree.
+
+import { getUserSettings } from '../db/settings.js';
+import { defaultsAsObject } from './settingsRegistry.js';
+import { resolveUploader } from './uploadProviders/resolve.js';
+
+/** The registry's own ceiling; a per-user cap can't exceed it, so neither can multer. */
+export const MAX_CAP_MB = 200;
+
+/** Resolve effective settings with registry defaults filled in. The per-user
+ *  image-pipeline settings (size cap, max dimension, JPEG quality) are the
+ *  fallback used when the resolved uploader carries no operator-baked policy caps
+ *  — i.e. every self-host uploader. Untyped (JS module) → Record<string, unknown>. */
+export function effectiveSettings(userId: number): Record<string, unknown> {
+  return { ...defaultsAsObject(), ...getUserSettings(userId) };
+}
+
+/** The user's size cap. effectiveSettings() has already merged the registry default
+ *  in, so this reads it from ONE place — a second hardcoded default here would be a
+ *  duplicate that quietly disagrees the next time the registry changes. */
+export function userCapMb(settings: Record<string, unknown>): number {
+  const n = Number(settings['uploads.image.max_upload_mb']);
+  return Number.isFinite(n) && n > 0 ? n : MAX_CAP_MB;
+}
+
+/**
+ * The instance's transport ceiling: the largest request body that can actually
+ * reach this process, as declared by the operator. Unset (the self-hoster with
+ * nothing in front of them) → MAX_CAP_MB, i.e. no extra ceiling.
+ *
+ * Deliberately an env var rather than a tenant setting, for the same reason the
+ * node-edition pipeline knobs are: it describes the deployment, not a preference,
+ * and a tenant must not be able to raise it. Garbage parses to "unset" rather
+ * than 0 — a typo here would otherwise refuse every upload on the instance.
+ */
+export function transportCapMb(): number {
+  const raw = (process.env.LURKER_MAX_UPLOAD_MB || '').trim();
+  if (!raw) return MAX_CAP_MB;
+  const n = Math.floor(Number(raw));
+  if (!Number.isFinite(n) || n <= 0) return MAX_CAP_MB;
+  return Math.min(n, MAX_CAP_MB);
+}
+
+/** Clamp a candidate cap to the instance-wide ceilings. Floors at 1 MB so a
+ *  hostile or fat-fingered value can never resolve to "refuse everything". */
+export function clampUploadCapMb(mb: number): number {
+  return Math.max(1, Math.min(mb, transportCapMb(), MAX_CAP_MB));
+}
+
+/**
+ * The effective cap for this user, in MB — what a client should size media to fit
+ * and what the server will actually accept. Resolves the user's DEFAULT uploader:
+ * a per-upload `uploaderId` override with a tighter policy cap is caught by the
+ * handler's own re-check, which is the number that ends up in the 413.
+ *
+ * An unusable uploader is not an error here. "How big may I upload" has an answer
+ * even when the answer to "where does it go" is currently 400/503 — reporting the
+ * user's own clamped cap keeps this from being a second failure surface.
+ */
+export function effectiveUploadCapMb(userId: number, isAdmin: boolean): number {
+  const fallback = userCapMb(effectiveSettings(userId));
+  let cap = fallback;
+  try {
+    cap = resolveUploader({ userId, isAdmin, requestedId: null }).policy.maxMb ?? fallback;
+  } catch {
+    // No usable uploader configured — fall through to the user's own cap.
+  }
+  return clampUploadCapMb(cap);
+}
+
+/** Same value in bytes, which is the unit clients compare a file size against. */
+export function effectiveUploadCapBytes(userId: number, isAdmin: boolean): number {
+  return effectiveUploadCapMb(userId, isAdmin) * 1024 * 1024;
+}

--- a/server/services/wsHub.burst.test.ts
+++ b/server/services/wsHub.burst.test.ts
@@ -199,3 +199,45 @@ describe('connect burst terminator (#635)', () => {
     }
   });
 });
+
+// #627: the snapshot's number is only current until the user edits their cap.
+// Their own edit already fans out a `settings` frame, so the recomputed cap rides
+// it rather than leaving them compressing against a stale value until reconnect.
+describe('upload cap on the settings frame (#627)', () => {
+  it('re-sends the effective cap when the user changes their own cap', async () => {
+    const settingsService = (await import('./settingsService.js')).default;
+    const { deleteUserSetting } = await import('../db/settings.js');
+    const { token } = createSession(userId);
+
+    const frame = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
+      const timer = setTimeout(() => {
+        ws.close();
+        reject(new Error('no settings frame arrived'));
+      }, 3000);
+      ws.on('message', (raw) => {
+        const f = JSON.parse(raw.toString()) as Record<string, unknown>;
+        // Change the setting only once the connect burst is done, so the frame
+        // we're waiting for can't be confused with anything in the burst.
+        if (f.kind === 'backlog-complete') {
+          settingsService.update(userId, { 'uploads.image.max_upload_mb': 7 });
+          return;
+        }
+        if (f.kind !== 'settings') return;
+        clearTimeout(timer);
+        ws.close();
+        resolve(f);
+      });
+      ws.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+
+    try {
+      expect(frame.maxUploadBytes).toBe(7 * 1024 * 1024);
+    } finally {
+      deleteUserSetting(userId, 'uploads.image.max_upload_mb');
+    }
+  });
+});

--- a/server/services/wsHub.burst.test.ts
+++ b/server/services/wsHub.burst.test.ts
@@ -183,4 +183,19 @@ describe('connect burst terminator (#635)', () => {
     expect(frames.filter((f) => f.kind === 'backlog-complete')).toHaveLength(2);
     expect(frames.at(-1)!.kind).toBe('backlog-complete');
   });
+
+  // #627: the cap has to arrive on the socket every client already opens. A
+  // client that has to make a REST call to learn it will hardcode a guess
+  // instead — which is exactly what lurker-ios did.
+  it('carries the effective upload cap on the snapshot frame', async () => {
+    const { setUserSetting } = await import('../db/settings.js');
+    setUserSetting(userId, 'uploads.image.max_upload_mb', 42);
+    try {
+      const [snapshot] = (await collectBurst()) as unknown as [{ maxUploadBytes?: number }];
+      expect(snapshot.maxUploadBytes).toBe(42 * 1024 * 1024);
+    } finally {
+      const { deleteUserSetting } = await import('../db/settings.js');
+      deleteUserSetting(userId, 'uploads.image.max_upload_mb');
+    }
+  });
 });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -24,6 +24,7 @@ import ignoreRulesService from './ignoreRulesService.js';
 import { parseIgnoreInput, maskToRuleInput } from './ignoreRuleInput.js';
 import { findSession } from '../db/sessions.js';
 import { findUserById, touchUserLastSeen } from '../db/users.js';
+import { effectiveUploadCapBytes } from './uploadLimits.js';
 import {
   listMessages,
   listMessagesAround,
@@ -1893,6 +1894,12 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // full gap-fill path untouched.
     const isFreshConnect = (ws.sinceId || 0) === 0;
     const cursor = isFreshConnect ? maxMessageId() : 0;
+    // #627: the effective upload cap rides the snapshot so a client can size media
+    // to fit BEFORE it starts an upload — lurker-ios compresses video against this
+    // number, and hardcoded a Cloudflare-safe guess until it existed. Advisory: it
+    // is resolved for the user's DEFAULT uploader at connect time, so a per-upload
+    // override or an operator change mid-session is still settled by the 413.
+    const maxUploadBytes = effectiveUploadCapBytes(userId, findUserById(userId)?.role === 'admin');
     // Global ignore rules (network_id NULL) aren't tied to any one network blob,
     // so they ride alongside the per-network snapshot as their own field (#350).
     send(ws, {
@@ -1901,6 +1908,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       // connected without pre-checking GET /api/config still learns what the
       // server speaks and can degrade knowingly.
       protocolVersion: PROTOCOL_VERSION,
+      maxUploadBytes,
       networks,
       globalIgnores: ircManager.listGlobalIgnoresFor(userId),
       ...(isFreshConnect ? { cursor } : {}),

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1650,7 +1650,21 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
   });
 
   settingsService.on('event', ({ userId, changes }) => {
-    fanOut(userId, { kind: 'settings', changes: changes || {} });
+    // #627: the raw setting isn't the effective cap — it still has to clear the
+    // transport ceiling and any operator-baked policy cap. The user's OWN change
+    // already has a delivery path right here, so recompute rather than leaving
+    // them compressing against a stale number until they next reconnect (lower it
+    // and every upload 413s; raise it and they over-compress for nothing).
+    const touchedCap = changes && 'uploads.image.max_upload_mb' in changes;
+    fanOut(userId, {
+      kind: 'settings',
+      changes: changes || {},
+      ...(touchedCap
+        ? {
+            maxUploadBytes: effectiveUploadCapBytes(userId, findUserById(userId)?.role === 'admin'),
+          }
+        : {}),
+    });
     // If the user toggled / shortened auto-away while disconnected, re-evaluate
     // the pending timer with the new value.
     const touchedAway =


### PR DESCRIPTION
Closes #627.

Nothing told a client how big an upload could be, so lurker-ios hardcoded a Cloudflare-safe 90 MiB — wrong for a self-hoster with no CDN in front of them (their video gets over-compressed for nothing) and fragile for anyone whose proxy limit differs.

## The three ceilings

Only the smallest is useful to a client:

1. the 200 MB registry hard limit
2. the request-body limit of whatever sits **in front of** this instance
3. the per-user setting, or the operator-baked uploader policy cap

The server cannot detect (2) — a body over Cloudflare's limit dies at the edge with a connection reset the client sees as `cannotParseResponse`, long before Express is reached — so the operator declares it with `LURKER_MAX_UPLOAD_MB`. An env var rather than a tenant setting for the same reason the node-edition pipeline knobs are: it describes the deployment, and a tenant must not be able to raise it.

`server/services/uploadLimits.ts` is now the single source of truth. Multer's pre-read limit, the handler's 413, and the number handed to clients all resolve through it, so they cannot drift. Declaring a transport limit also converts an uninterpretable edge reset into a real 413 naming the number.

## What clients get

`maxUploadBytes` on the **`snapshot` frame** — every client already opens that socket, and one that needs a REST call to learn the cap will hardcode a guess instead, which is exactly what happened. Also on `GET /api/uploads` next to `providers` for REST-only readers, computed by the same function.

Advisory, not a contract: it resolves the **default** uploader, so a per-upload `uploaderId` override or an operator change mid-session is still settled by the 413. It is re-sent on the `settings` frame when the user changes their own cap, so the only staleness window left is the one with no delivery path.

## Two things worth reading closely

**The cap describes a body, not a file.** The first pass applied the transport limit as multer's `fileSize` and advertised it with no headroom — so a client doing exactly what the docs said (compress to `maxUploadBytes`) shipped a body just *over* the proxy's limit once the multipart boundaries, part headers, and `uploaderId`/`progressToken` fields were added. 64 KiB now comes off the top. Caught in review.

**Decimal MB, not MiB, for the transport value.** Proxies disagree — Cloudflare documents decimal, nginx's `client_max_body_size 100m` is MiB — and decimal is the smaller reading, so it's the safe one when the proxy's unit is unknown. Erring 4.8% low costs a self-hoster nothing; erring high is the edge reset again. The per-user setting keeps its MiB semantics. Both roundings are why bytes became the canonical unit, and why the 413 gained a decimal ("exceeds 5 MB" when the real limit is 4.7 sends the user back with another file that fails identically).

## Tests

`npm run check` clean, full suite green (217 files / 2909 tests). New coverage: ceiling ordering and precedence, the envelope headroom, decimal-vs-MiB, the warn-once on a bad value, the 1-byte floor, the advertised value on both surfaces, the transport-ceiling 413, and the cap on the snapshot and settings frames.

## Follow-ups (not in scope here)

- **lurker-ios**: drop the hardcoded `Uploads.maxBytes = 90 MiB` and compress against the advertised value.
- **web**: pre-flight an over-cap file instead of eating a 413.
- **`POST /api/imports`** accepts a 500 MB body without consulting the transport ceiling — same class of bug on the other multipart endpoint, but an import isn't something a client sizes media against, so it wants its own issue rather than a scope widening here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)