### PR TITLE
Voice moderation, join policy, and call presence (slice 2 of #680)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,8 +98,21 @@ services:
     profiles: ['voice']
     command: --dev --node-ip=127.0.0.1
     environment:
-      # `key: secret` pairs. Keep in lockstep with the lurker service vars.
-      - 'LIVEKIT_KEYS=devkey: replace-me-with-a-long-random-secret'
+      # Inline LiveKit config. The `keys` pair must stay in lockstep with the
+      # LIVEKIT_API_KEY / LIVEKIT_API_SECRET vars on the lurker service. The
+      # `webhook` block is what makes live "Join call (N)" badges work: LiveKit
+      # posts signed room events to Lurker at the URL below (`lurker` is the
+      # compose service name — adjust if you renamed it or run the SFU
+      # elsewhere). Without it, calls still work but presence only refreshes
+      # on reconnect.
+      - |
+        LIVEKIT_CONFIG=
+        keys:
+          devkey: replace-me-with-a-long-random-secret
+        webhook:
+          api_key: devkey
+          urls:
+            - http://lurker:8015/api/voice/webhook
     ports:
       - '7880:7880' # signaling (WebSocket + HTTP)
       - '7881:7881' # WebRTC over TCP (ICE/TCP fallback)

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1140,11 +1140,13 @@ POST /moderate                 { networkId, target, action: mute|remove,
 `/presence` is the connect-time snapshot behind the `call-presence` frame
 (§7.1) — call it per connected network on every socket (re)connect. A token
 mint is gated by the channel's `minJoinMode` (403 with a human-readable
-`error` when below the bar). `mute` is a server-side mute of every published
-track (the target cannot self-unmute); `remove` kicks them from the room and
-invalidates re-joining on the same token. `POST /webhook` also lives under
-`/api/voice` but is LiveKit↔Lurker internal (signature-authenticated) — never
-call it from a client.
+`error` when below the bar; unknown modes on PUT are a 400, never coerced).
+`mute` is a server-side mute of every published track (the target cannot
+self-unmute); `remove` ejects them from the room — after which your client
+must NOT auto-reconnect that call (on self-hosted LiveKit the token itself
+stays valid until expiry, so honouring the removal is the client's job).
+`POST /webhook` also lives under `/api/voice` but is LiveKit↔Lurker internal
+(signature-authenticated) — never call it from a client.
 
 ### Export / import
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1141,10 +1141,12 @@ POST /moderate                 { networkId, target, action: mute|remove,
 (§7.1) — call it per connected network on every socket (re)connect. A token
 mint is gated by the channel's `minJoinMode` (403 with a human-readable
 `error` when below the bar; unknown modes on PUT are a 400, never coerced).
-`mute` is a server-side mute of every published track (the target cannot
-self-unmute); `remove` ejects them from the room — after which your client
-must NOT auto-reconnect that call (on self-hosted LiveKit the token itself
-stays valid until expiry, so honouring the removal is the client's job).
+`mute` server-mutes every published track — on self-hosted LiveKit this is
+advisory (the target CAN self-unmute; surface the mute to your user rather
+than pretending it's a lock). `remove` ejects them from the room — after
+which your client must NOT auto-reconnect that call (on self-hosted LiveKit
+the token itself stays valid until expiry, so honouring the removal is the
+client's job).
 `POST /webhook` also lives under `/api/voice` but is LiveKit↔Lurker internal
 (signature-authenticated) — never call it from a client.
 

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -657,6 +657,7 @@ a v1 client.
 | `chanlist-state` / `chanlist-result`                                                                                             | `/LIST` cache meta / result page                                                                                                                                                                                                                                                                                                                                                                            | Channel browser                                                                                                                                           |
 | `e2eExport` / `e2eImport`                                                                                                        | E2E key material / import result                                                                                                                                                                                                                                                                                                                                                                            | Replies, this socket only                                                                                                                                 |
 | `dcc-transfer`                                                                                                                   | full transfer row (snake_case)                                                                                                                                                                                                                                                                                                                                                                              | DCC state changes                                                                                                                                         |
+| `call-presence`                                                                                                                  | `networkId, target, active, count` — a voice call's participant count in a channel you've joined changed. `target` is in your connection's own spelling. Deltas only: re-snapshot via `GET /api/voice/presence` on every (re)connect, or a call that started while you had no socket never badges. Channels only — DM calls broadcast no presence                                                           | Voice-enabled instances, on SFU join/leave                                                                                                                |
 | `upload-progress`                                                                                                                | `token, phase, destination, percent`                                                                                                                                                                                                                                                                                                                                                                        | During REST upload (correlate via `progressToken`)                                                                                                        |
 | `export`                                                                                                                         | `job`                                                                                                                                                                                                                                                                                                                                                                                                       | Export job progress                                                                                                                                       |
 | `error`                                                                                                                          | `text`                                                                                                                                                                                                                                                                                                                                                                                                      | Non-fatal; also the reply to unknown verbs                                                                                                                |
@@ -1127,6 +1128,23 @@ nick are folded with the network's declared CASEMAPPING, the host ASCII-folded
 — so every member of a channel lands in the same room, even from another
 Lurker instance sharing the SFU. The host string must match **exactly** across
 users: different DNS aliases of one network derive different rooms.
+
+```
+GET  /presence?networkId       → { calls: [{ target, count }] }
+GET  /policy?networkId&target  → { minJoinMode }        none|voice|halfop|op
+PUT  /policy                   { networkId, target, minJoinMode }   ops (q/a/o)
+POST /moderate                 { networkId, target, action: mute|remove,
+                                 identity }             channel q/a/o/h only
+```
+
+`/presence` is the connect-time snapshot behind the `call-presence` frame
+(§7.1) — call it per connected network on every socket (re)connect. A token
+mint is gated by the channel's `minJoinMode` (403 with a human-readable
+`error` when below the bar). `mute` is a server-side mute of every published
+track (the target cannot self-unmute); `remove` kicks them from the room and
+invalidates re-joining on the same token. `POST /webhook` also lives under
+`/api/voice` but is LiveKit↔Lurker internal (signature-authenticated) — never
+call it from a client.
 
 ### Export / import
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -345,11 +345,13 @@ docker compose --profile voice up -d
 
 `LIVEKIT_API_KEY`/`SECRET` must match the `LIVEKIT_KEYS` pair on the `livekit` service — that shared secret is how Lurker signs call tokens the SFU trusts. `LIVEKIT_WS_URL` is the address **clients** connect to: `ws://<lan-ip>:7880` on a LAN, or `wss://` behind your TLS proxy for the public internet (put only the signaling port behind the proxy; media flows over UDP 7882 directly). Set the LiveKit `--node-ip` flag to an address clients can actually reach, and see the [LiveKit deployment docs](https://docs.livekit.io/home/self-hosting/deployment/) for TURN setup.
 
-Everyone in a channel can join that channel's call — from the button atop the member list, or with `/call` in the buffer. A DM call is `/call` in the DM: both sides join the same room, but nothing "rings" yet — tell the other person to `/call` you back (in-call presence indicators are planned as a follow-up). Call rooms are derived from the IRC server **hostname**, so users who should share calls must configure the _same_ host: `irc.libera.chat` and `irc.eu.libera.chat` are different rooms even though they're the same network.
+Everyone in a channel can join that channel's call — from the button atop the member list, or with `/call` in the buffer. When a channel call is in progress, everyone else in the channel sees a live **"Join call (N)"** count on that button (this needs the `webhook` block in the compose config above — without it, counts only refresh on reconnect). A DM call is `/call` in the DM: both sides join the same room, but DMs don't ring or badge — tell the other person to `/call` you back. Call rooms are derived from the IRC server **hostname**, so users who should share calls must configure the _same_ host: `irc.libera.chat` and `irc.eu.libera.chat` are different rooms even though they're the same network.
+
+Channel operators get call controls that mirror their IRC standing: ops and halfops (`q/a/o/h`) can server-mute or remove anyone from the channel's call (removal also invalidates their token — the answer to "kicked but still in the call"), and full ops (`q/a/o`) can restrict who may join the call at all (anyone / voiced+ / halfop+ / ops) from the picker under the Call button.
 
 Two trust caveats, both in line with IRC's own model — fine among people you already trust:
 
-- Channel membership is checked **when the call token is issued**, and tokens last 2 hours. Someone kicked or banned mid-call can rejoin the room on their existing token until it expires (op-side call moderation is planned as a follow-up).
+- Channel membership and the join policy are checked **when the call token is issued**, and tokens last 2 hours. Someone kicked or banned mid-call keeps their token until an op removes them from the call (or it expires).
 - DM call rooms are named by the two nicks, and IRC nicks are transferable: on networks without nick registration, someone who takes an offline person's nick could join a call room under that name.
 
 Disabling voice (removing the env vars) makes every call affordance disappear from clients; browsers only download the WebRTC code the first time someone actually joins a call.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -352,6 +352,7 @@ Channel operators get call controls that mirror their IRC standing: ops and half
 Two trust caveats, both in line with IRC's own model — fine among people you already trust:
 
 - Channel membership and the join policy are checked **when the call token is issued**, and tokens last 2 hours. Removing someone from a call ejects them now, but on self-hosted LiveKit it does **not** invalidate their token: Lurker's own clients won't rejoin after a removal, yet someone determined enough to use a raw LiveKit client can reconnect until the token expires. (Instant revocation on removal is a LiveKit Cloud feature.)
+- Likewise an op's **mute is a strong nudge, not a lock**: the muted person sees "a channel operator muted your microphone" but self-hosted LiveKit lets them unmute themselves. If someone won't stay muted, remove them — that's the enforcement tool.
 - DM call rooms are named by the two nicks, and IRC nicks are transferable: on networks without nick registration, someone who takes an offline person's nick could join a call room under that name.
 
 Disabling voice (removing the env vars) makes every call affordance disappear from clients; browsers only download the WebRTC code the first time someone actually joins a call.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -347,11 +347,11 @@ docker compose --profile voice up -d
 
 Everyone in a channel can join that channel's call — from the button atop the member list, or with `/call` in the buffer. When a channel call is in progress, everyone else in the channel sees a live **"Join call (N)"** count on that button (this needs the `webhook` block in the compose config above — without it, counts only refresh on reconnect). A DM call is `/call` in the DM: both sides join the same room, but DMs don't ring or badge — tell the other person to `/call` you back. Call rooms are derived from the IRC server **hostname**, so users who should share calls must configure the _same_ host: `irc.libera.chat` and `irc.eu.libera.chat` are different rooms even though they're the same network.
 
-Channel operators get call controls that mirror their IRC standing: ops and halfops (`q/a/o/h`) can server-mute or remove anyone from the channel's call (removal also invalidates their token — the answer to "kicked but still in the call"), and full ops (`q/a/o`) can restrict who may join the call at all (anyone / voiced+ / halfop+ / ops) from the picker under the Call button.
+Channel operators get call controls that mirror their IRC standing: ops and halfops (`q/a/o/h`) can server-mute or remove anyone from the channel's call, and full ops (`q/a/o`) can restrict who may join the call at all (anyone / voiced+ / halfop+ / ops) from the picker under the Call button.
 
 Two trust caveats, both in line with IRC's own model — fine among people you already trust:
 
-- Channel membership and the join policy are checked **when the call token is issued**, and tokens last 2 hours. Someone kicked or banned mid-call keeps their token until an op removes them from the call (or it expires).
+- Channel membership and the join policy are checked **when the call token is issued**, and tokens last 2 hours. Removing someone from a call ejects them now, but on self-hosted LiveKit it does **not** invalidate their token: Lurker's own clients won't rejoin after a removal, yet someone determined enough to use a raw LiveKit client can reconnect until the token expires. (Instant revocation on removal is a LiveKit Cloud feature.)
 - DM call rooms are named by the two nicks, and IRC nicks are transferable: on networks without nick registration, someone who takes an offline person's nick could join a call room under that name.
 
 Disabling voice (removing the env vars) makes every call affordance disappear from clients; browsers only download the WebRTC code the first time someone actually joins a call.

--- a/server/app.ts
+++ b/server/app.ts
@@ -27,7 +27,7 @@ import uploadsRouter from './routes/uploads.js';
 import uploadersRouter from './routes/uploaders.js';
 import localUploadsRouter from './routes/localUploads.js';
 import dccRouter from './routes/dcc.js';
-import voiceRouter from './routes/voice.js';
+import voiceRouter, { voicePublicRouter } from './routes/voice.js';
 import draftsRouter from './routes/drafts.js';
 import { exportsRouter, importRouter } from './routes/exports.js';
 import apiTokensRouter from './routes/apiTokens.js';
@@ -99,6 +99,10 @@ export function buildApp(sessionSecret: string): Express {
     app.use('/uploads', localUploadsRouter);
   }
   app.use('/api/dcc', dccRouter);
+  // Public voice sub-route (the LiveKit webhook) FIRST — it authenticates by
+  // webhook signature, not the session cookie, so it must match before the
+  // requireAuth'd voice router 401s it.
+  app.use('/api/voice', voicePublicRouter);
   app.use('/api/voice', voiceRouter);
   app.use('/api/drafts', draftsRouter);
   app.use('/api/exports', exportsRouter);

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -542,6 +542,11 @@ export const EXPORT_TABLES = Object.freeze({
       'bearer-token credentials bound to this instance; user re-issues tokens on the target instance',
   },
 
+  voice_channel_policy: {
+    mode: 'skip',
+    reason: 'per-channel voice-call join policy — instance/channel-scoped config, not user data',
+  },
+
   peer_presence_state: {
     mode: 'skip',
     reason: 'transient cache; rebuilt by IRC events on next connect',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -608,6 +608,20 @@ function migrate() {
     );
     CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
 
+    -- Per-channel voice-call join policy (voice, PR 2 of the #680 stack).
+    -- Keyed by IRC network host + folded channel so it is shared across all
+    -- users of the channel on this instance — the same scoping as the LiveKit
+    -- room name. min_join_mode is the lowest IRC prefix mode allowed to join a
+    -- call: 'none' (anyone), 'voice', 'halfop', or 'op'. Set by a channel op.
+    CREATE TABLE IF NOT EXISTS voice_channel_policy (
+      network_host TEXT NOT NULL,
+      channel_folded TEXT NOT NULL,
+      min_join_mode TEXT NOT NULL DEFAULT 'none',
+      updated_by TEXT,
+      updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      PRIMARY KEY (network_host, channel_folded)
+    );
+
     -- Per-user data-export jobs. A request to export account data spawns a
     -- background worker (separate readonly SQLite connection) that builds the
     -- .lurk archive to disk under data/exports/<token>.lurk; the row tracks

--- a/server/db/voicePolicy.test.ts
+++ b/server/db/voicePolicy.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-voicepolicy-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let vp: typeof import('./voicePolicy.js');
+
+beforeAll(async () => {
+  vp = await import('./voicePolicy.js');
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('voicePolicy', () => {
+  it("defaults to 'none' (anyone) when unset", () => {
+    expect(vp.getPolicy('irc.libera.chat', '#unset')).toBe('none');
+  });
+
+  it('upserts and reads back, last write wins', () => {
+    vp.setPolicy('irc.libera.chat', '#dev', 'op', 'jawsh');
+    expect(vp.getPolicy('irc.libera.chat', '#dev')).toBe('op');
+    vp.setPolicy('irc.libera.chat', '#dev', 'voice', 'jawsh');
+    expect(vp.getPolicy('irc.libera.chat', '#dev')).toBe('voice');
+  });
+
+  it('normalizes unknown modes to none', () => {
+    expect(vp.normalizeMinJoinMode('bogus')).toBe('none');
+    expect(vp.normalizeMinJoinMode(undefined)).toBe('none');
+    expect(vp.normalizeMinJoinMode('halfop')).toBe('halfop');
+  });
+
+  it('scopes by host + channel', () => {
+    vp.setPolicy('irc.libera.chat', '#scoped', 'op', 'j');
+    expect(vp.getPolicy('irc.rizon.net', '#scoped')).toBe('none');
+    expect(vp.getPolicy('irc.libera.chat', '#other')).toBe('none');
+  });
+});

--- a/server/db/voicePolicy.ts
+++ b/server/db/voicePolicy.ts
@@ -9,14 +9,11 @@ import db from './index.js';
 // on this instance. min_join_mode is the lowest IRC prefix mode allowed to join
 // a call. Set by a channel op (q/a/o, see canAdminCall).
 
-export type MinJoinMode = 'none' | 'voice' | 'halfop' | 'op';
+import { normalizeMinJoinMode } from '../../shared/voiceModes.js';
+import type { MinJoinMode } from '../../shared/voiceModes.js';
 
-const VALID_MODES: ReadonlySet<string> = new Set(['none', 'voice', 'halfop', 'op']);
-
-/** Normalize an untrusted string to a valid MinJoinMode ('none' fallback). */
-export function normalizeMinJoinMode(raw: unknown): MinJoinMode {
-  return typeof raw === 'string' && VALID_MODES.has(raw) ? (raw as MinJoinMode) : 'none';
-}
+export { normalizeMinJoinMode, isMinJoinMode } from '../../shared/voiceModes.js';
+export type { MinJoinMode } from '../../shared/voiceModes.js';
 
 const getStmt = db.prepare(`
   SELECT min_join_mode AS minJoinMode

--- a/server/db/voicePolicy.ts
+++ b/server/db/voicePolicy.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import db from './index.js';
+
+// Per-channel voice-call join policy. Keyed by IRC network host (ASCII-folded)
+// + casemapping-folded channel — the same scoping as the LiveKit room name in
+// services/voice.ts — so the policy is shared across every user of that channel
+// on this instance. min_join_mode is the lowest IRC prefix mode allowed to join
+// a call. Set by a channel op (q/a/o, see canAdminCall).
+
+export type MinJoinMode = 'none' | 'voice' | 'halfop' | 'op';
+
+const VALID_MODES: ReadonlySet<string> = new Set(['none', 'voice', 'halfop', 'op']);
+
+/** Normalize an untrusted string to a valid MinJoinMode ('none' fallback). */
+export function normalizeMinJoinMode(raw: unknown): MinJoinMode {
+  return typeof raw === 'string' && VALID_MODES.has(raw) ? (raw as MinJoinMode) : 'none';
+}
+
+const getStmt = db.prepare(`
+  SELECT min_join_mode AS minJoinMode
+  FROM voice_channel_policy
+  WHERE network_host = ? AND channel_folded = ?
+`);
+
+const upsertStmt = db.prepare(`
+  INSERT INTO voice_channel_policy
+    (network_host, channel_folded, min_join_mode, updated_by)
+  VALUES (@host, @channel, @mode, @by)
+  ON CONFLICT(network_host, channel_folded) DO UPDATE SET
+    min_join_mode = excluded.min_join_mode,
+    updated_by = excluded.updated_by,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+`);
+
+/** The min join mode for a channel, or 'none' (anyone) when unset. `host` and
+ *  `channelFolded` must already be folded (foldKey / foldTargetFor) to match
+ *  the room key. */
+export function getPolicy(host: string, channelFolded: string): MinJoinMode {
+  const row = getStmt.get(host, channelFolded) as { minJoinMode: string } | undefined;
+  return normalizeMinJoinMode(row?.minJoinMode);
+}
+
+/** Upsert the min join mode for a channel. Returns the stored (normalized) value. */
+export function setPolicy(
+  host: string,
+  channelFolded: string,
+  mode: MinJoinMode,
+  byNick: string,
+): MinJoinMode {
+  const m = normalizeMinJoinMode(mode);
+  upsertStmt.run({ host, channel: channelFolded, mode: m, by: byNick });
+  return m;
+}

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { createHash } from 'crypto';
+import { Router } from 'express';
 import type { LurkerTestAgent } from '../test-utils/testApp.js';
 import type { Express } from 'express';
 import {
@@ -15,23 +17,70 @@ import type { Network } from '../db/networks.js';
 
 const ctx = setupTestDb('routes-voice');
 
-// Stand-in ircManager so the route can be exercised through its whole gate
-// chain — not connected (409), not a member (403), and the happy path — without
-// opening real IRC sockets. Tests flip `conn` between null and a fake carrying
-// exactly the surface the route reads: currentNick + isChannelJoined.
+// Stand-in ircManager so routes can be exercised through their whole gate
+// chain — not connected (409), not a member (403), mode gates, and the happy
+// paths — without opening real IRC sockets. `makeConn` builds the minimal
+// surface the routes read: currentNick, isChannelJoined, channels (name +
+// member modes), and network (for fold + fan-out).
+interface FakeChannel {
+  name: string;
+  members: Map<string, { nick: string; modes: string[] }>;
+}
+interface FakeConn {
+  currentNick: string | null;
+  isChannelJoined: (c: string) => boolean;
+  channels: Map<string, FakeChannel>;
+  network: { id: number; host: string; user_id: number };
+}
+
+function makeConn(args: {
+  nick: string;
+  network: { id: number; host: string; user_id: number };
+  channels?: Array<{ name: string; modes?: Record<string, string[]> }>;
+}): FakeConn {
+  const channels = new Map<string, FakeChannel>();
+  for (const c of args.channels ?? []) {
+    const members = new Map<string, { nick: string; modes: string[] }>();
+    for (const [nick, modes] of Object.entries(c.modes ?? {})) {
+      members.set(nick.toLowerCase(), { nick, modes });
+    }
+    channels.set(c.name.toLowerCase(), { name: c.name, members });
+  }
+  return {
+    currentNick: args.nick,
+    isChannelJoined: (c: string) => channels.has(c.toLowerCase()),
+    channels,
+    network: args.network,
+  };
+}
+
 const fakeManager = {
-  conn: null as null | { currentNick: string | null; isChannelJoined: (c: string) => boolean },
+  conn: null as FakeConn | null,
+  all: [] as FakeConn[],
   getConnection(_userId: number, _networkId: number) {
     return this.conn;
+  },
+  listAllConnections() {
+    return this.all;
   },
 };
 
 vi.mock('../services/ircManager.js', () => ({ default: fakeManager }));
 
+// The webhook fans presence out through wsHub — spy it so tests can assert the
+// frame without dragging the real hub (and its socket state) into the app.
+const h = vi.hoisted(() => ({
+  fanOutToUser: vi.fn<(userId: number, payload: Record<string, unknown>) => void>(),
+}));
+vi.mock('../services/wsHub.js', () => ({ fanOutToUser: h.fanOutToUser }));
+const fanOutToUser = h.fanOutToUser;
+
 let app: Express;
 let agent: LurkerTestAgent;
 let user: User;
 let network: Network;
+
+const SECRET = 'devsecret-long-enough-for-hs256';
 
 // Turn voice on by populating the env the service reads. Individual tests toggle
 // pieces of this to exercise the gates.
@@ -39,7 +88,7 @@ function enableVoice() {
   process.env.LURKER_VOICE_ENABLED = 'true';
   process.env.LIVEKIT_WS_URL = 'ws://sfu.test:7880';
   process.env.LIVEKIT_API_KEY = 'devkey';
-  process.env.LIVEKIT_API_SECRET = 'devsecret-long-enough';
+  process.env.LIVEKIT_API_SECRET = SECRET;
 }
 
 const savedEnv = { ...process.env };
@@ -47,7 +96,7 @@ const savedEnv = { ...process.env };
 beforeAll(async () => {
   const { createUser } = await import('../db/users.js');
   const { createNetwork } = await import('../db/networks.js');
-  const router = (await import('./voice.js')).default;
+  const mod = await import('./voice.js');
   user = createUser('voice-routes-alice');
   network = createNetwork(user.id, {
     name: 'libera',
@@ -56,16 +105,33 @@ beforeAll(async () => {
     tls: true,
     nick: 'alice',
   })!;
-  app = createTestApp({ '/api/voice': router });
+  // Public router first, exactly like app.ts — the webhook must match before
+  // the requireAuth'd router 401s it.
+  const combined = Router();
+  combined.use(mod.voicePublicRouter);
+  combined.use(mod.default);
+  app = createTestApp({ '/api/voice': combined });
   agent = await createAuthedAgent(app, user.id);
 });
 
 afterEach(() => {
   process.env = { ...savedEnv };
   fakeManager.conn = null;
+  fakeManager.all = [];
+  fanOutToUser.mockClear();
 });
 
 afterAll(() => ctx.cleanup());
+
+function connectedAs(modes: string[]): FakeConn {
+  const conn = makeConn({
+    nick: 'alice',
+    network: { id: network.id, host: network.host, user_id: user.id },
+    channels: [{ name: '#dev', modes: { alice: modes, bob: ['o'] } }],
+  });
+  fakeManager.conn = conn;
+  return conn;
+}
 
 describe('POST /api/voice/token', () => {
   it('401 when unauthenticated', async () => {
@@ -85,6 +151,13 @@ describe('POST /api/voice/token', () => {
     expect(res.status).toBe(503);
   });
 
+  it('503 beats body validation when voice is disabled (documented gate order)', async () => {
+    delete process.env.LURKER_VOICE_ENABLED;
+    delete process.env.LIVEKIT_WS_URL;
+    const res = await agent.post('/api/voice/token').send({ networkId: network.id });
+    expect(res.status).toBe(503);
+  });
+
   it('400 for a missing/invalid networkId', async () => {
     enableVoice();
     const res = await agent.post('/api/voice/token').send({ target: '#dev' });
@@ -93,25 +166,13 @@ describe('POST /api/voice/token', () => {
 
   it('400 for a missing target (after the instance/network gates)', async () => {
     enableVoice();
-    // Connected on purpose: target validation sits BEHIND the 503/404/409
-    // gates (CLIENT_PROTOCOL's documented order), so give it a live network.
-    fakeManager.conn = { currentNick: 'alice', isChannelJoined: () => true };
+    connectedAs([]);
     const res = await agent.post('/api/voice/token').send({ networkId: network.id });
     expect(res.status).toBe(400);
   });
 
-  it('503 beats body validation when voice is disabled (documented gate order)', async () => {
-    delete process.env.LURKER_VOICE_ENABLED;
-    delete process.env.LIVEKIT_WS_URL;
-    // No target either — a disabled instance must still answer 503, not 400.
-    const res = await agent.post('/api/voice/token').send({ networkId: network.id });
-    expect(res.status).toBe(503);
-  });
-
   it('404 for a network the caller does not own (ownership gate)', async () => {
     enableVoice();
-    // networkId 999999 belongs to nobody, so getNetwork(id, user) is undefined —
-    // the request is refused before any room token can be minted.
     const res = await agent.post('/api/voice/token').send({ networkId: 999999, target: '#dev' });
     expect(res.status).toBe(404);
   });
@@ -127,16 +188,16 @@ describe('POST /api/voice/token', () => {
 
   it('403 for a channel the caller has not joined (membership gate)', async () => {
     enableVoice();
-    fakeManager.conn = { currentNick: 'alice', isChannelJoined: () => false };
+    connectedAs([]);
     const res = await agent
       .post('/api/voice/token')
-      .send({ networkId: network.id, target: '#dev' });
+      .send({ networkId: network.id, target: '#elsewhere' });
     expect(res.status).toBe(403);
   });
 
   it('mints a token for a joined channel, room keyed on the network HOST', async () => {
     enableVoice();
-    fakeManager.conn = { currentNick: 'alice', isChannelJoined: (c) => c === '#dev' };
+    connectedAs([]);
     const res = await agent
       .post('/api/voice/token')
       .send({ networkId: network.id, target: '#dev' });
@@ -148,10 +209,187 @@ describe('POST /api/voice/token', () => {
 
   it('mints a DM token without any membership gate (opening the call IS the invite)', async () => {
     enableVoice();
-    fakeManager.conn = { currentNick: 'alice', isChannelJoined: () => false };
+    connectedAs([]);
     const res = await agent.post('/api/voice/token').send({ networkId: network.id, target: 'Bob' });
     expect(res.status).toBe(200);
-    // Canonical sorted pair — Bob's end derives the identical room.
     expect(res.body.room).toBe('net-irc.libera.chat-d-alice:bob');
+  });
+
+  it('enforces the channel join policy (403 below the bar, 200 at it)', async () => {
+    enableVoice();
+    const { setPolicy } = await import('../db/voicePolicy.js');
+    setPolicy('irc.libera.chat', '#dev', 'voice', 'op');
+
+    connectedAs([]); // no modes → below voiced
+    const denied = await agent
+      .post('/api/voice/token')
+      .send({ networkId: network.id, target: '#dev' });
+    expect(denied.status).toBe(403);
+    expect(String(denied.body.error)).toContain('voice');
+
+    connectedAs(['v']);
+    const ok = await agent.post('/api/voice/token').send({ networkId: network.id, target: '#dev' });
+    expect(ok.status).toBe(200);
+
+    setPolicy('irc.libera.chat', '#dev', 'none', 'op'); // reset for later tests
+  });
+});
+
+describe('voice join policy — GET/PUT /api/voice/policy', () => {
+  it('any member may read; unset reads as none', async () => {
+    enableVoice();
+    connectedAs([]);
+    const res = await agent.get(`/api/voice/policy?networkId=${network.id}&target=%23dev`);
+    expect(res.status).toBe(200);
+    expect(res.body.minJoinMode).toBe('none');
+  });
+
+  it('non-ops (including halfops) cannot set policy', async () => {
+    enableVoice();
+    connectedAs(['h']);
+    const res = await agent
+      .put('/api/voice/policy')
+      .send({ networkId: network.id, target: '#dev', minJoinMode: 'op' });
+    expect(res.status).toBe(403);
+  });
+
+  it('ops set it; it round-trips through GET and normalizes garbage', async () => {
+    enableVoice();
+    connectedAs(['o']);
+    const put = await agent
+      .put('/api/voice/policy')
+      .send({ networkId: network.id, target: '#dev', minJoinMode: 'halfop' });
+    expect(put.status).toBe(200);
+    expect(put.body.minJoinMode).toBe('halfop');
+
+    const got = await agent.get(`/api/voice/policy?networkId=${network.id}&target=%23dev`);
+    expect(got.body.minJoinMode).toBe('halfop');
+
+    const garbage = await agent
+      .put('/api/voice/policy')
+      .send({ networkId: network.id, target: '#dev', minJoinMode: 'sudo' });
+    expect(garbage.body.minJoinMode).toBe('none'); // normalized, fails open to anyone
+  });
+
+  it('rejects a DM target (policies are channel-scoped)', async () => {
+    enableVoice();
+    connectedAs(['o']);
+    const res = await agent
+      .put('/api/voice/policy')
+      .send({ networkId: network.id, target: 'bob', minJoinMode: 'op' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/voice/moderate', () => {
+  it('403 for non-moderators (voice is not enough)', async () => {
+    enableVoice();
+    connectedAs(['v']);
+    const res = await agent
+      .post('/api/voice/moderate')
+      .send({ networkId: network.id, target: '#dev', action: 'remove', identity: 'bob' });
+    expect(res.status).toBe(403);
+  });
+
+  it('400 for a bogus action', async () => {
+    enableVoice();
+    connectedAs(['o']);
+    const res = await agent
+      .post('/api/voice/moderate')
+      .send({ networkId: network.id, target: '#dev', action: 'defenestrate', identity: 'bob' });
+    expect(res.status).toBe(400);
+  });
+
+  it('403 for a DM target — moderation is channel-only', async () => {
+    enableVoice();
+    connectedAs(['o']);
+    const res = await agent
+      .post('/api/voice/moderate')
+      .send({ networkId: network.id, target: 'bob', action: 'remove', identity: 'bob' });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/voice/webhook (public, signature-verified)', () => {
+  // Build a REAL LiveKit webhook auth header: a JWT signed with the shared
+  // secret whose sha256 claim covers the body — the same thing the SFU sends.
+  async function signedAuth(body: string): Promise<string> {
+    const { AccessToken } = await import('livekit-server-sdk');
+    const at = new AccessToken('devkey', SECRET, { identity: '' });
+    at.sha256 = createHash('sha256').update(body).digest('base64');
+    return at.toJwt();
+  }
+
+  function webhookBody(event: string, room: string, identity: string): string {
+    return JSON.stringify({ event, room: { name: room }, participant: { identity } });
+  }
+
+  it('401 for a missing or forged signature', async () => {
+    enableVoice();
+    const body = webhookBody('participant_joined', 'net-irc.libera.chat-c-#dev', 'bob');
+    const noAuth = await testRequest(app)
+      .post('/api/voice/webhook')
+      .set('Content-Type', 'application/webhook+json')
+      .send(body);
+    expect(noAuth.status).toBe(401);
+
+    const forged = await testRequest(app)
+      .post('/api/voice/webhook')
+      .set('Content-Type', 'application/webhook+json')
+      .set('Authorization', 'not-a-real-token')
+      .send(body);
+    expect(forged.status).toBe(401);
+  });
+
+  it('fans a verified join out to local accounts in the channel, in their own spelling', async () => {
+    enableVoice();
+    // Two local accounts on the host: one in #dev, one not.
+    const inChannel = makeConn({
+      nick: 'alice',
+      network: { id: network.id, host: 'irc.libera.chat', user_id: user.id },
+      channels: [{ name: '#Dev', modes: { alice: [] } }], // note the spelling
+    });
+    const elsewhere = makeConn({
+      nick: 'carol',
+      network: { id: network.id + 1, host: 'irc.libera.chat', user_id: user.id + 1 },
+      channels: [{ name: '#other', modes: { carol: [] } }],
+    });
+    fakeManager.all = [inChannel, elsewhere];
+
+    const body = webhookBody('participant_joined', 'net-irc.libera.chat-c-#dev', 'bob');
+    const res = await testRequest(app)
+      .post('/api/voice/webhook')
+      .set('Content-Type', 'application/webhook+json')
+      .set('Authorization', await signedAuth(body))
+      .send(body);
+    expect(res.status).toBe(200);
+
+    expect(fanOutToUser).toHaveBeenCalledTimes(1);
+    expect(fanOutToUser).toHaveBeenCalledWith(user.id, {
+      kind: 'call-presence',
+      networkId: network.id,
+      target: '#Dev', // the receiving connection's own wire spelling
+      active: true,
+      count: expect.any(Number),
+    });
+  });
+
+  it('broadcasts nothing for DM rooms', async () => {
+    enableVoice();
+    fakeManager.all = [
+      makeConn({
+        nick: 'alice',
+        network: { id: network.id, host: 'irc.libera.chat', user_id: user.id },
+        channels: [{ name: '#dev', modes: { alice: [] } }],
+      }),
+    ];
+    const body = webhookBody('participant_joined', 'net-irc.libera.chat-d-alice:bob', 'bob');
+    const res = await testRequest(app)
+      .post('/api/voice/webhook')
+      .set('Content-Type', 'application/webhook+json')
+      .set('Authorization', await signedAuth(body))
+      .send(body);
+    expect(res.status).toBe(200);
+    expect(fanOutToUser).not.toHaveBeenCalled();
   });
 });

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -71,9 +71,20 @@ vi.mock('../services/ircManager.js', () => ({ default: fakeManager }));
 // frame without dragging the real hub (and its socket state) into the app.
 const h = vi.hoisted(() => ({
   fanOutToUser: vi.fn<(userId: number, payload: Record<string, unknown>) => void>(),
+  liveCallCount: vi.fn<(room: string) => Promise<number | null>>(),
 }));
 vi.mock('../services/wsHub.js', () => ({ fanOutToUser: h.fanOutToUser }));
+// Partial mock: liveCallCount queries the SFU over HTTP, which doesn't exist in
+// tests — everything else in the voice service runs real.
+vi.mock('../services/voice.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../services/voice.js')>()),
+  liveCallCount: h.liveCallCount,
+}));
 const fanOutToUser = h.fanOutToUser;
+
+/** The webhook route acks the SFU BEFORE querying the count + fanning out —
+ *  let that post-response async work settle before asserting on it. */
+const settle = () => new Promise((r) => setTimeout(r, 20));
 
 let app: Express;
 let agent: LurkerTestAgent;
@@ -119,6 +130,7 @@ afterEach(() => {
   fakeManager.conn = null;
   fakeManager.all = [];
   fanOutToUser.mockClear();
+  h.liveCallCount.mockReset();
 });
 
 afterAll(() => ctx.cleanup());
@@ -370,23 +382,49 @@ describe('POST /api/voice/webhook (public, signature-verified)', () => {
       channels: [{ name: '#other', modes: { carol: [] } }],
     });
     fakeManager.all = [inChannel, elsewhere];
+    h.liveCallCount.mockResolvedValueOnce(3);
 
-    const body = webhookBody('participant_joined', 'net-irc.libera.chat-c-#dev', 3);
+    const body = webhookBody('participant_joined', 'net-irc.libera.chat-c-#dev', 1);
     const res = await testRequest(app)
       .post('/api/voice/webhook')
       .set('Content-Type', 'application/webhook+json')
       .set('Authorization', await signedAuth(body))
       .send(body);
     expect(res.status).toBe(200);
+    await settle();
 
+    // Count is the SFU's answer (3), NOT the event body's numParticipants (1) —
+    // the event field is unreliable (see liveCallCount).
+    expect(h.liveCallCount).toHaveBeenCalledWith('net-irc.libera.chat-c-#dev');
     expect(fanOutToUser).toHaveBeenCalledTimes(1);
     expect(fanOutToUser).toHaveBeenCalledWith(user.id, {
       kind: 'call-presence',
       networkId: network.id,
       target: '#Dev', // the receiving connection's own wire spelling
       active: true,
-      count: 3, // straight from the event's Room.numParticipants
+      count: 3,
     });
+  });
+
+  it('skips the broadcast when the SFU count query fails (stale beats wrongly-cleared)', async () => {
+    enableVoice();
+    fakeManager.all = [
+      makeConn({
+        nick: 'alice',
+        network: { id: network.id, host: 'irc.libera.chat', user_id: user.id },
+        channels: [{ name: '#dev', modes: { alice: [] } }],
+      }),
+    ];
+    h.liveCallCount.mockResolvedValueOnce(null);
+    const body = webhookBody('participant_left', 'net-irc.libera.chat-c-#dev', 1);
+    const res = await testRequest(app)
+      .post('/api/voice/webhook')
+      .set('Content-Type', 'application/webhook+json')
+      .set('Authorization', await signedAuth(body))
+      .send(body);
+    expect(res.status).toBe(200);
+    await settle();
+    expect(fanOutToUser).not.toHaveBeenCalled();
   });
 
   it('broadcasts nothing for DM rooms', async () => {
@@ -405,6 +443,9 @@ describe('POST /api/voice/webhook (public, signature-verified)', () => {
       .set('Authorization', await signedAuth(body))
       .send(body);
     expect(res.status).toBe(200);
+    await settle();
+    // A DM room is filtered before the SFU is even asked.
+    expect(h.liveCallCount).not.toHaveBeenCalled();
     expect(fanOutToUser).not.toHaveBeenCalled();
   });
 });

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -253,7 +253,7 @@ describe('voice join policy — GET/PUT /api/voice/policy', () => {
     expect(res.status).toBe(403);
   });
 
-  it('ops set it; it round-trips through GET and normalizes garbage', async () => {
+  it('ops set it and it round-trips through GET', async () => {
     enableVoice();
     connectedAs(['o']);
     const put = await agent
@@ -264,11 +264,22 @@ describe('voice join policy — GET/PUT /api/voice/policy', () => {
 
     const got = await agent.get(`/api/voice/policy?networkId=${network.id}&target=%23dev`);
     expect(got.body.minJoinMode).toBe('halfop');
+  });
 
-    const garbage = await agent
-      .put('/api/voice/policy')
-      .send({ networkId: network.id, target: '#dev', minJoinMode: 'sudo' });
-    expect(garbage.body.minJoinMode).toBe('none'); // normalized, fails open to anyone
+  it('rejects unknown modes with 400 instead of coercing them open', async () => {
+    // normalizeMinJoinMode falls back to 'none' — coercion here would mean a
+    // typo'd restrict request silently UNRESTRICTS the call with a 200.
+    enableVoice();
+    connectedAs(['o']);
+    for (const bad of ['sudo', 'ops', '', 42, null]) {
+      const res = await agent
+        .put('/api/voice/policy')
+        .send({ networkId: network.id, target: '#dev', minJoinMode: bad });
+      expect(res.status).toBe(400);
+    }
+    // The stored policy is untouched by the rejected writes.
+    const got = await agent.get(`/api/voice/policy?networkId=${network.id}&target=%23dev`);
+    expect(got.body.minJoinMode).toBe('halfop');
   });
 
   it('rejects a DM target (policies are channel-scoped)', async () => {
@@ -320,13 +331,17 @@ describe('POST /api/voice/webhook (public, signature-verified)', () => {
     return at.toJwt();
   }
 
-  function webhookBody(event: string, room: string, identity: string): string {
-    return JSON.stringify({ event, room: { name: room }, participant: { identity } });
+  function webhookBody(event: string, room: string, numParticipants: number): string {
+    return JSON.stringify({
+      event,
+      room: { name: room, numParticipants },
+      participant: { identity: 'bob' },
+    });
   }
 
   it('401 for a missing or forged signature', async () => {
     enableVoice();
-    const body = webhookBody('participant_joined', 'net-irc.libera.chat-c-#dev', 'bob');
+    const body = webhookBody('participant_joined', 'net-irc.libera.chat-c-#dev', 1);
     const noAuth = await testRequest(app)
       .post('/api/voice/webhook')
       .set('Content-Type', 'application/webhook+json')
@@ -356,7 +371,7 @@ describe('POST /api/voice/webhook (public, signature-verified)', () => {
     });
     fakeManager.all = [inChannel, elsewhere];
 
-    const body = webhookBody('participant_joined', 'net-irc.libera.chat-c-#dev', 'bob');
+    const body = webhookBody('participant_joined', 'net-irc.libera.chat-c-#dev', 3);
     const res = await testRequest(app)
       .post('/api/voice/webhook')
       .set('Content-Type', 'application/webhook+json')
@@ -370,7 +385,7 @@ describe('POST /api/voice/webhook (public, signature-verified)', () => {
       networkId: network.id,
       target: '#Dev', // the receiving connection's own wire spelling
       active: true,
-      count: expect.any(Number),
+      count: 3, // straight from the event's Room.numParticipants
     });
   });
 
@@ -383,7 +398,7 @@ describe('POST /api/voice/webhook (public, signature-verified)', () => {
         channels: [{ name: '#dev', modes: { alice: [] } }],
       }),
     ];
-    const body = webhookBody('participant_joined', 'net-irc.libera.chat-d-alice:bob', 'bob');
+    const body = webhookBody('participant_joined', 'net-irc.libera.chat-d-alice:bob', 2);
     const res = await testRequest(app)
       .post('/api/voice/webhook')
       .set('Content-Type', 'application/webhook+json')

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -22,7 +22,8 @@ import {
   removeFromCall,
   muteParticipant,
   receiveWebhook,
-  applyWebhookEvent,
+  webhookCallRoom,
+  liveCallCount,
   listActiveCalls,
   type CallPresenceChange,
 } from '../services/voice.js';
@@ -274,9 +275,17 @@ voicePublicRouter.post(
       res.status(401).end();
       return;
     }
-    const change = applyWebhookEvent(ev);
-    if (change) broadcastCallPresence(change);
+    // Ack the SFU immediately — the count query below must not stall LiveKit's
+    // webhook queue (it retries + drops slow deliveries).
     res.status(200).end();
+    const trigger = webhookCallRoom(ev);
+    if (!trigger) return;
+    // The event told us occupancy changed; the SFU's participant list says to
+    // what (the event's own numParticipants field is not reliable — see
+    // liveCallCount). room_finished needs no query: it IS the zero.
+    const count = ev.event === 'room_finished' ? 0 : await liveCallCount(trigger.room);
+    if (count == null) return; // SFU unreachable — better stale than wrongly cleared
+    broadcastCallPresence({ ...trigger, count, active: count > 0 });
   },
 );
 

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -1,21 +1,58 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { Router } from 'express';
+import express, { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth } from '../middleware/auth.js';
 import { getNetwork } from '../db/networks.js';
 import type { Network } from '../db/networks.js';
 import ircManager from '../services/ircManager.js';
 import type { IrcConnection } from '../services/ircConnection.js';
+import { fanOutToUser } from '../services/wsHub.js';
 import { isChannelTarget } from '../../shared/channels.js';
 import { foldTargetFor } from '../db/buffers.js';
-import { mintVoiceToken, roomFor, voiceEnabled } from '../services/voice.js';
+import {
+  mintVoiceToken,
+  roomFor,
+  voiceEnabled,
+  foldKey,
+  meetsJoinMode,
+  canModerateCall,
+  canAdminCall,
+  removeFromCall,
+  muteParticipant,
+  rememberRoom,
+  receiveWebhook,
+  applyWebhookEvent,
+  listActiveCalls,
+  type CallPresenceChange,
+} from '../services/voice.js';
+import { getPolicy, setPolicy, normalizeMinJoinMode } from '../db/voicePolicy.js';
 
-// Voice control surface. Lurker is the token authority (see services/voice.ts);
-// it never carries media. Everything here is requireAuth'd and gated on
-// voiceEnabled(), so on a non-voice instance this router is a wall of 503s and
-// the client never shows the UI that would call it.
+// Voice control surface. Lurker is the token authority + call moderator (see
+// services/voice.ts); it never carries media. Two routers:
+//   - the authed router (requireAuth): mint token, presence snapshot, moderate,
+//     join policy
+//   - the public router (no cookie): the LiveKit webhook, verified by its
+//     signature — mounted BEFORE the authed router in app.ts
+
+/** The caller's joined channel matching `target` under the network's declared
+ *  CASEMAPPING, or undefined. This is the fold-aware sibling of isChannelJoined
+ *  — used wherever we need the channel STATE (member modes) or its wire
+ *  spelling, so an rfc1459 variant like '#foo{bar}' resolves to the channel
+ *  joined as '#foo[bar]' instead of missing the map key. */
+function joinedChannel(conn: IrcConnection, target: string) {
+  const want = foldTargetFor(conn.network.id, target);
+  for (const ch of conn.channels.values()) {
+    if (foldTargetFor(conn.network.id, ch.name) === want) return ch;
+  }
+  return undefined;
+}
+
+/** The caller's IRC prefix modes in a joined channel (e.g. ['o','v']), or []. */
+function memberModes(conn: IrcConnection, target: string, nick: string): string[] {
+  return joinedChannel(conn, target)?.members.get(nick.toLowerCase())?.modes ?? [];
+}
 
 interface CallCtx {
   network: Network;
@@ -50,7 +87,7 @@ function resolveCall(req: Request, res: Response, networkId: number): CallCtx | 
 const router = Router();
 router.use(requireAuth);
 
-// ─── Join: mint a room-scoped token, gated by channel membership ────────────
+// ─── Join: mint a room-scoped token, gated by membership + channel policy ───
 router.post('/token', async (req: Request, res: Response) => {
   const networkId = Number(req.body?.networkId);
   const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
@@ -64,12 +101,23 @@ router.post('/token', async (req: Request, res: Response) => {
   }
   const { network, conn, nick } = ctx;
 
-  // Channels require live membership (the one casemapping-correct probe — see
-  // isChannelJoined). DMs deliberately don't gate on the peer: opening a DM
-  // call IS the invite, exactly like opening a DM buffer.
-  if (isChannelTarget(target) && !conn.isChannelJoined(target)) {
-    res.status(403).json({ error: 'not a member of that channel' });
-    return;
+  if (isChannelTarget(target)) {
+    // Channels require live membership (the one casemapping-correct probe —
+    // see isChannelJoined). DMs deliberately don't gate on the peer: opening a
+    // DM call IS the invite, exactly like opening a DM buffer.
+    if (!conn.isChannelJoined(target)) {
+      res.status(403).json({ error: 'not a member of that channel' });
+      return;
+    }
+    // Per-channel join gating: the caller must meet the channel's min join
+    // mode (set by an op via PUT /policy).
+    const min = getPolicy(foldKey(network.host), foldTargetFor(network.id, target));
+    if (!meetsJoinMode(memberModes(conn, target, nick), min)) {
+      res.status(403).json({
+        error: `this call is restricted to ${min}+ — you don't have that mode`,
+      });
+      return;
+    }
   }
 
   // Fold with the network's declared CASEMAPPING before deriving the room, so
@@ -82,6 +130,12 @@ router.post('/token', async (req: Request, res: Response) => {
     foldTargetFor(network.id, target),
     foldTargetFor(network.id, nick),
   );
+  // Seed the webhook's room → channel map — CHANNEL rooms only. DM rooms are
+  // never registered: DM presence is never broadcast (it would leak who is
+  // talking to whom).
+  if (isChannelTarget(target)) {
+    rememberRoom(room, network.host, foldTargetFor(network.id, target));
+  }
   try {
     const minted = await mintVoiceToken({ identity: nick, room });
     res.json(minted); // { token, room, url }
@@ -92,5 +146,157 @@ router.post('/token', async (req: Request, res: Response) => {
     res.status(500).json({ error: 'failed to mint token' });
   }
 });
+
+// ─── Presence snapshot: current calls in the caller's channels ─────────────
+// The webhook stream only pushes live join/leave deltas, so a client that
+// connects (or reconnects) mid-call would never learn about a call already in
+// progress. This hydrates that gap from the SFU (source of truth → correct
+// across a Lurker restart too). Filtered to channels the caller has joined,
+// and each channel is reported in THIS connection's wire spelling so the
+// client can match it to a buffer.
+router.get('/presence', async (req: Request, res: Response) => {
+  const networkId = Number(req.query?.networkId);
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  const host = foldKey(ctx.network.host);
+  const nameByFold = new Map<string, string>();
+  for (const ch of ctx.conn.channels.values()) {
+    nameByFold.set(foldTargetFor(ctx.network.id, ch.name), ch.name);
+  }
+  try {
+    const calls = await listActiveCalls();
+    const out: Array<{ target: string; count: number }> = [];
+    for (const c of calls) {
+      if (c.host !== host || c.count <= 0) continue;
+      const name = nameByFold.get(c.channel);
+      if (name) out.push({ target: name, count: c.count });
+    }
+    res.json({ calls: out });
+  } catch (err) {
+    console.error('[voice] presence snapshot failed:', err);
+    res.status(502).json({ error: 'could not list active calls' });
+  }
+});
+
+// ─── Moderate: op-only mute / remove another participant ───────────────────
+router.post('/moderate', async (req: Request, res: Response) => {
+  const networkId = Number(req.body?.networkId);
+  const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  const action = req.body?.action;
+  const identity = typeof req.body?.identity === 'string' ? req.body.identity : '';
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  if (!target || !identity || (action !== 'mute' && action !== 'remove')) {
+    res.status(400).json({ error: 'target, identity, action (mute|remove) required' });
+    return;
+  }
+  const { network, conn, nick } = ctx;
+  // Channel-only, and the guard must stay glued to the roomFor below: for a
+  // channel room `self` is unused, but a DM room derived from the MODERATOR's
+  // nick would target the wrong room entirely.
+  if (!isChannelTarget(target) || !canModerateCall(memberModes(conn, target, nick))) {
+    res.status(403).json({ error: 'you must be a channel operator to moderate this call' });
+    return;
+  }
+  const room = roomFor(
+    network.host,
+    foldTargetFor(network.id, target),
+    foldTargetFor(network.id, nick),
+  );
+  try {
+    if (action === 'remove') await removeFromCall(room, identity);
+    else await muteParticipant(room, identity);
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('[voice] moderation action failed:', err);
+    res.status(500).json({ error: 'moderation action failed' });
+  }
+});
+
+// ─── Join policy: read (any member of the network) / set (ops only) ────────
+router.get('/policy', (req: Request, res: Response) => {
+  const networkId = Number(req.query?.networkId);
+  const target = typeof req.query?.target === 'string' ? req.query.target.trim() : '';
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  if (!target) {
+    res.status(400).json({ error: 'target required' });
+    return;
+  }
+  res.json({
+    minJoinMode: getPolicy(foldKey(ctx.network.host), foldTargetFor(ctx.network.id, target)),
+  });
+});
+
+router.put('/policy', (req: Request, res: Response) => {
+  const networkId = Number(req.body?.networkId);
+  const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  const minJoinMode = normalizeMinJoinMode(req.body?.minJoinMode);
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  if (!target || !isChannelTarget(target)) {
+    res.status(400).json({ error: 'channel target required' });
+    return;
+  }
+  const { network, conn, nick } = ctx;
+  if (!canAdminCall(memberModes(conn, target, nick))) {
+    res.status(403).json({ error: 'you must be a channel operator to set the call policy' });
+    return;
+  }
+  setPolicy(foldKey(network.host), foldTargetFor(network.id, target), minJoinMode, nick);
+  res.json({ minJoinMode });
+});
+
+// ─── Public router (no cookie auth) — the LiveKit webhook ───────────────────
+export const voicePublicRouter = Router();
+
+// LiveKit posts room/participant events here (content-type
+// application/webhook+json, so the global express.json parser skips it and the
+// route-level text parser captures the raw body the signature covers).
+// Verified by signature, then fed to the presence registry; the change fans
+// out to every local account in the channel.
+voicePublicRouter.post(
+  '/webhook',
+  express.text({ type: '*/*', limit: '512kb' }),
+  async (req: Request, res: Response) => {
+    const body = typeof req.body === 'string' ? req.body : '';
+    const ev = await receiveWebhook(body, req.get('Authorization'));
+    if (!ev) {
+      res.status(401).end();
+      return;
+    }
+    const change = applyWebhookEvent(ev);
+    if (change) broadcastCallPresence(change);
+    res.status(200).end();
+  },
+);
+
+/** Notify every local account currently in this channel (any of their tabs)
+ *  that a call's participant count changed, so they can show/hide the badge.
+ *  The folded channel from the registry is translated to each connection's own
+ *  wire spelling before sending — clients match frames to buffers by target. */
+function broadcastCallPresence(change: CallPresenceChange): void {
+  for (const conn of ircManager.listAllConnections()) {
+    if (foldKey(conn.network.host) !== change.host) continue;
+    let name: string | null = null;
+    for (const ch of conn.channels.values()) {
+      if (foldTargetFor(conn.network.id, ch.name) === change.channel) {
+        name = ch.name;
+        break;
+      }
+    }
+    if (!name) continue; // this account isn't in the channel
+    fanOutToUser(conn.network.user_id, {
+      // Top-level frame kind — the client dispatches on `kind` in
+      // handleMessage. A bare `type:` would never reach the handler: only
+      // kind:'irc' frames are unwrapped to the inner type-switch.
+      kind: 'call-presence',
+      networkId: conn.network.id,
+      target: name,
+      active: change.active,
+      count: change.count,
+    });
+  }
+}
 
 export default router;

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -21,13 +21,12 @@ import {
   canAdminCall,
   removeFromCall,
   muteParticipant,
-  rememberRoom,
   receiveWebhook,
   applyWebhookEvent,
   listActiveCalls,
   type CallPresenceChange,
 } from '../services/voice.js';
-import { getPolicy, setPolicy, normalizeMinJoinMode } from '../db/voicePolicy.js';
+import { getPolicy, setPolicy, isMinJoinMode } from '../db/voicePolicy.js';
 
 // Voice control surface. Lurker is the token authority + call moderator (see
 // services/voice.ts); it never carries media. Two routers:
@@ -111,6 +110,15 @@ router.post('/token', async (req: Request, res: Response) => {
     }
     // Per-channel join gating: the caller must meet the channel's min join
     // mode (set by an op via PUT /policy).
+    //
+    // Invariant: the policy key and the room key below derive from the SAME
+    // foldTargetFor call on the SAME network row. A row whose declared
+    // casemapping diverges from its neighbours' (e.g. not yet refolded after
+    // #707) therefore derives a different policy key AND a different room —
+    // the caller can only ever "miss" the policy of a room they also can't
+    // derive, never mint an unrestricted token into the restricted call. The
+    // residual cost of divergence is cosmetic (a presence badge may not match,
+    // see broadcastCallPresence) and heals when the row refolds.
     const min = getPolicy(foldKey(network.host), foldTargetFor(network.id, target));
     if (!meetsJoinMode(memberModes(conn, target, nick), min)) {
       res.status(403).json({
@@ -130,12 +138,6 @@ router.post('/token', async (req: Request, res: Response) => {
     foldTargetFor(network.id, target),
     foldTargetFor(network.id, nick),
   );
-  // Seed the webhook's room → channel map — CHANNEL rooms only. DM rooms are
-  // never registered: DM presence is never broadcast (it would leak who is
-  // talking to whom).
-  if (isChannelTarget(target)) {
-    rememberRoom(room, network.host, foldTargetFor(network.id, target));
-  }
   try {
     const minted = await mintVoiceToken({ identity: nick, room });
     res.json(minted); // { token, room, url }
@@ -231,11 +233,18 @@ router.get('/policy', (req: Request, res: Response) => {
 router.put('/policy', (req: Request, res: Response) => {
   const networkId = Number(req.body?.networkId);
   const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
-  const minJoinMode = normalizeMinJoinMode(req.body?.minJoinMode);
+  const minJoinMode = req.body?.minJoinMode;
   const ctx = resolveCall(req, res, networkId);
   if (!ctx) return;
   if (!target || !isChannelTarget(target)) {
     res.status(400).json({ error: 'channel target required' });
+    return;
+  }
+  // STRICT here, unlike reads: this is a write to a security control, and the
+  // normalize fallback is 'none' — coercing a typo'd or version-skewed value
+  // would silently UNRESTRICT the call while answering 200.
+  if (!isMinJoinMode(minJoinMode)) {
+    res.status(400).json({ error: 'minJoinMode must be one of none|voice|halfop|op' });
     return;
   }
   const { network, conn, nick } = ctx;
@@ -273,8 +282,11 @@ voicePublicRouter.post(
 
 /** Notify every local account currently in this channel (any of their tabs)
  *  that a call's participant count changed, so they can show/hide the badge.
- *  The folded channel from the registry is translated to each connection's own
- *  wire spelling before sending — clients match frames to buffers by target. */
+ *  The folded channel from the room name is translated to each connection's
+ *  own wire spelling before sending — clients match frames to buffers by
+ *  target. A connection whose network row folds differently from the minter's
+ *  (transitional casemapping divergence) just misses the badge until its row
+ *  refolds; the /presence snapshot on its next reconnect self-heals it. */
 function broadcastCallPresence(change: CallPresenceChange): void {
   for (const conn of ircManager.listAllConnections()) {
     if (foldKey(conn.network.host) !== change.host) continue;

--- a/server/services/ircManager.ts
+++ b/server/services/ircManager.ts
@@ -156,6 +156,15 @@ class IrcManager extends EventEmitter {
     return Array.from(this.connectionsForUser(userId).values());
   }
 
+  /** Every live connection across ALL users — for cross-user broadcasts (e.g.
+   *  call-presence: a call by one account must badge other accounts sharing
+   *  the IRC channel on this instance). */
+  listAllConnections(): IrcConnection[] {
+    const out: IrcConnection[] = [];
+    for (const m of this.byUser.values()) for (const c of m.values()) out.push(c);
+    return out;
+  }
+
   initForUser(userId: number): void {
     // Bulk path — cold-start autoconnect (via initAll) and un-pause resume. The
     // herd of connects this fans out is exactly what issue #236 throttles, so

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -13,7 +13,8 @@ import {
   meetsJoinMode,
   canModerateCall,
   canAdminCall,
-  applyWebhookEvent,
+  webhookCallRoom,
+  liveCallCount,
   receiveWebhook,
   listActiveCalls,
 } from './voice.js';
@@ -234,61 +235,48 @@ describe('parseRoom', () => {
   });
 });
 
-describe('applyWebhookEvent', () => {
-  const ev = (event: string, room: string, numParticipants?: number): WebhookEvent =>
+describe('webhookCallRoom', () => {
+  const ev = (event: string, room: string): WebhookEvent =>
     ({
       event,
-      room: { name: room, numParticipants },
+      room: { name: room },
       participant: { identity: 'someone' },
     }) as WebhookEvent;
 
-  it('is stateless: count comes from the event, channel from the room name', () => {
-    // A delta registry lied after a restart (first post-restart join "reset" a
-    // 3-person call to 1; leaves broadcast nothing). Room.numParticipants is
-    // authoritative at event time, so a mid-call restart changes nothing.
-    const room = 'net-irc.libera.chat-c-#restart-proof';
-    const change = applyWebhookEvent(ev('participant_joined', room, 4));
-    expect(change).toEqual({
-      room,
-      host: 'irc.libera.chat',
-      channel: '#restart-proof',
-      active: true,
-      count: 4,
-    });
+  it('flags every occupancy-changing event for a channel room', () => {
+    // The event is only a TRIGGER — counts come from liveCallCount, because
+    // the event's own Room.numParticipants is not reliable (verified against
+    // a live SFU: absent on joins, stale on leaves).
+    const room = 'net-irc.libera.chat-c-#dev';
+    for (const e of [
+      'participant_joined',
+      'participant_left',
+      'participant_connection_aborted',
+      'room_finished',
+    ]) {
+      expect(webhookCallRoom(ev(e, room))).toEqual({
+        room,
+        host: 'irc.libera.chat',
+        channel: '#dev',
+      });
+    }
   });
 
-  it('handles leaves, aborted connections, and room end', () => {
-    const room = 'net-irc.libera.chat-c-#counting';
-    expect(applyWebhookEvent(ev('participant_left', room, 1))).toMatchObject({
-      count: 1,
-      active: true,
-    });
-    expect(applyWebhookEvent(ev('participant_left', room, 0))).toMatchObject({
-      count: 0,
-      active: false,
-    });
-    expect(applyWebhookEvent(ev('participant_connection_aborted', room, 2))).toMatchObject({
-      count: 2,
-    });
-    // room_finished carries no reliable count — it IS the zero.
-    expect(applyWebhookEvent(ev('room_finished', room, 3))).toMatchObject({
-      count: 0,
-      active: false,
-    });
-  });
-
-  it('ignores DM rooms (no channel to badge) and irrelevant events', () => {
-    expect(applyWebhookEvent(ev('participant_joined', 'net-h-d-a:b', 1))).toBeNull();
-    expect(applyWebhookEvent(ev('track_published', 'net-irc.libera.chat-c-#x', 1))).toBeNull();
+  it('ignores DM rooms (no channel to badge) and non-occupancy events', () => {
+    expect(webhookCallRoom(ev('participant_joined', 'net-h-d-a:b'))).toBeNull();
+    expect(webhookCallRoom(ev('track_published', 'net-irc.libera.chat-c-#x'))).toBeNull();
+    expect(webhookCallRoom(ev('room_started', 'net-irc.libera.chat-c-#x'))).toBeNull();
   });
 });
 
-describe('receiveWebhook / listActiveCalls (unconfigured)', () => {
-  it('both fail closed when voice is unconfigured', async () => {
+describe('receiveWebhook / listActiveCalls / liveCallCount (unconfigured)', () => {
+  it('all fail closed when voice is unconfigured', async () => {
     delete process.env.LIVEKIT_WS_URL;
     delete process.env.LIVEKIT_API_KEY;
     delete process.env.LIVEKIT_API_SECRET;
     await expect(receiveWebhook('{}', 'whatever')).resolves.toBeNull();
     await expect(listActiveCalls()).resolves.toEqual([]);
+    // null (unknown), NOT 0 — a fabricated zero would clear real badges.
+    await expect(liveCallCount('net-h-c-#x')).resolves.toBeNull();
   });
 });

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -7,9 +7,18 @@ import {
   liveKitConfig,
   mintVoiceToken,
   roomFor,
+  parseRoom,
   voiceEnabled,
   voiceMasterEnabled,
+  meetsJoinMode,
+  canModerateCall,
+  canAdminCall,
+  applyWebhookEvent,
+  rememberRoom,
+  receiveWebhook,
+  listActiveCalls,
 } from './voice.js';
+import type { WebhookEvent } from 'livekit-server-sdk';
 
 // LURKER_VOICE_ENABLED value parsing is the shared parseTruthyEnv — its accepted
 // set is pinned by truthyEnv's own tests; only the wiring is exercised here (in
@@ -145,5 +154,139 @@ describe('mintVoiceToken', () => {
     expect(claims.video?.room).toBe('net-x-c-#dev');
     expect(claims.video?.roomJoin).toBe(true);
     expect(claims.video?.canSubscribe).toBe(true);
+  });
+});
+
+describe('meetsJoinMode', () => {
+  it("'none' lets anyone in", () => {
+    expect(meetsJoinMode([], 'none')).toBe(true);
+    expect(meetsJoinMode(['v'], 'none')).toBe(true);
+  });
+  it('ranks voice < halfop < op; owner/admin count as op', () => {
+    expect(meetsJoinMode([], 'voice')).toBe(false);
+    expect(meetsJoinMode(['v'], 'voice')).toBe(true);
+    expect(meetsJoinMode(['v'], 'op')).toBe(false);
+    expect(meetsJoinMode(['h'], 'op')).toBe(false);
+    expect(meetsJoinMode(['h'], 'halfop')).toBe(true);
+    expect(meetsJoinMode(['o'], 'op')).toBe(true);
+    expect(meetsJoinMode(['q'], 'op')).toBe(true);
+    expect(meetsJoinMode(['o'], 'halfop')).toBe(true); // op exceeds the halfop bar
+  });
+});
+
+describe('canModerateCall / canAdminCall', () => {
+  it('moderation allows q/a/o/h; admin (join policy) allows q/a/o only', () => {
+    expect(canModerateCall(['h'])).toBe(true);
+    expect(canModerateCall(['o'])).toBe(true);
+    expect(canModerateCall(['v'])).toBe(false);
+    expect(canModerateCall([])).toBe(false);
+    expect(canAdminCall(['h'])).toBe(false);
+    expect(canAdminCall(['o'])).toBe(true);
+    expect(canAdminCall(['q'])).toBe(true);
+    expect(canAdminCall([])).toBe(false);
+  });
+});
+
+describe('parseRoom', () => {
+  it('is the inverse of roomFor for channel rooms', () => {
+    expect(parseRoom('net-irc.libera.chat-c-#dev')).toEqual({
+      host: 'irc.libera.chat',
+      channel: '#dev',
+    });
+    // Round-trips a host that contains dashes + a channel with brackets.
+    expect(parseRoom(roomFor('my-irc.host.net', '#Foo[Bar]', 'x'))).toEqual({
+      host: 'my-irc.host.net',
+      channel: '#foo[bar]',
+    });
+  });
+
+  it('round-trips ALL FOUR channel sigils (the #&+! rule)', () => {
+    for (const chan of ['#dev', '&local', '+modeless', '!ABCDEchan']) {
+      expect(parseRoom(roomFor('irc.libera.chat', chan, 'x'))).toEqual({
+        host: 'irc.libera.chat',
+        channel: chan.toLowerCase(),
+      });
+    }
+  });
+
+  it("anchors on the FIRST '-c-<sigil>' so a channel containing '-c-#' still parses", () => {
+    // Hostnames can contain '-c-' but never a sigil; channels can contain both.
+    expect(parseRoom('net-my-c-host.net-c-#dev')).toEqual({
+      host: 'my-c-host.net',
+      channel: '#dev',
+    });
+    expect(parseRoom('net-irc.host-c-#a-c-#b')).toEqual({
+      host: 'irc.host',
+      channel: '#a-c-#b',
+    });
+  });
+
+  it('folds ASCII-only so it matches roomFor / foldKey', () => {
+    expect(parseRoom('net-IRC.Libera.Chat-c-#DevOps')).toEqual({
+      host: 'irc.libera.chat',
+      channel: '#devops',
+    });
+  });
+
+  it('returns null for DM rooms and anything unparseable', () => {
+    expect(parseRoom('net-irc.libera.chat-d-alice:bob')).toBeNull();
+    expect(parseRoom('not-a-room')).toBeNull();
+    expect(parseRoom('net-irc.libera.chat-c-notachannel')).toBeNull();
+  });
+});
+
+describe('applyWebhookEvent', () => {
+  const ev = (event: string, room: string, identity?: string): WebhookEvent =>
+    ({
+      event,
+      room: { name: room },
+      participant: identity ? { identity } : undefined,
+    }) as WebhookEvent;
+
+  it('resolves the channel by parsing the room even without a prior rememberRoom', () => {
+    // The regression from the field: after a restart the roomChannel map is
+    // empty, but presence must still broadcast (the room name encodes it).
+    const room = 'net-irc.libera.chat-c-#restart-proof';
+    const change = applyWebhookEvent(ev('participant_joined', room, 'jawsh'));
+    expect(change).toEqual({
+      room,
+      host: 'irc.libera.chat',
+      channel: '#restart-proof',
+      active: true,
+      count: 1,
+    });
+  });
+
+  it('tracks a running count across joins and leaves', () => {
+    const room = 'net-irc.libera.chat-c-#counting';
+    applyWebhookEvent(ev('participant_joined', room, 'a'));
+    const two = applyWebhookEvent(ev('participant_joined', room, 'b'));
+    expect(two?.count).toBe(2);
+    const one = applyWebhookEvent(ev('participant_left', room, 'a'));
+    expect(one).toMatchObject({ count: 1, active: true });
+    const gone = applyWebhookEvent(ev('participant_left', room, 'b'));
+    expect(gone).toMatchObject({ count: 0, active: false });
+  });
+
+  it('prefers the rememberRoom mapping over parsing the room name', () => {
+    const room = 'net-irc.libera.chat-c-#seeded';
+    rememberRoom(room, 'IRC.Libera.Chat', '#Seeded');
+    const change = applyWebhookEvent(ev('participant_joined', room, 'x'));
+    expect(change).toMatchObject({ host: 'irc.libera.chat', channel: '#seeded' });
+  });
+
+  it('ignores DM rooms (no channel to badge) and irrelevant events', () => {
+    expect(applyWebhookEvent(ev('participant_joined', 'net-h-d-a:b', 'a'))).toBeNull();
+    expect(applyWebhookEvent(ev('track_published', 'net-irc.libera.chat-c-#x', 'a'))).toBeNull();
+  });
+});
+
+describe('receiveWebhook / listActiveCalls (unconfigured)', () => {
+  it('both fail closed when voice is unconfigured', async () => {
+    delete process.env.LIVEKIT_WS_URL;
+    delete process.env.LIVEKIT_API_KEY;
+    delete process.env.LIVEKIT_API_SECRET;
+    await expect(receiveWebhook('{}', 'whatever')).resolves.toBeNull();
+    await expect(listActiveCalls()).resolves.toEqual([]);
   });
 });

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -14,7 +14,6 @@ import {
   canModerateCall,
   canAdminCall,
   applyWebhookEvent,
-  rememberRoom,
   receiveWebhook,
   listActiveCalls,
 } from './voice.js';
@@ -236,48 +235,51 @@ describe('parseRoom', () => {
 });
 
 describe('applyWebhookEvent', () => {
-  const ev = (event: string, room: string, identity?: string): WebhookEvent =>
+  const ev = (event: string, room: string, numParticipants?: number): WebhookEvent =>
     ({
       event,
-      room: { name: room },
-      participant: identity ? { identity } : undefined,
+      room: { name: room, numParticipants },
+      participant: { identity: 'someone' },
     }) as WebhookEvent;
 
-  it('resolves the channel by parsing the room even without a prior rememberRoom', () => {
-    // The regression from the field: after a restart the roomChannel map is
-    // empty, but presence must still broadcast (the room name encodes it).
+  it('is stateless: count comes from the event, channel from the room name', () => {
+    // A delta registry lied after a restart (first post-restart join "reset" a
+    // 3-person call to 1; leaves broadcast nothing). Room.numParticipants is
+    // authoritative at event time, so a mid-call restart changes nothing.
     const room = 'net-irc.libera.chat-c-#restart-proof';
-    const change = applyWebhookEvent(ev('participant_joined', room, 'jawsh'));
+    const change = applyWebhookEvent(ev('participant_joined', room, 4));
     expect(change).toEqual({
       room,
       host: 'irc.libera.chat',
       channel: '#restart-proof',
       active: true,
-      count: 1,
+      count: 4,
     });
   });
 
-  it('tracks a running count across joins and leaves', () => {
+  it('handles leaves, aborted connections, and room end', () => {
     const room = 'net-irc.libera.chat-c-#counting';
-    applyWebhookEvent(ev('participant_joined', room, 'a'));
-    const two = applyWebhookEvent(ev('participant_joined', room, 'b'));
-    expect(two?.count).toBe(2);
-    const one = applyWebhookEvent(ev('participant_left', room, 'a'));
-    expect(one).toMatchObject({ count: 1, active: true });
-    const gone = applyWebhookEvent(ev('participant_left', room, 'b'));
-    expect(gone).toMatchObject({ count: 0, active: false });
-  });
-
-  it('prefers the rememberRoom mapping over parsing the room name', () => {
-    const room = 'net-irc.libera.chat-c-#seeded';
-    rememberRoom(room, 'IRC.Libera.Chat', '#Seeded');
-    const change = applyWebhookEvent(ev('participant_joined', room, 'x'));
-    expect(change).toMatchObject({ host: 'irc.libera.chat', channel: '#seeded' });
+    expect(applyWebhookEvent(ev('participant_left', room, 1))).toMatchObject({
+      count: 1,
+      active: true,
+    });
+    expect(applyWebhookEvent(ev('participant_left', room, 0))).toMatchObject({
+      count: 0,
+      active: false,
+    });
+    expect(applyWebhookEvent(ev('participant_connection_aborted', room, 2))).toMatchObject({
+      count: 2,
+    });
+    // room_finished carries no reliable count — it IS the zero.
+    expect(applyWebhookEvent(ev('room_finished', room, 3))).toMatchObject({
+      count: 0,
+      active: false,
+    });
   });
 
   it('ignores DM rooms (no channel to badge) and irrelevant events', () => {
-    expect(applyWebhookEvent(ev('participant_joined', 'net-h-d-a:b', 'a'))).toBeNull();
-    expect(applyWebhookEvent(ev('track_published', 'net-irc.libera.chat-c-#x', 'a'))).toBeNull();
+    expect(applyWebhookEvent(ev('participant_joined', 'net-h-d-a:b', 1))).toBeNull();
+    expect(applyWebhookEvent(ev('track_published', 'net-irc.libera.chat-c-#x', 1))).toBeNull();
   });
 });
 

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -24,7 +24,6 @@ import { AccessToken, RoomServiceClient, WebhookReceiver } from 'livekit-server-
 import type { WebhookEvent } from 'livekit-server-sdk';
 import { isChannelTarget } from '../../shared/channels.js';
 import { parseTruthyEnv } from '../utils/truthyEnv.js';
-import type { MinJoinMode } from '../db/voicePolicy.js';
 
 /** The operator master switch. */
 export function voiceMasterEnabled(): boolean {
@@ -173,37 +172,11 @@ export async function mintVoiceToken(args: {
 }
 
 // ─── Channel-mode authority ────────────────────────────────────────────────
-// IRC prefix modes, ranked. Owner (q), admin (a) and op (o) all count as the
-// top "op" tier; halfop (h) above voice (v). Read from ChannelMember.modes.
+// One definition, shared with the client (the UI mirrors these gates to decide
+// which controls to render) — see shared/voiceModes.ts. Re-exported so server
+// callers keep importing from the voice service.
 
-const MODE_RANK: Record<MinJoinMode, number> = {
-  none: 0,
-  voice: 1,
-  halfop: 2,
-  op: 3,
-};
-const LETTER_RANK: Record<string, number> = { v: 1, h: 2, o: 3, a: 3, q: 3 };
-const MODERATE_LETTERS = new Set(['q', 'a', 'o', 'h']); // may mute/remove in a call
-const OP_LETTERS = new Set(['q', 'a', 'o']); // may set the join policy
-
-/** Does a member holding these prefix modes meet a channel's min join mode? */
-export function meetsJoinMode(modes: readonly string[], min: MinJoinMode): boolean {
-  const need = MODE_RANK[min] ?? 0;
-  if (need === 0) return true;
-  let have = 0;
-  for (const m of modes) have = Math.max(have, LETTER_RANK[m] ?? 0);
-  return have >= need;
-}
-
-/** Ops/halfops — allowed to mute or remove others from a call. */
-export function canModerateCall(modes: readonly string[]): boolean {
-  return modes.some((m) => MODERATE_LETTERS.has(m));
-}
-
-/** Ops (q/a/o) — allowed to set the join policy. */
-export function canAdminCall(modes: readonly string[]): boolean {
-  return modes.some((m) => OP_LETTERS.has(m));
-}
+export { meetsJoinMode, canModerateCall, canAdminCall } from '../../shared/voiceModes.js';
 
 // ─── Server-side room control (moderation) ─────────────────────────────────
 // A fresh RoomServiceClient per call — construction is cheap and a config
@@ -217,9 +190,11 @@ function roomService(): RoomServiceClient | null {
   return new RoomServiceClient(cfg.wsUrl.replace(/^ws/, 'http'), cfg.apiKey, cfg.apiSecret);
 }
 
-/** Force-remove a participant (by identity) from a room. This is also the
- *  revocation path for an already-minted 2h token: LiveKit bans re-joining on
- *  the same token after a removeParticipant. */
+/** Force-remove a participant (by identity) from a room. NOTE: on self-hosted
+ *  (OSS) LiveKit this does NOT invalidate their still-valid join token —
+ *  immediate token revocation on removal is a LiveKit Cloud feature. Well-
+ *  behaved client SDKs won't auto-rejoin after a removal, but a raw client can
+ *  reconnect until the token's 2h TTL runs out. Docs carry the honest caveat. */
 export async function removeFromCall(room: string, identity: string): Promise<void> {
   const svc = roomService();
   if (!svc) throw new Error('voice not configured');
@@ -263,21 +238,13 @@ export async function listActiveCalls(): Promise<
   return out;
 }
 
-// ─── Call presence registry (fed by LiveKit webhooks) ──────────────────────
-// In-memory: which identities are in each room, plus a room → (host, channel)
-// map recorded at token mint so a webhook can resolve a room back to its
-// channel without re-parsing the room string. Lost on restart — parseRoom is
-// the fallback, and /presence re-hydrates clients from the SFU.
-
-const roomParticipants = new Map<string, Set<string>>();
-const roomChannel = new Map<string, { host: string; channel: string }>();
-
-/** Record the (host, channel) a room maps to — called when a CHANNEL token is
- *  minted. DM rooms are deliberately never registered: DM calls broadcast no
- *  presence (that would leak who is talking to whom). */
-export function rememberRoom(room: string, host: string, channel: string): void {
-  roomChannel.set(room, { host: foldAscii(host), channel: foldAscii(channel) });
-}
+// ─── Call presence (fed by LiveKit webhooks) ───────────────────────────────
+// Deliberately STATELESS. An earlier draft kept an in-memory identity registry
+// and derived counts from join/leave deltas — which lies after a restart (the
+// first post-restart join "resets" a 3-person call's badge to 1, and leaves
+// with an empty registry broadcast nothing, freezing badges). The webhook event
+// itself carries the authoritative Room.numParticipants at event time, and the
+// room NAME encodes (host, channel) — so there is nothing worth remembering.
 
 export interface CallPresenceChange {
   room: string;
@@ -302,37 +269,29 @@ export async function receiveWebhook(
   }
 }
 
-/** Apply a parsed webhook event to the registry. Returns the presence change to
- *  broadcast, or null when the event is irrelevant or the room is not a channel
- *  room (DM presence is never broadcast). */
+/** Turn a verified webhook event into the presence change to broadcast, or
+ *  null when the event carries no occupancy change or the room is not a
+ *  channel room (DM presence is never broadcast — that would leak who is
+ *  talking to whom). Counts come from the event's own Room.numParticipants —
+ *  authoritative at event time and immune to a Lurker restart. */
 export function applyWebhookEvent(ev: WebhookEvent): CallPresenceChange | null {
   const room = ev.room?.name;
   if (!room) return null;
-  const ident = ev.participant?.identity;
-  let set = roomParticipants.get(room);
+  let count: number;
   switch (ev.event) {
     case 'participant_joined':
-      if (!ident) return null;
-      if (!set) roomParticipants.set(room, (set = new Set()));
-      set.add(ident);
-      break;
     case 'participant_left':
-      if (!ident || !set) return null;
-      set.delete(ident);
-      if (set.size === 0) roomParticipants.delete(room);
+    case 'participant_connection_aborted':
+      count = Number(ev.room?.numParticipants ?? 0);
       break;
     case 'room_finished':
-      roomParticipants.delete(room);
+      count = 0;
       break;
     default:
       return null;
   }
-  // Prefer the map seeded at token-mint, but fall back to parsing the room
-  // name so presence survives a restart that cleared the map while a call
-  // kept running (the room name encodes both halves).
-  const mapping = roomChannel.get(room) ?? parseRoom(room);
+  const mapping = parseRoom(room); // the room name encodes (host, channel)
   if (!mapping) return null; // DM room / unparseable → nothing to broadcast
-  const count = roomParticipants.get(room)?.size ?? 0;
   return {
     room,
     host: mapping.host,

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -201,8 +201,11 @@ export async function removeFromCall(room: string, identity: string): Promise<vo
   await svc.removeParticipant(room, identity);
 }
 
-/** Server-mute all of a participant's published tracks (they cannot self-unmute
- *  a server mute). No-op if they are not currently in the room. */
+/** Server-mute all of a participant's published tracks. NOTE: on self-hosted
+ *  (OSS) LiveKit a server mute is not locked — the participant can unmute
+ *  themselves (mute-locking, like token revocation, is a Cloud feature). Their
+ *  client shows "an operator muted you", so it reads as a strong nudge; the
+ *  enforcement tool is remove. No-op if they are not currently in the room. */
 export async function muteParticipant(room: string, identity: string): Promise<void> {
   const svc = roomService();
   if (!svc) throw new Error('voice not configured');

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -20,9 +20,11 @@
 // put the two ends in two different rooms. So DM rooms are keyed by the
 // *canonical* (sorted) nick pair instead.
 
-import { AccessToken } from 'livekit-server-sdk';
+import { AccessToken, RoomServiceClient, WebhookReceiver } from 'livekit-server-sdk';
+import type { WebhookEvent } from 'livekit-server-sdk';
 import { isChannelTarget } from '../../shared/channels.js';
 import { parseTruthyEnv } from '../utils/truthyEnv.js';
+import type { MinJoinMode } from '../db/voicePolicy.js';
 
 /** The operator master switch. */
 export function voiceMasterEnabled(): boolean {
@@ -48,6 +50,15 @@ export function liveKitConfig(): LiveKitConfig | null {
 /** Voice is live only when the operator opted in AND the SFU is configured. */
 export function voiceEnabled(): boolean {
   return voiceMasterEnabled() && liveKitConfig() !== null;
+}
+
+/** ASCII-fold a host to the key used for room names, policy rows, and
+ *  presence-fanout comparison. Exported so routes fold identically to
+ *  roomFor(). Hostnames are DNS names — plain ASCII case-insensitivity is the
+ *  whole rule; channel/nick folding is casemapping territory and happens with
+ *  foldTargetFor at the route. */
+export function foldKey(s: string): string {
+  return foldAscii(s);
 }
 
 // ASCII-only lowercasing, to match the client casefold contract (docs
@@ -104,6 +115,26 @@ export function roomFor(networkKey: string, target: string, self: string): strin
   return `net-${net}-d-${lo}:${hi}`;
 }
 
+/**
+ * Inverse of roomFor for CHANNEL rooms: recover (host, channel) from a room
+ * name, both already folded. Returns null for DM rooms (no channel) or anything
+ * unparseable. This lets a webhook resolve presence to a channel even when the
+ * in-memory roomChannel map was never seeded for the room — e.g. after a Lurker
+ * restart mid-call, or a call started on another instance sharing the SFU.
+ *
+ * The anchor is the FIRST `-c-` followed by a channel sigil (lazy `.+?`): a
+ * hostname can legally contain `-c-` but never a sigil character, while a
+ * channel name may itself contain `-c-#…` — so the first sigil-anchored hit is
+ * always the true host/channel boundary. All four sigils (#&+!), per
+ * shared/channels.ts — anchoring on `[#&]` alone would silently drop the
+ * restart-survival fallback for `+`/`!` channels.
+ */
+export function parseRoom(room: string): { host: string; channel: string } | null {
+  const m = /^net-(.+?)-c-([#&+!].*)$/.exec(room);
+  if (!m) return null;
+  return { host: foldAscii(m[1]!), channel: foldAscii(m[2]!) };
+}
+
 export interface MintedToken {
   /** The signed JWT the client passes to LiveKit. */
   token: string;
@@ -139,4 +170,174 @@ export async function mintVoiceToken(args: {
   });
   const token = await at.toJwt();
   return { token, room: args.room, url: cfg.wsUrl };
+}
+
+// ─── Channel-mode authority ────────────────────────────────────────────────
+// IRC prefix modes, ranked. Owner (q), admin (a) and op (o) all count as the
+// top "op" tier; halfop (h) above voice (v). Read from ChannelMember.modes.
+
+const MODE_RANK: Record<MinJoinMode, number> = {
+  none: 0,
+  voice: 1,
+  halfop: 2,
+  op: 3,
+};
+const LETTER_RANK: Record<string, number> = { v: 1, h: 2, o: 3, a: 3, q: 3 };
+const MODERATE_LETTERS = new Set(['q', 'a', 'o', 'h']); // may mute/remove in a call
+const OP_LETTERS = new Set(['q', 'a', 'o']); // may set the join policy
+
+/** Does a member holding these prefix modes meet a channel's min join mode? */
+export function meetsJoinMode(modes: readonly string[], min: MinJoinMode): boolean {
+  const need = MODE_RANK[min] ?? 0;
+  if (need === 0) return true;
+  let have = 0;
+  for (const m of modes) have = Math.max(have, LETTER_RANK[m] ?? 0);
+  return have >= need;
+}
+
+/** Ops/halfops — allowed to mute or remove others from a call. */
+export function canModerateCall(modes: readonly string[]): boolean {
+  return modes.some((m) => MODERATE_LETTERS.has(m));
+}
+
+/** Ops (q/a/o) — allowed to set the join policy. */
+export function canAdminCall(modes: readonly string[]): boolean {
+  return modes.some((m) => OP_LETTERS.has(m));
+}
+
+// ─── Server-side room control (moderation) ─────────────────────────────────
+// A fresh RoomServiceClient per call — construction is cheap and a config
+// change (secret rotation) is always picked up. API host is the wss URL mapped
+// to http(s). These act with roomAdmin, which the SDK signs from the same api
+// key/secret — clients never receive an admin-capable token.
+
+function roomService(): RoomServiceClient | null {
+  const cfg = liveKitConfig();
+  if (!cfg) return null;
+  return new RoomServiceClient(cfg.wsUrl.replace(/^ws/, 'http'), cfg.apiKey, cfg.apiSecret);
+}
+
+/** Force-remove a participant (by identity) from a room. This is also the
+ *  revocation path for an already-minted 2h token: LiveKit bans re-joining on
+ *  the same token after a removeParticipant. */
+export async function removeFromCall(room: string, identity: string): Promise<void> {
+  const svc = roomService();
+  if (!svc) throw new Error('voice not configured');
+  await svc.removeParticipant(room, identity);
+}
+
+/** Server-mute all of a participant's published tracks (they cannot self-unmute
+ *  a server mute). No-op if they are not currently in the room. */
+export async function muteParticipant(room: string, identity: string): Promise<void> {
+  const svc = roomService();
+  if (!svc) throw new Error('voice not configured');
+  const parts = await svc.listParticipants(room);
+  const p = parts.find((x) => x.identity === identity);
+  if (!p) return;
+  for (const t of p.tracks ?? []) {
+    await svc.mutePublishedTrack(room, identity, t.sid, true);
+  }
+}
+
+/** Snapshot every active CHANNEL call the SFU currently knows about, so a
+ *  freshly-connected client can hydrate presence badges for calls that started
+ *  before it connected — the webhook stream only carries live deltas. LiveKit
+ *  is the source of truth, so this is correct across a Lurker restart (unlike
+ *  the in-memory registry). Returns [] when voice is unconfigured. */
+export async function listActiveCalls(): Promise<
+  Array<{ host: string; channel: string; count: number }>
+> {
+  const svc = roomService();
+  if (!svc) return [];
+  const rooms = await svc.listRooms();
+  const out: Array<{ host: string; channel: string; count: number }> = [];
+  for (const r of rooms) {
+    const parsed = parseRoom(r.name);
+    if (!parsed) continue; // DM rooms + anything unparseable carry no channel badge
+    out.push({
+      host: parsed.host,
+      channel: parsed.channel,
+      count: r.numParticipants ?? 0,
+    });
+  }
+  return out;
+}
+
+// ─── Call presence registry (fed by LiveKit webhooks) ──────────────────────
+// In-memory: which identities are in each room, plus a room → (host, channel)
+// map recorded at token mint so a webhook can resolve a room back to its
+// channel without re-parsing the room string. Lost on restart — parseRoom is
+// the fallback, and /presence re-hydrates clients from the SFU.
+
+const roomParticipants = new Map<string, Set<string>>();
+const roomChannel = new Map<string, { host: string; channel: string }>();
+
+/** Record the (host, channel) a room maps to — called when a CHANNEL token is
+ *  minted. DM rooms are deliberately never registered: DM calls broadcast no
+ *  presence (that would leak who is talking to whom). */
+export function rememberRoom(room: string, host: string, channel: string): void {
+  roomChannel.set(room, { host: foldAscii(host), channel: foldAscii(channel) });
+}
+
+export interface CallPresenceChange {
+  room: string;
+  host: string;
+  channel: string;
+  active: boolean;
+  count: number;
+}
+
+/** Verify + parse a LiveKit webhook body. Null if the signature is invalid or
+ *  voice is unconfigured. */
+export async function receiveWebhook(
+  body: string,
+  authHeader: string | undefined,
+): Promise<WebhookEvent | null> {
+  const cfg = liveKitConfig();
+  if (!cfg) return null;
+  try {
+    return await new WebhookReceiver(cfg.apiKey, cfg.apiSecret).receive(body, authHeader);
+  } catch {
+    return null;
+  }
+}
+
+/** Apply a parsed webhook event to the registry. Returns the presence change to
+ *  broadcast, or null when the event is irrelevant or the room is not a channel
+ *  room (DM presence is never broadcast). */
+export function applyWebhookEvent(ev: WebhookEvent): CallPresenceChange | null {
+  const room = ev.room?.name;
+  if (!room) return null;
+  const ident = ev.participant?.identity;
+  let set = roomParticipants.get(room);
+  switch (ev.event) {
+    case 'participant_joined':
+      if (!ident) return null;
+      if (!set) roomParticipants.set(room, (set = new Set()));
+      set.add(ident);
+      break;
+    case 'participant_left':
+      if (!ident || !set) return null;
+      set.delete(ident);
+      if (set.size === 0) roomParticipants.delete(room);
+      break;
+    case 'room_finished':
+      roomParticipants.delete(room);
+      break;
+    default:
+      return null;
+  }
+  // Prefer the map seeded at token-mint, but fall back to parsing the room
+  // name so presence survives a restart that cleared the map while a call
+  // kept running (the room name encodes both halves).
+  const mapping = roomChannel.get(room) ?? parseRoom(room);
+  if (!mapping) return null; // DM room / unparseable → nothing to broadcast
+  const count = roomParticipants.get(room)?.size ?? 0;
+  return {
+    room,
+    host: mapping.host,
+    channel: mapping.channel,
+    active: count > 0,
+    count,
+  };
 }

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -241,13 +241,16 @@ export async function listActiveCalls(): Promise<
   return out;
 }
 
-// ─── Call presence (fed by LiveKit webhooks) ───────────────────────────────
-// Deliberately STATELESS. An earlier draft kept an in-memory identity registry
-// and derived counts from join/leave deltas — which lies after a restart (the
-// first post-restart join "resets" a 3-person call's badge to 1, and leaves
-// with an empty registry broadcast nothing, freezing badges). The webhook event
-// itself carries the authoritative Room.numParticipants at event time, and the
-// room NAME encodes (host, channel) — so there is nothing worth remembering.
+// ─── Call presence (webhooks trigger, the SFU API answers) ─────────────────
+// Two designs died before this one. A delta registry lies after a restart (the
+// first post-restart join "resets" a 3-person badge to 1). The event's own
+// Room.numParticipants looked authoritative but is not, verified against a live
+// SFU: it is ABSENT (=0) on participant_joined, and on participant_left it
+// still included the leaver AND a participant whose unclean disconnect hadn't
+// registered yet. So a webhook is only a TRIGGER that occupancy changed; the
+// count is fetched from the SFU's participant list — the same source /presence
+// hydration uses, which QA showed is right. One API round-trip per join/leave
+// is nothing at call-event rates.
 
 export interface CallPresenceChange {
   room: string;
@@ -272,34 +275,44 @@ export async function receiveWebhook(
   }
 }
 
-/** Turn a verified webhook event into the presence change to broadcast, or
- *  null when the event carries no occupancy change or the room is not a
- *  channel room (DM presence is never broadcast — that would leak who is
- *  talking to whom). Counts come from the event's own Room.numParticipants —
- *  authoritative at event time and immune to a Lurker restart. */
-export function applyWebhookEvent(ev: WebhookEvent): CallPresenceChange | null {
+/** Pure half: does this verified webhook event mean a CHANNEL room's occupancy
+ *  may have changed, and for which (host, channel)? Null for non-occupancy
+ *  events and for DM rooms (DM presence is never broadcast — that would leak
+ *  who is talking to whom). */
+export function webhookCallRoom(
+  ev: WebhookEvent,
+): { room: string; host: string; channel: string } | null {
   const room = ev.room?.name;
   if (!room) return null;
-  let count: number;
   switch (ev.event) {
     case 'participant_joined':
     case 'participant_left':
     case 'participant_connection_aborted':
-      count = Number(ev.room?.numParticipants ?? 0);
-      break;
     case 'room_finished':
-      count = 0;
       break;
     default:
       return null;
   }
   const mapping = parseRoom(room); // the room name encodes (host, channel)
-  if (!mapping) return null; // DM room / unparseable → nothing to broadcast
-  return {
-    room,
-    host: mapping.host,
-    channel: mapping.channel,
-    active: count > 0,
-    count,
-  };
+  if (!mapping) return null;
+  return { room, host: mapping.host, channel: mapping.channel };
+}
+
+/** The room's live participant count straight from the SFU, or null when it
+ *  can't be determined (unconfigured / API failure) — callers must SKIP the
+ *  broadcast then, because a made-up 0 would wrongly clear every badge on a
+ *  transient error. A room the SFU no longer knows counts as genuinely 0. */
+export async function liveCallCount(room: string): Promise<number | null> {
+  const svc = roomService();
+  if (!svc) return null;
+  try {
+    return (await svc.listParticipants(room)).length;
+  } catch (err) {
+    // listParticipants rejects for a closed/unknown room — that IS zero. Only
+    // treat it as unknown if the SFU itself was unreachable.
+    const msg = String((err as Error)?.message ?? err);
+    if (/not found|does not exist|404/i.test(msg)) return 0;
+    console.error('[voice] live count query failed:', err);
+    return null;
+  }
 }

--- a/shared/voiceModes.ts
+++ b/shared/voiceModes.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// The single definition of voice-call mode authority, shared by both tiers —
+// the server enforces it (services/voice.ts, routes/voice.ts) and the client
+// mirrors it to decide which controls to render (CallBar, MemberList). Split
+// across tiers this had already been copied three times; a rank change made in
+// one place would desynchronize what the UI shows from what the server allows.
+//
+// IRC prefix modes, ranked. Owner (q), admin (a) and op (o) all count as the
+// top "op" tier; halfop (h) above voice (v). Read from a member's mode letters.
+//
+// (useMemberActions has its own op/halfop sets for the IRC action menus — that
+// is deliberate: kick/ban authority is the IRC server's call, not ours, and
+// its UX gates predate voice. Only VOICE-call authority lives here.)
+
+/** The lowest prefix mode allowed to join a channel's call. */
+export type MinJoinMode = 'none' | 'voice' | 'halfop' | 'op';
+
+const VALID_MODES: ReadonlySet<string> = new Set(['none', 'voice', 'halfop', 'op']);
+
+/** Strict validation — for WRITE boundaries. A security control must reject
+ *  unknown input, never coerce it (a coerced typo silently UNRESTRICTS the
+ *  call, because the fallback is 'none'). */
+export function isMinJoinMode(raw: unknown): raw is MinJoinMode {
+  return typeof raw === 'string' && VALID_MODES.has(raw);
+}
+
+/** Lenient normalization — for READS. A stored value from a future/older
+ *  version fails open to 'none' instead of throwing. */
+export function normalizeMinJoinMode(raw: unknown): MinJoinMode {
+  return isMinJoinMode(raw) ? raw : 'none';
+}
+
+const MODE_RANK: Record<MinJoinMode, number> = {
+  none: 0,
+  voice: 1,
+  halfop: 2,
+  op: 3,
+};
+const LETTER_RANK: Record<string, number> = { v: 1, h: 2, o: 3, a: 3, q: 3 };
+const MODERATE_LETTERS = new Set(['q', 'a', 'o', 'h']); // may mute/remove in a call
+const OP_LETTERS = new Set(['q', 'a', 'o']); // may set the join policy
+
+/** Does a member holding these prefix modes meet a channel's min join mode? */
+export function meetsJoinMode(modes: readonly string[], min: MinJoinMode): boolean {
+  const need = MODE_RANK[min] ?? 0;
+  if (need === 0) return true;
+  let have = 0;
+  for (const m of modes) have = Math.max(have, LETTER_RANK[m] ?? 0);
+  return have >= need;
+}
+
+/** Ops/halfops — allowed to mute or remove others from a call. */
+export function canModerateCall(modes: readonly string[]): boolean {
+  return modes.some((m) => MODERATE_LETTERS.has(m));
+}
+
+/** Ops (q/a/o) — allowed to set the join policy. */
+export function canAdminCall(modes: readonly string[]): boolean {
+  return modes.some((m) => OP_LETTERS.has(m));
+}

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -41,6 +41,19 @@
               aria-hidden="true"
             ></i>
             <span class="part-nick" :title="id">{{ id }}</span>
+            <IconButton
+              v-if="amOp"
+              icon="fa-microphone-slash"
+              :label="`Mute ${id} for everyone`"
+              @click="moderate(id, 'mute')"
+            />
+            <IconButton
+              v-if="amOp"
+              icon="fa-user-slash"
+              :label="`Remove ${id} from call`"
+              danger
+              @click="moderate(id, 'remove')"
+            />
           </div>
           <input
             class="vol"
@@ -73,15 +86,44 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useVoiceStore } from '../stores/voice.js';
+import { useBuffersStore, bufferKey } from '../stores/buffers.js';
+import { useNetworksStore } from '../stores/networks.js';
+import { api } from '../api.js';
 import IconButton from './IconButton.vue';
 
 const voice = useVoiceStore();
+const buffers = useBuffersStore();
+const networks = useNetworksStore();
 
 const statusText = computed(() => {
   if (voice.connecting) return 'connecting…';
   if (voice.active) return 'connected';
   return 'call failed';
 });
+
+// ─── Op moderation (q/a/o/h — mirrors the server's canModerateCall gate) ────
+// The server enforces; showing the buttons only to ops is UX, not security.
+const MODERATE_MODES = ['q', 'a', 'o', 'h'];
+const amOp = computed(() => {
+  if (voice.networkId == null || !voice.target) return false;
+  const b = buffers.byKey(bufferKey(voice.networkId, voice.target));
+  const selfNick = networks.states[voice.networkId]?.nick;
+  if (!b || !selfNick) return false;
+  const me = b.members?.find((m) => m.nick.toLowerCase() === selfNick.toLowerCase());
+  return !!me?.modes?.some((mm) => MODERATE_MODES.includes(mm));
+});
+
+async function moderate(identity: string, action: 'mute' | 'remove') {
+  if (voice.networkId == null) return;
+  try {
+    await api('/api/voice/moderate', {
+      method: 'POST',
+      body: { networkId: voice.networkId, target: voice.target, action, identity },
+    });
+  } catch (e: unknown) {
+    voice.error = e instanceof Error ? e.message : 'moderation failed';
+  }
+}
 
 function volPct(id: string): number {
   return Math.round((voice.volumes[id] ?? 1) * 100);

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -88,6 +88,7 @@ import { computed } from 'vue';
 import { useVoiceStore } from '../stores/voice.js';
 import { useBuffersStore, bufferKey } from '../stores/buffers.js';
 import { useNetworksStore } from '../stores/networks.js';
+import { useToastsStore } from '../stores/toasts.js';
 import { canModerateCall } from '../../../shared/voiceModes.js';
 import { api } from '../api.js';
 import IconButton from './IconButton.vue';
@@ -121,7 +122,13 @@ async function moderate(identity: string, action: 'mute' | 'remove') {
       body: { networkId: voice.networkId, target: voice.target, action, identity },
     });
   } catch (e: unknown) {
-    voice.error = e instanceof Error ? e.message : 'moderation failed';
+    // A toast, NOT voice.error — that field means "the CALL failed" and keeps
+    // the bar rendered; a failed moderation click must not wedge it open.
+    useToastsStore().push({
+      title: `Could not ${action} ${identity}`,
+      body: e instanceof Error ? e.message : 'the server rejected the action',
+      kind: 'warn',
+    });
   }
 }
 

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -88,6 +88,7 @@ import { computed } from 'vue';
 import { useVoiceStore } from '../stores/voice.js';
 import { useBuffersStore, bufferKey } from '../stores/buffers.js';
 import { useNetworksStore } from '../stores/networks.js';
+import { canModerateCall } from '../../../shared/voiceModes.js';
 import { api } from '../api.js';
 import IconButton from './IconButton.vue';
 
@@ -101,16 +102,15 @@ const statusText = computed(() => {
   return 'call failed';
 });
 
-// ─── Op moderation (q/a/o/h — mirrors the server's canModerateCall gate) ────
+// ─── Op moderation (the same shared gate the server enforces) ───────────────
 // The server enforces; showing the buttons only to ops is UX, not security.
-const MODERATE_MODES = ['q', 'a', 'o', 'h'];
 const amOp = computed(() => {
   if (voice.networkId == null || !voice.target) return false;
   const b = buffers.byKey(bufferKey(voice.networkId, voice.target));
   const selfNick = networks.states[voice.networkId]?.nick;
   if (!b || !selfNick) return false;
   const me = b.members?.find((m) => m.nick.toLowerCase() === selfNick.toLowerCase());
-  return !!me?.modes?.some((mm) => MODERATE_MODES.includes(mm));
+  return canModerateCall(me?.modes ?? []);
 });
 
 async function moderate(identity: string, action: 'mute' | 'remove') {

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -14,8 +14,17 @@
         @click="startCall"
       >
         <i class="fa-solid fa-phone" aria-hidden="true"></i>
-        <span>{{ inThisCall ? 'In call' : 'Call' }}</span>
+        <span>{{ callBtnLabel }}</span>
       </button>
+      <label v-if="isOp" class="call-policy" title="Who may join this channel's call">
+        <span>Join</span>
+        <select :value="policy" @change="onPolicyChange">
+          <option value="none">anyone</option>
+          <option value="voice">voiced+</option>
+          <option value="halfop">halfop+</option>
+          <option value="op">ops only</option>
+        </select>
+      </label>
     </div>
     <ul ref="listEl">
       <li
@@ -59,6 +68,8 @@ import { useMemberActions } from '../composables/useMemberActions.js';
 import { useIgnoresStore } from '../stores/ignores.js';
 import { useConfigStore } from '../stores/config.js';
 import { useVoiceStore } from '../stores/voice.js';
+import { useCallPresenceStore } from '../stores/callPresence.js';
+import { api } from '../api.js';
 import {
   PREFIX_ORDER,
   prefixOf as modePrefixOf,
@@ -94,6 +105,60 @@ function startCall() {
   if (!b || b.networkId == null) return;
   // label = the channel target; the store mints its own token + room.
   void voice.startCall(b.networkId, b.target, b.target);
+}
+
+// "Join call (N)" badge for a call already in progress (webhook-driven counts,
+// hydrated on connect — see stores/callPresence).
+const callPresence = useCallPresenceStore();
+const callCount = computed(() => {
+  const b = buffer.value;
+  return b?.networkId != null ? callPresence.countFor(b.networkId, b.target) : 0;
+});
+const callBtnLabel = computed(() => {
+  if (inThisCall.value) return 'In call';
+  if (callCount.value > 0) return `Join call (${callCount.value})`;
+  return 'Call';
+});
+
+// ─── Op join policy (q/a/o — mirrors the server's canAdminCall gate) ────────
+const OP_MODES = ['q', 'a', 'o'];
+const isOp = computed(() => selfModes.value.some((m) => OP_MODES.includes(m)));
+
+const policy = ref('none');
+
+// Load the channel's join policy whenever the active channel changes. Any
+// member may read it; only ops see the control (and only the server lets them
+// change it).
+watch(
+  buffer,
+  async (b) => {
+    policy.value = 'none';
+    if (!config.voiceEnabled || !b || b.kind !== 'channel' || b.networkId == null) return;
+    try {
+      const r = await api<{ minJoinMode: string }>(
+        `/api/voice/policy?networkId=${b.networkId}&target=${encodeURIComponent(b.target)}`,
+      );
+      policy.value = r.minJoinMode;
+    } catch {
+      /* leave default */
+    }
+  },
+  { immediate: true },
+);
+
+async function onPolicyChange(e: Event) {
+  const b = buffer.value;
+  if (!b || b.networkId == null) return;
+  const minJoinMode = (e.target as HTMLSelectElement).value;
+  try {
+    const r = await api<{ minJoinMode: string }>('/api/voice/policy', {
+      method: 'PUT',
+      body: { networkId: b.networkId, target: b.target, minJoinMode },
+    });
+    policy.value = r.minJoinMode;
+  } catch {
+    /* keep previous */
+  }
 }
 const selfNick = computed(() => {
   const b = buffer.value;
@@ -235,6 +300,17 @@ const sorted = computed(() => {
   align-items: center;
   justify-content: center;
   gap: var(--space-3);
+}
+.call-policy {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  color: var(--fg-muted);
+}
+.call-policy select {
+  flex: 1;
+  min-width: 0;
 }
 ul {
   list-style: none;

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -69,6 +69,8 @@ import { useIgnoresStore } from '../stores/ignores.js';
 import { useConfigStore } from '../stores/config.js';
 import { useVoiceStore } from '../stores/voice.js';
 import { useCallPresenceStore } from '../stores/callPresence.js';
+import { useToastsStore } from '../stores/toasts.js';
+import { canAdminCall } from '../../../shared/voiceModes.js';
 import { api } from '../api.js';
 import {
   PREFIX_ORDER,
@@ -120,24 +122,27 @@ const callBtnLabel = computed(() => {
   return 'Call';
 });
 
-// ─── Op join policy (q/a/o — mirrors the server's canAdminCall gate) ────────
-const OP_MODES = ['q', 'a', 'o'];
-const isOp = computed(() => selfModes.value.some((m) => OP_MODES.includes(m)));
+// ─── Op join policy (the same shared gate the server enforces) ──────────────
+const isOp = computed(() => canAdminCall(selfModes.value));
 
 const policy = ref('none');
 
-// Load the channel's join policy whenever the active channel changes. Any
-// member may read it; only ops see the control (and only the server lets them
-// change it).
+// Load the channel's join policy whenever the active channel changes — or when
+// voiceEnabled flips true, because the config fetch is async and can resolve
+// AFTER the immediate fire (a deep-linked cold load would otherwise show
+// 'anyone' for a locked channel and never retry).
 watch(
-  buffer,
-  async (b) => {
+  [buffer, () => config.voiceEnabled],
+  async ([b]) => {
     policy.value = 'none';
     if (!config.voiceEnabled || !b || b.kind !== 'channel' || b.networkId == null) return;
     try {
       const r = await api<{ minJoinMode: string }>(
         `/api/voice/policy?networkId=${b.networkId}&target=${encodeURIComponent(b.target)}`,
       );
+      // Staleness guard: a slow response for the PREVIOUS channel must not
+      // overwrite the picker after a switch.
+      if (buffer.value !== b) return;
       policy.value = r.minJoinMode;
     } catch {
       /* leave default */
@@ -148,16 +153,26 @@ watch(
 
 async function onPolicyChange(e: Event) {
   const b = buffer.value;
+  const select = e.target as HTMLSelectElement;
   if (!b || b.networkId == null) return;
-  const minJoinMode = (e.target as HTMLSelectElement).value;
+  const minJoinMode = select.value;
   try {
     const r = await api<{ minJoinMode: string }>('/api/voice/policy', {
       method: 'PUT',
       body: { networkId: b.networkId, target: b.target, minJoinMode },
     });
     policy.value = r.minJoinMode;
-  } catch {
-    /* keep previous */
+  } catch (err: unknown) {
+    // The DOM select already moved to the rejected choice, and since
+    // policy.value didn't change Vue schedules no re-patch — reset the element
+    // directly, and say why (an op believing a call is locked when it isn't is
+    // the worst silent failure this picker can produce).
+    select.value = policy.value;
+    useToastsStore().push({
+      title: 'Call policy not saved',
+      body: err instanceof Error ? err.message : 'the server rejected the change',
+      kind: 'warn',
+    });
   }
 }
 const selfNick = computed(() => {

--- a/vue_client/src/composables/useCallPresenceHydration.ts
+++ b/vue_client/src/composables/useCallPresenceHydration.ts
@@ -47,9 +47,17 @@ export function startCallPresenceHydration(): void {
 
     watch(
       hydratableKey,
-      (key) => {
+      (key, oldKey) => {
         if (!key) return;
-        for (const id of key.split(',')) void presence.hydrate(Number(id));
+        // Only networks that newly ENTERED the hydratable set — at boot the
+        // networks connect one by one and the key changes N times; re-fetching
+        // every already-hydrated network each time would be O(N²) requests.
+        // (An empty→set transition covers the reconnect edge: the key drops to
+        // '' while the socket is down, so every network re-enters on connect.)
+        const before = new Set((oldKey ?? '').split(',').filter(Boolean));
+        for (const id of key.split(',')) {
+          if (!before.has(id)) void presence.hydrate(Number(id));
+        }
       },
       { immediate: true },
     );

--- a/vue_client/src/composables/useCallPresenceHydration.ts
+++ b/vue_client/src/composables/useCallPresenceHydration.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Keeps voice-call presence badges correct across connect/reconnect edges. The
+// server's `call-presence` frame only carries live join/leave deltas, so a
+// client that connects (cold launch) or reconnects mid-call would otherwise
+// never learn about a call that started while it had no socket. On each connect
+// edge we re-snapshot every connected network's active calls from the server
+// (which reads the SFU — correct even across a Lurker restart).
+//
+// Detached, idempotent module singleton — mirrors startBufferHydration so it
+// survives the Desktop<->Mobile shell swap without double-registering.
+
+import { computed, effectScope, watch } from 'vue';
+import { connected } from './useSocket.js';
+import { useNetworksStore } from '../stores/networks.js';
+import { useConfigStore } from '../stores/config.js';
+import { useCallPresenceStore } from '../stores/callPresence.js';
+
+let started = false;
+
+export function startCallPresenceHydration(): void {
+  if (started) return;
+  started = true;
+
+  effectScope(true).run(() => {
+    const networks = useNetworksStore();
+    const config = useConfigStore();
+    const presence = useCallPresenceStore();
+
+    // The set of networks we can meaningfully hydrate right now, as a stable
+    // string key. Watching this (not the raw `connected` edge) is what makes
+    // hydration reliable: a network's per-connection state arrives over the WS
+    // *after* the socket opens, and voiceEnabled lands after the config fetch —
+    // a one-shot fire on the connect edge would run before either was ready
+    // and never retry. Re-deriving from all three reactive inputs fires the
+    // moment a network actually becomes connected, on every reconnect, and if
+    // voice is enabled late.
+    const hydratableKey = computed(() => {
+      if (!connected.value || !config.voiceEnabled) return '';
+      return networks.networks
+        .filter((n) => networks.states[n.id]?.state === 'connected')
+        .map((n) => n.id)
+        .sort((a, b) => a - b)
+        .join(',');
+    });
+
+    watch(
+      hydratableKey,
+      (key) => {
+        if (!key) return;
+        for (const id of key.split(',')) void presence.hydrate(Number(id));
+      },
+      { immediate: true },
+    );
+  });
+}

--- a/vue_client/src/composables/useChatBootstrap.ts
+++ b/vue_client/src/composables/useChatBootstrap.ts
@@ -13,6 +13,7 @@ import { onJumpIntent } from './useJumpIntent.js';
 import { connected } from './useSocket.js';
 import { startAppBadge } from './useAppBadge.js';
 import { startBufferHydration } from './useBufferHydration.js';
+import { startCallPresenceHydration } from './useCallPresenceHydration.js';
 import { whenReady } from './deferredReady.js';
 import type { Router } from 'vue-router';
 import { useRouter } from 'vue-router';
@@ -233,6 +234,11 @@ export function useChatBootstrap({ onJump }: ChatBootstrapOptions = {}): void {
     // send failures (idempotent module singleton, like the presence reporter —
     // survives the Desktop<->Mobile shell swap without double-registering).
     startBufferHydration();
+    // Re-snapshot voice-call presence per connect edge: the call-presence
+    // frame stream only carries deltas, so a call that started while this
+    // client was away would otherwise never badge. Same idempotent-singleton
+    // shape as the hydrators above.
+    startCallPresenceHydration();
     // Mirror the unread-highlight total onto the PWA app icon (#451). Idempotent
     // and feature-detected — a no-op where the Badging API is unavailable.
     startAppBadge();

--- a/vue_client/src/composables/useSocket.ts
+++ b/vue_client/src/composables/useSocket.ts
@@ -29,6 +29,7 @@ import { useWhoisStore } from '../stores/whois.js';
 import { useBookmarksStore } from '../stores/bookmarks.js';
 import { useDataExportStore } from '../stores/dataExport.js';
 import { useDccStore } from '../stores/dcc.js';
+import { useCallPresenceStore } from '../stores/callPresence.js';
 import { useUploadsStore } from '../stores/uploads.js';
 import { makeClientId } from '../utils/clientId.js';
 import { useToastsStore } from '../stores/toasts.js';
@@ -723,6 +724,18 @@ function handleMessage(raw: string): void {
     // cursor (#355).
     if (payload.networkId != null) trackSeenId(payload.id);
     applyEvent(payload);
+    return;
+  }
+  if (payload.kind === 'call-presence') {
+    // A voice call's participant count changed in a channel; badge users who
+    // aren't in the call. Its own top-level frame (not an 'irc' event) so it
+    // never rides the resume cursor — presence is re-snapshotted on reconnect
+    // by useCallPresenceHydration instead.
+    useCallPresenceStore().set(
+      payload.networkId as number,
+      payload.target as string,
+      payload.count as number,
+    );
     return;
   }
   if (payload.kind === 'account-state') {

--- a/vue_client/src/stores/callPresence.test.ts
+++ b/vue_client/src/stores/callPresence.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Call-presence counts feed the "Join call (N)" badge. These lock in the two
+// behaviors that matter: live deltas fold case-insensitively into the same key
+// a buffer lookup uses, and a hydrate() snapshot REPLACES the network's counts
+// (a call that ended while this client had no socket must clear, not linger).
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const h = vi.hoisted(() => ({
+  api: vi.fn<(url: string) => Promise<unknown>>(),
+}));
+vi.mock('../api.js', () => ({ api: h.api }));
+
+import { useCallPresenceStore } from './callPresence.js';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  h.api.mockReset();
+});
+
+describe('callPresence store', () => {
+  it('set() folds target case and clears at zero', () => {
+    const s = useCallPresenceStore();
+    s.set(1, '#Dev', 2);
+    expect(s.countFor(1, '#dev')).toBe(2);
+    expect(s.countFor(1, '#DEV')).toBe(2);
+    expect(s.countFor(2, '#dev')).toBe(0); // scoped by network
+    s.set(1, '#dev', 0);
+    expect(s.countFor(1, '#Dev')).toBe(0);
+  });
+
+  it('hydrate() replaces the network snapshot, clearing calls that ended', async () => {
+    const s = useCallPresenceStore();
+    s.set(1, '#ended', 3);
+    s.set(2, '#other-network', 1);
+    h.api.mockResolvedValueOnce({ calls: [{ target: '#fresh', count: 2 }] });
+    await s.hydrate(1);
+    expect(s.countFor(1, '#ended')).toBe(0); // stale entry cleared
+    expect(s.countFor(1, '#fresh')).toBe(2);
+    expect(s.countFor(2, '#other-network')).toBe(1); // other networks untouched
+  });
+
+  it('hydrate() keeps existing deltas when the snapshot fetch fails', async () => {
+    const s = useCallPresenceStore();
+    s.set(1, '#dev', 2);
+    h.api.mockRejectedValueOnce(new Error('offline'));
+    await s.hydrate(1);
+    expect(s.countFor(1, '#dev')).toBe(2);
+  });
+});

--- a/vue_client/src/stores/callPresence.ts
+++ b/vue_client/src/stores/callPresence.ts
@@ -17,6 +17,13 @@ function key(networkId: number | null, target: string): string {
   return `${networkId ?? ''}::${target.toLowerCase()}`;
 }
 
+// Per-network delta generation, bumped on every live `call-presence` frame.
+// hydrate() snapshots are fetched over REST while frames keep arriving on the
+// WS — an in-flight snapshot that resolves AFTER a delta is older than what it
+// would overwrite, so it must be dropped. Module-scoped: bookkeeping, not UI
+// state.
+const deltaGen = new Map<number, number>();
+
 export const useCallPresenceStore = defineStore('callPresence', {
   state: () => ({
     // `${networkId}::${lowercased target}` → participant count (absent = no call).
@@ -29,15 +36,24 @@ export const useCallPresenceStore = defineStore('callPresence', {
         s.counts[key(networkId, target)] ?? 0,
   },
   actions: {
+    /** Apply a live delta (a `call-presence` frame). */
     set(networkId: number, target: string, count: number) {
+      deltaGen.set(networkId, (deltaGen.get(networkId) ?? 0) + 1);
+      this.apply(networkId, target, count);
+    },
+
+    apply(networkId: number, target: string, count: number) {
       const k = key(networkId, target);
       if (count > 0) this.counts[k] = count;
       else delete this.counts[k];
     },
 
-    /** Replace this network's known call counts with a fresh server snapshot.
-     *  Best-effort: on failure we keep whatever deltas have arrived. */
+    /** Replace this network's known call counts with a fresh server snapshot —
+     *  unless a live delta arrived while the snapshot was in flight, in which
+     *  case the snapshot is the STALER source and is dropped. Best-effort: on
+     *  fetch failure we keep whatever deltas have arrived. */
     async hydrate(networkId: number) {
+      const genAtFetch = deltaGen.get(networkId) ?? 0;
       let calls: Array<{ target: string; count: number }>;
       try {
         const r = await api<{ calls: Array<{ target: string; count: number }> }>(
@@ -47,11 +63,12 @@ export const useCallPresenceStore = defineStore('callPresence', {
       } catch {
         return;
       }
+      if ((deltaGen.get(networkId) ?? 0) !== genAtFetch) return; // deltas are newer
       // Drop stale entries for this network before applying the snapshot, so a
       // call that ended while we were away clears rather than lingering.
       const prefix = `${networkId}::`;
       for (const k of Object.keys(this.counts)) if (k.startsWith(prefix)) delete this.counts[k];
-      for (const c of calls) this.set(networkId, c.target, c.count);
+      for (const c of calls) this.apply(networkId, c.target, c.count);
     },
   },
 });

--- a/vue_client/src/stores/callPresence.ts
+++ b/vue_client/src/stores/callPresence.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// Tracks which channels currently have an active voice call, so the UI can show
+// "Join call (N)" even for users who are not in the call. Fed two ways:
+//   - live deltas: the server's `call-presence` frame (driven by LiveKit
+//     webhooks, see routes/voice.ts broadcastCallPresence)
+//   - snapshots: hydrate() on each (re)connect edge, because the frame stream
+//     only carries deltas — a client that connects mid-call would otherwise
+//     never see the badge (see useCallPresenceHydration).
+// Channel-only and same-instance by design; DM calls broadcast no presence.
+
+import { defineStore } from 'pinia';
+import { api } from '../api.js';
+
+function key(networkId: number | null, target: string): string {
+  return `${networkId ?? ''}::${target.toLowerCase()}`;
+}
+
+export const useCallPresenceStore = defineStore('callPresence', {
+  state: () => ({
+    // `${networkId}::${lowercased target}` → participant count (absent = no call).
+    counts: {} as Record<string, number>,
+  }),
+  getters: {
+    countFor:
+      (s) =>
+      (networkId: number | null, target: string): number =>
+        s.counts[key(networkId, target)] ?? 0,
+  },
+  actions: {
+    set(networkId: number, target: string, count: number) {
+      const k = key(networkId, target);
+      if (count > 0) this.counts[k] = count;
+      else delete this.counts[k];
+    },
+
+    /** Replace this network's known call counts with a fresh server snapshot.
+     *  Best-effort: on failure we keep whatever deltas have arrived. */
+    async hydrate(networkId: number) {
+      let calls: Array<{ target: string; count: number }>;
+      try {
+        const r = await api<{ calls: Array<{ target: string; count: number }> }>(
+          `/api/voice/presence?networkId=${networkId}`,
+        );
+        calls = r.calls ?? [];
+      } catch {
+        return;
+      }
+      // Drop stale entries for this network before applying the snapshot, so a
+      // call that ended while we were away clears rather than lingering.
+      const prefix = `${networkId}::`;
+      for (const k of Object.keys(this.counts)) if (k.startsWith(prefix)) delete this.counts[k];
+      for (const c of calls) this.set(networkId, c.target, c.count);
+    },
+  },
+});

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -96,6 +96,19 @@ export const useVoiceStore = defineStore('voice', {
             detached.forEach((el) => el.remove());
             audioEls = audioEls.filter((el) => !detached.includes(el));
           })
+          .on(RoomEvent.TrackMuted, (pub, participant) => {
+            // Keep `muted` honest when the mute didn't come from OUR toggle —
+            // an op's server-mute would otherwise be invisible to the mutee
+            // (icon still live, no feedback at all).
+            if (
+              String(pub.source) === 'microphone' &&
+              participant.identity === r.localParticipant.identity &&
+              !this.muted
+            ) {
+              this.muted = true;
+              this.error = 'a channel operator muted your microphone';
+            }
+          })
           .on(RoomEvent.ParticipantConnected, () => this.syncParticipants())
           .on(RoomEvent.ParticipantDisconnected, () => this.syncParticipants())
           .on(RoomEvent.ActiveSpeakersChanged, (speakers: Participant[]) => {

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -27,6 +27,12 @@ interface VoiceTokenResponse {
 
 // Non-reactive session handles (see header note).
 let room: Room | null = null;
+// True while OUR OWN toggleMute() is awaiting the SFU — the TrackMuted event
+// fires before the await resolves, and without this flag a self-mute is
+// indistinguishable from an op's server-mute.
+let selfMuteInFlight = false;
+
+const OP_MUTED_MSG = 'a channel operator muted your microphone';
 let audioEls: HTMLAudioElement[] = [];
 // identity → remote MIC track, for per-participant volume.
 let tracksByIdentity = new Map<string, RemoteAudioTrack>();
@@ -99,14 +105,28 @@ export const useVoiceStore = defineStore('voice', {
           .on(RoomEvent.TrackMuted, (pub, participant) => {
             // Keep `muted` honest when the mute didn't come from OUR toggle —
             // an op's server-mute would otherwise be invisible to the mutee
-            // (icon still live, no feedback at all).
+            // (icon still live, no feedback at all). selfMuteInFlight excludes
+            // our own toggle, whose TrackMuted lands before its await resolves.
             if (
+              !selfMuteInFlight &&
               String(pub.source) === 'microphone' &&
               participant.identity === r.localParticipant.identity &&
               !this.muted
             ) {
               this.muted = true;
-              this.error = 'a channel operator muted your microphone';
+              this.error = OP_MUTED_MSG;
+            }
+          })
+          .on(RoomEvent.TrackUnmuted, (pub, participant) => {
+            // Self-unmute after a server mute is ALLOWED on self-hosted
+            // LiveKit (mute-locking is a Cloud feature) — sync the state and
+            // retire the op-mute notice rather than leaving it lying around.
+            if (
+              String(pub.source) === 'microphone' &&
+              participant.identity === r.localParticipant.identity
+            ) {
+              this.muted = false;
+              if (this.error === OP_MUTED_MSG) this.error = null;
             }
           })
           .on(RoomEvent.ParticipantConnected, () => this.syncParticipants())
@@ -158,11 +178,14 @@ export const useVoiceStore = defineStore('voice', {
       // rejects (device error, mid-reconnect) would render the mic-slash icon
       // while the track is still transmitting — the worst kind of wrong.
       const wantMuted = !this.muted;
+      selfMuteInFlight = true;
       try {
         await room.localParticipant.setMicrophoneEnabled(!wantMuted);
         this.muted = wantMuted;
       } catch (e: unknown) {
         this.error = e instanceof Error ? e.message : 'could not toggle mute';
+      } finally {
+        selfMuteInFlight = false;
       }
     },
 

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -151,8 +151,11 @@ export const useVoiceStore = defineStore('voice', {
         this.error = null;
         this.syncParticipants();
       } catch (e: unknown) {
-        this.error = e instanceof Error ? e.message : 'could not start call';
+        // Order matters: cleanup() clears `error` (so leaving a call never
+        // strands the bar open on a stale message) — set the failure reason
+        // AFTER it so the failed-call state still says why.
         await this.cleanup();
+        this.error = e instanceof Error ? e.message : 'could not start call';
       } finally {
         this.connecting = false;
       }
@@ -217,6 +220,10 @@ export const useVoiceStore = defineStore('voice', {
       this.volumes = {};
       this.networkId = null;
       this.target = '';
+      // In-call notices (op-mute, mute-toggle failures) die with the call —
+      // otherwise the CallBar stays wedged open showing them after /leave.
+      // startCall's catch re-sets its failure reason after calling this.
+      this.error = null;
     },
   },
 });


### PR DESCRIPTION
Second slice of the stack planned in VOICE_CALLS_PR_PLAN.md, rebuilt from @JawshTheDark's #680. Builds on #761.

## What this adds

- **Join policy**: ops (`q/a/o`) set a minimum prefix mode for a channel's call (anyone / voiced+ / halfop+ / ops) from a picker under the Call button; stored per (host, folded channel) in `voice_channel_policy` and enforced at token mint. Unknown modes on PUT are a **400, never coerced** — the coercion fallback is `none`, so a typo'd restrict request must not silently unrestrict a call.
- **Moderation**: ops/halfops (`q/a/o/h`) server-mute or remove participants via `POST /api/voice/moderate` (RoomServiceClient with the server-side secret; clients never hold admin tokens).
- **Call presence**: the LiveKit webhook (public router, signature-verified, mounted before the authed router) turns room events into top-level `call-presence` frames; everyone in the channel sees "Join call (N)". A `/presence` snapshot + client hydration covers connect edges, since frames are deltas.
- **The fix that makes presence real**: the bundled SFU's compose config now carries the `webhook` block the reference branch was missing — badges work out of the box (config format verified against a live livekit-server container).
- `shared/voiceModes.ts`: one definition of call-mode authority imported by **both tiers** — the server enforces it, the client mirrors it for UI gating.
- Docs: `call-presence` frame in §7.1, the new endpoints, and honest operator caveats.

## Notable divergences from the reference branch

- **Presence is stateless.** The reference (and my first cut) kept an in-memory join/leave registry — which lies after a restart: the first post-restart join "resets" a 3-person badge to 1, and leaves with an empty registry broadcast nothing. Counts now come from the webhook event's own `Room.numParticipants` (authoritative at event time); `(host, channel)` is parsed from the room name. No registry, no restart bug, no unbounded map.
- **Fold-correct fan-out**: presence frames translate the folded channel to *each receiving connection's own wire spelling*, and membership checks are casemapping-aware — the reference compared folded names to raw map keys, so any case-variant spelling silently lost its badge.
- `parseRoom` anchors on the first `-c-<sigil>` pair and handles all four sigils (`#&+!`) — the reference's `[#&]` anchor dropped `+`/`!` channels from restart recovery.
- **Removal ≠ revocation, documented**: on self-hosted (OSS) LiveKit, `removeParticipant` does not invalidate the removed party's still-valid token — that's a LiveKit Cloud feature. Docs say so plainly instead of overpromising.

## Review

`/code-review` (high) ran adversarial verification: 13 verifiers, 12 CONFIRMED. All 10 reported findings addressed — including three real client-side races in the policy picker (late `voiceEnabled` resolution, cross-channel fetch staleness, and a failed PUT leaving the select showing a policy the server rejected) and a hydrate-vs-delta race in the presence store.

Full `npm run check` + 3,882 tests green (48 voice tests server-side, incl. a webhook test that signs a real LiveKit-style auth header rather than mocking verification).

Follow-ups per the plan: PR 3 guest links, PR 4 video + screen share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)