### PR TITLE
Collapse event-noise filtering into one tier (#666)

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -259,9 +259,10 @@ hasMoreOlder:true}` — "this buffer exists; fetch content when the user opens i
 Hydrate a shell with **`{type:'history', mode:'latest'}`**, and only with that.
 It **changes nothing**: no reopen, no row minted, no JOIN, and nothing announced
 to the user's other devices. Send it for any buffer you hold, as often as you
-like. If you consolidate presence noise, send `countBy:'renderable'` with it
-(§8) — this is the fetch that fills the first screenful, so it's where sizing a
-page in stored rows shows up as a blank-looking channel.
+like. If you consolidate presence noise, send `countBy:'renderable'` with it —
+or `countBy:'chat'` if you hide events entirely (§8). This is the fetch that
+fills the first screenful, so it's where sizing a page in stored rows shows up
+as a blank-looking channel.
 
 It **always answers**, including for a target with no row and no history (an
 empty `events` array). A client that spends one request per buffer can't tell
@@ -678,9 +679,22 @@ rows still come back — consolidation needs the whole run to summarize it — t
 just don't spend the budget. Default is `'event'`, i.e. today's behavior; an
 older server ignores the field and answers exactly as before.
 
-- **What counts as renderable is the complement of the fold set**, not
-  "messages". A `kick`, `mode`, `topic`, `error`, or `invite` each renders
-  standalone, so each is worth one slot.
+Send **`countBy:'chat'`** instead if you hide event noise **entirely** — the
+`none` rung of the web client's event tier (`chat.events`). That unit also makes
+`mode` free, because a client drawing nothing for a mode change would otherwise
+spend budget on invisible rows. The canonical set is `NOISE_TYPES` in
+`shared/eventFilter.ts`: the fold set plus `mode`.
+
+There is deliberately **no unit for partial (smart) filtering**. Which events it
+hides depends on who spoke recently in your client, which the server can't know;
+ask for the unit your tier would otherwise use and accept the occasional short
+page.
+
+- **What counts is the complement of the set you hide**, not "messages". Under
+  `'renderable'` a `kick`, `mode`, `topic`, `error`, or `invite` each renders
+  standalone, so each is worth one slot; under `'chat'` the same holds minus
+  `mode`. Kicks, topics and invites are never free under either — they are
+  things that happened, not churn.
 - **The slice is still a contiguous id range**, exactly like an event-counted
   one. `hasMoreOlder`, prepend-and-dedupe, and the `before: <oldest returned
 id>` cursor are unchanged. This cannot open a hole.
@@ -688,12 +702,12 @@ id>` cursor are unchanged. This cannot open a hole.
   than you asked for and `hasMoreOlder` stays true — a buffer holding tens of
   thousands of joins between two sentences degrades to today's behavior instead
   of shipping a huge frame.
