### PR TITLE
Take hydration off open-buffer, and announce a real open

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -305,7 +305,7 @@ excluded from the announcement.
 >
 > You don't need a `buffer-opened` handler to _materialize_ the buffer — the
 > shell that travels with it already does, the same way every other
-> buffer-creating frame works (§9.1). `buffer-reopened` (`wsHub.ts:1618`) is
+> buffer-creating frame works (§9.1). `buffer-reopened` (`wsHub.ts:1815`) is
 > still emitted separately, when an incoming _event_ outranks a closed flag
 > rather than a verb doing it.
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -242,7 +242,9 @@ Two things that look like they'd answer the same question and don't:
   membership from it and you'll decide a user left channels they're still in.
 - **Don't probe with `open-buffer`.** For a `#channel` with no row the server
   reads that as "join it" (§9.1), so a probe silently re-JOINs a channel the
-  user deliberately left from another client.
+  user deliberately left from another client. `{type:'history', mode:'latest'}`
+  (§4.3) is the read — it answers for any target without creating, reopening, or
+  joining anything.
 
 An older server never sends frame 8 (it's additive, and `protocolVersion` does
 not move for it) — if you don't see one, keep whatever you do today rather than
@@ -254,30 +256,58 @@ never claims a buffer is missing.
 buffers arrive as _shells_: `{kind:'backlog', …, events:[], mode:'shell',
 hasMoreOlder:true}` — "this buffer exists; fetch content when the user opens it."
 
-Hydrate a shell with **`{type:'history', mode:'latest'}`**. It is a pure read.
-If you consolidate presence noise, send `countBy:'renderable'` with it (§8) —
-this is the fetch that fills the first screenful, so it's where sizing a page in
-stored rows shows up as a blank-looking channel. `open-buffer` accepts the same
-field, for clients still hydrating that way.
+Hydrate a shell with **`{type:'history', mode:'latest'}`**, and only with that.
+It **changes nothing**: no reopen, no row minted, no JOIN, and nothing announced
+to the user's other devices. Send it for any buffer you hold, as often as you
+like. If you consolidate presence noise, send `countBy:'renderable'` with it
+(§8) — this is the fetch that fills the first screenful, so it's where sizing a
+page in stored rows shows up as a blank-looking channel.
 
-> ⚠ `{type:'open-buffer'}` also returns a populated `backlog`, and the iOS app
-> currently hydrates with it — but it is a **write verb**, not a read: for a
-> closed buffer with history it _reopens_ the buffer (a persisted state flip),
-> and for an unjoined `#channel` it JOINs. Using it to hydrate means a user
-> merely _opening a screen_ mutates persisted state. Reserve it for explicit
-> user intent ("open this DM", "join this channel"). Same hazard as the "don't
-> probe with `open-buffer`" warning above, reached from a different direction.
+It **always answers**, including for a target with no row and no history (an
+empty `events` array). A client that spends one request per buffer can't tell
+"no reply yet" from "never coming", so a silent branch would be a permanent
+loading spinner.
+
+It is also **not gated for paused accounts** — reading your own history is not a
+write. That matters more than it sounds: see the warning below.
+
+> ⚠ **`{type:'open-buffer'}` is a WRITE — don't hydrate with it.** It returns a
+> populated `backlog` too, which is exactly why it was easy to reach for. But for
+> a closed buffer with history it _reopens_ it (a persisted state flip), for a
+> bare nick it mints a DM row, and for an unjoined `#channel` it JOINs. Hydrating
+> with it means a user merely _opening a screen_ mutates state on every device
+> they own — and since an open is now announced (below), visibly. Reserve it for
+> explicit user intent ("open this DM", "join this channel"). Same hazard as the
+> "don't probe with `open-buffer`" warning above, reached from a different
+> direction.
 >
-> **And the write is silent to the user's other devices.** All three branches
-> of `handleOpenBuffer` reply with `send(ws, …)` to the requesting socket only —
-> there is no fan-out (`wsHub.ts:1138-1163`). So a reopen triggered here reaches
-> the other clients **only on their next snapshot**, leaving them showing the
-> buffer as closed until then. Don't write a `buffer-opened` handler expecting
-> to be notified of another device's open: that frame is an ack to the socket
-> that asked, not a broadcast. Of the three lifecycle frames only
-> `buffer-closed` (`wsHub.ts:2452`) and `buffer-reopened` (`wsHub.ts:1618`,
-> emitted when an incoming _event_ outranks the closed flag — not by this verb)
-> are fanned out.
+> It is also gated for paused accounts, correctly, being a write. So a client
+> that hydrates through it **cannot show a paused user anything at all**:
+> `{kind:'error', text:'account paused'}`, then a loading spinner forever. That
+> pairing is what makes this seam load-bearing rather than tidy — the paused gate
+> has encoded it all along, and a client hydrating through the write verb was
+> simply on the wrong side of it.
+
+**A successful `open-buffer` is announced to the user's other devices**, which
+receive a `backlog` **shell** for the buffer followed by `buffer-opened`. The
+requesting socket gets its full backlog and the `buffer-opened` ack, and is
+excluded from the announcement.
+
+> ⚠ **`buffer-opened` is not a "focus this" instruction.** To the socket that
+> asked, it's the reply resolving canonical casing, and focusing is reasonable.
+> To every other device it means only _this buffer is now open_ — activating on
+> it would drag the user to a buffer they opened on a different device. The two
+> are the same frame, so the only thing that distinguishes them is whether you
+> asked: track your own outstanding `open-buffer` targets and focus only on a
+> match (`vue_client/src/stores/buffers.ts`, `pendingOpens`). Clear that record
+> when the socket drops, or a reply that never arrived will claim someone else's
+> open later.
+>
+> You don't need a `buffer-opened` handler to _materialize_ the buffer — the
+> shell that travels with it already does, the same way every other
+> buffer-creating frame works (§9.1). `buffer-reopened` (`wsHub.ts:1618`) is
+> still emitted separately, when an incoming _event_ outranks a closed flag
+> rather than a verb doing it.
 
 ### 4.4 Reconnect and resume (`?since`)
 
@@ -474,12 +504,18 @@ is emitted immediately from the server's optimistic local copy.
 
 ### Channels & buffers ⏸
 
