### PR TITLE
Auto-reconnect: a ban on a surviving socket no longer poisons the next drop

### DIFF
--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1549,6 +1549,48 @@ describe('auto-reconnect controller', () => {
     ).toBe(true);
   });
 
+  // #651: a ban-shaped ERROR that did NOT close its own socket must not lie in
+  // wait — before the pending/promote treatment it set the terminal flag on
+  // sight, and the next unrelated drop (netsplit, ping timeout, laptop lid)
+  // inherited it and stopped auto-reconnect for good, telling the user they
+  // were banned when they weren't.
+  it('a ban-shaped error on a surviving socket does not poison a later unrelated drop', () => {
+    vi.useFakeTimers();
+    const { conn, events } = makeConn('rc-ban-stale');
+    conn.client.emit('irc error', { error: 'irc', reason: 'you are banned from this server' });
+    // The socket lives on well past the promote window — the ban didn't close it.
+    vi.advanceTimersByTime(60 * 1000);
+    conn.client.emit('close', true);
+    vi.advanceTimersByTime(60 * 1000);
+    expect(conn.connect).toHaveBeenCalled();
+    expect(
+      events.some(
+        (e) => e.type === 'error' && /Not reconnecting automatically/i.test(String(e.text)),
+      ),
+    ).toBe(false);
+  });
+
+  // Registration is even stronger proof than time: whatever that line was, the
+  // server kept us, so even a close INSIDE the promote window must retry.
+  it('registering after a ban-shaped error clears it before any close can promote it', () => {
+    vi.useFakeTimers();
+    const { conn, events } = makeConn('rc-ban-registered');
+    conn.client.emit('irc error', { error: 'irc', reason: 'you are banned from this server' });
+    (conn.client as unknown as { options: unknown }).options = {
+      ping_interval: 0,
+      ping_timeout: 0,
+    };
+    conn.client.emit('registered', { nick: 'nick' });
+    conn.client.emit('close', true);
+    vi.advanceTimersByTime(60 * 1000);
+    expect(conn.connect).toHaveBeenCalled();
+    expect(
+      events.some(
+        (e) => e.type === 'error' && /Not reconnecting automatically/i.test(String(e.text)),
+      ),
+    ).toBe(false);
+  });
+
   // Was "stops on a hard SASL authentication failure" — stopping on the FIRST
   // one is the behavior #617 changed, because a rejection the server didn't drop
   // us for would kill an unrelated later drop's reconnect. The intent it was

