### PR TITLE
Link previews 3/6: metadata scraping and the embed table

### DIFF
--- a/server/services/linkEmbed.test.ts
+++ b/server/services/linkEmbed.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { videoEmbedFor, oembedEndpointFor, EMBED_ORIGINS } from './linkEmbed.js';
+
+const embed = (raw: string) => videoEmbedFor(new URL(raw));
+
+describe('videoEmbedFor — YouTube', () => {
+  it('recognises every shape people actually paste', () => {
+    for (const raw of [
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://m.youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://youtu.be/dQw4w9WgXcQ',
+      'https://www.youtube.com/embed/dQw4w9WgXcQ',
+      'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+      'https://www.youtube.com/live/dQw4w9WgXcQ',
+    ]) {
+      expect(embed(raw)?.embedUrl).toContain('dQw4w9WgXcQ');
+    }
+  });
+
+  it('always uses the no-cookie host', () => {
+    const e = embed('https://www.youtube.com/watch?v=abc123');
+    expect(e?.embedUrl.startsWith('https://www.youtube-nocookie.com/embed/')).toBe(true);
+    expect(e?.provider).toBe('YouTube');
+  });
+
+  it('carries a start time through', () => {
+    expect(embed('https://youtu.be/abc123?t=90')?.embedUrl).toContain('start=90');
+    expect(embed('https://www.youtube.com/watch?v=abc123&start=42')?.embedUrl).toContain(
+      'start=42',
+    );
+  });
+
+  it('ignores a nonsense start time rather than passing it on', () => {
+    expect(embed('https://youtu.be/abc123?t=notanumber')?.embedUrl).not.toContain('start=');
+    expect(embed('https://youtu.be/abc123?t=-5')?.embedUrl).not.toContain('start=');
+  });
+
+  it('suppresses end-screen recommendations from other channels', () => {
+    expect(embed('https://youtu.be/abc123')?.embedUrl).toContain('rel=0');
+  });
+
+  it('refuses an id that is not id-shaped', () => {
+    // The id lands in a URL we construct, so anything with structure in it is
+    // either a parse mistake or someone probing.
+    expect(embed('https://www.youtube.com/watch?v=../../evil')).toBeNull();
+    expect(embed('https://www.youtube.com/watch?v=a%2Fb')).toBeNull();
+    expect(embed('https://www.youtube.com/watch?v=')).toBeNull();
+  });
+
+  it('is not fooled by a lookalike hostname', () => {
+    expect(embed('https://youtube.com.evil.test/watch?v=abc123')).toBeNull();
+    expect(embed('https://notyoutube.com/watch?v=abc123')).toBeNull();
+  });
+});
+
+describe('videoEmbedFor — Vimeo', () => {
+  it('recognises the usual forms', () => {
+    expect(embed('https://vimeo.com/123456789')?.embedUrl).toContain('123456789');
+    expect(embed('https://player.vimeo.com/video/123456789')?.embedUrl).toContain('123456789');
+  });
+
+  it('asks Vimeo not to track', () => {
+    expect(embed('https://vimeo.com/123456789')?.embedUrl).toContain('dnt=1');
+  });
+});
+
+describe('videoEmbedFor — everything else', () => {
+  it('returns null, which is an ordinary outcome', () => {
+    // A non-video link still gets a normal card; it just has no play button.
+    expect(embed('https://example.com/an-article')).toBeNull();
+  });
+});
+
+describe('EMBED_ORIGINS', () => {
+  it('covers every origin the table can actually emit', () => {
+    const emitted = [
+      embed('https://youtu.be/abc123')!.embedUrl,
+      embed('https://vimeo.com/123')!.embedUrl,
+    ];
+    for (const url of emitted) {
+      expect(EMBED_ORIGINS.some((o) => url.startsWith(o))).toBe(true);
+    }
+  });
+});
+
+describe('oembedEndpointFor', () => {
+  const endpoint = (raw: string) => oembedEndpointFor(new URL(raw));
+
+  it('knows YouTube, from any shape the link was pasted in', () => {
+    // ⚠ This is the whole reason the provider table exists. Measured against the real
+    // site: 256 KB of youtube.com HTML read, truncated, and `og:title` NOT PRESENT in it
+    // — YouTube front-loads a huge inline config blob. The oEmbed endpoint answers the
+    // same question in 848 bytes.
+    for (const raw of [
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://youtu.be/dQw4w9WgXcQ',
+      'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+    ]) {
+      expect(endpoint(raw)).toBe(
+        'https://www.youtube.com/oembed?url=' +
+          encodeURIComponent('https://www.youtube.com/watch?v=dQw4w9WgXcQ') +
+          '&format=json',
+      );
+    }
+  });
+
+  it('canonicalises before asking, so one video is one cache entry', () => {
+    // youtu.be/X and youtube.com/watch?v=X are the same video; the endpoint must not
+    // depend on which one was typed.
+    expect(endpoint('https://youtu.be/abc123')).toBe(
+      endpoint('https://www.youtube.com/watch?v=abc123'),
+    );
+  });
+
+  it('knows Vimeo', () => {
+    expect(endpoint('https://vimeo.com/123456789')).toBe(
+      'https://vimeo.com/api/oembed.json?url=' + encodeURIComponent('https://vimeo.com/123456789'),
+    );
+  });
+
+  it('returns null for everything else, so the scraper handles it', () => {
+    expect(endpoint('https://example.com/an-article')).toBeNull();
+    expect(endpoint('https://youtube.com.evil.test/watch?v=abc')).toBeNull();
+  });
+});

--- a/server/services/linkEmbed.test.ts
+++ b/server/services/linkEmbed.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { videoEmbedFor, oembedEndpointFor, EMBED_ORIGINS } from './linkEmbed.js';
+import {
+  videoEmbedFor,
+  oembedEndpointFor,
+  EMBED_ORIGINS,
+  isEmbeddableOrigin,
+} from './linkEmbed.js';
 
 const embed = (raw: string) => videoEmbedFor(new URL(raw));
 
@@ -34,9 +39,38 @@ describe('videoEmbedFor — YouTube', () => {
     );
   });
 
