### PR TITLE
Native voice + video calls via LiveKit (token authority + moderation + guest links)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,4 +71,39 @@ services:
       # where the container itself sees cleartext. Flip on only if you serve
       # Lurker over true end-to-end HTTPS.
       # - COOKIE_SECURE=true
+      #
+      # ───── Optional: Voice / video calls (LiveKit) ───────────────────────
+      # Native voice+video for the Scully desktop client, via a self-hosted
+      # LiveKit SFU. OFF by default. To turn it on:
+      #   1. Uncomment the four vars below (and pick your own API secret).
+      #   2. Start the bundled SFU with the "voice" profile:
+      #        docker compose --profile voice up -d
+      #   3. Set LIVEKIT_WS_URL to the address the *desktop clients* reach —
+      #      ws://<this-host>:7880 on a LAN, or wss://<public-host> behind TLS.
+      # Lurker only mints room-scoped access tokens; it never carries media.
+      # - LURKER_VOICE_ENABLED=true
+      # - LIVEKIT_WS_URL=ws://localhost:7880
+      # - LIVEKIT_API_KEY=devkey
+      # - LIVEKIT_API_SECRET=replace-me-with-a-long-random-secret
+    restart: unless-stopped
+
+  # Self-hosted LiveKit SFU. Defined but inert unless you opt in with the
+  # "voice" profile: `docker compose --profile voice up -d`. The API key/secret
+  # here MUST match LIVEKIT_API_KEY / LIVEKIT_API_SECRET on the lurker service
+  # above — that shared secret is what lets Lurker sign tokens this SFU trusts.
+  livekit:
+    image: livekit/livekit-server:latest
+    container_name: lurker-livekit
+    profiles: ['voice']
+    command: --dev --node-ip=127.0.0.1
+    environment:
+      # `key: secret` pairs. Keep in lockstep with the lurker service vars.
+      - LIVEKIT_KEYS=devkey: replace-me-with-a-long-random-secret
+    ports:
+      - '7880:7880'       # signaling (WebSocket + HTTP)
+      - '7881:7881'       # WebRTC over TCP (ICE/TCP fallback)
+      - '7882:7882/udp'   # WebRTC over UDP (media)
+      # NOTE on NAT: --node-ip must be the address clients can reach the SFU at.
+      # 127.0.0.1 works for localhost only. On a LAN set it to this host's LAN IP;
+      # behind real NAT you need a public IP + a TURN server (see LiveKit docs).
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,9 +100,9 @@ services:
       # `key: secret` pairs. Keep in lockstep with the lurker service vars.
       - LIVEKIT_KEYS=devkey: replace-me-with-a-long-random-secret
     ports:
-      - '7880:7880'       # signaling (WebSocket + HTTP)
-      - '7881:7881'       # WebRTC over TCP (ICE/TCP fallback)
-      - '7882:7882/udp'   # WebRTC over UDP (media)
+      - '7880:7880' # signaling (WebSocket + HTTP)
+      - '7881:7881' # WebRTC over TCP (ICE/TCP fallback)
+      - '7882:7882/udp' # WebRTC over UDP (media)
       # NOTE on NAT: --node-ip must be the address clients can reach the SFU at.
       # 127.0.0.1 works for localhost only. On a LAN set it to this host's LAN IP;
       # behind real NAT you need a public IP + a TURN server (see LiveKit docs).

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "express": "^5.2.1",
         "file-type": "^22.0.1",
         "irc-framework": "^4.13.1",
+        "livekit-server-sdk": "^2.17.0",
         "multer": "^2.2.0",
         "selfsigned": "^5.5.0",
         "sharp": "^0.35.3",
@@ -121,6 +122,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -1169,6 +1176,15 @@
       "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
       "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
       "license": "MIT"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -4940,6 +4956,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -5281,6 +5306,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/livekit-server-sdk": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/livekit-server-sdk/-/livekit-server-sdk-2.17.0.tgz",
+      "integrity": "sha512-GWNEQrUD13UwZNrmosyTVFPgeBvSU2lFKGxdA4DaUI5F4sMb1cGeep/PPEE9vvRNELJYpxWS0ImS4gQmovKUDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.1",
+        "@livekit/protocol": "^1.48.0",
+        "jose": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/lodash": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "^5.2.1",
     "file-type": "^22.0.1",
     "irc-framework": "^4.13.1",
+    "livekit-server-sdk": "^2.17.0",
     "multer": "^2.2.0",
     "selfsigned": "^5.5.0",
     "sharp": "^0.35.3",

--- a/server/app.ts
+++ b/server/app.ts
@@ -29,7 +29,7 @@ import dccRouter from './routes/dcc.js';
 import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
-import voiceRouter from './routes/voice.js';
+import voiceRouter, { voicePublicRouter } from './routes/voice.js';
 import configRouter from './routes/config.js';
 import nodeRouter from './routes/node.js';
 import mcpRouter from './services/mcpServer.js';
