### PR TITLE
Gate auto-reconnect on the same policy every connect clears (#616, #617)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1460,6 +1460,30 @@ describe('auto-reconnect controller', () => {
       expect(conn.connect).not.toHaveBeenCalled();
     });
 
+    // A gate that THROWS is not a gate that refuses. It reads the DB, so
+    // SQLITE_BUSY or a closed handle can take it out — and connectScheduler only
+    // console.errors a throwing task, with the backoff timer already spent. If
+    // this escaped, the network would sit on "Reconnecting…" with nothing left
+    // to fire it.
+    it('re-arms rather than stranding the network when the gate throws', () => {
+      vi.useFakeTimers();
+      let throws = true;
+      const { conn } = makeGatedConn('rc-gate-throws', () => {
+        if (throws) throw new Error('SQLITE_BUSY: database is locked');
+        return { ok: true };
+      });
+      conn.client.emit('close', true);
+      // Bounded advance, not runAllTimers: a re-arming ladder never drains.
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      // The failed reads cost attempts, not the ladder itself.
+      expect(conn.connect).not.toHaveBeenCalled();
+      expect(conn.state).toBe('reconnecting');
+
+      throws = false;
+      vi.advanceTimersByTime(5 * 60 * 1000);
+      expect(conn.connect).toHaveBeenCalledTimes(1);
+    });
+
     it('stops the ladder — a refusal does not schedule another attempt', () => {
       vi.useFakeTimers();
       const { conn } = makeGatedConn('rc-gate-stops', () => ({
@@ -1488,64 +1512,80 @@ describe('auto-reconnect controller', () => {
     ).toBe(true);
   });
 
-  it('stops (no reconnect) on a hard SASL authentication failure', () => {
+  // Was "stops on a hard SASL authentication failure" — stopping on the FIRST
+  // one is the behavior #617 changed, because a rejection the server didn't drop
+  // us for would kill an unrelated later drop's reconnect. The intent it was
+  // written for (bad credentials must not retry forever) is unchanged and still
+  // asserted here; only the count moved.
+  it('stops after a hard SASL authentication failure repeats', () => {
     vi.useFakeTimers();
     const { conn, events } = makeConn('rc-sasl');
-    conn.client.emit('sasl failed', { reason: 'fail' });
-    conn.client.emit('close', true);
-    vi.runAllTimers();
-    expect(conn.connect).not.toHaveBeenCalled();
+    for (let i = 0; i < 3; i += 1) {
+      conn.client.emit('sasl failed', { reason: 'fail' });
+      conn.client.emit('close', true);
+      vi.runAllTimers();
+    }
+    // Two retries, then the ladder ends — bounded, not a failed-login hammer.
+    expect(conn.connect).toHaveBeenCalledTimes(2);
     expect(
       events.some((e) => e.type === 'error' && /SASL authentication failed/i.test(String(e.text))),
     ).toBe(true);
   });
 
-  // #617: the window that made the conservative policy wrong. On a network where
-  // SASL is OPTIONAL the server doesn't drop us for a failed auth — so a socket
-  // that dies much later died of something else (a stalled registration timing
-  // out, a network blip) and must get the ordinary backoff ladder. Before this,
-  // that unrelated drop inherited the SASL flag and killed reconnect forever.
-  it('does not blame a much-later socket close on an earlier SASL failure', () => {
+  // #617: a single rejection is not proof the credentials killed THIS socket. On
+  // a network where SASL is optional the server keeps us, so a later drop (a
+  // stalled registration timing out, a blip) is unrelated and must still retry —
+  // before this, that drop inherited the flag and killed reconnect forever.
+  it('does not give up on the first SASL failure', () => {
     vi.useFakeTimers();
-    const { conn } = makeConn('rc-sasl-stale');
+    const { conn } = makeConn('rc-sasl-first');
     conn.client.emit('sasl failed', { reason: 'fail' });
-    // The connection lived on well past the handshake — proof the server did not
-    // drop us for the rejection.
-    vi.advanceTimersByTime(60_000);
     conn.client.emit('close', true);
     vi.runAllTimers();
     expect(conn.connect).toHaveBeenCalledTimes(1);
   });
 
-  // The other half: a server that REQUIRES SASL drops the link as part of the
-  // handshake, and retrying that is a fast failed-login hammer. Still terminal.
-  it('still stops when the close follows the SASL failure immediately', () => {
+  // The optional-SASL recovery path the streak exists to protect: registering
+  // unauthenticated proves the credentials aren't fatal here, so the count starts
+  // over and a much later drop is still just a drop.
+  it('resets the streak when registration succeeds despite repeated SASL failures', () => {
     vi.useFakeTimers();
-    const { conn } = makeConn('rc-sasl-prompt');
+    const { conn } = makeConn('rc-sasl-reset');
+    (conn.client as unknown as { options: unknown }).options = {
+      ping_interval: 0,
+      ping_timeout: 0,
+    };
+    for (let i = 0; i < 2; i += 1) {
+      conn.client.emit('sasl failed', { reason: 'fail' });
+      conn.client.emit('close', true);
+      vi.runAllTimers();
+    }
+    conn.client.emit('registered', { nick: 'nick' });
+
+    // A third failure now starts a fresh streak rather than tipping the old one.
     conn.client.emit('sasl failed', { reason: 'fail' });
-    vi.advanceTimersByTime(200);
     conn.client.emit('close', true);
     vi.runAllTimers();
-    expect(conn.connect).not.toHaveBeenCalled();
+    expect(conn.connect).toHaveBeenCalledTimes(3);
   });
 
-  // A rejection that demonstrably did NOT kill its own socket must not sit around
-  // waiting to be blamed for the NEXT one.
+  // A rejection that didn't kill its own socket must not linger to be blamed for
+  // a later one.
   it('consumes the pending SASL failure at the close it survived', () => {
     vi.useFakeTimers();
     const { conn } = makeConn('rc-sasl-consumed');
     conn.client.emit('sasl failed', { reason: 'fail' });
-    vi.advanceTimersByTime(60_000);
-    conn.client.emit('close', true); // transient → reconnects
+    conn.client.emit('close', true);
     vi.runAllTimers();
     expect(conn.connect).toHaveBeenCalledTimes(1);
 
-    // A second drop, immediately after: with the flag consumed this is transient
-    // too. If it had lingered, this close would land inside the window relative
-    // to nothing and stop reconnection dead.
+    // Two further drops with no new SASL failure: nothing pending to promote, so
+    // both are ordinary transients even though the streak sits at 1.
     conn.client.emit('close', true);
     vi.runAllTimers();
-    expect(conn.connect).toHaveBeenCalledTimes(2);
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).toHaveBeenCalledTimes(3);
   });
 
   // A clean SASL abort is transient (server hiccup), not a credential problem —

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1375,6 +1375,104 @@ describe('auto-reconnect controller', () => {
     expect(conn.state).toBe('disconnected');
   });
 
+  // #616: auto-reconnect used to call connect() directly, walking past the
+  // paused-account and network-lockdown gates every other connect path clears.
+  describe('policy gate', () => {
+    function makeGatedConn(
+      name: string,
+      gate: () => { ok: true } | { ok: false; reason: string },
+    ): { conn: IrcConnection; events: Record<string, unknown>[] } {
+      const network = createNetwork(1, {
+        name,
+        host: 'irc.example.test',
+        port: 6697,
+        tls: 1,
+        trusted_certificates: 1,
+        nick: 'nick',
+        username: null,
+        realname: null,
+        server_password: null,
+        autoconnect: 0,
+        sasl_account: null,
+        sasl_password: null,
+        connect_commands: null,
+      })!;
+      const events: Record<string, unknown>[] = [];
+      const conn = new IrcConnection({
+        network,
+        onEvent: (e) => events.push(e as Record<string, unknown>),
+        reconnectGate: gate,
+      });
+      vi.spyOn(conn, 'connect').mockImplementation(() => {});
+      return { conn, events };
+    }
+
+    it('opens the socket when the gate allows it', () => {
+      vi.useFakeTimers();
+      const { conn } = makeGatedConn('rc-gate-ok', () => ({ ok: true }));
+      conn.client.emit('close', true);
+      vi.runAllTimers();
+      expect(conn.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('refuses to reconnect a paused account', () => {
+      vi.useFakeTimers();
+      const { conn, events } = makeGatedConn('rc-gate-paused', () => ({
+        ok: false,
+        reason: 'this account is paused',
+      }));
+      conn.client.emit('close', true);
+      vi.runAllTimers();
+      expect(conn.connect).not.toHaveBeenCalled();
+      expect(
+        events.some((e) => e.type === 'error' && /account is paused/i.test(String(e.text))),
+      ).toBe(true);
+    });
+
+    // The part review insisted on: scheduleReconnectIfWarranted has ALREADY
+    // announced 'reconnecting' by the time the gate is asked, so a silent refusal
+    // would pin the network on "Reconnecting…" forever — the exact stuck state
+    // the auto-reconnect overhaul removed.
+    it('settles to disconnected rather than hanging on "reconnecting"', () => {
+      vi.useFakeTimers();
+      const { conn } = makeGatedConn('rc-gate-state', () => ({
+        ok: false,
+        reason: 'this account is paused',
+      }));
+      conn.client.emit('close', true);
+      expect(conn.state).toBe('reconnecting');
+      vi.runAllTimers();
+      expect(conn.state).toBe('disconnected');
+    });
+
+    // Read live, not captured at construction: a user paused DURING the backoff
+    // wait must not get a socket out of a decision made before they were paused.
+    it('asks the gate at launch time, not when the retry was scheduled', () => {
+      vi.useFakeTimers();
+      let allowed = true;
+      const { conn } = makeGatedConn('rc-gate-live', () =>
+        allowed ? { ok: true } : { ok: false, reason: 'this account is paused' },
+      );
+      conn.client.emit('close', true);
+      expect(conn.state).toBe('reconnecting');
+      allowed = false; // paused mid-backoff
+      vi.runAllTimers();
+      expect(conn.connect).not.toHaveBeenCalled();
+    });
+
+    it('stops the ladder — a refusal does not schedule another attempt', () => {
+      vi.useFakeTimers();
+      const { conn } = makeGatedConn('rc-gate-stops', () => ({
+        ok: false,
+        reason: `irc.example.test is not permitted by this instance`,
+      }));
+      conn.client.emit('close', true);
+      vi.runAllTimers();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(conn.connect).not.toHaveBeenCalled();
+    });
+  });
+
   it('stops (no reconnect) and surfaces a notice on a detected server ban', () => {
     vi.useFakeTimers();
     const { conn, events } = makeConn('rc-ban');
@@ -1400,6 +1498,54 @@ describe('auto-reconnect controller', () => {
     expect(
       events.some((e) => e.type === 'error' && /SASL authentication failed/i.test(String(e.text))),
     ).toBe(true);
+  });
+
+  // #617: the window that made the conservative policy wrong. On a network where
+  // SASL is OPTIONAL the server doesn't drop us for a failed auth — so a socket
+  // that dies much later died of something else (a stalled registration timing
+  // out, a network blip) and must get the ordinary backoff ladder. Before this,
+  // that unrelated drop inherited the SASL flag and killed reconnect forever.
+  it('does not blame a much-later socket close on an earlier SASL failure', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-sasl-stale');
+    conn.client.emit('sasl failed', { reason: 'fail' });
+    // The connection lived on well past the handshake — proof the server did not
+    // drop us for the rejection.
+    vi.advanceTimersByTime(60_000);
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).toHaveBeenCalledTimes(1);
+  });
+
+  // The other half: a server that REQUIRES SASL drops the link as part of the
+  // handshake, and retrying that is a fast failed-login hammer. Still terminal.
+  it('still stops when the close follows the SASL failure immediately', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-sasl-prompt');
+    conn.client.emit('sasl failed', { reason: 'fail' });
+    vi.advanceTimersByTime(200);
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).not.toHaveBeenCalled();
+  });
+
+  // A rejection that demonstrably did NOT kill its own socket must not sit around
+  // waiting to be blamed for the NEXT one.
+  it('consumes the pending SASL failure at the close it survived', () => {
+    vi.useFakeTimers();
+    const { conn } = makeConn('rc-sasl-consumed');
+    conn.client.emit('sasl failed', { reason: 'fail' });
+    vi.advanceTimersByTime(60_000);
+    conn.client.emit('close', true); // transient → reconnects
+    vi.runAllTimers();
+    expect(conn.connect).toHaveBeenCalledTimes(1);
+
+    // A second drop, immediately after: with the flag consumed this is transient
+    // too. If it had lingered, this close would land inside the window relative
+    // to nothing and stop reconnection dead.
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).toHaveBeenCalledTimes(2);
   });
 
   // A clean SASL abort is transient (server hiccup), not a credential problem —

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -117,17 +117,25 @@ const DEFAULT_QUIT_MESSAGE = `Lurker ${APP_VERSION} (the truth is out there) htt
  */
 export type ReconnectGate = () => { ok: true } | { ok: false; reason: string };
 
-// How long after a SASL rejection a socket close is still attributable to it
-// (#617). A server that refuses your credentials drops the link as part of the
-// registration handshake — immediately, not minutes later. Past this window the
-// connection demonstrably survived the rejection (the network's SASL is
-// optional), so a later close is an unrelated transient drop and must NOT
-// inherit the give-up flag. There is no wire signal that distinguishes the two,
-// so this is a heuristic; it is deliberately generous, because the cost of
-// guessing "terminal" wrongly is a connection that never comes back on its own,
-// while guessing "transient" wrongly costs one extra reconnect attempt that
-// fails the same way and re-arms the flag.
-const SASL_FAILURE_TERMINAL_WINDOW_MS = 15_000;
+// How many SASL rejections in a row, with no successful registration in
+// between, before auto-reconnect gives up (#617).
+//
+// A COUNT rather than a timer. The obvious discriminator — "did the socket die
+// right after the rejection?" — can't actually separate the two cases it needs
+// to: #617's scenario (optional SASL, registration stalls, socket times out
+// minutes later) and a required-SASL server that holds the socket open and lets
+// it time out are the same shape on the wire, so any wall-clock window
+// misclassifies one of them. Worse, a window that decides "transient" reproduces
+// its own timing on the next attempt, so it re-decides "transient" forever —
+// an unbounded failed-login ladder, which is precisely what the give-up flag
+// exists to prevent.
+//
+// A streak has no such failure mode. On an optional-SASL network the retry
+// registers unauthenticated and 'registered' resets the count, so #617's
+// transient drop recovers; on a network that genuinely refuses the credentials
+// nothing ever registers and the count runs out. Worst case is a bounded 3
+// attempts spread over the backoff ladder, which is not a hammer.
+const MAX_CONSECUTIVE_SASL_FAILURES = 3;
 
 const NON_PERSISTED_TYPES = new Set([
   'state',
@@ -603,7 +611,11 @@ export class IrcConnection {
   private reconnectAttempt: number;
   private intentionalDisconnect: boolean;
   private terminalDisconnect: string | null;
-  private pendingSaslFailure: { text: string; at: number } | null;
+  private pendingSaslFailure: string | null;
+  // Consecutive SASL rejections with no successful registration between them.
+  // Deliberately NOT reset by connect(): it has to survive the retry ladder, or
+  // it could never run out. Only 'registered' clears it.
+  private saslFailureStreak: number;
   private readonly reconnectGate: ReconnectGate | undefined;
 
   constructor({
@@ -702,6 +714,7 @@ export class IrcConnection {
     this.intentionalDisconnect = false;
     this.terminalDisconnect = null;
     this.pendingSaslFailure = null;
+    this.saslFailureStreak = 0;
     this.bind();
   }
 
@@ -1018,14 +1031,12 @@ export class IrcConnection {
         // used to sit there until 'registered' cleared it — and if registration
         // then stalled and the socket timed out FIRST, that unrelated transient
         // drop inherited the flag and killed auto-reconnect permanently.
-        // Promoted to terminal at 'close' only while the rejection is still
-        // plausibly the cause; see maybePromoteSaslFailure.
-        this.pendingSaslFailure = {
-          text: `SASL authentication failed${
-            reason && reason !== 'fail' ? ` (${reason})` : ''
-          } — check the network's account credentials`,
-          at: Date.now(),
-        };
+        // Promoted to terminal at 'close' once the streak runs out; see
+        // maybePromoteSaslFailure.
+        this.saslFailureStreak += 1;
+        this.pendingSaslFailure = `SASL authentication failed${
+          reason && reason !== 'fail' ? ` (${reason})` : ''
+        } — check the network's account credentials`;
       }
     });
 
@@ -1042,6 +1053,9 @@ export class IrcConnection {
       // auto-reconnect rather than inherit a stale give-up flag.
       this.terminalDisconnect = null;
       this.pendingSaslFailure = null;
+      // Registering is the proof the credentials aren't fatal here (the network's
+      // SASL is optional, or they started working) — so the streak starts over.
+      this.saslFailureStreak = 0;
       // Fresh registration means a new socket — forget per-connection send
       // state so speak permission is re-probed and stale attribution can't leak
       // across the reconnect (#283).
@@ -2582,8 +2596,16 @@ export class IrcConnection {
       // Classify an oper/server ban (K/G/Z/D-line) so the auto-reconnect
       // controller stops instead of hammering a server that's actively refusing
       // us. Only server-scoped bans qualify: a channel-scoped ban (474) carries a
-      // channel param and is routed inline below, so gate on its absence. The flag
-      // is consumed at 'close'; setting it here is harmless if the socket lives.
+      // channel param and is routed inline below, so gate on its absence.
+      //
+      // ⚠ Unlike the SASL flag (which is pending until 'close' proves it fatal,
+      // #617), this one is terminal the moment it's set and is cleared ONLY by
+      // 'registered' or a fresh connect(). So a ban-shaped error on a live,
+      // already-registered connection lingers, and the next unrelated transient
+      // drop inherits it and stops auto-reconnect for good — the same staleness
+      // #617 fixed for SASL. In practice a "Closing Link" ERROR does close the
+      // link, so the window is narrow; giving this the same pending/promote
+      // treatment is tracked separately rather than widened into #616/#617.
       const banChannel = event?.channel as string | undefined;
       if (!banChannel) {
         const banned = classifyServerBan(reason);
@@ -4683,21 +4705,22 @@ export class IrcConnection {
   /**
    * Consume a pending SASL rejection at socket-close time (#617).
    *
-   * A server that requires SASL closes the link as part of the handshake, so a
-   * close within the window is that rejection and auto-reconnect must stop —
-   * retrying is a fast failed-login hammer. A close AFTER the window means the
-   * connection survived the rejection (optional SASL), so whatever killed it is
-   * unrelated and gets the ordinary backoff ladder.
+   * Give up only once the streak runs out. A single rejection is not proof the
+   * credentials are the reason THIS socket died — on a network where SASL is
+   * optional the server keeps you, and a later drop is unrelated. Retrying
+   * settles it far better than any guess at the wire could: if the network
+   * really does let us in unauthenticated we register and the streak resets, and
+   * if it doesn't we're back here with a higher count.
    *
-   * Either way the pending flag is consumed: a rejection that didn't kill this
-   * socket must not linger to be blamed for the next one.
+   * The pending flag is consumed either way — a rejection must not linger to be
+   * blamed for a socket death it had nothing to do with.
    */
   private maybePromoteSaslFailure(): void {
     const pending = this.pendingSaslFailure;
     if (!pending) return;
     this.pendingSaslFailure = null;
-    if (Date.now() - pending.at <= SASL_FAILURE_TERMINAL_WINDOW_MS) {
-      this.terminalDisconnect = pending.text;
+    if (this.saslFailureStreak >= MAX_CONSECUTIVE_SASL_FAILURES) {
+      this.terminalDisconnect = pending;
     }
   }
 
@@ -4767,7 +4790,23 @@ export class IrcConnection {
         // the answer is current at the moment we would open the socket — a user
         // paused mid-wait must not get a connection out of a decision made
         // before they were paused.
-        const gate = this.reconnectGate?.() ?? { ok: true as const };
+        let gate: { ok: true } | { ok: false; reason: string };
+        try {
+          gate = this.reconnectGate?.() ?? { ok: true as const };
+        } catch (err) {
+          // The gate reads the DB, so it can throw where a bare connect() never
+          // could (SQLITE_BUSY, a closed handle during shutdown). connectScheduler
+          // only console.errors a throwing task — and by now the backoff timer is
+          // already spent — so letting this escape would strand the network on
+          // "Reconnecting…" with nothing left to fire. A failed POLICY READ is not
+          // a policy refusal: re-arm and ask again next tick.
+          this.logNet(
+            `Reconnect gate check failed (${err instanceof Error ? err.message : String(err)}); retrying`,
+            'warn',
+          );
+          this.scheduleReconnectIfWarranted();
+          return;
+        }
         if (!gate.ok) {
           this.stopReconnecting(gate.reason);
           return;

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -100,6 +100,35 @@ export function outgoingAddr(): string | undefined {
 // etc.) pass their own reason and bypass this default.
 const DEFAULT_QUIT_MESSAGE = `Lurker ${APP_VERSION} (the truth is out there) https://lurker.chat`;
 
+/**
+ * The manager's policy check, asked before an auto-reconnect opens a socket (#616).
+ *
+ * Auto-reconnect used to call connect() directly, which walked straight past the
+ * two gates every OTHER connect path clears in ircManager.startNetwork: the
+ * paused-account check (the linchpin billing hooks into) and the instance network
+ * lockdown (#298). It wasn't actively exploitable — suspendUser happens to
+ * disconnect() first, which cancels the pending backoff — but that is a
+ * coincidence of ordering, not a guarantee, and any future pause path that
+ * forgot to disconnect a live connection would have let a transient drop
+ * resurrect a connection policy forbids.
+ *
+ * A callback rather than a manager back-reference: the connection needs to ASK
+ * the policy question, not gain the ability to start networks.
+ */
+export type ReconnectGate = () => { ok: true } | { ok: false; reason: string };
+
+// How long after a SASL rejection a socket close is still attributable to it
+// (#617). A server that refuses your credentials drops the link as part of the
+// registration handshake — immediately, not minutes later. Past this window the
+// connection demonstrably survived the rejection (the network's SASL is
+// optional), so a later close is an unrelated transient drop and must NOT
+// inherit the give-up flag. There is no wire signal that distinguishes the two,
+// so this is a heuristic; it is deliberately generous, because the cost of
+// guessing "terminal" wrongly is a connection that never comes back on its own,
+// while guessing "transient" wrongly costs one extra reconnect attempt that
+// fails the same way and re-arms the flag.
+const SASL_FAILURE_TERMINAL_WINDOW_MS = 15_000;
+
 const NON_PERSISTED_TYPES = new Set([
   'state',
   'names',
@@ -565,14 +594,30 @@ export class IrcConnection {
   // terminalDisconnect: a classified give-up reason (detected ban / hard SASL
   //   auth failure). Non-null = stop retrying and require a manual reconnect; the
   //   string is the human-readable cause shown in the "not reconnecting" notice.
+  // pendingSaslFailure: a SASL rejection that has NOT yet been proven fatal (#617).
+  //   See the 'sasl failed' handler for why it can't be terminal on sight.
+  // reconnectGate: the manager's policy check, consulted before each retry opens a
+  //   socket (#616). Absent = no gate (tests, and any caller that builds a
+  //   connection directly).
   private reconnectTimer: ReturnType<typeof setTimeout> | null;
   private reconnectAttempt: number;
   private intentionalDisconnect: boolean;
   private terminalDisconnect: string | null;
+  private pendingSaslFailure: { text: string; at: number } | null;
+  private readonly reconnectGate: ReconnectGate | undefined;
 
-  constructor({ network, onEvent }: { network: Network; onEvent: (event: EnrichedEvent) => void }) {
+  constructor({
+    network,
+    onEvent,
+    reconnectGate,
+  }: {
+    network: Network;
+    onEvent: (event: EnrichedEvent) => void;
+    reconnectGate?: ReconnectGate;
+  }) {
     this.network = network;
     this.onEvent = onEvent;
+    this.reconnectGate = reconnectGate;
     // ALL CTCP handling lives in our 'ctcp request' handler (VERSION/PING/TIME/
     // SOURCE/CLIENTINFO, rate-limited + surfaced), so irc-framework's built-in
     // VERSION auto-reply is disabled with `version: false`. That MUST go in the
@@ -656,6 +701,7 @@ export class IrcConnection {
     this.reconnectAttempt = 0;
     this.intentionalDisconnect = false;
     this.terminalDisconnect = null;
+    this.pendingSaslFailure = null;
     this.bind();
   }
 
@@ -967,9 +1013,19 @@ export class IrcConnection {
     c.on('sasl failed', (event: Record<string, unknown>) => {
       const reason = (event?.reason as string | undefined) || undefined;
       if (isTerminalSaslFailure(reason)) {
-        this.terminalDisconnect = `SASL authentication failed${
-          reason && reason !== 'fail' ? ` (${reason})` : ''
-        } — check the network's account credentials`;
+        // PENDING, not terminal on sight (#617). On a network where SASL is
+        // optional the server does not drop us for a failed auth, so the flag
+        // used to sit there until 'registered' cleared it — and if registration
+        // then stalled and the socket timed out FIRST, that unrelated transient
+        // drop inherited the flag and killed auto-reconnect permanently.
+        // Promoted to terminal at 'close' only while the rejection is still
+        // plausibly the cause; see maybePromoteSaslFailure.
+        this.pendingSaslFailure = {
+          text: `SASL authentication failed${
+            reason && reason !== 'fail' ? ` (${reason})` : ''
+          } — check the network's account credentials`,
+          at: Date.now(),
+        };
       }
     });
 
@@ -985,6 +1041,7 @@ export class IrcConnection {
       // us for it), it clearly wasn't fatal — a later transient drop must still
       // auto-reconnect rather than inherit a stale give-up flag.
       this.terminalDisconnect = null;
+      this.pendingSaslFailure = null;
       // Fresh registration means a new socket — forget per-connection send
       // state so speak permission is re-probed and stale attribution can't leak
       // across the reconnect (#283).
@@ -1138,6 +1195,9 @@ export class IrcConnection {
       // call is a no-op.
       this.markAllPeersOffline();
       this.setState('disconnected');
+      // Decide, now that we know WHEN the socket died, whether a SASL rejection
+      // earlier in this connection is what killed it (#617).
+      this.maybePromoteSaslFailure();
       // 'close' is now the single terminal socket-death event (irc-framework's
       // auto_reconnect is disabled, so it no longer retries internally): decide
       // here whether to schedule our own backoff retry. Runs after the state/
@@ -3115,6 +3175,7 @@ export class IrcConnection {
     this.clearReconnectTimer();
     this.intentionalDisconnect = false;
     this.terminalDisconnect = null;
+    this.pendingSaslFailure = null;
     const { sasl_password, sasl_account, nick } = this.network;
     const account = sasl_password
       ? { account: sasl_account || nick, password: sasl_password }
@@ -4619,6 +4680,47 @@ export class IrcConnection {
   // doesn't flood one host). Retries indefinitely for any transient drop; stops
   // only for a disposed connection, a user/system-requested disconnect, or a
   // classified-terminal reason (detected ban / hard SASL auth failure).
+  /**
+   * Consume a pending SASL rejection at socket-close time (#617).
+   *
+   * A server that requires SASL closes the link as part of the handshake, so a
+   * close within the window is that rejection and auto-reconnect must stop —
+   * retrying is a fast failed-login hammer. A close AFTER the window means the
+   * connection survived the rejection (optional SASL), so whatever killed it is
+   * unrelated and gets the ordinary backoff ladder.
+   *
+   * Either way the pending flag is consumed: a rejection that didn't kill this
+   * socket must not linger to be blamed for the next one.
+   */
+  private maybePromoteSaslFailure(): void {
+    const pending = this.pendingSaslFailure;
+    if (!pending) return;
+    this.pendingSaslFailure = null;
+    if (Date.now() - pending.at <= SASL_FAILURE_TERMINAL_WINDOW_MS) {
+      this.terminalDisconnect = pending.text;
+    }
+  }
+
+  /**
+   * Abandon the retry ladder because policy refuses this connection (#616).
+   *
+   * The state assertion is the load-bearing part. By the time the gate is asked,
+   * scheduleReconnectIfWarranted has already announced 'reconnecting' — so
+   * silently returning would leave the network pinned on "Reconnecting…" forever,
+   * which is exactly the stuck-state edge the auto-reconnect overhaul removed.
+   * Inlining the gate checks without this was rejected in review for that reason.
+   */
+  private stopReconnecting(reason: string): void {
+    this.clearReconnectTimer();
+    this.publish({
+      type: 'error',
+      target: this.serverTarget(),
+      text: `Not reconnecting automatically: ${reason}.`,
+    });
+    this.logNet(`Auto-reconnect blocked: ${reason}`, 'warn');
+    this.setState('disconnected');
+  }
+
   private scheduleReconnectIfWarranted(): void {
     if (this.disposed || this.intentionalDisconnect) return;
     if (this.reconnectTimer != null) return; // a retry is already pending
@@ -4660,6 +4762,16 @@ export class IrcConnection {
       // connections whose backoffs elapse together don't flood one IRC server.
       connectScheduler.schedule(this.network.host, () => {
         if (this.disposed || this.intentionalDisconnect) return;
+        // #616: clear the same policy gates every other connect path clears in
+        // ircManager.startNetwork. Asked HERE rather than before the backoff so
+        // the answer is current at the moment we would open the socket — a user
+        // paused mid-wait must not get a connection out of a decision made
+        // before they were paused.
+        const gate = this.reconnectGate?.() ?? { ok: true as const };
+        if (!gate.ok) {
+          this.stopReconnecting(gate.reason);
+          return;
+        }
         this.connect();
       });
     }, delay);

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -89,9 +89,15 @@ describe('ircManager.connectGate', () => {
     return { userId: user.id, networkId: net.id };
   }
 
-  it('allows an ordinary account and network', () => {
+  // Hands back the row it read. startNetwork consumes it instead of issuing a
+  // second getNetwork — a duplicate synchronous read on every connect, on the
+  // boot-time fan-out path #460 showed can starve the event loop.
+  it('allows an ordinary account and network, returning the row it read', () => {
     const { userId, networkId } = gateUserNet();
-    expect(ircManager.connectGate(userId, networkId)).toEqual({ ok: true });
+    const gate = ircManager.connectGate(userId, networkId);
+    expect(gate.ok).toBe(true);
+    expect(gate.ok === true && gate.network.id).toBe(networkId);
+    expect(gate.ok === true && gate.network.host).toBe('irc.example.invalid');
   });
 
   // The refusal reason is user-facing: auto-reconnect publishes it when it stops,

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -70,6 +70,48 @@ describe('ircManager pause linchpin', () => {
   });
 });
 
+// #616: the gate the auto-reconnect controller now asks before each retry. Same
+// implementation startNetwork uses, so the two can't drift apart — which is the
+// whole point, since the reconnect path used to skip both checks entirely.
+describe('ircManager.connectGate', () => {
+  let seq = 0;
+  function gateUserNet(host = 'irc.example.invalid') {
+    const user = createUser(`gate-${(seq += 1)}`);
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host,
+      port: 6697,
+      tls: true,
+      nick: 'x',
+      autoconnect: false,
+    });
+    if (!net) throw new Error('createNetwork returned undefined');
+    return { userId: user.id, networkId: net.id };
+  }
+
+  it('allows an ordinary account and network', () => {
+    const { userId, networkId } = gateUserNet();
+    expect(ircManager.connectGate(userId, networkId)).toEqual({ ok: true });
+  });
+
+  // The refusal reason is user-facing: auto-reconnect publishes it when it stops,
+  // and a connection that quits retrying without saying why reads as a bug.
+  it('refuses a paused account with a reason', () => {
+    const { userId, networkId } = gateUserNet();
+    setUserPaused(userId, true);
+    const gate = ircManager.connectGate(userId, networkId);
+    expect(gate.ok).toBe(false);
+    expect(gate.ok === false && gate.reason).toMatch(/paused/i);
+  });
+
+  it('refuses a network that has been deleted out from under a pending retry', () => {
+    const { userId, networkId } = gateUserNet();
+    const gate = ircManager.connectGate(userId, networkId + 100000);
+    expect(gate.ok).toBe(false);
+    expect(gate.ok === false && gate.reason).toMatch(/no longer exists/i);
+  });
+});
+
 describe('ircManager.acceptDccTransfer result codes', () => {
   let seq = 0;
   function dccUserNet() {

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -183,33 +183,53 @@ class IrcManager extends EventEmitter {
     for (const id of userIds) this.initForUser(id);
   }
 
+  /**
+   * May this user hold a live IRC connection to this network, right now?
+   *
+   * THE connect gate. Two checks, and every path that opens a socket clears
+   * them here rather than repeating them:
+   *
+   * - Paused accounts never hold a live IRC connection. This is the linchpin of
+   *   the pause feature — it covers boot-time autoconnect (initForUser →
+   *   initAll), the explicit connect/reconnect routes, restartNetwork, and
+   *   (since #616) the auto-reconnect controller's own retries. The boundary
+   *   guards (REST/WS) exist only to return a clean "account paused" instead of
+   *   a silent no-op.
+   * - The instance network lockdown (#298). Gating only the create route would
+   *   leave it trivially bypassable by anyone who already had the network — and
+   *   would do nothing at all on the next restart, when initAll reconnects it.
+   *
+   * The refusal reason is human-readable because auto-reconnect shows it to the
+   * user: a connection that stops retrying has to say why, or it reads as a bug.
+   */
+  connectGate(userId: number, networkId: number): { ok: true } | { ok: false; reason: string } {
+    if (findUserById(userId)?.is_paused) return { ok: false, reason: 'this account is paused' };
+    const network = getNetwork(networkId, userId);
+    if (!network) return { ok: false, reason: 'this network no longer exists' };
+    if (!isNetworkHostAllowed(network.host)) {
+      return { ok: false, reason: `${network.host} is not permitted by this instance` };
+    }
+    return { ok: true };
+  }
+
   startNetwork(
     userId: number,
     networkId: number,
     opts: { deferrable?: boolean } = {},
   ): IrcConnection | null {
-    // Paused accounts never hold a live IRC connection. This single gate is the
-    // linchpin of the pause feature: it covers boot-time autoconnect
-    // (initForUser → initAll), the explicit connect/reconnect routes, and
-    // restartNetwork — so a paused user can produce no IRC traffic no matter
-    // which path is taken. The boundary guards (REST/WS) exist only to return a
-    // clean "account paused" instead of a silent no-op.
-    if (findUserById(userId)?.is_paused) return null;
+    if (!this.connectGate(userId, networkId).ok) return null;
     const network = getNetwork(networkId, userId);
     if (!network) return null;
-    // The instance network lockdown (#298), gated in the same place and for the
-    // same reason as the pause check above: every connect path funnels through
-    // here, so one check covers boot-time autoconnect, the connect/reconnect
-    // routes and restartNetwork. Gating only the create route would leave the
-    // lockdown trivially bypassable by anyone who already had the network — and
-    // would do nothing at all on the next restart, when initAll reconnects it.
-    if (!isNetworkHostAllowed(network.host)) return null;
     let conn = this.getConnection(userId, networkId);
     if (conn) return conn;
 
     conn = new IrcConnection({
       network,
       onEvent: (event) => this.emit('event', event),
+      // #616: the retry controller asks this before each attempt opens a socket,
+      // so a reconnect re-clears the same gates the initial connect did. Read
+      // live (not captured), because pause/lockdown can change mid-backoff.
+      reconnectGate: () => this.connectGate(userId, networkId),
     });
     this.connectionsForUser(userId).set(networkId, conn);
     // Seed self-presence from the per-user truth before the IRC handshake. The

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -212,6 +212,33 @@ class IrcManager extends EventEmitter {
     return { ok: true };
   }
 
+  /**
+   * connectGate for the auto-reconnect path, plus the bookkeeping a refusal
+   * implies (#616).
+   *
+   * Dropping the connection from the map is the load-bearing half. A refused
+   * retry leaves an IrcConnection that is disconnected and will never retry
+   * again — and startNetwork is a documented no-op when a connection object
+   * already exists, "even if it's in a disconnected state" (see restartNetwork).
+   * Leaving it there would mean the network never comes back after the condition
+   * clears: resumeUser → initForUser → startNetwork would find the corpse and
+   * return it, and the /connect route would answer `ok: true` having done
+   * nothing. That would trade #616's "reconnect resurrects a forbidden
+   * connection" for a worse "connection never returns after unpause".
+   *
+   * Deleting here (before the connection publishes its refusal) is safe: the
+   * event path is the onEvent closure, not a map lookup, so the client still
+   * receives the error and the terminal 'disconnected' state.
+   */
+  private gateReconnect(
+    userId: number,
+    networkId: number,
+  ): { ok: true } | { ok: false; reason: string } {
+    const gate = this.connectGate(userId, networkId);
+    if (!gate.ok) this.connectionsForUser(userId).delete(networkId);
+    return gate;
+  }
+
   startNetwork(
     userId: number,
     networkId: number,
@@ -229,7 +256,7 @@ class IrcManager extends EventEmitter {
       // #616: the retry controller asks this before each attempt opens a socket,
       // so a reconnect re-clears the same gates the initial connect did. Read
       // live (not captured), because pause/lockdown can change mid-backoff.
-      reconnectGate: () => this.connectGate(userId, networkId),
+      reconnectGate: () => this.gateReconnect(userId, networkId),
     });
     this.connectionsForUser(userId).set(networkId, conn);
     // Seed self-presence from the per-user truth before the IRC handshake. The

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -6,6 +6,7 @@ import { IrcConnection } from './ircConnection.js';
 import * as systemLog from './systemLog.js';
 import connectScheduler from './connectScheduler.js';
 import { listNetworksForUser, getNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
 import {
   ensureOpen as ensureOpenBuffer,
   setAutojoin as setBufferAutojoin,
@@ -186,9 +187,11 @@ class IrcManager extends EventEmitter {
   /**
    * May this user hold a live IRC connection to this network, right now?
    *
-   * THE connect gate. Two checks, and every path that opens a socket clears
-   * them here rather than repeating them:
+   * THE connect gate. Every path that opens a socket clears it here rather than
+   * repeating the checks:
    *
+   * - The network still exists and belongs to this user. (A retry's backoff can
+   *   outlive the row it was scheduled for.)
    * - Paused accounts never hold a live IRC connection. This is the linchpin of
    *   the pause feature — it covers boot-time autoconnect (initForUser →
    *   initAll), the explicit connect/reconnect routes, restartNetwork, and
@@ -201,15 +204,24 @@ class IrcManager extends EventEmitter {
    *
    * The refusal reason is human-readable because auto-reconnect shows it to the
    * user: a connection that stops retrying has to say why, or it reads as a bug.
+   *
+   * Hands back the network row it had to read anyway. startNetwork needs the same
+   * row immediately afterwards, and re-reading would double the synchronous
+   * SQLite work on every connect and autoconnect — the boot-time fan-out across
+   * every network of every user is exactly the path #460 showed can starve the
+   * event loop.
    */
-  connectGate(userId: number, networkId: number): { ok: true } | { ok: false; reason: string } {
+  connectGate(
+    userId: number,
+    networkId: number,
+  ): { ok: true; network: Network } | { ok: false; reason: string } {
     if (findUserById(userId)?.is_paused) return { ok: false, reason: 'this account is paused' };
     const network = getNetwork(networkId, userId);
     if (!network) return { ok: false, reason: 'this network no longer exists' };
     if (!isNetworkHostAllowed(network.host)) {
       return { ok: false, reason: `${network.host} is not permitted by this instance` };
     }
-    return { ok: true };
+    return { ok: true, network };
   }
 
   /**
@@ -236,7 +248,9 @@ class IrcManager extends EventEmitter {
   ): { ok: true } | { ok: false; reason: string } {
     const gate = this.connectGate(userId, networkId);
     if (!gate.ok) this.connectionsForUser(userId).delete(networkId);
-    return gate;
+    // The network row goes no further: the retry reconnects the IrcConnection it
+    // already has, rather than building one from a fresh row.
+    return gate.ok ? { ok: true } : gate;
   }
 
   startNetwork(
@@ -244,9 +258,9 @@ class IrcManager extends EventEmitter {
     networkId: number,
     opts: { deferrable?: boolean } = {},
   ): IrcConnection | null {
-    if (!this.connectGate(userId, networkId).ok) return null;
-    const network = getNetwork(networkId, userId);
-    if (!network) return null;
+    const gate = this.connectGate(userId, networkId);
+    if (!gate.ok) return null;
+    const network = gate.network;
     let conn = this.getConnection(userId, networkId);
     if (conn) return conn;
 


### PR DESCRIPTION
Closes #616. Closes #617. Both are follow-ups from the auto-reconnect overhaul (#618).

## #616 — the reconnect walked past the connect gates

`scheduleReconnectIfWarranted` called `IrcConnection.connect()` directly, skipping the two checks `ircManager.startNetwork` makes on every other connect path: the `is_paused` check (the linchpin billing hooks into) and the instance network lockdown (#298).

It wasn't exploitable today, but only by coincidence: `suspendUser` happens to call `disconnect()` first, which sets `intentionalDisconnect` and cancels the pending backoff. Any future pause path that forgot to disconnect a live connection would have let a transient drop resurrect a connection policy forbids.

Extracted `ircManager.connectGate()` — now the single implementation, used by `startNetwork` itself — and handed `IrcConnection` a `reconnectGate` callback rather than a manager back-reference: it needs to ask the policy question, not gain the ability to start networks. Asked at **launch** time, not when the retry was scheduled, so a user paused mid-backoff doesn't get a socket out of a decision made before they were paused.

Review had rejected inlining the two checks because a silently-blocked reconnect would reintroduce the stuck-on-"Reconnecting" state the overhaul just fixed, so a refusal asserts terminal `disconnected` and publishes why. Both pinned by tests.

## #617 — a SASL failure could kill an unrelated reconnect

`terminalDisconnect` was set the moment `'sasl failed'` arrived and cleared only on `'registered'` or a fresh `connect()`. On a network where SASL is **optional** the server doesn't drop you for it, so the flag sat there — and if registration then stalled and the socket timed out first, that transient drop inherited the flag and stopped auto-reconnect permanently.

Now a **count**: three consecutive rejections with no successful registration between them. On an optional-SASL network the retry registers unauthenticated and `'registered'` resets the streak, so the transient drop recovers; on a network that genuinely refuses the credentials nothing registers and the count runs out at a bounded 3 attempts across the backoff ladder.

⚠ **This deliberately changes documented behavior**: "stops on a hard SASL failure" becomes "stops after it repeats". That *is* #617 — stopping on the first one is what let a rejection the server didn't drop us for kill an unrelated later drop. The original test keeps its intent (bad credentials must not retry forever) with the count moved, rather than being deleted.

## Review fixes (second commit)

`/code-review high` found three real defects, two of which this PR introduced:

- **A throwing gate stranded the network.** The gate does three synchronous DB reads from inside the `connectScheduler` callback, where a bare `connect()` used to sit — and `connectScheduler.launch` only `console.error`s a throwing task, by which point the backoff timer is spent and `'reconnecting'` is already published. A `SQLITE_BUSY` (a documented failure mode here) mid-backoff would have pinned the network on "Reconnecting…" with nothing left to fire it. A failed policy *read* is not a policy refusal: it re-arms and asks again next tick.
- **A refused retry left a dead connection in the map**, and `startNetwork` is a documented no-op when one already exists "even if it's in a disconnected state" (`restartNetwork`'s own comment). So after the condition cleared, `resumeUser → initForUser → startNetwork` would find the corpse and return it, and `/connect` would answer `ok: true` having done nothing — trading #616's hole for the same hole one step later. The refusal now drops the connection so a later start rebuilds it.
- **The first attempt at #617 used a 15s wall-clock window, which could not converge** — and the comment defending it was self-refuting: deciding "transient" reproduces its own timing next attempt, so it decides "transient" forever. Against a SASL-required server that holds the socket open (or a close delayed past 15s by the event-loop starvation of #460) that's an unbounded failed-login ladder. Replaced with the streak count above.

Also corrected a false comment on the ban classifier, which carries the identical staleness bug #617 fixes for SASL — filed as #651 rather than widened into this PR.

## Tests

`npm run check` clean, full suite green. New coverage: gate allow/refuse, the terminal-state assertion, live-vs-captured gate evaluation, a throwing gate re-arming, and the SASL streak in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)