### PR TITLE
Link previews: the Vue client

### DIFF
--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -91,6 +91,15 @@
   --icon-md: 1.1em;
   --icon-lg: 1.2em;
 
+  /* The raised panel a link-preview card sits on, so it reads as a distinct object
+     rather than as more chat text (Discord's treatment).
+     ⚠ Must differ from BOTH --bg (the chat background) and --bg-soft, because --bg-soft
+     is the message row's hover fill — a card painted --bg-soft would vanish the moment
+     you moved the pointer over its row. Derived rather than literal so it tracks whatever
+     theme the user has chosen: one step further from the background than hover is, in the
+     same direction. */
+  --embed-bg: color-mix(in srgb, var(--fg) 6%, var(--bg-soft));
+
   /* Corner radii. The app is intentionally flat (most things are square);
      these are the few deliberate exceptions. */
   --radius-sm: 2px;

--- a/vue_client/src/components/MediaViewerModal.vue
+++ b/vue_client/src/components/MediaViewerModal.vue
@@ -208,6 +208,8 @@ const DOUBLE_TAP_SLOP_PX = 32;
 const props = withDefaults(
   defineProps<{
     url: string;
+    /** What "copy link" should yield, when it differs from what we render. See GalleryItem. */
+    shareUrl?: string | null;
     // Gallery context (#547). All optional: a lone image opened from a message is a
     // gallery of one, and every one of these falls away to its single-image default.
     filename?: string | null;
@@ -403,7 +405,16 @@ function openInBrowser(): void {
 // something you do while still looking at the picture, and often while walking a
 // gallery. Closing would make copying two images in a row a chore.
 function onCopyLink(): void {
-  void clipboard.copy(props.url);
+  // ⚠ Absolute, and the share address rather than the rendered one. A relative path is not a
+  // link anyone can use — pasting it into a chat gives the reader a 404 at best.
+  const target = props.shareUrl || props.url;
+  let absolute = target;
+  try {
+    absolute = new URL(target, window.location.href).href;
+  } catch {
+    // A value URL couldn't parse is one we shouldn't rewrite; copy it as-is.
+  }
+  void clipboard.copy(absolute);
 }
 
 function toggleZoomFromCenter(): void {

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -164,12 +164,27 @@ describe('MessageAttachment — the click must not be eaten', () => {
     expect(img.attributes('tabindex')).toBeUndefined();
   });
 
-  it('is reachable from the keyboard when the viewer IS on', () => {
+  it('is reachable from the keyboard when the viewer IS on, and is NAMED', () => {
+    // ⚠ The name is the half that's easy to miss. `alt=""` is correct for a decorative image and
+    // stops being sufficient the instant `role="button"` is applied — the img role that gave the
+    // empty alt its meaning is gone, leaving a focusable control with no accessible name. The
+    // filename is carried so a strip of several doesn't present identically-named buttons.
     seedSettings();
     const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
     const img = wrapper.find('.inline-image');
     expect(img.attributes('role')).toBe('button');
     expect(img.attributes('tabindex')).toBe('0');
+    expect(img.attributes('aria-label')).toBe('Open image: a.png');
+  });
+
+  it('carries no name, and no role, when it is not a control', () => {
+    seedSettings();
+    useSettingsStore().values['chat.image_modal.enabled'] = false;
+    const img = mount(MessageAttachment, { props: { preview: IMAGE } }).find('.inline-image');
+    expect(img.attributes('role')).toBeUndefined();
+    expect(img.attributes('aria-label')).toBeUndefined();
+    // Still decorative, which is what an empty alt is for.
+    expect(img.attributes('alt')).toBe('');
   });
 
   it('activates on Enter and Space, not only on a mouse click', async () => {

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -1,0 +1,345 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// Two levels, matching the split in the components:
+//   - MessageAttachment renders ONE resolved preview.
+//   - MessageAttachments decides the ARRANGEMENT (strip vs stacked) and does the settings
+//     gating, since it needs the resolved set anyway to make that decision.
+//
+// The first suite exists because QA saw no YouTube card while the server was verified to be
+// answering correctly — nothing was testing the span between those two facts.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import MessageAttachment from './MessageAttachment.vue';
+import MessageAttachments from './MessageAttachments.vue';
+import type { LinkPreview } from '../composables/useLinkPreview.js';
+import { useSettingsStore } from '../stores/settings.js';
+import { useConfigStore } from '../stores/config.js';
+import { useMediaViewer } from '../composables/useMediaViewer.js';
+
+// Resolution is driven by message ingest, so components only read — stub the read. A real
+// `ref` is required: the templates rely on Vue's auto-unwrapping, which is keyed on `isRef`.
+const resolved = new Map<string, LinkPreview>();
+vi.mock('../composables/useLinkPreview.js', () => ({
+  useLinkPreview: (url: string) => ref(resolved.get(url) ?? null),
+}));
+
+function preview(over: Partial<LinkPreview> & { url: string }): LinkPreview {
+  return {
+    status: 'ok',
+    kind: 'page',
+    expiresAt: '2099-01-01T00:00:00Z',
+    ...over,
+  } as LinkPreview;
+}
+
+const YOUTUBE = preview({
+  url: 'https://www.youtube.com/watch?v=6yRUqNmcI_M',
+  kind: 'video-embed',
+  title: 'PAPA NUGS & DJ ADHD - THE VOICES',
+  siteName: 'YouTube',
+  author: 'Maslow Unknown',
+  thumb: '/api/link-preview/media/tok',
+  embedUrl: 'https://www.youtube-nocookie.com/embed/6yRUqNmcI_M?autoplay=1&rel=0',
+});
+
+const IMAGE = preview({
+  url: 'https://e.test/a.png',
+  kind: 'image',
+  src: '/api/link-preview/media/tok2',
+  thumbWidth: 800,
+  thumbHeight: 600,
+  mime: 'image/png',
+});
+
+function seedSettings({ inlineMedia = true, linkPreviews = true, feature = true } = {}) {
+  setActivePinia(createPinia());
+  // The instance feature flag gates both user settings — a stored `true` must not render on an
+  // instance that has the feature off, where the routes aren't even mounted. Defaults on here so
+  // the suite is about the user settings; `feature: false` covers the gate itself.
+  useConfigStore().features = { linkPreviews: feature };
+  const settings = useSettingsStore();
+  // Real store values rather than a mocked getter: `effective` is a Pinia getter returning a
+  // closure, so it can't be spied — and seeding state exercises the same lookup the app does.
+  settings.values = {
+    'chat.inline_media.enabled': inlineMedia,
+    'chat.link_previews.enabled': linkPreviews,
+    'chat.image_modal.enabled': true,
+  };
+  settings.loaded = true;
+}
+
+describe('MessageAttachment — video embed', () => {
+  beforeEach(() => seedSettings());
+
+  it('renders a card for a resolved YouTube descriptor', () => {
+    const wrapper = mount(MessageAttachment, { props: { preview: YOUTUBE } });
+    expect(wrapper.find('.card').exists()).toBe(true);
+    expect(wrapper.text()).toContain('PAPA NUGS');
+    expect(wrapper.text()).toContain('YouTube');
+  });
+
+  it('shows the play facade, and NOT an iframe, before any click', () => {
+    const wrapper = mount(MessageAttachment, { props: { preview: YOUTUBE } });
+    expect(wrapper.find('.card-play').exists()).toBe(true);
+    // The privacy property: nothing reaches the video host on render.
+    expect(wrapper.find('iframe').exists()).toBe(false);
+  });
+
+  it('creates the iframe only once the play button is clicked', async () => {
+    const wrapper = mount(MessageAttachment, { props: { preview: YOUTUBE } });
+    await wrapper.find('.card-play').trigger('click');
+    expect(wrapper.find('iframe').attributes('src')).toContain('youtube-nocookie.com');
+  });
+
+  it('points the thumbnail at our proxy, never at the origin', () => {
+    const wrapper = mount(MessageAttachment, { props: { preview: YOUTUBE } });
+    expect(wrapper.find('.card-thumb-wide').attributes('src')).toBe('/api/link-preview/media/tok');
+  });
+
+  it('falls back to a plain card when the kind says video but no embedUrl came with it', () => {
+    // ⚠ `kind: 'video-embed'` and `embedUrl` are NOT a guaranteed pair on the wire. The origin
+    // allowlist can recognise a page as a video and still withhold the embed URL, and while the
+    // server currently downgrades that case to `page`, a client that assumes the pairing renders
+    // a play button wired to `src="undefined"` — a facade that swallows the click and can never
+    // produce a player. Degrade to the ordinary card, which still links out.
+    const wrapper = mount(MessageAttachment, {
+      props: { preview: preview({ ...YOUTUBE, embedUrl: undefined }) },
+    });
+    expect(wrapper.find('.card').exists()).toBe(true);
+    expect(wrapper.find('.card-play').exists()).toBe(false);
+    expect(wrapper.find('iframe').exists()).toBe(false);
+    // The thumbnail survives, in its small right-aligned form.
+    expect(wrapper.find('.card-thumb').attributes('src')).toBe('/api/link-preview/media/tok');
+    expect(wrapper.find('.card-title').attributes('href')).toBe(YOUTUBE.url);
+  });
+});
+
+describe('MessageAttachment — inline image', () => {
+  beforeEach(() => seedSettings());
+
+  it('renders through the proxy with its real dimensions', () => {
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    const img = wrapper.find('img.inline-image');
+    expect(img.attributes('src')).toBe('/api/link-preview/media/tok2');
+    // Load-bearing: these reserve the box before the bytes arrive.
+    expect(img.attributes('width')).toBe('800');
+    expect(img.attributes('height')).toBe('600');
+  });
+
+  it('takes its height from the row when it is in a strip', () => {
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE, inStrip: true } });
+    expect(wrapper.find('img').classes()).toContain('strip-item');
+  });
+});
+
+describe('MessageAttachments — arrangement', () => {
+  beforeEach(() => resolved.clear());
+
+  function seed(...previews: LinkPreview[]) {
+    for (const p of previews) resolved.set(p.url, p);
+  }
+
+  const img = (n: number, w: number, h: number) =>
+    preview({
+      url: `https://e.test/${n}.png`,
+      kind: 'image',
+      src: `/api/link-preview/media/t${n}`,
+      thumbWidth: w,
+      thumbHeight: h,
+    });
+
+  function mountFor(text: string, opts = {}) {
+    seedSettings(opts);
+    return mount(MessageAttachments, { props: { text } });
+  }
+
+  it('leaves a single image on its own rather than in a one-item strip', () => {
+    seed(img(1, 800, 600));
+    const wrapper = mountFor('https://e.test/1.png');
+    expect(wrapper.find('.filmstrip').exists()).toBe(false);
+    expect(wrapper.find('img.inline-image').exists()).toBe(true);
+  });
+
+  it('puts two or more images into one horizontal strip', () => {
+    // Three portrait screenshots stacked is most of a screen of somebody else's message.
+    seed(img(1, 800, 600), img(2, 800, 600));
+    const strip = mountFor('https://e.test/1.png https://e.test/2.png').find('.filmstrip');
+    expect(strip.exists()).toBe(true);
+    expect(strip.findAll('img').length).toBe(2);
+  });
+
+  it('uses the landscape row height when the group is mostly wide', () => {
+    seed(img(1, 800, 600), img(2, 1200, 500));
+    const wrapper = mountFor('https://e.test/1.png https://e.test/2.png');
+    expect(wrapper.find('.filmstrip').attributes('style')).toContain('200px');
+  });
+
+  it('uses the taller row height when the group is mostly portrait', () => {
+    seed(img(1, 600, 900), img(2, 500, 1000));
+    const wrapper = mountFor('https://e.test/1.png https://e.test/2.png');
+    expect(wrapper.find('.filmstrip').attributes('style')).toContain('300px');
+  });
+
+  it('does not let one tall image make a wide group tall', () => {
+    // "Primarily portrait", not "any portrait".
+    seed(img(1, 600, 900), img(2, 1200, 500), img(3, 1000, 400));
+    const wrapper = mountFor('https://e.test/1.png https://e.test/2.png https://e.test/3.png');
+    expect(wrapper.find('.filmstrip').attributes('style')).toContain('200px');
+  });
+
+  it('keeps cards out of the strip', () => {
+    seed(img(1, 800, 600), img(2, 800, 600), YOUTUBE);
+    const wrapper = mountFor(`https://e.test/1.png https://e.test/2.png ${YOUTUBE.url}`);
+    expect(wrapper.find('.filmstrip').findAll('img').length).toBe(2);
+    expect(wrapper.find('.card').exists()).toBe(true);
+  });
+
+  it('renders nothing at all when both settings are off', () => {
+    seed(img(1, 800, 600), YOUTUBE);
+    const wrapper = mountFor(`https://e.test/1.png ${YOUTUBE.url}`, {
+      inlineMedia: false,
+      linkPreviews: false,
+    });
+    expect(wrapper.find('.attachments').exists()).toBe(false);
+  });
+
+  it('gates media and cards on their own settings, by the server answer', () => {
+    seed(img(1, 800, 600), YOUTUBE);
+    const text = `https://e.test/1.png ${YOUTUBE.url}`;
+
+    const mediaOnly = mountFor(text, { inlineMedia: true, linkPreviews: false });
+    expect(mediaOnly.find('img.inline-image').exists()).toBe(true);
+    expect(mediaOnly.find('.card').exists()).toBe(false);
+
+    const pagesOnly = mountFor(text, { inlineMedia: false, linkPreviews: true });
+    expect(pagesOnly.find('img.inline-image').exists()).toBe(false);
+    expect(pagesOnly.find('.card').exists()).toBe(true);
+  });
+
+  it('renders nothing when the INSTANCE has the feature off', () => {
+    // Both user settings on, feature flag off: nothing renders. A stored `true` carried over
+    // from another instance must not draw a card the server here could never resolve.
+    seed(img(1, 800, 600), YOUTUBE);
+    const wrapper = mountFor(`https://e.test/1.png ${YOUTUBE.url}`, { feature: false });
+    expect(wrapper.find('.attachments').exists()).toBe(false);
+  });
+
+  it('renders nothing for an unavailable preview', () => {
+    seed(preview({ url: 'https://e.test/gone', status: 'unavailable' }));
+    expect(mountFor('https://e.test/gone').find('.attachments').exists()).toBe(false);
+  });
+
+  it('renders nothing while a preview is still unresolved', () => {
+    // The ingest-driven model's normal early state, and the case a row must render as
+    // "nothing" rather than as a placeholder that later collapses.
+    expect(mountFor('https://e.test/not-primed').find('.attachments').exists()).toBe(false);
+  });
+});
+
+describe('MessageAttachments — the lightbox is a gallery over the strip', () => {
+  beforeEach(() => {
+    resolved.clear();
+    useMediaViewer().close();
+  });
+
+  const img = (n: number) =>
+    preview({
+      url: `https://e.test/${n}.png`,
+      kind: 'image',
+      src: `/api/link-preview/media/t${n}`,
+      thumbWidth: 800,
+      thumbHeight: 600,
+    });
+
+  it('opens every image in the strip, positioned on the one clicked', async () => {
+    // This is what makes a generous media cap safe: however many images a message carries,
+    // all of them are reachable by arrowing through the viewer.
+    for (const n of [1, 2, 3]) resolved.set(img(n).url, img(n));
+    seedSettings();
+    const wrapper = mount(MessageAttachments, {
+      props: { text: 'https://e.test/1.png https://e.test/2.png https://e.test/3.png' },
+    });
+
+    await wrapper.findAll('.filmstrip img')[1].trigger('click');
+
+    const viewer = useMediaViewer();
+    expect(viewer.isOpen.value).toBe(true);
+    expect(viewer.count.value).toBe(3);
+    expect(viewer.index.value).toBe(1);
+    // ⚠ OUR proxy path, not the origin URL. Handing the viewer `preview.url` broke the promise
+    // the setting makes in words ("the site hosting it never sees your device") — the image
+    // rendered inline via the proxy and then the click went straight to the remote host — and
+    // made an `http://` image fail as mixed content once the lightbox loaded it directly.
+    expect(viewer.url.value).toBe('/api/link-preview/media/t2');
+    expect(viewer.items.value.map((i) => i.url)).toEqual([
+      '/api/link-preview/media/t1',
+      '/api/link-preview/media/t2',
+      '/api/link-preview/media/t3',
+    ]);
+    // And the arrows are live in both directions, which is the whole point.
+    expect(viewer.hasPrev.value).toBe(true);
+    expect(viewer.hasNext.value).toBe(true);
+  });
+
+  it('opens a lone image as a gallery of one, also through the proxy', () => {
+    resolved.set(img(1).url, img(1));
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: 'https://e.test/1.png' } });
+    wrapper.find('img.inline-image').trigger('click');
+    expect(useMediaViewer().count.value).toBe(1);
+    expect(useMediaViewer().url.value).toBe('/api/link-preview/media/t1');
+  });
+
+  it('does not open anything when the media viewer is switched off', async () => {
+    for (const n of [1, 2]) resolved.set(img(n).url, img(n));
+    // Hand-built rather than via seedSettings because this one needs image_modal OFF.
+    setActivePinia(createPinia());
+    useConfigStore().features = { linkPreviews: true };
+    const settings = useSettingsStore();
+    settings.values = {
+      'chat.inline_media.enabled': true,
+      'chat.link_previews.enabled': true,
+      'chat.image_modal.enabled': false,
+    };
+    settings.loaded = true;
+    const wrapper = mount(MessageAttachments, {
+      props: { text: 'https://e.test/1.png https://e.test/2.png' },
+    });
+    await wrapper.findAll('.filmstrip img')[0].trigger('click');
+    expect(useMediaViewer().isOpen.value).toBe(false);
+  });
+});
+
+describe('MessageAttachments — the strip advertises that it scrolls', () => {
+  beforeEach(() => resolved.clear());
+
+  it('shows no fade when there is nothing to scroll to', () => {
+    // The affordance has to be honest in both directions: a permanent fade implies more
+    // content when the strip is fully scrolled, and dims the first image for no reason when
+    // there's nothing to the left. Under happy-dom nothing overflows, so neither side moves.
+    for (const n of [1, 2]) {
+      const p = preview({
+        url: `https://e.test/${n}.png`,
+        kind: 'image',
+        src: `/api/link-preview/media/t${n}`,
+        thumbWidth: 800,
+        thumbHeight: 600,
+      });
+      resolved.set(p.url, p);
+    }
+    seedSettings();
+    const strip = mount(MessageAttachments, {
+      props: { text: 'https://e.test/1.png https://e.test/2.png' },
+    }).find('.filmstrip');
+
+    expect(strip.exists()).toBe(true);
+    expect(strip.classes()).not.toContain('fade-start');
+    expect(strip.classes()).not.toContain('fade-end');
+  });
+});

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -21,6 +21,7 @@ import type { LinkPreview } from '../composables/useLinkPreview.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useConfigStore } from '../stores/config.js';
 import { useMediaViewer } from '../composables/useMediaViewer.js';
+import { MAX_CARDS_PER_MESSAGE } from '../utils/previewUrls.js';
 
 // Resolution is driven by message ingest, so components only read — stub the read. A real
 // `ref` is required: the templates rely on Vue's auto-unwrapping, which is keyed on `isRef`.
@@ -249,6 +250,23 @@ describe('MessageAttachments — arrangement', () => {
     expect(wrapper.find('.filmstrip').attributes('style')).toContain('200px');
   });
 
+  it('caps CARDS against the server answer, not against the extension guess', () => {
+    // ⚠ `previewableUrls` charges anything that LOOKS like media to the generous media budget
+    // (20), because a strip costs the same at 2 as at 12. But an image-looking URL that resolves
+    // as a page — an extensionless CDN link, a .png that redirects to an HTML login page —
+    // becomes a CARD, and a card costs real vertical space. Applying the tight cap only to the
+    // guess meant twenty such links rendered twenty stacked cards and took over the screen.
+    const urls: string[] = [];
+    for (let n = 0; n < 8; n++) {
+      const url = `https://e.test/looks-like-media${n}.png`;
+      urls.push(url);
+      resolved.set(url, preview({ url, kind: 'page', title: `T${n}` }));
+    }
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: urls.join(' ') } });
+    expect(wrapper.findAll('.card')).toHaveLength(MAX_CARDS_PER_MESSAGE);
+  });
+
   it('keeps cards out of the strip', () => {
     seed(img(1, 800, 600), img(2, 800, 600), YOUTUBE);
     const wrapper = mountFor(`https://e.test/1.png https://e.test/2.png ${YOUTUBE.url}`);
@@ -396,11 +414,12 @@ describe('MessageAttachments — the lightbox is a gallery over the strip', () =
 describe('MessageAttachments — the strip advertises that it scrolls', () => {
   beforeEach(() => resolved.clear());
 
-  it('shows no fade when there is nothing to scroll to', () => {
-    // The affordance has to be honest in both directions: a permanent fade implies more
-    // content when the strip is fully scrolled, and dims the first image for no reason when
-    // there's nothing to the left. Under happy-dom nothing overflows, so neither side moves.
-    for (const n of [1, 2]) {
+  // ⚠⚠ happy-dom reports every box as zero, so `scrollWidth - clientWidth` is 0 and BOTH edges
+  // read as reached no matter what the code does. The previous version of this suite asserted
+  // exactly that and was therefore vacuous — it passed with `updateEdges` inverted. Geometry has
+  // to be stubbed for the assertion to be about this component at all.
+  function stripWith(geometry: { scrollLeft: number; scrollWidth: number; clientWidth: number }) {
+    for (const n of [1, 2, 3]) {
       const p = preview({
         url: `https://e.test/${n}.png`,
         kind: 'image',
@@ -412,11 +431,41 @@ describe('MessageAttachments — the strip advertises that it scrolls', () => {
     }
     seedSettings();
     const strip = mount(MessageAttachments, {
-      props: { text: 'https://e.test/1.png https://e.test/2.png' },
+      props: { text: 'https://e.test/1.png https://e.test/2.png https://e.test/3.png' },
     }).find('.filmstrip');
+    for (const [key, value] of Object.entries(geometry)) {
+      Object.defineProperty(strip.element, key, { value, configurable: true });
+    }
+    return strip;
+  }
 
-    expect(strip.exists()).toBe(true);
+  it('shows no fade when there is nothing to scroll to', () => {
+    // A permanent fade would be a lie in both directions: it implies more content when the
+    // strip is fully scrolled, and dims the first image when there's nothing to the left.
+    const strip = stripWith({ scrollLeft: 0, scrollWidth: 300, clientWidth: 300 });
+    void strip.trigger('scroll');
     expect(strip.classes()).not.toContain('fade-start');
+    expect(strip.classes()).not.toContain('fade-end');
+  });
+
+  it('fades only the end while sitting at the left edge', async () => {
+    const strip = stripWith({ scrollLeft: 0, scrollWidth: 1000, clientWidth: 300 });
+    await strip.trigger('scroll');
+    expect(strip.classes()).toContain('fade-end');
+    expect(strip.classes()).not.toContain('fade-start');
+  });
+
+  it('fades both sides in the middle', async () => {
+    const strip = stripWith({ scrollLeft: 350, scrollWidth: 1000, clientWidth: 300 });
+    await strip.trigger('scroll');
+    expect(strip.classes()).toContain('fade-start');
+    expect(strip.classes()).toContain('fade-end');
+  });
+
+  it('fades only the start once scrolled to the far end', async () => {
+    const strip = stripWith({ scrollLeft: 700, scrollWidth: 1000, clientWidth: 300 });
+    await strip.trigger('scroll');
+    expect(strip.classes()).toContain('fade-start');
     expect(strip.classes()).not.toContain('fade-end');
   });
 });

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -138,6 +138,62 @@ describe('MessageAttachment — inline image', () => {
   });
 });
 
+describe('MessageAttachment — the click must not be eaten', () => {
+  it('lets the click reach the row when the media viewer is switched off', async () => {
+    // ⚠⚠ `@click.stop` runs its modifier BEFORE the handler, so propagation died and the
+    // handler's own `image_modal` guard then discarded the event. On touch the row's click is
+    // the only opener of the message-actions sheet — hover actions are desktop-only and there
+    // is no long-press path — so an image became a dead zone over the biggest target in the row:
+    // no viewer, no sheet, nothing at all.
+    seedSettings();
+    useSettingsStore().values['chat.image_modal.enabled'] = false;
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    const img = wrapper.find('.inline-image');
+
+    let reachedRow = false;
+    img.element.addEventListener('click', (e) => {
+      // Whatever the row would do, it must at least still SEE the event.
+      if (!e.cancelBubble) reachedRow = true;
+    });
+    await img.trigger('click');
+    expect(reachedRow).toBe(true);
+    expect(wrapper.emitted('activate')).toBeUndefined();
+    // Nor does it advertise a click it won't honour.
+    expect(img.attributes('role')).toBeUndefined();
+    expect(img.attributes('tabindex')).toBeUndefined();
+  });
+
+  it('is reachable from the keyboard when the viewer IS on', () => {
+    seedSettings();
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    const img = wrapper.find('.inline-image');
+    expect(img.attributes('role')).toBe('button');
+    expect(img.attributes('tabindex')).toBe('0');
+  });
+
+  it('activates on Enter and Space, not only on a mouse click', async () => {
+    seedSettings();
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    await wrapper.find('.inline-image').trigger('keydown.enter');
+    await wrapper.find('.inline-image').trigger('keydown.space');
+    expect(wrapper.emitted('activate')).toHaveLength(2);
+  });
+});
+
+describe('MessageAttachment — growth the list can react to', () => {
+  it('tells the list when a video finally reports its size', async () => {
+    // ⚠ The server measures dimensions for IMAGES only, so a video has no width/height to
+    // reserve a box with: it lays out at the UA default 300x150 and jumps to full size when
+    // metadata arrives. `previewRevision` has already fired by then and the scroller's
+    // ResizeObserver watches its own box rather than its content, so nothing else notices.
+    seedSettings();
+    const video = preview({ url: 'https://e.test/c.mp4', kind: 'video', src: '/api/lp/media/v' });
+    const wrapper = mount(MessageAttachment, { props: { preview: video } });
+    await wrapper.find('video').trigger('loadedmetadata');
+    expect(wrapper.emitted('measured')).toHaveLength(1);
+  });
+});
+
 describe('MessageAttachments — arrangement', () => {
   beforeEach(() => resolved.clear());
 
@@ -285,6 +341,27 @@ describe('MessageAttachments — the lightbox is a gallery over the strip', () =
     // And the arrows are live in both directions, which is the whole point.
     expect(viewer.hasPrev.value).toBe(true);
     expect(viewer.hasNext.value).toBe(true);
+    // ⚠ ...but "copy link" must hand over the ORIGIN. The rendered path is relative and behind
+    // requireAuth, so copying it produced something that resolves to nothing for anybody else —
+    // not even another user on the same instance — while the link TEXT in the same message
+    // copied the real URL. Two controls, two answers, one of them useless.
+    expect(viewer.shareUrl.value).toBe('https://e.test/2.png');
+    expect(viewer.items.value.map((i) => i.shareUrl)).toEqual([
+      'https://e.test/1.png',
+      'https://e.test/2.png',
+      'https://e.test/3.png',
+    ]);
+  });
+
+  it('carries the origin for a lone image too', () => {
+    const one = img(9);
+    resolved.set(one.url, one);
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: one.url } });
+    void wrapper.find('.inline-image').trigger('click');
+    const viewer = useMediaViewer();
+    expect(viewer.url.value).toBe('/api/link-preview/media/t9');
+    expect(viewer.shareUrl.value).toBe('https://e.test/9.png');
   });
 
   it('opens a lone image as a gallery of one, also through the proxy', () => {

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -1,0 +1,303 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<template>
+  <!-- Direct media: no card, no chrome. A frame around an image is furniture around content.
+       `width`/`height` are the server's real pixel dimensions, and they're load-bearing rather
+       than decorative — the browser derives the intrinsic aspect ratio from them and reserves
+       the right box BEFORE any bytes arrive. -->
+  <img
+    v-if="preview.kind === 'image' && preview.src"
+    class="inline-image"
+    :class="{ 'strip-item': inStrip }"
+    :src="preview.src"
+    :width="preview.thumbWidth || undefined"
+    :height="preview.thumbHeight || undefined"
+    alt=""
+    loading="lazy"
+    decoding="async"
+    @click.stop="openViewer"
+    @load="$emit('measured')"
+  />
+  <video
+    v-else-if="preview.kind === 'video' && preview.src"
+    class="inline-video"
+    :class="{ 'strip-item': inStrip }"
+    :src="preview.src"
+    controls
+    preload="metadata"
+    @click.stop
+  />
+  <audio
+    v-else-if="preview.kind === 'audio' && preview.src"
+    class="inline-audio"
+    :src="preview.src"
+    controls
+    preload="metadata"
+    @click.stop
+  />
+
+  <!-- A page, or a video page. Discord's panel treatment: the card sits on its own slightly
+       raised background so it reads as a distinct object rather than as more chat text. -->
+  <div v-else class="card" :class="{ 'card-video': isVideo }">
+    <div class="card-text">
+      <div v-if="preview.siteName" class="card-site">
+        {{ preview.siteName }}<template v-if="preview.author"> · {{ preview.author }}</template>
+      </div>
+      <a
+        v-if="preview.title"
+        class="card-title"
+        :href="preview.url"
+        target="_blank"
+        rel="noreferrer noopener"
+        @click.stop
+        >{{ preview.title }}</a
+      >
+      <div v-if="preview.description" class="card-desc">{{ preview.description }}</div>
+    </div>
+
+    <!-- Video: the thumbnail goes full-width with a play badge, because a video reduced to a
+         72px square is pointless. Everything else keeps the small right-aligned thumbnail. -->
+    <!-- ⚠ Gated on isVideo alone, NOT on having a thumbnail. `pageRecord` returns ok as soon as
+         there is a title OR an image, so an oEmbed reply with a title but no thumbnail_url (or
+         an og:image that normalizeUrl rejected) yielded embedUrl set and thumb undefined — both
+         this branch and the `v-else-if="preview.thumb"` one were false, so the card showed a
+         title with the ▶, and the whole video, unreachable. -->
+    <div v-if="isVideo" class="card-media">
+      <!-- THE FACADE. The iframe does not exist until this is clicked, so nothing is requested
+           from the video host on render — not even the thumbnail, which is proxied through us
+           like every other preview image. The first request the viewer makes to YouTube is the
+           one they asked for by pressing play. -->
+      <iframe
+        v-if="playing"
+        class="card-embed"
+        :src="preview.embedUrl"
+        title="Video player"
+        allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
+        referrerpolicy="no-referrer"
+        allowfullscreen
+      ></iframe>
+      <button
+        v-else
+        type="button"
+        class="card-play"
+        :aria-label="`Play ${preview.title ?? 'video'}`"
+        @click.stop="play"
+      >
+        <img
+          v-if="preview.thumb"
+          class="card-thumb-wide"
+          :src="preview.thumb"
+          alt=""
+          loading="lazy"
+        />
+        <span class="play-badge" aria-hidden="true">▶</span>
+      </button>
+    </div>
+    <img
+      v-else-if="preview.thumb"
+      class="card-thumb"
+      :src="preview.thumb"
+      alt=""
+      loading="lazy"
+      decoding="async"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { LinkPreview } from '../composables/useLinkPreview.js';
+import { useSettingsStore } from '../stores/settings.js';
+
+// Purely presentational: it renders ONE already-resolved, already-permitted preview.
+// Resolution happens at message ingest and the settings check happens in
+// MessageAttachments, which needs the resolved set anyway to decide the arrangement.
+const props = defineProps<{
+  preview: LinkPreview;
+  /** Sized by the strip's row height rather than by its own dimensions. */
+  inStrip?: boolean;
+}>();
+
+// Emitted when an image finishes decoding. Only matters when the server couldn't give us
+// dimensions (an exotic format, a truncated header) — there the box wasn't reserved, so the
+// row does grow on load and the list needs a chance to re-pin.
+// `activate` rather than opening the viewer here: what a click MEANS depends on the
+// arrangement, and the arrangement is the parent's business. A tap on one image of a strip
+// should open the whole strip as a gallery, and only the parent knows what the strip holds.
+const emit = defineEmits<{ measured: []; activate: [] }>();
+
+const settings = useSettingsStore();
+const playing = ref(false);
+
+const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.preview.embedUrl);
+
+function play(): void {
+  playing.value = true;
+}
+
+function openViewer(): void {
+  // The viewer is opt-out (chat.image_modal.enabled); when it's off, an inline image is just
+  // an image and a click does nothing special.
+  if (settings.effective('chat.image_modal.enabled') !== true) return;
+  emit('activate');
+}
+</script>
+
+<style scoped>
+.inline-image {
+  max-width: 100%;
+  /* Capped so one tall screenshot can't push the rest of the conversation off screen. The
+     viewer is one click away for the full thing. */
+  max-height: 240px;
+  /* ⚠ Both `auto`, and both needed. The `width`/`height` attributes give the browser the
+     intrinsic ratio to reserve space with; these let it SCALE that box down proportionally to
+     fit inside max-width/max-height. Without `width: auto` a portrait image hits the height
+     cap and keeps its attribute width, which is squashing rather than scaling. */
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  display: block;
+}
+.inline-video,
+.inline-audio {
+  max-width: 100%;
+  width: auto;
+  border-radius: var(--radius-md);
+  display: block;
+}
+.inline-video {
+  max-height: 280px;
+}
+.inline-audio {
+  width: 100%;
+}
+
+/* Inside a strip the ROW decides the height and every item fills it, so the group reads as
+   one band. Widths then vary with each image's aspect ratio, which is what makes a strip look
+   like a strip rather than a grid of letterboxed cells. `cover` because a uniform height is
+   the point — a panorama is cropped rather than allowed to be 2000px wide. */
+.strip-item {
+  height: 100%;
+  width: auto;
+  max-width: 360px;
+  max-height: none;
+  object-fit: cover;
+  flex: none;
+}
+
+.card {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+  /* A raised panel, Discord-style, so the card reads as a distinct object rather than as more
+     chat text. Doing the distinction with a background instead of a left rule is what lets the
+     rule go away on desktop (below) without the card losing its edges.
+     ⚠ --embed-bg, NOT --bg-soft: that's the message row's hover fill, and a card painted with
+     it disappears the moment the pointer crosses its row. */
+  background: var(--embed-bg);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+}
+/* The Slack-style left rule is a MOBILE-only cue. On desktop the app already has a vertical
+   border running down the side of the message column right next to this, and a second rule a
+   few pixels away just reads as noise. On a narrow viewport that border isn't there, so the
+   rule is doing real work. */
+@media (max-width: 768px) {
+  .card {
+    border-left: 3px solid var(--border);
+    /* The rule replaces the panel's own left padding rather than adding to it. */
+    padding-left: var(--space-5);
+  }
+}
+.card-video {
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.card-text {
+  min-width: 0;
+  flex: 1;
+}
+.card-site {
+  color: var(--fg-muted);
+  font-size: 0.85em;
+}
+.card-title {
+  display: block;
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+}
+.card-title:hover {
+  text-decoration: underline;
+}
+.card-desc {
+  color: var(--fg-muted);
+  /* Two lines: enough to tell what a page is, not enough to become the message. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.card-thumb {
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  flex: none;
+}
+
+.card-media {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  /* Reads against the card's own panel, not against the chat background. */
+  background: var(--bg);
+}
+.card-play {
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  position: relative;
+}
+.card-thumb-wide {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.play-badge {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+  color: var(--fg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  /* Optically centred: a triangle glyph's visual mass sits left of its box. */
+  padding-left: 3px;
+}
+.card-embed {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+}
+</style>

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -204,8 +204,18 @@ function activate(): void {
   border-radius: var(--radius-md);
   display: block;
 }
+/* ⚠ A FIXED height, not a max. The server measures dimensions for images only, so a video has
+   no intrinsic ratio to reserve a box from: it lays out at the UA default 300x150 and jumps to
+   its real size when `loadedmetadata` fires. `@loadedmetadata` lets the list re-pin, but that is
+   only a mitigation — the re-pin can follow the bottom and cannot hold a scrolled-up reader
+   still, because by the time we hear about the growth it has already happened.
+   Pinning the height removes the jump instead of compensating for it: the box is correct before
+   a single byte arrives. Width still settles when the ratio is known, which costs nothing —
+   only vertical movement disturbs a scroll position.
+   Matches the filmstrip's landscape row, so a lone video and a video in a group are the same
+   height. */
 .inline-video {
-  max-height: 280px;
+  height: 200px;
 }
 .inline-audio {
   width: 100%;

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -18,9 +18,18 @@
     alt=""
     loading="lazy"
     decoding="async"
-    @click.stop="openViewer"
+    :role="viewerEnabled ? 'button' : undefined"
+    :tabindex="viewerEnabled ? 0 : undefined"
+    @click="onImageClick"
+    @keydown.enter.prevent="activate"
+    @keydown.space.prevent="activate"
     @load="$emit('measured')"
   />
+  <!-- ⚠ `@loadedmetadata` matters more here than the image's `@load` does. The server measures
+       dimensions for images only, so a video has NO width/height to reserve a box with and lays
+       out at the UA default 300x150 until its metadata arrives — then jumps to full size. The
+       resolve-time `previewRevision` has already fired by then, and the scroller's ResizeObserver
+       watches its own box rather than its content, so without this nothing at all notices. -->
   <video
     v-else-if="preview.kind === 'video' && preview.src"
     class="inline-video"
@@ -29,6 +38,7 @@
     controls
     preload="metadata"
     @click.stop
+    @loadedmetadata="$emit('measured')"
   />
   <audio
     v-else-if="preview.kind === 'audio' && preview.src"
@@ -37,6 +47,7 @@
     controls
     preload="metadata"
     @click.stop
+    @loadedmetadata="$emit('measured')"
   />
 
   <!-- A page, or a video page. Discord's panel treatment: the card sits on its own slightly
@@ -138,10 +149,30 @@ function play(): void {
   playing.value = true;
 }
 
-function openViewer(): void {
-  // The viewer is opt-out (chat.image_modal.enabled); when it's off, an inline image is just
-  // an image and a click does nothing special.
-  if (settings.effective('chat.image_modal.enabled') !== true) return;
+// The viewer is opt-out (chat.image_modal.enabled); when it's off, an inline image is just an
+// image. That has to be true of the EVENT too, not only of the outcome — see below.
+const viewerEnabled = computed(() => settings.effective('chat.image_modal.enabled') === true);
+
+/**
+ * ⚠ Propagation is stopped only when the click is actually being consumed.
+ *
+ * `@click.stop="openViewer"` compiles to `withModifiers(openViewer, ['stop'])`, and the
+ * modifier runs BEFORE the handler — so with the media viewer switched off the tap was
+ * swallowed and then discarded by the handler's own guard. On touch the row's click is the only
+ * thing that opens the message-actions sheet (hover actions are desktop-only, and there is no
+ * long-press or contextmenu path), so an image became a dead zone covering the largest target
+ * in the row: no viewer, no sheet, nothing.
+ */
+function onImageClick(e: MouseEvent): void {
+  if (!viewerEnabled.value) return;
+  e.stopPropagation();
+  emit('activate');
+}
+
+/** Keyboard equivalent. An element advertising `cursor: pointer` and a `button` role has to be
+ *  reachable without one — matching RenderSegments, MircColorPicker and SuggestionStrip. */
+function activate(): void {
+  if (!viewerEnabled.value) return;
   emit('activate');
 }
 </script>
@@ -160,8 +191,11 @@ function openViewer(): void {
   height: auto;
   object-fit: contain;
   border-radius: var(--radius-md);
-  cursor: pointer;
   display: block;
+}
+/* Only advertises a click when a click does something — the viewer is opt-out. */
+.inline-image[role='button'] {
+  cursor: pointer;
 }
 .inline-video,
 .inline-audio {
@@ -222,9 +256,9 @@ function openViewer(): void {
   min-width: 0;
   flex: 1;
 }
+/* Hierarchy by colour alone — AGENTS.md: one font size across the entire UI. */
 .card-site {
   color: var(--fg-muted);
-  font-size: 0.85em;
 }
 .card-title {
   display: block;
@@ -290,7 +324,6 @@ function openViewer(): void {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 20px;
   /* Optically centred: a triangle glyph's visual mass sits left of its box. */
   padding-left: 3px;
 }

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -20,6 +20,7 @@
     decoding="async"
     :role="viewerEnabled ? 'button' : undefined"
     :tabindex="viewerEnabled ? 0 : undefined"
+    :aria-label="viewerEnabled ? imageLabel : undefined"
     @click="onImageClick"
     @keydown.enter.prevent="activate"
     @keydown.space.prevent="activate"
@@ -152,6 +153,28 @@ function play(): void {
 // The viewer is opt-out (chat.image_modal.enabled); when it's off, an inline image is just an
 // image. That has to be true of the EVENT too, not only of the outcome — see below.
 const viewerEnabled = computed(() => settings.effective('chat.image_modal.enabled') === true);
+
+/**
+ * The accessible name for the image WHEN IT IS A CONTROL.
+ *
+ * ⚠ `alt=""` is right for a decorative image and stops being sufficient the moment `role="button"`
+ * is applied: the img role that made an empty alt meaningful is gone, and what's left is a
+ * focusable control with no name. Only set while the viewer is enabled, because that is the only
+ * time this is a control at all — a plain inline image stays decoration of the message text,
+ * which the surrounding link already names.
+ *
+ * The filename is included when the URL yields one, so a strip of five doesn't present five
+ * identically-named buttons to anyone moving through them by keyboard.
+ */
+const imageLabel = computed(() => {
+  let name = '';
+  try {
+    name = decodeURIComponent(new URL(props.preview.url).pathname.split('/').pop() ?? '');
+  } catch {
+    // A URL that won't parse just doesn't contribute a filename.
+  }
+  return name ? `Open image: ${name}` : 'Open image';
+});
 
 /**
  * ⚠ Propagation is stopped only when the click is actually being consumed.

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -1,0 +1,268 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<template>
+  <div v-if="visible.length" class="attachments">
+    <!-- Two or more images/videos become one horizontally-scrolling row rather than a
+         vertical stack, following Slack. Three portrait screenshots stacked is most of a
+         screen of somebody else's message; as a strip it's one glance.
+
+         The row's height is ALSO the sizing win: it comes from the server's dimensions, so
+         it's known before a single byte of image data arrives, and it's ONE height for the
+         whole group instead of N unknown ones. -->
+    <div
+      v-if="strip.length > 1"
+      ref="stripEl"
+      class="filmstrip"
+      :class="{ 'fade-start': !atStart, 'fade-end': !atEnd }"
+      :style="{ height: `${stripHeight}px` }"
+      @scroll.passive="updateEdges"
+    >
+      <MessageAttachment
+        v-for="item in strip"
+        :key="item.url"
+        :preview="item"
+        in-strip
+        @measured="$emit('measured')"
+        @activate="openStripAt(item)"
+      />
+    </div>
+    <MessageAttachment
+      v-for="item in stacked"
+      :key="item.url"
+      :preview="item"
+      @measured="$emit('measured')"
+      @activate="openSingle(item)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
+import { useSettingsStore } from '../stores/settings.js';
+import { useConfigStore } from '../stores/config.js';
+import { previewableUrls } from '../utils/previewUrls.js';
+import { useLinkPreview, type LinkPreview } from '../composables/useLinkPreview.js';
+import { useMediaViewer } from '../composables/useMediaViewer.js';
+import MessageAttachment from './MessageAttachment.vue';
+
+// Owns the ARRANGEMENT of a message's attachments; MessageAttachment owns how any one of
+// them looks. That split is what makes grouping possible at all — while each child resolved
+// its own preview, nothing was in a position to know that a message had three images and
+// could lay them out as a row.
+//
+// Reads are pure (see composables/useLinkPreview): resolution happens at message ingest, so
+// nothing here triggers a fetch no matter how often it re-renders.
+const props = defineProps<{ text: string | null | undefined }>();
+
+defineEmits<{ measured: [] }>();
+
+const settings = useSettingsStore();
+const config = useConfigStore();
+const viewer = useMediaViewer();
+
+/** Row heights for a strip, picked by the group's dominant orientation.
+ *
+ *  Slack effectively has two, and it's the right simplification: it means a message list has
+ *  a small, known set of possible attachment heights instead of one per image. Portrait gets
+ *  more room because a tall photo squeezed into a landscape row is unreadable — but only a
+ *  little more, or one message wins the screen. */
+const STRIP_LANDSCAPE = 200;
+const STRIP_PORTRAIT = 300;
+
+// ⚠ ANDed with the instance feature flag. A stored `true` from an instance that had the feature
+// on must not render anything on one that doesn't — the routes aren't even mounted there, so a
+// preview could never resolve and the setting rows aren't shown either. One choke point, so the
+// render path and the priming path can't disagree.
+const toggles = computed(() => ({
+  inlineMedia: config.linkPreviews && settings.effective('chat.inline_media.enabled') === true,
+  linkPreviews: config.linkPreviews && settings.effective('chat.link_previews.enabled') === true,
+}));
+
+const urls = computed(() => previewableUrls(props.text, toggles.value));
+
+// One ref per URL, read-only. `useLinkPreview` on a URL nobody primed returns a permanently
+// null ref, which is exactly the "render nothing" case.
+const entries = computed(() => urls.value.map((url) => useLinkPreview(url)));
+
+/**
+ * Previews that are resolved AND allowed by the settings.
+ *
+ * Re-checked against the server's answer rather than the extension guess that prompted the
+ * request: an extensionless URL that turns out to be a PNG is inline media, and a `.jpg` that
+ * redirects to an HTML login page is not. Otherwise "link previews off" could still be talked
+ * into rendering a card.
+ */
+const visible = computed<LinkPreview[]>(() =>
+  entries.value
+    .map((entry) => entry.value)
+    .filter((p): p is LinkPreview => {
+      if (!p || p.status !== 'ok') return false;
+      const isMedia = p.kind === 'image' || p.kind === 'video' || p.kind === 'audio';
+      return isMedia ? toggles.value.inlineMedia : toggles.value.linkPreviews;
+    }),
+);
+
+/** Strip candidates: pictures and video, which read as a row. Audio doesn't — a row of
+ *  transport controls is not a gallery — so it stays stacked and full-width. */
+const strip = computed(() => visible.value.filter((p) => p.kind === 'image' || p.kind === 'video'));
+
+/** Everything the strip didn't take. A lone image renders on its own, at its own size: it's
+ *  the common case and a one-item strip would only make it smaller for no reason. */
+const stacked = computed(() =>
+  strip.value.length > 1 ? visible.value.filter((p) => !strip.value.includes(p)) : visible.value,
+);
+
+/**
+ * Open the lightbox over the WHOLE strip, positioned on the image that was clicked.
+ *
+ * This is what makes a generous media cap safe: however many images a message carries, every
+ * one of them is reachable by arrowing through the viewer rather than only by scrolling the
+ * strip. The viewer has always been a gallery — a single file is a gallery of one — so this
+ * needed no work there.
+ */
+/**
+ * ⚠ The viewer gets `src` — OUR proxy path — never the origin URL.
+ *
+ * Handing it `preview.url` broke the promise the setting makes in so many words ("the file is
+ * fetched and served by your Lurker server, so the site hosting it never sees your device"):
+ * the image rendered inline through the proxy, and then clicking it went straight to the remote
+ * host. It also meant an `http://` image displayed fine inline but was blocked as mixed content
+ * once the lightbox loaded it directly, so the click produced a dead "open in browser" card.
+ */
+function openStripAt(item: LinkPreview): void {
+  // ⚠ IMAGES only. MediaViewerModal derives which element to render from the URL's extension,
+  // and a proxy path has none — `mediaKindForUrl` even throws on a relative URL and returns
+  // null — so it falls back to `image` and would mount a <video>'s bytes in an <img>, producing
+  // the "open in browser" failure card for a file that plays fine inline. A video in a strip has
+  // its own inline controls anyway; it isn't a lightbox item.
+  const gallery = strip.value.filter((p) => p.kind === 'image');
+  const items = gallery.map((p) => ({ url: p.src ?? p.url }));
+  const at = gallery.indexOf(item);
+  if (at === -1) return;
+  viewer.openGallery(items, at);
+}
+
+function openSingle(item: LinkPreview): void {
+  viewer.open(item.src ?? item.url);
+}
+
+// ─── Scroll affordance ────────────────────────────────────────────────────────
+//
+// A strip that scrolls has to LOOK like it scrolls, or the images past the edge simply don't
+// exist as far as the reader is concerned. The fade is applied with `mask-image`, so the
+// content itself dissolves at the boundary rather than having a gradient laid over it — which
+// means it works on any background, including the highlight tint, with nothing to keep in sync.
+//
+// Only faded on a side that can actually move. A permanent fade would be a lie in both
+// directions: it implies more content when the strip is fully scrolled, and it dims the first
+// image for no reason when there's nothing to the left.
+const stripEl = useTemplateRef<HTMLElement>('stripEl');
+const atStart = ref(true);
+const atEnd = ref(true);
+
+function updateEdges(): void {
+  const el = stripEl.value;
+  if (!el) return;
+  const max = el.scrollWidth - el.clientWidth;
+  // A pixel of slack: fractional scroll positions and sub-pixel layout mean an exact
+  // comparison flickers the fade on and off at the extremes.
+  atStart.value = el.scrollLeft <= 1;
+  atEnd.value = el.scrollLeft >= max - 1;
+}
+
+// The strip's scrollable width changes without it being scrolled — the window resizes, images
+// finish laying out, a re-render swaps the group. One observer catches all of those, including
+// the initial measurement, which is why there's no separate onMounted call.
+let observer: ResizeObserver | null = null;
+watch(stripEl, (el) => {
+  observer?.disconnect();
+  observer = null;
+  if (!el) return;
+  observer = new ResizeObserver(() => updateEdges());
+  observer.observe(el);
+  for (const child of el.children) observer.observe(child);
+});
+onBeforeUnmount(() => observer?.disconnect());
+
+const stripHeight = computed(() => {
+  const portrait = strip.value.filter((p) => (p.thumbHeight ?? 0) > (p.thumbWidth ?? 0)).length;
+  // "Primarily portrait" rather than "any portrait": one tall image among four wide ones
+  // shouldn't make the whole row tall.
+  return portrait * 2 > strip.value.length ? STRIP_PORTRAIT : STRIP_LANDSCAPE;
+});
+</script>
+
+<style scoped>
+.attachments {
+  display: flex;
+  flex-direction: column;
+  /* NOT the default `stretch`. A flex column stretches its children across the cross axis,
+     which forced every inline image to the container's full width while `max-height` capped
+     its height — squashing it instead of scaling it. */
+  align-items: flex-start;
+  gap: var(--space-2);
+  /* Breathing room on BOTH sides. The bottom margin matters more than it looks: without it an
+     image or card sits flush against the next author's name, and the attachment reads as
+     belonging to the message below it rather than the one above. */
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-4);
+  /* No width cap HERE. The cap belongs to the card (below), not to the container: a strip
+     scrolls, so capping it at card width would mean two images visible out of five for no
+     reason other than that cards need a limit. */
+  max-width: 100%;
+  min-width: 0;
+}
+/* A card wants the width it's given — its text has to wrap against something — but not the
+   full width of a wide window, where it stops reading as part of the message and starts
+   reading as a page element. */
+.attachments > :deep(.card) {
+  align-self: stretch;
+  max-width: 480px;
+}
+
+.filmstrip {
+  display: flex;
+  gap: var(--space-2);
+  /* The strip scrolls itself; the message list must never scroll sideways. */
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+  /* Height comes from the inline style — one known value for the whole group. */
+  align-items: stretch;
+  /* No visible scrollbar: it would eat into a height that's deliberately fixed, and change the
+     strip's height depending on the platform's scrollbar style. The fade is the affordance. */
+  scrollbar-width: none;
+  /* Snap so a flick lands on an image rather than halfway across one. `proximity` rather than
+     `mandatory` — mandatory fights a deliberate small drag. */
+  scroll-snap-type: x proximity;
+}
+.filmstrip::-webkit-scrollbar {
+  display: none;
+}
+.filmstrip > :deep(*) {
+  scroll-snap-align: start;
+}
+
+/* The fade, as a mask on the content rather than a gradient laid over it — so it works on any
+   background (including the highlight tint) with nothing to keep in sync.
+   The three cases are spelled out rather than composited, because `mask-composite` for the
+   both-sides case is more machinery than three declarations. */
+.filmstrip.fade-end {
+  mask-image: linear-gradient(to right, #000 calc(100% - 40px), transparent 100%);
+}
+.filmstrip.fade-start {
+  mask-image: linear-gradient(to right, transparent 0, #000 40px);
+}
+.filmstrip.fade-start.fade-end {
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 40px,
+    #000 calc(100% - 40px),
+    transparent 100%
+  );
+}
+</style>

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -43,7 +43,7 @@
 import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
 import { useSettingsStore } from '../stores/settings.js';
 import { useConfigStore } from '../stores/config.js';
-import { previewableUrls } from '../utils/previewUrls.js';
+import { previewableUrls, MAX_CARDS_PER_MESSAGE } from '../utils/previewUrls.js';
 import { useLinkPreview, type LinkPreview } from '../composables/useLinkPreview.js';
 import { useMediaViewer } from '../composables/useMediaViewer.js';
 import MessageAttachment from './MessageAttachment.vue';
@@ -95,15 +95,28 @@ const entries = computed(() => urls.value.map((url) => useLinkPreview(url)));
  * redirects to an HTML login page is not. Otherwise "link previews off" could still be talked
  * into rendering a card.
  */
-const visible = computed<LinkPreview[]>(() =>
-  entries.value
-    .map((entry) => entry.value)
-    .filter((p): p is LinkPreview => {
-      if (!p || p.status !== 'ok') return false;
-      const isMedia = p.kind === 'image' || p.kind === 'video' || p.kind === 'audio';
-      return isMedia ? toggles.value.inlineMedia : toggles.value.linkPreviews;
-    }),
-);
+const visible = computed<LinkPreview[]>(() => {
+  const out: LinkPreview[] = [];
+  let cards = 0;
+  for (const entry of entries.value) {
+    const p = entry.value;
+    if (!p || p.status !== 'ok') continue;
+    const isMedia = p.kind === 'image' || p.kind === 'video' || p.kind === 'audio';
+    if (isMedia ? !toggles.value.inlineMedia : !toggles.value.linkPreviews) continue;
+    // ⚠ The card cap is re-applied to the SERVER's answer, not just to the extension guess that
+    // prompted the request. `previewableUrls` charges anything that looks like media to the
+    // generous media budget (20), so twenty image-looking URLs that all resolve as pages —
+    // extensionless CDN links, a `.png` that redirects to an HTML login page — arrived as twenty
+    // stacked cards and took over the screen. The tight cap exists because a card costs real
+    // vertical space, and only the resolved kind knows whether one is being built.
+    if (!isMedia) {
+      if (cards >= MAX_CARDS_PER_MESSAGE) continue;
+      cards++;
+    }
+    out.push(p);
+  }
+  return out;
+});
 
 /** Strip candidates: pictures and video, which read as a row. Audio doesn't — a row of
  *  transport controls is not a gallery — so it stays stacked and full-width. */
@@ -178,15 +191,26 @@ function updateEdges(): void {
 // The strip's scrollable width changes without it being scrolled — the window resizes, images
 // finish laying out, a re-render swaps the group. One observer catches all of those, including
 // the initial measurement, which is why there's no separate onMounted call.
+// ⚠ Re-runs when the strip's CONTENTS change, not only when the element itself is swapped. The
+// children were enumerated once, so a strip that gained an item — a later preview resolving into
+// a group that was already on screen — kept observing the old set and never re-measured. Its
+// `atEnd` then stayed true while there was now something to scroll to, and the fade that
+// advertises it silently stopped appearing. `flush: 'post'` so the new children exist to observe.
 let observer: ResizeObserver | null = null;
-watch(stripEl, (el) => {
-  observer?.disconnect();
-  observer = null;
-  if (!el) return;
-  observer = new ResizeObserver(() => updateEdges());
-  observer.observe(el);
-  for (const child of el.children) observer.observe(child);
-});
+watch(
+  [stripEl, strip],
+  () => {
+    observer?.disconnect();
+    observer = null;
+    const el = stripEl.value;
+    if (!el) return;
+    observer = new ResizeObserver(() => updateEdges());
+    observer.observe(el);
+    for (const child of el.children) observer.observe(child);
+    updateEdges();
+  },
+  { flush: 'post' },
+);
 onBeforeUnmount(() => observer?.disconnect());
 
 const stripHeight = computed(() => {

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -139,14 +139,16 @@ function openStripAt(item: LinkPreview): void {
   // the "open in browser" failure card for a file that plays fine inline. A video in a strip has
   // its own inline controls anyway; it isn't a lightbox item.
   const gallery = strip.value.filter((p) => p.kind === 'image');
-  const items = gallery.map((p) => ({ url: p.src ?? p.url }));
+  // `shareUrl` carries the ORIGIN address alongside the proxy path we render, so "copy link"
+  // hands over something another person can actually open.
+  const items = gallery.map((p) => ({ url: p.src ?? p.url, shareUrl: p.url }));
   const at = gallery.indexOf(item);
   if (at === -1) return;
   viewer.openGallery(items, at);
 }
 
 function openSingle(item: LinkPreview): void {
-  viewer.open(item.src ?? item.url);
+  viewer.openGallery([{ url: item.src ?? item.url, shareUrl: item.url }], 0);
 }
 
 // ─── Scroll affordance ────────────────────────────────────────────────────────

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -129,7 +129,11 @@
               interactive-nicks
               @nick-click="onMentionMenu"
             />
-            <MessageAttachments :text="row.m?.text" @measured="repinAfterPreviewGrowth(true)" />
+            <MessageAttachments
+              v-if="previewsActive && mightHaveLink(row.m?.text)"
+              :text="row.m?.text"
+              @measured="repinAfterPreviewGrowth(true)"
+            />
           </span>
           <span class="time">{{ row.continuationTime ? '' : time(row.m?.time) }}</span>
         </template>
@@ -272,7 +276,11 @@
                  deleted or doubled every event row, from an edit site that gives no hint the
                  two are connected. -->
             <MessageAttachments
-              v-if="row.m?.type === 'message' || row.m?.type === 'action'"
+              v-if="
+                (row.m?.type === 'message' || row.m?.type === 'action') &&
+                previewsActive &&
+                mightHaveLink(row.m?.text)
+              "
               :text="row.m?.text"
               @measured="repinAfterPreviewGrowth(true)"
             />
@@ -348,7 +356,7 @@ import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';
 import RenderSegments from './RenderSegments.vue';
 import MessageAttachments from './MessageAttachments.vue';
-import { previewRevision, primePreviews } from '../composables/useLinkPreview.js';
+import { previewRevision } from '../composables/useLinkPreview.js';
 import { useConfigStore } from '../stores/config.js';
 import IgnoreModal from './IgnoreModal.vue';
 import { useMessageActions } from '../composables/useMessageActions.js';
@@ -1681,7 +1689,13 @@ async function repinAfterPreviewGrowth(afterGrowth = false) {
 function topVisibleMessageId(el: HTMLElement): number | null {
   const box = el.getBoundingClientRect();
   const hit = document.elementFromPoint(box.left + box.width / 2, box.top + 2);
-  if (!hit) return null;
+  // ⚠ `elementFromPoint` is DOCUMENT-global and knows nothing about this scroller. The media
+  // viewer — which a filmstrip click opens — is `position: fixed; inset: 0` and a plain sibling
+  // of the list, as is every AppModal overlay (search, bookmarks, highlights). With one open the
+  // probe lands on the overlay, `closest()` finds no row, and the sibling walk below wanders
+  // through the overlay's own subtree. Scoped here so an unrelated overlay can't decide where a
+  // scrolled-up reader gets anchored.
+  if (!hit || !el.contains(hit)) return null;
 
   const idOf = (node: Element | null): number | null => {
     const raw = (node as HTMLElement | null)?.dataset?.msgId;
@@ -1708,7 +1722,22 @@ function topVisibleMessageId(el: HTMLElement): number | null {
   //
   // Walking siblings needs no measurement at all, is correct by construction, and costs a few
   // steps instead of a layout read per row.
-  let node: Element | null = hit.closest('.line, .notice') ?? hit;
+  let node: Element | null = hit.closest('.line, .notice');
+  if (!node) {
+    // ⚠ The point landed in the CONTAINER itself, not in a row — routine in compact mode, where
+    // `.line` carries a 10px top margin, so there is a real gap between rows to land in. The
+    // previous fallback (`?? hit`, then `querySelector('[data-msg-id]')`) then searched the
+    // whole list and returned its FIRST row: `pinAnchorRow` restored the identical scrollTop,
+    // which is the "reliably anchors the oldest row" outcome the note below says was designed
+    // out. Find the first row that is actually at or below the viewport top instead, comparing
+    // client rects — the one coordinate space both sides of the comparison agree on.
+    for (const child of el.children) {
+      if (child.getBoundingClientRect().bottom > box.top) {
+        node = child;
+        break;
+      }
+    }
+  }
   while (node) {
     const found = idOf(node.matches('[data-msg-id]') ? node : node.querySelector('[data-msg-id]'));
     if (found != null) return found;
@@ -1719,25 +1748,30 @@ function topVisibleMessageId(el: HTMLElement): number | null {
 
 watch(previewRevision, () => void repinAfterPreviewGrowth());
 
-// Priming happens at message INGEST, which means messages already in the store were never
-// asked about if the feature was off when they arrived — and turning a toggle on doesn't
-// re-ingest anything. Without this, enabling either setting shows previews only for messages
-// that arrive AFTERWARDS, which reads as the setting being broken.
-watch(
-  () => [
-    config.linkPreviews && settings.effective('chat.inline_media.enabled') === true,
-    config.linkPreviews && settings.effective('chat.link_previews.enabled') === true,
-  ],
-  ([inlineMedia, linkPreviews], previous) => {
-    // Only on a flip TO enabled. Turning one off needs no work: the rows simply stop rendering.
-    const gained = (inlineMedia && !previous?.[0]) || (linkPreviews && !previous?.[1]);
-    if (!gained) return;
-    primePreviews(
-      messages.value.map((m) => m.text as string | null | undefined),
-      { inlineMedia, linkPreviews },
-    );
-  },
+// ⚠ The re-prime-on-toggle watcher used to live here and could not work: Settings is a separate
+// route, so opening it destroys this component and the watcher, and the remount never sees the
+// flip. It now lives in useSocket, which outlives navigation — see `wirePreviewToggles`.
+
+/**
+ * Whether an attachment could render at all right now.
+ *
+ * ⚠ Checked HERE, at the mount site, rather than only inside MessageAttachments. The component
+ * was mounted once per message row regardless — 500 instances, each building a computed and
+ * running the URL regex — so every user of a default-off feature paid for it on every buffer
+ * switch. Hoisting the gate up also means an unrelated settings write can't invalidate a
+ * per-row computed 500 times over.
+ */
+const previewsActive = computed(
+  () =>
+    config.linkPreviews &&
+    (settings.effective('chat.inline_media.enabled') === true ||
+      settings.effective('chat.link_previews.enabled') === true),
 );
+
+/** Cheap pre-filter: no scheme, no possible attachment. Skips the regex for most rows. */
+function mightHaveLink(text: string | null | undefined): boolean {
+  return !!text && text.includes('://');
+}
 
 // Watch the messages array shape so we can react to:
 //   - prepend (older history): pin the OLD first row's viewport position.

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -129,6 +129,7 @@
               interactive-nicks
               @nick-click="onMentionMenu"
             />
+            <MessageAttachments :text="row.m?.text" @measured="repinAfterPreviewGrowth(true)" />
           </span>
           <span class="time">{{ row.continuationTime ? '' : time(row.m?.time) }}</span>
         </template>
@@ -262,6 +263,19 @@
             <template v-else-if="row.m?.type === 'error'"
               ><LinkedText :text="row.m.text ?? ''"
             /></template>
+            <!-- ⚠ OUTSIDE the v-if/v-else-if chain above, deliberately. Sitting between
+                 RenderSegments and the first `v-else-if` re-parented the ENTIRE event chain
+                 (join/part/quit/kick/…) onto this element's condition instead of
+                 `hasInlineText`. Output was identical only because message|action is a subset
+                 of what hasInlineText covers — so any later edit to the condition here (gating
+                 on a setting, adding `notice`, extracting the component) would have silently
+                 deleted or doubled every event row, from an edit site that gives no hint the
+                 two are connected. -->
+            <MessageAttachments
+              v-if="row.m?.type === 'message' || row.m?.type === 'action'"
+              :text="row.m?.text"
+              @measured="repinAfterPreviewGrowth(true)"
+            />
           </span>
         </template>
         <div
@@ -333,6 +347,9 @@ import { asEventMode, eventModeKey, isNoiseType } from '../../../shared/eventFil
 import NickRef from './NickRef.vue';
 import LinkedText from './LinkedText.vue';
 import RenderSegments from './RenderSegments.vue';
+import MessageAttachments from './MessageAttachments.vue';
+import { previewRevision, primePreviews } from '../composables/useLinkPreview.js';
+import { useConfigStore } from '../stores/config.js';
 import IgnoreModal from './IgnoreModal.vue';
 import { useMessageActions } from '../composables/useMessageActions.js';
 import type {
@@ -437,6 +454,7 @@ const props = withDefaults(
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
 const settings = useSettingsStore();
+const config = useConfigStore();
 const ignores = useIgnoresStore();
 const highlights = useHighlightRulesStore();
 const relayBots = useRelayBotsStore();
@@ -1603,6 +1621,124 @@ async function pinAnchorRow(el: HTMLElement, anchorId: number, useHeightFallback
   }
 }
 
+// The RESIDUAL preview case, after priming moved resolution to message ingest (see
+// composables/useLinkPreview): a reader scrolling fast enough to outrun the priming request
+// renders a row before its preview is known, and the row grows when it lands.
+//
+// This used to fire on every scroll into history, because resolution was triggered BY
+// rendering — and the compensation walked every row in the buffer reading offsetTop and
+// offsetHeight, forcing a synchronous layout per row. That was QA's "the whole screen is
+// trying to redraw". Priming makes the growth rare; this makes handling it cheap.
+//
+// `overflow-anchor: none` on the scroller (see the CSS) means the browser won't compensate on
+// its own — the same deliberate choice that makes history prepends predictable.
+//
+// BOTH cases need handling, and the previous pass got this wrong. The reasoning then was that
+// growth above the viewport "belongs to the prepend paths that already pin an anchor" — but a
+// prepend's pin runs when the prepend lands, and the previews for that batch resolve a moment
+// LATER. Nothing was covering the gap, which is exactly what QA hit: scroll up, history
+// arrives, previews arrive, position lost.
+//
+// This watcher runs BEFORE the DOM updates (Vue's default 'pre' flush), which is what makes a
+// correction possible at all: `pinAnchorRow` measures the anchor now, awaits the re-render, and
+// puts it back where it was.
+//
+// The anchor is found with elementFromPoint — O(1). Scanning every row for the first visible
+// one, as an earlier version did, read offsetTop/offsetHeight per row and forced a synchronous
+// layout for each; that was QA's "the whole screen is trying to redraw".
+/**
+ * @param afterGrowth true when the growth has ALREADY happened (an image `load` event) rather
+ *   than being about to happen (the pre-flush `previewRevision` watcher).
+ *
+ * ⚠ A post-growth call can only follow the bottom. `pinAnchorRow` works by measuring the
+ * anchor, awaiting the re-render, and restoring — so if the row grew before we were told, it
+ * measures the already-grown position and restores the same scrollTop it started from: a no-op
+ * that reads like a fix. Only the pre-flush path can hold a scrolled-up reader still, which is
+ * why server-provided dimensions matter — they move the growth into that path.
+ */
+async function repinAfterPreviewGrowth(afterGrowth = false) {
+  const el = scroller.value;
+  if (!el) return;
+  if (afterGrowth && !stickToBottom.value) return;
+  if (stickToBottom.value) {
+    // A reader at the live tail wants to follow the growth down, same as a live append.
+    await nextTick();
+    scrollToBottom();
+    return;
+  }
+  const anchorId = topVisibleMessageId(el);
+  if (anchorId != null) await pinAnchorRow(el, anchorId, false);
+}
+
+/**
+ * The id of the message row at the top of the viewport, in constant time.
+ *
+ * `elementFromPoint` asks the browser what it has already laid out rather than re-measuring
+ * anything, so this costs the same whether the buffer holds ten rows or a thousand. A point
+ * just inside the top edge lands on whatever the reader's eye is on; walking up to the nearest
+ * `[data-msg-id]` turns it into the anchor `pinAnchorRow` wants.
+ */
+function topVisibleMessageId(el: HTMLElement): number | null {
+  const box = el.getBoundingClientRect();
+  const hit = document.elementFromPoint(box.left + box.width / 2, box.top + 2);
+  if (!hit) return null;
+
+  const idOf = (node: Element | null): number | null => {
+    const raw = (node as HTMLElement | null)?.dataset?.msgId;
+    const id = Number(raw);
+    return raw != null && Number.isFinite(id) && id > 0 ? id : null;
+  };
+
+  // The row under the top edge is often NOT a message: date/unread/away/cleared dividers carry
+  // no `data-msg-id` at all, and a consolidated joins/parts block carries
+  // `data-cons-first-id`/`-last-id` instead. Both are routine at the top of the viewport when
+  // scrolling into history — which is precisely when this correction is needed — so returning
+  // null there silently skipped the re-pin. Walk forward to the next real message instead.
+  const direct = idOf(hit.closest('[data-msg-id]'));
+  if (direct != null) return direct;
+
+  // Walk FORWARD in document order from whatever is at the top edge, rather than measuring.
+  //
+  // ⚠ The obvious version — scanning every row for `offsetTop + offsetHeight > el.scrollTop` —
+  // is wrong here: `offsetTop` is relative to the nearest POSITIONED ancestor, and
+  // `.message-list` sets no `position`, so it carries the scroller's own document offset and the
+  // comparison mixes coordinate spaces. It came out true for row 0 at any realistic scrollTop,
+  // making the "fallback" reliably return the OLDEST row in the buffer. (The prepend code is
+  // safe from this because it only ever uses offsetTop *differences*.)
+  //
+  // Walking siblings needs no measurement at all, is correct by construction, and costs a few
+  // steps instead of a layout read per row.
+  let node: Element | null = hit.closest('.line, .notice') ?? hit;
+  while (node) {
+    const found = idOf(node.matches('[data-msg-id]') ? node : node.querySelector('[data-msg-id]'));
+    if (found != null) return found;
+    node = node.nextElementSibling;
+  }
+  return null;
+}
+
+watch(previewRevision, () => void repinAfterPreviewGrowth());
+
+// Priming happens at message INGEST, which means messages already in the store were never
+// asked about if the feature was off when they arrived — and turning a toggle on doesn't
+// re-ingest anything. Without this, enabling either setting shows previews only for messages
+// that arrive AFTERWARDS, which reads as the setting being broken.
+watch(
+  () => [
+    config.linkPreviews && settings.effective('chat.inline_media.enabled') === true,
+    config.linkPreviews && settings.effective('chat.link_previews.enabled') === true,
+  ],
+  ([inlineMedia, linkPreviews], previous) => {
+    // Only on a flip TO enabled. Turning one off needs no work: the rows simply stop rendering.
+    const gained = (inlineMedia && !previous?.[0]) || (linkPreviews && !previous?.[1]);
+    if (!gained) return;
+    primePreviews(
+      messages.value.map((m) => m.text as string | null | undefined),
+      { inlineMedia, linkPreviews },
+    );
+  },
+);
+
 // Watch the messages array shape so we can react to:
 //   - prepend (older history): pin the OLD first row's viewport position.
 //   - replace (wholesale snapshot): snap to bottom.
@@ -2084,9 +2220,17 @@ watch(
    own buffer + unread badge already. */
 .line.highlight {
   background: color-mix(in srgb, var(--warn) 12%, transparent);
+  /* A link-preview card inside a highlighted row needs a WARM panel: the neutral grey one
+     reads as a foreign object dropped onto the tint. Re-tinted rather than lightened, one
+     step further into the highlight than the row itself, so it still reads as raised.
+     Custom properties inherit through scoped styles, so overriding the token here is enough
+     — MessageAttachment needs no knowledge that highlights exist. */
+  --embed-bg: color-mix(in srgb, var(--warn) 24%, var(--bg));
 }
 .message-list:not(.compact) .line.highlight.alt {
   background: color-mix(in srgb, var(--warn) 18%, transparent);
+  /* Matched the alt row's stronger tint, so the panel stays a step above it. */
+  --embed-bg: color-mix(in srgb, var(--warn) 30%, var(--bg));
 }
 .line.scroll-target {
   animation: scroll-target-pulse 1.5s ease-out;

--- a/vue_client/src/composables/useLinkPreview.test.ts
+++ b/vue_client/src/composables/useLinkPreview.test.ts
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { primePreviews, useLinkPreview, resetLinkPreviewCache } from './useLinkPreview.js';
+import * as apiModule from '../api.js';
+
+const BOTH = { inlineMedia: true, linkPreviews: true };
+
+let posted: string[][];
+/** What the fake server does with a batch. Swappable mid-test so a suite can make the
+ *  instance fail and then recover, which is the whole shape of the re-ask cases below. */
+let respond: (urls: string[]) => unknown;
+
+const okFor = (urls: string[]) => ({
+  previews: urls.map((url) => ({
+    url,
+    status: 'ok',
+    kind: 'page',
+    title: 'T',
+    expiresAt: '2099-01-01T00:00:00Z',
+  })),
+});
+
+/** What the server sends when it declined to even try — pool saturation, a resolve deadline.
+ *  Deliberately NOT cached server-side, and stamped with a seconds-long TTL rather than the
+ *  one-hour failure TTL, precisely so a client comes back. See TRANSIENT_TTL_MS. */
+const transientFor = (urls: string[]) => ({
+  previews: urls.map((url) => ({
+    url,
+    status: 'unavailable',
+    kind: 'page',
+    expiresAt: new Date(Date.now() + 15_000).toISOString(),
+  })),
+});
+
+beforeEach(() => {
+  resetLinkPreviewCache();
+  posted = [];
+  respond = okFor;
+  vi.spyOn(apiModule, 'api').mockImplementation(async (_url, opts) => {
+    const urls = ((opts ?? {}).body as { urls: string[] }).urls;
+    posted.push(urls);
+    return respond(urls) as never;
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+/** Let the coalescing timer fire and the request settle. */
+const settle = () => new Promise((r) => setTimeout(r, 60));
+
+describe('rendering has no side effects', () => {
+  it('reading a preview NEVER triggers a request', async () => {
+    // ⚠⚠ The architectural invariant. The first version resolved as a side effect of
+    // rendering, which meant every scroll into history kicked off fetches that grew rows
+    // under the reader — and needed the list to keep correcting its own scroll position.
+    // A read must be a read.
+    const entry = useLinkPreview('https://e.test/page');
+    await settle();
+    expect(posted).toEqual([]);
+    expect(entry.value).toBeNull();
+  });
+
+  it('priming is what resolves, and a later read sees the result', async () => {
+    primePreviews(['look at https://e.test/page'], BOTH);
+    const entry = useLinkPreview('https://e.test/page');
+    await settle();
+    expect(posted).toEqual([['https://e.test/page']]);
+    expect(entry.value?.title).toBe('T');
+  });
+});
+
+describe('rendering never blocks priming', () => {
+  it('a URL that was RENDERED before priming is still primed', async () => {
+    // ⚠⚠ Regression guard, and this one shipped broken once: `useLinkPreview` inserts a cache
+    // entry as a side effect of being read, and the skip condition was `cache.has(url)` — so a
+    // mere render permanently blocked that URL. The failure path was the default one: both
+    // settings off → nothing primed → user enables one → rows render and create null entries →
+    // no later history page, backlog replay or live message could ever queue them.
+    const url = 'https://e.test/rendered-first';
+    useLinkPreview(url); // a row renders and reads it
+    await settle();
+    expect(posted).toEqual([]);
+
+    primePreviews([`look at ${url}`], BOTH);
+    await settle();
+    expect(posted).toEqual([[url]]);
+  });
+});
+
+describe('primePreviews', () => {
+  it('coalesces a whole batch into one request', async () => {
+    // A history page arrives as one batch; it must not become one POST per row.
+    primePreviews(['https://e.test/a', 'https://e.test/b', 'https://e.test/c'], BOTH);
+    await settle();
+    expect(posted.length).toBe(1);
+    expect(posted[0]).toHaveLength(3);
+  });
+
+  it('asks about a repeated link once across the whole batch', async () => {
+    primePreviews(['see https://e.test/x', 'also https://e.test/x'], BOTH);
+    await settle();
+    expect(posted).toEqual([['https://e.test/x']]);
+  });
+
+  it('does not re-ask for something already known', async () => {
+    primePreviews(['https://e.test/x'], BOTH);
+    await settle();
+    posted = [];
+    // An overlapping history page, or a re-render, must be free.
+    primePreviews(['https://e.test/x'], BOTH);
+    await settle();
+    expect(posted).toEqual([]);
+  });
+
+  it('does nothing at all when both settings are off', async () => {
+    primePreviews(['https://e.test/a https://e.test/b.png'], {
+      inlineMedia: false,
+      linkPreviews: false,
+    });
+    await settle();
+    expect(posted).toEqual([]);
+  });
+
+  it('splits a batch past the server cap across requests', async () => {
+    primePreviews(
+      Array.from({ length: 25 }, (_, i) => `https://e.test/${i}`),
+      BOTH,
+    );
+    await settle();
+    expect(posted.length).toBe(2);
+    expect(posted[0]).toHaveLength(20);
+    expect(posted[1]).toHaveLength(5);
+  });
+
+  it('tolerates null and empty bodies', async () => {
+    primePreviews([null, undefined, ''], BOTH);
+    await settle();
+    expect(posted).toEqual([]);
+  });
+});
+
+describe('re-asking after expiresAt', () => {
+  // ⚠⚠ The server splits `unavailable` into a VERDICT (cached, one-hour TTL) and a TRANSIENT
+  // refusal (not cached at all, ~15s TTL) — and that split buys nothing unless a client comes
+  // back when the short TTL lapses. It didn't: `dropIfExpired` runs only inside `primePreviews`,
+  // which is driven by message ingest, and a message already in the store is never ingested
+  // again. So a saturated instance blanked a preview for the life of the tab.
+  //
+  // Fake timers because the shortest honest wait here is the server's own 15 seconds.
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  /** Let the coalescing timer fire and the request settle, under fake timers. */
+  const tick = (ms: number) => vi.advanceTimersByTimeAsync(ms);
+
+  it('re-asks a transient unavailable once its expiresAt has passed, and recovers', async () => {
+    respond = transientFor;
+    primePreviews(['https://e.test/t'], BOTH);
+    await tick(60);
+    expect(posted).toEqual([['https://e.test/t']]);
+
+    const entry = useLinkPreview('https://e.test/t');
+    expect(entry.value?.status).toBe('unavailable');
+
+    // Nothing should move before the server's own deadline.
+    await tick(10_000);
+    expect(posted).toHaveLength(1);
+
+    respond = okFor; // the instance stops being saturated
+    await tick(10_000);
+    expect(posted).toHaveLength(2);
+    expect(entry.value?.status).toBe('ok');
+    expect(entry.value?.title).toBe('T');
+  });
+
+  it('never re-asks a resolved preview, even one with a short TTL', async () => {
+    // ⚠ The short TTL is the point. With the 7-day one this assertion would hold whether or not
+    // `ok` answers are excluded from the re-ask — it would be a test of the fixture, not of the
+    // module. A card that has ALREADY rendered must not become a standing poll when its TTL
+    // lapses: the proxy tokens in `src`/`thumb` are an HMAC over the URL and never expire, so
+    // there is nothing to refresh. `dropIfExpired` still re-asks on the next ingest.
+    respond = (urls) => ({
+      previews: urls.map((url) => ({
+        url,
+        status: 'ok',
+        kind: 'page',
+        title: 'T',
+        expiresAt: new Date(Date.now() + 15_000).toISOString(),
+      })),
+    });
+    primePreviews(['https://e.test/ok'], BOTH);
+    await tick(60);
+    expect(posted).toHaveLength(1);
+    await tick(10 * 60_000);
+    expect(posted).toHaveLength(1);
+  });
+
+  it('keeps a re-ask armed when the re-ask itself fails in transport', async () => {
+    // `runReask` disarms a URL as it queues it, expecting the ANSWER to re-arm it. A dropped
+    // connection is not an answer — so without the transport-failure branch the first blip
+    // during a re-ask retires that URL permanently, which is the bug all over again.
+    respond = transientFor;
+    primePreviews(['https://e.test/blip'], BOTH);
+    await tick(60);
+    expect(posted).toHaveLength(1);
+
+    respond = () => {
+      throw new Error('offline');
+    };
+    await tick(20_000);
+    expect(posted).toHaveLength(2); // the re-ask went out, and died
+
+    respond = okFor;
+    await tick(5 * 60_000);
+    expect(posted).toHaveLength(3);
+    expect(useLinkPreview('https://e.test/blip').value?.status).toBe('ok');
+  });
+
+  it('backs off rather than re-asking every 15s at the server-suggested rate', async () => {
+    // The floor doubles per consecutive failure. Without it a saturated instance is re-asked
+    // every 15 seconds by every open tab, for as long as the tabs stay open — a client
+    // hammering exactly the server that just told it that it was overloaded.
+    respond = transientFor;
+    primePreviews(['https://e.test/sat'], BOTH);
+    await tick(60);
+    expect(posted).toHaveLength(1);
+
+    await tick(16_000); // 1st re-ask, ~15s
+    expect(posted).toHaveLength(2);
+    await tick(16_000); // 2nd would be here at a flat rate; the floor is now 30s
+    expect(posted).toHaveLength(2);
+    await tick(16_000);
+    expect(posted).toHaveLength(3);
+  });
+});

--- a/vue_client/src/composables/useLinkPreview.test.ts
+++ b/vue_client/src/composables/useLinkPreview.test.ts
@@ -151,7 +151,13 @@ describe('re-asking after expiresAt', () => {
   // again. So a saturated instance blanked a preview for the life of the tab.
   //
   // Fake timers because the shortest honest wait here is the server's own 15 seconds.
-  beforeEach(() => vi.useFakeTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // The backoff is jittered ±25% on purpose (see `jitter`), which makes every deadline in
+    // these tests a range. Pinned to the midpoint so the timing assertions can be exact; the
+    // jitter itself is asserted separately below, where the randomness is the subject.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
   afterEach(() => vi.useRealTimers());
 
   /** Let the coalescing timer fire and the request settle, under fake timers. */
@@ -235,5 +241,83 @@ describe('re-asking after expiresAt', () => {
     expect(posted).toHaveLength(2);
     await tick(16_000);
     expect(posted).toHaveLength(3);
+  });
+
+  it('treats a one-hour verdict as an answer, not as something to come back for', async () => {
+    // ⚠⚠ The distinction the whole re-ask depends on. The server answers a genuine failure with
+    // FAIL_TTL_MS (1h) and a transient refusal with ~15s; re-asking both turns every dead link
+    // in the scrollback into an hourly outbound fetch for the life of the tab — and one that is
+    // guaranteed to miss the server's own cache, because both deadlines start together.
+    respond = (urls) => ({
+      previews: urls.map((url) => ({
+        url,
+        status: 'unavailable',
+        kind: 'page',
+        expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+      })),
+    });
+    primePreviews(['https://e.test/dead'], BOTH);
+    await tick(60);
+    expect(posted).toHaveLength(1);
+    await tick(3 * 60 * 60_000); // three hours
+    expect(posted).toHaveLength(1);
+  });
+
+  it('jitters the re-ask so simultaneous losers do not return as one wave', async () => {
+    // The server jitters its transient TTL precisely so that everything refused by one
+    // saturation event doesn't come back together. Taking `max(untilExpiry, floor)` against a
+    // FIXED floor threw that away and re-synchronised every client onto the same millisecond —
+    // a thundering herd aimed at a server that has just reported itself overloaded.
+    let n = 0;
+    vi.spyOn(Math, 'random').mockImplementation(() => (n++ === 0 ? 0 : 1)); // 0.75x, then 1.25x
+    respond = transientFor;
+    primePreviews(['https://e.test/a https://e.test/b'], BOTH);
+    await tick(60);
+    expect(posted).toEqual([['https://e.test/a', 'https://e.test/b']]);
+
+    // Answered together, they must not come BACK together: 11.25s and 18.75s.
+    await tick(12_000);
+    expect(posted).toHaveLength(2);
+    expect(posted[1]).toEqual(['https://e.test/a']);
+    await tick(8_000);
+    expect(posted).toHaveLength(3);
+    expect(posted[2]).toEqual(['https://e.test/b']);
+  });
+
+  it('recovers a row whose batch failed, without orphaning the ref it is watching', async () => {
+    // ⚠⚠ Components capture the Ref OBJECT, not the URL, so deleting a cache entry and minting
+    // a fresh one on the next ask delivers the answer into an object nothing is watching. The
+    // symptom is the nastiest kind: a fresh read reports `ok` while the row on screen stays
+    // blank forever, so the cache looks correct from every angle except the one that matters.
+    const held = useLinkPreview('https://e.test/held'); // a mounted row takes its ref
+    respond = () => {
+      throw new Error('offline');
+    };
+    primePreviews(['https://e.test/held'], BOTH);
+    await tick(60);
+    expect(posted).toHaveLength(1);
+    expect(held.value).toBeNull();
+
+    respond = okFor;
+    await tick(20_000);
+    expect(posted).toHaveLength(2);
+    // The SAME ref the row is watching must be the one that resolved.
+    expect(held.value?.status).toBe('ok');
+    expect(useLinkPreview('https://e.test/held')).toBe(held);
+  });
+
+  it('re-asks a URL the server silently omitted from an otherwise-fine response', async () => {
+    // No error, no verdict, no retry entry, and `asked` still holding it — a URL dropped from
+    // the response reached a state every recovery path stepped over. `?? []` on a malformed 200
+    // does the same thing to a whole batch at once.
+    respond = () => ({ previews: [] });
+    primePreviews(['https://e.test/ghost'], BOTH);
+    await tick(60);
+    expect(posted).toHaveLength(1);
+
+    respond = okFor;
+    await tick(20_000);
+    expect(posted).toHaveLength(2);
+    expect(useLinkPreview('https://e.test/ghost').value?.status).toBe('ok');
   });
 });

--- a/vue_client/src/composables/useLinkPreview.ts
+++ b/vue_client/src/composables/useLinkPreview.ts
@@ -104,12 +104,14 @@ async function flush(): Promise<void> {
         body: { urls: slice },
       });
       let changed = false;
+      const answered = new Set<string>();
       for (const preview of res.previews ?? []) {
         const entry = cache.get(preview.url);
         // Only an `ok` preview renders anything, so only an `ok` preview can change a row's
         // height — bumping the revision for a batch of `unavailable` answers would make the
         // list re-pin for no reason.
         if (entry) {
+          answered.add(preview.url);
           entry.value = preview;
           if (preview.status === 'ok') {
             changed = true;
@@ -119,30 +121,22 @@ async function flush(): Promise<void> {
           }
         }
       }
+      // ⚠⚠ Reconciled against what was SENT, not just iterated over what came back. A URL the
+      // server omits — a truncated response, a batch cap drifting out of step with MAX_BATCH,
+      // a 200 carrying an error body that `?? []` turns into zero previews — otherwise reached
+      // a state no recovery path could see: `asked` still holds it so priming skips it, no
+      // `retry` entry exists so nothing re-asks it, and `dropIfExpired` returns early because a
+      // null value has no `expiresAt`. Permanently blank, from a response that looked fine.
+      for (const url of slice) if (!answered.has(url)) forgetForRetry(url);
       if (changed) previewRevision.value++;
       scheduleReask();
     } catch {
-      // A failed resolve leaves the ref null, which renders as "no preview" —
-      // the same as a link the server couldn't unfurl. There is nothing useful
-      // to tell the user about a decoration that didn't appear, and an error
-      // state in the message list would be worse than the missing card.
-      // Dropped from `asked` as well as `cache`, so a request that failed for transport
-      // reasons can be retried on the next priming pass rather than being remembered as a
-      // permanent verdict about the URL.
-      for (const url of slice) {
-        const entry = cache.get(url);
-        if (entry && entry.value === null) {
-          cache.delete(url);
-          asked.delete(url);
-        } else if (entry && entry.value?.status !== 'ok') {
-          // ⚠ A re-ask that fails in transport must stay armed. `runReask` disarms a URL when it
-          // queues it, on the assumption that the answer re-arms it — so without this branch the
-          // FIRST dropped connection during a re-ask would retire that URL permanently, which is
-          // the same never-recovers outcome the re-ask exists to prevent. No deadline to honour
-          // here (there was no answer), so it's the backoff floor alone.
-          armReask(url, NaN);
-        }
-      }
+      // A failed resolve leaves the ref null, which renders as "no preview" — the same as a
+      // link the server couldn't unfurl. There is nothing useful to tell the user about a
+      // decoration that didn't appear, and an error state in the message list would be worse
+      // than the missing card. Every URL in the slice is put back in play; none of them got an
+      // answer, so none of them has a verdict to remember.
+      for (const url of slice) forgetForRetry(url);
       scheduleReask();
     }
   }
@@ -182,11 +176,54 @@ let reaskTimer: ReturnType<typeof setTimeout> | null = null;
 const REASK_FLOOR_MS = 15_000;
 const REASK_CEILING_MS = 5 * 60_000;
 
+/**
+ * The longest TTL that still means "come back" rather than "this is the answer".
+ *
+ * ⚠⚠ Without this test every dead link became a perpetual poller. The server answers a real
+ * failure with a one-hour TTL and a transient refusal with ~15 seconds, and re-asking both
+ * meant 300 dead links scrolled past turned into 300 outbound fetches an hour, per open tab,
+ * forever. Worse, the client's hourly deadline and the server's row TTL start at the same
+ * instant, so the re-ask landed just AFTER `expires_at` lapsed — a guaranteed cache miss and a
+ * fresh fetch to a known-dead origin every single time. A verdict is re-asked only by a new
+ * priming pass, which is what `dropIfExpired` is for.
+ */
+const VERDICT_TTL_MS = 60_000;
+
+/** ±25%, matching the server's own jitter on the TTL it sends. */
+function jitter(ms: number): number {
+  return Math.round(ms * (0.75 + Math.random() * 0.5));
+}
+
 function armReask(url: string, expiresAtMs: number): void {
+  const untilExpiry = Number.isFinite(expiresAtMs) ? expiresAtMs - Date.now() : 0;
+  if (untilExpiry > VERDICT_TTL_MS) {
+    retry.delete(url);
+    return;
+  }
   const tries = (retry.get(url)?.tries ?? 0) + 1;
   const floor = Math.min(REASK_CEILING_MS, REASK_FLOOR_MS * 2 ** (tries - 1));
-  const untilExpiry = Number.isFinite(expiresAtMs) ? expiresAtMs - Date.now() : 0;
-  retry.set(url, { at: Date.now() + Math.max(untilExpiry, floor), tries });
+  // ⚠ Jittered, and this is not cosmetic. The server jitters its transient TTL specifically so
+  // that "every loser of one saturation event doesn't come back as a single wave" — and taking
+  // `max(untilExpiry, floor)` against a fixed floor threw that away, re-synchronising every
+  // client onto the same millisecond. A thundering herd aimed at a server that has just said it
+  // is overloaded.
+  retry.set(url, { at: Date.now() + jitter(Math.max(untilExpiry, floor)), tries });
+}
+
+/**
+ * Put a URL back in play after an answer that wasn't one.
+ *
+ * ⚠⚠ The ref is deliberately NOT deleted. `MessageAttachments` captures the Ref OBJECT in a
+ * computed keyed on the message text, so a mounted row goes on watching whichever object it
+ * first received. Deleting the cache entry and minting a fresh one on the next ask therefore
+ * delivered the answer into an object nothing was watching: a fresh read showed `ok` while the
+ * row on screen stayed blank forever. Resetting `asked` re-opens the URL to priming without
+ * ever changing its identity.
+ */
+function forgetForRetry(url: string): void {
+  if (!cache.has(url)) return;
+  asked.delete(url);
+  armReask(url, NaN);
 }
 
 /** One timer for the whole map, set to the earliest deadline — not a timer per URL. */
@@ -253,9 +290,12 @@ function dropIfExpired(url: string): void {
   const expiresAt = entry?.value?.expiresAt;
   if (!expiresAt) return;
   if (Date.parse(expiresAt) > Date.now()) return;
-  cache.delete(url);
+  // ⚠ Neither the ref nor the backoff ladder is discarded. The ref because mounted rows hold it
+  // (see `forgetForRetry`); the `retry` entry because `tries` is the only record of how many
+  // times this URL has already failed — dropping it reset the ladder to zero, so a channel
+  // where a bot reposts a failing link never accumulated any backoff at all. The stale value
+  // keeps rendering meanwhile, which beats blanking a card that is merely due a refresh.
   asked.delete(url);
-  retry.delete(url);
 }
 
 function entryFor(url: string): Ref<LinkPreview | null> {

--- a/vue_client/src/composables/useLinkPreview.ts
+++ b/vue_client/src/composables/useLinkPreview.ts
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Client half of link previews.
+//
+// ⚠⚠ Resolution is driven by message INGEST, never by rendering. `primePreviews` is called
+// when messages enter the store — a backlog frame, a history page, a live message — and
+// components only ever READ, through `useLinkPreview`.
+//
+// The first version had this backwards: a row asked for its preview *while rendering*, which
+// kicked off a fetch, which mutated shared state, which grew the row, which forced the list to
+// correct its own scroll position. Rendering had side effects, so every scroll into history
+// triggered async growth and needed bespoke compensation. QA felt it exactly as described:
+// "the chat loads in completely flat, then inline content loads in a burst, throwing off the
+// scroll offset".
+//
+// Slack and Discord don't have this problem because an unfurl is part of the message record —
+// it arrives WITH the message, so scrollback is laid out correctly on first paint and async
+// growth only happens for a brand-new message at the bottom, where the list already follows.
+// Priming at ingest is how we get that property without the server storing unfurls on every
+// message (which would mean fetching for people who have the feature off).
+//
+// Two layers of coalescing, catching different things:
+//
+//   - `cache` dedupes across TIME. Scroll past a link and back, and the second pass is free.
+//   - `queue` dedupes across a TICK. A history page arrives with fifty rows; they become one
+//     POST rather than fifty.
+
+import { ref, type Ref } from 'vue';
+import { api } from '../api.js';
+import { previewableUrls, type PreviewToggles } from '../utils/previewUrls.js';
+
+export type PreviewKind = 'image' | 'video' | 'audio' | 'page' | 'video-embed';
+
+export interface LinkPreview {
+  url: string;
+  status: 'ok' | 'unavailable';
+  kind: PreviewKind;
+  title?: string;
+  description?: string;
+  siteName?: string;
+  author?: string;
+  /** Proxied bytes for direct media. Server-minted — never built here. */
+  src?: string;
+  /** Proxied card thumbnail. Server-minted — never built here. */
+  thumb?: string;
+  thumbWidth?: number;
+  thumbHeight?: number;
+  embedUrl?: string;
+  mime?: string;
+  expiresAt: string;
+}
+
+// Module-level, not per-component: two message rows showing the same link must
+// share one entry, and a row that unmounts on scroll must not throw away what
+// it learned.
+const cache = new Map<string, Ref<LinkPreview | null>>();
+
+/**
+ * URLs priming has already asked about.
+ *
+ * ⚠ Tracked SEPARATELY from `cache`, and that separation is load-bearing. `useLinkPreview`
+ * creates an empty entry as a side effect of being read, so when the skip condition was
+ * `cache.has(url)` a mere RENDER blocked that URL from ever being primed. The failure was
+ * exactly the default path: with both settings off nothing primes, then the user switches one
+ * on, every visible URL gets a null entry from the render pass, and no later history page or
+ * live message could ever queue them because they "already existed". Previews stayed missing
+ * until a full reload.
+ */
+const asked = new Set<string>();
+
+/**
+ * Bumped when a batch of previews lands and something changed.
+ *
+ * Only for the residual case: a reader scrolling fast enough to outrun the priming request,
+ * so a row renders before its preview is known and grows when it arrives. With priming at
+ * ingest this is the exception rather than — as it was — every single scroll into history.
+ */
+export const previewRevision = ref(0);
+
+let queue = new Set<string>();
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Server cap per request; batching past it just means a second POST. */
+const MAX_BATCH = 20;
+/**
+ * One frame-ish. Long enough that everything mounting in the same tick lands in
+ * one batch, short enough that a preview never feels like it's lagging behind
+ * the scroll.
+ */
+const FLUSH_MS = 24;
+
+async function flush(): Promise<void> {
+  flushTimer = null;
+  const urls = [...queue];
+  queue = new Set();
+  if (urls.length === 0) return;
+
+  for (let i = 0; i < urls.length; i += MAX_BATCH) {
+    const slice = urls.slice(i, i + MAX_BATCH);
+    try {
+      const res = await api<{ previews: LinkPreview[] }>('/api/link-preview/resolve', {
+        method: 'POST',
+        body: { urls: slice },
+      });
+      let changed = false;
+      for (const preview of res.previews ?? []) {
+        const entry = cache.get(preview.url);
+        // Only an `ok` preview renders anything, so only an `ok` preview can change a row's
+        // height — bumping the revision for a batch of `unavailable` answers would make the
+        // list re-pin for no reason.
+        if (entry) {
+          entry.value = preview;
+          if (preview.status === 'ok') {
+            changed = true;
+            retry.delete(preview.url);
+          } else {
+            armReask(preview.url, Date.parse(preview.expiresAt ?? ''));
+          }
+        }
+      }
+      if (changed) previewRevision.value++;
+      scheduleReask();
+    } catch {
+      // A failed resolve leaves the ref null, which renders as "no preview" —
+      // the same as a link the server couldn't unfurl. There is nothing useful
+      // to tell the user about a decoration that didn't appear, and an error
+      // state in the message list would be worse than the missing card.
+      // Dropped from `asked` as well as `cache`, so a request that failed for transport
+      // reasons can be retried on the next priming pass rather than being remembered as a
+      // permanent verdict about the URL.
+      for (const url of slice) {
+        const entry = cache.get(url);
+        if (entry && entry.value === null) {
+          cache.delete(url);
+          asked.delete(url);
+        } else if (entry && entry.value?.status !== 'ok') {
+          // ⚠ A re-ask that fails in transport must stay armed. `runReask` disarms a URL when it
+          // queues it, on the assumption that the answer re-arms it — so without this branch the
+          // FIRST dropped connection during a re-ask would retire that URL permanently, which is
+          // the same never-recovers outcome the re-ask exists to prevent. No deadline to honour
+          // here (there was no answer), so it's the backoff floor alone.
+          armReask(url, NaN);
+        }
+      }
+      scheduleReask();
+    }
+  }
+}
+
+// ─── Re-asking an `unavailable` once its TTL lapses ───────────────────────────
+//
+// ⚠⚠ The server deliberately does NOT cache some failures — pool saturation, a resolve
+// deadline — and stamps them with a ~15s `expiresAt` instead of the one-hour failure TTL,
+// specifically so a client comes back. Nothing was coming back: `dropIfExpired` only runs
+// inside `primePreviews`, which is driven by INGEST, and a message already in the store is
+// never ingested again. So a transient failure was indistinguishable from a permanent verdict
+// and the row stayed blank for the life of the tab — the exact outcome the server-side
+// transient/verdict split was built to avoid.
+//
+// This is time-driven, not render-driven, so the "a read is a read" invariant at the top of
+// this file still holds: rendering a row still cannot cause a fetch.
+
+/**
+ * When to ask again about a URL, and how many times we already have.
+ *
+ * `at: Infinity` means "asked, waiting for the answer" — see `runReask`.
+ */
+const retry = new Map<string, { at: number; tries: number }>();
+let reaskTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Floor on the gap between re-asks, doubling per consecutive failure up to a ceiling.
+ *
+ * ⚠ A FLOOR, not the delay itself — the delay is whatever the server's own `expiresAt` asks
+ * for, and this only raises it. That distinction is what keeps the steady state cheap without
+ * needing an attempt cap: a genuinely dead URL is answered with the one-hour failure TTL, so
+ * its next ask is an hour out and the floor never binds. The floor binds only on the 15s
+ * transient answer, which means the instance is saturated — precisely when backing off is the
+ * right thing to do rather than re-asking every 15 seconds for as long as the tab is open.
+ */
+const REASK_FLOOR_MS = 15_000;
+const REASK_CEILING_MS = 5 * 60_000;
+
+function armReask(url: string, expiresAtMs: number): void {
+  const tries = (retry.get(url)?.tries ?? 0) + 1;
+  const floor = Math.min(REASK_CEILING_MS, REASK_FLOOR_MS * 2 ** (tries - 1));
+  const untilExpiry = Number.isFinite(expiresAtMs) ? expiresAtMs - Date.now() : 0;
+  retry.set(url, { at: Date.now() + Math.max(untilExpiry, floor), tries });
+}
+
+/** One timer for the whole map, set to the earliest deadline — not a timer per URL. */
+function scheduleReask(): void {
+  if (reaskTimer !== null) {
+    clearTimeout(reaskTimer);
+    reaskTimer = null;
+  }
+  let earliest = Infinity;
+  for (const { at } of retry.values()) earliest = Math.min(earliest, at);
+  if (!Number.isFinite(earliest)) return;
+  reaskTimer = setTimeout(() => runReask(), Math.max(0, earliest - Date.now()));
+}
+
+function runReask(): void {
+  reaskTimer = null;
+  const now = Date.now();
+  let queued = false;
+  for (const [url, state] of retry) {
+    if (state.at > now) continue;
+    // Evicted by the cache ceiling, or dropped by `dropIfExpired` on a priming pass — either
+    // way nobody is holding a ref for it, so there is nothing to re-ask on behalf of.
+    if (!cache.has(url)) {
+      retry.delete(url);
+      continue;
+    }
+    // Parked as in-flight rather than deleted, and the difference is the whole backoff: the
+    // `tries` count lives in this entry, so deleting it meant the answer re-armed at tries=1
+    // every time and the floor never doubled — a "backoff" that was a flat 15s poll.
+    // Re-armed by whatever comes back (an answer, or the transport-failure branch in `flush`).
+    // Queued directly rather than through the `asked` gate: this URL is deliberately being
+    // asked about a second time.
+    retry.set(url, { at: Infinity, tries: state.tries });
+    queue.add(url);
+    queued = true;
+  }
+  if (queued && flushTimer === null) flushTimer = setTimeout(() => void flush(), FLUSH_MS);
+  scheduleReask();
+}
+
+/**
+ * Ceiling on remembered URLs.
+ *
+ * A long-lived tab would otherwise accumulate an entry per distinct URL for as long as it's
+ * open. Evicts oldest-first: `Map` preserves insertion order, and the oldest entry is the one
+ * least likely to still be on screen.
+ */
+const MAX_CACHE_ENTRIES = 2000;
+
+function evictIfNeeded(): void {
+  while (cache.size > MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+    asked.delete(oldest);
+    retry.delete(oldest);
+  }
+}
+
+/** Drop entries whose server-side TTL has lapsed, so they can be asked about again.
+ *  `expiresAt` was being carried on the wire and never read. */
+function dropIfExpired(url: string): void {
+  const entry = cache.get(url);
+  const expiresAt = entry?.value?.expiresAt;
+  if (!expiresAt) return;
+  if (Date.parse(expiresAt) > Date.now()) return;
+  cache.delete(url);
+  asked.delete(url);
+  retry.delete(url);
+}
+
+function entryFor(url: string): Ref<LinkPreview | null> {
+  let entry = cache.get(url);
+  if (!entry) {
+    entry = ref<LinkPreview | null>(null);
+    cache.set(url, entry);
+  }
+  return entry;
+}
+
+/**
+ * Ask the server about every previewable URL in a batch of message bodies.
+ *
+ * Called at INGEST — from the socket layer, as messages enter the store — so that by the time
+ * a row is rendered its preview is usually already known and the row is laid out correctly on
+ * its first paint. Idempotent and cheap: a URL already known or already queued is skipped, so
+ * calling this for an overlapping page costs a map lookup per URL.
+ *
+ * Returns immediately. Nothing awaits it: a history page must not wait on the internet before
+ * it can be read.
+ */
+export function primePreviews(
+  texts: readonly (string | null | undefined)[],
+  toggles: PreviewToggles,
+): void {
+  if (!toggles.inlineMedia && !toggles.linkPreviews) return;
+  let queued = false;
+  for (const text of texts) {
+    for (const url of previewableUrls(text, toggles)) {
+      dropIfExpired(url);
+      if (asked.has(url)) continue;
+      asked.add(url);
+      entryFor(url);
+      queue.add(url);
+      queued = true;
+    }
+  }
+  if (queued && flushTimer === null) flushTimer = setTimeout(() => void flush(), FLUSH_MS);
+  evictIfNeeded();
+}
+
+/**
+ * The preview for `url`, if one is known.
+ *
+ * READ-ONLY: this never triggers a fetch. A component asking about a URL nobody primed gets a
+ * permanently-null ref and renders nothing — which is correct, and is the property that keeps
+ * rendering free of side effects.
+ */
+export function useLinkPreview(url: string): Ref<LinkPreview | null> {
+  return entryFor(url);
+}
+
+/** Test-only: drop everything so a suite starts from a known state. */
+export function resetLinkPreviewCache(): void {
+  previewRevision.value = 0;
+  cache.clear();
+  asked.clear();
+  retry.clear();
+  queue = new Set();
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  // The re-ask timer too. `retry.clear()` above already makes a leaked one a no-op — it would
+  // wake to an empty map — so this is hygiene rather than a guard, and is deliberately not
+  // asserted by a test that would pass with it removed. It's here because a pending timer still
+  // holds the event loop open.
+  if (reaskTimer !== null) {
+    clearTimeout(reaskTimer);
+    reaskTimer = null;
+  }
+}

--- a/vue_client/src/composables/useMediaViewer.ts
+++ b/vue_client/src/composables/useMediaViewer.ts
@@ -18,6 +18,17 @@ import { computed, ref } from 'vue';
 export interface GalleryItem {
   url: string;
   filename?: string | null;
+  /**
+   * The address to hand a human, when it differs from the one we render.
+   *
+   * ⚠ Link previews render through our own media proxy, so `url` is `/api/link-preview/media/…`
+   * — a relative, auth-gated path that resolves to nothing for anyone else, not even another
+   * user on the same instance. Without somewhere to carry the origin, "copy link" on a previewed
+   * image silently produced that path, while the link TEXT two lines above it in the same
+   * message copied the real one. Falls back to `url` for everything else (uploads, plain links),
+   * where the rendered address IS the shareable one.
+   */
+  shareUrl?: string | null;
 }
 
 const isOpen = ref(false);
@@ -28,6 +39,9 @@ export function useMediaViewer() {
   const current = computed<GalleryItem | null>(() => items.value[index.value] ?? null);
   // The many call sites that only ever wanted "the image being viewed" keep working.
   const url = computed<string | null>(() => current.value?.url ?? null);
+  const shareUrl = computed<string | null>(
+    () => current.value?.shareUrl ?? current.value?.url ?? null,
+  );
   const count = computed(() => items.value.length);
   const hasPrev = computed(() => index.value > 0);
   const hasNext = computed(() => index.value < items.value.length - 1);
@@ -79,6 +93,7 @@ export function useMediaViewer() {
   return {
     isOpen,
     url,
+    shareUrl,
     items,
     index,
     current,

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type { Ref } from 'vue';
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { primePreviews } from './useLinkPreview.js';
+import { previewableEventTexts } from '../utils/previewEvents.js';
 import { useConfigStore } from '../stores/config.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
@@ -471,7 +472,11 @@ function applyEvent(event: any): void {
 //
 // Fire-and-forget by design. A history page must not wait on the internet before it can be
 // read, and nothing here can fail in a way a reader should hear about.
-function primeEventPreviews(events: unknown): void {
+function primeEventPreviews(
+  events: unknown,
+  fallbackNetworkId?: number | string | null,
+  fallbackTarget?: string | null,
+): void {
   if (!Array.isArray(events) || events.length === 0) return;
   // ANDed with the instance feature flag, matching MessageAttachments — priming a URL the
   // server has no route for would be a guaranteed 404 per batch.
@@ -483,9 +488,45 @@ function primeEventPreviews(events: unknown): void {
     linkPreviews: settings.effective('chat.link_previews.enabled') === true,
   };
   if (!toggles.inlineMedia && !toggles.linkPreviews) return;
-  primePreviews(
-    events.map((e) => (e as { text?: string | null }).text),
-    toggles,
+  primePreviews(previewableEventTexts(events, fallbackNetworkId, fallbackTarget), toggles);
+}
+
+let previewTogglesWired = false;
+
+/**
+ * Re-prime what is ALREADY in the store when a preview setting is switched on.
+ *
+ * ⚠⚠ Module-level and wired once, deliberately — this lived in `MessageList` and could not fire
+ * for the path almost everyone uses. Settings is a separate route with no `KeepAlive`, so
+ * opening it destroys the chat view and the watcher with it; coming back mounts a fresh one
+ * with no `immediate`, which therefore never observes the flip. Nor does the remount re-ingest
+ * anything, because the buffer already has messages. The net effect was that turning the
+ * setting on in the settings UI left every existing message without a preview, forever — the
+ * exact outcome the watcher was written to prevent. It only ever worked via `/set` and
+ * cross-device sync, which is why it survived QA.
+ *
+ * Every loaded buffer, not just the active one: `MessageList` is not keyed per buffer, so
+ * priming only what happens to be on screen left every other buffer blank for the session.
+ */
+function wirePreviewToggles(): void {
+  if (previewTogglesWired) return;
+  previewTogglesWired = true;
+  const config = useConfigStore();
+  const settings = useSettingsStore();
+  watch(
+    () => [
+      config.linkPreviews && settings.effective('chat.inline_media.enabled') === true,
+      config.linkPreviews && settings.effective('chat.link_previews.enabled') === true,
+    ],
+    ([inlineMedia, linkPreviews], previous) => {
+      // Only on a flip TO enabled. Turning one off needs no work: the rows stop rendering.
+      const gained = (inlineMedia && !previous?.[0]) || (linkPreviews && !previous?.[1]);
+      if (!gained) return;
+      const buffers = useBuffersStore();
+      for (const buf of Object.values(buffers.buffers)) {
+        primeEventPreviews(buf.messages, buf.networkId, buf.target);
+      }
+    },
   );
 }
 
@@ -587,7 +628,7 @@ function handleMessage(raw: string): void {
       for (const e of payload.events) trackSeenId(e?.id);
     }
     useBookmarksStore().noteFromEvents(payload.events, payload.networkId);
-    primeEventPreviews(payload.events);
+    primeEventPreviews(payload.events, payload.networkId, payload.target);
     applyBacklog(payload);
     return;
   }
@@ -601,7 +642,7 @@ function handleMessage(raw: string): void {
     // Every mode carries `events`; reconcile before the mode-specific dispatch so
     // one call covers around/latest/after/before alike.
     useBookmarksStore().noteFromEvents(payload.events, payload.networkId);
-    primeEventPreviews(payload.events);
+    primeEventPreviews(payload.events, payload.networkId, payload.target);
     if (mode === 'around') {
       buffers.applyAroundSlice(payload.networkId, payload.target, payload);
     } else if (mode === 'latest') {
@@ -1093,6 +1134,7 @@ function wireVisibility() {
 export function useSocket(): SocketAPI {
   onMounted(() => {
     wireVisibility();
+    wirePreviewToggles();
     open();
   });
   // Deliberately no teardown. The socket, and the reconnect timer that revives

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -7,6 +7,8 @@ import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useSettingsStore } from '../stores/settings.js';
+import { primePreviews } from './useLinkPreview.js';
+import { useConfigStore } from '../stores/config.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
 import { useDraftStore } from '../stores/drafts.js';
@@ -190,6 +192,10 @@ function applyEvent(event: any): void {
       // server's read-state broadcast (fired after every countable event),
       // so we don't increment them here.
       if (!buffers.pushMessage(event)) break;
+      // A live message is the one case where growth is expected and harmless: it lands at the
+      // bottom, where the list's existing stick-to-bottom logic follows it down. Primed after
+      // the dedupe check so a replayed event doesn't re-queue.
+      primeEventPreviews([event]);
       // Speakers feeds tab-complete and the nick-picker. Our own messages
       // would just clutter our own suggestions, so they don't count as
       // "people who recently spoke here."
@@ -455,6 +461,34 @@ function applyEvent(event: any): void {
   }
 }
 
+// Kick off preview resolution for a batch of incoming events.
+//
+// ⚠ This is the ONLY place previews are requested. Rendering a row never triggers a fetch —
+// see the header of composables/useLinkPreview. Priming here is what gives scrollback the
+// Slack/Discord property: by the time a history page's rows are rendered their previews are
+// usually already known, so the rows are laid out correctly on first paint instead of growing
+// under the reader a moment later.
+//
+// Fire-and-forget by design. A history page must not wait on the internet before it can be
+// read, and nothing here can fail in a way a reader should hear about.
+function primeEventPreviews(events: unknown): void {
+  if (!Array.isArray(events) || events.length === 0) return;
+  // ANDed with the instance feature flag, matching MessageAttachments — priming a URL the
+  // server has no route for would be a guaranteed 404 per batch.
+  const config = useConfigStore();
+  if (!config.linkPreviews) return;
+  const settings = useSettingsStore();
+  const toggles = {
+    inlineMedia: settings.effective('chat.inline_media.enabled') === true,
+    linkPreviews: settings.effective('chat.link_previews.enabled') === true,
+  };
+  if (!toggles.inlineMedia && !toggles.linkPreviews) return;
+  primePreviews(
+    events.map((e) => (e as { text?: string | null }).text),
+    toggles,
+  );
+}
+
 function applySnapshot(snapshot: any[], globalIgnores: any[] = []): void {
   const networks = useNetworksStore();
   const buffers = useBuffersStore();
@@ -553,6 +587,7 @@ function handleMessage(raw: string): void {
       for (const e of payload.events) trackSeenId(e?.id);
     }
     useBookmarksStore().noteFromEvents(payload.events, payload.networkId);
+    primeEventPreviews(payload.events);
     applyBacklog(payload);
     return;
   }
@@ -566,6 +601,7 @@ function handleMessage(raw: string): void {
     // Every mode carries `events`; reconcile before the mode-specific dispatch so
     // one call covers around/latest/after/before alike.
     useBookmarksStore().noteFromEvents(payload.events, payload.networkId);
+    primeEventPreviews(payload.events);
     if (mode === 'around') {
       buffers.applyAroundSlice(payload.networkId, payload.target, payload);
     } else if (mode === 'latest') {

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -67,7 +67,7 @@ function escapeRegex(s: string): string {
 // they'd be unbalanced inside the token — `https://en.wikipedia.org/wiki/Foo_(bar)`
 // keeps its trailing ')', but `(see https://example.com)` doesn't. Shared by
 // the URL and channel-name splitters.
-function trimTrailingPunctuation(s: string): string {
+export function trimTrailingPunctuation(s: string): string {
   const PAIRS: Record<string, string> = { ')': '(', ']': '[', '}': '{' };
   let end = s.length;
   while (end > 0) {
@@ -317,7 +317,7 @@ export function mircColor(
   return MIRC_PALETTE_FALLBACK[index] ?? null;
 }
 
-interface IrcRun {
+export interface IrcRun {
   text: string;
   bold: boolean;
   italic: boolean;
@@ -336,7 +336,7 @@ interface IrcRun {
 //   \x0F                                                 — reset all
 //   \x03[FG[,BG]] mIRC colour                            — FG and BG kept
 //   \x04[hex6[,hex6]] truecolour                         — consumed, dropped
-function parseIrcFormatting(text: string): IrcRun[] {
+export function parseIrcFormatting(text: string): IrcRun[] {
   const runs: IrcRun[] = [];
   let bold = false,
     italic = false,

--- a/vue_client/src/utils/previewEvents.test.ts
+++ b/vue_client/src/utils/previewEvents.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { previewableEventTexts } from './previewEvents.js';
+import { useIgnoresStore } from '../stores/ignores.js';
+
+const LINK = 'https://e.test/thing';
+
+function event(over: Record<string, unknown>) {
+  return { type: 'message', nick: 'alice', userhost: 'alice@host', text: `see ${LINK}`, ...over };
+}
+
+beforeEach(() => setActivePinia(createPinia()));
+
+describe('previewableEventTexts — only what can render', () => {
+  it('passes messages and actions through', () => {
+    const got = previewableEventTexts([event({}), event({ type: 'action' })], 1, '#chan');
+    expect(got).toHaveLength(2);
+  });
+
+  it('drops every event type that has no attachment renderer', () => {
+    // ⚠ These all carry a `text`, which is exactly why mapping over it was wrong: part and quit
+    // publish their REASON there, and topic publishes the topic. Joining a channel whose topic
+    // is a URL, or scrolling past `Quit: HexChat https://hexchat.github.io`, made the server
+    // perform a real outbound fetch for a row that can never show an attachment — burning the
+    // per-account resolve budget and the client's cache ceiling on unrenderable content.
+    const noise = ['quit', 'part', 'join', 'topic', 'notice', 'motd', 'nick', 'kick'].map((type) =>
+      event({ type }),
+    );
+    expect(previewableEventTexts(noise, 1, '#chan')).toEqual([]);
+  });
+
+  it('tolerates junk in the array', () => {
+    expect(previewableEventTexts([null, undefined, {}, event({ text: '' })], 1, '#chan')).toEqual(
+      [],
+    );
+    expect(previewableEventTexts(null, 1, '#chan')).toEqual([]);
+  });
+});
+
+describe('previewableEventTexts — ignoring is a veto on the FETCH', () => {
+  function ignore(mask: string) {
+    useIgnoresStore().byNetwork[1] = [
+      {
+        id: 1,
+        createdAt: '2026-01-01T00:00:00Z',
+        mask,
+        channels: null,
+        pattern: null,
+        patternKind: 'substr',
+        // `levels: []` compiles to a rule that hides nothing — a bare `/ignore mask` carries ALL.
+        levels: ['ALL'],
+        isExcept: false,
+        expiresAt: null,
+      },
+    ];
+  }
+
+  it('does not ask about a link from an ignored sender', () => {
+    // ⚠⚠ Ignores are client-side and render-time — the server ships the event intact and
+    // MessageList drops it while building rows. Priming runs BEFORE all of that, so a user who
+    // has `/ignore spammer` was still causing their own server to fetch every link that spammer
+    // posted, for rows they had explicitly chosen never to see.
+    ignore('spammer!*@*');
+    const events = [event({ nick: 'spammer', userhost: 'spammer@bad.host' }), event({})];
+    expect(previewableEventTexts(events, 1, '#chan')).toEqual([`see ${LINK}`]);
+  });
+
+  it('leaves everyone else alone', () => {
+    ignore('someoneelse!*@*');
+    expect(previewableEventTexts([event({})], 1, '#chan')).toHaveLength(1);
+  });
+
+  it('uses the FRAME network and target when the event carries none', () => {
+    // A backlog frame names its network and target once, at the top; only live events repeat
+    // them. Without the fallback the ignore check was skipped for every history page.
+    ignore('spammer!*@*');
+    const fromBacklog = {
+      type: 'message',
+      nick: 'spammer',
+      userhost: 'spammer@bad.host',
+      text: 'x',
+    };
+    expect(previewableEventTexts([fromBacklog], 1, '#chan')).toEqual([]);
+    // ...and with no network to evaluate against, it can only let it through.
+    expect(previewableEventTexts([fromBacklog], null, null)).toEqual(['x']);
+  });
+});

--- a/vue_client/src/utils/previewEvents.ts
+++ b/vue_client/src/utils/previewEvents.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { useIgnoresStore } from '../stores/ignores.js';
+
+export interface PrimableEvent {
+  type?: string;
+  text?: string | null;
+  nick?: string;
+  userhost?: string | null;
+  networkId?: number | string | null;
+  target?: string | null;
+}
+
+/**
+ * The message bodies in a batch of events that could actually produce a rendered attachment.
+ *
+ * Its own module, and not inlined in the socket layer, because it is pure policy about what the
+ * server is allowed to be asked to fetch — and because nothing in the socket layer is reachable
+ * from a test.
+ *
+ * Two filters, and both of them stop the SERVER making an outbound request on behalf of
+ * something nobody will ever see:
+ *
+ * ⚠ **Type.** `MessageList` mounts `MessageAttachments` for `message` and `action` only, but
+ * priming ran over every event in the frame — and part/quit publish their reason as `text`,
+ * topic publishes the topic, and a history page ships the whole contiguous range with the noise
+ * included. So joining a channel whose topic is a URL, or scrolling past
+ * `Quit: HexChat https://hexchat.github.io`, made the server fetch a page no render path can
+ * display. The live path already filtered this way and the backlog path did not; the two
+ * disagreeing is what hid it.
+ *
+ * ⚠ **Ignores.** Ignoring is client-side and render-time — the server ships the event intact and
+ * `MessageList` drops it while building rows — so priming, which runs BEFORE any of that,
+ * happily fetched every link posted by someone the user has explicitly silenced. Ignoring
+ * somebody is a veto on the fetch too, not just on the row.
+ */
+export function previewableEventTexts(
+  events: unknown,
+  fallbackNetworkId?: number | string | null,
+  fallbackTarget?: string | null,
+): (string | null | undefined)[] {
+  if (!Array.isArray(events) || events.length === 0) return [];
+  const ignores = useIgnoresStore();
+  const out: (string | null | undefined)[] = [];
+  for (const raw of events) {
+    const e = raw as PrimableEvent | null;
+    if (!e || (e.type !== 'message' && e.type !== 'action')) continue;
+    if (!e.text) continue;
+    // A frame carries its network and target once; a live event carries its own.
+    const networkId = e.networkId ?? fallbackNetworkId;
+    const target = e.target ?? fallbackTarget ?? '';
+    if (networkId != null && target) {
+      const verdict = ignores.evaluate(networkId, {
+        nick: e.nick ?? '',
+        userhost: e.userhost ?? null,
+        target,
+        text: e.text,
+        type: e.type,
+        // The same derivation MessageList uses; a store lookup would need the buffer.
+        isDm: !target.startsWith('#') && !target.startsWith(':server:'),
+      });
+      if (verdict.hide) continue;
+    }
+    out.push(e.text);
+  }
+  return out;
+}

--- a/vue_client/src/utils/previewUrls.test.ts
+++ b/vue_client/src/utils/previewUrls.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { previewableUrls, MAX_CARDS_PER_MESSAGE, MAX_MEDIA_PER_MESSAGE } from './previewUrls.js';
+
+const BOTH = { inlineMedia: true, linkPreviews: true };
+const NEITHER = { inlineMedia: false, linkPreviews: false };
+const MEDIA_ONLY = { inlineMedia: true, linkPreviews: false };
+const PAGES_ONLY = { inlineMedia: false, linkPreviews: true };
+
+describe('previewableUrls — the toggles', () => {
+  it('asks for nothing at all when both settings are off', () => {
+    // The load-bearing property of default-off: no work, not even a request
+    // that gets discarded.
+    expect(previewableUrls('https://e.test/a.png and https://e.test/page', NEITHER)).toEqual([]);
+  });
+
+  it('inline media selects file links and ignores pages', () => {
+    expect(previewableUrls('https://e.test/a.png https://e.test/article', MEDIA_ONLY)).toEqual([
+      'https://e.test/a.png',
+    ]);
+  });
+
+  it('link previews selects pages and ignores file links', () => {
+    expect(previewableUrls('https://e.test/a.png https://e.test/article', PAGES_ONLY)).toEqual([
+      'https://e.test/article',
+    ]);
+  });
+
+  it('both on selects both', () => {
+    expect(previewableUrls('https://e.test/a.png https://e.test/article', BOTH)).toEqual([
+      'https://e.test/a.png',
+      'https://e.test/article',
+    ]);
+  });
+
+  it('treats video and audio links as inline media, not as pages', () => {
+    expect(previewableUrls('https://e.test/clip.mp4 https://e.test/song.mp3', MEDIA_ONLY)).toEqual([
+      'https://e.test/clip.mp4',
+      'https://e.test/song.mp3',
+    ]);
+    expect(previewableUrls('https://e.test/clip.mp4', PAGES_ONLY)).toEqual([]);
+  });
+});
+
+describe('previewableUrls — what counts as a URL', () => {
+  it('ignores bare www hosts, which are not fetchable as written', () => {
+    expect(previewableUrls('see www.example.com for more', BOTH)).toEqual([]);
+  });
+
+  it('never resolves an email address', () => {
+    // The shared URL pattern matches these; resolving one would be both useless
+    // and a small privacy insult.
+    expect(previewableUrls('mail me at bob@example.com', BOTH)).toEqual([]);
+    expect(previewableUrls('mailto:bob@example.com', BOTH)).toEqual([]);
+  });
+
+  it('strips trailing sentence punctuation', () => {
+    expect(previewableUrls('go to https://e.test/page.', BOTH)).toEqual(['https://e.test/page']);
+    expect(previewableUrls('really? https://e.test/x!', BOTH)).toEqual(['https://e.test/x']);
+    expect(previewableUrls('(https://e.test/y)', BOTH)).toEqual(['https://e.test/y']);
+  });
+
+  it('keeps a path that legitimately contains punctuation', () => {
+    expect(previewableUrls('https://e.test/a.b.c/d', BOTH)).toEqual(['https://e.test/a.b.c/d']);
+  });
+
+  it('keeps a query string intact', () => {
+    expect(previewableUrls('https://e.test/s?q=1&r=2', BOTH)).toEqual(['https://e.test/s?q=1&r=2']);
+  });
+
+  it('handles a message that is nothing but a URL', () => {
+    expect(previewableUrls('https://e.test/only', BOTH)).toEqual(['https://e.test/only']);
+  });
+
+  it('is fine with empty, null, and undefined text', () => {
+    expect(previewableUrls('', BOTH)).toEqual([]);
+    expect(previewableUrls(null, BOTH)).toEqual([]);
+    expect(previewableUrls(undefined, BOTH)).toEqual([]);
+  });
+});
+
+describe('previewableUrls — limits', () => {
+  it('resolves a repeated link only once', () => {
+    const text = 'https://e.test/a https://e.test/a https://e.test/a';
+    expect(previewableUrls(text, BOTH)).toEqual(['https://e.test/a']);
+  });
+
+  it('caps CARDS tightly, because each one costs vertical space', () => {
+    const text = Array.from({ length: 12 }, (_, i) => `https://e.test/${i}`).join(' ');
+    expect(previewableUrls(text, BOTH).length).toBe(MAX_CARDS_PER_MESSAGE);
+  });
+
+  it('lets many images through, because a strip costs the same at 2 or at 12', () => {
+    // Media renders as one horizontally-scrolling strip of fixed height and the lightbox
+    // opens as a gallery over the whole thing, so the tenth image costs no more screen than
+    // the second and none of them is unreachable.
+    const text = Array.from({ length: 12 }, (_, i) => `https://e.test/${i}.png`).join(' ');
+    expect(previewableUrls(text, BOTH).length).toBe(12);
+  });
+
+  it('still bounds media, so a spam message is not fifty outbound fetches', () => {
+    const text = Array.from({ length: 40 }, (_, i) => `https://e.test/${i}.png`).join(' ');
+    expect(previewableUrls(text, BOTH).length).toBe(MAX_MEDIA_PER_MESSAGE);
+  });
+
+  it('counts the two caps independently', () => {
+    // Five cards' worth of pages plus five images: the pages are trimmed to three, the
+    // images all survive. One class filling up must not consume the other's budget.
+    const pages = Array.from({ length: 5 }, (_, i) => `https://e.test/page${i}`);
+    const images = Array.from({ length: 5 }, (_, i) => `https://e.test/img${i}.png`);
+    const got = previewableUrls([...pages, ...images].join(' '), BOTH);
+    expect(got.filter((u) => u.endsWith('.png')).length).toBe(5);
+    expect(got.filter((u) => !u.endsWith('.png')).length).toBe(MAX_CARDS_PER_MESSAGE);
+  });
+
+  it('counts the cap after deduping, not before', () => {
+    // Four mentions of one link plus two others should yield three previews,
+    // not one — otherwise a message quoting the same URL twice would silently
+    // lose its other links.
+    const text = 'https://e.test/a https://e.test/a https://e.test/b https://e.test/c';
+    expect(previewableUrls(text, BOTH)).toEqual([
+      'https://e.test/a',
+      'https://e.test/b',
+      'https://e.test/c',
+    ]);
+  });
+});

--- a/vue_client/src/utils/previewUrls.test.ts
+++ b/vue_client/src/utils/previewUrls.test.ts
@@ -16,10 +16,29 @@ describe('previewableUrls — the toggles', () => {
     expect(previewableUrls('https://e.test/a.png and https://e.test/page', NEITHER)).toEqual([]);
   });
 
-  it('inline media selects file links and ignores pages', () => {
-    expect(previewableUrls('https://e.test/a.png https://e.test/article', MEDIA_ONLY)).toEqual([
-      'https://e.test/a.png',
+  it('gates the two classes asymmetrically, because only one of them is knowable', () => {
+    // `mediaKindForUrl` recognises MEDIA extensions and returns null for everything else — a
+    // page, a bare host, an extensionless image alike. So "this is media" is a verdict the
+    // client can act on, and "this is not media" never is. Link-previews-off therefore drops a
+    // .png outright, while inline-media-off cannot drop an unknown without breaking the
+    // extensionless image case below.
+    expect(previewableUrls('https://e.test/a.png', PAGES_ONLY)).toEqual([]);
+    expect(previewableUrls('https://e.test/a.png', MEDIA_ONLY)).toEqual(['https://e.test/a.png']);
+  });
+
+  it('inline media still asks about an EXTENSIONLESS link, because it cannot tell', () => {
+    // ⚠ The deliberate trade, and it costs a fetch: with only inline media on, an extensionless
+    // URL is asked about even though most turn out to be pages. The alternative is worse —
+    // imgur, twimg and every CDN serve images from extensionless paths, so treating "no
+    // extension" as "definitely a page" made inline media permanently unable to render the
+    // majority of real image links. Bounded by the CARD cap (3), not the media cap, so a
+    // link-heavy message can't become twenty speculative fetches. A page that comes back is
+    // still not RENDERED — MessageAttachments re-checks the server's answer.
+    expect(previewableUrls('https://i.imgur.com/aBcDeF', MEDIA_ONLY)).toEqual([
+      'https://i.imgur.com/aBcDeF',
     ]);
+    const many = Array.from({ length: 9 }, (_, i) => `https://e.test/p${i}`).join(' ');
+    expect(previewableUrls(many, MEDIA_ONLY)).toHaveLength(MAX_CARDS_PER_MESSAGE);
   });
 
   it('link previews selects pages and ignores file links', () => {
@@ -64,6 +83,40 @@ describe('previewableUrls — what counts as a URL', () => {
 
   it('keeps a path that legitimately contains punctuation', () => {
     expect(previewableUrls('https://e.test/a.b.c/d', BOTH)).toEqual(['https://e.test/a.b.c/d']);
+  });
+
+  it('ends a URL where the LINKIFIER ends it, brackets and all', () => {
+    // ⚠ Two parsers disagreeing about where a URL stops is the bug. The anchor the user clicks
+    // is built by nickColor's balance-aware trimmer, so stripping ')' unconditionally here
+    // resolved a DIFFERENT address than the one in the message: the real page 200s, the
+    // clipped one 404s, and that 404 is cached for an hour under a string that appears nowhere
+    // in the text. Same helper for both, so they cannot drift.
+    const wiki = 'https://en.wikipedia.org/wiki/Rust_(programming_language)';
+    expect(previewableUrls(`see ${wiki}`, BOTH)).toEqual([wiki]);
+    // ...while a URL merely wrapped in brackets still loses them.
+    expect(previewableUrls('(https://e.test/y)', BOTH)).toEqual(['https://e.test/y']);
+  });
+
+  it('never resolves a link hidden behind a spoiler', () => {
+    // ⚠⚠ The renderer skips URL splitting inside a spoiler run precisely so a link cannot leak
+    // the hidden content. Resolving one anyway renders the target full-size as a SIBLING of the
+    // click-to-reveal box — the spoiler is defeated by the preview, and for an image the payload
+    // is on screen before anyone chooses to reveal it. Only inline media need be on.
+    const hidden = '\x0301,01https://secret.example/leak.png\x03';
+    expect(previewableUrls(hidden, BOTH)).toEqual([]);
+    expect(previewableUrls(hidden, MEDIA_ONLY)).toEqual([]);
+    // A visible link in the same message is unaffected.
+    expect(previewableUrls(`ok https://e.test/fine.png ${hidden}`, BOTH)).toEqual([
+      'https://e.test/fine.png',
+    ]);
+  });
+
+  it('strips formatting codes out of the URL rather than resolving them', () => {
+    // A colour reset immediately after a link put \x03 INSIDE the matched token, so the
+    // resolver was handed an address with a control character on the end.
+    expect(previewableUrls('\x0304https://e.test/red.png\x03 done', BOTH)).toEqual([
+      'https://e.test/red.png',
+    ]);
   });
 
   it('keeps a query string intact', () => {

--- a/vue_client/src/utils/previewUrls.ts
+++ b/vue_client/src/utils/previewUrls.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { createUrlRegex } from '../../../shared/urlPattern.js';
+import { mediaKindForUrl } from './uploadHostMatch.js';
+
+/**
+ * Cap on CARDS per message.
+ *
+ * Slack allows five, halloy defaults to one. Three is enough for a message genuinely sharing
+ * a few links, and short of enough for one message to take over a screen. Each card costs
+ * real vertical space, so this one has to stay tight.
+ */
+export const MAX_CARDS_PER_MESSAGE = 3;
+
+/**
+ * Cap on MEDIA per message — deliberately generous.
+ *
+ * Media doesn't cost vertical space the way a card does: two or more images render as one
+ * horizontally-scrolling strip of fixed height, so the tenth image costs exactly as much
+ * screen as the second. And clicking any of them opens the lightbox as a GALLERY over the
+ * whole strip, so nothing is unreachable.
+ *
+ * A limit still exists, because a message carrying fifty image URLs is spam and each one is
+ * an outbound fetch on the server's behalf. It's set high enough not to bind on anything a
+ * person would actually post.
+ */
+export const MAX_MEDIA_PER_MESSAGE = 20;
+
+export interface PreviewToggles {
+  inlineMedia: boolean;
+  linkPreviews: boolean;
+}
+
+/**
+ * Which URLs in a message body are worth asking the server about.
+ *
+ * The two toggles select different URLs, which is the whole reason they're two
+ * settings: inline media covers links that ARE a file, link previews cover links
+ * to a page. With both off this returns an empty array without touching the
+ * network — that's what makes the features genuinely free when disabled.
+ *
+ * ⚠ The extension test here is a HINT, not a verdict. It decides which setting
+ * would cover a URL and therefore whether to bother asking; the server answers
+ * authoritatively from Content-Type, and the render path re-checks that answer
+ * against the settings. Guessing wrong costs one wasted resolve, never a render
+ * the user switched off.
+ */
+export function previewableUrls(
+  text: string | null | undefined,
+  { inlineMedia, linkPreviews }: PreviewToggles,
+): string[] {
+  if (!inlineMedia && !linkPreviews) return [];
+  if (!text) return [];
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  let mediaCount = 0;
+  let cardCount = 0;
+
+  for (const match of text.matchAll(createUrlRegex())) {
+    const raw = match[0];
+    // The shared pattern also matches bare `www.` hosts and email addresses.
+    // Neither is fetchable as written, and we are emphatically not resolving
+    // somebody's email address.
+    if (!/^https?:\/\//i.test(raw)) continue;
+
+    // Trailing punctuation belongs to the sentence, not to the URL: "see
+    // https://example.com/x." must not resolve a path ending in a full stop.
+    // A closing bracket is included for the same reason, at the known cost of
+    // clipping the rare URL that legitimately ends in one.
+    const url = raw.replace(/[.,;:!?)\]}'"]+$/, '');
+    if (!url || seen.has(url)) continue;
+
+    const looksLikeMedia = mediaKindForUrl(url) !== null;
+    if (looksLikeMedia ? !inlineMedia : !linkPreviews) continue;
+    if (looksLikeMedia ? mediaCount >= MAX_MEDIA_PER_MESSAGE : cardCount >= MAX_CARDS_PER_MESSAGE)
+      continue;
+
+    if (looksLikeMedia) mediaCount++;
+    else cardCount++;
+    seen.add(url);
+    out.push(url);
+  }
+  return out;
+}

--- a/vue_client/src/utils/previewUrls.ts
+++ b/vue_client/src/utils/previewUrls.ts
@@ -3,6 +3,7 @@
 
 import { createUrlRegex } from '../../../shared/urlPattern.js';
 import { mediaKindForUrl } from './uploadHostMatch.js';
+import { parseIrcFormatting, trimTrailingPunctuation } from './nickColor.js';
 
 /**
  * Cap on CARDS per message.
@@ -45,6 +46,14 @@ export interface PreviewToggles {
  * authoritatively from Content-Type, and the render path re-checks that answer
  * against the settings. Guessing wrong costs one wasted resolve, never a render
  * the user switched off.
+ *
+ * ⚠⚠ Runs through the IRC formatting parser rather than over the raw wire text, for two
+ * reasons that both bite. A URL inside a SPOILER run must not be resolved at all — the
+ * renderer (nickColor's `toRenderSegments`) deliberately skips URL splitting there so a link
+ * can't leak hidden content, and unfurling one renders the target full-size next to the
+ * click-to-reveal box, which defeats the spoiler completely. And formatting codes live INSIDE
+ * the matched token otherwise: `\x03` on the end of a URL was being sent to the resolver as
+ * part of the address.
  */
 export function previewableUrls(
   text: string | null | undefined,
@@ -58,29 +67,44 @@ export function previewableUrls(
   let mediaCount = 0;
   let cardCount = 0;
 
-  for (const match of text.matchAll(createUrlRegex())) {
-    const raw = match[0];
-    // The shared pattern also matches bare `www.` hosts and email addresses.
-    // Neither is fetchable as written, and we are emphatically not resolving
-    // somebody's email address.
-    if (!/^https?:\/\//i.test(raw)) continue;
+  for (const run of parseIrcFormatting(text)) {
+    // Same test the renderer uses for the IRC spoiler convention: a run whose foreground and
+    // background are the same colour is invisible text.
+    if (run.fg != null && run.bg != null && run.fg === run.bg) continue;
 
-    // Trailing punctuation belongs to the sentence, not to the URL: "see
-    // https://example.com/x." must not resolve a path ending in a full stop.
-    // A closing bracket is included for the same reason, at the known cost of
-    // clipping the rare URL that legitimately ends in one.
-    const url = raw.replace(/[.,;:!?)\]}'"]+$/, '');
-    if (!url || seen.has(url)) continue;
+    for (const match of run.text.matchAll(createUrlRegex())) {
+      const raw = match[0];
+      // The shared pattern also matches bare `www.` hosts and email addresses.
+      // Neither is fetchable as written, and we are emphatically not resolving
+      // somebody's email address.
+      if (!/^https?:\/\//i.test(raw)) continue;
 
-    const looksLikeMedia = mediaKindForUrl(url) !== null;
-    if (looksLikeMedia ? !inlineMedia : !linkPreviews) continue;
-    if (looksLikeMedia ? mediaCount >= MAX_MEDIA_PER_MESSAGE : cardCount >= MAX_CARDS_PER_MESSAGE)
-      continue;
+      // ⚠ The LINKIFIER's trimmer, deliberately shared rather than re-expressed. The old
+      // regex stripped closing brackets unconditionally while the anchor-building path is
+      // balance-aware, so `…/wiki/Rust_(programming_language)` was resolved a character short
+      // of the URL the user actually clicks: the card silently never appeared, and the 404 was
+      // cached for an hour under a string appearing nowhere in the message. Two parsers
+      // disagreeing about where a URL ends is the bug; one parser is the fix.
+      const url = trimTrailingPunctuation(raw);
+      if (!url || seen.has(url)) continue;
 
-    if (looksLikeMedia) mediaCount++;
-    else cardCount++;
-    seen.add(url);
-    out.push(url);
+      // Three-way, not two. `mediaKindForUrl` returns null both for "definitely a page" and
+      // for "no extension to judge by" — and collapsing those meant an extensionless image
+      // host (imgur, twimg) could never render for someone who enabled ONLY inline media,
+      // permanently, since priming is ingest-driven. Unknowns are charged to the CARD budget,
+      // which is the tight one, so honouring them can't turn a link-heavy message into twenty
+      // speculative fetches.
+      const isMedia = mediaKindForUrl(url) !== null;
+      const wanted = isMedia ? inlineMedia : linkPreviews || inlineMedia;
+      if (!wanted) continue;
+      if (isMedia ? mediaCount >= MAX_MEDIA_PER_MESSAGE : cardCount >= MAX_CARDS_PER_MESSAGE)
+        continue;
+
+      if (isMedia) mediaCount++;
+      else cardCount++;
+      seen.add(url);
+      out.push(url);
+    }
   }
   return out;
 }

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -287,6 +287,7 @@
     <MediaViewerModal
       v-if="viewer.isOpen && viewer.url !== null"
       :url="viewer.url"
+      :share-url="viewer.shareUrl"
       :filename="viewer.current?.filename ?? null"
       :index="viewer.index"
       :count="viewer.count"

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -215,6 +215,7 @@
     <MediaViewerModal
       v-if="viewer.isOpen && viewer.url !== null"
       :url="viewer.url"
+      :share-url="viewer.shareUrl"
       :filename="viewer.current?.filename ?? null"
       :index="viewer.index"
       :count="viewer.count"


### PR DESCRIPTION
PR 5 of the link-previews stack, cut from `main` per `LINK_PREVIEWS_PR_PLAN.md`. Renders inline media and preview cards behind the two registry options PR 4 landed, both still off by default and hidden unless the operator sets `LURKER_LINK_PREVIEWS`.

Follows PR 4's ordering: **`/code-review max` was run before opening this**, so the fix commits are part of the diff rather than a follow-up nobody re-reviews.

## The architecture

Resolution is driven by message **ingest**, never by rendering. `primePreviews` is called as messages enter the store; components only ever read. That is what keeps scrollback laid out correctly on first paint instead of growing under the reader — the property Slack and Discord get by making the unfurl part of the message record.

## What was cut

Ten files. Deliberately **not** taken from the reference branch: `settingsRegistry.ts` + test, `MessageInput.vue`, `SettingsSidebar.vue` — `main` is ahead of the reference branch on all four, because PR 4 landed the better versions. Checking them out would have reverted real work.

## The two client bugs PR 4's review handed forward

- **`expiresAt` was honoured by nobody.** The server splits `unavailable` into a cached verdict (1h) and an uncached transient refusal (~15s) specifically so a client comes back. Nothing came back: `dropIfExpired` only ran inside `primePreviews`, which is ingest-driven, and a message already in the store is never ingested again. Re-asks are now time-driven, which keeps reads free of side effects.
- **`video-embed` without an `embedUrl`** already degraded correctly, but nothing tested it. Now pinned.

## Review findings

`/code-review max` returned **15 findings, all reproducible with executed probes**, plus a cut-list. All 15 are fixed here, and they are worth reading as a group because **four were in the re-ask added by the first commit** — the same "review fixes are risky" pattern PR 4 hit.

Headlines:

- **A spoilered link was unfurled and rendered in full.** The renderer deliberately skips URL splitting inside a spoiler run so a link can't leak the hidden content; priming ran over raw wire text and had no such rule, so the target rendered full-size next to the click-to-reveal box. Only inline media need be on.
- **Ignoring somebody was not a veto on the fetch.** Ignores are client-side and render-time; priming runs before all of it, so `/ignore spammer` still had the server fetch every link they posted.
- **The re-prime-on-toggle watcher could not fire for the GUI path.** Settings is a separate route, so opening it destroys `MessageList` and the watcher; the remount never sees the flip. Turning the setting on in the settings UI left every existing message previewless — the exact outcome the watcher's own comment claims it prevents. It only worked via `/set`, which is why QA would have missed it.
- **Every dead link became a perpetual poller.** My re-ask armed on any non-`ok` answer with no test for TTL length, so a verdict was re-asked hourly forever — landing just after the server's own row TTL lapsed, guaranteeing a cache miss and a fresh fetch to a dead origin. The backoff also had no jitter, re-synchronising every client onto the same millisecond against a server that had just reported itself saturated.
- **Two parsers disagreed about where a URL ends.** The linkifier is bracket-balance-aware; priming stripped `)` unconditionally, so `…/wiki/Rust_(programming_language)` resolved a character short: the card silently never appeared and the 404 was cached for an hour under a string appearing nowhere in the message.
- **A cache delete orphaned refs mounted rows were watching**, so a recovered answer landed in an object nothing observed — a fresh read said `ok` while the row stayed blank forever.
- Plus: `elementFromPoint` unscoped (any open modal redirected the scroll re-pin, or it anchored the buffer's oldest row); `<video>` growing uncompensated; `@click.stop` creating a dead tap zone over the largest target in the row with no keyboard path; attachments mounting on every row with the feature off; "copy link" yielding an auth-gated relative path; extensionless image hosts unable to render for inline-media-only users.

From the cut-list, also fixed: a **vacuous fade test** (the reviewer proved by mutation that inverting `updateEdges` kept all 22 tests green — happy-dom reports every box as zero), a ResizeObserver that enumerated children once and went stale, the card cap never being re-applied to the server's answer, and two `font-size` declarations that `AGENTS.md` forbids outright.

## Gates

Every fix was confirmed by **reverting it and watching the named test go red** — 14 individual revert probes. Two caught mistakes that would otherwise have shipped:

- Reverting the re-ask arming exposed a bug in my own first implementation: `runReask` deleted the retry entry before queueing, so `armReask` recomputed `tries` from zero and the "backoff" was a flat 15s poll.
- One test I wrote **guarded nothing** — an `ok` preview with a 2099 TTL isn't re-asked whether or not `ok` answers are excluded, so it asserted a fact about the fixture. Rewritten to use a short-TTL success, which does bite.

`npm run check` and `npm test` green: 243 files, 3396 tests.

## Not done

**Human QA.** Everything here is verified by tests and typechecks only. The scroll re-pin, the strip's drag/snap feel, and the card treatment on a highlighted row have not been looked at by a person since the branch was rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)