@@ -76,6 +76,10 @@ export function buildApp(sessionSecret: string): Express {
   app.use('/api/highlights', highlightsRouter);
   app.use('/api/bookmarks', bookmarksRouter);
   app.use('/api/push', pushRouter);
+  // Public voice sub-routes (LiveKit webhook + guest join token) FIRST — they
+  // authenticate by capability (webhook signature / guest-link token), not the
+  // session cookie, so they must be matched before the requireAuth'd router.
+  app.use('/api/voice', voicePublicRouter);
   app.use('/api/voice', voiceRouter);
   app.use('/api/admin', adminRouter);
   app.use('/api/uploads', uploadsRouter);

--- a/server/app.ts
+++ b/server/app.ts
@@ -29,6 +29,7 @@ import dccRouter from './routes/dcc.js';
 import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
+import voiceRouter from './routes/voice.js';
 import configRouter from './routes/config.js';
 import nodeRouter from './routes/node.js';
 import mcpRouter from './services/mcpServer.js';
@@ -75,6 +76,7 @@ export function buildApp(sessionSecret: string): Express {
   app.use('/api/highlights', highlightsRouter);
   app.use('/api/bookmarks', bookmarksRouter);
   app.use('/api/push', pushRouter);
+  app.use('/api/voice', voiceRouter);
   app.use('/api/admin', adminRouter);
   app.use('/api/uploads', uploadsRouter);
   app.use('/api/uploaders', uploadersRouter);

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -503,6 +503,17 @@ export const EXPORT_TABLES = Object.freeze({
       'bearer-token credentials bound to this instance; user re-issues tokens on the target instance',
   },
 
+  voice_channel_policy: {
+    mode: 'skip',
+    reason: 'per-channel voice-call join policy — instance/channel-scoped config, not user data',
+  },
+
+  voice_guest_link: {
+    mode: 'skip',
+    reason:
+      'public guest-call capability links — instance-scoped, expiring credentials, not user data',
+  },
+
   peer_presence_state: {
     mode: 'skip',
     reason: 'transient cache; rebuilt by IRC events on next connect',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -586,6 +586,37 @@ function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
 
+    -- Per-channel voice-call join policy (voice / #680). Keyed by IRC network
+    -- host + folded channel so it is shared across all users of the channel on
+    -- this instance (the same scoping as the LiveKit room name). min_join_mode
+    -- is the lowest IRC prefix mode allowed to join a call: 'none' (anyone),
+    -- 'voice', 'halfop', or 'op'. Set by a channel op.
+    CREATE TABLE IF NOT EXISTS voice_channel_policy (
+      network_host TEXT NOT NULL,
+      channel_folded TEXT NOT NULL,
+      min_join_mode TEXT NOT NULL DEFAULT 'none',
+      updated_by TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (network_host, channel_folded)
+    );
+
+    -- Public guest call links (voice / #680). A capability token that lets
+    -- someone without an account join exactly one LiveKit room. Opaque token,
+    -- 24h expiry, soft-revocable via revoked_at. can_publish gates talk vs
+    -- listen-only. Not tied to a user row — it outlives the op who minted it.
+    CREATE TABLE IF NOT EXISTS voice_guest_link (
+      token TEXT PRIMARY KEY,
+      network_host TEXT NOT NULL,
+      channel_folded TEXT NOT NULL,
+      room TEXT NOT NULL,
+      can_publish INTEGER NOT NULL DEFAULT 1,
+      created_by TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      expires_at TEXT NOT NULL,
+      revoked_at TEXT,
+      use_count INTEGER NOT NULL DEFAULT 0
+    );
+
     -- Per-user data-export jobs. A request to export account data spawns a
     -- background worker (separate readonly SQLite connection) that builds the
     -- .lurk archive to disk under data/exports/<token>.lurk; the row tracks

--- a/server/db/voiceLinks.test.ts
+++ b/server/db/voiceLinks.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-voicelinks-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let vl: typeof import('./voiceLinks.js');
+
+const base = {
+  networkHost: 'irc.libera.chat',
+  channelFolded: '#dev',
+  room: 'net-irc.libera.chat-c-#dev',
+  canPublish: true,
+  createdBy: 'jawsh',
+};
+
+beforeAll(async () => {
+  vl = await import('./voiceLinks.js');
+});
+
+describe('voiceLinks', () => {
+  it('creates a usable link with an opaque token and ~24h expiry', () => {
+    const link = vl.createGuestLink(base);
+    expect(link.token.length).toBeGreaterThan(30);
+    expect(link.canPublish).toBe(true);
+    expect(link.room).toBe(base.room);
+    expect(vl.getUsableGuestLink(link.token)?.token).toBe(link.token);
+    const ttl = Date.parse(link.expiresAt) - Date.now();
+    expect(ttl).toBeGreaterThan(vl.GUEST_LINK_TTL_MS - 60_000);
+    expect(ttl).toBeLessThanOrEqual(vl.GUEST_LINK_TTL_MS + 1_000);
+  });
+
+  it('carries a listen-only (canPublish:false) flag', () => {
+    const link = vl.createGuestLink({ ...base, canPublish: false });
+    expect(vl.getGuestLink(link.token)?.canPublish).toBe(false);
+  });
+
+  it('revoking makes it unusable but still fetchable', () => {
+    const link = vl.createGuestLink(base);
+    expect(vl.revokeGuestLink(link.token)).toBe(true);
+    expect(vl.getUsableGuestLink(link.token)).toBeNull();
+    expect(vl.getGuestLink(link.token)?.revokedAt).toBeTruthy();
+  });
+
+  it('lists only active links for a host+channel', () => {
+    const a = vl.createGuestLink({ ...base, channelFolded: '#list' });
+    const b = vl.createGuestLink({ ...base, channelFolded: '#list' });
+    vl.revokeGuestLink(b.token);
+    const active = vl.listActiveGuestLinks('irc.libera.chat', '#list').map((l) => l.token);
+    expect(active).toContain(a.token);
+    expect(active).not.toContain(b.token);
+  });
+
+  it('bumps the use count', () => {
+    const link = vl.createGuestLink(base);
+    vl.bumpGuestLinkUse(link.token);
+    vl.bumpGuestLinkUse(link.token);
+    expect(vl.getGuestLink(link.token)?.useCount).toBe(2);
+  });
+
+  it('returns null for an unknown token', () => {
+    expect(vl.getUsableGuestLink('does-not-exist')).toBeNull();
+    expect(vl.getGuestLink('does-not-exist')).toBeNull();
+  });
+});

--- a/server/db/voiceLinks.ts
+++ b/server/db/voiceLinks.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import crypto from 'crypto';
+import db from './index.js';
+
+// Public guest call links — capability tokens that let an account-less guest
+// join exactly one LiveKit room. The token is opaque and unguessable, the link
+// expires after GUEST_LINK_TTL_MS, and it is soft-revocable via revoked_at. Not
+// tied to a user row: it outlives the op who minted it (revoke to kill access).
+
+export interface GuestLink {
+  token: string;
+  networkHost: string;
+  channelFolded: string;
+  room: string;
+  canPublish: boolean;
+  createdBy: string | null;
+  createdAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  useCount: number;
+}
+
+interface RawGuestLink {
+  token: string;
+  networkHost: string;
+  channelFolded: string;
+  room: string;
+  canPublish: number;
+  createdBy: string | null;
+  createdAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  useCount: number;
+}
+
+export const GUEST_LINK_TTL_MS = 24 * 60 * 60 * 1000;
+
+const COLS = `
+  token, network_host AS networkHost, channel_folded AS channelFolded, room,
+  can_publish AS canPublish, created_by AS createdBy, created_at AS createdAt,
+  expires_at AS expiresAt, revoked_at AS revokedAt, use_count AS useCount
+`;
+
+const insertStmt = db.prepare(`
+  INSERT INTO voice_guest_link
+    (token, network_host, channel_folded, room, can_publish, created_by, expires_at)
+  VALUES (@token, @host, @channel, @room, @canPublish, @by, @expiresAt)
+`);
+const getStmt = db.prepare(`SELECT ${COLS} FROM voice_guest_link WHERE token = ?`);
+const listActiveStmt = db.prepare(`
+  SELECT ${COLS} FROM voice_guest_link
+  WHERE network_host = ? AND channel_folded = ?
+    AND revoked_at IS NULL AND expires_at > datetime('now')
+  ORDER BY created_at DESC
+`);
+const revokeStmt = db.prepare(`
+  UPDATE voice_guest_link SET revoked_at = datetime('now')
+  WHERE token = ? AND revoked_at IS NULL
+`);
+const bumpStmt = db.prepare(
+  `UPDATE voice_guest_link SET use_count = use_count + 1 WHERE token = ?`,
+);
+
+function toGuestLink(row: RawGuestLink): GuestLink {
+  return { ...row, canPublish: !!row.canPublish };
+}
+
+export function createGuestLink(args: {
+  networkHost: string;
+  channelFolded: string;
+  room: string;
+  canPublish: boolean;
+  createdBy: string;
+}): GuestLink {
+  const token = crypto.randomBytes(32).toString('base64url');
+  const expiresAt = new Date(Date.now() + GUEST_LINK_TTL_MS).toISOString();
+  insertStmt.run({
+    token,
+    host: args.networkHost,
+    channel: args.channelFolded,
+    room: args.room,
+    canPublish: args.canPublish ? 1 : 0,
+    by: args.createdBy,
+    expiresAt,
+  });
+  return getGuestLink(token) as GuestLink;
+}
+
+export function getGuestLink(token: string): GuestLink | null {
+  const row = getStmt.get(token) as RawGuestLink | undefined;
+  return row ? toGuestLink(row) : null;
+}
+
+/** The link only if it exists, is not revoked, and has not expired; else null.
+ *  This is the gate the public guest-token endpoint uses. */
+export function getUsableGuestLink(token: string): GuestLink | null {
+  const link = getGuestLink(token);
+  if (!link || link.revokedAt || Date.parse(link.expiresAt) <= Date.now()) return null;
+  return link;
+}
+
+export function listActiveGuestLinks(host: string, channelFolded: string): GuestLink[] {
+  return (listActiveStmt.all(host, channelFolded) as RawGuestLink[]).map(toGuestLink);
+}
+
+export function revokeGuestLink(token: string): boolean {
+  return revokeStmt.run(token).changes > 0;
+}
+
+export function bumpGuestLinkUse(token: string): void {
+  bumpStmt.run(token);
+}

--- a/server/db/voicePolicy.test.ts
+++ b/server/db/voicePolicy.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-voicepolicy-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let vp: typeof import('./voicePolicy.js');
+
+beforeAll(async () => {
+  vp = await import('./voicePolicy.js');
+});
+
+describe('voicePolicy', () => {
+  it("defaults to 'none' (anyone) when unset", () => {
+    expect(vp.getPolicy('irc.libera.chat', '#unset')).toBe('none');
+  });
+
+  it('upserts and reads back, last write wins', () => {
+    vp.setPolicy('irc.libera.chat', '#dev', 'op', 'jawsh');
+    expect(vp.getPolicy('irc.libera.chat', '#dev')).toBe('op');
+    vp.setPolicy('irc.libera.chat', '#dev', 'voice', 'jawsh');
+    expect(vp.getPolicy('irc.libera.chat', '#dev')).toBe('voice');
+  });
+
+  it('normalizes unknown modes to none', () => {
+    expect(vp.normalizeMinJoinMode('bogus')).toBe('none');
+    expect(vp.normalizeMinJoinMode(undefined)).toBe('none');
+    expect(vp.normalizeMinJoinMode('halfop')).toBe('halfop');
+  });
+
+  it('scopes by host + channel', () => {
+    vp.setPolicy('irc.libera.chat', '#scoped', 'op', 'j');
+    expect(vp.getPolicy('irc.rizon.net', '#scoped')).toBe('none');
+    expect(vp.getPolicy('irc.libera.chat', '#other')).toBe('none');
+  });
+});

--- a/server/db/voicePolicy.ts
+++ b/server/db/voicePolicy.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import db from './index.js';
+
+// Per-channel voice-call join policy. Keyed by IRC network host + folded
+// channel (the same scoping as roomFor() in services/voice.ts), so the policy
+// is shared across every user of that channel on this instance. min_join_mode
+// is the lowest IRC prefix mode allowed to join a call.
+
+export type MinJoinMode = 'none' | 'voice' | 'halfop' | 'op';
+
+const VALID_MODES: ReadonlySet<string> = new Set(['none', 'voice', 'halfop', 'op']);
+
+/** Normalize an untrusted string to a valid MinJoinMode ('none' fallback). */
+export function normalizeMinJoinMode(raw: unknown): MinJoinMode {
+  return typeof raw === 'string' && VALID_MODES.has(raw) ? (raw as MinJoinMode) : 'none';
+}
+
+const getStmt = db.prepare(`
+  SELECT min_join_mode AS minJoinMode
+  FROM voice_channel_policy
+  WHERE network_host = ? AND channel_folded = ?
+`);
+
+const upsertStmt = db.prepare(`
+  INSERT INTO voice_channel_policy
+    (network_host, channel_folded, min_join_mode, updated_by, updated_at)
+  VALUES (@host, @channel, @mode, @by, datetime('now'))
+  ON CONFLICT(network_host, channel_folded) DO UPDATE SET
+    min_join_mode = excluded.min_join_mode,
+    updated_by = excluded.updated_by,
+    updated_at = excluded.updated_at
+`);
+
+/** The min join mode for a channel, or 'none' (anyone) when unset. `host` and
+ *  `channelFolded` must already be folded (ASCII-lowercased) to match the room key. */
+export function getPolicy(host: string, channelFolded: string): MinJoinMode {
+  const row = getStmt.get(host, channelFolded) as { minJoinMode: string } | undefined;
+  return normalizeMinJoinMode(row?.minJoinMode);
+}
+
+/** Upsert the min join mode for a channel. Returns the stored (normalized) value. */
+export function setPolicy(
+  host: string,
+  channelFolded: string,
+  mode: MinJoinMode,
+  byNick: string,
+): MinJoinMode {
+  const m = normalizeMinJoinMode(mode);
+  upsertStmt.run({ host, channel: channelFolded, mode: m, by: byNick });
+  return m;
+}

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -5,6 +5,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { getEdition } from '../utils/edition.js';
 import { PROTOCOL_VERSION, MIN_PROTOCOL_VERSION } from '../protocol.js';
+import { voiceEnabled } from '../services/voice.js';
 
 const router = Router();
 
@@ -22,6 +23,9 @@ router.get('/', (_req: Request, res: Response) => {
     edition: getEdition(),
     protocolVersion: PROTOCOL_VERSION,
     minProtocolVersion: MIN_PROTOCOL_VERSION,
+    // Whether this instance offers voice/video calls (operator opt-in + a
+    // configured LiveKit SFU). The native client hides all call UI when false.
+    voiceEnabled: voiceEnabled(),
   });
 });
 

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -46,7 +46,9 @@ afterAll(() => ctx.cleanup());
 describe('POST /api/voice/token', () => {
   it('401 when unauthenticated', async () => {
     enableVoice();
-    const res = await testRequest(app).post('/api/voice/token').send({ networkId: 1, target: '#dev' });
+    const res = await testRequest(app)
+      .post('/api/voice/token')
+      .send({ networkId: 1, target: '#dev' });
     expect(res.status).toBe(401);
   });
 
@@ -74,6 +76,33 @@ describe('POST /api/voice/token', () => {
     // networkId 999999 belongs to nobody, so getNetwork(id, user) is undefined —
     // the request is refused before any room token can be minted.
     const res = await agent.post('/api/voice/token').send({ networkId: 999999, target: '#dev' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/voice/presence', () => {
+  it('401 when unauthenticated', async () => {
+    enableVoice();
+    const res = await testRequest(app).get('/api/voice/presence?networkId=1');
+    expect(res.status).toBe(401);
+  });
+
+  it('503 when voice is not enabled on the server', async () => {
+    delete process.env.LURKER_VOICE_ENABLED;
+    delete process.env.LIVEKIT_WS_URL;
+    const res = await agent.get('/api/voice/presence?networkId=1');
+    expect(res.status).toBe(503);
+  });
+
+  it('400 for a missing/invalid networkId', async () => {
+    enableVoice();
+    const res = await agent.get('/api/voice/presence');
+    expect(res.status).toBe(400);
+  });
+
+  it('404 for a network the caller does not own (ownership gate)', async () => {
+    enableVoice();
+    const res = await agent.get('/api/voice/presence?networkId=999999');
     expect(res.status).toBe(404);
   });
 });

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import type { Express } from 'express';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  testRequest,
+} from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+
+const ctx = setupTestDb('routes-voice');
+
+let app: Express;
+let agent: LurkerTestAgent;
+let user: User;
+
+// Turn voice on by populating the env the service reads. Individual tests toggle
+// pieces of this to exercise the gates.
+function enableVoice() {
+  process.env.LURKER_VOICE_ENABLED = 'true';
+  process.env.LIVEKIT_WS_URL = 'ws://sfu.test:7880';
+  process.env.LIVEKIT_API_KEY = 'devkey';
+  process.env.LIVEKIT_API_SECRET = 'devsecret-long-enough';
+}
+
+const savedEnv = { ...process.env };
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const router = (await import('./voice.js')).default;
+  user = createUser('voice-routes-alice');
+  app = createTestApp({ '/api/voice': router });
+  agent = await createAuthedAgent(app, user.id);
+});
+
+afterEach(() => {
+  process.env = { ...savedEnv };
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('POST /api/voice/token', () => {
+  it('401 when unauthenticated', async () => {
+    enableVoice();
+    const res = await testRequest(app).post('/api/voice/token').send({ networkId: 1, target: '#dev' });
+    expect(res.status).toBe(401);
+  });
+
+  it('503 when voice is not enabled on the server', async () => {
+    delete process.env.LURKER_VOICE_ENABLED;
+    delete process.env.LIVEKIT_WS_URL;
+    const res = await agent.post('/api/voice/token').send({ networkId: 1, target: '#dev' });
+    expect(res.status).toBe(503);
+  });
+
+  it('400 for a missing/invalid networkId', async () => {
+    enableVoice();
+    const res = await agent.post('/api/voice/token').send({ target: '#dev' });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 for a missing target', async () => {
+    enableVoice();
+    const res = await agent.post('/api/voice/token').send({ networkId: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  it('404 for a network the caller does not own (ownership gate)', async () => {
+    enableVoice();
+    // networkId 999999 belongs to nobody, so getNetwork(id, user) is undefined —
+    // the request is refused before any room token can be minted.
+    const res = await agent.post('/api/voice/token').send({ networkId: 999999, target: '#dev' });
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -358,7 +358,10 @@ function broadcastCallPresence(change: CallPresenceChange): void {
     if (foldKey(conn.network.host) !== change.host) continue;
     if (!conn.channels.has(change.channel)) continue;
     fanOutToUser(conn.network.user_id, {
-      type: 'call-presence',
+      // Top-level frame kind — the client dispatches on `kind` in handleMessage.
+      // (A bare `type:` never reached the handler: only kind:'irc' frames are
+      // unwrapped to the type-switch, so the badge only ever updated on refresh.)
+      kind: 'call-presence',
       networkId: conn.network.id,
       target: change.channel,
       active: change.active,

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -1,79 +1,342 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { Router } from 'express';
+import express, { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { getNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
 import ircManager from '../services/ircManager.js';
+import type { IrcConnection } from '../services/ircConnection.js';
+import { fanOutToUser } from '../services/wsHub.js';
 import {
   isChannelTarget,
   mintVoiceToken,
   roomFor,
   voiceEnabled,
+  meetsJoinMode,
+  canModerateCall,
+  canAdminCall,
+  guestIdentity,
+  removeFromCall,
+  muteParticipant,
+  rememberRoom,
+  receiveWebhook,
+  applyWebhookEvent,
+  foldKey,
+  type CallPresenceChange,
 } from '../services/voice.js';
+import { getPolicy, setPolicy, normalizeMinJoinMode } from '../db/voicePolicy.js';
+import {
+  createGuestLink,
+  listActiveGuestLinks,
+  revokeGuestLink,
+  getGuestLink,
+  getUsableGuestLink,
+  bumpGuestLinkUse,
+} from '../db/voiceLinks.js';
 
-// The write path for voice: mint a LiveKit access token scoped to one call room.
-// Lurker is the token authority only — it never carries media. Authenticated by
-// requireAuth (browser cookie OR native bearer), then gated three ways:
-//   1. voiceEnabled() — operator opt-in + a configured SFU, else 503.
-//   2. getNetwork(id, user) — you can only call on a network you own, else 404.
-//   3. for a channel target, you must actually be *in* the channel — else 403.
-//      (A DM has no such check: opening a call IS the invitation.)
-// The room name is derived server-side from (networkId, target, your live nick),
-// so a client cannot ask for a token to an arbitrary room.
+// Voice write/control surface. Lurker is the token authority + call moderator;
+// it never carries media. Two routers:
+//   - the authed router (requireAuth): mint token, moderate, policy, guest-link
+//   - the public router (no cookie): LiveKit webhook + guest join token, each
+//     verified by its own capability (webhook signature / guest-link token)
+
+/** A caller's IRC prefix modes in a channel (e.g. ['o','v']), or [] if absent. */
+function memberModes(conn: IrcConnection, channel: string, nick: string): string[] {
+  return conn.channels.get(channel.toLowerCase())?.members.get(nick.toLowerCase())?.modes ?? [];
+}
+
+interface CallCtx {
+  network: Network;
+  conn: IrcConnection;
+  nick: string;
+}
+
+/** Resolve + gate the common preconditions (voice on, network owned, live
+ *  connection). Sends the error response and returns null on any failure. */
+function resolveCall(req: Request, res: Response, networkId: number): CallCtx | null {
+  if (!voiceEnabled()) {
+    res.status(503).json({ error: 'voice not enabled on this server' });
+    return null;
+  }
+  if (!Number.isInteger(networkId) || networkId <= 0) {
+    res.status(400).json({ error: 'networkId required' });
+    return null;
+  }
+  const network = getNetwork(networkId, req.user!.id);
+  if (!network) {
+    res.status(404).json({ error: 'network not found' });
+    return null;
+  }
+  const conn = ircManager.getConnection(req.user!.id, networkId);
+  if (!conn || !conn.currentNick) {
+    res.status(409).json({ error: 'network not connected' });
+    return null;
+  }
+  return { network, conn, nick: conn.currentNick };
+}
 
 const router = Router();
 router.use(requireAuth);
 
+// ─── Join: mint a room-scoped token, gated by membership + channel policy ───
 router.post('/token', async (req: Request, res: Response) => {
-  if (!voiceEnabled()) {
-    res.status(503).json({ error: 'voice not enabled on this server' });
-    return;
-  }
-
   const networkId = Number(req.body?.networkId);
   const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
-  if (!Number.isInteger(networkId) || networkId <= 0) {
-    res.status(400).json({ error: 'networkId required' });
-    return;
-  }
   if (!target) {
     res.status(400).json({ error: 'target required' });
     return;
   }
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  const { network, conn, nick } = ctx;
 
-  // Ownership: getNetwork returns undefined for a network this user doesn't own.
-  const network = getNetwork(networkId, req.user!.id);
-  if (!network) {
-    res.status(404).json({ error: 'network not found' });
-    return;
+  if (isChannelTarget(target)) {
+    if (!conn.channels.has(target.toLowerCase())) {
+      res.status(403).json({ error: 'not a member of that channel' });
+      return;
+    }
+    // Per-channel join gating: caller must meet the channel's min join mode.
+    const min = getPolicy(foldKey(network.host), foldKey(target));
+    if (!meetsJoinMode(memberModes(conn, target, nick), min)) {
+      res
+        .status(403)
+        .json({ error: `this call is restricted to ${min}+ — you don't have that mode` });
+      return;
+    }
   }
 
-  // We need the live connection for the caller's current nick (the call
-  // identity) and, for a channel, to confirm membership. No connection → the
-  // network is disconnected, so there is nobody to call with.
-  const conn = ircManager.getConnection(req.user!.id, networkId);
-  if (!conn || !conn.currentNick) {
-    res.status(409).json({ error: 'network not connected' });
-    return;
-  }
-
-  if (isChannelTarget(target) && !conn.channels.has(target.toLowerCase())) {
-    res.status(403).json({ error: 'not a member of that channel' });
-    return;
-  }
-
-  // Key the room on the network HOST, not the per-user networkId, so every user
-  // (this instance or another sharing the SFU) on the same IRC network + channel
-  // lands in the same room. See services/voice.ts roomFor().
-  const room = roomFor(network.host, target, conn.currentNick);
+  const room = roomFor(network.host, target, nick);
+  rememberRoom(room, network.host, isChannelTarget(target) ? target : room);
   try {
-    const minted = await mintVoiceToken({ identity: conn.currentNick, room });
+    const minted = await mintVoiceToken({ identity: nick, room });
     res.json(minted); // { token, room, url }
   } catch {
     res.status(500).json({ error: 'failed to mint token' });
   }
 });
+
+// ─── Moderate: op-only mute / remove another participant ───────────────────
+router.post('/moderate', async (req: Request, res: Response) => {
+  const networkId = Number(req.body?.networkId);
+  const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  const action = req.body?.action;
+  const identity = typeof req.body?.identity === 'string' ? req.body.identity : '';
+  if (!target || !identity || (action !== 'mute' && action !== 'remove')) {
+    res.status(400).json({ error: 'target, identity, action (mute|remove) required' });
+    return;
+  }
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  const { network, conn, nick } = ctx;
+  if (!isChannelTarget(target) || !canModerateCall(memberModes(conn, target, nick))) {
+    res.status(403).json({ error: 'you must be a channel operator to moderate this call' });
+    return;
+  }
+  const room = roomFor(network.host, target, nick);
+  try {
+    if (action === 'remove') await removeFromCall(room, identity);
+    else await muteParticipant(room, identity);
+    res.json({ ok: true });
+  } catch {
+    res.status(500).json({ error: 'moderation action failed' });
+  }
+});
+
+// ─── Join policy: read (any member) / set (ops only) ───────────────────────
+router.get('/policy', (req: Request, res: Response) => {
+  const networkId = Number(req.query?.networkId);
+  const target = typeof req.query?.target === 'string' ? req.query.target.trim() : '';
+  if (!target) {
+    res.status(400).json({ error: 'target required' });
+    return;
+  }
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  res.json({ minJoinMode: getPolicy(foldKey(ctx.network.host), foldKey(target)) });
+});
+
+router.put('/policy', (req: Request, res: Response) => {
+  const networkId = Number(req.body?.networkId);
+  const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  const minJoinMode = normalizeMinJoinMode(req.body?.minJoinMode);
+  if (!target || !isChannelTarget(target)) {
+    res.status(400).json({ error: 'channel target required' });
+    return;
+  }
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  const { network, conn, nick } = ctx;
+  if (!canAdminCall(memberModes(conn, target, nick))) {
+    res.status(403).json({ error: 'you must be a channel operator to set the call policy' });
+    return;
+  }
+  setPolicy(foldKey(network.host), foldKey(target), minJoinMode, nick);
+  res.json({ minJoinMode });
+});
+
+// ─── Guest links: op mints / lists / revokes a public capability URL ───────
+router.post('/guest-link', (req: Request, res: Response) => {
+  const networkId = Number(req.body?.networkId);
+  const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  const canPublish = req.body?.canPublish !== false; // default talk
+  if (!target || !isChannelTarget(target)) {
+    res.status(400).json({ error: 'channel target required' });
+    return;
+  }
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  const { network, conn, nick } = ctx;
+  if (!canAdminCall(memberModes(conn, target, nick))) {
+    res.status(403).json({ error: 'you must be a channel operator to create a guest link' });
+    return;
+  }
+  const room = roomFor(network.host, target, nick);
+  rememberRoom(room, network.host, target);
+  const link = createGuestLink({
+    networkHost: foldKey(network.host),
+    channelFolded: foldKey(target),
+    room,
+    canPublish,
+    createdBy: nick,
+  });
+  res.json({
+    url: `https://${req.get('host')}/call/${link.token}`,
+    token: link.token,
+    canPublish: link.canPublish,
+    expiresAt: link.expiresAt,
+  });
+});
+
+router.get('/guest-link', (req: Request, res: Response) => {
+  const networkId = Number(req.query?.networkId);
+  const target = typeof req.query?.target === 'string' ? req.query.target.trim() : '';
+  if (!target || !isChannelTarget(target)) {
+    res.status(400).json({ error: 'channel target required' });
+    return;
+  }
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  const { network, conn, nick } = ctx;
+  if (!canAdminCall(memberModes(conn, target, nick))) {
+    res.status(403).json({ error: 'operators only' });
+    return;
+  }
+  const host = req.get('host');
+  const links = listActiveGuestLinks(foldKey(network.host), foldKey(target)).map((l) => ({
+    token: l.token,
+    url: `https://${host}/call/${l.token}`,
+    canPublish: l.canPublish,
+    createdBy: l.createdBy,
+    createdAt: l.createdAt,
+    expiresAt: l.expiresAt,
+    useCount: l.useCount,
+  }));
+  res.json({ links });
+});
+
+router.delete('/guest-link/:token', (req: Request, res: Response) => {
+  if (!voiceEnabled()) {
+    res.status(503).json({ error: 'voice not enabled on this server' });
+    return;
+  }
+  const token = typeof req.params.token === 'string' ? req.params.token : '';
+  const link = getGuestLink(token);
+  if (!link) {
+    res.status(404).json({ error: 'link not found' });
+    return;
+  }
+  // Authorize: caller must be an op of the link's channel on the matching host.
+  const conn = ircManager
+    .listConnections(req.user!.id)
+    .find((c) => !!c.currentNick && foldKey(c.network.host) === link.networkHost);
+  if (!conn || !canAdminCall(memberModes(conn, link.channelFolded, conn.currentNick!))) {
+    res.status(403).json({ error: 'operators only' });
+    return;
+  }
+  revokeGuestLink(token);
+  res.json({ ok: true });
+});
+
+// ─── Public router (no cookie auth) — webhook + guest join token ────────────
+export const voicePublicRouter = Router();
+
+// LiveKit posts room/participant events here (content-type application/webhook+json,
+// so the global express.json parser skips it). Verified by signature, then fed to
+// the presence registry; fan out the change to other local users in the channel.
+voicePublicRouter.post(
+  '/webhook',
+  express.text({ type: '*/*', limit: '512kb' }),
+  async (req: Request, res: Response) => {
+    const body = typeof req.body === 'string' ? req.body : '';
+    const ev = await receiveWebhook(body, req.get('Authorization'));
+    if (!ev) {
+      res.status(401).end();
+      return;
+    }
+    const change = applyWebhookEvent(ev);
+    if (change) broadcastCallPresence(change);
+    res.status(200).end();
+  },
+);
+
+// Guest join: exchange a guest-link token + display name for a room-scoped
+// LiveKit token. Public + rate-limited; the capability is the opaque link token.
+const guestHits = new Map<string, number[]>(); // ip → recent request timestamps
+function guestRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const win = (guestHits.get(ip) ?? []).filter((t) => now - t < 60_000);
+  win.push(now);
+  guestHits.set(ip, win);
+  return win.length > 10; // >10 guest-token requests/min per IP
+}
+
+voicePublicRouter.post('/guest-token', async (req: Request, res: Response) => {
+  if (!voiceEnabled()) {
+    res.status(503).json({ error: 'voice not enabled' });
+    return;
+  }
+  if (guestRateLimited(req.ip ?? 'unknown')) {
+    res.status(429).json({ error: 'too many requests' });
+    return;
+  }
+  const token = typeof req.body?.token === 'string' ? req.body.token : '';
+  const name = typeof req.body?.name === 'string' ? req.body.name : '';
+  const link = getUsableGuestLink(token);
+  if (!link) {
+    res.status(404).json({ error: 'this guest link is invalid, expired, or revoked' });
+    return;
+  }
+  rememberRoom(link.room, link.networkHost, link.channelFolded);
+  try {
+    const minted = await mintVoiceToken({
+      identity: guestIdentity(name || 'guest'),
+      room: link.room,
+      canPublish: link.canPublish,
+      ttlSeconds: 4 * 60 * 60,
+    });
+    bumpGuestLinkUse(token);
+    res.json({ token: minted.token, url: minted.url, canPublish: link.canPublish });
+  } catch {
+    res.status(500).json({ error: 'failed to mint token' });
+  }
+});
+
+/** Notify every other local account currently in this channel (any of their
+ *  tabs) that a call's participant count changed, so they can show/hide a badge. */
+function broadcastCallPresence(change: CallPresenceChange): void {
+  for (const conn of ircManager.listAllConnections()) {
+    if (foldKey(conn.network.host) !== change.host) continue;
+    if (!conn.channels.has(change.channel)) continue;
+    fanOutToUser(conn.network.user_id, {
+      type: 'call-presence',
+      networkId: conn.network.id,
+      target: change.channel,
+      active: change.active,
+      count: change.count,
+    });
+  }
+}
 
 export default router;

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { getNetwork } from '../db/networks.js';
+import ircManager from '../services/ircManager.js';
+import {
+  isChannelTarget,
+  mintVoiceToken,
+  roomFor,
+  voiceEnabled,
+} from '../services/voice.js';
+
+// The write path for voice: mint a LiveKit access token scoped to one call room.
+// Lurker is the token authority only — it never carries media. Authenticated by
+// requireAuth (browser cookie OR native bearer), then gated three ways:
+//   1. voiceEnabled() — operator opt-in + a configured SFU, else 503.
+//   2. getNetwork(id, user) — you can only call on a network you own, else 404.
+//   3. for a channel target, you must actually be *in* the channel — else 403.
+//      (A DM has no such check: opening a call IS the invitation.)
+// The room name is derived server-side from (networkId, target, your live nick),
+// so a client cannot ask for a token to an arbitrary room.
+
+const router = Router();
+router.use(requireAuth);
+
+router.post('/token', async (req: Request, res: Response) => {
+  if (!voiceEnabled()) {
+    res.status(503).json({ error: 'voice not enabled on this server' });
+    return;
+  }
+
+  const networkId = Number(req.body?.networkId);
+  const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  if (!Number.isInteger(networkId) || networkId <= 0) {
+    res.status(400).json({ error: 'networkId required' });
+    return;
+  }
+  if (!target) {
+    res.status(400).json({ error: 'target required' });
+    return;
+  }
+
+  // Ownership: getNetwork returns undefined for a network this user doesn't own.
+  const network = getNetwork(networkId, req.user!.id);
+  if (!network) {
+    res.status(404).json({ error: 'network not found' });
+    return;
+  }
+
+  // We need the live connection for the caller's current nick (the call
+  // identity) and, for a channel, to confirm membership. No connection → the
+  // network is disconnected, so there is nobody to call with.
+  const conn = ircManager.getConnection(req.user!.id, networkId);
+  if (!conn || !conn.currentNick) {
+    res.status(409).json({ error: 'network not connected' });
+    return;
+  }
+
+  if (isChannelTarget(target) && !conn.channels.has(target.toLowerCase())) {
+    res.status(403).json({ error: 'not a member of that channel' });
+    return;
+  }
+
+  const room = roomFor(networkId, target, conn.currentNick);
+  try {
+    const minted = await mintVoiceToken({ identity: conn.currentNick, room });
+    res.json(minted); // { token, room, url }
+  } catch {
+    res.status(500).json({ error: 'failed to mint token' });
+  }
+});
+
+export default router;

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -64,7 +64,10 @@ router.post('/token', async (req: Request, res: Response) => {
     return;
   }
 
-  const room = roomFor(networkId, target, conn.currentNick);
+  // Key the room on the network HOST, not the per-user networkId, so every user
+  // (this instance or another sharing the SFU) on the same IRC network + channel
+  // lands in the same room. See services/voice.ts roomFor().
+  const room = roomFor(network.host, target, conn.currentNick);
   try {
     const minted = await mintVoiceToken({ identity: conn.currentNick, room });
     res.json(minted); // { token, room, url }

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -23,6 +23,7 @@ import {
   rememberRoom,
   receiveWebhook,
   applyWebhookEvent,
+  listActiveCalls,
   foldKey,
   type CallPresenceChange,
 } from '../services/voice.js';
@@ -100,9 +101,9 @@ router.post('/token', async (req: Request, res: Response) => {
     // Per-channel join gating: caller must meet the channel's min join mode.
     const min = getPolicy(foldKey(network.host), foldKey(target));
     if (!meetsJoinMode(memberModes(conn, target, nick), min)) {
-      res
-        .status(403)
-        .json({ error: `this call is restricted to ${min}+ — you don't have that mode` });
+      res.status(403).json({
+        error: `this call is restricted to ${min}+ — you don't have that mode`,
+      });
       return;
     }
   }
@@ -114,6 +115,27 @@ router.post('/token', async (req: Request, res: Response) => {
     res.json(minted); // { token, room, url }
   } catch {
     res.status(500).json({ error: 'failed to mint token' });
+  }
+});
+
+// ─── Presence snapshot: current calls in the caller's channels ─────────────
+// The webhook stream only pushes live join/leave deltas, so a client that
+// connects (or reconnects) mid-call would never learn about a call already in
+// progress. This hydrates that gap from the SFU (source of truth → correct
+// across a Lurker restart too). Filtered to channels the caller is actually in.
+router.get('/presence', async (req: Request, res: Response) => {
+  const networkId = Number(req.query?.networkId);
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  const host = foldKey(ctx.network.host);
+  try {
+    const calls = await listActiveCalls();
+    const out = calls
+      .filter((c) => c.host === host && c.count > 0 && ctx.conn.channels.has(c.channel))
+      .map((c) => ({ target: c.channel, count: c.count }));
+    res.json({ calls: out });
+  } catch {
+    res.status(502).json({ error: 'could not list active calls' });
   }
 });
 
@@ -154,7 +176,9 @@ router.get('/policy', (req: Request, res: Response) => {
   }
   const ctx = resolveCall(req, res, networkId);
   if (!ctx) return;
-  res.json({ minJoinMode: getPolicy(foldKey(ctx.network.host), foldKey(target)) });
+  res.json({
+    minJoinMode: getPolicy(foldKey(ctx.network.host), foldKey(target)),
+  });
 });
 
 router.put('/policy', (req: Request, res: Response) => {
@@ -317,7 +341,11 @@ voicePublicRouter.post('/guest-token', async (req: Request, res: Response) => {
       ttlSeconds: 4 * 60 * 60,
     });
     bumpGuestLinkUse(token);
-    res.json({ token: minted.token, url: minted.url, canPublish: link.canPublish });
+    res.json({
+      token: minted.token,
+      url: minted.url,
+      canPublish: link.canPublish,
+    });
   } catch {
     res.status(500).json({ error: 'failed to mint token' });
   }

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -165,6 +165,15 @@ class IrcManager extends EventEmitter {
     return Array.from(this.connectionsForUser(userId).values());
   }
 
+  /** Every live connection across ALL users — for cross-user broadcasts (e.g.
+   *  call-presence: a call by one account must notify other accounts in the
+   *  same IRC channel on this instance). */
+  listAllConnections(): IrcConnection[] {
+    const out: IrcConnection[] = [];
+    for (const m of this.byUser.values()) for (const c of m.values()) out.push(c);
+    return out;
+  }
+
   initForUser(userId: number): void {
     // Bulk path — cold-start autoconnect (via initAll) and un-pause resume. The
     // herd of connects this fans out is exactly what issue #236 throttles, so

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -9,13 +9,17 @@ import {
   mintVoiceToken,
   parseVoiceEnabled,
   roomFor,
+  parseRoom,
   voiceEnabled,
   voiceMasterEnabled,
   meetsJoinMode,
   canModerateCall,
   canAdminCall,
   guestIdentity,
+  applyWebhookEvent,
+  listActiveCalls,
 } from './voice.js';
+import type { WebhookEvent } from 'livekit-server-sdk';
 
 describe('parseVoiceEnabled', () => {
   it('treats the conventional truthy values as on (trimmed, case-insensitive)', () => {
@@ -132,7 +136,10 @@ describe('mintVoiceToken', () => {
     process.env.LIVEKIT_API_KEY = 'devkey';
     process.env.LIVEKIT_API_SECRET = 'devsecret-long-enough-for-hs256';
 
-    const minted = await mintVoiceToken({ identity: 'alice', room: 'net-1-c-#dev' });
+    const minted = await mintVoiceToken({
+      identity: 'alice',
+      room: 'net-1-c-#dev',
+    });
     expect(minted.room).toBe('net-1-c-#dev');
     expect(minted.url).toBe('wss://sfu.example');
     expect(typeof minted.token).toBe('string');
@@ -177,5 +184,80 @@ describe('guestIdentity', () => {
     expect(guestIdentity('bad nick!@#')).toMatch(/^guest-badnick-[0-9a-f]{8}$/);
     expect(guestIdentity('')).toMatch(/^guest-guest-[0-9a-f]{8}$/);
     expect(guestIdentity('x')).not.toBe(guestIdentity('x')); // random suffix
+  });
+});
+
+describe('parseRoom', () => {
+  it('is the inverse of roomFor for channel rooms', () => {
+    expect(parseRoom('net-irc.libera.chat-c-#dev')).toEqual({
+      host: 'irc.libera.chat',
+      channel: '#dev',
+    });
+    // Round-trips a host that contains dashes + a channel with brackets.
+    expect(parseRoom(roomFor('my-irc.host.net', '#Foo[Bar]', 'x'))).toEqual({
+      host: 'my-irc.host.net',
+      channel: '#foo[bar]',
+    });
+  });
+
+  it('folds ASCII-only so it matches roomFor / foldKey', () => {
+    expect(parseRoom('net-IRC.Libera.Chat-c-#DevOps')).toEqual({
+      host: 'irc.libera.chat',
+      channel: '#devops',
+    });
+  });
+
+  it('returns null for DM rooms and anything unparseable', () => {
+    expect(parseRoom('net-irc.libera.chat-d-alice-bob')).toBeNull();
+    expect(parseRoom('not-a-room')).toBeNull();
+    expect(parseRoom('net-irc.libera.chat-c-notachannel')).toBeNull();
+  });
+});
+
+describe('applyWebhookEvent', () => {
+  const ev = (event: string, room: string, identity?: string): WebhookEvent =>
+    ({
+      event,
+      room: { name: room },
+      participant: identity ? { identity } : undefined,
+    }) as WebhookEvent;
+
+  it('resolves the channel by parsing the room even without a prior rememberRoom', () => {
+    // The regression from the field: after a restart the roomChannel map is
+    // empty, but presence must still broadcast (room name encodes the channel).
+    const room = 'net-irc.libera.chat-c-#restart-proof';
+    const change = applyWebhookEvent(ev('participant_joined', room, 'jawsh'));
+    expect(change).toEqual({
+      room,
+      host: 'irc.libera.chat',
+      channel: '#restart-proof',
+      active: true,
+      count: 1,
+    });
+  });
+
+  it('tracks a running count across joins and leaves', () => {
+    const room = 'net-irc.libera.chat-c-#counting';
+    applyWebhookEvent(ev('participant_joined', room, 'a'));
+    const two = applyWebhookEvent(ev('participant_joined', room, 'b'));
+    expect(two?.count).toBe(2);
+    const one = applyWebhookEvent(ev('participant_left', room, 'a'));
+    expect(one).toMatchObject({ count: 1, active: true });
+    const gone = applyWebhookEvent(ev('participant_left', room, 'b'));
+    expect(gone).toMatchObject({ count: 0, active: false });
+  });
+
+  it('ignores DM rooms (no channel to badge) and irrelevant events', () => {
+    expect(applyWebhookEvent(ev('participant_joined', 'net-h-d-a-b', 'a'))).toBeNull();
+    expect(applyWebhookEvent(ev('track_published', 'net-irc.libera.chat-c-#x', 'a'))).toBeNull();
+  });
+});
+
+describe('listActiveCalls', () => {
+  it('returns [] when voice is unconfigured (no SFU to query)', async () => {
+    delete process.env.LIVEKIT_WS_URL;
+    delete process.env.LIVEKIT_API_KEY;
+    delete process.env.LIVEKIT_API_SECRET;
+    await expect(listActiveCalls()).resolves.toEqual([]);
   });
 });

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  isChannelTarget,
+  liveKitConfig,
+  mintVoiceToken,
+  parseVoiceEnabled,
+  roomFor,
+  voiceEnabled,
+  voiceMasterEnabled,
+} from './voice.js';
+
+describe('parseVoiceEnabled', () => {
+  it('treats the conventional truthy values as on (trimmed, case-insensitive)', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on', ' On ']) {
+      expect(parseVoiceEnabled(v)).toBe(true);
+    }
+  });
+
+  it('is off for unset / empty / anything else (opt-in only)', () => {
+    for (const v of [undefined, '', '0', 'false', 'no', 'off', 'maybe']) {
+      expect(parseVoiceEnabled(v)).toBe(false);
+    }
+  });
+});
+
+describe('isChannelTarget', () => {
+  it('recognises IRC channel sigils', () => {
+    for (const t of ['#dev', '&local', '!ABCDEchan', '+modeless']) {
+      expect(isChannelTarget(t)).toBe(true);
+    }
+  });
+  it('treats a nick as a non-channel (DM) target', () => {
+    for (const t of ['alice', 'Bob', '', 'nick|away']) {
+      expect(isChannelTarget(t)).toBe(false);
+    }
+  });
+});
+
+describe('roomFor', () => {
+  it('makes a channel room everyone in the channel derives identically', () => {
+    // self is irrelevant for a channel — two members produce the same room.
+    expect(roomFor(7, '#dev', 'alice')).toBe('net-7-c-#dev');
+    expect(roomFor(7, '#dev', 'bob')).toBe('net-7-c-#dev');
+  });
+
+  it('folds the channel name ASCII-only, leaving sigils and non-ASCII intact', () => {
+    expect(roomFor(3, '#DevOps', 'x')).toBe('net-3-c-#devops');
+    // [] and {} are NOT folded (RFC casemapping deliberately absent, §9.2).
+    expect(roomFor(3, '#Foo[Bar]', 'x')).toBe('net-3-c-#foo[bar]');
+  });
+
+  it('gives a DM the SAME room from either end (canonical sorted pair)', () => {
+    // The bug this prevents: A's target is "B", B's target is "A" — verbatim
+    // naming would split one call into two rooms.
+    const fromAlice = roomFor(7, 'Bob', 'Alice');
+    const fromBob = roomFor(7, 'Alice', 'Bob');
+    expect(fromAlice).toBe(fromBob);
+    expect(fromAlice).toBe('net-7-d-alice-bob');
+  });
+
+  it('scopes rooms by network id', () => {
+    expect(roomFor(1, '#dev', 'x')).not.toBe(roomFor(2, '#dev', 'x'));
+  });
+});
+
+describe('config gating (env)', () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it('liveKitConfig is null unless all three vars are present', () => {
+    delete process.env.LIVEKIT_WS_URL;
+    delete process.env.LIVEKIT_API_KEY;
+    delete process.env.LIVEKIT_API_SECRET;
+    expect(liveKitConfig()).toBeNull();
+
+    process.env.LIVEKIT_WS_URL = 'wss://sfu.example';
+    process.env.LIVEKIT_API_KEY = 'devkey';
+    expect(liveKitConfig()).toBeNull(); // secret still missing
+
+    process.env.LIVEKIT_API_SECRET = 'devsecret';
+    expect(liveKitConfig()).toEqual({
+      wsUrl: 'wss://sfu.example',
+      apiKey: 'devkey',
+      apiSecret: 'devsecret',
+    });
+  });
+
+  it('voiceEnabled requires BOTH the master switch and a full config', () => {
+    process.env.LIVEKIT_WS_URL = 'wss://sfu.example';
+    process.env.LIVEKIT_API_KEY = 'devkey';
+    process.env.LIVEKIT_API_SECRET = 'devsecret';
+
+    process.env.LURKER_VOICE_ENABLED = 'off';
+    expect(voiceMasterEnabled()).toBe(false);
+    expect(voiceEnabled()).toBe(false);
+
+    process.env.LURKER_VOICE_ENABLED = 'true';
+    expect(voiceEnabled()).toBe(true);
+
+    delete process.env.LIVEKIT_API_SECRET;
+    expect(voiceEnabled()).toBe(false); // master on, but config incomplete
+  });
+});
+
+describe('mintVoiceToken', () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it('throws when voice is not configured', async () => {
+    delete process.env.LIVEKIT_WS_URL;
+    delete process.env.LIVEKIT_API_KEY;
+    delete process.env.LIVEKIT_API_SECRET;
+    await expect(mintVoiceToken({ identity: 'alice', room: 'net-1-c-#dev' })).rejects.toThrow();
+  });
+
+  it('mints a room-scoped token carrying the connection URL', async () => {
+    process.env.LIVEKIT_WS_URL = 'wss://sfu.example';
+    process.env.LIVEKIT_API_KEY = 'devkey';
+    process.env.LIVEKIT_API_SECRET = 'devsecret-long-enough-for-hs256';
+
+    const minted = await mintVoiceToken({ identity: 'alice', room: 'net-1-c-#dev' });
+    expect(minted.room).toBe('net-1-c-#dev');
+    expect(minted.url).toBe('wss://sfu.example');
+    expect(typeof minted.token).toBe('string');
+    // A JWT is three dot-separated base64url segments.
+    expect(minted.token.split('.')).toHaveLength(3);
+  });
+});

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -41,29 +41,31 @@ describe('isChannelTarget', () => {
 });
 
 describe('roomFor', () => {
-  it('makes a channel room everyone in the channel derives identically', () => {
-    // self is irrelevant for a channel — two members produce the same room.
-    expect(roomFor(7, '#dev', 'alice')).toBe('net-7-c-#dev');
-    expect(roomFor(7, '#dev', 'bob')).toBe('net-7-c-#dev');
+  it('makes a channel room everyone on the same host+channel derives identically', () => {
+    // self is irrelevant for a channel; the host is shared across users and
+    // instances, so two different accounts produce the same room.
+    expect(roomFor('irc.libera.chat', '#dev', 'alice')).toBe('net-irc.libera.chat-c-#dev');
+    expect(roomFor('irc.libera.chat', '#dev', 'bob')).toBe('net-irc.libera.chat-c-#dev');
   });
 
-  it('folds the channel name ASCII-only, leaving sigils and non-ASCII intact', () => {
-    expect(roomFor(3, '#DevOps', 'x')).toBe('net-3-c-#devops');
+  it('folds host + channel ASCII-only, leaving sigils and non-ASCII intact', () => {
+    expect(roomFor('IRC.Libera.Chat', '#DevOps', 'x')).toBe('net-irc.libera.chat-c-#devops');
     // [] and {} are NOT folded (RFC casemapping deliberately absent, §9.2).
-    expect(roomFor(3, '#Foo[Bar]', 'x')).toBe('net-3-c-#foo[bar]');
+    expect(roomFor('irc.libera.chat', '#Foo[Bar]', 'x')).toBe('net-irc.libera.chat-c-#foo[bar]');
   });
 
   it('gives a DM the SAME room from either end (canonical sorted pair)', () => {
     // The bug this prevents: A's target is "B", B's target is "A" — verbatim
     // naming would split one call into two rooms.
-    const fromAlice = roomFor(7, 'Bob', 'Alice');
-    const fromBob = roomFor(7, 'Alice', 'Bob');
+    const fromAlice = roomFor('irc.libera.chat', 'Bob', 'Alice');
+    const fromBob = roomFor('irc.libera.chat', 'Alice', 'Bob');
     expect(fromAlice).toBe(fromBob);
-    expect(fromAlice).toBe('net-7-d-alice-bob');
+    expect(fromAlice).toBe('net-irc.libera.chat-d-alice-bob');
   });
 
-  it('scopes rooms by network id', () => {
-    expect(roomFor(1, '#dev', 'x')).not.toBe(roomFor(2, '#dev', 'x'));
+  it('scopes rooms by host, not by per-user network id', () => {
+    // Same channel on two different networks → different rooms.
+    expect(roomFor('irc.libera.chat', '#dev', 'x')).not.toBe(roomFor('irc.rizon.net', '#dev', 'x'));
   });
 });
 

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -11,6 +11,10 @@ import {
   roomFor,
   voiceEnabled,
   voiceMasterEnabled,
+  meetsJoinMode,
+  canModerateCall,
+  canAdminCall,
+  guestIdentity,
 } from './voice.js';
 
 describe('parseVoiceEnabled', () => {
@@ -134,5 +138,44 @@ describe('mintVoiceToken', () => {
     expect(typeof minted.token).toBe('string');
     // A JWT is three dot-separated base64url segments.
     expect(minted.token.split('.')).toHaveLength(3);
+  });
+});
+
+describe('meetsJoinMode', () => {
+  it("'none' lets anyone in", () => {
+    expect(meetsJoinMode([], 'none')).toBe(true);
+    expect(meetsJoinMode(['v'], 'none')).toBe(true);
+  });
+  it('ranks voice < halfop < op; owner/admin count as op', () => {
+    expect(meetsJoinMode([], 'voice')).toBe(false);
+    expect(meetsJoinMode(['v'], 'voice')).toBe(true);
+    expect(meetsJoinMode(['v'], 'op')).toBe(false);
+    expect(meetsJoinMode(['h'], 'op')).toBe(false);
+    expect(meetsJoinMode(['h'], 'halfop')).toBe(true);
+    expect(meetsJoinMode(['o'], 'op')).toBe(true);
+    expect(meetsJoinMode(['q'], 'op')).toBe(true);
+    expect(meetsJoinMode(['o'], 'halfop')).toBe(true); // op exceeds the halfop bar
+  });
+});
+
+describe('canModerateCall / canAdminCall', () => {
+  it('moderation allows q/a/o/h; admin (policy + guest links) allows q/a/o only', () => {
+    expect(canModerateCall(['h'])).toBe(true);
+    expect(canModerateCall(['o'])).toBe(true);
+    expect(canModerateCall(['v'])).toBe(false);
+    expect(canModerateCall([])).toBe(false);
+    expect(canAdminCall(['h'])).toBe(false);
+    expect(canAdminCall(['o'])).toBe(true);
+    expect(canAdminCall(['q'])).toBe(true);
+    expect(canAdminCall([])).toBe(false);
+  });
+});
+
+describe('guestIdentity', () => {
+  it('namespaces + sanitizes so a guest can never be a bare IRC nick', () => {
+    expect(guestIdentity('Alice')).toMatch(/^guest-alice-[0-9a-f]{8}$/);
+    expect(guestIdentity('bad nick!@#')).toMatch(/^guest-badnick-[0-9a-f]{8}$/);
+    expect(guestIdentity('')).toMatch(/^guest-guest-[0-9a-f]{8}$/);
+    expect(guestIdentity('x')).not.toBe(guestIdentity('x')); // random suffix
   });
 });

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -19,7 +19,10 @@
 // put the two ends in two different rooms. So DM rooms are keyed by the
 // *canonical* (sorted) nick pair instead.
 
-import { AccessToken } from 'livekit-server-sdk';
+import crypto from 'crypto';
+import { AccessToken, RoomServiceClient, WebhookReceiver } from 'livekit-server-sdk';
+import type { WebhookEvent } from 'livekit-server-sdk';
+import type { MinJoinMode } from '../db/voicePolicy.js';
 
 // Conventional truthy env values — trimmed + case-insensitive. Matches dccConfig.
 const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
@@ -63,6 +66,12 @@ const CHANNEL_SIGILS = new Set(['#', '&', '!', '+']);
 
 export function isChannelTarget(target: string): boolean {
   return target.length > 0 && CHANNEL_SIGILS.has(target[0]!);
+}
+
+/** ASCII-fold a host or channel to the key used for room names + policy rows.
+ *  Exported so routes fold identically to roomFor(). */
+export function foldKey(s: string): string {
+  return foldAscii(s);
 }
 
 // ASCII-only lowercasing, to match the client's casefold (docs §9.2 — RFC 1459
@@ -121,6 +130,8 @@ export interface MintedToken {
 export async function mintVoiceToken(args: {
   identity: string;
   room: string;
+  /** false → a listen-only token (guests below the talk threshold). Default true. */
+  canPublish?: boolean;
   ttlSeconds?: number;
 }): Promise<MintedToken> {
   const cfg = liveKitConfig();
@@ -133,10 +144,152 @@ export async function mintVoiceToken(args: {
   at.addGrant({
     roomJoin: true,
     room: args.room,
-    canPublish: true,
+    canPublish: args.canPublish !== false,
     canSubscribe: true,
     canPublishData: true,
   });
   const token = await at.toJwt();
   return { token, room: args.room, url: cfg.wsUrl };
+}
+
+// ─── Channel-mode authority ────────────────────────────────────────────────
+// IRC prefix modes, ranked. Owner (q), admin (a) and op (o) all count as the
+// top "op" tier; halfop (h) above voice (v). Read from ChannelMember.modes.
+
+const MODE_RANK: Record<MinJoinMode, number> = { none: 0, voice: 1, halfop: 2, op: 3 };
+const LETTER_RANK: Record<string, number> = { v: 1, h: 2, o: 3, a: 3, q: 3 };
+const MODERATE_LETTERS = new Set(['q', 'a', 'o', 'h']); // may mute/remove in a call
+const OP_LETTERS = new Set(['q', 'a', 'o']); // may set policy / mint guest links
+
+/** Does a member holding these prefix modes meet a channel's min join mode? */
+export function meetsJoinMode(modes: readonly string[], min: MinJoinMode): boolean {
+  const need = MODE_RANK[min] ?? 0;
+  if (need === 0) return true;
+  let have = 0;
+  for (const m of modes) have = Math.max(have, LETTER_RANK[m] ?? 0);
+  return have >= need;
+}
+
+/** Ops/halfops — allowed to mute or remove others from a call. */
+export function canModerateCall(modes: readonly string[]): boolean {
+  return modes.some((m) => MODERATE_LETTERS.has(m));
+}
+
+/** Ops (q/a/o) — allowed to set the join policy and mint guest links. */
+export function canAdminCall(modes: readonly string[]): boolean {
+  return modes.some((m) => OP_LETTERS.has(m));
+}
+
+/** A safe, namespaced LiveKit identity for a guest so they can never collide
+ *  with or impersonate a real IRC nick (all real identities are bare nicks). */
+export function guestIdentity(name: string): string {
+  const clean =
+    foldAscii(name)
+      .replace(/[^a-z0-9_-]/g, '')
+      .slice(0, 24) || 'guest';
+  return `guest-${clean}-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+// ─── Server-side room control (moderation) ─────────────────────────────────
+// A fresh RoomServiceClient per call — construction is cheap and this way a
+// config change (secret rotation) is always picked up. API host is the wss URL
+// mapped to http(s). All these require roomAdmin, which the SDK signs from the
+// same api key/secret — clients never receive an admin token.
+
+function roomService(): RoomServiceClient | null {
+  const cfg = liveKitConfig();
+  if (!cfg) return null;
+  return new RoomServiceClient(cfg.wsUrl.replace(/^ws/, 'http'), cfg.apiKey, cfg.apiSecret);
+}
+
+/** Force-remove a participant (by identity) from a room. */
+export async function removeFromCall(room: string, identity: string): Promise<void> {
+  const svc = roomService();
+  if (!svc) throw new Error('voice not configured');
+  await svc.removeParticipant(room, identity);
+}
+
+/** Server-mute all of a participant's published tracks (they cannot self-unmute
+ *  a server mute). No-op if they are not currently in the room. */
+export async function muteParticipant(room: string, identity: string): Promise<void> {
+  const svc = roomService();
+  if (!svc) throw new Error('voice not configured');
+  const parts = await svc.listParticipants(room);
+  const p = parts.find((x) => x.identity === identity);
+  if (!p) return;
+  for (const t of p.tracks ?? []) {
+    await svc.mutePublishedTrack(room, identity, t.sid, true);
+  }
+}
+
+// ─── Call presence registry (fed by LiveKit webhooks) ──────────────────────
+// In-memory: which identities are in each room, plus a room → (host, channel)
+// map recorded at token mint so a webhook can resolve a room back to its
+// channel without parsing the room string. Lost on restart (repopulates as
+// tokens are minted / a boot reconcile via listRooms can seed it).
+
+const roomParticipants = new Map<string, Set<string>>();
+const roomChannel = new Map<string, { host: string; channel: string }>();
+
+/** Record the (host, channel) a room maps to — call this whenever a token is
+ *  minted for the room so the webhook can broadcast presence to that channel. */
+export function rememberRoom(room: string, host: string, channel: string): void {
+  roomChannel.set(room, { host: foldAscii(host), channel: foldAscii(channel) });
+}
+
+export function participantsIn(room: string): number {
+  return roomParticipants.get(room)?.size ?? 0;
+}
+
+export interface CallPresenceChange {
+  room: string;
+  host: string;
+  channel: string;
+  active: boolean;
+  count: number;
+}
+
+/** Verify + parse a LiveKit webhook body. Null if the signature is invalid or
+ *  voice is unconfigured. */
+export async function receiveWebhook(
+  body: string,
+  authHeader: string | undefined,
+): Promise<WebhookEvent | null> {
+  const cfg = liveKitConfig();
+  if (!cfg) return null;
+  try {
+    return await new WebhookReceiver(cfg.apiKey, cfg.apiSecret).receive(body, authHeader);
+  } catch {
+    return null;
+  }
+}
+
+/** Apply a parsed webhook event to the registry. Returns the presence change to
+ *  broadcast, or null when the event is irrelevant or the room is unmapped. */
+export function applyWebhookEvent(ev: WebhookEvent): CallPresenceChange | null {
+  const room = ev.room?.name;
+  if (!room) return null;
+  const ident = ev.participant?.identity;
+  let set = roomParticipants.get(room);
+  switch (ev.event) {
+    case 'participant_joined':
+      if (!ident) return null;
+      if (!set) roomParticipants.set(room, (set = new Set()));
+      set.add(ident);
+      break;
+    case 'participant_left':
+      if (!ident || !set) return null;
+      set.delete(ident);
+      if (set.size === 0) roomParticipants.delete(room);
+      break;
+    case 'room_finished':
+      roomParticipants.delete(room);
+      break;
+    default:
+      return null;
+  }
+  const mapping = roomChannel.get(room);
+  if (!mapping) return null; // can't map to a channel → nothing to broadcast
+  const count = roomParticipants.get(room)?.size ?? 0;
+  return { room, host: mapping.host, channel: mapping.channel, active: count > 0, count };
 }

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -80,20 +80,27 @@ function foldAscii(s: string): string {
 /**
  * Derive the LiveKit room name for a call. Pure and deterministic.
  *
- *  - Channel `#dev` on network 7      → `net-7-c-#dev`
- *  - DM between `Alice` and `bob`     → `net-7-d-alice-bob` (sorted, either end)
+ * Keyed on the IRC network's HOST — NOT a local network row id. A networkId is
+ * per-account, so two users of the same instance (jawsh + jawsh-qa) on the same
+ * channel would otherwise derive different rooms and never connect. Hosts are
+ * shared across users, and across *instances* pointed at a common SFU — so a
+ * host key is also what makes opt-in cross-instance bridging Just Work.
+ *
+ *  - Channel `#dev` on irc.libera.chat → `net-irc.libera.chat-c-#dev`
+ *  - DM `Alice`↔`bob`                  → `net-irc.libera.chat-d-alice-bob` (sorted, either end)
  *
  * `self` is the caller's own nick on the network; it is only consulted for DMs,
  * where it is paired with `target` and sorted so both ends agree on one room.
  */
-export function roomFor(networkId: number, target: string, self: string): string {
+export function roomFor(networkKey: string, target: string, self: string): string {
+  const net = foldAscii(networkKey);
   if (isChannelTarget(target)) {
-    return `net-${networkId}-c-${foldAscii(target)}`;
+    return `net-${net}-c-${foldAscii(target)}`;
   }
   const a = foldAscii(self);
   const b = foldAscii(target);
   const [lo, hi] = a <= b ? [a, b] : [b, a];
-  return `net-${networkId}-d-${lo}-${hi}`;
+  return `net-${net}-d-${lo}-${hi}`;
 }
 
 export interface MintedToken {

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Voice/video calls via a self-hosted LiveKit SFU. Lurker never carries media —
+// it is only the *token authority*: it already knows who you are and which
+// networks you own, so it is the right place to mint a room-scoped LiveKit
+// access token. The desktop client (Scully) holds only the short-lived token,
+// never the LiveKit API secret — the same trust split as session tokens.
+//
+// Gating mirrors DCC (see dccConfig.ts): OFF by default, opt-in for the operator.
+// Voice is "enabled" only when BOTH the master switch is on AND the three
+// LiveKit connection vars are present. Anything missing → dark, and /api/config
+// advertises voiceEnabled: false so the client hides the call UI entirely.
+//
+// The room-naming rules are pure (no env, no I/O) and unit-tested — they are the
+// load-bearing correctness surface. A channel is symmetric (everyone in #dev
+// derives the same room), but a DM is not: if A opens a call to B, A's target is
+// "B" and B's target is "A". Naming a DM room by (self, target) verbatim would
+// put the two ends in two different rooms. So DM rooms are keyed by the
+// *canonical* (sorted) nick pair instead.
+
+import { AccessToken } from 'livekit-server-sdk';
+
+// Conventional truthy env values — trimmed + case-insensitive. Matches dccConfig.
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+/** Parse a raw LURKER_VOICE_ENABLED value to a boolean. Pure (no env access) so
+ * it can be unit-tested without touching process.env. */
+export function parseVoiceEnabled(raw: string | undefined): boolean {
+  if (raw == null) return false;
+  return TRUTHY.has(raw.trim().toLowerCase());
+}
+
+/** The operator master switch. */
+export function voiceMasterEnabled(): boolean {
+  return parseVoiceEnabled(process.env.LURKER_VOICE_ENABLED);
+}
+
+export interface LiveKitConfig {
+  /** The wss:// URL the *client* connects to (public origin of the SFU). */
+  wsUrl: string;
+  apiKey: string;
+  apiSecret: string;
+}
+
+/** Read the three LiveKit connection vars, or null if any is missing/blank. */
+export function liveKitConfig(): LiveKitConfig | null {
+  const wsUrl = (process.env.LIVEKIT_WS_URL ?? '').trim();
+  const apiKey = (process.env.LIVEKIT_API_KEY ?? '').trim();
+  const apiSecret = (process.env.LIVEKIT_API_SECRET ?? '').trim();
+  if (!wsUrl || !apiKey || !apiSecret) return null;
+  return { wsUrl, apiKey, apiSecret };
+}
+
+/** Voice is live only when the operator opted in AND the SFU is configured. */
+export function voiceEnabled(): boolean {
+  return voiceMasterEnabled() && liveKitConfig() !== null;
+}
+
+// IRC channel sigils. A target that starts with one of these is a channel; any
+// other target is a nick (a DM peer).
+const CHANNEL_SIGILS = new Set(['#', '&', '!', '+']);
+
+export function isChannelTarget(target: string): boolean {
+  return target.length > 0 && CHANNEL_SIGILS.has(target[0]!);
+}
+
+// ASCII-only lowercasing, to match the client's casefold (docs §9.2 — RFC 1459
+// casemapping is deliberately absent; we do not fold [] {} etc). We only touch
+// A–Z so identity never splits with the server.
+function foldAscii(s: string): string {
+  let out = '';
+  for (const ch of s) {
+    const c = ch.charCodeAt(0);
+    out += c >= 65 && c <= 90 ? String.fromCharCode(c + 32) : ch;
+  }
+  return out;
+}
+
+/**
+ * Derive the LiveKit room name for a call. Pure and deterministic.
+ *
+ *  - Channel `#dev` on network 7      → `net-7-c-#dev`
+ *  - DM between `Alice` and `bob`     → `net-7-d-alice-bob` (sorted, either end)
+ *
+ * `self` is the caller's own nick on the network; it is only consulted for DMs,
+ * where it is paired with `target` and sorted so both ends agree on one room.
+ */
+export function roomFor(networkId: number, target: string, self: string): string {
+  if (isChannelTarget(target)) {
+    return `net-${networkId}-c-${foldAscii(target)}`;
+  }
+  const a = foldAscii(self);
+  const b = foldAscii(target);
+  const [lo, hi] = a <= b ? [a, b] : [b, a];
+  return `net-${networkId}-d-${lo}-${hi}`;
+}
+
+export interface MintedToken {
+  /** The signed JWT the client passes to LiveKit. */
+  token: string;
+  /** The room it is scoped to. */
+  room: string;
+  /** The wss:// URL to connect to. */
+  url: string;
+}
+
+/**
+ * Mint a room-scoped LiveKit access token. Grants join + publish + subscribe on
+ * exactly one room and nothing else — a token for `#dev` cannot touch `#ops`.
+ * Identity is the caller's IRC nick so remote participants render sensible names.
+ * Throws if voice is not configured (callers should have gated on voiceEnabled).
+ */
+export async function mintVoiceToken(args: {
+  identity: string;
+  room: string;
+  ttlSeconds?: number;
+}): Promise<MintedToken> {
+  const cfg = liveKitConfig();
+  if (!cfg) throw new Error('voice not configured');
+
+  const at = new AccessToken(cfg.apiKey, cfg.apiSecret, {
+    identity: args.identity,
+    ttl: args.ttlSeconds ?? 2 * 60 * 60, // 2h; a call outlives a token refresh
+  });
+  at.addGrant({
+    roomJoin: true,
+    room: args.room,
+    canPublish: true,
+    canSubscribe: true,
+    canPublishData: true,
+  });
+  const token = await at.toJwt();
+  return { token, room: args.room, url: cfg.wsUrl };
+}

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -112,6 +112,19 @@ export function roomFor(networkKey: string, target: string, self: string): strin
   return `net-${net}-d-${lo}-${hi}`;
 }
 
+/** Inverse of roomFor for CHANNEL rooms: recover (host, channel) from a room
+ *  name, both already ASCII-folded. Returns null for DM rooms (no channel) or
+ *  anything unparseable. This lets a webhook resolve presence to a channel even
+ *  when the in-memory roomChannel map was never seeded for the room — e.g. after
+ *  a Lurker restart mid-call, or a call started on another instance sharing the
+ *  SFU. The `-c-` before a channel-prefixed segment is the anchor; the host may
+ *  itself contain dashes. */
+export function parseRoom(room: string): { host: string; channel: string } | null {
+  const m = /^net-(.+)-c-([#&].*)$/.exec(room);
+  if (!m) return null;
+  return { host: foldAscii(m[1]), channel: foldAscii(m[2]) };
+}
+
 export interface MintedToken {
   /** The signed JWT the client passes to LiveKit. */
   token: string;
@@ -156,7 +169,12 @@ export async function mintVoiceToken(args: {
 // IRC prefix modes, ranked. Owner (q), admin (a) and op (o) all count as the
 // top "op" tier; halfop (h) above voice (v). Read from ChannelMember.modes.
 
-const MODE_RANK: Record<MinJoinMode, number> = { none: 0, voice: 1, halfop: 2, op: 3 };
+const MODE_RANK: Record<MinJoinMode, number> = {
+  none: 0,
+  voice: 1,
+  halfop: 2,
+  op: 3,
+};
 const LETTER_RANK: Record<string, number> = { v: 1, h: 2, o: 3, a: 3, q: 3 };
 const MODERATE_LETTERS = new Set(['q', 'a', 'o', 'h']); // may mute/remove in a call
 const OP_LETTERS = new Set(['q', 'a', 'o']); // may set policy / mint guest links
@@ -220,6 +238,30 @@ export async function muteParticipant(room: string, identity: string): Promise<v
   for (const t of p.tracks ?? []) {
     await svc.mutePublishedTrack(room, identity, t.sid, true);
   }
+}
+
+/** Snapshot every active CHANNEL call the SFU currently knows about, so a
+ *  freshly-connected client can hydrate presence badges for calls that started
+ *  before it connected — the webhook stream only carries live deltas. LiveKit is
+ *  the source of truth, so this is correct across a Lurker restart (unlike the
+ *  in-memory registry). Returns [] when voice is unconfigured. */
+export async function listActiveCalls(): Promise<
+  Array<{ host: string; channel: string; count: number }>
+> {
+  const svc = roomService();
+  if (!svc) return [];
+  const rooms = await svc.listRooms();
+  const out: Array<{ host: string; channel: string; count: number }> = [];
+  for (const r of rooms) {
+    const parsed = parseRoom(r.name);
+    if (!parsed) continue; // DM rooms + anything unparseable carry no channel badge
+    out.push({
+      host: parsed.host,
+      channel: parsed.channel,
+      count: r.numParticipants ?? 0,
+    });
+  }
+  return out;
 }
 
 // ─── Call presence registry (fed by LiveKit webhooks) ──────────────────────
@@ -288,8 +330,17 @@ export function applyWebhookEvent(ev: WebhookEvent): CallPresenceChange | null {
     default:
       return null;
   }
-  const mapping = roomChannel.get(room);
-  if (!mapping) return null; // can't map to a channel → nothing to broadcast
+  // Prefer the map seeded at token-mint (authoritative host/channel casing), but
+  // fall back to parsing the room name so presence survives a restart that
+  // cleared the map while a call kept running (the room name encodes both).
+  const mapping = roomChannel.get(room) ?? parseRoom(room);
+  if (!mapping) return null; // DM room / unparseable → nothing to broadcast
   const count = roomParticipants.get(room)?.size ?? 0;
-  return { room, host: mapping.host, channel: mapping.channel, active: count > 0, count };
+  return {
+    room,
+    host: mapping.host,
+    channel: mapping.channel,
+    active: count > 0,
+    count,
+  };
 }

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",
         "@simplewebauthn/browser": "^13.3.0",
+        "livekit-client": "^2.21.0",
         "pinia": "^3.0.4",
         "vue": "^3.5.40",
         "vue-router": "^5.2.0",
@@ -136,6 +137,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -237,6 +244,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -567,6 +589,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
@@ -1129,6 +1158,15 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
@@ -1261,6 +1299,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-beautify": {
@@ -1566,6 +1613,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.21.0.tgz",
+      "integrity": "sha512-RBUhPkV/sl1nzl8lokVlK5uATPwn0AlsudCBZXissw/kDl9yz8ac4pNJ43iPpMVoHOeBYH/BZ3vUC1adqa/zFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.50.4",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "9.0.6"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
@@ -1581,6 +1648,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/lru-cache": {
@@ -1965,11 +2045,36 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scule": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -2193,8 +2298,16 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -2558,6 +2671,19 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.3.1",
     "@simplewebauthn/browser": "^13.3.0",
+    "livekit-client": "^2.21.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0",

--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -10,6 +10,7 @@
   </div>
   <ToastContainer />
   <ContextMenu />
+  <CallBar />
 </template>
 
 <script setup lang="ts">
@@ -21,6 +22,7 @@ import { useTheme } from './composables/useTheme.js';
 import ToastContainer from './components/ToastContainer.vue';
 import ContextMenu from './components/ContextMenu.vue';
 import PausedBanner from './components/PausedBanner.vue';
+import CallBar from './components/CallBar.vue';
 
 const auth = useAuthStore();
 const settings = useSettingsStore();

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -1,0 +1,126 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  A persistent voice-call bar. Shown while a call is connecting or active so the
+  user can keep reading/typing during the call. Mounted once, globally, in
+  App.vue; it reads the singleton voice store, so it survives buffer switches.
+  Deliberately plain — a first-pass surface for amiantos to restyle.
+-->
+
+<template>
+  <div v-if="voice.active || voice.connecting" class="call-bar" role="dialog" aria-label="Voice call">
+    <div class="call-head">
+      <i class="fa-solid fa-phone"></i>
+      <span class="call-title">{{ voice.label || 'Voice call' }}</span>
+      <span class="call-status">{{ statusText }}</span>
+    </div>
+
+    <ul v-if="voice.participants.length" class="call-parts">
+      <li v-for="id in voice.participants" :key="id" :class="{ talking: voice.speaking.includes(id) }">
+        <i v-if="voice.speaking.includes(id)" class="fa-solid fa-volume-high"></i>
+        <span>{{ id }}</span>
+      </li>
+    </ul>
+    <p v-else class="call-empty">Just you so far…</p>
+
+    <div class="call-actions">
+      <button type="button" :class="{ muted: voice.muted }" @click="voice.toggleMute()">
+        <i :class="voice.muted ? 'fa-solid fa-microphone-slash' : 'fa-solid fa-microphone'"></i>
+        {{ voice.muted ? 'Unmute' : 'Mute' }}
+      </button>
+      <button type="button" class="leave" @click="voice.leave()">
+        <i class="fa-solid fa-phone-slash"></i> Leave
+      </button>
+    </div>
+
+    <p v-if="voice.error" class="call-error">{{ voice.error }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useVoiceStore } from '../stores/voice.js';
+
+const voice = useVoiceStore();
+const statusText = computed(() => (voice.connecting ? 'Connecting…' : 'Connected'));
+</script>
+
+<style scoped>
+.call-bar {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 60;
+  width: 15rem;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  background: var(--panel-bg, #1b1d24);
+  color: var(--text, #e7e9ee);
+  border: 1px solid var(--border, #2c2f38);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  font-size: 0.85rem;
+}
+.call-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
+}
+.call-title {
+  font-weight: 600;
+}
+.call-status {
+  margin-left: auto;
+  opacity: 0.7;
+  font-size: 0.75rem;
+}
+.call-parts {
+  list-style: none;
+  margin: 0 0 0.5rem;
+  padding: 0;
+  max-height: 8rem;
+  overflow-y: auto;
+}
+.call-parts li {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.1rem 0;
+}
+.call-parts li.talking {
+  color: var(--accent, #6ea8fe);
+}
+.call-empty {
+  margin: 0 0 0.5rem;
+  opacity: 0.6;
+}
+.call-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+.call-actions button {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.35rem;
+  border: 1px solid var(--border, #2c2f38);
+  background: var(--button-bg, #262933);
+  color: inherit;
+  cursor: pointer;
+}
+.call-actions button.muted {
+  background: var(--warn-bg, #5a4a1e);
+}
+.call-actions button.leave {
+  background: var(--danger-bg, #6e2b2b);
+}
+.call-error {
+  margin: 0.5rem 0 0;
+  color: var(--danger, #ff6b6b);
+  font-size: 0.75rem;
+}
+</style>

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -9,11 +9,27 @@
 -->
 
 <template>
-  <div v-if="voice.active || voice.connecting" class="call-bar" role="dialog" aria-label="Voice call">
+  <div
+    v-if="voice.active || voice.connecting"
+    class="call-bar"
+    :class="{ 'has-video': voice.videoTiles.length }"
+    role="dialog"
+    aria-label="Voice call"
+  >
     <div class="call-head">
       <i class="fa-solid fa-phone"></i>
       <span class="call-title">{{ voice.label || 'Voice call' }}</span>
       <span class="call-status">{{ statusText }}</span>
+    </div>
+
+    <div v-if="voice.videoTiles.length" class="video-grid">
+      <VideoTile
+        v-for="t in voice.videoTiles"
+        :key="`${t.identity}|${t.source}`"
+        :identity="t.identity"
+        :source="t.source"
+        :self="t.self"
+      />
     </div>
 
     <ul v-if="voice.participants.length" class="call-parts">
@@ -65,6 +81,24 @@
         <i :class="voice.muted ? 'fa-solid fa-microphone-slash' : 'fa-solid fa-microphone'"></i>
         {{ voice.muted ? 'Unmute' : 'Mute' }}
       </button>
+      <button
+        type="button"
+        class="icon-btn"
+        :class="{ on: voice.cameraOn }"
+        title="Toggle camera"
+        @click="voice.toggleCamera()"
+      >
+        <i :class="voice.cameraOn ? 'fa-solid fa-video' : 'fa-solid fa-video-slash'"></i>
+      </button>
+      <button
+        type="button"
+        class="icon-btn"
+        :class="{ on: voice.screenOn }"
+        title="Share screen"
+        @click="voice.toggleScreen()"
+      >
+        <i class="fa-solid fa-desktop"></i>
+      </button>
       <button type="button" class="leave" @click="voice.leave()">
         <i class="fa-solid fa-phone-slash"></i> Leave
       </button>
@@ -80,6 +114,7 @@ import { useVoiceStore } from '../stores/voice.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { api } from '../api.js';
+import VideoTile from './VideoTile.vue';
 
 const voice = useVoiceStore();
 const buffers = useBuffersStore();
@@ -191,9 +226,28 @@ async function moderate(identity: string, action: 'mute' | 'remove') {
   margin-top: 0.1rem;
   cursor: pointer;
 }
+.call-bar.has-video {
+  width: 30rem;
+  max-width: calc(100vw - 2rem);
+}
+.video-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8.5rem, 1fr));
+  gap: 0.35rem;
+  margin-bottom: 0.5rem;
+  max-height: 24rem;
+  overflow-y: auto;
+}
 .call-empty {
   margin: 0 0 0.5rem;
   opacity: 0.6;
+}
+.call-actions .icon-btn {
+  flex: 0 0 auto;
+}
+.call-actions button.on {
+  background: var(--accent, #6ea8fe);
+  color: #08101f;
 }
 .call-actions {
   display: flex;

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -17,9 +17,45 @@
     </div>
 
     <ul v-if="voice.participants.length" class="call-parts">
-      <li v-for="id in voice.participants" :key="id" :class="{ talking: voice.speaking.includes(id) }">
-        <i v-if="voice.speaking.includes(id)" class="fa-solid fa-volume-high"></i>
-        <span>{{ id }}</span>
+      <li
+        v-for="id in voice.participants"
+        :key="id"
+        :class="{ talking: voice.speaking.includes(id) }"
+      >
+        <div class="part-row">
+          <i
+            class="fa-solid"
+            :class="voice.speaking.includes(id) ? 'fa-volume-high' : 'fa-user'"
+          ></i>
+          <span class="part-nick" :title="id">{{ id }}</span>
+          <button
+            v-if="amOp"
+            type="button"
+            class="mod"
+            title="Mute in call"
+            @click="moderate(id, 'mute')"
+          >
+            <i class="fa-solid fa-microphone-slash"></i>
+          </button>
+          <button
+            v-if="amOp"
+            type="button"
+            class="mod danger"
+            title="Remove from call"
+            @click="moderate(id, 'remove')"
+          >
+            <i class="fa-solid fa-user-slash"></i>
+          </button>
+        </div>
+        <input
+          class="vol"
+          type="range"
+          min="0"
+          max="100"
+          :value="volPct(id)"
+          :aria-label="`Volume for ${id}`"
+          @input="onVol(id, $event)"
+        />
       </li>
     </ul>
     <p v-else class="call-empty">Just you so far…</p>
@@ -41,9 +77,45 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useVoiceStore } from '../stores/voice.js';
+import { useBuffersStore } from '../stores/buffers.js';
+import { useNetworksStore } from '../stores/networks.js';
+import { api } from '../api.js';
 
 const voice = useVoiceStore();
+const buffers = useBuffersStore();
+const networks = useNetworksStore();
 const statusText = computed(() => (voice.connecting ? 'Connecting…' : 'Connected'));
+
+// Am I an operator of the call's channel? Gates the mute/remove controls (the
+// server enforces this too). Guests never moderate.
+const MODERATE_MODES = ['q', 'a', 'o', 'h'];
+const amOp = computed(() => {
+  if (voice.isGuest || voice.networkId == null) return false;
+  const b = buffers.byKey(`${voice.networkId}::${voice.target.toLowerCase()}`);
+  const selfNick = networks.states[voice.networkId]?.nick;
+  if (!b || !selfNick) return false;
+  const me = b.members?.find((m) => m.nick.toLowerCase() === selfNick.toLowerCase());
+  return !!me?.modes?.some((mm) => MODERATE_MODES.includes(mm));
+});
+
+function volPct(id: string): number {
+  return Math.round((voice.volumes[id] ?? 1) * 100);
+}
+function onVol(id: string, e: Event) {
+  voice.setVolume(id, Number((e.target as HTMLInputElement).value) / 100);
+}
+
+async function moderate(identity: string, action: 'mute' | 'remove') {
+  if (voice.networkId == null) return;
+  try {
+    await api('/api/voice/moderate', {
+      method: 'POST',
+      body: { networkId: voice.networkId, target: voice.target, action, identity },
+    });
+  } catch {
+    /* server enforces; ignore transient failures */
+  }
+}
 </script>
 
 <style scoped>
@@ -83,13 +155,41 @@ const statusText = computed(() => (voice.connecting ? 'Connecting…' : 'Connect
   overflow-y: auto;
 }
 .call-parts li {
+  padding: 0.15rem 0;
+}
+.part-row {
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.1rem 0;
 }
-.call-parts li.talking {
+.part-nick {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.call-parts li.talking .part-nick {
   color: var(--accent, #6ea8fe);
+}
+.part-row .mod {
+  border: none;
+  background: transparent;
+  color: var(--fg-muted, #9aa0ac);
+  cursor: pointer;
+  padding: 0 0.15rem;
+}
+.part-row .mod:hover {
+  color: var(--text, #e7e9ee);
+}
+.part-row .mod.danger:hover {
+  color: var(--danger, #ff6b6b);
+}
+.vol {
+  width: 100%;
+  height: 0.6rem;
+  margin-top: 0.1rem;
+  cursor: pointer;
 }
 .call-empty {
   margin: 0 0 0.5rem;

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -2,10 +2,10 @@
   Copyright (c) 2026 Brad Root
   SPDX-License-Identifier: MPL-2.0
 
-  A persistent voice-call bar. Shown while a call is connecting or active so the
-  user can keep reading/typing during the call. Mounted once, globally, in
-  App.vue; it reads the singleton voice store, so it survives buffer switches.
-  Deliberately plain — a first-pass surface for amiantos to restyle.
+  Persistent, floating voice/video call window. Mounted once globally in App.vue
+  (reads the singleton voice store, so it survives buffer switches). Draggable by
+  its header, resizable from the bottom-right, and grows a video tile grid when
+  anyone shares camera/screen. Individual tiles can go fullscreen.
 -->
 
 <template>
@@ -13,78 +13,86 @@
     v-if="voice.active || voice.connecting"
     class="call-bar"
     :class="{ 'has-video': voice.videoTiles.length }"
+    :style="barStyle"
     role="dialog"
     aria-label="Voice call"
   >
-    <div class="call-head">
-      <i class="fa-solid fa-phone"></i>
+    <div class="call-head" @pointerdown="onHeaderDown">
+      <span class="dot" :class="{ live: voice.active }"></span>
       <span class="call-title">{{ voice.label || 'Voice call' }}</span>
       <span class="call-status">{{ statusText }}</span>
     </div>
 
-    <div v-if="voice.videoTiles.length" class="video-grid">
-      <VideoTile
-        v-for="t in voice.videoTiles"
-        :key="`${t.identity}|${t.source}`"
-        :identity="t.identity"
-        :source="t.source"
-        :self="t.self"
-      />
+    <div class="call-body">
+      <div v-if="voice.videoTiles.length" class="video-grid">
+        <VideoTile
+          v-for="t in voice.videoTiles"
+          :key="`${t.identity}|${t.source}`"
+          :identity="t.identity"
+          :source="t.source"
+          :self="t.self"
+        />
+      </div>
+
+      <ul v-if="voice.participants.length" class="call-parts">
+        <li
+          v-for="id in voice.participants"
+          :key="id"
+          :class="{ talking: voice.speaking.includes(id) }"
+        >
+          <div class="part-row">
+            <i
+              class="fa-solid"
+              :class="voice.speaking.includes(id) ? 'fa-volume-high' : 'fa-user'"
+            ></i>
+            <span class="part-nick" :title="id">{{ id }}</span>
+            <button
+              v-if="amOp"
+              type="button"
+              class="mod"
+              title="Mute in call"
+              @click="moderate(id, 'mute')"
+            >
+              <i class="fa-solid fa-microphone-slash"></i>
+            </button>
+            <button
+              v-if="amOp"
+              type="button"
+              class="mod danger"
+              title="Remove from call"
+              @click="moderate(id, 'remove')"
+            >
+              <i class="fa-solid fa-user-slash"></i>
+            </button>
+          </div>
+          <input
+            class="vol"
+            type="range"
+            min="0"
+            max="100"
+            :value="volPct(id)"
+            :aria-label="`Volume for ${id}`"
+            @input="onVol(id, $event)"
+          />
+        </li>
+      </ul>
+      <p v-else class="call-empty">Just you so far…</p>
     </div>
 
-    <ul v-if="voice.participants.length" class="call-parts">
-      <li
-        v-for="id in voice.participants"
-        :key="id"
-        :class="{ talking: voice.speaking.includes(id) }"
-      >
-        <div class="part-row">
-          <i
-            class="fa-solid"
-            :class="voice.speaking.includes(id) ? 'fa-volume-high' : 'fa-user'"
-          ></i>
-          <span class="part-nick" :title="id">{{ id }}</span>
-          <button
-            v-if="amOp"
-            type="button"
-            class="mod"
-            title="Mute in call"
-            @click="moderate(id, 'mute')"
-          >
-            <i class="fa-solid fa-microphone-slash"></i>
-          </button>
-          <button
-            v-if="amOp"
-            type="button"
-            class="mod danger"
-            title="Remove from call"
-            @click="moderate(id, 'remove')"
-          >
-            <i class="fa-solid fa-user-slash"></i>
-          </button>
-        </div>
-        <input
-          class="vol"
-          type="range"
-          min="0"
-          max="100"
-          :value="volPct(id)"
-          :aria-label="`Volume for ${id}`"
-          @input="onVol(id, $event)"
-        />
-      </li>
-    </ul>
-    <p v-else class="call-empty">Just you so far…</p>
-
     <div class="call-actions">
-      <button type="button" :class="{ muted: voice.muted }" @click="voice.toggleMute()">
+      <button
+        type="button"
+        class="act"
+        :class="{ active: !voice.muted }"
+        :title="voice.muted ? 'Unmute' : 'Mute'"
+        @click="voice.toggleMute()"
+      >
         <i :class="voice.muted ? 'fa-solid fa-microphone-slash' : 'fa-solid fa-microphone'"></i>
-        {{ voice.muted ? 'Unmute' : 'Mute' }}
       </button>
       <button
         type="button"
-        class="icon-btn"
-        :class="{ on: voice.cameraOn }"
+        class="act"
+        :class="{ active: voice.cameraOn }"
         title="Toggle camera"
         @click="voice.toggleCamera()"
       >
@@ -92,15 +100,15 @@
       </button>
       <button
         type="button"
-        class="icon-btn"
-        :class="{ on: voice.screenOn }"
+        class="act"
+        :class="{ active: voice.screenOn }"
         title="Share screen"
         @click="voice.toggleScreen()"
       >
         <i class="fa-solid fa-desktop"></i>
       </button>
-      <button type="button" class="leave" @click="voice.leave()">
-        <i class="fa-solid fa-phone-slash"></i> Leave
+      <button type="button" class="act leave" title="Leave call" @click="voice.leave()">
+        <i class="fa-solid fa-phone-slash"></i>
       </button>
     </div>
 
@@ -109,7 +117,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, onBeforeUnmount } from 'vue';
 import { useVoiceStore } from '../stores/voice.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useNetworksStore } from '../stores/networks.js';
@@ -121,8 +129,34 @@ const buffers = useBuffersStore();
 const networks = useNetworksStore();
 const statusText = computed(() => (voice.connecting ? 'Connecting…' : 'Connected'));
 
-// Am I an operator of the call's channel? Gates the mute/remove controls (the
-// server enforces this too). Guests never moderate.
+// ─── Drag ──────────────────────────────────────────────────────────────────
+const pos = ref<{ x: number; y: number } | null>(null);
+let offset = { x: 0, y: 0 };
+const barStyle = computed(() =>
+  pos.value
+    ? { left: `${pos.value.x}px`, top: `${pos.value.y}px`, right: 'auto', bottom: 'auto' }
+    : {},
+);
+function onHeaderDown(e: PointerEvent) {
+  const bar = (e.currentTarget as HTMLElement).closest('.call-bar') as HTMLElement | null;
+  if (!bar) return;
+  const rect = bar.getBoundingClientRect();
+  offset = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  window.addEventListener('pointermove', onMove);
+  window.addEventListener('pointerup', onUp);
+}
+function onMove(e: PointerEvent) {
+  const x = Math.max(4, Math.min(window.innerWidth - 60, e.clientX - offset.x));
+  const y = Math.max(4, Math.min(window.innerHeight - 40, e.clientY - offset.y));
+  pos.value = { x, y };
+}
+function onUp() {
+  window.removeEventListener('pointermove', onMove);
+  window.removeEventListener('pointerup', onUp);
+}
+onBeforeUnmount(onUp);
+
+// ─── Op moderation ─────────────────────────────────────────────────────────
 const MODERATE_MODES = ['q', 'a', 'o', 'h'];
 const amOp = computed(() => {
   if (voice.isGuest || voice.networkId == null) return false;
@@ -139,7 +173,6 @@ function volPct(id: string): number {
 function onVol(id: string, e: Event) {
   voice.setVolume(id, Number((e.target as HTMLInputElement).value) / 100);
 }
-
 async function moderate(identity: string, action: 'mute' | 'remove') {
   if (voice.networkId == null) return;
   try {
@@ -159,35 +192,75 @@ async function moderate(identity: string, action: 'mute' | 'remove') {
   right: 1rem;
   bottom: 1rem;
   z-index: 60;
-  width: 15rem;
-  padding: 0.75rem;
-  border-radius: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  width: 16rem;
+  max-width: calc(100vw - 2rem);
+  max-height: calc(100vh - 2rem);
+  min-width: 13rem;
+  min-height: 5rem;
+  border-radius: 0.6rem;
   background: var(--panel-bg, #1b1d24);
   color: var(--text, #e7e9ee);
   border: 1px solid var(--border, #2c2f38);
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
   font-size: 0.85rem;
+  overflow: hidden;
+  resize: both;
+}
+.call-bar.has-video {
+  width: 32rem;
+  min-height: 16rem;
 }
 .call-head {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  margin-bottom: 0.5rem;
+  gap: 0.45rem;
+  padding: 0.5rem 0.65rem;
+  border-bottom: 1px solid var(--border, #2c2f38);
+  cursor: move;
+  user-select: none;
+  touch-action: none;
+  flex: 0 0 auto;
+}
+.dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--fg-muted, #9aa0ac);
+  flex: 0 0 auto;
+}
+.dot.live {
+  background: #3ddc84;
+  box-shadow: 0 0 0 3px rgba(61, 220, 132, 0.18);
 }
 .call-title {
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .call-status {
   margin-left: auto;
-  opacity: 0.7;
-  font-size: 0.75rem;
+  opacity: 0.65;
+  font-size: 0.72rem;
+}
+.call-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 0.6rem;
+  min-height: 0;
+}
+.video-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
 }
 .call-parts {
   list-style: none;
-  margin: 0 0 0.5rem;
+  margin: 0;
   padding: 0;
-  max-height: 8rem;
-  overflow-y: auto;
 }
 .call-parts li {
   padding: 0.15rem 0;
@@ -222,58 +295,50 @@ async function moderate(identity: string, action: 'mute' | 'remove') {
 }
 .vol {
   width: 100%;
-  height: 0.6rem;
+  height: 0.55rem;
   margin-top: 0.1rem;
   cursor: pointer;
-}
-.call-bar.has-video {
-  width: 30rem;
-  max-width: calc(100vw - 2rem);
-}
-.video-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(8.5rem, 1fr));
-  gap: 0.35rem;
-  margin-bottom: 0.5rem;
-  max-height: 24rem;
-  overflow-y: auto;
+  accent-color: var(--accent, #6ea8fe);
 }
 .call-empty {
-  margin: 0 0 0.5rem;
-  opacity: 0.6;
-}
-.call-actions .icon-btn {
-  flex: 0 0 auto;
-}
-.call-actions button.on {
-  background: var(--accent, #6ea8fe);
-  color: #08101f;
+  margin: 0;
+  opacity: 0.55;
 }
 .call-actions {
   display: flex;
   gap: 0.4rem;
+  padding: 0.5rem 0.6rem;
+  border-top: 1px solid var(--border, #2c2f38);
+  flex: 0 0 auto;
 }
-.call-actions button {
+.call-actions .act {
   flex: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.3rem;
-  padding: 0.35rem 0.5rem;
-  border-radius: 0.35rem;
+  height: 2rem;
+  border-radius: 0.4rem;
   border: 1px solid var(--border, #2c2f38);
   background: var(--button-bg, #262933);
   color: inherit;
   cursor: pointer;
+  font-size: 0.9rem;
 }
-.call-actions button.muted {
-  background: var(--warn-bg, #5a4a1e);
+.call-actions .act:hover {
+  border-color: var(--accent, #6ea8fe);
 }
-.call-actions button.leave {
+.call-actions .act.active {
+  background: var(--accent, #6ea8fe);
+  color: #08101f;
+  border-color: transparent;
+}
+.call-actions .act.leave {
   background: var(--danger-bg, #6e2b2b);
+  color: #ffdede;
 }
 .call-error {
-  margin: 0.5rem 0 0;
+  margin: 0;
+  padding: 0 0.6rem 0.5rem;
   color: var(--danger, #ff6b6b);
   font-size: 0.75rem;
 }

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -10,12 +10,36 @@
         type="button"
         class="call-btn"
         :disabled="voice.connecting || voice.active"
-        :title="voice.active ? 'Already in a call' : 'Start a voice call in this channel'"
+        :title="voice.active ? 'Already in a call' : 'Start or join a voice call in this channel'"
         @click="startCall"
       >
         <i class="fa-solid fa-phone"></i>
-        <span>{{ voice.active ? 'In call' : 'Call' }}</span>
+        <span>{{ callBtnLabel }}</span>
       </button>
+      <div v-if="isOp" class="call-admin">
+        <label class="policy" title="Who may join this channel's call">
+          <span>Join</span>
+          <select :value="policy" @change="onPolicyChange">
+            <option value="none">anyone</option>
+            <option value="voice">voiced+</option>
+            <option value="halfop">halfop+</option>
+            <option value="op">ops only</option>
+          </select>
+        </label>
+        <button
+          type="button"
+          class="guest-btn"
+          :disabled="guestBusy"
+          title="Create a public link a guest can use to join without an account"
+          @click="createGuestLink"
+        >
+          <i class="fa-solid fa-link"></i> Guest link
+        </button>
+      </div>
+      <div v-if="guestUrl" class="guest-url">
+        <input :value="guestUrl" readonly aria-label="Guest call link" @focus="selectAll" />
+        <button type="button" @click="copyGuest">{{ copied ? 'Copied' : 'Copy' }}</button>
+      </div>
     </div>
     <ul ref="listEl">
       <li
@@ -59,6 +83,8 @@ import { useMemberActions } from '../composables/useMemberActions.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useConfigStore } from '../stores/config.js';
 import { useVoiceStore } from '../stores/voice.js';
+import { useCallPresenceStore } from '../stores/callPresence.js';
+import { api } from '../api.js';
 import {
   PREFIX_ORDER,
   prefixOf as modePrefixOf,
@@ -102,6 +128,95 @@ const selfModes = computed<string[]>(() => {
   const me = members.value.find((m) => nickOf(m).toLowerCase() === sn.toLowerCase());
   return me && Array.isArray(me.modes) ? me.modes : [];
 });
+
+// ─── Voice: join-with-count, op join policy, op guest links ─────────────────
+const callPresence = useCallPresenceStore();
+const OP_MODES = ['q', 'a', 'o'];
+const isOp = computed(() => selfModes.value.some((m) => OP_MODES.includes(m)));
+
+const inThisCall = computed(
+  () =>
+    voice.active &&
+    voice.networkId === (buffer.value?.networkId ?? null) &&
+    voice.target === buffer.value?.target,
+);
+const callCount = computed(() => {
+  const b = buffer.value;
+  return b?.networkId != null ? callPresence.countFor(b.networkId, b.target) : 0;
+});
+const callBtnLabel = computed(() => {
+  if (inThisCall.value) return 'In call';
+  if (callCount.value > 0) return `Join call (${callCount.value})`;
+  return 'Call';
+});
+
+const policy = ref('none');
+const guestUrl = ref('');
+const guestBusy = ref(false);
+const copied = ref(false);
+
+// Load the channel's join policy whenever the active channel changes (any member
+// may read it; only ops see/change the control).
+watch(
+  buffer,
+  async (b) => {
+    guestUrl.value = '';
+    copied.value = false;
+    policy.value = 'none';
+    if (!config.voiceEnabled || !b || b.kind !== 'channel' || b.networkId == null) return;
+    try {
+      const r = await api<{ minJoinMode: string }>(
+        `/api/voice/policy?networkId=${b.networkId}&target=${encodeURIComponent(b.target)}`,
+      );
+      policy.value = r.minJoinMode;
+    } catch {
+      /* leave default */
+    }
+  },
+  { immediate: true },
+);
+
+async function onPolicyChange(e: Event) {
+  const b = buffer.value;
+  if (!b || b.networkId == null) return;
+  const minJoinMode = (e.target as HTMLSelectElement).value;
+  try {
+    const r = await api<{ minJoinMode: string }>('/api/voice/policy', {
+      method: 'PUT',
+      body: { networkId: b.networkId, target: b.target, minJoinMode },
+    });
+    policy.value = r.minJoinMode;
+  } catch {
+    /* keep previous */
+  }
+}
+
+async function createGuestLink() {
+  const b = buffer.value;
+  if (!b || b.networkId == null) return;
+  guestBusy.value = true;
+  copied.value = false;
+  try {
+    const r = await api<{ url: string }>('/api/voice/guest-link', {
+      method: 'POST',
+      body: { networkId: b.networkId, target: b.target },
+    });
+    guestUrl.value = r.url;
+  } catch {
+    /* ignore */
+  } finally {
+    guestBusy.value = false;
+  }
+}
+
+function copyGuest() {
+  if (!guestUrl.value) return;
+  void navigator.clipboard?.writeText(guestUrl.value);
+  copied.value = true;
+}
+function selectAll(e: FocusEvent) {
+  (e.target as HTMLInputElement).select();
+}
 
 watch(
   () => networks.activeKey,
@@ -238,6 +353,61 @@ const sorted = computed(() => {
 .call-btn:disabled {
   opacity: 0.6;
   cursor: default;
+}
+.call-admin {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+}
+.call-admin .policy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--fg-muted);
+}
+.call-admin select {
+  background: var(--button-bg, #262933);
+  color: inherit;
+  border: 1px solid var(--border, #2c2f38);
+  border-radius: 0.25rem;
+  padding: 0.1rem 0.2rem;
+}
+.guest-btn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--border, #2c2f38);
+  background: var(--button-bg, #262933);
+  color: inherit;
+  cursor: pointer;
+}
+.guest-url {
+  display: flex;
+  gap: 0.3rem;
+  margin-top: 0.35rem;
+}
+.guest-url input {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.3rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--border, #2c2f38);
+  background: var(--bg-soft, #14161c);
+  color: inherit;
+}
+.guest-url button {
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--border, #2c2f38);
+  background: var(--button-bg, #262933);
+  color: inherit;
+  cursor: pointer;
 }
 ul {
   list-style: none;

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -5,6 +5,18 @@
 
 <template>
   <div class="members">
+    <div v-if="canCall" class="members-head">
+      <button
+        type="button"
+        class="call-btn"
+        :disabled="voice.connecting || voice.active"
+        :title="voice.active ? 'Already in a call' : 'Start a voice call in this channel'"
+        @click="startCall"
+      >
+        <i class="fa-solid fa-phone"></i>
+        <span>{{ voice.active ? 'In call' : 'Call' }}</span>
+      </button>
+    </div>
     <ul ref="listEl">
       <li
         v-for="m in sorted"
@@ -45,6 +57,8 @@ import { useBuffersStore, type BufferMember } from '../stores/buffers.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useMemberActions } from '../composables/useMemberActions.js';
 import { useIgnoresStore } from '../stores/ignores.js';
+import { useConfigStore } from '../stores/config.js';
+import { useVoiceStore } from '../stores/voice.js';
 import {
   PREFIX_ORDER,
   prefixOf as modePrefixOf,
@@ -57,11 +71,24 @@ const buffers = useBuffersStore();
 const nicks = useNickColors();
 const memberActions = useMemberActions();
 const ignores = useIgnoresStore();
+const config = useConfigStore();
+const voice = useVoiceStore();
 const modalMember = ref<BufferMember | null>(null);
 const listEl = ref<HTMLElement | null>(null);
 
 const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
 const members = computed((): BufferMember[] => buffer.value?.members || []);
+
+// Voice-call affordance: channels only, and only when the server advertises it.
+const canCall = computed(
+  () => config.voiceEnabled && buffer.value?.kind === 'channel' && buffer.value?.networkId != null,
+);
+function startCall() {
+  const b = buffer.value;
+  if (!b || b.networkId == null) return;
+  // label = the channel target; the store mints its own token + room.
+  voice.startCall(b.networkId, b.target, b.target);
+}
 const selfNick = computed(() => {
   const b = buffer.value;
   if (!b || b.networkId == null) return null;
@@ -190,6 +217,27 @@ const sorted = computed(() => {
   flex-direction: column;
   height: 100%;
   min-height: 0;
+}
+.members-head {
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border, #2c2f38);
+}
+.call-btn {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.35rem;
+  border: 1px solid var(--border, #2c2f38);
+  background: var(--button-bg, #262933);
+  color: inherit;
+  cursor: pointer;
+}
+.call-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 ul {
   list-style: none;

--- a/vue_client/src/components/VideoTile.vue
+++ b/vue_client/src/components/VideoTile.vue
@@ -1,0 +1,83 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  One video tile in the call panel. It owns the attach/detach of its LiveKit
+  track to the <video> element — REQUIRED for adaptiveStream to deliver remote
+  video (an unattached/hidden track never starts). Self camera tiles are mirrored
+  and muted; screen-share tiles are letterboxed (contain) and always muted here
+  (you don't play your own screen audio back).
+-->
+
+<template>
+  <div class="video-tile" :class="{ screen: source === 'screen_share' }">
+    <video
+      ref="el"
+      autoplay
+      playsinline
+      :muted="self"
+      :class="{ mirror: self && source !== 'screen_share' }"
+    ></video>
+    <span class="tile-label">
+      <i v-if="source === 'screen_share'" class="fa-solid fa-desktop"></i>
+      {{ self ? 'You' : identity }}<span v-if="source === 'screen_share'"> · screen</span>
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import { useVoiceStore } from '../stores/voice.js';
+
+const props = defineProps<{ identity: string; source: string; self: boolean }>();
+const voice = useVoiceStore();
+const el = ref<HTMLVideoElement | null>(null);
+
+onMounted(() => {
+  if (el.value) voice.attachVideo(props.identity, props.source, el.value, props.self);
+});
+onBeforeUnmount(() => {
+  if (el.value) voice.detachVideo(props.identity, props.source, el.value, props.self);
+});
+</script>
+
+<style scoped>
+.video-tile {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background: #000;
+  border-radius: 0.35rem;
+  overflow: hidden;
+  border: 1px solid var(--border, #2c2f38);
+}
+.video-tile video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.video-tile.screen video {
+  object-fit: contain;
+  background: #000;
+}
+.video-tile video.mirror {
+  transform: scaleX(-1);
+}
+.tile-label {
+  position: absolute;
+  left: 0.25rem;
+  bottom: 0.25rem;
+  max-width: calc(100% - 0.5rem);
+  padding: 0.05rem 0.3rem;
+  border-radius: 0.25rem;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/vue_client/src/components/VideoTile.vue
+++ b/vue_client/src/components/VideoTile.vue
@@ -5,12 +5,12 @@
   One video tile in the call panel. It owns the attach/detach of its LiveKit
   track to the <video> element — REQUIRED for adaptiveStream to deliver remote
   video (an unattached/hidden track never starts). Self camera tiles are mirrored
-  and muted; screen-share tiles are letterboxed (contain) and always muted here
-  (you don't play your own screen audio back).
+  and muted; screen-share tiles are letterboxed. A hover button fullscreens the
+  tile.
 -->
 
 <template>
-  <div class="video-tile" :class="{ screen: source === 'screen_share' }">
+  <div ref="tileEl" class="video-tile" :class="{ screen: source === 'screen_share' }">
     <video
       ref="el"
       autoplay
@@ -18,6 +18,9 @@
       :muted="self"
       :class="{ mirror: self && source !== 'screen_share' }"
     ></video>
+    <button type="button" class="fs" title="Fullscreen" @click="fullscreen">
+      <i class="fa-solid fa-expand"></i>
+    </button>
     <span class="tile-label">
       <i v-if="source === 'screen_share'" class="fa-solid fa-desktop"></i>
       {{ self ? 'You' : identity }}<span v-if="source === 'screen_share'"> · screen</span>
@@ -32,6 +35,14 @@ import { useVoiceStore } from '../stores/voice.js';
 const props = defineProps<{ identity: string; source: string; self: boolean }>();
 const voice = useVoiceStore();
 const el = ref<HTMLVideoElement | null>(null);
+const tileEl = ref<HTMLElement | null>(null);
+
+function fullscreen() {
+  const node = tileEl.value;
+  if (!node) return;
+  if (document.fullscreenElement) void document.exitFullscreen();
+  else void node.requestFullscreen?.();
+}
 
 onMounted(() => {
   if (el.value) voice.attachVideo(props.identity, props.source, el.value, props.self);
@@ -46,7 +57,7 @@ onBeforeUnmount(() => {
   position: relative;
   aspect-ratio: 16 / 9;
   background: #000;
-  border-radius: 0.35rem;
+  border-radius: 0.4rem;
   overflow: hidden;
   border: 1px solid var(--border, #2c2f38);
 }
@@ -62,6 +73,36 @@ onBeforeUnmount(() => {
 }
 .video-tile video.mirror {
   transform: scaleX(-1);
+}
+/* When a tile is the fullscreen element, fill the screen and letterbox. */
+.video-tile:fullscreen {
+  aspect-ratio: auto;
+  border: none;
+  border-radius: 0;
+}
+.video-tile:fullscreen video {
+  object-fit: contain;
+}
+.fs {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 0.25rem;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 80ms linear;
+}
+.video-tile:hover .fs,
+.fs:focus-visible {
+  opacity: 1;
 }
 .tile-label {
   position: absolute;

--- a/vue_client/src/composables/useCallPresenceHydration.ts
+++ b/vue_client/src/composables/useCallPresenceHydration.ts
@@ -11,7 +11,7 @@
 // Detached, idempotent module singleton — mirrors startBufferHydration so it
 // survives the Desktop<->Mobile shell swap without double-registering.
 
-import { effectScope, watch } from 'vue';
+import { computed, effectScope, watch } from 'vue';
 import { connected } from './useSocket.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useConfigStore } from '../stores/config.js';
@@ -28,19 +28,28 @@ export function startCallPresenceHydration(): void {
     const config = useConfigStore();
     const presence = useCallPresenceStore();
 
-    const hydrateAll = (): void => {
-      if (!connected.value || !config.voiceEnabled) return;
-      for (const n of networks.networks) {
-        if (networks.states[n.id]?.state === 'connected') void presence.hydrate(n.id);
-      }
-    };
+    // The set of networks we can meaningfully hydrate right now, as a stable
+    // string key. Watching this (not the raw `connected` edge) is what makes
+    // hydration reliable: a network's per-connection state arrives over the WS
+    // *after* the socket opens, and voiceEnabled lands after the config fetch —
+    // so a one-shot fire on the connect edge would run before either was ready
+    // and never retry. Re-deriving from all three reactive inputs means we fire
+    // the moment a network actually becomes connected, on every reconnect, and
+    // if voice is enabled late.
+    const hydratableKey = computed(() => {
+      if (!connected.value || !config.voiceEnabled) return '';
+      return networks.networks
+        .filter((n) => networks.states[n.id]?.state === 'connected')
+        .map((n) => n.id)
+        .sort((a, b) => a - b)
+        .join(',');
+    });
 
-    // immediate: reconcile the initial connected state on cold launch, not just
-    // later transitions. Re-runs on every reconnect edge.
     watch(
-      connected,
-      (isUp) => {
-        if (isUp) hydrateAll();
+      hydratableKey,
+      (key) => {
+        if (!key) return;
+        for (const id of key.split(',')) void presence.hydrate(Number(id));
       },
       { immediate: true },
     );

--- a/vue_client/src/composables/useCallPresenceHydration.ts
+++ b/vue_client/src/composables/useCallPresenceHydration.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Keeps voice-call presence badges correct across connect/reconnect edges. The
+// server's `call-presence` frame only carries live join/leave deltas, so a
+// client that connects (cold launch) or reconnects mid-call would otherwise
+// never learn about a call that started while it had no socket. On each connect
+// edge we re-snapshot every connected network's active calls from the server
+// (which reads the SFU — correct even across a Lurker restart).
+//
+// Detached, idempotent module singleton — mirrors startBufferHydration so it
+// survives the Desktop<->Mobile shell swap without double-registering.
+
+import { effectScope, watch } from 'vue';
+import { connected } from './useSocket.js';
+import { useNetworksStore } from '../stores/networks.js';
+import { useConfigStore } from '../stores/config.js';
+import { useCallPresenceStore } from '../stores/callPresence.js';
+
+let started = false;
+
+export function startCallPresenceHydration(): void {
+  if (started) return;
+  started = true;
+
+  effectScope(true).run(() => {
+    const networks = useNetworksStore();
+    const config = useConfigStore();
+    const presence = useCallPresenceStore();
+
+    const hydrateAll = (): void => {
+      if (!connected.value || !config.voiceEnabled) return;
+      for (const n of networks.networks) {
+        if (networks.states[n.id]?.state === 'connected') void presence.hydrate(n.id);
+      }
+    };
+
+    // immediate: reconcile the initial connected state on cold launch, not just
+    // later transitions. Re-runs on every reconnect edge.
+    watch(
+      connected,
+      (isUp) => {
+        if (isUp) hydrateAll();
+      },
+      { immediate: true },
+    );
+  });
+}

--- a/vue_client/src/composables/useChatBootstrap.ts
+++ b/vue_client/src/composables/useChatBootstrap.ts
@@ -13,6 +13,7 @@ import { onJumpIntent } from './useJumpIntent.js';
 import { connected } from './useSocket.js';
 import { startAppBadge } from './useAppBadge.js';
 import { startBufferHydration } from './useBufferHydration.js';
+import { startCallPresenceHydration } from './useCallPresenceHydration.js';
 import type { JumpTarget } from './useJumpToMessage.js';
 
 // How long to wait for the app to become able to honor a cold-start deep link
@@ -69,7 +70,12 @@ export function consumeColdStartJump(
   const parsed = msg != null && msg !== '' ? Number(msg) : null;
   const messageId = parsed != null && Number.isFinite(parsed) ? parsed : null;
 
-  const payload: JumpPayload = { kind: 'jump', networkId, target: buf, messageId };
+  const payload: JumpPayload = {
+    kind: 'jump',
+    networkId,
+    target: buf,
+    messageId,
+  };
   const ready = (): boolean => connected.value && buffers.isOpen(networkId, buf);
   if (ready()) {
     onJump(payload);
@@ -155,6 +161,9 @@ export function useChatBootstrap({ onJump }: ChatBootstrapOptions = {}): void {
     // send failures (idempotent module singleton, like the presence reporter —
     // survives the Desktop<->Mobile shell swap without double-registering).
     startBufferHydration();
+    // Re-snapshot voice-call presence on each connect edge, so badges show for
+    // calls that began while this client was away (webhooks only push deltas).
+    startCallPresenceHydration();
     // Mirror the unread-highlight total onto the PWA app icon (#451). Idempotent
     // and feature-detected — a no-op where the Badging API is unavailable.
     startAppBadge();

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -250,11 +250,6 @@ function applyEvent(event: any): void {
     case 'lag':
       networks.applyLag(event);
       break;
-    case 'call-presence':
-      // A voice call's participant count changed in a channel; surface a badge
-      // to users who aren't in the call. (Voice / #680.)
-      useCallPresenceStore().set(event.networkId, event.target, event.count);
-      break;
     case 'usermode':
       networks.applyUserMode(event);
       break;
@@ -611,6 +606,17 @@ function handleMessage(raw: string): void {
     // cursor (#355).
     if (payload.networkId != null) trackSeenId(payload.id);
     applyEvent(payload);
+    return;
+  }
+  if (payload.kind === 'call-presence') {
+    // A voice call's participant count changed in a channel; surface a badge to
+    // users who aren't in the call. Its own top-level frame (not an 'irc' event)
+    // so it never rides the resume cursor. (Voice / #680.)
+    useCallPresenceStore().set(
+      payload.networkId as number,
+      payload.target as string,
+      payload.count as number,
+    );
     return;
   }
   if (payload.kind === 'account-state') {

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -23,6 +23,7 @@ import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useDataExportStore } from '../stores/dataExport.js';
 import { useDccStore } from '../stores/dcc.js';
+import { useCallPresenceStore } from '../stores/callPresence.js';
 import { useUploadsStore } from '../stores/uploads.js';
 import { makeClientId } from '../utils/clientId.js';
 import { useToastsStore } from '../stores/toasts.js';
@@ -248,6 +249,11 @@ function applyEvent(event: any): void {
       break;
     case 'lag':
       networks.applyLag(event);
+      break;
+    case 'call-presence':
+      // A voice call's participant count changed in a channel; surface a badge
+      // to users who aren't in the call. (Voice / #680.)
+      useCallPresenceStore().set(event.networkId, event.target, event.count);
       break;
     case 'usermode':
       networks.applyUserMode(event);

--- a/vue_client/src/router.ts
+++ b/vue_client/src/router.ts
@@ -11,6 +11,14 @@ const routes: RouteRecordRaw[] = [
   { path: '/login', name: 'login', component: () => import('./views/Login.vue') },
   { path: '/invite/:token', name: 'invite', component: () => import('./views/InviteAccept.vue') },
   {
+    // Public guest voice-call page — no auth. The :token is a capability link an
+    // op minted (POST /api/voice/guest-link); the page exchanges it for a
+    // room-scoped LiveKit token. Deliberately has NO requiresAuth meta.
+    path: '/call/:token',
+    name: 'guest-call',
+    component: () => import('./views/GuestCall.vue'),
+  },
+  {
     path: '/',
     name: 'chat',
     component: () => import('./views/Chat.vue'),

--- a/vue_client/src/stores/callPresence.ts
+++ b/vue_client/src/stores/callPresence.ts
@@ -7,6 +7,7 @@
 // which is driven by LiveKit webhooks. Same-instance only.
 
 import { defineStore } from 'pinia';
+import { api } from '../api.js';
 
 function key(networkId: number | null, target: string): string {
   return `${networkId ?? ''}::${target.toLowerCase()}`;
@@ -28,6 +29,28 @@ export const useCallPresenceStore = defineStore('callPresence', {
       const k = key(networkId, target);
       if (count > 0) this.counts[k] = count;
       else delete this.counts[k];
+    },
+
+    /** Replace this network's known call counts with a fresh server snapshot.
+     *  Called on each (re)connect edge to catch calls that started while we had
+     *  no socket — the `call-presence` frame only carries live deltas, so without
+     *  this a client that joins mid-call never sees the badge. Best-effort: on
+     *  failure we keep whatever deltas have arrived. */
+    async hydrate(networkId: number) {
+      let calls: Array<{ target: string; count: number }>;
+      try {
+        const r = await api<{
+          calls: Array<{ target: string; count: number }>;
+        }>(`/api/voice/presence?networkId=${networkId}`);
+        calls = r.calls ?? [];
+      } catch {
+        return;
+      }
+      // Drop stale entries for this network before applying the snapshot, so a
+      // call that ended while we were away clears rather than lingering.
+      const prefix = `${networkId}::`;
+      for (const k of Object.keys(this.counts)) if (k.startsWith(prefix)) delete this.counts[k];
+      for (const c of calls) this.set(networkId, c.target, c.count);
     },
   },
 });

--- a/vue_client/src/stores/callPresence.ts
+++ b/vue_client/src/stores/callPresence.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Tracks which channels currently have an active voice call, so the UI can show
+// a badge / "Join call (N)" even for users who are not in the call. Fed by the
+// server's `call-presence` frame (see routes/voice.ts broadcastCallPresence),
+// which is driven by LiveKit webhooks. Same-instance only.
+
+import { defineStore } from 'pinia';
+
+function key(networkId: number | null, target: string): string {
+  return `${networkId ?? ''}::${target.toLowerCase()}`;
+}
+
+export const useCallPresenceStore = defineStore('callPresence', {
+  state: () => ({
+    // `${networkId}::${foldedTarget}` → participant count (absent = no call).
+    counts: {} as Record<string, number>,
+  }),
+  getters: {
+    countFor:
+      (s) =>
+      (networkId: number | null, target: string): number =>
+        s.counts[key(networkId, target)] ?? 0,
+  },
+  actions: {
+    set(networkId: number, target: string, count: number) {
+      const k = key(networkId, target);
+      if (count > 0) this.counts[k] = count;
+      else delete this.counts[k];
+    },
+  },
+});

--- a/vue_client/src/stores/config.ts
+++ b/vue_client/src/stores/config.ts
@@ -21,6 +21,10 @@ let inflight: Promise<Edition> | null = null;
 export const useConfigStore = defineStore('config', {
   state: () => ({
     edition: 'standalone' as Edition,
+    // Whether this instance offers voice calls (operator opt-in + a configured
+    // LiveKit SFU). Defaults false so a fetch failure hides the call UI rather
+    // than surfacing a button that can only 503.
+    voiceEnabled: false,
     checked: false,
   }),
   getters: {
@@ -33,8 +37,9 @@ export const useConfigStore = defineStore('config', {
       if (inflight) return inflight; // a fetch is in flight — share its result
       inflight = (async () => {
         try {
-          const data = await api<{ edition?: string }>('/api/config');
+          const data = await api<{ edition?: string; voiceEnabled?: boolean }>('/api/config');
           this.edition = data.edition === 'node' ? 'node' : 'standalone';
+          this.voiceEnabled = data.voiceEnabled === true;
           // Latch `checked` ONLY on success. A transient failure must not wedge
           // the session on the safe defaults — leaving it false lets the next
           // caller retry and self-heal. That second caller is the router guard,

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -2,24 +2,29 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // Voice call session for the web client. The browser IS the WebRTC engine here,
-// so unlike the native client this is thin: mint a room-scoped token from
-// /api/voice/token, connect the LiveKit room, publish the mic, and let
-// livekit-client attach <audio> elements for remote participants (they autoplay).
+// so unlike the native client this is thin: get a room-scoped token (from
+// /api/voice/token for members, or /api/voice/guest-token for a public guest),
+// connect the LiveKit room, publish the mic, and let livekit-client attach
+// <audio> elements for remote participants (they autoplay).
 //
 // Bundle bloat, addressed: livekit-client is ~500 KB, and voice is off by
 // default on most instances. So it is pulled in with a dynamic import() inside
-// startCall — Vite splits it into its own chunk that is fetched only when a user
-// actually places a call. It never touches the initial page load. `import type`
-// is erased at build time, so the type-only imports below add nothing to any
-// bundle.
+// the connect path — Vite splits it into its own chunk fetched only when a user
+// actually places a call. It never touches the initial page load.
 //
-// The Room and the attached <audio> elements are held module-scoped, NOT in
-// Pinia state: they are non-serializable and must not be wrapped in Vue's
-// reactive proxy, which would break livekit's internal object identity. State
-// carries only the primitives the UI renders.
+// The Room, attached <audio> elements, and per-identity RemoteAudioTracks are
+// held module-scoped, NOT in Pinia state: they are non-serializable and must not
+// be wrapped in Vue's reactive proxy, which would break livekit's object
+// identity. State carries only the primitives the UI renders.
 
 import { defineStore } from 'pinia';
-import type { Room, RemoteTrack, Participant } from 'livekit-client';
+import type {
+  Room,
+  RemoteTrack,
+  RemoteAudioTrack,
+  RemoteParticipant,
+  Participant,
+} from 'livekit-client';
 import { api } from '../api.js';
 
 interface VoiceTokenResponse {
@@ -31,6 +36,8 @@ interface VoiceTokenResponse {
 // Non-reactive session handles (see header note).
 let room: Room | null = null;
 let audioEls: HTMLAudioElement[] = [];
+// identity → its remote audio track, so we can set per-participant volume.
+let tracksByIdentity = new Map<string, RemoteAudioTrack>();
 
 export const useVoiceStore = defineStore('voice', {
   state: () => ({
@@ -39,40 +46,78 @@ export const useVoiceStore = defineStore('voice', {
     muted: false,
     // Human label for what's being called, e.g. "#dev".
     label: '',
+    // The channel/DM this call belongs to (for moderation + guest-link calls).
+    // Null for a guest session, which has no owning network.
+    networkId: null as number | null,
+    target: '',
+    // True when this tab joined via a public guest link (no account/session).
+    isGuest: false,
     // Remote participant identities (our IRC-nick convention).
     participants: [] as string[],
     // Subset of `participants` currently detected as speaking.
     speaking: [] as string[],
+    // Per-identity local playback volume, 0..1 (default 1 when absent).
+    volumes: {} as Record<string, number>,
     error: null as string | null,
   }),
   actions: {
+    // Member join: mint a token for a channel/DM, then connect.
     async startCall(networkId: number, target: string, label: string) {
       if (this.active || this.connecting) return;
       this.connecting = true;
       this.error = null;
       this.label = label;
+      this.networkId = networkId;
+      this.target = target;
+      this.isGuest = false;
       try {
         // Token first, so a 503/403/404 fails fast without paying to load the SDK.
         const { token, url } = await api<VoiceTokenResponse>('/api/voice/token', {
           method: 'POST',
           body: { networkId, target },
         });
+        await this.connectWithToken(url, token, label);
+      } catch (e: unknown) {
+        this.error = e instanceof Error ? e.message : 'could not start call';
+        await this.cleanup();
+        this.connecting = false;
+      }
+    },
 
+    // Shared connect path — used by member calls and by the public guest page
+    // (which has already exchanged its link token for a room token).
+    async connectWithToken(url: string, token: string, label: string, opts?: { guest?: boolean }) {
+      if (this.active) return;
+      this.connecting = true;
+      this.label = label;
+      if (opts?.guest) this.isGuest = true;
+      try {
         // Lazy chunk: livekit-client only lands over the network at first call.
         const { Room, RoomEvent, Track } = await import('livekit-client');
 
         const r = new Room({ adaptiveStream: true, dynacast: true });
-        r.on(RoomEvent.TrackSubscribed, (track: RemoteTrack) => {
-          if (track.kind === Track.Kind.Audio) {
-            const el = track.attach() as HTMLAudioElement;
-            el.autoplay = true;
-            document.body.appendChild(el);
-            audioEls.push(el);
-          }
-        })
-          .on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack) => {
-            track.detach().forEach((el) => el.remove());
-          })
+        r.on(
+          RoomEvent.TrackSubscribed,
+          (track: RemoteTrack, _pub, participant: RemoteParticipant) => {
+            if (track.kind === Track.Kind.Audio) {
+              const audio = track as RemoteAudioTrack;
+              tracksByIdentity.set(participant.identity, audio);
+              const stored = this.volumes[participant.identity];
+              if (stored != null) audio.setVolume(stored);
+              const el = audio.attach() as HTMLAudioElement;
+              el.autoplay = true;
+              document.body.appendChild(el);
+              audioEls.push(el);
+            }
+          },
+        )
+          .on(
+            RoomEvent.TrackUnsubscribed,
+            (track: RemoteTrack, _pub, participant: RemoteParticipant) => {
+              tracksByIdentity.delete(participant.identity);
+              track.detach().forEach((el) => el.remove());
+            },
+          )
           .on(RoomEvent.ParticipantConnected, () => this.syncParticipants())
           .on(RoomEvent.ParticipantDisconnected, () => this.syncParticipants())
           .on(RoomEvent.ActiveSpeakersChanged, (speakers: Participant[]) => {
@@ -88,9 +133,10 @@ export const useVoiceStore = defineStore('voice', {
         room = r;
         this.active = true;
         this.muted = false;
+        this.error = null;
         this.syncParticipants();
-      } catch (e: any) {
-        this.error = e?.message || 'could not start call';
+      } catch (e: unknown) {
+        this.error = e instanceof Error ? e.message : 'could not connect';
         await this.cleanup();
       } finally {
         this.connecting = false;
@@ -101,6 +147,14 @@ export const useVoiceStore = defineStore('voice', {
       this.participants = room
         ? Array.from(room.remoteParticipants.values()).map((p) => p.identity)
         : [];
+    },
+
+    /** Set a remote participant's local playback volume (0..1). Persisted so it
+     *  survives a track re-subscribe within the same session. */
+    setVolume(identity: string, volume: number) {
+      const v = Math.max(0, Math.min(1, volume));
+      this.volumes[identity] = v;
+      tracksByIdentity.get(identity)?.setVolume(v);
     },
 
     async toggleMute() {
@@ -124,11 +178,16 @@ export const useVoiceStore = defineStore('voice', {
       }
       audioEls.forEach((el) => el.remove());
       audioEls = [];
+      tracksByIdentity = new Map();
       this.active = false;
       this.connecting = false;
       this.muted = false;
       this.participants = [];
       this.speaking = [];
+      this.volumes = {};
+      this.networkId = null;
+      this.target = '';
+      this.isGuest = false;
     },
   },
 });

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -1,29 +1,38 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// Voice call session for the web client. The browser IS the WebRTC engine here,
-// so unlike the native client this is thin: get a room-scoped token (from
-// /api/voice/token for members, or /api/voice/guest-token for a public guest),
-// connect the LiveKit room, publish the mic, and let livekit-client attach
-// <audio> elements for remote participants (they autoplay).
+// Voice/video call session for the web client. The browser IS the WebRTC engine
+// here, so this is thin: get a room-scoped token (from /api/voice/token for
+// members, or /api/voice/guest-token for a public guest), connect the LiveKit
+// room, publish the mic (and optionally camera / screen), and render remote
+// tracks. Audio autoplays via a hidden <audio>; video is attached by the tile
+// components (see the adaptiveStream note below).
 //
-// Bundle bloat, addressed: livekit-client is ~500 KB, and voice is off by
-// default on most instances. So it is pulled in with a dynamic import() inside
-// the connect path — Vite splits it into its own chunk fetched only when a user
-// actually places a call. It never touches the initial page load.
+// Bundle bloat, addressed: livekit-client is ~500 KB and voice is off by default
+// on most instances, so it is pulled in with a dynamic import() inside the
+// connect path — Vite splits it into its own chunk fetched only at first call.
 //
-// The Room, attached <audio> elements, and per-identity RemoteAudioTracks are
-// held module-scoped, NOT in Pinia state: they are non-serializable and must not
-// be wrapped in Vue's reactive proxy, which would break livekit's object
-// identity. State carries only the primitives the UI renders.
+// The Room and all Track/element handles are held module-scoped, NOT in Pinia
+// state: they are non-serializable and must not be wrapped in Vue's reactive
+// proxy, which would break livekit's object identity. State carries only the
+// primitives the UI renders.
+//
+// adaptiveStream note: the Room uses adaptiveStream, so a remote *video* track
+// only starts flowing once it is attach()ed to a visible <video> element (and
+// pauses when hidden). So the store exposes video tracks and the VideoTile
+// components own the attach/detach lifecycle — video is NOT attached to a hidden
+// element here (audio is, which is correct for audio).
 
 import { defineStore } from 'pinia';
 import type {
   Room,
   RemoteTrack,
   RemoteAudioTrack,
+  RemoteVideoTrack,
   RemoteParticipant,
   Participant,
+  LocalTrackPublication,
+  LocalVideoTrack,
 } from 'livekit-client';
 import { api } from '../api.js';
 
@@ -33,21 +42,32 @@ interface VoiceTokenResponse {
   url: string;
 }
 
+export interface VideoTile {
+  identity: string;
+  source: string; // 'camera' | 'screen_share'
+  self: boolean;
+}
+
 // Non-reactive session handles (see header note).
 let room: Room | null = null;
 let audioEls: HTMLAudioElement[] = [];
-// identity → its remote audio track, so we can set per-participant volume.
+// identity → remote audio track, for per-participant volume.
 let tracksByIdentity = new Map<string, RemoteAudioTrack>();
+// `${identity}|${source}` → remote video track, attached by VideoTile.
+let videoTracksByKey = new Map<string, RemoteVideoTrack>();
+// source ('camera' | 'screen_share') → our own local video track, for self tiles.
+let localVideoTracks = new Map<string, LocalVideoTrack>();
 
 export const useVoiceStore = defineStore('voice', {
   state: () => ({
     active: false,
     connecting: false,
     muted: false,
+    cameraOn: false,
+    screenOn: false,
     // Human label for what's being called, e.g. "#dev".
     label: '',
     // The channel/DM this call belongs to (for moderation + guest-link calls).
-    // Null for a guest session, which has no owning network.
     networkId: null as number | null,
     target: '',
     // True when this tab joined via a public guest link (no account/session).
@@ -58,6 +78,8 @@ export const useVoiceStore = defineStore('voice', {
     speaking: [] as string[],
     // Per-identity local playback volume, 0..1 (default 1 when absent).
     volumes: {} as Record<string, number>,
+    // Video/screen tiles to render (self + remote).
+    videoTiles: [] as VideoTile[],
     error: null as string | null,
   }),
   actions: {
@@ -98,26 +120,55 @@ export const useVoiceStore = defineStore('voice', {
         const r = new Room({ adaptiveStream: true, dynacast: true });
         r.on(
           RoomEvent.TrackSubscribed,
-          (track: RemoteTrack, _pub, participant: RemoteParticipant) => {
+          (track: RemoteTrack, pub, participant: RemoteParticipant) => {
             if (track.kind === Track.Kind.Audio) {
               const audio = track as RemoteAudioTrack;
-              tracksByIdentity.set(participant.identity, audio);
-              const stored = this.volumes[participant.identity];
-              if (stored != null) audio.setVolume(stored);
+              // Attach ALL audio (mic + screen_share_audio) so both play; but only
+              // bind the per-participant volume slider to the mic track.
               const el = audio.attach() as HTMLAudioElement;
               el.autoplay = true;
               document.body.appendChild(el);
               audioEls.push(el);
+              if (String(pub.source) === 'microphone') {
+                tracksByIdentity.set(participant.identity, audio);
+                const stored = this.volumes[participant.identity];
+                if (stored != null) audio.setVolume(stored);
+              }
+            } else if (track.kind === Track.Kind.Video) {
+              const source = String(pub.source);
+              videoTracksByKey.set(`${participant.identity}|${source}`, track as RemoteVideoTrack);
+              this.addTile(participant.identity, source, false);
             }
           },
         )
           .on(
             RoomEvent.TrackUnsubscribed,
-            (track: RemoteTrack, _pub, participant: RemoteParticipant) => {
-              tracksByIdentity.delete(participant.identity);
+            (track: RemoteTrack, pub, participant: RemoteParticipant) => {
+              if (track.kind === Track.Kind.Audio) {
+                tracksByIdentity.delete(participant.identity);
+              } else if (track.kind === Track.Kind.Video) {
+                videoTracksByKey.delete(`${participant.identity}|${String(pub.source)}`);
+                this.removeTile(participant.identity, String(pub.source));
+              }
               track.detach().forEach((el) => el.remove());
             },
           )
+          .on(RoomEvent.LocalTrackPublished, (pub: LocalTrackPublication) => {
+            if (pub.track?.kind !== Track.Kind.Video) return;
+            const source = String(pub.source);
+            localVideoTracks.set(source, pub.track as LocalVideoTrack);
+            if (source === 'screen_share') this.screenOn = true;
+            else this.cameraOn = true;
+            this.addTile(r.localParticipant.identity, source, true);
+          })
+          .on(RoomEvent.LocalTrackUnpublished, (pub: LocalTrackPublication) => {
+            if (pub.track?.kind !== Track.Kind.Video) return;
+            const source = String(pub.source);
+            localVideoTracks.delete(source);
+            if (source === 'screen_share') this.screenOn = false;
+            else this.cameraOn = false;
+            this.removeTile(r.localParticipant.identity, source);
+          })
           .on(RoomEvent.ParticipantConnected, () => this.syncParticipants())
           .on(RoomEvent.ParticipantDisconnected, () => this.syncParticipants())
           .on(RoomEvent.ActiveSpeakersChanged, (speakers: Participant[]) => {
@@ -149,6 +200,32 @@ export const useVoiceStore = defineStore('voice', {
         : [];
     },
 
+    addTile(identity: string, source: string, self: boolean) {
+      if (!this.videoTiles.some((t) => t.identity === identity && t.source === source)) {
+        this.videoTiles.push({ identity, source, self });
+      }
+    },
+    removeTile(identity: string, source: string) {
+      this.videoTiles = this.videoTiles.filter(
+        (t) => !(t.identity === identity && t.source === source),
+      );
+    },
+
+    /** Attach a tile's track to its <video> element. VideoTile calls this on
+     *  mount — required for adaptiveStream to actually deliver remote video. */
+    attachVideo(identity: string, source: string, el: HTMLVideoElement, self: boolean) {
+      const track = self
+        ? localVideoTracks.get(source)
+        : videoTracksByKey.get(`${identity}|${source}`);
+      track?.attach(el);
+    },
+    detachVideo(identity: string, source: string, el: HTMLVideoElement, self: boolean) {
+      const track = self
+        ? localVideoTracks.get(source)
+        : videoTracksByKey.get(`${identity}|${source}`);
+      track?.detach(el);
+    },
+
     /** Set a remote participant's local playback volume (0..1). Persisted so it
      *  survives a track re-subscribe within the same session. */
     setVolume(identity: string, volume: number) {
@@ -161,6 +238,29 @@ export const useVoiceStore = defineStore('voice', {
       if (!room) return;
       this.muted = !this.muted;
       await room.localParticipant.setMicrophoneEnabled(!this.muted);
+    },
+
+    async toggleCamera() {
+      if (!room) return;
+      try {
+        // Flags + tiles are driven by LocalTrackPublished/Unpublished, so state
+        // stays correct even if the device fails or the user revokes permission.
+        await room.localParticipant.setCameraEnabled(!this.cameraOn);
+      } catch (e: unknown) {
+        this.error = e instanceof Error ? e.message : 'could not toggle camera';
+      }
+    },
+
+    async toggleScreen() {
+      if (!room) return;
+      try {
+        // { audio: true } also captures screen/tab audio where the browser+OS
+        // allow it (Chrome's "share tab audio"); it silently degrades to
+        // video-only otherwise.
+        await room.localParticipant.setScreenShareEnabled(!this.screenOn, { audio: true });
+      } catch {
+        /* user cancelled the screen picker — no-op */
+      }
     },
 
     async leave() {
@@ -179,12 +279,17 @@ export const useVoiceStore = defineStore('voice', {
       audioEls.forEach((el) => el.remove());
       audioEls = [];
       tracksByIdentity = new Map();
+      videoTracksByKey = new Map();
+      localVideoTracks = new Map();
       this.active = false;
       this.connecting = false;
       this.muted = false;
+      this.cameraOn = false;
+      this.screenOn = false;
       this.participants = [];
       this.speaking = [];
       this.volumes = {};
+      this.videoTiles = [];
       this.networkId = null;
       this.target = '';
       this.isGuest = false;

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Voice call session for the web client. The browser IS the WebRTC engine here,
+// so unlike the native client this is thin: mint a room-scoped token from
+// /api/voice/token, connect the LiveKit room, publish the mic, and let
+// livekit-client attach <audio> elements for remote participants (they autoplay).
+//
+// Bundle bloat, addressed: livekit-client is ~500 KB, and voice is off by
+// default on most instances. So it is pulled in with a dynamic import() inside
+// startCall — Vite splits it into its own chunk that is fetched only when a user
+// actually places a call. It never touches the initial page load. `import type`
+// is erased at build time, so the type-only imports below add nothing to any
+// bundle.
+//
+// The Room and the attached <audio> elements are held module-scoped, NOT in
+// Pinia state: they are non-serializable and must not be wrapped in Vue's
+// reactive proxy, which would break livekit's internal object identity. State
+// carries only the primitives the UI renders.
+
+import { defineStore } from 'pinia';
+import type { Room, RemoteTrack, Participant } from 'livekit-client';
+import { api } from '../api.js';
+
+interface VoiceTokenResponse {
+  token: string;
+  room: string;
+  url: string;
+}
+
+// Non-reactive session handles (see header note).
+let room: Room | null = null;
+let audioEls: HTMLAudioElement[] = [];
+
+export const useVoiceStore = defineStore('voice', {
+  state: () => ({
+    active: false,
+    connecting: false,
+    muted: false,
+    // Human label for what's being called, e.g. "#dev".
+    label: '',
+    // Remote participant identities (our IRC-nick convention).
+    participants: [] as string[],
+    // Subset of `participants` currently detected as speaking.
+    speaking: [] as string[],
+    error: null as string | null,
+  }),
+  actions: {
+    async startCall(networkId: number, target: string, label: string) {
+      if (this.active || this.connecting) return;
+      this.connecting = true;
+      this.error = null;
+      this.label = label;
+      try {
+        // Token first, so a 503/403/404 fails fast without paying to load the SDK.
+        const { token, url } = await api<VoiceTokenResponse>('/api/voice/token', {
+          method: 'POST',
+          body: { networkId, target },
+        });
+
+        // Lazy chunk: livekit-client only lands over the network at first call.
+        const { Room, RoomEvent, Track } = await import('livekit-client');
+
+        const r = new Room({ adaptiveStream: true, dynacast: true });
+        r.on(RoomEvent.TrackSubscribed, (track: RemoteTrack) => {
+          if (track.kind === Track.Kind.Audio) {
+            const el = track.attach() as HTMLAudioElement;
+            el.autoplay = true;
+            document.body.appendChild(el);
+            audioEls.push(el);
+          }
+        })
+          .on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack) => {
+            track.detach().forEach((el) => el.remove());
+          })
+          .on(RoomEvent.ParticipantConnected, () => this.syncParticipants())
+          .on(RoomEvent.ParticipantDisconnected, () => this.syncParticipants())
+          .on(RoomEvent.ActiveSpeakersChanged, (speakers: Participant[]) => {
+            const self = r.localParticipant.identity;
+            this.speaking = speakers.map((p) => p.identity).filter((id) => id !== self);
+          })
+          .on(RoomEvent.Disconnected, () => {
+            void this.cleanup();
+          });
+
+        await r.connect(url, token);
+        await r.localParticipant.setMicrophoneEnabled(true);
+        room = r;
+        this.active = true;
+        this.muted = false;
+        this.syncParticipants();
+      } catch (e: any) {
+        this.error = e?.message || 'could not start call';
+        await this.cleanup();
+      } finally {
+        this.connecting = false;
+      }
+    },
+
+    syncParticipants() {
+      this.participants = room
+        ? Array.from(room.remoteParticipants.values()).map((p) => p.identity)
+        : [];
+    },
+
+    async toggleMute() {
+      if (!room) return;
+      this.muted = !this.muted;
+      await room.localParticipant.setMicrophoneEnabled(!this.muted);
+    },
+
+    async leave() {
+      await this.cleanup();
+    },
+
+    async cleanup() {
+      if (room) {
+        try {
+          await room.disconnect();
+        } catch {
+          /* already gone */
+        }
+        room = null;
+      }
+      audioEls.forEach((el) => el.remove());
+      audioEls = [];
+      this.active = false;
+      this.connecting = false;
+      this.muted = false;
+      this.participants = [];
+      this.speaking = [];
+    },
+  },
+});

--- a/vue_client/src/views/GuestCall.vue
+++ b/vue_client/src/views/GuestCall.vue
@@ -1,0 +1,142 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+
+  Public guest voice-call page (/call/:token). Someone without an account opens
+  the capability link, picks a display name, and joins the call. It exchanges
+  the link token for a room-scoped LiveKit token and connects via the shared
+  voice store; the global CallBar then provides the in-call controls.
+-->
+
+<template>
+  <div class="guest-call">
+    <div class="card">
+      <h1><i class="fa-solid fa-phone"></i> Join voice call</h1>
+
+      <p v-if="!config.voiceEnabled" class="err">Voice calling isn't available here.</p>
+
+      <template v-else-if="!voice.active && !voice.connecting">
+        <p class="hint">You've been invited to a voice call. Pick a name to join.</p>
+        <input
+          v-model="name"
+          class="name"
+          placeholder="Your name"
+          maxlength="24"
+          spellcheck="false"
+          @keyup.enter="join"
+        />
+        <button class="join" type="button" :disabled="!name.trim() || joining" @click="join">
+          {{ joining ? 'Joining…' : 'Join call' }}
+        </button>
+        <p v-if="error" class="err">{{ error }}</p>
+      </template>
+
+      <template v-else-if="voice.connecting">
+        <p class="hint">Connecting…</p>
+      </template>
+
+      <template v-else>
+        <p class="ok"><i class="fa-solid fa-check"></i> You're in the call.</p>
+        <p class="hint">Use the call controls in the corner to mute or leave.</p>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useVoiceStore } from '../stores/voice.js';
+import { useConfigStore } from '../stores/config.js';
+import { api } from '../api.js';
+
+const route = useRoute();
+const voice = useVoiceStore();
+const config = useConfigStore();
+
+const token = String(route.params.token || '');
+const name = ref('');
+const joining = ref(false);
+const error = ref('');
+
+async function join() {
+  if (!name.value.trim() || joining.value) return;
+  joining.value = true;
+  error.value = '';
+  try {
+    const r = await api<{ token: string; url: string }>('/api/voice/guest-token', {
+      method: 'POST',
+      body: { token, name: name.value.trim() },
+    });
+    await voice.connectWithToken(r.url, r.token, 'Guest call', { guest: true });
+    if (voice.error) error.value = voice.error;
+  } catch (e: unknown) {
+    error.value = e instanceof Error ? e.message : 'could not join the call';
+  } finally {
+    joining.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.guest-call {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: var(--bg, #0f1116);
+  color: var(--text, #e7e9ee);
+}
+.card {
+  width: 100%;
+  max-width: 22rem;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: var(--panel-bg, #1b1d24);
+  border: 1px solid var(--border, #2c2f38);
+  text-align: center;
+}
+.card h1 {
+  font-size: 1.15rem;
+  margin: 0 0 0.75rem;
+}
+.hint {
+  opacity: 0.75;
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+}
+.name {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.4rem;
+  border: 1px solid var(--border, #2c2f38);
+  background: var(--bg-soft, #14161c);
+  color: inherit;
+  font-size: 1rem;
+}
+.join {
+  width: 100%;
+  padding: 0.55rem;
+  border-radius: 0.4rem;
+  border: none;
+  background: var(--accent, #6ea8fe);
+  color: #08101f;
+  font-weight: 600;
+  cursor: pointer;
+}
+.join:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.ok {
+  color: var(--accent, #6ea8fe);
+  font-weight: 600;
+}
+.err {
+  color: var(--danger, #ff6b6b);
+  font-size: 0.85rem;
+  margin: 0.5rem 0 0;
+}
+</style>


### PR DESCRIPTION
## Native voice + video calls via LiveKit

Adds optional voice **and video** calls to Lurker. **Lurker never carries media** — it acts only as a room-scoped *token authority* and *call moderator* for a self-hosted LiveKit SFU. Off by default, gated exactly like DCC. Discussed in `#lurker-spooky`; this is the PR you asked for.

> **Update since first review:** the original PR was voice-only; it now also includes per-user volume, channel-mode join gating, op moderation, in-channel call presence, public guest links, and full video + screen share. New commits are on top of the original — see the two Update sections below.

### Server
- **`services/voice.ts`** — env gating (`LURKER_VOICE_ENABLED` + `LIVEKIT_WS_URL` / `API_KEY` / `API_SECRET`), deterministic room naming, and JWT minting via `livekit-server-sdk`. Pure logic, unit-tested.
- **`POST /api/voice/token`** (`requireAuth`) — gates on `voiceEnabled` (503), network ownership (404), and channel membership (403). Derives the room server-side and returns `{ token, room, url }`. DMs skip the membership check — opening a call is the invite.
- **`GET /api/config`** — adds `voiceEnabled` so clients hide all call UI when the instance doesn't offer it.
- **`docker-compose.yml`** — a `livekit` SFU service behind a `--profile voice` (defined but inert unless opted in).

### Web client (`vue_client`)
- Config store reads `voiceEnabled`; a Pinia `voice` store connects the LiveKit room via `livekit-client`, publishes the mic, and plays remote audio.
- A `CallBar` overlay mounted globally, and a **Call** button in the member list for channels when voice is enabled.
- **Bloat handling:** `livekit-client` is loaded with a dynamic `import()`, so Vite code-splits it into a lazy chunk fetched only on the first call. The main bundle is unchanged; the ~490 KB SDK never touches standard deployments.

---

### Update 1 — moderation, gating, presence, guest links

Keyed room names on the **IRC host** rather than the per-user network id, so two users on the same instance (and users on *different* instances pointed at the same network) land in the same room. Then, on top of that:

- **Per-user volume** — each participant has a client-side volume slider (`RemoteAudioTrack.setVolume`), bound only to the `microphone` source.
- **Channel-mode join gating** — an op can set a minimum prefix mode required to join a channel's call (e.g. voiced-and-up), stored in a new `voice_channel_policy` table. `POST /token` enforces it.
- **Op moderation** — `POST /api/voice/moderate` lets a channel op mute (`mutePublishedTrack`) or remove (`removeParticipant`) someone from the call. Gated on `q/a/o/h` server-side; the client only shows the controls to ops.
- **In-channel call presence** — answers the open question from the first PR. LiveKit fires webhooks at `POST /api/voice/webhook` (signature-verified via `WebhookReceiver`), and the server fans a `call-presence` frame out to every connected client so the member list shows **"Join call (N)"** even for users not yet in the call. Same-instance for now; no CTCP required.
- **Public guest links** — an op can mint a capability link (`voice_guest_link` table, 24h TTL) that a person **without an account** opens at `/call/:token` to join a specific channel's call, with a per-link talk/listen setting. The public router authenticates by webhook signature / guest-link token, never the session cookie.

New tables are declared `skip` in the export registry (instance-scoped, not portable). 43 voice tests, `tsc` clean both sides.

### Update 2 — video + screen share

- **Camera + screen share** with `setCameraEnabled` / `setScreenShareEnabled({ audio: true })` (screen audio included). Gating is identical to talk: `canPublish: true` already permits every source, so listen-only guests are blocked from video too — **no server/token/route change was needed for video.**
- **`VideoTile.vue`** owns the track attach/detach lifecycle — required because the room runs with `adaptiveStream`, so a remote video track only flows once it's attached to a visible `<video>`. Tiles can go fullscreen; screen tiles letterbox (`object-fit: contain`), camera tiles fill.
- The `CallBar` grows into a **floating, draggable, resizable call window** with a responsive tile grid when anyone has video, and collapses back to the compact audio bar when nobody does. `adaptiveStream` + `dynacast` are on, so bandwidth scales with tile visibility automatically.

### Notes for you
- All four package-lock entries are committed for the deps (`livekit-server-sdk` server-side, `livekit-client` web).
- Everything voice/video is opt-in, so hosted `app.lurker.chat` cells stay clean until you flip the env on for a cell.
- Validated end-to-end on `chat.irc.so` — including a guest (you 🙂) joining via link, and camera/screen both directions.
