### PR TITLE
Guard the FTS update trigger on the columns it actually indexes

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1445,8 +1445,14 @@ if (tableExists('messages_fts')) {
       .get() as { sql: string } | undefined
   )?.sql;
   if (messagesAuSql !== MESSAGES_AU_SQL) {
-    db.exec(`DROP TRIGGER IF EXISTS messages_au`);
-    db.exec(MESSAGES_AU_SQL);
+    // One transaction: between a bare DROP and its CREATE the database has FTS
+    // insert/delete triggers but no update trigger. The next boot repairs that,
+    // but any `UPDATE messages SET text = ...` in the interim desyncs
+    // messages_fts — an external-content table, so nothing detects or heals it.
+    db.transaction(() => {
+      db.exec(`DROP TRIGGER IF EXISTS messages_au`);
+      db.exec(MESSAGES_AU_SQL);
+    })();
   }
 }
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1390,17 +1390,64 @@ if (schemaVersion < 3) {
     CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
       INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.id, old.text);
     END;
-    CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-      INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.id, old.text);
-      INSERT INTO messages_fts(rowid, text) VALUES (new.id, new.text);
-    END;
   `);
+  // messages_au is created unconditionally below rather than here — see there.
+  // Nothing updates `messages` between this block and that one, so the window
+  // in which the update trigger doesn't exist carries no rows.
+
   // Index every existing row, NULL text included. The insert trigger does the
   // same for new rows; keeping the backfill consistent with it means the
   // delete/update triggers (which replay old.text) always have a matching
   // index entry to remove — skipping NULL rows here would desync an
   // external-content FTS5 table and risk index corruption on later deletes.
   db.exec(`INSERT INTO messages_fts(rowid, text) SELECT id, text FROM messages`);
+}
+
+// The FTS update trigger. Defined here rather than in the v3 block because its
+// definition changed after v3 shipped, and an already-migrated DB would keep the
+// old one forever under CREATE IF NOT EXISTS.
+//
+// Recreated only when what's stored doesn't match what we want, so a steady-state
+// boot writes nothing. That matters more than the microseconds saved: an
+// unconditional DROP + CREATE dirties sqlite_master on every single boot, and
+// Litestream faithfully replicates each one.
+//
+// The WHEN clause is the point. messages_fts indexes ONLY `text`, keyed by
+// rowid = messages.id, but the unguarded trigger fired on any column update and
+// paid a full FTS delete+reinsert for each row regardless. That made a
+// buffer rename — `UPDATE messages SET target = ?`, which touches neither
+// indexed column — reindex the entire channel's text for nothing. Measured on a
+// synthetic 1M-row channel: 3.55s -> 1.18s (3.0x) and 40MB less database
+// growth, because each delete+reinsert pair leaves tombstone and duplicate
+// entries behind in the FTS b-tree until a merge reclaims them.
+//
+// Both indexed inputs are in the guard, so it cannot skip work the FTS index
+// actually needs: `text` is the indexed content, and `id` is the rowid the
+// entry is keyed by. `IS NOT` rather than `<>` so a NULL on either side
+// compares correctly — text is nullable, and `NULL <> NULL` is NULL (falsy),
+// which would silently skip a row transitioning to or from NULL.
+const MESSAGES_AU_SQL = `CREATE TRIGGER messages_au AFTER UPDATE ON messages
+  WHEN old.text IS NOT new.text OR old.id IS NOT new.id BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.id, old.text);
+    INSERT INTO messages_fts(rowid, text) VALUES (new.id, new.text);
+  END`;
+// Existence-gated on messages_fts, which the v3 block creates. Every real
+// database at v3 or above has it, but a trigger whose body names a missing table
+// is not inert: SQLite reparses the entire schema during any ALTER TABLE ...
+// RENAME, and an unresolvable trigger body fails that statement. So a database
+// without FTS would get a live trigger that breaks the next table rebuild
+// migration somewhere else entirely. Matching the v3 block's own condition keeps
+// the trigger and the table it writes to inseparable.
+if (tableExists('messages_fts')) {
+  const messagesAuSql = (
+    db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'messages_au'`)
+      .get() as { sql: string } | undefined
+  )?.sql;
+  if (messagesAuSql !== MESSAGES_AU_SQL) {
+    db.exec(`DROP TRIGGER IF EXISTS messages_au`);
+    db.exec(MESSAGES_AU_SQL);
+  }
 }
 
 if (schemaVersion < 4) {

--- a/server/db/messagesFtsTrigger.test.ts
+++ b/server/db/messagesFtsTrigger.test.ts
@@ -20,7 +20,7 @@
 //     content-agreement check — measured, it returns OK on the `<>` desync
 //     above — so it backstops the match assertions rather than replacing them.
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -75,6 +75,8 @@ beforeAll(async () => {
   if (!network) throw new Error('fixture: createNetwork returned undefined');
   networkId = network.id;
 });
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
 describe('messages_au trigger definition', () => {
   it('is installed with the text/id guard', () => {

--- a/server/db/messagesFtsTrigger.test.ts
+++ b/server/db/messagesFtsTrigger.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The messages_fts AFTER UPDATE trigger (messages_au).
+//
+// The trigger is guarded on `text`/`id` so that a buffer rename — which rewrites
+// `messages.target` in bulk and touches neither indexed column — doesn't pay a
+// full FTS delete+reinsert per row. These tests pin both halves of that: the
+// guard is actually installed (an already-migrated DB has to be upgraded off the
+// unguarded v3 definition), and skipping the reindex cannot desync the index.
+//
+// Two different assertions, because neither alone is enough:
+//
+//   - Explicit match assertions catch a guard that skips a reindex it needed.
+//     This is the one that does the work. Verified against the obvious wrong
+//     guard: with `old.text <> new.text`, a row whose text goes NULL keeps
+//     matching its old text, and these assertions fail.
+//
+//   - `integrity-check` catches structural damage to the index. It is NOT a
+//     content-agreement check — measured, it returns OK on the `<>` desync
+//     above — so it backstops the match assertions rather than replacing them.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-fts-trigger-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+let insertMessage: typeof import('./messages.js').insertMessage;
+let networkId: number;
+
+/** Throws if messages_fts disagrees with the messages table. */
+function integrityCheck(): void {
+  db.exec(`INSERT INTO messages_fts(messages_fts) VALUES('integrity-check')`);
+}
+
+/** Message ids whose text matches `q`, via the FTS index. */
+function ftsMatches(q: string): number[] {
+  return (
+    db
+      .prepare(`SELECT rowid FROM messages_fts WHERE messages_fts MATCH ? ORDER BY rowid`)
+      .all(q) as Array<{ rowid: number }>
+  ).map((r) => r.rowid);
+}
+
+function add(target: string, text: string): number {
+  return Number(
+    insertMessage({
+      networkId,
+      target,
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'alice',
+      text,
+    }).id,
+  );
+}
+
+beforeAll(async () => {
+  ({ default: db } = await import('./index.js'));
+  ({ createUser } = await import('./users.js'));
+  ({ createNetwork } = await import('./networks.js'));
+  ({ insertMessage } = await import('./messages.js'));
+  const user = createUser('fts-trigger-user');
+  const network = createNetwork(user.id, {
+    name: 'libera',
+    host: 'irc.libera.chat',
+    nick: 'alice',
+  });
+  if (!network) throw new Error('fixture: createNetwork returned undefined');
+  networkId = network.id;
+});
+
+describe('messages_au trigger definition', () => {
+  it('is installed with the text/id guard', () => {
+    const row = db
+      .prepare(`SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'messages_au'`)
+      .get() as { sql: string } | undefined;
+    expect(row?.sql).toBeTruthy();
+    // The whole point of the guard — without a WHEN clause the trigger fires on
+    // every column update, including a target-only rename.
+    expect(row?.sql).toMatch(/WHEN old\.text IS NOT new\.text OR old\.id IS NOT new\.id/);
+  });
+});
+
+describe('renaming a buffer (target-only update)', () => {
+  it('leaves the FTS index consistent and still searchable', () => {
+    const a = add('#old', 'renameable haddock');
+    const b = add('#old', 'another haddock here');
+    const c = add('#other', 'unrelated haddock');
+
+    expect(ftsMatches('renameable')).toEqual([a]);
+
+    db.prepare(`UPDATE messages SET target = ? WHERE network_id = ? AND target = ?`).run(
+      '#new',
+      networkId,
+      '#old',
+    );
+
+    // Rows moved...
+    const moved = db
+      .prepare(`SELECT COUNT(*) AS n FROM messages WHERE network_id = ? AND target = ?`)
+      .get(networkId, '#new') as { n: number };
+    expect(moved.n).toBe(2);
+
+    // ...and the index the trigger deliberately skipped is still correct.
+    integrityCheck();
+    expect(ftsMatches('renameable')).toEqual([a]);
+    // All three still match, each exactly once — the renamed rows kept their
+    // index entries and no duplicate was left behind. Row identity is by id, so
+    // the moved rows are found under the new target without being reindexed.
+    expect(ftsMatches('haddock')).toEqual([a, b, c]);
+  });
+});
+
+describe('updates that DO change indexed columns', () => {
+  it('reindexes when text changes', () => {
+    const id = add('#edit', 'original wobbegong');
+    expect(ftsMatches('wobbegong')).toContain(id);
+
+    db.prepare(`UPDATE messages SET text = ? WHERE id = ?`).run('replaced pilchard', id);
+
+    expect(ftsMatches('wobbegong')).not.toContain(id);
+    expect(ftsMatches('pilchard')).toContain(id);
+    integrityCheck();
+  });
+
+  it('reindexes when text becomes NULL and back', () => {
+    // `IS NOT` rather than `<>` in the guard exists for exactly this: `NULL <>
+    // NULL` is NULL (falsy), so a `<>` guard would skip these transitions and
+    // strand the old text in the index.
+    const id = add('#edit', 'nullable barramundi');
+    expect(ftsMatches('barramundi')).toContain(id);
+
+    db.prepare(`UPDATE messages SET text = NULL WHERE id = ?`).run(id);
+    expect(ftsMatches('barramundi')).not.toContain(id);
+    integrityCheck();
+
+    db.prepare(`UPDATE messages SET text = ? WHERE id = ?`).run('barramundi returns', id);
+    expect(ftsMatches('barramundi')).toContain(id);
+    integrityCheck();
+  });
+
+  it('still removes index entries on delete', () => {
+    const id = add('#gone', 'deletable tilapia');
+    expect(ftsMatches('tilapia')).toContain(id);
+
+    db.prepare(`DELETE FROM messages WHERE id = ?`).run(id);
+
+    expect(ftsMatches('tilapia')).not.toContain(id);
+    integrityCheck();
+  });
+});


### PR DESCRIPTION
Cherry-picked from the closed #706 (buffer-rename foundation), which is being superseded by the buffer-identity normalization plan — this piece is independent and is a prerequisite for the coming \`messages.buffer_id\` backfill migration.

## What

\`messages_au\` fired on **any** column update and paid a full FTS delete+reinsert per row even when neither indexed input (\`text\`, rowid \`id\`) changed. A bulk \`UPDATE messages SET target = ?\` — the shape of both a buffer rename and the upcoming buffer_id backfill — reindexed the entire channel's text for nothing.

- Trigger gains \`WHEN old.text IS NOT new.text OR old.id IS NOT new.id\` (\`IS NOT\`, not \`<>\`, because \`text\` is nullable and \`NULL <> NULL\` is falsy — a \`<>\` guard would strand old text in the index on NULL transitions).
- Moved out of the v3 \`CREATE IF NOT EXISTS\` block and recreated only when the stored \`sqlite_master\` SQL differs from the desired SQL — steady-state boots write nothing (Litestream replicates every \`sqlite_master\` dirty).
- DROP + CREATE share one transaction: between a bare drop and its create, an \`UPDATE … SET text\` would silently desync the external-content FTS index (this fix is from #706's review round \`7b06dc8\`, which the original guard commit predated).

Measured on a synthetic 1M-row channel: **3.55s → 1.18s (3.0×)** and 40MB less database growth on a target-only bulk update.

## Tests

\`server/db/messagesFtsTrigger.test.ts\`: guard presence pinned in \`sqlite_master\`; target-only update leaves FTS consistent and searchable (match assertions, not just \`integrity-check\` — the latter measures OK even on a real desync); text-change and NULL-transition reindexing; delete path. Full suite: 3,539 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)