### PR TITLE
Stop the spoiler close from eating the text after it

### DIFF
--- a/vue_client/src/utils/nickColor.ts
+++ b/vue_client/src/utils/nickColor.ts
@@ -624,7 +624,13 @@ export function splitTextByTokens(
     // inside the run would stay visible and leak the hidden content. Keep the
     // chosen colour on the segment so SpoilerText can paint the box in the
     // sender's colour rather than a generic gray.
-    if (run.fg != null && run.bg != null && run.fg === run.bg) {
+    // ⚠ `<= 15`, not just fg === bg. The palette has sixteen slots, so anything above resolves
+    // to null (see mircColor) and paints no box — `\x0399,99text\x03` satisfied fg === bg while
+    // drawing nothing, so text rendered in the clear became a neutral grey spoiler nobody could
+    // usefully reveal. 99 is mIRC's "default", a common way to write a run, and it is also what
+    // applySpoilerMarkup now emits to close a spoiler before a digit: without this check that
+    // close would turn the whole rest of the line into a spoiler box.
+    if (run.fg != null && run.bg != null && run.fg === run.bg && run.fg <= 15) {
       out.push({ text: run.text, spoiler: true, fg: run.fg, ...fmt });
       continue;
     }

--- a/vue_client/src/utils/previewUrls.test.ts
+++ b/vue_client/src/utils/previewUrls.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { previewableUrls, MAX_CARDS_PER_MESSAGE, MAX_MEDIA_PER_MESSAGE } from './previewUrls.js';
+import { applySpoilerMarkup } from './spoilerMarkup.js';
 
 const BOTH = { inlineMedia: true, linkPreviews: true };
 const NEITHER = { inlineMedia: false, linkPreviews: false };
@@ -109,6 +110,22 @@ describe('previewableUrls — what counts as a URL', () => {
     expect(previewableUrls(`ok https://e.test/fine.png ${hidden}`, BOTH)).toEqual([
       'https://e.test/fine.png',
     ]);
+  });
+
+  // The other side of the same test: a run whose matched pair is a slot the palette can't paint
+  // is NOT hidden, so its links are ordinary links.
+  //
+  // ⚠ This is load-bearing rather than academic. `applySpoilerMarkup` closes a spoiler with
+  // `\x0399,99` when a digit follows it, so the tail of those messages is a 99,99 run — and
+  // skipping it here would silently drop the preview for any URL after such a spoiler. A missing
+  // preview traced back to a colour code is not a debugging session anyone should have.
+  it('still resolves a link in an unrenderable matched pair, which is not a spoiler', () => {
+    expect(previewableUrls('\x0399,99https://e.test/fine.png', BOTH)).toEqual([
+      'https://e.test/fine.png',
+    ]);
+    expect(
+      previewableUrls(applySpoilerMarkup('||x||5 then https://e.test/fine.png'), BOTH),
+    ).toEqual(['https://e.test/fine.png']);
   });
 
   it('strips formatting codes out of the URL rather than resolving them', () => {

--- a/vue_client/src/utils/previewUrls.ts
+++ b/vue_client/src/utils/previewUrls.ts
@@ -69,8 +69,14 @@ export function previewableUrls(
 
   for (const run of parseIrcFormatting(text)) {
     // Same test the renderer uses for the IRC spoiler convention: a run whose foreground and
-    // background are the same colour is invisible text.
-    if (run.fg != null && run.bg != null && run.fg === run.bg) continue;
+    // background are the same *renderable* colour is invisible text.
+    //
+    // ⚠ The `<= 15` half has to match splitTextByTokens exactly. Slots above 15 paint nothing,
+    // so such a run isn't hidden and its links are ordinary links — and since applySpoilerMarkup
+    // now closes a spoiler with `\x0399,99` when a digit follows, the tail of those messages is
+    // a 99,99 run. Without this, a URL anywhere after such a spoiler would silently lose its
+    // preview, which is a hard failure to trace back to a colour code.
+    if (run.fg != null && run.bg != null && run.fg === run.bg && run.fg <= 15) continue;
 
     for (const match of run.text.matchAll(createUrlRegex())) {
       const raw = match[0];

--- a/vue_client/src/utils/spoilerMarkup.test.ts
+++ b/vue_client/src/utils/spoilerMarkup.test.ts
@@ -88,4 +88,44 @@ describe('applySpoilerMarkup → splitTextByTokens round trip', () => {
   it('still recognises an incoming 01,01 spoiler from another client', () => {
     expect(parse('\x0301,01secret\x03')).toEqual([{ text: 'secret', spoiler: true, fg: 1 }]);
   });
+
+  // ⚠⚠ The close is the dangerous end, and it ate typed text. A bare \x03 followed by a digit is
+  // a colour CODE, so the digit went with it: `||spoiler||5 stars` reached the channel as
+  // " stars" in colour 5 with the "5" deleted, and `the code is ||1234||5678` lost "56" and
+  // rendered the rest in colour 56.
+  //
+  // Asserted as a round trip rather than on the bytes: what matters is that every character
+  // typed after the spoiler survives, and that the spoiler's background doesn't bleed onto it.
+  it.each([
+    ['||spoiler||5 stars', 'spoiler', '5 stars'],
+    ['the code is ||1234||5678', '1234', '5678'],
+    ['||a||0', 'a', '0'],
+  ])('keeps the text after a spoiler when it starts with a digit (%s)', (input, hidden, after) => {
+    const segs = parse(applySpoilerMarkup(input));
+    const index = segs.findIndex((s) => s.spoiler);
+    expect(segs[index]?.text).toBe(hidden);
+
+    const tail = segs.slice(index + 1);
+    expect(tail.map((s) => s.text).join('')).toBe(after);
+    // …and it must not still be sitting on the spoiler's box, nor be a spoiler itself.
+    for (const seg of tail) {
+      expect(seg.bg).not.toBe(14);
+      expect(seg.spoiler).toBeFalsy();
+    }
+  });
+
+  it('keeps the cheap one-byte close when nothing collides', () => {
+    expect(applySpoilerMarkup('||a|| ok').endsWith('\x03 ok')).toBe(true);
+    expect(applySpoilerMarkup('||a||').endsWith('a\x03')).toBe(true);
+    // A comma is safe: only a digit can start a colour code.
+    expect(applySpoilerMarkup('||a||,b').endsWith('\x03,b')).toBe(true);
+  });
+
+  // The half that makes the close above safe. 99 is mIRC's "default" and paints nothing, so a
+  // 99,99 run is not hidden text — treating it as a spoiler turned readable text into a grey box
+  // nobody could usefully reveal, and would turn the tail of every digit-followed spoiler into
+  // one.
+  it('does not treat an unrenderable matched pair as a spoiler', () => {
+    expect(parse('\x0399,99tail text')).toEqual([{ text: 'tail text', fg: 99, bg: 99 }]);
+  });
 });

--- a/vue_client/src/utils/spoilerMarkup.ts
+++ b/vue_client/src/utils/spoilerMarkup.ts
@@ -31,6 +31,32 @@
 const SPOILER_OPEN = '\x0314,14';
 const SPOILER_CLOSE = '\x03';
 
+// ⚠⚠ The close needs help when a digit follows it. A bare \x03 is a colour RESET only when
+// nothing parseable comes next — \x03 then a digit is a colour CODE, and it eats up to two of
+// them. `||spoiler||5 stars` went out as `…spoiler\x035 stars` and arrived as " stars" in colour
+// 5, still on the spoiler's background, the "5" simply deleted; `the code is ||1234||5678` lost
+// "56" and rendered the rest in colour 56. Silent, on the wire, unrecoverable.
+//
+// 99 is IRC's "default colour" and, being two digits, consumes the parser's whole appetite so the
+// typed digit survives as text. Both halves are specified: a bare \x0399 sets only the foreground
+// and would leave the rest of the line sitting on the spoiler's grey box.
+//
+// ⚠ Not \x0F (reset-all), which would also drop any bold or italic still in effect around the
+// spoiler — the one thing the bare \x03 close was chosen to preserve. And not used
+// unconditionally: it's six bytes heavier and 99 is less universally understood than a reset, so
+// only the collision pays for it.
+//
+// ⚠ This depends on splitTextByTokens NOT treating 99,99 as a spoiler — see the renderable-slot
+// check there. Without it every spoiler followed by a digit would turn the REST OF THE LINE into
+// a spoiler box.
+const SPOILER_CLOSE_BEFORE_DIGIT = '\x0399,99';
+
+function spoilerClose(next: string | undefined): string {
+  return next !== undefined && next >= '0' && next <= '9'
+    ? SPOILER_CLOSE_BEFORE_DIGIT
+    : SPOILER_CLOSE;
+}
+
 interface Token {
   delim: boolean;
   value: string;
@@ -89,7 +115,12 @@ export function applySpoilerMarkup(text: string): string {
       content += tokens[j].value;
     }
     if (close !== -1 && content.length > 0) {
-      out += SPOILER_OPEN + content + SPOILER_CLOSE;
+      // What follows decides how the spoiler has to be closed. The next character is the first
+      // of the next text token, if there is one; a delimiter or the end of the message can't be
+      // a digit.
+      const following = tokens[close + 1];
+      const next = following && !following.delim ? following.value[0] : undefined;
+      out += SPOILER_OPEN + content + spoilerClose(next);
       i = close + 1;
     } else {
       // Unmatched, or an empty `||||` — the opening `||` is just literal text.


### PR DESCRIPTION
## The bug

A bare `\x03` is a colour **reset** only when nothing parseable follows it. `\x03` followed by a digit is a colour **code**, and it consumes up to two of them. So every `||spoiler||` followed by a digit silently deleted characters on the way out:

| typed | on the wire | received as |
|---|---|---|
| `\|\|spoiler\|\|5 stars` | `…spoiler\x035 stars` | `" stars"` in colour 5 — the **`5` is gone** |
| `the code is \|\|1234\|\|5678` | `…1234\x035678` | `"78"` in colour 56 — **`56` is gone** |

The lost text is also still sitting on the spoiler's grey background. This happens on the wire, before the sender sees anything is wrong, and there's nothing to recover from.

Found while porting spoilers to iOS (`lurker-ios` `ios-spoilers`), which inherited it along with the rest of the algorithm. Reproduced here by round trip before fixing.

## The fix

The close becomes `\x0399,99` when a digit follows, and stays a bare `\x03` otherwise.

99 is IRC's "default colour" and, being two digits, consumes the parser's whole appetite — so the typed digit survives as text. Both halves are specified because a bare `\x0399` sets only the foreground and would leave the rest of the line on the spoiler's box.

Not `\x0F` (reset-all): it would work, but also drops any bold or italic still in effect around the spoiler, which is the one thing the bare `\x03` close was chosen to preserve. Conditional rather than unconditional because it's six bytes heavier and 99 is less universally understood than a reset.

## ⚠ It required fixing a second bug, which was already live

`splitTextByTokens` treated **any** `fg === bg` as a spoiler — including slots above 15, which the palette can't paint. `\x0399,99text\x03` is a common way to write a run, and it became a neutral grey spoiler box over text that was rendering in the clear, revealing nothing when clicked.

That's a bug on its own, and it's also a trap for the fix above: without the `<= 15` gate, the new close would have turned **the entire rest of the line** into a spoiler box.

`previewUrls` carries the same `fg === bg` test and needed the same gate. It skips URLs inside a spoiler so a preview can't defeat one — and a `99,99` tail would have silently dropped the preview for any link after a digit-followed spoiler. That's a failure I'd rather nobody had to trace back to a colour code.

## Tests

Asserted as round trips rather than on the bytes: every character typed after a spoiler survives, doesn't inherit its background, and doesn't become a spoiler itself. Plus the unrenderable pair on both the render and the preview path.

Both fixes mutation-checked — reverting the close fails 3 tests, reverting the gate fails 4.

3831 tests, `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)