### PR TITLE
Add /j and /p aliases and a /shrug command (#412, #532)

### DIFF
--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -417,6 +417,23 @@ describe('MessageInput command dispatch', () => {
     );
   });
 
+  // /shrug produces a real PRIVMSG body, so it has to face the same split gate a
+  // plain message does. Without teaching bodyForSplit about it, the estimator
+  // reported 0 chunks and the identical text went straight out unconfirmed just
+  // because it was typed behind a slash command.
+  it('gates a long /shrug behind the split confirmation, like plain text', async () => {
+    seedStores('#zebra');
+    const { el } = await mountComposer();
+
+    await type(el, `/shrug ${'x'.repeat(900)}`);
+    await enter(el);
+    expect(socketSendWithAck).not.toHaveBeenCalled();
+
+    // Send again to confirm — the gate is a confirmation, not a refusal.
+    await enter(el);
+    expect(socketSendWithAck).toHaveBeenCalledTimes(1);
+  });
+
   it('a bare /shrug sends the kaomoji alone, with no leading space', async () => {
     seedStores('#zebra');
     const { el } = await mountComposer();

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -28,8 +28,11 @@ vi.mock('../composables/useSocket.js', () => ({
   onSocketOpen: vi.fn<() => () => void>(() => () => {}),
 }));
 
-// The mocked socketSend, so the command-dispatch tests can assert the wire payload.
-import { socketSend } from '../composables/useSocket.js';
+// The mocked socket senders, so the command-dispatch tests can assert the wire
+// payload. Which one a command uses is not incidental: `sendOrToast` fires
+// socketSend, while anything that wants delivery confirmation (`ackedSend`, and
+// so every message-shaped command) goes through socketSendWithAck.
+import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
 
 const CHANNELS = ['#apple', '#mango', '#zebra'];
 // `mallory` exists so the self-exclusion test has a positive control: without a
@@ -269,9 +272,13 @@ describe('MessageInput command dispatch', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.mocked(socketSend).mockClear();
+    vi.mocked(socketSendWithAck).mockClear();
     // sendOrToast reads the return value to decide whether to toast a failure; a
     // real open socket returns true, so make the mock say the send landed.
     vi.mocked(socketSend).mockReturnValue(true as never);
+    // ackedSend treats a null return as "socket closed" and bails before the
+    // payload matters, so hand it a resolved ack.
+    vi.mocked(socketSendWithAck).mockReturnValue(Promise.resolve({ ok: true }) as never);
   });
 
   afterEach(() => {
@@ -328,5 +335,97 @@ describe('MessageInput command dispatch', () => {
       channel: '#zebra',
       reason: '',
     });
+  });
+
+  // #412. Worth real coverage rather than trusting the switch: an unknown command
+  // falls through to `default:`, which ships it as a RAW IRC line — so before this
+  // existed, `/p cya` didn't fail loudly, it sent the server a bogus `p cya`.
+  it('/p is an alias for /part, reason parsing and all', async () => {
+    seedStores('#zebra');
+    const { el } = await mountComposer();
+
+    await type(el, '/p heading out');
+    await enter(el);
+
+    expect(socketSend).toHaveBeenCalledWith({
+      type: 'part',
+      networkId: 1,
+      channel: '#zebra',
+      reason: 'heading out',
+    });
+  });
+
+  // The reason is sliced with `line.slice(1 + cmd.length)`, so a shorter alias
+  // would silently eat or keep the wrong characters if that were hardcoded.
+  it('/p <#chan> [reason] retargets like /part does', async () => {
+    seedStores('#zebra');
+    const { el } = await mountComposer();
+
+    await type(el, '/p #mango cya');
+    await enter(el);
+
+    expect(socketSend).toHaveBeenCalledWith({
+      type: 'part',
+      networkId: 1,
+      channel: '#mango',
+      reason: 'cya',
+    });
+  });
+
+  // A channel NOT in the seeded set: joinOrActivate short-circuits to a plain
+  // activate() for a buffer that's already open and joined, so asserting the
+  // JOIN went out needs a channel the user isn't in.
+  it('/j is an alias for /join', async () => {
+    seedStores('#zebra');
+    const { el } = await mountComposer();
+
+    await type(el, '/j #brandnew');
+    await enter(el);
+
+    expect(socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'join', networkId: 1, channel: '#brandnew' }),
+    );
+  });
+
+  it('/j applies the same #-prefix normalization as /join', async () => {
+    seedStores('#zebra');
+    const { el } = await mountComposer();
+
+    await type(el, '/j brandnew');
+    await enter(el);
+
+    expect(socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'join', channel: '#brandnew' }),
+    );
+  });
+
+  // #532. A plain message, not an ACTION — /shrug SAYS the kaomoji.
+  it('/shrug says the kaomoji after your text', async () => {
+    seedStores('#zebra');
+    const { el } = await mountComposer();
+
+    await type(el, '/shrug no idea');
+    await enter(el);
+
+    expect(socketSendWithAck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'send',
+        networkId: 1,
+        target: '#zebra',
+        text: 'no idea ¯\\_(ツ)_/¯',
+      }),
+    );
+  });
+
+  it('a bare /shrug sends the kaomoji alone, with no leading space', async () => {
+    seedStores('#zebra');
+    const { el } = await mountComposer();
+
+    await type(el, '/shrug');
+    await enter(el);
+
+    expect(socketSendWithAck).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'send', text: '¯\\_(ツ)_/¯' }),
+    );
   });
 });

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2092,12 +2092,13 @@ const COMMANDS_LINES = [
   'commands:',
   '  /me <text>             — emote in the current buffer',
   '  /slap <nick>           — slap someone around a bit with a large trout',
+  '  /shrug [text]          — say your text followed by ¯\\_(ツ)_/¯',
   '  /msg <nick> <text>     — open a DM and send (alias: /query)',
   '  /notice <tgt> <text>   — send a NOTICE to a channel or nick',
   '  /ns <text>             — message NickServ (e.g. identify <pass>)',
   '  /cs <text>             — message ChanServ',
-  '  /join <#chan>          — join a channel',
-  '  /part [#chan] [reason] — leave channel (keeps buffer; alias: /leave)',
+  '  /join <#chan>          — join a channel (alias: /j)',
+  '  /part [#chan] [reason] — leave channel (keeps buffer; aliases: /leave, /p)',
   '  /close                 — close current buffer (parts if channel)',
   '  /clear [off]           — hide buffer up to now (off = undo, show again)',
   '  /away [message]        — set away across every network (no arg clears)',
@@ -2814,6 +2815,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       return sendOrToast({ type: 'raw', networkId, line: `PRIVMSG ${service} :${argLine}` }, line);
     }
     case 'join':
