### PR TITLE
Make the connect snapshot's resume path cheap (#469)

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -132,7 +132,10 @@ function migrate() {
       extra TEXT,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
     );
-    CREATE INDEX IF NOT EXISTS idx_messages_buffer ON messages(network_id, target, id DESC);
+    -- The per-buffer index lives further down as idx_messages_unread, because it
+    -- needs columns (type, from_ignored, notable) this CREATE TABLE predates and
+    -- ensureColumn adds later. It supersedes the old idx_messages_buffer, which
+    -- is dropped there.
 
     -- network_id is nullable: NULL keys the app-scoped system buffer (#355),
     -- which has no network. The composite PK stays (network buffers dedupe on it,
@@ -838,6 +841,10 @@ function tableExists(table: string): boolean {
   return !!db.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`).get(table);
 }
 
+function indexExists(name: string): boolean {
+  return !!db.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?`).get(name);
+}
+
 // Recovery for pre-role SELF-HOSTED installs: if no admin exists, promote the
 // earliest user so a single-user install that pre-dates the role column keeps
 // control. Deliberately SKIPPED in node edition — a cell is managed by the
@@ -1015,6 +1022,74 @@ ensureColumn('messages', 'notable', 'INTEGER NOT NULL DEFAULT 1');
 // behavior applies to existing history too. Gated on the column having been
 // absent, so it runs exactly once — never a repeated full scan on later boots.
 if (!hadNotableColumn) demoteLegacyServerStatusNotices();
+
+// Covering index for the connect-snapshot unread counts (#469). countUnreadRows
+// filters on `type` and `from_ignored` (and `notable` for :server: buffers), but
+// the index this replaces carried only (network_id, target, id) — so SQLite found
+// each candidate in the index and then fetched the full table ROW to evaluate those
+// predicates. On a flood-heavy channel only ~40% of rows are countable, so
+// reaching UNREAD_COUNT_CAP meant ~2,500 scattered rowid lookups PER BUFFER, and a
+// connect snapshot pays that for every buffer on the account. Warm it is invisible;
+// cold — a fresh boot, or an account whose DB doesn't fit in page cache — every one
+// of those lookups is a real seek, which is what pins the event loop for tens of
+// seconds on spinning disks and trips IRC ping timeouts in a feedback loop.
+//
+// Listing the filter columns after the cursor makes the count index-ONLY (verify
+// with EXPLAIN QUERY PLAN: "USING COVERING INDEX idx_messages_unread"). Column
+// order matters: (network_id, target) are the equality prefix, `id DESC` matches
+// the ORDER BY that lets the LIMIT stop early, and the three filter columns ride
+// along purely as payload — they must come last or they'd break the range scan.
+//
+// This REPLACES the old idx_messages_buffer rather than sitting alongside it —
+// see the DROP below for why keeping both would be pure write-path cost.
+//
+// Cost, measured on a synthetic 2.08M-row / 451MB account: a ONE-TIME build on the
+// first boot after upgrade (~1s on NVMe; expect meaningfully longer on the
+// spinning-disk installs this fix targets, since the build is a full scan plus a
+// sort). Startup blocks on it, which is the right trade — the alternative is
+// paying scattered row lookups on every connect, forever — but an operator
+// watching a slow first boot deserves to know why. Net disk after the DROP below
+// is roughly +3.5%, not the +13% this index costs on its own.
+
+// Tell the operator before starting, because a silent stall here is
+// indistinguishable from a hang. The build blocks module import, is not
+// resumable, and on the spinning-disk installs this targets can take long
+// enough that a
+// supervisor (Docker restart policy, the control-plane heartbeat watchdog) kills
+// the container mid-build — SQLite then rolls it back and the next boot starts
+// over, which is a restart loop on precisely the installs the fix is for. An
+// operator who can see WHY boot is stalled can raise the timeout instead of
+// guessing. Only warns when there's enough history for the build to be slow, so
+// ordinary instances stay quiet.
+if (!indexExists('idx_messages_unread')) {
+  const rows = (db.prepare(`SELECT COUNT(*) AS n FROM messages`).get() as { n: number }).n;
+  if (rows > 250_000) {
+    console.warn(
+      `[db] building idx_messages_unread over ${rows.toLocaleString()} messages — one-time, ` +
+        `blocks startup, and can take minutes on slow storage. Do not kill the process: the ` +
+        `build is not resumable and a restart begins again from zero.`,
+    );
+  }
+}
+db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_unread
+         ON messages(network_id, target, id DESC, type, from_ignored, notable)`);
+
+// ...and retire the index it supersedes. idx_messages_buffer was
+// (network_id, target, id DESC) — a strict column PREFIX of the above, so every
+// query it could serve, idx_messages_unread serves too. Keeping both would mean
+// maintaining two b-trees on every INSERT (on a busy channel, the write path
+// that matters most) to no read benefit.
+//
+// Measured on the same 2.08M-row account, dropping it: no query regresses
+// (the `SELECT *` reads are dominated by fetching full rows from the table, not
+// by index width, and come out within noise), the unread count gets ~24% FASTER,
+// and the database shrinks 44MB. That turns the net cost of this whole change
+// from +13% to roughly +3.5%.
+//
+// Ordered after the CREATE above so there is never a boot in which neither index
+// exists. On an existing database the old index stays live through every
+// migration that ran before this line; on a fresh one the table is empty.
+db.exec(`DROP INDEX IF EXISTS idx_messages_buffer`);
 
 // #470 backfill body, split out so it can be unit-tested against seeded rows
 // (a hoisted declaration, so the gated call above reaches it). Demotes only

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1053,23 +1053,29 @@ if (!hadNotableColumn) demoteLegacyServerStatusNotices();
 
 // Tell the operator before starting, because a silent stall here is
 // indistinguishable from a hang. The build blocks module import, is not
-// resumable, and on the spinning-disk installs this targets can take long
-// enough that a
-// supervisor (Docker restart policy, the control-plane heartbeat watchdog) kills
-// the container mid-build — SQLite then rolls it back and the next boot starts
-// over, which is a restart loop on precisely the installs the fix is for. An
-// operator who can see WHY boot is stalled can raise the timeout instead of
-// guessing. Only warns when there's enough history for the build to be slow, so
-// ordinary instances stay quiet.
-if (!indexExists('idx_messages_unread')) {
-  const rows = (db.prepare(`SELECT COUNT(*) AS n FROM messages`).get() as { n: number }).n;
-  if (rows > 250_000) {
-    console.warn(
-      `[db] building idx_messages_unread over ${rows.toLocaleString()} messages — one-time, ` +
-        `blocks startup, and can take minutes on slow storage. Do not kill the process: the ` +
-        `build is not resumable and a restart begins again from zero.`,
-    );
-  }
+// resumable, and on the spinning-disk installs this targets can take long enough
+// that a supervisor (Docker restart policy, the control-plane heartbeat
+// watchdog) kills the container mid-build — SQLite then rolls it back and the
+// next boot starts over, which is a restart loop on precisely the installs the
+// fix is for. An operator who can see WHY boot is stalled can raise the timeout
+// instead of guessing. Only warns when there's enough history for the build to
+// be slow, so ordinary instances stay quiet.
+//
+// The threshold test is an OFFSET probe, not COUNT(*). Counting the table to
+// decide whether to warn about a slow scan would itself be a full scan — silent,
+// and on exactly the cold-cache/spinning-disk install the warning exists for, so
+// it would just move the unexplained silence earlier. This stops at the
+// threshold. (Same idiom as messages.ts hasMoreThan, for the same reason.)
+const INDEX_BUILD_WARN_ROWS = 250_000;
+if (
+  !indexExists('idx_messages_unread') &&
+  db.prepare(`SELECT 1 FROM messages LIMIT 1 OFFSET ?`).get(INDEX_BUILD_WARN_ROWS)
+) {
+  console.warn(
+    `[db] building idx_messages_unread over ${INDEX_BUILD_WARN_ROWS.toLocaleString()}+ ` +
+      `messages — one-time, blocks startup, and can take minutes on slow storage. Do not ` +
+      `kill the process: the build is not resumable and a restart begins again from zero.`,
+  );
 }
 db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_unread
          ON messages(network_id, target, id DESC, type, from_ignored, notable)`);

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -21,6 +21,7 @@ let listMessagesAround: typeof import('./messages.js').listMessagesAround;
 let listMessagesCounted: typeof import('./messages.js').listMessagesCounted;
 let searchMessages: typeof import('./messages.js').searchMessages;
 let countNewer: typeof import('./messages.js').countNewer;
