### PR TITLE
DM buffers follow their peer through /nick

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -630,6 +630,7 @@ a v1 client.
 | `send-result`                                                                                                                                                            | `clientId, ok, error?`                                                                                                                                                                                                                                                | Ack for `send`/`action`/`notice`                                                                                                                          |
 | `buffer-opened` / `buffer-closed` / `buffer-reopened`                                                                                                                    | `networkId, target, bufferId?` (absent only on the ack for a channel still being JOINed — no row yet)                                                                                                                                                                 | Buffer lifecycle (§9.1). `buffer-opened` is an ack to the socket that asked **and** a fan-out to the user's other devices — only focus on your own (§4.3) |
 | `buffer-cleared`                                                                                                                                                         | `networkId, target, bufferId, clearedBeforeId, clearedAt`                                                                                                                                                                                                             | `/clear` marker                                                                                                                                           |
+| `buffer-renamed`                                                                                                                                                         | `networkId, from, to, bufferId, merged, mergedFromBufferId?` — see §9.7                                                                                                                                                                                               | A buffer changed names (same id): DM follows a peer's NICK                                                                                                |
 | `pins-changed`                                                                                                                                                           | `networkId, pinned[], pinnedIds[]` (parallel-indexed: `pinnedIds[i]` is `pinned[i]`'s buffer)                                                                                                                                                                         | Authoritative pin order                                                                                                                                   |
 | `nicklist-collapsed-changed` / `channel-notify-changed`                                                                                                                  | `networkId, target, bufferId, …`                                                                                                                                                                                                                                      | View-state sync                                                                                                                                           |
 | `draft-updated` / `input-history-added` / `bookmark-updated` / `nick-note-updated` / `relay-bot-updated` / `contact-updated` / `contact-deleted` / `ignore-list-updated` | various                                                                                                                                                                                                                                                               | Multi-device view-state fan-out                                                                                                                           |
@@ -948,6 +949,54 @@ remove, `kick`→remove `kicked`, `nick`→rename (`chghost` renders only; its
 nicklist patch arrives separately as `member-update`).
 
 ---
+
+### 9.7 Renames keep a buffer's identity
+
+**Emitted today for DM buffers following a peer's `/nick`** (weechat/irssi
+parity); channel renames (`draft/channel-rename`) will reuse the same frame.
+
+```jsonc
+{
+  "kind": "buffer-renamed",
+  "networkId": 4,
+  "from": "alice", // canonical pre-rename name (registry casing)
+  "to": "alice_away", // authoritative new name — key off THIS
+  "bufferId": 42, // the SURVIVING buffer; its id did not change
+  "merged": false,
+  "mergedFromBufferId": 17, // present iff merged: the absorbed, now-deleted id
+}
+```
+
+The contract, in the order a client should apply it:
+
+- **The id never changes.** `bufferId` is the same id this buffer has always
+  had; only the name moved. A client keying state by id has almost nothing to
+  do; a client keying by name rekeys `from → to` in every store holding
+  per-buffer state (the web client does this with one registry sweep —
+  `lib/bufferLifecycle.ts`).
+- **`merged: true` means another buffer was absorbed.** A row already held
+  the new name (a stale DM under the peer's old nick, usually). The SOURCE
+  survives — the live conversation keeps its id — and `mergedFromBufferId`
+  names the absorbed buffer: drop it everywhere first, then apply the rename;
+  done in that order there is no key collision. The merged history
+  interleaves server-side, so wipe the local slice and re-hydrate rather
+  than guessing at the interleave.
+- **Corrections ride behind a merge.** `read-state`, `pins-changed`, and (when
+  the surviving draft changed) `draft-updated` frames follow immediately —
+  the merge changed those server-side and an idle buffer would never
+  otherwise learn.
+- **Key off `to`, never a name you predicted**, and follow the active buffer:
+  a rename of the buffer the user is reading is the same buffer, not a
+  navigation.
+- The frame reaches **every** socket including whichever device's action
+  caused it — it describes a fact, not an instruction.
+- The DM also receives an ordinary persisted `type:'nick'` row ("x is now
+  known as y"), AFTER the rename, so it renders under the new name with the
+  same code path channel nick rows use.
+- What deliberately does NOT follow a rename: highlight/ignore rules scoped
+  to the old name (glob patterns, possibly cross-network), and e2e crypto
+  contexts (wire-keyed; a DM context keys on the peer's host and is already
+  rename-proof).
 
 ## 10. HTTP API reference
 

--- a/server/db/drafts.ts
+++ b/server/db/drafts.ts
@@ -62,3 +62,16 @@ export function clearDraft(userId: number, networkId: number, target: string): n
 export function listForUser(userId: number): DraftRow[] {
   return listStmt.all(userId) as DraftRow[];
 }
+
+const getForBufferStmt = db.prepare(`
+  SELECT d.buffer_id AS bufferId, b.network_id AS networkId, b.target AS target,
+         d.body AS body, d.updated_at AS updatedAt
+    FROM user_drafts d JOIN buffers b ON b.id = d.buffer_id
+   WHERE d.user_id = ? AND d.buffer_id = ?
+`);
+
+/** Point read by buffer id — the rename/merge announcement uses this to ship
+ *  the surviving draft. */
+export function getDraftForBuffer(userId: number, bufferId: number): DraftRow | undefined {
+  return getForBufferStmt.get(userId, bufferId) as DraftRow | undefined;
+}

--- a/server/db/renameBuffer.test.ts
+++ b/server/db/renameBuffer.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-rename-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+let buffers: typeof import('./buffers.js');
+let renameBuffer: typeof import('./renameBuffer.js').renameBuffer;
+let insertMessage: typeof import('./messages.js').insertMessage;
+let listMessages: typeof import('./messages.js').listMessages;
+let bufferReads: typeof import('./bufferReads.js');
+let pinned: typeof import('./pinnedBuffers.js');
+let drafts: typeof import('./drafts.js');
+let userId: number;
+let networkId: number;
+
+function seed(target: string, text: string): number {
+  return Number(
+    insertMessage({
+      networkId,
+      target,
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'peer',
+      text,
+    }).id,
+  );
+}
+
+beforeAll(async () => {
+  ({ default: db } = await import('./index.js'));
+  ({ createUser } = await import('./users.js'));
+  ({ createNetwork } = await import('./networks.js'));
+  buffers = await import('./buffers.js');
+  ({ renameBuffer } = await import('./renameBuffer.js'));
+  ({ insertMessage, listMessages } = await import('./messages.js'));
+  bufferReads = await import('./bufferReads.js');
+  pinned = await import('./pinnedBuffers.js');
+  drafts = await import('./drafts.js');
+  userId = createUser('rename-alice').id;
+  networkId = createNetwork(userId, {
+    name: 'libera',
+    host: 'h',
+    port: 6697,
+    tls: true,
+    nick: 'a',
+  })!.id;
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('plain rename', () => {
+  it('is one row update: same id, new name, satellites follow for free', () => {
+    buffers.ensureOpen(userId, networkId, 'oldnick');
+    const before = buffers.getBuffer(userId, networkId, 'oldnick')!;
+    seed('oldnick', 'hello');
+    bufferReads.setReadState(userId, networkId, 'oldnick', 1_000_000);
+    drafts.upsertDraft(userId, networkId, 'oldnick', 'wip');
+
+    const result = renameBuffer(userId, networkId, 'oldnick', 'newnick')!;
+    expect(result).toMatchObject({
+      renamed: true,
+      bufferId: before.id,
+      from: 'oldnick',
+      to: 'newnick',
+      merged: false,
+    });
+
+    // The old name is gone, the new one resolves to the SAME id.
+    expect(buffers.getBuffer(userId, networkId, 'oldnick')).toBeUndefined();
+    expect(buffers.getBuffer(userId, networkId, 'newnick')?.id).toBe(before.id);
+    // Satellites were never name-keyed, so they simply follow.
+    expect(listMessages(networkId, 'newnick').map((m) => m.text)).toEqual(['hello']);
+    expect(bufferReads.getReadState(userId, networkId, 'newnick')).toBe(1_000_000);
+    expect(drafts.listForUser(userId).find((d) => d.target === 'newnick')?.body).toBe('wip');
+  });
+
+  it('casing-only: adopts the display casing, same identity, no merge', () => {
+    buffers.ensureOpen(userId, networkId, 'carol');
+    const id = buffers.getBuffer(userId, networkId, 'carol')!.id;
+    const result = renameBuffer(userId, networkId, 'carol', 'Carol')!;
+    expect(result).toMatchObject({ renamed: true, merged: false, bufferId: id, to: 'Carol' });
+    expect(buffers.getBuffer(userId, networkId, 'carol')?.target).toBe('Carol');
+  });
+
+  it('a true no-op (same casing) reports renamed: false', () => {
+    buffers.ensureOpen(userId, networkId, 'dave');
+    expect(renameBuffer(userId, networkId, 'dave', 'dave')?.renamed).toBe(false);
+  });
+
+  it('unknown source returns undefined; sentinels refuse', () => {
+    expect(renameBuffer(userId, networkId, 'nobody-here', 'x')).toBeUndefined();
+    expect(renameBuffer(userId, networkId, `:server:${networkId}`, 'x')?.renamed).toBe(false);
+  });
+});
+
+describe('merge (a buffer already holds the new name): SOURCE survives', () => {
+  it('keeps the live id, repoints history, merges pointers, unions visibility', () => {
+    // The absorbed side: an old CLOSED dm under the new nick, with history,
+    // a further clear marker, and a pin.
+    buffers.ensureOpen(userId, networkId, 'erin_away');
+    const absorbedId = buffers.getBuffer(userId, networkId, 'erin_away')!.id;
+    const oldMsg = seed('erin_away', 'ancient chat');
+    bufferReads.setReadState(userId, networkId, 'erin_away', oldMsg);
+    pinned.pinBuffer(userId, networkId, 'erin_away');
+    buffers.close(userId, networkId, 'erin_away');
+
+    // The live side: the current conversation.
+    buffers.ensureOpen(userId, networkId, 'erin');
+    const liveId = buffers.getBuffer(userId, networkId, 'erin')!.id;
+    const liveMsg = seed('erin', 'current chat');
+    bufferReads.setReadState(userId, networkId, 'erin', liveMsg);
+    drafts.upsertDraft(userId, networkId, 'erin', 'live draft');
+
+    const result = renameBuffer(userId, networkId, 'erin', 'erin_away')!;
+    expect(result).toMatchObject({
+      renamed: true,
+      merged: true,
+      bufferId: liveId,
+      mergedFromBufferId: absorbedId,
+      to: 'erin_away',
+    });
+
+    // One buffer remains, under the live conversation's id, OPEN (union).
+    const survivor = buffers.getBuffer(userId, networkId, 'erin_away')!;
+    expect(survivor.id).toBe(liveId);
+    expect(survivor.state).toBe('open');
+    expect(db.prepare(`SELECT 1 FROM buffers WHERE id = ?`).get(absorbedId)).toBeUndefined();
+
+    // Histories interleave (global id order) on the survivor.
+    expect(listMessages(networkId, 'erin_away').map((m) => m.text)).toEqual([
+      'ancient chat',
+      'current chat',
+    ]);
+    // Furthest read pointer wins (liveMsg > oldMsg).
+    expect(bufferReads.getReadState(userId, networkId, 'erin_away')).toBe(liveMsg);
+    // The absorbed pin transferred to the survivor and positions are dense.
+    expect(pinned.listPinnedForUserNetwork(userId, networkId)).toContain('erin_away');
+    // The survivor's draft wins.
+    expect(drafts.getDraftForBuffer(userId, liveId)?.body).toBe('live draft');
+    expect(result.draftChanged).toBe(false);
+  });
+
+  it('adopts the absorbed draft when the survivor has none, and says so', () => {
+    buffers.ensureOpen(userId, networkId, 'frank2');
+    drafts.upsertDraft(userId, networkId, 'frank2', 'stashed');
+    buffers.ensureOpen(userId, networkId, 'frank');
+    const liveId = buffers.getBuffer(userId, networkId, 'frank')!.id;
+
+    const result = renameBuffer(userId, networkId, 'frank', 'frank2')!;
+    expect(result.merged).toBe(true);
+    expect(result.draftChanged).toBe(true);
+    expect(drafts.getDraftForBuffer(userId, liveId)?.body).toBe('stashed');
+  });
+});

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import db from './index.js';
+import { foldTarget } from './buffers.js';
+import { resolveBuffer } from './bufferResolve.js';
+
+// Rename a buffer — the primitive behind DM nick-follows (and, when the
+// draft/channel-rename CAP lands, channel renames). Under the normalized
+// schema this is what the closed PR #706 spent 650 lines approximating with
+// name-keyed rewrites: identity is buffers.id, so the plain case is ONE
+// UPDATE on one row, and nothing else in the database mentions the name.
+//
+// THE invariant (CLIENT_PROTOCOL §5.2): a buffer's id never changes, renames
+// included. A merge therefore deletes the OTHER row — the SOURCE survives.
+// The source is the live conversation (the DM being renamed under the user's
+// feet); destination-survives would force every client to handle "your
+// active buffer's identity just changed", which is strictly harder than
+// "some other buffer you may hold was absorbed".
+//
+// Merge policies for the absorbed row's satellite state mirror the v18
+// case-twin rebuild: furthest read pointer + max clear marker, survivor's
+// pin slot (or adopt the absorbed one), survivor's view-state rows win,
+// survivor's draft wins when present. Messages repoint wholesale — the
+// merged history interleaves by id, which is already global order.
+
+export interface RenameResult {
+  /** False when nothing happened (unknown source, or a true no-op). */
+  renamed: boolean;
+  /** The surviving buffer — same id the source always had. */
+  bufferId: number;
+  /** Canonical pre-rename name (registry casing, not the caller's). */
+  from: string;
+  /** The name as stored post-rename (the requested casing). */
+  to: string;
+  /** True when a row already existed under the new name and was absorbed. */
+  merged: boolean;
+  /** The absorbed row's id — clients must drop this buffer. */
+  mergedFromBufferId?: number;
+  /** True when the merge left the surviving draft different from the
+   *  source's (the client should refresh its mirror). */
+  draftChanged: boolean;
+}
+
+const setNameStmt = db.prepare(`UPDATE buffers SET target = ?, target_folded = ? WHERE id = ?`);
+const setOpenStmt = db.prepare(`UPDATE buffers SET state = 'open', closed_at = NULL WHERE id = ?`);
+const deleteRowStmt = db.prepare(`DELETE FROM buffers WHERE id = ?`);
+
+// --- merge helpers (absorbed → survivor) -----------------------------------
+
+const repointMessages = db.prepare(`UPDATE messages SET buffer_id = ? WHERE buffer_id = ?`);
+const repointInputHistory = db.prepare(
+  `UPDATE input_history SET buffer_id = ? WHERE buffer_id = ?`,
+);
+
+// buffer_reads: fold the absorbed row into the survivor's (furthest pointer,
+// max marker with its own timestamp), then let the absorbed row die with its
+// buffer (ON DELETE CASCADE).
+const mergeReadsStmt = db.prepare(`
+  UPDATE buffer_reads SET
+    last_read_message_id = MAX(
+      last_read_message_id,
+      COALESCE((SELECT r2.last_read_message_id FROM buffer_reads r2
+                 WHERE r2.user_id = buffer_reads.user_id AND r2.buffer_id = @absorbed), 0)),
+    cleared_at = CASE
+      WHEN COALESCE((SELECT r2.cleared_before_message_id FROM buffer_reads r2
+                      WHERE r2.user_id = buffer_reads.user_id AND r2.buffer_id = @absorbed), 0)
+           > COALESCE(cleared_before_message_id, 0)
+      THEN (SELECT r2.cleared_at FROM buffer_reads r2
+             WHERE r2.user_id = buffer_reads.user_id AND r2.buffer_id = @absorbed)
+      ELSE cleared_at END,
+    cleared_before_message_id = NULLIF(MAX(
+      COALESCE(cleared_before_message_id, 0),
+      COALESCE((SELECT r2.cleared_before_message_id FROM buffer_reads r2
+                 WHERE r2.user_id = buffer_reads.user_id AND r2.buffer_id = @absorbed), 0)), 0)
+  WHERE buffer_id = @survivor
+`);
+const adoptReadsStmt = db.prepare(
+  `UPDATE OR IGNORE buffer_reads SET buffer_id = ? WHERE buffer_id = ?`,
+);
+
+// pins: survivor keeps its slot; an absorbed-only pin transfers.
+const adoptPinStmt = db.prepare(
+  `UPDATE OR IGNORE pinned_buffers SET buffer_id = ? WHERE buffer_id = ?`,
+);
+
+// view-state singletons: survivor's row wins, absorbed-only rows transfer.
+const adoptNicklistStmt = db.prepare(
+  `UPDATE OR IGNORE nicklist_collapsed SET buffer_id = ? WHERE buffer_id = ?`,
+);
+const adoptNotifyStmt = db.prepare(
+  `UPDATE OR IGNORE channel_notify_settings SET buffer_id = ? WHERE buffer_id = ?`,
+);
+const adoptDraftStmt = db.prepare(
+  `UPDATE OR IGNORE user_drafts SET buffer_id = ? WHERE buffer_id = ?`,
+);
+const draftBodyStmt = db.prepare(
+  `SELECT body FROM user_drafts WHERE user_id = ? AND buffer_id = ?`,
+);
+
+// Re-densify a (user, network)'s pin positions after a merge dropped a row.
+const renumberPinsStmt = db.prepare(`
+  UPDATE pinned_buffers SET position = (
+    SELECT rn - 1 FROM (
+      SELECT p2.buffer_id AS bid2,
+             ROW_NUMBER() OVER (
+               PARTITION BY p2.user_id, p2.network_id ORDER BY p2.position, p2.buffer_id
+             ) AS rn
+      FROM pinned_buffers p2
+      WHERE p2.user_id = pinned_buffers.user_id AND p2.network_id = pinned_buffers.network_id
+    ) WHERE bid2 = pinned_buffers.buffer_id
+  )
+  WHERE user_id = ? AND network_id = ?
+`);
+
+const work = db.transaction(
+  (userId: number, networkId: number, from: string, to: string): RenameResult | undefined => {
+    const src = resolveBuffer(userId, networkId, from);
+    if (!src) return undefined;
+    const noop: RenameResult = {
+      renamed: false,
+      bufferId: src.id,
+      from: src.target,
+      to: src.target,
+      merged: false,
+      draftChanged: false,
+    };
+    // Sentinels never rename; a rename onto a sentinel name is nonsense.
+    if (src.target.startsWith(':') || to.startsWith(':')) return noop;
+    const toFolded = foldTarget(to);
+
+    // Casing-only: same identity under the fold, just adopt the new display
+    // casing. Announced (the display changed) but never a merge.
+    if (toFolded === src.targetFolded) {
+      if (src.target === to) return noop;
+      setNameStmt.run(to, toFolded, src.id);
+      return {
+        renamed: true,
+        bufferId: src.id,
+        from: src.target,
+        to,
+        merged: false,
+        draftChanged: false,
+      };
+    }
+
+    const dest = resolveBuffer(userId, networkId, to);
+    if (!dest) {
+      setNameStmt.run(to, toFolded, src.id);
+      return {
+        renamed: true,
+        bufferId: src.id,
+        from: src.target,
+        to,
+        merged: false,
+        draftChanged: false,
+      };
+    }
+
+    // Merge: the destination row is absorbed into the (surviving) source.
+    const survivorDraftBefore = (draftBodyStmt.get(userId, src.id) as { body: string } | undefined)
+      ?.body;
+    repointMessages.run(src.id, dest.id);
+    repointInputHistory.run(src.id, dest.id);
+    mergeReadsStmt.run({ survivor: src.id, absorbed: dest.id });
+    adoptReadsStmt.run(src.id, dest.id);
+    adoptPinStmt.run(src.id, dest.id);
+    adoptNicklistStmt.run(src.id, dest.id);
+    adoptNotifyStmt.run(src.id, dest.id);
+    adoptDraftStmt.run(src.id, dest.id);
+    // Visibility is the union: if either side was open, the merged buffer is.
+    if (dest.state === 'open' && src.state !== 'open') setOpenStmt.run(src.id);
+    // The absorbed row dies; its remaining satellites cascade with it (any
+    // UPDATE OR IGNORE above that lost to the survivor left rows behind).
+    deleteRowStmt.run(dest.id);
+    renumberPinsStmt.run(userId, networkId);
+    setNameStmt.run(to, toFolded, src.id);
+    const survivorDraftAfter = (draftBodyStmt.get(userId, src.id) as { body: string } | undefined)
+      ?.body;
+    return {
+      renamed: true,
+      bufferId: src.id,
+      from: src.target,
+      to,
+      merged: true,
+      mergedFromBufferId: dest.id,
+      draftChanged: survivorDraftAfter !== survivorDraftBefore,
+    };
+  },
+);
+
+/**
+ * Rename (user, network, from) → to, merging if a buffer already holds the
+ * new name. One IMMEDIATE transaction — it reads (resolves, draft probe)
+ * before it writes, and on a hosted cell a deferred BEGIN in that shape is
+ * the Litestream SQLITE_BUSY_SNAPSHOT crash class (db/index.ts:~2022).
+ * Returns undefined when the source doesn't exist.
+ */
+export function renameBuffer(
+  userId: number,
+  networkId: number,
+  from: string,
+  to: string,
+): RenameResult | undefined {
+  if (!to || !from) return undefined;
+  return work.immediate(userId, networkId, from, to);
+}

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2633,3 +2633,77 @@ describe('DM rename on peer NICK', () => {
     expect(published.find((e) => e.type === 'buffer-renamed')).toBeUndefined();
   });
 });
+
+// #716 QA follow-up: a DM opened fresh from the nicklist showed its peer
+// offline until the first message, because the presence probe refused to
+// track anything without a conversation. The gate exists for notice-only
+// service buffers (NickServ, #439) — an EMPTY buffer is deliberate user
+// intent and must probe.
+describe('probePresence intent gate', () => {
+  function connFor(name: string) {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'me',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+    })!;
+    const conn = new IrcConnection({ network, onEvent: () => {} });
+    const tracked: string[] = [];
+    conn.trackDmPeer = vi.fn<(nick: string) => boolean>((n) => {
+      tracked.push(n);
+      return true;
+    }) as typeof conn.trackDmPeer;
+    return { conn, network, tracked };
+  }
+
+  it('probes a brand-new empty DM (the just-opened query)', async () => {
+    const { conn, network, tracked } = connFor('probe-fresh');
+    const { ensureOpen } = await import('../db/buffers.js');
+    ensureOpen(network.user_id, network.id, 'newperson', { kind: 'dm' });
+    conn.probePresence('newperson');
+    expect(tracked).toEqual(['newperson']);
+  });
+
+  it('probes a real conversation', async () => {
+    const { conn, network, tracked } = connFor('probe-convo');
+    const { ensureOpen } = await import('../db/buffers.js');
+    const { insertMessage } = await import('../db/messages.js');
+    ensureOpen(network.user_id, network.id, 'talker', { kind: 'dm' });
+    insertMessage({
+      networkId: network.id,
+      target: 'talker',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'talker',
+      text: 'hi',
+    });
+    conn.probePresence('talker');
+    expect(tracked).toEqual(['talker']);
+  });
+
+  it('still refuses a notice-only service buffer', async () => {
+    const { conn, network, tracked } = connFor('probe-service');
+    const { ensureOpen } = await import('../db/buffers.js');
+    const { insertMessage } = await import('../db/messages.js');
+    ensureOpen(network.user_id, network.id, 'NickServ', { kind: 'dm' });
+    insertMessage({
+      networkId: network.id,
+      target: 'NickServ',
+      time: new Date().toISOString(),
+      type: 'notice',
+      nick: 'NickServ',
+      text: 'This nickname is registered.',
+    });
+    conn.probePresence('NickServ');
+    expect(tracked).toEqual([]);
+  });
+});

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2533,3 +2533,103 @@ describe('join echo, forwarded joins (470), and un-partable channels (442)', () 
     expect(getBuffer(conn.network.user_id, conn.network.id, '#apple')?.autojoin).toBe(false);
   });
 });
