### PR TITLE
Hoist the .ua flex+gap workaround into the shared .device row

### DIFF
--- a/vue_client/src/components/settings-panes/ApiTokensPane.vue
+++ b/vue_client/src/components/settings-panes/ApiTokensPane.vue
@@ -231,11 +231,6 @@ async function onRevoke(token: ApiToken) {
   min-width: 0;
 }
 
-.token-row .ua {
-  display: flex;
-  align-items: center;
-  gap: 1ch;
-}
 .token-row .name {
   color: var(--fg);
 }

--- a/vue_client/src/components/settings-panes/ThemesSection.vue
+++ b/vue_client/src/components/settings-panes/ThemesSection.vue
@@ -212,19 +212,6 @@ function remove(t: ThemePreset) {
 
 <style src="./panes.css"></style>
 <style scoped>
-.device-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.device .ua {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 8px;
-}
-.device .name {
-  color: var(--fg);
-}
 .tag {
   font-size: 0.85em;
   color: var(--fg-muted);

--- a/vue_client/src/components/settings-panes/panes.css
+++ b/vue_client/src/components/settings-panes/panes.css
@@ -92,6 +92,18 @@
 }
 .settings-pane .device .ua {
   color: var(--fg);
+  /* Adjacent spans inside a .ua render with NO gap otherwise: Vue's default
+     whitespace: 'condense' strips whitespace-only text nodes that contain a
+     newline, so "x0.at" + "x0" collide into "x0.atx0". Flex+gap provides the
+     spacing structurally, shared here so panes stop rediscovering the fix
+     locally (#538 — ApiTokensPane and ThemesSection each had a copy).
+     AccountPane's full-width passkey input is safe: .ua is a grid item
+     stretched across the 1fr column, so its width is the column's regardless
+     of its own display type. */
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 1ch;
 }
 .settings-pane .device .last-seen {
   color: var(--fg-muted);
@@ -126,22 +138,6 @@
   justify-self: start;
   flex-wrap: wrap;
 }
-/* Adjacent spans inside .ua (name + driver + badges) otherwise render with NO gap
-   at all: Vue's default whitespace: 'condense' strips whitespace-only text nodes
-   that contain a newline, so `x0.at` and `x0` collide into "x0.atx0". ApiTokensPane
-   already works around this with the same flex+gap in its own scoped styles.
-
-   Scoped to .stacked rather than hoisted onto every .device on purpose: AccountPane's
-   .ua wraps a full-width <input>, which a flex container would reflow, and that's not
-   something this change can verify. Hoisting it (and de-duplicating ApiTokensPane)
-   wants eyes on all three panes — see #538. */
-.settings-pane .device.stacked .ua {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 1ch;
-}
-
 .settings-pane .hl-sep {
   border: none;
   border-top: 1px solid var(--border);


### PR DESCRIPTION
One rule in `panes.css` instead of three local rediscoveries: the #535 `.stacked` scoping, ApiTokensPane's `.token-row .ua` copy, and ThemesSection's (written after the issue predicted a third copy would appear — it did, it was us).

The AccountPane caveat that blocked hoisting in #535 turned out to be moot: `.device` is a grid with `.ua` stretched across the `1fr` column, so the full-width passkey input's width never depended on `.ua`'s display type.

**QA ask (per the issue): eyeball four panes after this lands** — api-tokens rows, account passkeys, uploader rows, and the themes list.

Closes #538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)