### PR TITLE
Carry bookmark state on message rows, drop the connect snapshot

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -202,14 +202,13 @@ frames**, synchronously, in this order (`wsHub.ts` `sendSnapshotInner`, 1893):
    would otherwise leave your cursor at 0. `maxUploadBytes` is the largest
    upload this account may send right now — see §Uploads.
 2. `{kind:'draft-snapshot', drafts}` — saved per-buffer input drafts.
-3. `{kind:'bookmark-ids-snapshot', ids:[…]}` — bookmarked message ids.
-4. A `backlog` frame for the app-scoped **system buffer** (`networkId:null`,
+3. A `backlog` frame for the app-scoped **system buffer** (`networkId:null`,
    `target:':system:'`).
-5. `{kind:'contacts-snapshot', contacts:[…]}` — the friends/contacts list.
-6. One `backlog` frame per open buffer on each connected network.
-7. Per **offline** network: a real backlog for its `:server:` log, shells for
+4. `{kind:'contacts-snapshot', contacts:[…]}` — the friends/contacts list.
+5. One `backlog` frame per open buffer on each connected network.
+6. Per **offline** network: a real backlog for its `:server:` log, shells for
    its channels/DMs.
-8. `{kind:'backlog-complete'}` — terminal marker, nothing else in it.
+7. `{kind:'backlog-complete'}` — terminal marker, nothing else in it.
 
 Render progressively from frame 1; don't wait for the end.
 
@@ -404,7 +403,8 @@ Common fields on every **persisted** event (`db/messages.ts:31` +
   userhost, alt, mirrored, dm,
   matched, matchedRuleId,             // highlight decoration
   fromIgnored, notifyAlways, notify,
-  msgid? }                            // IRCv3 server message id, when supplied
+  msgid?,                             // IRCv3 server message id, when supplied
+  bookmarked? }                       // true when you've saved this line
 ```
 
 plus type-specific extras (`newNick`, `kicked`, `modes`, `members`, …).
@@ -420,6 +420,14 @@ with respect to `id` — order and dedupe by `id`, always (§9.3).
 own sends learn theirs via `echo-message`). Absent — not null — on rows from
 untagged networks and on optimistic self echoes. It is the future anchor for
 react/reply; today it is informational only.
+
+**`bookmarked`** is `true` when the account reading the row has saved it, and
+**absent — not `false`** otherwise, so unsaved rows (nearly all of them) cost
+nothing on the wire. There is no bookmark snapshot in the connect burst: keep a
+`Set` of the ids you've seen carrying this flag, add/remove on `bookmark-updated`,
+and treat "not in the Set" as unsaved. That bounds the state you hold by what
+you've loaded rather than by everything the account has ever saved. Full rows for
+the saved-messages list come from `GET /api/bookmarks`, which is paginated.
 
 **`notify` is the server's delivery decision — the one flag to gate a live
 alert (toast, sound, native buzz) on.** It is the union of the content signals
@@ -531,7 +539,7 @@ anything at all.
 | `set-channel-notify-always`       | `networkId, target, notifyAlways`                                                                                                                                                                                                                                                                                                                 |
 | `draft-set` / `draft-clear`       | `networkId, target, body?`                                                                                                                                                                                                                                                                                                                        |
 | `input-history-add`               | `networkId, target, text`                                                                                                                                                                                                                                                                                                                         |
-| `set-bookmark` / `unset-bookmark` | `messageId`                                                                                                                                                                                                                                                                                                                                       |
+| `set-bookmark` / `unset-bookmark` | `messageId`. Saving is a silent no-op for a message you don't own, and for system-buffer lines (`networkId:null`) which have no owning network — no `bookmark-updated` follows, so don't render a toggle optimistically                                                                                                                           |
 | `set-nick-note`                   | `networkId, nick, note`                                                                                                                                                                                                                                                                                                                           |
 | `set-relay-bot`                   | `networkId, nick, marked, pattern`                                                                                                                                                                                                                                                                                                                |
 | `set-contact` / `delete-contact`  | `contactId, displayName, notifyOnline, targets` / `contactId`                                                                                                                                                                                                                                                                                     |
@@ -572,7 +580,7 @@ a v1 client.
 | `kind`                                                                                                                                                                   | Payload                                                                                                                                                                                                                                                     | When                                                                                                                                                      |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `snapshot`                                                                                                                                                               | `protocolVersion, maxUploadBytes, networks[], globalIgnores[], cursor?`                                                                                                                                                                                     | Connect burst / gap-fill                                                                                                                                  |
-| `draft-snapshot` / `bookmark-ids-snapshot` / `contacts-snapshot`                                                                                                         | `drafts` / `ids[]` / `contacts[]`                                                                                                                                                                                                                           | Connect burst                                                                                                                                             |
+| `draft-snapshot` / `contacts-snapshot`                                                                                                                                   | `drafts` / `contacts[]`                                                                                                                                                                                                                                     | Connect burst                                                                                                                                             |
 | `backlog-complete`                                                                                                                                                       | —                                                                                                                                                                                                                                                           | Last frame of the burst; absence is proof (§4.3)                                                                                                          |
 | `backlog`                                                                                                                                                                | `networkId, target, events[], mode, reset?, hasMoreOlder, joined, lastReadId, unread, highlights, highlightsCapped, clearedBeforeId, clearedAt, speakers?, inputHistory?` — **`mode ∈ replace\|append\|shell` is how you merge it (§8); `reset` is legacy** | Burst, `open-buffer` reply, resume gap                                                                                                                    |
 | `irc`                                                                                                                                                                    | A decorated `MessageEvent` (§5.3) with `kind` clobbered to `'irc'`                                                                                                                                                                                          | Every live IRC-side event                                                                                                                                 |

--- a/server/db/bookmarks.test.ts
+++ b/server/db/bookmarks.test.ts
@@ -13,19 +13,27 @@ let createUser: typeof import('./users.js').createUser;
 let deleteUser: typeof import('./users.js').deleteUser;
 let createNetwork: typeof import('./networks.js').createNetwork;
 let insertMessage: typeof import('./messages.js').insertMessage;
+let listMessages: typeof import('./messages.js').listMessages;
 let addBookmark: typeof import('./bookmarks.js').addBookmark;
 let removeBookmark: typeof import('./bookmarks.js').removeBookmark;
 let isBookmarked: typeof import('./bookmarks.js').isBookmarked;
-let listBookmarkIdsForUser: typeof import('./bookmarks.js').listBookmarkIdsForUser;
 let listBookmarksForUser: typeof import('./bookmarks.js').listBookmarksForUser;
 
 beforeAll(async () => {
   ({ createUser, deleteUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
-  ({ insertMessage } = await import('./messages.js'));
-  ({ addBookmark, removeBookmark, isBookmarked, listBookmarkIdsForUser, listBookmarksForUser } =
+  ({ insertMessage, listMessages } = await import('./messages.js'));
+  ({ addBookmark, removeBookmark, isBookmarked, listBookmarksForUser } =
     await import('./bookmarks.js'));
 });
+
+// The ids a user has saved, newest-first, read back through the same paginated
+// path the REST list uses. There is deliberately no all-ids accessor to call
+// here: shipping every id at once is exactly what the per-row `bookmarked`
+// column replaced, so the tests read the way production does.
+function savedIds(userId: number): number[] {
+  return listBookmarksForUser(userId, { limit: 200 }).map((r) => r.id);
+}
 
 afterAll(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -72,7 +80,7 @@ describe('bookmarks', () => {
     const { id } = chat(net!.id, '#meta', 'bob', 'hi');
     addBookmark(u.id, id);
     addBookmark(u.id, id);
-    expect(listBookmarkIdsForUser(u.id)).toEqual([id]);
+    expect(savedIds(u.id)).toEqual([id]);
   });
 
   it("rejects bookmarking another user's message (ownership check)", () => {
@@ -84,7 +92,7 @@ describe('bookmarks', () => {
     // ownership check inside the INSERT statement fails. The function
     // reports false (not bookmarked after the call).
     expect(addBookmark(intruder.id, id)).toBe(false);
-    expect(listBookmarkIdsForUser(intruder.id)).toEqual([]);
+    expect(savedIds(intruder.id)).toEqual([]);
   });
 
   it('lists ids newest-first', () => {
@@ -96,7 +104,7 @@ describe('bookmarks', () => {
     addBookmark(u.id, a);
     addBookmark(u.id, b);
     addBookmark(u.id, c);
-    expect(listBookmarkIdsForUser(u.id)).toEqual([c, b, a]);
+    expect(savedIds(u.id)).toEqual([c, b, a]);
   });
 
   it('listBookmarksForUser returns rows with networkName + cursor pagination', () => {
@@ -120,8 +128,70 @@ describe('bookmarks', () => {
     const net = mkNetwork(u.id, 'libera');
     const { id } = chat(net!.id, '#meta', 'eve', 'goodbye');
     addBookmark(u.id, id);
-    expect(listBookmarkIdsForUser(u.id)).toEqual([id]);
+    expect(savedIds(u.id)).toEqual([id]);
     deleteUser(u.id);
-    expect(listBookmarkIdsForUser(u.id)).toEqual([]);
+    expect(savedIds(u.id)).toEqual([]);
+  });
+});
+
+// The `bookmarked` flag on message rows is what replaced the connect-burst id
+// snapshot: the client learns which lines it has saved from the lines
+// themselves, so the state it holds is bounded by what it has loaded rather
+// than by everything the account has ever saved.
+describe('bookmarked flag on message rows', () => {
+  it('rides on the row, and only for the rows actually saved', () => {
+    const u = createUser('bmcol-alice');
+    const net = mkNetwork(u.id, 'libera');
+    const plain = chat(net!.id, '#meta', 'alice', 'unsaved').id;
+    const saved = chat(net!.id, '#meta', 'alice', 'saved').id;
+    addBookmark(u.id, saved);
+
+    const byId = new Map(listMessages(net!.id, '#meta').map((e) => [e.id, e]));
+    expect(byId.get(saved)!.bookmarked).toBe(true);
+    // Absent, not `false` — an unbookmarked row must not grow a field, since
+    // that is nearly every row in every backlog ever sent.
+    expect(byId.get(plain)).not.toHaveProperty('bookmarked');
+  });
+
+  it('clears when the bookmark is removed', () => {
+    const u = createUser('bmcol-bob');
+    const net = mkNetwork(u.id, 'libera');
+    const { id } = chat(net!.id, '#meta', 'bob', 'hi');
+    addBookmark(u.id, id);
+    expect(listMessages(net!.id, '#meta')[0].bookmarked).toBe(true);
+    removeBookmark(u.id, id);
+    expect(listMessages(net!.id, '#meta')[0]).not.toHaveProperty('bookmarked');
+  });
+
+  it("does not leak another user's bookmark onto a row", () => {
+    // The flag resolves its user through the message's OWN network, so a second
+    // account bookmarking the same id is impossible — but were the derivation
+    // ever loosened to a bare message_id match, this is what would break.
+    const owner = createUser('bmcol-owner');
+    const other = createUser('bmcol-other');
+    const net = mkNetwork(owner.id, 'libera');
+    const { id } = chat(net!.id, '#meta', 'owner', 'mine');
+    expect(addBookmark(other.id, id)).toBe(false);
+    expect(listMessages(net!.id, '#meta')[0]).not.toHaveProperty('bookmarked');
+    expect(isBookmarked(owner.id, id)).toBe(false);
+  });
+
+  it('cannot be forged by a stray key in the message extra blob', () => {
+    // `extra` is built from what a network sent us; `bookmarked` is a fact about
+    // the reader's own account. rowToEvent applies the column AFTER the extra
+    // spread so the former can never light up a line nobody saved.
+    const u = createUser('bmcol-carol');
+    const net = mkNetwork(u.id, 'libera');
+    insertMessage({
+      networkId: net!.id,
+      target: '#meta',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'mallory',
+      text: 'trust me',
+      self: false,
+      extra: { bookmarked: true },
+    });
+    expect(listMessages(net!.id, '#meta')[0]).not.toHaveProperty('bookmarked');
   });
 });

--- a/server/db/bookmarks.ts
+++ b/server/db/bookmarks.ts
@@ -63,12 +63,6 @@ const existsStmt = db.prepare(`
   SELECT 1 FROM user_bookmarks WHERE user_id = ? AND message_id = ?
 `);
 
-const listIdsStmt = db.prepare(`
-  SELECT message_id AS messageId FROM user_bookmarks
-  WHERE user_id = ?
-  ORDER BY message_id DESC
-`);
-
 export function addBookmark(userId: number, messageId: number): boolean {
   insertStmt.run({ userId, messageId });
   return !!existsStmt.get(userId, messageId);
@@ -82,9 +76,10 @@ export function isBookmarked(userId: number, messageId: number): boolean {
   return !!existsStmt.get(userId, messageId);
 }
 
-export function listBookmarkIdsForUser(userId: number): number[] {
-  return (listIdsStmt.all(userId) as Array<{ messageId: number }>).map((r) => r.messageId);
-}
+// There is deliberately no "every id this user saved" accessor. That query
+// existed to seed a connect-burst snapshot, which grew without bound over an
+// account's life; bookmark state now rides on the message rows (`bookmarked` in
+// db/messages.ts), so nothing needs to ask for the whole set at once.
 
 // Paginated list joined with messages + networks. Row shape matches
 // listUserHighlights so the same HistoryMessageRow component can render

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -23,6 +23,9 @@ interface MessageRow {
   from_ignored: number;
   mirrored: number;
   msgid: string | null;
+  // 0/1 from the computed `bookmarked` column — see BOOKMARKED_COL. Optional
+  // because it exists only on the SELECTs that ask for it.
+  bookmarked?: number;
 }
 
 /** A raw message row joined with network_name. */
@@ -52,6 +55,10 @@ export interface MessageEvent {
   // IRCv3 server-assigned message id (#450). Only set when the network supplied
   // one — absent (not null) otherwise, so untagged backlogs don't grow a field.
   msgid?: string;
+  // Whether the owning user has saved this line. Absent (not `false`) when they
+  // haven't, on the same reasoning as `msgid`: almost no row is bookmarked, and
+  // a false on every row is pure wire weight. See BOOKMARKED_COL.
+  bookmarked?: true;
   [key: string]: unknown;
 }
 
@@ -145,6 +152,29 @@ export function insertMessage(row: MessageInput): { id: number | bigint; alt: bo
   return { id, alt: altRow?.alt === 1 };
 }
 
+// Whether the owning user has bookmarked a row, computed per row rather than
+// shipped as a wholesale id list at connect.
+//
+// The client only ever needs this flag for lines it is actually rendering, and a
+// bookmark set is the one thing in the connect burst that grows without bound
+// over an account's life — every other snapshot there (drafts, contacts) is
+// naturally bounded. So the state travels with the messages that carry it, and
+// the client keeps a Set of what it has seen rather than of everything it owns.
+//
+// The owner is derived from the message's own network, which is why no query in
+// this file has to thread a userId to ask the question. System-buffer rows
+// (network_id NULL) resolve no owner and so compute 0 — matching the insert in
+// db/bookmarks.ts, which gates on the same networks join and therefore refuses
+// to bookmark them in the first place.
+//
+// `alias` is the table's name or alias in the enclosing query, since some
+// callers select from a bare `messages` and others from `messages m`.
+const BOOKMARKED_COL = (alias: string) => `EXISTS (
+    SELECT 1 FROM user_bookmarks ub
+    WHERE ub.message_id = ${alias}.id
+      AND ub.user_id = (SELECT n_own.user_id FROM networks n_own WHERE n_own.id = ${alias}.network_id)
+  ) AS bookmarked`;
+
 function rowToEvent(row: MessageRow): MessageEvent {
   const event: MessageEvent = {
     id: row.id,
@@ -171,6 +201,16 @@ function rowToEvent(row: MessageRow): MessageEvent {
       /* ignore malformed */
     }
   }
+  // After the `extra` spread, and it CLEARS rather than merely overwrites.
+  //
+  // `extra` is JSON built from what a network sent us; `bookmarked` is a fact
+  // about the reader's own account, so a stray key in there must never light up
+  // a line nobody saved. Assigning-when-true alone wouldn't do it: on the rows
+  // that matter — the unbookmarked ones — there'd be no assignment to overwrite
+  // the forged value with, and it would sail through. The delete is the part
+  // that makes the column authoritative.
+  delete event.bookmarked;
+  if (row.bookmarked) event.bookmarked = true;
   return event;
 }
 
@@ -186,15 +226,15 @@ export function listMessages(
   if (afterId) {
     const rows = db
       .prepare(
-        `SELECT * FROM messages WHERE network_id = ? AND target = ? AND id > ?
+        `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE network_id = ? AND target = ? AND id > ?
        ORDER BY id ASC LIMIT ?`,
       )
       .all(networkId, target, afterId, limit) as MessageRow[];
     return rows.map(rowToEvent);
   }
   const sql = before
