### PR TITLE
Stop /ignore from quietly authoring a rule nobody asked for

### DIFF
--- a/server/services/parseIgnore.test.ts
+++ b/server/services/parseIgnore.test.ts
@@ -116,6 +116,27 @@ describe('parseIgnoreArgs — flags & errors', () => {
     expect(p('-time 300 mike').expiresAt).toBe('2026-06-18T00:05:00.000Z');
   });
 
+  it('-time joins a count and a unit typed as two tokens', () => {
+    // Reading only the first token made `/ignore -time 7 days` a seven-SECOND
+    // rule whose mask was the word "days" — which then lapsed, leaving no trace
+    // of what had happened.
+    expect(p('-time 7 days bob')).toMatchObject({
+      mask: 'bob',
+      expiresAt: '2026-06-25T00:00:00.000Z',
+    });
+    expect(p('-time "7 days" bob').expiresAt).toBe('2026-06-25T00:00:00.000Z');
+    // Only a bare count followed by a unit word joins; a mask stays a mask.
+    expect(p('-time 30 bob').mask).toBe('bob');
+  });
+
+  it('rejects a zero duration rather than creating a rule born expired', () => {
+    // It would be reported as added, never match, never appear in the listing,
+    // and — having no index — be removable only by mask until the sweeper ran.
+    for (const line of ['-time 0 bob', '-time 0m bob', '-time 000 bob']) {
+      expect(p(line).error).toMatch(/time/);
+    }
+  });
+
   it('rejects an absurd -time instead of overflowing Date (no RangeError)', () => {
     expect(p('-time 99999999999999999999 bob').error).toMatch(/time/);
   });
@@ -127,6 +148,50 @@ describe('parseIgnoreArgs — flags & errors', () => {
   it('rejects an unknown flag and a missing -pattern value', () => {
     expect(p('-bogus bob').error).toMatch(/unknown flag/);
     expect(p('bob -pattern').error).toMatch(/pattern/);
+  });
+
+  it('-pattern refuses to swallow a flag as its value', () => {
+    // Taking the next token whatever it was stored a rule matching the literal
+    // text "-network" AND dropped the scope, silently making global the rule the
+    // user had just scoped to one connection.
+    expect(p('bob -pattern -network').error).toMatch(/got the flag/);
+    expect(p('-pattern -regexp foo').error).toMatch(/got the flag/);
+    // Only the known flags are refused — a pattern may still start with a dash.
+    expect(p('bob -pattern -_-').pattern).toBe('-_-');
+  });
+
+  it('refuses -ALL rather than resolving it to the maximal hide set', () => {
+    // Expanding ALL first meant the removal found no ALL left to take off, so
+    // `-ALL` produced every concrete level instead of none.
+    expect(p('bob -ALL').error).toMatch(/-ALL/);
+    expect(p('bob -all').error).toMatch(/-ALL/);
+  });
+
+  it('refuses a rule that names nobody unless * is explicit', () => {
+    // Each of these used to parse into "hide every message from everyone".
+    for (const line of ['-network', '-global', '-time 1d', '', '   ', 'Quit', 'all']) {
+      expect(p(line).error, `expected a refusal from: ${line}`).toMatch(/names nobody/);
+    }
+    // Saying it out loud still works, and so does any other dimension.
+    expect(p('* JOINS')).toMatchObject({ mask: null, levels: ['JOINS'] });
+    expect(p('#idlerpg NOUNREAD').channels).toEqual(['#idlerpg']);
+    expect(p('-pattern spam').pattern).toBe('spam');
+  });
+
+  it('normalizes a blank mask and a blank pattern to absent', () => {
+    // strOrNull nulls both server-side; a null mask is "anyone" and a null
+    // pattern widens the rule from "what they say about X" to "everything".
+    expect(p('"" JOINS').mask).toBeNull();
+    expect(p('" " JOINS').mask).toBeNull();
+    expect(p('bob -pattern " "').pattern).toBeNull();
+  });
+
+  it('compiles a -regexp pattern rather than letting the server refuse it silently', () => {
+    // wsHub's add-ignore drops a failed validation with a bare `break` and sends
+    // no reply, so an unclosed bracket looked like it worked and never existed.
+    expect(p('-regexp -pattern [ bob').error).toMatch(/invalid regex/);
+    // A pattern that isn't a regex isn't compiled — `[` is a fine substring.
+    expect(p('-pattern [ bob').pattern).toBe('[');
   });
 });
 

