### PR TITLE
Bump version to 1.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version bump only — `package.json` + `package-lock.json` in root and `vue_client`.

Cut so the iOS app's bookmark support (lurker-ios#83) has a released server to run against: bookmark state now rides on message rows, which #674 added.

## What's in this release (34 commits since v1.1.4)

- **#674** — bookmark state on message rows; drops the `bookmark-ids-snapshot` connect frame
- **#672** — event-noise filtering collapsed into one `chat.events` tier
- **#671** — hydration split off `open-buffer`, which now announces a real open
- **#670** — history pages sized in rendered rows rather than stored ones
- **#669** — WS transport hygiene: backpressure judged by progress, wedged sockets dropped, reconnect jitter
- **#668** — WS protocol semantics + spec corrections

## Worth knowing before deploying

The bookmark change removes a frame from the connect burst and `open-buffer`'s contract changed. Skew is benign in both directions (an old client gets an empty bookmark set and self-heals on first press; a new client against an old server just never lights one up), which is why this is a patch bump.

**The transport work in #668–#671 is the part that deserves a real-world soak**, not bookmarks. Those changes touch every connect for every client and fail quietly under load or on bad networks — a flaky-mobile-connection session is the test that matters here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)