### PR TITLE
Drop wedged sockets, back off on reconnect, and always answer open-buffer

### DIFF
--- a/server/services/wsHub.backpressure.test.ts
+++ b/server/services/wsHub.backpressure.test.ts
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Backpressure detection against a REAL socket pair.
+//
+// wsHub.test.ts drives `dropIfBackpressured` as a function with a hand-built
+// stand-in, which proves the decision logic but assumes the thing the whole
+// design rests on: that `ws.bufferedAmount` actually reports what we think —
+// that it climbs when the peer stops reading, and falls when it starts again.
+// Every version of this feature that was wrong was wrong about THAT, not about
+// the arithmetic, so it's worth a test that can't be satisfied by a mock.
+//
+// Runs a real WebSocketServer over a real TCP loopback and pauses the client's
+// underlying socket to simulate a peer whose receive window has closed. No hub,
+// no DB rows, no IRC — the unit under test is one exported function and the
+// socket it reads.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { WebSocketServer, WebSocket } from 'ws';
+import type { AddressInfo } from 'net';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+// wsHub pulls in the db layer on import; point it at a throwaway file so this
+// can never touch real data.
+const testDb = setupTestDb('wshub-backpressure');
+
+let dropIfBackpressured: typeof import('./wsHub.js').dropIfBackpressured;
+let wss: WebSocketServer;
+let url: string;
+
+// Comfortably past MAX_BUFFERED_BYTES (8 MiB) once a few of these are queued.
+const CHUNK = 'x'.repeat(1024 * 1024);
+const CAP = 8 * 1024 * 1024;
+const GRACE = 30_000;
+
+beforeAll(async () => {
+  ({ dropIfBackpressured } = await import('./wsHub.js'));
+  wss = new WebSocketServer({ port: 0 });
+  await new Promise<void>((resolve) => wss.once('listening', resolve));
+  url = `ws://127.0.0.1:${(wss.address() as AddressInfo).port}`;
+});
+
+afterAll(() => {
+  wss.close();
+  testDb.cleanup();
+});
+
+/** A connected pair: the server's view of the socket, and the client's. */
+async function connectedPair(): Promise<{ server: WebSocket; client: WebSocket }> {
+  const serverSocket = new Promise<WebSocket>((resolve) => wss.once('connection', resolve));
+  const client = new WebSocket(url);
+  await new Promise<void>((resolve) => client.once('open', () => resolve()));
+  return { server: await serverSocket, client };
+}
+
+/** Queue frames until the socket is genuinely over the cap. */
+function fillPastCap(server: WebSocket): void {
+  while (server.bufferedAmount <= CAP) {
+    for (let i = 0; i < 4; i++) server.send(CHUNK);
+  }
+}
+
+/**
+ * The streak bookkeeping wsHub hangs off the socket. These are real `ws`
+ * sockets rather than `LurkerWebSocket`s (the hub isn't in play here), so the
+ * field isn't on the declared type — read it through a narrow cast rather than
+ * widening the production interface for a test.
+ */
+function streakOf(ws: WebSocket): unknown {
+  return (ws as unknown as { backpressure?: unknown }).backpressure;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return predicate();
+}
+
+describe('backpressure against a real socket', () => {
+  it('bufferedAmount climbs when the peer stops reading and falls when it resumes', async () => {
+    // The premise the whole feature rests on. If this ever fails, the detector
+    // is measuring nothing and every threshold above it is theatre.
+    const { server, client } = await connectedPair();
+    try {
+      // Stop reading: the kernel receive window closes, the server's writes stop
+      // completing, and `ws` queues them in the Node heap.
+      client.pause();
+      fillPastCap(server);
+      expect(server.bufferedAmount).toBeGreaterThan(CAP);
+
+      // Start reading again. A healthy-but-slow peer looks exactly like this.
+      client.resume();
+      client.on('message', () => {});
+      const drained = await waitFor(() => server.bufferedAmount === 0);
+      expect(drained).toBe(true);
+    } finally {
+      client.terminate();
+      server.terminate();
+    }
+  }, 20_000);
+
+  it('does not drop a socket that is still over the cap but has drained something', async () => {
+    // The regression that killed two earlier designs: "big for a while" is not
+    // "stuck". A real slow link sits over the cap for far longer than the grace
+    // period while behaving perfectly, and dropping it there sends it into a
+    // reconnect loop against an identical payload.
+    //
+    // Staging a *sustained* slow drain on loopback isn't possible — the transport
+    // is bimodal, moving either one frame or the entire queue per turn (measured;
+    // see the preconditions below, which fail loudly rather than letting this pass
+    // vacuously if that ever changes). So this proves the one step that matters:
+    // real bytes left the socket, it's still over the cap, and the elapsed time
+    // alone would have condemned it. The multi-step version lives in
+    // wsHub.test.ts against injected values.
+    const { server, client } = await connectedPair();
+    try {
+      client.pause();
+      // Fill well past the cap so a single frame's worth of drain leaves us
+      // comfortably above it.
+      while (server.bufferedAmount <= CAP * 4) server.send(CHUNK);
+      const filled = server.bufferedAmount;
+
+      expect(dropIfBackpressured(server, 0)).toBe(false); // start watching
+
+      // Consume a counted handful of frames, then stop reading again. Counting
+      // receipts rather than waiting a duration is what makes this deterministic:
+      // a timed window on loopback either moves nothing or the entire queue.
+      let received = 0;
+      client.on('message', () => {
+        received += 1;
+        if (received >= 3) client.pause();
+      });
+      client.resume();
+      await waitFor(() => received >= 3);
+      // A little more may already have been in flight when pause() landed; the
+      // fill is deep enough that it doesn't matter.
+      const afterDrain = server.bufferedAmount;
+      // Preconditions — if either fails the scenario didn't happen and the
+      // assertion below would be meaningless.
+      expect(afterDrain, 'expected some bytes to drain').toBeLessThan(filled);
+      expect(afterDrain, 'expected to still be over the cap').toBeGreaterThan(CAP);
+
+      // Exactly at the grace boundary, and deliberately so: any later and the
+      // staleness rule ("we haven't looked in a while, so the streak proves
+      // nothing") would restart the streak and this would pass without ever
+      // reaching the progress check. At exactly GRACE the streak is still
+      // current AND fully elapsed, so the ONLY thing that can save this socket
+      // is having drained. Verified by mutation: reverting the progress check
+      // fails this assertion.
+      expect(dropIfBackpressured(server, GRACE)).toBe(false);
+    } finally {
+      client.terminate();
+      server.terminate();
+    }
+  }, 20_000);
+
+  it('drops a socket whose peer never reads', async () => {
+    // The case the feature exists for: the window is closed, nothing moves, and
+    // the queue is memory we will never get back.
+    const { server, client } = await connectedPair();
+    try {
+      client.pause();
+      fillPastCap(server);
+      const queued = server.bufferedAmount;
+
+      expect(dropIfBackpressured(server, 0)).toBe(false); // start watching
+      // Still paused, so nothing has drained — no new low, streak intact.
+      expect(server.bufferedAmount).toBeGreaterThanOrEqual(queued - 1);
+      expect(dropIfBackpressured(server, GRACE)).toBe(true);
+
+      // terminate() must actually tear the socket down — a close() would queue
+      // behind the stuck bytes and leave them resident for ws's 30s closeTimeout.
+      const closed = await waitFor(() => server.readyState === WebSocket.CLOSED);
+      expect(closed).toBe(true);
+    } finally {
+      client.terminate();
+      server.terminate();
+    }
+  }, 20_000);
+
+  it('clears the streak once the socket is back under the cap', async () => {
+    const { server, client } = await connectedPair();
+    try {
+      client.pause();
+      fillPastCap(server);
+      dropIfBackpressured(server, 0);
+      expect(streakOf(server)).toBeDefined();
+
+      client.resume();
+      client.on('message', () => {});
+      await waitFor(() => server.bufferedAmount <= CAP);
+      expect(dropIfBackpressured(server, GRACE * 5)).toBe(false);
+      expect(streakOf(server)).toBeUndefined();
+    } finally {
+      client.terminate();
+      server.terminate();
+    }
+  }, 20_000);
+});

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -27,6 +27,7 @@ let buildOfflineBacklogFrames: typeof import('./wsHub.js').buildOfflineBacklogFr
 let maxMessageId: typeof import('../db/messages.js').maxMessageId;
 let handleOpenBuffer: typeof import('./wsHub.js').handleOpenBuffer;
 let sweepWsHeartbeat: typeof import('./wsHub.js').sweepWsHeartbeat;
