### PR TITLE
Reserve an inline image's box in Blink, not just in WebKit

### DIFF
--- a/server/services/linkPreview.test.ts
+++ b/server/services/linkPreview.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import sharp from 'sharp';
 import { setupTestDb } from '../test-utils/testApp.js';
 import type { PreviewRecord } from '../db/linkPreviews.js';
 
@@ -9,6 +10,7 @@ const ctx = setupTestDb('link-preview-service');
 
 let resolvePreview: typeof import('./linkPreview.js').resolvePreview;
 let toDescriptor: typeof import('./linkPreview.js').toDescriptor;
+let dimensionsFromHead: typeof import('./linkPreview.js').dimensionsFromHead;
 let getCachedPreview: typeof import('../db/linkPreviews.js').getCachedPreview;
 let putPreview: typeof import('../db/linkPreviews.js').putPreview;
 let OK_TTL_MS: number;
@@ -18,7 +20,7 @@ const SAVED_FLAG = process.env.LURKER_LINK_PREVIEWS;
 beforeAll(async () => {
   process.env.LURKER_LINK_PREVIEWS = 'on';
   ({ getCachedPreview, putPreview, OK_TTL_MS } = await import('../db/linkPreviews.js'));
-  ({ resolvePreview, toDescriptor } = await import('./linkPreview.js'));
+  ({ resolvePreview, toDescriptor, dimensionsFromHead } = await import('./linkPreview.js'));
 });
 
 afterAll(() => {
@@ -152,6 +154,54 @@ describe('toDescriptor', () => {
       // kind describes something that can't exist: a play button wired to nothing.
       expect(`${bad} → ${d.kind}`).toBe(`${bad} → page`);
     }
+  });
+});
+
+describe('dimensionsFromHead: the numbers a client reserves a box from', () => {
+  // ⚠⚠ These are a LAYOUT PROMISE, not a statistic. The client reserves an image's box from this
+  // ratio before any bytes arrive (MessageAttachment's `reserveStyle`, lurker#705), so a pair that
+  // disagrees with what the browser decodes is a permanently wrong-shaped box rather than a jump.
+  async function jpeg(w: number, h: number, orientation?: number) {
+    const img = sharp({ create: { width: w, height: h, channels: 3, background: '#888' } });
+    return await (orientation ? img.withMetadata({ orientation }) : img).jpeg().toBuffer();
+  }
+
+  it('reports what the BROWSER will decode, not what the file stores', async () => {
+    // A phone photo shot in portrait: stored landscape, with orientation 6 telling the decoder to
+    // rotate it. Browsers honour that (`image-orientation: from-image` is the default) and sharp's
+    // `metadata()` does not — so reading `meta.width`/`meta.height` hands the client a transposed
+    // box for the most ordinary photo on the platform. `imagePipeline.ts` already calls `.rotate()`
+    // for the same reason; this is that rule on the measuring path.
+    const rotated = await jpeg(400, 300, 6);
+
+    // ⚠ The probe is checked BEFORE it is trusted: sharp silently drops the tag on some write
+    // paths (`withExifMerge` did, in the console probe that first tried this), and a fixture with
+    // orientation 1 makes the assertion below pass against the very bug it guards.
+    expect((await sharp(rotated).metadata()).orientation).toBe(6);
+
+    expect(await dimensionsFromHead(rotated)).toEqual({ width: 300, height: 400 });
+
+    // And the ordinary case is untouched — no tag, no transpose.
+    expect(await dimensionsFromHead(await jpeg(400, 300))).toEqual({ width: 400, height: 300 });
+  });
+
+  it('falls back to the header reader for a container sharp refuses', async () => {
+    // The 64 KB truncation case (#697): webp/gif/tiff declare a total length and their loaders
+    // reject a short file before decoding it. A real photo is far past the cap, so this is the
+    // ordinary path for a pasted WebP — not an edge case.
+    const webp = await sharp({
+      create: { width: 120, height: 80, channels: 3, background: '#111' },
+    })
+      .webp()
+      .toBuffer();
+    const truncated = webp.subarray(0, 40);
+
+    // ⚠ Probe first: if sharp ever starts reading this buffer, the fallback stops being exercised
+    // and the assertion below would pass through the branch it is not written to cover.
+    await expect(sharp(truncated).metadata()).rejects.toThrow(/corrupt header/);
+
+    expect(await dimensionsFromHead(truncated)).toEqual({ width: 120, height: 80 });
+    expect(await dimensionsFromHead(Buffer.from('not an image at all'))).toBeNull();
   });
 });
 

