### PR TITLE
Source membership modes from ISUPPORT PREFIX, not a hardcode (#486)

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -2243,6 +2243,134 @@ describe('channel mode display (status bar)', () => {
     expect(modes).not.toContain('secret');
   });
 
+  // #486: prefix/membership modes come from ISUPPORT PREFIX, not a hardcode.
+  // solanum/Libera declare `q` as a quiet LIST mode and leave it out of PREFIX;
+  // the old q/a/o/h/v hardcode routed `+q` into the member branch, dropping it
+  // before listModes() was consulted.
+  function solanumIsupport(conn: IrcConnection): void {
+    const options = conn.client.network.options as { CHANMODES?: unknown; PREFIX?: unknown };
+    // `q` in group A (list), and absent from PREFIX — solanum's actual shape.
+    options.CHANMODES = ['eIbq', 'k', 'flj', 'CFLMPQScgimnprstz'];
+    options.PREFIX = [
+      { symbol: '@', mode: 'o' },
+      { symbol: '+', mode: 'v' },
+    ];
+  }
+
+  it('routes solanum +q to the list-mode path, not the member-prefix path (#486)', () => {
+    const conn = makeConn();
+    solanumIsupport(conn);
+    const ch = conn.upsertChannel('#chan');
+    // A joined member whose nick is exactly the quiet's parameter. This is the
+    // case the hardcode got wrong: a bare-nick quiet matched a real member, so
+    // `troll` was handed a phantom owner-style `q` badge.
+    ch.members.set('troll', {
+      nick: 'troll',
+      modes: [],
+      away: false,
+      user: null,
+      host: null,
+      account: null,
+    });
+    const publish = vi.fn<(event: unknown) => void>();
+    conn.publish = publish;
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+n' }, { mode: '+q', param: 'troll' }],
+      raw_modes: '+nq',
+      raw_params: ['troll'],
+    });
+
+    // No phantom badge: +q never reached the member branch.
+    expect(ch.members.get('troll')?.modes).toEqual([]);
+    // And it was excluded from the status bar as the list mode it is.
+    const modes = latestModes(publish);
+    expect(modes).toContain('n');
+    expect(modes).not.toContain('q');
+  });
+
+  it('still treats +q as a member prefix when the server declares it in PREFIX', () => {
+    const conn = makeConn();
+    // UnrealIRCd-shaped: q IS an owner prefix here, and not a list mode.
+    const options = conn.client.network.options as { CHANMODES?: unknown; PREFIX?: unknown };
+    options.CHANMODES = ['beI', 'k', 'l', 'imnpst'];
+    options.PREFIX = [
+      { symbol: '~', mode: 'q' },
+      { symbol: '@', mode: 'o' },
+      { symbol: '+', mode: 'v' },
+    ];
+    const ch = conn.upsertChannel('#chan');
+    ch.members.set('owner', {
+      nick: 'owner',
+      modes: [],
+      away: false,
+      user: null,
+      host: null,
+      account: null,
+    });
+    conn.publish = vi.fn<(event: unknown) => void>();
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+q', param: 'owner' }],
+      raw_modes: '+q',
+      raw_params: ['owner'],
+    });
+
+    expect(ch.members.get('owner')?.modes).toEqual(['q']);
+  });
+
+  it('falls back to the common prefix set before ISUPPORT PREFIX arrives', () => {
+    const conn = makeConn();
+    // No PREFIX declared yet (pre-005). +o must still land on the member.
+    const ch = conn.upsertChannel('#chan');
+    ch.members.set('bob', {
+      nick: 'bob',
+      modes: [],
+      away: false,
+      user: null,
+      host: null,
+      account: null,
+    });
+    conn.publish = vi.fn<(event: unknown) => void>();
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+o', param: 'bob' }],
+      raw_modes: '+o',
+      raw_params: ['bob'],
+    });
+
+    expect(ch.members.get('bob')?.modes).toEqual(['o']);
+  });
+
+  it('falls back rather than trusting a malformed PREFIX token', () => {
+    const conn = makeConn();
+    // irc-framework leaves the raw string in place when `(modes)symbols` fails
+    // to parse — Array.isArray, not truthiness, is what keeps this safe.
+    (conn.client.network.options as { PREFIX?: unknown }).PREFIX = 'garbage';
+    const ch = conn.upsertChannel('#chan');
+    ch.members.set('bob', {
+      nick: 'bob',
+      modes: [],
+      away: false,
+      user: null,
+      host: null,
+      account: null,
+    });
+    conn.publish = vi.fn<(event: unknown) => void>();
+
+    conn.client.emit('mode', {
+      target: '#chan',
+      modes: [{ mode: '+o', param: 'bob' }],
+      raw_modes: '+o',
+      raw_params: ['bob'],
+    });
+
+    expect(ch.members.get('bob')?.modes).toEqual(['o']);
+  });
+
   it('drops a channel mode when it is removed (-k)', () => {
     const conn = makeConn();
     conn.upsertChannel('#chan');

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -3436,7 +3436,10 @@ export class IrcConnection {
     const prefix = this.client.network?.options?.PREFIX as
       | { symbol: string; mode: string }[]
       | undefined;
-    if (!Array.isArray(prefix)) return DEFAULT_PREFIX_MODES;
+    // A FRESH Set on the fallback path too, matching listModes(). Handing out the shared
+    // module-level constant would let one connection's accidental mutation reach every other
+    // connection that ever fell back.
+    if (!Array.isArray(prefix)) return new Set(DEFAULT_PREFIX_MODES);
     return new Set(prefix.map((p) => p.mode).filter(Boolean));
   }
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -2325,13 +2325,14 @@ export class IrcConnection {
       let memberModesChanged = false;
       let chanModesChanged = false;
       const listModes = this.listModes();
+      const prefixModes = this.prefixModes();
       if (ch) {
         for (const m of eventModes) {
           if (!m || !m.mode) continue;
           const sign = m.mode[0];
           const letter = m.mode.slice(1);
           // Per-user prefix mode: lands on the member, not on the channel.
-          if (m.param && isPrefixMode(letter)) {
+          if (m.param && prefixModes.has(letter)) {
             const member = ch.members.get(m.param.toLowerCase());
             if (!member) continue;
             const set = new Set(member.modes);
@@ -3408,10 +3409,35 @@ export class IrcConnection {
   // This is the same categorisation weechat/irssi/gamja use. Parameter modes
   // like +k/+l are NOT list modes, so they still land in the (+...) display.
   // Member-prefix modes (o/v/h, plus q/a where an ircd uses them as prefixes)
-  // are filtered earlier by isPrefixMode(), so they never reach this set.
+  // are filtered earlier by prefixModes(), so they never reach this set.
   private listModes(): Set<string> {
     const chanmodes = this.client.network?.options?.CHANMODES as string[] | undefined;
     return new Set((chanmodes?.[0] ?? 'beI').split(''));
+  }
+
+  // Member-prefix (membership) modes, from the server's ISUPPORT PREFIX token —
+  // the same 005 origin listModes() reads CHANMODES from, so the two agree
+  // per-ircd. irc-framework parses `PREFIX=(ov)@+` into {symbol, mode} pairs
+  // (registration.js), and leaves the RAW STRING in place when the token is
+  // malformed — hence the Array.isArray check rather than a truthiness test.
+  //
+  // This used to be a hardcoded q/a/o/h/v set, which disagreed with solanum:
+  // there +q is a quiet LIST mode, not an owner prefix, so a live
+  // `MODE #chan +q <mask>` was routed into the member-prefix branch and dropped
+  // before listModes() was ever consulted — making listModes effectively dead
+  // code for `q`. It only ever LOOKED right because quiet masks (!/@/*) never
+  // match a member nick; a bare-nick quiet on a joined member would have minted
+  // a phantom owner badge.
+  //
+  // A server that declares an empty PREFIX genuinely has no membership modes,
+  // so an empty array is honoured rather than falling back (same intent as
+  // listModes' `??`). The fallback covers pre-005 and malformed tokens only.
+  private prefixModes(): Set<string> {
+    const prefix = this.client.network?.options?.PREFIX as
+      | { symbol: string; mode: string }[]
+      | undefined;
+    if (!Array.isArray(prefix)) return DEFAULT_PREFIX_MODES;
+    return new Set(prefix.map((p) => p.mode).filter(Boolean));
   }
 
   publishLag(): void {
@@ -5211,10 +5237,10 @@ export class IrcConnection {
   }
 }
 
-const PREFIX_MODES = new Set(['q', 'a', 'o', 'h', 'v']);
-function isPrefixMode(letter: string): boolean {
-  return PREFIX_MODES.has(letter);
-}
+// Pre-005 / malformed-PREFIX fallback for prefixModes(). The widest common set,
+// so a member mode isn't misread as a channel flag before ISUPPORT lands; once
+// the server declares PREFIX, that wins.
+const DEFAULT_PREFIX_MODES = new Set(['q', 'a', 'o', 'h', 'v']);
 
 // Decide how a channel +k / -k MODE change should update the persisted key.
 // Returns null for "leave the stored key alone" — the two cases that must NOT


### PR DESCRIPTION
Closes #486.

## The bug

`isPrefixMode` tested a fixed `q/a/o/h/v` set. That disagrees with solanum/Libera, where `+q` is a **quiet list mode** (CHANMODES group A), not an owner prefix.

Because `isPrefixMode('q')` returned true, a live `MODE #chan +q <mask>` was routed into the member-prefix branch, failed the member lookup, and was dropped silently — **before** the ISUPPORT-driven `listModes()` exclusion was ever consulted. That made `listModes` effectively dead code for `q`.

It only ever *looked* right because quiet masks (`!`/`@`/`*`) never match a member nick. A bare-nick quiet on a joined member would have handed that member a phantom owner-style badge.

## The fix

Source the set from `network.options.PREFIX` — the same 005 origin `listModes()` reads `CHANMODES` from, so the two now agree per-ircd. The new `prefixModes()` sits next to `listModes()` and mirrors its shape, including honouring a server-declared **empty** PREFIX rather than falling back over it (same intent as that method's `??`).

One wrinkle worth calling out: irc-framework leaves the **raw string** in `options.PREFIX` when the `(modes)symbols` token fails to parse (`registration.js:66-78` only replaces it on a successful match or an explicit empty). So the guard is `Array.isArray`, not a truthiness test — otherwise a malformed token would be spread into single-character garbage.

## Tests

Four cases, covering both directions so this can't be "fixed" by over-correcting:

- **solanum `+q` reaches the list path** — `q` in CHANMODES group A and absent from PREFIX, with a joined member whose nick is exactly the quiet's parameter. Asserts no phantom badge *and* exclusion from the status bar.
- **UnrealIRCd-shaped `+q` still lands on the member** when the server does declare it in PREFIX.
- **Pre-005 fallback** — `+o` still lands on the member with no PREFIX declared.
- **Malformed PREFIX falls back** rather than trusting the raw string.

Mutation-verified: reverting `prefixModes()` to return the hardcoded set fails the solanum test with `expected [ 'q' ] to deeply equal []` — the phantom badge. The other three still pass under that mutation by design; they guard the fallback and the over-correction, not the original bug.

`npm run check` clean, full suite green (260 files / 3628 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)