+let dropIfBackpressured: typeof import('./wsHub.js').dropIfBackpressured;
 let buildSystemBacklog: typeof import('./wsHub.js').buildSystemBacklog;
 let systemLineToEvent: typeof import('./wsHub.js').systemLineToEvent;
 let buildSystemHistoryReply: typeof import('./wsHub.js').buildSystemHistoryReply;
@@ -56,6 +57,7 @@ beforeAll(async () => {
     buildOfflineBacklogFrames,
     handleOpenBuffer,
     sweepWsHeartbeat,
+    dropIfBackpressured,
     buildSystemBacklog,
     systemLineToEvent,
     buildSystemHistoryReply,
@@ -552,6 +554,59 @@ describe('sweepWsHeartbeat', () => {
     expect(live.calls.ping).toBe(1);
     expect(dead1.calls.terminate).toBe(1);
     expect(dead2.calls.terminate).toBe(1);
+  });
+});
+
+// A ws stand-in carrying only what the backpressure check reads/calls.
+function bpWs(bufferedAmount: number) {
+  const calls: { close: Array<{ code: number; reason: string }> } = { close: [] };
+  const ws = {
+    bufferedAmount,
+    close(code: number, reason: string) {
+      calls.close.push({ code, reason });
+    },
+  };
+  return { ws, calls };
+}
+
+function drop(ws: ReturnType<typeof bpWs>['ws']): boolean {
+  return dropIfBackpressured(ws as unknown as Parameters<typeof dropIfBackpressured>[0]);
+}
+
+describe('dropIfBackpressured', () => {
+  const CAP = 8 * 1024 * 1024; // mirrors MAX_BUFFERED_BYTES
+
+  it('keeps a socket that is draining', () => {
+    const { ws, calls } = bpWs(0);
+    expect(drop(ws)).toBe(false);
+    expect(calls.close.length).toBe(0);
+  });
+
+  it('keeps a socket sitting exactly at the cap', () => {
+    // The heartbeat reaps dead sockets; this only fires for one that is provably
+    // NOT keeping up, so the boundary is deliberately inclusive.
+    const { ws, calls } = bpWs(CAP);
+    expect(drop(ws)).toBe(false);
+    expect(calls.close.length).toBe(0);
+  });
+
+  it('closes a wedged socket with 1013 so it reconnects and resumes', () => {
+    // 1013 Try Again Later, not terminate: the client comes back through its
+    // normal reconnect and refetches the gap via ?since, so this costs a
+    // reconnect rather than history.
+    const { ws, calls } = bpWs(CAP + 1);
+    expect(drop(ws)).toBe(true);
+    expect(calls.close).toEqual([{ code: 1013, reason: 'backpressure' }]);
+  });
+
+  it('reports the drop even when close throws on an already-dying socket', () => {
+    const ws = {
+      bufferedAmount: CAP + 1,
+      close() {
+        throw new Error('already closing');
+      },
+    };
+    expect(drop(ws as unknown as ReturnType<typeof bpWs>['ws'])).toBe(true);
   });
 });
 

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -147,6 +147,30 @@ describe('buildBufferBacklog', () => {
     expect(buildBufferBacklog(userId, networkId, 'carol').joined).toBe(true);
   });
 
