### PR TITLE
Harden and share the SSRF address guard

### DIFF
--- a/server/services/dcc.ts
+++ b/server/services/dcc.ts
@@ -21,6 +21,7 @@
 // carries a token, and a filename with spaces must be double-quoted.
 
 import zlib from 'zlib';
+import { isBlockedIpLiteral } from '../utils/ipGuard.js';
 
 /** A parsed inbound `DCC SEND` offer. `host` is decoded to a dotted-quad (IPv4)
  *  or kept as an IPv6 literal; `filename` is RAW and unsanitised — path-safety is
@@ -213,23 +214,6 @@ export function formatDccOfferLine(nick: string, offer: DccSend): string {
   return `${nick} offered "${offer.filename}" (${formatBytes(offer.size)}) via DCC SEND${mode}`;
 }
 
-function isBlockedIpv4(ip: string): boolean {
-  const parts = ip.split('.').map((p) => Number(p));
-  if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
-    return true; // malformed → block, fail safe
-  }
-  const [a, b] = parts;
-  if (a === 0) return true; // 0.0.0.0/8 "this network"
-  if (a === 10) return true; // 10/8 private
-  if (a === 127) return true; // loopback
-  if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254 cloud metadata
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12 private
-  if (a === 192 && b === 168) return true; // 192.168/16 private
-  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
-  if (a >= 224) return true; // 224/4 multicast + 240/4 reserved + 255.255.255.255 broadcast
-  return false;
-}
-
 /**
  * Whether the cell should REFUSE to dial this DCC host. The address comes from
  * the (attacker-controlled) offer, and the cell dials it directly — so without
@@ -240,21 +224,13 @@ function isBlockedIpv4(ip: string): boolean {
  * can opt back in for LAN bots via LURKER_DCC_ALLOW_PRIVATE_HOSTS (see dccConfig).
  * `host` is the decoded form from decodeDccAddress (dotted-quad IPv4 or IPv6
  * literal).
+ *
+ * The range list itself lives in utils/ipGuard — link previews dial
+ * user-supplied hosts too, and one drifting copy of "which addresses are
+ * internal" is exactly the bug you don't find until it's exploited.
  */
 export function isBlockedDccHost(host: string): boolean {
-  const h = host.trim().toLowerCase();
-  if (h === '') return true;
-  if (h.includes(':')) {
-    // IPv4-mapped IPv6 (::ffff:1.2.3.4) — judge by the embedded IPv4.
-    const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(h);
-    if (mapped) return isBlockedIpv4(mapped[1]);
-    if (h === '::1' || h === '::') return true; // loopback / unspecified
-    if (/^fe[89ab]/.test(h)) return true; // fe80::/10 link-local
-    if (/^f[cd]/.test(h)) return true; // fc00::/7 unique-local
-    if (h.startsWith('ff')) return true; // ff00::/8 multicast
-    return false;
-  }
-  return isBlockedIpv4(h);
+  return isBlockedIpLiteral(host);
 }
 
 // CRC32 (IEEE 802.3, the variant zip/PNG use and the one scene/anime releases

