### PR TITLE
Add the SSRF-safe fetcher behind link previews

### DIFF
--- a/server/services/linkFetch.redirects.test.ts
+++ b/server/services/linkFetch.redirects.test.ts
@@ -13,6 +13,12 @@
 // tested against the real implementation in ../utils/ipGuard.test.ts, and that this module
 // consults it is tested against the real implementation in ./linkFetch.test.ts. Neither of
 // those can reach a live origin; this one can't judge a real address. Together they cover it.
+//
+// ⚠⚠ Everything here goes through `localhost`, NOT `127.0.0.1`, and that is not incidental:
+// node skips DNS entirely for an address literal, so a test written against the literal never
+// invokes `pinnedLookup` at all. This is the only place its SUCCESS path runs — and since node
+// asks for `{all: true}` by default, `callback(null, safe)` is the branch every real fetch in
+// production takes. Break it and every preview fails against a fully green suite.
 
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import http from 'node:http';
@@ -23,7 +29,7 @@ vi.mock('../utils/ipGuard.js', () => ({
   isBlockedIpv4: (ip: string) => ip !== '127.0.0.1',
 }));
 
-const { safeRequest, bufferStream } = await import('./linkFetch.js');
+const { safeRequest, bufferStream, UnsafeUrlError } = await import('./linkFetch.js');
 
 /** A hop. Returns the response to send, given the request. */
 type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
@@ -32,6 +38,8 @@ let handler: Handler;
 let hits: string[] = [];
 let server: http.Server;
 let base: string;
