### PR TITLE
Make every mIRC slot a literal colour

### DIFF
--- a/shared/settingsRegistry.ts
+++ b/shared/settingsRegistry.ts
@@ -346,40 +346,53 @@ export const REGISTRY: readonly SettingOption[] = Object.freeze([
     type: 'string-list',
     // 16 entries, one per mIRC color code 0..15. The chromatic slots default
     // to the closest hue from look.nick.colors so coloured chat text harmonises
-    // with the rest of the theme; the mono-ish slots track the theme so they
-    // stay legible when the user changes look.color.bg / look.color.fg.
+    // with the rest of the theme.
     //
-    // ⚠ A slot must never resolve to the SURFACE it's drawn on. Slot 1 was
-    // var(--bg) — the background by definition — so black text rendered in
-    // exactly the colour behind it and disappeared. Anything derived from
-    // var(--fg) is safe; var(--bg) never is. Keep in sync with
+    // ⚠ EVERY slot is a literal colour, and must stay one. A mIRC code names a
+    // colour — `\x0300` means white, not "whatever this theme calls text" — and
+    // a sender who writes `\x0300,01` has specified both halves of a
+    // self-sufficient pair that we have no business overriding.
+    //
+    // Slots 0/14/15 were theme references (var(--fg), var(--fg-muted), 70% of
+    // var(--fg)) on the theory that they'd stay legible on any background. They
+    // don't: a run carries its OWN background, which is a second surface the
+    // theory never considered. In a light theme `\x0300,01` drew near-black on
+    // black, and `\x0301,00` — where slot 0 is the *background* — drew a dark
+    // box with black text in it. Both unreadable, both entirely the palette's
+    // doing. A slot that can't be named without knowing what it's painted on
+    // isn't a colour.
+    //
+    // The cost is accepted and is the sender's: white on a light canvas is
+    // invisible, exactly as black on a dark one already was. Keep in sync with
     // MIRC_PALETTE_FALLBACK in vue_client/src/utils/nickColor.ts.
     default: [
-      'var(--fg)', //                                       0  white
-      '#000000', //                                         1  black — NOT var(--bg)
-      '#6799f3', //                                         2  navy
-      '#a9dc76', //                                         3  green
-      '#ff6188', //                                         4  red
-      '#ed6c89', //                                         5  maroon
-      '#ab9df2', //                                         6  purple
-      '#fc9867', //                                         7  orange
-      '#ffd866', //                                         8  yellow
-      '#b3db82', //                                         9  lime
-      '#78dce8', //                                         10 teal
-      '#a0f1ff', //                                         11 cyan
-      '#7ba4ff', //                                         12 blue
-      '#ff7494', //                                         13 magenta
-      'var(--fg-muted)', //                                 14 gray
-      'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
+      '#ffffff', // 0  white
+      '#000000', // 1  black
+      '#6799f3', // 2  navy
+      '#a9dc76', // 3  green
+      '#ff6188', // 4  red
+      '#ed6c89', // 5  maroon
+      '#ab9df2', // 6  purple
+      '#fc9867', // 7  orange
+      '#ffd866', // 8  yellow
+      '#b3db82', // 9  lime
+      '#78dce8', // 10 teal
+      '#a0f1ff', // 11 cyan
+      '#7ba4ff', // 12 blue
+      '#ff7494', // 13 magenta
+      '#7f7f7f', // 14 gray       — mIRC's own grey
+      '#d2d2d2', // 15 light gray — mIRC's own light grey
     ],
     description:
       'How the 16 mIRC color codes (0-15) render in chat. One CSS color per line, ' +
       'in order: white, black, navy, green, red, maroon, purple, orange, yellow, ' +
       'lime, teal, cyan, blue, magenta, gray, light gray. Defaults pick the ' +
       'closest hue from your nick palette so coloured text matches the rest of ' +
-      'the theme. Any CSS color value works (hex, rgb(), var(--name), color-mix()) — ' +
-      'except var(--bg), which is the chat background itself, so text set to it is ' +
-      'invisible.',
+      'the theme. Any CSS color value works (hex, rgb(), var(--name), color-mix()), ' +
+      'but prefer a literal: a code names a colour, and a slot that follows the ' +
+      'theme instead is wrong the moment a sender pairs it with a background of ' +
+      'their own. var(--bg) is the worst case — it IS the chat background, so text ' +
+      'set to it is invisible.',
   },
 
   // ─── Alternating message rows ─────────────────────────────────────────

--- a/shared/themePresets.ts
+++ b/shared/themePresets.ts
@@ -9,8 +9,13 @@
 // THEMED_KEYS). Built-ins are code, not rows: Dark IS the registry defaults
 // (computed on demand so a default change never needs a data migration), and
 // Light overrides only the literal colors — keys whose default is a var()
-// reference (link, self nick, buffer unread/highlight, alt row bg, the mono
-// mIRC slots) keep the reference so they track whichever palette is active.
+// reference (link, self nick, buffer unread/highlight, alt row bg) keep the
+// reference so they track whichever palette is active.
+//
+// The mIRC palette is NOT among them: all sixteen slots are literals in both
+// presets. A colour code names a colour, and a slot that defers to the theme
+// breaks the moment a sender pairs it with a background of their own. See the
+// ⚠ on look.color.mirc_colors.
 
 import type { SettingValue } from './settingsRegistry.js';
 import { themedDefaults } from './settingsRegistry.js';
@@ -134,25 +139,32 @@ const LIGHT_OVERRIDES: Record<string, SettingValue> = {
   ],
   // Chromatic slots track the nick palette like the dark defaults do: slots
   // whose dark value is a Pro accent take the official light accent, the rest
-  // keep OKLCH. Mono slots keep their var() derivations. Slot 1 stays literal
-  // black — correct on a light canvas, and still never var(--bg).
+  // keep OKLCH.
+  //
+  // Slots 0/1/14/15 are the SAME literals as the dark preset, deliberately. A
+  // mIRC code names a colour, and white/black/grey are the four the sender is
+  // most likely to have paired with a background of their own — see the ⚠ on
+  // the registry default. Re-tinting those per theme is what broke `\x0300,01`
+  // and `\x0301,00` here. On this canvas white and light grey are the ones that
+  // disappear when used bare; that is the sender's call to have made, and the
+  // same deal the dark preset gives black.
   'look.color.mirc_colors': [
-    'var(--fg)', //                                       0  white
-    '#000000', //                                         1  black — NOT var(--bg)
-    '#3163c0', //                                         2  navy
-    '#269d69', //                                         3  green (official)
-    '#e14775', //                                         4  red (official)
-    '#b52d55', //                                         5  maroon
-    '#7058be', //                                         6  purple (official)
-    '#e16032', //                                         7  orange (official)
-    '#cc7a0a', //                                         8  yellow (official)
-    '#688f2d', //                                         9  lime
-    '#1c8ca8', //                                         10 teal (official)
-    '#409ba9', //                                         11 cyan
-    '#4268c5', //                                         12 blue
-    '#c12d5b', //                                         13 magenta
-    'var(--fg-muted)', //                                 14 gray
-    'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
+    '#ffffff', // 0  white
+    '#000000', // 1  black
+    '#3163c0', // 2  navy
+    '#269d69', // 3  green (official)
+    '#e14775', // 4  red (official)
+    '#b52d55', // 5  maroon
+    '#7058be', // 6  purple (official)
+    '#e16032', // 7  orange (official)
+    '#cc7a0a', // 8  yellow (official)
+    '#688f2d', // 9  lime
+    '#1c8ca8', // 10 teal (official)
+    '#409ba9', // 11 cyan
+    '#4268c5', // 12 blue
+    '#c12d5b', // 13 magenta
+    '#7f7f7f', // 14 gray       — mIRC's own grey
+    '#d2d2d2', // 15 light gray — mIRC's own light grey
   ],
 };
 

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -100,6 +100,23 @@
      same direction. */
   --embed-bg: color-mix(in srgb, var(--fg) 6%, var(--bg-soft));
 