--- a/server/services/ircConnection.test.ts
+++ b/server/services/ircConnection.test.ts
@@ -1357,6 +1357,18 @@ describe('auto-reconnect controller', () => {
     return { conn, events };
   }
 
+  // Emit 'registered' the way these stubbed connections must: connect() is
+  // mocked, so the library's own 'registered' listener has no live
+  // connection.options — pin harmless ping settings first so its
+  // startPeriodicPing early-returns instead of dereferencing null.
+  function emitRegistered(conn: IrcConnection): void {
+    (conn.client as unknown as { options: unknown }).options = {
+      ping_interval: 0,
+      ping_timeout: 0,
+    };
+    conn.client.emit('registered', { nick: 'nick' });
+  }
+
   // The connectScheduler is a process-wide singleton; clear its per-host gate
   // state before each test so a prior run's timestamps can't delay this launch.
   beforeEach(() => connectScheduler.reset());
@@ -1553,13 +1565,19 @@ describe('auto-reconnect controller', () => {
   // wait — before the pending/promote treatment it set the terminal flag on
   // sight, and the next unrelated drop (netsplit, ping timeout, laptop lid)
   // inherited it and stopped auto-reconnect for good, telling the user they
-  // were banned when they weren't.
-  it('a ban-shaped error on a surviving socket does not poison a later unrelated drop', () => {
+  // were banned when they weren't. The survival proof is ORDERING, not time: a
+  // real ban ERROR is the link's last line, so any later server line discards
+  // the flag.
+  it('a ban-shaped error followed by more server traffic does not poison a later drop', () => {
     vi.useFakeTimers();
     const { conn, events } = makeConn('rc-ban-stale');
     conn.client.emit('irc error', { error: 'irc', reason: 'you are banned from this server' });
-    // The socket lives on well past the promote window — the ban didn't close it.
-    vi.advanceTimersByTime(60 * 1000);
+    // The link keeps talking — proof the "ban" didn't kill it.
+    conn.client.emit('raw', {
+      from_server: true,
+      line: ':irc.example.test PONG irc.example.test :keepalive',
+    });
+    vi.advanceTimersByTime(60 * 60 * 1000);
     conn.client.emit('close', true);
     vi.advanceTimersByTime(60 * 1000);
     expect(conn.connect).toHaveBeenCalled();
@@ -1570,17 +1588,33 @@ describe('auto-reconnect controller', () => {
     ).toBe(false);
   });
 
-  // Registration is even stronger proof than time: whatever that line was, the
-  // server kept us, so even a close INSIDE the promote window must retry.
+  // The counterpart that a wall-clock window would get wrong: an IP-level ban
+  // whose FIN is blackholed closes only via the ping timeout, minutes after
+  // the ERROR — but with NO lines in between, the ERROR was the link's last
+  // word and must still be believed, or auto-reconnect hammers a server that
+  // banned us forever.
+  it('still stops when the close arrives long after the ban with no traffic in between', () => {
+    vi.useFakeTimers();
+    const { conn, events } = makeConn('rc-ban-blackhole');
+    conn.client.emit('irc error', { error: 'irc', reason: 'Closing Link: nick[u@h] (Z-Lined)' });
+    vi.advanceTimersByTime(120 * 1000); // irc-framework's ping timeout scale
+    conn.client.emit('close', true);
+    vi.runAllTimers();
+    expect(conn.connect).not.toHaveBeenCalled();
+    expect(
+      events.some(
+        (e) => e.type === 'error' && /Not reconnecting automatically/i.test(String(e.text)),
+      ),
+    ).toBe(true);
+  });
+
+  // Registration is proof positive too: whatever that line was, the server
+  // kept us, so a close right after must retry.
   it('registering after a ban-shaped error clears it before any close can promote it', () => {
     vi.useFakeTimers();
     const { conn, events } = makeConn('rc-ban-registered');
     conn.client.emit('irc error', { error: 'irc', reason: 'you are banned from this server' });
-    (conn.client as unknown as { options: unknown }).options = {
-      ping_interval: 0,
-      ping_timeout: 0,
-    };
-    conn.client.emit('registered', { nick: 'nick' });
+    emitRegistered(conn);
     conn.client.emit('close', true);
     vi.advanceTimersByTime(60 * 1000);
     expect(conn.connect).toHaveBeenCalled();
@@ -1630,16 +1664,12 @@ describe('auto-reconnect controller', () => {
   it('resets the streak when registration succeeds despite repeated SASL failures', () => {
     vi.useFakeTimers();
     const { conn } = makeConn('rc-sasl-reset');
-    (conn.client as unknown as { options: unknown }).options = {
-      ping_interval: 0,
-      ping_timeout: 0,
-    };
     for (let i = 0; i < 2; i += 1) {
       conn.client.emit('sasl failed', { reason: 'fail' });
       conn.client.emit('close', true);
       vi.runAllTimers();
     }
-    conn.client.emit('registered', { nick: 'nick' });
+    emitRegistered(conn);
 
     // A third failure now starts a fresh streak rather than tipping the old one.
     conn.client.emit('sasl failed', { reason: 'fail' });
@@ -1684,11 +1714,7 @@ describe('auto-reconnect controller', () => {
     vi.useFakeTimers();
     const { conn } = makeConn('rc-sasl-recovered');
     conn.client.emit('sasl failed', { reason: 'fail' });
-    (conn.client as unknown as { options: unknown }).options = {
-      ping_interval: 0,
-      ping_timeout: 0,
-    };
-    conn.client.emit('registered', { nick: 'nick' }); // server let us in anyway
+    emitRegistered(conn); // server let us in anyway
     conn.client.emit('close', false); // a later, unrelated drop
     vi.runAllTimers();
     expect(conn.connect).toHaveBeenCalledTimes(1);
@@ -1709,14 +1735,7 @@ describe('auto-reconnect controller', () => {
     expect(attemptOf()).toBe(1);
     vi.runAllTimers();
     // A full registration proves the network is reachable again → ladder resets.
-    // (connect() is stubbed here, so the library's own 'registered' listener has
-    // no live connection.options; pin harmless ping settings so its
-    // startPeriodicPing early-returns instead of dereferencing null.)
-    (conn.client as unknown as { options: unknown }).options = {
-      ping_interval: 0,
-      ping_timeout: 0,
-    };
-    conn.client.emit('registered', { nick: 'nick' });
+    emitRegistered(conn);
     // Next drop starts back at attempt 1, not 2.
     conn.client.emit('close', false);
     expect(attemptOf()).toBe(1);

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -250,6 +250,15 @@ function classifyServerBan(reason: string | undefined): string | null {
   return null;
 }
 
+// How recently a ban-shaped ERROR must have arrived for a 'close' to be
+// blamed on it (#651). A real "Closing Link (G-Lined)" ERROR is the server
+// narrating the disconnect it is about to perform, so the close follows
+// within moments; a ban-shaped line that did NOT close the socket is noise
+// (or channel-adjacent text the classifier over-matched), and a much later
+// unrelated drop must not inherit it. Generous on purpose — the failure mode
+// this guards against is HOURS of staleness, not seconds.
+const SERVER_BAN_CLOSE_WINDOW_MS = 10_000;
+
 // SASL failure reasons that mean the credentials themselves are wrong or the
 // account is locked — a retry with the same stored password is pointless. Other
 // SASL reasons (unsupported_mechanism, capability_missing) are server/config
@@ -613,6 +622,11 @@ export class IrcConnection {
   //   string is the human-readable cause shown in the "not reconnecting" notice.
   // pendingSaslFailure: a SASL rejection that has NOT yet been proven fatal (#617).
   //   See the 'sasl failed' handler for why it can't be terminal on sight.
+  // pendingServerBan: a ban-classified ERROR that has NOT yet been proven fatal
+  //   (#651) — promoted to terminal only by a 'close' arriving within
+  //   SERVER_BAN_CLOSE_WINDOW_MS of it. Unlike SASL there's no retry streak: the
+  //   server's own message is proof enough once it's shown to have closed the
+  //   link; the window only settles WHICH close it belongs to.
   // reconnectGate: the manager's policy check, consulted before each retry opens a
   //   socket (#616). Absent = no gate (tests, and any caller that builds a
   //   connection directly).
@@ -621,6 +635,7 @@ export class IrcConnection {
   private intentionalDisconnect: boolean;
   private terminalDisconnect: string | null;
   private pendingSaslFailure: string | null;
+  private pendingServerBan: { reason: string; at: number } | null;
   // Consecutive SASL rejections with no successful registration between them.
   // Deliberately NOT reset by connect(): it has to survive the retry ladder, or
   // it could never run out. Only 'registered' clears it.
@@ -724,6 +739,7 @@ export class IrcConnection {
     this.intentionalDisconnect = false;
     this.terminalDisconnect = null;
     this.pendingSaslFailure = null;
+    this.pendingServerBan = null;
     this.saslFailureStreak = 0;
     this.bind();
   }
@@ -1078,6 +1094,7 @@ export class IrcConnection {
       // auto-reconnect rather than inherit a stale give-up flag.
       this.terminalDisconnect = null;
       this.pendingSaslFailure = null;
+      this.pendingServerBan = null;
       // Registering is the proof the credentials aren't fatal here (the network's
       // SASL is optional, or they started working) — so the streak starts over.
       this.saslFailureStreak = 0;
@@ -1232,8 +1249,10 @@ export class IrcConnection {
       this.markAllPeersOffline();
       this.setState('disconnected');
       // Decide, now that we know WHEN the socket died, whether a SASL rejection
-      // earlier in this connection is what killed it (#617).
+      // (#617) or a ban-classified ERROR (#651) earlier in this connection is
+      // what killed it.
       this.maybePromoteSaslFailure();
+      this.maybePromoteServerBan();
       // 'close' is now the single terminal socket-death event (irc-framework's
       // auto_reconnect is disabled, so it no longer retries internally): decide
       // here whether to schedule our own backoff retry. Runs after the state/
@@ -2649,18 +2668,18 @@ export class IrcConnection {
       // us. Only server-scoped bans qualify: a channel-scoped ban (474) carries a
       // channel param and is routed inline below, so gate on its absence.
       //
-      // ⚠ Unlike the SASL flag (which is pending until 'close' proves it fatal,
-      // #617), this one is terminal the moment it's set and is cleared ONLY by
-      // 'registered' or a fresh connect(). So a ban-shaped error on a live,
-      // already-registered connection lingers, and the next unrelated transient
-      // drop inherits it and stops auto-reconnect for good — the same staleness
-      // #617 fixed for SASL. In practice a "Closing Link" ERROR does close the
-      // link, so the window is narrow; giving this the same pending/promote
-      // treatment is tracked separately rather than widened into #616/#617.
+      // PENDING, not terminal on sight — the same treatment SASL got in #617
+      // (#651). A real ban ERROR is the server narrating the close it is about
+      // to perform, so 'close' promotes this within moments; a ban-shaped line
+      // on a live connection that does NOT close it must not lie in wait to be
+      // blamed for an unrelated transient drop hours later. See
+      // maybePromoteServerBan for the freshness window.
       const banChannel = event?.channel as string | undefined;
       if (!banChannel) {
         const banned = classifyServerBan(reason);
-        if (banned) this.terminalDisconnect = `banned by the server (${banned})`;
+        if (banned) {
+          this.pendingServerBan = { reason: `banned by the server (${banned})`, at: Date.now() };
+        }
       }
       const isDmMiss = tag === 'no_such_nick' && eventNick && isDmTargetName(eventNick);
       // For ERR_NOSUCHNICK against a nick the user has any DM history with,
@@ -3500,6 +3519,7 @@ export class IrcConnection {
     this.intentionalDisconnect = false;
     this.terminalDisconnect = null;
     this.pendingSaslFailure = null;
+    this.pendingServerBan = null;
     const { sasl_password, sasl_account, nick } = this.network;
     const account = sasl_password
       ? { account: sasl_account || nick, password: sasl_password }
@@ -5042,6 +5062,24 @@ export class IrcConnection {
     this.pendingSaslFailure = null;
     if (this.saslFailureStreak >= MAX_CONSECUTIVE_SASL_FAILURES) {
       this.terminalDisconnect = pending;
+    }
+  }
+
+  /**
+   * Promote a ban-classified ERROR to terminal only if THIS close is the one
+   * it announced (#651). No retry streak, unlike SASL: the server's own
+   * message is proof once it's shown to have closed the link — the freshness
+   * window only settles which close it belongs to. A ban-shaped error on a
+   * connection that survived it is consumed here either way, so it can never
+   * be blamed for a later unrelated drop (the staleness #617 removed from the
+   * SASL half).
+   */
+  private maybePromoteServerBan(): void {
+    const pending = this.pendingServerBan;
+    if (!pending) return;
+    this.pendingServerBan = null;
+    if (Date.now() - pending.at <= SERVER_BAN_CLOSE_WINDOW_MS) {
+      this.terminalDisconnect = pending.reason;
     }
   }
 

--- a/server/services/ircConnection.ts
+++ b/server/services/ircConnection.ts
@@ -250,15 +250,6 @@ function classifyServerBan(reason: string | undefined): string | null {
   return null;
 }
 
-// How recently a ban-shaped ERROR must have arrived for a 'close' to be
-// blamed on it (#651). A real "Closing Link (G-Lined)" ERROR is the server
-// narrating the disconnect it is about to perform, so the close follows
-// within moments; a ban-shaped line that did NOT close the socket is noise
-// (or channel-adjacent text the classifier over-matched), and a much later
-// unrelated drop must not inherit it. Generous on purpose — the failure mode
-// this guards against is HOURS of staleness, not seconds.
-const SERVER_BAN_CLOSE_WINDOW_MS = 10_000;
-
 // SASL failure reasons that mean the credentials themselves are wrong or the
 // account is locked — a retry with the same stored password is pointless. Other
 // SASL reasons (unsupported_mechanism, capability_missing) are server/config
@@ -623,10 +614,7 @@ export class IrcConnection {
   // pendingSaslFailure: a SASL rejection that has NOT yet been proven fatal (#617).
   //   See the 'sasl failed' handler for why it can't be terminal on sight.
   // pendingServerBan: a ban-classified ERROR that has NOT yet been proven fatal
-  //   (#651) — promoted to terminal only by a 'close' arriving within
-  //   SERVER_BAN_CLOSE_WINDOW_MS of it. Unlike SASL there's no retry streak: the
-  //   server's own message is proof enough once it's shown to have closed the
-  //   link; the window only settles WHICH close it belongs to.
+  //   (#651) — see maybePromoteServerBan for the promote/discard rule.
   // reconnectGate: the manager's policy check, consulted before each retry opens a
   //   socket (#616). Absent = no gate (tests, and any caller that builds a
   //   connection directly).
@@ -635,7 +623,7 @@ export class IrcConnection {
   private intentionalDisconnect: boolean;
   private terminalDisconnect: string | null;
   private pendingSaslFailure: string | null;
-  private pendingServerBan: { reason: string; at: number } | null;
+  private pendingServerBan: string | null;
   // Consecutive SASL rejections with no successful registration between them.
   // Deliberately NOT reset by connect(): it has to survive the retry ladder, or
   // it could never run out. Only 'registered' clears it.
@@ -949,6 +937,14 @@ export class IrcConnection {
     // they never replace the raw line here.
     c.on('raw', (event: { from_server: boolean; line: string }) => {
       if (!event?.from_server || typeof event.line !== 'string') return;
+      // A ban-classified ERROR is only believed if it's the link's LAST line
+      // (#651). Every server line passes through here, and for the ban line
+      // itself raw fires BEFORE the parsed 'irc error' sets the flag
+      // (connection.js emits raw, then message) — so a set flag seen here
+      // means a LATER line arrived, the link survived, and the "ban" was
+      // noise. Ordering-based, so it needs no freshness window and is immune
+      // to event-loop stalls and wall-clock steps.
+      if (this.pendingServerBan != null) this.pendingServerBan = null;
       let msg;
       try {
         msg = ircLineParser(event.line);
@@ -2669,17 +2665,16 @@ export class IrcConnection {
       // channel param and is routed inline below, so gate on its absence.
       //
       // PENDING, not terminal on sight — the same treatment SASL got in #617
-      // (#651). A real ban ERROR is the server narrating the close it is about
-      // to perform, so 'close' promotes this within moments; a ban-shaped line
-      // on a live connection that does NOT close it must not lie in wait to be
-      // blamed for an unrelated transient drop hours later. See
-      // maybePromoteServerBan for the freshness window.
+      // (#651). A real ban ERROR is the last thing the server says before it
+      // closes the link, so 'close' promotes this; any LATER server line
+      // discards it first (the 'raw' handler), because a line after the ERROR
+      // proves the link survived whatever the classifier matched — that
+      // ban-shaped noise must not lie in wait to be blamed for an unrelated
+      // transient drop later. See maybePromoteServerBan.
       const banChannel = event?.channel as string | undefined;
       if (!banChannel) {
         const banned = classifyServerBan(reason);
-        if (banned) {
-          this.pendingServerBan = { reason: `banned by the server (${banned})`, at: Date.now() };
-        }
+        if (banned) this.pendingServerBan = `banned by the server (${banned})`;
       }
       const isDmMiss = tag === 'no_such_nick' && eventNick && isDmTargetName(eventNick);
       // For ERR_NOSUCHNICK against a nick the user has any DM history with,
@@ -5066,21 +5061,22 @@ export class IrcConnection {
   }
 
   /**
-   * Promote a ban-classified ERROR to terminal only if THIS close is the one
-   * it announced (#651). No retry streak, unlike SASL: the server's own
-   * message is proof once it's shown to have closed the link — the freshness
-   * window only settles which close it belongs to. A ban-shaped error on a
-   * connection that survived it is consumed here either way, so it can never
-   * be blamed for a later unrelated drop (the staleness #617 removed from the
-   * SASL half).
+   * Promote a ban-classified ERROR to terminal at the close that follows it
+   * (#651). No retry streak, unlike SASL: the server's own message is proof —
+   * IF it was the link's last line. Any later server line already discarded
+   * the flag (see the 'raw' handler), so reaching close with it still set
+   * means nothing followed the ERROR: exactly a ban. That ordering signal
+   * needs no freshness window, so a blackholed ban (the FIN never arrives and
+   * the socket only dies via the ping timeout minutes later, with no lines in
+   * between) still promotes — where a wall-clock window would have demoted it
+   * to a transient and retried forever against a server that banned us —
+   * while a ban-shaped error on a chattering connection can never be blamed
+   * for a drop hours later.
    */
   private maybePromoteServerBan(): void {
-    const pending = this.pendingServerBan;
-    if (!pending) return;
+    if (this.pendingServerBan == null) return;
+    this.terminalDisconnect = this.pendingServerBan;
     this.pendingServerBan = null;
-    if (Date.now() - pending.at <= SERVER_BAN_CLOSE_WINDOW_MS) {
-      this.terminalDisconnect = pending.reason;
-    }
   }
 
   /**


### PR DESCRIPTION
`terminalDisconnect` was set the moment a ban-shaped `irc error` arrived — even on a live, registered connection — and nothing cleared it except registration or a fresh connect. The next unrelated transient drop (netsplit, ping timeout, laptop lid) inherited it and disabled auto-reconnect permanently, telling the user they're banned when they aren't (#651). This is the same staleness #617 removed from the SASL half.

The ban flag now gets the pending/promote treatment, with an **ordering signal** instead of a freshness window (the `/code-review` pass showed a wall-clock window silently demotes a blackholed IP ban whose socket only dies via the 120s ping timeout): a real ban ERROR is the link's *last* line, so any later `from_server` raw line discards the pending flag — `connection.js` emits `raw` before the parsed event for the same line, so the ban's own line can't self-discard — and a close arriving with the flag still set, whenever it arrives, is the ban's close. No tunable, immune to event-loop stalls and clock steps. Registration still clears it outright.

Tests pin all three directions: ban→immediate close stops; ban→traffic→much-later drop retries; ban→silence→ping-timeout-scale close still stops. The four copies of the `registered` options incantation collapsed into an `emitRegistered` helper.

Reviewed via `/code-review high`; all findings addressed. Full check + suite green.

Closes #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)