### PR TITLE
build: move the runtime to Node 24 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,7 +78,7 @@ updates:
           - '*'
 
   # Docker base image. REQUIRED, not optional: the Dockerfile pins
-  # node:22-slim by digest for supply-chain reasons, which also freezes the
+  # node:24-slim by digest for supply-chain reasons, which also freezes the
   # Debian package set inside it. Without dependabot rewriting that digest the
   # base image silently rots and stops receiving OS security patches — the pin
   # would trade one risk for a worse one.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,7 +94,7 @@ updates:
     # reached end-of-life on 2026-06-01. Moving between Node majors also has
     # to bump node-version in test.yml/docs.yml in lockstep, so it is a
     # deliberate change that must never arrive as an automated one-file diff.
-    # semver-patch is deliberately NOT ignored: the tag (`22-slim`) carries no
+    # semver-patch is deliberately NOT ignored: the tag (`24-slim`) carries no
     # patch component, so it cannot produce a tag bump, and leaving it alone
     # keeps any risk of suppressing the digest updates this entry exists for.
     ignore:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Install root dependencies
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Install root dependencies
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Install root dependencies
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Install root dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,9 @@ Tests live **next to the code** they cover as `*.test.ts`.
 
 ## Setup & dev
 
-- **Node 22** — matches CI and the Docker runtime. better-sqlite3 + sharp are
-  native; stay on 22 to avoid ABI surprises.
+- **Node 24** (current LTS) — matches CI and the Docker runtime. `better-sqlite3`
+  and `sharp` are native, so stay on 24 to avoid ABI surprises. Track the LTS
+  line: odd-numbered majors never become LTS and go EOL within months.
 - `npm run install:all` — installs root **and** `vue_client/` deps.
 - `cp .env.example .env` — defaults are documented inline.
 - `npm run dev` — runs server + client concurrently.
@@ -141,10 +142,15 @@ These are the non-obvious constraints that have bitten changes before:
   throws `database connection is busy` and crashes the process. Read large sets
   with keyset pagination — `WHERE id > ? ORDER BY id LIMIT N`, a discrete
   `.all()` per page, yielding with `setImmediate` between pages.
