### PR TITLE
Rebuild the view-state satellites onto buffer_id keys (v18)

### DIFF
--- a/server/db/bufferKeyedTables.test.ts
+++ b/server/db/bufferKeyedTables.test.ts
@@ -98,15 +98,44 @@ describe('registry accuracy (registry → schema)', () => {
   });
 
   it("keeps 'pending' entries honest: their name column is still the key", () => {
-    // When the satellite rebuild flips a table to buffer_id, its registry
-    // entry must flip in the same PR — a 'pending' table that has grown a
-    // buffer_id (or lost its name column) is an undeclared migration.
+    // When a rebuild flips a table to buffer_id, its registry entry must flip
+    // in the same PR — a 'pending' table that has grown a buffer_id (or lost
+    // its name column) is an undeclared migration.
     const wrong: string[] = [];
     for (const t of PENDING_BUFFER_TABLES) {
       const names = new Set(columns(t.table).map((c) => c.name));
       if (names.has('buffer_id')) wrong.push(`${t.table}: has buffer_id but declared pending`);
       if (t.targetColumn && !names.has(t.targetColumn)) {
         wrong.push(`${t.table}: declared pending but ${t.targetColumn} is gone`);
+      }
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it("keeps 'wire-context' tables on the IRC side of the boundary", () => {
+    // These key on protocol context strings (e2e `@ident@host` pseudochannels,
+    // peer-supplied channel names), which only sometimes coincide with buffer
+    // names — a buffer_id here would be a category error. If one legitimately
+    // needs normalizing someday, that is a design decision to record in the
+    // registry, not a column to slip in.
+    const wrong: string[] = [];
+    for (const t of BUFFER_SCOPED_TABLES.filter((x) => x.status === 'wire-context')) {
+      const names = new Set(columns(t.table).map((c) => c.name));
+      if (names.has('buffer_id')) wrong.push(`${t.table}: wire-context table grew a buffer_id`);
+      if (t.targetColumn && !names.has(t.targetColumn)) {
+        wrong.push(`${t.table}: context column ${t.targetColumn} is gone`);
+      }
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it('the rebuilt view-state tables carry no name column at all', () => {
+    // The whole point of v18: for these, the name lives in `buffers` alone.
+    const wrong: string[] = [];
+    for (const t of BUFFER_SCOPED_TABLES.filter((x) => x.status === 'buffer_id' && !x.tombstone)) {
+      const names = new Set(columns(t.table).map((c) => c.name));
+      for (const shaped of BUFFER_TARGET_COLUMN_NAMES) {
+        if (names.has(shaped)) wrong.push(`${t.table}.${shaped}`);
       }
     }
     expect(wrong).toEqual([]);

--- a/server/db/bufferKeyedTables.ts
+++ b/server/db/bufferKeyedTables.ts
@@ -13,11 +13,24 @@
 // a single-row UPDATE.
 //
 // `status` records where each table is on that path:
-//   - 'buffer_id'  — normalized: keyed by a buffer_id FK to buffers(id).
-//   - 'pending'    — still name-keyed; scheduled for the satellite rebuild.
-//   - 'glob-list'  — a CSV of channel GLOBS that may span networks. These are
-//                    match patterns, not identities: they cannot reference a
-//                    buffer_id and deliberately do not follow renames.
+//   - 'buffer_id'    — normalized: keyed by a buffer_id FK to buffers(id).
+//   - 'pending'      — still name-keyed; scheduled for the satellite rebuild.
+//   - 'glob-list'    — a CSV of channel GLOBS that may span networks. These
+//                      are match patterns, not identities: they cannot
+//                      reference a buffer_id and deliberately do not follow
+//                      renames.
+//   - 'wire-context' — keyed by an IRC-side context string that only
+//                      COINCIDES with a buffer name sometimes. The e2e tables'
+//                      `channel` is the canonical case: it also holds
+//                      `@ident@host` DM pseudochannels (no buffer row exists
+//                      or should), the literal '@' from empty-handle call
+//                      sites, and peer-supplied names for channels this user
+//                      never joined. These live on the IRC side of the
+//                      name↔id boundary — like IrcConnection's in-memory maps
+//                      — and must NEVER grow a buffer_id (the drift test
+//                      enforces it). DM contexts are already rename-proof
+//                      (host-keyed); a channel rename starting a fresh crypto
+//                      context is correct, not a bug.
 //
 // The companion test introspects the live schema in BOTH directions, so this
 // list cannot silently drift from reality (its predecessor did exactly that:
@@ -25,7 +38,7 @@
 // and by 16 named two dropped tables). The test — not this comment — is what
 // keeps it honest.
 
-export type BufferTableStatus = 'buffer_id' | 'pending' | 'glob-list';
+export type BufferTableStatus = 'buffer_id' | 'pending' | 'glob-list' | 'wire-context';
 
 export interface BufferScopedTable {
   table: string;
@@ -63,49 +76,43 @@ export const BUFFER_SCOPED_TABLES: readonly BufferScopedTable[] = [
   },
   {
     table: 'buffer_reads',
-    status: 'pending',
-    targetColumn: 'target',
-    scope: ['user_id', 'network_id'],
-    note: 'read pointer + /clear marker',
+    status: 'buffer_id',
+    scope: ['user_id'],
+    note: 'read pointer + /clear marker; PK (user_id, buffer_id) since v18',
   },
   {
     table: 'input_history',
-    status: 'pending',
-    targetColumn: 'target',
-    scope: ['user_id', 'network_id'],
-    note: 'up-arrow input recall',
+    status: 'buffer_id',
+    scope: ['user_id'],
+    note: 'up-arrow input recall; buffer_id-keyed since v18',
   },
   {
     table: 'pinned_buffers',
-    status: 'pending',
-    targetColumn: 'target',
+    status: 'buffer_id',
     scope: ['user_id', 'network_id'],
-    note: 'sidebar pins; dense per-network position column',
+    note: 'sidebar pins; network_id kept — position density is per (user, network)',
   },
   {
     table: 'nicklist_collapsed',
-    status: 'pending',
-    targetColumn: 'target',
-    scope: ['user_id', 'network_id'],
-    note: 'per-channel nicklist toggle',
+    status: 'buffer_id',
+    scope: ['user_id'],
+    note: 'per-channel nicklist toggle; buffer_id-keyed since v18',
   },
   {
     table: 'channel_notify_settings',
-    status: 'pending',
-    targetColumn: 'target',
-    scope: ['user_id', 'network_id'],
-    note: 'notify_always',
+    status: 'buffer_id',
+    scope: ['user_id'],
+    note: "notify_always; the dead 'muted' column died in the v18 rebuild",
   },
   {
     table: 'user_drafts',
-    status: 'pending',
-    targetColumn: 'target',
-    scope: ['user_id', 'network_id'],
-    note: 'half-typed composer input',
+    status: 'buffer_id',
+    scope: ['user_id'],
+    note: 'half-typed composer input; buffer_id-keyed since v18',
   },
   {
     table: 'e2e_incoming_sessions',
-    status: 'pending',
+    status: 'wire-context',
     targetColumn: 'channel',
     caseInsensitive: true,
     scope: ['user_id', 'network_id'],
@@ -113,7 +120,7 @@ export const BUFFER_SCOPED_TABLES: readonly BufferScopedTable[] = [
   },
   {
     table: 'e2e_outgoing_sessions',
-    status: 'pending',
+    status: 'wire-context',
     targetColumn: 'channel',
     caseInsensitive: true,
     scope: ['user_id', 'network_id'],
@@ -121,7 +128,7 @@ export const BUFFER_SCOPED_TABLES: readonly BufferScopedTable[] = [
   },
   {
     table: 'e2e_channel_config',
-    status: 'pending',
+    status: 'wire-context',
     targetColumn: 'channel',
     caseInsensitive: true,
     scope: ['user_id', 'network_id'],
@@ -129,7 +136,7 @@ export const BUFFER_SCOPED_TABLES: readonly BufferScopedTable[] = [
   },
   {
     table: 'e2e_outgoing_recipients',
-    status: 'pending',
+    status: 'wire-context',
     targetColumn: 'channel',
     caseInsensitive: true,
     scope: ['user_id', 'network_id'],
@@ -137,12 +144,12 @@ export const BUFFER_SCOPED_TABLES: readonly BufferScopedTable[] = [
   },
   {
     table: 'e2e_autotrust',
-    status: 'pending',
+    status: 'wire-context',
     targetColumn: 'scope',
     excludeValues: ['global'],
     caseInsensitive: true,
     scope: ['user_id', 'network_id'],
-    note: "auto-trust rule; 'global' sentinel becomes buffer_id NULL at rebuild",
+    note: "auto-trust rule; scope is 'global' or a channel context string, never an id",
   },
   {
     table: 'highlight_rules',

--- a/server/db/bufferReads.test.ts
+++ b/server/db/bufferReads.test.ts
@@ -21,6 +21,28 @@ beforeAll(async () => {
   bufferReads = await import('./bufferReads.js');
   user = createUser('br-alice');
   net = createNetwork(user.id, { name: 'libera', host: 'h', port: 6697, tls: true, nick: 'a' });
+  // Read state is keyed by buffer_id (schema 18): a target only has state if
+  // the registry knows the buffer, so the fixtures mint every target used.
+  const { ensureExists } = await import('./buffers.js');
+  for (const t of [
+    '#a',
+    '#again',
+    '#b',
+    '#bad',
+    '#c',
+    '#empty',
+    '#has',
+    '#mixed',
+    '#mixed2',
+    '#mono',
+    '#never-cleared',
+    '#read-only',
+    '#undo',
+    '#vanish',
+    '#x',
+  ]) {
+    ensureExists(user.id, net!.id, t);
+  }
 });
 
 afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
@@ -60,27 +82,33 @@ describe('system buffer read pointer (null network_id, #355)', () => {
     expect(bufferReads.setReadState(user.id, null, ':system:', 10)).toBe(30);
   });
 
-  it('upserts a single row rather than duplicating (coalesced unique index)', async () => {
+  it('upserts a single row rather than duplicating (buffer_id primary key)', async () => {
     const u = createUser('br-sys-dedupe');
     bufferReads.setReadState(u.id, null, ':system:', 5);
     bufferReads.setReadState(u.id, null, ':system:', 9);
     const db = (await import('./index.js')).default;
     const row = db
       .prepare(
-        "SELECT COUNT(*) AS n FROM buffer_reads WHERE user_id = ? AND network_id IS NULL AND target = ':system:'",
+        `SELECT COUNT(*) AS n FROM buffer_reads r JOIN buffers b ON b.id = r.buffer_id
+         WHERE r.user_id = ? AND b.kind = 'system'`,
       )
       .get(u.id) as { n: number };
     expect(row.n).toBe(1);
     expect(bufferReads.getReadState(u.id, null, ':system:')).toBe(9);
   });
 
-  it('is independent of a network buffer with the same target name', () => {
+  it("a network-scoped ':system:' is not a buffer and stores nothing", () => {
+    // The old composite key could hold a per-network row under the ':system:'
+    // NAME — a shape nothing in production writes (wsHub always maps the
+    // system target to a null network). Under buffer_id keying that shape is
+    // unrepresentable: the write is a no-op and the app-scoped pointer is
+    // untouched.
     const u = createUser('br-sys-iso');
     const n = createNetwork(u.id, { name: 'lib', host: 'h', port: 6697, tls: true, nick: 'a' });
     bufferReads.setReadState(u.id, null, ':system:', 100);
-    bufferReads.setReadState(u.id, n!.id, ':system:', 7);
+    expect(bufferReads.setReadState(u.id, n!.id, ':system:', 7)).toBe(0);
     expect(bufferReads.getReadState(u.id, null, ':system:')).toBe(100);
-    expect(bufferReads.getReadState(u.id, n!.id, ':system:')).toBe(7);
+    expect(bufferReads.getReadState(u.id, n!.id, ':system:')).toBe(0);
   });
 });
 

--- a/server/db/bufferReads.ts
+++ b/server/db/bufferReads.ts
@@ -2,54 +2,51 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { resolveBuffer } from './bufferResolve.js';
 
-/** A row from `buffer_reads`. network_id is null for the app-scoped system
- * buffer (#355). */
-export interface BufferRead {
-  user_id: number;
-  network_id: number | null;
-  target: string;
-  last_read_message_id: number;
-  updated_at: string;
-  cleared_before_message_id: number | null;
-  cleared_at: string | null;
-}
+// buffer_reads is keyed (user_id, buffer_id) since schema 18 — the name lives
+// in `buffers` alone. Exported signatures still take (networkId, target)
+// because that's what callers hold; each entry point resolves the name once
+// through bufferResolve. A resolution miss means "no such buffer": reads
+// return the zero state, writes are a no-op — state for a buffer that doesn't
+// exist is meaningless, and the old path's implicit row-for-any-string was
+// exactly the detached-pointer bug class (#355's ms-blowup incident).
+//
+// The list functions join back through `buffers` so their wire shape —
+// `${networkId}::${target}` map keys — is byte-identical to the name-keyed
+// era (a NULL networkId stringifies to "null", matching the system buffer's
+// old key).
 
 export interface ClearedState {
   clearedBeforeId: number;
   clearedAt: string | null;
 }
 
-// ON CONFLICT targets the coalesced unique index (user_id, IFNULL(network_id,0),
-// target) so the app-scoped system buffer (NULL network_id) dedupes — a plain
-// (user_id, network_id, target) conflict target treats NULL as distinct.
 const upsertStmt = db.prepare(`
-  INSERT INTO buffer_reads (user_id, network_id, target, last_read_message_id, updated_at)
-  VALUES (?, ?, ?, ?, datetime('now'))
-  ON CONFLICT(user_id, IFNULL(network_id, 0), target) DO UPDATE SET
+  INSERT INTO buffer_reads (user_id, buffer_id, last_read_message_id, updated_at)
+  VALUES (?, ?, ?, datetime('now'))
+  ON CONFLICT(user_id, buffer_id) DO UPDATE SET
     last_read_message_id = MAX(last_read_message_id, excluded.last_read_message_id),
     updated_at = excluded.updated_at
 `);
 
-// IFNULL on both sides so a NULL network_id (system buffer) matches its own row;
-// for real network ids it's an identity, so network-buffer lookups are unchanged.
 const getOneStmt = db.prepare(`
   SELECT last_read_message_id AS lastReadId
   FROM buffer_reads
-  WHERE user_id = ? AND IFNULL(network_id, 0) = IFNULL(?, 0) AND target = ?
+  WHERE user_id = ? AND buffer_id = ?
 `);
 
 const listForUserStmt = db.prepare(`
-  SELECT network_id AS networkId, target, last_read_message_id AS lastReadId
-  FROM buffer_reads
-  WHERE user_id = ?
+  SELECT b.network_id AS networkId, b.target AS target, r.last_read_message_id AS lastReadId
+  FROM buffer_reads r JOIN buffers b ON b.id = r.buffer_id
+  WHERE r.user_id = ?
 `);
 
 // Returns map keyed by `${networkId}::${target}` → lastReadId.
 export function listReadStateForUser(userId: number): Record<string, number> {
   const out: Record<string, number> = {};
   for (const row of listForUserStmt.all(userId) as Array<{
-    networkId: number;
+    networkId: number | null;
     target: string;
     lastReadId: number;
   }>) {
@@ -59,7 +56,9 @@ export function listReadStateForUser(userId: number): Record<string, number> {
 }
 
 export function getReadState(userId: number, networkId: number | null, target: string): number {
-  const row = getOneStmt.get(userId, networkId, target) as { lastReadId: number } | undefined;
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return 0;
+  const row = getOneStmt.get(userId, buffer.id) as { lastReadId: number } | undefined;
   return row ? row.lastReadId : 0;
 }
 
@@ -72,10 +71,13 @@ export function setReadState(
   target: string,
   messageId: number,
 ): number {
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return 0;
   const id = Number(messageId);
   if (!Number.isFinite(id) || id <= 0) return getReadState(userId, networkId, target);
-  upsertStmt.run(userId, networkId, target, id);
-  return getReadState(userId, networkId, target);
+  upsertStmt.run(userId, buffer.id, id);
+  const row = getOneStmt.get(userId, buffer.id) as { lastReadId: number } | undefined;
+  return row ? row.lastReadId : 0;
 }
 
 // --- /clear marker state ---------------------------------------------------
@@ -87,10 +89,9 @@ export function setReadState(
 
 const upsertClearedStmt = db.prepare(`
   INSERT INTO buffer_reads
-    (user_id, network_id, target, last_read_message_id,
-     cleared_before_message_id, cleared_at, updated_at)
-  VALUES (?, ?, ?, 0, ?, ?, datetime('now'))
-  ON CONFLICT(user_id, IFNULL(network_id, 0), target) DO UPDATE SET
+    (user_id, buffer_id, last_read_message_id, cleared_before_message_id, cleared_at, updated_at)
+  VALUES (?, ?, 0, ?, ?, datetime('now'))
+  ON CONFLICT(user_id, buffer_id) DO UPDATE SET
     cleared_before_message_id = excluded.cleared_before_message_id,
     cleared_at = excluded.cleared_at,
     updated_at = excluded.updated_at
@@ -101,17 +102,17 @@ const getClearedStmt = db.prepare(`
     cleared_before_message_id AS clearedBeforeId,
     cleared_at AS clearedAt
   FROM buffer_reads
-  WHERE user_id = ? AND IFNULL(network_id, 0) = IFNULL(?, 0) AND target = ?
+  WHERE user_id = ? AND buffer_id = ?
 `);
 
 const listClearedStmt = db.prepare(`
-  SELECT network_id AS networkId, target,
-         cleared_before_message_id AS clearedBeforeId,
-         cleared_at AS clearedAt
-  FROM buffer_reads
-  WHERE user_id = ?
-    AND cleared_before_message_id IS NOT NULL
-    AND cleared_before_message_id > 0
+  SELECT b.network_id AS networkId, b.target AS target,
+         r.cleared_before_message_id AS clearedBeforeId,
+         r.cleared_at AS clearedAt
+  FROM buffer_reads r JOIN buffers b ON b.id = r.buffer_id
+  WHERE r.user_id = ?
+    AND r.cleared_before_message_id IS NOT NULL
+    AND r.cleared_before_message_id > 0
 `);
 
 export function getClearedState(
@@ -119,9 +120,12 @@ export function getClearedState(
   networkId: number | null,
   target: string,
 ): ClearedState {
-  const row = getClearedStmt.get(userId, networkId, target) as
-    | { clearedBeforeId: number | null; clearedAt: string | null }
-    | undefined;
+  const buffer = resolveBuffer(userId, networkId, target);
+  const row = buffer
+    ? (getClearedStmt.get(userId, buffer.id) as
+        | { clearedBeforeId: number | null; clearedAt: string | null }
+        | undefined)
+    : undefined;
   if (!row || !row.clearedBeforeId) return { clearedBeforeId: 0, clearedAt: null };
   return { clearedBeforeId: row.clearedBeforeId, clearedAt: row.clearedAt };
 }
@@ -137,12 +141,14 @@ export function setClearedState(
   boundaryId: number,
   clearedAt: string | null,
 ): ClearedState {
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return { clearedBeforeId: 0, clearedAt: null };
   const id = Number(boundaryId);
   if (!Number.isFinite(id) || id <= 0) {
-    upsertClearedStmt.run(userId, networkId, target, null, null);
+    upsertClearedStmt.run(userId, buffer.id, null, null);
     return { clearedBeforeId: 0, clearedAt: null };
   }
-  upsertClearedStmt.run(userId, networkId, target, id, clearedAt);
+  upsertClearedStmt.run(userId, buffer.id, id, clearedAt);
   return getClearedState(userId, networkId, target);
 }
 
@@ -152,7 +158,7 @@ export function setClearedState(
 export function listClearedStateForUser(userId: number): Record<string, ClearedState> {
   const out: Record<string, ClearedState> = {};
   for (const row of listClearedStmt.all(userId) as Array<{
-    networkId: number;
+    networkId: number | null;
     target: string;
     clearedBeforeId: number;
     clearedAt: string | null;

--- a/server/db/buffersMigration.test.ts
+++ b/server/db/buffersMigration.test.ts
@@ -161,10 +161,14 @@ describe('schemaVersion 16 — buffers backfill', () => {
       )
       .all() as Array<{ target: string }>;
     expect(msgTargets.map((r) => r.target)).toEqual(['#Chatty']);
-    // …and moved the stray-cased read pointer with it, so the exact-target
-    // read-state lookup still resolves against the registry's canonical name.
+    // …and moved the stray-cased read pointer with it — post-v18 the pointer
+    // is id-keyed, so it resolves through the registry row the fold chose.
     const reads = db
-      .prepare(`SELECT target, last_read_message_id AS lr FROM buffer_reads WHERE network_id = 10`)
+      .prepare(
+        `SELECT b.target AS target, r.last_read_message_id AS lr
+         FROM buffer_reads r JOIN buffers b ON b.id = r.buffer_id
+         WHERE b.network_id = 10`,
+      )
       .all() as Array<{ target: string; lr: number }>;
     expect(reads).toEqual([{ target: '#Chatty', lr: 2 }]);
   });

--- a/server/db/channelNotify.test.ts
+++ b/server/db/channelNotify.test.ts
@@ -14,8 +14,10 @@ let createNetwork: typeof import('./networks.js').createNetwork;
 let getChannelNotifyAlways: typeof import('./channelNotify.js').getChannelNotifyAlways;
 let listChannelNotifyForUser: typeof import('./channelNotify.js').listChannelNotifyForUser;
 let setChannelNotifyAlways: typeof import('./channelNotify.js').setChannelNotifyAlways;
+let ensureBuffer: typeof import('./buffers.js').ensureExists;
 
 beforeAll(async () => {
+  ({ ensureExists: ensureBuffer } = await import('./buffers.js'));
   ({ createUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
   ({ getChannelNotifyAlways, listChannelNotifyForUser, setChannelNotifyAlways } =
@@ -27,13 +29,16 @@ afterAll(() => {
 });
 
 function mkNetwork(userId: number, name: string) {
-  return createNetwork(userId, {
+  const net = createNetwork(userId, {
     name,
     host: 'irc.libera.chat',
     port: 6697,
     tls: true,
     nick: name,
   });
+  // buffer_id-keyed since schema 18 — mint the targets this file writes to.
+  for (const t of ['#chan', '#lurker', '#one', '#two', '#unset']) ensureBuffer(userId, net!.id, t);
+  return net;
 }
 
 describe('channelNotify', () => {

--- a/server/db/channelNotify.ts
+++ b/server/db/channelNotify.ts
@@ -2,46 +2,48 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { resolveBuffer } from './bufferResolve.js';
 
 /** Per-target settings shape returned to callers. */
 export interface ChannelNotifyShape {
   notifyAlways: boolean;
 }
 
-// Per-(user, network, channel) override. One flag lives here now:
+// Per-(user, buffer) override, keyed (user_id, buffer_id) since schema 18.
+// One flag lives here:
 //   notify_always — treat every message in the channel like a notification
 //                   trigger for push/toast (no visual highlight).
 // The old display-only `muted` flag was folded into the ignore engine as a
-// NOUNREAD/NONOTIFY rule (issue #359, so mute now also silences notifications).
-// The `muted` column remains in the table (always written 0) for backward-compat
-// with older images, but is no longer read or written meaningfully — the boot
-// migration in index.ts converts any lingering muted=1 rows into ignore rules.
+// NOUNREAD/NONOTIFY rule (issue #359) and its dead column died in the v18
+// rebuild.
 
 const getStmt = db.prepare(`
   SELECT notify_always FROM channel_notify_settings
-  WHERE user_id = ? AND network_id = ? AND target = ?
+  WHERE user_id = ? AND buffer_id = ?
 `);
 
 const listForUserStmt = db.prepare(`
-  SELECT network_id AS networkId, target, notify_always AS notifyAlways
-  FROM channel_notify_settings
-  WHERE user_id = ? AND notify_always = 1
+  SELECT b.network_id AS networkId, b.target AS target, c.notify_always AS notifyAlways
+  FROM channel_notify_settings c JOIN buffers b ON b.id = c.buffer_id
+  WHERE c.user_id = ? AND c.notify_always = 1
 `);
 
 const upsertStmt = db.prepare(`
-  INSERT INTO channel_notify_settings (user_id, network_id, target, notify_always, muted, updated_at)
-  VALUES (?, ?, ?, 1, 0, datetime('now'))
-  ON CONFLICT(user_id, network_id, target)
+  INSERT INTO channel_notify_settings (user_id, buffer_id, notify_always, updated_at)
+  VALUES (?, ?, 1, datetime('now'))
+  ON CONFLICT(user_id, buffer_id)
   DO UPDATE SET notify_always = 1, updated_at = excluded.updated_at
 `);
 
 const deleteStmt = db.prepare(`
   DELETE FROM channel_notify_settings
-  WHERE user_id = ? AND network_id = ? AND target = ?
+  WHERE user_id = ? AND buffer_id = ?
 `);
 
 export function getChannelNotifyAlways(userId: number, networkId: number, target: string): boolean {
-  const row = getStmt.get(userId, networkId, target) as { notify_always: number } | undefined;
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return false;
+  const row = getStmt.get(userId, buffer.id) as { notify_always: number } | undefined;
   return !!(row && row.notify_always);
 }
 
@@ -80,9 +82,11 @@ export function setChannelNotifyAlways(
   target: string,
   notifyAlways: boolean,
 ): void {
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return;
   if (notifyAlways) {
-    upsertStmt.run(userId, networkId, target);
+    upsertStmt.run(userId, buffer.id);
   } else {
-    deleteStmt.run(userId, networkId, target);
+    deleteStmt.run(userId, buffer.id);
   }
 }

--- a/server/db/drafts.test.ts
+++ b/server/db/drafts.test.ts
@@ -18,8 +18,10 @@ let createNetwork: typeof import('./networks.js').createNetwork;
 let upsertDraft: typeof import('./drafts.js').upsertDraft;
 let clearDraft: typeof import('./drafts.js').clearDraft;
 let listForUser: typeof import('./drafts.js').listForUser;
+let ensureBuffer: typeof import('./buffers.js').ensureExists;
 
 beforeAll(async () => {
+  ({ ensureExists: ensureBuffer } = await import('./buffers.js'));
   ({ createUser, deleteUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
   ({ upsertDraft, clearDraft, listForUser } = await import('./drafts.js'));
@@ -30,13 +32,16 @@ afterAll(() => {
 });
 
 function mkNetwork(userId: number, name: string) {
-  return createNetwork(userId, {
+  const net = createNetwork(userId, {
     name,
     host: 'irc.libera.chat',
     port: 6697,
     tls: true,
     nick: name,
   });
+  // buffer_id-keyed since schema 18 — mint the targets this file writes to.
+  for (const t of ['#a', '#b', '#meta']) ensureBuffer(userId, net!.id, t);
+  return net;
 }
 
 describe('drafts', () => {

--- a/server/db/drafts.ts
+++ b/server/db/drafts.ts
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { resolveBuffer } from './bufferResolve.js';
+
+// Keyed (user_id, buffer_id) since schema 18; the snapshot joins back through
+// `buffers` so the wire shape (networkId + target per draft) is unchanged.
 
 /** A draft row returned to callers (camelCase aliased columns). */
 export interface DraftRow {
@@ -12,30 +16,35 @@ export interface DraftRow {
 }
 
 const upsertStmt = db.prepare(`
-  INSERT INTO user_drafts (user_id, network_id, target, body, updated_at)
-  VALUES (?, ?, ?, ?, datetime('now'))
-  ON CONFLICT (user_id, network_id, target) DO UPDATE SET
+  INSERT INTO user_drafts (user_id, buffer_id, body, updated_at)
+  VALUES (?, ?, ?, datetime('now'))
+  ON CONFLICT (user_id, buffer_id) DO UPDATE SET
     body = excluded.body,
     updated_at = excluded.updated_at
 `);
 
 const clearStmt = db.prepare(`
   DELETE FROM user_drafts
-   WHERE user_id = ? AND network_id = ? AND target = ?
+   WHERE user_id = ? AND buffer_id = ?
 `);
 
 const listStmt = db.prepare(`
-  SELECT network_id AS networkId, target, body, updated_at AS updatedAt
-    FROM user_drafts
-   WHERE user_id = ?
+  SELECT b.network_id AS networkId, b.target AS target, d.body AS body,
+         d.updated_at AS updatedAt
+    FROM user_drafts d JOIN buffers b ON b.id = d.buffer_id
+   WHERE d.user_id = ?
 `);
 
 export function upsertDraft(userId: number, networkId: number, target: string, body: string): void {
-  upsertStmt.run(userId, networkId, target, body);
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return;
+  upsertStmt.run(userId, buffer.id, body);
 }
 
 export function clearDraft(userId: number, networkId: number, target: string): void {
-  clearStmt.run(userId, networkId, target);
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return;
+  clearStmt.run(userId, buffer.id);
 }
 
 // Returns every draft for this user as plain objects — the snapshot ships

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -17,7 +17,12 @@
 // EXPORT_FORMAT_VERSION when changing the file layout in a way that older
 // importers can't tolerate.
 
-export const EXPORT_FORMAT_VERSION = 1;
+// v2 (schema 18): the per-buffer view-state tables carry `buffer_id` (rekeyed
+// through the archive's own `buffers` rows) instead of (network_id, target),
+// and channel_notify_settings dropped its dead `muted` column. v1 archives
+// still import — the importer derives buffer_id from their name columns — but
+// a v1 SERVER rejects a v2 archive as format_too_new, deliberately.
+export const EXPORT_FORMAT_VERSION = 2;
 
 // `encryptedColumns` (declared per-table below) lists columns holding secrets
 // that are encrypted at rest on hosted cells (see server/utils/secretCrypto.ts).
@@ -219,7 +224,7 @@ export const EXPORT_TABLES = Object.freeze({
     // (last_read_message_id is NOT NULL — no anchor, no row).
     fkRekey: {
       user_id: 'users',
-      network_id: 'networks',
+      buffer_id: 'buffers',
       last_read_message_id: 'messages',
       cleared_before_message_id: 'messages',
     },
@@ -230,8 +235,7 @@ export const EXPORT_TABLES = Object.freeze({
     fkRekeyNullable: ['cleared_before_message_id'],
     columns: [
       'user_id',
-      'network_id',
-      'target',
+      'buffer_id',
       'last_read_message_id',
       'updated_at',
       'cleared_before_message_id',
@@ -289,8 +293,8 @@ export const EXPORT_TABLES = Object.freeze({
     scope: 'user_id',
     section: 'data',
     pk: 'id',
-    fkRekey: { user_id: 'users', network_id: 'networks' },
-    columns: ['id', 'user_id', 'network_id', 'target', 'text', 'created_at'],
+    fkRekey: { user_id: 'users', buffer_id: 'buffers' },
+    columns: ['id', 'user_id', 'buffer_id', 'text', 'created_at'],
   },
 
   upload_history: {
@@ -350,32 +354,32 @@ export const EXPORT_TABLES = Object.freeze({
     mode: 'export',
     scope: 'user_id',
     section: 'data',
-    fkRekey: { user_id: 'users', network_id: 'networks' },
-    columns: ['user_id', 'network_id', 'target', 'position', 'created_at'],
+    fkRekey: { user_id: 'users', buffer_id: 'buffers', network_id: 'networks' },
+    columns: ['user_id', 'buffer_id', 'network_id', 'position', 'created_at'],
   },
 
   nicklist_collapsed: {
     mode: 'export',
     scope: 'user_id',
     section: 'data',
-    fkRekey: { user_id: 'users', network_id: 'networks' },
-    columns: ['user_id', 'network_id', 'target', 'collapsed'],
+    fkRekey: { user_id: 'users', buffer_id: 'buffers' },
+    columns: ['user_id', 'buffer_id', 'collapsed'],
   },
 
   channel_notify_settings: {
     mode: 'export',
     scope: 'user_id',
     section: 'data',
-    fkRekey: { user_id: 'users', network_id: 'networks' },
-    columns: ['user_id', 'network_id', 'target', 'notify_always', 'muted', 'updated_at'],
+    fkRekey: { user_id: 'users', buffer_id: 'buffers' },
+    columns: ['user_id', 'buffer_id', 'notify_always', 'updated_at'],
   },
 
   user_drafts: {
     mode: 'export',
     scope: 'user_id',
     section: 'data',
-    fkRekey: { user_id: 'users', network_id: 'networks' },
-    columns: ['user_id', 'network_id', 'target', 'body', 'updated_at'],
+    fkRekey: { user_id: 'users', buffer_id: 'buffers' },
+    columns: ['user_id', 'buffer_id', 'body', 'updated_at'],
   },
 
   ignored_masks: {

--- a/server/db/foldBufferCase.test.ts
+++ b/server/db/foldBufferCase.test.ts
@@ -150,21 +150,30 @@ describe('foldBufferCase', () => {
     expect(targetCounts(net)).toEqual({ '#CoolChan': 3, Bob: 2, bob: 1 });
   });
 
-  it('merges buffer_reads keeping the furthest read pointer', () => {
+  it('skips buffer_reads, where a case fork is unrepresentable (buffer_id key)', () => {
+    // Pre-v18 this test asserted the fold's name-keyed read-pointer merge.
+    // Read state is id-keyed now: both casings resolve to one buffer at WRITE
+    // time (the MAX clamp merges them on the spot), and the fold's
+    // buffer_reads section is shape-gated off — the fork it repaired cannot
+    // exist. The migration-path merge is covered by the v18 rebuild tests.
     const net = freshNetwork();
     seed(net, '#Chan', 2);
-    seed(net, '#chan', 1); // stray, lower message count -> not canonical
+    seed(net, '#chan', 1); // stray casing, same buffer
     setReadState(userId, net, '#Chan', 5);
-    setReadState(userId, net, '#chan', 10); // further read pointer on the stray case
+    setReadState(userId, net, '#chan', 10); // same buffer — clamps to MAX
 
-    foldBufferCase(db, { scope: 'all' });
+    foldBufferCase(db, { scope: 'all' }); // must not error on the id-keyed table
 
     const reads = db
-      .prepare(`SELECT target, last_read_message_id AS lr FROM buffer_reads WHERE network_id = ?`)
+      .prepare(
+        `SELECT b.target AS target, r.last_read_message_id AS lr
+         FROM buffer_reads r JOIN buffers b ON b.id = r.buffer_id
+         WHERE b.network_id = ?`,
+      )
       .all(net) as { target: string; lr: number }[];
     expect(reads).toHaveLength(1);
     expect(reads[0].target).toBe('#Chan');
-    expect(reads[0].lr).toBe(10); // MAX of the two merged pointers
+    expect(reads[0].lr).toBe(10);
   });
 
   it('still folds with report:false (the migration path), returning an empty report', () => {

--- a/server/db/foldBufferCase.ts
+++ b/server/db/foldBufferCase.ts
@@ -72,6 +72,14 @@ export interface FoldReport {
 // Tables keyed by a per-buffer `target` column (channels live in `channels.name`,
 // handled separately). Order matters only for readability; each fold is
 // independent.
+//
+// The fold runs against whatever SHAPE the given db actually has: it's called
+// from the schemaVersion<9 and <16 blocks (every table below still name-keyed
+// there), but the v18 rebuild moves the view-state satellites onto buffer_id
+// keys — on a migrated database only `messages.target` (an insert-time log)
+// and any lingering legacy tables remain foldable, and the per-table guards
+// below skip the rest. Case forks in the id-keyed world are two `buffers`
+// rows, which merge via the rename machinery, not this fold.
 const TARGET_TABLES = [
   'messages',
   'input_history',
@@ -111,6 +119,19 @@ export function foldBufferCase(
         WHERE c.network_id = ${t}.network_id AND c.lkey = lower(${t}.target)
           AND c.canon <> ${t}.target)`;
 
+  // A table participates only while it exists AND still carries a `target`
+  // column (a missing table's PRAGMA returns no rows, so both collapse to one
+  // check). See the TARGET_TABLES comment — the v18 rebuild retires the
+  // satellites' name columns.
+  const hasTargetColumn = (t: string): boolean =>
+    (db.prepare(`PRAGMA table_info(${t})`).all() as Array<{ name: string }>).some(
+      (c) => c.name === 'target',
+    );
+  const foldable = TARGET_TABLES.filter(hasTargetColumn);
+  const hasChannelsTable = !!db
+    .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'channels'`)
+    .get();
+
   const work = (): FoldReport => {
     // Connection-local temp table; drop defensively in case a prior run in this
     // same connection left one behind.
@@ -134,22 +155,24 @@ export function foldBufferCase(
     const rowsAffected: Record<string, number> = {};
     let forks: FoldGroup[] = [];
     if (wantReport) {
-      for (const t of TARGET_TABLES) {
+      for (const t of foldable) {
         rowsAffected[t] = (
           db.prepare(`SELECT COUNT(*) AS n FROM ${t} WHERE ${needsFold(t)}`).get() as { n: number }
         ).n;
       }
-      rowsAffected['channels'] = (
-        db
-          .prepare(
-            `SELECT COUNT(*) AS n FROM channels
+      if (hasChannelsTable) {
+        rowsAffected['channels'] = (
+          db
+            .prepare(
+              `SELECT COUNT(*) AS n FROM channels
                WHERE ${pred('name')} AND EXISTS (
                  SELECT 1 FROM _buf_canon c
                  WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
                    AND c.canon <> channels.name)`,
-          )
-          .get() as { n: number }
-      ).n;
+            )
+            .get() as { n: number }
+        ).n;
+      }
 
       const variantRows = db
         .prepare(
@@ -190,7 +213,9 @@ export function foldBufferCase(
     if (!dryRun) {
       // id-keyed (target not unique) — straight rewrite. messages_fts only indexes
       // text, so the AFTER UPDATE trigger reindexes identical text (harmless).
-      for (const t of ['messages', 'input_history']) {
+      for (const t of ['messages', 'input_history'].filter((t) =>
+        foldable.includes(t as (typeof TARGET_TABLES)[number]),
+      )) {
         db.exec(`UPDATE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
       }
 
@@ -199,7 +224,8 @@ export function foldBufferCase(
       // drop the off-case variant. Carrying `key` here is essential — without it
       // the merge would strip the channel key off a case-forked keyed channel
       // and it would fail to auto-rejoin after the next reconnect.
-      db.exec(`
+      if (hasChannelsTable) {
+        db.exec(`
         INSERT INTO channels (network_id, name, joined, created_at, key)
           SELECT ch.network_id, c.canon, ch.joined, ch.created_at, ch.key
           FROM channels ch JOIN _buf_canon c
@@ -210,16 +236,18 @@ export function foldBufferCase(
           created_at = MIN(channels.created_at, excluded.created_at),
           key = COALESCE(channels.key, excluded.key)
       `);
-      db.exec(`
+        db.exec(`
         DELETE FROM channels WHERE ${pred('name')} AND EXISTS (
           SELECT 1 FROM _buf_canon c
           WHERE c.network_id = channels.network_id AND c.lkey = lower(channels.name)
             AND c.canon <> channels.name)
       `);
+      }
 
       // buffer_reads: composite PK. Merge keeping the furthest read pointer and any
       // clear marker, then drop the variant so nothing resurfaces as unread.
-      db.exec(`
+      if (foldable.includes('buffer_reads')) {
+        db.exec(`
         INSERT INTO buffer_reads
           (user_id, network_id, target, last_read_message_id, updated_at,
            cleared_before_message_id, cleared_at)
@@ -243,11 +271,14 @@ export function foldBufferCase(
             THEN excluded.cleared_at ELSE buffer_reads.cleared_at END,
           updated_at = MAX(buffer_reads.updated_at, excluded.updated_at)
       `);
-      db.exec(`DELETE FROM buffer_reads WHERE ${needsFold('buffer_reads')}`);
+        db.exec(`DELETE FROM buffer_reads WHERE ${needsFold('buffer_reads')}`);
+      }
 
       // closed_buffers: a stray-cased row was the junk buffer the user closed; the
       // canonical buffer's own open/closed state wins, so drop the off-case rows.
-      db.exec(`DELETE FROM closed_buffers WHERE ${needsFold('closed_buffers')}`);
+      if (foldable.includes('closed_buffers')) {
+        db.exec(`DELETE FROM closed_buffers WHERE ${needsFold('closed_buffers')}`);
+      }
 
       // Remaining per-(user, network, target) state: move to canon, or drop if a
       // canon row already exists (its state wins).
@@ -256,14 +287,15 @@ export function foldBufferCase(
         'nicklist_collapsed',
         'channel_notify_settings',
         'user_drafts',
-      ]) {
+      ].filter((t) => foldable.includes(t as (typeof TARGET_TABLES)[number]))) {
         db.exec(`UPDATE OR IGNORE ${t} SET target = ${canonExpr(t)} WHERE ${needsFold(t)}`);
         db.exec(`DELETE FROM ${t} WHERE ${needsFold(t)}`);
       }
 
       // Keep pin positions dense per (user, network): a dropped duplicate pin can
       // leave a gap, and reorderPins assumes 0..n-1 (same fix as schemaVersion 7).
-      db.exec(`
+      if (foldable.includes('pinned_buffers')) {
+        db.exec(`
         WITH renum AS (
           SELECT user_id, network_id, target,
                  ROW_NUMBER() OVER (
@@ -278,6 +310,7 @@ export function foldBufferCase(
             AND renum.target = pinned_buffers.target
         )
       `);
+      }
     }
 
     db.exec(`DROP TABLE _buf_canon`);

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -8,7 +8,13 @@ import path from 'path';
 import fs from 'fs';
 import { isNodeMode } from '../utils/edition.js';
 import { foldBufferCase } from './foldBufferCase.js';
-import { normalizeMessagesBufferIds, messagesBackfillDone } from './normalizeBuffers.js';
+import {
+  normalizeMessagesBufferIds,
+  messagesBackfillDone,
+  mintSentinelBuffers,
+  mintOrphanBuffersFromSatellites,
+  rebuildSatellitesToBufferId,
+} from './normalizeBuffers.js';
 import {
   seedUploaderConfig,
   reconcileBuiltInUploaders,
@@ -156,7 +162,6 @@ function migrate() {
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
     );
-    CREATE INDEX IF NOT EXISTS idx_buffer_reads_user ON buffer_reads(user_id);
 
     -- User-level self-presence state. /away applies across every IRC connection
     -- the user has, so the truth lives once per user. The completed-pair shape
@@ -459,7 +464,6 @@ function migrate() {
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
     );
-    CREATE INDEX IF NOT EXISTS idx_user_drafts_user ON user_drafts(user_id);
 
     -- Per-user ignore list, irssi-style (issue #301, scoping #350). network_id
     -- NULL = a global rule that applies on every network (the default); a real
@@ -1202,7 +1206,7 @@ ensureColumn('push_subscriptions', 'transport', "TEXT NOT NULL DEFAULT 'webpush'
 // Schema versioning lets us retire one-shot recovery blocks once every
 // production DB has run through them. Bump SCHEMA_VERSION when adding a new
 // recovery block, and delete blocks for versions far enough in the past.
-const SCHEMA_VERSION = 17;
+const SCHEMA_VERSION = 18;
 const schemaVersionRow = db
   .prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`)
   .get() as { value: string } | undefined;
@@ -1684,9 +1688,11 @@ if (schemaVersion < 11) {
 // Issue #359: fold the old display-only per-channel `muted` flag into the ignore
 // engine (see migrateMutedFold.ts). Runs after the ignored_masks rebuild above so
 // the table is in its final shape. Best-effort — a failure leaves muted=1 rows to
-// retry on the next boot.
+// retry on the next boot. Gated on the column: the v18 satellite rebuild (below)
+// drops `muted` outright — any lingering muted=1 rows were folded on an earlier
+// boot by this very call, which always precedes it.
 try {
-  foldMutedIntoIgnoreRules(db);
+  if (columnExists('channel_notify_settings', 'muted')) foldMutedIntoIgnoreRules(db);
 } catch (err) {
   // Log rather than swallow: the self-gating retry masks a deterministic bug as
   // a transient failure, so surface it or a broken fold vanishes silently.
@@ -2058,6 +2064,41 @@ if (schemaVersion < 16 && tableExists('channels')) {
   }
 }
 
+// --- v18: satellite tables onto buffer_id (#695) -----------------------------
+//
+// The six per-buffer view-state tables (read pointers, input history, pins,
+// nicklist toggles, notify flags, drafts) rebuild onto (user_id, buffer_id)
+// keys and lose their name columns entirely; see normalizeBuffers.ts for the
+// bodies and the case-twin merge policies. The e2e tables deliberately do NOT
+// join them — their `channel` is an IRC-side crypto-context string (DM
+// pseudochannels, peer-supplied names), not a buffer reference; see
+// bufferKeyedTables.ts 'wire-context'.
+//
+// Version + shape gated: the block re-runs harmlessly after a kill between
+// the transaction and the version bump (columnExists turns it into a no-op),
+// and the whole rebuild is ONE immediate transaction — these tables are
+// thousands of rows, so atomic-and-quick, with the write lock taken up front
+// (the Litestream deferred-BEGIN snapshot race, see the v16 block).
+if (schemaVersion < 18 && columnExists('buffer_reads', 'target')) {
+  mintSentinelBuffers(db);
+  mintOrphanBuffersFromSatellites(db, [
+    'buffer_reads',
+    'input_history',
+    'pinned_buffers',
+    'nicklist_collapsed',
+    'channel_notify_settings',
+    'user_drafts',
+  ]);
+  const rebuild = db.transaction(() => rebuildSatellitesToBufferId(db));
+  const prevFk = db.pragma('foreign_keys', { simple: true });
+  db.pragma('foreign_keys = OFF');
+  try {
+    rebuild.immediate();
+  } finally {
+    db.pragma(`foreign_keys = ${prevFk ? 'ON' : 'OFF'}`);
+  }
+}
+
 // Issue #510: seed the uploader data model — instance x0/catbox rows +
 // per-user conversion of existing uploads.* settings (self-host), or a single
 // locked hosted uploader from env + allow_user_defined=0 (hosted). Behavior is
@@ -2154,14 +2195,11 @@ db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_auto_rule_unique
 db.exec(`CREATE INDEX IF NOT EXISTS idx_ignored_masks_user_net
          ON ignored_masks(user_id, network_id)`);
 
-// #355 buffer_reads uniqueness: coalesced so a NULL network_id (the app-scoped
-// system buffer) dedupes on upsert; a plain composite index would treat NULL as
-// distinct. Created here (not in migrate()) so it survives the schemaVersion < 12
-// rebuild and applies to fresh installs alike. idx_buffer_reads_user is also
-// recreated since the rebuild drops it.
-db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_buffer_reads_key
-         ON buffer_reads(user_id, IFNULL(network_id, 0), target)`);
-db.exec(`CREATE INDEX IF NOT EXISTS idx_buffer_reads_user ON buffer_reads(user_id)`);
+// (buffer_reads carries no extra indexes since the v18 rebuild: its
+// (user_id, buffer_id) PRIMARY KEY serves both the point lookups and the
+// per-user scans that idx_buffer_reads_key / idx_buffer_reads_user used to —
+// the coalesced-IFNULL uniqueness dance existed only because the name-keyed
+// composite treated a NULL network_id as distinct.)
 
 // #490: the push_subscriptions rebuild drops this with the table, and migrate()'s
 // CREATE already ran before it — so recreate here for both fresh and rebuilt

--- a/server/db/inputHistory.test.ts
+++ b/server/db/inputHistory.test.ts
@@ -21,6 +21,9 @@ beforeAll(async () => {
   inputHistory = await import('./inputHistory.js');
   user = createUser('ih-alice');
   net = createNetwork(user.id, { name: 'libera', host: 'h', port: 6697, tls: true, nick: 'a' });
+  // buffer_id-keyed since schema 18 — mint the targets the tests write to.
+  const { ensureExists } = await import('./buffers.js');
+  for (const t of ['#a', '#b', '#chat', '#wall']) ensureExists(user.id, net!.id, t);
 });
 
 afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));

--- a/server/db/inputHistory.ts
+++ b/server/db/inputHistory.ts
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
-import { resolveBufferIdByNetwork } from './bufferResolve.js';
+import { resolveBuffer } from './bufferResolve.js';
 
 // Keyed (user_id, buffer_id) since schema 18. Signatures unchanged — callers
-// hold names; resolution happens here. A miss on add is a silent drop (input
-// history for a buffer that doesn't exist has nowhere to live and nothing to
-// replay it), matching the old behavior of rows nothing would ever read.
+// hold names; resolution happens here, scoped to the CALLER's userId (not
+// derived from the network) so a mismatched (userId, networkId) pair can
+// never write rows referencing another user's buffers — the satellite FK
+// points at buffers(id) alone, so ownership is this layer's job. A miss on
+// add is a silent drop (input history for a buffer that doesn't exist has
+// nowhere to live and nothing to replay it).
 
 const insertStmt = db.prepare(`
   INSERT INTO input_history (user_id, buffer_id, text)
@@ -22,9 +25,9 @@ const listRecentStmt = db.prepare(`
 `);
 
 export function addEntry(userId: number, networkId: number, target: string, text: string): void {
-  const bufferId = resolveBufferIdByNetwork(networkId, target);
-  if (bufferId === undefined) return;
-  insertStmt.run(userId, bufferId, text);
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return;
+  insertStmt.run(userId, buffer.id, text);
 }
 
 // Returns the `limit` most recent entries, oldest-first — the order the client
@@ -36,9 +39,9 @@ export function listRecent(
   target: string,
   limit = 200,
 ): string[] {
-  const bufferId = resolveBufferIdByNetwork(networkId, target);
-  if (bufferId === undefined) return [];
-  return (listRecentStmt.all(userId, bufferId, limit) as Array<{ text: string }>)
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return [];
+  return (listRecentStmt.all(userId, buffer.id, limit) as Array<{ text: string }>)
     .map((row) => row.text)
     .toReversed();
 }

--- a/server/db/inputHistory.ts
+++ b/server/db/inputHistory.ts
@@ -2,21 +2,29 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { resolveBufferIdByNetwork } from './bufferResolve.js';
+
+// Keyed (user_id, buffer_id) since schema 18. Signatures unchanged — callers
+// hold names; resolution happens here. A miss on add is a silent drop (input
+// history for a buffer that doesn't exist has nowhere to live and nothing to
+// replay it), matching the old behavior of rows nothing would ever read.
 
 const insertStmt = db.prepare(`
-  INSERT INTO input_history (user_id, network_id, target, text)
-  VALUES (?, ?, ?, ?)
+  INSERT INTO input_history (user_id, buffer_id, text)
+  VALUES (?, ?, ?)
 `);
 
 const listRecentStmt = db.prepare(`
   SELECT text FROM input_history
-  WHERE user_id = ? AND network_id = ? AND target = ?
+  WHERE user_id = ? AND buffer_id = ?
   ORDER BY id DESC
   LIMIT ?
 `);
 
 export function addEntry(userId: number, networkId: number, target: string, text: string): void {
-  insertStmt.run(userId, networkId, target, text);
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return;
+  insertStmt.run(userId, bufferId, text);
 }
 
 // Returns the `limit` most recent entries, oldest-first — the order the client
@@ -28,7 +36,9 @@ export function listRecent(
   target: string,
   limit = 200,
 ): string[] {
-  return (listRecentStmt.all(userId, networkId, target, limit) as Array<{ text: string }>)
+  const bufferId = resolveBufferIdByNetwork(networkId, target);
+  if (bufferId === undefined) return [];
+  return (listRecentStmt.all(userId, bufferId, limit) as Array<{ text: string }>)
     .map((row) => row.text)
     .toReversed();
 }

--- a/server/db/migrateMutedFold.test.ts
+++ b/server/db/migrateMutedFold.test.ts
@@ -1,42 +1,54 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+// foldMutedIntoIgnoreRules runs only on databases that still carry the
+// deprecated channel_notify_settings.muted column — its index.ts call is gated
+// on that column existing, which is only true BEFORE the v18 satellite rebuild
+// reshapes the table. So this test builds the legacy-shape tables in a scratch
+// database (the function takes its db handle) rather than running against the
+// live migrated schema, where the column is unrepresentable.
+
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import type BetterSqlite3 from 'better-sqlite3';
+import Database from 'better-sqlite3';
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-'));
-process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+import { foldMutedIntoIgnoreRules } from './migrateMutedFold.js';
 
-let db: BetterSqlite3.Database;
-let createUser: typeof import('./users.js').createUser;
-let createNetwork: typeof import('./networks.js').createNetwork;
-let listRules: typeof import('./ignoredMasks.js').listRules;
-let foldMutedIntoIgnoreRules: typeof import('./migrateMutedFold.js').foldMutedIntoIgnoreRules;
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-mutedfold-'));
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
-beforeAll(async () => {
-  db = (await import('./index.js')).default;
-  ({ createUser } = await import('./users.js'));
-  ({ createNetwork } = await import('./networks.js'));
-  ({ listRules } = await import('./ignoredMasks.js'));
-  ({ foldMutedIntoIgnoreRules } = await import('./migrateMutedFold.js'));
+let db: Database.Database;
+let n = 0;
+
+beforeEach(() => {
+  db = new Database(path.join(tmpDir, `t${n++}.db`));
+  db.exec(`
+    CREATE TABLE channel_notify_settings (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      target TEXT NOT NULL,
+      notify_always INTEGER NOT NULL DEFAULT 0,
+      muted INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, network_id, target)
+    );
+    CREATE TABLE ignored_masks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      network_id INTEGER,
+      mask TEXT COLLATE NOCASE,
+      channels TEXT,
+      pattern TEXT,
+      pattern_kind TEXT NOT NULL DEFAULT 'substr',
+      levels TEXT NOT NULL DEFAULT 'ALL',
+      is_except INTEGER NOT NULL DEFAULT 0,
+      expires_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+    );
+  `);
 });
-
-afterAll(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
-});
-
-function mkNetwork(userId: number, name: string) {
-  return createNetwork(userId, {
-    name,
-    host: 'irc.libera.chat',
-    port: 6697,
-    tls: true,
-    nick: name,
-  });
-}
 
 function setRawMuted(userId: number, networkId: number, target: string, notifyAlways: number) {
   db.prepare(
@@ -55,50 +67,44 @@ function mutedFlag(userId: number, networkId: number, target: string): number | 
   )?.muted;
 }
 
+function rules(userId: number, networkId: number): Array<{ channels: string; levels: string }> {
+  return db
+    .prepare(
+      `SELECT channels, levels FROM ignored_masks
+       WHERE user_id = ? AND network_id = ? AND mask IS NULL AND is_except = 0`,
+    )
+    .all(userId, networkId) as Array<{ channels: string; levels: string }>;
+}
+
 describe('foldMutedIntoIgnoreRules (issue #359 migration)', () => {
   it('converts a muted channel into a NOUNREAD+NONOTIFY ignore rule and drops the row', () => {
-    const u = createUser('mig-alice');
-    const net = mkNetwork(u.id, 'libera')!;
-    setRawMuted(u.id, net.id, '#Radio', 0); // mixed case, notify_always off
+    setRawMuted(1, 10, '#Radio', 0); // mixed case, notify_always off
 
     const converted = foldMutedIntoIgnoreRules(db);
     expect(converted).toBeGreaterThanOrEqual(1);
 
-    const rules = listRules({ userId: u.id, networkId: net.id });
-    const muteRule = rules.find((r) => r.channels?.[0] === '#radio');
+    const muteRule = rules(1, 10).find((r) => r.channels === '#radio');
     expect(muteRule).toBeTruthy();
-    expect(muteRule!.mask).toBeNull();
-    expect(muteRule!.isExcept).toBe(false);
-    expect([...muteRule!.levels].sort()).toEqual(['NONOTIFY', 'NOUNREAD']);
+    expect(muteRule!.levels.split(',').toSorted()).toEqual(['NONOTIFY', 'NOUNREAD']);
     // notify_always was off, so the now-empty settings row is gone entirely.
-    expect(mutedFlag(u.id, net.id, '#Radio')).toBeUndefined();
+    expect(mutedFlag(1, 10, '#Radio')).toBeUndefined();
   });
 
   it('preserves notify_always: clears muted, keeps the row, creates NO suppressor rule', () => {
-    const u = createUser('mig-bob');
-    const net = mkNetwork(u.id, 'libera')!;
-    setRawMuted(u.id, net.id, '#keep', 1); // notify_always on
+    setRawMuted(1, 10, '#keep', 1); // notify_always on
 
     foldMutedIntoIgnoreRules(db);
-    expect(mutedFlag(u.id, net.id, '#keep')).toBe(0); // row kept, muted cleared
+    expect(mutedFlag(1, 10, '#keep')).toBe(0); // row kept, muted cleared
     // notify_always is the explicit opt-in to push; muting it would contradict it,
     // so no NONOTIFY/NOUNREAD rule is created for this channel.
-    const muteRule = listRules({ userId: u.id, networkId: net.id }).find(
-      (r) => r.channels?.[0] === '#keep',
-    );
-    expect(muteRule).toBeUndefined();
+    expect(rules(1, 10).find((r) => r.channels === '#keep')).toBeUndefined();
   });
 
   it('is idempotent — a second run finds nothing and adds no duplicate rule', () => {
-    const u = createUser('mig-carol');
-    const net = mkNetwork(u.id, 'libera')!;
-    setRawMuted(u.id, net.id, '#once', 0);
+    setRawMuted(1, 10, '#once', 0);
 
     expect(foldMutedIntoIgnoreRules(db)).toBeGreaterThanOrEqual(1);
     expect(foldMutedIntoIgnoreRules(db)).toBe(0); // nothing left to convert
-    const ruleCount = listRules({ userId: u.id, networkId: net.id }).filter(
-      (r) => r.channels?.[0] === '#once',
-    ).length;
-    expect(ruleCount).toBe(1);
+    expect(rules(1, 10).filter((r) => r.channels === '#once')).toHaveLength(1);
   });
 });

--- a/server/db/migrateMutedFold.test.ts
+++ b/server/db/migrateMutedFold.test.ts
@@ -8,7 +8,7 @@
 // database (the function takes its db handle) rather than running against the
 // live migrated schema, where the column is unrepresentable.
 
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -21,6 +21,8 @@ afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
 let db: Database.Database;
 let n = 0;
+
+afterEach(() => db.close());
 
 beforeEach(() => {
   db = new Database(path.join(tmpDir, `t${n++}.db`));

--- a/server/db/nicklistCollapsed.test.ts
+++ b/server/db/nicklistCollapsed.test.ts
@@ -17,8 +17,10 @@ let createNetwork: typeof import('./networks.js').createNetwork;
 let listCollapsedForUser: typeof import('./nicklistCollapsed.js').listCollapsedForUser;
 let listCollapsedForUserNetwork: typeof import('./nicklistCollapsed.js').listCollapsedForUserNetwork;
 let setNicklistCollapsed: typeof import('./nicklistCollapsed.js').setNicklistCollapsed;
+let ensureBuffer: typeof import('./buffers.js').ensureExists;
 
 beforeAll(async () => {
+  ({ ensureExists: ensureBuffer } = await import('./buffers.js'));
   ({ createUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
   ({ listCollapsedForUser, listCollapsedForUserNetwork, setNicklistCollapsed } =
@@ -30,13 +32,16 @@ afterAll(() => {
 });
 
 function mkNetwork(userId: number, name: string) {
-  return createNetwork(userId, {
+  const net = createNetwork(userId, {
     name,
     host: 'irc.libera.chat',
     port: 6697,
     tls: true,
     nick: name,
   });
+  // buffer_id-keyed since schema 18 — mint the targets this file writes to.
+  for (const t of ['#chan', '#one', '#three', '#two', '#vue']) ensureBuffer(userId, net!.id, t);
+  return net;
 }
 
 describe('nicklistCollapsed', () => {

--- a/server/db/nicklistCollapsed.ts
+++ b/server/db/nicklistCollapsed.ts
@@ -2,33 +2,29 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { resolveBuffer } from './bufferResolve.js';
 
-// Per-(user, network, channel) override for the desktop nicklist collapsed
-// state. Only explicitly-toggled channels have a row; everything else falls
-// back to the global look.layout.show_member_list default on the client.
-
-/** A row from the `nicklist_collapsed` table. */
-export interface NicklistCollapsed {
-  user_id: number;
-  network_id: number;
-  target: string;
-  collapsed: number;
-}
+// Per-(user, buffer) override for the desktop nicklist collapsed state,
+// keyed (user_id, buffer_id) since schema 18. Only explicitly-toggled
+// channels have a row; everything else falls back to the global
+// look.layout.show_member_list default on the client.
 
 const listForUserStmt = db.prepare(`
-  SELECT network_id AS networkId, target, collapsed FROM nicklist_collapsed
-  WHERE user_id = ?
+  SELECT b.network_id AS networkId, b.target AS target, n.collapsed AS collapsed
+  FROM nicklist_collapsed n JOIN buffers b ON b.id = n.buffer_id
+  WHERE n.user_id = ?
 `);
 
 const listForUserNetworkStmt = db.prepare(`
-  SELECT target, collapsed FROM nicklist_collapsed
-  WHERE user_id = ? AND network_id = ?
+  SELECT b.target AS target, n.collapsed AS collapsed
+  FROM nicklist_collapsed n JOIN buffers b ON b.id = n.buffer_id
+  WHERE n.user_id = ? AND b.network_id = ?
 `);
 
 const upsertStmt = db.prepare(`
-  INSERT INTO nicklist_collapsed (user_id, network_id, target, collapsed)
-  VALUES (?, ?, ?, ?)
-  ON CONFLICT(user_id, network_id, target)
+  INSERT INTO nicklist_collapsed (user_id, buffer_id, collapsed)
+  VALUES (?, ?, ?)
+  ON CONFLICT(user_id, buffer_id)
   DO UPDATE SET collapsed = excluded.collapsed
 `);
 
@@ -68,5 +64,7 @@ export function setNicklistCollapsed(
   target: string,
   collapsed: boolean | number,
 ): void {
-  upsertStmt.run(userId, networkId, target, collapsed ? 1 : 0);
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return;
+  upsertStmt.run(userId, buffer.id, collapsed ? 1 : 0);
 }

--- a/server/db/normalizeBuffers.test.ts
+++ b/server/db/normalizeBuffers.test.ts
@@ -12,7 +12,7 @@
 //   - the whole pass is idempotent once the done-flag is set,
 //   - the SQL-side fold is the JS rule (Unicode), not SQLite lower() (ASCII).
 
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -31,6 +31,8 @@ afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
 let db: Database.Database;
 let n = 0;
+
+afterEach(() => db.close());
 
 function freshDb(): Database.Database {
   const d = new Database(path.join(tmpDir, `t${n++}.db`));

--- a/server/db/normalizeBuffers.ts
+++ b/server/db/normalizeBuffers.ts
@@ -366,13 +366,27 @@ export function rebuildSatellitesToBufferId(db: Database): void {
       FOREIGN KEY (buffer_id) REFERENCES buffers(id) ON DELETE CASCADE
     );
   `);
+  // cleared_at must ride with the row that WINS the boundary merge — two
+  // independent MAX()es could pair one twin's boundary with the other's
+  // timestamp, an impossible state /clear-undo would then mis-render (the old
+  // fold's CASE did exactly this pairing). FIRST_VALUE over the boundary
+  // ordering stamps every row in the group with the winner's cleared_at, and
+  // the outer MAX() then reads that constant. A cleared_at never exists
+  // without its boundary (setClearedState writes or nulls them together), so
+  // the no-marker group stays NULL.
   db.exec(`
     INSERT INTO buffer_reads_new
       (user_id, buffer_id, last_read_message_id, updated_at, cleared_before_message_id, cleared_at)
     SELECT user_id, bid, MAX(last_read_message_id), MAX(updated_at),
-           MAX(cleared_before_message_id), MAX(cleared_at)
-    FROM (SELECT r.*, ${satelliteResolveSql('r')} AS bid FROM buffer_reads r)
-    WHERE bid IS NOT NULL
+           MAX(cleared_before_message_id), MAX(win_cleared_at)
+    FROM (
+      SELECT *, FIRST_VALUE(cleared_at) OVER (
+        PARTITION BY user_id, bid
+        ORDER BY COALESCE(cleared_before_message_id, 0) DESC
+      ) AS win_cleared_at
+      FROM (SELECT r.*, ${satelliteResolveSql('r')} AS bid FROM buffer_reads r)
+      WHERE bid IS NOT NULL
+    )
     GROUP BY user_id, bid
   `);
   db.exec(`DROP TABLE buffer_reads`);

--- a/server/db/normalizeBuffers.ts
+++ b/server/db/normalizeBuffers.ts
@@ -254,6 +254,263 @@ export function normalizeMessagesBufferIds(
   return result;
 }
 
+// --- v18: satellite rebuild -------------------------------------------------
+
+/** The resolve expression shared by every satellite rebuild's SELECT: the
+ *  ordinary folded lookup, then (for ':'-prefixed targets only) the row's
+ *  sentinel — the user's system console when the row is app-scoped, the
+ *  network's server console otherwise. Same coalescing as the v17 messages
+ *  backfill. `r` is the source-table alias; requires the fold function to be
+ *  registered and sentinels minted. */
+function satelliteResolveSql(r: string): string {
+  return `COALESCE(
+    (SELECT b.id FROM buffers b
+      WHERE b.user_id = ${r}.user_id
+        AND IFNULL(b.network_id, 0) = IFNULL(${r}.network_id, 0)
+        AND b.target_folded = ${FOLD_FN}(${r}.target)),
+    CASE WHEN ${r}.target LIKE ':%' THEN
+      CASE WHEN ${r}.network_id IS NULL THEN
+        (SELECT bs.id FROM buffers bs WHERE bs.user_id = ${r}.user_id AND bs.kind = 'system')
+      ELSE
+        (SELECT bn.id FROM buffers bn WHERE bn.network_id = ${r}.network_id AND bn.kind = 'server')
+      END
+    END
+  )`;
+}
+
+/**
+ * Mint CLOSED buffers rows for satellite targets that resolve to nothing —
+ * same policy and shape as the messages orphan mint: user view-state for a
+ * buffer the registry forgot must not be dropped when a hidden row preserves
+ * it. ':'-prefixed targets are skipped (they coalesce onto sentinels).
+ */
+export function mintOrphanBuffersFromSatellites(db: Database, tables: readonly string[]): number {
+  const insert = db.prepare(
+    `INSERT INTO buffers (user_id, network_id, target, target_folded, kind, state, autojoin, key)
+     VALUES (?, ?, ?, ?, ?, 'closed', 0, NULL)
+     ON CONFLICT(user_id, IFNULL(network_id, 0), target_folded) DO NOTHING`,
+  );
+  const networkExists = db.prepare(`SELECT 1 FROM networks WHERE id = ?`);
+  let minted = 0;
+  for (const table of tables) {
+    const rows = db
+      .prepare(
+        `SELECT DISTINCT r.user_id AS userId, r.network_id AS networkId, r.target AS target
+         FROM ${table} r
+         WHERE ${satelliteResolveSql('r')} IS NULL`,
+      )
+      .all() as Array<{ userId: number; networkId: number | null; target: string }>;
+    for (const { userId, networkId, target } of rows) {
+      if (target.startsWith(':')) continue;
+      if (networkId != null && !networkExists.get(networkId)) continue; // FK would reject
+      const kind = '#&+!'.includes(target[0] ?? '') ? 'channel' : 'dm';
+      minted += insert.run(userId, networkId, target, target.toLowerCase(), kind).changes;
+    }
+  }
+  return minted;
+}
+
+/**
+ * The v18 cutover body: rebuild the six view-state satellites onto
+ * (user_id, buffer_id) keys, dropping their name columns. One synchronous
+ * transaction — the tables are small (thousands of rows, not millions), so
+ * atomic-and-quick is the right shape; the caller wraps it `.immediate()`
+ * with foreign_keys OFF (the established rebuild pattern).
+ *
+ * Case-twin merges: the old binary-collated PKs let `#Chan` and `#chan`
+ * coexist; both resolve to one buffer_id now, so each table declares a merge
+ * policy — furthest read pointer / max cleared marker (mirrors what
+ * foldBufferCase did), earliest pin slot, latest draft, MAX for booleans.
+ * Where a policy needs "the rest of that row's columns", the SELECT uses
+ * SQLite's documented single-aggregate bare-column rule (min/max queries pull
+ * bare columns from the winning row — same device as listSpeakers).
+ *
+ * Rows whose target resolves to nothing even after the orphan mint (an
+ * orphaned network id, garbage) are DROPPED — they are view-state pointers
+ * with no buffer to point at — and the count is logged, never silent.
+ */
+export function rebuildSatellitesToBufferId(db: Database): void {
+  registerFoldFunction(db);
+
+  const dropped = (table: string): number =>
+    (
+      db
+        .prepare(`SELECT COUNT(*) AS n FROM ${table} r WHERE ${satelliteResolveSql('r')} IS NULL`)
+        .get() as { n: number }
+    ).n;
+  for (const table of [
+    'buffer_reads',
+    'input_history',
+    'pinned_buffers',
+    'nicklist_collapsed',
+    'channel_notify_settings',
+    'user_drafts',
+  ]) {
+    const n = dropped(table);
+    if (n > 0) {
+      console.warn(`[db] v18: dropping ${n} ${table} row(s) whose buffer cannot be resolved`);
+    }
+  }
+
+  // buffer_reads — merge policy: furthest read pointer, max cleared marker.
+  db.exec(`
+    CREATE TABLE buffer_reads_new (
+      user_id INTEGER NOT NULL,
+      buffer_id INTEGER NOT NULL,
+      last_read_message_id INTEGER NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      cleared_before_message_id INTEGER,
+      cleared_at TEXT,
+      PRIMARY KEY (user_id, buffer_id),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (buffer_id) REFERENCES buffers(id) ON DELETE CASCADE
+    );
+  `);
+  db.exec(`
+    INSERT INTO buffer_reads_new
+      (user_id, buffer_id, last_read_message_id, updated_at, cleared_before_message_id, cleared_at)
+    SELECT user_id, bid, MAX(last_read_message_id), MAX(updated_at),
+           MAX(cleared_before_message_id), MAX(cleared_at)
+    FROM (SELECT r.*, ${satelliteResolveSql('r')} AS bid FROM buffer_reads r)
+    WHERE bid IS NOT NULL
+    GROUP BY user_id, bid
+  `);
+  db.exec(`DROP TABLE buffer_reads`);
+  db.exec(`ALTER TABLE buffer_reads_new RENAME TO buffer_reads`);
+
+  // input_history — ids preserved (ordering key + export pk); no dedupe
+  // needed, the surrogate id was the PK.
+  db.exec(`
+    CREATE TABLE input_history_new (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      buffer_id INTEGER NOT NULL,
+      text TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (buffer_id) REFERENCES buffers(id) ON DELETE CASCADE
+    );
+  `);
+  db.exec(`
+    INSERT INTO input_history_new (id, user_id, buffer_id, text, created_at)
+    SELECT id, user_id, bid, text, created_at
+    FROM (SELECT r.*, ${satelliteResolveSql('r')} AS bid FROM input_history r)
+    WHERE bid IS NOT NULL
+  `);
+  db.exec(`DROP TABLE input_history`);
+  db.exec(`ALTER TABLE input_history_new RENAME TO input_history`);
+  db.exec(`CREATE INDEX idx_input_history_buffer
+           ON input_history(user_id, buffer_id, id DESC)`);
+
+  // pinned_buffers — earliest slot wins for a case twin (single MIN aggregate;
+  // network_id/created_at ride from that row), then positions re-densified per
+  // (user, network) since a merge can leave holes.
+  db.exec(`
+    CREATE TABLE pinned_buffers_new (
+      user_id INTEGER NOT NULL,
+      buffer_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      position INTEGER NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, buffer_id),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (buffer_id) REFERENCES buffers(id) ON DELETE CASCADE,
+      FOREIGN KEY (network_id) REFERENCES networks(id) ON DELETE CASCADE
+    );
+  `);
+  db.exec(`
+    INSERT INTO pinned_buffers_new (user_id, buffer_id, network_id, position, created_at)
+    SELECT user_id, bid, network_id, MIN(position), created_at
+    FROM (SELECT r.*, ${satelliteResolveSql('r')} AS bid FROM pinned_buffers r)
+    WHERE bid IS NOT NULL
+    GROUP BY user_id, bid
+  `);
+  db.exec(`DROP TABLE pinned_buffers`);
+  db.exec(`ALTER TABLE pinned_buffers_new RENAME TO pinned_buffers`);
+  db.exec(`
+    UPDATE pinned_buffers SET position = (
+      SELECT rn - 1 FROM (
+        SELECT p2.buffer_id AS bid2,
+               ROW_NUMBER() OVER (
+                 PARTITION BY p2.user_id, p2.network_id ORDER BY p2.position, p2.buffer_id
+               ) AS rn
+        FROM pinned_buffers p2
+        WHERE p2.user_id = pinned_buffers.user_id AND p2.network_id = pinned_buffers.network_id
+      ) WHERE bid2 = pinned_buffers.buffer_id
+    )
+  `);
+  db.exec(`CREATE INDEX idx_pinned_buffers_user_net
+           ON pinned_buffers(user_id, network_id, position)`);
+
+  // nicklist_collapsed — MAX(collapsed): if any case twin was collapsed, stay
+  // collapsed.
+  db.exec(`
+    CREATE TABLE nicklist_collapsed_new (
+      user_id INTEGER NOT NULL,
+      buffer_id INTEGER NOT NULL,
+      collapsed INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (user_id, buffer_id),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (buffer_id) REFERENCES buffers(id) ON DELETE CASCADE
+    );
+  `);
+  db.exec(`
+    INSERT INTO nicklist_collapsed_new (user_id, buffer_id, collapsed)
+    SELECT user_id, bid, MAX(collapsed)
+    FROM (SELECT r.*, ${satelliteResolveSql('r')} AS bid FROM nicklist_collapsed r)
+    WHERE bid IS NOT NULL
+    GROUP BY user_id, bid
+  `);
+  db.exec(`DROP TABLE nicklist_collapsed`);
+  db.exec(`ALTER TABLE nicklist_collapsed_new RENAME TO nicklist_collapsed`);
+
+  // channel_notify_settings — MAX(notify_always); the dead `muted` column
+  // (written 0 since the /ignore unification, #359) dies here.
+  db.exec(`
+    CREATE TABLE channel_notify_settings_new (
+      user_id INTEGER NOT NULL,
+      buffer_id INTEGER NOT NULL,
+      notify_always INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, buffer_id),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (buffer_id) REFERENCES buffers(id) ON DELETE CASCADE
+    );
+  `);
+  db.exec(`
+    INSERT INTO channel_notify_settings_new (user_id, buffer_id, notify_always, updated_at)
+    SELECT user_id, bid, MAX(notify_always), updated_at
+    FROM (SELECT r.*, ${satelliteResolveSql('r')} AS bid FROM channel_notify_settings r)
+    WHERE bid IS NOT NULL
+    GROUP BY user_id, bid
+  `);
+  db.exec(`DROP TABLE channel_notify_settings`);
+  db.exec(`ALTER TABLE channel_notify_settings_new RENAME TO channel_notify_settings`);
+
+  // user_drafts — the LATEST draft wins (single MAX(updated_at); body rides
+  // from that row).
+  db.exec(`
+    CREATE TABLE user_drafts_new (
+      user_id INTEGER NOT NULL,
+      buffer_id INTEGER NOT NULL,
+      body TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, buffer_id),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      FOREIGN KEY (buffer_id) REFERENCES buffers(id) ON DELETE CASCADE
+    );
+  `);
+  db.exec(`
+    INSERT INTO user_drafts_new (user_id, buffer_id, body, updated_at)
+    SELECT user_id, bid, body, MAX(updated_at)
+    FROM (SELECT r.*, ${satelliteResolveSql('r')} AS bid FROM user_drafts r)
+    WHERE bid IS NOT NULL
+    GROUP BY user_id, bid
+  `);
+  db.exec(`DROP TABLE user_drafts`);
+  db.exec(`ALTER TABLE user_drafts_new RENAME TO user_drafts`);
+}
+
 function getMeta(db: Database, key: string): string | undefined {
   return (
     db.prepare(`SELECT value FROM app_meta WHERE key = ?`).get(key) as { value: string } | undefined

--- a/server/db/pinnedBuffers.test.ts
+++ b/server/db/pinnedBuffers.test.ts
@@ -11,20 +11,30 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 
 let createUser: typeof import('./users.js').createUser;
 let createNetwork: typeof import('./networks.js').createNetwork;
+let ensureBuffer: typeof import('./buffers.js').ensureExists;
 let pinned: typeof import('./pinnedBuffers.js');
 let db: typeof import('./index.js').default;
 let user: ReturnType<typeof import('./users.js').createUser>;
 let net: ReturnType<typeof import('./networks.js').createNetwork>;
 let net2: ReturnType<typeof import('./networks.js').createNetwork>;
 
+function mkNet(userId: number, name: string) {
+  return createNetwork(userId, { name, host: 'h', port: 6697, tls: true, nick: name });
+}
+
 beforeAll(async () => {
   ({ createUser } = await import('./users.js'));
   ({ createNetwork } = await import('./networks.js'));
+  ({ ensureExists: ensureBuffer } = await import('./buffers.js'));
   pinned = await import('./pinnedBuffers.js');
   db = (await import('./index.js')).default;
   user = createUser('pin-alice');
-  net = createNetwork(user.id, { name: 'libera', host: 'h', port: 6697, tls: true, nick: 'a' });
-  net2 = createNetwork(user.id, { name: 'oftc', host: 'h2', port: 6697, tls: true, nick: 'a' });
+  net = mkNet(user.id, 'libera');
+  net2 = mkNet(user.id, 'oftc');
+  // Pins are keyed by buffer_id (schema 18): a pin only exists for a buffer
+  // the registry knows, so the fixtures mint every target used.
+  for (const t of ['#a', '#b', '#c', '#d']) ensureBuffer(user.id, net!.id, t);
+  ensureBuffer(user.id, net2!.id, '#meta');
 });
 
 afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
@@ -40,6 +50,10 @@ describe('pinBuffer / listPinnedForUserNetwork', () => {
   it('is idempotent — pinning twice does not duplicate or move the entry', () => {
     pinned.pinBuffer(user.id, net!.id, '#a');
     expect(pinned.listPinnedForUserNetwork(user.id, net!.id)).toEqual(['#a', '#b', '#c']);
+  });
+
+  it('pinning an unknown target is a no-op', () => {
+    expect(pinned.pinBuffer(user.id, net!.id, '#never-existed')).toEqual(['#a', '#b', '#c']);
   });
 });
 
@@ -70,6 +84,13 @@ describe('reorderPins', () => {
     expect(pinned.reorderPins(user.id, net!.id, ['#d', '#d'])).toBeNull();
   });
 
+  it('returns null on two casings of the same pin (they resolve to one buffer)', () => {
+    // Pre-normalization these were distinct raw strings and failed the
+    // membership check by luck of exact matching; now they resolve to the
+    // same buffer_id and fail the duplicate check deliberately.
+    expect(pinned.reorderPins(user.id, net!.id, ['#d', '#D'])).toBeNull();
+  });
+
   // The client drops pins it can't render (closed/parted buffers, friend
   // primary DMs), so a drag legitimately reorders only a subset of the pinned
   // set. The reorder must still apply, keeping the unmentioned ("hidden") pins
@@ -77,13 +98,8 @@ describe('reorderPins', () => {
   it('accepts a subset, reordering the supplied targets and keeping hidden pins after them', () => {
     // Fresh user/network so the suite-wide ordering above stays intact.
     const carol = createUser('pin-carol');
-    const netC = createNetwork(carol.id, {
-      name: 'c',
-      host: 'h',
-      port: 6697,
-      tls: true,
-      nick: 'c',
-    });
+    const netC = mkNet(carol.id, 'c');
+    for (const t of ['#visibleA', 'hiddenDM', '#visibleB']) ensureBuffer(carol.id, netC!.id, t);
     pinned.pinBuffer(carol.id, netC!.id, '#visibleA'); // pos 0
     pinned.pinBuffer(carol.id, netC!.id, 'hiddenDM'); // pos 1 (invisible to the client)
     pinned.pinBuffer(carol.id, netC!.id, '#visibleB'); // pos 2
@@ -102,14 +118,10 @@ describe('reorderPins', () => {
 describe('unpinBufferCaseInsensitive', () => {
   it('removes a pin whose stored casing differs from the requested target', () => {
     const dave = createUser('pin-dave');
-    const netD = createNetwork(dave.id, {
-      name: 'd',
-      host: 'h',
-      port: 6697,
-      tls: true,
-      nick: 'd',
-    });
-    pinned.pinBuffer(dave.id, netD!.id, '#Channel'); // stored with a capital C
+    const netD = mkNet(dave.id, 'd');
+    ensureBuffer(dave.id, netD!.id, '#Channel'); // canonical casing: capital C
+    ensureBuffer(dave.id, netD!.id, '#other');
+    pinned.pinBuffer(dave.id, netD!.id, '#Channel');
     pinned.pinBuffer(dave.id, netD!.id, '#other');
 
     // close-buffer arrives with the server's lowercased casing.
@@ -118,41 +130,41 @@ describe('unpinBufferCaseInsensitive', () => {
     expect(pinned.listPinnedForUserNetwork(dave.id, netD!.id)).toEqual(['#other']);
   });
 
-  it('removes every case-variant in one pass (PRIMARY KEY is case-sensitive)', () => {
+  it('case variants resolve to ONE pin — a twin row is unrepresentable', () => {
+    // Pre-normalization the raw-string PRIMARY KEY let '#Channel' and
+    // '#channel' coexist as separate pin rows, and this function existed to
+    // sweep all of them. Under (user_id, buffer_id) keying the second pin is
+    // the same buffer, so it's an idempotent no-op, and one unpin (any
+    // casing) clears it with positions staying dense.
     const frank = createUser('pin-frank');
-    const netF = createNetwork(frank.id, {
-      name: 'f',
-      host: 'h',
-      port: 6697,
-      tls: true,
-      nick: 'f',
-    });
-    // The schema allows both rows since the target column has no NOCASE.
+    const netF = mkNet(frank.id, 'f');
+    ensureBuffer(frank.id, netF!.id, '#Channel');
+    ensureBuffer(frank.id, netF!.id, '#kept');
     pinned.pinBuffer(frank.id, netF!.id, '#Channel');
-    pinned.pinBuffer(frank.id, netF!.id, '#channel');
+    pinned.pinBuffer(frank.id, netF!.id, '#channel'); // same buffer — no-op
     pinned.pinBuffer(frank.id, netF!.id, '#kept');
+    expect(pinned.listPinnedForUserNetwork(frank.id, netF!.id)).toEqual(['#Channel', '#kept']);
 
     const next = pinned.unpinBufferCaseInsensitive(frank.id, netF!.id, '#CHANNEL');
     expect(next).toEqual(['#kept']);
-    expect(pinned.listPinnedForUserNetwork(frank.id, netF!.id)).toEqual(['#kept']);
-    // Positions stay dense after pulling two rows out of the middle/front.
     const rows = db
-      .prepare(`SELECT target, position FROM pinned_buffers WHERE user_id = ? AND network_id = ?`)
+      .prepare(
+        `SELECT b.target AS target, p.position AS position
+         FROM pinned_buffers p JOIN buffers b ON b.id = p.buffer_id
+         WHERE p.user_id = ? AND p.network_id = ?`,
+      )
       .all(frank.id, netF!.id) as Array<{ target: string; position: number }>;
     expect(rows).toEqual([{ target: '#kept', position: 0 }]);
   });
 
   it('returns null when nothing matches so the caller can skip the broadcast', () => {
     const erin = createUser('pin-erin');
-    const netE = createNetwork(erin.id, {
-      name: 'e',
-      host: 'h',
-      port: 6697,
-      tls: true,
-      nick: 'e',
-    });
+    const netE = mkNet(erin.id, 'e');
+    ensureBuffer(erin.id, netE!.id, '#kept');
+    ensureBuffer(erin.id, netE!.id, '#nope'); // exists but isn't pinned
     pinned.pinBuffer(erin.id, netE!.id, '#kept');
     expect(pinned.unpinBufferCaseInsensitive(erin.id, netE!.id, '#nope')).toBeNull();
+    expect(pinned.unpinBufferCaseInsensitive(erin.id, netE!.id, '#gone')).toBeNull();
     expect(pinned.listPinnedForUserNetwork(erin.id, netE!.id)).toEqual(['#kept']);
   });
 });
@@ -166,107 +178,9 @@ describe('listPinnedForUser', () => {
   });
 });
 
-// Mirrors the schemaVersion < 7 cleanup in db/index.ts. Kept here as a string
-// so the test can replay it against orphan rows that the public API can no
-// longer create (close-buffer now implies unpin).
-// The v7 migration repair ran against the legacy closed_buffers table (the
-// registry didn't exist yet), and is now gated on that table existing. Its
-// replay here recreates the legacy world: fixture table + fixture close.
-function ensureLegacyClosedBuffers(): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS closed_buffers (
-      user_id INTEGER NOT NULL,
-      network_id INTEGER NOT NULL,
-      target TEXT NOT NULL,
-      closed_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (user_id, network_id, target)
-    )
-  `);
-}
-function closeBuffer(userId: number, networkId: number, target: string): void {
-  ensureLegacyClosedBuffers();
-  db.prepare(
-    `INSERT INTO closed_buffers (user_id, network_id, target) VALUES (?, ?, ?)
-     ON CONFLICT(user_id, network_id, target) DO UPDATE SET closed_at = datetime('now')`,
-  ).run(userId, networkId, target);
-}
-
-const PURGE_ORPHANS_SQL = `
-  DELETE FROM pinned_buffers
-  WHERE EXISTS (
-    SELECT 1 FROM closed_buffers c
-    WHERE c.user_id = pinned_buffers.user_id
-      AND c.network_id = pinned_buffers.network_id
-      AND c.target = pinned_buffers.target
-  )
-`;
-const RENUMBER_PINS_SQL = `
-  WITH renum AS (
-    SELECT user_id, network_id, target,
-           ROW_NUMBER() OVER (
-             PARTITION BY user_id, network_id
-             ORDER BY position ASC, target ASC
-           ) - 1 AS new_pos
-    FROM pinned_buffers
-  )
-  UPDATE pinned_buffers
-  SET position = (
-    SELECT new_pos FROM renum
-    WHERE renum.user_id = pinned_buffers.user_id
-      AND renum.network_id = pinned_buffers.network_id
-      AND renum.target = pinned_buffers.target
-  )
-`;
-
-describe('schemaVersion < 7 orphan cleanup (issue #112)', () => {
-  it('drops pinned rows whose target is also closed, then renumbers positions per (user, network)', () => {
-    // Fresh user/networks so we don't entangle with the suite-wide state above.
-    const bob = createUser('pin-bob');
-    const netA = createNetwork(bob.id, {
-      name: 'a',
-      host: 'h',
-      port: 6697,
-      tls: true,
-      nick: 'b',
-    });
-    const netB = createNetwork(bob.id, {
-      name: 'b',
-      host: 'h',
-      port: 6697,
-      tls: true,
-      nick: 'b',
-    });
-
-    pinned.pinBuffer(bob.id, netA!.id, '#x');
-    pinned.pinBuffer(bob.id, netA!.id, '#y');
-    pinned.pinBuffer(bob.id, netA!.id, '#z');
-    pinned.pinBuffer(bob.id, netB!.id, '#solo');
-
-    // Simulate the pre-fix bug: close a pinned buffer without unpinning it,
-    // leaving an orphan pinned_buffers row pointing at a closed buffer.
-    closeBuffer(bob.id, netA!.id, '#y');
-    closeBuffer(bob.id, netB!.id, '#solo');
-
-    db.exec(PURGE_ORPHANS_SQL);
-    db.exec(RENUMBER_PINS_SQL);
-
-    expect(pinned.listPinnedForUserNetwork(bob.id, netA!.id)).toEqual(['#x', '#z']);
-    expect(pinned.listPinnedForUserNetwork(bob.id, netB!.id)).toEqual([]);
-
-    // Positions must be dense (0..n-1) so a subsequent pin appends at the
-    // correct slot — listPinnedForUserNetwork already orders by position,
-    // but reorderPins relies on the underlying numbering being gap-free.
-    const rows = db
-      .prepare(`SELECT target, position FROM pinned_buffers WHERE user_id = ? AND network_id = ?`)
-      .all(bob.id, netA!.id) as Array<{ target: string; position: number }>;
-    expect(rows.toSorted((a, b) => a.position - b.position)).toEqual([
-      { target: '#x', position: 0 },
-      { target: '#z', position: 1 },
-    ]);
-
-    // Pinning a new buffer after the cleanup lands at position 2, not 3
-    // (which is what would happen if renumber missed a gap).
-    pinned.pinBuffer(bob.id, netA!.id, '#w');
-    expect(pinned.listPinnedForUserNetwork(bob.id, netA!.id)).toEqual(['#x', '#z', '#w']);
-  });
-});
+// The schemaVersion < 7 orphan-cleanup replay that used to live here is gone
+// with the name-keyed schema: that repair runs only on legacy databases (gated
+// on the retired closed_buffers table existing, always before the v18 rebuild
+// reshapes pinned_buffers), and its SQL cannot execute against the buffer_id
+// schema. The migration path itself is covered by the v15-fixture migration
+// tests.

--- a/server/db/pinnedBuffers.ts
+++ b/server/db/pinnedBuffers.ts
@@ -2,26 +2,30 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
+import { resolveBuffer } from './bufferResolve.js';
 
-/** A row from the `pinned_buffers` table. */
-export interface PinnedBuffer {
-  user_id: number;
-  network_id: number;
-  target: string;
-  position: number;
-  created_at: string;
-}
+// Keyed (user_id, buffer_id) since schema 18; network_id stays as denormalized
+// immutable scope because position density is per (user, network). The listing
+// shapes still speak target strings (canonical casing, joined from `buffers`),
+// so callers and the wire are unchanged.
+//
+// The old file's case-twin machinery (unpinBufferCaseInsensitive walking every
+// casing variant) survives in name only: the PK now makes a twin
+// unrepresentable, and resolution folds the caller's casing — the exported
+// contract (null when nothing matched) is what callers still rely on.
 
 const listForUserNetworkStmt = db.prepare(`
-  SELECT target FROM pinned_buffers
-  WHERE user_id = ? AND network_id = ?
-  ORDER BY position ASC, target ASC
+  SELECT b.target AS target
+  FROM pinned_buffers p JOIN buffers b ON b.id = p.buffer_id
+  WHERE p.user_id = ? AND p.network_id = ?
+  ORDER BY p.position ASC, b.target ASC
 `);
 
 const listForUserStmt = db.prepare(`
-  SELECT network_id AS networkId, target FROM pinned_buffers
-  WHERE user_id = ?
-  ORDER BY network_id ASC, position ASC, target ASC
+  SELECT p.network_id AS networkId, b.target AS target
+  FROM pinned_buffers p JOIN buffers b ON b.id = p.buffer_id
+  WHERE p.user_id = ?
+  ORDER BY p.network_id ASC, p.position ASC, b.target ASC
 `);
 
 const nextPositionStmt = db.prepare(`
@@ -31,24 +35,24 @@ const nextPositionStmt = db.prepare(`
 `);
 
 const insertStmt = db.prepare(`
-  INSERT OR IGNORE INTO pinned_buffers (user_id, network_id, target, position)
+  INSERT OR IGNORE INTO pinned_buffers (user_id, buffer_id, network_id, position)
   VALUES (?, ?, ?, ?)
 `);
 
 const deleteStmt = db.prepare(`
   DELETE FROM pinned_buffers
-  WHERE user_id = ? AND network_id = ? AND target = ?
+  WHERE user_id = ? AND buffer_id = ?
 `);
 
 const allForUserNetworkStmt = db.prepare(`
-  SELECT target, position FROM pinned_buffers
+  SELECT buffer_id AS bufferId, position FROM pinned_buffers
   WHERE user_id = ? AND network_id = ?
   ORDER BY position ASC
 `);
 
 const setPositionStmt = db.prepare(`
   UPDATE pinned_buffers SET position = ?
-  WHERE user_id = ? AND network_id = ? AND target = ?
+  WHERE user_id = ? AND buffer_id = ?
 `);
 
 export function listPinnedForUserNetwork(userId: number, networkId: number): string[] {
@@ -69,75 +73,69 @@ export function listPinnedForUser(userId: number): Map<number, string[]> {
   return byNetwork;
 }
 
+// Renumber a (user, network)'s pins dense 0..n-1, preserving order.
+function renumber(userId: number, networkId: number): void {
+  const remaining = allForUserNetworkStmt.all(userId, networkId) as Array<{
+    bufferId: number;
+    position: number;
+  }>;
+  let i = 0;
+  for (const row of remaining) {
+    if (row.position !== i) setPositionStmt.run(i, userId, row.bufferId);
+    i += 1;
+  }
+}
+
 // Returns the new ordered target list for the (user, network). No-op if the
 // row already exists (idempotent — second pin of the same target keeps the
-// existing position rather than creating a duplicate or moving it).
+// existing position rather than creating a duplicate or moving it), or if the
+// target doesn't resolve to a buffer at all.
 export function pinBuffer(userId: number, networkId: number, target: string): string[] {
-  const tx = db.transaction(() => {
-    const { next } = nextPositionStmt.get(userId, networkId) as { next: number };
-    insertStmt.run(userId, networkId, target, next);
-  });
-  tx();
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (buffer) {
+    const tx = db.transaction(() => {
+      const { next } = nextPositionStmt.get(userId, networkId) as { next: number };
+      insertStmt.run(userId, buffer.id, networkId, next);
+    });
+    tx();
+  }
   return listPinnedForUserNetwork(userId, networkId);
 }
 
 // Unpin and renumber remaining rows to keep positions dense (0..n-1). Returns
 // the new ordered target list.
 export function unpinBuffer(userId: number, networkId: number, target: string): string[] {
-  const tx = db.transaction(() => {
-    deleteStmt.run(userId, networkId, target);
-    const remaining = allForUserNetworkStmt.all(userId, networkId) as Array<{
-      target: string;
-      position: number;
-    }>;
-    let i = 0;
-    for (const row of remaining) {
-      if (row.position !== i) {
-        setPositionStmt.run(i, userId, networkId, row.target);
-      }
-      i += 1;
-    }
-  });
-  tx();
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (buffer) {
+    const tx = db.transaction(() => {
+      deleteStmt.run(userId, buffer.id);
+      renumber(userId, networkId);
+    });
+    tx();
+  }
   return listPinnedForUserNetwork(userId, networkId);
 }
 
-// Unpin every buffer matching `target` case-insensitively. IRC targets are
-// case-insensitive but a pin row stores one canonical casing, so a caller that
-// only has the server's current casing (e.g. close-buffer, where the buffer may
-// have been re-cased by the server) can still find and remove the stranded pin.
-// The schema's PRIMARY KEY is on the raw target (no NOCASE), so two case
-// variants of the same channel can coexist as separate rows — remove ALL of
-// them in one transaction and renumber once, or closing one would leave the
-// other as an invisible orphan. Returns the new ordered list when at least one
-// row was removed, or null when nothing matched — callers use null to skip the
-// pins-changed broadcast. Matches the case-folding the snapshot already applies
-// to closed buffers (issue #405).
+// Unpin by name regardless of the caller's casing. Pre-normalization this had
+// to sweep every stored casing variant of the target; resolution now folds the
+// name and the (user_id, buffer_id) key makes variants unrepresentable, so it
+// is a single delete. The contract callers rely on is unchanged: the new
+// ordered list when a row was removed, null when nothing matched (used to skip
+// the pins-changed broadcast).
 export function unpinBufferCaseInsensitive(
   userId: number,
   networkId: number,
   target: string,
 ): string[] | null {
-  const lower = target.toLowerCase();
-  const matches = listPinnedForUserNetwork(userId, networkId).filter(
-    (t) => t.toLowerCase() === lower,
-  );
-  if (matches.length === 0) return null;
+  const buffer = resolveBuffer(userId, networkId, target);
+  if (!buffer) return null;
+  let removed = 0;
   const tx = db.transaction(() => {
-    for (const m of matches) deleteStmt.run(userId, networkId, m);
-    const remaining = allForUserNetworkStmt.all(userId, networkId) as Array<{
-      target: string;
-      position: number;
-    }>;
-    let i = 0;
-    for (const row of remaining) {
-      if (row.position !== i) {
-        setPositionStmt.run(i, userId, networkId, row.target);
-      }
-      i += 1;
-    }
+    removed = deleteStmt.run(userId, buffer.id).changes;
+    if (removed > 0) renumber(userId, networkId);
   });
   tx();
+  if (removed === 0) return null;
   return listPinnedForUserNetwork(userId, networkId);
 }
 
@@ -148,29 +146,34 @@ export function unpinBufferCaseInsensitive(
 //
 // The supplied list may be a strict SUBSET of the pinned set. The client only
 // renders pins that resolve to a visible buffer — it drops any pin whose buffer
-// is closed/parted/case-mismatched, or that is a friend's primary DM (shown
-// under FRIENDS) — so a drag legitimately reorders only the rows the user can
-// see. We honor that order for the supplied targets and keep the unmentioned
-// ("hidden") pins after them in their existing relative order. Requiring an
-// exact set match instead made a single invisible orphan pin wedge every
-// reorder for that network (issue #405). On success returns the new full
-// ordered target list.
+// is closed/parted, or that is a friend's primary DM (shown under FRIENDS) —
+// so a drag legitimately reorders only the rows the user can see. We honor
+// that order for the supplied targets and keep the unmentioned ("hidden") pins
+// after them in their existing relative order. Requiring an exact set match
+// instead made a single invisible orphan pin wedge every reorder for that
+// network (issue #405). On success returns the new full ordered target list
+// (canonical casing, which may differ from what the client sent).
 export function reorderPins(userId: number, networkId: number, targets: string[]): string[] | null {
-  const currentOrdered = listPinnedForUserNetwork(userId, networkId);
-  const current = new Set(currentOrdered);
-  const seen = new Set<string>();
+  const pinnedIds = (
+    allForUserNetworkStmt.all(userId, networkId) as Array<{ bufferId: number }>
+  ).map((r) => r.bufferId);
+  const pinned = new Set(pinnedIds);
+  const seen = new Set<number>();
+  const suppliedIds: number[] = [];
   for (const t of targets) {
-    if (!current.has(t) || seen.has(t)) return null;
-    seen.add(t);
+    const buffer = resolveBuffer(userId, networkId, t);
+    if (!buffer || !pinned.has(buffer.id) || seen.has(buffer.id)) return null;
+    seen.add(buffer.id);
+    suppliedIds.push(buffer.id);
   }
-  const next = [...targets, ...currentOrdered.filter((t) => !seen.has(t))];
+  const next = [...suppliedIds, ...pinnedIds.filter((id) => !seen.has(id))];
   const tx = db.transaction(() => {
     let i = 0;
-    for (const t of next) {
-      setPositionStmt.run(i, userId, networkId, t);
+    for (const id of next) {
+      setPositionStmt.run(i, userId, id);
       i += 1;
     }
   });
   tx();
-  return next;
+  return listPinnedForUserNetwork(userId, networkId);
 }

--- a/server/db/satelliteRebuild.test.ts
+++ b/server/db/satelliteRebuild.test.ts
@@ -154,11 +154,15 @@ beforeAll(async () => {
       (102, 1, 10, ':server:10', ':server:10', 'server', 'open'),
       (103, 1, NULL, ':system:', ':system:', 'system', 'open');
 
-    -- Case twins across the satellites, plus sentinel pointers.
+    -- Case twins across the satellites, plus sentinel pointers. The '#Chan'
+    -- pair carries markers on BOTH twins, with the FURTHER boundary paired
+    -- with the EARLIER timestamp — the shape that catches a merge pairing one
+    -- twin's boundary with the other's cleared_at (independent MAXes would
+    -- produce boundary 40 + timestamp 2026-03-01, an impossible row).
     INSERT INTO buffer_reads (user_id, network_id, target, last_read_message_id,
                               cleared_before_message_id, cleared_at) VALUES
-      (1, 10, '#Chan', 50, NULL, NULL),
-      (1, 10, '#chan', 90, 40, '2026-01-01T00:00:00Z'),  -- twin: further pointer + marker
+      (1, 10, '#Chan', 50, 25, '2026-03-01T00:00:00Z'),
+      (1, 10, '#chan', 90, 40, '2026-01-01T00:00:00Z'),  -- twin: further pointer + boundary
       (1, 10, ':server:10', 7, NULL, NULL),
       (1, NULL, ':system:', 3, NULL, NULL),
       (1, 10, '#vanished', 12, NULL, NULL);              -- no registry row: minted closed
@@ -216,9 +220,11 @@ describe('schema 18 — satellite rebuild', () => {
     }
   });
 
-  it('merges read-pointer case twins: furthest pointer, max clear marker', async () => {
+  it('merges read-pointer case twins: furthest pointer, winning boundary KEEPS ITS OWN timestamp', async () => {
     const { getReadState, getClearedState } = await import('./bufferReads.js');
     expect(getReadState(1, 10, '#CHAN')).toBe(90);
+    // Boundary 40 wins (further than 25), and its cleared_at rides with it —
+    // NOT the other twin's later 2026-03-01 timestamp.
     expect(getClearedState(1, 10, '#chan')).toEqual({
       clearedBeforeId: 40,
       clearedAt: '2026-01-01T00:00:00Z',

--- a/server/db/satelliteRebuild.test.ts
+++ b/server/db/satelliteRebuild.test.ts
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Integration test for the schema-18 satellite rebuild: a DB shaped like a
+// real v17 install (messages already buffer_id-keyed, view-state satellites
+// still name-keyed) is built RAW before db/index.ts is imported; importing it
+// runs the rebuild against that data. app_meta pins schema_version=17 and the
+// v17 done-flag so no earlier block interferes.
+//
+// The interesting inputs are the ones the rebuild's merge policies exist for:
+// case-twin rows (the old binary PKs let '#Chan' and '#chan' coexist),
+// sentinel read pointers (:system: with NULL network, :server:<id>), and a
+// row whose target resolves to nothing.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-satrebuild-'));
+const dbPath = path.join(tmpDir, 'test.db');
+process.env.DATABASE_PATH = dbPath;
+
+let db: typeof import('./index.js').default;
+
+beforeAll(async () => {
+  const raw = new Database(dbPath);
+  raw.pragma('journal_mode = WAL');
+  raw.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT UNIQUE NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE networks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      host TEXT NOT NULL,
+      port INTEGER NOT NULL DEFAULT 6697,
+      tls INTEGER NOT NULL DEFAULT 1,
+      trusted_certificates INTEGER NOT NULL DEFAULT 1,
+      nick TEXT NOT NULL,
+      username TEXT,
+      realname TEXT,
+      server_password TEXT,
+      autoconnect INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+    CREATE TABLE buffers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      network_id INTEGER,
+      target TEXT NOT NULL,
+      target_folded TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      state TEXT NOT NULL DEFAULT 'open',
+      autojoin INTEGER NOT NULL DEFAULT 0,
+      key TEXT,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      closed_at TEXT
+    );
+    CREATE UNIQUE INDEX idx_buffers_key
+      ON buffers(user_id, IFNULL(network_id, 0), target_folded);
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      network_id INTEGER NOT NULL,
+      buffer_id INTEGER,
+      target TEXT NOT NULL,
+      time TEXT NOT NULL,
+      type TEXT NOT NULL,
+      nick TEXT, text TEXT, kind TEXT,
+      self INTEGER NOT NULL DEFAULT 0,
+      extra TEXT, userhost TEXT, matched_rule_id INTEGER,
+      alt INTEGER NOT NULL DEFAULT 0,
+      from_ignored INTEGER NOT NULL DEFAULT 0,
+      mirrored INTEGER NOT NULL DEFAULT 0,
+      notable INTEGER NOT NULL DEFAULT 1,
+      msgid TEXT
+    );
+    CREATE INDEX idx_messages_buf_unread
+      ON messages(buffer_id, id DESC, type, from_ignored, notable);
+    CREATE INDEX idx_messages_matched_buf
+      ON messages(buffer_id, id DESC) WHERE matched_rule_id IS NOT NULL;
+
+    -- v17-shape satellites (name-keyed).
+    CREATE TABLE buffer_reads (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER,
+      target TEXT NOT NULL,
+      last_read_message_id INTEGER NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      cleared_before_message_id INTEGER,
+      cleared_at TEXT,
+      PRIMARY KEY (user_id, network_id, target)
+    );
+    CREATE TABLE input_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      target TEXT NOT NULL,
+      text TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE pinned_buffers (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      target TEXT NOT NULL,
+      position INTEGER NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, network_id, target)
+    );
+    CREATE TABLE nicklist_collapsed (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      target TEXT NOT NULL,
+      collapsed INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (user_id, network_id, target)
+    );
+    CREATE TABLE channel_notify_settings (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      target TEXT NOT NULL,
+      notify_always INTEGER NOT NULL DEFAULT 0,
+      muted INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, network_id, target)
+    );
+    CREATE TABLE user_drafts (
+      user_id INTEGER NOT NULL,
+      network_id INTEGER NOT NULL,
+      target TEXT NOT NULL,
+      body TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (user_id, network_id, target)
+    );
+
+    CREATE TABLE app_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    INSERT INTO app_meta (key, value) VALUES
+      ('schema_version', '17'),
+      ('messages_bufferid_done', '1'),
+      ('messages_bufferid_cursor', '0');
+
+    INSERT INTO users (id, username) VALUES (1, 'sat-alice');
+    INSERT INTO networks (id, user_id, name, host, nick)
+      VALUES (10, 1, 'libera', 'irc.libera.chat', 'alice');
+
+    -- v17 registry: canonical rows + the sentinels v17 minted.
+    INSERT INTO buffers (id, user_id, network_id, target, target_folded, kind, state) VALUES
+      (100, 1, 10, '#Chan',  '#chan',  'channel', 'open'),
+      (101, 1, 10, 'bob',    'bob',    'dm',      'open'),
+      (102, 1, 10, ':server:10', ':server:10', 'server', 'open'),
+      (103, 1, NULL, ':system:', ':system:', 'system', 'open');
+
+    -- Case twins across the satellites, plus sentinel pointers.
+    INSERT INTO buffer_reads (user_id, network_id, target, last_read_message_id,
+                              cleared_before_message_id, cleared_at) VALUES
+      (1, 10, '#Chan', 50, NULL, NULL),
+      (1, 10, '#chan', 90, 40, '2026-01-01T00:00:00Z'),  -- twin: further pointer + marker
+      (1, 10, ':server:10', 7, NULL, NULL),
+      (1, NULL, ':system:', 3, NULL, NULL),
+      (1, 10, '#vanished', 12, NULL, NULL);              -- no registry row: minted closed
+
+    INSERT INTO input_history (id, user_id, network_id, target, text) VALUES
+      (1, 1, 10, '#Chan', 'first'),
+      (2, 1, 10, '#chan', 'second'),
+      (3, 1, 10, 'bob', 'dm line');
+
+    INSERT INTO pinned_buffers (user_id, network_id, target, position) VALUES
+      (1, 10, '#chan', 0),   -- twin of #Chan: earliest slot wins
+      (1, 10, 'bob',   1),
+      (1, 10, '#Chan', 2);
+
+    INSERT INTO nicklist_collapsed (user_id, network_id, target, collapsed) VALUES
+      (1, 10, '#Chan', 0),
+      (1, 10, '#chan', 1);   -- MAX wins: stays collapsed
+
+    INSERT INTO channel_notify_settings (user_id, network_id, target, notify_always, muted) VALUES
+      (1, 10, '#Chan', 1, 0);
+
+    INSERT INTO user_drafts (user_id, network_id, target, body, updated_at) VALUES
+      (1, 10, '#Chan', 'older draft', '2026-01-01T00:00:00Z'),
+      (1, 10, '#chan', 'newer draft', '2026-02-01T00:00:00Z'), -- latest wins
+      -- Foreign-numbered :server: stray (legacy-import shape): must coalesce
+      -- onto the network's canonical sentinel, not drop or mint a hidden row.
+      (1, 10, ':server:99', 'console draft', '2026-03-01T00:00:00Z');
+  `);
+  raw.close();
+
+  ({ default: db } = await import('./index.js'));
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('schema 18 — satellite rebuild', () => {
+  it('bumps the version and drops every satellite name column', () => {
+    const v = db.prepare(`SELECT value FROM app_meta WHERE key = 'schema_version'`).get() as {
+      value: string;
+    };
+    expect(parseInt(v.value, 10)).toBeGreaterThanOrEqual(18);
+    for (const t of [
+      'buffer_reads',
+      'input_history',
+      'pinned_buffers',
+      'nicklist_collapsed',
+      'channel_notify_settings',
+      'user_drafts',
+    ]) {
+      const cols = (db.prepare(`PRAGMA table_info(${t})`).all() as Array<{ name: string }>).map(
+        (c) => `${t}.${c.name}`,
+      );
+      expect(cols).toContain(`${t}.buffer_id`);
+      expect(cols).not.toContain(`${t}.target`);
+    }
+  });
+
+  it('merges read-pointer case twins: furthest pointer, max clear marker', async () => {
+    const { getReadState, getClearedState } = await import('./bufferReads.js');
+    expect(getReadState(1, 10, '#CHAN')).toBe(90);
+    expect(getClearedState(1, 10, '#chan')).toEqual({
+      clearedBeforeId: 40,
+      clearedAt: '2026-01-01T00:00:00Z',
+    });
+    const count = db
+      .prepare(`SELECT COUNT(*) AS n FROM buffer_reads WHERE user_id = 1 AND buffer_id = 100`)
+      .get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+
+  it('repoints sentinel read pointers onto the sentinel rows', async () => {
+    const { getReadState } = await import('./bufferReads.js');
+    expect(getReadState(1, 10, ':server:10')).toBe(7);
+    expect(getReadState(1, null, ':system:')).toBe(3);
+    const sysRow = db
+      .prepare(`SELECT buffer_id AS b FROM buffer_reads WHERE user_id = 1 AND buffer_id = 103`)
+      .get() as { b: number } | undefined;
+    expect(sysRow?.b).toBe(103);
+  });
+
+  it('mints a closed row for a read pointer whose buffer the registry forgot', () => {
+    const vanished = db
+      .prepare(
+        `SELECT id, state FROM buffers WHERE user_id = 1 AND network_id = 10
+         AND target_folded = '#vanished'`,
+      )
+      .get() as { id: number; state: string } | undefined;
+    expect(vanished?.state).toBe('closed');
+    const read = db
+      .prepare(`SELECT last_read_message_id AS lr FROM buffer_reads WHERE buffer_id = ?`)
+      .get(vanished?.id) as { lr: number } | undefined;
+    expect(read?.lr).toBe(12);
+  });
+
+  it('preserves input-history ids and repoints case twins onto one buffer', async () => {
+    const { listRecent } = await import('./inputHistory.js');
+    expect(listRecent(1, 10, '#chan')).toEqual(['first', 'second']);
+    expect(listRecent(1, 10, 'bob')).toEqual(['dm line']);
+    const ids = db
+      .prepare(`SELECT id FROM input_history WHERE buffer_id = 100 ORDER BY id`)
+      .all() as Array<{ id: number }>;
+    expect(ids.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('merges pin twins keeping the earliest slot, then re-densifies positions', async () => {
+    const { listPinnedForUserNetwork } = await import('./pinnedBuffers.js');
+    // '#chan' (pos 0) and '#Chan' (pos 2) merge into position 0; 'bob' slides
+    // from 1 into the dense order after renumbering.
+    expect(listPinnedForUserNetwork(1, 10)).toEqual(['#Chan', 'bob']);
+    const rows = db
+      .prepare(`SELECT position FROM pinned_buffers WHERE user_id = 1 ORDER BY position`)
+      .all() as Array<{ position: number }>;
+    expect(rows.map((r) => r.position)).toEqual([0, 1]);
+  });
+
+  it('merges nicklist twins with MAX(collapsed)', async () => {
+    const { listCollapsedForUserNetwork } = await import('./nicklistCollapsed.js');
+    expect(listCollapsedForUserNetwork(1, 10)).toEqual({ '#Chan': true });
+  });
+
+  it('keeps notify_always and drops the dead muted column', async () => {
+    const { getChannelNotifyAlways } = await import('./channelNotify.js');
+    expect(getChannelNotifyAlways(1, 10, '#chan')).toBe(true);
+  });
+
+  it('the LATEST draft wins a case-twin merge', async () => {
+    const { listForUser } = await import('./drafts.js');
+    const drafts = listForUser(1);
+    expect(drafts).toHaveLength(2);
+    expect(drafts.find((d) => d.target === '#Chan')).toMatchObject({
+      networkId: 10,
+      body: 'newer draft',
+    });
+  });
+
+  it('coalesces a foreign-numbered :server: stray onto the canonical sentinel', async () => {
+    const { listForUser } = await import('./drafts.js');
+    // The ':server:99' draft (a legacy-import artifact) attaches to this
+    // network's real console — the same coalescing the v17 messages backfill
+    // and the live insert path apply — rather than dropping or minting a
+    // hidden ':' row.
+    expect(listForUser(1).find((d) => d.target === ':server:10')).toMatchObject({
+      body: 'console draft',
+    });
+    expect(db.prepare(`SELECT 1 FROM buffers WHERE target = ':server:99'`).get()).toBe(undefined);
+  });
+});

--- a/server/routes/drafts.test.ts
+++ b/server/routes/drafts.test.ts
@@ -46,6 +46,13 @@ beforeAll(async () => {
     nick: 'bob',
   })!;
 
+  // Drafts are buffer_id-keyed (schema 18) — flush targets must be buffers
+  // the registry knows.
+  const { ensureExists } = await import('../db/buffers.js');
+  for (const t of ['#meta', '#nope', '#ok', '#clear-me', 'bob']) {
+    ensureExists(alice.id, aliceNet.id, t);
+  }
+
   app = createTestApp({ '/api/drafts': router });
   aliceAgent = await createAuthedAgent(app, alice.id);
 });

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -191,7 +191,10 @@ describe('importFromZipBuffer — roundtrip', () => {
     expect(bobRules[0].pattern).toBe('alice');
 
     const bobPins = db
-      .prepare('SELECT * FROM pinned_buffers WHERE user_id = ?')
+      .prepare(
+        `SELECT p.network_id, b.target FROM pinned_buffers p
+         JOIN buffers b ON b.id = p.buffer_id WHERE p.user_id = ?`,
+      )
       .all(bob.id) as Array<{ network_id: number; target: string }>;
     expect(bobPins.length).toBe(1);
     expect(bobPins[0].network_id).toBe(bobNets[0].id);

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -31,7 +31,13 @@ import type { Statement, RunResult } from 'better-sqlite3';
 import db from '../db/index.js';
 import { EXPORT_TABLES, EXPORT_FORMAT_VERSION, IMPORT_ORDER } from '../db/exportSchema.js';
 import { encryptSecret } from '../utils/secretCrypto.js';
-import { importRow as importBufferRow, reopen as reopenBuffer } from '../db/buffers.js';
+import {
+  importRow as importBufferRow,
+  reopen as reopenBuffer,
+  ensureServerBuffer,
+  ensureSystemBuffer,
+} from '../db/buffers.js';
+import { resolveBuffer } from '../db/bufferResolve.js';
 import { listBufferTargets, hasMessageForTarget } from '../db/messages.js';
 import { resolveOrMintForInsert } from '../db/bufferResolve.js';
 import { migrateSmartFilterToEventMode } from '../db/migrateEventMode.js';
@@ -180,6 +186,34 @@ function dependsOnMessages(def: ExportTableDefFull): boolean {
   return !!(def.fkRekey && Object.values(def.fkRekey).includes('messages'));
 }
 
+// The buffer_id-keyed view-state tables (schema 18). Only these get the
+// v1-archive name→id derivation below.
+const SATELLITE_BUFFER_TABLES = new Set([
+  'buffer_reads',
+  'input_history',
+  'pinned_buffers',
+  'nicklist_collapsed',
+  'channel_notify_settings',
+  'user_drafts',
+]);
+
+/** Resolve an archive row's (networkId, target) — already mapped to THIS
+ *  install's network id — to a buffer id. Sentinel targets mint/attach to
+ *  this install's own consoles. */
+function resolveArchiveBufferId(
+  userId: number,
+  networkId: number | null,
+  target: string,
+): number | undefined {
+  if (!target) return undefined;
+  if (target.startsWith(':')) {
+    if (networkId == null || target === ':system:') return ensureSystemBuffer(userId).id;
+    return ensureServerBuffer(networkId)?.id;
+  }
+  if (networkId == null) return undefined;
+  return resolveBuffer(userId, networkId, target)?.id;
+}
+
 // Insert all rows of one data.json table, building its id map for FK rekeying.
 // Caller runs this inside a transaction.
 function insertTable(
@@ -216,6 +250,26 @@ function insertTable(
       // network id, which nothing on this install will ever ask for. The
       // target install mints its own sentinels on first use.
       if (String(row.target ?? '').startsWith(':')) continue;
+    }
+
+    // v1-archive fallback for the buffer_id-keyed view-state tables: pre-v2
+    // rows carry (network_id, target) instead of buffer_id. Derive it against
+    // the already-imported registry (Phase A puts `buffers` before all of
+    // these) — the old network id maps through idMaps.networks explicitly,
+    // since most of these tables no longer declare network_id as a column.
+    // ':'-prefixed targets route to this install's own sentinels, which is
+    // strictly better than v1-era behavior: an archived server-console read
+    // pointer used to strand under ':server:<oldNetId>'; now it lands on the
+    // network's real console. Unresolvable rows drop, same as any unmapped FK.
+    if (SATELLITE_BUFFER_TABLES.has(table) && row.buffer_id === undefined) {
+      const target = typeof original.target === 'string' ? original.target : '';
+      const oldNet = original.network_id;
+      const mappedNet =
+        oldNet == null ? null : (idMaps.networks?.get(oldNet) as number | undefined);
+      if (oldNet != null && mappedNet === undefined) continue; // network wasn't imported
+      row.buffer_id = resolveArchiveBufferId(targetUserId, mappedNet ?? null, target);
+      if (row.buffer_id === undefined) continue;
+      if (table === 'pinned_buffers' && row.network_id == null) row.network_id = mappedNet;
     }
 
     // Export carries at-rest secrets (network passwords, +k channel keys) as

--- a/server/services/wsHub.decorate.test.ts
+++ b/server/services/wsHub.decorate.test.ts
@@ -39,6 +39,10 @@ beforeAll(async () => {
     tls: true,
     nick: 'decorateuser',
   })!.id;
+  // Notify flags are buffer_id-keyed (schema 18) — the flag only exists for a
+  // registered buffer.
+  const { ensureExists } = await import('../db/buffers.js');
+  ensureExists(userId, networkId, '#lurker');
 });
 
 afterAll(() => {


### PR DESCRIPTION
Second migration tier of #695, on top of #711. **This is the rollback point of no return**: the six view-state tables' primary keys are rebuilt and their name columns dropped, so a binary rolled back past this release cannot read them. #711 was additive and rollback-safe; this one is deliberately not. Recommend running the migration drill on a production-DB copy before merging (same procedure as #711's: \`DATABASE_PATH=<copy> npx tsx server/db/index.ts\`).

## What rebuilds

\`buffer_reads\`, \`input_history\`, \`pinned_buffers\`, \`nicklist_collapsed\`, \`channel_notify_settings\`, \`user_drafts\` → \`(user_id, buffer_id)\` keys, name columns gone. Module signatures unchanged (callers still speak \`(networkId, target)\`; resolution happens once per call, list shapes join back through \`buffers\`). Writing state for a buffer the registry doesn't know becomes a no-op instead of an untethered row — the detached-read-pointer class (#355's ms-blowup incident) is now unrepresentable.

## What deliberately does NOT rebuild — a scope change from the plan

The five e2e tables were slated for buffer_id keying with an \`IFNULL\` sentinel dance. Exploration killed that: their \`channel\` column is an **IRC-side crypto-context string**, not a buffer-name domain — it holds \`@ident@host\` DM pseudochannels (no buffer row exists or should), the literal \`'@'\` from empty-handle call sites, and peer-supplied names for channels this user never joined. A buffer_id there is a category error. They're reclassified **\`wire-context\`** in the registry, with a drift test asserting they never grow a buffer_id. Bonus: DM crypto contexts are host-keyed, so they're already rename-proof, and the delicate RPE2E code is untouched by this whole stack.

## Migration (schema 18)

One immediate transaction (Litestream rule), \`prevFk\` OFF/ON, the established CREATE→INSERT SELECT→DROP→RENAME shape. These tables are thousands of rows — atomic-and-quick, no chunking needed. Version+shape gated so a kill between commit and version bump re-enters as a no-op.

- **Case-twin merges** (the old binary PKs let \`#Chan\`/\`#chan\` coexist): furthest read pointer + max clear marker (mirrors the old fold's policy), earliest pin slot then re-densified positions, MAX for booleans, latest draft wins.
- **Sentinel pointers** (\`:system:\` NULL-network, \`:server:<id>\`) repoint onto the v17 sentinel rows; **foreign-numbered \`:server:\` strays** coalesce onto the network's canonical console (same rule as the v17 backfill).
- Unresolvable targets mint closed orphan buffers (read pointers preserved); anything still unresolvable drops with a **logged count**, never silently.
- The dead \`channel_notify_settings.muted\` column (folded into the ignore engine at #359) dies here; its every-boot reconciler is gated on the column existing.
- \`foldBufferCase\` becomes shape-aware (it only ever runs against pre-v18 shapes inside the v9/v16 migration path; called on a migrated DB it now skips the id-keyed tables instead of erroring). The \`idx_buffer_reads_key\` coalesced-IFNULL dance and the redundant per-user indexes retire — the new PKs serve those scans.

## Export format v2

\`EXPORT_FORMAT_VERSION → 2\`. The six tables export \`buffer_id\`, rekeyed through the archive's own \`buffers\` rows via the existing idMaps machinery. **v1 archives still import** — the importer derives buffer_id per row from their \`(network_id, target)\`, routing sentinel targets to this install's own consoles (which un-strands archived server-console read pointers, previously lost). A v1 **server** rejects a v2 archive as \`format_too_new\` — deliberate and one-way.

## Tests

\`satelliteRebuild.test.ts\` (v17-shape raw fixture → module import): value-level assertions for every merge policy, sentinel repointing, the orphan mint, and the stray coalesce. **Mutation-verified**: MIN-pointer merge, disabled sentinel-coalesce, and disabled orphan-mint each fail named tests (the coalesce mutation initially passed — the fixture lacked a stray, the exact vacuous-test trap from the #706 post-mortem — fixed with a \`:server:99\` draft fixture). Drift test gains the wire-context and no-name-column invariants; \`migrateMutedFold\` tests moved to a legacy-shape scratch DB (matching the only world its code runs in); module test fixtures now mint the buffers they write to. Full suite: 3,573 passed. \`npm run check\` clean.

Part of #695. Next: PR 3 lifts db signatures to bufferId and puts it on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)