### PR TITLE
Network form: say what "commands to run on connect" actually wants

### DIFF
--- a/vue_client/src/components/NetworkForm.vue
+++ b/vue_client/src/components/NetworkForm.vue
@@ -122,11 +122,12 @@
               rows="4"
               autocomplete="off"
               spellcheck="false"
-              placeholder="AUTH <user> <password> etc…"
+              :placeholder="connectCommandsPlaceholder"
             />
             <small
-              >One per line, e.g. for opering up on connect. If you need to add a (eg, 15 sec) delay
-              between commands, you can write: WAIT 15</small
+              >Raw IRC protocol lines (not /commands), one per line, sent to the server verbatim
+              once connected — e.g. for identifying or opering up. A line like
+              <code>WAIT 15</code> pauses that many seconds before the next one.</small
             >
           </label>
           <label class="check">
@@ -276,6 +277,14 @@ const showSaslHint = computed(() => {
 // When SASL is effectively required (a hosted cell on a network that blocks
 // unauthenticated cloud IPs), drop the "(optional)" qualifier on the labels.
 const saslRequired = computed(() => showSaslHint.value);
+
+// A worked example beats prose here: raw wire lines, not slash commands, and
+// the WAIT pseudo-command in context. (#540)
+const connectCommandsPlaceholder = [
+  'PRIVMSG NickServ :IDENTIFY hunter2',
+  'WAIT 5',
+  'OPER admin hunter2',
+].join('\n');
 
 // Placeholder echoes the prefilled default if the user clears the field.
 const channelPlaceholder = computed(() => {


### PR DESCRIPTION
The field feeds `runConnectCommands`, which sends each line verbatim via `client.raw()` — but the old placeholder (`AUTH <user> <password> etc…`) suggested a command that doesn't exist in the protocol. The help text now says plainly these are raw IRC protocol lines (not /commands), and the placeholder is a worked multi-line example with `WAIT` shown in context:

```
PRIVMSG NickServ :IDENTIFY hunter2
WAIT 5
OPER admin hunter2
```

Copy-only; no behavior change. QA: one glance at the add/edit network form's advanced section.

Closes #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)