+  /* How far a coloured mIRC background bleeds above and below its own text.
+
+     An inline span paints its background over the font's content area, not the
+     full line box — so at line-height 1.55 roughly a third of every line goes
+     unpainted, and multi-line ASCII art built from \x03FG,BG runs comes out
+     striped instead of solid. This is half that shortfall, applied as VERTICAL
+     padding, which on a non-replaced inline element paints without affecting
+     line-box height. The grid survives; the stripes close.
+
+     ⚠ Deliberately a touch under half the leading. Overshooting makes each
+     line's background overlap the one above — and since a later line paints
+     after the earlier line's text, that clips the descenders above it
+     (commas, slashes: exactly what art is made of). A hairline seam is a far
+     cheaper failure than shaved glyphs, so err small. Tune here only; both the
+     spoiler box and ordinary coloured runs read this. */
+  --mirc-bg-bleed: 0.22em;
+
   /* Corner radii. The app is intentionally flat (most things are square);
      these are the few deliberate exceptions. */
   --radius-sm: 2px;

--- a/vue_client/src/assets/main.css
+++ b/vue_client/src/assets/main.css
@@ -109,13 +109,30 @@
      padding, which on a non-replaced inline element paints without affecting
      line-box height. The grid survives; the stripes close.
 
-     ⚠ Deliberately a touch under half the leading. Overshooting makes each
-     line's background overlap the one above — and since a later line paints
-     after the earlier line's text, that clips the descenders above it
-     (commas, slashes: exactly what art is made of). A hairline seam is a far
-     cheaper failure than shaved glyphs, so err small. Tune here only; both the
-     spoiler box and ordinary coloured runs read this. */
-  --mirc-bg-bleed: 0.22em;
+     ⚠ The budget is EXACTLY half the leading — (1.55em - content area) / 2 —
+     and there is nothing else to spend. `.line` rows sit flush: row-gap is 0
+     and they carry no vertical padding, so a box taller than its line box
+     immediately laps the message above and below. That looks far worse than a
+     seam, because it crosses between messages, and a later row paints after the
+     earlier row's text, so the overlap also clips descenders (commas, slashes:
+     what art is made of).
+
+     The content area is font-derived (~1.15-1.25em for the mono stack) and CSS
+     can't express it, so this is a conservative constant rather than a formula:
+     small enough not to lap on any font in the stack, at the cost of a hairline
+     seam on fonts with a shorter content area. To find the exact maximum for
+     the font actually in use, measure it — the bounding rect of an inline span
+     IS the content area:
+
+       const l = document.querySelector('.line'), s = document.createElement('span');
+       s.textContent = 'X'; l.appendChild(s);
+       const cs = getComputedStyle(l);
+       console.log(((parseFloat(cs.lineHeight) - s.getBoundingClientRect().height)
+         / 2 / parseFloat(cs.fontSize)).toFixed(3) + 'em');
+       s.remove();
+
+     Tune here only; both the spoiler box and ordinary coloured runs read it. */
+  --mirc-bg-bleed: 0.15em;
 
   /* Corner radii. The app is intentionally flat (most things are square);
      these are the few deliberate exceptions. */

