### PR TITLE
Fold targets per the server-declared CASEMAPPING (#707)

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -411,14 +411,17 @@ Sentinel targets are exact-match, never case-folded. (The web client's
 it.)
 
 **Case folding:** IRC targets are case-insensitive and servers echo
-inconsistently-cased names. Clients fold with **ASCII `toLowerCase`** for
-identity and keep the first/canonical casing for display. The _server_ folds
+inconsistently-cased names. Clients fold with plain `toLowerCase` for identity
+(the first-party clients use their platform's Unicode lowercase; ASCII-only is
+also fine) and keep the first/canonical casing for display. The _server_ folds
 per the network's declared ISUPPORT `CASEMAPPING` (#707) — including the
 RFC 1459 rule treating `{|}~` as the lowercase of `[\]^` — so two names a
-client held apart may be one buffer server-side. Don't implement that fold
-client-side: when the server learns a mapping that collapses names, it merges
-the rows and announces each merge with the ordinary `buffer-renamed` frame
-(§9.7), which is all a client needs to converge.
+client held apart may be one buffer server-side, and (rarely: non-ASCII
+case-twins on an ascii-family network) two server buffers may collide under a
+client's fold; prefer `bufferId` wherever a frame carries it. Don't implement
+the server's fold client-side: when the server learns a mapping that collapses
+names, it merges the rows and announces each merge with the ordinary
+`buffer-renamed` frame (§9.7), which is all a client needs to converge.
 
 ### 5.3 Messages (`MessageEvent`)
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -411,10 +411,14 @@ Sentinel targets are exact-match, never case-folded. (The web client's
 it.)
 
 **Case folding:** IRC targets are case-insensitive and servers echo
-inconsistently-cased names. Fold with **ASCII `toLowerCase`** for identity;
-keep the first/canonical casing for display. RFC 1459 casemapping (treating
-`{}|^` as the lowercase of `[]\~`) is deliberately **not** implemented anywhere
-in Lurker — match that, don't "fix" it unilaterally.
+inconsistently-cased names. Clients fold with **ASCII `toLowerCase`** for
+identity and keep the first/canonical casing for display. The _server_ folds
+per the network's declared ISUPPORT `CASEMAPPING` (#707) — including the
+RFC 1459 rule treating `{|}~` as the lowercase of `[\]^` — so two names a
+client held apart may be one buffer server-side. Don't implement that fold
+client-side: when the server learns a mapping that collapses names, it merges
+the rows and announces each merge with the ordinary `buffer-renamed` frame
+(§9.7), which is all a client needs to converge.
 
 ### 5.3 Messages (`MessageEvent`)
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -634,7 +634,7 @@ a v1 client.
 | `send-result`                                                                                                                                                            | `clientId, ok, error?`                                                                                                                                                                                                                                                | Ack for `send`/`action`/`notice`                                                                                                                          |
 | `buffer-opened` / `buffer-closed` / `buffer-reopened`                                                                                                                    | `networkId, target, bufferId?` (absent only on the ack for a channel still being JOINed — no row yet)                                                                                                                                                                 | Buffer lifecycle (§9.1). `buffer-opened` is an ack to the socket that asked **and** a fan-out to the user's other devices — only focus on your own (§4.3) |
 | `buffer-cleared`                                                                                                                                                         | `networkId, target, bufferId, clearedBeforeId, clearedAt`                                                                                                                                                                                                             | `/clear` marker                                                                                                                                           |
-| `buffer-renamed`                                                                                                                                                         | `networkId, from, to, bufferId, merged, mergedFromBufferId?` — see §9.7                                                                                                                                                                                               | A buffer changed names (same id): DM follows a peer's NICK                                                                                                |
+| `buffer-renamed`                                                                                                                                                         | `networkId, from, to, bufferId, merged, mergedFromBufferId?` — see §9.7                                                                                                                                                                                               | A buffer kept its id across a name event: DM follows a peer's NICK, or a CASEMAPPING refold merged case-twins (any kind)                                  |
 | `pins-changed`                                                                                                                                                           | `networkId, pinned[], pinnedIds[]` (parallel-indexed: `pinnedIds[i]` is `pinned[i]`'s buffer)                                                                                                                                                                         | Authoritative pin order                                                                                                                                   |
 | `nicklist-collapsed-changed` / `channel-notify-changed`                                                                                                                  | `networkId, target, bufferId, …`                                                                                                                                                                                                                                      | View-state sync                                                                                                                                           |
 | `draft-updated` / `input-history-added` / `bookmark-updated` / `nick-note-updated` / `relay-bot-updated` / `contact-updated` / `contact-deleted` / `ignore-list-updated` | various                                                                                                                                                                                                                                                               | Multi-device view-state fan-out                                                                                                                           |
@@ -956,8 +956,16 @@ nicklist patch arrives separately as `member-update`).
 
 ### 9.7 Renames keep a buffer's identity
 
-**Emitted today for DM buffers following a peer's `/nick`** (weechat/irssi
-parity); channel renames (`draft/channel-rename`) will reuse the same frame.
+**Two producers emit this frame today**, for buffers of any kind: a DM
+following its peer's `/nick` (weechat/irssi parity), and the CASEMAPPING
+refold (#707) merging rows — channels included — that fold together under a
+newly-declared mapping. Channel renames (`draft/channel-rename`) will reuse it
+too. ⚠ The producers orient `from`/`to` differently on a merge: the DM path
+absorbs the row that already held `to`, the refold path absorbs the `from` row
+(the survivor keeps its own name, so `from ≠ to` with no actual rename).
+Never derive which buffer died from orientation — `mergedFromBufferId` is the
+absorbed row, `bufferId` the survivor, and `to` is always the survivor's final
+name.
 
 ```jsonc
 {
@@ -978,13 +986,12 @@ The contract, in the order a client should apply it:
   do; a client keying by name rekeys `from → to` in every store holding
   per-buffer state (the web client does this with one registry sweep —
   `lib/bufferLifecycle.ts`).
-- **`merged: true` means another buffer was absorbed.** A row already held
-  the new name (a stale DM under the peer's old nick, usually). The SOURCE
-  survives — the live conversation keeps its id — and `mergedFromBufferId`
-  names the absorbed buffer: drop it everywhere first, then apply the rename;
-  done in that order there is no key collision. The merged history
-  interleaves server-side, so wipe the local slice and re-hydrate rather
-  than guessing at the interleave.
+- **`merged: true` means another buffer was absorbed**, and
+  `mergedFromBufferId` names it — drop THAT buffer everywhere first (by id,
+  per the orientation warning above), then apply the rename; done in that
+  order there is no key collision. The surviving conversation keeps its id.
+  The merged history interleaves server-side, so wipe the local slice and
+  re-hydrate rather than guessing at the interleave.
 - **Corrections ride behind a merge.** `read-state`, `pins-changed`, and (when
   the surviving draft changed) `draft-updated` frames follow immediately —
   the merge changed those server-side and an idle buffer would never

--- a/server/db/bufferResolve.ts
+++ b/server/db/bufferResolve.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
-import { foldTarget, ensureServerBuffer, ensureExists } from './buffers.js';
+import { foldTargetFor, ensureServerBuffer, ensureExists } from './buffers.js';
 import type { BufferKind, BufferState } from './buffers.js';
 
 // Name → buffer_id resolution, in one place.
@@ -14,18 +14,13 @@ import type { BufferKind, BufferState } from './buffers.js';
 // the normalization exists to kill. If profiling ever demands one, its
 // invalidation belongs to renameBuffer/deleteBuffer alone.
 //
-// Folding happens here (and only here) on the way in. `foldTargetFor` is the
-// seam for #707: target folding is server-declared (ISUPPORT CASEMAPPING) and
-// will become per-network. Getting the fold wrong through this seam fails to
-// FIND a buffer — visible and recoverable — rather than splitting one, which
-// is the property that makes deferring #707 safe.
+// Folding happens on the way in, through `foldTargetFor` (buffers.ts) — the
+// network's declared ISUPPORT CASEMAPPING since #707, legacy Unicode-lowercase
+// until a network declares one. Getting the fold wrong through this seam fails
+// to FIND a buffer — visible and recoverable — rather than splitting one,
+// which is the property that made deferring #707 safe while the seam waited.
 
-/** Per-network target folding. Today: the single ASCII/Unicode-lowercase rule
- *  (buffers.ts foldTarget); the networkId parameter is the #707 seam and is
- *  deliberately unused until CASEMAPPING capture lands. */
-export function foldTargetFor(_networkId: number | null, raw: string): string {
-  return foldTarget(raw);
-}
+export { foldTargetFor } from './buffers.js';
 
 /** Decrypt-free buffer identity row — no +k key material (a rotated secret
  *  must not make resolution throw; see buffers.ts getState). */

--- a/server/db/buffers.ts
+++ b/server/db/buffers.ts
@@ -59,19 +59,37 @@ export function foldTarget(target: string): string {
 
 const casemappingStmt = db.prepare(`SELECT casemapping FROM networks WHERE id = ?`);
 
+// networkId → declared mapping, lazily filled. Cached — unlike name→id
+// resolution, which stays uncached on principle — because the invalidation
+// story is the opposite of a name's: exactly two writers exist (the refold
+// pass that stores a newly-declared mapping, and network deletion, whose ids
+// SQLite may reuse), both call invalidateCasemappingCache below, and the
+// value is read on every buffer-keyed lookup — several times per inbound
+// message — where an uncached PK seek would double the statement count of
+// the whole hot path for a value that changes at most once per network life.
+const casemappingCache = new Map<number, Casemapping | null>();
+
+/** Drop a network's cached CASEMAPPING. Callers are the two writers: the
+ *  refold pass (after its transaction stores a new mapping) and network
+ *  deletion (SQLite can reuse the id for a future network). */
+export function invalidateCasemappingCache(networkId: number): void {
+  casemappingCache.delete(networkId);
+}
+
 /** The network's declared ISUPPORT CASEMAPPING, as last captured on connect
  *  (#707) — null until the network first declares one. */
 export function networkCasemapping(networkId: number): Casemapping | null {
+  const cached = casemappingCache.get(networkId);
+  if (cached !== undefined) return cached;
   const raw = (casemappingStmt.get(networkId) as { casemapping: string | null } | undefined)
     ?.casemapping;
-  return normalizeCasemapping(raw) ?? null;
+  const mapping = normalizeCasemapping(raw) ?? null;
+  casemappingCache.set(networkId, mapping);
+  return mapping;
 }
 
 /** Per-network target folding (#707): the server-declared CASEMAPPING rule,
- *  falling back to the legacy fold until the network declares one. One PK
- *  seek per call — deliberately uncached, same reasoning as name→id
- *  resolution (bufferResolve.ts): a cache would be a second copy of state
- *  whose invalidation belongs to the capture path alone. */
+ *  falling back to the legacy fold until the network declares one. */
 export function foldTargetFor(networkId: number | null, raw: string): string {
   if (networkId == null) return foldTarget(raw);
   return foldTargetWith(networkCasemapping(networkId), raw);

--- a/server/db/buffers.ts
+++ b/server/db/buffers.ts
@@ -69,11 +69,16 @@ const casemappingStmt = db.prepare(`SELECT casemapping FROM networks WHERE id = 
 // the whole hot path for a value that changes at most once per network life.
 const casemappingCache = new Map<number, Casemapping | null>();
 
-/** Drop a network's cached CASEMAPPING. Callers are the two writers: the
- *  refold pass (after its transaction stores a new mapping) and network
- *  deletion (SQLite can reuse the id for a future network). */
-export function invalidateCasemappingCache(networkId: number): void {
-  casemappingCache.delete(networkId);
+/** Drop a network's cached CASEMAPPING — or, with no argument, all of them.
+ *  Callers are the paths that can make an entry lie: the refold pass (after
+ *  its transaction stores a new mapping), network deletion (SQLite can reuse
+ *  the id for a future network), and an import ROLLBACK (whole-cache clear:
+ *  the buffers import folds through the cache mid-transaction, and a
+ *  rollback reverts sqlite_sequence, so the rolled-back ids — cached with
+ *  the rolled-back mappings — are exactly the ids the retry will mint). */
+export function invalidateCasemappingCache(networkId?: number): void {
+  if (networkId === undefined) casemappingCache.clear();
+  else casemappingCache.delete(networkId);
 }
 
 /** The network's declared ISUPPORT CASEMAPPING, as last captured on connect

--- a/server/db/buffers.ts
+++ b/server/db/buffers.ts
@@ -3,6 +3,8 @@
 
 import db from './index.js';
 import { encryptSecret, decryptSecret } from '../utils/secretCrypto.js';
+import { foldTargetWith, normalizeCasemapping } from './casemapping.js';
+import type { Casemapping } from './casemapping.js';
 
 // The buffer registry — the single owner of "does this buffer exist" and "is it
 // in the sidebar". A buffer exists because a row exists here, not because
@@ -12,11 +14,13 @@ import { encryptSecret, decryptSecret } from '../utils/secretCrypto.js';
 // IrcConnection.channels Map and is never persisted as truth.
 //
 // Casing: `target` keeps the canonical display casing (first writer wins; the
-// live paths fold forward to it). `target_folded` (ASCII toLowerCase, house
-// rule — see #268/#289/#327) is the ONLY lookup key, so a server relaying
-// `#Chan` for a buffer stored as `#chan` can neither fork a second row nor slip
-// past a closed check. That single folding rule is what retires the
-// exact-write/folded-read split that closed_buffers had.
+// live paths fold forward to it). `target_folded` is the ONLY lookup key, so a
+// server relaying `#Chan` for a buffer stored as `#chan` can neither fork a
+// second row nor slip past a closed check (#268/#289/#327). The folding rule
+// is per-network since #707 — the server-declared ISUPPORT CASEMAPPING, via
+// `foldTargetFor` — with the legacy Unicode-lowercase fold for undeclared
+// networks and the system buffer. Stored folds are rewritten (and collisions
+// merged) by db/refoldBuffers when a network's declared mapping changes.
 //
 // Write discipline (the whole reducer):
 //   - join ECHO            → ensureOpen(autojoin: true, key) — the only
@@ -45,9 +49,32 @@ export interface BufferRecord {
   closedAt: string | null;
 }
 
-/** The one folding rule for buffer targets (ASCII, matching the client). */
+/** The LEGACY folding rule — Unicode lowercase, what every pre-#707 row's
+ *  target_folded was built with. Still the rule for the system buffer (no
+ *  network to declare a mapping) and for any network that hasn't declared
+ *  one. Everything network-scoped should fold through `foldTargetFor`. */
 export function foldTarget(target: string): string {
   return target.toLowerCase();
+}
+
+const casemappingStmt = db.prepare(`SELECT casemapping FROM networks WHERE id = ?`);
+
+/** The network's declared ISUPPORT CASEMAPPING, as last captured on connect
+ *  (#707) — null until the network first declares one. */
+export function networkCasemapping(networkId: number): Casemapping | null {
+  const raw = (casemappingStmt.get(networkId) as { casemapping: string | null } | undefined)
+    ?.casemapping;
+  return normalizeCasemapping(raw) ?? null;
+}
+
+/** Per-network target folding (#707): the server-declared CASEMAPPING rule,
+ *  falling back to the legacy fold until the network declares one. One PK
+ *  seek per call — deliberately uncached, same reasoning as name→id
+ *  resolution (bufferResolve.ts): a cache would be a second copy of state
+ *  whose invalidation belongs to the capture path alone. */
+export function foldTargetFor(networkId: number | null, raw: string): string {
+  if (networkId == null) return foldTarget(raw);
+  return foldTargetWith(networkCasemapping(networkId), raw);
 }
 
 const CHANNEL_PREFIXES = new Set(['#', '&', '+', '!']);
@@ -175,7 +202,9 @@ export function getBuffer(
   networkId: number | null,
   target: string,
 ): BufferRecord | undefined {
-  return toRecord(getStmt.get(userId, networkId, foldTarget(target)) as BufferRow | undefined);
+  return toRecord(
+    getStmt.get(userId, networkId, foldTargetFor(networkId, target)) as BufferRow | undefined,
+  );
 }
 
 // Decrypt-free projections for the hot paths. The live event filter runs one
@@ -206,7 +235,9 @@ export function getState(
   target: string,
 ): BufferState | undefined {
   return (
-    stateStmt.get(userId, networkId, foldTarget(target)) as { state: BufferState } | undefined
+    stateStmt.get(userId, networkId, foldTargetFor(networkId, target)) as
+      | { state: BufferState }
+      | undefined
   )?.state;
 }
 
@@ -329,7 +360,7 @@ export const ensureOpen = db.transaction(
   ): EnsureResult => {
     const sentinel = ensureSentinel(userId, networkId, target);
     if (sentinel) return sentinel;
-    const folded = foldTarget(target);
+    const folded = foldTargetFor(networkId, target);
     const existing = getStmt.get(userId, networkId, folded) as BufferRow | undefined;
     if (!existing) {
       insertStmt.run({
@@ -376,7 +407,7 @@ export const ensureExists = db.transaction(
   ): { record: BufferRecord; created: boolean } => {
     const sentinel = ensureSentinel(userId, networkId, target);
     if (sentinel) return { record: sentinel.record, created: sentinel.created };
-    const folded = foldTarget(target);
+    const folded = foldTargetFor(networkId, target);
     const existing = getStmt.get(userId, networkId, folded) as BufferRow | undefined;
     if (existing) return { record: toRecord(existing), created: false };
     insertStmt.run({
@@ -400,14 +431,14 @@ export const ensureExists = db.transaction(
  *  the buffer-reopened fanout keys off this, same contract as the old
  *  reopenBuffer's rows-deleted. */
 export function reopen(userId: number, networkId: number | null, target: string): boolean {
-  return reopenStmt.run(userId, networkId, foldTarget(target)).changes > 0;
+  return reopenStmt.run(userId, networkId, foldTargetFor(networkId, target)).changes > 0;
 }
 
 /** Update-only open→closed flip. A no-op when the row doesn't exist — closing
  *  can never conjure a buffer (the phantom-row class the old
  *  upsertChannel-on-close path had). */
 export function close(userId: number, networkId: number | null, target: string): boolean {
-  return closeStmt.run(userId, networkId, foldTarget(target)).changes > 0;
+  return closeStmt.run(userId, networkId, foldTargetFor(networkId, target)).changes > 0;
 }
 
 /** Update-only; absent row = no-op. Lowered on part/kick/470/442 so a failed
@@ -418,7 +449,7 @@ export function setAutojoin(
   target: string,
   autojoin: boolean,
 ): void {
-  setAutojoinStmt.run(autojoin ? 1 : 0, userId, networkId, foldTarget(target));
+  setAutojoinStmt.run(autojoin ? 1 : 0, userId, networkId, foldTargetFor(networkId, target));
 }
 
 /** Update-only; null clears (MODE -k). Encrypted at rest via secretCrypto. */
@@ -428,7 +459,7 @@ export function setChannelKey(
   target: string,
   key: string | null,
 ): void {
-  setKeyStmt.run(encryptSecret(key), userId, networkId, foldTarget(target));
+  setKeyStmt.run(encryptSecret(key), userId, networkId, foldTargetFor(networkId, target));
 }
 
 /** Config-time channel seed (network create's default_channels): the buffer
@@ -438,7 +469,7 @@ export function setChannelKey(
  *  empty parted buffer. An existing row just gains autojoin (+key). */
 export const seedAutojoinChannel = db.transaction(
   (userId: number, networkId: number, target: string, key?: string | null): void => {
-    const folded = foldTarget(target);
+    const folded = foldTargetFor(networkId, target);
     const existing = getStmt.get(userId, networkId, folded) as BufferRow | undefined;
     if (!existing) {
       insertStmt.run({
@@ -473,7 +504,7 @@ export const importRow = db.transaction(
     key?: string | null;
     closedAt?: string | null;
   }): void => {
-    const folded = foldTarget(row.target);
+    const folded = foldTargetFor(row.networkId, row.target);
     const existing = getStmt.get(row.userId, row.networkId, folded) as BufferRow | undefined;
     if (!existing) {
       insertStmt.run({
@@ -511,7 +542,7 @@ export const importRow = db.transaction(
  *  to show. Callers with history use setAutojoin(false) instead so the buffer
  *  (and its messages) survive. */
 export function deleteBuffer(userId: number, networkId: number | null, target: string): boolean {
-  return deleteStmt.run(userId, networkId, foldTarget(target)).changes > 0;
+  return deleteStmt.run(userId, networkId, foldTargetFor(networkId, target)).changes > 0;
 }
 
 export function listForUser(userId: number): BufferRecord[] {

--- a/server/db/casemapping.test.ts
+++ b/server/db/casemapping.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { foldTargetWith, normalizeCasemapping } from './casemapping.js';
+
+describe('normalizeCasemapping', () => {
+  it('accepts the four known values, case-insensitively', () => {
+    expect(normalizeCasemapping('ascii')).toBe('ascii');
+    expect(normalizeCasemapping('RFC1459')).toBe('rfc1459');
+    expect(normalizeCasemapping('rfc1459-strict')).toBe('rfc1459-strict');
+    expect(normalizeCasemapping('rfc7613')).toBe('rfc7613');
+    expect(normalizeCasemapping('utf8')).toBe('rfc7613');
+  });
+
+  it("accepts irc-framework's strict-rfc1459 spelling", () => {
+    expect(normalizeCasemapping('strict-rfc1459')).toBe('rfc1459-strict');
+  });
+
+  it('rejects everything else — an unknown mapping must not be stored', () => {
+    expect(normalizeCasemapping('rfc8265')).toBeUndefined();
+    expect(normalizeCasemapping('')).toBeUndefined();
+    expect(normalizeCasemapping(undefined)).toBeUndefined();
+    expect(normalizeCasemapping(42)).toBeUndefined();
+  });
+});
+
+describe('foldTargetWith', () => {
+  it('ascii folds A-Z and nothing else', () => {
+    expect(foldTargetWith('ascii', '#FooBar')).toBe('#foobar');
+    expect(foldTargetWith('ascii', '#foo[BAR]\\^~')).toBe('#foo[bar]\\^~');
+    // Unicode stays: ascii means ascii.
+    expect(foldTargetWith('ascii', '#Ärger')).toBe('#Ärger');
+  });
+
+  it('rfc1459 additionally folds [ \\ ] ^ down to { | } ~', () => {
+    // The Scandinavian pairing: #foo[bar] and #foo{bar} are the same channel.
+    expect(foldTargetWith('rfc1459', '#foo[bar]')).toBe('#foo{bar}');
+    expect(foldTargetWith('rfc1459', '#a\\b')).toBe('#a|b');
+    // ⚠ Direction: ^ is the UPPERCASE of ~ (ircd tolower tables and
+    // irc-framework's bound of 94), despite RFC 2812's prose reading the
+    // other way. ^ folds down; ~ is already lowercase and stays.
+    expect(foldTargetWith('rfc1459', 'nick^')).toBe('nick~');
+    expect(foldTargetWith('rfc1459', 'nick~')).toBe('nick~');
+  });
+
+  it('rfc1459-strict folds the brackets but leaves ^ alone', () => {
+    expect(foldTargetWith('rfc1459-strict', '#Foo[Bar]\\')).toBe('#foo{bar}|');
+    expect(foldTargetWith('rfc1459-strict', 'nick^')).toBe('nick^');
+  });
+
+  it('rfc7613 and no-mapping use the legacy Unicode fold', () => {
+    // The rule every pre-#707 target_folded row was built with — an
+    // undeclared network's registry must not churn.
+    expect(foldTargetWith('rfc7613', '#Ärger')).toBe('#ärger');
+    expect(foldTargetWith(null, '#Ärger')).toBe('#ärger');
+    expect(foldTargetWith(undefined, '#foo[BAR]')).toBe('#foo[bar]');
+  });
+});

--- a/server/db/casemapping.ts
+++ b/server/db/casemapping.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// IRC target case-folding, per the server-declared ISUPPORT CASEMAPPING (#707).
+//
+// Four values exist in the wild. The folds:
+//
+//   ascii           A-Z → a-z, nothing else
+//   rfc1459         ascii plus [ \ ] ^ → { | } ~  (the RFC 2812 default)
+//   rfc1459-strict  ascii plus [ \ ]   → { | }    (no ^/~ pairing)
+//   rfc7613         full Unicode (Ergo and friends)
+//
+// ⚠ The ^/~ DIRECTION is the trap. RFC 2812's prose says "{}|^ are the lower
+// case equivalents of []\~" — i.e. ~ is uppercase and folds to ^. Every ircd
+// tolower table (and irc-framework, whose upper-ASCII bound for rfc1459 is 94
+// '^') does the OPPOSITE: the lowercase run is a-z{|}~, 32 above A-Z[\]^, so
+// ^ folds DOWN to ~. We match the implementations, not the prose — they are
+// what the servers we fold against actually run. Lurker's issue #707 quotes
+// the prose direction; this comment is the correction.
+//
+// rfc7613 folds with JS toLowerCase() — the same rule as the legacy/undeclared
+// fold below, not PRECIS. Real PRECIS enforcement lives server-side (the
+// network rejects names it considers confusable); our fold only has to agree
+// with itself, and toLowerCase() is the closest approximation that keeps
+// existing target_folded rows (all built with toLowerCase) stable.
+
+/** The CASEMAPPING values we understand, normalized. */
+export type Casemapping = 'ascii' | 'rfc1459' | 'rfc1459-strict' | 'rfc7613';
+
+/**
+ * Parse a raw ISUPPORT CASEMAPPING token. Returns undefined for anything
+ * unrecognized (including absent) — an unknown mapping is NOT stored, so the
+ * network keeps the legacy fold rather than adopting a rule we can't
+ * implement. 'strict-rfc1459' is irc-framework's spelling of the ISUPPORT
+ * draft's 'rfc1459-strict'; both appear in the wild.
+ */
+export function normalizeCasemapping(raw: unknown): Casemapping | undefined {
+  if (typeof raw !== 'string') return undefined;
+  switch (raw.trim().toLowerCase()) {
+    case 'ascii':
+      return 'ascii';
+    case 'rfc1459':
+      return 'rfc1459';
+    case 'rfc1459-strict':
+    case 'strict-rfc1459':
+      return 'rfc1459-strict';
+    case 'rfc7613':
+    case 'utf8':
+      return 'rfc7613';
+    default:
+      return undefined;
+  }
+}
+
+// Fold-to-lowercase upper bounds, per the bound-based scheme above:
+// everything in [65, bound] is uppercase and folds +32.
+const UPPER_BOUND: Record<Casemapping, number> = {
+  ascii: 90, // 'Z'
+  'rfc1459-strict': 93, // ']'
+  rfc1459: 94, // '^'
+  rfc7613: 0, // handled as toLowerCase(), never bound-folded
+};
+
+/**
+ * Fold a target to lowercase under `mapping`. null/undefined (no mapping
+ * declared or stored) and rfc7613 use the legacy rule — Unicode
+ * toLowerCase(), which is what every pre-#707 target_folded row was built
+ * with, so an undeclared network's registry never churns.
+ */
+export function foldTargetWith(mapping: Casemapping | null | undefined, target: string): string {
+  if (mapping == null || mapping === 'rfc7613') return target.toLowerCase();
+  const bound = UPPER_BOUND[mapping];
+  let out = '';
+  for (let i = 0; i < target.length; i++) {
+    const c = target.charCodeAt(i);
+    out += c >= 65 && c <= bound ? String.fromCharCode(c + 32) : target[i];
+  }
+  return out;
+}

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -118,6 +118,10 @@ export const EXPORT_TABLES = Object.freeze({
       'sasl_password',
       'connect_commands',
       'position',
+      // Server-declared CASEMAPPING (#707): exported so an imported network's
+      // registry folds don't churn (and case-twins don't merge) on the first
+      // reconnect after a restore.
+      'casemapping',
     ],
   },
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1003,6 +1003,11 @@ ensureColumn('networks', 'connect_commands', 'TEXT');
 // create/reorder; ties fall back to id ASC so freshly migrated rows stay in
 // their original creation order. See schemaVersion < 6 backfill below.
 ensureColumn('networks', 'position', 'INTEGER NOT NULL DEFAULT 0');
+// The server-declared ISUPPORT CASEMAPPING, captured on connect (#707). NULL
+// until the network first declares one; target folding falls back to the
+// legacy Unicode-lowercase rule until then (db/casemapping.ts). A change is
+// what triggers the per-network re-fold (db/refoldBuffers.ts).
+ensureColumn('networks', 'casemapping', 'TEXT');
 ensureColumn('users', 'password_hash', 'TEXT');
 ensureColumn('users', 'last_seen_at', 'TEXT');
 // Account access state, orthogonal to role. A paused account keeps all its data

--- a/server/db/messages.test.ts
+++ b/server/db/messages.test.ts
@@ -479,6 +479,30 @@ describe('searchMessages', () => {
     expect(hits.map((m) => m.target)).toEqual(['#a']);
   });
 
+  it('unscoped in: folds per network, not with one legacy fold (#707)', async () => {
+    // On an rfc1459 network '#chat[dev]' is stored under fold '#chat{dev}'.
+    // The unscoped search used to bind ONE legacy-folded string, which
+    // matches no per-network fold — zero results that look like missing data.
+    const user = createUser('search-refold');
+    const net = createNetwork(user.id, {
+      name: 'n',
+      host: 'h',
+      port: 6697,
+      tls: true,
+      nick: 'search-refold',
+    });
+    chat(net!.id, '#chat[dev]', 'alice', 'deploy went fine');
+    const { refoldNetworkBuffers } = await import('./refoldBuffers.js');
+    refoldNetworkBuffers(user.id, net!.id, 'rfc1459');
+
+    // Either bracket spelling finds it, with and without the network scope.
+    expect(searchMessages(user.id, { query: 'deploy', target: '#chat[dev]' })).toHaveLength(1);
+    expect(searchMessages(user.id, { query: 'deploy', target: '#chat{dev}' })).toHaveLength(1);
+    expect(
+      searchMessages(user.id, { query: 'deploy', target: '#chat[dev]', networkId: net!.id }),
+    ).toHaveLength(1);
+  });
+
   it('filters by networkId (on:)', () => {
     const user = createUser('search-network');
     const netA = createNetwork(user.id, {

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -3,7 +3,6 @@
 
 import db from './index.js';
 import {
-  foldTargetFor,
   resolveBuffer,
   resolveBufferIdByNetwork,
   resolveOrMintForInsert,
@@ -928,6 +927,10 @@ function toFtsMatch(text: string): string {
 // unread counts) so an ignored user stays ignored everywhere, including for
 // non-UI consumers of the search verb that have no client-side ignore filter.
 //
+// The `in:` scope's network enumeration (unscoped = "this name on any of my
+// networks"); prepared once like every other statement in this module.
+const userNetworkIdsStmt = db.prepare(`SELECT id FROM networks WHERE user_id = ?`);
+
 // `matched: true` restricts to highlight rows (matched_rule_id IS NOT NULL) —
 // this is what powers filterable highlights, which reuse the same from:/in:/on:
 // + free-text machinery as search. Unlike plain search, an all-empty filter set
@@ -994,31 +997,24 @@ export function searchMessages(
     params.push(networkId);
   }
   if (target) {
-    if (networkId) {
-      // `in:` scoped to one network: one fold under that network's rule, one
-      // folded-name probe bounded to the caller's buffers by idx_buffers_key.
-      where.push(
-        'm.buffer_id IN (SELECT b.id FROM buffers b WHERE b.user_id = ? AND b.target_folded = ?)',
-      );
-      params.push(userId, foldTargetFor(networkId, target));
-    } else {
-      // Unscoped `in:` means "this name on any of my networks" — and folds
-      // are per-network (#707), so ONE folded string can't probe them all: a
-      // Libera '#chat[dev]' is stored under its rfc1459 fold '#chat{dev}',
-      // which a legacy fold of the query would silently miss. Resolve per
-      // network in JS and bind the id list; an empty list matches nothing.
-      const ids: number[] = [];
-      for (const net of db.prepare(`SELECT id FROM networks WHERE user_id = ?`).all(userId) as {
-        id: number;
-      }[]) {
-        const found = resolveBuffer(userId, net.id, target);
-        if (found) ids.push(found.id);
-      }
-      if (ids.length === 0) where.push('0');
-      else {
-        where.push(`m.buffer_id IN (${ids.map(() => '?').join(', ')})`);
-        params.push(...ids);
-      }
+    // `in:` resolves through the registry once per candidate network — folds
+    // are per-network (#707), so ONE folded string can't probe several
+    // networks: a Libera '#chat[dev]' is stored under its rfc1459 fold
+    // '#chat{dev}', which a legacy fold of the query would silently miss.
+    // The scoped case is the one-network instance of the same loop, so both
+    // shapes share one mechanism. An empty id list matches nothing.
+    const nets = networkId
+      ? [{ id: networkId }]
+      : (userNetworkIdsStmt.all(userId) as { id: number }[]);
+    const ids: number[] = [];
+    for (const net of nets) {
+      const found = resolveBuffer(userId, net.id, target);
+      if (found) ids.push(found.id);
+    }
+    if (ids.length === 0) where.push('0');
+    else {
+      where.push(`m.buffer_id IN (${ids.map(() => '?').join(', ')})`);
+      params.push(...ids);
     }
   }
   // `nicks` OR-matches several senders (a friend's alts); `nick` is the single

--- a/server/db/messages.ts
+++ b/server/db/messages.ts
@@ -4,6 +4,7 @@
 import db from './index.js';
 import {
   foldTargetFor,
+  resolveBuffer,
   resolveBufferIdByNetwork,
   resolveOrMintForInsert,
 } from './bufferResolve.js';
@@ -993,14 +994,32 @@ export function searchMessages(
     params.push(networkId);
   }
   if (target) {
-    // `in:` scope. Without a networkId this means "this name on any of my
-    // networks", so it resolves through the registry as a folded-name subquery
-    // rather than a single id. The user_id prefix of idx_buffers_key bounds
-    // the subquery to the caller's own buffers.
-    where.push(
-      'm.buffer_id IN (SELECT b.id FROM buffers b WHERE b.user_id = ? AND b.target_folded = ?)',
-    );
-    params.push(userId, foldTargetFor(networkId ?? null, target));
+    if (networkId) {
+      // `in:` scoped to one network: one fold under that network's rule, one
+      // folded-name probe bounded to the caller's buffers by idx_buffers_key.
+      where.push(
+        'm.buffer_id IN (SELECT b.id FROM buffers b WHERE b.user_id = ? AND b.target_folded = ?)',
+      );
+      params.push(userId, foldTargetFor(networkId, target));
+    } else {
+      // Unscoped `in:` means "this name on any of my networks" — and folds
+      // are per-network (#707), so ONE folded string can't probe them all: a
+      // Libera '#chat[dev]' is stored under its rfc1459 fold '#chat{dev}',
+      // which a legacy fold of the query would silently miss. Resolve per
+      // network in JS and bind the id list; an empty list matches nothing.
+      const ids: number[] = [];
+      for (const net of db.prepare(`SELECT id FROM networks WHERE user_id = ?`).all(userId) as {
+        id: number;
+      }[]) {
+        const found = resolveBuffer(userId, net.id, target);
+        if (found) ids.push(found.id);
+      }
+      if (ids.length === 0) where.push('0');
+      else {
+        where.push(`m.buffer_id IN (${ids.map(() => '?').join(', ')})`);
+        params.push(...ids);
+      }
+    }
   }
   // `nicks` OR-matches several senders (a friend's alts); `nick` is the single
   // case. COLLATE NOCASE binds to the column so the IN comparison is case-fold.

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -38,6 +38,10 @@ export interface Network {
   sasl_password: string | null;
   connect_commands: string | null;
   position: number;
+  /** ISUPPORT CASEMAPPING as last declared by the server (#707); null until
+   *  the network first connects to one that declares it. Server-captured, not
+   *  user-editable — see setNetworkCasemapping. */
+  casemapping: string | null;
   created_at: string;
 }
 
@@ -128,6 +132,14 @@ export function createNetwork(userId: number, fields: NetworkFields): Network | 
   // pointer have an id from the first event.
   ensureServerBuffer(Number(result.lastInsertRowid));
   return getNetwork(result.lastInsertRowid, userId);
+}
+
+/** Record the server-declared CASEMAPPING (#707). Deliberately not part of
+ *  updateNetwork/NetworkFields: this is a fact captured from the wire, not a
+ *  setting a user edits, and routing it through the settings path would let a
+ *  PATCH body overwrite it. */
+export function setNetworkCasemapping(id: number, casemapping: string): void {
+  db.prepare(`UPDATE networks SET casemapping = ? WHERE id = ?`).run(casemapping, id);
 }
 
 export function updateNetwork(

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
-import { ensureServerBuffer } from './buffers.js';
+import { ensureServerBuffer, invalidateCasemappingCache } from './buffers.js';
 import { encryptSecret, decryptSecret } from '../utils/secretCrypto.js';
 import { ENCRYPTED_NETWORK_COLUMNS } from './exportSchema.js';
 
@@ -39,8 +39,10 @@ export interface Network {
   connect_commands: string | null;
   position: number;
   /** ISUPPORT CASEMAPPING as last declared by the server (#707); null until
-   *  the network first connects to one that declares it. Server-captured, not
-   *  user-editable — see setNetworkCasemapping. */
+   *  the network first connects to one that declares it. Server-captured
+   *  (stored by db/refoldBuffers inside the refold transaction), deliberately
+   *  not part of NetworkFields — a PATCH body must not be able to plant a
+   *  fold rule the registry wasn't rewritten under. */
   casemapping: string | null;
   created_at: string;
 }
@@ -134,14 +136,6 @@ export function createNetwork(userId: number, fields: NetworkFields): Network | 
   return getNetwork(result.lastInsertRowid, userId);
 }
 
-/** Record the server-declared CASEMAPPING (#707). Deliberately not part of
- *  updateNetwork/NetworkFields: this is a fact captured from the wire, not a
- *  setting a user edits, and routing it through the settings path would let a
- *  PATCH body overwrite it. */
-export function setNetworkCasemapping(id: number, casemapping: string): void {
-  db.prepare(`UPDATE networks SET casemapping = ? WHERE id = ?`).run(casemapping, id);
-}
-
 export function updateNetwork(
   id: number,
   userId: number,
@@ -186,6 +180,10 @@ export function updateNetwork(
 
 export function deleteNetwork(id: number, userId: number): void {
   db.prepare('DELETE FROM networks WHERE id = ? AND user_id = ?').run(id, userId);
+  // SQLite may hand a future network this id (rowid reuse); a cached
+  // CASEMAPPING surviving the row would fold the newcomer's targets with the
+  // dead network's rule.
+  invalidateCasemappingCache(id);
 }
 
 // The at-rest backfill that wraps any plaintext secret columns once a key is

--- a/server/db/networks.ts
+++ b/server/db/networks.ts
@@ -42,7 +42,14 @@ export interface Network {
    *  the network first connects to one that declares it. Server-captured
    *  (stored by db/refoldBuffers inside the refold transaction), deliberately
    *  not part of NetworkFields — a PATCH body must not be able to plant a
-   *  fold rule the registry wasn't rewritten under. */
+   *  fold rule the registry wasn't rewritten under.
+   *
+   *  Typed `string | null`, NOT the Casemapping union, on purpose: this
+   *  mirrors the raw column, which archive import writes verbatim — so an
+   *  archive from a newer Lurker could legally hold a value this build
+   *  doesn't know. The union lives at the read boundary
+   *  (buffers.networkCasemapping normalizes, unknown → null = legacy fold)
+   *  and at the sole writer (refoldNetworkBuffers takes Casemapping). */
   casemapping: string | null;
   created_at: string;
 }

--- a/server/db/normalizeBuffers.ts
+++ b/server/db/normalizeBuffers.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import type { Database } from 'better-sqlite3';
+import type { Database, Statement } from 'better-sqlite3';
+import { foldTargetWith, normalizeCasemapping } from './casemapping.js';
 
 // The v17 normalization bodies: mint the buffers rows that message history
 // implies, then stamp messages.buffer_id from them. Exported (and handed the
@@ -17,12 +18,17 @@ import type { Database } from 'better-sqlite3';
 // loop documented on the idx_messages_unread build (a one-shot, non-resumable
 // stall) structurally cannot happen here.
 //
-// Folding: lookups everywhere else fold with JS toLowerCase (buffers.ts
-// foldTarget — Unicode-aware), but a set-based UPDATE can only call SQL
-// functions, and SQLite's lower() is ASCII-only. `#Ärger` folds differently
-// under the two, which is exactly the class of bug #707 catalogues. So the
-// SQL side calls a registered custom function that IS foldTarget, and the two
-// rules cannot diverge.
+// Folding: the set-based SQL passes call a registered custom function that IS
+// the legacy JS fold (toLowerCase) — SQLite's own lower() is ASCII-only and
+// `#Ärger` folds differently under the two, exactly the class of bug #707
+// catalogues. That's correct for the version-gated migration bodies, which
+// run before any network can have declared a CASEMAPPING. The JS-side mints
+// are different: they ALSO run on straggler-retry boots and on archive
+// import, where a network may carry a declared mapping — so they fold
+// per-network via foldForNetworkFn below (reading through the handed db;
+// importing buffers.ts here would cycle back through index.ts
+// mid-evaluation). Probing with the legacy fold there misses a refolded row
+// and mints an unreachable zombie twin beside it.
 
 const FOLD_FN = 'lurker_fold_target';
 
@@ -82,6 +88,31 @@ export function mintSentinelBuffers(db: Database): void {
  * iterating a live cursor while writing on the shared connection is the
  * documented crash class (AGENTS.md).
  */
+/** Per-network fold for the JS-side mints (see the module header). Returns a
+ *  closure over a per-run mapping cache; NULL network (app-scoped) and
+ *  undeclared networks use the legacy fold. On a pre-#707 schema (a mid-
+ *  migration fixture where networks.casemapping doesn't exist yet) no mapping
+ *  can have been declared, so the legacy fold is exact by definition. */
+function foldForNetworkFn(db: Database): (networkId: number | null, target: string) => string {
+  let stmt: Statement | null;
+  try {
+    stmt = db.prepare(`SELECT casemapping FROM networks WHERE id = ?`);
+  } catch {
+    stmt = null;
+  }
+  const cache = new Map<number, string | null>();
+  return (networkId, target) => {
+    if (networkId == null || !stmt) return target.toLowerCase();
+    let raw = cache.get(networkId);
+    if (raw === undefined) {
+      raw =
+        (stmt.get(networkId) as { casemapping: string | null } | undefined)?.casemapping ?? null;
+      cache.set(networkId, raw);
+    }
+    return foldTargetWith(normalizeCasemapping(raw) ?? null, target);
+  };
+}
+
 export function mintOrphanBuffersFromMessages(db: Database): number {
   const distinct = db
     .prepare(`SELECT DISTINCT network_id AS networkId, target FROM messages`)
@@ -99,6 +130,7 @@ export function mintOrphanBuffersFromMessages(db: Database): number {
      ON CONFLICT(user_id, IFNULL(network_id, 0), target_folded) DO NOTHING`,
   );
 
+  const foldFor = foldForNetworkFn(db);
   let minted = 0;
   for (const { networkId, target } of distinct) {
     const owner = userByNetwork.get(networkId) as { userId: number } | undefined;
@@ -110,7 +142,7 @@ export function mintOrphanBuffersFromMessages(db: Database): number {
     // instead — the same coalescing the live insert path applies — so
     // imported server-console history becomes reachable rather than hidden.
     if (target.startsWith(':')) continue;
-    const folded = target.toLowerCase();
+    const folded = foldFor(networkId, target);
     if (exists.get(owner.userId, networkId, folded)) continue;
     const kind = '#&+!'.includes(target[0] ?? '') ? 'channel' : 'dm';
     minted += insert.run(owner.userId, networkId, target, folded, kind).changes;
@@ -291,6 +323,7 @@ export function mintOrphanBuffersFromSatellites(db: Database, tables: readonly s
      ON CONFLICT(user_id, IFNULL(network_id, 0), target_folded) DO NOTHING`,
   );
   const networkExists = db.prepare(`SELECT 1 FROM networks WHERE id = ?`);
+  const foldFor = foldForNetworkFn(db);
   let minted = 0;
   for (const table of tables) {
     const rows = db
@@ -304,7 +337,7 @@ export function mintOrphanBuffersFromSatellites(db: Database, tables: readonly s
       if (target.startsWith(':')) continue;
       if (networkId != null && !networkExists.get(networkId)) continue; // FK would reject
       const kind = '#&+!'.includes(target[0] ?? '') ? 'channel' : 'dm';
-      minted += insert.run(userId, networkId, target, target.toLowerCase(), kind).changes;
+      minted += insert.run(userId, networkId, target, foldFor(networkId, target), kind).changes;
     }
   }
   return minted;

--- a/server/db/refoldBuffers.test.ts
+++ b/server/db/refoldBuffers.test.ts
@@ -113,6 +113,7 @@ describe('newly-colliding rows merge (the #foo[bar] ≡ #foo{bar} fix)', () => {
         absorbedId: bracketId,
         absorbedTarget: '#foo[bar]',
         draftChanged: false,
+        survivorOpen: true,
       },
     ]);
     // One row remains, open, and BOTH spellings resolve to it now.
@@ -144,6 +145,23 @@ describe('newly-colliding rows merge (the #foo[bar] ≡ #foo{bar} fix)', () => {
     const survivor = buffers.getBuffer(userId, networkId, '#ops{1}')!;
     expect(survivor.autojoin).toBe(true);
     expect(survivor.key).toBe('hunter2');
+  });
+
+  it('two CLOSED twins merge with survivorOpen false — nothing to announce', () => {
+    // Clients hold no state for closed buffers; the caller uses this flag to
+    // suppress the buffer-renamed frame, or clients would materialize a
+    // sidebar row for a conversation closed everywhere.
+    const networkId = makeNetwork('closedtwins');
+    buffers.ensureOpen(userId, networkId, 'ghost^');
+    buffers.ensureOpen(userId, networkId, 'ghost~');
+    buffers.close(userId, networkId, 'ghost^');
+    buffers.close(userId, networkId, 'ghost~');
+
+    const merges = refoldNetworkBuffers(userId, networkId, 'rfc1459');
+
+    expect(merges).toHaveLength(1);
+    expect(merges[0].survivorOpen).toBe(false);
+    expect(buffers.getBuffer(userId, networkId, 'ghost~')?.state).toBe('closed');
   });
 
   it('between two open rows, the one with the most recent message survives', () => {

--- a/server/db/refoldBuffers.test.ts
+++ b/server/db/refoldBuffers.test.ts
@@ -12,7 +12,6 @@ process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
 let db: typeof import('./index.js').default;
 let createUser: typeof import('./users.js').createUser;
 let createNetwork: typeof import('./networks.js').createNetwork;
-let setNetworkCasemapping: typeof import('./networks.js').setNetworkCasemapping;
 let buffers: typeof import('./buffers.js');
 let refoldNetworkBuffers: typeof import('./refoldBuffers.js').refoldNetworkBuffers;
 let resolveBuffer: typeof import('./bufferResolve.js').resolveBuffer;
@@ -41,7 +40,7 @@ function seed(networkId: number, target: string, text: string): number {
 beforeAll(async () => {
   ({ default: db } = await import('./index.js'));
   ({ createUser } = await import('./users.js'));
-  ({ createNetwork, setNetworkCasemapping } = await import('./networks.js'));
+  ({ createNetwork } = await import('./networks.js'));
   buffers = await import('./buffers.js');
   ({ refoldNetworkBuffers } = await import('./refoldBuffers.js'));
   ({ resolveBuffer } = await import('./bufferResolve.js'));
@@ -59,10 +58,19 @@ describe('fold drift without collision', () => {
     buffers.ensureOpen(userId, networkId, '#Ärger');
     const id = buffers.getBuffer(userId, networkId, '#Ärger')!.id;
 
-    setNetworkCasemapping(networkId, 'rfc1459');
     const merges = refoldNetworkBuffers(userId, networkId, 'rfc1459');
     expect(merges).toEqual([]);
 
+    // The mapping stores atomically WITH the refold — a mapping committed
+    // ahead of a failed refold would never be retried (the stored value is
+    // the capture path's only "already done" signal).
+    expect(
+      (
+        db.prepare(`SELECT casemapping FROM networks WHERE id = ?`).get(networkId) as {
+          casemapping: string | null;
+        }
+      ).casemapping,
+    ).toBe('rfc1459');
     // ascii-family rules leave Ä alone, so the stored fold must now carry it.
     const folded = (
       db.prepare(`SELECT target_folded FROM buffers WHERE id = ?`).get(id) as {
@@ -78,7 +86,6 @@ describe('fold drift without collision', () => {
 
   it('leaves sentinels alone', () => {
     const networkId = makeNetwork('sentinels');
-    setNetworkCasemapping(networkId, 'rfc1459');
     refoldNetworkBuffers(userId, networkId, 'rfc1459');
     expect(buffers.getBuffer(userId, networkId, `:server:${networkId}`)).toBeTruthy();
   });
@@ -97,7 +104,6 @@ describe('newly-colliding rows merge (the #foo[bar] ≡ #foo{bar} fix)', () => {
     bufferReads.setReadState(userId, networkId, '#foo[bar]', bracketMsg);
     buffers.close(userId, networkId, '#foo[bar]');
 
-    setNetworkCasemapping(networkId, 'rfc1459');
     const merges = refoldNetworkBuffers(userId, networkId, 'rfc1459');
 
     expect(merges).toEqual([
@@ -122,6 +128,24 @@ describe('newly-colliding rows merge (the #foo[bar] ≡ #foo{bar} fix)', () => {
     expect(bufferReads.getReadState(userId, networkId, '#foo{bar}')).toBe(bracketMsg);
   });
 
+  it('a merge unions autojoin and adopts the absorbed +k key', () => {
+    // The absorbed side can be the one carrying the channel's autojoin flag
+    // and key (joined recently, no history yet); deleting the row must not
+    // take them with it — importRow's channel semantics (autojoin = MAX,
+    // key = first non-null) apply to merges too.
+    const networkId = makeNetwork('channelprops');
+    buffers.ensureOpen(userId, networkId, '#ops{1}');
+    seed(networkId, '#ops{1}', 'chatty survivor');
+    buffers.ensureOpen(userId, networkId, '#ops[1]', { autojoin: true, key: 'hunter2' });
+
+    const merges = refoldNetworkBuffers(userId, networkId, 'rfc1459');
+
+    expect(merges).toHaveLength(1);
+    const survivor = buffers.getBuffer(userId, networkId, '#ops{1}')!;
+    expect(survivor.autojoin).toBe(true);
+    expect(survivor.key).toBe('hunter2');
+  });
+
   it('between two open rows, the one with the most recent message survives', () => {
     const networkId = makeNetwork('recency');
     buffers.ensureOpen(userId, networkId, 'nick^');
@@ -130,7 +154,6 @@ describe('newly-colliding rows merge (the #foo[bar] ≡ #foo{bar} fix)', () => {
     seed(networkId, 'nick~', 'newest');
     const tildeId = buffers.getBuffer(userId, networkId, 'nick~')!.id;
 
-    setNetworkCasemapping(networkId, 'rfc1459');
     const merges = refoldNetworkBuffers(userId, networkId, 'rfc1459');
 
     expect(merges).toHaveLength(1);
@@ -142,7 +165,8 @@ describe('newly-colliding rows merge (the #foo[bar] ≡ #foo{bar} fix)', () => {
 describe('the live paths fold per-network once a mapping is stored', () => {
   it('ensureOpen cannot fork a bracket variant on an rfc1459 network', () => {
     const networkId = makeNetwork('nofork');
-    setNetworkCasemapping(networkId, 'rfc1459');
+    // The refold IS the mapping's writer (it stores inside its transaction).
+    refoldNetworkBuffers(userId, networkId, 'rfc1459');
     buffers.ensureOpen(userId, networkId, '#chan[1]');
     const id = buffers.getBuffer(userId, networkId, '#chan[1]')!.id;
     // Pre-#707 this minted a second row; now it lands on the same one.

--- a/server/db/refoldBuffers.test.ts
+++ b/server/db/refoldBuffers.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-refold-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let db: typeof import('./index.js').default;
+let createUser: typeof import('./users.js').createUser;
+let createNetwork: typeof import('./networks.js').createNetwork;
+let setNetworkCasemapping: typeof import('./networks.js').setNetworkCasemapping;
+let buffers: typeof import('./buffers.js');
+let refoldNetworkBuffers: typeof import('./refoldBuffers.js').refoldNetworkBuffers;
+let resolveBuffer: typeof import('./bufferResolve.js').resolveBuffer;
+let insertMessage: typeof import('./messages.js').insertMessage;
+let listMessages: typeof import('./messages.js').listMessages;
+let bufferReads: typeof import('./bufferReads.js');
+let userId: number;
+
+function makeNetwork(name: string): number {
+  return createNetwork(userId, { name, host: 'h', port: 6697, tls: true, nick: 'a' })!.id;
+}
+
+function seed(networkId: number, target: string, text: string): number {
+  return Number(
+    insertMessage({
+      networkId,
+      target,
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'peer',
+      text,
+    }).id,
+  );
+}
+
+beforeAll(async () => {
+  ({ default: db } = await import('./index.js'));
+  ({ createUser } = await import('./users.js'));
+  ({ createNetwork, setNetworkCasemapping } = await import('./networks.js'));
+  buffers = await import('./buffers.js');
+  ({ refoldNetworkBuffers } = await import('./refoldBuffers.js'));
+  ({ resolveBuffer } = await import('./bufferResolve.js'));
+  ({ insertMessage, listMessages } = await import('./messages.js'));
+  bufferReads = await import('./bufferReads.js');
+  userId = createUser('refold-alice').id;
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('fold drift without collision', () => {
+  it('rewrites target_folded in place under the declared rule', () => {
+    const networkId = makeNetwork('drift');
+    // Created under the legacy fold: target_folded = '#ärger'.
+    buffers.ensureOpen(userId, networkId, '#Ärger');
+    const id = buffers.getBuffer(userId, networkId, '#Ärger')!.id;
+
+    setNetworkCasemapping(networkId, 'rfc1459');
+    const merges = refoldNetworkBuffers(userId, networkId, 'rfc1459');
+    expect(merges).toEqual([]);
+
+    // ascii-family rules leave Ä alone, so the stored fold must now carry it.
+    const folded = (
+      db.prepare(`SELECT target_folded FROM buffers WHERE id = ?`).get(id) as {
+        target_folded: string;
+      }
+    ).target_folded;
+    expect(folded).toBe('#Ärger');
+    // And resolution agrees with itself: the raw name still resolves…
+    expect(resolveBuffer(userId, networkId, '#Ärger')?.id).toBe(id);
+    // …while '#ärger' is now a DIFFERENT name under rfc1459, per the spec.
+    expect(resolveBuffer(userId, networkId, '#ärger')).toBeUndefined();
+  });
+
+  it('leaves sentinels alone', () => {
+    const networkId = makeNetwork('sentinels');
+    setNetworkCasemapping(networkId, 'rfc1459');
+    refoldNetworkBuffers(userId, networkId, 'rfc1459');
+    expect(buffers.getBuffer(userId, networkId, `:server:${networkId}`)).toBeTruthy();
+  });
+});
+
+describe('newly-colliding rows merge (the #foo[bar] ≡ #foo{bar} fix)', () => {
+  it('merges bracket-variant channels; the open row survives a closed one', () => {
+    const networkId = makeNetwork('collide');
+    // The stale side: closed, but with the NEWER message — open must still win.
+    buffers.ensureOpen(userId, networkId, '#foo[bar]');
+    buffers.ensureOpen(userId, networkId, '#foo{bar}');
+    const bracketId = buffers.getBuffer(userId, networkId, '#foo[bar]')!.id;
+    const braceId = buffers.getBuffer(userId, networkId, '#foo{bar}')!.id;
+    seed(networkId, '#foo{bar}', 'old chat');
+    const bracketMsg = seed(networkId, '#foo[bar]', 'newer chat');
+    bufferReads.setReadState(userId, networkId, '#foo[bar]', bracketMsg);
+    buffers.close(userId, networkId, '#foo[bar]');
+
+    setNetworkCasemapping(networkId, 'rfc1459');
+    const merges = refoldNetworkBuffers(userId, networkId, 'rfc1459');
+
+    expect(merges).toEqual([
+      {
+        survivorId: braceId,
+        survivorTarget: '#foo{bar}',
+        absorbedId: bracketId,
+        absorbedTarget: '#foo[bar]',
+        draftChanged: false,
+      },
+    ]);
+    // One row remains, open, and BOTH spellings resolve to it now.
+    expect(resolveBuffer(userId, networkId, '#foo[bar]')?.id).toBe(braceId);
+    expect(resolveBuffer(userId, networkId, '#FOO{BAR}')?.id).toBe(braceId);
+    expect(buffers.getBuffer(userId, networkId, '#foo{bar}')?.state).toBe('open');
+    expect(db.prepare(`SELECT 1 FROM buffers WHERE id = ?`).get(bracketId)).toBeUndefined();
+    // Histories interleave on the survivor; the furthest read pointer carried.
+    expect(listMessages(networkId, '#foo{bar}').map((m) => m.text)).toEqual([
+      'old chat',
+      'newer chat',
+    ]);
+    expect(bufferReads.getReadState(userId, networkId, '#foo{bar}')).toBe(bracketMsg);
+  });
+
+  it('between two open rows, the one with the most recent message survives', () => {
+    const networkId = makeNetwork('recency');
+    buffers.ensureOpen(userId, networkId, 'nick^');
+    buffers.ensureOpen(userId, networkId, 'nick~');
+    seed(networkId, 'nick^', 'older');
+    seed(networkId, 'nick~', 'newest');
+    const tildeId = buffers.getBuffer(userId, networkId, 'nick~')!.id;
+
+    setNetworkCasemapping(networkId, 'rfc1459');
+    const merges = refoldNetworkBuffers(userId, networkId, 'rfc1459');
+
+    expect(merges).toHaveLength(1);
+    expect(merges[0].survivorId).toBe(tildeId);
+    expect(resolveBuffer(userId, networkId, 'nick^')?.id).toBe(tildeId);
+  });
+});
+
+describe('the live paths fold per-network once a mapping is stored', () => {
+  it('ensureOpen cannot fork a bracket variant on an rfc1459 network', () => {
+    const networkId = makeNetwork('nofork');
+    setNetworkCasemapping(networkId, 'rfc1459');
+    buffers.ensureOpen(userId, networkId, '#chan[1]');
+    const id = buffers.getBuffer(userId, networkId, '#chan[1]')!.id;
+    // Pre-#707 this minted a second row; now it lands on the same one.
+    buffers.ensureOpen(userId, networkId, '#CHAN{1}');
+    expect(buffers.getBuffer(userId, networkId, '#CHAN{1}')?.id).toBe(id);
+    expect(
+      (
+        db.prepare(`SELECT COUNT(*) AS c FROM buffers WHERE network_id = ?`).get(networkId) as {
+          c: number;
+        }
+      ).c,
+    ).toBe(2); // the channel + the :server: sentinel
+  });
+
+  it('an undeclared network keeps the legacy fold — no churn', () => {
+    const networkId = makeNetwork('legacy');
+    buffers.ensureOpen(userId, networkId, '#foo[bar]');
+    buffers.ensureOpen(userId, networkId, '#foo{bar}');
+    // No mapping declared: the bracket variants stay distinct, exactly as
+    // they always were.
+    expect(buffers.getBuffer(userId, networkId, '#foo[bar]')?.id).not.toBe(
+      buffers.getBuffer(userId, networkId, '#foo{bar}')?.id,
+    );
+  });
+});

--- a/server/db/refoldBuffers.ts
+++ b/server/db/refoldBuffers.ts
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import db from './index.js';
+import { foldTargetWith } from './casemapping.js';
+import type { Casemapping } from './casemapping.js';
+import { absorbBufferRow } from './renameBuffer.js';
+
+// Re-fold one network's buffer registry under a newly-declared CASEMAPPING
+// (#707). Runs when the capture path (ircConnection 'server options') sees a
+// declared mapping that differs from what's stored — first contact with a
+// declaring server included, since every existing row was folded with the
+// legacy Unicode-lowercase rule.
+//
+// Two things can change:
+//
+//  - A row's stored fold no longer matches the declared rule (`#Ärger` was
+//    folded to `#ärger`; ascii-family rules leave `Ä` alone). Rewritten in
+//    place — nothing user-visible, target_folded never leaves the server.
+//  - Two rows now fold TOGETHER (`#foo[bar]` and `#foo{bar}` under rfc1459).
+//    Merged via the rename machinery's absorb, one buffer-renamed frame per
+//    absorbed row (the caller announces) — clients handle it exactly like a
+//    DM nick-collision merge.
+//
+// Survivor choice mirrors what the fold repair has always preferred (see
+// foldBufferCase: "the buffer you actually used"): an open row beats a closed
+// one, then the row with the most recent message, then the older row id — a
+// deterministic tiebreak, not a policy.
+
+export interface RefoldMerge {
+  survivorId: number;
+  survivorTarget: string;
+  absorbedId: number;
+  absorbedTarget: string;
+  /** Same contract as RenameResult.draftChanged: the surviving draft differs
+   *  from what the survivor had before the absorb. */
+  draftChanged: boolean;
+}
+
+interface Row {
+  id: number;
+  target: string;
+  target_folded: string;
+  state: string;
+}
+
+// Sentinels (kind server/system) never re-fold — their ':'-prefixed names are
+// ours, not the network's.
+const rowsStmt = db.prepare(`
+  SELECT id, target, target_folded, state FROM buffers
+  WHERE user_id = ? AND network_id = ? AND kind IN ('channel', 'dm')
+`);
+const lastMessageStmt = db.prepare(`SELECT MAX(id) AS m FROM messages WHERE buffer_id = ?`);
+const setFoldedStmt = db.prepare(`UPDATE buffers SET target_folded = ? WHERE id = ?`);
+const draftBodyStmt = db.prepare(
+  `SELECT body FROM user_drafts WHERE user_id = ? AND buffer_id = ?`,
+);
+
+const work = db.transaction(
+  (userId: number, networkId: number, mapping: Casemapping): RefoldMerge[] => {
+    const rows = rowsStmt.all(userId, networkId) as Row[];
+    const groups = new Map<string, Row[]>();
+    for (const row of rows) {
+      const folded = foldTargetWith(mapping, row.target);
+      const group = groups.get(folded);
+      if (group) group.push(row);
+      else groups.set(folded, [row]);
+    }
+
+    const merges: RefoldMerge[] = [];
+    // Surviving row id → its fold under the new rule.
+    const finalFolds: { row: Row; folded: string }[] = [];
+    for (const [folded, group] of groups) {
+      let survivor = group[0];
+      if (group.length > 1) {
+        const ranked = group
+          .map((row) => ({
+            row,
+            open: row.state === 'open' ? 1 : 0,
+            last: Number((lastMessageStmt.get(row.id) as { m: number | null }).m ?? 0),
+          }))
+          .sort((a, b) => b.open - a.open || b.last - a.last || a.row.id - b.row.id);
+        survivor = ranked[0].row;
+        for (const { row: absorbed } of ranked.slice(1)) {
+          const before = (draftBodyStmt.get(userId, survivor.id) as { body: string } | undefined)
+            ?.body;
+          absorbBufferRow(userId, networkId, survivor, absorbed);
+          // The union may have opened the survivor; later absorbs in this
+          // group must see that, or they'd re-run the flip's subquery dance.
+          if (absorbed.state === 'open') survivor.state = 'open';
+          const after = (draftBodyStmt.get(userId, survivor.id) as { body: string } | undefined)
+            ?.body;
+          merges.push({
+            survivorId: survivor.id,
+            survivorTarget: survivor.target,
+            absorbedId: absorbed.id,
+            absorbedTarget: absorbed.target,
+            draftChanged: after !== before,
+          });
+        }
+      }
+      finalFolds.push({ row: survivor, folded });
+    }
+
+    // Rewrite drifted folds in two phases, so a one-pass UPDATE order can
+    // never trip idx_buffers_key transiently (row A's new fold landing on row
+    // B's not-yet-rewritten old fold). Belt-and-braces: for every mapping
+    // transition we could construct, such a pair already collides under the
+    // OLD fold and merged above — but that's an argument about four specific
+    // fold functions, and parking changing rows on a synthetic fold first
+    // costs two statements to make the argument unnecessary. `refold:<id>`
+    // can't collide with a real fold: DM targets can't contain ':' on the
+    // wire and channel folds keep their sigil prefix.
+    const changing = finalFolds.filter(({ row, folded }) => row.target_folded !== folded);
+    for (const { row } of changing) setFoldedStmt.run(`refold:${row.id}`, row.id);
+    for (const { row, folded } of changing) setFoldedStmt.run(folded, row.id);
+    return merges;
+  },
+);
+
+/**
+ * Re-fold every buffer of (user, network) under `mapping`, merging rows that
+ * now collide. Returns the merges for the caller to announce (one
+ * buffer-renamed frame each, merged: true). One IMMEDIATE transaction — it
+ * reads before it writes, the Litestream SQLITE_BUSY_SNAPSHOT shape.
+ */
+export function refoldNetworkBuffers(
+  userId: number,
+  networkId: number,
+  mapping: Casemapping,
+): RefoldMerge[] {
+  return work.immediate(userId, networkId, mapping);
+}

--- a/server/db/refoldBuffers.ts
+++ b/server/db/refoldBuffers.ts
@@ -5,12 +5,14 @@ import db from './index.js';
 import { foldTargetWith } from './casemapping.js';
 import type { Casemapping } from './casemapping.js';
 import { absorbBufferRow } from './renameBuffer.js';
+import { invalidateCasemappingCache } from './buffers.js';
 
 // Re-fold one network's buffer registry under a newly-declared CASEMAPPING
-// (#707). Runs when the capture path (ircConnection 'server options') sees a
-// declared mapping that differs from what's stored — first contact with a
-// declaring server included, since every existing row was folded with the
-// legacy Unicode-lowercase rule.
+// (#707). Runs when the capture path (ircConnection's raw-005 token scan)
+// sees a declared mapping that differs from what's stored — first contact
+// with a declaring server included, since every existing row was folded with
+// the legacy Unicode-lowercase rule. This pass is also the mapping's ONE
+// writer: the store rides inside the refold transaction (see below).
 //
 // Two things can change:
 //
@@ -52,12 +54,18 @@ const rowsStmt = db.prepare(`
 `);
 const lastMessageStmt = db.prepare(`SELECT MAX(id) AS m FROM messages WHERE buffer_id = ?`);
 const setFoldedStmt = db.prepare(`UPDATE buffers SET target_folded = ? WHERE id = ?`);
-const draftBodyStmt = db.prepare(
-  `SELECT body FROM user_drafts WHERE user_id = ? AND buffer_id = ?`,
-);
+const storeMappingStmt = db.prepare(`UPDATE networks SET casemapping = ? WHERE id = ?`);
 
 const work = db.transaction(
   (userId: number, networkId: number, mapping: Casemapping): RefoldMerge[] => {
+    // The mapping is stored INSIDE the refold transaction, not before it: the
+    // stored value is the capture path's only "already done" signal, so a
+    // mapping committed ahead of a refold that then failed (Litestream write
+    // contention, a crash between the two) would never be retried — every
+    // lookup would fold with the new rule against rows still holding legacy
+    // folds, minting the exact duplicate-buffer split this seam exists to
+    // prevent. Fail together, retry together on the next 005.
+    storeMappingStmt.run(mapping, networkId);
     const rows = rowsStmt.all(userId, networkId) as Row[];
     const groups = new Map<string, Row[]>();
     for (const row of rows) {
@@ -82,20 +90,16 @@ const work = db.transaction(
           .sort((a, b) => b.open - a.open || b.last - a.last || a.row.id - b.row.id);
         survivor = ranked[0].row;
         for (const { row: absorbed } of ranked.slice(1)) {
-          const before = (draftBodyStmt.get(userId, survivor.id) as { body: string } | undefined)
-            ?.body;
-          absorbBufferRow(userId, networkId, survivor, absorbed);
+          const { draftChanged } = absorbBufferRow(userId, networkId, survivor, absorbed);
           // The union may have opened the survivor; later absorbs in this
           // group must see that, or they'd re-run the flip's subquery dance.
           if (absorbed.state === 'open') survivor.state = 'open';
-          const after = (draftBodyStmt.get(userId, survivor.id) as { body: string } | undefined)
-            ?.body;
           merges.push({
             survivorId: survivor.id,
             survivorTarget: survivor.target,
             absorbedId: absorbed.id,
             absorbedTarget: absorbed.target,
-            draftChanged: after !== before,
+            draftChanged,
           });
         }
       }
@@ -108,11 +112,13 @@ const work = db.transaction(
     // transition we could construct, such a pair already collides under the
     // OLD fold and merged above — but that's an argument about four specific
     // fold functions, and parking changing rows on a synthetic fold first
-    // costs two statements to make the argument unnecessary. `refold:<id>`
-    // can't collide with a real fold: DM targets can't contain ':' on the
-    // wire and channel folds keep their sigil prefix.
+    // costs two statements to make the argument unnecessary. The parking
+    // value opens with a NUL, which no wire target can carry and no fold
+    // produces — a stronger guarantee than any printable prefix, since the
+    // archive import writes targets verbatim and a hand-crafted row named
+    // "refold:7" would otherwise be able to abort the pass.
     const changing = finalFolds.filter(({ row, folded }) => row.target_folded !== folded);
-    for (const { row } of changing) setFoldedStmt.run(`refold:${row.id}`, row.id);
+    for (const { row } of changing) setFoldedStmt.run(`\u0000refold:${row.id}`, row.id);
     for (const { row, folded } of changing) setFoldedStmt.run(folded, row.id);
     return merges;
   },
@@ -129,5 +135,10 @@ export function refoldNetworkBuffers(
   networkId: number,
   mapping: Casemapping,
 ): RefoldMerge[] {
-  return work.immediate(userId, networkId, mapping);
+  const merges = work.immediate(userId, networkId, mapping);
+  // Only after the commit: an invalidation before a rolled-back store would
+  // just re-read the old value, but this ordering keeps the cache unable to
+  // ever run ahead of the database.
+  invalidateCasemappingCache(networkId);
+  return merges;
 }

--- a/server/db/refoldBuffers.ts
+++ b/server/db/refoldBuffers.ts
@@ -91,8 +91,9 @@ const work = db.transaction(
         survivor = ranked[0].row;
         for (const { row: absorbed } of ranked.slice(1)) {
           const { draftChanged } = absorbBufferRow(userId, networkId, survivor, absorbed);
-          // The union may have opened the survivor; later absorbs in this
-          // group must see that, or they'd re-run the flip's subquery dance.
+          // Keep the in-memory copy honest with the union absorbBufferRow may
+          // have just written, so later absorbs in this group pass the
+          // already-open survivor state instead of re-flipping it.
           if (absorbed.state === 'open') survivor.state = 'open';
           merges.push({
             survivorId: survivor.id,
@@ -106,20 +107,16 @@ const work = db.transaction(
       finalFolds.push({ row: survivor, folded });
     }
 
-    // Rewrite drifted folds in two phases, so a one-pass UPDATE order can
-    // never trip idx_buffers_key transiently (row A's new fold landing on row
-    // B's not-yet-rewritten old fold). Belt-and-braces: for every mapping
-    // transition we could construct, such a pair already collides under the
-    // OLD fold and merged above — but that's an argument about four specific
-    // fold functions, and parking changing rows on a synthetic fold first
-    // costs two statements to make the argument unnecessary. The parking
-    // value opens with a NUL, which no wire target can carry and no fold
-    // produces — a stronger guarantee than any printable prefix, since the
-    // archive import writes targets verbatim and a hand-crafted row named
-    // "refold:7" would otherwise be able to abort the pass.
-    const changing = finalFolds.filter(({ row, folded }) => row.target_folded !== folded);
-    for (const { row } of changing) setFoldedStmt.run(`\u0000refold:${row.id}`, row.id);
-    for (const { row, folded } of changing) setFoldedStmt.run(folded, row.id);
+    // Rewrite drifted folds in one pass. Order can't trip idx_buffers_key:
+    // the final folds are unique by construction (one survivor per group),
+    // and a transient collision would need row A's NEW fold to equal row B's
+    // still-stored OLD fold — checked case-by-case across the four
+    // implemented rules, any pair in that shape already folded together
+    // under the old rule and merged above, so B's slot is never occupied
+    // when A's rewrite lands.
+    for (const { row, folded } of finalFolds) {
+      if (row.target_folded !== folded) setFoldedStmt.run(folded, row.id);
+    }
     return merges;
   },
 );

--- a/server/db/refoldBuffers.ts
+++ b/server/db/refoldBuffers.ts
@@ -37,6 +37,11 @@ export interface RefoldMerge {
   /** Same contract as RenameResult.draftChanged: the surviving draft differs
    *  from what the survivor had before the absorb. */
   draftChanged: boolean;
+  /** Same contract as RenameResult.open: a closed survivor (both twins were
+   *  closed — the ranking puts any open row first, so this is constant per
+   *  group) must NOT be announced, or clients materialize a sidebar row for
+   *  a conversation closed everywhere. */
+  survivorOpen: boolean;
 }
 
 interface Row {
@@ -101,6 +106,7 @@ const work = db.transaction(
             absorbedId: absorbed.id,
             absorbedTarget: absorbed.target,
             draftChanged,
+            survivorOpen: survivor.state === 'open',
           });
         }
       }

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -98,6 +98,17 @@ const draftBodyStmt = db.prepare(
   `SELECT body FROM user_drafts WHERE user_id = ? AND buffer_id = ?`,
 );
 
+// Channel-property union, mirroring importRow's conflict semantics (autojoin
+// = MAX, key = first non-null): a merge must not silently drop the absorbed
+// row's autojoin flag or its +k key, which are properties of the CHANNEL both
+// rows name. `key` is encrypted at rest; COALESCE copies the opaque blob.
+const mergeChannelPropsStmt = db.prepare(`
+  UPDATE buffers SET
+    autojoin = MAX(autojoin, (SELECT b2.autojoin FROM buffers b2 WHERE b2.id = @absorbed)),
+    key = COALESCE(key, (SELECT b2.key FROM buffers b2 WHERE b2.id = @absorbed))
+  WHERE id = @survivor
+`);
+
 // Re-densify a (user, network)'s pin positions after a merge dropped a row.
 const renumberPinsStmt = db.prepare(`
   UPDATE pinned_buffers SET position = (
@@ -119,16 +130,20 @@ const renumberPinsStmt = db.prepare(`
  * the old rule collide under the declared one. Same policies as the rename
  * merge (they ARE the rename merge): repoint history wholesale, furthest read
  * pointer + max clear marker, survivor's pin slot (or adopt), survivor's
- * view-state and draft win, visibility is the union, absorbed row deleted,
- * pin positions re-densified. Runs inside the caller's transaction; the
- * caller announces.
+ * view-state and draft win (with the absorbed draft adopted when the survivor
+ * has none — reported via `draftChanged` so callers can announce it),
+ * autojoin/+k union per importRow's channel semantics, visibility is the
+ * union, absorbed row deleted, pin positions re-densified. Runs inside the
+ * caller's transaction; the caller announces.
  */
 export function absorbBufferRow(
   userId: number,
   networkId: number,
   survivor: { id: number; state: string },
   absorbed: { id: number; state: string },
-): void {
+): { draftChanged: boolean } {
+  const draftBefore = (draftBodyStmt.get(userId, survivor.id) as { body: string } | undefined)
+    ?.body;
   repointMessages.run(survivor.id, absorbed.id);
   repointInputHistory.run(survivor.id, absorbed.id);
   mergeReadsStmt.run({ survivor: survivor.id, absorbed: absorbed.id });
@@ -137,12 +152,15 @@ export function absorbBufferRow(
   adoptNicklistStmt.run(survivor.id, absorbed.id);
   adoptNotifyStmt.run(survivor.id, absorbed.id);
   adoptDraftStmt.run(survivor.id, absorbed.id);
+  mergeChannelPropsStmt.run({ survivor: survivor.id, absorbed: absorbed.id });
   // Visibility is the union: if either side was open, the merged buffer is.
   if (absorbed.state === 'open' && survivor.state !== 'open') setOpenStmt.run(survivor.id);
   // The absorbed row dies; its remaining satellites cascade with it (any
   // UPDATE OR IGNORE above that lost to the survivor left rows behind).
   deleteRowStmt.run(absorbed.id);
   renumberPinsStmt.run(userId, networkId);
+  const draftAfter = (draftBodyStmt.get(userId, survivor.id) as { body: string } | undefined)?.body;
+  return { draftChanged: draftAfter !== draftBefore };
 }
 
 const work = db.transaction(
@@ -190,12 +208,8 @@ const work = db.transaction(
     }
 
     // Merge: the destination row is absorbed into the (surviving) source.
-    const survivorDraftBefore = (draftBodyStmt.get(userId, src.id) as { body: string } | undefined)
-      ?.body;
-    absorbBufferRow(userId, networkId, src, dest);
+    const { draftChanged } = absorbBufferRow(userId, networkId, src, dest);
     setNameStmt.run(to, toFolded, src.id);
-    const survivorDraftAfter = (draftBodyStmt.get(userId, src.id) as { body: string } | undefined)
-      ?.body;
     return {
       renamed: true,
       bufferId: src.id,
@@ -203,7 +217,7 @@ const work = db.transaction(
       to,
       merged: true,
       mergedFromBufferId: dest.id,
-      draftChanged: survivorDraftAfter !== survivorDraftBefore,
+      draftChanged,
     };
   },
 );

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import db from './index.js';
-import { foldTarget } from './buffers.js';
+import { foldTargetFor } from './buffers.js';
 import { resolveBuffer } from './bufferResolve.js';
 
 // Rename a buffer — the primitive behind DM nick-follows (and, when the
@@ -113,6 +113,38 @@ const renumberPinsStmt = db.prepare(`
   WHERE user_id = ? AND network_id = ?
 `);
 
+/**
+ * Absorb one buffer row into another — the merge half of a rename, shared
+ * with the CASEMAPPING re-fold pass (#707), where two rows folded apart under
+ * the old rule collide under the declared one. Same policies as the rename
+ * merge (they ARE the rename merge): repoint history wholesale, furthest read
+ * pointer + max clear marker, survivor's pin slot (or adopt), survivor's
+ * view-state and draft win, visibility is the union, absorbed row deleted,
+ * pin positions re-densified. Runs inside the caller's transaction; the
+ * caller announces.
+ */
+export function absorbBufferRow(
+  userId: number,
+  networkId: number,
+  survivor: { id: number; state: string },
+  absorbed: { id: number; state: string },
+): void {
+  repointMessages.run(survivor.id, absorbed.id);
+  repointInputHistory.run(survivor.id, absorbed.id);
+  mergeReadsStmt.run({ survivor: survivor.id, absorbed: absorbed.id });
+  adoptReadsStmt.run(survivor.id, absorbed.id);
+  adoptPinStmt.run(survivor.id, absorbed.id);
+  adoptNicklistStmt.run(survivor.id, absorbed.id);
+  adoptNotifyStmt.run(survivor.id, absorbed.id);
+  adoptDraftStmt.run(survivor.id, absorbed.id);
+  // Visibility is the union: if either side was open, the merged buffer is.
+  if (absorbed.state === 'open' && survivor.state !== 'open') setOpenStmt.run(survivor.id);
+  // The absorbed row dies; its remaining satellites cascade with it (any
+  // UPDATE OR IGNORE above that lost to the survivor left rows behind).
+  deleteRowStmt.run(absorbed.id);
+  renumberPinsStmt.run(userId, networkId);
+}
+
 const work = db.transaction(
   (userId: number, networkId: number, from: string, to: string): RenameResult | undefined => {
     const src = resolveBuffer(userId, networkId, from);
@@ -127,7 +159,7 @@ const work = db.transaction(
     };
     // Sentinels never rename; a rename onto a sentinel name is nonsense.
     if (src.target.startsWith(':') || to.startsWith(':')) return noop;
-    const toFolded = foldTarget(to);
+    const toFolded = foldTargetFor(networkId, to);
 
     // Casing-only: same identity under the fold, just adopt the new display
     // casing. Announced (the display changed) but never a merge.
@@ -160,20 +192,7 @@ const work = db.transaction(
     // Merge: the destination row is absorbed into the (surviving) source.
     const survivorDraftBefore = (draftBodyStmt.get(userId, src.id) as { body: string } | undefined)
       ?.body;
-    repointMessages.run(src.id, dest.id);
-    repointInputHistory.run(src.id, dest.id);
-    mergeReadsStmt.run({ survivor: src.id, absorbed: dest.id });
-    adoptReadsStmt.run(src.id, dest.id);
-    adoptPinStmt.run(src.id, dest.id);
-    adoptNicklistStmt.run(src.id, dest.id);
-    adoptNotifyStmt.run(src.id, dest.id);
-    adoptDraftStmt.run(src.id, dest.id);
-    // Visibility is the union: if either side was open, the merged buffer is.
-    if (dest.state === 'open' && src.state !== 'open') setOpenStmt.run(src.id);
-    // The absorbed row dies; its remaining satellites cascade with it (any
-    // UPDATE OR IGNORE above that lost to the survivor left rows behind).
-    deleteRowStmt.run(dest.id);
-    renumberPinsStmt.run(userId, networkId);
+    absorbBufferRow(userId, networkId, src, dest);
     setNameStmt.run(to, toFolded, src.id);
     const survivorDraftAfter = (draftBodyStmt.get(userId, src.id) as { body: string } | undefined)
       ?.body;

--- a/server/db/renameBuffer.ts
+++ b/server/db/renameBuffer.ts
@@ -40,6 +40,11 @@ export interface RenameResult {
   /** True when the merge left the surviving draft different from the
    *  source's (the client should refresh its mirror). */
   draftChanged: boolean;
+  /** Whether the surviving buffer is OPEN after the rename (union on a
+   *  merge). Callers must not announce a closed survivor: clients hold no
+   *  state for closed buffers, and a merged frame for one makes them
+   *  materialize a sidebar row for a conversation closed everywhere. */
+  open: boolean;
 }
 
 const setNameStmt = db.prepare(`UPDATE buffers SET target = ?, target_folded = ? WHERE id = ?`);
@@ -174,6 +179,7 @@ const work = db.transaction(
       to: src.target,
       merged: false,
       draftChanged: false,
+      open: src.state === 'open',
     };
     // Sentinels never rename; a rename onto a sentinel name is nonsense.
     if (src.target.startsWith(':') || to.startsWith(':')) return noop;
@@ -191,6 +197,7 @@ const work = db.transaction(
         to,
         merged: false,
         draftChanged: false,
+        open: src.state === 'open',
       };
     }
 
@@ -204,6 +211,7 @@ const work = db.transaction(
         to,
         merged: false,
         draftChanged: false,
+        open: src.state === 'open',
       };
     }
 
@@ -218,6 +226,8 @@ const work = db.transaction(
       merged: true,
       mergedFromBufferId: dest.id,
       draftChanged,
+      // Visibility union already applied by absorbBufferRow.
+      open: src.state === 'open' || dest.state === 'open',
     };
   },
 );

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -49,7 +49,7 @@ import { verifyPassword, hashPassword } from './password.js';
 import { hashToken, findActiveByHash, touchLastUsed } from '../db/apiTokens.js';
 import { listNetworksForUser } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
-import { closedFoldedSetForNetwork } from '../db/buffers.js';
+import { closedFoldedSetForNetwork, foldTargetFor } from '../db/buffers.js';
 import {
   listMessages,
   listBuffersForNetwork,
@@ -1332,8 +1332,11 @@ class BouncerSession {
     // buffers registry this path enumerated straight from messages and offered
     // conversations the user had closed everywhere else.
     const closed = closedFoldedSetForNetwork(this.networkId);
+    // The set holds target_folded values — per-network folds since #707, so
+    // the probe must fold the same way or a closed 'foo[m]' (stored 'foo{m}'
+    // on an rfc1459 network) slips past and gets re-offered.
     const targets = listActiveTargetsInWindow(this.networkId, isoA, isoB, limit).filter(
-      (t) => !closed.has(t.target.toLowerCase()),
+      (t) => !closed.has(foldTargetFor(this.networkId, t.target)),
     );
     this.withBatch('draft/chathistory-targets', [], (ref) => {
       const tag = ref ? `@batch=${ref} ` : '';
@@ -1510,7 +1513,10 @@ class BouncerSession {
     const dms = listBuffersForNetwork(this.networkId)
       .filter((b) => !isChannelName(b.target) && !b.target.startsWith(':server:'))
       .filter((b) => !joined.has(b.target.toLowerCase()))
-      .filter((b) => !closed.has(b.target.toLowerCase()))
+      // Fold like the set was built (per-network target_folded, #707) — the
+      // legacy lowercase probe replays closed DMs on every attach once the
+      // folds diverge, the exact pre-registry regression this filter stops.
+      .filter((b) => !closed.has(foldTargetFor(this.networkId, b.target)))
       .slice(0, PLAYBACK_MAX_DM_BUFFERS);
     for (const b of dms) targets.push({ target: b.target, isChannel: false });
 

--- a/server/services/chghostWiring.test.ts
+++ b/server/services/chghostWiring.test.ts
@@ -45,6 +45,7 @@ function makeConn(): IrcConnection {
       sasl_password: null,
       connect_commands: null,
       position: 0,
+      casemapping: null,
       created_at: new Date().toISOString(),
     },
     onEvent: () => {},

--- a/server/services/ctcpWiring.test.ts
+++ b/server/services/ctcpWiring.test.ts
@@ -45,6 +45,7 @@ function makeConn(): IrcConnection {
       sasl_password: null,
       connect_commands: null,
       position: 0,
+      casemapping: null,
       created_at: new Date().toISOString(),
     },
     onEvent: () => {},

--- a/server/services/dccWiring.test.ts
+++ b/server/services/dccWiring.test.ts
@@ -72,6 +72,7 @@ function makeConn(): IrcConnection {
       sasl_password: null,
       connect_commands: null,
       position: 0,
+      casemapping: null,
       created_at: new Date().toISOString(),
     },
     onEvent: () => {},

--- a/server/services/importService.test.ts
+++ b/server/services/importService.test.ts
@@ -143,6 +143,61 @@ function seedAlice(): { alice: User; net: Network; ruleId: number } {
 }
 
 describe('importFromZipBuffer — roundtrip', () => {
+  it('restores an rfc1459 network with per-network folds — no mid-restore fork (#707)', async () => {
+    // The archive carries the network's declared CASEMAPPING, and the buffer
+    // rows must be re-folded under THAT rule on the way in: a legacy
+    // toLowerCase here writes folds the message import's own resolver then
+    // misses, minting a duplicate buffer during the restore — and the healing
+    // refold never runs, because the imported mapping makes the first
+    // reconnect's stored===declared check a no-op.
+    const src = createUser(`refold_src_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+    const net = createNetwork(src.id, {
+      name: 'rfc1459net',
+      host: 'irc.example.test',
+      port: 6697,
+      tls: true,
+      nick: 'src',
+    })!;
+    buffers.ensureOpen(src.id, net.id, '#foo[bar]');
+    insertMessage({
+      networkId: net.id,
+      target: '#foo[bar]',
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'peer',
+      text: 'bracket history',
+    });
+    const { refoldNetworkBuffers } = await import('../db/refoldBuffers.js');
+    refoldNetworkBuffers(src.id, net.id, 'rfc1459');
+
+    const dst = createUser(`refold_dst_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+    const result = await importFromZipBuffer(
+      dst.id,
+      await exportToBuffer(src.id, {
+        includeMessages: true,
+      }),
+    );
+    expect(result.manifest.export_format_version).toBe(EXPORT_FORMAT_VERSION);
+
+    const dstNet = db
+      .prepare(`SELECT id, casemapping FROM networks WHERE user_id = ?`)
+      .get(dst.id) as { id: number; casemapping: string | null };
+    expect(dstNet.casemapping).toBe('rfc1459');
+    // ONE channel row, folded under the imported mapping, holding the history.
+    const rows = db
+      .prepare(
+        `SELECT id, target, target_folded FROM buffers WHERE network_id = ? AND kind = 'channel'`,
+      )
+      .all(dstNet.id) as Array<{ id: number; target: string; target_folded: string }>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].target).toBe('#foo[bar]');
+    expect(rows[0].target_folded).toBe('#foo{bar}');
+    const msgRows = db
+      .prepare(`SELECT buffer_id FROM messages WHERE network_id = ?`)
+      .all(dstNet.id) as Array<{ buffer_id: number }>;
+    expect(msgRows.map((m) => m.buffer_id)).toEqual([rows[0].id]);
+  });
+
   it('rehydrates networks, channels, messages, bookmarks, highlights, pins, notes, masks, settings, uploads', async () => {
     const { alice, net } = seedAlice();
     const bob = createUser(`bob_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -36,6 +36,7 @@ import {
   reopen as reopenBuffer,
   ensureServerBuffer,
   ensureSystemBuffer,
+  foldTargetFor,
 } from '../db/buffers.js';
 import { resolveBuffer } from '../db/bufferResolve.js';
 import { listBufferTargets, hasMessageForTarget } from '../db/messages.js';
@@ -240,9 +241,18 @@ function insertTable(
 
     // target_folded is derived state (the registry's one folded lookup key);
     // recompute rather than trusting the archive so a hand-edited or corrupted
-    // file can't plant a row the folded lookups will never find.
+    // file can't plant a row the folded lookups will never find. Folded
+    // per-network (#707): network_id is already rekeyed and networks import
+    // before buffers, so the just-imported casemapping governs — a legacy
+    // toLowerCase here would write folds the message import's own resolver
+    // then misses, minting duplicate buffers mid-restore (and colliding
+    // outright on ascii-network case-twins), while the healing refold never
+    // runs because the imported mapping makes the next connect a no-op.
     if (table === 'buffers') {
-      row.target_folded = String(row.target ?? '').toLowerCase();
+      row.target_folded = foldTargetFor(
+        (row.network_id as number | null) ?? null,
+        String(row.target ?? ''),
+      );
       // Sentinel rows (:system:, :server:<id>) are install-local: the target
       // account already owns its :system: row (minted at account creation —
       // inserting the archive's copy violates idx_buffers_key), and an

--- a/server/services/importService.ts
+++ b/server/services/importService.ts
@@ -37,6 +37,7 @@ import {
   ensureServerBuffer,
   ensureSystemBuffer,
   foldTargetFor,
+  invalidateCasemappingCache,
 } from '../db/buffers.js';
 import { resolveBuffer } from '../db/bufferResolve.js';
 import { listBufferTargets, hasMessageForTarget } from '../db/messages.js';
@@ -508,6 +509,14 @@ async function streamMessagesInBatches(
 // we clear them explicitly. Must cover every importable user-scoped root in
 // EXPORT_TABLES.
 function resetImportedData(userId: number): void {
+  // The buffers import folds through the casemapping cache mid-transaction,
+  // and the rollback that lands us here reverts sqlite_sequence — so the
+  // rolled-back network ids (cached with the rolled-back mappings) are
+  // exactly the ids the next createNetwork or retried import will mint.
+  // A stale hit there folds new rows under a dead network's rule AND makes
+  // the healing refold's stored===declared compare read the lie. Clear it
+  // all; the cache is lazy and refills on first use.
+  invalidateCasemappingCache();
   const wipe = db.transaction(() => {
     db.prepare('DELETE FROM networks WHERE user_id = ?').run(userId);
     db.prepare('DELETE FROM highlight_rules WHERE user_id = ?').run(userId);

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2666,6 +2666,9 @@ describe('CASEMAPPING capture + refold (#707)', () => {
     })!;
     const conn = new IrcConnection({ network, onEvent: () => {} });
     const published: Array<Record<string, unknown>> = [];
+    conn.publish = vi.fn<(event: unknown) => void>((e) => {
+      published.push(e as Record<string, unknown>);
+    }) as typeof conn.publish;
     conn.publishEphemeral = vi.fn<(event: unknown) => void>((e) => {
       published.push(e as Record<string, unknown>);
     }) as typeof conn.publishEphemeral;
@@ -2730,7 +2733,9 @@ describe('CASEMAPPING capture + refold (#707)', () => {
     expect(get(network.user_id, network.id, '#a[1]')?.id).not.toBe(
       get(network.user_id, network.id, '#a{1}')?.id,
     );
-    expect(published).toEqual([]);
+    // No lifecycle frames — the raw 005 line itself still renders as server
+    // text via the ordinary numeric path, which is not this test's concern.
+    expect(published.filter((e) => e.type === 'buffer-renamed')).toEqual([]);
   });
 
   it('re-declaring the stored mapping is a no-op — reconnects do no work', () => {
@@ -2738,6 +2743,49 @@ describe('CASEMAPPING capture + refold (#707)', () => {
     raw005(conn, 'CASEMAPPING=rfc1459');
     raw005(conn, 'CASEMAPPING=rfc1459');
     expect(published.filter((e) => e.type === 'buffer-renamed')).toEqual([]);
+  });
+
+  it('a merge of two CLOSED twins is silent — clients hold nothing to correct', async () => {
+    const { conn, network, published } = connFor('casemap-closed');
+    const { ensureOpen, close, getBuffer: get } = await import('../db/buffers.js');
+    ensureOpen(network.user_id, network.id, 'ghost^', { kind: 'dm' });
+    ensureOpen(network.user_id, network.id, 'ghost~', { kind: 'dm' });
+    close(network.user_id, network.id, 'ghost^');
+    close(network.user_id, network.id, 'ghost~');
+
+    raw005(conn, 'CASEMAPPING=rfc1459');
+
+    // Merged server-side, closed, and NOT announced — an announced merge
+    // would make clients materialize a sidebar row for it.
+    expect(get(network.user_id, network.id, 'ghost~')?.state).toBe('closed');
+    expect(published.filter((e) => e.type === 'buffer-renamed')).toEqual([]);
+  });
+
+  it('adopts the wire spelling on a join echo when the folds diverge', async () => {
+    // The state a refold merge can leave behind: the surviving twin isn't the
+    // spelling the ircd echoes. The join echo respells it (casing-only
+    // rename, announced) so the id-less control frames that follow can't
+    // fork a ghost buffer client-side. Plain ASCII case differences keep
+    // first-writer-wins display casing.
+    const { conn, network, published } = connFor('casemap-respell');
+    const { ensureOpen, getBuffer: get } = await import('../db/buffers.js');
+    raw005(conn, 'CASEMAPPING=rfc1459');
+    ensureOpen(network.user_id, network.id, '#chat{dev}');
+    const id = get(network.user_id, network.id, '#chat{dev}')!.id;
+    conn.client.user.nick = 'me';
+
+    conn.client.emit('join', { nick: 'me', channel: '#chat[dev]' });
+
+    // Same row (the spellings fold together); display adopts the wire spelling.
+    const row = get(network.user_id, network.id, '#chat[dev]');
+    expect(row?.id).toBe(id);
+    expect(row?.target).toBe('#chat[dev]');
+    expect(published.find((e) => e.type === 'buffer-renamed')).toMatchObject({
+      from: '#chat{dev}',
+      to: '#chat[dev]',
+      bufferId: id,
+      merged: false,
+    });
   });
 
   it('isChannelJoined folds both sides per the declared mapping', () => {

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2739,6 +2739,24 @@ describe('CASEMAPPING capture + refold (#707)', () => {
     raw005(conn, 'CASEMAPPING=rfc1459');
     expect(published.filter((e) => e.type === 'buffer-renamed')).toEqual([]);
   });
+
+  it('isChannelJoined folds both sides per the declared mapping', () => {
+    // The one membership probe every consumer must use instead of the raw
+    // channels-map key (legacy-lowercased wire names): a fold-variant
+    // spelling of a joined channel reads joined, and a Unicode case-twin on
+    // an ascii-family network does NOT (toLowerCase over-folds).
+    const { conn } = connFor('casemap-joined');
+    conn.upsertChannel('#foo[bar]');
+    conn.upsertChannel('#ärger');
+    raw005(conn, 'CASEMAPPING=rfc1459');
+
+    expect(conn.isChannelJoined('#foo{bar}')).toBe(true);
+    expect(conn.isChannelJoined('#FOO[BAR]')).toBe(true);
+    expect(conn.isChannelJoined('#ärger')).toBe(true);
+    // Distinct channels under rfc1459: Ä is not in the fold range.
+    expect(conn.isChannelJoined('#Ärger')).toBe(false);
+    expect(conn.isChannelJoined('#elsewhere')).toBe(false);
+  });
 });
 
 // #716 QA follow-up: a DM opened fresh from the nicklist showed its peer

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2672,21 +2672,26 @@ describe('CASEMAPPING capture + refold (#707)', () => {
     return { conn, network, published };
   }
 
-  function declare(conn: IrcConnection, value: string) {
-    // 005 path: irc-framework accumulates ISUPPORT into network.options and
-    // re-emits 'server options' per line; drive the real handler through it.
-    (conn.client.network.options as Record<string, unknown>).CASEMAPPING = value;
-    conn.client.emit('server options', {});
+  function raw005(conn: IrcConnection, tokens: string) {
+    // Capture reads the RAW 005 tokens, deliberately NOT network.options —
+    // irc-framework pre-seeds options.CASEMAPPING to 'rfc1459' in its
+    // NetworkInfo constructor, so through the options bag "declared rfc1459"
+    // and "declared nothing" are the same value. Drive the real 'raw' handler
+    // with a wire line, exactly as the socket would.
+    conn.client.emit('raw', {
+      from_server: true,
+      line: `:irc.example.test 005 me ${tokens} :are supported by this server`,
+    });
   }
 
-  it('stores the declared mapping and merges rows that now fold together', async () => {
+  it('stores a declared mapping and merges rows that now fold together', async () => {
     const { conn, network, published } = connFor('casemap');
     const { ensureOpen, getBuffer: get } = await import('../db/buffers.js');
     // Two rows under the legacy fold; ONE channel under rfc1459.
     ensureOpen(network.user_id, network.id, '#foo[bar]');
     ensureOpen(network.user_id, network.id, '#foo{bar}');
 
-    declare(conn, 'rfc1459');
+    raw005(conn, 'CHANTYPES=# CASEMAPPING=rfc1459 MONITOR=100');
 
     expect(getNetwork(network.id, network.user_id)?.casemapping).toBe('rfc1459');
     const merged = get(network.user_id, network.id, '#foo[bar]');
@@ -2697,13 +2702,29 @@ describe('CASEMAPPING capture + refold (#707)', () => {
     });
   });
 
+  it("NEVER captures irc-framework's defaulted rfc1459 — no token, no store", () => {
+    const { conn, network } = connFor('casemap-absent');
+    // The framework default is sitting right there in the options bag; a 005
+    // line without the token must not launder it into a declaration.
+    expect(conn.client.network.options.CASEMAPPING).toBe('rfc1459');
+    raw005(conn, 'CHANTYPES=# MONITOR=100');
+    expect(getNetwork(network.id, network.user_id)?.casemapping).toBeNull();
+  });
+
+  it('a declaration on a LATER 005 line still captures', async () => {
+    const { conn, network } = connFor('casemap-late');
+    raw005(conn, 'CHANTYPES=# PREFIX=(ov)@+');
+    raw005(conn, 'MONITOR=100 CASEMAPPING=ascii TARGMAX=NAMES:1');
+    expect(getNetwork(network.id, network.user_id)?.casemapping).toBe('ascii');
+  });
+
   it('an unknown value is not stored and changes nothing', async () => {
     const { conn, network, published } = connFor('casemap-unknown');
     const { ensureOpen, getBuffer: get } = await import('../db/buffers.js');
     ensureOpen(network.user_id, network.id, '#a[1]');
     ensureOpen(network.user_id, network.id, '#a{1}');
 
-    declare(conn, 'rfc8265');
+    raw005(conn, 'CASEMAPPING=rfc8265');
 
     expect(getNetwork(network.id, network.user_id)?.casemapping).toBeNull();
     expect(get(network.user_id, network.id, '#a[1]')?.id).not.toBe(
@@ -2714,10 +2735,8 @@ describe('CASEMAPPING capture + refold (#707)', () => {
 
   it('re-declaring the stored mapping is a no-op — reconnects do no work', () => {
     const { conn, published } = connFor('casemap-again');
-    declare(conn, 'rfc1459');
-    // Simulate the next socket: the latch resets on close, the value matches.
-    conn.capturedCasemapping = false;
-    declare(conn, 'rfc1459');
+    raw005(conn, 'CASEMAPPING=rfc1459');
+    raw005(conn, 'CASEMAPPING=rfc1459');
     expect(published.filter((e) => e.type === 'buffer-renamed')).toEqual([]);
   });
 });

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -31,7 +31,7 @@ import { createIdentdServer, unregisterIdent } from './identd.js';
 import connectScheduler from './connectScheduler.js';
 import { getRecent } from './systemLog.js';
 import { createUser } from '../db/users.js';
-import { createNetwork } from '../db/networks.js';
+import { createNetwork, getNetwork } from '../db/networks.js';
 import {
   getBuffer,
   ensureOpen as ensureBufferOpen,
@@ -385,6 +385,7 @@ describe('tls certificate trust setting', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -444,6 +445,7 @@ describe('addPeerWatch live presence seed (#302)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -502,6 +504,7 @@ describe('nick-regain MONITOR teardown gating (#384)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -651,6 +654,7 @@ describe('refused-message handler routing (#283)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -868,6 +872,7 @@ describe('built-in identd registration', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -967,6 +972,7 @@ describe('disconnect quit message (#324)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -1024,6 +1030,7 @@ describe('self nick updates the input bar (#362)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -1123,6 +1130,7 @@ describe('capability negotiation (#310)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -1664,6 +1672,7 @@ describe('IRCv3 draft/multiline (#381)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -1926,6 +1935,7 @@ describe('inbound INVITE handler (#261)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -2023,6 +2033,7 @@ describe('invite channel lines + dedup (#261)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -2110,6 +2121,7 @@ describe('channel mode display (status bar)', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -2299,6 +2311,7 @@ describe('join key forwarding', () => {
         sasl_password: null,
         connect_commands: null,
         position: 0,
+        casemapping: null,
         created_at: new Date().toISOString(),
       },
       onEvent: () => {},
@@ -2631,6 +2644,81 @@ describe('DM rename on peer NICK', () => {
 
     expect(get(network.user_id, network.id, 'me')).toBeDefined();
     expect(published.find((e) => e.type === 'buffer-renamed')).toBeUndefined();
+  });
+});
+
+describe('CASEMAPPING capture + refold (#707)', () => {
+  function connFor(name: string) {
+    const network = createNetwork(1, {
+      name,
+      host: 'irc.example.test',
+      port: 6697,
+      tls: 1,
+      trusted_certificates: 1,
+      nick: 'me',
+      username: null,
+      realname: null,
+      server_password: null,
+      autoconnect: 0,
+      sasl_account: null,
+      sasl_password: null,
+      connect_commands: null,
+    })!;
+    const conn = new IrcConnection({ network, onEvent: () => {} });
+    const published: Array<Record<string, unknown>> = [];
+    conn.publishEphemeral = vi.fn<(event: unknown) => void>((e) => {
+      published.push(e as Record<string, unknown>);
+    }) as typeof conn.publishEphemeral;
+    return { conn, network, published };
+  }
+
+  function declare(conn: IrcConnection, value: string) {
+    // 005 path: irc-framework accumulates ISUPPORT into network.options and
+    // re-emits 'server options' per line; drive the real handler through it.
+    (conn.client.network.options as Record<string, unknown>).CASEMAPPING = value;
+    conn.client.emit('server options', {});
+  }
+
+  it('stores the declared mapping and merges rows that now fold together', async () => {
+    const { conn, network, published } = connFor('casemap');
+    const { ensureOpen, getBuffer: get } = await import('../db/buffers.js');
+    // Two rows under the legacy fold; ONE channel under rfc1459.
+    ensureOpen(network.user_id, network.id, '#foo[bar]');
+    ensureOpen(network.user_id, network.id, '#foo{bar}');
+
+    declare(conn, 'rfc1459');
+
+    expect(getNetwork(network.id, network.user_id)?.casemapping).toBe('rfc1459');
+    const merged = get(network.user_id, network.id, '#foo[bar]');
+    expect(merged?.id).toBe(get(network.user_id, network.id, '#foo{bar}')?.id);
+    expect(published.find((e) => e.type === 'buffer-renamed')).toMatchObject({
+      merged: true,
+      bufferId: merged!.id,
+    });
+  });
+
+  it('an unknown value is not stored and changes nothing', async () => {
+    const { conn, network, published } = connFor('casemap-unknown');
+    const { ensureOpen, getBuffer: get } = await import('../db/buffers.js');
+    ensureOpen(network.user_id, network.id, '#a[1]');
+    ensureOpen(network.user_id, network.id, '#a{1}');
+
+    declare(conn, 'rfc8265');
+
+    expect(getNetwork(network.id, network.user_id)?.casemapping).toBeNull();
+    expect(get(network.user_id, network.id, '#a[1]')?.id).not.toBe(
+      get(network.user_id, network.id, '#a{1}')?.id,
+    );
+    expect(published).toEqual([]);
+  });
+
+  it('re-declaring the stored mapping is a no-op — reconnects do no work', () => {
+    const { conn, published } = connFor('casemap-again');
+    declare(conn, 'rfc1459');
+    // Simulate the next socket: the latch resets on close, the value matches.
+    conn.capturedCasemapping = false;
+    declare(conn, 'rfc1459');
+    expect(published.filter((e) => e.type === 'buffer-renamed')).toEqual([]);
   });
 });
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -17,6 +17,7 @@ import {
   deleteBuffer,
   listOpenDms,
   networkCasemapping,
+  foldTarget,
   foldTargetFor,
   kindForTarget,
 } from '../db/buffers.js';
@@ -482,6 +483,10 @@ export class IrcConnection {
   client: IrcClient;
   state: string;
   channels: Map<string, ChannelState>;
+  /** Lazily-built per-network-folded index over `channels` for
+   *  isChannelJoined. null = rebuild on next probe. MUST be nulled by every
+   *  channels-map mutation and by a CASEMAPPING change (the folds move). */
+  joinedFoldedCache: Set<string> | null;
   // Join keys awaiting their echo, keyed by lowercased channel. Nothing is
   // persisted on a join REQUEST (the buffers row is echo-written), so the key
   // rides here until the join lands; a forward (470) discards it. Lost on a
@@ -665,6 +670,7 @@ export class IrcConnection {
     this.client.requestCap('draft/multiline');
     this.state = 'disconnected';
     this.channels = new Map();
+    this.joinedFoldedCache = null;
     this.userModes = new Set();
     this.awayState = { active: false, message: null, since: null, autoSet: false, backAt: null };
     // Lowercase nicks we watch for presence, each tagged with why (DM peer
@@ -1009,10 +1015,7 @@ export class IrcConnection {
       // rejection, not a join failure — surface it inline in that channel so
       // the user sees why their message didn't land, instead of a misleading
       // "Couldn't join" toast (#283). publish() canonicalizes the channel case.
-      if (
-        channel &&
-        isOverloadedSpeakRejection(command, this.channels.has(channel.toLowerCase()))
-      ) {
+      if (channel && isOverloadedSpeakRejection(command, this.isChannelJoined(channel))) {
         this.handleSendRejection(channel, reason, { command, params });
         return;
       }
@@ -1979,6 +1982,29 @@ export class IrcConnection {
           if (stashedKey !== undefined) {
             setBufferChannelKey(this.network.user_id, this.network.id, eventChannel, stashedKey);
           }
+          // #707: adopt the WIRE spelling when the row's display name
+          // diverges beyond ASCII case — the state a refold merge leaves
+          // behind when the surviving twin wasn't the joined spelling
+          // ('#chat{dev}' survived on recency, the ircd echoes
+          // '#chat[dev]'). Left alone, the id-less control frames
+          // (channel-joined, names) fork a message-less ghost buffer
+          // client-side, since clients fold without the network rule. Both
+          // spellings resolve to this row, so this is renameBuffer's
+          // casing-only path: one UPDATE, one announce, clients rekey — and
+          // it converges permanently. Plain ASCII case differences (legacy
+          // folds equal) keep first-writer-wins display casing, as ever.
+          if (
+            record.target !== eventChannel &&
+            foldTarget(record.target) !== foldTarget(eventChannel)
+          ) {
+            const adopted = renameDmBuffer(
+              this.network.user_id,
+              this.network.id,
+              record.target,
+              eventChannel,
+            );
+            if (adopted?.renamed && adopted.open) this.announceBufferRenamed(adopted);
+          }
         } catch (_) {
           /* ignore */
         }
@@ -2039,6 +2065,7 @@ export class IrcConnection {
       });
       if (eventNick === c.user.nick) {
         this.channels.delete(eventChannel.toLowerCase());
+        this.joinedFoldedCache = null;
         this.publish({ type: 'channel-parted', target: channel });
         // No system-buffer "Parted #x" line — symmetric with the join above; the
         // part already shows in the channel buffer (#355).
@@ -2072,6 +2099,7 @@ export class IrcConnection {
       // channel that just kicked you reads as ban evasion to ops.
       if (eventKicked && c.user.nick && eventKicked.toLowerCase() === c.user.nick.toLowerCase()) {
         this.channels.delete(eventChannel.toLowerCase());
+        this.joinedFoldedCache = null;
         try {
           setBufferAutojoin(this.network.user_id, this.network.id, channel, false);
         } catch (_) {
@@ -2952,38 +2980,57 @@ export class IrcConnection {
     try {
       const stored = networkCasemapping(this.network.id);
       if (stored === declared) return;
+      // Synchronous by design (better-sqlite3), and bounded by the absorbed
+      // rows' history sizes: a merge repoints messages wholesale, so a
+      // case-twin with a very large history blocks the loop for the
+      // duration. Accepted with eyes open — it runs ONCE per network, on the
+      // first connect that declares the mapping — and the duration is logged
+      // so a slow one is visible rather than a mystery stall.
+      const startedAt = Date.now();
       const merges = refoldNetworkBuffers(this.network.user_id, this.network.id, declared);
       this.logNet(
         `CASEMAPPING ${declared}${stored ? ` (was ${stored})` : ''}` +
           (merges.length
             ? `; merged ${merges.length} case-colliding buffer${merges.length === 1 ? '' : 's'}`
-            : ''),
+            : '') +
+          ` (refold ${Date.now() - startedAt}ms)`,
       );
       for (const m of merges) {
-        this.announceBufferRenamed({
-          from: m.absorbedTarget,
-          to: m.survivorTarget,
-          bufferId: m.survivorId,
-          merged: true,
-          mergedFromBufferId: m.absorbedId,
-          draftChanged: m.draftChanged,
-        });
+        // A closed survivor (both twins were closed) is never announced:
+        // clients hold no state for closed buffers, so there is nothing to
+        // correct — and a merged frame would make them materialize a sidebar
+        // row for a conversation closed everywhere.
+        if (m.survivorOpen) {
+          this.announceBufferRenamed({
+            from: m.absorbedTarget,
+            to: m.survivorTarget,
+            bufferId: m.survivorId,
+            merged: true,
+            mergedFromBufferId: m.absorbedId,
+            draftChanged: m.draftChanged,
+          });
+        }
         // A merged DM must hand over its presence watch: the hydration seed
         // ran at 001 (before this 005) against pre-refold rows, so the
         // absorbed spelling holds a MONITOR slot for a registry row that no
         // longer exists — stranded until reconnect, consuming the shared cap.
         // The surviving spelling may never have been seeded at all (a closed
-        // survivor absorbed an open twin). Both trackers refcount, so this is
-        // safe when the survivor was already watched. Per-target maps
-        // (unsendableTargets & co.) are left alone deliberately: they key by
-        // wire name, sends go out under the surviving buffer's name from here
-        // on, and the dead spelling's entries are inert residue until the
-        // socket closes.
+        // survivor absorbed an open twin). Tracked-implies-open: a closed
+        // survivor gets no watch — the seed skips closed DMs, and a stray
+        // watch here would strand a capped slot on a hidden conversation.
+        // Both trackers refcount, so this is safe when the survivor was
+        // already watched. Per-target maps (unsendableTargets & co.) are
+        // left alone deliberately: they key by wire name, sends go out under
+        // the surviving buffer's name from here on, and the dead spelling's
+        // entries are inert residue until the socket closes.
         if (kindForTarget(m.absorbedTarget) === 'dm') {
           this.untrackDmPeer(m.absorbedTarget);
-          this.trackDmPeer(m.survivorTarget);
+          if (m.survivorOpen) this.trackDmPeer(m.survivorTarget);
         }
       }
+      // The folds themselves moved; any membership index built on the old
+      // rule is stale.
+      this.joinedFoldedCache = null;
     } catch (e) {
       console.warn('[casemapping] capture/refold failed:', (e as Error)?.message || e);
     }
@@ -3080,7 +3127,10 @@ export class IrcConnection {
       this.untrackDmPeer(oldNick);
       this.trackDmPeer(newNick);
     }
-    this.announceBufferRenamed(result);
+    // A closed DM renames silently: clients hold no state for closed buffers,
+    // so there is nothing to rekey — and a MERGED frame for one would make
+    // them materialize a sidebar row for a conversation closed everywhere.
+    if (result.open) this.announceBufferRenamed(result);
     // The DM's own "x is now known as y" line — same row shape the channel
     // loop above persists, no new renderer work anywhere.
     this.publish({
@@ -3289,6 +3339,7 @@ export class IrcConnection {
   private evictChannel(name: string, { forget = false }: { forget?: boolean } = {}): void {
     const canonical = canonicalChannelTarget(name, this.channels) ?? name;
     this.channels.delete(name.toLowerCase());
+    this.joinedFoldedCache = null;
     try {
       if (forget && !hasMessageForTarget(this.network.id, canonical)) {
         deleteBuffer(this.network.user_id, this.network.id, canonical);
@@ -3313,15 +3364,20 @@ export class IrcConnection {
    *  `#Ärger` must NOT read joined via its distinct case-twin `#ärger`).
    *  Folding BOTH sides with the network's rule is the one comparison that's
    *  right everywhere; on an undeclared network it reduces to exactly the
-   *  old map probe. O(channels) per call, with the mapping cached — cheap at
-   *  IRC scale, and the single definition every consumer must use instead of
-   *  the idiomatic-looking raw probe. */
+   *  old map probe. One fold + one Set probe per call — the folded index is
+   *  rebuilt lazily after any channels-map mutation or a mapping change,
+   *  because this backs per-buffer loops (snapshot shells, mark-all-read)
+   *  where a per-call scan would be O(buffers × channels) on the same
+   *  event-loop-sensitive path the snapshot-starvation fixes targeted. It is
+   *  the single definition every consumer must use instead of the
+   *  idiomatic-looking raw probe. */
   isChannelJoined(name: string): boolean {
-    const folded = foldTargetFor(this.network.id, name);
-    for (const ch of this.channels.values()) {
-      if (foldTargetFor(this.network.id, ch.name) === folded) return true;
+    if (!this.joinedFoldedCache) {
+      const set = new Set<string>();
+      for (const ch of this.channels.values()) set.add(foldTargetFor(this.network.id, ch.name));
+      this.joinedFoldedCache = set;
     }
-    return false;
+    return this.joinedFoldedCache.has(foldTargetFor(this.network.id, name));
   }
 
   upsertChannel(name: string): ChannelState {
@@ -3330,6 +3386,7 @@ export class IrcConnection {
     if (!ch) {
       ch = { name, topic: null, members: new Map(), modes: new Set() };
       this.channels.set(key, ch);
+      this.joinedFoldedCache = null;
     }
     if (!ch.modes) ch.modes = new Set();
     return ch;
@@ -4133,7 +4190,7 @@ export class IrcConnection {
   // the prompt appears where the user is actually typing) when we're in that
   // channel, else the server buffer. Ephemeral: status, not history.
   surfaceE2eNotice(notice: UserNotice, channel?: string): void {
-    const inChannel = !!channel && this.channels.has(channel.toLowerCase());
+    const inChannel = !!channel && this.isChannelJoined(channel);
     this.publishEphemeral({
       type: 'e2e',
       level: notice.level,

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -17,6 +17,8 @@ import {
   deleteBuffer,
   listOpenDms,
   networkCasemapping,
+  foldTargetFor,
+  kindForTarget,
 } from '../db/buffers.js';
 import { listTargetsForNetwork as listFriendTargetsForNetwork } from '../db/contacts.js';
 import * as chanlistDb from '../db/chanlist.js';
@@ -2966,6 +2968,21 @@ export class IrcConnection {
           mergedFromBufferId: m.absorbedId,
           draftChanged: m.draftChanged,
         });
+        // A merged DM must hand over its presence watch: the hydration seed
+        // ran at 001 (before this 005) against pre-refold rows, so the
+        // absorbed spelling holds a MONITOR slot for a registry row that no
+        // longer exists — stranded until reconnect, consuming the shared cap.
+        // The surviving spelling may never have been seeded at all (a closed
+        // survivor absorbed an open twin). Both trackers refcount, so this is
+        // safe when the survivor was already watched. Per-target maps
+        // (unsendableTargets & co.) are left alone deliberately: they key by
+        // wire name, sends go out under the surviving buffer's name from here
+        // on, and the dead spelling's entries are inert residue until the
+        // socket closes.
+        if (kindForTarget(m.absorbedTarget) === 'dm') {
+          this.untrackDmPeer(m.absorbedTarget);
+          this.trackDmPeer(m.survivorTarget);
+        }
       }
     } catch (e) {
       console.warn('[casemapping] capture/refold failed:', (e as Error)?.message || e);
@@ -3285,6 +3302,26 @@ export class IrcConnection {
       /* ignore */
     }
     this.publish({ type: 'channel-parted', target: canonical });
+  }
+
+  /** Fold-aware live membership (#707): is `name` one of this connection's
+   *  joined channels under the network's declared CASEMAPPING? The channels
+   *  map is keyed by the legacy-lowercased WIRE name, so a raw
+   *  `.has(x.toLowerCase())` probe has two failure modes on a declared
+   *  network — it misses a fold-variant spelling (`#foo{bar}` asked, joined
+   *  as `#foo[bar]`), and it over-folds Unicode (on an ascii network
+   *  `#Ärger` must NOT read joined via its distinct case-twin `#ärger`).
+   *  Folding BOTH sides with the network's rule is the one comparison that's
+   *  right everywhere; on an undeclared network it reduces to exactly the
+   *  old map probe. O(channels) per call, with the mapping cached — cheap at
+   *  IRC scale, and the single definition every consumer must use instead of
+   *  the idiomatic-looking raw probe. */
+  isChannelJoined(name: string): boolean {
+    const folded = foldTargetFor(this.network.id, name);
+    for (const ch of this.channels.values()) {
+      if (foldTargetFor(this.network.id, ch.name) === folded) return true;
+    }
+    return false;
   }
 
   upsertChannel(name: string): ChannelState {

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -8,7 +8,6 @@ import { renameBuffer as renameDmBuffer } from '../db/renameBuffer.js';
 import { refoldNetworkBuffers } from '../db/refoldBuffers.js';
 import { normalizeCasemapping } from '../db/casemapping.js';
 import type { Network } from '../db/networks.js';
-import { setNetworkCasemapping } from '../db/networks.js';
 import {
   isClosed as isBufferClosed,
   getBuffer,
@@ -518,9 +517,6 @@ export class IrcConnection {
   useMonitor: boolean;
   monitorLimit: number;
   pendingMonitorSeed: boolean;
-  /** Per-socket latch: CASEMAPPING has been captured off this connection's
-   *  005 burst, so later 'server options' firings skip the DB read. */
-  capturedCasemapping: boolean;
   disposed: boolean;
   connectCommandTimer: ReturnType<typeof setTimeout> | null;
   lagMs: number | null;
@@ -684,7 +680,6 @@ export class IrcConnection {
     this.useMonitor = false;
     this.monitorLimit = 0;
     this.pendingMonitorSeed = false;
-    this.capturedCasemapping = false;
     this.disposed = false;
     // Pending timer for the next WAIT-delayed connect command. Cleared on
     // close/dispose so we never call client.raw() after the socket is gone.
@@ -963,6 +958,21 @@ export class IrcConnection {
       // so a stray mid-session numeric can't graft onto a stale burst. The
       // raw line keeps its trailing CR; strip it so replay consumers get a
       // clean single-line payload.
+      // CASEMAPPING capture (#707) reads the RAW 005 tokens, NOT
+      // client.network.options: irc-framework pre-seeds options.CASEMAPPING
+      // to 'rfc1459' in its NetworkInfo constructor, so through the options
+      // bag "the server declared rfc1459" and "the server declared nothing"
+      // are indistinguishable — and storing the framework default would
+      // trigger a destructive registry merge on servers that declared
+      // something else on a later 005 line, or nothing at all. A token seen
+      // here is a declaration by construction.
+      if (rawCommand === '005') {
+        for (const param of msg?.params ?? []) {
+          if (typeof param === 'string' && param.startsWith('CASEMAPPING=')) {
+            this.adoptDeclaredCasemapping(param.slice('CASEMAPPING='.length));
+          }
+        }
+      }
       const burstLine = event.line.replace(/[\r\n]+$/, '');
       if (rawCommand === '001') this.registrationLines = [burstLine];
       else if (
@@ -1222,9 +1232,6 @@ export class IrcConnection {
       this.useMonitor = false;
       this.monitorLimit = 0;
       this.pendingMonitorSeed = false;
-      // The next socket's 005 re-captures CASEMAPPING (cheap: it early-outs
-      // when the declared value matches what's stored).
-      this.capturedCasemapping = false;
       // Safety-net presence sweep. The primary one runs in 'socket close',
       // which fires on every disconnect (including auto-reconnect blips), so it
       // has almost always swept already by the time this terminal 'close'
@@ -1297,9 +1304,6 @@ export class IrcConnection {
       // (harmless — they're just booleans, and trackDmPeer's per-add path
       // also checks useMonitor before sending).
       const opts = this.client.network?.options || {};
-      // CASEMAPPING rides the same 005 bursts (#707); capture before the
-      // MONITOR gate below can return early.
-      this.captureCasemapping(opts);
       const limit = Number(opts.MONITOR) || 0;
       if (limit === 0 || this.useMonitor) return;
       this.useMonitor = true;
@@ -2923,29 +2927,29 @@ export class IrcConnection {
     }
   }
 
-  // ISUPPORT CASEMAPPING capture (#707). The declared fold is a property of
-  // the network ROW, not the socket: stored once, compared on every connect,
-  // and only a CHANGE does real work — most connects are one PK read and out.
-  // Absent/unknown values store nothing: the network keeps the legacy fold
-  // rather than adopting a rule we can't implement.
+  // A CASEMAPPING token seen on a raw 005 line (#707) — a declaration by
+  // construction, never irc-framework's default (see the 'raw' handler). The
+  // declared fold is a property of the network ROW, not the socket: stored
+  // once, compared per token, and only a CHANGE does real work — a reconnect
+  // that re-declares the stored value is one cached compare and out. No
+  // latch, deliberately: the stored===declared compare is already idempotent,
+  // and a latch would freeze the first token of a burst against a correction
+  // on a later line. Unknown values store nothing: the network keeps the
+  // legacy fold rather than adopting a rule we can't implement.
   //
-  // On a change, db/refoldBuffers rewrites drifted folds silently and merges
-  // rows that now fold together (`#foo[bar]`/`#foo{bar}` under rfc1459), each
-  // merge announced with the same buffer-renamed frame a DM nick-collision
-  // rides — nothing new for clients to handle. In-memory per-target maps
+  // On a change, db/refoldBuffers stores the mapping and rewrites the
+  // registry in ONE transaction (a failed refold leaves the mapping unstored,
+  // so the next 005 retries) — drifted folds rewrite silently, rows that now
+  // fold together (`#foo[bar]`/`#foo{bar}` under rfc1459) merge, each merge
+  // announced like a DM nick-collision. In-memory per-target maps
   // (unsendableTargets & co.) are keyed by the wire name, which a re-fold
   // doesn't change, so they're left alone.
-  private captureCasemapping(opts: Record<string, unknown>): void {
-    if (this.capturedCasemapping) return;
-    const declared = normalizeCasemapping(opts.CASEMAPPING);
-    // Not in this 005 line (they arrive in bursts), or a value we don't
-    // implement — keep listening either way; the latch only sets on capture.
+  private adoptDeclaredCasemapping(rawValue: string): void {
+    const declared = normalizeCasemapping(rawValue);
     if (!declared) return;
-    this.capturedCasemapping = true;
     try {
       const stored = networkCasemapping(this.network.id);
       if (stored === declared) return;
-      setNetworkCasemapping(this.network.id, declared);
       const merges = refoldNetworkBuffers(this.network.user_id, this.network.id, declared);
       this.logNet(
         `CASEMAPPING ${declared}${stored ? ` (was ${stored})` : ''}` +
@@ -2954,9 +2958,7 @@ export class IrcConnection {
             : ''),
       );
       for (const m of merges) {
-        this.publishEphemeral({
-          type: 'buffer-renamed',
-          target: m.survivorTarget,
+        this.announceBufferRenamed({
           from: m.absorbedTarget,
           to: m.survivorTarget,
           bufferId: m.survivorId,
@@ -2968,6 +2970,32 @@ export class IrcConnection {
     } catch (e) {
       console.warn('[casemapping] capture/refold failed:', (e as Error)?.message || e);
     }
+  }
+
+  /** The one builder for the buffer-renamed announcement, shared by the DM
+   *  nick-follow and the casemapping refold so the frame shape cannot drift
+   *  between its two producers. `to` is ALWAYS the surviving buffer's final
+   *  name and `mergedFromBufferId` the absorbed row — clients identify the
+   *  absorbed side by that id, never by which of from/to it sat under
+   *  (docs §9.7: the two producers orient from/to differently). */
+  private announceBufferRenamed(r: {
+    from: string;
+    to: string;
+    bufferId: number;
+    merged: boolean;
+    mergedFromBufferId?: number;
+    draftChanged: boolean;
+  }): void {
+    this.publishEphemeral({
+      type: 'buffer-renamed',
+      target: r.to,
+      from: r.from,
+      to: r.to,
+      bufferId: r.bufferId,
+      merged: r.merged,
+      ...(r.mergedFromBufferId != null ? { mergedFromBufferId: r.mergedFromBufferId } : {}),
+      draftChanged: r.draftChanged,
+    });
   }
 
   // ---- presence watch list (shared MONITOR + peer_presence_state rails) ----
@@ -3035,18 +3063,7 @@ export class IrcConnection {
       this.untrackDmPeer(oldNick);
       this.trackDmPeer(newNick);
     }
-    this.publishEphemeral({
-      type: 'buffer-renamed',
-      target: result.to,
-      from: result.from,
-      to: result.to,
-      bufferId: result.bufferId,
-      merged: result.merged,
-      ...(result.mergedFromBufferId != null
-        ? { mergedFromBufferId: result.mergedFromBufferId }
-        : {}),
-      draftChanged: result.draftChanged,
-    });
+    this.announceBufferRenamed(result);
     // The DM's own "x is now known as y" line — same row shape the channel
     // loop above persists, no new renderer work anywhere.
     this.publish({

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -5,7 +5,10 @@ import IRC, { ircLineParser } from 'irc-framework';
 import type { Client as IrcClient } from 'irc-framework';
 import { insertMessage, hasMessageForTarget, hasConversationForTarget } from '../db/messages.js';
 import { renameBuffer as renameDmBuffer } from '../db/renameBuffer.js';
+import { refoldNetworkBuffers } from '../db/refoldBuffers.js';
+import { normalizeCasemapping } from '../db/casemapping.js';
 import type { Network } from '../db/networks.js';
+import { setNetworkCasemapping } from '../db/networks.js';
 import {
   isClosed as isBufferClosed,
   getBuffer,
@@ -14,6 +17,7 @@ import {
   setChannelKey as setBufferChannelKey,
   deleteBuffer,
   listOpenDms,
+  networkCasemapping,
 } from '../db/buffers.js';
 import { listTargetsForNetwork as listFriendTargetsForNetwork } from '../db/contacts.js';
 import * as chanlistDb from '../db/chanlist.js';
@@ -514,6 +518,9 @@ export class IrcConnection {
   useMonitor: boolean;
   monitorLimit: number;
   pendingMonitorSeed: boolean;
+  /** Per-socket latch: CASEMAPPING has been captured off this connection's
+   *  005 burst, so later 'server options' firings skip the DB read. */
+  capturedCasemapping: boolean;
   disposed: boolean;
   connectCommandTimer: ReturnType<typeof setTimeout> | null;
   lagMs: number | null;
@@ -677,6 +684,7 @@ export class IrcConnection {
     this.useMonitor = false;
     this.monitorLimit = 0;
     this.pendingMonitorSeed = false;
+    this.capturedCasemapping = false;
     this.disposed = false;
     // Pending timer for the next WAIT-delayed connect command. Cleared on
     // close/dispose so we never call client.raw() after the socket is gone.
@@ -1214,6 +1222,9 @@ export class IrcConnection {
       this.useMonitor = false;
       this.monitorLimit = 0;
       this.pendingMonitorSeed = false;
+      // The next socket's 005 re-captures CASEMAPPING (cheap: it early-outs
+      // when the declared value matches what's stored).
+      this.capturedCasemapping = false;
       // Safety-net presence sweep. The primary one runs in 'socket close',
       // which fires on every disconnect (including auto-reconnect blips), so it
       // has almost always swept already by the time this terminal 'close'
@@ -1286,6 +1297,9 @@ export class IrcConnection {
       // (harmless — they're just booleans, and trackDmPeer's per-add path
       // also checks useMonitor before sending).
       const opts = this.client.network?.options || {};
+      // CASEMAPPING rides the same 005 bursts (#707); capture before the
+      // MONITOR gate below can return early.
+      this.captureCasemapping(opts);
       const limit = Number(opts.MONITOR) || 0;
       if (limit === 0 || this.useMonitor) return;
       this.useMonitor = true;
@@ -2906,6 +2920,53 @@ export class IrcConnection {
       this.client.raw('MONITOR S');
     } catch (_) {
       /* ignore */
+    }
+  }
+
+  // ISUPPORT CASEMAPPING capture (#707). The declared fold is a property of
+  // the network ROW, not the socket: stored once, compared on every connect,
+  // and only a CHANGE does real work — most connects are one PK read and out.
+  // Absent/unknown values store nothing: the network keeps the legacy fold
+  // rather than adopting a rule we can't implement.
+  //
+  // On a change, db/refoldBuffers rewrites drifted folds silently and merges
+  // rows that now fold together (`#foo[bar]`/`#foo{bar}` under rfc1459), each
+  // merge announced with the same buffer-renamed frame a DM nick-collision
+  // rides — nothing new for clients to handle. In-memory per-target maps
+  // (unsendableTargets & co.) are keyed by the wire name, which a re-fold
+  // doesn't change, so they're left alone.
+  private captureCasemapping(opts: Record<string, unknown>): void {
+    if (this.capturedCasemapping) return;
+    const declared = normalizeCasemapping(opts.CASEMAPPING);
+    // Not in this 005 line (they arrive in bursts), or a value we don't
+    // implement — keep listening either way; the latch only sets on capture.
+    if (!declared) return;
+    this.capturedCasemapping = true;
+    try {
+      const stored = networkCasemapping(this.network.id);
+      if (stored === declared) return;
+      setNetworkCasemapping(this.network.id, declared);
+      const merges = refoldNetworkBuffers(this.network.user_id, this.network.id, declared);
+      this.logNet(
+        `CASEMAPPING ${declared}${stored ? ` (was ${stored})` : ''}` +
+          (merges.length
+            ? `; merged ${merges.length} case-colliding buffer${merges.length === 1 ? '' : 's'}`
+            : ''),
+      );
+      for (const m of merges) {
+        this.publishEphemeral({
+          type: 'buffer-renamed',
+          target: m.survivorTarget,
+          from: m.absorbedTarget,
+          to: m.survivorTarget,
+          bufferId: m.survivorId,
+          merged: true,
+          mergedFromBufferId: m.absorbedId,
+          draftChanged: m.draftChanged,
+        });
+      }
+    } catch (e) {
+      console.warn('[casemapping] capture/refold failed:', (e as Error)?.message || e);
     }
   }
 

--- a/server/services/ircE2eWiring.test.ts
+++ b/server/services/ircE2eWiring.test.ts
@@ -54,6 +54,7 @@ function makeConn(): IrcConnection {
       sasl_password: null,
       connect_commands: null,
       position: 0,
+      casemapping: null,
       created_at: new Date().toISOString(),
     },
     onEvent: () => {},

--- a/server/services/ircEchoMessage.test.ts
+++ b/server/services/ircEchoMessage.test.ts
@@ -56,6 +56,7 @@ function makeConn(onEvent: (event: unknown) => void = () => {}): IrcConnection {
       sasl_password: null,
       connect_commands: null,
       position: 0,
+      casemapping: null,
       created_at: new Date().toISOString(),
     },
     onEvent,

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -391,7 +391,11 @@ class IrcManager extends EventEmitter {
     // write the row (and any key) directly — and do NOT stash the key, since
     // no echo will ever consume it and an orphaned stash would be misapplied
     // by some later join's echo.
-    if (conn.channels.has(name.toLowerCase())) {
+    // Fold-aware (#707): '/join #ops{1}' while joined as '#ops[1]' on an
+    // rfc1459 network IS the already-in case — a raw map probe would miss it,
+    // stash a key no echo will consume, and hand the orphaned stash to the
+    // next join's echo (the exact hazard above).
+    if (conn.isChannelJoined(name)) {
       ensureOpenBuffer(userId, networkId, name, {
         kind: 'channel',
         autojoin: true,

--- a/server/services/noticeRouting.test.ts
+++ b/server/services/noticeRouting.test.ts
@@ -63,6 +63,7 @@ function makeConn(): IrcConnection {
       sasl_password: null,
       connect_commands: null,
       position: 0,
+      casemapping: null,
       created_at: new Date().toISOString(),
     },
     onEvent: () => {},

--- a/server/services/wsHub.test.ts
+++ b/server/services/wsHub.test.ts
@@ -538,9 +538,9 @@ describe('handleOpenBuffer', () => {
     // spends its one hydrate request on something that can never be answered and sits on
     // a loading spinner for the rest of the connection.
     buffers.ensureExists(userId, networkId, '#emptyjoined');
-    const spy = vi
-      .spyOn(ircManager, 'getConnection')
-      .mockReturnValue({ channels: new Map([['#emptyjoined', {}]]) } as never);
+    const spy = vi.spyOn(ircManager, 'getConnection').mockReturnValue({
+      isChannelJoined: (n: string) => n.toLowerCase() === '#emptyjoined',
+    } as never);
     try {
       const { ws, frames } = mockWs();
       handleOpenBuffer(ws, userId, networkId, '#emptyjoined');
@@ -564,7 +564,7 @@ describe('handleOpenBuffer', () => {
     buffers.ensureExists(userId, networkId, '&unjoined');
     const spy = vi
       .spyOn(ircManager, 'getConnection')
-      .mockReturnValue({ channels: new Map() } as never);
+      .mockReturnValue({ isChannelJoined: () => false } as never);
     try {
       const { ws, frames } = mockWs();
       handleOpenBuffer(ws, userId, networkId, '&unjoined');
@@ -578,7 +578,7 @@ describe('handleOpenBuffer', () => {
     buffers.ensureExists(userId, networkId, '&joined');
     const spy = vi
       .spyOn(ircManager, 'getConnection')
-      .mockReturnValue({ channels: new Map([['&joined', {}]]) } as never);
+      .mockReturnValue({ isChannelJoined: (n: string) => n.toLowerCase() === '&joined' } as never);
     try {
       const { ws, frames } = mockWs();
       handleOpenBuffer(ws, userId, networkId, '&joined');
@@ -1044,15 +1044,21 @@ describe('computeTotalHighlights', () => {
 // precedence on a live network (finding #3), and per-buffer highlight parity
 // between the frames the client receives and the total the badge shows.
 describe('eachUserBufferTarget / badge-vs-snapshot parity (#454)', () => {
-  // A minimal live-connection stand-in: the enumerator only reads network.id and
-  // the lowercased-keyed channels map (has() for join-precedence, values().name to
-  // surface joined-but-history-less channels). Injected straight into the shared
-  // ircManager singleton — remember to clear it so sibling "offline" tests aren't
-  // poisoned by a lingering live connection.
+  // A minimal live-connection stand-in: the enumerator reads network.id, the
+  // lowercased-keyed channels map (values().name to surface joined-but-
+  // history-less channels), and the fold-aware isChannelJoined probe (#707)
+  // — stubbed here with the legacy fold, which is exact for these undeclared
+  // test networks. Injected straight into the shared ircManager singleton —
+  // remember to clear it so sibling "offline" tests aren't poisoned by a
+  // lingering live connection.
   type LiveConn = ReturnType<typeof ircManager.listConnections>[number];
   function stubLiveConn(netId: number, joinedChannels: string[]): LiveConn {
     const channels = new Map(joinedChannels.map((c) => [c.toLowerCase(), { name: c }]));
-    return { network: { id: netId }, channels } as unknown as LiveConn;
+    return {
+      network: { id: netId },
+      channels,
+      isChannelJoined: (name: string) => channels.has(name.toLowerCase()),
+    } as unknown as LiveConn;
   }
   function setLiveConn(uid: number, conn: LiveConn) {
     // connectionsForUser creates the inner map if absent — same seam the bouncer

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -74,7 +74,6 @@ import {
   listStatesForUser as listBufferStatesForUser,
   kindForTarget,
   foldTargetFor,
-  networkCasemapping,
 } from '../db/buffers.js';
 import { resolveBuffer, requireBufferForUser } from '../db/bufferResolve.js';
 import { getDraftForBuffer } from '../db/drafts.js';
@@ -731,32 +730,17 @@ export function computeTotalHighlights(userId: number): number {
 // dimmed). `conn` is optional — an offline network passes none, which folds a
 // #channel to parted. Centralized so the four snapshot/backlog sites can't drift
 // (channel-case folding already bit this codebase — see #289/#269).
-function channelJoined(
-  networkId: number,
-  target: string,
-  conn?: { channels: JoinedChannels } | null,
-): boolean {
-  if (!target.startsWith('#')) return true;
-  if (!conn) return false;
-  // Fast path: the channels map is keyed by the legacy-lowercased WIRE name,
-  // which matches whenever buffer name and joined name agree up to ASCII case
-  // — every lookup until a declared CASEMAPPING diverges from the legacy fold.
-  if (conn.channels.has(target.toLowerCase())) return true;
-  // Fold-aware path (#707): after a refold merge the registry name can be the
-  // bracket-variant that was never the JOINed spelling ('#foo{bar}' joined as
-  // '#foo[bar]'); on a declared network, compare per-network folds of the
-  // live wire names before calling the channel parted.
-  if (!networkCasemapping(networkId)) return false;
-  const folded = foldTargetFor(networkId, target);
-  for (const ch of conn.channels.values()) {
-    if (foldTargetFor(networkId, ch.name) === folded) return true;
-  }
-  return false;
+function channelJoined(target: string, conn?: JoinedProbe | null): boolean {
+  return target.startsWith('#') ? !!conn?.isChannelJoined(target) : true;
 }
 
-interface JoinedChannels {
-  has(name: string): boolean;
-  values(): Iterable<{ name: string }>;
+// The one membership surface (IrcConnection.isChannelJoined): fold-aware per
+// the network's declared CASEMAPPING, so a refold-merged registry spelling
+// still reads joined, and a Unicode case-twin on an ascii network doesn't.
+// Never probe conn.channels with `.has(x.toLowerCase())` here — the map is
+// keyed by legacy-lowercased wire names, which is the pre-#707 rule.
+interface JoinedProbe {
+  isChannelJoined(name: string): boolean;
 }
 
 // The per-buffer read/unread/cleared block shared by every backlog frame
@@ -846,7 +830,7 @@ export function buildBufferBacklog(
     // Non-empty buffers hid the bug — any event at all reads as hydrated.
     hasMoreOlder: oldestId > 0 && hasOlderRow(networkId, target, oldestId),
     speakers: listSpeakers(networkId, target),
-    joined: channelJoined(networkId, target, conn),
+    joined: channelJoined(target, conn),
     ...bufferStateFields(userId, networkId, target),
     inputHistory: listRecentInputHistory(userId, networkId, target, INPUT_HISTORY_SLICE),
   };
@@ -1196,7 +1180,7 @@ function buildOfflineFrame(
 ): WsPayload {
   return target.startsWith(':server:')
     ? buildBufferBacklog(userId, networkId, target)
-    : buildBufferShell(userId, networkId, target, channelJoined(networkId, target), { bufferId });
+    : buildBufferShell(userId, networkId, target, channelJoined(target), { bufferId });
 }
 
 // `targets` lets the snapshot hand in the enumeration it already materialized for
@@ -1261,19 +1245,21 @@ function verbBuffer(
 // per-network since #707, so 'john^' probes the 'john~' key an rfc1459
 // network stored (servers also hand us inconsistently-cased names, #289). A
 // currently-joined channel always beats a stale closed flag (defensive
-// against autorejoin/state races); the channel probe is fold-aware for the
-// same reason, but stays channels-only — a DM is never "joined", and letting
-// channelJoined's trivially-true non-channel arm in here would exempt every
-// closed DM from hiding.
+// against autorejoin/state races). The joined probe is the RAW membership
+// scan, not `channelJoined`: that helper answers true for anything that
+// isn't '#'-prefixed — right for the display field it feeds (a DM is always
+// "joined"), but here it would exempt every closed DM from hiding, and its
+// '#'-only test would strip the joined-beats-closed defense from '&'/'+'/'!'
+// channels, which the membership map covers regardless of prefix.
 function isHiddenClosedBuffer(
   closed: Set<string>,
-  conn: { channels: JoinedChannels } | null | undefined,
+  conn: JoinedProbe | null | undefined,
   networkId: number,
   target: string,
 ): boolean {
   return (
     closed.has(`${networkId}::${foldTargetFor(networkId, target)}`) &&
-    !(target.startsWith('#') && channelJoined(networkId, target, conn))
+    !conn?.isChannelJoined(target)
   );
 }
 
@@ -1320,10 +1306,12 @@ export function handleOpenBuffer(
   // which is right for the display field it feeds (a DM is always "joined") but wrong
   // as a branch condition: `kindForTarget` counts '&', '+' and '!' as channels too, so
   // routing through it would report an unjoined `&local` as joined and hand back a
-  // backlog for a channel we aren't in.
+  // backlog for a channel we aren't in. Fold-aware (#707): a refold-merged
+  // buffer's registry spelling can differ from the joined wire spelling, and
+  // a raw map probe would send a channel we're sitting in down the join
+  // branch — the no-echo spinner this comment exists to prevent.
   const conn = ircManager.getConnection(userId, networkId);
-  const inChannel =
-    kindForTarget(requested) === 'channel' && !!conn?.channels.has(requested.toLowerCase());
+  const inChannel = kindForTarget(requested) === 'channel' && !!conn?.isChannelJoined(requested);
   if (row && (hasMessageForTarget(networkId, row.target) || inChannel)) {
     reopenBufferRow(userId, networkId, row.target);
     send(ws, buildBufferBacklog(userId, networkId, row.target, countBy));
@@ -1373,21 +1361,15 @@ function announceOpen(
   userId: number,
   networkId: number,
   target: string,
-  conn: { channels: JoinedChannels } | null | undefined,
+  conn: JoinedProbe | null | undefined,
   bufferId: number | null = null,
 ): void {
   // Pass the live connection: `channelJoined` folds a #channel to parted without
   // one, which would land the other devices' rows dimmed for a channel we're
   // sitting in, until some later frame corrected them.
-  const shell = buildBufferShell(
-    userId,
-    networkId,
-    target,
-    channelJoined(networkId, target, conn),
-    {
-      bufferId,
-    },
-  );
+  const shell = buildBufferShell(userId, networkId, target, channelJoined(target, conn), {
+    bufferId,
+  });
   fanOut(userId, shell, { exceptWs: requester });
   fanOut(userId, { kind: 'buffer-opened', networkId, target, bufferId }, { exceptWs: requester });
 }
@@ -2446,7 +2428,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           userId,
           conn.network.id,
           target,
-          channelJoined(conn.network.id, target, conn),
+          channelJoined(target, conn),
           precomputed,
         );
         unreadMs += Date.now() - tShell;
@@ -2497,7 +2479,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // from `reset` + `networkId` + whether it sent ?since.
         mode: slice.mode,
         hasMoreOlder: slice.hasMoreOlder,
-        joined: channelJoined(conn.network.id, target, conn),
+        joined: channelJoined(target, conn),
         ...stateFields,
         inputHistory,
       });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -73,6 +73,8 @@ import {
   setAutojoin as setBufferAutojoin,
   listStatesForUser as listBufferStatesForUser,
   kindForTarget,
+  foldTargetFor,
+  networkCasemapping,
 } from '../db/buffers.js';
 import { resolveBuffer, requireBufferForUser } from '../db/bufferResolve.js';
 import { getDraftForBuffer } from '../db/drafts.js';
@@ -674,15 +676,23 @@ export function* eachUserBufferTarget(userId: number): Generator<UserBufferTarge
       bufferId: serverBufferIdByNetwork.get(net.id) ?? null,
       conn,
     };
+    // One folded view of the live channel set per network: both probes below
+    // compare against registry folds (per-network since #707), and the
+    // channels map's own keys are legacy-lowercased wire names, which diverge
+    // from those folds on a declared network ('#a[b]' joined vs '#a{b}'
+    // stored). Probing the map raw double-yielded the bracket variants.
+    const joinedFolded = conn
+      ? new Set(Array.from(conn.channels.values(), (ch) => foldTargetFor(net.id, ch.name)))
+      : undefined;
     const seen = new Set<string>();
     for (const row of rowsByNetwork.get(net.id) ?? []) {
       seen.add(row.targetFolded);
-      if (row.state === 'closed' && !conn?.channels.has(row.targetFolded)) continue;
+      if (row.state === 'closed' && !joinedFolded?.has(row.targetFolded)) continue;
       yield { networkId: net.id, target: row.target, bufferId: row.id, conn };
     }
     if (conn) {
       for (const ch of conn.channels.values()) {
-        if (!seen.has(ch.name.toLowerCase())) {
+        if (!seen.has(foldTargetFor(net.id, ch.name))) {
           // Defensive: a live-joined channel whose row was forgotten
           // mid-session — genuinely no id to carry.
           yield { networkId: net.id, target: ch.name, bufferId: null, conn };
@@ -722,10 +732,31 @@ export function computeTotalHighlights(userId: number): number {
 // #channel to parted. Centralized so the four snapshot/backlog sites can't drift
 // (channel-case folding already bit this codebase — see #289/#269).
 function channelJoined(
+  networkId: number,
   target: string,
-  conn?: { channels: { has(name: string): boolean } } | null,
+  conn?: { channels: JoinedChannels } | null,
 ): boolean {
-  return target.startsWith('#') ? !!conn?.channels.has(target.toLowerCase()) : true;
+  if (!target.startsWith('#')) return true;
+  if (!conn) return false;
+  // Fast path: the channels map is keyed by the legacy-lowercased WIRE name,
+  // which matches whenever buffer name and joined name agree up to ASCII case
+  // — every lookup until a declared CASEMAPPING diverges from the legacy fold.
+  if (conn.channels.has(target.toLowerCase())) return true;
+  // Fold-aware path (#707): after a refold merge the registry name can be the
+  // bracket-variant that was never the JOINed spelling ('#foo{bar}' joined as
+  // '#foo[bar]'); on a declared network, compare per-network folds of the
+  // live wire names before calling the channel parted.
+  if (!networkCasemapping(networkId)) return false;
+  const folded = foldTargetFor(networkId, target);
+  for (const ch of conn.channels.values()) {
+    if (foldTargetFor(networkId, ch.name) === folded) return true;
+  }
+  return false;
+}
+
+interface JoinedChannels {
+  has(name: string): boolean;
+  values(): Iterable<{ name: string }>;
 }
 
 // The per-buffer read/unread/cleared block shared by every backlog frame
@@ -815,7 +846,7 @@ export function buildBufferBacklog(
     // Non-empty buffers hid the bug — any event at all reads as hydrated.
     hasMoreOlder: oldestId > 0 && hasOlderRow(networkId, target, oldestId),
     speakers: listSpeakers(networkId, target),
-    joined: channelJoined(target, conn),
+    joined: channelJoined(networkId, target, conn),
     ...bufferStateFields(userId, networkId, target),
     inputHistory: listRecentInputHistory(userId, networkId, target, INPUT_HISTORY_SLICE),
   };
@@ -1165,7 +1196,7 @@ function buildOfflineFrame(
 ): WsPayload {
   return target.startsWith(':server:')
     ? buildBufferBacklog(userId, networkId, target)
-    : buildBufferShell(userId, networkId, target, channelJoined(target), { bufferId });
+    : buildBufferShell(userId, networkId, target, channelJoined(networkId, target), { bufferId });
 }
 
 // `targets` lets the snapshot hand in the enumeration it already materialized for
@@ -1226,17 +1257,24 @@ function verbBuffer(
 // A buffer the user closed and isn't currently joined to is hidden from the
 // sidebar; broadcasting a read-state frame for it would resurrect it (#319).
 // The closed set is folded `${networkId}::${folded}` keys built from the
-// buffers registry (closedBufferKeySet); fold the target here too — servers
-// hand us inconsistently-cased names (#289). A currently-joined channel always
-// beats a stale closed flag (defensive against autorejoin/state races).
+// buffers registry (closedBufferKeySet); fold the target the same way —
+// per-network since #707, so 'john^' probes the 'john~' key an rfc1459
+// network stored (servers also hand us inconsistently-cased names, #289). A
+// currently-joined channel always beats a stale closed flag (defensive
+// against autorejoin/state races); the channel probe is fold-aware for the
+// same reason, but stays channels-only — a DM is never "joined", and letting
+// channelJoined's trivially-true non-channel arm in here would exempt every
+// closed DM from hiding.
 function isHiddenClosedBuffer(
   closed: Set<string>,
-  joined: { has(name: string): boolean },
+  conn: { channels: JoinedChannels } | null | undefined,
   networkId: number,
   target: string,
 ): boolean {
-  const lower = target.toLowerCase();
-  return closed.has(`${networkId}::${lower}`) && !joined.has(lower);
+  return (
+    closed.has(`${networkId}::${foldTargetFor(networkId, target)}`) &&
+    !(target.startsWith('#') && channelJoined(networkId, target, conn))
+  );
 }
 
 // The folded closed-buffer key set for isHiddenClosedBuffer, from the registry.
@@ -1335,15 +1373,21 @@ function announceOpen(
   userId: number,
   networkId: number,
   target: string,
-  conn: { channels: { has(name: string): boolean } } | null | undefined,
+  conn: { channels: JoinedChannels } | null | undefined,
   bufferId: number | null = null,
 ): void {
   // Pass the live connection: `channelJoined` folds a #channel to parted without
   // one, which would land the other devices' rows dimmed for a channel we're
   // sitting in, until some later frame corrected them.
-  const shell = buildBufferShell(userId, networkId, target, channelJoined(target, conn), {
-    bufferId,
-  });
+  const shell = buildBufferShell(
+    userId,
+    networkId,
+    target,
+    channelJoined(networkId, target, conn),
+    {
+      bufferId,
+    },
+  );
   fanOut(userId, shell, { exceptWs: requester });
   fanOut(userId, { kind: 'buffer-opened', networkId, target, bufferId }, { exceptWs: requester });
 }
@@ -2402,7 +2446,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           userId,
           conn.network.id,
           target,
-          channelJoined(target, conn),
+          channelJoined(conn.network.id, target, conn),
           precomputed,
         );
         unreadMs += Date.now() - tShell;
@@ -2453,7 +2497,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // from `reset` + `networkId` + whether it sent ?since.
         mode: slice.mode,
         hasMoreOlder: slice.hasMoreOlder,
-        joined: channelJoined(target, conn),
+        joined: channelJoined(conn.network.id, target, conn),
         ...stateFields,
         inputHistory,
       });
@@ -3007,7 +3051,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
             const before = getReadState(userId, networkId, target);
             if (before >= maxId) continue;
             const after = setReadState(userId, networkId, target, maxId);
-            if (isHiddenClosedBuffer(closed, conn.channels, networkId, target)) continue;
+            if (isHiddenClosedBuffer(closed, conn, networkId, target)) continue;
             broadcastReadState(userId, networkId, target, after);
           }
         }

--- a/vue_client/src/lib/bufferLifecycle.test.ts
+++ b/vue_client/src/lib/bufferLifecycle.test.ts
@@ -210,4 +210,51 @@ describe('applyBufferRenamed — the full frame contract', () => {
     expect(useDraftStore().drafts[`${NET}::${ABSORBED}`]).toBe('half-typed');
     expect(usePinsStore().byNetwork[NET]).toEqual([ABSORBED]);
   });
+
+  it('refold orientation: the absorbed row is identified by id, never by `to`', () => {
+    // The frame's OTHER producer (#707 casemapping refold) absorbs the FROM
+    // row — the survivor already sits at `to` under its own name, no actual
+    // rename. Reading orientation here ("drop `to`") swept the survivor — the
+    // open channel the user was reading — out of every store.
+    useBuffersStore().ensure(NET, '#foo{bar}', 42); // survivor
+    useBuffersStore().ensure(NET, '#foo[bar]', 99); // absorbed bracket-twin
+    useDraftStore().drafts[`${NET}::#foo[bar]`] = 'stale';
+
+    applyBufferRenamed({
+      networkId: NET,
+      from: '#foo[bar]',
+      to: '#foo{bar}',
+      bufferId: 42,
+      merged: true,
+      mergedFromBufferId: 99,
+    });
+
+    const survivor = useBuffersStore().buffers[`${NET}::#foo{bar}`]!;
+    expect(survivor.id).toBe(42);
+    expect(survivor.unseeded).toBe(true); // history interleaved → refetch
+    expect(useBuffersStore().buffers[`${NET}::#foo[bar]`]).toBeUndefined();
+    expect(useDraftStore().drafts[`${NET}::#foo[bar]`]).toBeUndefined();
+    // The absorbed side was DROPPED, not renamed onto the survivor — its
+    // stale draft must not wear the survivor's key (the drop-`to`-then-rekey
+    // failure mode converges on ids but leaks exactly this).
+    expect(useDraftStore().drafts[`${NET}::#foo{bar}`]).toBeUndefined();
+  });
+
+  it('a refold merge with the absorbed id unknown still spares the proven survivor', () => {
+    // Fallback path: no local row carries mergedFromBufferId, so the DM
+    // orientation would say "drop `to`" — but the row at `to` records the
+    // SURVIVING id, which is proof it must stay.
+    useBuffersStore().ensure(NET, '#foo{bar}', 42);
+
+    applyBufferRenamed({
+      networkId: NET,
+      from: '#foo[bar]',
+      to: '#foo{bar}',
+      bufferId: 42,
+      merged: true,
+      mergedFromBufferId: 99,
+    });
+
+    expect(useBuffersStore().buffers[`${NET}::#foo{bar}`]?.id).toBe(42);
+  });
 });

--- a/vue_client/src/lib/bufferLifecycle.test.ts
+++ b/vue_client/src/lib/bufferLifecycle.test.ts
@@ -240,6 +240,33 @@ describe('applyBufferRenamed — the full frame contract', () => {
     expect(useDraftStore().drafts[`${NET}::#foo{bar}`]).toBeUndefined();
   });
 
+  it('a merge frame can never leave the survivor rowless — worst case it re-materializes', () => {
+    // The pathological corner: both twins held with NO learned ids, so neither
+    // the id lookup nor the survivor-proof can orient the sweep. Whatever the
+    // fallback decides, the frame proves a live buffer named `to` exists
+    // server-side — the handler must end with a row there, flagged for a
+    // fresh hydrate, never with the buffer vanished from the sidebar.
+    // Names and ids unused by any other test: the id→key index is
+    // module-level and outlives each test's pinia, so reused values would
+    // quietly route this through the id-known path instead of the corner.
+    useBuffersStore().ensure(NET, '#twin{a}');
+    useBuffersStore().ensure(NET, '#twin[a]');
+
+    applyBufferRenamed({
+      networkId: NET,
+      from: '#twin[a]',
+      to: '#twin{a}',
+      bufferId: 4200,
+      merged: true,
+      mergedFromBufferId: 9900,
+    });
+
+    const survivor = useBuffersStore().buffers[`${NET}::#twin{a}`];
+    expect(survivor).toBeTruthy();
+    expect(survivor?.id).toBe(4200);
+    expect(survivor?.unseeded).toBe(true);
+  });
+
   it('a refold merge with the absorbed id unknown still spares the proven survivor', () => {
     // Fallback path: no local row carries mergedFromBufferId, so the DM
     // orientation would say "drop `to`" — but the row at `to` records the

--- a/vue_client/src/lib/bufferLifecycle.ts
+++ b/vue_client/src/lib/bufferLifecycle.ts
@@ -18,7 +18,7 @@
 // only be instantiated once an active pinia exists — these run inside socket
 // handlers, long after app init.
 
-import { useBuffersStore } from '../stores/buffers.js';
+import { useBuffersStore, bufferKeyForId } from '../stores/buffers.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useNavHistoryStore } from '../stores/navHistory.js';
 import { useRecentBuffersStore } from '../stores/recentBuffers.js';
@@ -77,14 +77,14 @@ export function bufferRenamed(networkId: number | string | null, from: string, t
 
 /**
  * The full `buffer-renamed` frame contract (docs §9.7): the buffer keeps its
- * id and adopts the new name; on a merge the ABSORBED buffer (the one that
- * already held the new name — `mergedFromBufferId`) is dropped everywhere
- * first, so the rename lands with no collision and the destination-wins
- * fallbacks in the rekey hooks never fire on an announced merge. A merged
- * buffer's history interleaves two message streams server-side, so the local
- * slice is wiped and flagged for a fresh hydrate rather than guessed at —
- * the read-state / pins / draft corrections ride in right behind the frame.
- * Following the active buffer is free: networks.rekeyBuffer moves activeKey.
+ * id and adopts the new name; on a merge the ABSORBED buffer
+ * (`mergedFromBufferId`) is dropped everywhere first, so the rename lands
+ * with no collision and the destination-wins fallbacks in the rekey hooks
+ * never fire on an announced merge. A merged buffer's history interleaves two
+ * message streams server-side, so the local slice is wiped and flagged for a
+ * fresh hydrate rather than guessed at — the read-state / pins / draft
+ * corrections ride in right behind the frame. Following the active buffer is
+ * free: networks.rekeyBuffer moves activeKey.
  */
 export function applyBufferRenamed(payload: {
   networkId: number | string | null;
@@ -92,9 +92,33 @@ export function applyBufferRenamed(payload: {
   to: string;
   bufferId?: number | null;
   merged?: boolean;
+  mergedFromBufferId?: number | null;
 }): void {
-  const { networkId, from, to, bufferId, merged } = payload;
-  if (merged) bufferClosed(networkId, to);
+  const { networkId, from, to, bufferId, merged, mergedFromBufferId } = payload;
+  if (merged) {
+    // The absorbed row is identified by ID, never by which of from/to it sat
+    // under: the frame's two producers orient the pair differently. A DM
+    // nick-collision absorbs the row already holding `to`; a casemapping
+    // refold (#707) absorbs the `from` row while the survivor keeps its own
+    // name — so reading orientation here ("drop `to`") swept the SURVIVOR of
+    // a refold merge out of every store, vanishing the open channel the
+    // reader was sitting in.
+    const buffers = useBuffersStore();
+    const absorbedKey = mergedFromBufferId != null ? bufferKeyForId(mergedFromBufferId) : undefined;
+    const absorbed = absorbedKey ? buffers.byKey(absorbedKey) : null;
+    if (absorbed) {
+      bufferClosed(absorbed.networkId, absorbed.target);
+    } else {
+      // Absorbed id unknown locally (optimistically-created row merged before
+      // any id-carrying frame): fall back to the DM orientation — but never
+      // sweep a row that PROVES it is the survivor by recording the
+      // surviving id.
+      const atTo = buffers.findByTarget(networkId, to);
+      if (atTo && !(typeof bufferId === 'number' && atTo.id === bufferId)) {
+        bufferClosed(networkId, to);
+      }
+    }
+  }
   bufferRenamed(networkId, from, to);
   const buffers = useBuffersStore();
   const buf = buffers.findByTarget(networkId, to);

--- a/vue_client/src/lib/bufferLifecycle.ts
+++ b/vue_client/src/lib/bufferLifecycle.ts
@@ -121,7 +121,16 @@ export function applyBufferRenamed(payload: {
   }
   bufferRenamed(networkId, from, to);
   const buffers = useBuffersStore();
-  const buf = buffers.findByTarget(networkId, to);
+  let buf = buffers.findByTarget(networkId, to);
+  if (!buf && merged && typeof bufferId === 'number' && networkId != null) {
+    // Whatever the sweep above decided, a merged frame PROVES a live buffer
+    // named `to` exists server-side. If local state ended up rowless — both
+    // twins held id-less and the fallback swept the wrong one — materialize
+    // the survivor instead of bailing, so the buffer can never vanish from
+    // the sidebar; the wipe below routes it through the ordinary hydration
+    // fetch, and the read-state/pins/draft follow-ups correct the rest.
+    buf = buffers.ensure(networkId, to, bufferId);
+  }
   if (!buf) return;
   // Learn/confirm the id under the new key (also heals the case where the
   // rename raced ahead of the burst and we never knew the id).


### PR DESCRIPTION
The last concrete piece of the buffer-identity stack (#708–#716, lurker-ios#95). Closes #707.

## What changes

- **Capture** — the `'server options'` handler reads `CASEMAPPING` off the same 005 bursts the MONITOR gate uses and stores the normalized value on the `networks` row (`ensureColumn`, additive). Unknown values store nothing: the network keeps the legacy fold rather than adopting a rule we can't implement. A reconnect that re-declares the stored value is one PK read and out.
- **Fold** — `foldTargetFor` stops being the stub PR #711 left: `ascii` folds A–Z; `rfc1459` adds `[ \ ] ^` → `{ | } ~`; `rfc1459-strict` stops at `]`. Every write/lookup path in the buffer registry (`ensureOpen`, `getBuffer`, `close`, resolution, rename) folds per-network. `rfc7613` and *undeclared* networks keep the legacy Unicode `toLowerCase` — the rule every existing `target_folded` row was built with — so **nothing churns until a network actually declares**.
- **Re-fold** — on a mapping change, `db/refoldBuffers` rewrites the network's drifted folds in place (`#Ärger`'s stored fold stops being `#ärger` under an ascii-family rule) and **merges rows that now fold together** (`#foo[bar]` ≡ `#foo{bar}` on a stock rfc1459 network — the headline bug). Merges reuse the rename primitive's absorb machinery (extracted as `absorbBufferRow`, byte-for-byte the #716 merge policies) and each is announced with the ordinary `buffer-renamed` frame — clients already converge on it, nothing new to handle. Survivor choice mirrors `foldBufferCase`: open beats closed, then most recent message, then older id.

## The ^/~ direction

RFC 2812's prose says `{}|^` are the lowercase of `[]\~` (issue #707 quotes this). Every ircd tolower table — and irc-framework, whose upper-ASCII bound for rfc1459 is 94 (`^`) — does the opposite: `^` folds **down** to `~`. This PR matches the implementations, not the prose; `server/db/casemapping.ts` documents the discrepancy.

## Deliberately out of scope

- Client-side folding stays ASCII lowercase (docs §5.2 updated to say so): when the server learns a mapping that collapses names it announces the merges, which is all a client needs.
- The `COLLATE NOCASE` columns the issue lists (e2e ×5, `ignored_masks.mask`) are wire-context/glob tables — documented exceptions that never followed the registry fold.
- The bouncer side still advertises `CASEMAPPING=ascii` for its own listener.

## Verification

- Full suite: 3,629 pass. New: fold-rule units (direction pinned), refold DB tests (drift rewrite, bracket-variant merge with read-pointer/history assertions, survivor recency, no-fork-after-declare, undeclared-network no-churn, sentinel exclusion), capture-path tests through the real `'server options'` handler (store+merge+announce, unknown-value no-op, re-declare no-op).
- Mutation-verified: `foldTargetFor` ignoring the mapping fails 4 named tests; dropping open-beats-closed from the survivor sort fails the merge test.
- `networks.casemapping` is exported/imported so a restored archive doesn't churn on first reconnect (export-schema drift test caught the omission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)