### PR TITLE
Size history pages in rendered rows, not stored ones

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -255,6 +255,10 @@ buffers arrive as _shells_: `{kind:'backlog', …, events:[], mode:'shell',
 hasMoreOlder:true}` — "this buffer exists; fetch content when the user opens it."
 
 Hydrate a shell with **`{type:'history', mode:'latest'}`**. It is a pure read.
+If you consolidate presence noise, send `countBy:'renderable'` with it (§8) —
+this is the fetch that fills the first screenful, so it's where sizing a page in
+stored rows shows up as a blank-looking channel. `open-buffer` accepts the same
+field, for clients still hydrating that way.
 
 > ⚠ `{type:'open-buffer'}` also returns a populated `backlog`, and the iOS app
 > currently hydrates with it — but it is a **write verb**, not a read: for a
@@ -474,7 +478,7 @@ is emitted immediately from the server's optimistic local copy.
 | -------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `join`         | `networkId, channel, key?`    | Request only — the buffer appears on `channel-joined` (§9.1)                                                            |
 | `part`         | `networkId, channel, reason?` | Buffer survives, parted                                                                                                 |
-| `open-buffer`  | `networkId, target`           | Reopen/create: replies `backlog` + `buffer-opened`; JOINs if an unjoined channel; mints an empty DM row for a bare nick |
+| `open-buffer`  | `networkId, target, countBy?` | Reopen/create: replies `backlog` + `buffer-opened`; JOINs if an unjoined channel; mints an empty DM row for a bare nick |
 | `close-buffer` | `networkId, target, reason?`  | Closes (PARTs a joined channel, untracks a DM peer). `:server:` refuses                                                 |
 
 ### View state (persisted server-side, fanned out to your other devices)
@@ -632,7 +636,8 @@ gap is enormous: a 100-row page out of a netsplit can render as three visible
 lines. You fetch, fold it to nothing, notice the page was short, fetch again —
 and the user watches the buffer assemble itself.
 
-Send **`countBy:'renderable'`** (modes `before`, `after`, `latest`) and the
+Send **`countBy:'renderable'`** (modes `before`, `after`, `latest`; also honored
+on `open-buffer`, not on `around`) and the
 server sizes the page in rows that render as their own line. The consolidatable
 rows still come back — consolidation needs the whole run to summarize it — they
 just don't spend the budget. Default is `'event'`, i.e. today's behavior; an

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -507,13 +507,13 @@ is emitted immediately from the server's optimistic local copy.
 
 ### Sync & fetch
 
-| `type`            | Fields                                                                                                      | Reply                                            |
-| ----------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `snapshot`        | —                                                                                                           | Re-runs the snapshot burst as a gap-fill (§4.4)  |
-| `history`         | `networkId, target, mode: before\|after\|around\|latest, limit (1–500), token?, before?/afterId?/anchorId?` | `{kind:'history'}` (§8)                          |
-| `search`          | `query, networkId?, target?, nick?, nicks?, before?, limit?, token?`                                        | `{kind:'search-result'}`                         |
-| `list-channels` ⏸ | `networkId`                                                                                                 | Kicks off `/LIST`; progress via `chanlist-state` |
-| `chanlist-search` | `networkId, query, sortBy, sortDir, offset, limit`                                                          | `{kind:'chanlist-result'}`                       |
+| `type`            | Fields                                                                                                                | Reply                                            |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `snapshot`        | —                                                                                                                     | Re-runs the snapshot burst as a gap-fill (§4.4)  |
+| `history`         | `networkId, target, mode: before\|after\|around\|latest, limit (1–500), token?, countBy?, before?/afterId?/anchorId?` | `{kind:'history'}` (§8)                          |
+| `search`          | `query, networkId?, target?, nick?, nicks?, before?, limit?, token?`                                                  | `{kind:'search-result'}`                         |
+| `list-channels` ⏸ | `networkId`                                                                                                           | Kicks off `/LIST`; progress via `chanlist-state` |
+| `chanlist-search` | `networkId, query, sortBy, sortDir, offset, limit`                                                                    | `{kind:'chanlist-result'}`                       |
 
 ### E2E (RPE2E, per-channel opt-in)
 
@@ -621,6 +621,41 @@ connection-independent — offline networks still serve it.
 `hasMoreOlder`). Echo the request `token` discipline the web client uses if you
 pipeline requests: keep a monotonically increasing token and drop any reply
 whose token you've superseded.
+
+### `countBy` — what `limit` counts
+
+`limit` counts **stored rows**. If you consolidate presence noise — both
+first-party clients fold runs of `join`/`part`/`quit`/`nick`/`chghost` into one
+summary line, per `shared/consolidate.ts`, which is the canonical set — that is
+not the unit you render in, and on a busy channel the
+gap is enormous: a 100-row page out of a netsplit can render as three visible
+lines. You fetch, fold it to nothing, notice the page was short, fetch again —
+and the user watches the buffer assemble itself.
+
+Send **`countBy:'renderable'`** (modes `before`, `after`, `latest`) and the
+server sizes the page in rows that render as their own line. The consolidatable
+rows still come back — consolidation needs the whole run to summarize it — they
+just don't spend the budget. Default is `'event'`, i.e. today's behavior; an
+older server ignores the field and answers exactly as before.
+
+- **What counts as renderable is the complement of the fold set**, not
+  "messages". A `kick`, `mode`, `topic`, `error`, or `invite` each renders
+  standalone, so each is worth one slot.
+- **The slice is still a contiguous id range**, exactly like an event-counted
+  one. `hasMoreOlder`, prepend-and-dedupe, and the `before: <oldest returned
+id>` cursor are unchanged. This cannot open a hole.
+- **The scan is capped** (2000 rows). Past the cap you get fewer renderable rows
+  than you asked for and `hasMoreOlder` stays true — a buffer holding tens of
+  thousands of joins between two sentences degrades to today's behavior instead
+  of shipping a huge frame.
+- **Only ask for it if you actually fold.** If your client renders every event
+  as its own line (the web client makes this a user setting), `'event'` is
+  already the right unit, and `'renderable'` would hand you up to a full scan
+  window of rows you then display in full.
+- **Re-arm your pager if your own ring trims the reply.** `hasMoreOlder`
+  describes the slice the server _sent_. A renderable-counted page can exceed a
+  fixed in-memory cap, and dropping rows off the old edge means there is more
+  older history than you hold regardless of what the flag said.
 
 **Jump-to-message detaches the buffer** (Discord/Slack convention): after
 `around`, live events for that buffer should _not_ be spliced into the visible
