### PR TITLE
Bump Lurker version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@noble/ciphers": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lurker",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Self-hosted IRC client with persistent server-side connection and a Vue web UI",
   "main": "server/server.ts",
   "type": "module",

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lurker-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lurker-client",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lurker-client",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "license": "MPL-2.0",
   "scripts": {


### PR DESCRIPTION
Version bump for the 2.1.0 release. Draft release notes (reusable for the GitHub release):

---

## Lurker 2.1.0

### Themes
- **Theme presets**: the appearance settings are now snapshottable, saveable themes, synced across devices. Two built-ins ship — **Monokai Plus** (the existing dark look) and **Monokai Plus Light**, built from the official Monokai Pro Light filter palette (#750)
- **Follow your system**: optionally map a light-mode theme and a dark-mode theme and let each device follow its OS setting (#395)
- Everything is also a command: `/theme apply` / `save` / `delete` / `mode` / `use light|dark`
- Foundation for the visual theme editor coming in a future release

### Buffers & navigation
- **Buffer URLs**: the address bar names the buffer you're looking at — links are shareable, refresh keeps your place, and mobile screens are real routes with real back-button behavior (#749)

### Composer
- **IME fix for Android keyboards** (and desktop CJK): suggesters, the Send button, and drafts now track your typing letter-by-letter during composition instead of freezing a word at a time — most noticeable on Firefox for Android (#624). Cross-device draft sync now also defers while you're mid-word, so another device can't repaint the composer under an in-flight composition

### Fixes
- Auto-reconnect: a ban-shaped server error on a surviving connection no longer disables reconnect for a later unrelated drop — and a blackholed IP ban is still recognized as one (#651)
- A self-hosted server now survives its launch terminal going away (dropped SSH session + `disown`) instead of crashing on the next log line; fatal errors are recorded to the in-app system log before exit (#442)
- "Commands to run on connect" now explains it wants raw IRC lines, with a worked example (#540)
- Settings-pane spacing rule deduplicated into the shared styles (#538)
- Removed the Express-4-era async handler wrapper (#146)
- Client protocol docs updated: settings `resets`, `themes-changed`, `GET /api/settings/bootstrap` themes, `/api/themes` (docs/CLIENT_PROTOCOL.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)