--- a/shared/parseIgnore.ts
+++ b/shared/parseIgnore.ts
@@ -70,9 +70,37 @@ function parseDuration(s: string | undefined): number | null {
   const mult = DURATION_MULT[(m[2] || 's').toLowerCase()];
   if (mult == null) return null;
   const ms = parseInt(m[1], 10) * mult;
-  if (!Number.isFinite(ms) || ms > MAX_DURATION_MS) return null;
+  // Zero is rejected rather than taken literally: `-time 0` expires the rule at
+  // the instant it is created, so it is reported as added, never matches, and —
+  // having no index in the listing — can only be removed by mask until the
+  // sweeper notices. A permanent ignore is `-time` omitted.
+  if (ms <= 0 || !Number.isFinite(ms) || ms > MAX_DURATION_MS) return null;
   return ms;
 }
+
+// Whether a token is a bare unit word — what `-time 7 days` splits into.
+function isDurationUnit(token: string): boolean {
+  return DURATION_MULT[token.toLowerCase()] != null;
+}
+
+// The flags this grammar knows. `-pattern` refuses to take one as its value:
+// otherwise `/ignore bob -pattern -network` stores a rule matching the literal
+// text "-network" AND silently drops the scope, making global the rule the user
+// had just scoped to one connection. Only known flags are refused, so a pattern
+// may still begin with a dash.
+const FLAGS = new Set([
+  '-regexp',
+  '-regex',
+  '-full',
+  '-word',
+  '-except',
+  '-network',
+  '-net',
+  '-global',
+  '-replies',
+  '-pattern',
+  '-time',
+]);
 
 // Turn a duration string (e.g. "7 days", "30m") into an ISO expiry timestamp,
 // or null if it doesn't parse. Same grammar as the -time flag, exported so the
@@ -144,6 +172,9 @@ export function parseIgnoreArgs(argLine: string, now: number = Date.now()): Pars
   const subLevels: string[] = [];
   const channels: string[] = [];
   let mask: string | null = null;
+  // Whether an explicit `*` (or an empty token) claimed the mask slot — "anyone",
+  // said on purpose, as against never naming a subject at all.
+  let sawAnyone = false;
   let sawRegexp = false;
   let sawFull = false;
 