-| `type`         | Fields                        | Notes                                                                                                                   |
-| -------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `join`         | `networkId, channel, key?`    | Request only — the buffer appears on `channel-joined` (§9.1)                                                            |
-| `part`         | `networkId, channel, reason?` | Buffer survives, parted                                                                                                 |
-| `open-buffer`  | `networkId, target, countBy?` | Reopen/create: replies `backlog` + `buffer-opened`; JOINs if an unjoined channel; mints an empty DM row for a bare nick |
-| `close-buffer` | `networkId, target, reason?`  | Closes (PARTs a joined channel, untracks a DM peer). `:server:` refuses                                                 |
+| `type`         | Fields                        | Notes                                                                                                                                                                                               |
+| -------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `join`         | `networkId, channel, key?`    | Request only — the buffer appears on `channel-joined` (§9.1)                                                                                                                                        |
+| `part`         | `networkId, channel, reason?` | Buffer survives, parted                                                                                                                                                                             |
+| `open-buffer`  | `networkId, target, countBy?` | **Write.** Reopen/create: replies `backlog` + `buffer-opened`, announces a shell + `buffer-opened` to the user's other devices; JOINs if an unjoined channel; mints an empty DM row for a bare nick |
+| `close-buffer` | `networkId, target, reason?`  | Closes (PARTs a joined channel, untracks a DM peer). `:server:` refuses                                                                                                                             |
+
+Every verb in this section is rejected while an account is paused — they are all
+writes. **Hydration is not in this section for that reason:** it's
+`{type:'history', mode:'latest'}` (§4.3, §8), which is a read and stays
+available. A client that hydrates through `open-buffer` can't show a paused user
+anything at all.
 
 ### View state (persisted server-side, fanned out to your other devices)
 
@@ -532,30 +568,30 @@ a v1 client.
 
 ### 7.1 Frame kinds
 
-| `kind`                                                                                                                                                                   | Payload                                                                                                                                                                                                                                                     | When                                               |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| `snapshot`                                                                                                                                                               | `protocolVersion, maxUploadBytes, networks[], globalIgnores[], cursor?`                                                                                                                                                                                     | Connect burst / gap-fill                           |
-| `draft-snapshot` / `bookmark-ids-snapshot` / `contacts-snapshot`                                                                                                         | `drafts` / `ids[]` / `contacts[]`                                                                                                                                                                                                                           | Connect burst                                      |
-| `backlog-complete`                                                                                                                                                       | —                                                                                                                                                                                                                                                           | Last frame of the burst; absence is proof (§4.3)   |
-| `backlog`                                                                                                                                                                | `networkId, target, events[], mode, reset?, hasMoreOlder, joined, lastReadId, unread, highlights, highlightsCapped, clearedBeforeId, clearedAt, speakers?, inputHistory?` — **`mode ∈ replace\|append\|shell` is how you merge it (§8); `reset` is legacy** | Burst, `open-buffer` reply, resume gap             |
-| `irc`                                                                                                                                                                    | A decorated `MessageEvent` (§5.3) with `kind` clobbered to `'irc'`                                                                                                                                                                                          | Every live IRC-side event                          |
-| `history`                                                                                                                                                                | `networkId, target, mode, token, events[], speakers, hasMoreOlder, hasMoreNewer, hasMore, before/afterId/anchorId/anchorMissing` (per mode)                                                                                                                 | Reply to `history`                                 |
-| `read-state`                                                                                                                                                             | see §5.4                                                                                                                                                                                                                                                    | After every countable event / mark-read            |
-| `send-result`                                                                                                                                                            | `clientId, ok, error?`                                                                                                                                                                                                                                      | Ack for `send`/`action`/`notice`                   |
-| `buffer-opened` / `buffer-closed` / `buffer-reopened`                                                                                                                    | `networkId, target`                                                                                                                                                                                                                                         | Buffer lifecycle (§9.1)                            |
-| `buffer-cleared`                                                                                                                                                         | `networkId, target, clearedBeforeId, clearedAt`                                                                                                                                                                                                             | `/clear` marker                                    |
-| `pins-changed`                                                                                                                                                           | `networkId, pinned[]`                                                                                                                                                                                                                                       | Authoritative pin order                            |
-| `nicklist-collapsed-changed` / `channel-notify-changed`                                                                                                                  | `networkId, target, …`                                                                                                                                                                                                                                      | View-state sync                                    |
-| `draft-updated` / `input-history-added` / `bookmark-updated` / `nick-note-updated` / `relay-bot-updated` / `contact-updated` / `contact-deleted` / `ignore-list-updated` | various                                                                                                                                                                                                                                                     | Multi-device view-state fan-out                    |
-| `settings`                                                                                                                                                               | `changes`, `maxUploadBytes?` (only when the upload cap was touched)                                                                                                                                                                                         | Server-side settings changed                       |
-| `highlight-rules-changed`                                                                                                                                                | —                                                                                                                                                                                                                                                           | Re-fetch highlight rules                           |
-| `account-state`                                                                                                                                                          | `paused: bool`                                                                                                                                                                                                                                              | Hosted pause/resume                                |
-| `chanlist-state` / `chanlist-result`                                                                                                                                     | `/LIST` cache meta / result page                                                                                                                                                                                                                            | Channel browser                                    |
-| `e2eExport` / `e2eImport`                                                                                                                                                | E2E key material / import result                                                                                                                                                                                                                            | Replies, this socket only                          |
-| `dcc-transfer`                                                                                                                                                           | full transfer row (snake_case)                                                                                                                                                                                                                              | DCC state changes                                  |
-| `upload-progress`                                                                                                                                                        | `token, phase, destination, percent`                                                                                                                                                                                                                        | During REST upload (correlate via `progressToken`) |
-| `export`                                                                                                                                                                 | `job`                                                                                                                                                                                                                                                       | Export job progress                                |
-| `error`                                                                                                                                                                  | `text`                                                                                                                                                                                                                                                      | Non-fatal; also the reply to unknown verbs         |
+| `kind`                                                                                                                                                                   | Payload                                                                                                                                                                                                                                                     | When                                                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `snapshot`                                                                                                                                                               | `protocolVersion, maxUploadBytes, networks[], globalIgnores[], cursor?`                                                                                                                                                                                     | Connect burst / gap-fill                                                                                                                                  |
+| `draft-snapshot` / `bookmark-ids-snapshot` / `contacts-snapshot`                                                                                                         | `drafts` / `ids[]` / `contacts[]`                                                                                                                                                                                                                           | Connect burst                                                                                                                                             |
+| `backlog-complete`                                                                                                                                                       | —                                                                                                                                                                                                                                                           | Last frame of the burst; absence is proof (§4.3)                                                                                                          |
+| `backlog`                                                                                                                                                                | `networkId, target, events[], mode, reset?, hasMoreOlder, joined, lastReadId, unread, highlights, highlightsCapped, clearedBeforeId, clearedAt, speakers?, inputHistory?` — **`mode ∈ replace\|append\|shell` is how you merge it (§8); `reset` is legacy** | Burst, `open-buffer` reply, resume gap                                                                                                                    |
+| `irc`                                                                                                                                                                    | A decorated `MessageEvent` (§5.3) with `kind` clobbered to `'irc'`                                                                                                                                                                                          | Every live IRC-side event                                                                                                                                 |
+| `history`                                                                                                                                                                | `networkId, target, mode, token, events[], speakers, hasMoreOlder, hasMoreNewer, hasMore, before/afterId/anchorId/anchorMissing` (per mode)                                                                                                                 | Reply to `history`                                                                                                                                        |
+| `read-state`                                                                                                                                                             | see §5.4                                                                                                                                                                                                                                                    | After every countable event / mark-read                                                                                                                   |
+| `send-result`                                                                                                                                                            | `clientId, ok, error?`                                                                                                                                                                                                                                      | Ack for `send`/`action`/`notice`                                                                                                                          |
+| `buffer-opened` / `buffer-closed` / `buffer-reopened`                                                                                                                    | `networkId, target`                                                                                                                                                                                                                                         | Buffer lifecycle (§9.1). `buffer-opened` is an ack to the socket that asked **and** a fan-out to the user's other devices — only focus on your own (§4.3) |
+| `buffer-cleared`                                                                                                                                                         | `networkId, target, clearedBeforeId, clearedAt`                                                                                                                                                                                                             | `/clear` marker                                                                                                                                           |
+| `pins-changed`                                                                                                                                                           | `networkId, pinned[]`                                                                                                                                                                                                                                       | Authoritative pin order                                                                                                                                   |
+| `nicklist-collapsed-changed` / `channel-notify-changed`                                                                                                                  | `networkId, target, …`                                                                                                                                                                                                                                      | View-state sync                                                                                                                                           |
+| `draft-updated` / `input-history-added` / `bookmark-updated` / `nick-note-updated` / `relay-bot-updated` / `contact-updated` / `contact-deleted` / `ignore-list-updated` | various                                                                                                                                                                                                                                                     | Multi-device view-state fan-out                                                                                                                           |
+| `settings`                                                                                                                                                               | `changes`, `maxUploadBytes?` (only when the upload cap was touched)                                                                                                                                                                                         | Server-side settings changed                                                                                                                              |
+| `highlight-rules-changed`                                                                                                                                                | —                                                                                                                                                                                                                                                           | Re-fetch highlight rules                                                                                                                                  |
+| `account-state`                                                                                                                                                          | `paused: bool`                                                                                                                                                                                                                                              | Hosted pause/resume                                                                                                                                       |
+| `chanlist-state` / `chanlist-result`                                                                                                                                     | `/LIST` cache meta / result page                                                                                                                                                                                                                            | Channel browser                                                                                                                                           |
+| `e2eExport` / `e2eImport`                                                                                                                                                | E2E key material / import result                                                                                                                                                                                                                            | Replies, this socket only                                                                                                                                 |
+| `dcc-transfer`                                                                                                                                                           | full transfer row (snake_case)                                                                                                                                                                                                                              | DCC state changes                                                                                                                                         |
+| `upload-progress`                                                                                                                                                        | `token, phase, destination, percent`                                                                                                                                                                                                                        | During REST upload (correlate via `progressToken`)                                                                                                        |
+| `export`                                                                                                                                                                 | `job`                                                                                                                                                                                                                                                       | Export job progress                                                                                                                                       |
+| `error`                                                                                                                                                                  | `text`                                                                                                                                                                                                                                                      | Non-fatal; also the reply to unknown verbs                                                                                                                |
 
 ### 7.2 `irc` event types (the inner `type` field)
 
