### PR TITLE
Bump Lurker version to 1.1.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@
 
 services:
   lurker:
-    image: ghcr.io/amiantos/lurker:1.1.5
+    image: ghcr.io/amiantos/lurker:1.1.6
     container_name: lurker
     ports:
       - '8015:8015'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Bumps the Lurker version from 1.1.5 to 1.1.6 in:

- `package.json` / `package-lock.json`
- `vue_client/package.json` / `vue_client/package-lock.json`
- `docker-compose.yml` image tag (`ghcr.io/amiantos/lurker:1.1.6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)