### PR TITLE
Clamp imports to the transport ceiling and warn before the upload (#649)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,13 @@ VAPID_SUBJECT=mailto:you@example.com
 # instance imposes a limit — the per-user cap (Settings → Uploads) then applies
 # on its own. Clamped to 200 MB, the hard ceiling.
 #
+# ⚠ This also caps ACCOUNT IMPORTS (Settings → Data), whose own limit is 500 MB
+# and which are NOT bound by the 200 MB upload ceiling. So setting this to 50 to
+# rein in image uploads also cuts the largest importable .lurk archive to 50 MB —
+# and an archive can't be compressed to fit the way media can. Set it to your
+# proxy's real limit, not to a number you picked to discourage big images; use
+# the per-user upload cap for that.
+#
 # A bare whole number of megabytes ("100MB" and "100m" do NOT work). A value that
 # won't parse is ignored with a warning logged the first time the cap is needed —
 # the first client connect or upload, NOT at boot — so check the logs after

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -763,6 +763,15 @@ real number. It is refreshed on reconnect, and re-sent on the `settings` frame
 whenever the user changes their own cap — so a client that reads it from both
 frames never compresses against a stale number.
 
+**Imports are capped separately.** `POST /api/imports` has its own, much larger
+limit (500 MB) and is **not** bound by the 200 MB upload ceiling — so
+`maxUploadBytes` is the wrong number to check an archive against. Read
+`maxImportBytes` from `GET /api/exports/preview` instead. Only the instance's
+transport limit is shared between the two, which does mean lowering
+`LURKER_MAX_UPLOAD_MB` lowers both. Over-limit archives get a `413` with
+`code: "archive_too_large"`; there is no way to compress an archive to fit, so
+check before uploading.
+
 ### DCC — `/api/dcc` (403 unless enabled for the account)
 
 `GET /?limit` list · `POST /:id/accept|reject|cancel`. Live updates via

--- a/server/routes/exports.test.ts
+++ b/server/routes/exports.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
 import { PassThrough } from 'stream';
 import Database from 'better-sqlite3';
 import type { LurkerTestAgent } from '../test-utils/testApp.js';
@@ -105,6 +105,33 @@ describe('GET /api/exports/preview', () => {
     const wm = (Object.values(res.body.withMessages) as number[]).reduce((s, n) => s + n, 0);
     expect(wm).toBeGreaterThanOrEqual(so);
   });
+
+  // #649: the pane needs this to refuse an over-limit archive at file-pick, so
+  // the user isn't told minutes into an upload that could never finish.
+  describe('maxImportBytes', () => {
+    afterEach(() => {
+      delete process.env.LURKER_MAX_UPLOAD_MB;
+    });
+
+    it('is the full 500 MB import limit when no transport ceiling is declared', async () => {
+      const res = await aliceAgent.get('/api/exports/preview');
+      expect(res.body.maxImportBytes).toBe(500 * 1024 * 1024);
+    });
+
+    // The regression this split exists to prevent: transportCapBytes() reports an
+    // UNSET ceiling as the upload path's 200 MB hard cap, so clamping to it would
+    // have quietly cut every self-hoster's import limit from 500 MB to 200 MB.
+    it('is never lowered to the upload hard cap by an unset ceiling', async () => {
+      const res = await aliceAgent.get('/api/exports/preview');
+      expect(res.body.maxImportBytes).toBeGreaterThan(200 * 1024 * 1024);
+    });
+
+    it('drops to the declared transport ceiling when the operator sets one', async () => {
+      process.env.LURKER_MAX_UPLOAD_MB = '100';
+      const res = await aliceAgent.get('/api/exports/preview');
+      expect(res.body.maxImportBytes).toBe(100 * 1_000_000 - 64 * 1024);
+    });
+  });
 });
 
 describe('export job flow', () => {
@@ -151,6 +178,25 @@ describe('POST /api/imports', () => {
   it('requires a file', async () => {
     const res = await aliceAgent.post('/api/imports');
     expect(res.status).toBe(400);
+  });
+
+  // #649: without this the body dies at the proxy with a connection reset the
+  // client can't interpret, because Express never sees the request at all.
+  it('refuses an archive over the declared transport ceiling with a real 413', async () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '1';
+    try {
+      const big = Buffer.alloc(2 * 1024 * 1024, 0x7a);
+      const res = await aliceAgent
+        .post('/api/imports')
+        .attach('archive', big, { filename: 'big.lurk' });
+      expect(res.status).toBe(413);
+      expect(res.body.code).toBe('archive_too_large');
+      // 1 decimal MB minus the multipart envelope = 934,464 bytes = 0.891 MiB,
+      // reported rounded DOWN so the number named is one the user can actually hit.
+      expect(res.body.error).toBe('archive exceeds 0.8 MB');
+    } finally {
+      delete process.env.LURKER_MAX_UPLOAD_MB;
+    }
   });
 
   it('rejects a non-zip body with code=not_a_zip', async () => {

--- a/server/routes/exports.ts
+++ b/server/routes/exports.ts
@@ -145,14 +145,34 @@ fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true, mode: 0o700 });
  * decrypted network passwords. Recreate it ourselves first, and chmod so a dir
  * that already exists with the wrong mode self-heals rather than staying wrong
  * for the life of the process.
+ *
+ * THROWS rather than proceeding if the mode can't be enforced. A chmod that
+ * fails on POSIX means the directory isn't ours to secure (EPERM — someone else
+ * owns it), and staging an archive of decrypted network passwords somewhere
+ * other local users can read it is worse than refusing the import. Refusing is
+ * loud, recoverable, and tells the operator something real; proceeding is a
+ * silent credential leak.
  */
 function ensureImportTmpDir(): void {
   fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true, mode: 0o700 });
   try {
     fs.chmodSync(IMPORT_TMP_DIR, 0o700);
-  } catch {
-    // Best-effort: a platform without POSIX modes (or a dir we don't own) must
-    // not take the import path down. The mkdir above is the load-bearing half.
+  } catch (err) {
+    // Windows has no POSIX modes — chmod there is a no-op at best and its
+    // st_mode is meaningless, so there is nothing to verify and nothing to
+    // refuse over.
+    if (process.platform === 'win32') return;
+    // chmod can also fail somewhere the mode is already fine (an exotic mount).
+    // Verify before refusing, so we fail on the actual exposure rather than on
+    // the syscall.
+    const mode = fs.statSync(IMPORT_TMP_DIR).mode & 0o777;
+    if ((mode & 0o077) === 0) return;
+    throw new Error(
+      `import staging dir ${IMPORT_TMP_DIR} is mode ${mode.toString(8)} and could not be ` +
+        `secured to 0700 (${err instanceof Error ? err.message : String(err)}); refusing to ` +
+        'stage an archive containing decrypted network credentials where other local users ' +
+        'can read it',
+    );
   }
 }
 