+/** The same origin by address literal, for the one test that wants DNS skipped. */
+let literalBase: string;
 
 beforeAll(async () => {
   server = http.createServer((req, res) => {
@@ -39,7 +47,12 @@ beforeAll(async () => {
     handler(req, res);
   });
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  const port = (server.address() as AddressInfo).port;
+  // `localhost` commonly resolves to ::1 as well, which the test policy above refuses — so
+  // reaching this server at all also proves the lookup FILTERS rather than taking the first
+  // answer node hands it.
+  base = `http://localhost:${port}`;
+  literalBase = `http://127.0.0.1:${port}`;
 });
 
 afterAll(async () => {
@@ -62,6 +75,26 @@ function redirectTo(location: string, status = 302): Handler {
     res.end('ignore me');
   };
 }
+
+describe('pinnedLookup, on the path where it actually runs', () => {
+  it('connects through a resolved hostname, dropping the answers the policy refuses', async () => {
+    // The success path: `localhost` resolves, at least one answer survives the filter, node
+    // gets handed that address and the fetch completes. Nothing else in the suite runs this —
+    // the other lookup test asserts the refusal, and every literal-addressed request skips DNS.
+    reset(redirectTo('/end'));
+    const res = await safeRequest(new URL(`${base}/end`));
+    const body = await bufferStream(res, { maxBytes: 4096 });
+    expect(body.body.toString()).toContain('ARRIVED');
+    expect(hits).toEqual(['/end']);
+  });
+
+  it('is skipped entirely for an address literal, so the parse guard is the only one', async () => {
+    reset(redirectTo('/end'));
+    const res = await safeRequest(new URL(`${literalBase}/end`));
+    res.stream.destroy();
+    expect(hits).toEqual(['/end']);
+  });
+});
 
 describe('safeRequest — following redirects', () => {
   it('follows a hop and reports the URL it ENDED at', async () => {
@@ -111,6 +144,48 @@ describe('safeRequest — following redirects', () => {
     await expect(safeRequest(new URL(`${base}/loop`))).rejects.toThrow(/too many redirects/);
     // Four requests: the entry plus MAX_REDIRECTS hops, and then it stops.
     expect(hits.length).toBe(4);
+  });
+
+  it('fails CLOSED on a Location it cannot even parse', async () => {
+    // ⚠ Regression guard. `new URL(location, base)` throws ERR_INVALID_URL while BUILDING
+    // normalizeUrl's argument, so its own try/catch never saw it and an attacker-controlled
+    // header escaped as a raw TypeError — which a caller sorting UnsafeUrlError from real
+    // defects would file as a bug against us. Written straight to the socket so node's own
+    // header validation can't sanitise it first.
+    for (const bad of ['http://[', 'https://exa mple.com/', 'http://%zz/', 'http://:80/']) {
+      reset((_req, res) => {
+        res.socket?.end(`HTTP/1.1 302 Found\r\nLocation: ${bad}\r\nContent-Length: 0\r\n\r\n`);
+      });
+      await expect(safeRequest(new URL(`${base}/start`))).rejects.toThrow(UnsafeUrlError);
+    }
+  });
+
+  it('refuses a body it cannot reason about, before anyone can pipe it', async () => {
+    // ⚠ We ask for identity; an origin that gzips anyway hands back bytes we can neither size
+    // nor relay. Checked in `requestOnce` rather than `bufferStream` because the byte proxy
+    // never buffers — it would have streamed DEFLATE bytes to a browser under the origin's own
+    // `Content-Type: image/png`, a corrupt image with no transport error to explain it.
+    reset((_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png', 'content-encoding': 'gzip' });
+      res.end('nonsense');
+    });
+    await expect(safeRequest(new URL(`${base}/img`))).rejects.toThrow(/content-encoding/);
+  });
+
+  it('refuses to forward a Range it cannot vouch for', async () => {
+    // The value arrives from a browser via the proxy route. A CR/LF in it makes node throw
+    // ERR_INVALID_CHAR out of the promise executor — node blocks the injection, so nothing is
+    // smuggled, but the caller gets a TypeError where this module promises to fail closed.
+    reset(redirectTo('/end'));
+    for (const bad of ['bytes=0-1\r\nX-Evil: 1', 'everything', 'bytes=abc-def']) {
+      await expect(safeRequest(new URL(`${base}/end`), { range: bad })).rejects.toThrow(
+        UnsafeUrlError,
+      );
+    }
+    expect(hits).toEqual([]); // refused before it dialled
+    const ok = await safeRequest(new URL(`${base}/end`), { range: 'bytes=0-1023' });
+    ok.stream.destroy();
+    expect(hits).toEqual(['/end']);
   });
 
   it('DESTROYS a redirect body instead of draining it', async () => {

--- a/server/services/linkFetch.redirects.test.ts
+++ b/server/services/linkFetch.redirects.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Redirect following, at a real origin.
+//
+// This is its own file because it needs the address policy INVERTED: the real guard blocks
+// loopback, correctly and on purpose, which means no test can ever watch `safeRequest` complete
+// a hop against a server it just started. So the guard is swapped for a test policy — allow
+// 127.0.0.1, refuse everything else — and the mechanism runs for real over real sockets.
+//
+// ⚠ What's mocked is the POLICY, never the mechanism. `normalizeUrl`, the redirect loop, the
+// per-hop re-validation and the pinned lookup are all the shipping code. The policy itself is
+// tested against the real implementation in ../utils/ipGuard.test.ts, and that this module
+// consults it is tested against the real implementation in ./linkFetch.test.ts. Neither of
+// those can reach a live origin; this one can't judge a real address. Together they cover it.
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+vi.mock('../utils/ipGuard.js', () => ({
+  isBlockedIpLiteral: (host: string) => host.replace(/^\[|\]$/g, '') !== '127.0.0.1',
+  isBlockedIpv4: (ip: string) => ip !== '127.0.0.1',
+}));
+
+const { safeRequest, bufferStream } = await import('./linkFetch.js');
+
+/** A hop. Returns the response to send, given the request. */
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+let handler: Handler;
+let hits: string[] = [];
+let server: http.Server;
+let base: string;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    hits.push(req.url || '');
+    handler(req, res);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function reset(h: Handler) {
+  hits = [];
+  handler = h;
+}
+
+function redirectTo(location: string, status = 302): Handler {
+  return (req, res) => {
+    if (req.url?.endsWith('/end')) {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<head><title>ARRIVED</title></head>');
+      return;
+    }
+    res.writeHead(status, { location });
+    res.end('ignore me');
+  };
+}
+
+describe('safeRequest — following redirects', () => {
+  it('follows a hop and reports the URL it ENDED at', async () => {
+    // `finalUrl` is the base for resolving a relative og:image, so a stale one silently points
+    // metadata at the wrong host.
+    reset(redirectTo('/end'));
+    const res = await safeRequest(new URL(`${base}/start`));
+    const body = await bufferStream(res, { maxBytes: 4096 });
+    expect(body.body.toString()).toContain('ARRIVED');
+    expect(body.finalUrl.toString()).toBe(`${base}/end`);
+    expect(hits).toEqual(['/start', '/end']);
+  });
+
+  it('resolves a relative Location against the hop that sent it', async () => {
+    reset(redirectTo('end'));
+    const res = await safeRequest(new URL(`${base}/a/b`));
+    expect(res.finalUrl.toString()).toBe(`${base}/a/end`);
+    res.stream.destroy();
+  });
+
+  it('re-vets every hop, so a redirect into internal space is refused', async () => {
+    // ⚠⚠ The way this bug actually ships. The entry URL passes review — it's an ordinary
+    // public page — and the origin answers 302 to the cloud metadata endpoint. Only a check
+    // on the TARGET of each hop catches it.
+    for (const evil of [
+      'http://169.254.169.254/latest/meta-data/',
+      'http://10.0.0.1/',
+      'http://[::1]/',
+      'file:///etc/passwd',
+      'https://user:pass@example.com/', // credentials a further hop would carry onward
+    ]) {
+      reset(redirectTo(evil));
+      await expect(safeRequest(new URL(`${base}/start`))).rejects.toThrow(/disallowed target/);
+      expect(hits).toEqual(['/start']);
+    }
+  });
+
+  it('treats every 3xx that carries a Location the same way', async () => {
+    for (const status of [301, 302, 303, 307, 308]) {
+      reset(redirectTo('http://169.254.169.254/', status));
+      await expect(safeRequest(new URL(`${base}/start`))).rejects.toThrow(/disallowed target/);
+    }
+  });
+
+  it('gives up rather than following a redirect loop', async () => {
+    reset(redirectTo('/loop'));
+    await expect(safeRequest(new URL(`${base}/loop`))).rejects.toThrow(/too many redirects/);
+    // Four requests: the entry plus MAX_REDIRECTS hops, and then it stops.
+    expect(hits.length).toBe(4);
+  });
+
+  it('DESTROYS a redirect body instead of draining it', async () => {
+    // ⚠ Regression guard, and a resource one rather than a correctness one: draining calls
+    // `resume()`, which reads the entire body — and a hostile origin can answer 302 with a
+    // gigabyte, on every hop, none of it covered by any byte cap. Draining only exists to
+    // return a socket to the pool, and keep-alive is off on both agents.
+    //
+    // The proof is server-side: this response is never ended, so the connection can only close
+    // because the client tore it down. A drained-and-abandoned socket stays open and this test
+    // times out.
+    let finished: boolean | null = null;
+    const closed = new Promise<void>((resolve) => {
+      reset((_req, res) => {
+        res.on('error', () => {});
+        res.on('close', () => {
+          finished = res.writableFinished;
+          resolve();
+        });
+        res.writeHead(302, { location: 'http://169.254.169.254/' });
+        res.write('a body we should never read');
+        // deliberately no res.end()
+      });
+    });
+
+    await expect(safeRequest(new URL(`${base}/start`))).rejects.toThrow(/disallowed target/);
+    await closed;
+    expect(finished).toBe(false);
+  });
+});

--- a/server/services/linkFetch.test.ts
+++ b/server/services/linkFetch.test.ts
@@ -1,0 +1,275 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { Readable } from 'node:stream';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { normalizeUrl, userAgent, bufferStream, safeRequest } from './linkFetch.js';
+
+// The address guard itself is tested in ../utils/ipGuard.test.ts. What this file tests is that
+// this module consults it — on parse, on connect, and on every redirect hop.
+
+describe('normalizeUrl', () => {
+  it('accepts ordinary http and https URLs', () => {
+    expect(normalizeUrl('https://example.com/a')?.toString()).toBe('https://example.com/a');
+    expect(normalizeUrl('http://example.com/a')?.toString()).toBe('http://example.com/a');
+  });
+
+  it('rejects schemes that have no business being fetched', () => {
+    for (const raw of [
+      'file:///etc/passwd',
+      'gopher://example.com/',
+      'ftp://example.com/x',
+      'data:text/html,<script>',
+      'javascript:alert(1)',
+      'not a url at all',
+    ]) {
+      expect(normalizeUrl(raw)).toBeNull();
+    }
+  });
+
+  it('rejects embedded credentials, which a redirect would carry onward', () => {
+    expect(normalizeUrl('https://user:pass@example.com/')).toBeNull();
+    expect(normalizeUrl('https://user@example.com/')).toBeNull();
+  });
+
+  it('rejects hosts that are literally an internal address', () => {
+    for (const raw of [
+      'http://127.0.0.1/',
+      'http://169.254.169.254/latest/meta-data/',
+      'http://10.0.0.1/',
+      'http://[::1]/',
+      'http://[fd00::1]/',
+      // The mapped forms, through the real parser this time.
+      'http://[::ffff:127.0.0.1]/',
+      'http://[::ffff:169.254.169.254]/latest/meta-data/',
+      'http://[::ffff:10.0.0.5]:8015/',
+    ]) {
+      expect(normalizeUrl(raw)).toBeNull();
+    }
+  });
+
+  it('allows a public IP literal', () => {
+    expect(normalizeUrl('http://8.8.8.8/')).not.toBeNull();
+  });
+
+  it('drops the fragment so #a and #b share one cache entry', () => {
+    expect(normalizeUrl('https://example.com/p#section')?.toString()).toBe('https://example.com/p');
+  });
+
+  it('leaves hostnames to be judged at connect time, not parse time', () => {
+    // A name that resolves internally must still PARSE — the guard that catches
+    // it is the pinned lookup, because only that one can't be raced by DNS.
+    expect(normalizeUrl('http://localhost.example.com/')).not.toBeNull();
+  });
+});
+
+/** A live origin on loopback plus a probe that proves it's serving. */
+async function reachableOrigin(secret: string) {
+  let hits = 0;
+  const server = http.createServer((_req, res) => {
+    hits++;
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end(`<head><meta property="og:title" content="${secret}"></head>`);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    port,
+    hits: () => hits,
+    /** Fetch it for real, over the shared global agent, and return the body. */
+    probe: (url: string) =>
+      new Promise<string>((resolve, reject) => {
+        http
+          .get(url, (r) => {
+            let body = '';
+            r.on('data', (c) => (body += c));
+            r.on('end', () => resolve(body));
+          })
+          .on('error', reject);
+      }),
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe('safeRequest refuses an internal origin that is genuinely reachable', () => {
+  // ⚠ A test asserting only "the fetch failed" would pass for the wrong reason — an unreachable
+  // URL fails too. So stand up a real server, PROVE it answers, and only then prove we won't
+  // touch it. The request counter is the assertion: not "it errored" but "nothing arrived".
+
+  it('refuses an address literal, which node would dial without any DNS at all', async () => {
+    // The parse-time guard is the ONLY one on this path: `net.isIP` matches, so node connects
+    // straight to the address and `pinnedLookup` never runs.
+    const origin = await reachableOrigin('INTERNAL SECRET');
+    try {
+      const target = `http://127.0.0.1:${origin.port}/admin`;
+      expect(await origin.probe(target)).toContain('INTERNAL SECRET');
+      expect(origin.hits()).toBe(1);
+
+      expect(normalizeUrl(target)).toBeNull();
+      // And again through safeRequest, since a caller that skipped normalizeUrl must not be
+      // able to turn this module into an open proxy.
+      await expect(safeRequest(new URL(target))).rejects.toThrow(/disallowed/);
+
+      expect(origin.hits()).toBe(1); // the probe's own request, and nothing of ours
+    } finally {
+      await origin.close();
+    }
+  });
+
+  it('refuses a HOSTNAME that resolves internally', async () => {
+    // A distinct code path, and the one DNS rebinding attacks: `localhost` parses perfectly
+    // well and is caught only when the pinned lookup sees what it resolved to.
+    //
+    // The probe runs first on purpose. It uses `http.globalAgent`, which is keep-alive by
+    // default, so by the time we call safeRequest there is a warm socket to this exact origin
+    // sitting in the shared pool. If this module ever went back to the global agent, that
+    // socket would be reused, no DNS would happen, and the pin would be bypassed — which is
+    // how the bug was found in the first place.
+    const origin = await reachableOrigin('VIA HOSTNAME');
+    try {
+      const target = `http://localhost:${origin.port}/`;
+      expect(await origin.probe(target)).toContain('VIA HOSTNAME');
+      expect(origin.hits()).toBe(1);
+
+      expect(normalizeUrl(target)).not.toBeNull(); // parses fine; that's the point
+      await expect(safeRequest(new URL(target))).rejects.toThrow(/internal addresses/);
+
+      expect(origin.hits()).toBe(1);
+    } finally {
+      await origin.close();
+    }
+  });
+});
+
+describe('userAgent', () => {
+  it('identifies as Lurker and as a preview fetcher, with a contact URL', () => {
+    const ua = userAgent();
+    expect(ua).toContain('Lurker');
+    expect(ua).toContain('+https://');
+    expect(ua).toContain('facebookexternalhit');
+  });
+
+  it('carries the real app version rather than a hardcoded one', async () => {
+    const { APP_VERSION } = await import('../utils/userAgent.js');
+    expect(userAgent()).toContain(APP_VERSION);
+  });
+
+  it('is overridable by the operator', () => {
+    const saved = process.env.LURKER_PREVIEW_USER_AGENT;
+    process.env.LURKER_PREVIEW_USER_AGENT = 'CustomAgent/9';
+    try {
+      expect(userAgent()).toBe('CustomAgent/9');
+    } finally {
+      if (saved === undefined) delete process.env.LURKER_PREVIEW_USER_AGENT;
+      else process.env.LURKER_PREVIEW_USER_AGENT = saved;
+    }
+  });
+});
+
+/**
+ * A RawResponse delivering exactly these chunks.
+ *
+ * The chunking is load-bearing in several tests below: the head scan carries state across
+ * chunk boundaries, and `destroy()` doesn't stop ones already queued.
+ */
+function fakeChunks(parts: string[], headers: Record<string, string> = {}) {
+  return {
+    status: 200,
+    headers: headers as never,
+    contentType: 'text/html',
+    finalUrl: new URL('https://example.com/'),
+    stream: Readable.from(parts.map((p) => Buffer.from(p, 'utf8'))) as never,
+  };
+}
+
+/** The same, as a single chunk. */
+function fake(body: string | Buffer, headers: Record<string, string> = {}) {
+  const buf = Buffer.isBuffer(body) ? body : Buffer.from(body, 'utf8');
+  return { ...fakeChunks([], headers), stream: Readable.from([buf]) as never };
+}
+
+describe('bufferStream', () => {
+  // The SSRF guard blocks loopback (correctly), so a real local origin can't be used here —
+  // and this is a pure stream-consumption question anyway.
+
+  it('reads a whole small body', async () => {
+    const res = await bufferStream(fake('hello'), { maxBytes: 1000 });
+    expect(res.body.toString()).toBe('hello');
+    expect(res.truncated).toBe(false);
+  });
+
+  it('truncates at the cap and says so', async () => {
+    const res = await bufferStream(fake('x'.repeat(500)), { maxBytes: 100 });
+    expect(res.body.length).toBe(100);
+    expect(res.truncated).toBe(true);
+  });
+
+  it('reads a PREFIX of an oversized body rather than refusing it', async () => {
+    // ⚠ Regression guard. An earlier version threw on a Content-Length over the cap, which
+    // broke two things at once: Wikipedia (a 572 KB article) got NO preview at all, and
+    // image dimensions failed for every image over the 64 KB header read — i.e. most of
+    // them. `maxBytes` means "read at most this much", never "refuse anything bigger".
+    const res = await bufferStream(fake('y'.repeat(5000), { 'content-length': '5000' }), {
+      maxBytes: 100,
+    });
+    expect(res.body.length).toBe(100);
+    expect(res.truncated).toBe(true);
+  });
+
+  it('stops once the head closes, so a long document costs only its head', async () => {
+    const html = `<html><head><title>T</title></head><body>${'z'.repeat(100_000)}</body></html>`;
+    const res = await bufferStream(fake(html), { maxBytes: 512 * 1024, stopAtHeadEnd: true });
+    expect(res.body.length).toBeLessThan(1000);
+    expect(res.body.toString()).toContain('<title>T</title>');
+    // Stopping early on purpose is not truncation — we got everything we wanted.
+    expect(res.truncated).toBe(false);
+  });
+
+  it('finds a </head> split across chunk boundaries', async () => {
+    const res = await bufferStream(
+      fakeChunks(['<head><title>T</title></he', 'ad><body>tail</body>']),
+      { maxBytes: 512 * 1024, stopAtHeadEnd: true },
+    );
+    expect(res.body.toString()).toContain('<title>T</title>');
+    expect(res.body.toString()).not.toContain('tail');
+  });
+
+  it('finds a </head> dribbled out one byte at a time', async () => {
+    // ⚠ Regression guard. The carried-over window used to be "the previous chunk", which
+    // spans the needle only when chunks are longer than it is. With small chunks the tag was
+    // missed entirely — and worse, the offset arithmetic assumed an overlap it hadn't been
+    // given, so a match found just after a short chunk trimmed bytes off the end of the head.
+    const doc = '<head><title>T</title></head><body>tail</body>';
+    const res = await bufferStream(fakeChunks([...doc]), {
+      maxBytes: 512 * 1024,
+      stopAtHeadEnd: true,
+    });
+    expect(res.body.toString()).toBe('<head><title>T</title>');
+  });
+
+  it('cuts exactly at the tag when the head ends mid-chunk', async () => {
+    const res = await bufferStream(fakeChunks(['<head><title>T</title>', '</head><body>tail']), {
+      maxBytes: 512 * 1024,
+      stopAtHeadEnd: true,
+    });
+    expect(res.body.toString()).toBe('<head><title>T</title>');
+  });
+
+  it('reads to the end when a document has no head at all', async () => {
+    const res = await bufferStream(fake('just text, no tags'), {
+      maxBytes: 1000,
+      stopAtHeadEnd: true,
+    });
+    expect(res.body.toString()).toBe('just text, no tags');
+  });
+
+  it('refuses a body it cannot measure', async () => {
+    // We ask for identity precisely so the byte counter means something; a compressed
+    // response would let a small payload expand into something enormous.
+    await expect(
+      bufferStream(fake('...', { 'content-encoding': 'gzip' }), { maxBytes: 1000 }),
+    ).rejects.toThrow(/content-encoding/);
+  });
+});

--- a/server/services/linkFetch.test.ts
+++ b/server/services/linkFetch.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Readable } from 'node:stream';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -144,16 +144,21 @@ describe('safeRequest refuses an internal origin that is genuinely reachable', (
 });
 
 describe('userAgent', () => {
-  it('identifies as Lurker and as a preview fetcher, with a contact URL', () => {
+  it('identifies as Lurker and as a preview fetcher, with the operator contact', async () => {
+    // ⚠ Asserted against the module's own values, not against literals. `USER_AGENT_CONTACT` is
+    // read from the real environment at import time — `docs/SELF_HOSTING.md` tells operators to
+    // set it, and `mailto:` is a documented value — so a literal `+https://` here turns
+    // `npm test`, the pre-push gate, red on the machines most likely to run it.
+    const { APP_VERSION, USER_AGENT_CONTACT } = await import('../utils/userAgent.js');
+    // Empty is falsy, so this neutralises an operator's exported override without pretending
+    // to know what they set it to.
+    vi.stubEnv('LURKER_PREVIEW_USER_AGENT', '');
     const ua = userAgent();
-    expect(ua).toContain('Lurker');
-    expect(ua).toContain('+https://');
-    expect(ua).toContain('facebookexternalhit');
-  });
-
-  it('carries the real app version rather than a hardcoded one', async () => {
-    const { APP_VERSION } = await import('../utils/userAgent.js');
-    expect(userAgent()).toContain(APP_VERSION);
+    vi.unstubAllEnvs();
+    const contact = USER_AGENT_CONTACT ? `; +${USER_AGENT_CONTACT}` : '';
+    expect(ua).toBe(
+      `Mozilla/5.0 (compatible; Lurker/${APP_VERSION}${contact}) facebookexternalhit/1.1`,
+    );
   });
 
   it('is overridable by the operator', () => {
@@ -179,6 +184,7 @@ function fakeChunks(parts: string[], headers: Record<string, string> = {}) {
     status: 200,
     headers: headers as never,
     contentType: 'text/html',
+    charset: null,
     finalUrl: new URL('https://example.com/'),
     stream: Readable.from(parts.map((p) => Buffer.from(p, 'utf8'))) as never,
   };
@@ -271,5 +277,78 @@ describe('bufferStream', () => {
     await expect(
       bufferStream(fake('...', { 'content-encoding': 'gzip' }), { maxBytes: 1000 }),
     ).rejects.toThrow(/content-encoding/);
+  });
+
+  it('is not fooled by </header>, which is in the markup of half the web', async () => {
+    // ⚠⚠ Regression guard, and the nastiest of the lot: `</head` matched as a bare substring
+    // also matches `</header>` — and because a match TRIMS rather than merely stopping, a page
+    // that omits the optional `</head>` tag had its document cut at the site nav and reported
+    // `truncated: false` about the metadata it had just thrown away.
+    const doc =
+      '<html><body><header class="site-header">Nav</header>' +
+      '<meta property="og:title" content="REAL TITLE"></body>';
+    for (const chunking of [[doc], [...doc], [doc.slice(0, 40), doc.slice(40)]]) {
+      const res = await bufferStream(fakeChunks(chunking), {
+        maxBytes: 512 * 1024,
+        stopAtHeadEnd: true,
+      });
+      expect(res.body.toString()).toContain('REAL TITLE');
+    }
+  });
+
+  it('accepts the tag however it is spelled', async () => {
+    for (const tag of ['</head>', '</head >', '</head\n>']) {
+      const res = await bufferStream(fakeChunks([`<head><title>T</title>${tag}<body>tail`]), {
+        maxBytes: 512 * 1024,
+        stopAtHeadEnd: true,
+      });
+      expect(res.body.toString()).toBe('<head><title>T</title>');
+    }
+  });
+
+  it('calls a head that arrived whole COMPLETE, even when the cap fired in the same chunk', async () => {
+    // ⚠ Regression guard. The cap check used to return before the head scan, so a chunk that
+    // both crossed the cap and closed the head skipped the trim and reported `truncated: true`
+    // — telling a caller its metadata might be incomplete about a head that was all there.
+    const res = await bufferStream(
+      fakeChunks(['<head><title>T</title></head>' + 'B'.repeat(1000)]),
+      {
+        maxBytes: 100,
+        stopAtHeadEnd: true,
+      },
+    );
+    expect(res.body.toString()).toBe('<head><title>T</title>');
+    expect(res.truncated).toBe(false);
+  });
+
+  it('keeps a buffered prefix when the peer resets mid-body, and says it is one', async () => {
+    // ⚠ Regression guard. A reset used to reject and throw the buffer away — the opposite of
+    // the policy three lines up at the cap, and it costs real previews: a complete <head>
+    // followed by a reset is every tag we needed.
+    const stream = new Readable({ read() {} });
+    stream.push(Buffer.from('<head><meta property="og:title" content="GOT IT">'));
+    const res = bufferStream({ ...fakeChunks([]), stream: stream as never }, { maxBytes: 4096 });
+    setImmediate(() => stream.destroy(new Error('ECONNRESET')));
+    const out = await res;
+    expect(out.body.toString()).toContain('GOT IT');
+    expect(out.truncated).toBe(true);
+  });
+
+  it('still rejects a reset that delivered nothing at all', async () => {
+    const stream = new Readable({ read() {} });
+    const res = bufferStream({ ...fakeChunks([]), stream: stream as never }, { maxBytes: 4096 });
+    setImmediate(() => stream.destroy(new Error('ECONNRESET')));
+    await expect(res).rejects.toThrow(/ECONNRESET/);
+  });
+
+  it('refuses a stream that is already finished rather than hanging on it', async () => {
+    // ⚠ Listeners attached to a destroyed stream fire NOTHING: no data, no end, no error. This
+    // used to be a promise that never settled — a leaked await with nothing in the log —
+    // reachable as soon as a caller inspects the headers and awaits a cache lookup.
+    const stream = new Readable({ read() {} });
+    stream.destroy();
+    await expect(
+      bufferStream({ ...fakeChunks([]), stream: stream as never }, { maxBytes: 4096 }),
+    ).rejects.toThrow(/already closed/);
   });
 });

--- a/server/services/linkFetch.ts
+++ b/server/services/linkFetch.ts
@@ -1,0 +1,406 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The outbound half of link previews: fetching a URL that an arbitrary IRC user
+// pasted, from a server that sits inside a VPC, without becoming an SSRF hole or
+// a memory hazard.
+//
+// On node:http/https rather than fetch, for two reasons — one shared with the
+// uploader and one specific to here:
+//
+//   1. DNS pinning needs a custom `lookup`, and fetch/undici gives no equivalent
+//      hook. Without it, "validate the hostname, then connect" is a TOCTOU bug:
+//      DNS rebinding makes the second resolution return 127.0.0.1 and the guard
+//      you wrote never sees it. See `pinnedLookup` below.
+//   2. undici buffers, and buffering a response whose size we don't trust is the
+//      whole problem. Streaming with a running byte counter is the point.
+//
+// Everything here fails CLOSED. A malformed URL, an unresolvable host, an
+// unexpected content-encoding, a redirect we can't re-validate — all of it ends
+// as `null`/throw, never as "well, try connecting and see".
+
+import http from 'node:http';
+import https from 'node:https';
+import dns from 'node:dns';
+import type { IncomingMessage } from 'node:http';
+import type { LookupAddress } from 'node:dns';
+import { isBlockedIpLiteral } from '../utils/ipGuard.js';
+import { APP_NAME, APP_VERSION, USER_AGENT_CONTACT } from '../utils/userAgent.js';
+
+/** Wall-clock budget for a single hop. */
+const TIMEOUT_MS = 5000;
+/** Redirects followed before giving up. Each hop is re-validated. */
+const MAX_REDIRECTS = 3;
+
+/**
+ * How much of an HTML document we read before giving up on finding metadata.
+ *
+ * Generous, because `stopAtHeadEnd` means a well-formed page costs its head and not a byte
+ * more — the ceiling only binds on documents that bury their metadata, and for those the
+ * choice is a large read or no preview. The Lounge defaults to 50 KB and had to expose a
+ * config knob when YouTube pushed its og: tags past 300 KB; Slack asks for the first 32 KB
+ * via a Range header and silently misses anything later.
+ *
+ * Note this is NOT the YouTube fix. Sites that hide their metadata behind half a megabyte of
+ * inline script get asked directly, via their oEmbed endpoint, rather than scraped — no cap
+ * large enough to scrape YouTube would be a sane thing to apply to the whole web.
+ */
+export const MAX_SCRAPE_BYTES = 512 * 1024;
+
+/**
+ * What we tell the origin we are.
+ *
+ * We are not a crawler. We fetch one URL, once, because a person pasted it in a
+ * channel and another person is looking at it — which is exactly the traffic
+ * class the social-preview user-agents denote, and exactly the class sites
+ * deliberately serve, because a preview card is free distribution. It is
+ * categorically not what "block AI crawlers" is aimed at; that's bulk
+ * training-data scraping.
+ *
+ * The two shipped implementations we have to compare against both reached the
+ * same conclusion: The Lounge sends `facebookexternalhit/1.1 Twitterbot/1.0`,
+ * halloy defaults to `WhatsApp/2` "for wide compatibility". We lead with our own
+ * identity and a contact URL, then name the class, so an operator reading their
+ * logs can tell exactly who we are and block us on purpose if they want to.
+ *
+ * Overridable because reasonable operators will disagree, and because the string
+ * that gets served will drift over time.
+ *
+ * Distinct from the app-wide `USER_AGENT` on purpose — that one is a plain
+ * `Lurker/x.y (+contact)` for talking to upload providers, and naming the
+ * social-preview class is exactly what we do NOT want on those. It shares the
+ * version and the operator's contact override, so a deployment identifies itself
+ * consistently and neither string goes stale on its own.
+ */
+export function userAgent(): string {
+  const override = process.env.LURKER_PREVIEW_USER_AGENT;
+  if (override) return override;
+  const contact = USER_AGENT_CONTACT ? `; +${USER_AGENT_CONTACT}` : '';
+  return `Mozilla/5.0 (compatible; ${APP_NAME}/${APP_VERSION}${contact}) facebookexternalhit/1.1`;
+}
+
+export class UnsafeUrlError extends Error {}
+
+/**
+ * Parse and vet a URL string before anything dials it.
+ *
+ * Rejects non-http(s) schemes (`file:`, `gopher:`, and friends have no business
+ * here), embedded credentials (which a redirect would happily carry somewhere
+ * else), and hosts that are *literally* an internal address. A hostname that
+ * merely resolves to one is caught later, at connect time — see `pinnedLookup`.
+ */
+export function normalizeUrl(raw: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  if (url.username || url.password) return null;
+  if (!url.hostname) return null;
+
+  // `new URL` keeps IPv6 literals bracketed; the guard wants the bare address.
+  const host = url.hostname.replace(/^\[|\]$/g, '');
+  // Only judge things that are already addresses. A name gets judged by what it
+  // resolves to, which is a question for connect time, not parse time.
+  if (/^[\d.]+$/.test(host) || host.includes(':')) {
+    if (isBlockedIpLiteral(host)) return null;
+  }
+
+  // The fragment is client-side only and never reaches the origin; dropping it
+  // means `#a` and `#b` share one cache entry instead of two.
+  url.hash = '';
+  return url;
+}
+
+/**
+ * A `lookup` that resolves once, refuses internal addresses, and hands node the
+ * exact address it approved.
+ *
+ * This is the pin. node connects to whatever this callback yields, so there is
+ * no second resolution for an attacker's short-TTL record to win — the classic
+ * DNS-rebinding SSRF (validate `evil.com` → A 1.2.3.4, connect → A 127.0.0.1)
+ * has nowhere to happen. Validating a hostname anywhere else in this file would
+ * be theatre.
+ */
+function pinnedLookup(
+  hostname: string,
+  options: dns.LookupOneOptions | dns.LookupAllOptions | number,
+  callback: (err: NodeJS.ErrnoException | null, address: never, family?: number) => void,
+): void {
+  const wantAll = typeof options === 'object' && options !== null && options.all === true;
+  dns.lookup(hostname, { all: true, verbatim: true }, (err, addresses: LookupAddress[]) => {
+    if (err) return callback(err, undefined as never);
+    const safe = addresses.filter((a) => !isBlockedIpLiteral(a.address));
+    if (safe.length === 0) {
+      const e: NodeJS.ErrnoException = new UnsafeUrlError(
+        `refusing to connect to ${hostname}: resolves only to internal addresses`,
+      );
+      e.code = 'EACCES';
+      return callback(e, undefined as never);
+    }
+    if (wantAll) return callback(null, safe as never);
+    callback(null, safe[0].address as never, safe[0].family);
+  });
+}
+
+/**
+ * Dedicated connection pools. **Never `globalAgent`.**
+ *
+ * A reused socket skips DNS entirely — which means it skips `pinnedLookup`,
+ * which means it skips the guard. `http.globalAgent` has been keep-alive by
+ * default since node 19 and is shared with every other part of the process, so
+ * using it would let a socket that something else opened, to a host we never
+ * vetted, be handed to a preview fetch. That is not hypothetical: it is how this
+ * was found, when a test probe's pooled socket got reused by the fetcher and the
+ * lookup never ran — the guard tests below dial their origin first, exactly so a
+ * warm socket is sitting in the pool when they assert the refusal.
+ *
+ * A private agent with keep-alive off means every request we make goes through
+ * the pin, every time. Preview fetching is not a hot path; correctness of the
+ * guard is worth one handshake.
+ */
+const httpAgent = new http.Agent({ keepAlive: false });
+const httpsAgent = new https.Agent({ keepAlive: false });
+
+export interface FetchOptions {
+  /** `Accept` header. Defaults to a browser-ish HTML preference. */
+  accept?: string;
+  /** A `Range` header to forward, so the byte proxy can serve partial content. Media elements
+   *  require it: Safari won't play a <video> from a source that ignores ranges. */
+  range?: string;
+  /** Overall byte ceiling. The stream is destroyed the moment it's crossed. */
+  maxBytes?: number;
+}
+
+export interface RawResponse {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  contentType: string;
+  /** The URL actually served, after redirects — the base for relative og:image. */
+  finalUrl: URL;
+  stream: IncomingMessage;
+}
+
+/**
+ * One hop, no redirect following, no body read. The caller decides whether to
+ * buffer it (scraping) or pipe it (the byte proxy).
+ */
+function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const mod = url.protocol === 'https:' ? https : http;
+    const req = mod.request(
+      url,
+      {
+        method: 'GET',
+        lookup: pinnedLookup,
+        agent: mod === https ? httpsAgent : httpAgent,
+        timeout: TIMEOUT_MS,
+        headers: {
+          'User-Agent': userAgent(),
+          Accept: opts.accept || 'text/html,application/xhtml+xml,*/*;q=0.8',
+          // No Accept-Encoding on purpose. A byte cap counts *compressed* bytes,
+          // so accepting gzip would let a small response decompress into
+          // something enormous — a zip bomb aimed straight at the scrape buffer.
+          // Identity costs bandwidth and removes a whole class of surprise.
+          'Accept-Encoding': 'identity',
+          ...(opts.range ? { Range: opts.range } : {}),
+          // No cookies, no auth, ever. Included explicitly so a future edit that
+          // adds a header set has to walk past this note.
+        },
+      },
+      (res) => {
+        const contentType = String(res.headers['content-type'] || '')
+          .split(';')[0]
+          .trim()
+          .toLowerCase();
+        resolve({
+          status: res.statusCode || 0,
+          headers: res.headers,
+          contentType,
+          finalUrl: url,
+          stream: res,
+        });
+      },
+    );
+    req.on('timeout', () => req.destroy(new Error('timeout')));
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/**
+ * Follow up to MAX_REDIRECTS hops, re-vetting the target of every single one.
+ *
+ * A redirect into internal space is the most common way this bug actually ships:
+ * the entry URL passes review, and `https://harmless.example/go` 302s to
+ * `http://169.254.169.254/latest/meta-data/`. Each `Location` goes back through
+ * `normalizeUrl` and a fresh pinned lookup, so hop 3 is checked exactly as hard
+ * as hop 0.
+ */
+export async function safeRequest(start: URL, opts: FetchOptions = {}): Promise<RawResponse> {
+  // Hop 0 goes through the same check as every other hop. Callers do normalize before they get
+  // here, but "the caller remembered" is not a guard, and for an entry URL it's the ONLY one:
+  // node skips DNS for an address literal, so `pinnedLookup` never runs and nothing downstream
+  // would ever look at `http://169.254.169.254/`.
+  const entry = normalizeUrl(start.toString());
+  if (!entry) throw new UnsafeUrlError('refusing to fetch a disallowed URL');
+  let url = entry;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const res = await requestOnce(url, opts);
+    const isRedirect = res.status >= 300 && res.status < 400 && res.headers.location;
+    if (!isRedirect) return res;
+
+    // Destroyed, not drained. `resume()` reads the ENTIRE redirect body first — a hostile
+    // origin can answer 302 with a gigabyte, per hop, and none of the byte caps apply to it.
+    // Draining exists to let a socket be reused, and keep-alive is off on both agents, so
+    // nothing here needs the socket back.
+    res.stream.destroy();
+    if (hop === MAX_REDIRECTS) throw new UnsafeUrlError('too many redirects');
+    const next = normalizeUrl(new URL(String(res.headers.location), url).toString());
+    if (!next) throw new UnsafeUrlError('redirect to a disallowed target');
+    url = next;
+  }
+  throw new UnsafeUrlError('too many redirects');
+}
+
+export interface BufferedResponse {
+  status: number;
+  contentType: string;
+  finalUrl: URL;
+  body: Buffer;
+  /** True when we stopped early because the cap was reached. */
+  truncated: boolean;
+}
+
+export interface BufferOptions {
+  maxBytes?: number;
+  /**
+   * Stop as soon as `</head>` has been seen.
+   *
+   * Everything we scrape lives in the head, so the rest of the document is bytes we pay for
+   * and discard. This is what lets the cap be generous — a well-formed page costs its head
+   * and not a byte more, whatever the ceiling is set to.
+   */
+  stopAtHeadEnd?: boolean;
+}
+
+/**
+ * Buffer a response we've already opened, hard-capped.
+ *
+ * Separate from `safeRequest` so a caller that has to inspect the headers before deciding
+ * what to do — which is every caller — doesn't have to throw the response away and issue a
+ * second request for the body. Doing that doubled every page fetch, which is both wasteful
+ * and twice the chance of tripping a rate limit on a host we want to stay welcome at.
+ *
+ * The cap is enforced on bytes actually received, and ONLY on those. `Content-Length` is
+ * deliberately not consulted — see the ⚠ note in the body: rejecting early on an oversized
+ * declared length broke every caller here, all of which want a PREFIX. A maintainer trusting
+ * the sentence that used to be here would have believed in a guard that had been removed.
+ */
+/** What `stopAtHeadEnd` looks for. Lowercased; the scan lowercases its window to match. */
+const NEEDLE = '</head';
+
+export async function bufferStream(
+  res: RawResponse,
+  opts: BufferOptions = {},
+): Promise<BufferedResponse> {
+  const maxBytes = opts.maxBytes ?? MAX_SCRAPE_BYTES;
+
+  // ⚠ `maxBytes` means "read at most this much", NOT "refuse anything bigger". Every caller
+  // here wants a PREFIX: the scraper wants a document's head, `imageDimensions` wants an
+  // image's first few hundred bytes. An earlier version threw on an oversized
+  // `Content-Length` and it broke both — Wikipedia (a 572 KB article) got no preview at all,
+  // and image dimensions silently failed for every image over 64 KB, which is most of them.
+  //
+  // The place a size limit genuinely belongs is the byte proxy, which is serving a whole file
+  // to a browser and enforces its own ceiling.
+
+  // We asked for identity; anything else means we can't reason about the byte
+  // count, so we don't try.
+  const encoding = String(res.headers['content-encoding'] || 'identity').toLowerCase();
+  if (encoding !== 'identity') {
+    res.stream.destroy();
+    throw new UnsafeUrlError(`unexpected content-encoding: ${encoding}`);
+  }
+
+  return await new Promise<BufferedResponse>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let truncated = false;
+    let settled = false;
+    // Rolling state for the `</head` scan — see the data handler.
+    let tail: Buffer = Buffer.alloc(0);
+    let scanned = 0;
+
+    res.stream.on('data', (chunk: Buffer) => {
+      // ⚠ `destroy()` is not instantaneous — anything already queued still arrives. Without
+      // this, a chunk landing after the cut appends bytes AFTER the `</head>` we just trimmed
+      // to, and a chunk landing after truncation pushes the body past `maxBytes`. Both
+      // guarantees this function makes are only true if it stops listening once it's done.
+      if (settled || truncated) return;
+      total += chunk.length;
+      if (total > maxBytes) {
+        // Keep the prefix — a truncated head is often still enough to find og: tags in, and
+        // a partial answer beats no answer.
+        chunks.push(chunk.subarray(0, chunk.length - (total - maxBytes)));
+        truncated = true;
+        res.stream.destroy();
+        return;
+      }
+      chunks.push(chunk);
+      if (opts.stopAtHeadEnd && !settled) {
+        // Search only the NEW bytes plus a small overlap, not the whole buffer. Concatenating
+        // and latin1-decoding everything on every chunk is O(n²) — on exactly the documents the
+        // 512 KB ceiling exists for (metadata buried behind hundreds of KB of script) that's
+        // tens of MB of copying and a full decode per chunk.
+        //
+        // `tail` is the last NEEDLE.length - 1 bytes of everything scanned so far — the most
+        // that can carry over — so a `</head` split across a boundary is found however small
+        // the chunks are. ⚠ It is NOT "the previous chunk": with chunks shorter than the
+        // needle, one chunk of context isn't enough to span it, and the offset arithmetic
+        // below silently trims into the head when it assumes more overlap than it was given.
+        const window = Buffer.concat([tail, chunk]);
+        const at = window.toString('latin1').toLowerCase().indexOf(NEEDLE);
+        if (at !== -1) {
+          settled = true;
+          // TRIM to the tag rather than merely stopping: stopping bounds the read at whatever
+          // chunk boundary we landed on, so the saving would depend on the socket's chunk size.
+          // Cutting makes the guarantee real — the caller gets the head and nothing after it.
+          const keep = scanned - tail.length + at;
+          const whole = Buffer.concat(chunks);
+          chunks.length = 0;
+          chunks.push(whole.subarray(0, keep));
+          res.stream.destroy();
+          return;
+        }
+        tail = window.subarray(Math.max(0, window.length - (NEEDLE.length - 1)));
+        scanned += chunk.length;
+      }
+    });
+
+    res.stream.on('error', (err) => (truncated || settled ? resolve(done()) : reject(err)));
+    res.stream.on('close', () => resolve(done()));
+    res.stream.on('end', () => resolve(done()));
+
+    function done(): BufferedResponse {
+      return {
+        status: res.status,
+        contentType: res.contentType,
+        finalUrl: res.finalUrl,
+        body: Buffer.concat(chunks),
+        truncated,
+      };
+    }
+  });
+}
+
+/** Open a URL and buffer it in one step, for callers with nothing to decide. */
+export async function fetchBuffered(
+  url: URL,
+  opts: FetchOptions & BufferOptions = {},
+): Promise<BufferedResponse> {
+  const res = await safeRequest(url, opts);
+  return await bufferStream(res, opts);
+}

--- a/server/services/linkFetch.ts
+++ b/server/services/linkFetch.ts
@@ -28,8 +28,22 @@ import type { LookupFunction } from 'node:net';
 import { isBlockedIpLiteral } from '../utils/ipGuard.js';
 import { APP_NAME, APP_VERSION, USER_AGENT_CONTACT } from '../utils/userAgent.js';
 
-/** Wall-clock budget for a single hop. */
-const TIMEOUT_MS = 5000;
+/**
+ * Idle timeout: node arms this as `socket.setTimeout`, which every arriving byte resets. It
+ * bounds a STALL — a dead connect, headers that never come — and not the transfer.
+ */
+const IDLE_TIMEOUT_MS = 5000;
+
+/**
+ * Hard ceiling on one hop, start to finish, however busy it looks.
+ *
+ * ⚠ The idle timer alone is not a budget, and the gap is exploitable rather than theoretical:
+ * an origin dribbling one byte every four seconds resets it forever, so a 512 KB read could
+ * hold a socket for weeks. This one is never reset, so a fetch is bounded at MAX_REDIRECTS + 1
+ * hops of it. Verified against a real dribbling origin: cut at ~20 s, with the prefix that had
+ * arrived returned and flagged `truncated`.
+ */
+const HOP_DEADLINE_MS = 20_000;
 /** Redirects followed before giving up. Each hop is re-validated. */
 const MAX_REDIRECTS = 3;
 
@@ -171,9 +185,18 @@ const pinnedLookup: LookupFunction = (hostname, options, callback) => {
  * A private agent with keep-alive off means every request we make goes through
  * the pin, every time. Preview fetching is not a hot path; correctness of the
  * guard is worth one handshake.
+ *
+ * ⚠⚠ The invariant is `keepAlive: false` AND an UNBOUNDED `maxSockets` — both halves, which is
+ * why the second is spelled out rather than left to the default. node only marks a request
+ * `shouldKeepAlive = false` when `!agent.keepAlive && !isFinite(agent.maxSockets)`, and the
+ * Agent's `free` handler hands a released socket to a queued same-host request BEFORE it ever
+ * consults `keepAlive`. So capping these — the obvious way to bound preview concurrency — would
+ * quietly restore socket reuse and put the DNS-pin bypass straight back. Measured: 6 concurrent
+ * requests through `{keepAlive: false}` do 6 lookups; through `{keepAlive: false, maxSockets: 2}`
+ * they do 2. Bound concurrency in the CALLER, above this module.
  */
-const httpAgent = new http.Agent({ keepAlive: false });
-const httpsAgent = new https.Agent({ keepAlive: false });
+const httpAgent = new http.Agent({ keepAlive: false, maxSockets: Infinity });
+const httpsAgent = new https.Agent({ keepAlive: false, maxSockets: Infinity });
 
 export interface FetchOptions {
   /** `Accept` header. Defaults to a browser-ish HTML preference. */
@@ -181,17 +204,49 @@ export interface FetchOptions {
   /** A `Range` header to forward, so the byte proxy can serve partial content. Media elements
    *  require it: Safari won't play a <video> from a source that ignores ranges. */
   range?: string;
-  /** Overall byte ceiling. The stream is destroyed the moment it's crossed. */
-  maxBytes?: number;
+  // ⚠ No byte ceiling here. It reads like it belongs — but nothing on this path consumes a
+  // body, so nothing could enforce it, and an option that documents a guarantee it doesn't
+  // provide is worse than no option. The cap lives in `BufferOptions`, where the read is.
 }
 
-export interface RawResponse {
+/** The bare MIME type, plus the charset the origin declared alongside it. */
+interface ContentType {
+  /** Lowercased, parameters stripped: `text/html`. */
+  contentType: string;
+  /**
+   * The declared charset, lowercased, or null.
+   *
+   * Kept as its own field because `contentType` throws the parameters away, and a caller
+   * decoding a body needs it: `text/html; charset=windows-1251` with no in-document `<meta
+   * charset>` renders as replacement characters if you assume UTF-8.
+   */
+  charset: string | null;
+}
+
+export interface RawResponse extends ContentType {
   status: number;
   headers: http.IncomingHttpHeaders;
-  contentType: string;
   /** The URL actually served, after redirects — the base for relative og:image. */
   finalUrl: URL;
   stream: IncomingMessage;
+}
+
+/**
+ * A `Range` we're willing to forward.
+ *
+ * The value comes from a browser, which means it comes from anyone who can reach the proxy
+ * route. Unvalidated, a CR or LF in it makes node throw `ERR_INVALID_CHAR` out of the promise
+ * executor below — node blocks the header injection, so nothing is smuggled, but the caller
+ * gets a raw `TypeError` where this module promises to fail closed with an `UnsafeUrlError`.
+ */
+const RANGE_RE = /^bytes=\d*-\d*(?:,\s*\d*-\d*)*$/;
+
+/** Split `text/html; charset=utf-8` into the parts callers actually use. */
+function parseContentType(raw: string): ContentType {
+  return {
+    contentType: raw.split(';')[0].trim().toLowerCase(),
+    charset: /;\s*charset\s*=\s*"?([\w-]+)"?/i.exec(raw)?.[1]?.toLowerCase() ?? null,
+  };
 }
 
 /**
@@ -200,6 +255,9 @@ export interface RawResponse {
  */
 function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
+    if (opts.range !== undefined && !RANGE_RE.test(opts.range)) {
+      return reject(new UnsafeUrlError(`refusing to forward a malformed Range: ${opts.range}`));
+    }
     const mod = url.protocol === 'https:' ? https : http;
     const req = mod.request(
       url,
@@ -207,7 +265,7 @@ function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
         method: 'GET',
         lookup: pinnedLookup,
         agent: mod === https ? httpsAgent : httpAgent,
-        timeout: TIMEOUT_MS,
+        timeout: IDLE_TIMEOUT_MS,
         headers: {
           'User-Agent': userAgent(),
           Accept: opts.accept || 'text/html,application/xhtml+xml,*/*;q=0.8',
@@ -222,20 +280,36 @@ function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
         },
       },
       (res) => {
-        const contentType = String(res.headers['content-type'] || '')
-          .split(';')[0]
-          .trim()
-          .toLowerCase();
+        // ⚠ Checked HERE, not in `bufferStream`, because the other consumer of a RawResponse
+        // pipes it. We asked for identity; an origin that gzips anyway hands back bytes we
+        // can neither size nor pass on — relaying them to a browser under the origin's own
+        // `Content-Type: image/png` is a corrupt image with no transport error to explain it.
+        const encoding = String(res.headers['content-encoding'] || 'identity').toLowerCase();
+        if (encoding !== 'identity') {
+          res.destroy();
+          return reject(new UnsafeUrlError(`unexpected content-encoding: ${encoding}`));
+        }
         resolve({
           status: res.statusCode || 0,
           headers: res.headers,
-          contentType,
+          ...parseContentType(String(res.headers['content-type'] || '')),
           finalUrl: url,
           stream: res,
         });
       },
     );
-    req.on('timeout', () => req.destroy(new Error('timeout')));
+    // Cleared when the request is done either way, and unref'd so a pending fetch can never be
+    // the reason the process stays up.
+    const deadline = setTimeout(() => {
+      req.destroy(new UnsafeUrlError(`hop took longer than ${HOP_DEADLINE_MS}ms`));
+    }, HOP_DEADLINE_MS);
+    deadline.unref();
+    req.on('close', () => clearTimeout(deadline));
+    // ⚠ Only observable BEFORE the response headers arrive. After that this promise has already
+    // resolved, so the reject is a no-op and the destroy surfaces to whoever holds the stream —
+    // as an ordinary stream error, indistinguishable from a peer reset. `bufferStream` treats
+    // both the same way: what arrived is a prefix, and it says so.
+    req.on('timeout', () => req.destroy(new UnsafeUrlError('timed out with no data')));
     req.on('error', reject);
     req.end();
   });
@@ -269,19 +343,34 @@ export async function safeRequest(start: URL, opts: FetchOptions = {}): Promise<
     // nothing here needs the socket back.
     res.stream.destroy();
     if (hop === MAX_REDIRECTS) throw new UnsafeUrlError('too many redirects');
-    const next = normalizeUrl(new URL(String(res.headers.location), url).toString());
+    // ⚠ The resolve is inside the try, not just the normalize. `Location: http://[` throws
+    // `ERR_INVALID_URL` while BUILDING normalizeUrl's argument, so its own try/catch never sees
+    // it — and an attacker-controlled header escaping as a raw TypeError makes a caller that
+    // sorts `UnsafeUrlError` from everything else file a bug report against us.
+    let next: URL | null = null;
+    try {
+      next = normalizeUrl(new URL(String(res.headers.location), url).toString());
+    } catch {
+      next = null;
+    }
     if (!next) throw new UnsafeUrlError('redirect to a disallowed target');
     url = next;
   }
   throw new UnsafeUrlError('too many redirects');
 }
 
-export interface BufferedResponse {
+export interface BufferedResponse extends ContentType {
   status: number;
-  contentType: string;
   finalUrl: URL;
   body: Buffer;
-  /** True when we stopped early because the cap was reached. */
+  /**
+   * True when `body` is a PREFIX of what the origin was sending — the cap fired, the peer went
+   * away mid-message, or a deadline cut it off.
+   *
+   * ⚠ Stopping at `</head>` is deliberately NOT truncation: we got the whole of what we asked
+   * for. The distinction is the whole value of this flag — a caller deciding whether metadata
+   * might be missing gets told the truth either way.
+   */
   truncated: boolean;
 }
 
@@ -310,8 +399,22 @@ export interface BufferOptions {
  * declared length broke every caller here, all of which want a PREFIX. A maintainer trusting
  * the sentence that used to be here would have believed in a guard that had been removed.
  */
-/** What `stopAtHeadEnd` looks for. Lowercased; the scan lowercases its window to match. */
-const NEEDLE = '</head';
+/**
+ * What `stopAtHeadEnd` looks for.
+ *
+ * ⚠ The trailing delimiter is load-bearing, not decoration. Matching `</head` as a bare
+ * substring also matches `</header>`, which is in the markup of roughly every site on the web
+ * — and since a match TRIMS rather than merely stops, a page that omits the optional `</head>`
+ * tag had its document silently cut at the first `</header>`, reporting `truncated: false`
+ * about metadata that had been thrown away.
+ *
+ * Known residual: a literal `</head>` inside a comment or a script string still matches, since
+ * this is a byte scan and not a tokenizer. That costs a preview, never a wrong one, and the
+ * fix is a parser rather than a longer regex.
+ */
+const HEAD_END = /<\/head[\s/>]/;
+/** The longest partial match that can carry across a chunk boundary: `</head`. */
+const HEAD_END_CARRY = 6;
 
 export async function bufferStream(
   res: RawResponse,
@@ -328,20 +431,32 @@ export async function bufferStream(
   // The place a size limit genuinely belongs is the byte proxy, which is serving a whole file
   // to a browser and enforces its own ceiling.
 
-  // We asked for identity; anything else means we can't reason about the byte
-  // count, so we don't try.
+  // We asked for identity; anything else means we can't reason about the byte count, so we
+  // don't try. `requestOnce` refuses these too — this is the same rule applied to a response
+  // that reached us some other way, since a RawResponse is just an object.
   const encoding = String(res.headers['content-encoding'] || 'identity').toLowerCase();
   if (encoding !== 'identity') {
     res.stream.destroy();
     throw new UnsafeUrlError(`unexpected content-encoding: ${encoding}`);
   }
 
+  // ⚠ Attaching listeners to a stream that is already finished means NOTHING ever fires, and
+  // this promise hangs forever with no error and no log — a leaked await, not a failure. That
+  // is reachable exactly the way the docblock above invites: inspect the headers, await a cache
+  // lookup, and come back to a response the peer reset while you were gone.
+  if (res.stream.destroyed || res.stream.readableEnded) {
+    throw new UnsafeUrlError('the response stream was already closed');
+  }
+
   return await new Promise<BufferedResponse>((resolve, reject) => {
     const chunks: Buffer[] = [];
     let total = 0;
     let truncated = false;
+    /** The `</head>` cut fired: we have everything we asked for and are done reading. */
     let settled = false;
-    // Rolling state for the `</head` scan — see the data handler.
+    /** This promise has been resolved. Distinct from `settled` — see `finish`. */
+    let finished = false;
+    // Rolling state for the `</head>` scan — see the data handler.
     let tail: Buffer = Buffer.alloc(0);
     let scanned = 0;
 
@@ -350,55 +465,87 @@ export async function bufferStream(
       // this, a chunk landing after the cut appends bytes AFTER the `</head>` we just trimmed
       // to, and a chunk landing after truncation pushes the body past `maxBytes`. Both
       // guarantees this function makes are only true if it stops listening once it's done.
-      if (settled || truncated) return;
-      total += chunk.length;
-      if (total > maxBytes) {
+      if (settled) return;
+
+      // Trim to the cap but keep going into the scan below, rather than returning here. A
+      // chunk can both cross the cap AND close the head, and bailing early called that
+      // `truncated: true` — telling a caller its metadata might be incomplete about a head
+      // that had arrived whole.
+      let piece = chunk;
+      if (total + chunk.length > maxBytes) {
         // Keep the prefix — a truncated head is often still enough to find og: tags in, and
         // a partial answer beats no answer.
-        chunks.push(chunk.subarray(0, chunk.length - (total - maxBytes)));
+        piece = chunk.subarray(0, maxBytes - total);
         truncated = true;
-        res.stream.destroy();
-        return;
       }
-      chunks.push(chunk);
-      if (opts.stopAtHeadEnd && !settled) {
+      total += piece.length;
+      chunks.push(piece);
+
+      if (opts.stopAtHeadEnd) {
         // Search only the NEW bytes plus a small overlap, not the whole buffer. Concatenating
         // and latin1-decoding everything on every chunk is O(n²) — on exactly the documents the
         // 512 KB ceiling exists for (metadata buried behind hundreds of KB of script) that's
         // tens of MB of copying and a full decode per chunk.
         //
-        // `tail` is the last NEEDLE.length - 1 bytes of everything scanned so far — the most
-        // that can carry over — so a `</head` split across a boundary is found however small
-        // the chunks are. ⚠ It is NOT "the previous chunk": with chunks shorter than the
-        // needle, one chunk of context isn't enough to span it, and the offset arithmetic
-        // below silently trims into the head when it assumes more overlap than it was given.
-        const window = Buffer.concat([tail, chunk]);
-        const at = window.toString('latin1').toLowerCase().indexOf(NEEDLE);
-        if (at !== -1) {
+        // `tail` is the last HEAD_END_CARRY bytes of everything scanned so far — the most that
+        // can carry over — so a `</head>` split across a boundary is found however small the
+        // chunks are. ⚠ It is NOT "the previous chunk": with chunks shorter than the tag, one
+        // chunk of context isn't enough to span it, and the offset arithmetic below silently
+        // trims into the head when it assumes more overlap than it was given.
+        const window = Buffer.concat([tail, piece]);
+        const found = HEAD_END.exec(window.toString('latin1').toLowerCase());
+        if (found) {
           settled = true;
+          // The head arrived complete, whatever the cap did to the bytes after it.
+          truncated = false;
           // TRIM to the tag rather than merely stopping: stopping bounds the read at whatever
           // chunk boundary we landed on, so the saving would depend on the socket's chunk size.
           // Cutting makes the guarantee real — the caller gets the head and nothing after it.
-          const keep = scanned - tail.length + at;
+          const keep = scanned - tail.length + found.index;
           const whole = Buffer.concat(chunks);
           chunks.length = 0;
           chunks.push(whole.subarray(0, keep));
           res.stream.destroy();
-          return;
+          return finish();
         }
-        tail = window.subarray(Math.max(0, window.length - (NEEDLE.length - 1)));
-        scanned += chunk.length;
+        tail = window.subarray(Math.max(0, window.length - HEAD_END_CARRY));
+        scanned += piece.length;
       }
+
+      if (truncated) res.stream.destroy();
     });
 
-    res.stream.on('error', (err) => (truncated || settled ? resolve(done()) : reject(err)));
-    res.stream.on('close', () => resolve(done()));
-    res.stream.on('end', () => resolve(done()));
+    // A peer reset, our own deadline, a `req.destroy()` — all arrive here or at 'close', and
+    // all of them mean the same thing: what we have is a prefix. Throwing it away would be
+    // the opposite of the policy applied at the cap, and it throws away real previews —
+    // a complete `<head>` followed by a reset is every tag we needed.
+    res.stream.on('error', (err) => {
+      if (settled) return finish(); // the head was already complete and cut
+      if (total === 0) return reject(err); // nothing arrived; there is no partial answer
+      truncated = true;
+      finish();
+    });
+    res.stream.on('close', () => {
+      // `complete` is node's "the message framing said this was all of it". False means the
+      // body was cut short — best-effort, since a response framed only by EOF can't be judged
+      // by anyone, but it catches the Content-Length and chunked cases.
+      if (!settled && res.stream.complete === false) truncated = true;
+      finish();
+    });
+    res.stream.on('end', finish);
+
+    /** Settle once. Three events can fire for one response and `done()` copies the body. */
+    function finish(): void {
+      if (finished) return;
+      finished = true;
+      resolve(done());
+    }
 
     function done(): BufferedResponse {
       return {
         status: res.status,
         contentType: res.contentType,
+        charset: res.charset,
         finalUrl: res.finalUrl,
         body: Buffer.concat(chunks),
         truncated,

--- a/server/services/linkFetch.ts
+++ b/server/services/linkFetch.ts
@@ -24,6 +24,7 @@ import https from 'node:https';
 import dns from 'node:dns';
 import type { IncomingMessage } from 'node:http';
 import type { LookupAddress } from 'node:dns';
+import type { LookupFunction } from 'node:net';
 import { isBlockedIpLiteral } from '../utils/ipGuard.js';
 import { APP_NAME, APP_VERSION, USER_AGENT_CONTACT } from '../utils/userAgent.js';
 
@@ -123,27 +124,37 @@ export function normalizeUrl(raw: string): URL | null {
  * DNS-rebinding SSRF (validate `evil.com` → A 1.2.3.4, connect → A 127.0.0.1)
  * has nowhere to happen. Validating a hostname anywhere else in this file would
  * be theatre.
+ *
+ * Typed as node's own `net.LookupFunction`, which is the contract this has to
+ * satisfy — the two shapes of callback below aren't ours to choose.
  */
-function pinnedLookup(
-  hostname: string,
-  options: dns.LookupOneOptions | dns.LookupAllOptions | number,
-  callback: (err: NodeJS.ErrnoException | null, address: never, family?: number) => void,
-): void {
-  const wantAll = typeof options === 'object' && options !== null && options.all === true;
-  dns.lookup(hostname, { all: true, verbatim: true }, (err, addresses: LookupAddress[]) => {
-    if (err) return callback(err, undefined as never);
+const pinnedLookup: LookupFunction = (hostname, options, callback) => {
+  // node wants ONE address, or ALL of them when it intends to race the families — which is
+  // what it actually asks for here, `autoSelectFamily` having been on by default since node
+  // 20. Both shapes have to be answered in kind, or node reads back the wrong thing.
+  const wantAll = options.all === true;
+  // The options are node's to decide, and forwarding them is not just tidiness: it hands us
+  // `hints: ADDRCONFIG`, meaning "only answer with families this host has configured". Dropping
+  // that lets the pin approve an address the connection could never have used — a working fetch
+  // turned into a failed one on a v4-only box. Same for a `family` a future caller sets.
+  //
+  // `all` is forced on regardless of what was asked: every answer has to be judged, not just
+  // whichever one node would have picked.
+  dns.lookup(hostname, { ...options, all: true }, (err, addresses: LookupAddress[]) => {
+    // node never reads the address when the error is set; its own lookup passes nothing.
+    if (err) return callback(err, '');
     const safe = addresses.filter((a) => !isBlockedIpLiteral(a.address));
     if (safe.length === 0) {
       const e: NodeJS.ErrnoException = new UnsafeUrlError(
         `refusing to connect to ${hostname}: resolves only to internal addresses`,
       );
       e.code = 'EACCES';
-      return callback(e, undefined as never);
+      return callback(e, '');
     }
-    if (wantAll) return callback(null, safe as never);
-    callback(null, safe[0].address as never, safe[0].family);
+    if (wantAll) return callback(null, safe);
+    callback(null, safe[0].address, safe[0].family);
   });
-}
+};
 
 /**
  * Dedicated connection pools. **Never `globalAgent`.**

--- a/server/utils/userAgent.ts
+++ b/server/utils/userAgent.ts
@@ -24,6 +24,8 @@ const contact = (process.env.USER_AGENT_CONTACT || DEFAULT_CONTACT).trim();
 
 export const APP_NAME = 'Lurker';
 export const APP_VERSION: string = pkg.version;
+/** Where an operator whose logs we show up in should complain. May be blank. */
+export const USER_AGENT_CONTACT: string = contact;
 
 // Used as the HTTP User-Agent header on outbound requests to upload providers
 // and any future external service. Format follows the conventional


### PR DESCRIPTION
PR 2 of the link-previews stack (after #682, which this builds directly on). Nothing calls it yet — the resolver and routes land in PR 4 — so it merges dormant.

The outbound half of link previews: fetching a URL an arbitrary IRC user pasted, from a server sitting inside a VPC.

### Why node:http and not fetch

DNS pinning needs a custom `lookup`, and undici gives no equivalent hook — without one, "validate the hostname, then connect" is a TOCTOU bug. And a byte cap has to be enforced *while* streaming; undici buffers the whole response first, which is the exact thing we're defending against.

### Three guards, one per way in

| guard | catches | why it's the only one that can |
|---|---|---|
| `normalizeUrl` | non-http(s) schemes, embedded credentials, hosts that literally *are* an internal address | `net.isIP` matches an address literal, so node connects without ever consulting a `lookup` |
| `pinnedLookup` | a hostname that *resolves* internally | resolves once and hands node the approved address, so DNS rebinding has no second resolution to win |
| the redirect loop | `https://harmless.example/go` → 302 → `http://169.254.169.254/` | hop 3 is re-vetted exactly as hard as hop 0 |

`safeRequest` now re-vets its **entry** URL too, which the reference branch left to the caller. "The caller remembered to normalize" isn't a guard, and for a literal it's the only check on the path.

Both agents are private with keep-alive off. Never `globalAgent` — a pooled socket skips DNS, which skips the pin, which skips the guard.

### Two defects the new tests turned up

- **The `</head>` scan carried only the previous chunk as overlap.** A tag split across chunks shorter than the 6-byte needle was missed entirely, and worse, the offset arithmetic assumed an overlap it hadn't been given — so a match just after a short chunk trimmed bytes off the end of the head. It now carries the last `needle - 1` bytes of everything scanned.
- **`destroy()` isn't instantaneous.** Already-queued chunks were still being appended *after* the cut — past the `</head>` we'd just trimmed to, and past `maxBytes` on the truncation path. Both of this function's guarantees needed the handler to stop listening once it was done.

Each was confirmed by reverting the fix and watching the new test fail.

### On the testing

The guard is asserted at a **real origin**, by counting requests rather than by observing a failure — an unreachable URL fails too, so "it errored" is not evidence of a block. Each test stands up a live server, proves it's serving, then proves nothing of ours ever arrives. The hostname test dials the origin first on purpose: that leaves a warm keep-alive socket in `globalAgent`'s pool, so a regression back to the shared agent would show up here.

Redirect following has its own file. It needs the address policy **inverted** to reach a live origin at all, since the real guard (correctly) blocks loopback. What's mocked is the policy; `normalizeUrl`, the redirect loop, the per-hop re-validation and the pin are all the shipping code, over real sockets. Redirect behaviour had no test anywhere on the reference branch.

### Also

The preview user-agent shares the app's version and `USER_AGENT_CONTACT` override instead of hardcoding `Lurker/1.0` and its own contact URL — it was already stale against 1.1.5. It stays a separate string from the app-wide `USER_AGENT`: naming the social-preview class is exactly what we don't want on upload-provider requests.

`previewsEnabled()` deliberately **isn't** here. It's a feature flag rather than a fetch concern, and it'd have no consumers until PR 4, so it moves there with its tests.

### Checks

`npm run check` and the full suite (3129 tests, 228 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)