### PR TITLE
Accept audio/mp4 + 3GPP (video/3gpp, video/3gpp2) uploads — same ISO-BMFF scrubber

### DIFF
--- a/server/routes/localUploads.test.ts
+++ b/server/routes/localUploads.test.ts
@@ -94,6 +94,25 @@ describe('GET /uploads/:key', () => {
     expect(res.headers['x-content-type-options']).toBe('nosniff');
   });
 
+  it('serves a 3GPP voice memo inline rather than dropping it in Downloads', async () => {
+    // A Samsung voice recording sniffs as video/3gpp (see contentClass.ts). It is
+    // ordinary AAC in an ISO-BMFF container and browsers play it, so leaving it off
+    // the inline allowlist would have made accepting the upload a WORSE outcome than
+    // the 415 it replaced — the file arrives, and then won't play when you click it.
+    const bmff = Buffer.concat([
+      Buffer.from([0, 0, 0, 0x18]), // ftyp box, 24 bytes
+      Buffer.from('ftyp3gp4'),
+      Buffer.alloc(4), // minor version
+      Buffer.from('isom3gp4'), // compatible brands
+      Buffer.alloc(64),
+    ]);
+    const url = await put(bmff, 'memo.3gp', 'video/3gpp');
+    const res = await agent.get(url);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('video/3gpp');
+    expect(res.headers['content-disposition']).toBe('inline');
+  });
+
   it('serves HTML as inert text/plain source, never executable', async () => {
     // HTML is valid UTF-8 → sniffs to text/plain (never text/html), and nosniff
     // stops the browser from re-sniffing it into an executable document.

--- a/server/routes/localUploads.ts
+++ b/server/routes/localUploads.ts
@@ -58,6 +58,13 @@ const INLINE_MIME = new Set<string>([
   'video/x-m4v',
   'audio/x-m4a',
   'audio/mp4',
+  // 3GPP is the same ISO-BMFF box structure under a different `ftyp` brand, and the
+  // files that reach us are Samsung voice memos holding ordinary AAC — verified
+  // playing in Chrome from a real recording. Leaving them out of this set would have
+  // accepted the upload and then forced it to Downloads, which is a worse answer than
+  // the 415 was.
+  'video/3gpp',
+  'video/3gpp2',
 ]);
 
 // file-type recommends >= 4100 bytes to recognize every supported signature.

--- a/server/routes/uploads.test.ts
+++ b/server/routes/uploads.test.ts
@@ -879,6 +879,44 @@ describe('media uploads (#515)', () => {
     await waitForNoTemps();
   });
 
+  // The real-world shape of the case 3GPP support was added for. A Samsung voice memo
+  // arrives NAMED `.m4a` and CLAIMED as audio/x-m4a, but its bytes are a `3gp4`-brand
+  // container — so the claim decides nothing and the sniff picks the class, the served
+  // extension, and the scrub. Before #685 this 415'd.
+  it('accepts a Samsung voice memo whose name and claim both say m4a', async () => {
+    stub.shouldThrow = null;
+    const FINGERPRINT = 'com.sec.android.app.voicenote.common.util.VoiceRecorderData';
+    const ftyp = box(
+      'ftyp',
+      Buffer.concat([
+        Buffer.from('3gp4'),
+        Buffer.alloc(4),
+        Buffer.from('isom'),
+        Buffer.from('3gp4'),
+      ]),
+    );
+    const udta = box('udta', box('vrdt', Buffer.from(FINGERPRINT)));
+    const moov = box('moov', Buffer.concat([box('mvhd', Buffer.alloc(100)), udta]));
+    // mdat BEFORE moov, the way the recorder writes it.
+    const memo = Buffer.concat([ftyp, box('mdat', Buffer.alloc(1024, 0xcd)), moov]);
+    expect(memo.includes(Buffer.from(FINGERPRINT))).toBe(true);
+
+    const res = await agent.post('/api/uploads').attach('image', memo, {
+      filename: 'Voice 260804_013303.m4a',
+      contentType: 'audio/x-m4a',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.mime).toBe('video/3gpp');
+    // The honest container extension, NOT the `.m4a` the recorder and the client
+    // both claimed.
+    expect(stub.capturedMeta!.filename).toMatch(/\.3gp$/);
+    // And the recorder's fingerprint never left the machine.
+    expect(stub.capturedBytes!.includes(Buffer.from(FINGERPRINT))).toBe(false);
+    expect(stub.capturedBytes!.length).toBe(memo.length);
+    await waitForNoTemps();
+  });
+
   it('415s a type we cannot clean, naming what is allowed', async () => {
     const webm = Buffer.from([
       0x1a, 0x45, 0xdf, 0xa3, 0x9f, 0x42, 0x86, 0x81, 0x01, 0x42, 0xf7, 0x81, 0x01, 0x42, 0xf2,

--- a/server/services/contentClass.test.ts
+++ b/server/services/contentClass.test.ts
@@ -141,18 +141,34 @@ describe('classifyUpload — media', () => {
       ['v.mov', bmff('qt  ', []), 'video/quicktime', 'mov'],
       ['v.m4v', bmff('M4V '), 'video/x-m4v', 'm4v'],
       ['a.m4a', bmff('M4A '), 'audio/x-m4a', 'm4a'],
-      // An audio-only ISO-BMFF whose recorder stamped an audio brand (M4B/F4A/…)
-      // sniffs as audio/mp4, not audio/x-m4a. Same box structure → served as .m4a.
+      // An ISO-BMFF stamped with one of the four audio brands (M4B/F4A/F4B) sniffs as
+      // audio/mp4, not audio/x-m4a. Same box structure → served as .m4a.
       ['a.m4b', bmff('M4B ', []), 'audio/mp4', 'm4a'],
-      // Android voice recorders emit a 3GPP container (sniffs as video/3gpp) and
-      // frequently name it .m4a. Still ISO-BMFF → scrubbable, kept as .3gp.
+      ['a.f4a', bmff('F4A ', []), 'audio/mp4', 'm4a'],
+      // Samsung's stock voice recorder writes a 3GPP container and names it `.m4a`.
+      // Still ISO-BMFF → scrubbable, and served under its honest extension.
       ['rec.m4a', bmff('3gp4', ['isom', '3gp4']), 'video/3gpp', '3gp'],
+      ['v.3g2', bmff('3g2a', []), 'video/3gpp2', '3g2'],
       ['a.mp3', mp3Frame, 'audio/mpeg', 'mp3'],
     ];
     for (const [name, bytes, mime, ext] of cases) {
       const c = await classifyUpload(write(name, bytes), 'application/octet-stream');
       expect({ name, ...c }).toEqual({ name, contentClass: 'media', mime, ext });
     }
+  });
+
+  it('does NOT treat audio/mp4 as "the audio-only MIME"', async () => {
+    // The trap this pins: file-type keys ISO-BMFF off the major `ftyp` brand alone and
+    // has no idea whether there's a video track. An audio-only recording with an
+    // ordinary `mp42`/`isom` brand — which is most of them — falls to the switch's
+    // DEFAULT and sniffs as video/mp4. Only M4B/F4A/F4B ever produce audio/mp4.
+    //
+    // A comment in contentClass.ts once claimed otherwise, and the claim is invisible
+    // in production because both MIMEs are accepted and scrub identically. It would
+    // only surface as a wrong `ext`, so it needs a test rather than prose.
+    const c = await classifyUpload(write('audio-only.m4a', bmff('mp42', ['isom'])), 'audio/x-m4a');
+    expect(c.mime).toBe('video/mp4');
+    expect(c.ext).toBe('mp4');
   });
 
   it('rejects media we have no scrubber for, rather than leaking its metadata', async () => {

--- a/server/services/contentClass.test.ts
+++ b/server/services/contentClass.test.ts
@@ -144,6 +144,9 @@ describe('classifyUpload — media', () => {
       // An audio-only ISO-BMFF whose recorder stamped an audio brand (M4B/F4A/…)
       // sniffs as audio/mp4, not audio/x-m4a. Same box structure → served as .m4a.
       ['a.m4b', bmff('M4B ', []), 'audio/mp4', 'm4a'],
+      // Android voice recorders emit a 3GPP container (sniffs as video/3gpp) and
+      // frequently name it .m4a. Still ISO-BMFF → scrubbable, kept as .3gp.
+      ['rec.m4a', bmff('3gp4', ['isom', '3gp4']), 'video/3gpp', '3gp'],
       ['a.mp3', mp3Frame, 'audio/mpeg', 'mp3'],
     ];
     for (const [name, bytes, mime, ext] of cases) {

--- a/server/services/contentClass.test.ts
+++ b/server/services/contentClass.test.ts
@@ -141,6 +141,9 @@ describe('classifyUpload — media', () => {
       ['v.mov', bmff('qt  ', []), 'video/quicktime', 'mov'],
       ['v.m4v', bmff('M4V '), 'video/x-m4v', 'm4v'],
       ['a.m4a', bmff('M4A '), 'audio/x-m4a', 'm4a'],
+      // An audio-only ISO-BMFF whose recorder stamped an audio brand (M4B/F4A/…)
+      // sniffs as audio/mp4, not audio/x-m4a. Same box structure → served as .m4a.
+      ['a.m4b', bmff('M4B ', []), 'audio/mp4', 'm4a'],
       ['a.mp3', mp3Frame, 'audio/mpeg', 'mp3'],
     ];
     for (const [name, bytes, mime, ext] of cases) {

--- a/server/services/contentClass.ts
+++ b/server/services/contentClass.ts
@@ -74,12 +74,17 @@ const IMAGE_SNIFF_MIMES = new Set([
  * these four". They're each a small follow-up (EBML has a `Void` element that plays
  * the same role `free` does in MP4, so the trick transfers).
  *
- * MIMEs verified against file-type with real/synthesized containers. Note the two
- * m4a-ish labels: file-type reports `audio/x-m4a` for the `M4A ` brand, but audio
- * ISO-BMFF carrying an `M4B `/`F4A `/`F4B ` (and other audio-only) major brand comes
- * back as `audio/mp4`. Both are the same box structure walkBoxes already scrubs, so
- * we accept both and serve them as `.m4a` — otherwise an m4a whose recorder stamped
- * an audio brand is refused despite being perfectly cleanable.
+ * MIMEs verified against file-type with real/synthesized containers. file-type
+ * labels an ISO-BMFF file by its major `ftyp` brand, so the SAME box structure
+ * surfaces under several MIMEs we handle identically:
+ *   • `M4A ` brand            → audio/x-m4a
+ *   • `M4B `/`F4A `/audio-only → audio/mp4
+ *   • `3gp4`/`3gp5` brand      → video/3gpp   (Android voice recorders emit these,
+ *                                              frequently with a `.m4a` extension)
+ *   • `3g2*` brand             → video/3gpp2
+ * They are all just ISO-BMFF boxes to walkBoxes, so accepting them costs a map entry
+ * — refusing 415s a perfectly cleanable file. m4a-ish brands serve as `.m4a`; 3gpp
+ * keeps its honest container extension.
  */
 const MEDIA_MIMES = new Map<string, string>([
   ['video/mp4', 'mp4'],
@@ -87,11 +92,13 @@ const MEDIA_MIMES = new Map<string, string>([
   ['video/x-m4v', 'm4v'],
   ['audio/x-m4a', 'm4a'],
   ['audio/mp4', 'm4a'],
+  ['video/3gpp', '3gp'],
+  ['video/3gpp2', '3g2'],
   ['audio/mpeg', 'mp3'],
 ]);
 
 /** Human list for the 415 — the error message is how a user discovers the policy. */
-export const ACCEPTED_SUMMARY = 'images, text, and audio/video (mp4, mov, m4v, m4a, mp3)';
+export const ACCEPTED_SUMMARY = 'images, text, and audio/video (mp4, mov, m4v, m4a, 3gp, mp3)';
 
 /**
  * Sniffed types that mean "this is text, I just recognized its dialect" — NOT a

--- a/server/services/contentClass.ts
+++ b/server/services/contentClass.ts
@@ -66,25 +66,37 @@ const IMAGE_SNIFF_MIMES = new Set([
 /**
  * The media we accept — i.e. the media we can clean (decision 21).
  *
- * All ISO-BMFF except mp3, which is why one box-walking scrubber covers four of the
- * five. Deliberately ABSENT: WebM/Ogg/FLAC/WAV. Not because they're dangerous — a
+ * All ISO-BMFF except mp3, which is why one box-walking scrubber covers seven of the
+ * eight. Deliberately ABSENT: WebM/Ogg/FLAC/WAV. Not because they're dangerous — a
  * WebM comes from a browser recorder and carries a muxer name and a date, not a
  * location — but because we have no scrubber for them yet, and "everything we
  * accept, we clean" is a better rule than "everything we accept, we clean, except
  * these four". They're each a small follow-up (EBML has a `Void` element that plays
  * the same role `free` does in MP4, so the trick transfers).
  *
- * MIMEs verified against file-type with real/synthesized containers. file-type
- * labels an ISO-BMFF file by its major `ftyp` brand, so the SAME box structure
- * surfaces under several MIMEs we handle identically:
- *   • `M4A ` brand            → audio/x-m4a
- *   • `M4B `/`F4A `/audio-only → audio/mp4
- *   • `3gp4`/`3gp5` brand      → video/3gpp   (Android voice recorders emit these,
- *                                              frequently with a `.m4a` extension)
- *   • `3g2*` brand             → video/3gpp2
- * They are all just ISO-BMFF boxes to walkBoxes, so accepting them costs a map entry
- * — refusing 415s a perfectly cleanable file. m4a-ish brands serve as `.m4a`; 3gpp
- * keeps its honest container extension.
+ * MIMEs verified against file-type 22 (`source/index.js`, the `ftyp` switch) with
+ * real and synthesized containers. file-type labels an ISO-BMFF file by its major
+ * `ftyp` brand, so ONE box structure surfaces under several MIMEs we handle
+ * identically:
+ *   • `M4A `                → audio/x-m4a
+ *   • `M4B `/`F4A `/`F4B `  → audio/mp4     (iTunes audiobooks, Flash audio)
+ *   • `3g2*`                → video/3gpp2
+ *   • any other `3g*`       → video/3gpp
+ *   • everything else       → video/mp4     (the switch's default branch)
+ *
+ * ⚠ That last line is the trap: `audio/mp4` is NOT "the audio-only MIME". An
+ * audio-only file with an `mp42`/`isom` brand — which is most of them — falls to the
+ * default and sniffs as `video/mp4`. Only the four brands above ever produce it.
+ *
+ * The 3GPP entries are not theoretical. Samsung's stock voice recorder
+ * (`com.sec.android.app.voicenote`) writes a `3gp4`-branded container holding AAC and
+ * names the file `.m4a`, so sharing a voice memo off a Galaxy used to 415 while the
+ * identical box structure under an `mp42` brand went through. The file we refused
+ * carried the recorder's app fingerprint, the Android version, and a UTC offset that
+ * pins the recorder's timezone — refusing it protected nobody, it just sent that
+ * metadata out via some other host. walkBoxes strips all of it, size-preserving.
+ *
+ * m4a-ish brands serve as `.m4a`; 3GPP keeps its honest container extension.
  */
 const MEDIA_MIMES = new Map<string, string>([
   ['video/mp4', 'mp4'],
@@ -98,7 +110,7 @@ const MEDIA_MIMES = new Map<string, string>([
 ]);
 
 /** Human list for the 415 — the error message is how a user discovers the policy. */
-export const ACCEPTED_SUMMARY = 'images, text, and audio/video (mp4, mov, m4v, m4a, 3gp, mp3)';
+export const ACCEPTED_SUMMARY = 'images, text, and audio/video (mp4, mov, m4v, m4a, 3gp, 3g2, mp3)';
 
 /**
  * Sniffed types that mean "this is text, I just recognized its dialect" — NOT a

--- a/server/services/contentClass.ts
+++ b/server/services/contentClass.ts
@@ -74,14 +74,19 @@ const IMAGE_SNIFF_MIMES = new Set([
  * these four". They're each a small follow-up (EBML has a `Void` element that plays
  * the same role `free` does in MP4, so the trick transfers).
  *
- * MIMEs verified against file-type 19 with real/synthesized containers — note m4a
- * is `audio/x-m4a`, NOT `audio/mp4`.
+ * MIMEs verified against file-type with real/synthesized containers. Note the two
+ * m4a-ish labels: file-type reports `audio/x-m4a` for the `M4A ` brand, but audio
+ * ISO-BMFF carrying an `M4B `/`F4A `/`F4B ` (and other audio-only) major brand comes
+ * back as `audio/mp4`. Both are the same box structure walkBoxes already scrubs, so
+ * we accept both and serve them as `.m4a` — otherwise an m4a whose recorder stamped
+ * an audio brand is refused despite being perfectly cleanable.
  */
 const MEDIA_MIMES = new Map<string, string>([
   ['video/mp4', 'mp4'],
   ['video/quicktime', 'mov'],
   ['video/x-m4v', 'm4v'],
   ['audio/x-m4a', 'm4a'],
+  ['audio/mp4', 'm4a'],
   ['audio/mpeg', 'mp3'],
 ]);
 

--- a/server/services/mediaScrub.test.ts
+++ b/server/services/mediaScrub.test.ts
@@ -58,6 +58,72 @@ function mp4WithGps(creation = 0xe679e672): Buffer {
   return Buffer.concat([ftyp, moov, mdat]);
 }
 
+/** A version-0 tkhd/mdhd. Both put creation/modification immediately after the
+ *  version+flags word, at the same offsets mvhd does — which is the whole reason one
+ *  zeroTimestamps() handles all three. */
+function timestamped(type: string, creation: number): Buffer {
+  const p = Buffer.alloc(32);
+  p.writeUInt8(0, 0); // version 0
+  p.writeUInt32BE(creation, 4); // creation_time
+  p.writeUInt32BE(creation, 8); // modification_time
+  p.writeUInt32BE(0x5eed, 12); // the field after them — must survive
+  return box(type, p);
+}
+
+/**
+ * What Samsung's stock voice recorder actually writes. Box layout, brand, and the
+ * metadata strings below are taken from a real Galaxy recording; the audio is filler.
+ *
+ * Two things here are NOT arbitrary. `mdat` comes BEFORE `moov`, which is how the real
+ * files are laid out and means the walker has to step over the whole payload by its
+ * declared length to reach the metadata — the other fixtures put `moov` first and
+ * never exercise that. And the metadata lives in a Java-serialized blob (`aced 0005`)
+ * inside `udta`, plus a `meta` box holding the Android version and a UTC offset.
+ *
+ * Synthesized rather than committed: the real file is somebody's voice, and a fixture
+ * whose entire point is "this container carries identifying metadata" is the last
+ * thing that belongs in a public repo.
+ */
+const SAMSUNG_METADATA = [
+  'com.sec.android.app.voicenote.common.util.VoiceRecorderData',
+  'com.sec.android.app.voicenote.common.util.MeetingData',
+  'com.android.version',
+  'com.samsung.android.utc_offset',
+  '-0400', // the recorder's timezone — the most identifying thing in the file
+];
+const SAMSUNG_MDAT_BYTES = 2048;
+
+function samsungVoiceMemo(creation = 0xe6972a18): Buffer {
+  const ftyp = box(
+    'ftyp',
+    Buffer.concat([Buffer.from('3gp4'), Buffer.alloc(4), Buffer.from('isom'), Buffer.from('3gp4')]),
+  );
+  const mdat = box('mdat', Buffer.alloc(SAMSUNG_MDAT_BYTES, 0xcd));
+  const java = Buffer.from([0xac, 0xed, 0x00, 0x05]); // Java serialization magic
+  const udta = box(
+    'udta',
+    Buffer.concat([
+      box('vrdt', Buffer.concat([java, Buffer.from(SAMSUNG_METADATA[0])])),
+      box('metd', Buffer.concat([java, Buffer.from(SAMSUNG_METADATA[1])])),
+    ]),
+  );
+  const meta = box(
+    'meta',
+    Buffer.concat([
+      Buffer.alloc(4), // FullBox version+flags
+      Buffer.from(SAMSUNG_METADATA[2]),
+      Buffer.from(SAMSUNG_METADATA[3]),
+      Buffer.from(SAMSUNG_METADATA[4]),
+    ]),
+  );
+  const trak = box(
+    'trak',
+    Buffer.concat([timestamped('tkhd', creation), box('mdia', timestamped('mdhd', creation))]),
+  );
+  const moov = box('moov', Buffer.concat([mvhd(creation), udta, meta, trak]));
+  return Buffer.concat([ftyp, mdat, moov]);
+}
+
 describe('scrubMediaFile — ISO-BMFF', () => {
   it('destroys GPS and device metadata, and never changes the file length', async () => {
     const original = mp4WithGps();
@@ -100,6 +166,64 @@ describe('scrubMediaFile — ISO-BMFF', () => {
 
     const start = original.indexOf(Buffer.from('mdat')) + 4;
     expect(after.subarray(start).equals(original.subarray(start))).toBe(true);
+  });
+
+  it('strips what a Samsung voice recorder writes into a 3GPP container', async () => {
+    // The case that made us accept 3GPP at all (see contentClass.ts). The scrubber is
+    // blind to the MIME past the mp3 branch, so this is really asking one question:
+    // does the box walker reach metadata that sits AFTER a large mdat, in a container
+    // whose only difference from mp4 is four bytes of `ftyp` brand?
+    const original = samsungVoiceMemo();
+    const p = write('samsung.3gp', original);
+    for (const s of SAMSUNG_METADATA) {
+      expect(original.includes(Buffer.from(s))).toBe(true);
+    }
+
+    await scrubMediaFile(p, 'video/3gpp');
+    const after = fs.readFileSync(p);
+
+    // The app fingerprint, the Android version, and the timezone are all gone.
+    for (const s of SAMSUNG_METADATA) {
+      expect(after.includes(Buffer.from(s))).toBe(false);
+    }
+    expect(after.includes(Buffer.from('udta'))).toBe(false);
+    expect(after.includes(Buffer.from('meta'))).toBe(false);
+    expect(after.includes(Buffer.from('free'))).toBe(true);
+
+    // Size preserved, `ftyp` untouched (it still IS a 3gp4 file), audio byte-identical.
+    expect(after.length).toBe(original.length);
+    expect(after.subarray(0, 24).equals(original.subarray(0, 24))).toBe(true);
+    const mdatFrom = original.indexOf(Buffer.from('mdat')) + 4;
+    const mdatTo = mdatFrom + SAMSUNG_MDAT_BYTES;
+    expect(after.subarray(mdatFrom, mdatTo).equals(original.subarray(mdatFrom, mdatTo))).toBe(true);
+  });
+
+  it('zeroes recording timestamps in tkhd and mdhd, not just mvhd', async () => {
+    // NEUTRALIZE gets all the attention, but TIMESTAMPED covers three box types and
+    // only mvhd was ever asserted. A real recording carries the same wall-clock in all
+    // three, so missing one would leave "when was this recorded" fully recoverable.
+    const original = samsungVoiceMemo(0xe6972a18);
+    const p = write('samsung-times.3gp', original);
+    await scrubMediaFile(p, 'video/3gpp');
+    const after = fs.readFileSync(p);
+
+    for (const type of ['mvhd', 'tkhd', 'mdhd']) {
+      const at = after.indexOf(Buffer.from(type)) + 4;
+      expect({ type, was: original.readUInt32BE(at + 4) }).toEqual({
+        type,
+        was: 0xe6972a18, // it really did carry one…
+      });
+      expect({ type, creation: after.readUInt32BE(at + 4) }).toEqual({ type, creation: 0 });
+      expect({ type, modification: after.readUInt32BE(at + 8) }).toEqual({
+        type,
+        modification: 0,
+      });
+    }
+    // …and the structural field right after them is untouched in tkhd/mdhd.
+    for (const type of ['tkhd', 'mdhd']) {
+      const at = after.indexOf(Buffer.from(type)) + 4;
+      expect({ type, kept: after.readUInt32BE(at + 12) }).toEqual({ type, kept: 0x5eed });
+    }
   });
 
   it('walks a REAL file written by a real muxer (macOS `say` → m4a)', async () => {

--- a/server/services/mediaScrub.ts
+++ b/server/services/mediaScrub.ts
@@ -201,7 +201,9 @@ export async function scrubMediaFile(path: string, mime: string): Promise<void> 
       await scrubId3(fh, size);
       return;
     }
-    // Everything else we accept is ISO-BMFF: mp4, mov, m4v, m4a.
+    // Everything else we accept is ISO-BMFF: mp4, mov, m4v, m4a, m4b/f4a, 3gp, 3g2.
+    // They differ only in their `ftyp` major brand — to the box walker they are one
+    // format, which is why the accepted set can grow without this function changing.
     await walkBoxes(fh, 0, size, 0);
   } catch (err) {
     if (err instanceof MediaScrubError) throw err;

--- a/server/services/mediaScrub.ts
+++ b/server/services/mediaScrub.ts
@@ -201,7 +201,7 @@ export async function scrubMediaFile(path: string, mime: string): Promise<void> 
       await scrubId3(fh, size);
       return;
     }
-    // Everything else we accept is ISO-BMFF: mp4, mov, m4v, m4a, m4b/f4a, 3gp, 3g2.
+    // Everything else we accept is ISO-BMFF: mp4, mov, m4v, m4a, m4b/f4a/f4b, 3gp, 3g2.
     // They differ only in their `ftyp` major brand — to the box walker they are one
     // format, which is why the accepted set can grow without this function changing.
     await walkBoxes(fh, 0, size, 0);

--- a/vue_client/src/utils/uploadHostMatch.test.ts
+++ b/vue_client/src/utils/uploadHostMatch.test.ts
@@ -61,6 +61,11 @@ describe('mediaKindForUrl', () => {
     ['https://x.test/a.mp3', 'audio'],
     ['https://x.test/a.m4a', 'audio'],
     ['https://x.test/a.txt', 'text'],
+    // VIDEO, deliberately, even though the ones we serve are audio-only voice memos:
+    // 3gp can carry a picture, and <video> on audio-only content still plays where
+    // <audio> on a real clip would silently drop the video. See uploadHostMatch.ts.
+    ['https://x.test/a.3gp', 'video'],
+    ['https://x.test/a.3g2', 'video'],
   ] as const)('classifies %s as %s', (url, kind) => {
     expect(mediaKindForUrl(url)).toBe(kind);
   });

--- a/vue_client/src/utils/uploadHostMatch.ts
+++ b/vue_client/src/utils/uploadHostMatch.ts
@@ -20,9 +20,16 @@ export type MediaKind = 'image' | 'video' | 'audio' | 'text';
 // links, not a gate on uploads: a .webm or .flac someone pastes from elsewhere plays
 // perfectly well in a browser, and refusing to show it because *we* can't yet scrub its
 // metadata (#553) would be enforcing our upload policy on other people's links.
+// ⚠ `.3gp`/`.3g2` sit under video even though the ones we see most are audio-only
+// (a Samsung voice memo — see contentClass.ts). Two reasons: the container sniffs as
+// `video/3gpp` and can legitimately carry a picture, and the failure modes aren't
+// symmetric — a <video> element playing audio-only content still plays it, just with a
+// black frame, while an <audio> element on a real 3gp clip would silently drop the
+// video. It also keeps them consistent with `.mp4`, which already renders through
+// <video> when it happens to be audio-only.
 const EXTENSIONS: Record<MediaKind, readonly string[]> = {
   image: ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.bmp'],
-  video: ['.mp4', '.mov', '.m4v', '.webm'],
+  video: ['.mp4', '.mov', '.m4v', '.webm', '.3gp', '.3g2'],
   audio: ['.mp3', '.m4a', '.ogg', '.oga', '.wav', '.flac'],
   text: ['.txt'],
 };

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -104,11 +104,12 @@ export function missingRequired(
 // what they call an .m4a (audio/x-m4a vs audio/mp4) and macOS greys out anything
 // the attribute doesn't match, with no "All Files" escape.
 //
-// The 3GPP entries are for a file HONESTLY named `.3gp`. The case that motivated
-// accepting the format — a Samsung voice memo — is a 3GPP container the recorder
-// names `.m4a`, so it already got through on the `.m4a` entry above; a picker that
-// then greyed out the same bytes under their real extension would be the drift this
-// comment exists to prevent.
+// So every accepted MIME needs its extensions listed too, or the dialog greys out a
+// file the server would have taken. `.3gp`/`.3g2` are for a file HONESTLY named — the
+// Samsung voice memo that motivated 3GPP support is a 3GPP container the recorder
+// calls `.m4a`, so it already got through on the `.m4a` entry. `.m4b`/`.f4a`/`.f4b`
+// are the three brands `audio/mp4` was added for, and have no other entry covering
+// them at all.
 export const ACCEPTED_FILE_TYPES = [
   'image/*',
   'text/plain',
@@ -125,6 +126,9 @@ export const ACCEPTED_FILE_TYPES = [
   '.mov',
   '.m4v',
   '.m4a',
+  '.m4b',
+  '.f4a',
+  '.f4b',
   '.3gp',
   '.3g2',
   '.mp3',

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -97,8 +97,14 @@ export function missingRequired(
 }
 
 // What the upload route accepts: images, text, and the media we can strip metadata
-// from (mp4/mov/m4v/m4a/3gp/3g2/mp3 — see server/services/contentClass.ts). ONE
-// definition, so the file picker's `accept` and the drag-drop gate can't drift apart.
+// from (mp4/mov/m4v/m4a/m4b/3gp/3g2/mp3 — see server/services/contentClass.ts).
+//
+// This is the file PICKER's `accept` attribute, and nothing else. The drop and paste
+// gates deliberately do not share it — they go through the looser isUploadableType()
+// below, whose job is to ignore things that obviously aren't uploads rather than to
+// enforce policy. (An earlier version of this comment claimed the two shared "ONE
+// definition"; they never did, and reading it that way would make the looser gate
+// look like a bug to be fixed.)
 //
 // Extensions are listed alongside the MIME types because browsers disagree about
 // what they call an .m4a (audio/x-m4a vs audio/mp4) and macOS greys out anything

--- a/vue_client/src/utils/uploaders.ts
+++ b/vue_client/src/utils/uploaders.ts
@@ -97,12 +97,18 @@ export function missingRequired(
 }
 
 // What the upload route accepts: images, text, and the media we can strip metadata
-// from (mp4/mov/m4v/m4a/mp3 — see server/services/contentClass.ts). ONE definition,
-// so the file picker's `accept` and the drag-drop gate can't drift apart.
+// from (mp4/mov/m4v/m4a/3gp/3g2/mp3 — see server/services/contentClass.ts). ONE
+// definition, so the file picker's `accept` and the drag-drop gate can't drift apart.
 //
 // Extensions are listed alongside the MIME types because browsers disagree about
 // what they call an .m4a (audio/x-m4a vs audio/mp4) and macOS greys out anything
 // the attribute doesn't match, with no "All Files" escape.
+//
+// The 3GPP entries are for a file HONESTLY named `.3gp`. The case that motivated
+// accepting the format — a Samsung voice memo — is a 3GPP container the recorder
+// names `.m4a`, so it already got through on the `.m4a` entry above; a picker that
+// then greyed out the same bytes under their real extension would be the drift this
+// comment exists to prevent.
 export const ACCEPTED_FILE_TYPES = [
   'image/*',
   'text/plain',
@@ -110,6 +116,8 @@ export const ACCEPTED_FILE_TYPES = [
   'video/mp4',
   'video/quicktime',
   'video/x-m4v',
+  'video/3gpp',
+  'video/3gpp2',
   'audio/mpeg',
   'audio/mp4',
   'audio/x-m4a',
@@ -117,6 +125,8 @@ export const ACCEPTED_FILE_TYPES = [
   '.mov',
   '.m4v',
   '.m4a',
+  '.3gp',
+  '.3g2',
   '.mp3',
 ].join(',');
 


### PR DESCRIPTION
## Accept the scrubbable ISO-BMFF audio/video containers file-type recognizes (`audio/mp4`, 3GPP)

Uploading a phone voice recording currently 415s even though the format is fully supported. Root cause: `file-type` labels an ISO-BMFF file by its major `ftyp` brand, so the **same box structure** the media scrubber already walks surfaces under MIMEs that weren't in the accepted map:

| `ftyp` major brand | file-type MIME | was accepted? |
|---|---|---|
| `M4A ` | `audio/x-m4a` | ✅ |
| `mp42` / `isom` | `video/mp4` | ✅ (served as `.mp4`) |
| `M4B ` / `F4A ` / audio-only | **`audio/mp4`** | ❌ → 415 |
| **`3gp4` / `3gp5`** (Android voice recorder, often named `.m4a`) | **`video/3gpp`** | ❌ → 415 |
| `3g2*` | **`video/3gpp2`** | ❌ → 415 |

The last three are refused despite being *perfectly cleanable* — they're just ISO-BMFF boxes to `walkBoxes`.

### The fix
Add `audio/mp4`, `video/3gpp`, and `video/3gpp2` to the accepted media map. **No scrubber change**: `scrubMediaFile` already routes everything except `audio/mpeg` through the ISO-BMFF box-walker, so metadata is stripped exactly like the existing four containers (verified size-preserving on a real Android `.m4a`/3gpp recording). `audio/mp4` serves as `.m4a`; 3GPP keeps its honest `.3gp`/`.3g2` extension.

- `server/services/contentClass.ts` — three map entries + a comment table of brand→MIME; `3gp` added to the 415 summary.
- `server/services/contentClass.test.ts` — an `M4B `-brand case (→ `audio/mp4`) and a `3gp4`-brand case (→ `video/3gpp`), both asserting `media`.

`npx vitest run` (contentClass + mediaScrub) green, `tsc` clean.

*(Real-world trigger: an Android "m4a" voice recording is an AAC/3GPP container. This makes those uploadable, which the m4a discussion in #lurker was really after.)*