-    ? `SELECT * FROM messages WHERE network_id = ? AND target = ? AND id < ? ORDER BY id DESC LIMIT ?`
-    : `SELECT * FROM messages WHERE network_id = ? AND target = ? ORDER BY id DESC LIMIT ?`;
+    ? `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE network_id = ? AND target = ? AND id < ? ORDER BY id DESC LIMIT ?`
+    : `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE network_id = ? AND target = ? ORDER BY id DESC LIMIT ?`;
   const params = before ? [networkId, target, before, limit] : [networkId, target, limit];
   const rows = db.prepare(sql).all(...params) as MessageRow[];
   return rows.map(rowToEvent).toReversed();
@@ -316,7 +356,9 @@ export function listMessagesCounted(
     }
   }
   const rows = db
-    .prepare(`SELECT * FROM messages WHERE ${conds.join(' AND ')} ORDER BY id ASC`)
+    .prepare(
+      `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE ${conds.join(' AND ')} ORDER BY id ASC`,
+    )
     .all(...params) as MessageRow[];
   return rows.map(rowToEvent);
 }
@@ -341,7 +383,9 @@ export function listMessagesAround(
   | { events: MessageEvent[]; hasMoreOlder: boolean; hasMoreNewer: boolean }
   | { events: []; hasMoreOlder: false; hasMoreNewer: false; anchorMissing: true } {
   const anchorRow = db
-    .prepare(`SELECT * FROM messages WHERE id = ? AND network_id = ? AND target = ?`)
+    .prepare(
+      `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE id = ? AND network_id = ? AND target = ?`,
+    )
     .get(anchorId, networkId, target) as MessageRow | undefined;
   if (!anchorRow) {
     return { events: [], hasMoreOlder: false, hasMoreNewer: false, anchorMissing: true };
@@ -432,7 +476,7 @@ export function loadHistoryWindow(
   const dir = newestFirst ? 'DESC' : 'ASC';
   const rows = db
     .prepare(
-      `SELECT * FROM messages WHERE ${conds.join(' AND ')}
+      `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE ${conds.join(' AND ')}
        ORDER BY time ${dir}, id ${dir} LIMIT ?`,
     )
     .all(...params) as MessageRow[];
@@ -725,7 +769,7 @@ export function listUserHighlights(
   { before, limit = 50 }: { before?: number; limit?: number } = {},
 ): MessageEventWithNetwork[] {
   const sql = before
-    ? `SELECT m.*, n.name AS network_name
+    ? `SELECT m.*, n.name AS network_name, ${BOOKMARKED_COL('m')}
        FROM messages m
        JOIN networks n ON n.id = m.network_id
        WHERE n.user_id = ?
@@ -734,7 +778,7 @@ export function listUserHighlights(
          AND m.id < ?
        ORDER BY m.id DESC
        LIMIT ?`
-    : `SELECT m.*, n.name AS network_name
+    : `SELECT m.*, n.name AS network_name, ${BOOKMARKED_COL('m')}
        FROM messages m
        JOIN networks n ON n.id = m.network_id
        WHERE n.user_id = ?
@@ -856,7 +900,7 @@ export function searchMessages(
     params.push(before);
   }
 
-  const sql = `SELECT m.*, n.name AS network_name
+  const sql = `SELECT m.*, n.name AS network_name, ${BOOKMARKED_COL('m')}
                FROM ${from}
                WHERE ${where.join(' AND ')}
                ORDER BY m.id DESC

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -162,10 +162,14 @@ export function insertMessage(row: MessageInput): { id: number | bigint; alt: bo
 // the client keeps a Set of what it has seen rather than of everything it owns.
 //
 // The owner is derived from the message's own network, which is why no query in
-// this file has to thread a userId to ask the question. System-buffer rows
-// (network_id NULL) resolve no owner and so compute 0 — matching the insert in
-// db/bookmarks.ts, which gates on the same networks join and therefore refuses
-// to bookmark them in the first place.
+// this file has to thread a userId to ask the question. `messages.network_id` is
+// NOT NULL and foreign-keyed, so the subquery always resolves to exactly one
+// user — this is the same join `addBookmark` gates its insert on, so what a row
+// reports here and what the server will let you save can't disagree.
+//
+// System-buffer lines don't come through here at all: they live in their own
+// `system_messages` table, which is also why they can't be bookmarked and why
+// their ids overlap this table's.
 //
 // `alias` is the table's name or alias in the enclosing query, since some
 // callers select from a bare `messages` and others from `messages m`.

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -861,7 +861,7 @@ interface SnapshotBreakdown {
   bufferCount: number;
   fresh: boolean; // true = fresh connect → online loop shipped shells, not resume frames
   networksMs: number; // ircManager.snapshotForUser (serializes channel member lists)
-  seedsMs: number; // drafts/bookmarks/system/contacts + the bulk read/cleared/closed maps
+  seedsMs: number; // drafts/system/contacts + the bulk read/cleared/closed maps
   onlineMs: number; // the live per-buffer loop (shells: unread counts; resume: +reads/speakers)
   offlineMs: number; // buildOfflineBacklogFrames
   // Online-loop op split (the rest of onlineMs is sends/input-history/overhead).

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -82,7 +82,7 @@ import {
   listPinnedForUserNetwork,
 } from '../db/pinnedBuffers.js';
 import { setNicklistCollapsed } from '../db/nicklistCollapsed.js';
-import { addBookmark, removeBookmark, listBookmarkIdsForUser } from '../db/bookmarks.js';
+import { addBookmark, removeBookmark } from '../db/bookmarks.js';
 import {
   getChannelNotifyAlways,
   setChannelNotifyAlways,
@@ -2171,11 +2171,13 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     // the keying is global to the user, not per-buffer, so a single message is
     // cheaper than fanning a body field into every backlog row.
     send(ws, { kind: 'draft-snapshot', drafts: draftsService.snapshotForUser(userId) });
-    // Lightweight id-only seed for the bookmarks store. Per-row payloads are
-    // lazy-loaded by the BookmarksModal via REST when the user opens it; this
-    // snapshot exists solely so the message context menu can flip its label
-    // ("Save" ↔ "Remove bookmark") without a network round-trip.
-    send(ws, { kind: 'bookmark-ids-snapshot', ids: listBookmarkIdsForUser(userId) });
+    // No bookmark seed here on purpose. There used to be an id-only snapshot so
+    // the message context menu could flip its label ("Save" ↔ "Remove bookmark")
+    // without a round-trip — but it shipped EVERY id the account had ever saved,
+    // on every connect, and unlike drafts or contacts that set only ever grows.
+    // Bookmark state now rides on the message rows themselves (`bookmarked`, see
+    // db/messages.ts BOOKMARKED_COL), so a client learns what it saved from the
+    // lines it actually renders and holds state bounded by what it has loaded.
     // System buffer seed: the app-scoped system log rides the same 'backlog'
     // frame network buffers use (events + read-state + hasMoreOlder), so the
     // client treats it like any other buffer — no bespoke system-log path (#355).

--- a/server/tenantIsolation.test.ts
+++ b/server/tenantIsolation.test.ts
@@ -61,7 +61,7 @@ let callVerb: typeof import('./services/verbRegistry.js').callVerb;
 let searchMessages: typeof import('./db/messages.js').searchMessages;
 let getNetwork: typeof import('./db/networks.js').getNetwork;
 let addBookmark: typeof import('./db/bookmarks.js').addBookmark;
-let listBookmarkIdsForUser: typeof import('./db/bookmarks.js').listBookmarkIdsForUser;
+let listBookmarksForUser: typeof import('./db/bookmarks.js').listBookmarksForUser;
 let listDraftsForUser: typeof import('./db/drafts.js').listForUser;
 let listPushForUser: typeof import('./db/pushSubscriptions.js').listAllForUser;
 
@@ -112,7 +112,7 @@ beforeAll(async () => {
   searchMessages = search;
   getNetwork = networksDb.getNetwork;
   addBookmark = bookmarks.addBookmark;
-  listBookmarkIdsForUser = bookmarks.listBookmarkIdsForUser;
+  listBookmarksForUser = bookmarks.listBookmarksForUser;
   listDraftsForUser = drafts.listForUser;
   listPushForUser = push.listAllForUser;
 
@@ -455,13 +455,18 @@ describe('DB isolation primitives', () => {
     expect(getNetwork(netAId, userAId)).toBeDefined();
   });
 
+  // Read back through the paginated list, which is how production reads
+  // bookmarks now that no all-ids accessor exists.
+  const savedIds = (userId: number) =>
+    listBookmarksForUser(userId, { limit: 200 }).map((r) => r.id);
+
   it('addBookmark cannot cross tenants (the messageId IDOR is closed)', () => {
     // B tries to bookmark A's message by id — must be a silent no-op so it
     // can't then be read back through B's bookmarks list.
     expect(addBookmark(userBId, msgIdA)).toBe(false);
-    expect(listBookmarkIdsForUser(userBId)).toHaveLength(0);
+    expect(savedIds(userBId)).toHaveLength(0);
     // Positive control: A's own bookmark is present.
-    expect(listBookmarkIdsForUser(userAId)).toContain(msgIdA);
+    expect(savedIds(userAId)).toContain(msgIdA);
   });
 
   it('searchMessages is user-scoped at the SQL layer', () => {

--- a/vue_client/src/composables/useMessageActions.test.ts
+++ b/vue_client/src/composables/useMessageActions.test.ts
@@ -18,7 +18,7 @@ function makeCtx(): MessageContext {
 // A message from someone else, with text and a stable id — the case that yields
 // the full action set. Override individual fields per case.
 function other(over: Partial<MessageLike> = {}): MessageLike {
-  return { id: 42, nick: 'bob', text: 'hi', self: false, ...over };
+  return { id: 42, networkId: 1, nick: 'bob', text: 'hi', self: false, ...over };
 }
 
 describe('useMessageActions', () => {
@@ -49,8 +49,26 @@ describe('useMessageActions', () => {
       expect(actions.map((a) => a.key)).toEqual(['reply', 'copy', 'ignore']);
     });
 
+    it('drops save on a system-buffer line, which has no owning network', () => {
+      // networkId null == the app-scoped system buffer. The server can't save
+      // these (the ownership check joins through networks), so offering it
+      // would be a button that silently does nothing.
+      const actions = useMessageActions().buildActions(other({ networkId: null }));
+      expect(actions.map((a) => a.key)).toEqual(['reply', 'copy', 'ignore']);
+    });
+
+    it('does not label a system line saved when a real message shares its id', () => {
+      // System lines have their own id sequence, so #42 here is NOT the #42 the
+      // user bookmarked in a channel.
+      useBookmarksStore().noteFromEvents([{ id: 42, bookmarked: true }]);
+      const actions = useMessageActions().buildActions(other({ networkId: null }));
+      expect(actions.find((a) => a.key === 'save')).toBeUndefined();
+    });
+
     it('reflects a saved bookmark in the save label, icon, and active flag', () => {
-      useBookmarksStore().applySnapshot([42]);
+      // Seeded the way production seeds it: off the `bookmarked` flag riding on
+      // a message row, not a connect-burst snapshot.
+      useBookmarksStore().noteFromEvents([{ id: 42, bookmarked: true }]);
       const save = useMessageActions()
         .buildActions(other())
         .find((a) => a.key === 'save');

--- a/vue_client/src/composables/useMessageActions.test.ts
+++ b/vue_client/src/composables/useMessageActions.test.ts
@@ -60,7 +60,7 @@ describe('useMessageActions', () => {
     it('does not label a system line saved when a real message shares its id', () => {
       // System lines have their own id sequence, so #42 here is NOT the #42 the
       // user bookmarked in a channel.
-      useBookmarksStore().noteFromEvents([{ id: 42, bookmarked: true }]);
+      useBookmarksStore().noteFromEvents([{ id: 42, bookmarked: true }], 1);
       const actions = useMessageActions().buildActions(other({ networkId: null }));
       expect(actions.find((a) => a.key === 'save')).toBeUndefined();
     });
@@ -68,7 +68,7 @@ describe('useMessageActions', () => {
     it('reflects a saved bookmark in the save label, icon, and active flag', () => {
       // Seeded the way production seeds it: off the `bookmarked` flag riding on
       // a message row, not a connect-burst snapshot.
-      useBookmarksStore().noteFromEvents([{ id: 42, bookmarked: true }]);
+      useBookmarksStore().noteFromEvents([{ id: 42, bookmarked: true }], 1);
       const save = useMessageActions()
         .buildActions(other())
         .find((a) => a.key === 'save');

--- a/vue_client/src/composables/useMessageActions.ts
+++ b/vue_client/src/composables/useMessageActions.ts
@@ -11,8 +11,10 @@ export interface MessageLike {
   text?: string;
   self?: boolean;
   userhost?: string;
-  networkId?: number;
-  network_id?: number;
+  // Null on the app-scoped system buffer, which has no owning network — see the
+  // bookmark gate in buildActions.
+  networkId?: number | null;
+  network_id?: number | null;
 }
 
 export interface MessageContext {
@@ -81,8 +83,20 @@ export function useMessageActions(): MessageActionsAPI {
       actions.push({ key: 'copy', label: 'Copy text', icon: 'fa-regular fa-copy' });
     }
 
-    // Bookmarks are only meaningful for messages with a stable server id.
-    if (message.id != null) {
+    // Bookmarks need a stable server id AND an owning network.
+    //
+    // The network gate is not cosmetic. Bookmarking is ownership-checked by
+    // joining the message to its network (db/bookmarks.ts), so a system-buffer
+    // line — `networkId: null`, app-scoped — can never be saved: the insert
+    // writes nothing and the server sends no echo back. Offering "Save message"
+    // there was a button that did nothing, forever, with no feedback.
+    //
+    // It also closes a mislabel. System lines come from their own table with
+    // their own id sequence (`systemLineToEvent`), so system line #42 and
+    // message #42 coexist; asking `isSaved(42)` for the former would light up
+    // "Remove bookmark" on a line nobody ever saved.
+    const networkId = message.networkId ?? message.network_id;
+    if (message.id != null && networkId != null) {
       const saved = bookmarks.isSaved(message.id);
       actions.push({
         key: 'save',

--- a/vue_client/src/composables/useSessionReset.ts
+++ b/vue_client/src/composables/useSessionReset.ts
@@ -5,6 +5,7 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useHighlightsStore } from '../stores/highlights.js';
+import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
 import { useNavHistoryStore } from '../stores/navHistory.js';
@@ -32,6 +33,11 @@ export function resetSession(): void {
   useNetworksStore().$reset();
   useSettingsStore().$reset();
   useHighlightsStore().$reset();
+  // Saved messages are per-account and this store holds fetched ROWS, not just ids —
+  // leaving them would show the next user the previous one's saved conversations. It was
+  // never in this list; the `bookmark-ids-snapshot` frame used to overwrite the id set on
+  // every connect, which hid the gap for the ids and never covered the rows at all.
+  useBookmarksStore().$reset();
   useHighlightRulesStore().$reset();
   useInputHistoryStore().$reset();
   useNavHistoryStore().$reset();

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -546,6 +546,7 @@ function handleMessage(raw: string): void {
     if (payload.networkId != null && Array.isArray(payload.events)) {
       for (const e of payload.events) trackSeenId(e?.id);
     }
+    useBookmarksStore().noteFromEvents(payload.events);
     applyBacklog(payload);
     return;
   }
@@ -556,6 +557,9 @@ function handleMessage(raw: string): void {
     // 'history' kind — disambiguated by `mode`.
     const buffers = useBuffersStore();
     const mode = payload.mode || 'before';
+    // Every mode carries `events`; harvest before the mode-specific dispatch so
+    // one call covers around/latest/after/before alike.
+    useBookmarksStore().noteFromEvents(payload.events);
     if (mode === 'around') {
       buffers.applyAroundSlice(payload.networkId, payload.target, payload);
     } else if (mode === 'latest') {
@@ -771,11 +775,6 @@ function handleMessage(raw: string): void {
   }
   if (payload.kind === 'contact-deleted') {
     useFriendsStore().applyContactDeleted(payload.contactId);
-    return;
-  }
-  if (payload.kind === 'bookmark-ids-snapshot') {
-    const bookmarks = useBookmarksStore();
-    bookmarks.applySnapshot(payload.ids || []);
     return;
   }
   if (payload.kind === 'bookmark-updated') {

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -537,6 +537,12 @@ function handleMessage(raw: string): void {
     // ?since pulls only genuinely-new events rather than re-gap-filling history
     // the shells intentionally omitted. Present on fresh connects only.
     if (typeof payload.cursor === 'number') trackSeenId(payload.cursor);
+    // Saves made elsewhere while we were away are replayed by no frame — the
+    // backlogs that follow reconcile the id set row by row, but the loaded
+    // bookmarks LIST would stay as it was before the gap. Re-arm it so the next
+    // modal open refetches. This is what the departed `bookmark-ids-snapshot`
+    // used to do as a side effect of overwriting the store.
+    useBookmarksStore().markListStale();
     return;
   }
   if (payload.kind === 'backlog') {
@@ -546,7 +552,7 @@ function handleMessage(raw: string): void {
     if (payload.networkId != null && Array.isArray(payload.events)) {
       for (const e of payload.events) trackSeenId(e?.id);
     }
-    useBookmarksStore().noteFromEvents(payload.events);
+    useBookmarksStore().noteFromEvents(payload.events, payload.networkId);
     applyBacklog(payload);
     return;
   }
@@ -557,9 +563,9 @@ function handleMessage(raw: string): void {
     // 'history' kind — disambiguated by `mode`.
     const buffers = useBuffersStore();
     const mode = payload.mode || 'before';
-    // Every mode carries `events`; harvest before the mode-specific dispatch so
+    // Every mode carries `events`; reconcile before the mode-specific dispatch so
     // one call covers around/latest/after/before alike.
-    useBookmarksStore().noteFromEvents(payload.events);
+    useBookmarksStore().noteFromEvents(payload.events, payload.networkId);
     if (mode === 'around') {
       buffers.applyAroundSlice(payload.networkId, payload.target, payload);
     } else if (mode === 'latest') {

--- a/vue_client/src/stores/bookmarks.test.ts
+++ b/vue_client/src/stores/bookmarks.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+// The store sends verbs over the socket; nothing here needs a real one.
+vi.mock('../composables/useSocket.js', () => ({
+  socketSend: vi.fn<(payload: Record<string, unknown>) => boolean>(),
+}));
+
+import { useBookmarksStore } from './bookmarks.js';
+
+// The id set is a cache of what the client has SEEN — there is no bookmark snapshot in
+// the connect burst, so it is fed entirely by the `bookmarked` flag riding on message
+// rows plus the `bookmark-updated` echo. These are the rules that keeps it honest.
+describe('bookmarks store', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  const NET = 1;
+
+  it('seeds the set from the flags on a page of rows', () => {
+    const store = useBookmarksStore();
+    store.noteFromEvents([{ id: 1 }, { id: 2, bookmarked: true }], NET);
+    expect(store.isSaved(2)).toBe(true);
+    expect(store.isSaved(1)).toBe(false);
+  });
+
+  // A row that arrives WITHOUT the flag is authoritative for itself: the server omits it
+  // when false. Without this, an unsave made on another device while this tab was
+  // disconnected would never land — the echo was missed, and the reconnect backlog that
+  // carries the truth was only ever read for additions.
+  it('clears a bookmark when the row comes back unflagged', () => {
+    const store = useBookmarksStore();
+    store.noteFromEvents([{ id: 2, bookmarked: true }], NET);
+    store.noteFromEvents([{ id: 2 }], NET);
+    expect(store.isSaved(2)).toBe(false);
+  });
+
+  // …but only for the rows it actually contains. A page knows its own slice and no more,
+  // so silence about an id is not an unsave — otherwise paging up would unlight every
+  // bookmark above the fold.
+  it('does not touch ids the page says nothing about', () => {
+    const store = useBookmarksStore();
+    store.noteFromEvents([{ id: 2, bookmarked: true }], NET);
+    store.noteFromEvents([{ id: 9 }], NET);
+    expect(store.isSaved(2)).toBe(true);
+  });
+
+  // System-buffer rows come from a different table with its own id sequence, overlapping
+  // the message ids this set is keyed by. They never carry the flag, so reconciling
+  // against them would clear real bookmarks that happen to share an id.
+  it('ignores system-buffer pages entirely', () => {
+    const store = useBookmarksStore();
+    store.noteFromEvents([{ id: 2, bookmarked: true }], NET);
+    store.noteFromEvents([{ id: 2 }], null);
+    expect(store.isSaved(2)).toBe(true);
+  });
+
+  // The list holds fetched ROWS of someone's private conversations, and `ensureLoaded`
+  // skips the refetch while it believes them current — so a connect (a new session, or
+  // a gap during which another device saved something) has to re-arm it.
+  it('markListStale forces the next open to refetch', () => {
+    const store = useBookmarksStore();
+    store.listDirty = false;
+    store.markListStale();
+    expect(store.listDirty).toBe(true);
+  });
+
+  it('applyUpdate is the echo path, in both directions', () => {
+    const store = useBookmarksStore();
+    store.applyUpdate({ messageId: 7, saved: true });
+    expect(store.isSaved(7)).toBe(true);
+    store.applyUpdate({ messageId: 7, saved: false });
+    expect(store.isSaved(7)).toBe(false);
+  });
+
+  // Unsaving splices the row out of the loaded page so the modal updates without a
+  // refetch — the echo carries no row payload to re-add it with.
+  it('an unsave echo removes the row from the loaded list', () => {
+    const store = useBookmarksStore();
+    store.items = [{ id: 7, networkId: NET, target: '#a', nick: 'alice' }];
+    store.ids.add(7);
+    store.applyUpdate({ messageId: 7, saved: false });
+    expect(store.items).toEqual([]);
+  });
+});

--- a/vue_client/src/stores/bookmarks.test.ts
+++ b/vue_client/src/stores/bookmarks.test.ts
@@ -13,7 +13,7 @@ import { useBookmarksStore } from './bookmarks.js';
 
 // The id set is a cache of what the client has SEEN — there is no bookmark snapshot in
 // the connect burst, so it is fed entirely by the `bookmarked` flag riding on message
-// rows plus the `bookmark-updated` echo. These are the rules that keeps it honest.
+// rows plus the `bookmark-updated` echo. These are the rules that keep it honest.
 describe('bookmarks store', () => {
   beforeEach(() => setActivePinia(createPinia()));
 

--- a/vue_client/src/stores/bookmarks.ts
+++ b/vue_client/src/stores/bookmarks.ts
@@ -8,8 +8,8 @@ import { socketSend } from '../composables/useSocket.js';
 // Two-track state: a lightweight `Set<messageId>` always in memory, used by the
 // message context menu to flip "Save" ↔ "Remove bookmark" without a network
 // call. The heavyweight paginated `items` list is lazy-loaded by the
-// BookmarksModal via REST. Adds invalidate `items` so the next modal open
-// refetches, since we don't have the full row payload from the echo alone.
+// BookmarksModal via REST. A save marks that list stale so the next modal open
+// refetches, since the echo alone carries no row payload to insert.
 //
 // The Set is a cache of what we've SEEN, not a mirror of what the account owns.
 // It used to be seeded wholesale by a `bookmark-ids-snapshot` frame at connect,

--- a/vue_client/src/stores/bookmarks.ts
+++ b/vue_client/src/stores/bookmarks.ts
@@ -19,6 +19,9 @@ import { socketSend } from '../composables/useSocket.js';
 // client was going to render anyway, and an id we haven't seen is simply one
 // whose line isn't on screen to label. `isSaved` is only ever asked about a
 // message the user is looking at, which is exactly what the Set covers.
+//
+// There is deliberately no `count` getter: the Set is a partial view, so any
+// total derived from it would under-report. Ask the server if that's ever needed.
 const PAGE_SIZE = 50;
 
 // The wire shape of a `GET /api/bookmarks` row (`db/bookmarks.ts`
@@ -54,20 +57,44 @@ export const useBookmarksStore = defineStore('bookmarks', {
   getters: {
     hasMore: (state) => state.nextBefore != null,
     isSaved: (state) => (messageId: number | string) => state.ids.has(Number(messageId)),
-    count: (state) => state.ids.size,
   },
   actions: {
-    // Harvest the `bookmarked` flags off a page of message rows. MERGES rather
-    // than replaces: each page only knows about its own slice, so a later page
-    // must not evict what an earlier one taught us. Unbookmarking is the echo's
-    // job (`applyUpdate`), never a page's silence.
-    noteFromEvents(events: Array<{ id?: number | string | null; bookmarked?: boolean }>) {
-      if (!Array.isArray(events)) return;
+    // Reconcile the id set against a page of message rows.
+    //
+    // Each row is authoritative FOR ITSELF, in both directions: the server computes
+    // `bookmarked` per row and omits it when false, so a row that arrives without the
+    // flag is telling us it isn't saved. Without the clear, an unsave made on another
+    // device while this tab was disconnected would never land — the `bookmark-updated`
+    // echo was missed, and the reconnect backlog that does carry the truth was being
+    // read for additions only, so the row stayed lit until someone clicked it.
+    //
+    // What it must NOT do is evict ids the page says nothing about: a page knows its own
+    // slice and no more, so silence about an id is not an unsave.
+    //
+    // `networkId` gates the whole thing because the SYSTEM buffer's rows come from a
+    // different table with its own id sequence, overlapping this one. They never carry
+    // the flag, so reconciling against them would clear real bookmarks that happen to
+    // share an id.
+    noteFromEvents(
+      events: Array<{ id?: number | string | null; bookmarked?: boolean }>,
+      networkId: number | null | undefined,
+    ) {
+      if (!Array.isArray(events) || networkId == null) return;
       for (const e of events) {
-        if (!e?.bookmarked || e.id == null) continue;
+        if (e?.id == null) continue;
         const n = Number(e.id);
-        if (Number.isFinite(n)) this.ids.add(n);
+        if (!Number.isFinite(n)) continue;
+        if (e.bookmarked) this.ids.add(n);
+        else this.ids.delete(n);
       }
+    },
+
+    // A connect burst means anything could have changed while we were away — including
+    // saves made elsewhere, which no frame replays. Re-arm the list so the next modal
+    // open refetches rather than showing what was true before the gap. The id set needs
+    // no equivalent: the backlog frames that follow reconcile it row by row.
+    markListStale() {
+      this.listDirty = true;
     },
     applyUpdate({ messageId, saved }: { messageId: number | string; saved: boolean }) {
       const id = Number(messageId);

--- a/vue_client/src/stores/bookmarks.ts
+++ b/vue_client/src/stores/bookmarks.ts
@@ -5,23 +5,41 @@ import { defineStore } from 'pinia';
 import { api } from '../api.js';
 import { socketSend } from '../composables/useSocket.js';
 
-// Two-track state: a lightweight `Set<messageId>` always in memory, seeded by
-// the `bookmark-ids-snapshot` envelope at connect and mutated by echoes — used
-// by the message context menu to flip "Save" ↔ "Remove bookmark" without a
-// network call. The heavyweight paginated `items` list is lazy-loaded by the
+// Two-track state: a lightweight `Set<messageId>` always in memory, used by the
+// message context menu to flip "Save" ↔ "Remove bookmark" without a network
+// call. The heavyweight paginated `items` list is lazy-loaded by the
 // BookmarksModal via REST. Adds invalidate `items` so the next modal open
 // refetches, since we don't have the full row payload from the echo alone.
+//
+// The Set is a cache of what we've SEEN, not a mirror of what the account owns.
+// It used to be seeded wholesale by a `bookmark-ids-snapshot` frame at connect,
+// which shipped every id the account had ever saved — the one piece of connect
+// state that grows without bound. Now each message row carries its own
+// `bookmarked` flag, so the Set fills in from the backlog/history pages the
+// client was going to render anyway, and an id we haven't seen is simply one
+// whose line isn't on screen to label. `isSaved` is only ever asked about a
+// message the user is looking at, which is exactly what the Set covers.
 const PAGE_SIZE = 50;
 
+// The wire shape of a `GET /api/bookmarks` row (`db/bookmarks.ts`
+// listBookmarksForUser), which is deliberately the same shape highlights and
+// search return so one HistoryMessageRow renders all three.
+//
+// `text`/`time` are the real field names. This used to declare `body`/`createdAt`,
+// which the server has never sent; it went unnoticed because the modal reads the
+// row through HistoryMessageRow's own type and nothing ever touched the two
+// phantom fields.
 export interface BookmarkMessage {
   id: number;
   networkId: number;
   target: string;
   nick: string;
-  body: string;
-  createdAt: string;
+  text?: string;
+  time?: string;
+  networkName?: string;
   // Sender hostmask, when known — drives client-side ignore filtering.
   userhost?: string | null;
+  [key: string]: unknown;
 }
 
 export const useBookmarksStore = defineStore('bookmarks', {
@@ -39,14 +57,17 @@ export const useBookmarksStore = defineStore('bookmarks', {
     count: (state) => state.ids.size,
   },
   actions: {
-    applySnapshot(ids: (number | string)[]) {
-      const next = new Set<number>();
-      for (const id of ids || []) {
-        const n = Number(id);
-        if (Number.isFinite(n)) next.add(n);
+    // Harvest the `bookmarked` flags off a page of message rows. MERGES rather
+    // than replaces: each page only knows about its own slice, so a later page
+    // must not evict what an earlier one taught us. Unbookmarking is the echo's
+    // job (`applyUpdate`), never a page's silence.
+    noteFromEvents(events: Array<{ id?: number | string | null; bookmarked?: boolean }>) {
+      if (!Array.isArray(events)) return;
+      for (const e of events) {
+        if (!e?.bookmarked || e.id == null) continue;
+        const n = Number(e.id);
+        if (Number.isFinite(n)) this.ids.add(n);
       }
-      this.ids = next;
-      this.listDirty = true;
     },
     applyUpdate({ messageId, saved }: { messageId: number | string; saved: boolean }) {
       const id = Number(messageId);
@@ -74,6 +95,15 @@ export const useBookmarksStore = defineStore('bookmarks', {
         socketSend({ type: 'set-bookmark', messageId: id });
       }
     },
+    // Every row in the saved-messages list is saved by definition — the REST
+    // rows carry no `bookmarked` flag because the endpoint returns nothing else.
+    noteFromList(items: Array<{ id?: number | string | null }>) {
+      for (const m of items || []) {
+        if (m?.id == null) continue;
+        const n = Number(m.id);
+        if (Number.isFinite(n)) this.ids.add(n);
+      }
+    },
     remove(messageId: number | string) {
       const id = Number(messageId);
       if (!Number.isFinite(id)) return;
@@ -87,6 +117,7 @@ export const useBookmarksStore = defineStore('bookmarks', {
         this.items = items || [];
         this.nextBefore = nextBefore ?? null;
         this.listDirty = false;
+        this.noteFromList(this.items);
       } catch (e: any) {
         this.error = e.message || 'failed to load bookmarks';
       } finally {
@@ -103,6 +134,7 @@ export const useBookmarksStore = defineStore('bookmarks', {
         );
         this.items = this.items.concat(items || []);
         this.nextBefore = nextBefore ?? null;
+        this.noteFromList(items || []);
       } catch (e: any) {
         this.error = e.message || 'failed to load more bookmarks';
       } finally {


### PR DESCRIPTION
Replaces the `bookmark-ids-snapshot` connect frame with a `bookmarked` flag on the message rows themselves. Prep for bookmarks on iOS (lurker-ios#82), but it stands on its own — **this should land before that one**, which needs the flag.

## Why

The connect burst shipped every message id the account had ever saved, on every connect. Unlike the drafts and contacts snapshots beside it, that set only ever grows: it's bounded by the account's lifetime rather than by anything the client is about to render. It existed solely so the message context menu could flip "Save" ↔ "Remove bookmark" without a round-trip — a question only ever asked about a line currently on screen.

So the state now travels with the messages that carry it. `bookmarked` is computed per row (`BOOKMARKED_COL`) and emitted **only when true**, so unsaved rows — nearly every row in every backlog — cost nothing on the wire. The owner derives from the message's own network in SQL, which is why no query grew a `userId` parameter.

Clients keep a `Set` of ids they've *seen*, merged from the pages they were going to render anyway. That's sound because the only question ever asked of it is "is the line on screen saved?", and a line on screen is a line that was loaded.

## Deploy skew

Benign in both directions, so no version bump:

- **Old client, new server** — gets an empty set and self-heals on first press; the insert is idempotent and echoes back `saved: true`.
- **New client, old server** — no flags arrive, so nothing lights up. No crash, no wrong state.

## Bugs fixed along the way

- **"Save message" was offered on system-buffer lines, where it does nothing, silently, forever.** Bookmarking is ownership-checked by joining through `networks`; system lines have none, so the insert writes nothing and no echo fires. The menu gated only on `message.id != null`.
- **A system line could be labelled "Remove bookmark" because an unrelated message shared its id.** System lines come from `system_messages`, which has its own id sequence overlapping `messages`. Both close by gating the action on an owning network.
- **The bookmarks store was never in `resetSession()`.** It holds fetched *rows*, so after a sign-out with no page reload the next user opening the modal saw the previous account's saved conversations. The departed snapshot had been overwriting the id set on every connect, which masked the gap for the ids and never covered the rows at all. Caught in review.
- `BookmarkMessage` declared `body`/`createdAt`; the wire has always sent `text`/`time`. Nothing read them, so the type just quietly lied.

## Two subtleties worth a reviewer's eye

**`rowToEvent` deletes `bookmarked` before re-applying it.** Applying the column after the `extra` spread isn't enough: on unbookmarked rows there's no assignment to overwrite a forged key with, so it would sail through. `extra` is JSON built from what a network sent us; this is a fact about the reader's own account. Verified by mutating the ordering and watching the test fail.

**Page reconciliation is per-row authoritative, not additive.** A row arriving *without* the flag is the server saying it isn't saved, so reading pages for additions only meant an unsave made on another device while a tab was disconnected never landed. Now cleared per row — while still never evicting ids a page says nothing about, since a page knows only its own slice. Gated on `networkId`, because reconciling against system-buffer rows would clear real bookmarks sharing an id.

## Testing

`npm run check` clean; `npm test` 3076 tests / 225 files pass. New coverage for the column (including the forged-`extra` case), the store's reconcile rules, and the tenant-isolation suite retargeted at the paginated read now that there's no all-ids accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)