### PR TITLE
Inline media: reveal a message's attachments all at once, and never size from bytes

### DIFF
--- a/vue_client/src/api.ts
+++ b/vue_client/src/api.ts
@@ -11,6 +11,16 @@ export interface ApiRequestOptions {
   method?: string;
   body?: unknown;
   headers?: Record<string, string>;
+  /**
+   * Abort the request.
+   *
+   * ⚠ Without one, a `fetch` here can hang FOREVER — there is no default timeout in any browser
+   * for a socket that stays open, so a dead NAT mapping, a sleeping laptop or a proxy that
+   * accepts and never answers leaves the promise pending for the life of the tab. Racing a timer
+   * against it is not the same thing: the request keeps its socket, still downloads and parses
+   * the body, and resolves into a handler that has already given up.
+   */
+  signal?: AbortSignal;
 }
 
 // One-shot guard so an unrecoverable 401 can't loop the page reload.
@@ -82,10 +92,11 @@ export function clearAuthRecoveryGuard(): void {
 // that want a checked shape can pass it explicitly: `api<{ user: User }>(url)`.
 export async function api<T = any>(
   url: string,
-  { method = 'GET', body, headers }: ApiRequestOptions = {},
+  { method = 'GET', body, headers, signal }: ApiRequestOptions = {},
 ): Promise<T> {
   const res = await fetch(url, {
     method,
+    signal,
     credentials: 'include',
     headers: {
       Accept: 'application/json',

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -11,8 +11,8 @@
 // The first suite exists because QA saw no YouTube card while the server was verified to be
 // answering correctly — nothing was testing the span between those two facts.
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ref } from 'vue';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { nextTick, ref, type Ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import MessageAttachment from './MessageAttachment.vue';
@@ -25,9 +25,27 @@ import { MAX_CARDS_PER_MESSAGE } from '../utils/previewUrls.js';
 
 // Resolution is driven by message ingest, so components only read — stub the read. A real
 // `ref` is required: the templates rely on Vue's auto-unwrapping, which is keyed on `isRef`.
+//
+// ⚠ ONE ref per URL, cached, rather than a fresh one per call. The real composable does the same
+// (`entryFor`), and the atomic-reveal suite depends on it: seeding a URL AFTER mount has to reach
+// the ref the component is already watching. `seedSettings` clears the cache, so each test still
+// starts from a clean slate.
 const resolved = new Map<string, LinkPreview>();
+const refs = new Map<string, Ref<LinkPreview | null>>();
+function entryRef(url: string): Ref<LinkPreview | null> {
+  let entry = refs.get(url);
+  if (!entry) {
+    entry = ref<LinkPreview | null>(resolved.get(url) ?? null);
+    refs.set(url, entry);
+  }
+  return entry;
+}
+// `vi.hoisted` because a `vi.mock` factory runs before module-level consts initialise, and this
+// one is dereferenced AT factory time rather than inside a lazy arrow like `useLinkPreview` is.
+const previewRevision = vi.hoisted(() => ({ value: 0 }));
 vi.mock('../composables/useLinkPreview.js', () => ({
-  useLinkPreview: (url: string) => ref(resolved.get(url) ?? null),
+  useLinkPreview: (url: string) => entryRef(url),
+  previewRevision,
 }));
 
 function preview(over: Partial<LinkPreview> & { url: string }): LinkPreview {
@@ -59,6 +77,8 @@ const IMAGE = preview({
 });
 
 function seedSettings({ inlineMedia = true, linkPreviews = true, feature = true } = {}) {
+  // Per-test slate for the cached preview refs — see the mock above.
+  refs.clear();
   setActivePinia(createPinia());
   // The instance feature flag gates both user settings — a stored `true` must not render on an
   // instance that has the feature off, where the routes aren't even mounted. Defaults on here so
@@ -328,6 +348,165 @@ describe('MessageAttachments — arrangement', () => {
     // The ingest-driven model's normal early state, and the case a row must render as
     // "nothing" rather than as a placeholder that later collapses.
     expect(mountFor('https://e.test/not-primed').find('.attachments').exists()).toBe(false);
+  });
+});
+
+describe('MessageAttachments — atomic reveal', () => {
+  // The rule: no layout may depend on WHEN A SIBLING RESOLVES. A message with two image URLs, one
+  // of them already cached from an earlier post, used to paint as a lone image and then
+  // re-arrange into a filmstrip when the second landed — and `stripHeight` re-picked
+  // portrait-vs-landscape as the mix changed. Both moved a scrolled-up reader with no way to
+  // compensate, because the growth had already happened by the time anything heard about it.
+
+  beforeEach(() => {
+    resolved.clear();
+    previewRevision.value = 0;
+  });
+  afterEach(() => vi.useRealTimers());
+
+  const img = (n: number, w = 800, h = 600) =>
+    preview({
+      url: `https://e.test/${n}.png`,
+      kind: 'image',
+      src: `/api/link-preview/media/t${n}`,
+      thumbWidth: w,
+      thumbHeight: h,
+    });
+
+  const TWO = 'https://e.test/1.png https://e.test/2.png';
+
+  it('shows nothing while a sibling is still unresolved, then the whole block at once', async () => {
+    // ⚠ The assertion that bites is the FIRST one: with the gate removed this renders a lone
+    // `.inline-image`, which is the arrangement that then flips.
+    resolved.set(img(1).url, img(1));
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: TWO } });
+    expect(wrapper.find('.attachments').exists()).toBe(false);
+    expect(wrapper.find('.inline-image').exists()).toBe(false);
+
+    entryRef(img(2).url).value = img(2);
+    await nextTick();
+
+    expect(wrapper.find('.filmstrip').exists()).toBe(true);
+    expect(wrapper.findAll('.filmstrip img')).toHaveLength(2);
+  });
+
+  it('decides the strip height once, from the complete group', async () => {
+    // ⚠ TWO portraits resolve first, so that without the gate there IS a filmstrip mid-flight —
+    // at 300px, since the group is entirely portrait — which then collapses to 200px when the
+    // third lands and tips the predicate. The first assertion is what notices the loss of the
+    // gate; an earlier draft of this test seeded ONE image and passed with the fix reverted,
+    // because one image is never a filmstrip either way.
+    // Two of four portrait is landscape ("primarily portrait" is `portrait * 2 > length`), so the
+    // complete group is a 200px row while the half that resolves first is a 300px one.
+    resolved.set(img(1, 600, 900).url, img(1, 600, 900));
+    resolved.set(img(2, 500, 1000).url, img(2, 500, 1000));
+    seedSettings();
+    const wrapper = mount(MessageAttachments, {
+      props: { text: `${TWO} https://e.test/3.png https://e.test/4.png` },
+    });
+    expect(wrapper.find('.filmstrip').exists()).toBe(false);
+
+    entryRef(img(3).url).value = img(3, 1200, 500);
+    entryRef(img(4).url).value = img(4, 1000, 400);
+    await nextTick();
+
+    expect(wrapper.find('.filmstrip').attributes('style')).toContain('200px');
+  });
+
+  it('reveals synchronously, and arms no timer, when everything already resolved', () => {
+    // The common case once a row scrolls back into view: the answers landed long ago. A timer
+    // apiece for every mounted row would be pure waste.
+    vi.useFakeTimers();
+    resolved.set(img(1).url, img(1));
+    resolved.set(img(2).url, img(2));
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: TWO } });
+    expect(wrapper.find('.filmstrip').exists()).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('reveals what it has after the deadline, and bumps previewRevision BEFORE it does', async () => {
+    // ⚠⚠ The safety net. `useLinkPreview` returns a permanently-null ref for a URL nobody primed,
+    // so without this a parser/policy divergence between the render path and the priming path
+    // would blank the message for the life of the tab.
+    vi.useFakeTimers();
+    resolved.set(img(1).url, img(1));
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: TWO } });
+    expect(wrapper.find('.attachments').exists()).toBe(false);
+
+    vi.advanceTimersByTime(1500);
+    await nextTick();
+
+    expect(wrapper.find('.inline-image').exists()).toBe(true);
+    // ⚠ The bump is what `MessageList`'s pre-flush watcher re-pins on. A timer-driven reveal is
+    // invisible to it otherwise, so the growth lands uncompensated on a scrolled-up reader — the
+    // exact failure mode this whole change exists to remove. Asserting the COUNT would not
+    // notice the ordering, so the ordering is covered by the bump happening at all plus the
+    // component's own statement order; this assertion guards the bump.
+    expect(previewRevision.value).toBe(1);
+  });
+
+  it('clears its deadline timer on unmount', () => {
+    // "Leaked" here means a timer that outlives the row and bumps previewRevision — a re-pin on
+    // behalf of a component that no longer exists.
+    vi.useFakeTimers();
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: TWO } });
+    expect(vi.getTimerCount()).toBe(1);
+    wrapper.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe('MessageAttachment — a box that does not depend on bytes', () => {
+  beforeEach(() => seedSettings());
+
+  // ⚠ These assert the CLASS BINDING, which is the load-bearing logic; the height itself is CSS
+  // and happy-dom applies no stylesheet. Stated rather than implied, because a test that can't
+  // observe what it names is the trap this feature has already been caught by once.
+
+  const unmeasured = preview({
+    url: 'https://e.test/exotic',
+    kind: 'image',
+    src: '/api/link-preview/media/tokX',
+  });
+
+  it('gives an image the server could not measure a fixed box', () => {
+    // `imageDimensions` returns null for a format sharp can't parse in the 64 KB it reads. With
+    // no width/height attributes there is no ratio to reserve a box from, so the element lays out
+    // at the UA default and grows on decode — video's pre-465f838 bug, still live for images.
+    const wrapper = mount(MessageAttachment, { props: { preview: unmeasured } });
+    expect(wrapper.find('img').classes()).toContain('no-dims');
+  });
+
+  it('leaves a measured image to its own aspect ratio', () => {
+    // The descriptor arrives atomically with the decision to render at all, so natural aspect
+    // costs nothing — and a fixed box would letterbox or upscale for no reason.
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    expect(wrapper.find('img').classes()).not.toContain('no-dims');
+    expect(wrapper.find('img').attributes('width')).toBe('800');
+  });
+
+  it('does not fix the height of an unmeasured image inside a strip', () => {
+    // The row already decides the height there; a second fixed height would fight it.
+    const wrapper = mount(MessageAttachment, {
+      props: { preview: unmeasured, inStrip: true },
+    });
+    expect(wrapper.find('img').classes()).not.toContain('no-dims');
+    expect(wrapper.find('img').classes()).toContain('strip-item');
+  });
+
+  it('keeps the reserved box when the bytes never arrive', async () => {
+    // A rotated session secret invalidates outstanding proxy tokens, and an origin can die
+    // between resolve and render. The attributes are what reserve the box, so the failure must
+    // not remove them — it only swaps the UA's broken-image glyph for the card panel's fill.
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    await wrapper.find('img').trigger('error');
+    expect(wrapper.find('img').classes()).toContain('failed');
+    expect(wrapper.find('img').attributes('width')).toBe('800');
+    expect(wrapper.find('img').attributes('height')).toBe('600');
   });
 });
 

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -11,8 +11,8 @@
 // The first suite exists because QA saw no YouTube card while the server was verified to be
 // answering correctly — nothing was testing the span between those two facts.
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { nextTick, ref, type Ref } from 'vue';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { computed, nextTick, ref, type Ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import MessageAttachment from './MessageAttachment.vue';
@@ -27,9 +27,8 @@ import { MAX_CARDS_PER_MESSAGE } from '../utils/previewUrls.js';
 // `ref` is required: the templates rely on Vue's auto-unwrapping, which is keyed on `isRef`.
 //
 // ⚠ ONE ref per URL, cached, rather than a fresh one per call. The real composable does the same
-// (`entryFor`), and the atomic-reveal suite depends on it: seeding a URL AFTER mount has to reach
-// the ref the component is already watching. `seedSettings` clears the cache, so each test still
-// starts from a clean slate.
+// (`entryFor`), and the atomic-reveal suite depends on it: answering a URL AFTER mount has to
+// reach the ref the component is already watching. Cleared by the top-level `beforeEach` below.
 const resolved = new Map<string, LinkPreview>();
 const refs = new Map<string, Ref<LinkPreview | null>>();
 function entryRef(url: string): Ref<LinkPreview | null> {
@@ -40,13 +39,37 @@ function entryRef(url: string): Ref<LinkPreview | null> {
   }
   return entry;
 }
-// `vi.hoisted` because a `vi.mock` factory runs before module-level consts initialise, and this
-// one is dereferenced AT factory time rather than inside a lazy arrow like `useLinkPreview` is.
-const previewRevision = vi.hoisted(() => ({ value: 0 }));
+
+// URLs the real module would say an answer is still expected for. Kept separate from `resolved`
+// because the whole point of the reveal gate is that "no value yet" and "no answer coming" are
+// DIFFERENT states — a stub that conflated them could not observe the distinction it exists for.
+const inFlight = new Set<string>();
+const flightBump = ref(0);
+
+// ⚠ Every export is a lazy arrow, so nothing here is dereferenced at factory time. A `vi.mock`
+// factory runs before this file's module-level consts initialise, which is why a value export
+// (`previewRevision: ref(0)`) dies at collection and these do not.
 vi.mock('../composables/useLinkPreview.js', () => ({
   useLinkPreview: (url: string) => entryRef(url),
-  previewRevision,
+  usePreviewsSettled: (urls: Ref<readonly string[]>) =>
+    computed(() => {
+      void flightBump.value;
+      return urls.value.every((url) => !inFlight.has(url));
+    }),
 }));
+
+/** Mark URLs as awaiting an answer. */
+function setInFlight(...urls: string[]): void {
+  for (const url of urls) inFlight.add(url);
+  flightBump.value++;
+}
+
+/** Deliver an answer into the ref the component is already watching. */
+function answer(p: LinkPreview): void {
+  entryRef(p.url).value = p;
+  inFlight.delete(p.url);
+  flightBump.value++;
+}
 
 function preview(over: Partial<LinkPreview> & { url: string }): LinkPreview {
   return {
@@ -76,9 +99,16 @@ const IMAGE = preview({
   mime: 'image/png',
 });
 
-function seedSettings({ inlineMedia = true, linkPreviews = true, feature = true } = {}) {
-  // Per-test slate for the cached preview refs — see the mock above.
+// ⚠ TOP-LEVEL, not inside `seedSettings`. The ref cache lived there and so was skipped by the one
+// test that builds its own Pinia (it needs `image_modal` off), which then rendered the PREVIOUS
+// test's refs — its own `resolved.set` calls were dead, and planting a null ref made it crash on
+// an undefined element rather than fail its stated assertion.
+beforeEach(() => {
   refs.clear();
+  inFlight.clear();
+});
+
+function seedSettings({ inlineMedia = true, linkPreviews = true, feature = true } = {}) {
   setActivePinia(createPinia());
   // The instance feature flag gates both user settings — a stored `true` must not render on an
   // instance that has the feature off, where the routes aren't even mounted. Defaults on here so
@@ -358,11 +388,7 @@ describe('MessageAttachments — atomic reveal', () => {
   // portrait-vs-landscape as the mix changed. Both moved a scrolled-up reader with no way to
   // compensate, because the growth had already happened by the time anything heard about it.
 
-  beforeEach(() => {
-    resolved.clear();
-    previewRevision.value = 0;
-  });
-  afterEach(() => vi.useRealTimers());
+  beforeEach(() => resolved.clear());
 
   const img = (n: number, w = 800, h = 600) =>
     preview({
@@ -375,16 +401,17 @@ describe('MessageAttachments — atomic reveal', () => {
 
   const TWO = 'https://e.test/1.png https://e.test/2.png';
 
-  it('shows nothing while a sibling is still unresolved, then the whole block at once', async () => {
-    // ⚠ The assertion that bites is the FIRST one: with the gate removed this renders a lone
+  it('shows nothing while a sibling is still in flight, then the whole block at once', async () => {
+    // ⚠ The FIRST assertion is the one that bites: without the gate this renders a lone
     // `.inline-image`, which is the arrangement that then flips.
     resolved.set(img(1).url, img(1));
     seedSettings();
+    setInFlight(img(2).url);
     const wrapper = mount(MessageAttachments, { props: { text: TWO } });
     expect(wrapper.find('.attachments').exists()).toBe(false);
     expect(wrapper.find('.inline-image').exists()).toBe(false);
 
-    entryRef(img(2).url).value = img(2);
+    answer(img(2));
     await nextTick();
 
     expect(wrapper.find('.filmstrip').exists()).toBe(true);
@@ -392,71 +419,84 @@ describe('MessageAttachments — atomic reveal', () => {
   });
 
   it('decides the strip height once, from the complete group', async () => {
-    // ⚠ TWO portraits resolve first, so that without the gate there IS a filmstrip mid-flight —
-    // at 300px, since the group is entirely portrait — which then collapses to 200px when the
-    // third lands and tips the predicate. The first assertion is what notices the loss of the
-    // gate; an earlier draft of this test seeded ONE image and passed with the fix reverted,
-    // because one image is never a filmstrip either way.
-    // Two of four portrait is landscape ("primarily portrait" is `portrait * 2 > length`), so the
-    // complete group is a 200px row while the half that resolves first is a 300px one.
+    // ⚠ TWO portraits arrive first, so that without the gate there IS a filmstrip mid-flight — at
+    // 300px, the whole-group-portrait height — which then collapses to 200px when the rest land.
+    // An earlier draft seeded ONE image and passed with the gate reverted, because one image is
+    // never a filmstrip either way. Two of four portrait is landscape ("primarily portrait" is
+    // `portrait * 2 > length`), so the complete group is a 200px row.
     resolved.set(img(1, 600, 900).url, img(1, 600, 900));
     resolved.set(img(2, 500, 1000).url, img(2, 500, 1000));
     seedSettings();
+    setInFlight(img(3).url, img(4).url);
     const wrapper = mount(MessageAttachments, {
       props: { text: `${TWO} https://e.test/3.png https://e.test/4.png` },
     });
     expect(wrapper.find('.filmstrip').exists()).toBe(false);
 
-    entryRef(img(3).url).value = img(3, 1200, 500);
-    entryRef(img(4).url).value = img(4, 1000, 400);
+    answer(img(3, 1200, 500));
+    answer(img(4, 1000, 400));
     await nextTick();
 
     expect(wrapper.find('.filmstrip').attributes('style')).toContain('200px');
   });
 
-  it('reveals synchronously, and arms no timer, when everything already resolved', () => {
-    // The common case once a row scrolls back into view: the answers landed long ago. A timer
-    // apiece for every mounted row would be pure waste.
-    vi.useFakeTimers();
+  it('does not stall on a URL no answer is coming for', () => {
+    // ⚠⚠ The property the whole gate rests on, and the reason it asks the module rather than
+    // running a timer. `useLinkPreview` hands back a permanently-null ref for a URL nobody primed,
+    // so a gate of "every entry has a value" would blank this message for the life of the tab.
+    // Not in flight means not coming, and the block renders now.
+    //
+    // ⚠ This one does NOT fail if the gate is deleted, and it CANNOT observe the pending rule
+    // itself — this suite mocks `usePreviewsSettled`, so mutating `previewPending` leaves it
+    // green. (Checked, after an earlier version of this comment claimed otherwise.) The real rule
+    // is guarded in `useLinkPreview.test.ts` → "is an answer still coming?", where all three of
+    // its clauses are revert-proven. What this asserts is the component half: that a settled-but-
+    // valueless URL is rendered past rather than waited on.
+    resolved.set(img(1).url, img(1));
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: TWO } });
+    expect(wrapper.find('.inline-image').exists()).toBe(true);
+  });
+
+  it('does not hide a block already on screen when a URL goes back in flight', async () => {
+    // A transient failure is re-asked (`runReask` re-queues it), which puts a settled URL back
+    // into the pending set. Un-revealing would be a SHRINK, which disturbs a reader exactly as
+    // much as the growth this gate exists to prevent.
     resolved.set(img(1).url, img(1));
     resolved.set(img(2).url, img(2));
     seedSettings();
     const wrapper = mount(MessageAttachments, { props: { text: TWO } });
     expect(wrapper.find('.filmstrip').exists()).toBe(true);
-    expect(vi.getTimerCount()).toBe(0);
-  });
 
-  it('reveals what it has after the deadline, and bumps previewRevision BEFORE it does', async () => {
-    // ⚠⚠ The safety net. `useLinkPreview` returns a permanently-null ref for a URL nobody primed,
-    // so without this a parser/policy divergence between the render path and the priming path
-    // would blank the message for the life of the tab.
-    vi.useFakeTimers();
-    resolved.set(img(1).url, img(1));
-    seedSettings();
-    const wrapper = mount(MessageAttachments, { props: { text: TWO } });
-    expect(wrapper.find('.attachments').exists()).toBe(false);
-
-    vi.advanceTimersByTime(1500);
+    setInFlight(img(2).url);
     await nextTick();
 
-    expect(wrapper.find('.inline-image').exists()).toBe(true);
-    // ⚠ The bump is what `MessageList`'s pre-flush watcher re-pins on. A timer-driven reveal is
-    // invisible to it otherwise, so the growth lands uncompensated on a scrolled-up reader — the
-    // exact failure mode this whole change exists to remove. Asserting the COUNT would not
-    // notice the ordering, so the ordering is covered by the bump happening at all plus the
-    // component's own statement order; this assertion guards the bump.
-    expect(previewRevision.value).toBe(1);
+    expect(wrapper.find('.filmstrip').exists()).toBe(true);
   });
 
-  it('clears its deadline timer on unmount', () => {
-    // "Leaked" here means a timer that outlives the row and bumps previewRevision — a re-pin on
-    // behalf of a component that no longer exists.
-    vi.useFakeTimers();
-    seedSettings();
-    const wrapper = mount(MessageAttachments, { props: { text: TWO } });
-    expect(vi.getTimerCount()).toBe(1);
-    wrapper.unmount();
-    expect(vi.getTimerCount()).toBe(0);
+  it('closes the gate again when a settings flip grows the URL set', async () => {
+    // ⚠ The one path that changes `urls` WITHOUT remounting: `/set` from the composer, or a
+    // settings sync from another device. A latch scoped to the component's lifetime stays open,
+    // and the newly-previewable images then paint one at a time — the piecemeal render this gate
+    // exists to prevent, arriving by the only route that never remounts.
+    const CARD = 'https://news.example/article';
+    resolved.set(CARD, preview({ url: CARD, kind: 'page', title: 'A page' }));
+    seedSettings({ inlineMedia: false, linkPreviews: true });
+    const wrapper = mount(MessageAttachments, {
+      props: { text: `https://e.test/1.png ${CARD}` },
+    });
+    expect(wrapper.find('.card').exists()).toBe(true);
+
+    setInFlight(img(1).url);
+    useSettingsStore().values['chat.inline_media.enabled'] = true;
+    await nextTick();
+
+    expect(wrapper.find('.attachments').exists()).toBe(false);
+
+    answer(img(1));
+    await nextTick();
+    expect(wrapper.find('.inline-image').exists()).toBe(true);
+    expect(wrapper.find('.card').exists()).toBe(true);
   });
 });
 
@@ -473,40 +513,83 @@ describe('MessageAttachment — a box that does not depend on bytes', () => {
     src: '/api/link-preview/media/tokX',
   });
 
-  it('gives an image the server could not measure a fixed box', () => {
-    // `imageDimensions` returns null for a format sharp can't parse in the 64 KB it reads. With
-    // no width/height attributes there is no ratio to reserve a box from, so the element lays out
-    // at the UA default and grows on decode — video's pre-465f838 bug, still live for images.
-    const wrapper = mount(MessageAttachment, { props: { preview: unmeasured } });
-    expect(wrapper.find('img').classes()).toContain('no-dims');
+  it('fixes the box only for an unmeasured image outside a strip', () => {
+    // ⚠ All three cases in ONE test, deliberately. Split apart, the two negative cases asserted
+    // `not.toContain('no-dims')` and stayed green with the binding deleted entirely — vacuous
+    // against the very mutation they look like they guard. Together, deleting the binding fails
+    // this test on its first case.
+    //
+    // `imageDimensions` returns null for a format sharp can't parse in the 64 KB it reads — ico
+    // and bmp both arrive as `kind: 'image'` with null dimensions. With no width/height attributes
+    // there is no ratio to reserve a box from, so the element lays out at the UA default and grows
+    // on decode: video's pre-465f838 bug, still live for images.
+    const lone = mount(MessageAttachment, { props: { preview: unmeasured } });
+    expect(lone.find('img').classes()).toContain('no-dims');
+
+    // A measured image keeps its own aspect — the descriptor arrives atomically with the decision
+    // to render at all, so natural aspect costs nothing and a fixed box would only waste space.
+    const measured = mount(MessageAttachment, { props: { preview: IMAGE } });
+    expect(measured.find('img').classes()).not.toContain('no-dims');
+
+    // In a strip the row already decides the height; a second fixed height would fight it.
+    const strip = mount(MessageAttachment, { props: { preview: unmeasured, inStrip: true } });
+    expect(strip.find('img').classes()).not.toContain('no-dims');
+    expect(strip.find('img').classes()).toContain('strip-item');
   });
 
-  it('leaves a measured image to its own aspect ratio', () => {
-    // The descriptor arrives atomically with the decision to render at all, so natural aspect
-    // costs nothing — and a fixed box would letterbox or upscale for no reason.
-    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
-    expect(wrapper.find('img').classes()).not.toContain('no-dims');
-    expect(wrapper.find('img').attributes('width')).toBe('800');
-  });
-
-  it('does not fix the height of an unmeasured image inside a strip', () => {
-    // The row already decides the height there; a second fixed height would fight it.
-    const wrapper = mount(MessageAttachment, {
-      props: { preview: unmeasured, inStrip: true },
-    });
-    expect(wrapper.find('img').classes()).not.toContain('no-dims');
-    expect(wrapper.find('img').classes()).toContain('strip-item');
-  });
-
-  it('keeps the reserved box when the bytes never arrive', async () => {
+  it('keeps the reserved attributes when the bytes never arrive, and asks for a re-pin', async () => {
     // A rotated session secret invalidates outstanding proxy tokens, and an origin can die
-    // between resolve and render. The attributes are what reserve the box, so the failure must
-    // not remove them — it only swaps the UA's broken-image glyph for the card panel's fill.
+    // between resolve and render. The attributes must survive it — they are what reserve the box.
+    //
+    // ⚠ And `measured` is emitted, which is NOT symmetry for its own sake. After this change a
+    // successful load grows nothing (attributes or `.no-dims` already sized the box), so `@error`
+    // is the one image event left that can still move a row: a failed image stops being a
+    // replaced element and what the UA falls back to varies by engine. Silence here meant neither
+    // MessageList compensation path was reachable, with `overflow-anchor: none` ruling out the
+    // browser's own.
     const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
     await wrapper.find('img').trigger('error');
     expect(wrapper.find('img').classes()).toContain('failed');
+    expect(wrapper.emitted('measured')).toHaveLength(1);
     expect(wrapper.find('img').attributes('width')).toBe('800');
     expect(wrapper.find('img').attributes('height')).toBe('600');
+  });
+
+  it('stops being a control once its bytes are known to be gone', async () => {
+    // ⚠ A failed image kept `role="button"`, `tabindex="0"` and `aria-label="Open image: a.png"`
+    // over bytes that are not coming. A screen reader announced a button onto an empty panel, and
+    // activating it opened the viewer — which independently re-fetched the same dead URL and
+    // landed on its own failure card. The only way to discover the failure was to click through
+    // to a second one.
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    expect(wrapper.find('img').attributes('role')).toBe('button');
+
+    await wrapper.find('img').trigger('error');
+
+    expect(wrapper.find('img').attributes('role')).toBeUndefined();
+    expect(wrapper.find('img').attributes('tabindex')).toBeUndefined();
+    // ⚠ And it gains a name, because `alt=""` is only right while the image is decoration. Once
+    // it has failed, the empty panel IS the information.
+    expect(wrapper.find('img').attributes('alt')).toBe('Image unavailable');
+    await wrapper.find('img').trigger('click');
+    expect(wrapper.emitted('activate')).toBeUndefined();
+  });
+
+  it('clears the failure when a re-ask delivers a fresh source', async () => {
+    // ⚠ `forgetForRetry` and `runReask` re-deliver a recovered answer into the SAME ref with a
+    // freshly minted proxy token, and the row is keyed on the URL — so Vue patches this component
+    // rather than remounting it. A write-once latch kept the failure fill painted over an image
+    // that had since loaded, visible through any transparent PNG and in the letterbox bars.
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    await wrapper.find('img').trigger('error');
+    expect(wrapper.find('img').classes()).toContain('failed');
+
+    await wrapper.setProps({
+      preview: preview({ ...IMAGE, src: '/api/link-preview/media/fresh' }),
+    });
+
+    expect(wrapper.find('img').classes()).not.toContain('failed');
+    expect(wrapper.find('img').attributes('role')).toBe('button');
   });
 });
 

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -474,6 +474,32 @@ describe('MessageAttachments — atomic reveal', () => {
     expect(wrapper.find('.filmstrip').exists()).toBe(true);
   });
 
+  it('survives an unrelated settings write while a URL is back in flight', async () => {
+    // ⚠⚠ `urls` is a computed that allocates a fresh array every evaluation, and it re-evaluates
+    // on ANY settings write, because the store replaces `values` wholesale. Watching the array
+    // IDENTITY therefore fired the re-gate on a byte-identical URL list — so toggling the channel
+    // list, or a highlight sound, or a cross-device sync, re-derived `revealed` from a `settled`
+    // that can legitimately be false and made a strip vanish mid-read. That is the same shrink
+    // the latch exists to prevent, reintroduced by the line meant to scope it.
+    resolved.set(img(1).url, img(1));
+    resolved.set(img(2).url, img(2));
+    seedSettings();
+    const wrapper = mount(MessageAttachments, { props: { text: TWO } });
+    expect(wrapper.find('.filmstrip').exists()).toBe(true);
+
+    // A cache eviction plus a repost re-primes a URL against a fresh null ref, so `settled` goes
+    // false again under a latch that is holding the strip on screen.
+    setInFlight(img(2).url);
+    // ...and now something entirely unrelated writes a setting.
+    useSettingsStore().values = {
+      ...useSettingsStore().values,
+      'chat.highlight_sound.enabled': true,
+    };
+    await nextTick();
+
+    expect(wrapper.find('.filmstrip').exists()).toBe(true);
+  });
+
   it('closes the gate again when a settings flip grows the URL set', async () => {
     // ⚠ The one path that changes `urls` WITHOUT remounting: `/set` from the composer, or a
     // settings sync from another device. A latch scoped to the component's lifetime stays open,
@@ -535,61 +561,6 @@ describe('MessageAttachment — a box that does not depend on bytes', () => {
     const strip = mount(MessageAttachment, { props: { preview: unmeasured, inStrip: true } });
     expect(strip.find('img').classes()).not.toContain('no-dims');
     expect(strip.find('img').classes()).toContain('strip-item');
-  });
-
-  it('keeps the reserved attributes when the bytes never arrive, and asks for a re-pin', async () => {
-    // A rotated session secret invalidates outstanding proxy tokens, and an origin can die
-    // between resolve and render. The attributes must survive it — they are what reserve the box.
-    //
-    // ⚠ And `measured` is emitted, which is NOT symmetry for its own sake. After this change a
-    // successful load grows nothing (attributes or `.no-dims` already sized the box), so `@error`
-    // is the one image event left that can still move a row: a failed image stops being a
-    // replaced element and what the UA falls back to varies by engine. Silence here meant neither
-    // MessageList compensation path was reachable, with `overflow-anchor: none` ruling out the
-    // browser's own.
-    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
-    await wrapper.find('img').trigger('error');
-    expect(wrapper.find('img').classes()).toContain('failed');
-    expect(wrapper.emitted('measured')).toHaveLength(1);
-    expect(wrapper.find('img').attributes('width')).toBe('800');
-    expect(wrapper.find('img').attributes('height')).toBe('600');
-  });
-
-  it('stops being a control once its bytes are known to be gone', async () => {
-    // ⚠ A failed image kept `role="button"`, `tabindex="0"` and `aria-label="Open image: a.png"`
-    // over bytes that are not coming. A screen reader announced a button onto an empty panel, and
-    // activating it opened the viewer — which independently re-fetched the same dead URL and
-    // landed on its own failure card. The only way to discover the failure was to click through
-    // to a second one.
-    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
-    expect(wrapper.find('img').attributes('role')).toBe('button');
-
-    await wrapper.find('img').trigger('error');
-
-    expect(wrapper.find('img').attributes('role')).toBeUndefined();
-    expect(wrapper.find('img').attributes('tabindex')).toBeUndefined();
-    // ⚠ And it gains a name, because `alt=""` is only right while the image is decoration. Once
-    // it has failed, the empty panel IS the information.
-    expect(wrapper.find('img').attributes('alt')).toBe('Image unavailable');
-    await wrapper.find('img').trigger('click');
-    expect(wrapper.emitted('activate')).toBeUndefined();
-  });
-
-  it('clears the failure when a re-ask delivers a fresh source', async () => {
-    // ⚠ `forgetForRetry` and `runReask` re-deliver a recovered answer into the SAME ref with a
-    // freshly minted proxy token, and the row is keyed on the URL — so Vue patches this component
-    // rather than remounting it. A write-once latch kept the failure fill painted over an image
-    // that had since loaded, visible through any transparent PNG and in the letterbox bars.
-    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
-    await wrapper.find('img').trigger('error');
-    expect(wrapper.find('img').classes()).toContain('failed');
-
-    await wrapper.setProps({
-      preview: preview({ ...IMAGE, src: '/api/link-preview/media/fresh' }),
-    });
-
-    expect(wrapper.find('img').classes()).not.toContain('failed');
-    expect(wrapper.find('img').attributes('role')).toBe('button');
   });
 });
 

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -500,6 +500,30 @@ describe('MessageAttachments — atomic reveal', () => {
     expect(wrapper.find('.filmstrip').exists()).toBe(true);
   });
 
+  it('shows a URL added by a settings flip that was ALREADY resolved', async () => {
+    // ⚠⚠ `shown` grows inside a watcher on `settled`, and Vue only runs that when the VALUE
+    // changes. If the flip adds a URL that is already in the cache — the same image posted
+    // earlier in the session, or previewed in another buffer — `settled` is true before and true
+    // after, so the watcher never fires and the URL is never admitted. The attachment then stays
+    // hidden for the life of the row, with everything about it resolved and ready.
+    const CARD = 'https://news.example/article';
+    resolved.set(CARD, preview({ url: CARD, kind: 'page', title: 'A page' }));
+    resolved.set(img(1).url, img(1));
+    seedSettings({ inlineMedia: false, linkPreviews: true });
+    const wrapper = mount(MessageAttachments, {
+      props: { text: `https://e.test/1.png ${CARD}` },
+    });
+    expect(wrapper.find('.card').exists()).toBe(true);
+    expect(wrapper.find('.inline-image').exists()).toBe(false);
+
+    // Nothing goes in flight: the image was resolved all along, it simply wasn't previewable.
+    useSettingsStore().values['chat.inline_media.enabled'] = true;
+    await nextTick();
+
+    expect(wrapper.find('.inline-image').exists()).toBe(true);
+    expect(wrapper.find('.card').exists()).toBe(true);
+  });
+
   it('holds back only the NEW URLs when a settings flip grows the set', async () => {
     // ⚠⚠ The one path that changes `urls` without remounting: `/set` from the composer, or a
     // settings sync from another device. Two things have to be true at once here, and an earlier

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -500,11 +500,16 @@ describe('MessageAttachments — atomic reveal', () => {
     expect(wrapper.find('.filmstrip').exists()).toBe(true);
   });
 
-  it('closes the gate again when a settings flip grows the URL set', async () => {
-    // ⚠ The one path that changes `urls` WITHOUT remounting: `/set` from the composer, or a
-    // settings sync from another device. A latch scoped to the component's lifetime stays open,
-    // and the newly-previewable images then paint one at a time — the piecemeal render this gate
-    // exists to prevent, arriving by the only route that never remounts.
+  it('holds back only the NEW URLs when a settings flip grows the set', async () => {
+    // ⚠⚠ The one path that changes `urls` without remounting: `/set` from the composer, or a
+    // settings sync from another device. Two things have to be true at once here, and an earlier
+    // version got the second exactly backwards.
+    //
+    //   1. The newly-previewable image must NOT paint until it has settled — otherwise the flip
+    //      renders it piecemeal, which is what the gate exists to prevent.
+    //   2. The card that was ALREADY on screen must stay on screen. Re-deriving one shared
+    //      `revealed` flag from `settled` tore the whole block down instead: ten resolved cards
+    //      collapsing buffer-wide, ~1200px of uncompensated shrink, for a setting about images.
     const CARD = 'https://news.example/article';
     resolved.set(CARD, preview({ url: CARD, kind: 'page', title: 'A page' }));
     seedSettings({ inlineMedia: false, linkPreviews: true });
@@ -517,7 +522,8 @@ describe('MessageAttachments — atomic reveal', () => {
     useSettingsStore().values['chat.inline_media.enabled'] = true;
     await nextTick();
 
-    expect(wrapper.find('.attachments').exists()).toBe(false);
+    expect(wrapper.find('.inline-image').exists()).toBe(false);
+    expect(wrapper.find('.card').exists()).toBe(true);
 
     answer(img(1));
     await nextTick();
@@ -539,27 +545,32 @@ describe('MessageAttachment — a box that does not depend on bytes', () => {
     src: '/api/link-preview/media/tokX',
   });
 
-  it('fixes the box only for an unmeasured image outside a strip', () => {
+  it('reserves the box on a WRAPPER, and only for an unmeasured image outside a strip', () => {
     // ⚠ All three cases in ONE test, deliberately. Split apart, the two negative cases asserted
-    // `not.toContain('no-dims')` and stayed green with the binding deleted entirely — vacuous
-    // against the very mutation they look like they guard. Together, deleting the binding fails
-    // this test on its first case.
+    // `not.toContain(...)` and stayed green with the binding deleted entirely — vacuous against
+    // the very mutation they look like they guard.
     //
     // `imageDimensions` returns null for a format sharp can't parse in the 64 KB it reads — ico
     // and bmp both arrive as `kind: 'image'` with null dimensions. With no width/height attributes
     // there is no ratio to reserve a box from, so the element lays out at the UA default and grows
     // on decode: video's pre-465f838 bug, still live for images.
+    //
+    // ⚠⚠ The height is on the WRAPPER and that is the assertion that matters. Pinned on the
+    // `<img>`, the empty letterbox around a 16x16 favicon became part of a 240px-tall control
+    // that calls `stopPropagation` — swallowing the row tap that is the only opener of the
+    // message-actions sheet on touch. A wrapper with no handlers leaves those pixels to the row.
     const lone = mount(MessageAttachment, { props: { preview: unmeasured } });
-    expect(lone.find('img').classes()).toContain('no-dims');
+    expect(lone.find('.dim-reserve').exists()).toBe(true);
+    expect(lone.find('.dim-reserve img.inline-image').exists()).toBe(true);
 
     // A measured image keeps its own aspect — the descriptor arrives atomically with the decision
     // to render at all, so natural aspect costs nothing and a fixed box would only waste space.
     const measured = mount(MessageAttachment, { props: { preview: IMAGE } });
-    expect(measured.find('img').classes()).not.toContain('no-dims');
+    expect(measured.find('.dim-reserve').exists()).toBe(false);
 
-    // In a strip the row already decides the height; a second fixed height would fight it.
+    // In a strip the row already decides the height; a second fixed box would fight it.
     const strip = mount(MessageAttachment, { props: { preview: unmeasured, inStrip: true } });
-    expect(strip.find('img').classes()).not.toContain('no-dims');
+    expect(strip.find('.dim-reserve').exists()).toBe(false);
     expect(strip.find('img').classes()).toContain('strip-item');
   });
 });

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -15,17 +15,17 @@
     :src="preview.src"
     :width="preview.thumbWidth || undefined"
     :height="preview.thumbHeight || undefined"
-    alt=""
+    :alt="failed ? 'Image unavailable' : ''"
     loading="lazy"
     decoding="async"
-    :role="viewerEnabled ? 'button' : undefined"
-    :tabindex="viewerEnabled ? 0 : undefined"
-    :aria-label="viewerEnabled ? imageLabel : undefined"
+    :role="interactive ? 'button' : undefined"
+    :tabindex="interactive ? 0 : undefined"
+    :aria-label="interactive ? imageLabel : undefined"
     @click="onImageClick"
     @keydown.enter.prevent="activate"
     @keydown.space.prevent="activate"
-    @load="$emit('measured')"
-    @error="failed = true"
+    @load="onImageLoad"
+    @error="onImageError"
   />
   <!-- ⚠ `@loadedmetadata` matters more here than the image's `@load` does. The server measures
        dimensions for images only, so a video has NO width/height to reserve a box with and lays
@@ -121,7 +121,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import type { LinkPreview } from '../composables/useLinkPreview.js';
 import { useSettingsStore } from '../stores/settings.js';
 
@@ -161,11 +161,54 @@ const hasDimensions = computed(() => !!props.preview.thumbWidth && !!props.previ
  * The bytes didn't arrive.
  *
  * A proxy token that no longer verifies (the session secret was rotated), an origin that has
- * since died. Only affects PAINT: the reserved box is a function of the width/height attributes
- * and `.no-dims`, both of which survive a failed load, so this never changes the row's height —
- * it swaps the UA's broken-image glyph for the same panel fill a card uses.
+ * since died.
+ *
+ * ⚠ RESET when the source changes, and that isn't hypothetical: `forgetForRetry` and `runReask`
+ * deliberately re-deliver a recovered answer into the SAME ref object (useLinkPreview) with a
+ * freshly minted proxy token, and the row is keyed on `item.url` so Vue patches the existing
+ * component rather than remounting it. A write-once latch would keep the failure fill painted
+ * over an image that had since loaded — visible through any transparent PNG and in the
+ * `contain` letterbox bars. MediaViewerModal does the same reset for the same reason.
  */
 const failed = ref(false);
+watch(
+  () => props.preview.src,
+  () => {
+    failed.value = false;
+  },
+);
+
+function onImageLoad(): void {
+  // A late success after a failure — see the reset above; the `src` may not have changed if the
+  // origin merely recovered.
+  failed.value = false;
+  emit('measured');
+}
+
+/**
+ * ⚠⚠ `measured` is emitted here too, and this is the event that can now actually move the row.
+ *
+ * After this change a successful `@load` grows nothing — every rendered inline image has either
+ * the server's width/height or `.no-dims`'s fixed box. A FAILURE is different: the UA stops
+ * treating the element as a replaced box, and what it falls back to varies by engine. Emitting
+ * lets `MessageList` re-pin, which is all the compensation available for something we only learn
+ * about after it has happened.
+ */
+function onImageError(): void {
+  failed.value = true;
+  emit('measured');
+}
+
+/**
+ * Whether this image is a control.
+ *
+ * ⚠ NOT `viewerEnabled` alone. A failed image kept `role="button"`, `tabindex="0"` and
+ * `aria-label="Open image: a.png"` over bytes known to be gone — so a screen reader announced a
+ * button onto an empty panel, and activating it opened the viewer, which independently re-fetched
+ * the same dead URL and landed on its own failure card. The only way to discover the failure was
+ * to click through to a second one.
+ */
+const interactive = computed(() => viewerEnabled.value && !failed.value);
 
 function play(): void {
   playing.value = true;
@@ -208,7 +251,7 @@ const imageLabel = computed(() => {
  * in the row: no viewer, no sheet, nothing.
  */
 function onImageClick(e: MouseEvent): void {
-  if (!viewerEnabled.value) return;
+  if (!interactive.value) return;
   e.stopPropagation();
   emit('activate');
 }
@@ -216,7 +259,7 @@ function onImageClick(e: MouseEvent): void {
 /** Keyboard equivalent. An element advertising `cursor: pointer` and a `button` role has to be
  *  reachable without one — matching RenderSegments, MircColorPicker and SuggestionStrip. */
 function activate(): void {
-  if (!viewerEnabled.value) return;
+  if (!interactive.value) return;
   emit('activate');
 }
 </script>
@@ -250,9 +293,20 @@ function activate(): void {
    NOT applied in a strip: the row already fixes the height there (see `.strip-item`). */
 .inline-image.no-dims {
   height: 240px;
+  /* ⚠ `scale-down`, NOT `contain`. `contain` scales UP to fill the box, so an unmeasured 16x16
+     favicon.ico — sharp decodes jpeg/png/webp/tiff/gif/svg/heif/raw, so ico and bmp arrive as
+     `kind: 'image'` with null dimensions — rendered at 240x240 and 15x blurry. `scale-down` takes
+     the smaller of `none` and `contain`, so a small image stays its own size inside the box.
+     The box is still 240px tall, which is the price of a height that's knowable before the bytes:
+     empty space around a rare small image, rather than a jump on every one. */
+  object-fit: scale-down;
+  /* And a fill, so the reserved box reads as a placeholder rather than as a hole punched in the
+     conversation — `loading="lazy"` means it can sit empty until the row nears the viewport. */
+  background: var(--embed-bg);
 }
-/* A failed load keeps whatever box was reserved — the attributes and `.no-dims` both survive it —
-   so this is paint only: the panel fill a card uses, instead of the UA's broken-image glyph. */
+/* Paint for a load that failed: the panel fill a card uses, instead of the UA's broken-image
+   glyph. ⚠ The BOX is not this rule's business — see `onImageError`, which emits `measured`
+   because a failed image stops being a replaced element and what the UA falls back to varies. */
 .inline-image.failed {
   background: var(--embed-bg);
 }

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -11,7 +11,7 @@
   <img
     v-if="preview.kind === 'image' && preview.src"
     class="inline-image"
-    :class="{ 'strip-item': inStrip }"
+    :class="{ 'strip-item': inStrip, 'no-dims': !inStrip && !hasDimensions, failed }"
     :src="preview.src"
     :width="preview.thumbWidth || undefined"
     :height="preview.thumbHeight || undefined"
@@ -25,6 +25,7 @@
     @keydown.enter.prevent="activate"
     @keydown.space.prevent="activate"
     @load="$emit('measured')"
+    @error="failed = true"
   />
   <!-- ⚠ `@loadedmetadata` matters more here than the image's `@load` does. The server measures
        dimensions for images only, so a video has NO width/height to reserve a box with and lays
@@ -146,6 +147,26 @@ const playing = ref(false);
 
 const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.preview.embedUrl);
 
+/**
+ * Whether the server could measure this image.
+ *
+ * The `width`/`height` attributes are what reserve the box before any bytes arrive, so their
+ * ABSENCE is the one case where an inline image's height depends on the decode — see `.no-dims`.
+ * `imageDimensions` fails legitimately and not rarely: an exotic format, or a header sharp can't
+ * parse inside the 64 KB it reads.
+ */
+const hasDimensions = computed(() => !!props.preview.thumbWidth && !!props.preview.thumbHeight);
+
+/**
+ * The bytes didn't arrive.
+ *
+ * A proxy token that no longer verifies (the session secret was rotated), an origin that has
+ * since died. Only affects PAINT: the reserved box is a function of the width/height attributes
+ * and `.no-dims`, both of which survive a failed load, so this never changes the row's height —
+ * it swaps the UA's broken-image glyph for the same panel fill a card uses.
+ */
+const failed = ref(false);
+
 function play(): void {
   playing.value = true;
 }
@@ -215,6 +236,25 @@ function activate(): void {
   object-fit: contain;
   border-radius: var(--radius-md);
   display: block;
+}
+/* ⚠ A FIXED height, for the same reason `.inline-video` has one: with no width/height attributes
+   there is no intrinsic ratio to reserve a box from, so the element is laid out at the UA default
+   for a replaced element with no dimensions and grows to its real size on decode — the one case
+   where an inline image's height depends on bytes rather than on its descriptor.
+   `max-width: 100%` still applies, and because `height` is no longer `auto` a too-wide image is
+   constrained horizontally and letterboxed by `object-fit: contain` rather than changing height.
+   Only vertical movement disturbs a scroll position, so the width settling on decode costs
+   nothing.
+   240px, matching the `max-height` an image with dimensions would have been scaled into, so the
+   fallback and the normal case agree on the tallest a lone image gets.
+   NOT applied in a strip: the row already fixes the height there (see `.strip-item`). */
+.inline-image.no-dims {
+  height: 240px;
+}
+/* A failed load keeps whatever box was reserved — the attributes and `.no-dims` both survive it —
+   so this is paint only: the panel fill a card uses, instead of the UA's broken-image glyph. */
+.inline-image.failed {
+  background: var(--embed-bg);
 }
 /* Only advertises a click when a click does something — the viewer is opt-out. */
 .inline-image[role='button'] {

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -11,21 +11,20 @@
   <img
     v-if="preview.kind === 'image' && preview.src"
     class="inline-image"
-    :class="{ 'strip-item': inStrip, 'no-dims': !inStrip && !hasDimensions, failed }"
+    :class="{ 'strip-item': inStrip, 'no-dims': !inStrip && !hasDimensions }"
     :src="preview.src"
     :width="preview.thumbWidth || undefined"
     :height="preview.thumbHeight || undefined"
-    :alt="failed ? 'Image unavailable' : ''"
+    alt=""
     loading="lazy"
     decoding="async"
-    :role="interactive ? 'button' : undefined"
-    :tabindex="interactive ? 0 : undefined"
-    :aria-label="interactive ? imageLabel : undefined"
+    :role="viewerEnabled ? 'button' : undefined"
+    :tabindex="viewerEnabled ? 0 : undefined"
+    :aria-label="viewerEnabled ? imageLabel : undefined"
     @click="onImageClick"
     @keydown.enter.prevent="activate"
     @keydown.space.prevent="activate"
-    @load="onImageLoad"
-    @error="onImageError"
+    @load="$emit('measured')"
   />
   <!-- ⚠ `@loadedmetadata` matters more here than the image's `@load` does. The server measures
        dimensions for images only, so a video has NO width/height to reserve a box with and lays
@@ -158,57 +157,26 @@ const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.p
 const hasDimensions = computed(() => !!props.preview.thumbWidth && !!props.preview.thumbHeight);
 
 /**
- * The bytes didn't arrive.
+ * ⚠⚠ THERE IS DELIBERATELY NO `@error` HANDLING, and that is a decision rather than an omission.
  *
- * A proxy token that no longer verifies (the session secret was rotated), an origin that has
- * since died.
+ * A version of this component tracked a `failed` flag to paint a panel fill instead of the UA's
+ * broken-image glyph. Measured in three engines, it made things worse rather than better:
  *
- * ⚠ RESET when the source changes, and that isn't hypothetical: `forgetForRetry` and `runReask`
- * deliberately re-deliver a recovered answer into the SAME ref object (useLinkPreview) with a
- * freshly minted proxy token, and the row is keyed on `item.url` so Vue patches the existing
- * component rather than remounting it. A write-once latch would keep the failure fill painted
- * over an image that had since loaded — visible through any transparent PNG and in the
- * `contain` letterbox bars. MediaViewerModal does the same reset for the same reason.
+ *   - Setting a non-empty `alt` on failure re-triggers frame construction in Gecko and DROPS the
+ *     attribute-derived aspect ratio, collapsing a measured 240px box to an 18px text line —
+ *     222px of uncompensated shrink that plain `alt=""` does not suffer. The old shape held 240px
+ *     in Blink, WebKit and Gecko alike.
+ *   - The reset that was supposed to clear the flag could never fire: `mintProxyToken` is an HMAC
+ *     over the URL, so a re-delivered answer carries a byte-identical `src` and the watch on it
+ *     never runs. And an `ok` preview is never re-asked at all, so the flag was permanent — a
+ *     two-second network blip greyed out every inline image for the life of the row.
+ *   - Dropping `role`/`tabindex` on failure removed them from an element that may currently HOLD
+ *     focus, dumping a keyboard user back to `<body>` mid-strip.
+ *
+ * The byte-independence rule this file serves is already satisfied without any of it: the
+ * width/height attributes survive a failed load, and `.no-dims` pins the one shape that has none.
+ * A broken-image glyph in a correctly-sized box is a smaller problem than every one of the above.
  */
-const failed = ref(false);
-watch(
-  () => props.preview.src,
-  () => {
-    failed.value = false;
-  },
-);
-
-function onImageLoad(): void {
-  // A late success after a failure — see the reset above; the `src` may not have changed if the
-  // origin merely recovered.
-  failed.value = false;
-  emit('measured');
-}
-
-/**
- * ⚠⚠ `measured` is emitted here too, and this is the event that can now actually move the row.
- *
- * After this change a successful `@load` grows nothing — every rendered inline image has either
- * the server's width/height or `.no-dims`'s fixed box. A FAILURE is different: the UA stops
- * treating the element as a replaced box, and what it falls back to varies by engine. Emitting
- * lets `MessageList` re-pin, which is all the compensation available for something we only learn
- * about after it has happened.
- */
-function onImageError(): void {
-  failed.value = true;
-  emit('measured');
-}
-
-/**
- * Whether this image is a control.
- *
- * ⚠ NOT `viewerEnabled` alone. A failed image kept `role="button"`, `tabindex="0"` and
- * `aria-label="Open image: a.png"` over bytes known to be gone — so a screen reader announced a
- * button onto an empty panel, and activating it opened the viewer, which independently re-fetched
- * the same dead URL and landed on its own failure card. The only way to discover the failure was
- * to click through to a second one.
- */
-const interactive = computed(() => viewerEnabled.value && !failed.value);
 
 function play(): void {
   playing.value = true;
@@ -251,7 +219,7 @@ const imageLabel = computed(() => {
  * in the row: no viewer, no sheet, nothing.
  */
 function onImageClick(e: MouseEvent): void {
-  if (!interactive.value) return;
+  if (!viewerEnabled.value) return;
   e.stopPropagation();
   emit('activate');
 }
@@ -259,7 +227,7 @@ function onImageClick(e: MouseEvent): void {
 /** Keyboard equivalent. An element advertising `cursor: pointer` and a `button` role has to be
  *  reachable without one — matching RenderSegments, MircColorPicker and SuggestionStrip. */
 function activate(): void {
-  if (!interactive.value) return;
+  if (!viewerEnabled.value) return;
   emit('activate');
 }
 </script>
@@ -302,12 +270,6 @@ function activate(): void {
   object-fit: scale-down;
   /* And a fill, so the reserved box reads as a placeholder rather than as a hole punched in the
      conversation — `loading="lazy"` means it can sit empty until the row nears the viewport. */
-  background: var(--embed-bg);
-}
-/* Paint for a load that failed: the panel fill a card uses, instead of the UA's broken-image
-   glyph. ⚠ The BOX is not this rule's business — see `onImageError`, which emits `measured`
-   because a failed image stops being a replaced element and what the UA falls back to varies. */
-.inline-image.failed {
   background: var(--embed-bg);
 }
 /* Only advertises a click when a click does something — the viewer is opt-out. */

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -8,24 +8,36 @@
        `width`/`height` are the server's real pixel dimensions, and they're load-bearing rather
        than decorative — the browser derives the intrinsic aspect ratio from them and reserves
        the right box BEFORE any bytes arrive. -->
-  <img
+  <!-- ⚠ The RESERVER is this span, not the image. When the server could not measure an image
+       there is no ratio to reserve a box from, and pinning the height on the `<img>` itself made
+       its empty letterbox part of the image: a 16x16 favicon.ico became a 240px-tall,
+       full-column-wide element carrying `role="button"` and a handler that calls
+       `stopPropagation`, so a tap anywhere in the ~99% of it that is background opened the
+       lightbox AND swallowed the row click — which on touch is the only thing that opens the
+       message-actions sheet. The height belongs to a wrapper that has no handlers, so those
+       pixels keep belonging to the row. Same defect class as the `@click.stop` note below,
+       re-created by a fixed box instead of by a modifier. -->
+  <span
     v-if="preview.kind === 'image' && preview.src"
-    class="inline-image"
-    :class="{ 'strip-item': inStrip, 'no-dims': !inStrip && !hasDimensions }"
-    :src="preview.src"
-    :width="preview.thumbWidth || undefined"
-    :height="preview.thumbHeight || undefined"
-    alt=""
-    loading="lazy"
-    decoding="async"
-    :role="viewerEnabled ? 'button' : undefined"
-    :tabindex="viewerEnabled ? 0 : undefined"
-    :aria-label="viewerEnabled ? imageLabel : undefined"
-    @click="onImageClick"
-    @keydown.enter.prevent="activate"
-    @keydown.space.prevent="activate"
-    @load="$emit('measured')"
-  />
+    :class="needsReservedBox ? 'dim-reserve' : 'dim-passthrough'"
+  >
+    <img
+      class="inline-image"
+      :class="{ 'strip-item': inStrip, 'in-reserve': needsReservedBox }"
+      :src="preview.src"
+      :width="preview.thumbWidth || undefined"
+      :height="preview.thumbHeight || undefined"
+      alt=""
+      loading="lazy"
+      decoding="async"
+      :role="viewerEnabled ? 'button' : undefined"
+      :tabindex="viewerEnabled ? 0 : undefined"
+      :aria-label="viewerEnabled ? imageLabel : undefined"
+      @click="onImageClick"
+      @keydown.enter.prevent="activate"
+      @keydown.space.prevent="activate"
+    />
+  </span>
   <!-- ⚠ `@loadedmetadata` matters more here than the image's `@load` does. The server measures
        dimensions for images only, so a video has NO width/height to reserve a box with and lays
        out at the UA default 300x150 until its metadata arrives — then jumps to full size. The
@@ -120,7 +132,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import type { LinkPreview } from '../composables/useLinkPreview.js';
 import { useSettingsStore } from '../stores/settings.js';
 
@@ -133,9 +145,13 @@ const props = defineProps<{
   inStrip?: boolean;
 }>();
 
-// Emitted when an image finishes decoding. Only matters when the server couldn't give us
-// dimensions (an exotic format, a truncated header) — there the box wasn't reserved, so the
-// row does grow on load and the list needs a chance to re-pin.
+// ⚠ `measured` is emitted by VIDEO and AUDIO only, and the image `@load` emit that used to sit
+// beside them is deliberately gone. Every rendered image now has its box before any bytes: the
+// server's width/height attributes, `.strip-item`'s row height, or `.dim-reserve`'s wrapper. So
+// `@load` could no longer report growth — but it still fired `repinAfterPreviewGrowth(true)`,
+// which for a reader at the live tail runs `scrollToBottom()`. With the atomic reveal landing a
+// message's images in one flush, a five-image message meant five scroll corrections for growth
+// that cannot happen.
 // `activate` rather than opening the viewer here: what a click MEANS depends on the
 // arrangement, and the arrangement is the parent's business. A tap on one image of a strip
 // should open the whole strip as a gallery, and only the parent knows what the strip holds.
@@ -155,6 +171,14 @@ const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.p
  * parse inside the 64 KB it reads.
  */
 const hasDimensions = computed(() => !!props.preview.thumbWidth && !!props.preview.thumbHeight);
+
+/**
+ * Whether this image needs a wrapper to hold its height open.
+ *
+ * Only outside a strip: the strip row already fixes the height there, and a second fixed box
+ * would fight it.
+ */
+const needsReservedBox = computed(() => !props.inStrip && !hasDimensions.value);
 
 /**
  * ⚠⚠ THERE IS DELIBERATELY NO `@error` HANDLING, and that is a decision rather than an omission.
@@ -248,29 +272,36 @@ function activate(): void {
   border-radius: var(--radius-md);
   display: block;
 }
-/* ⚠ A FIXED height, for the same reason `.inline-video` has one: with no width/height attributes
-   there is no intrinsic ratio to reserve a box from, so the element is laid out at the UA default
-   for a replaced element with no dimensions and grows to its real size on decode — the one case
-   where an inline image's height depends on bytes rather than on its descriptor.
-   `max-width: 100%` still applies, and because `height` is no longer `auto` a too-wide image is
-   constrained horizontally and letterboxed by `object-fit: contain` rather than changing height.
-   Only vertical movement disturbs a scroll position, so the width settling on decode costs
-   nothing.
-   240px, matching the `max-height` an image with dimensions would have been scaled into, so the
-   fallback and the normal case agree on the tallest a lone image gets.
-   NOT applied in a strip: the row already fixes the height there (see `.strip-item`). */
-.inline-image.no-dims {
+/* ⚠ The height lives on the WRAPPER, and the image sizes itself inside it.
+   With no width/height attributes there is no intrinsic ratio to reserve a box from, so the
+   element lays out at the UA default for a replaced element with no dimensions and grows to its
+   real size on decode — the one shape whose height would otherwise depend on bytes rather than on
+   its descriptor. 240px matches the `max-height` a measured image is scaled into, so the fallback
+   and the normal case agree on the tallest a lone image gets.
+   Putting it here rather than on the `<img>` is what keeps the empty area around a small image
+   from becoming a click target — see the template. */
+/* When no box needs reserving the wrapper generates NO box at all, so layout, flex participation
+   and the strip's sizing behave exactly as they did when the image was the direct child. */
+.dim-passthrough {
+  display: contents;
+}
+.dim-reserve {
+  display: block;
   height: 240px;
-  /* ⚠ `scale-down`, NOT `contain`. `contain` scales UP to fill the box, so an unmeasured 16x16
-     favicon.ico — sharp decodes jpeg/png/webp/tiff/gif/svg/heif/raw, so ico and bmp arrive as
-     `kind: 'image'` with null dimensions — rendered at 240x240 and 15x blurry. `scale-down` takes
-     the smaller of `none` and `contain`, so a small image stays its own size inside the box.
-     The box is still 240px tall, which is the price of a height that's knowable before the bytes:
-     empty space around a rare small image, rather than a jump on every one. */
-  object-fit: scale-down;
-  /* And a fill, so the reserved box reads as a placeholder rather than as a hole punched in the
+  /* A fill, so the reserved box reads as a placeholder rather than as a hole punched in the
      conversation — `loading="lazy"` means it can sit empty until the row nears the viewport. */
   background: var(--embed-bg);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+/* Inside the reserve the image is bounded by the box and never scaled up: sharp decodes
+   jpeg/png/webp/tiff/gif/svg/heif/raw, so ico and bmp arrive as `kind: 'image'` with null
+   dimensions, and a 16x16 favicon stretched to 240px would be 15x blurry. */
+.inline-image.in-reserve {
+  max-height: 100%;
+  max-width: 100%;
+  width: auto;
+  height: auto;
 }
 /* Only advertises a click when a click does something — the viewer is opt-out. */
 .inline-image[role='button'] {

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -288,11 +288,11 @@ function activate(): void {
 .dim-reserve {
   display: block;
   height: 240px;
-  /* A fill, so the reserved box reads as a placeholder rather than as a hole punched in the
-     conversation — `loading="lazy"` means it can sit empty until the row nears the viewport. */
-  background: var(--embed-bg);
-  border-radius: var(--radius-md);
-  overflow: hidden;
+  /* ⚠ NO fill, deliberately. It had one — the reasoning was that a lazily-loaded empty box reads
+     as a hole punched in the conversation. QA read it the other way round: a panel-coloured
+     rectangle is what a link-preview CARD looks like, so an image that merely hadn't been
+     measured announced itself as a different kind of object entirely. Direct media has no chrome
+     anywhere else in this component, and reserved space is not a thing to advertise. */
 }
 /* Inside the reserve the image is bounded by the box and never scaled up: sharp decodes
    jpeg/png/webp/tiff/gif/svg/heif/raw, so ico and bmp arrive as `kind: 'image'` with null

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -151,13 +151,24 @@ const settled = usePreviewsSettled(urls);
  *
  * A set only ever grows. New URLs stay hidden until the whole set settles, which is the property
  * the gate exists for; anything already painted stays painted, which is the property the latch
- * exists for. Neither needs a watcher on `urls`, so the spurious-fire problem goes with it — that
- * watcher keyed on array identity, and `urls` allocates a fresh array on ANY settings write.
+ * exists for.
+ *
+ * ⚠⚠ Watches `urls` AS WELL, and watching `settled` alone was a bug. Vue runs a watcher when its
+ * source's VALUE changes, so a flip that admits a URL which is ALREADY resolved — the same image
+ * posted earlier in the session, or previewed in another buffer — left `settled` true before and
+ * true after. The watcher never ran, the URL was never admitted, and its attachment stayed hidden
+ * for the life of the row with everything about it resolved and ready.
+ *
+ * The array identity churns on any settings write (`urls` allocates a fresh array each
+ * evaluation), so this fires more often than it strictly needs to. That is harmless HERE and was
+ * not in the version this replaced: the callback only ever ADDS, and re-adding a URL already in
+ * the set changes nothing, so no spurious render can follow. The defect before was a callback
+ * that could REMOVE.
  */
 const shown = ref<ReadonlySet<string>>(new Set());
 watch(
-  settled,
-  (ok) => {
+  [settled, urls],
+  ([ok]) => {
     if (!ok) return;
     const next = new Set(shown.value);
     for (const url of urls.value) next.add(url);

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -40,11 +40,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue';
 import { useSettingsStore } from '../stores/settings.js';
 import { useConfigStore } from '../stores/config.js';
 import { previewableUrls, MAX_CARDS_PER_MESSAGE } from '../utils/previewUrls.js';
-import { useLinkPreview, type LinkPreview } from '../composables/useLinkPreview.js';
+import {
+  useLinkPreview,
+  previewRevision,
+  type LinkPreview,
+} from '../composables/useLinkPreview.js';
 import { useMediaViewer } from '../composables/useMediaViewer.js';
 import MessageAttachment from './MessageAttachment.vue';
 
@@ -87,6 +91,85 @@ const urls = computed(() => previewableUrls(props.text, toggles.value));
 // null ref, which is exactly the "render nothing" case.
 const entries = computed(() => urls.value.map((url) => useLinkPreview(url)));
 
+// ─── Atomic reveal ────────────────────────────────────────────────────────────
+//
+// A message shows NONE of its attachments until every URL in it has an answer, then the whole
+// block appears at once.
+//
+// The rule this serves: no layout may depend on WHEN A SIBLING RESOLVES. Deriving the
+// arrangement from the resolved set meant a message with three images, one of which was already
+// cached from an earlier post, painted as a lone image (natural aspect, `max-height: 240px`) and
+// then re-arranged into a 200px filmstrip when the other two landed — and `stripHeight` re-picked
+// portrait-vs-landscape as the mix changed, a 100px collapse mid-read. Both are sibling-timing
+// dependencies, and both are invisible to a scrolled-up reader's re-pin because the growth has
+// already happened by the time anything hears about it.
+//
+// ⚠ Deciding the arrangement from the URL list instead was considered and does NOT work:
+// `mediaKindForUrl` charges extensionless hosts to the CARD budget (previewUrls.ts), so an imgur
+// or twimg link — the common case on IRC — is predicted as a card and flips to a strip when it
+// resolves as an image. The prediction is wrong exactly where it matters.
+//
+// What this deliberately does NOT cost: a preview's own descriptor arrives atomically with the
+// decision to render it, so there is no earlier layout for it to disturb. `STRIP_PORTRAIT` stays,
+// and a lone image keeps `object-fit: contain` at its natural aspect.
+const allResolved = computed(() => entries.value.every((entry) => entry.value !== null));
+
+/**
+ * How long to wait for the stragglers before showing what we have.
+ *
+ * ⚠⚠ NOT a nicety — this is the safety net, and the gate above is unsafe without it.
+ * `useLinkPreview` returns a PERMANENTLY null ref for a URL nobody primed, so any divergence
+ * between what this component treats as previewable and what the priming path actually asked
+ * about would mean the message shows nothing for the life of the tab — strictly worse than the
+ * partial render this replaces. Both sides call the same `previewableUrls`, so they should not
+ * diverge; this is what makes "should not" survive being wrong.
+ *
+ * Long enough that the normal case never sees it (everything in one message lands in one batch,
+ * ~24ms after ingest), short enough that a real straggler doesn't read as a broken message.
+ */
+const REVEAL_DEADLINE_MS = 1500;
+
+const revealed = ref(false);
+let revealTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearRevealTimer(): void {
+  if (revealTimer === null) return;
+  clearTimeout(revealTimer);
+  revealTimer = null;
+}
+
+// Latched: once shown, stay shown. A straggler arriving after a deadline reveal then appends,
+// which is a growth event — accepted, because it can only happen on the deadline path.
+watch(
+  allResolved,
+  (ok) => {
+    if (!ok) return;
+    clearRevealTimer();
+    revealed.value = true;
+  },
+  { immediate: true },
+);
+
+onMounted(() => {
+  // ⚠ Only armed when the gate is unsatisfied AT MOUNT. Scrolling into history mounts rows whose
+  // previews resolved long ago; those reveal synchronously through the watcher above and must
+  // not pay for a timer apiece.
+  if (revealed.value) return;
+  revealTimer = setTimeout(() => {
+    revealTimer = null;
+    // ⚠⚠ BEFORE the flag, and this ordering is load-bearing. MessageList re-pins by watching
+    // `previewRevision`, which only bumps when a BATCH lands — a reveal fired by this timer
+    // would otherwise grow the row with nothing watching, and the growth would be uncompensated
+    // for a scrolled-up reader. Bumping first puts the pre-flush watcher (a lower scheduler id,
+    // since MessageList is the parent) ahead of this component's re-render, which is what lets
+    // it measure the anchor BEFORE the block appears.
+    previewRevision.value++;
+    revealed.value = true;
+  }, REVEAL_DEADLINE_MS);
+});
+
+onBeforeUnmount(clearRevealTimer);
+
 /**
  * Previews that are resolved AND allowed by the settings.
  *
@@ -96,6 +179,8 @@ const entries = computed(() => urls.value.map((url) => useLinkPreview(url)));
  * into rendering a card.
  */
 const visible = computed<LinkPreview[]>(() => {
+  // All-or-nothing: see the atomic-reveal block above.
+  if (!revealed.value) return [];
   const out: LinkPreview[] = [];
   let cards = 0;
   for (const entry of entries.value) {

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -40,13 +40,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue';
+import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
 import { useSettingsStore } from '../stores/settings.js';
 import { useConfigStore } from '../stores/config.js';
 import { previewableUrls, MAX_CARDS_PER_MESSAGE } from '../utils/previewUrls.js';
 import {
   useLinkPreview,
-  previewRevision,
+  usePreviewsSettled,
   type LinkPreview,
 } from '../composables/useLinkPreview.js';
 import { useMediaViewer } from '../composables/useMediaViewer.js';
@@ -112,63 +112,49 @@ const entries = computed(() => urls.value.map((url) => useLinkPreview(url)));
 // What this deliberately does NOT cost: a preview's own descriptor arrives atomically with the
 // decision to render it, so there is no earlier layout for it to disturb. `STRIP_PORTRAIT` stays,
 // and a lone image keeps `object-fit: contain` at its natural aspect.
-const allResolved = computed(() => entries.value.every((entry) => entry.value !== null));
+//
+// Two residuals, both deliberate, both stated so a later reader doesn't take them for oversights:
+//
+//   1. A short-TTL failure that RECOVERS on a re-ask grows the block, and can re-arrange it (one
+//      image becoming two is a strip). Holding the gate for it instead would hide a whole message
+//      for up to five minutes on the strength of one saturated fetch, which is far worse. The
+//      growth goes through `previewRevision`, so it is compensated; only its arrangement isn't.
+//   2. A message mixing an image with a slow PAGE link shows nothing until the page answers, and
+//      that can be tens of seconds. The page URL cannot be excluded from the gate: an
+//      extension-less URL might itself resolve as an image and belong in the arrangement, so
+//      "what could render" is not knowable before the answer. This is the trade atomic reveal
+//      makes — late but stable, rather than early and re-arranging.
+//
+// ⚠⚠ Asked, never timed. The first version of this gate revealed on a 1500ms deadline, on the
+// reasoning that a message's URLs all land in one batch "~24ms after ingest" — which was the
+// coalescing debounce (`FLUSH_MS`) mistaken for the round trip. The server allows 10s of queue
+// wait plus a 30s resolve deadline per URL and answers a slice with one `Promise.all`, so the
+// deadline fired on any cold link and revealed a PARTIAL set: a lone image that then became a
+// filmstrip when the straggler landed, which is verbatim the defect above. `usePreviewsSettled`
+// asks the module that actually knows, so there is no latency to guess at and no partial reveal
+// to recover from.
+const settled = usePreviewsSettled(urls);
 
-/**
- * How long to wait for the stragglers before showing what we have.
- *
- * ⚠⚠ NOT a nicety — this is the safety net, and the gate above is unsafe without it.
- * `useLinkPreview` returns a PERMANENTLY null ref for a URL nobody primed, so any divergence
- * between what this component treats as previewable and what the priming path actually asked
- * about would mean the message shows nothing for the life of the tab — strictly worse than the
- * partial render this replaces. Both sides call the same `previewableUrls`, so they should not
- * diverge; this is what makes "should not" survive being wrong.
- *
- * Long enough that the normal case never sees it (everything in one message lands in one batch,
- * ~24ms after ingest), short enough that a real straggler doesn't read as a broken message.
- */
-const REVEAL_DEADLINE_MS = 1500;
-
+// Latched, so a URL re-entering the queue (a re-ask after a transient failure) cannot HIDE a
+// block that is already on screen — a shrink disturbs a reader exactly as much as a growth.
 const revealed = ref(false);
-let revealTimer: ReturnType<typeof setTimeout> | null = null;
-
-function clearRevealTimer(): void {
-  if (revealTimer === null) return;
-  clearTimeout(revealTimer);
-  revealTimer = null;
-}
-
-// Latched: once shown, stay shown. A straggler arriving after a deadline reveal then appends,
-// which is a growth event — accepted, because it can only happen on the deadline path.
 watch(
-  allResolved,
+  settled,
   (ok) => {
-    if (!ok) return;
-    clearRevealTimer();
-    revealed.value = true;
+    if (ok) revealed.value = true;
   },
   { immediate: true },
 );
 
-onMounted(() => {
-  // ⚠ Only armed when the gate is unsatisfied AT MOUNT. Scrolling into history mounts rows whose
-  // previews resolved long ago; those reveal synchronously through the watcher above and must
-  // not pay for a timer apiece.
-  if (revealed.value) return;
-  revealTimer = setTimeout(() => {
-    revealTimer = null;
-    // ⚠⚠ BEFORE the flag, and this ordering is load-bearing. MessageList re-pins by watching
-    // `previewRevision`, which only bumps when a BATCH lands — a reveal fired by this timer
-    // would otherwise grow the row with nothing watching, and the growth would be uncompensated
-    // for a scrolled-up reader. Bumping first puts the pre-flush watcher (a lower scheduler id,
-    // since MessageList is the parent) ahead of this component's re-render, which is what lets
-    // it measure the anchor BEFORE the block appears.
-    previewRevision.value++;
-    revealed.value = true;
-  }, REVEAL_DEADLINE_MS);
+// ⚠ The latch is scoped to the CURRENT url set, not to the component's lifetime. Switching
+// `chat.inline_media.enabled` on from the composer or from another device re-primes without
+// remounting anything (see useSocket's `wirePreviewToggles`), so `urls` grows under a latch that
+// was already open and the new images paint one at a time — the piecemeal render this gate
+// exists to prevent, arriving by the one path that never remounts. Re-deriving from `settled`
+// closes the gate again until the new set is complete.
+watch(urls, () => {
+  revealed.value = settled.value;
 });
-
-onBeforeUnmount(clearRevealTimer);
 
 /**
  * Previews that are resolved AND allowed by the settings.

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -152,9 +152,19 @@ watch(
 // was already open and the new images paint one at a time — the piecemeal render this gate
 // exists to prevent, arriving by the one path that never remounts. Re-deriving from `settled`
 // closes the gate again until the new set is complete.
-watch(urls, () => {
-  revealed.value = settled.value;
-});
+// ⚠⚠ Keyed on the CONTENTS, not the array. `urls` is a computed that allocates a fresh array on
+// every evaluation, and it re-evaluates whenever `toggles` does — which is on ANY settings write,
+// because the store replaces `values` wholesale. So watching the array identity fired this on an
+// unrelated toggle (the channel-list chevron, a highlight sound, a cross-device sync) with a
+// byte-identical URL list, and re-derived `revealed` from a `settled` that can legitimately be
+// false — making a strip that was on screen vanish mid-read. That is the same shrink the latch
+// above exists to prevent, reintroduced by the line meant to scope it.
+watch(
+  () => urls.value.join('\n'),
+  () => {
+    revealed.value = settled.value;
+  },
+);
 
 /**
  * Previews that are resolved AND allowed by the settings.

--- a/vue_client/src/components/MessageAttachments.vue
+++ b/vue_client/src/components/MessageAttachments.vue
@@ -119,6 +119,10 @@ const entries = computed(() => urls.value.map((url) => useLinkPreview(url)));
 //      image becoming two is a strip). Holding the gate for it instead would hide a whole message
 //      for up to five minutes on the strength of one saturated fetch, which is far worse. The
 //      growth goes through `previewRevision`, so it is compensated; only its arrangement isn't.
+//      ⚠ The gate cannot RE-CLOSE for this: `flush` writes the answer into the ref before it
+//      branches on status, so a transient `unavailable` carries a value, and nothing ever writes
+//      null back to a cached ref. The only way a settled URL becomes pending again is cache
+//      eviction followed by a re-prime against a fresh ref — which is why `shown` latches.
 //   2. A message mixing an image with a slow PAGE link shows nothing until the page answers, and
 //      that can be tens of seconds. The page URL cannot be excluded from the gate: an
 //      extension-less URL might itself resolve as an image and belong in the arrangement, so
@@ -135,35 +139,31 @@ const entries = computed(() => urls.value.map((url) => useLinkPreview(url)));
 // to recover from.
 const settled = usePreviewsSettled(urls);
 
-// Latched, so a URL re-entering the queue (a re-ask after a transient failure) cannot HIDE a
-// block that is already on screen — a shrink disturbs a reader exactly as much as a growth.
-const revealed = ref(false);
+/**
+ * The URLs this message has already committed to showing.
+ *
+ * ⚠⚠ A PER-URL latch, not a per-component boolean, and the difference is a defect. The boolean
+ * had to be re-derived whenever `urls` changed — otherwise a settings flip grew the set under an
+ * already-open latch and the new images painted one at a time — and re-deriving it meant
+ * `revealed = settled`, which could go true→false and tear the whole block down. Enabling inline
+ * media with ten resolved cards on screen therefore collapsed all ten, buffer-wide, in one frame:
+ * ~1200px of uncompensated shrink, for a setting that has nothing to do with cards.
+ *
+ * A set only ever grows. New URLs stay hidden until the whole set settles, which is the property
+ * the gate exists for; anything already painted stays painted, which is the property the latch
+ * exists for. Neither needs a watcher on `urls`, so the spurious-fire problem goes with it — that
+ * watcher keyed on array identity, and `urls` allocates a fresh array on ANY settings write.
+ */
+const shown = ref<ReadonlySet<string>>(new Set());
 watch(
   settled,
   (ok) => {
-    if (ok) revealed.value = true;
+    if (!ok) return;
+    const next = new Set(shown.value);
+    for (const url of urls.value) next.add(url);
+    if (next.size !== shown.value.size) shown.value = next;
   },
   { immediate: true },
-);
-
-// ⚠ The latch is scoped to the CURRENT url set, not to the component's lifetime. Switching
-// `chat.inline_media.enabled` on from the composer or from another device re-primes without
-// remounting anything (see useSocket's `wirePreviewToggles`), so `urls` grows under a latch that
-// was already open and the new images paint one at a time — the piecemeal render this gate
-// exists to prevent, arriving by the one path that never remounts. Re-deriving from `settled`
-// closes the gate again until the new set is complete.
-// ⚠⚠ Keyed on the CONTENTS, not the array. `urls` is a computed that allocates a fresh array on
-// every evaluation, and it re-evaluates whenever `toggles` does — which is on ANY settings write,
-// because the store replaces `values` wholesale. So watching the array identity fired this on an
-// unrelated toggle (the channel-list chevron, a highlight sound, a cross-device sync) with a
-// byte-identical URL list, and re-derived `revealed` from a `settled` that can legitimately be
-// false — making a strip that was on screen vanish mid-read. That is the same shrink the latch
-// above exists to prevent, reintroduced by the line meant to scope it.
-watch(
-  () => urls.value.join('\n'),
-  () => {
-    revealed.value = settled.value;
-  },
 );
 
 /**
@@ -175,13 +175,13 @@ watch(
  * into rendering a card.
  */
 const visible = computed<LinkPreview[]>(() => {
-  // All-or-nothing: see the atomic-reveal block above.
-  if (!revealed.value) return [];
   const out: LinkPreview[] = [];
   let cards = 0;
   for (const entry of entries.value) {
     const p = entry.value;
     if (!p || p.status !== 'ok') continue;
+    // All-or-nothing, per URL: see `shown` above.
+    if (!shown.value.has(p.url)) continue;
     const isMedia = p.kind === 'image' || p.kind === 'video' || p.kind === 'audio';
     if (isMedia ? !toggles.value.inlineMedia : !toggles.value.linkPreviews) continue;
     // ⚠ The card cap is re-applied to the SERVER's answer, not just to the extension guess that
@@ -349,7 +349,11 @@ const stripHeight = computed(() => {
 .filmstrip::-webkit-scrollbar {
   display: none;
 }
-.filmstrip > :deep(*) {
+/* ⚠ Targets the media itself, not the direct child. An inline image is wrapped in a
+   `display: contents` span (see MessageAttachment), which generates no box — so a snap point on
+   the direct child would have nothing to align. */
+.filmstrip :deep(.inline-image),
+.filmstrip :deep(.inline-video) {
   scroll-snap-align: start;
 }
 

--- a/vue_client/src/composables/useLinkPreview.test.ts
+++ b/vue_client/src/composables/useLinkPreview.test.ts
@@ -8,6 +8,7 @@ import {
   primePreviews,
   useLinkPreview,
   usePreviewsSettled,
+  previewRevision,
   resetLinkPreviewCache,
 } from './useLinkPreview.js';
 import * as apiModule from '../api.js';
@@ -47,9 +48,23 @@ beforeEach(() => {
   posted = [];
   respond = okFor;
   vi.spyOn(apiModule, 'api').mockImplementation(async (_url, opts) => {
-    const urls = ((opts ?? {}).body as { urls: string[] }).urls;
+    const options = opts ?? {};
+    const urls = (options.body as { urls: string[] }).urls;
     posted.push(urls);
-    return respond(urls) as never;
+    const answer = respond(urls);
+    // ⚠ The stub HONOURS `signal`, because `fetch` does and the caller now depends on it. A stub
+    // that accepts a signal and ignores it makes a hung request untestable — the promise the
+    // caller is waiting on simply never settles, and the timeout it added looks broken.
+    if (!options.signal) return answer as never;
+    return (await new Promise<unknown>((resolve, reject) => {
+      const signal = options.signal!;
+      if (signal.aborted) {
+        reject(new Error('aborted'));
+        return;
+      }
+      signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      Promise.resolve(answer).then(resolve, reject);
+    })) as never;
   });
 });
 
@@ -404,6 +419,101 @@ describe('is an answer still coming?', () => {
     primePreviews(['https://e.test/transient'], BOTH);
     await settle();
     expect(useLinkPreview('https://e.test/transient').value?.status).toBe('unavailable');
+    expect(settledRef.value).toBe(true);
+  });
+});
+
+describe('the re-pin signal', () => {
+  // ⚠⚠ `previewRevision` is what MessageList watches to re-anchor a scrolled-up reader, and until
+  // now NOTHING in the repo asserted it — the branch's headline change to it could be reverted
+  // with a fully green suite. Every path that moves a URL out of the pending set can open a
+  // reveal gate, and every gate that opens grows a row, so every such path has to bump it.
+
+  it('bumps for a batch that answers with no `ok` at all', async () => {
+    // The old condition was `if (changed)` — some answer was `ok`. With the gate, an
+    // `unavailable` is very often the answer that COMPLETES a message's gate and paints its whole
+    // block, so an all-unavailable batch is exactly when a re-pin is needed.
+    respond = transientFor;
+    const before = previewRevision.value;
+    primePreviews(['https://e.test/dead'], BOTH);
+    await settle();
+    expect(previewRevision.value).toBeGreaterThan(before);
+  });
+
+  it('bumps when the request fails and the gate falls open', async () => {
+    // The largest single growth this feature produces: a 502 mid-deploy fails every URL in the
+    // slice open at once, painting every block that was waiting on it — cached siblings included.
+    respond = () => {
+      throw new Error('502');
+    };
+    const before = previewRevision.value;
+    primePreviews(['https://e.test/boom'], BOTH);
+    await settle();
+    expect(previewRevision.value).toBeGreaterThan(before);
+  });
+
+  it('does NOT bump when eviction only drops URLs that had already settled', async () => {
+    // ⚠⚠ Once a long-lived tab saturates the cache, `while (size > MAX)` trims to exactly the
+    // ceiling — so EVERY prime that creates an entry evicts one. Reporting that as a layout event
+    // fired a re-pin (two forced synchronous layouts over an unvirtualised 500-row list) on
+    // essentially every incoming message, compensating for a growth that had not happened. Only
+    // an evicted URL something was still WAITING on can change what renders.
+    //
+    // Entries are created by reading, not by priming: `useLinkPreview` calls `entryFor` without
+    // touching `asked`, so these are settled from birth and eviction cannot open a gate.
+    for (let n = 0; n <= 2000; n++) useLinkPreview(`https://e.test/fill/${n}`);
+    respond = okFor;
+    const before = previewRevision.value;
+
+    primePreviews(['https://e.test/evictor'], BOTH);
+
+    expect(previewRevision.value).toBe(before);
+  });
+
+  it('does NOT bump merely for queueing work', async () => {
+    // Priming only ever ADDS to the pending set, so it can close a gate but never open one. A
+    // bump here would re-pin the list on every incoming line of chat.
+    respond = okFor;
+    primePreviews(['https://e.test/one'], BOTH);
+    await settle();
+    const before = previewRevision.value;
+    primePreviews(['https://e.test/two'], BOTH);
+    expect(previewRevision.value).toBe(before);
+  });
+});
+
+describe('a re-ask that is in flight', () => {
+  // ⚠⚠ The ordering case in `previewPending`, and the one its docblock calls load-bearing.
+  // `runReask` does `retry.set(url, {at: Infinity})` AND `queue.add(url)` on a URL whose value is
+  // still null — so if `queue`/`asked` were tested first, a recovery ATTEMPT would report the URL
+  // pending and re-hide a block that is already on screen. A shrink, caused by trying to help.
+  //
+  // Nothing else reaches it. The neighbouring tests either carry a value (which short-circuits
+  // before the clause) or run after `forgetForRetry` has emptied `asked`, so `queue || asked` is
+  // false whatever the order. Deleting the clause, or moving it after those two, left 61/61 green.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Pins the ±25% backoff jitter to its midpoint, so the re-ask lands at exactly the 15s floor
+    // and the assertion can sit inside the 24ms window before the flush drains `queue`.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('stays SETTLED while its re-ask is queued and in flight', async () => {
+    respond = () => {
+      throw new Error('502');
+    };
+    const settledRef = usePreviewsSettled(ref(['https://e.test/reasked']));
+    primePreviews(['https://e.test/reasked'], BOTH);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(settledRef.value).toBe(true);
+
+    // Hang the retry, and stop the clock the instant `runReask` has re-queued it — before the
+    // 24ms coalescing timer drains `queue` again. This is the only window in which the URL is in
+    // `retry` AND `queue` with a null value, which is precisely the state the clause is about.
+    respond = () => new Promise(() => {});
+    await vi.advanceTimersByTimeAsync(15_000);
+
     expect(settledRef.value).toBe(true);
   });
 });

--- a/vue_client/src/composables/useLinkPreview.test.ts
+++ b/vue_client/src/composables/useLinkPreview.test.ts
@@ -11,7 +11,7 @@ import {
   resetLinkPreviewCache,
 } from './useLinkPreview.js';
 import * as apiModule from '../api.js';
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 
 const BOTH = { inlineMedia: true, linkPreviews: true };
 
@@ -365,6 +365,37 @@ describe('is an answer still coming?', () => {
     expect(usePreviewsSettled(urls('https://e.test/never-primed')).value).toBe(true);
   });
 
+  it('says SETTLED when a transport failure puts a URL back in play, with no value to show', async () => {
+    // ⚠⚠ THE FAIL-OPEN CASE, and the one the gate got wrong. `forgetForRetry` runs for every URL
+    // in a slice whose POST threw and for every URL the server omitted from a 200 — leaving a
+    // null value AND a `retry` entry. Counting that as pending hid the whole message's attachment
+    // block, cached siblings included, for the entire 15s→5min ladder and indefinitely while the
+    // server kept failing: one 502 during a deploy blanked every message sharing its batch.
+    //
+    // ⚠ This is also the ONLY test that can observe `usePreviewsSettled`'s `pendingRevision` read.
+    // Every other transition in this file moves an entry ref too, and a ref read makes the
+    // computed reactive by itself. Here the ref is null before and null after — only the pending
+    // set moves — so a SUBSCRIBED computed (which is what the component's `watch` creates) never
+    // re-evaluates without that line.
+    respond = () => {
+      throw new Error('502');
+    };
+    const settledRef = usePreviewsSettled(urls('https://e.test/broken'));
+
+    // ⚠ Subscribe AFTER priming, so the first value observed is `false`. Subscribing before means
+    // the immediate call records `true` (nothing is pending yet), the assertion at the end reads
+    // `true` whatever happened in between, and the test passes against every mutation.
+    primePreviews(['https://e.test/broken'], BOTH);
+    const seen: boolean[] = [];
+    watch(settledRef, (v) => seen.push(v), { immediate: true });
+    expect(seen).toEqual([false]);
+
+    await settle();
+
+    expect(useLinkPreview('https://e.test/broken').value).toBeNull();
+    expect(seen.at(-1)).toBe(true);
+  });
+
   it('says SETTLED for a failure awaiting a re-ask, rather than holding the message', async () => {
     // A transient refusal has an ANSWER; the re-ask may be minutes out. Treating a queued re-ask
     // as pending would hide a whole message on the strength of one saturated fetch.
@@ -374,5 +405,35 @@ describe('is an answer still coming?', () => {
     await settle();
     expect(useLinkPreview('https://e.test/transient').value?.status).toBe('unavailable');
     expect(settledRef.value).toBe(true);
+  });
+});
+
+describe('a resolve that never answers', () => {
+  // ⚠⚠ `api()` is a bare `fetch` with no signal and no timeout, so a dead NAT mapping or a proxy
+  // that accepts and never replies leaves the promise pending forever — and `flush` awaits its
+  // slices sequentially, so one hung POST also strands every later slice. Before the reveal gate
+  // that cost a missing card; with it, every message holding one of those URLs renders NO
+  // attachments, permanently. A gate that must fail open cannot be built on a request that never
+  // settles.
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const tick = (ms: number) => vi.advanceTimersByTimeAsync(ms);
+
+  it('gives up on a hung request and reports the URL settled', async () => {
+    respond = () => new Promise(() => {});
+    const settledRef = usePreviewsSettled(ref(['https://e.test/hung']));
+    primePreviews(['https://e.test/hung'], BOTH);
+    const seen: boolean[] = [];
+    watch(settledRef, (v) => seen.push(v), { immediate: true });
+
+    await tick(60);
+    expect(seen.at(-1)).toBe(false);
+
+    // Past RESOLVE_TIMEOUT_MS. The URL goes back in play through the same `forgetForRetry` path a
+    // transport error takes, which is what makes it settled rather than merely un-asked.
+    await tick(46_000);
+
+    expect(seen.at(-1)).toBe(true);
   });
 });

--- a/vue_client/src/composables/useLinkPreview.test.ts
+++ b/vue_client/src/composables/useLinkPreview.test.ts
@@ -4,8 +4,14 @@
 // @vitest-environment happy-dom
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { primePreviews, useLinkPreview, resetLinkPreviewCache } from './useLinkPreview.js';
+import {
+  primePreviews,
+  useLinkPreview,
+  usePreviewsSettled,
+  resetLinkPreviewCache,
+} from './useLinkPreview.js';
 import * as apiModule from '../api.js';
+import { ref } from 'vue';
 
 const BOTH = { inlineMedia: true, linkPreviews: true };
 
@@ -319,5 +325,54 @@ describe('re-asking after expiresAt', () => {
     await tick(20_000);
     expect(posted).toHaveLength(2);
     expect(useLinkPreview('https://e.test/ghost').value?.status).toBe('ok');
+  });
+});
+
+describe('is an answer still coming?', () => {
+  // ⚠⚠ The distinction the reveal gate in `MessageAttachments` rests on. That component holds a
+  // message's whole attachment block back until every URL in it has settled, so it has to tell
+  // "in flight" apart from "nobody ever asked" — and only this module knows. Its own suite mocks
+  // `usePreviewsSettled`, so this is the ONLY place the real rule is exercised.
+  //
+  // The gate's first version guessed with a 1500ms timer instead. The guess was wrong by more
+  // than an order of magnitude (the server allows 10s of queue wait plus a 30s resolve deadline
+  // per URL, answered as one `Promise.all` over the slice), so it fired on any cold link and
+  // revealed a partial set — re-creating the very arrangement flip it existed to prevent.
+
+  const urls = (...list: string[]) => ref(list);
+
+  it('says NOT SETTLED while a primed URL is still in flight', async () => {
+    let release: (() => void) | undefined;
+    respond = (list) =>
+      new Promise((resolve) => {
+        release = () => resolve(okFor(list));
+      });
+
+    const settledRef = usePreviewsSettled(urls('https://e.test/slow'));
+    primePreviews(['https://e.test/slow'], BOTH);
+    await settle();
+    expect(settledRef.value).toBe(false);
+
+    release?.();
+    await settle();
+    expect(settledRef.value).toBe(true);
+  });
+
+  it('says SETTLED for a URL nobody ever primed', () => {
+    // ⚠ The property that makes the gate safe. `useLinkPreview` hands back a permanently-null ref
+    // for an unprimed URL, so a gate of "every entry has a value" would blank that message for
+    // the life of the tab. Not in flight means not coming, so render now.
+    expect(usePreviewsSettled(urls('https://e.test/never-primed')).value).toBe(true);
+  });
+
+  it('says SETTLED for a failure awaiting a re-ask, rather than holding the message', async () => {
+    // A transient refusal has an ANSWER; the re-ask may be minutes out. Treating a queued re-ask
+    // as pending would hide a whole message on the strength of one saturated fetch.
+    respond = transientFor;
+    const settledRef = usePreviewsSettled(urls('https://e.test/transient'));
+    primePreviews(['https://e.test/transient'], BOTH);
+    await settle();
+    expect(useLinkPreview('https://e.test/transient').value?.status).toBe('unavailable');
+    expect(settledRef.value).toBe(true);
   });
 });

--- a/vue_client/src/composables/useLinkPreview.ts
+++ b/vue_client/src/composables/useLinkPreview.ts
@@ -91,37 +91,22 @@ const MAX_BATCH = 20;
 const FLUSH_MS = 24;
 
 /**
- * Ceiling on one resolve round trip, client side.
+ * Ceiling on ONE FLUSH — every slice of it, not each slice separately.
  *
- * ⚠⚠ Not belt-and-braces. `api()` is a bare `fetch` with no signal and no timeout, so a dead NAT
- * mapping, a sleeping laptop or a proxy that accepts and never answers leaves the promise pending
- * FOREVER — and `flush` awaits its slices sequentially, so one hung POST also strands every later
- * slice with no request ever sent. Before the reveal gate that cost a missing card; with it, every
- * message holding one of those URLs renders no attachments at all, permanently. The gate must
- * fail open, and a request that never settles is the one way it cannot.
+ * ⚠⚠ Two distinct hangs, and the per-slice form only fixed one. `api()` had no signal and no
+ * timeout, so a proxy that accepts and never answers left the promise pending for the life of the
+ * tab; and `flush` awaits its slices SEQUENTIALLY, so that one stuck POST also stranded every
+ * later slice with no request ever sent. Bounding each slice separately left the second hang
+ * intact at 45s x sliceIndex — a 200-URL history page would not issue its last POST for seven and
+ * a half minutes, and with the reveal gate every message holding one of those URLs renders no
+ * attachments at all until it does. One deadline across the call bounds the blanking to this
+ * number no matter how many slices there are.
  *
- * Generous against the server's own budget (10s of queue wait plus a 30s resolve deadline, all
- * answered as one `Promise.all`), so this only fires when the round trip is genuinely stuck
- * rather than merely slow. Losing the race puts the slice back in play through the same
- * `forgetForRetry` path a transport error takes.
+ * Generous against the server's own budget — 10s of queue wait plus a 30s resolve deadline,
+ * answered as one `Promise.all` over the slice — so it only fires when the round trip is
+ * genuinely stuck rather than merely slow.
  */
 const RESOLVE_TIMEOUT_MS = 45_000;
-
-function withTimeout<T>(work: Promise<T>): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error('resolve timed out')), RESOLVE_TIMEOUT_MS);
-    work.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (err) => {
-        clearTimeout(timer);
-        reject(err as Error);
-      },
-    );
-  });
-}
 
 async function flush(): Promise<void> {
   flushTimer = null;
@@ -129,15 +114,35 @@ async function flush(): Promise<void> {
   queue = new Set();
   if (urls.length === 0) return;
 
+  const deadline = Date.now() + RESOLVE_TIMEOUT_MS;
   for (let i = 0; i < urls.length; i += MAX_BATCH) {
     const slice = urls.slice(i, i + MAX_BATCH);
     try {
-      const res = await withTimeout(
-        api<{ previews: LinkPreview[] }>('/api/link-preview/resolve', {
+      const remaining = deadline - Date.now();
+      // Nothing left of the budget: put the rest back in play WITHOUT posting. A request issued
+      // against an already-blown deadline would only add load to a server that has just failed to
+      // answer, and the URLs reach the same recoverable state either way.
+      if (remaining <= 0) throw new Error('resolve budget exhausted');
+      // ⚠ A real abort, not a race. `Promise.race` against a timer leaves the socket open, the
+      // body still downloading, and the completed answer discarded into a handler that has
+      // already re-armed all 20 URLs for a re-ask — so one stuck slice fanned out into ~18
+      // duplicate POSTs aimed at a server that was already struggling.
+      //
+      // ⚠ `AbortController` + `setTimeout` rather than `AbortSignal.timeout`, which no test can
+      // reach: vitest's fake timers don't patch it, so the only way to exercise this would be a
+      // 45-second wall-clock wait — i.e. it would never be exercised.
+      const abort = new AbortController();
+      const abortTimer = setTimeout(() => abort.abort(), remaining);
+      let res: { previews: LinkPreview[] };
+      try {
+        res = await api<{ previews: LinkPreview[] }>('/api/link-preview/resolve', {
           method: 'POST',
           body: { urls: slice },
-        }),
-      );
+          signal: abort.signal,
+        });
+      } finally {
+        clearTimeout(abortTimer);
+      }
       const answered = new Set<string>();
       for (const preview of res.previews ?? []) {
         const entry = cache.get(preview.url);
@@ -158,15 +163,20 @@ async function flush(): Promise<void> {
       // `retry` entry exists so nothing re-asks it, and `dropIfExpired` returns early because a
       // null value has no `expiresAt`. Permanently blank, from a response that looked fine.
       for (const url of slice) if (!answered.has(url)) forgetForRetry(url);
-      // ⚠⚠ Any ANSWER bumps this, not only an `ok` one. This used to be `if (changed)`, guarded by
-      // a comment reading "only an `ok` preview renders anything, so only an `ok` preview can
-      // change a row's height" — which stopped being true when the reveal gate landed.
-      // `MessageAttachments` holds a message's whole block back until every URL in it has settled,
-      // so an `unavailable` is very often the answer that COMPLETES that gate and paints the
-      // block: growth out of a batch containing no `ok` at all, with nothing telling the list to
-      // re-pin. The cost of the wider condition is one no-op re-pin per all-unavailable batch —
-      // per BATCH, not per row — which is the cheaper side of the trade by a wide margin.
-      if (answered.size > 0) previewRevision.value++;
+      // ⚠⚠ UNCONDITIONAL, and the condition it replaced went through two wrong versions.
+      //
+      // It was `if (changed)` — only an `ok` answer — guarded by a comment reading "only an `ok`
+      // preview renders anything, so only an `ok` preview can change a row's height". True until
+      // the reveal gate existed; after it, an `unavailable` is very often the answer that
+      // COMPLETES a gate and paints a whole block. Then it was `answered.size > 0`, which still
+      // missed the case where the server answers with nothing at all: `forgetForRetry` runs for
+      // every unanswered URL, that too opens gates, and nothing bumped.
+      //
+      // The rule this now follows: ANY path that can move a URL out of the pending set can open a
+      // gate, and every gate that opens grows a row. `pendingRevision` marks exactly those paths,
+      // so the two are bumped together wherever a gate can open — never in `primePreviews`'s
+      // queueing branch, which only ever ADDS to the pending set and so can only close one.
+      previewRevision.value++;
       pendingRevision.value++;
       scheduleReask();
     } catch {
@@ -176,6 +186,11 @@ async function flush(): Promise<void> {
       // than the missing card. Every URL in the slice is put back in play; none of them got an
       // answer, so none of them has a verdict to remember.
       for (const url of slice) forgetForRetry(url);
+      // ⚠ Both, for the reason above: `forgetForRetry` fails the gate OPEN, so a 502 mid-deploy
+      // paints every block that was waiting on this slice — including cached siblings that have
+      // been resolved all along. That is the largest single growth this feature produces, and it
+      // was the one path with no re-pin at all.
+      previewRevision.value++;
       pendingRevision.value++;
       scheduleReask();
     }
@@ -287,11 +302,11 @@ function runReask(): void {
     // Evicted by the cache ceiling, or dropped by `dropIfExpired` on a priming pass — either
     // way nobody is holding a ref for it, so there is nothing to re-ask on behalf of.
     if (!cache.has(url)) {
+      // ⚠ No bump, and not by omission: `previewPending` tests `retry` BEFORE `queue`/`asked`, so
+      // a URL in this loop is already settled and stays settled — deleting its `retry` entry is
+      // not a transition anything can observe. (`retry ⊆ cache` also makes this branch itself
+      // unreachable today; it is kept as a guard, not as a live path.)
       retry.delete(url);
-      // ⚠ Bumped, because this IS a pending->settled transition. The `continue` skips `queued`,
-      // so without it every `usePreviewsSettled` keeps its cached `false` and a message's block
-      // stays hidden until some unrelated bump happens along.
-      pendingRevision.value++;
       continue;
     }
     // Parked as in-flight rather than deleted, and the difference is the whole backoff: the
@@ -318,17 +333,27 @@ function runReask(): void {
  */
 const MAX_CACHE_ENTRIES = 2000;
 
+/**
+ * Returns whether eviction removed a URL that was still PENDING — i.e. whether it can have opened
+ * a reveal gate.
+ *
+ * ⚠ Not "did it evict anything". Once a long-lived tab saturates the cache, `while (size > MAX)`
+ * trims to exactly the ceiling, so EVERY prime that creates an entry evicts one — and reporting
+ * that as a layout event fired a re-pin (two forced synchronous layouts over an unvirtualised
+ * 500-row list) on essentially every incoming message, to compensate for a growth that had not
+ * happened. Only an evicted URL that something was still waiting on can change what renders.
+ */
 function evictIfNeeded(): boolean {
-  let evicted = false;
+  let openedGate = false;
   while (cache.size > MAX_CACHE_ENTRIES) {
     const oldest = cache.keys().next().value;
     if (oldest === undefined) break;
+    if (previewPending(oldest)) openedGate = true;
     cache.delete(oldest);
     asked.delete(oldest);
     retry.delete(oldest);
-    evicted = true;
   }
-  return evicted;
+  return openedGate;
 }
 
 /** Drop entries whose server-side TTL has lapsed, so they can be asked about again.
@@ -383,7 +408,7 @@ export function primePreviews(
     }
   }
   if (queued && flushTimer === null) flushTimer = setTimeout(() => void flush(), FLUSH_MS);
-  const evicted = evictIfNeeded();
+  const evictionOpenedGate = evictIfNeeded();
   // ⚠ CONDITIONAL, and that matters more than it looks. This runs for every live message, whether
   // or not it carries a URL, and every mounted `MessageAttachments` is an eager subscriber to a
   // computed that reads this ref — so an unconditional bump made one ordinary line of channel
@@ -398,11 +423,11 @@ export function primePreviews(
   // an unconditional bump changes no observable behaviour — the computed re-evaluates to the same
   // value, so a `watch` never fires — it only burns the work. A test would have to count
   // evaluations from outside the computed, which nothing here can do.
-  if (queued || evicted) pendingRevision.value++;
+  if (queued || evictionOpenedGate) pendingRevision.value++;
   // ⚠ Eviction can OPEN a reveal gate — it makes a URL non-pending without any answer arriving —
   // so the block paints with nothing having bumped `previewRevision`. That happens during a
   // history-page ingest, which is exactly when a scrolled-up reader is being anchored.
-  if (evicted) previewRevision.value++;
+  if (evictionOpenedGate) previewRevision.value++;
 }
 
 /**

--- a/vue_client/src/composables/useLinkPreview.ts
+++ b/vue_client/src/composables/useLinkPreview.ts
@@ -90,6 +90,39 @@ const MAX_BATCH = 20;
  */
 const FLUSH_MS = 24;
 
+/**
+ * Ceiling on one resolve round trip, client side.
+ *
+ * ⚠⚠ Not belt-and-braces. `api()` is a bare `fetch` with no signal and no timeout, so a dead NAT
+ * mapping, a sleeping laptop or a proxy that accepts and never answers leaves the promise pending
+ * FOREVER — and `flush` awaits its slices sequentially, so one hung POST also strands every later
+ * slice with no request ever sent. Before the reveal gate that cost a missing card; with it, every
+ * message holding one of those URLs renders no attachments at all, permanently. The gate must
+ * fail open, and a request that never settles is the one way it cannot.
+ *
+ * Generous against the server's own budget (10s of queue wait plus a 30s resolve deadline, all
+ * answered as one `Promise.all`), so this only fires when the round trip is genuinely stuck
+ * rather than merely slow. Losing the race puts the slice back in play through the same
+ * `forgetForRetry` path a transport error takes.
+ */
+const RESOLVE_TIMEOUT_MS = 45_000;
+
+function withTimeout<T>(work: Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('resolve timed out')), RESOLVE_TIMEOUT_MS);
+    work.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err as Error);
+      },
+    );
+  });
+}
+
 async function flush(): Promise<void> {
   flushTimer = null;
   const urls = [...queue];
@@ -99,10 +132,12 @@ async function flush(): Promise<void> {
   for (let i = 0; i < urls.length; i += MAX_BATCH) {
     const slice = urls.slice(i, i + MAX_BATCH);
     try {
-      const res = await api<{ previews: LinkPreview[] }>('/api/link-preview/resolve', {
-        method: 'POST',
-        body: { urls: slice },
-      });
+      const res = await withTimeout(
+        api<{ previews: LinkPreview[] }>('/api/link-preview/resolve', {
+          method: 'POST',
+          body: { urls: slice },
+        }),
+      );
       const answered = new Set<string>();
       for (const preview of res.previews ?? []) {
         const entry = cache.get(preview.url);
@@ -253,6 +288,10 @@ function runReask(): void {
     // way nobody is holding a ref for it, so there is nothing to re-ask on behalf of.
     if (!cache.has(url)) {
       retry.delete(url);
+      // ⚠ Bumped, because this IS a pending->settled transition. The `continue` skips `queued`,
+      // so without it every `usePreviewsSettled` keeps its cached `false` and a message's block
+      // stays hidden until some unrelated bump happens along.
+      pendingRevision.value++;
       continue;
     }
     // Parked as in-flight rather than deleted, and the difference is the whole backoff: the
@@ -279,14 +318,17 @@ function runReask(): void {
  */
 const MAX_CACHE_ENTRIES = 2000;
 
-function evictIfNeeded(): void {
+function evictIfNeeded(): boolean {
+  let evicted = false;
   while (cache.size > MAX_CACHE_ENTRIES) {
     const oldest = cache.keys().next().value;
     if (oldest === undefined) break;
     cache.delete(oldest);
     asked.delete(oldest);
     retry.delete(oldest);
+    evicted = true;
   }
+  return evicted;
 }
 
 /** Drop entries whose server-side TTL has lapsed, so they can be asked about again.
@@ -341,10 +383,26 @@ export function primePreviews(
     }
   }
   if (queued && flushTimer === null) flushTimer = setTimeout(() => void flush(), FLUSH_MS);
-  evictIfNeeded();
-  // ⚠ Unconditional, not gated on `queued`. `dropIfExpired` and `evictIfNeeded` both remove URLs
-  // from `asked`, which changes whether an answer is expected without anything being queued.
-  pendingRevision.value++;
+  const evicted = evictIfNeeded();
+  // ⚠ CONDITIONAL, and that matters more than it looks. This runs for every live message, whether
+  // or not it carries a URL, and every mounted `MessageAttachments` is an eager subscriber to a
+  // computed that reads this ref — so an unconditional bump made one ordinary line of channel
+  // chatter refresh 100-200 computeds that all re-derive `true === true`. MessageList hoists
+  // `previewsActive` out of its rows for the same reason, against a colder trigger than this one.
+  //
+  // `dropIfExpired` is deliberately NOT a reason to bump: it only touches a URL whose ref already
+  // has a value, `previewPending` short-circuits on that, and the same loop iteration re-queues it
+  // and sets `queued` anyway.
+  //
+  // ⚠ NO TEST GUARDS THIS CONDITION, and that is stated rather than papered over. Reverting it to
+  // an unconditional bump changes no observable behaviour — the computed re-evaluates to the same
+  // value, so a `watch` never fires — it only burns the work. A test would have to count
+  // evaluations from outside the computed, which nothing here can do.
+  if (queued || evicted) pendingRevision.value++;
+  // ⚠ Eviction can OPEN a reveal gate — it makes a URL non-pending without any answer arriving —
+  // so the block paints with nothing having bumped `previewRevision`. That happens during a
+  // history-page ingest, which is exactly when a scrolled-up reader is being anchored.
+  if (evicted) previewRevision.value++;
 }
 
 /**
@@ -384,17 +442,30 @@ const pendingRevision = ref(0);
 /**
  * Whether an answer is still expected for `url`.
  *
- * A URL that carries a value has settled, whatever that value says. A URL nobody ever primed is
- * NOT pending — that's the divergence case, and answering `false` is what makes it render
- * immediately (as nothing) rather than stall a whole message forever.
+ * ⚠⚠ THIS PREDICATE FAILS OPEN, deliberately and in every branch. Its consumer withholds a whole
+ * message's attachment block while it answers true, so every "not sure" it returns turns a
+ * partial failure into a blank message — a strictly worse outcome than the layout shift the gate
+ * exists to prevent. Only a request we are actively waiting on counts as pending.
  *
- * ⚠ A short-TTL failure awaiting a re-ask counts as SETTLED, not pending: it has an answer, and
- * the re-ask may be up to five minutes out. Holding a message's block for that would be far worse
- * than the growth a recovery causes — see the residual noted in `MessageAttachments`.
+ *   - carries a value          → settled, whatever the value says
+ *   - nobody ever primed it    → settled. The divergence case: a permanently-null ref must render
+ *                                as nothing NOW rather than stall the message forever.
+ *   - waiting on a re-ask      → SETTLED, and this is the branch that matters most. `retry` holds
+ *                                two different states — a short-TTL `unavailable` (has a value)
+ *                                and a URL put back in play by `forgetForRetry` after a transport
+ *                                failure or an omitted answer (value still null). Counting the
+ *                                second as pending hid the block for the entire 15s→5min backoff
+ *                                ladder, and indefinitely while a server kept failing: one 502
+ *                                during a deploy blanked the attachments of every message that
+ *                                shared a batch with it, cached siblings included.
+ *   - queued or in flight      → pending, bounded by RESOLVE_TIMEOUT_MS below.
  */
 function previewPending(url: string): boolean {
   if (cache.get(url)?.value != null) return false;
-  return queue.has(url) || asked.has(url) || retry.has(url);
+  // Before `queue`/`asked`, not after: `runReask` re-queues a URL it is retrying, so the retry
+  // state has to win or a recovery attempt would re-hide a block that is already on screen.
+  if (retry.has(url)) return false;
+  return queue.has(url) || asked.has(url);
 }
 
 /**
@@ -405,14 +476,13 @@ function previewPending(url: string): boolean {
  */
 export function usePreviewsSettled(urls: Ref<readonly string[]>): ComputedRef<boolean> {
   return computed(() => {
+    // ⚠ Load-bearing, and not obviously so. `previewPending` reads plain Sets and Maps, so this
+    // is the computed's ONLY dependency on the pending set — without it a subscribed computed
+    // (which `watch(settled, ...)` creates) never re-evaluates when a URL merely leaves the queue
+    // without its ref changing, e.g. the transport-failure path above.
     void pendingRevision.value;
     return urls.value.every((url) => !previewPending(url));
   });
-}
-
-/** Test-only: observe the pending set without reaching into module state. */
-export function isPreviewPending(url: string): boolean {
-  return previewPending(url);
 }
 
 /** Test-only: drop everything so a suite starts from a known state. */

--- a/vue_client/src/composables/useLinkPreview.ts
+++ b/vue_client/src/composables/useLinkPreview.ts
@@ -26,7 +26,7 @@
 //   - `queue` dedupes across a TICK. A history page arrives with fifty rows; they become one
 //     POST rather than fifty.
 
-import { ref, type Ref } from 'vue';
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
 import { api } from '../api.js';
 import { previewableUrls, type PreviewToggles } from '../utils/previewUrls.js';
 
@@ -103,18 +103,13 @@ async function flush(): Promise<void> {
         method: 'POST',
         body: { urls: slice },
       });
-      let changed = false;
       const answered = new Set<string>();
       for (const preview of res.previews ?? []) {
         const entry = cache.get(preview.url);
-        // Only an `ok` preview renders anything, so only an `ok` preview can change a row's
-        // height — bumping the revision for a batch of `unavailable` answers would make the
-        // list re-pin for no reason.
         if (entry) {
           answered.add(preview.url);
           entry.value = preview;
           if (preview.status === 'ok') {
-            changed = true;
             retry.delete(preview.url);
           } else {
             armReask(preview.url, Date.parse(preview.expiresAt ?? ''));
@@ -128,7 +123,16 @@ async function flush(): Promise<void> {
       // `retry` entry exists so nothing re-asks it, and `dropIfExpired` returns early because a
       // null value has no `expiresAt`. Permanently blank, from a response that looked fine.
       for (const url of slice) if (!answered.has(url)) forgetForRetry(url);
-      if (changed) previewRevision.value++;
+      // ⚠⚠ Any ANSWER bumps this, not only an `ok` one. This used to be `if (changed)`, guarded by
+      // a comment reading "only an `ok` preview renders anything, so only an `ok` preview can
+      // change a row's height" — which stopped being true when the reveal gate landed.
+      // `MessageAttachments` holds a message's whole block back until every URL in it has settled,
+      // so an `unavailable` is very often the answer that COMPLETES that gate and paints the
+      // block: growth out of a batch containing no `ok` at all, with nothing telling the list to
+      // re-pin. The cost of the wider condition is one no-op re-pin per all-unavailable batch —
+      // per BATCH, not per row — which is the cheaper side of the trade by a wide margin.
+      if (answered.size > 0) previewRevision.value++;
+      pendingRevision.value++;
       scheduleReask();
     } catch {
       // A failed resolve leaves the ref null, which renders as "no preview" — the same as a
@@ -137,6 +141,7 @@ async function flush(): Promise<void> {
       // than the missing card. Every URL in the slice is put back in play; none of them got an
       // answer, so none of them has a verdict to remember.
       for (const url of slice) forgetForRetry(url);
+      pendingRevision.value++;
       scheduleReask();
     }
   }
@@ -261,6 +266,7 @@ function runReask(): void {
     queued = true;
   }
   if (queued && flushTimer === null) flushTimer = setTimeout(() => void flush(), FLUSH_MS);
+  if (queued) pendingRevision.value++;
   scheduleReask();
 }
 
@@ -336,6 +342,9 @@ export function primePreviews(
   }
   if (queued && flushTimer === null) flushTimer = setTimeout(() => void flush(), FLUSH_MS);
   evictIfNeeded();
+  // ⚠ Unconditional, not gated on `queued`. `dropIfExpired` and `evictIfNeeded` both remove URLs
+  // from `asked`, which changes whether an answer is expected without anything being queued.
+  pendingRevision.value++;
 }
 
 /**
@@ -349,9 +358,67 @@ export function useLinkPreview(url: string): Ref<LinkPreview | null> {
   return entryFor(url);
 }
 
+// ─── Is an answer still coming? ───────────────────────────────────────────────
+//
+// `MessageAttachments` holds a message's whole attachment block back until every URL in it has
+// settled, so that its arrangement is decided once instead of re-deciding as siblings trickle in.
+// That gate needs to tell "still in flight" apart from "will never come", and this module is the
+// only thing that knows the difference — `asked`, `queue` and `retry` ARE that knowledge.
+//
+// ⚠⚠ The first version of the gate guessed instead, with a 1500ms timer. The guess was wrong by
+// more than an order of magnitude: `FLUSH_MS` is the coalescing debounce before the POST is sent,
+// not the round trip, and the server allows MAX_QUEUE_WAIT_MS (10s) plus RESOLVE_DEADLINE_MS
+// (30s) per URL while `/resolve` answers with a `Promise.all` over the whole slice. So the
+// deadline fired routinely on any cold link, revealing a partial set — which re-created the exact
+// arrangement flip the gate exists to remove, 1.5s later. Asking beats guessing.
+
+/**
+ * Bumped whenever a URL enters or leaves the set awaiting an answer.
+ *
+ * `queue`, `asked` and `retry` are plain collections and deliberately stay that way — they're
+ * touched on hot paths and nothing should re-render because a Set gained a member. This counter
+ * is the one reactive handle onto them, so a consumer reads it to know when to look again.
+ */
+const pendingRevision = ref(0);
+
+/**
+ * Whether an answer is still expected for `url`.
+ *
+ * A URL that carries a value has settled, whatever that value says. A URL nobody ever primed is
+ * NOT pending — that's the divergence case, and answering `false` is what makes it render
+ * immediately (as nothing) rather than stall a whole message forever.
+ *
+ * ⚠ A short-TTL failure awaiting a re-ask counts as SETTLED, not pending: it has an answer, and
+ * the re-ask may be up to five minutes out. Holding a message's block for that would be far worse
+ * than the growth a recovery causes — see the residual noted in `MessageAttachments`.
+ */
+function previewPending(url: string): boolean {
+  if (cache.get(url)?.value != null) return false;
+  return queue.has(url) || asked.has(url) || retry.has(url);
+}
+
+/**
+ * Reactive "every one of these URLs has settled".
+ *
+ * The `pendingRevision` read is what makes it reactive, and it lives HERE rather than at the call
+ * site so that the one fragile line sits next to the state it depends on.
+ */
+export function usePreviewsSettled(urls: Ref<readonly string[]>): ComputedRef<boolean> {
+  return computed(() => {
+    void pendingRevision.value;
+    return urls.value.every((url) => !previewPending(url));
+  });
+}
+
+/** Test-only: observe the pending set without reaching into module state. */
+export function isPreviewPending(url: string): boolean {
+  return previewPending(url);
+}
+
 /** Test-only: drop everything so a suite starts from a known state. */
 export function resetLinkPreviewCache(): void {
   previewRevision.value = 0;
+  pendingRevision.value = 0;
   cache.clear();
   asked.clear();
   retry.clear();


### PR DESCRIPTION
First half of [#692](https://github.com/amiantos/lurker/issues/692), and the reason PR 6 (iOS) is gated on it: settle the design here so iOS implements it once.

## The rule

Every layout jump QA found after #691 is the same event — **a row's height changed after it was painted** — and only two clocks can cause that: the *answer* arrives (resolve round trip) and the *bytes* arrive (decode). [465f838](https://github.com/amiantos/lurker/commit/465f838) fixed video by making its box knowable in advance; this generalises that:

> **R1 — no layout may depend on BYTES.**
> **R2 — no layout may depend on WHEN A SIBLING RESOLVES.**

⚠ Layout derived from a preview's own descriptor is fine — it arrives atomically with the decision to render the attachment at all, so there is no earlier layout for it to disturb. That is why a lone image keeps `object-fit: contain` at its natural aspect and `STRIP_PORTRAIT` survives.

## R2 — atomic reveal

A message shows **none** of its attachments until every URL in it has settled. Previously `strip`/`stacked`/`stripHeight` were all derived from the *resolved* set, so a message with three images — one already cached from an earlier post — painted as a lone image and re-arranged into a filmstrip when the others landed, and the row height re-picked portrait-vs-landscape as the mix changed. Both move a scrolled-up reader with no way to compensate: by the time anything hears about the growth it has happened.

Deciding the arrangement from the URL list instead does **not** work, and that is why this is a gate rather than a prediction — `mediaKindForUrl` charges extensionless hosts to the card budget, so imgur and twimg links are guessed as cards and flip when they resolve as images.

The gate **asks** rather than guesses: `usePreviewsSettled` reads the module that already knows (`asked`/`queue`/`retry`), so there is no latency to estimate. It **fails open** in every branch — a URL nobody primed, a transport failure, a queued re-ask all count as settled — because the gate withholds a whole message's block, so every "not sure" would turn a partial failure into a blank message.

`shown` is a per-URL latch that only grows: new URLs stay hidden until the set settles, anything already painted stays painted.

## R1 — a box before the bytes

- An image the server could not measure gets a fixed 240px box on a **wrapper**, not on the `<img>` — pinning it on the image made the empty letterbox part of a control that calls `stopPropagation`, swallowing the row tap that is the only opener of the message-actions sheet on touch.
- No `@error` handling, deliberately, with the measurements in the source: a non-empty `alt` on failure drops the attribute-derived aspect ratio in Gecko (240px → 18px), and the reset could never fire because the proxy token is an HMAC over the URL, so a re-delivered answer carries a byte-identical `src`.
- The image `@load` → `measured` emit is gone: every image box is now reserved before bytes, but it was still firing a `scrollToBottom()` per image.

## Supporting changes

- `previewRevision` is bumped by **every** path that can move a URL out of the pending set, since each of those can open a gate and every gate that opens grows a row. It previously fired only for an `ok` answer, so the transport-failure path — which fails a whole slice open at once, the largest single growth this feature produces — had no re-pin at all.
- `ApiRequestOptions` gains `signal`. `api()` was a bare `fetch` with no timeout, so a hung POST parked its URLs pending forever *and* stranded every later slice; one deadline now bounds the whole flush. This also bounds the other ~80 `api()` call sites with the same exposure.

## Known limitations, stated in the source

1. A short-TTL failure that recovers on a re-ask grows the block and can re-arrange it. Holding the gate for it would hide a message for up to five minutes on the strength of one saturated fetch.
2. A message mixing an image with a slow **page** link shows nothing until the page answers. The page URL cannot be excluded — an extensionless URL might itself resolve as an image and belong in the arrangement — so this is the trade atomic reveal makes: late but stable.

## Verification

`npm run check` and `npm test` both exit 0 (3414 tests). Every fix is revert-proven: each has a test that goes red with only that fix removed.

Three `/code-review max` rounds ran before this was opened, and each found the *previous round's fixes* to be the weakest code in the diff — a 1500ms reveal deadline built on a misread constant, a `failed` flag that was a net regression in three engines, and five separate ways the gate could open without telling the scroll anchor. Gate 6 also caught four vacuous tests of my own, including one whose comment claimed a mutation would take it red when the suite structurally could not observe it.

Manual QA on a real instance: good.

Two pre-existing bugs found along the way are filed separately rather than folded in: #693 (the re-prime-on-toggle watcher dies on the first route change) and #694 (cache eviction deletes refs mounted rows still hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)