### PR TITLE
Check that a cached image is actually an image

### DIFF
--- a/server/routes/linkPreview.cache.test.ts
+++ b/server/routes/linkPreview.cache.test.ts
@@ -323,4 +323,91 @@ describe('the byte cache, end to end', () => {
     expect(Buffer.from(after.body).equals(PNG)).toBe(true);
     expect(originHits).toBe(2);
   });
+
+  it('refuses to cache a document served as an image, but still serves the reader', async () => {
+    // ⚠⚠ The attack this closes. `cacheable` asks `kindForContentType`, which reads
+    // the header the ORIGIN sent — so an origin under someone else's control answers
+    // `Content-Type: image/png` with an HTML document and, before the signature
+    // check, we kept those bytes and served them back under our own name with
+    // `Content-Disposition: inline`. The URL is minted to the poster's own client,
+    // so handing it to a victim is not a hurdle.
+    const HTML = Buffer.from('<!DOCTYPE html><html><script>alert(1)</script></html>', 'utf8');
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(HTML.length) });
+      res.end(HTML);
+    };
+    const token = tokenFor('/not-really.png');
+    const res = await agent.get(`/api/link-preview/media/${token}`);
+    // ⚠ The reader is NOT failed. This is a cache gate, not a content filter — the
+    // proxy has always passed these bytes through with `nosniff` and a CSP sandbox
+    // on them, and changing that is a different decision from declining to KEEP
+    // them. Failing here would be a behaviour change for every uncached instance.
+    expect(res.status).toBe(200);
+    await whenStoresSettle();
+    expect(countCached()).toBe(0);
+
+    // ...and nothing was left on disk either, since the writer was aborted rather
+    // than merely un-recorded.
+    const dir = process.env.LURKER_PREVIEW_CACHE_DIR!;
+    const stray: string[] = [];
+    if (fs.existsSync(dir)) {
+      for (const shard of fs.readdirSync(dir)) {
+        for (const f of fs.readdirSync(path.join(dir, shard))) stray.push(f);
+      }
+    }
+    expect(stray).toEqual([]);
+  });
+
+  it('still caches a real image whose content type the origin got wrong', async () => {
+    // ⚠ The gate asks "are these bytes an image at all", NOT "do they match the
+    // declared subtype". Origins mislabel real images routinely, browsers decode by
+    // magic bytes regardless, and refusing those would cost hit rate to fix nothing.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/jpeg', 'content-length': String(PNG.length) });
+      res.end(PNG); // actually a PNG
+    };
+    const token = tokenFor('/mislabelled.png');
+    await agent.get(`/api/link-preview/media/${token}`);
+    await whenStoresSettle();
+    expect(countCached()).toBe(1);
+
+    const second = await agent.get(`/api/link-preview/media/${token}`);
+    expect(originHits).toBe(1);
+    expect(Buffer.from(second.body).equals(PNG)).toBe(true);
+    // ⚠ Served back with what the ORIGIN said, not with the sniffed type: the
+    // uncached path passes the origin's header through untouched, so correcting it
+    // only when cached would make the first and second loads disagree.
+    expect(second.headers['content-type']).toBe('image/jpeg');
+  });
+
+  it('assembles the signature from a header that arrives one byte at a time', async () => {
+    // ⚠ The header is not guaranteed to be in the first chunk. A slow origin, a
+    // proxy, or TCP itself can split it anywhere — and the accumulator that stitches
+    // it back together is the kind of index arithmetic that is wrong by one and
+    // still passes every single-chunk test. A PNG signature is 8 bytes, so dribbling
+    // guarantees it spans several.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(PNG.length) });
+      let i = 0;
+      const tick = (): void => {
+        if (i >= PNG.length) {
+          res.end();
+          return;
+        }
+        res.write(PNG.subarray(i, i + 1));
+        i++;
+        setImmediate(tick);
+      };
+      tick();
+    };
+    const token = tokenFor('/dribbled.png');
+    const first = await agent.get(`/api/link-preview/media/${token}`);
+    expect(first.status).toBe(200);
+    expect(Buffer.from(first.body).equals(PNG)).toBe(true);
+    await whenStoresSettle();
+    // ⚠ It must be CACHED — a gate that cannot reassemble a split header would
+    // silently refuse every slow origin, which reads as "caching does not work"
+    // rather than as a bug.
+    expect(countCached()).toBe(1);
+  });
 });

