### PR TITLE
Give the link-preview card a shape, and make YouTube embeds play

### DIFF
--- a/server/db/linkPreviews.ts
+++ b/server/db/linkPreviews.ts
@@ -66,16 +66,6 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  * URL anyone had already pasted. From outside a process that is indistinguishable from the
  * feature never having worked, which is how it gets reported.
  *
- * ⚠ Live example, deliberately left unfixed here rather than fixed in passing: **#697** taught
- * `imageDimensions` to measure WebP and GIF headers sharp refuses to read, so `kind: 'image'`
- * rows now carry dimensions where they stored null — a different record, and no bump was taken
- * with it. Every such row cached before it is still a live hit with no dimensions, so the client
- * reserves `.dim-reserve` instead of the picture's own aspect: the exact QA report #697 was
- * merged to fix. `imageDimensions` has one call site and it is `kind === 'image'` only
- * (`linkPreview.ts:501`), so the affected set is `kind='image' AND image_width IS NULL` — which
- * a targeted migration can clear without orphaning the other kinds. That choice belongs to
- * whoever fixes it; it is recorded here so the next reader does not have to rediscover it.
- *
  * Say what changed on the line below.
  *
  *   v1 — initial.
@@ -85,8 +75,21 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  *        rows into `ok` ones, which is precisely what this counter is for — and the `urlHash`
  *        rewrite in the same change is NOT a substitute, because it produces byte-identical
  *        hashes for canonically-spelled URLs and so orphans none of the affected rows.
+ *   v3 — #697 taught `imageDimensions` to measure WebP and GIF headers sharp refuses to read, so
+ *        `kind: 'image'` rows now carry dimensions where they stored null. ⚠ Owed by that change
+ *        and not taken with it: every such row cached before it is still a live hit with no
+ *        dimensions, so `toDescriptor` omits `thumbWidth`, the client reserves `.dim-reserve`
+ *        instead of the picture's own aspect, and the QA report #697 was merged to fix ("solo
+ *        .webp renders with the fallback placeholder, .png doesn't") is still true for every one
+ *        of them. A different record for the same input, with no change of verdict — exactly the
+ *        case the rule above was widened to cover, which is how it was found.
+ *
+ *        ⚠ Taken as a full bump rather than the narrower `kind='image' AND image_width IS NULL`
+ *        a targeted migration could use, because the blunt cost is not a cost here: link
+ *        previews have not shipped to anyone, so there is no cache in the world worth keeping.
+ *        A later bump against a live fleet should weigh that predicate instead.
  */
-const RESOLVER_VERSION = 2;
+const RESOLVER_VERSION = 3;
 
 /**
  * Cache key: the requested URL, scoped to the resolver version.

--- a/server/db/linkPreviews.ts
+++ b/server/db/linkPreviews.ts
@@ -48,9 +48,16 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  *
  * ⚠ Starts at 1, deliberately, even though the resolver was rewritten several times before
  * this point: the table has never existed in a release, so there are no v0 rows anywhere to
- * orphan and a higher number would only imply a version somebody ran. Bump it when a change
- * to the resolver could turn a stored `unavailable` into an `ok` — a new provider, a parser
- * fix, a relaxed content-type — and say what changed on the line below.
+ * orphan and a higher number would only imply a version somebody ran.
+ *
+ * ⚠⚠ Bump it whenever the resolver would produce a DIFFERENT RECORD for the same input — not
+ * only when a stored `unavailable` becomes an `ok`. That narrower rule is what this said for two
+ * versions and it reads as the whole test, which it isn't: a change that extracts a NEW FIELD
+ * from the same page leaves every affected row a perfectly good `ok`, so nothing looks stale
+ * anywhere, and the new field is simply empty for a week on every URL anyone had already pasted.
+ * Caught during development of a card-layout change that read one — and it presented as the
+ * LAYOUT never working, because from outside a process a stale cache is indistinguishable from a
+ * broken feature. Say what changed on the line below.
  *
  *   v1 — initial.
  *   v2 — a video embed survives a page with no title and no image (a rate-limited provider

--- a/server/db/linkPreviews.ts
+++ b/server/db/linkPreviews.ts
@@ -38,10 +38,17 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  * Bumped whenever the resolver would produce a DIFFERENT RECORD for the same input.
  *
  * Folded into the cache key, so a bump orphans every old row rather than requiring a schema
- * change or a manual flush — the expiry sweep collects them in its own time. ⚠ It orphans them
- * ALL, not only the affected ones, so every previously-previewed URL is re-fetched from its
- * origin the next time somebody scrolls past it. That is the price of the mechanism and the
- * reason this is a deliberate edit rather than something derived from a file hash.
+ * change or a manual flush — the expiry sweep collects them in its own time.
+ *
+ * ⚠ It is a BLUNT instrument, and worth costing before reaching for it. It orphans every row of
+ * every kind, not the affected ones, so the whole table is re-fetched from its origins; with
+ * `MAX_CONCURRENT` at 20 instance-wide and a 10 s queue wait, a busy first load after deploy can
+ * hand back `unavailable` for links that would have been cache hits, and those wait out the
+ * re-ask ladder. And it reaches a running client slowly: previews resolve at message INGEST and
+ * an `ok` entry is never re-asked before its own `expiresAt`, so an open tab keeps rendering
+ * what it already has until a reload — a bump is not a push. Where the affected rows are
+ * describable by a predicate, a one-shot boot migration (`db/migrateEventMode.ts` and its
+ * siblings) targets them without disturbing anything else.
  *
  * This is not hypothetical bookkeeping. During development the YouTube fix was invisible for
  * an hour after it shipped, because the previous code had already cached
@@ -57,9 +64,19 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  * the loudest case: a change that fills in a FIELD leaves every affected row a perfectly good
  * `ok`, so nothing looks stale anywhere and the new value is simply missing for a week on every
  * URL anyone had already pasted. From outside a process that is indistinguishable from the
- * feature never having worked, which is how it gets reported. v3 below is exactly that shape,
- * and it was already merged and live before anyone noticed the bump was owed. Say what changed
- * on the line below.
+ * feature never having worked, which is how it gets reported.
+ *
+ * ⚠ Live example, deliberately left unfixed here rather than fixed in passing: **#697** taught
+ * `imageDimensions` to measure WebP and GIF headers sharp refuses to read, so `kind: 'image'`
+ * rows now carry dimensions where they stored null — a different record, and no bump was taken
+ * with it. Every such row cached before it is still a live hit with no dimensions, so the client
+ * reserves `.dim-reserve` instead of the picture's own aspect: the exact QA report #697 was
+ * merged to fix. `imageDimensions` has one call site and it is `kind === 'image'` only
+ * (`linkPreview.ts:501`), so the affected set is `kind='image' AND image_width IS NULL` — which
+ * a targeted migration can clear without orphaning the other kinds. That choice belongs to
+ * whoever fixes it; it is recorded here so the next reader does not have to rediscover it.
+ *
+ * Say what changed on the line below.
  *
  *   v1 — initial.
  *   v2 — a video embed survives a page with no title and no image (a rate-limited provider
@@ -68,16 +85,8 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  *        rows into `ok` ones, which is precisely what this counter is for — and the `urlHash`
  *        rewrite in the same change is NOT a substitute, because it produces byte-identical
  *        hashes for canonically-spelled URLs and so orphans none of the affected rows.
- *   v3 — #697: `imageDimensions` measures WebP and GIF headers sharp refuses to read, so those
- *        records now carry `imageWidth`/`imageHeight` where they stored null. ⚠ Owed by that
- *        change and not taken with it — every WebP or GIF over 64 KB previewed before it is
- *        still a live cache hit with no dimensions, so `toDescriptor` omits `thumbWidth`, the
- *        client reserves `.dim-reserve` instead of the picture's own aspect, and the QA report
- *        #697 was merged to fix ("solo .webp renders with the fallback placeholder, .png
- *        doesn't") is still true for every one of them. Verbatim the failure the rule above now
- *        describes, which is how it was found.
  */
