### PR TITLE
Dependency batch, part 2: the security fixes #658 missed

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.2.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v7.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@types/yauzl": "^3.4.0",
         "@vitest/coverage-v8": "^4.1.10",
         "concurrently": "^10.0.3",
-        "happy-dom": "^20.10.6",
+        "happy-dom": "^20.11.1",
         "oxfmt": "^0.59.0",
         "oxlint": "^1.75.0",
         "supertest": "^7.2.2",
@@ -3639,15 +3639,15 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
         "yargs": "18.0.0"
@@ -4549,9 +4549,9 @@
       "license": "MIT"
     },
     "node_modules/happy-dom": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
-      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5467,9 +5467,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5766,9 +5766,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -5786,7 +5786,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6243,9 +6243,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/yauzl": "^3.4.0",
     "@vitest/coverage-v8": "^4.1.10",
     "concurrently": "^10.0.3",
-    "happy-dom": "^20.10.6",
+    "happy-dom": "^20.11.1",
     "oxfmt": "^0.59.0",
     "oxlint": "^1.75.0",
     "supertest": "^7.2.2",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^6.0.3",
         "vite": "^8.1.5",
         "vite-plugin-mkcert": "^2.1.0",
-        "vue-tsc": "^3.3.7"
+        "vue-tsc": "^3.3.8"
       }
     },
     "node_modules/@babel/generator": {
@@ -741,9 +741,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.7.tgz",
-      "integrity": "sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.8.tgz",
+      "integrity": "sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2525,14 +2525,14 @@
       "license": "MIT"
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.7.tgz",
-      "integrity": "sha512-+C+rgD49wAQ5bUTl2sp5a8Bzg4YoldMNXM+g7CFe604MYcQ8PrZPMQhIjJSzKXtPBCa+C5ayMipqjbA7splekQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.8.tgz",
+      "integrity": "sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.7"
+        "@vue/language-core": "3.3.8"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -26,6 +26,6 @@
     "typescript": "^6.0.3",
     "vite": "^8.1.5",
     "vite-plugin-mkcert": "^2.1.0",
-    "vue-tsc": "^3.3.7"
+    "vue-tsc": "^3.3.8"
   }
 }


### PR DESCRIPTION
The second half of #658. That PR merged one second before this commit was pushed to it, so these changes never reached `main` — including **two high-severity advisory fixes**.

Supersedes **#659, #661, #662, #663** — close them when this merges.

| Bump | | |
|---|---|---|
| `postcss` 8.5.16 → **8.5.23** | #659 | 🔒 advisory |
| `shell-quote` 1.8.4 → **1.9.0** (via `concurrently`) | — | 🔒 advisory, no PR existed |
| `vue-tsc` 3.3.7 → **3.3.8** | #661 | |
| `happy-dom` 20.10.6 → **20.11.1** | #662 | |
| `actions/checkout` 7.0.0 → **7.0.1** | #663 | CI |

## Security

`npm audit` on `main` right now reports **3 high**. This takes it to **0**:

- **postcss ≤8.5.17** — [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849), path traversal via `sourceMappingURL` leading to arbitrary `.map` file disclosure. This is what #659 fixes.
- **shell-quote ≤1.8.4** — [GHSA-395f-4hp3-45gv](https://github.com/advisories/GHSA-395f-4hp3-45gv), quadratic-complexity DoS in `parse()`, pulled in via `concurrently`. **No dependabot PR was ever filed for this one**, so it would have sat unnoticed.
- **brace-expansion** — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — already cleared by #658's 5.0.8 bump, which means #605 was a security fix wearing a routine-patch title.

All three are **devDependencies**, so the exposure is build/dev-time rather than the running server. Worth clearing; not worth alarm.

## Checked

`npm run check` clean · full suite green (2947) · `npm run client:build` succeeds · `npm audit` 0 vulnerabilities · `npm run format` touches zero files.

## Still not included

**TypeScript 7 (#631, #633).** Re-tested with **vue-tsc 3.3.8** — the version this PR bumps to, and the current latest — against TS 7.0.2. It fails identically: `vue-tsc` resolves `require.resolve('typescript/lib/tsc')`, a subpath TS 7 no longer exports, so the client typecheck dies before compiling anything. Its peer range advertises `typescript: >=5.0.0`, but that range is just loose. Both stay parked.

**The `vue_client` tree's 6 dev-only advisories**, all behind `@vue/test-utils` → `js-beautify` → `editorconfig` → `minimatch` → `brace-expansion`. `brace-expansion` 2.x has no patched release (2.1.2 is latest and is itself affected), so the only fixes are npm's suggested **downgrade** of `@vue/test-utils`, or forcing a 5.x override through `minimatch`'s `^2.0.1` range. Breaking the test toolchain to patch a dev-time DoS isn't a good trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
