### PR TITLE
Give every buffer a URL, and derive the mobile screens from it (#744, #200)

### DIFF
--- a/server/services/notificationContent.ts
+++ b/server/services/notificationContent.ts
@@ -35,6 +35,11 @@ export interface PushPayload {
   networkId: number;
   networkName: string;
   target: string;
+  /** buffers(id) the notification points at, so a tap on a COLD app can launch
+   *  straight into `/buffer/<id>` (#744) instead of a name-carrying query
+   *  string. Optional: a handful of synthetic events are never persisted and so
+   *  have no row, and sw.js falls back to the name form for those. */
+  bufferId?: number;
   nick?: string | null;
   text?: string | null;
   time?: string;

--- a/server/services/push/apnsSender.ts
+++ b/server/services/push/apnsSender.ts
@@ -133,10 +133,13 @@ export function buildApnsRequest(
         'thread-id': content.tag,
       },
       // Custom keys live beside `aps`, and are what tap-to-open reads to know
-      // which buffer to jump to.
+      // which buffer to jump to. bufferId rides along for the same reason it
+      // rides the web push payload (#744): a cold tap can address the buffer
+      // by row id. Shipped iOS builds read networkId/target and ignore it.
       networkId: payload.networkId,
       target: payload.target,
       messageId: payload.messageId,
+      bufferId: payload.bufferId,
       kind: payload.kind,
     }),
   };

--- a/server/services/push/fcmSender.ts
+++ b/server/services/push/fcmSender.ts
@@ -114,6 +114,7 @@ export function buildFcmMessage(
         networkId: String(payload.networkId),
         target: payload.target,
         ...(payload.messageId != null ? { messageId: String(payload.messageId) } : {}),
+        ...(payload.bufferId != null ? { bufferId: String(payload.bufferId) } : {}),
         ...(typeof payload.badge === 'number' ? { badge: String(payload.badge) } : {}),
       },
     },

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -1932,6 +1932,7 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         networkId: decorated.networkId,
         networkName: network?.name || `net:${decorated.networkId}`,
         target: decorated.target,
+        bufferId: decorated.bufferId,
         nick: decorated.nick,
         text: decorated.text,
         time: decorated.time,
@@ -1972,6 +1973,13 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
         networkName: network?.name || `net:${networkId}`,
         // target is the friend's nick so a notification tap opens their DM.
         target: nick,
+        // The DM row is guaranteed to exist — isFavoriteDmPeer above resolved
+        // one to check the favorite — so this always lands, letting a cold tap
+        // launch straight into /buffer/<id> (#744). resolveBuffer, not
+        // getBuffer: identity is all that's wanted, and getBuffer materializes
+        // the full record including +k key decryption, which throws outright on
+        // a rotated key-id. No push path should be able to fail that way.
+        bufferId: resolveBuffer(userId, networkId, nick)?.id,
         // The contacts model had a display name distinct from the nick; a
         // favorite IS its buffer, so they coincide now. Kept in the payload
         // so shipped iOS builds' tap-routing sees the shape it expects.

--- a/vue_client/public/sw.js
+++ b/vue_client/public/sw.js
@@ -91,7 +91,7 @@ self.addEventListener('push', (event) => {
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
   const data = event.notification.data || {};
-  const { networkId, target, messageId } = data;
+  const { networkId, target, messageId, bufferId } = data;
   event.waitUntil(
     (async () => {
       const list = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
@@ -103,11 +103,23 @@ self.addEventListener('notificationclick', (event) => {
         }
       }
       if (self.clients.openWindow) {
-        const params = new URLSearchParams();
-        if (networkId != null) params.set('net', String(networkId));
-        if (target != null) params.set('buf', String(target));
-        if (messageId != null) params.set('msg', String(messageId));
-        const url = `/?${params.toString()}`;
+        // Cold launch: the app isn't running, so the only channel for the jump
+        // target is the URL (a postMessage would race the not-yet-registered
+        // listener). Prefer the id form — it's a real client route, so the app
+        // routes into the buffer normally instead of parsing a query string,
+        // and no channel or DM name ends up in browser history (#744). The
+        // name form stays as the fallback for a payload with no buffer row.
+        const msg = messageId != null ? `?msg=${encodeURIComponent(String(messageId))}` : '';
+        let url;
+        if (bufferId != null) {
+          url = `/buffer/${encodeURIComponent(String(bufferId))}${msg}`;
+        } else {
+          const params = new URLSearchParams();
+          if (networkId != null) params.set('net', String(networkId));
+          if (target != null) params.set('buf', String(target));
+          if (messageId != null) params.set('msg', String(messageId));
+          url = `/?${params.toString()}`;
+        }
         await self.clients.openWindow(url);
       }
     })(),

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -2167,7 +2167,15 @@ function holdCentred(el: HTMLElement, target: HTMLElement, id: number | string):
       const box = el.getBoundingClientRect();
       const drift = rect.top + rect.height / 2 - (box.top + box.height / 2);
       if (Math.abs(drift) > SCROLL_DRIFT_PX) {
+        // Give up once the scroller stops moving. A target within half a
+        // viewport of either end of the slice can never BE centred — scrollTop
+        // clamps — so the drift check stays true forever and this would force a
+        // style+layout pass every frame for the full hold, on exactly the large
+        // slices that motivated it. Jumping to the oldest or newest message in
+        // a buffer hits this every time.
+        const before = el.scrollTop;
         node.scrollIntoView({ block: 'center', behavior: 'auto' });
+        if (el.scrollTop === before) return finish();
       }
     }
     if (performance.now() < until) requestAnimationFrame(tick);

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -2123,6 +2123,55 @@ defineExpose({ scrollByPage });
 // the jump, which is the main reason a *delivered* jump fails to scroll on mobile.
 const SCROLL_RETRY_FRAMES = 60;
 
+// How long to keep the jump target centred after the first scroll.
+//
+// Landing on the row isn't enough. A jump renders a whole slice at once, and
+// this pane deliberately disables browser scroll anchoring (see overflow-anchor
+// below — it picks bad anchors when older history prepends). So as images and
+// wrapped text ABOVE the target finish resolving, everything below shifts down
+// while scrollTop stays put, and the row the user asked for drifts off screen.
+// Re-centre while that settles.
+//
+// Measured on device, not assumed: a jump into a 1870-event slice took 74
+// corrections before it stopped moving. A smaller slice took none — which is
+// why the drift only showed up sometimes, and why it can't be reasoned away.
+const SCROLL_HOLD_MS = 1200;
+// Don't fight sub-pixel noise, do fix a row that has moved meaningfully.
+const SCROLL_DRIFT_PX = 8;
+
+function holdCentred(el: HTMLElement, target: HTMLElement, id: number | string): void {
+  const until = performance.now() + SCROLL_HOLD_MS;
+  let released = false;
+  // The moment the user takes over, stop — being dragged back to a row you're
+  // scrolling away from is worse than the drift.
+  const release = () => {
+    released = true;
+  };
+  el.addEventListener('touchstart', release, { passive: true, once: true });
+  el.addEventListener('wheel', release, { passive: true, once: true });
+
+  const tick = () => {
+    if (released || props.pendingScrollId !== id) return finish();
+    // Re-query: a re-render can replace the node under us.
+    const node = el.querySelector(`[data-msg-id="${id}"]`) as HTMLElement | null;
+    if (node) {
+      const rect = node.getBoundingClientRect();
+      const box = el.getBoundingClientRect();
+      const drift = rect.top + rect.height / 2 - (box.top + box.height / 2);
+      if (Math.abs(drift) > SCROLL_DRIFT_PX) {
+        node.scrollIntoView({ block: 'center', behavior: 'auto' });
+      }
+    }
+    if (performance.now() < until) requestAnimationFrame(tick);
+    else finish();
+  };
+  function finish(): void {
+    el.removeEventListener('touchstart', release);
+    el.removeEventListener('wheel', release);
+  }
+  requestAnimationFrame(tick);
+}
+
 watch(
   () => props.pendingScrollId,
   async (id) => {
@@ -2140,9 +2189,13 @@ watch(
         return;
       }
       stickToBottom.value = false;
-      target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      // 'auto', not 'smooth': a jump is a teleport, and an animated scroll over
+      // a slice this size is both meaningless and fragile — it races the layout
+      // settling below and loses.
+      target.scrollIntoView({ block: 'center', behavior: 'auto' });
       target.classList.add('scroll-target');
       setTimeout(() => target.classList.remove('scroll-target'), 1500);
+      holdCentred(el, target as HTMLElement, id);
     };
     tryScroll();
   },

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -2158,10 +2158,18 @@ function holdCentred(el: HTMLElement, target: HTMLElement, id: number | string):
     });
   }
 
