### PR TITLE
Stop asking a host that just rate-limited us

### DIFF
--- a/server/routes/linkPreview.media.test.ts
+++ b/server/routes/linkPreview.media.test.ts
@@ -11,7 +11,7 @@
 // ⚠ What's mocked is the POLICY, never the mechanism. Express, the token, the throttles, the
 // pool, safeRequest, the pinned lookup and the pipe are all shipping code.
 
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import type { Express } from 'express';
@@ -34,6 +34,8 @@ type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
 let handler: Handler;
 let origin: http.Server;
 let base: string;
+/** How many times the ORIGIN was actually asked — the whole point of the hold. */
+let originHits = 0;
 
 /** A token for a path on the live origin, reached through `localhost` so the pinned lookup runs. */
 const tokenFor = (path: string): string => mintProxyToken(`${base}${path}`);
@@ -47,7 +49,10 @@ beforeAll(async () => {
   app = createTestApp({ '/api/link-preview': router });
   agent = await createAuthedAgent(app, alice.id);
 
-  origin = http.createServer((req, res) => handler(req, res));
+  origin = http.createServer((req, res) => {
+    originHits++;
+    handler(req, res);
+  });
   await new Promise<void>((resolve) => origin.listen(0, '127.0.0.1', resolve));
   base = `http://localhost:${(origin.address() as AddressInfo).port}`;
 });
@@ -351,5 +356,72 @@ describe('range advertisement', () => {
     const res = await agent.get(`/api/link-preview/media/${tokenFor('/dupehdr.mp4')}`);
     expect(res.status).toBe(200);
     expect(res.headers['accept-ranges']).toBe('bytes');
+  });
+});
+
+describe('a rate-limiting origin', () => {
+  // ⚠⚠ FROM A REAL FAILURE ON A LIVE INSTANCE. `opengraph.githubassets.com` — where
+  // every GitHub link's og:image lives — advertises a budget of 100 in
+  // `x-ratelimit-*`. A channel with a run of GitHub links spends it in one burst
+  // from the instance's single IP, and every image on that host went permanently
+  // blank: the 429 was reported to the browser as 404, which an <img> treats as a
+  // final answer and never re-asks.
+
+  beforeEach(async () => {
+    const { resetCooldownsForTests } = await import('../utils/originCooldown.js');
+    resetCooldownsForTests();
+    originHits = 0;
+  });
+
+  it('reports a 429 as 503 with Retry-After, not as a 404', async () => {
+    handler = (_req, res) => {
+      res.writeHead(429, { 'retry-after': '42' });
+      res.end();
+    };
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/limited.png')}`);
+    // ⚠ THE assertion. 404 is what an <img> caches as "this does not exist"; 503
+    // leaves the door open for the reload that will succeed a minute later.
+    expect(res.status).toBe(503);
+    expect(res.headers['retry-after']).toBe('42');
+  });
+
+  it('stops asking a host that just refused, until its window passes', async () => {
+    handler = (_req, res) => {
+      res.writeHead(429, { 'retry-after': '60' });
+      res.end();
+    };
+    // Different images, same host — which is exactly the shape of a channel full
+    // of GitHub links.
+    const first = await agent.get(`/api/link-preview/media/${tokenFor('/a.png')}`);
+    expect(first.status).toBe(503);
+    expect(originHits).toBe(1);
+
+    for (const p of ['/b.png', '/c.png', '/d.png']) {
+      const res = await agent.get(`/api/link-preview/media/${tokenFor(p)}`);
+      expect(res.status).toBe(503);
+    }
+    // ⚠⚠ THE POINT. One request went out; the rest were answered from the hold.
+    // Without it each of those spends another unit of a budget that is already
+    // exhausted, so it can never recover — the failure sustains itself.
+    expect(originHits).toBe(1);
+  });
+
+  it('keeps reporting a 404 as a 404', async () => {
+    // ⚠ "Not now" and "not ever" must stay distinguishable. A genuinely missing
+    // image is a fact about that URL, and an <img> that stops asking is correct.
+    handler = (_req, res) => {
+      res.writeHead(404);
+      res.end();
+    };
+    const res = await agent.get(`/api/link-preview/media/${tokenFor('/gone.png')}`);
+    expect(res.status).toBe(404);
+
+    // ...and a permanent failure must NOT bench the host for everything else.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'image/png', 'content-length': String(PNG.length) });
+      res.end(PNG);
+    };
+    const ok = await agent.get(`/api/link-preview/media/${tokenFor('/fine.png')}`);
+    expect(ok.status).toBe(200);
   });
 });

