### PR TITLE
Buffer rename foundation: registry, renameBuffer, and the buffer-renamed frame

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -597,6 +597,7 @@ a v1 client.
 | `read-state`                                                                                                                                                             | see §5.4                                                                                                                                                                                                                                                    | After every countable event / mark-read                                                                                                                   |
 | `send-result`                                                                                                                                                            | `clientId, ok, error?`                                                                                                                                                                                                                                      | Ack for `send`/`action`/`notice`                                                                                                                          |
 | `buffer-opened` / `buffer-closed` / `buffer-reopened`                                                                                                                    | `networkId, target`                                                                                                                                                                                                                                         | Buffer lifecycle (§9.1). `buffer-opened` is an ack to the socket that asked **and** a fan-out to the user's other devices — only focus on your own (§4.3) |
+| `buffer-renamed`                                                                                                                                                         | `networkId, from, to, merged`                                                                                                                                                                                                                               | A buffer changed identity (§9.7). Goes to **every** socket, including the one that caused it                                                              |
 | `buffer-cleared`                                                                                                                                                         | `networkId, target, clearedBeforeId, clearedAt`                                                                                                                                                                                                             | `/clear` marker                                                                                                                                           |
 | `pins-changed`                                                                                                                                                           | `networkId, pinned[]`                                                                                                                                                                                                                                       | Authoritative pin order                                                                                                                                   |
 | `nicklist-collapsed-changed` / `channel-notify-changed`                                                                                                                  | `networkId, target, …`                                                                                                                                                                                                                                      | View-state sync                                                                                                                                           |
@@ -912,6 +913,44 @@ bugs both came from mutating state below a missing dedupe check. Membership
 side effects ride the same events you render: `join`→add member, `part`/`quit`→
 remove, `kick`→remove `kicked`, `nick`→rename (`chghost` renders only; its
 nicklist patch arrives separately as `member-update`).
+
+### 9.7 Renames change a buffer's identity
+
+`buffer-renamed` (`networkId, from, to, merged`) says a buffer you already hold
+is now called something else. It is sent when a channel is renamed and when a DM
+peer changes nick.
+
+Unlike `buffer-opened`, this frame goes to **every** socket including the one
+whose action caused it, and it is **not** a focus instruction. It describes a
+change that has already happened server-side; a client that ignores it is simply
+wrong about what its buffers are called. Rules:
+
+- **Rekey everything you store per buffer**, not just the message list:
+  membership, draft, read/unread state, pin position, scroll anchor, nicklist
+  collapse, search scope, and any navigation history. A rekey that misses one of
+  these strands it under a name nothing will ask for again.
+- **Key off `to`, never off a name you predicted.** When `merged` is true the
+  server adopted the _destination's_ stored casing, which may differ from the
+  new name you saw on the wire (a `NICK` to `Robert` merging into an existing
+  `robert` buffer resolves to `robert`). §9.2's rule still holds: the server owns
+  display casing.
+- **`merged: true` means fold, not rename.** A buffer already existed at `to`,
+  and the two are now one. Concatenate the message lists and re-sort by id
+  rather than replacing one with the other; drop your row for `from` entirely.
+  Server-side the destination wins for scalar state (draft, collapse) while read
+  progress takes the furthest of the two, so re-reading state from the next
+  `read-state` frame is safer than merging it yourself.
+- **If the renamed buffer is your active one, follow it.** That is the same
+  conversation under a new name, so following is not a navigation — and leaving
+  the user on a buffer key that no longer exists shows them an empty room.
+- **A rename you have no buffer for is not an error** — ignore it. Renames are
+  fanned out per network, and a client may legitimately not hold that buffer
+  (never opened, or closed).
+
+Some things deliberately do **not** follow a rename, and the server will not
+pretend otherwise: highlight and ignore rules scoped to the old channel name are
+left alone, because their scope can span networks and can contain globs. If you
+surface rule management, that is worth telling the user about.
 
 ---
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -916,6 +916,11 @@ nicklist patch arrives separately as `member-update`).
 
 ### 9.7 Renames change a buffer's identity
 
+> ⚠ **Not yet emitted.** The server-side plumbing exists but nothing produces
+> this frame today — the two producers (channel `RENAME`, and a DM peer changing
+> nick) haven't landed. Implementing a handler now is safe and forward-looking;
+> just don't expect to see one on the wire yet.
+
 `buffer-renamed` (`networkId, from, to, merged`) says a buffer you already hold
 is now called something else. It is sent when a channel is renamed and when a DM
 peer changes nick.

