### PR TITLE
Hoist the per-row notify-always lookup out of N-row decorates (#679)

### DIFF
--- a/server/services/verbs/recentMessages.ts
+++ b/server/services/verbs/recentMessages.ts
@@ -5,6 +5,7 @@ import { registerVerb } from '../verbRegistry.js';
 import { listMessagesCounted, hasOlderRow } from '../../db/messages.js';
 import { asPageUnit } from '../../../shared/eventFilter.js';
 import { decorateMessage } from '../wsHub.js';
+import { getChannelNotifyAlways } from '../../db/channelNotify.js';
 
 /** Authenticated caller context passed to every verb handler. */
 interface VerbContext {
@@ -67,7 +68,10 @@ registerVerb({
       before,
       limit,
     });
-    const events = rows.map((e) => decorateMessage(ctx.userId, e));
+    // One buffer per call, so the notify-always answer is constant across the
+    // page — hoist it out of the map (#679).
+    const notifyAlways = getChannelNotifyAlways(ctx.userId, networkId, target);
+    const events = rows.map((e) => decorateMessage(ctx.userId, e, notifyAlways));
     const oldestId = events.length ? events[0].id : 0;
     return {
       messages: events,

--- a/server/services/verbs/recentMessages.ts
+++ b/server/services/verbs/recentMessages.ts
@@ -4,8 +4,7 @@
 import { registerVerb } from '../verbRegistry.js';
 import { listMessagesCounted, hasOlderRow } from '../../db/messages.js';
 import { asPageUnit } from '../../../shared/eventFilter.js';
-import { decorateMessage } from '../wsHub.js';
-import { getChannelNotifyAlways } from '../../db/channelNotify.js';
+import { decorateMessage, bufferNotifyAlways } from '../wsHub.js';
 
 /** Authenticated caller context passed to every verb handler. */
 interface VerbContext {
@@ -70,7 +69,7 @@ registerVerb({
     });
     // One buffer per call, so the notify-always answer is constant across the
     // page — hoist it out of the map (#679).
-    const notifyAlways = getChannelNotifyAlways(ctx.userId, networkId, target);
+    const notifyAlways = bufferNotifyAlways(ctx.userId, networkId, target);
     const events = rows.map((e) => decorateMessage(ctx.userId, e, notifyAlways));
     const oldestId = events.length ? events[0].id : 0;
     return {

--- a/server/services/verbs/searchMessages.ts
+++ b/server/services/verbs/searchMessages.ts
@@ -75,6 +75,8 @@ registerVerb({
       limit: limit + 1,
     });
     const hasMore = rows.length > limit;
+    // NOT hoisted (#679): search spans buffers, so unlike every other N-row
+    // decorate site the notify-always answer genuinely varies per row.
     const messages = (hasMore ? rows.slice(0, limit) : rows).map((e) =>
       decorateMessage(ctx.userId, e),
     );

--- a/server/services/wsHub.notifyAlways.test.ts
+++ b/server/services/wsHub.notifyAlways.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// #679: decorateMessage's notify-always lookup is a DB point query whose
+// arguments (userId + networkId + target) are identical for every row of a
+// buffer. Every N-row caller hoists it; these tests pin the call COUNT, which is
+// the only thing that regresses if someone later drops the argument back out of
+// a .map(). A behaviour-only test cannot catch that — the naive and hoisted
+// paths return the same answer, just N times instead of once.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { setupTestDb } from '../test-utils/testApp.js';
+
+const testDb = setupTestDb('wshub-notify-hoist');
+
+// Spy at the module boundary: the statement inside channelNotify.js is
+// module-private, and wsHub imports the function by name, so this is the seam
+// where the per-row calls are countable.
+vi.mock('../db/channelNotify.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db/channelNotify.js')>();
+  return {
+    ...actual,
+    getChannelNotifyAlways: vi.fn<typeof actual.getChannelNotifyAlways>(
+      actual.getChannelNotifyAlways,
+    ),
+  };
+});
+
+let createUser: typeof import('../db/users.js').createUser;
+let createNetwork: typeof import('../db/networks.js').createNetwork;
+let insertMessage: typeof import('../db/messages.js').insertMessage;
+let buffers: typeof import('../db/buffers.js');
+let channelNotify: typeof import('../db/channelNotify.js');
+let buildBufferBacklog: typeof import('./wsHub.js').buildBufferBacklog;
+let buildResumeSlice: typeof import('./wsHub.js').buildResumeSlice;
+
+let userId: number;
+let networkId: number;
+
+beforeAll(async () => {
+  ({ createUser } = await import('../db/users.js'));
+  ({ createNetwork } = await import('../db/networks.js'));
+  ({ insertMessage } = await import('../db/messages.js'));
+  buffers = await import('../db/buffers.js');
+  channelNotify = await import('../db/channelNotify.js');
+  ({ buildBufferBacklog, buildResumeSlice } = await import('./wsHub.js'));
+
+  userId = createUser('alice').id;
+  networkId = createNetwork(userId, {
+    name: 'libera',
+    host: 'h',
+    port: 6697,
+    tls: true,
+    nick: 'alice',
+  })!.id;
+});
+
+afterAll(() => testDb.cleanup());
+
+function seed(target: string, text: string): number {
+  buffers.ensureExists(userId, networkId, target);
+  return Number(
+    insertMessage({
+      networkId,
+      target,
+      time: new Date().toISOString(),
+      type: 'message',
+      nick: 'bob',
+      text,
+      self: false,
+    }).id,
+  );
+}
+
+const spy = () => vi.mocked(channelNotify.getChannelNotifyAlways);
+
+describe('notify-always lookups are hoisted out of N-row decorates (#679)', () => {
+  it('queries once for a 25-row backlog, not once per row', () => {
+    for (let i = 0; i < 25; i++) seed('#hoist', `line ${i}`);
+    channelNotify.setChannelNotifyAlways(userId, networkId, '#hoist', true);
+    spy().mockClear();
+
+    const frame = buildBufferBacklog(userId, networkId, '#hoist');
+
+    const events = frame.events as Array<{ notifyAlways?: boolean }>;
+    expect(events).toHaveLength(25);
+    // The answer still reaches every row...
+    expect(events.every((e) => e.notifyAlways === true)).toBe(true);
+    // ...from a single lookup.
+    expect(spy()).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a false answer false (the hoisted value must not fall through)', () => {
+    for (let i = 0; i < 5; i++) seed('#quiet', `line ${i}`);
+    spy().mockClear();
+
+    const frame = buildBufferBacklog(userId, networkId, '#quiet');
+
+    const events = frame.events as Array<{ notifyAlways?: boolean }>;
+    expect(events).toHaveLength(5);
+    expect(events.every((e) => e.notifyAlways === false)).toBe(true);
+    expect(spy()).toHaveBeenCalledTimes(1);
+  });
+
+  it('queries once per resume slice, whichever branch ships it', () => {
+    const ids: number[] = [];
+    for (let i = 0; i < 20; i++) ids.push(seed('#resume', `line ${i}`));
+    channelNotify.setChannelNotifyAlways(userId, networkId, '#resume', true);
+
+    // Gap branch: everything after the 5th row.
+    spy().mockClear();
+    const gap = buildResumeSlice(userId, networkId, '#resume', ids[4]);
+    expect(gap.events).toHaveLength(15);
+    expect(gap.events.every((e) => e.notifyAlways === true)).toBe(true);
+    expect(spy()).toHaveBeenCalledTimes(1);
+
+    // Latest branch: fresh connect, no cursor.
+    spy().mockClear();
+    const latest = buildResumeSlice(userId, networkId, '#resume', 0);
+    expect(latest.events).toHaveLength(20);
+    expect(latest.events.every((e) => e.notifyAlways === true)).toBe(true);
+    expect(spy()).toHaveBeenCalledTimes(1);
+  });
+
+  it('a DM buffer still costs at most one lookup', () => {
+    for (let i = 0; i < 10; i++) seed('carol', `line ${i}`);
+    spy().mockClear();
+
+    const frame = buildBufferBacklog(userId, networkId, 'carol');
+
+    const events = frame.events as Array<{ notifyAlways?: boolean }>;
+    expect(events).toHaveLength(10);
+    // notifyAlways is channel-only, so a DM is false regardless.
+    expect(events.every((e) => e.notifyAlways === false)).toBe(true);
+    expect(spy().mock.calls.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/server/services/wsHub.notifyAlways.test.ts
+++ b/server/services/wsHub.notifyAlways.test.ts
@@ -122,7 +122,11 @@ describe('notify-always lookups are hoisted out of N-row decorates (#679)', () =
     expect(spy()).toHaveBeenCalledTimes(1);
   });
 
-  it('a DM buffer still costs at most one lookup', () => {
+  // ⚠ ZERO, not "at most one". notify-always is a channel setting, and `decorateMessage`
+  // short-circuits before the query for anything else — so hoisting UNCONDITIONALLY would turn no
+  // queries into one for every DM and `:server:` slice, making the commonest backlog slower in
+  // the name of a speedup. The guard inside `bufferNotifyAlways` is what these pin.
+  it('never queries at all for a DM buffer', () => {
     for (let i = 0; i < 10; i++) seed('carol', `line ${i}`);
     spy().mockClear();
 
@@ -130,8 +134,26 @@ describe('notify-always lookups are hoisted out of N-row decorates (#679)', () =
 
     const events = frame.events as Array<{ notifyAlways?: boolean }>;
     expect(events).toHaveLength(10);
-    // notifyAlways is channel-only, so a DM is false regardless.
     expect(events.every((e) => e.notifyAlways === false)).toBe(true);
-    expect(spy().mock.calls.length).toBeLessThanOrEqual(1);
+    expect(spy()).not.toHaveBeenCalled();
+  });
+
+  it('never queries at all for a :server: buffer', () => {
+    for (let i = 0; i < 5; i++) seed(':server:', `line ${i}`);
+    spy().mockClear();
+
+    buildBufferBacklog(userId, networkId, ':server:');
+
+    expect(spy()).not.toHaveBeenCalled();
+  });
+
+  it('never queries for a DM resume slice either', () => {
+    for (let i = 0; i < 8; i++) seed('dave', `line ${i}`);
+    spy().mockClear();
+
+    const slice = buildResumeSlice(userId, networkId, 'dave', 0);
+
+    expect(slice.events).toHaveLength(8);
+    expect(spy()).not.toHaveBeenCalled();
   });
 });

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -512,6 +512,37 @@ function ignoreVerdictForEvent(
 // authoritative delivery gate — the union of those signals WITH the ignore/mute
 // veto folded in (see below), consulted by push delivery and by every live
 // client (web toast, native buzz).
+/**
+ * Whether a target can carry a notify-always setting at all.
+ *
+ * ONE definition, consulted by `decorateMessage`'s per-event guard and by `bufferNotifyAlways`
+ * below, so the guard and the hoisted lookup cannot drift into disagreeing — which would show up
+ * either as a query nothing reads, or as a hoisted answer the guard then throws away.
+ */
+function notifyAlwaysApplies(target: string): boolean {
+  return target.startsWith('#');
+}
+
+/**
+ * The notify-always answer for a whole single-buffer slice, or `undefined` when the target can't
+ * have one.
+ *
+ * ⚠ The guard matters as much as the hoist. `decorateMessage` short-circuits before the query for
+ * DMs and `:server:` buffers, so hoisting unconditionally would turn ZERO queries into one for
+ * exactly those slices — making the common DM backlog slower, not faster, in the name of a
+ * speedup. `undefined` keeps the per-event guard the authority: the `??` it feeds is only ever
+ * reached once `isChannel` has already passed, so it can never trigger the query it replaced.
+ */
+export function bufferNotifyAlways(
+  userId: number,
+  networkId: number,
+  target: string,
+): boolean | undefined {
+  return notifyAlwaysApplies(target)
+    ? getChannelNotifyAlways(userId, networkId, target)
+    : undefined;
+}
+
 // `channelNotifyAlways` lets a caller that decorates MANY rows of ONE buffer
 // pass the notify-always answer in, instead of paying a DB point query per row
 // for a value that's constant across the slice (#679 — 52k lookups / 51.9ms on
@@ -529,7 +560,7 @@ export function decorateMessage(
   const matchedRuleId = event.matchedRuleId ?? null;
   const dm = isDirect(event) && !event.self;
   const target = event.target || '';
-  const isChannel = target.startsWith('#');
+  const isChannel = notifyAlwaysApplies(target);
   // CTCP request/reply/echo lines are status, not conversation — never notify,
   // even when routed to a notify-always channel (otherwise running /ctcp from
   // such a channel would self-notify on your own echo). (#263)
@@ -829,7 +860,7 @@ export function buildBufferBacklog(
 ): WsPayload {
   const conn = ircManager.getConnection(userId, networkId);
   const rows = listMessagesCounted(networkId, target, countBy, { limit: 200 });
-  const notifyAlways = getChannelNotifyAlways(userId, networkId, target);
+  const notifyAlways = bufferNotifyAlways(userId, networkId, target);
   const events = rows.map((e) => decorateMessage(userId, e, notifyAlways));
   const oldestId = rows.length ? (rows[0].id ?? 0) : 0;
   return {
@@ -982,7 +1013,7 @@ export function buildResumeSlice(
   sinceId: number,
 ): { events: DecoratedEvent[]; reset: boolean; mode: BacklogMode; hasMoreOlder: boolean } {
   // One query for the whole slice, whichever branch below ships it (#679).
-  const notifyAlways = getChannelNotifyAlways(userId, networkId, target);
+  const notifyAlways = bufferNotifyAlways(userId, networkId, target);
   if (sinceId > 0) {
     // Ask whether the gap overflows BEFORE reading it. The truncation test used to
     // be "read RESUME_GAP_CAP rows, and if we filled the cap, is there another one
@@ -3462,7 +3493,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         };
         // Every mode below pages ONE buffer, so the notify-always answer is
         // constant across whichever slice we ship (#679).
-        const histNotifyAlways = getChannelNotifyAlways(userId, histNetworkId, histTarget);
+        const histNotifyAlways = bufferNotifyAlways(userId, histNetworkId, histTarget);
 
         if (mode === 'around') {
           // Detached jump path. The DB lookup enforces (networkId, target);

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -512,7 +512,19 @@ function ignoreVerdictForEvent(
 // authoritative delivery gate — the union of those signals WITH the ignore/mute
 // veto folded in (see below), consulted by push delivery and by every live
 // client (web toast, native buzz).
-export function decorateMessage(userId: number, event: MessageEvent): DecoratedEvent {
+// `channelNotifyAlways` lets a caller that decorates MANY rows of ONE buffer
+// pass the notify-always answer in, instead of paying a DB point query per row
+// for a value that's constant across the slice (#679 — 52k lookups / 51.9ms on
+// a 104-buffer resume, vs 19 lookups / 0.047ms hoisted). Only the DB answer is
+// hoisted; the per-event guards below (CTCP, self, channel) still run per row.
+// Omit it on the single-event live path, which is what the function was written
+// for, and on any slice spanning multiple buffers (search results) where the
+// answer genuinely varies per row.
+export function decorateMessage(
+  userId: number,
+  event: MessageEvent,
+  channelNotifyAlways?: boolean,
+): DecoratedEvent {
   const matched = !!event.matched;
   const matchedRuleId = event.matchedRuleId ?? null;
   const dm = isDirect(event) && !event.self;
@@ -526,7 +538,9 @@ export function decorateMessage(userId: number, event: MessageEvent): DecoratedE
     !isStatus &&
     isChannel &&
     !event.self &&
-    getChannelNotifyAlways(userId, event.networkId, target);
+    // `??`, not `||`: a hoisted `false` is a real answer and must not fall
+    // through to the query it was computed to replace.
+    (channelNotifyAlways ?? getChannelNotifyAlways(userId, event.networkId, target));
   // Content says this line is notification-worthy: a highlight, a DM, or a
   // notify-always channel.
   const contentNotify = !isStatus && (matched || dm || notifyAlways);
@@ -815,7 +829,8 @@ export function buildBufferBacklog(
 ): WsPayload {
   const conn = ircManager.getConnection(userId, networkId);
   const rows = listMessagesCounted(networkId, target, countBy, { limit: 200 });
-  const events = rows.map((e) => decorateMessage(userId, e));
+  const notifyAlways = getChannelNotifyAlways(userId, networkId, target);
+  const events = rows.map((e) => decorateMessage(userId, e, notifyAlways));
   const oldestId = rows.length ? (rows[0].id ?? 0) : 0;
   return {
     kind: 'backlog',
@@ -966,6 +981,8 @@ export function buildResumeSlice(
   target: string,
   sinceId: number,
 ): { events: DecoratedEvent[]; reset: boolean; mode: BacklogMode; hasMoreOlder: boolean } {
+  // One query for the whole slice, whichever branch below ships it (#679).
+  const notifyAlways = getChannelNotifyAlways(userId, networkId, target);
   if (sinceId > 0) {
     // Ask whether the gap overflows BEFORE reading it. The truncation test used to
     // be "read RESUME_GAP_CAP rows, and if we filled the cap, is there another one
@@ -987,7 +1004,7 @@ export function buildResumeSlice(
       // older than what we shipped).
       const anchor = gap.length ? (gap[0].id ?? sinceId + 1) : sinceId + 1;
       return {
-        events: gap.map((e) => decorateMessage(userId, e)),
+        events: gap.map((e) => decorateMessage(userId, e, notifyAlways)),
         reset: false,
         mode: 'append',
         hasMoreOlder: hasOlderRow(networkId, target, anchor),
@@ -998,7 +1015,7 @@ export function buildResumeSlice(
   const latest = listMessages(networkId, target, { limit: RESUME_LATEST_LIMIT });
   const oldestId = latest.length ? (latest[0].id ?? 0) : 0;
   return {
-    events: latest.map((e) => decorateMessage(userId, e)),
+    events: latest.map((e) => decorateMessage(userId, e, notifyAlways)),
     // Only signal a replace on a real resume. First connect (sinceId<=0) lands
     // on the client's empty-buffer seed path, which already replaces — flagging
     // reset there is harmless but needlessly noisy.
@@ -3443,6 +3460,9 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           token,
           speakers,
         };
+        // Every mode below pages ONE buffer, so the notify-always answer is
+        // constant across whichever slice we ship (#679).
+        const histNotifyAlways = getChannelNotifyAlways(userId, histNetworkId, histTarget);
 
         if (mode === 'around') {
           // Detached jump path. The DB lookup enforces (networkId, target);
@@ -3461,7 +3481,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           // clamped 1..500). Total slice length tops out at 2*limit + 1.
           const halfLimit = limit;
           const slice = listMessagesAround(histNetworkId, histTarget, anchorId, halfLimit, countBy);
-          const events = slice.events.map((e) => decorateMessage(userId, e));
+          const events = slice.events.map((e) => decorateMessage(userId, e, histNotifyAlways));
           send(ws, {
             ...baseReply,
             anchorId,
@@ -3483,7 +3503,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
             break;
           }
           const rows = listMessagesCounted(histNetworkId, histTarget, countBy, { afterId, limit });
-          const events = rows.map((e) => decorateMessage(userId, e));
+          const events = rows.map((e) => decorateMessage(userId, e, histNotifyAlways));
           const newestId = events.length ? events[events.length - 1].id : afterId;
           send(ws, {
             ...baseReply,
@@ -3505,7 +3525,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
           // restored for a shell (fresh-connect shells omit it, so this is the
           // only place a reloaded client gets its per-buffer recall back).
           const rows = listMessagesCounted(histNetworkId, histTarget, countBy, { limit });
-          const events = rows.map((e) => decorateMessage(userId, e));
+          const events = rows.map((e) => decorateMessage(userId, e, histNotifyAlways));
           const oldestId = events.length ? events[0].id : 0;
           send(ws, {
             ...baseReply,


### PR DESCRIPTION
Closes #679.

## The problem

`decorateMessage` resolved `notifyAlways` with `getChannelNotifyAlways(userId, event.networkId, target)` — a DB point query whose arguments are **identical for every row of a buffer**. Every path that maps it over a slice issued N queries for one answer.

From the issue's measurements:

| | lookups | time |
|---|---|---|
| 19 buffers × 500-row gap | 9,500 | 10.1 ms |
| 104 buffers × 500-row gap | 52,000 | 51.9 ms |
| hoisted to once per buffer | 19 | 0.047 ms |

## The change

`decorateMessage` takes an optional precomputed answer; each single-buffer caller resolves it once:

- `buildBufferBacklog`
- `buildResumeSlice` — both the gap and latest branches
- the `history` handler — hoisted once before the mode split, so `around`/`after`/`latest` all share it
- the `recentMessages` verb

Only the DB answer is hoisted. The per-event guards (CTCP status, `self`, channel) still run per row, so behaviour is unchanged.

The single-event live path is untouched — one event, one query, which is what the function was written for.

`searchMessages` is **deliberately not hoisted**, and now carries a comment saying why: its results span buffers, so unlike every other N-row site the answer genuinely varies per row. Worth knowing before someone "finishes the job".

Hoisted rather than memoized inside `decorateMessage`: a memo would need invalidation on the settings write path (`upsertStmt`/`deleteStmt` in `db/channelNotify.ts`). The hoist avoids that entirely.

`ignoreVerdictForEvent` was checked and left alone — it's gated on `contentNotify` so most rows skip it, and `ignoreRulesService.getCompiled` is already cached.

## Tests

New `wsHub.notifyAlways.test.ts` pins the **call count**, which is the only thing that regresses here — a behaviour-only test can't catch it, because the naive and hoisted paths return the same answer, just N times instead of once.

Covers: a 25-row backlog querying once; a `false` answer staying false (guards `??` vs `||`, so a hoisted `false` can't fall back into the query it replaced); both resume branches; and a DM buffer costing at most one lookup.

Mutation-verified: dropping the argument back out of `buildBufferBacklog`'s `.map()` fails the count tests at 26 calls instead of 1.

`npm run check` clean, full suite green (261 files / 3628 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)