@@ -1008,8 +1044,10 @@ What the iOS app actually ships with (`FrameParser.parseWs`,
   `join`, `part`, `quit`, `nick`, `kick`, `mode`, `topic`, `motd`, `invite`
   (plus `channel-topic` for state). Unknown → drop.
 - **Send verbs (8):** `presence`, `send`, `history` (`before`/`latest`; add
-  `countBy:'renderable'` if you consolidate — §8),
-  `mark-read`, `mark-all-read`, `join`, `open-buffer`, `close-buffer`.
+  `countBy:'renderable'` if you consolidate — §8), `mark-read`, `mark-all-read`,
+  `join`, `open-buffer`, `close-buffer`. Hydrate with `{mode:'latest'}`, never
+  with `open-buffer` — §4.3 for why that's the difference between reading a
+  buffer and reopening it on every device the user owns.
 - **REST (4):** `POST /api/auth/login/token` (or the CP login), `GET
 /api/networks`, `POST /api/auth/logout`, and optionally `GET
 /api/push/config`.

--- a/server/services/wsHub.openBuffer.test.ts
+++ b/server/services/wsHub.openBuffer.test.ts
@@ -181,6 +181,24 @@ describe('hydration is a pure read', () => {
     client.close();
   });
 
+  it('resolves a divergently-cased target to the stored row', async () => {
+    // `messages.target` is BINARY-collated TEXT and rows keep the network's casing, so an
+    // exact match against the caller's casing finds NOTHING — which surfaces as a hydrated,
+    // permanently blank buffer rather than an error. Newly load-bearing because hydration
+    // moved onto this verb: a client can hold a key it built before the row existed (iOS
+    // synthesizes one from the typed name when joining) and its own store folds case, so the
+    // mismatch is invisible to it.
+    seed('#CasedBuf', 'canonical row');
+    const client = await connect();
+    client.send({ type: 'history', mode: 'latest', networkId, target: '#casedbuf' });
+    const reply = await client.waitFor((f) => f.kind === 'history', 'history');
+
+    expect((reply.events as Frame[]).map((e) => e.text)).toEqual(['canonical row']);
+    // Answered under the stored casing, so a client keying by target converges on the row.
+    expect(reply.target).toBe('#CasedBuf');
+    client.close();
+  });
+
   it('is invisible to the user’s other devices', async () => {
     seed('#quiet', 'a line');
     const reader = await connect();

--- a/server/services/wsHub.openBuffer.test.ts
+++ b/server/services/wsHub.openBuffer.test.ts
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The read/write seam: `{type:'history', mode:'latest'}` vs `open-buffer`
+// (WS_PROTOCOL_FIXES #1).
+//
+// Every claim here is about a SIDE EFFECT — whether a persisted flag moved, and
+// what the user's OTHER devices were told — which is exactly what a
+// function-level test can't see. `handleOpenBuffer` can be called directly with a
+// mock socket (wsHub.test.ts does), but a mock socket has no siblings, so the
+// fan-out is invisible to it. So: two real sockets for one user, and assertions
+// on what each of them received.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import { WebSocket } from 'ws';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const testDb = setupTestDb('wshub-openbuffer');
+
+let server: http.Server;
+let userId: number;
+let networkId: number;
+let url: string;
+let createSession: typeof import('../db/sessions.js').createSession;
+let buffers: typeof import('../db/buffers.js');
+let insertMessage: typeof import('../db/messages.js').insertMessage;
+let setUserPaused: typeof import('../db/users.js').setUserPaused;
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  ({ setUserPaused } = await import('../db/users.js'));
+  const { createNetwork } = await import('../db/networks.js');
+  ({ insertMessage } = await import('../db/messages.js'));
+  buffers = await import('../db/buffers.js');
+  ({ createSession } = await import('../db/sessions.js'));
+  const { attachWsHub } = await import('./wsHub.js');
+
+  userId = createUser('openbufferuser').id;
+  networkId = createNetwork(userId, {
+    name: 'libera',
+    host: 'h',
+    port: 6697,
+    tls: true,
+    nick: 'openbufferuser',
+  })!.id;
+
+  server = http.createServer();
+  attachWsHub(server, 'openbuffer-test-secret');
+  server.listen(0);
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('test server did not bind synchronously to a TCP port');
+  }
+  server.unref();
+  url = `ws://127.0.0.1:${address.port}/ws`;
+});
+
+afterAll(() => {
+  server.close();
+  testDb.cleanup();
+});
+
+type Frame = Record<string, unknown>;
+
+function seed(target: string, text: string): void {
+  buffers.ensureExists(userId, networkId, target);
+  insertMessage({
+    networkId,
+    target,
+    time: new Date().toISOString(),
+    type: 'message',
+    nick: 'bob',
+    text,
+    self: false,
+  });
+}
+
+/** One connected client, recording every frame it receives after the burst. */
+interface Client {
+  ws: WebSocket;
+  frames: Frame[];
+  send(frame: Frame): void;
+  /** Resolve once a frame matching `pred` arrives, or reject on timeout. */
+  waitFor(pred: (f: Frame) => boolean, what: string): Promise<Frame>;
+  close(): void;
+}
+
+async function connect(): Promise<Client> {
+  const { token } = createSession(userId);
+  const ws = new WebSocket(url, { headers: { Authorization: `Bearer ${token}` } });
+  const frames: Frame[] = [];
+  const waiters: Array<{ pred: (f: Frame) => boolean; resolve: (f: Frame) => void }> = [];
+  ws.on('message', (raw) => {
+    const frame = JSON.parse(raw.toString()) as Frame;
+    frames.push(frame);
+    for (let i = waiters.length - 1; i >= 0; i -= 1) {
+      if (waiters[i].pred(frame)) waiters.splice(i, 1)[0].resolve(frame);
+    }
+  });
+  // The burst has to drain before anything below, or its frames get mistaken
+  // for answers.
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no backlog-complete')), 3000);
+    waiters.push({
+      pred: (f) => f.kind === 'backlog-complete',
+      resolve: () => {
+        clearTimeout(timer);
+        resolve();
+      },
+    });
+  });
+  frames.length = 0;
+  return {
+    ws,
+    frames,
+    send: (frame) => ws.send(JSON.stringify(frame)),
+    waitFor: (pred, what) =>
+      new Promise<Frame>((resolve, reject) => {
+        const existing = frames.find(pred);
+        if (existing) return resolve(existing);
+        const timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `timed out waiting for ${what}; got: ${frames.map((f) => f.kind).join(', ')}`,
+              ),
+            ),
+          3000,
+        );
+        waiters.push({
+          pred,
+          resolve: (f) => {
+            clearTimeout(timer);
+            resolve(f);
+          },
+        });
+      }),
+    close: () => ws.close(),
+  };
+}
+
+/** Let anything the server was going to push actually arrive. */
+const settle = (): Promise<void> => new Promise((r) => setTimeout(r, 150));
+
+const isBacklogFor = (target: string) => (f: Frame) => f.kind === 'backlog' && f.target === target;
+
+const isHistoryFor = (target: string) => (f: Frame) =>
+  f.kind === 'history' && f.target === target && f.mode === 'latest';
+
+describe('hydration is a pure read', () => {
+  it('serves a CLOSED buffer’s history and leaves it closed', async () => {
+    // The bug the split exists for. Hydrating through `open-buffer` reopened the
+    // row, so merely opening a screen on a stale row resurrected the buffer on
+    // every one of the user's devices — and now that an open is announced, it
+    // would do so loudly.
+    seed('#closedbuf', 'still here');
+    buffers.close(userId, networkId, '#closedbuf');
+    expect(buffers.isClosed(userId, networkId, '#closedbuf')).toBe(true);
+
+    const client = await connect();
+    client.send({ type: 'history', mode: 'latest', networkId, target: '#closedbuf' });
+    const reply = await client.waitFor(isHistoryFor('#closedbuf'), 'history');
+
+    expect((reply.events as Frame[]).map((e) => e.text)).toEqual(['still here']);
+    // The whole point: reading it changed nothing.
+    expect(buffers.isClosed(userId, networkId, '#closedbuf')).toBe(true);
+    client.close();
+  });
+
+  it('answers for a target with no row and no history, rather than staying silent', async () => {
+    // A client that spends one request per buffer can't tell "no reply yet" from
+    // "never coming", so a silent branch is a permanent loading spinner (#635).
+    const client = await connect();
+    client.send({ type: 'history', mode: 'latest', networkId, target: '#never-existed' });
+    const reply = await client.waitFor(isHistoryFor('#never-existed'), 'history');
+
+    expect(reply.events).toEqual([]);
+    // ...and answering didn't mint anything.
+    expect(buffers.getBuffer(userId, networkId, '#never-existed')).toBeUndefined();
+    client.close();
+  });
+
+  it('is invisible to the user’s other devices', async () => {
+    seed('#quiet', 'a line');
+    const reader = await connect();
+    const other = await connect();
+
+    reader.send({ type: 'history', mode: 'latest', networkId, target: '#quiet' });
+    await reader.waitFor(isHistoryFor('#quiet'), 'history');
+    await settle();
+
+    // A read is nobody else's business. `open-buffer` announces; this must not.
+    expect(other.frames).toEqual([]);
+    reader.close();
+    other.close();
+  });
+
+  it('works for a paused account, unlike the write verb', async () => {
+    // The paused gate already encodes this seam: it blocks `open-buffer` and not
+    // `history`. So a client that hydrated through the write verb couldn't show a
+    // paused user anything at all — `account paused`, then a loading spinner
+    // forever. This pins both halves, since it's the pairing that makes the
+    // split load-bearing rather than tidy.
+    seed('#paused', 'readable while paused');
+    setUserPaused(userId, true);
+    try {
+      const client = await connect();
+      client.send({ type: 'history', mode: 'latest', networkId, target: '#paused' });
+      const reply = await client.waitFor(isHistoryFor('#paused'), 'history');
+      expect((reply.events as Frame[]).map((e) => e.text)).toEqual(['readable while paused']);
+
+      client.send({ type: 'open-buffer', networkId, target: '#paused' });
+      const err = await client.waitFor((f) => f.kind === 'error', 'error');
+      expect(err.text).toBe('account paused');
+      client.close();
+    } finally {
+      setUserPaused(userId, false);
+    }
+  });
+});
+
+describe('open-buffer — the announced write', () => {
+  it('reopens for the requester and tells the other devices, without moving their focus', async () => {
+    seed('#shared', 'history');
+    buffers.close(userId, networkId, '#shared');
+
+    const opener = await connect();
+    const other = await connect();
+    opener.send({ type: 'open-buffer', networkId, target: '#shared' });
+
+    // The requester gets the content it asked for, plus the reply that resolves
+    // canonical casing and tells it to focus.
+    const mine = await opener.waitFor(isBacklogFor('#shared'), 'backlog');
+    expect((mine.events as Frame[]).length).toBe(1);
+    await opener.waitFor(
+      (f) => f.kind === 'buffer-opened' && f.target === '#shared',
+      'buffer-opened',
+    );
+    expect(buffers.isClosed(userId, networkId, '#shared')).toBe(false);
+
+    // The other device learns the buffer exists — as a SHELL. That's what keeps
+    // `buffer-opened` from reading as "focus this" over there: the row is
+    // already present when it lands, so the frame is a state signal, and the
+    // device fetches the contents only if the user actually goes there.
+    const theirs = await other.waitFor(isBacklogFor('#shared'), 'shell backlog');
+    expect(theirs.mode).toBe('shell');
+    expect(theirs.events).toEqual([]);
+    await other.waitFor(
+      (f) => f.kind === 'buffer-opened' && f.target === '#shared',
+      'buffer-opened',
+    );
+
+    opener.close();
+    other.close();
+  });
+
+  it('does not echo the announcement back to the socket that asked', async () => {
+    seed('#echo', 'x');
+    buffers.close(userId, networkId, '#echo');
+
+    const opener = await connect();
+    opener.send({ type: 'open-buffer', networkId, target: '#echo' });
+    await opener.waitFor((f) => f.kind === 'buffer-opened', 'buffer-opened');
+    await settle();
+
+    // Exactly one of each: the real backlog and one buffer-opened. A shell
+    // arriving here would un-hydrate the buffer the requester just received.
+    expect(opener.frames.filter((f) => f.kind === 'backlog')).toHaveLength(1);
+    expect(opener.frames.filter((f) => f.kind === 'buffer-opened')).toHaveLength(1);
+    expect(opener.frames.find((f) => f.kind === 'backlog')!.mode).not.toBe('shell');
+    opener.close();
+  });
+});

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -3058,7 +3058,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       }
       case 'history': {
         const histNetworkId = msg.networkId as number;
-        const histTarget = msg.target as string;
+        let histTarget = msg.target as string;
 
         // System buffer: app-scoped, no IRC connection — dispatch to the
         // system_messages keyset access. Reply shapes match the network path
@@ -3079,6 +3079,22 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           send(ws, { kind: 'error', text: 'unknown network' });
           break;
         }
