### PR TITLE
Bump version to 1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
`1.1.3` → `1.1.4`. Same four files as the last bump (#621): both `package.json`s and both lockfiles. `APP_VERSION` reads through from `package.json` (`server/utils/userAgent.ts:26`), so the CTCP VERSION reply and the default QUIT message follow automatically — nothing else to touch.

`npm run check` clean, full suite green.

---

## ⚠ Before tagging: QA the username lockdown (#645)

The one thing in this release that fails **silently and only in production**. `isValidLoginUsername` is deliberately looser than signup validation so legacy usernames containing spaces (`bob smith`) can still sign in. That looseness is load-bearing — if it regressed, the symptom is an existing user locked out, and nothing in the test suite or a fresh local instance will show it.

Signup now rejects spaces, so reproducing it means inserting a legacy-style row directly into SQLite on the cell and confirming that account can still log in.

---

## Draft release notes

Paste-ready for the GitHub release; reword freely.

### What's Changed

- Spoilers were invisible — clicking one revealed nothing at all. Fixed, along with the underlying cause: mIRC color 1 ("black") was mapped to the app's own background color, so **any** black text vanished, not just spoilers.
- Uploads: the server now tells clients the real maximum upload size instead of leaving them to guess. Clients can size media to fit before uploading rather than discovering the limit by failing.
- Operators behind Cloudflare or a reverse proxy can declare their real request-body limit with `LURKER_MAX_UPLOAD_MB`. Oversized uploads now get a clear "too large" error naming the actual limit, instead of dying at the CDN as an unreadable connection reset.
- Account imports respect that same limit, and the import screen refuses an oversized archive up front rather than failing partway through a long upload.
- Auto-reconnect no longer reconnects an account that's paused, or a network the instance has since disallowed — it now clears the same checks every other connect path does.
- A failed SASL login no longer permanently stops auto-reconnect on networks where SASL is optional. Bad credentials still stop retrying, but only after the failure repeats, so an unrelated network blip can't be mistaken for an auth problem.
- `/j` and `/p` now work as shortcuts for `/join` and `/part`, and `/shrug` has been added.
- A buffer with no messages no longer spins forever waiting for history that was never coming.
- Fixed a login redirect loop that ended in a rate-limit error.
- identd now answers with your Lurker account name rather than your current nick, and admins can assign it per user.
- Usernames are locked down: no spaces, and case-insensitive identity, so `Bob` and `bob` can't be two accounts. Existing usernames keep working.
- New docs page documenting IRCv3 support by what each capability actually delivers, at docs.lurker.chat.
- The buffer-list toggle shows a highlight count, so you can see you've been pinged without opening the list.
- **Security:** cleared three high-severity advisories in the dependency tree (path traversal in `postcss`, a denial-of-service in `shell-quote`, and an out-of-memory crash in `brace-expansion`). All build/dev-time dependencies rather than the running server, and one of them had no dependabot PR at all.

### Upgrade notes

- **Behind a CDN or reverse proxy?** Set `LURKER_MAX_UPLOAD_MB` to your real request-body limit (Cloudflare is 100 MB on Free/Pro). Leave it unset if nothing in front of your instance imposes one. See `.env.example` — it must be a bare whole number, and it also caps account imports.
- No migrations. No config changes required.

---

## Still open, deliberately

**TypeScript 7** (#631, #633) is parked: `vue-tsc` resolves `typescript/lib/tsc`, a subpath TS 7 no longer exports, so the client typecheck can't run. Re-tested against the latest `vue-tsc` 3.3.8 — same failure. Waiting on upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
