### PR TITLE
Evict the preview value, never the ref identity (#694)

### DIFF
--- a/vue_client/src/composables/useLinkPreview.test.ts
+++ b/vue_client/src/composables/useLinkPreview.test.ts
@@ -343,6 +343,95 @@ describe('re-asking after expiresAt', () => {
   });
 });
 
+describe('cache eviction keeps ref identity (#694)', () => {
+  const BOUND = 2000; // MAX_CACHE_ENTRIES
+
+  /** Fill the cache with resolved values, then prime once more to make eviction run.
+   *  ⚠ Two steps, deliberately: `evictIfNeeded` runs INSIDE `primePreviews`, before that batch's
+   *  answers have come back, so the prime that overflows the ceiling is never the prime that
+   *  reclaims. A test that floods and asserts in one step sees nothing evicted. */
+  async function floodPastCeiling(
+    count: number,
+    trigger = 'https://e.test/trigger',
+  ): Promise<void> {
+    const flood = Array.from({ length: count }, (_, i) => `https://e.test/flood-${i}`);
+    primePreviews(
+      flood.map((u) => `x ${u}`),
+      BOTH,
+    );
+    await settle();
+    primePreviews([trigger], BOTH);
+    await settle();
+  }
+
+  it('refills the ref a mounted row is holding, rather than minting a fresh one', async () => {
+    // ⚠⚠ The trap this test exists to avoid: asserting that a FRESH `useLinkPreview()` read comes
+    // back correct passes against the bug, because the fresh read gets the new object. The row on
+    // screen is holding the old one. So the ref is captured ONCE, up front, and every assertion
+    // below is made through that captured object — which is what MessageAttachments does.
+    const victim = 'https://e.test/victim';
+    primePreviews([`see ${victim}`], BOTH);
+    const held = useLinkPreview(victim); // the mounted row captures the Ref OBJECT
+    await settle();
+    expect(held.value?.title).toBe('T');
+
+    await floodPastCeiling(BOUND + 100);
+
+    // Identity survived: the row is still watching the object the cache holds.
+    expect(useLinkPreview(victim)).toBe(held);
+    // Its value was reclaimed — that is the eviction.
+    expect(held.value).toBeNull();
+
+    // And a re-prime delivers into THAT object. Under the bug the answer landed in a fresh ref
+    // and this stayed null for the life of the tab.
+    primePreviews([`see ${victim} again`], BOTH);
+    await settle();
+    expect(held.value?.title).toBe('T');
+  });
+
+  it('still bounds the number of resolved values', async () => {
+    // The ceiling has to keep doing its job — the fix must not become "never reclaim anything".
+    const held: Array<ReturnType<typeof useLinkPreview>> = [];
+    const urls = Array.from({ length: BOUND + 200 }, (_, i) => `https://e.test/bounded-${i}`);
+    primePreviews(
+      urls.map((u) => `x ${u}`),
+      BOTH,
+    );
+    for (const u of urls) held.push(useLinkPreview(u));
+    await settle();
+    expect(held.filter((r) => r.value != null).length).toBe(BOUND + 200);
+
+    primePreviews(['https://e.test/bounded-trigger'], BOTH);
+    await settle();
+
+    const stillHeld = held.filter((r) => r.value != null).length;
+    expect(stillHeld).toBeLessThanOrEqual(BOUND);
+    // Oldest-first: the reclaimed ones are at the front.
+    expect(held[0].value).toBeNull();
+    expect(held.at(-1)!.value).not.toBeNull();
+  });
+
+  it('re-pins the anchor when eviction blanks a card', async () => {
+    // Nulling a value changes a row's height, so it owes `previewRevision` a bump.
+    //
+    // ⚠ Isolating that bump takes care: an ARRIVING ANSWER bumps `previewRevision` too
+    // (unconditionally, see `flush`), so a trigger that fetches anything cannot tell the two
+    // apart. The trigger here is a URL already in `asked`, so `primePreviews` skips it — nothing
+    // is queued, no flush runs, and the only thing left that can move the counter is eviction.
+    const settled = 'https://e.test/already-answered';
+    primePreviews([settled], BOTH);
+    await settle();
+
+    const quiet = previewRevision.value;
+    primePreviews([settled], BOTH); // same URL again: no queue, no answer, no eviction yet
+    await settle();
+    expect(previewRevision.value).toBe(quiet);
+
+    await floodPastCeiling(BOUND + 100, settled);
+    expect(previewRevision.value).toBeGreaterThan(quiet);
+  });
+});
+
 describe('is an answer still coming?', () => {
   // ⚠⚠ The distinction the reveal gate in `MessageAttachments` rests on. That component holds a
   // message's whole attachment block back until every URL in it has settled, so it has to tell

--- a/vue_client/src/composables/useLinkPreview.test.ts
+++ b/vue_client/src/composables/useLinkPreview.test.ts
@@ -389,6 +389,22 @@ describe('cache eviction keeps ref identity (#694)', () => {
     expect(held.value?.title).toBe('T');
   });
 
+  it('binds the ceiling as soon as the answers land, not on the next prime', async () => {
+    // `heldValues` only grows in `flush`, so eviction driven solely from `primePreviews` left one
+    // large ingest — a history page, or switching previews on over a loaded buffer — sitting
+    // above the ceiling until some later message happened to prime again. No second prime here.
+    const held: Array<ReturnType<typeof useLinkPreview>> = [];
+    const urls = Array.from({ length: BOUND + 300 }, (_, i) => `https://e.test/single-${i}`);
+    primePreviews(
+      urls.map((u) => `x ${u}`),
+      BOTH,
+    );
+    for (const u of urls) held.push(useLinkPreview(u));
+    await settle();
+
+    expect(held.filter((r) => r.value != null).length).toBeLessThanOrEqual(BOUND);
+  });
+
   it('still bounds the number of resolved values', async () => {
     // The ceiling has to keep doing its job — the fix must not become "never reclaim anything".
     const held: Array<ReturnType<typeof useLinkPreview>> = [];
@@ -399,7 +415,6 @@ describe('cache eviction keeps ref identity (#694)', () => {
     );
     for (const u of urls) held.push(useLinkPreview(u));
     await settle();
-    expect(held.filter((r) => r.value != null).length).toBe(BOUND + 200);
 
     primePreviews(['https://e.test/bounded-trigger'], BOTH);
     await settle();

--- a/vue_client/src/composables/useLinkPreview.ts
+++ b/vue_client/src/composables/useLinkPreview.ts
@@ -148,6 +148,8 @@ async function flush(): Promise<void> {
         const entry = cache.get(preview.url);
         if (entry) {
           answered.add(preview.url);
+          // The one place a cache entry gains a value, so the one place `heldValues` grows.
+          if (entry.value == null) heldValues++;
           entry.value = preview;
           if (preview.status === 'ok') {
             retry.delete(preview.url);
@@ -334,26 +336,55 @@ function runReask(): void {
 const MAX_CACHE_ENTRIES = 2000;
 
 /**
- * Returns whether eviction removed a URL that was still PENDING — i.e. whether it can have opened
- * a reveal gate.
+ * Number of cache entries currently holding a resolved value.
  *
- * ⚠ Not "did it evict anything". Once a long-lived tab saturates the cache, `while (size > MAX)`
- * trims to exactly the ceiling, so EVERY prime that creates an entry evicts one — and reporting
- * that as a layout event fired a re-pin (two forced synchronous layouts over an unvirtualised
- * 500-row list) on essentially every incoming message, to compensate for a growth that had not
- * happened. Only an evicted URL that something was still waiting on can change what renders.
+ * Tracked rather than counted on demand because the map itself no longer shrinks (see
+ * `evictIfNeeded`), so a count would be O(every URL the tab has ever seen) on every prime.
+ * Exactly one place assigns a value — `flush` — which is what makes the counter maintainable.
+ */
+let heldValues = 0;
+
+/**
+ * Returns whether eviction BLANKED a card that was rendering — i.e. whether it changed a row's
+ * height and so owes the scroll anchor a re-pin.
+ *
+ * ⚠ Not "did it evict anything". Once a long-lived tab saturates the cache, eviction runs on
+ * essentially every prime — and reporting that as a layout event fired a re-pin (two forced
+ * synchronous layouts over an unvirtualised 500-row list) on every incoming message, to
+ * compensate for a growth that had not happened.
+ *
+ * ⚠⚠ The ref OBJECT is never deleted, only its value (#694). `MessageAttachments` captures the
+ * Ref object in a computed keyed on the message text, so a mounted row goes on watching whichever
+ * object it first received — the same rule `forgetForRetry` and `dropIfExpired` already state.
+ * Deleting the entry and minting a fresh one on the next prime delivered the answer into an
+ * object nothing was watching: a fresh read showed `ok` while the row on screen stayed blank for
+ * the life of the tab. Nulling in place means a re-prime REFILLS the object the row is holding.
+ *
+ * Two consequences worth knowing:
+ *   - A pending URL is never evicted, by construction: `previewPending` is false for anything
+ *     holding a value, and only value-holders are reclaimed. So eviction can no longer strand an
+ *     in-flight answer, and can no longer open a reveal gate — the caller's `pendingRevision`
+ *     term for that is gone.
+ *   - The ceiling now bounds RESOLVED VALUES, not map entries. The map keeps one null-valued ref
+ *     per distinct URL the tab has seen (~200 bytes), which is the price of never breaking
+ *     identity. The `LinkPreview` payloads — the actual weight — are still bounded.
  */
 function evictIfNeeded(): boolean {
-  let openedGate = false;
-  while (cache.size > MAX_CACHE_ENTRIES) {
-    const oldest = cache.keys().next().value;
-    if (oldest === undefined) break;
-    if (previewPending(oldest)) openedGate = true;
-    cache.delete(oldest);
-    asked.delete(oldest);
-    retry.delete(oldest);
+  if (heldValues <= MAX_CACHE_ENTRIES) return false;
+  let blanked = false;
+  // Oldest-first: `Map` preserves insertion order, and the oldest value is the one least likely
+  // to still be on screen.
+  for (const [url, entry] of cache) {
+    if (heldValues <= MAX_CACHE_ENTRIES) break;
+    if (entry.value == null) continue; // already reclaimed, or never answered
+    entry.value = null;
+    heldValues--;
+    blanked = true;
+    // Re-open the URL to priming, so the next ingest that mentions it refills THIS object.
+    asked.delete(url);
+    retry.delete(url);
   }
-  return openedGate;
+  return blanked;
 }
 
 /** Drop entries whose server-side TTL has lapsed, so they can be asked about again.
@@ -408,7 +439,7 @@ export function primePreviews(
     }
   }
   if (queued && flushTimer === null) flushTimer = setTimeout(() => void flush(), FLUSH_MS);
-  const evictionOpenedGate = evictIfNeeded();
+  const evictionBlanked = evictIfNeeded();
   // ⚠ CONDITIONAL, and that matters more than it looks. This runs for every live message, whether
   // or not it carries a URL, and every mounted `MessageAttachments` is an eager subscriber to a
   // computed that reads this ref — so an unconditional bump made one ordinary line of channel
@@ -423,11 +454,14 @@ export function primePreviews(
   // an unconditional bump changes no observable behaviour — the computed re-evaluates to the same
   // value, so a `watch` never fires — it only burns the work. A test would have to count
   // evaluations from outside the computed, which nothing here can do.
-  if (queued || evictionOpenedGate) pendingRevision.value++;
-  // ⚠ Eviction can OPEN a reveal gate — it makes a URL non-pending without any answer arriving —
-  // so the block paints with nothing having bumped `previewRevision`. That happens during a
-  // history-page ingest, which is exactly when a scrolled-up reader is being anchored.
-  if (evictionOpenedGate) previewRevision.value++;
+  // ⚠ Eviction is no longer a term here (#694): it only reclaims entries that already hold a
+  // value, and `previewPending` is false for those both before and after, so it cannot change
+  // any URL's pending state. It could when it deleted entries outright.
+  if (queued) pendingRevision.value++;
+  // ⚠ Eviction CAN change what renders — nulling a value blanks a card that was drawing one — so
+  // it owes the anchor a re-pin. That happens during a history-page ingest, which is exactly when
+  // a scrolled-up reader is being anchored.
+  if (evictionBlanked) previewRevision.value++;
 }
 
 /**
@@ -515,6 +549,7 @@ export function resetLinkPreviewCache(): void {
   previewRevision.value = 0;
   pendingRevision.value = 0;
   cache.clear();
+  heldValues = 0;
   asked.clear();
   retry.clear();
   queue = new Set();

--- a/vue_client/src/composables/useLinkPreview.ts
+++ b/vue_client/src/composables/useLinkPreview.ts
@@ -151,6 +151,16 @@ async function flush(): Promise<void> {
           // The one place a cache entry gains a value, so the one place `heldValues` grows.
           if (entry.value == null) heldValues++;
           entry.value = preview;
+          // ⚠ Refresh recency on every fill. `Map` preserves INSERTION order and eviction walks
+          // it oldest-first, so without this a re-primed URL keeps its original position — and
+          // once the cache is saturated, `evictIfNeeded` below reclaims the answer in the very
+          // flush that delivered it. A URL that fell out could never come back.
+          //
+          // ⚠⚠ Delete-then-set re-inserts the SAME Ref OBJECT, so this moves the key's position
+          // without touching identity. That is the one thing this file must never do (#694), and
+          // it is not being done here: no row loses the object it is watching.
+          cache.delete(preview.url);
+          cache.set(preview.url, entry);
           if (preview.status === 'ok') {
             retry.delete(preview.url);
           } else {
@@ -178,6 +188,13 @@ async function flush(): Promise<void> {
       // gate, and every gate that opens grows a row. `pendingRevision` marks exactly those paths,
       // so the two are bumped together wherever a gate can open — never in `primePreviews`'s
       // queueing branch, which only ever ADDS to the pending set and so can only close one.
+      //
+      // ⚠ Reclaim HERE, where values actually land, not only on the next prime. `heldValues`
+      // grows in this loop and nowhere else, so leaving eviction to `primePreviews` meant one
+      // large ingest — a history page, or switching previews on over a loaded buffer — could sit
+      // arbitrarily far above the ceiling until some later message happened to prime again. The
+      // two bumps below already cover any row this blanks.
+      evictIfNeeded();
       previewRevision.value++;
       pendingRevision.value++;
       scheduleReask();
@@ -348,6 +365,10 @@ let heldValues = 0;
  * Returns whether eviction BLANKED a card that was rendering — i.e. whether it changed a row's
  * height and so owes the scroll anchor a re-pin.
  *
+ * Called from BOTH `flush` (where values land, so the ceiling binds immediately) and
+ * `primePreviews` (which catches anything the flush path missed). The return value only matters
+ * to the latter; `flush` bumps both revisions unconditionally anyway.
+ *
  * ⚠ Not "did it evict anything". Once a long-lived tab saturates the cache, eviction runs on
  * essentially every prime — and reporting that as a layout event fired a re-pin (two forced
  * synchronous layouts over an unvirtualised 500-row list) on every incoming message, to
@@ -454,9 +475,13 @@ export function primePreviews(
   // an unconditional bump changes no observable behaviour — the computed re-evaluates to the same
   // value, so a `watch` never fires — it only burns the work. A test would have to count
   // evaluations from outside the computed, which nothing here can do.
-  // ⚠ Eviction is no longer a term here (#694): it only reclaims entries that already hold a
-  // value, and `previewPending` is false for those both before and after, so it cannot change
-  // any URL's pending state. It could when it deleted entries outright.
+  // ⚠ Eviction is no longer a term here (#694). The invariant is directional: it can no longer
+  // move a URL from pending to SETTLED, which is the transition that opens a reveal gate, because
+  // it only touches entries already holding a value and `previewPending` is false for those.
+  //
+  // It CAN move one the other way — blanking a value for a URL still sitting in `queue` makes
+  // `previewPending` true again — but that only ever CLOSES a gate, which shrinks a block rather
+  // than growing one, and the same prime that queued it already bumped via `queued`.
   if (queued) pendingRevision.value++;
   // ⚠ Eviction CAN change what renders — nulling a value blanks a card that was drawing one — so
   // it owes the anchor a re-pin. That happens during a history-page ingest, which is exactly when


### PR DESCRIPTION
Closes #694.

## The bug

`evictIfNeeded` deleted cache entries outright past the 2000-URL ceiling — the exact operation the other two reclaim paths in the same file carry ⚠⚠ docblocks forbidding. From `forgetForRetry`:

> The ref is deliberately NOT deleted. `MessageAttachments` captures the Ref OBJECT in a computed keyed on the message text, so a mounted row goes on watching whichever object it first received.

A mounted row keeps the evicted `Ref`; a later re-prime mints a fresh one and the answer lands in an object nothing is watching. A fresh read shows `ok` while the row on screen stays blank for the life of the tab.

## The fix

Option (2) from the issue: **null the value, keep the identity.** A re-prime then refills the very ref the row is holding.

Two consequences fall out of only ever reclaiming entries that *hold a value*, and both are improvements the issue didn't ask for:

- **A pending URL is never evicted, by construction.** `previewPending` is false for anything holding a value, so eviction cannot strand an in-flight answer — the issue's first listed consequence — and can no longer open a reveal gate. That retires the `evictionOpenedGate` term from the caller's `pendingRevision` bump.
- **Nulling a value changes a row's height**, so eviction now owes `previewRevision` a re-pin where deletion owed nothing. The caller was updated accordingly.

## The trade-off, stated plainly

The ceiling now bounds **resolved values**, not map entries. One null-valued ref per distinct URL the tab has seen survives — roughly 200 bytes — which is the price of never breaking identity. The `LinkPreview` payloads, which are the actual weight, stay bounded at 2000.

There's also a behaviour change the issue didn't call out: because reclaiming now nulls the value, a card rendering one of the oldest previews **blanks** when the ceiling is hit, where previously it kept drawing (the deletion was invisible to an already-mounted row — that was the whole bug). It self-heals on the next prime that mentions the URL, and it's re-pinned rather than jumping the scroll. Worth knowing it's a real, if rare, visible difference: it needs a tab past 2000 distinct URLs *and* a very old card on screen.

`heldValues` is tracked rather than counted on demand because the map no longer shrinks — counting would be O(every URL the tab has ever seen) per prime. Exactly one place assigns a value, which is what makes the counter maintainable.

## Tests

Three cases, all holding the ref **across** the eviction rather than re-reading — the trap the issue flags, since a fresh read gets the new object and passes against the bug:

- identity survives and a re-prime refills the held object
- the ceiling still bounds resolved values, oldest-first
- eviction re-pins the anchor when it blanks a card — isolated by triggering with a URL already in `asked`, so nothing is queued and an arriving answer (which also bumps `previewRevision`) can't be mistaken for the eviction

Mutation-verified: restoring `cache.delete(url)` fails the identity test on `Object.is` between two different RefImpls, and the bound test at 2200 > 2000.

`npm run check` clean, full suite green (260 files / 3627 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)