+        // Resolve the caller's casing to the row's, the way `open-buffer` always
+        // has. IRC target names are case-insensitive, but `messages.target` is
+        // BINARY-collated TEXT and rows keep whatever casing the network handed
+        // us (`#idleRPG` stays `#idleRPG` — foldBufferCase.ts:26), so an exact
+        // match against a divergently-cased request finds NOTHING. That reads as
+        // an empty buffer with `hasMoreOlder:false`: hydrated, permanently blank,
+        // and unpageable.
+        //
+        // Newly load-bearing because hydration moved onto this verb: a client can
+        // legitimately hold a key it built before the row existed (iOS synthesizes
+        // one from the typed name when joining, and the row arrives later with the
+        // server's casing), and its store folds case so the two never look
+        // different to it. The registry lookup folds; no row (a `:server:`
+        // pseudo-buffer, or a target with history but no row) falls through to
+        // what was asked. See feedback_irc_target_case_insensitive.
+        histTarget = getBuffer(userId, histNetworkId, histTarget)?.target ?? histTarget;
         const limit = Math.min(Math.max(Number(msg.limit) || 100, 1), 500);
         const mode = typeof msg.mode === 'string' ? msg.mode : 'before';
         // What `limit` counts (#10). 'renderable' sizes the page in the unit the

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1205,6 +1205,7 @@ export function handleOpenBuffer(
     reopenBufferRow(userId, networkId, row.target);
     send(ws, buildBufferBacklog(userId, networkId, row.target, countBy));
     send(ws, { kind: 'buffer-opened', networkId, target: row.target });
+    announceOpen(ws, userId, networkId, row.target, conn);
   } else if (requested.startsWith('#')) {
     ircManager.joinChannel(userId, networkId, requested);
     send(ws, { kind: 'buffer-opened', networkId, target: requested });
@@ -1217,7 +1218,44 @@ export function handleOpenBuffer(
     const { record } = ensureBufferOpen(userId, networkId, requested);
     send(ws, buildBufferBacklog(userId, networkId, record.target, countBy));
     send(ws, { kind: 'buffer-opened', networkId, target: record.target });
+    announceOpen(ws, userId, networkId, record.target, conn);
   }
+}
+
+// Tell the user's OTHER devices that a buffer is now open.
+//
+// Until this existed, an open was invisible to them until their next snapshot —
+// a reconnect, or the in-band resync a hidden tab fires — so a user's devices
+// quietly disagreed about whether a buffer existed. That was tolerable only
+// while every hydration was accidentally an open; now that opening is deliberate
+// (`hydrate` carries the reads), it's worth announcing.
+//
+// **The shell is what makes this safe, and it isn't optional.** `buffer-opened`
+// is a reply first: the requesting client reads it as "here's the canonical
+// target — focus it" (`useSocket.ts:787`). Fanned out on its own it would yank
+// every other tab to a buffer the user opened somewhere else. Sending a shell
+// alongside means the other devices already have the row when it lands, so the
+// frame is a state signal there rather than an instruction — and it matches how
+// every other buffer-materializing frame travels (§9.1: `buffer-opened` rides
+// with a `backlog`).
+//
+// A shell rather than the full backlog on purpose: those devices may never look
+// at this buffer, and a shell is precisely "it exists, fetch on open" — the same
+// thing a fresh connect ships. They hydrate through `hydrate` if the user goes
+// there.
+function announceOpen(
+  requester: LurkerWebSocket,
+  userId: number,
+  networkId: number,
+  target: string,
+  conn: { channels: { has(name: string): boolean } } | null | undefined,
+): void {
+  // Pass the live connection: `channelJoined` folds a #channel to parted without
+  // one, which would land the other devices' rows dimmed for a channel we're
+  // sitting in, until some later frame corrected them.
+  const shell = buildBufferShell(userId, networkId, target, channelJoined(target, conn));
+  fanOut(userId, shell, { exceptWs: requester });
+  fanOut(userId, { kind: 'buffer-opened', networkId, target }, { exceptWs: requester });
 }
 
 // Per-user socket bookkeeping lives at module scope so the verb registry can