@@ -165,7 +185,17 @@ function ensureImportTmpDir(): void {
 // only makes the failure honest; #650 (chunked upload) is what makes a large
 // import possible on a CDN-fronted instance.
 const importUpload = (req: Request, res: Response, next: NextFunction): void => {
-  ensureImportTmpDir();
+  try {
+    ensureImportTmpDir();
+  } catch (err) {
+    // Operator-actionable, so say what's wrong rather than emitting a bare 500.
+    console.error('[lurker] import staging dir is not secure:', err);
+    res.status(500).json({
+      error: 'the server could not prepare a private staging directory for the import',
+      code: 'staging_dir_insecure',
+    });
+    return;
+  }
   const limit = clampToTransport(HARD_IMPORT_LIMIT);
   const handler = multer({
     dest: IMPORT_TMP_DIR,

--- a/server/routes/exports.ts
+++ b/server/routes/exports.ts
@@ -26,6 +26,7 @@ import { computeExportPreview } from '../services/exportService.js';
 import { startExport, toClientJob, exportArtifactPath } from '../services/exportJobs.js';
 import { getLatestJobForUser, getExportJobForUser, markDownloaded } from '../db/dataExports.js';
 import { importFromZipFile, ImportError } from '../services/importService.js';
+import { clampToTransport, formatCapMb } from '../services/uploadLimits.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 
 const router = Router();
@@ -46,6 +47,10 @@ router.get('/preview', (req: Request, res: Response, next: NextFunction) => {
       settingsOnly,
       withMessages,
       username: req.user!.username,
+      // #649: the import pane already fetches this on mount, so it rides along
+      // rather than costing a second request. Distinct from the upload cap on the
+      // snapshot — an archive gets its own, much larger, limit.
+      maxImportBytes: clampToTransport(HARD_IMPORT_LIMIT),
     });
   } catch (err) {
     next(err);
@@ -127,19 +132,40 @@ const IMPORT_TMP_DIR = path.join(os.tmpdir(), 'lurker-imports');
 // passwords, so other local users on a shared host mustn't be able to read the
 // staged upload. Matches the 0700/0600 posture on the export side.
 fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true, mode: 0o700 });
-const upload = multer({
-  dest: IMPORT_TMP_DIR,
-  // See routes/uploads.ts: busboy's default param charset is latin-1, which mangles
-  // any non-ASCII filename.
-  defParamCharset: 'utf8',
-  limits: { fileSize: HARD_IMPORT_LIMIT, files: 1 },
-});
+// Resolved per request, not once at module load, so the operator's declared
+// transport ceiling is read live (and so tests can drive it). #649: an archive
+// bigger than what the proxy in front of us will pass is rejected AT THE EDGE
+// with a connection reset — Express never sees the request, and the 500 MB limit
+// below is never consulted. Borrowing the ceiling turns that into a real 413
+// naming a size. Unlike an upload an archive can't be compressed to fit, so this
+// only makes the failure honest; #650 (chunked upload) is what makes a large
+// import possible on a CDN-fronted instance.
+const importUpload = (req: Request, res: Response, next: NextFunction): void => {
+  const limit = clampToTransport(HARD_IMPORT_LIMIT);
+  const handler = multer({
+    dest: IMPORT_TMP_DIR,
+    // See routes/uploads.ts: busboy's default param charset is latin-1, which mangles
+    // any non-ASCII filename.
+    defParamCharset: 'utf8',
+    limits: { fileSize: limit, files: 1 },
+  }).single('archive');
+  handler(req, res, (err: unknown) => {
+    if ((err as { code?: string })?.code === 'LIMIT_FILE_SIZE') {
+      res.status(413).json({
+        error: `archive exceeds ${formatCapMb(limit)} MB`,
+        code: 'archive_too_large',
+      });
+      return;
+    }
+    next(err as Error | undefined);
+  });
+};
 
 // POST /api/imports — upload an export zip and restore it into the
 // caller's account. Refuses if the account already has data.
 importRouter.post(
   '/',
-  upload.single('archive'),
+  importUpload,
   asyncHandler(async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!req.file) {

--- a/server/routes/exports.ts
+++ b/server/routes/exports.ts
@@ -132,6 +132,30 @@ const IMPORT_TMP_DIR = path.join(os.tmpdir(), 'lurker-imports');
 // passwords, so other local users on a shared host mustn't be able to read the
 // staged upload. Matches the 0700/0600 posture on the export side.
 fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true, mode: 0o700 });
+
+/**
+ * Re-assert the staging dir and its mode before each import.
+ *
+ * Multer's DiskStorage constructor runs `fs.mkdirSync(dest, {recursive:true})`
+ * with NO mode (multer/storage/disk.js). While multer was built once at module
+ * load that was a harmless no-op — the 0700 mkdir above had just run. Building
+ * it per request means a tmp reaper (systemd-tmpfiles, macOS's /var/folders
+ * cleaner) that removes the dir while the process is up would have multer
+ * recreate it at 0777 & ~umask, i.e. world-readable, holding archives full of
+ * decrypted network passwords. Recreate it ourselves first, and chmod so a dir
+ * that already exists with the wrong mode self-heals rather than staying wrong
+ * for the life of the process.
+ */
+function ensureImportTmpDir(): void {
+  fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(IMPORT_TMP_DIR, 0o700);
+  } catch {
+    // Best-effort: a platform without POSIX modes (or a dir we don't own) must
+    // not take the import path down. The mkdir above is the load-bearing half.
+  }
+}
+
 // Resolved per request, not once at module load, so the operator's declared
 // transport ceiling is read live (and so tests can drive it). #649: an archive
 // bigger than what the proxy in front of us will pass is rejected AT THE EDGE
@@ -141,6 +165,7 @@ fs.mkdirSync(IMPORT_TMP_DIR, { recursive: true, mode: 0o700 });
 // only makes the failure honest; #650 (chunked upload) is what makes a large
 // import possible on a CDN-fronted instance.
 const importUpload = (req: Request, res: Response, next: NextFunction): void => {
+  ensureImportTmpDir();
   const limit = clampToTransport(HARD_IMPORT_LIMIT);
   const handler = multer({
     dest: IMPORT_TMP_DIR,

--- a/server/services/uploadLimits.test.ts
+++ b/server/services/uploadLimits.test.ts
@@ -113,6 +113,44 @@ describe('effectiveUploadCapBytes', () => {
   });
 });
 
+// #649: a caller with its own, larger limit (imports allow 500 MB) needs the raw
+// declaration. transportCapBytes() reports "unset" as the upload path's 200 MB
+// hard cap, so reusing it would have silently cost imports 300 MB of headroom.
+describe('clampToTransport', () => {
+  const IMPORT_LIMIT = 500 * 1024 * 1024;
+
+  it('leaves a larger own-limit ALONE when no ceiling is declared', () => {
+    expect(limits.clampToTransport(IMPORT_LIMIT)).toBe(IMPORT_LIMIT);
+    expect(limits.transportCapBytes()).toBe(limits.MAX_CAP_BYTES); // the trap
+  });
+
+  it('lowers it to the declared ceiling', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '100';
+    expect(limits.clampToTransport(IMPORT_LIMIT)).toBe(100 * 1_000_000 - ENVELOPE);
+  });
+
+  it('never RAISES an own-limit that is already lower than the ceiling', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '400';
+    expect(limits.clampToTransport(10 * 1024 * 1024)).toBe(10 * 1024 * 1024);
+  });
+
+  it('is not bounded by the upload hard cap — that is an upload-path rule', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '400';
+    expect(limits.clampToTransport(IMPORT_LIMIT)).toBeGreaterThan(limits.MAX_CAP_BYTES);
+  });
+});
+
+describe('declaredTransportCapBytes', () => {
+  it('is null when unset, distinguishing "no ceiling" from "200 MB"', () => {
+    expect(limits.declaredTransportCapBytes()).toBeNull();
+  });
+
+  it('is null for a value that will not parse', () => {
+    process.env.LURKER_MAX_UPLOAD_MB = '100m';
+    expect(limits.declaredTransportCapBytes()).toBeNull();
+  });
+});
+
 describe('clampUploadCapBytes', () => {
   it('never resolves to a zero or negative cap', () => {
     expect(limits.clampUploadCapBytes(0)).toBe(1);

--- a/server/services/uploadLimits.test.ts
+++ b/server/services/uploadLimits.test.ts
@@ -146,6 +146,11 @@ describe('declaredTransportCapBytes', () => {
   });
 
   it('is null for a value that will not parse', () => {
+    // Stub console.warn: this trips the warn-once path, and whether it actually
+    // prints depends on whether an earlier test already latched it. Stubbing
+    // makes the output the same either way, so reordering this file can't start
+    // spraying warnings through an unrelated suite run.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     process.env.LURKER_MAX_UPLOAD_MB = '100m';
     expect(limits.declaredTransportCapBytes()).toBeNull();
   });

--- a/server/services/uploadLimits.ts
+++ b/server/services/uploadLimits.ts
@@ -17,10 +17,11 @@
 //   3. the per-user cap  the operator-baked uploader policy (hosted locked row),
 //                        else the user's own `uploads.image.max_upload_mb`.
 //
-// Every upload path that enforces or advertises a cap goes through here, so
+// Every path that enforces or advertises a size cap goes through here, so
 // multer's limit, the handler's 413, and the number we hand clients can never
-// disagree. (`POST /api/imports` has its own, much larger, body limit and is
-// deliberately not covered — it isn't something a client sizes media against.)
+// disagree. `POST /api/imports` keeps its own much larger limit (an archive isn't
+// something a client sizes media against) but borrows the transport ceiling via
+// clampToTransport — see #649.
 //
 // Bytes, not MB, is the canonical unit: it's what multer takes, what a client
 // compares a file size against, and the only unit in which the transport
@@ -68,10 +69,11 @@ export function userCapBytes(settings: Record<string, unknown>): number {
 let warnedBadTransportCap = false;
 
 /**
- * The instance's transport ceiling in bytes: the largest request body that can
- * actually reach this process, as declared by the operator. Unset (the
- * self-hoster with nothing in front of them) → MAX_CAP_BYTES, i.e. no extra
- * ceiling.
+ * What the operator DECLARED, in bytes, or null when they declared nothing —
+ * the self-hoster with no proxy in front of them. Not clamped to any upload
+ * ceiling: a caller with its own, larger limit (`POST /api/imports` allows
+ * 500 MB) needs the raw declaration, and would silently lose 300 MB of headroom
+ * if "unset" were reported as the upload path's 200 MB hard cap.
  *
  * Deliberately an env var rather than a tenant setting, for the same reason the
  * node-edition pipeline knobs are: it describes the deployment, not a preference,
@@ -83,9 +85,9 @@ let warnedBadTransportCap = false;
  * the safe one when the proxy's own unit is unknown. Erring 4.8% low costs a
  * self-hoster nothing; erring high is the edge reset again.
  */
-export function transportCapBytes(): number {
+export function declaredTransportCapBytes(): number | null {
   const raw = (process.env.LURKER_MAX_UPLOAD_MB || '').trim();
-  if (!raw) return MAX_CAP_BYTES;
+  if (!raw) return null;
   const mb = Math.floor(Number(raw));
   if (!Number.isFinite(mb) || mb <= 0) {
     // "100MB" / "100m" — the natural typo, given the var is named _MB — parses to
@@ -101,9 +103,25 @@ export function transportCapBytes(): number {
           'Use a bare integer, e.g. LURKER_MAX_UPLOAD_MB=100.',
       );
     }
-    return MAX_CAP_BYTES;
+    return null;
   }
-  return Math.min(mb * 1_000_000 - ENVELOPE_HEADROOM_BYTES, MAX_CAP_BYTES);
+  return mb * 1_000_000 - ENVELOPE_HEADROOM_BYTES;
+}
+
+/** The transport ceiling as the UPLOAD path sees it: the declaration, else no
+ *  extra ceiling beyond the hard cap. */
+export function transportCapBytes(): number {
+  return Math.min(declaredTransportCapBytes() ?? MAX_CAP_BYTES, MAX_CAP_BYTES);
+}
+
+/**
+ * Apply the transport ceiling to a caller that has its OWN limit — currently the
+ * import route's 500 MB. Nothing here involves the upload hard cap or a user's
+ * preference; it answers only "can a body this big reach us at all".
+ */
+export function clampToTransport(ownLimitBytes: number): number {
+  const declared = declaredTransportCapBytes();
+  return declared == null ? ownLimitBytes : Math.max(1, Math.min(ownLimitBytes, declared));
 }
 
 /** Clamp a candidate cap to the instance-wide ceilings. Floors at 1 byte so no

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -76,7 +76,7 @@
         <span class="muted small">({{ formatBytes(chosenFile.size) }})</span>
       </div>
       <div class="actions">
-        <button class="link" :disabled="importing || !confirmed" @click="onImport">
+        <button class="link" :disabled="importing || !confirmed || tooLarge" @click="onImport">
           {{ importing ? `importing… ${progress}%` : 'import' }}
         </button>
         <button v-if="!importing" class="link danger" @click="onCancelFile">cancel</button>
@@ -99,6 +99,9 @@ import { useDataExportStore } from '../../stores/dataExport.js';
 interface ExportPreview {
   settingsOnly: Record<string, number>;
   withMessages: { messages: number };
+  // The largest archive this instance can actually receive — the 500 MB limit,
+  // lowered to whatever proxy sits in front of it (#649).
+  maxImportBytes?: number;
 }
 
 const router = useRouter();
@@ -143,6 +146,13 @@ const confirmed = ref(false);
 
 // `users` is always 1 (the row representing the caller); excluding it so a
 // brand-new account with no real activity reads as 0 small rows instead of 1.
+// An archive the instance can't receive. Blocks the button as well as showing the
+// error: the whole point is not starting an upload that cannot finish.
+const tooLarge = computed(() => {
+  const cap = preview.value?.maxImportBytes;
+  return Boolean(cap && chosenFile.value && chosenFile.value.size > cap);
+});
+
 const SMALL_ROW_EXCLUDE = new Set(['networks', 'messages', 'user_bookmarks', 'users']);
 const totalSmallRows = computed(() => {
   if (!preview.value) return 0;
@@ -188,6 +198,16 @@ function onFileChosen(e: Event) {
   importError.value = '';
   importNotice.value = '';
   confirmed.value = false;
+  // Say so BEFORE the upload rather than after it (#649). An over-limit archive
+  // on a CDN-fronted instance doesn't come back as a 413 — it dies at the edge
+  // as an opaque network error, minutes into uploading a file that never had a
+  // chance. The size is known the instant the file is picked.
+  const cap = preview.value?.maxImportBytes;
+  if (cap && f.size > cap) {
+    importError.value =
+      `This archive is ${formatBytes(f.size)}, but this instance can only accept ` +
+      `${formatBytes(cap)}. Uploading it would fail partway through.`;
+  }
 }
 
 function onCancelFile() {

--- a/vue_client/src/components/settings-panes/DataPane.vue
+++ b/vue_client/src/components/settings-panes/DataPane.vue
@@ -64,6 +64,7 @@
       Imports replace nothing — the target account must be empty. Sign in to the new instance as a
       fresh user, then drop the .zip file here.
     </p>
+    <p v-if="tooLargeMessage" class="error inline">{{ tooLargeMessage }}</p>
     <p v-if="importError" class="error inline">{{ importError }}</p>
     <p v-if="importNotice" class="muted small">{{ importNotice }}</p>
 
@@ -144,15 +145,30 @@ const importing = ref(false);
 const progress = ref(0);
 const confirmed = ref(false);
 
-// `users` is always 1 (the row representing the caller); excluding it so a
-// brand-new account with no real activity reads as 0 small rows instead of 1.
-// An archive the instance can't receive. Blocks the button as well as showing the
-// error: the whole point is not starting an upload that cannot finish.
+// An archive this instance can't receive (#649). Derived, not set once at pick
+// time: `preview` arrives asynchronously while the file input is already
+// interactive, so a file chosen before it lands would otherwise disable the
+// import button with no explanation of why — a dead end whose only exit is
+// cancel. As a computed, the message appears the moment the cap is known.
+//
+// A cap we never learned (the preview fetch failed) means no client-side gate,
+// which is a graceful degradation rather than a hole: the server enforces the
+// same number and now answers with a real 413 naming it (#649) instead of the
+// edge reset that made this worth pre-flighting in the first place.
 const tooLarge = computed(() => {
   const cap = preview.value?.maxImportBytes;
   return Boolean(cap && chosenFile.value && chosenFile.value.size > cap);
 });
+const tooLargeMessage = computed(() =>
+  tooLarge.value
+    ? `This archive is ${formatBytes(chosenFile.value!.size)}, but this instance can ` +
+      `only accept ${formatBytes(preview.value!.maxImportBytes!)}. Uploading it would ` +
+      `fail partway through.`
+    : '',
+);
 
+// `users` is always 1 (the row representing the caller); excluding it so a
+// brand-new account with no real activity reads as 0 small rows instead of 1.
 const SMALL_ROW_EXCLUDE = new Set(['networks', 'messages', 'user_bookmarks', 'users']);
 const totalSmallRows = computed(() => {
   if (!preview.value) return 0;
@@ -198,16 +214,8 @@ function onFileChosen(e: Event) {
   importError.value = '';
   importNotice.value = '';
   confirmed.value = false;
-  // Say so BEFORE the upload rather than after it (#649). An over-limit archive
-  // on a CDN-fronted instance doesn't come back as a 413 — it dies at the edge
-  // as an opaque network error, minutes into uploading a file that never had a
-  // chance. The size is known the instant the file is picked.
-  const cap = preview.value?.maxImportBytes;
-  if (cap && f.size > cap) {
-    importError.value =
-      `This archive is ${formatBytes(f.size)}, but this instance can only accept ` +
-      `${formatBytes(cap)}. Uploading it would fail partway through.`;
-  }
+  // The over-limit warning is NOT set here — see tooLargeMessage. It has to
+  // survive `preview` landing after the file was picked.
 }
 
 function onCancelFile() {


### PR DESCRIPTION
Closes #649. Follow-up to #648.

`POST /api/imports` never learned about `LURKER_MAX_UPLOAD_MB`, so on a CDN-fronted instance a large `.lurk` was rejected **at the edge** with a connection reset — Express never saw the request, the 500 MB limit was never consulted, and the user got an opaque network error minutes into uploading a file that never had a chance.

## The trap this had to avoid

Reusing `transportCapBytes()` here would have been a silent 300 MB regression. It reports an **unset** ceiling as the upload path's 200 MB hard cap — correct for uploads, wrong for anyone with their own larger limit. Split out `declaredTransportCapBytes()` (null when the operator declared nothing) and `clampToTransport(ownLimit)`, which imports uses. There's a test asserting the trap directly, so it can't come back.

multer is now built per request rather than once at module load, so the declaration is read live, and `LIMIT_FILE_SIZE` becomes a `413` naming a size instead of falling through to the generic error handler.

## Client

`GET /api/exports/preview` — already fetched on mount by the Data pane — carries `maxImportBytes`, and the pane refuses an over-limit archive at file-pick: message shown, import button disabled. The size is known the instant the file is chosen; there's no reason to learn this by failing.

## Scope

This only makes the failure **honest**. An archive can't be compressed to fit the way media can, so a hosted user whose export exceeds the CDN limit still cannot restore it — #650 (chunked upload) is what makes that possible. Worth stating plainly: Lurker can currently produce an export artifact it cannot re-ingest.

## Review fixes (second commit)

`/code-review high` found four, one of which was a security regression this PR introduced:

- **Moving multer per-request weakened the staging dir's 0700 posture.** multer's `DiskStorage` constructor runs `fs.mkdirSync(dest, {recursive:true})` with **no mode**. Harmless as a module-load no-op; per request, a tmp reaper removing the dir mid-process would have multer recreate it at `0777 & ~umask` — world-readable, holding archives containing the source account's *decrypted network passwords*. Now re-asserted before each import, with a chmod so an already-wrong dir self-heals.
- **The over-limit warning raced the preview fetch** — set imperatively at file-pick from a `preview` that arrives asynchronously, so picking a file first meant no message and then a silently disabled button. Now a computed.
- **`LURKER_MAX_UPLOAD_MB` was documented purely as a media knob**, but it now also caps imports (whose own limit is 500 MB, deliberately not bound by the 200 MB upload ceiling). Called out in `.env.example`; `CLIENT_PROTOCOL.md` now points clients at `maxImportBytes` rather than letting them check an archive against `maxUploadBytes`.
- A comment/const separation nit.

## Tests

`npm run check` clean, full suite green. New coverage: the unset-ceiling trap, transport clamping in both directions, the `413` and its `archive_too_large` code, and `maxImportBytes` on the preview payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)