+let hasMoreThan: typeof import('./messages.js').hasMoreThan;
 let countServerBufferUnread: typeof import('./messages.js').countServerBufferUnread;
 let typeCountsForUnread: typeof import('./messages.js').typeCountsForUnread;
 let countHighlightsNewer: typeof import('./messages.js').countHighlightsNewer;
@@ -44,6 +45,7 @@ beforeAll(async () => {
     listMessagesCounted,
     searchMessages,
     countNewer,
+    hasMoreThan,
     countServerBufferUnread,
     typeCountsForUnread,
     countHighlightsNewer,
@@ -1441,5 +1443,75 @@ describe('listMessagesAround countBy', () => {
     // Still one contiguous run, so the paging cursors either side stay valid.
     const rendIds = renderable.events.map((e) => e.id);
     expect(rendIds.at(-1)! - rendIds[0] + 1).toBe(rendIds.length);
+  });
+});
+
+describe('hasMoreThan (#469 resume-gap probe)', () => {
+  // The connect snapshot decides append-vs-replace on this one boolean, so its
+  // boundary IS the protocol decision: one off-by-one silently flips a gap-fill
+  // into a wholesale replace and throws away the client's scrollback.
+  const setup = (name: string) => {
+    const user = createUser(name);
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: name,
+    });
+    return net!.id;
+  };
+
+  it('is exclusive at the boundary: exactly `count` rows is NOT more than `count`', () => {
+    const net = setup('hmt-boundary');
+    const since = chat(net, '#b', 'a', 'cursor').id;
+    const ids = Array.from({ length: 10 }, (_, i) => chat(net, '#b', 'a', `m${i}`).id);
+    expect(hasMoreThan(net, '#b', since, 10)).toBe(false); // exactly 10 after
+    expect(hasMoreThan(net, '#b', since, 9)).toBe(true); // 10 > 9
+    chat(net, '#b', 'a', 'one more');
+    expect(hasMoreThan(net, '#b', since, 10)).toBe(true); // now 11
+    // Anchored on the CURSOR, not on the buffer's size.
+    expect(hasMoreThan(net, '#b', ids[4], 6)).toBe(false); // 6 rows after ids[4]
+    expect(hasMoreThan(net, '#b', ids[4], 5)).toBe(true);
+  });
+
+  it('counts only THIS buffer, since message ids are a global sequence', () => {
+    // The reason the probe uses OFFSET rather than id arithmetic. Interleaving a
+    // second buffer inflates the id span without adding rows here, so any
+    // `afterId + count` shortcut would report the gap as overflowed.
+    const net = setup('hmt-global-ids');
+    const since = chat(net, '#quiet', 'a', 'cursor').id;
+    for (let i = 0; i < 50; i++) chat(net, '#loud', 'a', `noise${i}`);
+    chat(net, '#quiet', 'a', 'only one more');
+    expect(hasMoreThan(net, '#quiet', since, 1)).toBe(false);
+    expect(hasMoreThan(net, '#quiet', since, 0)).toBe(true);
+    expect(hasMoreThan(net, '#loud', since, 49)).toBe(true);
+    expect(hasMoreThan(net, '#loud', since, 50)).toBe(false);
+  });
+
+  it('handles an empty gap, an unknown buffer, and a cursor past the tail', () => {
+    const net = setup('hmt-edges');
+    const tail = chat(net, '#e', 'a', 'only').id;
+    expect(hasMoreThan(net, '#e', tail, 0)).toBe(false); // nothing after the tail
+    expect(hasMoreThan(net, '#e', 0, 0)).toBe(true); // one row from the start
+    expect(hasMoreThan(net, '#e', tail + 1000, 0)).toBe(false); // cursor past the end
+    expect(hasMoreThan(net, '#nope', 0, 0)).toBe(false); // no such buffer
+  });
+
+  it('agrees with the read-then-measure test it replaced', () => {
+    // The probe exists to avoid READING the gap, so pin it against the thing it
+    // replaced: "the capped read filled up AND another row exists past its last".
+    // Any divergence here is a behaviour change wearing a performance label.
+    const net = setup('hmt-oracle');
+    const since = chat(net, '#o', 'a', 'cursor').id;
+    const CAP = 8;
+    for (let n = 0; n <= 12; n++) {
+      if (n > 0) chat(net, '#o', 'a', `m${n}`);
+      const gap = listMessages(net, '#o', { afterId: since, limit: CAP });
+      const lastGapId = gap.length ? gap[gap.length - 1].id : since;
+      const oracle =
+        gap.length >= CAP && listMessages(net, '#o', { afterId: lastGapId, limit: 1 }).length > 0;
+      expect(hasMoreThan(net, '#o', since, CAP)).toBe(oracle);
+    }
   });
 });

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -301,7 +301,7 @@ interface PageOptions {
  * open a hole. That property is what makes it worth doing server-side rather
  * than having clients over-fetch and trim.
  *
- * Two indexed reads, both on idx_messages_buffer(network_id, target, id DESC):
+ * Two indexed reads, both on idx_messages_unread(network_id, target, id DESC, ...):
  * a (id, type) scan to find the boundary row, then a fetch of the range it
  * bounds.
  */
@@ -434,6 +434,35 @@ export function hasOlderRow(networkId: number, target: string, id: number): bool
 }
 export function hasNewerRow(networkId: number, target: string, id: number): boolean {
   return hasNewerThan(networkId, target, id);
+}
+
+// Are there MORE than `count` rows newer than `afterId` in this buffer? Answers
+// buildResumeSlice's "did the gap overflow the cap?" question without reading the
+// gap body: the caller used to fetch all `count` rows, decorate them, discover the
+// overflow from their length, and throw every one away before re-reading a latest
+// slice. On a flooding account every buffer overflows after any real disconnect,
+// so that discarded read was the dominant cost of a resume snapshot.
+//
+// OFFSET, not id arithmetic: message ids are a single GLOBAL sequence shared by
+// every buffer, so `afterId + count` says nothing about how many rows THIS buffer
+// holds in that span. The offset walks the buffer's own rows. Selecting only `id`
+// keeps it inside idx_messages_unread (index-only, no table fetches), so the probe
+// costs a bounded index walk instead of `count` random row reads.
+export function hasMoreThan(
+  networkId: number,
+  target: string,
+  afterId: number,
+  count: number,
+): boolean {
+  return !!db
+    .prepare(
+      `SELECT 1 FROM (
+         SELECT id FROM messages
+         WHERE network_id = ? AND target = ? AND id > ?
+         ORDER BY id ASC LIMIT 1 OFFSET ?
+       )`,
+    )
+    .get(networkId, target, afterId, count);
 }
 
 // --- IRCv3 draft/chathistory window queries --------------------------------