+
+// #695: a DM buffer follows its peer through /nick (weechat/irssi parity).
+describe('DM rename on peer NICK', () => {
+  function connFor(name: string) {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'me',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+    })!;
+    const conn = new IrcConnection({ network, onEvent: () => {} });
+    conn.client.user.nick = 'me';
+    const published: Array<Record<string, unknown>> = [];
+    conn.publish = vi.fn<(event: unknown) => void>((e) => {
+      published.push(e as Record<string, unknown>);
+    }) as typeof conn.publish;
+    conn.publishEphemeral = vi.fn<(event: unknown) => void>((e) => {
+      published.push(e as Record<string, unknown>);
+    }) as typeof conn.publishEphemeral;
+    return { conn, network, published };
+  }
+
+  it('renames the DM row, announces it, and persists the "known as" line under the NEW name', async () => {
+    const { conn, network, published } = connFor('dmrename');
+    const { ensureOpen, getBuffer: get } = await import('../db/buffers.js');
+    ensureOpen(network.user_id, network.id, 'bob', { kind: 'dm' });
+    const id = get(network.user_id, network.id, 'bob')!.id;
+
+    conn.client.emit('nick', { nick: 'bob', new_nick: 'bob_away' });
+
+    // The registry row kept its id and adopted the new name.
+    expect(get(network.user_id, network.id, 'bob')).toBeUndefined();
+    expect(get(network.user_id, network.id, 'bob_away')?.id).toBe(id);
+    // The announcement, then the DM's own nick row — in that order, so the
+    // row lands under the buffer's new name.
+    const renamed = published.find((e) => e.type === 'buffer-renamed');
+    expect(renamed).toMatchObject({ from: 'bob', to: 'bob_away', bufferId: id, merged: false });
+    const nickRow = published.find((e) => e.type === 'nick' && e.target === 'bob_away');
+    expect(nickRow).toMatchObject({ nick: 'bob', newNick: 'bob_away' });
+    expect(published.indexOf(renamed!)).toBeLessThan(published.indexOf(nickRow!));
+  });
+
+  it('a collision merges source-survives and announces the absorbed id', async () => {
+    const { conn, network, published } = connFor('dmrename-merge');
+    const { ensureOpen, getBuffer: get } = await import('../db/buffers.js');
+    ensureOpen(network.user_id, network.id, 'stale_carol', { kind: 'dm' });
+    const absorbedId = get(network.user_id, network.id, 'stale_carol')!.id;
+    ensureOpen(network.user_id, network.id, 'carol', { kind: 'dm' });
+    const liveId = get(network.user_id, network.id, 'carol')!.id;
+
+    conn.client.emit('nick', { nick: 'carol', new_nick: 'stale_carol' });
+
+    expect(get(network.user_id, network.id, 'stale_carol')?.id).toBe(liveId);
+    expect(published.find((e) => e.type === 'buffer-renamed')).toMatchObject({
+      bufferId: liveId,
+      merged: true,
+      mergedFromBufferId: absorbedId,
+    });
+  });
+
+  it('a closed DM renames too, without reopening', async () => {
+    const { conn, network } = connFor('dmrename-closed');
+    const { ensureOpen, close, getBuffer: get } = await import('../db/buffers.js');
+    ensureOpen(network.user_id, network.id, 'ghost', { kind: 'dm' });
+    close(network.user_id, network.id, 'ghost');
+
+    conn.client.emit('nick', { nick: 'ghost', new_nick: 'phantom' });
+
+    expect(get(network.user_id, network.id, 'phantom')?.state).toBe('closed');
+  });
+
+  it('no DM row means no rename and no announcement', async () => {
+    const { conn, network, published } = connFor('dmrename-none');
+    conn.client.emit('nick', { nick: 'stranger', new_nick: 'stranger2' });
+    const { getBuffer: get } = await import('../db/buffers.js');
+    expect(get(network.user_id, network.id, 'stranger2')).toBeUndefined();
+    expect(published.find((e) => e.type === 'buffer-renamed')).toBeUndefined();
+  });
+
+  it('our own /nick never renames a buffer', async () => {
+    const { conn, network, published } = connFor('dmrename-self');
+    const { ensureOpen, getBuffer: get } = await import('../db/buffers.js');
+    // Pathological but possible: a DM buffer named like our own nick.
+    ensureOpen(network.user_id, network.id, 'me', { kind: 'dm' });
+
+    conn.client.emit('nick', { nick: 'me', new_nick: 'me2' });
+
+    expect(get(network.user_id, network.id, 'me')).toBeDefined();
+    expect(published.find((e) => e.type === 'buffer-renamed')).toBeUndefined();
+  });
+});

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -4,6 +4,7 @@
 import IRC, { ircLineParser } from 'irc-framework';
 import type { Client as IrcClient } from 'irc-framework';
 import { insertMessage, hasMessageForTarget, hasConversationForTarget } from '../db/messages.js';
