### PR TITLE
Say how to merge a backlog frame instead of implying it

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -251,11 +251,19 @@ it once the whole burst went out, so a snapshot that failed part-way through
 never claims a buffer is missing.
 
 **Shells vs. hydrated backlogs.** On a fresh connect (`since=0`) channel/DM
-buffers arrive as _shells_: `{kind:'backlog', …, events:[], hasMoreOlder:true}` —
-"this buffer exists; fetch content when the user opens it." Hydrate a shell with
-either `{type:'open-buffer'}` (server replies with a populated `backlog` — the
-iOS approach) or `{type:'history', mode:'latest'}` (the web-client approach).
-Both are valid; pick one.
+buffers arrive as _shells_: `{kind:'backlog', …, events:[], mode:'shell',
+hasMoreOlder:true}` — "this buffer exists; fetch content when the user opens it."
+
+Hydrate a shell with **`{type:'history', mode:'latest'}`**. It is a pure read.
+
+> ⚠ `{type:'open-buffer'}` also returns a populated `backlog`, and the iOS app
+> currently hydrates with it — but it is a **write verb**, not a read: for a
+> closed buffer with history it _reopens_ the buffer and fans `buffer-opened`
+> out to every one of the user's other clients, and for an unjoined `#channel`
+> it JOINs. Using it to hydrate means a user merely _opening a screen_ silently
+> mutates shared state. Reserve it for explicit user intent ("open this DM",
+> "join this channel"). Same hazard as the "don't probe with `open-buffer`"
+> warning above, reached from a different direction.
 
 ### 4.4 Reconnect and resume (`?since`)
 
@@ -410,6 +418,21 @@ network you don't own gets `{kind:'error', text:'unknown network'}`. Unknown
 verbs are non-fatal (§2). Verbs marked ⏸ are rejected when the account is
 paused. Dispatch: `handleClientMessage`, `wsHub.ts:2031`.
 
+**Request/reply correlation.** There is no envelope-level request id. The verbs
+that answer you carry a per-verb correlation field instead, which you generate
+and the server echoes back verbatim:
+
+| Verb(s)                      | Field           | Echoed on                   | Discipline                                                           |
+| ---------------------------- | --------------- | --------------------------- | -------------------------------------------------------------------- |
+| `send` / `action` / `notice` | `clientId`      | `send-result`               | Optional. Omit it and you get no ack (the `irc` echo still arrives)  |
+| `history` / `search`         | `token`         | `history` / `search-result` | Keep it monotonic and **drop replies whose token you've superseded** |
+| `POST /api/uploads` (REST)   | `progressToken` | `upload-progress`           | ≤64 chars; the only cross-transport one (REST request, WS replies)   |
+
+Three names for one concept is a historical accident, not a pattern to extend.
+Nothing else is correlated: every other verb either replies with a frame whose
+`(networkId, target)` identifies it unambiguously, or doesn't reply at all.
+Match on those keys rather than inventing your own correlation.
+
 ### Sending ⏸
 
 | `type`   | Fields                                             | Notes                                                                            |
@@ -489,30 +512,30 @@ a v1 client.
 
 ### 7.1 Frame kinds
 
