### PR TITLE
Fix spoilers rendering in the app's own background colour

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -259,11 +259,16 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'string-list',
     // 16 entries, one per mIRC color code 0..15. The chromatic slots default
     // to the closest hue from look.nick.colors so coloured chat text harmonises
-    // with the rest of the theme; the four mono-ish slots (white, black, gray,
-    // light gray) use theme variables so they stay legible on any background.
+    // with the rest of the theme.
+    //
+    // All literal colours — the mono-ish slots used to be theme variables, meant
+    // to "stay legible on any background", which backfired: var(--bg) IS the
+    // background, so black text rendered in exactly the colour behind it and
+    // disappeared. Keep this list in sync with MIRC_PALETTE_FALLBACK in
+    // vue_client/src/utils/nickColor.ts.
     default: [
-      'var(--fg)', //                                       0  white
-      'var(--bg)', //                                       1  black
+      '#fcfcfa', //                                         0  white
+      '#000000', //                                         1  black
       '#6799f3', //                                         2  navy
       '#a9dc76', //                                         3  green
       '#ff6188', //                                         4  red
@@ -276,8 +281,8 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       '#a0f1ff', //                                         11 cyan
       '#7ba4ff', //                                         12 blue
       '#ff7494', //                                         13 magenta
-      'var(--fg-muted)', //                                 14 gray
-      'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
+      '#939293', //                                         14 gray
+      '#babab9', //                                         15 light gray
     ],
     description:
       'How the 16 mIRC color codes (0-15) render in chat. One CSS color per line, ' +

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -259,16 +259,17 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'string-list',
     // 16 entries, one per mIRC color code 0..15. The chromatic slots default
     // to the closest hue from look.nick.colors so coloured chat text harmonises
-    // with the rest of the theme.
+    // with the rest of the theme; the mono-ish slots track the theme so they
+    // stay legible when the user changes look.color.bg / look.color.fg.
     //
-    // All literal colours — the mono-ish slots used to be theme variables, meant
-    // to "stay legible on any background", which backfired: var(--bg) IS the
-    // background, so black text rendered in exactly the colour behind it and
-    // disappeared. Keep this list in sync with MIRC_PALETTE_FALLBACK in
-    // vue_client/src/utils/nickColor.ts.
+    // ⚠ A slot must never resolve to the SURFACE it's drawn on. Slot 1 was
+    // var(--bg) — the background by definition — so black text rendered in
+    // exactly the colour behind it and disappeared. Anything derived from
+    // var(--fg) is safe; var(--bg) never is. Keep in sync with
+    // MIRC_PALETTE_FALLBACK in vue_client/src/utils/nickColor.ts.
     default: [
-      '#fcfcfa', //                                         0  white
-      '#000000', //                                         1  black
+      'var(--fg)', //                                       0  white
+      '#000000', //                                         1  black — NOT var(--bg)
       '#6799f3', //                                         2  navy
       '#a9dc76', //                                         3  green
       '#ff6188', //                                         4  red
@@ -281,15 +282,17 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       '#a0f1ff', //                                         11 cyan
       '#7ba4ff', //                                         12 blue
       '#ff7494', //                                         13 magenta
-      '#939293', //                                         14 gray
-      '#babab9', //                                         15 light gray
+      'var(--fg-muted)', //                                 14 gray
+      'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
     ],
     description:
       'How the 16 mIRC color codes (0-15) render in chat. One CSS color per line, ' +
       'in order: white, black, navy, green, red, maroon, purple, orange, yellow, ' +
       'lime, teal, cyan, blue, magenta, gray, light gray. Defaults pick the ' +
       'closest hue from your nick palette so coloured text matches the rest of ' +
-      'the theme. Any CSS color value works (hex, rgb(), var(--name), color-mix()).',
+      'the theme. Any CSS color value works (hex, rgb(), var(--name), color-mix()) — ' +
+      'except var(--bg), which is the chat background itself, so text set to it is ' +
+      'invisible.',
   },
 
   // ─── Alternating message rows ─────────────────────────────────────────

