### PR TITLE
Add "stay put when you send" to the composer

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -796,6 +796,23 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'this client from sending typing/paused/done notifications while you compose ' +
       "a message. Doesn't affect seeing other people's typing indicators.",
   },
+  {
+    key: 'chat.keep_position_on_send',
+    label: 'Stay where you are when you send',
+    category: 'chat',
+    group: 'composing',
+    type: 'bool',
+    default: false,
+    description:
+      'Keep your scroll position when you send a message, instead of jumping to ' +
+      'the newest message. For reading back through a busy channel while still ' +
+      'replying — your own line lands at the bottom and the "Return ↓" button ' +
+      'counts it, so you can drop back down when you are ready. Off (the default) ' +
+      'jumps to the bottom on every send. Sending while you are viewing a ' +
+      'jumped-to point in history returns you to the live conversation either ' +
+      'way, since that view holds live messages back and there is nowhere in it ' +
+      'for your own message to appear.',
+  },
 
   // ─── Smart filter (join/part/quit/nick noise) ─────────────────────────
   {

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -18,6 +18,8 @@ import { createPinia, setActivePinia } from 'pinia';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useRecentBuffersStore } from '../stores/recentBuffers.js';
+import { useSettingsStore } from '../stores/settings.js';
+import { useScrollState } from '../composables/useScrollState.js';
 import MessageInput from './MessageInput.vue';
 
 // The composer sends typing state / drafts over the socket as you type. There's
@@ -444,5 +446,166 @@ describe('MessageInput command dispatch', () => {
     expect(socketSendWithAck).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'send', text: '¯\\_(ツ)_/¯' }),
     );
