### PR TITLE
Survive the controlling terminal going away

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -418,4 +418,4 @@ npm run client:build
 npm start
 ```
 
-The server listens on port 8010 by default. Configure with the same envvars described above (set them in a `.env` file next to `package.json`, or export them in your shell). Use a process supervisor (`systemd`, `pm2`, etc.) or a persistent session (`tmux`, `nohup`) to keep it running — note that backgrounding + `disown` alone is not enough to fully detach from an SSH session, since the process keeps its stdout/stderr attached to the disappearing terminal. (Lurker survives that since #442, but a supervisor restarts it after a genuine crash too.)
+The server listens on port 8010 by default. Configure with the same envvars described above (set them in a `.env` file next to `package.json`, or export them in your shell). Use a process supervisor (`systemd`, `pm2`, etc.) to keep it running: it restarts the server after a crash, which nothing else on this page does. Backgrounding with `disown` and logging out also works — the server survives its terminal going away — but console output is gone for good at that point (the in-app system log keeps recording), and a crash stays down until you notice.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -418,4 +418,4 @@ npm run client:build
 npm start
 ```
 
-The server listens on port 8010 by default. Configure with the same envvars described above (set them in a `.env` file next to `package.json`, or export them in your shell). Use a process supervisor (`systemd`, `pm2`, etc.) to keep it running.
+The server listens on port 8010 by default. Configure with the same envvars described above (set them in a `.env` file next to `package.json`, or export them in your shell). Use a process supervisor (`systemd`, `pm2`, etc.) or a persistent session (`tmux`, `nohup`) to keep it running — note that backgrounding + `disown` alone is not enough to fully detach from an SSH session, since the process keeps its stdout/stderr attached to the disappearing terminal. (Lurker survives that since #442, but a supervisor restarts it after a genuine crash too.)

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,6 +1,13 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
+// FIRST import on purpose: it installs the dead-pty stdout/stderr guards as an
+// import side effect (#442), and module evaluation follows import-declaration
+// order — dotenv's injection banner and the db module's boot-migration logs
+// write to stdout during the import phase, before any statement in this file
+// runs. Moving this down (or installing from this file's body, as a previous
+// revision did) re-opens the boot-time crash window this exists to close.
+import { onStdioSuppressed, installFatalExceptionExit } from './utils/processGuards.js';
 import 'dotenv/config';
 import http from 'http';
 
@@ -46,30 +53,36 @@ import {
 import { startIgnoreSweeper, stopIgnoreSweeper } from './services/ignoreSweeper.js';
 import { sweepTempUploads } from './routes/uploads.js';
 import { startEventLoopMonitor, stopEventLoopMonitor } from './services/eventLoopMonitor.js';
-import { swallowDeadTtyErrors } from './utils/processGuards.js';
+import * as systemMessages from './db/systemMessages.js';
 
-// Before ANY console output: a vanished controlling terminal (dropped SSH
-// session + `disown`) leaves fds 1/2 pointing at a dead pty, and the next
-// console write would otherwise crash the whole server with EIO (#442).
-swallowDeadTtyErrors(process.stdout);
-swallowDeadTtyErrors(process.stderr);
-
-// An uncaught exception still exits — a process in an unknown state must not
-// limp on — but the reason is recorded in the DB-backed system log first,
-// because the terminal that would have shown the stack may be long gone.
-process.on('uncaughtException', (err) => {
-  try {
-    systemLog.log({
-      scope: 'server',
-      level: 'error',
-      text: `fatal uncaught exception: ${err?.stack || err}`,
-    });
-  } catch {
-    /* the log write failing must not mask the exit path */
-  }
-  console.error('[lurker] fatal uncaught exception:', err);
-  process.exit(1);
+// Wired here rather than inside processGuards (which must stay import-free —
+// see its header): both records target the DB-backed system log, which only
+// exists once the import phase is over. The breadcrumb makes "console logging
+// stopped" (dead pty, or the consumer of `npm start | tee` exiting)
+// discoverable instead of a silent weeks-long gap in the log file.
+onStdioSuppressed((detail) => {
+  systemLog.log({
+    scope: 'server',
+    level: 'warn',
+    text: `Console stream write failed (${detail}) — stdout/stderr logging is suspended; the system log is unaffected`,
+  });
 });
+
+// Fatal exceptions (and, under Node's default mode, unhandled rejections)
+// still exit — see installFatalExceptionExit for the ordering contract. The
+// record writes via systemMessages.insert directly, NOT systemLog.log: log()
+// synchronously runs the full wsHub fan-out (per-user reads, frame queuing)
+// for frames the exit(1) is about to discard mid-crash.
+installFatalExceptionExit((text) =>
+  systemMessages.insert({
+    userId: null,
+    ts: new Date().toISOString(),
+    level: 'error',
+    scope: 'server',
+    source: 'server',
+    text,
+  }),
+);
 
 const PORT = Number(process.env.PORT || 8010);
 // Optional bind address for the web/API server (HOST). Unset keeps upstream

--- a/server/server.ts
+++ b/server/server.ts
@@ -46,6 +46,30 @@ import {
 import { startIgnoreSweeper, stopIgnoreSweeper } from './services/ignoreSweeper.js';
 import { sweepTempUploads } from './routes/uploads.js';
 import { startEventLoopMonitor, stopEventLoopMonitor } from './services/eventLoopMonitor.js';
+import { swallowDeadTtyErrors } from './utils/processGuards.js';
+
+// Before ANY console output: a vanished controlling terminal (dropped SSH
+// session + `disown`) leaves fds 1/2 pointing at a dead pty, and the next
+// console write would otherwise crash the whole server with EIO (#442).
+swallowDeadTtyErrors(process.stdout);
+swallowDeadTtyErrors(process.stderr);
+
+// An uncaught exception still exits — a process in an unknown state must not
+// limp on — but the reason is recorded in the DB-backed system log first,
+// because the terminal that would have shown the stack may be long gone.
+process.on('uncaughtException', (err) => {
+  try {
+    systemLog.log({
+      scope: 'server',
+      level: 'error',
+      text: `fatal uncaught exception: ${err?.stack || err}`,
+    });
+  } catch {
+    /* the log write failing must not mask the exit path */
+  }
+  console.error('[lurker] fatal uncaught exception:', err);
+  process.exit(1);
+});
 
 const PORT = Number(process.env.PORT || 8010);
 // Optional bind address for the web/API server (HOST). Unset keeps upstream

--- a/server/services/wsHub.ts
+++ b/server/services/wsHub.ts
@@ -2370,7 +2370,10 @@ export function attachWsHub(httpServer: HttpServer, sessionSecret: string) {
   // Wrapper around the (synchronous) snapshot builder. Two jobs: (1) time it,
   // so a stall serving one connect is visible; (2) contain any throw so a bad
   // snapshot for ONE client can't take down the process and drop every user's
-  // IRC. There is no global unhandledRejection guard, so this is the backstop.
+  // IRC. Still load-bearing after #442's global fatal handler: that handler
+  // records the failure and EXITS (a process in unknown state must not limp
+  // on) — it does not make uncontained throws survivable, so removing this
+  // catch would turn one bad snapshot into every user's IRC dropping.
   function sendSnapshot(
     ws: LurkerWebSocket,
     userId: number,

--- a/server/utils/processGuards.test.ts
+++ b/server/utils/processGuards.test.ts
@@ -78,7 +78,7 @@ describe('installFatalExceptionExit', () => {
 
   it('still exits when the record itself throws', () => {
     const target = new EventEmitter();
-    const exit = vi.fn();
+    const exit = vi.fn<(code: number) => void>();
     installFatalExceptionExit(
       () => {
         throw new Error('db is gone too');

--- a/server/utils/processGuards.test.ts
+++ b/server/utils/processGuards.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect } from 'vitest';
+import { EventEmitter } from 'events';
+import { swallowDeadTtyErrors } from './processGuards.js';
+
+function errWithCode(code: string): NodeJS.ErrnoException {
+  const e: NodeJS.ErrnoException = new Error(code);
+  e.code = code;
+  return e;
+}
+
+describe('swallowDeadTtyErrors', () => {
+  it('is the difference between surviving and crashing: an unhandled stream error throws', () => {
+    const stream = new EventEmitter();
+    expect(() => stream.emit('error', errWithCode('EIO'))).toThrow('EIO');
+  });
+
+  it('swallows EPIPE and EIO (the dead-pty write errors)', () => {
+    const stream = new EventEmitter();
+    swallowDeadTtyErrors(stream);
+    expect(() => stream.emit('error', errWithCode('EPIPE'))).not.toThrow();
+    expect(() => stream.emit('error', errWithCode('EIO'))).not.toThrow();
+  });
+
+  it('rethrows every other stream error', () => {
+    const stream = new EventEmitter();
+    swallowDeadTtyErrors(stream);
+    expect(() => stream.emit('error', errWithCode('ENOSPC'))).toThrow('ENOSPC');
+    expect(() => stream.emit('error', new Error('no code'))).toThrow('no code');
+  });
+});

--- a/server/utils/processGuards.test.ts
+++ b/server/utils/processGuards.test.ts
@@ -1,9 +1,21 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
-import { swallowDeadTtyErrors } from './processGuards.js';
+import {
+  suppressStdioStreamErrors,
+  onStdioSuppressed,
+  installFatalExceptionExit,
+  resetStdioSuppressionForTests,
+} from './processGuards.js';
+
+// These suites prove the module's own decision logic (swallow-everything, the
+// one-time notifier, the fatal-exit ordering) against injected fakes. What
+// they deliberately cannot prove is the INSTALL ORDER on the real process —
+// that the side-effect import in server.ts really precedes dotenv's banner
+// and the boot migration's writes — which lives in import-declaration order
+// and is documented in both files.
 
 function errWithCode(code: string): NodeJS.ErrnoException {
   const e: NodeJS.ErrnoException = new Error(code);
@@ -11,23 +23,86 @@ function errWithCode(code: string): NodeJS.ErrnoException {
   return e;
 }
 
-describe('swallowDeadTtyErrors', () => {
-  it('is the difference between surviving and crashing: an unhandled stream error throws', () => {
-    const stream = new EventEmitter();
-    expect(() => stream.emit('error', errWithCode('EIO'))).toThrow('EIO');
+function fakeStream() {
+  return new EventEmitter() as unknown as Pick<NodeJS.WriteStream, 'on'> & EventEmitter;
+}
+
+beforeEach(() => {
+  resetStdioSuppressionForTests();
+});
+
+describe('suppressStdioStreamErrors', () => {
+  it('swallows every stream error, not an allowlist — EBADF would otherwise rethrow into the fatal handler', () => {
+    const stream = fakeStream();
+    suppressStdioStreamErrors(stream, 'stdout');
+    for (const code of ['EPIPE', 'EIO', 'EBADF', 'ENOSPC']) {
+      expect(() => stream.emit('error', errWithCode(code))).not.toThrow();
+    }
+    expect(() => stream.emit('error', new Error('no code at all'))).not.toThrow();
   });
 
-  it('swallows EPIPE and EIO (the dead-pty write errors)', () => {
-    const stream = new EventEmitter();
-    swallowDeadTtyErrors(stream);
-    expect(() => stream.emit('error', errWithCode('EPIPE'))).not.toThrow();
-    expect(() => stream.emit('error', errWithCode('EIO'))).not.toThrow();
+  it('reports only the FIRST suppression to the notifier', () => {
+    const stream = fakeStream();
+    suppressStdioStreamErrors(stream, 'stdout');
+    const seen: string[] = [];
+    onStdioSuppressed((d) => seen.push(d));
+    stream.emit('error', errWithCode('EPIPE'));
+    stream.emit('error', errWithCode('EIO'));
+    expect(seen).toEqual(['stdout: EPIPE']);
   });
 
-  it('rethrows every other stream error', () => {
-    const stream = new EventEmitter();
-    swallowDeadTtyErrors(stream);
-    expect(() => stream.emit('error', errWithCode('ENOSPC'))).toThrow('ENOSPC');
-    expect(() => stream.emit('error', new Error('no code'))).toThrow('no code');
+  it('fires a late-registered notifier immediately — an import-phase failure must not be lost', () => {
+    const stream = fakeStream();
+    suppressStdioStreamErrors(stream, 'stderr');
+    stream.emit('error', errWithCode('EIO'));
+    const seen: string[] = [];
+    onStdioSuppressed((d) => seen.push(d));
+    expect(seen).toEqual(['stderr: EIO']);
+  });
+});
+
+describe('installFatalExceptionExit', () => {
+  it('records first (with origin), then exits 1', () => {
+    const target = new EventEmitter();
+    const order: string[] = [];
+    installFatalExceptionExit(
+      (text) => order.push(`record:${text}`),
+      target,
+      (code) => order.push(`exit:${code}`),
+    );
+    target.emit('uncaughtException', new Error('boom'), 'uncaughtException');
+    expect(order).toHaveLength(2);
+    expect(order[0]).toMatch(/^record:fatal uncaughtException: Error: boom/);
+    expect(order[1]).toBe('exit:1');
+  });
+
+  it('still exits when the record itself throws', () => {
+    const target = new EventEmitter();
+    const exit = vi.fn();
+    installFatalExceptionExit(
+      () => {
+        throw new Error('db is gone too');
+      },
+      target,
+      exit,
+    );
+    target.emit('uncaughtException', new Error('boom'), 'uncaughtException');
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('names an unhandled rejection as such and survives a non-Error reason', () => {
+    // Under Node's default --unhandled-rejections=throw, rejections land here
+    // with origin 'unhandledRejection' — and reject('nope') has no stack, so
+    // the record must say what kind of value arrived rather than logging a
+    // bare, hint-free string.
+    const target = new EventEmitter();
+    const records: string[] = [];
+    installFatalExceptionExit(
+      (t) => records.push(t),
+      target,
+      () => {},
+    );
+    target.emit('uncaughtException', 'nope', 'unhandledRejection');
+    expect(records[0]).toBe('fatal unhandledRejection: non-Error thrown: "nope"');
   });
 });

--- a/server/utils/processGuards.ts
+++ b/server/utils/processGuards.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// A self-hosted instance often outlives the terminal it was launched from
+// (`disown`, a dropped SSH session). `disown` only stops the shell's SIGHUP —
+// the process still holds fds 1/2 into the pty, and when the pty is torn down
+// the NEXT write to stdout/stderr fails with EIO/EPIPE. Without an 'error'
+// listener Node surfaces that as an uncaught exception, so the first log line
+// after the terminal vanishes kills the server (#442).
+
+/**
+ * Swallow exactly the dead-terminal write errors on a stdio stream. Anything
+ * else rethrows — a genuine stream failure should still be loud.
+ */
+export function swallowDeadTtyErrors(stream: NodeJS.EventEmitter): void {
+  stream.on('error', (err: NodeJS.ErrnoException) => {
+    if (err?.code !== 'EPIPE' && err?.code !== 'EIO') throw err;
+  });
+}

--- a/server/utils/processGuards.ts
+++ b/server/utils/processGuards.ts
@@ -1,19 +1,93 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-// A self-hosted instance often outlives the terminal it was launched from
-// (`disown`, a dropped SSH session). `disown` only stops the shell's SIGHUP —
-// the process still holds fds 1/2 into the pty, and when the pty is torn down
-// the NEXT write to stdout/stderr fails with EIO/EPIPE. Without an 'error'
-// listener Node surfaces that as an uncaught exception, so the first log line
-// after the terminal vanishes kills the server (#442).
+// Process-level guards for a self-hosted instance that outlives its terminal
+// (#442). `disown` only stops the shell's SIGHUP — the process keeps fds 1/2
+// into the pty, and once the pty is torn down the NEXT stdout/stderr write
+// fails; without an 'error' listener Node turns that into an uncaught
+// exception and the first log line after the terminal vanishes kills the
+// server.
+//
+// ⚠ This module is IMPORTED FOR ITS SIDE EFFECT as server.ts's FIRST import,
+// ahead of 'dotenv/config' and everything that pulls in db/index.ts. Module
+// evaluation follows import-declaration order, and the import phase itself
+// writes to stdout on every boot (dotenv's injection banner, the boot
+// migration's '[db] …' lines) — guards installed from server.ts's module BODY
+// would arrive after the exact writes that crash a dead-pty boot. That is
+// also why nothing here may import anything: a dependency would evaluate
+// before dotenv populates the environment it reads.
+//
+// ALL 'error' events on the two streams are swallowed, not just EPIPE/EIO: a
+// failed stdio write is never worth killing the server, and an allowlist
+// merely converts the exotic variants (EBADF from an fd something closed)
+// into a one-tick-delayed copy of the same crash via the fatal handler. The
+// first suppression is surfaced through onStdioSuppressed so "console logging
+// stopped" (e.g. the consumer of `npm start | tee` died) is a discoverable
+// system-log line rather than a weeks-long mystery gap in the log file.
 
-/**
- * Swallow exactly the dead-terminal write errors on a stdio stream. Anything
- * else rethrows — a genuine stream failure should still be loud.
- */
-export function swallowDeadTtyErrors(stream: NodeJS.EventEmitter): void {
+let suppressed: string | null = null;
+let notify: ((detail: string) => void) | null = null;
+
+export function suppressStdioStreamErrors(stream: Pick<NodeJS.WriteStream, 'on'>, name: string) {
   stream.on('error', (err: NodeJS.ErrnoException) => {
-    if (err?.code !== 'EPIPE' && err?.code !== 'EIO') throw err;
+    if (suppressed != null) return;
+    suppressed = `${name}: ${err?.code || err?.message || 'unknown stream error'}`;
+    notify?.(suppressed);
   });
 }
+
+// server.ts registers the DB-backed breadcrumb here once its own imports are
+// usable (the guards must exist long before systemLog can be). If a write
+// already failed during the import phase, the notifier fires immediately.
+export function onStdioSuppressed(fn: (detail: string) => void): void {
+  notify = fn;
+  if (suppressed != null) fn(suppressed);
+}
+
+function describeThrown(err: unknown): string {
+  if (err instanceof Error) return err.stack || `${err.name}: ${err.message}`;
+  try {
+    return `non-Error thrown: ${JSON.stringify(err)}`;
+  } catch {
+    return `non-Error thrown: ${String(err)}`;
+  }
+}
+
+/**
+ * Fatal-exception exit with a durable record: an uncaught exception (or, under
+ * Node's default mode, an unhandled rejection — `origin` says which) still
+ * exits — a process in an unknown state must not limp on — but the reason is
+ * recorded first, because the terminal that would have shown the stack may be
+ * long gone. Ordering is load-bearing and pinned by tests: record first, a
+ * failed record must not mask the exit, exit(1) last.
+ */
+export function installFatalExceptionExit(
+  record: (text: string) => void,
+  target: NodeJS.EventEmitter = process,
+  exit: (code: number) => void = (code) => process.exit(code),
+): void {
+  target.on('uncaughtException', (err: unknown, origin: string) => {
+    try {
+      record(`fatal ${origin || 'uncaughtException'}: ${describeThrown(err)}`);
+    } catch {
+      /* the record failing must not mask the exit path */
+    }
+    try {
+      console.error(`[lurker] fatal ${origin || 'uncaughtException'}:`, err);
+    } catch {
+      /* a dead stdio stream may be exactly why we're here */
+    }
+    exit(1);
+  });
+}
+
+// Test seam: `suppressed`/`notify` are deliberately module-global (first
+// failure wins, process-wide), which tests have to be able to unwind.
+export function resetStdioSuppressionForTests(): void {
+  suppressed = null;
+  notify = null;
+}
+
+// The side effect this module exists for — see the header note on ordering.
+suppressStdioStreamErrors(process.stdout, 'stdout');
+suppressStdioStreamErrors(process.stderr, 'stderr');


### PR DESCRIPTION
A self-hosted instance backgrounded with `disown` still holds fds 1/2 into its pty; when the SSH session drops and the pty is torn down, the next `console.*` write raised an unhandled stream error and killed the server (#442).

- `processGuards.ts` installs stdout/stderr `error` listeners **as an import side effect, as `server.ts`'s first import** — the `/code-review` pass proved the import phase itself writes to stdout on every boot (dotenv's banner, the boot migration's logs), so guards installed from the module body arrived after the exact writes that crash a dead-pty boot.
- **All** stream errors are swallowed on those two streams, not an EPIPE/EIO allowlist (EBADF from a closed fd would otherwise rethrow into a one-tick-delayed copy of the same crash). The first suppression writes a one-time system-log breadcrumb so "console logging stopped" (dead pty, or the consumer of `npm start | tee` dying) is discoverable.
- A fatal handler records uncaught exceptions **and** (under Node's default mode) unhandled rejections to the DB-backed system log before exiting 1 — same crash semantics, but the reason survives the vanished terminal. Ordering contract (record → console → exit; a failed record can't mask the exit) is pinned by unit tests; the record goes through `systemMessages.insert` directly rather than running the wsHub fan-out mid-crash.
- Self-host docs: supervisor vs `disown` tradeoff stated plainly.

Reviewed via `/code-review high`; all findings addressed (one candidate empirically refuted). Full check + suite green.

Closes #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)