-const RESOLVER_VERSION = 3;
+const RESOLVER_VERSION = 2;
 
 /**
  * Cache key: the requested URL, scoped to the resolver version.

--- a/server/db/linkPreviews.ts
+++ b/server/db/linkPreviews.ts
@@ -35,11 +35,13 @@ export const OK_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 export const FAIL_TTL_MS = 60 * 60 * 1000;
 
 /**
- * Bumped whenever the resolver's LOGIC changes in a way that could turn a previous
- * `unavailable` into an `ok`.
+ * Bumped whenever the resolver would produce a DIFFERENT RECORD for the same input.
  *
  * Folded into the cache key, so a bump orphans every old row rather than requiring a schema
- * change or a manual flush — the expiry sweep collects them in its own time.
+ * change or a manual flush — the expiry sweep collects them in its own time. ⚠ It orphans them
+ * ALL, not only the affected ones, so every previously-previewed URL is re-fetched from its
+ * origin the next time somebody scrolls past it. That is the price of the mechanism and the
+ * reason this is a deliberate edit rather than something derived from a file hash.
  *
  * This is not hypothetical bookkeeping. During development the YouTube fix was invisible for
  * an hour after it shipped, because the previous code had already cached
@@ -50,14 +52,14 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  * this point: the table has never existed in a release, so there are no v0 rows anywhere to
  * orphan and a higher number would only imply a version somebody ran.
  *
- * ⚠⚠ Bump it whenever the resolver would produce a DIFFERENT RECORD for the same input — not
- * only when a stored `unavailable` becomes an `ok`. That narrower rule is what this said for two
- * versions and it reads as the whole test, which it isn't: a change that extracts a NEW FIELD
- * from the same page leaves every affected row a perfectly good `ok`, so nothing looks stale
- * anywhere, and the new field is simply empty for a week on every URL anyone had already pasted.
- * Caught during development of a card-layout change that read one — and it presented as the
- * LAYOUT never working, because from outside a process a stale cache is indistinguishable from a
- * broken feature. Say what changed on the line below.
+ * ⚠⚠ A DIFFERENT RECORD, not only a different VERDICT. This said "could turn a stored
+ * `unavailable` into an `ok`" for two versions, and that reads as the whole test when it is only
+ * the loudest case: a change that fills in a FIELD leaves every affected row a perfectly good
+ * `ok`, so nothing looks stale anywhere and the new value is simply missing for a week on every
+ * URL anyone had already pasted. From outside a process that is indistinguishable from the
+ * feature never having worked, which is how it gets reported. v3 below is exactly that shape,
+ * and it was already merged and live before anyone noticed the bump was owed. Say what changed
+ * on the line below.
  *
  *   v1 — initial.
  *   v2 — a video embed survives a page with no title and no image (a rate-limited provider
@@ -66,8 +68,16 @@ export const FAIL_TTL_MS = 60 * 60 * 1000;
  *        rows into `ok` ones, which is precisely what this counter is for — and the `urlHash`
  *        rewrite in the same change is NOT a substitute, because it produces byte-identical
  *        hashes for canonically-spelled URLs and so orphans none of the affected rows.
+ *   v3 — #697: `imageDimensions` measures WebP and GIF headers sharp refuses to read, so those
+ *        records now carry `imageWidth`/`imageHeight` where they stored null. ⚠ Owed by that
+ *        change and not taken with it — every WebP or GIF over 64 KB previewed before it is
+ *        still a live cache hit with no dimensions, so `toDescriptor` omits `thumbWidth`, the
+ *        client reserves `.dim-reserve` instead of the picture's own aspect, and the QA report
+ *        #697 was merged to fix ("solo .webp renders with the fallback placeholder, .png
+ *        doesn't") is still true for every one of them. Verbatim the failure the rule above now
+ *        describes, which is how it was found.
  */