@@ -954,7 +989,8 @@ What the iOS app actually ships with (`FrameParser.parseWs`,
 - **`irc` types rendered:** `message`, `action`, `notice`, `error`, `system`,
   `join`, `part`, `quit`, `nick`, `kick`, `mode`, `topic`, `motd`, `invite`
   (plus `channel-topic` for state). Unknown → drop.
-- **Send verbs (8):** `presence`, `send`, `history` (`before`/`latest`),
+- **Send verbs (8):** `presence`, `send`, `history` (`before`/`latest`; add
+  `countBy:'renderable'` if you consolidate — §8),
   `mark-read`, `mark-all-read`, `join`, `open-buffer`, `close-buffer`.
 - **REST (4):** `POST /api/auth/login/token` (or the CP login), `GET
 /api/networks`, `POST /api/auth/logout`, and optionally `GET

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -636,8 +636,7 @@ gap is enormous: a 100-row page out of a netsplit can render as three visible
 lines. You fetch, fold it to nothing, notice the page was short, fetch again —
 and the user watches the buffer assemble itself.
 
-Send **`countBy:'renderable'`** (modes `before`, `after`, `latest`; also honored
-on `open-buffer`, not on `around`) and the
+Send **`countBy:'renderable'`** (every `history` mode, and `open-buffer`) and the
 server sizes the page in rows that render as their own line. The consolidatable
 rows still come back — consolidation needs the whole run to summarize it — they
 just don't spend the budget. Default is `'event'`, i.e. today's behavior; an
@@ -653,14 +652,28 @@ id>` cursor are unchanged. This cannot open a hole.
   than you asked for and `hasMoreOlder` stays true — a buffer holding tens of
   thousands of joins between two sentences degrades to today's behavior instead
   of shipping a huge frame.
-- **Only ask for it if you actually fold.** If your client renders every event
-  as its own line (the web client makes this a user setting), `'event'` is
-  already the right unit, and `'renderable'` would hand you up to a full scan
-  window of rows you then display in full.
-- **Re-arm your pager if your own ring trims the reply.** `hasMoreOlder`
-  describes the slice the server _sent_. A renderable-counted page can exceed a
-  fixed in-memory cap, and dropping rows off the old edge means there is more
-  older history than you hold regardless of what the flag said.
+- **Only ask for it if you actually fold** — and only once you _know_ whether
+  you do. If your client renders every event as its own line (the web client
+  makes this a user setting), `'event'` is already the right unit, and
+  `'renderable'` would hand you up to a full scan window of rows you then
+  display in full. If the preference hasn't loaded yet, send `'event'`: of the
+  two wrong guesses, that one just costs a short first page.
+- **On `around` it sizes each side**, so the window is up to `2×limit+1`
+  _renderable_ rows. Worth sending: for a client that enters a buffer with a
+  pending jump (a push tap, a highlight, jump-to-first-unread), the `around`
+  slice **is** the hydrate — no `latest` or `open-buffer` precedes it.
+- **A page can now be much bigger than your in-memory cap, if you keep one.**
+  Two consequences, both silent when missed:
+  - `hasMoreOlder` describes the slice the server _sent_. If your ring drops
+    rows off the old edge, there is more older history than you hold regardless
+    of what the flag said — re-arm the pager yourself.
+  - Don't merge a page larger than your ring into an existing slice. It evicts
+    the very rows the reader is looking at, and their scroll position ends up
+    pointing at content that no longer exists. Take the end **adjacent** to what
+    you hold (newest rows of an older page, oldest rows of a newer one), keep
+    the merge contiguous, and treat the remainder as still fetchable. The web
+    client caps an incremental merge at 250 rows for exactly this
+    (`vue_client/src/stores/buffers.ts:28`).
 
 **Jump-to-message detaches the buffer** (Discord/Slack convention): after
 `around`, live events for that buffer should _not_ be spliced into the visible

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -5,6 +5,9 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+// Pure, no DB side effects — safe to import statically alongside the lazy
+// db-layer imports below.
+import { CONSOLIDATABLE_TYPES } from '../../shared/consolidate.js';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
 process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
@@ -14,6 +17,7 @@ let createNetwork: typeof import('./networks.js').createNetwork;
 let insertMessage: typeof import('./messages.js').insertMessage;
 let listMessages: typeof import('./messages.js').listMessages;
 let listMessagesAround: typeof import('./messages.js').listMessagesAround;
+let listMessagesRenderable: typeof import('./messages.js').listMessagesRenderable;
 let searchMessages: typeof import('./messages.js').searchMessages;
 let countNewer: typeof import('./messages.js').countNewer;
 let countServerBufferUnread: typeof import('./messages.js').countServerBufferUnread;
@@ -36,6 +40,7 @@ beforeAll(async () => {
     insertMessage,
     listMessages,
     listMessagesAround,
+    listMessagesRenderable,
     searchMessages,
     countNewer,
     countServerBufferUnread,
@@ -1144,5 +1149,170 @@ describe('chathistory window queries', () => {
       100,
     );
     expect(targets.map((t) => t.target)).toEqual(['#b', '#a']); // #old outside window; :server:/#joinonly excluded
+  });
+});
+
+// A page sized in the unit the reader perceives (WS_PROTOCOL_FIXES #10). The
+// property under test throughout is the one that makes it safe to do at the
+// server: the result is a CONTIGUOUS id range, exactly like a listMessages
+// slice, so it can never open a hole in the client's scrollback.
+describe('listMessagesRenderable', () => {
+  function netFor(name: string): number {
+    const user = createUser(name);
+    return createNetwork(user.id, { name: 'n', host: 'h', port: 6697, tls: true, nick: name })!.id;
+  }
+
+  /** Every id in the buffer between the slice's ends, in order. */
+  function idRange(networkId: number, target: string, from: number, to: number): number[] {
+    return listMessages(networkId, target, { limit: 10_000 })
+      .map((e) => e.id)
+      .filter((id) => id >= from && id <= to);
+  }
+
+  /** Assert the slice is a gapless run of the buffer's ids. */
+  function expectContiguous(rows: Array<{ id: number }>, networkId: number, target: string): void {
+    expect(rows.length).toBeGreaterThan(0);
+    const ids = rows.map((r) => r.id);
+    expect(ids).toEqual(idRange(networkId, target, ids[0], ids[ids.length - 1]));
+  }
+
+  it('fills the page with renderable rows where an event-counted page would not', () => {
+    const net = netFor('rend-fill');
+    // 20 messages, each buried under a netsplit's worth of presence churn — the
+    // shape that made the client fetch, fold to nothing, and fetch again.
+    for (let i = 1; i <= 20; i += 1) {
+      for (let j = 0; j < 30; j += 1) event(net, '#a', 'join', `n${j}`);
+      chat(net, '#a', 'alice', `m${i}`);
+    }
+
+    const eventCounted = listMessages(net, '#a', { limit: 10 });
+    const renderable = listMessagesRenderable(net, '#a', { limit: 10 });
+
+    // Today's page: ten rows, nine of them noise that folds into one line.
+    expect(eventCounted).toHaveLength(10);
+    expect(eventCounted.filter((e) => e.type === 'message')).toHaveLength(1);
+    // The new page: ten actual messages, with their runs along for the ride.
+    expect(renderable.filter((e) => e.type === 'message')).toHaveLength(10);
+    expectContiguous(renderable, net, '#a');
+  });
+
+  it('stops ON the limit-th renderable row, leaving its run to the next page', () => {
+    const net = netFor('rend-boundary');
+    for (let i = 1; i <= 5; i += 1) {
+      for (let j = 0; j < 4; j += 1) event(net, '#a', 'part', `n${j}`);
+      chat(net, '#a', 'alice', `m${i}`);
+    }
+    const rows = listMessagesRenderable(net, '#a', { limit: 2 });
+    // Oldest row is the boundary message itself, not the joins that precede it:
+    // the next page picks that run up whole, so consolidation summarizes it once
+    // rather than splitting it across two pages.
+    expect(rows[0].type).toBe('message');
+    expect(rows[0].text).toBe('m4');
+    expect(rows.filter((e) => e.type === 'message').map((e) => e.text)).toEqual(['m4', 'm5']);
+  });
+
+  it('pages backward through `before` without a gap or an overlap', () => {
+    const net = netFor('rend-page');
+    for (let i = 1; i <= 12; i += 1) {
+      for (let j = 0; j < 3; j += 1) event(net, '#a', 'quit', `n${j}`);
+      chat(net, '#a', 'alice', `m${i}`);
+    }
+    const page1 = listMessagesRenderable(net, '#a', { limit: 4 });
+    const page2 = listMessagesRenderable(net, '#a', { limit: 4, before: page1[0].id });
+    expect(page1.filter((e) => e.type === 'message').map((e) => e.text)).toEqual([
+      'm9',
+      'm10',
+      'm11',
+      'm12',
+    ]);
+    expect(page2.filter((e) => e.type === 'message').map((e) => e.text)).toEqual([
+      'm5',
+      'm6',
+      'm7',
+      'm8',
+    ]);
+    // Joined end to end, the two pages are still one gapless run — the paging
+    // cursor is unchanged from the event-counted case (`before: oldest id`).
+    expectContiguous([...page2, ...page1], net, '#a');
+    expect(page2[page2.length - 1].id).toBeLessThan(page1[0].id);
+  });
+
+  it('pages forward through `afterId`, exclusive of the cursor', () => {
+    const net = netFor('rend-after');
+    const ids: number[] = [];
+    for (let i = 1; i <= 10; i += 1) {
+      for (let j = 0; j < 3; j += 1) event(net, '#a', 'join', `n${j}`);
+      ids.push(chat(net, '#a', 'alice', `m${i}`).id);
+    }
+    const rows = listMessagesRenderable(net, '#a', { afterId: ids[2], limit: 3 });
+    expect(rows.every((r) => r.id > ids[2])).toBe(true);
+    expect(rows.filter((e) => e.type === 'message').map((e) => e.text)).toEqual(['m4', 'm5', 'm6']);
+    expectContiguous(rows, net, '#a');
+  });
+
+  it('returns the whole buffer when it holds fewer renderable rows than the limit', () => {
+    const net = netFor('rend-short');
+    for (let j = 0; j < 8; j += 1) event(net, '#a', 'join', `n${j}`);
+    chat(net, '#a', 'alice', 'only one');
+    const rows = listMessagesRenderable(net, '#a', { limit: 100 });
+    expect(rows).toHaveLength(9);
+    expect(rows.filter((e) => e.type === 'message')).toHaveLength(1);
+  });
+
+  it('returns an all-noise buffer rather than an empty page', () => {
+    // No renderable row exists to spend the budget on. Returning [] here would
+    // read to a client as "start of history" and stop its pager dead.
+    const net = netFor('rend-allnoise');
+    for (let j = 0; j < 40; j += 1) event(net, '#a', 'join', `n${j}`);
+    const rows = listMessagesRenderable(net, '#a', { limit: 100 });
+    expect(rows).toHaveLength(40);
+  });
+
+  it('returns an empty page for a buffer with nothing in it', () => {
+    const net = netFor('rend-empty');
+    expect(listMessagesRenderable(net, '#nothing', { limit: 100 })).toEqual([]);
+  });
+
+  it('bounds the scan (and so the payload) at maxScan', () => {
+    // The whole safety story: a netsplit can put tens of thousands of joins
+    // between two sentences. Past the cap the page ships fewer renderable rows
+    // than asked and the caller's hasMoreOlder stays true — the pathological
+    // buffer degrades to today's behavior instead of a 50 MB frame.
+    const net = netFor('rend-cap');
+    for (let j = 0; j < 300; j += 1) event(net, '#a', 'join', `n${j}`);
+    chat(net, '#a', 'alice', 'the one message');
+    const rows = listMessagesRenderable(net, '#a', { limit: 50, maxScan: 100 });
+    expect(rows).toHaveLength(100);
+    expect(rows.filter((e) => e.type === 'message')).toHaveLength(1);
+    expectContiguous(rows, net, '#a');
+    // Still contiguous with the tail, so the next page's cursor is valid.
+    expect(rows[rows.length - 1].text).toBe('the one message');
+  });
+
+  it('spends the budget on standalone lines that consolidation deliberately excludes', () => {
+    // kick/mode/topic each render as their own line — counting only
+    // message/action/notice would under-fill a buffer whose traffic is those.
+    const net = netFor('rend-standalone');
+    for (const type of ['kick', 'mode', 'topic', 'kick', 'mode']) {
+      event(net, '#a', type, 'alice');
+    }
+    const rows = listMessagesRenderable(net, '#a', { limit: 2 });
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.type)).toEqual(['kick', 'mode']);
+  });
+
+  it('treats every type shared/consolidate folds — and only those — as free', () => {
+    // Drift guard: the server must fold on the EXACT set the clients fold on,
+    // or a page is sized in a unit nobody renders.
+    const net = netFor('rend-types');
+    for (const type of CONSOLIDATABLE_TYPES) event(net, '#a', type, 'alice');
+    const noiseCount = CONSOLIDATABLE_TYPES.size;
+    chat(net, '#a', 'alice', 'the only renderable row');
+
+    const rows = listMessagesRenderable(net, '#a', { limit: 1 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text).toBe('the only renderable row');
+    // ...and asking for two pulls in the whole noise run behind it.
+    expect(listMessagesRenderable(net, '#a', { limit: 2 })).toHaveLength(noiseCount + 1);
   });
 });

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -1316,3 +1316,40 @@ describe('listMessagesRenderable', () => {
     expect(listMessagesRenderable(net, '#a', { limit: 2 })).toHaveLength(noiseCount + 1);
   });
 });
