### PR TITLE
Voice guest links: account-less callers via capability URLs (slice 3 of #680)

### DIFF
--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1150,6 +1150,26 @@ client's job).
 `POST /webhook` also lives under `/api/voice` but is LiveKit↔Lurker internal
 (signature-authenticated) — never call it from a client.
 
+**Guest links** (ops, `q/a/o`): capability URLs that let someone without an
+account join one channel's call.
+
+```
+POST   /guest-link          { networkId, target, canPublish? }  → { url, token,
+                              canPublish, expiresAt }           24h link TTL
+GET    /guest-link?networkId&target → { links: [...] }          active links
+DELETE /guest-link/:token   → { ok }                            revoke
+POST   /guest-token         { token, name }                     PUBLIC, throttled
+       → { token, url, canPublish }
+```
+
+`/guest-token` exchanges the link for a **1-hour** room token (`canPublish:
+false` = listen-only — don't try to publish, the SFU refuses). Guest
+identities are always `guest-<name>-<hex>` — render them differently from
+members; a bare-nick identity is never a guest. Revoking a link stops NEW
+exchanges only: already-minted guest tokens live out their hour (OSS LiveKit
+cannot revoke tokens) — ops `remove` lingering guests. The web client serves
+the joining UI at `/call/:token`.
+
 ### Export / import
 
 `GET /api/exports/preview` · `POST /api/exports` (`{include_messages}`, allowed

--- a/docs/CLIENT_PROTOCOL.md
+++ b/docs/CLIENT_PROTOCOL.md
@@ -1170,6 +1170,11 @@ exchanges only: already-minted guest tokens live out their hour (OSS LiveKit
 cannot revoke tokens) — ops `remove` lingering guests. The web client serves
 the joining UI at `/call/:token`.
 
+Build shareable URLs as `<your own origin>/call/<token>` — the `url` field in
+mint/list responses is best-effort (derived from the request's `Origin`
+header, which browsers omit on same-origin GETs) and may carry the server's
+internal host.
+
 ### Export / import
 
 `GET /api/exports/preview` · `POST /api/exports` (`{include_messages}`, allowed

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -349,6 +349,8 @@ Everyone in a channel can join that channel's call — from the button atop the 
 
 Channel operators get call controls that mirror their IRC standing: ops and halfops (`q/a/o/h`) can server-mute or remove anyone from the channel's call, and full ops (`q/a/o`) can restrict who may join the call at all (anyone / voiced+ / halfop+ / ops) from the picker under the Call button.
 
+Ops can also mint **guest links** from the same panel — a URL that lets someone without a Lurker account join that channel's call from their browser (optionally listen-only). Links expire after 24 hours and can be revoked; revoking stops _new_ guests from joining, while anyone already in the call keeps their (1-hour) access until an op removes them. Guests appear in the call as `guest-<name>-<id>`, so they can never impersonate a real nick.
+
 Two trust caveats, both in line with IRC's own model — fine among people you already trust:
 
 - Channel membership and the join policy are checked **when the call token is issued**, and tokens last 2 hours. Removing someone from a call ejects them now, but on self-hosted LiveKit it does **not** invalidate their token: Lurker's own clients won't rejoin after a removal, yet someone determined enough to use a raw LiveKit client can reconnect until the token expires. (Instant revocation on removal is a LiveKit Cloud feature.)

--- a/server/app.ts
+++ b/server/app.ts
@@ -99,9 +99,9 @@ export function buildApp(sessionSecret: string): Express {
     app.use('/uploads', localUploadsRouter);
   }
   app.use('/api/dcc', dccRouter);
-  // Public voice sub-route (the LiveKit webhook) FIRST — it authenticates by
-  // webhook signature, not the session cookie, so it must match before the
-  // requireAuth'd voice router 401s it.
+  // Public voice sub-routes (LiveKit webhook + guest join) FIRST — they
+  // authenticate by capability (webhook signature / guest-link token), not the
+  // session cookie, so they must match before the requireAuth'd router 401s them.
   app.use('/api/voice', voicePublicRouter);
   app.use('/api/voice', voiceRouter);
   app.use('/api/drafts', draftsRouter);

--- a/server/db/exportSchema.ts
+++ b/server/db/exportSchema.ts
@@ -547,6 +547,12 @@ export const EXPORT_TABLES = Object.freeze({
     reason: 'per-channel voice-call join policy — instance/channel-scoped config, not user data',
   },
 
+  voice_guest_link: {
+    mode: 'skip',
+    reason:
+      'public guest-call capability links — instance-scoped, expiring credentials, not user data',
+  },
+
   peer_presence_state: {
     mode: 'skip',
     reason: 'transient cache; rebuilt by IRC events on next connect',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -643,6 +643,8 @@ function migrate() {
       revoked_at TEXT,
       use_count INTEGER NOT NULL DEFAULT 0
     );
+    CREATE INDEX IF NOT EXISTS idx_voice_guest_link_scope
+      ON voice_guest_link(network_host, channel_folded);
 
     -- Per-user data-export jobs. A request to export account data spawns a
     -- background worker (separate readonly SQLite connection) that builds the

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -622,6 +622,28 @@ function migrate() {
       PRIMARY KEY (network_host, channel_folded)
     );
 
+    -- Public guest call links (voice, PR 3 of the #680 stack). A capability
+    -- token that lets someone without an account join exactly one LiveKit
+    -- room. Opaque token, 24h expiry, soft-revocable via revoked_at —
+    -- revocation stops NEW joins only; already-minted room tokens live until
+    -- their own TTL (OSS LiveKit has no revocation). can_publish gates talk vs
+    -- listen-only. Not tied to a user row — it outlives the op who minted it.
+    -- ⚠ every timestamp here uses ONE format (strftime %Y-%m-%dT%H:%M:%fZ),
+    -- because expiry is compared IN SQL: a JS toISOString 'T' against a SQL
+    -- datetime(' ') would corrupt the comparison for a whole day.
+    CREATE TABLE IF NOT EXISTS voice_guest_link (
+      token TEXT PRIMARY KEY,
+      network_host TEXT NOT NULL,
+      channel_folded TEXT NOT NULL,
+      room TEXT NOT NULL,
+      can_publish INTEGER NOT NULL DEFAULT 1,
+      created_by TEXT,
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+      expires_at TEXT NOT NULL,
+      revoked_at TEXT,
+      use_count INTEGER NOT NULL DEFAULT 0
+    );
+
     -- Per-user data-export jobs. A request to export account data spawns a
     -- background worker (separate readonly SQLite connection) that builds the
     -- .lurk archive to disk under data/exports/<token>.lurk; the row tracks

--- a/server/db/linkPreviews.ts
+++ b/server/db/linkPreviews.ts
@@ -160,7 +160,11 @@ export function urlHash(url: string): string {
 /** ⚠ Exported so a test can substitute a fixed instant for `'now'` and assert the ranking
  *  deterministically. A test that spells the expression out itself asserts a fact about SQLite
  *  rather than about this module, and stays green when this line changes. */
-export const NOW_ISO = `strftime('%Y-%m-%dT%H:%M:%fZ','now')`;
+/** The one SQL timestamp format for tables whose expiry is compared
+ *  lexicographically in SQL — the same shape as JS toISOString, so both tiers
+ *  compare soundly. Also consumed by voiceLinks (guest call links). */
+export const ISO_TS_FMT = '%Y-%m-%dT%H:%M:%fZ';
+export const NOW_ISO = `strftime('${ISO_TS_FMT}','now')`;
 
 /** ⚠ Exported so a test can EXPLAIN the statements that ACTUALLY run. Planning a paraphrase
  *  proves nothing: an index assertion written against a hand-copied string stays green when the

--- a/server/db/voiceLinks.test.ts
+++ b/server/db/voiceLinks.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lurker-test-voicelinks-'));
+process.env.DATABASE_PATH = path.join(tmpDir, 'test.db');
+
+let vl: typeof import('./voiceLinks.js');
+let db: typeof import('./index.js').default;
+
+const base = {
+  networkHost: 'irc.libera.chat',
+  channelFolded: '#dev',
+  room: 'net-irc.libera.chat-c-#dev',
+  canPublish: true,
+  createdBy: 'jawsh',
+};
+
+beforeAll(async () => {
+  vl = await import('./voiceLinks.js');
+  db = (await import('./index.js')).default;
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('voiceLinks', () => {
+  it('creates a usable link with an opaque token and ~24h expiry', () => {
+    const link = vl.createGuestLink(base);
+    expect(link.token.length).toBeGreaterThan(30);
+    expect(link.canPublish).toBe(true);
+    expect(link.room).toBe(base.room);
+    expect(vl.getUsableGuestLink(link.token)?.token).toBe(link.token);
+    const ttl = Date.parse(link.expiresAt) - Date.now();
+    expect(ttl).toBeGreaterThan(vl.GUEST_LINK_TTL_MS - 60_000);
+    expect(ttl).toBeLessThanOrEqual(vl.GUEST_LINK_TTL_MS + 1_000);
+  });
+
+  it('carries a listen-only (canPublish:false) flag', () => {
+    const link = vl.createGuestLink({ ...base, canPublish: false });
+    expect(vl.getGuestLink(link.token)?.canPublish).toBe(false);
+  });
+
+  it('revoking makes it unusable but still fetchable', () => {
+    const link = vl.createGuestLink(base);
+    expect(vl.revokeGuestLink(link.token)).toBe(true);
+    expect(vl.getUsableGuestLink(link.token)).toBeNull();
+    expect(vl.getGuestLink(link.token)?.revokedAt).toBeTruthy();
+  });
+
+  it('lists only active links for a host+channel', () => {
+    const a = vl.createGuestLink({ ...base, channelFolded: '#list' });
+    const b = vl.createGuestLink({ ...base, channelFolded: '#list' });
+    vl.revokeGuestLink(b.token);
+    const active = vl.listActiveGuestLinks('irc.libera.chat', '#list').map((l) => l.token);
+    expect(active).toContain(a.token);
+    expect(active).not.toContain(b.token);
+  });
+
+  it('an expired link is excluded from BOTH the SQL listing and the JS gate', () => {
+    // Regression for the format-mismatch defect: the reference stored a JS
+    // toISOString expiry ('...T...') but compared it against SQLite's
+    // space-format datetime('now') in SQL — and since 'T' > ' ', a link
+    // expiring ANY time today counted as active for the whole day in the ops'
+    // list. One strftime format everywhere makes the comparison sound; this
+    // pins it by expiring a link one second into the past (same-day).
+    const link = vl.createGuestLink({ ...base, channelFolded: '#expired' });
+    db.prepare(
+      `UPDATE voice_guest_link
+       SET expires_at = strftime('%Y-%m-%dT%H:%M:%fZ','now','-1 seconds')
+       WHERE token = ?`,
+    ).run(link.token);
+    expect(vl.listActiveGuestLinks('irc.libera.chat', '#expired')).toEqual([]);
+    expect(vl.getUsableGuestLink(link.token)).toBeNull();
+  });
+
+  it('bumps the use count', () => {
+    const link = vl.createGuestLink(base);
+    vl.bumpGuestLinkUse(link.token);
+    vl.bumpGuestLinkUse(link.token);
+    expect(vl.getGuestLink(link.token)?.useCount).toBe(2);
+  });
+
+  it('returns null for an unknown token', () => {
+    expect(vl.getUsableGuestLink('does-not-exist')).toBeNull();
+    expect(vl.getGuestLink('does-not-exist')).toBeNull();
+  });
+});

--- a/server/db/voiceLinks.ts
+++ b/server/db/voiceLinks.ts
@@ -123,3 +123,17 @@ export function revokeGuestLink(token: string): boolean {
 export function bumpGuestLinkUse(token: string): void {
   bumpStmt.run(token);
 }
+
+const sweepStmt = db.prepare(`
+  DELETE FROM voice_guest_link
+  WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now','-1 days')
+     OR revoked_at < strftime('%Y-%m-%dT%H:%M:%fZ','now','-1 days')
+`);
+
+/** Hourly janitor (see server.ts): a guest link is dead 24h after expiry or
+ *  revocation and carries zero data value — without this, every link ever
+ *  minted lives in the table (and every backup) forever. The one-day grace
+ *  keeps a just-revoked link visible to `getGuestLink` for debugging. */
+export function sweepDeadGuestLinks(): number {
+  return sweepStmt.run().changes;
+}

--- a/server/db/voiceLinks.ts
+++ b/server/db/voiceLinks.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import crypto from 'crypto';
+import db from './index.js';
+
+// Public guest call links — capability tokens that let an account-less guest
+// join exactly one LiveKit room. The token is opaque and unguessable, the link
+// expires after GUEST_LINK_TTL_MS, and it is soft-revocable via revoked_at.
+// Revocation stops NEW joins only — a guest who already exchanged the link
+// holds a LiveKit room token we cannot revoke on self-hosted LiveKit (ops
+// remove them from the call instead). Not tied to a user row: the link
+// outlives the op who minted it.
+//
+// ⚠ Timestamps: ONE format everywhere — strftime('%Y-%m-%dT%H:%M:%fZ'), i.e.
+// the same shape as JS toISOString. Expiry is compared IN SQL (listActive),
+// and mixing a 'T'-format value against SQLite's default space-format
+// datetime() makes 'T' > ' ' decide the comparison for the whole expiry day.
+// Both sides below are strftime, and getUsableGuestLink re-checks in JS.
+
+export interface GuestLink {
+  token: string;
+  networkHost: string;
+  channelFolded: string;
+  room: string;
+  canPublish: boolean;
+  createdBy: string | null;
+  createdAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  useCount: number;
+}
+
+interface RawGuestLink {
+  token: string;
+  networkHost: string;
+  channelFolded: string;
+  room: string;
+  canPublish: number;
+  createdBy: string | null;
+  createdAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  useCount: number;
+}
+
+export const GUEST_LINK_TTL_MS = 24 * 60 * 60 * 1000;
+
+const COLS = `
+  token, network_host AS networkHost, channel_folded AS channelFolded, room,
+  can_publish AS canPublish, created_by AS createdBy, created_at AS createdAt,
+  expires_at AS expiresAt, revoked_at AS revokedAt, use_count AS useCount
+`;
+
+const insertStmt = db.prepare(`
+  INSERT INTO voice_guest_link
+    (token, network_host, channel_folded, room, can_publish, created_by, expires_at)
+  VALUES (@token, @host, @channel, @room, @canPublish, @by,
+          strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+' || @ttlSeconds || ' seconds'))
+`);
+const getStmt = db.prepare(`SELECT ${COLS} FROM voice_guest_link WHERE token = ?`);
+const listActiveStmt = db.prepare(`
+  SELECT ${COLS} FROM voice_guest_link
+  WHERE network_host = ? AND channel_folded = ?
+    AND revoked_at IS NULL
+    AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ','now')
+  ORDER BY created_at DESC
+`);
+const revokeStmt = db.prepare(`
+  UPDATE voice_guest_link
+  SET revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+  WHERE token = ? AND revoked_at IS NULL
+`);
+const bumpStmt = db.prepare(
+  `UPDATE voice_guest_link SET use_count = use_count + 1 WHERE token = ?`,
+);
+
+function toGuestLink(row: RawGuestLink): GuestLink {
+  return { ...row, canPublish: !!row.canPublish };
+}
+
+export function createGuestLink(args: {
+  networkHost: string;
+  channelFolded: string;
+  room: string;
+  canPublish: boolean;
+  createdBy: string;
+}): GuestLink {
+  const token = crypto.randomBytes(32).toString('base64url');
+  insertStmt.run({
+    token,
+    host: args.networkHost,
+    channel: args.channelFolded,
+    room: args.room,
+    canPublish: args.canPublish ? 1 : 0,
+    by: args.createdBy,
+    ttlSeconds: Math.floor(GUEST_LINK_TTL_MS / 1000),
+  });
+  return getGuestLink(token) as GuestLink;
+}
+
+export function getGuestLink(token: string): GuestLink | null {
+  const row = getStmt.get(token) as RawGuestLink | undefined;
+  return row ? toGuestLink(row) : null;
+}
+
+/** The link only if it exists, is not revoked, and has not expired; else null.
+ *  This is the gate the public guest-token endpoint uses. */
+export function getUsableGuestLink(token: string): GuestLink | null {
+  const link = getGuestLink(token);
+  if (!link || link.revokedAt || Date.parse(link.expiresAt) <= Date.now()) return null;
+  return link;
+}
+
+export function listActiveGuestLinks(host: string, channelFolded: string): GuestLink[] {
+  return (listActiveStmt.all(host, channelFolded) as RawGuestLink[]).map(toGuestLink);
+}
+
+export function revokeGuestLink(token: string): boolean {
+  return revokeStmt.run(token).changes > 0;
+}
+
+export function bumpGuestLinkUse(token: string): void {
+  bumpStmt.run(token);
+}

--- a/server/db/voiceLinks.ts
+++ b/server/db/voiceLinks.ts
@@ -3,6 +3,7 @@
 
 import crypto from 'crypto';
 import db from './index.js';
+import { ISO_TS_FMT, NOW_ISO } from './linkPreviews.js';
 
 // Public guest call links — capability tokens that let an account-less guest
 // join exactly one LiveKit room. The token is opaque and unguessable, the link
@@ -12,11 +13,12 @@ import db from './index.js';
 // remove them from the call instead). Not tied to a user row: the link
 // outlives the op who minted it.
 //
-// ⚠ Timestamps: ONE format everywhere — strftime('%Y-%m-%dT%H:%M:%fZ'), i.e.
-// the same shape as JS toISOString. Expiry is compared IN SQL (listActive),
-// and mixing a 'T'-format value against SQLite's default space-format
-// datetime() makes 'T' > ' ' decide the comparison for the whole expiry day.
-// Both sides below are strftime, and getUsableGuestLink re-checks in JS.
+// ⚠ Timestamps: ONE format everywhere — the shared ISO_TS_FMT / NOW_ISO from
+// linkPreviews (the same shape as JS toISOString). Expiry is compared IN SQL
+// (listActive), and mixing a 'T'-format value against SQLite's default
+// space-format datetime() makes 'T' > ' ' decide the comparison for the whole
+// expiry day. Every statement below builds from the shared constants so the
+// format cannot drift per-site; getUsableGuestLink re-checks in JS.
 
 export interface GuestLink {
   token: string;
@@ -56,19 +58,19 @@ const insertStmt = db.prepare(`
   INSERT INTO voice_guest_link
     (token, network_host, channel_folded, room, can_publish, created_by, expires_at)
   VALUES (@token, @host, @channel, @room, @canPublish, @by,
-          strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+' || @ttlSeconds || ' seconds'))
+          strftime('${ISO_TS_FMT}', 'now', '+' || @ttlSeconds || ' seconds'))
 `);
 const getStmt = db.prepare(`SELECT ${COLS} FROM voice_guest_link WHERE token = ?`);
 const listActiveStmt = db.prepare(`
   SELECT ${COLS} FROM voice_guest_link
   WHERE network_host = ? AND channel_folded = ?
     AND revoked_at IS NULL
-    AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ','now')
+    AND expires_at > ${NOW_ISO}
   ORDER BY created_at DESC
 `);
 const revokeStmt = db.prepare(`
   UPDATE voice_guest_link
-  SET revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+  SET revoked_at = ${NOW_ISO}
   WHERE token = ? AND revoked_at IS NULL
 `);
 const bumpStmt = db.prepare(
@@ -126,8 +128,8 @@ export function bumpGuestLinkUse(token: string): void {
 
 const sweepStmt = db.prepare(`
   DELETE FROM voice_guest_link
-  WHERE expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now','-1 days')
-     OR revoked_at < strftime('%Y-%m-%dT%H:%M:%fZ','now','-1 days')
+  WHERE expires_at < strftime('${ISO_TS_FMT}','now','-1 days')
+     OR revoked_at < strftime('${ISO_TS_FMT}','now','-1 days')
 `);
 
 /** Hourly janitor (see server.ts): a guest link is dead 24h after expiry or

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -4,6 +4,7 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 import { requireAuth, requireAdmin } from '../middleware/auth.js';
+import { originFromRequest } from '../utils/requestOrigin.js';
 import {
   listUsers,
   findUserById,
@@ -54,18 +55,7 @@ function publicInvite(row: any, { origin }: { origin: string }): Record<string, 
   };
 }
 
-// Prefer the browser-supplied Origin header so the link reflects the URL the
-// admin is actually using — through Vite's dev proxy that's
-// https://irc.local.bradroot.me:5173, and in prod it's whatever the public
-// origin is, regardless of how the reverse proxy forwards to Express.
-// req.protocol/req.get('host') would otherwise leak the upstream Express
-// scheme + host (http://localhost:8010). Falls back to scheme://host for the
-// rare request without an Origin header.
-function originFromRequest(req: Request): string {
-  const origin = req.get('origin');
-  if (origin) return origin;
-  return `${req.protocol}://${req.get('host')}`;
-}
+// Link origin rule shared with guest call links — see utils/requestOrigin.ts.
 
 function effectiveIdent(u: User): string {
   return deriveIdent({

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Brad Root
 // SPDX-License-Identifier: MPL-2.0
 
-import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach, vi } from 'vitest';
 import { createHash } from 'crypto';
 import { Router } from 'express';
 import type { LurkerTestAgent } from '../test-utils/testApp.js';
@@ -59,6 +59,9 @@ const fakeManager = {
   all: [] as FakeConn[],
   getConnection(_userId: number, _networkId: number) {
     return this.conn;
+  },
+  listConnections(_userId: number) {
+    return this.conn ? [this.conn] : [];
   },
   listAllConnections() {
     return this.all;
@@ -447,5 +450,138 @@ describe('POST /api/voice/webhook (public, signature-verified)', () => {
     // A DM room is filtered before the SFU is even asked.
     expect(h.liveCallCount).not.toHaveBeenCalled();
     expect(fanOutToUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('guest links — /api/voice/guest-link (op-only CRUD)', () => {
+  it('403 for non-ops (halfop is not enough to mint)', async () => {
+    enableVoice();
+    connectedAs(['h']);
+    const res = await agent
+      .post('/api/voice/guest-link')
+      .send({ networkId: network.id, target: '#dev' });
+    expect(res.status).toBe(403);
+  });
+
+  it('ops mint a link whose URL rides the browser Origin, not the Express host', async () => {
+    enableVoice();
+    connectedAs(['o']);
+    const res = await agent
+      .post('/api/voice/guest-link')
+      .set('Origin', 'https://irc.example.com')
+      .send({ networkId: network.id, target: '#dev' });
+    expect(res.status).toBe(200);
+    expect(res.body.url).toBe(`https://irc.example.com/call/${res.body.token}`);
+    expect(res.body.canPublish).toBe(true);
+  });
+
+  it('mints listen-only links and lists active links for ops', async () => {
+    enableVoice();
+    connectedAs(['q']);
+    const mint = await agent
+      .post('/api/voice/guest-link')
+      .send({ networkId: network.id, target: '#dev', canPublish: false });
+    expect(mint.status).toBe(200);
+    expect(mint.body.canPublish).toBe(false);
+
+    const list = await agent.get(`/api/voice/guest-link?networkId=${network.id}&target=%23dev`);
+    expect(list.status).toBe(200);
+    const tokens = (list.body.links as Array<{ token: string }>).map((l) => l.token);
+    expect(tokens).toContain(mint.body.token);
+
+    connectedAs(['v']);
+    const denied = await agent.get(`/api/voice/guest-link?networkId=${network.id}&target=%23dev`);
+    expect(denied.status).toBe(403);
+  });
+
+  it('ops revoke; the link stops being usable for NEW joins', async () => {
+    enableVoice();
+    connectedAs(['o']);
+    const mint = await agent
+      .post('/api/voice/guest-link')
+      .send({ networkId: network.id, target: '#dev' });
+    const del = await agent.delete(`/api/voice/guest-link/${mint.body.token}`);
+    expect(del.status).toBe(200);
+
+    const res = await testRequest(app)
+      .post('/api/voice/guest-token')
+      .send({ token: mint.body.token, name: 'late guest' });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/voice/guest-token (public)', () => {
+  beforeEach(async () => {
+    const { resetGuestRateLimit } = await import('./voice.js');
+    resetGuestRateLimit();
+  });
+
+  async function mintLink(canPublish = true): Promise<string> {
+    connectedAs(['o']);
+    const mint = await agent
+      .post('/api/voice/guest-link')
+      .send({ networkId: network.id, target: '#dev', canPublish });
+    return mint.body.token as string;
+  }
+
+  it('404 for unknown tokens', async () => {
+    enableVoice();
+    const res = await testRequest(app)
+      .post('/api/voice/guest-token')
+      .send({ token: 'no-such-link', name: 'x' });
+    expect(res.status).toBe(404);
+  });
+
+  it('exchanges a live link for a namespaced, room-scoped, SHORT token', async () => {
+    enableVoice();
+    const link = await mintLink();
+    const res = await testRequest(app)
+      .post('/api/voice/guest-token')
+      .send({ token: link, name: 'Cool Guest!' });
+    expect(res.status).toBe(200);
+    expect(res.body.canPublish).toBe(true);
+
+    const claims = JSON.parse(
+      Buffer.from(String(res.body.token).split('.')[1]!, 'base64url').toString(),
+    ) as { sub?: string; exp?: number; nbf?: number; video?: { room?: string } };
+    // Identity is namespaced — a guest can never collide with a bare IRC nick.
+    expect(claims.sub).toMatch(/^guest-coolguest-[0-9a-f]{8}$/);
+    expect(claims.video?.room).toBe('net-irc.libera.chat-c-#dev');
+    // 1h TTL, not the members' 2h: a minted token is irrevocable on OSS
+    // LiveKit, so its lifetime IS the revocation story for a killed link.
+    expect((claims.exp ?? 0) - (claims.nbf ?? 0)).toBeLessThanOrEqual(60 * 60 + 60);
+  });
+
+  it('honours the listen-only flag in the LiveKit grant', async () => {
+    enableVoice();
+    const link = await mintLink(false);
+    const res = await testRequest(app)
+      .post('/api/voice/guest-token')
+      .send({ token: link, name: 'quiet' });
+    expect(res.status).toBe(200);
+    expect(res.body.canPublish).toBe(false);
+    const claims = JSON.parse(
+      Buffer.from(String(res.body.token).split('.')[1]!, 'base64url').toString(),
+    ) as { video?: { canPublish?: boolean; canSubscribe?: boolean } };
+    expect(claims.video?.canPublish).toBe(false);
+    expect(claims.video?.canSubscribe).toBe(true);
+  });
+
+  it('throttles per IP (429 with Retry-After past the window cap)', async () => {
+    // Deterministic: the throttle was reset in beforeEach and allows 10/min —
+    // ten mints succeed, the eleventh trips.
+    enableVoice();
+    const link = await mintLink();
+    for (let i = 0; i < 10; i++) {
+      const res = await testRequest(app)
+        .post('/api/voice/guest-token')
+        .send({ token: link, name: `g${i}` });
+      expect(res.status).toBe(200);
+    }
+    const tripped = await testRequest(app)
+      .post('/api/voice/guest-token')
+      .send({ token: link, name: 'g11' });
+    expect(tripped.status).toBe(429);
+    expect(Number(tripped.headers['retry-after'])).toBeGreaterThan(0);
   });
 });

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -568,11 +568,12 @@ describe('POST /api/voice/guest-token (public)', () => {
   });
 
   it('throttles per IP (429 with Retry-After past the window cap)', async () => {
-    // Deterministic: the throttle was reset in beforeEach and allows 10/min —
-    // ten mints succeed, the eleventh trips.
+    // Deterministic: the throttle was reset in beforeEach and allows 60/min
+    // (sized for a NAT'd crowd joining one call) — sixty exchanges succeed,
+    // the sixty-first trips.
     enableVoice();
     const link = await mintLink();
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 60; i++) {
       const res = await testRequest(app)
         .post('/api/voice/guest-token')
         .send({ token: link, name: `g${i}` });
@@ -580,7 +581,7 @@ describe('POST /api/voice/guest-token (public)', () => {
     }
     const tripped = await testRequest(app)
       .post('/api/voice/guest-token')
-      .send({ token: link, name: 'g11' });
+      .send({ token: link, name: 'g61' });
     expect(tripped.status).toBe(429);
     expect(Number(tripped.headers['retry-after'])).toBeGreaterThan(0);
   });

--- a/server/routes/voice.test.ts
+++ b/server/routes/voice.test.ts
@@ -494,6 +494,21 @@ describe('guest links — /api/voice/guest-link (op-only CRUD)', () => {
     expect(denied.status).toBe(403);
   });
 
+  it("the link's creator can revoke even without currently-resolvable op modes", async () => {
+    // The op-mode check folds the stored channel key under the REVOKER's row,
+    // which can transiently diverge from the minter's fold — the creator path
+    // keeps the emergency revoke working through that window.
+    enableVoice();
+    connectedAs(['o']);
+    const mint = await agent
+      .post('/api/voice/guest-link')
+      .send({ networkId: network.id, target: '#dev' });
+    // Same nick, but no longer op'd (deopped after minting).
+    connectedAs([]);
+    const del = await agent.delete(`/api/voice/guest-link/${mint.body.token}`);
+    expect(del.status).toBe(200);
+  });
+
   it('ops revoke; the link stops being usable for NEW joins', async () => {
     enableVoice();
     connectedAs(['o']);
@@ -562,9 +577,13 @@ describe('POST /api/voice/guest-token (public)', () => {
     expect(res.body.canPublish).toBe(false);
     const claims = JSON.parse(
       Buffer.from(String(res.body.token).split('.')[1]!, 'base64url').toString(),
-    ) as { video?: { canPublish?: boolean; canSubscribe?: boolean } };
+    ) as { video?: { canPublish?: boolean; canSubscribe?: boolean; canPublishData?: boolean } };
     expect(claims.video?.canPublish).toBe(false);
     expect(claims.video?.canSubscribe).toBe(true);
+    // The data channel is an INDEPENDENT grant — listen-only must close it
+    // too, or a "can hear but not speak" guest could spam data packets at the
+    // room from a raw client for the token's whole hour.
+    expect(claims.video?.canPublishData).toBe(false);
   });
 
   it('throttles per IP (429 with Retry-After past the window cap)', async () => {

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -349,13 +349,19 @@ router.delete('/guest-link/:token', (req: Request, res: Response) => {
     res.status(404).json({ error: 'link not found' });
     return;
   }
-  // Authorize: the caller must be an op of the link's channel on the matching
-  // host — resolved across ALL their connections, since the revoke may come
-  // from a different device/network row than the mint did.
-  const conn = ircManager
+  // Authorize: the caller must be an op of the link's channel on ANY of their
+  // connections to the matching host — a user with two network rows on one
+  // host (main + alt) must be able to revoke from whichever holds the op, or
+  // the emergency revoke for a leaked link fails exactly when needed.
+  const authorized = ircManager
     .listConnections(req.user!.id)
-    .find((c) => !!c.currentNick && foldKey(c.network.host) === link.networkHost);
-  if (!conn || !canAdminCall(memberModes(conn, link.channelFolded, conn.currentNick!))) {
+    .some(
+      (c) =>
+        !!c.currentNick &&
+        foldKey(c.network.host) === link.networkHost &&
+        canAdminCall(memberModes(c, link.channelFolded, c.currentNick)),
+    );
+  if (!authorized) {
     res.status(403).json({ error: 'operators only' });
     return;
   }
@@ -412,7 +418,11 @@ voicePublicRouter.post(
 // for a link an op just killed. A legit guest whose call outlives the token
 // re-clicks the link — the LINK lasts 24h.
 const GUEST_TOKEN_TTL_SECONDS = 60 * 60;
-const guestTokenThrottle = new RequestThrottle({ windowMs: 60_000, maxRequests: 10 });
+// 60/min per IP: generous enough for a whole NAT'd household joining a
+// community call at once (and behind an untrusted proxy the bucket is shared
+// instance-wide — see LURKER_TRUST_PROXY in rateLimit.ts), while still making
+// brute-force probing of 43-char base64url tokens a non-starter.
+const guestTokenThrottle = new RequestThrottle({ windowMs: 60_000, maxRequests: 60 });
 
 /** Test hook, mirroring resetAuthRateLimits — the throttle is module state. */
 export function resetGuestRateLimit(): void {

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -349,18 +349,24 @@ router.delete('/guest-link/:token', (req: Request, res: Response) => {
     res.status(404).json({ error: 'link not found' });
     return;
   }
-  // Authorize: the caller must be an op of the link's channel on ANY of their
-  // connections to the matching host — a user with two network rows on one
-  // host (main + alt) must be able to revoke from whichever holds the op, or
-  // the emergency revoke for a leaked link fails exactly when needed.
-  const authorized = ircManager
-    .listConnections(req.user!.id)
-    .some(
-      (c) =>
-        !!c.currentNick &&
-        foldKey(c.network.host) === link.networkHost &&
-        canAdminCall(memberModes(c, link.channelFolded, c.currentNick)),
-    );
+  // Authorize: on ANY of the caller's connections to the matching host — a
+  // user with two network rows on one host (main + alt) must be able to revoke
+  // from whichever holds the op, or the emergency revoke for a leaked link
+  // fails exactly when needed. The link's CREATOR may always revoke their own
+  // link too: the op-mode check compares the stored channel key (folded under
+  // the MINTER's row's casemapping) against a fold under the REVOKER's row,
+  // which can transiently diverge (see the invariant note at /token) — the
+  // creator path keeps revocation working through that window.
+  const authorized = ircManager.listConnections(req.user!.id).some((c) => {
+    if (!c.currentNick || foldKey(c.network.host) !== link.networkHost) return false;
+    if (
+      link.createdBy &&
+      foldTargetFor(c.network.id, c.currentNick) === foldTargetFor(c.network.id, link.createdBy)
+    ) {
+      return true;
+    }
+    return canAdminCall(memberModes(c, link.channelFolded, c.currentNick));
+  });
   if (!authorized) {
     res.status(403).json({ error: 'operators only' });
     return;

--- a/server/routes/voice.ts
+++ b/server/routes/voice.ts
@@ -28,6 +28,17 @@ import {
   type CallPresenceChange,
 } from '../services/voice.js';
 import { getPolicy, setPolicy, isMinJoinMode } from '../db/voicePolicy.js';
+import { guestIdentity } from '../services/voice.js';
+import {
+  createGuestLink,
+  listActiveGuestLinks,
+  revokeGuestLink,
+  getGuestLink,
+  getUsableGuestLink,
+  bumpGuestLinkUse,
+} from '../db/voiceLinks.js';
+import { RequestThrottle, limitRequests } from '../middleware/rateLimit.js';
+import { originFromRequest } from '../utils/requestOrigin.js';
 
 // Voice control surface. Lurker is the token authority + call moderator (see
 // services/voice.ts); it never carries media. Two routers:
@@ -257,7 +268,104 @@ router.put('/policy', (req: Request, res: Response) => {
   res.json({ minJoinMode });
 });
 
-// ─── Public router (no cookie auth) — the LiveKit webhook ───────────────────
+// ─── Guest links: op mints / lists / revokes a public capability URL ───────
+// Revocation stops NEW joins only: a guest who already exchanged the link
+// holds a LiveKit room token that cannot be revoked on self-hosted LiveKit —
+// ops remove lingering guests from the call instead. The client UI says the
+// same thing next to its revoke button.
+
+router.post('/guest-link', (req: Request, res: Response) => {
+  const networkId = Number(req.body?.networkId);
+  const target = typeof req.body?.target === 'string' ? req.body.target.trim() : '';
+  const canPublish = req.body?.canPublish !== false; // default talk
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  if (!target || !isChannelTarget(target)) {
+    res.status(400).json({ error: 'channel target required' });
+    return;
+  }
+  const { network, conn, nick } = ctx;
+  if (!canAdminCall(memberModes(conn, target, nick))) {
+    res.status(403).json({ error: 'you must be a channel operator to create a guest link' });
+    return;
+  }
+  const room = roomFor(
+    network.host,
+    foldTargetFor(network.id, target),
+    foldTargetFor(network.id, nick),
+  );
+  const link = createGuestLink({
+    networkHost: foldKey(network.host),
+    channelFolded: foldTargetFor(network.id, target),
+    room,
+    canPublish,
+    createdBy: nick,
+  });
+  res.json({
+    url: `${originFromRequest(req)}/call/${link.token}`,
+    token: link.token,
+    canPublish: link.canPublish,
+    expiresAt: link.expiresAt,
+  });
+});
+
+router.get('/guest-link', (req: Request, res: Response) => {
+  const networkId = Number(req.query?.networkId);
+  const target = typeof req.query?.target === 'string' ? req.query.target.trim() : '';
+  const ctx = resolveCall(req, res, networkId);
+  if (!ctx) return;
+  if (!target || !isChannelTarget(target)) {
+    res.status(400).json({ error: 'channel target required' });
+    return;
+  }
+  const { network, conn, nick } = ctx;
+  if (!canAdminCall(memberModes(conn, target, nick))) {
+    res.status(403).json({ error: 'operators only' });
+    return;
+  }
+  const origin = originFromRequest(req);
+  const links = listActiveGuestLinks(foldKey(network.host), foldTargetFor(network.id, target)).map(
+    (l) => ({
+      token: l.token,
+      url: `${origin}/call/${l.token}`,
+      canPublish: l.canPublish,
+      createdBy: l.createdBy,
+      createdAt: l.createdAt,
+      expiresAt: l.expiresAt,
+      useCount: l.useCount,
+    }),
+  );
+  res.json({ links });
+});
+
+router.delete('/guest-link/:token', (req: Request, res: Response) => {
+  if (!voiceEnabled()) {
+    res.status(503).json({ error: 'voice not enabled on this server' });
+    return;
+  }
+  const token = typeof req.params.token === 'string' ? req.params.token : '';
+  const link = getGuestLink(token);
+  if (!link) {
+    res.status(404).json({ error: 'link not found' });
+    return;
+  }
+  // Authorize: the caller must be an op of the link's channel on the matching
+  // host — resolved across ALL their connections, since the revoke may come
+  // from a different device/network row than the mint did.
+  const conn = ircManager
+    .listConnections(req.user!.id)
+    .find((c) => !!c.currentNick && foldKey(c.network.host) === link.networkHost);
+  if (!conn || !canAdminCall(memberModes(conn, link.channelFolded, conn.currentNick!))) {
+    res.status(403).json({ error: 'operators only' });
+    return;
+  }
+  revokeGuestLink(token);
+  res.json({ ok: true });
+});
+
+// ─── Public router (no cookie auth) — webhook + guest join ──────────────────
+// Each route authenticates by its own capability: the webhook by LiveKit's
+// signature, the guest join by the opaque link token. Never the session cookie.
 export const voicePublicRouter = Router();
 
 // LiveKit posts room/participant events here (content-type
@@ -296,6 +404,56 @@ voicePublicRouter.post(
  *  target. A connection whose network row folds differently from the minter's
  *  (transitional casemapping divergence) just misses the badge until its row
  *  refolds; the /presence snapshot on its next reconnect self-heals it. */
+// Guest join: exchange a guest-link token + display name for a room-scoped
+// LiveKit token. Public; the capability IS the opaque link token, throttled
+// per-IP by the shared RequestThrottle (self-capping — see rateLimit.ts).
+// The guest token is deliberately SHORT (1h vs members' 2h): on OSS LiveKit a
+// minted token cannot be revoked, so its TTL is the entire revocation story
+// for a link an op just killed. A legit guest whose call outlives the token
+// re-clicks the link — the LINK lasts 24h.
+const GUEST_TOKEN_TTL_SECONDS = 60 * 60;
+const guestTokenThrottle = new RequestThrottle({ windowMs: 60_000, maxRequests: 10 });
+
+/** Test hook, mirroring resetAuthRateLimits — the throttle is module state. */
+export function resetGuestRateLimit(): void {
+  guestTokenThrottle.clear();
+}
+
+voicePublicRouter.post(
+  '/guest-token',
+  limitRequests(guestTokenThrottle),
+  async (req: Request, res: Response) => {
+    if (!voiceEnabled()) {
+      res.status(503).json({ error: 'voice not enabled' });
+      return;
+    }
+    const token = typeof req.body?.token === 'string' ? req.body.token : '';
+    const name = typeof req.body?.name === 'string' ? req.body.name : '';
+    const link = getUsableGuestLink(token);
+    if (!link) {
+      res.status(404).json({ error: 'this guest link is invalid, expired, or revoked' });
+      return;
+    }
+    try {
+      const minted = await mintVoiceToken({
+        identity: guestIdentity(name || 'guest'),
+        room: link.room,
+        canPublish: link.canPublish,
+        ttlSeconds: GUEST_TOKEN_TTL_SECONDS,
+      });
+      bumpGuestLinkUse(token);
+      res.json({
+        token: minted.token,
+        url: minted.url,
+        canPublish: link.canPublish,
+      });
+    } catch (err) {
+      console.error('[voice] guest token mint failed:', err);
+      res.status(500).json({ error: 'failed to mint token' });
+    }
+  },
+);
+
 function broadcastCallPresence(change: CallPresenceChange): void {
   for (const conn of ircManager.listAllConnections()) {
     if (foldKey(conn.network.host) !== change.host) continue;

--- a/server/server.ts
+++ b/server/server.ts
@@ -20,6 +20,7 @@ import { nodeUploadConfigured } from './services/uploadProviders/nodeUpload.js';
 import * as systemLog from './services/systemLog.js';
 import { purgeExpiredSessions } from './db/sessions.js';
 import { sweepExpiredPreviews } from './db/linkPreviews.js';
+import { sweepDeadGuestLinks } from './db/voiceLinks.js';
 import { sweepPreviewCache } from './services/previewCache/index.js';
 import { listGrandfatheredUsernames } from './db/users.js';
 import { backfillEncryptColumns } from './db/secretBackfill.js';
@@ -123,6 +124,12 @@ setInterval(purgeExpiredSessions, 60 * 60 * 1000).unref();
 // feature off still has whatever it cached while it was on, and that should still expire.
 sweepExpiredPreviews();
 setInterval(sweepExpiredPreviews, 60 * 60 * 1000).unref();
+
+// Guest call links die 24h after expiry/revocation (voice, #680 stack) — same
+// only-ever-grows shape as the preview cache, same janitor cadence. Not gated
+// on voiceEnabled() for the same reason as above.
+sweepDeadGuestLinks();
+setInterval(sweepDeadGuestLinks, 60 * 60 * 1000).unref();
 
 // The BYTE cache's index needs the same treatment, and for `s3` it is not merely
 // hygiene: nothing else bounds that table, and a row that outlives its object has

--- a/server/services/voice.test.ts
+++ b/server/services/voice.test.ts
@@ -14,6 +14,7 @@ import {
   canModerateCall,
   canAdminCall,
   webhookCallRoom,
+  guestIdentity,
   liveCallCount,
   receiveWebhook,
   listActiveCalls,
@@ -278,5 +279,14 @@ describe('receiveWebhook / listActiveCalls / liveCallCount (unconfigured)', () =
     await expect(listActiveCalls()).resolves.toEqual([]);
     // null (unknown), NOT 0 — a fabricated zero would clear real badges.
     await expect(liveCallCount('net-h-c-#x')).resolves.toBeNull();
+  });
+});
+
+describe('guestIdentity', () => {
+  it('namespaces + sanitizes so a guest can never be a bare IRC nick', () => {
+    expect(guestIdentity('Alice')).toMatch(/^guest-alice-[0-9a-f]{8}$/);
+    expect(guestIdentity('bad nick!@#')).toMatch(/^guest-badnick-[0-9a-f]{8}$/);
+    expect(guestIdentity('')).toMatch(/^guest-guest-[0-9a-f]{8}$/);
+    expect(guestIdentity('x')).not.toBe(guestIdentity('x')); // random suffix
   });
 });

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -20,6 +20,7 @@
 // put the two ends in two different rooms. So DM rooms are keyed by the
 // *canonical* (sorted) nick pair instead.
 
+import crypto from 'crypto';
 import { AccessToken, RoomServiceClient, WebhookReceiver } from 'livekit-server-sdk';
 import type { WebhookEvent } from 'livekit-server-sdk';
 import { isChannelTarget } from '../../shared/channels.js';
@@ -144,31 +145,51 @@ export interface MintedToken {
 }
 
 /**
- * Mint a room-scoped LiveKit access token. Grants join + publish + subscribe on
- * exactly one room and nothing else — a token for `#dev` cannot touch `#ops`.
- * Identity is the caller's IRC nick so remote participants render sensible names.
- * Throws if voice is not configured (callers should have gated on voiceEnabled).
+ * Mint a room-scoped LiveKit access token. Grants join + subscribe on exactly
+ * one room and nothing else — a token for `#dev` cannot touch `#ops`.
+ * Identity is the caller's IRC nick (or a namespaced guest identity) so remote
+ * participants render sensible names. `canPublish: false` produces a
+ * listen-only token (guest links below the talk threshold). Throws if voice is
+ * not configured (callers should have gated on voiceEnabled).
  */
 export async function mintVoiceToken(args: {
   identity: string;
   room: string;
+  /** false → listen-only. Default true. */
+  canPublish?: boolean;
+  /** Default 2h — a call comfortably outlives its join token. Guest tokens are
+   *  shorter: a token, once minted, is irrevocable on OSS LiveKit, so its TTL
+   *  is the whole revocation story. */
+  ttlSeconds?: number;
 }): Promise<MintedToken> {
   const cfg = liveKitConfig();
   if (!cfg) throw new Error('voice not configured');
 
   const at = new AccessToken(cfg.apiKey, cfg.apiSecret, {
     identity: args.identity,
-    ttl: 2 * 60 * 60, // 2h — a call comfortably outlives its join token
+    ttl: args.ttlSeconds ?? 2 * 60 * 60,
   });
   at.addGrant({
     roomJoin: true,
     room: args.room,
-    canPublish: true,
+    canPublish: args.canPublish !== false,
     canSubscribe: true,
     canPublishData: true,
   });
   const token = await at.toJwt();
   return { token, room: args.room, url: cfg.wsUrl };
+}
+
+/** A safe, namespaced LiveKit identity for a guest so they can never collide
+ *  with or impersonate a real IRC nick (all real identities are bare nicks —
+ *  and a bare-nick collision would also hand the guest that nick's moderation
+ *  treatment). Folded, stripped to [a-z0-9_-], random suffix for uniqueness. */
+export function guestIdentity(name: string): string {
+  const clean =
+    foldAscii(name)
+      .replace(/[^a-z0-9_-]/g, '')
+      .slice(0, 24) || 'guest';
+  return `guest-${clean}-${crypto.randomBytes(4).toString('hex')}`;
 }
 
 // ─── Channel-mode authority ────────────────────────────────────────────────

--- a/server/services/voice.ts
+++ b/server/services/voice.ts
@@ -174,7 +174,10 @@ export async function mintVoiceToken(args: {
     room: args.room,
     canPublish: args.canPublish !== false,
     canSubscribe: true,
-    canPublishData: true,
+    // Data-channel publishing follows the same gate: canPublishData is an
+    // INDEPENDENT grant, so leaving it true would let a "listen-only" guest
+    // spam data packets at the room from a raw client for the token's hour.
+    canPublishData: args.canPublish !== false,
   });
   const token = await at.toJwt();
   return { token, room: args.room, url: cfg.wsUrl };

--- a/server/utils/requestOrigin.ts
+++ b/server/utils/requestOrigin.ts
@@ -3,19 +3,40 @@
 
 import type { Request } from 'express';
 
+function firstHeaderValue(v: unknown): string {
+  return String(v ?? '')
+    .split(',')[0]
+    .trim();
+}
+
+const HOST_RE = /^[A-Za-z0-9.\-:[\]]+$/;
+
 /**
  * The public origin to build user-facing links against (invite links, guest
- * call links). Prefer the browser-supplied Origin header so the link reflects
- * the URL the user is actually on — through Vite's dev proxy that's the :5173
- * origin, and in prod it's the public origin regardless of how the reverse
- * proxy forwards to Express. req.protocol/req.get('host') would otherwise leak
- * the upstream Express scheme + host (http://localhost:8010). Falls back to
- * scheme://host for the rare request without an Origin header.
+ * call links). Layered, most-trustworthy first:
+ *
+ *  1. The browser-supplied Origin header — the URL the user is actually on
+ *     (through Vite's dev proxy that's the :5173 origin; in prod the public
+ *     origin regardless of how the reverse proxy forwards to Express).
+ *  2. PUBLIC_BASE_URL — the operator's declared public origin. This is what
+ *     keeps links right for clients that send no Origin header at all
+ *     (native clients, and browsers on same-origin GETs).
+ *  3. Validated X-Forwarded-Proto/Host (same spoof guards as the uploads
+ *     absolutizer), then the raw Express scheme+host — which behind a proxy is
+ *     the internal address, hence the layers above.
  *
  * (Promoted from routes/admin.ts when guest call links needed the same rule.)
  */
 export function originFromRequest(req: Request): string {
   const origin = req.get('origin');
   if (origin) return origin;
-  return `${req.protocol}://${req.get('host')}`;
+
+  const configured = (process.env.PUBLIC_BASE_URL ?? '').trim().replace(/\/+$/, '');
+  if (configured) return configured;
+
+  const rawProto = firstHeaderValue(req.headers['x-forwarded-proto']) || req.protocol;
+  const proto = rawProto === 'http' || rawProto === 'https' ? rawProto : 'https';
+  const rawHost = firstHeaderValue(req.headers['x-forwarded-host']) || req.get('host') || '';
+  const host = HOST_RE.test(rawHost) ? rawHost : (req.get('host') ?? '');
+  return `${proto}://${host}`;
 }

--- a/server/utils/requestOrigin.ts
+++ b/server/utils/requestOrigin.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+import type { Request } from 'express';
+
+/**
+ * The public origin to build user-facing links against (invite links, guest
+ * call links). Prefer the browser-supplied Origin header so the link reflects
+ * the URL the user is actually on — through Vite's dev proxy that's the :5173
+ * origin, and in prod it's the public origin regardless of how the reverse
+ * proxy forwards to Express. req.protocol/req.get('host') would otherwise leak
+ * the upstream Express scheme + host (http://localhost:8010). Falls back to
+ * scheme://host for the rare request without an Origin header.
+ *
+ * (Promoted from routes/admin.ts when guest call links needed the same rule.)
+ */
+export function originFromRequest(req: Request): string {
+  const origin = req.get('origin');
+  if (origin) return origin;
+  return `${req.protocol}://${req.get('host')}`;
+}

--- a/shared/voiceModes.ts
+++ b/shared/voiceModes.ts
@@ -60,3 +60,24 @@ export function canModerateCall(modes: readonly string[]): boolean {
 export function canAdminCall(modes: readonly string[]): boolean {
   return modes.some((m) => OP_LETTERS.has(m));
 }
+
+// ─── Guest identities ───────────────────────────────────────────────────────
+// Guests joining via a capability link get namespaced LiveKit identities so
+// they can never collide with or impersonate a bare IRC nick. The server mints
+// them (see guestIdentity in server/services/voice.ts — shape pinned by its
+// tests); clients use these to RENDER guests differently instead of showing
+// the raw machine identity ('guest-coolguest-3fa9b2c1').
+
+const GUEST_IDENTITY_RE = /^guest-([a-z0-9_-]*)-[0-9a-f]{8}$/;
+
+/** True for a minted guest identity; a bare-nick identity is never a guest. */
+export function isGuestIdentity(identity: string): boolean {
+  return GUEST_IDENTITY_RE.test(identity);
+}
+
+/** The human name inside a guest identity ('guest-coolguest-3fa9b2c1' →
+ *  'coolguest'), or the identity unchanged when it isn't a guest. */
+export function guestDisplayName(identity: string): string {
+  const m = GUEST_IDENTITY_RE.exec(identity);
+  return m ? m[1] || 'guest' : identity;
+}

--- a/vue_client/src/api.ts
+++ b/vue_client/src/api.ts
@@ -31,7 +31,10 @@ const AUTH_RECOVERY_FLAG = 'lurker:authRecoveryAttempted';
 // NOT a stale session — bouncing would eject an invite/sign-in visitor to
 // `/login?next=/` before their page can even mount.
 function isPublicPath(pathname: string): boolean {
-  return pathname === '/login' || pathname.startsWith('/invite/');
+  // Mirrors the no-requiresAuth routes in router.ts. /call/ is the guest
+  // voice-call page: a logged-in user whose session dies mid-call must NOT be
+  // bounced to /, which would eject them from the call they're in.
+  return pathname === '/login' || pathname.startsWith('/invite/') || pathname.startsWith('/call/');
 }
 
 // Pure decision (exported for tests): a 401 from a normal authed call means the

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -40,17 +40,19 @@
               :class="voice.speaking.includes(id) ? 'fa-volume-high' : 'fa-user'"
               aria-hidden="true"
             ></i>
-            <span class="part-nick" :title="id">{{ id }}</span>
+            <span class="part-nick" :title="partName(id)">
+              {{ partName(id) }}<span v-if="isGuestIdentity(id)" class="guest-tag">guest</span>
+            </span>
             <IconButton
               v-if="amOp"
               icon="fa-microphone-slash"
-              :label="`Mute ${id} for everyone`"
+              :label="`Mute ${partName(id)} for everyone`"
               @click="moderate(id, 'mute')"
             />
             <IconButton
               v-if="amOp"
               icon="fa-user-slash"
-              :label="`Remove ${id} from call`"
+              :label="`Remove ${partName(id)} from call`"
               danger
               @click="moderate(id, 'remove')"
             />
@@ -61,7 +63,7 @@
             min="0"
             max="100"
             :value="volPct(id)"
-            :aria-label="`Volume for ${id}`"
+            :aria-label="`Volume for ${partName(id)}`"
             @input="onVol(id, $event)"
           />
         </li>
@@ -92,7 +94,7 @@ import { useVoiceStore } from '../stores/voice.js';
 import { useBuffersStore, bufferKey } from '../stores/buffers.js';
 import { useNetworksStore } from '../stores/networks.js';
 import { useToastsStore } from '../stores/toasts.js';
-import { canModerateCall } from '../../../shared/voiceModes.js';
+import { canModerateCall, isGuestIdentity, guestDisplayName } from '../../../shared/voiceModes.js';
 import { api } from '../api.js';
 import IconButton from './IconButton.vue';
 
@@ -133,6 +135,12 @@ async function moderate(identity: string, action: 'mute' | 'remove') {
       kind: 'warn',
     });
   }
+}
+
+/** Human name for a participant row — guests show their picked name, not the
+ *  raw machine identity (the guest-tag badge carries the "guest" fact). */
+function partName(id: string): string {
+  return guestDisplayName(id);
 }
 
 function volPct(id: string): number {
@@ -227,6 +235,13 @@ function onVol(id: string, e: Event) {
 }
 .call-empty {
   margin: 0;
+  color: var(--fg-muted);
+}
+.guest-tag {
+  margin-left: var(--space-2);
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
   color: var(--fg-muted);
 }
 .call-actions {

--- a/vue_client/src/components/CallBar.vue
+++ b/vue_client/src/components/CallBar.vue
@@ -70,7 +70,10 @@
     </div>
 
     <div v-if="voice.active || voice.connecting" class="call-actions">
+      <!-- Listen-only guests get no mute toggle: an unmute would prompt for
+           mic permission and then be refused by the SFU. -->
       <IconButton
+        v-if="voice.canPublish"
         :icon="voice.muted ? 'fa-microphone-slash' : 'fa-microphone'"
         :label="voice.muted ? 'Unmute' : 'Mute'"
         :danger="voice.muted"

--- a/vue_client/src/components/MemberList.test.ts
+++ b/vue_client/src/components/MemberList.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Brad Root
+// SPDX-License-Identifier: MPL-2.0
+
+// @vitest-environment happy-dom
+
+// This file exists because of a bug it would have caught: the guest-links
+// watcher runs with { immediate: true } during setup and evaluates `isOp` →
+// `selfModes` — when `selfModes` was declared BELOW that watcher, the
+// temporal-dead-zone ReferenceError crashed MemberList's setup, and with it
+// the entire chat view (clicking any buffer rendered nothing). Only a real
+// mount exercises setup-time evaluation order, so this mounts the real
+// component.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { setActivePinia, createPinia } from 'pinia';
+import MemberList from './MemberList.vue';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe('MemberList — setup survives a bare mount', () => {
+  it('mounts with empty stores (no active buffer) without throwing', async () => {
+    const w = mount(MemberList);
+    await flushPromises();
+    expect(w.find('.members').exists()).toBe(true);
+    // No buffer → no call affordances, and crucially: no crash.
+    expect(w.find('.members-head').exists()).toBe(false);
+  });
+});

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -25,6 +25,42 @@
           <option value="op">ops only</option>
         </select>
       </label>
+      <div v-if="isOp" class="guest-links">
+        <div class="guest-mint">
+          <button
+            type="button"
+            class="guest-btn"
+            :disabled="guestBusy"
+            title="Create a public link a guest can use to join this channel's call without an account (expires in 24h)"
+            @click="mintGuestLink"
+          >
+            <i class="fa-solid fa-link" aria-hidden="true"></i> Guest link
+          </button>
+          <label class="listen-only" title="Guests via this link can hear the call but not speak">
+            <input v-model="listenOnly" type="checkbox" /> listen-only
+          </label>
+        </div>
+        <div v-if="guestUrl" class="guest-url">
+          <input :value="guestUrl" readonly aria-label="Guest call link" @focus="selectAll" />
+          <button type="button" @click="copyGuest">{{ copied ? 'Copied' : 'Copy' }}</button>
+        </div>
+        <ul v-if="activeLinks.length" class="link-list">
+          <li v-for="l in activeLinks" :key="l.token">
+            <span class="link-meta" :title="`created by ${l.createdBy ?? 'unknown'}`">
+              {{ l.canPublish ? 'talk' : 'listen' }} · {{ l.useCount }} use{{
+                l.useCount === 1 ? '' : 's'
+              }}
+            </span>
+            <IconButton icon="fa-copy" label="Copy link" @click="copyLink(l)" />
+            <IconButton
+              icon="fa-ban"
+              danger
+              label="Revoke — stops new guests from joining; anyone already in the call stays until removed"
+              @click="revokeLink(l)"
+            />
+          </li>
+        </ul>
+      </div>
     </div>
     <ul ref="listEl">
       <li
@@ -78,6 +114,7 @@ import {
   prefixClass as modePrefixClass,
 } from '../utils/memberPrefix.js';
 import IgnoreModal from './IgnoreModal.vue';
+import IconButton from './IconButton.vue';
 
 const networks = useNetworksStore();
 const buffers = useBuffersStore();
@@ -150,6 +187,97 @@ watch(
   },
   { immediate: true },
 );
+
+// ─── Op guest links (mint / copy / revoke a public capability URL) ──────────
+interface GuestLinkRow {
+  token: string;
+  url: string;
+  canPublish: boolean;
+  createdBy: string | null;
+  useCount: number;
+}
+
+const guestUrl = ref('');
+const copied = ref(false);
+const guestBusy = ref(false);
+const listenOnly = ref(false);
+const activeLinks = ref<GuestLinkRow[]>([]);
+
+async function refreshLinks(b = buffer.value) {
+  if (!config.voiceEnabled || !isOp.value || !b || b.kind !== 'channel' || b.networkId == null) {
+    activeLinks.value = [];
+    return;
+  }
+  try {
+    const r = await api<{ links: GuestLinkRow[] }>(
+      `/api/voice/guest-link?networkId=${b.networkId}&target=${encodeURIComponent(b.target)}`,
+    );
+    if (buffer.value !== b) return; // stale response for a previous channel
+    activeLinks.value = r.links ?? [];
+  } catch {
+    /* leave as-is */
+  }
+}
+
+watch(
+  [buffer, isOp, () => config.voiceEnabled],
+  ([b]) => {
+    guestUrl.value = '';
+    copied.value = false;
+    activeLinks.value = [];
+    void refreshLinks(b);
+  },
+  { immediate: true },
+);
+
+async function mintGuestLink() {
+  const b = buffer.value;
+  if (!b || b.networkId == null) return;
+  guestBusy.value = true;
+  copied.value = false;
+  try {
+    const r = await api<{ url: string }>('/api/voice/guest-link', {
+      method: 'POST',
+      body: { networkId: b.networkId, target: b.target, canPublish: !listenOnly.value },
+    });
+    guestUrl.value = r.url;
+    void refreshLinks();
+  } catch (err: unknown) {
+    useToastsStore().push({
+      title: 'Could not create guest link',
+      body: err instanceof Error ? err.message : 'the server rejected the request',
+      kind: 'warn',
+    });
+  } finally {
+    guestBusy.value = false;
+  }
+}
+
+function copyGuest() {
+  if (!guestUrl.value) return;
+  void navigator.clipboard?.writeText(guestUrl.value);
+  copied.value = true;
+}
+function copyLink(l: GuestLinkRow) {
+  void navigator.clipboard?.writeText(l.url);
+}
+function selectAll(e: FocusEvent) {
+  (e.target as HTMLInputElement).select();
+}
+
+async function revokeLink(l: GuestLinkRow) {
+  try {
+    await api(`/api/voice/guest-link/${encodeURIComponent(l.token)}`, { method: 'DELETE' });
+    if (guestUrl.value === l.url) guestUrl.value = '';
+    void refreshLinks();
+  } catch (err: unknown) {
+    useToastsStore().push({
+      title: 'Could not revoke guest link',
+      body: err instanceof Error ? err.message : 'the server rejected the request',
+      kind: 'warn',
+    });
+  }
+}
 
 async function onPolicyChange(e: Event) {
   const b = buffer.value;
@@ -326,6 +454,59 @@ const sorted = computed(() => {
 .call-policy select {
   flex: 1;
   min-width: 0;
+}
+.guest-links {
+  margin-top: var(--space-3);
+}
+.guest-mint {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.guest-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.listen-only {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.guest-url {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+.guest-url input {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: inherit;
+  font: inherit;
+}
+.link-list {
+  list-style: none;
+  margin: var(--space-2) 0 0;
+  padding: 0;
+}
+.link-list li {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) 0;
+}
+.link-meta {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 ul {
   list-style: none;

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -134,6 +134,24 @@ const listEl = ref<HTMLElement | null>(null);
 const buffer = computed(() => (networks.activeKey ? buffers.byKey(networks.activeKey) : null));
 const members = computed((): BufferMember[] => buffer.value?.members || []);
 
+// ⚠ Declared BEFORE the voice section below: its guest-links watcher runs
+// IMMEDIATELY during setup and evaluates isOp → selfModes — a later `const`
+// here is a temporal-dead-zone crash that takes the whole chat view down
+// (regression-tested by MemberList.test.ts).
+const selfNick = computed(() => {
+  const b = buffer.value;
+  if (!b || b.networkId == null) return null;
+  return networks.states[b.networkId]?.nick || null;
+});
+// The current user's own modes in this channel, used to gate the operator
+// actions in the member context menu.
+const selfModes = computed<string[]>(() => {
+  const sn = selfNick.value;
+  if (!sn) return [];
+  const me = members.value.find((m) => nickOf(m).toLowerCase() === sn.toLowerCase());
+  return me && Array.isArray(me.modes) ? me.modes : [];
+});
+
 // ─── Voice call (channels only, and only when the instance offers it) ────────
 const config = useConfigStore();
 const voice = useVoiceStore();
@@ -319,20 +337,6 @@ async function onPolicyChange(e: Event) {
     });
   }
 }
-const selfNick = computed(() => {
-  const b = buffer.value;
-  if (!b || b.networkId == null) return null;
-  return networks.states[b.networkId]?.nick || null;
-});
-// The current user's own modes in this channel, used to gate the operator
-// actions in the member context menu.
-const selfModes = computed<string[]>(() => {
-  const sn = selfNick.value;
-  if (!sn) return [];
-  const me = members.value.find((m) => nickOf(m).toLowerCase() === sn.toLowerCase());
-  return me && Array.isArray(me.modes) ? me.modes : [];
-});
-
 watch(
   () => networks.activeKey,
   () => {

--- a/vue_client/src/components/MemberList.vue
+++ b/vue_client/src/components/MemberList.vue
@@ -42,7 +42,9 @@
         </div>
         <div v-if="guestUrl" class="guest-url">
           <input :value="guestUrl" readonly aria-label="Guest call link" @focus="selectAll" />
-          <button type="button" @click="copyGuest">{{ copied ? 'Copied' : 'Copy' }}</button>
+          <button type="button" @click="copyGuest">
+            {{ linkCopy.isCopied('mint') ? 'Copied' : 'Copy' }}
+          </button>
         </div>
         <ul v-if="activeLinks.length" class="link-list">
           <li v-for="l in activeLinks" :key="l.token">
@@ -51,7 +53,11 @@
                 l.useCount === 1 ? '' : 's'
               }}
             </span>
-            <IconButton icon="fa-copy" label="Copy link" @click="copyLink(l)" />
+            <IconButton
+              :icon="linkCopy.isCopied(l.token) ? 'fa-check' : 'fa-copy'"
+              :label="linkCopy.isCopied(l.token) ? 'Copied' : 'Copy link'"
+              @click="copyLink(l)"
+            />
             <IconButton
               icon="fa-ban"
               danger
@@ -107,6 +113,7 @@ import { useVoiceStore } from '../stores/voice.js';
 import { useCallPresenceStore } from '../stores/callPresence.js';
 import { useToastsStore } from '../stores/toasts.js';
 import { canAdminCall } from '../../../shared/voiceModes.js';
+import { useCopyFeedback } from '../composables/useCopyFeedback.js';
 import { api } from '../api.js';
 import {
   PREFIX_ORDER,
@@ -191,17 +198,24 @@ watch(
 // ─── Op guest links (mint / copy / revoke a public capability URL) ──────────
 interface GuestLinkRow {
   token: string;
-  url: string;
   canPublish: boolean;
   createdBy: string | null;
   useCount: number;
 }
 
+/** Build the shareable URL from OUR OWN origin. The server's `url` field is
+ *  derived from the request's Origin header, which browsers omit on
+ *  same-origin GETs — the listing's URLs would silently carry the internal
+ *  Express host. The web client always knows the right origin: its own. */
+function linkUrl(token: string): string {
+  return `${window.location.origin}/call/${token}`;
+}
+
 const guestUrl = ref('');
-const copied = ref(false);
 const guestBusy = ref(false);
 const listenOnly = ref(false);
 const activeLinks = ref<GuestLinkRow[]>([]);
+const linkCopy = useCopyFeedback();
 
 async function refreshLinks(b = buffer.value) {
   if (!config.voiceEnabled || !isOp.value || !b || b.kind !== 'channel' || b.networkId == null) {
@@ -223,7 +237,7 @@ watch(
   [buffer, isOp, () => config.voiceEnabled],
   ([b]) => {
     guestUrl.value = '';
-    copied.value = false;
+    linkCopy.reset();
     activeLinks.value = [];
     void refreshLinks(b);
   },
@@ -234,13 +248,16 @@ async function mintGuestLink() {
   const b = buffer.value;
   if (!b || b.networkId == null) return;
   guestBusy.value = true;
-  copied.value = false;
   try {
-    const r = await api<{ url: string }>('/api/voice/guest-link', {
+    const r = await api<{ token: string }>('/api/voice/guest-link', {
       method: 'POST',
       body: { networkId: b.networkId, target: b.target, canPublish: !listenOnly.value },
     });
-    guestUrl.value = r.url;
+    // Stale guard: a slow mint for the PREVIOUS channel must not surface its
+    // URL under the newly selected channel — that would hand out access to
+    // the wrong call.
+    if (buffer.value !== b) return;
+    guestUrl.value = linkUrl(r.token);
     void refreshLinks();
   } catch (err: unknown) {
     useToastsStore().push({
@@ -255,11 +272,10 @@ async function mintGuestLink() {
 
 function copyGuest() {
   if (!guestUrl.value) return;
-  void navigator.clipboard?.writeText(guestUrl.value);
-  copied.value = true;
+  void linkCopy.copy(guestUrl.value, 'mint');
 }
 function copyLink(l: GuestLinkRow) {
-  void navigator.clipboard?.writeText(l.url);
+  void linkCopy.copy(linkUrl(l.token), l.token);
 }
 function selectAll(e: FocusEvent) {
   (e.target as HTMLInputElement).select();
@@ -268,7 +284,7 @@ function selectAll(e: FocusEvent) {
 async function revokeLink(l: GuestLinkRow) {
   try {
     await api(`/api/voice/guest-link/${encodeURIComponent(l.token)}`, { method: 'DELETE' });
-    if (guestUrl.value === l.url) guestUrl.value = '';
+    if (guestUrl.value === linkUrl(l.token)) guestUrl.value = '';
     void refreshLinks();
   } catch (err: unknown) {
     useToastsStore().push({

--- a/vue_client/src/router.ts
+++ b/vue_client/src/router.ts
@@ -16,6 +16,10 @@ const chatShell = () => import('./views/Chat.vue');
 const routes: RouteRecordRaw[] = [
   { path: '/login', name: 'login', component: () => import('./views/Login.vue') },
   { path: '/invite/:token', name: 'invite', component: () => import('./views/InviteAccept.vue') },
+  // Public guest voice-call page — deliberately NO requiresAuth. The :token is
+  // a capability link an op minted (POST /api/voice/guest-link); the page
+  // exchanges it for a room-scoped LiveKit token.
+  { path: '/call/:token', name: 'guest-call', component: () => import('./views/GuestCall.vue') },
   // The three chat locations. All render the same shell; only the params differ.
   //
   // `/buffer/:id` names ONE buffer by its SERVER ID (#744) — never by name. The

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -51,6 +51,11 @@ export const useVoiceStore = defineStore('voice', {
     // True when this tab joined via a public guest link (no account/session) —
     // gates off member-only affordances like moderation.
     isGuest: false,
+    // False for a listen-only token (guest links below the talk threshold):
+    // the mic is never requested, and the mute toggle must not render — an
+    // unmute attempt would prompt for mic permission and then be rejected by
+    // the SFU anyway.
+    canPublish: true,
     // Remote participant identities (their IRC nicks).
     participants: [] as string[],
     // Subset of `participants` currently detected as speaking.
@@ -65,6 +70,10 @@ export const useVoiceStore = defineStore('voice', {
       if (this.active || this.connecting) return;
       this.connecting = true;
       this.error = null;
+      // Label BEFORE the token fetch: the CallBar renders it while connecting,
+      // and a mint failure (403 policy) must blame the channel it belongs to,
+      // not whatever call came before.
+      this.label = label;
       this.networkId = networkId;
       this.target = target;
       try {
@@ -94,9 +103,11 @@ export const useVoiceStore = defineStore('voice', {
     ) {
       if (this.active) return;
       this.connecting = true;
+      this.error = null; // a retry must not show the previous attempt's failure
       this.label = label;
       if (opts?.guest) this.isGuest = true;
       const listenOnly = opts?.canPublish === false;
+      this.canPublish = !listenOnly;
       try {
         // Lazy chunk: livekit-client only lands over the network at first call.
         const { Room, RoomEvent, Track } = await import('livekit-client');
@@ -202,7 +213,7 @@ export const useVoiceStore = defineStore('voice', {
     },
 
     async toggleMute() {
-      if (!room) return;
+      if (!room || !this.canPublish) return; // listen-only: nothing to toggle
       // Flip state only after the SFU confirms. An optimistic flip that then
       // rejects (device error, mid-reconnect) would render the mic-slash icon
       // while the track is still transmitting — the worst kind of wrong.
@@ -247,6 +258,7 @@ export const useVoiceStore = defineStore('voice', {
       this.networkId = null;
       this.target = '';
       this.isGuest = false;
+      this.canPublish = true;
       // In-call notices (op-mute, mute-toggle failures) die with the call —
       // otherwise the CallBar stays wedged open showing them after /leave.
       // startCall's catch re-sets its failure reason after calling this.

--- a/vue_client/src/stores/voice.ts
+++ b/vue_client/src/stores/voice.ts
@@ -48,6 +48,9 @@ export const useVoiceStore = defineStore('voice', {
     // "in a call somewhere else".
     networkId: null as number | null,
     target: '',
+    // True when this tab joined via a public guest link (no account/session) —
+    // gates off member-only affordances like moderation.
+    isGuest: false,
     // Remote participant identities (their IRC nicks).
     participants: [] as string[],
     // Subset of `participants` currently detected as speaking.
@@ -62,7 +65,6 @@ export const useVoiceStore = defineStore('voice', {
       if (this.active || this.connecting) return;
       this.connecting = true;
       this.error = null;
-      this.label = label;
       this.networkId = networkId;
       this.target = target;
       try {
@@ -71,7 +73,31 @@ export const useVoiceStore = defineStore('voice', {
           method: 'POST',
           body: { networkId, target },
         });
+        await this.connectWithToken(url, token, label);
+      } catch (e: unknown) {
+        await this.cleanup();
+        this.error = e instanceof Error ? e.message : 'could not start call';
+      } finally {
+        this.connecting = false;
+      }
+    },
 
+    /** Shared connect path — member calls above, and the public guest page
+     *  (which has already exchanged its link token for a room token).
+     *  `canPublish: false` = a listen-only guest: the mic is never requested
+     *  (the SFU would reject the publish outright) and the state pins muted. */
+    async connectWithToken(
+      url: string,
+      token: string,
+      label: string,
+      opts?: { guest?: boolean; canPublish?: boolean },
+    ) {
+      if (this.active) return;
+      this.connecting = true;
+      this.label = label;
+      if (opts?.guest) this.isGuest = true;
+      const listenOnly = opts?.canPublish === false;
+      try {
         // Lazy chunk: livekit-client only lands over the network at first call.
         const { Room, RoomEvent, Track } = await import('livekit-client');
 
@@ -145,9 +171,9 @@ export const useVoiceStore = defineStore('voice', {
         // already-joined room — otherwise they stay in the call as a ghost
         // participant with no UI to leave.
         room = r;
-        await r.localParticipant.setMicrophoneEnabled(true);
+        if (!listenOnly) await r.localParticipant.setMicrophoneEnabled(true);
         this.active = true;
-        this.muted = false;
+        this.muted = listenOnly;
         this.error = null;
         this.syncParticipants();
       } catch (e: unknown) {
@@ -155,7 +181,7 @@ export const useVoiceStore = defineStore('voice', {
         // strands the bar open on a stale message) — set the failure reason
         // AFTER it so the failed-call state still says why.
         await this.cleanup();
-        this.error = e instanceof Error ? e.message : 'could not start call';
+        this.error = e instanceof Error ? e.message : 'could not connect';
       } finally {
         this.connecting = false;
       }
@@ -220,6 +246,7 @@ export const useVoiceStore = defineStore('voice', {
       this.volumes = {};
       this.networkId = null;
       this.target = '';
+      this.isGuest = false;
       // In-call notices (op-mute, mute-toggle failures) die with the call —
       // otherwise the CallBar stays wedged open showing them after /leave.
       // startCall's catch re-sets its failure reason after calling this.

--- a/vue_client/src/views/GuestCall.vue
+++ b/vue_client/src/views/GuestCall.vue
@@ -1,0 +1,150 @@
+<!--
+  Copyright (c) 2026 Brad Root
+  SPDX-License-Identifier: MPL-2.0
+-->
+
+<!--
+  Public guest voice-call page (/call/:token). Someone without an account opens
+  the capability link an op minted, picks a display name, and joins the call.
+  It exchanges the link token for a room-scoped LiveKit token and connects via
+  the shared voice store; the global CallBar provides the in-call controls.
+-->
+
+<template>
+  <div class="guest-call">
+    <div class="card">
+      <h1><i class="fa-solid fa-phone" aria-hidden="true"></i> Join voice call</h1>
+
+      <!-- config arrives async and defaults voice OFF — don't flash
+           "unavailable" at a legitimate guest while the fetch is in flight. -->
+      <p v-if="!config.checked" class="hint">Loading…</p>
+
+      <p v-else-if="!config.voiceEnabled" class="err">Voice calling isn't available here.</p>
+
+      <template v-else-if="!voice.active && !voice.connecting">
+        <p class="hint">You've been invited to a voice call. Pick a name to join.</p>
+        <input
+          v-model="name"
+          class="name"
+          placeholder="Your name"
+          maxlength="24"
+          spellcheck="false"
+          @keyup.enter="join"
+        />
+        <button
+          class="btn-primary join"
+          type="button"
+          :disabled="!name.trim() || joining"
+          @click="join"
+        >
+          {{ joining ? 'Joining…' : 'Join call' }}
+        </button>
+        <p v-if="error" class="err">{{ error }}</p>
+      </template>
+
+      <p v-else-if="voice.connecting" class="hint">Connecting…</p>
+
+      <template v-else>
+        <p class="ok"><i class="fa-solid fa-check" aria-hidden="true"></i> You're in the call.</p>
+        <p class="hint">
+          {{
+            listenOnly
+              ? 'This link is listen-only — you can hear the call but not speak.'
+              : 'Use the call controls in the corner to mute or leave.'
+          }}
+        </p>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useVoiceStore } from '../stores/voice.js';
+import { useConfigStore } from '../stores/config.js';
+import { api } from '../api.js';
+
+const route = useRoute();
+const voice = useVoiceStore();
+const config = useConfigStore();
+
+const token = String(route.params.token || '');
+const name = ref('');
+const joining = ref(false);
+const error = ref('');
+const listenOnly = ref(false);
+
+async function join() {
+  if (!name.value.trim() || joining.value) return;
+  joining.value = true;
+  error.value = '';
+  try {
+    const r = await api<{ token: string; url: string; canPublish: boolean }>(
+      '/api/voice/guest-token',
+      { method: 'POST', body: { token, name: name.value.trim() } },
+    );
+    listenOnly.value = r.canPublish === false;
+    await voice.connectWithToken(r.url, r.token, 'Guest call', {
+      guest: true,
+      canPublish: r.canPublish,
+    });
+    // connectWithToken reports its failures through the store, not a throw.
+    if (voice.error) error.value = voice.error;
+  } catch (e: unknown) {
+    error.value = e instanceof Error ? e.message : 'could not join the call';
+  } finally {
+    joining.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.guest-call {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  background: var(--bg);
+  color: var(--fg);
+}
+.card {
+  width: 100%;
+  max-width: 360px;
+  padding: var(--space-8);
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  text-align: center;
+}
+.card h1 {
+  font-size: inherit;
+  font-weight: 600;
+  margin: 0 0 var(--space-5);
+}
+.hint {
+  color: var(--fg-muted);
+  margin: 0 0 var(--space-5);
+}
+.name {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-5);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: inherit;
+  font: inherit;
+}
+.join {
+  width: 100%;
+}
+.ok {
+  color: var(--good);
+  font-weight: 600;
+  margin: 0 0 var(--space-3);
+}
+.err {
+  color: var(--bad);
+  margin: var(--space-3) 0 0;
+}
+</style>

--- a/vue_client/src/views/GuestCall.vue
+++ b/vue_client/src/views/GuestCall.vue
@@ -16,8 +16,16 @@
       <h1><i class="fa-solid fa-phone" aria-hidden="true"></i> Join voice call</h1>
 
       <!-- config arrives async and defaults voice OFF — don't flash
-           "unavailable" at a legitimate guest while the fetch is in flight. -->
-      <p v-if="!config.checked" class="hint">Loading…</p>
+           "unavailable" at a legitimate guest while the fetch is in flight,
+           and don't dead-end them if that one fetch fails (this page has no
+           router navigations to retrigger the store's retry path). -->
+      <template v-if="!config.checked">
+        <p v-if="!bootFailed" class="hint">Loading…</p>
+        <template v-else>
+          <p class="err">Couldn't reach the server.</p>
+          <button class="btn-secondary" type="button" @click="boot">Retry</button>
+        </template>
+      </template>
 
       <p v-else-if="!config.voiceEnabled" class="err">Voice calling isn't available here.</p>
 
@@ -59,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { useVoiceStore } from '../stores/voice.js';
 import { useConfigStore } from '../stores/config.js';
@@ -74,6 +82,16 @@ const name = ref('');
 const joining = ref(false);
 const error = ref('');
 const listenOnly = ref(false);
+const bootFailed = ref(false);
+
+async function boot() {
+  bootFailed.value = false;
+  await config.fetch().catch(() => {});
+  if (!config.checked) bootFailed.value = true;
+}
+onMounted(() => {
+  if (!config.checked) void boot();
+});
 
 async function join() {
   if (!name.value.trim() || joining.value) return;


### PR DESCRIPTION
Third slice of the stack planned in VOICE_CALLS_PR_PLAN.md, rebuilt from @JawshTheDark's #680. Builds on #761 + #762.

## What this adds

- **Guest links**: ops (`q/a/o`) mint a capability URL (24h TTL, optionally listen-only) from the member-list panel; someone without an account opens `/call/<token>`, picks a name, and joins that one channel's call. Opaque 32-byte tokens, soft revocation, per-link use counts.
- **Public `POST /guest-token`** exchanges the link for a **1-hour** room token — deliberately half the member TTL, because an OSS LiveKit token is irrevocable and its lifetime is the entire revocation story for a link an op just killed. Guest identities are namespaced (`guest-<name>-<hex>`) so they can never collide with or impersonate a real nick (JWT-decode tested, as is the listen-only grant).
- **Honest revocation, everywhere it's shown**: revoke stops *new* guests; anyone already in keeps their remaining hour unless removed. The revoke button's tooltip, SELF_HOSTING, and CLIENT_PROTOCOL all say exactly that.

## Defects fixed relative to the reference branch

- **The expiry comparison was format-broken**: a JS `toISOString` expiry compared against SQLite's space-format `datetime('now')` in SQL — `'T' > ' '`, so a link expiring any time today counted as active for the whole day in the ops' list. One `strftime` ISO format everywhere now, regression-tested with a same-day-expired link.
- The unbounded hand-rolled per-IP rate-limit map is replaced by the house `RequestThrottle` (self-capping), at 60/min per IP (sized for a NAT'd crowd joining one community call).
- Link URLs no longer trust `req.get('host')` — and after review, the web client builds them from `window.location.origin` outright, since browsers omit `Origin` on same-origin GETs and the server-side fallback leaks the internal Express host.
- Listen-only guests never request the mic (the reference enabled it unconditionally; the SFU rejects the publish for a `canPublish: false` grant, killing the join), and the CallBar hides the mute toggle for them.
- The guest page no longer flashes "voice isn't available here" during the config fetch, and retries with an error state instead of dead-ending if that fetch fails.

## Review

`/code-review` (high) with adversarial verification; all 10 findings addressed (details in the fix commit), including a broken emergency-revoke path for users with two network rows on one host, two refactor regressions in the voice store the reviewers caught (call-label timing, stale error on retry), and the missing index + hourly sweep for the links table.

Full `npm run check` + 3,898 tests green (60 voice tests server-side).

Remaining per the plan: PR 4 — video + screen share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)