+    case 'j':
       if (rest[0]) {
         const ch = ensureChannelPrefix(rest[0]);
         // A channel key is a single whitespace-free token — take just the next
@@ -2828,7 +2830,8 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       }
       return true;
     case 'part':
-    case 'leave': {
+    case 'leave':
+    case 'p': {
       // /part leaves the channel but KEEPS the buffer so the user can scroll
       // history and rejoin later. The buffer just renders dimmed in the
       // sidebar. Use /close to actually drop a buffer.
@@ -3183,6 +3186,19 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       }
       const slapText = `slaps ${who} around a bit with a large trout`;
       return ackedSend({ type: 'action', networkId, target, text: slapText }, slapText);
+    }
+    case 'shrug': {
+      // A plain message, not an ACTION: everywhere this convention comes from
+      // (Slack, Discord, mIRC scripts) /shrug SAYS the kaomoji, optionally after
+      // your own text — "/shrug no idea" reads as "no idea ¯\_(ツ)_/¯".
+      if (isServer.value) {
+        localInfo(networkId, target, 'usage: /shrug [text] — run inside a channel or DM');
+        return true;
+      }
+      // The backslash is literal: Lurker's inline formatting is IRC control
+      // codes (\x02, \x1D…), not markdown, so nothing eats the `\_`.
+      const shrugText = argLine ? `${argLine} ¯\\_(ツ)_/¯` : '¯\\_(ツ)_/¯';
+      return ackedSend({ type: 'send', networkId, target, text: shrugText }, shrugText);
     }
     // Info/query commands. These already function via the raw fallback now that
     // unhandled server numerics surface in the server buffer (#269) — listing

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -472,6 +472,17 @@ const longMessageChunks = ref(0);
 const longMessageMultiline = ref(false);
 const longMessageUploading = ref(false);
 
