### PR TITLE
Voice calls core: LiveKit token authority + audio calls (slice 1 of #680)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,4 +71,40 @@ services:
       # where the container itself sees cleartext. Flip on only if you serve
       # Lurker over true end-to-end HTTPS.
       # - COOKIE_SECURE=true
+      #
+      # ───── Optional: Voice calls (LiveKit) ───────────────────────────────
+      # Native voice calls via a self-hosted LiveKit SFU. OFF by default —
+      # media flows through the SFU (NOT peer-to-peer, and never through
+      # Lurker itself, which only mints room-scoped access tokens). To enable:
+      #   1. Uncomment the four vars below (and pick your own API secret).
+      #   2. Start the bundled SFU with the "voice" profile:
+      #        docker compose --profile voice up -d
+      #   3. Set LIVEKIT_WS_URL to the address the *clients* reach —
+      #      ws://<this-host>:7880 on a LAN, or wss://<public-host> behind TLS.
+      # See docs/SELF_HOSTING.md → "Voice calls" for NAT/TURN caveats.
+      # - LURKER_VOICE_ENABLED=true
+      # - LIVEKIT_WS_URL=ws://localhost:7880
+      # - LIVEKIT_API_KEY=devkey
+      # - LIVEKIT_API_SECRET=replace-me-with-a-long-random-secret
+    restart: unless-stopped
+
+  # Self-hosted LiveKit SFU. Defined but inert unless you opt in with the
+  # "voice" profile: `docker compose --profile voice up -d`. The API key/secret
+  # here MUST match LIVEKIT_API_KEY / LIVEKIT_API_SECRET on the lurker service
+  # above — that shared secret is what lets Lurker sign tokens this SFU trusts.
+  livekit:
+    image: livekit/livekit-server:latest
+    container_name: lurker-livekit
+    profiles: ['voice']
+    command: --dev --node-ip=127.0.0.1
+    environment:
+      # `key: secret` pairs. Keep in lockstep with the lurker service vars.
+      - 'LIVEKIT_KEYS=devkey: replace-me-with-a-long-random-secret'
+    ports:
+      - '7880:7880' # signaling (WebSocket + HTTP)
+      - '7881:7881' # WebRTC over TCP (ICE/TCP fallback)
+      - '7882:7882/udp' # WebRTC over UDP (media)
+      # NOTE on NAT: --node-ip must be the address clients can reach the SFU at.
+      # 127.0.0.1 works for localhost only. On a LAN set it to this host's LAN IP;
+      # behind real NAT you need a public IP + a TURN server (see LiveKit docs).
     restart: unless-stopped

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1122,9 +1122,11 @@ current IRC nick, which is what other participants render.
 
 Room names are derived server-side from the network **host** (never the
 `networkId`): `net-<host>-c-<channel>` for channels,
-`net-<host>-d-<nickA>-<nickB>` (sorted pair) for DMs, all ASCII-folded — so
-every member of a channel lands in the same room, even from another Lurker
-instance sharing the SFU.
+`net-<host>-d-<nickA>:<nickB>` (sorted pair, `:`-joined) for DMs. Channel and
+nick are folded with the network's declared CASEMAPPING, the host ASCII-folded
+— so every member of a channel lands in the same room, even from another
+Lurker instance sharing the SFU. The host string must match **exactly** across
+users: different DNS aliases of one network derive different rooms.
 
 ### Export / import
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -48,7 +48,7 @@ GET /api/config            (no auth)
 → { "edition": "standalone" | "node",
     "protocolVersion": 1,
     "minProtocolVersion": 1,
-    "features": { "linkPreviews": false } }
+    "features": { "linkPreviews": false, "voice": false } }
 ```
 
 `features` carries instance-level flags an operator turned on. Treat a missing
@@ -57,7 +57,8 @@ Settings whose registry entry names a feature (`requiresFeature`) must be
 **hidden**, not merely disabled, when that flag is false: there is no server
 behind them, and the endpoints aren't mounted, so a toggle would do nothing.
 `linkPreviews` gates `chat.inline_media.enabled`, `chat.link_previews.enabled`,
-and the `/api/link-preview/*` endpoints.
+and the `/api/link-preview/*` endpoints. `voice` gates the `/api/voice/*`
+endpoints — when false, render no call UI at all.
 
 Node edition disables `/api/api-tokens`, `/mcp`, and `/uploads/*` static serving;
 standalone has no `/api/node/*`. The WS protocol itself is identical in both.
@@ -1101,6 +1102,29 @@ check before uploading.
 
 `GET /?limit` list · `POST /:id/accept|reject|cancel`. Live updates via
 `dcc-transfer` frames; file bytes move over IRC, not HTTP.
+
+### Voice calls — `/api/voice` (503 unless the instance enables voice)
+
+Lurker never carries call media — it mints room-scoped tokens for the
+operator's LiveKit SFU, and your client connects to the SFU directly (any
+LiveKit client SDK).
+
+```
+POST /token   { networkId, target }
+→ { token, room, url }        url = the SFU's ws(s):// origin
+```
+
+Gates, in order: `503` voice not enabled · `404` network not owned · `409`
+network not connected · `403` target is a channel you haven't joined (DMs skip
+this — opening a DM call **is** the invite). The token is a 2-hour JWT granting
+join/publish/subscribe on exactly one room; `identity` inside it is your
+current IRC nick, which is what other participants render.
+
+Room names are derived server-side from the network **host** (never the
+`networkId`): `net-<host>-c-<channel>` for channels,
+`net-<host>-d-<nickA>-<nickB>` (sorted pair) for DMs, all ASCII-folded — so
+every member of a channel lands in the same room, even from another Lurker
+instance sharing the SFU.
 
 ### Export / import
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -322,6 +322,35 @@ Playback replays the last 50 lines per joined channel (plus your 20 most recentl
 
 Known limitations (shared-connection bouncer semantics): replies to one attached client's WHOIS/LIST are visible to all attached clients on that network; Lurker-side ignore rules don't filter the live relay; and on end-to-end encrypted channels an attached client sees the wire ciphertext for incoming messages.
 
+### Voice calls (LiveKit)
+
+Lurker can offer native voice calls for channels and DMs, powered by a [LiveKit](https://livekit.io/) SFU you host yourself. Two things to understand before enabling it:
+
+- **Call audio is not peer-to-peer, and it never passes through Lurker.** Every participant streams to the SFU, which forwards to the others. Your host pays the bandwidth for every participant's stream.
+- **WebRTC has real networking requirements.** On a LAN this works out of the box; across the public internet the SFU needs its UDP port reachable, and clients behind restrictive NAT need a TURN server. This is where self-hosted calling most often fails — if calls connect but carry no audio, it is almost always NAT, not Lurker.
+
+Enable it by uncommenting the voice block in `docker-compose.yml` and starting the bundled SFU:
+
+```yaml
+environment:
+  - LURKER_VOICE_ENABLED=true
+  - LIVEKIT_WS_URL=ws://<host-clients-can-reach>:7880
+  - LIVEKIT_API_KEY=devkey
+  - LIVEKIT_API_SECRET=<your own long random secret>
+```
+
+```sh
+docker compose --profile voice up -d
+```
+
+`LIVEKIT_API_KEY`/`SECRET` must match the `LIVEKIT_KEYS` pair on the `livekit` service — that shared secret is how Lurker signs call tokens the SFU trusts. `LIVEKIT_WS_URL` is the address **clients** connect to: `ws://<lan-ip>:7880` on a LAN, or `wss://` behind your TLS proxy for the public internet (put only the signaling port behind the proxy; media flows over UDP 7882 directly). Set the LiveKit `--node-ip` flag to an address clients can actually reach, and see the [LiveKit deployment docs](https://docs.livekit.io/home/self-hosting/deployment/) for TURN setup.
+
+Everyone in a channel can join that channel's call; a DM call simply rings by existing — the other side sees it and joins from the same button. Room membership is checked against your live IRC state, so you can only get a call token for a channel you are actually in.
+
+One caveat to know: DM call rooms are named by the two nicks. IRC nicks are transferable, so on networks without nick registration someone who takes an offline person's nick could join a call room under that name — the same level of trust as IRC itself. Treat calls like you treat the channel: fine among people you already trust.
+
+Disabling voice (removing the env vars) makes every call affordance disappear from clients; browsers only download the WebRTC code the first time someone actually joins a call.
+
 ---
 
 ## Troubleshooting

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -345,9 +345,12 @@ docker compose --profile voice up -d
 
 `LIVEKIT_API_KEY`/`SECRET` must match the `LIVEKIT_KEYS` pair on the `livekit` service — that shared secret is how Lurker signs call tokens the SFU trusts. `LIVEKIT_WS_URL` is the address **clients** connect to: `ws://<lan-ip>:7880` on a LAN, or `wss://` behind your TLS proxy for the public internet (put only the signaling port behind the proxy; media flows over UDP 7882 directly). Set the LiveKit `--node-ip` flag to an address clients can actually reach, and see the [LiveKit deployment docs](https://docs.livekit.io/home/self-hosting/deployment/) for TURN setup.
 
-Everyone in a channel can join that channel's call; a DM call simply rings by existing — the other side sees it and joins from the same button. Room membership is checked against your live IRC state, so you can only get a call token for a channel you are actually in.
+Everyone in a channel can join that channel's call — from the button atop the member list, or with `/call` in the buffer. A DM call is `/call` in the DM: both sides join the same room, but nothing "rings" yet — tell the other person to `/call` you back (in-call presence indicators are planned as a follow-up). Call rooms are derived from the IRC server **hostname**, so users who should share calls must configure the _same_ host: `irc.libera.chat` and `irc.eu.libera.chat` are different rooms even though they're the same network.
 
-One caveat to know: DM call rooms are named by the two nicks. IRC nicks are transferable, so on networks without nick registration someone who takes an offline person's nick could join a call room under that name — the same level of trust as IRC itself. Treat calls like you treat the channel: fine among people you already trust.
+Two trust caveats, both in line with IRC's own model — fine among people you already trust:
+
+- Channel membership is checked **when the call token is issued**, and tokens last 2 hours. Someone kicked or banned mid-call can rejoin the room on their existing token until it expires (op-side call moderation is planned as a follow-up).
+- DM call rooms are named by the two nicks, and IRC nicks are transferable: on networks without nick registration, someone who takes an offline person's nick could join a call room under that name.
 
 Disabling voice (removing the env vars) makes every call affordance disappear from clients; browsers only download the WebRTC code the first time someone actually joins a call.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "express": "^5.2.1",
         "file-type": "^22.0.1",
         "irc-framework": "^4.13.1",
+        "livekit-server-sdk": "^2.17.0",
         "multer": "^2.2.0",
         "selfsigned": "^5.5.0",
         "sharp": "^0.35.3",
@@ -121,6 +122,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
@@ -1169,6 +1176,15 @@
       "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
       "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
       "license": "MIT"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -4940,6 +4956,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -5281,6 +5306,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/livekit-server-sdk": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/livekit-server-sdk/-/livekit-server-sdk-2.17.0.tgz",
+      "integrity": "sha512-GWNEQrUD13UwZNrmosyTVFPgeBvSU2lFKGxdA4DaUI5F4sMb1cGeep/PPEE9vvRNELJYpxWS0ImS4gQmovKUDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.1",
+        "@livekit/protocol": "^1.48.0",
+        "jose": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/lodash": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "^5.2.1",
     "file-type": "^22.0.1",
     "irc-framework": "^4.13.1",
+    "livekit-server-sdk": "^2.17.0",
     "multer": "^2.2.0",
     "selfsigned": "^5.5.0",
     "sharp": "^0.35.3",

--- a/server/app.ts
+++ b/server/app.ts
@@ -27,6 +27,7 @@ import uploadsRouter from './routes/uploads.js';
 import uploadersRouter from './routes/uploaders.js';
 import localUploadsRouter from './routes/localUploads.js';
 import dccRouter from './routes/dcc.js';
+import voiceRouter from './routes/voice.js';
 import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
@@ -98,6 +99,7 @@ export function buildApp(sessionSecret: string): Express {
     app.use('/uploads', localUploadsRouter);
   }
   app.use('/api/dcc', dccRouter);
+  app.use('/api/voice', voiceRouter);
   app.use('/api/drafts', draftsRouter);
   app.use('/api/exports', exportsRouter);
   app.use('/api/imports', importRouter);

--- a/server/routes/config.ts
+++ b/server/routes/config.ts
@@ -6,6 +6,7 @@ import type { Request, Response } from 'express';
 import { getEdition } from '../utils/edition.js';
 import { PROTOCOL_VERSION, MIN_PROTOCOL_VERSION } from '../protocol.js';
 import { previewsEnabled } from '../utils/previews.js';
+import { voiceEnabled } from '../services/voice.js';
 
 const router = Router();
 
@@ -28,6 +29,9 @@ router.get('/', (_req: Request, res: Response) => {
     // presenting toggles that can't do anything.
     features: {
       linkPreviews: previewsEnabled(),
+      // Voice calls (LiveKit): operator opt-in + a configured SFU. Clients
+      // render zero call UI when false.
+      voice: voiceEnabled(),
     },
   });
 });

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -91,10 +91,21 @@ describe('POST /api/voice/token', () => {
     expect(res.status).toBe(400);
   });
 
-  it('400 for a missing target', async () => {
+  it('400 for a missing target (after the instance/network gates)', async () => {
     enableVoice();
+    // Connected on purpose: target validation sits BEHIND the 503/404/409
+    // gates (CLIENT_PROTOCOL's documented order), so give it a live network.
+    fakeManager.conn = { currentNick: 'alice', isChannelJoined: () => true };
     const res = await agent.post('/api/voice/token').send({ networkId: network.id });
     expect(res.status).toBe(400);
+  });
+
+  it('503 beats body validation when voice is disabled (documented gate order)', async () => {
+    delete process.env.LURKER_VOICE_ENABLED;
+    delete process.env.LIVEKIT_WS_URL;
+    // No target either — a disabled instance must still answer 503, not 400.
+    const res = await agent.post('/api/voice/token').send({ networkId: network.id });
+    expect(res.status).toBe(503);
   });
 
   it('404 for a network the caller does not own (ownership gate)', async () => {

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -141,6 +141,6 @@ describe('POST /api/voice/token', () => {
     const res = await agent.post('/api/voice/token').send({ networkId: network.id, target: 'Bob' });
     expect(res.status).toBe(200);
     // Canonical sorted pair — Bob's end derives the identical room.
-    expect(res.body.room).toBe('net-irc.libera.chat-d-alice-bob');
+    expect(res.body.room).toBe('net-irc.libera.chat-d-alice:bob');
   });
 });

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import type { LurkerTestAgent } from '../test-utils/testApp.js';
+import type { Express } from 'express';
+import {
+  setupTestDb,
+  createTestApp,
+  createAuthedAgent,
+  testRequest,
+} from '../test-utils/testApp.js';
+import type { User } from '../db/users.js';
+import type { Network } from '../db/networks.js';
+
+const ctx = setupTestDb('routes-voice');
+
+// Stand-in ircManager so the route can be exercised through its whole gate
+// chain — not connected (409), not a member (403), and the happy path — without
+// opening real IRC sockets. Tests flip `conn` between null and a fake carrying
+// exactly the surface the route reads: currentNick + isChannelJoined.
+const fakeManager = {
+  conn: null as null | { currentNick: string | null; isChannelJoined: (c: string) => boolean },
+  getConnection(_userId: number, _networkId: number) {
+    return this.conn;
+  },
+};
+
+vi.mock('../services/ircManager.js', () => ({ default: fakeManager }));
+
+let app: Express;
+let agent: LurkerTestAgent;
+let user: User;
+let network: Network;
+
+// Turn voice on by populating the env the service reads. Individual tests toggle
+// pieces of this to exercise the gates.
+function enableVoice() {
+  process.env.LURKER_VOICE_ENABLED = 'true';
+  process.env.LIVEKIT_WS_URL = 'ws://sfu.test:7880';
+  process.env.LIVEKIT_API_KEY = 'devkey';
+  process.env.LIVEKIT_API_SECRET = 'devsecret-long-enough';
+}
+
+const savedEnv = { ...process.env };
+
+beforeAll(async () => {
+  const { createUser } = await import('../db/users.js');
+  const { createNetwork } = await import('../db/networks.js');
+  const router = (await import('./voice.js')).default;
+  user = createUser('voice-routes-alice');
+  network = createNetwork(user.id, {
+    name: 'libera',
+    host: 'irc.libera.chat',
+    port: 6697,
+    tls: true,
+    nick: 'alice',
+  })!;
+  app = createTestApp({ '/api/voice': router });
+  agent = await createAuthedAgent(app, user.id);
+});
+
+afterEach(() => {
+  process.env = { ...savedEnv };
+  fakeManager.conn = null;
+});
+
+afterAll(() => ctx.cleanup());
+
+describe('POST /api/voice/token', () => {
+  it('401 when unauthenticated', async () => {
+    enableVoice();
+    const res = await testRequest(app)
+      .post('/api/voice/token')
+      .send({ networkId: network.id, target: '#dev' });
+    expect(res.status).toBe(401);
+  });
+
+  it('503 when voice is not enabled on the server', async () => {
+    delete process.env.LURKER_VOICE_ENABLED;
+    delete process.env.LIVEKIT_WS_URL;
+    const res = await agent
+      .post('/api/voice/token')
+      .send({ networkId: network.id, target: '#dev' });
+    expect(res.status).toBe(503);
+  });
+
+  it('400 for a missing/invalid networkId', async () => {
+    enableVoice();
+    const res = await agent.post('/api/voice/token').send({ target: '#dev' });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 for a missing target', async () => {
+    enableVoice();
+    const res = await agent.post('/api/voice/token').send({ networkId: network.id });
+    expect(res.status).toBe(400);
+  });
+
+  it('404 for a network the caller does not own (ownership gate)', async () => {
+    enableVoice();
+    // networkId 999999 belongs to nobody, so getNetwork(id, user) is undefined —
+    // the request is refused before any room token can be minted.
+    const res = await agent.post('/api/voice/token').send({ networkId: 999999, target: '#dev' });
+    expect(res.status).toBe(404);
+  });
+
+  it('409 when the network is not connected', async () => {
+    enableVoice();
+    fakeManager.conn = null;
+    const res = await agent
+      .post('/api/voice/token')
+      .send({ networkId: network.id, target: '#dev' });
+    expect(res.status).toBe(409);
+  });
+
+  it('403 for a channel the caller has not joined (membership gate)', async () => {
+    enableVoice();
+    fakeManager.conn = { currentNick: 'alice', isChannelJoined: () => false };
+    const res = await agent
+      .post('/api/voice/token')
+      .send({ networkId: network.id, target: '#dev' });
+    expect(res.status).toBe(403);
+  });
+
+  it('mints a token for a joined channel, room keyed on the network HOST', async () => {
+    enableVoice();
+    fakeManager.conn = { currentNick: 'alice', isChannelJoined: (c) => c === '#dev' };
+    const res = await agent
+      .post('/api/voice/token')
+      .send({ networkId: network.id, target: '#dev' });
+    expect(res.status).toBe(200);
+    expect(res.body.room).toBe('net-irc.libera.chat-c-#dev');
+    expect(res.body.url).toBe('ws://sfu.test:7880');
+    expect(String(res.body.token).split('.')).toHaveLength(3);
+  });
+
+  it('mints a DM token without any membership gate (opening the call IS the invite)', async () => {
+    enableVoice();
+    fakeManager.conn = { currentNick: 'alice', isChannelJoined: () => false };
+    const res = await agent.post('/api/voice/token').send({ networkId: network.id, target: 'Bob' });
+    expect(res.status).toBe(200);
+    // Canonical sorted pair — Bob's end derives the identical room.
+    expect(res.body.room).toBe('net-irc.libera.chat-d-alice-bob');
+  });
+});

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { requireAuth } from '../middleware/auth.js';
+import { getNetwork } from '../db/networks.js';
+import type { Network } from '../db/networks.js';
+import ircManager from '../services/ircManager.js';
+import type { IrcConnection } from '../services/ircConnection.js';
+import { isChannelTarget } from '../../shared/channels.js';
+import { mintVoiceToken, roomFor, voiceEnabled } from '../services/voice.js';
+
+// Voice control surface. Lurker is the token authority (see services/voice.ts);
+// it never carries media. Everything here is requireAuth'd and gated on
+// voiceEnabled(), so on a non-voice instance this router is a wall of 503s and
+// the client never shows the UI that would call it.
+
+interface CallCtx {
+  network: Network;
+  conn: IrcConnection;
+  nick: string;
+}
+
+/** Resolve + gate the common preconditions (voice on, network owned, live
+ *  connection). Sends the error response and returns null on any failure. */
+function resolveCall(req: Request, res: Response, networkId: number): CallCtx | null {
+  if (!voiceEnabled()) {
+    res.status(503).json({ error: 'voice not enabled on this server' });
+    return null;
+  }
+  if (!Number.isInteger(networkId) || networkId <= 0) {
+    res.status(400).json({ error: 'networkId required' });
+    return null;
+  }
+  const network = getNetwork(networkId, req.user!.id);
+  if (!network) {
+    res.status(404).json({ error: 'network not found' });
+    return null;
+  }
+  const conn = ircManager.getConnection(req.user!.id, networkId);
+  if (!conn || !conn.currentNick) {
+    res.status(409).json({ error: 'network not connected' });
+    return null;
+  }
+  return { network, conn, nick: conn.currentNick };
+}
+
+const router = Router();
+router.use(requireAuth);
+
+// ─── Join: mint a room-scoped token, gated by channel membership ────────────
+router.post('/token', async (req: Request, res: Response) => {
+  const networkId = Number(req.body?.networkId);
+  const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  if (!target) {
+    res.status(400).json({ error: 'target required' });
+    return;
+  }
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  const { network, conn, nick } = ctx;
+
+  // Channels require live membership (the one casemapping-correct probe — see
+  // isChannelJoined). DMs deliberately don't gate on the peer: opening a DM
+  // call IS the invite, exactly like opening a DM buffer.
+  if (isChannelTarget(target) && !conn.isChannelJoined(target)) {
+    res.status(403).json({ error: 'not a member of that channel' });
+    return;
+  }
+
+  const room = roomFor(network.host, target, nick);
+  try {
+    const minted = await mintVoiceToken({ identity: nick, room });
+    res.json(minted); // { token, room, url }
+  } catch {
+    res.status(500).json({ error: 'failed to mint token' });
+  }
+});
+
+export default router;

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -54,12 +54,14 @@ router.use(requireAuth);
 router.post('/token', async (req: Request, res: Response) => {
   const networkId = Number(req.body?.networkId);
   const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  // Gate order matches CLIENT_PROTOCOL: a voice-disabled instance answers 503
+  // to everything (inside resolveCall), before any body validation.
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
   if (!target) {
     res.status(400).json({ error: 'target required' });
     return;
   }
-  const ctx = resolveCall(req, res, networkId);
-  if (!ctx) return;
   const { network, conn, nick } = ctx;
 
   // Channels require live membership (the one casemapping-correct probe — see

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -9,6 +9,7 @@ import type { Network } from '../db/networks.js';
 import ircManager from '../services/ircManager.js';
 import type { IrcConnection } from '../services/ircConnection.js';
 import { isChannelTarget } from '../../shared/channels.js';
+import { foldTargetFor } from '../db/buffers.js';
 import { mintVoiceToken, roomFor, voiceEnabled } from '../services/voice.js';
 
 // Voice control surface. Lurker is the token authority (see services/voice.ts);
@@ -69,11 +70,23 @@ router.post('/token', async (req: Request, res: Response) => {
     return;
   }
 
-  const room = roomFor(network.host, target, nick);
+  // Fold with the network's declared CASEMAPPING before deriving the room, so
+  // rfc1459 spelling variants of one channel ('#foo[bar]' vs '#foo{bar}') — or
+  // of a nick — agree on one room. isChannelJoined folds the same way, so the
+  // membership gate and the room key can never diverge. Deterministic across
+  // instances too: the mapping is whatever the shared IRC server declared.
+  const room = roomFor(
+    network.host,
+    foldTargetFor(network.id, target),
+    foldTargetFor(network.id, nick),
+  );
   try {
     const minted = await mintVoiceToken({ identity: nick, room });
     res.json(minted); // { token, room, url }
-  } catch {
+  } catch (err) {
+    // Operator-actionable (bad LIVEKIT_API_SECRET, SDK failure) — log it; a
+    // silent 500 here would leave both ends of the failure invisible.
+    console.error('[voice] token mint failed:', err);
     res.status(500).json({ error: 'failed to mint token' });
   }
 });

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -6,25 +6,14 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   liveKitConfig,
   mintVoiceToken,
-  parseVoiceEnabled,
   roomFor,
   voiceEnabled,
   voiceMasterEnabled,
 } from './voice.js';
 