+
+describe('listMessagesAround countBy', () => {
+  it('sizes each side in renderable rows when asked', () => {
+    // A jump is a hydrate for any client that enters a buffer with a pending
+    // anchor (push tap, highlight, jump-to-first-unread), so an event-counted
+    // window lands them on the same near-blank screen (#10).
+    const user = createUser('around-renderable');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'me',
+    })!;
+    const ids: number[] = [];
+    for (let i = 1; i <= 20; i += 1) {
+      for (let j = 0; j < 10; j += 1) event(net.id, '#a', 'join', `n${j}`);
+      ids.push(chat(net.id, '#a', 'alice', `m${i}`).id);
+    }
+    const anchorId = ids[9]; // m10
+
+    const eventCounted = listMessagesAround(net.id, '#a', anchorId, 11);
+    const renderable = listMessagesAround(net.id, '#a', anchorId, 3, 'renderable');
+    const texts = (s: {
+      events: ReadonlyArray<{ type: string; text: string | null }>;
+    }): unknown[] => s.events.filter((e) => e.type === 'message').map((e) => e.text);
+
+    // 11 rows a side is one message either way — the churn ate the window.
+    expect(texts(eventCounted)).toEqual(['m9', 'm10', 'm11']);
+    // 3 renderable a side is three messages either way, anchor in the middle.
+    expect(texts(renderable)).toEqual(['m7', 'm8', 'm9', 'm10', 'm11', 'm12', 'm13']);
+    expect(renderable.events.find((e) => e.id === anchorId)).toBeDefined();
+    // Still one contiguous run, so the paging cursors either side stay valid.
+    const rendIds = renderable.events.map((e) => e.id);
+    expect(rendIds.at(-1)! - rendIds[0] + 1).toBe(rendIds.length);
+  });
+});

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { CONSOLIDATABLE_TYPES } from '../../shared/consolidate.js';
 
 /** A raw row from the `messages` table. */
 interface MessageRow {
@@ -196,6 +197,115 @@ export function listMessages(
   const params = before ? [networkId, target, before, limit] : [networkId, target, limit];
   const rows = db.prepare(sql).all(...params) as MessageRow[];
   return rows.map(rowToEvent).toReversed();
+}
+
+// --- Renderable-counted paging -------------------------------------------
+
+// The same page, sized in the unit the reader perceives.
+//
+// `listMessages` counts rows in the `messages` table. Clients render
+// CONSOLIDATED rows: a run of join/part/quit/nick/chghost collapses to one
+// summary line. So on a channel with heavy presence churn a 100-row page can
+// render as three visible lines — the client sees a short page, asks for
+// another, folds that one too, and the user watches the buffer assemble itself
+// (WS_PROTOCOL_FIXES #10). Only the server can see the type mix in a slice
+// before it ships it, so only the server can size the page correctly.
+//
+// "Renderable" is deliberately the COMPLEMENT of the set the clients fold on,
+// imported from shared/consolidate.ts rather than restated here — a `kick`,
+// `mode`, `topic`, `error` or `invite` each renders as its own standalone line
+// (consolidation excludes them on purpose), so each is worth one slot. Counting
+// only message/action/notice would still under-fill a buffer whose traffic is
+// kicks and topic edits.
+function isRenderableType(type: string): boolean {
+  return !CONSOLIDATABLE_TYPES.has(type);
+}
+
+// Bounds both the floor scan and the resulting payload. A netsplit can put tens
+// of thousands of joins between two sentences; past this many rows the page
+// simply ships fewer renderable rows than asked and `hasMoreOlder` stays true,
+// i.e. the pathological buffer degrades to today's behavior instead of shipping
+// a 50 MB frame. Without it the query is unbounded on exactly the buffers that
+// motivated the feature.
+export const RENDERABLE_MAX_SCAN = 2000;
+
+/**
+ * A page holding up to `limit` RENDERABLE rows, plus every consolidatable row
+ * interleaved with them (consolidation needs the whole run to summarize it
+ * accurately). Oldest-first, like `listMessages`.
+ *
+ * `before` pages backward (id < before), `afterId` pages forward (id > afterId),
+ * neither pages the newest slice — matching `listMessages`' cursor semantics so
+ * the two are interchangeable at the call site.
+ *
+ * The result is a CONTIGUOUS id range within the buffer, exactly like today's
+ * slice: `hasMoreOlder`, prepend-and-dedupe, and the `before: <oldest returned
+ * id>` paging cursor all keep working untouched, and there is no way for this to
+ * open a hole. That property is what makes it worth doing server-side rather
+ * than having clients over-fetch and trim.
+ *
+ * Two indexed reads, both on idx_messages_buffer(network_id, target, id DESC):
+ * a (id, type) scan to find the boundary row, then a fetch of the range it
+ * bounds.
+ */
+export function listMessagesRenderable(
+  networkId: number,
+  target: string,
+  {
+    before,
+    afterId,
+    limit = 100,
+    maxScan = RENDERABLE_MAX_SCAN,
+  }: { before?: number; afterId?: number; limit?: number; maxScan?: number } = {},
+): MessageEvent[] {
+  const forward = afterId != null && afterId > 0;
+
+  // Step 1: walk out from the cursor and stop at whichever comes first — the
+  // `limit`-th renderable row, or `maxScan` rows.
+  const scanSql = forward
+    ? `SELECT id, type FROM messages WHERE network_id = ? AND target = ? AND id > ? ORDER BY id ASC LIMIT ?`
+    : before
+      ? `SELECT id, type FROM messages WHERE network_id = ? AND target = ? AND id < ? ORDER BY id DESC LIMIT ?`
+      : `SELECT id, type FROM messages WHERE network_id = ? AND target = ? ORDER BY id DESC LIMIT ?`;
+  const cursor = forward ? afterId : before;
+  const scanParams: Array<number | string> = cursor
+    ? [networkId, target, cursor, maxScan]
+    : [networkId, target, maxScan];
+  const scanned = db.prepare(scanSql).all(...scanParams) as Array<{ id: number; type: string }>;
+  if (scanned.length === 0) return [];
+
+  // The last row to include. Landing ON the `limit`-th renderable row (rather
+  // than past it) leaves any adjacent noise for the NEXT page, where it will be
+  // consolidated with the rest of its run instead of dangling.
+  let boundary = scanned[scanned.length - 1].id;
+  let renderable = 0;
+  for (const row of scanned) {
+    if (!isRenderableType(row.type)) continue;
+    renderable += 1;
+    if (renderable === limit) {
+      boundary = row.id;
+      break;
+    }
+  }
+
+  // Step 2: ship the whole contiguous range, noise included.
+  const conds = ['network_id = ?', 'target = ?'];
+  const params: Array<number | string> = [networkId, target];
+  if (forward) {
+    conds.push('id > ?', 'id <= ?');
+    params.push(afterId as number, boundary);
+  } else {
+    conds.push('id >= ?');
+    params.push(boundary);
+    if (before) {
+      conds.push('id < ?');
+      params.push(before);
+    }
+  }
+  const rows = db
+    .prepare(`SELECT * FROM messages WHERE ${conds.join(' AND ')} ORDER BY id ASC`)
+    .all(...params) as MessageRow[];
+  return rows.map(rowToEvent);
 }
 
 // Bounded context window around an arbitrary message id. Used by the

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -318,6 +318,12 @@ export function listMessagesAround(
   target: string,
   anchorId: number,
   halfLimit = 100,
+  // Sizes each SIDE in renderable rows (#10). Matters more here than the name
+  // "jump" suggests: a client entering a buffer with a pending jump — a push
+  // notification, a highlight, jump-to-first-unread — hydrates from this slice
+  // and nothing else, so on a channel back from a netsplit an event-counted
+  // window is the same near-blank screenful the feature exists to remove.
+  countBy: 'event' | 'renderable' = 'event',
 ):
   | { events: MessageEvent[]; hasMoreOlder: boolean; hasMoreNewer: boolean }
   | { events: []; hasMoreOlder: false; hasMoreNewer: false; anchorMissing: true } {
@@ -327,8 +333,9 @@ export function listMessagesAround(
   if (!anchorRow) {
     return { events: [], hasMoreOlder: false, hasMoreNewer: false, anchorMissing: true };
   }
-  const older = listMessages(networkId, target, { before: anchorId, limit: halfLimit });
-  const newer = listMessages(networkId, target, { afterId: anchorId, limit: halfLimit });
+  const page = countBy === 'renderable' ? listMessagesRenderable : listMessages;
+  const older = page(networkId, target, { before: anchorId, limit: halfLimit });
+  const newer = page(networkId, target, { afterId: anchorId, limit: halfLimit });
   const events = [...older, rowToEvent(anchorRow), ...newer];
   const oldestId = events[0].id as number;
   const newestId = events[events.length - 1].id as number;

--- a/server/services/verbs/recentMessages.ts
+++ b/server/services/verbs/recentMessages.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { registerVerb } from '../verbRegistry.js';
-import { listMessages, hasOlderRow } from '../../db/messages.js';
+import { listMessages, listMessagesRenderable, hasOlderRow } from '../../db/messages.js';
 import { decorateMessage } from '../wsHub.js';
 
 /** Authenticated caller context passed to every verb handler. */
@@ -37,6 +37,15 @@ registerVerb({
         type: 'integer',
         description: 'Optional. Return only messages with id < before, for backward pagination.',
       },
+      countBy: {
+        type: 'string',
+        enum: ['event', 'renderable'],
+        description:
+          'What `limit` counts. "event" (default) counts every stored row. "renderable" counts ' +
+          'only rows that render as their own line — join/part/quit/nick/host-change events are ' +
+          'still returned, but do not spend the budget, so a channel full of presence churn ' +
+          'still yields a full page of readable content.',
+      },
     },
     required: ['networkId', 'target'],
     additionalProperties: false,
@@ -49,9 +58,13 @@ registerVerb({
     }
     const limit = Math.min(Math.max(Number(input.limit) || 100, 1), 500);
     const before = input.before ? Number(input.before) : undefined;
-    const events = listMessages(networkId, target, { before, limit }).map((e) =>
-      decorateMessage(ctx.userId, e),
-    );
+    // Unrecognized values fall back to today's behavior rather than erroring —
+    // the field is additive and an old caller never sends it at all.
+    const renderable = input.countBy === 'renderable';
+    const rows = renderable
+      ? listMessagesRenderable(networkId, target, { before, limit })
+      : listMessages(networkId, target, { before, limit });
+    const events = rows.map((e) => decorateMessage(ctx.userId, e));
     const oldestId = events.length ? events[0].id : 0;
     return {
       messages: events,

--- a/server/services/wsHub.history.test.ts
+++ b/server/services/wsHub.history.test.ts
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// `countBy:'renderable'` end to end, over a real socket (WS_PROTOCOL_FIXES #10).
+//
+// messages.test.ts proves the paging primitive. It cannot prove the thing that
+// actually broke for the user, which is the WIRING: each `history` mode reaches
+// the primitive by a different route — `latest` and `after` call it directly,
+// `before` goes through the `recent_messages` verb, whose input schema is
+// `additionalProperties:false` and would reject an undeclared field. A
+// function-level test passes with any one of those three wired up wrong.
+//
+// So: a real client, a real socket, one request per mode, against a channel
+// shaped like the one that motivated the feature — twenty messages buried under
+// a netsplit's worth of joins.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import { WebSocket } from 'ws';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const testDb = setupTestDb('wshub-history');
+
+const CHANNEL = '#noisy';
+// Per real message. Comfortably more than any `limit` used below, so an
+// event-counted page of that limit can only ever hold ONE message.
+const NOISE_PER_MESSAGE = 30;
+const MESSAGE_COUNT = 20;
+
+let server: http.Server;
+let userId: number;
+let networkId: number;
+let createSession: typeof import('../db/sessions.js').createSession;
+let url: string;
+/** Ids of the real messages, oldest first. */
+const messageIds: number[] = [];
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { createNetwork } = await import('../db/networks.js');
+  const { insertMessage } = await import('../db/messages.js');
+  const buffers = await import('../db/buffers.js');
+  ({ createSession } = await import('../db/sessions.js'));
+  const { attachWsHub } = await import('./wsHub.js');
+  // `history` mode 'before' delegates to the `recent_messages` verb, and the
+  // registry is populated by import side effect (server.ts does this at boot).
+  // Without it that one mode answers `error: history fetch failed`.
+  await import('./verbs/index.js');
+
+  userId = createUser('historyuser').id;
+  const net = createNetwork(userId, {
+    name: 'libera',
+    host: 'h',
+    port: 6697,
+    tls: true,
+    nick: 'historyuser',
+  });
+  networkId = net!.id;
+  buffers.ensureExists(userId, networkId, CHANNEL);
+
+  const put = (type: string, nick: string, text?: string): number =>
+    Number(
+      insertMessage({
+        networkId,
+        target: CHANNEL,
+        time: new Date().toISOString(),
+        type,
+        nick,
+        text: text ?? null,
+        self: false,
+      }).id,
+    );
+  for (let i = 1; i <= MESSAGE_COUNT; i += 1) {
+    for (let j = 0; j < NOISE_PER_MESSAGE; j += 1) put('join', `lurker${j}`);
+    messageIds.push(put('message', 'alice', `m${i}`));
+  }
+
+  server = http.createServer();
+  attachWsHub(server, 'history-test-secret');
+  server.listen(0);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test server did not bind synchronously to a TCP port');
+  }
+  server.unref();
+  url = `ws://127.0.0.1:${address.port}/ws`;
+});
+
+afterAll(() => {
+  server.close();
+  testDb.cleanup();
+});
+
+type Frame = Record<string, unknown>;
+interface HistoryReply extends Frame {
+  kind: 'history';
+  events: Array<{ id: number; type: string; text: string | null }>;
+  hasMoreOlder?: boolean;
+  hasMoreNewer?: boolean;
+}
+
+/**
+ * Connect, let the burst drain, send one `history` request and hand back its
+ * reply. Waiting for `backlog-complete` first is what keeps the connect frames
+ * from being mistaken for the answer.
+ */
+function requestHistory(request: Frame): Promise<HistoryReply> {
+  return new Promise((resolve, reject) => {
+    const { token } = createSession(userId);
+    const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
+    const seen: string[] = [];
+    let sent = false;
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error(`no history reply; got: ${seen.join(', ')}`));
+    }, 3000);
+    ws.on('message', (raw) => {
+      const frame = JSON.parse(raw.toString()) as Frame;
+      seen.push(String(frame.kind));
+      if (frame.kind === 'backlog-complete' && !sent) {
+        sent = true;
+        ws.send(JSON.stringify(request));
+        return;
+      }
+      // Surface a refused request as itself rather than as a timeout — the
+      // reason is in the frame, and waiting three seconds to say "no reply"
+      // throws it away.
+      if (frame.kind === 'error' && sent) {
+        clearTimeout(timer);
+        ws.close();
+        reject(new Error(`server refused the request: ${String(frame.text)}`));
+        return;
+      }
+      if (frame.kind !== 'history') return;
+      clearTimeout(timer);
+      ws.close();
+      resolve(frame as HistoryReply);
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+const realMessages = (reply: HistoryReply): string[] =>
+  reply.events.filter((e) => e.type === 'message').map((e) => e.text as string);
+
+describe("history countBy:'renderable' (#10)", () => {
+  it('fills a `latest` page with messages instead of presence churn', async () => {
+    const base = { type: 'history', mode: 'latest', networkId, target: CHANNEL, limit: 5 };
+
+    // Today's behavior, unchanged: five rows, four of them noise.
+    const eventCounted = await requestHistory(base);
+    expect(eventCounted.events).toHaveLength(5);
+    expect(realMessages(eventCounted)).toEqual(['m20']);
+
+    // The hydrate a client actually wants: five real messages, with their runs
+    // along for the ride so consolidation can still summarize them.
+    const renderable = await requestHistory({ ...base, countBy: 'renderable' });
+    expect(realMessages(renderable)).toEqual(['m16', 'm17', 'm18', 'm19', 'm20']);
+    expect(renderable.events.length).toBeGreaterThan(5);
+    // More history behind it, so the upward pager stays armed.
+    expect(renderable.hasMoreOlder).toBe(true);
+  });
+
+  it('honors countBy on `before` — the page that goes through the verb', async () => {
+    const reply = await requestHistory({
+      type: 'history',
+      networkId,
+      target: CHANNEL,
+      before: messageIds[10],
+      limit: 4,
+      countBy: 'renderable',
+    });
+    expect(realMessages(reply)).toEqual(['m7', 'm8', 'm9', 'm10']);
+    expect(reply.events.every((e) => e.id < messageIds[10])).toBe(true);
+    expect(reply.hasMoreOlder).toBe(true);
+  });
+
+  it('honors countBy on `after`', async () => {
+    const reply = await requestHistory({
+      type: 'history',
+      mode: 'after',
+      networkId,
+      target: CHANNEL,
+      afterId: messageIds[2],
+      limit: 3,
+      countBy: 'renderable',
+    });
+    expect(realMessages(reply)).toEqual(['m4', 'm5', 'm6']);
+    expect(reply.events.every((e) => e.id > messageIds[2])).toBe(true);
+    expect(reply.hasMoreNewer).toBe(true);
+  });
+
+  it('ships a contiguous id range, so paging can never open a hole', async () => {
+    // The property the whole design rests on: a renderable-counted page is the
+    // same shape as an event-counted one — a gapless run — so `before: <oldest
+    // returned id>` keeps working and a client that prepends-and-dedupes ends up
+    // with an unbroken buffer.
+    const page1 = await requestHistory({
+      type: 'history',
+      mode: 'latest',
+      networkId,
+      target: CHANNEL,
+      limit: 3,
+      countBy: 'renderable',
+    });
+    const page2 = await requestHistory({
+      type: 'history',
+      networkId,
+      target: CHANNEL,
+      before: page1.events[0].id,
+      limit: 3,
+      countBy: 'renderable',
+    });
+    const ids = [...page2.events, ...page1.events].map((e) => e.id);
+    expect(ids).toEqual([...ids].toSorted((a, b) => a - b));
+    expect(new Set(ids).size).toBe(ids.length); // no overlap between the pages
+    // Gapless: the two pages joined cover every id in their span. Message ids
+    // are a global sequence, but this buffer's rows were seeded contiguously.
+    expect(ids.at(-1)! - ids[0] + 1).toBe(ids.length);
+    expect(realMessages(page2)).toEqual(['m15', 'm16', 'm17']);
+  });
+
+  it('ignores an unknown countBy rather than erroring', async () => {
+    // Additive field, forward-compatible in both directions: a value this server
+    // doesn't know degrades to today's page instead of failing the request.
+    const reply = await requestHistory({
+      type: 'history',
+      mode: 'latest',
+      networkId,
+      target: CHANNEL,
+      limit: 5,
+      countBy: 'sausages',
+    });
+    expect(reply.kind).toBe('history');
+    expect(reply.events).toHaveLength(5);
+  });
+});

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -557,6 +557,44 @@ describe('handleOpenBuffer', () => {
     expect(frames.find((f) => f.kind === 'buffer-opened')?.target).toBe('#reopen');
   });
 
+  it("sizes the hydrate reply in rendered rows when asked (countBy:'renderable')", () => {
+    // For a client that hydrates with open-buffer rather than {mode:'latest'} —
+    // iOS does — this frame IS the first screenful, so it needs the same knob
+    // `history` carries (#10) or a netsplit-heavy channel opens looking blank.
+    buffers.ensureExists(userId, networkId, '#churn');
+    for (let i = 1; i <= 20; i += 1) {
+      for (let j = 0; j < 30; j += 1) {
+        insertMessage({
+          networkId,
+          target: '#churn',
+          time: new Date().toISOString(),
+          type: 'join',
+          nick: `n${j}`,
+          self: false,
+        });
+      }
+      seed('#churn', `m${i}`);
+    }
+    const messagesIn = (frames: Array<Record<string, unknown>>): unknown[] => {
+      const backlog = frames.find((f) => f.kind === 'backlog')!;
+      return (backlog.events as Array<Record<string, unknown>>)
+        .filter((e) => e.type === 'message')
+        .map((e) => e.text);
+    };
+
+    const plain = mockWs();
+    handleOpenBuffer(plain.ws, userId, networkId, '#churn');
+    const asked = mockWs();
+    handleOpenBuffer(asked.ws, userId, networkId, '#churn', 'renderable');
+
+    // The builder's fixed 200-row slice, spent on presence churn: seven messages
+    // out of twenty, and the client folds the other 193 rows into a few lines.
+    expect(messagesIn(plain.frames)).toEqual(['m14', 'm15', 'm16', 'm17', 'm18', 'm19', 'm20']);
+    // Asked in the unit it renders in, the same buffer hands back everything —
+    // the runs still ride along so consolidation can summarize them.
+    expect(messagesIn(asked.frames)).toHaveLength(20);
+  });
+
   it('joins a channel with no history instead of reopening', () => {
     const { ws, frames } = mockWs();
     handleOpenBuffer(ws, userId, networkId, '#never-visited');

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -3080,7 +3080,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           // halfLimit caps each side at the request's limit (default 100,
           // clamped 1..500). Total slice length tops out at 2*limit + 1.
           const halfLimit = limit;
-          const slice = listMessagesAround(histNetworkId, histTarget, anchorId, halfLimit);
+          const slice = listMessagesAround(histNetworkId, histTarget, anchorId, halfLimit, countBy);
           const events = slice.events.map((e) => decorateMessage(userId, e));
           send(ws, {
             ...baseReply,

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -27,6 +27,7 @@ import { findUserById, touchUserLastSeen } from '../db/users.js';
 import { effectiveUploadCapBytes } from './uploadLimits.js';
 import {
   listMessages,
+  listMessagesRenderable,
   listMessagesAround,
   hasOlderRow,
   hasNewerRow,
@@ -3023,6 +3024,19 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         }
         const limit = Math.min(Math.max(Number(msg.limit) || 100, 1), 500);
         const mode = typeof msg.mode === 'string' ? msg.mode : 'before';
+        // What `limit` counts (#10). 'renderable' sizes the page in the unit the
+        // reader perceives — consolidatable presence churn rides along for free
+        // instead of eating the budget — so one fetch fills a screen even on a
+        // channel that just came back from a netsplit. Default is today's
+        // behavior; an unknown value degrades to it rather than erroring, since
+        // this is an additive field an older client simply never sends.
+        //
+        // Only the CLIENT knows whether it actually folds those runs (web gates
+        // on chat.consolidate_joins), which is why this is a request field and
+        // not a server-side default: for a client rendering every event as its
+        // own line, 'event' is already the right unit.
+        const countBy: 'event' | 'renderable' =
+          msg.countBy === 'renderable' ? 'renderable' : 'event';
         const token = msg.token ?? null;
         const speakers = listSpeakers(histNetworkId, histTarget);
         const baseReply = {
@@ -3072,9 +3086,11 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
             send(ws, { kind: 'error', text: 'invalid afterId' });
             break;
           }
-          const events = listMessages(histNetworkId, histTarget, { afterId, limit }).map((e) =>
-            decorateMessage(userId, e),
-          );
+          const rows =
+            countBy === 'renderable'
+              ? listMessagesRenderable(histNetworkId, histTarget, { afterId, limit })
+              : listMessages(histNetworkId, histTarget, { afterId, limit });
+          const events = rows.map((e) => decorateMessage(userId, e));
           const newestId = events.length ? events[events.length - 1].id : afterId;
           send(ws, {
             ...baseReply,
@@ -3095,9 +3111,11 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           // upward paging cleanly, plus inputHistory so up-arrow recall is
           // restored for a shell (fresh-connect shells omit it, so this is the
           // only place a reloaded client gets its per-buffer recall back).
-          const events = listMessages(histNetworkId, histTarget, { limit }).map((e) =>
-            decorateMessage(userId, e),
-          );
+          const rows =
+            countBy === 'renderable'
+              ? listMessagesRenderable(histNetworkId, histTarget, { limit })
+              : listMessages(histNetworkId, histTarget, { limit });
+          const events = rows.map((e) => decorateMessage(userId, e));
           const oldestId = events.length ? events[0].id : 0;
           send(ws, {
             ...baseReply,
@@ -3130,6 +3148,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
               target: msg.target,
               before,
               limit,
+              countBy,
             },
           ) as { messages: WsPayload[]; hasOlder: boolean };
         } catch (_) {

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -736,9 +736,23 @@ function bufferStateFields(
 // buffer is reopened (the user clicked its channel name). Unlike the snapshot
 // loop this ignores the resume cursor and always ships the recent slice; the
 // client dedupes by id, so it's safe even if the buffer is already open.
-export function buildBufferBacklog(userId: number, networkId: number, target: string): WsPayload {
+// `countBy` is the same knob `history` carries (#10) and matters for the same
+// reason: for a client that hydrates with `open-buffer` rather than
+// `{mode:'latest'}` — iOS does — this frame IS the first screenful, so sizing it
+// in stored rows is what leaves a netsplit-heavy channel looking blank on open.
+// Defaults to 'event' so the snapshot's offline `:server:` frames (which have no
+// caller to ask) are untouched.
+export function buildBufferBacklog(
+  userId: number,
+  networkId: number,
+  target: string,
+  countBy: 'event' | 'renderable' = 'event',
+): WsPayload {
   const conn = ircManager.getConnection(userId, networkId);
-  const rows = listMessages(networkId, target, { limit: 200 });
+  const rows =
+    countBy === 'renderable'
+      ? listMessagesRenderable(networkId, target, { limit: 200 })
+      : listMessages(networkId, target, { limit: 200 });
   const events = rows.map((e) => decorateMessage(userId, e));
   const oldestId = rows.length ? (rows[0].id ?? 0) : 0;
   return {
@@ -1167,6 +1181,7 @@ export function handleOpenBuffer(
   userId: number,
   networkId: number,
   requested: string,
+  countBy: 'event' | 'renderable' = 'event',
 ): void {
   if (!networkId || !requested || requested.startsWith(':server:')) return;
   const row = getBuffer(userId, networkId, requested);
@@ -1188,7 +1203,7 @@ export function handleOpenBuffer(
     kindForTarget(requested) === 'channel' && !!conn?.channels.has(requested.toLowerCase());
   if (row && (hasMessageForTarget(networkId, row.target) || inChannel)) {
     reopenBufferRow(userId, networkId, row.target);
-    send(ws, buildBufferBacklog(userId, networkId, row.target));
+    send(ws, buildBufferBacklog(userId, networkId, row.target, countBy));
     send(ws, { kind: 'buffer-opened', networkId, target: row.target });
   } else if (requested.startsWith('#')) {
     ircManager.joinChannel(userId, networkId, requested);
@@ -1200,7 +1215,7 @@ export function handleOpenBuffer(
     // buffer that never JOINs — those fall through as a no-op, exactly as the
     // pre-registry code behaved.
     const { record } = ensureBufferOpen(userId, networkId, requested);
-    send(ws, buildBufferBacklog(userId, networkId, record.target));
+    send(ws, buildBufferBacklog(userId, networkId, record.target, countBy));
     send(ws, { kind: 'buffer-opened', networkId, target: record.target });
   }
 }
@@ -2545,6 +2560,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           userId,
           Number(msg.networkId),
           typeof msg.target === 'string' ? msg.target : '',
+          msg.countBy === 'renderable' ? 'renderable' : 'event',
         );
         break;
       case 'part':

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -325,6 +325,7 @@ import {
   formatDayLabel,
 } from '../utils/timestamp.js';
 import { consolidateRows } from '../utils/consolidate.js';
+import { historyCountBy } from '../lib/historyPaging.js';
 import type { ConsolidationGroup, NickEntry, RenameEntry } from '../../../shared/consolidate.js';
 import { collapseDisplay } from '../utils/collapseDisplay.js';
 import { parseRelayMessage } from '../../../shared/parseRelay.js';
@@ -1394,6 +1395,7 @@ function requestMoreHistory() {
     target: buf.target,
     before,
     limit: 100,
+    countBy: historyCountBy(),
   });
 }
 
@@ -1418,6 +1420,7 @@ function requestNewerHistory() {
     target: buf.target,
     afterId,
     limit: 100,
+    countBy: historyCountBy(),
   });
 }
 

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -62,6 +62,7 @@ import { useSettingsStore } from '../stores/settings.js';
 import { useMircPalette } from '../composables/useNickColors.js';
 import { useMediaViewer } from '../composables/useMediaViewer.js';
 import { socketSend } from '../composables/useSocket.js';
+import { historyCountBy } from '../lib/historyPaging.js';
 import { mediaKindForUrl } from '../utils/uploadHostMatch.js';
 import SpoilerText from './SpoilerText.vue';
 
@@ -149,6 +150,14 @@ function openChannel(channel: string): void {
     buffers.activate(nid, existing.target);
     return;
   }
-  socketSend({ type: 'open-buffer', networkId: nid, target: channel });
+  // The reply re-seeds history for a since-closed buffer, making this frame the
+  // first screenful for a channel we don't hold — so it gets sized in the unit
+  // we render in, same as any other hydrate (§8).
+  socketSend({
+    type: 'open-buffer',
+    networkId: nid,
+    target: channel,
+    countBy: historyCountBy(),
+  });
 }
 </script>

--- a/vue_client/src/lib/historyPaging.ts
+++ b/vue_client/src/lib/historyPaging.ts
@@ -20,8 +20,19 @@
 
 import { useSettingsStore } from '../stores/settings.js';
 
+// Until the settings bootstrap lands we don't know which the user chose, and the
+// two wrong answers aren't equally wrong. Guessing 'renderable' for someone who
+// turned consolidation OFF hands them a page of up to the server's whole scan
+// window, rendered line by line — the exact thing this gate exists to prevent.
+// Guessing 'event' for someone who left it ON just means their first page is
+// sized the way every page was before this feature, and the next scroll corrects
+// it. So: no opinion until we have one. (`settings.effective` would otherwise
+// answer from the registry default, which is `true` — a real preference for the
+// majority, but not one we've been told.)
 export type HistoryCountBy = 'event' | 'renderable';
 
 export function historyCountBy(): HistoryCountBy {
-  return useSettingsStore().effective('chat.consolidate_joins') ? 'renderable' : 'event';
+  const settings = useSettingsStore();
+  if (!settings.loaded) return 'event';
+  return settings.effective('chat.consolidate_joins') ? 'renderable' : 'event';
 }

--- a/vue_client/src/lib/historyPaging.ts
+++ b/vue_client/src/lib/historyPaging.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// What `limit` counts on a `history` request.
+//
+// The server sizes a page in stored rows; we render CONSOLIDATED rows, folding
+// each run of join/part/quit/nick/chghost into one summary line. On a channel
+// coming back from a netsplit that mismatch is the difference between a full
+// screen and three visible lines — we'd fetch, fold, notice the page was short,
+// fetch again, and the user would watch the buffer assemble itself.
+// `countBy:'renderable'` asks the server to spend the budget only on rows that
+// render as their own line; the presence churn still arrives (consolidation
+// needs the whole run to summarize it) but no longer eats the page.
+//
+// Asking for it is only correct WHEN WE ACTUALLY FOLD. With
+// `chat.consolidate_joins` off every event renders as its own line, so 'event'
+// is already the right unit — and asking for 'renderable' there would pull the
+// server's whole scan window (up to 2000 rows) into a page the user then sees
+// in full. Hence the gate: the unit we request must match the unit we render.
+
+import { useSettingsStore } from '../stores/settings.js';
+
+export type HistoryCountBy = 'event' | 'renderable';
+
+export function historyCountBy(): HistoryCountBy {
+  return useSettingsStore().effective('chat.consolidate_joins') ? 'renderable' : 'event';
+}

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -30,6 +30,7 @@ vi.mock('../composables/useSocket.js', () => ({
 }));
 
 import { useBuffersStore, bufferNeedsHydration } from './buffers.js';
+import { useSettingsStore } from './settings.js';
 import { socketSend } from '../composables/useSocket.js';
 
 // The store always seeds the app-scoped system buffer (#355). These tests assert
@@ -706,5 +707,90 @@ describe('hydration lifecycle (blank-buffer fix)', () => {
         expect.objectContaining({ type: 'history', mode: 'latest', target: '#a' }),
       );
     });
+  });
+});
+
+// WS_PROTOCOL_FIXES #10. Two halves of one rule: ask the server to size a page
+// in the unit we render it in, and don't let our own ring silently swallow the
+// extra rows that unit brings with it.
+describe('renderable-counted history paging', () => {
+  const useSettings = () => useSettingsStore();
+
+  it('asks for renderable-counted pages while consolidation is on', () => {
+    const store = useBuffersStore();
+    vi.mocked(socketSend).mockReturnValue(true);
+
+    store.reattachToLive(1, '#a');
+
+    expect(socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'history', mode: 'latest', countBy: 'renderable' }),
+    );
+  });
+
+  it('falls back to event counting when the user turned consolidation off', () => {
+    // With every event rendering as its own line, 'event' IS the unit we render
+    // in — and asking for 'renderable' would drag the server's whole scan window
+    // into a page the user then sees in full.
+    const store = useBuffersStore();
+    useSettings().values['chat.consolidate_joins'] = false;
+    vi.mocked(socketSend).mockReturnValue(true);
+
+    store.reattachToLive(1, '#a');
+
+    expect(socketSend).toHaveBeenCalledWith(expect.objectContaining({ countBy: 'event' }));
+  });
+
+  it('re-arms the upward pager when a latest slice overflows the ring', () => {
+    // The server computes hasMoreOlder against the WHOLE slice it sent. A
+    // renderable-counted page can exceed our 500-row ring (a netsplit's noise
+    // rides along), and honoring a `false` after trimming would strand the pager
+    // on history we evicted ourselves.
+    const store = useBuffersStore();
+    vi.mocked(socketSend).mockReturnValue(true);
+    store.reattachToLive(1, '#a');
+    const token = store.byKey('1::#a')!.pendingHistoryToken;
+
+    const events = Array.from({ length: 600 }, (_, i) => ({
+      networkId: 1,
+      target: '#a',
+      id: i + 1,
+      type: 'message',
+      nick: 'bob',
+      body: 'x',
+    }));
+    store.applyLatestReplace(1, '#a', { token, events, hasMoreOlder: false });
+
+    const buf = store.byKey('1::#a')!;
+    expect(buf.messages).toHaveLength(500);
+    expect(buf.messages[0].id).toBe(101); // oldest 100 evicted
+    expect(buf.hasMoreOlder).toBe(true);
+  });
+
+  it('re-arms the upward pager when appendHistory evicts off the old edge', () => {
+    const store = useBuffersStore();
+    vi.mocked(socketSend).mockReturnValue(true);
+    store.reattachToLive(1, '#a');
+    const token = store.byKey('1::#a')!.pendingHistoryToken;
+    const row = (id: number) => ({
+      networkId: 1,
+      target: '#a',
+      id,
+      type: 'message',
+      nick: 'bob',
+      body: 'x',
+    });
+    store.applyLatestReplace(1, '#a', {
+      token,
+      events: Array.from({ length: 500 }, (_, i) => row(i + 1)),
+      hasMoreOlder: false,
+    });
+    const buf = store.byKey('1::#a')!;
+    expect(buf.hasMoreOlder).toBe(false); // nothing evicted yet
+
+    store.appendHistory(1, '#a', [row(501), row(502)], false, undefined);
+
+    expect(buf.messages).toHaveLength(500);
+    expect(buf.messages[0].id).toBe(3);
+    expect(buf.hasMoreOlder).toBe(true);
   });
 });

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -714,10 +714,16 @@ describe('hydration lifecycle (blank-buffer fix)', () => {
 // in the unit we render it in, and don't let our own ring silently swallow the
 // extra rows that unit brings with it.
 describe('renderable-counted history paging', () => {
-  const useSettings = () => useSettingsStore();
+  /** Settings as they are once the bootstrap has landed. */
+  const settingsLoaded = (consolidate: boolean) => {
+    const settings = useSettingsStore();
+    settings.loaded = true;
+    settings.values['chat.consolidate_joins'] = consolidate;
+  };
 
   it('asks for renderable-counted pages while consolidation is on', () => {
     const store = useBuffersStore();
+    settingsLoaded(true);
     vi.mocked(socketSend).mockReturnValue(true);
 
     store.reattachToLive(1, '#a');
@@ -732,7 +738,22 @@ describe('renderable-counted history paging', () => {
     // in — and asking for 'renderable' would drag the server's whole scan window
     // into a page the user then sees in full.
     const store = useBuffersStore();
-    useSettings().values['chat.consolidate_joins'] = false;
+    settingsLoaded(false);
+    vi.mocked(socketSend).mockReturnValue(true);
+
+    store.reattachToLive(1, '#a');
+
+    expect(socketSend).toHaveBeenCalledWith(expect.objectContaining({ countBy: 'event' }));
+  });
+
+  it('holds off on renderable pages until the settings bootstrap lands', () => {
+    // The registry default is `true`, so `effective` would answer 'renderable'
+    // here — for a user who may well have turned consolidation off. Of the two
+    // wrong guesses that's the damaging one (a scan window rendered line by
+    // line); guessing 'event' just means the first page is sized the way every
+    // page used to be, and the next scroll corrects it.
+    const store = useBuffersStore();
+    expect(useSettingsStore().loaded).toBe(false);
     vi.mocked(socketSend).mockReturnValue(true);
 
     store.reattachToLive(1, '#a');
@@ -791,6 +812,117 @@ describe('renderable-counted history paging', () => {
 
     expect(buf.messages).toHaveLength(500);
     expect(buf.messages[0].id).toBe(3);
+    expect(buf.hasMoreOlder).toBe(true);
+  });
+});
+
+// The other half of "a page can now be bigger than the ring": what an
+// INCREMENTAL merge does with one. Both of these are silent when wrong — the
+// reader just ends up looking at the wrong content, or at a buffer with a hole
+// in it — so they're pinned rather than reasoned about.
+describe('oversized history pages vs the in-memory ring', () => {
+  const row = (id: number) => ({
+    networkId: 1,
+    target: '#a',
+    id,
+    type: 'message',
+    nick: 'bob',
+    body: 'x',
+  });
+
+  /** Hydrate '#a' with `count` rows, ids 1..count. */
+  const seed = (store: ReturnType<typeof useBuffersStore>, count: number) => {
+    vi.mocked(socketSend).mockReturnValue(true);
+    store.reattachToLive(1, '#a');
+    store.applyLatestReplace(1, '#a', {
+      token: store.byKey('1::#a')!.pendingHistoryToken,
+      events: Array.from({ length: count }, (_, i) => row(i + 1)),
+      hasMoreOlder: true,
+    });
+    return store.byKey('1::#a')!;
+  };
+
+  it('keeps the reader’s context when an append page dwarfs the ring', () => {
+    // A renderable-counted `after` page can be thousands of rows. Merged
+    // wholesale it would evict every row held, MessageList would read both ends
+    // changing as a wholesale replace, and a detached reader's scroll position
+    // would point at content that no longer exists.
+    const store = useBuffersStore();
+    const buf = seed(store, 500);
+
+    store.appendHistory(
+      1,
+      '#a',
+      Array.from({ length: 2000 }, (_, i) => row(501 + i)),
+      false,
+      undefined,
+    );
+
+    expect(buf.messages).toHaveLength(500);
+    // The previous tail survived, which is what tells the scroll watcher this
+    // was an append and not a re-snapshot.
+    expect(buf.messages.some((m) => m.id === 500)).toBe(true);
+    // Contiguous, and the page we didn't take is still fetchable.
+    expect(buf.messages.at(-1)!.id).toBe(750);
+    expect(buf.hasMoreNewer).toBe(true);
+  });
+
+  it('takes the adjacent end of an oversized prepend page and stays contiguous', () => {
+    const store = useBuffersStore();
+    // Hold ids 1000..1099 (seed() emits 1..100, so shift them up).
+    vi.mocked(socketSend).mockReturnValue(true);
+    store.reattachToLive(1, '#a');
+    store.applyLatestReplace(1, '#a', {
+      token: store.byKey('1::#a')!.pendingHistoryToken,
+      events: Array.from({ length: 100 }, (_, i) => row(1000 + i)),
+      hasMoreOlder: true,
+    });
+    const buf = store.byKey('1::#a')!;
+
+    // 900 older rows, ids 100..999 — contiguous, ending right below what we hold.
+    store.prependHistory(
+      1,
+      '#a',
+      Array.from({ length: 900 }, (_, i) => row(100 + i)),
+      false,
+      undefined,
+    );
+
+    // We took the NEWEST 250 of the page, so the merged slice is one gapless run
+    // ending where it did before. Taking the oldest 250 instead would have left
+    // a 650-row hole in the middle with nothing to signal it.
+    const ids = buf.messages.map((m) => m.id);
+    expect(ids[0]).toBe(750);
+    expect(ids.at(-1)).toBe(1099);
+    expect(ids).toEqual(Array.from({ length: 350 }, (_, i) => 750 + i));
+    expect(buf.oldestId).toBe(750);
+    // We deliberately didn't take the whole page, so the pager stays armed even
+    // though the server said there was nothing older.
+    expect(buf.hasMoreOlder).toBe(true);
+  });
+
+  it('re-anchors the paging cursor when a live line evicts the rows it pointed at', () => {
+    // prependHistory doesn't trim (the reader is walking backwards), so paging
+    // up grows the buffer past the ring and the NEXT live line re-imposes it.
+    // Leaving oldestId pointing at an evicted row makes the following upward
+    // page non-contiguous — a silent hole with nothing to signal it.
+    const store = useBuffersStore();
+    const buf = seed(store, 500);
+    store.prependHistory(
+      1,
+      '#a',
+      Array.from({ length: 200 }, (_, i) => row(i - 199)),
+      true,
+      undefined,
+    );
+    expect(buf.messages).toHaveLength(700); // over the ring, by design
+    const staleOldest = buf.oldestId;
+
+    store.pushMessage(row(501));
+
+    expect(buf.messages).toHaveLength(500);
+    expect(buf.oldestId).not.toBe(staleOldest);
+    expect(buf.oldestId).toBe(buf.messages[0].id); // the cursor tracks what survived
     expect(buf.hasMoreOlder).toBe(true);
   });
 });

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -6,6 +6,7 @@ import { useNetworksStore } from './networks.js';
 import { useToastsStore } from './toasts.js';
 import { socketSend } from '../composables/useSocket.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
+import { historyCountBy } from '../lib/historyPaging.js';
 
 const MAX_PER_BUFFER = 500;
 const MAX_SPEAKERS = 128;
@@ -584,13 +585,15 @@ export const useBuffersStore = defineStore('buffers', {
         (e) => (e.id == null || !existing.has(e.id)) && e.type !== 'away' && e.type !== 'back',
       );
       const combined = [...buf.messages, ...fresh];
-      buf.messages =
-        combined.length > MAX_PER_BUFFER
-          ? combined.slice(combined.length - MAX_PER_BUFFER)
-          : combined;
+      const evictedOlder = combined.length > MAX_PER_BUFFER;
+      buf.messages = evictedOlder ? combined.slice(combined.length - MAX_PER_BUFFER) : combined;
       buf.oldestId = buf.messages[0]?.id ?? buf.oldestId;
       buf.newestId = buf.messages[buf.messages.length - 1]?.id ?? buf.newestId;
       buf.hasMoreNewer = !!hasMoreNewer;
+      // We just evicted rows off the old edge, so there is provably more older
+      // history than we hold — whatever the pager thought before. Re-arming it
+      // here is what keeps the eviction from reading as "start of buffer".
+      if (evictedOlder) buf.hasMoreOlder = true;
       buf.loadingHistory = false;
       if (speakers !== undefined) this.seedSpeakers(networkId, target, speakers);
     },
@@ -662,7 +665,9 @@ export const useBuffersStore = defineStore('buffers', {
       buf.messages = filtered.slice(-MAX_PER_BUFFER);
       buf.oldestId = buf.messages[0]?.id ?? null;
       buf.newestId = buf.messages[buf.messages.length - 1]?.id ?? null;
-      buf.hasMoreOlder = !!payload.hasMoreOlder;
+      // Same eviction rule as applyLatestReplace: an `around` window tops out at
+      // 2×limit+1 rows, which already exceeds the ring at the default limit.
+      buf.hasMoreOlder = filtered.length > buf.messages.length || !!payload.hasMoreOlder;
       buf.hasMoreNewer = !!payload.hasMoreNewer;
       buf.pendingHistoryToken = null;
       buf.loadingHistory = false;
@@ -692,6 +697,9 @@ export const useBuffersStore = defineStore('buffers', {
         target,
         token,
         limit,
+        // This is the hydrate — the fetch that fills the FIRST screenful, and so
+        // the one the spin-loop was most visible on.
+        countBy: historyCountBy(),
       });
       // socketSend returns false when the socket isn't open. No response will
       // arrive to clear loadingHistory — so without this rollback the buffer
@@ -741,6 +749,12 @@ export const useBuffersStore = defineStore('buffers', {
         (e: BufferMessage) => e.type !== 'away' && e.type !== 'back',
       );
       buf.messages = filtered.slice(-MAX_PER_BUFFER);
+      // The ring dropped rows off the old edge. `payload.hasMoreOlder` was
+      // computed by the server against the WHOLE slice it sent, so honoring a
+      // `false` here would strand the pager on history we evicted ourselves —
+      // and countBy:'renderable' can legitimately make a slice bigger than the
+      // ring (a netsplit's worth of noise rides along with the page).
+      const evictedOlder = filtered.length > buf.messages.length;
       buf.oldestId = buf.messages[0]?.id ?? null;
       buf.newestId = buf.messages[buf.messages.length - 1]?.id ?? null;
       // A token-matched latest reply is TERMINAL hydration even when every row
@@ -752,7 +766,7 @@ export const useBuffersStore = defineStore('buffers', {
       // messages yet." between attempts. Clamping to false costs nothing: an
       // empty buffer has no anchor row, so the upward pager can't page it
       // anyway.
-      buf.hasMoreOlder = filtered.length > 0 ? !!payload.hasMoreOlder : false;
+      buf.hasMoreOlder = filtered.length > 0 ? evictedOlder || !!payload.hasMoreOlder : false;
       buf.hasMoreNewer = false;
       buf.detached = false;
       buf.liveDuringDetach = 0;

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -9,6 +9,23 @@ import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { historyCountBy } from '../lib/historyPaging.js';
 
 const MAX_PER_BUFFER = 500;
+// The most rows one INCREMENTAL merge (prepend/append) may take from a single
+// page. Deliberately well under MAX_PER_BUFFER, so a merge can never evict the
+// rows the reader is looking at.
+//
+// `countBy:'renderable'` makes this reachable: a page is sized in rows that
+// render standalone, and the presence churn rides along with them, so one page
+// can legitimately be several times the ring. Merging it wholesale would drop
+// the entire held slice — appendHistory would leave nothing of the previous
+// tail, MessageList would read both ends changing as a wholesale replace
+// (`MessageList.vue:1644`), and a detached reader's scrollTop would be left
+// pointing at content that no longer exists.
+//
+// Nothing is lost by trimming: we keep the end ADJACENT to what we already
+// hold, so the slice stays contiguous and the pager fetches the remainder on
+// the next scroll — which is why a trim forces the matching hasMore flag true
+// regardless of what the server reported for the full page.
+const MAX_MERGE_ROWS = 250;
 const MAX_SPEAKERS = 128;
 const TYPING_DURATIONS: Record<string, number> = { active: 6000, paused: 30000 };
 
@@ -401,8 +418,20 @@ export const useBuffersStore = defineStore('buffers', {
       // so it can skip unread/highlight side effects too.
       if (event.id != null && event.id <= prevMaxId) return false;
       buf.messages.push(event);
-      if (buf.messages.length > MAX_PER_BUFFER)
+      if (buf.messages.length > MAX_PER_BUFFER) {
         buf.messages.splice(0, buf.messages.length - MAX_PER_BUFFER);
+        // The ring just evicted the rows `oldestId` pointed at — reachable
+        // whenever paging up has grown the buffer past the cap, since
+        // prependHistory doesn't trim (the reader is walking backwards; the ring
+        // is re-imposed here, on the next live line). Leaving the cursor stale
+        // makes the next upward page ask for `before: <an id we no longer hold>`
+        // and prepend a slice that isn't contiguous with what's on screen — a
+        // silent hole between the two, with nothing to signal it. Re-anchor on
+        // what survived, and re-arm the pager: there is now provably more older
+        // history than we hold.
+        buf.oldestId = buf.messages[0]?.id ?? buf.oldestId;
+        buf.hasMoreOlder = true;
+      }
       if (buf.oldestId == null && event.id != null) buf.oldestId = event.id;
       // Active-divider tracking + live mark-read. Applies to the system buffer
       // too (#355): it's now a normal buffer with a server-owned read pointer
@@ -556,10 +585,14 @@ export const useBuffersStore = defineStore('buffers', {
       const fresh = events.filter(
         (e) => (e.id == null || !existing.has(e.id)) && e.type !== 'away' && e.type !== 'back',
       );
-      buf.messages = [...fresh, ...buf.messages];
+      // Keep the NEWEST rows of an oversized page — they're the ones adjacent to
+      // what we hold, so the merged slice stays contiguous.
+      const trimmed = fresh.length > MAX_MERGE_ROWS;
+      const page = trimmed ? fresh.slice(-MAX_MERGE_ROWS) : fresh;
+      buf.messages = [...page, ...buf.messages];
       const first = buf.messages[0];
       buf.oldestId = first?.id ?? buf.oldestId;
-      buf.hasMoreOlder = !!hasMoreOlder;
+      buf.hasMoreOlder = trimmed || !!hasMoreOlder;
       buf.loadingHistory = false;
       buf.unseeded = false;
       if (speakers !== undefined) this.seedSpeakers(networkId, target, speakers);
@@ -584,12 +617,17 @@ export const useBuffersStore = defineStore('buffers', {
       const fresh = events.filter(
         (e) => (e.id == null || !existing.has(e.id)) && e.type !== 'away' && e.type !== 'back',
       );
-      const combined = [...buf.messages, ...fresh];
+      // Keep the OLDEST rows of an oversized page — the ones adjacent to our
+      // tail — so the merged slice stays contiguous and the reader's context
+      // survives the ring's eviction.
+      const trimmed = fresh.length > MAX_MERGE_ROWS;
+      const page = trimmed ? fresh.slice(0, MAX_MERGE_ROWS) : fresh;
+      const combined = [...buf.messages, ...page];
       const evictedOlder = combined.length > MAX_PER_BUFFER;
       buf.messages = evictedOlder ? combined.slice(combined.length - MAX_PER_BUFFER) : combined;
       buf.oldestId = buf.messages[0]?.id ?? buf.oldestId;
       buf.newestId = buf.messages[buf.messages.length - 1]?.id ?? buf.newestId;
-      buf.hasMoreNewer = !!hasMoreNewer;
+      buf.hasMoreNewer = trimmed || !!hasMoreNewer;
       // We just evicted rows off the old edge, so there is provably more older
       // history than we hold — whatever the pager thought before. Re-arming it
       // here is what keeps the eviction from reading as "start of buffer".
@@ -640,6 +678,7 @@ export const useBuffersStore = defineStore('buffers', {
         anchorId,
         token,
         limit: halfLimit,
+        countBy: historyCountBy(),
       });
       // Same rollback rationale as reattachToLive — a failed send leaves no
       // response to clear the loading flag. Restoring detached to its prior


### PR DESCRIPTION
Open a busy channel and the first screenful is nearly blank, then fills in staccato as the client pages again and again. A `history` fetch of 100 returns 100 rows from the `messages` table; the client folds runs of join/part/quit/nick/chghost into one summary line, so on a channel coming back from a netsplit 100 rows can render as three visible lines. The client sees a short page, asks for more, folds that too, and the user watches the buffer assemble itself.

Nobody was translating between the two units, and the client is the one party that can't: knowing its page was mostly noise requires fetching it. The server can see the type mix in a slice before it ships it.

Closes WS_PROTOCOL_FIXES #10 (PR 4 of that list).

## The change

`countBy: 'event' | 'renderable'` on `history` (every mode), on the `recent_messages` verb behind the `before` path, and on `open-buffer`. `renderable` spends the budget only on rows that render standalone — deliberately the **complement** of `shared/consolidate.ts`'s fold set, imported rather than restated, so a `kick`, `mode` or `topic` still counts. The consolidatable rows ride along for free, since consolidation needs the whole run to summarize it accurately.

Two places beyond the original plan:

- **`open-buffer`**, because that reply is what iOS hydrates with — without it the fix reaches iOS's scroll-up pager but not the screenful the symptom is about.
- **`around`**, because on iOS `hydrateIfNeeded` returns early while a jump is pending, so a push tap / highlight / jump-to-first-unread never sends `open-buffer` at all. The `around` slice *is* the first screenful there.

## Why it can't open a hole

The slice stays a contiguous id range, exactly like today's: `hasMoreOlder`, prepend-and-dedupe and the `before: <oldest returned id>` cursor are untouched. That property is what makes it worth doing at the server rather than having clients over-fetch and trim.

The scan is capped at 2000 rows and **that cap is the whole safety story** — past it the page ships fewer renderable rows than asked and `hasMoreOlder` stays true, so a buffer with tens of thousands of joins between two sentences degrades to today's behavior instead of shipping a huge frame.

## The second-order cost: a page can now exceed the client's ring

The web keeps 500 rows/buffer. A renderable page can be four times that, and three separate things assumed it couldn't. All are fixed here; the first two are silent when wrong.

- **An incremental merge could evict the reader's context.** A 2000-row `after` page into a 500-row ring leaves nothing of the previous tail, so `MessageList` reads both ends changing as a wholesale replace, takes the detached branch, and returns without any scroll correction — the viewport silently swaps to different content. `prependHistory`/`appendHistory` now take at most `MAX_MERGE_ROWS` (250) from one page, from the end **adjacent** to what's held, so the merge stays contiguous. A trim forces the matching `hasMore` flag true.
- **A live line could strand the paging cursor.** `prependHistory` doesn't trim, so the ring is re-imposed by `pushMessage`'s splice on the next live message — and that splice never updated `oldestId`. The following upward page then asked for `before: <an id we no longer hold>` and prepended non-contiguously. Pre-existing (reachable after ~5 pages up), but one renderable page now clears the cap alone.
- **`hasMoreOlder` describes the slice the server sent**, so trimming it into the ring without re-arming the pager stranded the buffer on history the client evicted itself.

## Client-side gating

Both clients ask for `renderable` only while `chat.consolidate_joins` is on — with every event rendering as its own line, `event` is already the right unit, and `renderable` would drag a full scan window into a page the user then sees in full.

The web additionally waits for `settings.loaded`: `effective()` answers from the registry default (`true`) before bootstrap, which would have handed a scan window to precisely the users who opted out. The two wrong guesses aren't symmetric — guessing `event` just costs a short first page.

## Tests

- `server/db/messages.test.ts` — the primitive: cap boundary, all-noise buffer, fewer renderables than `limit`, empty buffer, contiguity across pages both directions, and a drift guard asserting the fold set is exactly `CONSOLIDATABLE_TYPES`.
- `server/services/wsHub.history.test.ts` (new) — the wiring, over a real socket. Each mode reaches the primitive by a different route, and this caught `before` answering `error` because the verb registry is populated by an import side effect.
- `vue_client/src/stores/buffers.test.ts` — the gate both ways plus pre-bootstrap, and the three ring interactions above. I broke each fix and confirmed the tests fail before restoring.

`npm run check` clean, `npm test` 3006 passed. Reviewed with `/code-review high`; every finding is addressed above.

## Worth watching in QA

iOS has no ring, and `ChatViewController.apply()` re-consolidates and reloads the whole buffer on every state change. A hydrate can now be up to 2000 rows (`around` up to double), so each subsequent live line pays that on the main thread — on exactly the channels this targets. Unmeasured; the lever is `RENDERABLE_MAX_SCAN`.

Additive throughout — no `PROTOCOL_VERSION` bump. An older server ignores the field; an older client never sends it. Pairs with amiantos/lurker-ios#79, which can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)