### PR TITLE
Measure WebP and GIF dimensions sharp refuses to read from a truncated header

### DIFF
--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -14,6 +14,7 @@
 // for a per-user, default-off setting.
 
 import sharp from 'sharp';
+import { dimensionsFromHeader } from '../utils/imageHeader.js';
 import {
   bufferStream,
   fetchBuffered,
@@ -422,19 +423,37 @@ async function resolveScrapedPage(
  * simply appears inside it.
  *
  * A header-sized read is enough for every format that matters: the dimensions live in the
- * first few hundred bytes of a JPEG/PNG/GIF/WebP. Failure is fine and common (a truncated
- * buffer sharp can't parse, an exotic format) — the clients fall back to a fixed max height,
- * which is merely the old behaviour.
+ * first few hundred bytes of a JPEG/PNG/GIF/WebP. Failure is fine (an exotic format, a header
+ * sharp can't make sense of) — the client falls back to a reserved box, which costs a little
+ * space rather than a layout jump.
+ *
+ * ⚠⚠ SHARP ALONE IS NOT ENOUGH, and the reason is counter-intuitive: it is not that the header
+ * is truncated — every format here puts its dimensions in the first few dozen bytes — it is that
+ * some containers declare a TOTAL LENGTH and their loaders refuse a file shorter than it claims,
+ * before decoding anything. Measured at this exact cap: png, jpeg and avif read fine; webp, gif
+ * and tiff all throw. No sharp option relaxes it (`failOn: 'none'` and `failOn: 'truncated'` both
+ * still throw), because the rejection is above the decoder.
+ *
+ * QA saw this as "solo .webp images get a grey background but .png ones don't" — a size-specific
+ * bug wearing a format-specific costume, since a WebP under 64 KB was measured correctly. The
+ * fallback reads the two fields directly for the two formats that are ordinary to paste into IRC.
  */
 async function imageDimensions(
   res: RawResponse,
 ): Promise<{ width: number; height: number } | null> {
   try {
     const head = await bufferStream(res, { maxBytes: 64 * 1024 });
-    const meta = await sharp(head.body).metadata();
-    if (meta.width && meta.height) return { width: meta.width, height: meta.height };
+    try {
+      const meta = await sharp(head.body).metadata();
+      if (meta.width && meta.height) return { width: meta.width, height: meta.height };
+    } catch {
+      // Fall through: sharp refusing a truncated container is the case below, not a dead end.
+    }
+    // ⚠ Second, never first. sharp handles more formats and is the better answer wherever it
+    // works; this must not shadow it with a narrower implementation that could disagree.
+    return dimensionsFromHeader(head.body);
   } catch {
-    // Not worth distinguishing: no dimensions means no reservation, not no preview.
+    // The read itself failed. No dimensions means no reservation, not no preview.
   }
   return null;
 }

--- a/server/utils/imageHeader.test.ts
+++ b/server/utils/imageHeader.test.ts
@@ -77,7 +77,10 @@ describe('the case that motivated this', () => {
     expect(full.length).toBeGreaterThan(64 * 1024);
     const head = full.subarray(0, 64 * 1024);
 
-    await expect(sharp(head).metadata()).rejects.toThrow(/corrupt header|unable to parse/i);
+    // ⚠ Asserts only that it REJECTS. Matching the message text couples this to a libvips /
+    // libwebp build — and the regex was only there because oxlint's `require-to-throw-message`
+    // refuses a bare `toThrow()`. `toBeInstanceOf` satisfies both: no message, no lint rule.
+    await expect(sharp(head).metadata()).rejects.toBeInstanceOf(Error);
     expect(dimensionsFromHeader(head)).toEqual({ width: 600, height: 400 });
   });
 
@@ -86,7 +89,10 @@ describe('the case that motivated this', () => {
     expect(full.length).toBeGreaterThan(64 * 1024);
     const head = full.subarray(0, 64 * 1024);
 
-    await expect(sharp(head).metadata()).rejects.toThrow(/corrupt header|unable to parse/i);
+    // ⚠ Asserts only that it REJECTS. Matching the message text couples this to a libvips /
+    // libwebp build — and the regex was only there because oxlint's `require-to-throw-message`
+    // refuses a bare `toThrow()`. `toBeInstanceOf` satisfies both: no message, no lint rule.
+    await expect(sharp(head).metadata()).rejects.toBeInstanceOf(Error);
     expect(dimensionsFromHeader(head)).toEqual({ width: 600, height: 400 });
   });
 });

--- a/server/utils/imageHeader.test.ts
+++ b/server/utils/imageHeader.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// ⚠⚠ SHARP IS THE ORACLE, and that is the whole design of this suite. A hand-written header
+// reader is exactly the shape of code this feature has been bitten by before — the entity decoder
+// in linkMeta shipped with a hex/decimal alternation bug that eleven review agents missed and
+// Copilot caught. So nothing here asserts a dimension I worked out by hand: every case encodes a
+// real image at a known size, asks sharp what the FULL buffer is, and requires this module to
+// agree from a truncated prefix. If the two ever disagree, the test says so without anyone having
+// to have anticipated the case.
+
+import { describe, it, expect } from 'vitest';
+import crypto from 'node:crypto';
+import sharp from 'sharp';
+import { dimensionsFromHeader } from './imageHeader.js';
+
+/** Random pixels, so the encoders cannot compress the fixture down under the truncation cap. */
+function noise(width: number, height: number, channels: 3 | 4): Buffer {
+  return crypto.randomBytes(width * height * channels);
+}
+
+function raw(width: number, height: number, channels: 3 | 4) {
+  return sharp(noise(width, height, channels), { raw: { width, height, channels } });
+}
+
+// Sizes chosen for the edges of the field widths this module reads: 1 is the minimum, 16383 is
+// the maximum a WebP 14-bit dimension can express, and the middle sizes are ordinary.
+//
+// ⚠ Deliberately kept small in PIXEL COUNT. An earlier version used 2000x1500, and quantising 3M
+// random pixels to a GIF palette took long enough to blow vitest's 5s default — but only when the
+// suite shared a machine with another, so it passed alone and failed in the full run. Every size
+// here still exceeds the 64 KB truncation cap once encoded from noise, which is the only property
+// the fixtures need.
+const SIZES: Array<[number, number]> = [
+  [1, 1],
+  [16383, 3],
+  [3, 16383],
+  [640, 480],
+  [1234, 567],
+  [600, 400],
+];
+
+describe('dimensionsFromHeader agrees with sharp, from a truncated buffer', () => {
+  const encoders: Record<string, (w: number, h: number) => Promise<Buffer>> = {
+    'webp lossy': (w, h) => raw(w, h, 3).webp({ quality: 90 }).toBuffer(),
+    'webp lossless': (w, h) => raw(w, h, 3).webp({ lossless: true }).toBuffer(),
+    'webp alpha (VP8X)': (w, h) => raw(w, h, 4).webp().toBuffer(),
+    gif: (w, h) => raw(w, h, 3).gif().toBuffer(),
+  };
+
+  for (const [label, encode] of Object.entries(encoders)) {
+    for (const [w, h] of SIZES) {
+      it(`${label} ${w}x${h}`, async () => {
+        const full = await encode(w, h);
+        const truth = await sharp(full).metadata();
+
+        // The cap the resolver actually uses, plus a far tighter one — the header is tiny, so a
+        // reader that needs 64 KB is reading more than it should.
+        for (const cap of [64 * 1024, 512]) {
+          expect(dimensionsFromHeader(full.subarray(0, cap))).toEqual({
+            width: truth.width,
+            height: truth.height,
+          });
+        }
+      });
+    }
+  }
+});
+
+describe('the case that motivated this', () => {
+  it('reads a WebP that sharp itself refuses at the resolver cap', async () => {
+    // ⚠ The bug in one test. libwebp validates the RIFF length against the bytes supplied and
+    // rejects the file before decoding anything, so a WebP over 64 KB reached the client with no
+    // dimensions while the same picture as a PNG did not. Both halves are asserted, because
+    // "our reader works" is only interesting alongside "the thing it replaces does not".
+    const full = await raw(600, 400, 3).webp().toBuffer();
+    expect(full.length).toBeGreaterThan(64 * 1024);
+    const head = full.subarray(0, 64 * 1024);
+
+    await expect(sharp(head).metadata()).rejects.toThrow(/corrupt header|unable to parse/i);
+    expect(dimensionsFromHeader(head)).toEqual({ width: 600, height: 400 });
+  });
+
+  it('reads a GIF that sharp refuses at the same cap', async () => {
+    const full = await raw(600, 400, 3).gif().toBuffer();
+    expect(full.length).toBeGreaterThan(64 * 1024);
+    const head = full.subarray(0, 64 * 1024);
+
+    await expect(sharp(head).metadata()).rejects.toThrow(/corrupt header|unable to parse/i);
+    expect(dimensionsFromHeader(head)).toEqual({ width: 600, height: 400 });
+  });
+});
+
+describe('refuses what it does not understand', () => {
+  it('returns null for formats sharp already handles', async () => {
+    // Not a fallback for everything — PNG, JPEG and AVIF all read fine truncated, so this module
+    // must not shadow them with a second implementation that could disagree.
+    for (const fmt of ['png', 'jpeg', 'avif'] as const) {
+      const buf = await raw(300, 200, 3).toFormat(fmt).toBuffer();
+      expect(dimensionsFromHeader(buf)).toBeNull();
+    }
+  });
+
+  it('returns null rather than inventing a size for junk', () => {
+    expect(dimensionsFromHeader(Buffer.alloc(0))).toBeNull();
+    expect(dimensionsFromHeader(Buffer.from('not an image at all'))).toBeNull();
+    // Long enough to index into, wrong everywhere it counts.
+    expect(dimensionsFromHeader(Buffer.alloc(4096))).toBeNull();
+  });
+
+  it('refuses a RIFF/WEBP wrapper around an unknown chunk', () => {
+    // A container we recognise carrying a chunk we do not is exactly where a lenient parser
+    // starts reading two arbitrary integers out of whatever follows.
+    const buf = Buffer.alloc(64);
+    buf.write('RIFF', 0, 'latin1');
+    buf.writeUInt32LE(56, 4);
+    buf.write('WEBP', 8, 'latin1');
+    buf.write('XXXX', 12, 'latin1');
+    expect(dimensionsFromHeader(buf)).toBeNull();
+  });
+
+  it('refuses a VP8 chunk whose start code is wrong', () => {
+    // ⚠ Without the start-code check, this returns the two 14-bit numbers that happen to sit at
+    // those offsets — a confidently wrong box, which is worse than no box.
+    const buf = Buffer.alloc(64);
+    buf.write('RIFF', 0, 'latin1');
+    buf.writeUInt32LE(56, 4);
+    buf.write('WEBP', 8, 'latin1');
+    buf.write('VP8 ', 12, 'latin1');
+    buf.writeUInt16LE(1234, 26);
+    buf.writeUInt16LE(567, 28);
+    expect(dimensionsFromHeader(buf)).toBeNull();
+
+    // ...and with the start code present, the same bytes ARE the size.
+    buf[23] = 0x9d;
+    buf[24] = 0x01;
+    buf[25] = 0x2a;
+    expect(dimensionsFromHeader(buf)).toEqual({ width: 1234, height: 567 });
+  });
+
+  it('reads only 14 bits of a VP8 dimension, not 16', () => {
+    // ⚠ SYNTHETIC on purpose, and it is the one case sharp cannot act as oracle for: the top two
+    // bits of each 16-bit field are the horizontal/vertical SCALE, not part of the size, and
+    // sharp's encoder always writes them as zero — so every generated fixture agrees whether the
+    // mask is there or not. Dropping the mask left the whole suite green while a real file
+    // carrying a scale would have reported a wildly wrong box.
+    const buf = Buffer.alloc(64);
+    buf.write('RIFF', 0, 'latin1');
+    buf.writeUInt32LE(56, 4);
+    buf.write('WEBP', 8, 'latin1');
+    buf.write('VP8 ', 12, 'latin1');
+    buf[23] = 0x9d;
+    buf[24] = 0x01;
+    buf[25] = 0x2a;
+    // 800 and 600 with both scale bits set (0b11 << 14 = 0xc000).
+    buf.writeUInt16LE(800 | 0xc000, 26);
+    buf.writeUInt16LE(600 | 0xc000, 28);
+    expect(dimensionsFromHeader(buf)).toEqual({ width: 800, height: 600 });
+  });
+
+  it('refuses a GIF header claiming a zero dimension', () => {
+    // A zero-sized box is worse than an absent one: the client reserves nothing while believing
+    // it has measured.
+    const buf = Buffer.alloc(32);
+    buf.write('GIF89a', 0, 'latin1');
+    buf.writeUInt16LE(0, 6);
+    buf.writeUInt16LE(400, 8);
+    expect(dimensionsFromHeader(buf)).toBeNull();
+  });
+});

--- a/server/utils/imageHeader.ts
+++ b/server/utils/imageHeader.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Pixel dimensions read straight out of an image's first bytes.
+//
+// ⚠⚠ This exists because sharp cannot do it for every format from a TRUNCATED buffer, and the
+// preview resolver deliberately only reads a header's worth (64 KB) rather than downloading whole
+// images. Measured across formats at that cap:
+//
+//   png   -> ok        jpeg -> ok        avif -> ok
+//   webp  -> THROWS    gif  -> THROWS    tiff -> THROWS
+//
+// The cause is not a truncated *header* — every one of these puts its dimensions in the first
+// few dozen bytes. It is that the container declares a total length: libwebp validates the RIFF
+// size against the bytes actually supplied and refuses the file outright, before decoding
+// anything, and the GIF loader behaves the same way. No sharp option relaxes it (`failOn: 'none'`
+// and `failOn: 'truncated'` both still throw), because the rejection happens above the decoder.
+//
+// The consequence was visible in QA: a WebP over 64 KB reached the client with no dimensions, so
+// the client could not reserve an aspect ratio and fell back to a fixed placeholder box — while
+// the same picture as a PNG rendered correctly. A *size*-specific bug that looked format-specific.
+//
+// GIF and WebP are handled here because both are ordinary things to paste into IRC and both have
+// a fixed-offset header. TIFF is deliberately NOT: its dimensions live behind an IFD offset walk,
+// it is rare as an inline image, and the fallback (no dimensions) is now merely a reserved box
+// rather than a layout jump. A parser is a liability in proportion to what it must understand.
+
+export interface PixelSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * WebP, from the RIFF container's first chunk.
+ *
+ * Three chunk types carry a size, and all three put it at a fixed offset:
+ *
+ *   VP8   lossy      — 14-bit width/height after the 3-byte start code
+ *   VP8L  lossless   — 14-bit width-1/height-1 packed into one LE32
+ *   VP8X  extended   — 24-bit canvas width-1/height-1 (alpha, animation, metadata)
+ *
+ * ⚠ VP8X is the CANVAS size, which is the right answer: for an animated or alpha WebP the first
+ * frame can be smaller than the canvas it is composited onto, and the canvas is what occupies
+ * space on screen.
+ */
+function webpSize(buf: Buffer): PixelSize | null {
+  if (buf.length < 30) return null;
+  if (buf.toString('latin1', 0, 4) !== 'RIFF' || buf.toString('latin1', 8, 12) !== 'WEBP') {
+    return null;
+  }
+  switch (buf.toString('latin1', 12, 16)) {
+    case 'VP8 ': {
+      // The 3-byte start code is the only thing distinguishing a real key frame from noise at
+      // this offset; without it a corrupt file yields two plausible-looking 14-bit numbers.
+      if (buf[23] !== 0x9d || buf[24] !== 0x01 || buf[25] !== 0x2a) return null;
+      return { width: buf.readUInt16LE(26) & 0x3fff, height: buf.readUInt16LE(28) & 0x3fff };
+    }
+    case 'VP8L': {
+      if (buf[20] !== 0x2f) return null;
+      const bits = buf.readUInt32LE(21);
+      return { width: (bits & 0x3fff) + 1, height: ((bits >>> 14) & 0x3fff) + 1 };
+    }
+    case 'VP8X':
+      return { width: buf.readUIntLE(24, 3) + 1, height: buf.readUIntLE(27, 3) + 1 };
+    default:
+      return null;
+  }
+}
+
+/**
+ * GIF, from the logical screen descriptor.
+ *
+ * ⚠ The LOGICAL SCREEN, not the first frame. A GIF's frames are composited onto that screen and
+ * may each be smaller than it, so the screen is the box the image occupies — and it is what sharp
+ * reports for an untruncated file, which the tests assert directly rather than assume.
+ */
+function gifSize(buf: Buffer): PixelSize | null {
+  if (buf.length < 10) return null;
+  const magic = buf.toString('latin1', 0, 6);
+  if (magic !== 'GIF87a' && magic !== 'GIF89a') return null;
+  return { width: buf.readUInt16LE(6), height: buf.readUInt16LE(8) };
+}
+
+/**
+ * Dimensions from a header, or null if this module doesn't understand the format.
+ *
+ * A null answer is not an error — it means "ask something else", and the only caller falls back
+ * to shipping no dimensions at all, which costs a reserved box rather than a wrong one. Anything
+ * non-positive is refused rather than passed on: a zero-sized box is worse than an absent one,
+ * because the client would reserve nothing and still believe it had measured.
+ */
+export function dimensionsFromHeader(buf: Buffer): PixelSize | null {
+  const size = webpSize(buf) ?? gifSize(buf);
+  if (!size) return null;
+  if (!Number.isInteger(size.width) || !Number.isInteger(size.height)) return null;
+  if (size.width <= 0 || size.height <= 0) return null;
+  return size;
+}


### PR DESCRIPTION
Found by manual QA on #696: solo `.webp` images render with the client's fallback placeholder box while `.png` ones don't. It looks format-specific and is actually **size-specific**.

## The cause

`imageDimensions` (`server/services/linkPreview.ts`) reads a header's worth — 64 KB — rather than downloading whole images, and hands that to sharp. Measured at that exact cap:

| format | 64 KB prefix |
|---|---|
| png | ok |
| jpeg | ok |
| avif | ok |
| **webp** | **throws** |
| **gif** | **throws** |
| tiff | throws |

⚠ The cause is *not* a truncated header — every one of these formats puts its dimensions in the first few dozen bytes. It is that the container declares a **total length**, and its loader refuses a file shorter than the declaration before decoding anything. So any WebP or GIF over 64 KB reached the client with no dimensions, the client could not reserve an aspect ratio, and it fell back to a placeholder box. The same picture under 64 KB measured correctly, which is what made it look like a format problem.

Cheaper escapes were tried first and none work:

- `failOn: 'none'` and `failOn: 'truncated'` both still throw — the rejection is above the decoder.
- Patching the RIFF length lets VP8/VP8L through but **not** the extended VP8X container, whose later chunks overrun too.

## The change

`server/utils/imageHeader.ts` reads the two fields directly for the two formats that are ordinary to paste into IRC. It is consulted **second, never first**: sharp handles more formats and is the better answer wherever it works, and a narrower reader must not shadow it with one that could disagree.

TIFF is deliberately not covered — its dimensions live behind an IFD offset walk, it is rare as an inline image, and the fallback is now a reserved box rather than a layout jump. A parser is a liability in proportion to what it must understand.

## Why the tests are the deliverable

⚠⚠ **Sharp is the oracle.** A hand-written header reader is the exact shape of code this feature has been bitten by before — linkMeta's entity decoder shipped with a hex/decimal alternation bug that eleven `/code-review` agents missed and Copilot caught. So nothing here asserts a dimension worked out by hand: every case encodes a real image at a known size, asks sharp what the **full** buffer is, and requires this module to agree from a truncated prefix. Lossy, lossless and alpha/VP8X containers, 1×1 through 16383×3, at caps of 64 KB and 512 bytes.

All seven behaviours are revert-proven. One needed a synthetic case and is worth naming: the top two bits of a VP8 dimension are the **scale**, not part of the size, and sharp's encoder always writes them as zero — so dropping the 14-bit mask left every generated fixture green while a real file carrying a scale would have reported a wildly wrong box. Same for the VP8 start-code check, without which a corrupt file yields two plausible-looking integers.

⚠ Fixtures are small in pixel count on purpose. An earlier version used 2000×1500, and quantising 3M random pixels to a GIF palette blew vitest's 5 s default — but only when the suite shared a machine with another, so it passed alone and failed in the full run.

## Verification

`npm run check` and `npm test` both exit 0. Independent of #696 — that PR changes what the client does with a missing dimension, this one makes it missing far less often.

🤖 Generated with [Claude Code](https://claude.com/claude-code)