### PR TITLE
Bump Lurker version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "1.1.6",
+      "version": "2.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "1.1.6",
+      "version": "2.0.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "1.1.6",
+  "version": "2.0.0",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version bump for the 2.0.0 release. All seven issues in the release sweep have merged (#738–#743, #745).

## Why a major

2.0 removes client protocol surface for the first time rather than only adding to it:

- **Verbs gone**: `set-contact`, `delete-contact`
- **Frames gone**: `contacts-snapshot`, `contact-updated`, `contact-deleted`
- Friends/Contacts replaced wholesale by server-side buffer favorites (`favorites-changed`)
- **Schema 16 → 19, one-way** — v17 re-keys `messages` onto `buffers.id`, v18 rebuilds the view-state satellites, v19 converts contacts into favorites
- **Runtime floor is Node 24 LTS**

`bufferId` itself is additive — every buffer verb still accepts `networkId` + `target` — so it's the deletions that force the major. Client authors have `docs/MIGRATION_2_0.md`.

## Scope

Only the four files the 1.1.6 bump touched (`2b5ac56`): both `package.json`s and both lockfiles, via `npm version --no-git-tag-version`.

**`docker-compose.yml` is deliberately NOT re-pinned.** The 1.1.6 bump moved it from `:1.1.5` to `:1.1.6`, but #717 has since switched it to `:latest`, so it follows releases on its own now. Re-pinning would undo that.

`APP_VERSION` reads `package.json` at runtime (`server/utils/userAgent.ts`), so the outbound HTTP User-Agent, the CTCP VERSION reply and the default quit message all pick this up with no further change — `/ctcp <yournick> VERSION` against a running instance is a quick way to confirm the deployed build.

`npm run check` exit 0, full suite green (263 files / 3672 tests).

## After this merges

1. Push to `main` publishes `ghcr.io/amiantos/lurker:staging` — for self-hosted validation and iOS testing against a real 2.0 server
2. Cutting the GitHub release publishes `:latest`, `:2.0.0` and `:2.0`
3. ⚠ Coordinate the iOS release: ios#97 (favorites adoption) is merged on `main`, but a pre-#97 App Store build against a 2.0.0 server has a Friends section talking to frames that no longer exist. ios#98 (the `isDmTarget` twin) is a second, smaller reason to ship alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)