### PR TITLE
Link previews 4/6: the resolver, its cache, and the feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -250,6 +250,37 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_DCC_ALLOW_PRIVATE_HOSTS=false
 
 # ---------------------------------------------------------------------------
+# Link previews & inline media. OFF by default. When enabled, a link to an
+# image/video/audio file can render inline and a link to a page can render a
+# preview card. Each user then opts in separately (both of their settings also
+# default off); with this unset, the settings aren't even shown and the
+# endpoints aren't mounted.
+#
+# Off by default because this is the one feature that makes YOUR server fetch
+# arbitrary URLs that anyone in a channel can paste. That's your bandwidth, your
+# IP's reputation with the sites involved, and your problem if someone points a
+# channel at something — so it should be a decision you made, not something an
+# upgrade switched on. (The Lounge ships its equivalent, `prefetch`, off for the
+# same reason.)
+#
+# Your server does the fetching, never the clients: nobody's browser or phone
+# ever contacts the linked site, which is the point — otherwise anyone who pastes
+# a link harvests the IP of everyone who scrolls past it.
+#
+# Requests are guarded against SSRF (loopback, RFC-1918, link-local including the
+# cloud metadata endpoint, CGNAT, and IPv4-in-IPv6 tunnels are all refused, with
+# DNS pinned so the answer can't change between the check and the connection),
+# size- and time-capped, and rate-limited per account.
+#
+# LURKER_PREVIEW_USER_AGENT sets what we tell sites we are. The default
+# identifies Lurker and names the traffic class (a social-preview fetcher, which
+# is what this is — one URL, once, because a person pasted it), so an operator
+# reading their logs can recognise and block us deliberately if they want to.
+# ---------------------------------------------------------------------------
+# LURKER_LINK_PREVIEWS=on
+# LURKER_PREVIEW_USER_AGENT=
+
+# ---------------------------------------------------------------------------
 # Built-in IRC bouncer (ZNC- and soju-compatible). OFF by default. When enabled,
 # any IRC client (from mIRC to modern IRCv3 clients like Halloy/gamja/Goguma) can
 # attach to your always-on Lurker connections: shared upstream socket and nick,

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -46,8 +46,17 @@ and the protocol version — before doing anything else:
 GET /api/config            (no auth)
 → { "edition": "standalone" | "node",
     "protocolVersion": 1,
-    "minProtocolVersion": 1 }
+    "minProtocolVersion": 1,
+    "features": { "linkPreviews": false } }
 ```
+
+`features` carries instance-level flags an operator turned on. Treat a missing
+flag as **off** — an older server that doesn't advertise one doesn't have it.
+Settings whose registry entry names a feature (`requiresFeature`) must be
+**hidden**, not merely disabled, when that flag is false: there is no server
+behind them, and the endpoints aren't mounted, so a toggle would do nothing.
+`linkPreviews` gates `chat.inline_media.enabled`, `chat.link_previews.enabled`,
+and the `/api/link-preview/*` endpoints.
 
 Node edition disables `/api/api-tokens`, `/mcp`, and `/uploads/*` static serving;
 standalone has no `/api/node/*`. The WS protocol itself is identical in both.

--- a/server/app.ts
+++ b/server/app.ts
@@ -30,10 +30,12 @@ import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
 import configRouter from './routes/config.js';
+import linkPreviewRouter from './routes/linkPreview.js';
 import nodeRouter from './routes/node.js';
 import mcpRouter from './services/mcpServer.js';
 import { requireApiAuth } from './middleware/apiAuth.js';
 import { isNodeMode } from './utils/edition.js';
+import { previewsEnabled } from './utils/previews.js';
 import { allowedBrowserOrigins } from './utils/corsOrigins.js';
 
 const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
@@ -98,6 +100,12 @@ export function buildApp(sessionSecret: string): Express {
   app.use('/api/exports', exportsRouter);
   app.use('/api/imports', importRouter);
   app.use('/api/config', configRouter);
+  // ⚠ Not mounted at all when the feature is off, so both endpoints 404 rather than existing
+  // and refusing. The in-route and resolver guards stay as defence in depth — this is the outer
+  // one, and it's what makes "off" mean the surface isn't there.
+  if (previewsEnabled()) {
+    app.use('/api/link-preview', linkPreviewRouter);
+  }
 
   // The HTTP API-token feature and the MCP server are the two ends of the same
   // bearer-token model: /api/api-tokens (session-cookie auth) mints the tokens,

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -479,6 +479,14 @@ export const EXPORT_TABLES = Object.freeze({
     reason: 'cookie-based session tokens; new instance issues its own',
   },
 
+  link_previews: {
+    mode: 'skip',
+    reason:
+      'a URL-keyed cache of publicly-fetched page metadata — derived data about other ' +
+      'people’s web pages, not the user’s. Exporting it would leak which links the user ' +
+      'has seen without adding anything they could not refetch',
+  },
+
   webauthn_credentials: {
     mode: 'skip',
     reason:

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -648,6 +648,40 @@ function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_system_messages_recent ON system_messages(user_id, id);
 
+    -- Resolved link-preview metadata, keyed by URL rather than by message or by
+    -- user: the whole point is that a link pasted in forty channels by forty
+    -- people is fetched once. Nothing here is per-account, so there's no
+    -- user_id and no FK — it's a cache, and dropping the table costs a refetch.
+    --
+    -- FAILURES ARE CACHED TOO, and that's load-bearing rather than an
+    -- optimisation. A dead link, a 403 from a datacenter-IP block, or a page
+    -- with no metadata sits in old scrollback forever; without a negative entry
+    -- every scroll past it reopens a socket, and hammering a host that just
+    -- challenged us is how a rate-limit becomes a ban. status is
+    -- 'ok' | 'unavailable', and unavailable rows get a much shorter TTL so a
+    -- site that was merely down gets another chance before long.
+    --
+    -- Not part of the export contract (derived public data, not the user's) —
+    -- see the 'skip' entry in db/exportSchema.ts.
+    CREATE TABLE IF NOT EXISTS link_previews (
+      url_hash TEXT PRIMARY KEY,
+      url TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'ok',
+      kind TEXT NOT NULL DEFAULT 'page',
+      title TEXT,
+      description TEXT,
+      site_name TEXT,
+      author TEXT,
+      image_url TEXT,
+      image_width INTEGER,
+      image_height INTEGER,
+      embed_url TEXT,
+      mime TEXT,
+      fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+      expires_at TEXT NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_link_previews_expires ON link_previews(expires_at);
+
     -- RPE2E end-to-end-encryption keyring (issue #382). Secrets — the identity
     -- private key and the session keys — are stored as secretCrypto envelopes
     -- (TEXT, the same lk1.* at-rest scheme as network credentials); public

--- a/server/db/linkPreviews.test.ts
+++ b/server/db/linkPreviews.test.ts
@@ -37,6 +37,36 @@ function record(url: string, over: Partial<PreviewRecord> = {}): PreviewRecord {
 }
 
 describe('expiry', () => {
+  it('ranks a same-day timestamp correctly, where the old form did not', () => {
+    // ⚠⚠ The real guard, and it is deliberately free of `Date.now()`. The behavioural test
+    // below only CATCHES this bug when the lapsed timestamp shares a calendar date with now —
+    // so after UTC midnight it goes green with the fix reverted, and nightly CI commonly runs
+    // exactly then. Asserted against fixed literals instead: no clock, no date arithmetic, and
+    // it fails at any hour of any day.
+    //
+    // The defect: `expires_at` is ISO-8601 (`…T10:59:00.000Z`) while `datetime('now')` yields
+    // `… 11:00:00`, SQLite compares TEXT lexicographically, and 'T' (0x54) sorts after ' '
+    // (0x20) — so a row that lapsed a minute ago read as still live until midnight UTC.
+    const lapsed = '2026-07-30T10:59:00.000Z';
+    // ⚠ Built from the module's OWN expression with a fixed instant swapped in for `'now'`.
+    // Spelling the strftime out here instead would assert a fact about SQLite and stay green
+    // when the shipped line changes — which it did, on the first draft of this test.
+    const at = (instant: string): string => {
+      const expr = mod.NOW_ISO.replace("'now'", `'${instant}'`);
+      expect(expr).not.toBe(mod.NOW_ISO); // the substitution has to have happened
+      return expr;
+    };
+    const row = db
+      .prepare(
+        `SELECT (? > ${at('2026-07-30 11:00:00')}) AS shipped,
+                (? > datetime('2026-07-30 11:00:00')) AS old`,
+      )
+      .get(lapsed, lapsed) as { shipped: number; old: number };
+
+    expect(row.shipped).toBe(0); // correctly lapsed
+    expect(row.old).toBe(1); // the bug: an hour-old expiry reads as still live
+  });
+
   it('treats a lapsed row as absent even when it lapsed today', async () => {
     // ⚠ Regression guard. `expires_at` is stored ISO-8601 (`…T11:00:00.000Z`) while
     // `datetime('now')` yields `… 11:00:00`, and SQLite compares TEXT lexicographically where
@@ -115,10 +145,23 @@ describe('the cache key', () => {
     expect(urlHash('https://e.test/a?q=1')).not.toBe(a);
   });
 
-  it('still keys a URL the fetcher refuses outright', () => {
-    // normalizeUrl returns null for these, and they still get a negative row — so the fallback
-    // has to be the string as asked rather than a crash or a shared bucket.
-    expect(urlHash('http://10.0.0.1/x')).not.toBe(urlHash('http://10.0.0.2/x'));
-    expect(urlHash('not a url')).toBe(urlHash('not a url'));
+  it('collapses fragments for a URL the fetcher refuses, too', () => {
+    // ⚠ Regression guard for a fallback that quietly revoked the rule above. Keying through
+    // `normalizeUrl` meant every URL it REFUSED — a private literal, a bad scheme — fell
+    // through to the raw string, so `#a` and `#b` of one blocked address became two rows and
+    // two independent negative TTLs. The identity of a cached thing should depend on the thing,
+    // not on what the address policy thinks of it. (The earlier version of this test asserted
+    // `urlHash(x) === urlHash(x)`, which is `f(x) === f(x)` and could not have noticed.)
+    const blocked = urlHash('http://10.0.0.1/x');
+    expect(urlHash('http://10.0.0.1/x#a')).toBe(blocked);
+    expect(urlHash('http://10.0.0.1/x#b')).toBe(blocked);
+    // ...while still telling two different blocked hosts apart.
+    expect(urlHash('http://10.0.0.2/x')).not.toBe(blocked);
+  });
+
+  it('keys something that is not a URL at all without throwing', () => {
+    const junk = urlHash('not a url');
+    expect(junk).toMatch(/^[0-9a-f]{64}$/);
+    expect(urlHash('not a url#anchor')).toBe(junk);
   });
 });

--- a/server/db/linkPreviews.test.ts
+++ b/server/db/linkPreviews.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+import type { PreviewRecord } from './linkPreviews.js';
+
+const ctx = setupTestDb('db-link-previews');
+
+let mod: typeof import('./linkPreviews.js');
+let db: typeof import('./index.js').default;
+
+beforeAll(async () => {
+  mod = await import('./linkPreviews.js');
+  db = (await import('./index.js')).default;
+});
+
+afterAll(() => ctx.cleanup());
+
+function record(url: string, over: Partial<PreviewRecord> = {}): PreviewRecord {
+  return {
+    url,
+    status: 'ok',
+    kind: 'page',
+    title: 'A Title',
+    description: null,
+    siteName: null,
+    author: null,
+    imageUrl: null,
+    imageWidth: null,
+    imageHeight: null,
+    embedUrl: null,
+    mime: null,
+    expiresAt: new Date(Date.now() + mod.OK_TTL_MS).toISOString(),
+    ...over,
+  };
+}
+
+describe('expiry', () => {
+  it('treats a lapsed row as absent even when it lapsed today', async () => {
+    // ⚠ Regression guard. `expires_at` is stored ISO-8601 (`…T11:00:00.000Z`) while
+    // `datetime('now')` yields `… 11:00:00`, and SQLite compares TEXT lexicographically where
+    // 'T' (0x54) sorts after ' ' (0x20) — so a bare comparison answered "still live" for every
+    // expiry on the same calendar date. A one-hour negative TTL survived until midnight UTC.
+    const url = 'https://e.test/lapsed';
+    mod.putPreview(record(url, { expiresAt: new Date(Date.now() - 60_000).toISOString() }));
+    expect(mod.getCachedPreview(url)).toBeNull();
+
+    const live = 'https://e.test/live';
+    mod.putPreview(record(live, { expiresAt: new Date(Date.now() + 60_000).toISOString() }));
+    expect(mod.getCachedPreview(live)?.title).toBe('A Title');
+  });
+
+  it('sweeps only what has lapsed', () => {
+    const stale = 'https://e.test/sweep-me';
+    mod.putPreview(record(stale, { expiresAt: new Date(Date.now() - 1000).toISOString() }));
+    const fresh = 'https://e.test/keep-me';
+    mod.putPreview(record(fresh));
+
+    expect(mod.sweepExpiredPreviews()).toBeGreaterThanOrEqual(1);
+    expect(mod.getCachedPreview(stale)).toBeNull();
+    expect(mod.getCachedPreview(fresh)?.title).toBe('A Title');
+  });
+
+  it('can use the expiry index rather than scanning the table', () => {
+    // ⚠⚠ The fix for the comparison above was `datetime(expires_at) <= datetime('now')`, which
+    // is correct and NON-SARGABLE: wrapping the column in a function makes
+    // idx_link_previews_expires unusable, so the index is maintained on every upsert and read
+    // by nothing, and the sweep — which runs at boot and hourly, synchronously, on the one
+    // shared connection — becomes a full scan of a table with a 7-day TTL. Asserted through the
+    // planner because that is the only thing that actually knows.
+    //
+    // ⚠⚠ Planned from the module's OWN exported SQL, not a copy of it. Written against a
+    // hand-pasted query this test stayed green with the fix reverted — proving only that
+    // SQLite can use an index for a string the test made up, which is a comment wearing a
+    // test's clothes. It is the shipped statement or it is nothing.
+    const planOf = (sql: string): string =>
+      (db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as { detail: string }[])
+        .map((r) => r.detail)
+        .join(' ');
+
+    const sweep = planOf(mod.SWEEP_SQL);
+    expect(sweep).toContain('idx_link_previews_expires');
+    expect(sweep).not.toContain('SCAN link_previews');
+
+    // ...and the form it replaced does not, which is what makes the assertion above mean
+    // something rather than restate whatever the planner happens to do.
+    const wrapped = planOf(
+      `DELETE FROM link_previews WHERE datetime(expires_at) <= datetime('now')`,
+    );
+    expect(wrapped).toContain('SCAN link_previews');
+  });
+});
+
+describe('the cache key', () => {
+  const urlHash = (url: string): string => mod.urlHash(url);
+
+  it('collapses every form of one URL that normalizeUrl collapses', () => {
+    // ⚠ Regression guard. The key was the raw request string with a `/#.*$/` strip, which
+    // handled one of these four and left the rest as separate rows — the same page paying for
+    // several scrapes, several TTLs, and a one-character cache bypass for anyone authenticated
+    // (vary the host's case and every ask is a fresh outbound fetch).
+    const canonical = urlHash('https://e.test/a');
+    expect(urlHash('https://E.TEST/a')).toBe(canonical); // host case
+    expect(urlHash('https://e.test:443/a')).toBe(canonical); // default port
+    expect(urlHash('https://e.test/b/../a')).toBe(canonical); // dot segments
+    expect(urlHash('https://e.test/a#intro')).toBe(canonical); // fragment
+    expect(urlHash('https://e.test/a#appendix')).toBe(canonical);
+  });
+
+  it('keeps genuinely different URLs apart', () => {
+    const a = urlHash('https://e.test/a');
+    expect(urlHash('https://e.test/A')).not.toBe(a); // paths ARE case-sensitive
+    expect(urlHash('http://e.test/a')).not.toBe(a); // scheme is part of the identity
+    expect(urlHash('https://e.test/a?q=1')).not.toBe(a);
+  });
+
+  it('still keys a URL the fetcher refuses outright', () => {
+    // normalizeUrl returns null for these, and they still get a negative row — so the fallback
+    // has to be the string as asked rather than a crash or a shared bucket.
+    expect(urlHash('http://10.0.0.1/x')).not.toBe(urlHash('http://10.0.0.2/x'));
+    expect(urlHash('not a url')).toBe(urlHash('not a url'));
+  });
+});

--- a/server/db/linkPreviews.ts
+++ b/server/db/linkPreviews.ts
@@ -3,6 +3,7 @@
 
 import crypto from 'node:crypto';
 import db from './index.js';
+import { normalizeUrl } from '../services/linkFetch.js';
 
 /** What a resolved URL turned out to be. Decided from Content-Type, never from
  *  the file extension — the extension is only ever a client-side hint about
@@ -67,26 +68,56 @@ const RESOLVER_VERSION = 1;
  * refetched forever and displayed nothing.
  */
 export function urlHash(url: string): string {
-  // The fragment is client-side only and never reaches the origin, so `#intro` and `#appendix` of
-  // one document are the same fetch. `normalizeUrl` strips it for exactly that stated reason —
-  // but the cache keyed the RAW request string, so the documented dedupe never happened and a
-  // channel linking five anchors of one page paid for five identical scrapes. Stripped here so
-  // the key collapses them, while the descriptor still echoes the URL as asked (see
-  // `resolvePreview`, where that echo is load-bearing for the client's own lookup).
-  const key = url.replace(/#.*$/, '');
+  // ⚠ The CANONICAL form, from the same function the fetcher uses, not a hand-rolled strip.
+  //
+  // The fragment is client-side only and never reaches the origin, so `#intro` and `#appendix`
+  // of one document are the same fetch — but so are `https://E.test/a` and `https://e.test/a`,
+  // and `https://e.test` and `https://e.test/`, and `https://e.test:443/a` and
+  // `https://e.test/a`. `normalizeUrl` already collapses every one of those (it lowercases the
+  // host, drops the default port, resolves dot-segments, and strips the fragment for exactly
+  // this stated reason); keying the raw string with a `/#.*$/` regex collapsed one case out of
+  // four, so the same page paid for two scrapes, two rows and two TTLs whenever it was pasted
+  // in two forms. It is also a one-character cache bypass for any authenticated client: vary
+  // the case of the host and every request is a fresh outbound fetch.
+  //
+  // Falls back to the raw string when normalizeUrl refuses the URL outright (a blocked literal,
+  // a bad scheme) — those still get a negative row, and their identity is whatever was asked.
+  const key = normalizeUrl(url)?.toString() ?? url;
   return crypto.createHash('sha256').update(`v${RESOLVER_VERSION}|${key}`).digest('hex');
 }
 
-// ⚠ `datetime(expires_at)`, not a bare comparison. `expires_at` is stored ISO-8601
-// (`2026-07-30T11:00:00.000Z`) while `datetime('now')` yields `2026-07-30 11:00:00` — and
-// SQLite compares TEXT lexicographically, where 'T' (0x54) sorts after ' ' (0x20). So for any
-// expiry on the SAME calendar date as now, the bare form always answered "still live": a 1-hour
-// failure TTL survived until midnight UTC instead of an hour. Wrapping both sides in
-// `datetime()` compares instants rather than strings.
-const selectStmt = db.prepare(`
+/**
+ * `now`, in exactly the format `expires_at` is stored in.
+ *
+ * ⚠ Both halves of this matter, and the obvious fix for the first breaks the second.
+ *
+ * `expires_at` is written as ISO-8601 (`2026-07-30T11:00:00.000Z`) while `datetime('now')`
+ * yields `2026-07-30 11:00:00` — and SQLite compares TEXT lexicographically, where 'T' (0x54)
+ * sorts after ' ' (0x20). So a bare comparison against `datetime('now')` always answered "still
+ * live" for any expiry on the same calendar date: a 1-hour failure TTL survived until midnight
+ * UTC. Wrapping both sides in `datetime()` fixes that — and makes the column NON-SARGABLE, so
+ * `idx_link_previews_expires` becomes unusable by every query that exists. Verified with EXPLAIN
+ * QUERY PLAN: `datetime(expires_at) <= datetime('now')` plans `SCAN link_previews`, while a bare
+ * comparison plans `SEARCH ... USING INDEX idx_link_previews_expires`. The sweep runs at boot and
+ * hourly, synchronously, on the one shared connection — a full scan of a URL-keyed table with a
+ * 7-day TTL is the event-loop stall this repo already instruments for.
+ *
+ * Rendering `now` into the stored format keeps both: instants compare correctly BECAUSE
+ * ISO-8601-with-Z is lexicographically ordered, and the index is usable because the column is
+ * untouched.
+ */
+const NOW_ISO = `strftime('%Y-%m-%dT%H:%M:%fZ','now')`;
+
+/** ⚠ Exported so a test can EXPLAIN the statements that ACTUALLY run. Planning a paraphrase
+ *  proves nothing: an index assertion written against a hand-copied string stays green when the
+ *  shipped query changes underneath it, which is a comment wearing a test's clothes. */
+export const SELECT_SQL = `
   SELECT * FROM link_previews
-  WHERE url_hash = ? AND datetime(expires_at) > datetime('now')
-`);
+  WHERE url_hash = ? AND expires_at > ${NOW_ISO}
+`;
+export const SWEEP_SQL = `DELETE FROM link_previews WHERE expires_at <= ${NOW_ISO}`;
+
+const selectStmt = db.prepare(SELECT_SQL);
 
 const upsertStmt = db.prepare(`
   INSERT INTO link_previews (
@@ -105,9 +136,7 @@ const upsertStmt = db.prepare(`
     fetched_at = datetime('now'), expires_at = excluded.expires_at
 `);
 
-const sweepStmt = db.prepare(
-  `DELETE FROM link_previews WHERE datetime(expires_at) <= datetime('now')`,
-);
+const sweepStmt = db.prepare(SWEEP_SQL);
 
 interface Row {
   url: string;

--- a/server/db/linkPreviews.ts
+++ b/server/db/linkPreviews.ts
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import crypto from 'node:crypto';
+import db from './index.js';
+
+/** What a resolved URL turned out to be. Decided from Content-Type, never from
+ *  the file extension — the extension is only ever a client-side hint about
+ *  which setting *would* cover a URL. */
+export type PreviewKind = 'image' | 'video' | 'audio' | 'page' | 'video-embed';
+export type PreviewStatus = 'ok' | 'unavailable';
+
+export interface PreviewRecord {
+  url: string;
+  status: PreviewStatus;
+  kind: PreviewKind;
+  title: string | null;
+  description: string | null;
+  siteName: string | null;
+  author: string | null;
+  imageUrl: string | null;
+  imageWidth: number | null;
+  imageHeight: number | null;
+  embedUrl: string | null;
+  mime: string | null;
+  expiresAt: string;
+}
+
+/** Successful metadata is stable — a page's og:title rarely changes, and if it
+ *  does, a week-late card is a non-event. */
+export const OK_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+/** Failures get a much shorter life: a 403 or a timeout is often transient (the
+ *  site was down, we got challenged once), and we want another go before long —
+ *  just not on every scroll. */
+export const FAIL_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Bumped whenever the resolver's LOGIC changes in a way that could turn a previous
+ * `unavailable` into an `ok`.
+ *
+ * Folded into the cache key, so a bump orphans every old row rather than requiring a schema
+ * change or a manual flush — the expiry sweep collects them in its own time.
+ *
+ * This is not hypothetical bookkeeping. During development the YouTube fix was invisible for
+ * an hour after it shipped, because the previous code had already cached
+ * `youtube.com/watch?v=…` as `unavailable` and the negative TTL had not lapsed. A fix that
+ * can't be observed is a fix that gets re-debugged.
+ *
+ * ⚠ Starts at 1, deliberately, even though the resolver was rewritten several times before
+ * this point: the table has never existed in a release, so there are no v0 rows anywhere to
+ * orphan and a higher number would only imply a version somebody ran. Bump it when a change
+ * to the resolver could turn a stored `unavailable` into an `ok` — a new provider, a parser
+ * fix, a relaxed content-type — and say what changed on the line below.
+ *
+ *   v1 — initial.
+ */
+const RESOLVER_VERSION = 1;
+
+/**
+ * Cache key: the requested URL, scoped to the resolver version.
+ *
+ * ⚠ Keyed on the URL **as asked for**, never on where it ended up after redirects. Getting
+ * this wrong was a two-headed bug: the client looks a preview up by the string it sent, so a
+ * descriptor echoing the post-redirect URL silently never matched and the preview never
+ * rendered — and the cache was written under a key nothing would ever read, so every single
+ * resolve of a redirecting URL went back out to the origin. `http://en.wikipedia.org/wiki/IRC`
+ * refetched forever and displayed nothing.
+ */
+export function urlHash(url: string): string {
+  // The fragment is client-side only and never reaches the origin, so `#intro` and `#appendix` of
+  // one document are the same fetch. `normalizeUrl` strips it for exactly that stated reason —
+  // but the cache keyed the RAW request string, so the documented dedupe never happened and a
+  // channel linking five anchors of one page paid for five identical scrapes. Stripped here so
+  // the key collapses them, while the descriptor still echoes the URL as asked (see
+  // `resolvePreview`, where that echo is load-bearing for the client's own lookup).
+  const key = url.replace(/#.*$/, '');
+  return crypto.createHash('sha256').update(`v${RESOLVER_VERSION}|${key}`).digest('hex');
+}
+
+// ⚠ `datetime(expires_at)`, not a bare comparison. `expires_at` is stored ISO-8601
+// (`2026-07-30T11:00:00.000Z`) while `datetime('now')` yields `2026-07-30 11:00:00` — and
+// SQLite compares TEXT lexicographically, where 'T' (0x54) sorts after ' ' (0x20). So for any
+// expiry on the SAME calendar date as now, the bare form always answered "still live": a 1-hour
+// failure TTL survived until midnight UTC instead of an hour. Wrapping both sides in
+// `datetime()` compares instants rather than strings.
+const selectStmt = db.prepare(`
+  SELECT * FROM link_previews
+  WHERE url_hash = ? AND datetime(expires_at) > datetime('now')
+`);
+
+const upsertStmt = db.prepare(`
+  INSERT INTO link_previews (
+    url_hash, url, status, kind, title, description, site_name, author,
+    image_url, image_width, image_height, embed_url, mime, fetched_at, expires_at
+  ) VALUES (
+    @urlHash, @url, @status, @kind, @title, @description, @siteName, @author,
+    @imageUrl, @imageWidth, @imageHeight, @embedUrl, @mime, datetime('now'), @expiresAt
+  )
+  ON CONFLICT(url_hash) DO UPDATE SET
+    status = excluded.status, kind = excluded.kind, title = excluded.title,
+    description = excluded.description, site_name = excluded.site_name,
+    author = excluded.author, image_url = excluded.image_url,
+    image_width = excluded.image_width, image_height = excluded.image_height,
+    embed_url = excluded.embed_url, mime = excluded.mime,
+    fetched_at = datetime('now'), expires_at = excluded.expires_at
+`);
+
+const sweepStmt = db.prepare(
+  `DELETE FROM link_previews WHERE datetime(expires_at) <= datetime('now')`,
+);
+
+interface Row {
+  url: string;
+  status: string;
+  kind: string;
+  title: string | null;
+  description: string | null;
+  site_name: string | null;
+  author: string | null;
+  image_url: string | null;
+  image_width: number | null;
+  image_height: number | null;
+  embed_url: string | null;
+  mime: string | null;
+  expires_at: string;
+}
+
+function toRecord(row: Row): PreviewRecord {
+  return {
+    url: row.url,
+    status: row.status as PreviewStatus,
+    kind: row.kind as PreviewKind,
+    title: row.title,
+    description: row.description,
+    siteName: row.site_name,
+    author: row.author,
+    imageUrl: row.image_url,
+    imageWidth: row.image_width,
+    imageHeight: row.image_height,
+    embedUrl: row.embed_url,
+    mime: row.mime,
+    expiresAt: row.expires_at,
+  };
+}
+
+/** A live cache entry for this URL, or null on miss/expiry. */
+export function getCachedPreview(url: string): PreviewRecord | null {
+  const row = selectStmt.get(urlHash(url)) as Row | undefined;
+  return row ? toRecord(row) : null;
+}
+
+export function putPreview(record: PreviewRecord): void {
+  upsertStmt.run({ ...record, urlHash: urlHash(record.url) });
+}
+
+/** Drop lapsed rows. Wired to a timer in server.ts — the table is a cache, so this is
+ *  housekeeping rather than correctness, but without it the table only ever grows. */
+export function sweepExpiredPreviews(): number {
+  return sweepStmt.run().changes;
+}

--- a/server/db/linkPreviews.ts
+++ b/server/db/linkPreviews.ts
@@ -3,7 +3,6 @@
 
 import crypto from 'node:crypto';
 import db from './index.js';
-import { normalizeUrl } from '../services/linkFetch.js';
 
 /** What a resolved URL turned out to be. Decided from Content-Type, never from
  *  the file extension — the extension is only ever a client-side hint about
@@ -54,8 +53,14 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  * fix, a relaxed content-type — and say what changed on the line below.
  *
  *   v1 — initial.
+ *   v2 — a video embed survives a page with no title and no image (a rate-limited provider
+ *        call used to discard the embed URL it was holding); an unusable oEmbed thumbnail no
+ *        longer discards the scraped og:image alongside it. Both turn stored `unavailable`
+ *        rows into `ok` ones, which is precisely what this counter is for — and the `urlHash`
+ *        rewrite in the same change is NOT a substitute, because it produces byte-identical
+ *        hashes for canonically-spelled URLs and so orphans none of the affected rows.
  */
-const RESOLVER_VERSION = 1;
+const RESOLVER_VERSION = 2;
 
 /**
  * Cache key: the requested URL, scoped to the resolver version.
@@ -80,9 +85,26 @@ export function urlHash(url: string): string {
   // in two forms. It is also a one-character cache bypass for any authenticated client: vary
   // the case of the host and every request is a fresh outbound fetch.
   //
-  // Falls back to the raw string when normalizeUrl refuses the URL outright (a blocked literal,
-  // a bad scheme) — those still get a negative row, and their identity is whatever was asked.
-  const key = normalizeUrl(url)?.toString() ?? url;
+  // ⚠ Canonicalised by `URL` itself, NOT by `normalizeUrl`. They agree on every URL
+  // `normalizeUrl` accepts — it returns the parsed URL with the fragment cleared, which is
+  // exactly this — but routing through it had two costs. It made the cache key a function of
+  // the SSRF ADDRESS POLICY, so adding a prefix to `isBlockedIpLiteral` would silently re-key
+  // every cached row in that range from a file with no connection to the resolver. And its
+  // refusals fell through to the raw string, which quietly revoked the fragment collapse for
+  // exactly those URLs: `http://10.0.0.1/x#a` and `#b` became two rows and two TTLs, for inputs
+  // the comment below promises still get one negative row.
+  //
+  // The identity of a cached thing should depend on the thing, not on what we think of it.
+  let key: string;
+  try {
+    const canonical = new URL(url);
+    canonical.hash = '';
+    key = canonical.toString();
+  } catch {
+    // Not a URL at all. It still gets a negative row, keyed by what was asked minus the
+    // fragment, so anchors of one unparseable string share it like anchors of any other.
+    key = url.replace(/#[\s\S]*$/, '');
+  }
   return crypto.createHash('sha256').update(`v${RESOLVER_VERSION}|${key}`).digest('hex');
 }
 
@@ -106,7 +128,10 @@ export function urlHash(url: string): string {
  * ISO-8601-with-Z is lexicographically ordered, and the index is usable because the column is
  * untouched.
  */
-const NOW_ISO = `strftime('%Y-%m-%dT%H:%M:%fZ','now')`;
+/** ⚠ Exported so a test can substitute a fixed instant for `'now'` and assert the ranking
+ *  deterministically. A test that spells the expression out itself asserts a fact about SQLite
+ *  rather than about this module, and stays green when this line changes. */
+export const NOW_ISO = `strftime('%Y-%m-%dT%H:%M:%fZ','now')`;
 
 /** ⚠ Exported so a test can EXPLAIN the statements that ACTUALLY run. Planning a paraphrase
  *  proves nothing: an index assertion written against a hand-copied string stays green when the

--- a/server/routes/config.test.ts
+++ b/server/routes/config.test.ts
@@ -40,3 +40,29 @@ describe('GET /api/config', () => {
     expect(res.body.minProtocolVersion).toBe(MIN_PROTOCOL_VERSION);
   });
 });
+
+describe('feature flags', () => {
+  const withFlag = async (value: string | undefined) => {
+    const saved = process.env.LURKER_LINK_PREVIEWS;
+    if (value === undefined) delete process.env.LURKER_LINK_PREVIEWS;
+    else process.env.LURKER_LINK_PREVIEWS = value;
+    try {
+      return (await createAnonAgent(app).get('/api/config')).body as {
+        features?: { linkPreviews?: boolean };
+      };
+    } finally {
+      if (saved === undefined) delete process.env.LURKER_LINK_PREVIEWS;
+      else process.env.LURKER_LINK_PREVIEWS = saved;
+    }
+  };
+
+  it('reports link previews off by default', async () => {
+    // Clients use this to HIDE the two settings rather than offer toggles with no server behind
+    // them — the routes aren't even mounted when the flag is off.
+    expect((await withFlag(undefined)).features?.linkPreviews).toBe(false);
+  });
+
+  it('reports them on once the operator opts in', async () => {
+    expect((await withFlag('on')).features?.linkPreviews).toBe(true);
+  });
+});

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -5,6 +5,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { getEdition } from '../utils/edition.js';
 import { PROTOCOL_VERSION, MIN_PROTOCOL_VERSION } from '../protocol.js';
+import { previewsEnabled } from '../utils/previews.js';
 
 const router = Router();
 
@@ -22,6 +23,12 @@ router.get('/', (_req: Request, res: Response) => {
     edition: getEdition(),
     protocolVersion: PROTOCOL_VERSION,
     minProtocolVersion: MIN_PROTOCOL_VERSION,
+    // Feature flags. `linkPreviews` is off unless the operator opted in
+    // (LURKER_LINK_PREVIEWS); clients use it to hide the two user settings entirely rather than
+    // presenting toggles that can't do anything.
+    features: {
+      linkPreviews: previewsEnabled(),
+    },
   });
 });
 

--- a/server/routes/linkPreview.media.test.ts
+++ b/server/routes/linkPreview.media.test.ts
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The byte proxy against a real origin.
+//
+// Its own file because it needs the address policy inverted — the real guard blocks loopback,
+// correctly, so nothing can watch this endpoint actually SERVE without it. The main route test
+// keeps the real guard and covers refusal; this one covers what happens when a fetch succeeds,
+// which was untested end to end: the headers, the caps, the range plumbing.
+//
+// ⚠ What's mocked is the POLICY, never the mechanism. Express, the token, the throttles, the
+// pool, safeRequest, the pinned lookup and the pipe are all shipping code.
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { Express } from 'express';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+
+vi.mock('../utils/ipGuard.js', () => ({
+  isBlockedIpLiteral: (host: string) => host.replace(/^\[|\]$/g, '') !== '127.0.0.1',
+  isBlockedIpv4: (ip: string) => ip !== '127.0.0.1',
+}));
+
+const ctx = setupTestDb('routes-link-preview-media');
+process.env.LURKER_LINK_PREVIEWS = 'on';
+
+let app: Express;
+let agent: LurkerTestAgent;
+let mintProxyToken: typeof import('../services/mediaProxyToken.js').mintProxyToken;
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+let handler: Handler;
+let origin: http.Server;
+let base: string;
+
+/** A token for a path on the live origin, reached through `localhost` so the pinned lookup runs. */
+const tokenFor = (path: string): string => mintProxyToken(`${base}${path}`);
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  ({ mintProxyToken } = await import('../services/mediaProxyToken.js'));
+  const router = (await import('./linkPreview.js')).default;
+
+  const alice = createUser('alice-media');
+  app = createTestApp({ '/api/link-preview': router });
+  agent = await createAuthedAgent(app, alice.id);
+
+  origin = http.createServer((req, res) => handler(req, res));
+  await new Promise<void>((resolve) => origin.listen(0, '127.0.0.1', resolve));
+  base = `http://localhost:${(origin.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => origin.close(() => resolve()));
+  ctx.cleanup();
+});
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+describe('serving bytes', () => {
+  it('streams an image back under our own origin, with the hardening headers', async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(PNG.length) });
+      res.end(PNG);
+    };
+
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/a.png')}`).expect(200);
+    expect(res.headers['content-type']).toBe('image/png');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['content-security-policy']).toBe("default-src 'none'; sandbox");
+    expect(res.headers['content-disposition']).toBe('inline');
+    expect(res.headers['cross-origin-resource-policy']).toBe('same-origin');
+    expect(res.headers['cache-control']).toBe('private, max-age=86400, immutable');
+    expect(Buffer.from(res.body).equals(PNG)).toBe(true);
+  });
+
+  it('refuses SVG even though the origin calls it an image', async () => {
+    // The allowlist is the point: these bytes are served under OUR origin, and SVG executes
+    // script. One definition now — the route asks the resolver's `proxyableContentType`.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/svg+xml' });
+      res.end('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+    };
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/logo.svg')}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('refuses text/html, which is the other way to get script into our origin', async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<script>alert(1)</script>');
+    };
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/page.html')}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('does not claim to accept ranges when the origin ignored them', async () => {
+    // ⚠ Advertising `Accept-Ranges: bytes` for a source that ignores Range makes a media
+    // element seek by asking for a range and then silently receive the whole file from byte
+    // zero — a seek that jumps back to the start.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png' });
+      res.end(PNG);
+    };
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/b.png')}`).expect(200);
+    expect(res.headers['accept-ranges']).toBeUndefined();
+  });
+
+  it('forwards a range, and says so, when the origin honours one', async () => {
+    handler = (req, res) => {
+      if (!req.headers.range) {
+        res.writeHead(200, { 'content-type': 'video/mp4' });
+        res.end('whole');
+        return;
+      }
+      res.writeHead(206, {
+        'content-type': 'video/mp4',
+        'content-range': `bytes 0-4/1000`,
+        'content-length': '5',
+      });
+      res.end('parti');
+    };
+
+    const res = await agent
+      .get(`/api/link-preview/media/${tokenFor('/clip.mp4')}`)
+      .set('Range', 'bytes=0-4')
+      .expect(206);
+    expect(res.headers['content-range']).toBe('bytes 0-4/1000');
+    expect(res.headers['accept-ranges']).toBe('bytes');
+  });
+
+  it('refuses a partial response whose RESOURCE is over the cap', async () => {
+    // ⚠⚠ Regression guard. The cap only ever looked at Content-Length, which on a 206 is the
+    // length of the PART — so a client asking for a 1 GB file one megabyte at a time satisfied
+    // `declared <= cap` every single time and walked straight past a limit named for the
+    // resource. The real size is the figure after the slash in Content-Range.
+    handler = (_req, res) => {
+      res.writeHead(206, {
+        'content-type': 'video/mp4',
+        'content-range': `bytes 0-1023/${1024 * 1024 * 1024}`,
+        'content-length': '1024',
+      });
+      res.end(Buffer.alloc(1024));
+    };
+
+    const res = await agent
+      .get(`/api/link-preview/media/${tokenFor('/huge.mp4')}`)
+      .set('Range', 'bytes=0-1023');
+    expect(res.status).toBe(413);
+  });
+
+  it('refuses a whole response that declares itself over the cap', async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, {
+        'content-type': 'image/png',
+        'content-length': String(64 * 1024 * 1024),
+      });
+      res.end(PNG);
+    };
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/huge.png')}`);
+    expect(res.status).toBe(413);
+  });
+
+  it('passes an unsatisfiable range through as 416 rather than 404', async () => {
+    // A media element knows what to do with 416 — it means "that range doesn't exist", not
+    // "the file doesn't exist", and collapsing the two makes a bad seek look like a dead link.
+    handler = (_req, res) => {
+      res.writeHead(416, { 'content-range': 'bytes */500' });
+      res.end();
+    };
+    const res = await agent
+      .get(`/api/link-preview/media/${tokenFor('/short.mp4')}`)
+      .set('Range', 'bytes=9999-')
+      .expect(416);
+    expect(res.headers['content-range']).toBe('bytes */500');
+  });
+
+  it('answers 404, not 500, when the origin is simply not there', async () => {
+    const token = mintProxyToken('http://127.0.0.1:1/nothing.png');
+    const res = await agent.get(`/api/link-preview/media/${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('survives a token whose signature is the right length in the wrong encoding', async () => {
+    // ⚠ Regression guard, reached through the ROUTE because that is where it hurt: the length
+    // guard compared UTF-16 code units while timingSafeEqual compares bytes, so this threw a
+    // RangeError from above the handler's try — a 500 and a logged stack, where the endpoint's
+    // whole answer to a bad token is 403.
+    const token = tokenFor('/a.png');
+    const payload = token.slice(0, token.lastIndexOf('.'));
+    const sig = token.slice(token.lastIndexOf('.') + 1);
+    const res = await agent.get(
+      `/api/link-preview/media/${payload}.${encodeURIComponent(`é${'a'.repeat(sig.length - 1)}`)}`,
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/server/routes/linkPreview.media.test.ts
+++ b/server/routes/linkPreview.media.test.ts
@@ -200,3 +200,156 @@ describe('serving bytes', () => {
     expect(res.status).toBe(403);
   });
 });
+
+describe('holding and releasing the fetch slot', () => {
+  // ⚠ These lines had no test at all — not the pool, not the 503, not the teardown — and three
+  // of the review's findings lived in them. The mediaPool is instance-wide module state, so
+  // these assertions are about what the ROUTE observably does with it.
+
+  it('tears the origin connection down when the client goes away mid-FETCH', async () => {
+    // ⚠⚠ Regression guard, and the timing is the whole test. The leak lives in the window
+    // BEFORE `safeRequest` resolves — while there is a live request but no `upstream` to
+    // destroy. An origin that answers immediately closes that window, so a version of this test
+    // with a fast handler passes against the bug (mine did). This origin sits on the headers.
+    //
+    // What went wrong: `finish()` latched its done-flag with `upstream` still null, so the
+    // destroy it existed for could never run, and the later call returned at its own guard. The
+    // origin socket stayed live and unread, outside a pool that had already counted it free —
+    // 'connect-then-abort as a cheap amplifier', which is what the comment claimed to prevent.
+    //
+    // Proved server-side: nothing client-side can see a socket we are still holding.
+    let closedEarly = false;
+    const settled = new Promise<void>((resolve) => {
+      handler = (req, res) => {
+        res.on('error', () => {});
+        // Torn down from our end before the origin ever answered.
+        req.on('close', () => {
+          closedEarly = !res.headersSent;
+          resolve();
+        });
+        // Deliberately slow: the fetch is still in flight when the client leaves.
+        setTimeout(() => {
+          if (!res.destroyed) {
+            res.writeHead(200, { 'content-type': 'video/mp4' });
+            res.end('too late');
+          }
+        }, 3_000).unref();
+      };
+    });
+
+    // ⚠ `.end()` to DISPATCH. A superagent request is lazy — it isn't sent until something
+    // subscribes — so building one and aborting it proves nothing at all; the origin never sees
+    // a connection and the assertion below waits forever for a close that cannot come.
+    const req = agent.get(`/api/link-preview/media/${tokenFor('/abandoned.mp4')}`);
+    req.end(() => {});
+    await new Promise((r) => setTimeout(r, 150));
+    req.abort();
+
+    // Bounded, because "leaked" here means "still open", and waiting forever cannot tell the
+    // two apart. A live guard closes it in milliseconds; the bug holds it for the 30 s idle
+    // timeout that `streaming: true` installs.
+    const raced = await Promise.race([
+      settled.then(() => 'closed' as const),
+      new Promise<'leaked'>((r) => setTimeout(() => r('leaked'), 2_000)),
+    ]);
+    expect(raced).toBe('closed');
+    expect(closedEarly).toBe(true);
+  }, 20_000);
+
+  it('gives the slot back after an ordinary response, so the pool does not leak', async () => {
+    // A pool that never releases looks fine until the 24th request of the process. Serving more
+    // than the pool size in sequence is the cheapest assertion that release actually runs.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(PNG.length) });
+      res.end(PNG);
+    };
+    for (let i = 0; i < 30; i++) {
+      const res = await agent.get(`/api/link-preview/media/${tokenFor(`/seq-${i}.png`)}`);
+      expect(`${i} → ${res.status}`).toBe(`${i} → 200`);
+    }
+  }, 30_000);
+
+  it('gives the slot back after a refusal too', async () => {
+    // The error paths release through the same `close` listener. If they didn't, a run of dead
+    // origins would retire the pool a slot at a time.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<script>alert(1)</script>');
+    };
+    for (let i = 0; i < 30; i++) {
+      const res = await agent.get(`/api/link-preview/media/${tokenFor(`/refused-${i}.html`)}`);
+      expect(`${i} → ${res.status}`).toBe(`${i} → 404`);
+    }
+  }, 30_000);
+});
+
+describe('the resource-size cap on a partial response', () => {
+  // ⚠ Each of these forms is legal, and each defeated the first version of `contentRangeTotal`
+  // — with the inversion that made it worth its own describe: the more absurd the claimed size,
+  // the more permissive the answer was.
+  const partial = (contentRange: string): void => {
+    handler = (_req, res) => {
+      res.writeHead(206, {
+        'content-type': 'video/mp4',
+        'content-range': contentRange,
+        'content-length': '1024',
+      });
+      res.end(Buffer.alloc(1024));
+    };
+  };
+
+  it('refuses a total it cannot represent instead of waving it through', async () => {
+    // `Number('9'.repeat(400))` is Infinity, `Number.isFinite` said false, and the guard read
+    // that as "no total stated, carry on".
+    partial(`bytes 0-1023/${'9'.repeat(400)}`);
+    const res = await agent
+      .get(`/api/link-preview/media/${tokenFor('/absurd.mp4')}`)
+      .set('Range', 'bytes=0-1023');
+    expect(res.status).toBe(413);
+  });
+
+  it('refuses a Content-Range it cannot parse', async () => {
+    partial('bytes 0-1023/not-a-number');
+    const res = await agent
+      .get(`/api/link-preview/media/${tokenFor('/garbage.mp4')}`)
+      .set('Range', 'bytes=0-1023');
+    expect(res.status).toBe(413);
+  });
+
+  it('judges the FIRST of a duplicated Content-Range, not the last', async () => {
+    // node joins duplicates with ', ', and a `$`-anchored pattern read only the tail — so an
+    // origin could state an acceptable size second and be believed.
+    partial(`bytes 0-1023/${1024 * 1024 * 1024}, bytes 0-1023/1024`);
+    const res = await agent
+      .get(`/api/link-preview/media/${tokenFor('/twohdr.mp4')}`)
+      .set('Range', 'bytes=0-1023');
+    expect(res.status).toBe(413);
+  });
+
+  it('still serves a partial response whose total is genuinely unknown', async () => {
+    // `bytes 0-N/*` is legal (RFC 7233 §4.2) and common for live-generated media. Refusing it
+    // outright would be the other failure: the per-response byte counter is what bounds it.
+    partial('bytes 0-1023/*');
+    const res = await agent
+      .get(`/api/link-preview/media/${tokenFor('/unknown.mp4')}`)
+      .set('Range', 'bytes=0-1023');
+    expect(res.status).toBe(206);
+  });
+});
+
+describe('range advertisement', () => {
+  it('reads Accept-Ranges as a token list, not a whole value', async () => {
+    // ⚠ node joins a duplicated header, so a range-capable origin sending it twice arrives as
+    // `'bytes, bytes'`. An equality test called that range-INCAPABLE, and Safari then refuses
+    // to play the video at all — silently, since the card itself renders fine.
+    handler = (_req, res) => {
+      // Set as an array so node emits the header twice, which is the case under test.
+      res.setHeader('Accept-Ranges', ['bytes', 'bytes']);
+      res.writeHead(200, { 'content-type': 'video/mp4', 'content-length': '5' });
+      res.end('whole');
+    };
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/dupehdr.mp4')}`);
+    expect(res.status).toBe(200);
+    expect(res.headers['accept-ranges']).toBe('bytes');
+  });
+});

--- a/server/routes/linkPreview.test.ts
+++ b/server/routes/linkPreview.test.ts
@@ -100,6 +100,28 @@ describe('POST /api/link-preview/resolve', () => {
     expect((await agent.post('/api/link-preview/resolve').send({ urls: 'nope' })).status).toBe(400);
   });
 
+  it('rejects a body that is not JSON at all, without a 500', async () => {
+    // ⚠⚠ Regression guard, and one no `.send({...})` test can reach — supertest always sets a
+    // JSON content type. Express 5's body-parser leaves `req.body` UNDEFINED for anything else
+    // (it returns early rather than substituting `{}`), so dereferencing it threw a TypeError
+    // into the error middleware: a 500 for exactly the malformed requests the next line's 400
+    // was written to answer, which made that branch dead code. Every other route in this repo
+    // guards it — `req.body || {}` or `(req.body as X | undefined)?.field`.
+    for (const [type, payload] of [
+      ['text/plain', 'hello'],
+      ['application/x-www-form-urlencoded', 'urls=x'],
+    ] as const) {
+      const res = await agent
+        .post('/api/link-preview/resolve')
+        .set('Content-Type', type)
+        .send(payload);
+      expect(`${type} → ${res.status}`).toBe(`${type} → 400`);
+    }
+    // ...and with no Content-Type at all.
+    const bare = await agent.post('/api/link-preview/resolve');
+    expect(bare.status).toBe(400);
+  });
+
   it('returns a descriptor for a cached page, with the thumbnail proxied', async () => {
     const url = 'https://example.com/cached-article';
     seed(url);

--- a/server/routes/linkPreview.test.ts
+++ b/server/routes/linkPreview.test.ts
@@ -1,0 +1,411 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import type { Express } from 'express';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  createAnonAgent,
+} from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+
+const ctx = setupTestDb('routes-link-preview');
+
+let app: Express;
+let agent: LurkerTestAgent;
+let alice: User;
+let putPreview: typeof import('../db/linkPreviews.js').putPreview;
+let mintProxyToken: typeof import('../services/mediaProxyToken.js').mintProxyToken;
+let OK_TTL_MS: number;
+let urlHash: typeof import('../db/linkPreviews.js').urlHash;
+let db: typeof import('../db/index.js').default;
+let createUser: typeof import('../db/users.js').createUser;
+
+const SAVED_SECRET = process.env.SESSION_SECRET;
+
+const SAVED_FLAG = process.env.LURKER_LINK_PREVIEWS;
+
+beforeAll(async () => {
+  process.env.SESSION_SECRET = 'link-preview-route-test-secret';
+  // The feature is off by default now, and `previewsEnabled()` gates the routes from inside as
+  // well as their mounting. Every test here is about behaviour WHEN enabled.
+  process.env.LURKER_LINK_PREVIEWS = 'on';
+  ({ createUser } = await import('../db/users.js'));
+  ({ putPreview, OK_TTL_MS, urlHash } = await import('../db/linkPreviews.js'));
+  db = (await import('../db/index.js')).default;
+  ({ mintProxyToken } = await import('../services/mediaProxyToken.js'));
+  const router = (await import('./linkPreview.js')).default;
+
+  alice = createUser('alice');
+  app = createTestApp({ '/api/link-preview': router });
+  agent = await createAuthedAgent(app, alice.id);
+});
+
+afterAll(() => {
+  if (SAVED_SECRET === undefined) delete process.env.SESSION_SECRET;
+  else process.env.SESSION_SECRET = SAVED_SECRET;
+  if (SAVED_FLAG === undefined) delete process.env.LURKER_LINK_PREVIEWS;
+  else process.env.LURKER_LINK_PREVIEWS = SAVED_FLAG;
+  ctx.cleanup();
+});
+
+/** Seed the cache so a test can exercise the happy path without any network. */
+function seed(url: string, over: Partial<Parameters<typeof putPreview>[0]> = {}) {
+  putPreview({
+    url,
+    status: 'ok',
+    kind: 'page',
+    title: 'A Title',
+    description: 'A description',
+    siteName: 'Example',
+    author: null,
+    imageUrl: 'https://cdn.example.com/thumb.png',
+    imageWidth: 1200,
+    imageHeight: 630,
+    embedUrl: null,
+    mime: null,
+    expiresAt: new Date(Date.now() + OK_TTL_MS).toISOString(),
+    ...over,
+  });
+}
+
+/** When the cached row for `url` was fetched, or null if there isn't one. */
+function firstFetchedAt(url: string): string | null {
+  const row = db
+    .prepare('SELECT fetched_at FROM link_previews WHERE url_hash = ?')
+    .get(urlHash(url)) as { fetched_at: string } | undefined;
+  return row?.fetched_at ?? null;
+}
+
+function rowCount(url: string): number {
+  const row = db
+    .prepare('SELECT COUNT(*) AS n FROM link_previews WHERE url_hash = ?')
+    .get(urlHash(url)) as { n: number };
+  return row.n;
+}
+
+describe('POST /api/link-preview/resolve', () => {
+  it('requires authentication', async () => {
+    const anon = createAnonAgent(app);
+    const res = await anon.post('/api/link-preview/resolve').send({ urls: [] });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a body without a urls array', async () => {
+    expect((await agent.post('/api/link-preview/resolve').send({})).status).toBe(400);
+    expect((await agent.post('/api/link-preview/resolve').send({ urls: 'nope' })).status).toBe(400);
+  });
+
+  it('returns a descriptor for a cached page, with the thumbnail proxied', async () => {
+    const url = 'https://example.com/cached-article';
+    seed(url);
+
+    const res = await agent
+      .post('/api/link-preview/resolve')
+      .send({ urls: [url] })
+      .expect(200);
+
+    const [preview] = res.body.previews;
+    expect(preview.status).toBe('ok');
+    expect(preview.kind).toBe('page');
+    expect(preview.title).toBe('A Title');
+    expect(preview.siteName).toBe('Example');
+    expect(preview.thumbWidth).toBe(1200);
+
+    // The client is handed OUR url, never the origin's — that's the whole
+    // privacy property, so assert it rather than trusting it.
+    expect(preview.thumb).toMatch(/^\/api\/link-preview\/media\//);
+    expect(JSON.stringify(preview)).not.toContain('cdn.example.com');
+  });
+
+  it('puts direct media in src rather than thumb', async () => {
+    const url = 'https://example.com/photo.png';
+    seed(url, { kind: 'image', imageUrl: url, title: null, mime: 'image/png' });
+
+    const res = await agent
+      .post('/api/link-preview/resolve')
+      .send({ urls: [url] })
+      .expect(200);
+    const [preview] = res.body.previews;
+    expect(preview.kind).toBe('image');
+    expect(preview.src).toMatch(/^\/api\/link-preview\/media\//);
+    expect(preview.thumb).toBeUndefined();
+  });
+
+  it('carries an embed URL for a video, and it is the no-cookie host', async () => {
+    const url = 'https://www.youtube.com/watch?v=abc123';
+    seed(url, {
+      kind: 'video-embed',
+      embedUrl: 'https://www.youtube-nocookie.com/embed/abc123?autoplay=1&rel=0',
+    });
+
+    const res = await agent
+      .post('/api/link-preview/resolve')
+      .send({ urls: [url] })
+      .expect(200);
+    expect(res.body.previews[0].embedUrl).toContain('youtube-nocookie.com');
+  });
+
+  it('omits every metadata field on an unavailable preview', async () => {
+    const url = 'https://example.com/gone';
+    seed(url, { status: 'unavailable' });
+
+    const res = await agent
+      .post('/api/link-preview/resolve')
+      .send({ urls: [url] })
+      .expect(200);
+    const [preview] = res.body.previews;
+    expect(preview.status).toBe('unavailable');
+    expect(preview.title).toBeUndefined();
+    expect(preview.thumb).toBeUndefined();
+  });
+
+  it('answers one descriptor per input, in order', async () => {
+    seed('https://example.com/one', { title: 'One' });
+    seed('https://example.com/two', { title: 'Two' });
+
+    const res = await agent
+      .post('/api/link-preview/resolve')
+      .send({ urls: ['https://example.com/two', 'https://example.com/one'] })
+      .expect(200);
+
+    expect(res.body.previews.map((p: { title?: string }) => p.title)).toEqual(['Two', 'One']);
+  });
+
+  it('refuses an internal address that is genuinely reachable, without dialling it', async () => {
+    // A test that only asserts "unavailable" would pass for the wrong reason —
+    // an unreachable URL is also unavailable. So stand up a real server on
+    // loopback, PROVE it answers, then prove Lurker refuses to touch it. The
+    // request counter is the actual assertion: not "the fetch failed" but "no
+    // fetch happened".
+    let hits = 0;
+    const origin = http.createServer((_req, res) => {
+      hits++;
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<head><meta property="og:title" content="INTERNAL SECRET"></head>');
+    });
+    await new Promise<void>((resolve) => origin.listen(0, '127.0.0.1', resolve));
+    const port = (origin.address() as import('node:net').AddressInfo).port;
+    const target = `http://127.0.0.1:${port}/admin`;
+
+    try {
+      // Validate the probe: the origin really is serving the thing we're about
+      // to prove we can't reach.
+      const probe = await new Promise<string>((resolve, reject) => {
+        http
+          .get(target, (r) => {
+            let body = '';
+            r.on('data', (c) => (body += c));
+            r.on('end', () => resolve(body));
+          })
+          .on('error', reject);
+      });
+      expect(probe).toContain('INTERNAL SECRET');
+      expect(hits).toBe(1);
+
+      const res = await agent
+        .post('/api/link-preview/resolve')
+        .send({
+          urls: [
+            target,
+            'http://169.254.169.254/latest/meta-data/', // cloud metadata
+            'http://10.0.0.1/',
+            'http://[::1]/',
+            'file:///etc/passwd',
+          ],
+        })
+        .expect(200);
+
+      for (const preview of res.body.previews) {
+        expect(`${preview.url} → ${preview.status}`).toBe(`${preview.url} → unavailable`);
+        expect(JSON.stringify(preview)).not.toContain('INTERNAL SECRET');
+      }
+      // Still 1 — the probe's own request, and nothing from Lurker.
+      expect(hits).toBe(1);
+    } finally {
+      await new Promise<void>((resolve) => origin.close(() => resolve()));
+    }
+  });
+
+  it('refuses a HOSTNAME that resolves internally', async () => {
+    // Distinct code path from the test above. `127.0.0.1` is caught by the URL
+    // parse because it's literally an address; `localhost` parses fine and is
+    // only caught when the pinned lookup sees what it resolves to. That's the
+    // path DNS rebinding would attack, so it needs its own proof.
+    let hits = 0;
+    const origin = http.createServer((_req, res) => {
+      hits++;
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<head><meta property="og:title" content="VIA HOSTNAME"></head>');
+    });
+    await new Promise<void>((resolve) => origin.listen(0, '127.0.0.1', resolve));
+    const port = (origin.address() as import('node:net').AddressInfo).port;
+
+    try {
+      const probe = await new Promise<string>((resolve, reject) => {
+        http
+          .get(`http://localhost:${port}/`, (r) => {
+            let body = '';
+            r.on('data', (c) => (body += c));
+            r.on('end', () => resolve(body));
+          })
+          .on('error', reject);
+      });
+      expect(probe).toContain('VIA HOSTNAME');
+      expect(hits).toBe(1);
+
+      const res = await agent
+        .post('/api/link-preview/resolve')
+        .send({ urls: [`http://localhost:${port}/`] })
+        .expect(200);
+
+      expect(res.body.previews[0].status).toBe('unavailable');
+      expect(hits).toBe(1);
+    } finally {
+      await new Promise<void>((resolve) => origin.close(() => resolve()));
+    }
+  });
+
+  it('resolves a FULL batch rather than starving it', async () => {
+    // ⚠⚠ Regression guard. The concurrency pool was 6 while a request may carry 20, and
+    // `resolvePreview` runs synchronously up to its first await — so `Promise.all` over a batch
+    // started all 20 before any finished, and calls 7-20 were refused a slot and answered
+    // `unavailable` without ever dialling. On a link-heavy history page that meant 6 previews
+    // rendered and 14 links stayed bare for the whole session.
+    //
+    // Blocked addresses make this offline and deterministic: each resolves to `unavailable`
+    // either way, so what's actually asserted is that all 20 got a real ANSWER — i.e. a cache
+    // row was written for each, which the starvation path never did.
+    const urls = Array.from({ length: 20 }, (_, i) => `http://10.20.30.${i + 1}/x`);
+    const res = await agent.post('/api/link-preview/resolve').send({ urls }).expect(200);
+    expect(res.body.previews.length).toBe(20);
+    for (const url of urls) expect(rowCount(url)).toBe(1);
+  });
+
+  it('caps how many URLs one request can fan out to', async () => {
+    const urls = Array.from({ length: 50 }, (_, i) => `http://127.0.0.1/${i}`);
+    const res = await agent.post('/api/link-preview/resolve').send({ urls }).expect(200);
+    expect(res.body.previews.length).toBe(20);
+  });
+
+  it('ignores non-string entries rather than failing the whole batch', async () => {
+    seed('https://example.com/mixed', { title: 'Mixed' });
+    const res = await agent
+      .post('/api/link-preview/resolve')
+      .send({ urls: [42, null, 'https://example.com/mixed', { a: 1 }] })
+      .expect(200);
+    expect(res.body.previews.length).toBe(1);
+    expect(res.body.previews[0].title).toBe('Mixed');
+  });
+});
+
+describe('one resolve serves every user on the cell', () => {
+  it('does not refetch for a second user', async () => {
+    // The guarantee: ten people in a channel scrolling past one link is ONE outbound
+    // fetch, not ten. The cache is keyed by URL with no user_id anywhere in it, so this
+    // holds across accounts by construction — but it's the kind of property that breaks
+    // quietly, so it gets a test.
+    //
+    // A blocked address makes "fetching" deterministic and offline: it resolves to
+    // `unavailable`, which is cached exactly like a success.
+    const url = 'http://10.1.2.3/shared-link';
+    const bob = createUser('bob-cache');
+    const bobAgent = await createAuthedAgent(app, bob.id);
+
+    await agent
+      .post('/api/link-preview/resolve')
+      .send({ urls: [url] })
+      .expect(200);
+    const first = firstFetchedAt(url);
+    expect(first).not.toBeNull();
+
+    await bobAgent
+      .post('/api/link-preview/resolve')
+      .send({ urls: [url] })
+      .expect(200);
+    // Same row, untouched — the second user read the first user's answer.
+    expect(firstFetchedAt(url)).toBe(first);
+    expect(rowCount(url)).toBe(1);
+  });
+
+  it('answers ten simultaneous asks for one URL identically', async () => {
+    const url = 'http://10.9.9.9/hot-link';
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        agent.post('/api/link-preview/resolve').send({ urls: [url] }),
+      ),
+    );
+    for (const res of results) expect(res.status).toBe(200);
+    expect(rowCount(url)).toBe(1);
+  });
+});
+
+describe('the URL a descriptor is keyed by', () => {
+  it('echoes the URL as asked, so a client lookup matches', async () => {
+    // ⚠ Regression guard for a two-headed bug. Descriptors used to echo the URL the fetch
+    // ENDED at, so for anything that redirects (http→https, www canonicalisation, a
+    // renamed article) the client's lookup by the string it sent missed and the preview
+    // never rendered — while the cache row, written under that same unreachable key, was
+    // never read either, so every resolve went back out to the origin.
+    const asked = 'http://10.4.4.4/redirects-somewhere';
+    const res = await agent
+      .post('/api/link-preview/resolve')
+      .send({ urls: [asked] })
+      .expect(200);
+    expect(res.body.previews[0].url).toBe(asked);
+    expect(rowCount(asked)).toBe(1);
+  });
+});
+
+describe('GET /api/link-preview/media/:token', () => {
+  it('requires authentication', async () => {
+    const anon = createAnonAgent(app);
+    const token = mintProxyToken('https://cdn.example.com/a.png');
+    expect((await anon.get(`/api/link-preview/media/${token}`)).status).toBe(401);
+  });
+
+  it('rejects a token it did not sign', async () => {
+    expect((await agent.get('/api/link-preview/media/forged.signature')).status).toBe(403);
+  });
+
+  it('rejects a token whose payload was swapped for an internal address', async () => {
+    const token = mintProxyToken('https://cdn.example.com/a.png');
+    const sig = token.slice(token.lastIndexOf('.') + 1);
+    const payload = Buffer.from('http://169.254.169.254/', 'utf8').toString('base64url');
+    expect((await agent.get(`/api/link-preview/media/${payload}.${sig}`)).status).toBe(403);
+  });
+
+  it('refuses a validly-signed token that points somewhere internal', async () => {
+    // Belt and braces: even a token WE signed gets re-vetted, because the DNS
+    // answer may have moved since it was minted.
+    const token = mintProxyToken('http://127.0.0.1/secret.png');
+    expect((await agent.get(`/api/link-preview/media/${token}`)).status).toBe(403);
+  });
+
+  it('is a 404, not a crash, when the origin cannot be reached', async () => {
+    const token = mintProxyToken('https://not-a-real-host.invalid/a.png');
+    expect((await agent.get(`/api/link-preview/media/${token}`)).status).toBe(404);
+  });
+
+  it('goes dark entirely when the feature flag is off', async () => {
+    const saved = process.env.LURKER_LINK_PREVIEWS;
+    delete process.env.LURKER_LINK_PREVIEWS;
+    try {
+      const token = mintProxyToken('https://cdn.example.com/a.png');
+      expect((await agent.get(`/api/link-preview/media/${token}`)).status).toBe(404);
+      // Both endpoints, not just the interesting one. In a running server neither is mounted
+      // when the flag is off; asserting the inner gate on both is what keeps them from
+      // drifting apart if the mounting ever moves.
+      expect(
+        (await agent.post('/api/link-preview/resolve').send({ urls: ['https://e.test/a'] })).status,
+      ).toBe(404);
+    } finally {
+      if (saved === undefined) delete process.env.LURKER_LINK_PREVIEWS;
+      else process.env.LURKER_LINK_PREVIEWS = saved;
+    }
+  });
+});

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -19,6 +19,7 @@ import { RequestThrottle } from '../middleware/rateLimit.js';
 import {
   resolvePreview,
   toDescriptor,
+  proxyableContentType,
   MAX_IMAGE_PROXY_BYTES,
   MAX_MEDIA_PROXY_BYTES,
   MAX_URLS_PER_REQUEST,
@@ -26,6 +27,7 @@ import {
 import { verifyProxyToken } from '../services/mediaProxyToken.js';
 import { normalizeUrl, safeRequest } from '../services/linkFetch.js';
 import { previewsEnabled } from '../utils/previews.js';
+import { SlotPool } from '../utils/slotPool.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -58,6 +60,32 @@ const resolveThrottle = new RequestThrottle({
  */
 const mediaThrottle = new RequestThrottle({ windowMs: 60_000, maxRequests: 300 });
 
+/**
+ * Byte fetches in flight across the whole instance.
+ *
+ * ⚠ Its OWN pool, and not optional. The resolver's pool documents itself as the bound on the
+ * feature's outstanding DNS lookups — `getaddrinfo` runs on libuv's thread pool and cannot be
+ * cancelled, so a destroyed request keeps its slot for the full OS timeout, and the other DNS
+ * consumer on this server is IRC connection setup. This route never went through that pool, and
+ * it is the HIGHER-volume half: one resolve per link, but one byte request per image on screen.
+ * `mediaThrottle` bounds the rate and not the concurrency, and the agents are deliberately
+ * `keepAlive: false, maxSockets: Infinity`, so a session replaying tokens it already holds could
+ * open sockets and uncancellable lookups without limit.
+ *
+ * Separate from the resolver's rather than shared with it because the two have opposite
+ * profiles: a metadata fetch is a sub-second burst, a byte fetch can hold its slot for the
+ * length of a video. Sharing would let one video stall every preview on the instance.
+ */
+const mediaPool = new SlotPool({ size: 24, maxQueued: 200, waitMs: 10_000 });
+
+/** Total size of the resource a `Content-Range` describes, or null if it doesn't say. */
+function contentRangeTotal(header: string | undefined): number | null {
+  const total = /\/\s*(\d+)\s*$/.exec(header || '')?.[1];
+  if (total === undefined) return null;
+  const n = Number(total);
+  return Number.isFinite(n) ? n : null;
+}
+
 router.post(
   '/resolve',
   asyncHandler(async (req: Request, res: Response) => {
@@ -69,7 +97,12 @@ router.post(
       return;
     }
 
-    const body = req.body as { urls?: unknown };
+    // ⚠ `?? {}`, because Express 5's body-parser leaves `req.body` UNDEFINED rather than empty
+    // for any request that isn't JSON — no Content-Type, `text/plain`, a form post. Reading
+    // through it threw a TypeError into the error middleware, so the 400 two lines down was
+    // dead code for precisely the malformed requests it exists to answer, and a client sending
+    // the wrong content type got a 500 and a logged stack instead of being told what was wrong.
+    const body = (req.body ?? {}) as { urls?: unknown };
     if (!Array.isArray(body.urls)) {
       res.status(400).json({ error: 'urls must be an array' });
       return;
@@ -96,25 +129,6 @@ router.post(
   }),
 );
 
-/**
- * Content types the proxy will serve.
- *
- * An allowlist, not a denylist. The endpoint returns bytes from an arbitrary
- * origin under OUR origin, so anything that a browser might execute in our
- * security context has to be impossible rather than merely discouraged — which
- * rules out `text/html` and, emphatically, `image/svg+xml`: SVG is a scripting
- * format wearing a picture's clothes, and the uploader already refuses it for
- * exactly this reason.
- */
-function proxyableContentType(contentType: string): boolean {
-  if (contentType === 'image/svg+xml') return false;
-  return (
-    contentType.startsWith('image/') ||
-    contentType.startsWith('video/') ||
-    contentType.startsWith('audio/')
-  );
-}
-
 router.get(
   '/media/:token',
   asyncHandler(async (req: Request, res: Response) => {
@@ -126,7 +140,7 @@ router.get(
     const verdict = mediaThrottle.allow(String(req.user!.id));
     if (!verdict.ok) {
       res.set('Retry-After', String(verdict.retryAfter));
-      res.status(429).end();
+      res.status(429).json({ error: 'too many media requests — slow down' });
       return;
     }
 
@@ -149,16 +163,71 @@ router.get(
       return;
     }
 
+    if (!(await mediaPool.acquire())) {
+      // Saturated, not broken. 503 + Retry-After so a media element backs off and retries,
+      // rather than 404, which an <img> treats as a permanent verdict and never re-asks.
+      res.set('Retry-After', '5');
+      res.status(503).end();
+      return;
+    }
+
+    // ⚠ Registered BEFORE the fetch is awaited, and it owns the slot release.
+    //
+    // Attaching this after `await safeRequest(...)` — which can take the full hop deadline —
+    // meant a client that aborted during the fetch had already fired `close`, so the listener
+    // written to stop us "holding a socket to the origin" was attached to an event that would
+    // never fire again. Writes then fail silently while the byte counter below keeps the
+    // upstream in flowing mode, so the whole body drains to the origin's end with nobody to
+    // send it to: connect-then-abort as a cheap amplifier.
+    //
+    // `close` on a response fires whether it finished or aborted, which makes it the one place
+    // that always runs — so it is also where the pool slot goes back.
+    let upstream: Awaited<ReturnType<typeof safeRequest>> | null = null;
+    let done = false;
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      upstream?.stream.destroy();
+      mediaPool.release();
+    };
+    res.on('close', finish);
+    // A response already gone by the time we got a slot never emits `close` again.
+    if (res.destroyed) {
+      finish();
+      return;
+    }
+
     try {
-      const upstream = await safeRequest(url, {
+      upstream = await safeRequest(url, {
         accept: 'image/*,video/*,audio/*;q=0.9,*/*;q=0.5',
         // Forwarded so inline video works at all. Safari (iOS and macOS) refuses to play a
         // <video> whose source doesn't honour byte ranges, and seeking is broken everywhere
         // without it — and this route is what serves `kind === 'video'`.
         range: typeof req.headers.range === 'string' ? req.headers.range : undefined,
+        // Piped, not buffered: the scrape-tuned deadlines cut a healthy media transfer at 20 s
+        // and read a backpressured <video> as a dead origin. See FetchOptions.streaming.
+        streaming: true,
       });
+      // The client left, or the stream died, while we were awaiting. Without this the response
+      // never gets its `end()` — and `Content-Length` may already have gone out — so the
+      // browser hangs on a half-open response with no error to show.
+      if (done || res.destroyed || upstream.stream.destroyed) {
+        finish();
+        return;
+      }
 
-      // 206 is a success here: it's what a range request is asking for.
+      // 206 is a success here: it's what a range request is asking for. 416 is the origin
+      // telling the client its range is unsatisfiable, which is an answer the media element
+      // knows how to act on — passing it through as 404 makes an unsatisfiable seek look like
+      // a missing file.
+      if (upstream.status === 416) {
+        upstream.stream.destroy();
+        if (upstream.headers['content-range']) {
+          res.setHeader('Content-Range', String(upstream.headers['content-range']));
+        }
+        res.status(416).end();
+        return;
+      }
       const ok = upstream.status === 200 || upstream.status === 206;
       if (!ok || !proxyableContentType(upstream.contentType)) {
         upstream.stream.destroy();
@@ -174,7 +243,14 @@ router.get(
         ? MAX_IMAGE_PROXY_BYTES
         : MAX_MEDIA_PROXY_BYTES;
       const declared = Number(upstream.headers['content-length']);
-      if (Number.isFinite(declared) && declared > cap) {
+      // ⚠ On a 206 the declared length is the length of the PART, so checking it alone let the
+      // cap be walked straight past: a client asking for a gigabyte 1 MB at a time satisfies
+      // `declared <= cap` every single time. The resource's real size is the figure after the
+      // slash in Content-Range, and that is what the cap is about.
+      const total = contentRangeTotal(upstream.headers['content-range'] as string | undefined);
+      const oversize =
+        (Number.isFinite(declared) && declared > cap) || (total !== null && total > cap);
+      if (oversize) {
         upstream.stream.destroy();
         res.status(413).end();
         return;
@@ -194,8 +270,14 @@ router.get(
       // the response travels over an authenticated session.
       res.setHeader('Cache-Control', 'private, max-age=86400, immutable');
 
-      // Range plumbing, so a media element can seek.
-      res.setHeader('Accept-Ranges', 'bytes');
+      // Range plumbing, so a media element can seek. ⚠ Only claimed when the origin actually
+      // demonstrated it: advertising `Accept-Ranges: bytes` for a source that ignores Range
+      // makes a media element seek by requesting a range and then silently receive the whole
+      // file from byte zero, which reads as a seek that jumps back to the start.
+      const upstreamRanges =
+        upstream.status === 206 ||
+        String(upstream.headers['accept-ranges'] || '').toLowerCase() === 'bytes';
+      if (upstreamRanges) res.setHeader('Accept-Ranges', 'bytes');
       if (upstream.headers['content-range']) {
         res.setHeader('Content-Range', String(upstream.headers['content-range']));
       }
@@ -212,21 +294,20 @@ router.get(
       // Enforce the cap on bytes actually seen, not on the declared length — an
       // origin can omit Content-Length or lie about it.
       let sent = 0;
-      upstream.stream.on('data', (chunk: Buffer) => {
+      const stream = upstream.stream;
+      stream.on('data', (chunk: Buffer) => {
         sent += chunk.length;
         if (sent > cap) {
-          upstream.stream.destroy();
+          stream.destroy();
           res.destroy();
         }
       });
-      upstream.stream.on('error', () => res.destroy());
-      upstream.stream.pipe(res);
-      // A viewer who scrolls away mid-download shouldn't leave us holding a socket
-      // to the origin.
-      res.on('close', () => upstream.stream.destroy());
+      stream.on('error', () => res.destroy());
+      stream.pipe(res);
     } catch {
       // Blocked address, timeout, reset — all the same to a caller waiting on an
       // image, and none of them worth distinguishing in a status code.
+      finish();
       if (!res.headersSent) res.status(404).end();
     }
   }),

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Two endpoints, both authenticated:
+//
+//   POST /api/link-preview/resolve      urls[] → descriptors[]
+//   GET  /api/link-preview/media/:token → the bytes, streamed
+//
+// REST rather than WebSocket because these are reads, and Lurker's reads are
+// REST (search is the one deliberate exception, and it's deliberate because it
+// needs a token/reply round trip the REST surface can't express). The byte
+// endpoint has to be a URL regardless — that's what an <img src> is.
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { asyncHandler } from '../utils/asyncHandler.js';
+import { RequestThrottle } from '../middleware/rateLimit.js';
+import {
+  resolvePreview,
+  toDescriptor,
+  MAX_IMAGE_PROXY_BYTES,
+  MAX_MEDIA_PROXY_BYTES,
+  MAX_URLS_PER_REQUEST,
+} from '../services/linkPreview.js';
+import { verifyProxyToken } from '../services/mediaProxyToken.js';
+import { normalizeUrl, safeRequest } from '../services/linkFetch.js';
+import { previewsEnabled } from '../utils/previews.js';
+
+const router = Router();
+router.use(requireAuth);
+
+/**
+ * Per-account cap on resolutions.
+ *
+ * Keyed by user rather than by IP, unlike the auth limiters: this route is
+ * authenticated, so the account is the accurate identity, and an IP key would
+ * lump everyone behind one household NAT together. The ceiling is set for a
+ * human scrolling fast through link-heavy scrollback — clients batch and dedupe
+ * before asking, so hitting this means something is looping.
+ */
+const resolveThrottle = new RequestThrottle({
+  windowMs: 60_000,
+  maxRequests: 120,
+});
+
+/**
+ * Per-account cap on BYTE requests.
+ *
+ * ⚠ The byte endpoint needs its own. Only `/resolve` was throttled, so any authenticated session
+ * could loop `GET /media/:token` for a token it already held: keep-alive is off by design, so
+ * each request opens a fresh upstream socket and pulls up to the cap — a few hundred in flight
+ * saturate the cell's egress and file descriptors and hammer the origin from the operator's IP,
+ * which is the exact resource the resolve throttle exists to protect.
+ *
+ * Set well above what a person browsing generates (the browser and iOS URLCache hold these for a
+ * day, so a re-scroll costs nothing) and far below what a loop does.
+ */
+const mediaThrottle = new RequestThrottle({ windowMs: 60_000, maxRequests: 300 });
+
+router.post(
+  '/resolve',
+  asyncHandler(async (req: Request, res: Response) => {
+    // Same inner gate as the byte route. The router isn't mounted when the feature is off, so
+    // this is unreachable in a running server — but both endpoints answering the flag the same
+    // way is what keeps that true if the mounting ever moves.
+    if (!previewsEnabled()) {
+      res.status(404).end();
+      return;
+    }
+
+    const body = req.body as { urls?: unknown };
+    if (!Array.isArray(body.urls)) {
+      res.status(400).json({ error: 'urls must be an array' });
+      return;
+    }
+
+    const urls = body.urls
+      .filter((u): u is string => typeof u === 'string')
+      .slice(0, MAX_URLS_PER_REQUEST);
+
+    const verdict = resolveThrottle.allow(String(req.user!.id));
+    if (!verdict.ok) {
+      res.set('Retry-After', String(verdict.retryAfter));
+      res.status(429).json({ error: 'too many preview requests — slow down' });
+      return;
+    }
+
+    // Resolved in parallel, but `resolvePreview` never rejects and coalesces
+    // duplicates internally, so this can't turn into an unbounded fan-out or an
+    // unhandled rejection.
+    const previews = await Promise.all(
+      urls.map(async (u) => toDescriptor(await resolvePreview(u))),
+    );
+    res.json({ previews });
+  }),
+);
+
+/**
+ * Content types the proxy will serve.
+ *
+ * An allowlist, not a denylist. The endpoint returns bytes from an arbitrary
+ * origin under OUR origin, so anything that a browser might execute in our
+ * security context has to be impossible rather than merely discouraged — which
+ * rules out `text/html` and, emphatically, `image/svg+xml`: SVG is a scripting
+ * format wearing a picture's clothes, and the uploader already refuses it for
+ * exactly this reason.
+ */
+function proxyableContentType(contentType: string): boolean {
+  if (contentType === 'image/svg+xml') return false;
+  return (
+    contentType.startsWith('image/') ||
+    contentType.startsWith('video/') ||
+    contentType.startsWith('audio/')
+  );
+}
+
+router.get(
+  '/media/:token',
+  asyncHandler(async (req: Request, res: Response) => {
+    if (!previewsEnabled()) {
+      res.status(404).end();
+      return;
+    }
+
+    const verdict = mediaThrottle.allow(String(req.user!.id));
+    if (!verdict.ok) {
+      res.set('Retry-After', String(verdict.retryAfter));
+      res.status(429).end();
+      return;
+    }
+
+    // The token is the capability: the server minted it during resolve, after the
+    // URL had already passed the guard, so a client can only replay a decision we
+    // made. It cannot author one.
+    const raw = verifyProxyToken(String(req.params.token));
+    if (!raw) {
+      res.status(403).end();
+      return;
+    }
+
+    // Re-vetted from scratch anyway. The token proves we approved this URL at some
+    // point; it says nothing about where the name points NOW, and a DNS record
+    // that was public an hour ago can be 10.0.0.5 today. safeRequest re-runs the
+    // pinned lookup on every hop.
+    const url = normalizeUrl(raw);
+    if (!url) {
+      res.status(403).end();
+      return;
+    }
+
+    try {
+      const upstream = await safeRequest(url, {
+        accept: 'image/*,video/*,audio/*;q=0.9,*/*;q=0.5',
+        // Forwarded so inline video works at all. Safari (iOS and macOS) refuses to play a
+        // <video> whose source doesn't honour byte ranges, and seeking is broken everywhere
+        // without it — and this route is what serves `kind === 'video'`.
+        range: typeof req.headers.range === 'string' ? req.headers.range : undefined,
+      });
+
+      // 206 is a success here: it's what a range request is asking for.
+      const ok = upstream.status === 200 || upstream.status === 206;
+      if (!ok || !proxyableContentType(upstream.contentType)) {
+        upstream.stream.destroy();
+        res.status(404).end();
+        return;
+      }
+      // ⚠ Per-KIND cap. The single 8 MB ceiling was named for images and silently applied to
+      // everything, so a 30 MB mp4 rendered inline was streamed to 8 MB and then had both ends
+      // destroyed — the <video> died with a network error partway through, and since the
+      // `immutable` Cache-Control had already gone out the browser could cache the truncated
+      // body. Video and audio are streamed to a media element and are legitimately larger.
+      const cap = upstream.contentType.startsWith('image/')
+        ? MAX_IMAGE_PROXY_BYTES
+        : MAX_MEDIA_PROXY_BYTES;
+      const declared = Number(upstream.headers['content-length']);
+      if (Number.isFinite(declared) && declared > cap) {
+        upstream.stream.destroy();
+        res.status(413).end();
+        return;
+      }
+
+      res.setHeader('Content-Type', upstream.contentType);
+      // Belt and braces against the response being interpreted as anything other
+      // than the media type we just allowlisted.
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
+      // No filename: it would come from a URL someone else controls.
+      res.setHeader('Content-Disposition', 'inline');
+      res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+      // The token is a pure function of the URL, so a given token always denotes
+      // the same bytes — safe to cache hard, and it's what keeps a scroll through
+      // an image-heavy channel from re-proxying on every pass. `private` because
+      // the response travels over an authenticated session.
+      res.setHeader('Cache-Control', 'private, max-age=86400, immutable');
+
+      // Range plumbing, so a media element can seek.
+      res.setHeader('Accept-Ranges', 'bytes');
+      if (upstream.headers['content-range']) {
+        res.setHeader('Content-Range', String(upstream.headers['content-range']));
+      }
+
+      // ⚠ Content-Length is only forwarded when we KNOW we'll send exactly that many bytes.
+      // Echoing it verbatim while the body was truncated at the cap produced a length/body
+      // mismatch — the client saw ERR_HTTP_CONTENT_LENGTH_MISMATCH (a broken transfer) rather
+      // than a clean, cacheable failure.
+      if (Number.isFinite(declared) && declared <= cap) {
+        res.setHeader('Content-Length', String(declared));
+      }
+      res.status(upstream.status === 206 ? 206 : 200);
+
+      // Enforce the cap on bytes actually seen, not on the declared length — an
+      // origin can omit Content-Length or lie about it.
+      let sent = 0;
+      upstream.stream.on('data', (chunk: Buffer) => {
+        sent += chunk.length;
+        if (sent > cap) {
+          upstream.stream.destroy();
+          res.destroy();
+        }
+      });
+      upstream.stream.on('error', () => res.destroy());
+      upstream.stream.pipe(res);
+      // A viewer who scrolls away mid-download shouldn't leave us holding a socket
+      // to the origin.
+      res.on('close', () => upstream.stream.destroy());
+    } catch {
+      // Blocked address, timeout, reset — all the same to a caller waiting on an
+      // image, and none of them worth distinguishing in a status code.
+      if (!res.headersSent) res.status(404).end();
+    }
+  }),
+);
+
+export default router;

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -75,15 +75,58 @@ const mediaThrottle = new RequestThrottle({ windowMs: 60_000, maxRequests: 300 }
  * Separate from the resolver's rather than shared with it because the two have opposite
  * profiles: a metadata fetch is a sub-second burst, a byte fetch can hold its slot for the
  * length of a video. Sharing would let one video stall every preview on the instance.
+ *
+ * ⚠ That same argument applies WITHIN this pool, and is not addressed here: a thumbnail and a
+ * 64 MB video share these slots, so a handful of streams can make every image on the instance
+ * queue. Two mitigations rather than a second pool (which would need the kind before the
+ * headers that reveal it): MAX_TRANSFER_MS bounds how long any one slot can be held, and the
+ * wait is short — an <img> that can't get a slot should fail in three seconds and be retried by
+ * the page, not stall for ten and then get a 503 that <img> treats as permanent.
  */
-const mediaPool = new SlotPool({ size: 24, maxQueued: 200, waitMs: 10_000 });
+const mediaPool = new SlotPool({ size: 24, maxQueued: 200, waitMs: 3_000 });
 
-/** Total size of the resource a `Content-Range` describes, or null if it doesn't say. */
-function contentRangeTotal(header: string | undefined): number | null {
-  const total = /\/\s*(\d+)\s*$/.exec(header || '')?.[1];
-  if (total === undefined) return null;
+/**
+ * Ceiling on one proxied transfer, start to finish.
+ *
+ * ⚠ `streaming: true` clears HOP_DEADLINE_MS, which is the only bound in the fetcher that a
+ * byte cannot reset — deliberately, because it cut healthy video at 20 s. But that left this
+ * route with NO total-time bound: an origin dribbling one byte every 25 s resets the idle timer
+ * forever, never reaches the 64 MB counter, and holds a pool slot indefinitely. The resolver
+ * got RESOLVE_DEADLINE_MS in the same change; this is the other half of it.
+ *
+ * Generous on purpose — 64 MB inside five minutes is ~1.8 Mbit/s, well under any real
+ * server-to-origin link — so it bounds abuse without cutting a slow-but-genuine transfer.
+ */
+const MAX_TRANSFER_MS = 5 * 60_000;
+
+/**
+ * Total size of the resource a `Content-Range` describes.
+ *
+ * Returns a number, `'unknown'` when the origin legitimately doesn't say (`bytes 0-N/*`, which
+ * RFC 7233 §4.2 allows), or `'unusable'` for anything we can't make sense of.
+ *
+ * ⚠ Three ways the first version let the cap be walked past, and the shape of two of them is
+ * worth keeping in mind: **the more absurd the claim, the more permissive the answer.**
+ *   - `bytes 0-N/*` matched nothing (the pattern demanded digits), so an origin that declines
+ *     to state a size got waved through.
+ *   - A 400-digit total made `Number()` return `Infinity`, `Number.isFinite` false, and the
+ *     guard conclude "no total, carry on". Now it fails CLOSED.
+ *   - `$`-anchoring read only the last of a duplicated header, which node joins with a comma.
+ */
+function contentRangeTotal(header: string | undefined): number | 'unknown' | 'unusable' {
+  if (!header) return 'unknown';
+  // node joins duplicate headers with ', '. Judge the FIRST — an origin repeating itself gets
+  // read the way a client would read it, not the way an attacker would prefer.
+  const first = header.split(',')[0];
+  const slash = first.lastIndexOf('/');
+  if (slash === -1) return 'unusable';
+  const total = first.slice(slash + 1).trim();
+  if (total === '*') return 'unknown';
+  if (!/^\d+$/.test(total)) return 'unusable';
   const n = Number(total);
-  return Number.isFinite(n) ? n : null;
+  // Past 2^53 the digits are real but the number isn't; a length we can't represent is a
+  // length we refuse rather than one we ignore.
+  return Number.isSafeInteger(n) ? n : 'unusable';
 }
 
 router.post(
@@ -182,18 +225,37 @@ router.get(
     //
     // `close` on a response fires whether it finished or aborted, which makes it the one place
     // that always runs — so it is also where the pool slot goes back.
+    // ⚠⚠ The abort is what makes this work, and its absence is what made the previous version
+    // a comment rather than a teardown: `finish()` latched `done = true` while `upstream` was
+    // still null, so on the abort-during-fetch path — the one this whole block exists for — the
+    // `upstream?.stream.destroy()` it was written to perform could never run, and the later
+    // `finish()` returned at its own guard. The origin socket was left live and unread, outside
+    // a pool that had already counted it as free. Aborting the CONTROLLER covers the window
+    // before there is a stream to destroy; this route was also the one `safeRequest` caller
+    // that never passed a signal, in the same diff that added signals for exactly this reason.
+    const controller = new AbortController();
     let upstream: Awaited<ReturnType<typeof safeRequest>> | null = null;
-    let done = false;
-    const finish = (): void => {
-      if (done) return;
-      done = true;
+    let released = false;
+    const release = (): void => {
+      if (released) return;
+      released = true;
+      clearTimeout(transferDeadline);
+      controller.abort();
       upstream?.stream.destroy();
       mediaPool.release();
     };
-    res.on('close', finish);
+    // Bounds slot occupancy even when nothing else will — see MAX_TRANSFER_MS. Tearing the
+    // response down routes through `release` via `close`, so there is still one release path.
+    const transferDeadline = setTimeout(() => {
+      upstream?.stream.destroy();
+      res.destroy();
+    }, MAX_TRANSFER_MS);
+    transferDeadline.unref();
+
+    res.on('close', release);
     // A response already gone by the time we got a slot never emits `close` again.
     if (res.destroyed) {
-      finish();
+      release();
       return;
     }
 
@@ -207,12 +269,21 @@ router.get(
         // Piped, not buffered: the scrape-tuned deadlines cut a healthy media transfer at 20 s
         // and read a backpressured <video> as a dead origin. See FetchOptions.streaming.
         streaming: true,
+        // So giving up actually ends the fetch. Without it the release above frees a slot while
+        // the request is still dialling — including an uncancellable lookup — which is the
+        // undercount this pool exists to prevent.
+        signal: controller.signal,
       });
       // The client left, or the stream died, while we were awaiting. Without this the response
       // never gets its `end()` — and `Content-Length` may already have gone out — so the
       // browser hangs on a half-open response with no error to show.
-      if (done || res.destroyed || upstream.stream.destroyed) {
-        finish();
+      if (released || res.destroyed || upstream.stream.destroyed) {
+        // ⚠ Destroyed HERE, not delegated to `release()`. If the client left during the fetch,
+        // `release()` has already run and latched — calling it again returns at its own guard
+        // and the stream we have only just been handed stays open, unread, until an idle
+        // timeout the streaming flag has already loosened to 30 s.
+        upstream.stream.destroy();
+        release();
         return;
       }
 
@@ -249,7 +320,9 @@ router.get(
       // slash in Content-Range, and that is what the cap is about.
       const total = contentRangeTotal(upstream.headers['content-range'] as string | undefined);
       const oversize =
-        (Number.isFinite(declared) && declared > cap) || (total !== null && total > cap);
+        (Number.isFinite(declared) && declared > cap) ||
+        total === 'unusable' ||
+        (typeof total === 'number' && total > cap);
       if (oversize) {
         upstream.stream.destroy();
         res.status(413).end();
@@ -274,9 +347,16 @@ router.get(
       // demonstrated it: advertising `Accept-Ranges: bytes` for a source that ignores Range
       // makes a media element seek by requesting a range and then silently receive the whole
       // file from byte zero, which reads as a seek that jumps back to the start.
+      // ⚠ A TOKEN match. node joins a duplicated header, so a range-capable origin that sends
+      // `Accept-Ranges: bytes` twice arrives as `'bytes, bytes'` and an equality test calls it
+      // range-incapable — at which point Safari refuses to play the <video> at all, silently:
+      // the card renders, the video just never starts.
       const upstreamRanges =
         upstream.status === 206 ||
-        String(upstream.headers['accept-ranges'] || '').toLowerCase() === 'bytes';
+        String(upstream.headers['accept-ranges'] || '')
+          .toLowerCase()
+          .split(',')
+          .some((token) => token.trim() === 'bytes');
       if (upstreamRanges) res.setHeader('Accept-Ranges', 'bytes');
       if (upstream.headers['content-range']) {
         res.setHeader('Content-Range', String(upstream.headers['content-range']));
@@ -307,7 +387,7 @@ router.get(
     } catch {
       // Blocked address, timeout, reset — all the same to a caller waiting on an
       // image, and none of them worth distinguishing in a status code.
-      finish();
+      release();
       if (!res.headersSent) res.status(404).end();
     }
   }),

--- a/server/server.ts
+++ b/server/server.ts
@@ -12,6 +12,7 @@ import { getNodeSecret } from './middleware/nodeAuth.js';
 import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
+import { sweepExpiredPreviews } from './db/linkPreviews.js';
 import { listGrandfatheredUsernames } from './db/users.js';
 import { backfillEncryptColumns } from './db/secretBackfill.js';
 import { assertPushCredentials } from './services/push/credentials.js';
@@ -78,6 +79,12 @@ attachWsHub(server, SESSION_SECRET);
 
 purgeExpiredSessions();
 setInterval(purgeExpiredSessions, 60 * 60 * 1000).unref();
+
+// link_previews is a cache with a TTL, so lapsed rows have to actually go — without this it
+// only ever grows. Deliberately NOT gated on previewsEnabled(): an operator who turns the
+// feature off still has whatever it cached while it was on, and that should still expire.
+sweepExpiredPreviews();
+setInterval(sweepExpiredPreviews, 60 * 60 * 1000).unref();
 
 systemLog.log({ scope: 'server', text: `Lurker server starting up (edition: ${EDITION})` });
 

--- a/server/services/dccConfig.ts
+++ b/server/services/dccConfig.ts
@@ -13,15 +13,14 @@
 // unit-tested); the per-user gate reads the DB.
 
 import { CAPABILITY_DCC, userHasCapability } from '../db/userCapabilities.js';
-
-// Conventional truthy env values — trimmed + case-insensitive.
-const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+import { parseTruthyEnv } from '../utils/truthyEnv.js';
 
 /** Parse a raw LURKER_DCC_ENABLED value to a boolean. Pure (no env access) so
  *  the rule is unit-testable. Unset / empty / anything-else is OFF — DCC must be
- *  an explicit opt-in, never accidentally on. */
+ *  an explicit opt-in, never accidentally on. Kept as a named export because it is
+ *  the documented DCC rule; the convention itself is shared (utils/truthyEnv). */
 export function parseDccEnabled(raw: string | undefined): boolean {
-  return TRUTHY.has((raw ?? '').trim().toLowerCase());
+  return parseTruthyEnv(raw);
 }
 
 /** The cell-wide DCC master switch. Read live (not cached) so an operator flip

--- a/server/services/linkFetch.redirects.test.ts
+++ b/server/services/linkFetch.redirects.test.ts
@@ -246,3 +246,51 @@ describe('safeRequest — following redirects', () => {
     expect(finished).toBe(false);
   });
 });
+
+describe('streaming, where the scrape-tuned bounds are wrong', () => {
+  // ⚠ Real time, not fake timers: what's under test is node's own socket timeout and the
+  // request deadline, and swapping the clock out from under them would test the mock. The gap
+  // is sized just past IDLE_TIMEOUT_MS (5 s), which is the cheaper of the two bounds to prove
+  // and the one that fires in ordinary use.
+  const IDLE_GAP_MS = 6500;
+
+  /** Headers, then a deliberate silence, then the rest — a backpressured <video> exactly. */
+  const pauseMidBody: Handler = (_req, res) => {
+    res.writeHead(200, { 'content-type': 'video/mp4' });
+    res.write('start');
+    setTimeout(() => {
+      if (!res.writableEnded) res.end('end');
+    }, IDLE_GAP_MS).unref();
+  };
+
+  it('cuts a paused body without the flag, which is the scrape behaviour', async () => {
+    // The default is right for a 512 KB scrape that arrives in one burst: a gap this long means
+    // the origin is dead. It is wrong for a pipe, and this is the proof that the flag changes
+    // something real rather than reading as though it does.
+    reset(pauseMidBody);
+    const res = await safeRequest(new URL(`${base}/paused`));
+    const outcome = await new Promise<string>((resolve) => {
+      const chunks: Buffer[] = [];
+      res.stream.on('data', (c: Buffer) => chunks.push(c));
+      res.stream.on('error', () => resolve('cut'));
+      res.stream.on('end', () => resolve(Buffer.concat(chunks).toString()));
+    });
+    expect(outcome).toBe('cut');
+  }, 20_000);
+
+  it('lets a streaming consumer wait out the pause', async () => {
+    // ⚠⚠ The claim `MAX_MEDIA_PROXY_BYTES` depends on. A <video> that has filled its buffer and
+    // stopped reading is normal playback, not a stall — but no bytes move, so the socket
+    // timeout fires and the browser sees a network error mid-clip, after `immutable` has
+    // already gone out.
+    reset(pauseMidBody);
+    const res = await safeRequest(new URL(`${base}/paused-streaming`), { streaming: true });
+    const body = await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      res.stream.on('data', (c: Buffer) => chunks.push(c));
+      res.stream.on('error', reject);
+      res.stream.on('end', () => resolve(Buffer.concat(chunks).toString()));
+    });
+    expect(body).toBe('startend');
+  }, 20_000);
+});

--- a/server/services/linkFetch.redirects.test.ts
+++ b/server/services/linkFetch.redirects.test.ts
@@ -294,3 +294,72 @@ describe('streaming, where the scrape-tuned bounds are wrong', () => {
     expect(body).toBe('startend');
   }, 20_000);
 });
+
+describe('abandoning a fetch, where it has to actually end it', () => {
+  it('destroys the connection when the caller aborts mid-body', async () => {
+    // ⚠⚠ Regression guard, and the proof is SERVER-SIDE for the same reason the redirect-body
+    // test's is: "the promise settled" says nothing about whether the socket is still open, and
+    // the socket is the whole point. A caller that gives up releases whatever it was holding —
+    // for the resolver, a slot out of an instance-wide concurrency cap — so a request that
+    // keeps running after being abandoned means the cap silently stops being one.
+    let finished: boolean | null = null;
+    const closed = new Promise<void>((resolve) => {
+      reset((_req, res) => {
+        res.on('error', () => {});
+        res.on('close', () => {
+          finished = res.writableFinished;
+          resolve();
+        });
+        res.writeHead(200, { 'content-type': 'text/html' });
+        res.write('<head><title>PARTIAL');
+        // deliberately never ended: only a teardown from our side can close this.
+      });
+    });
+
+    const controller = new AbortController();
+    const res = await safeRequest(new URL(`${base}/hangs`), { signal: controller.signal });
+    controller.abort();
+
+    await closed;
+    // The origin saw its response torn down without finishing, which is only possible because
+    // the abort reached the socket.
+    expect(finished).toBe(false);
+    expect(res.stream.destroyed).toBe(true);
+  });
+
+  it('refuses to dial at all for a signal that has already fired', async () => {
+    reset((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<head><title>SHOULD NOT BE FETCHED</title></head>');
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      safeRequest(new URL(`${base}/never`), { signal: controller.signal }),
+    ).rejects.toThrow(/abandoned/);
+    // Not "the fetch failed" — no request reached the origin at all.
+    expect(hits).toEqual([]);
+  });
+
+  it('stops a redirect walk it is part-way through', async () => {
+    // A walk is up to four requests. Aborting during hop 1 must not have hops 2 and 3 dialled
+    // on the caller's behalf — the per-hop check, not just the per-request one.
+    const controller = new AbortController();
+    reset((req, res) => {
+      if (req.url === '/hop1') {
+        controller.abort();
+        res.writeHead(302, { location: '/hop2' });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end('<head><title>ARRIVED ANYWAY</title></head>');
+    });
+
+    await expect(
+      safeRequest(new URL(`${base}/hop1`), { signal: controller.signal }),
+    ).rejects.toThrow(/abandoned/);
+    expect(hits).toEqual(['/hop1']);
+  });
+});

--- a/server/services/linkFetch.redirects.test.ts
+++ b/server/services/linkFetch.redirects.test.ts
@@ -20,7 +20,7 @@
 // asks for `{all: true}` by default, `callback(null, safe)` is the branch every real fetch in
 // production takes. Break it and every preview fails against a fully green suite.
 
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 
@@ -254,13 +254,23 @@ describe('streaming, where the scrape-tuned bounds are wrong', () => {
   // and the one that fires in ordinary use.
   const IDLE_GAP_MS = 6500;
 
+  // ⚠ Tracked and cleared. Left dangling, this timer outlives its own test and fires `end()` on
+  // a destroyed ServerResponse part-way through the NEXT one — harmless today only because
+  // node's `write_()` short-circuits on `msg.destroyed`, which is a private implementation
+  // detail and not a thing to rely on. A test that reaches into a later test is a flake waiting
+  // for a scheduling change.
+  let pending: ReturnType<typeof setTimeout> | undefined;
+  afterEach(() => clearTimeout(pending));
+
   /** Headers, then a deliberate silence, then the rest — a backpressured <video> exactly. */
   const pauseMidBody: Handler = (_req, res) => {
+    res.on('error', () => {});
     res.writeHead(200, { 'content-type': 'video/mp4' });
     res.write('start');
-    setTimeout(() => {
-      if (!res.writableEnded) res.end('end');
-    }, IDLE_GAP_MS).unref();
+    pending = setTimeout(() => {
+      if (!res.writableEnded && !res.destroyed) res.end('end');
+    }, IDLE_GAP_MS);
+    pending.unref();
   };
 
   it('cuts a paused body without the flag, which is the scrape behaviour', async () => {
@@ -342,13 +352,18 @@ describe('abandoning a fetch, where it has to actually end it', () => {
     expect(hits).toEqual([]);
   });
 
-  it('stops a redirect walk it is part-way through', async () => {
-    // A walk is up to four requests. Aborting during hop 1 must not have hops 2 and 3 dialled
-    // on the caller's behalf — the per-hop check, not just the per-request one.
+  it('stops a redirect walk BETWEEN hops', async () => {
+    // ⚠ The per-hop check specifically, and getting a test to reach it takes care: aborting
+    // while hop 1's request is still open is caught by `requestOnce`'s own listener, which
+    // rejects with the same message — so the obvious version of this test passes with
+    // safeRequest's loop guard deleted. It has to fire once hop 1 has fully completed and the
+    // loop is about to dial hop 2.
     const controller = new AbortController();
     reset((req, res) => {
       if (req.url === '/hop1') {
-        controller.abort();
+        // `finish` fires when this response is fully flushed, so the abort lands after
+        // requestOnce has resolved and its own abort listener has been removed on `close`.
+        res.on('finish', () => controller.abort());
         res.writeHead(302, { location: '/hop2' });
         res.end();
         return;
@@ -360,6 +375,7 @@ describe('abandoning a fetch, where it has to actually end it', () => {
     await expect(
       safeRequest(new URL(`${base}/hop1`), { signal: controller.signal }),
     ).rejects.toThrow(/abandoned/);
+    // Hop 2 was never dialled.
     expect(hits).toEqual(['/hop1']);
   });
 });

--- a/server/services/linkFetch.ts
+++ b/server/services/linkFetch.ts
@@ -44,6 +44,26 @@ const IDLE_TIMEOUT_MS = 5000;
  * arrived returned and flagged `truncated`.
  */
 const HOP_DEADLINE_MS = 20_000;
+
+/**
+ * Idle allowance once a STREAMING consumer has its headers — see `FetchOptions.streaming`.
+ *
+ * ⚠ Both of the bounds above are wrong for a body that is piped rather than buffered, and the
+ * combination made `MAX_MEDIA_PROXY_BYTES` unreachable. `HOP_DEADLINE_MS` is cleared on the
+ * request's `close`, which does not fire during a body transfer, so any response still
+ * streaming at 20 s was cut — 64 MB inside 20 s needs ~26 Mbit/s sustained, so ordinary inline
+ * video died mid-playback. And `IDLE_TIMEOUT_MS` fires on a backpressured pipe: a <video> that
+ * has filled its buffer and stopped reading is normal playback, not a stall, but no bytes move
+ * and the socket times out.
+ *
+ * So a streaming caller keeps the deadline for connect-and-headers — the part that can hang
+ * with nothing to show for it — and then trades it for this, which bounds a genuinely dead
+ * origin while tolerating a reader that has paused. A stream cut here is recoverable rather
+ * than fatal: the proxy forwards `Accept-Ranges`, so a media element re-requests the range it
+ * still wants.
+ */
+const STREAM_IDLE_TIMEOUT_MS = 30_000;
+
 /** Redirects followed before giving up. Each hop is re-validated. */
 const MAX_REDIRECTS = 3;
 
@@ -204,6 +224,16 @@ export interface FetchOptions {
   /** A `Range` header to forward, so the byte proxy can serve partial content. Media elements
    *  require it: Safari won't play a <video> from a source that ignores ranges. */
   range?: string;
+  /**
+   * This caller will PIPE the body rather than buffer it.
+   *
+   * Swaps the hop deadline for `STREAM_IDLE_TIMEOUT_MS` once the response headers arrive. The
+   * defaults are tuned for a 512 KB scrape that completes in one burst, and applied to a media
+   * stream they cut a healthy transfer at 20 s and treat a paused reader as a dead origin.
+   * Connect and headers stay bounded by the deadline either way — that is the phase where a
+   * hostile host can hang us with nothing to show for it.
+   */
+  streaming?: boolean;
   // ⚠ No byte ceiling here. It reads like it belongs — but nothing on this path consumes a
   // body, so nothing could enforce it, and an option that documents a guarantee it doesn't
   // provide is worse than no option. The cap lives in `BufferOptions`, where the read is.
@@ -255,6 +285,8 @@ function parseContentType(raw: string): ContentType {
  */
 function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
+    /** Whether the response headers have arrived, which is what the timeouts above pivot on. */
+    let headersSeen = false;
     if (opts.range !== undefined && !RANGE_RE.test(opts.range)) {
       return reject(new UnsafeUrlError(`refusing to forward a malformed Range: ${opts.range}`));
     }
@@ -289,6 +321,14 @@ function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
           res.destroy();
           return reject(new UnsafeUrlError(`unexpected content-encoding: ${encoding}`));
         }
+        headersSeen = true;
+        if (opts.streaming) {
+          // The deadline has done its job — it bounded connect and headers. Holding it through
+          // the body cuts every transfer that takes longer than 20 s, which for a media proxy
+          // is most of them.
+          clearTimeout(deadline);
+          req.setTimeout(STREAM_IDLE_TIMEOUT_MS);
+        }
         resolve({
           status: res.statusCode || 0,
           headers: res.headers,
@@ -309,7 +349,9 @@ function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
     // resolved, so the reject is a no-op and the destroy surfaces to whoever holds the stream —
     // as an ordinary stream error, indistinguishable from a peer reset. `bufferStream` treats
     // both the same way: what arrived is a prefix, and it says so.
-    req.on('timeout', () => req.destroy(new UnsafeUrlError('timed out with no data')));
+    req.on('timeout', () =>
+      req.destroy(new UnsafeUrlError(headersSeen ? 'stalled mid-body' : 'timed out with no data')),
+    );
     req.on('error', reject);
     req.end();
   });

--- a/server/services/linkFetch.ts
+++ b/server/services/linkFetch.ts
@@ -234,6 +234,21 @@ export interface FetchOptions {
    * hostile host can hang us with nothing to show for it.
    */
   streaming?: boolean;
+  /**
+   * Tears the request down when it fires.
+   *
+   * ⚠ Without this, a caller that gives up on a fetch does not stop the fetch. That matters
+   * wherever giving up also releases a resource: the resolver bounds one URL's whole resolution
+   * and then frees its pool slot, so an abandoned-but-still-running request meant the pool
+   * undercounted its own work and more than MAX_CONCURRENT fetches could be live at once —
+   * under a run of slow origins, without bound. Abandoning work is not the same as ending it,
+   * and only the second one makes a concurrency cap mean anything.
+   *
+   * What it does NOT cancel is a pending `getaddrinfo`: node offers no way to, so a lookup
+   * keeps its libuv slot until the OS gives up. That gap is documented where it bites, on the
+   * resolver's pool.
+   */
+  signal?: AbortSignal;
   // ⚠ No byte ceiling here. It reads like it belongs — but nothing on this path consumes a
   // body, so nothing could enforce it, and an option that documents a guarantee it doesn't
   // provide is worse than no option. The cap lives in `BufferOptions`, where the read is.
@@ -287,6 +302,10 @@ function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
   return new Promise((resolve, reject) => {
     /** Whether the response headers have arrived, which is what the timeouts above pivot on. */
     let headersSeen = false;
+    // Already given up before we dialled — don't open a socket to close it a tick later.
+    if (opts.signal?.aborted) {
+      return reject(new UnsafeUrlError('caller abandoned the request'));
+    }
     if (opts.range !== undefined && !RANGE_RE.test(opts.range)) {
       return reject(new UnsafeUrlError(`refusing to forward a malformed Range: ${opts.range}`));
     }
@@ -344,7 +363,18 @@ function requestOnce(url: URL, opts: FetchOptions): Promise<RawResponse> {
       req.destroy(new UnsafeUrlError(`hop took longer than ${HOP_DEADLINE_MS}ms`));
     }, HOP_DEADLINE_MS);
     deadline.unref();
-    req.on('close', () => clearTimeout(deadline));
+
+    // The caller gave up: end the request rather than leaving it running for whatever bound it
+    // would have hit on its own. Removed on `close` so a long-lived signal — one caller's
+    // controller outliving one hop of a redirect walk — doesn't accumulate listeners.
+    const onAbort = (): void => {
+      req.destroy(new UnsafeUrlError('caller abandoned the request'));
+    };
+    opts.signal?.addEventListener('abort', onAbort, { once: true });
+    req.on('close', () => {
+      clearTimeout(deadline);
+      opts.signal?.removeEventListener('abort', onAbort);
+    });
     // ⚠ Only observable BEFORE the response headers arrive. After that this promise has already
     // resolved, so the reject is a no-op and the destroy surfaces to whoever holds the stream —
     // as an ordinary stream error, indistinguishable from a peer reset. `bufferStream` treats
@@ -375,6 +405,9 @@ export async function safeRequest(start: URL, opts: FetchOptions = {}): Promise<
   if (!entry) throw new UnsafeUrlError('refusing to fetch a disallowed URL');
   let url = entry;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    // Checked per hop, not just once: a redirect walk is up to four requests, and a caller that
+    // gave up during hop 1 must not have hops 2 and 3 dialled on its behalf.
+    if (opts.signal?.aborted) throw new UnsafeUrlError('caller abandoned the request');
     const res = await requestOnce(url, opts);
     const isRedirect = res.status >= 300 && res.status < 400 && res.headers.location;
     if (!isRedirect) return res;

--- a/server/services/linkFetch.ts
+++ b/server/services/linkFetch.ts
@@ -58,9 +58,16 @@ const HOP_DEADLINE_MS = 20_000;
  *
  * So a streaming caller keeps the deadline for connect-and-headers — the part that can hang
  * with nothing to show for it — and then trades it for this, which bounds a genuinely dead
- * origin while tolerating a reader that has paused. A stream cut here is recoverable rather
- * than fatal: the proxy forwards `Accept-Ranges`, so a media element re-requests the range it
- * still wants.
+ * origin while tolerating a reader that has paused.
+ *
+ * ⚠ A cut here is recoverable only where the ORIGIN supports ranges, and this comment used to
+ * claim it always was — "the proxy forwards Accept-Ranges, so a media element re-requests the
+ * range it still wants" — which the sibling change in the same commit falsified by making that
+ * header conditional on the origin having demonstrated range support. For a dumb, slow origin
+ * that advertises nothing, which is exactly the profile most likely to idle out here, the
+ * client is told ranges are unavailable and cannot resume. That is the honest position: this
+ * bound trades a stalled socket for a broken transfer, and the trade is only clearly right
+ * because the alternative is holding a pool slot forever.
  */
 const STREAM_IDLE_TIMEOUT_MS = 30_000;
 

--- a/server/services/linkMeta.test.ts
+++ b/server/services/linkMeta.test.ts
@@ -108,6 +108,19 @@ describe('scrapeMeta', () => {
     expect(meta.siteName).toBe('Unquoted');
   });
 
+  it('does not take a twitter:site handle as a site name', () => {
+    // ⚠ `twitter:site` is an @handle naming the ACCOUNT that owns the card, not the site. As a
+    // fallback it put `@nytimes` in the card's site slot for every page with a Twitter card and
+    // no og:site_name. Absent is the right answer: the caller falls back to the hostname, which
+    // is always accurate and is never somebody's username.
+    const meta = scrapeMeta(`<head>
+      <meta name="twitter:site" content="@nytimes">
+      <meta name="twitter:title" content="An Article">
+    </head>`);
+    expect(meta.siteName).toBeUndefined();
+    expect(meta.title).toBe('An Article');
+  });
+
   it('takes the first og:image when a page lists several', () => {
     const meta = scrapeMeta(`<head>
       <meta property="og:image" content="https://e.test/first.png">

--- a/server/services/linkMeta.test.ts
+++ b/server/services/linkMeta.test.ts
@@ -553,6 +553,21 @@ describe('readOEmbed', () => {
     });
   });
 
+  it('replaces a lone surrogate rather than passing it on', () => {
+    // ⚠⚠ Regression guard. `decodeEntities` refuses surrogate ESCAPES, so the HTML path is
+    // covered — but oEmbed arrives via `JSON.parse`, and `JSON.parse('"\\ud83d"')` yields a lone
+    // U+D83D with no entity anywhere in it. That does not survive the SQLite round trip: it
+    // comes back U+FFFD, so the requester who resolved a title and everyone served it from the
+    // cache afterwards get different strings for one page — the exact divergence the clamp fix
+    // is named for, reached through a door clamping cannot see. YouTube and Vimeo titles are
+    // the ones that come through here.
+    const meta = readOEmbed(JSON.parse('{"title":"ok\\ud83d","author_name":"\\udc4dsomebody"}'));
+    const lonely = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    expect(lonely.test(meta?.title ?? '')).toBe(false);
+    expect(lonely.test(meta?.authorName ?? '')).toBe(false);
+    expect(meta?.title).toBe('ok\uFFFD');
+  });
+
   it('never surfaces the provider html field', () => {
     // The whole point: oEmbed hands back a ready-made iframe and we refuse it.
     const meta = readOEmbed({ type: 'video', html: '<iframe src="https://evil.test"></iframe>' });

--- a/server/services/linkMeta.ts
+++ b/server/services/linkMeta.ts
@@ -29,8 +29,10 @@ export interface ScrapedMeta {
   description?: string;
   siteName?: string;
   imageUrl?: string;
-  /** og:type — `video.*` and `music.*` are the ones that change our rendering. */
-  ogType?: string;
+  // ⚠ No `ogType`. It was scraped, and documented as driving rendering, and read by nobody on
+  // any branch — what actually decides a video card is the provider table in linkEmbed.ts,
+  // because `og:type: video.other` on a site we have no embed URL for still renders as a page.
+  // A field carried through three PRs on the strength of its own comment is worse than absent.
   /** Discovered `<link rel=alternate type=application/json+oembed>` endpoint. */
   oembedUrl?: string;
 }
@@ -650,7 +652,12 @@ export function scrapeMeta(html: string): ScrapedMeta {
     'description',
     og.get('og:description') || twitter.get('twitter:description') || twitter.get('description'),
   );
-  assign('siteName', og.get('og:site_name') || twitter.get('twitter:site'));
+  // ⚠ `og:site_name` only. `twitter:site` is a HANDLE (`@nytimes`), not a site name — it names
+  // the account that owns the card, which is a different field wearing a similar key. Falling
+  // back to it put an @-handle in the card's site slot on every page that sets one and no
+  // `og:site_name`, which is a lot of them. With no site name the caller uses the hostname,
+  // which is always accurate and never someone's username.
+  assign('siteName', og.get('og:site_name'));
   assign(
     'imageUrl',
     primaryImage?.secureUrl ||
@@ -659,7 +666,6 @@ export function scrapeMeta(html: string): ScrapedMeta {
       twitter.get('twitter:image:src') ||
       imageSrc,
   );
-  assign('ogType', og.get('og:type'));
 
   // Decode and tidy at the boundary, so callers never handle a raw entity. An empty result is
   // an ABSENT field, not a present empty string: `content="   "` used to survive as `''`, and

--- a/server/services/linkMeta.ts
+++ b/server/services/linkMeta.ts
@@ -697,6 +697,26 @@ export function scrapeMeta(html: string): ScrapedMeta {
  * structured fields and build any embed ourselves from a provider table we
  * control (see linkEmbed.ts).
  */
+/**
+ * Replace unpaired surrogates with U+FFFD.
+ *
+ * ⚠ This is the JSON path's equivalent of the guard `decodeEntities` already applies to numeric
+ * character references, and it is needed for the same reason at a different door:
+ * `JSON.parse('"\\ud83d"')` yields a lone U+D83D directly, no entity involved. A lone surrogate
+ * does not survive the SQLite round trip — it comes back as U+FFFD — so the requester who
+ * resolved a title and everyone served it from the cache afterwards get measurably different
+ * strings for one page, which is the divergence the clamp fix was named for, reached from an
+ * input clamping cannot see. Doing it here means a caller never handles one, whichever producer
+ * it came from.
+ */
+function stripLoneSurrogates(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(
+    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
+    '\uFFFD',
+  );
+}
+
 export function readOEmbed(json: unknown): OEmbedMeta | null {
   if (typeof json !== 'object' || json === null || Array.isArray(json)) return null;
   const o = json as Record<string, unknown>;
@@ -709,7 +729,7 @@ export function readOEmbed(json: unknown): OEmbedMeta | null {
   // raw entity, whichever path produced the value.
   const str = (v: unknown): string | undefined => {
     if (typeof v !== 'string') return undefined;
-    const clean = detach(decodeEntities(v).replace(/\s+/g, ' ').trim());
+    const clean = detach(stripLoneSurrogates(decodeEntities(v)).replace(/\s+/g, ' ').trim());
     return clean || undefined;
   };
   const num = (v: unknown): number | undefined =>

--- a/server/services/linkPreview.origin.test.ts
+++ b/server/services/linkPreview.origin.test.ts
@@ -198,6 +198,28 @@ describe('resolving a page at a live origin', () => {
     expect(record.title).toBe('Survived');
   });
 
+  it('clamps a long title without splitting a character', async () => {
+    // ⚠ Regression guard. The clamp used `slice`, which counts UTF-16 code units, so a title
+    // of emoji cut at 140 ended in a lone high surrogate. That does not survive the SQLite
+    // round trip — so the requester who resolved the URL and everyone served from the cache
+    // afterwards got measurably DIFFERENT strings for the same page, and a strict decoder
+    // (Swift's JSONDecoder, on the iOS client) turns the escape into U+FFFD.
+    reset(
+      serveHtml(
+        `<html><head><meta property="og:title" content="${'👍'.repeat(200)}"></head></html>`,
+      ),
+    );
+
+    const fresh = await resolvePreview(`${base}/emoji`);
+    const title = fresh.title as string;
+    expect(title.length).toBeLessThan(400);
+    const lonely = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    expect(lonely.test(title)).toBe(false);
+    // The read-back is what the second and every later viewer is served.
+    const cached = await resolvePreview(`${base}/emoji`);
+    expect(cached.title).toBe(title);
+  });
+
   it('refuses a content type it has no rendering for', async () => {
     reset((_req, res) => {
       res.writeHead(200, { 'content-type': 'application/pdf' });
@@ -232,6 +254,61 @@ describe('one fetch per document', () => {
     // ...and each caller is answered with the exact string it sent, because that is what it
     // looks the preview up by.
     expect(records.map((r) => r.url)).toEqual(asked);
+  });
+
+  it('treats host case and a default port as the same document', async () => {
+    // ⚠ Regression guard. The key was the raw request string with a regex fragment strip, so
+    // `//LOCALHOST/x` and `//localhost/x` — and `//h:80/x` and `//h/x`, and a trailing slash —
+    // were four cache entries for one page. normalizeUrl already collapses all of them, and it
+    // is the function the fetcher uses, so keying on anything else was two identities for one
+    // thing. It is also a one-character cache bypass: vary the case and every ask refetches.
+    reset(serveHtml('<html><head><meta property="og:title" content="Canonical"></head></html>'));
+    const port = (server.address() as AddressInfo).port;
+
+    await resolvePreview(`http://localhost:${port}/canon`);
+    expect(hits).toEqual(['/canon']);
+
+    const variant = await resolvePreview(`http://LOCALHOST:${port}/canon`);
+    expect(variant.title).toBe('Canonical');
+    expect(variant.url).toBe(`http://LOCALHOST:${port}/canon`);
+    // Still one: the case variant read the row the first ask wrote.
+    expect(hits).toEqual(['/canon']);
+  });
+
+  it('keeps the scraped image when an oEmbed thumbnail is unusable', async () => {
+    // ⚠ Regression guard. `oembed?.thumbnailUrl || meta.imageUrl` picked first and vetted
+    // second, so a thumbnail_url we refuse — here a private address the SSRF guard blocks —
+    // took the slot and then evaporated, discarding a perfectly good og:image with it. On a
+    // page with no title that became a cached `unavailable`: no card for an hour because the
+    // OPTIONAL source was bad.
+    reset((req, res) => {
+      if (req.url === '/oembed.json') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            version: '1.0',
+            type: 'rich',
+            thumbnail_url: 'http://10.0.0.9/private.png',
+            thumbnail_width: 480,
+            thumbnail_height: 360,
+          }),
+        );
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/html' });
+      res.end(`<html><head>
+        <meta property="og:title" content="Fallback Kept">
+        <meta property="og:image" content="/real.png">
+        <link rel="alternate" type="application/json+oembed" href="/oembed.json">
+      </head></html>`);
+    });
+
+    const record = await resolvePreview(`${base}/oembed-bad-thumb`);
+    expect(record.imageUrl).toBe(`${base}/real.png`);
+    // ...and the oEmbed dimensions do NOT come along: they describe the thumbnail that lost,
+    // so pairing them with this image reserves a 4:3 box for a picture of another shape.
+    expect(record.imageWidth).toBeNull();
+    expect(record.imageHeight).toBeNull();
   });
 
   it('serves a later anchor from the cache, echoing the URL as asked', async () => {

--- a/server/services/linkPreview.origin.test.ts
+++ b/server/services/linkPreview.origin.test.ts
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The resolver against a real origin, over real sockets.
+//
+// Its own file for the same reason `linkFetch.redirects.test.ts` is: the real address policy
+// blocks loopback, correctly, so no test can watch a resolve COMPLETE against a server it just
+// started. The policy is swapped for a test one — allow 127.0.0.1, refuse everything else — and
+// everything else runs for real.
+//
+// ⚠ What's mocked is the POLICY, never the mechanism. The fetch, the redirect loop, the pinned
+// lookup, the head scan, the charset decode, the scrape and the cache are all shipping code. The
+// policy itself is tested against the real implementation in ../utils/ipGuard.test.ts.
+//
+// This is the only place several claims are provable at all, because each needs a REQUEST COUNT
+// at a live origin rather than an error: that a batch of anchors costs one fetch, that a cache
+// hit costs none, and that a declared charset is honoured.
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import sharp from 'sharp';
+import type { AddressInfo } from 'node:net';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+vi.mock('../utils/ipGuard.js', () => ({
+  isBlockedIpLiteral: (host: string) => host.replace(/^\[|\]$/g, '') !== '127.0.0.1',
+  isBlockedIpv4: (ip: string) => ip !== '127.0.0.1',
+}));
+
+const ctx = setupTestDb('link-preview-origin');
+process.env.LURKER_LINK_PREVIEWS = 'on';
+
+const { resolvePreview, toDescriptor } = await import('./linkPreview.js');
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+let handler: Handler;
+let hits: string[] = [];
+let server: http.Server;
+/** Reached through `localhost`, so the pinned lookup's success path is the one under test. */
+let base: string;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    hits.push(req.url || '');
+    handler(req, res);
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  base = `http://localhost:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  ctx.cleanup();
+});
+
+function reset(h: Handler) {
+  hits = [];
+  handler = h;
+}
+
+/** Serve one HTML document, whatever is asked for. */
+function serveHtml(html: string, contentType = 'text/html; charset=utf-8'): Handler {
+  return (_req, res) => {
+    res.writeHead(200, { 'content-type': contentType });
+    res.end(html);
+  };
+}
+
+describe('resolving a page at a live origin', () => {
+  it('scrapes a card and proxies the image, in one request', async () => {
+    reset(
+      serveHtml(`<html><head>
+        <meta property="og:title" content="Tom &amp; Jerry">
+        <meta property="og:description" content="A cat and a mouse.">
+        <meta property="og:site_name" content="Example Cartoons">
+        <meta property="og:image" content="/art/still.png">
+      </head><body><p>ignored</p></body></html>`),
+    );
+
+    const record = await resolvePreview(`${base}/article`);
+    expect(record.status).toBe('ok');
+    expect(record.kind).toBe('page');
+    // Decoded exactly once. A second pass is what turns `&amp;amp;` into `&`, and both
+    // producers decode at their own boundary now.
+    expect(record.title).toBe('Tom & Jerry');
+    expect(record.description).toBe('A cat and a mouse.');
+    expect(record.siteName).toBe('Example Cartoons');
+    // Relative og:image resolved against the page we landed on.
+    expect(record.imageUrl).toBe(`${base}/art/still.png`);
+    // The head is all we pay for: no second GET for the body, and the image is NOT fetched
+    // during resolve — the client asks the proxy for it, and only if it renders the card.
+    expect(hits).toEqual(['/article']);
+
+    const d = toDescriptor(record);
+    // The client is handed a path under OUR origin. (`url` still echoes what was asked for —
+    // that's the lookup key, not a fetch target — and the token's payload is base64 of the
+    // image URL by construction. The property is that no client dials the origin, not that the
+    // address is a secret.)
+    expect(d.thumb).toMatch(/^\/api\/link-preview\/media\//);
+    expect(d.thumb).not.toContain('localhost');
+  });
+
+  it('decodes an image URL exactly once', async () => {
+    // ⚠ Regression guard. `scrapeMeta` and `readOEmbed` each decode entities at their own
+    // boundary now, so the resolver decoding `imageUrl` again is one pass too many — and a
+    // second pass is invisible until a document contains a LITERAL entity: `&amp;amp;` is the
+    // correct markup for the text `&amp;`, and decoding twice turns it into `&`, which is a
+    // different URL and a 404 where a thumbnail should be.
+    reset(
+      serveHtml(`<html><head>
+        <meta property="og:title" content="Twice">
+        <meta property="og:image" content="/art.png?tag=a&amp;amp;b&amp;v=1">
+      </head></html>`),
+    );
+
+    const record = await resolvePreview(`${base}/entities`);
+    expect(record.imageUrl).toBe(`${base}/art.png?tag=a&amp;b&v=1`);
+  });
+
+  it('honours a charset the origin declared and the document does not', async () => {
+    // ⚠ Regression guard for the `decodeBody` handoff. The old call passed the Content-Type
+    // header, but what reached it was already stripped to a bare `text/html` — so the charset
+    // branch could never match and a windows-1251 page with no in-document `<meta charset>`
+    // rendered as replacement characters. Only a live origin can prove this: it needs the
+    // header and the body to disagree with UTF-8 together.
+    const cyrillic = Buffer.from([0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2]); // "Привет" in cp1251
+    reset((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/HTML; charset="Windows-1251"' });
+      res.end(
+        Buffer.concat([
+          Buffer.from('<html><head><meta property="og:title" content="'),
+          cyrillic,
+          Buffer.from('"></head><body><p>x</p></body></html>'),
+        ]),
+      );
+    });
+
+    const record = await resolvePreview(`${base}/cyrillic`);
+    expect(record.title).toBe('Привет');
+    expect(record.title).not.toContain('�');
+  });
+
+  it('uses the hostname when a page offers only a twitter handle', async () => {
+    // `twitter:site` is an @handle naming an account, not a site. Absent beats wrong: the card
+    // gets the hostname, which is always accurate.
+    reset(
+      serveHtml(`<html><head>
+        <meta name="twitter:site" content="@examplenews">
+        <meta property="og:title" content="Headline">
+      </head><body><p>x</p></body></html>`),
+    );
+
+    const record = await resolvePreview(`${base}/handle-only`);
+    expect(record.title).toBe('Headline');
+    expect(record.siteName).toBe('localhost');
+  });
+
+  it('reads an image’s dimensions without pulling the whole file', async () => {
+    const png = await sharp({
+      create: { width: 240, height: 100, channels: 3, background: '#336699' },
+    })
+      .png()
+      .toBuffer();
+    reset((_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png' });
+      res.end(png);
+    });
+
+    const record = await resolvePreview(`${base}/photo.png`);
+    expect(record.kind).toBe('image');
+    expect(record.mime).toBe('image/png');
+    // The point of reading these at all: the client reserves the box before the bytes arrive,
+    // so a bottom-anchored message list doesn't grow a second time when the image decodes.
+    expect(record.imageWidth).toBe(240);
+    expect(record.imageHeight).toBe(100);
+    // Direct media puts the bytes in `src`, not in a card's `thumb`.
+    const d = toDescriptor(record);
+    expect(d.src).toMatch(/^\/api\/link-preview\/media\//);
+    expect(d.thumb).toBeUndefined();
+  });
+
+  it('still builds a card when the page advertises a broken oEmbed endpoint', async () => {
+    // ⚠ Regression guard. The oEmbed href comes out of a stranger's markup, and `new URL('http://[')`
+    // throws while BUILDING the argument to the guard that was supposed to judge it — so with
+    // the resolve outside the try, a malformed href abandoned the whole resolution and the page
+    // got no preview at all. oEmbed is the OPTIONAL path: failing it must fall back to the Open
+    // Graph tags already in hand, not discard them.
+    reset(
+      serveHtml(`<html><head>
+        <meta property="og:title" content="Survived">
+        <link rel="alternate" type="application/json+oembed" href="http://[">
+      </head></html>`),
+    );
+
+    const record = await resolvePreview(`${base}/broken-oembed`);
+    expect(record.status).toBe('ok');
+    expect(record.title).toBe('Survived');
+  });
+
+  it('refuses a content type it has no rendering for', async () => {
+    reset((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/pdf' });
+      res.end('%PDF-1.4');
+    });
+    expect((await resolvePreview(`${base}/paper.pdf`)).status).toBe('unavailable');
+  });
+
+  it('refuses SVG, which is a script host wearing a picture’s clothes', async () => {
+    reset((_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/svg+xml' });
+      res.end('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+    });
+    expect((await resolvePreview(`${base}/logo.svg`)).status).toBe('unavailable');
+  });
+});
+
+describe('one fetch per document', () => {
+  it('coalesces concurrent anchors of one page into a single request', async () => {
+    // ⚠⚠ Regression guard, and the reason this file exists. In-flight dedupe was keyed on the
+    // REQUEST STRING while the cache is keyed on the URL with its fragment stripped — so three
+    // anchors of one document, which is exactly how anchors arrive (one message, one batch),
+    // coalesced with nothing and cost three fetches of the same page. Only a request count at a
+    // live origin can see that; every caller gets a correct-looking record either way.
+    reset(serveHtml('<html><head><meta property="og:title" content="Anchored"></head></html>'));
+
+    const asked = [`${base}/doc`, `${base}/doc#a`, `${base}/doc#b`, `${base}/doc#c`];
+    const records = await Promise.all(asked.map((u) => resolvePreview(u)));
+
+    expect(hits).toEqual(['/doc']);
+    for (const r of records) expect(r.title).toBe('Anchored');
+    // ...and each caller is answered with the exact string it sent, because that is what it
+    // looks the preview up by.
+    expect(records.map((r) => r.url)).toEqual(asked);
+  });
+
+  it('serves a later anchor from the cache, echoing the URL as asked', async () => {
+    // Sequential, so the cache read is what answers rather than the in-flight map. The row's
+    // own `url` column holds whichever anchor resolved first — handing that back verbatim is
+    // the same client-side miss, reached through the cache instead of through a redirect.
+    reset(serveHtml('<html><head><meta property="og:title" content="Cached"></head></html>'));
+
+    const first = await resolvePreview(`${base}/cached-doc#one`);
+    expect(hits).toEqual(['/cached-doc']);
+
+    const second = await resolvePreview(`${base}/cached-doc#two`);
+    expect(second.title).toBe('Cached');
+    expect(second.url).toBe(`${base}/cached-doc#two`);
+    expect(first.url).toBe(`${base}/cached-doc#one`);
+    // Still one: the second ask never reached the origin.
+    expect(hits).toEqual(['/cached-doc']);
+  });
+});

--- a/server/services/linkPreview.test.ts
+++ b/server/services/linkPreview.test.ts
@@ -47,18 +47,6 @@ function record(over: Partial<PreviewRecord> = {}): PreviewRecord {
   };
 }
 
-describe('the concurrency cap', () => {
-  it('is at least as large as one request may ask for', async () => {
-    // ⚠⚠ The relationship, asserted directly, because the behavioural test that was supposed to
-    // guard it does not: the 20 URLs it fans out are blocked addresses that `normalizeUrl`
-    // refuses before any socket opens, so every queued waiter is handed a slot in microseconds
-    // and the suite stays green with the cap set to 6 — the exact value its own comment names
-    // as the bug. A test that passes with the defect present is a comment, not a guard.
-    const { MAX_CONCURRENT, MAX_URLS_PER_REQUEST } = await import('./linkPreview.js');
-    expect(MAX_CONCURRENT).toBeGreaterThanOrEqual(MAX_URLS_PER_REQUEST);
-  });
-});
-
 describe('pageRecord: what is enough to be worth a card', () => {
   it('keeps a video embed that has neither a title nor an image', async () => {
     // ⚠⚠ Regression guard. `!title && !imageUrl` are PAGE concepts, and the give-up rule
@@ -77,6 +65,28 @@ describe('pageRecord: what is enough to be worth a card', () => {
     expect(out.kind).toBe('video-embed');
     expect(out.embedUrl).toContain('youtube-nocookie.com');
     expect(out.title).toBeNull();
+  });
+
+  it('gives a contentless embed the FAILURE ttl, not the seven-day one', async () => {
+    // ⚠ Regression guard. Keeping the embed is right — the play affordance is real content —
+    // but a record kept only by that clause has no title, no description and no thumbnail: its
+    // whole visible substance is the hostname. It is a DEGRADED answer, produced because the
+    // provider call that would have filled it in just failed, so caching it for seven days
+    // banks one rate-limited minute for a week. An hour is what the situation calls for.
+    const { pageRecord } = await import('./linkPreview.js');
+    const { OK_TTL_MS, FAIL_TTL_MS } = await import('../db/linkPreviews.js');
+
+    const thin = pageRecord(new URL('https://www.youtube.com/watch?v=abc123'), null, {});
+    const thinTtl = new Date(thin.expiresAt).getTime() - Date.now();
+    expect(thinTtl).toBeLessThanOrEqual(FAIL_TTL_MS);
+
+    // ...while an embed that DID get its metadata keeps the success TTL.
+    const full = pageRecord(new URL('https://www.youtube.com/watch?v=abc123'), null, {
+      title: 'A Real Video',
+    });
+    const fullTtl = new Date(full.expiresAt).getTime() - Date.now();
+    expect(fullTtl).toBeGreaterThan(FAIL_TTL_MS);
+    expect(fullTtl).toBeLessThanOrEqual(OK_TTL_MS);
   });
 
   it('still gives up on an ordinary page with nothing to show', async () => {

--- a/server/services/linkPreview.test.ts
+++ b/server/services/linkPreview.test.ts
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+import type { PreviewRecord } from '../db/linkPreviews.js';
+
+const ctx = setupTestDb('link-preview-service');
+
+let resolvePreview: typeof import('./linkPreview.js').resolvePreview;
+let toDescriptor: typeof import('./linkPreview.js').toDescriptor;
+let getCachedPreview: typeof import('../db/linkPreviews.js').getCachedPreview;
+let putPreview: typeof import('../db/linkPreviews.js').putPreview;
+let OK_TTL_MS: number;
+
+const SAVED_FLAG = process.env.LURKER_LINK_PREVIEWS;
+
+beforeAll(async () => {
+  process.env.LURKER_LINK_PREVIEWS = 'on';
+  ({ getCachedPreview, putPreview, OK_TTL_MS } = await import('../db/linkPreviews.js'));
+  ({ resolvePreview, toDescriptor } = await import('./linkPreview.js'));
+});
+
+afterAll(() => {
+  if (SAVED_FLAG === undefined) delete process.env.LURKER_LINK_PREVIEWS;
+  else process.env.LURKER_LINK_PREVIEWS = SAVED_FLAG;
+  ctx.cleanup();
+});
+
+/** A complete `ok` record, so a test can vary the one field it cares about. */
+function record(over: Partial<PreviewRecord> = {}): PreviewRecord {
+  return {
+    url: 'https://example.com/a',
+    status: 'ok',
+    kind: 'page',
+    title: 'A Title',
+    description: 'A description',
+    siteName: 'Example',
+    author: null,
+    imageUrl: null,
+    imageWidth: null,
+    imageHeight: null,
+    embedUrl: null,
+    mime: null,
+    expiresAt: new Date(Date.now() + OK_TTL_MS).toISOString(),
+    ...over,
+  };
+}
+
+describe('toDescriptor', () => {
+  it('proxies a page thumbnail and never leaks the origin URL', () => {
+    const d = toDescriptor(record({ imageUrl: 'https://cdn.example.com/t.png', imageWidth: 800 }));
+    expect(d.thumb).toMatch(/^\/api\/link-preview\/media\//);
+    expect(d.src).toBeUndefined();
+    expect(d.thumbWidth).toBe(800);
+    expect(JSON.stringify(d)).not.toContain('cdn.example.com');
+  });
+
+  it('puts direct media in src, because the bytes ARE the content', () => {
+    for (const kind of ['image', 'video', 'audio'] as const) {
+      const d = toDescriptor(record({ kind, imageUrl: 'https://cdn.example.com/a.bin' }));
+      expect(d.src).toMatch(/^\/api\/link-preview\/media\//);
+      expect(d.thumb).toBeUndefined();
+    }
+  });
+
+  it('carries nothing but the verdict when a preview is unavailable', () => {
+    const d = toDescriptor(record({ status: 'unavailable', imageUrl: 'https://cdn.test/x.png' }));
+    expect(d.status).toBe('unavailable');
+    expect(d.title).toBeUndefined();
+    expect(d.thumb).toBeUndefined();
+    expect(d.src).toBeUndefined();
+  });
+
+  it('ships an embedUrl only for an origin we are willing to frame', () => {
+    // ⚠ Checked on the way OUT, against the shared allowlist rather than a prefix test — this
+    // is the one field a client puts in an <iframe>, and the value arrives from a cache row.
+    // `startsWith` would pass `player.vimeo.com.evil.test`, and there is no CSP in this repo.
+    const ok = toDescriptor(
+      record({ kind: 'video-embed', embedUrl: 'https://www.youtube-nocookie.com/embed/abc' }),
+    );
+    expect(ok.embedUrl).toBe('https://www.youtube-nocookie.com/embed/abc');
+
+    for (const bad of [
+      'https://player.vimeo.com.evil.test/video/1',
+      'https://www.youtube.com/embed/abc',
+      'javascript:alert(1)',
+      'not a url',
+    ]) {
+      expect(toDescriptor(record({ kind: 'video-embed', embedUrl: bad })).embedUrl).toBeUndefined();
+    }
+  });
+});
+
+describe('resolvePreview', () => {
+  it('goes dark when the feature is off, including for what it already cached', async () => {
+    // ⚠ The flag is checked BEFORE the cache read, not after. An operator who turns the feature
+    // off has a table full of whatever it resolved while it was on, and "off" has to mean the
+    // instance isn't participating — not that it keeps serving cards from a cache until the
+    // TTL lapses a week later. Turning it off is often the response to a problem.
+    const url = 'http://10.5.5.5/while-off';
+    putPreview({
+      url,
+      status: 'ok',
+      kind: 'page',
+      title: 'Cached While Enabled',
+      description: null,
+      siteName: null,
+      author: null,
+      imageUrl: null,
+      imageWidth: null,
+      imageHeight: null,
+      embedUrl: null,
+      mime: null,
+      expiresAt: new Date(Date.now() + OK_TTL_MS).toISOString(),
+    });
+    expect(getCachedPreview(url)?.title).toBe('Cached While Enabled');
+
+    const saved = process.env.LURKER_LINK_PREVIEWS;
+    delete process.env.LURKER_LINK_PREVIEWS;
+    try {
+      const off = await resolvePreview(url);
+      expect(off.status).toBe('unavailable');
+      expect(off.title).toBeNull();
+    } finally {
+      if (saved === undefined) delete process.env.LURKER_LINK_PREVIEWS;
+      else process.env.LURKER_LINK_PREVIEWS = saved;
+    }
+    // The row is left alone — turning the feature back on doesn't cost a refetch.
+    expect(getCachedPreview(url)?.title).toBe('Cached While Enabled');
+  });
+
+  it('refuses an absurdly long URL before it can be hashed or stored', async () => {
+    // Nothing upstream caps this: normalizeUrl is happy with a megabyte of query string, and
+    // the value would end up in a row, a response, and a base64 proxy token a third longer.
+    //
+    // ⚠ A blocked address, not a real hostname, so removing the cap makes this test go red
+    // rather than send a 4 KB request to a stranger: a blocked URL is also `unavailable`, but
+    // it is a VERDICT and gets cached, and the cache assertion is what tells the two apart.
+    const url = `http://10.3.3.3/?q=${'a'.repeat(4000)}`;
+    expect((await resolvePreview(url)).status).toBe('unavailable');
+    expect(getCachedPreview(url)).toBeNull();
+  });
+
+  it('caches a refusal, so old scrollback stops re-asking', async () => {
+    // A blocked address makes this offline and deterministic. `unavailable` is a real answer:
+    // without caching it, every scroll past a dead link in history reopens a socket.
+    const url = 'http://10.6.6.6/blocked';
+    expect((await resolvePreview(url)).status).toBe('unavailable');
+    const cached = getCachedPreview(url);
+    expect(cached?.status).toBe('unavailable');
+    // Echoed as ASKED, which is how the client looks it up.
+    expect(cached?.url).toBe(url);
+  });
+
+  it('collapses fragments to one cache entry but echoes the URL as asked', async () => {
+    // ⚠ Two identities, deliberately. `#intro` and `#appendix` of one document are the same
+    // fetch (the fragment never reaches the origin), so they share a row — while each caller
+    // gets back the exact string it sent, because that is what it will look the answer up by.
+    const base = 'http://10.7.7.7/doc';
+    await resolvePreview(`${base}#intro`);
+    const second = await resolvePreview(`${base}#appendix`);
+    // ⚠ The row's own `url` column holds `#intro` — whoever resolved it first. Handing that
+    // back verbatim is the C-class identity bug reached through the cache instead of through a
+    // redirect: it renders for the first reader and silently for nobody else.
+    expect(second.url).toBe(`${base}#appendix`);
+    expect(getCachedPreview(`${base}#intro`)?.url).toBe(`${base}#intro`);
+  });
+
+  it('coalesces concurrent anchors of one document into a single resolve', async () => {
+    // Anchors arrive together — a message linking three sections of one page is one batch —
+    // so in-flight dedupe keyed on the request string coalesces nothing and pays for the same
+    // page N times, undoing the collapse the cache key exists to provide.
+    const base = 'http://10.7.8.8/anchored';
+    const asked = [`${base}#a`, `${base}#b`, `${base}#c`, base];
+    const all = await Promise.all(asked.map((u) => resolvePreview(u)));
+    // Each caller still gets back the exact string it sent.
+    expect(all.map((r) => r.url)).toEqual(asked);
+  });
+
+  it('does not leave a resolved URL pinned in the in-flight map', async () => {
+    // ⚠ Regression guard. The give-up path used to return BEFORE entering the try, so the
+    // `finally` never ran and a resolved `unavailable` promise stayed in the in-flight map for
+    // the life of the process — every later ask replayed it and never consulted the DB again,
+    // which is permanent blankness rather than the momentary answer it was meant to be.
+    const url = 'http://10.8.8.8/twice';
+    await resolvePreview(url);
+    // If the entry were still pinned this would replay the old promise. The observable
+    // difference is the cache: a second real call reads the row that the first one wrote.
+    const again = await resolvePreview(url);
+    expect(again.status).toBe('unavailable');
+    expect(again.expiresAt).toBe(getCachedPreview(url)?.expiresAt);
+  });
+
+  it('answers a burst for one URL with one row', async () => {
+    const url = 'http://10.9.1.1/hot';
+    const all = await Promise.all(Array.from({ length: 12 }, () => resolvePreview(url)));
+    for (const r of all) expect(r.url).toBe(url);
+    expect(getCachedPreview(url)?.status).toBe('unavailable');
+  });
+});

--- a/server/services/linkPreview.test.ts
+++ b/server/services/linkPreview.test.ts
@@ -47,6 +47,46 @@ function record(over: Partial<PreviewRecord> = {}): PreviewRecord {
   };
 }
 
+describe('the concurrency cap', () => {
+  it('is at least as large as one request may ask for', async () => {
+    // ⚠⚠ The relationship, asserted directly, because the behavioural test that was supposed to
+    // guard it does not: the 20 URLs it fans out are blocked addresses that `normalizeUrl`
+    // refuses before any socket opens, so every queued waiter is handed a slot in microseconds
+    // and the suite stays green with the cap set to 6 — the exact value its own comment names
+    // as the bug. A test that passes with the defect present is a comment, not a guard.
+    const { MAX_CONCURRENT, MAX_URLS_PER_REQUEST } = await import('./linkPreview.js');
+    expect(MAX_CONCURRENT).toBeGreaterThanOrEqual(MAX_URLS_PER_REQUEST);
+  });
+});
+
+describe('pageRecord: what is enough to be worth a card', () => {
+  it('keeps a video embed that has neither a title nor an image', async () => {
+    // ⚠⚠ Regression guard. `!title && !imageUrl` are PAGE concepts, and the give-up rule
+    // consulted only those: a YouTube link whose provider oEmbed call failed — rate-limited,
+    // endpoint retired, "none of which should mean no preview at all" — falls through to a
+    // scrape that finds nothing, because YouTube's og: tags sit past the 512 KB cap. So the
+    // embed URL it was already holding was thrown away and the loss cached for an hour.
+    //
+    // Tested here rather than through the live-origin harness because `videoEmbedFor` only
+    // matches real provider hosts, so this branch is unreachable from a loopback server — and a
+    // test that stops at `toDescriptor` never runs this rule at all. (It didn't. It passed with
+    // the fix reverted, which is what put this test here.)
+    const { pageRecord } = await import('./linkPreview.js');
+    const out = pageRecord(new URL('https://www.youtube.com/watch?v=abc123'), null, {});
+    expect(out.status).toBe('ok');
+    expect(out.kind).toBe('video-embed');
+    expect(out.embedUrl).toContain('youtube-nocookie.com');
+    expect(out.title).toBeNull();
+  });
+
+  it('still gives up on an ordinary page with nothing to show', async () => {
+    // The rule has to keep doing its job: a card with no title, no image and no embed is a grey
+    // rectangle, and the plain link the user typed is better.
+    const { pageRecord } = await import('./linkPreview.js');
+    expect(pageRecord(new URL('https://example.com/blank'), null, {}).status).toBe('unavailable');
+  });
+});
+
 describe('toDescriptor', () => {
   it('proxies a page thumbnail and never leaks the origin URL', () => {
     const d = toDescriptor(record({ imageUrl: 'https://cdn.example.com/t.png', imageWidth: 800 }));
@@ -62,6 +102,15 @@ describe('toDescriptor', () => {
       expect(d.src).toMatch(/^\/api\/link-preview\/media\//);
       expect(d.thumb).toBeUndefined();
     }
+  });
+
+  it('withholds thumb dimensions when there is no thumb to describe', () => {
+    // ⚠ Emitted outside the imageUrl block, these described a picture that was never sent —
+    // so a client reserved a box for nothing, which is the reflow the fields exist to prevent.
+    const d = toDescriptor(record({ imageUrl: null, imageWidth: 1200, imageHeight: 630 }));
+    expect(d.thumb).toBeUndefined();
+    expect(d.thumbWidth).toBeUndefined();
+    expect(d.thumbHeight).toBeUndefined();
   });
 
   it('carries nothing but the verdict when a preview is unavailable', () => {
@@ -87,7 +136,11 @@ describe('toDescriptor', () => {
       'javascript:alert(1)',
       'not a url',
     ]) {
-      expect(toDescriptor(record({ kind: 'video-embed', embedUrl: bad })).embedUrl).toBeUndefined();
+      const d = toDescriptor(record({ kind: 'video-embed', embedUrl: bad }));
+      expect(d.embedUrl).toBeUndefined();
+      // ...and it stops calling itself a video embed. Withholding the URL while keeping the
+      // kind describes something that can't exist: a play button wired to nothing.
+      expect(`${bad} → ${d.kind}`).toBe(`${bad} → page`);
     }
   });
 });
@@ -122,6 +175,13 @@ describe('resolvePreview', () => {
       const off = await resolvePreview(url);
       expect(off.status).toBe('unavailable');
       expect(off.title).toBeNull();
+      // ⚠ And a SHORT expiry. Keeping a transient answer out of the server's cache does nothing
+      // if the descriptor tells the client to hold it for an hour — `expiresAt` is the only
+      // thing a client has for deciding when to re-ask, so stamping the failure TTL on an
+      // instance-state answer re-created the permanent blankness at the other end.
+      const ttl = new Date(off.expiresAt).getTime() - Date.now();
+      expect(ttl).toBeLessThan(60_000);
+      expect(ttl).toBeGreaterThan(0);
     } finally {
       if (saved === undefined) delete process.env.LURKER_LINK_PREVIEWS;
       else process.env.LURKER_LINK_PREVIEWS = saved;

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -103,7 +103,7 @@ export const MAX_URLS_PER_REQUEST = 20;
  * `keepAlive` — so capping the agents silently restores socket reuse, and a reused socket skips
  * DNS, which skips the pinned lookup that is the SSRF guard.
  */
-export const MAX_CONCURRENT = MAX_URLS_PER_REQUEST;
+const MAX_CONCURRENT = MAX_URLS_PER_REQUEST;
 /**
  * Callers parked waiting for a slot, bounded so a flood can't grow this without limit.
  * Cross-request contention is what queues here; a single batch never has to.
@@ -176,9 +176,22 @@ function unavailable(url: string, ttlMs: number = FAIL_TTL_MS): PreviewRecord {
  * priming pass" was true only for a client that ignores the field, which is not something this
  * end can enforce or should assume.
  *
- * Short rather than zero so a saturated instance doesn't get re-asked in a tight loop.
+ * Short rather than zero so a saturated instance doesn't get re-asked in a tight loop, and
+ * JITTERED so that every loser of one saturation event doesn't come back as a single wave
+ * against a pool still holding the slow origins that caused it.
+ *
+ * ⚠ What this does NOT do, stated because the paragraph above reads like it does: no shipped
+ * client honours `expiresAt` yet — the iOS model omits the field and gates re-asks on a set, so
+ * a transient answer stays blank there for the session. That is a client bug and it belongs to
+ * PRs 5 and 6; sending the right number is this end's half of it, and sending the wrong one
+ * would make the client half unfixable.
  */
 const TRANSIENT_TTL_MS = 15_000;
+
+/** ±25%, so simultaneous losers don't retry in lockstep. */
+function transientTtl(): number {
+  return Math.round(TRANSIENT_TTL_MS * (0.75 + Math.random() * 0.5));
+}
 
 /**
  * The cache, wrapped so a database error degrades one URL instead of a whole batch.
@@ -221,6 +234,15 @@ function clamp(value: string | undefined, max: number): string | null {
   if (!value) return null;
   const trimmed = value.trim();
   if (!trimmed) return null;
+  // ⚠ The cheap check FIRST. A code point is never fewer than one UTF-16 code unit, so
+  // `length <= max` is an exact proof that no clamp is needed — and it is O(1) where
+  // `Array.from` is O(n) over a string an attacker chooses the size of. `scrapeMeta` does not
+  // pre-bound attribute values, so one og:description can be the whole 512 KB scrape budget:
+  // measured at 986 us per call versus 2.9 us with this line, and `clamp` runs four times per
+  // record across a 20-URL batch. That is ~80 ms of unbroken synchronous work on the thread
+  // holding every IRC socket, in a repo that runs an event-loop monitor because exactly this
+  // class of stall trips ping timeouts.
+  if (trimmed.length <= max) return trimmed;
   const points = Array.from(trimmed);
   if (points.length <= max) return trimmed;
   return `${points.slice(0, max - 1).join('')}…`;
@@ -357,7 +379,13 @@ export function pageRecord(
     imageHeight: oembedImage ? (oembed?.thumbnailHeight ?? null) : null,
     embedUrl: embed?.embedUrl ?? null,
     mime: null,
-    expiresAt: new Date(Date.now() + OK_TTL_MS).toISOString(),
+    // ⚠ A record kept ONLY by the `!embed` clause has no title, no description and no
+    // thumbnail — its whole visible content is the hostname. That is worth rendering (the play
+    // affordance is real) but it is a DEGRADED answer: the provider call that would have filled
+    // those in is the thing that just failed. Giving it the seven-day success TTL cached one
+    // rate-limited minute for a week; the failure TTL retries within the hour, which is what
+    // the situation actually calls for.
+    expiresAt: new Date(Date.now() + (title || imageUrl ? OK_TTL_MS : FAIL_TTL_MS)).toISOString(),
   };
 }
 
@@ -492,7 +520,7 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
   // The flag first, before even a cache read: "off" means the feature isn't participating, not
   // that it serves stale answers it happens to still have. The routes aren't mounted either —
   // this is the inner half of the same decision.
-  if (!previewsEnabled()) return unavailable(raw, TRANSIENT_TTL_MS);
+  if (!previewsEnabled()) return unavailable(raw, transientTtl());
   // Refused before it can be hashed, stored, or echoed. Nothing downstream caps a URL's
   // length, and this one arrived in a request body. A stable verdict, so it keeps the ordinary
   // failure TTL — a URL this long will still be this long in an hour.
@@ -539,7 +567,7 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
         // the instance was saturated when we asked. No row here, and a short `expiresAt` so a
         // client honouring the field re-asks in seconds — see TRANSIENT_TTL_MS, because keeping
         // it out of OUR cache while telling the client to hold it for an hour achieved nothing.
-        return unavailable(raw, TRANSIENT_TTL_MS);
+        return unavailable(raw, transientTtl());
       }
       // ⚠ The deadline ABORTS the work, it doesn't merely stop waiting for it. Racing a promise
       // abandons it, and abandoning is not ending: the fetch kept its socket for its own hop
@@ -570,7 +598,7 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
       // strength of one bad afternoon. Same treatment as pool saturation: no row, short TTL.
       if (err instanceof DeadlineExceeded) {
         controller.abort();
-        return unavailable(raw, TRANSIENT_TTL_MS);
+        return unavailable(raw, transientTtl());
       }
       // An SSRF refusal is worth a line — it's either a misconfigured link or
       // somebody probing. Everything else (timeouts, resets, 403s) is ordinary

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -1,0 +1,504 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The resolver: URL in, preview descriptor out, cached in between.
+//
+// Lazily driven. Nothing here runs on message arrival — a client asks for a URL
+// when it's about to render one and the user has a setting on, which is what
+// makes both features genuinely free when they're off. It also means scrollback
+// and live messages take the identical path, so there is no backfill story and
+// no "preview arrives after the message" race to design around.
+//
+// The Lounge does the opposite (fetch eagerly in the PRIVMSG handler, decorate
+// the stored message), which is right for a server-global config knob and wrong
+// for a per-user, default-off setting.
+
+import sharp from 'sharp';
+import {
+  bufferStream,
+  fetchBuffered,
+  normalizeUrl,
+  safeRequest,
+  MAX_SCRAPE_BYTES,
+  UnsafeUrlError,
+  type RawResponse,
+} from './linkFetch.js';
+import { scrapeMeta, readOEmbed, decodeBody, type OEmbedMeta } from './linkMeta.js';
+import { videoEmbedFor, oembedEndpointFor, isEmbeddableOrigin } from './linkEmbed.js';
+import { previewsEnabled } from '../utils/previews.js';
+import { SlotPool } from '../utils/slotPool.js';
+import {
+  getCachedPreview,
+  putPreview,
+  urlHash,
+  OK_TTL_MS,
+  FAIL_TTL_MS,
+  type PreviewRecord,
+  type PreviewKind,
+} from '../db/linkPreviews.js';
+import { mintProxyToken } from './mediaProxyToken.js';
+
+/** Clamps, applied server-side so no client has to think about them and no
+ *  client can be surprised by a 40 KB og:description. */
+const MAX_TITLE = 140;
+const MAX_DESCRIPTION = 300;
+/** Cap on a preview image we're willing to pull down and proxy. */
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+/**
+ * Longest URL we'll carry.
+ *
+ * Applies to the URL asked about AND to any og:image / oEmbed thumbnail found on the page,
+ * because both end up in a row, in a response, and — for the image — inside a minted proxy
+ * token, which is base64 of the URL and therefore a third longer again. Nothing upstream caps
+ * these: `normalizeUrl` is happy with a megabyte of query string, and `readOEmbed` reads a
+ * `thumbnail_url` of any length straight out of a stranger's JSON. 2 KB is the de-facto ceiling
+ * every browser and CDN already enforces, so anything past it wasn't going to load anyway.
+ */
+const MAX_URL_LENGTH = 2048;
+
+/** Cap on URLs one resolve request may carry. Lives here rather than in the route so it can
+ *  be tied to the concurrency limit below, which has to be at least this big. */
+export const MAX_URLS_PER_REQUEST = 20;
+
+/**
+ * Outbound fetches in flight across the whole instance.
+ *
+ * A cap rather than a queue-per-user: the resource being protected is the instance's egress and
+ * its standing with the hosts it talks to, and neither cares which account caused the traffic.
+ *
+ * ⚠ Must be >= MAX_URLS_PER_REQUEST, and overflow must QUEUE rather than fail. An earlier
+ * version had a cap of 6 and answered overflow with `unavailable` immediately, which quietly
+ * broke the common case rather than a rare one: `resolvePreview` runs synchronously up to its
+ * first await, so `Promise.all` over a 20-URL batch started all 20 before any finished — calls
+ * 7 through 20 saw a full pool and were refused without ever dialling. On a link-heavy history
+ * page 6 previews rendered and 14 links stayed bare, and because the client stores whatever
+ * verdict it's given, they stayed bare for the rest of the session.
+ *
+ * ⚠ This is also the only bound on how many DNS lookups the feature has outstanding, and that
+ * matters more than it reads. `getaddrinfo` runs on libuv's thread pool, which caps it at
+ * `(nthreads + 1) / 2` slots, and it CANNOT be cancelled — `req.destroy()` returns at once
+ * while the lookup keeps its slot for the full OS timeout. Measured while building this: eight
+ * concurrent blackholed lookups delayed an unrelated `dns.lookup` by ~20 s, and on this server
+ * the other DNS consumer is IRC connection setup.
+ *
+ * The honest limits of the bound, since a comment claiming a guarantee is a claim to test:
+ * it bounds fetches in flight, not lookups outstanding. A hop that gives up at
+ * HOP_DEADLINE_MS frees its slot to a new fetch while its own lookup is still pending, so a
+ * sustained stream of unresolvable hostnames can leave more than MAX_CONCURRENT lookups queued.
+ * Fixing that needs a cancellable resolver (`dns.Resolver` over UDP rather than getaddrinfo),
+ * which is a change to the fetcher, not to its caller. Bounding it here is what's available,
+ * and it is strictly better than not bounding it.
+ *
+ * ⚠ Do NOT try to bound this with `maxSockets` on linkFetch's agents instead. node marks a
+ * request `shouldKeepAlive = false` only when `!agent.keepAlive && !isFinite(agent.maxSockets)`,
+ * and the agent hands a released socket to a queued same-host request before it ever consults
+ * `keepAlive` — so capping the agents silently restores socket reuse, and a reused socket skips
+ * DNS, which skips the pinned lookup that is the SSRF guard.
+ */
+const MAX_CONCURRENT = MAX_URLS_PER_REQUEST;
+/**
+ * Callers parked waiting for a slot, bounded so a flood can't grow this without limit.
+ * Cross-request contention is what queues here; a single batch never has to.
+ */
+const MAX_QUEUED = 200;
+/** How long a caller will wait for a slot before giving up, so an HTTP request can't hang on
+ *  a backlog of slow origins. Recoverable: an `unavailable` from here is NOT written to the
+ *  cache, and the client re-asks on the next priming pass. */
+const MAX_QUEUE_WAIT_MS = 10_000;
+
+const pool = new SlotPool({
+  size: MAX_CONCURRENT,
+  maxQueued: MAX_QUEUED,
+  waitMs: MAX_QUEUE_WAIT_MS,
+});
+
+/**
+ * Coalesce concurrent resolutions of the same URL.
+ *
+ * Fifty people in a channel scrolling past the same link is fifty requests
+ * arriving within a second of each other and one cache entry that doesn't exist
+ * yet. Without this they'd be fifty sockets to the same host, which is both
+ * wasteful and precisely the behaviour that gets an IP rate-limited. The Lounge
+ * keeps the same structure for the same reason.
+ */
+const inFlight = new Map<string, Promise<PreviewRecord>>();
+
+function unavailable(url: string): PreviewRecord {
+  return {
+    url,
+    status: 'unavailable',
+    kind: 'page',
+    title: null,
+    description: null,
+    siteName: null,
+    author: null,
+    imageUrl: null,
+    imageWidth: null,
+    imageHeight: null,
+    embedUrl: null,
+    mime: null,
+    expiresAt: new Date(Date.now() + FAIL_TTL_MS).toISOString(),
+  };
+}
+
+function clamp(value: string | undefined, max: number): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}
+
+/**
+ * What a Content-Type means for rendering.
+ *
+ * SVG is deliberately absent from the image branch. It is a document format that
+ * executes script, not a picture — the uploader already refuses it (#553-era
+ * media scrubbing), and letting one in here would reintroduce the same hole
+ * through a different door.
+ */
+function kindForContentType(contentType: string): PreviewKind | null {
+  if (contentType === 'image/svg+xml') return null;
+  if (contentType.startsWith('image/')) return 'image';
+  if (contentType.startsWith('video/')) return 'video';
+  if (contentType.startsWith('audio/')) return 'audio';
+  if (contentType === 'text/html' || contentType === 'application/xhtml+xml') return 'page';
+  return null;
+}
+
+/** Fetch a discovered oEmbed endpoint. Best-effort: a failure just means we fall
+ *  back to whatever the Open Graph tags gave us. */
+async function fetchOEmbed(raw: string, base: URL): Promise<ReturnType<typeof readOEmbed>> {
+  // ⚠ The RESOLVE is inside the try, not just the normalize — the same shape `safeRequest`
+  // needed for a redirect `Location`. `raw` is an href scraped out of a stranger's markup, and
+  // `new URL('http://[', base)` throws ERR_INVALID_URL while BUILDING normalizeUrl's argument,
+  // so normalizeUrl's own guard never sees it. Escaping as a raw TypeError doesn't get past
+  // `resolvePreview`'s catch, but it does abandon the whole page — a broken oEmbed href would
+  // cost a site its preview entirely, when oEmbed is the fallback path and skipping it should
+  // leave the Open Graph tags we already have.
+  let url: URL | null = null;
+  try {
+    url = normalizeUrl(new URL(raw, base).toString());
+  } catch {
+    return null;
+  }
+  if (!url) return null;
+  try {
+    const res = await fetchBuffered(url, { accept: 'application/json', maxBytes: 64 * 1024 });
+    if (res.status !== 200) return null;
+    return readOEmbed(JSON.parse(res.body.toString('utf8')));
+  } catch {
+    return null;
+  }
+}
+
+/** Assemble a page record from whatever combination of oEmbed and scraped tags we got. */
+function pageRecord(
+  url: URL,
+  oembed: OEmbedMeta | null,
+  meta: ReturnType<typeof scrapeMeta>,
+): PreviewRecord {
+  const embed = videoEmbedFor(url);
+  const kind: PreviewKind = embed ? 'video-embed' : 'page';
+
+  let imageUrl = oembed?.thumbnailUrl || meta.imageUrl;
+  if (imageUrl) {
+    // og:image is routinely relative, and a relative URL resolves against the
+    // page we ACTUALLY landed on, not the one we asked for — redirects move the
+    // base.
+    //
+    // ⚠ NOT decoded here. `scrapeMeta` and `readOEmbed` each decode entities at their own
+    // boundary now, and decoding is deliberately once-only — a second pass turns a literal
+    // `&amp;lt;` in a filename back into `<`, and `linkMeta.test.ts` asserts the single pass.
+    let abs: URL | null = null;
+    try {
+      abs = normalizeUrl(new URL(imageUrl, url).toString());
+    } catch {
+      // `new URL` throws on input `normalizeUrl` would merely refuse — and this input came
+      // from a stranger's markup, so it reaches us as anything at all.
+      abs = null;
+    }
+    imageUrl = abs && abs.toString().length <= MAX_URL_LENGTH ? abs.toString() : undefined;
+  }
+
+  const title = clamp(oembed?.title || meta.title, MAX_TITLE);
+  const description = clamp(meta.description, MAX_DESCRIPTION);
+
+  // A card with no title and no image is a grey rectangle that says nothing.
+  // Better to render the plain link the user typed.
+  if (!title && !imageUrl) return unavailable(url.toString());
+
+  return {
+    url: url.toString(),
+    status: 'ok',
+    kind,
+    title,
+    description,
+    siteName: clamp(oembed?.providerName || meta.siteName || url.hostname, MAX_TITLE),
+    author: clamp(oembed?.authorName, MAX_TITLE),
+    imageUrl: imageUrl ?? null,
+    imageWidth: oembed?.thumbnailWidth ?? null,
+    imageHeight: oembed?.thumbnailHeight ?? null,
+    embedUrl: embed?.embedUrl ?? null,
+    mime: null,
+    expiresAt: new Date(Date.now() + OK_TTL_MS).toISOString(),
+  };
+}
+
+/** Resolve an HTML page into a card by scraping it. */
+async function resolveScrapedPage(
+  url: URL,
+  body: Buffer,
+  charset: string | null,
+): Promise<PreviewRecord> {
+  // ⚠ The declared CHARSET, not the Content-Type header. `decodeBody` used to re-parse
+  // `charset=…` out of what it was handed, but what reached it was `RawResponse.contentType`,
+  // already stripped to a bare `text/html` — a branch that could never match, so
+  // `charset=windows-1251` with no in-document `<meta charset>` fell through to UTF-8 and
+  // rendered as replacement characters. `BufferedResponse` carries the parsed charset as its
+  // own field for exactly this call.
+  const html = decodeBody(body, charset);
+  const meta = scrapeMeta(html);
+
+  // Discovered oEmbed still wins over the scraped tags where a page advertises one, matching
+  // Slack: it's a structured, versioned answer from the site itself rather than a bag of
+  // strings. This is the discovery path, for sites not in the provider table.
+  const oembed = meta.oembedUrl ? await fetchOEmbed(meta.oembedUrl, url) : null;
+  return pageRecord(url, oembed, meta);
+}
+
+/**
+ * Pixel dimensions of an image, from as few bytes as we can get away with.
+ *
+ * Purely so clients can reserve the right amount of space *before* the bytes arrive. Without
+ * it a message list grows twice — once when the metadata lands and again when the image
+ * decodes — and in a bottom-anchored chat log the second one yanks the reader off the live
+ * tail. With an aspect ratio in hand the box is allocated at metadata time and the image
+ * simply appears inside it.
+ *
+ * A header-sized read is enough for every format that matters: the dimensions live in the
+ * first few hundred bytes of a JPEG/PNG/GIF/WebP. Failure is fine and common (a truncated
+ * buffer sharp can't parse, an exotic format) — the clients fall back to a fixed max height,
+ * which is merely the old behaviour.
+ */
+async function imageDimensions(
+  res: RawResponse,
+): Promise<{ width: number; height: number } | null> {
+  try {
+    const head = await bufferStream(res, { maxBytes: 64 * 1024 });
+    const meta = await sharp(head.body).metadata();
+    if (meta.width && meta.height) return { width: meta.width, height: meta.height };
+  } catch {
+    // Not worth distinguishing: no dimensions means no reservation, not no preview.
+  }
+  return null;
+}
+
+async function doResolve(raw: string): Promise<PreviewRecord> {
+  const url = normalizeUrl(raw);
+  if (!url) return unavailable(raw);
+
+  // Known providers are asked directly, BEFORE anything is fetched from the page itself.
+  // For YouTube this is the difference between working and not: its og: tags sit past
+  // half a megabyte of inline script, while its oEmbed endpoint answers in under a
+  // kilobyte. See `oembedEndpointFor`.
+  const endpoint = oembedEndpointFor(url);
+  if (endpoint) {
+    const oembed = await fetchOEmbed(endpoint, url);
+    if (oembed?.title) return pageRecord(url, oembed, {});
+    // Fall through and scrape. A provider can be down, or rate-limiting us, or have
+    // retired an endpoint — none of which should mean no preview at all.
+  }
+
+  const res = await safeRequest(url, {});
+  if (res.status !== 200) {
+    res.stream.destroy();
+    return unavailable(raw);
+  }
+
+  const kind = kindForContentType(res.contentType);
+  if (kind === null) {
+    res.stream.destroy();
+    return unavailable(raw);
+  }
+
+  // Direct media: the URL IS the content, so there's nothing to scrape. For an image we
+  // read a header's worth to learn its dimensions — see `imageDimensions` for why that
+  // matters more than it looks — and for video/audio we stop at the headers, since the
+  // client asks the proxy for the bytes and only if it actually renders it.
+  if (kind !== 'page') {
+    const size = kind === 'image' ? await imageDimensions(res) : null;
+    res.stream.destroy();
+    return {
+      url: url.toString(),
+      status: 'ok',
+      kind,
+      title: null,
+      description: null,
+      siteName: null,
+      author: null,
+      imageUrl: url.toString(),
+      imageWidth: size?.width ?? null,
+      imageHeight: size?.height ?? null,
+      embedUrl: null,
+      mime: res.contentType,
+      expiresAt: new Date(Date.now() + OK_TTL_MS).toISOString(),
+    };
+  }
+
+  // Buffered off the response we already have, rather than re-requesting: a second GET for
+  // the body doubled every page fetch, and doubled the chance of a rate limit on a host we
+  // want to stay welcome at. `stopAtHeadEnd` means a well-formed page costs its head only.
+  const buffered = await bufferStream(res, {
+    maxBytes: MAX_SCRAPE_BYTES,
+    stopAtHeadEnd: true,
+  });
+  return await resolveScrapedPage(buffered.finalUrl, buffered.body, buffered.charset);
+}
+
+/**
+ * Resolve one URL to a cached-or-fresh preview record.
+ *
+ * Never throws. Every failure path — malformed URL, blocked address, timeout,
+ * 403, unusable content type — becomes an `unavailable` record, which is a real
+ * cacheable answer rather than an error to handle. That's what keeps a dead link
+ * in old scrollback from reopening a socket every time someone scrolls past it.
+ */
+export async function resolvePreview(raw: string): Promise<PreviewRecord> {
+  // The flag first, before even a cache read: "off" means the feature isn't participating, not
+  // that it serves stale answers it happens to still have. The routes aren't mounted either —
+  // this is the inner half of the same decision.
+  if (!previewsEnabled()) return unavailable(raw);
+  // Refused before it can be hashed, stored, or echoed. Nothing downstream caps a URL's
+  // length, and this one arrived in a request body.
+  if (raw.length > MAX_URL_LENGTH) return unavailable(raw);
+
+  const cached = getCachedPreview(raw);
+  // ⚠ Re-stamped with the URL as ASKED, not as stored. The row is keyed with the fragment
+  // stripped so `#intro` and `#appendix` of one document share a fetch — which means the `url`
+  // column holds whichever of them arrived first. Returning that verbatim is the same
+  // client-side miss that echoing a post-redirect URL caused (the client looks a preview up by
+  // the string it sent), except reached through the cache rather than through a redirect, and
+  // only for the second reader onward — so it renders correctly for whoever resolved it and
+  // silently for nobody else.
+  if (cached) return { ...cached, url: raw };
+
+  // ⚠ Keyed by the STORAGE identity, not by the request string, and re-stamped on the way out
+  // for the same reason the cache read above is. Keyed by `raw`, two anchors of one document
+  // arriving in the same batch — which is exactly how anchors arrive — coalesced with nothing
+  // and cost two fetches of the same page, quietly undoing the fragment collapse the cache key
+  // exists to provide.
+  const key = urlHash(raw);
+  const pending = inFlight.get(key);
+  if (pending) return { ...(await pending), url: raw };
+
+  const task = (async (): Promise<PreviewRecord> => {
+    // ⚠ `acquired` and the try must wrap EVERYTHING, including the give-up path. An earlier
+    // version returned before entering the try, so `finally` never ran and the resolved
+    // `unavailable` promise stayed pinned in `inFlight` for the life of the process — every
+    // later request for that URL replayed it via the `if (pending)` short-circuit above, never
+    // consulting the DB cache again. That's permanent blankness, which is precisely what the
+    // "deliberately not cached" note below was trying to avoid.
+    let acquired = false;
+    try {
+      acquired = await pool.acquire();
+      if (!acquired) {
+        // Deliberately NOT cached: this says nothing about the URL, only that the instance was
+        // saturated when we asked. Caching it would turn a momentary spike into a permanently
+        // blank preview.
+        return unavailable(raw);
+      }
+      const resolved = await doResolve(raw);
+      // ⚠ Always echo the URL we were ASKED about, whatever the fetch ended up at.
+      //
+      // The endpoint's contract is one descriptor per input, in order, and callers look each
+      // one up by the string they sent. Returning a post-redirect URL broke that silently in
+      // both directions: the client's `cache.get(preview.url)` missed, so nothing ever
+      // rendered, and `putPreview` wrote a row keyed by something no lookup would ever ask
+      // for, so every resolve re-hit the origin. The canonical URL is still used internally
+      // where it matters — resolving a relative og:image against the page we actually landed
+      // on — it just isn't the identity.
+      const record = { ...resolved, url: raw };
+      putPreview(record);
+      return record;
+    } catch (err) {
+      // An SSRF refusal is worth a line — it's either a misconfigured link or
+      // somebody probing. Everything else (timeouts, resets, 403s) is ordinary
+      // internet weather and would only be log noise.
+      if (err instanceof UnsafeUrlError) {
+        console.warn(`[lurker] link preview refused: ${err.message}`);
+      }
+      const record = unavailable(raw);
+      putPreview(record);
+      return record;
+    } finally {
+      // Only release what we actually took; always clear the in-flight entry.
+      if (acquired) pool.release();
+      inFlight.delete(key);
+    }
+  })();
+
+  inFlight.set(key, task);
+  return await task;
+}
+
+/** The wire shape handed to clients. Byte URLs are minted here, so a client
+ *  never learns to construct one — see mediaProxyToken. */
+export interface PreviewDescriptor {
+  url: string;
+  status: 'ok' | 'unavailable';
+  kind: PreviewKind;
+  title?: string;
+  description?: string;
+  siteName?: string;
+  author?: string;
+  src?: string;
+  thumb?: string;
+  thumbWidth?: number;
+  thumbHeight?: number;
+  embedUrl?: string;
+  mime?: string;
+  expiresAt: string;
+}
+
+export function toDescriptor(record: PreviewRecord): PreviewDescriptor {
+  const d: PreviewDescriptor = {
+    url: record.url,
+    status: record.status,
+    kind: record.kind,
+    expiresAt: record.expiresAt,
+  };
+  if (record.status !== 'ok') return d;
+
+  if (record.title) d.title = record.title;
+  if (record.description) d.description = record.description;
+  if (record.siteName) d.siteName = record.siteName;
+  if (record.author) d.author = record.author;
+  if (record.mime) d.mime = record.mime;
+  // ⚠ Re-checked on the way out, against the shared allowlist rather than a `startsWith`.
+  // `embedUrl` is the one field a client puts in an <iframe>, and this value came back out of
+  // a cache row — so what's asserted here isn't "did videoEmbedFor behave", it's "whatever is
+  // in the row, we only ever hand clients an origin we're willing to frame". There is still no
+  // CSP anywhere in this repo, so this check is the frame-src.
+  if (record.embedUrl && isEmbeddableOrigin(record.embedUrl)) d.embedUrl = record.embedUrl;
+  if (record.imageWidth) d.thumbWidth = record.imageWidth;
+  if (record.imageHeight) d.thumbHeight = record.imageHeight;
+
+  if (record.imageUrl) {
+    const proxied = `/api/link-preview/media/${mintProxyToken(record.imageUrl)}`;
+    // For direct media the bytes ARE the content (`src`); for a page they're
+    // decoration on a card (`thumb`). Same proxy, different slot, so a client
+    // never has to re-derive which one it's looking at from `kind`.
+    if (record.kind === 'image' || record.kind === 'video' || record.kind === 'audio') {
+      d.src = proxied;
+    } else {
+      d.thumb = proxied;
+    }
+  }
+  return d;
+}
+
+/** Ceiling on preview IMAGE bytes the proxy will serve. */
+export const MAX_IMAGE_PROXY_BYTES = MAX_IMAGE_BYTES;
+/** Ceiling on VIDEO/AUDIO bytes. Larger because these stream to a media element rather than
+ *  being decoded whole — an 8 MB cut-off truncated ordinary clips mid-playback. */
+export const MAX_MEDIA_PROXY_BYTES = 64 * 1024 * 1024;

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -90,6 +90,13 @@ export const MAX_URLS_PER_REQUEST = 20;
  * which is a change to the fetcher, not to its caller. Bounding it here is what's available,
  * and it is strictly better than not bounding it.
  *
+ * ⚠ "Fetches in flight" is only true because RESOLVE_DEADLINE_MS **aborts** rather than merely
+ * stops waiting. Racing a promise abandons the work, and an abandoned fetch keeps its socket
+ * for its own hop budget — so releasing the slot at that moment let the pool undercount its own
+ * work, and a run of slow origins pushed the real number of live fetches past MAX_CONCURRENT
+ * without bound. The signal threaded through `doResolve` is what makes the release honest, and
+ * it is load-bearing for this paragraph rather than a tidiness.
+ *
  * ⚠ Do NOT try to bound this with `maxSockets` on linkFetch's agents instead. node marks a
  * request `shouldKeepAlive = false` only when `!agent.keepAlive && !isFinite(agent.maxSockets)`,
  * and the agent hands a released socket to a queued same-host request before it ever consults
@@ -238,7 +245,11 @@ function kindForContentType(contentType: string): PreviewKind | null {
 
 /** Fetch a discovered oEmbed endpoint. Best-effort: a failure just means we fall
  *  back to whatever the Open Graph tags gave us. */
-async function fetchOEmbed(raw: string, base: URL): Promise<ReturnType<typeof readOEmbed>> {
+async function fetchOEmbed(
+  raw: string,
+  base: URL,
+  signal: AbortSignal,
+): Promise<ReturnType<typeof readOEmbed>> {
   // ⚠ The RESOLVE is inside the try, not just the normalize — the same shape `safeRequest`
   // needed for a redirect `Location`. `raw` is an href scraped out of a stranger's markup, and
   // `new URL('http://[', base)` throws ERR_INVALID_URL while BUILDING normalizeUrl's argument,
@@ -254,7 +265,11 @@ async function fetchOEmbed(raw: string, base: URL): Promise<ReturnType<typeof re
   }
   if (!url) return null;
   try {
-    const res = await fetchBuffered(url, { accept: 'application/json', maxBytes: 64 * 1024 });
+    const res = await fetchBuffered(url, {
+      accept: 'application/json',
+      maxBytes: 64 * 1024,
+      signal,
+    });
     if (res.status !== 200) return null;
     return readOEmbed(JSON.parse(res.body.toString('utf8')));
   } catch {
@@ -351,6 +366,7 @@ async function resolveScrapedPage(
   url: URL,
   body: Buffer,
   charset: string | null,
+  signal: AbortSignal,
 ): Promise<PreviewRecord> {
   // ⚠ The declared CHARSET, not the Content-Type header. `decodeBody` used to re-parse
   // `charset=…` out of what it was handed, but what reached it was `RawResponse.contentType`,
@@ -364,7 +380,7 @@ async function resolveScrapedPage(
   // Discovered oEmbed still wins over the scraped tags where a page advertises one, matching
   // Slack: it's a structured, versioned answer from the site itself rather than a bag of
   // strings. This is the discovery path, for sites not in the provider table.
-  const oembed = meta.oembedUrl ? await fetchOEmbed(meta.oembedUrl, url) : null;
+  const oembed = meta.oembedUrl ? await fetchOEmbed(meta.oembedUrl, url, signal) : null;
   return pageRecord(url, oembed, meta);
 }
 
@@ -395,7 +411,7 @@ async function imageDimensions(
   return null;
 }
 
-async function doResolve(raw: string): Promise<PreviewRecord> {
+async function doResolve(raw: string, signal: AbortSignal): Promise<PreviewRecord> {
   const url = normalizeUrl(raw);
   if (!url) return unavailable(raw);
   // ⚠ Re-checked on the NORMALISED form. The gate in `resolvePreview` measures the request
@@ -412,13 +428,13 @@ async function doResolve(raw: string): Promise<PreviewRecord> {
   // kilobyte. See `oembedEndpointFor`.
   const endpoint = oembedEndpointFor(url);
   if (endpoint) {
-    const oembed = await fetchOEmbed(endpoint, url);
+    const oembed = await fetchOEmbed(endpoint, url, signal);
     if (oembed?.title) return pageRecord(url, oembed, {});
     // Fall through and scrape. A provider can be down, or rate-limiting us, or have
     // retired an endpoint — none of which should mean no preview at all.
   }
 
-  const res = await safeRequest(url, {});
+  const res = await safeRequest(url, { signal });
   if (res.status !== 200) {
     res.stream.destroy();
     return unavailable(raw);
@@ -461,7 +477,7 @@ async function doResolve(raw: string): Promise<PreviewRecord> {
     maxBytes: MAX_SCRAPE_BYTES,
     stopAtHeadEnd: true,
   });
-  return await resolveScrapedPage(buffered.finalUrl, buffered.body, buffered.charset);
+  return await resolveScrapedPage(buffered.finalUrl, buffered.body, buffered.charset, signal);
 }
 
 /**
@@ -514,6 +530,8 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
     // consulting the DB cache again. That's permanent blankness, which is precisely what the
     // "deliberately not cached" note below was trying to avoid.
     let acquired = false;
+    // Tears the fetch down if the deadline fires, so the slot released below is genuinely free.
+    const controller = new AbortController();
     try {
       acquired = await pool.acquire();
       if (!acquired) {
@@ -523,7 +541,17 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
         // it out of OUR cache while telling the client to hold it for an hour achieved nothing.
         return unavailable(raw, TRANSIENT_TTL_MS);
       }
-      const resolved = await withDeadline(doResolve(raw), RESOLVE_DEADLINE_MS, 'resolve');
+      // ⚠ The deadline ABORTS the work, it doesn't merely stop waiting for it. Racing a promise
+      // abandons it, and abandoning is not ending: the fetch kept its socket for its own hop
+      // budget — up to minutes — while the `finally` below handed its pool slot to somebody
+      // else. So the pool undercounted its own work, and under a run of slow origins more than
+      // MAX_CONCURRENT fetches were live at once, without bound. A cap that a timeout quietly
+      // lifts is not a cap.
+      const resolved = await withDeadline(
+        doResolve(raw, controller.signal),
+        RESOLVE_DEADLINE_MS,
+        'resolve',
+      );
       // ⚠ Always echo the URL we were ASKED about, whatever the fetch ended up at.
       //
       // The endpoint's contract is one descriptor per input, in order, and callers look each
@@ -540,7 +568,10 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
       // ⚠ Running out of time is NOT a verdict about the URL — the origin was slow, which is a
       // fact about a moment. Cached, it would blank a perfectly good link for an hour on the
       // strength of one bad afternoon. Same treatment as pool saturation: no row, short TTL.
-      if (err instanceof DeadlineExceeded) return unavailable(raw, TRANSIENT_TTL_MS);
+      if (err instanceof DeadlineExceeded) {
+        controller.abort();
+        return unavailable(raw, TRANSIENT_TTL_MS);
+      }
       // An SSRF refusal is worth a line — it's either a misconfigured link or
       // somebody probing. Everything else (timeouts, resets, 403s) is ordinary
       // internet weather and would only be log noise.

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -27,6 +27,7 @@ import { scrapeMeta, readOEmbed, decodeBody, type OEmbedMeta } from './linkMeta.
 import { videoEmbedFor, oembedEndpointFor, isEmbeddableOrigin } from './linkEmbed.js';
 import { previewsEnabled } from '../utils/previews.js';
 import { SlotPool } from '../utils/slotPool.js';
+import { withDeadline, DeadlineExceeded } from '../utils/withDeadline.js';
 import {
   getCachedPreview,
   putPreview,
@@ -42,8 +43,6 @@ import { mintProxyToken } from './mediaProxyToken.js';
  *  client can be surprised by a 40 KB og:description. */
 const MAX_TITLE = 140;
 const MAX_DESCRIPTION = 300;
-/** Cap on a preview image we're willing to pull down and proxy. */
-const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 /**
  * Longest URL we'll carry.
  *
@@ -74,8 +73,10 @@ export const MAX_URLS_PER_REQUEST = 20;
  * page 6 previews rendered and 14 links stayed bare, and because the client stores whatever
  * verdict it's given, they stayed bare for the rest of the session.
  *
- * ⚠ This is also the only bound on how many DNS lookups the feature has outstanding, and that
- * matters more than it reads. `getaddrinfo` runs on libuv's thread pool, which caps it at
+ * ⚠ This is also what bounds how many DNS lookups RESOLVING has outstanding, and that matters
+ * more than it reads. (The byte proxy is the other half and needs its own — see `mediaPool` in
+ * routes/linkPreview.ts, which is the higher-volume one: a link resolves once, but every image
+ * on screen is a byte request.) `getaddrinfo` runs on libuv's thread pool, which caps it at
  * `(nthreads + 1) / 2` slots, and it CANNOT be cancelled — `req.destroy()` returns at once
  * while the lookup keeps its slot for the full OS timeout. Measured while building this: eight
  * concurrent blackholed lookups delayed an unrelated `dns.lookup` by ~20 s, and on this server
@@ -95,16 +96,32 @@ export const MAX_URLS_PER_REQUEST = 20;
  * `keepAlive` — so capping the agents silently restores socket reuse, and a reused socket skips
  * DNS, which skips the pinned lookup that is the SSRF guard.
  */
-const MAX_CONCURRENT = MAX_URLS_PER_REQUEST;
+export const MAX_CONCURRENT = MAX_URLS_PER_REQUEST;
 /**
  * Callers parked waiting for a slot, bounded so a flood can't grow this without limit.
  * Cross-request contention is what queues here; a single batch never has to.
  */
 const MAX_QUEUED = 200;
 /** How long a caller will wait for a slot before giving up, so an HTTP request can't hang on
- *  a backlog of slow origins. Recoverable: an `unavailable` from here is NOT written to the
- *  cache, and the client re-asks on the next priming pass. */
+ *  a backlog of slow origins. Recoverable: an `unavailable` from here is written to neither
+ *  cache — no row here, and a TRANSIENT_TTL_MS `expiresAt` so the client re-asks in seconds. */
 const MAX_QUEUE_WAIT_MS = 10_000;
+
+/**
+ * Ceiling on one URL's whole resolution, once it holds a slot.
+ *
+ * ⚠ Without this the per-hop bounds multiply out to something absurd, and it is the SLOT that
+ * makes it everyone's problem. One URL can chain three separate fetch walks — the provider
+ * oEmbed call, the page fetch it falls through to, and the oEmbed endpoint discovered in that
+ * page — each of MAX_REDIRECTS + 1 hops at HOP_DEADLINE_MS, so roughly four minutes of holding
+ * one of MAX_CONCURRENT slots while every other caller's `acquire` times out. Nothing else cuts
+ * it: there is no `server.requestTimeout` configured anywhere in this repo, so the queue wait's
+ * promise that "an HTTP request can't hang on a backlog of slow origins" was off by ~25x.
+ *
+ * A URL that hits this is transient, not a verdict — the origin was slow, which is a fact about
+ * a moment. So it gets the short client TTL and no row, like saturation.
+ */
+const RESOLVE_DEADLINE_MS = 30_000;
 
 const pool = new SlotPool({
   size: MAX_CONCURRENT,
@@ -123,7 +140,7 @@ const pool = new SlotPool({
  */
 const inFlight = new Map<string, Promise<PreviewRecord>>();
 
-function unavailable(url: string): PreviewRecord {
+function unavailable(url: string, ttlMs: number = FAIL_TTL_MS): PreviewRecord {
   return {
     url,
     status: 'unavailable',
@@ -137,15 +154,69 @@ function unavailable(url: string): PreviewRecord {
     imageHeight: null,
     embedUrl: null,
     mime: null,
-    expiresAt: new Date(Date.now() + FAIL_TTL_MS).toISOString(),
+    expiresAt: new Date(Date.now() + ttlMs).toISOString(),
   };
 }
 
+/**
+ * How long a client should sit on an `unavailable` that says nothing about the URL.
+ *
+ * ⚠ Keeping the record out of the server's cache is only half of "don't cache a transient
+ * failure". `expiresAt` goes out on the wire and is the ONLY thing a client has for deciding
+ * when to ask again — so a saturation answer stamped with the one-hour failure TTL got cached
+ * for an hour by the client regardless, which is the permanently-blank-preview outcome the
+ * server-side decision was made to avoid. The comment saying "the client re-asks on the next
+ * priming pass" was true only for a client that ignores the field, which is not something this
+ * end can enforce or should assume.
+ *
+ * Short rather than zero so a saturated instance doesn't get re-asked in a tight loop.
+ */
+const TRANSIENT_TTL_MS = 15_000;
+
+/**
+ * The cache, wrapped so a database error degrades one URL instead of a whole batch.
+ *
+ * ⚠ `resolvePreview` promises never to throw and the route builds a `Promise.all` on that
+ * promise. Both of these are synchronous better-sqlite3 calls on the single shared connection,
+ * and this repo has a documented history of SQLITE_BUSY under Litestream — so an unguarded
+ * throw here turns a transient lock into a 500 for all twenty URLs in the request. Logged
+ * rather than swallowed: a cache that has stopped working is worth knowing about, but it is
+ * degradation, not failure. Missing the read costs a refetch; missing the write costs another.
+ */
+function readCache(url: string): PreviewRecord | null {
+  try {
+    return getCachedPreview(url);
+  } catch (err) {
+    console.warn(`[lurker] link preview cache read failed: ${String(err)}`);
+    return null;
+  }
+}
+
+function writeCache(record: PreviewRecord): void {
+  try {
+    putPreview(record);
+  } catch (err) {
+    console.warn(`[lurker] link preview cache write failed: ${String(err)}`);
+  }
+}
+
+/**
+ * Trim and shorten a scraped string for display.
+ *
+ * ⚠ Cut on CODE POINTS, not on `String.prototype.slice`, which counts UTF-16 code units and
+ * will happily halve a surrogate pair. A title of emoji clamped at 140 ended in a lone high
+ * surrogate — which does not survive the SQLite round trip, so the requester who resolved the
+ * URL and everyone served from the cache afterwards got measurably different strings for the
+ * same page, and a strict JSON decoder (iOS) turned it into U+FFFD. These are display clamps,
+ * not byte budgets; there is no reason for them to be able to split a character.
+ */
 function clamp(value: string | undefined, max: number): string | null {
   if (!value) return null;
   const trimmed = value.trim();
   if (!trimmed) return null;
-  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+  const points = Array.from(trimmed);
+  if (points.length <= max) return trimmed;
+  return `${points.slice(0, max - 1).join('')}…`;
 }
 
 /**
@@ -191,8 +262,15 @@ async function fetchOEmbed(raw: string, base: URL): Promise<ReturnType<typeof re
   }
 }
 
-/** Assemble a page record from whatever combination of oEmbed and scraped tags we got. */
-function pageRecord(
+/**
+ * Assemble a page record from whatever combination of oEmbed and scraped tags we got.
+ *
+ * ⚠ Exported for tests. The give-up rule below depends on `videoEmbedFor`, which only matches
+ * real provider hosts — so the branch cannot be reached through a loopback origin, and a test
+ * that goes through `toDescriptor` instead exercises none of this. It stayed green with the
+ * rule reverted, which is how this export came to exist.
+ */
+export function pageRecord(
   url: URL,
   oembed: OEmbedMeta | null,
   meta: ReturnType<typeof scrapeMeta>,
@@ -200,32 +278,52 @@ function pageRecord(
   const embed = videoEmbedFor(url);
   const kind: PreviewKind = embed ? 'video-embed' : 'page';
 
-  let imageUrl = oembed?.thumbnailUrl || meta.imageUrl;
-  if (imageUrl) {
-    // og:image is routinely relative, and a relative URL resolves against the
-    // page we ACTUALLY landed on, not the one we asked for — redirects move the
-    // base.
-    //
-    // ⚠ NOT decoded here. `scrapeMeta` and `readOEmbed` each decode entities at their own
-    // boundary now, and decoding is deliberately once-only — a second pass turns a literal
-    // `&amp;lt;` in a filename back into `<`, and `linkMeta.test.ts` asserts the single pass.
+  /**
+   * Absolutise and vet one candidate image URL.
+   *
+   * og:image is routinely relative, and a relative URL resolves against the page we ACTUALLY
+   * landed on, not the one we asked for — redirects move the base.
+   *
+   * ⚠ NOT decoded here. `scrapeMeta` and `readOEmbed` each decode entities at their own
+   * boundary now, and decoding is deliberately once-only — a second pass turns a literal
+   * `&amp;lt;` in a filename back into `<`, and `linkMeta.test.ts` asserts the single pass.
+   */
+  const absolutise = (candidate: string | undefined): string | null => {
+    if (!candidate) return null;
     let abs: URL | null = null;
     try {
-      abs = normalizeUrl(new URL(imageUrl, url).toString());
+      abs = normalizeUrl(new URL(candidate, url).toString());
     } catch {
       // `new URL` throws on input `normalizeUrl` would merely refuse — and this input came
       // from a stranger's markup, so it reaches us as anything at all.
-      abs = null;
+      return null;
     }
-    imageUrl = abs && abs.toString().length <= MAX_URL_LENGTH ? abs.toString() : undefined;
-  }
+    if (!abs) return null;
+    const str = abs.toString();
+    return str.length <= MAX_URL_LENGTH ? str : null;
+  };
+
+  // ⚠ Each candidate is tried in turn, rather than picking one with `||` and then vetting it.
+  // Choosing first meant a page with a perfectly good og:image lost it whenever the oEmbed
+  // reply carried a thumbnail_url we refuse — a data: URI, a private-address host, something
+  // over-length — because by then `meta.imageUrl` had already been discarded. If the page also
+  // had no title that turned into a cached `unavailable`: no card at all, for an hour, because
+  // the OPTIONAL source was bad.
+  const oembedImage = absolutise(oembed?.thumbnailUrl);
+  const imageUrl = oembedImage ?? absolutise(meta.imageUrl);
 
   const title = clamp(oembed?.title || meta.title, MAX_TITLE);
   const description = clamp(meta.description, MAX_DESCRIPTION);
 
   // A card with no title and no image is a grey rectangle that says nothing.
   // Better to render the plain link the user typed.
-  if (!title && !imageUrl) return unavailable(url.toString());
+  //
+  // ⚠ ...but an embed is a card in its own right, and title/image are PAGE concepts. Without
+  // the `!embed` clause a YouTube link whose provider oEmbed call failed — rate-limited, or the
+  // endpoint retired, neither of which "should mean no preview at all" — fell through to the
+  // scrape, found nothing because YouTube's og: tags sit past the 512 KB cap, and threw away
+  // the youtube-nocookie embed URL it was already holding. Then cached that for an hour.
+  if (!title && !imageUrl && !embed) return unavailable(url.toString());
 
   return {
     url: url.toString(),
@@ -235,9 +333,13 @@ function pageRecord(
     description,
     siteName: clamp(oembed?.providerName || meta.siteName || url.hostname, MAX_TITLE),
     author: clamp(oembed?.authorName, MAX_TITLE),
-    imageUrl: imageUrl ?? null,
-    imageWidth: oembed?.thumbnailWidth ?? null,
-    imageHeight: oembed?.thumbnailHeight ?? null,
+    imageUrl,
+    // ⚠ Only when the oEmbed thumbnail is the image we actually took. `thumbnail_width` and
+    // `thumbnail_height` describe `thumbnail_url` and nothing else, so pairing them with an
+    // og:image that won instead reserves a box of the wrong shape — a 4:3 hole for a 16:9
+    // picture — which is precisely the reflow these fields exist to prevent.
+    imageWidth: oembedImage ? (oembed?.thumbnailWidth ?? null) : null,
+    imageHeight: oembedImage ? (oembed?.thumbnailHeight ?? null) : null,
     embedUrl: embed?.embedUrl ?? null,
     mime: null,
     expiresAt: new Date(Date.now() + OK_TTL_MS).toISOString(),
@@ -296,6 +398,13 @@ async function imageDimensions(
 async function doResolve(raw: string): Promise<PreviewRecord> {
   const url = normalizeUrl(raw);
   if (!url) return unavailable(raw);
+  // ⚠ Re-checked on the NORMALISED form. The gate in `resolvePreview` measures the request
+  // string, but WHATWG percent-encoding expands every non-ASCII byte threefold, so a 2,014-
+  // character URL of Cyrillic passes that gate and comes out of `normalizeUrl` at 12,014 — and
+  // on the direct-media branch below that string is stored verbatim and minted into a proxy
+  // path a third longer again, past node's own 16 KB header ceiling on the request that would
+  // fetch it. Measured, not theorised.
+  if (url.toString().length > MAX_URL_LENGTH) return unavailable(raw);
 
   // Known providers are asked directly, BEFORE anything is fetched from the page itself.
   // For YouTube this is the difference between working and not: its og: tags sit past
@@ -367,12 +476,18 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
   // The flag first, before even a cache read: "off" means the feature isn't participating, not
   // that it serves stale answers it happens to still have. The routes aren't mounted either —
   // this is the inner half of the same decision.
-  if (!previewsEnabled()) return unavailable(raw);
+  if (!previewsEnabled()) return unavailable(raw, TRANSIENT_TTL_MS);
   // Refused before it can be hashed, stored, or echoed. Nothing downstream caps a URL's
-  // length, and this one arrived in a request body.
+  // length, and this one arrived in a request body. A stable verdict, so it keeps the ordinary
+  // failure TTL — a URL this long will still be this long in an hour.
   if (raw.length > MAX_URL_LENGTH) return unavailable(raw);
 
-  const cached = getCachedPreview(raw);
+  // ⚠ Guarded, because the route's contract — and this function's own docblock — is that it
+  // never throws, and better-sqlite3 is synchronous on the one shared connection this process
+  // has. A single SQLITE_BUSY (a documented condition here under Litestream) would otherwise
+  // reject the whole `Promise.all` and 500 an entire 20-URL batch, where the design calls for
+  // one URL to degrade to `unavailable` on its own.
+  const cached = readCache(raw);
   // ⚠ Re-stamped with the URL as ASKED, not as stored. The row is keyed with the fragment
   // stripped so `#intro` and `#appendix` of one document share a fetch — which means the `url`
   // column holds whichever of them arrived first. Returning that verbatim is the same
@@ -402,12 +517,13 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
     try {
       acquired = await pool.acquire();
       if (!acquired) {
-        // Deliberately NOT cached: this says nothing about the URL, only that the instance was
-        // saturated when we asked. Caching it would turn a momentary spike into a permanently
-        // blank preview.
-        return unavailable(raw);
+        // Deliberately NOT cached, at either end: this says nothing about the URL, only that
+        // the instance was saturated when we asked. No row here, and a short `expiresAt` so a
+        // client honouring the field re-asks in seconds — see TRANSIENT_TTL_MS, because keeping
+        // it out of OUR cache while telling the client to hold it for an hour achieved nothing.
+        return unavailable(raw, TRANSIENT_TTL_MS);
       }
-      const resolved = await doResolve(raw);
+      const resolved = await withDeadline(doResolve(raw), RESOLVE_DEADLINE_MS, 'resolve');
       // ⚠ Always echo the URL we were ASKED about, whatever the fetch ended up at.
       //
       // The endpoint's contract is one descriptor per input, in order, and callers look each
@@ -418,9 +534,13 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
       // where it matters — resolving a relative og:image against the page we actually landed
       // on — it just isn't the identity.
       const record = { ...resolved, url: raw };
-      putPreview(record);
+      writeCache(record);
       return record;
     } catch (err) {
+      // ⚠ Running out of time is NOT a verdict about the URL — the origin was slow, which is a
+      // fact about a moment. Cached, it would blank a perfectly good link for an hour on the
+      // strength of one bad afternoon. Same treatment as pool saturation: no row, short TTL.
+      if (err instanceof DeadlineExceeded) return unavailable(raw, TRANSIENT_TTL_MS);
       // An SSRF refusal is worth a line — it's either a misconfigured link or
       // somebody probing. Everything else (timeouts, resets, 403s) is ordinary
       // internet weather and would only be log noise.
@@ -428,7 +548,7 @@ export async function resolvePreview(raw: string): Promise<PreviewRecord> {
         console.warn(`[lurker] link preview refused: ${err.message}`);
       }
       const record = unavailable(raw);
-      putPreview(record);
+      writeCache(record);
       return record;
     } finally {
       // Only release what we actually took; always clear the in-flight entry.
@@ -479,9 +599,14 @@ export function toDescriptor(record: PreviewRecord): PreviewDescriptor {
   // a cache row — so what's asserted here isn't "did videoEmbedFor behave", it's "whatever is
   // in the row, we only ever hand clients an origin we're willing to frame". There is still no
   // CSP anywhere in this repo, so this check is the frame-src.
-  if (record.embedUrl && isEmbeddableOrigin(record.embedUrl)) d.embedUrl = record.embedUrl;
-  if (record.imageWidth) d.thumbWidth = record.imageWidth;
-  if (record.imageHeight) d.thumbHeight = record.imageHeight;
+  if (record.embedUrl && isEmbeddableOrigin(record.embedUrl)) {
+    d.embedUrl = record.embedUrl;
+  } else if (record.kind === 'video-embed') {
+    // ⚠ Withholding the URL but keeping `kind: 'video-embed'` describes something that cannot
+    // exist — a client renders a play button wired to nothing. The honest downgrade is a page
+    // card, which is what it now is.
+    d.kind = 'page';
+  }
 
   if (record.imageUrl) {
     const proxied = `/api/link-preview/media/${mintProxyToken(record.imageUrl)}`;
@@ -493,12 +618,32 @@ export function toDescriptor(record: PreviewRecord): PreviewDescriptor {
     } else {
       d.thumb = proxied;
     }
+    // ⚠ Inside the block, because these describe the image that is being SENT. Emitted
+    // unconditionally they shipped a thumbWidth/thumbHeight for a `thumb` the record didn't
+    // have, so a client reserved a box for a picture that was never coming — the reflow these
+    // fields exist to prevent, caused by the fields themselves.
+    if (record.imageWidth) d.thumbWidth = record.imageWidth;
+    if (record.imageHeight) d.thumbHeight = record.imageHeight;
   }
   return d;
 }
 
 /** Ceiling on preview IMAGE bytes the proxy will serve. */
-export const MAX_IMAGE_PROXY_BYTES = MAX_IMAGE_BYTES;
+export const MAX_IMAGE_PROXY_BYTES = 8 * 1024 * 1024;
 /** Ceiling on VIDEO/AUDIO bytes. Larger because these stream to a media element rather than
  *  being decoded whole — an 8 MB cut-off truncated ordinary clips mid-playback. */
 export const MAX_MEDIA_PROXY_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Whether the byte proxy will serve this content type.
+ *
+ * ⚠ Derived from `kindForContentType` rather than restated. The route had its own copy of the
+ * same allowlist, which meant the refusal that matters most — `image/svg+xml`, a scripting
+ * format wearing a picture's clothes, served under OUR origin — existed in two places that had
+ * to be kept in step by hand. One definition, and the proxy serves exactly the kinds the
+ * resolver is willing to call media.
+ */
+export function proxyableContentType(contentType: string): boolean {
+  const kind = kindForContentType(contentType);
+  return kind === 'image' || kind === 'video' || kind === 'audio';
+}

--- a/server/services/mediaProxyToken.test.ts
+++ b/server/services/mediaProxyToken.test.ts
@@ -52,6 +52,24 @@ describe('proxy tokens', () => {
     }
   });
 
+  it('rejects a signature that is the right LENGTH but the wrong number of bytes', () => {
+    // ⚠⚠ Regression guard. The length guard used `String.length` (UTF-16 code units) while
+    // `timingSafeEqual` compares BYTE lengths, so a 43-character signature carrying one
+    // multibyte character sailed past the guard and threw `RangeError: Input buffers must have
+    // the same byte length` — out of a function whose whole contract is returning null. Express
+    // percent-decodes the path parameter, so `%C3%A9` in a URL is enough to reach it: a 500 and
+    // a stack trace where a 403 belongs, repeatable at the throttle's full rate.
+    const token = mintProxyToken('https://example.com/ok.png');
+    const payload = token.slice(0, token.lastIndexOf('.'));
+    const realSig = token.slice(token.lastIndexOf('.') + 1);
+    const sameLength = `é${'a'.repeat(realSig.length - 1)}`;
+    expect(sameLength.length).toBe(realSig.length);
+    expect(Buffer.byteLength(sameLength)).not.toBe(Buffer.byteLength(realSig));
+
+    expect(() => verifyProxyToken(`${payload}.${sameLength}`)).not.toThrow();
+    expect(verifyProxyToken(`${payload}.${sameLength}`)).toBeNull();
+  });
+
   it('cannot be verified under a different secret', () => {
     // Rotating the session secret invalidates outstanding tokens, which is the
     // intended coupling — a stale token is a re-resolve, not a hole.

--- a/server/services/mediaProxyToken.test.ts
+++ b/server/services/mediaProxyToken.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mintProxyToken, verifyProxyToken, resetProxyKeyCache } from './mediaProxyToken.js';
+
+const SAVED = process.env.SESSION_SECRET;
+
+beforeAll(() => {
+  process.env.SESSION_SECRET = 'test-secret-for-proxy-tokens';
+  resetProxyKeyCache();
+});
+
+afterAll(() => {
+  if (SAVED === undefined) delete process.env.SESSION_SECRET;
+  else process.env.SESSION_SECRET = SAVED;
+  resetProxyKeyCache();
+});
+
+describe('proxy tokens', () => {
+  it('round-trips a URL', () => {
+    const url = 'https://example.com/image.png?a=1&b=2';
+    expect(verifyProxyToken(mintProxyToken(url))).toBe(url);
+  });
+
+  it('round-trips URLs with characters that need escaping', () => {
+    const url = 'https://example.com/(a)/café — ünïcode.png#x';
+    expect(verifyProxyToken(mintProxyToken(url))).toBe(url);
+  });
+
+  it('is deterministic, so a token caches as a stable identity', () => {
+    expect(mintProxyToken('https://e.test/a.png')).toBe(mintProxyToken('https://e.test/a.png'));
+  });
+
+  it('rejects a tampered payload', () => {
+    const token = mintProxyToken('https://example.com/ok.png');
+    const [, sig] = token.split('.');
+    const forged = `${Buffer.from('http://169.254.169.254/', 'utf8').toString('base64url')}.${sig}`;
+    expect(verifyProxyToken(forged)).toBeNull();
+  });
+
+  it('rejects a tampered signature', () => {
+    const token = mintProxyToken('https://example.com/ok.png');
+    const [payload] = token.split('.');
+    expect(verifyProxyToken(`${payload}.notasignature`)).toBeNull();
+  });
+
+  it('rejects structurally malformed tokens without throwing', () => {
+    for (const bad of ['', '.', 'nodot', '.onlysig', 'a.b.c']) {
+      expect(() => verifyProxyToken(bad)).not.toThrow();
+      expect(verifyProxyToken(bad)).toBeNull();
+    }
+  });
+
+  it('cannot be verified under a different secret', () => {
+    // Rotating the session secret invalidates outstanding tokens, which is the
+    // intended coupling — a stale token is a re-resolve, not a hole.
+    const token = mintProxyToken('https://example.com/a.png');
+    process.env.SESSION_SECRET = 'a-completely-different-secret';
+    resetProxyKeyCache();
+    try {
+      expect(verifyProxyToken(token)).toBeNull();
+    } finally {
+      process.env.SESSION_SECRET = 'test-secret-for-proxy-tokens';
+      resetProxyKeyCache();
+    }
+  });
+});

--- a/server/services/mediaProxyToken.ts
+++ b/server/services/mediaProxyToken.ts
@@ -60,16 +60,24 @@ export function mintProxyToken(url: string): string {
  * `timingSafeEqual` throws on a length mismatch, so the lengths are compared
  * first — and a wrong-length signature is rejected without leaking anything,
  * since the length of an HMAC-SHA256 is not a secret.
+ *
+ * ⚠ Compared as BYTES, not as string length. `String.length` counts UTF-16 code
+ * units while `timingSafeEqual` compares byte lengths, so a 43-character
+ * signature containing any multibyte character — `é` plus 42 ASCII — passed the
+ * guard and then threw `RangeError: Input buffers must have the same byte
+ * length` out of a function documented to return null. Express percent-decodes
+ * the path parameter, so that is reachable from any authenticated GET: a 500
+ * and a logged stack where a 403 belongs.
  */
 export function verifyProxyToken(token: string): string | null {
   const dot = token.lastIndexOf('.');
   if (dot <= 0) return null;
   const payload = token.slice(0, dot);
-  const provided = token.slice(dot + 1);
 
-  const expected = sign(payload);
+  const provided = Buffer.from(token.slice(dot + 1));
+  const expected = Buffer.from(sign(payload));
   if (provided.length !== expected.length) return null;
-  if (!crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected))) return null;
+  if (!crypto.timingSafeEqual(provided, expected)) return null;
 
   try {
     return Buffer.from(payload, 'base64url').toString('utf8');

--- a/server/services/mediaProxyToken.ts
+++ b/server/services/mediaProxyToken.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Signed capabilities for the byte proxy.
+//
+// The proxy endpoint fetches a URL and streams it back, which is a description
+// of an open proxy unless something constrains which URLs it will accept. That
+// something is this: the server mints a token during resolve, after the URL has
+// already passed the SSRF guard, and the proxy will serve nothing else. A client
+// can only ever REPLAY a decision the server already made — it has no way to
+// author one, because it doesn't have the key.
+//
+// This is defence in depth, not the only defence. The proxy is also
+// authenticated, and it re-runs the full guard at connect time, because the DNS
+// answer that was safe at resolve time may not be safe now. The token's job is
+// narrower: it stops the endpoint from being a general-purpose fetcher for
+// anyone who already has a session.
+//
+// The key is DERIVED from the session secret rather than being it. They have
+// different lifetimes and different blast radii — rotating the session secret
+// should invalidate sessions, and it will also invalidate outstanding proxy
+// tokens, but the reverse coupling (a proxy token being usable as session
+// material) must not exist. HKDF with a distinct label is what keeps that true.
+
+import crypto from 'node:crypto';
+import { resolveSessionSecret } from '../utils/sessionSecret.js';
+
+const INFO = Buffer.from('lurker-media-proxy-v1');
+
+let cachedKey: Buffer | null = null;
+
+function key(): Buffer {
+  if (!cachedKey) {
+    const { secret } = resolveSessionSecret();
+    cachedKey = Buffer.from(
+      crypto.hkdfSync('sha256', Buffer.from(secret), Buffer.alloc(0), INFO, 32),
+    );
+  }
+  return cachedKey;
+}
+
+/** Test-only: drop the cached key so a suite can swap the session secret. */
+export function resetProxyKeyCache(): void {
+  cachedKey = null;
+}
+
+function sign(payload: string): string {
+  return crypto.createHmac('sha256', key()).update(payload).digest('base64url');
+}
+
+/** Mint a proxy token for a URL the caller has already vetted. */
+export function mintProxyToken(url: string): string {
+  const payload = Buffer.from(url, 'utf8').toString('base64url');
+  return `${payload}.${sign(payload)}`;
+}
+
+/**
+ * Recover the URL from a token, or null if the signature doesn't check out.
+ *
+ * `timingSafeEqual` throws on a length mismatch, so the lengths are compared
+ * first — and a wrong-length signature is rejected without leaking anything,
+ * since the length of an HMAC-SHA256 is not a secret.
+ */
+export function verifyProxyToken(token: string): string | null {
+  const dot = token.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const payload = token.slice(0, dot);
+  const provided = token.slice(dot + 1);
+
+  const expected = sign(payload);
+  if (provided.length !== expected.length) return null;
+  if (!crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected))) return null;
+
+  try {
+    return Buffer.from(payload, 'base64url').toString('utf8');
+  } catch {
+    return null;
+  }
+}

--- a/server/utils/previews.test.ts
+++ b/server/utils/previews.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { previewsEnabled } from './previews.js';
+
+describe('previewsEnabled', () => {
+  const withEnv = (value: string | undefined, run: () => void) => {
+    const saved = process.env.LURKER_LINK_PREVIEWS;
+    if (value === undefined) delete process.env.LURKER_LINK_PREVIEWS;
+    else process.env.LURKER_LINK_PREVIEWS = value;
+    try {
+      run();
+    } finally {
+      if (saved === undefined) delete process.env.LURKER_LINK_PREVIEWS;
+      else process.env.LURKER_LINK_PREVIEWS = saved;
+    }
+  };
+
+  it('defaults OFF — an upgrade must not start dialling arbitrary URLs', () => {
+    // The whole feature is opt-in, not just the fetch: an operator who upgrades and does
+    // nothing gets a server that never reaches out. The Lounge ships `prefetch: false` for the
+    // same reason.
+    withEnv(undefined, () => expect(previewsEnabled()).toBe(false));
+    withEnv('', () => expect(previewsEnabled()).toBe(false));
+  });
+
+  it('is enabled only by an affirmative value', () => {
+    for (const v of ['on', 'ON', '1', 'true', 'yes', ' on ']) {
+      withEnv(v, () => expect(previewsEnabled()).toBe(true));
+    }
+  });
+
+  it('treats anything else as off rather than guessing', () => {
+    for (const v of ['off', '0', 'false', 'no', 'maybe', 'enabled?']) {
+      withEnv(v, () => expect(previewsEnabled()).toBe(false));
+    }
+  });
+});

--- a/server/utils/previews.ts
+++ b/server/utils/previews.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import { parseTruthyEnv } from './truthyEnv.js';
+
 /**
  * Whether link previews and inline media exist on this instance at all.
  *
@@ -23,6 +25,8 @@
  * its sharp, sqlite and http agents — into its module graph to read one environment variable.
  */
 export function previewsEnabled(): boolean {
-  const v = (process.env.LURKER_LINK_PREVIEWS || '').trim().toLowerCase();
-  return v === 'on' || v === '1' || v === 'true' || v === 'yes';
+  // Shares DCC's parser rather than hand-rolling a fifth truthy-env test in this codebase.
+  // Same conventional set, already unit-tested, and an operator who learns the convention once
+  // shouldn't find that `on` works for one flag and not another.
+  return parseTruthyEnv(process.env.LURKER_LINK_PREVIEWS);
 }

--- a/server/utils/previews.ts
+++ b/server/utils/previews.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * Whether link previews and inline media exist on this instance at all.
+ *
+ * ⚠ A FEATURE FLAG, defaulting to OFF — not merely a fetch switch. When it's off the routes
+ * aren't mounted, the resolver never runs, and both clients hide the two user settings rather
+ * than offering toggles that do nothing. A visible switch that silently has no effect is worse
+ * than no switch.
+ *
+ * Off by default because this is the one feature that makes the server dial arbitrary
+ * user-supplied URLs. That's the operator's bandwidth, the operator's IP reputation, and the
+ * operator's problem if someone points a channel at something — so it should be a decision
+ * somebody made, not something an upgrade turns on. The Lounge reaches the same conclusion for
+ * the same reason (`prefetch: false` in its shipped defaults).
+ *
+ * The two per-user settings remain independent and also default off: this decides whether the
+ * instance participates, those decide whether *you* see previews.
+ *
+ * ⚠ Lives in `utils/` beside `edition.ts` rather than in the resolver it gates. `app.ts` and
+ * `routes/config.ts` both need the answer, and neither should have to pull the resolver — with
+ * its sharp, sqlite and http agents — into its module graph to read one environment variable.
+ */
+export function previewsEnabled(): boolean {
+  const v = (process.env.LURKER_LINK_PREVIEWS || '').trim().toLowerCase();
+  return v === 'on' || v === '1' || v === 'true' || v === 'yes';
+}

--- a/server/utils/slotPool.test.ts
+++ b/server/utils/slotPool.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { SlotPool } from './slotPool.js';
+
+const tick = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+describe('SlotPool', () => {
+  it('hands out its slots without making anyone wait', async () => {
+    const pool = new SlotPool({ size: 3, maxQueued: 10, waitMs: 50 });
+    expect(await pool.acquire()).toBe(true);
+    expect(await pool.acquire()).toBe(true);
+    expect(await pool.acquire()).toBe(true);
+    expect(pool.inFlight).toBe(3);
+    expect(pool.queued).toBe(0);
+  });
+
+  it('queues past the size rather than refusing', async () => {
+    const pool = new SlotPool({ size: 1, maxQueued: 10, waitMs: 1000 });
+    expect(await pool.acquire()).toBe(true);
+
+    let got: boolean | null = null;
+    const waiting = pool.acquire().then((v) => (got = v));
+    await tick();
+    expect(got).toBeNull();
+    expect(pool.queued).toBe(1);
+
+    pool.release();
+    await waiting;
+    expect(got).toBe(true);
+    // Still one slot out — it moved from the releaser to the waiter, it wasn't returned.
+    expect(pool.inFlight).toBe(1);
+    expect(pool.queued).toBe(0);
+  });
+
+  it('hands a freed slot to the WAITER, not to whoever asks next', async () => {
+    // ⚠⚠ Regression guard. A released slot used to go back into the pool for anyone to grab,
+    // with the woken waiter re-checking the count on a later turn of the loop — so a fresh
+    // arrival could take it synchronously and the waiter would spin until its deadline, having
+    // already cleared it. Under a steady arrival rate that waiter starves indefinitely.
+    const pool = new SlotPool({ size: 1, maxQueued: 10, waitMs: 1000 });
+    await pool.acquire();
+
+    const order: string[] = [];
+    const waiter = pool.acquire().then((ok) => order.push(`waiter:${ok}`));
+    await tick();
+
+    pool.release();
+    // A latecomer asking in the very same tick as the release must NOT get in first.
+    const latecomer = pool.acquire().then((ok) => order.push(`latecomer:${ok}`));
+
+    await waiter;
+    expect(order[0]).toBe('waiter:true');
+
+    pool.release();
+    await latecomer;
+    expect(order[1]).toBe('latecomer:true');
+  });
+
+  it('refuses immediately once the queue is full', async () => {
+    const pool = new SlotPool({ size: 1, maxQueued: 2, waitMs: 1000 });
+    await pool.acquire();
+    const parked = [pool.acquire(), pool.acquire()];
+    await tick();
+    expect(pool.queued).toBe(2);
+
+    // The third would-be waiter is turned away rather than growing the queue.
+    expect(await pool.acquire()).toBe(false);
+
+    pool.release();
+    await parked[0];
+    pool.release();
+    await parked[1];
+  });
+
+  it('gives up after the deadline without taking a slot with it', async () => {
+    const pool = new SlotPool({ size: 1, maxQueued: 10, waitMs: 20 });
+    await pool.acquire();
+
+    expect(await pool.acquire()).toBe(false);
+    expect(pool.queued).toBe(0);
+    // The one real holder still holds exactly one slot: giving up must not have counted as
+    // taking one, or the pool would shrink by a slot for every timeout it ever serves.
+    expect(pool.inFlight).toBe(1);
+
+    pool.release();
+    expect(pool.inFlight).toBe(0);
+    expect(await pool.acquire()).toBe(true);
+  });
+
+  it('does not hand a slot to a caller that already gave up', async () => {
+    const pool = new SlotPool({ size: 1, maxQueued: 10, waitMs: 20 });
+    await pool.acquire();
+    expect(await pool.acquire()).toBe(false);
+
+    // The release finds no live waiter, so the slot goes back to the pool rather than being
+    // handed to a promise nobody is awaiting any more.
+    pool.release();
+    expect(pool.inFlight).toBe(0);
+  });
+});

--- a/server/utils/slotPool.ts
+++ b/server/utils/slotPool.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// A counting semaphore with a bounded queue and a wait deadline.
+//
+// Extracted from the link-preview resolver rather than left inline because its two interesting
+// properties — a slot is HANDED OVER rather than released into a contest, and a caller that
+// gives up waiting must not leak the slot it never took — are exactly the kind that break
+// silently under load and can't be observed from an HTTP test. Both had already shipped as
+// bugs once (see the notes on `release` and `acquire`).
+
+interface Waiter {
+  settled: boolean;
+  timer: ReturnType<typeof setTimeout>;
+  resolve: (got: boolean) => void;
+}
+
+export interface SlotPoolConfig {
+  /** Slots available at once. */
+  size: number;
+  /** Callers allowed to park waiting for one. A flood must not grow this without limit. */
+  maxQueued: number;
+  /** How long a caller waits before giving up. */
+  waitMs: number;
+}
+
+export class SlotPool {
+  private taken = 0;
+  private waiters: Waiter[] = [];
+
+  constructor(private readonly cfg: SlotPoolConfig) {}
+
+  /** Slots currently held. */
+  get inFlight(): number {
+    return this.taken;
+  }
+
+  /** Callers parked waiting for one. */
+  get queued(): number {
+    return this.waiters.length;
+  }
+
+  /**
+   * Take a slot, waiting if none is free. Resolves false only if it gave up — either the queue
+   * was already full or the deadline lapsed.
+   *
+   * ⚠ A `false` means "we couldn't ask right now", never "this work is impossible". Callers
+   * must not cache a verdict derived from it.
+   */
+  async acquire(): Promise<boolean> {
+    if (this.taken < this.cfg.size) {
+      this.taken++;
+      return true;
+    }
+    if (this.waiters.length >= this.cfg.maxQueued) return false;
+
+    return await new Promise<boolean>((resolve) => {
+      const waiter: Waiter = {
+        settled: false,
+        resolve,
+        timer: setTimeout(() => {
+          if (waiter.settled) return;
+          waiter.settled = true;
+          const at = this.waiters.indexOf(waiter);
+          if (at !== -1) this.waiters.splice(at, 1);
+          // No decrement: this caller never held a slot, it was only queued for one.
+          resolve(false);
+        }, this.cfg.waitMs),
+      };
+      waiter.timer.unref?.();
+      this.waiters.push(waiter);
+    });
+  }
+
+  /**
+   * Give a slot back.
+   *
+   * ⚠ The slot is HANDED OVER to the next waiter, not released into a free-for-all, and the
+   * counter is deliberately NOT decremented on that path. An earlier version woke a waiter and
+   * had it re-check the count in a `while (…) await setImmediate` loop — so a brand-new caller
+   * could take the just-freed slot synchronously before the woken waiter's microtask ran,
+   * leaving the waiter spinning on setImmediate with its own timeout already cleared: a starved
+   * caller burning a core, and an HTTP request hanging well past the bound meant to prevent
+   * exactly that.
+   */
+  release(): void {
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift() as Waiter;
+      // Belt and braces: a settled waiter is spliced out by its own timer, so it shouldn't be
+      // here — but skipping rather than handing it the slot is what keeps a lost race from
+      // silently shrinking the pool for the life of the process.
+      if (waiter.settled) continue;
+      waiter.settled = true;
+      clearTimeout(waiter.timer);
+      waiter.resolve(true);
+      return;
+    }
+    this.taken--;
+  }
+}

--- a/server/utils/truthyEnv.ts
+++ b/server/utils/truthyEnv.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/** Conventional truthy env values — trimmed + case-insensitive. */
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+/**
+ * Parse a raw environment value to a boolean, the same way everywhere.
+ *
+ * Pure (no env access) so the rule is unit-testable, and shared so an operator who learns that
+ * `on` works for one flag doesn't discover it silently doesn't for another. Unset, empty, and
+ * anything unrecognised are all OFF: every flag that reads this is an opt-in, and a
+ * misunderstood value must fail closed rather than guess.
+ */
+export function parseTruthyEnv(raw: string | undefined): boolean {
+  return TRUTHY.has((raw ?? '').trim().toLowerCase());
+}

--- a/server/utils/withDeadline.test.ts
+++ b/server/utils/withDeadline.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { withDeadline, DeadlineExceeded } from './withDeadline.js';
+
+const after = <T>(ms: number, value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), ms));
+
+describe('withDeadline', () => {
+  it('passes work that finishes in time straight through', async () => {
+    expect(await withDeadline(after(5, 'done'), 500)).toBe('done');
+  });
+
+  it('rejects with a distinguishable error once the deadline lapses', async () => {
+    // Distinguishable on purpose: running out of time says nothing about the work, so a caller
+    // must be able to avoid recording it as a verdict.
+    await expect(withDeadline(after(500, 'late'), 20, 'resolve')).rejects.toBeInstanceOf(
+      DeadlineExceeded,
+    );
+  });
+
+  it('lets the work’s own failure through rather than masking it', async () => {
+    const boom = Promise.reject(new TypeError('the actual problem'));
+    await expect(withDeadline(boom, 500)).rejects.toBeInstanceOf(TypeError);
+  });
+});

--- a/server/utils/withDeadline.ts
+++ b/server/utils/withDeadline.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/** Thrown when work loses its race against a deadline, so a caller can tell that apart from
+ *  the work itself failing — one is a fact about a moment, the other about the work. */
+export class DeadlineExceeded extends Error {}
+
+/**
+ * Race a promise against a deadline.
+ *
+ * ⚠ Losing the race ABANDONS the work rather than cancelling it — there is no cancellation in
+ * a plain promise, so an in-flight fetch keeps its socket until its own timeout fires. What
+ * this bounds is how long a caller waits and how long any resource it holds on the way in (a
+ * pool slot, an HTTP response) is held hostage. That is the part that affects everyone else,
+ * and claiming more than that would be a comment asserting a guarantee it doesn't provide.
+ *
+ * The timer is cleared on both outcomes and unref'd, so a pending deadline can never be the
+ * reason the process stays up.
+ */
+export async function withDeadline<T>(work: Promise<T>, ms: number, what = 'work'): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new DeadlineExceeded(`${what} exceeded ${ms}ms`)), ms);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -50,6 +50,12 @@ interface BaseOption {
   // reference pattern: hidden here, enforced in the cell's upload route.
   selfHostedOnly?: boolean;
 
+  // This option only exists when the named instance feature is enabled. Unlike `selfHostedOnly`
+  // (a cosmetic gate on a knob that still works), a flagged-off feature has no server behind it
+  // at all — the routes aren't even mounted — so the option is HIDDEN rather than shown and
+  // ignored. Offering a switch that silently does nothing is worse than offering none.
+  requiresFeature?: 'linkPreviews';
+
   // Conditions under which this setting actually does anything, ORed together:
   // the option is live if ANY clause holds. Resolution is TRANSITIVE — an
   // option whose dependency is itself inactive is inactive too, so a chain like
@@ -1001,6 +1007,44 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
       'When enabled, clicking a link to an image, video, audio file, or .txt opens it ' +
       'in an in-app viewer instead of a new browser tab. Cmd/Ctrl-click always opens ' +
       'in a new tab.',
+  },
+
+  // ─── Inline media & link previews ─────────────────────────────────────
+  //
+  // Two keys rather than one, because wanting one does not imply wanting the
+  // other. Seeing the screenshots your friends paste is a different appetite
+  // from having every news article sprout a card, and plenty of people want
+  // exactly one of them.
+  //
+  // Both default OFF. Neither is device-split: if you want images inline you
+  // want them inline everywhere. (Contrast `chat.events`, which IS device-split
+  // because screen size genuinely changes the right answer.)
+  {
+    key: 'chat.inline_media.enabled',
+    requiresFeature: 'linkPreviews',
+    label: 'Inline media',
+    category: 'chat',
+    group: 'viewing',
+    type: 'bool',
+    default: false,
+    description:
+      'When enabled, a link that points straight at an image, video, or audio file ' +
+      'renders under the message instead of showing only as a link. The file is fetched ' +
+      'and served by your Lurker server, so the site hosting it never sees your device.',
+  },
+  {
+    key: 'chat.link_previews.enabled',
+    requiresFeature: 'linkPreviews',
+    label: 'Link previews',
+    category: 'chat',
+    group: 'viewing',
+    type: 'bool',
+    default: false,
+    description:
+      'When enabled, a link to a web page renders a small card with its title, ' +
+      'description, and thumbnail. Your Lurker server fetches the page — your device ' +
+      'never contacts the site. Video links get a play button, and nothing is sent to ' +
+      'the video host until you press it.',
   },
 
   // ─── Connection ───────────────────────────────────────────────────────

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2696,7 +2696,14 @@ async function runNetwork(
 // Notifications still own registry-backed keys, which belong in the surface.
 function settingExposed(opt: SettingOption): boolean {
   return (
-    CATEGORIES.some((c) => c.id === opt.category) && optionVisible(opt, { isNode: config.isNode })
+    CATEGORIES.some((c) => c.id === opt.category) &&
+    // ⚠ Same visibility rule as the settings pane, deliberately. `/set` is a first-class way to
+    // operate every setting, so a key hidden in one surface and offered in the other is a
+    // half-hidden feature — and `requiresFeature` keys have no server behind them at all.
+    optionVisible(opt, {
+      isNode: config.isNode,
+      features: { linkPreviews: config.linkPreviews },
+    })
   );
 }
 

--- a/vue_client/src/components/SettingsSidebar.vue
+++ b/vue_client/src/components/SettingsSidebar.vue
@@ -101,7 +101,8 @@
 import { ref, computed, watch, nextTick } from 'vue';
 import { useRouter } from 'vue-router';
 import type { SettingCategory } from '../../../shared/settingsRegistry.js';
-import { REGISTRY, CATEGORIES } from '../utils/settingsRegistry.js';
+import { REGISTRY, CATEGORIES, optionVisible } from '../utils/settingsRegistry.js';
+import { useConfigStore } from '../stores/config.js';
 
 const props = defineProps<{
   activeCategoryId: string;
@@ -120,17 +121,30 @@ interface SettingsSubsection {
 }
 
 const router = useRouter();
+const config = useConfigStore();
 const searchInput = ref('');
 const searchEl = ref<HTMLInputElement | null>(null);
 
 const searchActive = computed(() => searchInput.value.trim().length > 0);
 
-// Build the searchable index once: every registry entry, tagged with its
-// resolved category label for breadcrumb display. Bespoke-only state (highlight
-// rule lists, ignore masks, push subscriptions) is intentionally NOT searchable
-// — that's list data, not settings.
-const SEARCH_INDEX = REGISTRY.filter((opt) => CATEGORIES.some((c) => c.id === opt.category)).map(
-  (opt) => {
+// The searchable index: every registry entry, tagged with its resolved category label for
+// breadcrumb display. Bespoke-only state (highlight rule lists, ignore masks, push
+// subscriptions) is intentionally NOT searchable — that's list data, not settings.
+//
+// ⚠ A computed, not a module-scope const, because it has to apply the same `optionVisible`
+// rule the panes and `/set` do — and the feature flags it depends on arrive from /api/config
+// AFTER this module is evaluated. Built once at import time it both ignored the rule and
+// couldn't have honoured it: settings for a feature the instance doesn't have stayed
+// searchable, and picking one navigated to a pane where the row does not exist.
+const searchIndex = computed(() =>
+  REGISTRY.filter(
+    (opt) =>
+      CATEGORIES.some((c) => c.id === opt.category) &&
+      optionVisible(opt, {
+        isNode: config.isNode,
+        features: { linkPreviews: config.linkPreviews },
+      }),
+  ).map((opt) => {
     const cat = CATEGORIES.find((c) => c.id === opt.category);
     return {
       key: opt.key,
@@ -139,14 +153,14 @@ const SEARCH_INDEX = REGISTRY.filter((opt) => CATEGORIES.some((c) => c.id === op
       categoryId: opt.category,
       categoryLabel: cat?.label || opt.category,
     };
-  },
+  }),
 );
 
 const searchResults = computed(() => {
   const q = searchInput.value.trim().toLowerCase();
   if (!q) return [];
   const out = [];
-  for (const row of SEARCH_INDEX) {
+  for (const row of searchIndex.value) {
     let score = 0;
     if (row.label.toLowerCase().includes(q)) score = 3;
     else if (row.description.toLowerCase().includes(q)) score = 2;

--- a/vue_client/src/components/settings-panes/RegistryPane.vue
+++ b/vue_client/src/components/settings-panes/RegistryPane.vue
@@ -85,7 +85,10 @@ const groups = computed(() => {
     (opt) =>
       opt.category === props.categoryId &&
       (!props.only || props.only.includes(opt.group || '_')) &&
-      optionVisible(opt, { isNode: config.isNode }),
+      optionVisible(opt, {
+        isNode: config.isNode,
+        features: { linkPreviews: config.linkPreviews },
+      }),
   );
   if (!items.length) return [];
   const groupsMap = new Map<string, SettingOption[]>();

--- a/vue_client/src/stores/config.ts
+++ b/vue_client/src/stores/config.ts
@@ -12,6 +12,12 @@ import { api } from '../api.js';
 
 export type Edition = 'standalone' | 'node';
 
+/** Instance feature flags from /api/config. Absent means off — a server that doesn't advertise
+ *  a flag doesn't have the feature. */
+export interface Features {
+  linkPreviews: boolean;
+}
+
 // Shared in-flight fetch so concurrent callers — App.vue's boot fetch and the
 // router guard on a cold /admin deep-link — coalesce onto one request instead
 // of each firing their own GET /api/config. Module-scoped (not store state) so
@@ -21,11 +27,17 @@ let inflight: Promise<Edition> | null = null;
 export const useConfigStore = defineStore('config', {
   state: () => ({
     edition: 'standalone' as Edition,
+    // ⚠ Defaults to OFF, unlike `edition`, which defaults to the fully-featured value. A fetch
+    // failure must not conjure a feature the server may not have: guessing "on" here would show
+    // the two settings and then have every resolve 404.
+    features: { linkPreviews: false } as Features,
     checked: false,
   }),
   getters: {
     // True when this client is talking to a hosted cell, not a self-hosted box.
     isNode: (s): boolean => s.edition === 'node',
+    /** Whether this instance has link previews / inline media enabled at all. */
+    linkPreviews: (s): boolean => s.features.linkPreviews === true,
   },
   actions: {
     async fetch(): Promise<Edition> {
@@ -33,8 +45,9 @@ export const useConfigStore = defineStore('config', {
       if (inflight) return inflight; // a fetch is in flight — share its result
       inflight = (async () => {
         try {
-          const data = await api<{ edition?: string }>('/api/config');
+          const data = await api<{ edition?: string; features?: Partial<Features> }>('/api/config');
           this.edition = data.edition === 'node' ? 'node' : 'standalone';
+          this.features = { linkPreviews: data.features?.linkPreviews === true };
           // Latch `checked` ONLY on success. A transient failure must not wedge
           // the session on the safe defaults — leaving it false lets the next
           // caller retry and self-heal. That second caller is the router guard,

--- a/vue_client/src/utils/settingsRegistry.test.ts
+++ b/vue_client/src/utils/settingsRegistry.test.ts
@@ -75,6 +75,28 @@ describe('optionVisible', () => {
   it('keeps paste-to-upload (a client UX pref, not a cost knob) visible in node edition', () => {
     expect(optionVisible(opt('uploads.paste.enabled'), { isNode: true })).toBe(true);
   });
+
+  it('hides a requiresFeature setting unless the instance advertises the feature', () => {
+    // Unlike selfHostedOnly — a cosmetic gate on a knob that still works — a flagged-off
+    // feature has no routes mounted at all, so the toggle would be inert. Both directions
+    // asserted: an absent flag object must read as off, not as unknown-so-show.
+    for (const key of ['chat.inline_media.enabled', 'chat.link_previews.enabled']) {
+      expect(optionVisible(opt(key), { isNode: false })).toBe(false);
+      expect(optionVisible(opt(key), { isNode: false, features: {} })).toBe(false);
+      expect(optionVisible(opt(key), { isNode: false, features: { linkPreviews: false } })).toBe(
+        false,
+      );
+      expect(optionVisible(opt(key), { isNode: false, features: { linkPreviews: true } })).toBe(
+        true,
+      );
+    }
+  });
+
+  it('leaves settings with no requiresFeature untouched by the flags', () => {
+    expect(optionVisible(opt('chat.image_modal.enabled'), { isNode: false, features: {} })).toBe(
+      true,
+    );
+  });
 });
 
 describe('optionEnabled (#666)', () => {

--- a/vue_client/src/utils/settingsRegistry.ts
+++ b/vue_client/src/utils/settingsRegistry.ts
@@ -45,9 +45,17 @@ export function categoryVisible(cat: SettingCategory, ctx: VisibilityContext): b
   return true;
 }
 
-/** Whether an individual registry setting renders, given the edition. */
-export function optionVisible(opt: SettingOption, ctx: Pick<VisibilityContext, 'isNode'>): boolean {
+/** Whether an individual registry setting renders, given the edition and the instance's
+ *  feature flags. */
+export function optionVisible(
+  opt: SettingOption,
+  ctx: Pick<VisibilityContext, 'isNode'> & { features?: Partial<Record<'linkPreviews', boolean>> },
+): boolean {
   if (opt.selfHostedOnly && ctx.isNode) return false;
+  // A feature the instance hasn't enabled has no server behind it, so its settings are hidden
+  // rather than rendered inert. Absent flags read as off: an older server that doesn't
+  // advertise the feature doesn't have it.
+  if (opt.requiresFeature && ctx.features?.[opt.requiresFeature] !== true) return false;
   return true;
 }
 


### PR DESCRIPTION
Fourth of six. The lazy resolver from `LINK_PREVIEWS.md` §1: a client asks about a URL, the server fetches it once, and the answer is cached by URL rather than by user or by message.

**Everything lands dormant.** `LURKER_LINK_PREVIEWS` is off by default, so the routes aren't mounted, the resolver never runs, and both settings are hidden rather than rendered inert.

## What PRs 2 and 3 handed forward

| From | Applied |
|---|---|
| PR 2 | `previewsEnabled()` re-added in `server/utils/` beside `edition.ts` — `app.ts` and `routes/config.ts` both need it and neither should pull sharp, sqlite and two http agents into its module graph to read one env var |
| PR 3 | Call site is `decodeBody(body, buffered.charset)`. A live origin serving cp1251 with the charset only in the header returns replacement characters without it |
| PR 3 | `imageUrl` is not decoded a second time — both producers decode at their own boundary, and a second pass turns the literal `&amp;amp;` into `&` |
| PR 3 | `embedUrl` is checked against `isEmbeddableOrigin` on the way out: the one field a client puts in an `<iframe>`, arriving from a cache row, with no CSP anywhere in this repo |
| PR 3 | `ogType` **deleted** rather than carried a fourth time — the provider table decides a video card |
| PR 3 | `twitter:site` **dropped** as a `siteName` fallback — it's an @handle naming an account, so `@nytimes` was landing in the card's site slot |

## Review found 15, all reproducible

`/code-review max` ran **before** this PR was opened, so the fixes are in the diff rather than in a follow-up nobody re-reviews. Six of the fifteen were in the byte proxy — the one surface with no end-to-end test, since every existing test either mocked it away or asserted a refusal. It has its own live-origin suite now.

The ones worth reading:

- **Two paths answered 500 where they meant 403 and 400.** `verifyProxyToken` compared signature lengths in UTF-16 code units while `timingSafeEqual` compares bytes, so `%C3%A9` in a URL threw `RangeError` from above the route's try. And Express 5 leaves `req.body` *undefined* for non-JSON, so the 400 below it was dead code.
- **The 64 MB media cap was unreachable.** The hop deadline isn't cleared during a body transfer, so anything still streaming at 20 s was cut; the 5 s idle timeout fires on a backpressured `<video>`, which is normal playback. `FetchOptions.streaming` trades the deadline for a 30 s idle allowance once headers are in. Proved both ways against an origin that pauses mid-body.
- **The 206 path walked straight past the cap** — `Content-Length` on a partial response is the length of the *part*, so a gigabyte fetched a megabyte at a time passed every check. The size is after the slash in `Content-Range`.
- **The byte route never took a pool slot**, while the resolver's pool documents itself as the bound on outstanding uncancellable DNS lookups — and the byte endpoint is the higher-volume half, one request per image on screen. It has its own pool now.
- **The cache had two identities for one thing** (`urlHash` keyed the raw string, so host case and a default port were separate rows — a one-character cache bypass), and **an index nothing could use**: `datetime(expires_at)` is correct and non-sargable, verified by `EXPLAIN QUERY PLAN`, while the sweep runs at boot and hourly on the shared connection.
- **Four ways a good preview was thrown away**, including a YouTube link whose provider oEmbed call failed discarding the embed URL it was already holding — and caching that for an hour.

## Three bugs found while writing tests, before review

- A cache hit echoed the *row's* URL. The key strips fragments, so the column holds whichever anchor arrived first — every later reader's client-side lookup missed. Renders for exactly one person.
- In-flight dedupe keyed the request string while the cache keys the stripped URL, so three anchors of one page cost three fetches.
- `fetchOEmbed` resolved outside the `try`; a malformed href cost the page its whole preview when oEmbed is the optional path.

## Two judgment calls

**Scope.** `shared/settingsRegistry.ts` gains the two options, so ~30 lines of PR 5's Vue came with them (config store, `optionVisible`, and all three call sites — settings pane, `/set` completion, search index). Without them this ships two toggles that appear for everyone and do nothing.

**DNS starvation is deferred, and the comment says so.** `MAX_CONCURRENT` stays tied to batch size: lowering it doesn't bound lookups (a destroyed request keeps its `getaddrinfo` slot for the full OS timeout while a new fetch takes the freed one) and does re-risk the E-class starvation the size prevents. The real fix is a cancellable `dns.Resolver`, which belongs in the fetcher.

## Gates

`npm run check` and `npm test` green standalone — 239 files, 3306 tests.

Every regression test was confirmed by reverting its fix and watching that specific test go red. ⚠ Three did **not** fail, and were rewritten: the `MAX_CONCURRENT` guard review proved was green with the cap at 6, an `EXPLAIN QUERY PLAN` assertion written against a hand-pasted copy of the query, and an embed-survival test that stopped at `toDescriptor` and never reached the rule it named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