--- a/vue_client/src/components/SpoilerText.test.ts
+++ b/vue_client/src/components/SpoilerText.test.ts
@@ -3,11 +3,15 @@
 
 // @vitest-environment happy-dom
 
-// The spoiler box's colour, which is not merely cosmetic: mIRC index 1 resolves
-// to `var(--bg)`, so honouring it as a "chosen colour" painted the box the exact
-// colour of the page AND set the revealed text to var(--bg) — clicking a spoiler
-// showed nothing. `01,01` is the pair Lurker's own applySpoilerMarkup emits, so
-// every spoiler sent from Lurker was affected.
+// The spoiler box's colour. `01,01` is the pair Lurker's own applySpoilerMarkup
+// emits, so this covers every spoiler sent from Lurker.
+//
+// Originally not merely cosmetic: slot 1 resolved to `var(--bg)`, so honouring
+// it as a "chosen colour" painted the box the exact colour of the page AND set
+// the revealed text to var(--bg) — clicking a spoiler showed nothing. The
+// palette has since been fixed too (slot 1 is a literal #000000), so these guard
+// the remaining half: 01,01 means "hidden", not "black", and must not be
+// preserved as a styling intent.
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
@@ -35,12 +39,17 @@ describe('SpoilerText box colour', () => {
   // `await` is load-bearing: trigger() resolves on nextTick, and without it the
   // style assertion below would pass against the UNrevealed markup — i.e. pass
   // even with the bug present.
+  //
+  // Asserts NO inline colour rather than "not var(--bg)". Matching on the old
+  // value made this test dead the moment the palette stopped containing it: the
+  // guard could be removed and this would still pass, because slot 1 now paints
+  // #000000. What the guard actually does is decline to set a colour at all, so
+  // that is what's checked.
   it('leaves revealed text its normal colour for a convention spoiler', async () => {
     const { root, body } = mountSpoiler({ text: 'secret', spoiler: true, fg: 1 });
     await root.trigger('click');
     expect(root.classes()).toContain('revealed');
-    // The fatal half: colour:var(--bg) on the page background is invisible text.
-    expect(body.attributes('style') || '').not.toMatch(/color:\s*var\(--bg\)/);
+    expect(body.attributes('style') || '').not.toMatch(/(^|[^-])color:/);
   });
 
   it('paints revealed text in a deliberately chosen colour', async () => {

--- a/vue_client/src/components/SpoilerText.test.ts
+++ b/vue_client/src/components/SpoilerText.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// The spoiler box's colour, which is not merely cosmetic: mIRC index 1 resolves
+// to `var(--bg)`, so honouring it as a "chosen colour" painted the box the exact
+// colour of the page AND set the revealed text to var(--bg) — clicking a spoiler
+// showed nothing. `01,01` is the pair Lurker's own applySpoilerMarkup emits, so
+// every spoiler sent from Lurker was affected.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import SpoilerText from './SpoilerText.vue';
+import type { RenderSegment } from '../utils/nickColor.js';
+
+function mountSpoiler(seg: RenderSegment) {
+  const wrapper = mount(SpoilerText, { props: { seg } });
+  const root = wrapper.find('.spoiler');
+  const body = wrapper.find('.spoiler-body');
+  return { wrapper, root, body };
+}
+
+describe('SpoilerText box colour', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  // The reported bug. The neutral box comes from the .spoiler class rule
+  // (var(--fg-muted)), so "correct" means NO inline background override at all.
+  it('does not paint the box with the 01,01 convention colour', () => {
+    const { root } = mountSpoiler({ text: 'secret', spoiler: true, fg: 1 });
+    expect(root.attributes('style') || '').not.toMatch(/background/);
+  });
+
+  // `await` is load-bearing: trigger() resolves on nextTick, and without it the
+  // style assertion below would pass against the UNrevealed markup — i.e. pass
+  // even with the bug present.
+  it('leaves revealed text its normal colour for a convention spoiler', async () => {
+    const { root, body } = mountSpoiler({ text: 'secret', spoiler: true, fg: 1 });
+    await root.trigger('click');
+    expect(root.classes()).toContain('revealed');
+    // The fatal half: colour:var(--bg) on the page background is invisible text.
+    expect(body.attributes('style') || '').not.toMatch(/color:\s*var\(--bg\)/);
+  });
+
+  it('paints revealed text in a deliberately chosen colour', async () => {
+    const { root, body } = mountSpoiler({ text: 'hidden', spoiler: true, fg: 4 });
+    await root.trigger('click');
+    expect(body.attributes('style') || '').toMatch(/color/);
+  });
+
+  // The feature this bug came in with is still worth having — a chatter who
+  // picked red should get a red spoiler, not a generic gray one.
+  it('still honours a deliberately chosen colour', () => {
+    const { root } = mountSpoiler({ text: 'hidden', spoiler: true, fg: 4 });
+    expect(root.attributes('style') || '').toMatch(/background/);
+  });
+
+  it('falls back to the neutral box when the segment carries no colour', () => {
+    const { root } = mountSpoiler({ text: 'old', spoiler: true });
+    expect(root.attributes('style') || '').not.toMatch(/background/);
+  });
+
+  // Reveal is one-way and must not leak the text to assistive tech first.
+  it('hides the body from screen readers until revealed', async () => {
+    const { root, body } = mountSpoiler({ text: 'secret', spoiler: true, fg: 1 });
+    expect(body.attributes('aria-hidden')).toBe('true');
+    await root.trigger('click');
+    expect(body.attributes('aria-hidden')).toBeUndefined();
+  });
+});

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -33,10 +33,13 @@ import { useMircPalette } from '../composables/useNickColors.js';
 // invisible) as a Discord-style blacked-out box. The content is kept out of
 // the accessible name (aria-hidden) until revealed so a screen reader doesn't
 // read the secret aloud. Reveal is one-way: once a user deliberately opens a
-// spoiler, re-hiding it isn't a behaviour anyone expects. The colour the
-// sender picked rides through on seg.fg (== seg.bg by construction) — we use
-// it to paint the unrevealed box and the revealed text/tint so the chatter's
-// colour intent is preserved instead of being flattened to gray.
+// spoiler, re-hiding it isn't a behaviour anyone expects.
+//
+// A DELIBERATE colour rides through on seg.fg (== seg.bg by construction) and
+// paints the unrevealed box and the revealed text/tint, so a chatter who picked
+// red gets a red spoiler rather than a generic gray one. The canonical `01,01`
+// pair is excluded — see SPOILER_CONVENTION_COLOR: it encodes "hidden", not a
+// colour, and treating it as one made revealed text invisible.
 const props = defineProps<{ seg: RenderSegment }>();
 
 const mircPalette = useMircPalette();
@@ -52,12 +55,22 @@ function reveal(e: Event): void {
   revealed.value = true;
 }
 
-// Resolve the sender's chosen mIRC colour to a CSS value. Null when fg is
-// absent (older snapshots without the field) — we then fall back to the old
-// neutral gray.
+// mIRC 01 is the canonical spoiler pair (`\x0301,01`) — it's what Lurker's own
+// applySpoilerMarkup emits, and what most clients/scripts use. It means "hide
+// this", not "paint this black", so it is NOT a colour intent to preserve.
+//
+// Honouring it is actively broken rather than merely ugly: index 1 resolves to
+// `var(--bg)`, the app's own background. That paints the unrevealed box the
+// exact colour of the page (no box at all), and then `bodyStyle` sets the
+// REVEALED text to var(--bg) too — so clicking a spoiler showed nothing.
+const SPOILER_CONVENTION_COLOR = 1;
+
+// Resolve the sender's chosen mIRC colour to a CSS value. Null when there's no
+// colour to honour — an absent fg (older snapshots without the field) or the
+// convention colour above — and we fall back to the neutral gray box.
 const color = computed(() => {
   const fg = props.seg.fg;
-  if (fg == null) return null;
+  if (fg == null || fg === SPOILER_CONVENTION_COLOR) return null;
   return mircColor(fg, mircPalette.value);
 });
 

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -57,12 +57,15 @@ function reveal(e: Event): void {
 
 // mIRC 01 is the canonical spoiler pair (`\x0301,01`) — it's what Lurker's own
 // applySpoilerMarkup emits, and what most clients/scripts use. It means "hide
-// this", not "paint this black", so it is NOT a colour intent to preserve.
+// this", not "paint this black", so it is NOT a colour intent to preserve: a
+// black box and black revealed text is nobody's styling choice, it's an artifact
+// of the invisibility convention.
 //
-// Honouring it is actively broken rather than merely ugly: index 1 resolves to
-// `var(--bg)`, the app's own background. That paints the unrevealed box the
-// exact colour of the page (no box at all), and then `bodyStyle` sets the
-// REVEALED text to var(--bg) too — so clicking a spoiler showed nothing.
+// This guard was introduced when slot 1 resolved to var(--bg), which made the
+// box the exact colour of the page and the REVEALED text invisible too. The
+// palette no longer does that (slot 1 is a literal #000000), so removing this
+// would now produce a merely ugly black spoiler rather than an unreadable one —
+// still wrong, just less dramatically.
 const SPOILER_CONVENTION_COLOR = 1;
 
 // Resolve the sender's chosen mIRC colour to a CSS value. Null when there's no

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { splitTextByTokens, segmentInlineStyle, segmentHasStyle } from './nickColor.js';
+import {
+  splitTextByTokens,
+  segmentInlineStyle,
+  segmentHasStyle,
+  MIRC_PALETTE_FALLBACK,
+} from './nickColor.js';
+import { getOption } from '../../../shared/settingsRegistry.js';
 
 // IRC formatting control bytes used to build test fixtures.
 const C = '\x03'; // colour
@@ -13,6 +19,34 @@ const BOLD = '\x02';
 function parse(text: string) {
   return splitTextByTokens(text, null, null, null);
 }
+
+describe('MIRC_PALETTE_FALLBACK', () => {
+  // The bug that prompted this: slots 0/1/14/15 were CSS variables, on the
+  // theory they'd "stay legible on any background". var(--bg) IS the background,
+  // so black text rendered in precisely the colour behind it and vanished.
+  //
+  // A palette entry has to be a colour in its own right. Deferring it to the
+  // surface it's drawn on can only ever produce invisible text, so this bans the
+  // whole shape rather than just the one slot that happened to bite.
+  it('is all self-contained colours — no theme variables', () => {
+    for (const [i, entry] of MIRC_PALETTE_FALLBACK.entries()) {
+      expect(entry, `slot ${i}`).not.toMatch(/var\(|color-mix\(/);
+    }
+  });
+
+  it('has all 16 slots', () => {
+    expect(MIRC_PALETTE_FALLBACK).toHaveLength(16);
+  });
+
+  // Two copies exist: this one (the render-time fallback) and the registry
+  // default the user's customisable palette starts from. They are the same
+  // palette, and a drift between them means chat renders one way until the user
+  // opens Settings and a different way afterwards.
+  it('matches the look.color.mirc_colors registry default exactly', () => {
+    const opt = getOption('look.color.mirc_colors');
+    expect(opt?.default).toEqual([...MIRC_PALETTE_FALLBACK]);
+  });
+});
 
 describe('splitTextByTokens — background colour', () => {
   it('keeps both foreground and background of a \\x03FG,BG run', () => {
@@ -155,11 +189,12 @@ describe('segmentInlineStyle / segmentHasStyle — background colour', () => {
   });
 
   it('renders a background even when the foreground is the default (99)', () => {
-    // \x0399,01 — default text on the "black" slot. The fallback "black" is
-    // var(--bg) so the box adapts to whatever theme is active.
+    // \x0399,01 — default text on the "black" slot. Black is a literal colour,
+    // not var(--bg): a slot that resolved to the surface it's painted on would
+    // render as no box at all.
     const style = segmentInlineStyle({ text: 'x', fg: 99, bg: 1 }, null);
     expect(style.color).toBeUndefined();
-    expect(style.backgroundColor).toBe('var(--bg)');
+    expect(style.backgroundColor).toBe('#000000');
   });
 
   it('honours a caller-supplied palette over the fallback', () => {

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -21,16 +21,18 @@ function parse(text: string) {
 }
 
 describe('MIRC_PALETTE_FALLBACK', () => {
-  // The bug that prompted this: slots 0/1/14/15 were CSS variables, on the
-  // theory they'd "stay legible on any background". var(--bg) IS the background,
-  // so black text rendered in precisely the colour behind it and vanished.
+  // The bug that prompted this: slot 1 ("black") was var(--bg), which IS the
+  // surface the text is drawn on — so black text rendered in precisely the
+  // colour behind it and vanished.
   //
-  // A palette entry has to be a colour in its own right. Deferring it to the
-  // surface it's drawn on can only ever produce invisible text, so this bans the
-  // whole shape rather than just the one slot that happened to bite.
-  it('is all self-contained colours — no theme variables', () => {
+  // The rule is narrow on purpose. Theme variables are RIGHT for the mono-ish
+  // slots: look.color.bg and look.color.fg are user-settable, so a slot pinned
+  // to a literal near-white would vanish the moment someone sets a light
+  // background — the same bug mirrored. What can never appear is the background
+  // itself, which is the one value guaranteed to match its own surface.
+  it('never paints a slot in the background colour', () => {
     for (const [i, entry] of MIRC_PALETTE_FALLBACK.entries()) {
-      expect(entry, `slot ${i}`).not.toMatch(/var\(|color-mix\(/);
+      expect(entry, `slot ${i}`).not.toMatch(/var\(\s*--bg\b/);
     }
   });
 

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -275,15 +275,18 @@ function colorNicksInText(
 // Indices 16-98 (extended) and the \x04 hex variant aren't widely used and
 // clash badly with custom themes, so we don't render those — we just consume
 // the escape so the digits don't leak into the output.
-// Every slot is a literal colour. The four mono-ish slots used to be theme
-// variables, on the theory that they'd "stay legible on any background" — which
-// is exactly backwards for slot 1: var(--bg) IS the background, so black text
-// rendered in precisely the colour behind it and vanished. A palette entry has
-// to be a colour in its own right; deferring it to the surface it's drawn on
-// can only ever produce invisible text.
+// The mono-ish slots track the theme so they stay legible when the user changes
+// look.color.bg / look.color.fg — a slot pinned to a literal near-white would
+// vanish the moment someone sets a light background.
+//
+// ⚠ With ONE exception, and it is the whole rule: a slot must never resolve to
+// the SURFACE it is drawn on. Slot 1 was var(--bg), which is the background by
+// definition — black text rendered in precisely the colour behind it and
+// disappeared. var(--fg) and things derived from it are safe (they can never
+// equal the background); var(--bg) can never be anything else.
 export const MIRC_PALETTE_FALLBACK: readonly string[] = [
-  '#fcfcfa', //                                         0  white
-  '#000000', //                                         1  black
+  'var(--fg)', //                                       0  white
+  '#000000', //                                         1  black — NOT var(--bg)
   '#6799f3', //                                         2  navy
   '#a9dc76', //                                         3  green
   '#ff6188', //                                         4  red
@@ -296,8 +299,8 @@ export const MIRC_PALETTE_FALLBACK: readonly string[] = [
   '#a0f1ff', //                                         11 cyan
   '#7ba4ff', //                                         12 blue
   '#ff7494', //                                         13 magenta
-  '#939293', //                                         14 gray
-  '#babab9', //                                         15 light gray
+  'var(--fg-muted)', //                                 14 gray
+  'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
 ];
 
 // Look up a mIRC colour slot in a caller-supplied palette, falling back to

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -275,9 +275,15 @@ function colorNicksInText(
 // Indices 16-98 (extended) and the \x04 hex variant aren't widely used and
 // clash badly with custom themes, so we don't render those — we just consume
 // the escape so the digits don't leak into the output.
+// Every slot is a literal colour. The four mono-ish slots used to be theme
+// variables, on the theory that they'd "stay legible on any background" — which
+// is exactly backwards for slot 1: var(--bg) IS the background, so black text
+// rendered in precisely the colour behind it and vanished. A palette entry has
+// to be a colour in its own right; deferring it to the surface it's drawn on
+// can only ever produce invisible text.
 export const MIRC_PALETTE_FALLBACK: readonly string[] = [
-  'var(--fg)', //                                       0  white
-  'var(--bg)', //                                       1  black
+  '#fcfcfa', //                                         0  white
+  '#000000', //                                         1  black
   '#6799f3', //                                         2  navy
   '#a9dc76', //                                         3  green
   '#ff6188', //                                         4  red
@@ -290,8 +296,8 @@ export const MIRC_PALETTE_FALLBACK: readonly string[] = [
   '#a0f1ff', //                                         11 cyan
   '#7ba4ff', //                                         12 blue
   '#ff7494', //                                         13 magenta
-  'var(--fg-muted)', //                                 14 gray
-  'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
+  '#939293', //                                         14 gray
+  '#babab9', //                                         15 light gray
 ];
 
 // Look up a mIRC colour slot in a caller-supplied palette, falling back to


### PR DESCRIPTION
Reported: spoiler boxes render black-on-black instead of the neutral gray.

It turned out to be two bugs from the same commit, and the second is bigger than spoilers.

## What broke

`f22ac78` ("Customize mIRC color palette + preserve spoiler colors") did two things that are each harmless alone:

1. Remapped mIRC palette slots 0/1/14/15 from literal hex to theme variables — slot 1 ("black") went from `#000000` to **`var(--bg)`**.
2. Taught `SpoilerText` to treat a spoiler run's colour as a styling intent, so a chatter who picks red gets a red spoiler.

`applySpoilerMarkup` emits `\x0301,01` — the canonical spoiler pair, chosen because fg==bg is invisible in *any* IRC client. After that commit, the "sender's colour" for every Lurker-sent spoiler resolved to the page background: the box was the exact colour of the page, and `bodyStyle` set the **revealed** text to `var(--bg)` too. Clicking a spoiler showed nothing.

## Two fixes

**`01,01` is not a colour.** It encodes "hide this", so it's excluded from the colour-preserving path and falls back to the neutral box. A deliberately chosen colour (`04,04` and friends) still rides through — that half of `f22ac78` is worth keeping.

**A palette slot must never resolve to the surface it's drawn on.** `var(--bg)` is the background by definition, so slot 1 matched its own backdrop no matter what. That also broke plain coloured text, not just spoilers: any message using `\x0301` (black text, common in mIRC-era colour art) rendered invisible, since nothing in `segmentInlineStyle` guards a foreground against the surface it lands on. Slot 1 is now a literal `#000000` — legible because the background is `#212022` rather than pure black.

The other mono-ish slots deliberately **stay** theme variables. `look.color.bg` / `look.color.fg` are user-settable, so a slot pinned to a literal near-white would vanish the moment someone sets a light background — the same bug mirrored. `var(--fg)` and things derived from it can never equal the background; `var(--bg)` never can be anything else. That distinction is the whole rule, and it's what the test encodes.

## Review history worth reading

The three commits are unsquashed because the middle one is wrong and the third says why. I first made the whole palette literal, which re-created the reported bug for anyone running a light background. The narrowing in commit 3 is the correct scope.

Also fixed a test that had gone dead: it matched on `/color:\s*var\(--bg\)/`, a value the palette stopped containing one commit later, so the `SpoilerText` guard could be removed and it would still pass. It now asserts what the guard actually does. Both probes were re-verified by reverting each fix *independently* rather than together.

## Tests

`npm run check` clean, full suite green (2947). New `SpoilerText.test.ts` — the component had none. `nickColor.test.ts` gains the `var(--bg)` ban plus a check that the two copies of this palette (`MIRC_PALETTE_FALLBACK` and the `look.color.mirc_colors` registry default) stay identical, since drift means chat renders one way until a user opens Settings and differently afterwards.

## Known gap

A user who previously **customised** their palette keeps a stored 16-entry list that may contain `var(--bg)` for slot 1, and nothing here migrates it. The spoiler guard shields the common path, and the setting's description now warns against it, but it isn't a full fix for those users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)