### PR TITLE
One channel-prefix test, shared by both tiers (#724)

### DIFF
--- a/server/db/buffers.ts
+++ b/server/db/buffers.ts
@@ -4,6 +4,7 @@
 import db from './index.js';
 import { encryptSecret, decryptSecret } from '../utils/secretCrypto.js';
 import { foldTargetWith, normalizeCasemapping } from './casemapping.js';
+import { isChannelTarget } from '../../shared/channels.js';
 import type { Casemapping } from './casemapping.js';
 
 // The buffer registry — the single owner of "does this buffer exist" and "is it
@@ -100,12 +101,10 @@ export function foldTargetFor(networkId: number | null, raw: string): string {
   return foldTargetWith(networkCasemapping(networkId), raw);
 }
 
-const CHANNEL_PREFIXES = new Set(['#', '&', '+', '!']);
-
 /** channel/dm classification by target shape (server/system rows are minted
  *  explicitly by their owners, never inferred). */
 export function kindForTarget(target: string): BufferKind {
-  return CHANNEL_PREFIXES.has(target[0] ?? '') ? 'channel' : 'dm';
+  return isChannelTarget(target) ? 'channel' : 'dm';
 }
 
 interface BufferRow {

--- a/server/db/contactsToFavoritesSeed.ts
+++ b/server/db/contactsToFavoritesSeed.ts
@@ -70,6 +70,11 @@ export function seedFavoritesFromContacts(db: Database.Database): number {
     const raw = (nick || '').trim();
     // A channel-shaped or sentinel "nick" can't have been a real DM target;
     // skip rather than mint a mis-kinded buffer.
+    //
+    // ⚠ The prefix set is spelled out here rather than calling the shared `isChannelTarget`, and
+    // deliberately so: a migration has to keep classifying rows the way it did the day it ran. If
+    // the shared notion of a channel prefix ever changes, an already-migrated database must not
+    // retroactively disagree with itself about what v19 did. Do not "clean this up".
     if (!raw || raw.startsWith(':') || /^[#&+!]/.test(raw)) continue;
     const mappingRow = casemappingStmt.get(networkId) as { casemapping: string | null } | undefined;
     if (!mappingRow) continue; // network row gone mid-migration; nothing to favorite

--- a/server/services/bouncer.ts
+++ b/server/services/bouncer.ts
@@ -66,6 +66,7 @@ import {
   certFingerprint,
   keyMatchesCert,
 } from '../utils/bouncerCert.js';
+import { isChannelTarget } from '../../shared/channels.js';
 
 const SERVER_NAME = 'lurker.bouncer';
 
@@ -461,7 +462,7 @@ export function isValidServerTime(s: string): boolean {
 type ChatBound = { star: true } | { iso: string };
 
 function isChannelName(target: string): boolean {
-  return target.startsWith('#') || target.startsWith('&');
+  return isChannelTarget(target);
 }
 
 // Network-services pseudo-users (NickServ/ChanServ/…). Playback replays their

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -351,17 +351,27 @@ describe('resolveChannelContext (#439)', () => {
     expect(resolveChannelContext(undefined, '[info] something', channels)).toBe(null);
   });
 
-  it('only resolves `#` channels, not `&`/`!`/`+` (matches Lurker routing)', () => {
-    // Even when "joined" to a non-# channel, channel-context must not redirect to
-    // it — Lurker routes `&`/`!`/`+` targets as non-channels.
+  it('resolves every channel prefix once joined, not just `#` (#724)', () => {
+    // This test used to assert the opposite, on the rationale that "Lurker routes `&`/`!`/`+`
+    // targets as non-channels" — which was the bug, not a decision. Now that both tiers classify
+    // all four prefixes, a channel-context tag naming a joined `&local` must resolve to it;
+    // refusing would strand the notice in the server buffer instead of its channel.
     const withLocal = new Map([
       ['#christian', { name: '#Christian' }],
       ['&local', { name: '&local' }],
     ]);
     expect(resolveChannelContext({ '+draft/channel-context': '&local' }, 'x', withLocal)).toBe(
-      null,
+      '&local',
     );
-    expect(resolveChannelContext(undefined, '[&local] hi', withLocal)).toBe(null);
+    expect(resolveChannelContext(undefined, '[&local] hi', withLocal)).toBe('&local');
+  });
+
+  it('still refuses a channel prefix we are NOT joined to', () => {
+    // The membership check is what keeps this safe — widening the prefix set must not turn any
+    // bracketed `[+foo]` in a notice body into a redirect target.
+    const channels = new Map([['#christian', { name: '#Christian' }]]);
+    expect(resolveChannelContext({ '+draft/channel-context': '&nope' }, 'x', channels)).toBe(null);
+    expect(resolveChannelContext(undefined, '[+nope] hi', channels)).toBe(null);
   });
 });
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -89,6 +89,7 @@ import {
 import { getChannelConfig as getE2eChannelConfig } from '../db/e2e.js';
 import type { ChannelMode } from '../db/e2e.js';
 import { randomBytes } from 'node:crypto';
+import { isChannelTarget, CHANNEL_PREFIX_CLASS } from '../../shared/channels.js';
 
 // Optional source address for outbound IRC connections (LURKER_OUTGOING_ADDR),
 // passed to irc-framework as `outgoing_addr` → the socket's localAddress. Lets a
@@ -334,7 +335,7 @@ interface EnrichedEvent extends IrcEvent {
 
 function isDmTargetName(target: string | undefined | null): boolean {
   if (!target) return false;
-  return !target.startsWith('#') && !target.startsWith(':server:');
+  return !isChannelTarget(target) && !target.startsWith(':server:');
 }
 
 // Persisted timestamps prefer IRCv3 server-time (#450): irc-framework parses
@@ -1624,7 +1625,7 @@ export class IrcConnection {
       // IRCv3 server message id (#450) — the future react/reply anchor. Tag
       // keys arrive lowercased; draft/msgid covers pre-ratification servers.
       const msgid = tags?.msgid || tags?.['draft/msgid'] || undefined;
-      const targetIsChannel = eventTarget && eventTarget.startsWith('#');
+      const targetIsChannel = isChannelTarget(eventTarget);
       const type =
         eventType === 'action' ? 'action' : eventType === 'notice' ? 'notice' : 'message';
 
@@ -1678,7 +1679,7 @@ export class IrcConnection {
 
       let target: string;
       if (isServer) target = `:server:${this.network.id}`;
-      else if (targetIsChannel) target = eventTarget;
+      else if (eventTarget && targetIsChannel) target = eventTarget;
       else if (isNotice) {
         // A NOTICE addressed to us persists to the sender's buffer (its natural
         // home), like a PRIVMSG — so the buffer surfaces on first notice and the
@@ -2318,7 +2319,7 @@ export class IrcConnection {
         return;
       }
 
-      if (!target || !target.startsWith('#')) return;
+      if (!target || !isChannelTarget(target)) return;
       const ch = this.channels.get(target.toLowerCase());
       // Apply per-user prefix modes (+o/-o, +v/-v, etc.) to the member map so
       // the snapshot keeps current modes after page reload.
@@ -2757,7 +2758,7 @@ export class IrcConnection {
       const typing = tags && tags['+typing'];
       if (!typing) return;
       const eventTarget = event.target as string | undefined;
-      const targetIsChannel = eventTarget && eventTarget.startsWith('#');
+      const targetIsChannel = isChannelTarget(eventTarget);
       const target = targetIsChannel ? eventTarget : eventNick;
       this.publishEphemeral({
         type: 'typing',
@@ -3746,6 +3747,7 @@ export class IrcConnection {
     const m = /^\s*xdcc\s+(?:send|get)\s+(#?\d+)/i.exec(text);
     if (!m) return;
     if (!dccEnabledForUser(this.network.user_id)) return;
+    // ⚠ NOT a channel test (#724): `#` here is the XDCC PACK-NUMBER sigil.
     const pack = m[1].startsWith('#') ? m[1] : `#${m[1]}`;
     insertDccTransfer(this.network.user_id, {
       network_id: this.network.id,
@@ -4311,6 +4313,8 @@ export class IrcConnection {
     // `+` targets as DMs (see `targetIsChannel` in the message handler), so they
     // can never be E2E channels here — accepting them would only enable a config
     // whose inbound ciphertext would mis-route to a DM buffer (review #1 on #407).
+    // ⚠ `#`-only on purpose (#724): these tokens are free CTCP text, so widening would claim
+    // any leading `+` or `!` word as a channel name. A misparse here mis-routes the reply.
     const channelToken = tokens.find((t) => t.startsWith('#') && t.length > 1);
     const nonChannel = tokens.filter((t) => !t.startsWith('#'));
     // The channel an op targets: an explicit #arg wins, else the issuing buffer
@@ -4606,6 +4610,9 @@ export class IrcConnection {
           // (db/e2e.ts matchAutotrustStmt), so reject anything else up front
           // rather than storing a rule that can never match (a dead rule the
           // user is told was "added").
+          // ⚠ `#`-only on purpose (#724): this mirrors what db/e2e.ts matchAutotrustStmt can
+          // actually match. Widening the VALIDATOR alone would store rules that never fire —
+          // the dead-rule outcome this guard exists to prevent. Widen both together or neither.
           if (scope.toLowerCase() !== 'global' && !(scope.startsWith('#') && scope.length > 1)) {
             info(
               `/e2e autotrust add: scope must be 'global' or a #channel (got '${scope}')`,
@@ -5414,17 +5421,21 @@ export function canonicalChannelTarget(
   target: string | undefined,
   channels: Map<string, { name: string }>,
 ): string | undefined {
-  if (typeof target !== 'string' || !target.startsWith('#')) return target;
+  if (!target || !isChannelTarget(target)) return target;
   const known = channels.get(target.toLowerCase());
   return known ? known.name : target;
 }
 
 // Matches a conventional "[#chan] …" channel-context body prefix, also tolerating
-// (#chan), <#chan>, {#chan}. Restricted to `#` to match Lurker's routing, which
-// treats only `#` as a channel (`&`/`!`/`+` are routed as non-channels); the
-// captured name is validated against the joined set before use, and brackets
-// aren't required to pair since the joined-channel check is the real gate.
-const CHANNEL_CONTEXT_PREFIX = /^\s*[[(<{]\s*(#[^\])>}\s]+)\s*[\])>}]/;
+// (#chan), <#chan>, {#chan}. Accepts every channel prefix (#724) — it used to be
+// restricted to `#` "to match Lurker's routing, which treats only `#` as a
+// channel", which is the misclassification that has since been fixed. Widening
+// is safe here for the reason the old comment already gave: the captured name is
+// validated against the JOINED set before use, so a bracketed `[+nope]` in an
+// ordinary notice still resolves to nothing.
+const CHANNEL_CONTEXT_PREFIX = new RegExp(
+  `^\\s*[[(<{]\\s*([${CHANNEL_PREFIX_CLASS}][^\\])>}\\s]+)\\s*[\\])>}]`,
+);
 
 // A nick-addressed NOTICE sometimes belongs in a channel rather than a DM with
 // the sender: services announce per-channel info to your nick (Atheme ENTRYMSG,
@@ -5440,7 +5451,7 @@ export function resolveChannelContext(
   channels: Map<string, { name: string }>,
 ): string | null {
   const joinedChannel = (name: string | undefined): string | null => {
-    if (!name || !name.startsWith('#')) return null;
+    if (!name || !isChannelTarget(name)) return null;
     const known = channels.get(name.toLowerCase());
     return known ? known.name : null;
   };

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -1691,10 +1691,12 @@ export class IrcConnection {
         //   - EXCEPTION 1: a channel-context hint (the IRCv3 +draft/channel-context
         //     tag, or a leading "[#chan]" body prefix) for a channel we're in
         //     routes the notice to that channel.
-        //   - EXCEPTION 2: a notice NOT addressed to our nick (e.g. to an `&`/`!`/`+`
-        //     local channel, which Lurker routes as a non-channel, or a STATUSMSG
-        //     target) has no DM home — surface it in the server buffer rather than
-        //     fabricating a bogus DM with the sender.
+        //   - EXCEPTION 2: a notice NOT addressed to our nick and not placeable in a
+        //     channel — an oper broadcast (`$$*`), a mask target, a STATUSMSG whose
+        //     channel we aren't in — has no DM home, so surface it in the server
+        //     buffer rather than fabricating a bogus DM with the sender.
+        //     (This used to name `&`/`!`/`+` channels as the example; since #724 they
+        //     route as the channels they are and never reach here.)
         const ctx = resolveChannelContext(
           event.tags as Record<string, string> | undefined,
           eventMessage,
@@ -4308,13 +4310,23 @@ export class IrcConnection {
     const sub = (tokens.shift() || 'help').toLowerCase();
     // `#`-prefixed channels only — INCLUDING double-hash names like `##anime`
     // (the `length > 1` guard rejects only a bare lone `#`, which would otherwise
-    // persist a junk config row; #382 review #6). This is intentionally narrower
-    // than isChannelContext's `# & ! +`: Lurker's message routing treats `&`/`!`/
-    // `+` targets as DMs (see `targetIsChannel` in the message handler), so they
-    // can never be E2E channels here — accepting them would only enable a config
-    // whose inbound ciphertext would mis-route to a DM buffer (review #1 on #407).
-    // ⚠ `#`-only on purpose (#724): these tokens are free CTCP text, so widening would claim
-    // any leading `+` or `!` word as a channel name. A misparse here mis-routes the reply.
+    // persist a junk config row; #382 review #6). Narrower than isChannelContext's
+    // `# & ! +`.
+    //
+    // ⚠⚠ The ORIGINAL reason for that gap is gone: it read "Lurker's message routing treats
+    // `&`/`!`/`+` targets as DMs, so they can never be E2E channels here", which #724 falsified —
+    // those targets now route as the channels they are. What keeps this `#`-only today is
+    // narrower and deliberate: these tokens are an `/e2e` ARGUMENT LINE that mixes channels,
+    // nicks and handle masks, and `nonChannel` below is derived by exclusion from this same
+    // test. Widening the prefix set would silently reclassify a mask like `+*!*@host` as a
+    // channel and drop it from the peer argument — a misparse with security consequences in the
+    // one subsystem where that matters most.
+    //
+    // ⚠ Known asymmetry this leaves, and the reason it is a follow-up rather than a shrug:
+    // `isChannelContext` (e2e/context.ts) and the inbound decrypt gate both accept `&local`, so
+    // such a channel can RECEIVE ciphertext it can never be configured to decrypt — `/e2e on`
+    // there answers "run this from a channel". Widening wants the arg grammar disambiguated
+    // first (positional, or an explicit `--channel`), not a wider prefix test.
     const channelToken = tokens.find((t) => t.startsWith('#') && t.length > 1);
     const nonChannel = tokens.filter((t) => !t.startsWith('#'));
     // The channel an op targets: an explicit #arg wins, else the issuing buffer
@@ -4610,9 +4622,12 @@ export class IrcConnection {
           // (db/e2e.ts matchAutotrustStmt), so reject anything else up front
           // rather than storing a rule that can never match (a dead rule the
           // user is told was "added").
-          // ⚠ `#`-only on purpose (#724): this mirrors what db/e2e.ts matchAutotrustStmt can
-          // actually match. Widening the VALIDATOR alone would store rules that never fire —
-          // the dead-rule outcome this guard exists to prevent. Widen both together or neither.
+          // ⚠ `#`-only on purpose (#724), but NOT for the reason it might look like:
+          // `matchAutotrustStmt` (db/e2e.ts) is `scope = 'global' OR scope = ?`, a prefix-agnostic
+          // exact match that would happily match `&local`. What makes a non-`#` scope dead is
+          // upstream — `effectiveMode` gates on `getChannelConfig(...).enabled`, and `/e2e on`
+          // above cannot enable a non-`#` channel. So this validator stays aligned with `/e2e on`;
+          // widen the two together, and look at the config gate rather than the SQL.
           if (scope.toLowerCase() !== 'global' && !(scope.startsWith('#') && scope.length > 1)) {
             info(
               `/e2e autotrust add: scope must be 'global' or a #channel (got '${scope}')`,
@@ -5444,7 +5459,7 @@ const CHANNEL_CONTEXT_PREFIX = new RegExp(
 // and irssi's notice_channel_context: redirect to the referenced channel, but ONLY
 // when it's a `#` channel we're currently joined to (so a stray tag/prefix can't
 // fabricate a buffer), returning its canonical (joined) casing. The tag wins over
-// the body prefix. Returns null when there's no usable, joined `#`-channel context.
+// the body prefix. Returns null when there's no usable, joined-channel context.
 export function resolveChannelContext(
   tags: Record<string, string> | undefined,
   body: string | undefined,

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -5457,8 +5457,9 @@ const CHANNEL_CONTEXT_PREFIX = new RegExp(
 // ChanServ welcome) either via the IRCv3 +draft/channel-context client tag or a
 // conventional "[#chan] …" body prefix. Mirrors weechat's notice_welcome_redirect
 // and irssi's notice_channel_context: redirect to the referenced channel, but ONLY
-// when it's a `#` channel we're currently joined to (so a stray tag/prefix can't
-// fabricate a buffer), returning its canonical (joined) casing. The tag wins over
+// when it's a channel we're currently JOINED to (so a stray tag/prefix can't
+// fabricate a buffer), returning its canonical (joined) casing. Every channel
+// prefix qualifies since #724 — membership, not the prefix set, is the gate. The tag wins over
 // the body prefix. Returns null when there's no usable, joined-channel context.
 export function resolveChannelContext(
   tags: Record<string, string> | undefined,

--- a/server/services/noticeRouting.test.ts
+++ b/server/services/noticeRouting.test.ts
@@ -222,11 +222,13 @@ describe('NOTICE routing (#439)', () => {
 
   it('routes a notice not addressed to our nick to the server buffer (no bogus DM)', () => {
     const { conn, publish } = harness();
-    // A NOTICE to an `&` local channel Lurker does not route as a channel, and
-    // not addressed to us → server buffer, not a fabricated DM with the sender.
+    // ⚠ Retargeted by #724. This used to send a NOTICE to `&admin` to the SERVER buffer, on the
+    // rationale that "Lurker does not route `&` as a channel" — the bug. An `&` channel is a
+    // channel, so its notice belongs in its own buffer; a target we genuinely can't place is what
+    // must fall back to the server buffer, which the case below covers.
     emitNotice(conn, { nick: 'LogBot', target: '&admin', message: 'audit log line' });
     expect(publish).toHaveBeenCalledWith(
-      expect.objectContaining({ target: ':server:1', type: 'notice' }),
+      expect.objectContaining({ target: '&admin', type: 'notice' }),
     );
   });
 

--- a/server/services/noticeRouting.test.ts
+++ b/server/services/noticeRouting.test.ts
@@ -220,15 +220,28 @@ describe('NOTICE routing (#439)', () => {
     expect(publish).toHaveBeenCalledWith(expect.objectContaining({ target: 'caseserv' }));
   });
 
-  it('routes a notice not addressed to our nick to the server buffer (no bogus DM)', () => {
+  it('routes a notice to an `&` channel into that channel (#724)', () => {
     const { conn, publish } = harness();
-    // ⚠ Retargeted by #724. This used to send a NOTICE to `&admin` to the SERVER buffer, on the
-    // rationale that "Lurker does not route `&` as a channel" — the bug. An `&` channel is a
-    // channel, so its notice belongs in its own buffer; a target we genuinely can't place is what
-    // must fall back to the server buffer, which the case below covers.
+    // ⚠ Retargeted by #724. This used to expect the SERVER buffer, on the stated rationale that
+    // "Lurker does not route `&` as a channel" — which was the bug. An `&` channel is a channel,
+    // so its notice belongs in its own buffer.
     emitNotice(conn, { nick: 'LogBot', target: '&admin', message: 'audit log line' });
     expect(publish).toHaveBeenCalledWith(
       expect.objectContaining({ target: '&admin', type: 'notice' }),
+    );
+  });
+
+  it('still falls back to the server buffer for a target it cannot place', () => {
+    // ⚠⚠ The branch the case above USED to cover, restored rather than dropped. Retargeting that
+    // test left `else target = ':server:'` in the notice handler with no coverage at all — the
+    // other `:server:` assertions in this file exercise the no-nick and closed-mirror branches,
+    // which are different code. This is the live case: an oper broadcast has a real sender, a
+    // target that is neither our nick nor any channel, and so no DM home. Fabricating a DM with
+    // the sender is the outcome the fallback exists to prevent.
+    const { conn, publish } = harness();
+    emitNotice(conn, { nick: 'oper', target: '$$*', message: 'global operator broadcast' });
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({ target: ':server:1', type: 'notice' }),
     );
   });
 

--- a/server/services/verbs/listBuffers.ts
+++ b/server/services/verbs/listBuffers.ts
@@ -4,6 +4,7 @@
 import { registerVerb } from '../verbRegistry.js';
 import { listNetworksForUser } from '../../db/networks.js';
 import { listBuffersForNetwork } from '../../db/messages.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 /** Authenticated caller context passed to every verb handler. */
 interface VerbContext {
@@ -12,7 +13,7 @@ interface VerbContext {
 }
 
 function bufferKind(target: string): 'channel' | 'dm' {
-  if (target.startsWith('#')) return 'channel';
+  if (isChannelTarget(target)) return 'channel';
   return 'dm';
 }
 

--- a/server/services/wsHub.notifyAlways.test.ts
+++ b/server/services/wsHub.notifyAlways.test.ts
@@ -157,12 +157,32 @@ describe('notify-always lookups are hoisted out of N-row decorates (#679)', () =
 
     const frame = buildBufferBacklog(userId, networkId, '&local');
 
-    const events = frame.events as Array<{ notifyAlways?: boolean; notify?: boolean }>;
+    const events = frame.events as Array<{
+      notifyAlways?: boolean;
+      notify?: boolean;
+      dm?: boolean;
+    }>;
     expect(events).toHaveLength(4);
     expect(events.every((e) => e.notifyAlways === true)).toBe(true);
-    expect(events.every((e) => e.notify === true)).toBe(true);
     // And it still costs exactly one lookup, like any other channel.
     expect(spy()).toHaveBeenCalledTimes(1);
+  });
+
+  // ⚠⚠ The assertion that makes the one above mean anything. `decorateMessage` sets
+  // `dm = isDirect(event)`, which routed through a `#`-only `isDmTarget` — so an `&local` message
+  // was ALREADY dm:true, `contentNotify` was already true, and widening the notify-always test
+  // changed `notify` for nothing. A `notify === true` assertion passes either way and hides that.
+  // The DM misclassification is also the worse bug: `isDmTarget` feeds `computeUnreadFor`, where
+  // every unread line in a "DM" counts as a highlight.
+  it('does not treat a &-prefixed channel as a DM', () => {
+    for (let i = 0; i < 3; i++) seed('&notdm', `line ${i}`);
+    const frame = buildBufferBacklog(userId, networkId, '&notdm');
+
+    const events = frame.events as Array<{ dm?: boolean; notify?: boolean }>;
+    expect(events).toHaveLength(3);
+    expect(events.every((e) => e.dm === false)).toBe(true);
+    // With no notify-always set and no highlight, an ordinary channel line is not notify-worthy.
+    expect(events.every((e) => e.notify === false)).toBe(true);
   });
 
   it('never queries for a DM resume slice either', () => {

--- a/server/services/wsHub.notifyAlways.test.ts
+++ b/server/services/wsHub.notifyAlways.test.ts
@@ -147,6 +147,24 @@ describe('notify-always lookups are hoisted out of N-row decorates (#679)', () =
     expect(spy()).not.toHaveBeenCalled();
   });
 
+  // #724: notify-always is stored against any target `kindForTarget` calls a channel, but
+  // decorateMessage only CONSULTED it for `#`. So on a network with `&`/`+`/`!` channels the
+  // toggle stored fine, showed as on, and then never fired — the setting was inert.
+  it('applies notify-always to a &-prefixed channel, not just #', () => {
+    for (let i = 0; i < 4; i++) seed('&local', `line ${i}`);
+    channelNotify.setChannelNotifyAlways(userId, networkId, '&local', true);
+    spy().mockClear();
+
+    const frame = buildBufferBacklog(userId, networkId, '&local');
+
+    const events = frame.events as Array<{ notifyAlways?: boolean; notify?: boolean }>;
+    expect(events).toHaveLength(4);
+    expect(events.every((e) => e.notifyAlways === true)).toBe(true);
+    expect(events.every((e) => e.notify === true)).toBe(true);
+    // And it still costs exactly one lookup, like any other channel.
+    expect(spy()).toHaveBeenCalledTimes(1);
+  });
+
   it('never queries for a DM resume slice either', () => {
     for (let i = 0; i < 8; i++) seed('dave', `line ${i}`);
     spy().mockClear();

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -465,7 +465,7 @@ export function reopensClosedBuffer(type: string, id: unknown): boolean {
 // DMs. Shared by isDirect (event path) and computeUnreadFor (read-state counts)
 // so the two never drift on what counts as a DM.
 function isDmTarget(target: string): boolean {
-  return !!target && !target.startsWith('#') && !target.startsWith(':server:');
+  return !!target && !isChannelTarget(target) && !target.startsWith(':server:');
 }
 
 function isDirect(event: MessageEvent): boolean {
@@ -787,7 +787,7 @@ export function computeTotalHighlights(userId: number): number {
 // #channel to parted. Centralized so the four snapshot/backlog sites can't drift
 // (channel-case folding already bit this codebase — see #289/#269).
 function channelJoined(target: string, conn?: JoinedProbe | null): boolean {
-  return target.startsWith('#') ? !!conn?.isChannelJoined(target) : true;
+  return isChannelTarget(target) ? !!conn?.isChannelJoined(target) : true;
 }
 
 // The one membership surface (IrcConnection.isChannelJoined): fold-aware per
@@ -1385,6 +1385,11 @@ export function handleOpenBuffer(
     send(ws, buildBufferBacklog(userId, networkId, row.target, countBy));
     send(ws, { kind: 'buffer-opened', networkId, target: row.target, bufferId: row.id });
     announceOpen(ws, userId, networkId, row.target, conn, row.id);
+    // ⚠ `#`-only on purpose, and NOT an oversight in the #724 sweep: this branch JOINs a channel
+    // that has no registry row yet, and the join wiring below only exists for `#`. Widening it made
+    // `open-buffer` on a never-visited `&local` mint an open kind='channel' row that never receives
+    // a JOIN — a permanently dead buffer, which two tests in wsHub.test.ts exist to prevent.
+    // `/join &local` reaches the real join path and works; this is the click-an-unvisited-row case.
   } else if (requested.startsWith('#')) {
     // No row yet — the JOIN echo mints it — so this is the one ack that
     // cannot carry a bufferId; the id arrives with the channel's first frames.
@@ -2913,7 +2918,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         if (unfavoriteBuffer(userId, networkId, target)) {
           fanOut(userId, favoritesChangedFrame(userId));
         }
-        if (target.startsWith('#')) {
+        if (isChannelTarget(target)) {
           // Send PART if connected; partChannel also lowers autojoin. If
           // disconnected, partChannel is a no-op, so lower autojoin here to
           // keep the channel from auto-rejoining the next time the network
@@ -3295,7 +3300,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         // Only channels have a nicklist; server/DM buffers are never tracked.
         // (The guard runs on the RESOLVED target, so the id form is policed
         // identically to the name form.)
-        if (!networkId || !target.startsWith('#')) break;
+        if (!networkId || !isChannelTarget(target)) break;
         const collapsed = !!msg.collapsed;
         setNicklistCollapsed(userId, networkId, target, collapsed);
         fanOut(userId, {

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -9,6 +9,7 @@ import type { LogLine } from './systemLog.js';
 import type { MessageEvent } from '../db/messages.js';
 import type { PageUnit } from '../../shared/eventFilter.js';
 import { asPageUnit } from '../../shared/eventFilter.js';
+import { isChannelTarget } from '../../shared/channels.js';
 import { WebSocketServer } from 'ws';
 import cookie from 'cookie';
 import cookieParser from 'cookie-parser';
@@ -520,7 +521,11 @@ function ignoreVerdictForEvent(
  * either as a query nothing reads, or as a hoisted answer the guard then throws away.
  */
 function notifyAlwaysApplies(target: string): boolean {
-  return target.startsWith('#');
+  // ⚠ All four channel prefixes, not just `#` (#724). `set-channel-notify-always` has accepted
+  // any of them since it moved to `kindForTarget`, so a `#`-only test here meant the setting
+  // could be STORED for an `&`/`+`/`!` channel and then never consulted when a message arrived —
+  // the toggle looked on and did nothing.
+  return isChannelTarget(target);
 }
 
 /**

--- a/shared/channels.test.ts
+++ b/shared/channels.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { isChannelTarget, stripChannelPrefix } from './channels.js';
+
+describe('isChannelTarget (#724)', () => {
+  it('accepts all four RFC 2811 prefixes, not just #', () => {
+    // The whole point: `#`-only is the bug this replaced, in ~30 client sites.
+    expect(isChannelTarget('#lurker')).toBe(true);
+    expect(isChannelTarget('&local')).toBe(true);
+    expect(isChannelTarget('+nomodes')).toBe(true);
+    expect(isChannelTarget('!ABCDEsafe')).toBe(true);
+  });
+
+  it('rejects nicks', () => {
+    expect(isChannelTarget('bob')).toBe(false);
+    expect(isChannelTarget('bob_')).toBe(false);
+    // A nick may legally contain a prefix character — only position one counts.
+    expect(isChannelTarget('a#b')).toBe(false);
+    expect(isChannelTarget('nick+tag')).toBe(false);
+  });
+
+  it('rejects the `:`-prefixed sentinels', () => {
+    // `:server:` / `:system:` are real buffers but neither channel nor DM, and the callers that
+    // ask this question rely on them answering false.
+    expect(isChannelTarget(':server:1')).toBe(false);
+    expect(isChannelTarget(':system:')).toBe(false);
+  });
+
+  it('is safe on absent and empty input', () => {
+    expect(isChannelTarget('')).toBe(false);
+    expect(isChannelTarget(null)).toBe(false);
+    expect(isChannelTarget(undefined)).toBe(false);
+  });
+});
+
+describe('stripChannelPrefix', () => {
+  it('strips every leading sigil, not only #', () => {
+    expect(stripChannelPrefix('#lurker')).toBe('lurker');
+    expect(stripChannelPrefix('&local')).toBe('local');
+    expect(stripChannelPrefix('##double')).toBe('double');
+    expect(stripChannelPrefix('+plus')).toBe('plus');
+  });
+
+  it('leaves a nick alone', () => {
+    expect(stripChannelPrefix('bob')).toBe('bob');
+  });
+
+  it('sorts &local next to #local rather than under punctuation', () => {
+    // The sidebar/quick-switcher sort key. `&local` used to keep its sigil and file under `&`.
+    expect(stripChannelPrefix('&local')).toBe(stripChannelPrefix('#local'));
+  });
+});

--- a/shared/channels.ts
+++ b/shared/channels.ts
@@ -29,13 +29,31 @@
 export const CHANNEL_PREFIX_CHARS = '#&+!';
 const CHANNEL_PREFIXES = new Set(CHANNEL_PREFIX_CHARS);
 
+// ⚠ A plain boolean, deliberately NOT a `target is string` type predicate. Most callers pass an
+// already-`string` target, and a predicate would narrow the ELSE branch of those to `never` —
+// so `!isChannelTarget(t)` would stop compiling wherever `t` is used afterwards, which is most of
+// the DM paths. The handful of callers holding `string | undefined` guard once themselves.
 export function isChannelTarget(target: string | null | undefined): boolean {
   return typeof target === 'string' && CHANNEL_PREFIXES.has(target[0] ?? '');
 }
 
+/**
+ * The prefix set as a regex character-class BODY (no brackets), for callers that must match a
+ * channel name inside a larger pattern rather than test a whole target.
+ *
+ * ⚠ Escaped, because it gets interpolated into a class — `]`, `\`, `^` or `-` would otherwise
+ * change the class's meaning instead of being matched literally. None of the four prefixes needs
+ * it today; the escape is what makes adding a fifth safe.
+ */
+export const CHANNEL_PREFIX_CLASS = CHANNEL_PREFIX_CHARS.replace(/[\\\]^-]/g, '\\$&');
+
+// Hoisted, not built per call: this runs inside a sort comparator (twice per comparison in
+// `bufferSortKey`) and once per row in the quick switcher, on every sidebar rebuild.
+const CHANNEL_PREFIX_RE = new RegExp(`^[${CHANNEL_PREFIX_CLASS}]+`);
+
 /** Strip every leading channel sigil — for sort keys and display, never for addressing. */
 export function stripChannelPrefix(target: string): string {
-  return target.replace(new RegExp(`^[${CHANNEL_PREFIX_CHARS}]+`), '');
+  return target.replace(CHANNEL_PREFIX_RE, '');
 }
 
 // Normalize an array of channel names: trim, lowercase, drop blanks, dedupe.

--- a/shared/channels.ts
+++ b/shared/channels.ts
@@ -7,6 +7,37 @@
 // blanks. Previously this logic was reimplemented four times with inconsistent
 // casing.
 
+/**
+ * The four IRC channel prefixes (RFC 2811 §2.1): `#` global, `&` server-local,
+ * `+` no-modes, `!` safe/timestamped.
+ *
+ * ⚠⚠ Testing only for `#` is the single most-repeated bug in this codebase — it had accumulated
+ * in ~30 places in the web client alone (#724), where an `&`/`+`/`!` channel was then treated as
+ * a DM: no nicklist, a `probe-presence` fired at the channel name as if it were a nick, nick
+ * colouring, whois menu items, and sorting among the DMs. It survived because `&` is server-local
+ * and `+`/`!` are historic, so almost every real network only uses `#`.
+ *
+ * Shared rather than per-tier precisely because the halves disagreeing is what caused the damage:
+ * the server has classified all four since `kindForTarget` was written, so every client-side `#`
+ * test was a place the two tiers silently parted company.
+ *
+ * ⚠ This answers "is this the name of a CHANNEL". It is NOT the question a completion trigger
+ * asks — that one is "did the user type a `#`", where the character is a literal sigil and
+ * widening it would pop a channel picker on any `+` in ordinary prose. Those sites stay `#`-only
+ * and say so.
+ */
+export const CHANNEL_PREFIX_CHARS = '#&+!';
+const CHANNEL_PREFIXES = new Set(CHANNEL_PREFIX_CHARS);
+
+export function isChannelTarget(target: string | null | undefined): boolean {
+  return typeof target === 'string' && CHANNEL_PREFIXES.has(target[0] ?? '');
+}
+
+/** Strip every leading channel sigil — for sort keys and display, never for addressing. */
+export function stripChannelPrefix(target: string): string {
+  return target.replace(new RegExp(`^[${CHANNEL_PREFIX_CHARS}]+`), '');
+}
+
 // Normalize an array of channel names: trim, lowercase, drop blanks, dedupe.
 // Non-string entries are ignored.
 export function normalizeChannelList(values: readonly unknown[]): string[] {

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -367,6 +367,7 @@ import {
   isPeerOffline as derivePeerOffline,
   isPeerAway as derivePeerAway,
 } from '../utils/peerPresence.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -472,7 +473,7 @@ function isServerBuffer(buf: Buffer): boolean {
 }
 
 function isDmBuffer(buf: Buffer): boolean {
-  return !isServerBuffer(buf) && !buf.target.startsWith('#');
+  return !isServerBuffer(buf) && !isChannelTarget(buf.target);
 }
 
 function serverTarget(networkId: number): string {
@@ -500,7 +501,7 @@ function labelFor(buf: Buffer): string {
 }
 
 function bufferOrder(buf: Buffer): number {
-  if (buf.target.startsWith('#')) return 0;
+  if (isChannelTarget(buf.target)) return 0;
   return 1;
 }
 
@@ -754,7 +755,7 @@ function stateClass(networkId: number): string {
 // just a history view, not a live channel. DMs and server buffers have no
 // "joined" concept and are never dimmed by this rule.
 function isUnjoined(buf: Buffer, networkId: number): boolean {
-  if (!buf.target.startsWith('#')) return false;
+  if (!isChannelTarget(buf.target)) return false;
   if (buf.joined === false) return true;
   return networks.states[networkId]?.state !== 'connected';
 }

--- a/vue_client/src/components/BufferList.vue
+++ b/vue_client/src/components/BufferList.vue
@@ -368,6 +368,7 @@ import {
   isPeerAway as derivePeerAway,
 } from '../utils/peerPresence.js';
 import { isChannelTarget } from '../../../shared/channels.js';
+import { bufferSortKey } from '../utils/bufferOrder.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -505,11 +506,16 @@ function bufferOrder(buf: Buffer): number {
   return 1;
 }
 
-// Strip leading hashes so ##anime sorts next to #anime, not before #aardvark
+// Strip leading sigils so ##anime sorts next to #anime, not before #aardvark
 // (raw localeCompare would weight every leading '#' as sort-significant).
-function sortKey(target: string): string {
-  return target.replace(/^#+/, '').toLowerCase();
-}
+//
+// ⚠⚠ This is the RENDERED sidebar's key, and `bufferOrder.ts`'s `bufferSortKey` is the one
+// keyboard nav and the quick switcher use — whose docblock promises they "walk the same order
+// the user sees in the sidebar". Two implementations of one rule: they must be changed together
+// or the promise quietly breaks, which is exactly what happened when only one of them learned
+// about `&`/`+`/`!` (#724). Delegated rather than re-implemented so there is nothing to keep in
+// sync next time.
+const sortKey = bufferSortKey;
 
 // A favorited buffer renders in its FRIENDS/FAVORITES section instead of its
 // network group (dedupe, matching the old FRIENDS behavior) — filtered from

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -509,7 +509,6 @@ describe('MessageInput command dispatch', () => {
   // channel when one by that name is actually open.
   describe('channel-vs-free-text arguments (#724)', () => {
     it('/part &local parts that channel when it exists', async () => {
-      seedStores('#zebra');
       const { buffers } = seedStores('#zebra');
       buffers.buffers['1::&local'] = {
         networkId: 1,
@@ -555,6 +554,35 @@ describe('MessageInput command dispatch', () => {
       await enter(el);
 
       expect(rawLine('TOPIC')).toBe('TOPIC #zebra :!!! maintenance !!!');
+    });
+
+    it('/mode +local +m targets the channel, not the current buffer flags', async () => {
+      // `+local` satisfies the leading-sign flag heuristic AND is a channel name. With an open
+      // buffer by that name the channel reading wins; without one it is flags (next case).
+      const { buffers } = seedStores('#zebra');
+      buffers.buffers['1::+local'] = {
+        networkId: 1,
+        target: '+local',
+        members: [],
+        messages: [],
+      } as never;
+      const { el } = await mountComposer();
+
+      await type(el, '/mode +local +m');
+      await enter(el);
+
+      expect(rawLine('MODE')).toBe('MODE +local +m');
+    });
+
+    it('/mode +m still applies flags to the current channel', async () => {
+      // The positive control: no buffer is ever named `+m`, so real flags keep working.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '/mode +m');
+      await enter(el);
+
+      expect(rawLine('MODE')).toBe('MODE #zebra +m');
     });
 
     it('/kick &local bob still takes the channel-first form', async () => {

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -495,6 +495,81 @@ describe('MessageInput command dispatch', () => {
     });
   });
 
+  // ⚠ Find the RAW call by its verb rather than taking the last one: the composer also fires
+  // typing/draft sends around a submit, so `.at(-1)` is whichever of those landed last.
+  const rawLine = (verb: string): string | undefined =>
+    vi
+      .mocked(socketSend)
+      .mock.calls.map(([p]) => p as { type?: string; line?: string })
+      .filter((p) => p?.type === 'raw' && p.line?.startsWith(verb))
+      .at(-1)?.line;
+
+  // #724: commands whose first argument may be free text can't use the plain prefix test. `#`
+  // never starts a sentence, but `+` and `!` do — so the other three prefixes only address a
+  // channel when one by that name is actually open.
+  describe('channel-vs-free-text arguments (#724)', () => {
+    it('/part &local parts that channel when it exists', async () => {
+      seedStores('#zebra');
+      const { buffers } = seedStores('#zebra');
+      buffers.buffers['1::&local'] = {
+        networkId: 1,
+        target: '&local',
+        members: [],
+        messages: [],
+      } as never;
+      const { el } = await mountComposer();
+
+      await type(el, '/part &local');
+      await enter(el);
+
+      expect(socketSend).toHaveBeenCalledWith({
+        type: 'part',
+        networkId: 1,
+        channel: '&local',
+        reason: '',
+      });
+    });
+
+    it('/part +brb leaves the CURRENT channel with that reason', async () => {
+      // No `+brb` buffer exists, so the argument is prose. Reading it as a channel would part a
+      // channel that isn't there and silently leave the user where they were.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '/part +brb');
+      await enter(el);
+
+      expect(socketSend).toHaveBeenCalledWith({
+        type: 'part',
+        networkId: 1,
+        channel: '#zebra',
+        reason: '+brb',
+      });
+    });
+
+    it('/topic !!! maintenance !!! sets the current channel topic', async () => {
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '/topic !!! maintenance !!!');
+      await enter(el);
+
+      expect(rawLine('TOPIC')).toBe('TOPIC #zebra :!!! maintenance !!!');
+    });
+
+    it('/kick &local bob still takes the channel-first form', async () => {
+      // Unambiguous by shape: /kick's first argument is a nick or a channel, never prose, so it
+      // uses the plain prefix test and needs no open buffer.
+      seedStores('#zebra');
+      const { el } = await mountComposer();
+
+      await type(el, '/kick &local bob rude');
+      await enter(el);
+
+      expect(rawLine('KICK')).toBe('KICK &local bob :rude');
+    });
+  });
+
   // #412. Worth real coverage rather than trusting the switch: an unknown command
   // falls through to `default:`, which ships it as a RAW IRC line — so before this
   // existed, `/p cya` didn't fail loudly, it sent the server a bogus `p cya`.

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -2280,6 +2280,28 @@ function isChannelArg(t: string | undefined): boolean {
   return isChannelTarget(t);
 }
 
+/**
+ * The same question for commands whose first argument may instead be FREE TEXT — `/part [reason]`,
+ * `/topic [text]`.
+ *
+ * ⚠⚠ These cannot use the plain prefix test, and the reason is the mirror of why widening was
+ * right everywhere else. `#` is effectively never how a sentence starts, so reading a leading `#`
+ * as "this is a channel" is safe; `+` and `!` absolutely are — `/part +brb` would part a channel
+ * named `+brb` instead of leaving the current one with reason "+brb", and `/topic !!! maintenance
+ * !!!` would set the topic of a channel called `!!!`. Both fail silently and do the wrong thing.
+ *
+ * So: `#` always addresses a channel (unambiguous, and the long-standing behaviour), and the
+ * other three prefixes only do so when they name a channel this network actually has open. That
+ * keeps `/part &local` working where `&local` exists, without letting punctuation-led prose
+ * hijack the argument.
+ */
+function isChannelArgAmbiguous(t: string | undefined, networkId: number | null): boolean {
+  if (!t) return false;
+  if (t.startsWith('#')) return true;
+  if (!isChannelTarget(t)) return false;
+  return !!buffers.findByTarget(networkId, t);
+}
+
 // Shared builder for the op/voice/ban-family MODE shortcuts (/op, /voice, /ban,
 // …). The channel defaults to the current buffer; an explicit #chan may lead
 // the args (so `/op #other alice` works from anywhere). Each nick/mask consumes
@@ -2990,7 +3012,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // silently stayed put; a leading # now distinguishes the two.
       let channel;
       let reason;
-      if (isChannelArg(rest[0])) {
+      if (isChannelArgAmbiguous(rest[0], networkId)) {
         channel = rest[0];
         reason = line
           .slice(1 + cmd.length)
@@ -3097,7 +3119,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // /topic <#chan> [text]         — set/get on another channel
       let channel;
       let body;
-      if (isChannelArg(rest[0])) {
+      if (isChannelArgAmbiguous(rest[0], networkId)) {
         channel = rest[0];
         body = line
           .slice(1 + cmd.length)

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -3152,7 +3152,12 @@ function handleCommand(line: string, networkId: number | null, target: string): 
         localInfo(networkId, target, 'usage: /mode [target] <flags> [args]');
         return true;
       }
-      const looksLikeFlagsOnly = /^[+-]/.test(rest[0]);
+      // ⚠ `+local` is both a valid flag string and a valid channel name, so the leading-sign
+      // heuristic alone sent `/mode +local +m` as flags against the CURRENT buffer (#724). Same
+      // disambiguation /part and /topic use: a channel wins only when one by that name is open,
+      // so real flags (`+m`, `-nt`) are untouched — no buffer is ever called that.
+      const looksLikeFlagsOnly =
+        /^[+-]/.test(rest[0]) && !isChannelArgAmbiguous(rest[0], networkId);
       if (looksLikeFlagsOnly && isChannelTarget(target)) {
         return sendOrToast(
           { type: 'raw', networkId, line: `MODE ${target} ${rest.join(' ')}` },

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -159,6 +159,7 @@ import { useToastsStore } from '../stores/toasts.js';
 import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
 import { useRelayBotsStore } from '../stores/relayBots.js';
 import { useHighlightRulesStore, type HighlightRule } from '../stores/highlightRules.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 import { parseIgnoreArgs } from '../../../shared/parseIgnore.js';
 import { parseHighlightArgs } from '../../../shared/parseHighlight.js';
 import { highlightRuleDetailParts } from '../utils/highlightFormat.js';
@@ -1238,6 +1239,9 @@ function onKeydown(e: KeyboardEvent): void {
   if (!buf || !active.value) return;
   const networkId = active.value.networkId;
 
+  // ⚠ `#`-only on purpose (#724): this asks what SIGIL the user typed, not whether a target is
+  // a channel. Tab after `&loc` completes nicks, which is the lesser evil — widening it would
+  // make a leading `+` or `!` in ordinary prose start completing channel names.
   const isChannel = token.startsWith('#');
   // Strip the sigil off both forms. '#' is part of a channel name so it stays in
   // the *result*, but neither sigil belongs in the *prefix* we match on: asking
@@ -1440,6 +1444,8 @@ function refreshPicker() {
   // typed so you get the full joined-channel list; the picker self-hides when
   // nothing matches (its v-if gates on candidate count), so a stray `#5` or a
   // channel you're not in just shows no popover.
+  // ⚠ `#`-only on purpose (#724): the picker trigger is a typed character, not a classification.
+  // Opening it on `+` or `!` would pop a channel popover mid-sentence.
   if (token.startsWith('#')) {
     closePicker();
     closeStrip();
@@ -2262,8 +2268,16 @@ const COMMANDS_LINES = [
   '  //text                 — send literal "/text" as a message (escape)',
 ];
 
-function isChannelTarget(t: string): boolean {
-  return typeof t === 'string' && t.startsWith('#');
+/**
+ * Whether a COMMAND ARGUMENT names a channel — `/part &local`, `/kick &local bob`.
+ *
+ * ⚠ Distinct from the completion sigil tests further up this file, which stay `#`-only on
+ * purpose: those ask "did the user type a `#`" about text being edited, and widening them would
+ * pop a channel picker on any `+` in ordinary prose. This one asks "is this token a channel
+ * name", which is the shared question.
+ */
+function isChannelArg(t: string | undefined): boolean {
+  return isChannelTarget(t);
 }
 
 // Shared builder for the op/voice/ban-family MODE shortcuts (/op, /voice, /ban,
@@ -2282,7 +2296,7 @@ function modeShortcut(
 ): boolean {
   let channel = isChannelTarget(target) ? target : null;
   let args = rest;
-  if (rest[0] && rest[0].startsWith('#')) {
+  if (isChannelArg(rest[0])) {
     channel = rest[0];
     args = rest.slice(1);
   }
@@ -2976,7 +2990,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // silently stayed put; a leading # now distinguishes the two.
       let channel;
       let reason;
-      if (rest[0] && rest[0].startsWith('#')) {
+      if (isChannelArg(rest[0])) {
         channel = rest[0];
         reason = line
           .slice(1 + cmd.length)
@@ -3029,7 +3043,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       let channel;
       let nick;
       let reason;
-      if (rest[0] && rest[0].startsWith('#')) {
+      if (isChannelArg(rest[0])) {
         channel = rest[0];
         nick = rest[1];
         reason = rest.slice(2).join(' ');
@@ -3058,13 +3072,12 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // /invite <#chan> <nick>     (channel-first, mirroring /kick)
       let channel;
       let nick;
-      if (rest[0] && rest[0].startsWith('#')) {
+      if (isChannelArg(rest[0])) {
         channel = rest[0];
         nick = rest[1];
       } else {
         nick = rest[0];
-        channel =
-          rest[1] && rest[1].startsWith('#') ? rest[1] : isChannelTarget(target) ? target : null;
+        channel = isChannelArg(rest[1]) ? rest[1] : isChannelTarget(target) ? target : null;
       }
       if (!nick) {
         localInfo(networkId, target, 'usage: /invite <nick> [#channel]');
@@ -3084,7 +3097,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // /topic <#chan> [text]         — set/get on another channel
       let channel;
       let body;
-      if (rest[0] && rest[0].startsWith('#')) {
+      if (isChannelArg(rest[0])) {
         channel = rest[0];
         body = line
           .slice(1 + cmd.length)
@@ -3239,7 +3252,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // is optional; otherwise the current channel is used.
       let channel = isChannelTarget(target) ? target : null;
       let args = rest;
-      if (rest[0] && rest[0].startsWith('#')) {
+      if (isChannelArg(rest[0])) {
         channel = rest[0];
         args = rest.slice(1);
       }

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -371,6 +371,7 @@ import { useContextMenu, type ContextMenuItem } from '../composables/useContextM
 import { useWhoisStore } from '../stores/whois.js';
 import { addressNick } from '../composables/useComposerOverlay.js';
 import { setViewedBuffer } from '../composables/useViewedBuffer.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 // Extended BufferMessage fields accessed in the template and script
 // (beyond the core BufferMessage definition which uses [key: string]: unknown).
@@ -618,7 +619,7 @@ const nickSet = computed((): Set<string> => {
     const n = typeof mem === 'string' ? mem : mem.nick;
     if (n) set.add(n);
   }
-  if (b.target && !b.target.startsWith('#') && !b.target.startsWith(':server:')) {
+  if (b.target && !isChannelTarget(b.target) && !b.target.startsWith(':server:')) {
     set.add(b.target);
   }
   const sn = b.networkId != null ? networks.states[b.networkId]?.nick : undefined;
@@ -787,7 +788,7 @@ const selfModes = computed<string[]>(() => {
 function authorModes(m: ChatMessage | undefined): string[] | undefined {
   if (!showModePrefix.value || !m?.nick) return undefined;
   const b = buffer.value;
-  if (!b || !b.target?.startsWith('#')) return undefined;
+  if (!b || !isChannelTarget(b.target)) return undefined;
   return nickMember(m.nick)?.modes;
 }
 
@@ -1044,7 +1045,7 @@ const renderRows = computed((): RenderRow[] => {
 
   const networkId = buf?.networkId;
   const bufTarget = buf?.target ?? '';
-  const bufIsDm = !bufTarget.startsWith('#') && !bufTarget.startsWith(':server:');
+  const bufIsDm = !isChannelTarget(bufTarget) && !bufTarget.startsWith(':server:');
 
   for (let i = 0; i < list.length; i++) {
     // Cast to ChatMessage so template-used properties are typed; BufferMessage
@@ -1623,7 +1624,7 @@ function maybeBumpNewBelow() {
       target: tail.target,
       text: tail.text ?? '',
       type: tail.type,
-      isDm: !tail.target.startsWith('#') && !tail.target.startsWith(':server:'),
+      isDm: !isChannelTarget(tail.target) && !tail.target.startsWith(':server:'),
     });
   if (!tailIgnored && tail?.id != null) bumpNewBelow();
 }

--- a/vue_client/src/components/QuickSwitcher.vue
+++ b/vue_client/src/components/QuickSwitcher.vue
@@ -50,6 +50,7 @@ import { useRecentBuffersStore } from '../stores/recentBuffers.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { flattenBufferOrder, bufferSortKey } from '../utils/bufferOrder.js';
 import { smartSortRows } from '../utils/switcherSort.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 interface Row {
   networkId: string | number;
@@ -86,7 +87,7 @@ function isServerTarget(t: string) {
   return t.startsWith(':server:');
 }
 function isDmTarget(t: string) {
-  return !isServerTarget(t) && !t.startsWith('#');
+  return !isServerTarget(t) && !isChannelTarget(t);
 }
 
 function netById(id: string | number) {

--- a/vue_client/src/components/StatusBar.vue
+++ b/vue_client/src/components/StatusBar.vue
@@ -165,6 +165,7 @@ import {
   type NickStripItem,
 } from '../composables/useComposerOverlay.js';
 import type { EmojiMatch } from '../utils/emojiData.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 withDefaults(
   defineProps<{
@@ -254,7 +255,7 @@ const nickKeyFor = (item: NickStripItem): string => item.nick.toLowerCase();
 // template — same shape as the emoji strip.
 const onNickStripSelect = (item: NickStripItem): void => selectNick(item.nick);
 
-const isChannel = computed(() => !!active.value?.target?.startsWith('#'));
+const isChannel = computed(() => isChannelTarget(active.value?.target));
 
 const networkLabel = computed(() => {
   const a = active.value;
@@ -283,7 +284,7 @@ const modeSuffix = computed(() => {
 const isDmBuffer = computed(
   () =>
     !!active.value?.target &&
-    !active.value.target.startsWith('#') &&
+    !isChannelTarget(active.value.target) &&
     !active.value.target.startsWith(':server:'),
 );
 const peerForActive = computed(() => {

--- a/vue_client/src/composables/useActiveBuffer.ts
+++ b/vue_client/src/composables/useActiveBuffer.ts
@@ -7,6 +7,7 @@ import { storeToRefs } from 'pinia';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { SYSTEM_KEY, virtualConfig } from '../lib/virtualBuffers.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 export interface ActiveBufferState {
   activeKey: Ref<string | null>;
@@ -60,7 +61,7 @@ export function useActiveBuffer(): ActiveBufferState {
     return buf.topic ?? undefined;
   });
   const isServerBuffer = computed(() => !!active.value?.target?.startsWith(':server:'));
-  const isChannel = computed(() => !!active.value?.target?.startsWith('#'));
+  const isChannel = computed(() => isChannelTarget(active.value?.target));
   const bufferLabel = computed(() => {
     if (virtualCfg.value) return virtualCfg.value.label;
     const t = active.value?.target;

--- a/vue_client/src/composables/useBufferActions.ts
+++ b/vue_client/src/composables/useBufferActions.ts
@@ -9,6 +9,7 @@ import { useWhoisStore } from '../stores/whois.js';
 import { useContextMenu } from './useContextMenu.js';
 import { useNotifyLadder } from './useNotifyLadder.js';
 import { socketSend } from './useSocket.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 export interface BufferLike {
   // The server's stable buffer id, when the caller's store entry has learned
@@ -50,7 +51,7 @@ export function useBufferActions(): BufferActionsAPI {
     // channel labels, the channel notify ladder, and channel icons — and are
     // never offered the DM-only profile/note items (whois on '&local' is
     // nonsense the old '#'-only test allowed).
-    const isChannel = /^[#&+!]/.test(buf.target);
+    const isChannel = isChannelTarget(buf.target);
     const kind = isChannel ? 'Channel' : 'DM';
     const pinned = pins.isPinned(networkId, buf.target);
     // One flag, two labels: a favorited channel surfaces in the FAVORITES

--- a/vue_client/src/composables/useMemberActions.ts
+++ b/vue_client/src/composables/useMemberActions.ts
@@ -10,6 +10,7 @@ import { useContextMenu } from './useContextMenu.js';
 import { socketSend } from './useSocket.js';
 import { historyCountBy } from '../lib/historyPaging.js';
 import { addressNick } from './useComposerOverlay.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 export interface MemberLike {
   nick: string;
@@ -193,8 +194,7 @@ export function useMemberActions(): MemberActionsAPI {
     // channel. Each sends a raw IRC line and lets the server's MODE/KICK echo
     // update state — the same path the /kick and /mode slash commands use, so
     // no optimistic mutation here. Never offered against yourself.
-    const channel =
-      typeof ctx.channel === 'string' && ctx.channel.startsWith('#') ? ctx.channel : null;
+    const channel = isChannelTarget(ctx.channel as string) ? (ctx.channel as string) : null;
     const selfModes = Array.isArray(ctx.selfModes) ? ctx.selfModes : [];
     if (!isSelf && channel && hasAny(selfModes, MODERATE_MODES)) {
       const networkId = ctx.networkId;

--- a/vue_client/src/composables/useMemberActions.ts
+++ b/vue_client/src/composables/useMemberActions.ts
@@ -194,7 +194,12 @@ export function useMemberActions(): MemberActionsAPI {
     // channel. Each sends a raw IRC line and lets the server's MODE/KICK echo
     // update state — the same path the /kick and /mode slash commands use, so
     // no optimistic mutation here. Never offered against yourself.
-    const channel = isChannelTarget(ctx.channel as string) ? (ctx.channel as string) : null;
+    // ⚠ `typeof` first, not a cast. `isChannelTarget` deliberately returns a plain boolean rather
+    // than a `target is string` predicate (see shared/channels.ts), so it cannot narrow
+    // `string | null | undefined` on its own — and casting to satisfy that would let a non-string
+    // through unchecked. This is the guard the pre-#724 code already had; keep it.
+    const channel =
+      typeof ctx.channel === 'string' && isChannelTarget(ctx.channel) ? ctx.channel : null;
     const selfModes = Array.isArray(ctx.selfModes) ? ctx.selfModes : [];
     if (!isSelf && channel && hasAny(selfModes, MODERATE_MODES)) {
       const networkId = ctx.networkId;

--- a/vue_client/src/composables/useSelfLabel.ts
+++ b/vue_client/src/composables/useSelfLabel.ts
@@ -6,6 +6,7 @@ import { computed } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore } from '../stores/buffers.js';
 import { prefixOf } from '../utils/memberPrefix.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 export interface SelfLabelState {
   promptLabelNoModes: ComputedRef<string>;
@@ -32,7 +33,7 @@ export function useSelfLabel(): SelfLabelState {
 
   const channelPrefix = computed(() => {
     const buf = buffer.value;
-    if (!buf || buf.networkId == null || !buf.target.startsWith('#')) return '';
+    if (!buf || buf.networkId == null || !isChannelTarget(buf.target)) return '';
     const nick = networks.states[buf.networkId]?.nick;
     if (!nick) return '';
     const lc = nick.toLowerCase();

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -32,6 +32,7 @@ import { makeClientId } from '../utils/clientId.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { downloadTextFile } from '../utils/download.js';
 import { notifyForEvent, playSound } from './useHighlightNotifier.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 export interface AckResult {
   ok: boolean;
@@ -307,7 +308,7 @@ function applyEvent(event: any): void {
       // toast with a one-click Join. The durable record for the latter lives in
       // the system buffer (logged server-side), so the long TTL is just a
       // convenience window, not the only chance to act.
-      if (typeof event.target === 'string' && event.target.startsWith('#')) {
+      if (isChannelTarget(event.target as string)) {
         buffers.pushMessage(event);
         break;
       }

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -244,6 +244,61 @@ describe('case-insensitive buffer identity (#327)', () => {
 // Feeds the PWA app-icon badge (#451). The sum must track each buffer's
 // server-owned `highlighted` count and inherit applyReadState's active-buffer
 // suppression, so the focused conversation never inflates the badge.
+// #724: deriveKind tested a bare `#`, so an `&`/`+`/`!` channel was kinded a DM — and that
+// cascaded. The nicklist pane keys off kind, and activate() fires a `probe-presence` for DMs,
+// which meant WHOIS-probing the channel NAME as if it were a nick.
+describe('non-# channels are kinded as channels (#724)', () => {
+  const line = (target: string, id: number) => ({
+    networkId: 1,
+    target,
+    id,
+    type: 'message',
+    nick: 'bob',
+    body: 'x',
+  });
+
+  it('kinds &, + and ! targets as channels', () => {
+    const store = useBuffersStore();
+    store.pushMessage(line('&local', 1));
+    store.pushMessage(line('+nomodes', 2));
+    store.pushMessage(line('!ABCDEsafe', 3));
+    store.pushMessage(line('bob', 4));
+
+    expect(store.byKey('1::&local')!.kind).toBe('channel');
+    expect(store.byKey('1::+nomodes')!.kind).toBe('channel');
+    expect(store.byKey('1::!ABCDEsafe')!.kind).toBe('channel');
+    expect(store.byKey('1::bob')!.kind).toBe('dm');
+  });
+
+  it('does not WHOIS-probe a &channel as if its name were a nick', () => {
+    const store = useBuffersStore();
+    store.pushMessage(line('&local', 1));
+    vi.mocked(socketSend).mockClear();
+
+    store.activate(1, '&local');
+
+    // The probe is DMs-only. Sending it for a channel asks the server to WHOIS `&local`.
+    const probes = vi
+      .mocked(socketSend)
+      .mock.calls.filter(([p]) => (p as { type?: string })?.type === 'probe-presence');
+    expect(probes).toEqual([]);
+  });
+
+  it('still probes a real DM', () => {
+    // Positive control: without this, "no probe" could just mean activate() did nothing at all.
+    const store = useBuffersStore();
+    store.pushMessage(line('bob', 1));
+    vi.mocked(socketSend).mockClear();
+
+    store.activate(1, 'bob');
+
+    const probes = vi
+      .mocked(socketSend)
+      .mock.calls.filter(([p]) => (p as { type?: string })?.type === 'probe-presence');
+    expect(probes).toHaveLength(1);
+  });
+});
+
 describe('totalHighlights', () => {
   it('is zero with only the seeded system buffer', () => {
     const store = useBuffersStore();

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -241,9 +241,6 @@ describe('case-insensitive buffer identity (#327)', () => {
   });
 });
 
-// Feeds the PWA app-icon badge (#451). The sum must track each buffer's
-// server-owned `highlighted` count and inherit applyReadState's active-buffer
-// suppression, so the focused conversation never inflates the badge.
 // #724: deriveKind tested a bare `#`, so an `&`/`+`/`!` channel was kinded a DM — and that
 // cascaded. The nicklist pane keys off kind, and activate() fires a `probe-presence` for DMs,
 // which meant WHOIS-probing the channel NAME as if it were a nick.
@@ -299,6 +296,9 @@ describe('non-# channels are kinded as channels (#724)', () => {
   });
 });
 
+// Feeds the PWA app-icon badge (#451). The sum must track each buffer's
+// server-owned `highlighted` count and inherit applyReadState's active-buffer
+// suppression, so the focused conversation never inflates the badge.
 describe('totalHighlights', () => {
   it('is zero with only the seeded system buffer', () => {
     const store = useBuffersStore();

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -7,6 +7,7 @@ import { useToastsStore } from './toasts.js';
 import { socketSend } from '../composables/useSocket.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { historyCountBy } from '../lib/historyPaging.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 const MAX_PER_BUFFER = 500;
 // The most rows one INCREMENTAL merge (prepend/append) may take from a single
@@ -197,7 +198,7 @@ export type BufferKind = 'channel' | 'dm' | 'server' | 'system';
 // are the system buffer today; network buffers split by target shape.
 function deriveKind(networkId: number | null, target: string): BufferKind {
   if (networkId == null) return 'system';
-  if (target.startsWith('#')) return 'channel';
+  if (isChannelTarget(target)) return 'channel';
   if (target.startsWith(':server:')) return 'server';
   return 'dm';
 }
@@ -477,7 +478,7 @@ export const useBuffersStore = defineStore('buffers', {
             (b) =>
               b.networkId === Number(networkId) &&
               b.target.toLowerCase() === lower &&
-              !b.target.startsWith('#') &&
+              !isChannelTarget(b.target) &&
               !b.target.startsWith(':'),
           ) ?? null
         );
@@ -1477,7 +1478,7 @@ export const useBuffersStore = defineStore('buffers', {
       // resulting peer-presence event flows back to update local state.
       // DMs only — channels (#…) and the flat sentinels (:server:, :system:) have
       // no peer to probe.
-      if (canonTarget && !canonTarget.startsWith('#') && !canonTarget.startsWith(':')) {
+      if (canonTarget && !isChannelTarget(canonTarget) && !canonTarget.startsWith(':')) {
         socketSend({ type: 'probe-presence', networkId, nick: canonTarget });
       }
     },

--- a/vue_client/src/stores/favorites.ts
+++ b/vue_client/src/stores/favorites.ts
@@ -4,6 +4,7 @@
 import { defineStore } from 'pinia';
 import { socketSend } from '../composables/useSocket.js';
 import { idFor, useBuffersStore } from './buffers.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 // Buffer favorites — the Friends/Contacts replacement. ONE per-user global
 // ordered list spanning networks; the sidebar renders it as two kind-filtered
@@ -56,7 +57,7 @@ export const useFavoritesStore = defineStore('favorites', {
         // knows '#', but the server counts '&'/'+'/'!' channels too
         // (kindForTarget) — a favorited &local must land under FAVORITES with
         // channel chrome, not under FRIENDS with a bogus presence dot.
-        if (/^[#&+!]/.test(buf.target)) channels.push(resolved);
+        if (isChannelTarget(buf.target)) channels.push(resolved);
         else friends.push(resolved);
       }
       return { friends, channels };

--- a/vue_client/src/stores/ignores.ts
+++ b/vue_client/src/stores/ignores.ts
@@ -12,6 +12,7 @@ import {
   type IgnoreInput,
   type IgnoreVerdict,
 } from '../utils/ignoreMatch.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 // The two "mute" modifier levels (issue #359). A per-buffer or per-network mute
 // rung is a canonical rule carrying only these (no hide levels, no mask/pattern/
@@ -211,7 +212,7 @@ export const useIgnoresStore = defineStore('ignores', {
           target: m.target,
           text: m.text ?? m.body ?? '',
           type: m.type ?? 'message',
-          isDm: !m.target.startsWith('#') && !m.target.startsWith(':server:'),
+          isDm: !isChannelTarget(m.target) && !m.target.startsWith(':server:'),
         }).hide;
       },
 

--- a/vue_client/src/utils/bufferOrder.test.ts
+++ b/vue_client/src/utils/bufferOrder.test.ts
@@ -112,6 +112,42 @@ describe('flattenBufferOrder', () => {
   });
 });
 
+// #724: the sidebar sorted channels before DMs using a bare `#` test, so an `&`/`+`/`!` channel
+// filed among the DMs — and its sort key kept the sigil, so it sorted under punctuation instead
+// of by name.
+describe('non-# channels sort as channels', () => {
+  it('puts &, + and ! channels in the channel block, before DMs', () => {
+    const order = flattenBufferOrder({
+      networks: [{ id: 1 }],
+      buffers: makeBuffers({ '1': ['bob', '&local', '#zeta', '+nomodes', 'amy', '!ABCDEsafe'] }),
+      pins: makePins({}),
+    });
+    expect(order.map((e) => e.key)).toEqual([
+      srvKey(1),
+      // Channels, alphabetical by name with the sigil stripped:
+      // ABCDEsafe, local, nomodes, zeta
+      '1::!ABCDEsafe',
+      '1::&local',
+      '1::+nomodes',
+      '1::#zeta',
+      // …then the DMs.
+      '1::amy',
+      '1::bob',
+    ]);
+  });
+
+  it('sorts &local by its name, adjacent to #local', () => {
+    const order = flattenBufferOrder({
+      networks: [{ id: 1 }],
+      buffers: makeBuffers({ '1': ['#apple', '&banana', '#cherry'] }),
+      pins: makePins({}),
+    });
+    // Sigil-blind alphabetical: apple, banana, cherry. With the old `/^#+/` strip, `&banana`
+    // sorted on the literal `&` and led the list.
+    expect(order.map((e) => e.key)).toEqual([srvKey(1), '1::#apple', '1::&banana', '1::#cherry']);
+  });
+});
+
 describe('flattenUnreadOrder', () => {
   it('keeps only entries whose buffer has unread > 0, server pseudo-buffers included', () => {
     const args = {

--- a/vue_client/src/utils/bufferOrder.ts
+++ b/vue_client/src/utils/bufferOrder.ts
@@ -7,6 +7,8 @@
 // alphabetically). Used by keyboard navigation so prev/next-channel and the
 // quick switcher walk the same order the user sees in the sidebar.
 
+import { isChannelTarget, stripChannelPrefix } from '../../../shared/channels.js';
+
 interface BufferEntry {
   target: string;
 }
@@ -65,15 +67,14 @@ function isServerTarget(target: string): boolean {
   return typeof target === 'string' && target.startsWith(':server:');
 }
 
-function isChannelTarget(target: string): boolean {
-  return typeof target === 'string' && target.startsWith('#');
-}
-
 // Alphabetical sort key for a buffer: leading channel sigils stripped, ASCII-
 // lowercased (matching the house case-folding style). Exported so the quick
 // switcher's smart sort (#393) alphabetises identically to the sidebar.
+//
+// ⚠ All four sigils, not just `#` (#724) — the comment always said "channel sigils", but the
+// pattern stripped only one of them, so `&local` sorted under `&` instead of alongside `#local`.
 export function bufferSortKey(target: string): string {
-  return target.replace(/^#+/, '').toLowerCase();
+  return stripChannelPrefix(target).toLowerCase();
 }
 
 function bufferOrder(target: string): number {

--- a/vue_client/src/utils/channelCompletion.ts
+++ b/vue_client/src/utils/channelCompletion.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import { isChannelTarget } from '../../../shared/channels.js';
+
 // Shared candidate builder for channel completion — used by both Tab-completion
 // in MessageInput and the `#`-triggered ChannelPicker. Returns the targets of
 // joined channels matching `prefix` (case-insensitive), most-recently-visited
@@ -50,7 +52,11 @@ export function buildChannelCandidates(
   return (
     buffers
       .map((b) => b.target ?? '')
-      .filter((t) => t.startsWith('#') && t.toLowerCase().startsWith(lower))
+      // The classification half widens with everything else (#724); the TRIGGER that produced
+      // `prefix` is still `#`-only (see MessageInput), so today `lower` always starts with `#`
+      // and this can't actually surface an `&`/`+`/`!` channel. It asks the right question
+      // anyway, so a future trigger change doesn't have to remember to come back here.
+      .filter((t) => isChannelTarget(t) && t.toLowerCase().startsWith(lower))
       // Rank each candidate once up front rather than inside the comparator: a
       // rank lookup is a linear scan of the MRU trail, and a comparator would
       // repeat it twice per comparison — on every keystroke, since the picker's

--- a/vue_client/src/utils/channelTarget.ts
+++ b/vue_client/src/utils/channelTarget.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import { isChannelTarget } from '../../../shared/channels.js';
+
 // The single notion of "what is a channel prefix" for the client's join paths.
 // IRC channels start with one of #, &, +, ! (RFC 2811); a bare, prefix-less
 // name is what people usually type, so prepend the common `#`. Callers own
@@ -8,5 +10,5 @@
 // settles the prefix. Shared by the Join Channel modal, the channel-list
 // browser, and the `/join` command so all three normalize identically (#496).
 export function ensureChannelPrefix(name: string): string {
-  return /^[#&+!]/.test(name) ? name : `#${name}`;
+  return isChannelTarget(name) ? name : `#${name}`;
 }

--- a/vue_client/src/utils/nickCompletion.ts
+++ b/vue_client/src/utils/nickCompletion.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+import { isChannelTarget } from '../../../shared/channels.js';
+
 // Shared candidate builder for nick completion — used by both Tab-completion in
 // MessageInput and the @-triggered NickPicker. Returns nicks matching `prefix`
 // (case-insensitive), with `recent: true` marking entries that come from the
@@ -61,7 +63,7 @@ export function buildNickCandidates(
     .map((m) => (typeof m === 'string' ? m : m.nick))
     .filter((n): n is string => !!n);
   const memberLcSet = new Set(memberNames.map((n) => n.toLowerCase()));
-  const filterSpeakersByMembership = !!buf.target?.startsWith('#');
+  const filterSpeakersByMembership = isChannelTarget(buf.target);
   const memberByLc = new Map<string, Member>();
   for (const m of buf.members || []) {
     const nick = typeof m === 'string' ? m : m?.nick;

--- a/vue_client/src/utils/previewEvents.ts
+++ b/vue_client/src/utils/previewEvents.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { useIgnoresStore } from '../stores/ignores.js';
+import { isChannelTarget } from '../../../shared/channels.js';
 
 export interface PrimableEvent {
   type?: string;
@@ -58,7 +59,7 @@ export function previewableEventTexts(
         text: e.text,
         type: e.type,
         // The same derivation MessageList uses; a store lookup would need the buffer.
-        isDm: !target.startsWith('#') && !target.startsWith(':server:'),
+        isDm: !isChannelTarget(target) && !target.startsWith(':server:'),
       });
       if (verdict.hide) continue;
     }

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -293,6 +293,7 @@ watch(
     if (!hash) return;
     await nextTick();
     await nextTick();
+    // ⚠ NOT a channel test (#724): this `#` is the URL fragment marker. Left alone on purpose.
     const target = hash.startsWith('#') ? hash.slice(1) : hash;
     const root = contentEl.value;
     if (!root) return;


### PR DESCRIPTION
Closes #724.

IRC channels start with `#`, `&`, `+` or `!` (RFC 2811). The server has classified all four since `kindForTarget` was written; the web client tested a bare `#` in about thirty places. Every one of those was a spot where the two tiers silently parted company.

## The cascade, not the classification

Getting the kind wrong was cheap on its own. What it fed wasn't:

- `deriveKind` kinded `&local` a DM → no nicklist pane, and `activate()` fired a **`probe-presence` at the channel name as if it were a nick**
- it sorted among the DMs, and under punctuation rather than by name (the sort key stripped only `#`)
- nick-coloured in the quick switcher; offered whois/note menu items
- `/part &local` parsed `&local` as a part **reason** and quietly parted the current channel instead

## One predicate, in `shared/`

The test now lives in `shared/channels.ts` and both tiers use it — two copies is what caused this. `kindForTarget`, `ensureChannelPrefix`, and the two inline `/^[#&+!]/` regexes the favorites work left behind all route through it, as do ~30 client sites and seven command-argument probes.

## The server half was worse than cosmetic

`decorateMessage` had the same `#`-only test — but fixing only that would have been **inert**, which the first review caught. `dm = isDirect(event)` routes through `isDmTarget`, so an `&local` message was already `dm: true` and `notify` never changed. `isDmTarget` also feeds `computeUnreadFor`, where every unread line in a "DM" counts as a **highlight** — the larger bug, fixed by the same change.

Also widened: `channelJoined`, close⇒PART, `set-nicklist-collapsed` (the client already showed a members toggle for these buffers and the server silently dropped it — no optimistic write, so the button did nothing), `listBuffers`' `bufferKind`, `bouncer`, `targetIsChannel` ×2, `canonicalChannelTarget`, and the channel-context prefix.

## Where widening is wrong, and why

Three classes stay `#`-only, each commented so they don't read as misses:

**A literal sigil, not a classification** — the URL fragment in `Settings.vue`, and the two completion triggers. Those ask what character the user *typed*; widening would pop a channel picker on any `+` in ordinary prose.

**Free-text first arguments** — `/part`, `/topic` and `/mode`. `#` never starts a sentence; `+` and `!` do. `/part +brb` would part a channel named `+brb`, `/topic !!! maintenance !!!` would set the topic of a channel called `!!!`, and `/mode +local +m` would send flags against the current buffer. These address a channel only when one by that name is actually **open** — so real flags (`+m`, `-nt`) are untouched, since no buffer is ever named that.

**No wiring behind it** — `open-buffer`'s JOIN branch. Widening it minted permanently dead buffers; two existing tests guard exactly that and they were right. `/join &local` reaches the real join path and works.

Plus the XDCC pack sigil, the CTCP channel token, and the `/e2e` argument line — text parsing, not classification.

## Two existing tests asserted the old behaviour

Both on the stated rationale that *"Lurker routes `&`/`!`/`+` as non-channels"* — the bug itself, not a decision. Retargeted, with a new sibling test pinning that **membership**, not the prefix set, is what stops a bracketed `[+foo]` from hijacking channel-context.

Retargeting one of them also dropped the only coverage of the notice→server-buffer fallback; restored as its own case and mutation-checked.

The **v19 migration keeps its own spelled-out prefix set**, with a "do not clean this up" note: an already-migrated database must not retroactively disagree with itself about what that migration did.

## Verification

- `npm run check` exit 0; full suite **263 files / 3672 tests** green
- Mutation-verified: reverting the shared predicate to `#`-only fails **15 tests** across both tiers
- New coverage: `shared/channels.test.ts`, sidebar ordering, `deriveKind` + the probe-presence cascade (with a positive control so "no probe" can't mean "activate did nothing"), notify-always and `dm` on an `&` channel, and the free-text argument cases

## Follow-ups filed, not fixed here

- The iOS `IgnoreSet` twin of `isDmTarget` is still `#`-only, so a DMs-level ignore rule now behaves differently on iOS than on web
- `/e2e on` can't enable a non-`#` channel, so an `&` channel can receive ciphertext it can never be configured to decrypt. Widening wants the `/e2e` argument grammar disambiguated first — the token test is also what derives the peer argument by exclusion, so a wider prefix set would reclassify a handle mask as a channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)