--- a/server/services/previewCache/cache.test.ts
+++ b/server/services/previewCache/cache.test.ts
@@ -61,7 +61,23 @@ beforeEach(async () => {
   mod.resetCacheConfigForTests();
 });
 
-const bytes = (n: number, fill = 0x61) => Buffer.alloc(n, fill);
+/**
+ * `n` bytes that are actually shaped like an image.
+ *
+ * ⚠ The filler used to be the whole buffer, and every test here passed with bodies
+ * that were just repeated 'a'. The store path now asks what the bytes ARE — a
+ * Content-Type is the origin's claim, and an origin someone else controls will
+ * answer `image/png` for an HTML document — so a fixture that is not an image is
+ * correctly refused. Real signature, exact length, filler behind it: the tests
+ * below care about SIZES (ceilings, eviction, truncation), and this keeps those
+ * arithmetic while making the fixture honest about what it always stood for.
+ */
+const bytes = (n: number, fill = 0x61) => {
+  const buf = Buffer.alloc(n, fill);
+  PNG_SIGNATURE.copy(buf, 0, 0, Math.min(PNG_SIGNATURE.length, n));
+  return buf;
+};
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 describe('preview byte cache — local', () => {
   it('stores bytes and gives them back verbatim', async () => {

--- a/server/services/previewCache/index.ts
+++ b/server/services/previewCache/index.ts
@@ -28,6 +28,7 @@ import {
   forget,
 } from '../../db/previewCache.js';
 import { kindForContentType, MAX_IMAGE_PROXY_BYTES } from '../linkPreview.js';
+import { imageSignatureOf, SIGNATURE_BYTES } from '../../utils/imageSignature.js';
 import { cacheConfig, cacheEnabled, expired, MAX_AGE_MS } from './config.js';
 import { evictLocal, objectPath, openLocalWrite, readLocal, removeLocal } from './local.js';
 import { openS3Write, readS3, removeS3, type S3Writer } from './s3.js';
@@ -332,8 +333,34 @@ export async function beginStore(key: string, expected: number): Promise<StoreWr
     }
 
     let size = 0;
+    // ⚠ The first bytes are kept so `commit` can ask what they actually ARE. Only
+    // `SIGNATURE_BYTES` of them: a signature is a fixed-offset fact, so there is
+    // nothing to gain from holding more, and this runs per store on a path whose
+    // whole design is to keep bytes out of the heap.
+    const head: Buffer[] = [];
+    let headLen = 0;
     return {
       write(chunk: Buffer): void {
+        if (headLen < SIGNATURE_BYTES) {
+          // ⚠⚠ COPIED, not a view. `subarray` shares the chunk's backing
+          // ArrayBuffer, so keeping a 16-byte view of a 64 KB network chunk pins
+          // the whole 64 KB until `commit` — which is after the entire body has
+          // streamed. In a module whose stated purpose is keeping bytes out of the
+          // heap, that is the bug wearing the fix's clothes: bounded by the store
+          // ceilings, but retained for the full life of every store, for nothing.
+          // (Copilot.)
+          //
+          // ⚠ NO TEST, deliberately, and this note is the substitute. `head` is
+          // closure state, so asserting it would need a seam that exists only to be
+          // asserted — and `byteLength` reports 16 either way, so the giveaway is
+          // the backing store, which is not reachable from outside. Verified once by
+          // hand instead: a 16-byte `subarray` of a 64 KB chunk reports
+          // `buffer.byteLength` 65536 and `view.buffer === chunk.buffer`; the
+          // `Buffer.from` copy reports 8192 and shares nothing.
+          const want = Buffer.from(chunk.subarray(0, SIGNATURE_BYTES - headLen));
+          head.push(want);
+          headLen += want.length;
+        }
         size += chunk.length;
         writer.write(chunk);
       },
@@ -347,6 +374,25 @@ export async function beginStore(key: string, expected: number): Promise<StoreWr
           // the leak `openLocalWrite`'s own comment says the design must not have,
           // reached through the one exit that skipped the cleanup. (Copilot.)
           if (size === 0) {
+            await writer.abort();
+            return false;
+          }
+          // ⚠⚠ THE CONTENT TYPE IS A CLAIM, and until this check nothing tested
+          // it. `cacheable` asks `kindForContentType`, which reads the header the
+          // ORIGIN sent — so an origin someone else controls answers
+          // `Content-Type: image/png` with an HTML document and we would keep the
+          // bytes, then serve them back under our own name with
+          // `Content-Disposition: inline`. The URL is minted to the poster's own
+          // client, so getting it to a victim is not a hurdle.
+          //
+          // ⚠ This is where it belongs rather than in either backend: it is a fact
+          // about the BYTES, identical for a file, a bucket and the hosted dropper,
+          // and putting it here means a backend cannot be added without it.
+          //
+          // ⚠ An unrecognised format is REFUSED, so a future image format stops
+          // being cached until it is listed. That is the safe direction — the proxy
+          // still serves it, so the failure is "no saving", not "no picture".
+          if (!imageSignatureOf(Buffer.concat(head))) {
             await writer.abort();
             return false;
           }

--- a/server/utils/imageSignature.test.ts
+++ b/server/utils/imageSignature.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// ⚠ Signatures are asserted against bytes sharp ACTUALLY PRODUCES, not against a
+// table of magic numbers copied out of a reference and back into a test. A
+// hand-written fixture agrees with a hand-written parser by construction — it
+// proves the two were typed from the same source, which is the one thing never in
+// doubt. The formats sharp can emit here are generated; the rest are the smallest
+// real headers of their kind.
+
+import { describe, it, expect } from 'vitest';
+import sharp from 'sharp';
+import { imageSignatureOf, SIGNATURE_BYTES } from './imageSignature.js';
+
+const raw = (channels: 3 | 4 = 3) =>
+  sharp({ create: { width: 8, height: 8, channels, background: { r: 1, g: 2, b: 3 } } });
+
+describe('imageSignatureOf', () => {
+  it('recognises what sharp encodes, from the first bytes alone', async () => {
+    const made: Array<[string, Buffer]> = [
+      ['image/png', await raw().png().toBuffer()],
+      ['image/jpeg', await raw().jpeg().toBuffer()],
+      ['image/gif', await raw().gif().toBuffer()],
+      ['image/webp', await raw().webp().toBuffer()],
+      ['image/webp', await raw(4).webp().toBuffer()], // VP8X (alpha) — a different chunk
+      ['image/avif', await raw().avif().toBuffer()],
+      ['image/tiff', await raw().tiff().toBuffer()],
+    ];
+    for (const [want, buf] of made) {
+      // ⚠ Sliced to the header, because that is all the caller ever keeps.
+      const head = buf.subarray(0, SIGNATURE_BYTES);
+      expect(`${want}: ${imageSignatureOf(head)}`).toBe(`${want}: ${want}`);
+    }
+  });
+
+  it('refuses documents wearing an image content type', () => {
+    // ⚠⚠ The whole reason this module exists. Each of these can be served with
+    // `Content-Type: image/png` by an origin someone else controls.
+    const hostile: Array<[string, string]> = [
+      ['html', '<!DOCTYPE html><html><script>alert(1)</script></html>'],
+      ['bare script', '<script>alert(1)</script>'],
+      // ⚠ SVG is the one the resolver already refuses by name. It has no
+      // signature, so it can never match here either — an independent second no.
+      ['svg', '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'],
+      ['svg with xml prolog', '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"/>'],
+      ['json', '{"not":"an image"}'],
+      ['plain text', 'just some text, honestly'],
+      ['empty', ''],
+    ];
+    for (const [label, body] of hostile) {
+      const got = imageSignatureOf(Buffer.from(body, 'utf8').subarray(0, SIGNATURE_BYTES));
+      expect(`${label}: ${got}`).toBe(`${label}: null`);
+    }
+  });
+
+  it('distinguishes HEIF from HEIC rather than collapsing both', () => {
+    // ⚠ `mif1`/`msf1` are the generic ISO brands — the container without the HEVC
+    // codec claim — and this codebase already tells the two apart
+    // (`contentClass.ts`, `imagePipeline.ts`). The distinction is inert while the
+    // only caller uses this as a yes/no gate, which is precisely why an untested
+    // wrong answer would have survived to surprise the first caller that reads it.
+    const ftyp = (brand: string) =>
+      Buffer.concat([
+        Buffer.alloc(4),
+        Buffer.from('ftyp', 'latin1'),
+        Buffer.from(brand, 'latin1'),
+        Buffer.alloc(4),
+      ]);
+    for (const [brand, want] of [
+      ['heic', 'image/heic'],
+      ['heix', 'image/heic'],
+      ['mif1', 'image/heif'],
+      ['msf1', 'image/heif'],
+      ['avif', 'image/avif'],
+      ['avis', 'image/avif'],
+    ] as const) {
+      expect(`${brand} -> ${imageSignatureOf(ftyp(brand))}`).toBe(`${brand} -> ${want}`);
+    }
+  });
+
+  it('refuses a RIFF container that is not WebP, and an ftyp that is not an image', () => {
+    // ⚠ RIFF carries WAV and AVI too, and the ISO base-media `ftyp` box carries
+    // MP4 video. Matching on the outer container alone would call both an image.
+    const riffWav = Buffer.concat([
+      Buffer.from('RIFF', 'latin1'),
+      Buffer.alloc(4),
+      Buffer.from('WAVE', 'latin1'),
+      Buffer.alloc(4),
+    ]);
+    expect(imageSignatureOf(riffWav)).toBeNull();
+
+    const mp4 = Buffer.concat([
+      Buffer.alloc(4),
+      Buffer.from('ftyp', 'latin1'),
+      Buffer.from('isom', 'latin1'),
+      Buffer.alloc(4),
+    ]);
+    expect(imageSignatureOf(mp4)).toBeNull();
+  });
+
+  it('does not match a truncated signature', () => {
+    // Nothing shorter than a signature is an image, and answering "maybe" would
+    // defeat the gate — the caller treats a match as permission to store.
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    expect(imageSignatureOf(png)).toBeNull();
+    expect(imageSignatureOf(Buffer.alloc(0))).toBeNull();
+  });
+
+  it('reads a real ICO and BMP header', () => {
+    // Not sharp-encodable, so these are the genuine fixed headers of each format.
+    expect(imageSignatureOf(Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]))).toBe(
+      'image/x-icon',
+    );
+    expect(imageSignatureOf(Buffer.from('BM', 'latin1'))).toBe('image/bmp');
+  });
+});

--- a/server/utils/imageSignature.ts
+++ b/server/utils/imageSignature.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// What an image's first bytes say it actually is.
+//
+// ⚠⚠ This exists because a Content-Type is a CLAIM, and everywhere else in the
+// preview path we were treating it as a fact. `kindForContentType` tests
+// `contentType.startsWith('image/')` against what the origin asserted; nothing
+// looked at the body. So an origin under someone else's control can answer
+// `Content-Type: image/png` with an HTML document, and — before this — we would
+// cache those bytes verbatim and later serve them back under our own name, or
+// from a bucket, with `Content-Disposition: inline`.
+//
+// ⚠ This is a GATE, not a correction. It answers "are these bytes a raster image
+// at all", and the caller refuses to cache when they are not. It deliberately
+// does NOT rewrite the stored Content-Type to the detected one: an origin that
+// labels a real PNG as `image/jpeg` is mislabelling something harmless, browsers
+// decode by magic bytes regardless, and the UNCACHED path passes the origin's
+// header through untouched — so correcting it only on the cached path would make
+// the first load and the second load disagree for no benefit.
+//
+// ⚠ Sniffing rather than sharp, deliberately. sharp is the better answer for
+// DIMENSIONS and is used for that (`imageDimensions`), but it refuses several
+// containers outright when handed fewer bytes than their header claims — webp,
+// gif and tiff all throw on a truncated read, as `imageHeader.ts` documents at
+// length. A gate built on it would refuse to cache exactly the formats most
+// ordinary to paste into IRC. A signature is a fixed-offset fact and cannot be
+// truncated out of existence.
+//
+// ⚠ SVG has no signature and can never match here, which is the correct outcome
+// twice over: it is the one format `kindForContentType` already refuses by name —
+// "a scripting format wearing a picture's clothes" — and a second, independent
+// refusal for it is exactly the belt-and-braces this module is for.
+
+/** Enough for every signature below; AVIF's brand is the deepest, at byte 12. */
+export const SIGNATURE_BYTES = 16;
+
+const ASCII = (buf: Buffer, start: number, end: number): string =>
+  buf.length >= end ? buf.toString('latin1', start, end) : '';
+
+const starts = (buf: Buffer, bytes: number[]): boolean =>
+  buf.length >= bytes.length && bytes.every((b, i) => buf[i] === b);
+
+/**
+ * ISO base-media brands we are willing to call an image.
+ *
+ * ⚠ An allowlist, not "anything with an ftyp box". The same container carries
+ * MP4 video, and this module's answer decides what gets stored as a picture.
+ */
+const IMAGE_BRANDS = new Map<string, string>([
+  ['avif', 'image/avif'],
+  ['avis', 'image/avif'],
+  ['heic', 'image/heic'],
+  ['heix', 'image/heic'],
+  ['heim', 'image/heic'],
+  ['heis', 'image/heic'],
+  // ⚠ HEIF, not HEIC. The generic ISO brands are the container without the HEVC
+  // codec claim, and this codebase already distinguishes the two
+  // (`contentClass.ts`, `imagePipeline.ts`). Collapsing them was inert while the
+  // only caller uses this as a yes/no gate — which is exactly why it would have
+  // survived to surprise the first caller that reads the value. (Copilot.)
+  ['mif1', 'image/heif'],
+  ['msf1', 'image/heif'],
+]);
+
+/**
+ * The image type these bytes really are, or null.
+ *
+ * Needs only the first `SIGNATURE_BYTES`; a short buffer simply fails to match,
+ * which is the safe direction — nothing smaller than a signature is an image.
+ */
+export function imageSignatureOf(head: Buffer): string | null {
+  // PNG, and APNG, which shares the signature and differs only in later chunks.
+  if (starts(head, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return 'image/png';
+  // JPEG — SOI plus the first marker byte.
+  if (starts(head, [0xff, 0xd8, 0xff])) return 'image/jpeg';
+  const gif = ASCII(head, 0, 6);
+  if (gif === 'GIF87a' || gif === 'GIF89a') return 'image/gif';
+  // WebP is a RIFF container; the form type at byte 8 is what distinguishes it
+  // from the many other things RIFF carries (WAV, AVI).
+  if (ASCII(head, 0, 4) === 'RIFF' && ASCII(head, 8, 12) === 'WEBP') return 'image/webp';
+  if (ASCII(head, 4, 8) === 'ftyp') {
+    const brand = IMAGE_BRANDS.get(ASCII(head, 8, 12));
+    if (brand) return brand;
+  }
+  if (ASCII(head, 0, 2) === 'BM') return 'image/bmp';
+  // TIFF, both endiannesses. Rare inline, but harmless and trivially recognised.
+  if (starts(head, [0x49, 0x49, 0x2a, 0x00]) || starts(head, [0x4d, 0x4d, 0x00, 0x2a])) {
+    return 'image/tiff';
+  }
+  if (starts(head, [0x00, 0x00, 0x01, 0x00])) return 'image/x-icon';
+  return null;
+}


### PR DESCRIPTION
A `Content-Type` is a **claim**, and the preview byte path was treating it as a fact.

`cacheable()` asks `kindForContentType`, which tests `contentType.startsWith('image/')` against the header the **origin** sent (`linkPreview.ts:266`). Nothing on the byte path inspects the body. So an origin under someone else's control answers `Content-Type: image/png` with an HTML document, we cache those bytes, and later serve them back under our own name with `Content-Disposition: inline`. The URL is minted to the poster's own client, so getting it to a victim is not a hurdle.

The store path now asks what the first bytes actually are, and refuses anything that is not a raster image.

## Scope

Narrow, and worth being precise about. The content lands on the **cache/CDN origin**, not the app origin, and Lurker's session cookie is host-only — so this is not a session-theft path. Modern browsers also do not sniff a document out of a declared `image/*` on a top-level navigation. It is a real residual rather than an emergency, and the reason to close it at the source is that every mitigation *above* it is a header, and headers are exactly what a bucket cannot carry.

## Why here

**In the shared store path, not in a backend.** It is a fact about the bytes — identical for a file, a bucket, and the hosted dropper — so putting it in `beginStore` means a backend cannot be added without it. `local` gets it today; #701's `s3` inherits it on merge with no change.

It also makes the `s3` header story honest. Three of the six hardening headers the proxy sets (`nosniff`, the CSP sandbox, CORP) cannot be stored on an S3 object, and the argument for that being acceptable rested on *"only allowlisted image types are ever stored"* — which was true of the **declared** type and not of the content. With this, that claim is true of the bytes.

## Design calls

- **A gate, not a correction.** It answers "is this an image at all", not "does it match the declared subtype". Origins mislabel real images routinely, browsers decode by magic bytes regardless, and the uncached path passes the origin's header through untouched — so rewriting the type only when cached would make the first load and the second load disagree. A mislabelled PNG is still cached, and still served as whatever the origin called it. There is a test for exactly this.
- **Signatures, not `sharp`.** `sharp` is the better answer for *dimensions* and is used for that, but it refuses several containers outright when handed fewer bytes than their header claims — webp, gif and tiff all throw on a truncated read, as `imageHeader.ts` documents at length. A gate built on it would decline to cache the formats most ordinary to paste into IRC.
- **Unrecognised formats are refused.** A future image format stops being cached until it is listed. That is the safe direction: the proxy still serves it, so the failure is "no saving", not "no picture".
- **SVG can never match**, which is right twice over — it is the one format `kindForContentType` already refuses by name, and an independent second refusal is the point of a second layer.
- 16 bytes of header are kept per store, assembled across chunks. A signature is a fixed-offset fact, and this runs on a path whose whole design is to keep bytes out of the heap.

## Tests

Unit coverage asserts against **bytes `sharp` actually produces** rather than magic numbers copied from a reference into a fixture — a hand-written fixture agrees with a hand-written parser by construction, which proves only that both were typed from the same source. Route-level coverage runs the attack through Express: HTML served as `image/png` is **served to the reader** (this is a cache gate, not a content filter — failing the request would be a behaviour change for every uncached instance) and **not cached**, with no temp file left behind.

⚠ **The existing unit fixtures were `Buffer.alloc(n, 0x61)`** — every test in `cache.test.ts` passed with bodies that were just repeated `'a'`. They now carry a real signature at exact length, which keeps the size arithmetic those tests are about while making the fixture honest about what it always stood for.

Revert-proven: removing the gate, making it strict against the declared subtype, dropping the WEBP form-type check, dropping the `ftyp` brand allowlist, and keeping only the first chunk of the header each take a named test red.

⚠ One probe did **not** bite, recorded so nobody re-runs it: bounding the header slice by `SIGNATURE_BYTES` rather than the remaining need is benign, not an off-by-one — over-collecting a few bytes cannot change a signature match.

248 files, 3500 tests, green. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)