--- a/server/services/linkPreview.test.ts
+++ b/server/services/linkPreview.test.ts
@@ -198,7 +198,11 @@ describe('dimensionsFromHead: the numbers a client reserves a box from', () => {
 
     // ⚠ Probe first: if sharp ever starts reading this buffer, the fallback stops being exercised
     // and the assertion below would pass through the branch it is not written to cover.
-    await expect(sharp(truncated).metadata()).rejects.toThrow(/corrupt header/);
+    // ⚠ Asserts THAT it rejects, never with what wording — libvips' message is its own business and
+    // varies by version and platform. It reads as an odd way to write `.rejects.toThrow()` because
+    // it is: the bare form trips `vitest(require-to-throw-message)`, and satisfying that lint rule
+    // is what pinned /corrupt header/ here in the first place (Copilot, #737).
+    await expect(sharp(truncated).metadata()).rejects.toBeInstanceOf(Error);
 
     expect(await dimensionsFromHead(truncated)).toEqual({ width: 120, height: 80 });
     expect(await dimensionsFromHead(Buffer.from('not an image at all'))).toBeNull();

--- a/server/services/linkPreview.ts
+++ b/server/services/linkPreview.ts
@@ -449,19 +449,49 @@ async function imageDimensions(
 ): Promise<{ width: number; height: number } | null> {
   try {
     const head = await bufferStream(res, { maxBytes: 64 * 1024 });
-    try {
-      const meta = await sharp(head.body).metadata();
-      if (meta.width && meta.height) return { width: meta.width, height: meta.height };
-    } catch {
-      // Fall through: sharp refusing a truncated container is the case below, not a dead end.
-    }
-    // ⚠ Second, never first. sharp handles more formats and is the better answer wherever it
-    // works; this must not shadow it with a narrower implementation that could disagree.
-    return dimensionsFromHeader(head.body);
+    return await dimensionsFromHead(head.body);
   } catch {
     // The read itself failed. No dimensions means no reservation, not no preview.
   }
   return null;
+}
+
+/**
+ * The measuring half, split out from the stream read so it can be TESTED.
+ *
+ * ⚠ Exported for the test alone, and that is worth one line of module surface: the resolver's
+ * only route to real image bytes is a network fetch, and the SSRF guard blocks loopback by
+ * design — so nothing that goes through `resolvePreview` can hand this function a real photo.
+ * Un-split, the EXIF rule below was a claim backed by a console probe and by nothing that runs.
+ */
+export async function dimensionsFromHead(
+  body: Buffer,
+): Promise<{ width: number; height: number } | null> {
+  try {
+    const meta = await sharp(body).metadata();
+    // ⚠⚠ `autoOrient`, NOT `width`/`height`. sharp reports the dimensions as STORED; a browser
+    // decodes with `image-orientation: from-image` and applies the EXIF rotation, so for the
+    // most ordinary photo on the platform — a phone JPEG with orientation 6 — the two disagree
+    // by a transpose. Measured on the sharp in this tree: stored 400x300, `autoOrient`
+    // {300,400}, and `.rotate()` (what the browser effectively does) 300x400.
+    //
+    // These numbers are a LAYOUT PROMISE, not a statistic: the client reserves the box from
+    // this ratio before any bytes arrive (MessageAttachment's `reserveStyle`), so a transposed
+    // pair means a portrait photo sits letterboxed in a landscape box — and on a column narrow
+    // enough for `max-width` to bite, the wrong ratio drags the reserved height down with it.
+    // `imagePipeline.ts` already calls `.rotate()` for the same reason; this is that rule on
+    // the measuring path.
+    const dims = meta.autoOrient ?? meta;
+    if (dims.width && dims.height) return { width: dims.width, height: dims.height };
+  } catch {
+    // Fall through: sharp refusing a truncated container is the case below, not a dead end.
+  }
+  // ⚠ Second, never first. sharp handles more formats and is the better answer wherever it
+  // works; this must not shadow it with a narrower implementation that could disagree.
+  // ⚠ This fallback reads stored dimensions and knows nothing of EXIF, so it can still return a
+  // transposed pair. It is reached only for a container sharp refuses at 64 KB — webp, gif and
+  // tiff — and the orientation tag in the wild is a JPEG phenomenon, which sharp measures.
+  return dimensionsFromHeader(body);
 }
 
 async function doResolve(raw: string, signal: AbortSignal): Promise<PreviewRecord> {

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -467,6 +467,22 @@ describe('MessageAttachment — growth the list can react to', () => {
     await wrapper.find('video').trigger('loadedmetadata');
     expect(wrapper.emitted('measured')).toHaveLength(1);
   });
+
+  it('tells the list when an image decodes, even though its box was reserved', async () => {
+    // ⚠⚠ The NET, and it is deliberately kept rather than reasoned away. This emit was deleted
+    // once on the argument that a reserved box makes late growth impossible, and the box being
+    // reserved was itself false in Blink (0x0 until the bytes landed) — so the one thing that
+    // would have noticed lurker#705 had been removed on the strength of the belief the bug
+    // disproves. `reserveStyle` should now make this redundant; "should" is why it stays.
+    //
+    // It costs nothing when redundant: `repinAfterPreviewGrowth(true)` in MessageList returns
+    // immediately unless the reader is at the tail, and for one who is, the correction is an
+    // idempotent `scrollTop = scrollHeight`.
+    seedSettings();
+    const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
+    await wrapper.find('img.inline-image').trigger('load');
+    expect(wrapper.emitted('measured')).toHaveLength(1);
+  });
 });
 
 describe('MessageAttachments — arrangement', () => {
@@ -778,33 +794,53 @@ describe('MessageAttachment — a box that does not depend on bytes', () => {
     src: '/api/link-preview/media/tokX',
   });
 
-  it('reserves the box on a WRAPPER, and only for an unmeasured image outside a strip', () => {
-    // ⚠ All three cases in ONE test, deliberately. Split apart, the two negative cases asserted
+  it('reserves the box on a WRAPPER for every image outside a strip, measured or not', () => {
+    // ⚠ All three cases in ONE test, deliberately. Split apart, the negative case asserted
     // `not.toContain(...)` and stayed green with the binding deleted entirely — vacuous against
-    // the very mutation they look like they guard.
+    // the very mutation it looks like it guards.
     //
-    // `imageDimensions` returns null for a format sharp can't parse in the 64 KB it reads — ico
-    // and bmp both arrive as `kind: 'image'` with null dimensions. With no width/height attributes
-    // there is no ratio to reserve a box from, so the element lays out at the UA default and grows
-    // on decode: video's pre-465f838 bug, still live for images.
-    //
-    // ⚠⚠ The height is on the WRAPPER and that is the assertion that matters. Pinned on the
+    // ⚠⚠ The geometry is on the WRAPPER and that is the assertion that matters. Pinned on the
     // `<img>`, the empty letterbox around a 16x16 favicon became part of a 240px-tall control
     // that calls `stopPropagation` — swallowing the row tap that is the only opener of the
     // message-actions sheet on touch. A wrapper with no handlers leaves those pixels to the row.
+    //
+    // `imageDimensions` returns null for a format sharp can't parse in the 64 KB it reads — ico
+    // and bmp both arrive as `kind: 'image'` with null dimensions. With no ratio to derive a box
+    // from, that case falls back to the flat height `.dim-fallback` carries.
     const lone = mount(MessageAttachment, { props: { preview: unmeasured } });
     expect(lone.find('.dim-reserve').exists()).toBe(true);
     expect(lone.find('.dim-reserve img.inline-image').exists()).toBe(true);
+    expect(lone.find('.dim-reserve').classes()).toContain('dim-fallback');
+    expect(lone.find('.dim-reserve').attributes('style')).toBeUndefined();
 
-    // A measured image keeps its own aspect — the descriptor arrives atomically with the decision
-    // to render at all, so natural aspect costs nothing and a fixed box would only waste space.
+    // ⚠⚠ lurker#705. A MEASURED image used to get no wrapper box at all, on the belief that its
+    // width/height attributes reserved one — which is false wherever author CSS sets `width:
+    // auto` (this component does). Measured against a `src` that never resolves: Safari reserved
+    // 319x240, Chrome reserved 0x0, and the 240px it gained at decode time is what stopped a
+    // buffer opening at its own tail. The wrapper now carries a definite width and the ratio.
     const measured = mount(MessageAttachment, { props: { preview: IMAGE } });
-    expect(measured.find('.dim-reserve').exists()).toBe(false);
+    const box = measured.find('.dim-reserve');
+    expect(box.exists()).toBe(true);
+    expect(box.classes()).not.toContain('dim-fallback');
+    // 800x600 (see IMAGE): 240 * 4/3 = 320px of width, so the height lands on the 240 cap exactly
+    // as the loaded image would. The cap is applied to the WIDTH because `max-height` cannot bite
+    // until the natural width is known — which is the whole reason the old box arrived late.
+    expect(box.attributes('style')).toContain('width: 320px');
+    expect(box.attributes('style')).toContain('aspect-ratio: 800 / 600');
 
-    // In a strip the row already decides the height; a second fixed box would fight it.
+    // Never upscaled: a 16x16 favicon takes its own width, not the 240px cap. (`.dim-fallback`
+    // has no ratio to do this with, which is why an unmeasured image gets the flat box instead.)
+    const tiny = mount(MessageAttachment, {
+      props: { preview: preview({ ...IMAGE, thumbWidth: 16, thumbHeight: 16 }) },
+    });
+    expect(tiny.find('.dim-reserve').attributes('style')).toContain('width: 16px');
+
+    // In a strip the row already decides the height; a second box would fight it.
     const strip = mount(MessageAttachment, { props: { preview: unmeasured, inStrip: true } });
     expect(strip.find('.dim-reserve').exists()).toBe(false);
     expect(strip.find('img').classes()).toContain('strip-item');
+    const measuredStrip = mount(MessageAttachment, { props: { preview: IMAGE, inStrip: true } });
+    expect(measuredStrip.find('.dim-passthrough').attributes('style')).toBeUndefined();
   });
 });
 

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -387,7 +387,10 @@ describe('MessageAttachment — inline image', () => {
     const wrapper = mount(MessageAttachment, { props: { preview: IMAGE } });
     const img = wrapper.find('img.inline-image');
     expect(img.attributes('src')).toBe('/api/link-preview/media/tok2');
-    // Load-bearing: these reserve the box before the bytes arrive.
+    // ⚠ These do NOT reserve the box, whatever this comment used to say — `.inline-image` sets
+    // `width: auto`, which beats the presentational hint and leaves an unloaded image with no box
+    // at all in Blink (lurker#705). The wrapper is the reserver; these stay for the UA ratio,
+    // which is what still sizes the image inside that box.
     expect(img.attributes('width')).toBe('800');
     expect(img.attributes('height')).toBe('600');
   });

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -838,6 +838,15 @@ describe('MessageAttachment — a box that does not depend on bytes', () => {
     });
     expect(tiny.find('.dim-reserve').attributes('style')).toContain('width: 16px');
 
+    // ⚠⚠ A SLIVER, and the width stays fractional. `aspect-ratio` derives the height by dividing
+    // this width, so a rounding error is multiplied by h/w: 13x1200 rounded to a whole 3px makes
+    // the box 277px tall, and a 2x1000 floored to 1px makes it 500px — against a cap of 240. The
+    // fraction is what keeps `MAX_IMAGE_HEIGHT` true for the shapes it exists for (Copilot, #737).
+    const sliver = mount(MessageAttachment, {
+      props: { preview: preview({ ...IMAGE, thumbWidth: 13, thumbHeight: 1200 }) },
+    });
+    expect(sliver.find('.dim-reserve').attributes('style')).toContain('width: 2.6px');
+
     // In a strip the row already decides the height; a second box would fight it.
     const strip = mount(MessageAttachment, { props: { preview: unmeasured, inStrip: true } });
     expect(strip.find('.dim-reserve').exists()).toBe(false);

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -4,26 +4,42 @@
 -->
 
 <template>
-  <!-- Direct media: no card, no chrome. A frame around an image is furniture around content.
-       `width`/`height` are the server's real pixel dimensions, and they're load-bearing rather
-       than decorative — the browser derives the intrinsic aspect ratio from them and reserves
-       the right box BEFORE any bytes arrive. -->
-  <!-- ⚠ The RESERVER is this span, not the image. When the server could not measure an image
-       there is no ratio to reserve a box from, and pinning the height on the `<img>` itself made
-       its empty letterbox part of the image: a 16x16 favicon.ico became a 240px-tall,
-       full-column-wide element carrying `role="button"` and a handler that calls
-       `stopPropagation`, so a tap anywhere in the ~99% of it that is background opened the
-       lightbox AND swallowed the row click — which on touch is the only thing that opens the
-       message-actions sheet. The height belongs to a wrapper that has no handlers, so those
-       pixels keep belonging to the row. Same defect class as the `@click.stop` note below,
-       re-created by a fixed box instead of by a modifier. -->
+  <!-- Direct media: no card, no chrome. A frame around an image is furniture around content. -->
+  <!-- ⚠⚠ THE RESERVER IS THIS SPAN, ALWAYS — never the `<img>`, and never its width/height
+       attributes. Those attributes were believed to reserve the box "BEFORE any bytes arrive";
+       measured in both engines against a `src` that never resolves, they do not:
+
+         Safari   pending 319x240   loaded 319x240
+         Chrome   pending   0x0     loaded 319x240      (attrs 1841x1384)
+
+       `.inline-image` sets `width: auto; height: auto` (below), which beats the attributes'
+       presentational hints and leaves only the UA `aspect-ratio`. An `<img>` that has not loaded
+       and carries `alt=""` "represents nothing" per HTML, and Blink honours that literally:
+       no box at all. WebKit keeps one from the ratio, which is the whole of lurker#705 — every
+       inline image in Chrome jumped 0 -> 240px at DECODE time, long after the atomic reveal's
+       `previewRevision` re-pin had run, so a buffer opened at the tail landed 240px short of it.
+
+       So the wrapper carries the geometry for every non-strip image, derived from the server's
+       dimensions rather than from bytes: `reserveStyle` resolves to exactly the box the loaded
+       image occupies. In a strip the row's fixed height governs and the wrapper stays out of the
+       way — see `dim-passthrough`.
+
+       ⚠ Geometry on the WRAPPER also keeps the empty letterbox out of the image: pinned on the
+       `<img>`, a 16x16 favicon.ico became a 240px-tall, full-column-wide element carrying
+       `role="button"` and a handler that calls `stopPropagation`, so a tap anywhere in the ~99%
+       of it that is background opened the lightbox AND swallowed the row click — which on touch
+       is the only thing that opens the message-actions sheet. A wrapper has no handlers, so those
+       pixels keep belonging to the row. Same defect class as the `@click.stop` note below. -->
   <span
     v-if="preview.kind === 'image' && preview.src"
-    :class="needsReservedBox ? 'dim-reserve' : 'dim-passthrough'"
+    :class="
+      inStrip ? 'dim-passthrough' : hasDimensions ? 'dim-reserve' : 'dim-reserve dim-fallback'
+    "
+    :style="reserveStyle"
   >
     <img
       class="inline-image"
-      :class="{ 'strip-item': inStrip, 'in-reserve': needsReservedBox }"
+      :class="{ 'strip-item': inStrip, 'in-reserve': !inStrip }"
       :src="preview.src"
       :width="preview.thumbWidth || undefined"
       :height="preview.thumbHeight || undefined"
@@ -33,6 +49,7 @@
       :role="viewerEnabled ? 'button' : undefined"
       :tabindex="viewerEnabled ? 0 : undefined"
       :aria-label="viewerEnabled ? imageLabel : undefined"
+      @load="$emit('measured')"
       @click="onImageClick"
       @keydown.enter.prevent="activate"
       @keydown.space.prevent="activate"
@@ -197,13 +214,17 @@ const props = defineProps<{
   inStrip?: boolean;
 }>();
 
-// ⚠ `measured` is emitted by VIDEO and AUDIO only, and the image `@load` emit that used to sit
-// beside them is deliberately gone. Every rendered image now has its box before any bytes: the
-// server's width/height attributes, `.strip-item`'s row height, or `.dim-reserve`'s wrapper. So
-// `@load` could no longer report growth — but it still fired `repinAfterPreviewGrowth(true)`,
-// which for a reader at the live tail runs `scrollToBottom()`. With the atomic reveal landing a
-// message's images in one flush, a five-image message meant five scroll corrections for growth
-// that cannot happen.
+// ⚠⚠ `measured` is emitted by IMAGE, VIDEO and AUDIO. The image `@load` emit was removed once,
+// on the reasoning that "every rendered image now has its box before any bytes" and so `@load`
+// could no longer report growth — the cost cited was five idempotent scroll corrections for a
+// five-image message. The premise was false in Blink (see the template: pending 0x0), the
+// removal took away the only thing that would have NOTICED, and lurker#705 is what that cost.
+//
+// It is back as a NET, and it is kept even though `reserveStyle` should now make it redundant.
+// A correction while pinned is `scrollTop = scrollHeight` — idempotent, invisible, and cheap
+// enough that "this growth cannot happen" is not worth betting a scroll position on. The guard
+// that makes it safe lives in the list: `repinAfterPreviewGrowth(true)` returns immediately
+// unless the reader is at the tail, so a scrolled-up reader is never moved by a late decode.
 // `activate` rather than opening the viewer here: what a click MEANS depends on the
 // arrangement, and the arrangement is the parent's business. A tap on one image of a strip
 // should open the whole strip as a gallery, and only the parent knows what the strip holds.
@@ -280,20 +301,51 @@ const heading = computed(() => {
 /**
  * Whether the server could measure this image.
  *
- * The `width`/`height` attributes are what reserve the box before any bytes arrive, so their
- * ABSENCE is the one case where an inline image's height depends on the decode — see `.dim-reserve`.
  * `imageDimensions` fails legitimately and not rarely: an exotic format, or a header sharp can't
- * parse inside the 64 KB it reads.
+ * parse inside the 64 KB it reads — ico and bmp both arrive as `kind: 'image'` with null
+ * dimensions. Measured or not, the box is reserved either way; this only picks WHICH box.
  */
 const hasDimensions = computed(() => !!props.preview.thumbWidth && !!props.preview.thumbHeight);
 
+/** The tallest a lone image gets. Mirrors `.inline-image`'s `max-height`, and `.dim-fallback`. */
+const MAX_IMAGE_HEIGHT = 240;
+
 /**
- * Whether this image needs a wrapper to hold its height open.
+ * The box this image will occupy, resolved from the server's dimensions instead of from bytes.
  *
- * Only outside a strip: the strip row already fixes the height there, and a second fixed box
- * would fight it.
+ * Null in the two cases that must not carry geometry: inside a strip, where the row's fixed
+ * height governs and a second box would fight it, and for an unmeasured image, which has no
+ * ratio to derive one from and falls back to `.dim-fallback`'s flat height.
+ *
+ * ⚠⚠ The HEIGHT CAP IS APPLIED AS A WIDTH, and that is what makes this exact rather than
+ * approximate. `max-height` cannot bite until the natural width is known — it is the reason the
+ * loaded box (319x240) is one no pre-load layout could have guessed — so the same cap, applied to
+ * the width as `MAX_IMAGE_HEIGHT * ratio`, reproduces the post-load result with no bytes:
+ *
+ *   width  = min(naturalWidth, MAX_IMAGE_HEIGHT * ratio)   here
+ *   width  = min(that, 100%)                               via `.dim-reserve`'s `max-width`
+ *   height = width / ratio                                 via `aspect-ratio`
+ *
+ * Each term is a constraint that would otherwise be discovered late: `naturalWidth` stops a 16x16
+ * favicon being upscaled to a blurry 240px, the cap holds a portrait shot, and `max-width` clamps
+ * a wide one to the column — with `aspect-ratio` carrying the height down with it, so a narrow
+ * viewport stays exact too.
+ *
+ * ⚠ The column term is a SEPARATE `max-width` declaration rather than a third argument to a CSS
+ * `min()`, which is what this returned first. `min()` is universally supported and would have
+ * worked in every browser — but happy-dom's style parser drops a declaration it can't parse, so
+ * the assertion in MessageAttachment.test.ts saw an empty width and could not have failed if the
+ * binding were deleted. Two plain declarations are observable by the test that guards them.
  */
-const needsReservedBox = computed(() => !props.inStrip && !hasDimensions.value);
+const reserveStyle = computed(() => {
+  if (props.inStrip || !hasDimensions.value) return null;
+  const w = props.preview.thumbWidth!;
+  const h = props.preview.thumbHeight!;
+  return {
+    width: `${Math.round(Math.min(w, MAX_IMAGE_HEIGHT * (w / h)))}px`,
+    aspectRatio: `${w} / ${h}`,
+  };
+});
 
 /**
  * ⚠⚠ THERE IS DELIBERATELY NO `@error` HANDLING, and that is a decision rather than an omission.
@@ -391,41 +443,53 @@ function activate(): void {
   /* Capped so one tall screenshot can't push the rest of the conversation off screen. The
      viewer is one click away for the full thing. */
   max-height: 240px;
-  /* ⚠ Both `auto`, and both needed. The `width`/`height` attributes give the browser the
-     intrinsic ratio to reserve space with; these let it SCALE that box down proportionally to
-     fit inside max-width/max-height. Without `width: auto` a portrait image hits the height
-     cap and keeps its attribute width, which is squashing rather than scaling. */
+  /* ⚠ Both `auto`, and both needed — for SCALING, which is all they were ever doing. They let the
+     box shrink proportionally inside max-width/max-height; without `width: auto` a portrait image
+     hits the height cap and keeps its attribute width, which is squashing rather than scaling.
+     ⚠⚠ What they do NOT do, and were long claimed to do, is leave the width/height attributes
+     free to reserve space: author styles beat presentational hints, so these two declarations are
+     precisely why an unloaded image had no box in Blink. The reservation lives on the wrapper
+     (see the template); these stay because a loaded image still has to fit the box it was given. */
   width: auto;
   height: auto;
   object-fit: contain;
   border-radius: var(--radius-md);
   display: block;
 }
-/* ⚠ The height lives on the WRAPPER, and the image sizes itself inside it.
-   With no width/height attributes there is no intrinsic ratio to reserve a box from, so the
-   element lays out at the UA default for a replaced element with no dimensions and grows to its
-   real size on decode — the one shape whose height would otherwise depend on bytes rather than on
-   its descriptor. 240px matches the `max-height` a measured image is scaled into, so the fallback
-   and the normal case agree on the tallest a lone image gets.
-   Putting it here rather than on the `<img>` is what keeps the empty area around a small image
-   from becoming a click target — see the template. */
-/* When no box needs reserving the wrapper generates NO box at all, so layout, flex participation
-   and the strip's sizing behave exactly as they did when the image was the direct child. */
+/* In a strip the ROW's fixed height is the reservation, so the wrapper generates no box at all
+   and layout, flex participation and the strip's snap points behave exactly as they did when the
+   image was the direct child (MessageAttachments' `.filmstrip :deep(.inline-image)` depends on
+   this — a snap point on a `display: contents` span would have nothing to align). */
 .dim-passthrough {
   display: contents;
 }
+/* Everywhere else the wrapper IS the box. Measured images get their geometry inline from
+   `reserveStyle` (a definite width plus `aspect-ratio`); `.dim-fallback` below covers the rest. */
 .dim-reserve {
   display: block;
-  height: 240px;
+  /* The column clamp, and the third term of the box `reserveStyle` computes — kept here rather
+     than inline because it is the one constraint that isn't knowable from the descriptor.
+     `aspect-ratio` carries the height down with the width when it bites, so the box stays exact
+     on a narrow viewport instead of only on a wide one. */
+  max-width: 100%;
   /* ⚠ NO fill, deliberately. It had one — the reasoning was that a lazily-loaded empty box reads
      as a hole punched in the conversation. QA read it the other way round: a panel-coloured
      rectangle is what a link-preview CARD looks like, so an image that merely hadn't been
      measured announced itself as a different kind of object entirely. Direct media has no chrome
      anywhere else in this component, and reserved space is not a thing to advertise. */
 }
-/* Inside the reserve the image is bounded by the box and never scaled up: sharp decodes
-   jpeg/png/webp/tiff/gif/svg/heif/raw, so ico and bmp arrive as `kind: 'image'` with null
-   dimensions, and a 16x16 favicon stretched to 240px would be 15x blurry. */
+/* No dimensions from the server means no ratio to derive a box from, so the one flat height that
+   remains honest is the tallest a lone image gets. 240px matches `.inline-image`'s `max-height`
+   and `MAX_IMAGE_HEIGHT`, so the fallback and the measured case agree on that ceiling. */
+.dim-fallback {
+  height: 240px;
+}
+/* Inside the reserve the image is bounded by the box and never scaled up. For a measured image
+   the two agree exactly — `reserveStyle` derives the box from the same ratio the image decodes
+   to — so this is what makes the arrival a no-op rather than a resize. For an unmeasured one it
+   is a real constraint: sharp decodes jpeg/png/webp/tiff/gif/svg/heif/raw, so ico and bmp arrive
+   as `kind: 'image'` with null dimensions, and a 16x16 favicon stretched to 240px would be 15x
+   blurry. */
 .inline-image.in-reserve {
   max-height: 100%;
   max-width: 100%;

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -342,11 +342,21 @@ const reserveStyle = computed(() => {
   const w = props.preview.thumbWidth!;
   const h = props.preview.thumbHeight!;
   return {
-    // ⚠ `max(1, …)`: rounding a sliver's capped width down to `0px` would give the wrapper a 0x0
-    // box and, through `.in-reserve`'s `max-width: 100%`, an image with no width at all. Reached
-    // whenever the ratio is under 1/480 — a 2x1000 strip is degenerate either way, but a
-    // one-pixel box degrades and a zero-pixel one disappears.
-    width: `${Math.max(1, Math.round(Math.min(w, MAX_IMAGE_HEIGHT * (w / h))))}px`,
+    // ⚠⚠ FRACTIONAL, and never rounded to a whole pixel. `aspect-ratio` derives the height by
+    // DIVIDING this width by the ratio, so a rounding error is multiplied by `h / w` — and for the
+    // shapes the cap exists to hold, that multiplier is enormous. Measured: a 13x1200 sliver's
+    // exact 2.6px width rounds to 3px and the box becomes 277px tall; a 2x1000 one, floored to 1px
+    // to keep it from rounding to 0, becomes **500px** — more than double the ceiling the rounding
+    // was decorating. (No decode-time growth either way: the box is byte-independent whatever this
+    // number is. What breaks is `MAX_IMAGE_HEIGHT` meaning anything.)
+    //
+    // A fractional width keeps the cap exact and makes the zero case unreachable in one move,
+    // since `MAX_IMAGE_HEIGHT * (w / h)` is greater than zero for any real pair of dimensions —
+    // so the floor that caused the 500px box is gone rather than tuned. Three decimals to keep the
+    // attribute readable; the residual is `0.001 * h / w`, which is a tenth of a pixel on the
+    // worst shape above. `Number()` drops the trailing zeros `toFixed` adds, so the ordinary case
+    // stays `320px` rather than `320.000px`.
+    width: `${Number(Math.min(w, MAX_IMAGE_HEIGHT * (w / h)).toFixed(3))}px`,
     aspectRatio: `${w} / ${h}`,
   };
 });

--- a/vue_client/src/components/MessageAttachment.vue
+++ b/vue_client/src/components/MessageAttachment.vue
@@ -342,7 +342,11 @@ const reserveStyle = computed(() => {
   const w = props.preview.thumbWidth!;
   const h = props.preview.thumbHeight!;
   return {
-    width: `${Math.round(Math.min(w, MAX_IMAGE_HEIGHT * (w / h)))}px`,
+    // ⚠ `max(1, …)`: rounding a sliver's capped width down to `0px` would give the wrapper a 0x0
+    // box and, through `.in-reserve`'s `max-width: 100%`, an image with no width at all. Reached
+    // whenever the ratio is under 1/480 — a 2x1000 strip is degenerate either way, but a
+    // one-pixel box degrades and a zero-pixel one disappears.
+    width: `${Math.max(1, Math.round(Math.min(w, MAX_IMAGE_HEIGHT * (w / h))))}px`,
     aspectRatio: `${w} / ${h}`,
   };
 });
@@ -355,8 +359,10 @@ const reserveStyle = computed(() => {
  *
  *   - Setting a non-empty `alt` on failure re-triggers frame construction in Gecko and DROPS the
  *     attribute-derived aspect ratio, collapsing a measured 240px box to an 18px text line —
- *     222px of uncompensated shrink that plain `alt=""` does not suffer. The old shape held 240px
- *     in Blink, WebKit and Gecko alike.
+ *     222px of uncompensated shrink that plain `alt=""` does not suffer. (⚠ That measurement was
+ *     taken when the `<img>` was the reserver. It no longer is — the wrapper holds the box and an
+ *     `alt` swap cannot reach it — so this particular collapse is now structurally impossible.
+ *     Kept as the record of why the flag was tried, not as a live constraint.)
  *   - The reset that was supposed to clear the flag could never fire: `mintProxyToken` is an HMAC
  *     over the URL, so a re-delivered answer carries a byte-identical `src` and the watch on it
  *     never runs. And an `ok` preview is never re-asked at all, so the flag was permanent — a
@@ -364,8 +370,12 @@ const reserveStyle = computed(() => {
  *   - Dropping `role`/`tabindex` on failure removed them from an element that may currently HOLD
  *     focus, dumping a keyboard user back to `<body>` mid-strip.
  *
- * The byte-independence rule this file serves is already satisfied without any of it: the
- * width/height attributes survive a failed load, and `.dim-reserve` pins the one shape that has none.
+ * The byte-independence rule this file serves is already satisfied without any of it, and since
+ * lurker#705 it is satisfied MORE strongly than this paragraph used to claim: the reservation does
+ * not depend on the image element at all — `.dim-reserve` holds the box for every non-strip image,
+ * from the descriptor, whether the bytes arrive or not. (The old claim, that "the width/height
+ * attributes survive a failed load", was doubly wrong: those attributes reserve nothing once author
+ * CSS sets `width: auto`, so what survived a failed load was nothing at all in Blink.)
  * A broken-image glyph in a correctly-sized box is a smaller problem than every one of the above.
  */
 


### PR DESCRIPTION
Fixes #705.

Opening a buffer in Chrome did not land at the tail when the backlog held inline previews. Safari was always fine, which is the shape of the bug: **the client's own reservation only ever worked in one engine, and WebKit was quietly covering for it.**

## What was wrong

`.inline-image` sets `width: auto; height: auto`. Author styles beat the `width`/`height` attributes' presentational hints, so all that survived was the UA `aspect-ratio` — and an `<img>` that has not loaded and carries `alt=""` "represents nothing" per HTML. Blink honours that literally and generates **no box at all**.

Measured in both engines, by cloning a rendered image and pointing the clone at a `src` that never resolves:

| | pending | loaded | attrs |
|---|---|---|---|
| Safari | 319x240 | 319x240 | 1841x1384 |
| Chrome | **0x0** | 319x240 | 1841x1384 |

So in Chrome every measured inline image gained its full height at *decode* time — long after the atomic reveal's `previewRevision` re-pin had run. The operator's instrumented trace shows it exactly: three compensated growths (`gap below fold: 0`), then `1443 -> 1683` with **`gap below fold: 240`** and nothing left watching, because the image `@load` hook had been deleted on the reasoning that a reserved box makes late growth impossible.

That premise was false in Blink, and its removal took away the one thing that would have noticed.

## The fix

**The wrapper carries the geometry for every non-strip image**, derived from the server's dimensions rather than from bytes:

```
width  = min(naturalWidth, 240 * ratio)   inline, from the descriptor
width  = min(that, 100%)                  via .dim-reserve's max-width
height = width / ratio                    via aspect-ratio
```

The height cap is applied to the **width** because `max-height` cannot bite until the natural width is known — which is precisely why the old box arrived late. Pre-load and post-load boxes are now identical by construction. Unmeasured images keep the flat 240px (now `.dim-fallback`); strips are untouched, since the row's fixed height already governs there.

`@load` -> `measured` is **back as a net**, kept even though the reservation should make it redundant: `repinAfterPreviewGrowth(true)` no-ops unless the reader is at the tail, so it costs an idempotent `scrollTop` write. "This growth cannot happen" is what the last round bet a scroll position on.

## Second commit — review findings

`/code-review high`, four fixed:

- ⚠⚠ **sharp reports STORED dimensions.** A browser decodes with `image-orientation: from-image`, so a phone JPEG with orientation 6 was measured transposed. Before this branch that self-corrected on load; now that the box is reserved permanently from that ratio, it is a portrait photo letterboxed in a landscape box for good — and on a narrow column the wrong ratio drags the reserved height to 187px where the picture wants 240. `imagePipeline.ts` already calls `.rotate()` for this reason; the measuring path now uses `meta.autoOrient`.
- `max(1, ...)` on the reserved width — a ratio under 1/480 rounded the capped width to `0px`.
- The `@error` rationale and an untouched test comment still asserted that the width/height attributes reserve the box: the belief this branch exists to disprove, left standing in the file where it already cost a bug.

One finding dropped after checking it: an agent read the strip's `observe(child)` loop as meaning the scroll fade never appears for image strips. The sibling `observe(el)` two lines above catches it — `.attachments` is `align-items: flex-start`, so the strip is shrink-to-fit and its own box grows with its images. The child loop is dead code for image strips, nothing more, and QA confirms the fade works.

## Verification

- **Manual QA in Chrome confirms the fix** — this is the load-bearing verification, because **no test can observe any of it**: happy-dom applies no stylesheet. The guards assert the style string instead, and say so.
- Both new guards checked by **revert**: stubbing `reserveStyle` to null fails the geometry test; removing `meta.autoOrient` fails the EXIF test 400x300 against 300x400.
- ⚠ The first EXIF probe was **invalid** — `withExifMerge` silently dropped the tag and reported orientation 1, which would have "confirmed" no bug. The test asserts its fixture's orientation before trusting it.
- `dimensionsFromHead` is split out of the stream read so it is testable at all: the resolver's only route to real bytes is a network fetch, and the SSRF guard blocks loopback by design.
- happy-dom drops a CSS `min()` it cannot parse, which silently emptied the first version of the geometry assertion — hence the column clamp is a separate declaration rather than a third `min()` argument.
- `npm run check` exit 0, `npm test` exit 0 (3624 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)