+  // Cached across frames: rows are keyed, so the node only changes when a
+  // re-render actually replaces it — which isConnected detects. Without the
+  // cache every frame of the hold pays an attribute-selector scan over the
+  // whole slice even when nothing is drifting (the common case).
+  let node: HTMLElement | null = target;
   const tick = () => {
-    if (released || props.pendingScrollId !== id) return finish();
-    // Re-query: a re-render can replace the node under us.
-    const node = el.querySelector(`[data-msg-id="${id}"]`) as HTMLElement | null;
+    // el.isConnected: the scroller can be unmounted mid-hold (buffer switch,
+    // screen change) — stop instead of measuring detached rects to deadline.
+    if (released || props.pendingScrollId !== id || !el.isConnected) return finish();
+    if (!node || !node.isConnected) {
+      node = el.querySelector(`[data-msg-id="${id}"]`) as HTMLElement | null;
+    }
     if (node) {
       const rect = node.getBoundingClientRect();
       const box = el.getBoundingClientRect();

--- a/vue_client/src/components/MessageList.vue
+++ b/vue_client/src/components/MessageList.vue
@@ -2143,12 +2143,20 @@ function holdCentred(el: HTMLElement, target: HTMLElement, id: number | string):
   const until = performance.now() + SCROLL_HOLD_MS;
   let released = false;
   // The moment the user takes over, stop — being dragged back to a row you're
-  // scrolling away from is worse than the drift.
+  // scrolling away from is worse than the drift. Keyboard and pointer count as
+  // taking over too: this same component binds PageUp/PageDown to scroll, and a
+  // scrollbar drag is a mousedown, so listening for touch and wheel alone would
+  // fight all of them for over a second.
   const release = () => {
     released = true;
   };
-  el.addEventListener('touchstart', release, { passive: true, once: true });
-  el.addEventListener('wheel', release, { passive: true, once: true });
+  const RELEASE_ON = ['touchstart', 'wheel', 'pointerdown', 'keydown'] as const;
+  for (const evt of RELEASE_ON) {
+    (evt === 'keydown' ? window : el).addEventListener(evt, release, {
+      passive: true,
+      once: true,
+    });
+  }
 
   const tick = () => {
     if (released || props.pendingScrollId !== id) return finish();
@@ -2166,8 +2174,9 @@ function holdCentred(el: HTMLElement, target: HTMLElement, id: number | string):
     else finish();
   };
   function finish(): void {
-    el.removeEventListener('touchstart', release);
-    el.removeEventListener('wheel', release);
+    for (const evt of RELEASE_ON) {
+      (evt === 'keydown' ? window : el).removeEventListener(evt, release);
+    }
   }
   requestAnimationFrame(tick);
 }

--- a/vue_client/src/composables/deferredReady.ts
+++ b/vue_client/src/composables/deferredReady.ts
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+// Lives in composables/, not lib/: it leans on Vue's watch, and lib/ is
+// documented (AGENTS.md) as framework-free logic. Not a use* composable — it
+// needs no component context — but this is the Vue-coupled directory.
 import { watch } from 'vue';
 
 // How long to wait for the app to become able to honor a cold-start deep link

--- a/vue_client/src/composables/useBufferRoute.integration.test.ts
+++ b/vue_client/src/composables/useBufferRoute.integration.test.ts
@@ -8,7 +8,7 @@
 // and everything that reads `route.params` to decide whether to navigate is
 // reading a value that lags a push by a tick. These run against the real router.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { defineComponent, h, reactive } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createRouter, createMemoryHistory, RouterView } from 'vue-router';
@@ -43,6 +43,8 @@ function known(key: string, id: number): void {
 /** Let an in-flight navigation actually land, the way a real gesture would. */
 const settle = () => new Promise((r) => setTimeout(r, 0));
 
+const mounted: Array<{ unmount: () => void }> = [];
+
 async function mkApp() {
   const router = createRouter({
     history: createMemoryHistory(),
@@ -63,6 +65,7 @@ async function mkApp() {
   );
   // Record only once the initial `/` navigation has landed, so `navs` counts
   // what the test does rather than the router booting.
+  mounted.push(app);
   await router.isReady();
   const navs: string[] = [];
   router.afterEach((to) => navs.push(to.fullPath));
@@ -83,6 +86,14 @@ async function tapBuffer(
 beforeEach(() => {
   s.networks.activeKey = null;
   s.buffers = {};
+});
+
+afterEach(() => {
+  // Every mount adds another useBufferRoute, and they SHARE the module-level
+  // in-flight guard — a leaked one will swallow the next test's navigation and
+  // push it into a stale router. (Found the hard way: four live instances made
+  // an entire suite pass for the wrong reason.)
+  while (mounted.length) mounted.pop()?.unmount();
 });
 
 describe('useBufferRoute against the real router', () => {
@@ -136,5 +147,73 @@ describe('useBufferRoute against the real router', () => {
     router.back();
     await settle();
     expect(router.currentRoute.value.fullPath).toBe('/');
+  });
+});
+
+describe('navigating off the members screen', () => {
+  it('goes to the buffer even though the members route carries the same id', async () => {
+    // `/buffer/7/members` has params.id === '7' too, so a guard that only
+    // compares the id reads it as "already there" and does nothing. Then a jump
+    // to the buffer you are ALREADY in — an in-app toast (#444), a search hit —
+    // can't carry you off the member list, and the messages scroll underneath
+    // it unseen.
+    known('1::#a', 7);
+    const { router } = await mkApp();
+    await tapBuffer(router, '1::#a', 7);
+    await router.push('/buffer/7/members');
+    await settle();
+
+    pushBuffer(router, 7); // what useJumpToMessage's afterActivate does
+    await settle();
+
+    expect(router.currentRoute.value.name).toBe('buffer');
+    expect(router.currentRoute.value.fullPath).toBe('/buffer/7');
+  });
+});
+
+describe('a cold-start deep link vs. a later activation', () => {
+  it('lets ANY activation take the URL from a pending resolution', async () => {
+    // Documenting the contract, not a wish: while `/buffer/7` is still waiting
+    // on the socket, an activation of something else wins and cancels the wait.
+    // That has to be so — a user who clicks another buffer mid-resolve must not
+    // be left on a URL naming somewhere they aren't, then yanked there when it
+    // resolves.
+    //
+    // The cost is that a DEFAULT activation wins too, which is how a cold deep
+    // link came to be overwritten by the system buffer. The guard therefore
+    // lives at the default's call site, where deliberate and default can be
+    // told apart — see utils/defaultBuffer.
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'chat', component: { render: () => null } },
+        { path: '/buffer/:id', name: 'buffer', component: { render: () => null } },
+        { path: '/buffer/:id/members', name: 'buffer-members', component: { render: () => null } },
+      ],
+    });
+    await router.push('/buffer/7');
+    const app = mount(
+      defineComponent({
+        setup() {
+          useBufferRoute();
+          return () => h(RouterView);
+        },
+      }),
+      { global: { plugins: [router] } },
+    );
+    mounted.push(app);
+    await settle();
+
+    known('2::#other', 3);
+    s.networks.activeKey = '2::#other';
+    await settle();
+
+    expect(router.currentRoute.value.fullPath).toBe('/buffer/3');
+
+    // And the abandoned wait is dead: buffer 7 arriving later must not drag the
+    // user back.
+    known('1::#a', 7);
+    await settle();
+    expect(s.networks.activeKey).toBe('2::#other');
   });
 });

--- a/vue_client/src/composables/useBufferRoute.integration.test.ts
+++ b/vue_client/src/composables/useBufferRoute.integration.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// The sibling suite mocks vue-router, which makes navigation synchronous and so
+// cannot see the bug this file exists for: router.push resolves ASYNCHRONOUSLY,
+// and everything that reads `route.params` to decide whether to navigate is
+// reading a value that lags a push by a tick. These run against the real router.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { defineComponent, h, reactive } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createRouter, createMemoryHistory, RouterView } from 'vue-router';
+
+const s = reactive({
+  networks: { activeKey: null as string | null },
+  buffers: {} as Record<string, { id?: number; networkId: number | null; target: string }>,
+});
+
+vi.mock('./useSocket.js', () => ({ connected: { value: true } }));
+vi.mock('../stores/networks.js', () => ({ useNetworksStore: () => s.networks }));
+vi.mock('../stores/toasts.js', () => ({ useToastsStore: () => ({ push: () => {} }) }));
+vi.mock('../stores/buffers.js', () => ({
+  useBuffersStore: () => ({
+    byKey: (k: string) => s.buffers[k] ?? null,
+    byId: (id: number) => Object.values(s.buffers).find((b) => b.id === id) ?? null,
+    activate: (networkId: number | null, target: string) => {
+      s.networks.activeKey = networkId == null ? target : `${networkId}::${target}`;
+    },
+  }),
+  bufferKey: (networkId: number | null, target: string) =>
+    networkId == null ? target : `${networkId}::${target}`,
+}));
+
+import { useBufferRoute, pushBuffer } from './useBufferRoute.js';
+
+function known(key: string, id: number): void {
+  const sep = key.indexOf('::');
+  s.buffers[key] = { networkId: Number(key.slice(0, sep)), target: key.slice(sep + 2), id };
+}
+
+/** Let an in-flight navigation actually land, the way a real gesture would. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+async function mkApp() {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'chat', component: { render: () => null } },
+      { path: '/buffer/:id', name: 'buffer', component: { render: () => null } },
+      { path: '/buffer/:id/members', name: 'buffer-members', component: { render: () => null } },
+    ],
+  });
+  const app = mount(
+    defineComponent({
+      setup() {
+        useBufferRoute();
+        return () => h(RouterView);
+      },
+    }),
+    { global: { plugins: [router] } },
+  );
+  // Record only once the initial `/` navigation has landed, so `navs` counts
+  // what the test does rather than the router booting.
+  await router.isReady();
+  const navs: string[] = [];
+  router.afterEach((to) => navs.push(to.fullPath));
+  return { router, app, navs };
+}
+
+/** Tap a row in the buffer list: the store activates, the shell navigates. */
+async function tapBuffer(
+  router: Awaited<ReturnType<typeof mkApp>>['router'],
+  key: string,
+  id: number,
+) {
+  s.networks.activeKey = key;
+  pushBuffer(router, id); // what MobileChat's openActiveBuffer does
+  await settle();
+}
+
+beforeEach(() => {
+  s.networks.activeKey = null;
+  s.buffers = {};
+});
+
+describe('useBufferRoute against the real router', () => {
+  it('opens a buffer with exactly ONE navigation', async () => {
+    known('1::#a', 7);
+    const { router, navs } = await mkApp();
+
+    await tapBuffer(router, '1::#a', 7);
+
+    // Two pushes land two history entries for one tap, so the first swipe back
+    // appears to do nothing — and the interleaved navigations resolve through
+    // an intermediate route naming the PREVIOUS buffer, which is visible as the
+    // wrong channel highlighted in the list.
+    expect(navs).toEqual(['/buffer/7']);
+  });
+
+  it('leaves the active buffer alone when swiping back to the list', async () => {
+    known('1::#a', 7);
+    known('1::#b', 8);
+    const { router, navs } = await mkApp();
+
+    await tapBuffer(router, '1::#a', 7);
+    await router.push('/'); // back arrow to the list
+    await settle();
+    await tapBuffer(router, '1::#b', 8);
+    navs.length = 0;
+
+    router.back(); // the swipe
+    await settle();
+
+    expect(router.currentRoute.value.fullPath).toBe('/');
+    // The list highlights whatever activeKey names. Landing here with #a active
+    // — because a stray navigation resolved through /buffer/7 on the way — is
+    // the flash of the wrong row reported on device.
+    expect(s.networks.activeKey).toBe('1::#b');
+    expect(navs).toEqual(['/']);
+  });
+
+  it('walks one screen per gesture: members -> buffer -> list', async () => {
+    known('1::#a', 7);
+    const { router } = await mkApp();
+
+    await tapBuffer(router, '1::#a', 7);
+    await router.push('/buffer/7/members');
+    await settle();
+
+    router.back();
+    await settle();
+    expect(router.currentRoute.value.name).toBe('buffer');
+
+    router.back();
+    await settle();
+    expect(router.currentRoute.value.fullPath).toBe('/');
+  });
+});

--- a/vue_client/src/composables/useBufferRoute.test.ts
+++ b/vue_client/src/composables/useBufferRoute.test.ts
@@ -310,8 +310,11 @@ describe('useBufferRoute — URL to active buffer', () => {
     start();
     await activate(':system:');
 
-    expect(h.replace).toHaveBeenCalledWith('/system');
-    expect(h.push).not.toHaveBeenCalled();
+    // PUSH, not replace: opening the console is a navigation like any other
+    // buffer switch. Replacing swallowed the entry the user came from, so
+    // reading a channel then opening the console lost the channel from history.
+    expect(h.push).toHaveBeenCalledWith('/system');
+    expect(h.replace).not.toHaveBeenCalled();
   });
 
   it('drops a non-numeric /buffer/<junk> back to /', async () => {
@@ -392,9 +395,13 @@ describe('useBufferRoute — URL to active buffer', () => {
 
     await vi.advanceTimersByTimeAsync(10_000);
 
-    expect(h.activate).not.toHaveBeenCalled();
     expect(h.toast).toHaveBeenCalledTimes(1);
     expect(h.replace).toHaveBeenCalledWith('/');
+    // And it lands SOMEWHERE. Desktop has no "nothing selected" screen, and its
+    // mount-time fallback already declined because the URL named a buffer at
+    // the time; nothing re-runs it, so a stale bookmark used to end on the
+    // blank pane that #355's landing rule exists to prevent.
+    expect(h.activate).toHaveBeenCalledWith(null, ':system:');
   });
 
   it('does not toast for a stale wait once the user has navigated on', async () => {

--- a/vue_client/src/composables/useBufferRoute.test.ts
+++ b/vue_client/src/composables/useBufferRoute.test.ts
@@ -40,9 +40,16 @@ const h = vi.hoisted(() => ({
 function applyPath(to: string): void {
   const [path] = to.split('?');
   h.s.route.path = path;
+  const members = /^\/buffer\/([^/]+)\/members$/.exec(path);
   const m = /^\/buffer\/([^/]+)$/.exec(path);
-  h.s.route.params = m ? { id: m[1] } : {};
-  h.s.route.name = m ? 'buffer' : path === '/system' ? 'system' : 'chat';
+  h.s.route.params = members ? { id: members[1] } : m ? { id: m[1] } : {};
+  h.s.route.name = members
+    ? 'buffer-members'
+    : m
+      ? 'buffer'
+      : path === '/system'
+        ? 'system'
+        : 'chat';
 }
 
 vi.mock('vue-router', () => ({
@@ -127,7 +134,13 @@ beforeEach(() => {
   h.s = reactive({
     route: { path: '/', name: 'chat' as string, params: {} as Record<string, string> },
     connected: true,
-    networks: { activeKey: null as string | null },
+    networks: {
+      activeKey: null as string | null,
+      // As on the real store: deactivate without closing anything.
+      clearActive() {
+        this.activeKey = null;
+      },
+    },
     buffers: {} as Record<string, { id?: number; networkId: number | null; target: string }>,
   });
   h.push.mockReset();
@@ -393,6 +406,39 @@ describe('useBufferRoute — URL to active buffer', () => {
     expect(h.s.networks.activeKey).toBe('1::#chan');
   });
 
+  it('DOES deactivate an id-less buffer when the URL lands on /', async () => {
+    // The back-gesture lock. An optimistic DM has no URL, so the mobile shell
+    // shows it on EVERY route via activeLacksId — landing on `/` while it is
+    // active can only mean the user backed out of it (the platform gesture, or
+    // goList normalizing). Holding it pinned the shell on the DM screen with a
+    // back button that moved the URL and nothing else.
+    known('1::#chan', 7);
+    start();
+    await activate('1::#chan');
+    known('1::pal'); // no id
+    await activate('1::pal'); // URL stays /buffer/7 — nothing can name the DM
+
+    applyPath('/'); // the back gesture
+    await nextTick();
+
+    expect(h.s.networks.activeKey).toBeNull();
+  });
+
+  it('does not push when an activation echoes onto its own members route', async () => {
+    // Back onto a /buffer/7/members history entry (or a members deep link
+    // resolving): the inbound side activates buffer 7, and the outbound
+    // watcher must read the members route as "already there" — pushing
+    // /buffer/7 here ejects the user from the member list they just reached.
+    // This is why routeId() is NOT name-gated; see its divergence note.
+    known('1::#a', 7);
+    start();
+    applyPath('/buffer/7/members');
+    await nextTick();
+
+    expect(h.activate).toHaveBeenCalledWith(1, '#a');
+    expect(h.push).not.toHaveBeenCalled();
+  });
+
   it('defers an unresolvable id until the buffer arrives over the socket', async () => {
     vi.useFakeTimers();
     h.s.connected = false;
@@ -470,5 +516,23 @@ describe('useBufferRoute — URL to active buffer', () => {
 
     expect(h.activate).toHaveBeenCalledWith(1, '#chan');
     expect(h.toast).not.toHaveBeenCalled();
+  });
+
+  it('cancels a dead-id wait when an id-less buffer activates', async () => {
+    // Send DM mid-wait: the optimistic buffer cannot move the URL, so the
+    // timeout's routeId() guard alone can never suppress the stale toast —
+    // the route still names the dead id. The 'pending' branch has to cancel
+    // the wait like every other activation does.
+    vi.useFakeTimers();
+    applyPath('/buffer/999');
+    start();
+    await nextTick();
+
+    known('1::newpal'); // no id
+    await activate('1::newpal');
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(h.toast).not.toHaveBeenCalled();
+    expect(h.replace).not.toHaveBeenCalled();
   });
 });

--- a/vue_client/src/composables/useBufferRoute.test.ts
+++ b/vue_client/src/composables/useBufferRoute.test.ts
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { defineComponent, nextTick, reactive } from 'vue';
+import { mount } from '@vue/test-utils';
+
+// The composable's whole job is wiring, so everything it talks to is stubbed and
+// the assertions are about which navigations happen — and, as much as anything,
+// which DON'T: a feedback loop between the two directions would surface as an
+// endless stream of pushes.
+//
+// The fakes must be exactly as reactive as the real thing and no more. An
+// earlier version of this file backed the buffer-id lookup with a reactive
+// object while production read a plain module-level Map; every test passed and
+// the cold-start deep link never fired in the app. `byId` below is a store
+// getter reading reactive state, which is what the real one is.
+//
+// `h.s` is assigned in beforeEach: vi.hoisted() runs before any import, so it
+// can't build reactive state itself — but the mock factories only CREATE the
+// exported bindings there, and every getter body runs later, from inside a test.
+const h = vi.hoisted(() => ({
+  s: null as any,
+  push: vi.fn<(to: string) => void>(),
+  replace: vi.fn<(to: string) => void>(),
+  // Echoes the activation back into activeKey, exactly as the real
+  // buffers.activate() does. Load-bearing, not convenience: without the echo
+  // the inbound direction never feeds the outbound one, and the feedback loop
+  // these tests exist to pin down is never actually run.
+  activate: vi.fn<(networkId: number | null, target: string) => void>((networkId, target) => {
+    h.s.networks.activeKey = networkId == null ? target : `${networkId}::${target}`;
+  }),
+  toast: vi.fn<(t: unknown) => void>(),
+}));
+
+// Navigation applies to the fake route, so the composable observes the same
+// param flip a real router would produce.
+function applyPath(to: string): void {
+  const [path] = to.split('?');
+  h.s.route.path = path;
+  const m = /^\/buffer\/([^/]+)$/.exec(path);
+  h.s.route.params = m ? { id: m[1] } : {};
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => h.s.route,
+  useRouter: () => ({
+    // currentRoute is the same reactive route object useRoute() hands back, as
+    // on the real router — pushBuffer reads it to skip a navigation to where we
+    // already are.
+    currentRoute: {
+      get value() {
+        return h.s.route;
+      },
+    },
+    // push/replace both return a promise, like the real router — pushBuffer
+    // chains off it to clear its in-flight guard, so a void-returning fake
+    // would wedge after the first navigation.
+    push: (to: string) => {
+      h.push(to);
+      applyPath(to);
+      return Promise.resolve();
+    },
+    replace: (to: string) => {
+      h.replace(to);
+      applyPath(to);
+      return Promise.resolve();
+    },
+  }),
+}));
+vi.mock('./useSocket.js', () => ({
+  connected: {
+    get value(): boolean {
+      return h.s.connected;
+    },
+    set value(v: boolean) {
+      h.s.connected = v;
+    },
+  },
+}));
+vi.mock('../stores/networks.js', () => ({ useNetworksStore: () => h.s.networks }));
+vi.mock('../stores/toasts.js', () => ({ useToastsStore: () => ({ push: h.toast }) }));
+vi.mock('../stores/buffers.js', () => ({
+  useBuffersStore: () => ({
+    byKey: (k: string) => h.s.buffers[k] ?? null,
+    // Scans the reactive buffer collection, like the real getter — so a watcher
+    // over it re-fires when a buffer arrives or learns its id.
+    byId: (id: number) => Object.values(h.s.buffers).find((b: any) => b.id === id) ?? null,
+    activate: h.activate,
+  }),
+  bufferKey: (networkId: number | null, target: string) =>
+    networkId == null ? target : `${networkId}::${target}`,
+}));
+
+import { useBufferRoute } from './useBufferRoute.js';
+
+const Harness = defineComponent({
+  setup() {
+    useBufferRoute();
+    return () => null;
+  },
+});
+
+/** Open a buffer the way the rest of the app does: flip activeKey. */
+async function activate(key: string): Promise<void> {
+  h.s.networks.activeKey = key;
+  await nextTick();
+}
+
+/** Register a buffer as known to the store, keyed the way the real store keys
+ *  it. No id models a buffer created optimistically, before the server has
+ *  answered with its row id. */
+function known(key: string, id?: number): void {
+  const sep = key.indexOf('::');
+  const networkId = sep === -1 ? null : Number(key.slice(0, sep));
+  const target = sep === -1 ? key : key.slice(sep + 2);
+  h.s.buffers[key] = { networkId, target, ...(id == null ? {} : { id }) };
+}
+
+let wrapper: ReturnType<typeof mount> | null = null;
+const start = () => (wrapper = mount(Harness));
+
+beforeEach(() => {
+  h.s = reactive({
+    route: { path: '/', params: {} as Record<string, string> },
+    connected: true,
+    networks: { activeKey: null as string | null },
+    buffers: {} as Record<string, { id?: number; networkId: number | null; target: string }>,
+  });
+  h.push.mockReset();
+  h.replace.mockReset();
+  h.activate.mockClear();
+  h.toast.mockReset();
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  vi.useRealTimers();
+});
+
+describe('useBufferRoute — active buffer to URL', () => {
+  it('pushes /buffer/<id> when a buffer is activated', async () => {
+    known('1::#chan', 7);
+    start();
+    await activate('1::#chan');
+
+    expect(h.push).toHaveBeenCalledWith('/buffer/7');
+  });
+
+  it('pushes once per buffer and does not re-push the route it just made', async () => {
+    known('1::#a', 7);
+    known('1::#b', 8);
+    start();
+    await activate('1::#a');
+    await activate('1::#b');
+    await nextTick();
+
+    // The loop guard: each activation produces exactly one navigation, and the
+    // route change it causes doesn't bounce back through the inbound watcher
+    // into another push.
+    expect(h.push.mock.calls).toEqual([['/buffer/7'], ['/buffer/8']]);
+    // Nor did the inbound direction re-activate what was already active.
+    expect(h.activate).not.toHaveBeenCalled();
+  });
+
+  it.each([['#chan'], ['&local'], ['+modeless'], ['!12345chan'], ['alice']])(
+    'addresses %s by id, with no name in the URL',
+    async (target) => {
+      known(`1::${target}`, 42);
+      start();
+      await activate(`1::${target}`);
+
+      expect(h.push).toHaveBeenCalledWith('/buffer/42');
+      // The point of id addressing: no sigil ever reaches the URL, so there is
+      // no encoding path left to get wrong.
+      expect(h.push.mock.calls[0][0]).not.toContain(target);
+    },
+  );
+
+  it('holds the URL for an optimistic buffer, then pushes when its id lands', async () => {
+    // "Send DM" to a nick never messaged before: the buffer exists locally but
+    // the server hasn't answered with a row id yet.
+    known('1::#old', 7);
+    start();
+    await activate('1::#old');
+    h.push.mockReset();
+
+    known('1::newpal'); // no id
+    await activate('1::newpal');
+    expect(h.push).not.toHaveBeenCalled();
+
+    known('1::newpal', 9); // server answers
+    await nextTick();
+
+    // Push, not replace — the buffer we came from has to keep its entry, or
+    // back/swipe would skip straight past it.
+    expect(h.push).toHaveBeenCalledWith('/buffer/9');
+    expect(h.replace).not.toHaveBeenCalled();
+  });
+
+  it('replaces to / when the active buffer goes away', async () => {
+    known('1::#chan', 7);
+    start();
+    await activate('1::#chan');
+
+    h.s.networks.activeKey = null; // buffer closed, or its network was removed
+    await nextTick();
+
+    expect(h.replace).toHaveBeenCalledWith('/');
+  });
+
+  it('replaces to / when an ID-LESS active buffer goes away', async () => {
+    // The 'none'/'pending' distinction: both mean "no id to name it with", so
+    // collapsing them would leave this transition silent and the URL pointing at
+    // a buffer that is gone.
+    known('1::#chan', 7);
+    start();
+    await activate('1::#chan');
+    known('1::pal'); // no id
+    await activate('1::pal');
+
+    // Landing on an id-less buffer is NOT "nothing is active" — the URL just
+    // stays where it was. Bouncing to / here would throw the user back to the
+    // buffer list the instant they opened a new DM.
+    expect(h.replace).not.toHaveBeenCalled();
+
+    h.s.networks.activeKey = null;
+    await nextTick();
+
+    expect(h.replace).toHaveBeenCalledExactlyOnceWith('/');
+  });
+
+  it('leaves the URL alone when a rename moves a buffer to a new key', async () => {
+    known('1::oldnick', 7);
+    start();
+    await activate('1::oldnick');
+    h.push.mockReset();
+
+    // A rename keeps the same Buffer (and id) under a new key — the id index
+    // re-points. The URL names the id, so it stays correct with no navigation.
+    delete h.s.buffers['1::oldnick'];
+    known('1::newnick', 7);
+    await activate('1::newnick');
+
+    expect(h.push).not.toHaveBeenCalled();
+    expect(h.s.route.path).toBe('/buffer/7');
+  });
+});
+
+describe('useBufferRoute — URL to active buffer', () => {
+  it('activates the buffer a launch URL names', async () => {
+    known('1::#chan', 7);
+    applyPath('/buffer/7'); // the launch URL is already in place when we mount
+    start();
+    await nextTick();
+
+    expect(h.activate).toHaveBeenCalledWith(1, '#chan');
+    expect(h.push).not.toHaveBeenCalled();
+  });
+
+  it('activates on a back/forward hop', async () => {
+    known('1::#a', 7);
+    known('1::#b', 8);
+    start();
+    await activate('1::#a');
+    await activate('1::#b');
+    h.activate.mockClear();
+    h.push.mockReset(); // discard the two setup activations' own pushes
+
+    // Browser back — or, on an installed PWA, the platform swipe gesture, which
+    // is the same history.back(). The route moves and nothing else does.
+    applyPath('/buffer/7');
+    await nextTick();
+
+    expect(h.activate).toHaveBeenCalledWith(1, '#a');
+    // And the activation it triggered must NOT push the route back on. This is
+    // the whole loop guard: a back hop that re-pushes its own destination adds
+    // a forward entry every time, so back/forward (and the PWA swipe) would
+    // walk into a stack that grows in both directions and never leaves #a.
+    expect(h.push).not.toHaveBeenCalled();
+  });
+
+  it('ignores a non-numeric id rather than resolving NaN', async () => {
+    start();
+    applyPath('/buffer/nonsense');
+    await nextTick();
+
+    expect(h.activate).not.toHaveBeenCalled();
+    expect(h.toast).not.toHaveBeenCalled();
+  });
+
+  it('does not deactivate when navigating to /', async () => {
+    known('1::#chan', 7);
+    start();
+    await activate('1::#chan');
+    h.activate.mockClear();
+
+    // Mobile "back to the buffer list": a screen change, not a buffer change.
+    // Deactivating here would run activate()'s mark-read and divider snapshot.
+    applyPath('/');
+    await nextTick();
+
+    expect(h.activate).not.toHaveBeenCalled();
+    expect(h.s.networks.activeKey).toBe('1::#chan');
+  });
+
+  it('defers an unresolvable id until the buffer arrives over the socket', async () => {
+    vi.useFakeTimers();
+    h.s.connected = false;
+    applyPath('/buffer/7');
+    start();
+    await nextTick();
+
+    // Cold launch: the route landed before any buffer did.
+    expect(h.activate).not.toHaveBeenCalled();
+
+    known('1::#chan', 7);
+    h.s.connected = true;
+    await nextTick();
+
+    expect(h.activate).toHaveBeenCalledWith(1, '#chan');
+    expect(h.toast).not.toHaveBeenCalled();
+  });
+
+  it('resolves when the buffers land AFTER the socket connects', async () => {
+    // The real cold-start order, and the one that matters: useSocket flips
+    // `connected` on open, and only then does the snapshot frame arrive and
+    // register any buffers. A resolver that only re-checks when `connected`
+    // changes has already missed its one chance by the time the ids exist.
+    vi.useFakeTimers();
+    h.s.connected = false;
+    applyPath('/buffer/7');
+    start();
+    await nextTick();
+
+    h.s.connected = true; // socket open — no buffers yet
+    await nextTick();
+    expect(h.activate).not.toHaveBeenCalled();
+
+    known('1::#chan', 7); // snapshot frame lands
+    await nextTick();
+
+    expect(h.activate).toHaveBeenCalledWith(1, '#chan');
+    expect(h.toast).not.toHaveBeenCalled();
+  });
+
+  it('toasts and drops back to / when the buffer never arrives', async () => {
+    vi.useFakeTimers();
+    h.s.connected = false;
+    applyPath('/buffer/7');
+    start();
+    await nextTick();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(h.activate).not.toHaveBeenCalled();
+    expect(h.toast).toHaveBeenCalledTimes(1);
+    expect(h.replace).toHaveBeenCalledWith('/');
+  });
+
+  it('does not toast for a stale wait once the user has navigated on', async () => {
+    vi.useFakeTimers();
+    h.s.connected = false;
+    applyPath('/buffer/7');
+    start();
+    await nextTick();
+
+    // The user reaches a real buffer before the dead id's timeout fires. The
+    // superseded wait must not fire its toast on top of a working session.
+    known('1::#chan', 8);
+    h.s.connected = true;
+    applyPath('/buffer/8');
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(h.activate).toHaveBeenCalledWith(1, '#chan');
+    expect(h.toast).not.toHaveBeenCalled();
+  });
+});

--- a/vue_client/src/composables/useBufferRoute.test.ts
+++ b/vue_client/src/composables/useBufferRoute.test.ts
@@ -95,7 +95,7 @@ vi.mock('../stores/buffers.js', () => ({
     networkId == null ? target : `${networkId}::${target}`,
 }));
 
-import { useBufferRoute } from './useBufferRoute.js';
+import { useBufferRoute, pushBuffer } from './useBufferRoute.js';
 
 const Harness = defineComponent({
   setup() {
@@ -251,6 +251,53 @@ describe('useBufferRoute — active buffer to URL', () => {
   });
 });
 
+describe('pushBuffer — one guard, not two', () => {
+  /** A router parked at `at`, whose pushes stay in flight until released. */
+  function pendingRouter(at: string) {
+    const pushes: string[] = [];
+    let release!: () => void;
+    const settled = new Promise<void>((r) => (release = r));
+    const m = /^\/buffer\/(\d+)$/.exec(at);
+    return {
+      pushes,
+      release,
+      router: {
+        currentRoute: {
+          value: { name: m ? 'buffer' : 'chat', params: m ? { id: m[1] } : {} },
+        },
+        push: (to: string) => {
+          pushes.push(to);
+          return settled;
+        },
+      } as any,
+    };
+  }
+
+  it('navigates to the current route when a push elsewhere is in flight', async () => {
+    // The route lags a push — the whole reason an in-flight target is tracked.
+    // pushBuffer used to re-check the route ANYWAY, so with /buffer/8 in flight
+    // a re-activation of #a (id 7, which the route still names) read as
+    // "already there" and was dropped; /buffer/8 then landed and the inbound
+    // binding moved the user to #b. Two guards for one decision.
+    const { router, pushes, release } = pendingRouter('/buffer/7');
+
+    pushBuffer(router, 8); // in flight, route still says 7
+    pushBuffer(router, 7); // the user comes back to #a before it lands
+
+    expect(pushes).toEqual(['/buffer/8', '/buffer/7']);
+    release();
+    await Promise.resolve();
+  });
+
+  it('still skips a push to where we already are', async () => {
+    const { router, pushes, release } = pendingRouter('/buffer/7');
+    pushBuffer(router, 7);
+    expect(pushes).toEqual([]);
+    release();
+    await Promise.resolve();
+  });
+});
+
 describe('useBufferRoute — URL to active buffer', () => {
   it('activates the buffer a launch URL names', async () => {
     known('1::#chan', 7);
@@ -397,11 +444,13 @@ describe('useBufferRoute — URL to active buffer', () => {
 
     expect(h.toast).toHaveBeenCalledTimes(1);
     expect(h.replace).toHaveBeenCalledWith('/');
-    // And it lands SOMEWHERE. Desktop has no "nothing selected" screen, and its
-    // mount-time fallback already declined because the URL named a buffer at
-    // the time; nothing re-runs it, so a stale bookmark used to end on the
-    // blank pane that #355's landing rule exists to prevent.
-    expect(h.activate).toHaveBeenCalledWith(null, ':system:');
+    // And NOTHING else navigates. Activating a landing buffer here fired the
+    // outbound watcher, which pushed /system before this replace had finalized
+    // and cancelled it — leaving the dead /buffer/<id> one Back press away,
+    // where it would time out and toast all over again. Choosing where to land
+    // is the shell's job (DesktopChat's rule re-runs when the route settles).
+    expect(h.activate).not.toHaveBeenCalled();
+    expect(h.push).not.toHaveBeenCalled();
   });
 
   it('does not toast for a stale wait once the user has navigated on', async () => {

--- a/vue_client/src/composables/useBufferRoute.test.ts
+++ b/vue_client/src/composables/useBufferRoute.test.ts
@@ -42,6 +42,7 @@ function applyPath(to: string): void {
   h.s.route.path = path;
   const m = /^\/buffer\/([^/]+)$/.exec(path);
   h.s.route.params = m ? { id: m[1] } : {};
+  h.s.route.name = m ? 'buffer' : path === '/system' ? 'system' : 'chat';
 }
 
 vi.mock('vue-router', () => ({
@@ -124,7 +125,7 @@ const start = () => (wrapper = mount(Harness));
 
 beforeEach(() => {
   h.s = reactive({
-    route: { path: '/', params: {} as Record<string, string> },
+    route: { path: '/', name: 'chat' as string, params: {} as Record<string, string> },
     connected: true,
     networks: { activeKey: null as string | null },
     buffers: {} as Record<string, { id?: number; networkId: number | null; target: string }>,
@@ -290,6 +291,41 @@ describe('useBufferRoute — URL to active buffer', () => {
 
     expect(h.activate).not.toHaveBeenCalled();
     expect(h.toast).not.toHaveBeenCalled();
+  });
+
+  it('activates the system buffer from /system, and routes back to it by name', async () => {
+    h.s.buffers[':system:'] = { networkId: null, target: ':system:' }; // no id yet
+    start();
+    h.s.route.name = 'system';
+    h.s.route.path = '/system';
+    await nextTick();
+
+    expect(h.activate).toHaveBeenCalledWith(null, ':system:');
+  });
+
+  it('sends an active app-scoped buffer to /system rather than an id', async () => {
+    // It may have no row id at all before the socket connects, so an id-based
+    // URL would make the connection log unreachable exactly when it's wanted.
+    h.s.buffers[':system:'] = { networkId: null, target: ':system:' };
+    start();
+    await activate(':system:');
+
+    expect(h.replace).toHaveBeenCalledWith('/system');
+    expect(h.push).not.toHaveBeenCalled();
+  });
+
+  it('drops a non-numeric /buffer/<junk> back to /', async () => {
+    known('1::#chan', 7);
+    start();
+    await activate('1::#chan');
+    h.replace.mockReset();
+
+    applyPath('/buffer/nonsense');
+    await nextTick();
+
+    // Otherwise the address bar keeps asserting a buffer the shell isn't
+    // showing; an unknown NUMERIC id already ends the same way, on timeout.
+    expect(h.replace).toHaveBeenCalledWith('/');
   });
 
   it('does not deactivate when navigating to /', async () => {

--- a/vue_client/src/composables/useBufferRoute.ts
+++ b/vue_client/src/composables/useBufferRoute.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { onBeforeUnmount, watch } from 'vue';
+import { useRoute, useRouter, type Router } from 'vue-router';
+import { useNetworksStore } from '../stores/networks.js';
+import { useBuffersStore, bufferKey } from '../stores/buffers.js';
+import { useToastsStore } from '../stores/toasts.js';
+import { connected } from './useSocket.js';
+import { whenReady } from '../lib/deferredReady.js';
+
+// Two-way binding between the active buffer and the URL (#744), so every buffer
+// has a direct link and browser back/forward walks between them. On an installed
+// PWA that is also what makes the platform's back gesture work — the iOS
+// left-edge swipe and the Android system back both just call history.back() —
+// which is why #200 needs no gesture code of its own.
+//
+// This sits alongside navHistory (#309, Cmd+[ / ]) rather than replacing it. The
+// two are deliberately independent: navHistory is a BUFFER trail with its own
+// cursor, dead-buffer skipping and a 100-entry cap; browser history is the
+// LOCATION stack. Neither drives the other, so they cannot desync. A hop driven
+// from here lands in navHistory as an ordinary visit (recordVisit's
+// consecutive-dupe collapse absorbs the degenerate case), and navHistory's own
+// back()/forward() go through activate() and so push a URL like any other
+// navigation — which is right, since a nav-history hop IS a navigation.
+
+// The buffer id of a navigation we've started but that hasn't landed yet.
+//
+// router.push resolves ASYNCHRONOUSLY, so `route.params.id` still reports the
+// old buffer for a tick after a push is issued — long enough for the activeKey
+// watcher below to check the route, see a stale id, and push the same buffer a
+// second time. Opening a buffer has two legitimate callers (the watcher, and
+// MobileChat's list tap, which has to cover re-tapping the buffer that is
+// already active), so both go through here and the guard is this synchronous
+// value rather than the lagging route.
+let inFlightId: number | null = null;
+
+/** Navigate to a buffer, unless we're already there or already on the way. */
+export function pushBuffer(router: Router, id: number): void {
+  if (inFlightId === id) return;
+  // Already the current route. vue-router would reject this as a duplicated
+  // navigation anyway, but it is reached on every single buffer open — the
+  // watcher pushes, the route lands, and the click handler then asks for the
+  // same place ~30ms later — so it is worth not starting the navigation at all.
+  if (router.currentRoute.value.params.id === String(id)) return;
+  inFlightId = id;
+  void router.push(`/buffer/${id}`).finally(() => {
+    if (inFlightId === id) inFlightId = null;
+  });
+}
+
+export function useBufferRoute(): void {
+  const router = useRouter();
+  const route = useRoute();
+  const networks = useNetworksStore();
+  const buffers = useBuffersStore();
+  const toasts = useToastsStore();
+
+  // Cleanup for the deferred cold-start resolver below. Only ever one in
+  // flight: a new route supersedes whatever the last one was waiting for.
+  // Null out BEFORE invoking so a cancel that navigates (the timeout path
+  // replaces to `/`) can't re-enter this and cancel its own successor.
+  let cancelPending: (() => void) | null = null;
+  function clearPending(): void {
+    const cancel = cancelPending;
+    cancelPending = null;
+    cancel?.();
+  }
+
+  // The id currently in the URL, or null at `/`. Params are strings; anything
+  // non-numeric (a hand-typed /buffer/foo) is treated as "no buffer" rather
+  // than parsed to NaN, which would silently match nothing downstream.
+  function routeId(): number | null {
+    const raw = route.params.id;
+    if (typeof raw !== 'string' || raw === '') return null;
+    const n = Number(raw);
+    return Number.isInteger(n) ? n : null;
+  }
+
+  // --- Outbound: active buffer -> URL -------------------------------------
+  //
+  // Watches the (key, id) PAIR, not activeKey alone. A buffer created
+  // optimistically — the profile modal's "Send DM" to a nick never DM'd before
+  // — has no id until the server answers (see Buffer.id), and there is no URL
+  // to name it with until then. So we hold: the URL stays on the previous
+  // buffer, and the moment the id lands this watcher re-fires and pushes. Push,
+  // not replace: the buffer we came from has to keep its history entry, or
+  // back/swipe would skip straight past it.
+  watch(
+    // Three distinct states, not two: 'none' (nothing active) and 'pending' (a
+    // buffer is active but has no server id yet) must not collapse into one
+    // value, or the transition between them wouldn't fire the watcher and the
+    // URL would be left naming a buffer that is gone.
+    (): 'none' | 'pending' | number => {
+      const key = networks.activeKey;
+      if (!key) return 'none';
+      return buffers.byKey(key)?.id ?? 'pending';
+    },
+    (id) => {
+      if (id === 'none') {
+        // The active buffer went away (closed, or its network was removed) —
+        // activeKey only nulls in those cases. Replace rather than push: this
+        // is involuntary, and a dead buffer must not stay reachable by pressing
+        // Forward.
+        clearPending();
+        if (route.path !== '/') void router.replace('/');
+        return;
+      }
+      if (id === 'pending') return; // no server id yet — see above
+      // Already there. This is the loop guard for the inbound direction: a
+      // route-driven activation produces an outbound target identical to the
+      // route that caused it, and stops here.
+      if (routeId() === id || inFlightId === id) return;
+      clearPending();
+      pushBuffer(router, id);
+    },
+  );
+
+  // --- Inbound: URL -> active buffer --------------------------------------
+  //
+  // Resolution goes through the store's `byId` getter, NOT the module-level
+  // bufferKeyForId index: that Map is invisible to Vue, so a watcher built on
+  // it would never re-fire when the ids finally land — and on a cold launch
+  // they land after the socket connects, which is the one case this whole
+  // deferral exists for.
+  function open(id: number): boolean {
+    const buf = buffers.byId(id);
+    if (!buf) return false;
+    const key = bufferKey(buf.networkId, buf.target);
+    if (key !== networks.activeKey) buffers.activate(buf.networkId, buf.target);
+    return true;
+  }
+
+  watch(
+    () => route.params.id,
+    () => {
+      const id = routeId();
+      clearPending();
+      if (id == null) return; // at `/` — see note below on not deactivating
+
+      if (open(id)) return;
+      // Unknown id. Either a cold start where buffers haven't arrived over the
+      // WS yet, or a link to a buffer this account no longer has. Wait for the
+      // first, time out into the second.
+      cancelPending = whenReady(
+        () => connected.value && buffers.byId(id) != null,
+        () => open(id),
+        () => {
+          // Say so rather than leaving the user on an empty shell wondering,
+          // and drop the URL back to `/` so it stops claiming a buffer we can't
+          // show. Guarded on the id still being the one in the URL: by now the
+          // user may have navigated somewhere that works.
+          if (routeId() !== id) return;
+          toasts.push({
+            kind: 'info',
+            title: 'Couldn’t open that conversation',
+            body: '',
+            ttlMs: 5000,
+          });
+          void router.replace('/');
+        },
+      );
+    },
+    // The first render has to honor whatever the launch URL named — that IS the
+    // cold-start deep link — not just later changes.
+    //
+    // Default 'pre' flush, deliberately: it runs the callback before the
+    // component re-renders in the same flush, so the activation is always in
+    // place by the time anything paints. A 'sync' flush was tried while chasing
+    // a reported flash, and would put activate()'s mark-read, socket sends and
+    // hydration inside the route mutation itself — real cost, and the flash
+    // turned out to be Safari compositing a cached snapshot during its back
+    // gesture, which no flush timing can touch.
+    { immediate: true },
+  );
+
+  // Navigating to `/` deliberately does NOT deactivate. `/` means "not looking
+  // at a buffer" (the mobile list screen), not "no buffer selected": clearing
+  // activeKey would run activate()'s mark-read, divider snapshot and detached
+  // cleanup for what is only a change of screen.
+
+  onBeforeUnmount(clearPending);
+}

--- a/vue_client/src/composables/useBufferRoute.ts
+++ b/vue_client/src/composables/useBufferRoute.ts
@@ -9,6 +9,7 @@ import { useToastsStore } from '../stores/toasts.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { connected } from './useSocket.js';
 import { whenReady } from '../lib/deferredReady.js';
+import { shouldPushBuffer } from '../utils/bufferNav.js';
 
 // Two-way binding between the active buffer and the URL (#744), so every buffer
 // has a direct link and browser back/forward walks between them. On an installed
@@ -121,13 +122,15 @@ export function useBufferRoute(): void {
       if (id === 'pending') return; // no server id yet — see above
       if (id === 'system') {
         clearPending();
-        if (route.name !== 'system') void router.replace('/system');
+        // Push, not replace. Opening the console is a navigation like any other
+        // buffer switch, and replacing swallows the entry the user came from —
+        // read a channel, tap the logo, press Back, and the channel is gone.
+        // It also beats MobileChat's own push (this watcher flushes first), so
+        // making it a replace here overrode the correct behaviour there.
+        if (route.name !== 'system') void router.push('/system');
         return;
       }
-      // Already there. This is the loop guard for the inbound direction: a
-      // route-driven activation produces an outbound target identical to the
-      // route that caused it, and stops here.
-      if (routeId() === id || inFlightId === id) return;
+      if (!shouldPushBuffer(id, routeId(), inFlightId)) return;
       clearPending();
       pushBuffer(router, id);
     },
@@ -191,6 +194,12 @@ export function useBufferRoute(): void {
             ttlMs: 5000,
           });
           void router.replace('/');
+          // Desktop has no "nothing selected" screen — #355's landing rule —
+          // and its mount-time fallback already declined, correctly, because
+          // the URL named a buffer at the time. Nothing re-runs it, so without
+          // this a stale bookmark ends on the blank pane that rule exists to
+          // prevent. Harmless on mobile: `/` still derives the list.
+          if (networks.activeKey == null) buffers.activate(null, SYSTEM_KEY);
         },
       );
     },

--- a/vue_client/src/composables/useBufferRoute.ts
+++ b/vue_client/src/composables/useBufferRoute.ts
@@ -8,7 +8,7 @@ import { useBuffersStore, bufferKey } from '../stores/buffers.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { connected } from './useSocket.js';
-import { whenReady } from '../lib/deferredReady.js';
+import { whenReady } from './deferredReady.js';
 import { shouldPushBuffer } from '../utils/bufferNav.js';
 
 // Two-way binding between the active buffer and the URL (#744), so every buffer
@@ -20,11 +20,12 @@ import { shouldPushBuffer } from '../utils/bufferNav.js';
 // This sits alongside navHistory (#309, Cmd+[ / ]) rather than replacing it. The
 // two are deliberately independent: navHistory is a BUFFER trail with its own
 // cursor, dead-buffer skipping and a 100-entry cap; browser history is the
-// LOCATION stack. Neither drives the other, so they cannot desync. A hop driven
-// from here lands in navHistory as an ordinary visit (recordVisit's
-// consecutive-dupe collapse absorbs the degenerate case), and navHistory's own
+// LOCATION stack. Neither reads the other, and neither needs the other to
+// agree: a hop driven from here lands in navHistory as an ordinary visit —
+// which, like any visit recorded from a back position, truncates navHistory's
+// forward branch (recordVisit's contract) — and navHistory's own
 // back()/forward() go through activate() and so push a URL like any other
-// navigation — which is right, since a nav-history hop IS a navigation.
+// navigation, which is right, since a nav-history hop IS a navigation.
 
 // The buffer id of a navigation we've started but that hasn't landed yet.
 //
@@ -55,8 +56,11 @@ export function pushBuffer(router: Router, id: number): void {
   // re-check the route unconditionally, which quietly overrode it: with a push
   // to another buffer in flight, shouldPushBuffer correctly says "navigate" and
   // this said "already there" off the stale route — so the user's last
-  // activation was dropped and the in-flight one landed instead. Two guards for
-  // one decision is what made that possible; now there is one.
+  // activation was dropped and the in-flight one landed instead. Two independent
+  // guards for one decision is what made that possible; now the predicate is
+  // shared. The route READER is not: this one name-gates to 'buffer' (a
+  // deliberate push from the member list must leave it), where the watcher's
+  // routeId() counts the members route as "already there" — see its comment.
   if (!shouldPushBuffer(id, currentRouteBufferId(router), inFlightId)) return;
   inFlightId = id;
   void router.push(`/buffer/${id}`).finally(() => {
@@ -85,6 +89,14 @@ export function useBufferRoute(): void {
   // The id currently in the URL, or null at `/`. Params are strings; anything
   // non-numeric (a hand-typed /buffer/foo) is treated as "no buffer" rather
   // than parsed to NaN, which would silently match nothing downstream.
+  //
+  // Deliberately NOT name-gated, unlike pushBuffer's currentRouteBufferId:
+  // `/buffer/7/members` answers 7 here. The outbound watcher is the only
+  // caller, and for it the members route IS "already there" — an activation
+  // echoing back onto its own members entry (Back onto one, or a members deep
+  // link resolving) must not push the chat screen over the member list. The
+  // name-gated twin exists for the opposite case; unifying the two re-breaks
+  // whichever side the merge favours.
   function routeId(): number | null {
     const raw = route.params.id;
     if (typeof raw !== 'string' || raw === '') return null;
@@ -126,7 +138,17 @@ export function useBufferRoute(): void {
         if (route.path !== '/') void router.replace('/');
         return;
       }
-      if (id === 'pending') return; // no server id yet — see above
+      if (id === 'pending') {
+        // No server id yet — see above. But the ACTIVATION is real, so it
+        // cancels a pending resolution like every other branch: without this,
+        // opening an optimistic DM while a dead /buffer/<id> was still waiting
+        // left its 10s timer armed, and the timeout's routeId() guard can't
+        // suppress it — an id-less buffer can't move the URL, so the route
+        // still names the dead id — landing a spurious "couldn't open" toast
+        // and a replace('/') on top of the user's composing session.
+        clearPending();
+        return;
+      }
       if (id === 'system') {
         clearPending();
         // Push, not replace. Opening the console is a navigation like any other
@@ -177,7 +199,21 @@ export function useBufferRoute(): void {
       // the shell isn't showing; an unknown NUMERIC id already ends the same
       // way, via the timeout below.
       if (id == null) {
-        if (route.params.id != null) void router.replace('/');
+        if (route.params.id != null) {
+          void router.replace('/');
+          return;
+        }
+        // At `/`. An id-ADDRESSABLE active buffer stays active (see the note
+        // below on not deactivating) — but an id-LESS one (an optimistic DM)
+        // cannot be named by any URL, so the mobile shell shows it on every
+        // route via activeLacksId. Landing on `/` while it is active therefore
+        // means the user backed out of it (the platform gesture, or goList
+        // normalizing) — hold it and the shell is pinned on the DM screen with
+        // a dead back button. Deactivate, exactly as if the buffer had closed;
+        // it stays in the store and the list.
+        const activeKey = networks.activeKey;
+        const active = activeKey ? buffers.byKey(activeKey) : null;
+        if (active && active.networkId != null && active.id == null) networks.clearActive();
         return;
       }
 

--- a/vue_client/src/composables/useBufferRoute.ts
+++ b/vue_client/src/composables/useBufferRoute.ts
@@ -6,6 +6,7 @@ import { useRoute, useRouter, type Router } from 'vue-router';
 import { useNetworksStore } from '../stores/networks.js';
 import { useBuffersStore, bufferKey } from '../stores/buffers.js';
 import { useToastsStore } from '../stores/toasts.js';
+import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 import { connected } from './useSocket.js';
 import { whenReady } from '../lib/deferredReady.js';
 
@@ -42,7 +43,13 @@ export function pushBuffer(router: Router, id: number): void {
   // navigation anyway, but it is reached on every single buffer open — the
   // watcher pushes, the route lands, and the click handler then asks for the
   // same place ~30ms later — so it is worth not starting the navigation at all.
-  if (router.currentRoute.value.params.id === String(id)) return;
+  //
+  // Match the NAME too: `/buffer/7/members` carries id 7 as well, and treating
+  // that as "already there" would make this a no-op from the members screen —
+  // so a jump to the buffer you're already in (a toast, a search hit) couldn't
+  // get you back off the member list.
+  const current = router.currentRoute.value;
+  if (current.name === 'buffer' && current.params.id === String(id)) return;
   inFlightId = id;
   void router.push(`/buffer/${id}`).finally(() => {
     if (inFlightId === id) inFlightId = null;
@@ -91,10 +98,15 @@ export function useBufferRoute(): void {
     // buffer is active but has no server id yet) must not collapse into one
     // value, or the transition between them wouldn't fire the watcher and the
     // URL would be left naming a buffer that is gone.
-    (): 'none' | 'pending' | number => {
+    (): 'none' | 'pending' | 'system' | number => {
       const key = networks.activeKey;
       if (!key) return 'none';
-      return buffers.byKey(key)?.id ?? 'pending';
+      const buf = buffers.byKey(key);
+      if (!buf) return 'pending';
+      // App-scoped (networkId null) — addressable by name, and deliberately not
+      // by row id, which it may not have yet. See the /system route.
+      if (buf.networkId == null) return 'system';
+      return buf.id ?? 'pending';
     },
     (id) => {
       if (id === 'none') {
@@ -107,6 +119,11 @@ export function useBufferRoute(): void {
         return;
       }
       if (id === 'pending') return; // no server id yet — see above
+      if (id === 'system') {
+        clearPending();
+        if (route.name !== 'system') void router.replace('/system');
+        return;
+      }
       // Already there. This is the loop guard for the inbound direction: a
       // route-driven activation produces an outbound target identical to the
       // route that caused it, and stops here.
@@ -132,11 +149,27 @@ export function useBufferRoute(): void {
   }
 
   watch(
-    () => route.params.id,
+    // Name AND id: `/`, `/system` and `/buffer/:id` are three destinations, and
+    // two of them carry no id at all. A string rather than an array because the
+    // callback only needs to know that something moved.
+    () => `${String(route.name)}|${String(route.params.id ?? '')}`,
     () => {
+      if (route.name === 'system') {
+        clearPending();
+        if (networks.activeKey !== SYSTEM_KEY) buffers.activate(null, SYSTEM_KEY);
+        return;
+      }
       const id = routeId();
       clearPending();
-      if (id == null) return; // at `/` — see note below on not deactivating
+      // At `/` (see the note below on not deactivating) — or at a hand-typed
+      // `/buffer/nonsense`, which names no buffer we could ever resolve. Drop
+      // that back to `/` rather than leaving the address bar asserting a buffer
+      // the shell isn't showing; an unknown NUMERIC id already ends the same
+      // way, via the timeout below.
+      if (id == null) {
+        if (route.params.id != null) void router.replace('/');
+        return;
+      }
 
       if (open(id)) return;
       // Unknown id. Either a cold start where buffers haven't arrived over the

--- a/vue_client/src/composables/useBufferRoute.ts
+++ b/vue_client/src/composables/useBufferRoute.ts
@@ -37,20 +37,27 @@ import { shouldPushBuffer } from '../utils/bufferNav.js';
 // value rather than the lagging route.
 let inFlightId: number | null = null;
 
+/** The buffer id the CURRENT route names, or null. Only the buffer route counts:
+ *  `/buffer/7/members` carries id 7 too, and treating that as "already there"
+ *  would strand a jump to the buffer you're on behind the member list. */
+function currentRouteBufferId(router: Router): number | null {
+  const current = router.currentRoute.value;
+  if (current.name !== 'buffer') return null;
+  const raw = current.params.id;
+  if (typeof raw !== 'string') return null;
+  const n = Number(raw);
+  return Number.isInteger(n) ? n : null;
+}
+
 /** Navigate to a buffer, unless we're already there or already on the way. */
 export function pushBuffer(router: Router, id: number): void {
-  if (inFlightId === id) return;
-  // Already the current route. vue-router would reject this as a duplicated
-  // navigation anyway, but it is reached on every single buffer open — the
-  // watcher pushes, the route lands, and the click handler then asks for the
-  // same place ~30ms later — so it is worth not starting the navigation at all.
-  //
-  // Match the NAME too: `/buffer/7/members` carries id 7 as well, and treating
-  // that as "already there" would make this a no-op from the members screen —
-  // so a jump to the buffer you're already in (a toast, a search hit) couldn't
-  // get you back off the member list.
-  const current = router.currentRoute.value;
-  if (current.name === 'buffer' && current.params.id === String(id)) return;
+  // The SAME predicate the watcher uses, deliberately. This function used to
+  // re-check the route unconditionally, which quietly overrode it: with a push
+  // to another buffer in flight, shouldPushBuffer correctly says "navigate" and
+  // this said "already there" off the stale route — so the user's last
+  // activation was dropped and the in-flight one landed instead. Two guards for
+  // one decision is what made that possible; now there is one.
+  if (!shouldPushBuffer(id, currentRouteBufferId(router), inFlightId)) return;
   inFlightId = id;
   void router.push(`/buffer/${id}`).finally(() => {
     if (inFlightId === id) inFlightId = null;
@@ -193,13 +200,13 @@ export function useBufferRoute(): void {
             body: '',
             ttlMs: 5000,
           });
+          // Drop the dead URL. Nothing is activated here on purpose: doing so
+          // fired the outbound watcher, which pushed /system before this
+          // replace had finalized and cancelled it — leaving the dead
+          // /buffer/<id> one Back press away, where it would time out and toast
+          // all over again. Landing somewhere is the shell's business, and
+          // DesktopChat re-runs its rule when the route settles at `/`.
           void router.replace('/');
-          // Desktop has no "nothing selected" screen — #355's landing rule —
-          // and its mount-time fallback already declined, correctly, because
-          // the URL named a buffer at the time. Nothing re-runs it, so without
-          // this a stale bookmark ends on the blank pane that rule exists to
-          // prevent. Harmless on mobile: `/` still derives the list.
-          if (networks.activeKey == null) buffers.activate(null, SYSTEM_KEY);
         },
       );
     },

--- a/vue_client/src/composables/useChatBootstrap.test.ts
+++ b/vue_client/src/composables/useChatBootstrap.test.ts
@@ -12,8 +12,8 @@ vi.mock('./useSocket.js', () => ({ connected: h.connected }));
 
 import { consumeColdStartJump } from './useChatBootstrap.js';
 
-function installWindow(search: string): void {
-  const loc = { pathname: '/', search, hash: '' };
+function installWindow(search: string, pathname = '/'): void {
+  const loc = { pathname, search, hash: '' };
   (globalThis as any).window = {
     location: loc,
     history: {
@@ -44,7 +44,12 @@ const fakeRouter = () =>
       return Promise.resolve();
     },
   }) as any;
-const openBuffers = { isOpen: () => true } as any;
+const openBuffers = { isOpen: () => true, byId: () => null } as any;
+// Resolves buffer 7, for the route form.
+const byIdBuffers = {
+  isOpen: () => true,
+  byId: (id: number) => (id === 7 ? { networkId: 1, target: '#chan', id: 7 } : null),
+} as any;
 
 beforeEach(() => {
   h.connected.value = false;
@@ -52,6 +57,57 @@ beforeEach(() => {
 });
 afterEach(() => {
   delete (globalThis as any).window;
+});
+
+describe('consumeColdStartJump — the /buffer/<id> route form', () => {
+  // Every other test in this file loads at `/`, so the entire route branch —
+  // bufferIdFromPath, consumeRouteJump, its strip and its deliberate silent
+  // give-up — went uncovered. That is how a URIError that blanks the whole chat
+  // shell got through.
+  it('does not throw on a mangled path', () => {
+    h.connected.value = true;
+    installWindow('', '/buffer/%');
+
+    // `%` survives to the client verbatim and vue-router still matches the
+    // route, so this runs; decoding it threw URIError inside setup and left the
+    // shell unrendered.
+    expect(() =>
+      consumeColdStartJump(openBuffers, fakeRouter(), vi.fn<(p: unknown) => void>()),
+    ).not.toThrow();
+  });
+
+  it('does not throw on a non-numeric id', () => {
+    h.connected.value = true;
+    installWindow('?msg=42', '/buffer/nonsense');
+    expect(() =>
+      consumeColdStartJump(openBuffers, fakeRouter(), vi.fn<(p: unknown) => void>()),
+    ).not.toThrow();
+  });
+
+  it('fires the jump for a resolvable buffer route', () => {
+    h.connected.value = true;
+    installWindow('?msg=42', '/buffer/7');
+    const onJump = vi.fn<(payload: unknown) => void>();
+
+    consumeColdStartJump(byIdBuffers, fakeRouter(), onJump);
+
+    expect(onJump).toHaveBeenCalledWith({
+      kind: 'jump',
+      networkId: 1,
+      target: '#chan',
+      messageId: 42,
+    });
+  });
+
+  it('does not jump when the route names a buffer but no message', () => {
+    h.connected.value = true;
+    installWindow('', '/buffer/7');
+    const onJump = vi.fn<(payload: unknown) => void>();
+
+    consumeColdStartJump(byIdBuffers, fakeRouter(), onJump);
+
+    expect(onJump).not.toHaveBeenCalled();
+  });
 });
 
 describe('consumeColdStartJump', () => {

--- a/vue_client/src/composables/useChatBootstrap.test.ts
+++ b/vue_client/src/composables/useChatBootstrap.test.ts
@@ -28,6 +28,22 @@ function installWindow(search: string): void {
 }
 
 const currentSearch = (): string => (globalThis as any).window.location.search;
+
+// Stands in for vue-router: consumeColdStartJump strips the deep-link params
+// through it now (a raw replaceState left the router's own location holding the
+// consumed ?msg, which then leaked into Settings' back target and re-fired the
+// jump). Mirrors the URL the same way the real router does.
+const replaceCalls: Array<Record<string, string>> = [];
+const fakeRouter = () =>
+  ({
+    replace: ({ query }: { query: Record<string, string> }) => {
+      replaceCalls.push(query);
+      const qs = new URLSearchParams(query).toString();
+      const loc = (globalThis as any).window.location;
+      loc.search = qs ? `?${qs}` : '';
+      return Promise.resolve();
+    },
+  }) as any;
 const openBuffers = { isOpen: () => true } as any;
 
 beforeEach(() => {
@@ -44,7 +60,7 @@ describe('consumeColdStartJump', () => {
     installWindow('?net=1&buf=%23chan&msg=42');
     const onJump = vi.fn<(payload: unknown) => void>();
 
-    consumeColdStartJump(openBuffers, onJump);
+    consumeColdStartJump(openBuffers, fakeRouter(), onJump);
 
     expect(onJump).toHaveBeenCalledWith({
       kind: 'jump',
@@ -61,7 +77,7 @@ describe('consumeColdStartJump', () => {
     installWindow('?net=2&buf=alice');
     const onJump = vi.fn<(payload: unknown) => void>();
 
-    consumeColdStartJump(openBuffers, onJump);
+    consumeColdStartJump(openBuffers, fakeRouter(), onJump);
 
     expect(onJump).toHaveBeenCalledWith({
       kind: 'jump',
@@ -76,7 +92,7 @@ describe('consumeColdStartJump', () => {
     installWindow('?net=1&buf=%23x&msg=foo');
     const onJump = vi.fn<(payload: unknown) => void>();
 
-    consumeColdStartJump(openBuffers, onJump);
+    consumeColdStartJump(openBuffers, fakeRouter(), onJump);
 
     expect(onJump).toHaveBeenCalledWith({
       kind: 'jump',
@@ -86,12 +102,27 @@ describe('consumeColdStartJump', () => {
     });
   });
 
+  it('strips THROUGH the router, not raw history', () => {
+    // A raw replaceState updates the address bar while vue-router's own
+    // recorded location keeps the consumed ?msg — and that stale location is
+    // what lands in history.state.back on the next push, which Settings
+    // captures as its return target. "← back" then replayed the jump.
+    h.connected.value = true;
+    installWindow('?net=1&buf=%23chan&msg=42');
+    replaceCalls.length = 0;
+
+    consumeColdStartJump(openBuffers, fakeRouter(), vi.fn<(p: unknown) => void>());
+
+    expect(replaceCalls).toHaveLength(1);
+    expect(replaceCalls[0]).not.toHaveProperty('msg');
+  });
+
   it('does nothing and leaves unrelated params when there is no deep link', () => {
     h.connected.value = true;
     installWindow('?foo=bar');
     const onJump = vi.fn<(payload: unknown) => void>();
 
-    consumeColdStartJump(openBuffers, onJump);
+    consumeColdStartJump(openBuffers, fakeRouter(), onJump);
 
     expect(onJump).not.toHaveBeenCalled();
     expect(currentSearch()).toBe('?foo=bar');
@@ -105,7 +136,7 @@ describe('consumeColdStartJump', () => {
       installWindow('?net=1&buf=%23chan&msg=42');
       const onJump = vi.fn<(payload: unknown) => void>();
 
-      dispose = consumeColdStartJump(openBuffers, onJump);
+      dispose = consumeColdStartJump(openBuffers, fakeRouter(), onJump);
 
       // Not fired yet, but the URL is already cleaned so a refresh can't double it.
       expect(onJump).not.toHaveBeenCalled();

--- a/vue_client/src/composables/useChatBootstrap.test.ts
+++ b/vue_client/src/composables/useChatBootstrap.test.ts
@@ -2,18 +2,27 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { nextTick } from 'vue';
 
 // consumeColdStartJump only consults the socket-`connected` flag and the buffers
 // store passed to it. Stub useSocket so we control readiness; everything else in
 // the bootstrap module is import-safe. The suite has no DOM environment, so we
 // install a minimal window (location + history) rather than pull in jsdom.
-const h = vi.hoisted(() => ({ connected: { value: false } as { value: boolean } }));
-vi.mock('./useSocket.js', () => ({ connected: h.connected }));
+//
+// `connected` must be a REAL ref, not a { value } literal: whenReady watches it,
+// and a plain object never fires the watch — every deferred test would then
+// assert "not fired" against a harness that cannot fire at all.
+const h = vi.hoisted(() => ({ connected: null as any as { value: boolean } }));
+vi.mock('./useSocket.js', async () => {
+  const { ref } = await import('vue');
+  h.connected = ref(false);
+  return { connected: h.connected };
+});
 
 import { consumeColdStartJump } from './useChatBootstrap.js';
 
-function installWindow(search: string, pathname = '/'): void {
-  const loc = { pathname, search, hash: '' };
+function installWindow(search: string, pathname = '/', hash = ''): void {
+  const loc = { pathname, search, hash };
   (globalThis as any).window = {
     location: loc,
     history: {
@@ -33,14 +42,24 @@ const currentSearch = (): string => (globalThis as any).window.location.search;
 // through it now (a raw replaceState left the router's own location holding the
 // consumed ?msg, which then leaked into Settings' back target and re-fired the
 // jump). Mirrors the URL the same way the real router does.
-const replaceCalls: Array<Record<string, string>> = [];
+const replaceCalls: Array<{ query: Record<string, string>; hash?: string }> = [];
 const fakeRouter = () =>
   ({
-    replace: ({ query }: { query: Record<string, string> }) => {
-      replaceCalls.push(query);
+    // The deferred route-form jump re-checks the CURRENT route before firing;
+    // derive it from the installed window the way the real router mirrors it.
+    get currentRoute() {
+      const loc = (globalThis as any).window.location;
+      const m = /^\/buffer\/([^/]+)$/.exec(loc.pathname);
+      return { value: { name: m ? 'buffer' : 'chat', params: m ? { id: m[1] } : {} } };
+    },
+    replace: ({ query, hash }: { query: Record<string, string>; hash?: string }) => {
+      replaceCalls.push({ query, hash });
       const qs = new URLSearchParams(query).toString();
       const loc = (globalThis as any).window.location;
       loc.search = qs ? `?${qs}` : '';
+      // Like the real router: an absent hash on a location object DROPS the
+      // fragment — mirroring that is what lets the hash test mean anything.
+      loc.hash = hash ?? '';
       return Promise.resolve();
     },
   }) as any;
@@ -53,6 +72,7 @@ const byIdBuffers = {
 
 beforeEach(() => {
   h.connected.value = false;
+  replaceCalls.length = 0;
   installWindow('');
 });
 afterEach(() => {
@@ -107,6 +127,71 @@ describe('consumeColdStartJump — the /buffer/<id> route form', () => {
     consumeColdStartJump(byIdBuffers, fakeRouter(), onJump);
 
     expect(onJump).not.toHaveBeenCalled();
+    // And no strip either: with nothing to consume, the old unconditional
+    // strip issued a do-nothing same-location replace on every plain
+    // /buffer/<id> load.
+    expect(replaceCalls).toHaveLength(0);
+  });
+
+  it('carries the launch hash through the strip', () => {
+    // router.replace with an absent `hash` DROPS the fragment (resolve takes
+    // rawLocation.hash || ''), so stripQuery has to pass it explicitly — the
+    // raw-replaceState code it replaced preserved it.
+    h.connected.value = true;
+    installWindow('?msg=42', '/buffer/7', '#x');
+
+    consumeColdStartJump(byIdBuffers, fakeRouter(), vi.fn<(p: unknown) => void>());
+
+    expect(replaceCalls).toHaveLength(1);
+    expect((globalThis as any).window.location.hash).toBe('#x');
+  });
+
+  it('fires a deferred jump once ready, when the user stayed put', async () => {
+    // The positive half of the pair below — proves this harness CAN fire a
+    // deferred jump, so the "dropped" assertion is meaningful.
+    let dispose: (() => void) | undefined;
+    try {
+      h.connected.value = false;
+      installWindow('?msg=42', '/buffer/7');
+      const onJump = vi.fn<(payload: unknown) => void>();
+      dispose = consumeColdStartJump(byIdBuffers, fakeRouter(), onJump);
+      expect(onJump).not.toHaveBeenCalled();
+
+      h.connected.value = true; // the snapshot lands
+      await nextTick();
+
+      expect(onJump).toHaveBeenCalledWith({
+        kind: 'jump',
+        networkId: 1,
+        target: '#chan',
+        messageId: 42,
+      });
+    } finally {
+      dispose?.();
+    }
+  });
+
+  it('drops a deferred jump once the user has navigated elsewhere', async () => {
+    let dispose: (() => void) | undefined;
+    try {
+      h.connected.value = false;
+      installWindow('?msg=42', '/buffer/7');
+      const onJump = vi.fn<(payload: unknown) => void>();
+      dispose = consumeColdStartJump(byIdBuffers, fakeRouter(), onJump);
+      expect(onJump).not.toHaveBeenCalled();
+
+      // The user gives up on the slow load and goes back to the list before
+      // the snapshot lands. All chat routes share one shell, so the disposer
+      // never runs — only the fire-time route check stands between them and
+      // being yanked to the link's buffer (and detaching it) seconds later.
+      (globalThis as any).window.location.pathname = '/';
+      h.connected.value = true;
+      await nextTick();
+
+      expect(onJump).not.toHaveBeenCalled();
+    } finally {
+      dispose?.();
+    }
   });
 });
 
@@ -170,7 +255,7 @@ describe('consumeColdStartJump', () => {
     consumeColdStartJump(openBuffers, fakeRouter(), vi.fn<(p: unknown) => void>());
 
     expect(replaceCalls).toHaveLength(1);
-    expect(replaceCalls[0]).not.toHaveProperty('msg');
+    expect(replaceCalls[0].query).not.toHaveProperty('msg');
   });
 
   it('does nothing and leaves unrelated params when there is no deep link', () => {

--- a/vue_client/src/composables/useChatBootstrap.ts
+++ b/vue_client/src/composables/useChatBootstrap.ts
@@ -13,7 +13,7 @@ import { onJumpIntent } from './useJumpIntent.js';
 import { connected } from './useSocket.js';
 import { startAppBadge } from './useAppBadge.js';
 import { startBufferHydration } from './useBufferHydration.js';
-import { whenReady } from '../lib/deferredReady.js';
+import { whenReady } from './deferredReady.js';
 import type { Router } from 'vue-router';
 import { useRouter } from 'vue-router';
 import type { JumpTarget } from './useJumpToMessage.js';
@@ -35,9 +35,17 @@ export interface ChatBootstrapOptions {
  *  `?msg` — and that stale location is what gets written into history.state.back
  *  on the next push, which Settings captures as its return target. Clicking
  *  "← back" from Settings then navigated to the un-stripped URL and re-fired the
- *  jump, defeating the "strip it so a refresh doesn't re-jump" guarantee. */
+ *  jump, defeating the "strip it so a refresh doesn't re-jump" guarantee.
+ *
+ *  The hash is carried through explicitly: to router.replace an absent `hash`
+ *  on a location object means "no hash", not "keep the current one", so the
+ *  raw-replaceState code this replaced preserved the fragment and the plain
+ *  form silently dropped it. */
 function stripQuery(router: Router, params: URLSearchParams): void {
-  void router.replace({ query: Object.fromEntries(params.entries()) });
+  void router.replace({
+    query: Object.fromEntries(params.entries()),
+    hash: window.location.hash,
+  });
 }
 
 /** The buffer id a `/buffer/<id>` path names, or null for any other route.
@@ -71,11 +79,16 @@ function consumeRouteJump(
 ): () => void {
   const noop = (): void => {};
   const msg = params.get('msg');
-  const messageId = msg != null && msg !== '' ? Number(msg) : null;
-  // Strip ?msg immediately so a manual refresh doesn't re-jump. The PATH stays
-  // — it's the buffer the user is now looking at, not a consumed intent.
+  // A plain /buffer/<id> carries no intent — and therefore gets NO strip: the
+  // unconditional version issued a do-nothing same-location replace through
+  // the router pipeline on every bookmark, refresh and shell swap.
+  if (msg == null || msg === '') return noop;
+  // Strip ?msg immediately so a manual refresh doesn't re-jump — a malformed
+  // one included, consumed to nothing rather than left to re-parse. The PATH
+  // stays: it's the buffer the user is now looking at, not a consumed intent.
   params.delete('msg');
   stripQuery(router, params);
+  const messageId = Number(msg);
   if (!Number.isFinite(messageId)) return noop;
 
   // byId (not the module-level bufferKeyForId index) so the wait below is
@@ -91,6 +104,14 @@ function consumeRouteJump(
   return whenReady(
     () => connected.value && resolve() != null,
     () => {
+      // The wait can outlive the user's patience. If they navigated anywhere
+      // else in-shell during it — back to the list, another buffer, /system —
+      // the disposer never ran (all chat routes share one shell), and firing
+      // now would yank them to the link's buffer and detach it for an intent
+      // they've moved past. The route is the truth about where they are;
+      // useBufferRoute's parallel wait re-checks its own the same way.
+      const current = router.currentRoute.value;
+      if (current.name !== 'buffer' || current.params.id !== String(bufferId)) return;
       const payload = resolve();
       if (payload) onJump(payload);
     },

--- a/vue_client/src/composables/useChatBootstrap.ts
+++ b/vue_client/src/composables/useChatBootstrap.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { onBeforeUnmount, onMounted, watch } from 'vue';
+import { onBeforeUnmount, onMounted } from 'vue';
 import { useNetworksStore } from '../stores/networks.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useBuffersStore } from '../stores/buffers.js';
@@ -13,13 +13,8 @@ import { onJumpIntent } from './useJumpIntent.js';
 import { connected } from './useSocket.js';
 import { startAppBadge } from './useAppBadge.js';
 import { startBufferHydration } from './useBufferHydration.js';
+import { whenReady } from '../lib/deferredReady.js';
 import type { JumpTarget } from './useJumpToMessage.js';
-
-// How long to wait for the app to become able to honor a cold-start deep link
-// before giving up. networks.fetchAll() (REST) has resolved by the time we look,
-// but buffers + the socket come up asynchronously over the WS — and loadAround()
-// no-ops while the socket is closed — so we hold the jump until both land.
-const COLD_START_JUMP_TIMEOUT_MS = 10000;
 
 // The bus/notification payload is a jump target plus a `kind` discriminator
 // shared with the service-worker message channel; it IS what jump() consumes.
@@ -31,13 +26,87 @@ export interface ChatBootstrapOptions {
   onJump?: (data: JumpPayload) => void;
 }
 
+/** Rewrite the query string in place, leaving path and hash alone.
+ *
+ *  Carries the CURRENT history.state through rather than passing null: since
+ *  #744 there is a real history stack under `/buffer/<id>`, and vue-router keeps
+ *  its position/scroll bookkeeping in that state. Blanking it would leave the
+ *  entry the user is standing on unable to resolve a later go(delta). */
+function stripQuery(params: URLSearchParams): void {
+  const qs = params.toString();
+  window.history.replaceState(
+    window.history.state,
+    '',
+    window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash,
+  );
+}
+
+/** The buffer id a `/buffer/<id>` path names, or null for any other route.
+ *  Deliberately strict: a non-integer segment is "not a buffer route", never
+ *  NaN, which downstream `== null` checks would wave through. */
+function bufferIdFromPath(pathname: string): number | null {
+  const m = /^\/buffer\/([^/]+)\/?$/.exec(pathname);
+  if (!m) return null;
+  const n = Number(decodeURIComponent(m[1]));
+  return Number.isInteger(n) ? n : null;
+}
+
+// `/buffer/<id>?msg=<id>` — useBufferRoute owns activating the buffer, so the
+// only thing left here is the message to scroll to. Resolving the id needs the
+// same wait as the legacy form (buffers arrive over the WS after the route
+// does), but NOT the same failure toast: useBufferRoute is watching the same id
+// and already reports it, so this one gives up quietly rather than double-
+// toasting the one event.
+function consumeRouteJump(
+  bufferId: number,
+  params: URLSearchParams,
+  buffers: ReturnType<typeof useBuffersStore>,
+  onJump: (data: JumpPayload) => void,
+): () => void {
+  const noop = (): void => {};
+  const msg = params.get('msg');
+  const messageId = msg != null && msg !== '' ? Number(msg) : null;
+  // Strip ?msg immediately so a manual refresh doesn't re-jump. The PATH stays
+  // — it's the buffer the user is now looking at, not a consumed intent.
+  params.delete('msg');
+  stripQuery(params);
+  if (!Number.isFinite(messageId)) return noop;
+
+  // byId (not the module-level bufferKeyForId index) so the wait below is
+  // reactive — see the note on the store getter. The record already carries
+  // networkId/target, so there is no key to take apart.
+  const resolve = (): JumpPayload | null => {
+    const buf = buffers.byId(bufferId);
+    // networkId null == an app-scoped buffer (the system console), which has no
+    // per-message jump.
+    if (!buf || buf.networkId == null) return null;
+    return { kind: 'jump', networkId: buf.networkId, target: buf.target, messageId };
+  };
+  return whenReady(
+    () => connected.value && resolve() != null,
+    () => {
+      const payload = resolve();
+      if (payload) onJump(payload);
+    },
+  );
+}
+
 // The service worker can only hand a launched-from-closed PWA its jump target
 // through the URL (a postMessage would race the not-yet-registered listener and
-// be dropped), so the notificationclick handler writes /?net&buf&msg. Nothing
-// read it back before — the user just landed on the default screen. Recover it
-// here, strip it so a refresh doesn't re-jump, and fire it through the same
-// onJump the warm push path uses once the app can actually honor it. Returns a
-// disposer for the deferred-readiness watch/timer.
+// be dropped). Two forms exist:
+//
+//   /buffer/<id>?msg=<id>      current (#744) — a real route. useBufferRoute
+//                              activates the buffer; all this has to recover is
+//                              the message to scroll to.
+//   /?net&buf&msg              legacy. A service worker updates on its own
+//                              schedule, so an installed client keeps minting
+//                              this form until its worker rolls over — this
+//                              branch has to stay for at least a release, and
+//                              is removable once that's had time to propagate.
+//
+// Either way: recover the intent, strip it so a refresh doesn't re-jump, and
+// fire it through the same onJump the warm push path uses once the app can
+// actually honor it. Returns a disposer for the deferred-readiness watch/timer.
 export function consumeColdStartJump(
   buffers: ReturnType<typeof useBuffersStore>,
   onJump: (data: JumpPayload) => void,
@@ -45,8 +114,10 @@ export function consumeColdStartJump(
   const noop = (): void => {};
   // new URLSearchParams(string) never throws, so no guard is needed.
   const params = new URLSearchParams(window.location.search);
+  const routeBufferId = bufferIdFromPath(window.location.pathname);
   const net = params.get('net');
   const buf = params.get('buf');
+  if (routeBufferId != null) return consumeRouteJump(routeBufferId, params, buffers, onJump);
   if (!net || !buf) return noop;
   const networkId = Number(net);
   if (!Number.isFinite(networkId)) return noop;
@@ -56,12 +127,7 @@ export function consumeColdStartJump(
   params.delete('net');
   params.delete('buf');
   params.delete('msg');
-  const qs = params.toString();
-  window.history.replaceState(
-    null,
-    '',
-    window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash,
-  );
+  stripQuery(params);
 
   // Validate msg the same way as networkId: a malformed ?msg=foo must become a
   // null "open the conversation" intent, not NaN — NaN slips past the
@@ -70,40 +136,22 @@ export function consumeColdStartJump(
   const messageId = parsed != null && Number.isFinite(parsed) ? parsed : null;
 
   const payload: JumpPayload = { kind: 'jump', networkId, target: buf, messageId };
-  const ready = (): boolean => connected.value && buffers.isOpen(networkId, buf);
-  if (ready()) {
-    onJump(payload);
-    return noop;
-  }
-
-  let done = false;
-  // Watch the boolean directly (not a fresh [a, b] array, which compares
-  // unequal every tick) so the callback runs only when readiness actually flips.
-  const stop = watch(ready, (ok) => {
-    if (!ok) return;
-    cleanup();
-    onJump(payload);
-  });
-  const timer = setTimeout(() => {
-    cleanup();
-    // The buffer never re-opened (e.g. a channel/DM closed before the app was
-    // killed). The URL is already stripped, so without this the intent would
-    // vanish silently. Surface it instead of leaving the user on the default
-    // screen wondering why the notification did nothing.
-    useToastsStore().push({
-      kind: 'info',
-      title: messageId != null ? 'Couldn’t open that message' : 'Couldn’t open that conversation',
-      body: '',
-      ttlMs: 5000,
-    });
-  }, COLD_START_JUMP_TIMEOUT_MS);
-  function cleanup(): void {
-    if (done) return;
-    done = true;
-    stop();
-    clearTimeout(timer);
-  }
-  return cleanup;
+  return whenReady(
+    () => connected.value && buffers.isOpen(networkId, buf),
+    () => onJump(payload),
+    () => {
+      // The buffer never re-opened (e.g. a channel/DM closed before the app was
+      // killed). The URL is already stripped, so without this the intent would
+      // vanish silently. Surface it instead of leaving the user on the default
+      // screen wondering why the notification did nothing.
+      useToastsStore().push({
+        kind: 'info',
+        title: messageId != null ? 'Couldn’t open that message' : 'Couldn’t open that conversation',
+        body: '',
+        ttlMs: 5000,
+      });
+    },
+  );
 }
 
 // Shared post-login bootstrap for the chat shells (Desktop + Mobile).

--- a/vue_client/src/composables/useChatBootstrap.ts
+++ b/vue_client/src/composables/useChatBootstrap.ts
@@ -14,6 +14,8 @@ import { connected } from './useSocket.js';
 import { startAppBadge } from './useAppBadge.js';
 import { startBufferHydration } from './useBufferHydration.js';
 import { whenReady } from '../lib/deferredReady.js';
+import type { Router } from 'vue-router';
+import { useRouter } from 'vue-router';
 import type { JumpTarget } from './useJumpToMessage.js';
 
 // The bus/notification payload is a jump target plus a `kind` discriminator
@@ -26,19 +28,16 @@ export interface ChatBootstrapOptions {
   onJump?: (data: JumpPayload) => void;
 }
 
-/** Rewrite the query string in place, leaving path and hash alone.
+/** Drop the consumed deep-link params, leaving path and hash alone.
  *
- *  Carries the CURRENT history.state through rather than passing null: since
- *  #744 there is a real history stack under `/buffer/<id>`, and vue-router keeps
- *  its position/scroll bookkeeping in that state. Blanking it would leave the
- *  entry the user is standing on unable to resolve a later go(delta). */
-function stripQuery(params: URLSearchParams): void {
-  const qs = params.toString();
-  window.history.replaceState(
-    window.history.state,
-    '',
-    window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash,
-  );
+ *  Goes through the ROUTER, not raw replaceState. A raw call updates the
+ *  address bar while vue-router's own recorded location keeps the consumed
+ *  `?msg` — and that stale location is what gets written into history.state.back
+ *  on the next push, which Settings captures as its return target. Clicking
+ *  "← back" from Settings then navigated to the un-stripped URL and re-fired the
+ *  jump, defeating the "strip it so a refresh doesn't re-jump" guarantee. */
+function stripQuery(router: Router, params: URLSearchParams): void {
+  void router.replace({ query: Object.fromEntries(params.entries()) });
 }
 
 /** The buffer id a `/buffer/<id>` path names, or null for any other route.
@@ -61,6 +60,7 @@ function consumeRouteJump(
   bufferId: number,
   params: URLSearchParams,
   buffers: ReturnType<typeof useBuffersStore>,
+  router: Router,
   onJump: (data: JumpPayload) => void,
 ): () => void {
   const noop = (): void => {};
@@ -69,7 +69,7 @@ function consumeRouteJump(
   // Strip ?msg immediately so a manual refresh doesn't re-jump. The PATH stays
   // — it's the buffer the user is now looking at, not a consumed intent.
   params.delete('msg');
-  stripQuery(params);
+  stripQuery(router, params);
   if (!Number.isFinite(messageId)) return noop;
 
   // byId (not the module-level bufferKeyForId index) so the wait below is
@@ -109,6 +109,7 @@ function consumeRouteJump(
 // actually honor it. Returns a disposer for the deferred-readiness watch/timer.
 export function consumeColdStartJump(
   buffers: ReturnType<typeof useBuffersStore>,
+  router: Router,
   onJump: (data: JumpPayload) => void,
 ): () => void {
   const noop = (): void => {};
@@ -117,7 +118,8 @@ export function consumeColdStartJump(
   const routeBufferId = bufferIdFromPath(window.location.pathname);
   const net = params.get('net');
   const buf = params.get('buf');
-  if (routeBufferId != null) return consumeRouteJump(routeBufferId, params, buffers, onJump);
+  if (routeBufferId != null)
+    return consumeRouteJump(routeBufferId, params, buffers, router, onJump);
   if (!net || !buf) return noop;
   const networkId = Number(net);
   if (!Number.isFinite(networkId)) return noop;
@@ -127,7 +129,7 @@ export function consumeColdStartJump(
   params.delete('net');
   params.delete('buf');
   params.delete('msg');
-  stripQuery(params);
+  stripQuery(router, params);
 
   // Validate msg the same way as networkId: a malformed ?msg=foo must become a
   // null "open the conversation" intent, not NaN — NaN slips past the
@@ -163,6 +165,7 @@ export function useChatBootstrap({ onJump }: ChatBootstrapOptions = {}): void {
   const networks = useNetworksStore();
   const settings = useSettingsStore();
   const buffers = useBuffersStore();
+  const router = useRouter();
   const onboarding = useOnboarding();
   const disposers: Array<() => void> = [];
 
@@ -179,7 +182,7 @@ export function useChatBootstrap({ onJump }: ChatBootstrapOptions = {}): void {
       }),
     );
     disposers.push(onJumpIntent(onJump));
-    disposers.push(consumeColdStartJump(buffers, onJump));
+    disposers.push(consumeColdStartJump(buffers, router, onJump));
   }
 
   onMounted(async () => {

--- a/vue_client/src/composables/useChatBootstrap.ts
+++ b/vue_client/src/composables/useChatBootstrap.ts
@@ -46,7 +46,13 @@ function stripQuery(router: Router, params: URLSearchParams): void {
 function bufferIdFromPath(pathname: string): number | null {
   const m = /^\/buffer\/([^/]+)\/?$/.exec(pathname);
   if (!m) return null;
-  const n = Number(decodeURIComponent(m[1]));
+  // NOT decodeURIComponent: a buffer id is an integer, so there is nothing to
+  // decode — and a mangled link like `/buffer/%` reaches the client verbatim
+  // (the SPA fallback serves it, and vue-router swallows its own decode error),
+  // where decoding threw URIError inside this synchronous setup path and left
+  // the whole chat shell unrendered. Number() on anything unexpected is NaN,
+  // which is already the "not a buffer route" answer.
+  const n = Number(m[1]);
   return Number.isInteger(n) ? n : null;
 }
 

--- a/vue_client/src/composables/useMessageActions.test.ts
+++ b/vue_client/src/composables/useMessageActions.test.ts
@@ -1,11 +1,14 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+// @vitest-environment happy-dom
+
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useMessageActions, type MessageContext, type MessageLike } from './useMessageActions.js';
 import { useContextMenu } from './useContextMenu.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
+import { useBuffersStore } from '../stores/buffers.js';
 
 function makeCtx(): MessageContext {
   return {
@@ -137,5 +140,87 @@ describe('useMessageActions', () => {
       api.openMenu(null, makeCtx(), 1, 2);
       expect(menu.state.open).toBe(false);
     });
+  });
+});
+
+describe('copy link to message (#744)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useContextMenu().close();
+  });
+
+  /** A line in a buffer the server has given an id. */
+  function inBuffer(target: string, bufferId: number, over: Partial<MessageLike> = {}) {
+    useBuffersStore().ensure(1, target, bufferId);
+    return other({ target, ...over });
+  }
+
+  it('offers the link once the buffer has a server id', () => {
+    const actions = useMessageActions().buildActions(inBuffer('#chan', 7));
+    expect(actions.map((a) => a.key)).toEqual(['reply', 'copy', 'link', 'save', 'ignore']);
+  });
+
+  it('copies an absolute /buffer/<id>?msg=<id> URL', async () => {
+    const writeText = vi.fn<(t: string) => Promise<void>>(() => Promise.resolve());
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    const msg = inBuffer('#chan', 7);
+    useMessageActions().run('link', msg, makeCtx());
+
+    // The id form is the whole point: no `#` to percent-encode, and the channel
+    // name never reaches the URL.
+    expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/buffer/7?msg=42`);
+    vi.unstubAllGlobals();
+  });
+
+  it.each([['#chan'], ['&local'], ['+modeless'], ['!12345chan'], ['alice']])(
+    'links %s by id, with no name in the URL',
+    (target) => {
+      const writeText = vi.fn<(t: string) => Promise<void>>(() => Promise.resolve());
+      vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+      useMessageActions().run('link', inBuffer(target, 7), makeCtx());
+
+      const url = writeText.mock.calls[0][0];
+      expect(url).toBe(`${window.location.origin}/buffer/7?msg=42`);
+      // All four channel sigils and a DM nick: none of them reach the URL, so
+      // there is no encoding path here to get wrong.
+      expect(url).not.toContain(target);
+      vi.unstubAllGlobals();
+    },
+  );
+
+  it('drops the link on a system line, which has no buffer route', () => {
+    const actions = useMessageActions().buildActions(
+      inBuffer('#chan', 7, { networkId: null, target: ':system:' }),
+    );
+    expect(actions.map((a) => a.key)).not.toContain('link');
+  });
+
+  it('drops the link in a server console, where a jump is refused anyway', () => {
+    // useJumpToMessage bails on `:server:` with "Cannot jump in server buffer",
+    // so a link there would open the buffer and then toast instead of scrolling.
+    const actions = useMessageActions().buildActions(inBuffer(':server:1', 8));
+    expect(actions.map((a) => a.key)).not.toContain('link');
+  });
+
+  it('drops the link while the buffer has no server id yet', () => {
+    // An optimistically created buffer — "Send DM" to a never-DM'd nick — has
+    // no row id until the server answers, so there is nothing to address.
+    useBuffersStore().ensure(1, 'newpal');
+    const actions = useMessageActions().buildActions(other({ target: 'newpal' }));
+    expect(actions.map((a) => a.key)).not.toContain('link');
+  });
+
+  it('drops the link on a line with no message id', () => {
+    const actions = useMessageActions().buildActions(inBuffer('#chan', 7, { id: null }));
+    expect(actions.map((a) => a.key)).not.toContain('link');
+  });
+
+  it('reaches the context menu too, not just the hover bar', () => {
+    const labels = useMessageActions()
+      .buildItems(inBuffer('#chan', 7), makeCtx())
+      .map((i) => i.label);
+    expect(labels).toContain('Copy link to message');
   });
 });

--- a/vue_client/src/composables/useMessageActions.test.ts
+++ b/vue_client/src/composables/useMessageActions.test.ts
@@ -155,6 +155,15 @@ describe('copy link to message (#744)', () => {
     return other({ target, ...over });
   }
 
+  it('uses the id the row carries, without a store lookup', () => {
+    // Server message events ship bufferId, and buildActions runs for every
+    // rendered row — so the common path must not go through findByTarget.
+    const actions = useMessageActions().buildActions(
+      other({ target: '#chan', bufferId: 7 }), // no buffer registered in the store
+    );
+    expect(actions.map((a) => a.key)).toContain('link');
+  });
+
   it('offers the link once the buffer has a server id', () => {
     const actions = useMessageActions().buildActions(inBuffer('#chan', 7));
     expect(actions.map((a) => a.key)).toEqual(['reply', 'copy', 'link', 'save', 'ignore']);

--- a/vue_client/src/composables/useMessageActions.ts
+++ b/vue_client/src/composables/useMessageActions.ts
@@ -94,7 +94,12 @@ export function useMessageActions(): MessageActionsAPI {
   // whenever the message's server-cased target differs from the buffer key —
   // the #327 case — which would make it O(rows x buffers) per render.
   // findByTarget stays as the fallback for rows minted locally.
-  function messageLink(message: MessageLike): string | null {
+  //
+  // Split in two — linkBufferId answers "can this line link, and to which
+  // buffer", messageLink formats the URL — so buildActions' per-row
+  // eligibility test stays allocation-free: building the string just to test
+  // truthiness was waste at that call frequency.
+  function linkBufferId(message: MessageLike): number | null {
     const networkId = message.networkId ?? message.network_id;
     if (message.id == null || networkId == null) return null;
     if (!message.target || message.target.startsWith(':server:')) return null;
@@ -102,6 +107,11 @@ export function useMessageActions(): MessageActionsAPI {
       typeof message.bufferId === 'number'
         ? message.bufferId
         : buffers.findByTarget(networkId, message.target)?.id;
+    return bufferId ?? null;
+  }
+
+  function messageLink(message: MessageLike): string | null {
+    const bufferId = linkBufferId(message);
     if (bufferId == null) return null;
     return `${window.location.origin}/buffer/${bufferId}?msg=${message.id}`;
   }
@@ -124,7 +134,7 @@ export function useMessageActions(): MessageActionsAPI {
 
     // Sits next to Copy text because it's the other "take this away with you"
     // action: a permalink to bookmark, or to open in a new window.
-    if (messageLink(message)) {
+    if (linkBufferId(message) != null) {
       actions.push({ key: 'link', label: 'Copy link to message', icon: 'fa-solid fa-link' });
     }
 

--- a/vue_client/src/composables/useMessageActions.ts
+++ b/vue_client/src/composables/useMessageActions.ts
@@ -3,6 +3,7 @@
 
 import type { ContextMenuItem } from './useContextMenu.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
+import { useBuffersStore } from '../stores/buffers.js';
 import { useContextMenu } from './useContextMenu.js';
 
 export interface MessageLike {
@@ -15,6 +16,9 @@ export interface MessageLike {
   // bookmark gate in buildActions.
   networkId?: number | null;
   network_id?: number | null;
+  // The buffer the line belongs to. Present on every real message row; used to
+  // resolve the buffer id the "Copy link" action addresses.
+  target?: string;
 }
 
 export interface MessageContext {
@@ -23,7 +27,7 @@ export interface MessageContext {
   onIgnore(message: MessageLike): void;
 }
 
-export type MessageActionKey = 'reply' | 'copy' | 'save' | 'ignore';
+export type MessageActionKey = 'reply' | 'copy' | 'link' | 'save' | 'ignore';
 
 export interface MessageAction {
   key: MessageActionKey;
@@ -65,7 +69,31 @@ export interface MessageActionsAPI {
 // `context` shape: { networkId, onReply(message), onIgnore(message) }
 export function useMessageActions(): MessageActionsAPI {
   const bookmarks = useBookmarksStore();
+  const buffers = useBuffersStore();
   const menu = useContextMenu();
+
+  // Absolute permalink to one message, or null when the line can't have one.
+  // The buffer route addresses by server id (#744), so this needs the message's
+  // id AND its buffer's — and it deliberately refuses the two kinds of line a
+  // link couldn't actually land on:
+  //
+  //   - app-scoped system lines (networkId null), which have no buffer route
+  //     that a per-message jump accepts
+  //   - `:server:` consoles, which useJumpToMessage rejects outright ("Cannot
+  //     jump in server buffer") — a link there would open the buffer and then
+  //     toast at the user instead of scrolling
+  //
+  // Resolving through findByTarget is an exact-key hit for every row rendered
+  // in a buffer (the O(n) folded scan only runs on a miss), which is what keeps
+  // this cheap enough to call per row from buildActions.
+  function messageLink(message: MessageLike): string | null {
+    const networkId = message.networkId ?? message.network_id;
+    if (message.id == null || networkId == null) return null;
+    if (!message.target || message.target.startsWith(':server:')) return null;
+    const bufferId = buffers.findByTarget(networkId, message.target)?.id;
+    if (bufferId == null) return null;
+    return `${window.location.origin}/buffer/${bufferId}?msg=${message.id}`;
+  }
 
   function buildActions(message: MessageLike | null | undefined): MessageAction[] {
     if (!message) return [];
@@ -81,6 +109,12 @@ export function useMessageActions(): MessageActionsAPI {
 
     if (message.text) {
       actions.push({ key: 'copy', label: 'Copy text', icon: 'fa-regular fa-copy' });
+    }
+
+    // Sits next to Copy text because it's the other "take this away with you"
+    // action: a permalink to bookmark, or to open in a new window.
+    if (messageLink(message)) {
+      actions.push({ key: 'link', label: 'Copy link to message', icon: 'fa-solid fa-link' });
     }
 
     // Bookmarks need a stable server id AND an owning network.
@@ -123,6 +157,14 @@ export function useMessageActions(): MessageActionsAPI {
           navigator.clipboard.writeText(String(message.text || '')).catch(() => {});
         }
         break;
+      case 'link': {
+        // Fire-and-forget with no tick, matching its neighbour above — the
+        // action bar renders stateless descriptors, and useCopyFeedback calls
+        // out the copy-message action as deliberately not that shape.
+        const url = messageLink(message);
+        if (url && navigator.clipboard) navigator.clipboard.writeText(url).catch(() => {});
+        break;
+      }
       case 'save':
         bookmarks.toggle(message);
         break;

--- a/vue_client/src/composables/useMessageActions.ts
+++ b/vue_client/src/composables/useMessageActions.ts
@@ -16,9 +16,12 @@ export interface MessageLike {
   // bookmark gate in buildActions.
   networkId?: number | null;
   network_id?: number | null;
-  // The buffer the line belongs to. Present on every real message row; used to
-  // resolve the buffer id the "Copy link" action addresses.
+  // The buffer the line belongs to. Present on every real message row; the
+  // fallback for resolving the buffer id "Copy link" addresses.
   target?: string;
+  // buffers(id), as it rides on the server's message events — the direct
+  // answer, when the row came from the server rather than being minted here.
+  bufferId?: number;
 }
 
 export interface MessageContext {
@@ -83,14 +86,22 @@ export function useMessageActions(): MessageActionsAPI {
   //     jump in server buffer") — a link there would open the buffer and then
   //     toast at the user instead of scrolling
   //
-  // Resolving through findByTarget is an exact-key hit for every row rendered
-  // in a buffer (the O(n) folded scan only runs on a miss), which is what keeps
-  // this cheap enough to call per row from buildActions.
+  // Prefers the id the row already carries — server message events ship
+  // `bufferId` and the store keeps the event object whole, so the usual case
+  // needs no lookup at all. That matters because buildActions runs for EVERY
+  // rendered row (up to MAX_PER_BUFFER of them) on every re-render, and
+  // findByTarget's exact-key fast path degrades to an O(buffers) folded scan
+  // whenever the message's server-cased target differs from the buffer key —
+  // the #327 case — which would make it O(rows x buffers) per render.
+  // findByTarget stays as the fallback for rows minted locally.
   function messageLink(message: MessageLike): string | null {
     const networkId = message.networkId ?? message.network_id;
     if (message.id == null || networkId == null) return null;
     if (!message.target || message.target.startsWith(':server:')) return null;
-    const bufferId = buffers.findByTarget(networkId, message.target)?.id;
+    const bufferId =
+      typeof message.bufferId === 'number'
+        ? message.bufferId
+        : buffers.findByTarget(networkId, message.target)?.id;
     if (bufferId == null) return null;
     return `${window.location.origin}/buffer/${bufferId}?msg=${message.id}`;
   }

--- a/vue_client/src/lib/deferredReady.ts
+++ b/vue_client/src/lib/deferredReady.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { watch } from 'vue';
+
+// How long to wait for the app to become able to honor a cold-start deep link
+// before giving up. networks.fetchAll() (REST) has resolved by the time anyone
+// looks, but buffers and the socket come up asynchronously over the WS — and
+// loadAround() no-ops while the socket is closed — so the intent is held until
+// both land. Shared by every deep-link entry point: the legacy `?net&buf&msg`
+// query, the `/buffer/<id>?msg=` route, and the route resolver in
+// useBufferRoute, which all wait on the same cold start and would be arbitrary
+// to give different budgets.
+export const COLD_START_TIMEOUT_MS = 10000;
+
+/**
+ * Run `act` as soon as `ready()` first holds, or `onTimeout` if it hasn't held
+ * within `timeoutMs`. Fires at most once either way; returns a disposer that
+ * cancels whichever is still pending.
+ *
+ * `ready` must read only REACTIVE state — a getter over a plain Map or a
+ * module-level variable tracks nothing, so the watch would never re-fire and
+ * every caller would silently fall through to its timeout. (That is not
+ * hypothetical: resolving a buffer id through the module-level keyById index
+ * instead of the store's reactive `byId` getter did exactly this.)
+ */
+export function whenReady(
+  ready: () => boolean,
+  act: () => void,
+  onTimeout?: () => void,
+  timeoutMs: number = COLD_START_TIMEOUT_MS,
+): () => void {
+  if (ready()) {
+    act();
+    return () => {};
+  }
+  let done = false;
+  // Watch the boolean directly (not a fresh [a, b] array, which compares
+  // unequal every tick) so the callback runs only when readiness actually flips.
+  const stop = watch(ready, (ok) => {
+    if (!ok) return;
+    cleanup();
+    act();
+  });
+  const timer = setTimeout(() => {
+    cleanup();
+    onTimeout?.();
+  }, timeoutMs);
+  function cleanup(): void {
+    if (done) return;
+    done = true;
+    stop();
+    clearTimeout(timer);
+  }
+  return cleanup;
+}

--- a/vue_client/src/router.test.ts
+++ b/vue_client/src/router.test.ts
@@ -22,6 +22,9 @@ describe('chat routes', () => {
     expect(byName.get('chat')).toBe('/');
     expect(byName.get('buffer')).toBe('/buffer/:id');
     expect(byName.get('buffer-members')).toBe('/buffer/:id/members');
+    // Named, not id-addressed: the app-scoped console has to be reachable
+    // before the server has handed out any row ids.
+    expect(byName.get('system')).toBe('/system');
   });
 
   it('resolves a buffer path to its id param', () => {
@@ -37,6 +40,11 @@ describe('chat routes', () => {
   it('distinguishes the members screen by name, not by path sniffing', () => {
     expect(router.resolve('/buffer/42/members').name).toBe('buffer-members');
     expect(router.resolve('/buffer/42/members').params.id).toBe('42');
+  });
+
+  it('keeps /system out of the id-addressed space', () => {
+    expect(router.resolve('/system').name).toBe('system');
+    expect(router.resolve('/system').params.id).toBeUndefined();
   });
 
   it('does not swallow other routes', () => {

--- a/vue_client/src/router.test.ts
+++ b/vue_client/src/router.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect } from 'vitest';
+import { defineComponent, h, onMounted } from 'vue';
+import { mount } from '@vue/test-utils';
+import { createRouter, createMemoryHistory, RouterView } from 'vue-router';
+import router from './router.js';
+
+// Shape assertions run against the REAL route table, not a copy. An earlier
+// version of this file rebuilt the table by hand, which is how it managed to
+// pass while the real one was malformed: `/buffer/:id` was declared as an ALIAS
+// of `/`, and an alias must carry the same params as the record it aliases.
+// vue-router warned (R0102) and navigation misbehaved — pushes landed back on
+// `/` — but resolve() still worked, so a hand-copied table looked fine.
+
+describe('chat routes', () => {
+  it('gives each chat screen its own named record', () => {
+    const byName = new Map(router.getRoutes().map((r) => [r.name, r.path]));
+    expect(byName.get('chat')).toBe('/');
+    expect(byName.get('buffer')).toBe('/buffer/:id');
+    expect(byName.get('buffer-members')).toBe('/buffer/:id/members');
+  });
+
+  it('resolves a buffer path to its id param', () => {
+    expect(router.resolve('/buffer/42').params).toEqual({ id: '42' });
+    expect(router.resolve('/buffer/42').name).toBe('buffer');
+  });
+
+  it('leaves the id param empty at /', () => {
+    expect(router.resolve('/').params.id).toBeUndefined();
+    expect(router.resolve('/').name).toBe('chat');
+  });
+
+  it('distinguishes the members screen by name, not by path sniffing', () => {
+    expect(router.resolve('/buffer/42/members').name).toBe('buffer-members');
+    expect(router.resolve('/buffer/42/members').params.id).toBe('42');
+  });
+
+  it('does not swallow other routes', () => {
+    expect(router.resolve('/settings/appearance').name).toBe('settings');
+    expect(router.resolve('/admin/users').name).toBe('admin');
+  });
+
+  it('routes every chat screen to the same component', () => {
+    // What lets RouterView patch in place instead of remounting the shell (see
+    // below) — they must be the same component object, which is why router.ts
+    // declares one shared lazy loader rather than three inline imports.
+    const comp = (name: string) =>
+      router.getRoutes().find((r) => r.name === name)?.components?.default;
+    expect(comp('buffer')).toBe(comp('chat'));
+    expect(comp('buffer-members')).toBe(comp('chat'));
+  });
+});
+
+describe('chat shell lifetime', () => {
+  it('does NOT remount moving between /, a buffer, and members', async () => {
+    // A remount re-runs useChatBootstrap's onMounted — a fresh networks.fetchAll
+    // on every mobile trip back to the buffer list. Uses a local router because
+    // the real one's auth guard would try to fetch on navigation; the property
+    // under test is the shared component, which the suite above pins to the real
+    // table.
+    let mounts = 0;
+    const Counted = defineComponent({
+      setup() {
+        onMounted(() => {
+          mounts += 1;
+        });
+        return () => null;
+      },
+    });
+    const local = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'chat', component: Counted },
+        { path: '/buffer/:id', name: 'buffer', component: Counted },
+        { path: '/buffer/:id/members', name: 'buffer-members', component: Counted },
+      ],
+    });
+    const app = mount(defineComponent({ render: () => h(RouterView) }), {
+      global: { plugins: [local] },
+    });
+    await local.isReady();
+
+    await local.push('/buffer/7');
+    await local.push('/buffer/7/members');
+    await local.push('/buffer/8');
+    await local.push('/');
+    await local.push('/buffer/7');
+
+    expect(mounts).toBe(1);
+    app.unmount();
+  });
+});

--- a/vue_client/src/router.ts
+++ b/vue_client/src/router.ts
@@ -7,13 +7,44 @@ import { useConfigStore } from './stores/config.js';
 import { useToastsStore } from './stores/toasts.js';
 import { isChunkLoadError, safeSessionStorage, shouldReloadFor } from './lib/chunkReload.js';
 
+// ONE lazy loader shared by the three chat routes below. Declaring
+// `() => import(...)` three times would make three distinct async wrappers, and
+// component reuse across those routes depends on them resolving to the same
+// component object.
+const chatShell = () => import('./views/Chat.vue');
+
 const routes: RouteRecordRaw[] = [
   { path: '/login', name: 'login', component: () => import('./views/Login.vue') },
   { path: '/invite/:token', name: 'invite', component: () => import('./views/InviteAccept.vue') },
+  // The three chat locations. All render the same shell; only the params differ.
+  //
+  // `/buffer/:id` names ONE buffer by its SERVER ID (#744) — never by name. The
+  // id is stable across renames (see Buffer.id in stores/buffers.ts) and
+  // survives part/rejoin (closing a buffer flips its state server-side, it
+  // doesn't delete the row), so a bookmark keeps resolving. Addressing by name
+  // would instead mean percent-encoding every `#&+!` sigil into the path, and
+  // would leak channel and DM names into browser history, PWA recents and
+  // Referer. `/buffer/:id/members` is the mobile member list (#200) — its own
+  // entry, so the platform back gesture walks members → buffer → list one step
+  // at a time.
+  //
+  // THREE RECORDS, not one record with aliases. An alias must declare the same
+  // params as the record it aliases, so aliasing `/buffer/:id` onto `/` is
+  // malformed — vue-router warns R0102 and navigation misbehaves (a push to
+  // `/buffer/8` lands back on `/`, and the shell renders a buffer the URL
+  // doesn't name). Separate records cost nothing: they share `chatShell` below,
+  // so RouterView patches the same component in place instead of remounting —
+  // router.test.ts pins that down, since a remount would re-run
+  // useChatBootstrap's onMounted on every trip back to the list.
+  //
+  // The routes only name WHICH buffer; useBufferRoute owns the activation and
+  // the reverse (activeKey → URL) direction.
+  { path: '/', name: 'chat', component: chatShell, meta: { requiresAuth: true } },
+  { path: '/buffer/:id', name: 'buffer', component: chatShell, meta: { requiresAuth: true } },
   {
-    path: '/',
-    name: 'chat',
-    component: () => import('./views/Chat.vue'),
+    path: '/buffer/:id/members',
+    name: 'buffer-members',
+    component: chatShell,
     meta: { requiresAuth: true },
   },
   {

--- a/vue_client/src/router.ts
+++ b/vue_client/src/router.ts
@@ -40,6 +40,12 @@ const routes: RouteRecordRaw[] = [
   // The routes only name WHICH buffer; useBufferRoute owns the activation and
   // the reverse (activeKey → URL) direction.
   { path: '/', name: 'chat', component: chatShell, meta: { requiresAuth: true } },
+  // The app-scoped system buffer (#355) gets a NAMED path rather than an id.
+  // It is the one buffer that exists before the server answers — the store
+  // seeds it at boot — so addressing it by row id would make it unreachable
+  // exactly when it matters most: while disconnected, which is when the
+  // connection log it carries is what you want to read.
+  { path: '/system', name: 'system', component: chatShell, meta: { requiresAuth: true } },
   { path: '/buffer/:id', name: 'buffer', component: chatShell, meta: { requiresAuth: true } },
   {
     path: '/buffer/:id/members',

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -30,7 +30,7 @@ vi.mock('../composables/useSocket.js', () => ({
   socketSend: vi.fn<(payload: unknown) => boolean>(),
 }));
 
-import { useBuffersStore, bufferNeedsHydration } from './buffers.js';
+import { useBuffersStore, bufferNeedsHydration, windowAroundAnchor } from './buffers.js';
 import { useSettingsStore } from './settings.js';
 import { socketSend } from '../composables/useSocket.js';
 
@@ -1189,5 +1189,102 @@ describe('byId — the reactive counterpart to the keyById index', () => {
     stop();
 
     expect(seen).toEqual([true]);
+  });
+});
+
+describe('windowAroundAnchor — trimming an around slice', () => {
+  const ev = (id: number) => ({ id, networkId: 1, target: '#c', type: 'message' }) as any;
+  const run = (n: number, anchor: unknown, max: number) =>
+    windowAroundAnchor(
+      Array.from({ length: n }, (_, i) => ev(i + 1)),
+      anchor,
+      max,
+    );
+
+  it('leaves a slice that already fits', () => {
+    const r = run(10, 5, 500);
+    expect(r.events).toHaveLength(10);
+    expect(r.trimmedOlder).toBe(false);
+    expect(r.trimmedNewer).toBe(false);
+  });
+
+  it('centres the window on the anchor', () => {
+    // THE bug: `slice(-max)` kept the newest rows, so a 963-row around slice
+    // trimmed to 500 left the anchor ~18 rows from the top with no context
+    // above it — "loaded high up in the list, but not at the message".
+    const r = run(963, 482, 500);
+    const ids = r.events.map((e: any) => e.id);
+    expect(ids).toContain(482);
+    // Roughly centred: a comfortable block of context on each side.
+    expect(ids.indexOf(482)).toBeGreaterThan(200);
+    expect(ids.length - ids.indexOf(482)).toBeGreaterThan(200);
+    expect(r.trimmedOlder).toBe(true);
+    expect(r.trimmedNewer).toBe(true);
+  });
+
+  it('keeps the anchor when it sits near the start', () => {
+    const r = run(963, 3, 500);
+    expect(r.events.map((e: any) => e.id)).toContain(3);
+    expect(r.events).toHaveLength(500);
+    expect(r.trimmedOlder).toBe(false);
+    expect(r.trimmedNewer).toBe(true);
+  });
+
+  it('keeps the anchor when it sits near the end', () => {
+    const r = run(963, 960, 500);
+    expect(r.events.map((e: any) => e.id)).toContain(960);
+    expect(r.events).toHaveLength(500);
+    expect(r.trimmedOlder).toBe(true);
+    expect(r.trimmedNewer).toBe(false);
+  });
+
+  it('never drops the anchor, wherever it falls', () => {
+    // The failure mode behind the "couldn't load that message" toast: when more
+    // than max rows follow the anchor, tail-trimming discarded it outright.
+    for (const anchor of [1, 250, 481, 700, 963]) {
+      expect(run(963, anchor, 500).events.map((e: any) => e.id)).toContain(anchor);
+    }
+  });
+
+  it('falls back to the newest rows when the anchor is absent', () => {
+    const r = run(963, 99999, 500);
+    expect(r.events).toHaveLength(500);
+    expect(r.events[r.events.length - 1].id).toBe(963);
+    expect(r.trimmedOlder).toBe(true);
+  });
+});
+
+describe('applyAroundSlice — the anchor survives the ring', () => {
+  it('keeps the anchor centred rather than trimming to the newest rows', () => {
+    // Exercised through the store, not just the helper: the bug was in which
+    // window applyAroundSlice asked for, so a helper-only test lets the old
+    // `slice(-MAX)` back in unnoticed.
+    vi.mocked(socketSend).mockReturnValue(true);
+    const store = useBuffersStore();
+    store.ensure(1, '#busy', 47);
+    const token = store.loadAround(1, '#busy', 250528);
+    expect(token).not.toBeNull();
+
+    // A noisy channel: far more rows come back than the ring holds, spread
+    // either side of the anchor.
+    const events = Array.from({ length: 963 }, (_, i) => ({
+      id: 250528 - 481 + i,
+      networkId: 1,
+      target: '#busy',
+      type: 'message',
+      nick: 'someone',
+      text: 'x',
+    }));
+
+    store.applyAroundSlice(1, '#busy', { token, anchorId: 250528, events });
+
+    const buf = store.findByTarget(1, '#busy')!;
+    const ids = buf.messages.map((m) => m.id);
+    expect(ids).toContain(250528);
+    // And with real context above it — landing the anchor at the top of the
+    // pane is the visible half of this bug.
+    expect(ids.indexOf(250528)).toBeGreaterThan(100);
+    expect(buf.hasMoreOlder).toBe(true);
+    expect(buf.hasMoreNewer).toBe(true);
   });
 });

--- a/vue_client/src/stores/buffers.test.ts
+++ b/vue_client/src/stores/buffers.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { nextTick, watch } from 'vue';
 import { setActivePinia, createPinia } from 'pinia';
 
 // buffers.ts reaches into the networks/toasts stores and the socket. The actions
@@ -1139,5 +1140,54 @@ describe('userhostFor — the DM header identity', () => {
       self: true,
     });
     expect(store.userhostFor(3, 'dave')).toBeNull();
+  });
+});
+
+describe('byId — the reactive counterpart to the keyById index', () => {
+  it('resolves a buffer by its server id', () => {
+    const store = useBuffersStore();
+    store.ensure(1, '#chan', 7);
+
+    expect(store.byId(7)?.target).toBe('#chan');
+    expect(store.byId(999)).toBeNull();
+  });
+
+  it('re-fires a watcher when a buffer arrives — the whole reason it exists', async () => {
+    // The module-level keyById Map is invisible to Vue, so a watcher built on
+    // bufferKeyForId never re-runs when an id is learned. That silently broke
+    // the cold-start deep link (#744): the socket connects FIRST, buffers land
+    // after, and the resolver had already taken its only look. This getter must
+    // track reactive state instead — asserted here against the real store,
+    // because a test double is free to be more reactive than production is.
+    const store = useBuffersStore();
+    const seen: boolean[] = [];
+    const stop = watch(
+      () => store.byId(7) != null,
+      (found) => seen.push(found),
+    );
+
+    store.ensure(1, '#chan', 7);
+    await nextTick();
+    stop();
+
+    expect(seen).toEqual([true]);
+  });
+
+  it('re-fires when an already-open buffer LEARNS its id', async () => {
+    // The optimistic path: "Send DM" materializes the buffer, and the row id
+    // only arrives with the server's answer.
+    const store = useBuffersStore();
+    store.ensure(1, 'newpal');
+    const seen: boolean[] = [];
+    const stop = watch(
+      () => store.byId(9) != null,
+      (found) => seen.push(found),
+    );
+
+    store.ensure(1, 'newpal', 9);
+    await nextTick();
+    stop();
+
+    expect(seen).toEqual([true]);
   });
 });

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -385,6 +385,18 @@ export const useBuffersStore = defineStore('buffers', {
   getters: {
     list: (state) => Object.values(state.buffers),
     byKey: (state) => (k: string) => state.buffers[k] || null,
+    // Buffer by its server id — the REACTIVE counterpart to bufferKeyForId
+    // above. Both answer the same question, and the split is deliberate:
+    // bufferKeyForId reads the module-level keyById Map, which is the right
+    // shape for the hot frame-application path (O(1), no proxy) but is invisible
+    // to Vue, so a watcher built on it never re-fires when an id is learned.
+    // Anything reactive — the URL route resolver waiting on a cold-start deep
+    // link (#744) — has to come through here instead. O(buffers) per call, which
+    // is why it's for the route paths and not for frame application.
+    byId: (state) => (id: number) => {
+      for (const b of Object.values(state.buffers)) if (b.id === id) return b;
+      return null;
+    },
     // App-wide highlight total — the sum of every buffer's server-owned
     // `highlighted` count: channel mentions, every unread DM, and notable system
     // lines (see the server's computeUnreadFor). The active buffer always reads

--- a/vue_client/src/stores/buffers.ts
+++ b/vue_client/src/stores/buffers.ts
@@ -328,6 +328,38 @@ function makeBuffer(networkId: number | string | null, target: string): Buffer {
 // doesn't refetch forever. Detached and in-flight buffers are never "in need"
 // — the jump slice is deliberate, and a pending fetch will resolve or be
 // failed by failInFlightHistory on socket close.
+/**
+ * Trim an `around` slice to at most `max` rows while KEEPING THE ANCHOR, with as
+ * much context either side as the budget allows.
+ *
+ * The naive `slice(-max)` keeps the newest rows, which is right for a `latest`
+ * reply and wrong for this one: the point of an around slice is the anchor and
+ * its surroundings. Reports which end(s) were trimmed so the pager flags stay
+ * honest — unlike the tail-only case, either end can now lose rows.
+ */
+export function windowAroundAnchor(
+  events: BufferMessage[],
+  anchorId: unknown,
+  max: number,
+): { events: BufferMessage[]; trimmedOlder: boolean; trimmedNewer: boolean } {
+  if (events.length <= max) return { events, trimmedOlder: false, trimmedNewer: false };
+  const idx = typeof anchorId === 'number' ? events.findIndex((e) => e.id === anchorId) : -1;
+  // Anchor not in the slice (or not told what it is) — nothing to centre on, so
+  // the newest rows are as good a choice as any.
+  if (idx === -1) return { events: events.slice(-max), trimmedOlder: true, trimmedNewer: false };
+  const half = Math.floor(max / 2);
+  // Clamp at both ends so an anchor near either edge still yields a full window
+  // rather than a short one.
+  let start = Math.max(0, idx - half);
+  const end = Math.min(events.length, start + max);
+  start = Math.max(0, end - max);
+  return {
+    events: events.slice(start, end),
+    trimmedOlder: start > 0,
+    trimmedNewer: end < events.length,
+  };
+}
+
 export function bufferNeedsHydration(buf: Buffer): boolean {
   if (buf.networkId == null) return false;
   if (buf.detached || buf.loadingHistory) return false;
@@ -823,13 +855,21 @@ export const useBuffersStore = defineStore('buffers', {
       const filtered = (payload.events || []).filter(
         (e: BufferMessage) => e.type !== 'away' && e.type !== 'back',
       );
-      buf.messages = filtered.slice(-MAX_PER_BUFFER);
+      // Centred on the anchor, NOT `slice(-MAX)`. An `around` window is
+      // symmetrical about the anchor by construction (the server sends up to
+      // halfLimit either side), and a busy channel's noise easily pushes it past
+      // the ring — 963 rows for a 200-row request was the case that exposed
+      // this. Keeping the tail throws away the older half, which lands the
+      // anchor a handful of rows from the top with no context above it, and when
+      // more than MAX rows follow the anchor it discards the anchor itself and
+      // the jump reports that it couldn't find the message.
+      const win = windowAroundAnchor(filtered, payload.anchorId, MAX_PER_BUFFER);
+      buf.messages = win.events;
       buf.oldestId = buf.messages[0]?.id ?? null;
       buf.newestId = buf.messages[buf.messages.length - 1]?.id ?? null;
-      // Same eviction rule as applyLatestReplace: an `around` window tops out at
-      // 2×limit+1 rows, which already exceeds the ring at the default limit.
-      buf.hasMoreOlder = filtered.length > buf.messages.length || !!payload.hasMoreOlder;
-      buf.hasMoreNewer = !!payload.hasMoreNewer;
+      // Trimming can now happen at EITHER end, so each flag follows its own end.
+      buf.hasMoreOlder = win.trimmedOlder || !!payload.hasMoreOlder;
+      buf.hasMoreNewer = win.trimmedNewer || !!payload.hasMoreNewer;
       buf.pendingHistoryToken = null;
       buf.loadingHistory = false;
     },

--- a/vue_client/src/stores/networks.ts
+++ b/vue_client/src/stores/networks.ts
@@ -173,6 +173,13 @@ export const useNetworksStore = defineStore('networks', {
       // sentinel target, matching the buffers store's key() helper.
       this.activeKey = networkId == null ? target : `${networkId}::${target}`;
     },
+    // Leave no buffer active WITHOUT closing anything — the buffer stays in the
+    // store and the list. Exists for backing out of an optimistically created
+    // buffer (#744): it has no server row id, so no URL can name it, and "back
+    // to the list" can only be expressed by clearing the active pointer.
+    clearActive() {
+      this.activeKey = null;
+    },
     // Virtual buffers (the system console) aren't tied to an IRC network.
     // They use a flat sentinel key (no `::`) so the existing
     // `${networkId}::${target}` parsers ignore them.

--- a/vue_client/src/utils/bufferNav.test.ts
+++ b/vue_client/src/utils/bufferNav.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect } from 'vitest';
-import { shouldPushBuffer } from './bufferNav.js';
+import { shouldPushBuffer, shouldLeaveMembers } from './bufferNav.js';
 
 describe('shouldPushBuffer', () => {
   it('navigates to somewhere new', () => {
@@ -27,5 +27,26 @@ describe('shouldPushBuffer', () => {
     // inbound binding drags the user to #b. The in-flight target is the only
     // honest comparison while one exists.
     expect(shouldPushBuffer(7, 7, 8)).toBe(true);
+  });
+});
+
+describe('shouldLeaveMembers', () => {
+  it('holds when the activation IS the buffer the members route names', () => {
+    // Cold refresh of /buffer/7/members: the snapshot resolves and
+    // useBufferRoute activates buffer 7 — the route already names it, and
+    // navigating for that bounced the user to the chat screen before the
+    // members screen ever rendered.
+    expect(shouldLeaveMembers(7, '7')).toBe(false);
+  });
+
+  it('leaves for an activation of a different buffer', () => {
+    // Send DM out of the nick menu: holding would leave the user staring at
+    // the old channel's member list.
+    expect(shouldLeaveMembers(8, '7')).toBe(true);
+  });
+
+  it('leaves for an id-less activation, which can never be the routed buffer', () => {
+    expect(shouldLeaveMembers(undefined, '7')).toBe(true);
+    expect(shouldLeaveMembers(null, '7')).toBe(true);
   });
 });

--- a/vue_client/src/utils/bufferNav.test.ts
+++ b/vue_client/src/utils/bufferNav.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { shouldPushBuffer } from './bufferNav.js';
+
+describe('shouldPushBuffer', () => {
+  it('navigates to somewhere new', () => {
+    expect(shouldPushBuffer(7, null, null)).toBe(true);
+    expect(shouldPushBuffer(7, 8, null)).toBe(true);
+  });
+
+  it('stays put when the route already names the buffer', () => {
+    // The loop guard: a route-driven activation produces an outbound target
+    // identical to the route that caused it, and has to stop there.
+    expect(shouldPushBuffer(7, 7, null)).toBe(false);
+  });
+
+  it('stays put when a push to the same buffer is already in flight', () => {
+    expect(shouldPushBuffer(7, null, 7)).toBe(false);
+  });
+
+  it('IGNORES the route while a push is in flight', () => {
+    // THE regression. At /buffer/7, activating #b starts a push to /buffer/8
+    // while the route still reads 7. Re-activating #a(7) then looks "already
+    // there" against the stale route — so it skips, /buffer/8 lands, and the
+    // inbound binding drags the user to #b. The in-flight target is the only
+    // honest comparison while one exists.
+    expect(shouldPushBuffer(7, 7, 8)).toBe(true);
+  });
+});

--- a/vue_client/src/utils/bufferNav.ts
+++ b/vue_client/src/utils/bufferNav.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * Should activating buffer `id` produce a navigation?
+ *
+ * Two ways the answer is no: we are already there, or we are already on our way
+ * there. The subtlety is WHICH source to believe. `router.push` resolves
+ * asynchronously, so while a push is in flight the route still reports the
+ * PREVIOUS buffer — that lag is the entire reason an in-flight target is
+ * tracked at all, and consulting the route as well as it reintroduces the bug
+ * from the other side:
+ *
+ *   at /buffer/7, activate #b(8)  -> push /buffer/8 starts, route still says 7
+ *   activate #a(7) again          -> route says 7, so "already there", skip
+ *   /buffer/8 lands               -> the inbound binding activates #b
+ *
+ * and the user's second choice is silently undone. So: while a push is in
+ * flight it is the only thing worth comparing against; otherwise the route is
+ * current and authoritative.
+ *
+ * Pure and separate from the composable because the race needs three specific
+ * values to line up — a state a component harness can't reliably stage, since
+ * activations in one scheduler flush coalesce into a single watcher run.
+ */
+export function shouldPushBuffer(
+  id: number,
+  routeId: number | null,
+  inFlightId: number | null,
+): boolean {
+  return (inFlightId != null ? inFlightId : routeId) !== id;
+}

--- a/vue_client/src/utils/bufferNav.ts
+++ b/vue_client/src/utils/bufferNav.ts
@@ -30,3 +30,27 @@ export function shouldPushBuffer(
 ): boolean {
   return (inFlightId != null ? inFlightId : routeId) !== id;
 }
+
+/**
+ * On the members screen, should this activation carry the user off it?
+ *
+ * Two activations reach a mounted members route and they must diverge:
+ *
+ *   - Send DM out of the nick menu: a DIFFERENT buffer became active, and
+ *     holding would leave the user staring at the old channel's member list.
+ *     Navigate.
+ *   - A cold refresh (or bookmark/share) of `/buffer/:id/members`: the
+ *     snapshot resolves and useBufferRoute activates the buffer the route
+ *     ALREADY NAMES. Navigating here bounces to the chat screen the moment
+ *     the app loads, and the members screen the URL asked for never renders.
+ *     Hold.
+ *
+ * An id-less activation (an optimistic DM) can never be the routed buffer, so
+ * it navigates — where its no-address handling takes over.
+ */
+export function shouldLeaveMembers(
+  activeBufferId: number | null | undefined,
+  routeIdParam: unknown,
+): boolean {
+  return activeBufferId == null || String(activeBufferId) !== routeIdParam;
+}

--- a/vue_client/src/utils/defaultBuffer.test.ts
+++ b/vue_client/src/utils/defaultBuffer.test.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { shouldOpenSystemBufferOnLoad } from './defaultBuffer.js';
+
+describe('shouldOpenSystemBufferOnLoad', () => {
+  it('opens the system buffer on a plain cold load', () => {
+    expect(shouldOpenSystemBufferOnLoad(null, undefined)).toBe(true);
+  });
+
+  it('stands aside for a deep link that has not resolved yet', () => {
+    // THE regression. A cold load at /buffer/7 can't resolve that id until the
+    // socket and buffer list arrive, so activeKey is null at mount — exactly the
+    // condition the old `activeKey == null` check took as "nothing claimed a
+    // buffer". Falling back here ends with the system buffer's row id
+    // overwriting the URL, and every bookmark, refresh and copied message link
+    // landing on the system console.
+    expect(shouldOpenSystemBufferOnLoad(null, '7')).toBe(false);
+  });
+
+  it('stands aside once anything is already active', () => {
+    expect(shouldOpenSystemBufferOnLoad('1::#chan', undefined)).toBe(false);
+    expect(shouldOpenSystemBufferOnLoad(':system:', undefined)).toBe(false);
+  });
+});

--- a/vue_client/src/utils/defaultBuffer.ts
+++ b/vue_client/src/utils/defaultBuffer.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+/**
+ * Should the desktop shell open the system buffer as its landing target?
+ *
+ * Desktop has no "no buffer selected" screen the way mobile's list is, so it
+ * falls back to the system buffer rather than a blank pane (#355).
+ *
+ * The route half of this is load-bearing and easy to lose. `activeKey == null`
+ * alone used to mean "nothing has claimed a buffer", because a deep link set one
+ * synchronously. Under URL routing (#744) it cannot: resolving `/buffer/7` needs
+ * the socket and the buffer list, so activeKey IS null at mount on a cold deep
+ * link. Falling back then doesn't just show the wrong thing for a moment — the
+ * system buffer's own row id arrives in the backlog frame, the activeKey→URL
+ * binding treats that as a navigation, and it pushes `/buffer/<system>` over the
+ * link the user opened. Bookmarks, refreshes and "Copy link to message" URLs all
+ * land on the system console instead.
+ *
+ * Deliberately NOT solved inside useBufferRoute by refusing to move the URL
+ * while a resolution is pending: a user who clicks another buffer mid-resolve
+ * must still win, or they'd sit on a URL naming somewhere they aren't and get
+ * yanked away when it finally resolves. The distinction is default-vs-deliberate,
+ * which only the call site knows.
+ */
+export function shouldOpenSystemBufferOnLoad(
+  activeKey: string | null | undefined,
+  routeBufferId: unknown,
+): boolean {
+  return activeKey == null && routeBufferId == null;
+}

--- a/vue_client/src/utils/mobileScreen.test.ts
+++ b/vue_client/src/utils/mobileScreen.test.ts
@@ -20,6 +20,15 @@ describe('screenForRoute', () => {
     expect(screenForRoute(id, isMembers as boolean, active as boolean)).toBe(expected);
   });
 
+  it('shows an optimistically opened buffer that has no address yet', () => {
+    // "Send DM" to a nick never messaged before creates a buffer with no row id,
+    // and the server only mints one when a message is sent. Routing to `/`
+    // stranded the user on the list with a DM they could not reach from it —
+    // the composer they needed was on the screen they could not get to.
+    expect(screenForRoute(undefined, false, true, false, true)).toBe('buffer');
+    expect(screenForRoute('7', true, true, false, true)).toBe('buffer');
+  });
+
   it('holds on the list while a routed buffer is still resolving', () => {
     // Cold launch from a bookmark or a notification: the route names a buffer
     // several seconds before the WS delivers it. Showing the buffer screen with

--- a/vue_client/src/utils/mobileScreen.test.ts
+++ b/vue_client/src/utils/mobileScreen.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { screenForRoute } from './mobileScreen.js';
+
+describe('screenForRoute', () => {
+  it.each([
+    ['at /', undefined, false, true, 'list'],
+    ['on a buffer', '7', false, true, 'buffer'],
+    ['on its members list', '7', true, true, 'members'],
+  ])('%s', (_label, id, isMembers, active, expected) => {
+    expect(screenForRoute(id, isMembers as boolean, active as boolean)).toBe(expected);
+  });
+
+  it('holds on the list while a routed buffer is still resolving', () => {
+    // Cold launch from a bookmark or a notification: the route names a buffer
+    // several seconds before the WS delivers it. Showing the buffer screen with
+    // nothing in it looks like a broken app.
+    expect(screenForRoute('7', false, false)).toBe('list');
+    expect(screenForRoute('7', true, false)).toBe('list');
+  });
+
+  it('falls back to the list when the active buffer goes away', () => {
+    // Closing the buffer (or removing its network) nulls activeKey. Stranding
+    // the user on an empty buffer or a members list for a buffer that no longer
+    // exists is the #137 bug.
+    expect(screenForRoute('7', true, false)).toBe('list');
+  });
+});

--- a/vue_client/src/utils/mobileScreen.test.ts
+++ b/vue_client/src/utils/mobileScreen.test.ts
@@ -5,6 +5,13 @@ import { describe, it, expect } from 'vitest';
 import { screenForRoute } from './mobileScreen.js';
 
 describe('screenForRoute', () => {
+  it('shows the system console from /system, with or without an id', () => {
+    // The app-scoped buffer routes by name because it exists before the server
+    // answers — reachable while disconnected, which is when its log matters.
+    expect(screenForRoute(undefined, false, true, true)).toBe('buffer');
+    expect(screenForRoute(undefined, false, false, true)).toBe('buffer');
+  });
+
   it.each([
     ['at /', undefined, false, true, 'list'],
     ['on a buffer', '7', false, true, 'buffer'],

--- a/vue_client/src/utils/mobileScreen.ts
+++ b/vue_client/src/utils/mobileScreen.ts
@@ -8,7 +8,8 @@
 export type MobileScreen = 'list' | 'buffer' | 'members';
 
 /**
- * `/` → list, `/buffer/<id>` → buffer, `/buffer/<id>/members` → members.
+ * `/` → list, `/buffer/<id>` → buffer, `/buffer/<id>/members` → members,
+ * `/system` → buffer (the app-scoped console).
  *
  * `isMembers` is the route NAME test (`buffer-members`), not a path-suffix
  * sniff — the three screens are three route records.
@@ -29,7 +30,12 @@ export function screenForRoute(
   id: unknown,
   isMembers: boolean,
   hasActiveBuffer: boolean,
+  isSystem = false,
 ): MobileScreen {
+  // `/system` names the app-scoped buffer without an id — it exists before the
+  // server answers, so it stays reachable while disconnected, which is when its
+  // connection log is what you want.
+  if (isSystem) return 'buffer';
   if (!id || !hasActiveBuffer) return 'list';
   return isMembers ? 'members' : 'buffer';
 }

--- a/vue_client/src/utils/mobileScreen.ts
+++ b/vue_client/src/utils/mobileScreen.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Which screen the mobile shell shows, as a pure function of the route (#200).
+// Kept free of Vue/store deps — like utils/navHistory — so the edge cases below
+// are unit-testable without standing up the whole shell.
+
+export type MobileScreen = 'list' | 'buffer' | 'members';
+
+/**
+ * `/` → list, `/buffer/<id>` → buffer, `/buffer/<id>/members` → members.
+ *
+ * `isMembers` is the route NAME test (`buffer-members`), not a path-suffix
+ * sniff — the three screens are three route records.
+ *
+ * This is DERIVED, never assigned. The shell used to keep it in a ref nudged
+ * from four places, which is what let the screen and the URL disagree: the list
+ * had no history entry of its own, so a back gesture from it popped to a BUFFER
+ * url, and an auto-advance watcher hauled the user into that buffer on top of
+ * the list they had just asked for. With one source, that cannot happen.
+ *
+ * `hasActiveBuffer` is the cold-launch guard. `/buffer/7` is a real screen the
+ * moment it routes, but the buffer behind it only arrives over the WS a beat
+ * later, and an empty buffer shell in the meantime reads as broken — so hold on
+ * the list until there's something to show. (useBufferRoute owns the other end:
+ * it drops the URL back to `/` if the id never resolves.)
+ */
+export function screenForRoute(
+  id: unknown,
+  isMembers: boolean,
+  hasActiveBuffer: boolean,
+): MobileScreen {
+  if (!id || !hasActiveBuffer) return 'list';
+  return isMembers ? 'members' : 'buffer';
+}

--- a/vue_client/src/utils/mobileScreen.ts
+++ b/vue_client/src/utils/mobileScreen.ts
@@ -31,11 +31,20 @@ export function screenForRoute(
   isMembers: boolean,
   hasActiveBuffer: boolean,
   isSystem = false,
+  activeLacksId = false,
 ): MobileScreen {
   // `/system` names the app-scoped buffer without an id — it exists before the
   // server answers, so it stays reachable while disconnected, which is when its
   // connection log is what you want.
   if (isSystem) return 'buffer';
+  // The one honest exception to "screen and URL cannot disagree": a buffer
+  // opened optimistically has NO ADDRESS yet, so no route can name it. "Send
+  // DM" to a nick never messaged before creates exactly that, and the server
+  // only mints the row when a message is sent — which needs the composer, on
+  // the screen the user would otherwise never reach. Showing it under whatever
+  // URL we came from beats a dead end; the moment the id lands the URL binding
+  // pushes the real route and this stops applying.
+  if (activeLacksId) return 'buffer';
   if (!id || !hasActiveBuffer) return 'list';
   return isMembers ? 'members' : 'buffer';
 }

--- a/vue_client/src/utils/routerBack.test.ts
+++ b/vue_client/src/utils/routerBack.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { backOrPush, canGoBack } from './routerBack.js';
+
+function router() {
+  return { back: vi.fn<() => void>(), push: vi.fn<(to: string) => Promise<void>>() } as any;
+}
+
+afterEach(() => {
+  window.history.replaceState(null, '', '/');
+});
+
+describe('backOrPush', () => {
+  it('goes back when there is an entry behind us', () => {
+    window.history.replaceState({ back: '/buffer/7' }, '', '/buffer/7/members');
+    const r = router();
+
+    backOrPush(r, '/buffer/7');
+
+    expect(r.back).toHaveBeenCalled();
+    expect(r.push).not.toHaveBeenCalled();
+  });
+
+  it('navigates instead when this is the first entry', () => {
+    // The case these screens only acquired by getting real URLs: opened cold —
+    // refreshed, bookmarked, shared — history.back() would do nothing, or walk
+    // out of Lurker altogether.
+    window.history.replaceState({ back: null }, '', '/buffer/7/members');
+    const r = router();
+
+    backOrPush(r, '/buffer/7');
+
+    expect(r.push).toHaveBeenCalledWith('/buffer/7');
+    expect(r.back).not.toHaveBeenCalled();
+  });
+
+  it('treats a stateless entry as nothing to go back to', () => {
+    window.history.replaceState(null, '', '/buffer/7/members');
+    expect(canGoBack()).toBe(false);
+  });
+});

--- a/vue_client/src/utils/routerBack.ts
+++ b/vue_client/src/utils/routerBack.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type { Router } from 'vue-router';
+
+/**
+ * True when there is an entry of OUR OWN to go back to.
+ *
+ * vue-router records the previous location in `history.state.back`; it is null
+ * on the first entry of a document. That distinction only started mattering
+ * once inner screens got real URLs (#744/#200): a screen that used to be
+ * reachable solely by navigating into it can now be opened cold — refreshed,
+ * bookmarked, shared — and `history.back()` from there either does nothing or
+ * leaves the app entirely.
+ */
+export function canGoBack(): boolean {
+  try {
+    return !!(window.history.state as { back?: string | null } | null)?.back;
+  } catch {
+    return false;
+  }
+}
+
+/** Go back if we came from somewhere, otherwise navigate to `fallback`. */
+export function backOrPush(router: Router, fallback: string): void {
+  if (canGoBack()) router.back();
+  else void router.push(fallback);
+}

--- a/vue_client/src/views/Chat.vue
+++ b/vue_client/src/views/Chat.vue
@@ -16,11 +16,15 @@
 import { reactive } from 'vue';
 import { useViewport } from '../composables/useViewport.js';
 import { useOnboarding } from '../composables/useOnboarding.js';
+import { useBufferRoute } from '../composables/useBufferRoute.js';
 import DesktopChat from './DesktopChat.vue';
 import MobileChat from './MobileChat.vue';
 import OnboardingFlow from '../components/OnboardingFlow.vue';
 
 const { isMobile } = useViewport();
+// Bound here, not in either shell: the URL <-> active-buffer binding has to
+// survive the Desktop<->Mobile swap below, exactly like OnboardingFlow above.
+useBufferRoute();
 // reactive() so the composable's refs unwrap in the template, matching how the
 // shells consume useNetworkEditor.
 const onboarding = reactive(useOnboarding());

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -301,7 +301,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue';
-import { useRouter } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import type { Network } from '../stores/networks.js';
 import { useBuffersStore, type Buffer } from '../stores/buffers.js';
 import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
@@ -335,6 +335,7 @@ import UserProfileModal from '../components/UserProfileModal.vue';
 import MediaViewerModal from '../components/MediaViewerModal.vue';
 import { useKeyboardShortcuts } from '../composables/useKeyboardShortcuts.js';
 import { useNicklistCollapseStore } from '../stores/nicklistCollapse.js';
+import { shouldOpenSystemBufferOnLoad } from '../utils/defaultBuffer.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useDccStore } from '../stores/dcc.js';
 import { useWhoisStore } from '../stores/whois.js';
@@ -354,12 +355,13 @@ const buffers = useBuffersStore();
 useSocket();
 
 // Land on the system buffer instead of a blank "No messages yet." pane when
-// nothing else is active on load (#355). The last-active buffer isn't persisted,
-// so activeKey is null on every fresh load; the system buffer always exists in
-// the store, so this is always a valid target. Guarded on null so a deep-link /
-// push-jump that set a buffer first still wins.
+// nothing else is active on load (#355) — but not over the top of a deep link
+// that hasn't resolved yet. See shouldOpenSystemBufferOnLoad for why the route
+// half of that test is load-bearing.
 onMounted(() => {
-  if (networks.activeKey == null) buffers.activate(null, SYSTEM_KEY);
+  if (shouldOpenSystemBufferOnLoad(networks.activeKey, route.params.id)) {
+    buffers.activate(null, SYSTEM_KEY);
+  }
 });
 const {
   active,
@@ -576,6 +578,7 @@ function onChatClick(e: MouseEvent) {
 const onJumpToMessage = useJumpToMessage({ pendingScrollId });
 
 const router = useRouter();
+const route = useRoute();
 // Collapsed-only footer affordance: the settings cog normally lives on the
 // LURKER sidebar row, but that whole list is unmounted when the sidebar is
 // collapsed (BufferList v-if), so the rail offers the cog here instead (#355).

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -354,25 +354,6 @@ const buffers = useBuffersStore();
 // the socket never opens: red status light + no buffers (#355 regression).
 useSocket();
 
-// Land on the system buffer instead of a blank "No messages yet." pane when
-// nothing else is active (#355) — but not over the top of a deep link that
-// hasn't resolved yet. See shouldOpenSystemBufferOnLoad for why the route half
-// of that test is load-bearing.
-//
-// A watcher rather than a one-shot onMounted, because the interesting case
-// arrives LATE: a stale bookmark declines this rule at mount (the URL names a
-// buffer), then fails to resolve and drops the route back to `/` ten seconds
-// later with nothing active. A one-shot never sees that, and desktop is left on
-// the blank pane this rule exists to prevent.
-watch(
-  () => [networks.activeKey, route.params.id] as const,
-  () => {
-    if (shouldOpenSystemBufferOnLoad(networks.activeKey, route.params.id)) {
-      buffers.activate(null, SYSTEM_KEY);
-    }
-  },
-  { immediate: true },
-);
 const {
   active,
   activeBuf,
@@ -589,6 +570,33 @@ const onJumpToMessage = useJumpToMessage({ pendingScrollId });
 
 const router = useRouter();
 const route = useRoute();
+
+// Land on the system buffer instead of a blank "No messages yet." pane when
+// nothing else is active (#355) — but not over the top of a deep link that
+// hasn't resolved yet. See shouldOpenSystemBufferOnLoad for why the route half
+// of that test is load-bearing.
+//
+// A watcher rather than a one-shot onMounted, because the interesting case
+// arrives LATE: a stale bookmark declines this rule at mount (the URL names a
+// buffer), then fails to resolve and drops the route back to `/` ten seconds
+// later with nothing active. A one-shot never sees that, and desktop is left on
+// the blank pane this rule exists to prevent.
+//
+// MUST stay below `route` above. `immediate: true` evaluates the getter
+// synchronously inside watch(), and <script setup> preserves statement order —
+// declared any earlier this throws a temporal-dead-zone ReferenceError during
+// setup and the desktop shell never mounts at all. Neither vue-tsc (it cannot
+// see through the closure) nor the suite (nothing mounts this component) catches
+// it, so the ordering is load-bearing and invisible.
+watch(
+  () => [networks.activeKey, route.params.id] as const,
+  () => {
+    if (shouldOpenSystemBufferOnLoad(networks.activeKey, route.params.id)) {
+      buffers.activate(null, SYSTEM_KEY);
+    }
+  },
+  { immediate: true },
+);
 // Collapsed-only footer affordance: the settings cog normally lives on the
 // LURKER sidebar row, but that whole list is unmounted when the sidebar is
 // collapsed (BufferList v-if), so the rail offers the cog here instead (#355).

--- a/vue_client/src/views/DesktopChat.vue
+++ b/vue_client/src/views/DesktopChat.vue
@@ -355,14 +355,24 @@ const buffers = useBuffersStore();
 useSocket();
 
 // Land on the system buffer instead of a blank "No messages yet." pane when
-// nothing else is active on load (#355) — but not over the top of a deep link
-// that hasn't resolved yet. See shouldOpenSystemBufferOnLoad for why the route
-// half of that test is load-bearing.
-onMounted(() => {
-  if (shouldOpenSystemBufferOnLoad(networks.activeKey, route.params.id)) {
-    buffers.activate(null, SYSTEM_KEY);
-  }
-});
+// nothing else is active (#355) — but not over the top of a deep link that
+// hasn't resolved yet. See shouldOpenSystemBufferOnLoad for why the route half
+// of that test is load-bearing.
+//
+// A watcher rather than a one-shot onMounted, because the interesting case
+// arrives LATE: a stale bookmark declines this rule at mount (the URL names a
+// buffer), then fails to resolve and drops the route back to `/` ten seconds
+// later with nothing active. A one-shot never sees that, and desktop is left on
+// the blank pane this rule exists to prevent.
+watch(
+  () => [networks.activeKey, route.params.id] as const,
+  () => {
+    if (shouldOpenSystemBufferOnLoad(networks.activeKey, route.params.id)) {
+      buffers.activate(null, SYSTEM_KEY);
+    }
+  },
+  { immediate: true },
+);
 const {
   active,
   activeBuf,

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -122,7 +122,7 @@
           class="icon"
           title="Members"
           aria-label="Members"
-          @click="screen = 'members'"
+          @click="goMembers"
         >
           <i class="fa-solid fa-users"></i>
         </button>
@@ -151,7 +151,7 @@
     <!-- Screen: members -->
     <section v-else-if="screen === 'members'" class="screen members-screen">
       <header class="bar">
-        <button class="icon back" title="Back" @click="screen = 'buffer'">
+        <button class="icon back" title="Back" @click="router.back()">
           <i class="fa-solid fa-arrow-left"></i>
         </button>
         <span class="title">{{ bufferLabel }} — members</span>
@@ -226,11 +226,13 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import type { Network } from '../stores/networks.js';
 import type { BufferLike } from '../composables/useBufferActions.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useSocket } from '../composables/useSocket.js';
 import { useChatBootstrap } from '../composables/useChatBootstrap.js';
+import { pushBuffer } from '../composables/useBufferRoute.js';
 import { useActiveBuffer } from '../composables/useActiveBuffer.js';
 import { useBufferSearchScope } from '../composables/useBufferSearchScope.js';
 import { useBufferActions } from '../composables/useBufferActions.js';
@@ -253,6 +255,7 @@ import SearchModal from '../components/SearchModal.vue';
 import NickNoteModal from '../components/NickNoteModal.vue';
 import UserProfileModal from '../components/UserProfileModal.vue';
 import MediaViewerModal from '../components/MediaViewerModal.vue';
+import { screenForRoute } from '../utils/mobileScreen.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useDccStore } from '../stores/dcc.js';
 import { useWhoisStore } from '../stores/whois.js';
@@ -269,6 +272,8 @@ import { SYSTEM_KEY } from '../lib/virtualBuffers.js';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
+const router = useRouter();
+const route = useRoute();
 const auth = useAuthStore();
 
 // Admin panel entry in the mobile top bar.
@@ -309,22 +314,33 @@ function openSystemConsole() {
   // Route through activate() (not networks.activateSystem) so the system buffer
   // gets the full read-state lifecycle: divider snapshot + mark-read on entry.
   buffers.activate(null, SYSTEM_KEY);
-  // The activeKey watcher only fires on value change. If the user is
-  // already on `:system:` (e.g. they hit Back to the list, then re-tap
-  // the logo), the watcher won't advance them — drive the screen
-  // directly so the second tap behaves like the first.
-  screen.value = 'buffer';
+  openActiveBuffer();
 }
 
-// `list` (default) → tap a buffer → `buffer` → tap members icon → `members`.
-// Back arrows walk the stack backwards. We don't sync this to the URL — the
-// flow is short and stateful, and a URL would expose us to bookmarks that
-// land on the buffer screen with no active buffer.
 const channelListModal = reactive(useChannelListModal());
 const joinChannelModal = reactive(useJoinChannelModal());
 const viewer = reactive(useMediaViewer());
 const networkEditor = reactive(useNetworkEditor());
-const screen = ref('list');
+
+// `/` → list, `/buffer/<id>` → buffer, `/buffer/<id>/members` → members.
+//
+// DERIVED, never assigned (#744/#200). It used to be a ref nudged from four
+// places, which is what made the mobile shell and the URL able to disagree: the
+// list screen had no history entry of its own, so a back gesture from it popped
+// to a BUFFER url and the auto-advance watcher dutifully hauled the user into
+// that buffer, on top of the list they'd just asked for. With the route as the
+// single source, "which screen" and "which URL" cannot come apart, and the
+// platform back gesture walks members → buffer → list for free.
+//
+// The activeKey clause keeps a cold launch honest: `/buffer/7` is a real screen
+// the instant it's routed, but the buffer behind it arrives over the WS a beat
+// later, and rendering an empty buffer shell in the meantime looks broken. Wait
+// on the list, exactly as the old auto-advance did. useBufferRoute owns the
+// other end of that wait — it drops the URL back to `/` if the id never lands.
+const screen = computed(() => {
+  const v = screenForRoute(route.params.id, route.name === 'buffer-members', !!activeKey.value);
+  return v;
+});
 const showBookmarks = ref(false);
 const showTopic = ref(false);
 const showUploads = ref(false);
@@ -423,53 +439,49 @@ function closeNetworkForm() {
   networkEditor.close();
 }
 
-// BufferList calls buffers.activate() directly on click; we react to the
-// activeKey flip rather than intercepting the click so the same store state
-// drives both layouts. Auto-advance from list (the natural buffer-open
-// flow) AND from members (Send DM out of the nick menu flips activeKey to a
-// new DM buffer — the members screen for the old channel would otherwise be
-// stranded). The buffer screen itself doesn't auto-advance — we let in-
-// buffer activations (e.g. a user explicitly switching) drop the user
-// straight into the new buffer without re-triggering the watcher's screen
-// change since they're already on that screen.
-watch(activeKey, (next) => {
-  if (next && (screen.value === 'list' || screen.value === 'members')) {
-    screen.value = 'buffer';
-  } else if (next === null && screen.value !== 'list') {
-    // The active buffer went away (closed it, or its network was removed) while
-    // we were viewing it — activeKey only nulls in those "no buffer" cases, so
-    // fall back to the list instead of stranding the user on an empty buffer or
-    // members screen (#137). Buffer-to-buffer switches set activeKey directly
-    // (no null transition), so this never flickers mid-switch.
-    screen.value = 'list';
-  }
+// Send DM out of a nick menu flips activeKey to a new DM buffer while the user
+// is on the members screen; the route has to follow or they'd be left looking
+// at the old channel's member list. Every other activation path already
+// navigates (useBufferRoute's binding, or openActiveBuffer above).
+watch(activeKey, () => {
+  if (route.name === 'buffer-members') openActiveBuffer();
 });
 
-// Re-tapping the *same* buffer the user was last in doesn't change activeKey
-// so the watcher above doesn't fire. Catch the bubbled click here as a
-// belt-and-suspenders advance: if a row was hit and a buffer is active, go
-// to the buffer screen. Vue event bubbling runs BufferList's @click first,
-// so by the time we read activeKey it's already up to date.
+// Navigate to whichever buffer is active NOW.
+//
+// Needed wherever an activation might not CHANGE activeKey, because
+// useBufferRoute's activeKey → URL binding is a watcher and correctly does
+// nothing when there's no change: re-tapping the buffer you were last in, or
+// re-tapping the Lurker logo while already on `:system:`. Both are a
+// navigation from the user's point of view even though no state moved.
+function openActiveBuffer() {
+  const id = (activeBuf.value as { id?: number } | null)?.id;
+  if (id != null) pushBuffer(router, id);
+}
+
 function onBufferListClick(e: MouseEvent) {
   // :not(.section-head): the FRIENDS/FAVORITES headers are inert labels — a
   // tap on one must not teleport into whatever buffer was last active.
   const hit = (e.target as Element).closest('.channels li, .net-head:not(.section-head)');
   if (!hit) return;
-  if (activeKey.value) screen.value = 'buffer';
+  // BufferList's own @click ran first (Vue event bubbling), so activeKey is
+  // already up to date by the time we read it.
+  openActiveBuffer();
 }
 
 function goList() {
-  screen.value = 'list';
+  void router.push('/');
+}
+
+function goMembers() {
+  if (route.params.id) void router.push(`/buffer/${route.params.id}/members`);
 }
 
 const onJumpToMessage = useJumpToMessage({
   pendingScrollId,
-  // Mobile shell stacks list → buffer → members. Tapping a search result or
-  // notification needs to forward us onto the buffer screen so the message
-  // we just jumped to is actually visible.
-  afterActivate: () => {
-    screen.value = 'buffer';
-  },
+  // A search hit or notification for the buffer the user is ALREADY in doesn't
+  // move activeKey, so nothing would carry them off the list to see it.
+  afterActivate: openActiveBuffer,
 });
 
 useChatBootstrap({ onJump: onJumpToMessage });

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -314,7 +314,9 @@ function openSystemConsole() {
   // Route through activate() (not networks.activateSystem) so the system buffer
   // gets the full read-state lifecycle: divider snapshot + mark-read on entry.
   buffers.activate(null, SYSTEM_KEY);
-  openActiveBuffer();
+  // By NAME, not id: this is the one buffer that has to open before the server
+  // has answered — which is exactly when its connection log is worth reading.
+  void router.push('/system');
 }
 
 const channelListModal = reactive(useChannelListModal());
@@ -337,10 +339,14 @@ const networkEditor = reactive(useNetworkEditor());
 // later, and rendering an empty buffer shell in the meantime looks broken. Wait
 // on the list, exactly as the old auto-advance did. useBufferRoute owns the
 // other end of that wait — it drops the URL back to `/` if the id never lands.
-const screen = computed(() => {
-  const v = screenForRoute(route.params.id, route.name === 'buffer-members', !!activeKey.value);
-  return v;
-});
+const screen = computed(() =>
+  screenForRoute(
+    route.params.id,
+    route.name === 'buffer-members',
+    !!activeKey.value,
+    route.name === 'system',
+  ),
+);
 const showBookmarks = ref(false);
 const showTopic = ref(false);
 const showUploads = ref(false);
@@ -455,8 +461,22 @@ watch(activeKey, () => {
 // re-tapping the Lurker logo while already on `:system:`. Both are a
 // navigation from the user's point of view even though no state moved.
 function openActiveBuffer() {
-  const id = (activeBuf.value as { id?: number } | null)?.id;
-  if (id != null) pushBuffer(router, id);
+  const buf = activeBuf.value as { id?: number; networkId?: number | null } | null;
+  if (!buf) return;
+  // App-scoped (the system console) routes by name — it may have no row id yet.
+  if (buf.networkId == null) {
+    void router.push('/system');
+    return;
+  }
+  if (buf.id != null) {
+    pushBuffer(router, buf.id);
+    return;
+  }
+  // Active but not addressable yet — a DM opened optimistically has no row id
+  // until the server answers. Leave whatever sub-screen we're on rather than
+  // sitting on it (the member list of the channel we just left, say); the URL
+  // binding pushes the real route the moment the id lands.
+  if (route.name !== 'chat') void router.push('/');
 }
 
 function onBufferListClick(e: MouseEvent) {

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -340,12 +340,20 @@ const networkEditor = reactive(useNetworkEditor());
 // later, and rendering an empty buffer shell in the meantime looks broken. Wait
 // on the list, exactly as the old auto-advance did. useBufferRoute owns the
 // other end of that wait — it drops the URL back to `/` if the id never lands.
+// True while the active buffer is a real IRC buffer the server hasn't given a
+// row id yet — an optimistically opened DM. Nothing can route to it.
+const activeLacksId = computed(() => {
+  const buf = activeBuf.value as { id?: number; networkId?: number | null } | null;
+  return !!buf && buf.networkId != null && buf.id == null;
+});
+
 const screen = computed(() =>
   screenForRoute(
     route.params.id,
     route.name === 'buffer-members',
     !!activeKey.value,
     route.name === 'system',
+    activeLacksId.value,
   ),
 );
 const showBookmarks = ref(false);
@@ -474,10 +482,11 @@ function openActiveBuffer() {
     return;
   }
   // Active but not addressable yet — a DM opened optimistically has no row id
-  // until the server answers. Leave whatever sub-screen we're on rather than
-  // sitting on it (the member list of the channel we just left, say); the URL
-  // binding pushes the real route the moment the id lands.
-  if (route.name !== 'chat') void router.push('/');
+  // until the server answers. Deliberately does NOT navigate: pushing `/` here
+  // dropped the user on the buffer list with a DM they could not reach from it
+  // (no id to route to, and the server only mints the row once a message is
+  // sent — which needs the composer). `screen` shows it via activeLacksId
+  // instead, until the id lands and the URL binding routes to it properly.
 }
 
 function onBufferListClick(e: MouseEvent) {

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -257,6 +257,7 @@ import UserProfileModal from '../components/UserProfileModal.vue';
 import MediaViewerModal from '../components/MediaViewerModal.vue';
 import { screenForRoute } from '../utils/mobileScreen.js';
 import { backOrPush } from '../utils/routerBack.js';
+import { shouldLeaveMembers } from '../utils/bufferNav.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useDccStore } from '../stores/dcc.js';
 import { useWhoisStore } from '../stores/whois.js';
@@ -458,8 +459,15 @@ function closeNetworkForm() {
 // is on the members screen; the route has to follow or they'd be left looking
 // at the old channel's member list. Every other activation path already
 // navigates (useBufferRoute's binding, or openActiveBuffer above).
+//
+// Guarded by shouldLeaveMembers: a cold refresh of /buffer/:id/members also
+// lands here — the snapshot resolves and useBufferRoute activates the buffer
+// this route already names — and navigating for THAT bounced the user to the
+// chat screen before the members screen ever rendered.
 watch(activeKey, () => {
-  if (route.name === 'buffer-members') openActiveBuffer();
+  if (route.name !== 'buffer-members') return;
+  const buf = activeBuf.value as { id?: number } | null;
+  if (shouldLeaveMembers(buf?.id, route.params.id)) openActiveBuffer();
 });
 
 // Navigate to whichever buffer is active NOW.
@@ -500,6 +508,15 @@ function onBufferListClick(e: MouseEvent) {
 }
 
 function goList() {
+  // Backing out of an optimistically opened buffer can't be a navigation: it
+  // has no URL, so the route may already BE `/` (Send DM from the list), where
+  // a push is a no-op and the screen would stay locked on the DM. Clear the
+  // active pointer instead — the buffer keeps its place in the list, and the
+  // URL binding normalizes whatever route we're on.
+  if (activeLacksId.value) {
+    networks.clearActive();
+    return;
+  }
   void router.push('/');
 }
 
@@ -511,7 +528,13 @@ function goBufferFromMembers() {
 }
 
 function goMembers() {
-  if (route.params.id) void router.push(`/buffer/${route.params.id}/members`);
+  // The ACTIVE buffer's id, not route.params.id: the button belongs to the
+  // buffer on screen, and the two can disagree — a channel shown via
+  // activeLacksId before its row id lands leaves the route naming the PREVIOUS
+  // buffer, so the route form opened the wrong channel's member list. While
+  // the id is missing there is nothing to route to; the button no-ops.
+  const buf = activeBuf.value as { id?: number } | null;
+  if (buf?.id != null) void router.push(`/buffer/${buf.id}/members`);
 }
 
 const onJumpToMessage = useJumpToMessage({

--- a/vue_client/src/views/MobileChat.vue
+++ b/vue_client/src/views/MobileChat.vue
@@ -151,7 +151,7 @@
     <!-- Screen: members -->
     <section v-else-if="screen === 'members'" class="screen members-screen">
       <header class="bar">
-        <button class="icon back" title="Back" @click="router.back()">
+        <button class="icon back" title="Back" @click="goBufferFromMembers">
           <i class="fa-solid fa-arrow-left"></i>
         </button>
         <span class="title">{{ bufferLabel }} — members</span>
@@ -256,6 +256,7 @@ import NickNoteModal from '../components/NickNoteModal.vue';
 import UserProfileModal from '../components/UserProfileModal.vue';
 import MediaViewerModal from '../components/MediaViewerModal.vue';
 import { screenForRoute } from '../utils/mobileScreen.js';
+import { backOrPush } from '../utils/routerBack.js';
 import { useNickNotesStore } from '../stores/nickNotes.js';
 import { useDccStore } from '../stores/dcc.js';
 import { useWhoisStore } from '../stores/whois.js';
@@ -491,6 +492,13 @@ function onBufferListClick(e: MouseEvent) {
 
 function goList() {
   void router.push('/');
+}
+
+// The members screen has its own URL now, so it can be the FIRST entry of a
+// document (refresh, or a shared link) — in which case back() either does
+// nothing or leaves Lurker. Fall back to the buffer it belongs to.
+function goBufferFromMembers() {
+  backOrPush(router, route.params.id ? `/buffer/${route.params.id}` : '/');
 }
 
 function goMembers() {

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -79,8 +79,15 @@ const router = useRouter();
 // history.state.back live wouldn't do either: every settings category is its
 // own push (SettingsSidebar), so it would walk back through the categories
 // browsed instead of leaving. Falls back to `/` when Settings was opened cold.
-const chatEntry =
-  (canGoBack() ? (window.history.state as { back?: string } | null)?.back : null) ?? '/';
+//
+// Settings-internal entries are rejected, not just missing ones: vue-router
+// state survives a reload, so after an intra-settings refresh state.back names
+// the PREVIOUS CATEGORY — a back link that switches categories once and then
+// goes dead, with no other way out of the Settings shell. `/` always exits.
+const entryCandidate = canGoBack()
+  ? (window.history.state as { back?: string } | null)?.back
+  : null;
+const chatEntry = entryCandidate && !entryCandidate.startsWith('/settings') ? entryCandidate : '/';
 
 const error = ref('');
 

--- a/vue_client/src/views/Settings.vue
+++ b/vue_client/src/views/Settings.vue
@@ -16,7 +16,7 @@
 <template>
   <div class="settings-page">
     <header class="bar">
-      <RouterLink to="/" class="back">← back</RouterLink>
+      <RouterLink :to="chatEntry" class="back">← back</RouterLink>
       <h1>settings</h1>
     </header>
 
@@ -46,6 +46,7 @@
 import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue';
 import type { Component } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
+import { canGoBack } from '../utils/routerBack.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useAuthStore } from '../stores/auth.js';
 import { useConfigStore } from '../stores/config.js';
@@ -70,6 +71,16 @@ const auth = useAuthStore();
 const config = useConfigStore();
 const route = useRoute();
 const router = useRouter();
+
+// Where "← back" returns to, captured ONCE on entry rather than read at click
+// time. Since #744 the chat URL names a specific buffer, so a hard-coded `/`
+// silently drops it — you return to chat still looking at #foo while the URL
+// says `/`, and copying or refreshing then lands somewhere else. Reading
+// history.state.back live wouldn't do either: every settings category is its
+// own push (SettingsSidebar), so it would walk back through the categories
+// browsed instead of leaving. Falls back to `/` when Settings was opened cold.
+const chatEntry =
+  (canGoBack() ? (window.history.state as { back?: string } | null)?.back : null) ?? '/';
 
 const error = ref('');
 


### PR DESCRIPTION
Closes #744. Closes #200.

Gives every buffer a URL, and derives the mobile screen from it — which is what makes swipe-back work without writing a single line of gesture code.

## Why these are one PR

#200 (swipe-back on mobile) was deferred in June because hand-rolling a web swipe gesture — direction locking, scroll hijack, text selection, an interactive translated track — risked degrading the mobile experience for a marginal win. None of that is needed. In an installed PWA the iOS edge swipe and the Android system back are both `history.back()`, so once the mobile screens are history entries the platform does the work.

They also can't ship apart. The routing half alone makes mobile *worse*: the list had no history entry, so a back gesture from it popped to a buffer URL and the old auto-advance watcher hauled the user into that buffer on top of the list they'd just asked for. Found on a real device.

## Design decisions worth knowing

**URLs carry the server buffer id, never the name.** The id is stable across renames and survives part/rejoin (closing flips `buffers.state`, it doesn't delete the row), so a bookmark keeps resolving. It also means no `#&+!` sigil ever needs percent-encoding into a path, and no channel or DM name leaks into browser history, PWA recents or `Referer`.

**Three plain route records sharing one lazy loader**, not one record with aliases — an alias must carry the same params as the record it aliases, so aliasing `/buffer/:id` onto `/` is malformed (vue-router warns R0102 and pushes land back on `/`). Sharing the loader is what lets RouterView patch the shell in place instead of remounting it and re-running bootstrap on every trip back to the list.

**`/system` is named, not id-addressed.** It's the one buffer that exists before the server answers, and its connection log is what you want precisely when there is no connection.

**navHistory (Cmd+`[`/`]`) is untouched and stays independent** — a buffer trail with its own cursor and dead-buffer skipping, alongside the location stack.

**`Copy link to message`** falls out of the above: a `fa-link` action copying `/buffer/<id>?msg=<n>`, the same form the service worker already mints for a cold notification tap.

## Pre-existing bugs fixed along the way

Both surfaced by the new deep links, but reachable from search jumps too and not introduced here:

- **`applyAroundSlice` trimmed with `slice(-MAX_PER_BUFFER)`.** Right for a `latest` reply, wrong for an `around` window, which is symmetrical about its anchor. A busy channel returned 963 rows for a 200-row request, so keeping the tail left the anchor ~18 rows from the top — and when more than 500 rows followed it, discarded the anchor outright and reported "couldn't load that message" for a message that arrived intact.
- **Jump scrolls didn't stay put.** A jump renders a whole slice at once and this pane disables scroll anchoring, so content resolving above the target shifted it off screen after a scroll that had succeeded. Now instant rather than smooth, and re-centred while the layout settles (measured: 74 corrections on a 1870-event slice, 0 on a small one).

## Known and accepted

**The PWA back gesture briefly shows the previous channel highlighted.** Not ours and not fixable from JS: on-device sampling showed the DOM's active row going `(none)` → the correct channel with nothing in between, across a ~466ms gap in delivered frames. Safari composites a cached snapshot of the list entry during its own gesture animation. Happens in the installed PWA as well as in a tab.

**An optimistically opened buffer has no address.** "Send DM" to a nick never messaged before creates a buffer with no row id — the server only mints one when a message is sent — so no route can name it. The mobile shell shows it under whatever URL we came from until the id lands. This is the one documented place where screen and URL may legitimately disagree.

## Testing

`npm run check` clean; 3763 tests pass. Verified on-device in an installed iOS PWA: swipe-back through members → buffer → list, cold launch from a bookmark, and `?msg=` permalinks landing on the message.

Five `/code-review` rounds (the last two at `max`). Notable: the mocked-router suite makes navigation synchronous, which is exactly the property that hides this class of bug — hence the separate real-router integration suite.

The second `max` round surfaced three more user-visible navigation traps plus a cleanup tail, all fixed in d17c050 (each behavioral fix mutation-verified: fix reverted, its test fails, fix restored): backing out of an optimistic id-less DM locked the mobile shell (back moved the URL and nothing else), a deferred cold-start `?msg` jump could yank the user away seconds after they had deliberately navigated elsewhere, a cold refresh of `/buffer/:id/members` bounced to the chat screen before the members screen ever rendered, and the `'pending'` branch leaked a dead-id wait into a spurious toast. It also confirmed the APNs/FCM senders dropped the documented `bufferId` field — both carry it now.

## Follow-ups (deferred, not blocking)

Updated after the second `max` round; everything else from the earlier list is fixed in d17c050.

- Warm navigation to a closed buffer's `/buffer/<id>` (routinely reachable: Back into its history entry) burns the full 10s cold-start timeout — the shell renders the previously active buffer under the dead URL, then toasts and drops to `/`. Failing fast wants the client to track the server's backlog-complete terminator, which has no client handlers yet — its own PR.
- A cold desktop load at `/` (including every sign-in) builds `['/', '/system']`, so the first Back press is a visual no-op. The outbound watcher can't tell the default system landing from a deliberate logo tap; only the call site knows, and it doesn't signal.
- `inFlightId` is cleared by value, so a cancelled push can clear the guard belonging to a newer live push to the same id (needs three rapid navigations). An epoch/token would fix it.
- `openSystemConsole`'s explicit push and the outbound watcher's system branch can both push `/system` for one activation — the watcher's `route.name` guard reads the stale route while the explicit push is in flight. vue-router cancels the first so it converges to one entry; the system branch deserves the same in-flight guard buffers get.
- `shouldOpenSystemBufferOnLoad` infers "deep link still resolving" from `route.params.id` — a proxy silently coupled to the route table. Exporting a real pending signal from `useBufferRoute` would answer the question directly.
- `maybePushFavoriteOnline` resolves the same DM row twice (`isFavoriteDmPeer`'s gate, then the payload id); the favorites layer could surface the row it already fetched.
- `Admin.vue` still hard-codes `RouterLink to="/"`, dropping the buffer from the URL on return.
- `holdCentred` tests its deadline after applying a correction, so one final correction can land just past the budget (harmless by design).
- `stripQuery` collapses repeated query keys (the fragment is now carried through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