-| `kind`                                                                                                                                                                   | Payload                                                                                                                                                             | When                                               |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `snapshot`                                                                                                                                                               | `protocolVersion, maxUploadBytes, networks[], globalIgnores[], cursor?`                                                                                             | Connect burst / gap-fill                           |
-| `draft-snapshot` / `bookmark-ids-snapshot` / `contacts-snapshot`                                                                                                         | `drafts` / `ids[]` / `contacts[]`                                                                                                                                   | Connect burst                                      |
-| `backlog-complete`                                                                                                                                                       | —                                                                                                                                                                   | Last frame of the burst; absence is proof (§4.3)   |
-| `backlog`                                                                                                                                                                | `networkId, target, events[], reset?, hasMoreOlder, joined, lastReadId, unread, highlights, highlightsCapped, clearedBeforeId, clearedAt, speakers?, inputHistory?` | Burst, `open-buffer` reply, resume gap             |
-| `irc`                                                                                                                                                                    | A decorated `MessageEvent` (§5.3) with `kind` clobbered to `'irc'`                                                                                                  | Every live IRC-side event                          |
-| `history`                                                                                                                                                                | `networkId, target, mode, token, events[], speakers, hasMoreOlder, hasMoreNewer, hasMore, before/afterId/anchorId/anchorMissing` (per mode)                         | Reply to `history`                                 |
-| `read-state`                                                                                                                                                             | see §5.4                                                                                                                                                            | After every countable event / mark-read            |
-| `send-result`                                                                                                                                                            | `clientId, ok, error?`                                                                                                                                              | Ack for `send`/`action`/`notice`                   |
-| `buffer-opened` / `buffer-closed` / `buffer-reopened`                                                                                                                    | `networkId, target`                                                                                                                                                 | Buffer lifecycle (§9.1)                            |
-| `buffer-cleared`                                                                                                                                                         | `networkId, target, clearedBeforeId, clearedAt`                                                                                                                     | `/clear` marker                                    |
-| `pins-changed`                                                                                                                                                           | `networkId, pinned[]`                                                                                                                                               | Authoritative pin order                            |
-| `nicklist-collapsed-changed` / `channel-notify-changed`                                                                                                                  | `networkId, target, …`                                                                                                                                              | View-state sync                                    |
-| `draft-updated` / `input-history-added` / `bookmark-updated` / `nick-note-updated` / `relay-bot-updated` / `contact-updated` / `contact-deleted` / `ignore-list-updated` | various                                                                                                                                                             | Multi-device view-state fan-out                    |
-| `settings`                                                                                                                                                               | `changes`, `maxUploadBytes?` (only when the upload cap was touched)                                                                                                 | Server-side settings changed                       |
-| `highlight-rules-changed`                                                                                                                                                | —                                                                                                                                                                   | Re-fetch highlight rules                           |
-| `account-state`                                                                                                                                                          | `paused: bool`                                                                                                                                                      | Hosted pause/resume                                |
-| `chanlist-state` / `chanlist-result`                                                                                                                                     | `/LIST` cache meta / result page                                                                                                                                    | Channel browser                                    |
-| `e2eExport` / `e2eImport`                                                                                                                                                | E2E key material / import result                                                                                                                                    | Replies, this socket only                          |
-| `dcc-transfer`                                                                                                                                                           | full transfer row (snake_case)                                                                                                                                      | DCC state changes                                  |
-| `upload-progress`                                                                                                                                                        | `token, phase, destination, percent`                                                                                                                                | During REST upload (correlate via `progressToken`) |
-| `export`                                                                                                                                                                 | `job`                                                                                                                                                               | Export job progress                                |
-| `error`                                                                                                                                                                  | `text`                                                                                                                                                              | Non-fatal; also the reply to unknown verbs         |
+| `kind`                                                                                                                                                                   | Payload                                                                                                                                                                                                                                                     | When                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `snapshot`                                                                                                                                                               | `protocolVersion, maxUploadBytes, networks[], globalIgnores[], cursor?`                                                                                                                                                                                     | Connect burst / gap-fill                           |
+| `draft-snapshot` / `bookmark-ids-snapshot` / `contacts-snapshot`                                                                                                         | `drafts` / `ids[]` / `contacts[]`                                                                                                                                                                                                                           | Connect burst                                      |
+| `backlog-complete`                                                                                                                                                       | —                                                                                                                                                                                                                                                           | Last frame of the burst; absence is proof (§4.3)   |
+| `backlog`                                                                                                                                                                | `networkId, target, events[], mode, reset?, hasMoreOlder, joined, lastReadId, unread, highlights, highlightsCapped, clearedBeforeId, clearedAt, speakers?, inputHistory?` — **`mode ∈ replace\|append\|shell` is how you merge it (§8); `reset` is legacy** | Burst, `open-buffer` reply, resume gap             |
+| `irc`                                                                                                                                                                    | A decorated `MessageEvent` (§5.3) with `kind` clobbered to `'irc'`                                                                                                                                                                                          | Every live IRC-side event                          |
+| `history`                                                                                                                                                                | `networkId, target, mode, token, events[], speakers, hasMoreOlder, hasMoreNewer, hasMore, before/afterId/anchorId/anchorMissing` (per mode)                                                                                                                 | Reply to `history`                                 |
+| `read-state`                                                                                                                                                             | see §5.4                                                                                                                                                                                                                                                    | After every countable event / mark-read            |
+| `send-result`                                                                                                                                                            | `clientId, ok, error?`                                                                                                                                                                                                                                      | Ack for `send`/`action`/`notice`                   |
+| `buffer-opened` / `buffer-closed` / `buffer-reopened`                                                                                                                    | `networkId, target`                                                                                                                                                                                                                                         | Buffer lifecycle (§9.1)                            |
+| `buffer-cleared`                                                                                                                                                         | `networkId, target, clearedBeforeId, clearedAt`                                                                                                                                                                                                             | `/clear` marker                                    |
+| `pins-changed`                                                                                                                                                           | `networkId, pinned[]`                                                                                                                                                                                                                                       | Authoritative pin order                            |
+| `nicklist-collapsed-changed` / `channel-notify-changed`                                                                                                                  | `networkId, target, …`                                                                                                                                                                                                                                      | View-state sync                                    |
+| `draft-updated` / `input-history-added` / `bookmark-updated` / `nick-note-updated` / `relay-bot-updated` / `contact-updated` / `contact-deleted` / `ignore-list-updated` | various                                                                                                                                                                                                                                                     | Multi-device view-state fan-out                    |
+| `settings`                                                                                                                                                               | `changes`, `maxUploadBytes?` (only when the upload cap was touched)                                                                                                                                                                                         | Server-side settings changed                       |
+| `highlight-rules-changed`                                                                                                                                                | —                                                                                                                                                                                                                                                           | Re-fetch highlight rules                           |
+| `account-state`                                                                                                                                                          | `paused: bool`                                                                                                                                                                                                                                              | Hosted pause/resume                                |
+| `chanlist-state` / `chanlist-result`                                                                                                                                     | `/LIST` cache meta / result page                                                                                                                                                                                                                            | Channel browser                                    |
+| `e2eExport` / `e2eImport`                                                                                                                                                | E2E key material / import result                                                                                                                                                                                                                            | Replies, this socket only                          |
+| `dcc-transfer`                                                                                                                                                           | full transfer row (snake_case)                                                                                                                                                                                                                              | DCC state changes                                  |
+| `upload-progress`                                                                                                                                                        | `token, phase, destination, percent`                                                                                                                                                                                                                        | During REST upload (correlate via `progressToken`) |
+| `export`                                                                                                                                                                 | `job`                                                                                                                                                                                                                                                       | Export job progress                                |
+| `error`                                                                                                                                                                  | `text`                                                                                                                                                                                                                                                      | Non-fatal; also the reply to unknown verbs         |
 
 ### 7.2 `irc` event types (the inner `type` field)
 