-- **Only ask for it if you actually fold** — and only once you _know_ whether
-  you do. If your client renders every event as its own line (the web client
+- **Ask for the unit you actually render in** — and only once you _know_ what
+  that is. If your client renders every event as its own line (the web client
   makes this a user setting), `'event'` is already the right unit, and
   `'renderable'` would hand you up to a full scan window of rows you then
   display in full. If the preference hasn't loaded yet, send `'event'`: of the
-  two wrong guesses, that one just costs a short first page.
+  wrong guesses, that one just costs a short first page.
 - **On `around` it sizes each side**, so the window is up to `2×limit+1`
   _renderable_ rows. Worth sending: for a client that enters a buffer with a
   pending jump (a push tap, a highlight, jump-to-first-unread), the `around`
@@ -1044,7 +1058,8 @@ What the iOS app actually ships with (`FrameParser.parseWs`,
   `join`, `part`, `quit`, `nick`, `kick`, `mode`, `topic`, `motd`, `invite`
   (plus `channel-topic` for state). Unknown → drop.
 - **Send verbs (8):** `presence`, `send`, `history` (`before`/`latest`; add
-  `countBy:'renderable'` if you consolidate — §8), `mark-read`, `mark-all-read`,
+  `countBy:'renderable'` if you consolidate, `'chat'` if you hide events — §8),
+  `mark-read`, `mark-all-read`,
   `join`, `open-buffer`, `close-buffer`. Hydrate with `{mode:'latest'}`, never
   with `open-buffer` — §4.3 for why that's the difference between reading a
   buffer and reopening it on every device the user owns.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -3,6 +3,7 @@
 
 import Database from 'better-sqlite3';
 import { foldMutedIntoIgnoreRules } from './migrateMutedFold.js';
+import { migrateSmartFilterToEventMode } from './migrateEventMode.js';
 import path from 'path';
 import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
@@ -1879,6 +1880,15 @@ try {
   reconcileHostedUploaderFromEnv(db);
 } catch (err) {
   console.warn('[db] hosted uploader env reconcile failed:', err);
+}
+
+// Carry the retired `chat.smart_filter` switch onto the `chat.events` tier
+// (#666). Every boot, idempotent, self-terminating — see db/migrateEventMode.ts
+// for why it writes both the desktop and the mobile key.
+try {
+  migrateSmartFilterToEventMode(db);
+} catch (err) {
+  console.warn('[db] smart-filter→event-tier migration failed (will retry next boot):', err);
 }
 
 // Gate on uploaderSeedOk: if the uploader seed threw, leave schema_version

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -8,6 +8,7 @@ import path from 'path';
 // Pure, no DB side effects — safe to import statically alongside the lazy
 // db-layer imports below.
 import { CONSOLIDATABLE_TYPES } from '../../shared/consolidate.js';
+import { NOISE_TYPES } from '../../shared/eventFilter.js';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
 process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
@@ -17,7 +18,7 @@ let createNetwork: typeof import('./networks.js').createNetwork;
 let insertMessage: typeof import('./messages.js').insertMessage;
 let listMessages: typeof import('./messages.js').listMessages;
 let listMessagesAround: typeof import('./messages.js').listMessagesAround;
-let listMessagesRenderable: typeof import('./messages.js').listMessagesRenderable;
+let listMessagesCounted: typeof import('./messages.js').listMessagesCounted;
 let searchMessages: typeof import('./messages.js').searchMessages;
 let countNewer: typeof import('./messages.js').countNewer;
 let countServerBufferUnread: typeof import('./messages.js').countServerBufferUnread;
@@ -40,7 +41,7 @@ beforeAll(async () => {
     insertMessage,
     listMessages,
     listMessagesAround,
-    listMessagesRenderable,
+    listMessagesCounted,
     searchMessages,
     countNewer,
     countServerBufferUnread,
@@ -1156,7 +1157,7 @@ describe('chathistory window queries', () => {
 // property under test throughout is the one that makes it safe to do at the
 // server: the result is a CONTIGUOUS id range, exactly like a listMessages
 // slice, so it can never open a hole in the client's scrollback.
-describe('listMessagesRenderable', () => {
+describe("listMessagesCounted unit: 'renderable'", () => {
   function netFor(name: string): number {
     const user = createUser(name);
     return createNetwork(user.id, { name: 'n', host: 'h', port: 6697, tls: true, nick: name })!.id;
@@ -1186,7 +1187,7 @@ describe('listMessagesRenderable', () => {
     }
 
     const eventCounted = listMessages(net, '#a', { limit: 10 });
-    const renderable = listMessagesRenderable(net, '#a', { limit: 10 });
+    const renderable = listMessagesCounted(net, '#a', 'renderable', { limit: 10 });
 
     // Today's page: ten rows, nine of them noise that folds into one line.
     expect(eventCounted).toHaveLength(10);
@@ -1202,7 +1203,7 @@ describe('listMessagesRenderable', () => {
       for (let j = 0; j < 4; j += 1) event(net, '#a', 'part', `n${j}`);
       chat(net, '#a', 'alice', `m${i}`);
     }
-    const rows = listMessagesRenderable(net, '#a', { limit: 2 });
+    const rows = listMessagesCounted(net, '#a', 'renderable', { limit: 2 });
     // Oldest row is the boundary message itself, not the joins that precede it:
     // the next page picks that run up whole, so consolidation summarizes it once
     // rather than splitting it across two pages.
@@ -1217,8 +1218,8 @@ describe('listMessagesRenderable', () => {
       for (let j = 0; j < 3; j += 1) event(net, '#a', 'quit', `n${j}`);
       chat(net, '#a', 'alice', `m${i}`);
     }
-    const page1 = listMessagesRenderable(net, '#a', { limit: 4 });
-    const page2 = listMessagesRenderable(net, '#a', { limit: 4, before: page1[0].id });
+    const page1 = listMessagesCounted(net, '#a', 'renderable', { limit: 4 });
+    const page2 = listMessagesCounted(net, '#a', 'renderable', { limit: 4, before: page1[0].id });
     expect(page1.filter((e) => e.type === 'message').map((e) => e.text)).toEqual([
       'm9',
       'm10',
@@ -1244,7 +1245,7 @@ describe('listMessagesRenderable', () => {
       for (let j = 0; j < 3; j += 1) event(net, '#a', 'join', `n${j}`);
       ids.push(chat(net, '#a', 'alice', `m${i}`).id);
     }
-    const rows = listMessagesRenderable(net, '#a', { afterId: ids[2], limit: 3 });
+    const rows = listMessagesCounted(net, '#a', 'renderable', { afterId: ids[2], limit: 3 });
     expect(rows.every((r) => r.id > ids[2])).toBe(true);
     expect(rows.filter((e) => e.type === 'message').map((e) => e.text)).toEqual(['m4', 'm5', 'm6']);
     expectContiguous(rows, net, '#a');
@@ -1254,7 +1255,7 @@ describe('listMessagesRenderable', () => {
     const net = netFor('rend-short');
     for (let j = 0; j < 8; j += 1) event(net, '#a', 'join', `n${j}`);
     chat(net, '#a', 'alice', 'only one');
-    const rows = listMessagesRenderable(net, '#a', { limit: 100 });
+    const rows = listMessagesCounted(net, '#a', 'renderable', { limit: 100 });
     expect(rows).toHaveLength(9);
     expect(rows.filter((e) => e.type === 'message')).toHaveLength(1);
   });
@@ -1264,13 +1265,13 @@ describe('listMessagesRenderable', () => {
     // read to a client as "start of history" and stop its pager dead.
     const net = netFor('rend-allnoise');
     for (let j = 0; j < 40; j += 1) event(net, '#a', 'join', `n${j}`);
-    const rows = listMessagesRenderable(net, '#a', { limit: 100 });
+    const rows = listMessagesCounted(net, '#a', 'renderable', { limit: 100 });
     expect(rows).toHaveLength(40);
   });
 
   it('returns an empty page for a buffer with nothing in it', () => {
     const net = netFor('rend-empty');
-    expect(listMessagesRenderable(net, '#nothing', { limit: 100 })).toEqual([]);
+    expect(listMessagesCounted(net, '#nothing', 'renderable', { limit: 100 })).toEqual([]);
   });
 
   it('bounds the scan (and so the payload) at maxScan', () => {
@@ -1281,7 +1282,7 @@ describe('listMessagesRenderable', () => {
     const net = netFor('rend-cap');
     for (let j = 0; j < 300; j += 1) event(net, '#a', 'join', `n${j}`);
     chat(net, '#a', 'alice', 'the one message');
-    const rows = listMessagesRenderable(net, '#a', { limit: 50, maxScan: 100 });
+    const rows = listMessagesCounted(net, '#a', 'renderable', { limit: 50, maxScan: 100 });
     expect(rows).toHaveLength(100);
     expect(rows.filter((e) => e.type === 'message')).toHaveLength(1);
     expectContiguous(rows, net, '#a');
@@ -1296,7 +1297,7 @@ describe('listMessagesRenderable', () => {
     for (const type of ['kick', 'mode', 'topic', 'kick', 'mode']) {
       event(net, '#a', type, 'alice');
     }
-    const rows = listMessagesRenderable(net, '#a', { limit: 2 });
+    const rows = listMessagesCounted(net, '#a', 'renderable', { limit: 2 });
     expect(rows).toHaveLength(2);
     expect(rows.map((r) => r.type)).toEqual(['kick', 'mode']);
   });
@@ -1309,11 +1310,100 @@ describe('listMessagesRenderable', () => {
     const noiseCount = CONSOLIDATABLE_TYPES.size;
     chat(net, '#a', 'alice', 'the only renderable row');
 
-    const rows = listMessagesRenderable(net, '#a', { limit: 1 });
+    const rows = listMessagesCounted(net, '#a', 'renderable', { limit: 1 });
     expect(rows).toHaveLength(1);
     expect(rows[0].text).toBe('the only renderable row');
     // ...and asking for two pulls in the whole noise run behind it.
-    expect(listMessagesRenderable(net, '#a', { limit: 2 })).toHaveLength(noiseCount + 1);
+    expect(listMessagesCounted(net, '#a', 'renderable', { limit: 2 })).toHaveLength(noiseCount + 1);
+  });
+});
+
+describe("listMessagesCounted unit: 'chat' (#666)", () => {
+  function netFor(name: string): number {
+    const user = createUser(name);
+    return createNetwork(user.id, { name: 'n', host: 'h', port: 6697, tls: true, nick: name })!.id;
+  }
+
+  it("delegates to the plain pager at unit 'event'", () => {
+    // 'event' has no scan pass to do — every stored row counts — so it must be
+    // indistinguishable from listMessages, cursor semantics included.
+    const net = netFor('unit-event');
+    for (let i = 1; i <= 6; i += 1) chat(net, '#a', 'alice', `m${i}`);
+    expect(listMessagesCounted(net, '#a', 'event', { limit: 3 })).toEqual(
+      listMessages(net, '#a', { limit: 3 }),
+    );
+  });
+
+  it('excludes mode rows from the budget where renderable would spend it', () => {
+    // The reason this unit exists: a reader on the `none` tier draws nothing for
+    // a mode row, so counting it hands them a page that renders short. An op
+    // handing out +v to a room is exactly the shape that produces this.
+    const net = netFor('unit-chat-mode');
+    for (let i = 1; i <= 10; i += 1) {
+      for (let j = 0; j < 5; j += 1) event(net, '#a', 'mode', `n${j}`);
+      chat(net, '#a', 'alice', `m${i}`);
+    }
+
+    const renderable = listMessagesCounted(net, '#a', 'renderable', { limit: 6 });
+    const chatUnit = listMessagesCounted(net, '#a', 'chat', { limit: 6 });
+
+    // 'renderable' counts modes as their own line, so six slots buy one message.
+    expect(renderable.filter((e) => e.type === 'message')).toHaveLength(1);
+    // 'chat' spends all six on messages.
+    expect(chatUnit.filter((e) => e.type === 'message')).toHaveLength(6);
+  });
+
+  it('still spends the budget on kicks, topics and invites', () => {
+    // The `none` tier hides churn, not events that carry information. If these
+    // were free the page would over-fetch on a buffer made mostly of them.
+    const net = netFor('unit-chat-standalone');
+    for (const type of ['kick', 'topic', 'invite', 'kick', 'topic']) {
+      event(net, '#a', type, 'alice');
+    }
+    const rows = listMessagesCounted(net, '#a', 'chat', { limit: 2 });
+    expect(rows.map((r) => r.type)).toEqual(['kick', 'topic']);
+  });
+
+  it('treats exactly NOISE_TYPES as free', () => {
+    // Drift guard, matching the renderable one above: the server must size the
+    // page in the same unit the client renders, or the whole exercise is moot.
+    const net = netFor('unit-chat-types');
+    for (const type of NOISE_TYPES) event(net, '#a', type, 'alice');
+    chat(net, '#a', 'alice', 'the only chat row');
+
+    const rows = listMessagesCounted(net, '#a', 'chat', { limit: 1 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text).toBe('the only chat row');
+    expect(listMessagesCounted(net, '#a', 'chat', { limit: 2 })).toHaveLength(NOISE_TYPES.size + 1);
+  });
+
+  it('returns an all-noise buffer rather than an empty page', () => {
+    // Same trap as the renderable case: [] reads to a client as "start of
+    // history" and stops its pager dead.
+    const net = netFor('unit-chat-allnoise');
+    for (let j = 0; j < 12; j += 1) event(net, '#a', 'mode', `n${j}`);
+    expect(listMessagesCounted(net, '#a', 'chat', { limit: 50 })).toHaveLength(12);
+  });
+
+  it('pages backward through `before` without a gap or an overlap', () => {
+    const net = netFor('unit-chat-page');
+    for (let i = 1; i <= 8; i += 1) {
+      event(net, '#a', 'mode', 'op');
+      event(net, '#a', 'join', `n${i}`);
+      chat(net, '#a', 'alice', `m${i}`);
+    }
+    const page1 = listMessagesCounted(net, '#a', 'chat', { limit: 3 });
+    const page2 = listMessagesCounted(net, '#a', 'chat', { limit: 3, before: page1[0].id });
+    expect(page1.filter((e) => e.type === 'message').map((e) => e.text)).toEqual([
+      'm6',
+      'm7',
+      'm8',
+    ]);
+    expect(page2.filter((e) => e.type === 'message').map((e) => e.text)).toEqual([
+      'm3',
+      'm4',
+      'm5',
+    ]);
   });
 });
 

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
-import { CONSOLIDATABLE_TYPES } from '../../shared/consolidate.js';
+import { countsTowardPage } from '../../shared/eventFilter.js';
+import type { PageUnit } from '../../shared/eventFilter.js';
 
 /** A raw row from the `messages` table. */
 interface MessageRow {
@@ -217,9 +218,12 @@ export function listMessages(
 // (consolidation excludes them on purpose), so each is worth one slot. Counting
 // only message/action/notice would still under-fill a buffer whose traffic is
 // kicks and topic edits.
-function isRenderableType(type: string): boolean {
-  return !CONSOLIDATABLE_TYPES.has(type);
-}
+//
+// The `chat` unit (#666) is the same idea one rung stricter: a client on the
+// `none` event tier draws nothing at all for join/part/quit/nick/chghost OR
+// mode, so those must not spend budget either, or the reader pages through
+// screenfuls of rows that render as nothing. `countsTowardPage` owns both
+// definitions so the server and the clients can't disagree about them.
 
 // Bounds both the floor scan and the resulting payload. A netsplit can put tens
 // of thousands of joins between two sentences; past this many rows the page
@@ -229,10 +233,19 @@ function isRenderableType(type: string): boolean {
 // motivated the feature.
 export const RENDERABLE_MAX_SCAN = 2000;
 
+/** Cursor + sizing options shared by every paging entry point here. */
+interface PageOptions {
+  before?: number;
+  afterId?: number;
+  limit?: number;
+  maxScan?: number;
+}
+
 /**
- * A page holding up to `limit` RENDERABLE rows, plus every consolidatable row
- * interleaved with them (consolidation needs the whole run to summarize it
- * accurately). Oldest-first, like `listMessages`.
+ * A page holding up to `limit` rows that COUNT under `unit`, plus every
+ * non-counting row interleaved with them (consolidation needs the whole run to
+ * summarize it accurately, and at the `chat` unit the extra rows are simply
+ * dropped by the client). Oldest-first, like `listMessages`.
  *
  * `before` pages backward (id < before), `afterId` pages forward (id > afterId),
  * neither pages the newest slice — matching `listMessages`' cursor semantics so
@@ -248,20 +261,20 @@ export const RENDERABLE_MAX_SCAN = 2000;
  * a (id, type) scan to find the boundary row, then a fetch of the range it
  * bounds.
  */
-export function listMessagesRenderable(
+export function listMessagesCounted(
   networkId: number,
   target: string,
-  {
-    before,
-    afterId,
-    limit = 100,
-    maxScan = RENDERABLE_MAX_SCAN,
-  }: { before?: number; afterId?: number; limit?: number; maxScan?: number } = {},
+  unit: PageUnit,
+  { before, afterId, limit = 100, maxScan = RENDERABLE_MAX_SCAN }: PageOptions = {},
 ): MessageEvent[] {
+  // 'event' counts every stored row, which is precisely what the plain cursor
+  // pager already does — no scan pass needed.
+  if (unit === 'event') return listMessages(networkId, target, { before, afterId, limit });
+
   const forward = afterId != null && afterId > 0;
 
   // Step 1: walk out from the cursor and stop at whichever comes first — the
-  // `limit`-th renderable row, or `maxScan` rows.
+  // `limit`-th COUNTING row, or `maxScan` rows.
   const scanSql = forward
     ? `SELECT id, type FROM messages WHERE network_id = ? AND target = ? AND id > ? ORDER BY id ASC LIMIT ?`
     : before
@@ -274,15 +287,15 @@ export function listMessagesRenderable(
   const scanned = db.prepare(scanSql).all(...scanParams) as Array<{ id: number; type: string }>;
   if (scanned.length === 0) return [];
 
-  // The last row to include. Landing ON the `limit`-th renderable row (rather
+  // The last row to include. Landing ON the `limit`-th counting row (rather
   // than past it) leaves any adjacent noise for the NEXT page, where it will be
   // consolidated with the rest of its run instead of dangling.
   let boundary = scanned[scanned.length - 1].id;
-  let renderable = 0;
+  let counted = 0;
   for (const row of scanned) {
-    if (!isRenderableType(row.type)) continue;
-    renderable += 1;
-    if (renderable === limit) {
+    if (!countsTowardPage(row.type, unit)) continue;
+    counted += 1;
+    if (counted === limit) {
       boundary = row.id;
       break;
     }
@@ -318,12 +331,12 @@ export function listMessagesAround(
   target: string,
   anchorId: number,
   halfLimit = 100,
-  // Sizes each SIDE in renderable rows (#10). Matters more here than the name
+  // Sizes each SIDE in the caller's unit (#10). Matters more here than the name
   // "jump" suggests: a client entering a buffer with a pending jump — a push
   // notification, a highlight, jump-to-first-unread — hydrates from this slice
   // and nothing else, so on a channel back from a netsplit an event-counted
   // window is the same near-blank screenful the feature exists to remove.
-  countBy: 'event' | 'renderable' = 'event',
+  countBy: PageUnit = 'event',
 ):
   | { events: MessageEvent[]; hasMoreOlder: boolean; hasMoreNewer: boolean }
   | { events: []; hasMoreOlder: false; hasMoreNewer: false; anchorMissing: true } {
@@ -333,9 +346,14 @@ export function listMessagesAround(
   if (!anchorRow) {
     return { events: [], hasMoreOlder: false, hasMoreNewer: false, anchorMissing: true };
   }
-  const page = countBy === 'renderable' ? listMessagesRenderable : listMessages;
-  const older = page(networkId, target, { before: anchorId, limit: halfLimit });
-  const newer = page(networkId, target, { afterId: anchorId, limit: halfLimit });
+  const older = listMessagesCounted(networkId, target, countBy, {
+    before: anchorId,
+    limit: halfLimit,
+  });
+  const newer = listMessagesCounted(networkId, target, countBy, {
+    afterId: anchorId,
+    limit: halfLimit,
+  });
   const events = [...older, rowToEvent(anchorRow), ...newer];
   const oldestId = events[0].id as number;
   const newestId = events[events.length - 1].id as number;

--- a/server/db/migrateEventMode.test.ts
+++ b/server/db/migrateEventMode.test.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type BetterSqlite3 from 'better-sqlite3';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: BetterSqlite3.Database;
+let createUser: typeof import('./users.js').createUser;
+let getUserSettings: typeof import('./settings.js').getUserSettings;
+let migrateSmartFilterToEventMode: typeof import('./migrateEventMode.js').migrateSmartFilterToEventMode;
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  ({ createUser } = await import('./users.js'));
+  ({ getUserSettings } = await import('./settings.js'));
+  ({ migrateSmartFilterToEventMode } = await import('./migrateEventMode.js'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Write a raw settings row, bypassing the registry validation the API applies. */
+function setRaw(userId: number, key: string, json: string): void {
+  db.prepare(
+    `INSERT INTO user_settings (user_id, key, value, updated_at)
+     VALUES (?, ?, ?, datetime('now'))
+     ON CONFLICT (user_id, key) DO UPDATE SET value = excluded.value`,
+  ).run(userId, key, json);
+}
+
+function rawKeys(userId: number): string[] {
+  return (
+    db
+      .prepare(`SELECT key FROM user_settings WHERE user_id = ? ORDER BY key`)
+      .all(userId) as Array<{
+      key: string;
+    }>
+  ).map((r) => r.key);
+}
+
+describe('migrateSmartFilterToEventMode (#666)', () => {
+  it('carries an enabled smart filter onto BOTH tier keys', () => {
+    // The whole point of the migration. Writing only the desktop key would
+    // quietly downgrade this person's phone to "show me everything" — a
+    // behavior change on a device they never touched a setting for, since
+    // smart filtering was one global preference before the tier split it.
+    const user = createUser('sf-on');
+    setRaw(user.id, 'chat.smart_filter', 'true');
+
+    expect(migrateSmartFilterToEventMode(db)).toBe(1);
+
+    const values = getUserSettings(user.id);
+    expect(values['chat.events']).toBe('smart');
+    expect(values['chat.events.mobile']).toBe('smart');
+    expect(rawKeys(user.id)).not.toContain('chat.smart_filter');
+  });
+
+  it('retires an explicitly-disabled smart filter without storing a default row', () => {
+    // `all` IS the registry default, and the server drops rows equal to their
+    // default on ordinary writes. Persisting one here would light the Settings
+    // UI's "modified" marker up on a setting the user never chose.
+    const user = createUser('sf-off');
+    setRaw(user.id, 'chat.smart_filter', 'false');
+
+    expect(migrateSmartFilterToEventMode(db)).toBe(1);
+
+    expect(getUserSettings(user.id)['chat.events']).toBeUndefined();
+    expect(rawKeys(user.id)).not.toContain('chat.smart_filter');
+  });
+
+  it('never clobbers a tier the user has already set', () => {
+    // A client on the new build can write a tier before this runs — a
+    // mid-upgrade session, or a DB restored from a mixed backup. The explicit
+    // newer choice outranks the legacy row we are here to retire.
+    const user = createUser('sf-conflict');
+    setRaw(user.id, 'chat.smart_filter', 'true');
+    setRaw(user.id, 'chat.events', '"none"');
+
+    migrateSmartFilterToEventMode(db);
+
+    const values = getUserSettings(user.id);
+    expect(values['chat.events']).toBe('none');
+    // The key they hadn't set still gets the legacy preference.
+    expect(values['chat.events.mobile']).toBe('smart');
+  });
+
+  it('treats a malformed legacy row as unset and retires it', () => {
+    // getUserSettings already skips unparseable rows, so this one was doing
+    // nothing. Converting it to the default and deleting it stops it being a
+    // row nothing in the system can read.
+    const user = createUser('sf-garbage');
+    setRaw(user.id, 'chat.smart_filter', 'not json');
+
+    expect(migrateSmartFilterToEventMode(db)).toBe(1);
+
+    expect(getUserSettings(user.id)['chat.events']).toBeUndefined();
+    expect(rawKeys(user.id)).not.toContain('chat.smart_filter');
+  });
+
+  it('is idempotent and self-terminating', () => {
+    const user = createUser('sf-rerun');
+    setRaw(user.id, 'chat.smart_filter', 'true');
+
+    expect(migrateSmartFilterToEventMode(db)).toBe(1);
+    // Nothing left to convert — this is what lets it run unguarded on every
+    // boot instead of needing a schema_version it could be stamped past.
+    expect(migrateSmartFilterToEventMode(db)).toBe(0);
+    expect(getUserSettings(user.id)['chat.events']).toBe('smart');
+  });
+
+  it('leaves users who never set the legacy key alone', () => {
+    const user = createUser('sf-untouched');
+    setRaw(user.id, 'chat.consolidate_max_names', '9');
+
+    migrateSmartFilterToEventMode(db);
+
+    expect(rawKeys(user.id)).toEqual(['chat.consolidate_max_names']);
+  });
+
+  it('migrates several users in one pass', () => {
+    const a = createUser('sf-multi-a');
+    const b = createUser('sf-multi-b');
+    setRaw(a.id, 'chat.smart_filter', 'true');
+    setRaw(b.id, 'chat.smart_filter', 'true');
+
+    expect(migrateSmartFilterToEventMode(db)).toBe(2);
+
+    expect(getUserSettings(a.id)['chat.events']).toBe('smart');
+    expect(getUserSettings(b.id)['chat.events']).toBe('smart');
+  });
+});

--- a/server/db/migrateEventMode.ts
+++ b/server/db/migrateEventMode.ts
@@ -53,18 +53,22 @@ export function migrateSmartFilterToEventMode(db: Database.Database): number {
         // does with it — so it converts to the default tier and stops being a
         // row nothing can read.
       }
+      // Only `smart` needs storing. `all` IS the registry default, and the server
+      // drops rows equal to their default on normal writes — persisting one here
+      // would light the Settings UI's "modified" marker on a setting the user
+      // never chose. Checked before the point reads below so the common
+      // (smart-filter-off) row costs nothing but its delete.
       const mode: EventMode = smart ? 'smart' : 'all';
-      for (const key of [EVENT_MODE_KEY, EVENT_MODE_KEY_MOBILE]) {
-        // Don't clobber a tier the user has ALREADY set. That happens when a
-        // client running the new build wrote a tier before this migration ran
-        // (a mid-upgrade session, or a DB restored from a mixed backup) — their
-        // explicit newer choice outranks a legacy row we're here to retire.
-        if ((readKey.get(row.userId, key) as { value: string } | undefined) !== undefined) continue;
-        // The server drops rows equal to the registry default on normal writes;
-        // match that here so a migrated `all` doesn't leave the Settings UI
-        // showing "modified" on a setting the user never chose.
-        if (mode === 'all') continue;
-        writeKey.run(row.userId, key, JSON.stringify(mode));
+      if (mode === 'smart') {
+        for (const key of [EVENT_MODE_KEY, EVENT_MODE_KEY_MOBILE]) {
+          // Don't clobber a tier the user has ALREADY set. That happens when a
+          // client running the new build wrote a tier before this migration ran
+          // (a mid-upgrade session, or a DB restored from a mixed backup) — their
+          // explicit newer choice outranks a legacy row we're here to retire.
+          const existing = readKey.get(row.userId, key) as { value: string } | undefined;
+          if (existing !== undefined) continue;
+          writeKey.run(row.userId, key, JSON.stringify(mode));
+        }
       }
       dropLegacy.run(row.userId, LEGACY_KEY);
       migrated += 1;
@@ -72,5 +76,14 @@ export function migrateSmartFilterToEventMode(db: Database.Database): number {
     return migrated;
   });
 
-  return migrate(rows) as number;
+  // BEGIN IMMEDIATE, not deferred: this transaction opens with a READ (the
+  // don't-clobber probe) before its first write. Under a deferred BEGIN that read
+  // establishes the snapshot, and on a hosted cell Litestream's once-a-second sync
+  // writes its own bookkeeping in that window — staling the snapshot so the first
+  // write dies with SQLITE_BUSY_SNAPSHOT, which is non-retryable (the 2026-07-19
+  // roswell incident, see the note in db/index.ts). The caller swallows the throw
+  // as a warning, so the cost isn't a crash: it's this migration being silently
+  // skipped for that boot, leaving everyone who had smart filtering on running
+  // with it off until some later boot wins the race.
+  return migrate.immediate(rows) as number;
 }

--- a/server/db/migrateEventMode.ts
+++ b/server/db/migrateEventMode.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type Database from 'better-sqlite3';
+import { EVENT_MODE_KEY, EVENT_MODE_KEY_MOBILE, type EventMode } from '../../shared/eventFilter.js';
+
+const LEGACY_KEY = 'chat.smart_filter';
+
+// Issue #666: the standalone smart-filter master switch became the middle rung of
+// the `chat.events` tier. This is a RENAME OF MEANING, not just of a key, so it
+// needs a real migration — the registry no longer has a `chat.smart_filter`
+// entry, and a stored row under a key nothing reads is indistinguishable from
+// never having set it. Skipping this would silently put every person who
+// deliberately turned smart filtering on back onto "show me everything", which
+// is precisely the failure `chat.image_modal.enabled` carries a comment about.
+//
+// Both tier keys are written, not just the desktop one. Smart filtering was a
+// single global preference before the tier split it by device class, so writing
+// only `chat.events` would quietly downgrade these users' phones to `all` — a
+// behavior change on a device they never touched a setting for.
+//
+// Idempotent and self-terminating: the legacy rows are deleted as they convert,
+// so a re-run finds nothing. No schema_version gate — a version-gated block
+// can't fix a DB already stamped past it, and this one self-heals.
+//
+// Returns the number of users migrated.
+export function migrateSmartFilterToEventMode(db: Database.Database): number {
+  const rows = db
+    .prepare(`SELECT user_id AS userId, value FROM user_settings WHERE key = ?`)
+    .all(LEGACY_KEY) as Array<{ userId: number; value: string }>;
+  if (!rows.length) return 0;
+
+  const readKey = db.prepare(
+    `SELECT value FROM user_settings WHERE user_id = ? AND key = ?`,
+  ) as Database.Statement;
+  const writeKey = db.prepare(`
+    INSERT INTO user_settings (user_id, key, value, updated_at)
+    VALUES (?, ?, ?, datetime('now'))
+    ON CONFLICT (user_id, key) DO UPDATE SET
+      value = excluded.value,
+      updated_at = excluded.updated_at
+  `);
+  const dropLegacy = db.prepare(`DELETE FROM user_settings WHERE user_id = ? AND key = ?`);
+
+  const migrate = db.transaction((pending: Array<{ userId: number; value: string }>) => {
+    let migrated = 0;
+    for (const row of pending) {
+      let smart = false;
+      try {
+        smart = JSON.parse(row.value) === true;
+      } catch {
+        // A malformed row is treated as unset — the same thing getUserSettings
+        // does with it — so it converts to the default tier and stops being a
+        // row nothing can read.
+      }
+      const mode: EventMode = smart ? 'smart' : 'all';
+      for (const key of [EVENT_MODE_KEY, EVENT_MODE_KEY_MOBILE]) {
+        // Don't clobber a tier the user has ALREADY set. That happens when a
+        // client running the new build wrote a tier before this migration ran
+        // (a mid-upgrade session, or a DB restored from a mixed backup) — their
+        // explicit newer choice outranks a legacy row we're here to retire.
+        if ((readKey.get(row.userId, key) as { value: string } | undefined) !== undefined) continue;
+        // The server drops rows equal to the registry default on normal writes;
+        // match that here so a migrated `all` doesn't leave the Settings UI
+        // showing "modified" on a setting the user never chose.
+        if (mode === 'all') continue;
+        writeKey.run(row.userId, key, JSON.stringify(mode));
+      }
+      dropLegacy.run(row.userId, LEGACY_KEY);
+      migrated += 1;
+    }
+    return migrated;
+  });
+
+  return migrate(rows) as number;
+}

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -33,6 +33,7 @@ import { EXPORT_TABLES, EXPORT_FORMAT_VERSION, IMPORT_ORDER } from '../db/export
 import { encryptSecret } from '../utils/secretCrypto.js';
 import { importRow as importBufferRow } from '../db/buffers.js';
 import { listBufferTargets, hasMessageForTarget } from '../db/messages.js';
+import { migrateSmartFilterToEventMode } from '../db/migrateEventMode.js';
 import ignoreRulesService from './ignoreRulesService.js';
 import type { IgnorePatternKind } from '../db/ignoredMasks.js';
 
@@ -592,6 +593,14 @@ export async function importFromZipFile(
         // history. Modern archives skip this (their buffers table imported in
         // Phase A).
         convertLegacyBuffers(data, idMaps, counts, targetUserId);
+
+        // An archive taken before #666 carries a live `chat.smart_filter` row,
+        // which the boot migration has already retired everywhere else — so
+        // importing one reintroduces a key nothing reads, and the user's smart
+        // filtering silently reverts to "show everything" until the next restart
+        // happens to re-run it. Idempotent and self-terminating, so calling it
+        // here just converts whatever this import brought in.
+        migrateSmartFilterToEventMode(db);
       })();
     } catch (err) {
       resetImportedData(targetUserId);

--- a/server/services/verbs/recentMessages.ts
+++ b/server/services/verbs/recentMessages.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { registerVerb } from '../verbRegistry.js';
-import { listMessages, listMessagesRenderable, hasOlderRow } from '../../db/messages.js';
+import { listMessagesCounted, hasOlderRow } from '../../db/messages.js';
+import { asPageUnit } from '../../../shared/eventFilter.js';
 import { decorateMessage } from '../wsHub.js';
 
 /** Authenticated caller context passed to every verb handler. */
@@ -39,12 +40,14 @@ registerVerb({
       },
       countBy: {
         type: 'string',
-        enum: ['event', 'renderable'],
+        enum: ['event', 'renderable', 'chat'],
         description:
           'What `limit` counts. "event" (default) counts every stored row. "renderable" counts ' +
           'only rows that render as their own line — join/part/quit/nick/host-change events are ' +
           'still returned, but do not spend the budget, so a channel full of presence churn ' +
-          'still yields a full page of readable content.',
+          'still yields a full page of readable content. "chat" goes one further and also ' +
+          'excludes mode changes from the budget, matching a reader who hides event noise ' +
+          'entirely. All three return the same contiguous id range; only the sizing differs.',
       },
     },
     required: ['networkId', 'target'],
@@ -60,10 +63,10 @@ registerVerb({
     const before = input.before ? Number(input.before) : undefined;
     // Unrecognized values fall back to today's behavior rather than erroring —
     // the field is additive and an old caller never sends it at all.
-    const renderable = input.countBy === 'renderable';
-    const rows = renderable
-      ? listMessagesRenderable(networkId, target, { before, limit })
-      : listMessages(networkId, target, { before, limit });
+    const rows = listMessagesCounted(networkId, target, asPageUnit(input.countBy), {
+      before,
+      limit,
+    });
     const events = rows.map((e) => decorateMessage(ctx.userId, e));
     const oldestId = events.length ? events[0].id : 0;
     return {

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -7,6 +7,8 @@ import type { WebSocket } from 'ws';
 import type { User } from '../db/users.js';
 import type { LogLine } from './systemLog.js';
 import type { MessageEvent } from '../db/messages.js';
+import type { PageUnit } from '../../shared/eventFilter.js';
+import { asPageUnit } from '../../shared/eventFilter.js';
 import { WebSocketServer } from 'ws';
 import cookie from 'cookie';
 import cookieParser from 'cookie-parser';
@@ -27,7 +29,7 @@ import { findUserById, touchUserLastSeen } from '../db/users.js';
 import { effectiveUploadCapBytes } from './uploadLimits.js';
 import {
   listMessages,
-  listMessagesRenderable,
+  listMessagesCounted,
   listMessagesAround,
   hasOlderRow,
   hasNewerRow,
@@ -746,13 +748,10 @@ export function buildBufferBacklog(
   userId: number,
   networkId: number,
   target: string,
-  countBy: 'event' | 'renderable' = 'event',
+  countBy: PageUnit = 'event',
 ): WsPayload {
   const conn = ircManager.getConnection(userId, networkId);
-  const rows =
-    countBy === 'renderable'
-      ? listMessagesRenderable(networkId, target, { limit: 200 })
-      : listMessages(networkId, target, { limit: 200 });
+  const rows = listMessagesCounted(networkId, target, countBy, { limit: 200 });
   const events = rows.map((e) => decorateMessage(userId, e));
   const oldestId = rows.length ? (rows[0].id ?? 0) : 0;
   return {
@@ -1181,7 +1180,7 @@ export function handleOpenBuffer(
   userId: number,
   networkId: number,
   requested: string,
-  countBy: 'event' | 'renderable' = 'event',
+  countBy: PageUnit = 'event',
 ): void {
   if (!networkId || !requested || requested.startsWith(':server:')) return;
   const row = getBuffer(userId, networkId, requested);
@@ -2601,7 +2600,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           userId,
           Number(msg.networkId),
           typeof msg.target === 'string' ? msg.target : '',
-          msg.countBy === 'renderable' ? 'renderable' : 'event',
+          asPageUnit(msg.countBy),
         );
         break;
       case 'part':
@@ -3107,9 +3106,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // Only the CLIENT knows whether it actually folds those runs (web gates
         // on chat.consolidate_joins), which is why this is a request field and
         // not a server-side default: for a client rendering every event as its
-        // own line, 'event' is already the right unit.
-        const countBy: 'event' | 'renderable' =
-          msg.countBy === 'renderable' ? 'renderable' : 'event';
+        // own line, 'event' is already the right unit. 'chat' is the same
+        // argument one rung further for a client on the `none` event tier (#666),
+        // which draws no event rows at all.
+        const countBy = asPageUnit(msg.countBy);
         const token = msg.token ?? null;
         const speakers = listSpeakers(histNetworkId, histTarget);
         const baseReply = {
@@ -3159,10 +3159,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
             send(ws, { kind: 'error', text: 'invalid afterId' });
             break;
           }
-          const rows =
-            countBy === 'renderable'
-              ? listMessagesRenderable(histNetworkId, histTarget, { afterId, limit })
-              : listMessages(histNetworkId, histTarget, { afterId, limit });
+          const rows = listMessagesCounted(histNetworkId, histTarget, countBy, { afterId, limit });
           const events = rows.map((e) => decorateMessage(userId, e));
           const newestId = events.length ? events[events.length - 1].id : afterId;
           send(ws, {
@@ -3184,10 +3181,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           // upward paging cleanly, plus inputHistory so up-arrow recall is
           // restored for a shell (fresh-connect shells omit it, so this is the
           // only place a reloaded client gets its per-buffer recall back).
-          const rows =
-            countBy === 'renderable'
-              ? listMessagesRenderable(histNetworkId, histTarget, { limit })
-              : listMessages(histNetworkId, histTarget, { limit });
+          const rows = listMessagesCounted(histNetworkId, histTarget, countBy, { limit });
           const events = rows.map((e) => decorateMessage(userId, e));
           const oldestId = events.length ? events[0].id : 0;
           send(ws, {

--- a/shared/eventFilter.test.ts
+++ b/shared/eventFilter.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { CONSOLIDATABLE_TYPES } from './consolidate.js';
+import {
+  EVENT_MODES,
+  EVENT_MODE_KEY,
+  EVENT_MODE_KEY_MOBILE,
+  NOISE_TYPES,
+  asEventMode,
+  asPageUnit,
+  countsTowardPage,
+  eventModeKey,
+  isNoiseType,
+  pageUnitFor,
+} from './eventFilter.js';
+import { REGISTRY } from './settingsRegistry.js';
+
+describe('the noise set', () => {
+  it('is everything consolidation folds, plus mode', () => {
+    expect(NOISE_TYPES).toEqual(new Set([...CONSOLIDATABLE_TYPES, 'mode']));
+  });
+
+  it('spares the event types that carry information rather than churn', () => {
+    // A reader asking for no event noise wants a quieter buffer, not one that
+    // lies about what happened. Being kicked, a topic change, and an invite
+    // addressed to you all survive every tier.
+    for (const type of ['kick', 'topic', 'invite', 'error', 'message', 'action', 'notice']) {
+      expect(isNoiseType(type)).toBe(false);
+    }
+  });
+
+  it('hides presence churn and mode changes', () => {
+    for (const type of ['join', 'part', 'quit', 'nick', 'chghost', 'mode']) {
+      expect(isNoiseType(type)).toBe(true);
+    }
+  });
+});
+
+describe('tier resolution', () => {
+  it('reads the mobile key on mobile and the desktop key otherwise', () => {
+    expect(eventModeKey(true)).toBe(EVENT_MODE_KEY_MOBILE);
+    expect(eventModeKey(false)).toBe(EVENT_MODE_KEY);
+  });
+
+  it('falls back to `all` for anything unrecognized', () => {
+    // Stored values arrive from a DB row and the wire, neither of which is
+    // guaranteed to have been written by this version. Degrading to today's
+    // behavior beats throwing inside a render pass.
+    for (const bad of [undefined, null, '', 'smart-ish', 42, true]) {
+      expect(asEventMode(bad)).toBe('all');
+    }
+    for (const mode of EVENT_MODES) expect(asEventMode(mode)).toBe(mode);
+  });
+
+  it('exposes both tier keys as enum settings with matching choices', () => {
+    // Drift guard: the tier's values live in two places by necessity (the
+    // registry validates writes, this module drives rendering).
+    for (const key of [EVENT_MODE_KEY, EVENT_MODE_KEY_MOBILE]) {
+      const opt = REGISTRY.find((o) => o.key === key);
+      expect(opt?.type).toBe('enum');
+      expect(opt?.type === 'enum' && opt.choices).toEqual([...EVENT_MODES]);
+      expect(opt?.default).toBe('all');
+    }
+  });
+
+  it('has retired the standalone smart-filter switch', () => {
+    expect(REGISTRY.find((o) => o.key === 'chat.smart_filter')).toBeUndefined();
+  });
+});
+
+describe('page sizing', () => {
+  it('matches the unit to what the client actually draws', () => {
+    // The invariant the whole feature rests on: ask for a coarser unit than you
+    // render and pages arrive looking empty; ask for a finer one and a single
+    // page can drag in the server's entire scan window.
+    expect(pageUnitFor('all', true)).toBe('renderable');
+    expect(pageUnitFor('all', false)).toBe('event');
+    expect(pageUnitFor('smart', true)).toBe('renderable');
+    expect(pageUnitFor('smart', false)).toBe('event');
+    // `none` draws nothing for any noise type, so consolidation is moot.
+    expect(pageUnitFor('none', true)).toBe('chat');
+    expect(pageUnitFor('none', false)).toBe('chat');
+  });
+
+  it('counts every row under `event`', () => {
+    for (const type of [...NOISE_TYPES, 'message', 'kick']) {
+      expect(countsTowardPage(type, 'event')).toBe(true);
+    }
+  });
+
+  it('makes mode free under `chat` but not under `renderable`', () => {
+    expect(countsTowardPage('mode', 'renderable')).toBe(true);
+    expect(countsTowardPage('mode', 'chat')).toBe(false);
+  });
+
+  it('makes presence churn free under both of the counted units', () => {
+    for (const unit of ['renderable', 'chat'] as const) {
+      expect(countsTowardPage('join', unit)).toBe(false);
+      expect(countsTowardPage('quit', unit)).toBe(false);
+      expect(countsTowardPage('message', unit)).toBe(true);
+      expect(countsTowardPage('kick', unit)).toBe(true);
+    }
+  });
+
+  it('falls back to `event` for an unrecognized wire value', () => {
+    // The field is additive: an older client never sends it, and a newer one
+    // might send a unit this build has never heard of.
+    for (const bad of [undefined, null, 'renderable-ish', 7]) {
+      expect(asPageUnit(bad)).toBe('event');
+    }
+    expect(asPageUnit('renderable')).toBe('renderable');
+    expect(asPageUnit('chat')).toBe('chat');
+  });
+});

--- a/shared/eventFilter.test.ts
+++ b/shared/eventFilter.test.ts
@@ -15,7 +15,7 @@ import {
   isNoiseType,
   pageUnitFor,
 } from './eventFilter.js';
-import { REGISTRY } from './settingsRegistry.js';
+import { REGISTRY, CATEGORIES } from './settingsRegistry.js';
 
 describe('the noise set', () => {
   it('is everything consolidation folds, plus mode', () => {
@@ -67,6 +67,53 @@ describe('tier resolution', () => {
 
   it('has retired the standalone smart-filter switch', () => {
     expect(REGISTRY.find((o) => o.key === 'chat.smart_filter')).toBeUndefined();
+  });
+
+  /// The tier's values stay ids and its wording lives in `choiceLabels`. Renaming
+  /// a stored enum value to improve wording would be a migration paid for in
+  /// orphaned rows — the same trap `chat.image_modal.enabled` documents.
+  it('labels the tier choices without renaming the stored values', () => {
+    for (const key of [EVENT_MODE_KEY, EVENT_MODE_KEY_MOBILE]) {
+      const opt = REGISTRY.find((o) => o.key === key);
+      expect(opt?.type === 'enum' && opt.choiceLabels).toEqual({
+        all: 'No filter',
+        smart: 'Smart filter',
+        none: 'Hide all',
+      });
+    }
+  });
+
+  /// Every event setting lives in its own category, in narrowing order: the
+  /// filter, then how survivors are folded, then the tuning for the one rung
+  /// that needs it. Registry order IS render order, so this pins both.
+  it('collects every event setting into the Events category, in narrowing order', () => {
+    const events = REGISTRY.filter((o) => o.category === 'events');
+    expect(events.map((o) => o.key)).toEqual([
+      'chat.events',
+      'chat.events.mobile',
+      'chat.consolidate_joins',
+      'chat.consolidate_max_names',
+      'chat.show_event_host',
+      'chat.show_join_account',
+      'chat.smart_filter_delay',
+      'chat.smart_filter_join',
+      'chat.smart_filter_quit',
+      'chat.smart_filter_nick',
+      'chat.smart_filter_join_unmask',
+    ]);
+    expect([...new Set(events.map((o) => o.group))]).toEqual([
+      'event-filter',
+      'consolidate',
+      'smart-filter',
+    ]);
+    // The category has to exist in the sidebar, or the pane is unreachable.
+    expect(CATEGORIES.find((c) => c.id === 'events')).toEqual({
+      id: 'events',
+      label: 'Events',
+      kind: 'registry',
+    });
+    // ...and nothing event-shaped is left behind in Chat.
+    expect(REGISTRY.filter((o) => o.category === 'chat' && o.group === 'consolidate')).toEqual([]);
   });
 });
 

--- a/shared/eventFilter.ts
+++ b/shared/eventFilter.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The event-noise tier (#666) — the single primary answer to "which presence
+// events survive into the message list", shared by the server (page sizing) and
+// every client (rendering).
+//
+// Before this, the same question was spread across two independent switches
+// (`chat.consolidate_joins` and `chat.smart_filter`) whose combinations a user
+// had to reason about themselves, and there was no way to express "hide all of
+// it" at all — the ask that motivated the tier on mobile. The tier collapses the
+// primary choice to one enum; everything else in the `chat` category is a
+// modifier on the survivors (how they render, how aggressive `smart` is).
+//
+// The tier is resolved CLIENT-side: it decides what to draw, and the server has
+// no business knowing a given device's preference. The one thing the server does
+// need is the page UNIT (see PageUnit below), which the client asks for.
+
+import { CONSOLIDATABLE_TYPES } from './consolidate.js';
+
+// ─── The tier ──────────────────────────────────────────────────────────────
+
+/**
+ * How much join/part/quit/nick/host-change/mode noise reaches the message list.
+ *
+ * - `all`   — every event renders (folded into summary lines when
+ *             `chat.consolidate_joins` is on, which is the default).
+ * - `smart`  — events render only for nicks who have recently spoken; the
+ *             `chat.smart_filter_*` modifiers tune "recently" and which event
+ *             kinds participate.
+ * - `none`  — no event rows at all. Conversation only.
+ */
+export type EventMode = 'all' | 'smart' | 'none';
+
+/** Every valid tier value, in escalating-strictness order (the UI's order too). */
+export const EVENT_MODES = ['all', 'smart', 'none'] as const;
+
+/** Registry key holding the tier for a given device class. */
+export const EVENT_MODE_KEY = 'chat.events';
+export const EVENT_MODE_KEY_MOBILE = 'chat.events.mobile';
+
+/**
+ * Which of the two keys a client reads. Mirrors `look.font.size` /
+ * `look.font.size.mobile`: the web app switches on viewport width, and a native
+ * phone client is unconditionally mobile.
+ *
+ * Only the TIER is device-scoped. The modifiers stay global on purpose — at
+ * `none` they are all moot anyway, and nobody wants a different
+ * `chat.consolidate_max_names` on their phone than on their desktop.
+ */
+export function eventModeKey(isMobile: boolean): string {
+  return isMobile ? EVENT_MODE_KEY_MOBILE : EVENT_MODE_KEY;
+}
+
+/** Narrow an unvalidated stored/wire value to a tier, falling back to `all`. */
+export function asEventMode(value: unknown): EventMode {
+  return (EVENT_MODES as readonly string[]).includes(value as string)
+    ? (value as EventMode)
+    : 'all';
+}
+
+// ─── The noise set ─────────────────────────────────────────────────────────
+
+/**
+ * The row types `none` hides — and the set every other part of the system means
+ * by "event noise", so consolidation, smart filtering, and page sizing can't
+ * drift apart on the definition.
+ *
+ * It is CONSOLIDATABLE_TYPES plus `mode`. Mode changes are excluded from
+ * consolidation (they render as their own line and don't fold into a per-nick
+ * net effect), but a reader who asked for no event noise means op/voice/ban
+ * churn too — that's the point of the tier's strictest rung.
+ *
+ * Deliberately NOT included, because they are content rather than churn:
+ * `kick` (someone was removed, and by whom), `topic`, `invite`, `error`,
+ * `motd` and the various status lines. Hiding those would make the buffer lie
+ * about what happened rather than merely quieter.
+ */
+export const NOISE_TYPES: ReadonlySet<string> = new Set([...CONSOLIDATABLE_TYPES, 'mode']);
+
+/** Whether a message row is event noise, i.e. hidden entirely at `none`. */
+export function isNoiseType(type: string): boolean {
+  return NOISE_TYPES.has(type);
+}
+
+// ─── Page sizing ───────────────────────────────────────────────────────────
+
+/**
+ * What a `history` request's `limit` counts. The unit a client asks for must
+ * match the unit it RENDERS, or paging misbehaves in one of two directions:
+ * ask for too coarse a unit and pages arrive looking empty (the netsplit
+ * problem #10 fixed); too fine a unit and one page can drag in the server's
+ * whole scan window.
+ *
+ * - `event`      — every stored row. Correct when the client renders each
+ *                  event on its own line (tier `all`, consolidation off).
+ * - `renderable` — rows outside CONSOLIDATABLE_TYPES. Correct when the client
+ *                  FOLDS those runs into summary lines (tier `all`,
+ *                  consolidation on).
+ * - `chat`       — rows outside NOISE_TYPES. Correct at tier `none`, where the
+ *                  client draws nothing for any of them.
+ *
+ * There is deliberately no unit for `smart`: which events it hides depends on
+ * who spoke recently in that reader's client, which the server cannot know. A
+ * `smart` reader asks for `renderable` (or `event`) and can still get a
+ * short-looking page — the same pre-#10 behavior, tracked separately.
+ */
+export type PageUnit = 'event' | 'renderable' | 'chat';
+
+/** Narrow an unvalidated wire value to a page unit, falling back to `event`. */
+export function asPageUnit(value: unknown): PageUnit {
+  return value === 'renderable' || value === 'chat' ? value : 'event';
+}
+
+/**
+ * Whether a row spends page budget under the given unit. `event` counts
+ * everything; the other two subtract their respective noise set.
+ */
+export function countsTowardPage(type: string, unit: PageUnit): boolean {
+  if (unit === 'renderable') return !CONSOLIDATABLE_TYPES.has(type);
+  if (unit === 'chat') return !NOISE_TYPES.has(type);
+  return true;
+}
+
+/**
+ * The page unit a client should request, given its tier and whether it folds.
+ * Shared so the web and native clients can't answer it differently.
+ */
+export function pageUnitFor(mode: EventMode, consolidate: boolean): PageUnit {
+  if (mode === 'none') return 'chat';
+  return consolidate ? 'renderable' : 'event';
+}

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -93,6 +93,16 @@ export interface EnumOption extends BaseOption {
   type: 'enum';
   choices: readonly string[];
   default: string;
+  // Display text per choice, for enums whose stored values read as identifiers
+  // rather than as English. Omit and clients render the raw value, which is the
+  // right answer for a choice like `auto` / `standard` / `compact`.
+  //
+  // The values stay the ids — see the note on `chat.image_modal.enabled` about
+  // keys aging. Renaming a stored enum value is a MIGRATION, and doing one to
+  // improve wording would be paying in orphaned rows for something a label
+  // fixes for free. A choice with no entry here falls back to its raw value, so
+  // a partial map is safe.
+  choiceLabels?: Readonly<Record<string, string>>;
 }
 
 /** Multi-value settings: an ordered list of strings. */
@@ -117,10 +127,10 @@ export interface SettingCategory {
 }
 
 // ─── Shared dependency clauses ─────────────────────────────────────────────
-// The `chat` category's modifiers all hang off the event-noise tier, which is
-// two keys (desktop + mobile). A modifier is live if EITHER device class can
-// still see the thing it modifies — a phone set to "none" must not grey out the
-// consolidation knobs a desktop is actively using, and vice versa.
+// Everything else in the Events category hangs off the event filter, which is
+// two keys (desktop + mobile). A setting is live if EITHER device class can
+// still see the thing it modifies — a phone set to "Hide all" must not grey out
+// the consolidation knobs a desktop is actively using, and vice versa.
 
 /** Live when at least one device class renders event rows at all. */
 const EVENTS_VISIBLE: readonly SettingDependency[] = Object.freeze([
@@ -749,47 +759,52 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'overrides this per channel and is remembered. Has no effect on mobile.',
   },
 
-  // ─── Event noise tier (#666) ──────────────────────────────────────────
-  // The primary "how much presence churn do I want to see" choice. Everything
-  // in the two groups below is a modifier on whatever this leaves standing —
-  // see shared/eventFilter.ts for the tier semantics and the noise set.
+  // ─── Events: the filter (#666) ────────────────────────────────────────
+  // The primary "how much presence churn do I want to see" choice, and the
+  // reason this category exists. Everything in the two groups below is a
+  // modifier on whatever this leaves standing — see shared/eventFilter.ts for
+  // the tier semantics and the noise set. Registry ORDER decides the order the
+  // pane renders its groups in, so keep these three adjacent and in this
+  // sequence: filter, then consolidation, then smart-filter tuning.
   {
     key: 'chat.events',
-    label: 'Event noise',
-    category: 'chat',
-    group: 'events',
+    label: 'Event filter',
+    category: 'events',
+    group: 'event-filter',
     type: 'enum',
     choices: ['all', 'smart', 'none'],
+    choiceLabels: { all: 'No filter', smart: 'Smart filter', none: 'Hide all' },
     default: 'all',
     description:
       'How much join/part/quit/nick/host-change/mode noise reaches the message list. ' +
-      '"all" (the default) shows every event, folded into summary lines when ' +
-      'consolidation is on. "smart" shows events only for nicks who have recently ' +
-      'spoken, so silent lurkers cycling on and off stay invisible. "none" hides ' +
+      '"No filter" (the default) shows every event, folded into summary lines when ' +
+      'consolidation is on. "Smart filter" shows events only for nicks who have recently ' +
+      'spoken, so silent lurkers cycling on and off stay invisible. "Hide all" removes ' +
       'event rows entirely, leaving conversation only. Kicks, topic changes and ' +
       'invites are never hidden — they are things that happened, not churn.',
   },
   {
     key: 'chat.events.mobile',
-    label: 'Event noise (mobile)',
-    category: 'chat',
-    group: 'events',
+    label: 'Event filter (mobile)',
+    category: 'events',
+    group: 'event-filter',
     type: 'enum',
     choices: ['all', 'smart', 'none'],
+    choiceLabels: { all: 'No filter', smart: 'Smart filter', none: 'Hide all' },
     default: 'all',
     description:
       'The same choice for phone-sized viewports (≤768px) and the native mobile ' +
       'apps, which read this key unconditionally. A phone screen holds a fraction ' +
-      'of the lines a desktop one does, so "none" is a common pick here even for ' +
-      'people who want "all" at their desk. Only the tier is split by device — the ' +
-      'modifiers below are shared.',
+      'of the lines a desktop one does, so "Hide all" is a common pick here even for ' +
+      'people who want everything at their desk. Only the filter is split by device — ' +
+      'the settings below are shared.',
   },
 
   // ─── Join/part consolidation (IRCCloud-style summary line) ────────────
   {
     key: 'chat.consolidate_joins',
     label: 'Consolidate join/part/quit/nick/host-change events',
-    category: 'chat',
+    category: 'events',
     group: 'consolidate',
     type: 'bool',
     default: true,
@@ -803,7 +818,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   {
     key: 'chat.consolidate_max_names',
     label: 'Max nicks per summary category',
-    category: 'chat',
+    category: 'events',
     group: 'consolidate',
     type: 'int',
     min: 1,
@@ -821,7 +836,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   {
     key: 'chat.show_event_host',
     label: 'Show user@host on join/part/quit/nick',
-    category: 'chat',
+    category: 'events',
     group: 'consolidate',
     type: 'bool',
     default: false,
@@ -838,7 +853,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   {
     key: 'chat.show_join_account',
     label: 'Show services account on join lines',
-    category: 'chat',
+    category: 'events',
     group: 'consolidate',
     type: 'bool',
     default: false,
@@ -853,9 +868,8 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
 
   // ─── Smart filter tuning (join/part/quit/nick noise) ──────────────────
-  // Sits directly under the tier and consolidation — the three groups answer
-  // one question between them, and the render order here is what the Settings
-  // pane groups by, so nothing unrelated may be inserted between them.
+  // Last of the three Events groups, and the narrowest — it only does anything
+  // on one rung of the filter.
   //
   // The master switch used to live here as `chat.smart_filter`; it is now the
   // middle rung of `chat.events` (#666), and a boot migration carries anyone who
@@ -863,7 +877,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   {
     key: 'chat.smart_filter_delay',
     label: '"Recently spoke" window (minutes)',
-    category: 'chat',
+    category: 'events',
     group: 'smart-filter',
     type: 'int',
     min: 0,
@@ -878,7 +892,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   {
     key: 'chat.smart_filter_join',
     label: 'Filter joins',
-    category: 'chat',
+    category: 'events',
     group: 'smart-filter',
     type: 'bool',
     default: true,
@@ -888,7 +902,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   {
     key: 'chat.smart_filter_quit',
     label: 'Filter parts and quits',
-    category: 'chat',
+    category: 'events',
     group: 'smart-filter',
     type: 'bool',
     default: true,
@@ -898,7 +912,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   {
     key: 'chat.smart_filter_nick',
     label: 'Filter nick changes',
-    category: 'chat',
+    category: 'events',
     group: 'smart-filter',
     type: 'bool',
     default: true,
@@ -908,7 +922,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   {
     key: 'chat.smart_filter_join_unmask',
     label: 'Reveal join when user speaks (minutes)',
-    category: 'chat',
+    category: 'events',
     group: 'smart-filter',
     type: 'int',
     min: 0,
@@ -1599,6 +1613,12 @@ export function defaultsAsObject(): Record<string, SettingValue> {
 export const CATEGORIES: readonly SettingCategory[] = Object.freeze([
   { id: 'appearance', label: 'Appearance', kind: 'registry' },
   { id: 'chat', label: 'Chat', kind: 'registry' },
+  // Everything about join/part/quit/nick/host-change/mode lines: whether you see
+  // them at all, how they're folded, and how much detail each carries. Split out
+  // of Chat (#666) because the tier turned three loosely-related groups into one
+  // subject with a single primary control, and that subject is big enough to
+  // stop being a tail on a category about composing and reading messages.
+  { id: 'events', label: 'Events', kind: 'registry' },
   { id: 'input', label: 'Input bar', kind: 'registry' },
   // Bespoke: the pane leads with the configured-uploader list + picker (which is
   // table-backed, not registry-backed) and renders the surviving registry rows
@@ -1629,8 +1649,8 @@ export const GROUPS: Readonly<Record<string, string>> = Object.freeze({
   nicks: 'Nick coloring',
   layout: 'Layout',
   misc: 'Misc',
-  events: 'Event noise',
-  consolidate: 'Join/part consolidation',
+  'event-filter': 'Filter',
+  consolidate: 'Consolidation',
   composing: 'Composing',
   'smart-filter': 'Smart filter tuning',
   connection: 'Connection',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -21,6 +21,15 @@ export type SettingType = 'string' | 'color' | 'secret' | 'int' | 'bool' | 'enum
 /** A stored setting value, in its decoded (non-string) form. */
 export type SettingValue = string | number | boolean | string[];
 
+/**
+ * One "this setting is live when …" clause. `key` must name another registry
+ * option; the clause holds when that option's effective value is one of `in`.
+ */
+export interface SettingDependency {
+  key: string;
+  in: readonly SettingValue[];
+}
+
 interface BaseOption {
   key: string;
   label: string;
@@ -40,6 +49,23 @@ interface BaseOption {
   // trivially bypassable. The upload pipeline limits (uploads.image.*) are the
   // reference pattern: hidden here, enforced in the cell's upload route.
   selfHostedOnly?: boolean;
+
+  // Conditions under which this setting actually does anything, ORed together:
+  // the option is live if ANY clause holds. Resolution is TRANSITIVE — an
+  // option whose dependency is itself inactive is inactive too, so a chain like
+  // `consolidate_max_names → consolidate_joins → chat.events` only needs each
+  // link stated once.
+  //
+  // Presentation only, and deliberately so: an inactive setting still stores and
+  // returns its value, because the condition can flip back (switching a phone
+  // off `none` must restore exactly the modifiers that were set before, not a
+  // pile of defaults). Clients render these greyed out; nothing enforces them.
+  //
+  // The tier keys (chat.events / chat.events.mobile) are why this exists as
+  // registry data rather than a hardcoded map per client — the iOS settings
+  // screen was already carrying one of these by hand for consolidate_max_names,
+  // and the tier adds eight more.
+  dependsOn?: readonly SettingDependency[];
 }
 
 /** Free-text settings: plain strings, CSS colors, and write-only secrets. */
@@ -89,6 +115,24 @@ export interface SettingCategory {
   // As on BaseOption: hide the whole category in the hosted (node) edition.
   selfHostedOnly?: boolean;
 }
+
+// ─── Shared dependency clauses ─────────────────────────────────────────────
+// The `chat` category's modifiers all hang off the event-noise tier, which is
+// two keys (desktop + mobile). A modifier is live if EITHER device class can
+// still see the thing it modifies — a phone set to "none" must not grey out the
+// consolidation knobs a desktop is actively using, and vice versa.
+
+/** Live when at least one device class renders event rows at all. */
+const EVENTS_VISIBLE: readonly SettingDependency[] = Object.freeze([
+  { key: 'chat.events', in: ['all', 'smart'] },
+  { key: 'chat.events.mobile', in: ['all', 'smart'] },
+]);
+
+/** Live when at least one device class is on the smart tier. */
+const EVENTS_SMART: readonly SettingDependency[] = Object.freeze([
+  { key: 'chat.events', in: ['smart'] },
+  { key: 'chat.events.mobile', in: ['smart'] },
+]);
 
 export const REGISTRY: readonly SettingOption[] = Object.freeze([
   // ─── Fonts ─────────────────────────────────────────────────────────────
@@ -705,6 +749,42 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'overrides this per channel and is remembered. Has no effect on mobile.',
   },
 
+  // ─── Event noise tier (#666) ──────────────────────────────────────────
+  // The primary "how much presence churn do I want to see" choice. Everything
+  // in the two groups below is a modifier on whatever this leaves standing —
+  // see shared/eventFilter.ts for the tier semantics and the noise set.
+  {
+    key: 'chat.events',
+    label: 'Event noise',
+    category: 'chat',
+    group: 'events',
+    type: 'enum',
+    choices: ['all', 'smart', 'none'],
+    default: 'all',
+    description:
+      'How much join/part/quit/nick/host-change/mode noise reaches the message list. ' +
+      '"all" (the default) shows every event, folded into summary lines when ' +
+      'consolidation is on. "smart" shows events only for nicks who have recently ' +
+      'spoken, so silent lurkers cycling on and off stay invisible. "none" hides ' +
+      'event rows entirely, leaving conversation only. Kicks, topic changes and ' +
+      'invites are never hidden — they are things that happened, not churn.',
+  },
+  {
+    key: 'chat.events.mobile',
+    label: 'Event noise (mobile)',
+    category: 'chat',
+    group: 'events',
+    type: 'enum',
+    choices: ['all', 'smart', 'none'],
+    default: 'all',
+    description:
+      'The same choice for phone-sized viewports (≤768px) and the native mobile ' +
+      'apps, which read this key unconditionally. A phone screen holds a fraction ' +
+      'of the lines a desktop one does, so "none" is a common pick here even for ' +
+      'people who want "all" at their desk. Only the tier is split by device — the ' +
+      'modifiers below are shared.',
+  },
+
   // ─── Join/part consolidation (IRCCloud-style summary line) ────────────
   {
     key: 'chat.consolidate_joins',
@@ -713,11 +793,12 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'consolidate',
     type: 'bool',
     default: true,
+    dependsOn: EVENTS_VISIBLE,
     description:
       'Merge consecutive join/part/quit/nick/host-change events into a single summary line ' +
       'per nick (e.g. "Alice and Bob joined; Dave left; Eve → Eve_afk"). ' +
-      'Off shows every event individually. Composes with smart filter — events ' +
-      'the smart filter hides are excluded from the summary.',
+      'Off shows every event individually. Composes with the "smart" tier — events ' +
+      'it hides are excluded from the summary.',
   },
   {
     key: 'chat.consolidate_max_names',
@@ -728,6 +809,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     min: 1,
     max: 50,
     default: 5,
+    // Only names the switch directly above it: the tier condition arrives
+    // transitively through chat.consolidate_joins.
+    dependsOn: [{ key: 'chat.consolidate_joins', in: [true] }],
     description:
       'In each category (joined / left / reconnected / renamed / changed host) of a summary ' +
       'line, show at most this many nicks before collapsing the rest into ' +
@@ -741,6 +825,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'consolidate',
     type: 'bool',
     default: false,
+    // Hangs off the tier, not off consolidation: this decorates the individual
+    // lines, which is exactly what survives when consolidation is OFF.
+    dependsOn: EVENTS_VISIBLE,
     description:
       'Show the affected user’s user@host next to their nick on JOIN, PART, ' +
       'QUIT, and nick-change lines (e.g. "alice (~alice@host.example.net) ' +
@@ -755,6 +842,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'consolidate',
     type: 'bool',
     default: false,
+    dependsOn: EVENTS_VISIBLE,
     description:
       'Show the joining user’s services (NickServ) account next to their nick ' +
       'on JOIN lines (e.g. "alice [aliceacct] joined") — useful for channel ops ' +
@@ -815,19 +903,9 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
 
   // ─── Smart filter (join/part/quit/nick noise) ─────────────────────────
-  {
-    key: 'chat.smart_filter',
-    label: 'Smart filter (hide noise from quiet users)',
-    category: 'chat',
-    group: 'smart-filter',
-    type: 'bool',
-    default: false,
-    description:
-      'Master switch for smart filtering of join/part/quit/nick noise. When enabled, ' +
-      'these events are hidden for nicks that have not recently spoken in the channel. ' +
-      'Off by default — the consolidation summary line above is usually a better fit, ' +
-      'but turn this on to also hide events for nicks who never chat.',
-  },
+  // The master switch used to live here as `chat.smart_filter`; it is now the
+  // middle rung of `chat.events` (#666), and a boot migration carries anyone who
+  // had it on across to the tier. What remains is the tuning it always had.
   {
     key: 'chat.smart_filter_delay',
     label: '"Recently spoke" window (minutes)',
@@ -837,6 +915,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     min: 0,
     max: 1440,
     default: 5,
+    dependsOn: EVENTS_SMART,
     description:
       'Window in minutes for "recently spoke". A join/part/quit/nick event is hidden ' +
       'if the affected nick has not posted a message within this many minutes before ' +
@@ -849,6 +928,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'smart-filter',
     type: 'bool',
     default: true,
+    dependsOn: EVENTS_SMART,
     description: 'Apply smart filter to JOIN events.',
   },
   {
@@ -858,6 +938,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'smart-filter',
     type: 'bool',
     default: true,
+    dependsOn: EVENTS_SMART,
     description: 'Apply smart filter to PART and QUIT events.',
   },
   {
@@ -867,6 +948,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     group: 'smart-filter',
     type: 'bool',
     default: true,
+    dependsOn: EVENTS_SMART,
     description: 'Apply smart filter to NICK change events.',
   },
   {
@@ -878,6 +960,7 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     min: 0,
     max: 1440,
     default: 30,
+    dependsOn: EVENTS_SMART,
     description:
       'If a smart-filtered nick speaks within this many minutes after their JOIN, ' +
       'the JOIN line is revealed. 0 disables unmasking.',
@@ -1542,9 +1625,10 @@ export const GROUPS: Readonly<Record<string, string>> = Object.freeze({
   nicks: 'Nick coloring',
   layout: 'Layout',
   misc: 'Misc',
+  events: 'Event noise',
   consolidate: 'Join/part consolidation',
   composing: 'Composing',
-  'smart-filter': 'Smart filter',
+  'smart-filter': 'Smart filter tuning',
   connection: 'Connection',
   ctcp: 'CTCP replies',
   'auto-away': 'Auto-away',

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -852,57 +852,11 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'that collapse into the consolidation summary above stay account-less.',
   },
 
-  // ─── Composing (outgoing message guardrails) ─────────────────────────
-  // irc-framework splits anything past ~350 bytes into multiple PRIVMSGs on
-  // the wire. The default UX blocks the user from accidentally flooding —
-  // they have to either shorten, hit Send a second time to confirm, or flip
-  // this on to send splits silently like a traditional client.
-  {
-    key: 'chat.allow_split_messages',
-    label: 'Allow long messages to split',
-    category: 'chat',
-    group: 'composing',
-    type: 'bool',
-    default: false,
-    description:
-      'Allow long messages to send as multiple consecutive IRC lines without ' +
-      'confirmation. When off (the default), trying to send a message that ' +
-      "would split shows a SPLIT warning in the status bar and won't submit " +
-      'until you press Send a second time; one that would split into three or ' +
-      'more offers to upload the text as a file instead. /me actions never ' +
-      'split — they are blocked outright regardless of this setting.',
-  },
-  {
-    key: 'chat.send_typing_notifications',
-    label: 'Send typing notifications',
-    category: 'chat',
-    group: 'composing',
-    type: 'bool',
-    default: true,
-    description:
-      'Let other clients see when you are typing (IRCv3 +typing tag). Off stops ' +
-      'this client from sending typing/paused/done notifications while you compose ' +
-      "a message. Doesn't affect seeing other people's typing indicators.",
-  },
-  {
-    key: 'chat.keep_position_on_send',
-    label: 'Stay where you are when you send',
-    category: 'chat',
-    group: 'composing',
-    type: 'bool',
-    default: false,
-    description:
-      'Keep your scroll position when you send a message, instead of jumping to ' +
-      'the newest message. For reading back through a busy channel while still ' +
-      'replying — your own line lands at the bottom and the "Return ↓" button ' +
-      'counts it, so you can drop back down when you are ready. Off (the default) ' +
-      'jumps to the bottom on every send. Sending while you are viewing a ' +
-      'jumped-to point in history returns you to the live conversation either ' +
-      'way, since that view holds live messages back and there is nowhere in it ' +
-      'for your own message to appear.',
-  },
-
-  // ─── Smart filter (join/part/quit/nick noise) ─────────────────────────
+  // ─── Smart filter tuning (join/part/quit/nick noise) ──────────────────
+  // Sits directly under the tier and consolidation — the three groups answer
+  // one question between them, and the render order here is what the Settings
+  // pane groups by, so nothing unrelated may be inserted between them.
+  //
   // The master switch used to live here as `chat.smart_filter`; it is now the
   // middle rung of `chat.events` (#666), and a boot migration carries anyone who
   // had it on across to the tier. What remains is the tuning it always had.
@@ -964,6 +918,56 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     description:
       'If a smart-filtered nick speaks within this many minutes after their JOIN, ' +
       'the JOIN line is revealed. 0 disables unmasking.',
+  },
+
+  // ─── Composing (outgoing message guardrails) ─────────────────────────
+  // irc-framework splits anything past ~350 bytes into multiple PRIVMSGs on
+  // the wire. The default UX blocks the user from accidentally flooding —
+  // they have to either shorten, hit Send a second time to confirm, or flip
+  // this on to send splits silently like a traditional client.
+  {
+    key: 'chat.allow_split_messages',
+    label: 'Allow long messages to split',
+    category: 'chat',
+    group: 'composing',
+    type: 'bool',
+    default: false,
+    description:
+      'Allow long messages to send as multiple consecutive IRC lines without ' +
+      'confirmation. When off (the default), trying to send a message that ' +
+      "would split shows a SPLIT warning in the status bar and won't submit " +
+      'until you press Send a second time; one that would split into three or ' +
+      'more offers to upload the text as a file instead. /me actions never ' +
+      'split — they are blocked outright regardless of this setting.',
+  },
+  {
+    key: 'chat.send_typing_notifications',
+    label: 'Send typing notifications',
+    category: 'chat',
+    group: 'composing',
+    type: 'bool',
+    default: true,
+    description:
+      'Let other clients see when you are typing (IRCv3 +typing tag). Off stops ' +
+      'this client from sending typing/paused/done notifications while you compose ' +
+      "a message. Doesn't affect seeing other people's typing indicators.",
+  },
+  {
+    key: 'chat.keep_position_on_send',
+    label: 'Stay where you are when you send',
+    category: 'chat',
+    group: 'composing',
+    type: 'bool',
+    default: false,
+    description:
+      'Keep your scroll position when you send a message, instead of jumping to ' +
+      'the newest message. For reading back through a busy channel while still ' +
+      'replying — your own line lands at the bottom and the "Return ↓" button ' +
+      'counts it, so you can drop back down when you are ready. Off (the default) ' +
+      'jumps to the bottom on every send. Sending while you are viewing a ' +
+      'jumped-to point in history returns you to the live conversation either ' +
+      'way, since that view holds live messages back and there is nowhere in it ' +
+      'for your own message to appear.',
   },
 
   // ─── Inline media viewer ──────────────────────────────────────────────

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -329,6 +329,7 @@ import { historyCountBy } from '../lib/historyPaging.js';
 import type { ConsolidationGroup, NickEntry, RenameEntry } from '../../../shared/consolidate.js';
 import { collapseDisplay } from '../utils/collapseDisplay.js';
 import { parseRelayMessage } from '../../../shared/parseRelay.js';
+import { asEventMode, eventModeKey, isNoiseType } from '../../../shared/eventFilter.js';
 import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';
 import RenderSegments from './RenderSegments.vue';
@@ -861,7 +862,10 @@ function onMentionMenu(nick: string, e: MouseEvent): void {
   onNickMenu(e, nick);
 }
 
-const smartFilterEnabled = computed(() => !!settings.effective('chat.smart_filter'));
+// The event-noise tier (#666). One enum answers "which presence events survive"
+// for this device class; everything below it only tunes the survivors.
+const eventMode = computed(() => asEventMode(settings.effective(eventModeKey(isMobile.value))));
+const smartFilterEnabled = computed(() => eventMode.value === 'smart');
 const smartFilterDelayMs = computed(
   () => ((settings.effective('chat.smart_filter_delay') as number) || 0) * 60_000,
 );
@@ -872,7 +876,11 @@ const smartFilterJoin = computed(() => !!settings.effective('chat.smart_filter_j
 const smartFilterQuit = computed(() => !!settings.effective('chat.smart_filter_quit'));
 const smartFilterNick = computed(() => !!settings.effective('chat.smart_filter_nick'));
 
-const consolidateEnabled = computed(() => !!settings.effective('chat.consolidate_joins'));
+// At the `none` tier there are no event rows left to fold, so the consolidation
+// pass is skipped outright rather than run over a stream it can't match.
+const consolidateEnabled = computed(
+  () => eventMode.value !== 'none' && !!settings.effective('chat.consolidate_joins'),
+);
 const consolidateMaxNames = computed(
   () => (settings.effective('chat.consolidate_max_names') as number) || 5,
 );
@@ -945,6 +953,7 @@ const renderRows = computed((): RenderRow[] => {
   const out: RenderRow[] = [];
 
   const filterOn = smartFilterEnabled.value && !!buf?.speakers;
+  const hideAllEvents = eventMode.value === 'none';
   const ownNickLc = selfLower.value;
   const delayMs = smartFilterDelayMs.value;
   const unmaskMs = smartFilterUnmaskMs.value;
@@ -1021,6 +1030,16 @@ const renderRows = computed((): RenderRow[] => {
     // /clear filter (hard hide). Comes first so the divider, when emitted
     // below, lands above every other filter's surviving rows.
     if (clearedBeforeId > 0 && m.id != null && Number(m.id) <= clearedBeforeId) continue;
+
+    // `none` tier (#666): drop every event row outright — including your own,
+    // and including mode changes. Unconditional on purpose: a reader who asked
+    // for no event noise on this device wants none of it, not
+    // none-except-mine. Kicks, topic changes and invites sit outside
+    // NOISE_TYPES and still render, because they are things that happened
+    // rather than churn. Placed with the other hard hides so the rows never
+    // reach the ignore/highlight evaluation below, and so dividers anchor to
+    // the first row the reader can actually see.
+    if (hideAllEvents && isNoiseType(m.type)) continue;
 
     // Render-time ignore filter (issue #301). Self-authored events are never
     // hidden. The matcher gets full event context so level/channel/pattern

--- a/vue_client/src/components/SettingsRow.vue
+++ b/vue_client/src/components/SettingsRow.vue
@@ -46,7 +46,14 @@
         :disabled="!!hint"
         @change="$emit('commit', ($event.target as HTMLSelectElement).value)"
       >
-        <option v-for="c in opt.choices" :key="c" :value="c">{{ c }}</option>
+        <!--
+          `choiceLabels` is optional: an enum whose values already read as
+          English (auto / standard / compact) renders them raw, and one whose
+          values are ids gets prose without those ids having to change.
+        -->
+        <option v-for="c in opt.choices" :key="c" :value="c">
+          {{ opt.choiceLabels?.[c] ?? c }}
+        </option>
       </select>
       <span v-else-if="opt.type === 'color'" class="color-edit">
         <span class="swatch" :style="{ background: value as string }"></span>

--- a/vue_client/src/components/SettingsRow.vue
+++ b/vue_client/src/components/SettingsRow.vue
@@ -146,6 +146,10 @@ function formatDefault(opt: SettingOption): string {
   const v = opt.default;
   if (Array.isArray(v)) return v.join(', ');
   if (typeof v === 'boolean') return v ? 'on' : 'off';
+  // Same lookup the <select> does. This line exists to tell the user what they
+  // changed away from, so it has to name it the way the control does — showing
+  // the id here while the dropdown above shows prose reads as a different value.
+  if (opt.type === 'enum') return opt.choiceLabels?.[String(v)] ?? String(v);
   return String(v);
 }
 </script>

--- a/vue_client/src/components/SettingsRow.vue
+++ b/vue_client/src/components/SettingsRow.vue
@@ -6,7 +6,7 @@
 <template>
   <li
     class="row"
-    :class="{ modified }"
+    :class="{ modified, inactive: !!hint }"
     :data-setting-key="opt.key"
     :title="modified ? 'modified from default' : ''"
   >
@@ -26,6 +26,7 @@
         <input
           type="checkbox"
           :checked="!!value"
+          :disabled="!!hint"
           @change="$emit('commit', ($event.target as HTMLInputElement).checked)"
         />
         <span>{{ value ? 'on' : 'off' }}</span>
@@ -36,11 +37,13 @@
         :min="opt.min"
         :max="opt.max"
         :value="value"
+        :disabled="!!hint"
         @change="$emit('commit', Number(($event.target as HTMLInputElement).value))"
       />
       <select
         v-else-if="opt.type === 'enum'"
         :value="value"
+        :disabled="!!hint"
         @change="$emit('commit', ($event.target as HTMLSelectElement).value)"
       >
         <option v-for="c in opt.choices" :key="c" :value="c">{{ c }}</option>
@@ -50,12 +53,14 @@
         <input
           type="text"
           :value="value"
+          :disabled="!!hint"
           @change="$emit('commit', ($event.target as HTMLInputElement).value)"
         />
       </span>
       <textarea
         v-else-if="opt.type === 'string-list'"
         :value="(Array.isArray(value) ? value : []).join('\n')"
+        :disabled="!!hint"
         @change="
           $emit(
             'commit',
@@ -73,6 +78,7 @@
           autocomplete="off"
           spellcheck="false"
           :value="value"
+          :disabled="!!hint"
           @change="$emit('commit', ($event.target as HTMLInputElement).value)"
         />
         <button type="button" class="link reveal" @click="revealed = !revealed">
@@ -83,9 +89,16 @@
         v-else
         type="text"
         :value="value"
+        :disabled="!!hint"
         @change="$emit('commit', ($event.target as HTMLInputElement).value)"
       />
     </div>
+    <!--
+      Why this row is greyed out, and which setting to change to wake it up.
+      The value behind it is untouched — see optionEnabled() — so flipping the
+      dependency back restores exactly what was here.
+    -->
+    <p v-if="hint" class="dep-hint">{{ hint }}</p>
     <div v-if="modified" class="default-line">
       default: <code>{{ formatDefault(opt) }}</code>
     </div>
@@ -101,10 +114,17 @@ withDefaults(
     opt: SettingOption;
     value?: SettingValue;
     modified?: boolean;
+    /**
+     * Non-empty when the setting's `dependsOn` clauses don't currently hold:
+     * the explanation to show, and the flag that greys the editor out. Empty
+     * (the default) for an ordinary live row.
+     */
+    hint?: string;
   }>(),
   {
     value: undefined,
     modified: false,
+    hint: '',
   },
 );
 
@@ -144,6 +164,19 @@ function formatDefault(opt: SettingOption): string {
 }
 .row.modified .headline {
   color: var(--warn);
+}
+
+/* Dimmed, not hidden: an inactive setting still tells the reader it exists and
+   what it would do, which is how they learn the tier controls it. */
+.row.inactive .headline,
+.row.inactive .desc,
+.row.inactive .editor {
+  opacity: 0.55;
+}
+.dep-hint {
+  margin: 0;
+  color: var(--fg-muted);
+  font-style: italic;
 }
 
 .head {

--- a/vue_client/src/components/settings-panes/RegistryPane.vue
+++ b/vue_client/src/components/settings-panes/RegistryPane.vue
@@ -39,6 +39,7 @@
           :opt="opt"
           :value="settings.effective(opt.key)"
           :modified="settings.isModified(opt.key)"
+          :hint="dependencyHintFor(opt)"
           @commit="(v) => onCommit(opt.key, v)"
           @reset="onReset(opt.key)"
         />
@@ -53,7 +54,13 @@
 import { ref, computed } from 'vue';
 import { useSettingsStore } from '../../stores/settings.js';
 import { useConfigStore } from '../../stores/config.js';
-import { CATEGORIES, GROUPS, optionVisible } from '../../utils/settingsRegistry.js';
+import {
+  CATEGORIES,
+  GROUPS,
+  optionVisible,
+  optionEnabled,
+  dependencyHint,
+} from '../../utils/settingsRegistry.js';
 import type { SettingOption, SettingValue } from '../../../../shared/settingsRegistry.js';
 import SettingsRow from '../SettingsRow.vue';
 
@@ -98,6 +105,14 @@ const groups = computed(() => {
   const order = props.only;
   return built.toSorted((a, b) => order.indexOf(a.id) - order.indexOf(b.id));
 });
+
+// Empty for a live row; the "needs X" line for one whose dependsOn clauses
+// don't hold. Reads through `settings.effective` so it re-evaluates the moment
+// the setting it hangs off changes — flipping the event tier greys and un-greys
+// its modifiers without a reload.
+function dependencyHintFor(opt: SettingOption): string {
+  return optionEnabled(opt, (key) => settings.effective(key)) ? '' : dependencyHint(opt);
+}
 
 async function onCommit(key: string, value: SettingValue) {
   error.value = '';

--- a/vue_client/src/components/settings-panes/RegistryPane.vue
+++ b/vue_client/src/components/settings-panes/RegistryPane.vue
@@ -111,7 +111,8 @@ const groups = computed(() => {
 // the setting it hangs off changes — flipping the event tier greys and un-greys
 // its modifiers without a reload.
 function dependencyHintFor(opt: SettingOption): string {
-  return optionEnabled(opt, (key) => settings.effective(key)) ? '' : dependencyHint(opt);
+  const read = (key: string) => settings.effective(key);
+  return optionEnabled(opt, read) ? '' : dependencyHint(opt, read);
 }
 
 async function onCommit(key: string, value: SettingValue) {

--- a/vue_client/src/components/settings-panes/RegistryPane.vue
+++ b/vue_client/src/components/settings-panes/RegistryPane.vue
@@ -58,8 +58,7 @@ import {
   CATEGORIES,
   GROUPS,
   optionVisible,
-  optionEnabled,
-  dependencyHint,
+  dependencyStateFor,
 } from '../../utils/settingsRegistry.js';
 import type { SettingOption, SettingValue } from '../../../../shared/settingsRegistry.js';
 import SettingsRow from '../SettingsRow.vue';
@@ -111,8 +110,7 @@ const groups = computed(() => {
 // the setting it hangs off changes — flipping the event tier greys and un-greys
 // its modifiers without a reload.
 function dependencyHintFor(opt: SettingOption): string {
-  const read = (key: string) => settings.effective(key);
-  return optionEnabled(opt, read) ? '' : dependencyHint(opt, read);
+  return dependencyStateFor(opt, (key) => settings.effective(key));
 }
 
 async function onCommit(key: string, value: SettingValue) {

--- a/vue_client/src/lib/commands/settings.test.ts
+++ b/vue_client/src/lib/commands/settings.test.ts
@@ -114,4 +114,31 @@ describe('formatSettingValue', () => {
     expect(formatSettingValue(strOpt, '')).toBe('(empty)');
     expect(formatSettingValue(intOpt, 14)).toBe('14');
   });
+
+  // A labelled enum reads as its id with the label in parens — the REVERSE of the
+  // Settings pane, on purpose. The id is what you type back to `/set`, so it has
+  // to stay the value; the label is only there to connect this line to what the
+  // GUI calls the same setting.
+  it('shows a labelled enum as id (Label), keeping the id typeable', () => {
+    const labelled = {
+      ...enumOpt,
+      key: 'a.labelled',
+      choices: ['all', 'none'],
+      choiceLabels: { all: 'No filter', none: 'Hide all' },
+    } satisfies SettingOption;
+    expect(formatSettingValue(labelled, 'all')).toBe('all (No filter)');
+    expect(formatSettingValue(labelled, 'none')).toBe('none (Hide all)');
+  });
+
+  it('leaves an unlabelled enum choice as the bare value', () => {
+    // Both the no-choiceLabels case (every enum before this existed) and a
+    // partial map, which the registry explicitly allows.
+    expect(formatSettingValue(enumOpt, 'left')).toBe('left');
+    const partial = {
+      ...enumOpt,
+      key: 'a.partial',
+      choiceLabels: { left: 'Left' },
+    } satisfies SettingOption;
+    expect(formatSettingValue(partial, 'right')).toBe('right');
+  });
 });

--- a/vue_client/src/lib/commands/settings.ts
+++ b/vue_client/src/lib/commands/settings.ts
@@ -110,5 +110,14 @@ export function formatSettingValue(opt: SettingOption, value: SettingValue | und
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   if (value === undefined) return '(unset)';
   const s = String(value);
-  return s === '' ? '(empty)' : s;
+  if (s === '') return '(empty)';
+  // An enum with prose labels reads as its id here, with the label in parens —
+  // the reverse of the Settings pane, and deliberately. The id is what you have
+  // to TYPE back to `/set`, so it stays the value; the label is only there so
+  // someone who saw "Hide all" in the GUI can tell it is this same setting.
+  if (opt.type === 'enum') {
+    const label = opt.choiceLabels?.[s];
+    if (label && label !== s) return `${s} (${label})`;
+  }
+  return s;
 }

--- a/vue_client/src/lib/historyPaging.ts
+++ b/vue_client/src/lib/historyPaging.ts
@@ -17,11 +17,38 @@
 // is already the right unit — and asking for 'renderable' there would pull the
 // server's whole scan window (up to 2000 rows) into a page the user then sees
 // in full. Hence the gate: the unit we request must match the unit we render.
+//
+// The `none` event tier (#666) adds a third answer. There we draw nothing for
+// join/part/quit/nick/chghost OR mode, so 'renderable' is no longer strict
+// enough — mode rows would still spend budget while rendering as nothing — and
+// 'chat' is the matching unit. pageUnitFor() owns that mapping so the native
+// clients can't resolve it differently.
+//
+// There is no unit for the `smart` tier: which events it hides depends on who
+// spoke recently in this reader's client, which the server can't know. `smart`
+// asks for the same unit `all` would and can still see a short page — pre-#10
+// behavior, on the buffers where it's least likely to matter.
 
 import { useSettingsStore } from '../stores/settings.js';
+import { useViewport } from '../composables/useViewport.js';
+import { asEventMode, eventModeKey, pageUnitFor } from '../../../shared/eventFilter.js';
+import type { EventMode, PageUnit } from '../../../shared/eventFilter.js';
+
+export type HistoryCountBy = PageUnit;
+
+/**
+ * The event tier in force for THIS device. Only the tier is device-scoped — see
+ * shared/eventFilter.ts. `useViewport`'s isMobile is a module-level ref, so this
+ * is safe to call outside a component setup.
+ */
+export function currentEventMode(): EventMode {
+  const settings = useSettingsStore();
+  const { isMobile } = useViewport();
+  return asEventMode(settings.effective(eventModeKey(isMobile.value)));
+}
 
 // Until the settings bootstrap lands we don't know which the user chose, and the
-// two wrong answers aren't equally wrong. Guessing 'renderable' for someone who
+// wrong answers aren't equally wrong. Guessing 'renderable' for someone who
 // turned consolidation OFF hands them a page of up to the server's whole scan
 // window, rendered line by line — the exact thing this gate exists to prevent.
 // Guessing 'event' for someone who left it ON just means their first page is
@@ -29,10 +56,8 @@ import { useSettingsStore } from '../stores/settings.js';
 // it. So: no opinion until we have one. (`settings.effective` would otherwise
 // answer from the registry default, which is `true` — a real preference for the
 // majority, but not one we've been told.)
-export type HistoryCountBy = 'event' | 'renderable';
-
 export function historyCountBy(): HistoryCountBy {
   const settings = useSettingsStore();
   if (!settings.loaded) return 'event';
-  return settings.effective('chat.consolidate_joins') ? 'renderable' : 'event';
+  return pageUnitFor(currentEventMode(), !!settings.effective('chat.consolidate_joins'));
 }

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -2,10 +2,24 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { CATEGORIES, REGISTRY, categoryVisible, optionVisible } from './settingsRegistry.js';
+import {
+  CATEGORIES,
+  REGISTRY,
+  categoryVisible,
+  optionVisible,
+  optionEnabled,
+  dependencyHint,
+} from './settingsRegistry.js';
+import type { SettingOption, SettingValue } from '../../../shared/settingsRegistry.js';
 
 const cat = (id: string) => CATEGORIES.find((c) => c.id === id)!;
 const opt = (key: string) => REGISTRY.find((o) => o.key === key)!;
+
+/** An effective-value reader over an override map, defaulting to the registry. */
+function reader(overrides: Record<string, SettingValue>) {
+  return (key: string): SettingValue | undefined =>
+    key in overrides ? overrides[key] : REGISTRY.find((o) => o.key === key)?.default;
+}
 
 describe('categoryVisible', () => {
   const standalone = { isNode: false };
@@ -59,5 +73,105 @@ describe('optionVisible', () => {
 
   it('keeps paste-to-upload (a client UX pref, not a cost knob) visible in node edition', () => {
     expect(optionVisible(opt('uploads.paste.enabled'), { isNode: true })).toBe(true);
+  });
+});
+
+describe('optionEnabled (#666)', () => {
+  it('leaves settings without dependencies alone', () => {
+    expect(optionEnabled(opt('chat.events'), reader({}))).toBe(true);
+  });
+
+  it('ORs its clauses — one device class still using events keeps modifiers live', () => {
+    // Why the clauses are ORed rather than ANDed: a phone set to `none` must not
+    // grey out the consolidation knobs a desktop is actively using.
+    const phoneOnly = reader({ 'chat.events': 'all', 'chat.events.mobile': 'none' });
+    expect(optionEnabled(opt('chat.consolidate_joins'), phoneOnly)).toBe(true);
+
+    const bothOff = reader({ 'chat.events': 'none', 'chat.events.mobile': 'none' });
+    expect(optionEnabled(opt('chat.consolidate_joins'), bothOff)).toBe(false);
+  });
+
+  it('resolves transitively through a chain', () => {
+    // consolidate_max_names names only consolidate_joins; the tier condition has
+    // to arrive through it, or the registry would restate the whole chain on
+    // every leaf.
+    const bothOff = reader({ 'chat.events': 'none', 'chat.events.mobile': 'none' });
+    expect(optionEnabled(opt('chat.consolidate_max_names'), bothOff)).toBe(false);
+
+    // Its own direct dependency failing is enough on its own.
+    const consolidationOff = reader({ 'chat.consolidate_joins': false });
+    expect(optionEnabled(opt('chat.consolidate_max_names'), consolidationOff)).toBe(false);
+
+    expect(optionEnabled(opt('chat.consolidate_max_names'), reader({}))).toBe(true);
+  });
+
+  it('gates the smart-filter tuning on some device being on the smart tier', () => {
+    // Default is `all` on both keys, so the tuning starts inactive — it was
+    // reachable-but-inert before the tier, which is the confusion #666 names.
+    expect(optionEnabled(opt('chat.smart_filter_delay'), reader({}))).toBe(false);
+
+    const mobileSmart = reader({ 'chat.events.mobile': 'smart' });
+    for (const key of [
+      'chat.smart_filter_delay',
+      'chat.smart_filter_join',
+      'chat.smart_filter_quit',
+      'chat.smart_filter_nick',
+      'chat.smart_filter_join_unmask',
+    ]) {
+      expect(optionEnabled(opt(key), mobileSmart)).toBe(true);
+    }
+  });
+
+  it('keeps the event-display modifiers tied to the tier, not to consolidation', () => {
+    // show_event_host decorates the INDIVIDUAL lines, which is exactly what
+    // survives when consolidation is off — so turning consolidation off must
+    // not grey it out.
+    const consolidationOff = reader({ 'chat.consolidate_joins': false });
+    expect(optionEnabled(opt('chat.show_event_host'), consolidationOff)).toBe(true);
+    expect(optionEnabled(opt('chat.show_join_account'), consolidationOff)).toBe(true);
+
+    const bothOff = reader({ 'chat.events': 'none', 'chat.events.mobile': 'none' });
+    expect(optionEnabled(opt('chat.show_event_host'), bothOff)).toBe(false);
+  });
+
+  it('points every dependency clause at a real registry key', () => {
+    // A typo here fails OPEN — the clause can't be resolved further and passes —
+    // so nothing would visibly break, which is exactly why it needs asserting.
+    const keys = new Set(REGISTRY.map((o) => o.key));
+    for (const option of REGISTRY) {
+      for (const dep of option.dependsOn ?? []) {
+        expect(keys, `${option.key} depends on unknown ${dep.key}`).toContain(dep.key);
+      }
+    }
+  });
+
+  it('bottoms out rather than recursing forever on a cycle', () => {
+    const cyclic = {
+      ...opt('chat.consolidate_joins'),
+      key: 'x.a',
+      dependsOn: [{ key: 'x.a', in: [true] }],
+    } as SettingOption;
+    // getOption('x.a') finds nothing (it isn't in the registry), so the clause
+    // resolves on its value check alone — the depth cap is the backstop for a
+    // cycle made of keys that ARE registered.
+    expect(optionEnabled(cyclic, () => true)).toBe(true);
+  });
+});
+
+describe('dependencyHint', () => {
+  it('names the keys and values that would wake the setting up', () => {
+    expect(dependencyHint(opt('chat.smart_filter_delay'))).toBe(
+      'Inactive — needs chat.events = smart, or chat.events.mobile = smart.',
+    );
+  });
+
+  it('renders booleans as on/off rather than true/false', () => {
+    expect(dependencyHint(opt('chat.consolidate_max_names'))).toBe(
+      'Inactive — needs chat.consolidate_joins = on.',
+    );
+  });
+
+  it('is empty for a setting with no dependencies', () => {
+    expect(dependencyHint(opt('chat.events'))).toBe('');
   });
 });

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -9,6 +9,7 @@ import {
   optionVisible,
   optionEnabled,
   dependencyHint,
+  dependencyStateFor,
 } from './settingsRegistry.js';
 import type { SettingOption, SettingValue } from '../../../shared/settingsRegistry.js';
 
@@ -205,5 +206,50 @@ describe('dependencyHint', () => {
 
   it('is empty for a setting whose dependencies are satisfied', () => {
     expect(dependencyHint(opt('chat.consolidate_max_names'), reader({}))).toBe('');
+  });
+});
+
+describe('dependencyStateFor', () => {
+  it('is empty for a live setting and explains an inactive one', () => {
+    expect(dependencyStateFor(opt('chat.consolidate_max_names'), reader({}))).toBe('');
+    expect(
+      dependencyStateFor(
+        opt('chat.consolidate_max_names'),
+        reader({ 'chat.consolidate_joins': false }),
+      ),
+    ).toBe('Inactive — needs chat.consolidate_joins = on.');
+  });
+
+  it('fails CLOSED when the resolvers give up, rather than rendering a live row', () => {
+    // A registry cycle drives both resolvers into the depth cap, where they bail
+    // DIFFERENTLY: `optionEnabled` returns false, `dependencyHint` returns ''
+    // because there is no clause left to name. The pane greys a row on "hint is
+    // non-empty", so composing the two naively would mark this row inactive and
+    // then draw it fully usable — a control that looks like it works and doesn't.
+    //
+    // The cycle has to be resolvable, or it isn't a cycle: an unregistered key
+    // resolves on its value check alone and passes. Hence the injected lookup —
+    // the real REGISTRY has no cycle, which is exactly why this branch would
+    // otherwise be asserted only in a comment.
+    const a = {
+      ...opt('chat.consolidate_joins'),
+      key: 'x.a',
+      dependsOn: [{ key: 'x.b', in: [true] }],
+    } as SettingOption;
+    const b = {
+      ...opt('chat.consolidate_joins'),
+      key: 'x.b',
+      dependsOn: [{ key: 'x.a', in: [true] }],
+    } as SettingOption;
+    const lookup = (key: string) => ({ 'x.a': a, 'x.b': b })[key];
+    const readTrue = () => true;
+
+    // Both halves of the trap, asserted so a change to either shows up here.
+    expect(optionEnabled(a, readTrue, 0, lookup)).toBe(false);
+    expect(dependencyHint(a, readTrue, lookup)).toBe('');
+    // ...and the composition that has to survive them disagreeing.
+    expect(dependencyStateFor(a, readTrue, lookup)).toBe(
+      'Inactive — its dependencies could not be resolved.',
+    );
   });
 });

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -160,18 +160,50 @@ describe('optionEnabled (#666)', () => {
 
 describe('dependencyHint', () => {
   it('names the keys and values that would wake the setting up', () => {
-    expect(dependencyHint(opt('chat.smart_filter_delay'))).toBe(
+    expect(dependencyHint(opt('chat.smart_filter_delay'), reader({}))).toBe(
       'Inactive — needs chat.events = smart, or chat.events.mobile = smart.',
     );
   });
 
   it('renders booleans as on/off rather than true/false', () => {
-    expect(dependencyHint(opt('chat.consolidate_max_names'))).toBe(
+    expect(
+      dependencyHint(
+        opt('chat.consolidate_max_names'),
+        reader({ 'chat.consolidate_joins': false }),
+      ),
+    ).toBe('Inactive — needs chat.consolidate_joins = on.');
+  });
+
+  it('walks past a dependency that is itself inactive', () => {
+    // The dead end this exists to prevent: with both tiers on `none`,
+    // consolidate_max_names is greyed out even though chat.consolidate_joins —
+    // the only key its own clause names — reads `on`. Pointing at that row would
+    // send the user somewhere that already looks correct, with its editor
+    // disabled so they can't even try. Name the tier instead.
+    const bothOff = reader({ 'chat.events': 'none', 'chat.events.mobile': 'none' });
+    expect(dependencyHint(opt('chat.consolidate_max_names'), bothOff)).toBe(
+      'Inactive — needs chat.events = all or smart, or chat.events.mobile = all or smart.',
+    );
+  });
+
+  it('prefers the clause the user can actually act on', () => {
+    // Consolidation is off AND the tiers are off. The nearer, directly-actionable
+    // clause wins — turning consolidation back on is a step the user can take.
+    const both = reader({
+      'chat.consolidate_joins': false,
+      'chat.events': 'none',
+      'chat.events.mobile': 'none',
+    });
+    expect(dependencyHint(opt('chat.consolidate_max_names'), both)).toBe(
       'Inactive — needs chat.consolidate_joins = on.',
     );
   });
 
   it('is empty for a setting with no dependencies', () => {
-    expect(dependencyHint(opt('chat.events'))).toBe('');
+    expect(dependencyHint(opt('chat.events'), reader({}))).toBe('');
+  });
+
+  it('is empty for a setting whose dependencies are satisfied', () => {
+    expect(dependencyHint(opt('chat.consolidate_max_names'), reader({}))).toBe('');
   });
 });

--- a/vue_client/src/utils/settingsRegistry.ts
+++ b/vue_client/src/utils/settingsRegistry.ts
@@ -16,6 +16,7 @@ import type {
   SettingValue,
   SettingOption,
   SettingCategory,
+  SettingDependency,
 } from '../../../shared/settingsRegistry.js';
 
 export { REGISTRY, getOption, defaultsAsObject, CATEGORIES, GROUPS };
@@ -87,16 +88,61 @@ export function optionEnabled(
 }
 
 /**
- * Human-readable "why is this greyed out" line for an inactive setting, built
- * from its own clauses. Deliberately shows dotted keys rather than labels: the
- * settings pane already prints the key under every headline, so this reads as
- * an instruction you can act on rather than a riddle about which row to find.
+ * The clauses actually standing between this setting and being live.
+ *
+ * NOT simply `opt.dependsOn`. Because `optionEnabled` is transitive, a clause can
+ * fail with its own value already satisfied — the parent it names is itself
+ * inactive. Reporting that clause verbatim sends the user to a row that already
+ * reads the way the hint demands, with no way forward (and the editor disabled,
+ * so they can't even poke at it). So: report the clauses the user can act on,
+ * and when every failure is transitive, report what the PARENTS need instead.
  */
-export function dependencyHint(opt: SettingOption): string {
-  if (!opt.dependsOn?.length) return '';
-  const clauses = opt.dependsOn.map((dep) => {
+function unmetClauses(
+  opt: SettingOption,
+  read: (key: string) => SettingValue | undefined,
+  depth = 0,
+): SettingDependency[] {
+  if (!opt.dependsOn?.length || depth >= MAX_DEPENDENCY_DEPTH) return [];
+  const actionable: SettingDependency[] = [];
+  const blockedParents: SettingOption[] = [];
+  for (const dep of opt.dependsOn) {
+    const parent = getOption(dep.key);
+    // Wrong value → the user changes this one. That's the actionable case.
+    if (!dep.in.includes(read(dep.key) as SettingValue)) {
+      actionable.push(dep);
+      continue;
+    }
+    // Right value, but the row it names is greyed out too — recurse past it.
+    if (parent && !optionEnabled(parent, read, depth + 1)) blockedParents.push(parent);
+  }
+  if (actionable.length) return actionable;
+  const inherited = blockedParents.flatMap((parent) => unmetClauses(parent, read, depth + 1));
+  // Two parents can bottom out on the same root clause (both consolidation keys
+  // hang off the same tier pair); say it once.
+  const seen = new Set<string>();
+  return inherited.filter((dep) => {
+    const id = `${dep.key}=${dep.in.join('|')}`;
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+}
+
+/**
+ * Human-readable "why is this greyed out, and what do I change" line.
+ *
+ * Deliberately shows dotted keys rather than labels: the settings pane already
+ * prints the key under every headline, so this reads as an instruction you can
+ * act on rather than a riddle about which row to find.
+ */
+export function dependencyHint(
+  opt: SettingOption,
+  read: (key: string) => SettingValue | undefined,
+): string {
+  const clauses = unmetClauses(opt, read).map((dep) => {
     const values = dep.in.map((v) => (typeof v === 'boolean' ? (v ? 'on' : 'off') : String(v)));
     return `${dep.key} = ${values.join(' or ')}`;
   });
+  if (!clauses.length) return '';
   return `Inactive — needs ${clauses.join(', or ')}.`;
 }

--- a/vue_client/src/utils/settingsRegistry.ts
+++ b/vue_client/src/utils/settingsRegistry.ts
@@ -49,3 +49,54 @@ export function optionVisible(opt: SettingOption, ctx: Pick<VisibilityContext, '
   if (opt.selfHostedOnly && ctx.isNode) return false;
   return true;
 }
+
+// How deep a dependsOn chain we follow before giving up. Real chains are two
+// links (`consolidate_max_names → consolidate_joins → chat.events`); the cap is
+// purely so a registry edit that accidentally makes a cycle greys a row out
+// instead of hanging the settings pane.
+const MAX_DEPENDENCY_DEPTH = 8;
+
+/**
+ * Whether a setting currently DOES anything, per its `dependsOn` clauses.
+ *
+ * Clauses are ORed: the option is live if any one of them holds. Resolution is
+ * transitive — an option whose dependency is itself inactive is inactive too —
+ * so the registry states each link once instead of restating the whole chain on
+ * every leaf.
+ *
+ * Inactive is a rendering state, never a storage one: the value is kept and
+ * still returned, because flipping the condition back has to restore what the
+ * user had rather than a pile of defaults.
+ *
+ * `read` supplies effective values (i.e. `settingsStore.effective`).
+ */
+export function optionEnabled(
+  opt: SettingOption,
+  read: (key: string) => SettingValue | undefined,
+  depth = 0,
+): boolean {
+  if (!opt.dependsOn?.length) return true;
+  if (depth >= MAX_DEPENDENCY_DEPTH) return false;
+  return opt.dependsOn.some((dep) => {
+    if (!dep.in.includes(read(dep.key) as SettingValue)) return false;
+    const parent = getOption(dep.key);
+    // A clause naming a key that isn't in the registry can't be evaluated any
+    // further; the value check above is all we have, and it passed.
+    return parent ? optionEnabled(parent, read, depth + 1) : true;
+  });
+}
+
+/**
+ * Human-readable "why is this greyed out" line for an inactive setting, built
+ * from its own clauses. Deliberately shows dotted keys rather than labels: the
+ * settings pane already prints the key under every headline, so this reads as
+ * an instruction you can act on rather than a riddle about which row to find.
+ */
+export function dependencyHint(opt: SettingOption): string {
+  if (!opt.dependsOn?.length) return '';
+  const clauses = opt.dependsOn.map((dep) => {
+    const values = dep.in.map((v) => (typeof v === 'boolean' ? (v ? 'on' : 'off') : String(v)));
+    return `${dep.key} = ${values.join(' or ')}`;
+  });
+  return `Inactive — needs ${clauses.join(', or ')}.`;
+}

--- a/vue_client/src/utils/settingsRegistry.ts
+++ b/vue_client/src/utils/settingsRegistry.ts
@@ -58,6 +58,14 @@ export function optionVisible(opt: SettingOption, ctx: Pick<VisibilityContext, '
 const MAX_DEPENDENCY_DEPTH = 8;
 
 /**
+ * How a dependency clause's key is resolved to its registry option. Injectable
+ * purely so the depth cap is testable: with the real registry the cap is
+ * unreachable (there is no cycle, and a test asserts every clause names a real
+ * key), which would leave the fail-closed path below asserted only in a comment.
+ */
+export type OptionLookup = (key: string) => SettingOption | null | undefined;
+
+/**
  * Whether a setting currently DOES anything, per its `dependsOn` clauses.
  *
  * Clauses are ORed: the option is live if any one of them holds. Resolution is
@@ -75,15 +83,16 @@ export function optionEnabled(
   opt: SettingOption,
   read: (key: string) => SettingValue | undefined,
   depth = 0,
+  lookup: OptionLookup = getOption,
 ): boolean {
   if (!opt.dependsOn?.length) return true;
   if (depth >= MAX_DEPENDENCY_DEPTH) return false;
   return opt.dependsOn.some((dep) => {
     if (!dep.in.includes(read(dep.key) as SettingValue)) return false;
-    const parent = getOption(dep.key);
+    const parent = lookup(dep.key);
     // A clause naming a key that isn't in the registry can't be evaluated any
     // further; the value check above is all we have, and it passed.
-    return parent ? optionEnabled(parent, read, depth + 1) : true;
+    return parent ? optionEnabled(parent, read, depth + 1, lookup) : true;
   });
 }
 
@@ -101,22 +110,25 @@ function unmetClauses(
   opt: SettingOption,
   read: (key: string) => SettingValue | undefined,
   depth = 0,
+  lookup: OptionLookup = getOption,
 ): SettingDependency[] {
   if (!opt.dependsOn?.length || depth >= MAX_DEPENDENCY_DEPTH) return [];
   const actionable: SettingDependency[] = [];
   const blockedParents: SettingOption[] = [];
   for (const dep of opt.dependsOn) {
-    const parent = getOption(dep.key);
+    const parent = lookup(dep.key);
     // Wrong value → the user changes this one. That's the actionable case.
     if (!dep.in.includes(read(dep.key) as SettingValue)) {
       actionable.push(dep);
       continue;
     }
     // Right value, but the row it names is greyed out too — recurse past it.
-    if (parent && !optionEnabled(parent, read, depth + 1)) blockedParents.push(parent);
+    if (parent && !optionEnabled(parent, read, depth + 1, lookup)) blockedParents.push(parent);
   }
   if (actionable.length) return actionable;
-  const inherited = blockedParents.flatMap((parent) => unmetClauses(parent, read, depth + 1));
+  const inherited = blockedParents.flatMap((parent) =>
+    unmetClauses(parent, read, depth + 1, lookup),
+  );
   // Two parents can bottom out on the same root clause (both consolidation keys
   // hang off the same tier pair); say it once.
   const seen = new Set<string>();
@@ -135,11 +147,32 @@ function unmetClauses(
  * prints the key under every headline, so this reads as an instruction you can
  * act on rather than a riddle about which row to find.
  */
+/**
+ * What the Settings pane actually needs: '' when the setting is live, otherwise
+ * the line to show under a greyed-out row.
+ *
+ * Composed here rather than at the call site because the two resolvers have to
+ * agree and they bail differently. `optionEnabled` returns false at the depth
+ * cap; `dependencyHint` returns '' at the same cap, having nothing to name. A
+ * caller that greys the row on "hint is non-empty" would then render a row it
+ * knows is inactive as fully live — a registry cycle would produce a control
+ * that looks usable and isn't. Fail closed instead.
+ */
+export function dependencyStateFor(
+  opt: SettingOption,
+  read: (key: string) => SettingValue | undefined,
+  lookup: OptionLookup = getOption,
+): string {
+  if (optionEnabled(opt, read, 0, lookup)) return '';
+  return dependencyHint(opt, read, lookup) || 'Inactive — its dependencies could not be resolved.';
+}
+
 export function dependencyHint(
   opt: SettingOption,
   read: (key: string) => SettingValue | undefined,
+  lookup: OptionLookup = getOption,
 ): string {
-  const clauses = unmetClauses(opt, read).map((dep) => {
+  const clauses = unmetClauses(opt, read, 0, lookup).map((dep) => {
     const values = dep.in.map((v) => (typeof v === 'boolean' ? (v ? 'on' : 'off') : String(v)));
     return `${dep.key} = ${values.join(' or ')}`;
   });


### PR DESCRIPTION
Two independent switches — `chat.consolidate_joins` and `chat.smart_filter` — answered the same question between them: how much join/part/quit/nick/mode churn reaches the message list. Neither could express "hide all of it", which is what prompted #666.

`chat.events` is now the primary choice — **No filter / Smart filter / Hide all** — and everything else is a modifier on the survivors. `chat.events.mobile` splits *only the tier* by device class, mirroring `look.font.size.mobile`; the modifiers stay global, since at "Hide all" they're moot anyway and nobody wants a different consolidation cap on their phone.

"Hide all" hides `NOISE_TYPES` — the fold set plus `mode`. Kicks, topic changes and invites survive every rung: they're things that happened, not churn.

## What came with it

**A third page unit.** `renderable` still counts `mode` rows, so a reader on "Hide all" would page through screenfuls that render as nothing. `countBy: 'chat'` is the matching unit, and `pageUnitFor()` owns the tier → unit mapping so native clients can't answer it differently. `listMessagesRenderable` generalises to `listMessagesCounted`.

**A boot migration.** Retiring `chat.smart_filter` without one would silently put everyone who deliberately turned it on back onto "show me everything" — the failure `chat.image_modal.enabled` carries a note about. It writes both tier keys, since smart filtering was one global preference before the split.

**`dependsOn` in the registry.** Nine settings hang off the tier. iOS was already hand-maintaining one such dependency; this makes them data, resolved with OR semantics (across device classes) and transitively. Presentation only — an inactive setting keeps its value, so flipping the tier back restores what was there.

**An Events settings category.** The tier turned three loosely-related groups into one subject, so they moved out of Chat into their own category, narrowing top to bottom: filter → consolidation → smart-filter tuning.

## Deliberate non-changes

- **Stored values stay `all`/`smart`/`none`**, with wording in a new optional `choiceLabels`. Renaming a stored enum value is a migration; paying in orphaned rows to improve a phrase isn't worth it.
- **Keys stay `chat.*`.** A category is presentation, a key is an id.
- **Both tier keys default to `all`**, so nothing changes for existing users on upgrade.
- **Mode consolidation** (the aside in #666) is not here. Folding consecutive mode changes would move `mode` into `CONSOLIDATABLE_TYPES`, which changes page sizing for every client including shipped iOS builds — its own card.

## Verification

`npm run check` clean, 3061 tests passing. Reviewed with `/code-review high`; three findings fixed in their own commit — a non-transitive `dependencyHint` that could dead-end the user, a `BEGIN DEFERRED` migration matching the roswell `SQLITE_BUSY_SNAPSHOT` shape, and an import path that reintroduced the retired key.

iOS consumes the tier in amiantos/lurker-ios#81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)