--- a/server/routes/linkPreview.ts
+++ b/server/routes/linkPreview.ts
@@ -35,6 +35,7 @@ import {
 import { verifyProxyToken } from '../services/mediaProxyToken.js';
 import { normalizeUrl, safeRequest } from '../services/linkFetch.js';
 import { previewsEnabled } from '../utils/previews.js';
+import { cooldownRemaining, isTransientStatus, noteRefusal } from '../utils/originCooldown.js';
 import { SlotPool } from '../utils/slotPool.js';
 
 const router = Router();
@@ -250,6 +251,28 @@ router.get(
     const isRange = typeof req.headers.range === 'string' && req.headers.range !== '';
     const cacheKey = byteCacheKey(url.toString());
 
+    // ⚠⚠ A host that just rate-limited us is not asked again until it says we may.
+    // Measured on a real instance: `opengraph.githubassets.com` — where every
+    // GitHub link's og:image lives — advertises a budget of 100 in `x-ratelimit-*`,
+    // and a channel with a run of GitHub links spends it in one burst from the
+    // instance's single IP. Without this, every later view of every one of those
+    // images went out and asked again, so the budget never recovered.
+    //
+    // ⚠ Checked BEFORE the pool, deliberately, unlike the cache read below. The
+    // whole point is to spend nothing — not a slot, not a socket, not a DNS
+    // lookup — on a request we already know the answer to. The cache read is
+    // inside the pool because a hit costs memory; this costs a map lookup.
+    //
+    // ⚠ 503, never 404. Same reasoning the saturation branch spells out: an <img>
+    // treats 404 as permanent and never re-asks, so reporting a temporary refusal
+    // that way turns a minute of rate limiting into a blank image forever.
+    const cooling = cooldownRemaining(url.hostname);
+    if (cooling > 0) {
+      res.set('Retry-After', String(cooling));
+      res.status(503).end();
+      return;
+    }
+
     if (!(await mediaPool.acquire())) {
       // Saturated, not broken. 503 + Retry-After so a media element backs off and retries,
       // rather than 404, which an <img> treats as a permanent verdict and never re-asks.
@@ -362,9 +385,31 @@ router.get(
       const ok = upstream.status === 200 || upstream.status === 206;
       if (!ok || !proxyableContentType(upstream.contentType)) {
         upstream.stream.destroy();
-        res.status(404).end();
+        // ⚠⚠ "Not now" and "not ever" are different answers, and collapsing them
+        // into 404 is what made a GitHub rate limit look like a missing image.
+        // An <img> treats 404 as a permanent verdict — the browser never re-asks,
+        // so a minute of 429s became a blank card that no reload could repair.
+        // ⚠ Only the STATUS gets this treatment. A content type we refuse to proxy
+        // is a fact about the URL and stays a 404 however many times it is asked.
+        if (ok || !isTransientStatus(upstream.status)) {
+          res.status(404).end();
+          return;
+        }
+        // The host's own instruction is preferred over any guess we could make —
+        // `Retry-After` in either legal form, else `x-ratelimit-reset`.
+        noteRefusal(url.hostname, upstream.headers);
+        res.set('Retry-After', String(cooldownRemaining(url.hostname) || 60));
+        res.status(503).end();
         return;
       }
+      // ⚠⚠ NOTHING clears the hold on success, and that is deliberate — an earlier
+      // version called `noteSuccess` here and it was both dead and harmful. Dead,
+      // because an active hold short-circuits above and no fetch can reach this
+      // line while one is armed. Harmful, because the one interleaving that DOES
+      // reach it is the burst this exists to damp: two dozen requests go out
+      // together, several are refused and arm the hold, and a single success then
+      // tears it down before it can stop anything. The hold expires on its own
+      // clock, which is short by design.
       // ⚠ Per-KIND cap. The single 8 MB ceiling was named for images and silently applied to
       // everything, so a 30 MB mp4 rendered inline was streamed to 8 MB and then had both ends
       // destroyed — the <video> died with a network error partway through, and since the

--- a/server/utils/originCooldown.test.ts
+++ b/server/utils/originCooldown.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
+  cooldownCountForTests,
   cooldownRemaining,
   isTransientStatus,
   noteRefusal,
@@ -86,6 +87,34 @@ describe('cooldowns', () => {
     // reads as "cool down for no time at all" and hides the refusal.
     noteRefusal('stale.example', { 'x-ratelimit-reset': String((NOW - 5000) / 1000) }, NOW);
     expect(cooldownRemaining('stale.example', NOW)).toBe(60);
+  });
+
+  it('sweeps expired entries instead of remembering every host that ever failed', () => {
+    // ⚠⚠ `cooldownRemaining` deletes lazily and only for the host it is handed, so
+    // a one-off refusal from a host nobody links again would sit in the map for the
+    // life of the process — and these run for months. (Copilot.)
+    for (let i = 0; i < 500; i++) {
+      noteRefusal(`host-${i}.example`, { 'retry-after': '30' }, NOW);
+    }
+    expect(cooldownCountForTests()).toBe(500);
+
+    // Nobody ever asks about those hosts again. A refusal from a DIFFERENT host,
+    // after their windows lapse, is what collects them.
+    noteRefusal('later.example', { 'retry-after': '30' }, NOW + 31_000);
+    expect(cooldownCountForTests()).toBe(1);
+  });
+
+  it('keeps entries that have not expired yet', () => {
+    // ⚠ The sweep must not be a `clear()` in disguise — a live hold on another host
+    // is the whole point of the map, and dropping it would re-open the flood this
+    // module exists to stop.
+    noteRefusal('long.example', { 'retry-after': '300' }, NOW);
+    noteRefusal('short.example', { 'retry-after': '10' }, NOW);
+    noteRefusal('trigger.example', { 'retry-after': '30' }, NOW + 11_000);
+
+    expect(cooldownRemaining('long.example', NOW + 11_000)).toBe(289);
+    expect(cooldownRemaining('short.example', NOW + 11_000)).toBe(0);
+    expect(cooldownCountForTests()).toBe(2);
   });
 
   it('takes a repeated refusal as the new deadline', () => {

--- a/server/utils/originCooldown.test.ts
+++ b/server/utils/originCooldown.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  cooldownRemaining,
+  isTransientStatus,
+  noteRefusal,
+  resetCooldownsForTests,
+} from './originCooldown.js';
+
+// A fixed clock. `Date.now()` would make every boundary assertion a race.
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => resetCooldownsForTests());
+
+describe('isTransientStatus', () => {
+  it('separates "not now" from "not ever"', () => {
+    // ⚠⚠ The distinction the whole fix rests on. 404/403/410 are facts about a
+    // URL and must keep reporting as permanent — retrying a hotlink-protected
+    // image forever helps nobody, and an <img> that never re-asks is CORRECT
+    // there. 429 and the 5xx family are the ones that change on their own.
+    for (const s of [429, 500, 502, 503, 504]) {
+      expect(`${s}: ${isTransientStatus(s)}`).toBe(`${s}: true`);
+    }
+    for (const s of [400, 401, 403, 404, 410, 418, 451]) {
+      expect(`${s}: ${isTransientStatus(s)}`).toBe(`${s}: false`);
+    }
+  });
+});
+
+describe('cooldowns', () => {
+  it('holds a host off, then lets it go once the window passes', () => {
+    noteRefusal('example.com', { 'retry-after': '30' }, NOW);
+    expect(cooldownRemaining('example.com', NOW)).toBe(30);
+    expect(cooldownRemaining('example.com', NOW + 29_000)).toBe(1);
+    expect(cooldownRemaining('example.com', NOW + 30_001)).toBe(0);
+  });
+
+  it('holds only the host that refused', () => {
+    noteRefusal('example.com', {}, NOW);
+    expect(cooldownRemaining('example.com', NOW)).toBeGreaterThan(0);
+    expect(cooldownRemaining('other.example', NOW)).toBe(0);
+  });
+
+  it('prefers the host’s own instruction over a guess', () => {
+    // ⚠ Both legal forms of Retry-After, then GitHub's actual flavour. Guessing
+    // when the answer is sitting in the response is how a backoff ends up either
+    // useless or far too long.
+    noteRefusal('a.example', { 'retry-after': '45' }, NOW);
+    expect(cooldownRemaining('a.example', NOW)).toBe(45);
+
+    resetCooldownsForTests();
+    noteRefusal('b.example', { 'retry-after': new Date(NOW + 90_000).toUTCString() }, NOW);
+    expect(cooldownRemaining('b.example', NOW)).toBe(90);
+
+    resetCooldownsForTests();
+    // What `opengraph.githubassets.com` actually sends: an epoch SECOND.
+    noteRefusal('c.example', { 'x-ratelimit-reset': String((NOW + 120_000) / 1000) }, NOW);
+    expect(cooldownRemaining('c.example', NOW)).toBe(120);
+  });
+
+  it('falls back to a short guess when the host says nothing', () => {
+    // ⚠ SHORT on purpose. A wrong guess that is too long blanks every image on
+    // that host for the whole window, which is worse than one extra rejected
+    // request — a host that means it will simply refuse again.
+    noteRefusal('quiet.example', {}, NOW);
+    expect(cooldownRemaining('quiet.example', NOW)).toBe(60);
+  });
+
+  it('refuses to be benched for a day by a hostile Retry-After', () => {
+    // ⚠⚠ The value comes from a third party. Honouring it unbounded would let any
+    // origin turn off previews for its own images — and for a shared host like
+    // githubassets, for every repository at once — for as long as it likes.
+    noteRefusal('hostile.example', { 'retry-after': '86400' }, NOW);
+    expect(cooldownRemaining('hostile.example', NOW)).toBe(600);
+
+    resetCooldownsForTests();
+    noteRefusal('hostile.example', { 'x-ratelimit-reset': String((NOW + 86_400_000) / 1000) }, NOW);
+    // Past the ceiling the header is not believed at all, and the default applies.
+    expect(cooldownRemaining('hostile.example', NOW)).toBe(60);
+  });
+
+  it('ignores a reset time that has already passed', () => {
+    // A stale or misread header must not produce a zero-or-negative window that
+    // reads as "cool down for no time at all" and hides the refusal.
+    noteRefusal('stale.example', { 'x-ratelimit-reset': String((NOW - 5000) / 1000) }, NOW);
+    expect(cooldownRemaining('stale.example', NOW)).toBe(60);
+  });
+
+  it('takes a repeated refusal as the new deadline', () => {
+    noteRefusal('example.com', { 'retry-after': '10' }, NOW);
+    noteRefusal('example.com', { 'retry-after': '120' }, NOW);
+    expect(cooldownRemaining('example.com', NOW)).toBe(120);
+  });
+});

--- a/server/utils/originCooldown.ts
+++ b/server/utils/originCooldown.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Remembering that a host told us to go away.
+//
+// ⚠⚠ Written from a real failure, not a hypothetical. `opengraph.githubassets.com`
+// — the host every GitHub link's og:image lives on — enforces a budget of 100
+// requests, advertised in `x-ratelimit-*`. A channel with a run of GitHub links
+// spends that in one burst from a single instance IP, GitHub answers 429, and
+// nothing here remembered it: every later view of every one of those images went
+// out and asked again, so the budget could never recover and the images stayed
+// blank.
+//
+// ⚠ The byte cache is what ultimately fixes this — one successful fetch serves
+// every user of the instance forever — but the cache can only be populated by a
+// SUCCESS. While a host is rate-limiting, the mechanism that would end the
+// hammering is precisely the one that cannot engage. Something has to break that
+// loop from outside, and this is it.
+//
+// ⚠ Deliberately NOT a per-host concurrency cap, which is what this looked like
+// it needed at first glance. Concurrency is not rate: four in flight at half a
+// second each is ~480/min, still far past a 100/min budget, so a cap would smooth
+// the burst and still exhaust the limit on a sustained scroll. What actually
+// protects a budget is not spending it — and 429 is the host telling us exactly
+// when to stop.
+
+/** Hosts we are holding off, and until when (epoch ms). */
+const cooldowns = new Map<string, number>();
+
+/**
+ * How long to wait when the host does not say.
+ *
+ * ⚠ Short on purpose. This is a guess, and a wrong guess that is too long makes
+ * every image on a host blank for that whole window — a worse outcome than one
+ * extra rejected request. A host that means it will simply 429 again.
+ */
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+/** Ceiling on anything a host asks for. An origin sending `Retry-After: 86400`
+ *  must not be able to disable previews for that host for a day. */
+const MAX_COOLDOWN_MS = 10 * 60_000;
+
+/**
+ * Statuses that mean "not now" rather than "not ever".
+ *
+ * ⚠ 429 and 503 are the two that carry `Retry-After` by convention. The 5xx
+ * neighbours are included because they are transient by definition; 4xx other
+ * than 429 are NOT, and must keep reporting as a permanent failure — a 403 on a
+ * hotlink-protected image is a fact about that URL, and retrying it forever
+ * helps nobody.
+ */
+export function isTransientStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status <= 599);
+}
+
+/** Seconds until this host may be asked again, or 0 if it may be asked now. */
+export function cooldownRemaining(host: string, now = Date.now()): number {
+  const until = cooldowns.get(host);
+  if (until === undefined) return 0;
+  if (until <= now) {
+    cooldowns.delete(host);
+    return 0;
+  }
+  return Math.ceil((until - now) / 1000);
+}
+
+/**
+ * Record that a host refused us, and for how long to believe it.
+ *
+ * ⚠ Reads the host's OWN instruction first — `Retry-After` in both its legal
+ * forms (delta-seconds and an HTTP-date), then `x-ratelimit-reset`, which is what
+ * `opengraph.githubassets.com` actually sends. Guessing when the answer is in the
+ * response is how a backoff ends up either useless or far too long.
+ */
+export function noteRefusal(
+  host: string,
+  headers: Record<string, string | string[] | undefined>,
+  now = Date.now(),
+): void {
+  const wait = retryAfterMs(headers, now) ?? DEFAULT_COOLDOWN_MS;
+  cooldowns.set(host, now + Math.min(wait, MAX_COOLDOWN_MS));
+}
+
+function first(value: string | string[] | undefined): string {
+  return String(Array.isArray(value) ? value[0] : (value ?? '')).trim();
+}
+
+function retryAfterMs(
+  headers: Record<string, string | string[] | undefined>,
+  now: number,
+): number | null {
+  const retryAfter = first(headers['retry-after']);
+  if (retryAfter) {
+    // delta-seconds
+    if (/^\d+$/.test(retryAfter)) return Number(retryAfter) * 1000;
+    // ...or an HTTP-date, which RFC 9110 allows and some CDNs prefer.
+    const at = Date.parse(retryAfter);
+    if (Number.isFinite(at)) return Math.max(0, at - now);
+  }
+  // GitHub's flavour: an epoch SECOND at which the budget refills.
+  const reset = first(headers['x-ratelimit-reset']);
+  if (/^\d+$/.test(reset)) {
+    const at = Number(reset) * 1000;
+    // ⚠ Sanity-checked rather than trusted. A header in the past, or absurdly far
+    // ahead, means we are reading something that is not what we think it is.
+    if (at > now && at - now < MAX_COOLDOWN_MS) return at - now;
+  }
+  return null;
+}
+
+// ⚠ There is deliberately NO `noteSuccess`. Clearing a hold when a request
+// succeeds sounds obviously right and is not: a hold short-circuits the fetch, so
+// nothing can succeed while one is armed EXCEPT in the concurrent burst this
+// exists to damp — where a single success among two dozen refusals would tear
+// down the hold the refusals just armed. Holds end on their own clock.
+
+/** Test seam. */
+export function resetCooldownsForTests(): void {
+  cooldowns.clear();
+}

--- a/server/utils/originCooldown.ts
+++ b/server/utils/originCooldown.ts
@@ -77,6 +77,23 @@ export function noteRefusal(
   headers: Record<string, string | string[] | undefined>,
   now = Date.now(),
 ): void {
+  // ⚠⚠ Expired entries are swept HERE, not only when their own host is asked
+  // about again. `cooldownRemaining` deletes lazily and only for the host it was
+  // handed, so a host that refuses once and is never linked again keeps its entry
+  // for the life of the process — and these processes run for months. (Copilot.)
+  //
+  // ⚠ The sweep is what gives this a real bound rather than a smaller leak. Size
+  // becomes proportional to refusals within one window instead of to every host
+  // that has ever failed: `mediaThrottle` caps byte requests at 300/min and
+  // MAX_COOLDOWN_MS is ten minutes, so the map cannot exceed a few thousand
+  // entries however long the process lives or how hard anyone leans on it.
+  //
+  // ⚠ On refusal rather than on a timer, because refusals are the rare path — an
+  // O(n) pass here costs microseconds and needs no interval to own, unref, or
+  // remember to clear in tests.
+  for (const [seen, until] of cooldowns) {
+    if (until <= now) cooldowns.delete(seen);
+  }
   const wait = retryAfterMs(headers, now) ?? DEFAULT_COOLDOWN_MS;
   cooldowns.set(host, now + Math.min(wait, MAX_COOLDOWN_MS));
 }
@@ -117,4 +134,10 @@ function retryAfterMs(
 /** Test seam. */
 export function resetCooldownsForTests(): void {
   cooldowns.clear();
+}
+
+/** Test seam: the sweep is invisible from the outside, since an expired entry and
+ *  an absent one answer identically. */
+export function cooldownCountForTests(): number {
+  return cooldowns.size;
 }


### PR DESCRIPTION
Reported from a live self-hosted instance running the new `s3` byte cache: a run of GitHub links left every preview image **permanently blank**.

## What was actually happening

Two mistakes compounding, neither of them in the cache.

**1. `opengraph.githubassets.com` rate-limits, and we mistranslated it.** That host — where every GitHub link's og:image lives — advertises a budget of 100 in `x-ratelimit-*`. A channel with a run of GitHub links spends it in one burst from the instance's single IP, and GitHub answers 429. The route reported **any** non-200 as 404:

```js
const ok = upstream.status === 200 || upstream.status === 206;
if (!ok || !proxyableContentType(...)) { res.status(404).end(); }
```

So "come back in a minute" reached the browser as "this image does not exist" — and an `<img>` treats a 404 as a final answer and never re-asks. The route already knew this; its saturation branch says exactly that, and the reasoning had just never been applied to upstream failures.

**2. Nothing remembered the refusal.** Every later view of every one of those images went out and asked again, so the budget could never recover. The failure sustained itself.

⚠ Worth naming: **the byte cache is what ultimately fixes this** — one successful fetch serves every user of the instance forever. But the cache can only be populated by a *success*, so while a host is refusing, the mechanism that would end the hammering is precisely the one that cannot engage. Something had to break the loop from outside.

## What this does

- **Transient upstream statuses (429, 5xx) become 503 + `Retry-After`**, not 404. A content type we refuse to proxy stays a 404 — that's a fact about the URL, and an `<img>` that stops asking is correct there.
- **A refused host is not asked again until its window passes.** Checked *before* the pool and before the cache read, so a held request spends no slot, no socket and no DNS lookup. The hold reads the host's own instruction — `Retry-After` in both legal forms, then `x-ratelimit-reset` — and is capped at ten minutes so an origin can't bench itself, or a shared host like githubassets, for a day.

## Two design calls worth reviewing

**Not a per-host concurrency cap**, which is what I first proposed and what this looks like it needs. Concurrency is not rate: four in flight at half a second each is ~480/min against a 100/min budget, so a cap would smooth the burst and still blow the limit on a sustained scroll. What protects a budget is not spending it, and 429 is the host telling us when.

**Deliberately no `noteSuccess`.** The first version cleared a hold when a request succeeded, which sounds obviously right and isn't — a hold short-circuits the fetch, so nothing can succeed while one is armed *except* in the concurrent burst this exists to damp, where a single success among two dozen refusals would tear down the hold the refusals just armed. Holds end on their own clock, which is short by design.

⚠ That one was found by the revert drill, not by review: the test for it passed with the route's call deleted, because it called `noteSuccess` itself rather than going through the route. Removed rather than strengthened.

## No Redis, deliberately

The hold is a plain in-process `Map`, alongside `mediaPool`, `mediaThrottle`, `resolveThrottle` and the resolver's `inFlight` map. That isn't a shortcut — **the budget being protected is per-IP, and the process that owns the IP is the process that owns the map.** One Lurker instance is one process; a hosted cell has its own IP, so a per-cell map matches its own budget exactly. Sharing this across processes would be describing someone else's rate limit. Losing it on restart is also correct: one extra probe, then the host tells us again.

## Testing

Unit coverage runs on an injected clock (`Date.now()` would make every boundary assertion a race). Route coverage runs the reported shape through Express: a 429 origin, then three *different* images on the same host — which is what a channel full of GitHub links looks like — asserting **one** origin hit and three 503s.

Revert-proven: the 503 mapping, the short-circuit, the `Retry-After` ceiling, the stale-reset guard and the 404-stays-404 rule each take a named test red.

250 files, 3532 tests, green. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)