@@ -589,14 +612,29 @@ slice (track them separately or refetch); `latest` reattaches.
 
 **Merge rules that protect you from data loss:**
 
-1. `backlog` with `reset:true` → replace the buffer's contents wholesale
-   (resume gap overflowed; splicing leaves a hole).
-2. `backlog` without a `reset` field, or the system buffer's backlog (which
-   hardcodes `reset:false` but means "replace") → replace. Only
-   `networkId != null` **and** `reset === false` means gap-append. (iOS
-   `FrameParser.swift:104-111`; web detects the non-overlap case instead.)
-3. **Never un-hydrate:** a later shell (`events:[]`) for a buffer you already
-   populated must not wipe it.
+1. **Read `mode` on every `backlog` frame and do exactly what it says.** It is
+   the server stating how it built the slice, and it is the only field you need:
+
+   | `mode`    | Meaning                                      | Action                                           |
+   | --------- | -------------------------------------------- | ------------------------------------------------ |
+   | `replace` | This slice stands alone                      | Drop what you hold for the buffer, take `events` |
+   | `append`  | A contiguous gap-fill                        | Splice onto your existing tail                   |
+   | `shell`   | Buffer exists, nothing shipped (`events:[]`) | Leave existing contents alone; fetch on open     |
+
+2. **Ignore `reset`.** It predates `mode` and is not decodable on its own:
+   `reset:false` means _append_ on a resume gap but _replace_ on a fresh
+   connect and on the system buffer — three meanings, two values. Old clients
+   derived it by also reading `networkId` and by knowing out-of-band whether
+   they'd sent `?since` (iOS `FrameParser.swift:104-111`; web inferred from id
+   non-overlap). It is still sent, unchanged, and will keep being sent. Don't
+   build on it.
+
+   > A server predating `mode` omits the field. If you must support one, fall
+   > back to the old derivation: replace unless `networkId != null && reset === false`.
+
+3. **Never un-hydrate:** a `shell` for a buffer you already populated must not
+   wipe it. This is why shells are their own `mode` rather than
+   `replace`-with-empty.
 4. On any replace, **keep held live events newer than the slice tail** — a
    message can land mid-hydrate.
 5. Dedupe everything by id against what you hold; drop legacy `away`/`back`
