### PR TITLE
Revive friend-online notifications, keyed on favorited DMs

### DIFF
--- a/server/db/favoriteBuffers.test.ts
+++ b/server/db/favoriteBuffers.test.ts
@@ -165,6 +165,26 @@ describe('cascade', () => {
   });
 });
 
+describe('isFavoriteDmPeer', () => {
+  it('true only for the fold-matched peer of a favorited DM buffer', () => {
+    const hana = createUser('fav-hana');
+    const netH = mkNet(hana.id, 'h');
+    ensureBuffer(hana.id, netH!.id, 'pal');
+    ensureBuffer(hana.id, netH!.id, '#chan');
+    ensureBuffer(hana.id, netH!.id, 'stranger');
+    favorites.favoriteBuffer(hana.id, netH!.id, 'pal');
+    favorites.favoriteBuffer(hana.id, netH!.id, '#chan');
+
+    expect(favorites.isFavoriteDmPeer(hana.id, netH!.id, 'pal')).toBe(true);
+    // Fold-aware: the server relays its own casing on presence events.
+    expect(favorites.isFavoriteDmPeer(hana.id, netH!.id, 'PAL')).toBe(true);
+    // A favorited CHANNEL is never a person, and a non-favorite DM never gates in.
+    expect(favorites.isFavoriteDmPeer(hana.id, netH!.id, '#chan')).toBe(false);
+    expect(favorites.isFavoriteDmPeer(hana.id, netH!.id, 'stranger')).toBe(false);
+    expect(favorites.isFavoriteDmPeer(hana.id, netH!.id, 'never-seen')).toBe(false);
+  });
+});
+
 describe('favoritesChangedFrame (wsHub)', () => {
   it('ships the full global entry list — the burst seed and every correction', async () => {
     const iris = createUser('fav-iris');

--- a/server/db/favoriteBuffers.ts
+++ b/server/db/favoriteBuffers.ts
@@ -64,6 +64,21 @@ export function listFavoritesForUser(userId: number): FavoriteEntry[] {
   return listForUserStmt.all(userId) as FavoriteEntry[];
 }
 
+const isFavoriteStmt = db.prepare(`
+  SELECT 1 FROM favorite_buffers WHERE user_id = ? AND buffer_id = ?
+`);
+
+/** Is this nick the peer of a favorited DM buffer? The friend-online
+ *  notification's gate — the successor to the contacts model's per-contact
+ *  notify flag, now simply "they're under FRIENDS". Fold-aware via
+ *  resolveBuffer; kind-checked so a favorited channel whose name happens to
+ *  arrive here can never read as a person. */
+export function isFavoriteDmPeer(userId: number, networkId: number, nick: string): boolean {
+  const buffer = resolveBuffer(userId, networkId, nick);
+  if (!buffer || buffer.kind !== 'dm') return false;
+  return isFavoriteStmt.get(userId, buffer.id) !== undefined;
+}
+
 // Renumber a user's favorites dense 0..n-1, preserving order. Exported (unlike
 // the pins twin) because a network delete cascades favorite rows away through
 // buffers and leaves holes mid-sequence; the route re-densifies before it

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2799,8 +2799,8 @@ export class IrcConnection {
       stateAt: row?.stateAt || null,
       awayMessage: row?.awayMessage || null,
       // True only on a real offline→online transition (see markPeerEvent).
-      // Reserved for the came-online push (returning with buffer favorites);
-      // currently unconsumed. The client ignores it.
+      // wsHub reads this to fire the favorited-DM came-online push; the
+      // client computes its own transition for the toast and ignores it.
       cameOnline,
     });
   }

--- a/server/services/notificationContent.test.ts
+++ b/server/services/notificationContent.test.ts
@@ -46,6 +46,33 @@ describe('composeNotification', () => {
     );
   });
 
+  it('titles a friend-online transition with the nick (displayName == target now)', () => {
+    // Under buffer favorites the display name IS the nick, so the vestigial
+    // "(as nick)" branch never fires on real payloads.
+    expect(
+      composeNotification(
+        payload({ kind: 'friend_online', target: 'nostimo', displayName: 'nostimo', text: null }),
+      ),
+    ).toMatchObject({
+      title: 'nostimo came online (Libera)',
+      // No text on a presence transition — the title carries it.
+      body: '',
+    });
+  });
+
+  it('keeps the legacy displayName branch byte-compatible (crafted/stale payloads)', () => {
+    // The composition must keep matching sw.js's cached copy even for shapes
+    // the server no longer emits — the parity suite below runs the real worker.
+    expect(
+      composeNotification(
+        payload({ kind: 'friend_online', target: 'nostimo', displayName: 'Amiantos' }),
+      ).title,
+    ).toBe('Amiantos came online (as nostimo · Libera)');
+    expect(
+      composeNotification(payload({ kind: 'friend_online', displayName: null, target: '' })).title,
+    ).toBe('A friend came online (Libera)');
+  });
+
   it('falls back when a nick is missing', () => {
     expect(composeNotification(payload({ nick: null })).title).toBe('someone (Libera)');
     // The same fallback on the channel branch, which is a separate expression.
@@ -111,6 +138,27 @@ describe('parity with the service worker fallback', () => {
     [
       'always_notify with no nick',
       payload({ kind: 'always_notify', target: '#lurker', nick: null }),
+    ],
+    [
+      'friend_online (displayName == target, the only live shape)',
+      payload({ kind: 'friend_online', target: 'nostimo', displayName: 'nostimo' }),
+    ],
+    [
+      'friend_online under a legacy distinct display name',
+      payload({ kind: 'friend_online', target: 'nostimo', displayName: 'Amiantos' }),
+    ],
+    [
+      'friend_online with no display name',
+      payload({ kind: 'friend_online', target: 'nostimo', displayName: null }),
+    ],
+    [
+      'friend_online with no network',
+      payload({
+        kind: 'friend_online',
+        target: 'nostimo',
+        displayName: 'nostimo',
+        networkName: '',
+      }),
     ],
   ];
 

--- a/server/services/notificationContent.test.ts
+++ b/server/services/notificationContent.test.ts
@@ -88,6 +88,21 @@ describe('composeNotification', () => {
     expect(out.body).toBe('red and bold text');
   });
 
+  it('presence pushes never share a collapse tag with the peer’s messages', () => {
+    // Same buffer, different tag namespace: a connection flap must not
+    // replace an unread DM alert with "came online".
+    const dm = composeNotification(payload({ kind: 'dm', target: 'bob', nick: 'bob' }));
+    const presence = composeNotification(
+      payload({ kind: 'friend_online', target: 'bob', displayName: 'bob' }),
+    );
+    expect(presence.tag).not.toBe(dm.tag);
+    // ...but repeated flaps from the same peer DO collapse among themselves.
+    expect(
+      composeNotification(payload({ kind: 'friend_online', target: 'bob', displayName: 'bob' }))
+        .tag,
+    ).toBe(presence.tag);
+  });
+
   it('tags by buffer so a burst in one channel collapses', () => {
     const a = composeNotification(payload({ kind: 'highlight', target: '#lurker', text: 'one' }));
     const b = composeNotification(payload({ kind: 'highlight', target: '#lurker', text: 'two' }));

--- a/server/services/notificationContent.ts
+++ b/server/services/notificationContent.ts
@@ -91,6 +91,14 @@ export function composeNotification(payload: PushPayload): NotificationContent {
     // renders body as plain text, so the codes would otherwise arrive as literal
     // control chars on the lock screen (#606).
     body: stripFormatting(payload.text || ''),
-    tag: `${payload.networkId || 0}::${payload.target || ''}`,
+    // Presence transitions collapse among THEMSELVES, never with the peer's
+    // message notifications: the shared per-buffer tag meant "bob came online"
+    // silently REPLACED an unread "bob: hey" alert on a connection flap (the
+    // collapse key swaps content instead of stacking). A contacts-era quirk,
+    // fixed on revival rather than inherited.
+    tag:
+      payload.kind === 'friend_online'
+        ? `${payload.networkId || 0}::${payload.target || ''}::presence`
+        : `${payload.networkId || 0}::${payload.target || ''}`,
   };
 }

--- a/server/services/notificationContent.ts
+++ b/server/services/notificationContent.ts
@@ -21,7 +21,7 @@
 
 import { stripFormatting } from './textMatch.js';
 
-export type PushPayloadKind = 'dm' | 'highlight' | 'always_notify';
+export type PushPayloadKind = 'dm' | 'highlight' | 'always_notify' | 'friend_online';
 
 /**
  * The semantic push payload wsHub hands to pushService. Deliberately typed (it
@@ -39,6 +39,9 @@ export interface PushPayload {
   text?: string | null;
   time?: string;
   messageId?: number | null;
+  /** friend_online only. Under buffer favorites it always equals `target` —
+   *  the field survives for the sw.js/iOS payload shape (and its parity test). */
+  displayName?: string | null;
   /** Unread-highlight total for the app icon; absent when it can't have changed. */
   badge?: number;
 }
@@ -54,18 +57,36 @@ export interface NotificationContent {
   tag: string;
 }
 
+// "nostimo came online (Libera)". Byte-for-byte the composition sw.js's
+// legacyTitle applies (the parity suite runs the real worker against this).
+// The "(as nick)" branch is vestigial under buffer favorites — displayName
+// always equals target now — but a stale cached worker still carries it, so
+// the server keeps the identical expression rather than a simplification the
+// worker would disagree with on a crafted payload.
+function friendOnlineTitle(payload: PushPayload): string {
+  const name = payload.displayName || 'A friend';
+  const parts: string[] = [];
+  if (payload.target && String(payload.target).toLowerCase() !== name.toLowerCase()) {
+    parts.push(`as ${payload.target}`);
+  }
+  if (payload.networkName) parts.push(payload.networkName);
+  return `${name} came online${parts.length ? ` (${parts.join(' · ')})` : ''}`;
+}
+
 function title(payload: PushPayload): string {
   // A DM is already identified by its sender, so the target would just repeat the
   // nick; a channel highlight needs to say where it happened.
   if (payload.kind === 'dm') {
     return `${payload.nick || 'someone'}${payload.networkName ? ' (' + payload.networkName + ')' : ''}`;
   }
+  if (payload.kind === 'friend_online') return friendOnlineTitle(payload);
   return `${payload.nick || 'someone'} in ${payload.target || ''}`;
 }
 
 export function composeNotification(payload: PushPayload): NotificationContent {
   return {
     title: title(payload),
+    // friend_online carries no text, so its body is empty — the title says it all.
     // Strip mIRC formatting codes (\x03 colors, \x02 bold, …): a native alert
     // renders body as plain text, so the codes would otherwise arrive as literal
     // control chars on the lock screen (#606).

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1898,6 +1898,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     nick: string | null | undefined,
   ): void {
     if (!nick) return;
+    // Same early bail the message path uses: deliver() runs ensureVapid()
+    // BEFORE its own empty-subscription check, so without this every
+    // came-online event on a push-less account still does VAPID + DB work.
+    if (!pushService.hasSubscriptions(userId)) return;
     if (userHasVisibleClient(userId)) return;
     if (!effectiveSetting(userId, 'notifications.friend_online.enabled')) return;
     if (!isFavoriteDmPeer(userId, networkId, nick)) return;

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -90,6 +90,7 @@ import {
   unfavoriteBuffer,
   reorderFavorites,
   listFavoritesForUser,
+  isFavoriteDmPeer,
 } from '../db/favoriteBuffers.js';
 import { setNicklistCollapsed } from '../db/nicklistCollapsed.js';
 import { addBookmark, removeBookmark } from '../db/bookmarks.js';
@@ -1885,6 +1886,42 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
       .catch((err) => console.warn('[push] deliver failed:', err?.message || err));
   }
 
+  // Came-online push: fired from a peer-presence offline→online transition
+  // for the peer of a FAVORITED DM (someone under FRIENDS), when no client is
+  // visible (the in-app toast owns the visible case). The same
+  // enabled/quiet/away gates as message pushes apply, keyed off the
+  // friend_online settings namespace — the same key names the contacts-era
+  // push used, so preferences set back then revive untouched.
+  function maybePushFavoriteOnline(
+    userId: number,
+    networkId: number,
+    nick: string | null | undefined,
+  ): void {
+    if (!nick) return;
+    if (userHasVisibleClient(userId)) return;
+    if (!effectiveSetting(userId, 'notifications.friend_online.enabled')) return;
+    if (!isFavoriteDmPeer(userId, networkId, nick)) return;
+    if (pushQuietOrAway(userId)) return;
+    const network = ircManager.getConnection(userId, networkId)?.network;
+    pushService
+      .deliver(userId, {
+        kind: 'friend_online',
+        networkId,
+        networkName: network?.name || `net:${networkId}`,
+        // target is the friend's nick so a notification tap opens their DM.
+        target: nick,
+        // The contacts model had a display name distinct from the nick; a
+        // favorite IS its buffer, so they coincide now. Kept in the payload
+        // so shipped iOS builds' tap-routing sees the shape it expects.
+        displayName: nick,
+        // No `badge` here on purpose (#451 review): a friend coming online isn't
+        // a highlight, so the total can't have changed since the last message
+        // push set it. The SW no-ops when data.badge is absent, so omitting it
+        // avoids an O(buffers) scan that would only re-stamp the same number.
+      })
+      .catch((err) => console.warn('[push] friend-online deliver failed:', err?.message || err));
+  }
+
   ircManager.on('event', (rawEvent) => {
     // EnrichedEvent (from ircConnection) is a strict superset of MessageEvent.
     const event = rawEvent as MessageEvent & { userId: number; state?: string };
@@ -1986,6 +2023,11 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
     }
     fanOut(eventUserId, { ...decorated, kind: 'irc' });
     maybePush(eventUserId, decorated);
+    // A friend coming online is a presence transition, not a message, so it
+    // bypasses maybePush (no `notify`); push it on its own path.
+    if (event.type === 'peer-presence' && (event as { cameOnline?: boolean }).cameOnline) {
+      maybePushFavoriteOnline(eventUserId, event.networkId, event.nick);
+    }
     // A server-side path deleted a favorited buffer outright (evictChannel's
     // 470-forget is the one such path today) — the FK cascade took the
     // favorite row with it, so re-publish the authoritative list or every

--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -1375,6 +1375,54 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
   },
 
   {
+    // Same key names the contacts-era friend-online settings used: stored
+    // user_settings rows were orphaned (never purged) when the friends system
+    // left, so re-registering the names revives every preference untouched.
+    key: 'notifications.friend_online.enabled',
+    label: 'Friend online notifications',
+    category: 'notifications',
+    group: 'alerts',
+    type: 'bool',
+    default: true,
+    description:
+      'Toast me when a friend — the peer of a DM in your FRIENDS section — comes online.',
+  },
+  {
+    key: 'notifications.friend_online.sound.enabled',
+    label: 'Friend online sound',
+    category: 'notifications',
+    group: 'alerts',
+    type: 'bool',
+    default: false,
+    description:
+      'Play a short sound when a friend comes online. Off by default. Dependent on ' +
+      'notifications.friend_online.enabled.',
+  },
+  {
+    key: 'notifications.friend_online.sound.choice',
+    label: 'Friend online sound choice',
+    category: 'notifications',
+    group: 'alerts',
+    type: 'enum',
+    choices: ['ping', 'chime', 'pop', 'beep', 'knock', 'plink'],
+    default: 'knock',
+    description:
+      'Which bundled sound to play when a friend comes online. Distinct default ' +
+      'from the highlight/DM sounds so a friend signing on is recognizable by ear.',
+  },
+  {
+    key: 'notifications.friend_online.sound.volume',
+    label: 'Friend online sound volume',
+    category: 'notifications',
+    group: 'alerts',
+    type: 'int',
+    min: 0,
+    max: 100,
+    default: 60,
+    description: 'Playback volume for the friend-online sound, 0–100.',
+  },
+
+  {
     key: 'notifications.always_notify.enabled',
     label: 'Always-notify channel notifications',
     category: 'notifications',

--- a/vue_client/src/components/settings-panes/NotificationsPane.vue
+++ b/vue_client/src/components/settings-panes/NotificationsPane.vue
@@ -310,6 +310,11 @@ const NOTIFICATION_SIGNALS = [
     title: 'Always-notify channels',
     help: 'For every message in channels you have flagged via the channel context menu.',
   },
+  {
+    key: 'friend_online',
+    title: 'Friend online',
+    help: 'When the peer of a DM in your FRIENDS section comes online.',
+  },
 ];
 
 const notificationSignals = computed(() =>

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -31,7 +31,7 @@ import { useUploadsStore } from '../stores/uploads.js';
 import { makeClientId } from '../utils/clientId.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { downloadTextFile } from '../utils/download.js';
-import { notifyForEvent } from './useHighlightNotifier.js';
+import { notifyForEvent, playSound } from './useHighlightNotifier.js';
 
 export interface AckResult {
   ok: boolean;
@@ -351,11 +351,54 @@ function applyEvent(event: any): void {
       );
       break;
     case 'peer-presence': {
+      // Capture the prior known state BEFORE applying the update — the
+      // came-online toast must fire only on a transition we actually witnessed.
+      const prevPeerState =
+        networks.states[event.networkId]?.peerPresence?.[String(event.nick).toLowerCase()]?.state ??
+        null;
       networks.applyPeerPresence(event.networkId, event.nick, {
         state: event.state,
         stateAt: event.stateAt,
         awayMessage: event.awayMessage,
       });
+      // Came-online notification for FRIENDS (favorited DMs): only on a real
+      // offline→online transition. The server also reports current state on
+      // the MONITOR seed and whenever a nick is freshly added to the watch,
+      // so keying purely off `state === 'online'` would fire when you add an
+      // already-online friend or on a first connect.
+      //
+      // In-app toast + sound only when the tab is visible — the hidden case is
+      // the server-side push's job (wsHub.maybePushFavoriteOnline), gated on
+      // the same Page Visibility signal, so exactly one of the two fires.
+      if (
+        event.state === 'online' &&
+        prevPeerState === 'offline' &&
+        typeof document !== 'undefined' &&
+        !document.hidden
+      ) {
+        const nick = String(event.nick);
+        const settings = useSettingsStore();
+        if (
+          useFavoritesStore().isFavorite(event.networkId, nick) &&
+          settings.effective('notifications.friend_online.enabled')
+        ) {
+          useToastsStore().push({
+            kind: 'notify',
+            title: `${nick} came online`,
+            body: '',
+            networkId: event.networkId,
+            target: event.nick,
+          });
+          // Optional sound, same enable/choice/volume model as the DM/highlight/
+          // always-notify toasts (shared playSound helper).
+          if (settings.effective('notifications.friend_online.sound.enabled')) {
+            playSound(
+              (settings.effective('notifications.friend_online.sound.choice') as string) || 'knock',
+              settings.effective('notifications.friend_online.sound.volume'),
+            );
+          }
+        }
+      }
       break;
     }
     case 'system': {

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -387,7 +387,9 @@ function applyEvent(event: any): void {
             title: `${nick} came online`,
             body: '',
             networkId: event.networkId,
-            target: event.nick,
+            // The normalized string, not the raw payload field — click-routing
+            // downstream shouldn't meet whatever type the wire happened to carry.
+            target: nick,
           });
           // Optional sound, same enable/choice/volume model as the DM/highlight/
           // always-notify toasts (shared playSound helper).


### PR DESCRIPTION
## Summary

PR4 of the buffer-favorites sequence (#720 → #721 → #723 → this): the friend-online toast and push return, gated on "the peer of a DM under FRIENDS" (`isFavoriteDmPeer` — fold-aware, kind-checked) instead of the removed per-contact notify flag.

- `wsHub.maybePushFavoriteOnline` consumes the `cameOnline` flag ircConnection kept computing through the interregnum — same gates and payload shape as the contacts-era push (`displayName` now always equals `target`, kept for shipped iOS tap-routing and the untouched `sw.js` branch).
- The four `notifications.friend_online.*` settings keys re-register under their old names, byte-identical in type/default — stored preferences from the friends era revive untouched. NotificationsPane row returns.
- The vue toast recomputes the offline→online transition client-side and fires only on a visible tab; the push owns the hidden case (Page Visibility split — exactly one fires).
- `friendOnlineTitle` stays byte-for-byte with `sw.js`'s cached copy (vestigial `(as nick)` branch included); the parity suite runs the real worker over four friend_online shapes.
- **One deliberate behavior change from the contacts era:** presence pushes get their own collapse tag (`::presence`). The shared per-buffer tag meant a connection flap *replaced* an unread DM alert with "came online" — collapse keys swap content, they don't stack.

## Testing

`npm run check` + full suite green (3,614 tests; 8 new: title/parity/tag cases, `isFavoriteDmPeer`). Verification subagent review: no defects introduced; the collapse-tag quirk it surfaced is fixed in cfd73c6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)