+import { renameBuffer as renameDmBuffer } from '../db/renameBuffer.js';
 import type { Network } from '../db/networks.js';
 import {
   isClosed as isBufferClosed,
@@ -2214,6 +2215,7 @@ export class IrcConnection {
       if (!isSelfNick) {
         this.markPeerEvent(eventNick, 'offline');
         this.markPeerEvent(eventNewNick, 'online');
+        this.renameDmForNickChange(eventNick, eventNewNick, userhost, event.time);
       }
     });
 
@@ -2901,6 +2903,94 @@ export class IrcConnection {
   }
 
   // ---- presence watch list (shared MONITOR + peer_presence_state rails) ----
+  // weechat/irssi parity (#695): the DM buffer follows the person through a
+  // /nick. The rename itself is one registry UPDATE (db/renameBuffer);
+  // in-memory per-target state and the MONITOR watch re-key alongside; the
+  // announcement rides publishEphemeral to wsHub, which fans the
+  // buffer-renamed frame (plus merge follow-ups) to every device. The
+  // "is now known as" row is persisted AFTER the rename so it lands under
+  // the buffer's new name — both clients already render type:'nick' rows,
+  // so the DM shows the same line a shared channel does.
+  //
+  // Closed DMs rename too: their history should follow the person, and a
+  // rename never reopens (state carries over; a merge takes the open state
+  // if EITHER side was open — see renameBuffer).
+  //
+  // Deliberately unconditional (no setting): weechat and irssi both do this
+  // without asking. irssi's user@host re-identification (renaming when the
+  // peer RECONNECTS under a new nick, no NICK seen) is out of scope — see
+  // ROADMAP.
+  private renameDmForNickChange(
+    oldNick: string,
+    newNick: string,
+    userhost: string | null,
+    time: unknown,
+  ): void {
+    let result;
+    try {
+      const row = getBuffer(this.network.user_id, this.network.id, oldNick);
+      if (!row || row.kind !== 'dm') return;
+      result = renameDmBuffer(this.network.user_id, this.network.id, oldNick, newNick);
+    } catch (e) {
+      console.warn('[nick] DM rename failed:', (e as Error)?.message || e);
+      return;
+    }
+    if (!result?.renamed) return;
+    const oldLower = oldNick.toLowerCase();
+    const newLower = newNick.toLowerCase();
+    if (oldLower !== newLower) {
+      // Per-target in-memory state follows the buffer. Each map is keyed by
+      // the folded target; leaving an entry behind resurrects the exact bug
+      // class renameChannel's comment catalogues (a stale can't-speak-here
+      // flag, a leaked one-shot WHO suppression, a stranded CTCP queue).
+      if (this.unsendableTargets.delete(oldLower)) this.unsendableTargets.add(newLower);
+      const lastSend = this.lastUserSendAt.get(oldLower);
+      if (lastSend !== undefined) {
+        this.lastUserSendAt.delete(oldLower);
+        this.lastUserSendAt.set(newLower, lastSend);
+      }
+      if (this.autoWhoTargets.delete(oldLower)) this.autoWhoTargets.add(newLower);
+      const ctcpQueue = this.ctcpOutstanding.get(oldLower);
+      if (ctcpQueue) {
+        this.ctcpOutstanding.delete(oldLower);
+        this.ctcpOutstanding.set(newLower, ctcpQueue);
+      }
+      const hint = this.e2eHintAt.get(oldLower);
+      if (hint !== undefined) {
+        this.e2eHintAt.delete(oldLower);
+        this.e2eHintAt.set(newLower, hint);
+      }
+      // MONITOR follows the person: untrack first so the shared-watch
+      // refcount can't strand the old nick, then watch the new one — the
+      // renamed DM's presence dot stays live instead of going stale until
+      // the next reconnect.
+      this.untrackDmPeer(oldNick);
+      this.trackDmPeer(newNick);
+    }
+    this.publishEphemeral({
+      type: 'buffer-renamed',
+      target: result.to,
+      from: result.from,
+      to: result.to,
+      bufferId: result.bufferId,
+      merged: result.merged,
+      ...(result.mergedFromBufferId != null
+        ? { mergedFromBufferId: result.mergedFromBufferId }
+        : {}),
+      draftChanged: result.draftChanged,
+    });
+    // The DM's own "x is now known as y" line — same row shape the channel
+    // loop above persists, no new renderer work anywhere.
+    this.publish({
+      type: 'nick',
+      target: result.to,
+      nick: oldNick,
+      newNick,
+      userhost,
+      time,
+    });
+  }
+
   // trackDmPeer/trackFriend (and their untrackers) are thin wrappers over the
   // reference-counted helpers below: the wire watch and the DB row are added on
   // the first reason and removed on the last, so a nick held by both roles is

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1089,9 +1089,16 @@ export class IrcConnection {
       try {
         for (const buf of listOpenDms(this.network.id)) {
           // A notice-only buffer (NickServ/ChanServ, #439) is not a real DM —
-          // don't seed it into MONITOR or it consumes presence slots and shows a
-          // bogus presence dot for a service. Track only actual conversations.
-          if (!hasConversationForTarget(this.network.id, buf.target)) continue;
+          // don't seed it into MONITOR or it consumes presence slots and shows
+          // a bogus presence dot for a service. Seed actual conversations AND
+          // empty just-opened DMs (same intent test as probePresence), so a
+          // reconnect doesn't strand a fresh query's presence dot.
+          if (
+            !hasConversationForTarget(this.network.id, buf.target) &&
+            hasMessageForTarget(this.network.id, buf.target)
+          ) {
+            continue;
+          }
           this.addPeerReason(buf.target.toLowerCase(), 'dm', null);
         }
       } catch (e) {
@@ -3129,10 +3136,20 @@ export class IrcConnection {
   // RPL_MONOFFLINE from the server — no separate WHOIS probe needed.
   probePresence(nick: string | undefined | null): void {
     if (!nick || !isDmTargetName(nick)) return;
-    // Opening a notice-only buffer (a service like NickServ, #439) must not start
-    // MONITOR tracking — only probe presence for targets we have a real
-    // conversation with. Friends are tracked separately at hydrate time.
-    if (!hasConversationForTarget(this.network.id, nick)) return;
+    // Opening a notice-only buffer (a service like NickServ, #439) must not
+    // start MONITOR tracking. But an EMPTY buffer is different from a
+    // notice-only one: zero rows means the user just deliberately opened a
+    // DM (nicklist → "open query") and is about to talk — showing the peer
+    // as offline until the first message lands reads as a bug (QA on #716
+    // hit exactly this). Probe for real conversations AND for brand-new
+    // empty DMs; only the notice-only service shape stays blocked. Friends
+    // are tracked separately at hydrate time.
+    if (
+      !hasConversationForTarget(this.network.id, nick) &&
+      hasMessageForTarget(this.network.id, nick)
+    ) {
+      return;
+    }
     this.trackDmPeer(nick);
   }
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2933,7 +2933,7 @@ export class IrcConnection {
     userhost: string | null,
     time: unknown,
   ): void {
-    let result;
+    let result: ReturnType<typeof renameDmBuffer>;
     try {
       const row = getBuffer(this.network.user_id, this.network.id, oldNick);
       if (!row || row.kind !== 'dm') return;

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -75,6 +75,7 @@ import {
   kindForTarget,
 } from '../db/buffers.js';
 import { resolveBuffer, requireBufferForUser } from '../db/bufferResolve.js';
+import { getDraftForBuffer } from '../db/drafts.js';
 import type { BufferStateRow } from '../db/buffers.js';
 import {
   pinBuffer,
@@ -1887,6 +1888,54 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         kind: 'dcc-transfer',
         transfer: (event as unknown as { transfer: unknown }).transfer,
       });
+      return;
+    }
+    // A buffer changed names (a DM peer's NICK; later, channel RENAME). This
+    // is a lifecycle frame, not a message — intercept before decoration so it
+    // can't leak to clients as a kind:'irc' row. Fanned to EVERY socket
+    // including any originator: it describes a fact, not an instruction
+    // (docs §9.7). Follow-ups ride behind it on a merge, because the merged
+    // counts/pins/draft changed server-side and an idle buffer would
+    // otherwise never learn.
+    if ((event as { type?: string }).type === 'buffer-renamed') {
+      const ev = event as unknown as {
+        networkId: number;
+        from: string;
+        to: string;
+        bufferId: number;
+        merged?: boolean;
+        mergedFromBufferId?: number;
+        draftChanged?: boolean;
+      };
+      fanOut(eventUserId, {
+        kind: 'buffer-renamed',
+        networkId: ev.networkId,
+        from: ev.from,
+        to: ev.to,
+        bufferId: ev.bufferId,
+        merged: !!ev.merged,
+        ...(ev.mergedFromBufferId != null ? { mergedFromBufferId: ev.mergedFromBufferId } : {}),
+      });
+      if (ev.merged) {
+        broadcastReadState(
+          eventUserId,
+          ev.networkId,
+          ev.to,
+          getReadState(eventUserId, ev.networkId, ev.to),
+          ev.bufferId,
+        );
+        fanOut(eventUserId, pinsChangedFrame(eventUserId, ev.networkId));
+        if (ev.draftChanged) {
+          const draft = getDraftForBuffer(eventUserId, ev.bufferId);
+          fanOut(eventUserId, {
+            kind: 'draft-updated',
+            networkId: ev.networkId,
+            target: ev.to,
+            bufferId: ev.bufferId,
+            body: draft?.body ?? '',
+          });
+        }
+      }
       return;
     }
     const decorated = decorateMessage(eventUserId, event);

--- a/vue_client/src/composables/useActiveBuffer.ts
+++ b/vue_client/src/composables/useActiveBuffer.ts
@@ -54,7 +54,23 @@ export function useActiveBuffer(): ActiveBufferState {
     if (virtualCfg.value && virtualCfg.value.renderMode !== 'buffer') return null;
     return buffers.byKey(activeKey.value);
   });
-  const topic = computed(() => (activeBuf.value as any)?.topic);
+  // Channels show their topic; a DM shows the peer's ident@hostname in the
+  // same slot (irssi-style — it's the identity that survives nick changes,
+  // and the natural companion to DM renames, #695).
+  const topic = computed(() => {
+    const buf = activeBuf.value as {
+      topic?: string | null;
+      kind?: string;
+      networkId?: number | null;
+      target?: string;
+    } | null;
+    if (!buf) return undefined;
+    if (buf.topic) return buf.topic;
+    if (buf.kind === 'dm' && buf.networkId != null && buf.target) {
+      return buffers.userhostFor(buf.networkId, buf.target) ?? undefined;
+    }
+    return buf.topic ?? undefined;
+  });
   const isServerBuffer = computed(() => !!active.value?.target?.startsWith(':server:'));
   const isChannel = computed(() => !!active.value?.target?.startsWith('#'));
   const bufferLabel = computed(() => {

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -12,7 +12,7 @@ import { previewableEventTexts } from '../utils/previewEvents.js';
 import { useConfigStore } from '../stores/config.js';
 import { useHighlightRulesStore } from '../stores/highlightRules.js';
 import { useInputHistoryStore } from '../stores/inputHistory.js';
-import { bufferClosed } from '../lib/bufferLifecycle.js';
+import { bufferClosed, applyBufferRenamed } from '../lib/bufferLifecycle.js';
 import { useDraftStore } from '../stores/drafts.js';
 import { useChanlistStore } from '../stores/chanlist.js';
 import { useSearchStore } from '../stores/search.js';
@@ -722,6 +722,12 @@ function handleMessage(raw: string): void {
       clearedBeforeId: payload.clearedBeforeId,
       clearedAt: payload.clearedAt,
     });
+    return;
+  }
+  if (payload.kind === 'buffer-renamed') {
+    // A buffer kept its identity and changed names (a DM following a peer's
+    // /nick; later, channel renames). One call moves every store.
+    applyBufferRenamed(payload);
     return;
   }
   if (payload.kind === 'buffer-closed') {

--- a/vue_client/src/lib/bufferLifecycle.test.ts
+++ b/vue_client/src/lib/bufferLifecycle.test.ts
@@ -14,7 +14,7 @@ vi.mock('../composables/useSocket.js', () => ({
   socketSend: vi.fn<() => boolean>(() => true),
 }));
 
-import { bufferClosed, bufferRenamed } from './bufferLifecycle.js';
+import { bufferClosed, bufferRenamed, applyBufferRenamed } from './bufferLifecycle.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useNavHistoryStore } from '../stores/navHistory.js';
@@ -160,5 +160,54 @@ describe('rename collisions: destination wins everywhere', () => {
     // Nothing remains under the old name anywhere.
     expect(KEY in useDraftStore().drafts).toBe(false);
     expect(useBuffersStore().buffers[KEY]).toBeUndefined();
+  });
+});
+
+describe('applyBufferRenamed — the full frame contract', () => {
+  it('plain rename: moves everything, learns the id, keeps the slice', () => {
+    seedEverything();
+    const buf = useBuffersStore().buffers[KEY]!;
+    buf.messages.push({ id: 1, networkId: NET, target: TARGET, type: 'message' });
+
+    applyBufferRenamed({ networkId: NET, from: TARGET, to: '#fresh', bufferId: 42 });
+
+    const moved = useBuffersStore().buffers[`${NET}::#fresh`]!;
+    expect(moved.id).toBe(42);
+    expect(moved.messages).toHaveLength(1); // no merge — history is untouched
+    expect(useNetworksStore().activeKey).toBe(`${NET}::#fresh`);
+  });
+
+  it('merge: drops the absorbed buffer everywhere FIRST, then renames with no collision', () => {
+    seedEverything();
+    // The absorbed side: a stale buffer already holding the new name, with
+    // state scattered across stores.
+    const ABSORBED = '#stale';
+    useBuffersStore().ensure(NET, ABSORBED, 99);
+    useDraftStore().drafts[`${NET}::${ABSORBED}`] = 'stale draft';
+    usePinsStore().byNetwork[NET] = [TARGET, ABSORBED];
+    const live = useBuffersStore().buffers[KEY]!;
+    live.messages.push({ id: 5, networkId: NET, target: TARGET, type: 'message' });
+
+    applyBufferRenamed({
+      networkId: NET,
+      from: TARGET,
+      to: ABSORBED,
+      bufferId: 42,
+      merged: true,
+    });
+
+    const survivor = useBuffersStore().buffers[`${NET}::${ABSORBED}`]!;
+    // The LIVE buffer survived under the new name — id 42, not the stale 99.
+    expect(survivor.id).toBe(42);
+    // Merged history interleaves server-side: the slice is wiped and flagged
+    // for a fresh hydrate instead of guessed at.
+    expect(survivor.messages).toHaveLength(0);
+    expect(survivor.unseeded).toBe(true);
+    expect(survivor.hasMoreOlder).toBe(true);
+    // The stale buffer's satellite state is gone, not inherited; the live
+    // buffer's own state moved in (destination-wins never fired — the
+    // absorbed side was swept before the rename landed).
+    expect(useDraftStore().drafts[`${NET}::${ABSORBED}`]).toBe('half-typed');
+    expect(usePinsStore().byNetwork[NET]).toEqual([ABSORBED]);
   });
 });

--- a/vue_client/src/lib/bufferLifecycle.ts
+++ b/vue_client/src/lib/bufferLifecycle.ts
@@ -74,3 +74,42 @@ export function bufferRenamed(networkId: number | string | null, from: string, t
   const canonicalFrom = canonicalTarget(networkId, from);
   for (const get of participants) get().rekeyBuffer(networkId, canonicalFrom, to);
 }
+
+/**
+ * The full `buffer-renamed` frame contract (docs §9.7): the buffer keeps its
+ * id and adopts the new name; on a merge the ABSORBED buffer (the one that
+ * already held the new name — `mergedFromBufferId`) is dropped everywhere
+ * first, so the rename lands with no collision and the destination-wins
+ * fallbacks in the rekey hooks never fire on an announced merge. A merged
+ * buffer's history interleaves two message streams server-side, so the local
+ * slice is wiped and flagged for a fresh hydrate rather than guessed at —
+ * the read-state / pins / draft corrections ride in right behind the frame.
+ * Following the active buffer is free: networks.rekeyBuffer moves activeKey.
+ */
+export function applyBufferRenamed(payload: {
+  networkId: number | string | null;
+  from: string;
+  to: string;
+  bufferId?: number | null;
+  merged?: boolean;
+}): void {
+  const { networkId, from, to, bufferId, merged } = payload;
+  if (merged) bufferClosed(networkId, to);
+  bufferRenamed(networkId, from, to);
+  const buffers = useBuffersStore();
+  const buf = buffers.findByTarget(networkId, to);
+  if (!buf) return;
+  // Learn/confirm the id under the new key (also heals the case where the
+  // rename raced ahead of the burst and we never knew the id).
+  if (typeof bufferId === 'number' && networkId != null) buffers.ensure(networkId, to, bufferId);
+  if (merged && !buf.detached) {
+    buf.messages = [];
+    buf.oldestId = null;
+    buf.newestId = null;
+    buf.hasMoreOlder = true;
+    // The shell flag routes it through the ordinary hydration reconciler —
+    // activate() (or useBufferHydration, if it's already active) fetches the
+    // merged latest slice exactly like a fresh-connect shell.
+    buf.unseeded = true;
+  }
+}

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -1046,3 +1046,43 @@ describe('applyClearedState — unclearing resets to the latest page', () => {
     expect(buf.clearedBeforeId).toBe(300);
   });
 });