@@ -634,9 +672,28 @@ these signals:
   `read-state` for unknown buffers must resolve-or-drop. (`mark-all-read` fans
   out `read-state` for _closed_ buffers too — resurrecting them in the sidebar
   was bug #319; typing-tag DM creation was #292.)
-- NOTICEs never create or reopen a DM — a notice to a closed/absent DM arrives
-  on `:server:` with `mirrored:true`. Already handled server-side; just don't
-  special-case it.
+- **NOTICEs may create a DM buffer, but never reopen a closed one.** Both
+  outcomes are decided server-side and arrive as ordinary frames — don't
+  special-case either. What the server actually does with an incoming
+  DM-targeted event (`server/db/buffers.ts:21-29`):
+
+  | Trigger              | Buffer has no row | Buffer row is closed                      |
+  | -------------------- | ----------------- | ----------------------------------------- |
+  | `message` / `action` | creates it, open  | **reopens** it                            |
+  | `notice`             | creates it, open  | **stays closed** → mirrored to `:server:` |
+
+  So a NOTICE from a nick you've never talked to does open a buffer for that
+  nick — that's how services (NickServ, ChanServ, oper notices) get their own
+  buffer instead of dumping into `:server:`. Only the **closed-row** case
+  routes elsewhere: the real copy is persisted in the closed DM buffer (waiting
+  for a reopen) and a second, durable copy lands in `:server:` carrying
+  `mirrored:true`. Render the mirror like any other `:server:` line; it's
+  excluded from search so it can't double up results.
+
+  A notice-only buffer is deliberately **not** a "conversation": the server
+  won't start presence-tracking its nick (no MONITOR slot, no presence dot)
+  until a real PRIVMSG/ACTION arrives (`db/messages.ts:440`).
+
 - **Navigating to a buffer by key** (launch restore, notification tap) is the
   one case where you need to ask "does this exist?" rather than mirror a
   signal. Wait for `backlog-complete`; if the key still has no `backlog` frame

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -258,12 +258,22 @@ Hydrate a shell with **`{type:'history', mode:'latest'}`**. It is a pure read.
 
 > ⚠ `{type:'open-buffer'}` also returns a populated `backlog`, and the iOS app
 > currently hydrates with it — but it is a **write verb**, not a read: for a
-> closed buffer with history it _reopens_ the buffer and fans `buffer-opened`
-> out to every one of the user's other clients, and for an unjoined `#channel`
-> it JOINs. Using it to hydrate means a user merely _opening a screen_ silently
-> mutates shared state. Reserve it for explicit user intent ("open this DM",
-> "join this channel"). Same hazard as the "don't probe with `open-buffer`"
-> warning above, reached from a different direction.
+> closed buffer with history it _reopens_ the buffer (a persisted state flip),
+> and for an unjoined `#channel` it JOINs. Using it to hydrate means a user
+> merely _opening a screen_ mutates persisted state. Reserve it for explicit
+> user intent ("open this DM", "join this channel"). Same hazard as the "don't
+> probe with `open-buffer`" warning above, reached from a different direction.
+>
+> **And the write is silent to the user's other devices.** All three branches
+> of `handleOpenBuffer` reply with `send(ws, …)` to the requesting socket only —
+> there is no fan-out (`wsHub.ts:1138-1163`). So a reopen triggered here reaches
+> the other clients **only on their next snapshot**, leaving them showing the
+> buffer as closed until then. Don't write a `buffer-opened` handler expecting
+> to be notified of another device's open: that frame is an ack to the socket
+> that asked, not a broadcast. Of the three lifecycle frames only
+> `buffer-closed` (`wsHub.ts:2452`) and `buffer-reopened` (`wsHub.ts:1618`,
+> emitted when an incoming _event_ outranks the closed flag — not by this verb)
+> are fanned out.
 
 ### 4.4 Reconnect and resume (`?since`)
 
@@ -420,13 +430,19 @@ paused. Dispatch: `handleClientMessage`, `wsHub.ts:2031`.
 
 **Request/reply correlation.** There is no envelope-level request id. The verbs
 that answer you carry a per-verb correlation field instead, which you generate
-and the server echoes back verbatim:
+and the server echoes back (verbatim, with one length caveat noted below):
 
 | Verb(s)                      | Field           | Echoed on                   | Discipline                                                           |
 | ---------------------------- | --------------- | --------------------------- | -------------------------------------------------------------------- |
 | `send` / `action` / `notice` | `clientId`      | `send-result`               | Optional. Omit it and you get no ack (the `irc` echo still arrives)  |
 | `history` / `search`         | `token`         | `history` / `search-result` | Keep it monotonic and **drop replies whose token you've superseded** |
-| `POST /api/uploads` (REST)   | `progressToken` | `upload-progress`           | ≤64 chars; the only cross-transport one (REST request, WS replies)   |
+| `POST /api/uploads` (REST)   | `progressToken` | `upload-progress`           | **Must be ≤64 chars** — see below; the only cross-transport one      |
+
+> ⚠ `progressToken` is **truncated, not rejected**, at 64 characters
+> (`routes/uploads.ts:250`). Send a longer one and the upload succeeds while
+> every `upload-progress` frame carries the truncated token, matching nothing
+> you're waiting on — so progress silently never appears and no error is raised
+> anywhere. Keep yours short (a UUID is 36).
 
 Three names for one concept is a historical accident, not a pattern to extend.
 Nothing else is correlated: every other verb either replies with a frame whose
@@ -612,34 +628,54 @@ slice (track them separately or refetch); `latest` reattaches.
 
 **Merge rules that protect you from data loss:**
 
-1. **Read `mode` on every `backlog` frame and do exactly what it says.** It is
-   the server stating how it built the slice, and it is the only field you need:
+1. **Read `mode` on every `backlog` frame and do what it says.** It is the
+   server stating how it built the slice — the only field you need to decide
+   _how to merge_ (but not the only one you must record; see rule 4):
 
-   | `mode`    | Meaning                                      | Action                                           |
-   | --------- | -------------------------------------------- | ------------------------------------------------ |
-   | `replace` | This slice stands alone                      | Drop what you hold for the buffer, take `events` |
-   | `append`  | A contiguous gap-fill                        | Splice onto your existing tail                   |
-   | `shell`   | Buffer exists, nothing shipped (`events:[]`) | Leave existing contents alone; fetch on open     |
+   | `mode`    | Meaning                                      | Action                                       |
+   | --------- | -------------------------------------------- | -------------------------------------------- |
+   | `replace` | This slice stands alone                      | Take `events` as the buffer's contents       |
+   | `append`  | A contiguous gap-fill                        | Splice onto your existing tail               |
+   | `shell`   | Buffer exists, nothing shipped (`events:[]`) | Leave existing contents alone; fetch on open |
 
 2. **Ignore `reset`.** It predates `mode` and is not decodable on its own:
    `reset:false` means _append_ on a resume gap but _replace_ on a fresh
    connect and on the system buffer — three meanings, two values. Old clients
    derived it by also reading `networkId` and by knowing out-of-band whether
    they'd sent `?since` (iOS `FrameParser.swift:104-111`; web inferred from id
-   non-overlap). It is still sent, unchanged, and will keep being sent. Don't
-   build on it.
+   non-overlap). It is still sent wherever it was sent before, unchanged — note
+   that's only two of the four backlog shapes: shells and `open-buffer` replies
+   have never carried it at all. Don't build on it.
 