--- a/vue_client/src/components/MessageInput.completion.test.ts
+++ b/vue_client/src/components/MessageInput.completion.test.ts
@@ -661,7 +661,7 @@ describe('MessageInput command dispatch', () => {
   // click-to-reveal box when typed and literal pipes when sent through a command. Silent and
   // non-recoverable — the spoiler is on the wire before the user can see it didn't work.
   describe('||spoiler|| markup in commands (#652)', () => {
-    const OPEN = '\x0301,01';
+    const OPEN = '\x0314,14';
     const CLOSE = '\x03';
 
     it('/me rewrites the spoiler in the ACTION body', async () => {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -536,7 +536,7 @@ function bodyForSplit(raw: string): { body: string; isAction: boolean } {
   if (!m) return { body: '', isAction: false };
   const cmd = m[1].toLowerCase();
   // ⚠ Every branch below counts the POST-rewrite bytes, for the same reason the plain path above
-  // does: the spoiler rewrite ADDS bytes (`\x0301,01` … `\x03`), so a message that fits before it
+  // does: the spoiler rewrite ADDS bytes (`\x0314,14` … `\x03`), so a message that fits before it
   // may not after, and counting the typed form drifts the estimate LOW.
   //
   // ⚠ …and each branch reproduces its command's own whitespace handling, because `computeChunks`

--- a/vue_client/src/components/SpoilerText.test.ts
+++ b/vue_client/src/components/SpoilerText.test.ts
@@ -3,15 +3,20 @@
 
 // @vitest-environment happy-dom
 
-// The spoiler box's colour. `01,01` is the pair Lurker's own applySpoilerMarkup
-// emits, so this covers every spoiler sent from Lurker.
+// The spoiler box's colour, and the invariant underneath it: the BOX honours
+// whatever the sender named, and the REVEAL is always readable.
 //
-// Originally not merely cosmetic: slot 1 resolved to `var(--bg)`, so honouring
-// it as a "chosen colour" painted the box the exact colour of the page AND set
-// the revealed text to var(--bg) — clicking a spoiler showed nothing. The
-// palette has since been fixed too (slot 1 is a literal #000000), so these guard
-// the remaining half: 01,01 means "hidden", not "black", and must not be
-// preserved as a styling intent.
+// The two are split for a reason. An fg==bg run is not reliably a spoiler —
+// ASCII art fills a solid block the same way — so the box cannot second-guess
+// the colour without recolouring somebody's picture. But the revealed text can
+// never be allowed to take that colour, because the two commonest values are
+// black and white, and each is unreadable against a faint tint of itself on the
+// scheme that matches it. A reveal that reveals nothing is the one failure this
+// component cannot have.
+//
+// This replaces an earlier rule that special-cased slot 1 (the pair Lurker's own
+// applySpoilerMarkup emits) as "means hidden, not black". That fixed the reveal
+// by way of the box, which is the wrong lever — it also repainted art.
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
@@ -29,33 +34,39 @@ function mountSpoiler(seg: RenderSegment) {
 describe('SpoilerText box colour', () => {
   beforeEach(() => setActivePinia(createPinia()));
 
-  // The reported bug. The neutral box comes from the .spoiler class rule
-  // (var(--fg-muted)), so "correct" means NO inline background override at all.
-  it('does not paint the box with the 01,01 convention colour', () => {
+  // ASCII art fills solid blocks with fg==bg runs, so a `01,01` box has to come
+  // out actually black. Substituting the neutral gray here recoloured the art.
+  it('paints the 01,01 box black rather than substituting the neutral gray', () => {
     const { root } = mountSpoiler({ text: 'secret', spoiler: true, fg: 1 });
-    expect(root.attributes('style') || '').not.toMatch(/background/);
+    expect(root.attributes('style') || '').toMatch(/background:\s*#000000/);
+  });
+
+  // The mirror case, and a live regression once slot 0 stopped being var(--fg):
+  // white is a colour like any other and the box must be white, even though a
+  // white box on the light canvas is 1.1:1 and barely reads as a box.
+  it('paints the 00,00 box white', () => {
+    const { root } = mountSpoiler({ text: 'secret', spoiler: true, fg: 0 });
+    expect(root.attributes('style') || '').toMatch(/background:\s*#ffffff/);
   });
 
   // `await` is load-bearing: trigger() resolves on nextTick, and without it the
   // style assertion below would pass against the UNrevealed markup — i.e. pass
   // even with the bug present.
   //
-  // Asserts NO inline colour rather than "not var(--bg)". Matching on the old
-  // value made this test dead the moment the palette stopped containing it: the
-  // guard could be removed and this would still pass, because slot 1 now paints
-  // #000000. What the guard actually does is decline to set a colour at all, so
-  // that is what's checked.
-  it('leaves revealed text its normal colour for a convention spoiler', async () => {
-    const { root, body } = mountSpoiler({ text: 'secret', spoiler: true, fg: 1 });
+  // Asserts NO inline colour rather than "not black". Matching on a specific
+  // value is how the previous version of this test went dead: it pinned
+  // var(--bg), the palette stopped containing it, and the assertion could no
+  // longer fail. What the component does is decline to set a colour at all, so
+  // that is what's checked — every colour, not a chosen few.
+  it.each([
+    ['black', 1],
+    ['white', 0],
+    ['red', 4],
+  ])('leaves revealed text its normal colour (%s spoiler)', async (_name, fg) => {
+    const { root, body } = mountSpoiler({ text: 'secret', spoiler: true, fg });
     await root.trigger('click');
     expect(root.classes()).toContain('revealed');
     expect(body.attributes('style') || '').not.toMatch(/(^|[^-])color:/);
-  });
-
-  it('paints revealed text in a deliberately chosen colour', async () => {
-    const { root, body } = mountSpoiler({ text: 'hidden', spoiler: true, fg: 4 });
-    await root.trigger('click');
-    expect(body.attributes('style') || '').toMatch(/color/);
   });
 
   // The feature this bug came in with is still worth having — a chatter who

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -123,13 +123,14 @@ const bodyStyle = computed<CSSProperties>(() => {
 
 <style scoped>
 .spoiler {
-  border-radius: var(--radius-sm);
-  /* ⚠ NO horizontal padding, and don't add any back. An fg==bg run is not
-     always a spoiler — ASCII art uses the same encoding to fill a solid block
-     of colour — and any padding here widens that run past its own characters,
-     which shifts every glyph after it and shears the art off its grid. The box
-     has to measure exactly as many columns as it contains. Colour and radius
-     are free; anything that changes advance width is not. */
+  /* ⚠ NO padding and NO border-radius, and don't add either back. An fg==bg run
+     is not always a spoiler — ASCII art uses the same encoding to fill a solid
+     block of colour — so this box has to be able to BE a block. Padding widened
+     the run past its own characters and sheared everything after it off the
+     monospace grid; the radius notched its corners, which shows wherever two
+     filled runs meet and on any square area an artist drew. Colour is the only
+     decoration left, and that's the point: the run occupies exactly the cells
+     it contains, painted exactly as it was sent. */
   /* Wrapper-style overrides this for coloured spoilers; the var(--fg-muted)
      fallback covers older snapshots whose segments lack fg. */
   background: var(--fg-muted);

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -55,25 +55,26 @@ function reveal(e: Event): void {
   revealed.value = true;
 }
 
-// mIRC 01 is the canonical spoiler pair (`\x0301,01`) — it's what Lurker's own
-// applySpoilerMarkup emits, and what most clients/scripts use. It means "hide
-// this", not "paint this black", so it is NOT a colour intent to preserve: a
-// black box and black revealed text is nobody's styling choice, it's an artifact
-// of the invisibility convention.
+// Resolve the sender's chosen mIRC colour to a CSS value. Null only when there
+// is no colour at all to honour — an absent fg, i.e. an older snapshot from
+// before the field existed — and then we fall back to the neutral gray box.
 //
-// This guard was introduced when slot 1 resolved to var(--bg), which made the
-// box the exact colour of the page and the REVEALED text invisible too. The
-// palette no longer does that (slot 1 is a literal #000000), so removing this
-// would now produce a merely ugly black spoiler rather than an unreadable one —
-// still wrong, just less dramatically.
-const SPOILER_CONVENTION_COLOR = 1;
-
-// Resolve the sender's chosen mIRC colour to a CSS value. Null when there's no
-// colour to honour — an absent fg (older snapshots without the field) or the
-// convention colour above — and we fall back to the neutral gray box.
+// Slot 1 used to be excluded here, on the reasoning that `\x0301,01` is the
+// canonical spoiler convention and therefore means "hide this" rather than
+// "paint this black". True of a spoiler; false of ASCII art, which uses exactly
+// the same encoding to fill a solid black block. The wire bytes cannot tell the
+// two apart, and substituting gray guesses wrong on the art — visibly, since it
+// recolours part of a picture.
+//
+// So we honour whatever the sender named, and let the REVEAL carry the safety
+// (see bodyStyle). The cost is that a black box on the dark canvas is 1.3:1 and
+// a white one on the light canvas is 1.1:1 — a real spoiler in the matching
+// scheme is nearly invisible as an affordance. That's the trade: art renders
+// correctly, and a spoiler you can't see is still revealed by clicking where
+// the text would be.
 const color = computed(() => {
   const fg = props.seg.fg;
-  if (fg == null || fg === SPOILER_CONVENTION_COLOR) return null;
+  if (fg == null) return null;
   return mircColor(fg, mircPalette.value);
 });
 
@@ -95,11 +96,17 @@ const wrapperStyle = computed<CSSProperties>(() => {
 });
 
 // The spoiler run still carries any bold/italic/underline/strike toggles that
-// were active — apply them so the revealed text matches how it was sent. Once
-// revealed, the text takes the chosen colour against the faded backdrop.
+// were active — apply them so the revealed text matches how it was sent.
+//
+// ⚠ Revealed text sets NO colour, deliberately: it inherits the ordinary
+// message colour and is therefore always readable. It used to take the sender's
+// colour, which reads nicely for a red spoiler and is unreadable for the two
+// that matter most — black revealed on the dark canvas, white on the light one,
+// both against a faint tint of themselves. A reveal that reveals nothing is the
+// one failure this component cannot have, and it is not worth a tinted word.
+// The faded backdrop still marks the run as having been hidden.
 const bodyStyle = computed<CSSProperties>(() => {
   const s: CSSProperties = {};
-  if (revealed.value && color.value) s.color = color.value;
   if (props.seg.bold) s.fontWeight = 'bold';
   if (props.seg.italic) s.fontStyle = 'italic';
   const decos: string[] = [];
@@ -113,7 +120,12 @@ const bodyStyle = computed<CSSProperties>(() => {
 <style scoped>
 .spoiler {
   border-radius: var(--radius-sm);
-  padding: 0 var(--space-2);
+  /* ⚠ NO horizontal padding, and don't add any back. An fg==bg run is not
+     always a spoiler — ASCII art uses the same encoding to fill a solid block
+     of colour — and any padding here widens that run past its own characters,
+     which shifts every glyph after it and shears the art off its grid. The box
+     has to measure exactly as many columns as it contains. Colour and radius
+     are free; anything that changes advance width is not. */
   /* Wrapper-style overrides this for coloured spoilers; the var(--fg-muted)
      fallback covers older snapshots whose segments lack fg. */
   background: var(--fg-muted);

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -123,14 +123,19 @@ const bodyStyle = computed<CSSProperties>(() => {
 
 <style scoped>
 .spoiler {
-  /* ⚠ NO padding and NO border-radius, and don't add either back. An fg==bg run
-     is not always a spoiler — ASCII art uses the same encoding to fill a solid
-     block of colour — so this box has to be able to BE a block. Padding widened
-     the run past its own characters and sheared everything after it off the
-     monospace grid; the radius notched its corners, which shows wherever two
-     filled runs meet and on any square area an artist drew. Colour is the only
-     decoration left, and that's the point: the run occupies exactly the cells
-     it contains, painted exactly as it was sent. */
+  /* ⚠ NO HORIZONTAL padding and NO border-radius, and don't add either back. An
+     fg==bg run is not always a spoiler — ASCII art uses the same encoding to
+     fill a solid block of colour — so this box has to be able to BE a block.
+     Horizontal padding widened the run past its own characters and sheared
+     everything after it off the monospace grid; the radius notched its corners,
+     which shows wherever two filled runs meet and on any square area an artist
+     drew.
+
+     The VERTICAL padding below is the opposite case and is load-bearing: on a
+     non-replaced inline element it paints without affecting line-box height, so
+     it closes the gap between stacked rows and the grid is untouched. The two
+     axes genuinely behave differently here — see --mirc-bg-bleed. */
+  padding: var(--mirc-bg-bleed) 0;
   /* Wrapper-style overrides this for coloured spoilers; the var(--fg-muted)
      fallback covers older snapshots whose segments lack fg. */
   background: var(--fg-muted);

--- a/vue_client/src/components/SpoilerText.vue
+++ b/vue_client/src/components/SpoilerText.vue
@@ -67,11 +67,15 @@ function reveal(e: Event): void {
 // recolours part of a picture.
 //
 // So we honour whatever the sender named, and let the REVEAL carry the safety
-// (see bodyStyle). The cost is that a black box on the dark canvas is 1.3:1 and
-// a white one on the light canvas is 1.1:1 — a real spoiler in the matching
-// scheme is nearly invisible as an affordance. That's the trade: art renders
-// correctly, and a spoiler you can't see is still revealed by clicking where
-// the text would be.
+// (see bodyStyle).
+//
+// What makes that affordable is that the affordance is now the SENDER's problem
+// rather than the renderer's: applySpoilerMarkup emits grey on grey (14,14),
+// the one mono slot that reads as a box on both canvases (4.1:1 dark, 3.7:1
+// light), so every spoiler Lurker sends looks right without anyone here
+// second-guessing a colour. A spoiler that arrives as 01,01 from another client
+// is drawn honestly and is a poor affordance in dark mode — 1.3:1 — but it
+// still reveals on click, and that beats repainting somebody's ASCII art.
 const color = computed(() => {
   const fg = props.seg.fg;
   if (fg == null) return null;

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -192,7 +192,24 @@ describe('segmentInlineStyle / segmentHasStyle — background colour', () => {
     expect(segmentInlineStyle({ text: 'x', fg: 4, bg: 8 }, null)).toEqual({
       color: '#ff6188',
       backgroundColor: '#ffd866',
+      padding: 'var(--mirc-bg-bleed) 0',
     });
+  });
+
+  // The bleed rides with the background and nothing else. Stacked coloured rows
+  // need it to form a solid field rather than a striped one; a run with only a
+  // foreground has no fill to extend, and padding there would widen the hit
+  // area for no paint.
+  //
+  // ⚠ The vertical-only shorthand is the whole trick. A horizontal value would
+  // push the run past its own characters and shear ASCII art off the monospace
+  // grid — the exact bug removed from the spoiler box.
+  it('bleeds the background vertically, and only when there is one', () => {
+    expect(segmentInlineStyle({ text: 'x', fg: 4, bg: 8 }, null).padding).toBe(
+      'var(--mirc-bg-bleed) 0',
+    );
+    expect(segmentInlineStyle({ text: 'x', fg: 4 }, null).padding).toBeUndefined();
+    expect(segmentInlineStyle({ text: 'x' }, null).padding).toBeUndefined();
   });
 
   it('renders a background even when the foreground is the default (99)', () => {

--- a/vue_client/src/utils/nickColor.test.ts
+++ b/vue_client/src/utils/nickColor.test.ts
@@ -21,18 +21,23 @@ function parse(text: string) {
 }
 
 describe('MIRC_PALETTE_FALLBACK', () => {
-  // The bug that prompted this: slot 1 ("black") was var(--bg), which IS the
-  // surface the text is drawn on — so black text rendered in precisely the
-  // colour behind it and vanished.
+  // Every slot is a literal, and this is the test that keeps it that way.
   //
-  // The rule is narrow on purpose. Theme variables are RIGHT for the mono-ish
-  // slots: look.color.bg and look.color.fg are user-settable, so a slot pinned
-  // to a literal near-white would vanish the moment someone sets a light
-  // background — the same bug mirrored. What can never appear is the background
-  // itself, which is the one value guaranteed to match its own surface.
-  it('never paints a slot in the background colour', () => {
+  // It has been narrowed once already, to "no var(--bg)", on the theory that
+  // theme references were right for the mono-ish slots and only the background
+  // could ever match its own surface. That theory is wrong, and this is the
+  // second time round: a run carries its OWN background, so var(--fg) collides
+  // just as thoroughly the moment a sender writes `\x0300,01`. Worse, slot 0
+  // can BE the background (`\x0301,00`), and then a foreground reference paints
+  // the box.
+  //
+  // So: no var(), no color-mix(), nothing that has to be resolved against a
+  // surface to know what it is. A colour code names a colour. If the named
+  // colour is invisible on the reader's canvas, that is the sender's doing and
+  // it is allowed to look that way.
+  it('is entirely literal colours', () => {
     for (const [i, entry] of MIRC_PALETTE_FALLBACK.entries()) {
-      expect(entry, `slot ${i}`).not.toMatch(/var\(\s*--bg\b/);
+      expect(entry, `slot ${i}`).toMatch(/^#[0-9a-f]{6}$/);
     }
   });
 

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -447,6 +447,8 @@ export function parseIrcFormatting(text: string): IrcRun[] {
 export interface TextSegmentStyle {
   color?: string;
   backgroundColor?: string;
+  /** Vertical only — see `--mirc-bg-bleed`. Never a horizontal value. */
+  padding?: string;
   fontWeight?: string;
   fontStyle?: string;
   textDecoration?: string;
@@ -496,7 +498,14 @@ export function segmentInlineStyle(
   }
   if (seg.bg != null) {
     const bg = mircColor(seg.bg, mircPalette);
-    if (bg) style.backgroundColor = bg;
+    if (bg) {
+      style.backgroundColor = bg;
+      // Bleed the fill into the line's leading so stacked coloured rows form a
+      // solid field rather than a striped one — see --mirc-bg-bleed. Only when
+      // there IS a background: on a foreground-only run this would paint
+      // nothing and merely widen the hit area.
+      style.padding = 'var(--mirc-bg-bleed) 0';
+    }
   }
   if (seg.bold) style.fontWeight = 'bold';
   if (seg.italic) style.fontStyle = 'italic';

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -285,22 +285,22 @@ function colorNicksInText(
 // disappeared. var(--fg) and things derived from it are safe (they can never
 // equal the background); var(--bg) can never be anything else.
 export const MIRC_PALETTE_FALLBACK: readonly string[] = [
-  'var(--fg)', //                                       0  white
-  '#000000', //                                         1  black — NOT var(--bg)
-  '#6799f3', //                                         2  navy
-  '#a9dc76', //                                         3  green
-  '#ff6188', //                                         4  red
-  '#ed6c89', //                                         5  maroon
-  '#ab9df2', //                                         6  purple
-  '#fc9867', //                                         7  orange
-  '#ffd866', //                                         8  yellow
-  '#b3db82', //                                         9  lime
-  '#78dce8', //                                         10 teal
-  '#a0f1ff', //                                         11 cyan
-  '#7ba4ff', //                                         12 blue
-  '#ff7494', //                                         13 magenta
-  'var(--fg-muted)', //                                 14 gray
-  'color-mix(in srgb, var(--fg) 70%, transparent)', //  15 light gray
+  '#ffffff', // 0  white
+  '#000000', // 1  black
+  '#6799f3', // 2  navy
+  '#a9dc76', // 3  green
+  '#ff6188', // 4  red
+  '#ed6c89', // 5  maroon
+  '#ab9df2', // 6  purple
+  '#fc9867', // 7  orange
+  '#ffd866', // 8  yellow
+  '#b3db82', // 9  lime
+  '#78dce8', // 10 teal
+  '#a0f1ff', // 11 cyan
+  '#7ba4ff', // 12 blue
+  '#ff7494', // 13 magenta
+  '#7f7f7f', // 14 gray       — mIRC's own grey
+  '#d2d2d2', // 15 light gray — mIRC's own light grey
 ];
 
 // Look up a mIRC colour slot in a caller-supplied palette, falling back to

--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -271,19 +271,26 @@ function colorNicksInText(
 // Fallback for the 16 mIRC colour slots, used when no caller-supplied palette
 // covers a given index. The chromatic slots match nick.colors defaults so a
 // renderer without a settings store (tests, MOTD pre-paint) still produces
-// theme-friendly colours; the four mono-ish slots fall back to theme vars.
-// Indices 16-98 (extended) and the \x04 hex variant aren't widely used and
-// clash badly with custom themes, so we don't render those — we just consume
-// the escape so the digits don't leak into the output.
-// The mono-ish slots track the theme so they stay legible when the user changes
-// look.color.bg / look.color.fg — a slot pinned to a literal near-white would
-// vanish the moment someone sets a light background.
+// theme-friendly colours. Indices 16-98 (extended) and the \x04 hex variant
+// aren't widely used and clash badly with custom themes, so we don't render
+// those — we just consume the escape so the digits don't leak into the output.
 //
-// ⚠ With ONE exception, and it is the whole rule: a slot must never resolve to
-// the SURFACE it is drawn on. Slot 1 was var(--bg), which is the background by
-// definition — black text rendered in precisely the colour behind it and
-// disappeared. var(--fg) and things derived from it are safe (they can never
-// equal the background); var(--bg) can never be anything else.
+// ⚠ EVERY slot is a literal, and none may become a theme reference again.
+//
+// The rule used to be narrower — "never var(--bg), because that IS the surface;
+// var(--fg) and its derivatives are safe since they can never equal the
+// background" — and that reasoning only held for the CANVAS. A run carries its
+// own background, which is a second surface it never considered:
+//
+//   \x0300,01  white on black  →  var(--fg) on #000000, unreadable in a light
+//                                 theme
+//   \x0301,00  black on white  →  slot 0 is the BACKGROUND here, so a
+//                                 foreground reference painted the box
+//
+// A slot that can't be named without knowing what it's drawn on isn't a colour.
+// The cost is that white is invisible on a light canvas when used bare, exactly
+// as black already was on a dark one — the sender's call, and what every other
+// client does.
 export const MIRC_PALETTE_FALLBACK: readonly string[] = [
   '#ffffff', // 0  white
   '#000000', // 1  black

--- a/vue_client/src/utils/spoilerMarkup.test.ts
+++ b/vue_client/src/utils/spoilerMarkup.test.ts
@@ -3,9 +3,12 @@
 
 import { describe, it, expect } from 'vitest';
 import { applySpoilerMarkup } from './spoilerMarkup.js';
+import { splitTextByTokens } from './nickColor.js';
 
-// A spoiler on the wire is colour code 01 (black) on background 01.
-const OPEN = '\x0301,01';
+// A spoiler on the wire is any run whose foreground and background match. We
+// emit grey on grey (14,14) rather than black on black — see the note in
+// spoilerMarkup.ts for why the colour is the sender's problem now.
+const OPEN = '\x0314,14';
 const CLOSE = '\x03';
 
 describe('applySpoilerMarkup', () => {
@@ -55,5 +58,34 @@ describe('applySpoilerMarkup', () => {
   it('leaves a lone backslash literal', () => {
     expect(applySpoilerMarkup('a \\ b')).toBe('a \\ b');
     expect(applySpoilerMarkup('path\\to\\file')).toBe('path\\to\\file');
+  });
+});
+
+// Everything above pins the bytes we emit. This pins the thing that actually
+// matters: that our own renderer reads them back as a spoiler. The two halves
+// live in different files and were free to drift — a pair the parser didn't
+// recognise would ship as visible plaintext, which for a spoiler is the whole
+// failure.
+describe('applySpoilerMarkup → splitTextByTokens round trip', () => {
+  const parse = (text: string) => splitTextByTokens(text, null, null, null);
+
+  it('emits a run our own parser recognises as a spoiler', () => {
+    expect(parse(applySpoilerMarkup('||secret||'))).toEqual([
+      { text: 'secret', spoiler: true, fg: 14 },
+    ]);
+  });
+
+  // The delimiter is two digits and so is the colour code, so a spoiler opening
+  // on a digit is where a greedy parse would go wrong: `\x0314,14` + `42` must
+  // read as grey-on-grey plus the text "42", not as colour 14,1442.
+  it('does not swallow leading digits of the hidden text', () => {
+    expect(parse(applySpoilerMarkup('the answer is ||42||'))).toEqual([
+      { text: 'the answer is ' },
+      { text: '42', spoiler: true, fg: 14 },
+    ]);
+  });
+
+  it('still recognises an incoming 01,01 spoiler from another client', () => {
+    expect(parse('\x0301,01secret\x03')).toEqual([{ text: 'secret', spoiler: true, fg: 1 }]);
   });
 });

--- a/vue_client/src/utils/spoilerMarkup.ts
+++ b/vue_client/src/utils/spoilerMarkup.ts
@@ -3,17 +3,32 @@
 
 // Discord-style `||spoiler||` → IRC spoiler codes, applied to outgoing plain
 // messages. A spoiler on the wire is a run whose foreground and background
-// colour are identical (mIRC code 01 on 01: black on black) — invisible text
-// in any IRC client, which Lurker's renderer (splitTextByTokens in
-// nickColor.ts) upgrades into a click-to-reveal box. Closing with a bare \x03
-// resets the colour without disturbing any bold/italic still in effect.
+// colour are identical — invisible text in any IRC client, which Lurker's
+// renderer (splitTextByTokens in nickColor.ts) upgrades into a click-to-reveal
+// box. Closing with a bare \x03 resets the colour without disturbing any
+// bold/italic still in effect.
+//
+// ⚠ GREY on grey (14,14), not black on black. Any matching pair hides the text,
+// so this is purely about what the box looks like to a Lurker reader — and the
+// renderer paints the box in the colour it was sent, because an fg==bg run is
+// not reliably a spoiler (ASCII art fills solid blocks the same way, and
+// second-guessing it recolours the picture). That honesty is only affordable if
+// what WE emit is a colour that reads as a box on both canvases, and grey is
+// the only one that does:
+//
+//   slot 14 grey     4.05:1 on the dark canvas, 3.68:1 on the light
+//   slot 1  black    1.29:1 dark  — a black box on #212022 is barely there
+//   slot 0  white    1.09:1 light — likewise, mirrored
+//
+// Receiving is unchanged and unaffected: every fg==bg pair is still detected,
+// so spoilers from clients that send 01,01 keep working.
 //
 // `\||` is an escape: it emits a literal `||` and never acts as a delimiter,
 // so a message that genuinely needs a double-pipe (`exit code \|| 1`) can opt
 // out. There is no escape for the backslash itself — a lone `\` is always
 // literal, so `\||` is the only sequence treated specially.
 
-const SPOILER_OPEN = '\x0301,01';
+const SPOILER_OPEN = '\x0314,14';
 const SPOILER_CLOSE = '\x03';
 
 interface Token {


### PR DESCRIPTION
Slots 0, 14 and 15 were theme references — `var(--fg)`, `var(--fg-muted)`, and 70% of `var(--fg)`. The justification, written into 1a673ab, was that `var(--fg)` *"and things derived from it can never equal the background"*.

That is only true of the **canvas**. A run carries its **own** background, and that is a second surface the rule never considered. In the Light theme:

| code | means | rendered |
|---|---|---|
| `\x0300,01` | white on black | `#29242a` on `#000000` — **1.4:1** |
| `\x0315,01` | light grey on black | 70% of `#29242a` on `#000000` |
| `\x0301,00` | black on white | slot 0 is the **background** here, so the box came out dark and the black text vanished into it |

The last one is the tell. A foreground reference painting a background is the palette contradicting itself, and no amount of narrowing the rule fixes it: a slot that can't be named without knowing what it's drawn on isn't a colour.

## What changes

All sixteen slots are literals, with the same four mono values in **both** presets:

- **0** `#ffffff`
- **1** `#000000` (unchanged)
- **14** `#7f7f7f`, **15** `#d2d2d2` — mIRC's own greys rather than tinted foreground. A code names a colour, and mIRC has no notion of a light mode to have re-tinted them for.

The twelve chromatic slots are untouched and stay per-preset; those were already literal, and their light values are the Monokai Pro Light accents 2.1.0 shipped.

Three copies move together, as the existing test requires: the registry default, `LIGHT_OVERRIDES`, and `MIRC_PALETTE_FALLBACK`.

## The accepted cost

White and light grey are invisible on the light canvas when used **bare**. That's the deal black already had on the dark canvas, it's what every other client does, and it's the sender's call to have made. What we no longer do is break the case where the sender specified both halves themselves.

## Test

Goes back to banning the *shape* rather than the one value — no `var()`, no `color-mix()`, nothing needing a surface to resolve against. It had been narrowed to "no `var(--bg)`" on precisely the theory this PR removes.

3819 tests green, `npm run check` clean.

## Notes

- ⚠ A theme saved between 2.1.0 and this commit snapshotted the old references and keeps them. The setting takes any CSS colour so it stays valid, just wrong in the same way. Not migrated — the theme editor doesn't exist yet and the window was days long.
- Verified by rendering ten `fg,bg` pairs in both schemes (on the iOS client, which shares this palette): dark unchanged and correct throughout, light now correct where it was unreadable.
- The iOS port is amiantos/lurker-ios — merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)