@@ -657,7 +686,7 @@ const COUNTABLE_TYPES_SQL = `('${[...COUNTABLE_TYPES].join("','")}')`;
 // buffer's ENTIRE unread range (every row with id > the read pointer), which is
 // the dominant per-buffer cost of a connect snapshot on a deep buffer with a low
 // read pointer. Cap the count at UNREAD_COUNT_CAP: the inner ORDER BY id DESC +
-// LIMIT lets SQLite walk idx_messages_buffer(network_id, target, id DESC) and
+// LIMIT lets SQLite walk idx_messages_unread(network_id, target, id DESC, ...) and
 // stop once that many countable rows are found. Any value >= the cap renders
 // identically (">999"); below the cap it's still exact.
 //
@@ -925,8 +954,8 @@ export function searchMessages(
 // deep the buffer is. The window is small: autocomplete only cares about the last
 // handful of speakers, and the client keeps building the list live via
 // recordSpeaker as the conversation continues. The filters live INSIDE the
-// windowed subquery on purpose: SQLite walks the tail of idx_messages_buffer(
-// network_id, target, id DESC) applying them, so a burst of non-chat rows (a
+// windowed subquery on purpose: SQLite walks the tail of idx_messages_unread(
+// network_id, target, id DESC, ...) applying them, so a burst of non-chat rows (a
 // netsplit's join/quit flood) is skipped rather than eating the window and
 // starving the speaker set. (Backfilled CHATHISTORY isn't a concern: those batches
 // are dropped, not inserted, so id order tracks time order — see ircConnection.ts.)

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -283,6 +283,27 @@ describe('buildResumeSlice', () => {
     expect(slice.hasMoreOlder).toBe(true);
   });
 
+  it('appends a gap that exactly fills the cap without truncating it (#469)', () => {
+    // THE boundary. A gap of exactly RESUME_GAP_CAP rows is complete — the cap
+    // bounded it but nothing was dropped — so it must still append. Getting this
+    // wrong resets the client wholesale on a gap that fit, throwing away its
+    // scrollback for no reason.
+    //
+    // Guards the probe-first rewrite specifically: the old test was "did the read
+    // fill the cap AND is there another row after the last one I read", the new
+    // one is "are there MORE than cap rows after the cursor". They agree only if
+    // the probe's offset is exact — an off-by-one here flips this case to
+    // 'replace' and the cap+10 case above would never catch it.
+    const since = seed('#resumeExact', 'm0');
+    let lastId = since;
+    for (let i = 1; i <= RESUME_GAP_CAP; i++) lastId = seed('#resumeExact', `m${i}`);
+    const slice = buildResumeSlice(userId, networkId, '#resumeExact', since);
+    expect(slice.mode).toBe('append');
+    expect(slice.reset).toBe(false);
+    expect(slice.events.length).toBe(RESUME_GAP_CAP);
+    expect((slice.events.at(-1) as { id: number }).id).toBe(lastId);
+  });
+
   it('ships the latest slice without reset on first connect (sinceId=0)', () => {
     seed('#resumeFresh', 'a');
     seed('#resumeFresh', 'b');

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -23,6 +23,8 @@ let ircManager: typeof import('./ircManager.js').default;
 let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
 let buildBufferShell: typeof import('./wsHub.js').buildBufferShell;
 let buildResumeSlice: typeof import('./wsHub.js').buildResumeSlice;
+let RESUME_GAP_CAP: typeof import('./wsHub.js').RESUME_GAP_CAP;
+let RESUME_LATEST_LIMIT: typeof import('./wsHub.js').RESUME_LATEST_LIMIT;
 let buildOfflineBacklogFrames: typeof import('./wsHub.js').buildOfflineBacklogFrames;
 let maxMessageId: typeof import('../db/messages.js').maxMessageId;
 let handleOpenBuffer: typeof import('./wsHub.js').handleOpenBuffer;
@@ -54,6 +56,8 @@ beforeAll(async () => {
     buildBufferBacklog,
     buildBufferShell,
     buildResumeSlice,
+    RESUME_GAP_CAP,
+    RESUME_LATEST_LIMIT,
     buildOfflineBacklogFrames,
     handleOpenBuffer,
     sweepWsHeartbeat,
@@ -228,9 +232,11 @@ describe('buildBufferBacklog', () => {
 });
 
 describe('buildResumeSlice', () => {
-  // Mirrors the server-side constants in wsHub.ts. If those change, these move.
-  const RESUME_GAP_CAP = 500;
-  const RESUME_LATEST_LIMIT = 200;
+  // The REAL constants, imported rather than mirrored. A local copy passes even
+  // when it has drifted: raise the server's cap to 800 and a test seeding 500
+  // stops being a boundary case and becomes an ordinary sub-cap gap — still
+  // green, no longer guarding anything. (Lowering the cap fails loudly, so only
+  // the raise direction was silent, which is the one that goes unnoticed.)
 
   it('ships just the missed gap and does not reset when it fits the cap', () => {
     const since = seed('#resumeSmall', 'm0');

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -832,10 +832,10 @@ export function buildBufferShell(
 // Upper bound on how many missed rows a resume frame ships per buffer. Wider
 // than the first-connect default so a normal flap fills in one shot, but
 // bounded so a long disconnect can't produce an unbounded payload.
-const RESUME_GAP_CAP = 500;
+export const RESUME_GAP_CAP = 500;
 // When the gap exceeds the cap we fall back to a fresh latest slice; size it
 // to match the first-connect default.
-const RESUME_LATEST_LIMIT = 200;
+export const RESUME_LATEST_LIMIT = 200;
 
 // Per-buffer input-history slice shipped for up-arrow recall (on a :server:
 // backlog, a resume frame, or a shell's 'history' latest hydrate). This is the

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -33,6 +33,7 @@ import {
   listMessagesAround,
   hasOlderRow,
   hasNewerRow,
+  hasMoreThan,
   hasMessageForTarget,
   listSpeakers,
   countNewer,
@@ -903,10 +904,17 @@ export function buildResumeSlice(
   sinceId: number,
 ): { events: DecoratedEvent[]; reset: boolean; mode: BacklogMode; hasMoreOlder: boolean } {
   if (sinceId > 0) {
-    const gap = listMessages(networkId, target, { afterId: sinceId, limit: RESUME_GAP_CAP });
-    const lastGapId = gap.length ? (gap[gap.length - 1].id ?? sinceId) : sinceId;
-    const truncated = gap.length >= RESUME_GAP_CAP && hasNewerRow(networkId, target, lastGapId);
-    if (!truncated) {
+    // Ask whether the gap overflows BEFORE reading it. The truncation test used to
+    // be "read RESUME_GAP_CAP rows, and if we filled the cap, is there another one
+    // after the last?" — which meant a buffer that overflowed paid for a full
+    // capped read plus a decorate pass, then discarded every row and re-read a
+    // latest slice. That is the common case on a busy account after any real
+    // disconnect (every channel overflows), so the discarded work dominated the
+    // resume path. hasMoreThan settles the same question with one index-only
+    // probe. Equivalent by construction: "more than CAP rows exist after the
+    // cursor" is exactly what the old length-plus-hasNewerRow pair detected.
+    if (!hasMoreThan(networkId, target, sinceId, RESUME_GAP_CAP)) {
+      const gap = listMessages(networkId, target, { afterId: sinceId, limit: RESUME_GAP_CAP });
       // hasMoreOlder must be accurate even though a LOADED buffer ignores it
       // (gap-fill just appends): a client holding this buffer only as an empty
       // SHELL (the fresh-connect optimization) empty-seeds from this frame, and a


### PR DESCRIPTION
Closes half of #469. The other half is deliberately left out — see the end.

## The gap

The lazy-shell fix (#460) only ever covered **fresh** connects. It's gated on `isFreshConnect = (ws.sinceId || 0) === 0`, and every real reconnect sends `?since`, so the resume path was untouched. A contributor reported the consequence on a fat account (~104 buffers, ~900 MB) on HDD raid0: the resume snapshot blocked the event loop for 30-70 s, tripping IRC ping timeouts and reconnecting straight into another snapshot.

## Two costs

Both measured on a synthetic 2.08M-row / 451 MB account with a 64 KiB page cache.

**The unread count was never the arithmetic.** `countUnreadRows` filters on `type` and `from_ignored` (and `notable` for `:server:`), none of which `idx_messages_buffer` carried — so SQLite found each candidate in the index and then fetched its full table **row** to evaluate them. On a 40%-countable flood channel that's ~2,500 scattered row reads per buffer, for every buffer on the account. Invisible warm; on cold storage every one is a seek.

`idx_messages_unread` lists those columns after the cursor, making the count index-only (`EXPLAIN QUERY PLAN` → `USING COVERING INDEX`). **193 ms → 25 ms** across 104 buffers.

It supersedes `idx_messages_buffer`, whose columns are a strict prefix of it, so that index is **dropped** rather than kept alongside — two b-trees maintained on every INSERT for no read benefit. Nothing regresses (the `SELECT *` history reads are dominated by fetching rows, not index width), the count gets a further ~24% faster, and 44 MB comes back: net disk **~+3.5%**, not +13%.

**`buildResumeSlice` detected an overflowed gap by reading it.** Fetch 500 rows, decorate them, notice the cap filled, discard all 500, then read 200 more. After any real disconnect on a busy account *every* buffer overflows, so the discarded read dominated. `hasMoreThan` settles it first with one index-only OFFSET probe — OFFSET rather than id arithmetic, because message ids are a single global sequence and `afterId + cap` says nothing about how many rows one buffer holds in that span. **210 ms → 27 ms**, and 52k discarded rows per snapshot go to zero.

Together **~403 ms → ~52 ms** of DB work on that account.

## Operator note

The index build blocks module import and is not resumable, so it warns first above 250k messages — a supervisor killing the container mid-build restarts it from zero. Expect a slow first boot on large databases (~6 s for 2.08M rows on NVMe; longer on the disks this targets). The threshold test is an OFFSET probe, not `COUNT(*)`, so deciding whether to warn isn't itself a silent full scan.

## Not included

Chunking the snapshot so it yields to the event loop. That's the other half of #469 and addresses the reconnect-**herd** case, where cost sums across accounts. It's parked on `snapshot-chunked-burst-parked`: making an atomic burst concurrent turns every inbound verb, fan-out and captured connection reference into a race, and the per-call-site invariants it needs have no enforcement point. It wants a redesign (one enforcement point — e.g. deferring inbound verbs for the burst's duration), not more patches. This half carries the measured win and adds no concurrency surface.

## Testing

`npm run check` and `npm test` green (3081). New coverage: db-layer tests for `hasMoreThan` (exclusive `>count` boundary, global-id independence, edge cases, plus an oracle test pinning it against the read-then-measure logic it replaces), and a `buildResumeSlice` boundary test for a gap that exactly fills the cap. Each was verified to **fail** against the specific defect it guards.

⚠️ **Not QA'd on real hardware.** The numbers are synthetic and on NVMe. The mechanism is verified; "30-70 s becomes single digits on raid0" is a prediction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)