### PR TITLE
Normalize buffer identity: messages.buffer_id, sentinel rows, resumable backfill (v17)

### DIFF
--- a/server/db/bufferIdMigration.test.ts
+++ b/server/db/bufferIdMigration.test.ts
@@ -112,7 +112,8 @@ beforeAll(async () => {
       (103, 2, 20, '#other',  '#other',  'channel', 'open');
 
     -- History: stray casings that must fold onto the registry rows, a target
-    -- with NO registry row (orphan), and :server: sentinel rows.
+    -- with NO registry row (orphan), the network's own :server: target, and a
+    -- FOREIGN-numbered :server: stray (the shape a legacy import leaves).
     INSERT INTO messages (id, network_id, target, time, type, nick, text) VALUES
       (1, 10, '#Chatty',  '2026-01-01T00:00:00Z', 'message', 'x', 'a'),
       (2, 10, '#chatty',  '2026-01-01T00:01:00Z', 'message', 'x', 'stray case'),
@@ -120,7 +121,8 @@ beforeAll(async () => {
       (4, 10, '#ÄRGER',   '2026-01-01T00:03:00Z', 'message', 'x', 'unicode stray case'),
       (5, 10, '#orphan',  '2026-01-01T00:04:00Z', 'message', 'x', 'no registry row'),
       (6, 10, ':server:10', '2026-01-01T00:05:00Z', 'notice', NULL, 'motd'),
-      (7, 20, '#other',   '2026-01-01T00:06:00Z', 'message', 'y', 'd');
+      (7, 20, '#other',   '2026-01-01T00:06:00Z', 'message', 'y', 'd'),
+      (8, 10, ':server:99', '2026-01-01T00:07:00Z', 'notice', NULL, 'imported console line');
   `);
   raw.close();
 
@@ -209,6 +211,22 @@ describe('schema 17 — messages.buffer_id backfill', () => {
       .prepare(`SELECT kind FROM buffers WHERE network_id = 20 AND target = ':server:20'`)
       .get() as { kind: string } | undefined;
     expect(server20?.kind).toBe('server');
+  });
+
+  it('coalesces a foreign-numbered :server: stray into the canonical sentinel, minting no hidden row', () => {
+    // ':server:99' on network 10: the walk skips ':'-prefixed registry rows
+    // and nothing can open one, so minting it would strand its history in a
+    // hidden buffer. Instead the backfill maps it onto the network's own
+    // server console — the same coalescing the live insert path applies —
+    // which makes imported console history reachable.
+    const server10 = db
+      .prepare(`SELECT id FROM buffers WHERE network_id = 10 AND kind = 'server'`)
+      .get() as { id: number };
+    expect(bufferIdOf(8)).toBe(server10.id);
+    const strayRows = db
+      .prepare(`SELECT COUNT(*) AS n FROM buffers WHERE target = ':server:99'`)
+      .get() as { n: number };
+    expect(strayRows.n).toBe(0);
   });
 
   it('swaps the index generation: buf indexes in, name-keyed out', () => {

--- a/server/db/bufferIdMigration.test.ts
+++ b/server/db/bufferIdMigration.test.ts
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Integration test for the schema-17 buffer_id normalization: a DB shaped like
+// a real v16 install (buffers registry present, messages keyed by name, the
+// name-keyed index generation live) is built RAW before db/index.ts is ever
+// imported; importing it then runs the ensureColumn + mint + backfill + index
+// swap against that data. app_meta pins schema_version=16 so no earlier
+// recovery block interferes.
+//
+// Assertions are on VALUES (which buffers row each message landed on), not row
+// counts — a backfill that stamps the wrong id passes any count.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-bufid-'));
+const dbPath = path.join(tmpDir, 'test.db');
+process.env.DATABASE_PATH = dbPath;
+
+let db: typeof import('./index.js').default;
+
+beforeAll(async () => {
+  const raw = new Database(dbPath);
+  raw.pragma('journal_mode = WAL');
+  raw.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE networks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      host TEXT NOT NULL,
+      port INTEGER NOT NULL DEFAULT 6697,
+      tls INTEGER NOT NULL DEFAULT 1,
+      trusted_certificates INTEGER NOT NULL DEFAULT 1,
+      nick TEXT NOT NULL,
+      username TEXT,
+      realname TEXT,
+      server_password TEXT,
+      autoconnect INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    -- The v16 buffers registry, as migrate() creates it.
+    CREATE TABLE buffers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      network_id INTEGER,
+      target TEXT NOT NULL,
+      target_folded TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      state TEXT NOT NULL DEFAULT 'open',
+      autojoin INTEGER NOT NULL DEFAULT 0,
+      key TEXT,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      closed_at TEXT,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+    CREATE UNIQUE INDEX idx_buffers_key
+      ON buffers(user_id, IFNULL(network_id, 0), target_folded);
+    -- Full v16 messages shape (the later columns were ensureColumn'd long
+    -- before 16, so a real v16 DB carries them all — and the name-keyed index
+    -- generation references them).
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      network_id INTEGER NOT NULL,
+      target TEXT NOT NULL,
+      time TEXT NOT NULL,
+      type TEXT NOT NULL,
+      nick TEXT,
+      text TEXT,
+      kind TEXT,
+      self INTEGER NOT NULL DEFAULT 0,
+      extra TEXT,
+      userhost TEXT,
+      matched_rule_id INTEGER,
+      alt INTEGER NOT NULL DEFAULT 0,
+      from_ignored INTEGER NOT NULL DEFAULT 0,
+      mirrored INTEGER NOT NULL DEFAULT 0,
+      notable INTEGER NOT NULL DEFAULT 1,
+      msgid TEXT,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+    CREATE INDEX idx_messages_unread
+      ON messages(network_id, target, id DESC, type, from_ignored, notable);
+    CREATE INDEX idx_messages_matched
+      ON messages(network_id, target, id DESC)
+      WHERE matched_rule_id IS NOT NULL;
+    CREATE TABLE app_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO app_meta (key, value) VALUES ('schema_version', '16');
+
+    INSERT INTO users (id, username) VALUES (1, 'bufid-alice'), (2, 'bufid-bob');
+    INSERT INTO networks (id, user_id, name, host, nick)
+      VALUES (10, 1, 'libera', 'irc.libera.chat', 'alice'),
+             (20, 2, 'oftc', 'irc.oftc.net', 'bob');
+
+    -- Registry rows the v16 world holds: canonical '#Chatty', dm 'bob', and a
+    -- non-ASCII channel whose target_folded was written by JS toLowerCase
+    -- (Unicode-aware) — the fold-parity tripwire.
+    INSERT INTO buffers (id, user_id, network_id, target, target_folded, kind, state) VALUES
+      (100, 1, 10, '#Chatty', '#chatty', 'channel', 'open'),
+      (101, 1, 10, 'bob',     'bob',     'dm',      'open'),
+      (102, 1, 10, '#Ärger',  '#ärger',  'channel', 'open'),
+      (103, 2, 20, '#other',  '#other',  'channel', 'open');
+
+    -- History: stray casings that must fold onto the registry rows, a target
+    -- with NO registry row (orphan), and :server: sentinel rows.
+    INSERT INTO messages (id, network_id, target, time, type, nick, text) VALUES
+      (1, 10, '#Chatty',  '2026-01-01T00:00:00Z', 'message', 'x', 'a'),
+      (2, 10, '#chatty',  '2026-01-01T00:01:00Z', 'message', 'x', 'stray case'),
+      (3, 10, 'Bob',      '2026-01-01T00:02:00Z', 'message', 'Bob', 'dm stray case'),
+      (4, 10, '#ÄRGER',   '2026-01-01T00:03:00Z', 'message', 'x', 'unicode stray case'),
+      (5, 10, '#orphan',  '2026-01-01T00:04:00Z', 'message', 'x', 'no registry row'),
+      (6, 10, ':server:10', '2026-01-01T00:05:00Z', 'notice', NULL, 'motd'),
+      (7, 20, '#other',   '2026-01-01T00:06:00Z', 'message', 'y', 'd');
+  `);
+  raw.close();
+
+  ({ default: db } = await import('./index.js'));
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function bufferIdOf(messageId: number): number | null {
+  return (
+    db.prepare(`SELECT buffer_id AS b FROM messages WHERE id = ?`).get(messageId) as {
+      b: number | null;
+    }
+  ).b;
+}
+
+describe('schema 17 — messages.buffer_id backfill', () => {
+  it('bumps the version and records the backfill done', () => {
+    const version = db.prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`).get() as {
+      value: string;
+    };
+    expect(parseInt(version.value, 10)).toBeGreaterThanOrEqual(17);
+    const done = db
+      .prepare(`SELECT value FROM app_meta WHERE key = 'messages_bufferid_done'`)
+      .get() as { value: string } | undefined;
+    expect(done?.value).toBe('1');
+  });
+
+  it('leaves no NULL buffer_id behind', () => {
+    expect(db.prepare(`SELECT 1 FROM messages WHERE buffer_id IS NULL LIMIT 1`).get()).toBe(
+      undefined,
+    );
+  });
+
+  it('folds stray casings onto the registry row (value assertions)', () => {
+    expect(bufferIdOf(1)).toBe(100); // '#Chatty' exact
+    expect(bufferIdOf(2)).toBe(100); // '#chatty' stray casing, same buffer
+    expect(bufferIdOf(3)).toBe(101); // 'Bob' folds onto dm 'bob'
+    expect(bufferIdOf(7)).toBe(103); // other user's network untouched
+  });
+
+  it('folds non-ASCII casings with the JS rule, not SQL lower()', () => {
+    // '#ÄRGER'.toLowerCase() === '#ärger' (matches the registry row); SQLite
+    // lower() would leave it '#ÄRGER' and this row would either go NULL or
+    // mint a duplicate. Pins the registered fold function.
+    expect(bufferIdOf(4)).toBe(102);
+    // ...and no duplicate '#ärger'-family row was minted:
+    const family = db
+      .prepare(`SELECT COUNT(*) AS n FROM buffers WHERE network_id = 10 AND target LIKE '#Ä%'`)
+      .all() as Array<{ n: number }>;
+    expect(family[0].n).toBe(1);
+  });
+
+  it('mints a CLOSED row for an orphan target and repoints its history', () => {
+    const orphan = db
+      .prepare(
+        `SELECT id, kind, state FROM buffers
+         WHERE user_id = 1 AND network_id = 10 AND target_folded = '#orphan'`,
+      )
+      .get() as { id: number; kind: string; state: string } | undefined;
+    expect(orphan).toBeTruthy();
+    expect(orphan?.kind).toBe('channel');
+    expect(orphan?.state).toBe('closed'); // never surfaced by a mint
+    expect(bufferIdOf(5)).toBe(orphan?.id);
+  });
+
+  it('mints sentinel rows: :server: per network, :system: per user, open + kinded', () => {
+    const server10 = db
+      .prepare(
+        `SELECT id, kind, state FROM buffers
+         WHERE user_id = 1 AND network_id = 10 AND target = ':server:10'`,
+      )
+      .get() as { id: number; kind: string; state: string } | undefined;
+    expect(server10?.kind).toBe('server');
+    expect(server10?.state).toBe('open');
+    expect(bufferIdOf(6)).toBe(server10?.id);
+
+    const systems = db
+      .prepare(
+        `SELECT user_id FROM buffers WHERE kind = 'system' AND network_id IS NULL ORDER BY user_id`,
+      )
+      .all() as Array<{ user_id: number }>;
+    expect(systems.map((s) => s.user_id)).toEqual([1, 2]);
+
+    const server20 = db
+      .prepare(`SELECT kind FROM buffers WHERE network_id = 20 AND target = ':server:20'`)
+      .get() as { kind: string } | undefined;
+    expect(server20?.kind).toBe('server');
+  });
+
+  it('swaps the index generation: buf indexes in, name-keyed out', () => {
+    const names = new Set(
+      (
+        db
+          .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'messages'`)
+          .all() as Array<{ name: string }>
+      ).map((r) => r.name),
+    );
+    expect(names.has('idx_messages_buf_unread')).toBe(true);
+    expect(names.has('idx_messages_matched_buf')).toBe(true);
+    expect(names.has('idx_messages_unread')).toBe(false);
+    expect(names.has('idx_messages_matched')).toBe(false);
+  });
+
+  it('read paths resolve stray-cased requests onto the same history', async () => {
+    // End-to-end through messages.ts: a divergently-cased request finds the
+    // folded buffer's rows — the exact shape that used to open blank.
+    const messages = await import('./messages.js');
+    const events = messages.listMessages(10, '#CHATTY');
+    expect(events.map((e) => e.id)).toEqual([1, 2]);
+    expect(messages.hasMessageForTarget(10, 'BOB')).toBe(true);
+    expect(messages.countNewer(10, '#chatty', 0)).toBe(2);
+  });
+});