-const RESOLVER_VERSION = 2;
+const RESOLVER_VERSION = 3;
 
 /**
  * Cache key: the requested URL, scoped to the resolver version.

--- a/server/utils/imageHeader.test.ts
+++ b/server/utils/imageHeader.test.ts
@@ -31,6 +31,18 @@ function raw(width: number, height: number, channels: 3 | 4) {
 // suite shared a machine with another, so it passed alone and failed in the full run. Every size
 // here still exceeds the 64 KB truncation cap once encoded from noise, which is the only property
 // the fixtures need.
+//
+// ⚠⚠ Shrinking them was not enough, and could not have been. It lowered the PROBABILITY of that
+// failure without touching its cause, so the same test timed out again in CI on an unrelated PR
+// — `gif 1234x567`, one word of client CSS away from the previous green run. Measured on an idle
+// machine faster than any CI runner: that case alone costs ~1.6s of the 5s budget, and vitest
+// runs 244 test files across parallel workers on 2-4 vCPUs, so contention of 3x is ordinary
+// rather than exceptional. A margin that small is not a margin.
+//
+// The timeout below is the actual fix: this suite asserts CORRECTNESS and makes no claim about
+// speed, so a generous bound costs nothing when it passes and removes a load-dependent false
+// failure that no one can reproduce on demand. Shrinking the fixtures further is not available
+// — every size has to out-run the 64 KB cap to be a fixture at all.
 const SIZES: Array<[number, number]> = [
   [1, 1],
   [16383, 3],
@@ -62,7 +74,9 @@ describe('dimensionsFromHeader agrees with sharp, from a truncated buffer', () =
             height: truth.height,
           });
         }
-      });
+        // ⚠ The third argument is the per-test timeout, and it is load insurance rather than an
+        // admission that anything here is slow. See the note on SIZES above.
+      }, 30_000);
     }
   }
 });

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -237,6 +237,10 @@ describe('MessageAttachment — video embed', () => {
     expect(wrapper.find('a.card-title').attributes('href')).toBe(
       'https://www.youtube.com/watch?v=abc123',
     );
+    // ⚠ ...and the CONTROL is named from the same string. It read `Play ${preview.title ?? 'video'}`
+    // — so on the one record this whole fallback exists for, every play button in the buffer was
+    // called "Play video", which is the identical-names defect `imageLabel` was written to avoid.
+    expect(wrapper.find('.card-play').attributes('aria-label')).toBe('Play www.youtube.com');
   });
 });
 
@@ -308,21 +312,35 @@ describe('MessageAttachment — the two card shapes', () => {
     // Reachable, not theoretical: `pageRecord` deliberately stores ok records with title,
     // description and imageUrl all null (the `!embed` clause), and `toDescriptor` downgrades
     // such a row to `kind: 'page'` whenever `isEmbeddableOrigin` refuses its cached embedUrl.
+    // ⚠⚠ The `siteName` rung is the one PRODUCTION ACTUALLY TAKES, and an earlier version of this
+    // test could not see it: every fixture omitted `siteName`, so deleting that rung outright
+    // left the suite green (mutation-checked). `pageRecord` sets
+    // `providerName || og:site_name || url.hostname` on EVERY ok record, so a real titleless card
+    // always has one — and dropping the rung would silently downgrade "The Guardian" to
+    // "www.theguardian.com" everywhere with nothing red. The value here is deliberately NOT equal
+    // to the URL's host, or it could not tell the two rungs apart.
     const cases = [
-      ['an image and no title', page({ title: undefined, description: undefined })],
-      ['a description and no title', page({ title: undefined })],
-      ['nothing at all', preview({ url: 'https://news.example/article', kind: 'page' })],
+      [
+        'an image, no title, real site name',
+        page({ title: undefined, siteName: 'Example News' }),
+        'Example News',
+      ],
+      ['a description and no title', page({ title: undefined }), 'news.example'],
+      [
+        'nothing at all',
+        preview({ url: 'https://news.example/article', kind: 'page' }),
+        'news.example',
+      ],
     ] as const;
 
-    for (const [what, p] of cases) {
+    for (const [what, p, expected] of cases) {
       const wrapper = mount(MessageAttachment, { props: { preview: p } });
       const link = wrapper.find('a.card-title');
       // ⚠ `${what}` in the assertion, not just in a comment: three mounts in one test otherwise
       // report an anonymous failure and the reader has to count them.
       expect(`${what}: ${link.exists()}`).toBe(`${what}: true`);
       expect(`${what}: ${link.attributes('href')}`).toBe(`${what}: https://news.example/article`);
-      // Falls back to the host, which is the one thing every card can always show.
-      expect(`${what}: ${link.text()}`).toBe(`${what}: news.example`);
+      expect(`${what}: ${link.text()}`).toBe(`${what}: ${expected}`);
     }
   });
 

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -214,6 +214,30 @@ describe('MessageAttachment — video embed', () => {
     expect(wrapper.find('.card-play').exists()).toBe(true);
     expect(wrapper.find('.card-thumb-wide').exists()).toBe(false);
   });
+
+  it('names the degraded embed record the server deliberately stores', () => {
+    // ⚠ `pageRecord` keeps a video embed that has NO title, no description and no thumbnail —
+    // the provider oEmbed call was rate-limited and the scrape found nothing past the 512 KB
+    // cap — because the play affordance is real content. It gives that record the FAILURE ttl
+    // for the same reason, describing it in so many words as one whose "whole visible content
+    // is the hostname". So the client has to actually render a hostname: without the `heading`
+    // fallback this was a wordless black 16:9 box with a ▶ and no way to reach the page.
+    const wrapper = mount(MessageAttachment, {
+      props: {
+        preview: preview({
+          url: 'https://www.youtube.com/watch?v=abc123',
+          kind: 'video-embed',
+          siteName: 'www.youtube.com',
+          embedUrl: 'https://www.youtube-nocookie.com/embed/abc123',
+        }),
+      },
+    });
+    expect(wrapper.find('.card-play').exists()).toBe(true);
+    expect(wrapper.find('a.card-title').text()).toBe('www.youtube.com');
+    expect(wrapper.find('a.card-title').attributes('href')).toBe(
+      'https://www.youtube.com/watch?v=abc123',
+    );
+  });
 });
 
 describe('MessageAttachment — the two card shapes', () => {
@@ -274,14 +298,55 @@ describe('MessageAttachment — the two card shapes', () => {
     expect(wrapper.find('.card-thumb').exists()).toBe(false);
   });
 
-  it('renders no text block for a card that is only an image', () => {
-    // The other half of the same asymmetry: an og:image with no og:title. An empty `.card-text`
-    // still costs the card's gap, so it would carry a stray band beside its picture.
-    const wrapper = mount(MessageAttachment, {
-      props: { preview: page({ title: undefined, description: undefined }) },
-    });
-    expect(wrapper.find('.card-thumb').exists()).toBe(true);
-    expect(wrapper.find('.card-text').exists()).toBe(false);
+  it('is never empty, never nameless, and never without a link', () => {
+    // ⚠⚠ The regression this suite exists for now. `pageRecord` returns ok on a title OR an
+    // image, so a titleless card is an ordinary answer — and with the heading gated on `title`,
+    // each of these rendered as a tinted panel with NO anchor: a preview that goes nowhere,
+    // looks finished, and reads to a screen reader as an empty div, because the thumbnail is
+    // `alt=""`. The last one rendered as literally `<div class="card"></div>`.
+    //
+    // Reachable, not theoretical: `pageRecord` deliberately stores ok records with title,
+    // description and imageUrl all null (the `!embed` clause), and `toDescriptor` downgrades
+    // such a row to `kind: 'page'` whenever `isEmbeddableOrigin` refuses its cached embedUrl.
+    const cases = [
+      ['an image and no title', page({ title: undefined, description: undefined })],
+      ['a description and no title', page({ title: undefined })],
+      ['nothing at all', preview({ url: 'https://news.example/article', kind: 'page' })],
+    ] as const;
+
+    for (const [what, p] of cases) {
+      const wrapper = mount(MessageAttachment, { props: { preview: p } });
+      const link = wrapper.find('a.card-title');
+      // ⚠ `${what}` in the assertion, not just in a comment: three mounts in one test otherwise
+      // report an anonymous failure and the reader has to count them.
+      expect(`${what}: ${link.exists()}`).toBe(`${what}: true`);
+      expect(`${what}: ${link.attributes('href')}`).toBe(`${what}: https://news.example/article`);
+      // Falls back to the host, which is the one thing every card can always show.
+      expect(`${what}: ${link.text()}`).toBe(`${what}: news.example`);
+    }
+  });
+
+  it('prefers the page title over the fallback, so the host shows up nowhere', () => {
+    // The other direction, and the reason `heading` is not the site line returning: when a page
+    // HAS a title that is the whole heading, and the hostname appears in no part of the card.
+    const wrapper = mount(MessageAttachment, { props: { preview: page() } });
+    expect(wrapper.find('a.card-title').text()).toBe('A headline');
+    expect(wrapper.text()).not.toContain('news.example');
+  });
+
+  it('keeps a video card a COLUMN, or its text collapses to nothing', () => {
+    // ⚠⚠ The one load-bearing class binding here, and it had no guard: deleting
+    // `:class="{ 'card-video': isVideo }"` left the whole suite green.
+    //
+    // Losing it does not merely re-arrange the card, it DELETES the text. `.card` stays a row;
+    // `.card-text` is `flex: 1` (basis 0%) while `.card-media` carries `width: 100%` (basis =
+    // the entire content box), so the bases already fill the line and the text resolves to 0px
+    // wide — title and description vanish behind their own `overflow: hidden`, silently.
+    const wrapper = mount(MessageAttachment, { props: { preview: YOUTUBE } });
+    expect(wrapper.find('.card').classes()).toContain('card-video');
+    // ...and a page card must NOT get it, or its thumbnail drops below the text.
+    const card = mount(MessageAttachment, { props: { preview: page() } });
+    expect(card.find('.card').classes()).not.toContain('card-video');
   });
 });
 

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -163,6 +163,22 @@ describe('MessageAttachment — video embed', () => {
     expect(wrapper.find('iframe').attributes('src')).toContain('youtube-nocookie.com');
   });
 
+  it('sends the origin to the player, because no-referrer breaks every video', async () => {
+    // ⚠⚠ This looks like a privacy REGRESSION and is the opposite: it is what makes the player
+    // work at all. YouTube's embedded player validates the embedding page from the `Referer`
+    // header, and `referrerpolicy="no-referrer"` — which this shipped with — meant every video
+    // answered "Error 153, Video player configuration error" instead of playing. Proven by A/B:
+    // two iframes, same embed URL, same `allow`, differing only in this attribute.
+    //
+    // So the assertion is on the exact value, not on "some policy is set". `origin` sends
+    // `scheme://host` and never the path, and the property that does the real privacy work is
+    // the facade — nothing reaches the video host until the reader presses play, which the two
+    // tests above guard.
+    const wrapper = mount(MessageAttachment, { props: { preview: YOUTUBE } });
+    await wrapper.find('.card-play').trigger('click');
+    expect(wrapper.find('iframe').attributes('referrerpolicy')).toBe('origin');
+  });
+
   it('points the thumbnail at our proxy, never at the origin', () => {
     const wrapper = mount(MessageAttachment, { props: { preview: YOUTUBE } });
     expect(wrapper.find('.card-thumb-wide').attributes('src')).toBe('/api/link-preview/media/tok');

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -331,15 +331,27 @@ describe('MessageAttachment — the two card shapes', () => {
         preview({ url: 'https://news.example/article', kind: 'page' }),
         'news.example',
       ],
+      // ⚠ The URL rung must spell a host the way the SERVER spells it. `pageRecord` clamps
+      // `url.hostname`, and `URL.host` — which this used — appends the port, so one site was
+      // named `nas.local` or `nas.local:8096` depending on which rung fired. A non-default port
+      // is ordinary on exactly the self-hosted and LAN links this client is for. (Copilot found
+      // it; two `/code-review max` rounds did not.)
+      [
+        'a non-default port',
+        preview({ url: 'https://nas.local:8096/share/x', kind: 'page' }),
+        'nas.local',
+      ],
     ] as const;
 
     for (const [what, p, expected] of cases) {
       const wrapper = mount(MessageAttachment, { props: { preview: p } });
       const link = wrapper.find('a.card-title');
-      // ⚠ `${what}` in the assertion, not just in a comment: three mounts in one test otherwise
+      // ⚠ `${what}` in the assertion, not just in a comment: four mounts in one test otherwise
       // report an anonymous failure and the reader has to count them.
       expect(`${what}: ${link.exists()}`).toBe(`${what}: true`);
-      expect(`${what}: ${link.attributes('href')}`).toBe(`${what}: https://news.example/article`);
+      // ⚠ Against the case's OWN url. Hardcoded, this asserted the fixture rather than the
+      // component, and a case carrying a different URL failed on the wrong line.
+      expect(`${what}: ${link.attributes('href')}`).toBe(`${what}: ${p.url}`);
       expect(`${what}: ${link.text()}`).toBe(`${what}: ${expected}`);
     }
   });

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -132,7 +132,22 @@ describe('MessageAttachment — video embed', () => {
     const wrapper = mount(MessageAttachment, { props: { preview: YOUTUBE } });
     expect(wrapper.find('.card').exists()).toBe(true);
     expect(wrapper.text()).toContain('PAPA NUGS');
-    expect(wrapper.text()).toContain('YouTube');
+    // ⚠ ...and NOT the site or author. `siteName` and `author` stay on the wire — iOS may want
+    // them, and the hostname fallback is computed server-side — but the web card doesn't spend a
+    // line on naming a URL that is already in the message a word above it.
+    expect(wrapper.text()).not.toContain('YouTube');
+    expect(wrapper.text()).not.toContain('Maslow Unknown');
+  });
+
+  it('gives a video the player box whatever shape its thumbnail is', () => {
+    // ⚠ The layout rule below is about SHARE IMAGES. A video's box is the player's geometry —
+    // an iframe replaces it — so a square oEmbed thumbnail must not talk it into the small
+    // square, which would leave the play control in a 72px box and the video effectively gone.
+    const wrapper = mount(MessageAttachment, {
+      props: { preview: preview({ ...YOUTUBE, thumbWidth: 480, thumbHeight: 480 }) },
+    });
+    expect(wrapper.find('.card-media .card-play').exists()).toBe(true);
+    expect(wrapper.find('.card-thumb').exists()).toBe(false);
   });
 
   it('shows the play facade, and NOT an iframe, before any click', () => {
@@ -165,9 +180,92 @@ describe('MessageAttachment — video embed', () => {
     expect(wrapper.find('.card').exists()).toBe(true);
     expect(wrapper.find('.card-play').exists()).toBe(false);
     expect(wrapper.find('iframe').exists()).toBe(false);
-    // The thumbnail survives, in its small right-aligned form.
+    // The thumbnail survives — as an ordinary page card's image, and YOUTUBE declares no
+    // dimensions, so it takes the small square. See the layout suite below.
     expect(wrapper.find('.card-thumb').attributes('src')).toBe('/api/link-preview/media/tok');
     expect(wrapper.find('.card-title').attributes('href')).toBe(YOUTUBE.url);
+  });
+
+  it('keeps the box, and the play control, for a video with no thumbnail at all', () => {
+    // ⚠ The box is gated on `isVideo` alone and must stay that way: an oEmbed reply carrying a
+    // title but no thumbnail_url (or an og:image `normalizeUrl` refused) leaves `thumb` undefined
+    // with `embedUrl` set. Gating the block on the thumbnail instead put the card in a state with
+    // no branch true at all — a title, and a video that could never be played.
+    const wrapper = mount(MessageAttachment, {
+      props: { preview: preview({ ...YOUTUBE, thumb: undefined }) },
+    });
+    expect(wrapper.find('.card-media').exists()).toBe(true);
+    expect(wrapper.find('.card-play').exists()).toBe(true);
+    expect(wrapper.find('.card-thumb-wide').exists()).toBe(false);
+  });
+});
+
+describe('MessageAttachment — the two card shapes', () => {
+  beforeEach(() => seedSettings());
+
+  // #692 items 2 and 3. A card is a small square beside its text, or text on its own.
+  //
+  // ⚠⚠ A THIRD shape — the landscape band under the text, Discord's large embed — was built and
+  // removed after looking at it on real links. Its tests are gone with it, but the property they
+  // were really guarding survives here: whatever shape a card takes, it must take it from the
+  // DESCRIPTOR and not from the image. Measuring the picture on load would make the layout depend
+  // on bytes, so every card would lay out once and re-arrange on decode (R1).
+  //
+  // ⚠ The LINE BUDGET half of #692 (title 2, description 3) is pure CSS with no class binding to
+  // observe, and happy-dom applies no stylesheet — so there is deliberately no test for it here
+  // rather than one that would stay green with every clamp deleted.
+
+  const page = (over: Partial<LinkPreview> = {}) =>
+    preview({
+      url: 'https://news.example/article',
+      kind: 'page',
+      title: 'A headline',
+      description: 'A standfirst.',
+      thumb: '/api/link-preview/media/tokP',
+      ...over,
+    });
+
+  it('puts the image beside the text as a small square, whatever shape it is', () => {
+    // ⚠ The dimensions here are GitHub's real 1200x600 — a landscape share image, and once the
+    // trigger for the band. They must change nothing now: a shape that varies per link is
+    // exactly what was removed, and a descriptor field nothing reads is the easiest thing in the
+    // world to start reading again by accident.
+    const wide = mount(MessageAttachment, {
+      props: { preview: page({ thumbWidth: 1200, thumbHeight: 600 }) },
+    });
+    const square = mount(MessageAttachment, {
+      props: { preview: page({ thumbWidth: 512, thumbHeight: 512 }) },
+    });
+    const undeclared = mount(MessageAttachment, { props: { preview: page() } });
+
+    for (const wrapper of [wide, square, undeclared]) {
+      expect(wrapper.find('.card-thumb').attributes('src')).toBe('/api/link-preview/media/tokP');
+      // Not the player's box either, which is the only ratio-reserved block left.
+      expect(wrapper.find('.card-media').exists()).toBe(false);
+      // Text leads, in source order — nothing is re-ordered visually.
+      const kids = [...wrapper.find('.card').element.children].map((el) => el.className);
+      expect(kids).toEqual(['card-text', 'card-thumb']);
+    }
+  });
+
+  it('degrades to text only when the card has no image', () => {
+    // ⚠ `pageRecord` returns ok on a title OR an image, so this is an ordinary answer and not an
+    // edge case. Reserving the square regardless would leave an empty box beside the text —
+    // furniture for a picture that is never coming.
+    const wrapper = mount(MessageAttachment, { props: { preview: page({ thumb: undefined }) } });
+    expect(wrapper.find('.card').exists()).toBe(true);
+    expect(wrapper.text()).toContain('A headline');
+    expect(wrapper.find('.card-thumb').exists()).toBe(false);
+  });
+
+  it('renders no text block for a card that is only an image', () => {
+    // The other half of the same asymmetry: an og:image with no og:title. An empty `.card-text`
+    // still costs the card's gap, so it would carry a stray band beside its picture.
+    const wrapper = mount(MessageAttachment, {
+      props: { preview: page({ title: undefined, description: undefined }) },
+    });
+    expect(wrapper.find('.card-thumb').exists()).toBe(true);
+    expect(wrapper.find('.card-text').exists()).toBe(false);
   });
 });
 

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -100,13 +100,23 @@
            from the video host on render — not even the thumbnail, which is proxied through us
            like every other preview image. The first request the viewer makes to YouTube is the
            one they asked for by pressing play. -->
+      <!-- ⚠⚠ `origin`, NOT `no-referrer`, and this is the difference between a player and an
+           error message. YouTube's embedded player validates the embedding page from the
+           `Referer` header, and with none it refuses every video: **"Error 153 — Video player
+           configuration error"**, for the whole life of this component. Proven by A/B rather
+           than reasoned about — two iframes, same embed URL, same `allow`, differing only in
+           this attribute: `no-referrer` fails and `origin` plays.
+           `origin` sends `scheme://host` and never the path, so YouTube learns that some Lurker
+           instance framed a video — which the embed request tells it anyway — and not which
+           channel, which buffer, or which page. The privacy property that does the real work
+           here is the facade above it: nothing at all is requested until the reader asks. -->
       <iframe
         v-if="playing"
         class="card-embed"
         :src="preview.embedUrl"
         title="Video player"
         allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
-        referrerpolicy="no-referrer"
+        referrerpolicy="origin"
         allowfullscreen
       ></iframe>
       <button

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -233,13 +233,20 @@ const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.p
  *
  * ⚠ This is NOT the site line coming back. There is no separate row for it — when a page has a
  * title, that is the whole heading and the hostname appears nowhere.
+ *
+ * ⚠ `hostname`, NOT `host`, and the difference is the PORT. This rung is a backstop for the
+ * server's own last resort, so it has to produce the same string the server would: `pageRecord`
+ * clamps `url.hostname`, and `host` appends `:8096` to it. Otherwise one card is named
+ * `nas.local` or `nas.local:8096` depending on which rung happened to fire — two spellings of one
+ * site, from the same URL, which is the disagreeing-parsers class this feature has a rule about.
+ * Self-hosted and LAN links are exactly where a non-default port is ordinary. (Copilot.)
  */
 const heading = computed(() => {
   const p = props.preview;
   if (p.title) return p.title;
   if (p.siteName) return p.siteName;
   try {
-    return new URL(p.url).host || p.url;
+    return new URL(p.url).hostname || p.url;
   } catch {
     // A URL that won't parse is still a string worth showing over an empty card.
     return p.url;

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -70,20 +70,27 @@
        run against real links and rejected on looking at it: the picture dominates the message
        rather than annotating it, and a 240px band per link turns a few pasted URLs into a page
        of somebody else's pictures. The square annotates, which is what a preview is for.
-       ⚠ No site/author line. Discord doesn't have one and it was the least useful line on the
-       card: the URL it names is already in the message, a word above it. -->
+       ⚠ No site/author LINE. Discord doesn't have one and it was the least useful line on the
+       card: the URL it names is already in the message, a word above it. The site name is still
+       what the card falls back to when a page has no title — see `heading`. -->
   <div v-else class="card" :class="{ 'card-video': isVideo }">
-    <!-- ⚠ Gated, because a card is `ok` on a title OR an image (`pageRecord`). An image-only
-         card rendered this block empty and the gap then paid for text that isn't there. -->
-    <div v-if="hasText" class="card-text">
+    <!-- ⚠⚠ BOTH unconditional, and that is the fix for a whole class of empty card. `pageRecord`
+         returns ok on a title OR an image, so `preview.title` is absent on ordinary answers —
+         an og:image with no og:title, and the deliberately-degraded video record that keeps an
+         embed URL after a rate-limited provider call. With the heading gated on `title` those
+         rendered as a tinted panel containing a picture and nothing else, or nothing at all: no
+         text, no ANCHOR, and no accessible name, since the thumbnail is `alt=""`. A preview that
+         goes nowhere and names nothing still costs a card slot and a row of height.
+         `heading` cannot be empty, so this element always exists and the card always links. -->
+    <div class="card-text">
       <a
-        v-if="preview.title"
         class="card-title"
         :href="preview.url"
+        :title="heading"
         target="_blank"
         rel="noreferrer noopener"
         @click.stop
-        >{{ preview.title }}</a
+        >{{ heading }}</a
       >
       <div v-if="preview.description" class="card-desc">{{ preview.description }}</div>
     </div>
@@ -106,10 +113,20 @@
            configuration error"**, for the whole life of this component. Proven by A/B rather
            than reasoned about — two iframes, same embed URL, same `allow`, differing only in
            this attribute: `no-referrer` fails and `origin` plays.
-           `origin` sends `scheme://host` and never the path, so YouTube learns that some Lurker
-           instance framed a video — which the embed request tells it anyway — and not which
-           channel, which buffer, or which page. The privacy property that does the real work
-           here is the facade above it: nothing at all is requested until the reader asks. -->
+           ⚠ It is a REAL trade, not a free one, and an earlier version of this comment claimed
+           otherwise ("the embed request tells them anyway"). It does not: an iframe `src` load
+           is a navigation, so no `Origin` header is appended, and under `no-referrer` the
+           provider genuinely could not identify the embedding host. After this it learns
+           `scheme://host` — which for a self-hosted instance can itself be identifying. What is
+           bought is the feature existing at all, and what is NOT given up is the path: never
+           which channel, which buffer, or which message.
+           ⚠ `origin` rather than `strict-origin`, deliberately. They are byte-identical while
+           both EMBED_ORIGINS are https, and differ on an http page — where `strict-origin` sends
+           nothing and puts Error 153 straight back. Lurker is self-hosted and routinely reached
+           over plain http on a LAN, so the stricter value would break the case most likely to
+           hit it.
+           The privacy property doing the real work is the facade above: nothing at all is
+           requested from the video host until the reader asks for it. -->
       <iframe
         v-if="playing"
         class="card-embed"
@@ -182,13 +199,35 @@ const playing = ref(false);
 const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.preview.embedUrl);
 
 /**
- * Whether this card has anything to say in words.
+ * What the card is called, and what its link says. Never empty.
  *
- * `pageRecord` returns `ok` on a title OR an image, so "a card" does not imply text: an og:image
- * with no og:title (or a title `scrapeMeta` found nothing for) is a legitimate, common answer.
- * The text block is a flex child of a gapped card, so rendering it empty spends a gap on nothing.
+ * ⚠⚠ The guarantee is the point. `pageRecord` returns `ok` on a title OR an image, so a card
+ * without a title is an ordinary answer rather than an edge case — an og:image with no og:title,
+ * a paywalled article that ships a description and no heading, and the deliberately-degraded
+ * video record that survives a rate-limited provider call with nothing but an embed URL. Each of
+ * those rendered as a panel with no anchor in it at all: a preview that goes nowhere, looks
+ * finished, and (with an `alt=""` thumbnail) presents to a screen reader as an empty div.
+ *
+ * `siteName` is the fallback because the SERVER already guarantees it — `pageRecord` clamps
+ * `providerName || og:site_name || url.hostname`, so it is non-null for every ok card, and that
+ * hostname fallback exists precisely to be the thing a card can always show. The URL is parsed
+ * here as a third rung anyway: a descriptor is a wire value, and a client that depends on a
+ * server invariant should be able to survive its absence rather than render blank.
+ *
+ * ⚠ This is NOT the site line coming back. There is no separate row for it — when a page has a
+ * title, that is the whole heading and the hostname appears nowhere.
  */
-const hasText = computed(() => !!(props.preview.title || props.preview.description));
+const heading = computed(() => {
+  const p = props.preview;
+  if (p.title) return p.title;
+  if (p.siteName) return p.siteName;
+  try {
+    return new URL(p.url).host || p.url;
+  } catch {
+    // A URL that won't parse is still a string worth showing over an empty card.
+    return p.url;
+  }
+});
 
 /*
  * ⚠⚠ There is deliberately NO per-card layout choice, and it is a decision rather than an
@@ -431,7 +470,13 @@ function activate(): void {
 /* The exception: a video's facade goes UNDER the text and full width, because a player reduced
    to a 72px square is not a player. ⚠ This is about the PLAYER, not about the picture — an
    iframe replaces that box on the first click, so its 16:9 is the embed's geometry and not a
-   choice about how to present an image. */
+   choice about how to present an image.
+   ⚠⚠ Load-bearing beyond the arrangement: without it the card stays a ROW, and the flex maths
+   then deletes the text rather than shrinking the player. `.card-text` is `flex: 1` (basis 0%)
+   while `.card-media` carries `width: 100%` (basis = the whole content box), so the bases
+   already consume the line and the text resolves to 0px wide — title and description vanish
+   behind their own `overflow: hidden`, with no overflow anywhere to hint at it. The class
+   binding has a test for exactly this reason. */
 .card-video {
   flex-direction: column;
   gap: var(--space-3);
@@ -478,6 +523,12 @@ function activate(): void {
 }
 .card-desc {
   color: var(--fg-muted);
+  /* ⚠ Same break rule as the title, and for the same reason. `line-clamp` bounds LINES; it does
+     nothing about a single token too wide for the column, which `overflow: hidden` then cuts
+     mid-glyph with no ellipsis — the `…` only ever appears at a line boundary. An og:description
+     is a stranger's markup bounded only by MAX_DESCRIPTION (300 chars), and a bare tracking URL
+     or a German compound is one unbreakable token. */
+  overflow-wrap: anywhere;
   /* Three lines: enough to tell what a page is, not enough to become the message. */
   display: -webkit-box;
   -webkit-line-clamp: 3;

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -83,10 +83,15 @@
          goes nowhere and names nothing still costs a card slot and a row of height.
          `heading` cannot be empty, so this element always exists and the card always links. -->
     <div class="card-text">
+      <!-- ⚠ No `:title`. A previous round added one so a clamped heading could still be read in
+           full, and it cost more than it bought: on a link whose title fits it is a tooltip
+           byte-identical to the text under it, and since a link takes its name from its content
+           the attribute falls through to the accessible DESCRIPTION and is announced twice. It
+           also does nothing where the clamp actually bites — the narrow viewport this card has a
+           media query for is the one with no hover at all. -->
       <a
         class="card-title"
         :href="preview.url"
-        :title="heading"
         target="_blank"
         rel="noreferrer noopener"
         @click.stop
@@ -120,27 +125,38 @@
            `scheme://host` — which for a self-hosted instance can itself be identifying. What is
            bought is the feature existing at all, and what is NOT given up is the path: never
            which channel, which buffer, or which message.
-           ⚠ `origin` rather than `strict-origin`, deliberately. They are byte-identical while
-           both EMBED_ORIGINS are https, and differ on an http page — where `strict-origin` sends
-           nothing and puts Error 153 straight back. Lurker is self-hosted and routinely reached
-           over plain http on a LAN, so the stricter value would break the case most likely to
-           hit it.
+           ⚠ `origin` rather than `strict-origin` because `origin` is the value the A/B actually
+           measured. An earlier version of this comment justified the choice by claiming they
+           differ on an http page, with `strict-origin` sending nothing — that is backwards.
+           Referrer Policy suppresses only on a DOWNGRADE (secure → insecure), and both
+           EMBED_ORIGINS are https, so an http LAN page framing them is an upgrade and the two
+           values are byte-identical in every configuration reachable today. `strict-origin` is
+           the safer default the moment a non-https embed origin is ever added; it is not adopted
+           here on the strength of a spec reading, because a spec reading is what produced the
+           sentence this one replaces.
            The privacy property doing the real work is the facade above: nothing at all is
            requested from the video host until the reader asks for it. -->
       <iframe
         v-if="playing"
+        ref="embedEl"
         class="card-embed"
         :src="preview.embedUrl"
-        title="Video player"
+        :title="`${heading} — video player`"
         allow="autoplay; fullscreen; encrypted-media; picture-in-picture"
         referrerpolicy="origin"
         allowfullscreen
       ></iframe>
+      <!-- ⚠ Named from `heading`, not from `preview.title`. The record `heading` exists for — the
+           degraded embed with no title at all — is exactly the one whose control was called
+           "Play video", so two rate-limited YouTube links in a buffer presented two
+           identically-named buttons: the defect `imageLabel` is written to prevent, on the
+           element next to it. (`?? 'video'` also let a wire `title: ''` name it "Play ";
+           `heading`'s truthiness ladder falls through.) -->
       <button
         v-else
         type="button"
         class="card-play"
-        :aria-label="`Play ${preview.title ?? 'video'}`"
+        :aria-label="`Play ${heading}`"
         @click.stop="play"
       >
         <img
@@ -168,7 +184,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, nextTick, ref, useTemplateRef } from 'vue';
 import type { LinkPreview } from '../composables/useLinkPreview.js';
 import { useSettingsStore } from '../stores/settings.js';
 
@@ -195,6 +211,7 @@ const emit = defineEmits<{ measured: []; activate: [] }>();
 
 const settings = useSettingsStore();
 const playing = ref(false);
+const embedEl = useTemplateRef<HTMLIFrameElement>('embedEl');
 
 const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.preview.embedUrl);
 
@@ -257,7 +274,7 @@ const heading = computed(() => {
  * Whether the server could measure this image.
  *
  * The `width`/`height` attributes are what reserve the box before any bytes arrive, so their
- * ABSENCE is the one case where an inline image's height depends on the decode — see `.no-dims`.
+ * ABSENCE is the one case where an inline image's height depends on the decode — see `.dim-reserve`.
  * `imageDimensions` fails legitimately and not rarely: an exotic format, or a header sharp can't
  * parse inside the 64 KB it reads.
  */
@@ -289,12 +306,26 @@ const needsReservedBox = computed(() => !props.inStrip && !hasDimensions.value);
  *     focus, dumping a keyboard user back to `<body>` mid-strip.
  *
  * The byte-independence rule this file serves is already satisfied without any of it: the
- * width/height attributes survive a failed load, and `.no-dims` pins the one shape that has none.
+ * width/height attributes survive a failed load, and `.dim-reserve` pins the one shape that has none.
  * A broken-image glyph in a correctly-sized box is a smaller problem than every one of the above.
  */
 
+/**
+ * Swap the facade for the real player.
+ *
+ * ⚠ The focus move is not a nicety. `v-if="playing"` unmounts the button that is
+ * `document.activeElement` at the moment a keyboard user presses Enter on it, so focus falls to
+ * `<body>` and the next Tab restarts at the top of the document — past every message above, and
+ * never reaching the player they just opened. This file already names that failure in so many
+ * words for a different case ("dumping a keyboard user back to `<body>` mid-strip"), which is
+ * how it was noticed here.
+ *
+ * `nextTick` because the iframe does not exist until the re-render, and `?.` because a card
+ * unmounted in the same tick (a re-render dropping the attachment) has nothing to focus.
+ */
 function play(): void {
   playing.value = true;
+  void nextTick(() => embedEl.value?.focus());
 }
 
 // The viewer is opt-out (chat.image_modal.enabled); when it's off, an inline image is just an
@@ -509,6 +540,16 @@ function activate(): void {
   font-weight: 600;
   text-decoration: none;
   overflow-wrap: anywhere;
+  /* ⚠⚠ Sized to its TEXT, not to the column. `-webkit-box` is block-level and this is a flex item
+     of a column that never set `align-items`, so the default `stretch` made the anchor span the
+     full width — and the anchor is now unconditional. On a card whose heading is a 12-character
+     hostname that is a few hundred pixels of blank navigation target: a tap there opens a new tab
+     (`target="_blank"`), and the row's own click never fires, which on touch is the only thing
+     that opens the message-actions sheet. Same defect class this file records twice already, at
+     the reserved-box wrapper and at `@click.stop`.
+     Shrink-to-fit does not weaken the clamp: the width resolves to min(max-content, available),
+     so a long heading still wraps at the column edge and still stops at two lines. */
+  align-self: flex-start;
   /* Two lines. ⚠ `-webkit-box` REPLACES `display: block` rather than joining it — clamping is a
      property of that box type, so an anchor left inline (or set to block) ignores the clamp
      silently. */
@@ -553,9 +594,19 @@ function activate(): void {
    geometry, not a presentation choice, and any other value letterboxes a real video inside its
    own player. The ratio lives on the wrapper so the box exists before the thumbnail's bytes do,
    which is the same byte-independence direct media gets from its width/height attributes. */
+/* ⚠⚠ `width: 100%` is scoped to the column, and the scoping is the guard. Unscoped, this rule
+   arms the sizing that DELETES the card's text: in a row, a basis of the whole content box beside
+   `.card-text`'s basis of 0% leaves the text at 0px wide, hidden behind its own `overflow`. What
+   disarmed it was a class binding, so every CSS-side way of losing the column — renaming
+   `.card-video`, dropping its `flex-direction`, a later media query, a future non-video card
+   wanting this box — kept the suite green while the title vanished. happy-dom applies no
+   stylesheet, so no test can ever observe that; expressing the dependency in the selector is what
+   makes it unlosable. */
+.card-video .card-media {
+  width: 100%;
+}
 .card-media {
   position: relative;
-  width: 100%;
   aspect-ratio: 16 / 9;
   border-radius: var(--radius-md);
   overflow: hidden;
@@ -572,6 +623,12 @@ function activate(): void {
   cursor: pointer;
   position: relative;
 }
+/* ⚠ Drawn INSIDE the box. This button exactly fills `.card-media`, which is `overflow: hidden`,
+   so a UA focus ring — painted outside the border box — is clipped away entirely and a keyboard
+   user tabbing onto a video card sees nothing move before pressing Enter. */
+.card-play:focus-visible {
+  outline-offset: -3px;
+}
 .card-thumb-wide {
   width: 100%;
   height: 100%;
@@ -586,6 +643,12 @@ function activate(): void {
   height: 48px;
   border-radius: var(--radius-pill);
   background: color-mix(in srgb, var(--bg) 70%, transparent);
+  /* ⚠ The ring is what makes this a control when there is NO thumbnail. The fill is `--bg` at 70%
+     alpha and it sits on `.card-media`, which paints `--bg` — and 70%-alpha X over X is X, so on
+     a thumbnail-less video card (the degraded record, and a real state this suite mounts) the
+     pill was perfectly invisible and the ▶ floated bare on a flat rectangle. A border reads in
+     both cases: an edge here, a light rim against a photo. */
+  border: 1px solid color-mix(in srgb, var(--fg) 25%, transparent);
   color: var(--fg);
   display: flex;
   align-items: center;

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -64,12 +64,18 @@
   />
 
   <!-- A page, or a video page. Discord's panel treatment: the card sits on its own slightly
-       raised background so it reads as a distinct object rather than as more chat text. -->
+       raised background so it reads as a distinct object rather than as more chat text.
+       TWO shapes: a small square beside the text, or text on its own. ⚠ A landscape image under
+       the text — Discord's large-embed form, and what this component briefly did — was built,
+       run against real links and rejected on looking at it: the picture dominates the message
+       rather than annotating it, and a 240px band per link turns a few pasted URLs into a page
+       of somebody else's pictures. The square annotates, which is what a preview is for.
+       ⚠ No site/author line. Discord doesn't have one and it was the least useful line on the
+       card: the URL it names is already in the message, a word above it. -->
   <div v-else class="card" :class="{ 'card-video': isVideo }">
-    <div class="card-text">
-      <div v-if="preview.siteName" class="card-site">
-        {{ preview.siteName }}<template v-if="preview.author"> · {{ preview.author }}</template>
-      </div>
+    <!-- ⚠ Gated, because a card is `ok` on a title OR an image (`pageRecord`). An image-only
+         card rendered this block empty and the gap then paid for text that isn't there. -->
+    <div v-if="hasText" class="card-text">
       <a
         v-if="preview.title"
         class="card-title"
@@ -82,13 +88,13 @@
       <div v-if="preview.description" class="card-desc">{{ preview.description }}</div>
     </div>
 
-    <!-- Video: the thumbnail goes full-width with a play badge, because a video reduced to a
-         72px square is pointless. Everything else keeps the small right-aligned thumbnail. -->
     <!-- ⚠ Gated on isVideo alone, NOT on having a thumbnail. `pageRecord` returns ok as soon as
          there is a title OR an image, so an oEmbed reply with a title but no thumbnail_url (or
          an og:image that normalizeUrl rejected) yielded embedUrl set and thumb undefined — both
          this branch and the `v-else-if="preview.thumb"` one were false, so the card showed a
-         title with the ▶, and the whole video, unreachable. -->
+         title with the ▶, and the whole video, unreachable. A video keeps its box with no
+         thumbnail because the box is what the play control lives in; a PAGE with no image has
+         nothing to put in one and renders none — see below. -->
     <div v-if="isVideo" class="card-media">
       <!-- THE FACADE. The iframe does not exist until this is clicked, so nothing is requested
            from the video host on render — not even the thumbnail, which is proxied through us
@@ -120,6 +126,9 @@
         <span class="play-badge" aria-hidden="true">▶</span>
       </button>
     </div>
+    <!-- ⚠ NO block at all without an image, rather than an empty square. A card is `ok` on a
+         title OR an image, so a title-only card is an ordinary answer — and a reserved box with
+         nothing coming is furniture. -->
     <img
       v-else-if="preview.thumb"
       class="card-thumb"
@@ -161,6 +170,39 @@ const settings = useSettingsStore();
 const playing = ref(false);
 
 const isVideo = computed(() => props.preview.kind === 'video-embed' && !!props.preview.embedUrl);
+
+/**
+ * Whether this card has anything to say in words.
+ *
+ * `pageRecord` returns `ok` on a title OR an image, so "a card" does not imply text: an og:image
+ * with no og:title (or a title `scrapeMeta` found nothing for) is a legitimate, common answer.
+ * The text block is a flex child of a gapped card, so rendering it empty spends a gap on nothing.
+ */
+const hasText = computed(() => !!(props.preview.title || props.preview.description));
+
+/*
+ * ⚠⚠ There is deliberately NO per-card layout choice, and it is a decision rather than an
+ * omission — the version that had one was built and then removed.
+ *
+ * It read `thumbWidth`/`thumbHeight` and gave a landscape image the full-width band Discord uses,
+ * keeping the square for logos and portraits. It worked, and the shape it produced was worse:
+ * a 240px picture per link reads as the message rather than as a note about it, and two links in
+ * a row take a screenful. The square annotates. That is what a preview is for, and it is now the
+ * answer for every image regardless of its shape.
+ *
+ * Recorded because the evidence gathered for it is the expensive part and someone will want it
+ * again. Real markup, sampled from the sites themselves: GitHub declares `og:image:width` 1200 by
+ * 600, Ars Technica 512x512 (a square LOGO), Wikipedia 869x1200 (portrait), while the New York
+ * Times and the BBC declare an image and no size at all. And ⚠⚠ `twitter:card` cannot stand in
+ * for the missing sizes: Ars Technica declares `summary_large_image` beside that square logo, so
+ * the author's stated intent disagrees with the author's own picture in exactly the direction
+ * that produces the bad crop.
+ *
+ * Whatever replaces this must still take its shape from the DESCRIPTOR rather than the image.
+ * Reading `naturalWidth` on load would be accurate and is the one thing this component may not
+ * do: the layout would then depend on bytes and every card would re-arrange on decode, which is
+ * R1, the rule the rest of this file exists to keep.
+ */
 
 /**
  * Whether the server could measure this image.
@@ -346,6 +388,8 @@ function activate(): void {
 
 .card {
   display: flex;
+  /* A row: text, then the square to the right of it. Text first in the DOM, so this is source
+     order — nothing is re-ordered visually. `.card-video` below is the one exception. */
   gap: var(--space-4);
   align-items: flex-start;
   /* A raised panel, Discord-style, so the card reads as a distinct object rather than as more
@@ -355,7 +399,11 @@ function activate(): void {
      it disappears the moment the pointer crosses its row. */
   background: var(--embed-bg);
   border-radius: var(--radius-md);
-  padding: var(--space-4);
+  /* ⚠ Deliberately more than the app's usual inset. Elsewhere `--space-4` separates things
+     inside a dense list; here it is the margin of a PANEL, and at 8px the text sat on its edge
+     and the thumbnail ran to it. The padding is what makes the card read as an object with
+     content in it rather than as a tinted block. */
+  padding: var(--space-6);
 }
 /* The Slack-style left rule is a MOBILE-only cue. On desktop the app already has a vertical
    border running down the side of the message column right next to this, and a second rule a
@@ -364,41 +412,73 @@ function activate(): void {
 @media (max-width: 768px) {
   .card {
     border-left: 3px solid var(--border);
-    /* The rule replaces the panel's own left padding rather than adding to it. */
+    /* The rule replaces the panel's own left padding rather than adding to it: 3px of border
+       plus 10px lands within a pixel of the 12px the other three sides get, so the rule reads
+       as the panel's edge rather than as a stripe with a gutter beside it. */
     padding-left: var(--space-5);
   }
 }
+/* The exception: a video's facade goes UNDER the text and full width, because a player reduced
+   to a 72px square is not a player. ⚠ This is about the PLAYER, not about the picture — an
+   iframe replaces that box on the first click, so its 16:9 is the embed's geometry and not a
+   choice about how to present an image. */
 .card-video {
   flex-direction: column;
   gap: var(--space-3);
 }
 .card-text {
-  min-width: 0;
+  /* Takes the space the thumbnail doesn't, and `min-width: 0` is what lets it: a flex item's
+     automatic minimum is its content, so a long unbroken title would otherwise push the square
+     off the card instead of wrapping. */
   flex: 1;
+  min-width: 0;
+  /* The lines were flush against each other, separated by nothing but line-height, so a two-line
+     title ran into its description and the block read as one paragraph. Hierarchy is on colour
+     and weight (AGENTS.md: one font size), and spacing is the third thing that rule leaves
+     available. */
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
 }
+/* ─── The line budget ──────────────────────────────────────────────────────────
+   2 + 3, so a card's height is a small known set of values rather than one per link. Both fields
+   are a stranger's markup: the server clamps them by CHARACTERS (MAX_TITLE 140,
+   MAX_DESCRIPTION 300), which bounds the payload but not the height — 140 characters is one line
+   or four depending on the viewport.
+   ⚠ `line-clamp` is not `font-size`: the AGENTS.md rule forbids sizing text, and hierarchy here
+   stays where it was, on colour and weight. */
+
 /* Hierarchy by colour alone — AGENTS.md: one font size across the entire UI. */
-.card-site {
-  color: var(--fg-muted);
-}
 .card-title {
-  display: block;
   color: var(--accent);
   font-weight: 600;
   text-decoration: none;
   overflow-wrap: anywhere;
-}
-.card-title:hover {
-  text-decoration: underline;
-}
-.card-desc {
-  color: var(--fg-muted);
-  /* Two lines: enough to tell what a page is, not enough to become the message. */
+  /* Two lines. ⚠ `-webkit-box` REPLACES `display: block` rather than joining it — clamping is a
+     property of that box type, so an anchor left inline (or set to block) ignores the clamp
+     silently. */
   display: -webkit-box;
   -webkit-line-clamp: 2;
   line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+.card-title:hover {
+  text-decoration: underline;
+}
+.card-desc {
+  color: var(--fg-muted);
+  /* Three lines: enough to tell what a page is, not enough to become the message. */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* The small square. ⚠ A fixed CSS box, so it reserves its own height with no dimensions and no
+   decode — the same byte-independence the wide box gets from `aspect-ratio`. `cover` because a
+   square hole is being cut out of something that may not be square. */
 .card-thumb {
   width: 72px;
   height: 72px;
@@ -407,6 +487,11 @@ function activate(): void {
   flex: none;
 }
 
+/* The player's box, and the only place a card reserves a ratio.
+   ⚠ 16:9 because an iframe REPLACES this element on the first click — it is the embed's own
+   geometry, not a presentation choice, and any other value letterboxes a real video inside its
+   own player. The ratio lives on the wrapper so the box exists before the thumbnail's bytes do,
+   which is the same byte-independence direct media gets from its width/height attributes. */
 .card-media {
   position: relative;
   width: 100%;


### PR DESCRIPTION
Closes #692. PR B of the link-previews layout stack (`LINK_PREVIEWS_LAYOUT_PLAN.md`), and the last thing gating PR 6 (iOS).

## The card

A link-preview card is now **a small square beside its text, or text on its own**, with a **2 + 3 line budget** (title, description), no site/author row, and a panel with room to breathe (`--space-4` → `--space-6`, plus a gap between the title and the description, which were flush).

⚠ **The landscape image under the text — #692 item 3 — was built and then rejected.** It worked, including a per-link choice between the band and the square driven by scraped `og:image:width`. On real links it is the wrong design: a ~240px picture per link reads as *the message* rather than as a note about it, and two links in a row take a screenful of somebody else's images. **The issue's item 3 is withdrawn, not deferred**, and the planning docs are corrected in `amiantos/lurker-dev` so the iOS port doesn't implement a design that was thrown away.

The evidence gathered for that layout is kept in a comment, because gathering it is the expensive part and the next person to want a per-link layout will want it: GitHub declares `og:image:width` 1200x600, Ars Technica 512x512 — a square **logo** — Wikipedia 869x1200, and the NYT and BBC declare an image with no size at all. ⚠⚠ `twitter:card` cannot fill the gaps: Ars declares `summary_large_image` beside that square logo, so the author's stated intent disagrees with the author's own picture, in the direction that produces the bad crop.

## The bug the site line was hiding

Removing the site row exposed a class of card, and this is the part worth a reviewer's attention. `.card-site` was the only element **guaranteed** to render, because `pageRecord` clamps `providerName || og:site_name || url.hostname` — that hostname fallback exists precisely to be the string a card can always show. Without it, every child was conditional, and `pageRecord` returns `ok` on a title **or** an image, so a titleless card is an ordinary answer rather than an edge case. These rendered with **no `<a>` anywhere in them** — a preview that goes nowhere, looks finished, and reads to a screen reader as an empty div because the thumbnail is `alt=""`:

- an og:image with no og:title
- a description with no og:title (paywalled articles, several CMS templates)
- the degraded video record `pageRecord` deliberately stores after a rate-limited provider call
- all three fields null — reachable, via `toDescriptor` downgrading a cached `video-embed` whose origin `isEmbeddableOrigin` no longer accepts

`heading` now falls back `title → siteName → hostname`, and both the text block and the anchor are unconditional. ⚠ **This is not the site line returning**: when a page has a title, that is the whole heading and the hostname appears nowhere.

## Two things that are not about the card

**YouTube embeds have never played, on any version of this client.** `referrerpolicy="no-referrer"` shipped in `ed50249`, the commit that added the Vue client; YouTube's player validates the embedder from the `Referer` header and answers **"Error 153 — Video player configuration error"** without it. Proven by A/B rather than reasoned about: two iframes, identical embed URL and `allow`, differing only in that attribute. `origin` sends `scheme://host` and never the path. ⚠ It is a real privacy trade, not a free one — an iframe `src` load is a navigation, so no `Origin` header is appended and under `no-referrer` the provider genuinely could not identify the host. What the facade guarantees is unchanged: nothing reaches the video host until the reader presses play.

**`RESOLVER_VERSION` 2 → 3, owed by #697** and taken as its own commit. That change made WebP/GIF measurable, so `kind: 'image'` rows cached before it are live hits with no dimensions — the client still paints `.dim-reserve` and the QA report #697 was merged to fix is still true for all of them. The docblock's bump rule is widened accordingly: bump when the resolver would produce a **different record**, not only a different verdict.

## Gates

- **Two `/code-review max` rounds**, both before opening. Round 1: 9 findings actioned, including the empty-card class above. Round 2: 12, most of them *in round 1's fixes* — including a live regression that round's fix introduced (the unconditional anchor stretched to full column width, so blank space beside a short heading opened a new tab and swallowed the row tap that is the only opener of the actions sheet on touch).
- **Revert drill on every new guard.** One assertion failed it and was rewritten; one condition I had written turned out unable to fire and was deleted rather than left behind a comment claiming it prevented something.
- **Mutation-checked:** the `siteName` rung of the heading — the one production always takes — had a fixture that could not observe it, and deleting the rung left the suite green. Fixed.
- `npm run check` and `npm test`, exit 0 (3456 tests).

## What QA should actually look at

The suite is blind to all of this — happy-dom applies no stylesheet:

- a card heading's blank space to the right: the row's actions sheet must still open
- Tab to a ▶: the focus ring must be visible, and Enter must land focus in the player
- a video card with no thumbnail: the play badge must still read as a control

🤖 Generated with [Claude Code](https://claude.com/claude-code)