-describe('parseVoiceEnabled', () => {
-  it('treats the conventional truthy values as on (trimmed, case-insensitive)', () => {
-    for (const v of ['1', 'true', 'TRUE', 'yes', 'on', ' On ']) {
-      expect(parseVoiceEnabled(v)).toBe(true);
-    }
-  });
-
-  it('is off for unset / empty / anything else (opt-in only)', () => {
-    for (const v of [undefined, '', '0', 'false', 'no', 'off', 'maybe']) {
-      expect(parseVoiceEnabled(v)).toBe(false);
-    }
-  });
-});
+// LURKER_VOICE_ENABLED value parsing is the shared parseTruthyEnv — its accepted
+// set is pinned by truthyEnv's own tests; only the wiring is exercised here (in
+// the 'config gating' describe below).
 
 describe('roomFor', () => {
   it('makes a channel room everyone on the same host+channel derives identically', () => {
@@ -57,7 +46,16 @@ describe('roomFor', () => {
     const fromAlice = roomFor('irc.libera.chat', 'Bob', 'Alice');
     const fromBob = roomFor('irc.libera.chat', 'Alice', 'Bob');
     expect(fromAlice).toBe(fromBob);
-    expect(fromAlice).toBe('net-irc.libera.chat-d-alice-bob');
+    expect(fromAlice).toBe('net-irc.libera.chat-d-alice:bob');
+  });
+
+  it("joins the DM pair with ':' so pairs containing '-' can never collide", () => {
+    // '-' is legal inside a nick, so a '-' delimiter made ('john-w','ork') and
+    // ('john','w-ork') share a room — minting a DM token for the second pair
+    // would silently drop the caller into the first pair's private call.
+    const a = roomFor('irc.libera.chat', 'ork', 'john-w');
+    const b = roomFor('irc.libera.chat', 'w-ork', 'john');
+    expect(a).not.toBe(b);
   });
 
   it('scopes rooms by host, not by per-user network id', () => {

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  liveKitConfig,
+  mintVoiceToken,
+  parseVoiceEnabled,
+  roomFor,
+  voiceEnabled,
+  voiceMasterEnabled,
+} from './voice.js';
+
+describe('parseVoiceEnabled', () => {
+  it('treats the conventional truthy values as on (trimmed, case-insensitive)', () => {
+    for (const v of ['1', 'true', 'TRUE', 'yes', 'on', ' On ']) {
+      expect(parseVoiceEnabled(v)).toBe(true);
+    }
+  });
+
+  it('is off for unset / empty / anything else (opt-in only)', () => {
+    for (const v of [undefined, '', '0', 'false', 'no', 'off', 'maybe']) {
+      expect(parseVoiceEnabled(v)).toBe(false);
+    }
+  });
+});
+
+describe('roomFor', () => {
+  it('makes a channel room everyone on the same host+channel derives identically', () => {
+    // self is irrelevant for a channel; the host is shared across users and
+    // instances, so two different accounts produce the same room.
+    expect(roomFor('irc.libera.chat', '#dev', 'alice')).toBe('net-irc.libera.chat-c-#dev');
+    expect(roomFor('irc.libera.chat', '#dev', 'bob')).toBe('net-irc.libera.chat-c-#dev');
+  });
+
+  it('treats ALL FOUR channel sigils as channels, not DM peers', () => {
+    // The most-repeated bug in this codebase is testing only for '#'
+    // (see shared/channels.ts). A `&`/`+`/`!` channel misclassified as a DM
+    // here would put callers in a nick-pair room instead of the channel room.
+    for (const chan of ['#dev', '&local', '+modeless', '!ABCDEchan']) {
+      expect(roomFor('irc.libera.chat', chan, 'alice')).toBe(
+        `net-irc.libera.chat-c-${chan.toLowerCase()}`,
+      );
+    }
+  });
+
+  it('folds host + channel ASCII-only, leaving sigils and non-ASCII intact', () => {
+    expect(roomFor('IRC.Libera.Chat', '#DevOps', 'x')).toBe('net-irc.libera.chat-c-#devops');
+    // [] and {} are NOT folded (RFC casemapping deliberately absent, docs §9.2).
+    expect(roomFor('irc.libera.chat', '#Foo[Bar]', 'x')).toBe('net-irc.libera.chat-c-#foo[bar]');
+  });
+
+  it('gives a DM the SAME room from either end (canonical sorted pair)', () => {
+    // The bug this prevents: A's target is "B", B's target is "A" — verbatim
+    // naming would split one call into two rooms.
+    const fromAlice = roomFor('irc.libera.chat', 'Bob', 'Alice');
+    const fromBob = roomFor('irc.libera.chat', 'Alice', 'Bob');
+    expect(fromAlice).toBe(fromBob);
+    expect(fromAlice).toBe('net-irc.libera.chat-d-alice-bob');
+  });
+
+  it('scopes rooms by host, not by per-user network id', () => {
+    // Same channel on two different networks → different rooms.
+    expect(roomFor('irc.libera.chat', '#dev', 'x')).not.toBe(roomFor('irc.rizon.net', '#dev', 'x'));
+  });
+});
+
+describe('config gating (env)', () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it('liveKitConfig is null unless all three vars are present', () => {
+    delete process.env.LIVEKIT_WS_URL;
+    delete process.env.LIVEKIT_API_KEY;
+    delete process.env.LIVEKIT_API_SECRET;
+    expect(liveKitConfig()).toBeNull();
+
+    process.env.LIVEKIT_WS_URL = 'wss://sfu.example';
+    process.env.LIVEKIT_API_KEY = 'devkey';
+    expect(liveKitConfig()).toBeNull(); // secret still missing
+
+    process.env.LIVEKIT_API_SECRET = 'devsecret';
+    expect(liveKitConfig()).toEqual({
+      wsUrl: 'wss://sfu.example',
+      apiKey: 'devkey',
+      apiSecret: 'devsecret',
+    });
+  });
+
+  it('voiceEnabled requires BOTH the master switch and a full config', () => {
+    process.env.LIVEKIT_WS_URL = 'wss://sfu.example';
+    process.env.LIVEKIT_API_KEY = 'devkey';
+    process.env.LIVEKIT_API_SECRET = 'devsecret';
+
+    process.env.LURKER_VOICE_ENABLED = 'off';
+    expect(voiceMasterEnabled()).toBe(false);
+    expect(voiceEnabled()).toBe(false);
+
+    process.env.LURKER_VOICE_ENABLED = 'true';
+    expect(voiceEnabled()).toBe(true);
+
+    delete process.env.LIVEKIT_API_SECRET;
+    expect(voiceEnabled()).toBe(false); // master on, but config incomplete
+  });
+});
+
+describe('mintVoiceToken', () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  function enable() {
+    process.env.LIVEKIT_WS_URL = 'wss://sfu.example';
+    process.env.LIVEKIT_API_KEY = 'devkey';
+    process.env.LIVEKIT_API_SECRET = 'devsecret-long-enough-for-hs256';
+  }
+
+  it('throws when voice is not configured', async () => {
+    delete process.env.LIVEKIT_WS_URL;
+    delete process.env.LIVEKIT_API_KEY;
+    delete process.env.LIVEKIT_API_SECRET;
+    await expect(mintVoiceToken({ identity: 'alice', room: 'net-x-c-#dev' })).rejects.toThrow(
+      'voice not configured',
+    );
+  });
+
+  it('mints a JWT scoped to exactly the requested room', async () => {
+    enable();
+    const minted = await mintVoiceToken({ identity: 'alice', room: 'net-x-c-#dev' });
+    expect(minted.room).toBe('net-x-c-#dev');
+    expect(minted.url).toBe('wss://sfu.example');
+
+    // Decode the (unencrypted) JWT payload and assert the grant really is
+    // room-scoped — this is the security property the whole feature rests on:
+    // a token for #dev must not be able to touch #ops.
+    const parts = minted.token.split('.');
+    expect(parts).toHaveLength(3);
+    const claims = JSON.parse(Buffer.from(parts[1]!, 'base64url').toString()) as {
+      sub?: string;
+      video?: { room?: string; roomJoin?: boolean; canSubscribe?: boolean };
+    };
+    expect(claims.sub).toBe('alice');
+    expect(claims.video?.room).toBe('net-x-c-#dev');
+    expect(claims.video?.roomJoin).toBe(true);
+    expect(claims.video?.canSubscribe).toBe(true);
+  });
+});

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Voice calls via a self-hosted LiveKit SFU. Lurker never carries media — it is
+// only the *token authority*: it already knows who you are and which networks
+// you own, so it is the right place to mint a room-scoped LiveKit access token.
+// Clients hold only the short-lived token, never the LiveKit API secret — the
+// same trust split as session tokens.
+//
+// Gating mirrors DCC (see dccConfig.ts): OFF by default, opt-in for the
+// operator. Voice is "enabled" only when BOTH the master switch is on AND the
+// three LiveKit connection vars are present. Anything missing → dark, and
+// /api/config advertises voiceEnabled: false so clients hide the call UI
+// entirely.
+//
+// The room-naming rules are pure (no env, no I/O) and unit-tested — they are the
+// load-bearing correctness surface. A channel is symmetric (everyone in #dev
+// derives the same room), but a DM is not: if A opens a call to B, A's target is
+// "B" and B's target is "A". Naming a DM room by (self, target) verbatim would
+// put the two ends in two different rooms. So DM rooms are keyed by the
+// *canonical* (sorted) nick pair instead.
+
+import { AccessToken } from 'livekit-server-sdk';
+import { isChannelTarget } from '../../shared/channels.js';
+
+// Conventional truthy env values — trimmed + case-insensitive. Matches dccConfig.
+const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
+
+/** Parse a raw LURKER_VOICE_ENABLED value to a boolean. Pure (no env access) so
+ * it can be unit-tested without touching process.env. */
+export function parseVoiceEnabled(raw: string | undefined): boolean {
+  if (raw == null) return false;
+  return TRUTHY.has(raw.trim().toLowerCase());
+}
+
+/** The operator master switch. */
+export function voiceMasterEnabled(): boolean {
+  return parseVoiceEnabled(process.env.LURKER_VOICE_ENABLED);
+}
+
+export interface LiveKitConfig {
+  /** The wss:// URL the *client* connects to (public origin of the SFU). */
+  wsUrl: string;
+  apiKey: string;
+  apiSecret: string;
+}
+
+/** Read the three LiveKit connection vars, or null if any is missing/blank. */
+export function liveKitConfig(): LiveKitConfig | null {
+  const wsUrl = (process.env.LIVEKIT_WS_URL ?? '').trim();
+  const apiKey = (process.env.LIVEKIT_API_KEY ?? '').trim();
+  const apiSecret = (process.env.LIVEKIT_API_SECRET ?? '').trim();
+  if (!wsUrl || !apiKey || !apiSecret) return null;
+  return { wsUrl, apiKey, apiSecret };
+}
+
+/** Voice is live only when the operator opted in AND the SFU is configured. */
+export function voiceEnabled(): boolean {
+  return voiceMasterEnabled() && liveKitConfig() !== null;
+}
+
+// ASCII-only lowercasing, to match the client casefold contract (docs
+// CLIENT_PROTOCOL §9.2 — RFC 1459 casemapping is deliberately absent; we do not
+// fold [] {} etc). Room names must be derivable identically on any instance
+// pointed at the same SFU, so this deliberately ignores the per-network
+// CASEMAPPING and folds only A–Z.
+function foldAscii(s: string): string {
+  let out = '';
+  for (const ch of s) {
+    const c = ch.charCodeAt(0);
+    out += c >= 65 && c <= 90 ? String.fromCharCode(c + 32) : ch;
+  }
+  return out;
+}
+
+/**
+ * Derive the LiveKit room name for a call. Pure and deterministic.
+ *
+ * Keyed on the IRC network's HOST — NOT a local network row id. A networkId is
+ * per-account, so two users of the same instance on the same channel would
+ * otherwise derive different rooms and never connect. Hosts are shared across
+ * users, and across *instances* pointed at a common SFU — so a host key is also
+ * what makes opt-in cross-instance bridging Just Work.
+ *
+ *  - Channel `#dev` on irc.libera.chat → `net-irc.libera.chat-c-#dev`
+ *  - DM `Alice`↔`bob`                  → `net-irc.libera.chat-d-alice-bob` (sorted, either end)
+ *
+ * `self` is the caller's own nick on the network; it is only consulted for DMs,
+ * where it is paired with `target` and sorted so both ends agree on one room.
+ */
+export function roomFor(networkKey: string, target: string, self: string): string {
+  const net = foldAscii(networkKey);
+  if (isChannelTarget(target)) {
+    return `net-${net}-c-${foldAscii(target)}`;
+  }
+  const a = foldAscii(self);
+  const b = foldAscii(target);
+  const [lo, hi] = a <= b ? [a, b] : [b, a];
+  return `net-${net}-d-${lo}-${hi}`;
+}
+
+export interface MintedToken {
+  /** The signed JWT the client passes to LiveKit. */
+  token: string;
+  /** The room it is scoped to. */
+  room: string;
+  /** The wss:// URL to connect to. */
+  url: string;
+}
+
+/**
+ * Mint a room-scoped LiveKit access token. Grants join + publish + subscribe on
+ * exactly one room and nothing else — a token for `#dev` cannot touch `#ops`.
+ * Identity is the caller's IRC nick so remote participants render sensible names.
+ * Throws if voice is not configured (callers should have gated on voiceEnabled).
+ */
+export async function mintVoiceToken(args: {
+  identity: string;
+  room: string;
+}): Promise<MintedToken> {
+  const cfg = liveKitConfig();
+  if (!cfg) throw new Error('voice not configured');
+
+  const at = new AccessToken(cfg.apiKey, cfg.apiSecret, {
+    identity: args.identity,
+    ttl: 2 * 60 * 60, // 2h — a call comfortably outlives its join token
+  });
+  at.addGrant({
+    roomJoin: true,
+    room: args.room,
+    canPublish: true,
+    canSubscribe: true,
+    canPublishData: true,
+  });
+  const token = await at.toJwt();
+  return { token, room: args.room, url: cfg.wsUrl };
+}

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -22,20 +22,11 @@
 
 import { AccessToken } from 'livekit-server-sdk';
 import { isChannelTarget } from '../../shared/channels.js';
-
-// Conventional truthy env values — trimmed + case-insensitive. Matches dccConfig.
-const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
-
-/** Parse a raw LURKER_VOICE_ENABLED value to a boolean. Pure (no env access) so
- * it can be unit-tested without touching process.env. */
-export function parseVoiceEnabled(raw: string | undefined): boolean {
-  if (raw == null) return false;
-  return TRUTHY.has(raw.trim().toLowerCase());
-}
+import { parseTruthyEnv } from '../utils/truthyEnv.js';
 
 /** The operator master switch. */
 export function voiceMasterEnabled(): boolean {
-  return parseVoiceEnabled(process.env.LURKER_VOICE_ENABLED);
+  return parseTruthyEnv(process.env.LURKER_VOICE_ENABLED);
 }
 
 export interface LiveKitConfig {
@@ -76,17 +67,31 @@ function foldAscii(s: string): string {
 /**
  * Derive the LiveKit room name for a call. Pure and deterministic.
  *
- * Keyed on the IRC network's HOST — NOT a local network row id. A networkId is
- * per-account, so two users of the same instance on the same channel would
- * otherwise derive different rooms and never connect. Hosts are shared across
- * users, and across *instances* pointed at a common SFU — so a host key is also
- * what makes opt-in cross-instance bridging Just Work.
+ * Keyed on the IRC network's HOST — NOT a local network row id, and NOT the
+ * 005 NETWORK token. A networkId is per-account, so two users of the same
+ * instance on the same channel would otherwise derive different rooms and
+ * never connect. The NETWORK token is *self-declared by the IRC server*: keying
+ * on it would let anyone point a Lurker network at a hostile server claiming
+ * `NETWORK=Libera`, "join" #dev there, and mint a token for the real Libera
+ * channel's room. The host is the one key that is both shared across users and
+ * anchored to where the membership check actually ran. The trade-off (accepted,
+ * documented in SELF_HOSTING): users must configure the SAME hostname — DNS
+ * aliases like irc.libera.chat vs irc.eu.libera.chat derive different rooms.
  *
  *  - Channel `#dev` on irc.libera.chat → `net-irc.libera.chat-c-#dev`
- *  - DM `Alice`↔`bob`                  → `net-irc.libera.chat-d-alice-bob` (sorted, either end)
+ *  - DM `Alice`↔`bob`                  → `net-irc.libera.chat-d-alice:bob` (sorted, either end)
+ *
+ * The DM pair is joined with `:` — impossible in an IRC nick (it's the wire
+ * framing delimiter), where `-` is legal and made distinct pairs collide:
+ * ('john-w','ork') and ('john','w-ork') must NOT share a room, or minting a DM
+ * token becomes a way to listen in on someone else's call.
  *
  * `self` is the caller's own nick on the network; it is only consulted for DMs,
  * where it is paired with `target` and sorted so both ends agree on one room.
+ * Callers should pass `target`/`self` already folded with the network's
+ * declared CASEMAPPING (see routes/voice.ts) so rfc1459 spelling variants of
+ * one channel agree on one room; the ASCII fold here is the floor, not the
+ * whole rule.
  */
 export function roomFor(networkKey: string, target: string, self: string): string {
   const net = foldAscii(networkKey);
@@ -96,7 +101,7 @@ export function roomFor(networkKey: string, target: string, self: string): strin
   const a = foldAscii(self);
   const b = foldAscii(target);
   const [lo, hi] = a <= b ? [a, b] : [b, a];
-  return `net-${net}-d-${lo}-${hi}`;
+  return `net-${net}-d-${lo}:${hi}`;
 }
 
 export interface MintedToken {

--- a/vue_client/package-lock.json
+++ b/vue_client/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.3.1",
         "@simplewebauthn/browser": "^13.3.0",
+        "livekit-client": "^2.21.0",
         "pinia": "^4.0.2",
         "vue": "^3.5.40",
         "vue-router": "^5.2.0",
@@ -136,6 +137,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -237,6 +244,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -567,6 +589,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
@@ -1108,6 +1137,15 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
@@ -1228,6 +1266,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-beautify": {
@@ -1533,6 +1580,26 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.21.0.tgz",
+      "integrity": "sha512-RBUhPkV/sl1nzl8lokVlK5uATPwn0AlsudCBZXissw/kDl9yz8ac4pNJ43iPpMVoHOeBYH/BZ3vUC1adqa/zFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.50.4",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "9.0.6"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
@@ -1548,6 +1615,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/lru-cache": {
@@ -1924,11 +2004,36 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scule": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
       "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -2131,8 +2236,16 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -2463,6 +2576,19 @@
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "license": "MIT"
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/vue_client/package.json
+++ b/vue_client/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.3.1",
     "@simplewebauthn/browser": "^13.3.0",
+    "livekit-client": "^2.21.0",
     "pinia": "^4.0.2",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0",

--- a/vue_client/src/App.vue
+++ b/vue_client/src/App.vue
@@ -10,6 +10,7 @@
   </div>
   <ToastContainer />
   <ContextMenu />
+  <CallBar />
 </template>
 
 <script setup lang="ts">
@@ -21,6 +22,7 @@ import { useTheme } from './composables/useTheme.js';
 import ToastContainer from './components/ToastContainer.vue';
 import ContextMenu from './components/ContextMenu.vue';
 import PausedBanner from './components/PausedBanner.vue';
+import CallBar from './components/CallBar.vue';
 
 const auth = useAuthStore();
 const settings = useSettingsStore();

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -1,0 +1,176 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Persistent floating voice-call panel. Mounted once globally in App.vue (reads
+  the singleton voice store), so an active call survives buffer switches and
+  the Desktop<->Mobile shell swap. Shows who's in the call, who's speaking, a
+  per-participant volume slider, and mute/leave controls.
+-->
+
+<template>
+  <div
+    v-if="voice.active || voice.connecting"
+    class="call-bar"
+    role="dialog"
+    aria-label="Voice call"
+  >
+    <div class="call-head">
+      <span class="dot" :class="{ live: voice.active }" aria-hidden="true"></span>
+      <span class="call-title">{{ voice.label || 'Voice call' }}</span>
+      <span class="call-status">{{ voice.connecting ? 'connecting…' : 'connected' }}</span>
+    </div>
+
+    <div class="call-body">
+      <ul v-if="voice.participants.length" class="call-parts">
+        <li v-for="id in voice.participants" :key="id">
+          <div class="part-row" :class="{ talking: voice.speaking.includes(id) }">
+            <i
+              class="fa-solid"
+              :class="voice.speaking.includes(id) ? 'fa-volume-high' : 'fa-user'"
+              aria-hidden="true"
+            ></i>
+            <span class="part-nick" :title="id">{{ id }}</span>
+          </div>
+          <input
+            class="vol"
+            type="range"
+            min="0"
+            max="100"
+            :value="volPct(id)"
+            :aria-label="`Volume for ${id}`"
+            @input="onVol(id, $event)"
+          />
+        </li>
+      </ul>
+      <p v-else class="call-empty">Just you so far…</p>
+    </div>
+
+    <div class="call-actions">
+      <IconButton
+        :icon="voice.muted ? 'fa-microphone-slash' : 'fa-microphone'"
+        :label="voice.muted ? 'Unmute' : 'Mute'"
+        :danger="voice.muted"
+        @click="voice.toggleMute()"
+      />
+      <IconButton icon="fa-phone-slash" label="Leave call" danger @click="voice.leave()" />
+    </div>
+
+    <p v-if="voice.error" class="call-error">{{ voice.error }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useVoiceStore } from '../stores/voice.js';
+import IconButton from './IconButton.vue';
+
+const voice = useVoiceStore();
+
+function volPct(id: string): number {
+  return Math.round((voice.volumes[id] ?? 1) * 100);
+}
+function onVol(id: string, e: Event) {
+  voice.setVolume(id, Number((e.target as HTMLInputElement).value) / 100);
+}
+</script>
+
+<style scoped>
+.call-bar {
+  position: fixed;
+  right: var(--space-6);
+  bottom: var(--space-6);
+  z-index: var(--z-popover);
+  display: flex;
+  flex-direction: column;
+  width: 240px;
+  max-width: calc(100vw - var(--space-9));
+  max-height: 50vh;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-popover);
+}
+.call-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--fg-muted);
+  flex: 0 0 auto;
+}
+.dot.live {
+  background: var(--good);
+}
+.call-title {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.call-status {
+  margin-left: auto;
+  color: var(--fg-muted);
+}
+.call-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--space-3) var(--space-4);
+  min-height: 0;
+}
+.call-parts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.call-parts li {
+  padding: var(--space-1) 0;
+}
+.part-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.part-row i {
+  color: var(--fg-muted);
+}
+.part-row.talking i,
+.part-row.talking .part-nick {
+  color: var(--accent);
+}
+.part-nick {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.vol {
+  width: 100%;
+  margin: var(--space-1) 0 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+.call-empty {
+  margin: 0;
+  color: var(--fg-muted);
+}
+.call-actions {
+  display: flex;
+  justify-content: space-around;
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border);
+}
+.call-error {
+  margin: 0;
+  padding: 0 var(--space-4) var(--space-3);
+  color: var(--bad);
+}
+</style>

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -11,8 +11,10 @@
 -->
 
 <template>
+  <!-- Also rendered when only an error remains: a failed call must say WHY
+       (403/503, SFU unreachable, mic denied) instead of silently vanishing. -->
   <div
-    v-if="voice.active || voice.connecting"
+    v-if="voice.active || voice.connecting || voice.error"
     class="call-bar"
     role="dialog"
     aria-label="Voice call"
@@ -20,10 +22,16 @@
     <div class="call-head">
       <span class="dot" :class="{ live: voice.active }" aria-hidden="true"></span>
       <span class="call-title">{{ voice.label || 'Voice call' }}</span>
-      <span class="call-status">{{ voice.connecting ? 'connecting…' : 'connected' }}</span>
+      <span class="call-status">{{ statusText }}</span>
+      <IconButton
+        v-if="!voice.active && !voice.connecting"
+        icon="fa-xmark"
+        label="Dismiss"
+        @click="voice.clearError()"
+      />
     </div>
 
-    <div class="call-body">
+    <div v-if="voice.active || voice.connecting" class="call-body">
       <ul v-if="voice.participants.length" class="call-parts">
         <li v-for="id in voice.participants" :key="id">
           <div class="part-row" :class="{ talking: voice.speaking.includes(id) }">
@@ -48,7 +56,7 @@
       <p v-else class="call-empty">Just you so far…</p>
     </div>
 
-    <div class="call-actions">
+    <div v-if="voice.active || voice.connecting" class="call-actions">
       <IconButton
         :icon="voice.muted ? 'fa-microphone-slash' : 'fa-microphone'"
         :label="voice.muted ? 'Unmute' : 'Mute'"
@@ -63,10 +71,17 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useVoiceStore } from '../stores/voice.js';
 import IconButton from './IconButton.vue';
 
 const voice = useVoiceStore();
+
+const statusText = computed(() => {
+  if (voice.connecting) return 'connecting…';
+  if (voice.active) return 'connected';
+  return 'call failed';
+});
 
 function volPct(id: string): number {
   return Math.round((voice.volumes[id] ?? 1) * 100);

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -93,7 +93,7 @@ function startCall() {
   const b = buffer.value;
   if (!b || b.networkId == null) return;
   // label = the channel target; the store mints its own token + room.
-  voice.startCall(b.networkId, b.target, b.target);
+  void voice.startCall(b.networkId, b.target, b.target);
 }
 const selfNick = computed(() => {
   const b = buffer.value;

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -5,6 +5,18 @@
 
 <template>
   <div class="members">
+    <div v-if="canCall" class="members-head">
+      <button
+        type="button"
+        class="call-btn"
+        :disabled="voice.connecting || voice.active"
+        :title="inThisCall ? 'You are in this call' : 'Start or join a voice call in this channel'"
+        @click="startCall"
+      >
+        <i class="fa-solid fa-phone" aria-hidden="true"></i>
+        <span>{{ inThisCall ? 'In call' : 'Call' }}</span>
+      </button>
+    </div>
     <ul ref="listEl">
       <li
         v-for="m in sorted"
@@ -45,6 +57,8 @@ import { useBuffersStore, type BufferMember } from '../stores/buffers.js';
 import { useNickColors } from '../composables/useNickColors.js';
 import { useMemberActions } from '../composables/useMemberActions.js';
 import { useIgnoresStore } from '../stores/ignores.js';
+import { useConfigStore } from '../stores/config.js';
+import { useVoiceStore } from '../stores/voice.js';
 import {
   PREFIX_ORDER,
   prefixOf as modePrefixOf,
@@ -62,6 +76,25 @@ const listEl = ref<HTMLElement | null>(null);
 
 const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
 const members = computed((): BufferMember[] => buffer.value?.members || []);
+
+// ─── Voice call (channels only, and only when the instance offers it) ────────
+const config = useConfigStore();
+const voice = useVoiceStore();
+const canCall = computed(
+  () => config.voiceEnabled && buffer.value?.kind === 'channel' && buffer.value?.networkId != null,
+);
+const inThisCall = computed(
+  () =>
+    voice.active &&
+    voice.networkId === (buffer.value?.networkId ?? null) &&
+    voice.target === buffer.value?.target,
+);
+function startCall() {
+  const b = buffer.value;
+  if (!b || b.networkId == null) return;
+  // label = the channel target; the store mints its own token + room.
+  voice.startCall(b.networkId, b.target, b.target);
+}
 const selfNick = computed(() => {
   const b = buffer.value;
   if (!b || b.networkId == null) return null;
@@ -190,6 +223,18 @@ const sorted = computed(() => {
   flex-direction: column;
   height: 100%;
   min-height: 0;
+}
+.members-head {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+/* Layout only — color/border/disabled come from the global button language. */
+.call-btn {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
 }
 ul {
   list-style: none;

--- a/vue_client/src/components/MessageAttachment.test.ts
+++ b/vue_client/src/components/MessageAttachment.test.ts
@@ -113,7 +113,7 @@ function seedSettings({ inlineMedia = true, linkPreviews = true, feature = true 
   // The instance feature flag gates both user settings — a stored `true` must not render on an
   // instance that has the feature off, where the routes aren't even mounted. Defaults on here so
   // the suite is about the user settings; `feature: false` covers the gate itself.
-  useConfigStore().features = { linkPreviews: feature };
+  useConfigStore().features = { linkPreviews: feature, voice: false };
   const settings = useSettingsStore();
   // Real store values rather than a mocked getter: `effective` is a Pinia getter returning a
   // closure, so it can't be spied — and seeding state exercises the same lookup the app does.
@@ -935,7 +935,7 @@ describe('MessageAttachments — the lightbox is a gallery over the strip', () =
     for (const n of [1, 2]) resolved.set(img(n).url, img(n));
     // Hand-built rather than via seedSettings because this one needs image_modal OFF.
     setActivePinia(createPinia());
-    useConfigStore().features = { linkPreviews: true };
+    useConfigStore().features = { linkPreviews: true, voice: false };
     const settings = useSettingsStore();
     settings.values = {
       'chat.inline_media.enabled': true,

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -3123,7 +3123,7 @@ function handleCommand(line: string, networkId: number | null, target: string): 
         localInfo(networkId, target, `already in a call (${voice.label}) — /hangup first`);
         return true;
       }
-      voice.startCall(networkId, target, target);
+      void voice.startCall(networkId, target, target);
       return true;
     }
     case 'hangup': {

--- a/vue_client/src/components/MessageInput.vue
+++ b/vue_client/src/components/MessageInput.vue
@@ -166,6 +166,7 @@ import { useDraftStore } from '../stores/drafts.js';
 import { useSettingsStore } from '../stores/settings.js';
 import { useUploadsStore, onInsertUrl } from '../stores/uploads.js';
 import { useDccStore, percentReceived, type DccTransfer } from '../stores/dcc.js';
+import { useVoiceStore } from '../stores/voice.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { useIgnoresStore, type IgnoreEntry } from '../stores/ignores.js';
 import { useRelayBotsStore } from '../stores/relayBots.js';
@@ -2365,6 +2366,8 @@ const COMMANDS_LINES = [
   '      modify <name> [-flags…]   ·   remove <name>   ·   move <name> <position>',
   '      connect <name>   ·   disconnect <name>   (Lurker folds irssi /server into these)',
   '  /dcc [list]            — DCC downloads: list, or accept/reject/cancel <id>',
+  '  /call                  — start/join a voice call in this channel or DM (if enabled)',
+  '  /hangup                — leave the current voice call',
   '      e.g. /dcc   ·   /dcc accept 3   ·   /dcc reject 3   ·   /dcc cancel 3',
   '  /set <key> <value…>    — change a setting; /set (or /set ?) lists all keys',
   '  /get <key>             — read a setting back (output in the system buffer)',
@@ -3103,6 +3106,35 @@ function handleCommand(line: string, networkId: number | null, target: string): 
       // the buffer when it settles.
       void runDcc(argLine, networkId, target);
       return true;
+    case 'call': {
+      // Start/join a voice call in the current channel or DM buffer. This is
+      // the only DM entry point (the member-list button is channels-only), per
+      // the slash-command-first ethos: the button is a view of this verb.
+      const voice = useVoiceStore();
+      if (!config.voiceEnabled) {
+        localInfo(networkId, target, 'voice calls are not enabled on this server');
+        return true;
+      }
+      if (networkId == null || target.startsWith(':server:')) {
+        localInfo(networkId, target, 'usage: /call — in a channel or DM buffer');
+        return true;
+      }
+      if (voice.active || voice.connecting) {
+        localInfo(networkId, target, `already in a call (${voice.label}) — /hangup first`);
+        return true;
+      }
+      voice.startCall(networkId, target, target);
+      return true;
+    }
+    case 'hangup': {
+      const voice = useVoiceStore();
+      if (!voice.active && !voice.connecting) {
+        localInfo(networkId, target, 'not in a call');
+        return true;
+      }
+      void voice.leave();
+      return true;
+    }
     case 'theme':
       // Theme presets. App-scoped like /set; async like /dcc.
       void runTheme(argLine, networkId, target);

--- a/vue_client/src/composables/useSocket.previewToggles.test.ts
+++ b/vue_client/src/composables/useSocket.previewToggles.test.ts
@@ -56,7 +56,7 @@ const RouteView = defineComponent({
 
 function seed({ inlineMedia = false, linkPreviews = false } = {}) {
   setActivePinia(createPinia());
-  useConfigStore().features = { linkPreviews: true };
+  useConfigStore().features = { linkPreviews: true, voice: false };
   const settings = useSettingsStore();
   settings.values = {
     'chat.inline_media.enabled': inlineMedia,

--- a/vue_client/src/stores/config.ts
+++ b/vue_client/src/stores/config.ts
@@ -16,6 +16,7 @@ export type Edition = 'standalone' | 'node';
  *  a flag doesn't have the feature. */
 export interface Features {
   linkPreviews: boolean;
+  voice: boolean;
 }
 
 // Shared in-flight fetch so concurrent callers — App.vue's boot fetch and the
@@ -30,7 +31,7 @@ export const useConfigStore = defineStore('config', {
     // ⚠ Defaults to OFF, unlike `edition`, which defaults to the fully-featured value. A fetch
     // failure must not conjure a feature the server may not have: guessing "on" here would show
     // the two settings and then have every resolve 404.
-    features: { linkPreviews: false } as Features,
+    features: { linkPreviews: false, voice: false } as Features,
     checked: false,
   }),
   getters: {
@@ -38,6 +39,9 @@ export const useConfigStore = defineStore('config', {
     isNode: (s): boolean => s.edition === 'node',
     /** Whether this instance has link previews / inline media enabled at all. */
     linkPreviews: (s): boolean => s.features.linkPreviews === true,
+    /** Whether this instance offers voice calls (operator opt-in + a configured
+     *  LiveKit SFU). False hides every call affordance. */
+    voiceEnabled: (s): boolean => s.features.voice === true,
   },
   actions: {
     async fetch(): Promise<Edition> {
@@ -47,7 +51,10 @@ export const useConfigStore = defineStore('config', {
         try {
           const data = await api<{ edition?: string; features?: Partial<Features> }>('/api/config');
           this.edition = data.edition === 'node' ? 'node' : 'standalone';
-          this.features = { linkPreviews: data.features?.linkPreviews === true };
+          this.features = {
+            linkPreviews: data.features?.linkPreviews === true,
+            voice: data.features?.voice === true,
+          };
           // Latch `checked` ONLY on success. A transient failure must not wedge
           // the session on the safe defaults — leaving it false lets the next
           // caller retry and self-heal. That second caller is the router guard,

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -102,8 +102,12 @@ export const useVoiceStore = defineStore('voice', {
           });
 
         await r.connect(url, token);
-        await r.localParticipant.setMicrophoneEnabled(true);
+        // Hold the handle BEFORE enabling the mic: if the user denies mic
+        // permission, the catch's cleanup() must still disconnect this
+        // already-joined room — otherwise they stay in the call as a ghost
+        // participant with no UI to leave.
         room = r;
+        await r.localParticipant.setMicrophoneEnabled(true);
         this.active = true;
         this.muted = false;
         this.error = null;
@@ -132,8 +136,20 @@ export const useVoiceStore = defineStore('voice', {
 
     async toggleMute() {
       if (!room) return;
-      this.muted = !this.muted;
-      await room.localParticipant.setMicrophoneEnabled(!this.muted);
+      // Flip state only after the SFU confirms. An optimistic flip that then
+      // rejects (device error, mid-reconnect) would render the mic-slash icon
+      // while the track is still transmitting — the worst kind of wrong.
+      const wantMuted = !this.muted;
+      try {
+        await room.localParticipant.setMicrophoneEnabled(!wantMuted);
+        this.muted = wantMuted;
+      } catch (e: unknown) {
+        this.error = e instanceof Error ? e.message : 'could not toggle mute';
+      }
+    },
+
+    clearError() {
+      this.error = null;
     },
 
     async leave() {

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Voice call session for the web client. The browser IS the WebRTC engine here,
+// so this is thin: get a room-scoped token from /api/voice/token, connect the
+// LiveKit room, publish the mic, and play remote audio through hidden <audio>
+// elements.
+//
+// Bundle bloat, addressed: livekit-client is ~500 KB and voice is off by default
+// on most instances, so it is pulled in with a dynamic import() inside the
+// connect path — Vite splits it into its own chunk fetched only at first call.
+//
+// The Room and all Track/element handles are held module-scoped, NOT in Pinia
+// state: they are non-serializable and must not be wrapped in Vue's reactive
+// proxy, which would break livekit's object identity. State carries only the
+// primitives the UI renders.
+
+import { defineStore } from 'pinia';
+import type { Room, RemoteTrack, RemoteAudioTrack, Participant } from 'livekit-client';
+import { api } from '../api.js';
+
+interface VoiceTokenResponse {
+  token: string;
+  room: string;
+  url: string;
+}
+
+// Non-reactive session handles (see header note).
+let room: Room | null = null;
+let audioEls: HTMLAudioElement[] = [];
+// identity → remote MIC track, for per-participant volume.
+let tracksByIdentity = new Map<string, RemoteAudioTrack>();
+
+export const useVoiceStore = defineStore('voice', {
+  state: () => ({
+    active: false,
+    connecting: false,
+    muted: false,
+    // Human label for what's being called, e.g. "#dev".
+    label: '',
+    // The channel/DM this call belongs to, so UI can tell "in THIS call" from
+    // "in a call somewhere else".
+    networkId: null as number | null,
+    target: '',
+    // Remote participant identities (their IRC nicks).
+    participants: [] as string[],
+    // Subset of `participants` currently detected as speaking.
+    speaking: [] as string[],
+    // Per-identity local playback volume, 0..1 (default 1 when absent).
+    volumes: {} as Record<string, number>,
+    error: null as string | null,
+  }),
+  actions: {
+    /** Mint a token for a channel/DM on a network, then connect the room. */
+    async startCall(networkId: number, target: string, label: string) {
+      if (this.active || this.connecting) return;
+      this.connecting = true;
+      this.error = null;
+      this.label = label;
+      this.networkId = networkId;
+      this.target = target;
+      try {
+        // Token first, so a 503/403/409 fails fast without paying to load the SDK.
+        const { token, url } = await api<VoiceTokenResponse>('/api/voice/token', {
+          method: 'POST',
+          body: { networkId, target },
+        });
+
+        // Lazy chunk: livekit-client only lands over the network at first call.
+        const { Room, RoomEvent, Track } = await import('livekit-client');
+
+        const r = new Room({ adaptiveStream: true, dynacast: true });
+        r.on(RoomEvent.TrackSubscribed, (track: RemoteTrack, pub, participant) => {
+          if (track.kind !== Track.Kind.Audio) return; // video: PR'd separately
+          const audio = track as RemoteAudioTrack;
+          // Attach ALL audio so it plays, but only bind the per-participant
+          // volume slider to the mic track (a native client may also send
+          // screen-share audio, which shares the participant identity).
+          const el = audio.attach() as HTMLAudioElement;
+          el.autoplay = true;
+          document.body.appendChild(el);
+          audioEls.push(el);
+          if (String(pub.source) === 'microphone') {
+            tracksByIdentity.set(participant.identity, audio);
+            const stored = this.volumes[participant.identity];
+            if (stored != null) audio.setVolume(stored);
+          }
+        })
+          .on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack, _pub, participant) => {
+            if (track.kind !== Track.Kind.Audio) return;
+            tracksByIdentity.delete(participant.identity);
+            track.detach().forEach((el) => el.remove());
+          })
+          .on(RoomEvent.ParticipantConnected, () => this.syncParticipants())
+          .on(RoomEvent.ParticipantDisconnected, () => this.syncParticipants())
+          .on(RoomEvent.ActiveSpeakersChanged, (speakers: Participant[]) => {
+            const self = r.localParticipant.identity;
+            this.speaking = speakers.map((p) => p.identity).filter((id) => id !== self);
+          })
+          .on(RoomEvent.Disconnected, () => {
+            void this.cleanup();
+          });
+
+        await r.connect(url, token);
+        await r.localParticipant.setMicrophoneEnabled(true);
+        room = r;
+        this.active = true;
+        this.muted = false;
+        this.error = null;
+        this.syncParticipants();
+      } catch (e: unknown) {
+        this.error = e instanceof Error ? e.message : 'could not start call';
+        await this.cleanup();
+      } finally {
+        this.connecting = false;
+      }
+    },
+
+    syncParticipants() {
+      this.participants = room
+        ? Array.from(room.remoteParticipants.values()).map((p) => p.identity)
+        : [];
+    },
+
+    /** Set a remote participant's local playback volume (0..1). Kept in state so
+     *  it survives a track re-subscribe within the same session. */
+    setVolume(identity: string, volume: number) {
+      const v = Math.max(0, Math.min(1, volume));
+      this.volumes[identity] = v;
+      tracksByIdentity.get(identity)?.setVolume(v);
+    },
+
+    async toggleMute() {
+      if (!room) return;
+      this.muted = !this.muted;
+      await room.localParticipant.setMicrophoneEnabled(!this.muted);
+    },
+
+    async leave() {
+      await this.cleanup();
+    },
+
+    async cleanup() {
+      if (room) {
+        try {
+          await room.disconnect();
+        } catch {
+          /* already gone */
+        }
+        room = null;
+      }
+      audioEls.forEach((el) => el.remove());
+      audioEls = [];
+      tracksByIdentity = new Map();
+      this.active = false;
+      this.connecting = false;
+      this.muted = false;
+      this.participants = [];
+      this.speaking = [];
+      this.volumes = {};
+      this.networkId = null;
+      this.target = '';
+    },
+  },
+});

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -86,10 +86,15 @@ export const useVoiceStore = defineStore('voice', {
             if (stored != null) audio.setVolume(stored);
           }
         })
-          .on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack, _pub, participant) => {
+          .on(RoomEvent.TrackUnsubscribed, (track: RemoteTrack, pub, participant) => {
             if (track.kind !== Track.Kind.Audio) return;
-            tracksByIdentity.delete(participant.identity);
-            track.detach().forEach((el) => el.remove());
+            // Only the mic unsubscribing clears the volume mapping — a
+            // participant can also carry screen-share audio, and losing THAT
+            // must not orphan their volume slider.
+            if (String(pub.source) === 'microphone') tracksByIdentity.delete(participant.identity);
+            const detached = track.detach();
+            detached.forEach((el) => el.remove());
+            audioEls = audioEls.filter((el) => !detached.includes(el));
           })
           .on(RoomEvent.ParticipantConnected, () => this.syncParticipants())
           .on(RoomEvent.ParticipantDisconnected, () => this.syncParticipants())


### PR DESCRIPTION
First slice of the voice/video call stack planned in VOICE_CALLS_PR_PLAN.md, rebuilt from @JawshTheDark's #680 (thank you — the architecture survives intact; this re-cut adapts it to post-fork main and our conventions).

## What this adds

- **Server = token authority only.** `services/voice.ts` mints room-scoped LiveKit JWTs (2h, join/publish/subscribe on exactly one room). Media never touches Lurker — it flows through a self-hosted LiveKit SFU, bundled in docker-compose behind `--profile voice`, inert by default.
- **`POST /api/voice/token`** gated in order: 503 voice disabled → 400 bad args → 404 network not owned → 409 not connected → 403 channel not joined (via `isChannelJoined`, the casemapping-correct probe). DMs skip the membership gate — opening the call is the invite.
- **Rooms keyed on the IRC network host** (`net-<host>-c-#dev`), DM rooms on the casemapping-folded, `:`-joined sorted nick pair. See the `roomFor` doc comment for why host (not networkId, not the self-declared 005 NETWORK token) is the only safe key.
- **Web client:** `features.voice` config flag, audio-only floating CallBar (participants, speaking indicator, per-user volume, mute/leave, visible+dismissible failure state), member-list Call button, and `/call` + `/hangup` slash commands (the DM entry point).
- **Bundle:** `livekit-client` rides a dynamic `import()` — verified in the build: 489 KB lazy chunk, main bundle unchanged for non-voice instances.
- **Docs:** CLIENT_PROTOCOL voice section (token contract + room naming for third-party clients), SELF_HOSTING operator section with the honest caveats (SFU ≠ P2P, NAT/TURN, exact-host room keys, 2h token window, DM nick-transfer trust note).

## Differences from the reference branch worth knowing

- `conn.channels.has()` → `isChannelJoined()` (the post-#707 membership authority), and room inputs are folded with the network's declared CASEMAPPING so the gate and the room key can't diverge on rfc1459 variants.
- DM pair delimiter is `:` (illegal in nicks); the reference's `-` allowed distinct pairs to collide onto one room — regression-tested.
- CSS rebuilt on the real token system (the reference's invented vars rendered hardcoded dark fallbacks; light theme was broken).
- Route tests cover 409/403/happy-path/DM via the house fakeManager mock; the service test decodes the JWT and asserts the grant is room-scoped.

Follow-ups per the plan: PR 2 moderation + join policy + call presence (incl. the SFU webhook config the reference compose was missing), PR 3 guest links, PR 4 video + screen share.

Full `npm run check` + 3,850 tests green; /code-review (high) run and all 10 findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)