-- **No `worker_threads`.** Under `tsx` on Node 22 (the deploy runtime) the
-  `.js`→`.ts` loader does not propagate into worker threads, so a TS worker
-  entry fails with `Cannot find module` at runtime even though it type-checks
-  and runs on newer Node. Use in-process `setImmediate` chunking for heavy work.
+- **No `worker_threads`.** Historically, under `tsx` the `.js`→`.ts` loader did
+  not propagate into worker threads on Node 22 (then the deploy runtime), so a
+  TS worker entry failed with `Cannot find module` at runtime even though it
+  type-checked. ⚠ A minimal repro no longer reproduces this on **either** Node
+  22 or 24 with tsx 4.23.x, so treat the version framing as unverified and
+  re-establish the failure before relying on this note in either direction. The
+  guidance stands regardless: use in-process `setImmediate` chunking for heavy
+  work, which also avoids holding a long-lived cursor on the shared SQLite
+  connection (lurker#175).
 - **Fold IRC target case when matching buffers.** Servers send channel and nick
   names with inconsistent casing. Never look a buffer up by exact key — match
   case-insensitively (client: the buffers store's `findByTarget`/`findDm`;

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Stage 1: Build Vue client
-FROM node:22-slim@sha256:f32b81066cde10a75dbac96646099533316d94bac4150c55da1636e1f0ffdc46 AS vue-builder
+FROM node:24-slim@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f AS vue-builder
 
 WORKDIR /app/vue_client
 
@@ -27,10 +27,17 @@ RUN npm run build
 # multi-arch building on a single-arch GHA runner is glacial (or hangs
 # outright), and the prebuild path sidesteps it entirely.
 #
-# Pinned to node:22 specifically (rather than lts) because better-sqlite3
-# 11.x ships prebuilds for Node 22 but not Node 24 (which the lts tag
-# currently resolves to). Bump when better-sqlite3 catches up.
-FROM node:22-slim@sha256:f32b81066cde10a75dbac96646099533316d94bac4150c55da1636e1f0ffdc46 AS server-deps
+# Track the current LTS line explicitly (24, EOL 2028-04-30) rather than the
+# `lts` tag or the newest tag. Odd-numbered majors (23, 25, ...) never become
+# LTS and go EOL in months, so "newest" is actively wrong here.
+#
+# Both native modules stay on the prebuild path at 24: better-sqlite3 12.x
+# publishes ABI-137 builds for linux-x64 and linux-arm64, and sharp 0.35 uses
+# N-API platform packages, which are ABI-independent.
+#
+# The digest is refreshed by dependabot; see .github/dependabot.yml, which
+# also explains why tag bumps here are deliberately not automated.
+FROM node:24-slim@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f AS server-deps
 
 WORKDIR /app
 
@@ -38,7 +45,7 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 # Stage 3: Runtime image
-FROM node:22-slim@sha256:f32b81066cde10a75dbac96646099533316d94bac4150c55da1636e1f0ffdc46
+FROM node:24-slim@sha256:cd84903a12dbd26b46f1f3b8144a2568c41c5d37ddd0c7a80a34c7a19786b35f
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,5 +135,5 @@ Not scheduled. Ideas, big bets, cleanups, and work blocked on external dependenc
 - #414 RPE2E DMs — _blocked on repartee's DM E2E_
 - #55 Accessibility: screen-reader support for completion UIs
 - #485 Schema-driven export/import at-rest encryption
-- #146 Remove redundant asyncHandler wrapper · #184 Revisit node:22 Docker pin
+- #146 Remove redundant asyncHandler wrapper
 - #2 Containerized IRCD + Lurker guide

--- a/server/services/exportJobs.ts
+++ b/server/services/exportJobs.ts
@@ -13,10 +13,12 @@
 // exportService). That's what keeps it off the critical path without a worker
 // thread: no long-lived cursor is held on the shared connection (so a
 // concurrent IRC write can't crash the process — lurker#175) and the loop stays
-// responsive on a large export. We deliberately do NOT use worker_threads: tsx's
-// module resolution doesn't propagate into worker threads on Node 22 (the
-// deployed runtime), so a worker entry can't import the app's `.js`-specified
-// TS modules there.
+// responsive on a large export. We deliberately do NOT use worker_threads. The
+// original reason was that tsx's module resolution didn't propagate into worker
+// threads on Node 22 (then the deployed runtime), so a worker entry couldn't
+// import the app's `.js`-specified TS modules. That no longer reproduces on a
+// minimal case under tsx 4.23.x on either 22 or 24 — but the shared-connection
+// reason above is the load-bearing one and is unaffected, so this stays.
 
 import fs from 'node:fs';
 import path from 'node:path';

--- a/server/services/linkMeta.ts
+++ b/server/services/linkMeta.ts
@@ -474,7 +474,8 @@ const CHARSET_NAME = /^[a-z0-9][a-z0-9\-._:]*$/i;
  * every client. The old comment claimed latin1 was "close enough for the punctuation that
  * matters here"; it was inverted.
  *
- * The node 22 image ships full ICU, so `TextDecoder` also handles every registry alias
+ * The node runtime image ships full ICU (not a small-icu build), so `TextDecoder` handles
+ * every registry alias
  * (`cp1252`, `iso8859-1`, `us-ascii`) and the encodings the old triple had no answer for at
  * all — windows-1251, shift_jis, gbk, euc-kr. Each of those used to fall through to UTF-8;
  * worse, a *recognised* alias was strictly worse than sending nothing, because a non-matching


### PR DESCRIPTION
Closes #184.

## The pin's rationale was stale

```dockerfile
# Pinned to node:22 specifically (rather than lts) because better-sqlite3
# 11.x ships prebuilds for Node 22 but not Node 24 ...
```

`package.json` is on `better-sqlite3@^12.11.1`, which publishes ABI-137 (Node 24) prebuilds for **both** `linux-x64` and `linux-arm64`. `sharp@0.35.3` uses N-API platform packages (`@img/sharp-linux-x64`, `@img/sharp-linux-arm64`), which are ABI-independent. Both stay on the prebuild path, so the QEMU source-compile the pin existed to avoid does not come back.

## Why 24 and not 25

| Line | Status | EOL |
| --- | --- | --- |
| 22 (was) | maintenance since 2025-10-21 | 2027-04-30 |
| **24 (now)** | **current LTS** | 2028-04-30 |
| 25 | not an LTS line | **2026-06-01 — already passed** |

Dependabot's first unconstrained docker run proposed node 25 (#729). Odd-numbered majors never become LTS, and that one was already end-of-life when it was offered. The rewritten comment says to track the LTS line explicitly rather than `lts` or newest, so the next person doesn't rediscover this.

**CI moves in lockstep** — `node-version` 22 → 24 in `test.yml` (×4) and `docs.yml`. Merging the Dockerfile alone would have shipped a node 24 runtime tested exclusively on 22, which is why #729 was never simply mergeable.

## Verification, against #184's checklist

- [x] **Prebuilds on both arches** — better-sqlite3 12.11.1 publishes `node-v137-linux-x64` and `node-v137-linux-arm64`; sharp 0.35.3 ships the matching `@img/sharp-linux-*` optional packages, `engines: node >=20.9.0`.
- [x] **Multi-arch build stays fast, no source compile** — `buildx build --no-cache --platform linux/amd64,linux/arm64` completes in **11s** with **zero** node-gyp/`cc1plus`/"building from source" output. Confirmed genuinely uncached: 0 `CACHED` steps, and npm reports `added 158 packages` + `added 260 packages` separately per arch. Built on the local `desktop-linux` builder, with `linux/amd64` emulated — the same emulation the GHA runner uses.
- [x] **Image boots and the native modules work** — on arm64 *and* emulated amd64: better-sqlite3 opens a database and round-trips a row; sharp encodes a PNG through libvips 8.18.3.
- [x] **Full suite on Node 24** — 260 files, **3620 passed, 1 skipped**. The skip is `app.test.ts:87`'s `it.skipIf(!hasBuiltClient)`, which wants a built client in the tree, not a particular Node version.
- [x] **Obsolete comment dropped**, and #184 removed from the ROADMAP icebox.

`docker-publish.yml` only runs on push to `main`, so none of the image verification above can happen in PR CI — it was all run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