--- a/server/utils/ipGuard.test.ts
+++ b/server/utils/ipGuard.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The address guard is the single most security-sensitive thing in the tree: two features hand
+// the server an address that someone else chose, and it decides whether to dial it. These tests
+// are the record of three separate SSRF holes found in it, each a different IPv6 notation that a
+// deny-list didn't know about — which is why it's now an allowlist.
+
+import { describe, it, expect } from 'vitest';
+import { isBlockedIpv4, isBlockedIpLiteral } from './ipGuard.js';
+
+describe('isBlockedIpv4', () => {
+  it('blocks every internal range', () => {
+    for (const ip of [
+      '0.0.0.0',
+      '10.0.0.1',
+      '127.0.0.1',
+      '169.254.169.254', // the one that matters most: cloud metadata
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      '100.64.0.1', // CGNAT
+      '224.0.0.1', // multicast
+      '255.255.255.255',
+    ]) {
+      expect(isBlockedIpv4(ip)).toBe(true);
+    }
+  });
+
+  it('allows ordinary public addresses', () => {
+    for (const ip of ['8.8.8.8', '1.1.1.1', '172.15.0.1', '172.32.0.1', '100.63.0.1']) {
+      expect(isBlockedIpv4(ip)).toBe(false);
+    }
+  });
+
+  it('fails safe on anything malformed', () => {
+    for (const ip of ['', 'not-an-ip', '1.2.3', '1.2.3.4.5', '999.1.1.1', '1.2.3.-1']) {
+      expect(isBlockedIpv4(ip)).toBe(true);
+    }
+  });
+});
+
+describe('isBlockedIpLiteral', () => {
+  it('blocks internal IPv6', () => {
+    for (const ip of ['::1', '::', 'fe80::1', 'fc00::1', 'fd12::3', 'ff02::1']) {
+      expect(isBlockedIpLiteral(ip)).toBe(true);
+    }
+  });
+
+  it('judges IPv4-mapped IPv6 by the embedded address', () => {
+    expect(isBlockedIpLiteral('::ffff:127.0.0.1')).toBe(true);
+    expect(isBlockedIpLiteral('::ffff:169.254.169.254')).toBe(true);
+    expect(isBlockedIpLiteral('::ffff:8.8.8.8')).toBe(false);
+  });
+
+  it('allows public IPv6', () => {
+    expect(isBlockedIpLiteral('2606:4700:4700::1111')).toBe(false);
+  });
+});
+
+describe('isBlockedIpLiteral — IPv4-embedding IPv6 notations', () => {
+  it('blocks an IPv4-mapped address in the HEX form the URL parser produces', () => {
+    // ⚠⚠ The regression that matters. `new URL('http://[::ffff:169.254.169.254]/')` rewrites
+    // the host to `[::ffff:a9fe:a9fe]`, and an earlier deny-list version matched only the
+    // DOTTED form — so this sailed through to the cloud metadata endpoint. `net.isIP` calls it
+    // IPv6, so node skips DNS and `pinnedLookup` never runs: this function is the only guard.
+    expect(isBlockedIpLiteral('::ffff:a9fe:a9fe')).toBe(true); // 169.254.169.254
+    expect(isBlockedIpLiteral('::ffff:7f00:1')).toBe(true); // 127.0.0.1
+    expect(isBlockedIpLiteral('::ffff:a00:5')).toBe(true); // 10.0.0.5
+    expect(isBlockedIpLiteral('::ffff:c0a8:1')).toBe(true); // 192.168.0.1
+  });
+
+  it('still blocks the dotted mapped form', () => {
+    expect(isBlockedIpLiteral('::ffff:127.0.0.1')).toBe(true);
+    expect(isBlockedIpLiteral('::ffff:169.254.169.254')).toBe(true);
+  });
+
+  it('allows a mapped PUBLIC address in either notation', () => {
+    expect(isBlockedIpLiteral('::ffff:8.8.8.8')).toBe(false);
+    expect(isBlockedIpLiteral('::ffff:808:808')).toBe(false);
+  });
+
+  it('blocks deprecated IPv4-compatible and NAT64 embeddings', () => {
+    expect(isBlockedIpLiteral('::127.0.0.1')).toBe(true);
+    expect(isBlockedIpLiteral('::a9fe:a9fe')).toBe(true);
+    expect(isBlockedIpLiteral('64:ff9b::169.254.169.254')).toBe(true);
+  });
+
+  it('handles bracketed input, as `new URL().hostname` hands it over', () => {
+    expect(isBlockedIpLiteral('[::ffff:7f00:1]')).toBe(true);
+    expect(isBlockedIpLiteral('[2606:4700:4700::1111]')).toBe(false);
+  });
+});
+
+describe('isBlockedIpLiteral — IPv4-in-IPv6 tunnels', () => {
+  it('blocks 6to4, which sits INSIDE the 2000::/3 allowlist', () => {
+    // ⚠ The mapped-address hole again in a different notation: 2002::/16 embeds an IPv4 and is
+    // global unicast, so the allowlist passed it. `net.isIP` calls it IPv6, so `pinnedLookup`
+    // never runs either.
+    expect(isBlockedIpLiteral('2002:7f00:0001::')).toBe(true); // 127.0.0.1
+    expect(isBlockedIpLiteral('2002:0a00:0001::')).toBe(true); // 10.0.0.1
+    expect(isBlockedIpLiteral('2002:a9fe:a9fe::')).toBe(true); // 169.254.169.254
+  });
+
+  it('blocks Teredo', () => {
+    expect(isBlockedIpLiteral('2001:0:0:0:0:0:a9fe:a9fe')).toBe(true);
+    expect(isBlockedIpLiteral('2001:0::1')).toBe(true);
+  });
+
+  it('does not over-block ordinary public IPv6 that merely starts 2001', () => {
+    expect(isBlockedIpLiteral('2001:db8::1')).toBe(false);
+    expect(isBlockedIpLiteral('2001:4860:4860::8888')).toBe(false);
+    expect(isBlockedIpLiteral('2606:4700:4700::1111')).toBe(false);
+  });
+
+  it('refuses a literal with two elisions instead of parsing it', () => {
+    // `filter(g => g !== '')` swallowed the extra empty groups, so this parsed as valid — the
+    // parser failing open in a guard whose whole premise is failing closed.
+    expect(isBlockedIpLiteral('2001::1::1')).toBe(true);
+    expect(isBlockedIpLiteral('::1::')).toBe(true);
+  });
+});
+
+describe('isBlockedIpLiteral — IPv6 is an allowlist', () => {
+  it('allows only global unicast (2000::/3)', () => {
+    expect(isBlockedIpLiteral('2606:4700:4700::1111')).toBe(false);
+    expect(isBlockedIpLiteral('2001:db8::1')).toBe(false);
+    expect(isBlockedIpLiteral('3fff::1')).toBe(false);
+    // Just outside the range on either side.
+    expect(isBlockedIpLiteral('1fff::1')).toBe(true);
+    expect(isBlockedIpLiteral('4000::1')).toBe(true);
+  });
+
+  it('blocks unassigned space rather than allowing what it does not recognise', () => {
+    // The point of the allowlist: a deny-list cannot be audited over 128 bits.
+    for (const ip of ['0100::1', '5000::1', '8000::1', 'c000::1', 'e000::1']) {
+      expect(isBlockedIpLiteral(ip)).toBe(true);
+    }
+  });
+
+  it('blocks anything it cannot parse', () => {
+    for (const bad of [':::1', '::ffff:1.2.3', '12345::1', 'gggg::1', '1:2:3:4:5:6:7', '::1::2']) {
+      expect(isBlockedIpLiteral(bad)).toBe(true);
+    }
+  });
+});