--- a/server/db/bufferKeyedTables.test.ts
+++ b/server/db/bufferKeyedTables.test.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Drift test for the buffer-scoped table registry. Introspects the LIVE
+// migrated schema in both directions, so the registry cannot quietly diverge
+// from reality — its predecessor (a hand-copied list inside foldBufferCase)
+// did exactly that, and by schema 16 named two tables that had been dropped.
+//
+// The registry, not this file, is where a decision gets recorded; this file is
+// what makes an unrecorded decision fail CI.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  BUFFER_SCOPED_TABLES,
+  PENDING_BUFFER_TABLES,
+  BUFFER_TARGET_COLUMN_NAMES,
+  NON_BUFFER_TARGET_TABLES,
+} from './bufferKeyedTables.js';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-buffer-tables-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+
+interface ColumnRow {
+  name: string;
+  type: string;
+  notnull: number;
+}
+
+function tableNames(): string[] {
+  return (
+    db
+      .prepare(
+        `SELECT name FROM sqlite_master
+         WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'messages_fts%'`,
+      )
+      .all() as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+function columns(table: string): ColumnRow[] {
+  return db.prepare(`PRAGMA table_info(${table})`).all() as ColumnRow[];
+}
+
+beforeAll(async () => {
+  ({ default: db } = await import('./index.js'));
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('registry completeness (schema → registry)', () => {
+  it('declares every live table with a buffer-target-shaped column', () => {
+    const declared = new Set(BUFFER_SCOPED_TABLES.map((t) => t.table));
+    const exempt = new Set(NON_BUFFER_TARGET_TABLES);
+
+    const undeclared: string[] = [];
+    for (const table of tableNames()) {
+      if (declared.has(table) || exempt.has(table)) continue;
+      const hit = columns(table).find((c) => BUFFER_TARGET_COLUMN_NAMES.includes(c.name));
+      if (hit) undeclared.push(`${table}.${hit.name}`);
+      // Independently: any table that grows a buffer_id must be declared too —
+      // an id-keyed table that isn't in the registry would be invisible to the
+      // satellite-rebuild worklist and the export contract.
+      const idHit = columns(table).find((c) => c.name === 'buffer_id');
+      if (idHit && !hit) undeclared.push(`${table}.buffer_id`);
+    }
+
+    // A new buffer-scoped table must be declared in BUFFER_SCOPED_TABLES —
+    // keyed by buffer_id, or 'pending' with an explicit note. If the column
+    // only looks like a buffer target, add the table to
+    // NON_BUFFER_TARGET_TABLES with a reason.
+    expect(undeclared).toEqual([]);
+  });
+});
+
+describe('registry accuracy (registry → schema)', () => {
+  it('declares no table or column the live schema lacks', () => {
+    const live = new Set(tableNames());
+    const missing: string[] = [];
+    for (const t of BUFFER_SCOPED_TABLES) {
+      if (!live.has(t.table)) {
+        missing.push(t.table);
+        continue;
+      }
+      const names = new Set(columns(t.table).map((c) => c.name));
+      const expected = [t.targetColumn, ...t.scope].filter(Boolean) as string[];
+      if (t.status === 'buffer_id') expected.push('buffer_id');
+      for (const col of expected) {
+        if (!names.has(col)) missing.push(`${t.table}.${col}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps 'pending' entries honest: their name column is still the key", () => {
+    // When the satellite rebuild flips a table to buffer_id, its registry
+    // entry must flip in the same PR — a 'pending' table that has grown a
+    // buffer_id (or lost its name column) is an undeclared migration.
+    const wrong: string[] = [];
+    for (const t of PENDING_BUFFER_TABLES) {
+      const names = new Set(columns(t.table).map((c) => c.name));
+      if (names.has('buffer_id')) wrong.push(`${t.table}: has buffer_id but declared pending`);
+      if (t.targetColumn && !names.has(t.targetColumn)) {
+        wrong.push(`${t.table}: declared pending but ${t.targetColumn} is gone`);
+      }
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it('has no duplicate table entries', () => {
+    const names = BUFFER_SCOPED_TABLES.map((t) => t.table);
+    expect(names.length).toBe(new Set(names).size);
+  });
+
+  it('marks exactly the COLLATE NOCASE target columns as caseInsensitive', () => {
+    const mismatches: string[] = [];
+    for (const t of BUFFER_SCOPED_TABLES) {
+      if (!t.targetColumn) continue;
+      const ddl = (
+        db
+          .prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+          .get(t.table) as { sql: string } | undefined
+      )?.sql;
+      if (!ddl) continue;
+      const decl = new RegExp(`\\b${t.targetColumn}\\b[^,]*`, 'i').exec(ddl)?.[0] ?? '';
+      const nocase = /COLLATE\s+NOCASE/i.test(decl);
+      if (nocase !== !!t.caseInsensitive) {
+        mismatches.push(
+          `${t.table}.${t.targetColumn}: schema=${nocase} declared=${!!t.caseInsensitive}`,
+        );
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+});
+
+describe('the buffer_id foreign key', () => {
+  it('messages.buffer_id references buffers(id) ON DELETE CASCADE', () => {
+    const fks = db.prepare(`PRAGMA foreign_key_list(messages)`).all() as Array<{
+      table: string;
+      from: string;
+      to: string;
+      on_delete: string;
+    }>;
+    const fk = fks.find((f) => f.from === 'buffer_id');
+    expect(fk).toBeTruthy();
+    expect(fk?.table).toBe('buffers');
+    expect(fk?.to).toBe('id');
+    expect(fk?.on_delete).toBe('CASCADE');
+  });
+
+  it('the id-keyed message indexes exist and the name-keyed generation is gone', () => {
+    const indexes = new Set(
+      (
+        db
+          .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'messages'`)
+          .all() as Array<{ name: string }>
+      ).map((r) => r.name),
+    );
+    expect(indexes.has('idx_messages_buf_unread')).toBe(true);
+    expect(indexes.has('idx_messages_matched_buf')).toBe(true);
+    expect(indexes.has('idx_messages_unread')).toBe(false);
+    expect(indexes.has('idx_messages_matched')).toBe(false);
+    expect(indexes.has('idx_messages_buffer')).toBe(false);
+  });
+});
+
+describe('the retired tables really are retired', () => {
+  it('does not create channels or closed_buffers on a fresh install', () => {
+    const live = new Set(tableNames());
+    expect(live.has('channels')).toBe(false);
+    expect(live.has('closed_buffers')).toBe(false);
+  });
+});

--- a/server/db/bufferKeyedTables.ts
+++ b/server/db/bufferKeyedTables.ts
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The registry of buffer-scoped tables, and where each stands in the
+// name→buffer_id normalization (#695).
+//
+// Historically a buffer's NAME was its identity: every table below denormalized
+// the target as text with no foreign key, and the cost was a class of "two
+// places storing the name disagree" bugs — a rename or case-fold had to visit
+// every entry here and get each one's collision semantics right (the closed
+// PR #706 measured that cost at ~35 review findings). Normalized, each table
+// references buffers(id), the name lives in exactly one place, and a rename is
+// a single-row UPDATE.
+//
+// `status` records where each table is on that path:
+//   - 'buffer_id'  — normalized: keyed by a buffer_id FK to buffers(id).
+//   - 'pending'    — still name-keyed; scheduled for the satellite rebuild.
+//   - 'glob-list'  — a CSV of channel GLOBS that may span networks. These are
+//                    match patterns, not identities: they cannot reference a
+//                    buffer_id and deliberately do not follow renames.
+//
+// The companion test introspects the live schema in BOTH directions, so this
+// list cannot silently drift from reality (its predecessor did exactly that:
+// a hand-copied list in foldBufferCase stopped being updated around schema 9
+// and by 16 named two dropped tables). The test — not this comment — is what
+// keeps it honest.
+
+export type BufferTableStatus = 'buffer_id' | 'pending' | 'glob-list';
+
+export interface BufferScopedTable {
+  table: string;
+  status: BufferTableStatus;
+  /**
+   * The target-shaped text column. For 'pending' this is the current key; for
+   * 'glob-list' the pattern column; for 'buffer_id' tables it appears only when
+   * deliberately retained (see `tombstone`).
+   */
+  targetColumn?: string;
+  /**
+   * True when `targetColumn` survives normalization as a write-only log —
+   * "the target as observed at insert time", never a key, never rewritten.
+   * messages.target: dropping it would rewrite a multi-hundred-MB table for a
+   * few bytes a row, and as a non-key it can no longer disagree with anything.
+   */
+  tombstone?: boolean;
+  /** Values of targetColumn that are sentinels, not buffer names. */
+  excludeValues?: readonly string[];
+  /** targetColumn is declared COLLATE NOCASE (cross-checked against DDL). */
+  caseInsensitive?: boolean;
+  /** Immutable scope columns that stay denormalized alongside the key. */
+  scope: readonly string[];
+  note: string;
+}
+
+export const BUFFER_SCOPED_TABLES: readonly BufferScopedTable[] = [
+  {
+    table: 'messages',
+    status: 'buffer_id',
+    targetColumn: 'target',
+    tombstone: true,
+    scope: ['network_id'],
+    note: 'chat history — by far the largest; buffer_id backfilled at v17',
+  },
+  {
+    table: 'buffer_reads',
+    status: 'pending',
+    targetColumn: 'target',
+    scope: ['user_id', 'network_id'],
+    note: 'read pointer + /clear marker',
+  },
+  {
+    table: 'input_history',
+    status: 'pending',
+    targetColumn: 'target',
+    scope: ['user_id', 'network_id'],
+    note: 'up-arrow input recall',
+  },
+  {
+    table: 'pinned_buffers',
+    status: 'pending',
+    targetColumn: 'target',
+    scope: ['user_id', 'network_id'],
+    note: 'sidebar pins; dense per-network position column',
+  },
+  {
+    table: 'nicklist_collapsed',
+    status: 'pending',
+    targetColumn: 'target',
+    scope: ['user_id', 'network_id'],
+    note: 'per-channel nicklist toggle',
+  },
+  {
+    table: 'channel_notify_settings',
+    status: 'pending',
+    targetColumn: 'target',
+    scope: ['user_id', 'network_id'],
+    note: 'notify_always',
+  },
+  {
+    table: 'user_drafts',
+    status: 'pending',
+    targetColumn: 'target',
+    scope: ['user_id', 'network_id'],
+    note: 'half-typed composer input',
+  },
+  {
+    table: 'e2e_incoming_sessions',
+    status: 'pending',
+    targetColumn: 'channel',
+    caseInsensitive: true,
+    scope: ['user_id', 'network_id'],
+    note: 'RPE2E incoming session keys',
+  },
+  {
+    table: 'e2e_outgoing_sessions',
+    status: 'pending',
+    targetColumn: 'channel',
+    caseInsensitive: true,
+    scope: ['user_id', 'network_id'],
+    note: 'RPE2E outgoing session keys',
+  },
+  {
+    table: 'e2e_channel_config',
+    status: 'pending',
+    targetColumn: 'channel',
+    caseInsensitive: true,
+    scope: ['user_id', 'network_id'],
+    note: 'per-channel E2E enable/mode',
+  },
+  {
+    table: 'e2e_outgoing_recipients',
+    status: 'pending',
+    targetColumn: 'channel',
+    caseInsensitive: true,
+    scope: ['user_id', 'network_id'],
+    note: 'RPE2E first-sent bookkeeping',
+  },
+  {
+    table: 'e2e_autotrust',
+    status: 'pending',
+    targetColumn: 'scope',
+    excludeValues: ['global'],
+    caseInsensitive: true,
+    scope: ['user_id', 'network_id'],
+    note: "auto-trust rule; 'global' sentinel becomes buffer_id NULL at rebuild",
+  },
+  {
+    table: 'highlight_rules',
+    status: 'glob-list',
+    targetColumn: 'channels',
+    scope: ['user_id'],
+    note: 'CSV of channel globs, may span networks — never id-keyed',
+  },
+  {
+    table: 'ignored_masks',
+    status: 'glob-list',
+    targetColumn: 'channels',
+    scope: ['user_id', 'network_id'],
+    note: 'CSV of channel globs — never id-keyed',
+  },
+];
+
+/** Tables still keyed by name — the satellite-rebuild worklist. */
+export const PENDING_BUFFER_TABLES: readonly BufferScopedTable[] = BUFFER_SCOPED_TABLES.filter(
+  (t) => t.status === 'pending',
+);
+
+/**
+ * Column names that mean "a buffer target" for drift detection.
+ *
+ * `channels` is in the list because leaving it out is precisely how
+ * `highlight_rules.channels` and `ignored_masks.channels` stayed invisible to
+ * an earlier version of this sweep: the singular `channel` matched the e2e
+ * tables, the plural matched nothing. `scope` is here for `e2e_autotrust`,
+ * which hid the same way — it names a buffer without using any word the list
+ * knew about.
+ *
+ * This is a heuristic and its limits are real: it cannot catch a column that
+ * names the concept differently again — `instance_network.channels_json`
+ * (admin autojoin config) and `chanlist_channels.name` (ephemeral /LIST cache)
+ * are both buffer-name-shaped and both invisible here. Neither is per-user
+ * buffer state, so neither belongs in the registry. If you add a buffer-scoped
+ * table, key it by `buffer_id`; if it must carry a name, call the column
+ * `target` so the sweep sees it.
+ */
+export const BUFFER_TARGET_COLUMN_NAMES: readonly string[] = [
+  'target',
+  'channel',
+  'channels',
+  'scope',
+];
+
+/**
+ * Tables with a column named like a buffer target that genuinely isn't one.
+ * Listed explicitly so the drift test stays a real assertion rather than
+ * something that gets loosened the first time it fires.
+ */
+export const NON_BUFFER_TARGET_TABLES: readonly string[] = [
+  'api_tokens', // scope = permission scope
+  'system_messages', // scope = message origin ('lurker')
+  'uploader_config', // scope = 'instance' | 'user'
+  'buffers', // target/target_folded ARE the name — the one place it lives
+];
+
+/**
+ * Nick-keyed per-user state. Not buffer-scoped — these attach to a person, not
+ * a buffer — but for a DM the two coincide, so a peer's nick change moves the
+ * buffer and leaves these behind under the old nick. Deliberately NOT in the
+ * registry: whether a nick note follows its subject through a nick change is a
+ * product decision the DM-rename work makes explicitly, not a side effect.
+ */
+export const NICK_KEYED_TABLES: readonly string[] = [
+  'user_nick_notes',
+  'user_relay_bots',
+  'peer_presence_state',
+  'contact_targets',
+  'dcc_transfers',
+];
+
+/** The declared entry for a table, or undefined when it isn't buffer-scoped. */
+export function bufferScopedTable(table: string): BufferScopedTable | undefined {
+  return BUFFER_SCOPED_TABLES.find((t) => t.table === table);
+}

--- a/server/db/bufferResolve.ts
+++ b/server/db/bufferResolve.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import db from './index.js';
+import { foldTarget, ensureServerBuffer, ensureExists } from './buffers.js';
+import type { BufferKind, BufferState } from './buffers.js';
+
+// Name → buffer_id resolution, in one place.
+//
+// A buffer's identity is buffers.id; its name is an attribute resolved through
+// here. Resolution is deliberately UNCACHED: it is one idx_buffers_key point
+// seek — the same cost the hot paths already pay for getState — and a name→id
+// cache would be a second place storing the name, which is the exact bug class
+// the normalization exists to kill. If profiling ever demands one, its
+// invalidation belongs to renameBuffer/deleteBuffer alone.
+//
+// Folding happens here (and only here) on the way in. `foldTargetFor` is the
+// seam for #707: target folding is server-declared (ISUPPORT CASEMAPPING) and
+// will become per-network. Getting the fold wrong through this seam fails to
+// FIND a buffer — visible and recoverable — rather than splitting one, which
+// is the property that makes deferring #707 safe.
+
+/** Per-network target folding. Today: the single ASCII/Unicode-lowercase rule
+ *  (buffers.ts foldTarget); the networkId parameter is the #707 seam and is
+ *  deliberately unused until CASEMAPPING capture lands. */
+export function foldTargetFor(_networkId: number | null, raw: string): string {
+  return foldTarget(raw);
+}
+
+/** Decrypt-free buffer identity row — no +k key material (a rotated secret
+ *  must not make resolution throw; see buffers.ts getState). */
+export interface BufferIdentity {
+  id: number;
+  userId: number;
+  networkId: number | null;
+  target: string;
+  targetFolded: string;
+  kind: BufferKind;
+  state: BufferState;
+}
+
+interface IdentityRow {
+  id: number;
+  user_id: number;
+  network_id: number | null;
+  target: string;
+  target_folded: string;
+  kind: BufferKind;
+  state: BufferState;
+}
+
+const IDENTITY_COLS = `id, user_id, network_id, target, target_folded, kind, state`;
+
+function toIdentity(row: IdentityRow | undefined): BufferIdentity | undefined {
+  if (!row) return undefined;
+  return {
+    id: row.id,
+    userId: row.user_id,
+    networkId: row.network_id,
+    target: row.target,
+    targetFolded: row.target_folded,
+    kind: row.kind,
+    state: row.state,
+  };
+}
+
+const byUserStmt = db.prepare(`
+  SELECT ${IDENTITY_COLS} FROM buffers
+  WHERE user_id = ? AND IFNULL(network_id, 0) = IFNULL(?, 0) AND target_folded = ?
+`);
+
+// Network-scoped variant for the messages layer, which has no userId in hand:
+// messages carry no user_id (ownership is network → user), so the owner is
+// derived the same way BOOKMARKED_COL derives it.
+const byNetworkStmt = db.prepare(`
+  SELECT ${IDENTITY_COLS} FROM buffers
+  WHERE user_id = (SELECT user_id FROM networks WHERE id = ?)
+    AND IFNULL(network_id, 0) = ?
+    AND target_folded = ?
+`);
+
+const byIdStmt = db.prepare(`SELECT ${IDENTITY_COLS} FROM buffers WHERE id = ?`);
+
+/** Resolve (user, network, name) → identity, or undefined when no row exists. */
+export function resolveBuffer(
+  userId: number,
+  networkId: number | null,
+  target: string,
+): BufferIdentity | undefined {
+  return toIdentity(
+    byUserStmt.get(userId, networkId, foldTargetFor(networkId, target)) as IdentityRow | undefined,
+  );
+}
+
+/** Resolve (network, name) → buffer id for network-owned rows (messages). */
+export function resolveBufferIdByNetwork(networkId: number, target: string): number | undefined {
+  return (
+    byNetworkStmt.get(networkId, networkId, foldTargetFor(networkId, target)) as
+      | IdentityRow
+      | undefined
+  )?.id;
+}
+
+/** Identity by primary key — the wire-facing lookup for frames carrying
+ *  bufferId. */
+export function getBufferById(id: number): BufferIdentity | undefined {
+  return toIdentity(byIdStmt.get(id) as IdentityRow | undefined);
+}
+
+/** getBufferById gated on ownership — the verb-layer guard: a client-supplied
+ *  bufferId that doesn't belong to the user resolves to nothing, same as an
+ *  unknown name. */
+export function requireBufferForUser(userId: number, id: number): BufferIdentity | undefined {
+  const found = getBufferById(id);
+  return found && found.userId === userId ? found : undefined;
+}
+
+const networkOwnerStmt = db.prepare(`SELECT user_id FROM networks WHERE id = ?`);
+
+/**
+ * Insert-path resolution with a mint for targets that have no row yet.
+ *
+ * This is the SAME rule wsHub's live filter has applied since the registry
+ * landed — "a persisted event for a target with no registry row mints one"
+ * (ensureExists: creates OPEN, never reopens a closed row) — moved from a
+ * moment after the insert to the insert itself, because the id-keyed table
+ * cannot represent "row exists, buffer doesn't" the way name-keyed reads
+ * tolerated. The distinction that matters is preserved exactly: a target with
+ * an existing CLOSED row resolves to it without touching its state, so the
+ * filter's reopen gate (which events outrank a user's closed flag) still
+ * decides whether the buffer resurfaces.
+ *
+ * Sentinels route to their open mint; a stray ':'-prefixed non-sentinel
+ * target (an imported ':server:<foreignId>' string) is minted 'server'-kinded
+ * so kindForTarget's channel/dm split never claims it.
+ */
+export function resolveOrMintForInsert(networkId: number, target: string): number | undefined {
+  const found = resolveBufferIdByNetwork(networkId, target);
+  if (found !== undefined) return found;
+  if (target === `:server:${networkId}`) return ensureServerBuffer(networkId)?.id;
+  const owner = networkOwnerStmt.get(networkId) as { user_id: number } | undefined;
+  if (!owner) return undefined;
+  const kind: BufferKind | undefined = target.startsWith(':') ? 'server' : undefined;
+  return ensureExists(owner.user_id, networkId, target, kind ? { kind } : {}).record.id;
+}

--- a/server/db/buffers.test.ts
+++ b/server/db/buffers.test.ts
@@ -195,11 +195,21 @@ describe('importRow closed_at merging', () => {
 
 describe('app-scoped rows (NULL network_id)', () => {
   it('dedupe via the coalesced unique index', () => {
+    // The `:system:` row is minted with the account (schema 17) — ensureOpen
+    // routes ':'-prefixed targets to the sentinel path, which always resolves
+    // to that one row rather than inserting under the coalesced index.
     const a = buffers.ensureOpen(user.id, null, ':system:', { kind: 'system' });
     const b = buffers.ensureOpen(user.id, null, ':system:', { kind: 'system' });
-    expect(a.created).toBe(true);
+    expect(a.created).toBe(false);
     expect(b.created).toBe(false);
     expect(a.record.id).toBe(b.record.id);
+    expect(a.record.kind).toBe('system');
+  });
+
+  it('sentinel rows are uncloseable and undeletable', () => {
+    expect(buffers.close(user.id, null, ':system:')).toBe(false);
+    expect(buffers.deleteBuffer(user.id, null, ':system:')).toBe(false);
+    expect(buffers.getBuffer(user.id, null, ':system:')?.state).toBe('open');
   });
 });
 

--- a/server/db/buffers.ts
+++ b/server/db/buffers.ts
@@ -107,10 +107,13 @@ const reopenStmt = db.prepare(`
     AND state = 'closed'
 `);
 
+// server/system rows are permanent fixtures (the server console and the app
+// console always exist); the kind guard makes closing one structurally
+// impossible rather than a code-path promise.
 const closeStmt = db.prepare(`
   UPDATE buffers SET state = 'closed', closed_at = datetime('now')
   WHERE user_id = ? AND IFNULL(network_id, 0) = IFNULL(?, 0) AND target_folded = ?
-    AND state = 'open'
+    AND state = 'open' AND kind NOT IN ('server', 'system')
 `);
 
 const setAutojoinStmt = db.prepare(`
@@ -123,9 +126,13 @@ const setKeyStmt = db.prepare(`
   WHERE user_id = ? AND IFNULL(network_id, 0) = IFNULL(?, 0) AND target_folded = ?
 `);
 
+// Same kind guard as closeStmt — and doubly load-bearing now that satellite
+// rows cascade from buffers(id): deleting a sentinel row would take its read
+// pointer (and, post-v17, its messages) with it.
 const deleteStmt = db.prepare(`
   DELETE FROM buffers
   WHERE user_id = ? AND IFNULL(network_id, 0) = IFNULL(?, 0) AND target_folded = ?
+    AND kind NOT IN ('server', 'system')
 `);
 
 // Import-path only: close (or stamp) with an archive-supplied closed_at rather
@@ -251,6 +258,58 @@ export interface EnsureResult {
   reopened: boolean;
 }
 
+// --- Sentinel buffers -------------------------------------------------------
+//
+// `:server:<netId>` and `:system:` are real rows as of schema 17 (kinds
+// 'server'/'system', reserved since the registry landed). They are minted at
+// network/user creation, by the v17 migration for existing data, and
+// defensively below — never by the channel/dm reducer paths, whose
+// kindForTarget would misclassify a ':'-prefixed name as a DM.
+
+const networkOwnerStmt = db.prepare(`SELECT user_id FROM networks WHERE id = ?`);
+
+const sentinelInsertStmt = db.prepare(`
+  INSERT INTO buffers (user_id, network_id, target, target_folded, kind, state, autojoin, key)
+  VALUES (?, ?, ?, ?, ?, 'open', 0, NULL)
+  ON CONFLICT(user_id, IFNULL(network_id, 0), target_folded) DO NOTHING
+`);
+
+/** Make the network's `:server:` row exist; returns it. Undefined only for an
+ *  unknown networkId. */
+export function ensureServerBuffer(networkId: number): BufferRecord | undefined {
+  const owner = networkOwnerStmt.get(networkId) as { user_id: number } | undefined;
+  if (!owner) return undefined;
+  const target = `:server:${networkId}`;
+  sentinelInsertStmt.run(owner.user_id, networkId, target, target, 'server');
+  return toRecord(getStmt.get(owner.user_id, networkId, target) as BufferRow | undefined);
+}
+
+/** Make the user's app-scoped `:system:` row exist; returns it. */
+export function ensureSystemBuffer(userId: number): BufferRecord {
+  sentinelInsertStmt.run(userId, null, ':system:', ':system:', 'system');
+  return toRecord(getStmt.get(userId, null, ':system:') as BufferRow);
+}
+
+/** Route a ':'-prefixed target to its sentinel mint. Returns undefined for
+ *  non-sentinel targets (the ordinary reducer path applies). */
+function ensureSentinel(
+  userId: number,
+  networkId: number | null,
+  target: string,
+): EnsureResult | undefined {
+  if (!target.startsWith(':')) return undefined;
+  const record =
+    target === ':system:' || networkId == null
+      ? ensureSystemBuffer(userId)
+      : ensureServerBuffer(networkId);
+  if (!record) {
+    // Unknown network for a ':server:' target — surface it as a programming
+    // error; nothing legitimate constructs this.
+    throw new Error(`ensureSentinel: no network ${networkId} for target ${target}`);
+  }
+  return { record, created: false, reopened: false };
+}
+
 /** The reducer workhorse: make (user, network, target) exist and be open.
  *  Creates the row when absent (canonical casing = the caller's casing),
  *  reopens it when closed. `autojoin` set only when passed (the join echo
@@ -265,6 +324,8 @@ export const ensureOpen = db.transaction(
     target: string,
     opts: { kind?: BufferKind; autojoin?: boolean; key?: string | null } = {},
   ): EnsureResult => {
+    const sentinel = ensureSentinel(userId, networkId, target);
+    if (sentinel) return sentinel;
     const folded = foldTarget(target);
     const existing = getStmt.get(userId, networkId, folded) as BufferRow | undefined;
     if (!existing) {
@@ -310,6 +371,8 @@ export const ensureExists = db.transaction(
     target: string,
     opts: { kind?: BufferKind } = {},
   ): { record: BufferRecord; created: boolean } => {
+    const sentinel = ensureSentinel(userId, networkId, target);
+    if (sentinel) return { record: sentinel.record, created: sentinel.created };
     const folded = foldTarget(target);
     const existing = getStmt.get(userId, networkId, folded) as BufferRow | undefined;
     if (existing) return { record: toRecord(existing), created: false };

--- a/server/db/buffersMigration.test.ts
+++ b/server/db/buffersMigration.test.ts
@@ -210,14 +210,24 @@ describe('schemaVersion 16 — buffers backfill', () => {
     expect(tomb.closedAt).toBe('2026-02-02T00:00:00Z');
   });
 
-  it('never creates rows for :server: virtual targets', () => {
-    expect(buffers.getBuffer(1, 10, ':server:10')).toBeUndefined();
+  it('the v16 pass itself skips :server:, whose row arrives kinded from v17', () => {
+    // v16 derived channel/dm rows from history and deliberately never minted
+    // virtual targets; the schema-17 sentinel mint (which runs after it on
+    // the same boot) is what makes the row real — kinded 'server', open,
+    // never a history-derived channel/dm misclassification.
+    const server = buffers.getBuffer(1, 10, ':server:10');
+    expect(server?.kind).toBe('server');
+    expect(server?.state).toBe('open');
   });
 
   it('scopes rows to each network owner', () => {
     const other = buffers.getBuffer(2, 20, '#other')!;
     expect(other.userId).toBe(2);
     expect(buffers.getBuffer(1, 20, '#other')).toBeUndefined();
-    expect(buffers.listForUser(1).every((b) => b.networkId === 10)).toBe(true);
+    // The app-scoped :system: sentinel (networkId null, schema 17) rides
+    // alongside user 1's network-10 rows.
+    expect(buffers.listForUser(1).every((b) => b.networkId === 10 || b.kind === 'system')).toBe(
+      true,
+    );
   });
 });

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -128,6 +128,11 @@ export const EXPORT_TABLES = Object.freeze({
     section: 'data',
     pk: 'id',
     rekeyOnImport: true,
+    // Sentinel rows (:system:, :server:<id>) are install-local fixtures: the
+    // target install mints its own at account/network creation, and an
+    // archived ':server:<id>' target embeds the SOURCE install's network id.
+    // The importer independently drops any that appear (older archives).
+    rowWhere: "target NOT LIKE ':%'",
     fkRekey: { user_id: 'users', network_id: 'networks' },
     // The +k channel key gates entry to the channel — same credential class as
     // the network secrets, so same at-rest treatment.
@@ -176,6 +181,11 @@ export const EXPORT_TABLES = Object.freeze({
     fkRekey: {
       network_id: 'networks',
       matched_rule_id: 'highlight_rules',
+    },
+    skippedColumns: {
+      buffer_id:
+        'install-local buffers(id) reference; the importer re-resolves it from ' +
+        '(network_id, target) against the target install’s registry at insert time',
     },
     columns: [
       'id',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
 import { foldBufferCase } from './foldBufferCase.js';
+import { normalizeMessagesBufferIds, messagesBackfillDone } from './normalizeBuffers.js';
 import {
   seedUploaderConfig,
   reconcileBuiltInUploaders,
@@ -1044,13 +1045,28 @@ try {
   );
 }
 
+// Buffer identity (#695): every read path keys messages by buffer_id → buffers(id);
+// `target` remains as an insert-time observation only. Added here (nullable —
+// ALTER ADD COLUMN can't add NOT NULL without a constant default, and the
+// backfill is resumable across boots); "never NULL" is the application
+// invariant, enforced by insertMessage and established for existing rows by
+// the flag-driven backfill after the version blocks below. CASCADE rather
+// than NO ACTION because user/network deletes cascade into buffers and
+// messages in unspecified order — NO ACTION could abort a legitimate account
+// deletion mid-cascade. deleteBuffer's "only when no history" contract stays
+// a code contract (and sentinel rows are undeletable by kind guard).
+ensureColumn('messages', 'buffer_id', 'INTEGER REFERENCES buffers(id) ON DELETE CASCADE');
+
 // Persist which rule matched each message so the highlights modal can read
 // from disk instead of scanning whatever happens to be loaded in client memory.
 // Partial index keeps it cheap — only matched rows live in the index.
+//
+// The index itself (idx_messages_matched_buf) is built after the buffer_id
+// backfill below — its key is buffer_id. Its (network_id, target) predecessor
+// is no longer created: no statement issues that predicate shape anymore, and
+// module load is linear, so even a transition boot never queries between here
+// and the swap. The old index is dropped there.
 ensureColumn('messages', 'matched_rule_id', 'INTEGER');
-db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_matched
-         ON messages(network_id, target, id DESC)
-         WHERE matched_rule_id IS NOT NULL`);
 
 // Per-(network, target) alt-row parity, computed at insert time so the client
 // can stripe chat lines without doing its own counting. Only chat-shaped types
@@ -1103,78 +1119,17 @@ ensureColumn('messages', 'notable', 'INTEGER NOT NULL DEFAULT 1');
 // absent, so it runs exactly once — never a repeated full scan on later boots.
 if (!hadNotableColumn) demoteLegacyServerStatusNotices();
 
-// Covering index for the connect-snapshot unread counts (#469). countUnreadRows
-// filters on `type` and `from_ignored` (and `notable` for :server: buffers), but
-// the index this replaces carried only (network_id, target, id) — so SQLite found
-// each candidate in the index and then fetched the full table ROW to evaluate those
-// predicates. On a flood-heavy channel only ~40% of rows are countable, so
-// reaching UNREAD_COUNT_CAP meant ~2,500 scattered rowid lookups PER BUFFER, and a
-// connect snapshot pays that for every buffer on the account. Warm it is invisible;
-// cold — a fresh boot, or an account whose DB doesn't fit in page cache — every one
-// of those lookups is a real seek, which is what pins the event loop for tens of
-// seconds on spinning disks and trips IRC ping timeouts in a feedback loop.
-//
-// Listing the filter columns after the cursor makes the count index-ONLY (verify
-// with EXPLAIN QUERY PLAN: "USING COVERING INDEX idx_messages_unread"). Column
-// order matters: (network_id, target) are the equality prefix, `id DESC` matches
-// the ORDER BY that lets the LIMIT stop early, and the three filter columns ride
-// along purely as payload — they must come last or they'd break the range scan.
-//
-// This REPLACES the old idx_messages_buffer rather than sitting alongside it —
-// see the DROP below for why keeping both would be pure write-path cost.
-//
-// Cost, measured on a synthetic 2.08M-row / 451MB account: a ONE-TIME build on the
-// first boot after upgrade (~1s on NVMe; expect meaningfully longer on the
-// spinning-disk installs this fix targets, since the build is a full scan plus a
-// sort). Startup blocks on it, which is the right trade — the alternative is
-// paying scattered row lookups on every connect, forever — but an operator
-// watching a slow first boot deserves to know why. Net disk after the DROP below
-// is roughly +3.5%, not the +13% this index costs on its own.
-
-// Tell the operator before starting, because a silent stall here is
-// indistinguishable from a hang. The build blocks module import, is not
-// resumable, and on the spinning-disk installs this targets can take long enough
-// that a supervisor (Docker restart policy, the control-plane heartbeat
-// watchdog) kills the container mid-build — SQLite then rolls it back and the
-// next boot starts over, which is a restart loop on precisely the installs the
-// fix is for. An operator who can see WHY boot is stalled can raise the timeout
-// instead of guessing. Only warns when there's enough history for the build to
-// be slow, so ordinary instances stay quiet.
-//
-// The threshold test is an OFFSET probe, not COUNT(*). Counting the table to
-// decide whether to warn about a slow scan would itself be a full scan — silent,
-// and on exactly the cold-cache/spinning-disk install the warning exists for, so
-// it would just move the unexplained silence earlier. This stops at the
-// threshold. (Same idiom as messages.ts hasMoreThan, for the same reason.)
+// The per-buffer covering index (#469's design, re-keyed by buffer_id) is
+// built after the buffer_id backfill below — its key column doesn't have
+// values until then. The full rationale (covering payload columns, warn-probe
+// idiom, measured costs) lives at that build site. Warn threshold shared with
+// it:
 const INDEX_BUILD_WARN_ROWS = 250_000;
-if (
-  !indexExists('idx_messages_unread') &&
-  db.prepare(`SELECT 1 FROM messages LIMIT 1 OFFSET ?`).get(INDEX_BUILD_WARN_ROWS)
-) {
-  console.warn(
-    `[db] building idx_messages_unread over ${INDEX_BUILD_WARN_ROWS.toLocaleString()}+ ` +
-      `messages — one-time, blocks startup, and can take minutes on slow storage. Do not ` +
-      `kill the process: the build is not resumable and a restart begins again from zero.`,
-  );
-}
-db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_unread
-         ON messages(network_id, target, id DESC, type, from_ignored, notable)`);
 
-// ...and retire the index it supersedes. idx_messages_buffer was
-// (network_id, target, id DESC) — a strict column PREFIX of the above, so every
-// query it could serve, idx_messages_unread serves too. Keeping both would mean
-// maintaining two b-trees on every INSERT (on a busy channel, the write path
-// that matters most) to no read benefit.
-//
-// Measured on the same 2.08M-row account, dropping it: no query regresses
-// (the `SELECT *` reads are dominated by fetching full rows from the table, not
-// by index width, and come out within noise), the unread count gets ~24% FASTER,
-// and the database shrinks 44MB. That turns the net cost of this whole change
-// from +13% to roughly +3.5%.
-//
-// Ordered after the CREATE above so there is never a boot in which neither index
-// exists. On an existing database the old index stays live through every
-// migration that ran before this line; on a fresh one the table is empty.
+// Retire the ancient idx_messages_buffer (network_id, target, id DESC) on DBs
+// old enough to still carry it — superseded twice over by now. (Its
+// replacement idx_messages_unread is itself dropped after the buffer_id
+// backfill below.)
 db.exec(`DROP INDEX IF EXISTS idx_messages_buffer`);
 
 // #470 backfill body, split out so it can be unit-tested against seeded rows
@@ -1247,7 +1202,7 @@ ensureColumn('push_subscriptions', 'transport', "TEXT NOT NULL DEFAULT 'webpush'
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
-const SCHEMA_VERSION = 16;
+const SCHEMA_VERSION = 17;
 const schemaVersionRow = db
   .prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`)
   .get() as { value: string } | undefined;
@@ -2029,6 +1984,78 @@ if (schemaVersion < 16 && tableExists('channels')) {
   // up front makes Litestream's checkpoints wait/retry (their normal, harmless
   // behavior) instead of invalidating us.
   cutover.immediate();
+}
+
+// --- v17: buffer identity normalization (#695) -------------------------------
+//
+// messages.buffer_id becomes the read key (see the ensureColumn above and
+// server/db/messages.ts); this section establishes it for existing rows.
+// Placed AFTER the v16 block on purpose: on a pre-16 database the buffers
+// registry is itself derived by that block, and the backfill resolves against
+// it.
+//
+// Flag-driven rather than version-gated: normalizeMessagesBufferIds is
+// self-terminating on an app_meta done-flag, each chunk commits its own
+// progress cursor, and a mid-run kill resumes on the next boot — the
+// restart-loop failure mode of the one-shot idx_messages_unread build (a
+// supervisor killing a long non-resumable stall, SQLite rolling it back, the
+// next boot starting from zero) structurally cannot happen. Chunking across
+// transactions is safe here solely because this runs synchronously at module
+// load, before the server accepts work — see normalizeBuffers.ts.
+{
+  if (
+    !messagesBackfillDone(db) &&
+    db.prepare(`SELECT 1 FROM messages LIMIT 1 OFFSET ?`).get(INDEX_BUILD_WARN_ROWS)
+  ) {
+    console.warn(
+      `[db] backfilling messages.buffer_id over ${INDEX_BUILD_WARN_ROWS.toLocaleString()}+ ` +
+        `messages — one-time, blocks startup. Resumable: if the process is killed, the next ` +
+        `boot continues from where it stopped.`,
+    );
+  }
+  normalizeMessagesBufferIds(db);
+
+  {
+    // Deliberately NOT gated on the done-flag: reaching this line means the
+    // chunk loop ran to the end of the table (a kill never gets here), so the
+    // only not-done case is the stragglers warn above — a handful of rows a
+    // future boot retries. Gating would leave that server running buffer_id
+    // predicates with no buffer_id index: a full-scan cliff on every read,
+    // which is a far worse failure than indexing early.
+    //
+    // The per-buffer covering index (#469's design, one key column narrower:
+    // a 4-byte int replaces int+text). (buffer_id) is the equality prefix,
+    // `id DESC` matches the ORDER BY that lets unread-count LIMITs stop
+    // early, and (type, from_ignored, notable) ride along purely as payload
+    // so the counts are index-ONLY — they must come last or they'd break the
+    // range scan. Verify with EXPLAIN QUERY PLAN: "USING COVERING INDEX
+    // idx_messages_buf_unread" (messagesEqp.test.ts pins it).
+    //
+    // This build IS one-shot and non-resumable (an index build can't
+    // checkpoint), hence the warn above covers it too; it's a sort over one
+    // integer key — measured on the 2.08M-row reference account the old
+    // build was ~1s on NVMe, and this one is narrower.
+    if (
+      !indexExists('idx_messages_buf_unread') &&
+      db.prepare(`SELECT 1 FROM messages LIMIT 1 OFFSET ?`).get(INDEX_BUILD_WARN_ROWS)
+    ) {
+      console.warn(
+        `[db] building idx_messages_buf_unread — one-time, blocks startup, not resumable. ` +
+          `Do not kill the process.`,
+      );
+    }
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_buf_unread
+             ON messages(buffer_id, id DESC, type, from_ignored, notable)`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_matched_buf
+             ON messages(buffer_id, id DESC)
+             WHERE matched_rule_id IS NOT NULL`);
+    // Only after both successors exist: retire the name-keyed generation.
+    // Keeping them would be two dead b-trees maintained on every INSERT (no
+    // statement issues their predicate shape anymore); ordering the drops
+    // after the creates means no boot ever holds neither generation.
+    db.exec(`DROP INDEX IF EXISTS idx_messages_unread`);
+    db.exec(`DROP INDEX IF EXISTS idx_messages_matched`);
+  }
 }
 
 // Issue #510: seed the uploader data model — instance x0/catbox rows +

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -230,8 +230,11 @@ describe('listBufferTargets (loose-index-scan)', () => {
       chat(n, 'dave', 'dave', 'z');
     }
     chat(n, ':server:1', 'lurker', 'notice');
-    // Binary collation: '#'(0x23) < ':'(0x3A) < 'a' < 'd'.
-    expect(listBufferTargets(n)).toEqual(['#alpha', '#zeta', ':server:1', 'dave']);
+    // Binary collation: '#'(0x23) < ':'(0x3A) < 'a' < 'd'. The stray
+    // ':server:1' (a foreign network number, the shape a legacy import
+    // produces) resolves into THIS network's own server buffer — targets come
+    // back canonical from the registry, so the list reports :server:<n>.
+    expect(listBufferTargets(n)).toEqual(['#alpha', '#zeta', `:server:${n}`, 'dave']);
   });
 
   it('returns [] for a network with no messages', () => {

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -2,8 +2,21 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import {
+  foldTargetFor,
+  resolveBufferIdByNetwork,
+  resolveOrMintForInsert,
+} from './bufferResolve.js';
 import { countsTowardPage } from '../../shared/eventFilter.js';
 import type { PageUnit } from '../../shared/eventFilter.js';
+
+// Buffer identity is buffers.id as of schema 17: every predicate in this file
+// filters on `buffer_id`, and `target` is written at insert as an observation
+// (the name the network used at that moment) but never read as a key. The
+// exported signatures still take (networkId, target) — callers hold names —
+// so each entry point resolves name → id exactly once, up front, through
+// bufferResolve. A resolution miss means "no such buffer": empty results,
+// false, zero — the same shape an unknown name produced before.
 
 /** A raw row from the `messages` table. */
 interface MessageRow {
@@ -109,13 +122,13 @@ export interface MaxIdByBufferRow {
 // Non-striped types pass through with alt=0; the value is meaningless for them
 // and the client never reads it.
 const insertStmt = db.prepare(`
-  INSERT INTO messages (network_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, mirrored, notable, msgid, alt)
+  INSERT INTO messages (network_id, buffer_id, target, time, type, nick, text, kind, self, extra, matched_rule_id, userhost, from_ignored, mirrored, notable, msgid, alt)
   VALUES (
-    @networkId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored, @mirrored, @notable, @msgid,
+    @networkId, @bufferId, @target, @time, @type, @nick, @text, @kind, @self, @extra, @matchedRuleId, @userhost, @fromIgnored, @mirrored, @notable, @msgid,
     CASE WHEN @type IN ('message', 'action', 'notice')
          THEN 1 - COALESCE(
            (SELECT alt FROM messages
-             WHERE network_id = @networkId AND target = @target
+             WHERE buffer_id = @bufferId
                AND type IN ('message', 'action', 'notice')
              ORDER BY id DESC LIMIT 1),
            1)
@@ -127,8 +140,17 @@ const insertStmt = db.prepare(`
 const altByIdStmt = db.prepare(`SELECT alt FROM messages WHERE id = ?`);
 
 export function insertMessage(row: MessageInput): { id: number | bigint; alt: boolean } {
+  // Resolved (or defensively minted) BEFORE the insert: a row that went in
+  // with buffer_id NULL would be invisible to every id-keyed read forever.
+  const bufferId = resolveOrMintForInsert(row.networkId, row.target);
+  if (bufferId === undefined) {
+    // Only reachable for a networkId that doesn't exist — the network FK
+    // would reject the insert anyway; fail with a clearer message.
+    throw new Error(`insertMessage: cannot resolve a buffer for network ${row.networkId}`);
+  }
   const result = insertStmt.run({
     networkId: row.networkId,
+    bufferId,
     target: row.target,
     time: row.time,
     type: row.type,
@@ -225,21 +247,30 @@ function rowToEvent(row: MessageRow): MessageEvent {
 export function listMessages(
   networkId: number,
   target: string,
+  opts: { before?: number; afterId?: number; limit?: number } = {},
+): MessageEvent[] {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return [];
+  return listMessagesById(bufferId, opts);
+}
+
+function listMessagesById(
+  bufferId: number,
   { before, afterId, limit = 50 }: { before?: number; afterId?: number; limit?: number } = {},
 ): MessageEvent[] {
   if (afterId) {
     const rows = db
       .prepare(
-        `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE network_id = ? AND target = ? AND id > ?
+        `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE buffer_id = ? AND id > ?
        ORDER BY id ASC LIMIT ?`,
       )
-      .all(networkId, target, afterId, limit) as MessageRow[];
+      .all(bufferId, afterId, limit) as MessageRow[];
     return rows.map(rowToEvent);
   }
   const sql = before
-    ? `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE network_id = ? AND target = ? AND id < ? ORDER BY id DESC LIMIT ?`
-    : `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE network_id = ? AND target = ? ORDER BY id DESC LIMIT ?`;
-  const params = before ? [networkId, target, before, limit] : [networkId, target, limit];
+    ? `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE buffer_id = ? AND id < ? ORDER BY id DESC LIMIT ?`
+    : `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE buffer_id = ? ORDER BY id DESC LIMIT ?`;
+  const params = before ? [bufferId, before, limit] : [bufferId, limit];
   const rows = db.prepare(sql).all(...params) as MessageRow[];
   return rows.map(rowToEvent).toReversed();
 }
@@ -309,25 +340,35 @@ export function listMessagesCounted(
   networkId: number,
   target: string,
   unit: PageUnit,
+  opts: PageOptions = {},
+): MessageEvent[] {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return [];
+  return listMessagesCountedById(bufferId, unit, opts);
+}
+
+function listMessagesCountedById(
+  bufferId: number,
+  unit: PageUnit,
   { before, afterId, limit = 100, maxScan = RENDERABLE_MAX_SCAN }: PageOptions = {},
 ): MessageEvent[] {
   // 'event' counts every stored row, which is precisely what the plain cursor
   // pager already does — no scan pass needed.
-  if (unit === 'event') return listMessages(networkId, target, { before, afterId, limit });
+  if (unit === 'event') return listMessagesById(bufferId, { before, afterId, limit });
 
   const forward = afterId != null && afterId > 0;
 
   // Step 1: walk out from the cursor and stop at whichever comes first — the
   // `limit`-th COUNTING row, or `maxScan` rows.
   const scanSql = forward
-    ? `SELECT id, type FROM messages WHERE network_id = ? AND target = ? AND id > ? ORDER BY id ASC LIMIT ?`
+    ? `SELECT id, type FROM messages WHERE buffer_id = ? AND id > ? ORDER BY id ASC LIMIT ?`
     : before
-      ? `SELECT id, type FROM messages WHERE network_id = ? AND target = ? AND id < ? ORDER BY id DESC LIMIT ?`
-      : `SELECT id, type FROM messages WHERE network_id = ? AND target = ? ORDER BY id DESC LIMIT ?`;
+      ? `SELECT id, type FROM messages WHERE buffer_id = ? AND id < ? ORDER BY id DESC LIMIT ?`
+      : `SELECT id, type FROM messages WHERE buffer_id = ? ORDER BY id DESC LIMIT ?`;
   const cursor = forward ? afterId : before;
   const scanParams: Array<number | string> = cursor
-    ? [networkId, target, cursor, maxScan]
-    : [networkId, target, maxScan];
+    ? [bufferId, cursor, maxScan]
+    : [bufferId, maxScan];
   const scanned = db.prepare(scanSql).all(...scanParams) as Array<{ id: number; type: string }>;
   if (scanned.length === 0) return [];
 
@@ -346,8 +387,8 @@ export function listMessagesCounted(
   }
 
   // Step 2: ship the whole contiguous range, noise included.
-  const conds = ['network_id = ?', 'target = ?'];
-  const params: Array<number | string> = [networkId, target];
+  const conds = ['buffer_id = ?'];
+  const params: Array<number | string> = [bufferId];
   if (forward) {
     conds.push('id > ?', 'id <= ?');
     params.push(afterId as number, boundary);
@@ -386,19 +427,23 @@ export function listMessagesAround(
 ):
   | { events: MessageEvent[]; hasMoreOlder: boolean; hasMoreNewer: boolean }
   | { events: []; hasMoreOlder: false; hasMoreNewer: false; anchorMissing: true } {
-  const anchorRow = db
-    .prepare(
-      `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE id = ? AND network_id = ? AND target = ?`,
-    )
-    .get(anchorId, networkId, target) as MessageRow | undefined;
-  if (!anchorRow) {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  const anchorRow =
+    bufferId === undefined
+      ? undefined
+      : (db
+          .prepare(
+            `SELECT *, ${BOOKMARKED_COL('messages')} FROM messages WHERE id = ? AND buffer_id = ?`,
+          )
+          .get(anchorId, bufferId) as MessageRow | undefined);
+  if (bufferId === undefined || !anchorRow) {
     return { events: [], hasMoreOlder: false, hasMoreNewer: false, anchorMissing: true };
   }
-  const older = listMessagesCounted(networkId, target, countBy, {
+  const older = listMessagesCountedById(bufferId, countBy, {
     before: anchorId,
     limit: halfLimit,
   });
-  const newer = listMessagesCounted(networkId, target, countBy, {
+  const newer = listMessagesCountedById(bufferId, countBy, {
     afterId: anchorId,
     limit: halfLimit,
   });
@@ -407,33 +452,35 @@ export function listMessagesAround(
   const newestId = events[events.length - 1].id as number;
   return {
     events,
-    hasMoreOlder: hasOlderThan(networkId, target, oldestId),
-    hasMoreNewer: hasNewerThan(networkId, target, newestId),
+    hasMoreOlder: hasOlderThanById(bufferId, oldestId),
+    hasMoreNewer: hasNewerThanById(bufferId, newestId),
   };
 }
 
 // Cheap edge-exists probes for the around/before/after handlers. Using a
 // LIMIT 1 EXISTS-shaped query (rather than COUNT(*)) keeps this O(index seek)
 // regardless of how much history is in the buffer.
-function hasOlderThan(networkId: number, target: string, id: number): boolean {
+function hasOlderThanById(bufferId: number, id: number): boolean {
   return !!db
-    .prepare(`SELECT 1 FROM messages WHERE network_id = ? AND target = ? AND id < ? LIMIT 1`)
-    .get(networkId, target, id);
+    .prepare(`SELECT 1 FROM messages WHERE buffer_id = ? AND id < ? LIMIT 1`)
+    .get(bufferId, id);
 }
 
-function hasNewerThan(networkId: number, target: string, id: number): boolean {
+function hasNewerThanById(bufferId: number, id: number): boolean {
   return !!db
-    .prepare(`SELECT 1 FROM messages WHERE network_id = ? AND target = ? AND id > ? LIMIT 1`)
-    .get(networkId, target, id);
+    .prepare(`SELECT 1 FROM messages WHERE buffer_id = ? AND id > ? LIMIT 1`)
+    .get(bufferId, id);
 }
 
 // Public wrappers so wsHub can compute hasMoreOlder/Newer for the 'before',
 // 'after', and 'latest' modes without re-declaring the SQL there.
 export function hasOlderRow(networkId: number, target: string, id: number): boolean {
-  return hasOlderThan(networkId, target, id);
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  return bufferId === undefined ? false : hasOlderThanById(bufferId, id);
 }
 export function hasNewerRow(networkId: number, target: string, id: number): boolean {
-  return hasNewerThan(networkId, target, id);
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  return bufferId === undefined ? false : hasNewerThanById(bufferId, id);
 }
 
 // Are there MORE than `count` rows newer than `afterId` in this buffer? Answers
@@ -454,15 +501,17 @@ export function hasMoreThan(
   afterId: number,
   count: number,
 ): boolean {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return false;
   return !!db
     .prepare(
       `SELECT 1 FROM (
          SELECT id FROM messages
-         WHERE network_id = ? AND target = ? AND id > ?
+         WHERE buffer_id = ? AND id > ?
          ORDER BY id ASC LIMIT 1 OFFSET ?
        )`,
     )
-    .get(networkId, target, afterId, count);
+    .get(bufferId, afterId, count);
 }
 
 // --- IRCv3 draft/chathistory window queries --------------------------------
@@ -473,7 +522,11 @@ export function hasMoreThan(
 // netsplit's QUITs must not come back as an empty batch — that would make a
 // client think it reached the start of history and stop paging). Matches what
 // playbackLines will actually emit onto the wire.
-const CHATHISTORY_MSG_FILTER = `type IN ('message', 'action', 'notice') AND mirrored = 0 AND text IS NOT NULL AND text != ''`;
+const chathistoryMsgFilter = (alias = '') => {
+  const p = alias ? `${alias}.` : '';
+  return `${p}type IN ('message', 'action', 'notice') AND ${p}mirrored = 0 AND ${p}text IS NOT NULL AND ${p}text != ''`;
+};
+const CHATHISTORY_MSG_FILTER = chathistoryMsgFilter();
 
 // Windowed history fetch for CHATHISTORY. `lower`/`upper` are exclusive ISO time
 // bounds (null = unbounded on that side). `newestFirst` takes the `limit` from
@@ -495,8 +548,10 @@ export function loadHistoryWindow(
   limit: number,
   { newestFirst = false }: { newestFirst?: boolean } = {},
 ): MessageEvent[] {
-  const conds = ['network_id = ?', 'target = ?', CHATHISTORY_MSG_FILTER];
-  const params: (string | number)[] = [networkId, target];
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return [];
+  const conds = ['buffer_id = ?', CHATHISTORY_MSG_FILTER];
+  const params: (string | number)[] = [bufferId];
   if (lower !== null) {
     conds.push('time > ?');
     params.push(lower);
@@ -528,15 +583,20 @@ export function listActiveTargetsInWindow(
   limit: number,
 ): BufferSummary[] {
   const [lo, hi] = isoA <= isoB ? [isoA, isoB] : [isoB, isoA];
+  // Grouped by buffer_id and named from the registry row, so the summary
+  // carries the canonical casing rather than whichever casing the window's
+  // rows happened to arrive under. Sentinels are excluded by kind — the
+  // registry's classification, not a name-shape LIKE.
   return db
     .prepare(
-      `SELECT target, MAX(time) AS lastMessageAt
-         FROM messages
-        WHERE network_id = ?
-          AND target NOT LIKE ':server:%'
-          AND ${CHATHISTORY_MSG_FILTER}
-          AND time > ? AND time < ?
-        GROUP BY target
+      `SELECT b.target AS target, MAX(m.time) AS lastMessageAt
+         FROM messages m
+         JOIN buffers b ON b.id = m.buffer_id
+        WHERE b.network_id = ?
+          AND b.kind NOT IN ('server', 'system')
+          AND ${chathistoryMsgFilter('m')}
+          AND m.time > ? AND m.time < ?
+        GROUP BY b.id
         ORDER BY lastMessageAt DESC
         LIMIT ?`,
     )
@@ -555,62 +615,55 @@ export function listRecentForBuffers(
   return out;
 }
 
-// Distinct buffer targets (channels/DMs/:server:) that have history on a network
-// — the sidebar's buffer list. Called several times per connect snapshot (per
-// network, in the online loop / offline frames / app-badge total), so it's on
-// the hot path — hence the module-scoped prepared statement.
-//
-// A plain `SELECT DISTINCT target` visits EVERY message row: SQLite reads the
-// whole (network_id, target, id) index and de-dupes in the output rather than
-// seeking past duplicate targets, so it scaled with the network's ENTIRE history
-// and was the dominant snapshot cost on a deep buffer. This is a recursive "loose
-// index scan" (skip-scan): it seeks to the smallest target, then repeatedly to
-// the next target strictly greater, so it's O(distinct targets) index seeks — a
-// ~75x speedup measured on 50k rows / 8 targets, and far more on real history.
-//
-// The `IS NOT NULL` guards are LOAD-BEARING, not defensive: `min(target)` returns
-// NULL for a network with no messages, and the recursive subquery returns NULL
-// once no larger target exists — that NULL sentinel is what terminates the
-// recursion (via `WHERE t.target IS NOT NULL`) and is filtered from the output.
+// Distinct buffer targets (channels/DMs/:server:) that have history on a
+// network — the sidebar's buffer list. Enumerated from the registry with an
+// existence probe per row: O(buffers) index seeks against the head of each
+// buffer's idx_messages_buf_unread run. This retires the recursive skip-scan
+// workaround that used to live here — the loose-index-scan CTE existed only
+// because "which buffers exist" had to be derived from the messages table.
 const listBufferTargetsStmt = db.prepare(`
-  WITH RECURSIVE t(target) AS (
-    SELECT min(target) FROM messages WHERE network_id = ?
-    UNION ALL
-    SELECT (SELECT min(target) FROM messages WHERE network_id = ? AND target > t.target)
-    FROM t
-    WHERE t.target IS NOT NULL
-  )
-  SELECT target FROM t WHERE target IS NOT NULL ORDER BY target
+  SELECT target FROM buffers b
+  WHERE b.network_id = ?
+    AND EXISTS (SELECT 1 FROM messages m WHERE m.buffer_id = b.id)
+  ORDER BY target
 `);
 export function listBufferTargets(networkId: number): string[] {
-  return (listBufferTargetsStmt.all(networkId, networkId) as Array<{ target: string }>).map(
-    (r) => r.target,
-  );
+  return (listBufferTargetsStmt.all(networkId) as Array<{ target: string }>).map((r) => r.target);
 }
 
 // Per-(network, target) summary for the MCP list_buffers verb. Aggregates
-// every target that has at least one message, with the freshest message
-// timestamp. Pseudo-buffers (':server:*') are filtered at the SQL layer so
-// they never leak into the agent-facing surface; clients reach them via the
-// snapshot only.
+// every buffer that has at least one message, with the freshest message
+// timestamp. Sentinel buffers are filtered by kind so they never leak into
+// the agent-facing surface; clients reach them via the snapshot only.
 export function listBuffersForNetwork(networkId: number): BufferSummary[] {
   return db
     .prepare(
-      `SELECT target, MAX(time) AS lastMessageAt
-         FROM messages
-        WHERE network_id = ?
-          AND target NOT LIKE ':server:%'
-        GROUP BY target
+      `SELECT b.target AS target, MAX(m.time) AS lastMessageAt
+         FROM buffers b
+         JOIN messages m ON m.buffer_id = b.id
+        WHERE b.network_id = ?
+          AND b.kind NOT IN ('server', 'system')
+        GROUP BY b.id
         ORDER BY lastMessageAt DESC`,
     )
     .all(networkId) as BufferSummary[];
 }
 
 // (target, max_id) per buffer in this network. Used by /mark-all-read so the
-// server can clamp every buffer's read pointer to its tail in one pass.
+// server can clamp every buffer's read pointer to its tail in one pass. The
+// correlated MAX is the first entry of each buffer's `id DESC` index run —
+// O(buffers) seeks, where the old GROUP BY scanned the network's whole
+// message partition.
 export function maxIdByBuffer(networkId: number): MaxIdByBufferRow[] {
   return db
-    .prepare('SELECT target, MAX(id) AS maxId FROM messages WHERE network_id = ? GROUP BY target')
+    .prepare(
+      `SELECT target, maxId FROM (
+         SELECT b.target AS target,
+                (SELECT MAX(m.id) FROM messages m WHERE m.buffer_id = b.id) AS maxId
+         FROM buffers b
+         WHERE b.network_id = ?
+       ) WHERE maxId IS NOT NULL`,
+    )
     .all(networkId) as MaxIdByBufferRow[];
 }
 
@@ -630,9 +683,11 @@ export function maxMessageId(): number {
 // MAX(id) for a single buffer, or 0 when the buffer has no rows. Used by
 // /clear to anchor the marker at the current tail.
 export function maxIdForBuffer(networkId: number, target: string): number {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return 0;
   const row = db
-    .prepare('SELECT MAX(id) AS maxId FROM messages WHERE network_id = ? AND target = ?')
-    .get(networkId, target) as { maxId: number | null } | undefined;
+    .prepare('SELECT MAX(id) AS maxId FROM messages WHERE buffer_id = ?')
+    .get(bufferId) as { maxId: number | null } | undefined;
   return row?.maxId || 0;
 }
 
@@ -640,12 +695,17 @@ export function maxIdForBuffer(networkId: number, target: string): number {
 // no_such_nick router: only route a DM-shaped error into a per-nick buffer if
 // the user has actually conversed with that nick. Stops typo /whois replies
 // from spawning empty DM buffers.
+//
+// These two used to be `target = ? COLLATE NOCASE` — the one predicate shape
+// in this file that defeated the index prefix and scanned the network's whole
+// partition. Resolution now folds through the registry, so they're index-only
+// seeks, and the case-insensitivity is the registry's (foldTarget), not
+// SQLite's ASCII NOCASE.
 export function hasMessageForTarget(networkId: number, target: string): boolean {
   if (!networkId || !target) return false;
-  const row = db
-    .prepare('SELECT 1 FROM messages WHERE network_id = ? AND target = ? COLLATE NOCASE LIMIT 1')
-    .get(networkId, target);
-  return !!row;
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return false;
+  return !!db.prepare('SELECT 1 FROM messages WHERE buffer_id = ? LIMIT 1').get(bufferId);
 }
 
 // Whether a target has a real (non-notice) conversation — at least one PRIVMSG or
@@ -654,19 +714,20 @@ export function hasMessageForTarget(networkId: number, target: string): boolean 
 // this so services don't consume MONITOR slots or show a presence dot.
 export function hasConversationForTarget(networkId: number, target: string): boolean {
   if (!networkId || !target) return false;
-  const row = db
-    .prepare(
-      "SELECT 1 FROM messages WHERE network_id = ? AND target = ? COLLATE NOCASE AND type IN ('message', 'action') LIMIT 1",
-    )
-    .get(networkId, target);
-  return !!row;
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return false;
+  return !!db
+    .prepare("SELECT 1 FROM messages WHERE buffer_id = ? AND type IN ('message', 'action') LIMIT 1")
+    .get(bufferId);
 }
 
 export function countOlder(networkId: number, target: string, beforeId: number): number {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return 0;
   return (
     db
-      .prepare(`SELECT COUNT(*) AS n FROM messages WHERE network_id = ? AND target = ? AND id < ?`)
-      .get(networkId, target, beforeId) as { n: number }
+      .prepare(`SELECT COUNT(*) AS n FROM messages WHERE buffer_id = ? AND id < ?`)
+      .get(bufferId, beforeId) as { n: number }
   ).n;
 }
 
@@ -730,13 +791,15 @@ function countUnreadRows(
   notableOnly: boolean,
   cap: number,
 ): number {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return 0;
   const lim = Number.isInteger(cap) && cap > 0 ? cap : UNREAD_COUNT_CAP;
   return (
     db
       .prepare(
         `SELECT COUNT(*) AS n FROM (
            SELECT 1 FROM messages
-           WHERE network_id = ? AND target = ? AND id > ?
+           WHERE buffer_id = ? AND id > ?
              AND type IN ${typesSql}
              ${notableOnly ? 'AND notable = 1' : ''}
              AND from_ignored = 0
@@ -744,7 +807,7 @@ function countUnreadRows(
            LIMIT ?
          )`,
       )
-      .get(networkId, target, afterId || 0, lim) as { n: number }
+      .get(bufferId, afterId || 0, lim) as { n: number }
   ).n;
 }
 
@@ -781,16 +844,18 @@ export function countServerBufferUnread(
 // nick rule ("Reclaimed nick <you>.") must not highlight the server buffer when
 // it's deliberately not even counted as unread.
 export function countHighlightsNewer(networkId: number, target: string, afterId: number): number {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return 0;
   return (
     db
       .prepare(
         `SELECT COUNT(*) AS n FROM messages
-     WHERE network_id = ? AND target = ? AND id > ?
+     WHERE buffer_id = ? AND id > ?
        AND matched_rule_id IS NOT NULL
        AND from_ignored = 0
        AND notable = 1`,
       )
-      .get(networkId, target, afterId || 0) as { n: number }
+      .get(bufferId, afterId || 0) as { n: number }
   ).n;
 }
 
@@ -916,8 +981,14 @@ export function searchMessages(
     params.push(networkId);
   }
   if (target) {
-    where.push('m.target = ? COLLATE NOCASE');
-    params.push(target);
+    // `in:` scope. Without a networkId this means "this name on any of my
+    // networks", so it resolves through the registry as a folded-name subquery
+    // rather than a single id. The user_id prefix of idx_buffers_key bounds
+    // the subquery to the caller's own buffers.
+    where.push(
+      'm.buffer_id IN (SELECT b.id FROM buffers b WHERE b.user_id = ? AND b.target_folded = ?)',
+    );
+    params.push(userId, foldTargetFor(networkId ?? null, target));
   }
   // `nicks` OR-matches several senders (a friend's alts); `nick` is the single
   // case. COLLATE NOCASE binds to the column so the IN comparison is case-fold.
@@ -968,7 +1039,7 @@ const listSpeakersStmt = db.prepare(`
   FROM (
     SELECT nick, time
     FROM messages
-    WHERE network_id = ? AND target = ?
+    WHERE buffer_id = ?
       AND type IN ('message', 'action')
       AND self = 0
       AND nick IS NOT NULL
@@ -990,8 +1061,10 @@ export function listSpeakers(
   limit = 20,
   scanWindow = SPEAKER_SCAN_WINDOW,
 ): Array<{ nick: string; lastTime: number }> {
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return [];
   return (
-    listSpeakersStmt.all(networkId, target, scanWindow, limit) as Array<{
+    listSpeakersStmt.all(bufferId, scanWindow, limit) as Array<{
       nick: string;
       last_time: string;
     }>

--- a/server/db/messagesEqp.test.ts
+++ b/server/db/messagesEqp.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// EXPLAIN QUERY PLAN assertions for the id-keyed message paths. The unread
+// count being INDEX-ONLY is a load-bearing property (#469: reaching the count
+// cap used to mean thousands of scattered rowid lookups per buffer per connect
+// snapshot) — these tests pin the plan itself so an index or predicate edit
+// that silently de-covers the query fails CI instead of shipping a
+// spinning-disk regression.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-eqp-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+
+function plan(sql: string): string {
+  return (db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{ detail: string }>)
+    .map((r) => r.detail)
+    .join(' | ');
+}
+
+beforeAll(async () => {
+  ({ default: db } = await import('./index.js'));
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('unread-count path', () => {
+  it('uses the covering per-buffer index (countUnreadRows shape)', () => {
+    const detail = plan(
+      `SELECT COUNT(*) FROM (
+         SELECT 1 FROM messages
+         WHERE buffer_id = 1 AND id > 0
+           AND type IN ('message','action','notice')
+           AND from_ignored = 0
+         ORDER BY id DESC
+         LIMIT 1000
+       )`,
+    );
+    expect(detail).toMatch(/USING COVERING INDEX idx_messages_buf_unread/);
+  });
+});
+
+describe('page and probe paths', () => {
+  it('the backlog page walks the per-buffer index (listMessages shape)', () => {
+    const detail = plan(`SELECT * FROM messages WHERE buffer_id = 1 ORDER BY id DESC LIMIT 50`);
+    expect(detail).toMatch(/USING INDEX idx_messages_buf_unread/);
+  });
+
+  it('the edge probe is an index seek (hasOlderThan shape)', () => {
+    const detail = plan(`SELECT 1 FROM messages WHERE buffer_id = 1 AND id < 5 LIMIT 1`);
+    expect(detail).toMatch(/USING COVERING INDEX idx_messages_buf_unread/);
+  });
+});
+
+describe('highlight-count path', () => {
+  it('uses the partial matched index (countHighlightsNewer shape)', () => {
+    const detail = plan(
+      `SELECT COUNT(*) FROM messages
+       WHERE buffer_id = 1 AND id > 0
+         AND matched_rule_id IS NOT NULL
+         AND from_ignored = 0
+         AND notable = 1`,
+    );
+    expect(detail).toMatch(/USING INDEX idx_messages_matched_buf/);
+  });
+});

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { ensureServerBuffer } from './buffers.js';
 import { encryptSecret, decryptSecret } from '../utils/secretCrypto.js';
 import { ENCRYPTED_NETWORK_COLUMNS } from './exportSchema.js';
 
@@ -122,6 +123,10 @@ export function createNetwork(userId: number, fields: NetworkFields): Network | 
       encryptSecret(connect_commands || null),
       next,
     );
+  // The network's `:server:` buffer is a real registry row (kind 'server',
+  // schema 17) — minted with the network so its console history and read
+  // pointer have an id from the first event.
+  ensureServerBuffer(Number(result.lastInsertRowid));
   return getNetwork(result.lastInsertRowid, userId);
 }
 

--- a/server/db/normalizeBuffers.test.ts
+++ b/server/db/normalizeBuffers.test.ts
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for the v17 normalization bodies, against a RAW database — the
+// functions take their db handle precisely so the kill/resume behavior can be
+// exercised without booting the whole module. The properties pinned here are
+// the ones the migration's safety argument rests on:
+//
+//   - a mid-run kill loses at most one chunk and the next run RESUMES (the
+//     cursor is committed inside each chunk's transaction),
+//   - resuming never rewrites rows that were already stamped,
+//   - the whole pass is idempotent once the done-flag is set,
+//   - the SQL-side fold is the JS rule (Unicode), not SQLite lower() (ASCII).
+
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+
+import {
+  mintSentinelBuffers,
+  mintOrphanBuffersFromMessages,
+  backfillMessagesBufferId,
+  normalizeMessagesBufferIds,
+  messagesBackfillDone,
+} from './normalizeBuffers.js';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-normalize-'));
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+let db: Database.Database;
+let n = 0;
+
+function freshDb(): Database.Database {
+  const d = new Database(path.join(tmpDir, `t${n++}.db`));
+  d.pragma('journal_mode = WAL');
+  d.exec(`
+    CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT);
+    CREATE TABLE networks (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL);
+    CREATE TABLE buffers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      network_id INTEGER,
+      target TEXT NOT NULL,
+      target_folded TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      state TEXT NOT NULL DEFAULT 'open',
+      autojoin INTEGER NOT NULL DEFAULT 0,
+      key TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      closed_at TEXT
+    );
+    CREATE UNIQUE INDEX idx_buffers_key
+      ON buffers(user_id, IFNULL(network_id, 0), target_folded);
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      network_id INTEGER NOT NULL,
+      buffer_id INTEGER,
+      target TEXT NOT NULL,
+      time TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+      type TEXT NOT NULL DEFAULT 'message'
+    );
+    CREATE TABLE app_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO users (id, username) VALUES (1, 'u');
+    INSERT INTO networks (id, user_id) VALUES (10, 1);
+    INSERT INTO buffers (user_id, network_id, target, target_folded, kind)
+      VALUES (1, 10, '#chan', '#chan', 'channel');
+  `);
+  return d;
+}
+
+function seedMessages(count: number): void {
+  const ins = db.prepare(`INSERT INTO messages (network_id, target) VALUES (10, '#chan')`);
+  for (let i = 0; i < count; i += 1) ins.run();
+}
+
+function nullCount(): number {
+  return (
+    db.prepare(`SELECT COUNT(*) AS c FROM messages WHERE buffer_id IS NULL`).get() as {
+      c: number;
+    }
+  ).c;
+}
+
+beforeEach(() => {
+  db = freshDb();
+});
+
+describe('backfillMessagesBufferId — kill and resume', () => {
+  it('persists partial progress and resumes without rewriting done rows', () => {
+    seedMessages(100);
+
+    const first = backfillMessagesBufferId(db, { chunk: 30, abortAfterChunks: 1 });
+    expect(first.complete).toBe(false);
+    expect(first.updated).toBe(30);
+    expect(nullCount()).toBe(70);
+    const cursor = db
+      .prepare(`SELECT value FROM app_meta WHERE key = 'messages_bufferid_cursor'`)
+      .get() as { value: string };
+    expect(Number(cursor.value)).toBe(30);
+    expect(messagesBackfillDone(db)).toBe(false);
+
+    // The "next boot": same call, no abort. `updated` counts only rows this
+    // run stamped — a resume that re-wrote the first chunk would report 100.
+    const second = backfillMessagesBufferId(db, { chunk: 30 });
+    expect(second.complete).toBe(true);
+    expect(second.updated).toBe(70);
+    expect(nullCount()).toBe(0);
+    expect(messagesBackfillDone(db)).toBe(true);
+  });
+
+  it('is a no-op once the done-flag is set', () => {
+    seedMessages(5);
+    expect(backfillMessagesBufferId(db, {}).complete).toBe(true);
+    const again = backfillMessagesBufferId(db, {});
+    expect(again).toEqual({ updated: 0, complete: true });
+  });
+
+  it('completes an empty table immediately', () => {
+    expect(backfillMessagesBufferId(db, {}).complete).toBe(true);
+    expect(messagesBackfillDone(db)).toBe(true);
+  });
+
+  it('leaves unresolvable rows NULL and does not set the done-flag', () => {
+    db.exec(`INSERT INTO messages (network_id, target) VALUES (99, '#ghost')`); // no such network
+    const result = backfillMessagesBufferId(db, {});
+    expect(result.complete).toBe(false);
+    expect(messagesBackfillDone(db)).toBe(false);
+  });
+});
+
+describe('the fold parity tripwire', () => {
+  it('resolves non-ASCII case variants with the JS rule', () => {
+    db.exec(`
+      INSERT INTO buffers (user_id, network_id, target, target_folded, kind)
+        VALUES (1, 10, '#Ärger', '#ärger', 'channel');
+      INSERT INTO messages (network_id, target) VALUES (10, '#ÄRGER');
+    `);
+    const result = backfillMessagesBufferId(db, {});
+    // SQLite lower('#ÄRGER') = '#ÄRGER' — under that fold this row stays NULL
+    // and complete would be false. The registered JS-parity function is what
+    // makes it resolve.
+    expect(result.complete).toBe(true);
+    const row = db
+      .prepare(
+        `SELECT b.target_folded AS f FROM messages m JOIN buffers b ON b.id = m.buffer_id
+         WHERE m.target = '#ÄRGER'`,
+      )
+      .get() as { f: string };
+    expect(row.f).toBe('#ärger');
+  });
+});
+
+describe('mints', () => {
+  it('mintSentinelBuffers is idempotent and kinds the rows', () => {
+    mintSentinelBuffers(db);
+    mintSentinelBuffers(db);
+    const rows = db
+      .prepare(`SELECT target, kind, state, network_id FROM buffers WHERE target LIKE ':%'`)
+      .all() as Array<{ target: string; kind: string; state: string; network_id: number | null }>;
+    expect(rows).toHaveLength(2);
+    const system = rows.find((r) => r.target === ':system:');
+    expect(system?.kind).toBe('system');
+    expect(system?.network_id).toBe(null);
+    const server = rows.find((r) => r.target === ':server:10');
+    expect(server?.kind).toBe('server');
+    expect(server?.state).toBe('open');
+  });
+
+  it('mintOrphanBuffersFromMessages mints CLOSED rows for unmatched targets only', () => {
+    db.exec(`
+      INSERT INTO messages (network_id, target) VALUES (10, '#chan');
+      INSERT INTO messages (network_id, target) VALUES (10, 'Stray');
+    `);
+    const minted = mintOrphanBuffersFromMessages(db);
+    expect(minted).toBe(1); // '#chan' already had a row
+    const row = db
+      .prepare(`SELECT kind, state FROM buffers WHERE target_folded = 'stray'`)
+      .get() as { kind: string; state: string };
+    expect(row.kind).toBe('dm');
+    expect(row.state).toBe('closed');
+  });
+
+  it('normalizeMessagesBufferIds resolves rows minted after a first pass', () => {
+    // The straggler sweep: rows behind the cursor whose buffers row only
+    // exists after a re-mint still get stamped.
+    db.exec(`INSERT INTO messages (network_id, target) VALUES (10, 'newcomer')`);
+    const result = normalizeMessagesBufferIds(db);
+    expect(result.complete).toBe(true);
+    expect(nullCount()).toBe(0);
+  });
+});

--- a/server/db/normalizeBuffers.test.ts
+++ b/server/db/normalizeBuffers.test.ts
@@ -172,14 +172,33 @@ describe('mints', () => {
     db.exec(`
       INSERT INTO messages (network_id, target) VALUES (10, '#chan');
       INSERT INTO messages (network_id, target) VALUES (10, 'Stray');
+      INSERT INTO messages (network_id, target) VALUES (10, ':server:99');
     `);
     const minted = mintOrphanBuffersFromMessages(db);
-    expect(minted).toBe(1); // '#chan' already had a row
+    // '#chan' already had a row; ':server:99' is deliberately skipped — a
+    // minted ':' row would be hidden from the walk and unopenable, so the
+    // backfill coalesces those onto the canonical sentinel instead.
+    expect(minted).toBe(1);
     const row = db
       .prepare(`SELECT kind, state FROM buffers WHERE target_folded = 'stray'`)
       .get() as { kind: string; state: string };
     expect(row.kind).toBe('dm');
     expect(row.state).toBe('closed');
+    expect(db.prepare(`SELECT 1 FROM buffers WHERE target = ':server:99'`).get()).toBe(undefined);
+  });
+
+  it('the backfill coalesces :server: strays onto the canonical sentinel', () => {
+    mintSentinelBuffers(db);
+    db.exec(`INSERT INTO messages (network_id, target) VALUES (10, ':server:77')`);
+    const result = backfillMessagesBufferId(db, {});
+    expect(result.complete).toBe(true);
+    const mapped = db
+      .prepare(
+        `SELECT b.target AS t FROM messages m JOIN buffers b ON b.id = m.buffer_id
+         WHERE m.target = ':server:77'`,
+      )
+      .get() as { t: string };
+    expect(mapped.t).toBe(':server:10');
   });
 
   it('normalizeMessagesBufferIds resolves rows minted after a first pass', () => {

--- a/server/db/normalizeBuffers.ts
+++ b/server/db/normalizeBuffers.ts
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type { Database } from 'better-sqlite3';
+
+// The v17 normalization bodies: mint the buffers rows that message history
+// implies, then stamp messages.buffer_id from them. Exported (and handed the
+// db) rather than inlined in index.ts for three reasons: index.ts calls them
+// at module load mid-evaluation (importing it back would be a cycle — same
+// pattern as foldBufferCase/seedUploaderConfig), the import path reuses them
+// to normalize v1 archives, and the kill/resume behavior is unit-testable.
+//
+// Everything here is idempotent and re-runnable: mints are insert-if-absent,
+// the backfill only touches `buffer_id IS NULL` rows, and progress persists in
+// app_meta inside each chunk's transaction. A watchdog kill mid-run loses at
+// most one chunk and the next boot resumes where it left off — the restart
+// loop documented on the idx_messages_unread build (a one-shot, non-resumable
+// stall) structurally cannot happen here.
+//
+// Folding: lookups everywhere else fold with JS toLowerCase (buffers.ts
+// foldTarget — Unicode-aware), but a set-based UPDATE can only call SQL
+// functions, and SQLite's lower() is ASCII-only. `#Ärger` folds differently
+// under the two, which is exactly the class of bug #707 catalogues. So the
+// SQL side calls a registered custom function that IS foldTarget, and the two
+// rules cannot diverge.
+
+const FOLD_FN = 'lurker_fold_target';
+
+export function registerFoldFunction(db: Database): void {
+  // Registering the same name twice replaces the implementation — harmless —
+  // but wrap anyway so a driver that objects can't turn boot into a crash.
+  try {
+    db.function(FOLD_FN, { deterministic: true }, (target) =>
+      typeof target === 'string' ? target.toLowerCase() : null,
+    );
+  } catch {
+    /* already registered */
+  }
+}
+
+/**
+ * Mint the `:system:` row for every user and the `:server:<netId>` row for
+ * every network. These buffers have always existed behaviorally (real
+ * buffer_reads rows, real `:server:` message rows, synthesized by wsHub's
+ * walk) — the kind enum reserved 'server'/'system' for the day they became
+ * real rows, and buffer_id is that day: leaving them rowless would mean the
+ * unread path keeps a (network_id, target) index forever just for sentinels.
+ *
+ * state 'open': they are permanent, uncloseable fixtures (buffers.ts guards
+ * close/delete against these kinds).
+ */
+export function mintSentinelBuffers(db: Database): void {
+  // `WHERE true` disambiguates the upsert clause — without it SQLite parses
+  // the ON of ON CONFLICT as a join constraint and errors "near DO".
+  db.prepare(
+    `INSERT INTO buffers (user_id, network_id, target, target_folded, kind, state, autojoin, key)
+     SELECT u.id, NULL, ':system:', ':system:', 'system', 'open', 0, NULL FROM users u WHERE true
+     ON CONFLICT(user_id, IFNULL(network_id, 0), target_folded) DO NOTHING`,
+  ).run();
+  db.prepare(
+    `INSERT INTO buffers (user_id, network_id, target, target_folded, kind, state, autojoin, key)
+     SELECT n.user_id, n.id, ':server:' || n.id, ':server:' || n.id, 'server', 'open', 0, NULL
+     FROM networks n WHERE true
+     ON CONFLICT(user_id, IFNULL(network_id, 0), target_folded) DO NOTHING`,
+  ).run();
+}
+
+/**
+ * Mint a CLOSED buffers row for every distinct message target that lacks one.
+ *
+ * The v16 migration derived the registry FROM history, so on a healthy DB this
+ * mints nothing. It exists because the alternative on a damaged or hand-edited
+ * DB is worse in both directions: dropping the rows loses user data, and
+ * leaving them unmatched leaves messages.buffer_id NULL — invisible history.
+ * Closed means garbage never surfaces in a sidebar; genuinely-live targets get
+ * reopened by their next message through the ordinary reducer.
+ *
+ * Folding is done in JS (foldTarget parity — see module header), so the
+ * distinct targets are materialized and folded here rather than inserted
+ * set-based. The distinct list is O(buffers), not O(messages), in size; the
+ * scan to produce it is one index-only pass. Materialized with .all() —
+ * iterating a live cursor while writing on the shared connection is the
+ * documented crash class (AGENTS.md).
+ */
+export function mintOrphanBuffersFromMessages(db: Database): number {
+  const distinct = db
+    .prepare(`SELECT DISTINCT network_id AS networkId, target FROM messages`)
+    .all() as Array<{ networkId: number; target: string }>;
+  if (distinct.length === 0) return 0;
+
+  const userByNetwork = db.prepare(`SELECT user_id AS userId FROM networks WHERE id = ?`);
+  const exists = db.prepare(
+    `SELECT 1 FROM buffers
+     WHERE user_id = ? AND IFNULL(network_id, 0) = IFNULL(?, 0) AND target_folded = ?`,
+  );
+  const insert = db.prepare(
+    `INSERT INTO buffers (user_id, network_id, target, target_folded, kind, state, autojoin, key)
+     VALUES (?, ?, ?, ?, ?, 'closed', 0, NULL)
+     ON CONFLICT(user_id, IFNULL(network_id, 0), target_folded) DO NOTHING`,
+  );
+
+  let minted = 0;
+  for (const { networkId, target } of distinct) {
+    const owner = userByNetwork.get(networkId) as { userId: number } | undefined;
+    if (!owner) continue; // orphaned network row; the FK would reject the mint
+    const folded = target.toLowerCase();
+    if (exists.get(owner.userId, networkId, folded)) continue;
+    // ':'-prefixed strays (a sentinel casing variant, a corrupt import) are
+    // minted as 'server' so kindForTarget's channel/dm split never claims them.
+    const kind = target.startsWith(':')
+      ? 'server'
+      : '#&+!'.includes(target[0] ?? '')
+        ? 'channel'
+        : 'dm';
+    minted += insert.run(owner.userId, networkId, target, folded, kind).changes;
+  }
+  return minted;
+}
+
+const CURSOR_KEY = 'messages_bufferid_cursor';
+const DONE_KEY = 'messages_bufferid_done';
+
+/** Default rows per chunk. ~25k rows keeps each transaction (and the WAL it
+ *  appends) small enough that Litestream replicates increments instead of one
+ *  giant gulp, while the whole 2M-row reference account still completes in
+ *  well under a hundred transactions. */
+export const BACKFILL_CHUNK_ROWS = 25_000;
+
+export interface BackfillResult {
+  /** Rows actually stamped by this run (not counting already-done rows). */
+  updated: number;
+  /** True when the done-flag is set (no NULL buffer_id remains). */
+  complete: boolean;
+}
+
+/**
+ * Stamp messages.buffer_id in resumable, rowid-range chunks.
+ *
+ * Each chunk is its own IMMEDIATE transaction with the progress cursor written
+ * inside it, so any kill leaves a committed prefix and the next call resumes
+ * from the cursor. Chunking across transactions would be unsafe on the shared
+ * connection if the server were running (another write would join an open
+ * transaction) — it is safe here solely because this runs synchronously at
+ * module load, before anything else can touch the database. Do not call it
+ * from a live server without re-deriving that argument.
+ *
+ * The subquery's fold uses the registered JS-parity function (module header),
+ * and its IFNULL form matches idx_buffers_key so each row costs one index
+ * seek. Rows whose target resolves to no buffers row stay NULL — the caller
+ * loops mint→backfill and warns if anything survives both.
+ */
+export function backfillMessagesBufferId(
+  db: Database,
+  {
+    chunk = BACKFILL_CHUNK_ROWS,
+    abortAfterChunks,
+  }: { chunk?: number; abortAfterChunks?: number } = {},
+): BackfillResult {
+  registerFoldFunction(db);
+  if (getMeta(db, DONE_KEY)) return { updated: 0, complete: true };
+
+  const maxId =
+    (db.prepare(`SELECT MAX(id) AS m FROM messages`).get() as { m: number | null }).m ?? 0;
+  let cursor = Number(getMeta(db, CURSOR_KEY) ?? 0);
+  let updated = 0;
+  let chunks = 0;
+
+  const updateStmt = db.prepare(
+    `UPDATE messages SET buffer_id = (
+       SELECT b.id FROM buffers b
+       WHERE b.user_id = (SELECT n.user_id FROM networks n WHERE n.id = messages.network_id)
+         AND IFNULL(b.network_id, 0) = messages.network_id
+         AND b.target_folded = ${FOLD_FN}(messages.target)
+     )
+     WHERE id > ? AND id <= ? AND buffer_id IS NULL`,
+  );
+
+  const step = db.transaction((lo: number, hi: number) => {
+    const n = updateStmt.run(lo, hi).changes;
+    setMeta(db, CURSOR_KEY, String(hi));
+    return n;
+  });
+
+  while (cursor < maxId) {
+    const hi = Math.min(cursor + chunk, maxId);
+    updated += step.immediate(cursor, hi);
+    cursor = hi;
+    chunks += 1;
+    if (abortAfterChunks !== undefined && chunks >= abortAfterChunks) {
+      return { updated, complete: false };
+    }
+  }
+
+  // The cursor only moves forward, so rows a first pass could not resolve
+  // (no buffers row yet) are behind it by the time a re-mint fixes the cause.
+  // One full-range sweep picks them up: it touches only `buffer_id IS NULL`
+  // rows, which at this point is the (near-empty) straggler set.
+  if (db.prepare(`SELECT 1 FROM messages WHERE buffer_id IS NULL LIMIT 1`).get()) {
+    const sweep = db.transaction(() => updateStmt.run(0, maxId).changes);
+    updated += sweep.immediate();
+  }
+
+  const straggler = db.prepare(`SELECT 1 FROM messages WHERE buffer_id IS NULL LIMIT 1`).get();
+  if (straggler) return { updated, complete: false };
+  const finish = db.transaction(() => {
+    setMeta(db, DONE_KEY, '1');
+    setMeta(db, CURSOR_KEY, String(maxId));
+  });
+  finish.immediate();
+  return { updated, complete: true };
+}
+
+/** Is the messages backfill recorded as complete? (Gates the index swap.) */
+export function messagesBackfillDone(db: Database): boolean {
+  return !!getMeta(db, DONE_KEY);
+}
+
+/**
+ * The whole v17 data pass: sentinels, orphans, backfill — looped once more if
+ * stragglers survive (a target minted between fold rules can leave a first
+ * pass short; the second pass resolves against the fresh mints). Never throws
+ * on stragglers: a warn plus an unset done-flag retries next boot, which beats
+ * a crash-looping cell (the house rule about throwing at module load).
+ */
+export function normalizeMessagesBufferIds(
+  db: Database,
+  opts: { chunk?: number } = {},
+): BackfillResult {
+  registerFoldFunction(db);
+  let result: BackfillResult = { updated: 0, complete: messagesBackfillDone(db) };
+  if (result.complete) return result;
+  for (let pass = 0; pass < 2; pass += 1) {
+    mintSentinelBuffers(db);
+    mintOrphanBuffersFromMessages(db);
+    result = backfillMessagesBufferId(db, opts);
+    if (result.complete) return result;
+  }
+  console.warn(
+    '[db] messages.buffer_id backfill left unresolved rows; will retry next boot. ' +
+      'If this repeats, some message targets cannot be minted (orphaned network rows?).',
+  );
+  return result;
+}
+
+function getMeta(db: Database, key: string): string | undefined {
+  return (
+    db.prepare(`SELECT value FROM app_meta WHERE key = ?`).get(key) as { value: string } | undefined
+  )?.value;
+}
+
+function setMeta(db: Database, key: string, value: string): void {
+  db.prepare(
+    `INSERT INTO app_meta (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+  ).run(key, value);
+}

--- a/server/db/normalizeBuffers.ts
+++ b/server/db/normalizeBuffers.ts
@@ -103,15 +103,16 @@ export function mintOrphanBuffersFromMessages(db: Database): number {
   for (const { networkId, target } of distinct) {
     const owner = userByNetwork.get(networkId) as { userId: number } | undefined;
     if (!owner) continue; // orphaned network row; the FK would reject the mint
+    // ':'-prefixed strays (a sentinel casing variant, a ':server:<foreignId>'
+    // from a legacy import) are NOT minted: a ':' row the walk skips and
+    // nothing can open would be a hidden buffer stranding its history. The
+    // backfill maps these onto the network's canonical `:server:` sentinel
+    // instead — the same coalescing the live insert path applies — so
+    // imported server-console history becomes reachable rather than hidden.
+    if (target.startsWith(':')) continue;
     const folded = target.toLowerCase();
     if (exists.get(owner.userId, networkId, folded)) continue;
-    // ':'-prefixed strays (a sentinel casing variant, a corrupt import) are
-    // minted as 'server' so kindForTarget's channel/dm split never claims them.
-    const kind = target.startsWith(':')
-      ? 'server'
-      : '#&+!'.includes(target[0] ?? '')
-        ? 'channel'
-        : 'dm';
+    const kind = '#&+!'.includes(target[0] ?? '') ? 'channel' : 'dm';
     minted += insert.run(owner.userId, networkId, target, folded, kind).changes;
   }
   return minted;
@@ -165,12 +166,23 @@ export function backfillMessagesBufferId(
   let updated = 0;
   let chunks = 0;
 
+  // COALESCE second arm: any ':'-prefixed target that doesn't resolve on its
+  // own name (a ':server:<foreignId>' stray from a legacy import) lands on the
+  // network's canonical `:server:` sentinel — the same coalescing the live
+  // insert path applies, and the reason the orphan mint skips ':' targets
+  // (a minted ':' row would be hidden from the walk and unopenable, stranding
+  // its history). The canonical target ':server:<netId>' resolves via the
+  // FIRST arm, since the sentinel row's own folded name matches it.
   const updateStmt = db.prepare(
-    `UPDATE messages SET buffer_id = (
-       SELECT b.id FROM buffers b
-       WHERE b.user_id = (SELECT n.user_id FROM networks n WHERE n.id = messages.network_id)
-         AND IFNULL(b.network_id, 0) = messages.network_id
-         AND b.target_folded = ${FOLD_FN}(messages.target)
+    `UPDATE messages SET buffer_id = COALESCE(
+       (SELECT b.id FROM buffers b
+        WHERE b.user_id = (SELECT n.user_id FROM networks n WHERE n.id = messages.network_id)
+          AND IFNULL(b.network_id, 0) = messages.network_id
+          AND b.target_folded = ${FOLD_FN}(messages.target)),
+       CASE WHEN messages.target LIKE ':%' THEN
+         (SELECT b.id FROM buffers b
+          WHERE b.network_id = messages.network_id AND b.kind = 'server')
+       END
      )
      WHERE id > ? AND id <= ? AND buffer_id IS NULL`,
   );

--- a/server/db/users.ts
+++ b/server/db/users.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { ensureSystemBuffer } from './buffers.js';
 import { nonConformingReason } from '../../shared/username.js';
 
 /** User account roles. The first registered user is promoted to 'admin'. */
@@ -86,6 +87,10 @@ export function createUser(username: string, { role = 'user' }: { role?: UserRol
   const info = db.prepare('INSERT INTO users (username, role) VALUES (?, ?)').run(username, role);
   const user = findUserById(info.lastInsertRowid);
   if (!user) throw new Error('createUser: row missing immediately after insert');
+  // The app-scoped system buffer is a real registry row (kind 'system',
+  // schema 17) that everything else — read pointers, the connect walk —
+  // resolves by id, so it's minted with the account rather than lazily.
+  ensureSystemBuffer(user.id);
   return user;
 }
 

--- a/server/services/exportService.ts
+++ b/server/services/exportService.ts
@@ -35,6 +35,7 @@ interface ExportTableDefWithScope {
   encryptedColumns?: string[];
   rekeyOnImport?: boolean;
   fkRekey?: Record<string, string>;
+  rowWhere?: string;
 }
 
 /** Called periodically as messages stream out so the job row + WS can report progress. */
@@ -70,10 +71,20 @@ function scopeFilter(scope: string, userId: number): { where: string; params: nu
   }
 }
 
-function countRows(db: Database, table: string, scope: string, userId: number): number {
+function countRows(
+  db: Database,
+  table: string,
+  scope: string,
+  userId: number,
+  rowWhere?: string,
+): number {
   const { where, params } = scopeFilter(scope, userId);
-  return (db.prepare(`SELECT COUNT(*) AS n FROM ${table} ${where}`).get(...params) as { n: number })
-    .n;
+  const extra = rowWhere ? ` AND (${rowWhere})` : '';
+  return (
+    db.prepare(`SELECT COUNT(*) AS n FROM ${table} ${where}${extra}`).get(...params) as {
+      n: number;
+    }
+  ).n;
 }
 
 // Project a row into the shape that lands in the export. Strips BLOB columns
@@ -148,12 +159,12 @@ function selectAll(
   userId: number,
 ): Record<string, unknown>[] {
   const { where, params } = scopeFilter(def.scope, userId);
+  const rowWhere = def.rowWhere ? ` AND (${def.rowWhere})` : '';
   const cols = def.columns.join(', ');
   const order = def.pk ? `ORDER BY ${def.pk} ASC` : '';
-  return db.prepare(`SELECT ${cols} FROM ${table} ${where} ${order}`).all(...params) as Record<
-    string,
-    unknown
-  >[];
+  return db
+    .prepare(`SELECT ${cols} FROM ${table} ${where}${rowWhere} ${order}`)
+    .all(...params) as Record<string, unknown>[];
 }
 
 export function computeExportPreview(
@@ -173,7 +184,7 @@ export function computeExportPreview(
       counts[table] = 0;
       continue;
     }
-    counts[table] = countRows(db, table, d.scope, userId);
+    counts[table] = countRows(db, table, d.scope, userId, d.rowWhere);
   }
   return counts;
 }

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -1078,8 +1078,19 @@ describe('importFromZipBuffer — end-to-end equivalence', () => {
       if (table === 'users') continue;
 
       const anyDef = def as unknown as AnyTableDef;
-      const aliceRows = rowsFor(alice.id, table, anyDef);
-      const bobRows = rowsFor(bob.id, table, anyDef);
+      let aliceRows = rowsFor(alice.id, table, anyDef);
+      let bobRows = rowsFor(bob.id, table, anyDef);
+
+      // Sentinel buffer rows (:system:, :server:<id>) are install-local
+      // fixtures, excluded from the archive on export and minted by each
+      // install for itself (alice's exist for her networks; bob's imported
+      // networks mint theirs on first use) — so equivalence is over the real
+      // buffers only.
+      if (table === 'buffers') {
+        const real = (r: Record<string, unknown>) => !String(r.target).startsWith(':');
+        aliceRows = aliceRows.filter(real);
+        bobRows = bobRows.filter(real);
+      }
 
       // Count parity first — catches missing inserts before we get into
       // payload comparisons (the payload diff would also catch it, but the

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -31,8 +31,9 @@ import type { Statement, RunResult } from 'better-sqlite3';
 import db from '../db/index.js';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION, IMPORT_ORDER } from '../db/exportSchema.js';
 import { encryptSecret } from '../utils/secretCrypto.js';
-import { importRow as importBufferRow } from '../db/buffers.js';
+import { importRow as importBufferRow, reopen as reopenBuffer } from '../db/buffers.js';
 import { listBufferTargets, hasMessageForTarget } from '../db/messages.js';
+import { resolveOrMintForInsert } from '../db/bufferResolve.js';
 import { migrateSmartFilterToEventMode } from '../db/migrateEventMode.js';
 import ignoreRulesService from './ignoreRulesService.js';
 import type { IgnorePatternKind } from '../db/ignoredMasks.js';
@@ -208,6 +209,13 @@ function insertTable(
     // file can't plant a row the folded lookups will never find.
     if (table === 'buffers') {
       row.target_folded = String(row.target ?? '').toLowerCase();
+      // Sentinel rows (:system:, :server:<id>) are install-local: the target
+      // account already owns its :system: row (minted at account creation —
+      // inserting the archive's copy violates idx_buffers_key), and an
+      // archived ':server:<oldNetId>' target embeds the SOURCE install's
+      // network id, which nothing on this install will ever ask for. The
+      // target install mints its own sentinels on first use.
+      if (String(row.target ?? '').startsWith(':')) continue;
     }
 
     // Export carries at-rest secrets (network passwords, +k channel keys) as
@@ -309,16 +317,22 @@ function convertLegacyBuffers(
   if (!networkMap || (!legacyChannels.length && !legacyClosed.length && !networkMap.size)) return;
 
   let converted = 0;
-  // A: every imported message target becomes an open row.
+  // A: every imported message target becomes an open row. The message stream
+  // already minted these rows (insertMessage's defensive mint materializes
+  // unknown targets CLOSED so it can never conjure a surfaced buffer), and
+  // importRow's conflict policy deliberately never flips closed→open — so the
+  // "message targets are open" rule is applied with an explicit reopen. The
+  // closed_buffers pass below still wins last, exactly as before.
   for (const newNetworkId of networkMap.values()) {
     for (const target of listBufferTargets(newNetworkId as number)) {
-      if (target.startsWith(':')) continue; // virtual buffers are never rows
+      if (target.startsWith(':')) continue; // sentinel rows keep their own state
       importBufferRow({
         userId: targetUserId,
         networkId: newNetworkId as number,
         target,
         state: 'open',
       });
+      reopenBuffer(targetUserId, newNetworkId as number, target);
       converted += 1;
     }
   }
@@ -364,7 +378,15 @@ async function streamMessagesInBatches(
   idMaps: Record<string, Map<unknown, unknown>>,
 ): Promise<number> {
   const def = EXPORT_TABLES.messages as ExportTableDefFull;
-  const { stmt, cols } = buildInsertStatement('messages', def);
+  // buffer_id is not an archive column (archives carry names; ids are
+  // install-local), but the live table's invariant is "never NULL" — an
+  // imported row with a NULL buffer_id would be invisible to every id-keyed
+  // read. Stamped per row below, resolved against the already-imported
+  // buffers rows (IMPORT_ORDER puts `buffers` in Phase A, before messages);
+  // anything a legacy archive fails to resolve gets the same defensive
+  // closed-mint the insert path uses.
+  const defWithBufferId = { ...def, columns: [...def.columns, 'buffer_id'] };
+  const { stmt, cols } = buildInsertStatement('messages', defWithBufferId);
   const messagesMap = idMaps.messages;
   let inserted = 0;
 
@@ -392,6 +414,7 @@ async function streamMessagesInBatches(
       // is NOT NULL. Default to 1 (notable), matching the column default: old
       // history predates the server-buffer notability model, so it all counts.
       if (row.notable === undefined) row.notable = 1;
+      row.buffer_id = resolveOrMintForInsert(row.network_id as number, String(row.target ?? ''));
       const result = insertOne(stmt, cols, row);
       messagesMap.set(original.id, result.lastInsertRowid);
       inserted += 1;

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2375,14 +2375,21 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     expect(row?.key).toBe('hunter2');
   });
 
-  it("someone else's join mints nothing", () => {
+  it("someone else's join grants no autojoin and no key", () => {
     const conn = makeConn('echo-other');
     conn.client.user.nick = 'me';
     conn.upsertChannel('#chan');
 
     conn.client.emit('join', { channel: '#chan', nick: 'stranger' });
 
-    expect(getBuffer(conn.network.user_id, conn.network.id, '#chan')).toBeUndefined();
+    // Persisting the join event materializes the row (schema 17: the mint the
+    // wsHub live filter used to perform moved to the insert itself), but the
+    // property this test guards is unchanged: only the SELF echo is a join
+    // confirmation, so a stranger's join must not turn the channel into a
+    // rejoin carrier.
+    const row = getBuffer(conn.network.user_id, conn.network.id, '#chan');
+    expect(row?.autojoin).toBe(false);
+    expect(row?.key).toBe(null);
   });
 
   it('470 deletes a history-less pre-existing row even when the server relays a different case', () => {
@@ -2491,14 +2498,18 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
   it('442 for a channel with no row does not conjure one', () => {
     // Correcting state must not CREATE it: a typo'd /part answered with 442
     // used to leave a phantom channels row behind. setAutojoin is update-only,
-    // so the registry stays empty.
+    // so no channel row appears. (The error line itself persists into the
+    // server buffer, which as of schema 17 mints the `:server:` sentinel row —
+    // a real, deliberately-kinded fixture, not the phantom this test guards.)
     const conn = makeConn('notonchan-phantom');
     conn.client.emit('irc error', {
       error: 'not_on_channel',
       channel: '#never-joined',
       reason: "You're not on that channel",
     });
-    expect(listBufferRowsForNetwork(conn.network.id)).toHaveLength(0);
+    expect(
+      listBufferRowsForNetwork(conn.network.id).filter((b) => b.kind !== 'server'),
+    ).toHaveLength(0);
   });
 
   it('442 corrects a stale autojoin row even when the channel is not in the joined set', () => {

--- a/server/services/ircManager.test.ts
+++ b/server/services/ircManager.test.ts
@@ -520,7 +520,9 @@ describe('planChannelRejoins', () => {
 
     ircManager.partChannel(user.id, net.id, '#never-heard-of');
 
-    expect(buffers.listForNetwork(net.id)).toHaveLength(0);
+    // The network's `:server:` sentinel row (minted at network creation,
+    // schema 17) is the only row — no channel was conjured.
+    expect(buffers.listForNetwork(net.id).filter((b) => b.kind !== 'server')).toHaveLength(0);
     expect(conn.client.part).toHaveBeenCalledWith('#never-heard-of', undefined);
   });
 

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -642,6 +642,11 @@ export function* eachUserBufferTarget(userId: number): Generator<UserBufferTarge
   const rowsByNetwork = new Map<number, BufferStateRow[]>();
   for (const row of listBufferStatesForUser(userId)) {
     if (row.networkId == null) continue; // app-scoped rows are synthesized above
+    // Sentinel rows are REAL as of schema 17 (kinds 'server'/'system', minted
+    // for buffer_id), but this walk still yields the per-network `:server:`
+    // entry itself, in its fixed slot ahead of the network's buffers — so the
+    // registry copy is skipped here, not yielded twice.
+    if (row.target.startsWith(':')) continue;
     let list = rowsByNetwork.get(row.networkId);
     if (!list) rowsByNetwork.set(row.networkId, (list = []));
     list.push(row);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,10 @@ export default defineConfig({
           // never collects it, and the run still reports all-green. Everything
           // that isn't the client's belongs to this project.
           include: ['**/*.{test,spec}.ts'],
-          exclude: ['**/node_modules/**', 'vue_client/**'],
+          // .claude/ can hold agent-harness git WORKTREES (full checkouts,
+          // including their own copies of every test); collecting those runs
+          // another branch's suite inside this one's report.
+          exclude: ['**/node_modules/**', 'vue_client/**', '.claude/**'],
           environment: 'node',
         },
       },


### PR DESCRIPTION
First tier of the buffer-identity normalization (#695): a buffer's identity becomes \`buffers.id\`, and its name becomes an attribute resolved through one seam. This PR converts the biggest table — \`messages\` — plus the resolver and migration machinery; the satellite tables follow in the next PR, and \`bufferId\` reaches the wire after that. **Behavior-preserving by design** (exported db signatures unchanged; clients see identical frames), and **rollback-safe**: the schema change is purely additive, so the previous release still runs against a migrated database.

## Schema 17

- \`messages.buffer_id INTEGER REFERENCES buffers(id) ON DELETE CASCADE\` via \`ensureColumn\` — nullable in DDL (ALTER ADD COLUMN can't add NOT NULL, and the backfill must be resumable); "never NULL" is the application invariant, enforced at insert.
- **\`:server:\`/\`:system:\` become real rows** (kinds \`server\`/\`system\`, reserved since the registry landed): minted by the migration for existing data, at account/network creation going forward, defensively at resolve time. \`close\`/\`delete\` refuse sentinel kinds structurally. wsHub's walk still yields them in their fixed slots and skips the registry copies, so the connect burst is byte-identical.
- **Resumable, chunked backfill**, flag-driven via \`app_meta\`: rowid-range chunks (~25k rows), each its own \`BEGIN IMMEDIATE\` transaction with the progress cursor committed inside it. A watchdog kill mid-run loses at most one chunk and the next boot resumes — the restart-loop failure mode documented on the \`idx_messages_unread\` build cannot happen. Chunking across transactions is safe solely because this runs synchronously at module load, before the server accepts work (the shared-connection rule's hazard needs a live server); the module comment says so. WAL growth stays bounded per chunk instead of one ≥450 MB spike for Litestream to swallow. #708's FTS trigger guard makes the UPDATE FTS-free.
- **Fold parity**: the backfill's SQL joins through a registered JS-parity fold function, so it cannot diverge from \`foldTarget\` — SQLite \`lower()\` is ASCII-only and would silently strand \`#Ärger\`-class targets (the #707 trap). Pinned by a mutation-verified test.
- **Index swap** after the backfill: \`idx_messages_buf_unread (buffer_id, id DESC, type, from_ignored, notable)\` + \`idx_messages_matched_buf\`, one key column narrower than their predecessors; old generation dropped only after both exist. \`EXPLAIN QUERY PLAN\` pinned in \`messagesEqp.test.ts\`.

## Read/write paths

- Every predicate in \`messages.ts\` keys on \`buffer_id\`; exported signatures still take \`(networkId, target)\` and resolve once per call through the new \`server/db/bufferResolve.ts\` (no cache — a name→id cache would be the "second place storing the name" this project exists to kill).
- The two \`COLLATE NOCASE\` probes (\`hasMessageForTarget\`/\`hasConversationForTarget\`) — previously index-defeating partition scans on every buffer open — become index seeks. The \`listBufferTargets\` recursive skip-scan workaround is deleted outright; \`maxIdByBuffer\` becomes O(buffers) index seeks instead of a full partition GROUP BY.
- Insert-path minting moves from wsHub's live filter to the insert itself — the **same** \`ensureExists\` rule (creates open, never reopens), a moment earlier, so a message row can never exist without its buffer. The filter's reopen gate semantics (which events outrank a user's closed flag) are untouched.
- Deliberate improvement: a stray \`:server:<foreignId>\` target — the shape a legacy import produces — now resolves into the network's own server buffer, so imported server-console history is reachable for the first time (previously stranded under a target nothing asks for).

## Export/import

- Sentinel rows are install-local: excluded from export (\`rowWhere\`), dropped by the importer from older archives; each install mints its own.
- \`messages.buffer_id\` is not exported (\`skippedColumns\`); the importer re-resolves it per row against the target install's registry at insert time. Archive format unchanged — v2 lands with the satellite tier.

## Registry + tests

- \`bufferKeyedTables.ts\` returns as a status-carrying registry (\`buffer_id\` / \`pending\` / \`glob-list\`) with a both-directions live-schema drift test; the satellite rebuild must flip its \`pending\` entries in the same PR or CI fails.
- \`bufferIdMigration.test.ts\`: v16-shaped raw fixture → module import → **value-level** assertions (which row each message landed on): fold join, non-ASCII fold parity, orphan minted closed + repointed, sentinels minted + repointed, index generation swap, stray-cased reads resolving end-to-end.
- \`normalizeBuffers.test.ts\`: kill/resume simulation (partial progress + cursor persisted; resume stamps only the remainder), idempotence, unresolvable-row degradation (warn + retry next boot, never a crash-loop).
- **Mutation-verified** per the #706 post-mortem discipline: fold→\`lower()\`, sentinel mint deleted, and orphan mint deleted each fail their named tests (run and confirmed, then restored).

Also: \`vitest.config.ts\` excludes \`.claude/**\` — the harness can hold git worktrees there, and the catch-all glob was collecting another branch's entire suite into this one's report.

Full suite: 3,568 passed. \`npm run check\` clean.

Part of #695; groundwork for #707. Next: v18 satellite rebuild (the rollback point of no return — called out in that PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)