+
+describe('userhostFor — the DM header identity', () => {
+  it('prefers live member data, falls back to the DM rows, strips the nick half', async () => {
+    const { setActivePinia, createPinia } = await import('pinia');
+    setActivePinia(createPinia());
+    const { useBuffersStore } = await import('./buffers.js');
+    const store = useBuffersStore();
+
+    // Peer visible in a shared channel: member data wins.
+    const chan = store.ensure(1, '#shared');
+    chan.members = [{ nick: 'Bob', modes: [], away: false, user: 'rob', host: 'host.example' }];
+    expect(store.userhostFor(1, 'bob')).toBe('rob@host.example');
+
+    // No shared channel: the DM's own rows answer, mask stripped to ident@host.
+    const dm = store.ensure(2, 'carol');
+    dm.messages.push({
+      id: 1,
+      networkId: 2,
+      target: 'carol',
+      type: 'message',
+      nick: 'Carol',
+      userhost: 'Carol!cc@irc.example',
+      self: false,
+    });
+    expect(store.userhostFor(2, 'carol')).toBe('cc@irc.example');
+
+    // Own rows never answer for the peer.
+    const dm2 = store.ensure(3, 'dave');
+    dm2.messages.push({
+      id: 2,
+      networkId: 3,
+      target: 'dave',
+      type: 'message',
+      nick: 'me',
+      userhost: 'me!my@own.host',
+      self: true,
+    });
+    expect(store.userhostFor(3, 'dave')).toBeNull();
+  });
+});

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -429,6 +429,40 @@ export const useBuffersStore = defineStore('buffers', {
         }
         return undefined;
       },