+  it('says hasMoreOlder:false for an empty buffer so the hydrate is not read as a shell', () => {
+    // The frame answers `open-buffer` — a client's ONE hydrate of this buffer.
+    // Omitting the field left `events:[]` indistinguishable from a shell
+    // (`events:[] + hasMoreOlder:true`), so the client stayed unhydrated on its
+    // loading spinner forever and never re-asked. Non-empty buffers hid it.
+    buffers.ensureExists(userId, networkId, 'emptybuf');
+    const frame = buildBufferBacklog(userId, networkId, 'emptybuf');
+    expect((frame.events as unknown[]).length).toBe(0);
+    expect(frame.hasMoreOlder).toBe(false);
+  });
+
+  it('says hasMoreOlder:false when the whole history fits in the slice', () => {
+    seed('#shortlog', 'only one');
+    expect(buildBufferBacklog(userId, networkId, '#shortlog').hasMoreOlder).toBe(false);
+  });
+
+  it('says hasMoreOlder:true when history predates the slice', () => {
+    // 200 is the slice cap, so 201 rows leaves exactly one older than the tail.
+    for (let i = 0; i < 201; i++) seed('#longlog', `m${i}`);
+    const frame = buildBufferBacklog(userId, networkId, '#longlog');
+    expect((frame.events as unknown[]).length).toBe(200);
+    expect(frame.hasMoreOlder).toBe(true);
+  });
+
   it('server buffer unread counts notable lines only, and includes errors (#470)', () => {
     const target = `:server:${networkId}`;
     const putServer = (type: string, opts: { nick?: string; notable?: boolean } = {}) =>

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -508,6 +508,38 @@ describe('handleOpenBuffer', () => {
     }
   });
 
+  it("stays a no-op for an unjoined '&' channel even though it has a row", () => {
+    // '&', '+' and '!' are channels per kindForTarget, but `channelJoined` answers
+    // `true` for anything not starting with '#'. Deciding the backlog branch through
+    // that helper would report an unjoined `&local` as joined and hand back a backlog
+    // for a channel we are not in. Membership is checked directly instead.
+    buffers.ensureExists(userId, networkId, '&unjoined');
+    const spy = vi
+      .spyOn(ircManager, 'getConnection')
+      .mockReturnValue({ channels: new Map() } as never);
+    try {
+      const { ws, frames } = mockWs();
+      handleOpenBuffer(ws, userId, networkId, '&unjoined');
+      expect(frames).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("answers a JOINED '&' channel, which is a channel prefix too", () => {
+    buffers.ensureExists(userId, networkId, '&joined');
+    const spy = vi
+      .spyOn(ircManager, 'getConnection')
+      .mockReturnValue({ channels: new Map([['&joined', {}]]) } as never);
+    try {
+      const { ws, frames } = mockWs();
+      handleOpenBuffer(ws, userId, networkId, '&joined');
+      expect(frames.some((f) => f.kind === 'backlog')).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('reopens a since-closed channel without re-JOINing, resolving casing case-insensitively', () => {
     seed('#reopen', 'history line');
     closeBuffer(userId, networkId, '#reopen');

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { setupTestDb, TEST_SESSION_SECRET } from '../test-utils/testApp.js';
 import { sign as signCookie } from 'cookie-signature';
 import type { IncomingMessage } from 'http';
@@ -481,6 +481,31 @@ describe('handleOpenBuffer', () => {
     handleOpenBuffer(ws, userId, networkId, '&local-unvisited');
     expect(frames).toHaveLength(0);
     expect(buffers.getBuffer(userId, networkId, '&local-unvisited')).toBeUndefined();
+  });
+
+  it('answers with a backlog for a joined channel that has no persisted messages', () => {
+    // The permanent-spinner case. Gating only on "has messages" sent a channel you are
+    // sitting in but have no lines for — freshly joined, or history cleared — down the
+    // JOIN branch, which replies `buffer-opened` and NO backlog. An on-demand client
+    // spends its one hydrate request on something that can never be answered and sits on
+    // a loading spinner for the rest of the connection.
+    buffers.ensureExists(userId, networkId, '#emptyjoined');
+    const spy = vi
+      .spyOn(ircManager, 'getConnection')
+      .mockReturnValue({ channels: new Map([['#emptyjoined', {}]]) } as never);
+    try {
+      const { ws, frames } = mockWs();
+      handleOpenBuffer(ws, userId, networkId, '#emptyjoined');
+      const backlog = frames.find((f) => f.kind === 'backlog');
+      expect(backlog, 'open-buffer must always answer an existing buffer').toBeDefined();
+      expect((backlog!.events as unknown[]).length).toBe(0);
+      // hasMoreOlder:false is what lets the client read an empty answer as "hydrated,
+      // genuinely nothing here" instead of as another shell to fetch later.
+      expect(backlog!.hasMoreOlder).toBe(false);
+      expect(frames.some((f) => f.kind === 'buffer-opened')).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('reopens a since-closed channel without re-JOINing, resolving casing case-insensitively', () => {

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -558,55 +558,91 @@ describe('sweepWsHeartbeat', () => {
 });
 
 // A ws stand-in carrying only what the backpressure check reads/calls.
+// bufferedAmount is writable so a test can drain it between observations.
 function bpWs(bufferedAmount: number) {
-  const calls: { close: Array<{ code: number; reason: string }> } = { close: [] };
+  const calls = { terminate: 0 };
   const ws = {
     bufferedAmount,
-    close(code: number, reason: string) {
-      calls.close.push({ code, reason });
+    backpressureSince: undefined as number | undefined,
+    terminate() {
+      calls.terminate += 1;
     },
   };
   return { ws, calls };
 }
 
-function drop(ws: ReturnType<typeof bpWs>['ws']): boolean {
-  return dropIfBackpressured(ws as unknown as Parameters<typeof dropIfBackpressured>[0]);
+function drop(ws: ReturnType<typeof bpWs>['ws'], now: number): boolean {
+  return dropIfBackpressured(ws as unknown as Parameters<typeof dropIfBackpressured>[0], now);
 }
 
 describe('dropIfBackpressured', () => {
   const CAP = 8 * 1024 * 1024; // mirrors MAX_BUFFERED_BYTES
+  const GRACE = 30_000; // mirrors BACKPRESSURE_GRACE_MS
 
   it('keeps a socket that is draining', () => {
     const { ws, calls } = bpWs(0);
-    expect(drop(ws)).toBe(false);
-    expect(calls.close.length).toBe(0);
+    expect(drop(ws, 1000)).toBe(false);
+    expect(calls.terminate).toBe(0);
+    expect(ws.backpressureSince).toBeUndefined();
   });
 
   it('keeps a socket sitting exactly at the cap', () => {
-    // The heartbeat reaps dead sockets; this only fires for one that is provably
-    // NOT keeping up, so the boundary is deliberately inclusive.
-    const { ws, calls } = bpWs(CAP);
-    expect(drop(ws)).toBe(false);
-    expect(calls.close.length).toBe(0);
+    const { ws } = bpWs(CAP);
+    expect(drop(ws, 1000)).toBe(false);
+    expect(ws.backpressureSince).toBeUndefined();
   });
 
-  it('closes a wedged socket with 1013 so it reconnects and resumes', () => {
-    // 1013 Try Again Later, not terminate: the client comes back through its
-    // normal reconnect and refetches the gap via ?since, so this costs a
-    // reconnect rather than history.
+  it('only starts the clock on the first over-cap sighting, never drops on it', () => {
+    // THE case this whole design exists for: a large synchronous snapshot burst
+    // legitimately puts megabytes on the socket, and the first live event lands
+    // while it's still draining. Dropping there would disconnect big accounts on
+    // connect, forever — they'd reconnect into the same burst.
     const { ws, calls } = bpWs(CAP + 1);
-    expect(drop(ws)).toBe(true);
-    expect(calls.close).toEqual([{ code: 1013, reason: 'backpressure' }]);
+    expect(drop(ws, 1000)).toBe(false);
+    expect(calls.terminate).toBe(0);
+    expect(ws.backpressureSince).toBe(1000);
   });
 
-  it('reports the drop even when close throws on an already-dying socket', () => {
+  it('spares a socket that drains back under the cap, and forgets the clock', () => {
+    const { ws, calls } = bpWs(CAP + 1);
+    drop(ws, 1000); // clock starts
+    ws.bufferedAmount = 1024; // the burst flushed
+    expect(drop(ws, 5000)).toBe(false);
+    expect(ws.backpressureSince).toBeUndefined();
+    // Re-filling later starts a FRESH clock rather than inheriting the old one,
+    // so a socket that hiccups repeatedly is never condemned by accumulation.
+    ws.bufferedAmount = CAP + 1;
+    expect(drop(ws, 6000)).toBe(false);
+    expect(ws.backpressureSince).toBe(6000);
+    expect(calls.terminate).toBe(0);
+  });
+
+  it('holds on while still inside the grace period', () => {
+    const { ws, calls } = bpWs(CAP + 1);
+    drop(ws, 1000);
+    expect(drop(ws, 1000 + GRACE - 1)).toBe(false);
+    expect(calls.terminate).toBe(0);
+  });
+
+  it('terminates a socket still wedged after the full grace period', () => {
+    // terminate, not close(1013): a close frame would queue BEHIND the stuck
+    // bytes and ws would hold the connection for its 30s closeTimeout, so the
+    // memory this exists to reclaim would linger. The client resumes via ?since.
+    const { ws, calls } = bpWs(CAP + 1);
+    drop(ws, 1000);
+    expect(drop(ws, 1000 + GRACE)).toBe(true);
+    expect(calls.terminate).toBe(1);
+  });
+
+  it('reports the drop even when terminate throws on an already-dying socket', () => {
     const ws = {
       bufferedAmount: CAP + 1,
-      close() {
+      backpressureSince: 1000 as number | undefined,
+      terminate() {
         throw new Error('already closing');
       },
     };
-    expect(drop(ws as unknown as ReturnType<typeof bpWs>['ws'])).toBe(true);
+    expect(drop(ws as unknown as ReturnType<typeof bpWs>['ws'], 1000 + GRACE)).toBe(true);
   });
 });
 

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -563,7 +563,7 @@ function bpWs(bufferedAmount: number) {
   const calls = { terminate: 0 };
   const ws = {
     bufferedAmount,
-    backpressureSince: undefined as number | undefined,
+    backpressure: undefined as { since: number; at: number; floor: number } | undefined,
     terminate() {
       calls.terminate += 1;
     },
@@ -583,37 +583,45 @@ describe('dropIfBackpressured', () => {
     const { ws, calls } = bpWs(0);
     expect(drop(ws, 1000)).toBe(false);
     expect(calls.terminate).toBe(0);
-    expect(ws.backpressureSince).toBeUndefined();
+    expect(ws.backpressure).toBeUndefined();
   });
 
   it('keeps a socket sitting exactly at the cap', () => {
     const { ws } = bpWs(CAP);
     expect(drop(ws, 1000)).toBe(false);
-    expect(ws.backpressureSince).toBeUndefined();
+    expect(ws.backpressure).toBeUndefined();
   });
 
-  it('only starts the clock on the first over-cap sighting, never drops on it', () => {
-    // THE case this whole design exists for: a large synchronous snapshot burst
-    // legitimately puts megabytes on the socket, and the first live event lands
-    // while it's still draining. Dropping there would disconnect big accounts on
-    // connect, forever — they'd reconnect into the same burst.
+  it('only starts watching on the first over-cap sighting, never drops on it', () => {
+    // A large synchronous snapshot burst legitimately puts megabytes on the
+    // socket, and the first live event lands while it's still draining.
     const { ws, calls } = bpWs(CAP + 1);
     expect(drop(ws, 1000)).toBe(false);
     expect(calls.terminate).toBe(0);
-    expect(ws.backpressureSince).toBe(1000);
+    expect(ws.backpressure).toEqual({ since: 1000, at: 1000, floor: CAP + 1 });
   });
 
-  it('spares a socket that drains back under the cap, and forgets the clock', () => {
+  it('spares a socket that drains back under the cap, and forgets the streak', () => {
     const { ws, calls } = bpWs(CAP + 1);
-    drop(ws, 1000); // clock starts
+    drop(ws, 1000);
     ws.bufferedAmount = 1024; // the burst flushed
     expect(drop(ws, 5000)).toBe(false);
-    expect(ws.backpressureSince).toBeUndefined();
-    // Re-filling later starts a FRESH clock rather than inheriting the old one,
-    // so a socket that hiccups repeatedly is never condemned by accumulation.
-    ws.bufferedAmount = CAP + 1;
-    expect(drop(ws, 6000)).toBe(false);
-    expect(ws.backpressureSince).toBe(6000);
+    expect(ws.backpressure).toBeUndefined();
+    expect(calls.terminate).toBe(0);
+  });
+
+  it('spares a big-but-draining socket indefinitely (a slow link, not a wedge)', () => {
+    // The regression that a size-over-time rule gets wrong: a 12 MiB snapshot to
+    // a phone on a weak link stays over the cap for far longer than the grace
+    // while behaving perfectly. Every new low restarts the clock, so it is never
+    // dropped — otherwise it reconnects into an identical burst, forever.
+    const { ws, calls } = bpWs(12 * 1024 * 1024);
+    let t = 1000;
+    for (let queued = 12 * 1024 * 1024; queued > CAP; queued -= 256 * 1024) {
+      ws.bufferedAmount = queued;
+      expect(drop(ws, t)).toBe(false);
+      t += 10_000; // 10s per observation — three times the grace, cumulatively
+    }
     expect(calls.terminate).toBe(0);
   });
 
@@ -624,7 +632,7 @@ describe('dropIfBackpressured', () => {
     expect(calls.terminate).toBe(0);
   });
 
-  it('terminates a socket still wedged after the full grace period', () => {
+  it('terminates a socket that made no progress for the full grace period', () => {
     // terminate, not close(1013): a close frame would queue BEHIND the stuck
     // bytes and ws would hold the connection for its 30s closeTimeout, so the
     // memory this exists to reclaim would linger. The client resumes via ?since.
@@ -634,10 +642,33 @@ describe('dropIfBackpressured', () => {
     expect(calls.terminate).toBe(1);
   });
 
+  it('terminates a socket whose queue is still GROWING after the grace', () => {
+    const { ws, calls } = bpWs(CAP + 1);
+    drop(ws, 1000);
+    ws.bufferedAmount = CAP * 2; // no flush; we kept adding
+    expect(drop(ws, 1000 + GRACE)).toBe(true);
+    expect(calls.terminate).toBe(1);
+  });
+
+  it('restarts the streak when the last observation is older than the grace', () => {
+    // We only look during fan-out, so a quiet account can go minutes between
+    // calls. A socket that went over once, drained unobserved, and went over
+    // again on a later burst must not be judged against the stale timestamp —
+    // that would drop it on the FIRST sighting of the new burst.
+    const { ws, calls } = bpWs(CAP + 1);
+    drop(ws, 1000);
+    const muchLater = 1000 + GRACE * 3;
+    expect(drop(ws, muchLater)).toBe(false);
+    expect(calls.terminate).toBe(0);
+    expect(ws.backpressure).toEqual({ since: muchLater, at: muchLater, floor: CAP + 1 });
+  });
+
   it('reports the drop even when terminate throws on an already-dying socket', () => {
     const ws = {
       bufferedAmount: CAP + 1,
-      backpressureSince: 1000 as number | undefined,
+      backpressure: { since: 1000, at: 1000, floor: CAP + 1 } as
+        | { since: number; at: number; floor: number }
+        | undefined,
       terminate() {
         throw new Error('already closing');
       },

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -110,6 +110,11 @@ interface LurkerWebSocket extends WebSocket {
   // visible=true) and userHasVisibleClient() stays true forever, permanently
   // suppressing auto-away.
   isAlive?: boolean;
+  // When this socket's outbound queue first went over MAX_BUFFERED_BYTES and
+  // stayed there, or undefined when it's draining normally. Cleared the moment
+  // it drops back under, so only sustained backpressure accumulates time. See
+  // dropIfBackpressured.
+  backpressureSince?: number;
   // Mirrors the account's is_paused at connect time, then flipped live by the
   // user-suspended / user-resumed handlers so the read-only write guard never
   // needs a per-message DB read. (Named accountPaused, not isPaused, to avoid
@@ -1178,8 +1183,9 @@ export function handleOpenBuffer(
 // addSocket/removeSocket); the registry just reads through it.
 const socketsByUser = new Map<number, Set<LurkerWebSocket>>();
 
-// How many bytes of un-drained outbound frames a socket may accumulate on the
-// LIVE fan-out path before we give up on it.
+// How many bytes of un-drained outbound frames a socket may hold before it
+// counts as backpressured, and how long it must STAY that way before we give up
+// on it.
 //
 // The heartbeat reaps DEAD sockets (no pong within a sweep, ~60s). It does not
 // reap SLOW ones, and those are a different failure: a phone on a degraded link
@@ -1188,36 +1194,63 @@ const socketsByUser = new Map<number, Set<LurkerWebSocket>>();
 // event fanned out to such a socket is memory we never get back — a leak whose
 // only symptom is RSS climbing on a busy cell.
 //
-// Live events are small (a few hundred bytes), so this is roughly "tens of
-// thousands of frames behind". Nothing healthy gets there; anything that does
-// is not coming back on this socket.
+// The duration is the load-bearing half, and the reason this isn't a simple
+// size check. `bufferedAmount` is ONE number covering everything queued on the
+// socket, including the synchronous snapshot burst — which can legitimately be
+// megabytes on a large account (up to RESUME_GAP_CAP rows per buffer, across
+// every buffer) and takes real seconds to flush on a real link. A bare size
+// check would therefore fire on the first live event that lands mid-drain,
+// close the socket, and have the client reconnect straight into the same large
+// burst: a permanent disconnect loop for exactly the accounts the cap is
+// supposed to protect. Requiring the condition to PERSIST tells "a big burst,
+// draining" apart from "this socket has stopped moving", which is the thing we
+// actually want to act on.
 const MAX_BUFFERED_BYTES = 8 * 1024 * 1024;
+const BACKPRESSURE_GRACE_MS = 30_000;
 
 function send(ws: LurkerWebSocket, payload: WsPayload): void {
   if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
 }
 
-// Drop a socket that has stopped draining. Closing with 1013 (Try Again Later)
-// rather than terminating means the client reconnects through its normal path
-// and resumes from `?since` — the gap it missed is refetched, so this costs the
-// user a reconnect, not history.
+// Drop a socket that has been unable to drain for a full grace period. Called
+// per fan-out; the first over-cap observation only starts the clock.
 //
-// Deliberately NOT applied to `send`, which is what the snapshot burst uses.
-// The burst is synchronous: it writes every frame in one tick, and no socket I/O
-// happens until the event loop turns, so `bufferedAmount` there measures the
-// SIZE OF THE BURST, not the health of the client. A large account would trip
-// any threshold worth having and get disconnected on connect, forever. Live
-// fan-out is where slowness actually accumulates over time, so that's where the
-// check belongs.
-// Exported (and pure over its argument, like sweepWsHeartbeat) so the
-// drop/keep decision is unit-testable without a live WSS.
-export function dropIfBackpressured(ws: LurkerWebSocket): boolean {
-  if (ws.bufferedAmount <= MAX_BUFFERED_BYTES) return false;
+// `terminate()`, NOT `close(1013)`. A courteous close queues the close frame
+// BEHIND the megabytes already stuck — on a socket that by definition isn't
+// moving, the handshake can't complete, and `ws` only destroys the connection
+// after its 30s closeTimeout (`ws/lib/websocket.js` setCloseTimer). The bytes
+// this exists to reclaim would sit in the heap for another 30 seconds, and the
+// socket would linger in socketsByUser, which inverts the whole point.
+// Terminating frees both now. The client sees an abnormal close, reconnects
+// through its normal path, and resumes from `?since` — so this costs a
+// reconnect, not history, and the close code it doesn't get is one it could
+// never have received anyway.
+//
+// Deliberately NOT applied to `send`, which is what the snapshot burst uses:
+// judging a socket by the size of a burst the server itself just queued is what
+// the grace period above exists to avoid, and inside the burst there hasn't even
+// been an event-loop turn in which to drain.
+//
+// Exported (and pure over its arguments, like sweepWsHeartbeat) so the
+// drop/keep decision is unit-testable without a live WSS. `now` is injectable
+// for the same reason.
+export function dropIfBackpressured(ws: LurkerWebSocket, now: number = Date.now()): boolean {
+  if (ws.bufferedAmount <= MAX_BUFFERED_BYTES) {
+    // Drained back under the line — it was a burst, not a wedge.
+    ws.backpressureSince = undefined;
+    return false;
+  }
+  if (ws.backpressureSince === undefined) {
+    // First sighting. Start the clock; a healthy socket clears it by draining.
+    ws.backpressureSince = now;
+    return false;
+  }
+  if (now - ws.backpressureSince < BACKPRESSURE_GRACE_MS) return false;
   console.warn(
-    `[wsHub] socket ${ws.bufferedAmount} bytes behind on fan-out; closing (client resumes via ?since)`,
+    `[wsHub] socket stuck at ${ws.bufferedAmount} bytes for ${now - ws.backpressureSince}ms; terminating (client resumes via ?since)`,
   );
   try {
-    ws.close(1013, 'backpressure');
+    ws.terminate();
   } catch (_err) {
     // Already tearing down; the close handler prunes it either way.
   }
@@ -1232,10 +1265,10 @@ function fanOut(userId: number, payload: WsPayload, opts: FanOutOpts = {}): void
   for (const ws of set) {
     if (opts.exceptWs && ws === opts.exceptWs) continue;
     if (ws.readyState === ws.OPEN) {
-      // Checked BEFORE the send: once we're over the line, adding to the queue
-      // is exactly what we're trying to stop. The cursor is deliberately not
-      // advanced either — this socket never received the event, and claiming it
-      // did would make the resume skip it.
+      // Checked BEFORE the send: once a socket is provably wedged, adding to
+      // its queue is exactly what we're trying to stop. The cursor is
+      // deliberately not advanced for a dropped socket either — it never
+      // received the event, and claiming it did would make the resume skip it.
       if (dropIfBackpressured(ws)) continue;
       ws.send(json);
       // Advance the per-socket cursor so a subsequent sendSnapshot ships

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1176,8 +1176,16 @@ export function handleOpenBuffer(
   // all. A client that hydrates on demand has then spent its one request on something
   // that can never be answered, and sits on a loading spinner for the rest of the
   // connection. `open-buffer` must always produce a backlog for a buffer that exists.
-  const joinedChannel = channelJoined(requested, ircManager.getConnection(userId, networkId));
-  if (row && (hasMessageForTarget(networkId, row.target) || joinedChannel)) {
+  // Live membership, checked for EVERY channel prefix rather than through
+  // `channelJoined`. That helper answers `true` for anything not starting with '#',
+  // which is right for the display field it feeds (a DM is always "joined") but wrong
+  // as a branch condition: `kindForTarget` counts '&', '+' and '!' as channels too, so
+  // routing through it would report an unjoined `&local` as joined and hand back a
+  // backlog for a channel we aren't in.
+  const conn = ircManager.getConnection(userId, networkId);
+  const inChannel =
+    kindForTarget(requested) === 'channel' && !!conn?.channels.has(requested.toLowerCase());
+  if (row && (hasMessageForTarget(networkId, row.target) || inChannel)) {
     reopenBufferRow(userId, networkId, row.target);
     send(ws, buildBufferBacklog(userId, networkId, row.target));
     send(ws, { kind: 'buffer-opened', networkId, target: row.target });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -737,9 +737,9 @@ function bufferStateFields(
 // client dedupes by id, so it's safe even if the buffer is already open.
 export function buildBufferBacklog(userId: number, networkId: number, target: string): WsPayload {
   const conn = ircManager.getConnection(userId, networkId);
-  const events = listMessages(networkId, target, { limit: 200 }).map((e) =>
-    decorateMessage(userId, e),
-  );
+  const rows = listMessages(networkId, target, { limit: 200 });
+  const events = rows.map((e) => decorateMessage(userId, e));
+  const oldestId = rows.length ? (rows[0].id ?? 0) : 0;
   return {
     kind: 'backlog',
     networkId,
@@ -747,6 +747,17 @@ export function buildBufferBacklog(userId: number, networkId: number, target: st
     events,
     // Always the recent slice, never a gap — see the header comment.
     mode: 'replace' satisfies BacklogMode,
+    // This frame answers `open-buffer`, i.e. it is a client's ONE hydrate of this
+    // buffer, and omitting this field stranded the empty case forever.
+    //
+    // A shell is `events: [] + hasMoreOlder: true`, and a client that can't see
+    // `hasMoreOlder` has to assume the shell reading — anything else would mark a
+    // buffer hydrated that isn't and render it permanently blank. So on a buffer
+    // with no messages this frame (`events: []`, field absent) was indistinguishable
+    // from "fetch me later": the client stayed unhydrated, sat on its loading
+    // spinner, and never asked again because it had already spent its one request.
+    // Non-empty buffers hid the bug — any event at all reads as hydrated.
+    hasMoreOlder: oldestId > 0 && hasOlderRow(networkId, target, oldestId),
     speakers: listSpeakers(networkId, target),
     joined: channelJoined(target, conn),
     ...bufferStateFields(userId, networkId, target),

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1169,7 +1169,15 @@ export function handleOpenBuffer(
 ): void {
   if (!networkId || !requested || requested.startsWith(':server:')) return;
   const row = getBuffer(userId, networkId, requested);
-  if (row && hasMessageForTarget(networkId, row.target)) {
+  // A channel we are CURRENTLY IN answers with its backlog even when that backlog is
+  // empty. Gating purely on `hasMessageForTarget` sent a channel you're sitting in but
+  // have no persisted lines for — freshly joined, or one whose history was cleared —
+  // down the join branch below, which replies with `buffer-opened` and no `backlog` at
+  // all. A client that hydrates on demand has then spent its one request on something
+  // that can never be answered, and sits on a loading spinner for the rest of the
+  // connection. `open-buffer` must always produce a backlog for a buffer that exists.
+  const joinedChannel = channelJoined(requested, ircManager.getConnection(userId, networkId));
+  if (row && (hasMessageForTarget(networkId, row.target) || joinedChannel)) {
     reopenBufferRow(userId, networkId, row.target);
     send(ws, buildBufferBacklog(userId, networkId, row.target));
     send(ws, { kind: 'buffer-opened', networkId, target: row.target });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -110,11 +110,11 @@ interface LurkerWebSocket extends WebSocket {
   // visible=true) and userHasVisibleClient() stays true forever, permanently
   // suppressing auto-away.
   isAlive?: boolean;
-  // When this socket's outbound queue first went over MAX_BUFFERED_BYTES and
-  // stayed there, or undefined when it's draining normally. Cleared the moment
-  // it drops back under, so only sustained backpressure accumulates time. See
-  // dropIfBackpressured.
-  backpressureSince?: number;
+  // The current no-progress streak on this socket's outbound queue, or undefined
+  // when it isn't over MAX_BUFFERED_BYTES. `since` is when the streak began,
+  // `at` when we last looked, `floor` the lowest bufferedAmount seen during it.
+  // See dropIfBackpressured for why all three are needed.
+  backpressure?: { since: number; at: number; floor: number };
   // Mirrors the account's is_paused at connect time, then flipped live by the
   // user-suspended / user-resumed handlers so the read-only write guard never
   // needs a per-message DB read. (Named accountPaused, not isPaused, to avoid
@@ -1194,17 +1194,19 @@ const socketsByUser = new Map<number, Set<LurkerWebSocket>>();
 // event fanned out to such a socket is memory we never get back — a leak whose
 // only symptom is RSS climbing on a busy cell.
 //
-// The duration is the load-bearing half, and the reason this isn't a simple
-// size check. `bufferedAmount` is ONE number covering everything queued on the
-// socket, including the synchronous snapshot burst — which can legitimately be
-// megabytes on a large account (up to RESUME_GAP_CAP rows per buffer, across
-// every buffer) and takes real seconds to flush on a real link. A bare size
-// check would therefore fire on the first live event that lands mid-drain,
-// close the socket, and have the client reconnect straight into the same large
-// burst: a permanent disconnect loop for exactly the accounts the cap is
-// supposed to protect. Requiring the condition to PERSIST tells "a big burst,
-// draining" apart from "this socket has stopped moving", which is the thing we
-// actually want to act on.
+// Size alone is NOT the signal, and that's the whole subtlety here.
+// `bufferedAmount` is one number covering everything queued on the socket,
+// including the synchronous snapshot burst — legitimately megabytes on a large
+// account (up to RESUME_GAP_CAP rows per buffer, across every buffer), taking
+// real seconds to flush on a real link. A bare size check fires on the first
+// live event that lands mid-drain, kills the socket, and the client reconnects
+// into an identical burst: a permanent disconnect loop for exactly the accounts
+// the cap is meant to protect.
+//
+// So the cap only decides when to START WATCHING. What condemns a socket is
+// making no downward progress for the grace period — see dropIfBackpressured.
+// A slow client drains steadily and is never touched; one whose window has
+// closed goes flat and is dropped.
 const MAX_BUFFERED_BYTES = 8 * 1024 * 1024;
 const BACKPRESSURE_GRACE_MS = 30_000;
 
@@ -1235,19 +1237,43 @@ function send(ws: LurkerWebSocket, payload: WsPayload): void {
 // drop/keep decision is unit-testable without a live WSS. `now` is injectable
 // for the same reason.
 export function dropIfBackpressured(ws: LurkerWebSocket, now: number = Date.now()): boolean {
-  if (ws.bufferedAmount <= MAX_BUFFERED_BYTES) {
-    // Drained back under the line — it was a burst, not a wedge.
-    ws.backpressureSince = undefined;
+  const queued = ws.bufferedAmount;
+  if (queued <= MAX_BUFFERED_BYTES) {
+    // Under the line — it was a burst, not a wedge.
+    ws.backpressure = undefined;
     return false;
   }
-  if (ws.backpressureSince === undefined) {
-    // First sighting. Start the clock; a healthy socket clears it by draining.
-    ws.backpressureSince = now;
+  const streak = ws.backpressure;
+  // Restart the streak on a first sighting, OR when the last observation is
+  // older than the grace period. We only look during fan-out, so a quiet
+  // account can go minutes between calls — and a streak we weren't watching is
+  // no evidence of anything. Without this, a socket that went over the cap
+  // once, drained unobserved, and went over again on a later burst would be
+  // judged against a timestamp from minutes ago and killed on the FIRST
+  // sighting of the new burst, which is exactly what the grace exists to
+  // prevent.
+  if (streak === undefined || now - streak.at > BACKPRESSURE_GRACE_MS) {
+    ws.backpressure = { since: now, at: now, floor: queued };
     return false;
   }
-  if (now - ws.backpressureSince < BACKPRESSURE_GRACE_MS) return false;
+  // Did anything actually leave the machine? We only ever ADD on this path, so
+  // a new low can only come from the socket flushing. That — not absolute size
+  // — is what separates "slow but working" from "stopped".
+  //
+  // This is the difference between a big snapshot to a phone on a weak link
+  // (megabytes queued, grinding steadily down, never dropped) and a socket
+  // whose window has closed (queue flat or climbing, dropped after the grace).
+  // Judging by size alone would kill the first case while it was behaving
+  // correctly, and it would reconnect into an identical burst — a permanent
+  // loop for exactly the clients least able to afford one.
+  if (queued < streak.floor) {
+    ws.backpressure = { since: now, at: now, floor: queued };
+    return false;
+  }
+  streak.at = now;
+  if (now - streak.since < BACKPRESSURE_GRACE_MS) return false;
   console.warn(
-    `[wsHub] socket stuck at ${ws.bufferedAmount} bytes for ${now - ws.backpressureSince}ms; terminating (client resumes via ?since)`,
+    `[wsHub] socket made no progress on ${queued} queued bytes for ${now - streak.since}ms; terminating (client resumes via ?since)`,
   );
   try {
     ws.terminate();

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1178,8 +1178,50 @@ export function handleOpenBuffer(
 // addSocket/removeSocket); the registry just reads through it.
 const socketsByUser = new Map<number, Set<LurkerWebSocket>>();
 
+// How many bytes of un-drained outbound frames a socket may accumulate on the
+// LIVE fan-out path before we give up on it.
+//
+// The heartbeat reaps DEAD sockets (no pong within a sweep, ~60s). It does not
+// reap SLOW ones, and those are a different failure: a phone on a degraded link
+// is genuinely OPEN and may still pong while its TCP window is closed. `ws`
+// queues everything we hand it in the Node heap with no bound, so every live
+// event fanned out to such a socket is memory we never get back — a leak whose
+// only symptom is RSS climbing on a busy cell.
+//
+// Live events are small (a few hundred bytes), so this is roughly "tens of
+// thousands of frames behind". Nothing healthy gets there; anything that does
+// is not coming back on this socket.
+const MAX_BUFFERED_BYTES = 8 * 1024 * 1024;
+
 function send(ws: LurkerWebSocket, payload: WsPayload): void {
   if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
+}
+
+// Drop a socket that has stopped draining. Closing with 1013 (Try Again Later)
+// rather than terminating means the client reconnects through its normal path
+// and resumes from `?since` — the gap it missed is refetched, so this costs the
+// user a reconnect, not history.
+//
+// Deliberately NOT applied to `send`, which is what the snapshot burst uses.
+// The burst is synchronous: it writes every frame in one tick, and no socket I/O
+// happens until the event loop turns, so `bufferedAmount` there measures the
+// SIZE OF THE BURST, not the health of the client. A large account would trip
+// any threshold worth having and get disconnected on connect, forever. Live
+// fan-out is where slowness actually accumulates over time, so that's where the
+// check belongs.
+// Exported (and pure over its argument, like sweepWsHeartbeat) so the
+// drop/keep decision is unit-testable without a live WSS.
+export function dropIfBackpressured(ws: LurkerWebSocket): boolean {
+  if (ws.bufferedAmount <= MAX_BUFFERED_BYTES) return false;
+  console.warn(
+    `[wsHub] socket ${ws.bufferedAmount} bytes behind on fan-out; closing (client resumes via ?since)`,
+  );
+  try {
+    ws.close(1013, 'backpressure');
+  } catch (_err) {
+    // Already tearing down; the close handler prunes it either way.
+  }
+  return true;
 }
 
 function fanOut(userId: number, payload: WsPayload, opts: FanOutOpts = {}): void {
@@ -1190,6 +1232,11 @@ function fanOut(userId: number, payload: WsPayload, opts: FanOutOpts = {}): void
   for (const ws of set) {
     if (opts.exceptWs && ws === opts.exceptWs) continue;
     if (ws.readyState === ws.OPEN) {
+      // Checked BEFORE the send: once we're over the line, adding to the queue
+      // is exactly what we're trying to stop. The cursor is deliberately not
+      // advanced either — this socket never received the event, and claiming it
+      // did would make the resume skip it.
+      if (dropIfBackpressured(ws)) continue;
       ws.send(json);
       // Advance the per-socket cursor so a subsequent sendSnapshot ships
       // only the gap newer than what this socket has already received.

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -52,8 +52,10 @@ let socketListeners: AbortController | null = null;
 // calling useSocket() (which would re-register the connect lifecycle).
 export const connected = ref(false);
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-// Consecutive failed reconnect attempts, driving the backoff below. Reset the
-// moment a socket opens.
+// Consecutive failed reconnect attempts, driving the backoff below. Deliberately
+// NOT reset when a socket opens — only once one has survived RECONNECT_STABLE_MS,
+// which the close handler decides. See that constant for why opening is too early
+// to count as success.
 let reconnectAttempts = 0;
 // When the current socket opened, or null when there isn't one. Used to decide
 // whether a connection lasted long enough to count as healthy.

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -52,6 +52,25 @@ let socketListeners: AbortController | null = null;
 // calling useSocket() (which would re-register the connect lifecycle).
 export const connected = ref(false);
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+// Consecutive failed reconnect attempts, driving the backoff below. Reset the
+// moment a socket opens.
+let reconnectAttempts = 0;
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30_000;
+// How long to wait before the next reconnect: exponential 1s→30s with ±25%
+// jitter, matching the iOS client's policy.
+//
+// The jitter is the load-bearing half. A flat interval (this was a hard 2s)
+// means every tab the user has open — and on a hosted cell, every tab of every
+// user on it — reconnects inside the same window after a restart, and each
+// reconnect costs the server a full synchronous snapshot burst. That's a
+// thundering herd aimed at a process that has just started and is least able to
+// absorb it. Spreading the retries is what stops a routine deploy from looking
+// like an outage.
+function nextReconnectDelay(): number {
+  const capped = Math.min(RECONNECT_BASE_MS * 2 ** reconnectAttempts, RECONNECT_MAX_MS);
+  return Math.round(capped * (0.75 + Math.random() * 0.5));
+}
 const openHandlers = new Set<() => void>();
 // Outstanding send/action ACKs keyed by clientId. Resolver is called with
 // { ok, error } when the server returns a send-result, on socket close, or on
@@ -102,8 +121,9 @@ let lastMessageAt = 0;
 // Arm (or re-arm) the probe against the CURRENT socket. The callback captures
 // the socket instance it measured and re-checks identity before acting: a
 // probe armed against socket A must never close A's healthy replacement B
-// when A dies mid-window and the 2s reconnect brings B up before the timer
-// fires (B can be OPEN with its first snapshot frame still in flight). The
+// when A dies mid-window and the reconnect brings B up before the timer fires
+// (B can be OPEN with its first snapshot frame still in flight — and with
+// backoff the first retry can land in well under a second). The
 // close handler also clears the timer outright, so identity is a second
 // fence, not the only one.
 function armLivenessProbe(): void {
@@ -791,6 +811,11 @@ function open() {
     'open',
     () => {
       connected.value = true;
+      // A socket that opened is a successful attempt — the next drop starts its
+      // backoff from 1s again rather than inheriting the previous outage's
+      // ceiling. (A refused upgrade never reaches this handler, so a 401/426
+      // loop keeps backing off, which is what we want.)
+      reconnectAttempts = 0;
       // Detached buffers won't survive a reconnect cleanly — the incoming
       // snapshot/backlog would otherwise be short-circuited by replaceBacklog's
       // detached guard, leaving the slice stale and the buffer cut off from
@@ -854,7 +879,8 @@ function open() {
       }
       const auth = useAuthStore();
       if (auth.user) {
-        reconnectTimer = setTimeout(open, 2000);
+        reconnectTimer = setTimeout(open, nextReconnectDelay());
+        reconnectAttempts += 1;
       }
     },
     opts,
@@ -942,6 +968,10 @@ export function resetSocket(): void {
     socket = null;
   }
   connected.value = false;
+  // A teardown ends the session (sign-out, or an explicit reset) — whatever
+  // backoff the last outage had built up shouldn't be inherited by the next
+  // sign-in's first reconnect.
+  reconnectAttempts = 0;
   hiddenSince = null;
   lastSeenEventId = 0;
   failAllPendingAcks('disconnected');
@@ -955,9 +985,13 @@ function refreshSnapshot() {
     armLivenessProbe();
     return;
   }
-  // Socket isn't open — pull the reconnect forward instead of waiting on the
-  // 2s backoff timer. The fresh connection will trigger the server-side
-  // sendSnapshot path on its own.
+  // Socket isn't open — pull the reconnect forward instead of waiting out the
+  // backoff timer. The user is looking at the tab right now, so the wait that
+  // protects a restarting server from a herd is the wrong trade here. The
+  // attempt counter is deliberately NOT reset: if the server really is down,
+  // the retries that follow this one should resume backing off rather than
+  // restart at 1s. The fresh connection triggers the server-side sendSnapshot
+  // path on its own.
   if (reconnectTimer) {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type { Ref } from 'vue';
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useAuthStore } from '../stores/auth.js';
@@ -66,12 +66,18 @@ const RECONNECT_MAX_MS = 30_000;
 // Resetting on `open` instead is the obvious version and it's wrong: it clears
 // the backoff the instant the upgrade succeeds, before the connection has
 // proved it can survive. Any accept-then-close pattern then retries forever at
-// the base delay with no backoff at all — and the server-side backpressure
-// reaper is exactly such a pattern (accept → snapshot → drop → repeat), where
-// each iteration costs the server a full synchronous snapshot. Requiring the
-// socket to live a while first means a genuine one-off drop still reconnects
-// in ~1s, while a connect-and-die loop backs off like any other failure.
-const RECONNECT_STABLE_MS = 10_000;
+// the base delay with no backoff at all — and the server's backpressure reaper
+// is exactly such a pattern (accept → snapshot → drop → repeat), where each
+// iteration costs the server a full synchronous snapshot.
+//
+// **This must exceed the server's `BACKPRESSURE_GRACE_MS` (30s), or it doesn't
+// defend against the case it's named for.** That reaper can only fire after a
+// full grace period of no progress, i.e. at least 30s after the socket opened —
+// so a threshold below 30s classifies every backpressure drop as a healthy
+// connection, resets the counter, and retries in ~1s. Which is the unthrottled
+// loop. 60s keeps a comfortable margin; a normal session lasts hours, so the
+// only connections this denies a fast retry to are ones that died young.
+const RECONNECT_STABLE_MS = 60_000;
 // How long to wait before the next reconnect: exponential 1s→30s with ±25%
 // jitter, matching the iOS client's policy.
 //
@@ -1038,9 +1044,14 @@ export function useSocket(): SocketAPI {
     wireVisibility();
     open();
   });
-  onBeforeUnmount(() => {
-    if (reconnectTimer) clearTimeout(reconnectTimer);
-  });
+  // Deliberately no teardown. The socket, and the reconnect timer that revives
+  // it, are module-level singletons shared by every view that calls this
+  // (DesktopChat, MobileChat, Settings, Admin) — so cancelling the timer when
+  // any ONE of them unmounts kills a reconnect the others still depend on. It
+  // only ever looked harmless because the incoming route's onMounted → open()
+  // papered over it, which also meant every route change during an outage fired
+  // an immediate un-backed-off connect, defeating the backoff above. The
+  // lifecycle that matters is the session's, and resetSocket() owns that.
   return { connected, send, reconnect: open };
 }
 

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -55,8 +55,23 @@ let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 // Consecutive failed reconnect attempts, driving the backoff below. Reset the
 // moment a socket opens.
 let reconnectAttempts = 0;
+// When the current socket opened, or null when there isn't one. Used to decide
+// whether a connection lasted long enough to count as healthy.
+let socketOpenedAt: number | null = null;
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
+// How long a socket must stay open before we treat it as a *successful*
+// connection and reset the backoff.
+//
+// Resetting on `open` instead is the obvious version and it's wrong: it clears
+// the backoff the instant the upgrade succeeds, before the connection has
+// proved it can survive. Any accept-then-close pattern then retries forever at
+// the base delay with no backoff at all — and the server-side backpressure
+// reaper is exactly such a pattern (accept → snapshot → drop → repeat), where
+// each iteration costs the server a full synchronous snapshot. Requiring the
+// socket to live a while first means a genuine one-off drop still reconnects
+// in ~1s, while a connect-and-die loop backs off like any other failure.
+const RECONNECT_STABLE_MS = 10_000;
 // How long to wait before the next reconnect: exponential 1s→30s with ±25%
 // jitter, matching the iOS client's policy.
 //
@@ -811,11 +826,9 @@ function open() {
     'open',
     () => {
       connected.value = true;
-      // A socket that opened is a successful attempt — the next drop starts its
-      // backoff from 1s again rather than inheriting the previous outage's
-      // ceiling. (A refused upgrade never reaches this handler, so a 401/426
-      // loop keeps backing off, which is what we want.)
-      reconnectAttempts = 0;
+      // Stamped, not reset — the backoff clears on a connection that PROVED
+      // itself, which is decided in the close handler. See RECONNECT_STABLE_MS.
+      socketOpenedAt = Date.now();
       // Detached buffers won't survive a reconnect cleanly — the incoming
       // snapshot/backlog would otherwise be short-circuited by replaceBacklog's
       // detached guard, leaving the slice stale and the buffer cut off from
@@ -879,8 +892,14 @@ function open() {
       }
       const auth = useAuthStore();
       if (auth.user) {
+        // A socket that lived a while proves the server is healthy and this was
+        // an ordinary drop — start over at the base delay. One that died young
+        // counts as a failed attempt and escalates. Decided BEFORE scheduling,
+        // since the delay is computed from the count.
+        const livedMs = socketOpenedAt === null ? 0 : Date.now() - socketOpenedAt;
+        socketOpenedAt = null;
+        reconnectAttempts = livedMs >= RECONNECT_STABLE_MS ? 0 : reconnectAttempts + 1;
         reconnectTimer = setTimeout(open, nextReconnectDelay());
-        reconnectAttempts += 1;
       }
     },
     opts,
@@ -972,6 +991,7 @@ export function resetSocket(): void {
   // backoff the last outage had built up shouldn't be inherited by the next
   // sign-in's first reconnect.
   reconnectAttempts = 0;
+  socketOpenedAt = null;
   hiddenSince = null;
   lastSeenEventId = 0;
   failAllPendingAcks('disconnected');


### PR DESCRIPTION
Second PR from the WebSocket protocol audit (after #668). Three independent fixes, all additive — **no `PROTOCOL_VERSION` bump**.

## 1. Backpressure — judge progress, not size

Nothing read `ws.bufferedAmount`, so `fanOut` wrote to every socket that was `OPEN` regardless of whether it was draining. The heartbeat reaps **dead** sockets; a **slow** one is a different failure — a phone on a degraded link is genuinely open and may still pong while its window is closed, and `ws` queues everything we hand it in the Node heap with no bound. The only symptom is RSS climbing on a busy cell.

Getting the rule right took three attempts, and the first two are worth recording because both are plausible and both are wrong:

| Rule | Why it fails |
| --- | --- |
| `bufferedAmount > cap` | Fires during the snapshot burst's own drain → client reconnects into the same burst → **permanent disconnect loop**, for exactly the large accounts the cap is meant to protect |
| `> cap` for 30s | A slow-but-healthy client can't drain 12 MiB in 30s → same loop, slower |
| **no downward progress for 30s** | ✅ We only ever *add* on this path, so a new low can only come from the socket flushing |

The cap now only decides when to **start watching**. A draining socket restarts its clock on every new low and is never dropped however slow it is; one whose window has closed goes flat and is dropped. The streak also restarts when the previous observation is older than the grace — we only look during fan-out, and a streak nobody was watching is not evidence.

`terminate()`, not `close(1013)`: a close frame queues *behind* the stuck megabytes, so on a socket that by definition isn't moving the handshake can't complete and `ws` holds it for its 30s `closeTimeout` — the memory this exists to reclaim would linger, inverting the goal.

## 2. Reconnect backoff (web)

Flat 2s, no jitter, so every tab reconnected in the same window after a restart — each costing a full synchronous snapshot burst, aimed at a process that just started. Now exponential 1→30s with ±25% jitter, matching what iOS has always done.

Reset requires the socket to have lived `RECONNECT_STABLE_MS` (60s). **This must exceed the server's `BACKPRESSURE_GRACE_MS` (30s)** or every backpressure drop counts as a healthy connection and retries unthrottled — the exact loop the constant exists to prevent.

Also removed `useSocket`'s `onBeforeUnmount`, which cleared the module-level reconnect timer shared by all four views that call the composable — so unmounting any one of them killed a reconnect the others depended on, and every route change during an outage fired an un-backed-off connect.

## 3. `open-buffer` must always answer an existing buffer

Two bugs that both ended in a permanent "Loading messages…" spinner, both found during iOS QA:

- `buildBufferBacklog` never sent `hasMoreOlder`. A shell is `events:[] + hasMoreOlder:true`, and a client that can't see the field must assume the shell reading — so an **empty** buffer's hydrate reply was indistinguishable from "fetch me later". The client stayed unhydrated and never re-asked, having spent its one request.
- `handleOpenBuffer` gated its backlog on `hasMessageForTarget`, so a channel you are **currently in** with no persisted lines fell through to the JOIN branch, which replies `buffer-opened` and no backlog at all.

## Testing

`npm run check` clean, `npm test` 2979 passing.

New `wsHub.backpressure.test.ts` drives a **real socket pair** with the client's receive window paused — the arithmetic was never the thing that was wrong, the assumption about `bufferedAmount` was. Every case was mutation-checked rather than trusted for being green, which caught two that were passing for the wrong reason: one drained the whole queue before reaching the branch it claimed to test, and one passed at `now = GRACE * 10` because the staleness rule restarted the streak first. Both are pinned now, with comments on why the constants aren't arbitrary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)