--- a/server/db/bufferKeyedTables.test.ts
+++ b/server/db/bufferKeyedTables.test.ts
@@ -14,7 +14,7 @@
 // the migrations actually produced and compares reality to the declaration, in
 // both directions.
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -62,6 +62,8 @@ function columns(table: string): ColumnRow[] {
 beforeAll(async () => {
   ({ default: db } = await import('./index.js'));
 });
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
 describe('BUFFER_KEYED_TABLES completeness', () => {
   it('declares every table in the live schema with a buffer-target column', () => {

--- a/server/db/bufferKeyedTables.test.ts
+++ b/server/db/bufferKeyedTables.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Drift detection for BUFFER_KEYED_TABLES.
+//
+// The registry is a hand-written list of every table storing a buffer target as
+// a string, and the whole rename machinery trusts it to be complete. A hand
+// written list of that kind rots: the previous one (foldBufferCase's
+// TARGET_TABLES) stopped being updated around schema 9 and by schema 16 named
+// two tables that no longer existed, which the version guard hid rather than
+// surfaced.
+//
+// So this doesn't check the list against another list. It introspects the schema
+// the migrations actually produced and compares reality to the declaration, in
+// both directions.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  BUFFER_KEYED_TABLES,
+  CURRENT_BUFFER_KEYED_TABLES,
+  BUFFER_TARGET_COLUMN_NAMES,
+  NON_BUFFER_TARGET_TABLES,
+} from './bufferKeyedTables.js';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-buftables-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+
+interface ColumnRow {
+  name: string;
+  type: string;
+}
+
+function tableNames(): string[] {
+  return (
+    (
+      db
+        // Only SQLite's own internal tables are filtered, and with ESCAPE because
+        // `_` is a single-character LIKE wildcard. FTS5 shadow tables are left in
+        // deliberately: they carry no target/channel column, so they can't trip
+        // the completeness check, and a pattern broad enough to exclude them is a
+        // pattern broad enough to exclude a real table by accident. It already
+        // did — `%_fts%` matches `user_drafts`, because "drafts" ends in "fts".
+        .prepare(
+          `SELECT name FROM sqlite_master
+          WHERE type = 'table' AND name NOT LIKE 'sqlite\\_%' ESCAPE '\\'
+          ORDER BY name`,
+        )
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name)
+  );
+}
+
+function columns(table: string): ColumnRow[] {
+  return db.prepare(`PRAGMA table_info(${table})`).all() as ColumnRow[];
+}
+
+beforeAll(async () => {
+  ({ default: db } = await import('./index.js'));
+});
+
+describe('BUFFER_KEYED_TABLES completeness', () => {
+  it('declares every table in the live schema with a buffer-target column', () => {
+    const declared = new Set(BUFFER_KEYED_TABLES.map((t) => t.table));
+    const exempt = new Set(NON_BUFFER_TARGET_TABLES);
+
+    const undeclared: string[] = [];
+    for (const table of tableNames()) {
+      if (declared.has(table) || exempt.has(table)) continue;
+      const hit = columns(table).find((c) => BUFFER_TARGET_COLUMN_NAMES.includes(c.name));
+      if (hit) undeclared.push(`${table}.${hit.name}`);
+    }
+
+    // A new buffer-keyed table has to be added to BUFFER_KEYED_TABLES (with a
+    // collision policy) so renameBuffer visits it. If the column only looks like
+    // a buffer target and isn't one, add the table to NON_BUFFER_TARGET_TABLES
+    // with a reason — but read renameBuffer first and be sure.
+    expect(undeclared).toEqual([]);
+  });
+
+  it('declares no table or column that the live schema lacks', () => {
+    // The reverse drift, and the one that actually broke the fold: a declared
+    // table that has since been dropped. Legacy entries are exempt by
+    // definition — a fresh install never creates them.
+    const live = new Set(tableNames());
+    const missing: string[] = [];
+    for (const t of CURRENT_BUFFER_KEYED_TABLES) {
+      if (!live.has(t.table)) {
+        missing.push(t.table);
+        continue;
+      }
+      const names = new Set(columns(t.table).map((c) => c.name));
+      for (const col of [t.column, t.derivedColumn, ...t.scope].filter(Boolean) as string[]) {
+        if (!names.has(col)) missing.push(`${t.table}.${col}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('marks exactly the COLLATE NOCASE target columns as caseInsensitive', () => {
+    // caseInsensitive is what lets foldBufferCase skip a table. Getting it wrong
+    // in one direction makes the fold do pointless work; in the other it makes
+    // the fold miss a real case fork.
+    const mismatches: string[] = [];
+    for (const t of CURRENT_BUFFER_KEYED_TABLES) {
+      const ddl = (
+        db
+          .prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+          .get(t.table) as { sql: string } | undefined
+      )?.sql;
+      if (!ddl) continue;
+      const decl = new RegExp(`\\b${t.column}\\b[^,]*`, 'i').exec(ddl)?.[0] ?? '';
+      const nocase = /COLLATE\s+NOCASE/i.test(decl);
+      if (nocase !== !!t.caseInsensitive) {
+        mismatches.push(`${t.table}.${t.column}: schema=${nocase} declared=${!!t.caseInsensitive}`);
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it('has no duplicate table entries', () => {
+    const names = BUFFER_KEYED_TABLES.map((t) => t.table);
+    expect(names.length).toBe(new Set(names).size);
+  });
+});
+
+describe('the retired tables really are retired', () => {
+  it('does not create channels or closed_buffers on a fresh install', () => {
+    // Pins the reason the legacy entries exist. If a fresh install ever grows
+    // these back, the existence gates around them are wrong.
+    const live = new Set(tableNames());
+    expect(live.has('channels')).toBe(false);
+    expect(live.has('closed_buffers')).toBe(false);
+  });
+});

--- a/server/db/bufferKeyedTables.ts
+++ b/server/db/bufferKeyedTables.ts
@@ -65,6 +65,11 @@ export interface BufferKeyedTable {
    * forget, not because anything handles them generically.
    */
   listValued?: boolean;
+  /**
+   * Sentinel values in this column that are NOT buffer names and must never be
+   * rewritten, however exactly a target appears to match them.
+   */
+  excludeValues?: readonly string[];
 }
 
 export const BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = [
@@ -166,6 +171,20 @@ export const BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = [
     caseInsensitive: true,
   },
 
+  // E2E auto-trust rules, scoped per channel. The column is `scope` rather than
+  // `channel` and holds either a channel name or the literal sentinel 'global',
+  // which is why it hid from the first version of the drift test — and why it
+  // needs `excludeValues`: a DM buffer whose peer is nicked `global` would
+  // otherwise rewrite the user's network-wide auto-trust rule.
+  {
+    table: 'e2e_autotrust',
+    column: 'scope',
+    scope: ['user_id', 'network_id'],
+    policy: 'destination-wins',
+    caseInsensitive: true,
+    excludeValues: ['global'],
+  },
+
   // ---- List-valued scopes. ----
   // Both hold a CSV of channel GLOBS, not a single exact target, so neither can
   // be rewritten by the whole-column UPDATE every other entry uses. A rule
@@ -225,21 +244,53 @@ export const CURRENT_BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = BUFFER_K
  * singular `channel` matched the e2e tables, the plural did not match anything,
  * and both CSV columns sailed past a test whose whole job was catching them.
  *
+ * `scope` is here for `e2e_autotrust`, which hid from the first version of this
+ * list for the same reason `channels` did — it names a buffer without using any
+ * of the words the list knew about. It costs three exemptions below, which is
+ * the right trade: an exemption is a decision someone wrote down, an omission is
+ * a rename that silently strands rows.
+ *
  * This is a heuristic and its limits are real. It cannot catch a column that
- * names the same concept differently — `instance_network.channels_json` (admin
- * autojoin config) and `chanlist_channels.name` (an ephemeral /LIST cache) are
- * both buffer-name-shaped and both invisible here. Neither is per-user buffer
- * state, so neither belongs in a rename; adding `name` to this list would flag
- * half the schema. If you add a buffer-keyed table, name the column `target`.
+ * names the same concept differently again — `instance_network.channels_json`
+ * (admin autojoin config) and `chanlist_channels.name` (an ephemeral /LIST
+ * cache) are both buffer-name-shaped and both invisible here. Neither is
+ * per-user buffer state, so neither belongs in a rename; adding `name` would
+ * flag half the schema. If you add a buffer-keyed table, name the column
+ * `target`.
  */
-export const BUFFER_TARGET_COLUMN_NAMES: readonly string[] = ['target', 'channel', 'channels'];
+export const BUFFER_TARGET_COLUMN_NAMES: readonly string[] = [
+  'target',
+  'channel',
+  'channels',
+  'scope',
+];
 
 /**
- * Tables that have a column named like a buffer target but genuinely aren't
- * buffer-keyed. Listed explicitly so the drift test stays a real assertion
- * rather than something that gets loosened the first time it fires.
+ * Tables with a column named like a buffer target that genuinely isn't one.
+ * Listed explicitly so the drift test stays a real assertion rather than
+ * something that gets loosened the first time it fires.
  */
-export const NON_BUFFER_TARGET_TABLES: readonly string[] = [];
+export const NON_BUFFER_TARGET_TABLES: readonly string[] = [
+  'api_tokens', // scope = permission scope
+  'system_messages', // scope = message origin ('lurker')
+  'uploader_config', // scope = 'instance' | 'user'
+];
+
+/**
+ * Nick-keyed per-user state. Not buffer-keyed — these attach to a person, not a
+ * buffer — but for a DM the two coincide, so a peer's nick change moves the
+ * buffer and leaves these behind under the old nick.
+ *
+ * Deliberately NOT in the registry: renaming a channel must not touch them, and
+ * whether a nick note should follow its subject through a nick change is a
+ * product decision the DM-rename work has to make. Recorded here so that
+ * decision is made rather than missed.
+ */
+export const NICK_KEYED_TABLES: readonly string[] = [
+  'user_nick_notes',
+  'user_relay_bots',
+  'peer_presence_state',
+];
 
 /** The declared entry for a table, or undefined when it isn't buffer-keyed. */
 export function bufferKeyedTable(table: string): BufferKeyedTable | undefined {

--- a/server/db/bufferKeyedTables.ts
+++ b/server/db/bufferKeyedTables.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The registry of every table that stores a buffer target as a string.
+//
+// Buffers are not normalized: `buffers.id` exists but nothing references it, and
+// each table below denormalizes the target as text with no foreign key. That is
+// a deliberate trade (see docs on idx_messages_unread — a buffer_id join would
+// sit on the hottest read path there is), and the cost of it is this list. Any
+// operation that changes a buffer's name has to visit every entry, and one
+// that's missed is silent data loss: a rename that leaves a row behind orphans
+// the user's draft, or their pin, or their read pointer.
+//
+// The list has drifted before. `foldBufferCase` carried its own copy, stopped
+// being updated around schema 9, and by schema 16 was naming two tables that had
+// been dropped. bufferKeyedTables.test.ts introspects the live schema and fails
+// when a table with a buffer-shaped column isn't declared here — that test, not
+// this comment, is what keeps the list honest.
+
+/** How a rename resolves a row that would collide at the destination. */
+export type CollisionPolicy =
+  // No uniqueness on the target — every row is rewritten, collisions impossible.
+  | 'rewrite'
+  // (scope..., target) is unique. A destination row already exists, so the
+  // source row is dropped and the destination's value wins.
+  | 'destination-wins'
+  // Unique, but the two rows carry progress that has to be reconciled rather
+  // than picked between. Handled explicitly by the caller, never generically.
+  | 'merge';
+
+export interface BufferKeyedTable {
+  table: string;
+  /** The column holding the buffer target. */
+  column: string;
+  /**
+   * Columns that scope a target to one row, alongside `column` itself. Drives
+   * both the collision lookup and the WHERE clause of a per-user rename.
+   */
+  scope: readonly string[];
+  policy: CollisionPolicy;
+  /**
+   * A second column holding a derived form of the target that must be rewritten
+   * in lockstep. Only `buffers` has one (`target_folded`, its actual lookup key).
+   */
+  derivedColumn?: string;
+  /**
+   * True when the column is declared COLLATE NOCASE, so case variants already
+   * collapse to one row and a case-only fold has nothing to do. Renames still
+   * have to rewrite it; only `foldBufferCase` may skip these.
+   */
+  caseInsensitive?: boolean;
+  /**
+   * Retired tables kept here so the fold can still repair a database that is
+   * mid-upgrade and hasn't dropped them yet. Never present on a fresh install,
+   * so every use has to be existence-gated.
+   */
+  legacy?: boolean;
+}
+
+export const BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = [
+  // The buffer registry itself. `target` is display casing; `target_folded` is
+  // the real lookup key (unique index idx_buffers_key), so both move together or
+  // the row becomes unfindable.
+  {
+    table: 'buffers',
+    column: 'target',
+    derivedColumn: 'target_folded',
+    scope: ['user_id', 'network_id'],
+    policy: 'merge',
+  },
+
+  // History. By far the largest, and the only one where the rewrite cost is
+  // worth thinking about — see renameBuffer's chunking.
+  { table: 'messages', column: 'target', scope: ['network_id'], policy: 'rewrite' },
+
+  // Per-buffer input history: id-keyed, many rows per target.
+  {
+    table: 'input_history',
+    column: 'target',
+    scope: ['user_id', 'network_id'],
+    policy: 'rewrite',
+  },
+
+  // Read pointer + /clear marker. Both sides carry progress the user can lose,
+  // so a collision keeps the furthest of each rather than picking a row.
+  {
+    table: 'buffer_reads',
+    column: 'target',
+    scope: ['user_id', 'network_id'],
+    policy: 'merge',
+  },
+
+  // Sidebar pins. Positions are dense per (user, network), so dropping a
+  // colliding row leaves a gap that has to be renumbered afterwards.
+  {
+    table: 'pinned_buffers',
+    column: 'target',
+    scope: ['user_id', 'network_id'],
+    policy: 'merge',
+  },
+
+  // Plain per-buffer preferences: nothing to reconcile, the destination wins.
+  {
+    table: 'nicklist_collapsed',
+    column: 'target',
+    scope: ['user_id', 'network_id'],
+    policy: 'destination-wins',
+  },
+  {
+    table: 'channel_notify_settings',
+    column: 'target',
+    scope: ['user_id', 'network_id'],
+    policy: 'destination-wins',
+  },
+  {
+    table: 'user_drafts',
+    column: 'target',
+    scope: ['user_id', 'network_id'],
+    policy: 'destination-wins',
+  },
+
+  // E2E session state, keyed on `channel`. All COLLATE NOCASE, so these never
+  // case-forked and the fold correctly ignores them — but a rename moves a
+  // channel to a genuinely different name, and leaving the session state behind
+  // would silently break encryption for the renamed channel.
+  {
+    table: 'e2e_incoming_sessions',
+    column: 'channel',
+    scope: ['user_id', 'network_id', 'handle'],
+    policy: 'destination-wins',
+    caseInsensitive: true,
+  },
+  {
+    table: 'e2e_outgoing_sessions',
+    column: 'channel',
+    scope: ['user_id', 'network_id'],
+    policy: 'destination-wins',
+    caseInsensitive: true,
+  },
+  {
+    table: 'e2e_channel_config',
+    column: 'channel',
+    scope: ['user_id', 'network_id'],
+    policy: 'destination-wins',
+    caseInsensitive: true,
+  },
+  {
+    table: 'e2e_outgoing_recipients',
+    column: 'channel',
+    scope: ['user_id', 'network_id', 'handle'],
+    policy: 'destination-wins',
+    caseInsensitive: true,
+  },
+
+  // ---- Retired at schema 16, replaced by the `buffers` registry. ----
+  // foldBufferCase runs mid-upgrade, before these are dropped, so it still has
+  // to repair them; everything else must skip them. Existence-gated at every
+  // use — on a fresh install they were never created.
+  {
+    table: 'channels',
+    column: 'name',
+    scope: ['network_id'],
+    policy: 'merge',
+    legacy: true,
+  },
+  {
+    table: 'closed_buffers',
+    column: 'target',
+    scope: ['user_id', 'network_id'],
+    policy: 'destination-wins',
+    legacy: true,
+  },
+];
+
+/** Live (non-retired) tables — what a rename on a current database must visit. */
+export const CURRENT_BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = BUFFER_KEYED_TABLES.filter(
+  (t) => !t.legacy,
+);
+
+/**
+ * Column names that mean "a buffer target" for drift detection. A new table
+ * using one of these gets caught by bufferKeyedTables.test.ts; a new table that
+ * invents a different name for the same thing does not, so don't.
+ */
+export const BUFFER_TARGET_COLUMN_NAMES: readonly string[] = ['target', 'channel'];
+
+/**
+ * Tables that have a column named like a buffer target but genuinely aren't
+ * buffer-keyed. Listed explicitly so the drift test stays a real assertion
+ * rather than something that gets loosened the first time it fires.
+ */
+export const NON_BUFFER_TARGET_TABLES: readonly string[] = [];

--- a/server/db/bufferKeyedTables.ts
+++ b/server/db/bufferKeyedTables.ts
@@ -55,6 +55,16 @@ export interface BufferKeyedTable {
    * so every use has to be existence-gated.
    */
   legacy?: boolean;
+  /** Dropping a colliding row leaves a position gap that must be renumbered. */
+  requiresPinRenumber?: boolean;
+  /**
+   * The column holds a LIST of targets (CSV or JSON), not one. A whole-column
+   * rewrite is wrong for these — the value has to be parsed, the matching
+   * element replaced, and the rest left alone — so no generic path may touch
+   * them. Declared here so they are visible to the drift test and impossible to
+   * forget, not because anything handles them generically.
+   */
+  listValued?: boolean;
 }
 
 export const BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = [
@@ -90,13 +100,17 @@ export const BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = [
     policy: 'merge',
   },
 
-  // Sidebar pins. Positions are dense per (user, network), so dropping a
-  // colliding row leaves a gap that has to be renumbered afterwards.
+  // Sidebar pins. A collision drops the source row — there is no progress to
+  // reconcile, only a slot — but positions are dense per (user, network) and
+  // reorderPins assumes 0..n-1, so the drop leaves a gap that must be renumbered
+  // afterwards. That post-step is why this is flagged rather than being a plain
+  // destination-wins table.
   {
     table: 'pinned_buffers',
     column: 'target',
     scope: ['user_id', 'network_id'],
-    policy: 'merge',
+    policy: 'destination-wins',
+    requiresPinRenumber: true,
   },
 
   // Plain per-buffer preferences: nothing to reconcile, the destination wins.
@@ -152,6 +166,32 @@ export const BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = [
     caseInsensitive: true,
   },
 
+  // ---- List-valued scopes. ----
+  // Both hold a CSV of channel GLOBS, not a single exact target, so neither can
+  // be rewritten by the whole-column UPDATE every other entry uses. A rule
+  // scoped to the literal `#old` should follow a rename; one scoped to `#old*`
+  // is a pattern and must not be rewritten blindly.
+  //
+  // Nothing handles them yet — the fold skips them (case-folding a glob is
+  // safe to defer; the matcher is case-insensitive) and renameBuffer will need
+  // bespoke parse-and-replace. They are declared so the gap is visible in the
+  // registry and enforced by the drift test rather than being an omission
+  // nobody notices, which is exactly how the previous list rotted.
+  {
+    table: 'highlight_rules',
+    column: 'channels',
+    scope: ['user_id'],
+    policy: 'merge',
+    listValued: true,
+  },
+  {
+    table: 'ignored_masks',
+    column: 'channels',
+    scope: ['user_id', 'network_id'],
+    policy: 'merge',
+    listValued: true,
+  },
+
   // ---- Retired at schema 16, replaced by the `buffers` registry. ----
   // foldBufferCase runs mid-upgrade, before these are dropped, so it still has
   // to repair them; everything else must skip them. Existence-gated at every
@@ -178,11 +218,21 @@ export const CURRENT_BUFFER_KEYED_TABLES: readonly BufferKeyedTable[] = BUFFER_K
 );
 
 /**
- * Column names that mean "a buffer target" for drift detection. A new table
- * using one of these gets caught by bufferKeyedTables.test.ts; a new table that
- * invents a different name for the same thing does not, so don't.
+ * Column names that mean "a buffer target" for drift detection.
+ *
+ * `channels` is in the list because leaving it out is precisely how
+ * `highlight_rules.channels` and `ignored_masks.channels` stayed invisible: the
+ * singular `channel` matched the e2e tables, the plural did not match anything,
+ * and both CSV columns sailed past a test whose whole job was catching them.
+ *
+ * This is a heuristic and its limits are real. It cannot catch a column that
+ * names the same concept differently — `instance_network.channels_json` (admin
+ * autojoin config) and `chanlist_channels.name` (an ephemeral /LIST cache) are
+ * both buffer-name-shaped and both invisible here. Neither is per-user buffer
+ * state, so neither belongs in a rename; adding `name` to this list would flag
+ * half the schema. If you add a buffer-keyed table, name the column `target`.
  */
-export const BUFFER_TARGET_COLUMN_NAMES: readonly string[] = ['target', 'channel'];
+export const BUFFER_TARGET_COLUMN_NAMES: readonly string[] = ['target', 'channel', 'channels'];
 
 /**
  * Tables that have a column named like a buffer target but genuinely aren't
@@ -190,3 +240,8 @@ export const BUFFER_TARGET_COLUMN_NAMES: readonly string[] = ['target', 'channel
  * rather than something that gets loosened the first time it fires.
  */
 export const NON_BUFFER_TARGET_TABLES: readonly string[] = [];
+
+/** The declared entry for a table, or undefined when it isn't buffer-keyed. */
+export function bufferKeyedTable(table: string): BufferKeyedTable | undefined {
+  return BUFFER_KEYED_TABLES.find((t) => t.table === table);
+}

--- a/server/db/foldBufferCase.test.ts
+++ b/server/db/foldBufferCase.test.ts
@@ -194,3 +194,69 @@ describe('foldBufferCase', () => {
     expect(targetCounts(net)).toEqual({ '#solo': 3, Carol: 2 });
   });
 });
+
+// The `buffers` registry is the display casing every reader is handed, and the
+// backlog query matches `target` EXACTLY. So on a post-registry database the
+// fold must land history on the casing `buffers` holds — folding to the
+// message-majority casing instead leaves the registry pointing at a name no row
+// carries, and the buffer opens blank.
+describe('canon defers to the buffers registry', () => {
+  function addBufferRow(networkId: number, target: string): void {
+    db.prepare(
+      `INSERT INTO buffers (user_id, network_id, target, target_folded, kind, state)
+       VALUES (?, ?, ?, ?, 'channel', 'open')`,
+    ).run(userId, networkId, target, target.toLowerCase());
+  }
+  /** What the open-buffer path actually runs: exact match on buffers.target. */
+  function backlogCount(networkId: number, registryTarget: string): number {
+    return (
+      db
+        .prepare(`SELECT COUNT(*) AS n FROM messages WHERE network_id = ? AND target = ?`)
+        .get(networkId, registryTarget) as { n: number }
+    ).n;
+  }
+
+  it('folds to the registry casing even when the message majority disagrees', () => {
+    const net = freshNetwork();
+    addBufferRow(net, '#Foo'); // registry says '#Foo'...
+    seed(net, '#Foo', 3);
+    seed(net, '#foo', 900); // ...but the messages overwhelmingly say '#foo'
+
+    const report = foldBufferCase(db, { scope: 'all' });
+
+    expect(report.forks.find((f) => f.lkey === '#foo')?.canonical).toBe('#Foo');
+    expect(targetCounts(net)).toEqual({ '#Foo': 903 });
+    // The assertion that matters: the buffer the user opens is not empty.
+    expect(backlogCount(net, '#Foo')).toBe(903);
+  });
+
+  it('still uses the message majority when no registry row exists', () => {
+    // The schema-16 migration folds BEFORE it populates `buffers`, so this path
+    // has to keep working exactly as it always did.
+    const net = freshNetwork();
+    seed(net, '#Bar', 1);
+    seed(net, '#bar', 5);
+
+    foldBufferCase(db, { scope: 'all' });
+
+    expect(targetCounts(net)).toEqual({ '#bar': 6 });
+  });
+
+  it('carries per-user state onto the registry casing too', () => {
+    const net = freshNetwork();
+    addBufferRow(net, '#Baz');
+    seed(net, '#Baz', 1);
+    seed(net, '#baz', 50);
+    db.prepare(
+      `INSERT INTO user_drafts (user_id, network_id, target, body) VALUES (?, ?, '#baz', 'wip')`,
+    ).run(userId, net);
+
+    foldBufferCase(db, { scope: 'all' });
+
+    const draft = db
+      .prepare(`SELECT target FROM user_drafts WHERE user_id = ? AND network_id = ?`)
+      .get(userId, net) as { target: string } | undefined;
+    // Orphaning this under '#baz' would lose the draft — nothing looks it up.
+    expect(draft?.target).toBe('#Baz');
+  });
+});

--- a/server/db/foldBufferCase.test.ts
+++ b/server/db/foldBufferCase.test.ts
@@ -207,6 +207,13 @@ describe('canon defers to the buffers registry', () => {
        VALUES (?, ?, ?, ?, 'channel', 'open')`,
     ).run(userId, networkId, target, target.toLowerCase());
   }
+  function countUnder(networkId: number, target: string): number {
+    return (
+      db
+        .prepare(`SELECT COUNT(*) AS n FROM messages WHERE network_id = ? AND target = ?`)
+        .get(networkId, target) as { n: number }
+    ).n;
+  }
   /** What the open-buffer path actually runs: exact match on buffers.target. */
   function backlogCount(networkId: number, registryTarget: string): number {
     return (
@@ -228,6 +235,28 @@ describe('canon defers to the buffers registry', () => {
     expect(targetCounts(net)).toEqual({ '#Foo': 903 });
     // The assertion that matters: the buffer the user opens is not empty.
     expect(backlogCount(net, '#Foo')).toBe(903);
+  });
+
+  it('fires for a target containing a non-ASCII character', () => {
+    // The override joins with SQLite's lower() on BOTH sides. Joining
+    // buffers.target_folded (JS toLowerCase, Unicode-aware) against lkey
+    // (SQL lower, ASCII-only) silently never matched once a target held a
+    // non-ASCII letter — '#Ärger' folds to '#ärger' in JS and stays '#Ärger'
+    // in SQL — so the override skipped exactly the buffers it exists to protect.
+    //
+    // The two casings here differ only in ASCII letters, so SQLite groups them.
+    // A pair differing in the non-ASCII letter ('#Ärger' vs '#ärger') is NOT
+    // grouped by this fold at all — its canon query is ASCII-only too. That
+    // predates the override and is not something joining consistently can fix.
+    const net = freshNetwork();
+    addBufferRow(net, '#Ärger');
+    seed(net, '#ÄRGER', 20); // message majority...
+    seed(net, '#Ärger', 1); // ...but the registry says this one
+
+    foldBufferCase(db, { scope: 'all' });
+
+    expect(backlogCount(net, '#Ärger')).toBe(21);
+    expect(countUnder(net, '#ÄRGER')).toBe(0);
   });
 
   it('still uses the message majority when no registry row exists', () => {

--- a/server/db/foldBufferCase.ts
+++ b/server/db/foldBufferCase.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type Database from 'better-sqlite3';
-import { CURRENT_BUFFER_KEYED_TABLES } from './bufferKeyedTables.js';
+import { BUFFER_KEYED_TABLES, bufferKeyedTable } from './bufferKeyedTables.js';
 
 // Case-fold repair for forked buffers (#268 channels, #289/#327 generalization).
 //
@@ -85,26 +85,31 @@ export interface FoldReport {
 //     merge. A rename is different and must visit them; a case fold has nothing
 //     to do there.
 //
-//   - `buffers` is skipped. Its lookup key is `target_folded`, so it cannot fork
-//     either, and `buffers.target` is the authoritative display casing
-//     (first-writer-wins) rather than something derived from message counts.
-//     Overwriting it from the message-majority casing would be a behavior
-//     change, not a repair — left alone deliberately. The consequence is that
-//     after a fold the sidebar can show a different casing than the folded
-//     history; both still resolve to the same buffer, because every lookup goes
-//     through the folded key.
+//   - `buffers` is skipped, because it cannot fork (its lookup key is
+//     `target_folded`) and because it is not the fold's to rewrite: post-schema-16
+//     `buffers.target` is the authoritative display casing. Rather than fold it,
+//     the fold now DEFERS to it — see the _buf_canon override in work(), which
+//     takes canon from the registry row when one exists. Getting this backwards
+//     empties the buffer; the override comment has the mechanism.
 //
-// `channels` is handled separately below (its column is `name`, and it needs a
-// key-preserving merge).
+//   - List-valued columns are skipped. `highlight_rules.channels` and
+//     `ignored_masks.channels` hold CSVs of channel globs, and the matcher is
+//     case-insensitive, so a case fold has nothing it must repair there.
 //
-// This is the CANDIDATE set. Schema 16 drops `closed_buffers`, but the fold runs
-// mid-upgrade while it still exists, so it stays a candidate and every use is
-// filtered through `existing()` against the database actually in hand.
-const CANDIDATE_TARGET_TABLES: readonly string[] = CURRENT_BUFFER_KEYED_TABLES.filter(
-  (t) => !t.caseInsensitive && t.table !== 'buffers' && t.column === 'target',
-)
-  .map((t) => t.table)
-  .concat(['closed_buffers']);
+// `channels` (the retired table) is handled separately below — its column is
+// `name`, and it needs a key-preserving merge.
+//
+// This is the CANDIDATE set: schema 16 drops the legacy tables, but the fold
+// runs mid-upgrade while they still exist, so they stay candidates and every use
+// is filtered by `tableExists` against the database actually in hand. Legacy
+// entries come from the registry's own `legacy` flag rather than being named
+// again here — a second hardcoded copy is what rotted the first time.
+const SKIPPED_FROM_FOLD = new Set(['buffers']);
+const foldable = (t: (typeof BUFFER_KEYED_TABLES)[number]): boolean =>
+  t.column === 'target' && !t.caseInsensitive && !t.listValued && !SKIPPED_FROM_FOLD.has(t.table);
+const CANDIDATE_TARGET_TABLES: readonly string[] = BUFFER_KEYED_TABLES.filter(foldable).map(
+  (t) => t.table,
+);
 
 export function foldBufferCase(
   db: Database.Database,
@@ -160,6 +165,42 @@ export function foldBufferCase(
         GROUP BY network_id, target
       ) WHERE rn = 1
     `);
+
+    // Where a `buffers` row exists, ITS casing is canon — overriding the
+    // message-majority pick above.
+    //
+    // This is not a preference. Post-schema-16 `buffers.target` is the display
+    // casing every reader is handed: wsHub's open-buffer path passes `row.target`
+    // straight into buildBufferBacklog, and from there `listMessagesCounted`
+    // matches `target = ?` EXACTLY (messages.ts) — as do the draft, pin and
+    // read-pointer lookups. Only the existence gate in front of it
+    // (`hasMessageForTarget`) is COLLATE NOCASE.
+    //
+    // So folding history to the message-majority casing while leaving
+    // `buffers.target` alone doesn't produce a cosmetic mismatch, it empties the
+    // buffer: the NOCASE gate still says "has messages", the exact-match backlog
+    // query returns zero rows, and the draft and read pointer are orphaned under
+    // a name nothing looks up. Taking canon from `buffers` instead keeps every
+    // consumer pointing at the rows the fold just moved.
+    //
+    // Absent during the schema-16 migration's own call — the fold runs before
+    // `buffers` is populated — so that path keeps the message-majority behavior
+    // it has always had. Same for any buffer with history but no registry row.
+    if (tableExists('buffers')) {
+      db.exec(`
+        UPDATE _buf_canon SET canon = (
+          SELECT b.target FROM buffers b
+           WHERE b.network_id = _buf_canon.network_id
+             AND b.target_folded = _buf_canon.lkey
+           LIMIT 1
+        )
+        WHERE EXISTS (
+          SELECT 1 FROM buffers b
+           WHERE b.network_id = _buf_canon.network_id
+             AND b.target_folded = _buf_canon.lkey
+        )
+      `);
+    }
 
     // ---- Report (computed pre-apply so counts reflect what will change).
     // Skipped entirely when the caller doesn't want it (the migration), since
@@ -225,8 +266,9 @@ export function foldBufferCase(
     }
 
     if (!dryRun) {
-      // id-keyed (target not unique) — straight rewrite. messages_fts only indexes
-      // text, so the AFTER UPDATE trigger reindexes identical text (harmless).
+      // id-keyed (target not unique) — straight rewrite. messages_fts indexes
+      // only `text`, and messages_au is guarded on `text`/`id`, so rewriting
+      // `target` doesn't fire it at all.
       for (const t of ['messages', 'input_history']) {
         db.exec(`UPDATE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
       }
@@ -295,11 +337,25 @@ export function foldBufferCase(
       }
 
       // Remaining per-(user, network, target) state: move to canon, or drop if a
-      // canon row already exists (its state wins). Whatever the registry declares
-      // beyond the tables handled explicitly above — so a newly-added
-      // destination-wins table is folded without touching this loop.
+      // canon row already exists (its state wins).
+      //
+      // This loop implements destination-wins and NOTHING ELSE, so it asserts
+      // that rather than trusting the filter above to have excluded everything
+      // else. A table declared `merge` carries progress that has to be
+      // reconciled — the registry's own words — and quietly running it through
+      // here would delete that progress with no error and no report line. A new
+      // registry entry either belongs in this loop or fails loudly on the first
+      // fold, which is the only outcome that can't ship silently.
       const handledExplicitly = ['messages', 'input_history', 'buffer_reads', 'closed_buffers'];
       for (const t of TARGET_TABLES.filter((n) => !handledExplicitly.includes(n))) {
+        const policy = bufferKeyedTable(t)?.policy;
+        if (policy !== 'destination-wins') {
+          throw new Error(
+            `foldBufferCase: ${t} is declared policy '${policy}' but reached the ` +
+              `destination-wins loop. Give it explicit handling above, or correct ` +
+              `its policy in bufferKeyedTables.ts.`,
+          );
+        }
         db.exec(`UPDATE OR IGNORE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
         db.exec(`DELETE FROM ${t} WHERE ${needsFold(t)}`);
       }

--- a/server/db/foldBufferCase.ts
+++ b/server/db/foldBufferCase.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type Database from 'better-sqlite3';
+import { CURRENT_BUFFER_KEYED_TABLES } from './bufferKeyedTables.js';
 
 // Case-fold repair for forked buffers (#268 channels, #289/#327 generalization).
 //
@@ -34,11 +35,16 @@ import type Database from 'better-sqlite3';
 // The schema version this fold was last audited against. The schema-version-9
 // migration in index.ts calls foldBufferCase mid-upgrade (before the version row
 // is written), so it can't be gated — but the manual operator script refuses to
-// run unless the DB sits exactly here. A future migration that adds or reshapes
-// a buffer-keyed table must re-check TARGET_TABLES (and the channels/buffer_reads
-// merges) below, then deliberately bump this in lockstep with SCHEMA_VERSION in
-// index.ts — so the script can never silently fold an out-of-date table set.
-export const FOLD_VALIDATED_SCHEMA_VERSION = 9;
+// run unless the DB sits exactly here.
+//
+// It sat at 9 while SCHEMA_VERSION reached 16, which made the operator script
+// refuse to run on every current database. That guard was doing its job: by 16
+// this file was addressing `channels` and `closed_buffers`, both of which
+// schema 16 drops, so a run would have died on "no such table: channels". The
+// tables it names are now existence-gated and derived from BUFFER_KEYED_TABLES,
+// and bufferKeyedTables.test.ts fails when a new buffer-keyed table appears
+// undeclared — so re-auditing is a test failure now, not a memo.
+export const FOLD_VALIDATED_SCHEMA_VERSION = 16;
 
 export type FoldScope = 'channels' | 'all';
 
@@ -69,19 +75,36 @@ export interface FoldReport {
   forks: FoldGroup[];
 }
 
-// Tables keyed by a per-buffer `target` column (channels live in `channels.name`,
-// handled separately). Order matters only for readability; each fold is
-// independent.
-const TARGET_TABLES = [
-  'messages',
-  'input_history',
-  'buffer_reads',
-  'closed_buffers',
-  'pinned_buffers',
-  'nicklist_collapsed',
-  'channel_notify_settings',
-  'user_drafts',
-] as const;
+// Tables this fold rewrites, derived from the one registry rather than kept as a
+// second hand-maintained copy — the copy is what rotted.
+//
+// Two filters, both deliberate:
+//
+//   - COLLATE NOCASE columns are skipped. The e2e tables declare `channel` that
+//     way, so their rows already collapse across casings and there is no fork to
+//     merge. A rename is different and must visit them; a case fold has nothing
+//     to do there.
+//
+//   - `buffers` is skipped. Its lookup key is `target_folded`, so it cannot fork
+//     either, and `buffers.target` is the authoritative display casing
+//     (first-writer-wins) rather than something derived from message counts.
+//     Overwriting it from the message-majority casing would be a behavior
+//     change, not a repair — left alone deliberately. The consequence is that
+//     after a fold the sidebar can show a different casing than the folded
+//     history; both still resolve to the same buffer, because every lookup goes
+//     through the folded key.
+//
+// `channels` is handled separately below (its column is `name`, and it needs a
+// key-preserving merge).
+//
+// This is the CANDIDATE set. Schema 16 drops `closed_buffers`, but the fold runs
+// mid-upgrade while it still exists, so it stays a candidate and every use is
+// filtered through `existing()` against the database actually in hand.
+const CANDIDATE_TARGET_TABLES: readonly string[] = CURRENT_BUFFER_KEYED_TABLES.filter(
+  (t) => !t.caseInsensitive && t.table !== 'buffers' && t.column === 'target',
+)
+  .map((t) => t.table)
+  .concat(['closed_buffers']);
 
 export function foldBufferCase(
   db: Database.Database,
@@ -99,6 +122,16 @@ export function foldBufferCase(
   // channels; 'all' covers every real buffer — every channel prefix (#, &, +, !)
   // and DM nicks — while still excluding the ':'-virtual buffers.
   const pred = (col: string) => (scope === 'all' ? `${col} NOT LIKE ':%'` : `${col} LIKE '#%'`);
+
+  // Tables that exist in THIS database. The fold runs both mid-upgrade (schema
+  // 16, before it drops the legacy tables) and standalone from the operator
+  // script afterwards, so which tables are present is a property of the database
+  // in hand, not of the code. Resolved once — the set can't change under a
+  // single call, and every use below is inside the same transaction.
+  const tableExists = (t: string): boolean =>
+    !!db.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`).get(t);
+  const TARGET_TABLES = CANDIDATE_TARGET_TABLES.filter(tableExists);
+  const hasChannels = tableExists('channels');
 
   // Resolves a row's canonical case from the temp table; matches only off-case
   // rows that have a canonical to fold into (so single-case targets and virtuals
@@ -139,17 +172,21 @@ export function foldBufferCase(
           db.prepare(`SELECT COUNT(*) AS n FROM ${t} WHERE ${needsFold(t)}`).get() as { n: number }
         ).n;
       }
-      rowsAffected['channels'] = (
-        db
-          .prepare(
-            `SELECT COUNT(*) AS n FROM channels
-               WHERE ${pred('name')} AND EXISTS (
-                 SELECT 1 FROM _buf_canon c
-                 WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
-                   AND c.canon <> channels.name)`,
-          )
-          .get() as { n: number }
-      ).n;
+      // Omitted rather than reported as 0 once the table is gone, so the report
+      // distinguishes "nothing to fold" from "not applicable to this schema".
+      if (hasChannels) {
+        rowsAffected['channels'] = (
+          db
+            .prepare(
+              `SELECT COUNT(*) AS n FROM channels
+                 WHERE ${pred('name')} AND EXISTS (
+                   SELECT 1 FROM _buf_canon c
+                   WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
+                     AND c.canon <> channels.name)`,
+            )
+            .get() as { n: number }
+        ).n;
+      }
 
       const variantRows = db
         .prepare(
@@ -199,23 +236,28 @@ export function foldBufferCase(
       // drop the off-case variant. Carrying `key` here is essential — without it
       // the merge would strip the channel key off a case-forked keyed channel
       // and it would fail to auto-rejoin after the next reconnect.
-      db.exec(`
-        INSERT INTO channels (network_id, name, joined, created_at, key)
-          SELECT ch.network_id, c.canon, ch.joined, ch.created_at, ch.key
-          FROM channels ch JOIN _buf_canon c
-            ON c.network_id = ch.network_id AND c.lkey = lower(ch.name)
-          WHERE ${pred('ch.name')} AND c.canon <> ch.name
-        ON CONFLICT(network_id, name) DO UPDATE SET
-          joined = MAX(channels.joined, excluded.joined),
-          created_at = MIN(channels.created_at, excluded.created_at),
-          key = COALESCE(channels.key, excluded.key)
-      `);
-      db.exec(`
-        DELETE FROM channels WHERE ${pred('name')} AND EXISTS (
-          SELECT 1 FROM _buf_canon c
-          WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
-            AND c.canon <> channels.name)
-      `);
+      //
+      // Retired by schema 16 in favor of `buffers`; still reachable because the
+      // v16 migration folds before it drops the table.
+      if (hasChannels) {
+        db.exec(`
+          INSERT INTO channels (network_id, name, joined, created_at, key)
+            SELECT ch.network_id, c.canon, ch.joined, ch.created_at, ch.key
+            FROM channels ch JOIN _buf_canon c
+              ON c.network_id = ch.network_id AND c.lkey = lower(ch.name)
+            WHERE ${pred('ch.name')} AND c.canon <> ch.name
+          ON CONFLICT(network_id, name) DO UPDATE SET
+            joined = MAX(channels.joined, excluded.joined),
+            created_at = MIN(channels.created_at, excluded.created_at),
+            key = COALESCE(channels.key, excluded.key)
+        `);
+        db.exec(`
+          DELETE FROM channels WHERE ${pred('name')} AND EXISTS (
+            SELECT 1 FROM _buf_canon c
+            WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
+              AND c.canon <> channels.name)
+        `);
+      }
 
       // buffer_reads: composite PK. Merge keeping the furthest read pointer and any
       // clear marker, then drop the variant so nothing resurfaces as unread.
@@ -247,16 +289,17 @@ export function foldBufferCase(
 
       // closed_buffers: a stray-cased row was the junk buffer the user closed; the
       // canonical buffer's own open/closed state wins, so drop the off-case rows.
-      db.exec(`DELETE FROM closed_buffers WHERE ${needsFold('closed_buffers')}`);
+      // Retired by schema 16, same as `channels` above.
+      if (TARGET_TABLES.includes('closed_buffers')) {
+        db.exec(`DELETE FROM closed_buffers WHERE ${needsFold('closed_buffers')}`);
+      }
 
       // Remaining per-(user, network, target) state: move to canon, or drop if a
-      // canon row already exists (its state wins).
-      for (const t of [
-        'pinned_buffers',
-        'nicklist_collapsed',
-        'channel_notify_settings',
-        'user_drafts',
-      ]) {
+      // canon row already exists (its state wins). Whatever the registry declares
+      // beyond the tables handled explicitly above — so a newly-added
+      // destination-wins table is folded without touching this loop.
+      const handledExplicitly = ['messages', 'input_history', 'buffer_reads', 'closed_buffers'];
+      for (const t of TARGET_TABLES.filter((n) => !handledExplicitly.includes(n))) {
         db.exec(`UPDATE OR IGNORE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
         db.exec(`DELETE FROM ${t} WHERE ${needsFold(t)}`);
       }

--- a/server/db/foldBufferCase.ts
+++ b/server/db/foldBufferCase.ts
@@ -105,6 +105,9 @@ export interface FoldReport {
 // entries come from the registry's own `legacy` flag rather than being named
 // again here — a second hardcoded copy is what rotted the first time.
 const SKIPPED_FROM_FOLD = new Set(['buffers']);
+
+/** Tables the apply path handles by name, so the generic loop must not. */
+const HANDLED_EXPLICITLY = ['messages', 'input_history', 'buffer_reads', 'closed_buffers'];
 const foldable = (t: (typeof BUFFER_KEYED_TABLES)[number]): boolean =>
   t.column === 'target' && !t.caseInsensitive && !t.listValued && !SKIPPED_FROM_FOLD.has(t.table);
 const CANDIDATE_TARGET_TABLES: readonly string[] = BUFFER_KEYED_TABLES.filter(foldable).map(
@@ -148,6 +151,29 @@ export function foldBufferCase(
     `${pred(`${t}.target`)} AND EXISTS (SELECT 1 FROM _buf_canon c
         WHERE c.network_id = ${t}.network_id AND c.lkey = lower(${t}.target)
           AND c.canon <> ${t}.target)`;
+
+  // Validated BEFORE any work, and outside the dryRun branch.
+  //
+  // This check used to live inside the apply loop, which had it exactly backwards
+  // on both counts: an operator's dry run printed a clean report for a
+  // mis-declared table and only --apply threw, and — far worse — foldBufferCase
+  // is called from the schemaVersion<9 and <16 migrations at module load, so the
+  // same throw was an unhandled exception on the one boot that migrates. On a
+  // hosted cell that is a crash loop.
+  //
+  // Up here it is a plain precondition: cheap, side-effect free, and identical
+  // in dry run and apply.
+  for (const table of CANDIDATE_TARGET_TABLES) {
+    if (HANDLED_EXPLICITLY.includes(table)) continue;
+    const policy = bufferKeyedTable(table)?.policy;
+    if (policy !== 'destination-wins') {
+      throw new Error(
+        `foldBufferCase: ${table} is declared policy '${policy}' but the fold only ` +
+          `implements destination-wins for it. Give it explicit handling, or correct ` +
+          `its policy in bufferKeyedTables.ts.`,
+      );
+    }
+  }
 
   const work = (): FoldReport => {
     // Connection-local temp table; drop defensively in case a prior run in this
@@ -359,16 +385,7 @@ export function foldBufferCase(
       // here would delete that progress with no error and no report line. A new
       // registry entry either belongs in this loop or fails loudly on the first
       // fold, which is the only outcome that can't ship silently.
-      const handledExplicitly = ['messages', 'input_history', 'buffer_reads', 'closed_buffers'];
-      for (const t of TARGET_TABLES.filter((n) => !handledExplicitly.includes(n))) {
-        const policy = bufferKeyedTable(t)?.policy;
-        if (policy !== 'destination-wins') {
-          throw new Error(
-            `foldBufferCase: ${t} is declared policy '${policy}' but reached the ` +
-              `destination-wins loop. Give it explicit handling above, or correct ` +
-              `its policy in bufferKeyedTables.ts.`,
-          );
-        }
+      for (const t of TARGET_TABLES.filter((n) => !HANDLED_EXPLICITLY.includes(n))) {
         db.exec(`UPDATE OR IGNORE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
         db.exec(`DELETE FROM ${t} WHERE ${needsFold(t)}`);
       }

--- a/server/db/foldBufferCase.ts
+++ b/server/db/foldBufferCase.ts
@@ -186,18 +186,31 @@ export function foldBufferCase(
     // Absent during the schema-16 migration's own call — the fold runs before
     // `buffers` is populated — so that path keeps the message-majority behavior
     // it has always had. Same for any buffer with history but no registry row.
+    //
+    // Joined on `lower(b.target)`, NOT on `b.target_folded`. Those are folded by
+    // different functions and genuinely disagree: `target_folded` is written by
+    // JS `toLowerCase()` (Unicode-aware), while `lkey` here is SQLite's `lower()`
+    // (ASCII-only). For `#Ärger` that is `#ärger` versus `#Ärger`, so the join
+    // never matched and the override silently didn't fire for any target with a
+    // non-ASCII uppercase letter — the exact "buffer opens blank" case it exists
+    // to prevent. Folding both sides with SQLite's `lower()` makes them agree.
+    //
+    // The fold's grouping is ASCII-only either way (`_buf_canon` is built with
+    // `lower()` above), so a non-ASCII case fork isn't detected as a fork at all.
+    // That predates this override and isn't made worse by it; matching the
+    // fold's own folding is the consistent choice, not a second one.
     if (tableExists('buffers')) {
       db.exec(`
         UPDATE _buf_canon SET canon = (
           SELECT b.target FROM buffers b
            WHERE b.network_id = _buf_canon.network_id
-             AND b.target_folded = _buf_canon.lkey
+             AND lower(b.target) = _buf_canon.lkey
            LIMIT 1
         )
         WHERE EXISTS (
           SELECT 1 FROM buffers b
            WHERE b.network_id = _buf_canon.network_id
-             AND b.target_folded = _buf_canon.lkey
+             AND lower(b.target) = _buf_canon.lkey
         )
       `);
     }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1445,8 +1445,14 @@ if (tableExists('messages_fts')) {
       .get() as { sql: string } | undefined
   )?.sql;
   if (messagesAuSql !== MESSAGES_AU_SQL) {
-    db.exec(`DROP TRIGGER IF EXISTS messages_au`);
-    db.exec(MESSAGES_AU_SQL);
+    // One transaction: between a bare DROP and its CREATE the database has FTS
+    // insert/delete triggers but no update trigger. The next boot repairs that,
+    // but any `UPDATE messages SET text = ...` in the interim desyncs
+    // messages_fts — an external-content table, so nothing detects or heals it.
+    db.transaction(() => {
+      db.exec(`DROP TRIGGER IF EXISTS messages_au`);
+      db.exec(MESSAGES_AU_SQL);
+    })();
   }
 }
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1390,17 +1390,64 @@ if (schemaVersion < 3) {
     CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
       INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.id, old.text);
     END;
-    CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-      INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.id, old.text);
-      INSERT INTO messages_fts(rowid, text) VALUES (new.id, new.text);
-    END;
   `);
+  // messages_au is created unconditionally below rather than here — see there.
+  // Nothing updates `messages` between this block and that one, so the window
+  // in which the update trigger doesn't exist carries no rows.
+
   // Index every existing row, NULL text included. The insert trigger does the
   // same for new rows; keeping the backfill consistent with it means the
   // delete/update triggers (which replay old.text) always have a matching
   // index entry to remove — skipping NULL rows here would desync an
   // external-content FTS5 table and risk index corruption on later deletes.
   db.exec(`INSERT INTO messages_fts(rowid, text) SELECT id, text FROM messages`);
+}
+
+// The FTS update trigger. Defined here rather than in the v3 block because its
+// definition changed after v3 shipped, and an already-migrated DB would keep the
+// old one forever under CREATE IF NOT EXISTS.
+//
+// Recreated only when what's stored doesn't match what we want, so a steady-state
+// boot writes nothing. That matters more than the microseconds saved: an
+// unconditional DROP + CREATE dirties sqlite_master on every single boot, and
+// Litestream faithfully replicates each one.
+//
+// The WHEN clause is the point. messages_fts indexes ONLY `text`, keyed by
+// rowid = messages.id, but the unguarded trigger fired on any column update and
+// paid a full FTS delete+reinsert for each row regardless. That made a
+// buffer rename — `UPDATE messages SET target = ?`, which touches neither
+// indexed column — reindex the entire channel's text for nothing. Measured on a
+// synthetic 1M-row channel: 3.55s -> 1.18s (3.0x) and 40MB less database
+// growth, because each delete+reinsert pair leaves tombstone and duplicate
+// entries behind in the FTS b-tree until a merge reclaims them.
+//
+// Both indexed inputs are in the guard, so it cannot skip work the FTS index
+// actually needs: `text` is the indexed content, and `id` is the rowid the
+// entry is keyed by. `IS NOT` rather than `<>` so a NULL on either side
+// compares correctly — text is nullable, and `NULL <> NULL` is NULL (falsy),
+// which would silently skip a row transitioning to or from NULL.
+const MESSAGES_AU_SQL = `CREATE TRIGGER messages_au AFTER UPDATE ON messages
+  WHEN old.text IS NOT new.text OR old.id IS NOT new.id BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.id, old.text);
+    INSERT INTO messages_fts(rowid, text) VALUES (new.id, new.text);
+  END`;
+// Existence-gated on messages_fts, which the v3 block creates. Every real
+// database at v3 or above has it, but a trigger whose body names a missing table
+// is not inert: SQLite reparses the entire schema during any ALTER TABLE ...
+// RENAME, and an unresolvable trigger body fails that statement. So a database
+// without FTS would get a live trigger that breaks the next table rebuild
+// migration somewhere else entirely. Matching the v3 block's own condition keeps
+// the trigger and the table it writes to inseparable.
+if (tableExists('messages_fts')) {
+  const messagesAuSql = (
+    db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'messages_au'`)
+      .get() as { sql: string } | undefined
+  )?.sql;
+  if (messagesAuSql !== MESSAGES_AU_SQL) {
+    db.exec(`DROP TRIGGER IF EXISTS messages_au`);
+    db.exec(MESSAGES_AU_SQL);
+  }
 }
 
 if (schemaVersion < 4) {

--- a/server/db/messagesFtsTrigger.test.ts
+++ b/server/db/messagesFtsTrigger.test.ts
@@ -20,7 +20,7 @@
 //     content-agreement check — measured, it returns OK on the `<>` desync
 //     above — so it backstops the match assertions rather than replacing them.
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -75,6 +75,8 @@ beforeAll(async () => {
   if (!network) throw new Error('fixture: createNetwork returned undefined');
   networkId = network.id;
 });
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
 describe('messages_au trigger definition', () => {
   it('is installed with the text/id guard', () => {

--- a/server/db/messagesFtsTrigger.test.ts
+++ b/server/db/messagesFtsTrigger.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The messages_fts AFTER UPDATE trigger (messages_au).
+//
+// The trigger is guarded on `text`/`id` so that a buffer rename — which rewrites
+// `messages.target` in bulk and touches neither indexed column — doesn't pay a
+// full FTS delete+reinsert per row. These tests pin both halves of that: the
+// guard is actually installed (an already-migrated DB has to be upgraded off the
+// unguarded v3 definition), and skipping the reindex cannot desync the index.
+//
+// Two different assertions, because neither alone is enough:
+//
+//   - Explicit match assertions catch a guard that skips a reindex it needed.
+//     This is the one that does the work. Verified against the obvious wrong
+//     guard: with `old.text <> new.text`, a row whose text goes NULL keeps
+//     matching its old text, and these assertions fail.
+//
+//   - `integrity-check` catches structural damage to the index. It is NOT a
+//     content-agreement check — measured, it returns OK on the `<>` desync
+//     above — so it backstops the match assertions rather than replacing them.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-fts-trigger-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+let insertMessage: typeof import('./messages.js').insertMessage;
+let networkId: number;
+
+/** Throws if messages_fts disagrees with the messages table. */
+function integrityCheck(): void {
+  db.exec(`INSERT INTO messages_fts(messages_fts) VALUES('integrity-check')`);
+}
+
+/** Message ids whose text matches `q`, via the FTS index. */
+function ftsMatches(q: string): number[] {
+  return (
+    db
+      .prepare(`SELECT rowid FROM messages_fts WHERE messages_fts MATCH ? ORDER BY rowid`)
+      .all(q) as Array<{ rowid: number }>
+  ).map((r) => r.rowid);
+}
+
+function add(target: string, text: string): number {
+  return Number(
+    insertMessage({
+      networkId,
+      target,
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'alice',
+      text,
+    }).id,
+  );
+}
+
+beforeAll(async () => {
+  ({ default: db } = await import('./index.js'));
+  ({ createUser } = await import('./users.js'));
+  ({ createNetwork } = await import('./networks.js'));
+  ({ insertMessage } = await import('./messages.js'));
+  const user = createUser('fts-trigger-user');
+  const network = createNetwork(user.id, {
+    name: 'libera',
+    host: 'irc.libera.chat',
+    nick: 'alice',
+  });
+  if (!network) throw new Error('fixture: createNetwork returned undefined');
+  networkId = network.id;
+});
+
+describe('messages_au trigger definition', () => {
+  it('is installed with the text/id guard', () => {
+    const row = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'messages_au'`)
+      .get() as { sql: string } | undefined;
+    expect(row?.sql).toBeTruthy();
+    // The whole point of the guard — without a WHEN clause the trigger fires on
+    // every column update, including a target-only rename.
+    expect(row?.sql).toMatch(/WHEN old\.text IS NOT new\.text OR old\.id IS NOT new\.id/);
+  });
+});
+
+describe('renaming a buffer (target-only update)', () => {
+  it('leaves the FTS index consistent and still searchable', () => {
+    const a = add('#old', 'renameable haddock');
+    const b = add('#old', 'another haddock here');
+    const c = add('#other', 'unrelated haddock');
+
+    expect(ftsMatches('renameable')).toEqual([a]);
+
+    db.prepare(`UPDATE messages SET target = ? WHERE network_id = ? AND target = ?`).run(
+      '#new',
+      networkId,
+      '#old',
+    );
+
+    // Rows moved...
+    const moved = db
+      .prepare(`SELECT COUNT(*) AS n FROM messages WHERE network_id = ? AND target = ?`)
+      .get(networkId, '#new') as { n: number };
+    expect(moved.n).toBe(2);
+
+    // ...and the index the trigger deliberately skipped is still correct.
+    integrityCheck();
+    expect(ftsMatches('renameable')).toEqual([a]);
+    // All three still match, each exactly once — the renamed rows kept their
+    // index entries and no duplicate was left behind. Row identity is by id, so
+    // the moved rows are found under the new target without being reindexed.
+    expect(ftsMatches('haddock')).toEqual([a, b, c]);
+  });
+});
+
+describe('updates that DO change indexed columns', () => {
+  it('reindexes when text changes', () => {
+    const id = add('#edit', 'original wobbegong');
+    expect(ftsMatches('wobbegong')).toContain(id);
+
+    db.prepare(`UPDATE messages SET text = ? WHERE id = ?`).run('replaced pilchard', id);
+
+    expect(ftsMatches('wobbegong')).not.toContain(id);
+    expect(ftsMatches('pilchard')).toContain(id);
+    integrityCheck();
+  });
+
+  it('reindexes when text becomes NULL and back', () => {
+    // `IS NOT` rather than `<>` in the guard exists for exactly this: `NULL <>
+    // NULL` is NULL (falsy), so a `<>` guard would skip these transitions and
+    // strand the old text in the index.
+    const id = add('#edit', 'nullable barramundi');
+    expect(ftsMatches('barramundi')).toContain(id);
+
+    db.prepare(`UPDATE messages SET text = NULL WHERE id = ?`).run(id);
+    expect(ftsMatches('barramundi')).not.toContain(id);
+    integrityCheck();
+
+    db.prepare(`UPDATE messages SET text = ? WHERE id = ?`).run('barramundi returns', id);
+    expect(ftsMatches('barramundi')).toContain(id);
+    integrityCheck();
+  });
+
+  it('still removes index entries on delete', () => {
+    const id = add('#gone', 'deletable tilapia');
+    expect(ftsMatches('tilapia')).toContain(id);
+
+    db.prepare(`DELETE FROM messages WHERE id = ?`).run(id);
+
+    expect(ftsMatches('tilapia')).not.toContain(id);
+    integrityCheck();
+  });
+});

--- a/server/db/renameBuffer.test.ts
+++ b/server/db/renameBuffer.test.ts
@@ -256,6 +256,159 @@ describe('merging into an existing destination', () => {
   });
 });
 
+describe('casing hazards around a merge', () => {
+  it('adopts the destination stored casing rather than the caller string', () => {
+    // A NICK event says 'Robert' while we hold a 'robert' buffer. Writing rows
+    // as 'Robert' while the registry keeps 'robert' splits the buffer: the
+    // exact-match backlog finds only the rows that didn't move.
+    const net = freshNetwork();
+    addBuffer(net, 'bob');
+    addBuffer(net, 'robert');
+    seed(net, 'bob', 3);
+    seed(net, 'robert', 2);
+
+    renameBuffer(userId, net, 'bob', 'Robert');
+
+    expect(bufferTargets(net)).toEqual([{ target: 'robert', folded: 'robert' }]);
+    const byTarget = db
+      .prepare(`SELECT target, COUNT(*) AS n FROM messages WHERE network_id = ? GROUP BY target`)
+      .all(net) as Array<{ target: string; n: number }>;
+    expect(byTarget).toEqual([{ target: 'robert', n: 5 }]);
+  });
+
+  it('reconciles read pointers even when the caller casing differs', () => {
+    // Same root cause: a mismatched destination casing means ON CONFLICT never
+    // fires and both pointers survive.
+    const net = freshNetwork();
+    addBuffer(net, 'bob');
+    addBuffer(net, 'robert');
+    db.prepare(
+      `INSERT INTO buffer_reads (user_id, network_id, target, last_read_message_id)
+       VALUES (?, ?, 'bob', 100), (?, ?, 'robert', 40)`,
+    ).run(userId, net, userId, net);
+
+    renameBuffer(userId, net, 'bob', 'Robert');
+
+    const rows = db
+      .prepare(
+        `SELECT target, last_read_message_id AS lastRead FROM buffer_reads
+          WHERE user_id = ? AND network_id = ?`,
+      )
+      .all(userId, net) as Array<{ target: string; lastRead: number }>;
+    expect(rows).toEqual([{ target: 'robert', lastRead: 100 }]);
+  });
+
+  it('does not destroy E2E state on a case-only rename', () => {
+    // The four e2e tables declare their channel column COLLATE NOCASE, so a
+    // DELETE bound to '#Foo' also matches the row just rewritten to '#foo'.
+    // This wiped every session key for the channel.
+    const net = freshNetwork();
+    addBuffer(net, '#Foo');
+    db.prepare(
+      `INSERT INTO e2e_channel_config (user_id, network_id, channel, enabled, mode)
+       VALUES (?, ?, '#Foo', 1, 'normal')`,
+    ).run(userId, net);
+    db.prepare(
+      `INSERT INTO e2e_outgoing_sessions (user_id, network_id, channel, sk, created_at)
+       VALUES (?, ?, '#Foo', 'secret', 1)`,
+    ).run(userId, net);
+
+    renameBuffer(userId, net, '#Foo', '#foo');
+
+    const cfg = db
+      .prepare(`SELECT channel FROM e2e_channel_config WHERE user_id = ?`)
+      .all(userId) as Array<{ channel: string }>;
+    const out = db
+      .prepare(`SELECT channel, sk FROM e2e_outgoing_sessions WHERE user_id = ?`)
+      .all(userId) as Array<{ channel: string; sk: string }>;
+    expect(cfg).toEqual([{ channel: '#foo' }]);
+    expect(out).toEqual([{ channel: '#foo', sk: 'secret' }]);
+  });
+});
+
+describe('sentinel values in a shared column', () => {
+  it("never rewrites e2e_autotrust's 'global' scope", () => {
+    // `scope` holds either a channel or the literal 'global'. A DM peer nicked
+    // `global` must not rewrite the user's network-wide auto-trust rule.
+    const net = freshNetwork();
+    addBuffer(net, 'global');
+    seed(net, 'global', 1);
+    db.prepare(
+      `INSERT INTO e2e_autotrust (user_id, network_id, scope, handle_pattern, created_at)
+       VALUES (?, ?, 'global', '*', 1)`,
+    ).run(userId, net);
+
+    renameBuffer(userId, net, 'global', 'globular');
+
+    const rows = db
+      .prepare(`SELECT scope FROM e2e_autotrust WHERE user_id = ? AND network_id = ?`)
+      .all(userId, net) as Array<{ scope: string }>;
+    expect(rows).toEqual([{ scope: 'global' }]);
+  });
+
+  it('does move a real channel-scoped autotrust rule', () => {
+    const net = freshNetwork();
+    addBuffer(net, '#trusted');
+    db.prepare(
+      `INSERT INTO e2e_autotrust (user_id, network_id, scope, handle_pattern, created_at)
+       VALUES (?, ?, '#trusted', '*', 1)`,
+    ).run(userId, net);
+
+    renameBuffer(userId, net, '#trusted', '#vouched');
+
+    const rows = db
+      .prepare(`SELECT scope FROM e2e_autotrust WHERE user_id = ? AND network_id = ?`)
+      .all(userId, net) as Array<{ scope: string }>;
+    expect(rows).toEqual([{ scope: '#vouched' }]);
+  });
+});
+
+describe('merged buffer state', () => {
+  it('clears closed_at when it reopens the destination', () => {
+    const net = freshNetwork();
+    addBuffer(net, 'bob', 'open');
+    addBuffer(net, 'robert', 'closed');
+    db.prepare(
+      `UPDATE buffers SET closed_at = '2026-01-01T00:00:00Z'
+        WHERE user_id = ? AND network_id = ? AND target = 'robert'`,
+    ).run(userId, net);
+
+    renameBuffer(userId, net, 'bob', 'robert');
+
+    const row = db
+      .prepare(
+        `SELECT state, closed_at AS closedAt FROM buffers
+          WHERE user_id = ? AND network_id = ? AND target = 'robert'`,
+      )
+      .get(userId, net) as { state: string; closedAt: string | null };
+    // An open row carrying a closed_at is a contradiction the export round-trip
+    // branches on.
+    expect(row).toEqual({ state: 'open', closedAt: null });
+  });
+
+  it('renames a keyed channel whose +k envelope cannot be decrypted', () => {
+    // getBuffer would decrypt and THROW for an envelope under a rotated key id,
+    // aborting a rename that never reads the key.
+    const net = freshNetwork();
+    addBuffer(net, '#keyed');
+    // A well-formed envelope under a key id the registry doesn't have — what a
+    // LURKER_SECRET_KEY rotation leaves behind. The exact shape matters:
+    // decryptSecret only engages for strings matching
+    // `lk1.<8 hex>.<base64url>`, and passes anything else straight through. Two
+    // earlier fixtures here ('v99:...', then a non-hex keyid) both failed that
+    // pattern, so this test passed against the broken code as well. Verified
+    // that it now fails when canonicalName goes back through getBuffer.
+    db.prepare(
+      `UPDATE buffers SET key = 'lk1.deadbeef.${'A'.repeat(64)}'
+        WHERE user_id = ? AND network_id = ? AND target = '#keyed'`,
+    ).run(userId, net);
+    seed(net, '#keyed', 2);
+
+    expect(() => renameBuffer(userId, net, '#keyed', '#rekeyed')).not.toThrow();
+    expect(bufferTargets(net)).toEqual([{ target: '#rekeyed', folded: '#rekeyed' }]);
+  });
+});
+
 describe('rules that still name the old buffer', () => {
   it('reports them instead of rewriting or ignoring them', () => {
     const net = freshNetwork();

--- a/server/db/renameBuffer.test.ts
+++ b/server/db/renameBuffer.test.ts
@@ -1,0 +1,320 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// renameBuffer: moving a buffer across every table that stores its name.
+//
+// The failure this guards against is silent: a table missed by the rename leaves
+// the user's draft, pin, or read pointer stranded under a name nothing looks up
+// again. So the central test isn't "did messages move" — it's the registry
+// coverage test, which walks BUFFER_KEYED_TABLES and fails if any live entry is
+// neither handled nor explicitly declared unhandled.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type DatabaseType from 'better-sqlite3';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-rename-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: DatabaseType.Database;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+let insertMessage: typeof import('./messages.js').insertMessage;
+let renameBuffer: typeof import('./renameBuffer.js').renameBuffer;
+let estimateCost: typeof import('./renameBuffer.js').estimateCost;
+let rewriteChannelList: typeof import('./renameBuffer.js').rewriteChannelList;
+let hasRenameHandler: typeof import('./renameBuffer.js').hasRenameHandler;
+let unhandledRenameTables: typeof import('./renameBuffer.js').unhandledRenameTables;
+let CURRENT_BUFFER_KEYED_TABLES: typeof import('./bufferKeyedTables.js').CURRENT_BUFFER_KEYED_TABLES;
+let userId: number;
+
+const T = '2026-06-01T00:00:00.000Z';
+
+beforeAll(async () => {
+  db = (await import('./index.js')).default;
+  ({ createUser } = await import('./users.js'));
+  ({ createNetwork } = await import('./networks.js'));
+  ({ insertMessage } = await import('./messages.js'));
+  ({ renameBuffer, estimateCost, rewriteChannelList, hasRenameHandler, unhandledRenameTables } =
+    await import('./renameBuffer.js'));
+  ({ CURRENT_BUFFER_KEYED_TABLES } = await import('./bufferKeyedTables.js'));
+  userId = createUser('rename-user').id;
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function freshNetwork(): number {
+  return createNetwork(userId, { name: 'libera', host: 'h', port: 6697, tls: true, nick: 'a' })!.id;
+}
+function addBuffer(networkId: number, target: string, state: 'open' | 'closed' = 'open'): void {
+  db.prepare(
+    `INSERT INTO buffers (user_id, network_id, target, target_folded, kind, state)
+     VALUES (?, ?, ?, ?, 'channel', ?)`,
+  ).run(userId, networkId, target, target.toLowerCase(), state);
+}
+function seed(networkId: number, target: string, count: number): void {
+  for (let i = 0; i < count; i++)
+    insertMessage({ networkId, target, time: T, type: 'message', nick: 'x', text: 'hi' });
+}
+function messageCount(networkId: number, target: string): number {
+  return (
+    db
+      .prepare(`SELECT COUNT(*) AS n FROM messages WHERE network_id = ? AND target = ?`)
+      .get(networkId, target) as { n: number }
+  ).n;
+}
+function bufferTargets(networkId: number): Array<{ target: string; folded: string }> {
+  return db
+    .prepare(
+      `SELECT target, target_folded AS folded FROM buffers
+        WHERE user_id = ? AND network_id = ? ORDER BY target_folded`,
+    )
+    .all(userId, networkId) as Array<{ target: string; folded: string }>;
+}
+
+describe('registry coverage', () => {
+  it('handles or explicitly excuses every live buffer-keyed table', () => {
+    // The test that makes the registry worth having: adding a buffer-keyed table
+    // and forgetting renameBuffer is a failure here, not a stranded row in prod.
+    const unexplained = CURRENT_BUFFER_KEYED_TABLES.filter(
+      (t) => !hasRenameHandler(t.table) && !unhandledRenameTables()[t.table],
+    ).map((t) => t.table);
+    expect(unexplained).toEqual([]);
+  });
+
+  it('excuses only the two list-valued tables, with reasons', () => {
+    expect(Object.keys(unhandledRenameTables()).toSorted()).toEqual([
+      'highlight_rules',
+      'ignored_masks',
+    ]);
+    for (const reason of Object.values(unhandledRenameTables())) {
+      expect(reason.length).toBeGreaterThan(10);
+    }
+  });
+});
+
+describe('a plain rename', () => {
+  it('moves history and the registry row together', () => {
+    const net = freshNetwork();
+    addBuffer(net, '#old');
+    seed(net, '#old', 5);
+
+    const res = renameBuffer(userId, net, '#old', '#new');
+
+    expect(res.renamed).toBe(true);
+    expect(res.merged).toBe(false);
+    expect(messageCount(net, '#old')).toBe(0);
+    expect(messageCount(net, '#new')).toBe(5);
+    expect(bufferTargets(net)).toEqual([{ target: '#new', folded: '#new' }]);
+  });
+
+  it('resolves the caller casing against the registry before matching', () => {
+    // The DM case: a NICK event's old nick needn't match our stored casing. If
+    // this resolved wrong, the exact-match UPDATEs would silently move nothing.
+    const net = freshNetwork();
+    addBuffer(net, 'Bob');
+    seed(net, 'Bob', 3);
+
+    const res = renameBuffer(userId, net, 'bOb', 'Robert');
+
+    expect(res.resolvedFrom).toBe('Bob');
+    expect(messageCount(net, 'Robert')).toBe(3);
+    expect(bufferTargets(net)).toEqual([{ target: 'Robert', folded: 'robert' }]);
+  });
+
+  it('is a no-op when nothing references the old name', () => {
+    const net = freshNetwork();
+    const res = renameBuffer(userId, net, '#ghost', '#other');
+    expect(res.renamed).toBe(false);
+    expect(res.rowsAffected).toEqual({});
+  });
+
+  it('is a no-op when from and to are identical', () => {
+    const net = freshNetwork();
+    addBuffer(net, '#same');
+    seed(net, '#same', 2);
+    expect(renameBuffer(userId, net, '#same', '#same').renamed).toBe(false);
+    expect(messageCount(net, '#same')).toBe(2);
+  });
+});
+
+describe('a case-only rename', () => {
+  it('rewrites in place rather than colliding with itself', () => {
+    // folded key unchanged, so source and destination are the SAME row. Treating
+    // this as a merge would delete the row it just updated.
+    const net = freshNetwork();
+    addBuffer(net, '#Foo');
+    seed(net, '#Foo', 4);
+
+    const res = renameBuffer(userId, net, '#Foo', '#foo');
+
+    expect(res.merged).toBe(false);
+    expect(res.renamed).toBe(true);
+    expect(bufferTargets(net)).toEqual([{ target: '#foo', folded: '#foo' }]);
+    expect(messageCount(net, '#foo')).toBe(4);
+  });
+});
+
+describe('merging into an existing destination', () => {
+  it('keeps one buffer row and moves all history onto it', () => {
+    const net = freshNetwork();
+    addBuffer(net, 'bob');
+    addBuffer(net, 'robert');
+    seed(net, 'bob', 3);
+    seed(net, 'robert', 2);
+
+    const res = renameBuffer(userId, net, 'bob', 'robert');
+
+    expect(res.merged).toBe(true);
+    expect(bufferTargets(net)).toEqual([{ target: 'robert', folded: 'robert' }]);
+    expect(messageCount(net, 'robert')).toBe(5);
+    expect(messageCount(net, 'bob')).toBe(0);
+  });
+
+  it('reopens a closed destination rather than hiding the merged history', () => {
+    const net = freshNetwork();
+    addBuffer(net, 'bob', 'open');
+    addBuffer(net, 'robert', 'closed');
+    seed(net, 'bob', 3);
+
+    renameBuffer(userId, net, 'bob', 'robert');
+
+    const state = db
+      .prepare(`SELECT state FROM buffers WHERE user_id = ? AND network_id = ? AND target = ?`)
+      .get(userId, net, 'robert') as { state: string };
+    expect(state.state).toBe('open');
+  });
+
+  it('keeps the furthest read pointer and the furthest clear marker', () => {
+    const net = freshNetwork();
+    addBuffer(net, 'bob');
+    addBuffer(net, 'robert');
+    db.prepare(
+      `INSERT INTO buffer_reads
+         (user_id, network_id, target, last_read_message_id, cleared_before_message_id, cleared_at)
+       VALUES (?, ?, 'bob', 100, 50, 'A'), (?, ?, 'robert', 40, 90, 'B')`,
+    ).run(userId, net, userId, net);
+
+    renameBuffer(userId, net, 'bob', 'robert');
+
+    const row = db
+      .prepare(
+        `SELECT last_read_message_id AS lastRead, cleared_before_message_id AS clearedBefore,
+                cleared_at AS clearedAt
+           FROM buffer_reads WHERE user_id = ? AND network_id = ?`,
+      )
+      .all(userId, net) as Array<{ lastRead: number; clearedBefore: number; clearedAt: string }>;
+    expect(row).toHaveLength(1);
+    // Each dimension takes its own maximum — a merge may neither resurrect read
+    // messages nor un-clear cleared ones.
+    expect(row[0].lastRead).toBe(100);
+    expect(row[0].clearedBefore).toBe(90);
+    expect(row[0].clearedAt).toBe('B');
+  });
+
+  it('drops the colliding draft and keeps the destination its own', () => {
+    const net = freshNetwork();
+    addBuffer(net, 'bob');
+    addBuffer(net, 'robert');
+    db.prepare(
+      `INSERT INTO user_drafts (user_id, network_id, target, body)
+       VALUES (?, ?, 'bob', 'from-source'), (?, ?, 'robert', 'from-dest')`,
+    ).run(userId, net, userId, net);
+
+    renameBuffer(userId, net, 'bob', 'robert');
+
+    const drafts = db
+      .prepare(`SELECT target, body FROM user_drafts WHERE user_id = ? AND network_id = ?`)
+      .all(userId, net) as Array<{ target: string; body: string }>;
+    expect(drafts).toEqual([{ target: 'robert', body: 'from-dest' }]);
+  });
+
+  it('leaves pin positions dense after a collision drops one', () => {
+    const net = freshNetwork();
+    for (const [i, t] of ['#a', '#b', '#c'].entries()) {
+      addBuffer(net, t);
+      db.prepare(
+        `INSERT INTO pinned_buffers (user_id, network_id, target, position) VALUES (?, ?, ?, ?)`,
+      ).run(userId, net, t, i);
+    }
+
+    // '#a' merges into '#c', which is already pinned — one pin disappears, and
+    // reorderPins assumes 0..n-1, so the gap has to close.
+    renameBuffer(userId, net, '#a', '#c');
+
+    const positions = (
+      db
+        .prepare(
+          `SELECT target, position FROM pinned_buffers
+            WHERE user_id = ? AND network_id = ? ORDER BY position`,
+        )
+        .all(userId, net) as Array<{ target: string; position: number }>
+    ).map((r) => r.position);
+    expect(positions).toEqual([0, 1]);
+  });
+});
+
+describe('rules that still name the old buffer', () => {
+  it('reports them instead of rewriting or ignoring them', () => {
+    const net = freshNetwork();
+    addBuffer(net, '#old');
+    seed(net, '#old', 1);
+    db.prepare(
+      `INSERT INTO ignored_masks (user_id, network_id, mask, channels, pattern_kind, levels)
+       VALUES (?, ?, 'spammer', '#old', 'substr', 'ALL')`,
+    ).run(userId, net);
+
+    const res = renameBuffer(userId, net, '#old', '#new');
+
+    expect(res.renamed).toBe(true);
+    expect(res.stillReferencing.ignored_masks).toBe(1);
+    // Untouched, deliberately — see UNHANDLED_TABLES.
+    const rule = db.prepare(`SELECT channels FROM ignored_masks WHERE user_id = ?`).get(userId) as {
+      channels: string;
+    };
+    expect(rule.channels).toBe('#old');
+  });
+});
+
+describe('rewriteChannelList', () => {
+  it('replaces a literal entry and leaves the rest alone', () => {
+    expect(rewriteChannelList('#old,#keep', '#old', '#new')).toBe('#new,#keep');
+  });
+
+  it('never rewrites a glob', () => {
+    // '#old*' covers more than this buffer; rewriting it would change which
+    // channels the rule matches.
+    expect(rewriteChannelList('#old*,#old', '#old', '#new')).toBe('#old*,#new');
+  });
+
+  it('folds case on both sides', () => {
+    expect(rewriteChannelList('#OLD', '#oLd', '#New')).toBe('#new');
+  });
+
+  it('collapses a rename onto a name the list already had', () => {
+    expect(rewriteChannelList('#old,#new', '#old', '#new')).toBe('#new');
+  });
+
+  it('returns null for an empty or emptied list', () => {
+    expect(rewriteChannelList(null, '#old', '#new')).toBeNull();
+    expect(rewriteChannelList('  ', '#old', '#new')).toBeNull();
+  });
+});
+
+describe('estimateCost', () => {
+  it('counts the rows a rename would move, before moving them', () => {
+    const net = freshNetwork();
+    addBuffer(net, '#big');
+    seed(net, '#big', 12);
+
+    const cost = estimateCost(userId, net, '#big');
+
+    expect(cost.rowsByTable.messages).toBe(12);
+    expect(cost.rowsByTable.buffers).toBe(1);
+    expect(cost.total).toBe(13);
+    // Purely a pre-flight — nothing moved.
+    expect(messageCount(net, '#big')).toBe(12);
+  });
+});

--- a/server/db/renameBuffer.test.ts
+++ b/server/db/renameBuffer.test.ts
@@ -471,3 +471,125 @@ describe('estimateCost', () => {
     expect(messageCount(net, '#big')).toBe(12);
   });
 });
+
+describe('a source with a case fork', () => {
+  it("moves EVERY casing, not just the caller's", () => {
+    // IRC targets are case-insensitive, so '#Foo' and '#foo' are one channel and
+    // a forked database holds one buffer's history under both. Moving only the
+    // caller's casing stranded the rest under a name with no buffers row — and
+    // post-schema-16 the sidebar is registry-derived, so it became invisible.
+    const net = freshNetwork();
+    addBuffer(net, '#Foo');
+    seed(net, '#Foo', 3);
+    seed(net, '#foo', 900);
+    seed(net, '#FOO', 7);
+
+    const res = renameBuffer(userId, net, '#Foo', '#Bar');
+
+    expect(res.renamed).toBe(true);
+    expect(messageCount(net, '#Bar')).toBe(910);
+    const leftovers = db
+      .prepare(
+        `SELECT target, COUNT(*) AS n FROM messages WHERE network_id = ? AND target <> '#Bar'
+          GROUP BY target`,
+      )
+      .all(net);
+    expect(leftovers).toEqual([]);
+  });
+
+  it('estimates the cost of every casing', () => {
+    // The pre-flight exists so a caller can warn/defer/refuse. Counting one
+    // casing reported 3 for a 910-row rename.
+    const net = freshNetwork();
+    addBuffer(net, '#Foo');
+    seed(net, '#Foo', 3);
+    seed(net, '#foo', 900);
+
+    expect(estimateCost(userId, net, '#Foo').rowsByTable.messages).toBe(903);
+  });
+
+  it('folds per-user state across casings too', () => {
+    const net = freshNetwork();
+    addBuffer(net, '#Foo');
+    db.prepare(
+      `INSERT INTO buffer_reads (user_id, network_id, target, last_read_message_id)
+       VALUES (?, ?, '#Foo', 10), (?, ?, '#foo', 99)`,
+    ).run(userId, net, userId, net);
+
+    renameBuffer(userId, net, '#Foo', '#Bar');
+
+    const rows = db
+      .prepare(
+        `SELECT target, last_read_message_id AS lastRead FROM buffer_reads
+          WHERE user_id = ? AND network_id = ?`,
+      )
+      .all(userId, net);
+    // Both casings collapse onto the destination, keeping the furthest pointer.
+    expect(rows).toEqual([{ target: '#Bar', lastRead: 99 }]);
+  });
+});
+
+describe('targets a rename must refuse', () => {
+  it('will not move a virtual buffer', () => {
+    // ':' sentinels live outside the normal namespace, and foldBufferCase
+    // excludes them from both scopes — anything renamed into or out of that
+    // space is beyond the only repair tool there is.
+    const net = freshNetwork();
+    addBuffer(net, ':server:1');
+    seed(net, ':server:1', 2);
+
+    expect(renameBuffer(userId, net, ':server:1', '#hijacked').renamed).toBe(false);
+    expect(messageCount(net, ':server:1')).toBe(2);
+  });
+
+  it('will not rename a real buffer into the virtual namespace', () => {
+    const net = freshNetwork();
+    addBuffer(net, '#real');
+    seed(net, '#real', 2);
+
+    expect(renameBuffer(userId, net, '#real', ':server:1').renamed).toBe(false);
+    expect(messageCount(net, '#real')).toBe(2);
+  });
+
+  it('will not rename INTO a sentinel scope value', () => {
+    // The guard has to cover what is WRITTEN, not just what MATCHES: renaming
+    // into 'global' rewrote a one-channel auto-trust rule onto the network-wide
+    // scope, auto-accepting every E2E peer.
+    const net = freshNetwork();
+    addBuffer(net, '#trusted');
+    db.prepare(
+      `INSERT INTO e2e_autotrust (user_id, network_id, scope, handle_pattern, created_at)
+       VALUES (?, ?, '#trusted', '*', 1)`,
+    ).run(userId, net);
+
+    renameBuffer(userId, net, '#trusted', 'global');
+
+    const rows = db
+      .prepare(`SELECT scope FROM e2e_autotrust WHERE user_id = ? AND network_id = ?`)
+      .all(userId, net);
+    expect(rows).toEqual([{ scope: '#trusted' }]);
+  });
+});
+
+describe('merged reporting', () => {
+  it('reports merged when only a satellite table folds', () => {
+    // buffers is unique on target_folded so it can never hold both casings, but
+    // every satellite is BINARY-collated and can. Reporting merged:false there
+    // meant no read-state push and clients taking the wrong client-side path.
+    const net = freshNetwork();
+    addBuffer(net, '#Foo');
+    db.prepare(
+      `INSERT INTO user_drafts (user_id, network_id, target, body)
+       VALUES (?, ?, '#Foo', 'src'), (?, ?, '#foo', 'dst')`,
+    ).run(userId, net, userId, net);
+
+    const res = renameBuffer(userId, net, '#Foo', '#foo');
+
+    expect(res.renamed).toBe(true);
+    expect(res.merged).toBe(true);
+    const drafts = db
+      .prepare(`SELECT target, body FROM user_drafts WHERE user_id = ? AND network_id = ?`)
+      .all(userId, net);
+    expect(drafts).toEqual([{ target: '#foo', body: 'dst' }]);
+  });
+});

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -124,6 +124,12 @@ export interface RenameBufferResult {
   stillReferencing: Record<string, number>;
   /** The stored casing `from` resolved to. */
   resolvedFrom: string;
+  /**
+   * The name rows actually landed on. Differs from the caller's `to` when
+   * merging into an existing buffer, whose stored casing wins — so this, not
+   * the requested string, is what a client must be told to key by.
+   */
+  resolvedTo: string;
 }
 
 function tableExists(table: string): boolean {
@@ -241,6 +247,7 @@ export function renameBuffer(
     rowsAffected,
     stillReferencing,
     resolvedFrom,
+    resolvedTo: to,
   };
 
   if (!to || !resolvedFrom || resolvedFrom === to) return empty;
@@ -366,7 +373,7 @@ export function renameBuffer(
   });
 
   const renamed = run();
-  return { renamed, merged, rowsAffected, stillReferencing, resolvedFrom };
+  return { renamed, merged, rowsAffected, stillReferencing, resolvedFrom, resolvedTo: effectiveTo };
 }
 
 /**

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
-import { foldTarget, getBuffer } from './buffers.js';
+import { foldTarget } from './buffers.js';
 import { BUFFER_KEYED_TABLES, bufferKeyedTable } from './bufferKeyedTables.js';
 
 // Move a buffer to a new name, across every table that stores it.
@@ -147,7 +147,27 @@ function tableExists(table: string): boolean {
  * is foldBufferCase's job, not this one's.
  */
 function canonicalName(userId: number, networkId: number, target: string): string {
-  return getBuffer(userId, networkId, target)?.target ?? target;
+  return storedTarget(userId, networkId, target) ?? target;
+}
+
+/**
+ * The registry's display casing for a folded target, read WITHOUT materializing
+ * the record.
+ *
+ * Deliberately not `getBuffer`, which runs the row through `toRecord` and so
+ * `decryptSecret` on the channel's +k envelope — and that THROWS for an envelope
+ * sealed under a rotated or unknown key id. Renaming a keyed channel after a
+ * LURKER_SECRET_KEY rotation would abort the whole rename on a crypto error, for
+ * a key this function never looks at. Same reasoning as `getState` existing
+ * alongside `getBuffer` in buffers.ts.
+ */
+function storedTarget(userId: number, networkId: number, target: string): string | undefined {
+  const row = db
+    .prepare(
+      `SELECT target FROM buffers WHERE user_id = ? AND network_id = ? AND target_folded = ?`,
+    )
+    .get(userId, networkId, foldTarget(target)) as { target: string } | undefined;
+  return row?.target;
 }
 
 function scopeSql(table: string, scope: readonly string[]): string {
@@ -227,8 +247,20 @@ export function renameBuffer(
 
   const caseOnly = foldTarget(resolvedFrom) === foldTarget(to);
   // A destination row only counts as a collision when it's a DIFFERENT buffer.
-  const destination = caseOnly ? undefined : getBuffer(userId, networkId, to);
+  const destination = caseOnly ? undefined : storedTarget(userId, networkId, to);
   const merged = !!destination;
+
+  // When merging, the DESTINATION's stored casing is what everything moves to —
+  // not the caller's string.
+  //
+  // A NICK event is exactly this case: the wire says `Robert` while we already
+  // hold a `robert` buffer. Writing rows as `Robert` while the surviving
+  // registry row stays `robert` splits the buffer in half — the exact-match
+  // backlog query finds only the rows that didn't move, `destination-wins`
+  // quietly becomes "two rows", and mergeBufferReads' ON CONFLICT never fires so
+  // the read pointers are never reconciled. Same invariant the fold now honours:
+  // the registry owns display casing.
+  const effectiveTo = destination ?? to;
 
   const run = db.transaction((): boolean => {
     let touched = false;
@@ -242,8 +274,16 @@ export function renameBuffer(
     for (const t of BUFFER_KEYED_TABLES) {
       if (t.legacy || !tableExists(t.table)) continue;
 
-      const where = `${scopeSql(t.table, t.scope)} AND ${t.column} = ?`;
-      const args = [...scopeArgs(t.scope, userId, networkId), resolvedFrom];
+      // Sentinel values that share the column but aren't buffer names
+      // (e2e_autotrust's 'global'). Excluded from BOTH statements, so a DM peer
+      // nicked `global` can't rewrite a network-wide rule.
+      const guard = (t.excludeValues ?? []).map(() => `AND ${t.column} <> ?`).join(' ');
+      const where = `${scopeSql(t.table, t.scope)} AND ${t.column} = ? ${guard}`;
+      const args = [
+        ...scopeArgs(t.scope, userId, networkId),
+        resolvedFrom,
+        ...(t.excludeValues ?? []),
+      ];
 
       if (UNHANDLED_TABLES[t.table]) {
         const n = countListReferences(t, userId, resolvedFrom);
@@ -255,8 +295,8 @@ export function renameBuffer(
         bump(
           t.table,
           t.table === 'buffers'
-            ? renameBufferRow(userId, networkId, resolvedFrom, to, caseOnly)
-            : mergeBufferReads(userId, networkId, resolvedFrom, to),
+            ? renameBufferRow(userId, networkId, resolvedFrom, effectiveTo, caseOnly)
+            : mergeBufferReads(userId, networkId, resolvedFrom, effectiveTo),
         );
         continue;
       }
@@ -265,8 +305,9 @@ export function renameBuffer(
         // No uniqueness on the target, so every row moves and nothing collides.
         bump(
           t.table,
-          db.prepare(`UPDATE ${t.table} SET ${t.column} = ? WHERE ${where}`).run(to, ...args)
-            .changes,
+          db
+            .prepare(`UPDATE ${t.table} SET ${t.column} = ? WHERE ${where}`)
+            .run(effectiveTo, ...args).changes,
         );
         continue;
       }
@@ -276,8 +317,19 @@ export function renameBuffer(
         // the destination's own row as the survivor.
         const moved = db
           .prepare(`UPDATE OR IGNORE ${t.table} SET ${t.column} = ? WHERE ${where}`)
-          .run(to, ...args).changes;
-        const dropped = db.prepare(`DELETE FROM ${t.table} WHERE ${where}`).run(...args).changes;
+          .run(effectiveTo, ...args).changes;
+        // `<> ? COLLATE BINARY` on the DELETE, not a caseOnly short-circuit.
+        //
+        // Four e2e tables declare their target column COLLATE NOCASE, so on a
+        // case-only rename `WHERE channel = '#Foo'` still matches the row the
+        // UPDATE just rewrote to '#foo' — and the DELETE destroys it. That
+        // silently wiped every E2E session key for the channel. An explicit
+        // BINARY comparison excludes rows already sitting at the destination
+        // while still clearing genuine collision leftovers, which a caseOnly
+        // short-circuit would strand.
+        const dropped = db
+          .prepare(`DELETE FROM ${t.table} WHERE ${where} AND ${t.column} <> ? COLLATE BINARY`)
+          .run(...args, effectiveTo).changes;
         bump(t.table, moved + dropped);
         continue;
       }
@@ -334,7 +386,17 @@ function renameBufferRow(
   to: string,
   caseOnly: boolean,
 ): number {
-  const source = getBuffer(userId, networkId, from);
+  // Raw row, not getBuffer: `toRecord` decrypts the +k envelope and throws for
+  // one sealed under a rotated key id, which would abort a rename that never
+  // reads the key. See storedTarget.
+  const source = db
+    .prepare(
+      `SELECT state, autojoin, key, created_at AS createdAt FROM buffers
+        WHERE user_id = ? AND network_id = ? AND target_folded = ?`,
+    )
+    .get(userId, networkId, foldTarget(from)) as
+    | { state: string; autojoin: number; key: string | null; createdAt: string }
+    | undefined;
   if (!source) return 0;
 
   if (caseOnly) {
@@ -346,7 +408,7 @@ function renameBufferRow(
       .run(to, foldTarget(to), userId, networkId, foldTarget(from)).changes;
   }
 
-  const destination = getBuffer(userId, networkId, to);
+  const destination = storedTarget(userId, networkId, to);
   if (!destination) {
     return db
       .prepare(
@@ -360,6 +422,11 @@ function renameBufferRow(
     .prepare(
       `UPDATE buffers
           SET state      = CASE WHEN ? = 'open' THEN 'open' ELSE state END,
+              -- Paired with state, always: every other reopen path clears
+              -- closed_at too (buffers.reopen), and leaving a stale timestamp on
+              -- an open row is a contradiction the export/import round-trip
+              -- branches on.
+              closed_at  = CASE WHEN ? = 'open' THEN NULL ELSE closed_at END,
               autojoin   = MAX(autojoin, ?),
               key        = COALESCE(key, ?),
               created_at = MIN(created_at, ?)
@@ -367,11 +434,13 @@ function renameBufferRow(
     )
     .run(
       source.state,
+      source.state,
       source.autojoin ? 1 : 0,
-      // Re-encrypting the source key would need the plaintext; carry the stored
-      // envelope instead. COALESCE keeps the destination's own key when it has
-      // one, so this only fills a gap.
-      rawKey(userId, networkId, from),
+      // Carry the stored envelope rather than a plaintext key — re-encrypting
+      // would mean decrypting first, which is what we're avoiding. COALESCE
+      // keeps the destination's own key when it has one, so this only fills a
+      // gap.
+      source.key,
       source.createdAt,
       userId,
       networkId,
@@ -383,14 +452,6 @@ function renameBufferRow(
     .run(userId, networkId, foldTarget(from)).changes;
 
   return merged + dropped;
-}
-
-/** The stored (still-encrypted) channel key envelope, without decrypting it. */
-function rawKey(userId: number, networkId: number, target: string): string | null {
-  const row = db
-    .prepare(`SELECT key FROM buffers WHERE user_id = ? AND network_id = ? AND target_folded = ?`)
-    .get(userId, networkId, foldTarget(target)) as { key: string | null } | undefined;
-  return row?.key ?? null;
 }
 
 /**

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -54,13 +54,20 @@ export function estimateCost(
     // skips — keyed off the same predicate as the dispatch, not off `listValued`,
     // which happens to select the same tables today and needn't tomorrow.
     if (!hasRenameHandler(t.table) || !tableExists(t.table)) continue;
+    // Same excludeValues guard the rename applies, or the estimate counts rows
+    // the rename will deliberately refuse to move — a DM peer named `global`
+    // against an e2e_autotrust rule scoped 'global'. The number is exported so a
+    // caller can warn, defer or refuse on it; an over-count is a wrong decision.
+    const guard = (t.excludeValues ?? []).map(() => `AND ${t.column} <> ?`).join(' ');
     const n = (
       db
         .prepare(
           `SELECT COUNT(*) AS n FROM ${t.table}
-            WHERE ${scopeSql(t.table, t.scope)} AND ${t.column} = ?`,
+            WHERE ${scopeSql(t.table, t.scope)} AND ${t.column} = ? ${guard}`,
         )
-        .get(...scopeArgs(t.scope, userId, networkId), canonical) as { n: number }
+        .get(...scopeArgs(t.scope, userId, networkId), canonical, ...(t.excludeValues ?? [])) as {
+        n: number;
+      }
     ).n;
     if (n > 0) {
       rowsByTable[t.table] = n;

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -47,6 +47,7 @@ export function estimateCost(
   from: string,
 ): { rowsByTable: Record<string, number>; total: number } {
   const canonical = canonicalName(userId, networkId, from);
+  const folded = foldTarget(canonical);
   const rowsByTable: Record<string, number> = {};
   let total = 0;
   for (const t of BUFFER_KEYED_TABLES) {
@@ -58,17 +59,24 @@ export function estimateCost(
     // the rename will deliberately refuse to move — a DM peer named `global`
     // against an e2e_autotrust rule scoped 'global'. The number is exported so a
     // caller can warn, defer or refuse on it; an over-count is a wrong decision.
-    const guard = (t.excludeValues ?? []).map(() => `AND ${t.column} <> ?`).join(' ');
-    const n = (
-      db
-        .prepare(
-          `SELECT COUNT(*) AS n FROM ${t.table}
-            WHERE ${scopeSql(t.table, t.scope)} AND ${t.column} = ? ${guard}`,
-        )
-        .get(...scopeArgs(t.scope, userId, networkId), canonical, ...(t.excludeValues ?? [])) as {
-        n: number;
-      }
-    ).n;
+    const sentinels = t.excludeValues ?? [];
+    const guard = sentinels.map(() => `AND ${t.column} <> ?`).join(' ');
+    // Every casing, matching what the rename will actually move. Counting only
+    // the caller's casing reported "3 messages" for a rename that had 903 to
+    // move — and the number exists precisely so a caller can decide whether to
+    // accept the stall.
+    let n = 0;
+    for (const casing of casingsOf(t.table, t.column, t.scope, userId, networkId, folded)) {
+      if (sentinels.includes(casing)) continue;
+      n += (
+        db
+          .prepare(
+            `SELECT COUNT(*) AS n FROM ${t.table}
+              WHERE ${scopeSql(t.table, t.scope)} AND ${t.column} = ? ${guard}`,
+          )
+          .get(...scopeArgs(t.scope, userId, networkId), casing, ...sentinels) as { n: number }
+      ).n;
+    }
     if (n > 0) {
       rowsByTable[t.table] = n;
       total += n;
@@ -183,6 +191,44 @@ function storedTarget(userId: number, networkId: number, target: string): string
   return row?.target;
 }
 
+/**
+ * Every casing of `folded` actually present in a table — all of which the rename
+ * has to move.
+ *
+ * IRC targets are case-insensitive, so `#channeL`, `#Channel` and `#ChAnNeL` are
+ * one channel; a database that accumulated several casings (which is why
+ * foldBufferCase exists) holds one buffer's history under all of them. Moving
+ * only the caller's casing left the rest behind with no `buffers` row pointing
+ * at it — and post-schema-16 the sidebar is registry-derived, so that history
+ * became unreachable. It also destroyed the registry row the fold's own override
+ * needs, closing the one repair path that could have realigned it.
+ *
+ * Discovery rather than a case-insensitive UPDATE, deliberately. `COLLATE
+ * NOCASE` on the rewrite would defeat idx_messages_unread's (network_id, target)
+ * prefix and turn every rename into a scan; it is also ASCII-only, so it would
+ * silently miss the Unicode casings `foldTarget` folds together. A `DISTINCT`
+ * over the same index is proportional to how many buffers exist, not how many
+ * messages, and each rewrite it feeds stays an exact-match index range scan.
+ *
+ * Ordered longest-first only for determinism in tests and reports.
+ */
+function casingsOf(
+  table: string,
+  column: string,
+  scope: readonly string[],
+  userId: number,
+  networkId: number,
+  folded: string,
+): string[] {
+  const rows = db
+    .prepare(`SELECT DISTINCT ${column} AS v FROM ${table} WHERE ${scopeSql(table, scope)}`)
+    .all(...scopeArgs(scope, userId, networkId)) as Array<{ v: string | null }>;
+  return rows
+    .map((r) => r.v)
+    .filter((v): v is string => typeof v === 'string' && foldTarget(v) === folded)
+    .toSorted();
+}
+
 function scopeSql(table: string, scope: readonly string[]): string {
   return (
     scope
@@ -257,12 +303,21 @@ export function renameBuffer(
     resolvedTo: to,
   };
 
-  if (!to || !resolvedFrom || resolvedFrom === to) return empty;
+  // A rename must not be able to invent a target the rest of the system can't
+  // represent. Both producers feed remote strings straight in: a channel RENAME
+  // and a NICK event.
+  //
+  // The ':' sentinels (`:server:`, `:system:`) are virtual buffers that exist
+  // outside the normal namespace — foldBufferCase excludes them from BOTH its
+  // scopes, so anything renamed into or out of that space is permanently beyond
+  // the only repair tool there is.
+  if (!to.trim() || !resolvedFrom || resolvedFrom === to) return empty;
+  if (to.startsWith(':') || resolvedFrom.startsWith(':')) return empty;
 
-  const caseOnly = foldTarget(resolvedFrom) === foldTarget(to);
+  const fromFolded = foldTarget(resolvedFrom);
+  const caseOnly = fromFolded === foldTarget(to);
   // A destination row only counts as a collision when it's a DIFFERENT buffer.
   const destination = caseOnly ? undefined : storedTarget(userId, networkId, to);
-  const merged = !!destination;
 
   // When merging, the DESTINATION's stored casing is what everything moves to —
   // not the caller's string.
@@ -275,6 +330,32 @@ export function renameBuffer(
   // the read pointers are never reconciled. Same invariant the fold now honours:
   // the registry owns display casing.
   const effectiveTo = destination ?? to;
+
+  // `merged` cannot be read off the registry alone.
+  //
+  // `buffers` is unique on target_folded, so it can never hold both casings of a
+  // case-only rename — but every satellite table is BINARY-collated and can. A
+  // '#Foo' draft folding onto an existing '#foo' draft IS a merge: a row is
+  // dropped and read pointers are reconciled. Reporting merged:false there meant
+  // wsHub skipped the read-state push (nothing else corrects that badge) and
+  // clients took §9.7's rekey path instead of folding two message lists.
+  //
+  // So it's answered by asking whether anything actually sits at the
+  // destination, binary-distinct from what we're moving.
+  const mergedInto = (): boolean => {
+    if (destination) return true;
+    for (const t of BUFFER_KEYED_TABLES) {
+      if (!hasRenameHandler(t.table) || !tableExists(t.table)) continue;
+      const hit = db
+        .prepare(
+          `SELECT 1 FROM ${t.table} WHERE ${scopeSql(t.table, t.scope)} AND ${t.column} = ? LIMIT 1`,
+        )
+        .get(...scopeArgs(t.scope, userId, networkId), effectiveTo);
+      if (hit) return true;
+    }
+    return false;
+  };
+  const merged = mergedInto();
 
   const run = db.transaction((): boolean => {
     let touched = false;
@@ -289,14 +370,18 @@ export function renameBuffer(
       if (t.legacy || !tableExists(t.table)) continue;
 
       // Sentinel values that share the column but aren't buffer names
-      // (e2e_autotrust's 'global'). Excluded from BOTH statements, so a DM peer
-      // nicked `global` can't rewrite a network-wide rule.
-      const guard = (t.excludeValues ?? []).map(() => `AND ${t.column} <> ?`).join(' ');
+      // (e2e_autotrust's 'global'). The guard has to cover BOTH ends: filtering
+      // which rows MATCH says nothing about what gets WRITTEN, so renaming a
+      // buffer INTO 'global' rewrote a one-channel auto-trust rule onto the
+      // network-wide scope — auto-accepting every E2E peer on the network.
+      const sentinels = t.excludeValues ?? [];
+      if (sentinels.some((v) => v.toLowerCase() === effectiveTo.toLowerCase())) continue;
+      const guard = sentinels.map(() => `AND ${t.column} <> ?`).join(' ');
       const where = `${scopeSql(t.table, t.scope)} AND ${t.column} = ? ${guard}`;
-      const args = [
+      const argsFor = (casing: string) => [
         ...scopeArgs(t.scope, userId, networkId),
-        resolvedFrom,
-        ...(t.excludeValues ?? []),
+        casing,
+        ...sentinels,
       ];
 
       if (UNHANDLED_TABLES[t.table]) {
@@ -305,46 +390,61 @@ export function renameBuffer(
         continue;
       }
 
+      // EVERY casing this table holds, not just the caller's. IRC targets are
+      // case-insensitive, so a database that accumulated `#Foo` and `#foo` holds
+      // one buffer under both; moving only one stranded the rest under a name
+      // with no registry row, which post-schema-16 means invisible.
+      const casings = casingsOf(t.table, t.column, t.scope, userId, networkId, fromFolded).filter(
+        (c) => c !== effectiveTo && !sentinels.includes(c),
+      );
+
       if (BESPOKE_HANDLERS.has(t.table)) {
-        bump(
-          t.table,
-          t.table === 'buffers'
-            ? renameBufferRow(userId, networkId, resolvedFrom, effectiveTo, caseOnly)
-            : mergeBufferReads(userId, networkId, resolvedFrom, effectiveTo),
-        );
+        if (t.table === 'buffers') {
+          // Unique on target_folded, so there is at most one source row here and
+          // the casing loop cannot apply.
+          bump(t.table, renameBufferRow(userId, networkId, resolvedFrom, effectiveTo, caseOnly));
+        } else {
+          for (const casing of casings) {
+            bump(t.table, mergeBufferReads(userId, networkId, casing, effectiveTo));
+          }
+        }
         continue;
       }
 
       if (t.policy === 'rewrite') {
         // No uniqueness on the target, so every row moves and nothing collides.
-        bump(
-          t.table,
-          db
-            .prepare(`UPDATE ${t.table} SET ${t.column} = ? WHERE ${where}`)
-            .run(effectiveTo, ...args).changes,
-        );
+        for (const casing of casings) {
+          bump(
+            t.table,
+            db
+              .prepare(`UPDATE ${t.table} SET ${t.column} = ? WHERE ${where}`)
+              .run(effectiveTo, ...argsFor(casing)).changes,
+          );
+        }
         continue;
       }
 
       if (t.policy === 'destination-wins') {
         // OR IGNORE moves what it can; the DELETE clears what collided, leaving
         // the destination's own row as the survivor.
-        const moved = db
-          .prepare(`UPDATE OR IGNORE ${t.table} SET ${t.column} = ? WHERE ${where}`)
-          .run(effectiveTo, ...args).changes;
-        // `<> ? COLLATE BINARY` on the DELETE, not a caseOnly short-circuit.
-        //
-        // Four e2e tables declare their target column COLLATE NOCASE, so on a
-        // case-only rename `WHERE channel = '#Foo'` still matches the row the
-        // UPDATE just rewrote to '#foo' — and the DELETE destroys it. That
-        // silently wiped every E2E session key for the channel. An explicit
-        // BINARY comparison excludes rows already sitting at the destination
-        // while still clearing genuine collision leftovers, which a caseOnly
-        // short-circuit would strand.
-        const dropped = db
-          .prepare(`DELETE FROM ${t.table} WHERE ${where} AND ${t.column} <> ? COLLATE BINARY`)
-          .run(...args, effectiveTo).changes;
-        bump(t.table, moved + dropped);
+        for (const casing of casings) {
+          const moved = db
+            .prepare(`UPDATE OR IGNORE ${t.table} SET ${t.column} = ? WHERE ${where}`)
+            .run(effectiveTo, ...argsFor(casing)).changes;
+          // `<> ? COLLATE BINARY` on the DELETE, not a caseOnly short-circuit.
+          //
+          // Four e2e tables declare their target column COLLATE NOCASE, so on a
+          // case-only rename `WHERE channel = '#Foo'` still matches the row the
+          // UPDATE just rewrote to '#foo' — and the DELETE destroys it. That
+          // silently wiped every E2E session key for the channel. An explicit
+          // BINARY comparison excludes rows already sitting at the destination
+          // while still clearing genuine collision leftovers, which a caseOnly
+          // short-circuit would strand.
+          const dropped = db
+            .prepare(`DELETE FROM ${t.table} WHERE ${where} AND ${t.column} <> ? COLLATE BINARY`)
+            .run(...argsFor(casing), effectiveTo).changes;
+          bump(t.table, moved + dropped);
+        }
         continue;
       }
 

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -1,0 +1,475 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import db from './index.js';
+import { foldTarget, getBuffer } from './buffers.js';
+import { BUFFER_KEYED_TABLES, bufferKeyedTable } from './bufferKeyedTables.js';
+
+// Move a buffer to a new name, across every table that stores it.
+//
+// The one primitive behind both things that rename a buffer: a channel RENAME
+// (IRCv3 draft/channel-rename) and a DM peer changing nick. Buffers aren't
+// normalized — see bufferKeyedTables.ts for why — so "rename" means visiting
+// thirteen tables, and the registry is what makes that list auditable instead of
+// remembered.
+//
+// ## Why this is one synchronous transaction
+//
+// The obvious worry is cost: measured on a synthetic 1M-message channel with the
+// real schema and indexes, the `messages` rewrite alone is ~1.2s (3.5s before
+// the messages_au guard). That blocks the event loop, which on this codebase
+// has form — a synchronous snapshot once starved it hard enough to trip
+// irc-framework's ping timeouts.
+//
+// Chunking it with setImmediate looks like the fix and isn't, for two reasons
+// that both come back to there being exactly ONE shared SQLite connection:
+//
+//   1. Chunking INSIDE a transaction is unsafe. Yielding to the event loop with
+//      a write transaction open means any other write that runs in the meantime
+//      executes on the same connection, inside our transaction — and rolls back
+//      with us if we fail. That converts a slow rename into a correctness bug.
+//
+//   2. Chunking WITHOUT a transaction gives up atomicity, and buys nothing:
+//      other work still can't touch the database while our statement is in
+//      SQLite's C code, because it's the same connection. The event loop would
+//      be free to run everything except the thing it's waiting on.
+//
+// So the honest trade is a slower, atomic rename over a faster, half-applied
+// one. A half-applied rename splits a buffer's history across two names with no
+// record of which rows moved; there is no recovery for that short of a fold.
+// `estimateCost` is exported so callers can decide (warn, defer, refuse) before
+// committing to the stall.
+
+/** Rows that would move, per table — the pre-flight for a rename's cost. */
+export function estimateCost(
+  userId: number,
+  networkId: number,
+  from: string,
+): { rowsByTable: Record<string, number>; total: number } {
+  const canonical = canonicalName(userId, networkId, from);
+  const rowsByTable: Record<string, number> = {};
+  let total = 0;
+  for (const t of BUFFER_KEYED_TABLES) {
+    // Counts what the rename will MOVE, so it skips exactly what the rename
+    // skips — keyed off the same predicate as the dispatch, not off `listValued`,
+    // which happens to select the same tables today and needn't tomorrow.
+    if (!hasRenameHandler(t.table) || !tableExists(t.table)) continue;
+    const n = (
+      db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM ${t.table}
+            WHERE ${scopeSql(t.table, t.scope)} AND ${t.column} = ?`,
+        )
+        .get(...scopeArgs(t.scope, userId, networkId), canonical) as { n: number }
+    ).n;
+    if (n > 0) {
+      rowsByTable[t.table] = n;
+      total += n;
+    }
+  }
+  return { rowsByTable, total };
+}
+
+/**
+ * Registry tables this primitive deliberately does not move, with the reason.
+ *
+ * Both hold a comma-separated list of channel scopes, and both can govern more
+ * than the network being renamed: a highlight rule's network scope lives in a
+ * junction table (no rows = every network), and an ignore rule with a NULL
+ * network_id is global by definition. So "#foo was renamed on network 3" does
+ * not license rewriting a rule that also governs #foo on network 7 — and a rule
+ * scoped to `#foo*` is a pattern whose meaning would change if rewritten at all.
+ *
+ * Deciding what should happen there is a product question, not a mechanical one.
+ * Until it's answered these are COUNTED and REPORTED rather than touched, so a
+ * caller can surface "3 rules still mention the old name" instead of the rename
+ * silently half-applying. rewriteChannelList below is the pure part, already
+ * written and tested, for whoever picks this up.
+ */
+const UNHANDLED_TABLES: Readonly<Record<string, string>> = {
+  highlight_rules: 'channel scope can span networks (junction; no rows = all)',
+  ignored_masks: 'channel scope can be global (network_id NULL)',
+};
+
+/**
+ * Tables whose move can't be expressed by a policy alone and have a named
+ * function instead: `buffers` moves two columns in lockstep, `buffer_reads`
+ * reconciles two progress values.
+ */
+const BESPOKE_HANDLERS = new Set(['buffers', 'buffer_reads']);
+
+/**
+ * Policies the generic dispatch below actually implements.
+ *
+ * Shared with `hasRenameHandler` so the coverage test can't drift from the code:
+ * checking "is this table excused?" would be tautological, since the excuse list
+ * is the same list. Checking the DECLARED POLICY against the set of implemented
+ * ones is a real question — a new table declared `merge` fails the test rather
+ * than throwing the first time someone renames a buffer in production.
+ */
+const IMPLEMENTED_POLICIES: ReadonlySet<string> = new Set(['rewrite', 'destination-wins']);
+
+export interface RenameBufferResult {
+  /** False when nothing anywhere referenced `from` — the rename was a no-op. */
+  renamed: boolean;
+  /** True when a buffer already existed at `to` and rows were merged into it. */
+  merged: boolean;
+  /** Per-table count of rows rewritten, merged, or dropped. */
+  rowsAffected: Record<string, number>;
+  /**
+   * Rows in UNHANDLED_TABLES that still mention the old name. Non-empty means
+   * the rename is complete for buffer state but some rule still points at the
+   * old name — surface it, don't swallow it.
+   */
+  stillReferencing: Record<string, number>;
+  /** The stored casing `from` resolved to. */
+  resolvedFrom: string;
+}
+
+function tableExists(table: string): boolean {
+  return !!db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?`).get(table);
+}
+
+/**
+ * The casing this buffer is actually stored under.
+ *
+ * Callers hand us whatever the wire said — a NICK event's old nick, a RENAME's
+ * old channel — whose casing needn't match what we stored. Every UPDATE below
+ * then matches `target` EXACTLY, deliberately: `COLLATE NOCASE` or `lower()`
+ * would defeat idx_messages_unread's (network_id, target) prefix and turn an
+ * index range scan into a scan of every message on the network.
+ *
+ * So the folded lookup happens once, here, against the buffers registry — which
+ * is the authority on display casing — and everything downstream is exact.
+ *
+ * A buffer with no registry row falls back to the caller's string as-is. So does
+ * a genuine case fork in history: this renames ONE casing, and repairing a fork
+ * is foldBufferCase's job, not this one's.
+ */
+function canonicalName(userId: number, networkId: number, target: string): string {
+  return getBuffer(userId, networkId, target)?.target ?? target;
+}
+
+function scopeSql(table: string, scope: readonly string[]): string {
+  return (
+    scope
+      .filter((c) => c === 'user_id' || c === 'network_id')
+      .map((c) => `${table}.${c} = ?`)
+      .join(' AND ') || '1=1'
+  );
+}
+
+function scopeArgs(scope: readonly string[], userId: number, networkId: number): number[] {
+  return scope
+    .filter((c) => c === 'user_id' || c === 'network_id')
+    .map((c) => (c === 'user_id' ? userId : networkId));
+}
+
+/**
+ * Rewrite one comma-separated channel-scope list.
+ *
+ * Only entries that are a LITERAL match for the old name are replaced. An entry
+ * containing a glob metacharacter is left untouched: a rule scoped to `#old*`
+ * expresses a pattern the user chose, and rewriting it to `#new*` would silently
+ * change which channels it covers. A rule scoped to the literal `#old` clearly
+ * meant this buffer, and should follow it.
+ *
+ * Lists are stored already normalized (trimmed, lowercased, deduped), so the
+ * comparison is against the folded names and the replacement is written folded.
+ */
+export function rewriteChannelList(csv: string | null, from: string, to: string): string | null {
+  if (!csv) return null;
+  const fromFolded = foldTarget(from);
+  const toFolded = foldTarget(to);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of csv.split(',')) {
+    const entry = raw.trim();
+    if (!entry) continue;
+    const isGlob = /[*?]/.test(entry);
+    const next = !isGlob && entry.toLowerCase() === fromFolded ? toFolded : entry;
+    // Renaming onto a name the list already scopes would duplicate it.
+    if (seen.has(next)) continue;
+    seen.add(next);
+    out.push(next);
+  }
+  return out.length ? out.join(',') : null;
+}
+
+/**
+ * Rename `from` to `to` for one user on one network.
+ *
+ * Merges rather than refusing when `to` already exists — weechat declines the
+ * rename in that case and leaves two buffers, which for a DM peer who reclaims
+ * an old nick just strands history under a name they no longer use.
+ *
+ * A case-only rename (`#Foo` -> `#foo`) is a rewrite, not a merge: the folded
+ * key is unchanged, so source and destination are the same row everywhere.
+ */
+export function renameBuffer(
+  userId: number,
+  networkId: number,
+  from: string,
+  to: string,
+): RenameBufferResult {
+  const resolvedFrom = canonicalName(userId, networkId, from);
+  const rowsAffected: Record<string, number> = {};
+  const stillReferencing: Record<string, number> = {};
+  const empty: RenameBufferResult = {
+    renamed: false,
+    merged: false,
+    rowsAffected,
+    stillReferencing,
+    resolvedFrom,
+  };
+
+  if (!to || !resolvedFrom || resolvedFrom === to) return empty;
+
+  const caseOnly = foldTarget(resolvedFrom) === foldTarget(to);
+  // A destination row only counts as a collision when it's a DIFFERENT buffer.
+  const destination = caseOnly ? undefined : getBuffer(userId, networkId, to);
+  const merged = !!destination;
+
+  const run = db.transaction((): boolean => {
+    let touched = false;
+    const bump = (table: string, n: number) => {
+      if (n > 0) {
+        rowsAffected[table] = (rowsAffected[table] ?? 0) + n;
+        touched = true;
+      }
+    };
+
+    for (const t of BUFFER_KEYED_TABLES) {
+      if (t.legacy || !tableExists(t.table)) continue;
+
+      const where = `${scopeSql(t.table, t.scope)} AND ${t.column} = ?`;
+      const args = [...scopeArgs(t.scope, userId, networkId), resolvedFrom];
+
+      if (UNHANDLED_TABLES[t.table]) {
+        const n = countListReferences(t, userId, resolvedFrom);
+        if (n > 0) stillReferencing[t.table] = n;
+        continue;
+      }
+
+      if (BESPOKE_HANDLERS.has(t.table)) {
+        bump(
+          t.table,
+          t.table === 'buffers'
+            ? renameBufferRow(userId, networkId, resolvedFrom, to, caseOnly)
+            : mergeBufferReads(userId, networkId, resolvedFrom, to),
+        );
+        continue;
+      }
+
+      if (t.policy === 'rewrite') {
+        // No uniqueness on the target, so every row moves and nothing collides.
+        bump(
+          t.table,
+          db.prepare(`UPDATE ${t.table} SET ${t.column} = ? WHERE ${where}`).run(to, ...args)
+            .changes,
+        );
+        continue;
+      }
+
+      if (t.policy === 'destination-wins') {
+        // OR IGNORE moves what it can; the DELETE clears what collided, leaving
+        // the destination's own row as the survivor.
+        const moved = db
+          .prepare(`UPDATE OR IGNORE ${t.table} SET ${t.column} = ? WHERE ${where}`)
+          .run(to, ...args).changes;
+        const dropped = db.prepare(`DELETE FROM ${t.table} WHERE ${where}`).run(...args).changes;
+        bump(t.table, moved + dropped);
+        continue;
+      }
+
+      throw new Error(
+        `renameBuffer: ${t.table} is declared policy '${t.policy}' with no handler. ` +
+          `Add one, or correct its policy in bufferKeyedTables.ts.`,
+      );
+    }
+
+    // Pins are dense per (user, network) and reorderPins assumes 0..n-1, so a
+    // dropped collision has to be closed up. Cheap and idempotent, so it runs
+    // whenever pins moved at all rather than only when one actually collided.
+    if (rowsAffected.pinned_buffers) {
+      db.prepare(
+        `WITH renum AS (
+           SELECT user_id, network_id, target,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY user_id, network_id ORDER BY position ASC, target ASC
+                  ) - 1 AS new_pos
+             FROM pinned_buffers WHERE user_id = ? AND network_id = ?
+         )
+         UPDATE pinned_buffers SET position = (
+           SELECT new_pos FROM renum
+            WHERE renum.user_id = pinned_buffers.user_id
+              AND renum.network_id = pinned_buffers.network_id
+              AND renum.target = pinned_buffers.target
+         )
+         WHERE user_id = ? AND network_id = ?`,
+      ).run(userId, networkId, userId, networkId);
+    }
+
+    return touched;
+  });
+
+  const renamed = run();
+  return { renamed, merged, rowsAffected, stillReferencing, resolvedFrom };
+}
+
+/**
+ * The registry row itself: `target` and its `target_folded` lookup key move
+ * together, or the buffer becomes unfindable.
+ *
+ * On a merge the DESTINATION row survives, because it is the row already sitting
+ * at the name everything will now ask for. What carries across from the source
+ * is the state that would otherwise be lost: an open state (a rename shouldn't
+ * resurrect history into a closed buffer, but it shouldn't hide it either), the
+ * autojoin flag, a channel key, and the earlier created_at.
+ */
+function renameBufferRow(
+  userId: number,
+  networkId: number,
+  from: string,
+  to: string,
+  caseOnly: boolean,
+): number {
+  const source = getBuffer(userId, networkId, from);
+  if (!source) return 0;
+
+  if (caseOnly) {
+    return db
+      .prepare(
+        `UPDATE buffers SET target = ?, target_folded = ?
+          WHERE user_id = ? AND network_id = ? AND target_folded = ?`,
+      )
+      .run(to, foldTarget(to), userId, networkId, foldTarget(from)).changes;
+  }
+
+  const destination = getBuffer(userId, networkId, to);
+  if (!destination) {
+    return db
+      .prepare(
+        `UPDATE buffers SET target = ?, target_folded = ?
+          WHERE user_id = ? AND network_id = ? AND target_folded = ?`,
+      )
+      .run(to, foldTarget(to), userId, networkId, foldTarget(from)).changes;
+  }
+
+  const merged = db
+    .prepare(
+      `UPDATE buffers
+          SET state      = CASE WHEN ? = 'open' THEN 'open' ELSE state END,
+              autojoin   = MAX(autojoin, ?),
+              key        = COALESCE(key, ?),
+              created_at = MIN(created_at, ?)
+        WHERE user_id = ? AND network_id = ? AND target_folded = ?`,
+    )
+    .run(
+      source.state,
+      source.autojoin ? 1 : 0,
+      // Re-encrypting the source key would need the plaintext; carry the stored
+      // envelope instead. COALESCE keeps the destination's own key when it has
+      // one, so this only fills a gap.
+      rawKey(userId, networkId, from),
+      source.createdAt,
+      userId,
+      networkId,
+      foldTarget(to),
+    ).changes;
+
+  const dropped = db
+    .prepare(`DELETE FROM buffers WHERE user_id = ? AND network_id = ? AND target_folded = ?`)
+    .run(userId, networkId, foldTarget(from)).changes;
+
+  return merged + dropped;
+}
+
+/** The stored (still-encrypted) channel key envelope, without decrypting it. */
+function rawKey(userId: number, networkId: number, target: string): string | null {
+  const row = db
+    .prepare(`SELECT key FROM buffers WHERE user_id = ? AND network_id = ? AND target_folded = ?`)
+    .get(userId, networkId, foldTarget(target)) as { key: string | null } | undefined;
+  return row?.key ?? null;
+}
+
+/**
+ * Read pointer and /clear marker — the one table where both sides carry progress
+ * that has to be reconciled rather than picked between.
+ *
+ * Keeps the FURTHEST read pointer and the FURTHEST clear boundary independently,
+ * so a merge can neither resurrect messages the user already read nor un-clear
+ * ones they cleared. Same reasoning as foldBufferCase's merge; the shapes differ
+ * because that one folds every fork at once and this one moves a single buffer.
+ */
+function mergeBufferReads(userId: number, networkId: number, from: string, to: string): number {
+  const moved = db
+    .prepare(
+      `INSERT INTO buffer_reads
+         (user_id, network_id, target, last_read_message_id, updated_at,
+          cleared_before_message_id, cleared_at)
+       SELECT user_id, network_id, ?, last_read_message_id, updated_at,
+              cleared_before_message_id, cleared_at
+         FROM buffer_reads
+        WHERE user_id = ? AND network_id = ? AND target = ?
+       ON CONFLICT(user_id, network_id, target) DO UPDATE SET
+         last_read_message_id =
+           MAX(buffer_reads.last_read_message_id, excluded.last_read_message_id),
+         cleared_before_message_id = NULLIF(
+           MAX(COALESCE(buffer_reads.cleared_before_message_id, 0),
+               COALESCE(excluded.cleared_before_message_id, 0)), 0),
+         cleared_at = CASE
+           WHEN COALESCE(excluded.cleared_before_message_id, 0)
+                > COALESCE(buffer_reads.cleared_before_message_id, 0)
+           THEN excluded.cleared_at ELSE buffer_reads.cleared_at END,
+         updated_at = MAX(buffer_reads.updated_at, excluded.updated_at)`,
+    )
+    .run(to, userId, networkId, from).changes;
+
+  const dropped = db
+    .prepare(`DELETE FROM buffer_reads WHERE user_id = ? AND network_id = ? AND target = ?`)
+    .run(userId, networkId, from).changes;
+
+  return moved + dropped;
+}
+
+/**
+ * How many of this user's rules still name `from` literally.
+ *
+ * Scoped by user only — deliberately wider than the rename's own network scope,
+ * because the point is to report everything the user might need to fix, and a
+ * cross-network rule is exactly the case that can't be auto-rewritten.
+ */
+function countListReferences(
+  t: (typeof BUFFER_KEYED_TABLES)[number],
+  userId: number,
+  from: string,
+): number {
+  const rows = db
+    .prepare(`SELECT ${t.column} AS list FROM ${t.table} WHERE user_id = ?`)
+    .all(userId) as Array<{ list: string | null }>;
+  const fromFolded = foldTarget(from);
+  return rows.filter((r) =>
+    (r.list ?? '')
+      .split(',')
+      .some((e) => e.trim().toLowerCase() === fromFolded && !/[*?]/.test(e.trim())),
+  ).length;
+}
+
+/** Registry tables with no handler here, and why. Asserted by the tests. */
+export function unhandledRenameTables(): Readonly<Record<string, string>> {
+  return UNHANDLED_TABLES;
+}
+
+/**
+ * Whether a live registry entry is actually moved by renameBuffer.
+ *
+ * Mirrors the dispatch in the loop above via the same two constants, so this
+ * answers "is there code that moves it" rather than "did someone remember to
+ * excuse it".
+ */
+export function hasRenameHandler(table: string): boolean {
+  const t = bufferKeyedTable(table);
+  if (!t || t.legacy || UNHANDLED_TABLES[t.table]) return false;
+  return BESPOKE_HANDLERS.has(t.table) || IMPLEMENTED_POLICIES.has(t.policy);
+}

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2522,3 +2522,76 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     expect(getBuffer(conn.network.user_id, conn.network.id, '#apple')?.autojoin).toBe(false);
   });
 });
+
+// Live channel membership is in-memory only — `channels` is the sole record of
+// who is in a channel right now. A rename that moves the database rows but
+// leaves this Map keyed by the old name leaves the renamed channel with an
+// empty nicklist until the next NAMES, and strands a ghost key that
+// canonicalChannelTarget can still resolve incoming events onto.
+describe('renameChannel (in-memory rekey)', () => {
+  function makeConn(suffix: string): IrcConnection {
+    const user = createUser(`rename-chan-${suffix}`);
+    const network = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: true,
+      nick: 'nick',
+    })!;
+    return new IrcConnection({ network, onEvent: () => {} });
+  }
+
+  function joinMember(conn: IrcConnection, channel: string, nick: string): void {
+    conn.client.emit('join', { channel, nick, ident: 'i', hostname: 'h' });
+  }
+
+  it('moves membership and topic onto the new key', () => {
+    const conn = makeConn('basic');
+    joinMember(conn, '#old', 'alice');
+    joinMember(conn, '#old', 'bob');
+    conn.channels.get('#old')!.topic = 'the topic';
+
+    expect(conn.renameChannel('#old', '#new')).toBe(true);
+
+    expect(conn.channels.has('#old')).toBe(false);
+    const moved = conn.channels.get('#new');
+    expect(moved?.name).toBe('#new');
+    expect(moved?.topic).toBe('the topic');
+    expect([...(moved?.members.keys() ?? [])].toSorted()).toEqual(['alice', 'bob']);
+  });
+
+  it('updates the display name on a case-only rename without dropping the key', () => {
+    const conn = makeConn('case');
+    joinMember(conn, '#Foo', 'alice');
+
+    expect(conn.renameChannel('#Foo', '#foo')).toBe(true);
+
+    // Same folded key, so the entry must survive rather than be deleted and
+    // re-added — but the display casing has to follow.
+    expect(conn.channels.size).toBe(1);
+    expect(conn.channels.get('#foo')?.name).toBe('#foo');
+    expect([...conn.channels.get('#foo')!.members.keys()]).toEqual(['alice']);
+  });
+
+  it('reports false for a channel we are not in', () => {
+    const conn = makeConn('absent');
+    // A DM rename, or a channel we have history for but are not joined to.
+    expect(conn.renameChannel('#nothere', '#elsewhere')).toBe(false);
+    expect(conn.channels.size).toBe(0);
+  });
+
+  it('carries a pending join key across the rename', () => {
+    // A key stashed for a join whose echo hasn't landed yet is keyed by channel.
+    // If a rename lands in that window and leaves the key behind, the echo for
+    // the NEW name finds nothing, the +k is never persisted, and the channel
+    // silently fails to auto-rejoin after the next reconnect.
+    const conn = makeConn('pendingkey');
+    joinMember(conn, '#secret', 'nick');
+    conn.stashJoinKey('#secret', 'hunter2');
+
+    conn.renameChannel('#secret', '#classified');
+
+    expect(conn.takeStashedJoinKey('#secret')).toBeUndefined();
+    expect(conn.takeStashedJoinKey('#classified')).toBe('hunter2');
+  });
+});

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2581,17 +2581,36 @@ describe('renameChannel (in-memory rekey)', () => {
   });
 
   it('carries a pending join key across the rename', () => {
-    // A key stashed for a join whose echo hasn't landed yet is keyed by channel.
-    // If a rename lands in that window and leaves the key behind, the echo for
-    // the NEW name finds nothing, the +k is never persisted, and the channel
-    // silently fails to auto-rejoin after the next reconnect.
+    // NO joinMember here, and that's the point. ircManager stashes a key only in
+    // the else-branch of `channels.has(...)` — so the only state in which a
+    // pending key exists is one where we are NOT in the channel. An earlier
+    // version of this test joined first, which faked a precondition that cannot
+    // occur and let an unreachable code path look covered.
     const conn = makeConn('pendingkey');
-    joinMember(conn, '#secret', 'nick');
     conn.stashJoinKey('#secret', 'hunter2');
+    expect(conn.channels.has('#secret')).toBe(false);
 
-    conn.renameChannel('#secret', '#classified');
+    // Returns false (no live channel), but the key must still move.
+    expect(conn.renameChannel('#secret', '#classified')).toBe(false);
 
     expect(conn.takeStashedJoinKey('#secret')).toBeUndefined();
     expect(conn.takeStashedJoinKey('#classified')).toBe('hunter2');
+  });
+
+  it('rekeys the other channel-keyed marks', () => {
+    // Left behind, unsendableTargets keeps a "can't speak here" flag under a
+    // dead key so canSendTo reports the new name sendable, and autoWhoTargets
+    // leaks its one-shot suppression so an auto-WHO reply is echoed to the user.
+    const conn = makeConn('marks');
+    joinMember(conn, '#quiet', 'alice');
+    conn.unsendableTargets.add('#quiet');
+    conn.autoWhoTargets.add('#quiet');
+
+    conn.renameChannel('#quiet', '#loud');
+
+    expect(conn.unsendableTargets.has('#quiet')).toBe(false);
+    expect(conn.unsendableTargets.has('#loud')).toBe(true);
+    expect(conn.autoWhoTargets.has('#quiet')).toBe(false);
+    expect(conn.autoWhoTargets.has('#loud')).toBe(true);
   });
 });

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2614,3 +2614,65 @@ describe('renameChannel (in-memory rekey)', () => {
     expect(conn.autoWhoTargets.has('#loud')).toBe(true);
   });
 });
+
+describe('renameChannel with a live destination', () => {
+  function makeConn(suffix: string): IrcConnection {
+    const user = createUser(`rename-dest-${suffix}`);
+    const network = createNetwork(user.id, {
+      name: 'n',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: true,
+      nick: 'nick',
+    })!;
+    return new IrcConnection({ network, onEvent: () => {} });
+  }
+  function joinMember(conn: IrcConnection, channel: string, nick: string): void {
+    conn.client.emit('join', { channel, nick, ident: 'i', hostname: 'h' });
+  }
+
+  it('keeps the destination channel state instead of clobbering it', () => {
+    // renameBufferAndAnnounce drives the DB merge and this rekey together, and
+    // the merge exists precisely for a destination that already exists — so the
+    // "two live channels can't be the same" assumption was wrong. Clobbering
+    // left the surviving buffer showing the OLD channel's members and topic.
+    const conn = makeConn('clobber');
+    joinMember(conn, '#old', 'alice');
+    joinMember(conn, '#new', 'bob');
+    conn.channels.get('#old')!.topic = 'old topic';
+    conn.channels.get('#new')!.topic = 'new topic';
+
+    expect(conn.renameChannel('#old', '#new')).toBe(true);
+
+    expect(conn.channels.has('#old')).toBe(false);
+    const survivor = conn.channels.get('#new');
+    expect(survivor?.topic).toBe('new topic');
+    expect([...(survivor?.members.keys() ?? [])]).toEqual(['bob']);
+  });
+
+  it('does not carry send-state marks onto a live destination', () => {
+    // #old being +m-unsendable says nothing about #new, which we are really in.
+    const conn = makeConn('marks-dest');
+    joinMember(conn, '#old', 'alice');
+    joinMember(conn, '#new', 'bob');
+    conn.unsendableTargets.add('#old');
+
+    conn.renameChannel('#old', '#new');
+
+    expect(conn.unsendableTargets.has('#old')).toBe(false);
+    expect(conn.unsendableTargets.has('#new')).toBe(false);
+  });
+
+  it('carries lastUserSendAt when the destination is not live', () => {
+    // Losing it makes isOverloadedSpeakRejection misread a real failed PRIVMSG
+    // as an automated TAGMSG bounce — the message is silently dropped.
+    const conn = makeConn('sendat');
+    joinMember(conn, '#old', 'alice');
+    conn.lastUserSendAt.set('#old', 1234);
+
+    conn.renameChannel('#old', '#new');
+
+    expect(conn.lastUserSendAt.get('#old')).toBeUndefined();
+    expect(conn.lastUserSendAt.get('#new')).toBe(1234);
+  });
+});

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3035,15 +3035,45 @@ export class IrcConnection {
 
       // Other channel-keyed in-memory marks, for the same reason. Left behind,
       // `unsendableTargets` keeps a "can't speak here" flag under a dead key so
-      // canSendTo reports the new name sendable until something re-learns it,
-      // and `autoWhoTargets` leaks its one-shot suppression so an in-flight
-      // auto-WHO reply gets echoed to the user as visible output.
-      if (this.unsendableTargets.delete(fromKey)) this.unsendableTargets.add(toKey);
-      if (this.autoWhoTargets.delete(fromKey)) this.autoWhoTargets.add(toKey);
+      // canSendTo reports the new name sendable until something re-learns it;
+      // `autoWhoTargets` leaks its one-shot suppression so an in-flight auto-WHO
+      // reply gets echoed to the user; and `lastUserSendAt` loses the timestamp
+      // isOverloadedSpeakRejection needs, so a real failed PRIVMSG is
+      // misclassified as an automated TAGMSG bounce and silently dropped.
+      // resetSendState() already clears these together — they are one unit.
+      //
+      // Only migrated when the destination has no value of its own. On a merge
+      // the destination is a channel we are really in, and its marks describe
+      // it; overwriting them with the source's would suppress sends in a channel
+      // the user can speak in.
+      const destinationLive = this.channels.has(toKey);
+      const carry = (from: Set<string>, key: string, dest: string) => {
+        const had = from.delete(key);
+        if (had && !destinationLive) from.add(dest);
+      };
+      carry(this.unsendableTargets, fromKey, toKey);
+      carry(this.autoWhoTargets, fromKey, toKey);
+      const sentAt = this.lastUserSendAt.get(fromKey);
+      this.lastUserSendAt.delete(fromKey);
+      if (sentAt !== undefined && !destinationLive) this.lastUserSendAt.set(toKey, sentAt);
     }
 
     const ch = this.channels.get(fromKey);
     if (!ch) return false;
+
+    // A live destination wins, and the source entry is dropped rather than
+    // overwriting it.
+    //
+    // The docstring used to argue this state was impossible — "two live channels
+    // cannot be the same channel" — but renameBufferAndAnnounce drives the
+    // database merge and this rekey together, and the merge exists precisely for
+    // a destination that already exists. Clobbering left the surviving buffer
+    // showing the OLD channel's nicklist and topic until the next NAMES.
+    if (fromKey !== toKey && this.channels.has(toKey)) {
+      this.channels.delete(fromKey);
+      return true;
+    }
+
     ch.name = to;
     if (fromKey !== toKey) this.channels.delete(fromKey);
     this.channels.set(toKey, ch);

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2997,9 +2997,6 @@ export class IrcConnection {
     return this.addPeerWatch(nick, 'dm', null);
   }
 
-  // User closed the DM buffer: drop the 'dm' reason. If the nick is still a
-  // friend the shared watch + presence row stay; otherwise both are cleared —
-  // even when it wasn't actively tracked, so a stale row from history is swept.
   /**
    * Rekey a live channel in the in-memory map after a rename.
    *
@@ -3020,23 +3017,42 @@ export class IrcConnection {
   renameChannel(from: string, to: string): boolean {
     const fromKey = from.toLowerCase();
     const toKey = to.toLowerCase();
-    const ch = this.channels.get(fromKey);
-    if (!ch) return false;
-    ch.name = to;
+    if (fromKey === toKey && from === to) return this.channels.has(fromKey);
+
     if (fromKey !== toKey) {
-      this.channels.delete(fromKey);
-      // Any pending join key follows the channel it belongs to, or a rename
-      // racing a +k join would drop the key and break the auto-rejoin.
+      // ABOVE the membership check, deliberately. A key is stashed only while we
+      // are NOT yet in the channel (ircManager only calls stashJoinKey in the
+      // else-branch of `channels.has(...)`), so the one state in which a pending
+      // key exists is precisely the one where there is no `channels` entry to
+      // find. Migrating it after an early return made this unreachable — the key
+      // would be stranded under the old name, the +k never persisted, and the
+      // channel would quietly stop auto-rejoining.
       const pendingKey = this.pendingJoinKeys.get(fromKey);
       if (pendingKey !== undefined) {
         this.pendingJoinKeys.delete(fromKey);
         this.pendingJoinKeys.set(toKey, pendingKey);
       }
+
+      // Other channel-keyed in-memory marks, for the same reason. Left behind,
+      // `unsendableTargets` keeps a "can't speak here" flag under a dead key so
+      // canSendTo reports the new name sendable until something re-learns it,
+      // and `autoWhoTargets` leaks its one-shot suppression so an in-flight
+      // auto-WHO reply gets echoed to the user as visible output.
+      if (this.unsendableTargets.delete(fromKey)) this.unsendableTargets.add(toKey);
+      if (this.autoWhoTargets.delete(fromKey)) this.autoWhoTargets.add(toKey);
     }
+
+    const ch = this.channels.get(fromKey);
+    if (!ch) return false;
+    ch.name = to;
+    if (fromKey !== toKey) this.channels.delete(fromKey);
     this.channels.set(toKey, ch);
     return true;
   }
 
+  // User closed the DM buffer: drop the 'dm' reason. If the nick is still a
+  // friend the shared watch + presence row stay; otherwise both are cleared —
+  // even when it wasn't actively tracked, so a stale row from history is swept.
   untrackDmPeer(nick: string | undefined | null): void {
     if (!nick) return;
     const lower = nick.toLowerCase();

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3000,6 +3000,43 @@ export class IrcConnection {
   // User closed the DM buffer: drop the 'dm' reason. If the nick is still a
   // friend the shared watch + presence row stay; otherwise both are cleared —
   // even when it wasn't actively tracked, so a stale row from history is swept.
+  /**
+   * Rekey a live channel in the in-memory map after a rename.
+   *
+   * `channels` is the only record of who is currently IN a channel — membership
+   * is never persisted (see the class comment). A rename that moves the database
+   * rows but leaves this Map keyed by the old name leaves the renamed channel
+   * with an empty nicklist until the next NAMES, while the old key lingers as a
+   * ghost that `canonicalChannelTarget` can still resolve incoming events onto.
+   *
+   * Returns false when there was no live channel under `from` — a DM rename, or
+   * a channel we aren't currently joined to. Both are ordinary, not errors.
+   *
+   * Merging is deliberately NOT attempted: two live channels cannot be the same
+   * channel, so a destination key already existing means the server told us
+   * something contradictory. The incoming state wins, since it's the one the
+   * rename just described.
+   */
+  renameChannel(from: string, to: string): boolean {
+    const fromKey = from.toLowerCase();
+    const toKey = to.toLowerCase();
+    const ch = this.channels.get(fromKey);
+    if (!ch) return false;
+    ch.name = to;
+    if (fromKey !== toKey) {
+      this.channels.delete(fromKey);
+      // Any pending join key follows the channel it belongs to, or a rename
+      // racing a +k join would drop the key and break the auto-rejoin.
+      const pendingKey = this.pendingJoinKeys.get(fromKey);
+      if (pendingKey !== undefined) {
+        this.pendingJoinKeys.delete(fromKey);
+        this.pendingJoinKeys.set(toKey, pendingKey);
+      }
+    }
+    this.channels.set(toKey, ch);
+    return true;
+  }
+
   untrackDmPeer(nick: string | undefined | null): void {
     if (!nick) return;
     const lower = nick.toLowerCase();

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -36,6 +36,7 @@ let buildSystemHistoryReply: typeof import('./wsHub.js').buildSystemHistoryReply
 let startChanlistRefresh: typeof import('./wsHub.js').startChanlistRefresh;
 let DM_ELIGIBLE_TYPES: typeof import('./wsHub.js').DM_ELIGIBLE_TYPES;
 let reopensClosedBuffer: typeof import('./wsHub.js').reopensClosedBuffer;
+let renameBufferAndAnnounce: typeof import('./wsHub.js').renameBufferAndAnnounce;
 let chanlist: typeof import('../db/chanlist.js');
 let systemMessages: typeof import('../db/systemMessages.js').default;
 
@@ -68,6 +69,7 @@ beforeAll(async () => {
     startChanlistRefresh,
     DM_ELIGIBLE_TYPES,
     reopensClosedBuffer,
+    renameBufferAndAnnounce,
   } = await import('./wsHub.js'));
   chanlist = await import('../db/chanlist.js');
   systemMessages = (await import('../db/systemMessages.js')).default;
@@ -1464,5 +1466,86 @@ describe('allowInboundMessage', () => {
     expect(rejected).toBeGreaterThan(0); // the flood was throttled
     // Nowhere near all 10k were admitted — the cap held.
     expect(allowed).toBeLessThan(1_000);
+  });
+});
+
+// The single entry point for a rename: database rows, live channel membership,
+// and the clients all have to move together. Split across two call sites they
+// would drift, and each of the three failing alone is silent.
+describe('renameBufferAndAnnounce', () => {
+  it('moves the rows and rekeys the live channel together', () => {
+    buffers.ensureOpen(userId, networkId, '#before', { kind: 'channel', autojoin: true });
+    insertMessage({
+      networkId,
+      target: '#before',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'alice',
+      text: 'hello',
+    });
+    const renameChannel = vi.fn<(from: string, to: string) => boolean>().mockReturnValue(true);
+    const spy = vi
+      .spyOn(ircManager, 'getConnection')
+      .mockReturnValue({ channels: new Map(), renameChannel } as never);
+    try {
+      const result = renameBufferAndAnnounce(userId, networkId, '#before', '#after');
+
+      expect(result.renamed).toBe(true);
+      expect(buffers.getBuffer(userId, networkId, '#after')?.target).toBe('#after');
+      expect(buffers.getBuffer(userId, networkId, '#before')).toBeUndefined();
+      // The live map is the ONLY record of current membership; leaving it on the
+      // old key empties the renamed channel's nicklist until the next NAMES.
+      expect(renameChannel).toHaveBeenCalledWith('#before', '#after');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('passes the RESOLVED names to the live rekey, not the caller strings', () => {
+    // Both ends can be re-resolved: `from` against the registry's stored casing,
+    // `to` against an existing destination's. The in-memory map has to be told
+    // the same names the rows actually moved between.
+    buffers.ensureOpen(userId, networkId, '#Mixed', { kind: 'channel', autojoin: true });
+    buffers.ensureOpen(userId, networkId, '#dest', { kind: 'channel', autojoin: true });
+    const renameChannel = vi.fn<(from: string, to: string) => boolean>().mockReturnValue(true);
+    const spy = vi
+      .spyOn(ircManager, 'getConnection')
+      .mockReturnValue({ channels: new Map(), renameChannel } as never);
+    try {
+      const result = renameBufferAndAnnounce(userId, networkId, '#mIxEd', '#DEST');
+
+      expect(result.resolvedFrom).toBe('#Mixed');
+      expect(result.resolvedTo).toBe('#dest');
+      expect(result.merged).toBe(true);
+      expect(renameChannel).toHaveBeenCalledWith('#Mixed', '#dest');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('does nothing at all when there is no such buffer', () => {
+    const renameChannel = vi.fn<(from: string, to: string) => boolean>();
+    const spy = vi
+      .spyOn(ircManager, 'getConnection')
+      .mockReturnValue({ channels: new Map(), renameChannel } as never);
+    try {
+      const result = renameBufferAndAnnounce(userId, networkId, '#nope', '#other');
+      expect(result.renamed).toBe(false);
+      // No frame, and no live-state churn, for a rename that moved nothing.
+      expect(renameChannel).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('survives a disconnected network (no live connection to rekey)', () => {
+    buffers.ensureOpen(userId, networkId, '#offline', { kind: 'channel', autojoin: true });
+    const spy = vi.spyOn(ircManager, 'getConnection').mockReturnValue(undefined as never);
+    try {
+      expect(() => renameBufferAndAnnounce(userId, networkId, '#offline', '#backup')).not.toThrow();
+      expect(buffers.getBuffer(userId, networkId, '#backup')?.target).toBe('#backup');
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -37,7 +37,6 @@ let startChanlistRefresh: typeof import('./wsHub.js').startChanlistRefresh;
 let DM_ELIGIBLE_TYPES: typeof import('./wsHub.js').DM_ELIGIBLE_TYPES;
 let reopensClosedBuffer: typeof import('./wsHub.js').reopensClosedBuffer;
 let renameBufferAndAnnounce: typeof import('./wsHub.js').renameBufferAndAnnounce;
-let getReadState: typeof import('../db/bufferReads.js').getReadState;
 let chanlist: typeof import('../db/chanlist.js');
 let systemMessages: typeof import('../db/systemMessages.js').default;
 
@@ -50,7 +49,7 @@ beforeAll(async () => {
   dbHandle = (await import('../db/index.js')).default;
   ({ insertMessage, maxMessageId } = await import('../db/messages.js'));
   buffers = await import('../db/buffers.js');
-  ({ setClearedState, setReadState, getReadState } = await import('../db/bufferReads.js'));
+  ({ setClearedState, setReadState } = await import('../db/bufferReads.js'));
   ircManager = (await import('./ircManager.js')).default;
   ({
     computeTotalHighlights,
@@ -1519,11 +1518,13 @@ describe('renameBufferAndAnnounce', () => {
       expect(result.resolvedTo).toBe('#dest');
       expect(result.merged).toBe(true);
       expect(renameChannel).toHaveBeenCalledWith('#Mixed', '#dest');
-      // A merge also pushes read-state, since it reconciled the two read
-      // pointers and moved messages onto the survivor. Only the DB effect and
-      // the fact that the path completes are asserted here — observing the
-      // frame itself needs a socket seam wsHub does not currently expose.
-      expect(getReadState(userId, networkId, '#dest')).toBeGreaterThanOrEqual(0);
+      // NOT asserted here: that the merge's read-state frame reaches a socket.
+      // wsHub keeps socketsByUser private with no test seam, and no test in this
+      // file observes a fan-out. An earlier version of this line asserted
+      // `getReadState(...) >= 0`, which cannot fail — getReadState returns
+      // `row ? row.lastReadId : 0` and ids are positive — so deleting the whole
+      // `if (result.merged) broadcastReadState(...)` block kept the suite green.
+      // A gap that looks like coverage is worse than a visible one.
     } finally {
       spy.mockRestore();
     }

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -37,6 +37,7 @@ let startChanlistRefresh: typeof import('./wsHub.js').startChanlistRefresh;
 let DM_ELIGIBLE_TYPES: typeof import('./wsHub.js').DM_ELIGIBLE_TYPES;
 let reopensClosedBuffer: typeof import('./wsHub.js').reopensClosedBuffer;
 let renameBufferAndAnnounce: typeof import('./wsHub.js').renameBufferAndAnnounce;
+let getReadState: typeof import('../db/bufferReads.js').getReadState;
 let chanlist: typeof import('../db/chanlist.js');
 let systemMessages: typeof import('../db/systemMessages.js').default;
 
@@ -49,7 +50,7 @@ beforeAll(async () => {
   dbHandle = (await import('../db/index.js')).default;
   ({ insertMessage, maxMessageId } = await import('../db/messages.js'));
   buffers = await import('../db/buffers.js');
-  ({ setClearedState, setReadState } = await import('../db/bufferReads.js'));
+  ({ setClearedState, setReadState, getReadState } = await import('../db/bufferReads.js'));
   ircManager = (await import('./ircManager.js')).default;
   ({
     computeTotalHighlights,
@@ -1518,6 +1519,11 @@ describe('renameBufferAndAnnounce', () => {
       expect(result.resolvedTo).toBe('#dest');
       expect(result.merged).toBe(true);
       expect(renameChannel).toHaveBeenCalledWith('#Mixed', '#dest');
+      // A merge also pushes read-state, since it reconciled the two read
+      // pointers and moved messages onto the survivor. Only the DB effect and
+      // the fact that the path completes are asserted here — observing the
+      // frame itself needs a socket seam wsHub does not currently expose.
+      expect(getReadState(userId, networkId, '#dest')).toBeGreaterThanOrEqual(0);
     } finally {
       spy.mockRestore();
     }

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -75,6 +75,8 @@ import {
   kindForTarget,
 } from '../db/buffers.js';
 import type { BufferStateRow } from '../db/buffers.js';
+import { renameBuffer as renameBufferRows } from '../db/renameBuffer.js';
+import type { RenameBufferResult } from '../db/renameBuffer.js';
 import {
   pinBuffer,
   unpinBuffer,
@@ -1263,6 +1265,60 @@ function announceOpen(
   const shell = buildBufferShell(userId, networkId, target, channelJoined(target, conn));
   fanOut(userId, shell, { exceptWs: requester });
   fanOut(userId, { kind: 'buffer-opened', networkId, target }, { exceptWs: requester });
+}
+
+/**
+ * Move a buffer to a new name and tell every one of the user's clients.
+ *
+ * The single entry point for a rename, so the three things that must happen
+ * together can't be done in two places and drift: the database rows move, the
+ * live channel map is rekeyed, and the clients are told. Callers are the two
+ * events that rename a buffer — a channel RENAME, and a DM peer changing nick.
+ *
+ * ## The frame is not an instruction to focus
+ *
+ * Unlike `buffer-opened`, `buffer-renamed` goes to EVERY socket including the
+ * one that caused it. It describes a change of identity that already happened
+ * server-side, so a client that doesn't apply it is simply wrong about what its
+ * buffers are called — there is no "someone else's action" reading of it, and
+ * nothing to yank. A client whose active buffer was renamed should follow it:
+ * that's the same buffer, not a navigation.
+ *
+ * ## Why `to` is echoed back rather than assumed
+ *
+ * `resolvedTo` may differ from the requested name. Merging into an existing
+ * buffer adopts that buffer's stored casing, because the registry owns display
+ * casing and every read path matches it exactly. Clients must key off the
+ * frame's `to`, never the name they might have predicted.
+ *
+ * Returns the rename result (including `stillReferencing`) so the caller can
+ * surface what the rename could not follow. A no-op rename fans out nothing.
+ */
+export function renameBufferAndAnnounce(
+  userId: number,
+  networkId: number,
+  from: string,
+  to: string,
+): RenameBufferResult {
+  const result = renameBufferRows(userId, networkId, from, to);
+  if (!result.renamed) return result;
+
+  // Live membership is in-memory only, so it has to move with the rows or the
+  // renamed channel shows an empty nicklist until the next NAMES.
+  ircManager
+    .getConnection(userId, networkId)
+    ?.renameChannel(result.resolvedFrom, result.resolvedTo);
+
+  fanOut(userId, {
+    kind: 'buffer-renamed',
+    networkId,
+    from: result.resolvedFrom,
+    to: result.resolvedTo,
+    // A merge is materially different client work — fold two buffers into one
+    // rather than rekey one — and the client cannot infer it from the names.
+    merged: result.merged,
+  });
+  return result;
 }
 
 // Per-user socket bookkeeping lives at module scope so the verb registry can

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1267,6 +1267,33 @@ function announceOpen(
   fanOut(userId, { kind: 'buffer-opened', networkId, target }, { exceptWs: requester });
 }
 
+// Single path for "tell every tab of this user what the buffer's unread counts
+// are now." Used by mark-read echo, the live IRC-event fan-out, and a rename
+// that merged two buffers — the client doesn't increment locally anymore, so
+// this is the only source of badge state.
+//
+// Module scope rather than a closure inside attachWsHub: a merge reconciles read
+// progress in the database, and the frame that reports it has to be reachable
+// from the rename path too. Both callers need the same function or the badge
+// silently disagrees with the rows.
+export function broadcastReadState(
+  userId: number,
+  networkId: number | null,
+  target: string,
+  lastReadId: number,
+): void {
+  const counts = computeUnreadFor(userId, networkId, target, lastReadId);
+  fanOut(userId, {
+    kind: 'read-state',
+    networkId,
+    target,
+    lastReadId: counts.lastReadId,
+    unread: counts.unread,
+    highlights: counts.highlights,
+    highlightsCapped: counts.highlightsCapped,
+  });
+}
+
 /**
  * Move a buffer to a new name and tell every one of the user's clients.
  *
@@ -1318,6 +1345,21 @@ export function renameBufferAndAnnounce(
     // rather than rekey one — and the client cannot infer it from the names.
     merged: result.merged,
   });
+
+  // A merge moved messages onto the destination AND took the furthest of the two
+  // read pointers, so the unread count the clients hold for it is now wrong in
+  // both directions. Nothing else will correct it: badge state only ever changes
+  // on a countable event in that buffer, and an idle merged DM may not see one
+  // for days. Push it explicitly rather than telling clients to wait for a frame
+  // that may never come.
+  if (result.merged) {
+    broadcastReadState(
+      userId,
+      networkId,
+      result.resolvedTo,
+      getReadState(userId, networkId, result.resolvedTo),
+    );
+  }
   return result;
 }
 
@@ -1708,24 +1750,6 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
   // counts are now." Used by mark-read echo and by the live IRC-event fan-out
   // below — the client doesn't increment locally anymore, so this is the
   // only source of badge state.
-  function broadcastReadState(
-    userId: number,
-    networkId: number | null,
-    target: string,
-    lastReadId: number,
-  ): void {
-    const counts = computeUnreadFor(userId, networkId, target, lastReadId);
-    fanOut(userId, {
-      kind: 'read-state',
-      networkId,
-      target,
-      lastReadId: counts.lastReadId,
-      unread: counts.unread,
-      highlights: counts.highlights,
-      highlightsCapped: counts.highlightsCapped,
-    });
-  }
-
   // Push-suppression gates shared by message and presence pushes: a manual
   // /away (when mute_when_away is on — auto-away is the case push matters most,
   // so it's not gated) and the user's configured quiet-hours window.

--- a/tools/fold-buffer-case.ts
+++ b/tools/fold-buffer-case.ts
@@ -96,6 +96,20 @@ function printReport(report: FoldReport): void {
     return;
   }
 
+  // A row count with no forks listed is not a contradiction, and an operator
+  // staring at "Forked buffers: 0" next to "messages 903000" deserves to be told
+  // why before they hit --apply. History can also be rewritten to REALIGN a
+  // single-cased buffer onto the casing the buffers registry holds; the fold
+  // takes canon from the registry, and `forks` only lists targets that had more
+  // than one casing in `messages`.
+  if (report.forks.length === 0 && totalRows > 0) {
+    console.log(
+      'No case forks found, but rows below still move: history is being realigned\n' +
+        'onto the casing the buffer registry holds. This is the display casing every\n' +
+        'read path already matches exactly, so the rewrite is what makes them agree.\n',
+    );
+  }
+
   if (report.forks.length > 0) {
     console.log(`Forked buffers (${report.forks.length}):`);
     for (const f of report.forks) {


### PR DESCRIPTION
Foundation for renaming a buffer — both a channel `RENAME` (#695) and a DM peer changing nick. **No behaviour change: nothing calls the new entry point yet.**

Two things here are fixes that matter today, independent of renames:

- `tools/fold-buffer-case.ts` has been **un-runnable since schema 16**. Its `FOLD_VALIDATED_SCHEMA_VERSION` guard was pinned at 9, and rightly — by 16 the fold was addressing `channels` and `closed_buffers`, both of which schema 16 drops, so a run would have died on `no such table: channels`.
- The FTS update trigger fired on **any** column update, so a bulk `UPDATE messages` paid a full reindex of text that hadn't changed.

## What's in it

**`messages_au` guarded on the columns it indexes.** Measured on a synthetic 1M-message channel with the real schema and indexes: **3.55s → 1.18s (3.0×)**, and 40 MB less database growth. `IS NOT` rather than `<>` because text is nullable and `NULL <> NULL` is NULL — verified a `<>` guard strands old text in the index.

**`bufferKeyedTables.ts` — the registry.** Buffers aren't normalized (`buffers.id` exists but nothing references it; 14 tables denormalize the target as a string). That's the right trade — a `buffer_id` join would sit on the hottest read path — but the cost is a list every rename must visit, and a missed entry is silent data loss. `bufferKeyedTables.test.ts` introspects the live schema and fails when a buffer-keyed table is undeclared, in both directions.

**`renameBuffer.ts` — the primitive.** One synchronous transaction. The plan called for `setImmediate` chunking; that was wrong on both branches, because there is exactly one shared SQLite connection. Chunking *inside* a transaction is a correctness bug (another write executing in the gap joins our transaction and rolls back with us); chunking *without* one gives up atomicity and buys nothing, since other work can't touch the DB while the statement is in SQLite's C code anyway.

**`renameBufferAndAnnounce` + the `buffer-renamed` frame**, plus `IrcConnection.renameChannel` — live membership is in-memory only, so it has to move with the rows or the renamed channel shows an empty nicklist until the next NAMES.

**Protocol §9.7**, marked not-yet-emitted.

## Review history

Three `/code-review` rounds found **nine** defects, and the same invariant broke three separate times: *display casing has exactly one owner.* The fold wrote message-majority casing over the registry's; `renameBuffer` wrote the caller's over the destination's; the fold's override then joined two different fold functions and silently never fired for non-ASCII targets. Each was silent, and each produced a buffer that opens blank with its draft and read pointer stranded.

Also caught: a case-only rename **destroyed all E2E session state** for the channel (four e2e tables are `COLLATE NOCASE`, so the DELETE matched the row the UPDATE had just rewritten), and `renameChannel`'s pending-join-key migration was unreachable in production — its test passed only by faking a precondition that cannot occur.

Every fix is mutation-verified: reverting it individually fails exactly the intended test.

## Known gaps, deliberate

- **No producer yet.** DM rename and channel `RENAME` are follow-ups.
- **`highlight_rules.channels` / `ignored_masks.channels` are not rewritten.** Their scope can span networks (junction table; NULL `network_id` = global) and can contain globs, so a rename on one network can't license rewriting a rule governing another. Counted and returned as `stillReferencing` rather than silently skipped; `rewriteChannelList` is written and tested for whoever takes the decision.
- **`NICK_KEYED_TABLES`** (`user_nick_notes`, `user_relay_bots`, `peer_presence_state`) — for a DM these coincide with the buffer, so the DM-rename work has to decide whether they follow. Recorded so it's decided, not missed.
- **The merge read-state push is review-only.** `wsHub` keeps `socketsByUser` private with no test seam, and no existing test there observes a fanned-out frame. The DB reconciliation is covered; adding a seam is a production change I didn't want to make unasked.
- **Non-ASCII case forks** aren't detected by the fold at all — its grouping uses SQLite `lower()`. Pre-existing; documented rather than silently inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