+// The /shrug payload (#532). The backslash is literal — Lurker's inline
+// formatting is IRC control codes (\x02, \x1D…), not markdown, so nothing tries
+// to read `\_` as an escape. Shared by the send path and the split estimator so
+// the "will split into N lines" count is measured against the exact bytes that
+// go on the wire.
+const SHRUG = '¯\\_(ツ)_/¯';
+function shrugBody(text: string): string {
+  const trimmed = text.trim();
+  return trimmed ? `${trimmed} ${SHRUG}` : SHRUG;
+}
+
 // Strip a leading slash command (/me, /msg <who>) so chunk counting reflects
 // what irc-framework actually has to encode. For /me the relevant bytes are
 // the action body, not the slash-command prefix. For /msg the body goes to
@@ -490,6 +501,11 @@ function bodyForSplit(raw: string): { body: string; isAction: boolean } {
   if (!m) return { body: '', isAction: false };
   const cmd = m[1].toLowerCase();
   if (cmd === 'me') return { body: m[2], isAction: true };
+  // /shrug produces a real PRIVMSG body, so it carries the same split/flood risk
+  // a plain message does — count the kaomoji too, since it's part of what goes on
+  // the wire. Built by the same helper the send path uses so the estimate and the
+  // payload can't drift.
+  if (cmd === 'shrug') return { body: shrugBody(m[2]), isAction: false };
   if (cmd === 'msg' || cmd === 'query') {
     // /msg <who> <body...> — drop the recipient nick from the body.
     const rest = m[2];
@@ -3195,9 +3211,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
         localInfo(networkId, target, 'usage: /shrug [text] — run inside a channel or DM');
         return true;
       }
-      // The backslash is literal: Lurker's inline formatting is IRC control
-      // codes (\x02, \x1D…), not markdown, so nothing eats the `\_`.
-      const shrugText = argLine ? `${argLine} ¯\\_(ツ)_/¯` : '¯\\_(ツ)_/¯';
+      const shrugText = shrugBody(argLine);
       return ackedSend({ type: 'send', networkId, target, text: shrugText }, shrugText);
     }
     // Info/query commands. These already function via the raw fallback now that


### PR DESCRIPTION
Closes #412. Closes #532.

`/j` → `/join`, `/p` → `/part` (the two most common mIRC/irssi shortcuts), plus `/shrug`.

## These weren't failing loudly before

An unhandled command falls through to `default:`, which ships the line as **raw IRC** — so `/p cya` didn't say "unknown command", it sent the server a bogus `p cya`. Hence real dispatch tests for the aliases rather than trusting the switch: `/p` in particular slices its reason with `line.slice(1 + cmd.length)`, so a shorter alias would quietly eat the wrong characters if that length were ever hardcoded.

## /shrug

Sends a plain message, not an ACTION — everywhere the convention comes from (Slack, Discord, mIRC scripts) it *says* the kaomoji, optionally after your own text. That turns out to be load-bearing beyond convention: `refuseCleartextOnE2eChannel` (`ircManager.ts:530`) rejects ACTION on E2E channels, so a `/slap`-style implementation would have been silently dead on those buffers.

The backslash in `¯\_(ツ)_/¯` is literal and needs no escaping — Lurker's inline formatting is IRC control codes (`\x02`, `\x1D`…), not markdown, so nothing tries to read `\_` as an escape.

## Review fix (second commit)

`/code-review high` found no blockers and two low-severity gaps from `/shrug` producing a real PRIVMSG body outside the plain-send pipeline:

- **Fixed:** `bodyForSplit` only special-cased `me`/`msg`/`query`, so `/shrug <450 chars>` reported 0 chunks and went out with no split confirmation, while the identical text typed plainly hits the gate. `/notice` has the same hole, but that's a pre-existing bug to inherit, not one to add to — `/me` is handled, and a command producing a message body should face the same gate a message does. The payload construction moved into a shared `shrugBody()` used by both the send path and the estimator, so the chunk count is measured against the exact bytes on the wire.
- **Not fixed, deliberately:** `/shrug ||secret||` sends literal pipes rather than IRC spoiler codes. `/me` and `/msg` behave identically, so fixing it only here would make `/shrug` the odd one out in the other direction — filed as #652 for all of them.

## Note

The iOS client parses commands independently (`LurkerKit` `CommandParser`, which has `part`/`leave` but no aliases), so these are web-only until added there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)