+    // The peer's ident@hostname for a DM header (#695 QA follow-up — the slot
+    // a channel's topic occupies). Live shared-channel member data first (the
+    // freshest source, present even for a history-less DM opened from the
+    // nicklist); the DM's own persisted rows as fallback (covers a peer with
+    // no shared channel — every message row carries the sender's userhost).
+    userhostFor:
+      (state) =>
+      (networkId: number | string, nick: string): string | null => {
+        if (!nick) return null;
+        const lc = nick.toLowerCase();
+        const nid = Number(networkId);
+        for (const b of Object.values(state.buffers)) {
+          if (b.networkId !== nid) continue;
+          const m = b.members?.find(
+            (x) => typeof x === 'object' && (x.nick || '').toLowerCase() === lc,
+          );
+          if (m?.user && m?.host) return `${m.user}@${m.host}`;
+        }
+        for (const b of Object.values(state.buffers)) {
+          if (b.networkId !== nid || b.target.toLowerCase() !== lc) continue;
+          for (let i = b.messages.length - 1; i >= 0; i--) {
+            const msg = b.messages[i];
+            if (msg.self || (msg.nick || '').toLowerCase() !== lc) continue;
+            const uh = msg.userhost;
+            if (typeof uh === 'string' && uh) {
+              // Rows store the full mask (nick!user@host); the header wants
+              // the identity half.
+              const bang = uh.indexOf('!');
+              return bang === -1 ? uh : uh.slice(bang + 1);
+            }
+          }
+        }
+        return null;
+      },
     // The open DM buffer for a (network, nick), matched case-insensitively so we
     // resolve to whatever case is already open rather than forking a second
     // buffer that differs only by nick case. Channels and the flat virtual

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -112,7 +112,12 @@
       <div class="topic-meta">
         <span v-if="isVirtual || active" class="buffer">{{ bufferLabel }}</span>
         <template v-if="active && topic">
