### PR TITLE
Own the preview-toggle watcher at module level, not by a route (#693)

### DIFF
--- a/vue_client/src/composables/useSocket.previewToggles.test.ts
+++ b/vue_client/src/composables/useSocket.previewToggles.test.ts
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// #693: the preview re-prime watcher is created from inside `useSocket`'s `onMounted`, so it was
+// registered in the CALLING COMPONENT's effect scope and stopped when that component unmounted —
+// and the module-level `previewTogglesWired` latch then guaranteed it was never rebuilt. The
+// route that mounts first owns it; opening Settings destroys it.
+//
+// ⚠⚠ Every test here UNMOUNTS the owning component before flipping the toggle. Asserting that the
+// watcher fires while the first component is still mounted passes against the bug.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { defineComponent, nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+
+// `vi.hoisted`, because the `vi.mock` factory below is hoisted above ordinary top-level consts.
+const { primePreviews } = vi.hoisted(() => ({
+  primePreviews: vi.fn<(texts: unknown[], toggles: unknown) => void>(),
+}));
+vi.mock('./useLinkPreview.js', () => ({
+  primePreviews,
+  // `useSocket` imports the module, so anything else it pulls in must exist.
+  previewRevision: { value: 0 },
+}));
+
+// `open()` runs in the same onMounted; a fake keeps it from reaching the network.
+class FakeWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: (() => void) | null = null;
+  close(): void {}
+  send(): void {}
+  addEventListener(): void {}
+  removeEventListener(): void {}
+}
+
+import { useSocket, resetPreviewToggleWiring } from './useSocket.js';
+import { useConfigStore } from '../stores/config.js';
+import { useSettingsStore } from '../stores/settings.js';
+import { useBuffersStore } from '../stores/buffers.js';
+
+/** A route component, standing in for DesktopChat / Settings. */
+const RouteView = defineComponent({
+  setup() {
+    useSocket();
+    return () => null;
+  },
+});
+
+function seed({ inlineMedia = false, linkPreviews = false } = {}) {
+  setActivePinia(createPinia());
+  useConfigStore().features = { linkPreviews: true };
+  const settings = useSettingsStore();
+  settings.values = {
+    'chat.inline_media.enabled': inlineMedia,
+    'chat.link_previews.enabled': linkPreviews,
+  };
+  settings.loaded = true;
+  // One loaded buffer with a message, so a re-prime has something to prime.
+  const buffers = useBuffersStore();
+  buffers.buffers = {
+    'n1:#chan': {
+      networkId: 1,
+      target: '#chan',
+      messages: [{ id: 1, type: 'message', text: 'see https://e.test/x', target: '#chan' }],
+    },
+  } as unknown as typeof buffers.buffers;
+  return settings;
+}
+
+beforeEach(() => {
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  primePreviews.mockClear();
+  resetPreviewToggleWiring();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetPreviewToggleWiring();
+});
+
+describe('preview toggle re-prime survives a route change (#693)', () => {
+  it('still fires after the component that wired it has unmounted', async () => {
+    const settings = seed();
+
+    // 1. Load '/': the chat view mounts and calls useSocket().
+    const chat = mount(RouteView);
+    await nextTick();
+
+    // 2. Navigate to '/settings': the chat view is destroyed. No KeepAlive anywhere in the app,
+    //    so this is a real teardown, not a deactivation.
+    chat.unmount();
+    await nextTick();
+    primePreviews.mockClear();
+
+    // 3. The user switches link previews on, from the Settings route.
+    settings.values = { ...settings.values, 'chat.link_previews.enabled': true };
+    await nextTick();
+
+    // Under the bug: the watcher died with the chat view, the latch blocked a rebuild, and
+    // nothing primed — every existing message stayed without a preview until a full reload.
+    expect(primePreviews).toHaveBeenCalled();
+  });
+
+  it('fires for a second route that calls useSocket() after the first is gone', async () => {
+    const settings = seed();
+
+    const chat = mount(RouteView);
+    await nextTick();
+    chat.unmount();
+    await nextTick();
+
+    // The Settings route calls useSocket() too — and hits the wired-once latch.
+    const settingsView = mount(RouteView);
+    await nextTick();
+    primePreviews.mockClear();
+
+    settings.values = { ...settings.values, 'chat.inline_media.enabled': true };
+    await nextTick();
+
+    expect(primePreviews).toHaveBeenCalled();
+    settingsView.unmount();
+  });
+
+  it('primes every loaded buffer, not just the one on screen', async () => {
+    const settings = seed();
+    const buffers = useBuffersStore();
+    buffers.buffers = {
+      'n1:#a': {
+        networkId: 1,
+        target: '#a',
+        messages: [{ id: 1, type: 'message', text: 'https://e.test/a', target: '#a' }],
+      },
+      'n1:#b': {
+        networkId: 1,
+        target: '#b',
+        messages: [{ id: 2, type: 'message', text: 'https://e.test/b', target: '#b' }],
+      },
+    } as unknown as typeof buffers.buffers;
+
+    const chat = mount(RouteView);
+    await nextTick();
+    chat.unmount();
+    await nextTick();
+    primePreviews.mockClear();
+
+    settings.values = { ...settings.values, 'chat.link_previews.enabled': true };
+    await nextTick();
+
+    expect(primePreviews).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-prime when a setting is switched OFF', async () => {
+    const settings = seed({ linkPreviews: true });
+
+    const chat = mount(RouteView);
+    await nextTick();
+    chat.unmount();
+    await nextTick();
+    primePreviews.mockClear();
+
+    settings.values = { ...settings.values, 'chat.link_previews.enabled': false };
+    await nextTick();
+
+    // Turning one off needs no work — the rows simply stop rendering.
+    expect(primePreviews).not.toHaveBeenCalled();
+  });
+});

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import type { Ref } from 'vue';
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted, watch, effectScope } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { useAuthStore } from '../stores/auth.js';
@@ -492,40 +492,70 @@ function primeEventPreviews(
 let previewTogglesWired = false;
 
 /**
+ * Owns the preview-toggle watcher, so no component does.
+ *
+ * ⚠⚠ DETACHED, and that is the entire point (#693). `watch` registers with whatever effect scope
+ * is ACTIVE when it runs — and `wirePreviewToggles` is called from `useSocket`'s `onMounted`,
+ * which runs with the calling component's instance current. So the watcher was adopted by
+ * whichever route mounted first, and stopped when that route unmounted; the `previewTogglesWired`
+ * latch below then guaranteed it was never rebuilt. Declaring the watcher at module level did NOT
+ * fix that, because declaration site is not ownership.
+ *
+ * Created here rather than inside the function so it exists before any component does, and
+ * detached so it is never collected into a parent scope even if that changes.
+ */
+let previewToggleScope = effectScope(true);
+
+/**
  * Re-prime what is ALREADY in the store when a preview setting is switched on.
  *
- * ⚠⚠ Module-level and wired once, deliberately — this lived in `MessageList` and could not fire
- * for the path almost everyone uses. Settings is a separate route with no `KeepAlive`, so
- * opening it destroys the chat view and the watcher with it; coming back mounts a fresh one
- * with no `immediate`, which therefore never observes the flip. Nor does the remount re-ingest
- * anything, because the buffer already has messages. The net effect was that turning the
- * setting on in the settings UI left every existing message without a preview, forever — the
- * exact outcome the watcher was written to prevent. It only ever worked via `/set` and
- * cross-device sync, which is why it survived QA.
+ * ⚠⚠ Wired once and owned by a module-level scope, deliberately — this lived in `MessageList` and
+ * could not fire for the path almost everyone uses. Settings is a separate route with no
+ * `KeepAlive`, so opening it destroys the chat view; a watcher owned by that view goes with it,
+ * and coming back mounts a fresh one with no `immediate`, which therefore never observes the
+ * flip. Nor does the remount re-ingest anything, because the buffer already has messages. The net
+ * effect was that turning the setting on in the settings UI left every existing message without a
+ * preview, forever — the exact outcome the watcher was written to prevent. It only ever worked
+ * via `/set` and cross-device sync, which is why it survived QA.
  *
  * Every loaded buffer, not just the active one: `MessageList` is not keyed per buffer, so
  * priming only what happens to be on screen left every other buffer blank for the session.
+ *
+ * Still called lazily rather than at module load: it reads Pinia stores, which do not exist until
+ * the app has installed Pinia.
  */
 function wirePreviewToggles(): void {
   if (previewTogglesWired) return;
   previewTogglesWired = true;
-  const config = useConfigStore();
-  const settings = useSettingsStore();
-  watch(
-    () => [
-      config.linkPreviews && settings.effective('chat.inline_media.enabled') === true,
-      config.linkPreviews && settings.effective('chat.link_previews.enabled') === true,
-    ],
-    ([inlineMedia, linkPreviews], previous) => {
-      // Only on a flip TO enabled. Turning one off needs no work: the rows stop rendering.
-      const gained = (inlineMedia && !previous?.[0]) || (linkPreviews && !previous?.[1]);
-      if (!gained) return;
-      const buffers = useBuffersStore();
-      for (const buf of Object.values(buffers.buffers)) {
-        primeEventPreviews(buf.messages, buf.networkId, buf.target);
-      }
-    },
-  );
+  previewToggleScope.run(() => {
+    const config = useConfigStore();
+    const settings = useSettingsStore();
+    watch(
+      () => [
+        config.linkPreviews && settings.effective('chat.inline_media.enabled') === true,
+        config.linkPreviews && settings.effective('chat.link_previews.enabled') === true,
+      ],
+      ([inlineMedia, linkPreviews], previous) => {
+        // Only on a flip TO enabled. Turning one off needs no work: the rows stop rendering.
+        const gained = (inlineMedia && !previous?.[0]) || (linkPreviews && !previous?.[1]);
+        if (!gained) return;
+        const buffers = useBuffersStore();
+        for (const buf of Object.values(buffers.buffers)) {
+          primeEventPreviews(buf.messages, buf.networkId, buf.target);
+        }
+      },
+    );
+  });
+}
+
+/**
+ * Test-only: tear the watcher down so a suite can re-wire it from a known state.
+ * A stopped scope cannot be re-run, so this mints a fresh one rather than reusing it.
+ */
+export function resetPreviewToggleWiring(): void {
+  previewToggleScope.stop();
+  previewToggleScope = effectScope(true);
+  previewTogglesWired = false;
 }
 
 function applySnapshot(snapshot: any[], globalIgnores: any[] = []): void {


### PR DESCRIPTION
Closes #693.

## The bug

`wirePreviewToggles` is called from inside `useSocket`'s `onMounted`. A `watch` created in a lifecycle hook registers in the **calling component's effect scope**, because the hook runs with that instance current — so the watcher belonged to whichever route component called `useSocket()` first, and was stopped when that component unmounted. The module-level `previewTogglesWired` latch then guaranteed it was never re-created:

1. Load `/` → `DesktopChat` mounts, calls `useSocket()`, owns the watcher
2. Open `/settings` → `DesktopChat` unmounts → the watcher is stopped
3. `Settings` calls `useSocket()` too, but `wirePreviewToggles` early-returns at the latch

From then on, flipping either preview toggle primes nothing.

The irony is in the docblock: this watcher was **moved** to `useSocket` precisely because living in `MessageList` meant it couldn't survive opening Settings — and every word of that comment was still true of the code. Moving it changed *where the watcher is declared*, not *which scope owns it*, so "it only ever worked via `/set` and cross-device sync, which is why it survived QA" remained the live failure mode. There's no `KeepAlive` anywhere in `vue_client/src`; the only match in the tree is the comment asserting there isn't one.

## The fix

Run the `watch` inside a **detached module-level `effectScope`**, so no component can adopt it.

Still called lazily from `onMounted` rather than at module load, because it reads Pinia stores that don't exist until the app has installed Pinia — that constraint is why it lived in a lifecycle hook in the first place, and it's now noted in the comment so the next person doesn't "simplify" it back.

`resetPreviewToggleWiring()` is exported test-only (same shape as `resetLinkPreviewCache`), and mints a fresh scope rather than reusing the stopped one, since a stopped `effectScope` can't be re-run.

## Why it's not cosmetic

With the atomic reveal from the #692 work landed, an unprimed URL is *settled* rather than pending — correctly, since no answer is coming — so the gate opens immediately, `entries` mints permanently-null refs, and the newly-enabled previews render **nothing** until a full reload.

## Tests

Four cases in a new `useSocket.previewToggles.test.ts`. **Every one unmounts the owning component before flipping the toggle** — the trap the issue calls out, since asserting the watcher fires while the first component is still mounted passes against the bug:

- still fires after the component that wired it has unmounted
- fires for a second route that calls `useSocket()` after the first is gone (the latch path)
- primes every loaded buffer, not just the one on screen
- does *not* re-prime when a setting is switched off

Mutation-verified: replacing `previewToggleScope.run(...)` with a plain call — the old component-scoped behaviour — fails the first three. The fourth passes either way by design; it guards the `gained` condition, not the ownership.

`npm run check` clean, full suite green (261 files / 3628 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)