+  });
+});
+
+// Where the composer leaves the viewport after a send (#628). Driven through
+// real keystrokes for the same reason the completion tests are: the rule reads
+// three sources — the setting, whether the draft is a message or a command, and
+// whether the buffer is detached — and only submit() assembles all three.
+//
+// The observable is useScrollState's token rather than a spy on the composable:
+// it's the same thing MessageList watches, so a test that passes here is
+// asserting the signal the list actually acts on.
+describe('scroll position on send (#628)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    for (const wrapper of mounted) wrapper.unmount();
+    mounted = [];
+    vi.mocked(socketSendWithAck).mockReturnValue(null);
+  });
+
+  async function enter(el: HTMLTextAreaElement) {
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await flush();
+  }
+
+  function keepPosition(on: boolean) {
+    useSettingsStore().values['chat.keep_position_on_send'] = on;
+  }
+
+  // submit() bails before commitInput when the ack send reports a closed
+  // socket, and the shared mock returns null. Every message-shaped case needs
+  // delivery to look like it happened.
+  function allowSend() {
+    vi.mocked(socketSendWithAck).mockReturnValue(Promise.resolve({ ok: true }) as unknown as null);
+  }
+
+  const token = () => useScrollState().scrollToBottomToken.value;
+
+  it('re-pins to the bottom by default', async () => {
+    seedStores('#zebra');
+    allowSend();
+    const { el } = await mountComposer();
+
+    await type(el, 'hello');
+    const before = token();
+    await enter(el);
+
+    expect(token()).toBeGreaterThan(before);
+  });
+
+  it('leaves the viewport alone when the setting is on', async () => {
+    seedStores('#zebra');
+    keepPosition(true);
+    allowSend();
+    const { el } = await mountComposer();
+
+    await type(el, 'hello');
+    const before = token();
+    await enter(el);
+
+    expect(token()).toBe(before);
+    // The send itself is unaffected — this is a scroll rule, not a send gate.
+    expect(socketSendWithAck).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'send', text: 'hello' }),
+    );
+  });
+
+  it('re-pins for a command even with the setting on', async () => {
+    // /commands answers with 40-odd localInfo lines, and those rows are id-less
+    // so the "N new ↓" badge never counts them. Keeping your place would put
+    // the answer below the fold with nothing to say it arrived.
+    seedStores('#zebra');
+    keepPosition(true);
+    const { el } = await mountComposer();
+
+    await type(el, '/commands');
+    const before = token();
+    await enter(el);
+
+    expect(token()).toBeGreaterThan(before);
+  });
+
+  // One case per shape of message-producing command, because the first cut of
+  // this classified by parsing the verb and only knew the four that bodyForSplit
+  // knows for split-gating — so /slap and /jitsi jumped to the bottom while /me
+  // and /shrug stayed put. Now it's whether the command actually put something
+  // on the wire, and these are the three ways that happens.
+  it.each([
+    ['/me waves', 'action'],
+    ['/slap bob', 'action'],
+    ['/jitsi', 'send'],
+  ])('treats %s as the send it is, not a command', async (draft, wireType) => {
+    seedStores('#zebra');
+    keepPosition(true);
+    allowSend();
+    const { el } = await mountComposer();
+
+    await type(el, draft);
+    const before = token();
+    await enter(el);
+
+    expect(token()).toBe(before);
+    // Positive control: without this, a command that never reached commitInput
+    // would produce the same unchanged token and pass for the wrong reason.
+    expect(socketSendWithAck).toHaveBeenCalledWith(expect.objectContaining({ type: wireType }));
+  });
+
+  it('rejoins live when the send came from a detached slice', async () => {
+    // The message goes to the live tail, which a detached buffer holds out of
+    // the log — so staying put, setting or no setting, would show a stretch of
+    // history the message can never appear in.
+    const { buffers } = seedStores('#zebra');
+    buffers.buffers['1::#zebra'].detached = true;
+    keepPosition(true);
+    allowSend();
+    const reattach = vi.spyOn(buffers, 'reattachToLive').mockReturnValue(true);
+    const { el } = await mountComposer();
+
+    await type(el, 'hello');
+    const before = token();
+    await enter(el);
+
+    expect(reattach).toHaveBeenCalledWith(1, '#zebra');
+    expect(token()).toBeGreaterThan(before);
+  });
+
+  it('does not rejoin live for a command run from a detached slice', async () => {
+    // A command isn't a send: nothing of the user's went to the live tail, so
+    // throwing away the history slice they deliberately jumped to would be a
+    // change they never asked for — and this path is on by default.
+    const { buffers } = seedStores('#zebra');
+    buffers.buffers['1::#zebra'].detached = true;
+    const reattach = vi.spyOn(buffers, 'reattachToLive').mockReturnValue(true);
+    const { el } = await mountComposer();
+
+    await type(el, '/commands');
+    await enter(el);
+
+    expect(reattach).not.toHaveBeenCalled();
+  });
+
+  it('stays put when the rejoin request could not go out', async () => {
+    // reattachToLive returns false while another history page is in flight. The
+    // buffer is still detached and the message still isn't loaded, so scrolling
+    // would claim an arrival that hasn't happened; "Return ↓" stays the way back.
+    const { buffers } = seedStores('#zebra');
+    buffers.buffers['1::#zebra'].detached = true;
+    allowSend();
+    const reattach = vi.spyOn(buffers, 'reattachToLive').mockReturnValue(false);
+    const { el } = await mountComposer();
+
+    await type(el, 'hello');
+    const before = token();
+    await enter(el);
+
+    expect(token()).toBe(before);
+    // Positive control, as above: proves the send got as far as the detached
+    // branch rather than falling out of submit() somewhere earlier.
+    expect(reattach).toHaveBeenCalled();
   });
 });

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -24,9 +24,12 @@ import MessageInput from './MessageInput.vue';
 
 // The composer sends typing state / drafts over the socket as you type. There's
 // no socket in a test, and none of it is what we're exercising.
+// socketSendWithAck carries the real signature rather than `() => null`: it
+// returns a promise when the socket is open, and the tests that need a send to
+// look like it landed have to be able to say so without cast-fighting the mock.
 vi.mock('../composables/useSocket.js', () => ({
   socketSend: vi.fn<() => void>(),
-  socketSendWithAck: vi.fn<() => null>(() => null),
+  socketSendWithAck: vi.fn<() => Promise<AckResult> | null>(() => null),
   onSocketOpen: vi.fn<() => () => void>(() => () => {}),
 }));
 