+  it("understands YouTube's own 1h2m3s timestamp syntax", () => {
+    // ⚠⚠ Regression guard. `Number.parseInt` PREFIX-parses, so `?t=1m30s` — the form YouTube's
+    // share dialog emits for any timestamp past a minute — silently became `start=1`. A link
+    // shared at 1:30 started the player one second in, with no signal, which is strictly worse
+    // than the `?t=notanumber` case below where the guard correctly emits nothing.
+    const start = (u: string) => new URL(embed(u)!.embedUrl).searchParams.get('start');
+    expect(start('https://youtu.be/abc123?t=1m30s')).toBe('90');
+    expect(start('https://youtu.be/abc123?t=1h2m3s')).toBe('3723');
+    expect(start('https://youtu.be/abc123?t=45s')).toBe('45');
+    expect(start('https://youtu.be/abc123?t=2h')).toBe('7200');
+  });
+
   it('ignores a nonsense start time rather than passing it on', () => {
     expect(embed('https://youtu.be/abc123?t=notanumber')?.embedUrl).not.toContain('start=');
     expect(embed('https://youtu.be/abc123?t=-5')?.embedUrl).not.toContain('start=');
+    // ⚠ `1e3` prefix-parsed to 1, and a huge value passed `Number.isFinite` and `> 0` while
+    // `String(1e21)` is '1e+21' — so `start=1e%2B21` went to a third-party origin immediately
+    // after the module had validated the video id against SAFE_ID.
+    expect(embed('https://youtu.be/abc123?t=1e3')?.embedUrl).not.toContain('start=');
+    expect(embed('https://youtu.be/abc123?t=999999999999999999999')?.embedUrl).not.toContain(
+      'start=',
+    );
+    // Beyond a day is a parse mistake, not a timestamp.
+    expect(embed('https://youtu.be/abc123?t=90000')?.embedUrl).not.toContain('start=');
+  });
+
+  it('does not advertise a fragment form that cannot reach it', () => {
+    // ⚠ `normalizeUrl` strips the fragment upstream (deliberately, so #a and #b share a cache
+    // entry), so `searchParams` never sees one. The comment here used to claim `youtu.be#t=`
+    // was supported — a class-I defect: a comment asserting a behaviour is a testable
+    // assertion, and that one was false.
+    expect(embed('https://youtu.be/dQw4w9WgXcQ#t=90')?.embedUrl).not.toContain('start=');
   });
 
   it('suppresses end-screen recommendations from other channels', () => {
@@ -66,6 +100,31 @@ describe('videoEmbedFor — Vimeo', () => {
   it('asks Vimeo not to track', () => {
     expect(embed('https://vimeo.com/123456789')?.embedUrl).toContain('dnt=1');
   });
+
+  it('does not take digits out of an arbitrary path segment', () => {
+    // ⚠⚠ Regression guard. The pattern was unanchored where YouTube's is anchored, so an
+    // ordinary Vimeo page became an embed of an unrelated video — `/blog/post/10-tips` yielded
+    // id `10` and rendered video #10's title, author and thumbnail with a ▶ over it. A wrong
+    // answer presented as a right one, cached under the blog post's key.
+    expect(embed('https://vimeo.com/blog/post/10-tips-for-video')).toBeNull();
+    expect(embed('https://vimeo.com/album/12345/video/67890')).toBeNull();
+    expect(embed('https://vimeo.com/channels/staffpicks/page/2')).toBeNull();
+    expect(embed('https://vimeo.com/user12345')).toBeNull();
+  });
+
+  it('carries the privacy hash of an unlisted video, in either form', () => {
+    // ⚠ Without `h`, the player refuses the video — so the facade's ▶ opened a broken frame,
+    // which is worse than showing no button at all.
+    expect(embed('https://vimeo.com/123456789?h=deadbeef')?.embedUrl).toContain('h=deadbeef');
+    expect(embed('https://vimeo.com/123456789/deadbeef')?.embedUrl).toContain('h=deadbeef');
+    expect(oembedEndpointFor(new URL('https://vimeo.com/123456789/deadbeef'))).toContain(
+      encodeURIComponent('https://vimeo.com/123456789/deadbeef'),
+    );
+  });
+
+  it('is not fooled by a lookalike hostname', () => {
+    expect(embed('https://vimeo.com.evil.test/123456789')).toBeNull();
+  });
 });
 
 describe('videoEmbedFor — everything else', () => {
@@ -75,15 +134,36 @@ describe('videoEmbedFor — everything else', () => {
   });
 });
 
-describe('EMBED_ORIGINS', () => {
+describe('EMBED_ORIGINS / isEmbeddableOrigin', () => {
   it('covers every origin the table can actually emit', () => {
     const emitted = [
       embed('https://youtu.be/abc123')!.embedUrl,
       embed('https://vimeo.com/123')!.embedUrl,
     ];
     for (const url of emitted) {
-      expect(EMBED_ORIGINS.some((o) => url.startsWith(o))).toBe(true);
+      expect(isEmbeddableOrigin(url)).toBe(true);
+      // The exported array is what a client CSP would be generated from, so it has to contain
+      // the origin in its own right, not merely satisfy the predicate.
+      expect(EMBED_ORIGINS).toContain(new URL(url).origin);
     }
+  });
+
+  it('compares origins, not prefixes', () => {
+    // ⚠⚠ Regression guard. This test used to assert `url.startsWith(origin)`, which is unsound
+    // as an allowlist — and since nothing shipping consumed EMBED_ORIGINS at all, the unsound
+    // check lived only here, verifying the constant against its own module.
+    expect('https://player.vimeo.com.evil.test/x'.startsWith('https://player.vimeo.com')).toBe(
+      true,
+    );
+    expect(isEmbeddableOrigin('https://player.vimeo.com.evil.test/x')).toBe(false);
+    expect(isEmbeddableOrigin('https://www.youtube-nocookie.com.evil.test/embed/x')).toBe(false);
+  });
+
+  it('refuses anything that is not one of the two players', () => {
+    expect(isEmbeddableOrigin('https://www.youtube.com/embed/abc')).toBe(false);
+    expect(isEmbeddableOrigin('http://www.youtube-nocookie.com/embed/abc')).toBe(false); // scheme
+    expect(isEmbeddableOrigin('javascript:alert(1)')).toBe(false);
+    expect(isEmbeddableOrigin('not a url')).toBe(false);
   });
 });
 

--- a/server/services/linkEmbed.ts
+++ b/server/services/linkEmbed.ts
@@ -49,11 +49,56 @@ function youtubeId(url: URL): string | null {
   return null;
 }
 
-function vimeoId(url: URL): string | null {
+/**
+ * A Vimeo video id, and the privacy hash for an unlisted one.
+ *
+ * ⚠⚠ Anchored with `^`, as `youtubeId` always was. Unanchored, `/\/(?:video\/)?(\d+)/` took
+ * digits from ANY path segment, so ordinary Vimeo pages became an embed of an unrelated video:
+ * `vimeo.com/blog/post/10-tips-for-video` yielded id `10` and rendered video #10's title,
+ * author and thumbnail with a ▶ over it — a wrong answer presented as a right one, and cached
+ * under the blog post's key. `vimeo.com/album/12345/video/67890` gave the album id, and
+ * `/channels/staffpicks/page/2` gave the page number.
+ *
+ * ⚠ The `h` parameter is an unlisted video's access token. Dropping it produced an embed URL
+ * the player refuses, so the facade's ▶ opened a broken frame — worse than showing no button.
+ * It arrives two ways: `vimeo.com/ID/HASH` and `vimeo.com/ID?h=HASH`.
+ */
+function vimeoId(url: URL): { id: string; hash?: string } | null {
   const host = url.hostname.replace(/^www\./, '').toLowerCase();
   if (host !== 'vimeo.com' && host !== 'player.vimeo.com') return null;
-  const m = /\/(?:video\/)?(\d+)/.exec(url.pathname);
-  return m ? m[1] : null;
+  const m = /^\/(?:video\/)?(\d+)(?:\/([0-9a-z]+))?\/?$/i.exec(url.pathname);
+  if (!m) return null;
+  const hash = m[2] || url.searchParams.get('h') || undefined;
+  return { id: m[1], hash: hash && /^[0-9a-z]{1,32}$/i.test(hash) ? hash : undefined };
+}
+
+/**
+ * Seconds from a YouTube timestamp.
+ *
+ * ⚠ `Number.parseInt` PREFIX-parses, so YouTube's own `1h2m3s` syntax — which its share dialog
+ * emits for any timestamp past a minute — silently became `start=1`. A link shared at 1:30
+ * started the player one second in, with no signal that anything was wrong; strictly worse than
+ * the `?t=notanumber` case, where the guard correctly emitted nothing.
+ *
+ * Also bounded. `?t=999999999999999999999` passed `Number.isFinite` and `> 0`, and
+ * `String(1e21)` is `'1e+21'`, so the URL carried `start=1e%2B21` to a third-party origin
+ * immediately after the module had validated the video id against `SAFE_ID`.
+ */
+const MAX_START_SECONDS = 24 * 60 * 60;
+
+function startSeconds(raw: string | null): number | null {
+  if (!raw) return null;
+  let total: number;
+  const hms = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i.exec(raw);
+  if (hms && (hms[1] || hms[2] || hms[3])) {
+    total = Number(hms[1] || 0) * 3600 + Number(hms[2] || 0) * 60 + Number(hms[3] || 0);
+  } else if (/^\d+$/.test(raw)) {
+    total = Number(raw);
+  } else {
+    return null;
+  }
+  if (!Number.isSafeInteger(total) || total <= 0 || total > MAX_START_SECONDS) return null;
+  return total;
 }
 
 // Ids reach a URL we build, so they get a strict shape check first. Both
@@ -77,10 +122,15 @@ export function videoEmbedFor(url: URL): VideoEmbed | null {
       // Don't let the player suggest videos from unrelated channels when it ends.
       rel: '0',
     });
-    // Start time, if the link carried one (?t=90 / ?start=90 / youtu.be#t=).
-    const t = url.searchParams.get('t') || url.searchParams.get('start');
-    const seconds = t ? Number.parseInt(t, 10) : NaN;
-    if (Number.isFinite(seconds) && seconds > 0) params.set('start', String(seconds));
+    // Start time, if the link carried one: `?t=90`, `?t=1m30s`, `?start=90`.
+    //
+    // ⚠ A `youtu.be#t=` fragment is NOT reachable and never was — `normalizeUrl` strips the
+    // fragment upstream, deliberately, so `#a` and `#b` share one cache entry, and
+    // `searchParams` never sees one. The old comment here advertised it as supported, which is
+    // the class-I defect this project has a rule about: a comment claiming a behaviour is a
+    // testable assertion, and this one was false.
+    const seconds = startSeconds(url.searchParams.get('t') || url.searchParams.get('start'));
+    if (seconds !== null) params.set('start', String(seconds));
     return {
       embedUrl: `https://www.youtube-nocookie.com/embed/${yt}?${params}`,
       provider: 'YouTube',
@@ -88,9 +138,11 @@ export function videoEmbedFor(url: URL): VideoEmbed | null {
   }
 
   const vim = vimeoId(url);
-  if (vim && SAFE_ID.test(vim)) {
+  if (vim && SAFE_ID.test(vim.id)) {
+    const params = new URLSearchParams({ autoplay: '1', dnt: '1' });
+    if (vim.hash) params.set('h', vim.hash);
     return {
-      embedUrl: `https://player.vimeo.com/video/${vim}?autoplay=1&dnt=1`,
+      embedUrl: `https://player.vimeo.com/video/${vim.id}?${params}`,
       provider: 'Vimeo',
     };
   }
@@ -102,9 +154,10 @@ export function videoEmbedFor(url: URL): VideoEmbed | null {
  * A provider's oEmbed endpoint for a URL, when we know it without asking.
  *
  * ⚠ This exists because scraping YouTube does not work, and cannot be made to work by
- * turning a dial. Measured on `youtube.com/watch?v=…`: 256 KB of HTML read, truncated, and
- * `og:title` **not present anywhere in it** — YouTube front-loads a colossal inline config
- * blob and puts its metadata after it. The Lounge hit the same wall and exposed
+ * turning a dial. Measured on `youtube.com/watch?v=…` against a 256 KB cap (what
+ * `MAX_SCRAPE_BYTES` was at the time; it is 512 KB now, and the finding is the same): the read
+ * was truncated with `og:title` **not present anywhere in it** — YouTube front-loads a colossal
+ * inline config blob and puts its metadata after it. The Lounge hit the same wall and exposed
  * `prefetchMaxSearchSize` as a config knob so admins could raise it past 300 KB.
  *
  * The same request against YouTube's own oEmbed endpoint returns **848 bytes** containing
@@ -124,8 +177,11 @@ export function oembedEndpointFor(url: URL): string | null {
     return `https://www.youtube.com/oembed?url=${encodeURIComponent(canonical)}&format=json`;
   }
   const vim = vimeoId(url);
-  if (vim && SAFE_ID.test(vim)) {
-    const canonical = `https://vimeo.com/${vim}`;
+  if (vim && SAFE_ID.test(vim.id)) {
+    // The hash goes to the endpoint too, or an unlisted video answers 404.
+    const canonical = vim.hash
+      ? `https://vimeo.com/${vim.id}/${vim.hash}`
+      : `https://vimeo.com/${vim.id}`;
     return `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(canonical)}`;
   }
   return null;
@@ -134,8 +190,35 @@ export function oembedEndpointFor(url: URL): string | null {
 /**
  * Origins a client may load in a preview iframe.
  *
- * Exported so the Vue client's CSP frame-src and this table can't drift apart —
- * a provider added above without the CSP updated would silently render a blank
- * frame, which is the kind of bug that takes an afternoon.
+ * ⚠⚠ The comment that used to sit here said this existed "so the Vue client's CSP frame-src
+ * and this table can't drift apart." **There is no CSP frame-src anywhere in this repo** — the
+ * only Content-Security-Policy in the tree is `default-src 'none'; sandbox` on uploaded bytes
+ * in `routes/localUploads.ts`, which is a per-response header on a download, not a document
+ * policy. This exact false claim is item 30 of `LINK_PREVIEWS_BUG_INVENTORY.md`, found and
+ * written down once already, and it came back verbatim when the file was carried across
+ * untouched. A comment asserting a guarantee is a testable assertion; this one would have led
+ * whoever adds Twitch to believe the CSP had them covered.
+ *
+ * What is actually true: this is the allowlist, and `isEmbeddableOrigin` is how a client must
+ * check `embedUrl` before framing it. Adding a provider above means adding its origin here —
+ * and when a real CSP does land, generating `frame-src` from this array is the way to keep
+ * that promise honest.
  */
 export const EMBED_ORIGINS = ['https://www.youtube-nocookie.com', 'https://player.vimeo.com'];
+
+/**
+ * Whether a URL may be framed — a real origin comparison, not a prefix test.
+ *
+ * ⚠ `url.startsWith(origin)` is unsound as an allowlist and it was the idiom the test used:
+ * `'https://player.vimeo.com.evil.test/x'.startsWith('https://player.vimeo.com')` is `true`.
+ * Nothing shipping consumed `EMBED_ORIGINS` at all, so the unsound check lived only in a test
+ * that verified the constant against its own module — which is why this exists as a function
+ * clients can call rather than an array they each re-implement a check against.
+ */
+export function isEmbeddableOrigin(embedUrl: string): boolean {
+  try {
+    return EMBED_ORIGINS.includes(new URL(embedUrl).origin);
+  } catch {
+    return false;
+  }
+}

--- a/server/services/linkEmbed.ts
+++ b/server/services/linkEmbed.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Turning a video page URL into a player URL we're willing to put in an iframe.
+//
+// ⚠ The embed URL is derived HERE, from a table we maintain — never taken from
+// the provider. oEmbed replies carry an `html` field containing a ready-made
+// iframe, and dropping a third party's markup into the message list would be an
+// XSS vector with a standards document attached. We read the structured fields
+// (title, author, thumbnail) and construct the player ourselves, so the only
+// origins that can ever end up in a frame are the ones written below.
+//
+// Everything here is privacy-first by construction:
+//
+//   - YouTube goes to youtube-nocookie.com, which defers tracking cookies until
+//     playback actually starts.
+//   - The thumbnail is proxied through us like any other preview image, so not
+//     even the *thumbnail* request reaches Google. This matters more than it
+//     sounds: a channel with fifty YouTube links in scrollback would otherwise
+//     hand Google fifty impressions of you, from your IP, for videos you never
+//     watched.
+//   - The iframe is not created until the viewer clicks play (the facade
+//     pattern, in the clients). Nothing here talks to a provider on render.
+//
+// So the full sequence for a YouTube link is: our server scrapes the page, our
+// server fetches the thumbnail, our server hands the client a card — and the
+// first request the *viewer* makes to Google is the one they asked for by
+// pressing ▶.
+
+export interface VideoEmbed {
+  /** Origin-restricted player URL, safe to put in an iframe on click. */
+  embedUrl: string;
+  provider: string;
+}
+
+/** Extract a YouTube video id from any of the shapes people paste. */
+function youtubeId(url: URL): string | null {
+  const host = url.hostname.replace(/^www\./, '').toLowerCase();
+  if (host === 'youtu.be') {
+    const id = url.pathname.slice(1).split('/')[0];
+    return id || null;
+  }
+  if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com') {
+    if (url.pathname === '/watch') return url.searchParams.get('v');
+    // /embed/ID, /v/ID, /shorts/ID, /live/ID
+    const m = /^\/(?:embed|v|shorts|live)\/([^/?#]+)/.exec(url.pathname);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+function vimeoId(url: URL): string | null {
+  const host = url.hostname.replace(/^www\./, '').toLowerCase();
+  if (host !== 'vimeo.com' && host !== 'player.vimeo.com') return null;
+  const m = /\/(?:video\/)?(\d+)/.exec(url.pathname);
+  return m ? m[1] : null;
+}
+
+// Ids reach a URL we build, so they get a strict shape check first. Both
+// providers use short alphanumeric-ish tokens; anything else is either a parse
+// mistake or someone probing for an injection.
+const SAFE_ID = /^[\w-]{1,64}$/;
+
+/**
+ * The player URL for a video page, or null if we don't know this provider.
+ *
+ * Returning null is a normal outcome, not a failure: the link still gets an
+ * ordinary preview card with its thumbnail, it just doesn't get a ▶.
+ */
+export function videoEmbedFor(url: URL): VideoEmbed | null {
+  const yt = youtubeId(url);
+  if (yt && SAFE_ID.test(yt)) {
+    const params = new URLSearchParams({
+      // The user clicked play, so start playing; without this the facade costs
+      // a second click for no reason.
+      autoplay: '1',
+      // Don't let the player suggest videos from unrelated channels when it ends.
+      rel: '0',
+    });
+    // Start time, if the link carried one (?t=90 / ?start=90 / youtu.be#t=).
+    const t = url.searchParams.get('t') || url.searchParams.get('start');
+    const seconds = t ? Number.parseInt(t, 10) : NaN;
+    if (Number.isFinite(seconds) && seconds > 0) params.set('start', String(seconds));
+    return {
+      embedUrl: `https://www.youtube-nocookie.com/embed/${yt}?${params}`,
+      provider: 'YouTube',
+    };
+  }
+
+  const vim = vimeoId(url);
+  if (vim && SAFE_ID.test(vim)) {
+    return {
+      embedUrl: `https://player.vimeo.com/video/${vim}?autoplay=1&dnt=1`,
+      provider: 'Vimeo',
+    };
+  }
+
+  return null;
+}
+
+/**
+ * A provider's oEmbed endpoint for a URL, when we know it without asking.
+ *
+ * ⚠ This exists because scraping YouTube does not work, and cannot be made to work by
+ * turning a dial. Measured on `youtube.com/watch?v=…`: 256 KB of HTML read, truncated, and
+ * `og:title` **not present anywhere in it** — YouTube front-loads a colossal inline config
+ * blob and puts its metadata after it. The Lounge hit the same wall and exposed
+ * `prefetchMaxSearchSize` as a config knob so admins could raise it past 300 KB.
+ *
+ * The same request against YouTube's own oEmbed endpoint returns **848 bytes** containing
+ * the title, the author, and a thumbnail URL. Raising a byte cap to "fix" this would mean
+ * downloading a megabyte of someone's HTML to extract what they will hand over in under a
+ * kilobyte if asked properly.
+ *
+ * So: known providers are asked directly, before any scraping. Discovery via
+ * `<link rel=alternate type=application/json+oembed>` still runs for everyone else
+ * (see linkMeta), and HTML scraping remains the fallback for both.
+ */
+export function oembedEndpointFor(url: URL): string | null {
+  const yt = youtubeId(url);
+  if (yt && SAFE_ID.test(yt)) {
+    // The endpoint wants the canonical watch URL, not whatever shape was pasted.
+    const canonical = `https://www.youtube.com/watch?v=${yt}`;
+    return `https://www.youtube.com/oembed?url=${encodeURIComponent(canonical)}&format=json`;
+  }
+  const vim = vimeoId(url);
+  if (vim && SAFE_ID.test(vim)) {
+    const canonical = `https://vimeo.com/${vim}`;
+    return `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(canonical)}`;
+  }
+  return null;
+}
+
+/**
+ * Origins a client may load in a preview iframe.
+ *
+ * Exported so the Vue client's CSP frame-src and this table can't drift apart —
+ * a provider added above without the CSP updated would silently render a blank
+ * frame, which is the kind of bug that takes an afternoon.
+ */
+export const EMBED_ORIGINS = ['https://www.youtube-nocookie.com', 'https://player.vimeo.com'];

--- a/server/services/linkFetch.redirects.test.ts
+++ b/server/services/linkFetch.redirects.test.ts
@@ -96,6 +96,36 @@ describe('pinnedLookup, on the path where it actually runs', () => {
   });
 });
 
+describe('the Content-Type a real origin sends', () => {
+  it('splits into a bare type and the declared charset', async () => {
+    // ⚠ The producer half of a seam that was broken end to end. `decodeBody` used to re-parse
+    // a header it was never given — callers had only `contentType`, stripped of its
+    // parameters — so a page served in a non-UTF-8 encoding decoded as UTF-8 and rendered as
+    // replacement characters. `decodeBody` now takes `charset`; this asserts something real
+    // arrives in it, off a live response rather than a hand-built object.
+    reset((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/HTML; charset="Windows-1251"' });
+      res.end('<head><title>ARRIVED</title></head>');
+    });
+    const res = await safeRequest(new URL(`${base}/page`));
+    expect(res.contentType).toBe('text/html');
+    expect(res.charset).toBe('windows-1251');
+    // And it survives buffering, which is the object the scraper actually holds.
+    const buffered = await bufferStream(res, { maxBytes: 4096 });
+    expect(buffered.charset).toBe('windows-1251');
+  });
+
+  it('reports no charset when the origin declared none', async () => {
+    reset((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<head></head>');
+    });
+    const res = await safeRequest(new URL(`${base}/page`));
+    expect(res.charset).toBeNull();
+    res.stream.destroy();
+  });
+});
+
 describe('safeRequest — following redirects', () => {
   it('follows a hop and reports the URL it ENDED at', async () => {
     // `finalUrl` is the base for resolving a relative og:image, so a stale one silently points

--- a/server/services/linkMeta.test.ts
+++ b/server/services/linkMeta.test.ts
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { scrapeMeta, readOEmbed, decodeEntities, decodeBody } from './linkMeta.js';
+
+describe('decodeEntities', () => {
+  it('decodes the named entities that show up in titles', () => {
+    expect(decodeEntities('Tom &amp; Jerry')).toBe('Tom & Jerry');
+    expect(decodeEntities('&quot;quoted&quot;')).toBe('"quoted"');
+    expect(decodeEntities('it&apos;s')).toBe("it's");
+    expect(decodeEntities('a &mdash; b')).toBe('a — b');
+  });
+
+  it('decodes decimal and hex numeric references', () => {
+    expect(decodeEntities('caf&#233;')).toBe('café');
+    expect(decodeEntities('caf&#xe9;')).toBe('café');
+    expect(decodeEntities('&#x1F600;')).toBe('😀');
+  });
+
+  it('leaves unknown and malformed references alone rather than mangling them', () => {
+    expect(decodeEntities('&notarealentity;')).toBe('&notarealentity;');
+    // A lone surrogate would throw fromCodePoint; it must survive as literal text.
+    expect(decodeEntities('&#xD800;')).toBe('&#xD800;');
+    expect(decodeEntities('&#999999999;')).toBe('&#999999999;');
+  });
+
+  it('does not double-decode', () => {
+    // A site that double-escapes gets `&amp;` back, not `&`. Decoding twice
+    // would be a mangling risk for everyone else.
+    expect(decodeEntities('a &amp;amp; b')).toBe('a &amp; b');
+  });
+});
+
+describe('scrapeMeta', () => {
+  it('prefers Open Graph over Twitter Card over <title>', () => {
+    const meta = scrapeMeta(`
+      <html><head>
+        <title>Tab Title</title>
+        <meta name="twitter:title" content="Twitter Title">
+        <meta property="og:title" content="OG Title">
+      </head><body></body></html>`);
+    expect(meta.title).toBe('OG Title');
+  });
+
+  it('falls back down the chain when the preferred tag is absent', () => {
+    expect(scrapeMeta('<head><title>Only Title</title></head>').title).toBe('Only Title');
+    expect(scrapeMeta('<head><meta name="twitter:title" content="Tw"></head>').title).toBe('Tw');
+  });
+
+  it('reads attributes in any order and with any quoting', () => {
+    const meta = scrapeMeta(`<head>
+      <meta content='Single Quoted' property='og:title'>
+      <meta property=og:site_name content=Unquoted>
+    </head>`);
+    expect(meta.title).toBe('Single Quoted');
+    expect(meta.siteName).toBe('Unquoted');
+  });
+
+  it('takes the first og:image when a page lists several', () => {
+    const meta = scrapeMeta(`<head>
+      <meta property="og:image" content="https://e.test/first.png">
+      <meta property="og:image" content="https://e.test/second.png">
+    </head>`);
+    expect(meta.imageUrl).toBe('https://e.test/first.png');
+  });
+
+  it('prefers og:image:secure_url over og:image', () => {
+    const meta = scrapeMeta(`<head>
+      <meta property="og:image" content="http://e.test/plain.png">
+      <meta property="og:image:secure_url" content="https://e.test/secure.png">
+    </head>`);
+    expect(meta.imageUrl).toBe('https://e.test/secure.png');
+  });
+
+  it('is not fooled by a hyphen-prefixed attribute of the same name', () => {
+    // ⚠ `\bcontent` matches INSIDE `data-content` — a hyphen is a non-word character, so the
+    // boundary holds there — and the first match won, so the card showed the placeholder.
+    const meta = scrapeMeta(
+      `<head><meta property="og:title" data-content="Loading…" content="Real Title"></head>`,
+    );
+    expect(meta.title).toBe('Real Title');
+  });
+
+  it('is not fooled by data-name or data-type either', () => {
+    const meta = scrapeMeta(
+      `<head><meta data-name="decoy" name="twitter:title" content="Tw"></head>`,
+    );
+    expect(meta.title).toBe('Tw');
+
+    // `type` vs `data-type` in the oEmbed scan could hide an endpoint entirely.
+    const oembed = scrapeMeta(
+      `<head><link rel="alternate" data-type="text/xml+oembed" ` +
+        `type="application/json+oembed" href="https://e.test/o"></head>`,
+    );
+    expect(oembed.oembedUrl).toBe('https://e.test/o');
+  });
+
+  it('ignores meta tags that live in the body', () => {
+    // A stray <meta> inside a third-party embed must not win over the head.
+    const meta = scrapeMeta(`
+      <head><meta property="og:title" content="Real"></head>
+      <body><meta property="og:title" content="Injected"></body>`);
+    expect(meta.title).toBe('Real');
+  });
+
+  it('discovers an oEmbed endpoint', () => {
+    const meta = scrapeMeta(`<head>
+      <link rel="alternate" type="application/json+oembed" href="https://e.test/oembed?url=x">
+    </head>`);
+    expect(meta.oembedUrl).toBe('https://e.test/oembed?url=x');
+  });
+
+  it('ignores the XML oEmbed variant, which we do not parse', () => {
+    const meta = scrapeMeta(`<head>
+      <link rel="alternate" type="text/xml+oembed" href="https://e.test/oembed.xml">
+    </head>`);
+    expect(meta.oembedUrl).toBeUndefined();
+  });
+
+  it('decodes entities and collapses whitespace in text fields', () => {
+    const meta = scrapeMeta(
+      `<head><meta property="og:description" content="Tom &amp; Jerry\n   go   west"></head>`,
+    );
+    expect(meta.description).toBe('Tom & Jerry go west');
+  });
+
+  it('drops fields that decode to nothing', () => {
+    const meta = scrapeMeta(`<head><meta property="og:title" content="   "></head>`);
+    expect(meta.title).toBeUndefined();
+  });
+
+  it('returns an empty result for a document with no metadata', () => {
+    const meta = scrapeMeta('<html><body><p>hello</p></body></html>');
+    expect(meta.title).toBeUndefined();
+    expect(meta.imageUrl).toBeUndefined();
+  });
+});
+
+describe('decodeBody', () => {
+  const cafe = Buffer.from([0x63, 0x61, 0x66, 0xe9]); // café, latin1
+
+  it('honours the charset the origin declared', () => {
+    // ⚠ Regression guard. This took the raw `Content-Type` header and re-parsed it, which
+    // could never match — every caller had only `RawResponse.contentType`, already stripped
+    // to a bare `text/html`. The parameter is now the PARSED charset (`RawResponse.charset`),
+    // so this is the branch that keeps a windows-1252 title out of replacement characters.
+    expect(decodeBody(cafe, 'iso-8859-1')).toBe('café');
+    expect(decodeBody(cafe, 'windows-1252')).toBe('café');
+  });
+
+  it('is not passed a header, and does not try to read one', () => {
+    // Belt and braces on the same bug: a caller that regresses to handing over the whole
+    // header gets UTF-8, not a silently half-working parse.
+    expect(decodeBody(cafe, 'text/html; charset=iso-8859-1')).not.toBe('café');
+  });
+
+  it('honours a charset declared in the document when the origin declared none', () => {
+    const body = Buffer.concat([
+      Buffer.from('<meta charset="windows-1252">', 'latin1'),
+      Buffer.from([0xe9]),
+    ]);
+    expect(decodeBody(body, null)).toContain('é');
+  });
+
+  it('defaults to UTF-8', () => {
+    expect(decodeBody(Buffer.from('café', 'utf8'), null)).toBe('café');
+  });
+
+  it('falls back to UTF-8 for an encoding node cannot speak', () => {
+    // windows-1251 is Cyrillic; we have no decoder for it, and guessing latin1 would be
+    // worse than the modern default.
+    expect(decodeBody(Buffer.from('café', 'utf8'), 'windows-1251')).toBe('café');
+  });
+
+  it('lets the origin win over the document declaration', () => {
+    // A document copied between encodings keeps a stale <meta charset>; the header describes
+    // the bytes actually on the wire.
+    const body = Buffer.from('<meta charset="utf-8">', 'latin1');
+    expect(decodeBody(body, 'iso-8859-1')).toContain('meta charset');
+  });
+});
+
+describe('readOEmbed', () => {
+  it('reads the structured fields', () => {
+    const meta = readOEmbed({
+      type: 'video',
+      title: 'A Video',
+      author_name: 'Someone',
+      provider_name: 'YouTube',
+      thumbnail_url: 'https://i.test/t.jpg',
+      thumbnail_width: 480,
+      thumbnail_height: 360,
+    });
+    expect(meta).toMatchObject({
+      type: 'video',
+      title: 'A Video',
+      authorName: 'Someone',
+      providerName: 'YouTube',
+      thumbnailUrl: 'https://i.test/t.jpg',
+      thumbnailWidth: 480,
+      thumbnailHeight: 360,
+    });
+  });
+
+  it('never surfaces the provider html field', () => {
+    // The whole point: oEmbed hands back a ready-made iframe and we refuse it.
+    const meta = readOEmbed({ type: 'video', html: '<iframe src="https://evil.test"></iframe>' });
+    expect(JSON.stringify(meta)).not.toContain('iframe');
+  });
+
+  it('rejects non-object input', () => {
+    expect(readOEmbed(null)).toBeNull();
+    expect(readOEmbed('a string')).toBeNull();
+  });
+
+  it('ignores fields of the wrong type or nonsensical value', () => {
+    const meta = readOEmbed({ title: 42, thumbnail_width: -1, author_name: '   ' });
+    expect(meta?.title).toBeUndefined();
+    expect(meta?.thumbnailWidth).toBeUndefined();
+    expect(meta?.authorName).toBeUndefined();
+  });
+});

--- a/server/services/linkMeta.test.ts
+++ b/server/services/linkMeta.test.ts
@@ -30,6 +30,43 @@ describe('decodeEntities', () => {
     // would be a mangling risk for everyone else.
     expect(decodeEntities('a &amp;amp; b')).toBe('a &amp; b');
   });
+
+  it('decodes the accented entities that non-English metadata is full of', () => {
+    // ⚠ Regression guard. The table was punctuation-only, so this rendered LITERALLY in the
+    // card — the exact defect decodeEntities exists to prevent, on every French, German,
+    // Spanish and Nordic page.
+    expect(decodeEntities('Caf&eacute; M&uuml;ller')).toBe('Café Müller');
+    expect(decodeEntities('&Aring;ngstr&ouml;m &ccedil;a &ntilde;')).toBe('Ångström ça ñ');
+    expect(decodeEntities('&copy; 2026 &mdash; 50&deg;')).toBe('© 2026 — 50°');
+  });
+
+  it('respects entity case, which selects a different character', () => {
+    expect(decodeEntities('&eacute; vs &Eacute;')).toBe('é vs É');
+    expect(decodeEntities('&auml; vs &Auml;')).toBe('ä vs Ä');
+  });
+
+  it('does not read through to Object.prototype', () => {
+    // ⚠⚠ Regression guard. As a plain object literal the table's lookup walked the prototype
+    // chain, and `?? match` accepted what it found because a function is neither null nor
+    // undefined — so native-code source text was injected into user-facing card text and into
+    // an og:image URL the server then resolved and fetched.
+    expect(decodeEntities('Rock &constructor; Roll')).toBe('Rock &constructor; Roll');
+    expect(decodeEntities('&toString; &valueOf; &hasOwnProperty;')).toBe(
+      '&toString; &valueOf; &hasOwnProperty;',
+    );
+  });
+
+  it('refuses to mint control characters', () => {
+    // ⚠⚠ Regression guard. U+0003 is mIRC colour and U+0002 is mIRC bold, and Lurker's own
+    // renderer parses them — so a scraped page controlled formatting in the message list. A
+    // NUL additionally truncates in any C-string consumer of the SQLite column. The whitespace
+    // collapse removes none of these: `\s` matches neither C0 below \t nor the C1 range.
+    expect(decodeEntities('a&#3;04red&#0;NUL&#2;bold')).toBe('a&#3;04red&#0;NUL&#2;bold');
+    expect(decodeEntities('&#x1b;[31m')).toBe('&#x1b;[31m');
+    expect(decodeEntities('&#127; &#x85;')).toBe('&#127; &#x85;');
+    // The three legitimate whitespace controls still decode.
+    expect(decodeEntities('a&#9;b&#10;c&#13;d')).toBe('a\tb\nc\rd');
+  });
 });
 
 describe('scrapeMeta', () => {
@@ -118,6 +155,46 @@ describe('scrapeMeta', () => {
     expect(meta.oembedUrl).toBeUndefined();
   });
 
+  it('finds both an oEmbed endpoint and an image_src whatever their order', () => {
+    // ⚠ Regression guard. The loop `break`s on the first oEmbed-typed tag, so the same document
+    // produced a different card depending purely on tag order — and PR 4 returns `unavailable`
+    // for a page with neither title nor image, so a page whose best-effort oEmbed fetch failed
+    // got no card at all and was negative-cached.
+    const oembedFirst = scrapeMeta(`<head>
+      <link rel="alternate" type="application/json+oembed" href="https://e.test/o">
+      <link rel="image_src" href="https://e.test/i.png">
+    </head>`);
+    const imageFirst = scrapeMeta(`<head>
+      <link rel="image_src" href="https://e.test/i.png">
+      <link rel="alternate" type="application/json+oembed" href="https://e.test/o">
+    </head>`);
+    expect(oembedFirst).toEqual(imageFirst);
+    expect(oembedFirst.oembedUrl).toBe('https://e.test/o');
+    expect(oembedFirst.imageUrl).toBe('https://e.test/i.png');
+  });
+
+  it('does not let an href-less oEmbed link hide a valid one', () => {
+    const meta = scrapeMeta(`<head>
+      <link rel="alternate" type="application/json+oembed">
+      <link rel="alternate" type="application/json+oembed" href="https://e.test/real">
+    </head>`);
+    expect(meta.oembedUrl).toBe('https://e.test/real');
+  });
+
+  it('matches rel as a token list, not as a substring', () => {
+    // `includes('alternate')` accepted `notalternateatall`; a real rel is space-separated.
+    expect(
+      scrapeMeta(
+        '<head><link rel="notalternateatall" type="application/json+oembed" href="https://e.test/o"></head>',
+      ).oembedUrl,
+    ).toBeUndefined();
+    expect(
+      scrapeMeta(
+        '<head><link rel="alternate canonical" type="application/json+oembed" href="https://e.test/o"></head>',
+      ).oembedUrl,
+    ).toBe('https://e.test/o');
+  });
+
   it('decodes entities and collapses whitespace in text fields', () => {
     const meta = scrapeMeta(
       `<head><meta property="og:description" content="Tom &amp; Jerry\n   go   west"></head>`,
@@ -135,6 +212,184 @@ describe('scrapeMeta', () => {
     expect(meta.title).toBeUndefined();
     expect(meta.imageUrl).toBeUndefined();
   });
+
+  it('OMITS absent fields rather than setting them undefined', () => {
+    // ⚠⚠ Regression guard, and the bite is at the merge PR 4 writes. Every field used to be
+    // assigned unconditionally, so the result always carried five keys — and
+    // `{...oembedValues, ...scrapeMeta(html)}` evaluated to all-undefined, silently destroying
+    // every oEmbed field the spread was meant to fall back to. JSON.stringify hides it, so it
+    // would never show up in a logged payload either.
+    const meta = scrapeMeta('<html><body><p>hello</p></body></html>');
+    expect(Object.keys(meta)).toEqual([]);
+    expect('imageUrl' in meta).toBe(false);
+    const fromOEmbed = { title: 'from oEmbed', imageUrl: 'https://i.test/t.jpg' };
+    expect({ ...fromOEmbed, ...meta }.title).toBe('from oEmbed');
+  });
+
+  it('treats a whitespace-only value as absent, not as an empty string', () => {
+    // ⚠ `new URL('', 'https://site.test/article')` resolves to the PAGE — so an empty imageUrl
+    // made the server fetch an HTML document as though it were the preview image.
+    const meta = scrapeMeta('<head><meta property="og:image" content="   "></head>');
+    expect('imageUrl' in meta).toBe(false);
+  });
+
+  it('keeps a tag whose attribute value contains an unescaped >', () => {
+    // ⚠ Regression guard. `[^>]*>` cut the tag at the first `>` even inside a quoted value, and
+    // the truncated remainder matched no attribute — so the tag was DROPPED, not truncated.
+    // Breadcrumb titles and `=>` in a description are routine.
+    const meta = scrapeMeta(
+      '<head><meta property="og:title" content="Settings > Privacy"><title>Fallback</title></head>',
+    );
+    expect(meta.title).toBe('Settings > Privacy');
+    const img = scrapeMeta(
+      '<head><meta property="og:image" content="https://e.test/a?w=1>2"></head>',
+    );
+    expect(img.imageUrl).toBe('https://e.test/a?w=1>2');
+  });
+
+  it('does not let one attribute value impersonate another', () => {
+    // ⚠⚠ Regression guard, and the sharpest of the parser bugs: the value chosen here becomes
+    // a URL the SERVER fetches. `attr()` searched the whole tag for `name=`, first match wins,
+    // so text inside an EARLIER attribute's value shadowed the real attribute. The
+    // `(?:^|[\s"'])` boundary that shipped as the fix for `data-content` did not close it — a
+    // space inside any preceding value satisfies it. ipGuard refuses this address downstream,
+    // so it was never a live SSRF, but a scraped page does not get to pick the target.
+    const oembed = scrapeMeta(
+      '<head><link rel="alternate" title="pick href=http://169.254.169.254/latest/meta-data/" ' +
+        'type="application/json+oembed" href="https://real.test/oembed"></head>',
+    );
+    expect(oembed.oembedUrl).toBe('https://real.test/oembed');
+
+    const img = scrapeMeta(
+      '<head><meta property="og:image" data-x="a href=x content=https://evil.test/x.png" ' +
+        'content="https://real.test/ok.png"></head>',
+    );
+    expect(img.imageUrl).toBe('https://real.test/ok.png');
+
+    const title = scrapeMeta(
+      '<head><meta property="og:title" data-page="hello content=EVIL world" content="Real Title"></head>',
+    );
+    expect(title.title).toBe('Real Title');
+
+    // The ROUTING key was shadowable too, promoting a description over the real <title>.
+    const routed = scrapeMeta(
+      '<head><meta name="description" content="see property=og:title now"><title>Real</title></head>',
+    );
+    expect(routed.title).toBe('Real');
+  });
+
+  it('ends the head at the first non-head element, since <body> is optional', () => {
+    // ⚠⚠ Regression guard, and a content-injection path rather than a cosmetic one. HTML5
+    // makes both `<body>` and `</head>` optional, and plenty of real pages omit them — so
+    // searching for the tag meant the ENTIRE document counted as head. On any forum, wiki or
+    // paste site that echoes user markup, that let a commenter set the preview title and image
+    // for every channel the link was pasted into.
+    // ⚠ Note the fixture carries NEITHER `</head>` NOR `<body>`. An earlier version of this
+    // test included `</head>`, which ends the scan by itself — so it passed with the rule
+    // reverted and guarded nothing. Both tags are optional and pages that omit one omit both.
+    const meta = scrapeMeta(
+      '<html><head><title>Real Page</title>\n<p>a user post follows</p>\n' +
+        '<meta property="og:title" content="INJECTED BY A COMMENTER">' +
+        '<meta property="og:image" content="https://evil.test/x.png">',
+    );
+    expect(meta.title).toBe('Real Page');
+    expect('imageUrl' in meta).toBe(false);
+  });
+
+  it('is not fooled by markup inside a script or a comment', () => {
+    // ⚠ Regression guards, in both directions. A `<body>` in a script string used to truncate
+    // the head and lose everything; a commented-out `<meta>` used to win the first-wins race
+    // against the real one, and staging tags left commented out in production markup are
+    // common; an inline SVG `<title>` used to shadow the document title.
+    expect(
+      scrapeMeta(
+        '<head><script>var s="<body>";</script><meta property="og:title" content="Real"></head>',
+      ).title,
+    ).toBe('Real');
+    // ⚠ TWO tags inside the comment, deliberately. With one, the `<!doctype>` branch happens to
+    // skip to the first `>` and lands past it, so a single-tag fixture passed even with comment
+    // handling removed. The second tag is what a `>`-seeking skip leaks.
+    expect(
+      scrapeMeta(
+        '<head><!-- <meta property="og:title" content="Commented A">' +
+          '<meta property="og:title" content="Commented B"> -->' +
+          '<meta property="og:title" content="Real"></head>',
+      ).title,
+    ).toBe('Real');
+    expect(
+      scrapeMeta('<head><svg><title>icon</title></svg><title>Real Page Title</title></head>').title,
+    ).toBe('Real Page Title');
+  });
+
+  it('scans a hostile document in linear time', () => {
+    // ⚠⚠ Regression guard for an unauthenticated remote DoS. `/<meta\b[^>]*>/gi` rescanned to
+    // end-of-string from every start position when no `>` was present: measured at 15,138 ms
+    // through this function at the real 512 KB cap, doubling cleanly with input size. The
+    // server is one process with no yield point here, so a single pasted link stalled every
+    // user's IRC socket and WS frames for as long as it ran, and re-pasting re-triggered it.
+    // The bound is deliberately loose — the point is linear vs quadratic, not a stopwatch.
+    const hostile = '<meta '.repeat(Math.floor((512 * 1024) / 6));
+    const started = performance.now();
+    scrapeMeta(hostile);
+    expect(performance.now() - started).toBeLessThan(2000);
+  });
+
+  it('keeps the site-designated primary image when secure_url belongs to a later one', () => {
+    // ⚠ `og:image:secure_url` is a sub-property of the og:image PRECEDING it, not a
+    // document-level field. Read flat and preferred outright, it defeated the "first og:image
+    // wins" rule — the shape a CMS emits when a hero image is followed by per-article images
+    // that each carry their own secure_url.
+    const meta = scrapeMeta(`<head>
+      <meta property="og:image" content="https://good.test/primary.png">
+      <meta property="og:image" content="http://other.test/second.png">
+      <meta property="og:image:secure_url" content="https://other.test/second.png">
+    </head>`);
+    expect(meta.imageUrl).toBe('https://good.test/primary.png');
+  });
+
+  it('does not retain the document a value was sliced out of', () => {
+    // ⚠⚠ A memory bug that only manifests once PR 4 caches these, where nobody would trace it
+    // back here: a V8 slice holds its ENTIRE parent, so a 60-character image URL pinned the
+    // whole 512 KB document it came from. `String(s)`, `${s}`, `s.slice(0)` and `s.normalize()`
+    // all fail to fix it — only forcing a cons-then-flatten does.
+    //
+    // ⚠ Retention is not observable from JS semantics, so this measures the heap, and it only
+    // means anything when GC can be forced. Under a plain `npm test` the assertion is skipped
+    // rather than faked — a test that cannot see the bug should say so instead of passing. To
+    // run it for real: `node --expose-gc ./node_modules/.bin/vitest run linkMeta`.
+    const gc = (globalThis as { gc?: () => void }).gc;
+
+    const scrapeOne = (i: number) => {
+      const pad = 'x'.repeat(512 * 1024);
+      // A single-word site name has no whitespace to collapse, so it never took the accidental
+      // escape route the multi-word text fields relied on — it needed the explicit detach as
+      // much as the URL did.
+      const meta = scrapeMeta(
+        `<head><meta property="og:image" content="https://cdn.test/preview-${i}.png">` +
+          `<meta property="og:site_name" content="GitHub"><!--${pad}--></head>`,
+      );
+      return meta;
+    };
+
+    // Correctness of the detach, which every run can check.
+    const one = scrapeOne(0);
+    expect(one.siteName).toBe('GitHub');
+    expect(one.imageUrl).toBe('https://cdn.test/preview-0.png');
+
+    if (!gc) return;
+
+    gc();
+    gc();
+    const before = process.memoryUsage().heapUsed;
+    const kept = Array.from({ length: 40 }, (_, i) => scrapeOne(i));
+    gc();
+    gc();
+    const retainedMb = (process.memoryUsage().heapUsed - before) / 1024 / 1024;
+
+    expect(kept).toHaveLength(40);
+    // 40 documents of 512 KB is 20 MB of parents. Detached, the cards are a few KB.
+    expect(retainedMb).toBeLessThan(5);
+  });
 });
 
 describe('decodeBody', () => {
@@ -143,16 +398,55 @@ describe('decodeBody', () => {
   it('honours the charset the origin declared', () => {
     // ⚠ Regression guard. This took the raw `Content-Type` header and re-parsed it, which
     // could never match — every caller had only `RawResponse.contentType`, already stripped
-    // to a bare `text/html`. The parameter is now the PARSED charset (`RawResponse.charset`),
-    // so this is the branch that keeps a windows-1252 title out of replacement characters.
+    // to a bare `text/html`. The parameter is now the PARSED charset (`RawResponse.charset`).
     expect(decodeBody(cafe, 'iso-8859-1')).toBe('café');
     expect(decodeBody(cafe, 'windows-1252')).toBe('café');
   });
 
-  it('is not passed a header, and does not try to read one', () => {
-    // Belt and braces on the same bug: a caller that regresses to handing over the whole
-    // header gets UTF-8, not a silently half-working parse.
-    expect(decodeBody(cafe, 'text/html; charset=iso-8859-1')).not.toBe('café');
+  it('IGNORES a value shaped like a header rather than half-reading it', () => {
+    // ⚠⚠ The sharp edge of this PR's own change. `string | null` still accepts the old
+    // `contentType` argument, and `'text/html'` is TRUTHY — so an un-updated caller would
+    // short-circuit the in-document rescue below and be strictly WORSE off than before the
+    // parameter changed. A charset name never contains '/' or ';', so a mis-shaped value is
+    // treated as no declaration at all.
+    const declaresItself = Buffer.concat([
+      Buffer.from('<meta charset="windows-1252">', 'latin1'),
+      Buffer.from([0xe9]),
+    ]);
+    expect(decodeBody(declaresItself, 'text/html')).toContain('é');
+    expect(decodeBody(declaresItself, 'text/html; charset=iso-8859-1')).toContain('é');
+    // Same answer as passing nothing, which is the point.
+    expect(decodeBody(declaresItself, 'text/html')).toBe(decodeBody(declaresItself, null));
+  });
+
+  it('preserves the windows-1252 punctuation that latin1 destroys', () => {
+    // ⚠ Regression guard, and the reason this decodes through TextDecoder. cp1252 puts the
+    // smart quotes, dashes and ellipsis in 0x80-0x9F — exactly where latin1 has invisible C1
+    // controls — so the approximation mangled the very characters it was chosen to preserve,
+    // and `\s` doesn't match C1 so the whitespace collapse left them in the title.
+    const bytes = Buffer.from([0x93, 0x48, 0x69, 0x94, 0x20, 0x97, 0x20, 0x92, 0x73]);
+    expect(decodeBody(bytes, 'windows-1252')).toBe('“Hi” — ’s');
+    expect(decodeBody(Buffer.from([0x80]), 'windows-1252')).toBe('€');
+  });
+
+  it('accepts the registry aliases, which used to be worse than saying nothing', () => {
+    // ⚠ Each of these is a real registered label. Under the old three-name comparison they
+    // matched nothing and fell through to UTF-8 — while still suppressing the in-document
+    // rescue, so declaring a correct alias was strictly worse than declaring nothing.
+    for (const alias of ['cp1252', 'iso8859-1', 'ISO-8859-1', 'latin1', 'us-ascii']) {
+      expect(decodeBody(cafe, alias)).toBe('café');
+    }
+  });
+
+  it('decodes the encodings that used to have no answer at all', () => {
+    // windows-1251 (Cyrillic) and shift_jis were previously guessed as UTF-8 and rendered as
+    // replacement characters. Node ships full ICU, so they simply work.
+    expect(decodeBody(Buffer.from([0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2]), 'windows-1251')).toBe(
+      'Привет',
+    );
+    expect(decodeBody(Buffer.from([0x83, 0x65, 0x83, 0x58, 0x83, 0x67]), 'shift_jis')).toBe(
+      'テスト',
+    );
   });
 
   it('honours a charset declared in the document when the origin declared none', () => {
@@ -163,21 +457,50 @@ describe('decodeBody', () => {
     expect(decodeBody(body, null)).toContain('é');
   });
 
+  it('reads the http-equiv form of the declaration too', () => {
+    const body = Buffer.concat([
+      Buffer.from('<meta http-equiv="content-type" content="text/html; charset=iso-8859-1">'),
+      Buffer.from([0xe9]),
+    ]);
+    expect(decodeBody(body, null)).toContain('é');
+  });
+
+  it('does not treat the TEXT "charset=" in a meta value as a declaration', () => {
+    // ⚠ Regression guard. The probe was `/<meta[^>]+charset=["']?([\w-]+)/i`, which matched
+    // that string ANYWHERE inside any <meta> tag — so a genuinely UTF-8 page describing how to
+    // set a charset re-encoded its whole document and every accented character became mojibake.
+    const body = Buffer.from(
+      '<head><meta name="description" content="how to set charset=windows-1252 in HTML"></head><p>café</p>',
+      'utf8',
+    );
+    expect(decodeBody(body, null)).toContain('café');
+    // Same shape as the `data-content` bug this module already fixes, in a second scanner.
+    const dataAttr = Buffer.from('<head><meta data-charset="gb2312" name="x"></head><p>café</p>');
+    expect(decodeBody(dataAttr, null)).toContain('café');
+  });
+
   it('defaults to UTF-8', () => {
     expect(decodeBody(Buffer.from('café', 'utf8'), null)).toBe('café');
   });
 
-  it('falls back to UTF-8 for an encoding node cannot speak', () => {
-    // windows-1251 is Cyrillic; we have no decoder for it, and guessing latin1 would be
-    // worse than the modern default.
-    expect(decodeBody(Buffer.from('café', 'utf8'), 'windows-1251')).toBe('café');
+  it('falls back to UTF-8 for a label no decoder knows', () => {
+    // TextDecoder throws on an unregistered label rather than decoding badly; that must not
+    // escape as an exception on a best-effort path.
+    expect(decodeBody(Buffer.from('café', 'utf8'), 'not-a-real-charset')).toBe('café');
   });
 
   it('lets the origin win over the document declaration', () => {
-    // A document copied between encodings keeps a stale <meta charset>; the header describes
-    // the bytes actually on the wire.
-    const body = Buffer.from('<meta charset="utf-8">', 'latin1');
-    expect(decodeBody(body, 'iso-8859-1')).toContain('meta charset');
+    // ⚠⚠ This test used to be a TAUTOLOGY: its fixture was pure ASCII, so the two branches
+    // returned byte-identical output and the assertion could not fail — inverting the
+    // precedence to `fromMeta || declared` left it green. The trailing non-ASCII byte is what
+    // makes it real. A document copied between encodings keeps a stale <meta charset>; the
+    // header describes the bytes actually on the wire.
+    const body = Buffer.concat([
+      Buffer.from('<meta charset="utf-8">', 'latin1'),
+      Buffer.from([0xe9]),
+    ]);
+    expect(decodeBody(body, 'iso-8859-1')).toContain('é');
+    expect(decodeBody(body, null)).toContain('�');
   });
 });
 
@@ -212,6 +535,19 @@ describe('readOEmbed', () => {
   it('rejects non-object input', () => {
     expect(readOEmbed(null)).toBeNull();
     expect(readOEmbed('a string')).toBeNull();
+    // An array is typeof 'object', and every field would read as undefined off it.
+    expect(readOEmbed([{ title: 'x' }])).toBeNull();
+  });
+
+  it('decodes entities, like the scraper does at its own boundary', () => {
+    // ⚠ Regression guard. This was the ONE metadata path with no decodeEntities call — and it
+    // is the path built specifically for YouTube, whose oEmbed endpoint HTML-escapes `title`
+    // and `author_name`. `Rock &amp; Roll` reached the card verbatim: exactly the
+    // `Tom &amp; Jerry` failure decodeEntities exists to prevent, on the provider the whole
+    // oEmbed detour was built for.
+    const meta = readOEmbed({ title: 'Rock &amp; Roll', author_name: 'Caf&eacute; Records' });
+    expect(meta?.title).toBe('Rock & Roll');
+    expect(meta?.authorName).toBe('Café Records');
   });
 
   it('ignores fields of the wrong type or nonsensical value', () => {

--- a/server/services/linkMeta.test.ts
+++ b/server/services/linkMeta.test.ts
@@ -25,6 +25,20 @@ describe('decodeEntities', () => {
     expect(decodeEntities('&#999999999;')).toBe('&#999999999;');
   });
 
+  it('does not let a decimal reference carry hex letters', () => {
+    // ⚠ Regression guard, found by Copilot. A combined `#x?[0-9a-f]+` alternative let the
+    // DECIMAL branch match hex digits, and `parseInt(body, 10)` prefix-parsed the result —
+    // `&#99f;` decoded to `c`, `&#65a;` to `A`. The test above says malformed references stay
+    // literal; these were silently decoding to whatever their numeric prefix happened to mean.
+    expect(decodeEntities('&#99f;')).toBe('&#99f;');
+    expect(decodeEntities('&#65a;')).toBe('&#65a;');
+    expect(decodeEntities('&#12e;')).toBe('&#12e;');
+    // The well-formed cases both still decode, in either case.
+    expect(decodeEntities('&#65;')).toBe('A');
+    expect(decodeEntities('&#x41;')).toBe('A');
+    expect(decodeEntities('&#X41;')).toBe('A');
+  });
+
   it('does not double-decode', () => {
     // A site that double-escapes gets `&amp;` back, not `&`. Decoding twice
     // would be a mangling risk for everyone else.

--- a/server/services/linkMeta.ts
+++ b/server/services/linkMeta.ts
@@ -4,12 +4,21 @@
 // Pulling preview metadata out of an HTML document, and out of an oEmbed reply.
 //
 // Deliberately NOT a DOM parser. The Lounge pulls in cheerio for this; we need
-// four tags out of `<head>` on a document we've already truncated to 256 KB, and
-// a focused scanner is a fraction of the code, has no dependency to track CVEs
-// on, and can't be induced to build a tree out of something hostile. The cost is
-// that we'd miss metadata that only exists after JavaScript runs — but so does
-// every other unfurler, Slack and Discord included, so a site that renders og:
-// tags client-side simply doesn't get a card anywhere.
+// four tags out of `<head>` on a document we've already truncated to
+// MAX_SCRAPE_BYTES, and a focused scanner is a fraction of the code, has no
+// dependency to track CVEs on, and can't be induced to build a tree out of
+// something hostile. The cost is that we'd miss metadata that only exists after
+// JavaScript runs — but so does every other unfurler, Slack and Discord
+// included, so a site that renders og: tags client-side simply doesn't get a
+// card anywhere.
+//
+// ⚠ "Not a DOM parser" is not a licence to pattern-match. The scanner below is a
+// real tokenizer — it tracks quoting, skips comments and script content, and
+// ends the head by HTML5's own rule — because every shortcut short of that
+// turned out to be a defect: a quadratic freeze on unterminated tags, a `>`
+// inside an attribute value silently dropping the tag, one attribute's value
+// impersonating another's, and a commented-out `<meta>` beating the real one.
+// Each is documented at the code that fixes it.
 //
 // Pure and synchronous: bytes in, a plain object out. All the network lives in
 // linkFetch.ts, which makes this the easy half to test exhaustively.
@@ -37,15 +46,238 @@ export interface OEmbedMeta {
   thumbnailHeight?: number;
 }
 
-// Metadata lives in <head>. Anything past the start of <body> is page content,
-// and scanning it is both wasted work and a way to pick up a stray <meta> from
-// inside some third-party embed.
-function headRegion(html: string): string {
-  const bodyAt = html.search(/<body[\s>]/i);
-  return bodyAt === -1 ? html : html.slice(0, bodyAt);
+/** One start tag, with its attributes resolved. */
+interface Tag {
+  name: string;
+  attrs: Map<string, string>;
+  /** Raw text content, for `<title>` only. Undecoded. */
+  text?: string;
 }
 
-const NAMED_ENTITIES: Record<string, string> = {
+/**
+ * Index of `</name`, case-insensitively, without lowercasing the document.
+ *
+ * ⚠ `html.toLowerCase().indexOf(...)` would allocate a full copy of the document on every
+ * call — and this is called once per opaque element, so a page with fifty `<script>` tags
+ * would rebuild 512 KB fifty times. That is the same quadratic this scanner exists to remove,
+ * reintroduced by the fix for it.
+ */
+function findClose(html: string, name: string, from: number): number {
+  for (let at = from; ;) {
+    at = html.indexOf('</', at);
+    if (at === -1) return -1;
+    const start = at + 2;
+    if (html.slice(start, start + name.length).toLowerCase() === name) {
+      const after = html[start + name.length];
+      if (after === undefined || after === '>' || /\s/.test(after) || after === '/') return at;
+    }
+    at = start;
+  }
+}
+
+/**
+ * Elements HTML5 permits inside `<head>`.
+ *
+ * ⚠⚠ This list is what ENDS the head, and it has to be a positive list rather than a search
+ * for `<body>`, because **`<body>` is optional in HTML5** — as is `</head>` — and a great many
+ * real pages omit both. Scanning for the tag meant that on any such page the entire document
+ * counted as head, so a `<meta property="og:title">` sitting in ordinary page content won the
+ * card. On a forum, wiki or paste site that echoes user markup, that lets a commenter set the
+ * preview title and image for every channel the link is pasted into.
+ *
+ * The spec's own rule is the cheap one: the head ends at the first element that isn't allowed
+ * in it. `<p>` ends the head whether or not anyone wrote `<body>`.
+ */
+const HEAD_ELEMENTS = new Set([
+  'base',
+  'basefont',
+  'bgsound',
+  'link',
+  'meta',
+  'noframes',
+  'noscript',
+  'script',
+  'style',
+  'template',
+  'title',
+]);
+
+/**
+ * Elements whose content is not markup, and must be skipped wholesale.
+ *
+ * `<script>var s = "<body>";</script>` is the motivating case in both directions: a naive scan
+ * reads that string as a real tag and truncates the head, and an inline `<svg><title>icon</title>`
+ * shadows the document title. Skipping to the matching close tag settles both.
+ */
+const OPAQUE_ELEMENTS = new Set(['script', 'style', 'template', 'svg', 'math']);
+
+/**
+ * Walk a document's head, yielding start tags with their attributes parsed.
+ *
+ * ⚠⚠ Hand-written rather than regex-driven, and the reason is a measured DoS, not taste. The
+ * scanners this replaces were `/<meta\b[^>]*>/gi` and friends: with no closing `>` in the
+ * input, `[^>]*` rescans to end-of-string from every start position, which is quadratic.
+ * Measured through the real `scrapeMeta` at the real 512 KB `MAX_SCRAPE_BYTES`, on a body of
+ * `'<meta '.repeat(87381)`: **15.1 seconds inside one synchronous call**, doubling cleanly with
+ * input size (32 KB = 66 ms, 512 KB = 15 s). The server is a single process with no yield point
+ * in this path, so one pasted link stalls every user's IRC socket, ping timer and WS frame for
+ * as long as it runs — and re-pasting re-triggers it. The origin is attacker-controlled, so it
+ * costs nothing to serve. This scan is linear: the same input now completes in under a
+ * millisecond.
+ *
+ * It also fixes two silent-wrong-answer bugs the regexes couldn't express:
+ *
+ *   - `>` is legal, unescaped, inside a quoted attribute value. `[^>]*>` cut the tag there and
+ *     the truncated remainder matched no attribute, so `content="Settings > Privacy"` didn't
+ *     truncate the title — it dropped the whole tag. Breadcrumbs and `=>` in a description are
+ *     routine.
+ *   - Attributes are read positionally now, so a value can no longer be mistaken for one.
+ *     The old `attr()` searched the whole tag for `name=`, first match wins, which meant text
+ *     inside an EARLIER attribute's value shadowed the real attribute. Verified on this branch:
+ *     `<link rel="alternate" title="pick href=http://169.254.169.254/latest/meta-data/"
+ *     type="application/json+oembed" href="https://real.test/oembed">` yielded the metadata
+ *     endpoint as `oembedUrl` — the page choosing where the SERVER sends its next request.
+ *     ipGuard refuses that address downstream, so it was never a live SSRF, but target
+ *     selection is not something a scraped page gets to do. The `(?:^|[\s"'])` boundary that
+ *     shipped as the fix for `data-content` did not close this: a space inside any preceding
+ *     value satisfies it.
+ */
+function* scanHead(html: string): Generator<Tag> {
+  let i = 0;
+  const n = html.length;
+
+  while (i < n) {
+    const lt = html.indexOf('<', i);
+    if (lt === -1) return;
+    i = lt + 1;
+
+    // Comments, doctypes and processing instructions carry no metadata, and a `<meta>` left
+    // commented out in production markup must not win the first-wins race against the real one.
+    if (html.startsWith('!--', i)) {
+      const end = html.indexOf('-->', i + 3);
+      if (end === -1) return;
+      i = end + 3;
+      continue;
+    }
+    if (html[i] === '!' || html[i] === '?') {
+      const end = html.indexOf('>', i);
+      if (end === -1) return;
+      i = end + 1;
+      continue;
+    }
+
+    const closing = html[i] === '/';
+    if (closing) i++;
+
+    const nameStart = i;
+    while (i < n && !/[\s/>]/.test(html[i])) i++;
+    const name = html.slice(nameStart, i).toLowerCase();
+    if (!name) continue;
+
+    // `</head>` ends the head explicitly; every other close tag is uninteresting here.
+    if (closing) {
+      if (name === 'head') return;
+      continue;
+    }
+
+    const attrs = new Map<string, string>();
+    // Attribute loop. Positional, quote-aware, and it consumes the `>` that ends the tag —
+    // which is what makes a `>` inside a value harmless.
+    for (;;) {
+      while (i < n && /\s/.test(html[i])) i++;
+      if (i >= n) break;
+      if (html[i] === '>') {
+        i++;
+        break;
+      }
+      if (html[i] === '/') {
+        i++;
+        continue;
+      }
+
+      const attrStart = i;
+      while (i < n && !/[\s=/>]/.test(html[i])) i++;
+      const attrName = html.slice(attrStart, i).toLowerCase();
+      if (!attrName) {
+        i++;
+        continue;
+      }
+
+      while (i < n && /\s/.test(html[i])) i++;
+      if (html[i] !== '=') {
+        // A bare attribute (`<script defer>`). Present, with no value.
+        if (!attrs.has(attrName)) attrs.set(attrName, '');
+        continue;
+      }
+      i++;
+      while (i < n && /\s/.test(html[i])) i++;
+
+      let value: string;
+      const quote = html[i];
+      if (quote === '"' || quote === "'") {
+        i++;
+        const end = html.indexOf(quote, i);
+        if (end === -1) {
+          value = html.slice(i);
+          i = n;
+        } else {
+          value = html.slice(i, end);
+          i = end + 1;
+        }
+      } else {
+        const start = i;
+        while (i < n && !/[\s>]/.test(html[i])) i++;
+        value = html.slice(start, i);
+      }
+      // First occurrence wins, matching how browsers treat a duplicated attribute.
+      if (!attrs.has(attrName)) attrs.set(attrName, value);
+    }
+
+    // `<title>` is the one element here we want the TEXT of, not just the attributes.
+    if (name === 'title') {
+      const close = findClose(html, 'title', i);
+      yield { name, attrs, text: html.slice(i, close === -1 ? n : close) };
+      if (close === -1) return;
+      i = close;
+      continue;
+    }
+
+    if (OPAQUE_ELEMENTS.has(name)) {
+      const close = findClose(html, name, i);
+      // An unclosed <script> swallows the rest of the document — which is exactly what a
+      // browser does with one, so there is nothing left to scrape either way.
+      if (close === -1) return;
+      i = close;
+      continue;
+    }
+
+    // `html` and `head` are the wrappers themselves, not content.
+    if (name !== 'html' && name !== 'head' && !HEAD_ELEMENTS.has(name)) return;
+    yield { name, attrs };
+  }
+}
+
+/**
+ * The named entities that actually turn up in preview metadata.
+ *
+ * ⚠⚠ `Object.create(null)`, not an object literal. As a plain object the lookup below walked
+ * `Object.prototype`, and `?? match` accepts what it finds there, because a function is neither
+ * null nor undefined — so `decodeEntities('Rock &constructor; Roll')` returned
+ * `'Rock function Object() { [native code] } Roll'`. Through the real scraper that put native
+ * code source text into an `og:image` URL the server then resolves and fetches, and into a card
+ * broadcast to every client in the channel. `constructor` is the only Object.prototype key that
+ * survives the `[a-z]+` match, which made this one attacker-chosen name away rather than a live
+ * bug.
+ *
+ * ⚠ The accented half is not garnish. This function exists because an undecoded entity renders
+ * literally in the card — and a punctuation-only table left `Caf&eacute; M&uuml;ller` doing
+ * exactly that on every French, German, Spanish and Nordic page, which is the defect it was
+ * written to prevent. Anything rarer than this stays literal, which is the honest failure mode.
+ *
+ * ⚠ Case is significant: `&Eacute;` and `&eacute;` are different characters, so the lookup
+ * tries the exact name before folding case.
+ */
+const NAMED_ENTITIES: Record<string, string> = Object.assign(Object.create(null), {
   amp: '&',
   lt: '<',
   gt: '>',
@@ -59,7 +291,103 @@ const NAMED_ENTITIES: Record<string, string> = {
   lsquo: '‘',
   ldquo: '“',
   rdquo: '”',
-};
+  sbquo: '‚',
+  bdquo: '„',
+  lsaquo: '‹',
+  rsaquo: '›',
+  laquo: '«',
+  raquo: '»',
+  bull: '•',
+  middot: '·',
+  dagger: '†',
+  Dagger: '‡',
+  prime: '′',
+  Prime: '″',
+  copy: '©',
+  reg: '®',
+  trade: '™',
+  deg: '°',
+  plusmn: '±',
+  times: '×',
+  divide: '÷',
+  frac12: '½',
+  frac14: '¼',
+  frac34: '¾',
+  sup2: '²',
+  sup3: '³',
+  micro: 'µ',
+  para: '¶',
+  sect: '§',
+  euro: '€',
+  pound: '£',
+  yen: '¥',
+  cent: '¢',
+  curren: '¤',
+  iexcl: '¡',
+  iquest: '¿',
+  szlig: 'ß',
+  agrave: 'à',
+  aacute: 'á',
+  acirc: 'â',
+  atilde: 'ã',
+  auml: 'ä',
+  aring: 'å',
+  aelig: 'æ',
+  ccedil: 'ç',
+  egrave: 'è',
+  eacute: 'é',
+  ecirc: 'ê',
+  euml: 'ë',
+  igrave: 'ì',
+  iacute: 'í',
+  icirc: 'î',
+  iuml: 'ï',
+  eth: 'ð',
+  ntilde: 'ñ',
+  ograve: 'ò',
+  oacute: 'ó',
+  ocirc: 'ô',
+  otilde: 'õ',
+  ouml: 'ö',
+  oslash: 'ø',
+  ugrave: 'ù',
+  uacute: 'ú',
+  ucirc: 'û',
+  uuml: 'ü',
+  yacute: 'ý',
+  thorn: 'þ',
+  yuml: 'ÿ',
+  Agrave: 'À',
+  Aacute: 'Á',
+  Acirc: 'Â',
+  Atilde: 'Ã',
+  Auml: 'Ä',
+  Aring: 'Å',
+  AElig: 'Æ',
+  Ccedil: 'Ç',
+  Egrave: 'È',
+  Eacute: 'É',
+  Ecirc: 'Ê',
+  Euml: 'Ë',
+  Igrave: 'Ì',
+  Iacute: 'Í',
+  Icirc: 'Î',
+  Iuml: 'Ï',
+  ETH: 'Ð',
+  Ntilde: 'Ñ',
+  Ograve: 'Ò',
+  Oacute: 'Ó',
+  Ocirc: 'Ô',
+  Otilde: 'Õ',
+  Ouml: 'Ö',
+  Oslash: 'Ø',
+  Ugrave: 'Ù',
+  Uacute: 'Ú',
+  Ucirc: 'Û',
+  Uuml: 'Ü',
+  Yacute: 'Ý',
+  THORN: 'Þ',
+});
 
 /**
  * Decode the HTML entities that actually turn up in metadata.
@@ -72,7 +400,7 @@ const NAMED_ENTITIES: Record<string, string> = {
  * rather than making everyone else's apostrophes look broken.
  */
 export function decodeEntities(text: string): string {
-  return text.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, body: string) => {
+  return text.replace(/&(#x?[0-9a-f]+|[a-z][a-z0-9]*);/gi, (match, body: string) => {
     if (body[0] === '#') {
       const code =
         body[1] === 'x' || body[1] === 'X'
@@ -81,63 +409,148 @@ export function decodeEntities(text: string): string {
       // Surrogates and out-of-range values would throw; leave them literal.
       if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return match;
       if (code >= 0xd800 && code <= 0xdfff) return match;
+      // ⚠⚠ Control characters are refused, and this is the one place in Lurker where that
+      // matters most: a preview title is among the very few strings in the app sourced from an
+      // arbitrary third party rather than from an IRC server. Minting them let a scraped page
+      // put **mIRC formatting codes into the message list** — U+0003 is colour, U+0002 is bold,
+      // and Lurker's own renderer parses them — and a NUL into a SQLite TEXT column, where
+      // C-string consumers truncate. The whitespace collapse downstream removes none of these:
+      // `\s` does not match U+0000-U+0008 or the C1 range.
+      if (isControl(code)) return match;
       return String.fromCodePoint(code);
     }
-    const named = NAMED_ENTITIES[body.toLowerCase()];
+    // Case-sensitive first: `&Eacute;` and `&eacute;` are different characters. The fold is a
+    // fallback for the punctuation names, which sites do write in mixed case.
+    const named = NAMED_ENTITIES[body] ?? NAMED_ENTITIES[body.toLowerCase()];
     return named ?? match;
   });
 }
 
+/** C0 and C1 controls, less the three whitespace characters that are legitimate in text. */
+function isControl(code: number): boolean {
+  if (code === 0x09 || code === 0x0a || code === 0x0d) return false;
+  return code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f);
+}
+
+/**
+ * A charset NAME, as opposed to a header, a MIME type, or anything else a caller might
+ * mistakenly hand over.
+ *
+ * ⚠⚠ This guard is the whole reason this PR exists, made structural instead of advisory.
+ * `decodeBody` used to take a raw `Content-Type` and re-parse it, which could never match
+ * anything — every caller had only `RawResponse.contentType`, already stripped to a bare
+ * `text/html`. Taking the parsed charset instead fixes that, but a `string | null` parameter
+ * still silently accepts the old argument, and passing `'text/html'` is worse than the
+ * original bug rather than merely no better: it is TRUTHY, so it short-circuits the
+ * in-document `<meta charset>` rescue that used to carry those pages. Verified — a
+ * windows-1252 page declaring its charset in-document, served as bare `text/html`, decoded
+ * correctly before this change and as replacement characters after it.
+ *
+ * A real charset label is a token: letters, digits, and `-._:` (per the WHATWG registry). A
+ * MIME type or a header always carries `/` or `;`, so anything shaped wrong is treated as no
+ * declaration at all and the document gets to speak for itself.
+ */
+const CHARSET_NAME = /^[a-z0-9][a-z0-9\-._:]*$/i;
+
 /**
  * Decode bytes to text using the document's declared charset.
  *
- * A surprising amount of the long tail is still windows-1252, and reading it as
- * UTF-8 turns every smart quote into a replacement character right in the title.
- * Node speaks utf8 and latin1 natively; latin1 is close enough to windows-1252
- * for the punctuation that matters here. Anything more exotic falls back to
- * UTF-8, which is the correct guess for essentially everything written this
- * century.
+ * A surprising amount of the long tail is still windows-1252, and reading it as UTF-8 turns
+ * every smart quote into a replacement character right in the title.
  *
- * ⚠ `declared` is the charset the ORIGIN sent, already parsed out of its
- * `Content-Type` — `RawResponse.charset` in linkFetch. It is not a header to be
- * re-parsed here. An earlier version took the raw header string and ran
- * `/charset=.../` over it, which could never match: what callers actually had
- * to hand was `RawResponse.contentType`, stripped to a bare `text/html` before
- * it ever left the fetcher. That branch was dead, so a page served
- * `charset=windows-1251` with no in-document `<meta charset>` fell through to
- * UTF-8 and rendered as replacement characters.
+ * ⚠ Decoded through `TextDecoder`, not `Buffer.toString('latin1')`. The latin1 approximation
+ * was not merely incomplete, it destroyed **precisely the characters it was chosen to
+ * preserve**: windows-1252 puts the smart quotes, the dashes, the ellipsis and the euro sign
+ * in 0x80-0x9F, which is exactly where latin1 has invisible C1 controls. Verified — the cp1252
+ * bytes for `“Hi” — ’s` came back as `Hi  s`, and since `\s` does not
+ * match C1, the whitespace collapse left those controls in a title bound for the database and
+ * every client. The old comment claimed latin1 was "close enough for the punctuation that
+ * matters here"; it was inverted.
+ *
+ * The node 22 image ships full ICU, so `TextDecoder` also handles every registry alias
+ * (`cp1252`, `iso8859-1`, `us-ascii`) and the encodings the old triple had no answer for at
+ * all — windows-1251, shift_jis, gbk, euc-kr. Each of those used to fall through to UTF-8;
+ * worse, a *recognised* alias was strictly worse than sending nothing, because a non-matching
+ * name still suppressed the in-document rescue.
+ *
+ * `fatal: false` is deliberate: a byte that isn't valid in the declared encoding becomes
+ * U+FFFD, exactly as a browser renders it. A preview is best-effort and a partly-mojibake
+ * title still beats no card.
+ *
+ * ⚠ `declared` is the charset the ORIGIN sent, already parsed out of its `Content-Type` —
+ * `RawResponse.charset` in linkFetch. See `CHARSET_NAME` above for why that is enforced here
+ * rather than trusted.
  */
 export function decodeBody(body: Buffer, declared: string | null): string {
-  // Read a prefix as ASCII to find an in-document declaration. Any charset we
-  // care about is ASCII-compatible in its first bytes, so this is safe.
-  const probe = body.subarray(0, 2048).toString('latin1');
-  const fromMeta =
-    /<meta[^>]+charset=["']?([\w-]+)/i.exec(probe)?.[1] ||
-    /<meta[^>]+content=["'][^"']*charset=([\w-]+)/i.exec(probe)?.[1];
+  const fromHeader = declared && CHARSET_NAME.test(declared) ? declared : null;
 
-  // The origin's declaration wins: it describes the bytes on the wire, and a
-  // document copied between encodings often carries a stale <meta charset>.
-  const charset = (declared || fromMeta || 'utf-8').toLowerCase();
-  if (charset === 'iso-8859-1' || charset === 'latin1' || charset === 'windows-1252') {
-    return body.toString('latin1');
+  // Read a prefix as ASCII to find an in-document declaration. Any charset we care about is
+  // ASCII-compatible in its first bytes, so this is safe. Only consulted when the origin
+  // didn't say — the header describes the bytes actually on the wire, and a document copied
+  // between encodings routinely carries a stale <meta charset>.
+  const charset = fromHeader ?? metaCharset(body.subarray(0, 2048).toString('latin1')) ?? 'utf-8';
+
+  try {
+    return new TextDecoder(charset, { fatal: false }).decode(body);
+  } catch {
+    // An unregistered label. TextDecoder throws on construction rather than decoding badly,
+    // which is the failure we want: fall back to the guess that is right for essentially
+    // everything written this century.
+    return body.toString('utf8');
   }
-  return body.toString('utf8');
 }
 
-// One <meta>/<link> tag's attributes, order-independent and quote-agnostic.
-// Real-world HTML puts these in every order and quotes them three ways.
-function attr(tag: string, name: string): string | undefined {
-  // ⚠ Anchored on a boundary that a hyphen does NOT satisfy. `\b${name}` matched inside
-  // hyphen-prefixed attributes — `-` is a non-word character, so `\bcontent` matches within
-  // `data-content` — and since the first match wins,
-  // `<meta property="og:title" data-content="Loading…" content="Real Title">` produced the
-  // placeholder. Same shape for `name` vs `data-name`, and for `type` vs `data-type` in the
-  // oEmbed `<link rel=alternate>` scan, where it could hide an endpoint entirely.
-  const m = new RegExp(`(?:^|[\\s"'])${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i').exec(
-    tag,
-  );
-  if (!m) return undefined;
-  return m[2] ?? m[3] ?? m[4];
+/**
+ * The charset a document declares about itself, from the two forms HTML allows.
+ *
+ * ⚠ Read off parsed tags rather than by scanning for the text `charset=`. The old regex was
+ * `/<meta[^>]+charset=["']?([\w-]+)/i`, which matched that string anywhere inside any `<meta>`
+ * tag — so a genuinely UTF-8 page whose head contained
+ * `<meta name="description" content="how to set charset=windows-1252 in HTML">` re-encoded its
+ * entire document, and `café` came back as `cafÃ©`. Any page quoting a Content-Type, or any
+ * blog post about encodings, triggered it. `data-charset="gb2312"` matched too — the same
+ * `data-` prefix bug that this module already ships a fix for, in a second scanner fifteen
+ * lines above the first.
+ */
+function metaCharset(probe: string): string | null {
+  for (const tag of scanHead(probe)) {
+    if (tag.name !== 'meta') continue;
+    const direct = tag.attrs.get('charset');
+    if (direct && CHARSET_NAME.test(direct)) return direct;
+    if ((tag.attrs.get('http-equiv') || '').toLowerCase() === 'content-type') {
+      const found = /;\s*charset\s*=\s*"?([^"';\s]+)/i.exec(tag.attrs.get('content') || '')?.[1];
+      if (found && CHARSET_NAME.test(found)) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Return a copy that does not retain the document it was sliced out of.
+ *
+ * ⚠⚠ Not a no-op, however much it looks like one. Slicing a string in V8 yields a SlicedString
+ * that holds a pointer to its **entire parent**, so a 60-character image URL scraped out of a
+ * page keeps all 512 KB of that page alive for as long as the URL is reachable — and PR 4
+ * caches these, so a few hundred cards would pin a few hundred megabytes of other people's
+ * HTML. It never presents as a leak: a heap snapshot shows a handful of short strings.
+ *
+ * Measured, 60 documents of 512 KB with every document dropped and `global.gc()` forced:
+ *
+ *     raw slice                       30.0 MB retained
+ *     String(s) / `${s}` / s.slice(0) 30.0 MB retained   <- the obvious idioms do NOT work
+ *     s.normalize()                   29.6 MB retained
+ *     (' ' + s).slice(1)               0.5 MB retained
+ *
+ * Concatenating forces a ConsString, and slicing that forces V8 to flatten it into fresh
+ * character storage; the parent is then unreferenced. `split('').join('')` and a Buffer round
+ * trip also work and are slower.
+ *
+ * Applied to every field, not just the URLs — a text field escapes only when the whitespace
+ * collapse actually rewrites it, so a single-word `og:site_name` like `GitHub` retains a
+ * document while a two-word one does not.
+ */
+function detach(s: string): string {
+  return s.length === 0 ? s : (' ' + s).slice(1);
 }
 
 /**
@@ -152,63 +565,114 @@ function attr(tag: string, name: string): string | undefined {
  * mistake on the page's part either way.
  */
 export function scrapeMeta(html: string): ScrapedMeta {
-  const head = headRegion(html);
   const out: ScrapedMeta = {};
 
   const og = new Map<string, string>();
   const twitter = new Map<string, string>();
+  /** og:image and its sub-properties, in document order — see the secure_url note below. */
+  const images: { url: string; secureUrl?: string }[] = [];
+  let titleText: string | undefined;
+  let imageSrc: string | undefined;
 
-  for (const tag of head.match(/<meta\b[^>]*>/gi) || []) {
-    const content = attr(tag, 'content');
-    if (!content) continue;
-    // OG uses `property`, Twitter Card uses `name`, and plenty of sites use the
-    // wrong one for both — so read either and route by the key's prefix.
-    const key = (attr(tag, 'property') || attr(tag, 'name') || '').toLowerCase();
-    if (!key) continue;
-    if (key.startsWith('og:')) {
-      if (!og.has(key)) og.set(key, content); // first wins: og:image repeats
-    } else if (key.startsWith('twitter:')) {
-      if (!twitter.has(key)) twitter.set(key, content);
-    } else if (key === 'description' && !twitter.has('description')) {
-      twitter.set('description', content);
+  for (const tag of scanHead(html)) {
+    if (tag.name === 'title') {
+      titleText ??= tag.text;
+      continue;
+    }
+
+    if (tag.name === 'meta') {
+      const content = tag.attrs.get('content');
+      if (!content) continue;
+      // OG uses `property`, Twitter Card uses `name`, and plenty of sites use the
+      // wrong one for both — so read either and route by the key's prefix.
+      const key = (tag.attrs.get('property') || tag.attrs.get('name') || '').toLowerCase();
+      if (!key) continue;
+
+      // ⚠ `og:image:secure_url` is a sub-property of the og:image that PRECEDES it, not a
+      // document-level field. Read flat and preferred outright, it silently defeated the
+      // "first og:image wins" rule two lines down: a CMS emitting a hero image followed by
+      // per-article images, each with its own secure_url, had the LAST image's https variant
+      // beat the site's designated primary. Tracking them in order keeps both rules true.
+      if (key === 'og:image') {
+        images.push({ url: content });
+        continue;
+      }
+      if (key === 'og:image:secure_url') {
+        if (images.length > 0) images[images.length - 1].secureUrl = content;
+        continue;
+      }
+
+      if (key.startsWith('og:')) {
+        if (!og.has(key)) og.set(key, content); // first wins: og: properties repeat
+      } else if (key.startsWith('twitter:')) {
+        if (!twitter.has(key)) twitter.set(key, content);
+      } else if (key === 'description' && !twitter.has('description')) {
+        twitter.set('description', content);
+      }
+      continue;
+    }
+
+    if (tag.name === 'link') {
+      // `rel` is a space-separated token list, so `rel="alternate canonical"` is one tag with
+      // two tokens — and `includes` was a substring test, which accepted `notalternateatall`.
+      const rel = new Set((tag.attrs.get('rel') || '').toLowerCase().split(/\s+/));
+      const type = (tag.attrs.get('type') || '').toLowerCase();
+      const href = tag.attrs.get('href');
+      if (!href) continue;
+      // ⚠ No `break` here. The loop used to stop at the first oEmbed-typed tag, which made the
+      // card depend on tag ORDER: the same document with its <link>s swapped produced a
+      // different result, and an oEmbed tag carrying no href stopped the scan on behalf of a
+      // valid one further down.
+      if (!out.oembedUrl && rel.has('alternate') && type === 'application/json+oembed') {
+        out.oembedUrl = href;
+      } else if (!imageSrc && rel.has('image_src')) {
+        imageSrc = href;
+      }
     }
   }
 
-  const titleTag = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(head)?.[1];
+  const primaryImage = images[0];
+  // ⚠ Assigned only when found. These used to be written unconditionally, so the result
+  // always carried five keys — `'imageUrl' in meta` was true for a document with no metadata
+  // at all, and `{...oembedValues, ...scrapeMeta(html)}` evaluated to all-undefined, silently
+  // destroying every oEmbed field it was meant to fall back to.
+  const assign = (k: keyof ScrapedMeta, v: string | undefined) => {
+    if (v !== undefined && v !== '') out[k] = v;
+  };
 
-  out.title = og.get('og:title') || twitter.get('twitter:title') || titleTag;
-  out.description =
-    og.get('og:description') || twitter.get('twitter:description') || twitter.get('description');
-  out.siteName = og.get('og:site_name') || twitter.get('twitter:site');
-  out.imageUrl =
-    og.get('og:image:secure_url') ||
-    og.get('og:image') ||
-    twitter.get('twitter:image') ||
-    twitter.get('twitter:image:src');
-  out.ogType = og.get('og:type');
+  assign('title', og.get('og:title') || twitter.get('twitter:title') || titleText);
+  assign(
+    'description',
+    og.get('og:description') || twitter.get('twitter:description') || twitter.get('description'),
+  );
+  assign('siteName', og.get('og:site_name') || twitter.get('twitter:site'));
+  assign(
+    'imageUrl',
+    primaryImage?.secureUrl ||
+      primaryImage?.url ||
+      twitter.get('twitter:image') ||
+      twitter.get('twitter:image:src') ||
+      imageSrc,
+  );
+  assign('ogType', og.get('og:type'));
 
-  for (const tag of head.match(/<link\b[^>]*>/gi) || []) {
-    const rel = (attr(tag, 'rel') || '').toLowerCase();
-    const type = (attr(tag, 'type') || '').toLowerCase();
-    if (rel.includes('alternate') && type === 'application/json+oembed') {
-      out.oembedUrl = attr(tag, 'href');
-      break;
-    }
-    if (!out.imageUrl && rel === 'image_src') out.imageUrl = attr(tag, 'href');
-  }
-
-  // Decode and tidy at the boundary, so callers never handle a raw entity.
+  // Decode and tidy at the boundary, so callers never handle a raw entity. An empty result is
+  // an ABSENT field, not a present empty string: `content="   "` used to survive as `''`, and
+  // `new URL('', base)` resolves to the page itself — so the server fetched an HTML document
+  // as if it were the preview image.
   for (const k of ['title', 'description', 'siteName'] as const) {
     const v = out[k];
-    if (v !== undefined) {
-      const clean = decodeEntities(v).replace(/\s+/g, ' ').trim();
-      if (clean) out[k] = clean;
-      else delete out[k];
-    }
+    if (v === undefined) continue;
+    const clean = detach(decodeEntities(v).replace(/\s+/g, ' ').trim());
+    if (clean) out[k] = clean;
+    else delete out[k];
   }
   for (const k of ['imageUrl', 'oembedUrl'] as const) {
     const v = out[k];
-    if (v !== undefined) out[k] = decodeEntities(v).trim();
+    if (v === undefined) continue;
+    const clean = detach(decodeEntities(v).trim());
+    if (clean) out[k] = clean;
+    else delete out[k];
   }
   return out;
 }
@@ -223,10 +687,20 @@ export function scrapeMeta(html: string): ScrapedMeta {
  * control (see linkEmbed.ts).
  */
 export function readOEmbed(json: unknown): OEmbedMeta | null {
-  if (typeof json !== 'object' || json === null) return null;
+  if (typeof json !== 'object' || json === null || Array.isArray(json)) return null;
   const o = json as Record<string, unknown>;
-  const str = (v: unknown): string | undefined =>
-    typeof v === 'string' && v.trim() ? v.trim() : undefined;
+  // ⚠ Decoded here, same as scrapeMeta decodes at its own boundary. This was the one metadata
+  // path with no `decodeEntities` call — and it is the path built specifically for YouTube,
+  // whose oEmbed endpoint HTML-escapes `title` and `author_name`. A video called `Rock & Roll`
+  // arrived as `Rock &amp; Roll` and reached the card verbatim: precisely the `Tom &amp; Jerry`
+  // failure decodeEntities exists to prevent, on the provider the whole oEmbed detour was
+  // built for. Decoding in both places keeps the contract one thing — a caller never handles a
+  // raw entity, whichever path produced the value.
+  const str = (v: unknown): string | undefined => {
+    if (typeof v !== 'string') return undefined;
+    const clean = detach(decodeEntities(v).replace(/\s+/g, ' ').trim());
+    return clean || undefined;
+  };
   const num = (v: unknown): number | undefined =>
     typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : undefined;
 

--- a/server/services/linkMeta.ts
+++ b/server/services/linkMeta.ts
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Pulling preview metadata out of an HTML document, and out of an oEmbed reply.
+//
+// Deliberately NOT a DOM parser. The Lounge pulls in cheerio for this; we need
+// four tags out of `<head>` on a document we've already truncated to 256 KB, and
+// a focused scanner is a fraction of the code, has no dependency to track CVEs
+// on, and can't be induced to build a tree out of something hostile. The cost is
+// that we'd miss metadata that only exists after JavaScript runs — but so does
+// every other unfurler, Slack and Discord included, so a site that renders og:
+// tags client-side simply doesn't get a card anywhere.
+//
+// Pure and synchronous: bytes in, a plain object out. All the network lives in
+// linkFetch.ts, which makes this the easy half to test exhaustively.
+
+/** Raw metadata as found in a document. Any field may be absent. */
+export interface ScrapedMeta {
+  title?: string;
+  description?: string;
+  siteName?: string;
+  imageUrl?: string;
+  /** og:type — `video.*` and `music.*` are the ones that change our rendering. */
+  ogType?: string;
+  /** Discovered `<link rel=alternate type=application/json+oembed>` endpoint. */
+  oembedUrl?: string;
+}
+
+/** The subset of an oEmbed reply we're willing to act on. */
+export interface OEmbedMeta {
+  type?: string;
+  title?: string;
+  authorName?: string;
+  providerName?: string;
+  thumbnailUrl?: string;
+  thumbnailWidth?: number;
+  thumbnailHeight?: number;
+}
+
+// Metadata lives in <head>. Anything past the start of <body> is page content,
+// and scanning it is both wasted work and a way to pick up a stray <meta> from
+// inside some third-party embed.
+function headRegion(html: string): string {
+  const bodyAt = html.search(/<body[\s>]/i);
+  return bodyAt === -1 ? html : html.slice(0, bodyAt);
+}
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+  hellip: '…',
+  mdash: '—',
+  ndash: '–',
+  rsquo: '’',
+  lsquo: '‘',
+  ldquo: '“',
+  rdquo: '”',
+};
+
+/**
+ * Decode the HTML entities that actually turn up in metadata.
+ *
+ * `og:description` is a string sitting inside an HTML attribute, so it arrives
+ * escaped — an undecoded one renders as `Tom &amp; Jerry` in the card. halloy
+ * has a whole `description_decode_html` config knob because some sites
+ * double-escape; we decode once, unconditionally, which is right for the
+ * overwhelming majority and leaves a `&amp;amp;` site looking slightly wrong
+ * rather than making everyone else's apostrophes look broken.
+ */
+export function decodeEntities(text: string): string {
+  return text.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, body: string) => {
+    if (body[0] === '#') {
+      const code =
+        body[1] === 'x' || body[1] === 'X'
+          ? Number.parseInt(body.slice(2), 16)
+          : Number.parseInt(body.slice(1), 10);
+      // Surrogates and out-of-range values would throw; leave them literal.
+      if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) return match;
+      if (code >= 0xd800 && code <= 0xdfff) return match;
+      return String.fromCodePoint(code);
+    }
+    const named = NAMED_ENTITIES[body.toLowerCase()];
+    return named ?? match;
+  });
+}
+
+/**
+ * Decode bytes to text using the document's declared charset.
+ *
+ * A surprising amount of the long tail is still windows-1252, and reading it as
+ * UTF-8 turns every smart quote into a replacement character right in the title.
+ * Node speaks utf8 and latin1 natively; latin1 is close enough to windows-1252
+ * for the punctuation that matters here. Anything more exotic falls back to
+ * UTF-8, which is the correct guess for essentially everything written this
+ * century.
+ *
+ * ⚠ `declared` is the charset the ORIGIN sent, already parsed out of its
+ * `Content-Type` — `RawResponse.charset` in linkFetch. It is not a header to be
+ * re-parsed here. An earlier version took the raw header string and ran
+ * `/charset=.../` over it, which could never match: what callers actually had
+ * to hand was `RawResponse.contentType`, stripped to a bare `text/html` before
+ * it ever left the fetcher. That branch was dead, so a page served
+ * `charset=windows-1251` with no in-document `<meta charset>` fell through to
+ * UTF-8 and rendered as replacement characters.
+ */
+export function decodeBody(body: Buffer, declared: string | null): string {
+  // Read a prefix as ASCII to find an in-document declaration. Any charset we
+  // care about is ASCII-compatible in its first bytes, so this is safe.
+  const probe = body.subarray(0, 2048).toString('latin1');
+  const fromMeta =
+    /<meta[^>]+charset=["']?([\w-]+)/i.exec(probe)?.[1] ||
+    /<meta[^>]+content=["'][^"']*charset=([\w-]+)/i.exec(probe)?.[1];
+
+  // The origin's declaration wins: it describes the bytes on the wire, and a
+  // document copied between encodings often carries a stale <meta charset>.
+  const charset = (declared || fromMeta || 'utf-8').toLowerCase();
+  if (charset === 'iso-8859-1' || charset === 'latin1' || charset === 'windows-1252') {
+    return body.toString('latin1');
+  }
+  return body.toString('utf8');
+}
+
+// One <meta>/<link> tag's attributes, order-independent and quote-agnostic.
+// Real-world HTML puts these in every order and quotes them three ways.
+function attr(tag: string, name: string): string | undefined {
+  // ⚠ Anchored on a boundary that a hyphen does NOT satisfy. `\b${name}` matched inside
+  // hyphen-prefixed attributes — `-` is a non-word character, so `\bcontent` matches within
+  // `data-content` — and since the first match wins,
+  // `<meta property="og:title" data-content="Loading…" content="Real Title">` produced the
+  // placeholder. Same shape for `name` vs `data-name`, and for `type` vs `data-type` in the
+  // oEmbed `<link rel=alternate>` scan, where it could hide an endpoint entirely.
+  const m = new RegExp(`(?:^|[\\s"'])${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i').exec(
+    tag,
+  );
+  if (!m) return undefined;
+  return m[2] ?? m[3] ?? m[4];
+}
+
+/**
+ * Scan a document's head for preview metadata.
+ *
+ * Precedence within each field is Open Graph → Twitter Card → plain HTML, which
+ * is the order of decreasing intentionality: `og:title` was written to be a
+ * preview title, `<title>` was written to be a browser tab. Note this differs
+ * from Slack, which takes whichever of OG and Twitter appears *first* in the
+ * document; a fixed precedence is easier to reason about and to test, and the
+ * two disagree only on pages that set both to different values, which is a
+ * mistake on the page's part either way.
+ */
+export function scrapeMeta(html: string): ScrapedMeta {
+  const head = headRegion(html);
+  const out: ScrapedMeta = {};
+
+  const og = new Map<string, string>();
+  const twitter = new Map<string, string>();
+
+  for (const tag of head.match(/<meta\b[^>]*>/gi) || []) {
+    const content = attr(tag, 'content');
+    if (!content) continue;
+    // OG uses `property`, Twitter Card uses `name`, and plenty of sites use the
+    // wrong one for both — so read either and route by the key's prefix.
+    const key = (attr(tag, 'property') || attr(tag, 'name') || '').toLowerCase();
+    if (!key) continue;
+    if (key.startsWith('og:')) {
+      if (!og.has(key)) og.set(key, content); // first wins: og:image repeats
+    } else if (key.startsWith('twitter:')) {
+      if (!twitter.has(key)) twitter.set(key, content);
+    } else if (key === 'description' && !twitter.has('description')) {
+      twitter.set('description', content);
+    }
+  }
+
+  const titleTag = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(head)?.[1];
+
+  out.title = og.get('og:title') || twitter.get('twitter:title') || titleTag;
+  out.description =
+    og.get('og:description') || twitter.get('twitter:description') || twitter.get('description');
+  out.siteName = og.get('og:site_name') || twitter.get('twitter:site');
+  out.imageUrl =
+    og.get('og:image:secure_url') ||
+    og.get('og:image') ||
+    twitter.get('twitter:image') ||
+    twitter.get('twitter:image:src');
+  out.ogType = og.get('og:type');
+
+  for (const tag of head.match(/<link\b[^>]*>/gi) || []) {
+    const rel = (attr(tag, 'rel') || '').toLowerCase();
+    const type = (attr(tag, 'type') || '').toLowerCase();
+    if (rel.includes('alternate') && type === 'application/json+oembed') {
+      out.oembedUrl = attr(tag, 'href');
+      break;
+    }
+    if (!out.imageUrl && rel === 'image_src') out.imageUrl = attr(tag, 'href');
+  }
+
+  // Decode and tidy at the boundary, so callers never handle a raw entity.
+  for (const k of ['title', 'description', 'siteName'] as const) {
+    const v = out[k];
+    if (v !== undefined) {
+      const clean = decodeEntities(v).replace(/\s+/g, ' ').trim();
+      if (clean) out[k] = clean;
+      else delete out[k];
+    }
+  }
+  for (const k of ['imageUrl', 'oembedUrl'] as const) {
+    const v = out[k];
+    if (v !== undefined) out[k] = decodeEntities(v).trim();
+  }
+  return out;
+}
+
+/**
+ * Read the fields we trust out of an oEmbed reply.
+ *
+ * Note what is NOT read: `html`. oEmbed hands back a ready-made iframe, and
+ * injecting a third party's markup into the message list is not a thing we are
+ * going to do — it's an XSS vector wearing a standards badge. We take the
+ * structured fields and build any embed ourselves from a provider table we
+ * control (see linkEmbed.ts).
+ */
+export function readOEmbed(json: unknown): OEmbedMeta | null {
+  if (typeof json !== 'object' || json === null) return null;
+  const o = json as Record<string, unknown>;
+  const str = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.trim() ? v.trim() : undefined;
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : undefined;
+
+  return {
+    type: str(o.type),
+    title: str(o.title),
+    authorName: str(o.author_name),
+    providerName: str(o.provider_name),
+    thumbnailUrl: str(o.thumbnail_url),
+    thumbnailWidth: num(o.thumbnail_width),
+    thumbnailHeight: num(o.thumbnail_height),
+  };
+}

--- a/server/services/linkMeta.ts
+++ b/server/services/linkMeta.ts
@@ -400,7 +400,12 @@ const NAMED_ENTITIES: Record<string, string> = Object.assign(Object.create(null)
  * rather than making everyone else's apostrophes look broken.
  */
 export function decodeEntities(text: string): string {
-  return text.replace(/&(#x?[0-9a-f]+|[a-z][a-z0-9]*);/gi, (match, body: string) => {
+  // ⚠ The hex and decimal forms are separate alternatives on purpose. A combined
+  // `#x?[0-9a-f]+` let the DECIMAL branch match hex letters, and `parseInt(body, 10)` then
+  // prefix-parsed what it was handed: `&#99f;` decoded to `c` and `&#65a;` to `A`, where the
+  // docblock and the "leaves malformed references alone" test both say they stay literal.
+  // Splitting the alternatives means a malformed reference matches nothing at all.
+  return text.replace(/&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]*);/gi, (match, body: string) => {
     if (body[0] === '#') {
       const code =
         body[1] === 'x' || body[1] === 'X'


### PR DESCRIPTION
Third of six. Cut fresh from `main`, files taken from the `inline-media-link-previews` reference branch. Lands **dormant** — nothing imports either module until PR 4 wires up the resolver.

Stack: [#682 `ipGuard`](https://github.com/amiantos/lurker/pull/682) ✅ → [#683 `linkFetch`](https://github.com/amiantos/lurker/pull/683) ✅ → **this** → resolver/cache/routes → Vue → iOS.

## What's here

Two pure modules. No I/O, no state, and neither file imports anything.

**`linkMeta.ts`** — pulls preview metadata out of an HTML document and out of an oEmbed reply.

Deliberately not a DOM parser. The Lounge pulls in cheerio for this; we need four tags out of a `<head>` we have already truncated, and a focused scanner is a fraction of the code, has no dependency to track CVEs on, and can't be induced to build a tree out of something hostile. The cost is metadata that only exists after JavaScript runs — but so does every other unfurler, Slack and Discord included.

Precedence is Open Graph → Twitter Card → plain HTML, in decreasing order of intentionality: `og:title` was written to be a preview title, `<title>` was written to be a browser tab. Entities are decoded once at the boundary, so a card never shows `Tom &amp; Jerry`.

`readOEmbed` reads the structured fields and pointedly **not** `html`.

**`linkEmbed.ts`** — turns a video page URL into a player URL.

⚠ The embed URL is derived **here**, from a table in this file, and never taken from the provider. oEmbed hands back a ready-made iframe; dropping a third party's markup into the message list would be an XSS vector with a standards document attached. The only origins that can ever reach a frame are the two written down, exported as `EMBED_ORIGINS` so the client's CSP `frame-src` can't drift from the table.

Privacy falls out of that: YouTube goes to `youtube-nocookie.com`, the thumbnail is proxied like any other preview image, and no iframe exists until the viewer clicks ▶. A channel with fifty YouTube links in scrollback otherwise hands Google fifty impressions of you, from your IP, for videos you never watched.

`oembedEndpointFor` names YouTube's and Vimeo's endpoints directly, ahead of any scraping. This is not a tunable: measured against the real site, 256 KB of `youtube.com/watch` HTML contains **no `og:title` anywhere** — it front-loads a colossal inline config blob. The Lounge hit the same wall and exposed a config knob so admins could raise the cap past 300 KB. The same question asked of YouTube's oEmbed endpoint returns **848 bytes** with the title, author and thumbnail in it. `<link rel=alternate>` discovery still runs for everyone else, and scraping remains the fallback for both.

## The one change against the reference branch

`decodeBody(body, contentTypeHeader)` → `decodeBody(body, declared: string | null)`.

The old signature opened with `/charset=["']?([\w-]+)/i.exec(contentTypeHeader)`, which **could never match**. What every caller had to hand was `RawResponse.contentType`, and the fetcher strips that to a bare `text/html` before it returns. The header branch was dead code, so a page served `charset=windows-1251` with no in-document `<meta charset>` silently fell through to UTF-8 and rendered as replacement characters.

#683 already surfaces the value as its own field, so this takes `charset: string | null` and the regex is gone. PR 4's call site becomes `decodeBody(buffered.body, buffered.charset)`.

Nothing anywhere proved the *producer* of that field either — `parseContentType` had no test against a real header, only a hand-built object with `charset: null` in it. So `linkFetch.redirects.test.ts` (the one harness that can reach a live origin) now asserts `text/HTML; charset="Windows-1251"` splits into a bare lowercased type and a lowercased charset, and that it survives `bufferStream`.

## Verification

`npm run check` and `npm test` green standalone: 230 files, 3183 tests.

Per the plan's gate — every regression test proved failing without its fix. Reverting `decodeBody` to re-parse its argument and `parseContentType`'s charset to `null`:

```
× honours the charset the origin declared      expected 'caf�' to be 'café'
× is not passed a header, and does not read one  expected 'café' not to be 'café'
× splits into a bare type and the charset        expected null to be 'windows-1251'
```

Each fails for the reason it names, and the first is the user-visible bug verbatim.

## Known residual, carried from #683

A literal `</head>` inside a comment or a script string still cuts the buffer early — it's a byte scan, not a tokenizer. That costs a preview, never a wrong one, and the fix is a parser rather than a longer regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)