-   > A server predating `mode` omits the field. If you must support one, fall
-   > back to the old derivation: replace unless `networkId != null && reset === false`.
+   > A server predating `mode` omits the field entirely. If you must support
+   > one: treat `events:[] && hasMoreOlder` as a shell **first** (absent `reset`
+   > would otherwise fall into replace and un-hydrate it — rule 3), then append
+   > only when `networkId != null && reset === false`, else replace.
 
 3. **Never un-hydrate:** a `shell` for a buffer you already populated must not
    wipe it. This is why shells are their own `mode` rather than
    `replace`-with-empty.
-4. On any replace, **keep held live events newer than the slice tail** — a
+4. **`mode` tells you how to merge; `hasMoreOlder` tells you whether the pager
+   is still armed — record it on every frame, including `append` and `shell`.**
+   It's the flag your open-time lazy fetch and scroll-up pager gate on, so
+   dropping it on a gap-fill strands the buffer at whatever it happens to hold
+   (`wsHub.ts:870-876`).
+5. **`replace` permits preserving contiguous older history you already hold.**
+   The rule it must never break is _don't create a hole_. So: if the incoming
+   slice **overlaps** what you hold (its oldest id ≤ your newest id), you may
+   dedupe-merge and keep older rows the user paged in — this is what the web
+   client does (`vue_client/src/stores/buffers.ts:504-525`), and it matters
+   because `:system:` and offline `:server:` buffers get a full `replace` frame
+   on **every** snapshot, including the in-band `{type:'snapshot'}` resync a
+   client may fire on visibility return. Dropping everything there would throw
+   away the user's scrollback each time they tab back. If the slice is
+   **disjoint** (its oldest id > your newest id), rows went missing in between —
+   you must replace wholesale and let `hasMoreOlder` page the rest.
+6. On any replace, **keep held live events newer than the slice tail** — a
    message can land mid-hydrate.
-5. Dedupe everything by id against what you hold; drop legacy `away`/`back`
+7. Dedupe everything by id against what you hold; drop legacy `away`/`back`
    rows if you encounter them in old history.
-6. The web client caps its in-memory ring at 500 events/buffer and pages the
+8. The web client caps its in-memory ring at 500 events/buffer and pages the
    rest — policy, not protocol, but a sane default.
 
 ---

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -632,11 +632,15 @@ slice (track them separately or refetch); `latest` reattaches.
    server stating how it built the slice — the only field you need to decide
    _how to merge_ (but not the only one you must record; see rule 4):
 
