### PR TITLE
Cache preview image bytes on disk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -281,6 +281,37 @@ VAPID_SUBJECT=mailto:you@example.com
 # LURKER_PREVIEW_USER_AGENT=
 
 # ---------------------------------------------------------------------------
+# Caching the preview IMAGE BYTES on disk. OFF by default, and previews work
+# fine without it — this only changes how often the same picture is fetched from
+# the site hosting it.
+#
+# Without a cache, the metadata for a link is fetched once and remembered, but
+# the BYTES are not: ten people scrolling past the same image is ten fetches
+# from its origin. (Each browser holds its copy for a day, so it is once per
+# person per day, not once per view.) With a cache, it is fetched once for
+# everyone, and every byte still goes out through your own authenticated server.
+#
+#   off    stream through, store nothing. The default.
+#   local  a directory beside the database, evicting coldest-first at a ceiling.
+#
+# ⚠ Only IMAGES are cached. Video and audio are far larger and are read in
+# ranges (a seek is many requests for one object), so caching them would trade
+# the bandwidth this saves for memory it cannot bound.
+#
+# ⚠ Losing this directory costs nothing but a re-fetch — it is a cache, not
+# data. It is safe to delete while the server is stopped.
+#
+# Misconfiguration is never fatal: a bad value logs a warning and turns caching
+# off, and previews keep working.
+#
+# A bucket-backed mode (S3/R2, served from a CDN) is being developed separately;
+# `LURKER_PREVIEW_CACHE_MODE=s3` is not accepted yet and will warn.
+# ---------------------------------------------------------------------------
+# LURKER_PREVIEW_CACHE_MODE=off
+# LURKER_PREVIEW_CACHE_DIR=              # default: <data dir>/preview-cache
+# LURKER_PREVIEW_CACHE_MAX_BYTES=        # default: 2147483648 (2 GiB), digits only
+
+# ---------------------------------------------------------------------------
 # Built-in IRC bouncer (ZNC- and soju-compatible). OFF by default. When enabled,
 # any IRC client (from mIRC to modern IRCv3 clients like Halloy/gamja/Goguma) can
 # attach to your always-on Lurker connections: shared upstream socket and nick,

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -487,6 +487,15 @@ export const EXPORT_TABLES = Object.freeze({
       'has seen without adding anything they could not refetch',
   },
 
+  preview_cache: {
+    mode: 'skip',
+    reason:
+      'the index for the preview BYTE cache — url hashes, sizes and content types for ' +
+      'files held on disk or in a bucket. Derived from link_previews, which is skipped ' +
+      'for the same reason, and useless on a target instance whose cache directory or ' +
+      'bucket does not contain the objects it names',
+  },
+
   webauthn_credentials: {
     mode: 'skip',
     reason:

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -62,7 +62,7 @@ function migrate() {
     CREATE TABLE IF NOT EXISTS sessions (
       token TEXT PRIMARY KEY,
       user_id INTEGER NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       expires_at TEXT NOT NULL,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
@@ -82,7 +82,7 @@ function migrate() {
       realname TEXT,
       server_password TEXT,
       autoconnect INTEGER NOT NULL DEFAULT 1,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_networks_user ON networks(user_id);
@@ -110,7 +110,7 @@ function migrate() {
       state TEXT NOT NULL DEFAULT 'open',
       autojoin INTEGER NOT NULL DEFAULT 0,
       key TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       closed_at TEXT,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
@@ -200,7 +200,7 @@ function migrate() {
       case_sensitive INTEGER NOT NULL DEFAULT 0,
       enabled INTEGER NOT NULL DEFAULT 1,
       auto_managed INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_highlight_rules_user ON highlight_rules(user_id);
@@ -225,7 +225,7 @@ function migrate() {
       auth TEXT NOT NULL,
       user_agent TEXT,
       enabled INTEGER NOT NULL DEFAULT 1,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
@@ -242,7 +242,7 @@ function migrate() {
       network_id INTEGER NOT NULL,
       target TEXT NOT NULL,
       text TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
     );
@@ -255,7 +255,7 @@ function migrate() {
       expires_at TEXT,
       used_by_user_id INTEGER,
       used_at TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (used_by_user_id) REFERENCES users(id) ON DELETE SET NULL
     );
@@ -272,7 +272,7 @@ function migrate() {
       device_type TEXT,
       backed_up INTEGER NOT NULL DEFAULT 0,
       label TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       last_used_at TEXT,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
@@ -319,7 +319,7 @@ function migrate() {
       width INTEGER,
       height INTEGER,
       thumbnail BLOB,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_upload_history_user
@@ -368,7 +368,7 @@ function migrate() {
       crc_actual TEXT,
       crc_status TEXT,
       error TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now')),
       completed_at TEXT,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
@@ -404,7 +404,7 @@ function migrate() {
       network_id INTEGER NOT NULL,
       target TEXT NOT NULL,
       position INTEGER NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       PRIMARY KEY (user_id, network_id, target),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
@@ -482,7 +482,7 @@ function migrate() {
       levels TEXT NOT NULL DEFAULT 'ALL',
       is_except INTEGER NOT NULL DEFAULT 0,
       expires_at TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
     );
@@ -517,7 +517,7 @@ function migrate() {
       network_id INTEGER NOT NULL,
       nick TEXT NOT NULL COLLATE NOCASE,
       pattern TEXT NOT NULL DEFAULT '',
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       PRIMARY KEY (user_id, network_id, nick),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
@@ -537,7 +537,7 @@ function migrate() {
       user_id INTEGER NOT NULL,
       display_name TEXT NOT NULL,
       notify_online INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
     CREATE INDEX IF NOT EXISTS idx_contacts_user ON contacts(user_id);
@@ -563,7 +563,7 @@ function migrate() {
     CREATE TABLE IF NOT EXISTS user_bookmarks (
       user_id INTEGER NOT NULL,
       message_id INTEGER NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       PRIMARY KEY (user_id, message_id),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
@@ -582,7 +582,7 @@ function migrate() {
       name TEXT NOT NULL,
       token_hash TEXT NOT NULL UNIQUE,
       scope TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       last_used_at TEXT,
       revoked_at TEXT,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
@@ -611,7 +611,7 @@ function migrate() {
       byte_size INTEGER,
       token TEXT NOT NULL,
       error TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       started_at TEXT,
       completed_at TEXT,
       expires_at TEXT,
@@ -696,8 +696,15 @@ function migrate() {
       backend TEXT NOT NULL,
       content_type TEXT NOT NULL,
       size INTEGER NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      last_access TEXT NOT NULL DEFAULT (datetime('now'))
+      -- ⚠ ISO-8601 WITH Z, not datetime('now'). Two reasons, and the second is a
+      -- measured bug: this column is read back into Date.parse, and
+      -- "YYYY-MM-DD HH:MM:SS" is not ISO, so V8 parses it as LOCAL time — stored
+      -- 08:01:12 UTC came back as 15:01:12Z on a UTC-7 machine, skewing the age
+      -- bound by the operator's offset. It is also what link_previews already
+      -- stores (see NOW_ISO there), because ISO-with-Z is lexicographically
+      -- ordered and so compares correctly as TEXT in SQL.
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      last_access TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
     );
     -- ⚠ COMPOSITE, and COVERING. Both eviction reads filter on backend and order by
     -- last_access, so an index on last_access alone still scans — and the size
@@ -831,7 +838,7 @@ function migrate() {
       offered_to_users INTEGER NOT NULL DEFAULT 0,
       locked INTEGER NOT NULL DEFAULT 0,
       is_default INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now')),
       FOREIGN KEY (owner_user_id) REFERENCES users(id) ON DELETE CASCADE
     );
@@ -870,7 +877,7 @@ function migrate() {
       channels_json TEXT NOT NULL DEFAULT '[]',
       enabled INTEGER NOT NULL DEFAULT 1,
       position INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
   `);
@@ -1304,7 +1311,7 @@ if (schemaVersion < 1) {
           case_sensitive INTEGER NOT NULL DEFAULT 0,
           enabled INTEGER NOT NULL DEFAULT 1,
           auto_managed INTEGER NOT NULL DEFAULT 0,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
           FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
         )
       `);
@@ -1433,7 +1440,7 @@ if (schemaVersion < 5) {
           width INTEGER,
           height INTEGER,
           thumbnail BLOB,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
           FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
         )
       `);
@@ -1574,7 +1581,7 @@ if (schemaVersion < 10) {
           levels TEXT NOT NULL DEFAULT 'ALL',
           is_except INTEGER NOT NULL DEFAULT 0,
           expires_at TEXT,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
           FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
           FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
         )
@@ -1626,7 +1633,7 @@ if (schemaVersion < 11) {
           levels TEXT NOT NULL DEFAULT 'ALL',
           is_except INTEGER NOT NULL DEFAULT 0,
           expires_at TEXT,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
           FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
           FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
         )
@@ -1747,7 +1754,7 @@ try {
           auth TEXT,
           user_agent TEXT,
           enabled INTEGER NOT NULL DEFAULT 1,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
           last_seen_at TEXT NOT NULL DEFAULT (datetime('now')),
           fail_count INTEGER NOT NULL DEFAULT 0,
           FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
@@ -1801,7 +1808,7 @@ try {
           case_sensitive INTEGER NOT NULL DEFAULT 0,
           enabled INTEGER NOT NULL DEFAULT 1,
           auto_managed INTEGER NOT NULL DEFAULT 0,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
           FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
         )
       `);

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -682,6 +682,30 @@ function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_link_previews_expires ON link_previews(expires_at);
 
+    -- Bookkeeping for the preview BYTE cache (issue #681). ⚠ Metadata only — the
+    -- bytes live on disk or in a bucket, never here. The DB is Litestream-replicated
+    -- to R2, so blobs in a table would continuously ship every cached image to object
+    -- storage, which is the expensive mistake that looks convenient at the time.
+    --
+    -- Existence lives here rather than being probed from the backend because the
+    -- point of the cache is to avoid a round trip: a HEAD to S3 on every byte request
+    -- would trade an origin fetch for a bucket fetch. It also gives the local backend its LRU
+    -- accounting for free — a SUM(size) and an ORDER BY beat a readdir and N stats.
+    CREATE TABLE IF NOT EXISTS preview_cache (
+      cache_key TEXT PRIMARY KEY,
+      backend TEXT NOT NULL,
+      content_type TEXT NOT NULL,
+      size INTEGER NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_access TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    -- ⚠ COMPOSITE, and covering the eviction query exactly. Both eviction reads
+    -- filter on backend and then order by last_access, so an index on last_access
+    -- alone still scans; these run synchronously on the one shared connection that
+    -- also serves WebSocket fan-out and IRC sockets, on the byte path.
+    CREATE INDEX IF NOT EXISTS idx_preview_cache_evict
+      ON preview_cache(backend, last_access, created_at);
+
     -- RPE2E end-to-end-encryption keyring (issue #382). Secrets — the identity
     -- private key and the session keys — are stored as secretCrypto envelopes
     -- (TEXT, the same lk1.* at-rest scheme as network credentials); public

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -699,12 +699,15 @@ function migrate() {
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       last_access TEXT NOT NULL DEFAULT (datetime('now'))
     );
-    -- ⚠ COMPOSITE, and covering the eviction query exactly. Both eviction reads
-    -- filter on backend and then order by last_access, so an index on last_access
-    -- alone still scans; these run synchronously on the one shared connection that
-    -- also serves WebSocket fan-out and IRC sockets, on the byte path.
+    -- ⚠ COMPOSITE, and COVERING. Both eviction reads filter on backend and order by
+    -- last_access, so an index on last_access alone still scans — and the size
+    -- column has to be in it too, or SUM(size) fetches every matching row from the
+    -- table instead of reading the index. These run synchronously on the one shared
+    -- connection that also serves WebSocket fan-out and IRC sockets, on the byte
+    -- path, so at a 2 GiB ceiling that is tens of thousands of row reads per store.
+    -- (No backticks in here: this is inside a JS template literal.)
     CREATE INDEX IF NOT EXISTS idx_preview_cache_evict
-      ON preview_cache(backend, last_access, created_at);
+      ON preview_cache(backend, last_access, created_at, size);
 
     -- RPE2E end-to-end-encryption keyring (issue #382). Secrets — the identity
     -- private key and the session keys — are stored as secretCrypto envelopes

--- a/server/db/previewCache.ts
+++ b/server/db/previewCache.ts
@@ -15,6 +15,7 @@
 // row rather than failing the request. See `forget`.
 
 import db from './index.js';
+import { NOW_ISO } from './linkPreviews.js';
 
 // ⚠ Hoisted, as every other db/ module does. `db.prepare()` re-parses the SQL on
 // each call, and these run on the byte path — once per cache hit and twice per
@@ -23,8 +24,8 @@ const SELECT_ENTRY = db.prepare<[string], Row>(
   `SELECT cache_key, backend, content_type, size, created_at FROM preview_cache WHERE cache_key = ?`,
 );
 const TOUCH_ENTRY = db.prepare<[string]>(
-  `UPDATE preview_cache SET last_access = datetime('now')
-    WHERE cache_key = ? AND last_access <= datetime('now', '-1 hour')`,
+  `UPDATE preview_cache SET last_access = ${NOW_ISO}
+    WHERE cache_key = ? AND last_access <= strftime('%Y-%m-%dT%H:%M:%fZ','now','-1 hour')`,
 );
 const UPSERT_ENTRY = db.prepare<[string, string, string, number]>(
   `INSERT INTO preview_cache (cache_key, backend, content_type, size)
@@ -33,7 +34,7 @@ const UPSERT_ENTRY = db.prepare<[string, string, string, number]>(
      backend = excluded.backend,
      content_type = excluded.content_type,
      size = excluded.size,
-     last_access = datetime('now')`,
+     last_access = ${NOW_ISO}`,
 );
 const DELETE_ENTRY = db.prepare<[string]>(`DELETE FROM preview_cache WHERE cache_key = ?`);
 const SUM_BYTES = db.prepare<[string], { total: number | null }>(

--- a/server/db/previewCache.ts
+++ b/server/db/previewCache.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Bookkeeping for the preview BYTE cache — what is stored, how big it is, and
+// when it was last read. The bytes themselves live on disk or in a bucket; this
+// table holds only the index (see the schema note in db/index.ts for why blobs
+// here would be a mistake on a Litestream-replicated database).
+//
+// ⚠ Existence is answered from HERE, never by asking the backend. The whole
+// point of the cache is to remove a round trip, and a HEAD to S3 on every byte
+// request would just trade an origin fetch for a bucket fetch. The cost of that
+// choice is that the table can disagree with reality — a bucket emptied by a
+// lifecycle rule, a data directory wiped between deploys — so every read path
+// treats "row says yes, backend says no" as an ordinary miss and repairs the
+// row rather than failing the request. See `forget`.
+
+import db from './index.js';
+
+// ⚠ Hoisted, as every other db/ module does. `db.prepare()` re-parses the SQL on
+// each call, and these run on the byte path — once per cache hit and twice per
+// store. better-sqlite3 caches nothing for us.
+const SELECT_ENTRY = db.prepare<[string], Row>(
+  `SELECT cache_key, backend, content_type, size FROM preview_cache WHERE cache_key = ?`,
+);
+const TOUCH_ENTRY = db.prepare<[string]>(
+  `UPDATE preview_cache SET last_access = datetime('now')
+    WHERE cache_key = ? AND last_access <= datetime('now', '-1 hour')`,
+);
+const UPSERT_ENTRY = db.prepare<[string, string, string, number]>(
+  `INSERT INTO preview_cache (cache_key, backend, content_type, size)
+   VALUES (?, ?, ?, ?)
+   ON CONFLICT(cache_key) DO UPDATE SET
+     backend = excluded.backend,
+     content_type = excluded.content_type,
+     size = excluded.size,
+     last_access = datetime('now')`,
+);
+const DELETE_ENTRY = db.prepare<[string]>(`DELETE FROM preview_cache WHERE cache_key = ?`);
+const SUM_BYTES = db.prepare<[string], { total: number | null }>(
+  `SELECT SUM(size) AS total FROM preview_cache WHERE backend = ?`,
+);
+const COLDEST = db.prepare<[string, number], Row>(
+  `SELECT cache_key, backend, content_type, size FROM preview_cache
+    WHERE backend = ? ORDER BY last_access ASC, created_at ASC LIMIT ?`,
+);
+const COUNT_ALL = db.prepare<[], { n: number }>(`SELECT COUNT(*) AS n FROM preview_cache`);
+
+export interface CacheEntry {
+  key: string;
+  backend: string;
+  contentType: string;
+  size: number;
+}
+
+interface Row {
+  cache_key: string;
+  backend: string;
+  content_type: string;
+  size: number;
+}
+
+/**
+ * Look an object up, and mark it read.
+ *
+ * ⚠ `last_access` is only written when it is meaningfully stale. A touch per hit
+ * turns a read-only path into a write on the one shared connection, and the
+ * eviction order does not care about minutes — it cares about which objects are
+ * cold over days. An hour of granularity costs eviction nothing and removes the
+ * write from the hot path almost entirely.
+ */
+export function lookupCached(key: string): CacheEntry | null {
+  const row = SELECT_ENTRY.get(key);
+  if (!row) return null;
+
+  TOUCH_ENTRY.run(key);
+
+  return {
+    key: row.cache_key,
+    backend: row.backend,
+    contentType: row.content_type,
+    size: row.size,
+  };
+}
+
+/** Record a stored object. Upsert, because two readers can race the same miss. */
+export function recordCached(entry: CacheEntry): void {
+  UPSERT_ENTRY.run(entry.key, entry.backend, entry.contentType, entry.size);
+}
+
+/** Drop the row for an object that is gone, or that we failed to store. */
+export function forget(key: string): void {
+  DELETE_ENTRY.run(key);
+}
+
+/** Total bytes attributed to a backend. The number an eviction pass works against. */
+export function cachedBytes(backend: string): number {
+  const row = SUM_BYTES.get(backend);
+  return row?.total ?? 0;
+}
+
+/**
+ * The coldest entries for a backend, oldest first.
+ *
+ * ⚠ Returns candidates rather than deleting them, because the row and the bytes
+ * live in different places and the bytes are the half that can fail. The caller
+ * unlinks first and calls `forget` only for what it actually removed — the other
+ * order leaves a file nothing remembers, which is a leak no later pass can find.
+ */
+export function coldestCached(backend: string, limit: number): CacheEntry[] {
+  return COLDEST.all(backend, limit).map((row) => ({
+    key: row.cache_key,
+    backend: row.backend,
+    contentType: row.content_type,
+    size: row.size,
+  }));
+}
+
+/** Test seam, and the answer to "did anything actually get stored". */
+export function countCached(): number {
+  const row = COUNT_ALL.get();
+  return row?.n ?? 0;
+}

--- a/server/db/previewCache.ts
+++ b/server/db/previewCache.ts
@@ -20,7 +20,7 @@ import db from './index.js';
 // each call, and these run on the byte path — once per cache hit and twice per
 // store. better-sqlite3 caches nothing for us.
 const SELECT_ENTRY = db.prepare<[string], Row>(
-  `SELECT cache_key, backend, content_type, size FROM preview_cache WHERE cache_key = ?`,
+  `SELECT cache_key, backend, content_type, size, created_at FROM preview_cache WHERE cache_key = ?`,
 );
 const TOUCH_ENTRY = db.prepare<[string]>(
   `UPDATE preview_cache SET last_access = datetime('now')
@@ -40,7 +40,7 @@ const SUM_BYTES = db.prepare<[string], { total: number | null }>(
   `SELECT SUM(size) AS total FROM preview_cache WHERE backend = ?`,
 );
 const COLDEST = db.prepare<[string, number], Row>(
-  `SELECT cache_key, backend, content_type, size FROM preview_cache
+  `SELECT cache_key, backend, content_type, size, created_at FROM preview_cache
     WHERE backend = ? ORDER BY last_access ASC, created_at ASC LIMIT ?`,
 );
 const COUNT_ALL = db.prepare<[], { n: number }>(`SELECT COUNT(*) AS n FROM preview_cache`);
@@ -50,6 +50,8 @@ export interface CacheEntry {
   backend: string;
   contentType: string;
   size: number;
+  /** When it was stored. Read by the age bound in the cache's `lookup`. */
+  createdAt: string;
 }
 
 interface Row {
@@ -57,6 +59,7 @@ interface Row {
   backend: string;
   content_type: string;
   size: number;
+  created_at: string;
 }
 
 /**
@@ -79,11 +82,12 @@ export function lookupCached(key: string): CacheEntry | null {
     backend: row.backend,
     contentType: row.content_type,
     size: row.size,
+    createdAt: row.created_at,
   };
 }
 
 /** Record a stored object. Upsert, because two readers can race the same miss. */
-export function recordCached(entry: CacheEntry): void {
+export function recordCached(entry: Omit<CacheEntry, 'createdAt'>): void {
   UPSERT_ENTRY.run(entry.key, entry.backend, entry.contentType, entry.size);
 }
 
@@ -112,6 +116,7 @@ export function coldestCached(backend: string, limit: number): CacheEntry[] {
     backend: row.backend,
     contentType: row.content_type,
     size: row.size,
+    createdAt: row.created_at,
   }));
 }
 

--- a/server/routes/linkPreview.cache.test.ts
+++ b/server/routes/linkPreview.cache.test.ts
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The byte cache through the ROUTE, against a real origin that counts how often
+// it is asked. Its own file rather than cases bolted onto linkPreview.media.test:
+// the cache is configured from the environment and resolved once per process, so
+// a suite that shares a module registry with the uncached tests cannot have both.
+//
+// ⚠⚠ The assertion that matters everywhere here is the ORIGIN HIT COUNT. "The
+// second request returned the right bytes" is true with the cache ripped out —
+// it would just fetch them again. Counting the fetches is the only thing that
+// distinguishes a working cache from a working proxy, and it is the property the
+// whole feature exists for.
+//
+// ⚠ What's mocked is the POLICY, never the mechanism: the address guard is
+// inverted so a loopback origin is reachable at all. Express, the token, the
+// throttles, the pool, safeRequest, the pinned lookup, the pipe, the filesystem
+// and the SQLite index are all shipping code.
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import http from 'node:http';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+import type { Express } from 'express';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import { setupTestDb, createTestApp, createAuthedAgent } from '../test-utils/testApp.js';
+
+vi.mock('../utils/ipGuard.js', () => ({
+  isBlockedIpLiteral: (host: string) => host.replace(/^\[|\]$/g, '') !== '127.0.0.1',
+  isBlockedIpv4: (ip: string) => ip !== '127.0.0.1',
+}));
+
+const ctx = setupTestDb('routes-link-preview-cache');
+process.env.LURKER_LINK_PREVIEWS = 'on';
+process.env.LURKER_PREVIEW_CACHE_MODE = 'local';
+process.env.LURKER_PREVIEW_CACHE_DIR = path.join(ctx.tmpDir, 'preview-cache');
+
+let app: Express;
+let agent: LurkerTestAgent;
+let mintProxyToken: typeof import('../services/mediaProxyToken.js').mintProxyToken;
+let countCached: typeof import('../db/previewCache.js').countCached;
+let whenStoresSettle: typeof import('../services/previewCache/index.js').whenStoresSettle;
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+let handler: Handler;
+let origin: http.Server;
+let base: string;
+/** How many times the ORIGIN was actually asked. The whole point, in one number. */
+let originHits = 0;
+/** Connections to the raw (unframed) origin, which is its own server. */
+let rawHits = 0;
+
+const tokenFor = (p: string): string => mintProxyToken(`${base}${p}`);
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  ({ mintProxyToken } = await import('../services/mediaProxyToken.js'));
+  ({ countCached } = await import('../db/previewCache.js'));
+  ({ whenStoresSettle } = await import('../services/previewCache/index.js'));
+  const router = (await import('./linkPreview.js')).default;
+
+  const alice = createUser('alice-cache');
+  app = createTestApp({ '/api/link-preview': router });
+  agent = await createAuthedAgent(app, alice.id);
+
+  origin = http.createServer((req, res) => {
+    originHits++;
+    handler(req, res);
+  });
+  await new Promise<void>((resolve) => origin.listen(0, '127.0.0.1', resolve));
+  base = `http://localhost:${(origin.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => origin.close(() => resolve()));
+  delete process.env.LURKER_PREVIEW_CACHE_MODE;
+  delete process.env.LURKER_PREVIEW_CACHE_DIR;
+  ctx.cleanup();
+});
+
+beforeEach(async () => {
+  // ⚠⚠ Drains BEFORE clearing. The route stores fire-and-forget so a slow bucket
+  // cannot hold a response open, which means a write from the previous test can
+  // still be in flight while this one wipes the table — and it then lands in the
+  // clean state and reads as "this test cached something". That is precisely how
+  // the absence assertions below (`toBe(0)`) went green against the wrong cause.
+  await whenStoresSettle();
+  originHits = 0;
+  rawHits = 0;
+  const { default: db } = await import('../db/index.js');
+  db.prepare('DELETE FROM preview_cache').run();
+  fs.rmSync(process.env.LURKER_PREVIEW_CACHE_DIR!, { recursive: true, force: true });
+});
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+function servePng(body = PNG): void {
+  handler = (_req, res) => {
+    res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(body.length) });
+    res.end(body);
+  };
+}
+
+describe('the byte cache, end to end', () => {
+  it('fetches an image once and serves the second read from the cache', async () => {
+    servePng();
+    const token = tokenFor('/cached.png');
+
+    const first = await agent.get(`/api/link-preview/media/${token}`);
+    expect(first.status).toBe(200);
+    expect(Buffer.from(first.body).equals(PNG)).toBe(true);
+    expect(originHits).toBe(1);
+    await whenStoresSettle();
+
+    const second = await agent.get(`/api/link-preview/media/${token}`);
+    expect(second.status).toBe(200);
+    // ⚠ THE assertion. Same bytes proves nothing on its own — the uncached path
+    // returns those too. One origin hit for two reads is the feature.
+    expect(originHits).toBe(1);
+    expect(Buffer.from(second.body).equals(PNG)).toBe(true);
+  });
+
+  it('serves the cached copy with the same hardening headers as a live fetch', async () => {
+    servePng();
+    const token = tokenFor('/headers.png');
+    const live = await agent.get(`/api/link-preview/media/${token}`);
+    await whenStoresSettle();
+    const cached = await agent.get(`/api/link-preview/media/${token}`);
+    expect(originHits).toBe(1);
+
+    // ⚠⚠ The cache added a SECOND way to send a response body, and these headers are
+    // what stop a third party's bytes being interpreted as something other than the
+    // type we allowlisted. A cached image served without `nosniff` is the same
+    // vulnerability as an uncached one, reached by omission — which is exactly the
+    // kind of gap a "does it return the bytes" test sails past.
+    for (const h of [
+      'content-type',
+      'x-content-type-options',
+      'content-security-policy',
+      'content-disposition',
+      'cross-origin-resource-policy',
+      'cache-control',
+    ]) {
+      expect(`${h}: ${cached.headers[h]}`).toBe(`${h}: ${live.headers[h]}`);
+    }
+  });
+
+  it('does not cache a video, however many times it is asked for', async () => {
+    // ⚠ Deliberate: 64 MB against images' 8 MB, and range-read, so a cached copy
+    // would have to answer partial reads. Buffering one per miss to store it trades
+    // the bandwidth this feature saves for memory it cannot bound.
+    const MP4 = Buffer.alloc(2048, 7);
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'video/mp4', 'content-length': String(MP4.length) });
+      res.end(MP4);
+    };
+    const token = tokenFor('/clip.mp4');
+    await agent.get(`/api/link-preview/media/${token}`);
+    await agent.get(`/api/link-preview/media/${token}`);
+    await whenStoresSettle();
+    expect(originHits).toBe(2);
+    expect(countCached()).toBe(0);
+  });
+
+  it('passes a RANGE request through and stores nothing from it', async () => {
+    // Serving a whole object to a request that asked for a window is a correctness
+    // bug, not a slow path — so a ranged read is neither answered from the cache nor
+    // allowed to populate it with a partial body.
+    handler = (req, res) => {
+      if (req.headers.range) {
+        res.writeHead(206, {
+          'content-type': 'image/png',
+          'content-range': `bytes 0-9/${PNG.length}`,
+          'accept-ranges': 'bytes',
+        });
+        res.end(PNG.subarray(0, 10));
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'image/png' });
+      res.end(PNG);
+    };
+    const token = tokenFor('/ranged.png');
+    const ranged = await agent.get(`/api/link-preview/media/${token}`).set('Range', 'bytes=0-9');
+    expect(ranged.status).toBe(206);
+    await whenStoresSettle();
+    expect(countCached()).toBe(0);
+
+    // ...and the partial read did not poison the full one.
+    const full = await agent.get(`/api/link-preview/media/${token}`);
+    expect(full.status).toBe(200);
+    expect(Buffer.from(full.body).equals(PNG)).toBe(true);
+  });
+
+  it('stores nothing when the origin dies mid-body, and re-fetches next time', async () => {
+    // ⚠⚠ The corruption this design must not have. A body cut short is still a
+    // stream of real bytes; cached, it becomes a permanently broken image served to
+    // everyone afterwards, and the browser holds it for a day. Only `end` on the
+    // upstream means "complete object", which is why the store hangs off that rather
+    // than off the response finishing.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(PNG.length) });
+      res.write(PNG.subarray(0, 10));
+      // ⚠ Killed on a LATER tick, deliberately. Destroying the socket in the same
+      // breath as the headers made `safeRequest` itself reject, so the route took
+      // its catch branch and never began streaming — the test passed while proving
+      // only "a dead origin caches nothing", which is not the guard it names. The
+      // delay is what gets a partial body through the pipe and into the collector,
+      // which is the state the truncation check actually exists for.
+      setTimeout(() => res.destroy(), 60);
+    };
+    const token = tokenFor('/truncated.png');
+    await agent.get(`/api/link-preview/media/${token}`).catch(() => undefined);
+    await whenStoresSettle();
+    expect(countCached()).toBe(0);
+
+    servePng();
+    const retry = await agent.get(`/api/link-preview/media/${token}`);
+    expect(retry.status).toBe(200);
+    expect(Buffer.from(retry.body).equals(PNG)).toBe(true);
+  });
+
+  it('refuses to cache a body framed only by the connection closing', async () => {
+    // ⚠⚠ The hazard `ended` cannot see. With no Content-Length and no chunked
+    // encoding, the close of the connection IS the terminator — so node emits `end`
+    // with `complete: true` for a body that was cut short, and a truncated image
+    // looks exactly like a finished one. This route makes that ordinary rather than
+    // exotic: `linkFetch` sets `keepAlive: false`, so every request carries
+    // `Connection: close`, which is precisely when RFC 7230 lets an origin omit
+    // framing.
+    //
+    // A raw socket rather than `http.Server`, because node's server always frames a
+    // response for you — Content-Length or chunked — so the state under test cannot
+    // be produced through it at all.
+    const raw = net.createServer((sock) => {
+      rawHits++;
+      sock.write('HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nConnection: close\r\n\r\n');
+      sock.write(PNG.subarray(0, 12));
+      setTimeout(() => sock.destroy(), 60);
+    });
+    await new Promise<void>((r) => raw.listen(0, '127.0.0.1', r));
+    const rawPort = (raw.address() as AddressInfo).port;
+    try {
+      const token = mintProxyToken(`http://localhost:${rawPort}/unframed.png`);
+      await agent.get(`/api/link-preview/media/${token}`).catch(() => undefined);
+      await whenStoresSettle();
+      // ⚠ The origin WAS reached — otherwise this would pass for the boring reason
+      // that nothing happened, which is the failure mode absence tests have.
+      expect(rawHits).toBe(1);
+      // The half-image must not have been kept. Cached, it would be served to every
+      // viewer thereafter under `immutable`, and the repair path only fires for a
+      // file that is MISSING — a broken-but-present entry has none.
+      expect(countCached()).toBe(0);
+    } finally {
+      await new Promise<void>((r) => raw.close(() => r()));
+    }
+  });
+
+  it('still caches a CHUNKED response, which framing does prove', async () => {
+    // ⚠ The other half, and the reason the guard is not simply "require
+    // Content-Length". A chunked body cut short does NOT emit `end` — node raises
+    // `aborted` and leaves `complete` false — so `ended` already proves completeness
+    // there. Refusing chunked outright would have declined to cache a great many
+    // perfectly ordinary origins to fix a hazard chunked does not have.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png' }); // no content-length → chunked
+      res.end(PNG);
+    };
+    const token = tokenFor('/chunked.png');
+    const first = await agent.get(`/api/link-preview/media/${token}`);
+    expect(first.status).toBe(200);
+    await whenStoresSettle();
+    expect(countCached()).toBe(1);
+
+    const second = await agent.get(`/api/link-preview/media/${token}`);
+    expect(originHits).toBe(1);
+    expect(Buffer.from(second.body).equals(PNG)).toBe(true);
+  });
+
+  it('re-fetches, rather than failing, when the cached file is deleted underneath it', async () => {
+    servePng();
+    const token = tokenFor('/vanishing.png');
+    await agent.get(`/api/link-preview/media/${token}`);
+    await whenStoresSettle();
+    expect(countCached()).toBe(1);
+
+    fs.rmSync(process.env.LURKER_PREVIEW_CACHE_DIR!, { recursive: true, force: true });
+
+    const after = await agent.get(`/api/link-preview/media/${token}`);
+    expect(after.status).toBe(200);
+    expect(Buffer.from(after.body).equals(PNG)).toBe(true);
+    expect(originHits).toBe(2);
+  });
+});

--- a/server/routes/linkPreview.cache.test.ts
+++ b/server/routes/linkPreview.cache.test.ts
@@ -281,6 +281,34 @@ describe('the byte cache, end to end', () => {
     expect(Buffer.from(second.body).equals(PNG)).toBe(true);
   });
 
+  it('leaves no temp file behind when the origin sends an empty body', async () => {
+    // ⚠⚠ A 200 with `Content-Length: 0` is framed, complete and cacheable-looking —
+    // it just has nothing in it. The commit path declined it without closing or
+    // aborting the writer, so the stream's fd stayed open and its `.tmp` stayed on
+    // disk: one leaked descriptor and one orphaned file PER REQUEST, invisible to
+    // eviction because the index never learned about them, and nothing sweeps the
+    // shard directories. Repeatable by any origin serving an empty image.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': '0' });
+      res.end();
+    };
+    const token = tokenFor('/empty.png');
+    await agent.get(`/api/link-preview/media/${token}`);
+    await whenStoresSettle();
+
+    expect(countCached()).toBe(0);
+    // ⚠ The assertion that bites. countCached() is 0 whether or not the temp file
+    // was cleaned up — the leak is only visible on disk.
+    const dir = process.env.LURKER_PREVIEW_CACHE_DIR!;
+    const stray: string[] = [];
+    if (fs.existsSync(dir)) {
+      for (const shard of fs.readdirSync(dir)) {
+        for (const f of fs.readdirSync(path.join(dir, shard))) stray.push(f);
+      }
+    }
+    expect(stray).toEqual([]);
+  });
+
   it('re-fetches, rather than failing, when the cached file is deleted underneath it', async () => {
     servePng();
     const token = tokenFor('/vanishing.png');

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -18,10 +18,10 @@ import { asyncHandler } from '../utils/asyncHandler.js';
 import { RequestThrottle } from '../middleware/rateLimit.js';
 import {
   byteCacheKey,
+  beginStore,
   cacheEnabled,
   cacheable,
   lookup,
-  store,
   trackPendingStore,
 } from '../services/previewCache/index.js';
 import {
@@ -419,17 +419,23 @@ router.get(
       }
       res.status(upstream.status === 206 ? 206 : 200);
 
-      // ⚠ Tee'd into memory ONLY when this response is a cache candidate, and the
-      // predicate is the same one that decided whether to look. `cacheable` refuses
-      // anything but a whole-object image, so what accumulates here is bounded by
-      // MAX_IMAGE_PROXY_BYTES (8 MB) rather than by MAX_MEDIA_PROXY_BYTES (64 MB) —
-      // buffering a video to cache it would trade the bandwidth this saves for
-      // memory it cannot bound, per request, with no ceiling but the pool size.
-      const collecting = cacheable(upstream.contentType, isRange) && upstream.status !== 206;
-      const chunks: Buffer[] = [];
-      // Registered as soon as we commit to collecting, and settled on every exit
-      // below. Only a test waits on it; see `trackPendingStore`.
-      const settleDecision = collecting ? trackPendingStore() : null;
+      // ⚠⚠ STREAMED to the cache, never buffered. Collecting the object first cost a
+      // copy in `chunks` plus a second at `Buffer.concat`, and the per-request 8 MB
+      // ceiling multiplied by mediaPool's 24 slots — ~192 MB steady state, ~384 MB
+      // transient, memory the uncached path never allocated, reachable by anyone
+      // authenticated opening 24 concurrent large images. The destination is a file,
+      // so there was never a reason for the bytes to sit in RSS on the way there.
+      //
+      // ⚠ `declared` when the origin gave one, the cap when it did not: the writer
+      // reserves room before the first byte, and under-reserving is how the ceiling
+      // gets crossed.
+      const wantCache = cacheable(upstream.contentType, isRange) && upstream.status !== 206;
+      const writer = wantCache
+        ? await beginStore(cacheKey, Number.isFinite(declared) ? declared : cap)
+        : null;
+      // Registered only once there is something to decide; settled on every exit
+      // below. Only a test waits on it — see `trackPendingStore`.
+      const settleDecision = writer ? trackPendingStore() : null;
 
       // Enforce the cap on bytes actually seen, not on the declared length — an
       // origin can omit Content-Length or lie about it.
@@ -442,7 +448,7 @@ router.get(
           res.destroy();
           return;
         }
-        if (collecting) chunks.push(chunk);
+        writer?.write(chunk);
       });
       stream.on('error', () => res.destroy());
 
@@ -461,8 +467,7 @@ router.get(
       // every path — finished, destroyed by the cap, or aborted by the client — so
       // the decision is always settled and never left dangling.
       stream.on('close', () => {
-        if (!collecting) return;
-        const body = Buffer.concat(chunks);
+        if (!writer) return;
         // ⚠⚠ THE BODY MUST BE FRAMED, and `ended` alone does not prove it. Node emits
         // `end` — with `complete` true — for a body framed only by the connection
         // closing, because to the protocol a closed connection IS the terminator: a
@@ -472,12 +477,6 @@ router.get(
         // `Connection: close` — exactly the condition RFC 7230 §3.3.3 lets an origin
         // omit framing under.
         //
-        // The live path can afford the ambiguity — it serves the bad bytes once, to
-        // one viewer, and self-repairs on the next request. The cache cannot: it
-        // returns them to everyone thereafter under `max-age=86400, immutable`,
-        // eviction is by size rather than age, and the repair path only fires for a
-        // file that is MISSING. Refusing to cache an unframed body costs those
-        // origins a re-fetch; caching a half-image costs everyone a broken picture.
         // ⚠ Chunked counts as framed: a chunked body cut short does NOT emit `end` —
         // node raises `aborted` and leaves `complete` false — so `ended` already
         // proves completeness there. Requiring a Content-Length outright would have
@@ -487,14 +486,15 @@ router.get(
           .toLowerCase()
           .includes('chunked');
         const framed = chunked || (Number.isFinite(declared) && declared === sent);
-        if (!ended || !framed || sent > cap || body.length === 0) {
-          settleDecision?.();
+        if (!ended || !framed || sent > cap) {
+          void writer.abort().finally(() => settleDecision?.());
           return;
         }
         // Deliberately not awaited: the reader already has their bytes, and a slow
-        // bucket must not hold the response open. Failures are the cache's own
-        // problem — `store` swallows them and simply stays a miss.
-        void store(cacheKey, body, upstream!.contentType)
+        // disk must not hold the response open. Failures are the cache's own problem
+        // — the writer swallows them and simply stays a miss.
+        void writer
+          .commit(upstream!.contentType)
           .catch(() => {})
           .finally(() => settleDecision?.());
       });

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -17,6 +17,14 @@ import { requireAuth } from '../middleware/auth.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { RequestThrottle } from '../middleware/rateLimit.js';
 import {
+  byteCacheKey,
+  cacheEnabled,
+  cacheable,
+  lookup,
+  store,
+  trackPendingStore,
+} from '../services/previewCache/index.js';
+import {
   resolvePreview,
   toDescriptor,
   proxyableContentType,
@@ -59,6 +67,32 @@ const resolveThrottle = new RequestThrottle({
  * day, so a re-scroll costs nothing) and far below what a loop does.
  */
 const mediaThrottle = new RequestThrottle({ windowMs: 60_000, maxRequests: 300 });
+
+/**
+ * The response headers every byte answer carries, live or cached.
+ *
+ * ⚠⚠ Extracted rather than duplicated, and that is the point. These are the
+ * security headers that keep a third party's bytes from being interpreted as
+ * anything but the media type we allowlisted, and the cache added a SECOND way to
+ * send a response body. Two copies would drift, and the copy that drifts is the
+ * one nobody looks at — a cached image served without `nosniff` is the same
+ * vulnerability as an uncached one, arrived at by omission.
+ */
+function applyMediaHeaders(res: Response, contentType: string): void {
+  res.setHeader('Content-Type', contentType);
+  // Belt and braces against the response being interpreted as anything other
+  // than the media type we just allowlisted.
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
+  // No filename: it would come from a URL someone else controls.
+  res.setHeader('Content-Disposition', 'inline');
+  res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+  // The token is a pure function of the URL, so a given token always denotes
+  // the same bytes — safe to cache hard, and it's what keeps a scroll through
+  // an image-heavy channel from re-proxying on every pass. `private` because
+  // the response travels over an authenticated session.
+  res.setHeader('Cache-Control', 'private, max-age=86400, immutable');
+}
 
 /**
  * Byte fetches in flight across the whole instance.
@@ -206,6 +240,16 @@ router.get(
       return;
     }
 
+    // ⚠ The cache is consulted before the fetch, but NOT before the pool. An
+    // earlier version returned a hit ahead of `mediaPool.acquire()` on the
+    // reasoning that a hit does no outbound work — true of sockets and DNS, and
+    // inverted for memory. A hit reads the whole object into RSS, so bypassing the
+    // only concurrency bound let one session at the 300/min throttle ceiling park
+    // ~300 x 8 MB while the pool sat idle, and it got WORSE the warmer the cache
+    // was. The pool bounds a resource the cache also spends.
+    const isRange = typeof req.headers.range === 'string' && req.headers.range !== '';
+    const cacheKey = byteCacheKey(url.toString());
+
     if (!(await mediaPool.acquire())) {
       // Saturated, not broken. 503 + Retry-After so a media element backs off and retries,
       // rather than 404, which an <img> treats as a permanent verdict and never re-asks.
@@ -257,6 +301,22 @@ router.get(
     if (res.destroyed) {
       release();
       return;
+    }
+
+    // ⚠ Inside the pool, and after `release` is wired to the response's `close`, so
+    // a hit gives its slot back the same way a fetch does. `lookup` never throws —
+    // that is this module's headline promise, and it was a claim before it was true:
+    // `lookupCached` takes a WAL write lock for its `last_access` touch, and a
+    // SQLITE_BUSY thrown from here used to escape a `try` that had not opened yet
+    // and 500 an image request that would have succeeded with caching off.
+    if (cacheEnabled() && !isRange) {
+      const hit = await lookup(cacheKey);
+      if (hit) {
+        applyMediaHeaders(res, hit.contentType);
+        res.setHeader('Content-Length', String(hit.body.length));
+        res.status(200).end(hit.body);
+        return;
+      }
     }
 
     try {
@@ -329,19 +389,7 @@ router.get(
         return;
       }
 
-      res.setHeader('Content-Type', upstream.contentType);
-      // Belt and braces against the response being interpreted as anything other
-      // than the media type we just allowlisted.
-      res.setHeader('X-Content-Type-Options', 'nosniff');
-      res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
-      // No filename: it would come from a URL someone else controls.
-      res.setHeader('Content-Disposition', 'inline');
-      res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
-      // The token is a pure function of the URL, so a given token always denotes
-      // the same bytes — safe to cache hard, and it's what keeps a scroll through
-      // an image-heavy channel from re-proxying on every pass. `private` because
-      // the response travels over an authenticated session.
-      res.setHeader('Cache-Control', 'private, max-age=86400, immutable');
+      applyMediaHeaders(res, upstream.contentType);
 
       // Range plumbing, so a media element can seek. ⚠ Only claimed when the origin actually
       // demonstrated it: advertising `Accept-Ranges: bytes` for a source that ignores Range
@@ -371,6 +419,18 @@ router.get(
       }
       res.status(upstream.status === 206 ? 206 : 200);
 
+      // ⚠ Tee'd into memory ONLY when this response is a cache candidate, and the
+      // predicate is the same one that decided whether to look. `cacheable` refuses
+      // anything but a whole-object image, so what accumulates here is bounded by
+      // MAX_IMAGE_PROXY_BYTES (8 MB) rather than by MAX_MEDIA_PROXY_BYTES (64 MB) —
+      // buffering a video to cache it would trade the bandwidth this saves for
+      // memory it cannot bound, per request, with no ceiling but the pool size.
+      const collecting = cacheable(upstream.contentType, isRange) && upstream.status !== 206;
+      const chunks: Buffer[] = [];
+      // Registered as soon as we commit to collecting, and settled on every exit
+      // below. Only a test waits on it; see `trackPendingStore`.
+      const settleDecision = collecting ? trackPendingStore() : null;
+
       // Enforce the cap on bytes actually seen, not on the declared length — an
       // origin can omit Content-Length or lie about it.
       let sent = 0;
@@ -380,9 +440,64 @@ router.get(
         if (sent > cap) {
           stream.destroy();
           res.destroy();
+          return;
         }
+        if (collecting) chunks.push(chunk);
       });
       stream.on('error', () => res.destroy());
+
+      // ⚠⚠ `end` is what means "the origin sent a COMPLETE object", and it is the only
+      // thing that may authorise a store. A body cut short is still a stream of real
+      // bytes — cached, it becomes a permanently broken image served to everyone
+      // afterwards and held by their browsers for a day. `close` fires either way,
+      // which is why it cannot be the trigger, and why this is latched rather than
+      // inferred afterwards.
+      let ended = false;
+      stream.on('end', () => {
+        ended = true;
+      });
+
+      // ⚠ DECIDED on `close`, because that is the one event guaranteed to fire on
+      // every path — finished, destroyed by the cap, or aborted by the client — so
+      // the decision is always settled and never left dangling.
+      stream.on('close', () => {
+        if (!collecting) return;
+        const body = Buffer.concat(chunks);
+        // ⚠⚠ THE BODY MUST BE FRAMED, and `ended` alone does not prove it. Node emits
+        // `end` — with `complete` true — for a body framed only by the connection
+        // closing, because to the protocol a closed connection IS the terminator: a
+        // truncated one is indistinguishable from a finished one. This route makes
+        // that the common case rather than an exotic one, since `linkFetch` runs its
+        // agents `keepAlive: false` and every request therefore carries
+        // `Connection: close` — exactly the condition RFC 7230 §3.3.3 lets an origin
+        // omit framing under.
+        //
+        // The live path can afford the ambiguity — it serves the bad bytes once, to
+        // one viewer, and self-repairs on the next request. The cache cannot: it
+        // returns them to everyone thereafter under `max-age=86400, immutable`,
+        // eviction is by size rather than age, and the repair path only fires for a
+        // file that is MISSING. Refusing to cache an unframed body costs those
+        // origins a re-fetch; caching a half-image costs everyone a broken picture.
+        // ⚠ Chunked counts as framed: a chunked body cut short does NOT emit `end` —
+        // node raises `aborted` and leaves `complete` false — so `ended` already
+        // proves completeness there. Requiring a Content-Length outright would have
+        // refused to cache every chunked origin, which is a great many of them, to
+        // fix a hazard chunked does not have.
+        const chunked = String(upstream!.headers['transfer-encoding'] ?? '')
+          .toLowerCase()
+          .includes('chunked');
+        const framed = chunked || (Number.isFinite(declared) && declared === sent);
+        if (!ended || !framed || sent > cap || body.length === 0) {
+          settleDecision?.();
+          return;
+        }
+        // Deliberately not awaited: the reader already has their bytes, and a slow
+        // bucket must not hold the response open. Failures are the cache's own
+        // problem — `store` swallows them and simply stays a miss.
+        void store(cacheKey, body, upstream!.contentType)
+          .catch(() => {})
+          .finally(() => settleDecision?.());
+      });
       stream.pipe(res);
     } catch {
       // Blocked address, timeout, reset — all the same to a caller waiting on an

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -257,7 +257,10 @@ function clamp(value: string | undefined, max: number): string | null {
  * media scrubbing), and letting one in here would reintroduce the same hole
  * through a different door.
  */
-function kindForContentType(contentType: string): PreviewKind | null {
+/** ⚠ Exported so the byte cache can ask the SAME allowlist rather than keeping a
+ *  second copy. `image/svg+xml` is refused here and nowhere else, and a duplicated
+ *  rule is how it nearly got served under our own origin once already. */
+export function kindForContentType(contentType: string): PreviewKind | null {
   if (contentType === 'image/svg+xml') return null;
   if (contentType.startsWith('image/')) return 'image';
   if (contentType.startsWith('video/')) return 'video';

--- a/server/services/previewCache/cache.test.ts
+++ b/server/services/previewCache/cache.test.ts
@@ -143,6 +143,68 @@ describe('preview byte cache — local', () => {
     expect(await mod.lookup('1'.repeat(64))).not.toBeNull();
   });
 
+  it('settles rather than hanging when the write stream errors', async () => {
+    // A write stream that fails at open (ENOTDIR here — the shard directory is
+    // replaced by a FILE, which fails the same way for everyone on every platform)
+    // must settle and store nothing, rather than leaving the caller waiting.
+    //
+    // ⚠ HONEST SCOPE: this does NOT distinguish `handle.end(cb)` from waiting on
+    // `close`, which is what the implementation was changed to. Node's docs say
+    // end's callback "may or may not" be called when a stream errors, and `close`
+    // is the event that always fires — but on this runtime the callback did fire
+    // for every errno reachable from here, so the mutation stays green. The change
+    // is defensive against documented uncertainty, not against a reproduced hang,
+    // and saying so is better than a test comment implying otherwise.
+    const key = 'c'.repeat(64);
+    const cfg = mod.cacheConfig();
+    if (cfg.mode !== 'local') throw new Error('unreachable');
+    const shard = path.dirname(mod.objectPath(cfg, key));
+    fs.mkdirSync(cfg.dir, { recursive: true });
+    fs.writeFileSync(shard, 'not a directory');
+
+    try {
+      // ⚠ The timeout is the assertion. Before the fix this never resolved at all,
+      // and a hanging promise reads as a passing test right up until the suite
+      // times out with no useful message.
+      const settled = await Promise.race([
+        mod.store(key, bytes(64), 'image/png'),
+        new Promise<'HUNG'>((r) => setTimeout(() => r('HUNG'), 3000)),
+      ]);
+      expect(settled).toBe(false);
+      expect(dbmod.countCached()).toBe(0);
+    } finally {
+      fs.rmSync(shard, { force: true });
+    }
+  });
+
+  it('stores timestamps as ISO-8601 with Z, which is what Date.parse needs', async () => {
+    // ⚠⚠ MEASURED, not stylistic. `datetime('now')` yields "YYYY-MM-DD HH:MM:SS",
+    // which is not ISO — so V8 parses it as LOCAL time. Verified on this machine:
+    // SQLite stored 08:01:12 (UTC) and `Date.parse` read it back as 15:01:12Z, a
+    // seven-hour skew straight into the age bound below. It is also the format
+    // `link_previews` already uses (NOW_ISO), because ISO-with-Z is
+    // lexicographically ordered and so compares correctly as TEXT in SQL.
+    //
+    // ⚠ The age test below CANNOT see this: it backdates by eight days against a
+    // seven-day TTL, and no timezone offset is large enough to flip that. The format
+    // is the thing to assert.
+    const key = '5'.repeat(64);
+    await mod.store(key, bytes(32), 'image/png');
+    const { default: db } = await import('../../db/index.js');
+    const row = db
+      .prepare<[string], { created_at: string; last_access: string }>(
+        'SELECT created_at, last_access FROM preview_cache WHERE cache_key = ?',
+      )
+      .get(key);
+    const ISO_Z = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+    // ⚠ The raw value, not a labelled one — a prefix defeats the `^` anchor and the
+    // pattern then matches anything ending in a timestamp. (It did, briefly.)
+    expect(row?.created_at).toMatch(ISO_Z);
+    expect(row?.last_access).toMatch(ISO_Z);
+    // ...and it round-trips to the instant it actually was, within a minute.
+    expect(Math.abs(Date.now() - Date.parse(row!.created_at))).toBeLessThan(60_000);
+  });
+
   it('stops serving an entry once it is older than the metadata TTL', async () => {
     // ⚠ Eviction is by PRESSURE, so without an age bound an image at a stable
     // address that changed underneath us — an avatar, a `latest.png` — is served

--- a/server/services/previewCache/cache.test.ts
+++ b/server/services/previewCache/cache.test.ts
@@ -126,6 +126,71 @@ describe('preview byte cache — local', () => {
     expect(await mod.lookup('3'.repeat(64))).not.toBeNull();
   });
 
+  it('refuses an object bigger than the whole ceiling, without wiping the cache', async () => {
+    // ⚠⚠ `evictLocal` loops toward a total it can never reach when the incoming
+    // object alone exceeds the ceiling — so it throws away up to a full batch of
+    // LIVE entries and then stores the oversized object anyway. A small ceiling with
+    // large images therefore means every single store wipes the cache and the hit
+    // rate collapses to nothing, each miss paying a full eviction pass on the shared
+    // connection for the privilege.
+    await mod.store('1'.repeat(64), bytes(1024), 'image/png');
+    expect(dbmod.countCached()).toBe(1);
+
+    // The ceiling here is 2048; this is bigger than all of it.
+    expect(await mod.store('9'.repeat(64), bytes(4096), 'image/png')).toBe(false);
+
+    expect(dbmod.countCached()).toBe(1);
+    expect(await mod.lookup('1'.repeat(64))).not.toBeNull();
+  });
+
+  it('stops serving an entry once it is older than the metadata TTL', async () => {
+    // ⚠ Eviction is by PRESSURE, so without an age bound an image at a stable
+    // address that changed underneath us — an avatar, a `latest.png` — is served
+    // from disk indefinitely under `max-age=86400, immutable`, long after the
+    // metadata row for it has re-resolved. Before this cache existed the staleness
+    // window was a day; unbounded is a regression, not a feature.
+    const key = '7'.repeat(64);
+    await mod.store(key, bytes(64), 'image/png');
+    expect(await mod.lookup(key)).not.toBeNull();
+
+    const { default: db } = await import('../../db/index.js');
+    db.prepare(`UPDATE preview_cache SET created_at = datetime('now', '-8 days')`).run();
+
+    expect(await mod.lookup(key)).toBeNull();
+    // ...and it is cleared out rather than re-checked on every future request.
+    expect(dbmod.countCached()).toBe(0);
+    const cfg = mod.cacheConfig();
+    if (cfg.mode !== 'local') throw new Error('unreachable');
+    expect(fs.existsSync(mod.objectPath(cfg, key))).toBe(false);
+  });
+
+  it('keeps the index row when a read fails for a reason other than ENOENT', async () => {
+    // ⚠⚠ GONE and BROKEN are different. Both are a miss to the caller, so an earlier
+    // version collapsed every errno to null and the caller forgot the row for all of
+    // them — a transient EMFILE (24 concurrent reads is within this pool's own
+    // budget) or an EACCES after a permissions change would delete the index row
+    // while the object stayed on disk. That is an orphan eviction can never count
+    // and lookup can never find, in a module whose whole premise is that the index
+    // is how we know what exists.
+    //
+    // ⚠ EISDIR rather than chmod: a permissions test passes vacuously when the suite
+    // runs as root, which it does in plenty of containers. A directory where a file
+    // belongs fails the same way for everyone.
+    const key = '8'.repeat(64);
+    await mod.store(key, bytes(128), 'image/png');
+    const cfg = mod.cacheConfig();
+    if (cfg.mode !== 'local') throw new Error('unreachable');
+    const at = mod.objectPath(cfg, key);
+    fs.rmSync(at);
+    fs.mkdirSync(at);
+
+    expect(await mod.lookup(key)).toBeNull();
+    // The row SURVIVES: we could not read it, which is not the same as it being gone.
+    expect(dbmod.countCached()).toBe(1);
+
+    fs.rmdirSync(at);
+  });
+
   it('leaves no file behind for an entry it evicted', async () => {
     for (const n of ['1', '2', '3', '4']) await mod.store(n.repeat(64), bytes(1024), 'image/png');
     const onDisk: string[] = [];
@@ -153,7 +218,7 @@ describe('preview byte cache — local', () => {
   });
 
   it('MISSES a file that is present but the wrong size, and clears it out', async () => {
-    // ⚠⚠ `writeLocal` does not fsync before renaming, so a power loss or a killed
+    // ⚠⚠ The writer does not fsync before renaming, so a power loss or a killed
     // container can leave a short file under a row that claims the full length.
     // `readFile` succeeds, nothing throws, and the stump would be served with
     // `max-age=86400, immutable` — a permanently broken image every viewer holds for

--- a/server/services/previewCache/cache.test.ts
+++ b/server/services/previewCache/cache.test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The cache as the route uses it: store, then look up, and everything that can
+// go wrong in between. Against a real database and a real directory — the index
+// and the bytes living in two places IS the design, so a suite that mocked
+// either half would be testing neither.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { setupTestDb } from '../../test-utils/testApp.js';
+
+// ⚠ Delegates to the real module until `dbThrows` is set, so every other test in
+// this file runs against a real database and only the fail-soft case sees a
+// failure. Patching `db.prepare` used to do this job and stopped working the day
+// the statements were hoisted to module scope — which is exactly right for the
+// hot path, and left the test asserting nothing.
+let dbThrows = false;
+vi.mock('../../db/previewCache.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db/previewCache.js')>();
+  const boom = () => {
+    throw new Error('SQLITE_BUSY: database is locked');
+  };
+  return {
+    ...actual,
+    lookupCached: (key: string) => (dbThrows ? boom() : actual.lookupCached(key)),
+    recordCached: (entry: Parameters<typeof actual.recordCached>[0]) =>
+      dbThrows ? boom() : actual.recordCached(entry),
+    cachedBytes: (backend: string) => (dbThrows ? boom() : actual.cachedBytes(backend)),
+  };
+});
+
+const ctx = setupTestDb('preview-cache');
+const CACHE_DIR = path.join(ctx.tmpDir, 'preview-cache');
+
+let mod: typeof import('./index.js');
+let dbmod: typeof import('../../db/previewCache.js');
+
+beforeAll(async () => {
+  process.env.LURKER_PREVIEW_CACHE_MODE = 'local';
+  process.env.LURKER_PREVIEW_CACHE_DIR = CACHE_DIR;
+  // Two 1 KB objects fit; the third forces an eviction.
+  process.env.LURKER_PREVIEW_CACHE_MAX_BYTES = '2048';
+  await import('../../db/index.js');
+  dbmod = await import('../../db/previewCache.js');
+  mod = await import('./index.js');
+});
+
+afterAll(() => {
+  delete process.env.LURKER_PREVIEW_CACHE_MODE;
+  delete process.env.LURKER_PREVIEW_CACHE_DIR;
+  delete process.env.LURKER_PREVIEW_CACHE_MAX_BYTES;
+  ctx.cleanup();
+});
+
+beforeEach(async () => {
+  const { default: db } = await import('../../db/index.js');
+  db.prepare('DELETE FROM preview_cache').run();
+  fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+  mod.resetCacheConfigForTests();
+});
+
+const bytes = (n: number, fill = 0x61) => Buffer.alloc(n, fill);
+
+describe('preview byte cache — local', () => {
+  it('stores bytes and gives them back verbatim', async () => {
+    const body = bytes(1024, 0x7f);
+    expect(await mod.store('a'.repeat(64), body, 'image/png')).toBe(true);
+
+    const hit = await mod.lookup('a'.repeat(64));
+    expect(hit?.kind).toBe('buffer');
+    if (hit?.kind !== 'buffer') throw new Error('unreachable');
+    // ⚠ Byte equality, not length. A cache that returns the right NUMBER of wrong
+    // bytes is worse than one that misses, and it would render as a broken image
+    // that the browser then holds for a day.
+    expect(hit.body.equals(body)).toBe(true);
+    expect(hit.contentType).toBe('image/png');
+  });
+
+  it('shards the directory instead of piling everything in one', async () => {
+    // A million files in one directory is a directory a filesystem walks badly and
+    // an operator cannot list. Two hex characters cost nothing from a key that is
+    // already a digest.
+    const { objectPath } = await import('./local.js');
+    const cfg = mod.cacheConfig();
+    if (cfg.mode !== 'local') throw new Error('unreachable');
+    const key = 'ab' + 'c'.repeat(62);
+    expect(path.dirname(objectPath(cfg, key))).toBe(path.join(CACHE_DIR, 'ab'));
+  });
+
+  it('MISSES when the index says yes but the bytes are gone, and repairs itself', async () => {
+    // ⚠⚠ The state this design has to survive: the row and the file live in
+    // different places, so a wiped volume, a restored backup or a manual `rm`
+    // leaves rows that claim a hit. Without the repair, every one of them costs a
+    // failed read before the origin fetch that was going to happen anyway — forever,
+    // because nothing else ever revisits the row.
+    const key = 'd'.repeat(64);
+    await mod.store(key, bytes(512), 'image/gif');
+    expect(dbmod.countCached()).toBe(1);
+
+    fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+
+    expect(await mod.lookup(key)).toBeNull();
+    expect(dbmod.countCached()).toBe(0);
+  });
+
+  it('evicts the coldest entry once the ceiling is passed', async () => {
+    // Ceiling is 2048; three 1 KB objects cannot all fit.
+    await mod.store('1'.repeat(64), bytes(1024), 'image/png');
+    await mod.store('2'.repeat(64), bytes(1024), 'image/png');
+    expect(dbmod.cachedBytes('local')).toBe(2048);
+
+    await mod.store('3'.repeat(64), bytes(1024), 'image/png');
+
+    // ⚠⚠ EXACTLY two, not "fewer than three". `toBeLessThan(3)` could not tell
+    // "evicted the one it had to" from "evicted two" — changing the loop's `<=` to
+    // `<` over-evicts by one and left the suite green, which is a cache throwing
+    // away a live entry on every store once it is near its ceiling.
+    expect(dbmod.countCached()).toBe(2);
+    expect(dbmod.cachedBytes('local')).toBe(2048);
+    // ⚠ The budget, not a named victim: `last_access` has one-second resolution and
+    // these are written in the same tick, so which of the first two is coldest is
+    // genuinely a tie — demanding a specific key would assert SQLite's tie-break.
+    // The newest surviving is the only ordering guarantee that matters.
+    expect(await mod.lookup('3'.repeat(64))).not.toBeNull();
+  });
+
+  it('leaves no file behind for an entry it evicted', async () => {
+    for (const n of ['1', '2', '3', '4']) await mod.store(n.repeat(64), bytes(1024), 'image/png');
+    const onDisk: string[] = [];
+    for (const shard of fs.readdirSync(CACHE_DIR)) {
+      for (const f of fs.readdirSync(path.join(CACHE_DIR, shard))) onDisk.push(f);
+    }
+    // ⚠ Files and rows must agree. Unlinking after forgetting the row would leak a
+    // file nothing remembers, and nothing could ever find it again — the index IS
+    // how we know what exists.
+    expect(onDisk.length).toBe(dbmod.countCached());
+    // ...and no temp files survived either.
+    expect(onDisk.some((f) => f.endsWith('.tmp'))).toBe(false);
+  });
+
+  it('forgets, not just skips, a row left by another backend', async () => {
+    // ⚠ A row whose backend no longer matches is unreachable AND uncounted if it is
+    // merely skipped — its bytes sit on the volume forever with nothing able to name
+    // them, because the index is how we know what exists. Dropping the row is what
+    // lets a later store reclaim the space.
+    const key = 'e'.repeat(64);
+    await mod.store(key, bytes(64), 'image/png');
+    dbmod.recordCached({ key, backend: 'somewhere-else', contentType: 'image/png', size: 64 });
+    expect(await mod.lookup(key)).toBeNull();
+    expect(dbmod.countCached()).toBe(0);
+  });
+
+  it('MISSES a file that is present but the wrong size, and clears it out', async () => {
+    // ⚠⚠ `writeLocal` does not fsync before renaming, so a power loss or a killed
+    // container can leave a short file under a row that claims the full length.
+    // `readFile` succeeds, nothing throws, and the stump would be served with
+    // `max-age=86400, immutable` — a permanently broken image every viewer holds for
+    // a day. A zero-length Buffer is truthy, so a presence test misses it too.
+    const key = 'f'.repeat(64);
+    await mod.store(key, bytes(1024), 'image/png');
+    const cfg = mod.cacheConfig();
+    if (cfg.mode !== 'local') throw new Error('unreachable');
+    fs.writeFileSync(mod.objectPath(cfg, key), Buffer.alloc(10));
+
+    expect(await mod.lookup(key)).toBeNull();
+    expect(dbmod.countCached()).toBe(0);
+    expect(fs.existsSync(mod.objectPath(cfg, key))).toBe(false);
+  });
+
+  it('never throws out of lookup or store, whatever the database does', async () => {
+    // ⚠⚠ The module's headline promise, and it was a CLAIM before it was true.
+    // `lookupCached` takes a WAL write lock for its `last_access` touch — proven to
+    // block even when it matches zero rows — and a SQLITE_BUSY thrown from there
+    // escaped into the route, past a `try` that did not open for another seventy
+    // lines, and 500'd an image request that would have succeeded with caching
+    // switched off. A cache that can break the thing it accelerates is worse than
+    // no cache; the guard belongs in this module, where the promise is made.
+    dbThrows = true;
+    try {
+      await expect(mod.lookup('a'.repeat(64))).resolves.toBeNull();
+      await expect(mod.store('b'.repeat(64), bytes(16), 'image/png')).resolves.toBe(false);
+    } finally {
+      dbThrows = false;
+    }
+  });
+});
+
+describe('preview byte cache — what is worth caching', () => {
+  it('takes whole images and refuses everything else', () => {
+    expect(mod.cacheable('image/png', false)).toBe(true);
+    expect(mod.cacheable('image/webp', false)).toBe(true);
+    // ⚠ Video and audio are excluded on purpose: 64 MB against images' 8 MB, and
+    // they are read by RANGE, so one seek is many requests for one object and a
+    // cached copy would have to answer partial reads. Buffering those per miss
+    // trades bandwidth for unbounded memory.
+    expect(mod.cacheable('video/mp4', false)).toBe(false);
+    expect(mod.cacheable('audio/mpeg', false)).toBe(false);
+    expect(mod.cacheable('text/html', false)).toBe(false);
+    expect(mod.cacheable(undefined, false)).toBe(false);
+    // ⚠ A range request is passed straight through. Serving a whole object to a
+    // request that asked for bytes 100-200 is a correctness bug, not a slow path.
+    expect(mod.cacheable('image/png', true)).toBe(false);
+  });
+
+  it('is off, and answers nothing, when the mode is off', async () => {
+    process.env.LURKER_PREVIEW_CACHE_MODE = 'off';
+    mod.resetCacheConfigForTests();
+    try {
+      expect(mod.cacheEnabled()).toBe(false);
+      expect(mod.cacheable('image/png', false)).toBe(false);
+      expect(await mod.store('f'.repeat(64), bytes(16), 'image/png')).toBe(false);
+      expect(await mod.lookup('f'.repeat(64))).toBeNull();
+    } finally {
+      process.env.LURKER_PREVIEW_CACHE_MODE = 'local';
+      mod.resetCacheConfigForTests();
+    }
+  });
+});

--- a/server/services/previewCache/config.test.ts
+++ b/server/services/previewCache/config.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveCacheConfig } from './config.js';
+
+const KEYS = [
+  'LURKER_PREVIEW_CACHE_MODE',
+  'LURKER_PREVIEW_CACHE_DIR',
+  'LURKER_PREVIEW_CACHE_MAX_BYTES',
+];
+
+afterEach(() => {
+  for (const k of KEYS) delete process.env[k];
+});
+
+describe('resolveCacheConfig', () => {
+  it('is off when nothing is set, which is the shipped default', () => {
+    expect(resolveCacheConfig().mode).toBe('off');
+    process.env.LURKER_PREVIEW_CACHE_MODE = 'off';
+    expect(resolveCacheConfig().mode).toBe('off');
+  });
+
+  it('rejects an unknown mode rather than guessing at it, and says so', () => {
+    // ⚠⚠ `s3` lands here on purpose while it is split out. An operator who sets it
+    // gets a warning and a working uncached instance — never a half-configured
+    // cache that quietly behaves like something else.
+    for (const mode of ['r2', 's3', 'bucket']) {
+      process.env.LURKER_PREVIEW_CACHE_MODE = mode;
+      const warnings: string[] = [];
+      expect(`${mode} → ${resolveCacheConfig((m) => warnings.push(m)).mode}`).toBe(`${mode} → off`);
+      expect(warnings.join(' ')).toMatch(/caching is OFF/);
+    }
+  });
+
+  it('defaults the local directory and ceiling', () => {
+    process.env.LURKER_PREVIEW_CACHE_MODE = 'local';
+    const cfg = resolveCacheConfig();
+    if (cfg.mode !== 'local') throw new Error('unreachable');
+    expect(cfg.dir).toMatch(/preview-cache$/);
+    expect(cfg.maxBytes).toBe(2 * 1024 * 1024 * 1024);
+  });
+
+  it('takes a plain byte count, and refuses anything that is not one', () => {
+    process.env.LURKER_PREVIEW_CACHE_MODE = 'local';
+    const DEFAULT = 2 * 1024 * 1024 * 1024;
+
+    process.env.LURKER_PREVIEW_CACHE_MAX_BYTES = '1048576';
+    const set = resolveCacheConfig();
+    if (set.mode !== 'local') throw new Error('unreachable');
+    expect(set.maxBytes).toBe(1048576);
+
+    // ⚠ `parseInt` would take '2GB' and hand back 2 — a two-byte cache that evicts
+    // everything it stores and reads as "caching is broken". A number past
+    // MAX_SAFE_INTEGER is refused for the mirror-image reason: the eviction
+    // arithmetic stops being exact, and a silently wrong answer about whether we
+    // are over the ceiling is worse than no answer.
+    for (const bad of ['2GB', '-1', '0', 'lots', '1.5', '1e9', '99999999999999999999']) {
+      process.env.LURKER_PREVIEW_CACHE_MAX_BYTES = bad;
+      const warnings: string[] = [];
+      const cfg = resolveCacheConfig((m) => warnings.push(m));
+      if (cfg.mode !== 'local') throw new Error('unreachable');
+      expect(`${bad} → ${cfg.maxBytes}`).toBe(`${bad} → ${DEFAULT}`);
+      // ...and never silently, or an operator debugs a cache that looks like it is
+      // ignoring the setting they just wrote.
+      expect(`${bad}: ${warnings.length > 0 ? 'warned' : 'silent'}`).toBe(`${bad}: warned`);
+    }
+  });
+
+  it('honours an explicit cache directory', () => {
+    process.env.LURKER_PREVIEW_CACHE_MODE = 'local';
+    process.env.LURKER_PREVIEW_CACHE_DIR = '/tmp/somewhere-else';
+    const cfg = resolveCacheConfig();
+    if (cfg.mode !== 'local') throw new Error('unreachable');
+    expect(cfg.dir).toBe('/tmp/somewhere-else');
+  });
+});

--- a/server/services/previewCache/config.ts
+++ b/server/services/previewCache/config.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// How the preview byte cache is configured, and the one place that decides
+// whether it is on at all.
+//
+// ⚠ ENV, not instance settings, and that is a deliberate deviation from #681.
+// That issue asks for `previews.cache.mode` in `instance_settings` with an admin
+// form beside the uploader config, which is the right long-term surface. Every
+// other operator-level knob this app has — LURKER_LINK_PREVIEWS,
+// LURKER_SECRET_KEY, DATABASE_PATH — is already an env var, so this matches what
+// a self-hoster is already doing. `resolveCacheConfig` is the seam the admin
+// surface slots into; nothing above this module knows where the values came from.
+//
+// ⚠ "It would need somewhere to keep a secret" is NOT one of the reasons, and is
+// worth naming so nobody adds it: `uploader_config` already stores S3 credentials
+// encrypted behind a generic admin form, and `local` has no secret at all. The
+// reason is the one above — this knob's neighbours are env vars.
+
+import path from 'path';
+import { resolveDataDir } from '../../utils/dataDir.js';
+
+export type CacheMode = 'off' | 'local';
+
+export interface LocalCacheConfig {
+  mode: 'local';
+  dir: string;
+  /** Ceiling for the cache directory. Eviction runs BEFORE a write that would exceed it. */
+  maxBytes: number;
+}
+
+export type CacheConfig = { mode: 'off' } | LocalCacheConfig;
+
+/** 2 GiB. Big enough that a normal instance never evicts, small enough to notice. */
+const DEFAULT_LOCAL_MAX_BYTES = 2 * 1024 * 1024 * 1024;
+
+function env(name: string): string {
+  return (process.env[name] ?? '').trim();
+}
+
+/**
+ * ⚠ Misconfiguration resolves to `off`, and says so once, rather than throwing.
+ *
+ * This is a cache. A bad value is a reason to stop caching, never a reason for a
+ * server not to boot or for a link preview to stop rendering — the uncached path
+ * is a complete, working feature, which is what makes failing soft right here and
+ * wrong for, say, a database path.
+ */
+export function resolveCacheConfig(warn: (msg: string) => void = defaultWarn): CacheConfig {
+  const mode = env('LURKER_PREVIEW_CACHE_MODE').toLowerCase();
+  if (mode === '' || mode === 'off') return { mode: 'off' };
+
+  if (mode === 'local') {
+    const raw = env('LURKER_PREVIEW_CACHE_MAX_BYTES');
+    // ⚠ Digits only, and a SAFE integer. `parseInt` would take '2GB' and hand back
+    // 2 — a two-byte cache that evicts everything it stores and reads as "caching
+    // is broken". The upper bound matters for the same reason in the other
+    // direction: past MAX_SAFE_INTEGER the eviction arithmetic stops being exact,
+    // and a silently wrong answer about whether we are over the ceiling is worse
+    // than refusing the value.
+    const parsed = /^\d{1,19}$/.test(raw) ? Number(raw) : Number.NaN;
+    const usable = Number.isSafeInteger(parsed) && parsed > 0;
+    if (raw !== '' && !usable) {
+      warn(
+        `[preview-cache] LURKER_PREVIEW_CACHE_MAX_BYTES="${raw}" is not a usable byte count — ` +
+          `falling back to ${DEFAULT_LOCAL_MAX_BYTES}.`,
+      );
+    }
+    return {
+      mode: 'local',
+      dir: env('LURKER_PREVIEW_CACHE_DIR') || path.join(resolveDataDir(), 'preview-cache'),
+      maxBytes: usable ? parsed : DEFAULT_LOCAL_MAX_BYTES,
+    };
+  }
+
+  // ⚠ `s3` is deliberately NOT here yet, and this is where somebody will look for
+  // it. It was built alongside `local` and split back out, because serving cached
+  // bytes from a public CDN is a different feature wearing the same word: it needs
+  // a repair path for objects a lifecycle rule has deleted, its own hardening
+  // story (headers on a 302 do not apply to the redirect target), and an answer
+  // for native clients that forward `Authorization` across redirects. None of that
+  // is local's problem, and bundling them let the untested half hide behind the
+  // tested one.
+  warn(`[preview-cache] unknown LURKER_PREVIEW_CACHE_MODE "${mode}" — caching is OFF.`);
+  return { mode: 'off' };
+}
+
+function defaultWarn(msg: string): void {
+  console.warn(msg);
+}

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -24,7 +24,7 @@ import crypto from 'crypto';
 import { lookupCached, recordCached, forget } from '../../db/previewCache.js';
 import { kindForContentType } from '../linkPreview.js';
 import { resolveCacheConfig, type CacheConfig } from './config.js';
-import { evictLocal, objectPath, readLocal, removeLocal, writeLocal } from './local.js';
+import { evictLocal, objectPath, openLocalWrite, readLocal, removeLocal } from './local.js';
 
 export type { CacheConfig, CacheMode } from './config.js';
 export { objectPath };
@@ -36,6 +36,25 @@ export interface BufferHit {
   contentType: string;
 }
 export type CacheHit = BufferHit;
+
+/** A store in progress. The route feeds it the bytes it is already streaming. */
+export interface StoreWriter {
+  write(chunk: Buffer): void;
+  commit(contentType: string): Promise<boolean>;
+  abort(): Promise<void>;
+}
+
+/**
+ * How long a cached object may be served before it is re-fetched.
+ *
+ * ⚠ Deliberately the same seven days as `link_previews`' OK_TTL. The two caches
+ * describe the same URL, and letting the bytes outlive the metadata means an image
+ * that changed at a stable address — an avatar, a `latest.png` — is served from
+ * disk long after the record for it was re-resolved. Eviction is by PRESSURE, so
+ * without an age bound the staleness window is unbounded; before this cache
+ * existed it was a day.
+ */
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
  * The cache key for one URL's BYTES.
@@ -120,7 +139,7 @@ export function cacheable(contentType: string | undefined, isRangeRequest: boole
  * forever, costing a failed read before the origin fetch that was going to happen
  * anyway, because nothing else ever revisits the row.
  *
- * ⚠⚠ The SIZE is checked, not just presence. `writeLocal` does not fsync before
+ * ⚠⚠ The SIZE is checked, not just presence. the writer does not fsync before
  * renaming, so a power loss or a killed container can leave a short file under a
  * row (WAL-durable) claiming the full length. `readFile` then succeeds, nothing
  * throws, and the stump is served with `max-age=86400, immutable` — a permanently
@@ -142,13 +161,36 @@ export async function lookup(key: string): Promise<CacheHit | null> {
       return null;
     }
 
-    const body = await readLocal(cfg, key);
-    if (!body || body.length !== entry.size) {
-      forget(key);
-      if (body) await removeLocal(cfg, key);
+    // ⚠ An AGE bound as well as a size one. Eviction is by pressure, so without this
+    // an entry at a stable URL that changes underneath it — an avatar, a
+    // `latest.png` — is served from disk indefinitely under `max-age=86400,
+    // immutable`, long after the metadata row has re-resolved. Before the cache
+    // existed the staleness window was a day; unbounded is a regression, not a
+    // feature. Matched to the metadata cache's own OK_TTL so the two agree.
+    if (Date.now() - Date.parse(entry.createdAt) > MAX_AGE_MS) {
+      if (await removeLocal(cfg, key)) forget(key);
       return null;
     }
-    return { kind: 'buffer', body, contentType: entry.contentType };
+
+    const read = await readLocal(cfg, key);
+    // ⚠⚠ Only a GENUINELY MISSING file forgets its row. `readLocal` used to collapse
+    // every errno to null, so a transient EMFILE — 24 concurrent reads is within
+    // this pool's own budget — or an EACCES after a permissions change deleted the
+    // index row while the object stayed on disk. That is an orphan eviction can
+    // never count and lookup can never find, in a module whose whole premise is
+    // that the index is how we know what exists. Any other error is just a miss.
+    if (read.kind === 'missing') {
+      forget(key);
+      return null;
+    }
+    if (read.kind === 'error') return null;
+    if (read.body.length !== entry.size) {
+      // ⚠ The row is dropped only if the bad file actually went with it — otherwise
+      // we would forget an object that is still on the volume.
+      if (await removeLocal(cfg, key)) forget(key);
+      return null;
+    }
+    return { kind: 'buffer', body: read.body, contentType: entry.contentType };
   } catch {
     return null;
   }
@@ -200,25 +242,65 @@ export function whenStoresSettle(): Promise<void> {
  * design cannot tolerate quietly.
  */
 export async function store(key: string, body: Buffer, contentType: string): Promise<boolean> {
+  const writer = await beginStore(key, body.length);
+  if (!writer) return false;
+  writer.write(body);
+  return writer.commit(contentType);
+}
+
+/**
+ * Begin storing an object whose bytes are still arriving.
+ *
+ * ⚠ Room is made HERE, before a byte is written, so the ceiling is never crossed
+ * and eviction is not gated on the success of the write it exists to enable —
+ * which is what made it unreachable on a full volume, the one time it matters.
+ * `expected` is the origin's declared length when it gave one, and the transfer
+ * cap when it did not: over-reserving by a few megabytes is cheap, and under-
+ * reserving is how the ceiling gets crossed.
+ *
+ * ⚠ An object LARGER than the whole ceiling is refused outright. Without that,
+ * `evictLocal` loops toward a total it can never reach, throws away up to a full
+ * batch of live entries, and stores the oversized object anyway — so a small
+ * ceiling with large images means every single store wipes the cache and the hit
+ * rate collapses to nothing.
+ */
+export async function beginStore(key: string, expected: number): Promise<StoreWriter | null> {
   try {
     const cfg = cacheConfig();
-    if (cfg.mode !== 'local') return false;
+    if (cfg.mode !== 'local') return null;
 
-    // ⚠ Room is made BEFORE the write, so the ceiling is never crossed and eviction
-    // is not gated on the success of the very write it exists to enable — which is
-    // what made it unreachable on a full volume, the one time it matters.
-    await evictLocal(cfg, body.length);
+    if (expected > cfg.maxBytes) return null;
 
-    if (!(await writeLocal(cfg, key, body))) return false;
-    try {
-      recordCached({ key, backend: cfg.mode, contentType, size: body.length });
-    } catch {
-      // The bytes landed but the index did not, so nothing could ever find them.
-      await removeLocal(cfg, key);
-      return false;
-    }
-    return true;
+    await evictLocal(cfg, expected);
+    const writer = await openLocalWrite(cfg, key);
+    if (!writer) return null;
+
+    let size = 0;
+    return {
+      write(chunk: Buffer): void {
+        size += chunk.length;
+        writer.write(chunk);
+      },
+      async commit(contentType: string): Promise<boolean> {
+        try {
+          if (size === 0 || !(await writer.commit())) return false;
+          try {
+            recordCached({ key, backend: cfg.mode, contentType, size });
+          } catch {
+            // The bytes landed but the index did not, so nothing could find them.
+            await removeLocal(cfg, key);
+            return false;
+          }
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      async abort(): Promise<void> {
+        await writer.abort().catch(() => {});
+      },
+    };
   } catch {
-    return false;
+    return null;
   }
 }

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -283,7 +283,18 @@ export async function beginStore(key: string, expected: number): Promise<StoreWr
       },
       async commit(contentType: string): Promise<boolean> {
         try {
-          if (size === 0 || !(await writer.commit())) return false;
+          // ⚠⚠ An empty body is ABORTED, not just declined. Returning false here
+          // without touching the writer left its stream open and its temp file on
+          // disk — one leaked fd and one orphaned `.tmp` per request, from an origin
+          // answering 200 with `Content-Length: 0`, which nothing sweeps and which
+          // eviction cannot see because the index never learned about it. Exactly
+          // the leak `openLocalWrite`'s own comment says the design must not have,
+          // reached through the one exit that skipped the cleanup. (Copilot.)
+          if (size === 0) {
+            await writer.abort();
+            return false;
+          }
+          if (!(await writer.commit())) return false;
           try {
             recordCached({ key, backend: cfg.mode, contentType, size });
           } catch {

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The preview byte cache, as the route sees it: `lookup` before fetching, `store`
+// after. Everything below this line is a backend detail.
+//
+// ⚠⚠ THE CACHE IS NEVER A FAILURE PATH. Every function here answers "miss" rather
+// than throwing, for every cause — misconfiguration, a wiped directory, a locked
+// database, a race with eviction. The uncached path is a complete, working feature
+// (it is what shipped, and what runs with the cache off), so any doubt resolves to
+// using it. A cache that can break the thing it accelerates is worse than no cache.
+// ⚠ That was a CLAIM before it was true: `lookup` threw a SQLITE_BUSY straight out
+// of the route, past a `try` that did not open for another seventy lines, and 500'd
+// an image request that would have succeeded with caching switched off. The guard
+// now lives in this module, where the promise is made.
+//
+// ⚠ IMAGES ONLY, deliberately. Video and audio are capped at MAX_MEDIA_PROXY_BYTES
+// (64 MB) against images' 8 MB, they are served with RANGE requests so a cached
+// copy would have to answer partial reads, and one seek in a video is many
+// requests for one object. Buffering 64 MB per miss would trade the bandwidth this
+// feature saves for memory it cannot bound.
+
+import crypto from 'crypto';
+import { lookupCached, recordCached, forget } from '../../db/previewCache.js';
+import { kindForContentType } from '../linkPreview.js';
+import { resolveCacheConfig, type CacheConfig } from './config.js';
+import { evictLocal, objectPath, readLocal, removeLocal, writeLocal } from './local.js';
+
+export type { CacheConfig, CacheMode } from './config.js';
+export { objectPath };
+
+/** Served from bytes we hold. The only hit shape `local` can produce. */
+export interface BufferHit {
+  kind: 'buffer';
+  body: Buffer;
+  contentType: string;
+}
+export type CacheHit = BufferHit;
+
+/**
+ * The cache key for one URL's BYTES.
+ *
+ * ⚠⚠ Its own digest, deliberately NOT `db/linkPreviews.ts`'s `urlHash`. That one
+ * folds in `RESOLVER_VERSION`, a counter whose entire job is to invalidate
+ * METADATA when the resolver would produce a different record — it has already
+ * been bumped for a WebP/GIF *dimension* change, and its docblock actively invites
+ * more. Sharing it would mean a routine metadata bump silently discards every
+ * cached byte on the instance and re-fetches every image at once, from a diff that
+ * never mentions this module and a reviewer who has no reason to look here. The
+ * identity of a cached picture is its URL, and nothing else.
+ *
+ * ⚠ Canonicalised the way `urlHash` does — fragment stripped — so `#a` and `#b` of
+ * one image share an object rather than being fetched and stored twice.
+ */
+export function byteCacheKey(url: string): string {
+  let key: string;
+  try {
+    const canonical = new URL(url);
+    canonical.hash = '';
+    key = canonical.toString();
+  } catch {
+    key = url.replace(/#[\s\S]*$/, '');
+  }
+  return crypto.createHash('sha256').update(`bytes-v1|${key}`).digest('hex');
+}
+
+/**
+ * ⚠ Resolved ONCE per process, not per request.
+ *
+ * The config comes from the environment, which cannot change under a running
+ * process, and re-reading it per byte request would re-run the validation — and
+ * re-log its warnings — on the hottest path this feature has.
+ */
+let cached: CacheConfig | null = null;
+
+export function cacheConfig(): CacheConfig {
+  cached ??= resolveCacheConfig();
+  return cached;
+}
+
+/** Test seam: drop the memoised config so the next call re-reads the environment. */
+export function resetCacheConfigForTests(): void {
+  cached = null;
+}
+
+export function cacheEnabled(): boolean {
+  return cacheConfig().mode !== 'off';
+}
+
+/**
+ * Is this worth caching at all?
+ *
+ * Exported because the route makes the same judgement twice — once to decide
+ * whether to look, once to decide whether to store — and two copies of a predicate
+ * is how they drift.
+ *
+ * ⚠⚠ Asks `kindForContentType`, never `startsWith('image/')`. That allowlist is the
+ * one place `image/svg+xml` is refused — "a scripting format wearing a picture's
+ * clothes", in the resolver's own words — and a second copy of that rule is
+ * precisely how it nearly got served under our origin once before. A `startsWith`
+ * test here accepted SVG, and was safe only because `proxyableContentType` happens
+ * to run thirty-five lines earlier in the one caller. That is an ordering, not a
+ * guarantee.
+ */
+export function cacheable(contentType: string | undefined, isRangeRequest: boolean): boolean {
+  if (!cacheEnabled()) return false;
+  // ⚠ A range request is passed straight through, never served from cache and never
+  // stored. Answering one correctly means honouring an arbitrary byte window, and
+  // the only content that asks for ranges is the media this cache excludes anyway.
+  // Serving a whole object to a request for bytes 100-200 is a correctness bug.
+  if (isRangeRequest) return false;
+  return !!contentType && kindForContentType(contentType) === 'image';
+}
+
+/**
+ * A cached copy, or null. Never throws.
+ *
+ * ⚠ Repairs the index rather than merely missing. A row whose file has vanished —
+ * a wiped volume, a restored backup, a manual `rm` — would otherwise answer "hit"
+ * forever, costing a failed read before the origin fetch that was going to happen
+ * anyway, because nothing else ever revisits the row.
+ *
+ * ⚠⚠ The SIZE is checked, not just presence. `writeLocal` does not fsync before
+ * renaming, so a power loss or a killed container can leave a short file under a
+ * row (WAL-durable) claiming the full length. `readFile` then succeeds, nothing
+ * throws, and the stump is served with `max-age=86400, immutable` — a permanently
+ * broken image every viewer holds for a day. A zero-length Buffer is also truthy,
+ * so a presence test does not catch that one either.
+ */
+export async function lookup(key: string): Promise<CacheHit | null> {
+  try {
+    const cfg = cacheConfig();
+    if (cfg.mode !== 'local') return null;
+
+    const entry = lookupCached(key);
+    if (!entry) return null;
+    // ⚠ A row from another backend is FORGOTTEN, not merely skipped. Left in place
+    // after a mode change it is unreachable and uncounted at once, so its bytes sit
+    // on the volume forever with nothing able to name them.
+    if (entry.backend !== cfg.mode) {
+      forget(key);
+      return null;
+    }
+
+    const body = await readLocal(cfg, key);
+    if (!body || body.length !== entry.size) {
+      forget(key);
+      if (body) await removeLocal(cfg, key);
+      return null;
+    }
+    return { kind: 'buffer', body, contentType: entry.contentType };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Outstanding cache DECISIONS — not outstanding writes.
+ *
+ * ⚠⚠ A test seam, and the distinction is the whole reason it exists. The route
+ * deliberately does not await a store: the reader already has their bytes, and a
+ * slow disk must not hold the response open. From outside, that makes "nothing was
+ * cached" and "the decision has not been reached yet" indistinguishable — so a
+ * suite asserting an ABSENCE (a truncated body must not be stored; a video must
+ * not be) can pass for the wrong reason and never know.
+ *
+ * ⚠ An earlier version counted writes in flight and was worse than useless: it
+ * resolved instantly whenever no store had *started*, which is precisely the state
+ * an absence test is in, and reverting the truncation guard left the suite green.
+ */
+let pendingDecisions = 0;
+let decisionWaiters: Array<() => void> = [];
+
+/** Register a cache decision that has begun. Returns its one-shot settle. */
+export function trackPendingStore(): () => void {
+  pendingDecisions++;
+  let settled = false;
+  return () => {
+    if (settled) return;
+    settled = true;
+    pendingDecisions--;
+    if (pendingDecisions > 0) return;
+    const waiters = decisionWaiters;
+    decisionWaiters = [];
+    for (const w of waiters) w();
+  };
+}
+
+/** Resolves once every begun decision has been reached. Test-only. */
+export function whenStoresSettle(): Promise<void> {
+  if (pendingDecisions === 0) return Promise.resolve();
+  return new Promise((resolve) => decisionWaiters.push(resolve));
+}
+
+/**
+ * Store bytes we just fetched. Returns whether anything was kept. Never throws.
+ *
+ * ⚠ The row is written only AFTER the bytes are, and rolled back if the index
+ * write fails. An index entry for an object that does not exist is the state this
+ * design cannot tolerate quietly.
+ */
+export async function store(key: string, body: Buffer, contentType: string): Promise<boolean> {
+  try {
+    const cfg = cacheConfig();
+    if (cfg.mode !== 'local') return false;
+
+    // ⚠ Room is made BEFORE the write, so the ceiling is never crossed and eviction
+    // is not gated on the success of the very write it exists to enable — which is
+    // what made it unreachable on a full volume, the one time it matters.
+    await evictLocal(cfg, body.length);
+
+    if (!(await writeLocal(cfg, key, body))) return false;
+    try {
+      recordCached({ key, backend: cfg.mode, contentType, size: body.length });
+    } catch {
+      // The bytes landed but the index did not, so nothing could ever find them.
+      await removeLocal(cfg, key);
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/server/services/previewCache/local.ts
+++ b/server/services/previewCache/local.ts
@@ -92,9 +92,28 @@ export async function openLocalWrite(
   });
 
   let done = false;
+  /**
+   * ⚠⚠ Waits on `close`, NOT on `end`'s callback.
+   *
+   * `writable.end(cb)` attaches its callback to `finish`, which a stream that
+   * ERRORS never reaches — node's own docs say the callback "may or may not" be
+   * called on error. So on ENOSPC or EROFS, which is precisely the state a cache
+   * ceiling exists for, the promise never settled: `commit()` and `abort()` hung
+   * forever, the descriptor and the temp file stayed stranded, and the store
+   * decision was never reached. `close` fires on both paths.
+   *
+   * ⚠ The already-closed check is not belt-and-braces. A stream destroyed by an
+   * earlier error has emitted `close` before we ever get here, and a listener
+   * added afterwards waits for an event that has been and gone.
+   */
   const closeStream = () =>
     new Promise<void>((resolve) => {
-      handle.end(() => resolve());
+      if (handle.closed || handle.destroyed) {
+        resolve();
+        return;
+      }
+      handle.once('close', () => resolve());
+      handle.end();
     });
 
   return {

--- a/server/services/previewCache/local.ts
+++ b/server/services/previewCache/local.ts
@@ -7,6 +7,7 @@
 // re-fetch, not data.
 
 import crypto from 'crypto';
+import fsSync from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 import { cachedBytes, coldestCached, forget } from '../../db/previewCache.js';
@@ -22,47 +23,117 @@ export function objectPath(cfg: LocalCacheConfig, key: string): string {
   return path.join(cfg.dir, key.slice(0, 2), key);
 }
 
-export async function readLocal(cfg: LocalCacheConfig, key: string): Promise<Buffer | null> {
+/**
+ * ⚠⚠ Distinguishes GONE from BROKEN, and the distinction is load-bearing.
+ *
+ * Both are a miss to the caller, so an earlier version collapsed every errno to
+ * null — and the caller then forgot the index row for all of them. A transient
+ * EMFILE (24 concurrent reads is within this pool's own budget) or an EACCES after
+ * a permissions change therefore deleted the row while the object stayed on disk:
+ * an orphan eviction can never count and lookup can never find, in a module whose
+ * whole premise is that the index is how we know what exists. Only ENOENT means
+ * the file is really gone.
+ */
+export type LocalRead = { kind: 'ok'; body: Buffer } | { kind: 'missing' } | { kind: 'error' };
+
+export async function readLocal(cfg: LocalCacheConfig, key: string): Promise<LocalRead> {
   try {
-    return await fs.readFile(objectPath(cfg, key));
-  } catch {
-    // ⚠ Any failure is a MISS, not an error. The index and the disk can disagree —
-    // a wiped volume, a half-written file, a permissions change — and every one of
-    // those should re-fetch from the origin rather than fail a request for an image.
-    return null;
+    return { kind: 'ok', body: await fs.readFile(objectPath(cfg, key)) };
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === 'ENOENT'
+      ? { kind: 'missing' }
+      : { kind: 'error' };
   }
 }
 
-export async function writeLocal(
+/**
+ * A write in progress: bytes go to a temp file and are published, or thrown away.
+ *
+ * ⚠⚠ STREAMED, never buffered. Collecting the object in memory first cost a full
+ * copy in `chunks` plus a second at `Buffer.concat`, and the per-request 8 MB
+ * ceiling multiplied by `mediaPool`'s 24 slots — ~192 MB steady state and ~384 MB
+ * transient, memory the uncached path never allocated at all, reachable by anyone
+ * authenticated opening 24 concurrent large images. The destination is a file
+ * either way, so there was never a reason for the bytes to sit in RSS on the way
+ * there.
+ */
+export interface LocalWriter {
+  write(chunk: Buffer): void;
+  /** Publish under the real key. Atomic — a reader sees all of it or none. */
+  commit(): Promise<boolean>;
+  /** Throw the partial file away. Safe to call twice. */
+  abort(): Promise<void>;
+}
+
+export async function openLocalWrite(
   cfg: LocalCacheConfig,
   key: string,
-  body: Buffer,
-): Promise<boolean> {
+): Promise<LocalWriter | null> {
   const target = objectPath(cfg, key);
   // ⚠⚠ RANDOM, not pid+timestamp. Nothing dedupes the byte path — `mediaPool`
-  // bounds concurrency, not identity, and the store is fired un-awaited — so
-  // several writes of the SAME key can be in flight at once. Two in the same
-  // millisecond shared a temp path, and `fs.writeFile` truncates only at open: the
-  // shorter write left the longer body's tail in place and published a file
-  // matching NEITHER body, under a row recording the shorter length. Reproduced
-  // with 4 MB and 1 MB bodies while this was pid+timestamp.
+  // bounds concurrency, not identity — so several writes of the SAME key can be in
+  // flight at once. Two in the same millisecond shared a temp path, and a write
+  // truncates only at open: the shorter one left the longer body's tail in place
+  // and published a file matching NEITHER, under a row recording the shorter
+  // length. Reproduced with 4 MB and 1 MB bodies while this was pid+timestamp.
   const tmp = `${target}.${crypto.randomUUID()}.tmp`;
+  let handle: fsSync.WriteStream;
   try {
     await fs.mkdir(path.dirname(target), { recursive: true });
-    await fs.writeFile(tmp, body);
-    // `rename` within a directory is atomic, so a concurrent `readLocal` sees
-    // either nothing (a miss, which re-fetches) or the whole object — never a
-    // prefix, which would be served as a truncated image and held by a browser
-    // for a day.
-    await fs.rename(tmp, target);
-    return true;
+    handle = fsSync.createWriteStream(tmp);
   } catch {
-    // ⚠ The temp file is OURS to clean up. Left behind it is invisible to the
-    // index and therefore to eviction — bytes on the volume that nothing counts
-    // and nothing can ever reclaim.
-    await fs.unlink(tmp).catch(() => {});
-    return false;
+    return null;
   }
+  // A write error (ENOSPC, EROFS) must not become an unhandled 'error' event and
+  // take the process down; it is recorded and turns commit into a no-op.
+  let broken = false;
+  handle.on('error', () => {
+    broken = true;
+  });
+
+  let done = false;
+  const closeStream = () =>
+    new Promise<void>((resolve) => {
+      handle.end(() => resolve());
+    });
+
+  return {
+    write(chunk: Buffer): void {
+      if (done || broken) return;
+      // Backpressure is deliberately not awaited: the response is already being
+      // piped to the reader and must not wait on our disk. The stream's own buffer
+      // bounds this at the transfer's cap, which is what the memory fix is about.
+      handle.write(chunk);
+    },
+    async commit(): Promise<boolean> {
+      if (done) return false;
+      done = true;
+      await closeStream();
+      if (broken) {
+        await fs.unlink(tmp).catch(() => {});
+        return false;
+      }
+      try {
+        // `rename` within a directory is atomic, so a concurrent read sees either
+        // nothing (a miss, which re-fetches) or the whole object — never a prefix,
+        // which would be served as a truncated image and held for a day.
+        await fs.rename(tmp, target);
+        return true;
+      } catch {
+        await fs.unlink(tmp).catch(() => {});
+        return false;
+      }
+    },
+    async abort(): Promise<void> {
+      if (done) return;
+      done = true;
+      await closeStream();
+      // ⚠ The temp file is OURS. Left behind it is invisible to the index and
+      // therefore to eviction — bytes on the volume nothing counts and nothing can
+      // reclaim.
+      await fs.unlink(tmp).catch(() => {});
+    },
+  };
 }
 
 /**

--- a/server/services/previewCache/local.ts
+++ b/server/services/previewCache/local.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The filesystem backend. Bytes land under the data directory, beside the SQLite
+// file and the local uploads that are already there, so a self-hoster who is
+// backing up their volume is already backing this up — and losing it costs a
+// re-fetch, not data.
+
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import { cachedBytes, coldestCached, forget } from '../../db/previewCache.js';
+import type { LocalCacheConfig } from './config.js';
+
+/**
+ * ⚠ Sharded by the first two characters of the key. One flat directory of a
+ * million files is a directory a filesystem walks badly and an operator cannot
+ * `ls`; two hex characters give 256 buckets for free, from a key that is already
+ * a hex digest.
+ */
+export function objectPath(cfg: LocalCacheConfig, key: string): string {
+  return path.join(cfg.dir, key.slice(0, 2), key);
+}
+
+export async function readLocal(cfg: LocalCacheConfig, key: string): Promise<Buffer | null> {
+  try {
+    return await fs.readFile(objectPath(cfg, key));
+  } catch {
+    // ⚠ Any failure is a MISS, not an error. The index and the disk can disagree —
+    // a wiped volume, a half-written file, a permissions change — and every one of
+    // those should re-fetch from the origin rather than fail a request for an image.
+    return null;
+  }
+}
+
+export async function writeLocal(
+  cfg: LocalCacheConfig,
+  key: string,
+  body: Buffer,
+): Promise<boolean> {
+  const target = objectPath(cfg, key);
+  // ⚠⚠ RANDOM, not pid+timestamp. Nothing dedupes the byte path — `mediaPool`
+  // bounds concurrency, not identity, and the store is fired un-awaited — so
+  // several writes of the SAME key can be in flight at once. Two in the same
+  // millisecond shared a temp path, and `fs.writeFile` truncates only at open: the
+  // shorter write left the longer body's tail in place and published a file
+  // matching NEITHER body, under a row recording the shorter length. Reproduced
+  // with 4 MB and 1 MB bodies while this was pid+timestamp.
+  const tmp = `${target}.${crypto.randomUUID()}.tmp`;
+  try {
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(tmp, body);
+    // `rename` within a directory is atomic, so a concurrent `readLocal` sees
+    // either nothing (a miss, which re-fetches) or the whole object — never a
+    // prefix, which would be served as a truncated image and held by a browser
+    // for a day.
+    await fs.rename(tmp, target);
+    return true;
+  } catch {
+    // ⚠ The temp file is OURS to clean up. Left behind it is invisible to the
+    // index and therefore to eviction — bytes on the volume that nothing counts
+    // and nothing can ever reclaim.
+    await fs.unlink(tmp).catch(() => {});
+    return false;
+  }
+}
+
+/**
+ * Remove one object. Reports whether it is actually GONE.
+ *
+ * ⚠⚠ The boolean is load-bearing, and its absence was a defect. `previewCache.ts`
+ * promises a row is forgotten "only for what it actually removed", because the
+ * index is the only record of what exists — but a `void` return swallowing every
+ * errno made EACCES, EROFS and EBUSY indistinguishable from ENOENT. A volume
+ * remounted read-only — which is what a full disk does, i.e. exactly when eviction
+ * matters — would have eviction drop rows for files it had not freed, decrement
+ * the accounting anyway, and orphan the directory beyond reclaim.
+ *
+ * ENOENT counts as success: the object is not there, which is what was asked for.
+ */
+export async function removeLocal(cfg: LocalCacheConfig, key: string): Promise<boolean> {
+  try {
+    await fs.unlink(objectPath(cfg, key));
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === 'ENOENT';
+  }
+}
+
+/**
+ * Evict coldest-first until the directory is back under its ceiling.
+ *
+ * ⚠⚠ Called BEFORE the write it makes room for, never after. Gating eviction on a
+ * SUCCESSFUL store made it unreachable exactly when it was needed: once the volume
+ * fills, every `writeLocal` fails, so the pass that would free space never runs
+ * again and the cache stays pinned at full until a human intervenes. Lowering
+ * `maxBytes` and restarting had the same wedge — nothing shrinks until the next
+ * successful store, which on a full disk never comes. `incoming` is what we are
+ * about to add, so the ceiling accounts for it rather than being crossed first.
+ *
+ * ⚠ Unlinks first, forgets ONLY what it removed, and subtracts from the total only
+ * then. The other order leaves a file nothing remembers, which no later pass can
+ * find because the index is how we know what exists.
+ *
+ * ⚠ Bounded per call rather than looping to completion. This runs on the byte
+ * path, where a person is waiting for a picture; a cache suddenly far over its
+ * ceiling should drain over several requests instead of making one pay for all of
+ * it.
+ */
+const EVICT_BATCH = 64;
+
+export async function evictLocal(cfg: LocalCacheConfig, incoming = 0): Promise<number> {
+  let total = cachedBytes('local') + incoming;
+  if (total <= cfg.maxBytes) return 0;
+
+  let freed = 0;
+  for (const entry of coldestCached('local', EVICT_BATCH)) {
+    // ⚠ `continue`, not `break`: one unremovable file (a permissions oddity on a
+    // single shard) must not stop the pass from reclaiming everything else.
+    if (!(await removeLocal(cfg, entry.key))) continue;
+    forget(entry.key);
+    total -= entry.size;
+    freed++;
+    if (total <= cfg.maxBytes) break;
+  }
+  return freed;
+}


### PR DESCRIPTION
Part of [#681](https://github.com/amiantos/lurker/issues/681), self-hosted half.

## What it does

Today the **metadata** for a link is fetched once and remembered; the **bytes** are not. Ten people scrolling past the same image is ten fetches from its origin — `Cache-Control: private, max-age=86400` makes that once per person per day, which is not sharing. This makes it once for everyone, and every byte still goes out through the instance's own authenticated server.

Opt in with `LURKER_PREVIEW_CACHE_MODE=local`. `off` is the default, so nothing changes for anyone who doesn't. Bytes land beside the SQLite file, evicted coldest-first at a ceiling (2 GiB default), with a SQLite table as the index — metadata only, never blobs, because the database is Litestream-replicated and blobs in a table would ship every cached image to object storage continuously.

## ⚠ A bucket mode was built alongside this and split back out

`s3` existed on this branch and was removed. Serving cached bytes from a public CDN is a different feature wearing the same word: it needs a repair path for objects a lifecycle rule deleted, its own hardening story (headers on a 302 don't apply to the redirect target), and an answer for native clients that forward `Authorization` across redirects. Bundled, the half with no route-level coverage hid behind the half that had it. The twelve verified findings against it are written up in `lurker-dev/LINK_PREVIEWS_CACHE_PLAN.md` so that PR starts from them rather than paying for the same review twice.

## The rules this rests on, each of which was a defect first

- **⚠⚠ The cache is never a failure path.** Every function answers "miss" rather than throwing. `lookupCached` takes a WAL write lock for its `last_access` touch, so a `SQLITE_BUSY` could 500 an image request that would have *succeeded* with caching off. A cache that breaks the thing it accelerates is worse than no cache.
- **⚠⚠ Only a framed body may be stored.** `end` doesn't mean "complete" when a body is framed solely by the connection closing — node reports `complete: true`, because to the protocol a closed connection *is* the terminator. This route makes that ordinary rather than exotic, since `linkFetch` runs `keepAlive: false` and every request carries `Connection: close`. The live path serves bad bytes once and self-repairs; the cache would serve them to everyone under `immutable`. ⚠ Chunked counts as framed — a chunked body cut short never emits `end` — or this would decline ordinary origins to fix a hazard they don't have.
- **⚠⚠ Bytes stream to disk, never into memory.** Buffering cost a copy in `chunks` plus a second at `Buffer.concat`: 8 MB × `mediaPool`'s 24 slots is ~192 MB steady state, memory the uncached path never allocated.
- **⚠ Images only.** Video and audio are 64 MB against images' 8 MB and are read by range, so a cached copy would have to answer partial reads.
- **⚠ Its own cache key**, not `urlHash` — that folds in `RESOLVER_VERSION`, a counter for invalidating *metadata*, so sharing it would let a routine metadata bump silently discard every cached byte from a diff that never mentions this module.
- **⚠ `cacheable` asks `kindForContentType`** (now exported) rather than `startsWith('image/')`. That allowlist is the one place `image/svg+xml` is refused, and a second copy of that rule is how it nearly got served under our own origin once already.

Disk safety is one class of bug: the index is the only record of what exists, so anything that desynchronises them leaks bytes nothing can reclaim. `readLocal` distinguishes GONE from BROKEN (collapsing every errno meant a transient `EMFILE` deleted the row while the file survived); `removeLocal` reports failure rather than swallowing `EROFS` as `ENOENT`; eviction runs *before* the write it makes room for (gated on a successful store it became unreachable exactly when the volume filled); temp names are random (pid+timestamp collided between concurrent writes of one key and published a file matching neither body); `lookup` checks the size, since there's no fsync before rename and a zero-length Buffer is truthy.

## Gates

- **Two `/code-review` rounds before opening.** Round one found 15 — nearly all in the `s3` half, which is what decided the split. Round two found 6, all low/medium, none critical, and explicitly cleared round one's fixes.
- **Revert drill on every guard.** ⚠ It caught five of my own tests being vacuous: the seam counted writes in flight (so it resolved instantly in exactly the state an absence test is in), the truncation fixture killed the socket before streaming even began, eviction-removal and over-eviction both passed, and the oversize and age guards had no test at all.
- **Tests run against a real database, a real directory and a real origin that counts how often it's asked** — the origin hit count is the only thing that distinguishes a working cache from a working proxy. The truncation cases use a raw socket, because node's own server always frames a response for you.
- `npm run check` + `npm test`, exit 0 (3489 tests).

## QA

`LURKER_PREVIEW_CACHE_MODE=local` on a real instance, then scroll a link-heavy channel: `du -sh <data dir>/preview-cache` should grow and the `preview_cache` row count should track it. Already smoke-tested by the operator before the review fixes landed.

## Known and deliberate

`preview_cache` has no periodic sweep — `local` self-repairs on read, so rows only outlive files until the next lookup. The s3 mode will need one; it's in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)