--- a/server/utils/ipGuard.test.ts
+++ b/server/utils/ipGuard.test.ts
@@ -113,6 +113,33 @@ describe('isBlockedIpLiteral — IPv4-in-IPv6 tunnels', () => {
     expect(isBlockedIpLiteral('2606:4700:4700::1111')).toBe(false);
   });
 
+  it('refuses every shape of stray colon', () => {
+    // ⚠ Found by review after the two-elision case below. `.filter(g => g !== '')` dropped empty
+    // groups instead of rejecting them, so a leading, trailing or tripled colon all parsed as
+    // well-formed. Not reachable through a URL today — node's own parser rejects these first —
+    // but this guard is also called with DCC-supplied hosts, and "fails closed" has to mean it.
+    for (const bad of [':1:2:3:4:5:6:7:8', '1:2:3:4:5:6:7:8:', ':::1', 'a::b:', '::a:', ':']) {
+      expect(isBlockedIpLiteral(bad)).toBe(true);
+    }
+  });
+
+  it('refuses an elision that elides nothing', () => {
+    // ⚠ `::` must stand for AT LEAST one group. The lenient check didn't merely accept
+    // `1::2:3:4:5:6:7:8` — it silently REINTERPRETED it as `1:2:3:4:5:6:7:8`, a different
+    // address from the one written. A guard that judges a different address than the one that
+    // gets dialled is the classic parser-differential hole.
+    expect(isBlockedIpLiteral('1::2:3:4:5:6:7:8')).toBe(true);
+    expect(isBlockedIpLiteral('2001:0:0:0:0:0:0::1')).toBe(true);
+  });
+
+  it('still accepts the valid forms it has to', () => {
+    // The counterweight: strictness must not start refusing real addresses.
+    expect(isBlockedIpLiteral('2606:4700:4700::1111')).toBe(false); // elided middle
+    expect(isBlockedIpLiteral('2001:4860:4860:0:0:0:0:8888')).toBe(false); // fully spelled out
+    expect(isBlockedIpLiteral('::ffff:8.8.8.8')).toBe(false); // mapped, dotted
+    expect(isBlockedIpLiteral('::ffff:808:808')).toBe(false); // mapped, hex
+  });
+
   it('refuses a literal with two elisions instead of parsing it', () => {
     // `filter(g => g !== '')` swallowed the extra empty groups, so this parsed as valid — the
     // parser failing open in a guard whose whole premise is failing closed.

--- a/server/utils/ipGuard.ts
+++ b/server/utils/ipGuard.ts
@@ -59,65 +59,57 @@ export function isBlockedIpv4(ip: string): boolean {
  * because both call this.
  */
 function parseIpv6(input: string): number[] | null {
+  // A trailing dotted quad is rewritten into two hex groups FIRST, so everything below has a
+  // single parse path instead of a special case threaded through it. `::ffff:1.2.3.4` becomes
+  // `::ffff:0102:0304` and is then parsed like any other literal.
   let text = input;
-
-  // At most ONE elision. `filter(g => g !== '')` below silently swallows extra empty groups, so
-  // `2001::1::1` parsed as a perfectly good address — the parser failing open in a file whose
-  // whole premise is failing closed.
-  if (text.split('::').length > 2) return null;
-
-  // A trailing dotted quad contributes the last two groups.
-  const tail: number[] = [];
-  const dotted = /:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(text);
+  const dotted = /^(.*:)(\d{1,3}(?:\.\d{1,3}){3})$/.exec(text);
   if (dotted) {
-    const octets = dotted[1].split('.').map(Number);
+    const octets = dotted[2].split('.').map(Number);
     if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) return null;
-    tail.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
-    text = text.slice(0, dotted.index + 1); // keep the ':' so the split below still works
+    const pair = (a: number, b: number): string => (((a << 8) | b) >>> 0).toString(16);
+    text = `${dotted[1]}${pair(octets[0], octets[1])}:${pair(octets[2], octets[3])}`;
   }
 
-  const elision = text.indexOf('::');
-  let head: string[];
-  let rest: string[];
-  if (elision === -1) {
-    head = text.split(':').filter((g) => g !== '');
-    rest = [];
-  } else {
-    head = text
-      .slice(0, elision)
-      .split(':')
-      .filter((g) => g !== '');
-    rest = text
-      .slice(elision + 2)
-      .split(':')
-      .filter((g) => g !== '');
-  }
-
-  const toGroup = (g: string): number | null => {
-    if (!/^[0-9a-f]{1,4}$/i.test(g)) return null;
-    return Number.parseInt(g, 16);
+  /**
+   * One colon-separated run of hex groups, or null if anything in it is malformed.
+   *
+   * ⚠ An empty group is REJECTED rather than dropped. The previous version used
+   * `.filter(g => g !== '')`, which silently accepted every kind of stray colon — a leading
+   * `:1:2:…`, a trailing `…:7:8:`, `:::1` — because the empty pieces just vanished. That's a
+   * parser failing open inside a guard whose whole premise is failing closed.
+   */
+  const groupsOf = (part: string): number[] | null => {
+    if (part === '') return [];
+    const out: number[] = [];
+    for (const g of part.split(':')) {
+      if (!/^[0-9a-f]{1,4}$/i.test(g)) return null;
+      out.push(Number.parseInt(g, 16));
+    }
+    return out;
   };
 
-  const headGroups: number[] = [];
-  for (const g of head) {
-    const v = toGroup(g);
-    if (v === null) return null;
-    headGroups.push(v);
-  }
-  const restGroups: number[] = [];
-  for (const g of rest) {
-    const v = toGroup(g);
-    if (v === null) return null;
-    restGroups.push(v);
-  }
-  restGroups.push(...tail);
+  const halves = text.split('::');
+  if (halves.length > 2) return null; // more than one elision — `2001::1::1`
 
-  const total = headGroups.length + restGroups.length;
-  if (elision === -1) {
-    return total === 8 ? [...headGroups, ...restGroups] : null;
+  if (halves.length === 1) {
+    const groups = groupsOf(text);
+    return groups !== null && groups.length === 8 ? groups : null;
   }
-  if (total > 8) return null;
-  return [...headGroups, ...Array.from<number>({ length: 8 - total }).fill(0), ...restGroups];
+
+  const left = groupsOf(halves[0]);
+  const right = groupsOf(halves[1]);
+  if (left === null || right === null) return null;
+
+  // ⚠ `>=`, not `>`. `::` must elide AT LEAST one group, so a literal that already spells out
+  // eight is malformed — and the lenient check didn't just accept it, it silently REINTERPRETED
+  // it: `1::2:3:4:5:6:7:8` came out as `1:2:3:4:5:6:7:8`, a different address from the one
+  // written. A guard that judges a different address than the one that gets dialled is the
+  // classic parser-differential hole, even when (as today) node rejects the literal first.
+  if (left.length + right.length >= 8) return null;
+
+  const elided = Array.from<number>({ length: 8 - left.length - right.length }).fill(0);
+  return [...left, ...elided, ...right];
 }
 
 /** The IPv4 embedded in an IPv6 address, for every notation that embeds one. */

--- a/server/utils/ipGuard.ts
+++ b/server/utils/ipGuard.ts
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The one definition of "an address the cell must not dial".
+//
+// Two features hand the cell an address that someone else chose, and both are
+// SSRF in the classic shape — the cell connects, and the result comes back to a
+// user:
+//
+//   - DCC SEND offers (services/dcc.ts): the host comes from a CTCP message any
+//     IRC user can send, and the response is written to a downloadable file.
+//   - Link previews (services/linkFetch.ts): the host comes from a URL any IRC
+//     user can paste, and the response is parsed into a card or proxied to a
+//     browser.
+//
+// Same threat, same answer, so it lives once. On a hosted cell the VPC
+// neighbours — the control plane, other cells — sit squarely in the blocked
+// ranges, which is what makes this load-bearing rather than hygienic.
+//
+// ⚠⚠ IPv6 is an ALLOWLIST, not a denylist, and that asymmetry is deliberate.
+// An earlier version enumerated the bad IPv6 prefixes and returned `false`
+// (allow) for anything it didn't recognise. That shipped a real hole: the WHATWG
+// URL parser rewrites an IPv4-mapped literal into hex, so
+// `http://[::ffff:169.254.169.254]/` arrives as `[::ffff:a9fe:a9fe]` — which
+// matched none of the deny prefixes and was allowed straight through to the
+// cloud metadata endpoint. `net.isIP()` calls that string IPv6, so node skips
+// DNS for it and `pinnedLookup` never runs either; this function was the only
+// guard on the path, and it said yes.
+//
+// The lesson is the general one: a denylist over a 128-bit space with several
+// IPv4-embedding notations cannot be audited. Only 2000::/3 is global unicast,
+// so that's what we allow, and everything we can't parse or don't recognise is
+// refused.
+
+/** True when a dotted-quad IPv4 string is in a range the cell must not dial. */
+export function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split('.').map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) {
+    return true; // malformed → block, fail safe
+  }
+  const [a, b] = parts;
+  if (a === 0) return true; // 0.0.0.0/8 "this network"
+  if (a === 10) return true; // 10/8 private
+  if (a === 127) return true; // loopback
+  if (a === 169 && b === 254) return true; // link-local incl. 169.254.169.254 cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12 private
+  if (a === 192 && b === 168) return true; // 192.168/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64/10 CGNAT
+  if (a >= 224) return true; // 224/4 multicast + 240/4 reserved + 255.255.255.255 broadcast
+  return false;
+}
+
+/**
+ * Expand an IPv6 literal to its eight 16-bit groups, or null if it isn't one.
+ *
+ * Handles `::` elision and a trailing dotted quad (`::ffff:1.2.3.4`), which is
+ * the form DCC hands us — the URL parser has already converted that shape to
+ * hex by the time a preview URL reaches us, but both have to be understood
+ * because both call this.
+ */
+function parseIpv6(input: string): number[] | null {
+  let text = input;
+
+  // At most ONE elision. `filter(g => g !== '')` below silently swallows extra empty groups, so
+  // `2001::1::1` parsed as a perfectly good address — the parser failing open in a file whose
+  // whole premise is failing closed.
+  if (text.split('::').length > 2) return null;
+
+  // A trailing dotted quad contributes the last two groups.
+  const tail: number[] = [];
+  const dotted = /:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(text);
+  if (dotted) {
+    const octets = dotted[1].split('.').map(Number);
+    if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) return null;
+    tail.push((octets[0] << 8) | octets[1], (octets[2] << 8) | octets[3]);
+    text = text.slice(0, dotted.index + 1); // keep the ':' so the split below still works
+  }
+
+  const elision = text.indexOf('::');
+  let head: string[];
+  let rest: string[];
+  if (elision === -1) {
+    head = text.split(':').filter((g) => g !== '');
+    rest = [];
+  } else {
+    head = text
+      .slice(0, elision)
+      .split(':')
+      .filter((g) => g !== '');
+    rest = text
+      .slice(elision + 2)
+      .split(':')
+      .filter((g) => g !== '');
+  }
+
+  const toGroup = (g: string): number | null => {
+    if (!/^[0-9a-f]{1,4}$/i.test(g)) return null;
+    return Number.parseInt(g, 16);
+  };
+
+  const headGroups: number[] = [];
+  for (const g of head) {
+    const v = toGroup(g);
+    if (v === null) return null;
+    headGroups.push(v);
+  }
+  const restGroups: number[] = [];
+  for (const g of rest) {
+    const v = toGroup(g);
+    if (v === null) return null;
+    restGroups.push(v);
+  }
+  restGroups.push(...tail);
+
+  const total = headGroups.length + restGroups.length;
+  if (elision === -1) {
+    return total === 8 ? [...headGroups, ...restGroups] : null;
+  }
+  if (total > 8) return null;
+  return [...headGroups, ...Array.from<number>({ length: 8 - total }).fill(0), ...restGroups];
+}
+
+/** The IPv4 embedded in an IPv6 address, for every notation that embeds one. */
+function embeddedIpv4(groups: number[]): string | null {
+  const isZero = (n: number) => groups[n] === 0;
+  const last32 = () => {
+    const g6 = groups[6];
+    const g7 = groups[7];
+    return `${g6 >> 8}.${g6 & 0xff}.${g7 >> 8}.${g7 & 0xff}`;
+  };
+
+  // ::ffff:a.b.c.d — IPv4-mapped. The form that caused the hole.
+  if ([0, 1, 2, 3, 4].every(isZero) && groups[5] === 0xffff) return last32();
+  // ::a.b.c.d and ::0:a.b.c.d — deprecated IPv4-compatible, still routable by some stacks.
+  if ([0, 1, 2, 3, 4, 5].every(isZero)) return last32();
+  // 64:ff9b::/96 — NAT64. Blocked by the 2000::/3 rule anyway, but judging the
+  // embedded address gives a more honest answer than "unrecognised".
+  if (groups[0] === 0x64 && groups[1] === 0xff9b && [2, 3, 4, 5].every(isZero)) return last32();
+  return null;
+}
+
+/**
+ * Whether an IP *literal* — dotted-quad IPv4 or an IPv6 literal — is one the
+ * cell must not dial.
+ *
+ * Takes a literal, never a hostname: a name says nothing about where it points,
+ * so it has to be resolved first and judged by the answer. See `pinnedLookup` in
+ * linkFetch.ts for the pinning that makes that safe against DNS rebinding.
+ *
+ * Fails CLOSED throughout. Anything unparseable, and any IPv6 outside global
+ * unicast, is blocked.
+ */
+export function isBlockedIpLiteral(host: string): boolean {
+  const h = host.trim().toLowerCase();
+  if (h === '') return true;
+  // `new URL().hostname` keeps IPv6 literals bracketed; callers may or may not
+  // have stripped them.
+  const bare = h.replace(/^\[|\]$/g, '');
+  if (bare === '') return true;
+
+  if (!bare.includes(':')) return isBlockedIpv4(bare);
+
+  const groups = parseIpv6(bare);
+  if (groups === null) return true; // not a literal we understand → refuse
+
+  const embedded = embeddedIpv4(groups);
+  if (embedded !== null) return isBlockedIpv4(embedded);
+
+  // ⚠ IPv4-in-IPv6 TUNNELS, blocked outright. Both live INSIDE the 2000::/3 allowlist below, so
+  // without this they were the `::ffff:a9fe:a9fe` hole again wearing a different notation:
+  // `http://[2002:7f00:0001::]/` is 6to4 for 127.0.0.1 and `[2002:a9fe:a9fe::]` for the cloud
+  // metadata endpoint — `net.isIP` calls them IPv6, so `pinnedLookup` never runs.
+  //
+  // Refused rather than decoded. Both mechanisms are deprecated (6to4 by RFC 7526, Teredo
+  // effectively dead), Teredo's embedded client address is bit-complemented so reading it is
+  // fiddly, and a preview fetcher has no business dialling a tunnel broker either way. Blocking
+  // costs us nothing real and removes a whole class of notation from the audit.
+  if (groups[0] === 0x2002) return true; // 2002::/16 — 6to4
+  if (groups[0] === 0x2001 && groups[1] === 0x0000) return true; // 2001:0::/32 — Teredo
+
+  // ALLOWLIST: 2000::/3 is the global unicast range. Loopback (::1), the
+  // unspecified address, unique-local (fc00::/7), link-local (fe80::/10),
+  // multicast (ff00::/8) and every unassigned block all fall outside it, so one
+  // check covers the lot — including notations nobody has thought of yet.
+  return (groups[0] & 0xe000) !== 0x2000;
+}


### PR DESCRIPTION
First of six stacked PRs re-cutting `inline-media-link-previews` into independently
reviewable chunks. **This one stands entirely alone** — no new dependencies, no new consumers,
and it improves DCC's security whether link previews ever ship or not.

## What

Extracts DCC's "must not dial this address" range check into `server/utils/ipGuard.ts`, and
fixes three SSRF holes in it.

DCC takes a host from a CTCP message any IRC user can send and dials it directly, so this guard
already gated it — it was just narrower than it looked.

## The three holes

All the same shape: a **deny-list** over a space with several notations for one address.

1. **IPv4-mapped IPv6 in hex.** `new URL('http://[::ffff:169.254.169.254]/')` normalises the host
   to `[::ffff:a9fe:a9fe]`. The guard matched only the *dotted* form, matched no other prefix, and
   fell through to `return false` — allow. Straight to the cloud metadata endpoint.
2. **6to4 / Teredo.** `2002::/16` and `2001:0::/32` embed an IPv4 *and* are global unicast, so an
   allowlist of `2000::/3` passes them. `http://[2002:a9fe:a9fe::]/` is the same hole again.
3. **Unparseable input accepted.** `filter(g => g !== '')` swallowed a second `::`, so
   `2001::1::1` parsed as a well-formed address.

What makes these exploitable rather than theoretical: **`net.isIP()` calls all of them IPv6, so
node skips DNS resolution** — a pinned-lookup guard never runs, and this literal check is the only
guard on the path.

## The fix

A real IPv6 parser (elision, trailing dotted quad, at most one elision), every IPv4-embedding
notation judged by its embedded address, and IPv6 as an **allowlist**: only `2000::/3` global
unicast passes, tunnels refused outright. Loopback, unique-local, link-local, multicast and every
unassigned block fall outside it, so one check covers notations nobody has thought of yet.

⚠ **Do not reintroduce an IPv6 deny-list.** That a 128-bit space with multiple IPv4-embedding
forms cannot be audited is what all three holes have in common.

## Review notes

- `server/utils/ipGuard.ts` is pure — zero imports — so it can be reasoned about in isolation.
- The test file is deliberately the *record* of the three holes, so the next person to touch this
  knows which notations bit us.
- DCC's own 38 tests pass unchanged: the range list moved, its verdicts didn't — except for the
  addresses it should have been refusing all along.
- Worth a skeptical look at `parseIpv6` and `embeddedIpv4` specifically. If there's a fourth
  notation, that's where it hides.

3 files, +338/−30. 0 lint errors, 3099 tests.