@@ -2555,6 +2593,9 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         break;
       case 'open-buffer':
         // A clicked channel name — handleOpenBuffer resolves reopen-vs-join.
+        // A WRITE: it reopens a closed row, mints a DM row, or JOINs, and now
+        // announces that to the user's other devices. Filling in a shell is
+        // `{type:'history', mode:'latest'}`, which reads and changes nothing.
         handleOpenBuffer(
           ws,
           userId,

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1228,7 +1228,7 @@ export function handleOpenBuffer(
 // a reconnect, or the in-band resync a hidden tab fires — so a user's devices
 // quietly disagreed about whether a buffer existed. That was tolerable only
 // while every hydration was accidentally an open; now that opening is deliberate
-// (`hydrate` carries the reads), it's worth announcing.
+// (`{type:'history', mode:'latest'}` carries the reads), it's worth announcing.
 //
 // **The shell is what makes this safe, and it isn't optional.** `buffer-opened`
 // is a reply first: the requesting client reads it as "here's the canonical
@@ -1241,8 +1241,8 @@ export function handleOpenBuffer(
 //
 // A shell rather than the full backlog on purpose: those devices may never look
 // at this buffer, and a shell is precisely "it exists, fetch on open" — the same
-// thing a fresh connect ships. They hydrate through `hydrate` if the user goes
-// there.
+// thing a fresh connect ships. They fill it in with `{type:'history',
+// mode:'latest'}` if the user actually goes there.
 function announceOpen(
   requester: LurkerWebSocket,
   userId: number,

--- a/vue_client/src/components/RenderSegments.vue
+++ b/vue_client/src/components/RenderSegments.vue
@@ -61,8 +61,6 @@ import { useBuffersStore } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useMircPalette } from '../composables/useNickColors.js';
 import { useMediaViewer } from '../composables/useMediaViewer.js';
-import { socketSend } from '../composables/useSocket.js';
-import { historyCountBy } from '../lib/historyPaging.js';
 import { mediaKindForUrl } from '../utils/uploadHostMatch.js';
 import SpoilerText from './SpoilerText.vue';
 
@@ -150,14 +148,6 @@ function openChannel(channel: string): void {
     buffers.activate(nid, existing.target);
     return;
   }
-  // The reply re-seeds history for a since-closed buffer, making this frame the
-  // first screenful for a channel we don't hold — so it gets sized in the unit
-  // we render in, same as any other hydrate (§8).
-  socketSend({
-    type: 'open-buffer',
-    networkId: nid,
-    target: channel,
-    countBy: historyCountBy(),
-  });
+  buffers.openBuffer(nid, channel);
 }
 </script>

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -784,13 +784,21 @@ function handleMessage(raw: string): void {
     return;
   }
   if (payload.kind === 'buffer-opened') {
-    // Reply to our own `open-buffer` request: the server resolved the
-    // canonical target — reopened a since-closed buffer, or joined a new
-    // channel. Focus it now. For a reopen the `backlog` frame sent just
-    // before this already recreated the buffer; for a join the channel-joined
-    // flow will. activate() ensures the buffer exists either way.
     const buffers = useBuffersStore();
-    buffers.activate(payload.networkId, payload.target);
+    // Two meanings, one frame — tell them apart by whether WE asked.
+    //
+    // Our own reply: the server resolved the canonical target — reopened a
+    // since-closed buffer, or joined a new channel. Focus it. For a reopen the
+    // `backlog` frame sent just before already recreated the buffer; for a join
+    // the channel-joined flow will. activate() ensures it exists either way.
+    //
+    // Otherwise it's a fan-out: another of the user's devices opened this
+    // buffer. The shell that travelled with this frame has already put the row
+    // in the sidebar, and that's the whole job — activating here would drag this
+    // tab to a buffer someone opened on their phone.
+    if (buffers.claimPendingOpen(payload.networkId, payload.target)) {
+      buffers.activate(payload.networkId, payload.target);
+    }
     return;
   }
   if (payload.kind === 'buffer-reopened') {

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -963,6 +963,38 @@ describe('open-buffer focus correlation', () => {
     expect(store.claimPendingOpen(1, '#dropped')).toBe(false);
   });
 
+  it('forgets a request the server never answered', () => {
+    // `open-buffer` can be refused outright — a paused account gets `{kind:'error'}` and no
+    // `buffer-opened` — and without a backstop that request would sit armed for the life of
+    // the session, then claim an unrelated open from another device. Same backstop as
+    // pendingJoins.
+    vi.useFakeTimers();
+    try {
+      const store = useBuffersStore();
+      vi.mocked(socketSend).mockReturnValue(true);
+      store.openBuffer(1, '#unanswered');
+
+      vi.advanceTimersByTime(10_000);
+
+      expect(store.claimPendingOpen(1, '#unanswered')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('forgets pending requests on logout, which never reaches the socket-close path', () => {
+    // resetSession aborts the socket listeners, so 'close' — and therefore
+    // failInFlightHistory — never fires. A latch surviving into the next account's session
+    // would let a cross-device open steal that user's focus.
+    const store = useBuffersStore();
+    vi.mocked(socketSend).mockReturnValue(true);
+    store.openBuffer(1, '#previous-account');
+
+    store.resetTimers();
+
+    expect(store.claimPendingOpen(1, '#previous-account')).toBe(false);
+  });
+
   it('forgets pending requests when the socket drops', () => {
     // A reply that can no longer arrive must not leave us primed to treat some
     // unrelated open — days later, from another device — as our own.

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -926,3 +926,52 @@ describe('oversized history pages vs the in-memory ring', () => {
     expect(buf.hasMoreOlder).toBe(true);
   });
 });
+
+// `buffer-opened` means two different things depending on who asked, and the
+// frame looks identical either way (lurker WS_PROTOCOL_FIXES #1). Getting this
+// wrong is not subtle to the user — their active buffer changes under them
+// because they opened something on another device — but it is completely silent
+// in code, so it's pinned here.
+describe('open-buffer focus correlation', () => {
+  it('claims exactly one reply for a target this tab asked to open', () => {
+    const store = useBuffersStore();
+    vi.mocked(socketSend).mockReturnValue(true);
+
+    store.openBuffer(1, '#chan');
+
+    expect(socketSend).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'open-buffer', networkId: 1, target: '#chan' }),
+    );
+    // Case-insensitively, since the server answers with the row's canonical
+    // casing rather than the casing that was clicked.
+    expect(store.claimPendingOpen(1, '#CHAN')).toBe(true);
+    // ...and only once: a second frame for the same target is somebody else's.
+    expect(store.claimPendingOpen(1, '#chan')).toBe(false);
+  });
+
+  it('does not claim an open this tab never asked for', () => {
+    const store = useBuffersStore();
+    expect(store.claimPendingOpen(1, '#elsewhere')).toBe(false);
+  });
+
+  it('forgets a request whose send failed, so it cannot claim a later fan-out', () => {
+    const store = useBuffersStore();
+    vi.mocked(socketSend).mockReturnValue(false);
+
+    expect(store.openBuffer(1, '#dropped')).toBe(false);
+
+    expect(store.claimPendingOpen(1, '#dropped')).toBe(false);
+  });
+
+  it('forgets pending requests when the socket drops', () => {
+    // A reply that can no longer arrive must not leave us primed to treat some
+    // unrelated open — days later, from another device — as our own.
+    const store = useBuffersStore();
+    vi.mocked(socketSend).mockReturnValue(true);
+    store.openBuffer(1, '#stale');
+
+    store.failInFlightHistory();
+
+    expect(store.claimPendingOpen(1, '#stale')).toBe(false);
+  });
+});

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -51,10 +51,15 @@ function joinKey(networkId: number | string, channel: string) {
 // their phone. The frame looks identical either way, so the only thing that can
 // tell them apart is whether we asked.
 //
-// Claimed once (a reply answers one request), and cleared when the socket drops,
-// so a request whose reply never arrived can't leave a latch that hijacks focus
-// on some unrelated open days later.
-const pendingOpens = new Set<string>();
+// Claimed once (a reply answers one request), and dropped on a timeout, on
+// socket close, and on logout — because "focus the next open of this target" is
+// a dangerous thing to leave armed. `open-buffer` can be refused outright (a
+// paused account answers `{kind:'error'}` and never sends `buffer-opened`), and
+// without a backstop that request would sit here for the life of the session and
+// then claim someone else's open from another device. Same reasoning and the
+// same backstop as `pendingJoins`.
+const pendingOpens = new Map<string, ReturnType<typeof setTimeout>>();
+const PENDING_OPEN_TIMEOUT = 10000;
 
 // Monotonic token tagged onto each loadAround / reattachToLive request. The
 // response handler drops slices whose token has been superseded (e.g. user
@@ -810,7 +815,12 @@ export const useBuffersStore = defineStore('buffers', {
     // steal this tab's focus.
     openBuffer(networkId: number | string, target: string): boolean {
       const key = joinKey(networkId, target);
-      pendingOpens.add(key);
+      const existing = pendingOpens.get(key);
+      if (existing) clearTimeout(existing);
+      pendingOpens.set(
+        key,
+        setTimeout(() => pendingOpens.delete(key), PENDING_OPEN_TIMEOUT),
+      );
       const sent = socketSend({
         type: 'open-buffer',
         networkId,
@@ -819,13 +829,21 @@ export const useBuffersStore = defineStore('buffers', {
         // screenful like any other hydrate (§8).
         countBy: historyCountBy(),
       });
-      if (!sent) pendingOpens.delete(key);
+      if (!sent) {
+        clearTimeout(pendingOpens.get(key)!);
+        pendingOpens.delete(key);
+      }
       return sent;
     },
     // Did THIS tab ask for `target` to be opened? Consumes the record, so the
     // reply focuses exactly once.
     claimPendingOpen(networkId: number | string, target: string): boolean {
-      return pendingOpens.delete(joinKey(networkId, target));
+      const key = joinKey(networkId, target);
+      const timer = pendingOpens.get(key);
+      if (timer === undefined) return false;
+      clearTimeout(timer);
+      pendingOpens.delete(key);
+      return true;
     },
     applyLatestReplace(networkId: number | string, target: string, payload: any) {
       const buf = ensureBuffer(this, networkId, target);
@@ -1042,6 +1060,12 @@ export const useBuffersStore = defineStore('buffers', {
       typingTimers.clear();
       for (const id of pendingJoins.values()) clearTimeout(id);
       pendingJoins.clear();
+      // Also module-level, and logout doesn't reach the socket-close path that
+      // normally clears it (resetSocket aborts the listeners, so 'close' never
+      // fires). A latch surviving into the NEXT account's session would let a
+      // cross-device open of the same target steal that user's focus.
+      for (const id of pendingOpens.values()) clearTimeout(id);
+      pendingOpens.clear();
     },
     // Register intent to join a channel without opening its buffer yet (#260).
     // confirmPendingJoin() activates it on the channel-joined confirmation;

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -42,6 +42,20 @@ function joinKey(networkId: number | string, channel: string) {
   return `${networkId}::${channel.toLowerCase()}`;
 }
 
+// Targets THIS tab has asked the server to open.
+//
+// `buffer-opened` carries two meanings now that the server fans it out. To the
+// tab that asked it's a reply — "here's the canonical casing, focus it". To the
+// user's other devices it's a state signal — "this buffer is open now" — and
+// acting on that by activating would yank someone to a buffer they opened on
+// their phone. The frame looks identical either way, so the only thing that can
+// tell them apart is whether we asked.
+//
+// Claimed once (a reply answers one request), and cleared when the socket drops,
+// so a request whose reply never arrived can't leave a latch that hijacks focus
+// on some unrelated open days later.
+const pendingOpens = new Set<string>();
+
 // Monotonic token tagged onto each loadAround / reattachToLive request. The
 // response handler drops slices whose token has been superseded (e.g. user
 // clicked a second jump while the first was in flight, or reattached before
@@ -780,6 +794,38 @@ export const useBuffersStore = defineStore('buffers', {
           buf.pendingHistoryToken = null;
         }
       }
+      // Same reasoning, different latch: a reply that can no longer arrive must
+      // not leave us primed to treat someone else's open as ours. See pendingOpens.
+      pendingOpens.clear();
+    },
+    // Ask the server to OPEN a buffer. This is a WRITE — it reopens a closed
+    // row, mints a DM row for a bare nick, or JOINs an unjoined channel — so it
+    // belongs to deliberate user intent ("open this DM", a clicked channel
+    // name), never to filling in a shell. Hydration goes through
+    // ensureHydrated/reattachToLive, which read and change nothing.
+    //
+    // The send lives here rather than at the call site so the pendingOpens
+    // bookkeeping can't be forgotten by the next caller that needs this verb —
+    // forgetting it doesn't fail loudly, it just makes another device's open
+    // steal this tab's focus.
+    openBuffer(networkId: number | string, target: string): boolean {
+      const key = joinKey(networkId, target);
+      pendingOpens.add(key);
+      const sent = socketSend({
+        type: 'open-buffer',
+        networkId,
+        target,
+        // The reply re-seeds history for a since-closed buffer, so it's a first
+        // screenful like any other hydrate (§8).
+        countBy: historyCountBy(),
+      });
+      if (!sent) pendingOpens.delete(key);
+      return sent;
+    },
+    // Did THIS tab ask for `target` to be opened? Consumes the record, so the
+    // reply focuses exactly once.
+    claimPendingOpen(networkId: number | string, target: string): boolean {
+      return pendingOpens.delete(joinKey(networkId, target));
     },
     applyLatestReplace(networkId: number | string, target: string, payload: any) {
       const buf = ensureBuffer(this, networkId, target);

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -801,6 +801,9 @@ export const useBuffersStore = defineStore('buffers', {
       }
       // Same reasoning, different latch: a reply that can no longer arrive must
       // not leave us primed to treat someone else's open as ours. See pendingOpens.
+      // Timers first — clearing the Map alone would leave them to fire into an
+      // empty Map across the reconnect.
+      for (const id of pendingOpens.values()) clearTimeout(id);
       pendingOpens.clear();
     },
     // Ask the server to OPEN a buffer. This is a WRITE — it reopens a closed


### PR DESCRIPTION
`open-buffer` did two unrelated jobs: it returned a buffer's backlog, and it reopened/minted/JOINed. iOS hydrated with it, so on that client *opening a screen* was a persisted write — one tap on a stale row reopened the buffer for every device the user owns. The doc named the hazard ("Don't probe with `open-buffer`") while still listing both hydration paths as equally valid.

Closes WS_PROTOCOL_FIXES #1 (PR 5 of that list). Pairs with amiantos/lurker-ios#80.

## No new verb, despite what the audit specified

The plan called for adding `{type:'hydrate'}`. I built it, then removed it: **`{type:'history', mode:'latest'}` already is that read.** It performs no writes, always answers (including for a target with no row and no history), and isn't paused-gated. The only thing it lacks is the `backlog` frame's buffer-state fields, which no client needs at hydrate time — the burst's shell supplies them and `read-state` keeps them live.

Two reasons reuse beat adding:

- A new verb turns the "two ways to hydrate" the item complains about into **three**.
- **iOS could not have used it.** `protocol.ts` guarantees new-client-against-old-server as a normal operating condition — self-hosted operators upgrade on their own schedule. An App Store build sending an unknown verb gets a non-fatal error, no backlog, and a permanent "Loading messages…". The `history` verb predates every version of the app.

So this makes `mode:'latest'` the documented hydration path and `open-buffer` write-only, rather than adding surface. Happy to revisit if a reviewer thinks the buffer-state fields are needed at hydrate time — that's the argument that puts the verb back.

## A user-visible bug the audit never mentioned

`PAUSED_BLOCKED_TYPES` contains `open-buffer` and not `history` — **the paused gate had encoded this seam all along.** So a paused account hydrating through the write verb got `account paused` and could never read its own history at all. Fixed as a side effect, and pinned by a test asserting both halves, since it's the pairing that makes the split load-bearing rather than tidy.

## Announcing the write

A successful `open-buffer` now reaches the user's other devices instead of waiting for their next snapshot. They receive a `backlog` **shell** followed by `buffer-opened`; the requester gets its full backlog and the ack, and is excluded from the fan-out.

The shell isn't decoration — it's what makes the fan-out safe. `buffer-opened` is a reply first: the requesting client reads it as "here's the canonical target, focus it". Broadcast bare it would yank every other tab to a buffer the user opened somewhere else, while iOS — which parses only `buffer-closed` — would ignore it entirely. Exactly backwards. Sending the shell alongside means the row is already present when the frame lands, so it reads as state there, matching how every other buffer-materializing frame travels. A shell rather than the full backlog because those devices may never look at this buffer.

Web correspondingly focuses only on a `buffer-opened` it asked for. `openBuffer` moved into the store so the `pendingOpens` bookkeeping can't be forgotten by the next caller — forgetting it doesn't fail loudly, it just makes another device's open steal this tab's focus.

## Fixed after review

- **Casing, the one with teeth.** `messages.target` is BINARY-collated `TEXT` and rows keep the network's casing, but `history` matched the caller's target exactly — where `open-buffer` had always folded through the registry. A divergently-cased request found nothing, surfacing not as an error but as a hydrated, permanently blank buffer that scroll-up cannot repair. Newly load-bearing because hydration moved onto this verb: iOS synthesizes a screen key from the *typed* channel name when joining, the row arrives later with the server's casing, and `BufferKey.id` lowercases so its own store never sees a difference. Fixed at the server, where it covers all four modes and every client rather than the one call site iOS happens to use — this is the project's own fold-target-case rule, and `history` was the last verb not following it.
- **`pendingOpens` could outlive its request.** A refused `open-buffer` (paused account) leaves no reply, and logout never reaches the socket-close path that cleared it. Either way a stale latch could claim a later cross-device open and steal focus, including the next account's. Now a Map with a timeout backstop, cleared in `resetTimers`, mirroring `pendingJoins`.
- A wrong `file:line` in the rewritten §4.3.

## Tests

`wsHub.openBuffer.test.ts` drives **two real sockets for one user** — the fan-out is structurally invisible to a mock socket, which is what the existing `handleOpenBuffer` tests use. Covers: the read leaves a closed buffer closed, answers for a target with no row, resolves divergent casing, is invisible to other devices, works while paused (and the write verb still doesn't), the fan-out shape, and no self-echo.

I probe-verified the three that matter by breaking the fix and confirming they fail: removing `announceOpen`, dropping `exceptWs`, and reverting the casing resolution.

`npm run check` clean, `npm test` 3019 passed / 222 files.

## Not covered by tests

Two iOS-side fixes live in view controllers with no test harness; they're described in the paired PR. QA'd locally: the shell fan-out into an already-open buffer on a second device (contents and scroll position untouched), and two-tab focus (the non-requesting tab gains the sidebar row without changing its active buffer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)