@@ -177,11 +208,25 @@ export function parseIgnoreArgs(argLine: string, now: number = Date.now()): Pars
     if (lower === '-pattern') {
       const val = tokens[++i];
       if (val === undefined) return fail('-pattern needs a value');
+      if (FLAGS.has(val.toLowerCase())) return fail(`-pattern needs a value (got the flag ${val})`);
       base.pattern = val;
       continue;
     }
     if (lower === '-time') {
-      const val = tokens[++i];
+      let val = tokens[++i];
+      // `7 days` typed without quotes arrives as two tokens. Taking only the
+      // first makes `/ignore -time 7 days` a SEVEN-SECOND rule whose mask is the
+      // word "days" — which then lapses and leaves no trace of what happened.
+      // The pair is unambiguous (a bare count followed by a unit word), so join
+      // it and read the line the way it was written.
+      if (
+        val !== undefined &&
+        /^\d+$/.test(val) &&
+        tokens[i + 1] &&
+        isDurationUnit(tokens[i + 1])
+      ) {
+        val = `${val} ${tokens[++i]}`;
+      }
       const ms = parseDuration(val);
       if (ms == null) return fail(`invalid -time value: ${val ?? '(missing)'}`);
       base.expiresAt = new Date(now + ms).toISOString();
@@ -192,6 +237,14 @@ export function parseIgnoreArgs(argLine: string, now: number = Date.now()): Pars
     if (t.startsWith('-') && t.length > 1) {
       const lvl = canonicalLevel(t.slice(1));
       if (lvl) {
+        // `-ALL` reads as "everything except everything", and resolving it below
+        // produces the MAXIMUM hide set: the base expands ALL to its concrete
+        // members first, so the removal loop then looks for a token that is no
+        // longer in the set and takes nothing off. Refuse it — `PUBLIC -PUBLIC`
+        // already fails with "no levels remain", and this is the same request.
+        if (lvl === 'ALL') {
+          return fail("-ALL isn't a level to subtract — name what to keep, or drop the rule");
+        }
         subLevels.push(lvl);
         continue;
       }
@@ -209,8 +262,18 @@ export function parseIgnoreArgs(argLine: string, now: number = Date.now()): Pars
       continue;
     }
 
-    if (mask === null) {
-      mask = t === '*' ? null : t;
+    if (mask === null && !sawAnyone) {
+      // `*` is "anyone", which the matcher spells as no mask at all — and so are
+      // an empty quoted token (`/ignore ""`) and a whitespace-only one
+      // (`/ignore " "`), both of which `parseIgnoreInput`'s strOrNull nulls on
+      // the way in. Normalizing all three here keeps the rule the client shows
+      // the same as the one the server stores; `" "` previously survived as a
+      // mask, was nulled server-side, and became a rule hiding everyone.
+      const trimmed = t.trim();
+      // Remembered, because "the user asked for everyone" and "the user named
+      // nobody" both leave `mask` null and only the second is a mistake.
+      if (trimmed === '*' || trimmed === '') sawAnyone = true;
+      else mask = trimmed;
       continue;
     }
     return fail(`unexpected argument: ${t}`);
@@ -219,6 +282,13 @@ export function parseIgnoreArgs(argLine: string, now: number = Date.now()): Pars
   base.patternKind = sawRegexp ? 'regex' : sawFull ? 'full' : 'substr';
   base.mask = mask;
   base.channels = channels.length ? channels : null;
+  // A whitespace-only pattern is nulled by strOrNull server-side, and a null
+  // pattern WIDENS the rule from "hide what they say about X" to "hide
+  // everything they say" — so trim here and treat empty as absent.
+  if (base.pattern != null) {
+    const trimmed = base.pattern.trim();
+    base.pattern = trimmed === '' ? null : trimmed;
+  }
 
   // Resolve the level set. Additive tokens form the base; with none given the
   // base is ALL. Subtractive tokens expand ALL to its concrete members first,
@@ -232,6 +302,34 @@ export function parseIgnoreArgs(argLine: string, now: number = Date.now()): Pars
     for (const s of subLevels) levelSet.delete(s);
   }
   if (levelSet.size === 0) return fail('no levels remain');
+
+  // A rule that names no subject — no mask, no channel, no content — hides EVERY
+  // message from everyone, on every network if it's global. That is occasionally
+  // what someone means, so the escape hatch is to say it: `/ignore * JOINS` is
+  // explicit and passes. What's refused is arriving there by accident, which
+  // several ordinary lines do: `/ignore -network` sent by a stray Return,
+  // `/ignore -time 1d`, or `/ignore Quit`, where a nick that happens to spell a
+  // level token is consumed as the level (levels are read before masks) leaving
+  // the rule with no subject at all. `ignoreRulesService.add` deliberately
+  // declines to stop this, since by then the intent is unrecoverable.
+  if (mask === null && channels.length === 0 && !base.pattern && !sawAnyone) {
+    return fail(
+      'that names nobody to ignore — try /ignore <nick>, or /ignore * <levels> for everyone',
+    );
+  }
+
+  // A `-regexp` pattern is compiled here, where the engine is the same one the
+  // matcher will use. Without it the rule reaches the server, `add` refuses it
+  // ("invalid regex"), and `wsHub`'s add-ignore drops that failure with a bare
+  // `break` and no reply — so an unclosed bracket looks like it worked and the
+  // rule simply never exists.
+  if (sawRegexp && base.pattern) {
+    try {
+      void new RegExp(base.pattern);
+    } catch (e) {
+      return fail(`invalid regex: ${(e as Error).message}`);
+    }
+  }
 
   // Canonical order + dedupe for a stable stored CSV.
   base.levels = canonicalizeLevels([...levelSet]);


### PR DESCRIPTION
Six defects in `shared/parseIgnore.ts`, found while porting it to the iOS client ([lurker-ios#86](https://github.com/amiantos/lurker-ios/pull/91)) and all still live here. Every one ends the same way: a command line that reads as a narrow rule stores a much wider one, and nothing says so.

The settings pane already refuses this class of rule — `'that would hide everything — add a mask, channel, or text pattern.'` (`IgnoresPane.vue`) — so this isn't a new policy. It's the guard the product had already decided on, applied to the one path that skipped it.

## The six

| Input | Stored today |
|---|---|
| `/ignore bob -pattern -network` | a rule matching the literal text `-network`, **scoped globally** — the `-network` the user typed is consumed as the pattern |
| `/ignore bob -ALL` | the **maximal** hide set (every concrete level) |
| `/ignore -time 7 days` | a seven-**second** rule whose mask is the word `days` |
| `/ignore -time 0` | a rule that expired at the instant it was created |
| `/ignore " "` | mask `" "` → nulled by `strOrNull` → hides **everyone** |
| `/ignore -network` (stray Return) | mask-less, channel-less, pattern-less `ALL` → hides **everything** |

`-ALL` is the mechanism worth reading twice: the resolver expands `ALL` to its concrete members *before* the subtraction loop runs, so the loop then looks for a token no longer in the set and removes nothing. `-ALL` therefore means the exact opposite of how it reads.

The last row has a sharper variant that needs no typo at all: **`/ignore Quit`**. Levels are matched before masks, so a nick that happens to spell a level token is consumed as the level, and the rule is left with no subject — a global rule hiding every quit from everyone. Same for `/ignore all`, `/ignore Topic`, `/ignore nick`.

## What changed

Each of the six is refused or normalized, with the reasoning at the site. The escape hatch for "I really do mean everyone" is to say it: `/ignore * JOINS` is explicit and passes untouched, and so does any rule that names a channel or a content pattern.

Also here: a `-regexp` pattern is now compiled during parsing, with the same engine the matcher will use. `ignoreRulesService.add` refuses one it can't compile, and `wsHub`'s `add-ignore` drops that failure with a bare `break` and no reply — so an unclosed bracket looked like it worked, and the rule simply never existed.

## Scope

`shared/parseIgnore.ts` and its test suite only — the parser is pure, and this keeps the diff to the layer both clients share. `parseIgnoreArgs` has one caller (`MessageInput.vue:runIgnore`), which already prints `parsed.error` back to the buffer, so every new refusal surfaces without a UI change. `durationToExpiry` shares `parseDuration`, so `0` is now an invalid duration in the ignores pane too — it's handled there (`invalid duration: 0`).

**Not** included, and worth a follow-up if you want them — all in `MessageInput.vue:runUnignore`, all with iOS equivalents already written:

- `/unignore <all-digits>` can only ever be an index, so a numeric mask (a bot, `*!*@1234`) can be created and never named.
- `/unignore *` reports "no ignore with mask" for maskless rules, which the listing prints as `*` — they're removable by number only, and nothing says so.
- The match count uses `.toLowerCase() ===` while the server deletes with `mask = ? COLLATE NOCASE` (ASCII-only, byte-exact), so the reported count can differ from what the `DELETE` actually removes.

One asymmetry I left deliberately: the pane refuses an unscoped rule only when it carries `ALL` or `-except`, while this refuses an unscoped rule at any level unless `*` is explicit. Blanking a form field you're looking at is a deliberate act; a token silently eaten off a command line isn't. Happy to align them either way.

## Verification

`npm run check` clean, `npm test` 3454 passing. The parser suite gained 7 cases covering each refusal and each thing that must still work.