@@ -34,7 +37,7 @@ vi.mock('../composables/useSocket.js', () => ({
 // payload. Which one a command uses is not incidental: `sendOrToast` fires
 // socketSend, while anything that wants delivery confirmation (`ackedSend`, and
 // so every message-shaped command) goes through socketSendWithAck.
-import { socketSend, socketSendWithAck } from '../composables/useSocket.js';
+import { socketSend, socketSendWithAck, type AckResult } from '../composables/useSocket.js';
 
 const CHANNELS = ['#apple', '#mango', '#zebra'];
 // `mallory` exists so the self-exclusion test has a positive control: without a
@@ -481,7 +484,7 @@ describe('scroll position on send (#628)', () => {
   // socket, and the shared mock returns null. Every message-shaped case needs
   // delivery to look like it happened.
   function allowSend() {
-    vi.mocked(socketSendWithAck).mockReturnValue(Promise.resolve({ ok: true }) as unknown as null);
+    vi.mocked(socketSendWithAck).mockReturnValue(Promise.resolve({ ok: true }));
   }
 
   const token = () => useScrollState().scrollToBottomToken.value;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -177,6 +177,7 @@ import {
   splitGateFor,
   type MultilineLimits,
 } from '../utils/messageSplit.js';
+import { shouldRepinOnSend } from '../utils/sendScroll.js';
 import { applySpoilerMarkup } from '../utils/spoilerMarkup.js';
 import { buildNickCandidates } from '../utils/nickCompletion.js';
 import { buildChannelCandidates } from '../utils/channelCompletion.js';
@@ -1878,7 +1879,12 @@ function toastSendFailure(error: string, body: string): void {
 // Optimistically clear, but only AFTER we've confirmed the send actually
 // hit the wire. Anything we'd otherwise have lost (the typed text, the
 // history slot) is still recoverable via up-arrow if delivery later fails.
-function commitInput(raw: string, networkId: number, target: string): void {
+function commitInput(
+  raw: string,
+  networkId: number,
+  target: string,
+  opts: { isChatMessage: boolean },
+): void {
   inputHistory.add(networkId, target, raw);
   socketSend({ type: 'input-history-add', networkId, target, text: raw });
   // Clear the draft for the buffer the send came FROM, addressed explicitly
@@ -1894,10 +1900,54 @@ function commitInput(raw: string, networkId: number, target: string): void {
   pendingSplitConfirm = false;
   setComposingState({ chunks: 0, isAction: false });
   resetHistoryNav();
+  // A command always re-pins, whatever the setting says, and never reattaches.
+  // Its output lands in this buffer through localInfo — /commands, /ignore
+  // list, every usage and error line — and those rows are deliberately id-less,
+  // which is precisely what maybeBumpNewBelow skips. So keeping your place
+  // would drop the answer below the fold with no "Return (N new) ↓" to say it
+  // exists, and the command would look like it did nothing. That's the same
+  // reasoning the system buffer applies to everything it prints. Sends wearing
+  // a command's clothes (/me, /slap, /shrug, /jitsi, …) are messages, not
+  // commands; the caller tells them apart by whether the command actually put
+  // something on the wire, not by the verb.
+  if (!opts.isChatMessage) {
+    requestScrollToBottom();
+    return;
+  }
+
   // Re-pin to the bottom so a user who was scrolled up reading history sees
   // their own send land — and the live-append watcher in MessageList keeps
-  // following once stickToBottom flips back on.
-  requestScrollToBottom();
+  // following once stickToBottom flips back on. chat.keep_position_on_send
+  // opts out of the yank (#628); see shouldRepinOnSend for why a detached
+  // buffer overrides it.
+  //
+  // The buffer tested is the ACTIVE one, not the one the send was addressed to:
+  // this decides what happens to the list on screen, and a `/msg nick text` has
+  // already activated the DM by the time we get here. That new buffer is never
+  // detached, so switching to it still lands at the bottom.
+  const onScreen = networks.activeKey ? buffers.byKey(networks.activeKey) : null;
+  const detached = !!onScreen?.detached;
+  if (detached) {
+    // Sending from a detached slice returns to live, the same way the status
+    // bar's "Return ↓" does. The message went to the live tail, and a detached
+    // buffer holds that tail out of the log — so a plain scroll would land at
+    // the end of a stretch of history the message can never appear in, which
+    // reads as a failed send. Fetching the tail is the only way to show it.
+    const rejoined =
+      onScreen?.networkId != null && buffers.reattachToLive(onScreen.networkId, onScreen.target);
+    // The request doesn't go out while another history page is already in
+    // flight (the downward pager, mid-slice). The buffer is then still
+    // detached and the message still isn't loaded, so scrolling would claim an
+    // arrival that hasn't happened. Leaving the reader where they are keeps
+    // "Return ↓" and its count in front of them — one tap fetches the tail,
+    // this message included.
+    if (!rejoined) return;
+  }
+  const repin = shouldRepinOnSend({
+    keepPosition: settings.effective('chat.keep_position_on_send') === true,
+    detached,
+  });
+  if (repin) requestScrollToBottom();
 }
 
 async function submit() {
@@ -1926,6 +1976,10 @@ async function submit() {
     }
     systemText.value = '';
     resetHistoryNav();
+    // Unconditional, unlike the chat path above: chat.keep_position_on_send is
+    // for reading a conversation while replying to it, and this buffer isn't a
+    // conversation — you type a command to read what it prints back, so keeping
+    // your place would hide the only thing the send produced.
     requestScrollToBottom();
     return;
   }
@@ -1996,9 +2050,10 @@ async function submit() {
     // as a chat message; the rest stay best-effort but at least bail out
     // synchronously if the socket is closed so we don't silently swallow
     // them either.
+    const said = chatMessagesSent;
     const handled = await handleCommand(raw, networkId, target);
     if (!handled) return;
-    commitInput(raw, networkId, target);
+    commitInput(raw, networkId, target, { isChatMessage: chatMessagesSent > said });
     return;
   }
 
@@ -2018,7 +2073,7 @@ async function submit() {
   typingState = null;
   typingTarget = null;
   clearInactivityTimer();
-  commitInput(raw, networkId, target);
+  commitInput(raw, networkId, target, { isChatMessage: true });
   const result = await pending;
   if (!result.ok) toastSendFailure(result.error ?? 'unknown', raw);
 }
@@ -2228,12 +2283,28 @@ function sendOrToast(payload: Record<string, unknown>, body: string): boolean {
 // channel/DM (/me, /msg <body>, /jitsi). Same shape as the main submit path:
 // returns false synchronously if the socket is closed; otherwise kicks off
 // the await and toasts asynchronously on a non-ok ACK.
+// How many chat messages slash commands have put on the wire this session.
+// Read as a before/after pair around handleCommand (see submit) to answer "did
+// that command actually say something?", which decides whether the scroll rule
+// treats it as a send or as a command (#628).
+//
+// Counted here, at the one seam every message-shaped command goes through,
+// rather than by re-reading the verb: /me, /slap, /shrug, /jitsi, /talk, /msg
+// and /query all say something, and a list of them maintained anywhere else is
+// a list that goes stale the first time somebody adds the eighth. A counter
+// rather than a flag because submit() awaits handleCommand, so a second Enter
+// arriving mid-await would clobber a flag but can only inflate a counter.
+let chatMessagesSent = 0;
+
 function ackedSend(payload: Record<string, unknown>, body: string): boolean {
   const pending = socketSendWithAck(payload);
   if (!pending) {
     toastSendFailure('disconnected', body);
     return false;
   }
+  // 'notice' is deliberately not counted: it's addressed to someone else and
+  // puts nothing in the buffer the command was run from.
+  if (payload.type === 'send' || payload.type === 'action') chatMessagesSent += 1;
   pending.then((result) => {
     if (!result.ok) toastSendFailure(result.error ?? 'unknown', body);
     return result;

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2292,8 +2292,9 @@ function sendOrToast(payload: Record<string, unknown>, body: string): boolean {
 // rather than by re-reading the verb: /me, /slap, /shrug, /jitsi, /talk, /msg
 // and /query all say something, and a list of them maintained anywhere else is
 // a list that goes stale the first time somebody adds the eighth. A counter
-// rather than a flag because submit() awaits handleCommand, so a second Enter
-// arriving mid-await would clobber a flag but can only inflate a counter.
+// rather than a flag so the reader owns the whole question — take a reading,
+// run the command, compare — with no reset for a future call site to forget or
+// to sequence wrongly against the read.
 let chatMessagesSent = 0;
 
 function ackedSend(payload: Record<string, unknown>, body: string): boolean {

--- a/vue_client/src/utils/sendScroll.test.ts
+++ b/vue_client/src/utils/sendScroll.test.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { shouldRepinOnSend } from './sendScroll.js';
+
+describe('shouldRepinOnSend', () => {
+  it('re-pins by default', () => {
+    expect(shouldRepinOnSend({ keepPosition: false, detached: false })).toBe(true);
+  });
+
+  it('stays put when the user asked to keep their position', () => {
+    expect(shouldRepinOnSend({ keepPosition: true, detached: false })).toBe(false);
+  });
+
+  it('re-pins from a detached slice even with the setting on', () => {
+    // The sent message isn't in the loaded slice, so staying would show the
+    // user a stretch of history their line can never appear in. The caller
+    // re-attaches alongside this; the scroll is what follows the new tail in.
+    expect(shouldRepinOnSend({ keepPosition: true, detached: true })).toBe(true);
+  });
+
+  it('re-pins from a detached slice with the setting off', () => {
+    expect(shouldRepinOnSend({ keepPosition: false, detached: true })).toBe(true);
+  });
+});

--- a/vue_client/src/utils/sendScroll.ts
+++ b/vue_client/src/utils/sendScroll.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Whether sending should re-pin the message list to the bottom (#628).
+//
+// The default is yes, and always was: you send, you see your line land. But a
+// reader working back through a busy channel loses their place every time they
+// reply, so chat.keep_position_on_send lets them stay put — the send still goes
+// out, it just doesn't drag the viewport with it. Nothing is lost by staying:
+// the status bar's "Return (N new) ↓" counts the echo like any other arrival.
+//
+// Detached buffers (a #42 jump into history) re-pin no matter what the setting
+// says. Live events are held out of the slice while detached, so the sent
+// message isn't loaded at all — honouring "keep my position" there would leave
+// the user staring at a stretch of history their message can never appear in,
+// which reads as a failed send rather than a respected preference. The caller
+// pairs this with a reattachToLive for the same reason: the scroll alone would
+// only reach the end of the slice, and the message isn't there either.
+export function shouldRepinOnSend(opts: { keepPosition: boolean; detached: boolean }): boolean {
+  return !opts.keepPosition || opts.detached;
+}


### PR DESCRIPTION
Adds `chat.keep_position_on_send` (bool, default **off**) — the first half of #628. Replying while reading back through a busy channel currently costs you your place every time; this lets a reader opt out of the jump.

The iOS half is a companion PR in `lurker-ios`, so the two clients can't disagree about the rule. The second ask in #628 (the "Unread ↑" button timeout) is deliberately not in scope.

## What it does

With the setting on, sending leaves the viewport where it is. Nothing is lost by staying — the status bar's "Return (N new) ↓" counts your own line like any other arrival, so the send is still visibly confirmed and one click brings you back.

Two carve-outs, both of which came out of review:

**Commands still jump.** `commitInput` is the shared tail for sends *and* slash commands, and a command's output arrives via `localInfo` as id-less rows — precisely what `maybeBumpNewBelow` skips. Keeping your place for `/commands` or `/ignore list` would drop the answer below the fold with no badge to say it exists, so the command would look like it did nothing. That's the same reasoning the system buffer already applies to everything it prints.

Which commands count as sends is derived from `ackedSend` — the one seam every message-shaped command goes through — rather than from the verb. An earlier cut asked `bodyForSplit`, whose list exists for split gating and knows only `/me`, `/shrug`, `/msg`, `/query`; `/slap` and `/jitsi` say something too and jumped anyway. Asking "did this command put anything on the wire" can't go stale when an eighth verb lands.

**A detached buffer returns to live.** Previously a send from a jumped-to slice (#42) snapped to the end of *that slice* and never re-attached — so your message, which went to the live tail a detached buffer holds out of the log, was nowhere on screen and nothing said so. It now re-attaches, the way "Return ↓" does. Commands don't: nothing of yours went to the live tail, and discarding a slice the reader deliberately jumped to would be a default-path change nobody asked for. If the re-attach request can't go out (another history page in flight) the scroll is skipped too, since the buffer is still detached and the message still isn't loaded.

## Testing

- 9 new tests: 4 unit (`shouldRepinOnSend`) + 5 driving real keystrokes through the mounted composer, observing `scrollToBottomToken` — the same signal `MessageList` watches.
- Each fix was **mutation-tested**: reverting it fails exactly the tests that should catch it, including reproducing the `/slap` bug found in manual QA.
- The two tests asserting an *absence* of scrolling carry positive controls, so they can't pass because the send silently never happened.
- `npm run check` clean, 2960 tests pass.
- Manually QA'd in the browser by @amiantos, including the `/slap` regression.

`/code-review high` found three issues (command output invisible, the re-attach affecting default-path users, and the in-flight race); all three are fixed above.

Refs #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)