-   | `mode`    | Meaning                                      | Action                                       |
-   | --------- | -------------------------------------------- | -------------------------------------------- |
-   | `replace` | This slice stands alone                      | Take `events` as the buffer's contents       |
-   | `append`  | A contiguous gap-fill                        | Splice onto your existing tail               |
-   | `shell`   | Buffer exists, nothing shipped (`events:[]`) | Leave existing contents alone; fetch on open |
+   | `mode`    | Meaning                                                | Action                                                      |
+   | --------- | ------------------------------------------------------ | ----------------------------------------------------------- |
+   | `replace` | Authoritative slice, **not** contiguous with your tail | Take `events`; **may** keep overlapping older rows — rule 5 |
+   | `append`  | A contiguous gap-fill                                  | Splice onto your existing tail                              |
+   | `shell`   | Buffer exists, nothing shipped (`events:[]`)           | Leave existing contents alone; fetch on open                |
+
+   > Taking `events` wholesale is always **safe** on `replace`, and is the right
+   > first implementation. Rule 5 is the refinement that stops it costing the
+   > user their scrollback — read it before you ship.
 
 2. **Ignore `reset`.** It predates `mode` and is not decodable on its own:
    `reset:false` means _append_ on a resume gap but _replace_ on a fresh

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -132,6 +132,8 @@ describe('buildBufferBacklog', () => {
     expect(frame.networkId).toBe(networkId);
     expect(frame.target).toBe('#bl');
     expect((frame.events as unknown[]).length).toBe(3);
+    // A one-off hydrate always ships a standalone recent slice, never a gap.
+    expect(frame.mode).toBe('replace');
     // No live IRC connection in the test → the channel reads as parted.
     expect(frame.joined).toBe(false);
     expect(frame.unread).toBe(3);
@@ -210,6 +212,7 @@ describe('buildResumeSlice', () => {
     for (let i = 1; i <= 5; i++) ids.push(seed('#resumeSmall', `m${i}`));
     const slice = buildResumeSlice(userId, networkId, '#resumeSmall', since);
     expect(slice.reset).toBe(false);
+    expect(slice.mode).toBe('append');
     expect(slice.events.length).toBe(5);
     // The gap, oldest-first — exactly the rows after the cursor.
     expect((slice.events[0] as { id: number }).id).toBe(ids[0]);
@@ -234,6 +237,8 @@ describe('buildResumeSlice', () => {
     const slice = buildResumeSlice(userId, networkId, '#resumeEmptyGap', tail);
     expect(slice.events.length).toBe(0);
     expect(slice.reset).toBe(false);
+    // An empty gap is still a gap: appending nothing must not wipe the tail.
+    expect(slice.mode).toBe('append');
     expect(slice.hasMoreOlder).toBe(true);
   });
 
@@ -244,6 +249,7 @@ describe('buildResumeSlice', () => {
     for (let i = 1; i <= RESUME_GAP_CAP + 10; i++) lastId = seed('#resumeBig', `m${i}`);
     const slice = buildResumeSlice(userId, networkId, '#resumeBig', since);
     expect(slice.reset).toBe(true);
+    expect(slice.mode).toBe('replace');
     // Latest contiguous slice, NOT the oldest-after-cursor rows.
     expect(slice.events.length).toBe(RESUME_LATEST_LIMIT);
     expect((slice.events.at(-1) as { id: number }).id).toBe(lastId);
@@ -257,6 +263,21 @@ describe('buildResumeSlice', () => {
     const slice = buildResumeSlice(userId, networkId, '#resumeFresh', 0);
     expect(slice.reset).toBe(false);
     expect(slice.events.length).toBe(2);
+  });
+
+  it('says replace on a fresh connect even though reset is false (#668)', () => {
+    // THE regression this field exists to prevent. Both this slice and the
+    // gap-fill slice above report `reset:false`, but they mean opposite things:
+    // this one is a standalone latest slice (replace), that one is a contiguous
+    // gap (append). Nothing on the wire distinguished them — a client had to
+    // know out-of-band whether it had sent ?since. `mode` says it outright.
+    const since = seed('#resumeAmbiguous', 'm0');
+    seed('#resumeAmbiguous', 'm1');
+    const fresh = buildResumeSlice(userId, networkId, '#resumeAmbiguous', 0);
+    const gap = buildResumeSlice(userId, networkId, '#resumeAmbiguous', since);
+    expect(fresh.reset).toBe(gap.reset); // indistinguishable on the old field...
+    expect(fresh.mode).toBe('replace'); // ...and unambiguous on the new one.
+    expect(gap.mode).toBe('append');
   });
 });
 
@@ -276,6 +297,10 @@ describe('buildBufferShell', () => {
     expect(shell.speakers).toBeUndefined();
     // hasMoreOlder gates the client's open-time lazy fetch — must be true.
     expect(shell.hasMoreOlder).toBe(true);
+    // 'shell', NOT 'replace': events:[] means "nothing shipped", not "this
+    // buffer is empty". A client that replaced on this would un-hydrate a
+    // buffer it had already filled.
+    expect(shell.mode).toBe('shell');
     expect(shell.unread).toBe(2);
     // joined is caller-supplied (online membership vs offline parted).
     expect(shell.joined).toBe(true);
@@ -577,6 +602,11 @@ describe('system buffer delivery (#355)', () => {
     expect(frame.networkId).toBeNull();
     expect(frame.target).toBe(':system:');
     expect(frame.joined).toBe(true);
+    // The system buffer has always shipped `reset:false` while MEANING replace
+    // (it ignores ?since — its own id sequence makes the cursor meaningless).
+    // That mismatch is the other half of what #668 fixes.
+    expect(frame.reset).toBe(false);
+    expect(frame.mode).toBe('replace');
     const evIds = (frame.events as Array<{ id: number }>).map((e) => e.id);
     expect(evIds.slice(-3)).toEqual(ids); // our three, oldest-first
     expect(frame).toHaveProperty('lastReadId');

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -244,6 +244,32 @@ export function parseProtocolParam(rawUrl: string): number | null {
 // Generic payload for outgoing WS messages.
 type WsPayload = Record<string, unknown>;
 
+// How a client must fold a `backlog` frame's `events` into what it already
+// holds for that buffer. Shipped on EVERY backlog frame as of #668.
+//
+// Why this exists: the frame used to carry only `reset`, a boolean that wasn't
+// one. `reset:false` meant "append this gap" on a resume, but "replace with
+// this slice" on a fresh connect and on the system buffer — three meanings, two
+// values, disambiguated by reading a DIFFERENT field (`networkId`) and by
+// out-of-band knowledge of whether the socket sent `?since`. Both first-party
+// clients derived it differently (iOS branched on networkId; the web client
+// inferred from id non-overlap), and a third-party author had no way to get it
+// right from the wire alone. The server always knew which slice it built; it
+// just never said so.
+//
+//   'replace' — this slice stands alone; drop what you hold for this buffer and
+//               take these events. (Resume-gap overflow, fresh connect, an
+//               open-buffer/reopen hydrate, the system buffer.)
+//   'append'  — a contiguous gap-fill; splice onto your existing tail.
+//   'shell'   — buffer EXISTS but no events are shipped (`events: []`). Do NOT
+//               treat this as replace-with-empty: a shell for a buffer you have
+//               already hydrated must leave its contents alone (the "never
+//               un-hydrate" rule). Fetch content when the user opens it.
+//
+// `reset` is still sent, unchanged, for clients that predate this field. New
+// clients should read `mode` and ignore `reset` entirely.
+export type BacklogMode = 'replace' | 'append' | 'shell';
+
 // Inbound message types that mutate IRC state or produce outbound IRC traffic.
 // A paused account is read-only, so these are rejected while reads (snapshot,
 // history, search, chanlist-search) and local view state (read markers, pins,
@@ -704,6 +730,8 @@ export function buildBufferBacklog(userId: number, networkId: number, target: st
     networkId,
     target,
     events,
+    // Always the recent slice, never a gap — see the header comment.
+    mode: 'replace' satisfies BacklogMode,
     speakers: listSpeakers(networkId, target),
     joined: channelJoined(target, conn),
     ...bufferStateFields(userId, networkId, target),
@@ -752,6 +780,10 @@ export function buildBufferShell(
     // Shell marker: no messages loaded yet, but there IS history to fetch on
     // open. The client's empty-seed branch honors this flag (see replaceBacklog).
     hasMoreOlder: true,
+    // The empty `events` above is "nothing shipped", NOT "this buffer is empty".
+    // 'shell' says so on the wire so a client can't read it as replace-with-
+    // empty and wipe a buffer it already hydrated.
+    mode: 'shell' satisfies BacklogMode,
     ...bufferStateFields(userId, networkId, target, precomputed),
   };
 }
@@ -829,7 +861,7 @@ export function buildResumeSlice(
   networkId: number,
   target: string,
   sinceId: number,
-): { events: DecoratedEvent[]; reset: boolean; hasMoreOlder: boolean } {
+): { events: DecoratedEvent[]; reset: boolean; mode: BacklogMode; hasMoreOlder: boolean } {
   if (sinceId > 0) {
     const gap = listMessages(networkId, target, { afterId: sinceId, limit: RESUME_GAP_CAP });
     const lastGapId = gap.length ? (gap[gap.length - 1].id ?? sinceId) : sinceId;
@@ -846,6 +878,7 @@ export function buildResumeSlice(
       return {
         events: gap.map((e) => decorateMessage(userId, e)),
         reset: false,
+        mode: 'append',
         hasMoreOlder: hasOlderRow(networkId, target, anchor),
       };
     }
@@ -859,6 +892,12 @@ export function buildResumeSlice(
     // on the client's empty-buffer seed path, which already replaces — flagging
     // reset there is harmless but needlessly noisy.
     reset: sinceId > 0,
+    // ...but `mode` says what the frame MEANS, not what's noisy, and both
+    // branches here mean the same thing: this slice stands alone, replace with
+    // it. That divergence is exactly why `reset` alone was never decodable —
+    // `reset:false` reads as "append" for the gap branch above and as "replace"
+    // here, and only the out-of-band `sinceId` told them apart.
+    mode: 'replace',
     hasMoreOlder: oldestId > 0 && hasOlderRow(networkId, target, oldestId),
   };
 }
@@ -921,7 +960,12 @@ export function buildSystemBacklog(userId: number): WsPayload {
     clearedBeforeId: cleared.clearedBeforeId,
     clearedAt: cleared.clearedAt,
     inputHistory: [],
+    // `reset:false` here has ALWAYS meant "replace" — the system buffer ships a
+    // standalone latest slice and never a gap (it ignores the socket's ?since
+    // cursor, having its own id sequence). Kept as-is for old clients; `mode`
+    // states the real contract.
     reset: false,
+    mode: 'replace' satisfies BacklogMode,
     hasMoreOlder: oldestId > 0 && hasOlderSystem(userId, oldestId),
   };
 }
@@ -2053,6 +2097,9 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // a fresh latest slice — the client must replace its buffer, not
         // append, or it splices a permanent hole (issue #205).
         reset: slice.reset,
+        // The same decision, stated so a client doesn't have to re-derive it
+        // from `reset` + `networkId` + whether it sent ?since.
+        mode: slice.mode,
         hasMoreOlder: slice.hasMoreOlder,
         joined: channelJoined(target, conn),
         ...stateFields,

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -257,17 +257,27 @@ type WsPayload = Record<string, unknown>;
 // right from the wire alone. The server always knew which slice it built; it
 // just never said so.
 //
-//   'replace' — this slice stands alone; drop what you hold for this buffer and
-//               take these events. (Resume-gap overflow, fresh connect, an
-//               open-buffer/reopen hydrate, the system buffer.)
+//   'replace' — this slice stands alone; it is authoritative for the range it
+//               covers and is NOT contiguous with your tail. (Resume-gap
+//               overflow, fresh connect, an open-buffer/reopen hydrate, the
+//               system buffer.) The invariant is "don't create a hole", not
+//               "destroy everything": a client MAY keep older rows it already
+//               holds when the incoming slice OVERLAPS them, and must replace
+//               wholesale when it doesn't. That distinction matters because the
+//               system buffer and offline :server: buffers ship a replace frame
+//               on EVERY snapshot — reading this as unconditional truncation
+//               throws away the user's paged-in scrollback each resync. See
+//               CLIENT_PROTOCOL.md §8 rule 5.
 //   'append'  — a contiguous gap-fill; splice onto your existing tail.
 //   'shell'   — buffer EXISTS but no events are shipped (`events: []`). Do NOT
 //               treat this as replace-with-empty: a shell for a buffer you have
 //               already hydrated must leave its contents alone (the "never
 //               un-hydrate" rule). Fetch content when the user opens it.
 //
-// `reset` is still sent, unchanged, for clients that predate this field. New
-// clients should read `mode` and ignore `reset` entirely.
+// `reset` is still sent wherever it was sent before, unchanged, for clients that
+// predate this field — note that's only the resume/system frames; shells and
+// open-buffer replies have never carried it. New clients should read `mode` and
+// ignore `reset` entirely.
 export type BacklogMode = 'replace' | 'append' | 'shell';
 
 // Inbound message types that mutate IRC state or produce outbound IRC traffic.


### PR DESCRIPTION
First PR from a WebSocket protocol audit. Additive only — **no `PROTOCOL_VERSION` bump**, and no client change is required to merge this.

## The problem

`backlog` carried only `reset`, a boolean that wasn't one:

| Frame | `reset` | Actually means |
| --- | --- | --- |
| Resume gap | `false` | append |
| Fresh connect | `false` | **replace** |
| Resume gap overflow | `true` | replace |
| System buffer | `false` | **replace** |
| Shell / `open-buffer` reply | *absent* | shell / replace |

Three meanings across two values, disambiguated by reading a *different* field (`networkId`) and by knowing out-of-band whether the socket had sent `?since`. Both first-party clients derived it, differently — iOS branches on `networkId` (`FrameParser.swift:104-111`), the web client infers from id non-overlap. A third-party author had no way to get it right from the wire alone.

The server always knew which slice it built. It just never said so.

## The change

`mode: 'replace' | 'append' | 'shell'` on every `backlog` frame, from all four emitters.

`shell` is its own value rather than `replace`-with-empty so that a shell for an already-hydrated buffer can't be read as "wipe it" — the "never un-hydrate" rule, which until now existed only as client-side convention and a warning in the docs.

`reset` still ships exactly where it shipped before, unchanged. Old clients are unaffected; new clients read `mode` and ignore `reset`.

## Docs, same pass

- **§9.1's "NOTICEs never create or reopen a DM" was stale** — wrong on the "create" half since #439. The real rule: `notice` → `ensureExists` (may create, never reopens); `message`/`action` → `ensureOpen` (creates *and* reopens). Replaced with the create-vs-reopen table.
- **§4.3** now names `history mode:'latest'` as *the* hydration path. `open-buffer` also returns a backlog, but it's a write verb — it reopens closed buffers and JOINs unjoined channels, so hydrating with it means opening a screen mutates persisted state. It also replies only to the requesting socket, so that write is invisible to the user's other devices until their next snapshot.
- **§6** documents the three correlation fields (`clientId` / `token` / `progressToken`) as one convention, so the next request/reply verb reuses a pattern instead of minting a fourth name.
- **§8** merge rules rewritten around `mode`; `reset` marked legacy with a safe fallback for pre-`mode` servers.

## Review notes

`/code-review high` found five defects in the spec text (none in the code); all are fixed in the second commit. Two worth surfacing:

- The `open-buffer` warning initially claimed a `buffer-opened` fan-out that doesn't exist. Corrected — and the real behavior (silent until next snapshot) is the more dangerous property, now stated outright.
- `replace` initially said "drop what you hold," which would discard paged-in scrollback every time `:system:` and offline `:server:` buffers are re-sent — and they're re-sent on *every* snapshot, including the in-band resync. The reference client dedupe-merges on overlap and only replaces when the slice is disjoint; that's now documented as permitted, with the invariant that actually matters (don't create a hole).

## Testing

`npm run check` clean, `npm test` 2961 passing. New coverage pins the ambiguity directly: a fresh-connect slice and a gap-fill slice report identical `reset` but opposite `mode`.

## Follow-ups (not in this PR)

- `lurker-ios` never parses `buffer-closed` — closing a buffer in web leaves it in the iOS list until app restart.
- A pure-read `hydrate` verb, to retire `open-buffer` as a hydration path.
- `bufferedAmount` backpressure check in `fanOut`; web reconnect backoff+jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)