+          <!-- A channel topic is user prose: auto-link it and open the full
+               view on click. A DM's pseudo-topic is the peer's ident@host —
+               an identity string, not prose; auto-linking turns the host into
+               a bogus email/URL link, so it renders as plain static text. -->
           <button
+            v-if="isChannel"
             type="button"
             class="topic-text"
             title="View full topic"
@@ -120,6 +125,7 @@
           >
             <LinkedText :text="topic" />
           </button>
+          <span v-else class="topic-text">{{ topic }}</span>
         </template>
       </div>
       <div class="topic-actions">

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -904,14 +904,18 @@ useChatBootstrap({ onJump: onJumpToMessage });
   margin: 0;
   font: inherit;
   text-align: left;
-  cursor: pointer;
   white-space: nowrap;
   min-width: 0;
 }
-.topic .topic-text:hover {
+/* Hover/click affordances belong to the clickable channel-topic BUTTON only;
+   the DM identity renders as a static span sharing the layout styles above. */
+button.topic-text {
+  cursor: pointer;
+}
+button.topic-text:hover {
   color: var(--fg);
 }
-.topic .topic-text:focus-visible {
+button.topic-text:focus-visible {
   outline: 1px solid var(--accent);
   outline-offset: 2px;
 }

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -381,7 +381,9 @@ function openBufferActions() {
   const el = bufferCogBtn.value;
   if (!a || !el) return;
   const items: ContextMenuItem[] = [];
-  if (topic.value) {
+  // Channels only: a DM's pseudo-topic (the peer's ident@host) is a header
+  // identity, not prose worth a modal.
+  if (isChannel.value && topic.value) {
     items.push({
       label: 'View topic',
       icon: 'fa-solid fa-circle-info',


### PR DESCRIPTION
Fifth tier of #695 — **the payoff PR**. A DM buffer now follows its peer through `/nick`: the buffer renames in place across every device, drafts/pins/read state ride along untouched, the presence dot stays live, and the conversation shows "x is now known as y" exactly like a channel does. weechat/irssi parity, unconditional, like they do it.

## How it lands

- **`server/db/renameBuffer.ts`** — under the normalized schema, a rename is ONE UPDATE on one row (#706 needed 650 lines to approximate this name-keyed). Collisions merge **source-survives**: the live conversation keeps its id, the stale row under the new name (`mergedFromBufferId`) is absorbed — the plan's deliberate inversion of #706's destination-wins, because "some buffer you may hold was absorbed" is strictly easier for clients than "your active buffer changed identity". Merge policies mirror the v18 case-twin rebuild (furthest pointer, max marker with its own timestamp, survivor's draft/pins/view-state win, messages repoint wholesale). One `BEGIN IMMEDIATE` transaction.
- **`ircConnection`** — the NICK handler renames the DM row (open **or** closed — history follows the person without reopening), re-keys the per-target in-memory maps, re-keys MONITOR (untrack old before track new, so the refcount can't strand a watch), and persists the "known as" row **after** the rename so it lands under the new name via the `type:'nick'` renderer both clients already have. Self-nick never renames; no shared-channel peer, no DM row → no-op.
- **`wsHub`** — fans `buffer-renamed {networkId, from, to, bufferId, merged, mergedFromBufferId?}` to every socket (it states a fact, not an instruction), with merge corrections behind it: `read-state`, `pins-changed`, and `draft-updated` when the surviving draft changed.
- **Vue** — `applyBufferRenamed` applies §9.7: on a merge the absorbed buffer is swept everywhere FIRST, then the lifecycle registry (from #715) moves all nine stores in one call; `activeKey` follows for free, and a merged buffer's slice is wiped + flagged for the ordinary hydration reconciler (interleaved history is refetched, never guessed).

Deliberately not here: channel RENAME (the CAP work reuses every piece of this), irssi's user@host re-identification, manual `/rename`.

## Tests

Primitive: plain/casing-only/no-op/sentinel-refusal + both merge shapes with value-level policy assertions (6). NICK wiring against the real registry: rename + announce + row ordering, collision merge, closed-DM rename without reopen, no-DM no-op, self-nick no-op (5). Vue: the full frame contract including merge sweep-first ordering and id learning (2). Full suite: 3,614 passed; check clean.

## QA (the fun one)

This is the first tier with a *visible* feature: on a real network, have a peer you're DMing `/nick` — the buffer should rename in place in every tab, keep your half-typed draft, keep its pin, show the "is now known as" line, and keep the presence dot alive. For the merge case: DM someone, have them `/nick` to a name you have an old closed DM with — the histories should interleave and the buffer stays open under the live conversation's identity.

Part of #695.

🤖 Generated with [Claude Code](https://claude.com/claude-code)